### PR TITLE
fix: keep swap DeFi token switch interactive(OK-55144)

### DIFF
--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
@@ -236,14 +236,13 @@ const SwapTokenSelectPage = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentSelectNetwork?.networkId]);
 
-  const { fetchLoading, lpTokenRequestLoading, currentTokens } =
-    useSwapTokenList(
-      type,
-      currentSelectNetwork?.networkId,
-      requestedSearchKeyword,
-      swapTypeSwitch,
-      showLpTokenFilterSwitch ? showLpTokensOnly : undefined,
-    );
+  const { fetchLoading, currentTokens } = useSwapTokenList(
+    type,
+    currentSelectNetwork?.networkId,
+    requestedSearchKeyword,
+    swapTypeSwitch,
+    showLpTokenFilterSwitch ? showLpTokensOnly : undefined,
+  );
   const alertIndex = useMemo(
     () =>
       currentTokens.findIndex((item) => {
@@ -658,7 +657,6 @@ const SwapTokenSelectPage = ({
             <TokenSelectorLpTokenSwitch
               value={showLpTokensOnly}
               onChange={handleLpTokenFilterChange}
-              loading={lpTokenRequestLoading}
               disabled={!SWAP_LP_TOKEN_FILTER_SERVER_SUPPORTED}
             />
           ) : null}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55144](https://onekeyhq.atlassian.net/browse/OK-55144)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Stop passing LP token request loading state into the Swap token selector's DeFi token switch.
- Keep Home and Send/Receive switch loading behavior unchanged.

## Intent & Context
This fixes a follow-up from PR #11683 on `release/v6.3.0`: the DeFi token switch should keep its existing loading behavior on Home and Send/Receive, but Swap should not show switch loading or become disabled because that blocks user interaction while token-list requests are in flight.

## Root Cause
`SwapTokenSelectModal` passed `lpTokenRequestLoading` into the shared `TokenSelectorLpTokenSwitch`. The shared switch intentionally disables itself and shows a spinner when `loading` is true, which is correct for Home and Send/Receive but too restrictive for Swap.

## Design Decisions
- Scope the fix to Swap by removing only the Swap modal's `loading` prop.
- Leave the shared switch component and ordinary token selector behavior unchanged.
- Keep Swap token list request loading inside `useSwapTokenList`; only the switch interaction is decoupled from that loading state.

## Changes Detail
- `packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx`: stop destructuring `lpTokenRequestLoading` and stop passing it to `TokenSelectorLpTokenSwitch`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop/Web/Mobile Swap token selector
- **Risk Areas**: Rapid switch toggles can still trigger token list refetches, but this preserves the existing request-key token loading path and only removes the switch-level disabled/spinner state.

## Test plan
- [x] `git diff --check -- packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] Desktop local dev: opened Swap -> source token selector, verified the DeFi token switch stays interactive without switch loading, toggles on/off, and fires `lpToken=true/false` token-list requests.

[OK-55144]: https://onekeyhq.atlassian.net/browse/OK-55144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ