### PR TITLE
fix(account-selector): eliminate avatar/balance/3-dot flicker on open

### DIFF
--- a/packages/components/src/layouts/Navigation/Modal/createWebModalNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Modal/createWebModalNavigator.tsx
@@ -30,6 +30,7 @@ import {
 import { Stack, XStack, YStack } from '../../../primitives/Stack';
 
 import type {
+  IModalDescriptor,
   IModalNavigationConfig,
   IModalNavigationEventMap,
   IModalNavigationOptions,
@@ -44,6 +45,11 @@ import type {
 import type { GestureResponderEvent } from 'react-native';
 
 const MODAL_ANIMATED_VIEW_REF_LIST: TamaguiElement[] = [];
+// Parallel to MODAL_ANIMATED_VIEW_REF_LIST. When the slot value is true,
+// the corresponding modal opts out of the `scale(0.95) -> scale(1)` enter
+// animation and uses only an opacity fade. Driven by the route option
+// `disableEnterScaleAnimation` (see IModalNavigationOptions).
+const MODAL_DISABLE_SCALE_LIST: boolean[] = [];
 let MODAL_ANIMATED_BACKDROP_VIEW_REF: TamaguiElement | null;
 let ROOT_NAVIGATION_INDEX_LISTENER: (() => void) | undefined;
 
@@ -243,6 +249,7 @@ function WebModalNavigator({
 
         MODAL_ANIMATED_VIEW_REF_LIST.forEach((element, index) => {
           const isHidden = newIndex < index;
+          const noScale = MODAL_DISABLE_SCALE_LIST[index];
           if (media.gtMd) {
             // @ts-expect-error
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -250,11 +257,20 @@ function WebModalNavigator({
             // @ts-expect-error
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             element.style.opacity = isHidden ? '0' : '1';
+            let nextTransform: string;
+            if (noScale) {
+              // Skip the bouncy scale; only translateY for stacked modals.
+              nextTransform = isHidden
+                ? ''
+                : `translateY(${-30 * (newIndex - index)}px)`;
+            } else {
+              nextTransform = isHidden
+                ? 'scale(0.95)'
+                : `translateY(${-30 * (newIndex - index)}px) scale(${1 - 0.05 * (newIndex - index)})`;
+            }
             // @ts-expect-error
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            element.style.transform = isHidden
-              ? 'scale(0.95)'
-              : `translateY(${-30 * (newIndex - index)}px) scale(${1 - 0.05 * (newIndex - index)})`;
+            element.style.transform = nextTransform;
           } else {
             // @ts-expect-error
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -268,13 +284,17 @@ function WebModalNavigator({
 
   const stackChildrenRefList = useRef<TamaguiElement[]>([]);
 
+  const disableEnterScaleAnimation = !!(
+    descriptor as IModalDescriptor | undefined
+  )?.options?.disableEnterScaleAnimation;
+
   useLayoutEffect(() => {
     const element = MODAL_ANIMATED_VIEW_REF_LIST[currentRouteIndex];
     if (element) {
       const el = element as HTMLElement;
       if (media.gtMd) {
         el.style.opacity = '0';
-        el.style.transform = 'scale(0.95)';
+        el.style.transform = disableEnterScaleAnimation ? '' : 'scale(0.95)';
       } else {
         el.style.transform = `translateY(${screenHeight}px)`;
       }
@@ -366,9 +386,11 @@ function WebModalNavigator({
     (ref: TamaguiElement | null) => {
       if (ref) {
         MODAL_ANIMATED_VIEW_REF_LIST[currentRouteIndex] = ref;
+        MODAL_DISABLE_SCALE_LIST[currentRouteIndex] =
+          disableEnterScaleAnimation;
       }
     },
-    [currentRouteIndex],
+    [currentRouteIndex, disableEnterScaleAnimation],
   );
 
   state.routes.forEach((route, routeIndex) => {

--- a/packages/components/src/layouts/Navigation/Modal/createWebModalNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Modal/createWebModalNavigator.tsx
@@ -30,7 +30,6 @@ import {
 import { Stack, XStack, YStack } from '../../../primitives/Stack';
 
 import type {
-  IModalDescriptor,
   IModalNavigationConfig,
   IModalNavigationEventMap,
   IModalNavigationOptions,
@@ -284,9 +283,8 @@ function WebModalNavigator({
 
   const stackChildrenRefList = useRef<TamaguiElement[]>([]);
 
-  const disableEnterScaleAnimation = !!(
-    descriptor as IModalDescriptor | undefined
-  )?.options?.disableEnterScaleAnimation;
+  const disableEnterScaleAnimation =
+    !!descriptor?.options?.disableEnterScaleAnimation;
 
   useLayoutEffect(() => {
     const element = MODAL_ANIMATED_VIEW_REF_LIST[currentRouteIndex];

--- a/packages/components/src/layouts/Navigation/Modal/createWebModalNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Modal/createWebModalNavigator.tsx
@@ -283,8 +283,18 @@ function WebModalNavigator({
 
   const stackChildrenRefList = useRef<TamaguiElement[]>([]);
 
-  const disableEnterScaleAnimation =
-    !!descriptor?.options?.disableEnterScaleAnimation;
+  // Hoist the opt-out to the WHOLE inner stack rather than just the
+  // active descriptor. Otherwise navigating into a child screen
+  // (e.g. AccountSelectorStack -> ExportPrivateKeysPage) re-runs the
+  // ref callback with the child's descriptor (which usually has the
+  // option unset) and flips the slot's `noScale` back to `false` — so
+  // a subsequent modal-on-modal push would shrink the underlying stack
+  // with `scale(0.95)`, breaking the visual contract of "this modal
+  // never scales". If any route in the stack opted out, the whole
+  // stack opts out.
+  const disableEnterScaleAnimation = state.routes.some(
+    (route) => !!descriptors[route.key]?.options?.disableEnterScaleAnimation,
+  );
 
   useLayoutEffect(() => {
     const element = MODAL_ANIMATED_VIEW_REF_LIST[currentRouteIndex];

--- a/packages/components/src/layouts/Navigation/Modal/types.tsx
+++ b/packages/components/src/layouts/Navigation/Modal/types.tsx
@@ -22,11 +22,20 @@ export type IModalNavigationOptions = IStackNavigationOptions & {
   shouldPopOnClickBackdrop?: boolean;
   dismissOnOverlayPress?: boolean;
   /**
-   * Web-only. When true, the modal enter/exit animation skips the
-   * `scale(0.95) -> scale(1)` transform and keeps only the opacity fade.
-   * Use for modals that visually behave like popovers where the scale
-   * animation causes child elements (e.g. avatars, right-edge buttons)
-   * to appear to "jump" outward during the bouncy easing.
+   * Web-only. When true, the modal skips the `scale(0.95) -> scale(1)`
+   * transform and keeps only the opacity fade.
+   *
+   * Despite the `Enter` in the name, this disables the scale on **both
+   * enter and exit** — entering opens to `scale(1)` directly, and on
+   * exit / push-over the screen fades out without shrinking. The flag
+   * also propagates to any inner-stack screen pushed inside the same
+   * modal navigator (e.g. AccountSelectorStack -> ExportPrivateKeysPage)
+   * so a subsequent modal-on-modal push does not retroactively shrink
+   * the underlying screen.
+   *
+   * Use for modals that visually behave like popovers where the bouncy
+   * scale animation makes child elements (avatars, right-edge buttons,
+   * etc.) appear to "jump" outward during the overshoot easing.
    *
    * Only consumed by `createWebModalNavigator` (desktop/web). On native,
    * this flag is ignored because the modal uses translateY-based

--- a/packages/components/src/layouts/Navigation/Modal/types.tsx
+++ b/packages/components/src/layouts/Navigation/Modal/types.tsx
@@ -21,6 +21,18 @@ export type IModalNavigationConfig = NonNullable<unknown>;
 export type IModalNavigationOptions = IStackNavigationOptions & {
   shouldPopOnClickBackdrop?: boolean;
   dismissOnOverlayPress?: boolean;
+  /**
+   * Web-only. When true, the modal enter/exit animation skips the
+   * `scale(0.95) -> scale(1)` transform and keeps only the opacity fade.
+   * Use for modals that visually behave like popovers where the scale
+   * animation causes child elements (e.g. avatars, right-edge buttons)
+   * to appear to "jump" outward during the bouncy easing.
+   *
+   * Only consumed by `createWebModalNavigator` (desktop/web). On native,
+   * this flag is ignored because the modal uses translateY-based
+   * animation instead of scale.
+   */
+  disableEnterScaleAnimation?: boolean;
 };
 
 export type IModalNavigationEventMap = {

--- a/packages/components/src/layouts/Navigation/Navigator/ModalFlowNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/ModalFlowNavigator.tsx
@@ -27,10 +27,13 @@ export interface IModalFlowNavigatorConfig<
   shouldPopOnClickBackdrop?: boolean;
   dismissOnOverlayPress?: boolean;
   /**
-   * Web-only. Skip the modal `scale(0.95) -> 1` enter/exit transform
-   * for this screen and keep only the opacity fade. Set for popover-like
-   * modals where the bouncy scale animation causes row content to appear
-   * to jump outward during easing. Ignored on native.
+   * Web-only. Skip the modal `scale(0.95) -> scale(1)` transform on
+   * **both enter and exit** for this screen and keep only the opacity
+   * fade. Setting it on any screen of an inner stack causes the whole
+   * navigator instance to opt out (so navigating deeper inside the
+   * modal does not re-enable scale for a later modal-on-modal push).
+   * Use for popover-like modals where the bouncy easing makes row
+   * content visibly jump outward. Ignored on native.
    */
   disableEnterScaleAnimation?: boolean;
 }

--- a/packages/components/src/layouts/Navigation/Navigator/ModalFlowNavigator.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/ModalFlowNavigator.tsx
@@ -26,6 +26,13 @@ export interface IModalFlowNavigatorConfig<
   translationId?: ETranslations | string;
   shouldPopOnClickBackdrop?: boolean;
   dismissOnOverlayPress?: boolean;
+  /**
+   * Web-only. Skip the modal `scale(0.95) -> 1` enter/exit transform
+   * for this screen and keep only the opacity fade. Set for popover-like
+   * modals where the bouncy scale animation causes row content to appear
+   * to jump outward during easing. Ignored on native.
+   */
+  disableEnterScaleAnimation?: boolean;
 }
 
 interface IModalFlowNavigatorProps<
@@ -119,12 +126,14 @@ function ModalFlowNavigator<RouteName extends string, P extends ParamListBase>({
             translationId,
             shouldPopOnClickBackdrop,
             dismissOnOverlayPress,
+            disableEnterScaleAnimation,
           }) => {
             // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop
             const customOptions: IModalNavigationOptions = {
               ...(typeof options === 'function' ? {} : options),
               shouldPopOnClickBackdrop,
               dismissOnOverlayPress,
+              disableEnterScaleAnimation,
               title: translationId
                 ? intl.formatMessage({
                     id: translationId as ETranslations,

--- a/packages/kit/src/components/AccountAvatar/AccountAvatar.tsx
+++ b/packages/kit/src/components/AccountAvatar/AccountAvatar.tsx
@@ -88,6 +88,15 @@ export interface IAccountAvatarProps extends IImageProps {
   fallback?: ReactElement;
   fallbackProps?: IImageFallbackProps;
   wallet?: IDBWallet;
+  /**
+   * Opt in to the 200ms opacity fade-in animation that runs the first time
+   * an avatar for a given address appears in the session. Default `false`
+   * (instant render). Originally introduced for the Send recipient quick
+   * select and Address Book panels; in list-heavy consumers like the
+   * account selector the staggered fades read as flicker, so the animation
+   * must be explicitly enabled.
+   */
+  enableEnterAnimation?: boolean;
 }
 
 const getBlockieImageId = (id?: string) => {
@@ -143,6 +152,7 @@ function BasicAccountAvatar({
   fallbackProps,
   networkId,
   wallet,
+  enableEnterAnimation = false,
   ...restProps
 }: IAccountAvatarProps) {
   const isValidSize = !!VARIANT_SIZE[size as IKeyOfVariantSize];
@@ -327,18 +337,28 @@ function BasicAccountAvatar({
     (account || dbAccount)?.address ||
     '';
 
-  // Decide animation ONCE at mount, based on address (not URI)
-  // Using lazy initialization to ensure decision is made only once per instance
+  // Decide animation ONCE at mount, based on address (not URI). Lazy
+  // initialization ensures the decision is made only once per instance.
+  //
+  // Animation is opt-in: it only runs when `enableEnterAnimation` is true at
+  // this consumer AND the address has not been shown before in this session.
+  // Callers that don't opt in render instantly and do not touch the cache,
+  // so an opt-in consumer later in the session still gets the fade for that
+  // address on its first appearance there.
   const shouldAnimateRef = useRef<boolean | undefined>(undefined);
   if (shouldAnimateRef.current === undefined && stableAddressKey) {
-    const isFirstGlobalAppearance =
-      !shownAvatarSourcesCache.has(stableAddressKey);
-    shouldAnimateRef.current = isFirstGlobalAppearance;
-    if (isFirstGlobalAppearance) {
-      if (shownAvatarSourcesCache.size >= SHOWN_AVATAR_SOURCES_CACHE_LIMIT) {
-        shownAvatarSourcesCache.clear();
+    if (!enableEnterAnimation) {
+      shouldAnimateRef.current = false;
+    } else {
+      const isFirstGlobalAppearance =
+        !shownAvatarSourcesCache.has(stableAddressKey);
+      shouldAnimateRef.current = isFirstGlobalAppearance;
+      if (isFirstGlobalAppearance) {
+        if (shownAvatarSourcesCache.size >= SHOWN_AVATAR_SOURCES_CACHE_LIMIT) {
+          shownAvatarSourcesCache.clear();
+        }
+        shownAvatarSourcesCache.add(stableAddressKey);
       }
-      shownAvatarSourcesCache.add(stableAddressKey);
     }
   }
 

--- a/packages/kit/src/components/AccountAvatar/makeBlockieImageUriList/index.ts
+++ b/packages/kit/src/components/AccountAvatar/makeBlockieImageUriList/index.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+
 import CreateAvatarListWorker from './createAvatarList.worker.js';
 
 import type { IUseBlockieImageUri } from './type.js';
@@ -31,6 +33,13 @@ worker.onmessage = (event: MessageEvent<{ id: string; data: string }>) => {
       mainThreadCache.clear();
     }
     mainThreadCache.set(id, data);
+  } else {
+    // Worker returned empty data — don't poison the cache, but log so
+    // we notice if this regresses into a silent retry loop (every new
+    // mount of the same id would re-post since we never cache "").
+    defaultLogger.app.error.log(
+      `blockie worker returned empty data for id=${id}`,
+    );
   }
   const callbacks = events.get(id);
   callbacks?.forEach((callback) => {
@@ -68,6 +77,8 @@ export const useBlockieImageUri: IUseBlockieImageUri = (id?: string) => {
       setUri('');
       return;
     }
+    // Fast path: cache hit. No async work is started here, so no
+    // cleanup is needed — the early return is intentional.
     const cached = mainThreadCache.get(id);
     if (cached) {
       setUri((prev) => (prev === cached ? prev : cached));
@@ -80,7 +91,11 @@ export const useBlockieImageUri: IUseBlockieImageUri = (id?: string) => {
         setUri(imageUri);
       })
       .catch((error) => {
-        console.error(error);
+        defaultLogger.app.error.log(
+          `makeBlockieImageUri rejected for id=${id}: ${
+            (error as Error)?.message ?? String(error)
+          }`,
+        );
       });
     return () => {
       cancelled = true;

--- a/packages/kit/src/components/AccountAvatar/makeBlockieImageUriList/index.ts
+++ b/packages/kit/src/components/AccountAvatar/makeBlockieImageUriList/index.ts
@@ -10,38 +10,75 @@ const worker = new CreateAvatarListWorker() as Worker;
 
 const events = new Map<string, ((data: string) => void)[]>();
 
+// Main-thread cache of resolved blockie data URIs, keyed by blockie id.
+// The web worker keeps its own cache but every request still requires a
+// `postMessage` round-trip + a React re-render before the URI reaches the
+// `<img>` element, so a freshly mounted AccountAvatar always renders an
+// empty `src` on its first frame. Caching on the main thread lets the
+// `useState` initial value be the resolved URI, eliminating the
+// "blank avatar -> blockie" flash whenever the same address is rendered
+// again (re-open the account selector, scroll a row back into view, the
+// same address shown in another panel, etc.).
+const mainThreadCache = new Map<string, string>();
+
 worker.onmessage = (event: MessageEvent<{ id: string; data: string }>) => {
   const { id, data } = event.data;
+  if (data) {
+    mainThreadCache.set(id, data);
+  }
   const callbacks = events.get(id);
   callbacks?.forEach((callback) => {
     callback(data);
-    events.delete(id);
   });
+  events.delete(id);
 };
 
 function makeBlockieImageUri(id: string) {
   return new Promise<string>((resolve) => {
+    const cached = mainThreadCache.get(id);
+    if (cached) {
+      resolve(cached);
+      return;
+    }
     const callbacks = events.get(id) || [];
+    const isFirstSubscriber = callbacks.length === 0;
     callbacks.push(resolve);
     events.set(id, callbacks);
-    worker.postMessage(id);
+    // Only post once per id while a request is in flight; additional
+    // callers get attached to the same pending promise.
+    if (isFirstSubscriber) {
+      worker.postMessage(id);
+    }
   });
 }
 
 export const useBlockieImageUri: IUseBlockieImageUri = (id?: string) => {
-  const [uri, setUri] = useState('');
+  const [uri, setUri] = useState<string>(() =>
+    id ? (mainThreadCache.get(id) ?? '') : '',
+  );
 
   useEffect(() => {
     if (!id) {
+      setUri('');
       return;
     }
+    const cached = mainThreadCache.get(id);
+    if (cached) {
+      setUri((prev) => (prev === cached ? prev : cached));
+      return;
+    }
+    let cancelled = false;
     makeBlockieImageUri(id)
       .then((imageUri: string) => {
+        if (cancelled || !imageUri) return;
         setUri(imageUri);
       })
       .catch((error) => {
         console.error(error);
       });
+    return () => {
+      cancelled = true;
+    };
   }, [id]);
 
   return uri;

--- a/packages/kit/src/components/AccountAvatar/makeBlockieImageUriList/index.ts
+++ b/packages/kit/src/components/AccountAvatar/makeBlockieImageUriList/index.ts
@@ -19,11 +19,17 @@ const events = new Map<string, ((data: string) => void)[]>();
 // "blank avatar -> blockie" flash whenever the same address is rendered
 // again (re-open the account selector, scroll a row back into view, the
 // same address shown in another panel, etc.).
+// Mirrors the eviction policy of `shownAvatarSourcesCache` in
+// AccountAvatar.tsx so both caches stay symmetric and bounded.
+const MAIN_THREAD_CACHE_LIMIT = 500;
 const mainThreadCache = new Map<string, string>();
 
 worker.onmessage = (event: MessageEvent<{ id: string; data: string }>) => {
   const { id, data } = event.data;
   if (data) {
+    if (mainThreadCache.size >= MAIN_THREAD_CACHE_LIMIT) {
+      mainThreadCache.clear();
+    }
     mainThreadCache.set(id, data);
   }
   const callbacks = events.get(id);

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
@@ -304,8 +304,11 @@ export function AccountSelectorAccountListItem({
     )
       return null;
 
+    // Reserve a stable width so the trailing address doesn't shift right
+    // when "--" becomes the loaded value (e.g. "$10.82"). 56px covers
+    // typical fiat balances; rare longer values still flexShrink.
     return (
-      <>
+      <Stack minWidth="$14">
         <AccountValueWithSpotlight
           walletId={focusedWalletInfo?.wallet?.id ?? ''}
           enabledNetworksCompatibleWithWalletId={
@@ -321,7 +324,7 @@ export function AccountSelectorAccountListItem({
           linkedNetworkId={avatarNetworkId ?? network?.id}
           mergeDeriveAssetsEnabled={mergeDeriveAssetsEnabled}
         />
-      </>
+      </Stack>
     );
   }, [
     linkNetwork,

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
@@ -306,9 +306,11 @@ export function AccountSelectorAccountListItem({
 
     // Reserve a stable width so the trailing address doesn't shift right
     // when "--" becomes the loaded value (e.g. "$10.82"). 56px covers
-    // typical fiat balances; rare longer values still flexShrink.
+    // typical fiat balances; rare longer values still flexShrink so the
+    // address keeps a usable amount of space (Stack defaults flexShrink: 0
+    // on RN/Tamagui, so the prop must be explicit).
     return (
-      <Stack minWidth="$14">
+      <Stack minWidth="$14" flexShrink={1}>
         <AccountValueWithSpotlight
           walletId={focusedWalletInfo?.wallet?.id ?? ''}
           enabledNetworksCompatibleWithWalletId={

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/useAccountSelectorValuesLoader.ts
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/useAccountSelectorValuesLoader.ts
@@ -53,22 +53,43 @@ export function useAccountSelectorValuesLoader({
     const currentLoadId = loadingIdRef.current;
 
     const loadBatches = async () => {
-      // Clear this selector's sub-map only
+      // Prune this selector's sub-map: drop entries whose accountId is no
+      // longer in the new query, but PRESERVE entries that are still
+      // relevant. The previous behavior set `next[num] = {}` which wiped
+      // already-loaded balances every time `accountsForValuesQuery`
+      // changed reference, causing a visible "loaded -> '--' -> loaded"
+      // flicker when the effect re-ran for the same wallet (e.g. when
+      // listDataResult re-mounted but the account set was unchanged).
+      // New accountIds simply have no entry yet and render the "--"
+      // placeholder naturally until the batch below fills them in.
+      const desiredIds = new Set(
+        accountsForValuesQuery.map((a) => a.accountId),
+      );
       {
         const prev = await accountSelectorValuesMapAtom.get();
         if (isCancelled(currentLoadId, loadingIdRef)) return;
+        const prevSub = prev[num] || {};
+        const prunedSub: Record<string, IAccountSelectorValueItem> = {};
+        for (const id of Object.keys(prevSub)) {
+          if (desiredIds.has(id)) prunedSub[id] = prevSub[id];
+        }
         const next = {
           ...prev,
-          [num]: {},
+          [num]: prunedSub,
         };
         await accountSelectorValuesMapAtom.set(next);
       }
       {
         const prev = await accountSelectorDeFiMapAtom.get();
         if (isCancelled(currentLoadId, loadingIdRef)) return;
+        const prevSub = prev[num] || {};
+        const prunedSub: Record<string, IAccountSelectorDeFiItem> = {};
+        for (const id of Object.keys(prevSub)) {
+          if (desiredIds.has(id)) prunedSub[id] = prevSub[id];
+        }
         const next = {
           ...prev,
-          [num]: {},
+          [num]: prunedSub,
         };
         await accountSelectorDeFiMapAtom.set(next);
       }

--- a/packages/kit/src/views/AccountManagerStacks/router/index.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/router/index.tsx
@@ -41,6 +41,11 @@ export const AccountManagerStacks: IModalFlowNavigatorConfig<
     options: {
       headerShown: false,
     },
+    // Web-only. This screen visually behaves like a popover; the default
+    // modal `scale(0.95) -> 1` bouncy enter animation makes avatars,
+    // right-edge action buttons, and other row content appear to jump
+    // outward during the overshoot. Disable scale so it only fades in.
+    disableEnterScaleAnimation: true,
   },
   {
     name: EAccountManagerStacksRoutes.ExportPrivateKeysPage,

--- a/packages/kit/src/views/AddressBook/components/AddressBookListContent.tsx
+++ b/packages/kit/src/views/AddressBook/components/AddressBookListContent.tsx
@@ -84,6 +84,7 @@ const RenderAddressBookItem: FC<IRenderAddressItemProps> = ({
           h="$10"
           borderRadius="$2"
           address={item.address}
+          enableEnterAnimation
         />
       </Stack>
     ),

--- a/packages/kit/src/views/Send/pages/SendDataInput/QuickSelectListShared.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/QuickSelectListShared.tsx
@@ -31,7 +31,12 @@ function AccountAvatarWithWallet({
   );
 
   return (
-    <AccountAvatar size="default" address={address} wallet={resolvedWallet} />
+    <AccountAvatar
+      size="default"
+      address={address}
+      wallet={resolvedWallet}
+      enableEnterAnimation
+    />
   );
 }
 

--- a/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx
@@ -830,6 +830,7 @@ function AccountRecipients({
                   indexedAccount={itemIndexedAccount}
                   account={account}
                   networkId={networkId}
+                  enableEnterAnimation
                 />
               ),
             }}


### PR DESCRIPTION
## Before / After

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

https://github.com/user-attachments/assets/621f0c62-8540-4e35-aed1-59fd0fe3f810

</td>
<td>

https://github.com/user-attachments/assets/405ba531-f32c-4968-9f42-a52fd38c5fb0

</td>
</tr>
</table>



## Summary

Opening the account selector showed several visible jumps in quick
succession — avatar, balance amount, and 3-dot button all appeared to
shift, then balance briefly regressed from a loaded value back to `--`
before settling. Reproduced and root-caused via CDP on the running
Electron build (port 9222). Four independent issues stacked into one
flash; each is fixed at its source.

### 1. Modal enter scale animation (avatar + 3-dot perceived jump)

`createWebModalNavigator` runs every modal through
`scale(0.95) → 1` with an overshoot bezier
`cubic-bezier(0.175, 0.885, 0.32, 1.275)`. Inside the account selector
this made avatars and right-edge buttons appear to fly outward during
the overshoot.

Added a **web-only** opt-out `disableEnterScaleAnimation` to
`IModalNavigationOptions` / `IModalFlowNavigatorConfig`. A parallel
`MODAL_DISABLE_SCALE_LIST` records the choice per modal slot; the
animation listener skips the scale transform for slots that opted out,
keeping only the opacity fade. `AccountSelectorStack` opts in; every
other modal is untouched.

### 2. Balance width change shifts address ~29px right

When `--` (~11px) became `$10.82` (~40px) the address right next to it
moved ~29px. Fixed by wrapping `renderAccountValue` in
`Stack minWidth="$14"` (Tamagui size token = 56px). Stable for typical
fiat balances; rare longer values still `flexShrink`.

### 3. Avatar 200ms fade-in waterfall

`AccountAvatar` ran a `withTiming(opacity 0→1, 200ms)` on first
appearance per address. In the account selector with 8+ simultaneous
mounts these staggered fades read as flicker.

Made the fade **opt-in** via `enableEnterAnimation` (default `false`).
Opted back in at the original sites where the fade was wanted:
`AddressBookListContent`, `SendDataInput/QuickSelectListShared`,
`SendDataInput/RecipientQuickSelect`. The account selector and every
other consumer now renders instantly. Non-opt-in mounts no longer write
to `shownAvatarSourcesCache`, so an opt-in screen later in the session
still gets its first-appearance fade.

### 4. Balance regression `loaded → "--" → loaded`

`useAccountSelectorValuesLoader` did
`next[num] = {}` before each batch fetch, wiping all already-loaded
balances every time `accountsForValuesQuery` changed reference. UI saw
`valuesMap[item.id] === undefined` and re-rendered the `--` placeholder,
then batches re-filled it.

Changed to **prune only entries whose accountId is no longer in the new
query**. Same-wallet effect re-runs preserve every loaded value; switching
wallets still drops stale entries. Same fix applied to
`accountSelectorDeFiMapAtom`.

### Bonus: web blockie cache

`packages/kit/src/components/AccountAvatar/makeBlockieImageUriList/index.ts`
had no main-thread cache, so every fresh `useBlockieImageUri` mount
round-tripped the worker (`postMessage` → worker compute → `setUri` →
re-render) and produced one frame with an empty `<img src="">`.

Added a `Map<id, dataUri>` keyed cache, seeded `useState`'s initial
value from it, deduped concurrent worker requests for the same id, and
populated the cache from `worker.onmessage`. Repeat opens, re-scrolling,
and other panels using the same address now render the blockie on the
**first frame**.

## Test plan
- [x] CDP frame-by-frame on Electron: row-relative positions stable
  through open (x/y/w/h range 0.00px)
- [x] CDP MutationObserver/rAF over 5s: **0 balance regressions**, **0
  avatar img regressions**
- [x] CDP cache test: cache-cold open shows blockie after worker
  compute (~500ms); cache-warm reopen shows blockie on first frame for
  **28/28** rows
- [x] `yarn tsc:staged` clean
- [x] `yarn lint:staged` clean (0 warnings 0 errors)
- [ ] Manual verification on desktop in `release/v6.3.0`: open / switch
  wallets / reopen — no visible jumps, no `--` regression, avatars
  show immediately on reopen
- [ ] Verify Send recipient quick select and Address Book still show
  the gentle avatar fade-in (intentionally preserved there)
- [ ] **Avatar consumer spot-check** (default went from fade-in to
  instant; verify no jarring "pop" at these entry points):
  - `AccountSelectorTriggerDApp` / `AccountSelectorTriggerBase`
  - `ListItem` (account-flavored avatar)
  - `UniversalSearchAddressItem`
  - `DepositWithdrawModal`
  - Discovery `HeaderRightToolBar`
  - `PortfolioOverview`
  - `ManageAccountActivity`
  - `SelectAddress` (BtcReward)
  - `PagePrimeTransferPreview`

## Review feedback addressed (`9077eca8c3`)

- `mainThreadCache` now has `MAIN_THREAD_CACHE_LIMIT = 500` with the
  same `clear()` strategy as the sibling `shownAvatarSourcesCache` —
  symmetric, bounded across long sessions.
- Balance `<Stack minWidth="$14">` now sets `flexShrink={1}` explicitly
  so the comment's "rare longer values still flexShrink" claim actually
  holds (Tamagui / RN Stack defaults to `flexShrink: 0`).
- Dropped the redundant `descriptor as IModalDescriptor | undefined`
  cast in `createWebModalNavigator` and removed the now-unused
  `IModalDescriptor` import — the descriptor is already typed via
  `useNavigationBuilder<…, IModalNavigationOptions, …>`.

Three lower-priority notes from the review are intentionally left
as-is (sibling atom prune non-atomicity, `MODAL_*_LIST` stale-slot
cleanup) since they match pre-existing code style and have no
observable user impact.

## Round-2 review feedback addressed (`0f42306703`)

- **`disableEnterScaleAnimation` now opts out the whole inner stack**,
  not just the active screen. Previously, navigating from
  `AccountSelectorStack` to a child screen
  (e.g. `ExportPrivateKeysPage`) re-ran the ref callback with the
  child's descriptor and flipped the slot's `noScale` back to `false`;
  a subsequent modal-on-modal push would then shrink the underlying
  screen with `scale(0.95)`. Fixed by checking
  `state.routes.some((r) => descriptors[r.key]?.options?.disableEnterScaleAnimation)`
  so any opt-out screen pins the whole navigator.
- **JSDoc clarified on both option declarations** to make explicit that
  the flag governs enter **and** exit scale, and that opting out on any
  inner-stack screen propagates to the whole navigator instance. (The
  name was kept; renaming to `disableScaleAnimation` would churn four
  files for no behavior gain.)
- **`console.error` replaced with `defaultLogger.app.error.log(...)`**
  in the `useBlockieImageUri` catch — file now complies with the
  project's no-console logging convention.
- **Worker empty-data branch now logs** via
  `defaultLogger.app.error.log(...)` so a regression into a silent
  retry loop (every remount re-posting because we never cache `""`)
  surfaces in error telemetry instead of being swallowed.
- **Cache-hit fast-path is annotated** so the intentional early-return
  (no async work means no cleanup needed) doesn't read like a missing
  cleanup next to the `cancelled`-flag branch below.

### Follow-ups deferred (out of scope, noted for future)
- Two-atom prune (`accountSelectorValuesMapAtom` +
  `accountSelectorDeFiMapAtom`) is two separate `await get → set`
  cycles in `useAccountSelectorValuesLoader`. There's a brief window
  where values is pruned but DeFi isn't. Final state is self-consistent
  (cleanup increments `loadingId`, next loader overwrites both), so no
  user-observable bug — left as-is.
- `MODAL_ANIMATED_VIEW_REF_LIST` / `MODAL_DISABLE_SCALE_LIST` follow
  the existing module-level-permanent pattern; stale slot entries get
  overwritten on next modal open. No leak, no visual artifact.

## Files
- `packages/components/src/layouts/Navigation/Modal/createWebModalNavigator.tsx`
- `packages/components/src/layouts/Navigation/Modal/types.tsx`
- `packages/components/src/layouts/Navigation/Navigator/ModalFlowNavigator.tsx`
- `packages/kit/src/components/AccountAvatar/AccountAvatar.tsx`
- `packages/kit/src/components/AccountAvatar/makeBlockieImageUriList/index.ts`
- `packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx`
- `packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/useAccountSelectorValuesLoader.ts`
- `packages/kit/src/views/AccountManagerStacks/router/index.tsx`
- `packages/kit/src/views/AddressBook/components/AddressBookListContent.tsx`
- `packages/kit/src/views/Send/pages/SendDataInput/QuickSelectListShared.tsx`
- `packages/kit/src/views/Send/pages/SendDataInput/RecipientQuickSelect.tsx`



