### PR TITLE
fix: suppress WalletUpdate events during backup restore to improve performance

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -3544,7 +3544,11 @@ class ServiceAccount extends ServiceBase {
 
     await timerUtils.wait(100);
 
-    appEventBus.emit(EAppEventBusNames.WalletUpdate, undefined);
+    const isInImportFlow =
+      await this.backgroundApi.servicePrimeTransfer.isInTransferImportOrBackupRestoreFlow();
+    if (!isInImportFlow) {
+      appEventBus.emit(EAppEventBusNames.WalletUpdate, undefined);
+    }
     return result;
   }
 

--- a/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
+++ b/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
@@ -2234,6 +2234,7 @@ class ServicePrimeTransfer extends ServiceBase {
         refreshHook: prev.refreshHook + 1,
       }));
       await timerUtils.wait(300);
+      appEventBus.emit(EAppEventBusNames.WalletUpdate, undefined);
       appEventBus.emit(EAppEventBusNames.AccountUpdate, undefined);
     },
     1500,
@@ -2560,6 +2561,7 @@ class ServicePrimeTransfer extends ServiceBase {
             name: wallet.name,
             avatar: wallet.avatarInfo,
             applyRestoreSyncPolicy: true,
+            skipEmitEvent: true,
           });
         }
       } catch (e) {


### PR DESCRIPTION
## Summary

- Suppress `WalletUpdate` event emission during iCloud/transfer import flow
- Emit `WalletUpdate` once at the end when import completes
- Add `skipEmitEvent: true` to `setWalletNameAndAvatar` call during import

## Problem

During iCloud/transfer import with 6 wallets and 120 accounts, the import slowed down dramatically at 80-90% progress (from ~1m20s to ~3m). 

Root cause: Each wallet creation emitted `WalletUpdate` events, triggering:
1. `clearAccountCache()` calls in ServiceAccount
2. UI re-renders and SWR cache invalidation  
3. `autoSelectNextAccount` operations with additional `clearAccountCache()` + `getAllHdHwQrWallets()` calls

Log analysis showed **98 long tasks** totaling **97.8 seconds** of blocking time during the slowdown period, with memory spiking to **1181MB** and CPU at **97.8%**.

## Solution

Check `isInTransferImportOrBackupRestoreFlow()` before emitting `WalletUpdate` in `createHDWalletWithRs`, and emit it once at the end in `finallyImportProgress`.

## Test plan

- [ ] Test iCloud backup restore with multiple wallets (6+ wallets, 100+ accounts)
- [ ] Verify import completes in ~1m20s instead of ~3m
- [ ] Verify wallet list updates correctly after import completes
- [ ] Verify no regression in normal wallet creation flow

## Slack thread

https://onekeygroup.slack.com/archives/C02BL8XSJ4D/p1779781306500809?thread_ts=1779765357.537399&cid=C02BL8XSJ4D

https://claude.ai/code/session_01KHzJqMga29rMZNX1bdk4YZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHzJqMga29rMZNX1bdk4YZ)_