### PR TITLE
fix: upgrade shell-quote to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
     "days": 7,
     "allowlist": [
       "@onekeyhq/*",
-      "@onekeyfe/*"
+      "@onekeyfe/*",
+      "shell-quote"
     ],
     "blockOnFailure": true,
     "registryUrl": "https://registry.npmjs.org"
@@ -457,6 +458,7 @@
     "react-native-screens": "4.23.0",
     "react-native-get-random-values": "npm:@onekeyfe/react-native-get-random-values@3.0.37",
     "@isaacs/brace-expansion": "5.0.1",
-    "fast-xml-parser": "4.5.4"
+    "fast-xml-parser": "4.5.4",
+    "shell-quote": "1.8.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -44123,17 +44123,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.8.3, shell-quote@npm:^1.7.2, shell-quote@npm:^1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10/5473e354637c2bd698911224129c9a8961697486cff1fb221f234d71c153fc377674029b0223d1d3c953a68d451d79366abfe53d1a0b46ee1f28eb9ade928f4c
-  languageName: node
-  linkType: hard
-
-"shell-quote@npm:^1.6.1, shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1":
-  version: 1.8.1
-  resolution: "shell-quote@npm:1.8.1"
-  checksum: 10/af19ab5a1ec30cb4b2f91fd6df49a7442d5c4825a2e269b3712eded10eedd7f9efeaab96d57829880733fc55bcdd8e9b1d8589b4befb06667c731d08145e274d
+"shell-quote@npm:1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10/a3e3796385f2cd5cf0b78207a4439f0c7395c0833fc75b2473084b5d298c109c5c0fa687fcd1c04e4b4484866e5bb8eaae7efae443b80fff71ea7e29baf11f0c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Force all transitive `shell-quote` resolutions to `1.8.4`.
- Add a targeted `minimumReleaseAge` allowlist entry for `shell-quote` so the fresh security release can pass CI.

## Intent & Context
A Snyk Slack alert reported a Critical arbitrary command injection vulnerability in `shell-quote@1.8.1` for `apps/mobile/package.json`. The follow-up instruction was to upgrade to the fixed version `1.8.4`, which Snyk identifies as the latest non-vulnerable version.

## Root Cause
Several transitive dependencies resolved `shell-quote` to vulnerable or older versions. A recursive Yarn refresh moved semver-compatible ranges to `1.8.4`, but `concurrently@9.2.1` pins `shell-quote` exactly to `1.8.3`, so a root resolution is required to ensure every path uses `1.8.4`.

## Design Decisions
- Used a root `resolutions.shell-quote` override to force exact and ranged transitive dependencies onto the fixed version.
- Added only `shell-quote` to the release-age allowlist because `1.8.4` was published less than 7 days ago and this change is a security fix.
- Kept the change scoped to dependency metadata and lockfile updates; no application code changes were needed.

## Changes Detail
- `package.json`: add `shell-quote` to `minimumReleaseAge.allowlist` and pin `resolutions.shell-quote` to `1.8.4`.
- `yarn.lock`: collapse previous `shell-quote@1.8.1` and `shell-quote@1.8.3` entries into `shell-quote@1.8.4`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile/dev tooling, shared dependency installation across the monorepo
- **Risk Areas**: The resolution override affects transitive consumers of `shell-quote`; upstream `1.8.4` primarily tightens object token quoting validation for the security fix.

## Test plan
- [x] `yarn install --mode update-lockfile`
- [x] `yarn why shell-quote` confirms all paths resolve to `1.8.4`
- [x] `yarn check:release-age`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `yarn _packageVersions`
- [x] `git diff --check`