### PR TITLE
Reapply: feat(ios26) Liquid Glass UI for stack headers and tab bar (OK-54175)

### DIFF
--- a/apps/mobile/ios/OneKeyWallet/Info.plist
+++ b/apps/mobile/ios/OneKeyWallet/Info.plist
@@ -115,8 +115,6 @@
 	<array>
 		<string>remote-notification</string>
 	</array>
-	<key>UIDesignRequiresCompatibility</key>
-	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>SplashScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -20,8 +20,7 @@
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-markdown-display": "7.0.2",
     "react-native-root-siblings": "^5.0.1",
-    "react-native-svg": "15.15.1",
-    "react-native-tab-view": "^3.5.1"
+    "react-native-svg": "15.15.1"
   },
   "devDependencies": {
     "@svgr/cli": "8.1.0",

--- a/packages/components/src/layouts/Navigation/Header/HeaderButtonGroup.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderButtonGroup.tsx
@@ -1,4 +1,5 @@
 import type { GetProps } from '@onekeyhq/components/src/shared/tamagui';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { XStack } from '../../../primitives';
 
@@ -9,6 +10,17 @@ export default function HeaderButtonGroup(props: GetProps<typeof XStack>) {
     <XStack
       gap="$4"
       alignItems="center"
+      // iOS 26 wraps headerLeft/right custom views in a UIBarButtonItem
+      // glass container. With only a height set, our intrinsic 36-wide
+      // children produced a 36x44 frame; the glass container then padded
+      // it horizontally and rendered as a wide pill instead of a circle.
+      // Forcing a 44x44 square frame keeps the container circular and
+      // aligned to the bar's vertical center.
+      {...(platformEnv.isNativeIOS26Plus && {
+        height: 44,
+        minWidth: 44,
+        justifyContent: 'center',
+      })}
       testID="Navigation-HeaderView-ButtonGroup"
       {...rest}
     >

--- a/packages/components/src/layouts/Navigation/Header/HeaderIconButton.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderIconButton.tsx
@@ -1,3 +1,5 @@
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
 import { IconButton } from '../../../actions/IconButton';
 
 import type { IIconButtonProps } from '../../../actions/IconButton';
@@ -15,6 +17,13 @@ function HeaderIconButton(props: IIconButtonProps) {
       variant="tertiary"
       focusVisibleStyle={undefined}
       className="app-region-no-drag"
+      // IconButton's tertiary variant applies a negative margin (m: -7)
+      // intended for inline text alignment. On iOS 26 the navigation bar
+      // wraps headerLeft/right in a glass container that vertically
+      // centers the view's frame; the negative margin then shifts the
+      // visible icon up and to the left of that centered slot. Reset it
+      // for header use so the icon sits at the bar's true center.
+      {...(platformEnv.isNativeIOS26Plus && { m: 0 })}
       {...props}
     />
   );

--- a/packages/components/src/layouts/Navigation/Header/HeaderScreenOptions.tsx
+++ b/packages/components/src/layouts/Navigation/Header/HeaderScreenOptions.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 
 import { getFontSize } from '@onekeyhq/components/src/shared/tamagui';
 import type { VariableVal } from '@onekeyhq/components/src/shared/tamagui';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { hasNativeHeaderView } from '../Navigator/CommonConfig';
 
@@ -40,33 +41,109 @@ export function makeHeaderScreenOptions({
     const state = currentNavigation?.getState();
     const isCanGoBack = (state?.index ?? 0) > 0;
 
+    // Liquid Glass material is enabled for every screen inside a root
+    // tab (top-level and pushed). Modal/onboarding screens are excluded
+    // (isRootScreen=false).
+    //
+    // headerTransparent must be true for the glass to be visibly
+    // distinct from a flat opaque bar — iOS 26's
+    // configureWithDefaultBackground only refracts what's actually
+    // underneath the bar, and without `edgesForExtendedLayout =
+    // UIRectEdgeAll` the page content stays below the bar, leaving the
+    // glass to refract the navigation controller's plain view
+    // background (so the bar looks like a flat dark rectangle).
+    //
+    // Trade-off: pages with custom top-of-content layouts (e.g. the
+    // Perps ETH/USDC stat row) must add a safe-area top inset themselves
+    // to avoid sliding under the bar. Most pages already do via the
+    // Tamagui Page component / useSafeAreaInsets.
+    const useLiquidGlassHeader = platformEnv.isNativeIOS26Plus && isRootScreen;
+    const useTransparentHeader = useLiquidGlassHeader;
+
+    // iOS 26+ uses native-stack's built-in bar button rendering so
+    // UIKit draws each button in its proper iOS 26 circular glass
+    // container.
+    //   - Pushed screens (canGoBack): omit headerLeft so the system
+    //     back button renders. Setting headerBackButtonDisplayMode to
+    //     'minimal' hides the previous-screen back-title; the long-press
+    //     navigation history menu still works because that's a system
+    //     UIBarButtonItem feature controlled by
+    //     headerBackButtonMenuEnabled (default true).
+    //   - Modal/onboarding close (no canGoBack): use
+    //     unstable_headerLeftItems with the SF Symbol close glyph. UIKit
+    //     has no built-in modal close primitive, so we emit a button
+    //     item and own its onPress.
+    //   - Root tab with no buttons: nothing to wire.
+    //
+    // iOS <26 keeps the OneKey-drawn HeaderBackButton path unchanged.
+    let headerLeftOptions: IStackNavigationOptions;
+    if (platformEnv.isNativeIOS26Plus) {
+      if (isCanGoBack) {
+        headerLeftOptions = {
+          headerBackButtonDisplayMode: 'minimal' as const,
+        };
+      } else if ((isModelScreen || isOnboardingScreen) && !isRootScreen) {
+        headerLeftOptions = {
+          unstable_headerLeftItems: () => [
+            {
+              type: 'button' as const,
+              label: 'Close',
+              icon: { type: 'sfSymbol' as const, name: 'xmark' },
+              onPress: () => currentNavigation?.goBack?.(),
+            },
+          ],
+        };
+      } else {
+        headerLeftOptions = {};
+      }
+    } else {
+      headerLeftOptions = {
+        // TODO: don't override the headerLeft on iOS
+        headerLeft: (props: HeaderBackButtonProps): ReactNode => (
+          <HeaderBackButton
+            onPress={currentNavigation?.goBack}
+            isModelScreen={isModelScreen}
+            isRootScreen={isRootScreen}
+            isOnboardingScreen={isOnboardingScreen}
+            isWebViewScreen={isWebViewScreen}
+            {...props}
+            canGoBack={isCanGoBack}
+          />
+        ),
+      };
+    }
+
     return {
-      headerStyle: {
-        backgroundColor: bgColor as string,
-      },
+      // Omit headerStyle when Liquid Glass is active so the patched
+      // react-native-screens calls configureWithDefaultBackground and lets
+      // UIKit render the system glass material. Passing backgroundColor
+      // would force the appearance opaque and suppress glass.
+      ...(useLiquidGlassHeader
+        ? {}
+        : {
+            headerStyle: {
+              backgroundColor: bgColor as string,
+            },
+          }),
       headerTitleStyle: {
         fontSize: getFontSize('$headingLg'),
         color: titleColor as string,
       },
       headerShadowVisible: false,
-      /* Although the default value of `headerTransparent` is `false` too, 
+      /* Although the default value of `headerTransparent` is `false` too,
          we still cannot remove it here.
          because RNSSearchBar seems will read an incorrect default value.
+
+         On iOS 26+ root tabs flip it to `true` so react-native-screens
+         sets edgesForExtendedLayout = UIRectEdgeAll, letting the tab
+         content render under the navigation bar so the Liquid Glass
+         material refracts it. Modal/onboarding screens keep `false` —
+         their parent screen still draws underneath them, and an extended
+         layout would show that parent through the modal chrome.
       */
-      headerTransparent: false,
+      headerTransparent: useTransparentHeader,
       headerTitleAlign: 'left',
-      // TODO: don't override the headerLeft on iOS
-      headerLeft: (props: HeaderBackButtonProps): ReactNode => (
-        <HeaderBackButton
-          onPress={currentNavigation?.goBack}
-          isModelScreen={isModelScreen}
-          isRootScreen={isRootScreen}
-          isOnboardingScreen={isOnboardingScreen}
-          isWebViewScreen={isWebViewScreen}
-          {...props}
-          canGoBack={isCanGoBack}
-        />
-      ),
+      ...headerLeftOptions,
     };
   }
 

--- a/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
@@ -205,7 +205,14 @@ export function TabStackNavigator<RouteName extends string>({
     }
   }, [tabBarHidden, splitViewType, isLandscape]);
   const tabBarStyle = useMemo(
-    () => ({ backgroundColor: theme.bg.val }),
+    () =>
+      // On iOS 26+ omit backgroundColor so UITabBar renders the system
+      // Liquid Glass material via configureWithDefaultBackground. Setting
+      // appearance.backgroundColor in @onekeyfe/react-native-tab-view would
+      // overwrite the glass material with an opaque fill.
+      platformEnv.isNativeIOS26Plus
+        ? undefined
+        : { backgroundColor: theme.bg.val },
     [theme.bg.val],
   );
 

--- a/packages/kit/src/components/MoreActionButton/index.tsx
+++ b/packages/kit/src/components/MoreActionButton/index.tsx
@@ -20,6 +20,7 @@ import {
   Image,
   LottieView,
   NavBackButton,
+  Page,
   Popover,
   ScrollView,
   SizableText,
@@ -252,6 +253,43 @@ function MoreActionContentHeader({
       rootNavigationRef.current?.goBack();
     }
   }, []);
+
+  // iOS 26 page-level usage: render via the native UINavigationBar so
+  // the back chevron + right items get the system Liquid Glass material
+  // and the SF Symbols (headphones, qrcode.viewfinder) replace the
+  // small custom IconButton SVGs. The body of MoreActionContentPage
+  // continues to render the rest of the page below the bar.
+  const buildNativeRightItems = useCallback(
+    () => [
+      {
+        type: 'button' as const,
+        label: intl.formatMessage({ id: ETranslations.settings_contact_us }),
+        icon: { type: 'sfSymbol' as const, name: 'headphones' as const },
+        onPress: handleCustomerSupport,
+      },
+      {
+        type: 'button' as const,
+        label: intl.formatMessage({ id: ETranslations.scan_scan_qr_code }),
+        icon: {
+          type: 'sfSymbol' as const,
+          name: 'qrcode.viewfinder' as const,
+        },
+        onPress: () => {
+          void handleScan();
+        },
+      },
+    ],
+    [intl, handleCustomerSupport, handleScan],
+  );
+
+  if (platformEnv.isNativeIOS26Plus && showBackButton) {
+    return (
+      <Page.Header
+        headerShown
+        unstable_headerRightItems={buildNativeRightItems}
+      />
+    );
+  }
 
   return (
     <XStack

--- a/packages/kit/src/views/ActionCenter/pages/ActionCenter.tsx
+++ b/packages/kit/src/views/ActionCenter/pages/ActionCenter.tsx
@@ -1,13 +1,24 @@
 import { Page, useSafeAreaInsets } from '@onekeyhq/components';
 import { MoreActionContentPage } from '@onekeyhq/kit/src/components/MoreActionButton';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { ActionCenterTestIDs } from '../testIDs';
 
 export default function ActionCenter() {
   const { top } = useSafeAreaInsets();
+  // On iOS 26 MoreActionContentHeader emits a native <Page.Header />,
+  // and the screens framework already positions Page.Body below the bar
+  // (HeaderScreenOptions does NOT set headerTransparent for this modal
+  // style page, so content does not extend under the bar). Don't add
+  // any top inset here — that would double-shift the body and leave a
+  // tall empty band under the bar. The mt: top branch is kept for iOS
+  // <26 / Android / web where there's no native bar to reserve space.
   return (
     <Page>
-      <Page.Body mt={top} testID={ActionCenterTestIDs.pageBody}>
+      <Page.Body
+        mt={platformEnv.isNativeIOS26Plus ? 0 : top}
+        testID={ActionCenterTestIDs.pageBody}
+      >
         <MoreActionContentPage />
       </Page.Body>
     </Page>

--- a/packages/kit/src/views/Earn/components/EarnPageContainer.tsx
+++ b/packages/kit/src/views/Earn/components/EarnPageContainer.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useMemo } from 'react';
+import { Fragment, isValidElement, useCallback, useMemo } from 'react';
+
+import { useHeaderHeight } from '@react-navigation/elements';
 
 import type { IBreadcrumbProps, IScrollViewProps } from '@onekeyhq/components';
 import {
@@ -87,6 +89,108 @@ export function EarnPageContainer({
   const shouldShowTabPageHeader =
     platformEnv.isWebDappMode || showTabPageHeader;
 
+  // On iOS 26 push children, render via the native UINavigationBar so
+  // the header gets the system Liquid Glass material and the
+  // back-chevron sits in its proper iOS 26 circular glass container.
+  // Tab roots (showBackButton=false) keep TabPageHeader because they
+  // need account selector / notifications / search chrome that the
+  // native bar can't host as a single row.
+  const useNativeHeader = showBackButton && platformEnv.isNativeIOS26Plus;
+  // Liquid Glass header is translucent and the page content extends
+  // under it, so the ScrollView needs a top inset equal to the bar
+  // height — without it, the first content item sits clipped behind
+  // the navbar at scroll offset 0.
+  const nativeHeaderHeight = useHeaderHeight();
+
+  const renderNativeHeaderTitle = useCallback(
+    () =>
+      pageTitle ? (
+        <XStack gap="$2" ai="center">
+          {pageTitle}
+        </XStack>
+      ) : null,
+    [pageTitle],
+  );
+
+  // Callers (e.g. EarnProtocols) pass <></> on native to mean "hide the
+  // default right items of TabPageHeader". For the native Page.Header
+  // path we must NOT forward an empty fragment to headerRight — UIKit
+  // would still wrap the empty custom view in a bar button glass
+  // container and render a hollow circle. Treat null / undefined /
+  // false / empty Fragment as "no right item" and skip headerRight
+  // entirely so iOS 26 leaves the trailing slot empty.
+  const hasNativeHeaderRight = useMemo(() => {
+    const node = customHeaderRightItems;
+    if (node === null || node === undefined || node === false) return false;
+    if (
+      isValidElement(node) &&
+      node.type === Fragment &&
+      !(node as { props?: { children?: unknown } }).props?.children
+    ) {
+      return false;
+    }
+    return true;
+  }, [customHeaderRightItems]);
+
+  const renderNativeHeaderRight = useMemo(
+    () =>
+      hasNativeHeaderRight
+        ? () => <XStack>{customHeaderRightItems}</XStack>
+        : undefined,
+    [hasNativeHeaderRight, customHeaderRightItems],
+  );
+
+  const body = (
+    <Page.Body>
+      <ScrollView
+        testID={EarnTestIDs.earnPage}
+        contentContainerStyle={{
+          py: media.gtMd ? '$6' : 0,
+          ...contentContainerStyle,
+          ...(useNativeHeader ? { pt: nativeHeaderHeight } : {}),
+        }}
+        refreshControl={refreshControl}
+      >
+        <Page.Container
+          padded={false}
+          layout={disableMaxWidth ? 'full' : 'regular'}
+        >
+          {showBreadcrumb || showHeader ? (
+            <XStack
+              px="$pagePadding"
+              pb={showBreadcrumb && showBodyTitle && pageTitle ? '$6' : '$5'}
+              gap="$5"
+              ai="center"
+            >
+              {showBreadcrumb ? <Breadcrumb {...breadcrumbProps} /> : null}
+              {showHeader ? header : null}
+            </XStack>
+          ) : null}
+          {showBreadcrumb && showBodyTitle && pageTitle ? (
+            <XStack px="$pagePadding" pb="$5" gap="$3" ai="center">
+              {pageTitle}
+            </XStack>
+          ) : null}
+          {children}
+        </Page.Container>
+      </ScrollView>
+    </Page.Body>
+  );
+
+  if (useNativeHeader) {
+    return (
+      <Page>
+        <Page.Header
+          headerShown
+          headerTitle={renderNativeHeaderTitle}
+          headerRight={renderNativeHeaderRight}
+        />
+        {body}
+        {footer}
+      </Page>
+    );
+  }
+
   return (
     <Page>
       {shouldShowTabPageHeader ? (
@@ -102,39 +206,7 @@ export function EarnPageContainer({
           <LegacyUniversalSearchInput size="medium" initialTab="dapp" />
         </YStack>
       )}
-      <Page.Body>
-        <ScrollView
-          testID={EarnTestIDs.earnPage}
-          contentContainerStyle={{
-            py: media.gtMd ? '$6' : 0,
-            ...contentContainerStyle,
-          }}
-          refreshControl={refreshControl}
-        >
-          <Page.Container
-            padded={false}
-            layout={disableMaxWidth ? 'full' : 'regular'}
-          >
-            {showBreadcrumb || showHeader ? (
-              <XStack
-                px="$pagePadding"
-                pb={showBreadcrumb && showBodyTitle && pageTitle ? '$6' : '$5'}
-                gap="$5"
-                ai="center"
-              >
-                {showBreadcrumb ? <Breadcrumb {...breadcrumbProps} /> : null}
-                {showHeader ? header : null}
-              </XStack>
-            ) : null}
-            {showBreadcrumb && showBodyTitle && pageTitle ? (
-              <XStack px="$pagePadding" pb="$5" gap="$3" ai="center">
-                {pageTitle}
-              </XStack>
-            ) : null}
-            {children}
-          </Page.Container>
-        </ScrollView>
-      </Page.Body>
+      {body}
       {footer}
     </Page>
   );

--- a/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
+++ b/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef } from 'react';
 
 import { useRoute } from '@react-navigation/core';
+import { useHeaderHeight } from '@react-navigation/elements';
 import { useIntl } from 'react-intl';
 import { FlatList } from 'react-native';
 
@@ -73,6 +74,7 @@ function MarketBannerDetailContent({ title }: { title: string }) {
   const toDetailPage = useToDetailPage({ from: EEnterWay.BannerList });
   const { handleBackPress } = useMarketDetailBackNavigation();
   const { top } = useSafeAreaInsets();
+  const headerHeight = useHeaderHeight();
   const tabBarHeight = useTabBarHeight();
   const { gtMd } = useMedia();
 
@@ -212,6 +214,18 @@ function MarketBannerDetailContent({ title }: { title: string }) {
         />
       );
     }
+    // iOS 26 mobile uses the native UINavigationBar so the header gets
+    // Liquid Glass material and the system back chevron. Don't pass
+    // headerLeft — HeaderScreenOptions wires the system back button.
+    // headerShown is set explicitly because this route can also be
+    // reached as a modal (EModalMarketRoutes.MarketBannerDetail) where
+    // the modal-stack's screenOptions default to headerShown:false; the
+    // explicit prop ensures the bar renders in both navigation contexts.
+    // Notification icon is intentionally omitted — it belongs to the
+    // tab-level chrome (Market tab home), not to a banner detail page.
+    if (platformEnv.isNativeIOS26Plus) {
+      return <Page.Header headerShown headerTitle={renderHeaderTitle} />;
+    }
     return <Page.Header headerShown={false} />;
   }, [
     isWebDesktop,
@@ -229,7 +243,8 @@ function MarketBannerDetailContent({ title }: { title: string }) {
         </XStack>
       );
     }
-    if (!gtMd) {
+    // On iOS 26 mobile the title is in the native bar already.
+    if (!gtMd && !platformEnv.isNativeIOS26Plus) {
       return (
         <XStack ai="center" gap="$4" px="$4">
           {renderHeaderLeft()}
@@ -325,11 +340,20 @@ function MarketBannerDetailContent({ title }: { title: string }) {
     intl,
   ]);
 
+  let bodyTopInset: number;
+  if (gtMd) {
+    bodyTopInset = 0;
+  } else if (platformEnv.isNativeIOS26Plus) {
+    bodyTopInset = headerHeight;
+  } else {
+    bodyTopInset = top;
+  }
+
   return (
     <Page>
       {renderPageHeader}
       <Page.Body>
-        <Stack flex={1} pt={gtMd ? 0 : top} px={gtMd ? '$4' : 0} gap="$4">
+        <Stack flex={1} pt={bodyTopInset} px={gtMd ? '$4' : 0} gap="$4">
           {renderTitleSection}
           {renderTokenList}
         </Stack>

--- a/packages/kit/src/views/Market/MarketDetailV2/MarketDetailV2.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/MarketDetailV2.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useLayoutEffect } from 'react';
 
+import { useHeaderHeight } from '@react-navigation/elements';
 import { useFocusEffect } from '@react-navigation/native';
 
 import type { IPageScreenProps } from '@onekeyhq/components';
 import {
   Page,
   isNativeTablet,
+  useIsModalPage,
   useIsSplitView,
   useMedia,
 } from '@onekeyhq/components';
@@ -67,13 +69,24 @@ function MarketDetail({
   });
 
   const media = useMedia();
+  // iOS 26+ root-tab headers are translucent (Liquid Glass) so the page
+  // body extends under the bar — without an explicit top inset the
+  // chart / 图表 / 概述 tabs sit clipped behind the navbar position.
+  // The modal entry (EModalMarketRoutes.MarketDetailV2) renders against
+  // an opaque non-root header where react-native-screens already lays
+  // content out below the bar; adding headerHeight there would push the
+  // body down twice and leave a blank band at the top.
+  const isModalPage = useIsModalPage();
+  const headerHeight = useHeaderHeight();
+  const bodyPaddingTop =
+    platformEnv.isNativeIOS26Plus && !isModalPage ? headerHeight : 0;
 
   return (
     <BtcMetadataProvider>
       <Page>
         <MarketDetailHeader />
 
-        <Page.Body testID={MarketTestIDs.detailPage}>
+        <Page.Body pt={bodyPaddingTop} testID={MarketTestIDs.detailPage}>
           {media.gtLg && !platformEnv.isNative ? (
             <DesktopLayout />
           ) : (

--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketDetailHeader/MarketDetailHeader.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketDetailHeader/MarketDetailHeader.tsx
@@ -4,12 +4,14 @@ import {
   Icon,
   InteractiveIcon,
   NavBackButton,
+  Page,
   SizableText,
   XStack,
   YStack,
   useClipboard,
   useIsOverlayPage,
   useMedia,
+  useShare,
 } from '@onekeyhq/components';
 import { AccountSelectorTriggerHome } from '@onekeyhq/kit/src/components/AccountSelector';
 import { TabPageHeader } from '@onekeyhq/kit/src/components/TabPageHeader';
@@ -24,10 +26,15 @@ import {
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
-import { MarketStarV2 } from '../../../components/MarketStarV2';
+import {
+  MarketStarV2,
+  useStarV2Checked,
+} from '../../../components/MarketStarV2';
 import { TokenTagsPopover } from '../../../components/TokenTagsPopover';
+import { buildMarketFullUrlV2 } from '../../../marketUtils';
 import { EModalMarketRoutes } from '../../../router';
 import { useMarketDetailBackNavigation } from '../../hooks/useMarketDetailBackNavigation';
 import { useTokenDetail } from '../../hooks/useTokenDetail';
@@ -75,6 +82,151 @@ export function MarketDetailHeader() {
   );
 
   const customHeaderRight = useMemo(() => null, []);
+
+  // iOS 26+ mobile: render via the native UINavigationBar so the header
+  // gets the system Liquid Glass material and the back chevron sits in
+  // its proper iOS 26 circular glass container. The token symbol +
+  // dropdown chevron live in headerTitle; Star + Share live in
+  // headerRight. The address-copy secondary label that the custom pill
+  // used to render below the symbol is dropped here — single-row
+  // navigation bars can't host it cleanly. Pages that need the address
+  // can surface it in the body content.
+  const renderNativeHeaderTitle = useCallback(
+    () => (
+      <XStack ai="center" gap="$2" flex={1}>
+        <Token
+          size="sm"
+          tokenImageUri={tokenDetail?.logoUrl}
+          tokenImageUris={stableLogoUrls}
+          networkImageUri={networkLogoUri}
+          fallbackIcon="CryptoCoinOutline"
+        />
+        <XStack
+          ai="center"
+          gap="$1"
+          flexShrink={1}
+          {...(!isOverlayPage && {
+            onPress: onPressTokenSelector,
+            hoverStyle: { opacity: 0.8 },
+            pressStyle: { opacity: 0.6 },
+            cursor: 'pointer',
+          })}
+        >
+          <SizableText size="$headingLg" numberOfLines={1}>
+            {tokenDetail?.symbol || ''}
+          </SizableText>
+          {!isOverlayPage ? (
+            <Icon
+              name="ChevronDownSmallOutline"
+              size="$4"
+              color="$iconSubdued"
+            />
+          ) : null}
+        </XStack>
+      </XStack>
+    ),
+    [
+      tokenDetail?.logoUrl,
+      tokenDetail?.symbol,
+      stableLogoUrls,
+      networkLogoUri,
+      isOverlayPage,
+      onPressTokenSelector,
+    ],
+  );
+
+  // Drive native UIBarButtonItem-rendered SF Symbol buttons from the
+  // parent's React state. MarketDetailHeader is rendered inside the
+  // MarketWatchListProviderMirrorV2 so useStarV2Checked has access to
+  // the watchlist store; we only pass the resulting checked flag and
+  // onPress handler down to native via unstable_headerRightItems —
+  // there's no React subtree under the bar items, so no additional
+  // Mirror wrap is needed.
+  const { checked: starChecked, onPress: onStarPress } = useStarV2Checked({
+    chainId: networkId ?? '',
+    contractAddress: tokenDetail?.address ?? '',
+    from: EWatchlistFrom.Detail,
+    tokenSymbol: tokenDetail?.symbol ?? '',
+    isNative,
+  });
+
+  const { shareText } = useShare();
+
+  const handleShareNative = useCallback(() => {
+    if (!networkId) return;
+    const shortCode =
+      networkUtils.getNetworkShortCode({ networkId }) || networkId;
+    const url = buildMarketFullUrlV2({
+      network: shortCode,
+      address: tokenDetail?.address ?? '',
+      isNative,
+    });
+    void shareText(url);
+  }, [networkId, tokenDetail?.address, isNative, shareText]);
+
+  const handleStarNative = useCallback(() => {
+    void onStarPress();
+  }, [onStarPress]);
+
+  const buildNativeHeaderRightItems = useCallback(
+    () => [
+      {
+        type: 'button' as const,
+        label: 'Watchlist',
+        icon: {
+          type: 'sfSymbol' as const,
+          name: starChecked ? ('star.fill' as const) : ('star' as const),
+        },
+        onPress: handleStarNative,
+      },
+      {
+        type: 'button' as const,
+        label: 'Share',
+        icon: {
+          type: 'sfSymbol' as const,
+          name: 'square.and.arrow.up' as const,
+        },
+        onPress: handleShareNative,
+      },
+    ],
+    [starChecked, handleStarNative, handleShareNative],
+  );
+
+  // Drive the back button through useMarketDetailBackNavigation so the
+  // detail-specific routing (Search → Discovery, single-route stacks
+  // resetting to Market home, split-view pop, SwapPro return) keeps
+  // working under iOS 26's native bar. The default system back would
+  // only pop the current stack and would render no entry at all when
+  // state.index === 0.
+  const buildNativeHeaderLeftItems = useCallback(
+    () => [
+      {
+        type: 'button' as const,
+        label: 'Back',
+        icon: {
+          type: 'sfSymbol' as const,
+          name: 'chevron.left' as const,
+        },
+        onPress: handleBackPress,
+      },
+    ],
+    [handleBackPress],
+  );
+
+  if (media.md && platformEnv.isNativeIOS26Plus) {
+    // Explicit headerShown is required because this route can also be
+    // reached as a modal where the parent stack defaults headerShown to
+    // false; without it the bar wouldn't render and the page body would
+    // sit under the status bar.
+    return (
+      <Page.Header
+        headerShown
+        headerTitle={renderNativeHeaderTitle}
+        unstable_headerLeftItems={buildNativeHeaderLeftItems}
+        unstable_headerRightItems={buildNativeHeaderRightItems}
+      />
+    );
+  }
 
   return (
     <>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketDetailHeader/TabPageHeaderContainer.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketDetailHeader/TabPageHeaderContainer.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react';
 
+import { useHeaderHeight } from '@react-navigation/elements';
+
 import {
   Page,
   XStack,
@@ -16,12 +18,19 @@ export function TabPageHeaderContainer({
   children,
 }: ITabPageHeaderContainerProps) {
   const { top } = useSafeAreaInsets();
+  const headerHeight = useHeaderHeight();
   const isOverlayPage = useIsOverlayPage();
 
   // Skip top margin for modal pages on iOS, as modal has its own safe area handling
   const isIOSModalPage = platformEnv.isNativeIOS && isOverlayPage;
+  // On iOS 26 the screen options force headerTransparent: true so the
+  // page content extends under where the navigation bar would have sat.
+  // safe-area top alone (~50pt) doesn't clear that; we need the full
+  // header height (~94pt = safe area + bar). Falls back to the original
+  // safe-area behavior on iOS <26 / Android.
+  const topInset = platformEnv.isNativeIOS26Plus ? headerHeight : top;
   const shouldApplyTopMargin =
-    !isIOSModalPage && (top || platformEnv.isNativeAndroid);
+    !isIOSModalPage && (topInset || platformEnv.isNativeAndroid);
 
   return (
     <>
@@ -32,7 +41,7 @@ export function TabPageHeaderContainer({
         px="$5"
         minHeight="$12"
         py="$2"
-        {...(shouldApplyTopMargin ? { mt: top || '$2' } : {})}
+        {...(shouldApplyTopMargin ? { pt: topInset || '$2' } : {})}
       >
         {children}
       </XStack>

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { useHeaderHeight } from '@react-navigation/elements';
 import { useIntl } from 'react-intl';
 import { Dimensions, type LayoutChangeEvent } from 'react-native';
 
@@ -7,7 +8,6 @@ import type { IScrollViewRef } from '@onekeyhq/components';
 import {
   HeaderScrollGestureWrapper,
   Icon,
-  NavBackButton,
   Page,
   ScrollView,
   SizableText,
@@ -255,15 +255,16 @@ function MobilePerpMarket() {
     coin: activeTradeInstrument.coin,
     displayName: marketDetailDisplayName,
   });
+  // iOS 26's HeaderScreenOptions sets headerTransparent: true so the
+  // page content extends under the navigation bar. Page.Body has p="$0"
+  // here, which lets the chart and order book slide up behind the bar.
+  // Use the header height to push them back into view.
+  const headerHeight = useHeaderHeight();
 
   const onPressTokenSelector = useCallback(() => {
     navigation.pushModal(EModalRoutes.PerpModal, {
       screen: EModalPerpRoutes.MobileTokenSelector,
     });
-  }, [navigation]);
-
-  const onPageGoBack = useCallback(() => {
-    navigation.pop();
   }, [navigation]);
 
   const renderHeaderTitle = useCallback(() => {
@@ -275,44 +276,37 @@ function MobilePerpMarket() {
     } else {
       pairLabel = '--';
     }
+    // Match the MarketDetailV2 layout: Token + Symbol + dropdown sit
+    // in the native headerTitle slot. The system back chevron renders
+    // separately on the left via HeaderScreenOptions
+    // (headerBackButtonDisplayMode: 'minimal'), so we no longer wrap
+    // a NavBackButton inside this XStack — that's what was forcing
+    // UIKit to draw the whole thing as a single pill-shaped glass
+    // container on iOS 26.
     return (
-      <XStack alignItems="center" gap="$2">
-        <NavBackButton
-          hoverStyle={{ opacity: 0.8 }}
-          pressStyle={{ opacity: 0.6 }}
-          onPress={onPageGoBack}
+      <XStack
+        alignItems="center"
+        gap="$2"
+        onPress={onPressTokenSelector}
+        hoverStyle={{ opacity: 0.8 }}
+        pressStyle={{ opacity: 0.6 }}
+        cursor="default"
+      >
+        <Token
+          size="sm"
+          borderRadius="$full"
+          bg={themeVariant === 'light' ? undefined : '$bgInverse'}
+          tokenImageUri={
+            baseName ? getHyperliquidTokenImageUrl(baseName) : undefined
+          }
+          fallbackIcon="CryptoCoinOutline"
         />
-        <XStack
-          alignItems="center"
-          gap="$2"
-          onPress={onPressTokenSelector}
-          hoverStyle={{ opacity: 0.8 }}
-          pressStyle={{ opacity: 0.6 }}
-          cursor="default"
-        >
-          <Token
-            size="sm"
-            borderRadius="$full"
-            bg={themeVariant === 'light' ? undefined : '$bgInverse'}
-            tokenImageUri={
-              baseName ? getHyperliquidTokenImageUrl(baseName) : undefined
-            }
-            fallbackIcon="CryptoCoinOutline"
-          />
-          <SizableText size="$headingLg">{pairLabel}</SizableText>
-          <TradingModeBadge isSpot={mode === 'spot'} px="$1.5" />
-          <Icon name="ChevronDownSmallOutline" size="$4" color="$iconSubdued" />
-        </XStack>
+        <SizableText size="$headingLg">{pairLabel}</SizableText>
+        <TradingModeBadge isSpot={mode === 'spot'} px="$1.5" />
+        <Icon name="ChevronDownSmallOutline" size="$4" color="$iconSubdued" />
       </XStack>
     );
-  }, [
-    baseName,
-    displayName,
-    mode,
-    onPageGoBack,
-    onPressTokenSelector,
-    themeVariant,
-  ]);
+  }, [baseName, displayName, mode, onPressTokenSelector, themeVariant]);
 
   const isTablet = isNativeTablet();
   const isLandscape = useIsSplitView();
@@ -379,7 +373,8 @@ function MobilePerpMarket() {
   const pageHeader = useMemo(
     () => (
       <Page.Header
-        headerLeft={renderHeaderTitle}
+        headerShown
+        headerTitle={renderHeaderTitle}
         headerRight={renderHeaderRight}
       />
     ),
@@ -422,7 +417,12 @@ function MobilePerpMarket() {
     <Page scrollEnabled={pageScrollEnabled}>
       {pageHeader}
       <Page.Body p="$0">
-        <YStack flex={1} bg="$bgApp" onLayout={handleContainerLayout}>
+        <YStack
+          flex={1}
+          bg="$bgApp"
+          onLayout={handleContainerLayout}
+          pt={platformEnv.isNativeIOS26Plus ? headerHeight : 0}
+        >
           <MobilePerpMarketTabBar
             activeTab={activeTab}
             onChange={handleChangeActiveTab}

--- a/packages/shared/src/platformEnv.ts
+++ b/packages/shared/src/platformEnv.ts
@@ -137,6 +137,8 @@ export type IPlatformEnv = {
   /** ios, tablet only */
   isNativeIOSPad?: boolean;
   isNativeIOSPadStore?: boolean;
+  /** ios 26+, used to opt into Liquid Glass UIKit defaults */
+  isNativeIOS26Plus?: boolean;
   isNativeAndroid?: boolean;
   isNativeAndroidGooglePlay?: boolean;
   isNativeAndroidHuawei?: boolean;
@@ -227,6 +229,8 @@ const isNativeIOSPhone =
   isNative && Platform.OS === 'ios' && !Platform.isPad && !Platform.isTV;
 const isNativeIOSPad = isNative && Platform.OS === 'ios' && Platform.isPad;
 const isNativeIOSPadStore = isNativeIOSPad && isProduction;
+const isNativeIOS26Plus =
+  isNativeIOS && parseInt(String(Platform.Version), 10) >= 26;
 const isNativeAndroid = isNative && Platform.OS === 'android';
 const androidChannel = ANDROID_CHANNEL;
 const isNativeAndroidGooglePlay =
@@ -579,6 +583,7 @@ const platformEnv: IPlatformEnv = {
   isNativeIOSPhone,
   isNativeIOSPad,
   isNativeIOSPadStore,
+  isNativeIOS26Plus,
   isNativeAndroid,
   isNativeAndroidGooglePlay,
   isNativeAndroidHuawei,

--- a/patches/react-native-screens+4.23.0.patch
+++ b/patches/react-native-screens+4.23.0.patch
@@ -805,3 +805,45 @@ index 3e21388..e4f4785 100644
          break;
        }
        parentView = (UIView *)parentView.reactSuperview;
+diff --git a/node_modules/react-native-screens/ios/RNSScreenStackHeaderConfig.mm b/node_modules/react-native-screens/ios/RNSScreenStackHeaderConfig.mm
+index 3270127..3df3e65 100644
+--- a/node_modules/react-native-screens/ios/RNSScreenStackHeaderConfig.mm
++++ b/node_modules/react-native-screens/ios/RNSScreenStackHeaderConfig.mm
+@@ -451,7 +451,18 @@
+       appearance.shadowImage = shadowImage;
+     }
+   } else {
+-    [appearance configureWithOpaqueBackground];
++    // OneKey: when caller did not pass an explicit backgroundColor on iOS 26+, use
++    // configureWithDefaultBackground so UIKit applies the system Liquid Glass material.
++    // configureWithOpaqueBackground would forcibly opaque-fill the bar and suppress glass.
++    if (@available(iOS 26.0, *)) {
++      if (config.backgroundColor == nil) {
++        [appearance configureWithDefaultBackground];
++      } else {
++        [appearance configureWithOpaqueBackground];
++      }
++    } else {
++      [appearance configureWithOpaqueBackground];
++    }
+   }
+ 
+   // set background color if specified
+@@ -461,7 +472,16 @@
+ 
+   switch (config.blurEffect) {
+     case RNSBlurEffectStyleNone:
+-      appearance.backgroundEffect = nil;
++      // OneKey: on iOS 26+ with no caller-supplied backgroundColor, preserve the system
++      // Liquid Glass effect installed by configureWithDefaultBackground above. Clearing
++      // backgroundEffect here would defeat the whole point of opting in.
++      if (@available(iOS 26.0, *)) {
++        if (config.backgroundColor != nil) {
++          appearance.backgroundEffect = nil;
++        }
++      } else {
++        appearance.backgroundEffect = nil;
++      }
+       break;
+ 
+     case RNSBlurEffectStyleSystemDefault:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9800,7 +9800,6 @@ __metadata:
     react-native-markdown-display: "npm:7.0.2"
     react-native-root-siblings: "npm:^5.0.1"
     react-native-svg: "npm:15.15.1"
-    react-native-tab-view: "npm:^3.5.1"
     rimraf: "npm:3.0.2"
   languageName: unknown
   linkType: soft
@@ -41755,19 +41754,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-tab-view@npm:^3.5.1":
-  version: 3.5.2
-  resolution: "react-native-tab-view@npm:3.5.2"
-  dependencies:
-    use-latest-callback: "npm:^0.1.5"
-  peerDependencies:
-    react: "*"
-    react-native: "*"
-    react-native-pager-view: "*"
-  checksum: 10/417e608dab14c23277e48e583e0573e90b136fa87ccf3907d104da3717e7b2d0889d699b2341f35e2bbaad9dea89255398ac60f4380d84a042ba77759409a550
-  languageName: node
-  linkType: hard
-
 "react-native-tcp-socket@npm:@onekeyfe/react-native-tcp-socket@3.0.37":
   version: 3.0.37
   resolution: "@onekeyfe/react-native-tcp-socket@npm:3.0.37"
@@ -47476,15 +47462,6 @@ __metadata:
   peerDependencies:
     react: ">=16.8.0"
   checksum: 10/4412c771a195729b7ec1b1e885141b097001adfce1e206d26b70f379ffd7dcaf5eeefec66bf82dfbcbcefe61cacbd1d5b6749b56e48987d46c330853b9e457eb
-  languageName: node
-  linkType: hard
-
-"use-latest-callback@npm:^0.1.5":
-  version: 0.1.9
-  resolution: "use-latest-callback@npm:0.1.9"
-  peerDependencies:
-    react: ">=16.8"
-  checksum: 10/620969d85763b65aca5f9b601c31eb476a8f7602cfccfb3c0f9dc60ff3b863e04dd64360ada255e15606771513de33b25e4631607d702605b26630f61381b3d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-54175](https://onekeyhq.atlassian.net/browse/OK-54175)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Reverts the revert in #11492, reapplying the original #11468 Liquid Glass adoption for iOS 26+ stack headers and the bottom tab bar.
- Picks up the post-revert evolution on `x` while reconciling conflicts in 6 files (HeaderIconButton, HeaderScreenOptions, ActionCenter, EarnPageContainer, MarketDetailV2, MobilePerpMarket) and yarn.lock.
- `react-native-tab-view@3.5.x` dependency is dropped again (already unused; @onekeyfe fork is the live one).

## Conflict resolution notes

- `HeaderIconButton.tsx` — kept the new `className="app-region-no-drag"` from `x` AND restored the iOS 26 `m: 0` override.
- `HeaderScreenOptions.tsx` — restored `...headerLeftOptions` spread; merged the new `isWebViewScreen` prop into the non-iOS26 `HeaderBackButton` branch.
- `ActionCenter.tsx` — combined `mt={platformEnv.isNativeIOS26Plus ? 0 : top}` with the new `testID={ActionCenterTestIDs.pageBody}`.
- `EarnPageContainer.tsx` — restored the extracted `body` variable; added the new `testID={EarnTestIDs.earnPage}` on its `ScrollView`.
- `MarketDetailV2.tsx` — kept `pt={bodyPaddingTop}` and merged in the new `testID={MarketTestIDs.detailPage}`.
- `MobilePerpMarket.tsx` — merged the imports, kept the post-revert unified `pageScrollEnabled` layout, and applied `pt={platformEnv.isNativeIOS26Plus ? headerHeight : 0}` to the unified iOS 26 container instead of the old separate iOS branch.

## Test plan

- [ ] CI typecheck + lint pass
- [ ] iOS 26 (real device): root tab screens and pushed screens show the system Liquid Glass material on UINavigationBar / UITabBar
- [ ] iOS <26: navigation chrome is visually unchanged
- [ ] Web / Android / Desktop: visually unchanged
- [ ] Earn / Market detail / MobilePerpMarket / ActionCenter pages still render correctly and the new testIDs still resolve

[OK-54175]: https://onekeyhq.atlassian.net/browse/OK-54175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ