### PR TITLE
feat: trace Relay deposit status in Perps

### DIFF
--- a/packages/kit-bg/src/apis/BackgroundApi.ts
+++ b/packages/kit-bg/src/apis/BackgroundApi.ts
@@ -861,5 +861,15 @@ class BackgroundApi extends BackgroundApiBase implements IBackgroundApi {
     Object.defineProperty(this, 'serviceRookieGuide', { value });
     return value;
   }
+
+  get serviceRelay() {
+    const Service =
+      require('../services/ServiceRelay') as typeof import('../services/ServiceRelay');
+    const value = new Service.default({
+      backgroundApi: this,
+    });
+    Object.defineProperty(this, 'serviceRelay', { value });
+    return value;
+  }
 }
 export default BackgroundApi;

--- a/packages/kit-bg/src/apis/BackgroundApiProxy.ts
+++ b/packages/kit-bg/src/apis/BackgroundApiProxy.ts
@@ -73,6 +73,7 @@ import type ServicePrimeTransfer from '../services/ServicePrimeTransfer';
 import type ServicePromise from '../services/ServicePromise';
 import type ServiceQrWallet from '../services/ServiceQrWallet';
 import type ServiceReferralCode from '../services/ServiceReferralCode';
+import type ServiceRelay from '../services/ServiceRelay';
 import type ServiceRookieGuide from '../services/ServiceRookieGuide';
 import type ServiceScanQRCode from '../services/ServiceScanQRCode';
 import type ServiceSend from '../services/ServiceSend';
@@ -407,6 +408,8 @@ class BackgroundApiProxy
   serviceRookieGuide = this._createProxyService(
     'serviceRookieGuide',
   ) as ServiceRookieGuide;
+
+  serviceRelay = this._createProxyService('serviceRelay') as ServiceRelay;
 }
 
 export default BackgroundApiProxy;

--- a/packages/kit-bg/src/apis/IBackgroundApi.ts
+++ b/packages/kit-bg/src/apis/IBackgroundApi.ts
@@ -72,6 +72,7 @@ import type ServicePrimeTransfer from '../services/ServicePrimeTransfer';
 import type ServicePromise from '../services/ServicePromise';
 import type ServiceQrWallet from '../services/ServiceQrWallet';
 import type ServiceReferralCode from '../services/ServiceReferralCode';
+import type ServiceRelay from '../services/ServiceRelay';
 import type ServiceRookieGuide from '../services/ServiceRookieGuide';
 import type ServiceScanQRCode from '../services/ServiceScanQRCode';
 import type ServiceSend from '../services/ServiceSend';
@@ -237,4 +238,6 @@ export interface IBackgroundApi extends IBackgroundApiBridge {
   serviceNetworkDoctor: ServiceNetworkDoctor;
   serviceOneKeyID: ServiceOneKeyID;
   serviceRookieGuide: ServiceRookieGuide;
+
+  serviceRelay: ServiceRelay;
 }

--- a/packages/kit-bg/src/services/ServiceRelay.ts
+++ b/packages/kit-bg/src/services/ServiceRelay.ts
@@ -1,0 +1,458 @@
+import {
+  backgroundClass,
+  backgroundMethod,
+} from '@onekeyhq/shared/src/background/backgroundDecorators';
+import { OneKeyError } from '@onekeyhq/shared/src/errors';
+import type {
+  IRelayChain,
+  IRelayChainsResponse,
+  IRelayCurrency,
+  IRelayDepositInfo,
+  IRelayQuoteRequest,
+  IRelayQuoteResponse,
+} from '@onekeyhq/shared/types/relay';
+
+import ServiceBase from './ServiceBase';
+
+// --- Relay protocol constants ---
+const RELAY_API_BASE = 'https://api.relay.link';
+const HYPERLIQUID_CHAIN_ID = 1337;
+const HYPERLIQUID_DESTINATION_CURRENCY =
+  '0x00000000000000000000000000000000';
+// Hyperliquid uses 8-decimal USDC for EXACT_OUTPUT amount encoding
+const DESTINATION_DECIMALS = 8;
+const DEFAULT_EVM_DECIMALS = 18;
+const MAX_PROBE_AMOUNT = '10000000'; // 10M USD probe to find max liquidity
+
+// Non-EVM chain IDs
+const BITCOIN_CHAIN_ID = 8_253_038;
+const TRON_CHAIN_ID = 728_126_428;
+
+// Dummy users for non-EVM quote requests (API requires a valid address format)
+const NON_EVM_DUMMY_USERS: Record<number, string> = {
+  [BITCOIN_CHAIN_ID]: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+  [TRON_CHAIN_ID]: 'TCWTKkQUNJw5rUersaecwkGKkxpU5amwmJ',
+};
+const EVM_DUMMY_USER = '0x0000000000000000000000000000000000000001';
+
+@backgroundClass()
+class ServiceRelay extends ServiceBase {
+  constructor({ backgroundApi }: { backgroundApi: any }) {
+    super({ backgroundApi });
+  }
+
+  // Major chains supported for Relay deposit
+  private static readonly SUPPORTED_CHAIN_IDS = new Set([
+    1, // Ethereum
+    10, // Optimism
+    56, // BNB Chain
+    137, // Polygon
+    8453, // Base
+    42_161, // Arbitrum
+    43_114, // Avalanche
+    BITCOIN_CHAIN_ID,
+    TRON_CHAIN_ID,
+  ]);
+
+  // Major currencies to keep (by symbol, case-insensitive)
+  private static readonly SUPPORTED_CURRENCY_SYMBOLS = new Set([
+    'usdc',
+    'usdt',
+    'eth',
+    'weth',
+    'btc',
+    'wbtc',
+  ]);
+
+  // Chain display info overrides
+  private static readonly CHAIN_INFO_MAP: Record<
+    number,
+    { logo: string; displayName: string }
+  > = {
+    1: {
+      logo: 'https://uni.onekey-asset.com/static/chain/eth.png',
+      displayName: 'Ethereum',
+    },
+    10: {
+      logo: 'https://uni.onekey-asset.com/static/chain/optimism.png',
+      displayName: 'Optimism',
+    },
+    56: {
+      logo: 'https://uni.onekey-asset.com/static/chain/bsc.png',
+      displayName: 'BNB Chain',
+    },
+    137: {
+      logo: 'https://uni.onekey-asset.com/static/chain/polygon.png',
+      displayName: 'Polygon',
+    },
+    8453: {
+      logo: 'https://uni.onekey-asset.com/static/chain/base.png',
+      displayName: 'Base',
+    },
+    42_161: {
+      logo: 'https://uni.onekey-asset.com/static/chain/arbitrum.png',
+      displayName: 'Arbitrum',
+    },
+    43_114: {
+      logo: 'https://uni.onekey-asset.com/static/chain/avalanche.png',
+      displayName: 'Avalanche',
+    },
+    [BITCOIN_CHAIN_ID]: {
+      logo: 'https://uni.onekey-asset.com/static/chain/btc.png',
+      displayName: 'Bitcoin',
+    },
+    [TRON_CHAIN_ID]: {
+      logo: 'https://uni.onekey-asset.com/static/chain/tron.png',
+      displayName: 'Tron',
+    },
+  };
+
+  // Well-known token logos — takes priority over API-provided logoURI
+  private static readonly TOKEN_LOGO_MAP: Record<string, string> = {
+    eth: 'https://uni.onekey-asset.com/static/chain/eth.png',
+    weth: 'https://uni.onekey-asset.com/server-service-indexer/evm--1/tokens/address-0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png',
+    btc: 'https://uni.onekey-asset.com/static/chain/btc.png',
+    wbtc: 'https://uni.onekey-asset.com/server-service-indexer/evm--1/tokens/address-0x2260fac5e5542a773aa44fbcfedf7c193bc2c599.png',
+    usdt: 'https://uni.onekey-asset.com/server-service-indexer/evm--1/tokens/address-0xdac17f958d2ee523a2206206994597c13d831ec7.png',
+    usdc: 'https://uni.onekey-asset.com/server-service-indexer/evm--1/tokens/address-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png',
+  };
+
+  // Chains not returned by /chains API, hardcoded
+  private static readonly EXTRA_CHAINS: {
+    chain: IRelayChain;
+    currencies: IRelayCurrency[];
+  }[] = [
+    {
+      chain: {
+        id: BITCOIN_CHAIN_ID,
+        name: 'Bitcoin',
+        icon: 'https://uni.onekey-asset.com/static/chain/btc.png',
+        vmType: 'btc',
+      },
+      currencies: [
+        {
+          chainId: BITCOIN_CHAIN_ID,
+          address: 'bc1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqmql8k8',
+          symbol: 'BTC',
+          name: 'Bitcoin',
+          decimals: 8,
+          logoURI: 'https://uni.onekey-asset.com/static/chain/btc.png',
+        },
+      ],
+    },
+    {
+      chain: {
+        id: TRON_CHAIN_ID,
+        name: 'Tron',
+        icon: 'https://uni.onekey-asset.com/static/chain/tron.png',
+        vmType: 'tvm',
+      },
+      currencies: [
+        {
+          chainId: TRON_CHAIN_ID,
+          address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+          symbol: 'USDT',
+          name: 'Tether USD',
+          decimals: 6,
+          logoURI:
+            'https://uni.onekey-asset.com/server-service-indexer/tron--0x2b6653dc/tokens/address-TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t.png',
+        },
+      ],
+    },
+  ];
+
+  private _chainsCache: {
+    chains: IRelayChain[];
+    currencies: Record<number, IRelayCurrency[]>;
+  } | null = null;
+
+  @backgroundMethod()
+  async getRelayChains(): Promise<{
+    chains: IRelayChain[];
+    currencies: Record<number, IRelayCurrency[]>;
+  }> {
+    if (this._chainsCache) {
+      return this._chainsCache;
+    }
+
+    const response = await fetch(`${RELAY_API_BASE}/chains`);
+    const data = (await response.json()) as IRelayChainsResponse;
+
+    const chains: IRelayChain[] = [];
+    const currencies: Record<number, IRelayCurrency[]> = {};
+
+    for (const chain of data.chains ?? []) {
+      if (
+        chain.vmType === 'evm' &&
+        ServiceRelay.SUPPORTED_CHAIN_IDS.has(chain.id) &&
+        chain.solverCurrencies &&
+        chain.solverCurrencies.length > 0
+      ) {
+        const filteredCurrencies = chain.solverCurrencies.filter((c) =>
+          ServiceRelay.SUPPORTED_CURRENCY_SYMBOLS.has(c.symbol.toLowerCase()),
+        );
+        if (filteredCurrencies.length > 0) {
+          const chainInfo = ServiceRelay.CHAIN_INFO_MAP[chain.id];
+          chains.push({
+            id: chain.id,
+            name: chainInfo?.displayName || chain.name,
+            icon: chainInfo?.logo || chain.icon || '',
+            vmType: chain.vmType,
+          });
+          currencies[chain.id] = filteredCurrencies.map((c) => ({
+            chainId: c.chainId,
+            address: c.address,
+            symbol: c.symbol,
+            name: c.name,
+            decimals: c.decimals,
+            logoURI: ServiceRelay._resolveTokenLogo(
+              c.symbol,
+              c.logoURI,
+              chain.id,
+              c.address,
+            ),
+          }));
+        }
+      }
+    }
+
+    // Add chains not returned by /chains API (BTC, Tron, etc.)
+    for (const extra of ServiceRelay.EXTRA_CHAINS) {
+      chains.push(extra.chain);
+      currencies[extra.chain.id] = extra.currencies;
+    }
+
+    this._chainsCache = { chains, currencies };
+    return this._chainsCache;
+  }
+
+  /**
+   * Resolve token logo: our curated map takes priority, then API logoURI,
+   * then a generated URL from the indexer.
+   */
+  private static _resolveTokenLogo(
+    symbol: string,
+    apiLogoURI: string,
+    chainId: number,
+    address: string,
+  ): string {
+    const key = symbol.toLowerCase();
+    return (
+      ServiceRelay.TOKEN_LOGO_MAP[key] ||
+      apiLogoURI ||
+      `https://uni.onekey-asset.com/server-service-indexer/evm--${chainId}/tokens/address-${address}.png`
+    );
+  }
+
+  /**
+   * Convert a human-readable amount string to smallest-unit integer string.
+   * Uses string splitting instead of floating-point to avoid precision loss.
+   */
+  private static _toSmallestUnit(amount: string, decimals: number): string {
+    const [intPart, decPart = ''] = amount.split('.');
+    const paddedDec = decPart.slice(0, decimals).padEnd(decimals, '0');
+    const raw = `${intPart}${paddedDec}`.replace(/^0+/, '') || '0';
+    return raw;
+  }
+
+  private _buildQuoteRequest(params: {
+    originChainId: number;
+    originCurrency: string;
+    recipient: string;
+    amount: string;
+    tradeType?: 'EXACT_INPUT' | 'EXACT_OUTPUT';
+    decimals?: number;
+  }): IRelayQuoteRequest {
+    const { originChainId, originCurrency, recipient, amount } = params;
+    const amountDecimals =
+      params.tradeType === 'EXACT_INPUT'
+        ? (params.decimals ?? DEFAULT_EVM_DECIMALS)
+        : DESTINATION_DECIMALS;
+    const amountInSmallestUnit = ServiceRelay._toSmallestUnit(
+      amount,
+      amountDecimals,
+    );
+
+    const dummyUser = NON_EVM_DUMMY_USERS[originChainId];
+    const isNonEvm = !!dummyUser;
+
+    const baseRequest = {
+      originChainId,
+      destinationChainId: HYPERLIQUID_CHAIN_ID,
+      originCurrency,
+      destinationCurrency: HYPERLIQUID_DESTINATION_CURRENCY,
+      recipient,
+      amount: amountInSmallestUnit,
+      useDepositAddress: true,
+    };
+
+    if (isNonEvm) {
+      return {
+        ...baseRequest,
+        user: dummyUser,
+        tradeType:
+          params.tradeType === 'EXACT_INPUT'
+            ? 'EXACT_INPUT'
+            : 'EXPECTED_OUTPUT',
+      };
+    }
+
+    return {
+      ...baseRequest,
+      user: EVM_DUMMY_USER,
+      tradeType: params.tradeType || 'EXACT_OUTPUT',
+      refundTo: recipient,
+    };
+  }
+
+  private _parseDepositAddress(data: IRelayQuoteResponse): string {
+    for (const step of data.steps ?? []) {
+      if (step.depositAddress) {
+        return step.depositAddress;
+      }
+      let fallback = '';
+      for (const item of step.items ?? []) {
+        if (item.data?.depositAddress) {
+          return item.data.depositAddress;
+        }
+        if (!fallback && item.data?.to) {
+          fallback = item.data.to;
+        }
+      }
+      if (fallback) return fallback;
+    }
+    return '';
+  }
+
+  private _parseMaxAmountFromError(errorText: string): string | null {
+    // Error format: "Max amount is $318,361 USD"
+    const match = errorText.match(/Max amount is \$?([\d,]+(?:\.\d+)?)/i);
+    if (match?.[1]) {
+      return match[1].replace(/,/g, '');
+    }
+    return null;
+  }
+
+  private async _fetchQuote(
+    requestBody: IRelayQuoteRequest,
+  ): Promise<IRelayQuoteResponse> {
+    const response = await fetch(`${RELAY_API_BASE}/quote/v2`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new OneKeyError({ message: errorText });
+    }
+
+    return (await response.json()) as IRelayQuoteResponse;
+  }
+
+  private _buildDepositInfo(
+    data: IRelayQuoteResponse,
+    fallbackAmount: string,
+  ): Omit<IRelayDepositInfo, 'maxReceiveAmount'> {
+    const depositAddress = this._parseDepositAddress(data);
+    if (!depositAddress) {
+      throw new OneKeyError({
+        message: 'No deposit address found in relay quote response',
+      });
+    }
+
+    const totalFeeUsd = (
+      parseFloat(data.fees?.gas?.amountUsd ?? '0') +
+      parseFloat(data.fees?.relayer?.amountUsd ?? '0')
+    ).toFixed(2);
+
+    return {
+      depositAddress,
+      sendAmount:
+        data.details?.currencyIn?.amountFormatted ?? fallbackAmount,
+      sendSymbol: data.details?.currencyIn?.currency?.symbol ?? '',
+      receiveAmount: data.details?.currencyOut?.amountFormatted ?? '0',
+      receiveSymbol: data.details?.currencyOut?.currency?.symbol ?? 'USDC',
+      totalFeeUsd,
+      totalFeePercent: data.details?.totalImpact?.percent,
+      timeEstimate: data.details?.timeEstimate ?? 0,
+    };
+  }
+
+  @backgroundMethod()
+  async getRelayQuote(params: {
+    originChainId: number;
+    originCurrency: string;
+    recipient: string;
+    amount: string;
+  }): Promise<IRelayDepositInfo> {
+    const requestBody = this._buildQuoteRequest(params);
+    const data = await this._fetchQuote(requestBody);
+    return this._buildDepositInfo(data, params.amount);
+  }
+
+  @backgroundMethod()
+  async getRelayMaxQuote(params: {
+    originChainId: number;
+    originCurrency: string;
+    recipient: string;
+    amount?: string;
+    tradeType?: 'EXACT_INPUT' | 'EXACT_OUTPUT';
+    decimals?: number;
+  }): Promise<IRelayDepositInfo> {
+    const quoteAmount = params.amount || '100';
+
+    // Parallel: quote for deposit address + fees, large probe for max amount
+    const [quoteResult, probeResult] = await Promise.allSettled([
+      this._fetchQuote(
+        this._buildQuoteRequest({
+          originChainId: params.originChainId,
+          originCurrency: params.originCurrency,
+          recipient: params.recipient,
+          amount: quoteAmount,
+          tradeType: params.tradeType,
+          decimals: params.decimals,
+        }),
+      ),
+      this._fetchQuote(
+        this._buildQuoteRequest({
+          originChainId: params.originChainId,
+          originCurrency: params.originCurrency,
+          recipient: params.recipient,
+          amount: MAX_PROBE_AMOUNT,
+        }),
+      ),
+    ]);
+
+    if (quoteResult.status === 'rejected') {
+      throw new OneKeyError({
+        message: `Relay quote failed: ${quoteResult.reason instanceof Error ? quoteResult.reason.message : String(quoteResult.reason)}`,
+      });
+    }
+
+    const depositInfo = this._buildDepositInfo(quoteResult.value, quoteAmount);
+
+    // Extract max amount from probe result
+    let maxReceiveAmount: string | undefined;
+    if (probeResult.status === 'fulfilled') {
+      maxReceiveAmount =
+        probeResult.value.details?.currencyOut?.amountFormatted;
+    } else {
+      const errorMessage =
+        probeResult.reason instanceof Error
+          ? probeResult.reason.message
+          : String(probeResult.reason);
+      maxReceiveAmount =
+        this._parseMaxAmountFromError(errorMessage) ?? undefined;
+    }
+
+    return {
+      ...depositInfo,
+      maxReceiveAmount,
+    };
+  }
+}
+
+export default ServiceRelay;

--- a/packages/kit-bg/src/services/ServiceRelay.ts
+++ b/packages/kit-bg/src/services/ServiceRelay.ts
@@ -8,9 +8,13 @@ import type {
   IRelayChainsResponse,
   IRelayCurrency,
   IRelayDepositInfo,
+  IRelayDepositStatusInfo,
+  IRelayIntentStatusResponse,
   IRelayQuoteRequest,
   IRelayQuoteResponse,
   IRelayQuoteStep,
+  IRelayRequest,
+  IRelayRequestsResponse,
 } from '@onekeyhq/shared/types/relay';
 
 import ServiceBase from './ServiceBase';
@@ -293,6 +297,57 @@ class ServiceRelay extends ServiceBase {
     return (await response.json()) as IRelayQuoteResponse;
   }
 
+  private static _buildUrl(
+    path: string,
+    params: Record<string, string | number | boolean | undefined>,
+  ) {
+    const url = new URL(`${RELAY_API_BASE}${path}`);
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined) {
+        url.searchParams.set(key, String(value));
+      }
+    });
+    return url.toString();
+  }
+
+  private async _fetchRelayJson<T>(url: string): Promise<T> {
+    const response = await fetch(url);
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new OneKeyError({ message: errorText || 'Relay request failed' });
+    }
+    return (await response.json()) as T;
+  }
+
+  private static _normalizeRequestsResponse(
+    data: IRelayRequestsResponse,
+  ): IRelayRequest[] {
+    if (Array.isArray(data.requests)) {
+      return data.requests;
+    }
+    if (data.requests) {
+      return [data.requests];
+    }
+    return [];
+  }
+
+  private static _flattenRelayRequests(
+    requests: IRelayRequest[],
+  ): IRelayRequest[] {
+    return requests.flatMap((request) => [
+      request,
+      ...ServiceRelay._flattenRelayRequests(request.childRequests ?? []),
+    ]);
+  }
+
+  private static _getRequestId(request?: IRelayRequest): string | undefined {
+    return request?.id ?? request?.requestId;
+  }
+
+  private static _isRelayTerminalStatus(status?: string) {
+    return status === 'success' || status === 'refund' || status === 'failure';
+  }
+
   private _buildDepositInfo(
     data: IRelayQuoteResponse,
     fallbackAmount: string,
@@ -331,6 +386,72 @@ class ServiceRelay extends ServiceBase {
     });
     const data = await this._fetchQuote(requestBody);
     return this._buildDepositInfo(data, params.amount);
+  }
+
+  @backgroundMethod()
+  async getRelayRequestsByDepositAddress(params: {
+    depositAddress: string;
+    requestId?: string;
+  }): Promise<IRelayRequest[]> {
+    ServiceRelay._assertEvmAddress(params.depositAddress, 'deposit');
+
+    const url = ServiceRelay._buildUrl('/requests/v2', {
+      depositAddress: params.depositAddress,
+      includeChildRequests: true,
+      sortBy: 'updatedAt',
+      sortDirection: 'desc',
+      limit: 20,
+    });
+    const data = await this._fetchRelayJson<IRelayRequestsResponse>(url);
+    return ServiceRelay._normalizeRequestsResponse(data);
+  }
+
+  @backgroundMethod()
+  async getRelayIntentStatus(params: {
+    requestId: string;
+  }): Promise<IRelayIntentStatusResponse> {
+    if (!params.requestId) {
+      throw new OneKeyError({ message: 'Missing Relay requestId' });
+    }
+    const url = ServiceRelay._buildUrl('/intents/status/v3', {
+      requestId: params.requestId,
+    });
+    return this._fetchRelayJson<IRelayIntentStatusResponse>(url);
+  }
+
+  @backgroundMethod()
+  async getRelayDepositStatus(params: {
+    depositAddress: string;
+    requestId?: string;
+  }): Promise<IRelayDepositStatusInfo> {
+    const requests = ServiceRelay._flattenRelayRequests(
+      await this.getRelayRequestsByDepositAddress(params),
+    );
+    const request = params.requestId
+      ? requests.find(
+          (item) => ServiceRelay._getRequestId(item) === params.requestId,
+        )
+      : requests[0];
+    const requestId = ServiceRelay._getRequestId(request) ?? params.requestId;
+
+    let intentStatus: IRelayIntentStatusResponse | undefined;
+    if (requestId && !ServiceRelay._isRelayTerminalStatus(request?.status)) {
+      intentStatus = await this.getRelayIntentStatus({ requestId });
+    }
+
+    return {
+      status: request?.status ?? intentStatus?.status ?? 'waiting',
+      requestId,
+      depositAddress: params.depositAddress,
+      inTxs: request?.data?.inTxs ?? [],
+      outTxs: request?.data?.outTxs ?? [],
+      createdAt: request?.createdAt,
+      updatedAt: request?.updatedAt,
+      quoteCreatedAt: intentStatus?.quoteCreatedAt,
+      lastCheckedAt: Date.now(),
+      request,
+      intentStatus,
+    };
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceRelay.ts
+++ b/packages/kit-bg/src/services/ServiceRelay.ts
@@ -10,6 +10,7 @@ import type {
   IRelayDepositInfo,
   IRelayQuoteRequest,
   IRelayQuoteResponse,
+  IRelayQuoteStep,
 } from '@onekeyhq/shared/types/relay';
 
 import ServiceBase from './ServiceBase';
@@ -18,21 +19,8 @@ import ServiceBase from './ServiceBase';
 const RELAY_API_BASE = 'https://api.relay.link';
 const HYPERLIQUID_CHAIN_ID = 1337;
 const HYPERLIQUID_DESTINATION_CURRENCY = '0x00000000000000000000000000000000';
-// Hyperliquid uses 8-decimal USDC for EXACT_OUTPUT amount encoding
-const DESTINATION_DECIMALS = 8;
-const DEFAULT_EVM_DECIMALS = 18;
-const MAX_PROBE_AMOUNT = '10000000'; // 10M USD probe to find max liquidity
-
-// Non-EVM chain IDs
-const BITCOIN_CHAIN_ID = 8_253_038;
-const TRON_CHAIN_ID = 728_126_428;
-
-// Dummy users for non-EVM quote requests (API requires a valid address format)
-const NON_EVM_DUMMY_USERS: Record<number, string> = {
-  [BITCOIN_CHAIN_ID]: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
-  [TRON_CHAIN_ID]: 'TCWTKkQUNJw5rUersaecwkGKkxpU5amwmJ',
-};
-const EVM_DUMMY_USER = '0x0000000000000000000000000000000000000001';
+const DEFAULT_ORIGIN_DECIMALS = 18;
+const MAX_EXACT_INPUT_PROBE_AMOUNT = '10000000';
 
 @backgroundClass()
 class ServiceRelay extends ServiceBase {
@@ -40,7 +28,9 @@ class ServiceRelay extends ServiceBase {
     super({ backgroundApi });
   }
 
-  // Major chains supported for Relay deposit
+  // Curated EVM origins for the first Relay deposit UI. Relay also exposes
+  // non-EVM origins, but they need origin-specific refund address UX; using
+  // dummy BTC/TRON users would make refunds unsafe.
   private static readonly SUPPORTED_CHAIN_IDS = new Set([
     1, // Ethereum
     10, // Optimism
@@ -49,8 +39,6 @@ class ServiceRelay extends ServiceBase {
     8453, // Base
     42_161, // Arbitrum
     43_114, // Avalanche
-    BITCOIN_CHAIN_ID,
-    TRON_CHAIN_ID,
   ]);
 
   // Major currencies to keep (by symbol, case-insensitive)
@@ -59,106 +47,17 @@ class ServiceRelay extends ServiceBase {
     'usdt',
     'eth',
     'weth',
-    'btc',
     'wbtc',
   ]);
-
-  // Chain display info overrides
-  private static readonly CHAIN_INFO_MAP: Record<
-    number,
-    { logo: string; displayName: string }
-  > = {
-    1: {
-      logo: 'https://uni.onekey-asset.com/static/chain/eth.png',
-      displayName: 'Ethereum',
-    },
-    10: {
-      logo: 'https://uni.onekey-asset.com/static/chain/optimism.png',
-      displayName: 'Optimism',
-    },
-    56: {
-      logo: 'https://uni.onekey-asset.com/static/chain/bsc.png',
-      displayName: 'BNB Chain',
-    },
-    137: {
-      logo: 'https://uni.onekey-asset.com/static/chain/polygon.png',
-      displayName: 'Polygon',
-    },
-    8453: {
-      logo: 'https://uni.onekey-asset.com/static/chain/base.png',
-      displayName: 'Base',
-    },
-    42_161: {
-      logo: 'https://uni.onekey-asset.com/static/chain/arbitrum.png',
-      displayName: 'Arbitrum',
-    },
-    43_114: {
-      logo: 'https://uni.onekey-asset.com/static/chain/avalanche.png',
-      displayName: 'Avalanche',
-    },
-    [BITCOIN_CHAIN_ID]: {
-      logo: 'https://uni.onekey-asset.com/static/chain/btc.png',
-      displayName: 'Bitcoin',
-    },
-    [TRON_CHAIN_ID]: {
-      logo: 'https://uni.onekey-asset.com/static/chain/tron.png',
-      displayName: 'Tron',
-    },
-  };
 
   // Well-known token logos — takes priority over API-provided logoURI
   private static readonly TOKEN_LOGO_MAP: Record<string, string> = {
     eth: 'https://uni.onekey-asset.com/static/chain/eth.png',
     weth: 'https://uni.onekey-asset.com/server-service-indexer/evm--1/tokens/address-0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png',
-    btc: 'https://uni.onekey-asset.com/static/chain/btc.png',
     wbtc: 'https://uni.onekey-asset.com/server-service-indexer/evm--1/tokens/address-0x2260fac5e5542a773aa44fbcfedf7c193bc2c599.png',
     usdt: 'https://uni.onekey-asset.com/server-service-indexer/evm--1/tokens/address-0xdac17f958d2ee523a2206206994597c13d831ec7.png',
     usdc: 'https://uni.onekey-asset.com/server-service-indexer/evm--1/tokens/address-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png',
   };
-
-  // Chains not returned by /chains API, hardcoded
-  private static readonly EXTRA_CHAINS: {
-    chain: IRelayChain;
-    currencies: IRelayCurrency[];
-  }[] = [
-    {
-      chain: {
-        id: BITCOIN_CHAIN_ID,
-        name: 'Bitcoin',
-        icon: 'https://uni.onekey-asset.com/static/chain/btc.png',
-        vmType: 'btc',
-      },
-      currencies: [
-        {
-          chainId: BITCOIN_CHAIN_ID,
-          address: 'bc1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqmql8k8',
-          symbol: 'BTC',
-          name: 'Bitcoin',
-          decimals: 8,
-          logoURI: 'https://uni.onekey-asset.com/static/chain/btc.png',
-        },
-      ],
-    },
-    {
-      chain: {
-        id: TRON_CHAIN_ID,
-        name: 'Tron',
-        icon: 'https://uni.onekey-asset.com/static/chain/tron.png',
-        vmType: 'tvm',
-      },
-      currencies: [
-        {
-          chainId: TRON_CHAIN_ID,
-          address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
-          symbol: 'USDT',
-          name: 'Tether USD',
-          decimals: 6,
-          logoURI:
-            'https://uni.onekey-asset.com/server-service-indexer/tron--0x2b6653dc/tokens/address-TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t.png',
-        },
-      ],
-    },
-  ];
 
   private _chainsCache: {
     chains: IRelayChain[];
@@ -198,11 +97,10 @@ class ServiceRelay extends ServiceBase {
           ServiceRelay.SUPPORTED_CURRENCY_SYMBOLS.has(c.symbol.toLowerCase()),
         );
         if (filteredCurrencies.length > 0) {
-          const chainInfo = ServiceRelay.CHAIN_INFO_MAP[chain.id];
           chains.push({
             id: chain.id,
-            name: chainInfo?.displayName || chain.name,
-            icon: chainInfo?.logo || chain.icon || '',
+            name: chain.displayName || chain.name,
+            icon: chain.iconUrl || chain.icon || '',
             vmType: chain.vmType,
           });
           currencies[chain.id] = filteredCurrencies.map((c) => ({
@@ -220,12 +118,6 @@ class ServiceRelay extends ServiceBase {
           }));
         }
       }
-    }
-
-    // Add chains not returned by /chains API (BTC, Tron, etc.)
-    for (const extra of ServiceRelay.EXTRA_CHAINS) {
-      chains.push(extra.chain);
-      currencies[extra.chain.id] = extra.currencies;
     }
 
     this._chainsCache = { chains, currencies };
@@ -270,69 +162,59 @@ class ServiceRelay extends ServiceBase {
     originChainId: number;
     originCurrency: string;
     recipient: string;
+    user?: string;
+    refundTo?: string;
     amount: string;
-    tradeType?: 'EXACT_INPUT' | 'EXACT_OUTPUT';
     decimals?: number;
+    useDepositAddress?: boolean;
   }): IRelayQuoteRequest {
     const { originChainId, originCurrency, recipient, amount } = params;
-    const amountDecimals =
-      params.tradeType === 'EXACT_INPUT'
-        ? (params.decimals ?? DEFAULT_EVM_DECIMALS)
-        : DESTINATION_DECIMALS;
+    const refundTo = params.refundTo ?? recipient;
     const amountInSmallestUnit = ServiceRelay._toSmallestUnit(
       amount,
-      amountDecimals,
+      params.decimals ?? DEFAULT_ORIGIN_DECIMALS,
     );
 
-    const dummyUser = NON_EVM_DUMMY_USERS[originChainId];
-    const isNonEvm = !!dummyUser;
-
-    const baseRequest = {
+    return {
       originChainId,
       destinationChainId: HYPERLIQUID_CHAIN_ID,
       originCurrency,
       destinationCurrency: HYPERLIQUID_DESTINATION_CURRENCY,
+      user: params.user ?? refundTo,
       recipient,
       amount: amountInSmallestUnit,
-      useDepositAddress: true,
-    };
-
-    if (isNonEvm) {
-      return {
-        ...baseRequest,
-        user: dummyUser,
-        tradeType:
-          params.tradeType === 'EXACT_INPUT'
-            ? 'EXACT_INPUT'
-            : 'EXPECTED_OUTPUT',
-      };
-    }
-
-    return {
-      ...baseRequest,
-      user: EVM_DUMMY_USER,
-      tradeType: params.tradeType || 'EXACT_OUTPUT',
-      refundTo: recipient,
+      tradeType: 'EXACT_INPUT',
+      useDepositAddress: params.useDepositAddress ?? true,
+      refundTo,
     };
   }
 
-  private _parseDepositAddress(data: IRelayQuoteResponse): string {
+  private _parseDepositStep(data: IRelayQuoteResponse): {
+    depositAddress: string;
+    requestId?: string;
+  } {
     for (const step of data.steps ?? []) {
       if (step.depositAddress) {
-        return step.depositAddress;
+        return {
+          depositAddress: step.depositAddress,
+          requestId: ServiceRelay._parseRequestId(step),
+        };
       }
-      let fallback = '';
+
       for (const item of step.items ?? []) {
         if (item.data?.depositAddress) {
-          return item.data.depositAddress;
-        }
-        if (!fallback && item.data?.to) {
-          fallback = item.data.to;
+          return {
+            depositAddress: item.data.depositAddress,
+            requestId: ServiceRelay._parseRequestId(step),
+          };
         }
       }
-      if (fallback) return fallback;
     }
-    return '';
+    return { depositAddress: '' };
+  }
+
+  private static _parseRequestId(step: IRelayQuoteStep): string | undefined {
+    return step.requestId;
   }
 
   private _parseMaxAmountFromError(errorText: string): string | null {
@@ -367,7 +249,7 @@ class ServiceRelay extends ServiceBase {
     data: IRelayQuoteResponse,
     fallbackAmount: string,
   ): Omit<IRelayDepositInfo, 'maxReceiveAmount'> {
-    const depositAddress = this._parseDepositAddress(data);
+    const { depositAddress, requestId } = this._parseDepositStep(data);
     if (!depositAddress) {
       throw new OneKeyError({
         message: 'No deposit address found in relay quote response',
@@ -381,6 +263,7 @@ class ServiceRelay extends ServiceBase {
 
     return {
       depositAddress,
+      requestId,
       sendAmount: data.details?.currencyIn?.amountFormatted ?? fallbackAmount,
       sendSymbol: data.details?.currencyIn?.currency?.symbol ?? '',
       receiveAmount: data.details?.currencyOut?.amountFormatted ?? '0',
@@ -396,7 +279,10 @@ class ServiceRelay extends ServiceBase {
     originChainId: number;
     originCurrency: string;
     recipient: string;
+    user?: string;
+    refundTo?: string;
     amount: string;
+    decimals?: number;
   }): Promise<IRelayDepositInfo> {
     const requestBody = this._buildQuoteRequest(params);
     const data = await this._fetchQuote(requestBody);
@@ -408,8 +294,9 @@ class ServiceRelay extends ServiceBase {
     originChainId: number;
     originCurrency: string;
     recipient: string;
+    user?: string;
+    refundTo?: string;
     amount?: string;
-    tradeType?: 'EXACT_INPUT' | 'EXACT_OUTPUT';
     decimals?: number;
   }): Promise<IRelayDepositInfo> {
     const quoteAmount = params.amount || '100';
@@ -421,8 +308,9 @@ class ServiceRelay extends ServiceBase {
           originChainId: params.originChainId,
           originCurrency: params.originCurrency,
           recipient: params.recipient,
+          user: params.user,
+          refundTo: params.refundTo,
           amount: quoteAmount,
-          tradeType: params.tradeType,
           decimals: params.decimals,
         }),
       ),
@@ -431,7 +319,11 @@ class ServiceRelay extends ServiceBase {
           originChainId: params.originChainId,
           originCurrency: params.originCurrency,
           recipient: params.recipient,
-          amount: MAX_PROBE_AMOUNT,
+          user: params.user,
+          refundTo: params.refundTo,
+          amount: MAX_EXACT_INPUT_PROBE_AMOUNT,
+          useDepositAddress: false,
+          decimals: params.decimals,
         }),
       ),
     ]);

--- a/packages/kit-bg/src/services/ServiceRelay.ts
+++ b/packages/kit-bg/src/services/ServiceRelay.ts
@@ -17,8 +17,7 @@ import ServiceBase from './ServiceBase';
 // --- Relay protocol constants ---
 const RELAY_API_BASE = 'https://api.relay.link';
 const HYPERLIQUID_CHAIN_ID = 1337;
-const HYPERLIQUID_DESTINATION_CURRENCY =
-  '0x00000000000000000000000000000000';
+const HYPERLIQUID_DESTINATION_CURRENCY = '0x00000000000000000000000000000000';
 // Hyperliquid uses 8-decimal USDC for EXACT_OUTPUT amount encoding
 const DESTINATION_DECIMALS = 8;
 const DEFAULT_EVM_DECIMALS = 18;
@@ -176,6 +175,13 @@ class ServiceRelay extends ServiceBase {
     }
 
     const response = await fetch(`${RELAY_API_BASE}/chains`);
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new OneKeyError({
+        message: errorText || 'Failed to load Relay chains',
+      });
+    }
+
     const data = (await response.json()) as IRelayChainsResponse;
 
     const chains: IRelayChain[] = [];
@@ -200,14 +206,14 @@ class ServiceRelay extends ServiceBase {
             vmType: chain.vmType,
           });
           currencies[chain.id] = filteredCurrencies.map((c) => ({
-            chainId: c.chainId,
+            chainId: c.chainId ?? chain.id,
             address: c.address,
             symbol: c.symbol,
             name: c.name,
             decimals: c.decimals,
             logoURI: ServiceRelay._resolveTokenLogo(
               c.symbol,
-              c.logoURI,
+              c.logoURI ?? c.metadata?.logoURI ?? '',
               chain.id,
               c.address,
             ),
@@ -249,7 +255,12 @@ class ServiceRelay extends ServiceBase {
    * Uses string splitting instead of floating-point to avoid precision loss.
    */
   private static _toSmallestUnit(amount: string, decimals: number): string {
-    const [intPart, decPart = ''] = amount.split('.');
+    const normalizedAmount = amount.trim();
+    if (!/^(?:0|[1-9]\d*)(?:\.\d*)?$/.test(normalizedAmount)) {
+      throw new OneKeyError({ message: 'Invalid Relay quote amount' });
+    }
+
+    const [intPart, decPart = ''] = normalizedAmount.split('.');
     const paddedDec = decPart.slice(0, decimals).padEnd(decimals, '0');
     const raw = `${intPart}${paddedDec}`.replace(/^0+/, '') || '0';
     return raw;
@@ -370,8 +381,7 @@ class ServiceRelay extends ServiceBase {
 
     return {
       depositAddress,
-      sendAmount:
-        data.details?.currencyIn?.amountFormatted ?? fallbackAmount,
+      sendAmount: data.details?.currencyIn?.amountFormatted ?? fallbackAmount,
       sendSymbol: data.details?.currencyIn?.currency?.symbol ?? '',
       receiveAmount: data.details?.currencyOut?.amountFormatted ?? '0',
       receiveSymbol: data.details?.currencyOut?.currency?.symbol ?? 'USDC',

--- a/packages/kit-bg/src/services/ServiceRelay.ts
+++ b/packages/kit-bg/src/services/ServiceRelay.ts
@@ -22,6 +22,22 @@ const HYPERLIQUID_DESTINATION_CURRENCY = '0x00000000000000000000000000000000';
 const DEFAULT_ORIGIN_DECIMALS = 18;
 const MAX_EXACT_INPUT_PROBE_AMOUNT = '10000000';
 
+type IRelayQuoteParams = {
+  originChainId: number;
+  originCurrency: string;
+  recipient: string;
+  user?: string;
+  refundTo?: string;
+  amount: string;
+  decimals?: number;
+};
+
+type IRelayQuoteRouteParams = Omit<IRelayQuoteParams, 'amount' | 'decimals'>;
+
+type IRelayQuoteRequestParams = IRelayQuoteParams & {
+  useDepositAddress?: boolean;
+};
+
 @backgroundClass()
 class ServiceRelay extends ServiceBase {
   constructor({ backgroundApi }: { backgroundApi: any }) {
@@ -142,6 +158,45 @@ class ServiceRelay extends ServiceBase {
     );
   }
 
+  private static _isEvmAddress(address: string): boolean {
+    return /^0x[a-fA-F0-9]{40}$/.test(address);
+  }
+
+  private static _assertEvmAddress(address: string, fieldName: string) {
+    if (!ServiceRelay._isEvmAddress(address)) {
+      throw new OneKeyError({ message: `Invalid Relay ${fieldName} address` });
+    }
+  }
+
+  private async _validateQuoteRoute(
+    params: IRelayQuoteRouteParams,
+  ): Promise<IRelayCurrency> {
+    const { originChainId, originCurrency, recipient, user, refundTo } = params;
+
+    if (!ServiceRelay.SUPPORTED_CHAIN_IDS.has(originChainId)) {
+      throw new OneKeyError({ message: 'Unsupported Relay origin chain' });
+    }
+
+    ServiceRelay._assertEvmAddress(recipient, 'recipient');
+    ServiceRelay._assertEvmAddress(user ?? refundTo ?? recipient, 'user');
+    if (refundTo) {
+      ServiceRelay._assertEvmAddress(refundTo, 'refundTo');
+    }
+
+    const { currencies } = await this.getRelayChains();
+    const currency = currencies[originChainId]?.find(
+      (item) =>
+        item.address.toLowerCase() === originCurrency.toLowerCase() &&
+        ServiceRelay.SUPPORTED_CURRENCY_SYMBOLS.has(item.symbol.toLowerCase()),
+    );
+
+    if (!currency) {
+      throw new OneKeyError({ message: 'Unsupported Relay origin currency' });
+    }
+
+    return currency;
+  }
+
   /**
    * Convert a human-readable amount string to smallest-unit integer string.
    * Uses string splitting instead of floating-point to avoid precision loss.
@@ -158,16 +213,9 @@ class ServiceRelay extends ServiceBase {
     return raw;
   }
 
-  private _buildQuoteRequest(params: {
-    originChainId: number;
-    originCurrency: string;
-    recipient: string;
-    user?: string;
-    refundTo?: string;
-    amount: string;
-    decimals?: number;
-    useDepositAddress?: boolean;
-  }): IRelayQuoteRequest {
+  private _buildQuoteRequest(
+    params: IRelayQuoteRequestParams,
+  ): IRelayQuoteRequest {
     const { originChainId, originCurrency, recipient, amount } = params;
     const refundTo = params.refundTo ?? recipient;
     const amountInSmallestUnit = ServiceRelay._toSmallestUnit(
@@ -275,16 +323,12 @@ class ServiceRelay extends ServiceBase {
   }
 
   @backgroundMethod()
-  async getRelayQuote(params: {
-    originChainId: number;
-    originCurrency: string;
-    recipient: string;
-    user?: string;
-    refundTo?: string;
-    amount: string;
-    decimals?: number;
-  }): Promise<IRelayDepositInfo> {
-    const requestBody = this._buildQuoteRequest(params);
+  async getRelayQuote(params: IRelayQuoteParams): Promise<IRelayDepositInfo> {
+    const currency = await this._validateQuoteRoute(params);
+    const requestBody = this._buildQuoteRequest({
+      ...params,
+      decimals: currency.decimals,
+    });
     const data = await this._fetchQuote(requestBody);
     return this._buildDepositInfo(data, params.amount);
   }
@@ -300,6 +344,7 @@ class ServiceRelay extends ServiceBase {
     decimals?: number;
   }): Promise<IRelayDepositInfo> {
     const quoteAmount = params.amount || '100';
+    const currency = await this._validateQuoteRoute(params);
 
     // Parallel: quote for deposit address + fees, large probe for max amount
     const [quoteResult, probeResult] = await Promise.allSettled([
@@ -311,7 +356,7 @@ class ServiceRelay extends ServiceBase {
           user: params.user,
           refundTo: params.refundTo,
           amount: quoteAmount,
-          decimals: params.decimals,
+          decimals: currency.decimals,
         }),
       ),
       this._fetchQuote(
@@ -323,7 +368,7 @@ class ServiceRelay extends ServiceBase {
           refundTo: params.refundTo,
           amount: MAX_EXACT_INPUT_PROBE_AMOUNT,
           useDepositAddress: false,
-          decimals: params.decimals,
+          decimals: currency.decimals,
         }),
       ),
     ]);

--- a/packages/kit-bg/src/states/jotai/atomNames.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.ts
@@ -95,6 +95,7 @@ export enum EAtomNames {
   perpTokenSelectorTabsAtom = 'perpTokenSelectorTabsAtom',
   perpTokenFavoritesPersistAtom = 'perpTokenFavoritesPersistAtom',
   perpsDepositOrderAtom = 'perpsDepositOrderAtom',
+  perpsRelayDepositSessionsAtom = 'perpsRelayDepositSessionsAtom',
   perpsLastUsedLeverageAtom = 'perpsLastUsedLeverageAtom',
   perpsLayoutStateAtom = 'perpsLayoutStateAtom',
   perpsAbstractionModeAtom = 'perpsAbstractionModeAtom',
@@ -163,6 +164,9 @@ export const atomsConfig: Partial<
     mergeInitialValue: false,
   },
   [EAtomNames.perpsDepositOrderAtom]: {
+    mergeInitialValue: false,
+  },
+  [EAtomNames.perpsRelayDepositSessionsAtom]: {
     mergeInitialValue: false,
   },
 };

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -20,6 +20,10 @@ import {
   ETriggerOrderType,
 } from '@onekeyhq/shared/types/hyperliquid';
 import { DEFAULT_PERP_TOKEN_ACTIVE_TAB } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type {
+  IRelayDepositStatus,
+  IRelayDepositTx,
+} from '@onekeyhq/shared/types/relay';
 import type { ESwapTxHistoryStatus } from '@onekeyhq/shared/types/swap/types';
 
 import { EAtomNames } from '../atomNames';
@@ -533,6 +537,40 @@ export const { target: perpsDepositOrderAtom, use: usePerpsDepositOrderAtom } =
       orders: [],
     },
   });
+
+export interface IPerpsRelayDepositSessionAtom {
+  id: string;
+  accountId?: string | null;
+  indexedAccountId?: string | null;
+  accountAddress?: IHex | null;
+  originChainId: number;
+  originChainName: string;
+  originCurrency: string;
+  originCurrencySymbol: string;
+  depositAddress: string;
+  requestId?: string;
+  sendAmount: string;
+  receiveAmount: string;
+  receiveSymbol: string;
+  status: IRelayDepositStatus;
+  inTxs: IRelayDepositTx[];
+  outTxs: IRelayDepositTx[];
+  createdAt: number;
+  updatedAt: number;
+  lastCheckedAt?: number;
+  error?: string;
+}
+
+export const {
+  target: perpsRelayDepositSessionsAtom,
+  use: usePerpsRelayDepositSessionsAtom,
+} = globalAtom<{ sessions: IPerpsRelayDepositSessionAtom[] }>({
+  name: EAtomNames.perpsRelayDepositSessionsAtom,
+  persist: true,
+  initialValue: {
+    sessions: [],
+  },
+});
 
 export interface IPerpsUserConfigPersistAtom {
   perpUserConfig: IPerpUserConfig;

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
@@ -33,6 +33,7 @@ import {
   parseDexCoin,
   validateSizeInput,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
+import type { ISetTpslParams } from '@onekeyhq/shared/types/hyperliquid/routes';
 import type { IPerpsFrontendOrder } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 import { usePerpsMidPrice } from '../../hooks/usePerpsMidPrice';
@@ -45,13 +46,6 @@ import { TradingFormInput } from '../TradingPanel/inputs/TradingFormInput';
 
 import type { RouteProp } from '@react-navigation/core';
 import type { IntlShape } from 'react-intl';
-
-export interface ISetTpslParams {
-  coin: string;
-  szDecimals: number;
-  assetId: number;
-  isMobile?: boolean;
-}
 
 interface ISetTpslFormProps extends ISetTpslParams {
   onClose: () => void;

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/RelayDepositTrackingCard.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/RelayDepositTrackingCard.tsx
@@ -1,0 +1,179 @@
+import {
+  Badge,
+  IconButton,
+  SizableText,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
+import type { IPerpsRelayDepositSessionAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+
+import { PerpTestIDs } from '../../../testIDs';
+import {
+  formatRelayDepositLastCheckedText,
+  getRelayDepositBadgeType,
+  getRelayDepositFinalStepDesc,
+  getRelayDepositFinalStepTitle,
+  getRelayDepositStatusLabel,
+  getRelayDepositStepIndex,
+  getRelayDepositTimelineDotBg,
+  shortenRelayDepositTxHash,
+} from '../../../utils/relayDepositTracking';
+
+type IRelayDepositTrackingCardProps = {
+  session: IPerpsRelayDepositSessionAtom;
+  loading: boolean;
+  onRefresh: () => void;
+};
+
+export function RelayDepositTrackingCard({
+  session,
+  loading,
+  onRefresh,
+}: IRelayDepositTrackingCardProps) {
+  const stepIndex = getRelayDepositStepIndex(session);
+  const terminalFailed =
+    session.status === 'failure' || session.status === 'refund';
+  const steps = [
+    {
+      title: 'Waiting for transfer',
+      desc: 'Send from your wallet or exchange to the Relay address above.',
+    },
+    {
+      title: 'Transfer detected',
+      desc: 'Relay has detected the source-chain deposit.',
+    },
+    {
+      title: 'Relay processing',
+      desc: 'Relay is moving funds into your Hyperliquid Perps account.',
+    },
+    {
+      title: getRelayDepositFinalStepTitle(session.status),
+      desc: getRelayDepositFinalStepDesc(session.status),
+    },
+  ];
+
+  return (
+    <YStack
+      testID={PerpTestIDs.RelayDepositTrackingCard}
+      gap="$3"
+      bg="$bgSubdued"
+      borderRadius="$3"
+      p="$3"
+    >
+      <XStack alignItems="center" justifyContent="space-between" gap="$2">
+        <YStack gap="$0.5" flex={1}>
+          <XStack alignItems="center" gap="$2">
+            <SizableText size="$bodyMdMedium">Deposit tracking</SizableText>
+            <Badge
+              badgeType={getRelayDepositBadgeType(
+                session.status,
+                session.inTxs.length > 0,
+              )}
+              badgeSize="sm"
+            >
+              {getRelayDepositStatusLabel(session.status, {
+                hasSourceTx: session.inTxs.length > 0,
+              })}
+            </Badge>
+          </XStack>
+          <SizableText size="$bodySm" color="$textSubdued">
+            {formatRelayDepositLastCheckedText(session.lastCheckedAt)}
+          </SizableText>
+        </YStack>
+        <IconButton
+          testID={PerpTestIDs.RelayDepositTrackingRefreshButton}
+          icon="RefreshCcwOutline"
+          size="small"
+          variant="tertiary"
+          loading={loading}
+          onPress={onRefresh}
+        />
+      </XStack>
+
+      <YStack gap="$2.5">
+        {steps.map((step, index) => {
+          const active = index <= stepIndex;
+          const isLast = index === steps.length - 1;
+          const dotBg = getRelayDepositTimelineDotBg({
+            active,
+            terminalFailed,
+            isLast,
+          });
+          return (
+            <XStack key={step.title} gap="$2.5" alignItems="stretch">
+              <YStack alignItems="center" pt="$0.5">
+                <YStack
+                  width={14}
+                  height={14}
+                  borderRadius="$full"
+                  bg={dotBg}
+                  alignItems="center"
+                  justifyContent="center"
+                >
+                  {active ? (
+                    <YStack
+                      width={5}
+                      height={5}
+                      borderRadius="$full"
+                      bg="$bgApp"
+                    />
+                  ) : null}
+                </YStack>
+                {!isLast ? (
+                  <YStack
+                    width="$px"
+                    flex={1}
+                    minHeight={18}
+                    bg={active ? '$borderSuccess' : '$borderSubdued'}
+                  />
+                ) : null}
+              </YStack>
+              <YStack flex={1} gap="$0.5" pb={isLast ? undefined : '$1'}>
+                <SizableText
+                  size="$bodySmMedium"
+                  color={active ? '$text' : '$textSubdued'}
+                >
+                  {step.title}
+                </SizableText>
+                <SizableText size="$bodySm" color="$textSubdued">
+                  {step.desc}
+                </SizableText>
+              </YStack>
+            </XStack>
+          );
+        })}
+      </YStack>
+
+      {session.inTxs[0]?.hash || session.outTxs[0]?.hash ? (
+        <YStack gap="$1.5" pt="$1">
+          {session.inTxs[0]?.hash ? (
+            <XStack justifyContent="space-between" gap="$2">
+              <SizableText size="$bodySm" color="$textSubdued">
+                Source tx
+              </SizableText>
+              <SizableText size="$bodySmMedium">
+                {shortenRelayDepositTxHash(session.inTxs[0].hash)}
+              </SizableText>
+            </XStack>
+          ) : null}
+          {session.outTxs[0]?.hash ? (
+            <XStack justifyContent="space-between" gap="$2">
+              <SizableText size="$bodySm" color="$textSubdued">
+                Destination tx
+              </SizableText>
+              <SizableText size="$bodySmMedium">
+                {shortenRelayDepositTxHash(session.outTxs[0].hash)}
+              </SizableText>
+            </XStack>
+          ) : null}
+        </YStack>
+      ) : null}
+
+      {session.error ? (
+        <SizableText size="$bodySm" color="$textCritical">
+          {session.error}
+        </SizableText>
+      ) : null}
+    </YStack>
+  );
+}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { BigNumber } from 'bignumber.js';
@@ -12,12 +19,12 @@ import {
   DashText,
   Divider,
   Icon,
+  IconButton,
   Image,
   Input,
   ListView,
   Page,
   Popover,
-  SegmentControl,
   SizableText,
   Skeleton,
   Toast,
@@ -29,7 +36,6 @@ import {
   usePopoverContext,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { AccountAvatar } from '@onekeyhq/kit/src/components/AccountAvatar';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
@@ -48,12 +54,12 @@ import {
   perpsActiveAccountAtom,
   usePerpsActiveAccountAtom,
   usePerpsActiveAccountSummaryAtom,
-  usePerpsComputedAccountValueAtom,
   usePerpsDepositTokensAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
 import { dismissKeyboardWithDelay } from '@onekeyhq/shared/src/keyboard';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
@@ -86,14 +92,20 @@ import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
 
 import usePerpDeposit from '../../../hooks/usePerpDeposit';
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../../PerpDialogLayout';
 import { PerpsAccountNumberValue } from '../components/PerpsAccountNumberValue';
 import { InputAccessoryDoneButton } from '../inputs/TradingFormInput';
+
+import RelayDepositContent from './RelayDepositContent';
 
 import type { RouteProp } from '@react-navigation/native';
 import type { ListRenderItem } from 'react-native';
 
-export type IPerpsDepositWithdrawActionType = 'deposit' | 'withdraw';
+export type IPerpsDepositWithdrawActionType =
+  | 'deposit'
+  | 'depositSelect'
+  | 'withdraw'
+  | 'walletDeposit'
+  | 'relay';
 
 const DEPOSIT_WITHDRAW_INPUT_ACCESSORY_VIEW_ID =
   'perp-deposit-withdraw-accessory-view';
@@ -106,6 +118,7 @@ interface IDepositWithdrawContentProps {
   params: IDepositWithdrawParams;
   selectedAccount: IPerpsActiveAccountAtom;
   onClose?: () => void;
+  onNavigate?: (actionType: IPerpsDepositWithdrawActionType) => void;
   isMobile?: boolean;
 }
 
@@ -146,47 +159,6 @@ function usePerpsAccountResult(selectedAccount: IPerpsActiveAccountAtom) {
 
   return accountResult;
 }
-function PerpsAccountAvatar({
-  selectedAccount,
-}: {
-  selectedAccount: IPerpsActiveAccountAtom;
-}) {
-  const accountResult = usePerpsAccountResult(selectedAccount);
-
-  if (!accountResult) return null;
-
-  return (
-    <XStack alignItems="center" gap="$2" pb="$3">
-      <AccountAvatar
-        size="small"
-        account={
-          accountResult.isOtherAccount ? accountResult.account : undefined
-        }
-        indexedAccount={
-          accountResult.isOtherAccount
-            ? undefined
-            : accountResult.indexedAccount
-        }
-        wallet={accountResult.wallet}
-      />
-      <XStack flex={1} minWidth={0} maxWidth="70%" overflow="hidden">
-        <SizableText
-          flex={1}
-          size="$bodyMdMedium"
-          color="$text"
-          numberOfLines={1}
-          ellipsizeMode="tail"
-        >
-          {accountResult?.isOtherAccount
-            ? accountResult?.account?.name
-            : accountResult?.indexedAccount?.name}
-        </SizableText>
-      </XStack>
-    </XStack>
-  );
-}
-PerpsAccountAvatar.displayName = 'PerpsAccountAvatar';
-
 function SelectTokenPopoverContent({
   symbol,
   depositTokensWithPrice,
@@ -339,18 +311,18 @@ function SelectTokenPopoverContent({
   );
 }
 
-function DepositWithdrawContent({
+export function DepositWithdrawContent({
   params,
   selectedAccount,
   onClose,
+  onNavigate,
   isMobile,
 }: IDepositWithdrawContentProps) {
   const intl = useIntl();
   const { gtMd } = useMedia();
   const [accountSummary] = usePerpsActiveAccountSummaryAtom();
-  const [computedValue] = usePerpsComputedAccountValueAtom();
-  const accountValue = computedValue?.accountValue ?? '';
-  const withdrawable = computedValue?.withdrawable ?? '';
+  const accountValue = accountSummary?.accountValue ?? '';
+  const withdrawable = accountSummary?.withdrawable ?? '';
   const [selectedAction, setSelectedAction] =
     useState<IPerpsDepositWithdrawActionType>(params.actionType);
   const [amount, setAmount] = useState('');
@@ -359,6 +331,64 @@ function DepositWithdrawContent({
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showMinAmountError, setShowMinAmountError] = useState(false);
+
+  // On mobile, dynamically update page header to show back/close button
+  const pageNavigation = useNavigation();
+  const backActionMap: Partial<
+    Record<IPerpsDepositWithdrawActionType, IPerpsDepositWithdrawActionType>
+  > = useMemo(
+    () => ({
+      depositSelect: 'deposit',
+      walletDeposit: 'depositSelect',
+      relay: 'depositSelect',
+      withdraw: 'deposit',
+    }),
+    [],
+  );
+  const headerBackAction = backActionMap[selectedAction];
+  const handleHeaderBack = useCallback(() => {
+    if (headerBackAction) {
+      setSelectedAction(headerBackAction);
+    }
+  }, [headerBackAction, setSelectedAction]);
+  const handleHeaderClose = useCallback(() => {
+    pageNavigation.goBack();
+  }, [pageNavigation]);
+  useLayoutEffect(() => {
+    if (!isMobile) return;
+    if (headerBackAction) {
+      pageNavigation.setOptions({
+        // eslint-disable-next-line react/no-unstable-nested-components
+        headerLeft: () => (
+          <IconButton
+            icon="ChevronLeftOutline"
+            size="small"
+            variant="tertiary"
+            onPress={handleHeaderBack}
+          />
+        ),
+      });
+    } else {
+      pageNavigation.setOptions({
+        // eslint-disable-next-line react/no-unstable-nested-components
+        headerLeft: () => (
+          <IconButton
+            icon="CrossedLargeOutline"
+            size="small"
+            variant="tertiary"
+            onPress={handleHeaderClose}
+          />
+        ),
+      });
+    }
+  }, [
+    isMobile,
+    headerBackAction,
+    pageNavigation,
+    handleHeaderBack,
+    handleHeaderClose,
+  ]);
+
   const unrealizedPnl = accountSummary?.totalUnrealizedPnl ?? '0';
   const unrealizedPnlInfo = useMemo(() => {
     const pnlBn = new BigNumber(unrealizedPnl || '0');
@@ -680,7 +710,12 @@ function DepositWithdrawContent({
     [currentPerpsDepositSelectedToken?.price],
   );
 
-  const isUsdInput = selectedAction === 'deposit' && depositInputUnit === 'usd';
+  const isDepositAction =
+    selectedAction === 'deposit' ||
+    selectedAction === 'depositSelect' ||
+    selectedAction === 'walletDeposit' ||
+    selectedAction === 'relay';
+  const isUsdInput = isDepositAction && depositInputUnit === 'usd';
 
   const tokenAmountBN = useMemo(() => {
     if (isUsdInput && tokenPriceBN.gt(0)) {
@@ -703,7 +738,7 @@ function DepositWithdrawContent({
   );
 
   const convertedDisplayValue = useMemo(() => {
-    if (selectedAction !== 'deposit' || amountBN.isNaN() || amountBN.lte(0)) {
+    if (!isDepositAction || amountBN.isNaN() || amountBN.lte(0)) {
       return '';
     }
     if (isUsdInput && tokenPriceBN.gt(0)) {
@@ -724,12 +759,12 @@ function DepositWithdrawContent({
     }
     return '';
   }, [
-    selectedAction,
     amountBN,
     isUsdInput,
     tokenPriceBN,
     currentPerpsDepositSelectedToken?.decimals,
     currentPerpsDepositSelectedToken?.symbol,
+    isDepositAction,
   ]);
 
   const availableBalanceBN = useMemo(
@@ -789,7 +824,7 @@ function DepositWithdrawContent({
   const isValidAmount = useMemo(() => {
     if (amountBN.isNaN() || amountBN.lte(0)) return false;
 
-    if (selectedAction === 'deposit') {
+    if (isDepositAction) {
       return (
         tokenAmountBN.lte(availableBalanceBN) &&
         (!showMinAmountError || checkFromTokenFiatValue.value)
@@ -811,6 +846,7 @@ function DepositWithdrawContent({
     selectedAction,
     showMinAmountError,
     checkFromTokenFiatValue.value,
+    isDepositAction,
   ]);
 
   const errorMessage = useMemo(() => {
@@ -820,7 +856,7 @@ function DepositWithdrawContent({
       return '';
     }
 
-    if (selectedAction === 'deposit') {
+    if (isDepositAction) {
       if (showMinAmountError && !checkFromTokenFiatValue.value) {
         return intl.formatMessage(
           { id: ETranslations.perp_mini_deposit },
@@ -851,6 +887,7 @@ function DepositWithdrawContent({
     checkFromTokenFiatValue.minFromTokenAmount,
     intl,
     currentPerpsDepositSelectedToken?.symbol,
+    isDepositAction,
   ]);
 
   const {
@@ -865,8 +902,8 @@ function DepositWithdrawContent({
     perpDepositQuoteAction,
     handlePerpDepositTxSuccess,
   } = usePerpDeposit(
-    selectedAction === 'deposit' ? tokenAmount || '0' : amount,
-    selectedAction,
+    isDepositAction ? tokenAmount || '0' : amount,
+    isDepositAction ? 'deposit' : 'withdraw',
     selectedAccount.indexedAccountId ?? '',
     selectedAccount.accountId ?? '',
     currentPerpsDepositSelectedToken,
@@ -876,7 +913,7 @@ function DepositWithdrawContent({
   const handleAmountChange = useCallback(
     (value: string) => {
       const decimals =
-        selectedAction === 'deposit' && depositInputUnit === 'usd'
+        isDepositAction && depositInputUnit === 'usd'
           ? 2
           : currentPerpsDepositSelectedToken?.decimals;
       if (validateAmountInput(value, decimals)) {
@@ -885,8 +922,8 @@ function DepositWithdrawContent({
     },
     [
       currentPerpsDepositSelectedToken?.decimals,
-      selectedAction,
       depositInputUnit,
+      isDepositAction,
     ],
   );
   const calculateFinalAmount = (withdrawFee: number): string => {
@@ -900,7 +937,7 @@ function DepositWithdrawContent({
   };
   const handleAmountBlur = useCallback(() => {
     if (amount && !amountBN.isNaN() && amountBN.gt(0)) {
-      if (selectedAction === 'deposit' && !checkFromTokenFiatValue.value) {
+      if (isDepositAction && !checkFromTokenFiatValue.value) {
         setShowMinAmountError(true);
       } else if (
         selectedAction === 'withdraw' &&
@@ -909,7 +946,13 @@ function DepositWithdrawContent({
         setShowMinAmountError(true);
       }
     }
-  }, [amount, amountBN, selectedAction, checkFromTokenFiatValue.value]);
+  }, [
+    amount,
+    amountBN,
+    selectedAction,
+    checkFromTokenFiatValue.value,
+    isDepositAction,
+  ]);
 
   const checkNativeTokenGasToast = useCallback(
     (
@@ -959,7 +1002,7 @@ function DepositWithdrawContent({
   );
 
   const handleToggleInputUnit = useCallback(() => {
-    if (selectedAction !== 'deposit') return;
+    if (!isDepositAction) return;
     const newUnit = depositInputUnit === 'token' ? 'usd' : 'token';
     if (amount && !amountBN.isNaN() && amountBN.gt(0) && tokenPriceBN.gt(0)) {
       if (newUnit === 'usd') {
@@ -979,12 +1022,12 @@ function DepositWithdrawContent({
     }
     setDepositInputUnit(newUnit);
   }, [
-    selectedAction,
     depositInputUnit,
     amount,
     amountBN,
     tokenPriceBN,
     currentPerpsDepositSelectedToken?.decimals,
+    isDepositAction,
   ]);
 
   const handleMaxPress = useCallback(
@@ -996,7 +1039,7 @@ function DepositWithdrawContent({
       decimals: number;
       price?: string;
     }) => {
-      if (tokenParams && selectedAction === 'deposit') {
+      if (tokenParams && isDepositAction) {
         const maxAmount = checkNativeTokenGasToast(
           tokenParams.isNative,
           tokenParams.networkId,
@@ -1024,17 +1067,17 @@ function DepositWithdrawContent({
     [
       availableBalance,
       checkNativeTokenGasToast,
-      selectedAction,
       depositInputUnit,
       tokenPriceBN,
+      isDepositAction,
     ],
   );
 
   useEffect(() => {
-    if (selectedAction === 'deposit' && !checkFromTokenFiatValue.value) {
+    if (isDepositAction && !checkFromTokenFiatValue.value) {
       setShowMinAmountError(true);
     }
-  }, [selectedAction, checkFromTokenFiatValue.value, amount]);
+  }, [selectedAction, checkFromTokenFiatValue.value, amount, isDepositAction]);
 
   const validateAmountBeforeSubmit = useCallback(() => {
     if (amountBN.isNaN() || amountBN.lte(0)) {
@@ -1044,8 +1087,7 @@ function DepositWithdrawContent({
       return false;
     }
 
-    const balanceCheckBN =
-      selectedAction === 'deposit' ? tokenAmountBN : amountBN;
+    const balanceCheckBN = isDepositAction ? tokenAmountBN : amountBN;
     if (balanceCheckBN.gt(availableBalanceBN)) {
       Toast.error({
         title: intl.formatMessage({
@@ -1055,7 +1097,7 @@ function DepositWithdrawContent({
       return false;
     }
 
-    if (selectedAction === 'deposit' && !checkFromTokenFiatValue.value) {
+    if (isDepositAction && !checkFromTokenFiatValue.value) {
       setShowMinAmountError(true);
       const message = intl.formatMessage(
         { id: ETranslations.perp_mini_deposit },
@@ -1093,10 +1135,11 @@ function DepositWithdrawContent({
     intl,
     selectedAction,
     showMinAmountError,
+    isDepositAction,
   ]);
 
   const leftContent = useMemo(() => {
-    return selectedAction === 'deposit' ? (
+    return isDepositAction ? (
       <SizableText size="$bodyLgMedium" color="$textSubdued">
         {intl.formatMessage(
           { id: ETranslations.perp_size_least },
@@ -1111,7 +1154,7 @@ function DepositWithdrawContent({
         )}
       </SizableText>
     );
-  }, [intl, selectedAction]);
+  }, [intl, isDepositAction]);
 
   const handleConfirm = useCallback(async () => {
     if (!isValidAmount || !selectedAccount.accountAddress) return;
@@ -1137,14 +1180,11 @@ function DepositWithdrawContent({
         void perpDepositQuoteAction();
         return;
       }
-      if (
-        selectedAction === 'deposit' &&
-        (await checkDepositWalletNotBackedUp())
-      ) {
+      if (isDepositAction && (await checkDepositWalletNotBackedUp())) {
         return;
       }
       setIsSubmitting(true);
-      if (selectedAction === 'deposit') {
+      if (isDepositAction) {
         if (isArbitrumUsdcToken) {
           await normalizeTxConfirm({
             onSuccess: async (data: ISendTxOnSuccessData[]) => {
@@ -1222,6 +1262,7 @@ function DepositWithdrawContent({
     onClose,
     buildPerpDepositTx,
     withdraw,
+    isDepositAction,
   ]);
 
   const nativeInputProps = platformEnv.isNativeIOS
@@ -1229,9 +1270,9 @@ function DepositWithdrawContent({
     : {};
 
   const isInsufficientBalance = useMemo(() => {
-    const checkBN = selectedAction === 'deposit' ? tokenAmountBN : amountBN;
+    const checkBN = isDepositAction ? tokenAmountBN : amountBN;
     return checkBN.gt(availableBalanceBN) && checkBN.gt(0);
-  }, [amountBN, tokenAmountBN, availableBalanceBN, selectedAction]);
+  }, [amountBN, tokenAmountBN, availableBalanceBN, isDepositAction]);
 
   const accountTypeInfo = useMemo(() => {
     const isHwWallet = accountUtils.isHwAccount({
@@ -1286,7 +1327,7 @@ function DepositWithdrawContent({
         id: ETranslations.swap_page_button_fetching_quotes,
       });
     }
-    return selectedAction === 'deposit'
+    return isDepositAction
       ? depositActionText
       : intl.formatMessage({ id: ETranslations.perp_trade_withdraw });
   }, [
@@ -1296,29 +1337,31 @@ function DepositWithdrawContent({
     shouldApprove,
     checkRefreshQuote,
     perpDepositQuoteLoading,
-    selectedAction,
     accountTypeInfo.isHwWallet,
     accountTypeInfo.isExternalAccount,
     shouldResetApprove,
+    isDepositAction,
   ]);
 
   const shouldShowBuyButton = useMemo(
     () =>
+      !errorMessage &&
       isInsufficientBalance &&
-      selectedAction === 'deposit' &&
+      isDepositAction &&
       checkAccountSupport &&
       !balanceLoading,
     [
+      errorMessage,
       isInsufficientBalance,
-      selectedAction,
       checkAccountSupport,
       balanceLoading,
+      isDepositAction,
     ],
   );
 
   const allBalancesZero = useMemo(
     () =>
-      selectedAction === 'deposit' &&
+      isDepositAction &&
       !balanceLoading &&
       checkAccountSupport &&
       depositTokensWithPrice.length > 0 &&
@@ -1327,10 +1370,10 @@ function DepositWithdrawContent({
           !token.balanceParsed || new BigNumber(token.balanceParsed).isZero(),
       ),
     [
-      selectedAction,
       balanceLoading,
       checkAccountSupport,
       depositTokensWithPrice,
+      isDepositAction,
     ],
   );
 
@@ -1450,7 +1493,7 @@ function DepositWithdrawContent({
 
   const showDepositNoConfirmHint = useMemo(
     () =>
-      selectedAction === 'deposit' &&
+      isDepositAction &&
       !accountTypeInfo.isHwWallet &&
       !accountTypeInfo.isExternalAccount &&
       isValidAmount &&
@@ -1459,7 +1502,6 @@ function DepositWithdrawContent({
       !perpDepositQuoteLoading &&
       depositToAmount.canDeposit,
     [
-      selectedAction,
       accountTypeInfo.isHwWallet,
       accountTypeInfo.isExternalAccount,
       isValidAmount,
@@ -1467,6 +1509,7 @@ function DepositWithdrawContent({
       balanceLoading,
       perpDepositQuoteLoading,
       depositToAmount.canDeposit,
+      isDepositAction,
     ],
   );
 
@@ -1477,466 +1520,587 @@ function DepositWithdrawContent({
     );
   }, [currentPerpsDepositSelectedToken?.networkId]);
 
-  const onChangeSegmentControl = useCallback(
-    (value: string | number) => {
-      setAmount('');
-      setDepositInputUnit('token');
-      if (showMinAmountError) {
-        setShowMinAmountError(false);
-      }
-      setSelectedAction(value as IPerpsDepositWithdrawActionType);
-    },
-    [showMinAmountError],
-  );
+  const depositTitle = intl.formatMessage({
+    id: ETranslations.perp_trade_deposit,
+  });
 
   const content = (
-    <YStack
-      gap="$4"
-      px="$1"
-      pt="$1"
-      style={{
-        marginTop: isMobile ? 0 : -22,
-      }}
-    >
-      <YStack gap="$2.5">
-        {isMobile ? null : (
-          <PerpsAccountAvatar selectedAccount={selectedAccount} />
-        )}
-        <YStack bg="$bgSubdued" borderRadius="$3">
-          <XStack
-            alignItems="center"
-            gap="$2"
-            justifyContent="space-between"
-            py="$3"
-            px="$4"
-          >
-            <SizableText size="$bodyMd" color="$textSubdued">
-              {intl.formatMessage({
-                id: ETranslations.perp_portfolio_value,
-              })}
-            </SizableText>
-            <PerpsAccountNumberValue
-              value={accountValue}
-              skeletonWidth={120}
-              textSize="$bodyMdMedium"
-            />
+    <YStack gap="$4" px="$1">
+      {/* Custom header with back button + close button for deposit sub-pages (dialog only) */}
+      {!isMobile &&
+      (selectedAction === 'depositSelect' ||
+        selectedAction === 'walletDeposit' ||
+        selectedAction === 'relay') ? (
+        <XStack
+          alignItems="center"
+          justifyContent="space-between"
+          mt="$-5"
+          mx="$-1"
+          mb="$2"
+        >
+          <XStack alignItems="center" gap="$2">
+            {selectedAction === 'walletDeposit' ||
+            selectedAction === 'relay' ? (
+              <IconButton
+                icon="ChevronLeftOutline"
+                size="small"
+                variant="tertiary"
+                onPress={() => setSelectedAction('depositSelect')}
+              />
+            ) : null}
+            <SizableText size="$headingLg">{depositTitle}</SizableText>
           </XStack>
-          <Divider borderWidth="$0.3" borderColor="$bgApp" />
-          <XStack
-            alignItems="center"
-            gap="$2"
-            justifyContent="space-between"
-            py="$3"
-            px="$4"
-          >
-            <SizableText size="$bodyMd" color="$textSubdued">
-              {intl.formatMessage({
-                id: ETranslations.perp_account_unrealized_pnl,
-              })}
-            </SizableText>
-            <SizableText
-              size="$bodyMdMedium"
-              color={unrealizedPnlInfo.pnlColor}
+          {onClose ? (
+            <IconButton
+              icon="CrossedSmallOutline"
+              iconProps={{
+                color: '$iconSubdued',
+              }}
+              size="small"
+              onPress={onClose}
+            />
+          ) : null}
+        </XStack>
+      ) : null}
+
+      {/* Portfolio view: account info + deposit/withdraw buttons */}
+      {selectedAction === 'deposit' ? (
+        <YStack gap="$2.5">
+          <YStack bg="$bgSubdued" borderRadius="$3">
+            <XStack
+              alignItems="center"
+              gap="$2"
+              justifyContent="space-between"
+              py="$3"
+              px="$4"
             >
-              {`${unrealizedPnlInfo.pnlPlusOrMinus}${unrealizedPnlInfo.pnlFormatted}`}
-            </SizableText>
+              <SizableText size="$bodyMd" color="$textSubdued">
+                {intl.formatMessage({
+                  id: ETranslations.perp_account_panel_account_value,
+                })}
+              </SizableText>
+              <PerpsAccountNumberValue
+                value={accountValue}
+                skeletonWidth={120}
+                textSize="$bodyMdMedium"
+              />
+            </XStack>
+            <Divider borderWidth="$0.3" borderColor="$bgApp" />
+            <XStack
+              alignItems="center"
+              gap="$2"
+              justifyContent="space-between"
+              py="$3"
+              px="$4"
+            >
+              <SizableText size="$bodyMd" color="$textSubdued">
+                {intl.formatMessage({
+                  id: ETranslations.perp_account_unrealized_pnl,
+                })}
+              </SizableText>
+              <SizableText
+                size="$bodyMdMedium"
+                color={unrealizedPnlInfo.pnlColor}
+              >
+                {`${unrealizedPnlInfo.pnlPlusOrMinus}${unrealizedPnlInfo.pnlFormatted}`}
+              </SizableText>
+            </XStack>
+          </YStack>
+          <XStack gap="$2.5">
+            <Button
+              flex={1}
+              size="medium"
+              variant="primary"
+              onPress={() => {
+                if (onNavigate) {
+                  onNavigate('depositSelect');
+                } else {
+                  setSelectedAction('depositSelect');
+                }
+              }}
+              icon="ArrowBottomOutline"
+            >
+              {intl.formatMessage({
+                id: ETranslations.perp_trade_deposit,
+              })}
+            </Button>
+            <Button
+              flex={1}
+              size="medium"
+              variant="secondary"
+              onPress={() => {
+                if (onNavigate) {
+                  onNavigate('withdraw');
+                } else {
+                  setSelectedAction('withdraw');
+                }
+              }}
+              icon="AlignTopOutline"
+            >
+              {intl.formatMessage({
+                id: ETranslations.perp_trade_withdraw,
+              })}
+            </Button>
           </XStack>
         </YStack>
-      </YStack>
-      <SegmentControl
-        height={38}
-        segmentControlItemStyleProps={{
-          height: '100%',
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-        value={selectedAction}
-        onChange={onChangeSegmentControl}
-        options={[
-          {
-            label: intl.formatMessage({
-              id: ETranslations.perp_trade_deposit,
-            }),
-            value: 'deposit',
-          },
-          {
-            label: intl.formatMessage({
-              id: ETranslations.perp_trade_withdraw,
-            }),
-            value: 'withdraw',
-          },
-        ]}
-      />
+      ) : null}
 
-      <YStack gap="$2">
-        {selectedAction === 'deposit' ? (
+      {/* Deposit mode selection */}
+      {selectedAction === 'depositSelect' ? (
+        <YStack gap="$4">
           <XStack
+            alignItems="center"
+            px="$4"
+            py="$4"
+            gap="$3"
             borderWidth="$px"
             borderColor="$borderSubdued"
             borderRadius="$3"
-            px="$3"
-            bg="$bgSubdued"
-            alignItems="center"
-            justifyContent="space-between"
-            h={42}
+            cursor="pointer"
+            hoverStyle={{ bg: '$bgHover' }}
+            pressStyle={{ bg: '$bgActive' }}
+            onPress={() => setSelectedAction('walletDeposit')}
           >
-            <SizableText size="$bodyMd" color="$textSubdued">
-              {intl.formatMessage({ id: ETranslations.earn_pay_with })}
-            </SizableText>
-            {depositTokenSelectComponent}
+            <Icon name="WalletOutline" size="$6" color="$iconSubdued" />
+            <YStack flex={1} gap="$0.5">
+              <SizableText size="$bodyLgMedium">
+                {intl.formatMessage({ id: ETranslations.global_wallet })}
+              </SizableText>
+              <SizableText size="$bodySm" color="$textSubdued">
+                {intl.formatMessage({
+                  id: ETranslations.perp_relay_wallet_deposit__desc,
+                })}
+              </SizableText>
+            </YStack>
           </XStack>
-        ) : null}
+          <XStack
+            alignItems="center"
+            px="$4"
+            py="$4"
+            gap="$3"
+            borderWidth="$px"
+            borderColor="$borderSubdued"
+            borderRadius="$3"
+            cursor="pointer"
+            hoverStyle={{ bg: '$bgHover' }}
+            pressStyle={{ bg: '$bgActive' }}
+            onPress={() => setSelectedAction('relay')}
+          >
+            <Icon name="SwitchHorOutline" size="$6" color="$iconSubdued" />
+            <YStack flex={1} gap="$0.5">
+              <SizableText size="$bodyLgMedium">
+                {intl.formatMessage({
+                  id: ETranslations.perp_relay_crypto_transfer__title,
+                })}
+              </SizableText>
+              <SizableText size="$bodySm" color="$textSubdued">
+                {intl.formatMessage({
+                  id: ETranslations.perp_relay_crypto_transfer__desc,
+                })}
+              </SizableText>
+            </YStack>
+          </XStack>
+        </YStack>
+      ) : null}
 
-        <XStack
-          mt={selectedAction === 'deposit' ? '$1' : undefined}
-          borderWidth="$px"
-          borderColor={
-            errorMessage || isInsufficientBalance ? '$red7' : '$borderSubdued'
-          }
-          borderRadius="$3"
-          px="$3"
-          bg="$bgSubdued"
-          alignItems="center"
-          gap="$3"
-          h={42}
-        >
-          <XStack alignItems="center" gap="$1.5" flexShrink={0}>
-            <SizableText size="$bodyMd" color="$textSubdued">
-              {intl.formatMessage({
-                id: isUsdInput
-                  ? ETranslations.content__amount
-                  : ETranslations.send_nft_amount,
-              })}
-            </SizableText>
-            {selectedAction === 'deposit' ? (
+      {/* Relay deposit content */}
+      {selectedAction === 'relay' ? (
+        <RelayDepositContent
+          selectedAccount={selectedAccount}
+          isMobile={isMobile}
+        />
+      ) : null}
+
+      {/* Wallet deposit / Withdraw form */}
+      {selectedAction === 'walletDeposit' || selectedAction === 'withdraw' ? (
+        <>
+          <YStack gap="$2">
+            {isDepositAction ? (
               <XStack
-                cursor="pointer"
-                onPress={handleToggleInputUnit}
-                hoverStyle={{ opacity: 0.6 }}
+                borderWidth="$px"
+                borderColor="$borderSubdued"
+                borderRadius="$3"
+                px="$3"
+                bg="$bgSubdued"
+                alignItems="center"
+                justifyContent="space-between"
+                h={42}
               >
-                <Icon name="SwitchVerOutline" size="$3" color="$iconSubdued" />
+                <SizableText size="$bodyMd" color="$textSubdued">
+                  {intl.formatMessage({ id: ETranslations.earn_pay_with })}
+                </SizableText>
+                {depositTokenSelectComponent}
               </XStack>
             ) : null}
-          </XStack>
-          <Input
-            testID="perp-input"
-            alignItems="center"
-            flex={1}
-            placeholder={intl.formatMessage({
-              id: ETranslations.form_amount_placeholder,
-            })}
-            value={isUsdInput && amount ? `$${amount}` : amount}
-            onChangeText={(value: string) => {
-              const raw = isUsdInput ? value.replace(/^\$/, '') : value;
-              handleAmountChange(raw);
-            }}
-            onBlur={handleAmountBlur}
-            keyboardType="decimal-pad"
-            disabled={isSubmitting}
-            readonly={!checkAccountSupport}
-            borderWidth={0}
-            size="medium"
-            fontSize={getFontSize('$bodyMd')}
-            {...nativeInputProps}
-            containerProps={{
-              flex: 1,
-              borderWidth: 0,
-              bg: 'transparent',
-              p: 0,
-            }}
-            InputComponentStyle={{
-              p: 0,
-              bg: 'transparent',
-              justifyContent: 'flex-end',
-            }}
-            textAlign="right"
-          />
-        </XStack>
 
-        <XStack alignItems="center" justifyContent="space-between">
-          <XStack gap="$1" alignItems="center" flexShrink={1} minWidth={0}>
-            {errorMessage ? (
-              <SizableText size="$bodySm" color="$red10" numberOfLines={1}>
-                {errorMessage}
+            <XStack
+              mt={isDepositAction ? '$1' : undefined}
+              borderWidth="$px"
+              borderColor={
+                errorMessage || isInsufficientBalance
+                  ? '$red7'
+                  : '$borderSubdued'
+              }
+              borderRadius="$3"
+              px="$3"
+              bg="$bgSubdued"
+              alignItems="center"
+              gap="$3"
+              h={42}
+            >
+              <XStack alignItems="center" gap="$1.5" flexShrink={0}>
+                <SizableText size="$bodyMd" color="$textSubdued">
+                  {intl.formatMessage({
+                    id: isUsdInput
+                      ? ETranslations.content__amount
+                      : ETranslations.send_nft_amount,
+                  })}
+                </SizableText>
+                {isDepositAction ? (
+                  <XStack
+                    cursor="pointer"
+                    onPress={handleToggleInputUnit}
+                    hoverStyle={{ opacity: 0.6 }}
+                  >
+                    <Icon
+                      name="SwitchVerOutline"
+                      size="$3"
+                      color="$iconSubdued"
+                    />
+                  </XStack>
+                ) : null}
+              </XStack>
+              <Input
+                testID="perp-input"
+                alignItems="center"
+                flex={1}
+                placeholder={intl.formatMessage({
+                  id: ETranslations.form_amount_placeholder,
+                })}
+                value={isUsdInput && amount ? `$${amount}` : amount}
+                onChangeText={(value: string) => {
+                  const raw = isUsdInput ? value.replace(/^\$/, '') : value;
+                  handleAmountChange(raw);
+                }}
+                onBlur={handleAmountBlur}
+                keyboardType="decimal-pad"
+                disabled={isSubmitting}
+                readonly={!checkAccountSupport}
+                borderWidth={0}
+                size="medium"
+                fontSize={getFontSize('$bodyMd')}
+                {...nativeInputProps}
+                containerProps={{
+                  flex: 1,
+                  borderWidth: 0,
+                  bg: 'transparent',
+                  p: 0,
+                }}
+                InputComponentStyle={{
+                  p: 0,
+                  bg: 'transparent',
+                  justifyContent: 'flex-end',
+                }}
+                textAlign="right"
+              />
+            </XStack>
+
+            <XStack alignItems="center" justifyContent="space-between">
+              <XStack gap="$1" alignItems="center" flexShrink={1} minWidth={0}>
+                {errorMessage ? (
+                  <SizableText size="$bodySm" color="$red10" numberOfLines={1}>
+                    {errorMessage}
+                  </SizableText>
+                ) : null}
+                {shouldShowBuyButton ? (
+                  <>
+                    <SizableText
+                      size="$bodySm"
+                      color="$textSubdued"
+                      numberOfLines={1}
+                      flexShrink={1}
+                    >
+                      {intl.formatMessage(
+                        { id: ETranslations.perps_buy_tip },
+                        {
+                          token: currentPerpsDepositSelectedToken?.symbol ?? '',
+                        },
+                      )}
+                    </SizableText>
+                    <DashText
+                      onPress={handleBuyPress}
+                      color="$textSuccess"
+                      size="$bodySmMedium"
+                      dashColor="$textSuccess"
+                      flexShrink={0}
+                    >
+                      {intl.formatMessage({ id: ETranslations.global_top_up })}
+                    </DashText>
+                  </>
+                ) : null}
+              </XStack>
+              {convertedDisplayValue ? (
+                <SizableText
+                  size="$bodySm"
+                  color="$textSubdued"
+                  flexShrink={1}
+                  numberOfLines={1}
+                  minWidth={0}
+                >
+                  {convertedDisplayValue}
+                </SizableText>
+              ) : null}
+            </XStack>
+          </YStack>
+          {/* Available Balance & You Will Get */}
+          <YStack gap="$3">
+            <XStack justifyContent="space-between" alignItems="center">
+              <SizableText size="$bodyMd" color="$textSubdued">
+                {selectedAction === 'withdraw'
+                  ? intl.formatMessage({
+                      id: ETranslations.perp_account_panel_withrawable_value,
+                    })
+                  : intl.formatMessage({
+                      id: ETranslations.perp_available_balance,
+                    })}
               </SizableText>
-            ) : null}
-            {shouldShowBuyButton && !errorMessage ? (
-              <SizableText
-                size="$bodySm"
-                color="$textSubdued"
-                numberOfLines={1}
-                flexShrink={1}
-              >
-                {intl.formatMessage(
-                  { id: ETranslations.perps_buy_tip },
-                  { token: currentPerpsDepositSelectedToken?.symbol ?? '' },
+              <XStack alignItems="center" gap="$2">
+                {balanceLoading && checkAccountSupport ? (
+                  <XStack w={80} h={14}>
+                    <Skeleton w="100%" h="100%" />
+                  </XStack>
+                ) : (
+                  <>
+                    <SizableText size="$bodyMd" color="$text">
+                      {availableBalance.displayBalance || '0.00'}
+                    </SizableText>
+                    <SizableText
+                      size="$bodyMd"
+                      color="$textSuccess"
+                      onPress={() => {
+                        handleMaxPress({
+                          networkId:
+                            currentPerpsDepositSelectedToken?.networkId ?? '',
+                          isNative:
+                            !!currentPerpsDepositSelectedToken?.isNative,
+                          amount:
+                            currentPerpsDepositSelectedToken?.balanceParsed ||
+                            '0',
+                          symbol:
+                            currentPerpsDepositSelectedToken?.symbol ?? '',
+                          decimals:
+                            currentPerpsDepositSelectedToken?.decimals ?? 6,
+                        });
+                      }}
+                    >
+                      Max
+                    </SizableText>
+                  </>
                 )}
-              </SizableText>
+              </XStack>
+            </XStack>
+            {isDepositAction ? (
+              <>
+                <XStack justifyContent="space-between" alignItems="center">
+                  <SizableText size="$bodyMd" color="$textSubdued">
+                    {intl.formatMessage({
+                      id: ETranslations.perp_deposit_chain,
+                    })}
+                  </SizableText>
+                  <XStack alignItems="center" gap="$2">
+                    <SizableText size="$bodyMd" color="$text">
+                      {currentNetworkInfo?.name}
+                    </SizableText>
+                  </XStack>
+                </XStack>
+                {!isArbitrumUsdcToken && perpDepositQuote?.result ? (
+                  <XStack justifyContent="space-between" alignItems="center">
+                    <SizableText size="$bodyMd" color="$textSubdued">
+                      {intl.formatMessage({
+                        id: ETranslations.provider_route,
+                      })}
+                    </SizableText>
+                    <XStack alignItems="center" gap="$1">
+                      {perpDepositQuote.result.fromTokenInfo?.symbol !==
+                      (perpDepositQuote.result.toTokenInfo?.symbol ??
+                        'USDC') ? (
+                        <>
+                          <SizableText size="$bodyMd" color="$text">
+                            {perpDepositQuote.result.fromTokenInfo?.symbol ??
+                              ''}
+                          </SizableText>
+                          <SizableText size="$bodyMd" color="$textSubdued">
+                            →
+                          </SizableText>
+                        </>
+                      ) : null}
+                      {perpDepositQuote.result.info?.providerLogo ? (
+                        <Image
+                          src={perpDepositQuote.result.info.providerLogo}
+                          size="$4"
+                          borderRadius="$1"
+                        />
+                      ) : null}
+                      <SizableText size="$bodyMd" color="$text">
+                        {perpDepositQuote.result.info?.providerName ?? ''}
+                      </SizableText>
+                      {perpDepositQuote.result.fromTokenInfo?.symbol !==
+                      (perpDepositQuote.result.toTokenInfo?.symbol ??
+                        'USDC') ? (
+                        <>
+                          <SizableText size="$bodyMd" color="$textSubdued">
+                            →
+                          </SizableText>
+                          <SizableText size="$bodyMd" color="$text">
+                            {perpDepositQuote.result.toTokenInfo?.symbol ??
+                              'USDC'}
+                          </SizableText>
+                        </>
+                      ) : null}
+                    </XStack>
+                  </XStack>
+                ) : null}
+              </>
             ) : null}
-          </XStack>
-          {convertedDisplayValue ? (
+            {selectedAction === 'withdraw' ? (
+              <XStack justifyContent="space-between" alignItems="center">
+                {gtMd ? (
+                  <Tooltip
+                    renderTrigger={
+                      <DashText
+                        size="$bodyMd"
+                        color="$textSubdued"
+                        dashColor="$textDisabled"
+                        dashThickness={0.3}
+                        cursor="help"
+                      >
+                        {intl.formatMessage({
+                          id: ETranslations.perp_withdraw_fee,
+                        })}
+                      </DashText>
+                    }
+                    renderContent={
+                      <SizableText size="$bodySm">
+                        {intl.formatMessage({
+                          id: ETranslations.perp_withdraw_fee_mgs,
+                        })}
+                      </SizableText>
+                    }
+                  />
+                ) : (
+                  <Popover
+                    title={intl.formatMessage({
+                      id: ETranslations.perp_withdraw_fee,
+                    })}
+                    renderTrigger={
+                      <DashText
+                        size="$bodyMd"
+                        color="$textSubdued"
+                        dashColor="$textDisabled"
+                        dashThickness={0.3}
+                      >
+                        {intl.formatMessage({
+                          id: ETranslations.perp_withdraw_fee,
+                        })}
+                      </DashText>
+                    }
+                    renderContent={() => (
+                      <YStack px="$5" pb="$4">
+                        <SizableText size="$bodyMd" color="$text">
+                          {intl.formatMessage({
+                            id: ETranslations.perp_withdraw_fee_mgs,
+                          })}
+                        </SizableText>
+                      </YStack>
+                    )}
+                  />
+                )}
+                <SizableText color="$text" size="$bodyMd">
+                  ${WITHDRAW_FEE}
+                </SizableText>
+              </XStack>
+            ) : null}
+            <XStack justifyContent="space-between" alignItems="center">
+              <SizableText size="$bodyMd" color="$textSubdued">
+                {intl.formatMessage({ id: ETranslations.perp_you_will_get })}
+              </SizableText>
+              {selectedAction === 'withdraw' ? (
+                <SizableText color="$text" size="$bodyMd">
+                  ${calculateFinalAmount(WITHDRAW_FEE)}{' '}
+                  {intl.formatMessage(
+                    {
+                      id: ETranslations.perp_deposit_on,
+                    },
+                    {
+                      chain: 'Arbitrum One',
+                    },
+                  )}
+                </SizableText>
+              ) : (
+                <XStack gap="$1" alignItems="center" justifyContent="center">
+                  {perpDepositQuoteLoading ? (
+                    <XStack w={60} h={14}>
+                      <Skeleton w="100%" h="100%" />
+                    </XStack>
+                  ) : (
+                    <XStack gap="$1">
+                      <SizableText color="$text" size="$bodyMd">
+                        $
+                        {numberFormat(depositToAmount.value, {
+                          formatter: 'balance',
+                        })}{' '}
+                      </SizableText>
+                      <SizableText color="$text" size="$bodyMd">
+                        {intl.formatMessage(
+                          {
+                            id: ETranslations.perp_deposit_on,
+                          },
+                          {
+                            chain: 'Hyperliquid',
+                          },
+                        )}
+                      </SizableText>
+                    </XStack>
+                  )}
+                </XStack>
+              )}
+            </XStack>
+          </YStack>
+
+          <Button
+            testID="perp-btn"
+            variant="primary"
+            size="medium"
+            disabled={
+              !isValidAmount ||
+              isSubmitting ||
+              balanceLoading ||
+              (isDepositAction && perpDepositQuoteLoading) ||
+              (isDepositAction &&
+                !depositToAmount.canDeposit &&
+                !checkRefreshQuote)
+            }
+            loading={isSubmitting}
+            onPress={handleConfirm}
+          >
+            {buttonText}
+          </Button>
+          {showDepositNoConfirmHint ? (
             <SizableText
               size="$bodySm"
               color="$textSubdued"
-              flexShrink={1}
-              numberOfLines={1}
-              minWidth={0}
+              textAlign="center"
+              mt="$-1"
+              mb={isMobile ? '$4' : undefined}
             >
-              {convertedDisplayValue}
+              {intl.formatMessage({
+                id: ETranslations.perp__deposit_no_second_confirmation__desc,
+              })}
             </SizableText>
           ) : null}
-        </XStack>
-      </YStack>
-      {/* Available Balance & You Will Get */}
-      <YStack gap="$3">
-        <XStack justifyContent="space-between" alignItems="center">
-          <SizableText size="$bodyMd" color="$textSubdued">
-            {selectedAction === 'withdraw'
-              ? intl.formatMessage({
-                  id: ETranslations.perp_account_panel_withrawable_value,
-                })
-              : intl.formatMessage({
-                  id: ETranslations.perp_available_balance,
-                })}
-          </SizableText>
-          <XStack alignItems="center" gap="$2">
-            {balanceLoading && checkAccountSupport ? (
-              <XStack w={80} h={14}>
-                <Skeleton w="100%" h="100%" />
-              </XStack>
-            ) : (
-              <>
-                <SizableText size="$bodyMd" color="$text">
-                  {availableBalance.displayBalance || '0.00'}
-                </SizableText>
-                <SizableText
-                  size="$bodyMd"
-                  color="$textSuccess"
-                  onPress={() => {
-                    handleMaxPress({
-                      networkId:
-                        currentPerpsDepositSelectedToken?.networkId ?? '',
-                      isNative: !!currentPerpsDepositSelectedToken?.isNative,
-                      amount:
-                        currentPerpsDepositSelectedToken?.balanceParsed || '0',
-                      symbol: currentPerpsDepositSelectedToken?.symbol ?? '',
-                      decimals: currentPerpsDepositSelectedToken?.decimals ?? 6,
-                    });
-                  }}
-                >
-                  Max
-                </SizableText>
-              </>
-            )}
-          </XStack>
-        </XStack>
-        {selectedAction === 'deposit' ? (
-          <>
-            <XStack justifyContent="space-between" alignItems="center">
-              <SizableText size="$bodyMd" color="$textSubdued">
-                {intl.formatMessage({
-                  id: ETranslations.perp_deposit_chain,
-                })}
-              </SizableText>
-              <XStack alignItems="center" gap="$2">
-                <SizableText size="$bodyMd" color="$text">
-                  {currentNetworkInfo?.name}
-                </SizableText>
-              </XStack>
-            </XStack>
-            {!isArbitrumUsdcToken && perpDepositQuote?.result ? (
-              <XStack justifyContent="space-between" alignItems="center">
-                <SizableText size="$bodyMd" color="$textSubdued">
-                  {intl.formatMessage({
-                    id: ETranslations.provider_route,
-                  })}
-                </SizableText>
-                <XStack alignItems="center" gap="$1">
-                  {perpDepositQuote.result.fromTokenInfo?.symbol !==
-                  (perpDepositQuote.result.toTokenInfo?.symbol ?? 'USDC') ? (
-                    <>
-                      <SizableText size="$bodyMd" color="$text">
-                        {perpDepositQuote.result.fromTokenInfo?.symbol ?? ''}
-                      </SizableText>
-                      <SizableText size="$bodyMd" color="$textSubdued">
-                        →
-                      </SizableText>
-                    </>
-                  ) : null}
-                  {perpDepositQuote.result.info?.providerLogo ? (
-                    <Image
-                      src={perpDepositQuote.result.info.providerLogo}
-                      size="$4"
-                      borderRadius="$1"
-                    />
-                  ) : null}
-                  <SizableText size="$bodyMd" color="$text">
-                    {perpDepositQuote.result.info?.providerName ?? ''}
-                  </SizableText>
-                  {perpDepositQuote.result.fromTokenInfo?.symbol !==
-                  (perpDepositQuote.result.toTokenInfo?.symbol ?? 'USDC') ? (
-                    <>
-                      <SizableText size="$bodyMd" color="$textSubdued">
-                        →
-                      </SizableText>
-                      <SizableText size="$bodyMd" color="$text">
-                        {perpDepositQuote.result.toTokenInfo?.symbol ?? 'USDC'}
-                      </SizableText>
-                    </>
-                  ) : null}
-                </XStack>
-              </XStack>
-            ) : null}
-          </>
-        ) : null}
-        {selectedAction === 'withdraw' ? (
-          <XStack justifyContent="space-between" alignItems="center">
-            {gtMd ? (
-              <Tooltip
-                renderTrigger={
-                  <DashText
-                    size="$bodyMd"
-                    color="$textSubdued"
-                    dashColor="$textDisabled"
-                    dashThickness={0.3}
-                    cursor="help"
-                  >
-                    {intl.formatMessage({
-                      id: ETranslations.perp_withdraw_fee,
-                    })}
-                  </DashText>
-                }
-                renderContent={
-                  <SizableText size="$bodySm">
-                    {intl.formatMessage({
-                      id: ETranslations.perp_withdraw_fee_mgs,
-                    })}
-                  </SizableText>
-                }
-              />
-            ) : (
-              <Popover
-                title={intl.formatMessage({
-                  id: ETranslations.perp_withdraw_fee,
-                })}
-                renderTrigger={
-                  <DashText
-                    size="$bodyMd"
-                    color="$textSubdued"
-                    dashColor="$textDisabled"
-                    dashThickness={0.3}
-                  >
-                    {intl.formatMessage({
-                      id: ETranslations.perp_withdraw_fee,
-                    })}
-                  </DashText>
-                }
-                renderContent={() => (
-                  <YStack px="$5" pb="$4">
-                    <SizableText size="$bodyMd" color="$text">
-                      {intl.formatMessage({
-                        id: ETranslations.perp_withdraw_fee_mgs,
-                      })}
-                    </SizableText>
-                  </YStack>
-                )}
-              />
-            )}
-            <SizableText color="$text" size="$bodyMd">
-              ${WITHDRAW_FEE}
-            </SizableText>
-          </XStack>
-        ) : null}
-        <XStack justifyContent="space-between" alignItems="center">
-          <SizableText size="$bodyMd" color="$textSubdued">
-            {intl.formatMessage({ id: ETranslations.perp_you_will_get })}
-          </SizableText>
-          {selectedAction === 'withdraw' ? (
-            <SizableText color="$text" size="$bodyMd">
-              ${calculateFinalAmount(WITHDRAW_FEE)}{' '}
-              {intl.formatMessage(
-                {
-                  id: ETranslations.perp_deposit_on,
-                },
-                {
-                  chain: 'Arbitrum One',
-                },
-              )}
-            </SizableText>
-          ) : (
-            <XStack gap="$1" alignItems="center" justifyContent="center">
-              {perpDepositQuoteLoading ? (
-                <XStack w={60} h={14}>
-                  <Skeleton w="100%" h="100%" />
-                </XStack>
-              ) : (
-                <XStack gap="$1">
-                  <SizableText color="$text" size="$bodyMd">
-                    $
-                    {numberFormat(depositToAmount.value, {
-                      formatter: 'balance',
-                    })}{' '}
-                  </SizableText>
-                  <SizableText color="$text" size="$bodyMd">
-                    {intl.formatMessage(
-                      {
-                        id: ETranslations.perp_deposit_on,
-                      },
-                      {
-                        chain: 'Hyperliquid',
-                      },
-                    )}
-                  </SizableText>
-                </XStack>
-              )}
-            </XStack>
-          )}
-        </XStack>
-      </YStack>
-
-      {shouldShowBuyButton ? (
-        <Button
-          testID="perp-btn"
-          variant="primary"
-          size="medium"
-          onPress={handleBuyPress}
-        >
-          {intl.formatMessage({ id: ETranslations.global_top_up })}
-        </Button>
-      ) : (
-        <Button
-          testID="perp-btn"
-          variant="primary"
-          size="medium"
-          disabled={
-            !isValidAmount ||
-            isSubmitting ||
-            balanceLoading ||
-            (selectedAction === 'deposit' && perpDepositQuoteLoading) ||
-            (selectedAction === 'deposit' &&
-              !depositToAmount.canDeposit &&
-              !checkRefreshQuote)
-          }
-          loading={isSubmitting}
-          onPress={handleConfirm}
-        >
-          {buttonText}
-        </Button>
-      )}
-      {showDepositNoConfirmHint ? (
-        <SizableText
-          size="$bodySm"
-          color="$textSubdued"
-          textAlign="center"
-          mt="$-1"
-          mb={isMobile ? '$4' : undefined}
-        >
-          {intl.formatMessage({
-            id: ETranslations.perp__deposit_no_second_confirmation__desc,
-          })}
-        </SizableText>
+          {isMobile && !showDepositNoConfirmHint ? <YStack mb="$4" /> : null}
+        </>
       ) : null}
-      {isMobile && !showDepositNoConfirmHint ? <YStack mb="$4" /> : null}
     </YStack>
   );
 
@@ -1953,7 +2117,6 @@ function DepositWithdrawContent({
 }
 
 function MobileDepositWithdrawModal() {
-  const intl = useIntl();
   const navigation = useNavigation();
   const route =
     useRoute<
@@ -2004,7 +2167,7 @@ function MobileDepositWithdrawModal() {
   return (
     <Page>
       <Page.Header
-        title={intl.formatMessage({
+        title={appLocale.intl.formatMessage({
           id: ETranslations.perp_trade_account_overview,
         })}
       />
@@ -2039,7 +2202,23 @@ export async function showDepositWithdrawDialog(
     return;
   }
 
+  const isDepositRelated =
+    params.actionType === 'depositSelect' ||
+    params.actionType === 'walletDeposit' ||
+    params.actionType === 'relay';
+
+  const getDialogTitle = () => {
+    if (params.actionType === 'withdraw') {
+      return appLocale.intl.formatMessage({
+        id: ETranslations.perp_trade_withdraw,
+      });
+    }
+    return undefined;
+  };
+
   const dialogInTabRef = dialogInTab.show({
+    title: getDialogTitle(),
+    showExitButton: !isDepositRelated,
     renderContent: (
       <PerpsProviderMirror>
         <DepositWithdrawContent
@@ -2048,10 +2227,15 @@ export async function showDepositWithdrawDialog(
           onClose={() => {
             void dialogInTabRef.close();
           }}
+          onNavigate={(actionType) => {
+            void dialogInTabRef.close();
+            setTimeout(() => {
+              void showDepositWithdrawDialog({ actionType }, dialogInTab);
+            }, 100);
+          }}
         />
       </PerpsProviderMirror>
     ),
-    contentContainerProps: PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
     showFooter: false,
     onClose: () => {
       void dialogInTabRef.close();

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -59,7 +59,6 @@ import {
 import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
 import { dismissKeyboardWithDelay } from '@onekeyhq/shared/src/keyboard';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
@@ -82,6 +81,7 @@ import {
   USDC_TOKEN_INFO,
   WITHDRAW_FEE,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type { IPerpsDepositWithdrawActionType } from '@onekeyhq/shared/types/hyperliquid/routes';
 import { swapDefaultSetTokens } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import type {
   ISwapNativeTokenConfig,
@@ -99,13 +99,6 @@ import RelayDepositContent from './RelayDepositContent';
 
 import type { RouteProp } from '@react-navigation/native';
 import type { ListRenderItem } from 'react-native';
-
-export type IPerpsDepositWithdrawActionType =
-  | 'deposit'
-  | 'depositSelect'
-  | 'withdraw'
-  | 'walletDeposit'
-  | 'relay';
 
 const DEPOSIT_WITHDRAW_INPUT_ACCESSORY_VIEW_ID =
   'perp-deposit-withdraw-accessory-view';
@@ -2117,6 +2110,7 @@ export function DepositWithdrawContent({
 }
 
 function MobileDepositWithdrawModal() {
+  const intl = useIntl();
   const navigation = useNavigation();
   const route =
     useRoute<
@@ -2167,7 +2161,7 @@ function MobileDepositWithdrawModal() {
   return (
     <Page>
       <Page.Header
-        title={appLocale.intl.formatMessage({
+        title={intl.formatMessage({
           id: ETranslations.perp_trade_account_overview,
         })}
       />
@@ -2192,6 +2186,7 @@ export default MobileDepositWithdrawModal;
 export async function showDepositWithdrawDialog(
   params: IDepositWithdrawParams,
   dialogInTab: ReturnType<typeof useInTabDialog>,
+  title?: string,
 ) {
   const selectedAccount = await perpsActiveAccountAtom.get();
   if (!selectedAccount.accountId || !selectedAccount.accountAddress) {
@@ -2207,17 +2202,8 @@ export async function showDepositWithdrawDialog(
     params.actionType === 'walletDeposit' ||
     params.actionType === 'relay';
 
-  const getDialogTitle = () => {
-    if (params.actionType === 'withdraw') {
-      return appLocale.intl.formatMessage({
-        id: ETranslations.perp_trade_withdraw,
-      });
-    }
-    return undefined;
-  };
-
   const dialogInTabRef = dialogInTab.show({
-    title: getDialogTitle(),
+    title: params.actionType === 'withdraw' ? title : undefined,
     showExitButton: !isDepositRelated,
     renderContent: (
       <PerpsProviderMirror>
@@ -2230,7 +2216,11 @@ export async function showDepositWithdrawDialog(
           onNavigate={(actionType) => {
             void dialogInTabRef.close();
             setTimeout(() => {
-              void showDepositWithdrawDialog({ actionType }, dialogInTab);
+              void showDepositWithdrawDialog(
+                { actionType },
+                dialogInTab,
+                title,
+              );
             }, 100);
           }}
         />

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -92,6 +92,7 @@ import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
 
 import usePerpDeposit from '../../../hooks/usePerpDeposit';
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
+import { PerpTestIDs } from '../../../testIDs';
 import { PerpsAccountNumberValue } from '../components/PerpsAccountNumberValue';
 import { InputAccessoryDoneButton } from '../inputs/TradingFormInput';
 
@@ -354,6 +355,7 @@ export function DepositWithdrawContent({
         // eslint-disable-next-line react/no-unstable-nested-components
         headerLeft: () => (
           <IconButton
+            testID={PerpTestIDs.DepositModalMobileBackButton}
             icon="ChevronLeftOutline"
             size="small"
             variant="tertiary"
@@ -366,6 +368,7 @@ export function DepositWithdrawContent({
         // eslint-disable-next-line react/no-unstable-nested-components
         headerLeft: () => (
           <IconButton
+            testID={PerpTestIDs.DepositModalMobileCloseButton}
             icon="CrossedLargeOutline"
             size="small"
             variant="tertiary"
@@ -1535,6 +1538,7 @@ export function DepositWithdrawContent({
             {selectedAction === 'walletDeposit' ||
             selectedAction === 'relay' ? (
               <IconButton
+                testID={PerpTestIDs.DepositModalDialogBackButton}
                 icon="ChevronLeftOutline"
                 size="small"
                 variant="tertiary"
@@ -1545,6 +1549,7 @@ export function DepositWithdrawContent({
           </XStack>
           {onClose ? (
             <IconButton
+              testID={PerpTestIDs.DepositModalDialogCloseButton}
               icon="CrossedSmallOutline"
               iconProps={{
                 color: '$iconSubdued',
@@ -1601,6 +1606,7 @@ export function DepositWithdrawContent({
           </YStack>
           <XStack gap="$2.5">
             <Button
+              testID={PerpTestIDs.DepositModalDepositButton}
               flex={1}
               size="medium"
               variant="primary"
@@ -1618,6 +1624,7 @@ export function DepositWithdrawContent({
               })}
             </Button>
             <Button
+              testID={PerpTestIDs.DepositModalWithdrawButton}
               flex={1}
               size="medium"
               variant="secondary"
@@ -1642,6 +1649,7 @@ export function DepositWithdrawContent({
       {selectedAction === 'depositSelect' ? (
         <YStack gap="$4">
           <XStack
+            testID={PerpTestIDs.DepositModalWalletOption}
             alignItems="center"
             px="$4"
             py="$4"
@@ -1667,6 +1675,7 @@ export function DepositWithdrawContent({
             </YStack>
           </XStack>
           <XStack
+            testID={PerpTestIDs.DepositModalRelayOption}
             alignItems="center"
             px="$4"
             py="$4"

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/PerpPortfolioModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/PerpPortfolioModal.tsx
@@ -1,0 +1,107 @@
+import { useCallback } from 'react';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { Dialog, Page, YStack } from '@onekeyhq/components';
+import {
+  type IPerpsActiveAccountAtom,
+  usePerpsActiveAccountAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
+
+import { DepositWithdrawContent } from './DepositWithdrawModal';
+
+import type { IPerpsDepositWithdrawActionType } from './DepositWithdrawModal';
+
+function showPortfolioSubDialog(
+  actionType: IPerpsDepositWithdrawActionType,
+  selectedAccount: IPerpsActiveAccountAtom,
+) {
+  const isDepositRelated =
+    actionType === 'depositSelect' ||
+    actionType === 'walletDeposit' ||
+    actionType === 'relay';
+
+  const getTitle = () => {
+    if (actionType === 'withdraw') {
+      return appLocale.intl.formatMessage({
+        id: ETranslations.perp_trade_withdraw,
+      });
+    }
+    return undefined;
+  };
+
+  const dialogInstance = Dialog.show({
+    title: getTitle(),
+    showExitButton: !isDepositRelated,
+    renderContent: (
+      <PerpsProviderMirror>
+        <DepositWithdrawContent
+          params={{ actionType }}
+          selectedAccount={selectedAccount}
+          onClose={() => {
+            void dialogInstance.close();
+          }}
+        />
+      </PerpsProviderMirror>
+    ),
+    showFooter: false,
+  });
+}
+
+function PerpPortfolioModal() {
+  const navigation = useNavigation();
+  const [selectedAccount] = usePerpsActiveAccountAtom();
+
+  const handleClose = useCallback(() => {
+    setTimeout(
+      () => {
+        navigation.goBack();
+      },
+      platformEnv.isNative ? 350 : 0,
+    );
+  }, [navigation]);
+
+  const handleNavigate = useCallback(
+    (actionType: IPerpsDepositWithdrawActionType) => {
+      showPortfolioSubDialog(actionType, selectedAccount);
+    },
+    [selectedAccount],
+  );
+
+  if (!selectedAccount?.accountId || !selectedAccount?.accountAddress) {
+    return (
+      <Page>
+        <Page.Body />
+      </Page>
+    );
+  }
+
+  return (
+    <Page>
+      <Page.Header
+        title={appLocale.intl.formatMessage({
+          id: ETranslations.perp_trade_account_overview,
+        })}
+      />
+      <Page.Body>
+        <PerpsProviderMirror>
+          <YStack px="$4" flex={1}>
+            <DepositWithdrawContent
+              params={{ actionType: 'deposit' }}
+              selectedAccount={selectedAccount}
+              onClose={handleClose}
+              onNavigate={handleNavigate}
+            />
+          </YStack>
+        </PerpsProviderMirror>
+      </Page.Body>
+    </Page>
+  );
+}
+
+export default PerpPortfolioModal;

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/PerpPortfolioModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/PerpPortfolioModal.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 
 import { useNavigation } from '@react-navigation/native';
+import { useIntl } from 'react-intl';
 
 import { Dialog, Page, YStack } from '@onekeyhq/components';
 import {
@@ -8,35 +9,25 @@ import {
   usePerpsActiveAccountAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import type { IPerpsDepositWithdrawActionType } from '@onekeyhq/shared/types/hyperliquid/routes';
 
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
 
 import { DepositWithdrawContent } from './DepositWithdrawModal';
 
-import type { IPerpsDepositWithdrawActionType } from './DepositWithdrawModal';
-
 function showPortfolioSubDialog(
   actionType: IPerpsDepositWithdrawActionType,
   selectedAccount: IPerpsActiveAccountAtom,
+  title?: string,
 ) {
   const isDepositRelated =
     actionType === 'depositSelect' ||
     actionType === 'walletDeposit' ||
     actionType === 'relay';
 
-  const getTitle = () => {
-    if (actionType === 'withdraw') {
-      return appLocale.intl.formatMessage({
-        id: ETranslations.perp_trade_withdraw,
-      });
-    }
-    return undefined;
-  };
-
   const dialogInstance = Dialog.show({
-    title: getTitle(),
+    title: actionType === 'withdraw' ? title : undefined,
     showExitButton: !isDepositRelated,
     renderContent: (
       <PerpsProviderMirror>
@@ -54,6 +45,7 @@ function showPortfolioSubDialog(
 }
 
 function PerpPortfolioModal() {
+  const intl = useIntl();
   const navigation = useNavigation();
   const [selectedAccount] = usePerpsActiveAccountAtom();
 
@@ -68,9 +60,13 @@ function PerpPortfolioModal() {
 
   const handleNavigate = useCallback(
     (actionType: IPerpsDepositWithdrawActionType) => {
-      showPortfolioSubDialog(actionType, selectedAccount);
+      showPortfolioSubDialog(
+        actionType,
+        selectedAccount,
+        intl.formatMessage({ id: ETranslations.perp_trade_withdraw }),
+      );
     },
-    [selectedAccount],
+    [intl, selectedAccount],
   );
 
   if (!selectedAccount?.accountId || !selectedAccount?.accountAddress) {
@@ -84,7 +80,7 @@ function PerpPortfolioModal() {
   return (
     <Page>
       <Page.Header
-        title={appLocale.intl.formatMessage({
+        title={intl.formatMessage({
           id: ETranslations.perp_trade_account_overview,
         })}
       />

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/RelayDepositContent.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/RelayDepositContent.tsx
@@ -1,0 +1,673 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useIntl } from 'react-intl';
+import { Text, TextInput } from 'react-native';
+
+import {
+  Divider,
+  Icon,
+  IconButton,
+  Image,
+  QRCode,
+  Select,
+  SizableText,
+  Skeleton,
+  XStack,
+  YStack,
+  useClipboard,
+} from '@onekeyhq/components';
+import { useTheme } from '@onekeyhq/components/src/hooks/useStyle';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { HighlightAddress } from '@onekeyhq/kit/src/components/HighlightAddress';
+import type { IPerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type {
+  IRelayChain,
+  IRelayCurrency,
+  IRelayDepositInfo,
+} from '@onekeyhq/shared/types/relay';
+
+// Pure utility — format raw numeric string with thousands commas, preserving decimals
+function formatWithCommas(raw: string): string {
+  if (!raw) return raw;
+  const [integer, decimal] = raw.split('.');
+  const formattedInt = (integer ?? '').replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return decimal !== undefined ? `${formattedInt}.${decimal}` : formattedInt;
+}
+
+// Extract human-readable message from raw API error (may be JSON)
+function parseErrorMessage(raw: string): string {
+  try {
+    const jsonStart = raw.indexOf('{');
+    if (jsonStart !== -1) {
+      const parsed = JSON.parse(raw.slice(jsonStart)) as { message?: string };
+      return parsed.message ?? raw;
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return raw;
+}
+
+const DEPOSIT_WITHDRAW_INPUT_ACCESSORY_VIEW_ID =
+  'perp-deposit-withdraw-accessory-view';
+const DEBOUNCE_MS = 1000;
+const DEFAULT_RECEIVE_AMOUNT = '100';
+const PERPS_USDC_LOGO =
+  'https://uni.onekey-asset.com/server-service-indexer/evm--1/tokens/address-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png';
+
+interface IRelayDepositContentProps {
+  selectedAccount: IPerpsActiveAccountAtom;
+  isMobile?: boolean;
+}
+
+function RelayDepositContent({
+  selectedAccount,
+  isMobile,
+}: IRelayDepositContentProps) {
+  const intl = useIntl();
+  const { copyText } = useClipboard();
+  const theme = useTheme();
+
+  const [chains, setChains] = useState<IRelayChain[]>([]);
+  const [currencies, setCurrencies] = useState<
+    Record<number, IRelayCurrency[]>
+  >({});
+  const [selectedChainId, setSelectedChainId] = useState<number>(1);
+  const [selectedCurrencyAddress, setSelectedCurrencyAddress] =
+    useState<string>('');
+  const [quoteResult, setQuoteResult] = useState<IRelayDepositInfo | null>(
+    null,
+  );
+  const [sendAmount, setSendAmount] = useState('');
+  const [receiveAmount, setReceiveAmount] = useState(DEFAULT_RECEIVE_AMOUNT);
+  const [loading, setLoading] = useState(false);
+  const [chainsLoading, setChainsLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const recipientAddress = selectedAccount.accountAddress ?? '';
+  const lastEditedRef = useRef<'send' | 'receive'>('receive');
+
+  const currentCurrencies = useMemo(
+    () => currencies[selectedChainId] ?? [],
+    [currencies, selectedChainId],
+  );
+
+  const selectedCurrency = useMemo(
+    () => currentCurrencies.find((c) => c.address === selectedCurrencyAddress),
+    [currentCurrencies, selectedCurrencyAddress],
+  );
+
+  const chainOptions = useMemo(
+    () =>
+      chains.map((chain) => ({
+        label: chain.name,
+        value: chain.id,
+        leading: chain.icon ? (
+          <Image src={chain.icon} size="$5" borderRadius="$full" />
+        ) : undefined,
+      })),
+    [chains],
+  );
+
+  const currencyOptions = useMemo(
+    () =>
+      currentCurrencies.map((c) => ({
+        label: c.symbol,
+        value: c.address,
+        leading: c.logoURI ? (
+          <Image src={c.logoURI} size="$5" borderRadius="$full" />
+        ) : undefined,
+      })),
+    [currentCurrencies],
+  );
+
+  // --- Fetch quote logic ---
+  const fetchIdRef = useRef(0);
+  const fetchQuote = useCallback(
+    async (params: {
+      chainId: number;
+      currencyAddress: string;
+      amount: string;
+      tradeType?: 'EXACT_INPUT' | 'EXACT_OUTPUT';
+      decimals?: number;
+    }) => {
+      if (!recipientAddress) return;
+
+      fetchIdRef.current += 1;
+      const id = fetchIdRef.current;
+      setLoading(true);
+      setError('');
+
+      try {
+        const result = await backgroundApiProxy.serviceRelay.getRelayMaxQuote({
+          originChainId: params.chainId,
+          originCurrency: params.currencyAddress,
+          recipient: recipientAddress,
+          amount: params.amount,
+          tradeType: params.tradeType,
+          decimals: params.decimals,
+        });
+        if (id === fetchIdRef.current) {
+          setQuoteResult(result);
+          setSendAmount(result.sendAmount);
+          setReceiveAmount(result.receiveAmount);
+        }
+      } catch (e: unknown) {
+        if (id === fetchIdRef.current) {
+          const raw = e instanceof Error ? e.message : 'Failed to get quote';
+          setError(parseErrorMessage(raw));
+          // Keep previous quoteResult so QR code stays visible
+        }
+      } finally {
+        if (id === fetchIdRef.current) {
+          setLoading(false);
+        }
+      }
+    },
+    [recipientAddress],
+  );
+
+  // Debounce amount changes
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    },
+    [],
+  );
+
+  const handleSendAmountChange = useCallback(
+    (text: string) => {
+      const raw = text.replace(/,/g, '');
+      setSendAmount(raw);
+      lastEditedRef.current = 'send';
+
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = setTimeout(() => {
+        const parsed = parseFloat(raw);
+        if (!Number.isNaN(parsed) && parsed > 0) {
+          void fetchQuote({
+            chainId: selectedChainId,
+            currencyAddress: selectedCurrencyAddress,
+            amount: raw,
+            tradeType: 'EXACT_INPUT',
+            decimals: selectedCurrency?.decimals,
+          });
+        }
+      }, DEBOUNCE_MS);
+    },
+    [fetchQuote, selectedChainId, selectedCurrencyAddress, selectedCurrency],
+  );
+
+  const handleReceiveAmountChange = useCallback(
+    (text: string) => {
+      const raw = text.replace(/,/g, '');
+      setReceiveAmount(raw);
+      lastEditedRef.current = 'receive';
+
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = setTimeout(() => {
+        const parsed = parseFloat(raw);
+        if (!Number.isNaN(parsed) && parsed > 0) {
+          void fetchQuote({
+            chainId: selectedChainId,
+            currencyAddress: selectedCurrencyAddress,
+            amount: raw,
+          });
+        }
+      }, DEBOUNCE_MS);
+    },
+    [fetchQuote, selectedChainId, selectedCurrencyAddress],
+  );
+
+  // Load chains on mount, then auto-fetch first quote
+  useEffect(() => {
+    void (async () => {
+      try {
+        const result = await backgroundApiProxy.serviceRelay.getRelayChains();
+        setChains(result.chains);
+        setCurrencies(result.currencies);
+
+        // Set defaults
+        let defaultChainId = 1;
+        let defaultCurrencyAddr = '';
+
+        const ethChain = result.chains.find((c) => c.id === 1);
+        if (ethChain) {
+          const ethCurrencies = result.currencies[1];
+          const usdc = ethCurrencies?.find(
+            (c) => c.symbol.toUpperCase() === 'USDC',
+          );
+          if (usdc) {
+            defaultCurrencyAddr = usdc.address;
+          } else if (ethCurrencies?.[0]) {
+            defaultCurrencyAddr = ethCurrencies[0].address;
+          }
+        } else if (result.chains[0]) {
+          defaultChainId = result.chains[0].id;
+          const firstCurrencies = result.currencies[defaultChainId];
+          if (firstCurrencies?.[0]) {
+            defaultCurrencyAddr = firstCurrencies[0].address;
+          }
+        }
+
+        setSelectedChainId(defaultChainId);
+        setSelectedCurrencyAddress(defaultCurrencyAddr);
+        setChainsLoading(false);
+
+        // Auto-fetch quote with defaults (EXACT_OUTPUT, receive 100 USDC)
+        if (defaultCurrencyAddr) {
+          void fetchQuote({
+            chainId: defaultChainId,
+            currencyAddress: defaultCurrencyAddr,
+            amount: DEFAULT_RECEIVE_AMOUNT,
+          });
+        }
+      } catch (e) {
+        console.error('Failed to load relay chains', e);
+        setChainsLoading(false);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleChainChange = useCallback(
+    (chainId: number) => {
+      setSelectedChainId(chainId);
+      setQuoteResult(null);
+      setError('');
+      const chainCurrencies = currencies[chainId];
+      const usdc = chainCurrencies?.find(
+        (c) => c.symbol.toUpperCase() === 'USDC',
+      );
+      const picked = usdc ?? chainCurrencies?.[0];
+      if (picked) {
+        setSelectedCurrencyAddress(picked.address);
+        void fetchQuote({
+          chainId,
+          currencyAddress: picked.address,
+          amount: DEFAULT_RECEIVE_AMOUNT,
+        });
+      }
+    },
+    [currencies, fetchQuote],
+  );
+
+  const handleCurrencyChange = useCallback(
+    (address: string) => {
+      setSelectedCurrencyAddress(address);
+      setQuoteResult(null);
+      setError('');
+      const currency = currentCurrencies.find((c) => c.address === address);
+      if (currency) {
+        void fetchQuote({
+          chainId: selectedChainId,
+          currencyAddress: currency.address,
+          amount: DEFAULT_RECEIVE_AMOUNT,
+        });
+      }
+    },
+    [currentCurrencies, selectedChainId, fetchQuote],
+  );
+
+  const handleCopyAddress = useCallback(() => {
+    if (quoteResult?.depositAddress) {
+      copyText(quoteResult.depositAddress);
+    }
+  }, [quoteResult?.depositAddress, copyText]);
+
+  const timeEstimateText = useMemo(() => {
+    if (!quoteResult?.timeEstimate) return '';
+    const seconds = quoteResult.timeEstimate;
+    if (seconds < 60) return `~${seconds}s`;
+    const minutes = Math.round(seconds / 60);
+    return `~${minutes}m`;
+  }, [quoteResult?.timeEstimate]);
+
+  const hintText = useMemo(() => {
+    const maxRaw = quoteResult?.maxReceiveAmount;
+    if (maxRaw && parseFloat(maxRaw) > 0) {
+      const formatted = numberFormat(maxRaw, {
+        formatter: 'marketCap',
+        formatterOptions: { currency: '$' },
+      });
+      return intl.formatMessage(
+        { id: ETranslations.perp_relay_deposit_hint_with_max__desc },
+        { amount: formatted },
+      );
+    }
+    return intl.formatMessage({
+      id: ETranslations.perp_relay_deposit_hint__desc,
+    });
+  }, [quoteResult?.maxReceiveAmount, intl]);
+
+  if (chainsLoading) {
+    return (
+      <YStack gap="$4" py="$4">
+        <Skeleton width="100%" height={42} />
+        <Skeleton width="100%" height={42} />
+        <Skeleton width="100%" height={200} />
+      </YStack>
+    );
+  }
+
+  const amountSection = quoteResult ? (
+    <YStack gap="$2" opacity={loading ? 0.5 : 1}>
+      <XStack justifyContent="space-between" alignItems="center">
+        <SizableText size="$bodySm" color="$textSubdued">
+          {`${intl.formatMessage({ id: ETranslations.fee_fee })}: $${quoteResult.totalFeeUsd}`}
+        </SizableText>
+        {timeEstimateText ? (
+          <XStack alignItems="center" gap="$1">
+            <Icon
+              name="ClockTimeHistoryOutline"
+              size="$3.5"
+              color="$iconSubdued"
+            />
+            <SizableText size="$bodySm" color="$textSubdued">
+              {timeEstimateText}
+            </SizableText>
+          </XStack>
+        ) : null}
+      </XStack>
+      <XStack justifyContent="space-between" alignItems="center">
+        <SizableText size="$bodySm" color="$textSubdued">
+          {intl.formatMessage({ id: ETranslations.global_send })}
+        </SizableText>
+        <XStack alignItems="center" gap="$1.5">
+          <YStack
+            position="relative"
+            borderRadius="$2"
+            px="$1.5"
+            py="$0.5"
+            hoverStyle={{ bg: '$bgHover' }}
+          >
+            <Text
+              style={{
+                fontSize: 12,
+                opacity: 0,
+                minWidth: 30,
+                color: 'transparent',
+              }}
+              pointerEvents="none"
+            >
+              {formatWithCommas(sendAmount) || '0'}
+            </Text>
+            <TextInput
+              accessible
+              accessibilityLabel="Send amount"
+              inputAccessoryViewID={
+                platformEnv.isNativeIOS
+                  ? DEPOSIT_WITHDRAW_INPUT_ACCESSORY_VIEW_ID
+                  : undefined
+              }
+              value={formatWithCommas(sendAmount)}
+              onChangeText={handleSendAmountChange}
+              keyboardType="numeric"
+              placeholder="0"
+              placeholderTextColor={theme.textDisabled.val}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 6,
+                right: 6,
+                bottom: 0,
+                color: theme.text.val,
+                fontSize: 12,
+                textAlign: 'right',
+                padding: 0,
+              }}
+            />
+          </YStack>
+          {selectedCurrency?.logoURI ? (
+            <Image
+              src={selectedCurrency.logoURI}
+              size="$4"
+              borderRadius="$full"
+            />
+          ) : null}
+          <SizableText size="$bodySm" color="$text">
+            {selectedCurrency?.symbol ?? ''}
+          </SizableText>
+        </XStack>
+      </XStack>
+
+      <XStack justifyContent="space-between" alignItems="center">
+        <SizableText size="$bodySm" color="$textSubdued">
+          {intl.formatMessage({ id: ETranslations.global_receive })}
+        </SizableText>
+        <XStack alignItems="center" gap="$1.5">
+          <YStack
+            position="relative"
+            borderRadius="$2"
+            px="$1.5"
+            py="$0.5"
+            hoverStyle={{ bg: '$bgHover' }}
+          >
+            <Text
+              style={{
+                fontSize: 12,
+                opacity: 0,
+                minWidth: 30,
+                color: 'transparent',
+              }}
+              pointerEvents="none"
+            >
+              {formatWithCommas(receiveAmount) || DEFAULT_RECEIVE_AMOUNT}
+            </Text>
+            <TextInput
+              accessible
+              accessibilityLabel="Receive amount"
+              inputAccessoryViewID={
+                platformEnv.isNativeIOS
+                  ? DEPOSIT_WITHDRAW_INPUT_ACCESSORY_VIEW_ID
+                  : undefined
+              }
+              value={formatWithCommas(receiveAmount)}
+              onChangeText={handleReceiveAmountChange}
+              keyboardType="numeric"
+              placeholder={DEFAULT_RECEIVE_AMOUNT}
+              placeholderTextColor={theme.textDisabled.val}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 6,
+                right: 6,
+                bottom: 0,
+                color: theme.textSuccess.val,
+                fontSize: 12,
+                textAlign: 'right',
+                padding: 0,
+              }}
+            />
+          </YStack>
+          <Image src={PERPS_USDC_LOGO} size="$4" borderRadius="$full" />
+          <SizableText size="$bodySm" color="$textSuccess">
+            USDC (Perps)
+          </SizableText>
+        </XStack>
+      </XStack>
+
+      {/* Hint bubble */}
+      <YStack mt="$-1.5">
+        <XStack justifyContent="center" pl={110} overflow="hidden" h={6}>
+          <YStack
+            width={10}
+            height={10}
+            bg="$bgInfoSubdued"
+            mt={1}
+            transform={[{ rotate: '45deg' }]}
+          />
+        </XStack>
+        <YStack bg="$bgInfoSubdued" borderRadius="$2" px="$3" py="$2">
+          <SizableText size="$bodySm" color="$textSubdued">
+            {hintText}
+          </SizableText>
+        </YStack>
+      </YStack>
+    </YStack>
+  ) : null;
+
+  const addressSection = quoteResult ? (
+    <YStack gap="$4" opacity={loading ? 0.5 : 1}>
+      <YStack borderRadius="$3" p="$4" gap="$4" alignItems="center">
+        <QRCode value={quoteResult.depositAddress} size={180} />
+      </YStack>
+
+      <YStack gap="$1" py="$1">
+        <SizableText size="$bodySm" color="$textSubdued">
+          {intl.formatMessage({
+            id: ETranslations.global_address,
+          })}
+        </SizableText>
+        <XStack alignItems="center" gap="$10">
+          <YStack flex={1} width={0}>
+            <HighlightAddress address={quoteResult.depositAddress} />
+          </YStack>
+          <IconButton
+            size="small"
+            variant="primary"
+            icon="Copy1Outline"
+            onPress={handleCopyAddress}
+          />
+        </XStack>
+      </YStack>
+    </YStack>
+  ) : null;
+
+  return (
+    <YStack gap="$4">
+      {/* Chain & Token selectors */}
+      <XStack gap="$2.5">
+        <YStack gap="$2" flex={1}>
+          <SizableText size="$bodyMd" color="$textSubdued">
+            {intl.formatMessage({ id: ETranslations.global_network })}
+          </SizableText>
+          <Select
+            title={intl.formatMessage({ id: ETranslations.global_network })}
+            value={selectedChainId}
+            onChange={handleChainChange}
+            items={chainOptions}
+            renderTrigger={({ value: triggerValue }) => {
+              const chain = chains.find((c) => c.id === triggerValue);
+              return (
+                <XStack
+                  borderWidth="$px"
+                  borderColor="$borderSubdued"
+                  borderRadius="$3"
+                  px="$3"
+                  bg="$bgSubdued"
+                  alignItems="center"
+                  justifyContent="space-between"
+                  h={42}
+                  cursor="pointer"
+                  hoverStyle={{ bg: '$bgHover' }}
+                >
+                  <XStack alignItems="center" gap="$2" flex={1}>
+                    {chain?.icon ? (
+                      <Image src={chain.icon} size="$5" borderRadius="$full" />
+                    ) : null}
+                    <SizableText size="$bodyMd" numberOfLines={1}>
+                      {chain?.name ??
+                        intl.formatMessage({
+                          id: ETranslations.global_select_network,
+                        })}
+                    </SizableText>
+                  </XStack>
+                  <Icon name="ChevronDownSmallOutline" size="$4" />
+                </XStack>
+              );
+            }}
+          />
+        </YStack>
+
+        <YStack gap="$2" flex={1}>
+          <SizableText size="$bodyMd" color="$textSubdued">
+            {intl.formatMessage({ id: ETranslations.perp_relay_token__title })}
+          </SizableText>
+          <Select
+            title={intl.formatMessage({
+              id: ETranslations.perp_relay_token__title,
+            })}
+            value={selectedCurrencyAddress}
+            onChange={handleCurrencyChange}
+            items={currencyOptions}
+            renderTrigger={({ value: triggerValue }) => {
+              const currency = currentCurrencies.find(
+                (c) => c.address === triggerValue,
+              );
+              return (
+                <XStack
+                  borderWidth="$px"
+                  borderColor="$borderSubdued"
+                  borderRadius="$3"
+                  px="$3"
+                  bg="$bgSubdued"
+                  alignItems="center"
+                  justifyContent="space-between"
+                  h={42}
+                  cursor="pointer"
+                  hoverStyle={{ bg: '$bgHover' }}
+                >
+                  <XStack alignItems="center" gap="$2" flex={1}>
+                    {currency?.logoURI ? (
+                      <Image
+                        src={currency.logoURI}
+                        size="$5"
+                        borderRadius="$full"
+                      />
+                    ) : null}
+                    <SizableText size="$bodyMd" numberOfLines={1}>
+                      {currency?.symbol ??
+                        intl.formatMessage({
+                          id: ETranslations.dexmarket_select_token,
+                        })}
+                    </SizableText>
+                  </XStack>
+                  <Icon name="ChevronDownSmallOutline" size="$4" />
+                </XStack>
+              );
+            }}
+          />
+        </YStack>
+      </XStack>
+
+      {/* Error message */}
+      {error ? (
+        <SizableText size="$bodySm" color="$red10">
+          {error}
+        </SizableText>
+      ) : null}
+
+      {/* Loading state */}
+      {loading && !quoteResult ? (
+        <YStack gap="$4" alignItems="center" py="$4">
+          <Skeleton width={200} height={200} />
+          <Skeleton width="100%" height={40} />
+          <Skeleton width="100%" height={120} />
+        </YStack>
+      ) : null}
+
+      {/* Mobile: amount first, then address; Desktop: address first, then amount */}
+      {!isMobile ? (
+        <>
+          {addressSection}
+          {addressSection ? <Divider /> : null}
+          {amountSection}
+        </>
+      ) : (
+        <>
+          {amountSection}
+          {amountSection ? <Divider /> : null}
+          {addressSection}
+        </>
+      )}
+    </YStack>
+  );
+}
+
+export default RelayDepositContent;

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/RelayDepositContent.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/RelayDepositContent.tsx
@@ -21,7 +21,11 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { HighlightAddress } from '@onekeyhq/kit/src/components/HighlightAddress';
 import { validateAmountInput } from '@onekeyhq/kit/src/utils/validateAmountInput';
 import { PerpTestIDs } from '@onekeyhq/kit/src/views/Perp/testIDs';
-import type { IPerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  type IPerpsActiveAccountAtom,
+  type IPerpsRelayDepositSessionAtom,
+  usePerpsRelayDepositSessionsAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
@@ -30,6 +34,13 @@ import type {
   IRelayCurrency,
   IRelayDepositInfo,
 } from '@onekeyhq/shared/types/relay';
+
+import {
+  RELAY_DEPOSIT_DIALOG_POLL_INTERVAL_MS,
+  buildRelayDepositSessionId,
+  isRelayDepositTerminalStatus,
+} from '../../../utils/relayDepositTracking';
+import { RelayDepositTrackingCard } from '../components/RelayDepositTrackingCard';
 
 // Pure utility — format raw numeric string with thousands commas, preserving decimals
 function formatWithCommas(raw: string): string {
@@ -72,6 +83,8 @@ function RelayDepositContent({
   const intl = useIntl();
   const { copyText } = useClipboard();
   const theme = useTheme();
+  const [{ sessions: relayDepositSessions }, setRelayDepositSessions] =
+    usePerpsRelayDepositSessionsAtom();
 
   const [chains, setChains] = useState<IRelayChain[]>([]);
   const [currencies, setCurrencies] = useState<
@@ -86,11 +99,13 @@ function RelayDepositContent({
   const [sendAmount, setSendAmount] = useState(DEFAULT_SEND_AMOUNT);
   const [receiveAmount, setReceiveAmount] = useState('');
   const [loading, setLoading] = useState(false);
+  const [statusLoading, setStatusLoading] = useState(false);
   const [chainsLoading, setChainsLoading] = useState(true);
   const [error, setError] = useState('');
 
   const recipientAddress = selectedAccount.accountAddress ?? '';
   const fetchIdRef = useRef(0);
+  const statusFetchIdRef = useRef(0);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const latestQuoteInputRef = useRef({
     recipientAddress,
@@ -107,6 +122,25 @@ function RelayDepositContent({
   const selectedCurrency = useMemo(
     () => currentCurrencies.find((c) => c.address === selectedCurrencyAddress),
     [currentCurrencies, selectedCurrencyAddress],
+  );
+
+  const selectedChain = useMemo(
+    () => chains.find((c) => c.id === selectedChainId),
+    [chains, selectedChainId],
+  );
+
+  const currentSessionId = useMemo(() => {
+    if (!recipientAddress || !quoteResult?.depositAddress) return '';
+    return buildRelayDepositSessionId({
+      accountAddress: recipientAddress,
+      depositAddress: quoteResult.depositAddress,
+    });
+  }, [quoteResult?.depositAddress, recipientAddress]);
+
+  const currentRelayDepositSession = useMemo(
+    () =>
+      relayDepositSessions.find((session) => session.id === currentSessionId),
+    [currentSessionId, relayDepositSessions],
   );
 
   const chainOptions = useMemo(
@@ -406,6 +440,161 @@ function RelayDepositContent({
     ],
   );
 
+  useEffect(() => {
+    if (
+      !currentSessionId ||
+      !quoteResult?.depositAddress ||
+      !selectedCurrency ||
+      !selectedChain
+    ) {
+      return;
+    }
+
+    const now = Date.now();
+    setRelayDepositSessions((prev) => {
+      const existing = prev.sessions.find(
+        (session) => session.id === currentSessionId,
+      );
+      const isSameRequest =
+        !quoteResult.requestId || quoteResult.requestId === existing?.requestId;
+      const nextSession: IPerpsRelayDepositSessionAtom = {
+        id: currentSessionId,
+        accountId: selectedAccount.accountId,
+        indexedAccountId: selectedAccount.indexedAccountId,
+        accountAddress: selectedAccount.accountAddress,
+        originChainId: selectedChain.id,
+        originChainName: selectedChain.name,
+        originCurrency: selectedCurrency.address,
+        originCurrencySymbol: selectedCurrency.symbol,
+        depositAddress: quoteResult.depositAddress,
+        requestId:
+          quoteResult.requestId ??
+          (isSameRequest ? existing?.requestId : undefined),
+        sendAmount: quoteResult.sendAmount,
+        receiveAmount: quoteResult.receiveAmount,
+        receiveSymbol: quoteResult.receiveSymbol,
+        status: isSameRequest ? (existing?.status ?? 'waiting') : 'waiting',
+        inTxs: isSameRequest ? (existing?.inTxs ?? []) : [],
+        outTxs: isSameRequest ? (existing?.outTxs ?? []) : [],
+        createdAt: isSameRequest ? (existing?.createdAt ?? now) : now,
+        updatedAt: now,
+        lastCheckedAt: isSameRequest ? existing?.lastCheckedAt : undefined,
+        error: isSameRequest ? existing?.error : undefined,
+      };
+      const sessions = [
+        nextSession,
+        ...prev.sessions.filter((session) => session.id !== currentSessionId),
+      ];
+      return {
+        sessions: sessions.slice(0, 20),
+      };
+    });
+  }, [
+    currentSessionId,
+    quoteResult,
+    selectedAccount.accountAddress,
+    selectedAccount.accountId,
+    selectedAccount.indexedAccountId,
+    selectedChain,
+    selectedCurrency,
+    setRelayDepositSessions,
+  ]);
+
+  const refreshRelayDepositStatus = useCallback(async () => {
+    if (!currentSessionId || !quoteResult?.depositAddress) {
+      return undefined;
+    }
+
+    statusFetchIdRef.current += 1;
+    const id = statusFetchIdRef.current;
+    setStatusLoading(true);
+
+    try {
+      const result =
+        await backgroundApiProxy.serviceRelay.getRelayDepositStatus({
+          depositAddress: quoteResult.depositAddress,
+          requestId: quoteResult.requestId,
+        });
+      if (id !== statusFetchIdRef.current) {
+        return undefined;
+      }
+      setRelayDepositSessions((prev) => ({
+        sessions: prev.sessions.map((session) =>
+          session.id === currentSessionId
+            ? {
+                ...session,
+                requestId: result.requestId ?? session.requestId,
+                status: result.status,
+                inTxs: result.inTxs,
+                outTxs: result.outTxs,
+                lastCheckedAt: result.lastCheckedAt,
+                updatedAt: Date.now(),
+                error: undefined,
+              }
+            : session,
+        ),
+      }));
+      return result.status;
+    } catch (e) {
+      const raw = e instanceof Error ? e.message : 'Failed to load status';
+      if (id === statusFetchIdRef.current) {
+        setRelayDepositSessions((prev) => ({
+          sessions: prev.sessions.map((session) =>
+            session.id === currentSessionId
+              ? {
+                  ...session,
+                  lastCheckedAt: Date.now(),
+                  updatedAt: Date.now(),
+                  error: parseErrorMessage(raw),
+                }
+              : session,
+          ),
+        }));
+      }
+      return undefined;
+    } finally {
+      if (id === statusFetchIdRef.current) {
+        setStatusLoading(false);
+      }
+    }
+  }, [
+    currentSessionId,
+    quoteResult?.depositAddress,
+    quoteResult?.requestId,
+    setRelayDepositSessions,
+  ]);
+
+  useEffect(() => {
+    if (!currentSessionId || !quoteResult?.depositAddress) {
+      return undefined;
+    }
+
+    let isCancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const run = async () => {
+      const status = await refreshRelayDepositStatus();
+      if (isCancelled || isRelayDepositTerminalStatus(status)) return;
+      timer = setTimeout(() => {
+        void run();
+      }, RELAY_DEPOSIT_DIALOG_POLL_INTERVAL_MS);
+    };
+
+    void run();
+
+    return () => {
+      isCancelled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      statusFetchIdRef.current += 1;
+    };
+  }, [
+    currentSessionId,
+    quoteResult?.depositAddress,
+    refreshRelayDepositStatus,
+  ]);
+
   const handleCopyAddress = useCallback(() => {
     if (quoteResult?.depositAddress) {
       copyText(quoteResult.depositAddress);
@@ -633,6 +822,16 @@ function RelayDepositContent({
     </YStack>
   ) : null;
 
+  const trackingSection = currentRelayDepositSession ? (
+    <RelayDepositTrackingCard
+      session={currentRelayDepositSession}
+      loading={statusLoading}
+      onRefresh={() => {
+        void refreshRelayDepositStatus();
+      }}
+    />
+  ) : null;
+
   return (
     <YStack gap="$4">
       {/* Chain & Token selectors */}
@@ -752,7 +951,8 @@ function RelayDepositContent({
       {!isMobile ? (
         <>
           {addressSection}
-          {addressSection ? <Divider /> : null}
+          {addressSection ? trackingSection : null}
+          {addressSection || trackingSection ? <Divider /> : null}
           {amountSection}
         </>
       ) : (
@@ -760,6 +960,7 @@ function RelayDepositContent({
           {amountSection}
           {amountSection ? <Divider /> : null}
           {addressSection}
+          {addressSection ? trackingSection : null}
         </>
       )}
     </YStack>

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/RelayDepositContent.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/RelayDepositContent.tsx
@@ -20,6 +20,7 @@ import { useTheme } from '@onekeyhq/components/src/hooks/useStyle';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { HighlightAddress } from '@onekeyhq/kit/src/components/HighlightAddress';
 import { validateAmountInput } from '@onekeyhq/kit/src/utils/validateAmountInput';
+import { PerpTestIDs } from '@onekeyhq/kit/src/views/Perp/testIDs';
 import type { IPerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -89,6 +90,14 @@ function RelayDepositContent({
   const [error, setError] = useState('');
 
   const recipientAddress = selectedAccount.accountAddress ?? '';
+  const fetchIdRef = useRef(0);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestQuoteInputRef = useRef({
+    recipientAddress,
+    chainId: selectedChainId,
+    currencyAddress: selectedCurrencyAddress,
+    amount: sendAmount,
+  });
 
   const currentCurrencies = useMemo(
     () => currencies[selectedChainId] ?? [],
@@ -124,8 +133,26 @@ function RelayDepositContent({
     [currentCurrencies],
   );
 
+  const clearPendingQuoteDebounce = useCallback(() => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+  }, []);
+
+  const updateLatestQuoteInput = useCallback(
+    (params: { chainId: number; currencyAddress: string; amount: string }) => {
+      latestQuoteInputRef.current = {
+        recipientAddress,
+        chainId: params.chainId,
+        currencyAddress: params.currencyAddress,
+        amount: params.amount,
+      };
+    },
+    [recipientAddress],
+  );
+
   // --- Fetch quote logic ---
-  const fetchIdRef = useRef(0);
   const fetchQuote = useCallback(
     async (params: {
       chainId: number;
@@ -140,6 +167,17 @@ function RelayDepositContent({
       setLoading(true);
       setError('');
 
+      const isCurrentQuoteRequest = () => {
+        const latest = latestQuoteInputRef.current;
+        return (
+          id === fetchIdRef.current &&
+          latest.recipientAddress === recipientAddress &&
+          latest.chainId === params.chainId &&
+          latest.currencyAddress === params.currencyAddress &&
+          latest.amount === params.amount
+        );
+      };
+
       try {
         const result = await backgroundApiProxy.serviceRelay.getRelayMaxQuote({
           originChainId: params.chainId,
@@ -150,19 +188,19 @@ function RelayDepositContent({
           amount: params.amount,
           decimals: params.decimals,
         });
-        if (id === fetchIdRef.current) {
+        if (isCurrentQuoteRequest()) {
           setQuoteResult(result);
           setSendAmount(result.sendAmount);
           setReceiveAmount(result.receiveAmount);
         }
       } catch (e: unknown) {
-        if (id === fetchIdRef.current) {
+        if (isCurrentQuoteRequest()) {
           const raw = e instanceof Error ? e.message : 'Failed to get quote';
           setError(parseErrorMessage(raw));
           // Keep previous quoteResult so QR code stays visible
         }
       } finally {
-        if (id === fetchIdRef.current) {
+        if (isCurrentQuoteRequest()) {
           setLoading(false);
         }
       }
@@ -170,14 +208,11 @@ function RelayDepositContent({
     [recipientAddress],
   );
 
-  // Debounce amount changes
-  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   useEffect(
     () => () => {
-      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      clearPendingQuoteDebounce();
     },
-    [],
+    [clearPendingQuoteDebounce],
   );
 
   const handleSendAmountChange = useCallback(
@@ -191,8 +226,13 @@ function RelayDepositContent({
       setReceiveAmount('');
       setLoading(false);
       setError('');
+      updateLatestQuoteInput({
+        chainId: selectedChainId,
+        currencyAddress: selectedCurrencyAddress,
+        amount: raw,
+      });
 
-      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      clearPendingQuoteDebounce();
       debounceTimerRef.current = setTimeout(() => {
         const parsed = parseFloat(raw);
         if (!Number.isNaN(parsed) && parsed > 0) {
@@ -205,7 +245,14 @@ function RelayDepositContent({
         }
       }, DEBOUNCE_MS);
     },
-    [fetchQuote, selectedChainId, selectedCurrencyAddress, selectedCurrency],
+    [
+      clearPendingQuoteDebounce,
+      fetchQuote,
+      selectedChainId,
+      selectedCurrencyAddress,
+      selectedCurrency,
+      updateLatestQuoteInput,
+    ],
   );
 
   // Load chains and fetch the default quote for the active recipient.
@@ -262,6 +309,11 @@ function RelayDepositContent({
 
         // Deposit-address quotes use exact-input semantics.
         if (defaultCurrencyAddr) {
+          updateLatestQuoteInput({
+            chainId: defaultChainId,
+            currencyAddress: defaultCurrencyAddr,
+            amount: DEFAULT_SEND_AMOUNT,
+          });
           void fetchQuote({
             chainId: defaultChainId,
             currencyAddress: defaultCurrencyAddr,
@@ -279,14 +331,24 @@ function RelayDepositContent({
 
     return () => {
       isCancelled = true;
+      clearPendingQuoteDebounce();
       fetchIdRef.current += 1;
     };
-  }, [fetchQuote, recipientAddress]);
+  }, [
+    clearPendingQuoteDebounce,
+    fetchQuote,
+    recipientAddress,
+    updateLatestQuoteInput,
+  ]);
 
   const handleChainChange = useCallback(
     (chainId: number) => {
+      clearPendingQuoteDebounce();
+      fetchIdRef.current += 1;
       setSelectedChainId(chainId);
       setQuoteResult(null);
+      setSendAmount(DEFAULT_SEND_AMOUNT);
+      setReceiveAmount('');
       setError('');
       const chainCurrencies = currencies[chainId];
       const usdc = chainCurrencies?.find(
@@ -295,6 +357,11 @@ function RelayDepositContent({
       const picked = usdc ?? chainCurrencies?.[0];
       if (picked) {
         setSelectedCurrencyAddress(picked.address);
+        updateLatestQuoteInput({
+          chainId,
+          currencyAddress: picked.address,
+          amount: DEFAULT_SEND_AMOUNT,
+        });
         void fetchQuote({
           chainId,
           currencyAddress: picked.address,
@@ -303,16 +370,25 @@ function RelayDepositContent({
         });
       }
     },
-    [currencies, fetchQuote],
+    [clearPendingQuoteDebounce, currencies, fetchQuote, updateLatestQuoteInput],
   );
 
   const handleCurrencyChange = useCallback(
     (address: string) => {
+      clearPendingQuoteDebounce();
+      fetchIdRef.current += 1;
       setSelectedCurrencyAddress(address);
       setQuoteResult(null);
+      setSendAmount(DEFAULT_SEND_AMOUNT);
+      setReceiveAmount('');
       setError('');
       const currency = currentCurrencies.find((c) => c.address === address);
       if (currency) {
+        updateLatestQuoteInput({
+          chainId: selectedChainId,
+          currencyAddress: currency.address,
+          amount: DEFAULT_SEND_AMOUNT,
+        });
         void fetchQuote({
           chainId: selectedChainId,
           currencyAddress: currency.address,
@@ -321,7 +397,13 @@ function RelayDepositContent({
         });
       }
     },
-    [currentCurrencies, selectedChainId, fetchQuote],
+    [
+      clearPendingQuoteDebounce,
+      currentCurrencies,
+      selectedChainId,
+      fetchQuote,
+      updateLatestQuoteInput,
+    ],
   );
 
   const handleCopyAddress = useCallback(() => {
@@ -410,6 +492,7 @@ function RelayDepositContent({
             <TextInput
               accessible
               accessibilityLabel="Send amount"
+              testID={PerpTestIDs.RelayDepositSendAmountInput}
               inputAccessoryViewID={
                 platformEnv.isNativeIOS
                   ? DEPOSIT_WITHDRAW_INPUT_ACCESSORY_VIEW_ID
@@ -539,6 +622,7 @@ function RelayDepositContent({
             <HighlightAddress address={quoteResult.depositAddress} />
           </YStack>
           <IconButton
+            testID={PerpTestIDs.RelayDepositCopyAddressButton}
             size="small"
             variant="primary"
             icon="Copy1Outline"
@@ -558,6 +642,7 @@ function RelayDepositContent({
             {intl.formatMessage({ id: ETranslations.global_network })}
           </SizableText>
           <Select
+            testID={PerpTestIDs.RelayDepositNetworkSelector}
             title={intl.formatMessage({ id: ETranslations.global_network })}
             value={selectedChainId}
             onChange={handleChainChange}
@@ -600,6 +685,7 @@ function RelayDepositContent({
             {intl.formatMessage({ id: ETranslations.perp_relay_token__title })}
           </SizableText>
           <Select
+            testID={PerpTestIDs.RelayDepositTokenSelector}
             title={intl.formatMessage({
               id: ETranslations.perp_relay_token__title,
             })}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/RelayDepositContent.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/RelayDepositContent.tsx
@@ -19,6 +19,7 @@ import {
 import { useTheme } from '@onekeyhq/components/src/hooks/useStyle';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { HighlightAddress } from '@onekeyhq/kit/src/components/HighlightAddress';
+import { validateAmountInput } from '@onekeyhq/kit/src/utils/validateAmountInput';
 import type { IPerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -55,6 +56,7 @@ const DEPOSIT_WITHDRAW_INPUT_ACCESSORY_VIEW_ID =
   'perp-deposit-withdraw-accessory-view';
 const DEBOUNCE_MS = 1000;
 const DEFAULT_RECEIVE_AMOUNT = '100';
+const DEFAULT_RECEIVE_DECIMALS = 8;
 const PERPS_USDC_LOGO =
   'https://uni.onekey-asset.com/server-service-indexer/evm--1/tokens/address-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png';
 
@@ -183,6 +185,9 @@ function RelayDepositContent({
   const handleSendAmountChange = useCallback(
     (text: string) => {
       const raw = text.replace(/,/g, '');
+      if (!validateAmountInput(raw, selectedCurrency?.decimals)) {
+        return;
+      }
       setSendAmount(raw);
       lastEditedRef.current = 'send';
 
@@ -206,6 +211,9 @@ function RelayDepositContent({
   const handleReceiveAmountChange = useCallback(
     (text: string) => {
       const raw = text.replace(/,/g, '');
+      if (!validateAmountInput(raw, DEFAULT_RECEIVE_DECIMALS)) {
+        return;
+      }
       setReceiveAmount(raw);
       lastEditedRef.current = 'receive';
 
@@ -224,11 +232,24 @@ function RelayDepositContent({
     [fetchQuote, selectedChainId, selectedCurrencyAddress],
   );
 
-  // Load chains on mount, then auto-fetch first quote
+  // Load chains and fetch the default quote for the active recipient.
   useEffect(() => {
+    let isCancelled = false;
+    fetchIdRef.current += 1;
+    setQuoteResult(null);
+    setError('');
+
+    if (!recipientAddress) {
+      setChainsLoading(false);
+      return undefined;
+    }
+
     void (async () => {
+      setChainsLoading(true);
       try {
         const result = await backgroundApiProxy.serviceRelay.getRelayChains();
+        if (isCancelled) return;
+
         setChains(result.chains);
         setCurrencies(result.currencies);
 
@@ -268,12 +289,18 @@ function RelayDepositContent({
           });
         }
       } catch (e) {
-        console.error('Failed to load relay chains', e);
+        if (isCancelled) return;
+        const raw = e instanceof Error ? e.message : 'Failed to load chains';
+        setError(parseErrorMessage(raw));
         setChainsLoading(false);
       }
     })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+
+    return () => {
+      isCancelled = true;
+      fetchIdRef.current += 1;
+    };
+  }, [fetchQuote, recipientAddress]);
 
   const handleChainChange = useCallback(
     (chainId: number) => {

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/RelayDepositContent.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/RelayDepositContent.tsx
@@ -55,8 +55,7 @@ function parseErrorMessage(raw: string): string {
 const DEPOSIT_WITHDRAW_INPUT_ACCESSORY_VIEW_ID =
   'perp-deposit-withdraw-accessory-view';
 const DEBOUNCE_MS = 1000;
-const DEFAULT_RECEIVE_AMOUNT = '100';
-const DEFAULT_RECEIVE_DECIMALS = 8;
+const DEFAULT_SEND_AMOUNT = '100';
 const PERPS_USDC_LOGO =
   'https://uni.onekey-asset.com/server-service-indexer/evm--1/tokens/address-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png';
 
@@ -83,14 +82,13 @@ function RelayDepositContent({
   const [quoteResult, setQuoteResult] = useState<IRelayDepositInfo | null>(
     null,
   );
-  const [sendAmount, setSendAmount] = useState('');
-  const [receiveAmount, setReceiveAmount] = useState(DEFAULT_RECEIVE_AMOUNT);
+  const [sendAmount, setSendAmount] = useState(DEFAULT_SEND_AMOUNT);
+  const [receiveAmount, setReceiveAmount] = useState('');
   const [loading, setLoading] = useState(false);
   const [chainsLoading, setChainsLoading] = useState(true);
   const [error, setError] = useState('');
 
   const recipientAddress = selectedAccount.accountAddress ?? '';
-  const lastEditedRef = useRef<'send' | 'receive'>('receive');
 
   const currentCurrencies = useMemo(
     () => currencies[selectedChainId] ?? [],
@@ -133,7 +131,6 @@ function RelayDepositContent({
       chainId: number;
       currencyAddress: string;
       amount: string;
-      tradeType?: 'EXACT_INPUT' | 'EXACT_OUTPUT';
       decimals?: number;
     }) => {
       if (!recipientAddress) return;
@@ -148,8 +145,9 @@ function RelayDepositContent({
           originChainId: params.chainId,
           originCurrency: params.currencyAddress,
           recipient: recipientAddress,
+          user: recipientAddress,
+          refundTo: recipientAddress,
           amount: params.amount,
-          tradeType: params.tradeType,
           decimals: params.decimals,
         });
         if (id === fetchIdRef.current) {
@@ -188,8 +186,11 @@ function RelayDepositContent({
       if (!validateAmountInput(raw, selectedCurrency?.decimals)) {
         return;
       }
+      fetchIdRef.current += 1;
       setSendAmount(raw);
-      lastEditedRef.current = 'send';
+      setReceiveAmount('');
+      setLoading(false);
+      setError('');
 
       if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
       debounceTimerRef.current = setTimeout(() => {
@@ -199,37 +200,12 @@ function RelayDepositContent({
             chainId: selectedChainId,
             currencyAddress: selectedCurrencyAddress,
             amount: raw,
-            tradeType: 'EXACT_INPUT',
             decimals: selectedCurrency?.decimals,
           });
         }
       }, DEBOUNCE_MS);
     },
     [fetchQuote, selectedChainId, selectedCurrencyAddress, selectedCurrency],
-  );
-
-  const handleReceiveAmountChange = useCallback(
-    (text: string) => {
-      const raw = text.replace(/,/g, '');
-      if (!validateAmountInput(raw, DEFAULT_RECEIVE_DECIMALS)) {
-        return;
-      }
-      setReceiveAmount(raw);
-      lastEditedRef.current = 'receive';
-
-      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
-      debounceTimerRef.current = setTimeout(() => {
-        const parsed = parseFloat(raw);
-        if (!Number.isNaN(parsed) && parsed > 0) {
-          void fetchQuote({
-            chainId: selectedChainId,
-            currencyAddress: selectedCurrencyAddress,
-            amount: raw,
-          });
-        }
-      }, DEBOUNCE_MS);
-    },
-    [fetchQuote, selectedChainId, selectedCurrencyAddress],
   );
 
   // Load chains and fetch the default quote for the active recipient.
@@ -256,6 +232,7 @@ function RelayDepositContent({
         // Set defaults
         let defaultChainId = 1;
         let defaultCurrencyAddr = '';
+        let defaultCurrencyDecimals: number | undefined;
 
         const ethChain = result.chains.find((c) => c.id === 1);
         if (ethChain) {
@@ -265,14 +242,17 @@ function RelayDepositContent({
           );
           if (usdc) {
             defaultCurrencyAddr = usdc.address;
+            defaultCurrencyDecimals = usdc.decimals;
           } else if (ethCurrencies?.[0]) {
             defaultCurrencyAddr = ethCurrencies[0].address;
+            defaultCurrencyDecimals = ethCurrencies[0].decimals;
           }
         } else if (result.chains[0]) {
           defaultChainId = result.chains[0].id;
           const firstCurrencies = result.currencies[defaultChainId];
           if (firstCurrencies?.[0]) {
             defaultCurrencyAddr = firstCurrencies[0].address;
+            defaultCurrencyDecimals = firstCurrencies[0].decimals;
           }
         }
 
@@ -280,12 +260,13 @@ function RelayDepositContent({
         setSelectedCurrencyAddress(defaultCurrencyAddr);
         setChainsLoading(false);
 
-        // Auto-fetch quote with defaults (EXACT_OUTPUT, receive 100 USDC)
+        // Deposit-address quotes use exact-input semantics.
         if (defaultCurrencyAddr) {
           void fetchQuote({
             chainId: defaultChainId,
             currencyAddress: defaultCurrencyAddr,
-            amount: DEFAULT_RECEIVE_AMOUNT,
+            amount: DEFAULT_SEND_AMOUNT,
+            decimals: defaultCurrencyDecimals,
           });
         }
       } catch (e) {
@@ -317,7 +298,8 @@ function RelayDepositContent({
         void fetchQuote({
           chainId,
           currencyAddress: picked.address,
-          amount: DEFAULT_RECEIVE_AMOUNT,
+          amount: DEFAULT_SEND_AMOUNT,
+          decimals: picked.decimals,
         });
       }
     },
@@ -334,7 +316,8 @@ function RelayDepositContent({
         void fetchQuote({
           chainId: selectedChainId,
           currencyAddress: currency.address,
-          amount: DEFAULT_RECEIVE_AMOUNT,
+          amount: DEFAULT_SEND_AMOUNT,
+          decimals: currency.decimals,
         });
       }
     },
@@ -434,7 +417,7 @@ function RelayDepositContent({
               }
               value={formatWithCommas(sendAmount)}
               onChangeText={handleSendAmountChange}
-              keyboardType="numeric"
+              keyboardType="decimal-pad"
               placeholder="0"
               placeholderTextColor={theme.textDisabled.val}
               style={{
@@ -484,20 +467,20 @@ function RelayDepositContent({
               }}
               pointerEvents="none"
             >
-              {formatWithCommas(receiveAmount) || DEFAULT_RECEIVE_AMOUNT}
+              {formatWithCommas(receiveAmount) || '0'}
             </Text>
             <TextInput
               accessible
               accessibilityLabel="Receive amount"
+              editable={false}
               inputAccessoryViewID={
                 platformEnv.isNativeIOS
                   ? DEPOSIT_WITHDRAW_INPUT_ACCESSORY_VIEW_ID
                   : undefined
               }
               value={formatWithCommas(receiveAmount)}
-              onChangeText={handleReceiveAmountChange}
-              keyboardType="numeric"
-              placeholder={DEFAULT_RECEIVE_AMOUNT}
+              keyboardType="decimal-pad"
+              placeholder="0"
               placeholderTextColor={theme.textDisabled.val}
               style={{
                 position: 'absolute',

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
@@ -283,6 +283,7 @@ function PerpAccountPanel() {
                   actionType: 'withdraw',
                 },
                 dialogInTab,
+                intl.formatMessage({ id: ETranslations.perp_trade_withdraw }),
               )
             }
           />

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 
 import { BigNumber } from 'bignumber.js';
 import { useIntl } from 'react-intl';
@@ -15,6 +15,7 @@ import {
   useClipboard,
   useInTabDialog,
 } from '@onekeyhq/components';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { openHyperLiquidExplorerUrl } from '@onekeyhq/kit/src/utils/explorerUtils';
 import {
   usePerpsActiveAccountAtom,
@@ -24,6 +25,8 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { EModalRoutes } from '@onekeyhq/shared/src/routes';
+import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 
@@ -95,9 +98,16 @@ function PerpAccountPanel() {
   const [selectedAccount] = usePerpsActiveAccountAtom();
   const userAddress = selectedAccount.accountAddress;
   const dialogInTab = useInTabDialog();
+  const navigation = useAppNavigation();
   const intl = useIntl();
   const { copyText } = useClipboard();
   const { showPortfolio } = useShowPortfolio();
+
+  const handleOpenPortfolio = useCallback(() => {
+    navigation.pushModal(EModalRoutes.PerpModal, {
+      screen: EModalPerpRoutes.PerpPortfolioModal,
+    });
+  }, [navigation]);
 
   const unrealizedPnlInfo = useMemo(() => {
     const pnlBn = new BigNumber(accountSummary?.totalUnrealizedPnl || '0');
@@ -247,14 +257,7 @@ function PerpAccountPanel() {
             size="medium"
             h={36}
             variant="secondary"
-            onPress={() =>
-              showDepositWithdrawDialog(
-                {
-                  actionType: 'deposit',
-                },
-                dialogInTab,
-              )
-            }
+            onPress={handleOpenPortfolio}
             alignItems="center"
             justifyContent="center"
           >

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
@@ -1,9 +1,10 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback, useEffect, useMemo } from 'react';
 
 import { BigNumber } from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
 import {
+  Badge,
   Button,
   DashText,
   DebugRenderTracker,
@@ -15,6 +16,7 @@ import {
   useClipboard,
   useInTabDialog,
 } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { openHyperLiquidExplorerUrl } from '@onekeyhq/kit/src/utils/explorerUtils';
 import {
@@ -22,6 +24,7 @@ import {
   usePerpsActiveAccountMmrAtom,
   usePerpsActiveAccountSummaryAtom,
   usePerpsComputedAccountValueAtom,
+  usePerpsRelayDepositSessionsAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -31,6 +34,12 @@ import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 
 import { useShowPortfolio } from '../../../hooks/useShowPortfolio';
+import {
+  RELAY_DEPOSIT_PANEL_POLL_INTERVAL_MS,
+  getRelayDepositBadgeType,
+  getRelayDepositStatusLabel,
+  isRelayDepositTerminalStatus,
+} from '../../../utils/relayDepositTracking';
 import { getPortfolioTitle } from '../../Portfolio/PerpPortfolioModal';
 import { PerpsAccountNumberValue } from '../components/PerpsAccountNumberValue';
 import { showDepositWithdrawDialog } from '../modals/DepositWithdrawModal';
@@ -96,6 +105,8 @@ function PerpAccountPanel() {
   const [accountSummary] = usePerpsActiveAccountSummaryAtom();
   const [computedValue] = usePerpsComputedAccountValueAtom();
   const [selectedAccount] = usePerpsActiveAccountAtom();
+  const [{ sessions: relayDepositSessions }, setRelayDepositSessions] =
+    usePerpsRelayDepositSessionsAtom();
   const userAddress = selectedAccount.accountAddress;
   const dialogInTab = useInTabDialog();
   const navigation = useAppNavigation();
@@ -103,11 +114,98 @@ function PerpAccountPanel() {
   const { copyText } = useClipboard();
   const { showPortfolio } = useShowPortfolio();
 
+  const activeRelayDepositSession = useMemo(() => {
+    if (!userAddress) return undefined;
+    return relayDepositSessions.reduce<
+      (typeof relayDepositSessions)[number] | undefined
+    >((latest, session) => {
+      if (
+        session.accountAddress?.toLowerCase() !== userAddress.toLowerCase() ||
+        isRelayDepositTerminalStatus(session.status)
+      ) {
+        return latest;
+      }
+      if (!latest || session.updatedAt > latest.updatedAt) {
+        return session;
+      }
+      return latest;
+    }, undefined);
+  }, [relayDepositSessions, userAddress]);
+
   const handleOpenPortfolio = useCallback(() => {
     navigation.pushModal(EModalRoutes.PerpModal, {
       screen: EModalPerpRoutes.PerpPortfolioModal,
     });
   }, [navigation]);
+
+  const activeRelayDepositSessionId = activeRelayDepositSession?.id;
+  const activeRelayDepositAddress = activeRelayDepositSession?.depositAddress;
+  const activeRelayDepositRequestId = activeRelayDepositSession?.requestId;
+
+  useEffect(() => {
+    if (!activeRelayDepositSessionId || !activeRelayDepositAddress) {
+      return undefined;
+    }
+
+    let isCancelled = false;
+    const refresh = async () => {
+      try {
+        const result =
+          await backgroundApiProxy.serviceRelay.getRelayDepositStatus({
+            depositAddress: activeRelayDepositAddress,
+            requestId: activeRelayDepositRequestId,
+          });
+        if (isCancelled) return;
+        setRelayDepositSessions((prev) => ({
+          sessions: prev.sessions.map((session) =>
+            session.id === activeRelayDepositSessionId
+              ? {
+                  ...session,
+                  requestId: result.requestId ?? session.requestId,
+                  status: result.status,
+                  inTxs: result.inTxs,
+                  outTxs: result.outTxs,
+                  lastCheckedAt: result.lastCheckedAt,
+                  updatedAt: Date.now(),
+                  error: undefined,
+                }
+              : session,
+          ),
+        }));
+      } catch (e) {
+        if (isCancelled) return;
+        const message =
+          e instanceof Error ? e.message : 'Failed to load Relay status';
+        setRelayDepositSessions((prev) => ({
+          sessions: prev.sessions.map((session) =>
+            session.id === activeRelayDepositSessionId
+              ? {
+                  ...session,
+                  error: message,
+                  lastCheckedAt: Date.now(),
+                  updatedAt: Date.now(),
+                }
+              : session,
+          ),
+        }));
+      }
+    };
+
+    void refresh();
+    const timer = setInterval(() => {
+      void refresh();
+    }, RELAY_DEPOSIT_PANEL_POLL_INTERVAL_MS);
+
+    return () => {
+      isCancelled = true;
+      clearInterval(timer);
+    };
+  }, [
+    activeRelayDepositAddress,
+    activeRelayDepositRequestId,
+    activeRelayDepositSessionId,
+    setRelayDepositSessions,
+  ]);
 
   const unrealizedPnlInfo = useMemo(() => {
     const pnlBn = new BigNumber(accountSummary?.totalUnrealizedPnl || '0');
@@ -247,6 +345,39 @@ function PerpAccountPanel() {
           </XStack>
         ) : null}
       </YStack>
+      {activeRelayDepositSession ? (
+        <YStack bg="$bgSubdued" borderRadius="$3" p="$3" gap="$2">
+          <XStack justifyContent="space-between" alignItems="center" gap="$2">
+            <YStack gap="$0.5" flex={1}>
+              <SizableText size="$bodySmMedium">Relay deposit</SizableText>
+              <SizableText size="$bodySm" color="$textSubdued">
+                {activeRelayDepositSession.originChainName} → Hyperliquid
+              </SizableText>
+            </YStack>
+            <Badge
+              badgeType={getRelayDepositBadgeType(
+                activeRelayDepositSession.status,
+                activeRelayDepositSession.inTxs.length > 0,
+              )}
+              badgeSize="sm"
+            >
+              {getRelayDepositStatusLabel(activeRelayDepositSession.status, {
+                hasSourceTx: activeRelayDepositSession.inTxs.length > 0,
+                compact: true,
+              })}
+            </Badge>
+          </XStack>
+          <XStack justifyContent="space-between" alignItems="center">
+            <SizableText size="$bodySm" color="$textSubdued">
+              Expected
+            </SizableText>
+            <SizableText size="$bodySmMedium">
+              {activeRelayDepositSession.receiveAmount}{' '}
+              {activeRelayDepositSession.receiveSymbol || 'USDC'}
+            </SizableText>
+          </XStack>
+        </YStack>
+      ) : null}
       {/* Action Buttons */}
       {userAddress ? (
         <XStack gap="$2.5" alignItems="center">

--- a/packages/kit/src/views/Perp/hooks/useShowDepositWithdrawModal.ts
+++ b/packages/kit/src/views/Perp/hooks/useShowDepositWithdrawModal.ts
@@ -17,12 +17,18 @@ export function useShowDepositWithdrawModal() {
   const showModal = useCallback(
     async (actionType: IPerpsDepositWithdrawActionType = 'deposit') => {
       if (gtMd) {
-        await showDepositWithdrawDialog(
-          {
-            actionType,
-          },
-          dialogInTab,
-        );
+        if (actionType === 'deposit') {
+          navigation.pushModal(EModalRoutes.PerpModal, {
+            screen: EModalPerpRoutes.PerpPortfolioModal,
+          });
+        } else {
+          await showDepositWithdrawDialog(
+            {
+              actionType,
+            },
+            dialogInTab,
+          );
+        }
       } else {
         navigation.pushModal(EModalRoutes.PerpModal, {
           screen: EModalPerpRoutes.MobileDepositWithdrawModal,

--- a/packages/kit/src/views/Perp/hooks/useShowDepositWithdrawModal.ts
+++ b/packages/kit/src/views/Perp/hooks/useShowDepositWithdrawModal.ts
@@ -1,15 +1,18 @@
 import { useCallback } from 'react';
 
+import { useIntl } from 'react-intl';
+
 import { useInTabDialog, useMedia } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
+import type { IPerpsDepositWithdrawActionType } from '@onekeyhq/shared/types/hyperliquid/routes';
 
 import { showDepositWithdrawDialog } from '../components/TradingPanel/modals/DepositWithdrawModal';
 
-import type { IPerpsDepositWithdrawActionType } from '../components/TradingPanel/modals/DepositWithdrawModal';
-
 export function useShowDepositWithdrawModal() {
+  const intl = useIntl();
   const navigation = useAppNavigation();
   const { gtMd } = useMedia();
   const dialogInTab = useInTabDialog();
@@ -27,6 +30,9 @@ export function useShowDepositWithdrawModal() {
               actionType,
             },
             dialogInTab,
+            actionType === 'withdraw'
+              ? intl.formatMessage({ id: ETranslations.perp_trade_withdraw })
+              : undefined,
           );
         }
       } else {
@@ -36,7 +42,7 @@ export function useShowDepositWithdrawModal() {
         });
       }
     },
-    [gtMd, dialogInTab, navigation],
+    [gtMd, dialogInTab, navigation, intl],
   );
 
   return { showDepositWithdrawModal: showModal };

--- a/packages/kit/src/views/Perp/router/index.ts
+++ b/packages/kit/src/views/Perp/router/index.ts
@@ -46,6 +46,10 @@ const PerpGuidePage = LazyLoadPage(
   () => import('../components/Guide/PerpGuidePage'),
 );
 
+const PerpPortfolioModal = LazyLoadPage(
+  () => import('../components/TradingPanel/modals/PerpPortfolioModal'),
+);
+
 export const perpRouters: ITabSubNavigatorConfig<any, any>[] = [
   {
     rewrite: '/',
@@ -79,6 +83,10 @@ export const perpRouters: ITabSubNavigatorConfig<any, any>[] = [
   {
     name: EModalPerpRoutes.PerpGuidePage,
     component: PerpGuidePage,
+  },
+  {
+    name: EModalPerpRoutes.PerpPortfolioModal,
+    component: PerpPortfolioModal,
   },
 ];
 
@@ -118,5 +126,9 @@ export const ModalPerpStack: IModalFlowNavigatorConfig<
   {
     name: EModalPerpRoutes.PerpGuidePage,
     component: PerpGuidePage,
+  },
+  {
+    name: EModalPerpRoutes.PerpPortfolioModal,
+    component: PerpPortfolioModal,
   },
 ];

--- a/packages/kit/src/views/Perp/testIDs.ts
+++ b/packages/kit/src/views/Perp/testIDs.ts
@@ -57,6 +57,9 @@ export const PerpTestIDs = {
   RelayDepositCopyAddressButton: 'perp-relay-deposit-copy-address-button',
   RelayDepositNetworkSelector: 'perp-relay-deposit-network-selector',
   RelayDepositTokenSelector: 'perp-relay-deposit-token-selector',
+  RelayDepositTrackingCard: 'perp-relay-deposit-tracking-card',
+  RelayDepositTrackingRefreshButton:
+    'perp-relay-deposit-tracking-refresh-button',
 
   // -- Order info panel tabs --
   PositionsTab: 'perp-positions-tab',

--- a/packages/kit/src/views/Perp/testIDs.ts
+++ b/packages/kit/src/views/Perp/testIDs.ts
@@ -45,6 +45,18 @@ export const PerpTestIDs = {
   // -- Deposit --
   DepositButton: 'perp-deposit-button',
   MobileDepositButton: 'perp-trading-form-mobile-deposit-button',
+  DepositModalMobileBackButton: 'perp-deposit-modal-mobile-back-button',
+  DepositModalMobileCloseButton: 'perp-deposit-modal-mobile-close-button',
+  DepositModalDialogBackButton: 'perp-deposit-modal-dialog-back-button',
+  DepositModalDialogCloseButton: 'perp-deposit-modal-dialog-close-button',
+  DepositModalDepositButton: 'perp-deposit-modal-deposit-button',
+  DepositModalWithdrawButton: 'perp-deposit-modal-withdraw-button',
+  DepositModalWalletOption: 'perp-deposit-modal-wallet-option',
+  DepositModalRelayOption: 'perp-deposit-modal-relay-option',
+  RelayDepositSendAmountInput: 'perp-relay-deposit-send-amount-input',
+  RelayDepositCopyAddressButton: 'perp-relay-deposit-copy-address-button',
+  RelayDepositNetworkSelector: 'perp-relay-deposit-network-selector',
+  RelayDepositTokenSelector: 'perp-relay-deposit-token-selector',
 
   // -- Order info panel tabs --
   PositionsTab: 'perp-positions-tab',

--- a/packages/kit/src/views/Perp/utils/relayDepositTracking.ts
+++ b/packages/kit/src/views/Perp/utils/relayDepositTracking.ts
@@ -1,0 +1,110 @@
+import type { IPerpsRelayDepositSessionAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import type { IRelayDepositStatus } from '@onekeyhq/shared/types/relay';
+
+export const RELAY_DEPOSIT_DIALOG_POLL_INTERVAL_MS = 10_000;
+export const RELAY_DEPOSIT_PANEL_POLL_INTERVAL_MS = 15_000;
+
+export type IRelayDepositBadgeType =
+  | 'success'
+  | 'critical'
+  | 'info'
+  | 'warning';
+
+export function buildRelayDepositSessionId({
+  accountAddress,
+  depositAddress,
+}: {
+  accountAddress: string;
+  depositAddress: string;
+}) {
+  return `${accountAddress.toLowerCase()}-${depositAddress.toLowerCase()}`;
+}
+
+export function isRelayDepositTerminalStatus(status?: IRelayDepositStatus) {
+  return status === 'success' || status === 'refund' || status === 'failure';
+}
+
+export function getRelayDepositStatusLabel(
+  status?: IRelayDepositStatus,
+  options?: {
+    hasSourceTx?: boolean;
+    compact?: boolean;
+  },
+) {
+  if (status === 'success') return 'Completed';
+  if (status === 'refund') return 'Refunded';
+  if (status === 'failure') return 'Failed';
+  if (
+    status === 'pending' ||
+    status === 'submitted' ||
+    status === 'depositing'
+  ) {
+    return 'Processing';
+  }
+  if (options?.hasSourceTx) {
+    return options.compact ? 'Processing' : 'Transfer detected';
+  }
+  return options?.compact ? 'Waiting' : 'Waiting for transfer';
+}
+
+export function getRelayDepositBadgeType(
+  status?: IRelayDepositStatus,
+  hasSourceTx?: boolean,
+): IRelayDepositBadgeType {
+  if (status === 'success') return 'success';
+  if (status === 'refund' || status === 'failure') return 'critical';
+  if ((status && status !== 'waiting') || hasSourceTx) return 'info';
+  return 'warning';
+}
+
+export function getRelayDepositStepIndex(
+  session: IPerpsRelayDepositSessionAtom,
+) {
+  if (isRelayDepositTerminalStatus(session.status)) return 3;
+  if (session.status === 'pending' || session.status === 'submitted') return 2;
+  if (session.status === 'depositing' || session.inTxs.length > 0) return 1;
+  return 0;
+}
+
+export function getRelayDepositFinalStepTitle(status: IRelayDepositStatus) {
+  if (status === 'refund') return 'Refunded';
+  if (status === 'failure') return 'Failed';
+  return 'Completed';
+}
+
+export function getRelayDepositFinalStepDesc(status: IRelayDepositStatus) {
+  if (status === 'success') return 'Funds arrived in your Perps account.';
+  if (status === 'refund') {
+    return 'Relay returned funds to the refund address.';
+  }
+  if (status === 'failure') return 'Relay reported this deposit as failed.';
+  return 'Waiting for final confirmation.';
+}
+
+export function getRelayDepositTimelineDotBg({
+  active,
+  terminalFailed,
+  isLast,
+}: {
+  active: boolean;
+  terminalFailed: boolean;
+  isLast: boolean;
+}) {
+  if (!active) return '$bgStrong';
+  if (terminalFailed && isLast) return '$bgCriticalStrong';
+  return '$bgSuccessStrong';
+}
+
+export function shortenRelayDepositTxHash(hash?: string) {
+  if (!hash) return '';
+  if (hash.length <= 18) return hash;
+  return `${hash.slice(0, 10)}...${hash.slice(-8)}`;
+}
+
+export function formatRelayDepositLastCheckedText(lastCheckedAt?: number) {
+  if (!lastCheckedAt) return 'Not checked yet';
+  const seconds = Math.max(0, Math.floor((Date.now() - lastCheckedAt) / 1000));
+  if (seconds < 5) return 'Checked just now';
+  if (seconds < 60) return `Checked ${seconds}s ago`;
+  return `Checked ${Math.floor(seconds / 60)}m ago`;
+}

--- a/packages/shared/src/routes/perp.ts
+++ b/packages/shared/src/routes/perp.ts
@@ -9,6 +9,7 @@ export enum EModalPerpRoutes {
   PerpsInviteeRewardModal = 'PerpsInviteeRewardModal',
   MobilePortfolioPage = 'MobilePortfolioPage',
   PerpGuidePage = 'PerpGuidePage',
+  PerpPortfolioModal = 'PerpPortfolioModal',
 }
 
 export type IModalPerpParamList = {
@@ -17,9 +18,15 @@ export type IModalPerpParamList = {
   [EModalPerpRoutes.MobileTokenSelector]: undefined;
   [EModalPerpRoutes.MobileSetTpsl]: ISetTpslParams;
   [EModalPerpRoutes.MobileDepositWithdrawModal]: {
-    actionType?: 'deposit' | 'withdraw';
+    actionType?:
+      | 'deposit'
+      | 'depositSelect'
+      | 'withdraw'
+      | 'walletDeposit'
+      | 'relay';
   };
   [EModalPerpRoutes.PerpsInviteeRewardModal]: undefined;
   [EModalPerpRoutes.MobilePortfolioPage]: undefined;
   [EModalPerpRoutes.PerpGuidePage]: undefined;
+  [EModalPerpRoutes.PerpPortfolioModal]: undefined;
 };

--- a/packages/shared/src/routes/perp.ts
+++ b/packages/shared/src/routes/perp.ts
@@ -1,4 +1,7 @@
-import type { ISetTpslParams } from '@onekeyhq/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal';
+import type {
+  IPerpsDepositWithdrawActionType,
+  ISetTpslParams,
+} from '@onekeyhq/shared/types/hyperliquid/routes';
 
 export enum EModalPerpRoutes {
   PerpTradersHistoryList = 'PerpTradersHistoryList',
@@ -18,12 +21,7 @@ export type IModalPerpParamList = {
   [EModalPerpRoutes.MobileTokenSelector]: undefined;
   [EModalPerpRoutes.MobileSetTpsl]: ISetTpslParams;
   [EModalPerpRoutes.MobileDepositWithdrawModal]: {
-    actionType?:
-      | 'deposit'
-      | 'depositSelect'
-      | 'withdraw'
-      | 'walletDeposit'
-      | 'relay';
+    actionType?: IPerpsDepositWithdrawActionType;
   };
   [EModalPerpRoutes.PerpsInviteeRewardModal]: undefined;
   [EModalPerpRoutes.MobilePortfolioPage]: undefined;

--- a/packages/shared/types/hyperliquid/routes.ts
+++ b/packages/shared/types/hyperliquid/routes.ts
@@ -1,0 +1,13 @@
+export interface ISetTpslParams {
+  coin: string;
+  szDecimals: number;
+  assetId: number;
+  isMobile?: boolean;
+}
+
+export type IPerpsDepositWithdrawActionType =
+  | 'deposit'
+  | 'depositSelect'
+  | 'withdraw'
+  | 'walletDeposit'
+  | 'relay';

--- a/packages/shared/types/relay.ts
+++ b/packages/shared/types/relay.ts
@@ -1,0 +1,133 @@
+export interface IRelayChain {
+  id: number;
+  name: string;
+  icon: string;
+  vmType: string;
+}
+
+export interface IRelayCurrency {
+  chainId: number;
+  address: string;
+  symbol: string;
+  name: string;
+  decimals: number;
+  logoURI: string;
+}
+
+export interface IRelayQuoteRequest {
+  user: string;
+  originChainId: number;
+  destinationChainId: number;
+  originCurrency: string;
+  destinationCurrency: string;
+  recipient: string;
+  tradeType: 'EXACT_INPUT' | 'EXACT_OUTPUT' | 'EXPECTED_OUTPUT';
+  amount: string;
+  useDepositAddress: boolean;
+  refundTo?: string;
+}
+
+export interface IRelayQuoteStep {
+  id: string;
+  action: string;
+  description: string;
+  depositAddress?: string;
+  items?: Array<{
+    status: string;
+    data?: {
+      to?: string;
+      depositAddress?: string;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  }>;
+  [key: string]: unknown;
+}
+
+export interface IRelayQuoteResponse {
+  steps: IRelayQuoteStep[];
+  fees: {
+    gas: {
+      currency: {
+        symbol: string;
+        decimals: number;
+      };
+      amount: string;
+      amountFormatted: string;
+      amountUsd: string;
+    };
+    relayer: {
+      currency: {
+        symbol: string;
+        decimals: number;
+      };
+      amount: string;
+      amountFormatted: string;
+      amountUsd: string;
+    };
+  };
+  details: {
+    sender: string;
+    recipient: string;
+    currencyIn: {
+      currency: {
+        chainId: number;
+        address: string;
+        symbol: string;
+        name: string;
+        decimals: number;
+      };
+      amount: string;
+      amountFormatted: string;
+      amountUsd: string;
+    };
+    currencyOut: {
+      currency: {
+        chainId: number;
+        address: string;
+        symbol: string;
+        name: string;
+        decimals: number;
+      };
+      amount: string;
+      amountFormatted: string;
+      amountUsd: string;
+    };
+    rate: string;
+    timeEstimate: number;
+    totalImpact?: {
+      usd: string;
+      percent: string;
+    };
+  };
+}
+
+export interface IRelayDepositInfo {
+  depositAddress: string;
+  sendAmount: string;
+  sendSymbol: string;
+  receiveAmount: string;
+  receiveSymbol: string;
+  totalFeeUsd: string;
+  totalFeePercent?: string;
+  timeEstimate: number;
+  maxReceiveAmount?: string;
+}
+
+export interface IRelayChainsResponse {
+  chains: Array<{
+    id: number;
+    name: string;
+    icon: string;
+    vmType: string;
+    solverCurrencies?: Array<{
+      chainId: number;
+      address: string;
+      symbol: string;
+      name: string;
+      decimals: number;
+      logoURI: string;
+    }>;
+    [key: string]: unknown;
+  }>;
+}

--- a/packages/shared/types/relay.ts
+++ b/packages/shared/types/relay.ts
@@ -14,6 +14,18 @@ export interface IRelayCurrency {
   logoURI: string;
 }
 
+export interface IRelaySolverCurrency {
+  chainId?: number;
+  address: string;
+  symbol: string;
+  name: string;
+  decimals: number;
+  logoURI?: string;
+  metadata?: {
+    logoURI?: string;
+  };
+}
+
 export interface IRelayQuoteRequest {
   user: string;
   originChainId: number;
@@ -120,14 +132,7 @@ export interface IRelayChainsResponse {
     name: string;
     icon: string;
     vmType: string;
-    solverCurrencies?: Array<{
-      chainId: number;
-      address: string;
-      symbol: string;
-      name: string;
-      decimals: number;
-      logoURI: string;
-    }>;
+    solverCurrencies?: IRelaySolverCurrency[];
     [key: string]: unknown;
   }>;
 }

--- a/packages/shared/types/relay.ts
+++ b/packages/shared/types/relay.ts
@@ -128,6 +128,79 @@ export interface IRelayDepositInfo {
   maxReceiveAmount?: string;
 }
 
+export type IRelayDepositStatus =
+  | 'waiting'
+  | 'depositing'
+  | 'pending'
+  | 'submitted'
+  | 'success'
+  | 'refund'
+  | 'failure'
+  | 'unknown'
+  | (string & {});
+
+export interface IRelayDepositTx {
+  hash?: string;
+  type?: string;
+  chainId?: number;
+  timestamp?: number;
+  data?: {
+    from?: string;
+    to?: string;
+    value?: string;
+    data?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface IRelayRequest {
+  id?: string;
+  requestId?: string;
+  status?: IRelayDepositStatus;
+  user?: string;
+  recipient?: string;
+  depositAddress?: {
+    address?: string;
+    depositAddressType?: string;
+    depositor?: string;
+  };
+  data?: {
+    inTxs?: IRelayDepositTx[];
+    outTxs?: IRelayDepositTx[];
+    [key: string]: unknown;
+  };
+  createdAt?: string;
+  updatedAt?: string;
+  childRequests?: IRelayRequest[];
+  [key: string]: unknown;
+}
+
+export interface IRelayRequestsResponse {
+  requests?: IRelayRequest[] | IRelayRequest;
+  continuation?: string;
+}
+
+export interface IRelayIntentStatusResponse {
+  status?: IRelayDepositStatus;
+  quoteCreatedAt?: number;
+  [key: string]: unknown;
+}
+
+export interface IRelayDepositStatusInfo {
+  status: IRelayDepositStatus;
+  requestId?: string;
+  depositAddress: string;
+  inTxs: IRelayDepositTx[];
+  outTxs: IRelayDepositTx[];
+  createdAt?: string;
+  updatedAt?: string;
+  quoteCreatedAt?: number;
+  lastCheckedAt: number;
+  request?: IRelayRequest;
+  intentStatus?: IRelayIntentStatusResponse;
+}
+
 export interface IRelayChainsResponse {
   chains: Array<{
     id: number;

--- a/packages/shared/types/relay.ts
+++ b/packages/shared/types/relay.ts
@@ -36,7 +36,7 @@ export interface IRelayQuoteRequest {
   tradeType: 'EXACT_INPUT' | 'EXACT_OUTPUT' | 'EXPECTED_OUTPUT';
   amount: string;
   useDepositAddress: boolean;
-  refundTo?: string;
+  refundTo: string;
 }
 
 export interface IRelayQuoteStep {
@@ -44,6 +44,7 @@ export interface IRelayQuoteStep {
   action: string;
   description: string;
   depositAddress?: string;
+  requestId?: string;
   items?: Array<{
     status: string;
     data?: {
@@ -116,6 +117,7 @@ export interface IRelayQuoteResponse {
 
 export interface IRelayDepositInfo {
   depositAddress: string;
+  requestId?: string;
   sendAmount: string;
   sendSymbol: string;
   receiveAmount: string;
@@ -130,7 +132,9 @@ export interface IRelayChainsResponse {
   chains: Array<{
     id: number;
     name: string;
-    icon: string;
+    displayName?: string;
+    icon?: string;
+    iconUrl?: string;
     vmType: string;
     solverCurrencies?: IRelaySolverCurrency[];
     [key: string]: unknown;


### PR DESCRIPTION
## Summary
- Adds Relay deposit status tracking for the Perps crypto transfer deposit flow.
- Persists lightweight Relay deposit sessions so pending deposits remain visible after the QR/deposit dialog is closed.
- Surfaces a tracking timeline in the deposit dialog and a compact pending-deposit card in the Perps account panel.

## Intent & Context
This is a draft / handoff branch for the Relay deposit tracking UX. The current Relay deposit flow can show a QR code and deposit address, but after the user sends funds the client has little visible progress feedback. The goal is to reduce the black-box feeling for users while keeping the client architecture simple enough for follow-up work, Relay API confirmation, and possible handoff to another developer.

The implementation intentionally uses Relay as the primary source of truth instead of trying to watch or index every supported origin chain from the wallet client.

## Root Cause
The previous flow stopped at deposit address generation. It did not persist an in-progress Relay deposit session and did not query Relay request / intent status after the quote was generated. If the user closed the dialog, there was no lightweight UI anchor showing that a deposit was still pending.

## Design Decisions
- Use Relay status APIs instead of client-side chain indexing:
  - `/requests/v2?depositAddress=...&includeChildRequests=true`
  - `/intents/status/v3?requestId=...`
- Keep all network calls in `ServiceRelay` under `kit-bg`; UI talks to the background service only.
- Persist recent deposit sessions in `perpsRelayDepositSessionsAtom` so pending state survives dialog close and app navigation.
- Use `requestId` when available to avoid reusing stale terminal state if a new quote/request is generated for the same deposit address.
- Keep this branch dependency-free; no new packages were added.
- Leave i18n/explorer-link polish for follow-up because this is a draft branch and Relay status semantics still need confirmation with the Relay team.

## Changes Detail
- `packages/kit-bg/src/services/ServiceRelay.ts`
  - Adds Relay request/status fetchers and a normalized `getRelayDepositStatus` background method.
- `packages/shared/types/relay.ts`
  - Adds typed Relay request, intent status, deposit tx, and normalized deposit status shapes.
- `packages/kit-bg/src/states/jotai/atomNames.ts`
  - Registers the new persisted Relay deposit sessions atom.
- `packages/kit-bg/src/states/jotai/atoms/perps.ts`
  - Adds `perpsRelayDepositSessionsAtom` for recent Perps Relay deposit sessions.
- `packages/kit/src/views/Perp/components/TradingPanel/modals/RelayDepositContent.tsx`
  - Creates/updates deposit sessions when a Relay quote/deposit address is available.
  - Polls deposit status in the dialog and renders the tracking card below the QR/address area.
- `packages/kit/src/views/Perp/components/TradingPanel/components/RelayDepositTrackingCard.tsx`
  - Adds the UI timeline and tx hash display for Relay deposit progress.
- `packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx`
  - Shows the latest active Relay deposit card for the selected Perps account and keeps polling while non-terminal.
- `packages/kit/src/views/Perp/utils/relayDepositTracking.ts`
  - Centralizes status labels, terminal status checks, poll intervals, badge type mapping, and formatting helpers.
- `packages/kit/src/views/Perp/testIDs.ts`
  - Adds test IDs for the Relay tracking card and refresh button.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop, Mobile, Web, Extension Perps deposit surfaces
- **Risk Areas**:
  - Relay status semantics and response shapes should be confirmed with the Relay team before this is treated as final.
  - Live funded deposit flow has not been tested yet.
  - Copy/i18n and explorer links are still rough and should be polished before final merge.
  - Polling intervals are conservative MVP values and may need product/API feedback.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `npx eslint --no-ignore <changed files> --max-warnings=0`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings <changed files>`
- [x] `yarn jest --findRelatedTests <changed files> --passWithNoTests` — 36 suites / 626 tests passed
- [x] `git diff --check`
- [ ] Live Relay deposit with a funded source transaction
- [ ] Confirm Relay status semantics and edge cases with the Relay team
- [ ] Product/design review for final copy, i18n keys, and explorer-link behavior

## Follow-ups / Handoff Notes
- This PR is intentionally opened as a draft.
- No new dependencies are required.
- Suggested next steps:
  - Confirm Relay `waiting/depositing/pending/submitted/success/refund/failure` semantics.
  - Add explorer links for source and destination txs once chain metadata mapping is finalized.
  - Replace literal draft copy with proper i18n keys if this moves toward merge.
  - Decide whether the account-panel pending card should reopen the matching deposit dialog/session.
