### PR TITLE
chore: consolidate small dependency upgrades

### DIFF
--- a/apps/desktop/app/yarn.lock
+++ b/apps/desktop/app/yarn.lock
@@ -299,11 +299,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^5.0.2":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+  version: 5.0.6
+  resolution: "brace-expansion@npm:5.0.6"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10/f259b2ddf04489da9512ad637ba6b4ef2d77abd4445d20f7f1714585f153435200a53fa6a2e4a5ee974df14ddad4cd16421f6f803e96e8b452bd48598878d0ee
+  checksum: 10/a7acf120fefa79e9d7c9c92898114f57c07596a3920197f3c5917e6a628b04220a5f7f9618c30bdd973a6576a32113b99f9c3f1c8245ccc399dd2a9a718d81d8
   languageName: node
   linkType: hard
 

--- a/development/performance-server/package-lock.json
+++ b/development/performance-server/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@onekeyhq/performance-server",
       "version": "1.0.0",
       "dependencies": {
-        "ws": "^8.14.2"
+        "ws": "^8.20.1"
       },
       "devDependencies": {
         "tailwindcss": "^3.4.1"
@@ -1017,7 +1017,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/development/performance-server/package.json
+++ b/development/performance-server/package.json
@@ -11,7 +11,7 @@
     "build:css": "tailwindcss -i ./public/input.css -o ./public/style.css --minify"
   },
   "dependencies": {
-    "ws": "^8.14.2"
+    "ws": "^8.20.1"
   },
   "devDependencies": {
     "tailwindcss": "^3.4.1"

--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
     "socket.io-client": "^4.7.5",
     "sonner": "^1.4.41",
     "stream-browserify": "^3.0.0",
-    "systeminformation": "5.31.4",
+    "systeminformation": "5.31.6",
     "tamagui": "1.108.0",
     "text-encoding": "^0.7.0",
     "timeout-signal": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9751,7 +9751,7 @@ __metadata:
     sonner: "npm:^1.4.41"
     stream-browserify: "npm:^3.0.0"
     style-loader: "npm:^3.3.3"
-    systeminformation: "npm:5.31.4"
+    systeminformation: "npm:5.31.6"
     tamagui: "npm:1.108.0"
     tamagui-loader: "npm:1.108.0"
     text-encoding: "npm:^0.7.0"
@@ -45677,12 +45677,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"systeminformation@npm:5.31.4":
-  version: 5.31.4
-  resolution: "systeminformation@npm:5.31.4"
+"systeminformation@npm:5.31.6":
+  version: 5.31.6
+  resolution: "systeminformation@npm:5.31.6"
   bin:
     systeminformation: lib/cli.js
-  checksum: 10/8b42b0ff666ff748535324223aad2a71a61a3828a477331d245933beed2291cd5a2ca9fe68d565341cf484d79175685ff90ba708197cd58c2fd2658f6ef8fb14
+  checksum: 10/42c986adc6af3dc296458177a5bb79922d7892a684b8271bce6dfaf9d40285330606a36dbb0b41f3b76fd745b6658a92bf5c62d6d56d4a746d64bb45be81b394
   conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard


### PR DESCRIPTION

## Summary
- Consolidate the three smallest dependency PRs into one maintenance PR: #11706, #11659, and #11709.
- Bump systeminformation from 5.31.4 to 5.31.6 with the missing root yarn.lock update.
- Bump ws in development/performance-server to 8.20.1 and brace-expansion in the desktop app lockfile to 5.0.6.

## Intent & Context
The automatic dependency PR list had three very small upgrades. This PR combines them so the standalone Dependabot/Snyk PRs can be closed and reviewed as one low-risk dependency maintenance change.

## Design Decisions
- Kept the exact target versions from the source PRs.
- Limited the diff to package manifests and lockfiles only.
- Regenerated lockfile entries with Yarn or npm, then kept package-lock.json aligned with the Dependabot diff to avoid unrelated npm metadata churn.
- Added the root yarn.lock update for systeminformation because the Snyk PR updated package.json only and reported that lockfile generation failed.

## Changes Detail
- package.json and yarn.lock: systeminformation 5.31.4 -> 5.31.6.
- development/performance-server/package.json and package-lock.json: ws ^8.14.2 / 8.18.3 -> ^8.20.1 / 8.20.1.
- apps/desktop/app/yarn.lock: brace-expansion 5.0.5 -> 5.0.6.

## Risk Assessment
- Risk Level: Low
- Affected Platforms: Desktop and development performance tooling
- Risk Areas: Dependency behavior changes are small patch/same-major upgrades. Two subagent reviews found no blockers; repo usage does not exercise the changed high-risk paths for systeminformation or ws.

## Test plan
- [x] yarn install --mode=update-lockfile
- [x] yarn up -R brace-expansion --mode=update-lockfile in apps/desktop/app
- [x] npm install --package-lock-only --ignore-scripts in development/performance-server
- [x] yarn lint:staged
- [x] yarn tsc:staged
- [x] yarn test (358 suites passed, 4322 tests passed, 13 skipped)
- [x] Two subagent reviews completed with no blocking findings

Supersedes #11706, #11659, and #11709.
