### PR TITLE
fix(earn): align earn FAQ design with swap

### DIFF
--- a/packages/kit/src/views/Earn/components/FAQContent.tsx
+++ b/packages/kit/src/views/Earn/components/FAQContent.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 
 import { isEmpty } from 'lodash';
 
@@ -42,12 +42,6 @@ function BaseFAQContent({
 }) {
   const media = useMedia();
 
-  // On large screens (desktop), expand all items by default
-  const defaultValue = useMemo(
-    () => (media.gtMd ? faqList?.map((_, index) => String(index)) : undefined),
-    [faqList, media.gtMd],
-  );
-
   if (isLoading && isEmpty(faqList)) {
     return <FAQPanelSkeleton />;
   }
@@ -57,72 +51,70 @@ function BaseFAQContent({
   }
 
   return (
-    <Accordion
-      testID={EarnTestIDs.faqSection}
-      type="multiple"
-      gap="$2"
-      defaultValue={defaultValue}
-    >
+    <Accordion testID={EarnTestIDs.faqSection} type="multiple" pb="$8">
       {faqList.map(({ question, answer }, index) => (
-        <Accordion.Item value={String(index)} key={question}>
-          <Accordion.Trigger
-            unstyled
-            flexDirection="row"
-            alignItems="center"
-            borderWidth={0}
-            bg="$transparent"
-            px="$2"
-            py="$1"
-            mx="$-2"
-            my="$-1"
-            hoverStyle={{
-              bg: '$bgHover',
-            }}
-            pressStyle={{
-              bg: '$bgActive',
-            }}
-            borderRadius="$2"
-          >
-            {({ open }: { open: boolean }) => (
-              <>
-                <SizableText
-                  textAlign="left"
-                  flex={1}
-                  size="$headingMd"
-                  color={open ? '$text' : '$textSubdued'}
-                >
-                  {question}
-                </SizableText>
-                <Stack
-                  animation="quick"
-                  animateOnly={ANIMATE_ONLY_TRANSFORM}
-                  rotate={open ? '180deg' : '0deg'}
-                >
-                  <Icon
-                    name="ChevronDownSmallOutline"
-                    color={open ? '$iconActive' : '$iconSubdued'}
-                    size="$5"
-                  />
-                </Stack>
-              </>
-            )}
-          </Accordion.Trigger>
-          <Accordion.HeightAnimator animation="quick" overflow="hidden">
-            <Accordion.Content
+        <YStack key={question}>
+          <Accordion.Item value={String(index)}>
+            <Accordion.Trigger
               unstyled
-              pt="$2"
-              pb="$5"
-              animation="100ms"
-              animateOnly={ANIMATE_ONLY_OPACITY}
-              enterStyle={{ opacity: 0 }}
-              exitStyle={{ opacity: 0 }}
+              flexDirection="row"
+              alignItems="center"
+              justifyContent="space-between"
+              borderWidth={0}
+              bg="$transparent"
+              p={0}
+              py="$5"
+              m={0}
+              cursor="pointer"
             >
-              <SizableText size="$bodyMd" color="$text" whiteSpace="pre-line">
-                {answer}
-              </SizableText>
-            </Accordion.Content>
-          </Accordion.HeightAnimator>
-        </Accordion.Item>
+              {({ open }: { open: boolean }) => (
+                <>
+                  <SizableText
+                    textAlign="left"
+                    flex={1}
+                    size={media.gtMd ? '$headingLg' : '$headingMd'}
+                    color="$text"
+                    pr="$2"
+                  >
+                    {question}
+                  </SizableText>
+                  <Stack
+                    animation="quick"
+                    animateOnly={ANIMATE_ONLY_TRANSFORM}
+                    rotate={open ? '180deg' : '0deg'}
+                  >
+                    <Icon
+                      name="ChevronDownSmallOutline"
+                      color="$iconSubdued"
+                      size="$6"
+                    />
+                  </Stack>
+                </>
+              )}
+            </Accordion.Trigger>
+            <Accordion.HeightAnimator animation="quick" overflow="hidden">
+              <Accordion.Content
+                unstyled
+                p={0}
+                pt="$1"
+                pb="$5"
+                pr="$8"
+                animation="100ms"
+                animateOnly={ANIMATE_ONLY_OPACITY}
+                enterStyle={{ opacity: 0 }}
+                exitStyle={{ opacity: 0 }}
+              >
+                <SizableText
+                  size="$bodyLg"
+                  color="$textSubdued"
+                  whiteSpace="pre-line"
+                >
+                  {answer}
+                </SizableText>
+              </Accordion.Content>
+            </Accordion.HeightAnimator>
+          </Accordion.Item>
+        </YStack>
       ))}
     </Accordion>
   );

--- a/packages/kit/src/views/Staking/pages/ProtocolDetailsV2/FAQSection.tsx
+++ b/packages/kit/src/views/Staking/pages/ProtocolDetailsV2/FAQSection.tsx
@@ -1,6 +1,17 @@
 import { useCallback } from 'react';
 
-import { SizableText, YStack } from '@onekeyhq/components';
+import {
+  Accordion,
+  Icon,
+  SizableText,
+  Stack,
+  YStack,
+  useMedia,
+} from '@onekeyhq/components';
+import {
+  ANIMATE_ONLY_OPACITY,
+  ANIMATE_ONLY_TRANSFORM,
+} from '@onekeyhq/components/src/utils/animationConstants';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useUserWalletProfile } from '@onekeyhq/kit/src/hooks/useUserWalletProfile';
@@ -18,7 +29,6 @@ import {
   ESwapTabSwitchType,
 } from '@onekeyhq/shared/types/swap/types';
 
-import { FAQAccordion } from '../../components/FAQAccordion';
 import { EarnText } from '../../components/ProtocolDetails/EarnText';
 
 export function FAQSection({
@@ -28,6 +38,7 @@ export function FAQSection({
   faqs: IStakeEarnDetail['faqs'];
   tokenInfo?: IEarnTokenInfo;
 }) {
+  const media = useMedia();
   const navigation = useAppNavigation();
   const {
     activeAccount: { wallet },
@@ -85,33 +96,75 @@ export function FAQSection({
     ],
   );
   return faqs?.items?.length ? (
-    <YStack gap="$6">
-      <EarnText text={faqs.title} size="$headingLg" />
-      <YStack>
-        <FAQAccordion
-          items={faqs.items}
-          renderTitle={(item, { open }) => (
-            <SizableText
-              textAlign="left"
-              flex={1}
-              size="$bodyLgMedium"
-              color={open ? '$text' : '$textSubdued'}
-            >
-              {item.title.text}
-            </SizableText>
-          )}
-          renderContent={(item) => (
-            <EarnText
-              text={item.description}
-              size="$bodyMd"
-              onAction={handleAction}
-              underlineTextProps={{
-                color: '$textInfo',
-              }}
-            />
-          )}
-        />
-      </YStack>
+    <YStack pb="$8">
+      <Accordion type="multiple">
+        {faqs.items.map((item, index) => (
+          <YStack key={String(index)}>
+            <Accordion.Item value={String(index)}>
+              <Accordion.Trigger
+                unstyled
+                flexDirection="row"
+                alignItems="center"
+                justifyContent="space-between"
+                borderWidth={0}
+                bg="$transparent"
+                p={0}
+                py="$5"
+                m={0}
+                cursor="pointer"
+              >
+                {({ open }: { open: boolean }) => (
+                  <>
+                    <SizableText
+                      textAlign="left"
+                      flex={1}
+                      size={media.gtMd ? '$headingLg' : '$headingMd'}
+                      color="$text"
+                      pr="$2"
+                    >
+                      {item.title.text}
+                    </SizableText>
+                    <Stack
+                      animation="quick"
+                      animateOnly={ANIMATE_ONLY_TRANSFORM}
+                      rotate={open ? '180deg' : '0deg'}
+                    >
+                      <Icon
+                        name="ChevronDownSmallOutline"
+                        color="$iconSubdued"
+                        size="$6"
+                      />
+                    </Stack>
+                  </>
+                )}
+              </Accordion.Trigger>
+              <Accordion.HeightAnimator animation="quick">
+                <Accordion.Content
+                  unstyled
+                  p={0}
+                  pt="$1"
+                  pb="$5"
+                  pr="$8"
+                  animation="100ms"
+                  animateOnly={ANIMATE_ONLY_OPACITY}
+                  enterStyle={{ opacity: 0 }}
+                  exitStyle={{ opacity: 0 }}
+                >
+                  <EarnText
+                    text={item.description}
+                    size="$bodyLg"
+                    color="$textSubdued"
+                    onAction={handleAction}
+                    underlineTextProps={{
+                      color: '$textInfo',
+                    }}
+                  />
+                </Accordion.Content>
+              </Accordion.HeightAnimator>
+            </Accordion.Item>
+          </YStack>
+        ))}
+      </Accordion>
     </YStack>
   ) : null;
 }


### PR DESCRIPTION
## Summary
统一 Earn FAQ 与 Swap FAQ 的视觉设计，桌面与移动端一致。Swap 不动。

## Changes
- Earn 首页 FAQs tab (`FAQContent.tsx`) 与协议详情页 FAQ (`ProtocolDetailsV2/FAQSection.tsx`) 改用与 Swap 一致的 accordion 样式
- 移除详情页多余的 "FAQs" 区块标题（与同页其他区块标题风格冲突，直接去掉）
- 默认全部收起、移除项目间分隔线、底部预留 32px 间距
- 问题标题：移动端 `headingMd`、桌面 `headingLg`
- 未改动共用的 `FAQAccordion`（Borrow 仍在用）与 `SwapFAQ`

## Test plan
- [ ] 桌面：Earn 首页切到 FAQs tab、任一协议详情页 FAQ 区，对照 Swap 确认字级/间距/箭头一致
- [ ] 移动端：同上，确认问题标题为 headingMd
- [ ] 点击含 `trade_usdf` 链接的 FAQ，确认仍能跳转 Swap

<img width="1978" height="1126" alt="CleanShot 2026-05-26 at 16 59 38@2x" src="https://github.com/user-attachments/assets/89640e7b-dba7-47dc-83aa-d19118680ae8" />

