### PR TITLE
fix: improve chainlist search with pagination, fastest RPC selection, and retry logic(OK-55324)(OK-55319)(OK-55303)

### DIFF
--- a/packages/kit-bg/src/services/ServiceCustomRpc.ts
+++ b/packages/kit-bg/src/services/ServiceCustomRpc.ts
@@ -38,11 +38,11 @@ class ServiceCustomRpc extends ServiceBase {
   private buildChainListRequestParams(params: {
     keywords?: string;
     page?: number;
-  }) {
-    const keywords = params.keywords?.trim();
+  }): { keywords?: string; page: number; showTestNet: boolean } {
+    const keywords = params.keywords?.trim() || undefined;
     const page = Math.max(1, Math.floor(params.page ?? 1));
     return {
-      ...(keywords ? { keywords } : {}),
+      keywords,
       page,
       showTestNet: true,
     };
@@ -584,26 +584,20 @@ class ServiceCustomRpc extends ServiceBase {
     keywords?: string;
     page?: number;
   }): Promise<IChainListItem[]> {
-    const keywords = params.keywords?.trim();
-    const page = Math.max(1, Math.floor(params.page ?? 1));
+    const requestParams = this.buildChainListRequestParams(params);
     // Keyword search: always hit API, no cache.
     // Errors are propagated so callers can distinguish network failures
     // from genuinely empty result sets.
-    if (keywords) {
+    if (requestParams.keywords) {
       const client = await this.getClient(EServiceEndpointEnum.Wallet);
       const resp = await client.get<{ data: IChainListItem[] }>(
         '/wallet/v1/network/chainlist',
-        {
-          params: this.buildChainListRequestParams({
-            keywords,
-            page,
-          }),
-        },
+        { params: requestParams },
       );
       return resp.data.data || [];
     }
 
-    return this.fetchChainListPage(page);
+    return this.fetchChainListPage(requestParams.page);
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceCustomRpc.ts
+++ b/packages/kit-bg/src/services/ServiceCustomRpc.ts
@@ -323,7 +323,11 @@ class ServiceCustomRpc extends ServiceBase {
       rpcUrl: params.rpcUrl,
       validateChainId: false,
     });
-    if (Number(result.chainId) !== Number(params.chainId)) {
+    if (
+      !new BigNumber(result.chainId ?? 0).isEqualTo(
+        new BigNumber(params.chainId),
+      )
+    ) {
       throw new OneKeyError('Invalid chainId');
     }
     return result;

--- a/packages/kit-bg/src/services/ServiceCustomRpc.ts
+++ b/packages/kit-bg/src/services/ServiceCustomRpc.ts
@@ -7,6 +7,7 @@ import {
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { IMPL_EVM } from '@onekeyhq/shared/src/engine/engineConsts';
+import { OneKeyError } from '@onekeyhq/shared/src/errors';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -308,6 +309,24 @@ class ServiceCustomRpc extends ServiceBase {
     return {
       chainId: result.chainId,
     };
+  }
+
+  @backgroundMethod()
+  public async measureCustomNetworkRpcStatus(params: {
+    rpcUrl: string;
+    chainId: number;
+  }) {
+    const vault = await vaultFactory.getChainOnlyVault({
+      networkId: getNetworkIdsMap().eth,
+    });
+    const result = await vault.getCustomRpcEndpointStatus({
+      rpcUrl: params.rpcUrl,
+      validateChainId: false,
+    });
+    if (Number(result.chainId) !== Number(params.chainId)) {
+      throw new OneKeyError('Invalid chainId');
+    }
+    return result;
   }
 
   async upsertCustomNetworkInfo({

--- a/packages/kit-bg/src/services/ServiceCustomRpc.ts
+++ b/packages/kit-bg/src/services/ServiceCustomRpc.ts
@@ -34,12 +34,25 @@ import ServiceBase from './ServiceBase';
 class ServiceCustomRpc extends ServiceBase {
   private semaphore = new Semaphore(1);
 
+  private buildChainListRequestParams(params: {
+    keywords?: string;
+    page?: number;
+  }) {
+    const keywords = params.keywords?.trim();
+    const page = Math.max(1, Math.floor(params.page ?? 1));
+    return {
+      ...(keywords ? { keywords } : {}),
+      page,
+      showTestNet: true,
+    };
+  }
+
   private fetchChainListPage = memoizee(
     async (page: number): Promise<IChainListItem[]> => {
       const client = await this.getClient(EServiceEndpointEnum.Wallet);
       const resp = await client.get<{ data: IChainListItem[] }>(
         '/wallet/v1/network/chainlist',
-        { params: { page, showTestNet: true } },
+        { params: this.buildChainListRequestParams({ page }) },
       );
       return resp.data.data || [];
     },
@@ -548,19 +561,25 @@ class ServiceCustomRpc extends ServiceBase {
     keywords?: string;
     page?: number;
   }): Promise<IChainListItem[]> {
+    const keywords = params.keywords?.trim();
+    const page = Math.max(1, Math.floor(params.page ?? 1));
     // Keyword search: always hit API, no cache.
     // Errors are propagated so callers can distinguish network failures
     // from genuinely empty result sets.
-    if (params.keywords) {
+    if (keywords) {
       const client = await this.getClient(EServiceEndpointEnum.Wallet);
       const resp = await client.get<{ data: IChainListItem[] }>(
         '/wallet/v1/network/chainlist',
-        { params: { keywords: params.keywords, showTestNet: true } },
+        {
+          params: this.buildChainListRequestParams({
+            keywords,
+            page,
+          }),
+        },
       );
       return resp.data.data || [];
     }
 
-    const page = Math.max(1, Math.floor(params.page ?? 1));
     return this.fetchChainListPage(page);
   }
 
@@ -572,10 +591,10 @@ class ServiceCustomRpc extends ServiceBase {
       const resp = await client.get<{ data: IChainListItem[] }>(
         '/wallet/v1/network/chainlist',
         {
-          params: {
-            keywords: chainId,
-            showTestNet: true,
-          },
+          params: this.buildChainListRequestParams({
+            keywords: String(chainId),
+            page: 1,
+          }),
         },
       );
       return (

--- a/packages/kit/src/views/ChainSelector/pages/ChainListSearch.tsx
+++ b/packages/kit/src/views/ChainSelector/pages/ChainListSearch.tsx
@@ -47,21 +47,35 @@ type IChainListSearchRoute = RouteProp<
   | EModalSettingRoutes.SettingChainListSearch
 >;
 
-function pickBestRpcUrl(rpcUrls: string[]): string {
-  const httpUrls = rpcUrls.filter(
+type IMeasuredRpcUrl = {
+  rpcUrl: string;
+  responseTime: number;
+};
+
+function getCandidateRpcUrls(rpcUrls: string[]): string[] {
+  return rpcUrls.filter(
     (url) =>
       !url.includes('${') &&
       (url.startsWith('https://') || url.startsWith('http://')),
   );
-  const httpsUrl = httpUrls.find((url) => url.startsWith('https://'));
-  if (httpsUrl) return httpsUrl;
-  if (httpUrls.length > 0) return httpUrls[0];
-  // Fallback: leave empty so user fills it manually
-  return '';
 }
 
 function normalizeSearchKeywords(text?: string): string {
   return text?.trim() ?? '';
+}
+
+function pickFastestRpcUrl({
+  results,
+  fallbackRpcUrl,
+}: {
+  results: PromiseSettledResult<IMeasuredRpcUrl>[];
+  fallbackRpcUrl: string;
+}): string {
+  const availableRpcUrls = results
+    .filter((result) => result.status === 'fulfilled')
+    .map((result) => result.value)
+    .toSorted((a, b) => a.responseTime - b.responseTime);
+  return availableRpcUrls[0]?.rpcUrl ?? fallbackRpcUrl;
 }
 
 function ChainListSearchSkeletonList() {
@@ -104,6 +118,9 @@ function ChainListSearch() {
     new Set(),
   );
   const [hasError, setHasError] = useState(false);
+  const [measuringChainId, setMeasuringChainId] = useState<
+    number | undefined
+  >();
 
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isSearchingRef = useRef(false);
@@ -172,6 +189,13 @@ function ChainListSearch() {
   useEffect(() => {
     void reloadDefaultList();
   }, [reloadDefaultList]);
+
+  const visibleItems = useMemo(
+    () => items.filter((item) => getCandidateRpcUrls(item.rpc).length > 0),
+    [items],
+  );
+
+  const isMeasuringRpc = measuringChainId !== undefined;
 
   // Load more pages (pagination)
   const handleEndReached = useCallback(async () => {
@@ -304,20 +328,59 @@ function ChainListSearch() {
   );
 
   const handleSelectNetwork = useCallback(
-    (item: IChainListItem) => {
+    async (item: IChainListItem) => {
+      if (isMeasuringRpc) {
+        return;
+      }
+      const candidateRpcUrls = getCandidateRpcUrls(item.rpc);
+      if (!candidateRpcUrls.length) {
+        return;
+      }
       defaultLogger.setting.page.chainListNetworkSelected({
         chainId: String(item.chainId),
         networkName: item.name,
       });
+      let rpcUrl = candidateRpcUrls[0];
+      if (candidateRpcUrls.length > 1) {
+        setMeasuringChainId(item.chainId);
+        try {
+          const results = await Promise.allSettled(
+            candidateRpcUrls.map(async (candidateRpcUrl) => {
+              const result =
+                await backgroundApiProxy.serviceCustomRpc.measureCustomNetworkRpcStatus(
+                  {
+                    rpcUrl: candidateRpcUrl,
+                    chainId: item.chainId,
+                  },
+                );
+              return {
+                rpcUrl: candidateRpcUrl,
+                responseTime: result.responseTime,
+              };
+            }),
+          );
+          rpcUrl = pickFastestRpcUrl({
+            results,
+            fallbackRpcUrl: candidateRpcUrls[0],
+          });
+        } finally {
+          if (mountedRef.current) {
+            setMeasuringChainId(undefined);
+          }
+        }
+      }
+      if (!mountedRef.current) {
+        return;
+      }
       pushFormPage({
         networkName: item.name,
-        rpcUrl: pickBestRpcUrl(item.rpc),
+        rpcUrl,
         chainId: item.chainId,
         symbol: item.nativeCurrency?.symbol ?? '',
         blockExplorerUrl: item.explorers?.[0]?.url ?? '',
       });
     },
-    [pushFormPage],
+    [isMeasuringRpc, pushFormPage, mountedRef],
   );
 
   const handleManualAdd = useCallback(() => {
@@ -356,25 +419,43 @@ function ChainListSearch() {
   const renderItem = useCallback(
     ({ item }: { item: IChainListItem }) => {
       const isExisting = isNetworkExisting(item.chainId);
+      const isMeasuring = measuringChainId === item.chainId;
+      const rightContent = (() => {
+        if (isMeasuring) {
+          return <Spinner size="small" />;
+        }
+        if (isExisting) {
+          return (
+            <SizableText size="$bodyMd" color="$textSubdued">
+              {intl.formatMessage({ id: ETranslations.added })}
+            </SizableText>
+          );
+        }
+        return null;
+      })();
       return (
         <ListItem
           h={60}
-          disabled={isExisting}
+          disabled={isExisting || isMeasuringRpc}
           opacity={isExisting ? 0.5 : 1}
           renderAvatar={<LetterAvatar letter={item.name?.[0]} size="$10" />}
           title={item.name}
           subtitle={`Symbol: ${item.nativeCurrency?.symbol ?? '-'}    ID: ${item.chainId}`}
-          onPress={() => handleSelectNetwork(item)}
+          onPress={() => {
+            void handleSelectNetwork(item);
+          }}
         >
-          {isExisting ? (
-            <SizableText size="$bodyMd" color="$textSubdued">
-              {intl.formatMessage({ id: ETranslations.added })}
-            </SizableText>
-          ) : null}
+          {rightContent}
         </ListItem>
       );
     },
-    [isNetworkExisting, intl, handleSelectNetwork],
+    [
+      isNetworkExisting,
+      measuringChainId,
+      isMeasuringRpc,
+      intl,
+      handleSelectNetwork,
+    ],
   );
 
   const listFooter = useMemo(() => {
@@ -430,7 +511,7 @@ function ChainListSearch() {
           <ChainListSearchSkeletonList />
         ) : (
           <ListView
-            data={items}
+            data={visibleItems}
             estimatedItemSize={60}
             keyExtractor={(item) => String(item.chainId)}
             renderItem={renderItem}

--- a/packages/kit/src/views/ChainSelector/pages/ChainListSearch.tsx
+++ b/packages/kit/src/views/ChainSelector/pages/ChainListSearch.tsx
@@ -54,6 +54,8 @@ type IMeasuredRpcUrl = {
 
 const CHAIN_LIST_RETRY_DELAYS_MS = [2000, 5000, 10_000] as const;
 const CHAIN_LIST_RETRY_INTERVAL_MS = 60_000;
+const RPC_MEASURE_TIMEOUT_MS = 10_000;
+const RPC_MEASURE_MAX_CANDIDATES = 5;
 
 type IChainListLoadRequest = {
   append: boolean;
@@ -78,6 +80,32 @@ function getCandidateRpcUrls(rpcUrls: string[]): string[] {
 
 function normalizeSearchKeywords(text?: string): string {
   return text?.trim() ?? '';
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Timeout')), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function selectTopCandidateRpcUrls(
+  rpcUrls: string[],
+  max: number,
+): string[] {
+  const candidates = getCandidateRpcUrls(rpcUrls);
+  const httpsUrls = candidates.filter((url) => url.startsWith('https://'));
+  const httpUrls = candidates.filter((url) => !url.startsWith('https://'));
+  return [...httpsUrls, ...httpUrls].slice(0, max);
 }
 
 function pickFastestRpcUrl({
@@ -230,7 +258,13 @@ function ChainListSearch() {
           if (result.length === 0) {
             setHasMore(false);
           } else {
-            setItems((prev) => [...prev, ...result]);
+            setItems((prev) => {
+              const existingIds = new Set(prev.map((p) => p.chainId));
+              const newItems = result.filter(
+                (r) => !existingIds.has(r.chainId),
+              );
+              return [...prev, ...newItems];
+            });
             setHasMore(true);
             setCurrentPage(request.page);
           }
@@ -322,7 +356,7 @@ function ChainListSearch() {
   }, [reloadDefaultList]);
 
   const visibleItems = useMemo(
-    () => items.filter((item) => getCandidateRpcUrls(item.rpc).length > 0),
+    () => items.filter((item) => item.rpc.length > 0),
     [items],
   );
 
@@ -424,27 +458,29 @@ function ChainListSearch() {
       if (isMeasuringRpc) {
         return;
       }
-      const candidateRpcUrls = getCandidateRpcUrls(item.rpc);
-      if (!candidateRpcUrls.length) {
-        return;
-      }
       defaultLogger.setting.page.chainListNetworkSelected({
         chainId: String(item.chainId),
         networkName: item.name,
       });
-      let rpcUrl = candidateRpcUrls[0];
+      const candidateRpcUrls = selectTopCandidateRpcUrls(
+        item.rpc,
+        RPC_MEASURE_MAX_CANDIDATES,
+      );
+      let rpcUrl = candidateRpcUrls[0] ?? '';
       if (candidateRpcUrls.length > 1) {
         setMeasuringChainId(item.chainId);
         try {
           const results = await Promise.allSettled(
             candidateRpcUrls.map(async (candidateRpcUrl) => {
-              const result =
-                await backgroundApiProxy.serviceCustomRpc.measureCustomNetworkRpcStatus(
+              const result = await withTimeout(
+                backgroundApiProxy.serviceCustomRpc.measureCustomNetworkRpcStatus(
                   {
                     rpcUrl: candidateRpcUrl,
                     chainId: item.chainId,
                   },
-                );
+                ),
+                RPC_MEASURE_TIMEOUT_MS,
+              );
               return {
                 rpcUrl: candidateRpcUrl,
                 responseTime: result.responseTime,
@@ -455,6 +491,8 @@ function ChainListSearch() {
             results,
             fallbackRpcUrl: candidateRpcUrls[0],
           });
+        } catch {
+          rpcUrl = candidateRpcUrls[0];
         } finally {
           if (mountedRef.current) {
             setMeasuringChainId(undefined);
@@ -528,7 +566,7 @@ function ChainListSearch() {
       return (
         <ListItem
           h={60}
-          disabled={isExisting || isMeasuringRpc}
+          disabled={isExisting || isMeasuring}
           opacity={isExisting ? 0.5 : 1}
           renderAvatar={<LetterAvatar letter={item.name?.[0]} size="$10" />}
           title={item.name}
@@ -544,7 +582,6 @@ function ChainListSearch() {
     [
       isNetworkExisting,
       measuringChainId,
-      isMeasuringRpc,
       intl,
       handleSelectNetwork,
     ],

--- a/packages/kit/src/views/ChainSelector/pages/ChainListSearch.tsx
+++ b/packages/kit/src/views/ChainSelector/pages/ChainListSearch.tsx
@@ -98,10 +98,7 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   });
 }
 
-function selectTopCandidateRpcUrls(
-  rpcUrls: string[],
-  max: number,
-): string[] {
+function selectTopCandidateRpcUrls(rpcUrls: string[], max: number): string[] {
   const candidates = getCandidateRpcUrls(rpcUrls);
   const httpsUrls = candidates.filter((url) => url.startsWith('https://'));
   const httpUrls = candidates.filter((url) => !url.startsWith('https://'));
@@ -579,12 +576,7 @@ function ChainListSearch() {
         </ListItem>
       );
     },
-    [
-      isNetworkExisting,
-      measuringChainId,
-      intl,
-      handleSelectNetwork,
-    ],
+    [isNetworkExisting, measuringChainId, intl, handleSelectNetwork],
   );
 
   const listFooter = useMemo(() => {

--- a/packages/kit/src/views/ChainSelector/pages/ChainListSearch.tsx
+++ b/packages/kit/src/views/ChainSelector/pages/ChainListSearch.tsx
@@ -52,6 +52,22 @@ type IMeasuredRpcUrl = {
   responseTime: number;
 };
 
+const CHAIN_LIST_RETRY_DELAYS_MS = [2000, 5000, 10_000] as const;
+const CHAIN_LIST_RETRY_INTERVAL_MS = 60_000;
+
+type IChainListLoadRequest = {
+  append: boolean;
+  isRetry?: boolean;
+  keywords?: string;
+  page: number;
+};
+
+function getChainListRetryDelayMs(retryAttempt: number): number {
+  return (
+    CHAIN_LIST_RETRY_DELAYS_MS[retryAttempt] ?? CHAIN_LIST_RETRY_INTERVAL_MS
+  );
+}
+
 function getCandidateRpcUrls(rpcUrls: string[]): string[] {
   return rpcUrls.filter(
     (url) =>
@@ -123,6 +139,14 @@ function ChainListSearch() {
   >();
 
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const chainListRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const chainListRetryAttemptRef = useRef(0);
+  const chainListRetryRequestRef = useRef<IChainListLoadRequest | null>(null);
+  const loadChainListRef = useRef<
+    ((request: IChainListLoadRequest) => Promise<void>) | null
+  >(null);
   const isSearchingRef = useRef(false);
   const activeKeywordsRef = useRef('');
   // Monotonic id bumped on every list-replacing op (initial load, reload,
@@ -132,6 +156,131 @@ function ChainListSearch() {
   // requests before isLoadingMore state has propagated.
   const loadingMoreRef = useRef(false);
   const mountedRef = useIsMounted();
+
+  const clearChainListRetryTimer = useCallback(() => {
+    if (chainListRetryTimerRef.current) {
+      clearTimeout(chainListRetryTimerRef.current);
+      chainListRetryTimerRef.current = null;
+    }
+    chainListRetryAttemptRef.current = 0;
+    chainListRetryRequestRef.current = null;
+  }, []);
+
+  const scheduleChainListRetry = useCallback(
+    (request: IChainListLoadRequest) => {
+      if (!mountedRef.current) {
+        return;
+      }
+      if (chainListRetryTimerRef.current) {
+        clearTimeout(chainListRetryTimerRef.current);
+      }
+      const delay = getChainListRetryDelayMs(chainListRetryAttemptRef.current);
+      chainListRetryRequestRef.current = {
+        ...request,
+        isRetry: true,
+      };
+      chainListRetryTimerRef.current = setTimeout(() => {
+        chainListRetryTimerRef.current = null;
+        chainListRetryAttemptRef.current += 1;
+        const retryRequest = chainListRetryRequestRef.current;
+        if (!retryRequest) {
+          return;
+        }
+        void loadChainListRef.current?.({
+          ...retryRequest,
+          isRetry: true,
+        });
+      }, delay);
+    },
+    [mountedRef],
+  );
+
+  const loadChainList = useCallback(
+    async (request: IChainListLoadRequest) => {
+      const keywords = normalizeSearchKeywords(request.keywords);
+      if (!request.isRetry) {
+        clearChainListRetryTimer();
+      }
+      listReqIdRef.current += 1;
+      const reqId = listReqIdRef.current;
+      const isFirstPage = !request.append && request.page === 1;
+      const isSearchRequest = !!keywords;
+      try {
+        if (!request.isRetry) {
+          setHasError(false);
+          if (isFirstPage) {
+            setIsInitialLoading(!isSearchRequest);
+            isSearchingRef.current = isSearchRequest;
+            setIsSearching(isSearchRequest);
+          }
+        }
+        if (request.append) {
+          loadingMoreRef.current = true;
+          setIsLoadingMore(true);
+        }
+        const result =
+          await backgroundApiProxy.serviceCustomRpc.searchChainListByKeywords({
+            keywords: keywords || undefined,
+            page: request.page,
+          });
+        if (!mountedRef.current || reqId !== listReqIdRef.current) return;
+        setHasError(false);
+        clearChainListRetryTimer();
+        if (request.append) {
+          if (result.length === 0) {
+            setHasMore(false);
+          } else {
+            setItems((prev) => [...prev, ...result]);
+            setHasMore(true);
+            setCurrentPage(request.page);
+          }
+          return;
+        }
+        activeKeywordsRef.current = keywords;
+        setItems(result);
+        setHasMore(result.length > 0);
+        setCurrentPage(request.page);
+      } catch {
+        if (!mountedRef.current || reqId !== listReqIdRef.current) return;
+        if (request.append) {
+          setHasMore(false);
+        } else {
+          setHasError(true);
+          activeKeywordsRef.current = keywords;
+          setItems([]);
+          setHasMore(false);
+          setCurrentPage(1);
+        }
+        scheduleChainListRetry({
+          append: request.append,
+          keywords,
+          page: request.page,
+        });
+      } finally {
+        if (request.append) {
+          loadingMoreRef.current = false;
+          if (mountedRef.current) {
+            setIsLoadingMore(false);
+          }
+        }
+        if (
+          !request.append &&
+          !request.isRetry &&
+          mountedRef.current &&
+          reqId === listReqIdRef.current
+        ) {
+          setIsInitialLoading(false);
+          isSearchingRef.current = false;
+          setIsSearching(false);
+        }
+      }
+    },
+    [clearChainListRetryTimer, mountedRef, scheduleChainListRetry],
+  );
+
+  useEffect(() => {
+    loadChainListRef.current = loadChainList;
+  }, [loadChainList]);
 
   const refreshExistingNetworks = useCallback(async () => {
     try {
@@ -161,29 +310,11 @@ function ChainListSearch() {
   }, [refreshExistingNetworks]);
 
   const reloadDefaultList = useCallback(async () => {
-    listReqIdRef.current += 1;
-    const reqId = listReqIdRef.current;
-    try {
-      setIsInitialLoading(true);
-      setHasError(false);
-      const result =
-        await backgroundApiProxy.serviceCustomRpc.searchChainListByKeywords({
-          page: 1,
-        });
-      if (!mountedRef.current || reqId !== listReqIdRef.current) return;
-      activeKeywordsRef.current = '';
-      setItems(result);
-      setHasMore(result.length > 0);
-      setCurrentPage(1);
-    } catch {
-      if (!mountedRef.current || reqId !== listReqIdRef.current) return;
-      setHasError(true);
-    } finally {
-      if (mountedRef.current && reqId === listReqIdRef.current) {
-        setIsInitialLoading(false);
-      }
-    }
-  }, [mountedRef]);
+    await loadChainList({
+      append: false,
+      page: 1,
+    });
+  }, [loadChainList]);
 
   // Load first page on mount
   useEffect(() => {
@@ -203,6 +334,7 @@ function ChainListSearch() {
       loadingMoreRef.current ||
       isLoadingMore ||
       !hasMore ||
+      hasError ||
       isSearchingRef.current
     ) {
       return;
@@ -211,44 +343,26 @@ function ChainListSearch() {
     if (normalizeSearchKeywords(searchText) !== keywords) {
       return;
     }
-    loadingMoreRef.current = true;
-    listReqIdRef.current += 1;
-    const reqId = listReqIdRef.current;
     const nextPage = currentPage + 1;
-    try {
-      setIsLoadingMore(true);
-      const result =
-        await backgroundApiProxy.serviceCustomRpc.searchChainListByKeywords({
-          keywords: keywords || undefined,
-          page: nextPage,
-        });
-      if (
-        !mountedRef.current ||
-        reqId !== listReqIdRef.current ||
-        keywords !== activeKeywordsRef.current
-      ) {
-        return;
-      }
-      if (result.length === 0) {
-        setHasMore(false);
-      } else {
-        setItems((prev) => [...prev, ...result]);
-        setCurrentPage(nextPage);
-      }
-    } catch {
-      // Silently fail on pagination
-    } finally {
-      loadingMoreRef.current = false;
-      if (mountedRef.current) {
-        setIsLoadingMore(false);
-      }
-    }
-  }, [isLoadingMore, hasMore, searchText, currentPage, mountedRef]);
+    void loadChainList({
+      append: true,
+      keywords: keywords || undefined,
+      page: nextPage,
+    });
+  }, [
+    isLoadingMore,
+    hasMore,
+    hasError,
+    searchText,
+    currentPage,
+    loadChainList,
+  ]);
 
   // Handle search text change with debounce
   const handleSearchTextChange = useCallback(
     (text: string) => {
       listReqIdRef.current += 1;
+      clearChainListRetryTimer();
       setSearchText(text);
       const keywords = normalizeSearchKeywords(text);
 
@@ -265,40 +379,17 @@ function ChainListSearch() {
       }
 
       debounceTimerRef.current = setTimeout(async () => {
-        listReqIdRef.current += 1;
-        const reqId = listReqIdRef.current;
-        try {
-          isSearchingRef.current = true;
-          setIsSearching(true);
-          setHasError(false);
-          defaultLogger.setting.page.chainListSearchPerformed({
-            keywords,
-          });
-          const result =
-            await backgroundApiProxy.serviceCustomRpc.searchChainListByKeywords(
-              {
-                keywords,
-                page: 1,
-              },
-            );
-          if (!mountedRef.current || reqId !== listReqIdRef.current) return;
-          activeKeywordsRef.current = keywords;
-          setItems(result);
-          setHasMore(result.length > 0);
-          setCurrentPage(1);
-        } catch {
-          if (!mountedRef.current || reqId !== listReqIdRef.current) return;
-          setHasError(true);
-          setHasMore(false);
-        } finally {
-          if (mountedRef.current && reqId === listReqIdRef.current) {
-            isSearchingRef.current = false;
-            setIsSearching(false);
-          }
-        }
+        defaultLogger.setting.page.chainListSearchPerformed({
+          keywords,
+        });
+        await loadChainList({
+          append: false,
+          keywords,
+          page: 1,
+        });
       }, 1500);
     },
-    [reloadDefaultList, mountedRef],
+    [reloadDefaultList, loadChainList, clearChainListRetryTimer],
   );
 
   // Clean up debounce timer
@@ -307,8 +398,9 @@ function ChainListSearch() {
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
       }
+      clearChainListRetryTimer();
     },
-    [],
+    [clearChainListRetryTimer],
   );
 
   const pushFormPage = useCallback(

--- a/packages/kit/src/views/ChainSelector/pages/ChainListSearch.tsx
+++ b/packages/kit/src/views/ChainSelector/pages/ChainListSearch.tsx
@@ -60,6 +60,10 @@ function pickBestRpcUrl(rpcUrls: string[]): string {
   return '';
 }
 
+function normalizeSearchKeywords(text?: string): string {
+  return text?.trim() ?? '';
+}
+
 function ChainListSearchSkeletonList() {
   return (
     <Stack>
@@ -103,6 +107,7 @@ function ChainListSearch() {
 
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isSearchingRef = useRef(false);
+  const activeKeywordsRef = useRef('');
   // Monotonic id bumped on every list-replacing op (initial load, reload,
   // search, pagination); used to discard stale async results.
   const listReqIdRef = useRef(0);
@@ -149,6 +154,7 @@ function ChainListSearch() {
           page: 1,
         });
       if (!mountedRef.current || reqId !== listReqIdRef.current) return;
+      activeKeywordsRef.current = '';
       setItems(result);
       setHasMore(result.length > 0);
       setCurrentPage(1);
@@ -173,9 +179,12 @@ function ChainListSearch() {
       loadingMoreRef.current ||
       isLoadingMore ||
       !hasMore ||
-      searchText ||
       isSearchingRef.current
     ) {
+      return;
+    }
+    const keywords = activeKeywordsRef.current;
+    if (normalizeSearchKeywords(searchText) !== keywords) {
       return;
     }
     loadingMoreRef.current = true;
@@ -186,9 +195,16 @@ function ChainListSearch() {
       setIsLoadingMore(true);
       const result =
         await backgroundApiProxy.serviceCustomRpc.searchChainListByKeywords({
+          keywords: keywords || undefined,
           page: nextPage,
         });
-      if (!mountedRef.current || reqId !== listReqIdRef.current) return;
+      if (
+        !mountedRef.current ||
+        reqId !== listReqIdRef.current ||
+        keywords !== activeKeywordsRef.current
+      ) {
+        return;
+      }
       if (result.length === 0) {
         setHasMore(false);
       } else {
@@ -199,7 +215,7 @@ function ChainListSearch() {
       // Silently fail on pagination
     } finally {
       loadingMoreRef.current = false;
-      if (mountedRef.current && reqId === listReqIdRef.current) {
+      if (mountedRef.current) {
         setIsLoadingMore(false);
       }
     }
@@ -208,13 +224,15 @@ function ChainListSearch() {
   // Handle search text change with debounce
   const handleSearchTextChange = useCallback(
     (text: string) => {
+      listReqIdRef.current += 1;
       setSearchText(text);
+      const keywords = normalizeSearchKeywords(text);
 
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
       }
 
-      if (!text) {
+      if (!keywords) {
         // Clear search: reload default paginated list
         isSearchingRef.current = false;
         setIsSearching(false);
@@ -230,20 +248,24 @@ function ChainListSearch() {
           setIsSearching(true);
           setHasError(false);
           defaultLogger.setting.page.chainListSearchPerformed({
-            keywords: text,
+            keywords,
           });
           const result =
             await backgroundApiProxy.serviceCustomRpc.searchChainListByKeywords(
               {
-                keywords: text,
+                keywords,
+                page: 1,
               },
             );
           if (!mountedRef.current || reqId !== listReqIdRef.current) return;
+          activeKeywordsRef.current = keywords;
           setItems(result);
-          setHasMore(false); // search results are not paginated
+          setHasMore(result.length > 0);
+          setCurrentPage(1);
         } catch {
           if (!mountedRef.current || reqId !== listReqIdRef.current) return;
           setHasError(true);
+          setHasMore(false);
         } finally {
           if (mountedRef.current && reqId === listReqIdRef.current) {
             isSearchingRef.current = false;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55324](https://onekeyhq.atlassian.net/browse/OK-55324) [OK-55319](https://onekeyhq.atlassian.net/browse/OK-55319) [OK-55303](https://onekeyhq.atlassian.net/browse/OK-55303)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Add pagination support for chainlist search results (previously search returned only the first page)
- Select the fastest RPC URL by measuring response times across all candidate endpoints before navigating to the form
- Add automatic retry with exponential backoff (2s, 5s, 10s, then 60s intervals) when chainlist API calls fail
- Fix chainId comparison using BigNumber to avoid numeric precision issues

## Intent & Context
When users search or browse the chainlist in custom network settings, several usability issues were present: search results were not paginated (only the first page was returned), the first valid-looking RPC URL was picked without testing connectivity, and network failures resulted in a permanent error state with no recovery. These fixes address all three issues to improve the custom network addition flow.

## Root Cause
1. **No search pagination**: `searchChainListByKeywords` did not pass `page` parameter for keyword searches, so only page 1 was ever returned. The `handleEndReached` callback also skipped pagination when `searchText` was set.
2. **Suboptimal RPC selection**: `pickBestRpcUrl` simply picked the first HTTPS URL without testing if it was actually reachable or fast.
3. **No retry on failure**: API failures left the UI in an error state with no automatic recovery mechanism.
4. **ChainId mismatch**: Numeric chainId comparison could fail for very large chain IDs due to JavaScript number precision limits.

## Design Decisions
- **Unified `loadChainList` function**: Consolidated the duplicated loading logic (initial load, search, pagination) into a single `loadChainList` callback that handles all cases via a request descriptor object. This eliminates state management bugs from having separate code paths.
- **`measureCustomNetworkRpcStatus` in background service**: RPC measurement is done via a background method so it can reuse the existing vault infrastructure and validate chainId server-side, keeping the UI layer thin.
- **`pickFastestRpcUrl` with `Promise.allSettled`**: All candidate URLs are tested in parallel; the fastest responding one wins. Failed endpoints are silently excluded. Falls back to the first candidate if all fail.
- **Retry with escalating delays**: Uses fixed delay tiers (2s → 5s → 10s → 60s) rather than true exponential backoff for simplicity and predictability. Retries are cancelled on any user action (new search, unmount).
- **BigNumber for chainId**: Uses `BigNumber.isEqualTo` to safely compare chain IDs regardless of magnitude.

## Changes Detail
- `ServiceCustomRpc.ts`: Added `buildChainListRequestParams` helper, `measureCustomNetworkRpcStatus` background method, and passed `page` param through keyword search calls
- `ChainListSearch.tsx`: Unified loading into `loadChainList`, added retry scheduling, added RPC speed measurement on network selection with spinner UI, enabled pagination for search results, filtered out chains with no usable RPC URLs

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web (all platforms using custom network flow)
- **Risk Areas**: The RPC measurement adds latency to network selection (parallel requests mitigate this). Retry timers need proper cleanup on unmount to avoid memory leaks (handled via `clearChainListRetryTimer` in effect cleanup).

## Test plan
- [ ] Open Settings → Custom Network → Add Network
- [ ] Verify initial chainlist loads and scrolling triggers pagination
- [ ] Search for a network name and verify results appear, then scroll to trigger search pagination
- [ ] Clear search text and verify default paginated list is restored
- [ ] Select a network with multiple RPC URLs and verify spinner appears briefly while measuring
- [ ] Disconnect network, verify error state appears, then reconnect and verify auto-retry recovers
- [ ] Verify networks with no usable RPC URLs are filtered out from the list
- [ ] Test on both mobile and desktop platforms

[OK-55324]: https://onekeyhq.atlassian.net/browse/OK-55324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55319]: https://onekeyhq.atlassian.net/browse/OK-55319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55303]: https://onekeyhq.atlassian.net/browse/OK-55303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ