### PR TITLE
fix: remove chainlist page cache to surface network errors(OK-55303)

### DIFF
--- a/packages/kit-bg/src/services/ServiceCustomRpc.ts
+++ b/packages/kit-bg/src/services/ServiceCustomRpc.ts
@@ -47,9 +47,7 @@ class ServiceCustomRpc extends ServiceBase {
     };
   }
 
-  private async fetchChainListPage(
-    page: number,
-  ): Promise<IChainListItem[]> {
+  private async fetchChainListPage(page: number): Promise<IChainListItem[]> {
     const client = await this.getClient(EServiceEndpointEnum.Wallet);
     const resp = await client.get<{ data: IChainListItem[] }>(
       '/wallet/v1/network/chainlist',

--- a/packages/kit-bg/src/services/ServiceCustomRpc.ts
+++ b/packages/kit-bg/src/services/ServiceCustomRpc.ts
@@ -14,7 +14,6 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
-import { memoizee } from '@onekeyhq/shared/src/utils/cacheUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { ENetworkStatus, type IServerNetwork } from '@onekeyhq/shared/types';
 import type { IChainListItem } from '@onekeyhq/shared/types/customNetwork';
@@ -48,21 +47,16 @@ class ServiceCustomRpc extends ServiceBase {
     };
   }
 
-  private fetchChainListPage = memoizee(
-    async (page: number): Promise<IChainListItem[]> => {
-      const client = await this.getClient(EServiceEndpointEnum.Wallet);
-      const resp = await client.get<{ data: IChainListItem[] }>(
-        '/wallet/v1/network/chainlist',
-        { params: this.buildChainListRequestParams({ page }) },
-      );
-      return resp.data.data || [];
-    },
-    {
-      promise: true,
-      maxAge: timerUtils.getTimeDurationMs({ minute: 15 }),
-      max: 20,
-    },
-  );
+  private async fetchChainListPage(
+    page: number,
+  ): Promise<IChainListItem[]> {
+    const client = await this.getClient(EServiceEndpointEnum.Wallet);
+    const resp = await client.get<{ data: IChainListItem[] }>(
+      '/wallet/v1/network/chainlist',
+      { params: this.buildChainListRequestParams({ page }) },
+    );
+    return resp.data.data || [];
+  }
 
   constructor({ backgroundApi }: { backgroundApi: any }) {
     super({ backgroundApi });
@@ -585,9 +579,6 @@ class ServiceCustomRpc extends ServiceBase {
     page?: number;
   }): Promise<IChainListItem[]> {
     const requestParams = this.buildChainListRequestParams(params);
-    // Keyword search: always hit API, no cache.
-    // Errors are propagated so callers can distinguish network failures
-    // from genuinely empty result sets.
     if (requestParams.keywords) {
       const client = await this.getClient(EServiceEndpointEnum.Wallet);
       const resp = await client.get<{ data: IChainListItem[] }>(


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55303](https://onekeyhq.atlassian.net/browse/OK-55303)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Removed memoizee in-memory cache from `fetchChainListPage` in `ServiceCustomRpc`
- Both paginated browsing and keyword search now always hit the API directly
- Removed unused `memoizee` import from `cacheUtils`

## Intent & Context
QA reported that entering the Chainlist network list did not show network disconnection status because the 15-minute memoizee cache was serving stale data. Keyword search correctly showed network errors since it bypassed the cache, but the default paginated list did not.

## Root Cause
`fetchChainListPage` was wrapped with `memoizee` (15-min TTL, max 20 pages). When the network was down, cached responses were returned silently, preventing users from seeing network error states. Since the next step (adding a custom network) requires network connectivity anyway, hiding the error at the list stage delayed user awareness of connectivity issues.

## Design Decisions
- **Remove cache entirely** rather than reducing TTL or adding error-state bypass. Rationale from QA/PM:
  1. Users don't trigger this frequently enough for cache to meaningfully improve performance
  2. Users on long-running sessions (especially browser extension) need fresh data
  3. Surfacing network errors early helps users diagnose issues before attempting to add a network
- Converted `fetchChainListPage` from a memoizee-wrapped arrow function to a standard async method

## Changes Detail
- `packages/kit-bg/src/services/ServiceCustomRpc.ts`: Removed memoizee wrapper from `fetchChainListPage`, converted to plain async method, removed stale cache-related comments, removed unused `memoizee` import

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Slightly increased API calls when users paginate the Chainlist — acceptable given low usage frequency

## Test plan
- [ ] Open Chainlist network list with network connected — list loads normally
- [ ] Disconnect network, re-enter Chainlist list — network error state is displayed
- [ ] Search with keyword while disconnected — network error state is displayed
- [ ] Paginate through Chainlist pages — each page loads fresh data from API
- [ ] Long-running session: verify latest Chainlist data is always fetched (no stale cache)

[OK-55303]: https://onekeyhq.atlassian.net/browse/OK-55303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ