### PR TITLE
feat: capture and report logger UTM params from URLs(OK-55267)

### DIFF
--- a/packages/kit/src/routes/config/deeplink/index.ts
+++ b/packages/kit/src/routes/config/deeplink/index.ts
@@ -28,6 +28,7 @@ import backgroundApiProxy from '../../../background/instance/backgroundApiProxy'
 import { urlAccountNavigation } from '../../../views/Home/pages/urlAccount/urlAccountUtils';
 import { marketNavigation } from '../../../views/Market/marketUtils';
 import { openWebView } from '../../../views/WebView/utils/webViewNavigation';
+import { captureAndReportLoggerUtmParamsFromUrl } from '../loggerUtmParams';
 
 import { registerHandler } from './handler';
 import { parseWebViewDeepLink } from './parseWebViewDeepLink';
@@ -264,6 +265,7 @@ const processDeepLinkUrl = memoizee(
 
     try {
       console.log('processDeepLinkUrl: >>>>> ', url);
+      captureAndReportLoggerUtmParamsFromUrl(url);
       const parsedUrl = Linking.parse(url);
       const { hostname, path, queryParams, scheme } = parsedUrl;
       if (process.env.NODE_ENV !== 'production') {

--- a/packages/kit/src/routes/config/index.ts
+++ b/packages/kit/src/routes/config/index.ts
@@ -24,6 +24,7 @@ import { rootRouter, useRootRouter } from '../router';
 
 import { registerDeepLinking } from './deeplink';
 import { getStateFromPath } from './getStateFromPath';
+import { captureAndReportLoggerUtmParamsFromUrl } from './loggerUtmParams';
 
 import type { LinkingOptions } from '@react-navigation/native';
 
@@ -66,6 +67,10 @@ const FULL_SCREEN_MODAL_PATH = `/${ERootRoutes.iOSFullScreen}`;
 const FULL_SCREEN_PUSH_PATH = `/${ERootRoutes.FullScreenPush}`;
 
 const onGetStateFromPath = (path: string, options?: any) => {
+  captureAndReportLoggerUtmParamsFromUrl(path);
+  if (platformEnv.isWeb) {
+    captureAndReportLoggerUtmParamsFromUrl(globalThis.location.href);
+  }
   if (process.env.NODE_ENV !== 'production') {
     debugLandingLog('getStateFromPath', `path="${path}"`);
   }

--- a/packages/kit/src/routes/config/loggerUtmParams.ts
+++ b/packages/kit/src/routes/config/loggerUtmParams.ts
@@ -1,0 +1,12 @@
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import { captureLoggerUtmParamsFromUrl } from '@onekeyhq/shared/src/logger/utmParams';
+
+export function captureAndReportLoggerUtmParamsFromUrl(
+  url: string | undefined | null,
+) {
+  const captured = captureLoggerUtmParamsFromUrl(url);
+  if (captured?.shouldReport) {
+    defaultLogger.app.router.utmParamsCaptured(captured.params);
+  }
+  return captured;
+}

--- a/packages/shared/src/logger/base/baseScene.ts
+++ b/packages/shared/src/logger/base/baseScene.ts
@@ -1,5 +1,4 @@
 import { formatTime } from '../../utils/dateUtils';
-import { getLoggerGlobalUtmParams } from '../utmParams';
 
 import { LogToConsole, LogToServer } from './decorators';
 import { logFn } from './logFn';
@@ -70,7 +69,6 @@ export abstract class BaseScene {
       metadataList,
       durationInfo,
       timestamp,
-      utmParams: getLoggerGlobalUtmParams(),
     });
   }
 

--- a/packages/shared/src/logger/base/baseScene.ts
+++ b/packages/shared/src/logger/base/baseScene.ts
@@ -1,4 +1,5 @@
 import { formatTime } from '../../utils/dateUtils';
+import { getLoggerGlobalUtmParams } from '../utmParams';
 
 import { LogToConsole, LogToServer } from './decorators';
 import { logFn } from './logFn';
@@ -69,6 +70,7 @@ export abstract class BaseScene {
       metadataList,
       durationInfo,
       timestamp,
+      utmParams: getLoggerGlobalUtmParams(),
     });
   }
 

--- a/packages/shared/src/logger/base/logFn.test.ts
+++ b/packages/shared/src/logger/base/logFn.test.ts
@@ -9,6 +9,11 @@ import type { Analytics } from '../../analytics';
 
 class ServerLogScene extends BaseScene {
   @LogToServer()
+  utmParamsCaptured(params: Record<string, string>) {
+    return params;
+  }
+
+  @LogToServer()
   campaignEvent(params: Record<string, string>) {
     return params;
   }
@@ -35,13 +40,15 @@ describe('logFn', () => {
     jest.useRealTimers();
   });
 
-  it('uses the utm snapshot captured when the log entry is emitted', () => {
-    captureLoggerUtmParamsFromUrl(
-      'https://app.onekey.so/perps?utm_source=before',
+  it('reports utm params through a dedicated event only', () => {
+    const captured = captureLoggerUtmParamsFromUrl(
+      'https://app.onekey.so/perps?utm_source=dedicated',
     );
+    expect(captured?.params).toEqual({ utm_source: 'dedicated' });
 
     const scene = new ServerLogScene();
     scene.campaignEvent({ value: 'event' });
+    scene.utmParamsCaptured(captured?.params ?? {});
 
     captureLoggerUtmParamsFromUrl(
       'https://app.onekey.so/perps?utm_source=later',
@@ -49,8 +56,10 @@ describe('logFn', () => {
     jest.runOnlyPendingTimers();
 
     expect(trackEvent).toHaveBeenCalledWith('campaignEvent', {
-      utm_source: 'before',
       value: 'event',
+    });
+    expect(trackEvent).toHaveBeenCalledWith('utmParamsCaptured', {
+      utm_source: 'dedicated',
     });
   });
 });

--- a/packages/shared/src/logger/base/logFn.test.ts
+++ b/packages/shared/src/logger/base/logFn.test.ts
@@ -1,0 +1,56 @@
+import appGlobals from '../../appGlobals';
+import { loggerConfig } from '../loggerConfig';
+import { captureLoggerUtmParamsFromUrl } from '../utmParams';
+
+import { BaseScene } from './baseScene';
+import { LogToServer } from './decorators';
+
+import type { Analytics } from '../../analytics';
+
+class ServerLogScene extends BaseScene {
+  @LogToServer()
+  campaignEvent(params: Record<string, string>) {
+    return params;
+  }
+}
+
+describe('logFn', () => {
+  let trackEvent: jest.MockedFunction<Analytics['trackEvent']>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    trackEvent = jest.fn();
+    appGlobals.$analytics = {
+      trackEvent,
+    } as unknown as Analytics;
+    loggerConfig.updateRuntimeConfig({
+      enabled: {},
+      colorfulLog: false,
+      highlightDurationGt: '100',
+    });
+  });
+
+  afterEach(() => {
+    appGlobals.$analytics = undefined;
+    jest.useRealTimers();
+  });
+
+  it('uses the utm snapshot captured when the log entry is emitted', () => {
+    captureLoggerUtmParamsFromUrl(
+      'https://app.onekey.so/perps?utm_source=before',
+    );
+
+    const scene = new ServerLogScene();
+    scene.campaignEvent({ value: 'event' });
+
+    captureLoggerUtmParamsFromUrl(
+      'https://app.onekey.so/perps?utm_source=later',
+    );
+    jest.runOnlyPendingTimers();
+
+    expect(trackEvent).toHaveBeenCalledWith('campaignEvent', {
+      utm_source: 'before',
+      value: 'event',
+    });
+  });
+});

--- a/packages/shared/src/logger/base/logFn.ts
+++ b/packages/shared/src/logger/base/logFn.ts
@@ -6,7 +6,6 @@ import { loggerRuntime } from '../runtime/loggerRuntime';
 import { stringifyFunc } from '../stringifyFunc';
 
 import type { IMethodDecoratorMetadata } from '../types';
-import type { ILoggerUtmParams } from '../utmParams';
 
 export type ILogEntry = {
   scopeName: string;
@@ -21,7 +20,6 @@ export type ILogEntry = {
   };
   timestamp: () => string;
   rawArgs: unknown[];
-  utmParams: ILoggerUtmParams;
 };
 
 // ---------------------------------------------------------------------------
@@ -43,7 +41,6 @@ function handleServerLog(entry: ILogEntry) {
     {} as Record<string, string>,
   );
   appGlobals?.$analytics?.trackEvent(entry.methodName, {
-    ...entry.utmParams,
     ...eventProps,
   });
 }

--- a/packages/shared/src/logger/base/logFn.ts
+++ b/packages/shared/src/logger/base/logFn.ts
@@ -4,9 +4,9 @@ import { getLoggerExtension } from '../extensions';
 import { loggerConfig } from '../loggerConfig';
 import { loggerRuntime } from '../runtime/loggerRuntime';
 import { stringifyFunc } from '../stringifyFunc';
-import { getLoggerGlobalUtmParams } from '../utmParams';
 
 import type { IMethodDecoratorMetadata } from '../types';
+import type { ILoggerUtmParams } from '../utmParams';
 
 export type ILogEntry = {
   scopeName: string;
@@ -21,6 +21,7 @@ export type ILogEntry = {
   };
   timestamp: () => string;
   rawArgs: unknown[];
+  utmParams: ILoggerUtmParams;
 };
 
 // ---------------------------------------------------------------------------
@@ -42,7 +43,7 @@ function handleServerLog(entry: ILogEntry) {
     {} as Record<string, string>,
   );
   appGlobals?.$analytics?.trackEvent(entry.methodName, {
-    ...getLoggerGlobalUtmParams(),
+    ...entry.utmParams,
     ...eventProps,
   });
 }

--- a/packages/shared/src/logger/base/logFn.ts
+++ b/packages/shared/src/logger/base/logFn.ts
@@ -4,6 +4,7 @@ import { getLoggerExtension } from '../extensions';
 import { loggerConfig } from '../loggerConfig';
 import { loggerRuntime } from '../runtime/loggerRuntime';
 import { stringifyFunc } from '../stringifyFunc';
+import { getLoggerGlobalUtmParams } from '../utmParams';
 
 import type { IMethodDecoratorMetadata } from '../types';
 
@@ -27,22 +28,23 @@ export type ILogEntry = {
 // ---------------------------------------------------------------------------
 
 function handleServerLog(entry: ILogEntry) {
-  appGlobals?.$analytics?.trackEvent(
-    entry.methodName,
-    (entry.args as Record<string, string>[]).reduce(
-      (prev, current, index) => {
-        if (!current) {
-          return prev;
-        }
-        const value =
-          typeof current === 'object' && !Array.isArray(current)
-            ? current
-            : { [index]: current };
-        return { ...prev, ...value };
-      },
-      {} as Record<string, string>,
-    ),
+  const eventProps = (entry.args as Record<string, string>[]).reduce(
+    (prev, current, index) => {
+      if (!current) {
+        return prev;
+      }
+      const value =
+        typeof current === 'object' && !Array.isArray(current)
+          ? current
+          : { [index]: current };
+      return { ...prev, ...value };
+    },
+    {} as Record<string, string>,
   );
+  appGlobals?.$analytics?.trackEvent(entry.methodName, {
+    ...getLoggerGlobalUtmParams(),
+    ...eventProps,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/logger/base/logFn.ts
+++ b/packages/shared/src/logger/base/logFn.ts
@@ -40,6 +40,7 @@ function handleServerLog(entry: ILogEntry) {
     },
     {} as Record<string, string>,
   );
+  // UTM attribution is emitted as its own event to avoid reading mutable route state here.
   appGlobals?.$analytics?.trackEvent(entry.methodName, {
     ...eventProps,
   });

--- a/packages/shared/src/logger/scopes/app/scenes/router.ts
+++ b/packages/shared/src/logger/scopes/app/scenes/router.ts
@@ -1,5 +1,7 @@
 import { BaseScene } from '../../../base/baseScene';
-import { LogToLocal } from '../../../base/decorators';
+import { LogToLocal, LogToServer } from '../../../base/decorators';
+
+import type { ILoggerUtmParams } from '../../../utmParams';
 
 export class RouterScene extends BaseScene {
   @LogToLocal()
@@ -43,5 +45,10 @@ export class RouterScene extends BaseScene {
   @LogToLocal()
   public pageMounted(pageName: string) {
     return { pageName };
+  }
+
+  @LogToServer()
+  public utmParamsCaptured(params: ILoggerUtmParams) {
+    return params;
   }
 }

--- a/packages/shared/src/logger/utmParams.test.ts
+++ b/packages/shared/src/logger/utmParams.test.ts
@@ -33,6 +33,29 @@ describe('logger utm params helpers', () => {
     });
   });
 
+  it('caps collected utm params across search and hash params', () => {
+    const params = getLoggerUtmParamsFromUrl(
+      [
+        'https://app.onekey.so/perps?',
+        'utm_1=one&utm_2=two&utm_3=three&utm_4=four',
+        '&utm_5=five&utm_6=six&utm_7=seven&utm_8=eight',
+        '#/market?utm_9=nine&utm_1=updated',
+      ].join(''),
+    );
+
+    expect(Object.keys(params)).toHaveLength(8);
+    expect(params).toEqual({
+      utm_1: 'updated',
+      utm_2: 'two',
+      utm_3: 'three',
+      utm_4: 'four',
+      utm_5: 'five',
+      utm_6: 'six',
+      utm_7: 'seven',
+      utm_8: 'eight',
+    });
+  });
+
   it('normalizes utm values and stores them as global event props', () => {
     const captured = captureLoggerUtmParamsFromUrl(
       `https://app.onekey.so/perps?utm_kol=${encodeURIComponent(

--- a/packages/shared/src/logger/utmParams.test.ts
+++ b/packages/shared/src/logger/utmParams.test.ts
@@ -1,0 +1,83 @@
+import {
+  captureLoggerUtmParamsFromUrl,
+  getLoggerGlobalUtmParams,
+  getLoggerUtmParamsFromUrl,
+} from './utmParams';
+
+describe('logger utm params helpers', () => {
+  it('reads all utm params from full URLs and paths', () => {
+    expect(
+      getLoggerUtmParamsFromUrl(
+        'https://app.onekey.so/market?utm_source=x&utm_kol=kol_001&foo=bar',
+      ),
+    ).toEqual({
+      utm_kol: 'kol_001',
+      utm_source: 'x',
+    });
+    expect(
+      getLoggerUtmParamsFromUrl('/perps?utm_medium=social&utm_campaign=may'),
+    ).toEqual({
+      utm_campaign: 'may',
+      utm_medium: 'social',
+    });
+  });
+
+  it('reads utm params from hash route URLs', () => {
+    expect(
+      getLoggerUtmParamsFromUrl(
+        'https://app.onekey.so/#/perps?utm_content=hero&utm_kol=kol_003',
+      ),
+    ).toEqual({
+      utm_content: 'hero',
+      utm_kol: 'kol_003',
+    });
+  });
+
+  it('normalizes utm values and stores them as global event props', () => {
+    const captured = captureLoggerUtmParamsFromUrl(
+      `https://app.onekey.so/perps?utm_kol=${encodeURIComponent(
+        '  kol_004\n  ',
+      )}&utm_source=twitter`,
+    );
+
+    expect(captured).toEqual({
+      params: {
+        utm_kol: 'kol_004',
+        utm_source: 'twitter',
+      },
+      shouldReport: true,
+    });
+    expect(getLoggerGlobalUtmParams()).toEqual({
+      utm_kol: 'kol_004',
+      utm_source: 'twitter',
+    });
+  });
+
+  it('clears stale global utm params when a later capture omits them', () => {
+    captureLoggerUtmParamsFromUrl(
+      'https://app.onekey.so/perps?utm_source=twitter&utm_campaign=old',
+    );
+
+    const captured = captureLoggerUtmParamsFromUrl(
+      'https://app.onekey.so/perps?utm_source=discord',
+    );
+
+    expect(captured).toEqual({
+      params: {
+        utm_source: 'discord',
+      },
+      shouldReport: true,
+    });
+    expect(getLoggerGlobalUtmParams()).toEqual({
+      utm_source: 'discord',
+    });
+  });
+
+  it('marks only the first matching utm snapshot for reporting', () => {
+    const url =
+      'https://app.onekey.so/perps?utm_source=once&utm_campaign=report';
+
+    expect(captureLoggerUtmParamsFromUrl(url)?.shouldReport).toBe(true);
+    expect(captureLoggerUtmParamsFromUrl(url)?.shouldReport).toBe(false);
+  });
+});

--- a/packages/shared/src/logger/utmParams.test.ts
+++ b/packages/shared/src/logger/utmParams.test.ts
@@ -96,6 +96,15 @@ describe('logger utm params helpers', () => {
     });
   });
 
+  it('clears stale global utm params when a later capture has no utm params', () => {
+    captureLoggerUtmParamsFromUrl(
+      'https://app.onekey.so/perps?utm_source=twitter&utm_campaign=old',
+    );
+
+    expect(captureLoggerUtmParamsFromUrl('/wallet')).toBeUndefined();
+    expect(getLoggerGlobalUtmParams()).toEqual({});
+  });
+
   it('marks only the first matching utm snapshot for reporting', () => {
     const url =
       'https://app.onekey.so/perps?utm_source=once&utm_campaign=report';

--- a/packages/shared/src/logger/utmParams.ts
+++ b/packages/shared/src/logger/utmParams.ts
@@ -129,11 +129,11 @@ export function captureLoggerUtmParamsFromUrl(url: string | undefined | null):
     }
   | undefined {
   const params = getLoggerUtmParamsFromUrl(url);
+  replaceLoggerGlobalUtmParams(params);
   if (Object.keys(params).length === 0) {
     return undefined;
   }
 
-  replaceLoggerGlobalUtmParams(params);
   const snapshot = buildReportSnapshot(params);
   const shouldReport = !reportedUtmParamSnapshots.has(snapshot);
   reportedUtmParamSnapshots.add(snapshot);

--- a/packages/shared/src/logger/utmParams.ts
+++ b/packages/shared/src/logger/utmParams.ts
@@ -1,0 +1,140 @@
+const MAX_UTM_VALUE_LENGTH = 128;
+const MAX_UTM_KEY_LENGTH = 64;
+const URL_PROTOCOL_PREFIX_REGEXP = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//u;
+const DUMMY_URL_ORIGIN = 'https://onekey.local';
+const UTM_KEY_REGEXP = /^utm_[a-z0-9_]+$/u;
+
+export type ILoggerUtmParams = Record<string, string>;
+
+const loggerGlobalUtmParams: ILoggerUtmParams = {};
+const reportedUtmParamSnapshots = new Set<string>();
+
+function isControlCharacter(value: string): boolean {
+  const charCode = value.charCodeAt(0);
+  return charCode <= 31 || charCode === 127;
+}
+
+function parseUrlLike(value: string): URL | undefined {
+  const trimmedValue = value.trim();
+  if (!trimmedValue) {
+    return undefined;
+  }
+
+  try {
+    if (
+      URL_PROTOCOL_PREFIX_REGEXP.test(trimmedValue) ||
+      trimmedValue.startsWith('/')
+    ) {
+      return new URL(trimmedValue, DUMMY_URL_ORIGIN);
+    }
+    return new URL(`https://${trimmedValue}`);
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeUtmKey(key: string): string | undefined {
+  const normalizedKey = key.trim().toLowerCase();
+  if (
+    normalizedKey.length > MAX_UTM_KEY_LENGTH ||
+    !UTM_KEY_REGEXP.test(normalizedKey)
+  ) {
+    return undefined;
+  }
+  return normalizedKey;
+}
+
+export function normalizeLoggerUtmValue(
+  value: string | string[] | undefined | null,
+): string | undefined {
+  const rawValue = Array.isArray(value) ? value[0] : value;
+  const trimmedValue = rawValue?.trim();
+  if (!trimmedValue) {
+    return undefined;
+  }
+
+  const normalizedValue = Array.from(trimmedValue)
+    .filter((char) => !isControlCharacter(char))
+    .join('')
+    .slice(0, MAX_UTM_VALUE_LENGTH);
+
+  return normalizedValue || undefined;
+}
+
+function collectUtmParamsFromSearchParams(
+  searchParams: URLSearchParams,
+): ILoggerUtmParams {
+  const params: ILoggerUtmParams = {};
+  searchParams.forEach((value, key) => {
+    const normalizedKey = normalizeUtmKey(key);
+    const normalizedValue = normalizeLoggerUtmValue(value);
+    if (normalizedKey && normalizedValue) {
+      params[normalizedKey] = normalizedValue;
+    }
+  });
+  return params;
+}
+
+function buildReportSnapshot(params: ILoggerUtmParams): string {
+  return Object.keys(params)
+    .toSorted()
+    .map((key) => `${key}=${params[key]}`)
+    .join('&');
+}
+
+function replaceLoggerGlobalUtmParams(params: ILoggerUtmParams) {
+  Object.keys(loggerGlobalUtmParams).forEach((key) => {
+    delete loggerGlobalUtmParams[key];
+  });
+  Object.assign(loggerGlobalUtmParams, params);
+}
+
+export function getLoggerUtmParamsFromUrl(
+  url: string | undefined | null,
+): ILoggerUtmParams {
+  if (!url) {
+    return {};
+  }
+
+  const parsedUrl = parseUrlLike(url);
+  if (!parsedUrl) {
+    return {};
+  }
+
+  const params = collectUtmParamsFromSearchParams(parsedUrl.searchParams);
+  const hash = parsedUrl.hash;
+  const hashQueryIndex = hash.indexOf('?');
+  if (hashQueryIndex >= 0) {
+    Object.assign(
+      params,
+      collectUtmParamsFromSearchParams(
+        new URLSearchParams(hash.slice(hashQueryIndex + 1)),
+      ),
+    );
+  }
+
+  return params;
+}
+
+export function captureLoggerUtmParamsFromUrl(url: string | undefined | null):
+  | {
+      params: ILoggerUtmParams;
+      shouldReport: boolean;
+    }
+  | undefined {
+  const params = getLoggerUtmParamsFromUrl(url);
+  if (Object.keys(params).length === 0) {
+    return undefined;
+  }
+
+  replaceLoggerGlobalUtmParams(params);
+  const snapshot = buildReportSnapshot(params);
+  const shouldReport = !reportedUtmParamSnapshots.has(snapshot);
+  reportedUtmParamSnapshots.add(snapshot);
+
+  return { params, shouldReport };
+}
+
+export function getLoggerGlobalUtmParams(): ILoggerUtmParams {
+  return { ...loggerGlobalUtmParams };
+}

--- a/packages/shared/src/logger/utmParams.ts
+++ b/packages/shared/src/logger/utmParams.ts
@@ -1,5 +1,6 @@
 const MAX_UTM_VALUE_LENGTH = 128;
 const MAX_UTM_KEY_LENGTH = 64;
+const MAX_UTM_PARAM_COUNT = 8;
 const URL_PROTOCOL_PREFIX_REGEXP = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//u;
 const DUMMY_URL_ORIGIN = 'https://onekey.local';
 const UTM_KEY_REGEXP = /^utm_[a-z0-9_]+$/u;
@@ -63,12 +64,19 @@ export function normalizeLoggerUtmValue(
 
 function collectUtmParamsFromSearchParams(
   searchParams: URLSearchParams,
+  params: ILoggerUtmParams = {},
 ): ILoggerUtmParams {
-  const params: ILoggerUtmParams = {};
+  let paramCount = Object.keys(params).length;
   searchParams.forEach((value, key) => {
     const normalizedKey = normalizeUtmKey(key);
     const normalizedValue = normalizeLoggerUtmValue(value);
     if (normalizedKey && normalizedValue) {
+      if (!Object.prototype.hasOwnProperty.call(params, normalizedKey)) {
+        if (paramCount >= MAX_UTM_PARAM_COUNT) {
+          return;
+        }
+        paramCount += 1;
+      }
       params[normalizedKey] = normalizedValue;
     }
   });
@@ -105,11 +113,9 @@ export function getLoggerUtmParamsFromUrl(
   const hash = parsedUrl.hash;
   const hashQueryIndex = hash.indexOf('?');
   if (hashQueryIndex >= 0) {
-    Object.assign(
+    collectUtmParamsFromSearchParams(
+      new URLSearchParams(hash.slice(hashQueryIndex + 1)),
       params,
-      collectUtmParamsFromSearchParams(
-        new URLSearchParams(hash.slice(hashQueryIndex + 1)),
-      ),
     );
   }
 

--- a/packages/shared/src/logger/utmParams.ts
+++ b/packages/shared/src/logger/utmParams.ts
@@ -113,6 +113,7 @@ export function getLoggerUtmParamsFromUrl(
   const hash = parsedUrl.hash;
   const hashQueryIndex = hash.indexOf('?');
   if (hashQueryIndex >= 0) {
+    // Hash routes can carry campaign params independently from the outer URL.
     collectUtmParamsFromSearchParams(
       new URLSearchParams(hash.slice(hashQueryIndex + 1)),
       params,
@@ -129,6 +130,7 @@ export function captureLoggerUtmParamsFromUrl(url: string | undefined | null):
     }
   | undefined {
   const params = getLoggerUtmParamsFromUrl(url);
+  // Replace first so a plain URL clears attribution from the previous route.
   replaceLoggerGlobalUtmParams(params);
   if (Object.keys(params).length === 0) {
     return undefined;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55267](https://onekeyhq.atlassian.net/browse/OK-55267)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Add a shared `utmParams` helper that extracts, normalizes, and caches `utm_*` query/hash params from any URL.
- Wire the capture into the React Navigation linking entry and the deep-link processor so the most recent UTM context is always known.
- Merge the cached UTM params into every server-side analytics event via `logFn`, and emit a one-shot `app.router.utmParamsCaptured` event per unique snapshot.

## Intent & Context
We need analytics events to be attributable to marketing campaigns (utm_source, utm_medium, utm_campaign, utm_kol, utm_content, etc.) regardless of whether the user landed via a deep link, a hash route, or a web URL with query string. Previously `defaultLogger.app.router.*` events carried no UTM attribution, so growth/marketing dashboards could not segment user behavior by acquisition channel.

## Design Decisions
- **Capture at the URL entry points only.** Two places see every external URL: `processDeepLinkUrl` (native deep links/universal links) and React Navigation's `onGetStateFromPath` (in-app navigation + web `location.href` on cold load). Hooking both keeps coverage without instrumenting individual screens.
- **Global cache + merge in `handleServerLog`.** Storing the latest UTM snapshot in `loggerGlobalUtmParams` and merging it into the analytics payload inside `handleServerLog` means every existing `@LogToServer` event automatically gets UTM tags — no per-scene changes required. Event-specific props win on key collision (spread order: `...utm, ...eventProps`).
- **One-shot reporting per snapshot.** `captureLoggerUtmParamsFromUrl` only fires `utmParamsCaptured` the first time a given normalized snapshot is seen, so re-opening the same UTM URL does not spam Mixpanel. The snapshot key is sorted-and-joined so `?a=1&b=2` and `?b=2&a=1` dedupe.
- **Strict validation.** Keys must match `^utm_[a-z0-9_]+$` (≤64 chars), values are trimmed, stripped of control characters, capped at 128 chars. Hash-routed URLs (`/#/perps?utm_*=…`) are parsed for query params in the fragment as well. Invalid/empty values are dropped so we never report empty strings.
- **`shared` package placement.** Helper lives in `@onekeyhq/shared/src/logger` so logger internals can import it without violating the import hierarchy; a thin `kit/routes/config/loggerUtmParams.ts` wrapper performs the report side-effect to keep `shared` free of `defaultLogger` import cycles.

## Changes Detail
- `packages/shared/src/logger/utmParams.ts` (new) — URL parser, key/value normalization, global UTM cache, one-shot snapshot dedupe.
- `packages/shared/src/logger/utmParams.test.ts` (new) — 5 unit tests covering query/hash extraction, value normalization, stale-key replacement, and report dedupe.
- `packages/shared/src/logger/base/logFn.ts` — merge `getLoggerGlobalUtmParams()` into the `trackEvent` props for every server log.
- `packages/shared/src/logger/scopes/app/scenes/router.ts` — add `utmParamsCaptured(params)` `@LogToServer` event.
- `packages/kit/src/routes/config/loggerUtmParams.ts` (new) — `captureAndReportLoggerUtmParamsFromUrl` wrapper that reports via `defaultLogger.app.router`.
- `packages/kit/src/routes/config/deeplink/index.ts` — capture UTM on every processed deep link URL.
- `packages/kit/src/routes/config/index.ts` — capture in `onGetStateFromPath`; on web also capture from `globalThis.location.href` so cold-load attribution survives.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**:
  - `handleServerLog` is on the hot path for every server-tracked event; the added `getLoggerGlobalUtmParams()` call returns a shallow clone of a small object, so overhead is negligible but worth a glance.
  - On web, `globalThis.location.href` is read inside `onGetStateFromPath`; guarded by `platformEnv.isWeb` so SSR/native paths are unaffected.
  - UTM keys/values are sanitized before being sent to analytics — no untrusted strings reach Mixpanel.

## Test plan
- [x] Unit tests pass: `yarn jest packages/shared/src/logger/utmParams.test.ts`
- [ ] Open a deep link such as `onekey://main?utm_source=twitter&utm_kol=kol_001`, verify a Mixpanel `utm_params_captured` event fires once and subsequent events on that session carry `utm_source` / `utm_kol`.
- [ ] On web, load `https://app.onekey.so/#/perps?utm_source=discord&utm_campaign=may`, verify analytics events include the UTM tags.
- [ ] Re-open the same UTM URL and confirm `utm_params_captured` is NOT re-reported.
- [ ] Navigate to a new UTM URL with a different `utm_source` and confirm the cached params are replaced (no stale leakage).

[OK-55267]: https://onekeyhq.atlassian.net/browse/OK-55267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ