### PR TITLE
fix(ledger): stop onboarding from showing a previously-added device OK-53853

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -3238,7 +3238,12 @@ class ServiceAccount extends ServiceBase {
       });
     }
     // Refresh DB info when compatibility lookup resolves to another connectId.
-    if (compatibleConnectId !== params.device.connectId) {
+    // Skip empty connectId: getDeviceByQuery would otherwise match by vendor
+    // alone and swap in another device of the same vendor.
+    if (
+      compatibleConnectId &&
+      compatibleConnectId !== params.device.connectId
+    ) {
       const refreshedDevice = await localDb.getDeviceByQuery({
         connectId: params.device.connectId || compatibleConnectId,
         featuresDeviceId: deviceId,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-53853](https://onekeyhq.atlassian.net/browse/OK-53853)

----------

<!-- github-pr-monitor:jira-links:end -->


… info

When onboarding a Ledger over a transport with no stable connectId (USB → empty), createHWWalletBase's "refresh DB info" branch fired because `'' !== null` is true, then queried getDeviceByQuery with no usable identifier (empty connectId / deviceId / features). getDeviceByQuery falls back to matching by vendor alone and returns the FIRST device of that vendor, so params.device was silently swapped to a previously-added Ledger (e.g. onboarding a Nano X picked up an earlier Stax's name/model).

Guard the refresh so it only runs when there is a real resolved connectId. Empty compatibleConnectId has nothing to refresh by, so skipping is always correct; OneKey (persistent connectId) and BLE (resolved bleConnectId) are unaffected.

[OK-53853]: https://onekeyhq.atlassian.net/browse/OK-53853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ