### PR TITLE
fix: handle network errors during keyless passive backend share v2 migration

### DIFF
--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
@@ -505,6 +505,65 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
     expect(migrationPersist.byWalletId[WALLET_ID]).toBeUndefined();
   });
 
+  test('does not consume the 24-hour throttle when Prime API call fails with 429 rate limit', async () => {
+    const { service, serviceAny } = createService();
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(
+      async () => ({ accessToken: TOKEN, refreshToken: REFRESH_TOKEN }),
+    );
+    serviceAny.validateKeylessAccessTokenMatchesLocalWallet = jest.fn(
+      async () => undefined,
+    );
+    serviceAny.apiGetKeylessBackendShareMeta = jest.fn(async () => {
+      const error: Error & { httpStatusCode?: number } = new Error(
+        'rate limited',
+      );
+      error.httpStatusCode = 429;
+      throw error;
+    });
+
+    await expect(
+      service.tryMigrateLocalExistingKeylessBackendShareToV2(),
+    ).resolves.toMatchObject({
+      skipped: true,
+      reason: 'network_unavailable',
+    });
+
+    expect(migrationPersist.byWalletId[WALLET_ID]).toBeUndefined();
+  });
+
+  test('refresh helper surfaces 429 from Supabase auth as a network error so the throttle is not consumed', async () => {
+    const { service, serviceAny } = createService();
+    mockGetRefreshTokenFromStorageWithPassword.mockResolvedValue(REFRESH_TOKEN);
+    const originalFetch = (globalThis as { fetch?: typeof fetch }).fetch;
+    const fetchMock = jest.fn(
+      async () =>
+        ({
+          ok: false,
+          status: 429,
+          json: async () => ({}),
+        }) as unknown as Response,
+    );
+    (globalThis as { fetch?: unknown }).fetch = fetchMock;
+    try {
+      const { KeylessPassiveMigrationNetworkError } =
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        require('./keylessPassiveMigrationErrors');
+      await expect(
+        serviceAny.refreshAccessTokenForKeylessBackendShareV2MigrationPassive({
+          ownerId: OWNER_ID,
+          password: PASSWORD,
+        }),
+      ).rejects.toBeInstanceOf(KeylessPassiveMigrationNetworkError);
+    } finally {
+      if (originalFetch) {
+        (globalThis as { fetch?: typeof fetch }).fetch = originalFetch;
+      } else {
+        delete (globalThis as { fetch?: unknown }).fetch;
+      }
+    }
+    expect(service).toBeDefined();
+  });
+
   test('does not consume the 24-hour throttle when Prime API call fails with a client-side timeout', async () => {
     const { service, serviceAny } = createService();
     serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
@@ -235,7 +235,7 @@ function createService(params: { wallet?: any; password?: string } = {}) {
 }
 
 function mockPassiveV1HappyPath(serviceAny: any) {
-  serviceAny.getKeylessAccessTokenWithoutPrompt = jest.fn(async () => ({
+  serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => ({
     accessToken: TOKEN,
     refreshToken: REFRESH_TOKEN,
   }));
@@ -351,7 +351,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
 
   test('throttles passive migration for 24 hours after a failed attempt', async () => {
     const { service, serviceAny } = createService();
-    serviceAny.getKeylessAccessTokenWithoutPrompt = jest.fn(async () => null);
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => null);
 
     await expect(
       service.tryMigrateLocalExistingKeylessBackendShareToV2(),
@@ -367,14 +367,89 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       reason: 'passive_throttled',
     });
 
-    expect(serviceAny.getKeylessAccessTokenWithoutPrompt).toHaveBeenCalledTimes(
+    expect(serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive).toHaveBeenCalledTimes(
       1,
     );
   });
 
+  test('does not consume the 24-hour throttle when the refresh fetch fails with a network error', async () => {
+    const { service, serviceAny } = createService();
+    const { KeylessPassiveMigrationNetworkError } =
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      require('./keylessPassiveMigrationErrors');
+    // First call: simulate offline by throwing a network error.
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest
+      .fn()
+      .mockImplementationOnce(async () => {
+        throw new KeylessPassiveMigrationNetworkError();
+      })
+      .mockImplementationOnce(async () => null);
+
+    await expect(
+      service.tryMigrateLocalExistingKeylessBackendShareToV2(),
+    ).resolves.toMatchObject({
+      skipped: true,
+      reason: 'network_unavailable',
+    });
+
+    // Throttle should NOT be set — the next trigger must retry immediately.
+    expect(migrationPersist.byWalletId[WALLET_ID]).toBeUndefined();
+
+    await expect(
+      service.tryMigrateLocalExistingKeylessBackendShareToV2(),
+    ).resolves.toMatchObject({
+      skipped: true,
+      reason: 'token_missing',
+    });
+
+    expect(serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive).toHaveBeenCalledTimes(
+      2,
+    );
+  });
+
+  test('rolls back to previous record on network error for a record-matched wallet', async () => {
+    const PREVIOUS_ATTEMPT_AT = NOW - 25 * 60 * 60 * 1000;
+    migrationPersist = {
+      byWalletId: {
+        [WALLET_ID]: {
+          ownerId: OWNER_ID,
+          keylessProvider: EOAuthSocialLoginProvider.Google,
+          socialUserIdHash: SOCIAL_USER_ID_HASH,
+          lastPassiveAttemptAt: PREVIOUS_ATTEMPT_AT,
+          lastPassiveFailedAt: PREVIOUS_ATTEMPT_AT,
+        },
+      },
+    };
+    const { service, serviceAny } = createService();
+    const { KeylessPassiveMigrationNetworkError } =
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      require('./keylessPassiveMigrationErrors');
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => {
+      throw new KeylessPassiveMigrationNetworkError();
+    });
+
+    await expect(
+      service.tryMigrateLocalExistingKeylessBackendShareToV2(),
+    ).resolves.toMatchObject({
+      skipped: true,
+      reason: 'network_unavailable',
+    });
+
+    // Previous record must be restored — the throttle write done at NOW
+    // before the network attempt must be undone, so that the next natural
+    // trigger can retry immediately without waiting another 24h.
+    expect(migrationPersist.byWalletId[WALLET_ID]).toEqual({
+      ownerId: OWNER_ID,
+      keylessProvider: EOAuthSocialLoginProvider.Google,
+      socialUserIdHash: SOCIAL_USER_ID_HASH,
+      lastPassiveAttemptAt: PREVIOUS_ATTEMPT_AT,
+      lastPassiveFailedAt: PREVIOUS_ATTEMPT_AT,
+    });
+  });
+
   test('retries passive migration after the 24-hour failure throttle window', async () => {
     const { service, serviceAny } = createService();
-    serviceAny.getKeylessAccessTokenWithoutPrompt = jest.fn(async () => null);
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => null);
 
     await expect(
       service.tryMigrateLocalExistingKeylessBackendShareToV2(),
@@ -392,7 +467,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       reason: 'token_missing',
     });
 
-    expect(serviceAny.getKeylessAccessTokenWithoutPrompt).toHaveBeenCalledTimes(
+    expect(serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive).toHaveBeenCalledTimes(
       2,
     );
   });
@@ -437,7 +512,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       },
     };
     const { service, serviceAny } = createService();
-    serviceAny.getKeylessAccessTokenWithoutPrompt = jest.fn(async () => null);
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => null);
 
     await expect(
       service.tryMigrateLocalExistingKeylessBackendShareToV2(),
@@ -446,7 +521,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       reason: 'token_missing',
     });
 
-    expect(serviceAny.getKeylessAccessTokenWithoutPrompt).toHaveBeenCalledTimes(
+    expect(serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive).toHaveBeenCalledTimes(
       1,
     );
     expect(migrationPersist.byWalletId[WALLET_ID]).toMatchObject({
@@ -458,7 +533,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
 
   test('does not write server or save refreshed tokens when token social identity mismatches local wallet', async () => {
     const { service, serviceAny } = createService();
-    serviceAny.getKeylessAccessTokenWithoutPrompt = jest.fn(async () => ({
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => ({
       accessToken: TOKEN,
       refreshToken: REFRESH_TOKEN,
     }));
@@ -482,7 +557,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
 
   test('does not write server or save refreshed tokens when token provider mismatches local wallet', async () => {
     const { service, serviceAny } = createService();
-    serviceAny.getKeylessAccessTokenWithoutPrompt = jest.fn(async () => ({
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => ({
       accessToken: TOKEN,
       refreshToken: REFRESH_TOKEN,
     }));
@@ -506,7 +581,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
 
   test('does not write server or save refreshed tokens when token and server hash derive a different ownerId', async () => {
     const { service, serviceAny } = createService();
-    serviceAny.getKeylessAccessTokenWithoutPrompt = jest.fn(async () => ({
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => ({
       accessToken: TOKEN,
       refreshToken: REFRESH_TOKEN,
     }));
@@ -541,7 +616,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
 
   test('does not mark success when existing v2 server data does not match local mnemonic', async () => {
     const { service, serviceAny } = createService();
-    serviceAny.getKeylessAccessTokenWithoutPrompt = jest.fn(async () => ({
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => ({
       accessToken: TOKEN,
     }));
     serviceAny.validateKeylessAccessTokenMatchesLocalWallet = jest.fn(

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
@@ -453,6 +453,114 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
     });
   });
 
+  test('does not consume the 24-hour throttle when Prime API meta call fails with AxiosNetworkError', async () => {
+    const { service, serviceAny } = createService();
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(
+      async () => ({ accessToken: TOKEN, refreshToken: REFRESH_TOKEN }),
+    );
+    serviceAny.validateKeylessAccessTokenMatchesLocalWallet = jest.fn(
+      async () => undefined,
+    );
+    // Cached-token path: refresh skipped, Prime API fails with axios
+    // network error (offline / DNS / TLS). Must not consume the 24h throttle.
+    serviceAny.apiGetKeylessBackendShareMeta = jest.fn(async () => {
+      const error: Error & { className?: string } = new Error('Network Error');
+      error.className = 'AxiosNetworkError';
+      throw error;
+    });
+
+    await expect(
+      service.tryMigrateLocalExistingKeylessBackendShareToV2(),
+    ).resolves.toMatchObject({
+      skipped: true,
+      reason: 'network_unavailable',
+    });
+
+    expect(migrationPersist.byWalletId[WALLET_ID]).toBeUndefined();
+  });
+
+  test('does not consume the 24-hour throttle when Prime API meta call fails with 5xx', async () => {
+    const { service, serviceAny } = createService();
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(
+      async () => ({ accessToken: TOKEN, refreshToken: REFRESH_TOKEN }),
+    );
+    serviceAny.validateKeylessAccessTokenMatchesLocalWallet = jest.fn(
+      async () => undefined,
+    );
+    serviceAny.apiGetKeylessBackendShareMeta = jest.fn(async () => {
+      const error: Error & { httpStatusCode?: number } = new Error(
+        'server error',
+      );
+      error.httpStatusCode = 503;
+      throw error;
+    });
+
+    await expect(
+      service.tryMigrateLocalExistingKeylessBackendShareToV2(),
+    ).resolves.toMatchObject({
+      skipped: true,
+      reason: 'network_unavailable',
+    });
+
+    expect(migrationPersist.byWalletId[WALLET_ID]).toBeUndefined();
+  });
+
+  test('does not consume the 24-hour throttle when Prime API call fails with a client-side timeout', async () => {
+    const { service, serviceAny } = createService();
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(
+      async () => ({ accessToken: TOKEN, refreshToken: REFRESH_TOKEN }),
+    );
+    serviceAny.validateKeylessAccessTokenMatchesLocalWallet = jest.fn(
+      async () => undefined,
+    );
+    serviceAny.apiGetKeylessBackendShareMeta = jest.fn(async () => {
+      const error: Error & { code?: string } = new Error('timeout of 30000ms');
+      error.code = 'ECONNABORTED';
+      throw error;
+    });
+
+    await expect(
+      service.tryMigrateLocalExistingKeylessBackendShareToV2(),
+    ).resolves.toMatchObject({
+      skipped: true,
+      reason: 'network_unavailable',
+    });
+
+    expect(migrationPersist.byWalletId[WALLET_ID]).toBeUndefined();
+  });
+
+  test('still throttles for 24h when Prime API meta call fails with a 4xx (real auth failure)', async () => {
+    const { service, serviceAny } = createService();
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(
+      async () => ({ accessToken: TOKEN, refreshToken: REFRESH_TOKEN }),
+    );
+    serviceAny.validateKeylessAccessTokenMatchesLocalWallet = jest.fn(
+      async () => undefined,
+    );
+    serviceAny.apiGetKeylessBackendShareMeta = jest.fn(async () => {
+      const error: Error & { httpStatusCode?: number } = new Error(
+        'unauthorized',
+      );
+      error.httpStatusCode = 401;
+      throw error;
+    });
+
+    await expect(
+      service.tryMigrateLocalExistingKeylessBackendShareToV2(),
+    ).resolves.toMatchObject({
+      skipped: false,
+      reason: 'upgrade_failed',
+    });
+
+    // 4xx is a real failure — throttle must be set so we don't hammer the
+    // server on every wake.
+    expect(migrationPersist.byWalletId[WALLET_ID]).toMatchObject({
+      ownerId: OWNER_ID,
+      lastPassiveAttemptAt: NOW,
+      lastPassiveFailedAt: NOW,
+    });
+  });
+
   test('retries passive migration after the 24-hour failure throttle window', async () => {
     const { service, serviceAny } = createService();
     serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
@@ -235,10 +235,12 @@ function createService(params: { wallet?: any; password?: string } = {}) {
 }
 
 function mockPassiveV1HappyPath(serviceAny: any) {
-  serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => ({
-    accessToken: TOKEN,
-    refreshToken: REFRESH_TOKEN,
-  }));
+  serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(
+    async () => ({
+      accessToken: TOKEN,
+      refreshToken: REFRESH_TOKEN,
+    }),
+  );
   serviceAny.validateKeylessAccessTokenMatchesLocalWallet = jest.fn(
     async () => undefined,
   );
@@ -351,7 +353,9 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
 
   test('throttles passive migration for 24 hours after a failed attempt', async () => {
     const { service, serviceAny } = createService();
-    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => null);
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(
+      async () => null,
+    );
 
     await expect(
       service.tryMigrateLocalExistingKeylessBackendShareToV2(),
@@ -367,9 +371,9 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       reason: 'passive_throttled',
     });
 
-    expect(serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive).toHaveBeenCalledTimes(
-      1,
-    );
+    expect(
+      serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive,
+    ).toHaveBeenCalledTimes(1);
   });
 
   test('does not consume the 24-hour throttle when the refresh fetch fails with a network error', async () => {
@@ -402,9 +406,9 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       reason: 'token_missing',
     });
 
-    expect(serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive).toHaveBeenCalledTimes(
-      2,
-    );
+    expect(
+      serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive,
+    ).toHaveBeenCalledTimes(2);
   });
 
   test('rolls back to previous record on network error for a record-matched wallet', async () => {
@@ -424,9 +428,11 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
     const { KeylessPassiveMigrationNetworkError } =
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       require('./keylessPassiveMigrationErrors');
-    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => {
-      throw new KeylessPassiveMigrationNetworkError();
-    });
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(
+      async () => {
+        throw new KeylessPassiveMigrationNetworkError();
+      },
+    );
 
     await expect(
       service.tryMigrateLocalExistingKeylessBackendShareToV2(),
@@ -449,7 +455,9 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
 
   test('retries passive migration after the 24-hour failure throttle window', async () => {
     const { service, serviceAny } = createService();
-    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => null);
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(
+      async () => null,
+    );
 
     await expect(
       service.tryMigrateLocalExistingKeylessBackendShareToV2(),
@@ -467,9 +475,9 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       reason: 'token_missing',
     });
 
-    expect(serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive).toHaveBeenCalledTimes(
-      2,
-    );
+    expect(
+      serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive,
+    ).toHaveBeenCalledTimes(2);
   });
 
   test('skips permanently after successful migration for the same identity', async () => {
@@ -512,7 +520,9 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       },
     };
     const { service, serviceAny } = createService();
-    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => null);
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(
+      async () => null,
+    );
 
     await expect(
       service.tryMigrateLocalExistingKeylessBackendShareToV2(),
@@ -521,9 +531,9 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       reason: 'token_missing',
     });
 
-    expect(serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive).toHaveBeenCalledTimes(
-      1,
-    );
+    expect(
+      serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive,
+    ).toHaveBeenCalledTimes(1);
     expect(migrationPersist.byWalletId[WALLET_ID]).toMatchObject({
       ownerId: OWNER_ID,
       socialUserIdHash: SOCIAL_USER_ID_HASH,
@@ -533,10 +543,12 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
 
   test('does not write server or save refreshed tokens when token social identity mismatches local wallet', async () => {
     const { service, serviceAny } = createService();
-    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => ({
-      accessToken: TOKEN,
-      refreshToken: REFRESH_TOKEN,
-    }));
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(
+      async () => ({
+        accessToken: TOKEN,
+        refreshToken: REFRESH_TOKEN,
+      }),
+    );
     serviceAny.validateKeylessAccessTokenMatchesLocalWallet = jest.fn(
       async () => 'token_identity_mismatch',
     );
@@ -557,10 +569,12 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
 
   test('does not write server or save refreshed tokens when token provider mismatches local wallet', async () => {
     const { service, serviceAny } = createService();
-    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => ({
-      accessToken: TOKEN,
-      refreshToken: REFRESH_TOKEN,
-    }));
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(
+      async () => ({
+        accessToken: TOKEN,
+        refreshToken: REFRESH_TOKEN,
+      }),
+    );
     serviceAny.validateKeylessAccessTokenMatchesLocalWallet = jest.fn(
       async () => 'token_provider_mismatch',
     );
@@ -581,10 +595,12 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
 
   test('does not write server or save refreshed tokens when token and server hash derive a different ownerId', async () => {
     const { service, serviceAny } = createService();
-    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => ({
-      accessToken: TOKEN,
-      refreshToken: REFRESH_TOKEN,
-    }));
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(
+      async () => ({
+        accessToken: TOKEN,
+        refreshToken: REFRESH_TOKEN,
+      }),
+    );
     serviceAny.validateKeylessAccessTokenMatchesLocalWallet = jest.fn(
       async () => undefined,
     );
@@ -616,9 +632,11 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
 
   test('does not mark success when existing v2 server data does not match local mnemonic', async () => {
     const { service, serviceAny } = createService();
-    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(async () => ({
-      accessToken: TOKEN,
-    }));
+    serviceAny.getAccessTokenForKeylessBackendShareV2MigrationPassive = jest.fn(
+      async () => ({
+        accessToken: TOKEN,
+      }),
+    );
     serviceAny.validateKeylessAccessTokenMatchesLocalWallet = jest.fn(
       async () => undefined,
     );

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -85,6 +85,7 @@ import {
 import ServiceBase from '../ServiceBase';
 import keylessCloudSyncUtils from '../ServicePrimeCloudSync/keylessCloudSyncUtils';
 
+import { KeylessPassiveMigrationNetworkError } from './keylessPassiveMigrationErrors';
 import keylessAuthPackCache from './utils/keylessAuthPackCache';
 import keylessDeviceKeyStorage from './utils/keylessDeviceKeyStorage';
 import keylessMnemonicPasswordStorage from './utils/keylessMnemonicPasswordStorage';
@@ -151,6 +152,7 @@ type IKeylessBackendShareV2MigrationResult = {
     | 'local_keyless_wallet_missing'
     | 'mnemonic_mismatch'
     | 'mnemonic_password_missing'
+    | 'network_unavailable'
     | 'owner_id_missing'
     | 'owner_id_mismatch'
     | 'password_not_cached'
@@ -1729,26 +1731,21 @@ class ServiceKeylessWallet extends ServiceBase {
 
     const client = await this.getClient(EServiceEndpointEnum.Prime);
     const res = await client.post<
-      IApiClientResponse<{
-        backendShare: string;
-        hashId: string;
-        revision: number;
-        canonicalFormat: IKeylessBackendShareCanonicalFormat;
-      }>
+      IApiClientResponse<
+        | {
+            backendShare: string;
+            hashId: string;
+            revision: number;
+            canonicalFormat: IKeylessBackendShareCanonicalFormat;
+          }
+        | ''
+      >
     >('/prime/v1/keyless-wallet/getKeylessBackendShareV2', {
       token,
     });
 
     const isSuccess = res?.data?.code === 0 && res?.data?.message === 'success';
-    const responseData = res?.data?.data as
-      | {
-          backendShare?: string;
-          hashId?: string;
-          revision?: number;
-          canonicalFormat?: string;
-        }
-      | ''
-      | undefined;
+    const responseData = res?.data?.data;
 
     if (isSuccess && responseData === '') {
       return {
@@ -1902,8 +1899,18 @@ class ServiceKeylessWallet extends ServiceBase {
           };
         }
       | undefined;
-    const message = data?.message || data?.data?.message || plainError.message;
-    return messages.includes(message);
+    const rawMessage =
+      data?.message || data?.data?.message || plainError.message;
+    const message = typeof rawMessage === 'string' ? rawMessage : '';
+    if (!message) {
+      return false;
+    }
+    // Match exact codes or codes followed by `:` context, e.g.
+    // `revision_conflict` and `revision_conflict: actual=5 expected=3`.
+    return messages.some(
+      (candidate) =>
+        message === candidate || message.startsWith(`${candidate}:`),
+    );
   }
 
   private async withKeylessBackendShareWriteLock<T>(
@@ -2058,14 +2065,6 @@ class ServiceKeylessWallet extends ServiceBase {
     throw new OneKeyLocalError('Failed to upload keyless backend share');
   }
 
-  @backgroundMethod()
-  @toastIfError()
-  async apiUploadKeylessBackendShare(
-    params: IKeylessBackendShareUploadParams,
-  ): Promise<IKeylessBackendShare> {
-    return this.uploadKeylessBackendShare(params);
-  }
-
   private async migrateKeylessBackendShareToV2(params: {
     token: string;
     ownerId: string;
@@ -2155,7 +2154,11 @@ class ServiceKeylessWallet extends ServiceBase {
     }
   }
 
-  private async refreshKeylessAccessTokenFromStorageWithPassword(params: {
+  // Passive V2 migration internal helper. Translates fetch / 5xx / json-parse
+  // failures into `KeylessPassiveMigrationNetworkError` so the migration loop
+  // can roll back the 24h throttle on transient network issues. Other flows
+  // (e.g. user-driven refresh) must use `tryRefreshTokenFromStorage` instead.
+  private async refreshAccessTokenForKeylessBackendShareV2MigrationPassive(params: {
     ownerId: string;
     password: string;
   }): Promise<IKeylessAccessTokenWithoutPromptResult | null> {
@@ -2171,27 +2174,45 @@ class ServiceKeylessWallet extends ServiceBase {
     }
 
     const refreshUrl = `${KEYLESS_SUPABASE_PROJECT_URL}/auth/v1/token?grant_type=refresh_token`;
-    const response = await fetch(refreshUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
+    let response: Response;
+    try {
+      response = await fetch(refreshUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
 
-        // oxlint-disable-next-line @cspell/spellchecker
-        apikey: KEYLESS_SUPABASE_PUBLIC_API_KEY,
-      },
-      body: JSON.stringify({
-        refresh_token: refreshToken,
-      }),
-    });
+          // oxlint-disable-next-line @cspell/spellchecker
+          apikey: KEYLESS_SUPABASE_PUBLIC_API_KEY,
+        },
+        body: JSON.stringify({
+          refresh_token: refreshToken,
+        }),
+      });
+    } catch (error) {
+      // Fetch threw (offline / DNS / TLS / abort). Surface as a network
+      // error so the migration loop does not consume its 24h throttle window.
+      throw new KeylessPassiveMigrationNetworkError(error);
+    }
 
+    // 5xx indicates the auth server is unreachable or misbehaving — treat as
+    // a network-class failure. 4xx indicates the refresh token was rejected
+    // (revoked / mismatched), which is an auth failure we should throttle.
+    if (response.status >= 500) {
+      throw new KeylessPassiveMigrationNetworkError();
+    }
     if (!response.ok) {
       return null;
     }
 
-    const refreshResult = (await response.json()) as {
-      access_token?: string;
-      refresh_token?: string;
-    };
+    let refreshResult: { access_token?: string; refresh_token?: string };
+    try {
+      refreshResult = (await response.json()) as {
+        access_token?: string;
+        refresh_token?: string;
+      };
+    } catch (error) {
+      throw new KeylessPassiveMigrationNetworkError(error);
+    }
 
     if (!refreshResult?.access_token || !refreshResult?.refresh_token) {
       return null;
@@ -2203,7 +2224,12 @@ class ServiceKeylessWallet extends ServiceBase {
     };
   }
 
-  private async getKeylessAccessTokenWithoutPrompt(params: {
+  // Passive V2 migration internal helper. Returns the cached access token
+  // when still valid, otherwise delegates to the passive-migration refresh
+  // helper which may throw `KeylessPassiveMigrationNetworkError` on transient
+  // network failures. Other flows must NOT call this — use the regular
+  // `tryRefreshTokenFromStorage` path which preserves prompt-based UX.
+  private async getAccessTokenForKeylessBackendShareV2MigrationPassive(params: {
     ownerId: string;
     password: string;
   }): Promise<IKeylessAccessTokenWithoutPromptResult | null> {
@@ -2218,7 +2244,7 @@ class ServiceKeylessWallet extends ServiceBase {
         accessToken: cachedToken,
       };
     }
-    return this.refreshKeylessAccessTokenFromStorageWithPassword({
+    return this.refreshAccessTokenForKeylessBackendShareV2MigrationPassive({
       ownerId,
       password,
     });
@@ -2265,6 +2291,32 @@ class ServiceKeylessWallet extends ServiceBase {
       record?.keylessProvider === identity.keylessProvider &&
       record?.socialUserIdHash === identity.socialUserIdHash
     );
+  }
+
+  private async restoreKeylessBackendShareV2MigrationRecord(params: {
+    walletId: string;
+    previousRecord:
+      | {
+          ownerId?: string;
+          keylessProvider?: string;
+          socialUserIdHash?: string;
+          lastPassiveAttemptAt?: number;
+          lastPassiveFailedAt?: number;
+          succeededAt?: number;
+        }
+      | undefined;
+  }): Promise<void> {
+    const { walletId, previousRecord } = params;
+    await keylessBackendShareV2MigrationPersistAtom.set((prev) => {
+      const prevByWalletId = prev?.byWalletId ?? {};
+      const nextByWalletId = { ...prevByWalletId };
+      if (previousRecord) {
+        nextByWalletId[walletId] = previousRecord;
+      } else {
+        delete nextByWalletId[walletId];
+      }
+      return { byWalletId: nextByWalletId };
+    });
   }
 
   private async markKeylessBackendShareV2PassiveAttempt(params: {
@@ -2357,6 +2409,14 @@ class ServiceKeylessWallet extends ServiceBase {
         return 'token_identity_mismatch';
       }
 
+      // Compare the token's issuer-derived provider strictly against the
+      // local wallet's stored provider. Same-email both-providers wallets
+      // (whose local `keylessProvider` was rewritten by `fixedKeylessProviderMap`
+      // to the alternative provider) intentionally fall through to
+      // `token_provider_mismatch` here: passive migration must NOT auto-migrate
+      // this case. The user must first complete the manual same-email
+      // reconciliation flow; the subsequent restore/reset flow then performs
+      // the v1 -> v2 migration under user-driven context.
       const tokenProvider = this.buildKeylessProviderFromSocialToken({
         token,
         skipFixedProvider: true,
@@ -2493,6 +2553,12 @@ class ServiceKeylessWallet extends ServiceBase {
       };
     }
 
+    // Capture the previous record so we can roll back the throttle write if
+    // the migration fails with a network-class error.
+    const previousMigrationRecord = isMigrationRecordMatched
+      ? { ...migrationRecord }
+      : undefined;
+
     await this.markKeylessBackendShareV2PassiveAttempt({
       walletId: keylessWallet.id,
       identity: migrationIdentity,
@@ -2500,10 +2566,11 @@ class ServiceKeylessWallet extends ServiceBase {
     });
 
     try {
-      const tokenInfo = await this.getKeylessAccessTokenWithoutPrompt({
-        ownerId,
-        password,
-      });
+      const tokenInfo =
+        await this.getAccessTokenForKeylessBackendShareV2MigrationPassive({
+          ownerId,
+          password,
+        });
       if (!tokenInfo) {
         await this.markKeylessBackendShareV2MigrationFailed({
           walletId: keylessWallet.id,
@@ -2671,7 +2738,22 @@ class ServiceKeylessWallet extends ServiceBase {
         checked: true,
         skipped: false,
       };
-    } catch (_error) {
+    } catch (error) {
+      if (error instanceof KeylessPassiveMigrationNetworkError) {
+        // Roll back the throttle write so the next natural trigger (app
+        // launch / password cache) retries without delay once the network
+        // recovers. No `lastPassiveFailedAt` is set for network failures.
+        await this.restoreKeylessBackendShareV2MigrationRecord({
+          walletId: keylessWallet.id,
+          previousRecord: previousMigrationRecord,
+        });
+        return {
+          migrated: false,
+          checked: false,
+          skipped: true,
+          reason: 'network_unavailable',
+        };
+      }
       await this.markKeylessBackendShareV2MigrationFailed({
         walletId: keylessWallet.id,
         identity: migrationIdentity,

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -2293,6 +2293,51 @@ class ServiceKeylessWallet extends ServiceBase {
     );
   }
 
+  // Treat fetch / 5xx / timeout failures from any step of the passive
+  // migration (token refresh, Prime API reads, Prime API writes) as a
+  // network-class error. Rolling back the throttle here means the next
+  // natural trigger retries without waiting 24h, regardless of whether the
+  // failure happened in the refresh helper or in a subsequent Prime call.
+  private isKeylessPassiveMigrationNetworkLikeError(error: unknown): boolean {
+    if (error instanceof KeylessPassiveMigrationNetworkError) {
+      return true;
+    }
+    if (
+      errorUtils.isErrorByClassName({
+        error,
+        className: EOneKeyErrorClassNames.AxiosNetworkError,
+      })
+    ) {
+      return true;
+    }
+    const httpStatusCode = (error as IOneKeyError | undefined)?.httpStatusCode;
+    if (
+      typeof httpStatusCode === 'number' &&
+      httpStatusCode >= 500 &&
+      httpStatusCode < 600
+    ) {
+      return true;
+    }
+    // Axios timeout / DNS / connection errors that the interceptor does not
+    // rewrap (e.g. ECONNABORTED, ETIMEDOUT, ENOTFOUND) bubble up as raw
+    // AxiosError. Match by `.code` so we don't depend on locale-sensitive
+    // `.message` strings.
+    const errorCode = (error as { code?: string | number } | undefined)?.code;
+    if (typeof errorCode === 'string') {
+      if (
+        errorCode === 'ECONNABORTED' ||
+        errorCode === 'ETIMEDOUT' ||
+        errorCode === 'ECONNRESET' ||
+        errorCode === 'ECONNREFUSED' ||
+        errorCode === 'ENOTFOUND' ||
+        errorCode === 'ERR_NETWORK'
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private async restoreKeylessBackendShareV2MigrationRecord(params: {
     walletId: string;
     previousRecord:
@@ -2739,10 +2784,14 @@ class ServiceKeylessWallet extends ServiceBase {
         skipped: false,
       };
     } catch (error) {
-      if (error instanceof KeylessPassiveMigrationNetworkError) {
+      if (this.isKeylessPassiveMigrationNetworkLikeError(error)) {
         // Roll back the throttle write so the next natural trigger (app
         // launch / password cache) retries without delay once the network
         // recovers. No `lastPassiveFailedAt` is set for network failures.
+        // Covers both the refresh-helper path (which throws
+        // `KeylessPassiveMigrationNetworkError`) and the cached-token path
+        // (where Prime API calls fail with AxiosNetworkError / 5xx /
+        // timeout on a flaky connection).
         await this.restoreKeylessBackendShareV2MigrationRecord({
           walletId: keylessWallet.id,
           previousRecord: previousMigrationRecord,

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -2194,10 +2194,17 @@ class ServiceKeylessWallet extends ServiceBase {
       throw new KeylessPassiveMigrationNetworkError(error);
     }
 
-    // 5xx indicates the auth server is unreachable or misbehaving — treat as
-    // a network-class failure. 4xx indicates the refresh token was rejected
-    // (revoked / mismatched), which is an auth failure we should throttle.
-    if (response.status >= 500) {
+    // Transient HTTP failures must NOT consume the 24h throttle:
+    //   5xx — auth server unreachable or misbehaving
+    //   408 — request timeout
+    //   429 — rate limited (Supabase auth limits per IP / per refresh-token)
+    // Any other 4xx (401 / 403 / 422) means the refresh token was rejected
+    // (revoked / mismatched), which is a real auth failure we should throttle.
+    if (
+      response.status >= 500 ||
+      response.status === 408 ||
+      response.status === 429
+    ) {
       throw new KeylessPassiveMigrationNetworkError();
     }
     if (!response.ok) {
@@ -2311,12 +2318,18 @@ class ServiceKeylessWallet extends ServiceBase {
       return true;
     }
     const httpStatusCode = (error as IOneKeyError | undefined)?.httpStatusCode;
-    if (
-      typeof httpStatusCode === 'number' &&
-      httpStatusCode >= 500 &&
-      httpStatusCode < 600
-    ) {
-      return true;
+    if (typeof httpStatusCode === 'number') {
+      // Allowlist of HTTP statuses that represent transient infrastructure
+      // failures (vs. real policy/auth rejections). Anything else — e.g. 401
+      // / 403 / 404 / 422 — is a real failure that should consume the
+      // throttle so we don't hammer the server on every wake.
+      if (
+        (httpStatusCode >= 500 && httpStatusCode < 600) ||
+        httpStatusCode === 408 ||
+        httpStatusCode === 429
+      ) {
+        return true;
+      }
     }
     // Axios timeout / DNS / connection errors that the interceptor does not
     // rewrap (e.g. ECONNABORTED, ETIMEDOUT, ENOTFOUND) bubble up as raw

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/keylessPassiveMigrationErrors.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/keylessPassiveMigrationErrors.ts
@@ -1,0 +1,14 @@
+// Thrown when a passive-migration network request fails in a way that should
+// NOT consume the 24h throttle window — e.g., the device is offline or the
+// auth server is unreachable. The migration entrypoint catches this, rolls
+// back the throttle write, and lets the next natural trigger (app launch /
+// password cache) try again without delay.
+export class KeylessPassiveMigrationNetworkError extends Error {
+  constructor(cause?: unknown) {
+    super('Keyless passive migration network error');
+    this.name = 'KeylessPassiveMigrationNetworkError';
+    if (cause !== undefined) {
+      (this as { cause?: unknown }).cause = cause;
+    }
+  }
+}


### PR DESCRIPTION
[Claude session ↗](https://claude.ai/code/session_01ReCVwgmvzExCTnVze36Eqr)

## Summary

- Surface fetch / 5xx / JSON-parse failures during the passive token refresh as a dedicated `KeylessPassiveMigrationNetworkError`. The migration entrypoint catches this, rolls back the 24h throttle write, and lets the next natural trigger (app launch / password cache) retry immediately once the network recovers — instead of skipping for a full day on a transient failure.
- Rename the passive-migration-only access-token helpers to `getAccessTokenForKeylessBackendShareV2MigrationPassive` / `refreshAccessTokenForKeylessBackendShareV2MigrationPassive` to make their narrow scope explicit (other flows must continue to use `tryRefreshTokenFromStorage`).
- Tighten `getKeylessBackendShareV2` response typing so the `&#39;&#39;` empty-data case is part of the schema rather than cast.
- Broaden `KeylessBackendShareError` server-code matching to accept `code: detail` suffixes (e.g. `revision_conflict: actual=5 expected=3`).
- Drop the unused `apiUploadKeylessBackendShare` wrapper.
- Add tests covering: (1) network error does not consume the 24h throttle; (2) record-matched wallets roll back to the previous migration record on network error.

## Test plan

- [ ] `yarn jest packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts`
- [ ] Manual: simulate offline during keyless passive migration → confirm next foreground retry runs without waiting 24h
- [ ] Manual: simulate 5xx from Supabase token endpoint → confirm same retry behavior
- [ ] Regression: a real 4xx (revoked refresh token) still throttles for 24h