### PR TITLE
feat: support swap expected time (OK-55025)

### DIFF
--- a/packages/kit/src/views/Swap/components/SwapProviderListItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProviderListItem.tsx
@@ -19,6 +19,7 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import { formatSwapQuoteDuration } from '@onekeyhq/shared/src/utils/swapQuoteDurationUtils';
 import type {
   IFetchQuoteResult,
   ISwapToken,
@@ -54,6 +55,7 @@ const SwapProviderListItem = ({
   ...rest
 }: ISwapProviderListItemProps) => {
   const intl = useIntl();
+  const { estTime, estimatedTime } = providerResult;
   const networkFeeComponent = useMemo(() => {
     if (providerResult.fee?.estimatedFeeFiatValue) {
       return (
@@ -88,20 +90,8 @@ const SwapProviderListItem = ({
   }, [currencySymbol, intl, providerResult.fee?.estimatedFeeFiatValue]);
 
   const estimatedTimeComponent = useMemo(() => {
-    if (providerResult.estimatedTime) {
-      const timeInSeconds = new BigNumber(providerResult.estimatedTime);
-      const oneMinuteInSeconds = new BigNumber(60);
-      let displayTime;
-      if (timeInSeconds.isLessThan(oneMinuteInSeconds)) {
-        displayTime = '< 1min';
-      } else {
-        // Divide by 60 and round up to the nearest whole number
-        const timeInMinutes = timeInSeconds
-          .dividedBy(60)
-          .integerValue(BigNumber.ROUND_UP)
-          .toNumber();
-        displayTime = `${timeInMinutes}min`;
-      }
+    const displayTime = formatSwapQuoteDuration({ estTime, estimatedTime });
+    if (displayTime) {
       return (
         <XStack gap="$1" alignItems="center">
           <Tooltip
@@ -128,7 +118,7 @@ const SwapProviderListItem = ({
       );
     }
     return null;
-  }, [intl, providerResult.estimatedTime]);
+  }, [estTime, estimatedTime, intl]);
 
   const protocolFeeComponent = useMemo(
     () => (

--- a/packages/shared/src/utils/swapQuoteDurationUtils.ts
+++ b/packages/shared/src/utils/swapQuoteDurationUtils.ts
@@ -52,7 +52,7 @@ export function getSwapQuoteDurationSortValue(quote: ISwapQuoteDurationInput) {
 export function formatSwapQuoteDuration(quote: ISwapQuoteDurationInput) {
   const estTimeMinutes = toPositiveBigNumber(quote.estTime);
   if (estTimeMinutes) {
-    return formatMinutes(estTimeMinutes, BigNumber.ROUND_HALF_UP);
+    return formatMinutes(estTimeMinutes, BigNumber.ROUND_UP);
   }
 
   const estimatedTimeSeconds = toPositiveBigNumber(quote.estimatedTime);

--- a/packages/shared/src/utils/swapQuoteDurationUtils.ts
+++ b/packages/shared/src/utils/swapQuoteDurationUtils.ts
@@ -1,0 +1,64 @@
+import BigNumber from 'bignumber.js';
+
+import type { IFetchQuoteResult } from '../../types/swap/types';
+
+type ISwapQuoteDurationInput = {
+  estTime?: IFetchQuoteResult['estTime'] | null;
+  estimatedTime?: IFetchQuoteResult['estimatedTime'] | null;
+};
+
+function toPositiveBigNumber(value: string | number | null | undefined) {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  const valueBN = new BigNumber(value);
+  if (!valueBN.isFinite() || valueBN.lte(0)) {
+    return undefined;
+  }
+
+  return valueBN;
+}
+
+function formatMinutes(
+  minutes: BigNumber,
+  roundingMode: BigNumber.RoundingMode,
+) {
+  if (minutes.lt(1)) {
+    return '< 1min';
+  }
+
+  if (minutes.gt(60)) {
+    return '> 60min';
+  }
+
+  return `${minutes.integerValue(roundingMode).toFixed(0)}min`;
+}
+
+export function getSwapQuoteDurationMinutes(quote: ISwapQuoteDurationInput) {
+  const estTimeMinutes = toPositiveBigNumber(quote.estTime);
+  if (estTimeMinutes) {
+    return estTimeMinutes;
+  }
+
+  const estimatedTimeSeconds = toPositiveBigNumber(quote.estimatedTime);
+  return estimatedTimeSeconds?.dividedBy(60);
+}
+
+export function getSwapQuoteDurationSortValue(quote: ISwapQuoteDurationInput) {
+  return getSwapQuoteDurationMinutes(quote) ?? new BigNumber(Infinity);
+}
+
+export function formatSwapQuoteDuration(quote: ISwapQuoteDurationInput) {
+  const estTimeMinutes = toPositiveBigNumber(quote.estTime);
+  if (estTimeMinutes) {
+    return formatMinutes(estTimeMinutes, BigNumber.ROUND_HALF_UP);
+  }
+
+  const estimatedTimeSeconds = toPositiveBigNumber(quote.estimatedTime);
+  if (!estimatedTimeSeconds) {
+    return undefined;
+  }
+
+  return formatMinutes(estimatedTimeSeconds.dividedBy(60), BigNumber.ROUND_UP);
+}

--- a/packages/shared/src/utils/swapQuoteSortUtils.ts
+++ b/packages/shared/src/utils/swapQuoteSortUtils.ts
@@ -5,6 +5,8 @@ import {
   swapProviderRecommendApprovedWeights,
 } from '../../types/swap/SwapProvider.constants';
 
+import { getSwapQuoteDurationSortValue } from './swapQuoteDurationUtils';
+
 import type { IFetchQuoteResult } from '../../types/swap/types';
 
 // ---------------------------------------------------------------------------
@@ -118,8 +120,8 @@ export function sortSwapQuotes(
 
   // ---- Duration sort (ascending) ----
   const durationSorted = [...resetList].toSorted((a, b) => {
-    const aVal = new BigNumber(a.estimatedTime || Infinity);
-    const bVal = new BigNumber(b.estimatedTime || Infinity);
+    const aVal = getSwapQuoteDurationSortValue(a);
+    const bVal = getSwapQuoteDurationSortValue(b);
     return aVal.comparedTo(bVal);
   });
 

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -572,7 +572,8 @@ export interface IFetchQuoteResult {
   instantRate?: string;
   allowanceResult?: IAllowanceResult;
   approvedInfo?: IApprovedInfo;
-  estimatedTime?: string;
+  estimatedTime?: string | number; // legacy provider value, in seconds
+  estTime?: string | number; // server computed value, in minutes
   isBest?: boolean;
   receivedBest?: boolean;
   minGasCost?: boolean;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55025](https://onekeyhq.atlassian.net/browse/OK-55025)

----------

<!-- github-pr-monitor:jira-links:end -->


## Issues
- Fixes OK-55025
- Related OK-53931
- Backend OK-55024

## Summary
- Support backend-provided `estTime` for Swap provider expected-time display.
- Keep legacy `estimatedTime` fallback for providers that still return seconds.
- Share expected-time formatting between provider display and quote sorting.

## Test plan
- [x] `git diff --cached --check`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Swap/components/SwapProviderListItem.tsx packages/shared/src/utils/swapQuoteDurationUtils.ts packages/shared/src/utils/swapQuoteSortUtils.ts packages/shared/types/swap/types.ts`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`

[OK-55025]: https://onekeyhq.atlassian.net/browse/OK-55025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ