### PR TITLE
fix: optimize firmware upgrade copy(OK-55100)

### DIFF
--- a/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/DeviceUpdateAlert.tsx
+++ b/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/DeviceUpdateAlert.tsx
@@ -10,10 +10,10 @@ import {
 import { useFirmwareUpdatesDetectStatusPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
-import deviceUtils from '@onekeyhq/shared/src/utils/deviceUtils';
 
 import { FirmwareUpdateReminderAlert } from '../../../FirmwareUpdate/components/HomeFirmwareUpdateReminder';
 import { useFirmwareUpdateActions } from '../../../FirmwareUpdate/hooks/useFirmwareUpdateActions';
+import { getTargetFirmwareTypeLabel } from '../../../FirmwareUpdate/utils';
 
 export function DeviceUpdateAlert({ type }: { type?: 'top' | 'bottom' }) {
   const intl = useIntl();
@@ -51,11 +51,13 @@ export function DeviceUpdateAlert({ type }: { type?: 'top' | 'bottom' }) {
 
   let message = 'New firmware is available';
   if (detectResult?.detectInfo?.toVersion) {
-    const firmwareTypeLabel = deviceUtils.getFirmwareTypeLabelByFirmwareType({
+    const firmwareTypeLabel = getTargetFirmwareTypeLabel({
       firmwareType: detectResult.detectInfo.toFirmwareType,
-      displayFormat: 'withSpace',
+      intl,
     });
-    const version = `${firmwareTypeLabel}${detectResult.detectInfo.toVersion}`;
+    const version = [firmwareTypeLabel, detectResult.detectInfo.toVersion]
+      .filter(Boolean)
+      .join(' ');
     message = intl.formatMessage(
       { id: ETranslations.update_firmware_version_available },
       {

--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareChangeLogView.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareChangeLogView.tsx
@@ -110,10 +110,18 @@ function ChangeLogSection({
       >
         {({ open }: { open: boolean }) => (
           <>
-            <XStack ai="center" gap="$1.5" flex={1}>
+            <XStack
+              ai="center"
+              gap="$1.5"
+              flex={1}
+              minWidth={0}
+              flexShrink={1}
+              flexWrap="wrap"
+            >
               <SizableText
                 size="$bodyLgMedium"
                 color={open ? '$text' : '$textSubdued'}
+                flexShrink={0}
               >
                 {title}
               </SizableText>
@@ -130,6 +138,7 @@ function ChangeLogSection({
               animation="quick"
               animateOnly={ANIMATE_ONLY_TRANSFORM}
               rotate={open ? '-180deg' : '0deg'}
+              flexShrink={0}
             >
               <Icon
                 name="ChevronDownSmallOutline"

--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdatePageLayout.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdatePageLayout.tsx
@@ -41,14 +41,28 @@ export function FirmwareUpdatePageHeaderTitle(props: {
     title = result.deviceName;
   }
   return (
-    <XStack ai="center" gap={6}>
-      <DeviceAvatarWithColor
-        size="$6"
-        deviceType={result.deviceType || EDeviceType.Unknown}
-        features={result.features}
-      />
-      <SizableText size="$headingMd">{title}</SizableText>
-      <SizableText size="$bodyLg" color="$textSubdued">
+    <XStack ai="center" gap={6} flex={1} minWidth={0}>
+      <Stack flexShrink={0}>
+        <DeviceAvatarWithColor
+          size="$6"
+          deviceType={result.deviceType || EDeviceType.Unknown}
+          features={result.features}
+        />
+      </Stack>
+      <SizableText
+        size="$headingMd"
+        minWidth={0}
+        flexShrink={1}
+        numberOfLines={1}
+      >
+        {title}
+      </SizableText>
+      <SizableText
+        size="$bodyLg"
+        color="$textSubdued"
+        flexShrink={0}
+        numberOfLines={1}
+      >
         {result.deviceBleName}
       </SizableText>
     </XStack>

--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareVersionProgressBar.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareVersionProgressBar.tsx
@@ -1,7 +1,9 @@
+import { useIntl } from 'react-intl';
+
 import { Anchor, Badge, Icon, SizableText, XStack } from '@onekeyhq/components';
-import deviceUtils from '@onekeyhq/shared/src/utils/deviceUtils';
 
 import { useFirmwareVersionValid } from '../hooks/useFirmwareVersionValid';
+import { getTargetFirmwareTypeLabel } from '../utils';
 
 import type { EFirmwareType } from '@onekeyfe/hd-shared';
 
@@ -14,12 +16,12 @@ export function FirmwareVersionProgressBar({
 }) {
   const { versionValid, unknownMessage } = useFirmwareVersionValid();
   return (
-    <XStack gap="$2.5" alignItems="center">
-      <Badge badgeType="default" badgeSize="lg">
+    <XStack gap="$2.5" alignItems="center" minWidth={0} flexWrap="wrap">
+      <Badge badgeType="default" badgeSize="lg" flexShrink={1} minWidth={0}>
         {versionValid(fromVersion) ? fromVersion : unknownMessage}
       </Badge>
-      <Icon name="ArrowRightSolid" size="$4" />
-      <Badge badgeType="info" badgeSize="lg">
+      <Icon name="ArrowRightSolid" size="$4" flexShrink={0} />
+      <Badge badgeType="info" badgeSize="lg" flexShrink={1} minWidth={0}>
         {toVersion?.length > 0 ? toVersion : unknownMessage}
       </Badge>
     </XStack>
@@ -42,57 +44,60 @@ export function FirmwareVersionProgressText({
   active: boolean;
 }) {
   const { versionValid, unknownMessage } = useFirmwareVersionValid();
+  const intl = useIntl();
 
   const formatLabel = (firmwareType?: EFirmwareType) =>
-    deviceUtils.getFirmwareTypeLabelByFirmwareType({
-      firmwareType,
-      returnUniversal: true,
-      displayFormat: 'withSpace',
-    });
+    getTargetFirmwareTypeLabel({ firmwareType, intl });
+  const formatVersionText = (
+    firmwareType: EFirmwareType | undefined,
+    version: string,
+  ) => [formatLabel(firmwareType), version].filter(Boolean).join(' ');
 
-  const fromFirmwareTypeStr = formatLabel(fromFirmwareType);
-  const toFirmwareTypeStr = formatLabel(toFirmwareType);
+  const textColor = active ? '$text' : '$textSubdued';
+  const versionTextProps = {
+    size: '$bodyLgMedium',
+    minWidth: 0,
+    flexShrink: 1,
+    numberOfLines: 1,
+  } as const;
+  const fromVersionText = versionValid(fromVersion)
+    ? formatVersionText(fromFirmwareType, fromVersion)
+    : unknownMessage;
+  const toVersionText =
+    toVersion?.length > 0
+      ? formatVersionText(toFirmwareType, toVersion)
+      : unknownMessage;
 
   return (
-    <>
-      <SizableText
-        size="$bodyLgMedium"
-        color={active ? '$text' : '$textSubdued'}
-      >
-        {versionValid(fromVersion)
-          ? `${fromFirmwareTypeStr}${fromVersion}`
-          : unknownMessage}
+    <XStack
+      alignItems="center"
+      gap="$1.5"
+      minWidth={0}
+      flexShrink={1}
+      flexWrap="wrap"
+    >
+      <SizableText {...versionTextProps} color={textColor}>
+        {fromVersionText}
       </SizableText>
-      <Icon
-        name="ArrowRightSolid"
-        size="$4"
-        color={active ? '$text' : '$textSubdued'}
-      />
+      <Icon name="ArrowRightSolid" size="$4" color={textColor} flexShrink={0} />
       {githubReleaseUrl ? (
         <Anchor
+          {...versionTextProps}
           href={githubReleaseUrl}
           color="$textSuccess"
-          size="$bodyLgMedium"
           target="_blank"
           textDecorationLine="underline"
           onPress={(e) => {
             e.stopPropagation();
           }}
         >
-          {toVersion?.length > 0
-            ? `${toFirmwareTypeStr}${toVersion}`
-            : unknownMessage}
+          {toVersionText}
         </Anchor>
       ) : (
-        <SizableText
-          size="$bodyLgMedium"
-          color={active ? '$text' : '$textSubdued'}
-        >
-          {toVersion?.length > 0
-            ? `${toFirmwareTypeStr}${toVersion}`
-            : unknownMessage}
+        <SizableText {...versionTextProps} color={textColor}>
+          {toVersionText}
         </SizableText>
       )}
-    </>
+    </XStack>
   );
 }

--- a/packages/kit/src/views/FirmwareUpdate/pages/PageFirmwareUpdateChangeLog.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/pages/PageFirmwareUpdateChangeLog.tsx
@@ -27,7 +27,6 @@ import {
   ForceExtensionUpdatingFromExpandTab,
 } from '../components/FirmwareUpdateExitPrevent';
 import {
-  FirmwareUpdatePageHeader,
   FirmwareUpdatePageHeaderTitle,
   FirmwareUpdatePageLayout,
 } from '../components/FirmwareUpdatePageLayout';
@@ -100,6 +99,10 @@ function PageFirmwareUpdateChangeLog() {
     },
   );
 
+  const shouldShowChangeLog =
+    stepInfo.step === EFirmwareUpdateSteps.showChangeLog ||
+    stepInfo.step === EFirmwareUpdateSteps.showCheckList;
+
   const content = useMemo(() => {
     // keep change log modal content when install modal back
     if (confirmUpdateResult.current) {
@@ -129,10 +132,7 @@ function PageFirmwareUpdateChangeLog() {
         </>
       );
     }
-    if (
-      stepInfo.step === EFirmwareUpdateSteps.showChangeLog ||
-      stepInfo.step === EFirmwareUpdateSteps.showCheckList
-    ) {
+    if (shouldShowChangeLog) {
       return (
         <FirmwareChangeLogView
           result={result}
@@ -143,7 +143,15 @@ function PageFirmwareUpdateChangeLog() {
       );
     }
     return <FirmwareLatestVersionInstalled />;
-  }, [connectId, isLoading, result, run, stepInfo.payload, stepInfo.step]);
+  }, [
+    connectId,
+    isLoading,
+    result,
+    run,
+    shouldShowChangeLog,
+    stepInfo.payload,
+    stepInfo.step,
+  ]);
 
   return (
     <Page
@@ -155,14 +163,9 @@ function PageFirmwareUpdateChangeLog() {
     >
       <FirmwareUpdatePageLayout
         headerTitle={
-          <FirmwareUpdatePageHeader
-            headerTitle={
-              stepInfo.step === EFirmwareUpdateSteps.showChangeLog ||
-              stepInfo.step === EFirmwareUpdateSteps.showCheckList ? (
-                <FirmwareUpdatePageHeaderTitle result={result} />
-              ) : undefined
-            }
-          />
+          shouldShowChangeLog ? (
+            <FirmwareUpdatePageHeaderTitle result={result} />
+          ) : undefined
         }
         containerStyle={{
           p:

--- a/packages/kit/src/views/FirmwareUpdate/utils.ts
+++ b/packages/kit/src/views/FirmwareUpdate/utils.ts
@@ -11,6 +11,10 @@ export function getTargetFirmwareTypeLabel({
   firmwareType: EFirmwareType | undefined;
   intl: IntlShape;
 }) {
+  if (!firmwareType) {
+    return '';
+  }
+
   return intl.formatMessage({
     id:
       firmwareType === EFirmwareType.BitcoinOnly


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55100](https://onekeyhq.atlassian.net/browse/OK-55100)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Use localized firmware type labels for firmware switch/update copy so user-facing text shows Bitcoin-only / Multi-chain wording instead of raw Universal-style labels.
- Tighten firmware update mobile layout around the header, version row, and changelog row to avoid crowded or overlapping localized text.
- Remove nested firmware update header rendering in the changelog/checklist flow and keep undefined firmware types displayed as plain versions.

## Jira

- OK-55100

## Intent & Context

OK-55100 reported firmware upgrade copy inconsistencies: switch/update copy needed to be updated together, extra spacing around firmware type placeholders should be removed, Universal wording should become Multi-chain wording, and mobile firmware upgrade text was crowded/overlapping.

Current `x` already contains the generated locale updates from the Lokalise pull, so this PR only carries the code-side firmware label and layout changes.

## Risk Assessment

- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Desktop, Web, Extension
- **Risk Areas**: Header rendering differs across desktop and native iOS; firmware type labels now depend on localized keys instead of raw hardware utility labels.

## Test Plan

- [x] `yarn lint:staged`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/DeviceUpdateAlert.tsx packages/kit/src/views/FirmwareUpdate/components/FirmwareChangeLogView.tsx packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdatePageLayout.tsx packages/kit/src/views/FirmwareUpdate/components/FirmwareVersionProgressBar.tsx packages/kit/src/views/FirmwareUpdate/pages/PageFirmwareUpdateChangeLog.tsx packages/kit/src/views/FirmwareUpdate/utils.ts`
- [x] `git diff --check upstream/x...HEAD`
- [x] `yarn tsc:staged` passed before rebasing this change onto the latest `upstream/x`
- [ ] `yarn tsc:staged` on the latest `upstream/x` currently fails in an unrelated file not touched by this PR: `packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts:813` (`CoreApi.preInitialize` type mismatch)

[OK-55100]: https://onekeyhq.atlassian.net/browse/OK-55100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ