### PR TITLE
fix: account selector and chain selector missing Kaspa balance due to deriveType mismatch(OK-55367)

### DIFF
--- a/packages/kit-bg/src/services/ServiceNetwork/ServiceNetwork.ts
+++ b/packages/kit-bg/src/services/ServiceNetwork/ServiceNetwork.ts
@@ -1662,7 +1662,11 @@ class ServiceNetwork extends ServiceBase {
 
     const networkInfoMap: Record<
       string,
-      { deriveType: IAccountDeriveTypes; mergeDeriveAssetsEnabled: boolean }
+      {
+        deriveType: IAccountDeriveTypes;
+        mergeDeriveAssetsEnabled: boolean;
+        suffixToDeriveType: Record<string, string>;
+      }
     > = {};
 
     const formattedAccountNetworkValues: Record<string, string> = {};
@@ -1683,9 +1687,6 @@ class ServiceNetwork extends ServiceBase {
       const shouldUseAccountNetworkValue = Boolean(
         networkId && accountId && walletId === _walletId,
       );
-      const deriveType: IAccountDeriveTypes =
-        accountUtils.normalizeDeriveType(_deriveType) ?? 'default';
-
       if (shouldUseAccountNetworkValue) {
         if (!networkInfoMap[networkId]) {
           const [globalDeriveType, vaultSettings] = await Promise.all([
@@ -1695,13 +1696,29 @@ class ServiceNetwork extends ServiceBase {
             }),
             this.backgroundApi.serviceNetwork.getVaultSettings({ networkId }),
           ]);
+          const suffixToDeriveType: Record<string, string> = {};
+          for (const [dt, info] of Object.entries(
+            vaultSettings.accountDeriveInfo ?? {},
+          )) {
+            if (info.idSuffix) {
+              suffixToDeriveType[info.idSuffix.toLowerCase()] = dt;
+            }
+          }
           networkInfoMap[networkId] = {
             deriveType: globalDeriveType,
             mergeDeriveAssetsEnabled:
               vaultSettings.mergeDeriveAssetsEnabled ?? false,
+            suffixToDeriveType,
           };
         }
       }
+      const deriveType: IAccountDeriveTypes =
+        accountUtils.normalizeDeriveType(_deriveType) ??
+        (networkInfoMap[networkId]?.suffixToDeriveType?.[
+          (_deriveType ?? '').toLowerCase()
+        ] as IAccountDeriveTypes) ??
+        'default';
+
       if (
         shouldUseAccountNetworkValue &&
         networkInfoMap[networkId] &&

--- a/packages/kit-bg/src/services/ServiceNetwork/ServiceNetwork.ts
+++ b/packages/kit-bg/src/services/ServiceNetwork/ServiceNetwork.ts
@@ -60,6 +60,7 @@ import type {
   IAccountDeriveInfo,
   IAccountDeriveInfoItems,
   IAccountDeriveTypes,
+  INetworkDeriveInfo,
 } from '../../vaults/types';
 
 const defaultPinnedNetworkIds = [
@@ -1660,14 +1661,7 @@ class ServiceNetwork extends ServiceBase {
       };
     }
 
-    const networkInfoMap: Record<
-      string,
-      {
-        deriveType: IAccountDeriveTypes;
-        mergeDeriveAssetsEnabled: boolean;
-        suffixToDeriveType: Record<string, string>;
-      }
-    > = {};
+    const networkInfoMap: Record<string, INetworkDeriveInfo> = {};
 
     const formattedAccountNetworkValues: Record<string, string> = {};
     const allAccountValues: Record<string, string> = {};
@@ -1714,9 +1708,11 @@ class ServiceNetwork extends ServiceBase {
       }
       const deriveType: IAccountDeriveTypes =
         accountUtils.normalizeDeriveType(_deriveType) ??
-        (networkInfoMap[networkId]?.suffixToDeriveType?.[
-          (_deriveType ?? '').toLowerCase()
-        ] as IAccountDeriveTypes) ??
+        accountUtils.normalizeDeriveType(
+          networkInfoMap[networkId]?.suffixToDeriveType?.[
+            (_deriveType ?? '').toLowerCase()
+          ] ?? '',
+        ) ??
         'default';
 
       if (

--- a/packages/kit-bg/src/vaults/types.ts
+++ b/packages/kit-bg/src/vaults/types.ts
@@ -144,6 +144,12 @@ export type IAccountDeriveTypes =
   | IAccountDeriveTypesBtc
   | IAccountDeriveTypesKaspa;
 
+export type INetworkDeriveInfo = {
+  deriveType: IAccountDeriveTypes;
+  mergeDeriveAssetsEnabled: boolean;
+  suffixToDeriveType?: Record<string, string>;
+};
+
 export type IVaultSettingsNetworkInfo = {
   addressPrefix: string;
   curve: ICurveName;

--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -8,10 +8,7 @@ import type {
   IAllNetworkAccountsInfoResult,
 } from '@onekeyhq/kit-bg/src/services/ServiceAllNetwork/ServiceAllNetwork';
 import { useAppIsLockedAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import type {
-  IAccountDeriveTypes,
-  INetworkDeriveInfo,
-} from '@onekeyhq/kit-bg/src/vaults/types';
+import type { INetworkDeriveInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import { POLLING_DEBOUNCE_INTERVAL } from '@onekeyhq/shared/src/consts/walletConsts';
 import {
   EAppEventBusNames,

--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -197,7 +197,11 @@ function filterAllNetworkAccountsInfoResult({
 type IEnabledNetworksCompatResult = {
   networkInfoMap: Record<
     string,
-    { deriveType: IAccountDeriveTypes; mergeDeriveAssetsEnabled: boolean }
+    {
+      deriveType: IAccountDeriveTypes;
+      mergeDeriveAssetsEnabled: boolean;
+      suffixToDeriveType?: Record<string, string>;
+    }
   >;
   compatibleNetworks: IServerNetwork[];
   compatibleNetworksWithoutAccount: IServerNetwork[];
@@ -930,7 +934,11 @@ function useEnabledNetworksCompatibleWithWalletIdInAllNetworks({
       }
       const networkInfoMap: Record<
         string,
-        { deriveType: IAccountDeriveTypes; mergeDeriveAssetsEnabled: boolean }
+        {
+          deriveType: IAccountDeriveTypes;
+          mergeDeriveAssetsEnabled: boolean;
+          suffixToDeriveType?: Record<string, string>;
+        }
       > = {};
       if (networkId && !networkUtils.isAllNetwork({ networkId })) {
         return getEmptyEnabledNetworksResult();
@@ -998,9 +1006,18 @@ function useEnabledNetworksCompatibleWithWalletIdInAllNetworks({
               networkId: network.id,
             }),
           ]);
+          const suffixToDeriveType: Record<string, string> = {};
+          for (const [dt, info] of Object.entries(
+            vaultSettings.accountDeriveInfo ?? {},
+          )) {
+            if (info.idSuffix) {
+              suffixToDeriveType[info.idSuffix.toLowerCase()] = dt;
+            }
+          }
           networkInfoMap[network.id] = {
             deriveType: globalDeriveType,
             mergeDeriveAssetsEnabled: !!vaultSettings.mergeDeriveAssetsEnabled,
+            suffixToDeriveType,
           };
         }
       }

--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -8,7 +8,10 @@ import type {
   IAllNetworkAccountsInfoResult,
 } from '@onekeyhq/kit-bg/src/services/ServiceAllNetwork/ServiceAllNetwork';
 import { useAppIsLockedAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
+import type {
+  IAccountDeriveTypes,
+  INetworkDeriveInfo,
+} from '@onekeyhq/kit-bg/src/vaults/types';
 import { POLLING_DEBOUNCE_INTERVAL } from '@onekeyhq/shared/src/consts/walletConsts';
 import {
   EAppEventBusNames,
@@ -195,14 +198,7 @@ function filterAllNetworkAccountsInfoResult({
 }
 
 type IEnabledNetworksCompatResult = {
-  networkInfoMap: Record<
-    string,
-    {
-      deriveType: IAccountDeriveTypes;
-      mergeDeriveAssetsEnabled: boolean;
-      suffixToDeriveType?: Record<string, string>;
-    }
-  >;
+  networkInfoMap: Record<string, INetworkDeriveInfo>;
   compatibleNetworks: IServerNetwork[];
   compatibleNetworksWithoutAccount: IServerNetwork[];
 };
@@ -932,14 +928,7 @@ function useEnabledNetworksCompatibleWithWalletIdInAllNetworks({
       if (!walletId) {
         return getEmptyEnabledNetworksResult();
       }
-      const networkInfoMap: Record<
-        string,
-        {
-          deriveType: IAccountDeriveTypes;
-          mergeDeriveAssetsEnabled: boolean;
-          suffixToDeriveType?: Record<string, string>;
-        }
-      > = {};
+      const networkInfoMap: Record<string, INetworkDeriveInfo> = {};
       if (networkId && !networkUtils.isAllNetwork({ networkId })) {
         return getEmptyEnabledNetworksResult();
       }

--- a/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
+++ b/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
@@ -12,13 +12,13 @@ import type {
   IDBIndexedAccount,
   IDBWallet,
 } from '@onekeyhq/kit-bg/src/dbs/local/types';
-import type { INetworkDeriveInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import {
   useActiveAccountValueAtom,
   useAppIsLockedAtom,
   useCurrencyPersistAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import type { INetworkDeriveInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { getPresetNetworks } from '@onekeyhq/shared/src/config/presetNetworks';
 import {

--- a/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
+++ b/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
@@ -12,6 +12,7 @@ import type {
   IDBIndexedAccount,
   IDBWallet,
 } from '@onekeyhq/kit-bg/src/dbs/local/types';
+import type { INetworkDeriveInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import {
   useActiveAccountValueAtom,
   useAppIsLockedAtom,
@@ -342,13 +343,7 @@ async function getTrayActiveAccountScope({
 type ITrayEnabledNetworkScope = {
   enabledNetworkIds: string[];
   enabledNetworksCompatibleWithWalletId: Array<{ id: string }>;
-  networkInfoMap: Record<
-    string,
-    {
-      deriveType: string;
-      mergeDeriveAssetsEnabled: boolean;
-    }
-  >;
+  networkInfoMap: Record<string, INetworkDeriveInfo>;
 };
 
 async function getTrayEnabledNetworkScope({
@@ -408,11 +403,20 @@ async function getTrayEnabledNetworkScope({
           networkId: network.id,
         }),
       ]);
+      const suffixToDeriveType: Record<string, string> = {};
+      for (const [dt, info] of Object.entries(
+        vaultSettings.accountDeriveInfo ?? {},
+      )) {
+        if (info.idSuffix) {
+          suffixToDeriveType[info.idSuffix.toLowerCase()] = dt;
+        }
+      }
       return [
         network.id,
         {
           deriveType,
           mergeDeriveAssetsEnabled: !!vaultSettings.mergeDeriveAssetsEnabled,
+          suffixToDeriveType,
         },
       ] as const;
     }),

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
@@ -101,6 +101,7 @@ export function AccountSelectorAccountListItem({
     {
       deriveType: IAccountDeriveTypes;
       mergeDeriveAssetsEnabled: boolean;
+      suffixToDeriveType?: Record<string, string>;
     }
   >;
 }) {

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
@@ -30,7 +30,7 @@ import {
   useAccountSelectorValuesMapAtom,
   useIndexedAccountAddressCreationStateAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
+import type { INetworkDeriveInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
@@ -96,14 +96,7 @@ export function AccountSelectorAccountListItem({
   mergeDeriveAssetsEnabled: boolean | undefined;
   hideAddress?: boolean;
   enabledNetworksCompatibleWithWalletId: IServerNetwork[];
-  networkInfoMap: Record<
-    string,
-    {
-      deriveType: IAccountDeriveTypes;
-      mergeDeriveAssetsEnabled: boolean;
-      suffixToDeriveType?: Record<string, string>;
-    }
-  >;
+  networkInfoMap: Record<string, INetworkDeriveInfo>;
 }) {
   const actions = useAccountSelectorActions();
   const {

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountValue.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountValue.tsx
@@ -5,7 +5,7 @@ import BigNumber from 'bignumber.js';
 import { Currency } from '@onekeyhq/kit/src/components/Currency';
 import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
 import { useActiveAccountValueAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
+import type { INetworkDeriveInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { calculateAccountTotalValue } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { IServerNetwork } from '@onekeyhq/shared/types';
@@ -33,14 +33,7 @@ function AccountValue(accountValue: {
   mergeDeriveAssetsEnabled?: boolean;
   isSingleAddress?: boolean;
   enabledNetworksCompatibleWithWalletId: IServerNetwork[];
-  networkInfoMap: Record<
-    string,
-    {
-      deriveType: IAccountDeriveTypes;
-      mergeDeriveAssetsEnabled: boolean;
-      suffixToDeriveType?: Record<string, string>;
-    }
-  >;
+  networkInfoMap: Record<string, INetworkDeriveInfo>;
 }) {
   const [activeAccountValue] = useActiveAccountValueAtom();
   const isActiveAccount =
@@ -177,14 +170,7 @@ function AccountValueWithSpotlight({
   isSingleAddress?: boolean;
   walletId: string;
   enabledNetworksCompatibleWithWalletId: IServerNetwork[];
-  networkInfoMap: Record<
-    string,
-    {
-      deriveType: IAccountDeriveTypes;
-      mergeDeriveAssetsEnabled: boolean;
-      suffixToDeriveType?: Record<string, string>;
-    }
-  >;
+  networkInfoMap: Record<string, INetworkDeriveInfo>;
   accountDeFiOverview?: {
     overview: Record<
       string,

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountValue.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountValue.tsx
@@ -38,6 +38,7 @@ function AccountValue(accountValue: {
     {
       deriveType: IAccountDeriveTypes;
       mergeDeriveAssetsEnabled: boolean;
+      suffixToDeriveType?: Record<string, string>;
     }
   >;
 }) {
@@ -181,6 +182,7 @@ function AccountValueWithSpotlight({
     {
       deriveType: IAccountDeriveTypes;
       mergeDeriveAssetsEnabled: boolean;
+      suffixToDeriveType?: Record<string, string>;
     }
   >;
   accountDeFiOverview?: {

--- a/packages/shared/src/utils/tokenUtils.test.ts
+++ b/packages/shared/src/utils/tokenUtils.test.ts
@@ -158,6 +158,26 @@ describe('calculateAccountTotalValue — wallet-scoped derive matching branch', 
     ).toBe('175');
   });
 
+  test('resolves idSuffix via suffixToDeriveType when normalizeDeriveType fails (Kaspa KaspaOrg → kaspaOfficial)', () => {
+    expect(
+      calculateAccountTotalValue({
+        tokensValue: {
+          'hd-1--m/44\'/111111\'/0\'/0/0--KaspaOrg_kaspa--kaspa': '38',
+        },
+        deFiNetWorth: 0,
+        walletId: 'hd-1',
+        enabledNetworksCompatibleWithWalletId: [{ id: 'kaspa--kaspa' }],
+        networkInfoMap: {
+          'kaspa--kaspa': {
+            deriveType: 'kaspaOfficial',
+            mergeDeriveAssetsEnabled: false,
+            suffixToDeriveType: { kaspaorg: 'kaspaOfficial' },
+          },
+        },
+      }),
+    ).toBe('38');
+  });
+
   test('normalizes unknown deriveType to "default" per allowlist (regression: AccountValue parity)', () => {
     // Original AccountValue.tsx used accountUtils.normalizeDeriveType(_deriveType) ?? 'default'.
     // normalizeDeriveType validates against an allowlist and returns undefined for unknown values,

--- a/packages/shared/src/utils/tokenUtils.test.ts
+++ b/packages/shared/src/utils/tokenUtils.test.ts
@@ -162,7 +162,7 @@ describe('calculateAccountTotalValue — wallet-scoped derive matching branch', 
     expect(
       calculateAccountTotalValue({
         tokensValue: {
-          'hd-1--m/44\'/111111\'/0\'/0/0--KaspaOrg_kaspa--kaspa': '38',
+          "hd-1--m/44'/111111'/0'/0/0--KaspaOrg_kaspa--kaspa": '38',
         },
         deFiNetWorth: 0,
         walletId: 'hd-1',
@@ -171,6 +171,7 @@ describe('calculateAccountTotalValue — wallet-scoped derive matching branch', 
           'kaspa--kaspa': {
             deriveType: 'kaspaOfficial',
             mergeDeriveAssetsEnabled: false,
+            // cspell:ignore kaspaorg
             suffixToDeriveType: { kaspaorg: 'kaspaOfficial' },
           },
         },

--- a/packages/shared/src/utils/tokenUtils.ts
+++ b/packages/shared/src/utils/tokenUtils.ts
@@ -1266,6 +1266,7 @@ export function calculateAccountTotalValue(params: {
     {
       deriveType: string;
       mergeDeriveAssetsEnabled: boolean;
+      suffixToDeriveType?: Record<string, string>;
     }
   >;
 }): string | undefined {
@@ -1306,10 +1307,13 @@ export function calculateAccountTotalValue(params: {
       const restAccountId = keyArray.join('_');
       const parts = restAccountId.split(SEPARATOR);
       const keyWalletId = parts[0];
-      const keyDeriveType = (
-        accountUtils.normalizeDeriveType(parts[2] || '') ?? 'default'
-      ).toLowerCase();
       const infoEntry = networkInfoMap[netId];
+      const rawSuffix = parts[2] || '';
+      const keyDeriveType = (
+        accountUtils.normalizeDeriveType(rawSuffix) ??
+        infoEntry?.suffixToDeriveType?.[rawSuffix.toLowerCase()] ??
+        'default'
+      ).toLowerCase();
       if (
         keyWalletId === walletId &&
         compatibleIds.has(netId) &&


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55367](https://onekeyhq.atlassian.net/browse/OK-55367)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Fix Kaspa balance missing from account selector and chain/network selector when using `kaspaOfficial` derive type
- Build `suffixToDeriveType` reverse-map from vault settings to bridge the gap between `idSuffix` (address encoding) and derive type name
- Extract shared `INetworkDeriveInfo` type, add Kaspa-specific unit test, remove unsafe `as` cast

## Intent & Context
Users reported that the account selector showed a lower total balance than the home page — specifically missing the Kaspa network amount (~€38). The chain/network selector (both All Network and single chain views) also failed to display Kaspa balances under the `kaspaOfficial` derive path.

## Root Cause
Kaspa has two derive types: `default` and `kaspaOfficial`. The `kaspaOfficial` derive uses `idSuffix: EAddressEncodings.KASPA_ORG = 'KaspaOrg'`, which is embedded in the DB account ID (e.g. `hw-xxx--m/44'/111111'/0'/0/0--KaspaOrg`).

The wallet-scoped balance filter in `calculateAccountTotalValue` (and `sortChainSelectorNetworksByValue`) extracts this suffix and calls `normalizeDeriveType('KaspaOrg')` to resolve it. However, `normalizeDeriveType` only matches against the derive type *name* list (`['default', 'kaspaOfficial', ...]`), and `'KaspaOrg'` (an address encoding) is not in that list. The normalization fails, falls back to `'default'`, which doesn't match the global derive type `'kaspaOfficial'` — so Kaspa is silently excluded from the total.

This is unique to Kaspa because other chains with `idSuffix` (e.g. EVM's `LedgerLive`) happen to use the same string as their derive type name (case-insensitively), so normalization succeeds.

## Design Decisions
- **Approach chosen**: Build a `suffixToDeriveType` reverse-map from `vaultSettings.accountDeriveInfo` at the point where vault settings are already loaded, and pass it through `networkInfoMap`. This correctly maps `'KaspaOrg'` → `'kaspaOfficial'` without hardcoding aliases.
- **Alternative considered**: Hardcoding aliases in `normalizeDeriveType` — rejected as fragile and requiring maintenance for each new chain.
- **Alternative considered**: Changing Kaspa's `idSuffix` to match the derive type name — rejected as it would break existing account IDs in the database.

## Changes Detail
- `packages/shared/src/utils/tokenUtils.ts` — Use `suffixToDeriveType` fallback in `calculateAccountTotalValue` when `normalizeDeriveType` fails
- `packages/kit/src/hooks/useAllNetwork.ts` — Build `suffixToDeriveType` map from `vaultSettings.accountDeriveInfo` in the network info hook
- `packages/kit-bg/src/services/ServiceNetwork/ServiceNetwork.ts` — Same fix in `sortChainSelectorNetworksByValue` for chain selector; replace `as` cast with runtime-safe `normalizeDeriveType` call
- `packages/kit-bg/src/vaults/types.ts` — Extract `INetworkDeriveInfo` shared type
- `packages/kit/src/views/.../AccountValue.tsx`, `AccountSelectorAccountListItem.tsx` — Use shared `INetworkDeriveInfo` type
- `packages/shared/src/utils/tokenUtils.test.ts` — Add unit test for `KaspaOrg → kaspaOfficial` resolution

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: All (Extension / Mobile / Desktop / Web)
- **Risk Areas**: Balance calculation in account selector and chain selector. The fix is additive — it only adds a fallback lookup path. Existing chains where `idSuffix` matches the derive type name (EVM LedgerLive/LedgerLegacy) are unaffected as `normalizeDeriveType` succeeds before the fallback is reached.

## Test plan
- [ ] Use a hardware wallet (e.g. OneKey Classic 1S) with Kaspa account using `kaspaOfficial` derive path
- [ ] Verify account selector shows correct total balance including Kaspa
- [ ] Verify chain/network selector (All Network view) shows Kaspa balance
- [ ] Verify single-chain Kaspa selector shows correct balance
- [ ] Switch Kaspa global derive type between `default` and `kaspaOfficial`, confirm both work
- [ ] Verify BTC (mergeDeriveAssetsEnabled) and EVM (LedgerLive) are unaffected
- [ ] Run `yarn test packages/shared/src/utils/tokenUtils.test.ts` — all 13 tests pass

[OK-55367]: https://onekeyhq.atlassian.net/browse/OK-55367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ