### PR TITLE
fix(perp): restore SegmentSlider inactive mark ring on web

### DIFF
--- a/packages/components/src/composite/SegmentSlider/index.tsx
+++ b/packages/components/src/composite/SegmentSlider/index.tsx
@@ -105,14 +105,20 @@ const SegmentMark = memo(function SegmentMarkInner({
     [pct, disabled],
   );
 
-  // background and border are owned by applyMarkActiveStates (imperative
+  // background and borderColor are owned by applyMarkActiveStates (imperative
   // DOM mutation). Listing them here too would let a hover-triggered
   // re-render clobber the active-state fill set by the parent.
+  // borderWidth/borderStyle MUST live here: borderColor alone doesn't render a
+  // ring without a non-zero width and an explicit style, so the inactive marks
+  // would otherwise be invisible white circles on a white page.
   const visualStyle = useMemo<CSSProperties>(
     () => ({
       width: MARK_SIZE,
       height: MARK_SIZE,
       borderRadius: '50%',
+      borderWidth: 1,
+      borderStyle: 'solid',
+      borderColor: 'transparent',
       boxSizing: 'border-box',
       boxShadow: hovered ? `0 0 0 4px ${hoverGlowColor}` : 'none',
       transition: 'box-shadow 150ms ease',


### PR DESCRIPTION
## Summary

- Inactive marks on the web `SegmentSlider` rendered as invisible white circles after the pure-DOM rewrite in #11774 — the only thing you saw was a small white "gap" where the mark overlapped the gray track.
- Root cause: `applyMarkActiveStates` imperatively writes `el.style.borderColor`, but the static `visualStyle` never declared `border-width` or `border-style`. CDP confirmed the computed border was `0px none rgba(0, 0, 0, 0.12)` — color set, but width/style missing, so no ring rendered.
- Fix: declare a 1px solid transparent border in `visualStyle` so the imperative `borderColor` update has a non-zero width and explicit style to draw on. Active marks still rely on background fill and are unaffected.
- `border-color` continues to be owned by `applyMarkActiveStates` only; `box-sizing: border-box` keeps the outer 10×10 footprint, so the 24px hit area is unchanged.

## Test plan

- [ ] Gallery → SegmentSlider → "Default (4 segments, bubble on drag)": at value 0, 25, 50, 75, 100 the inactive marks each show a 1px gray ring, no longer invisible.
- [ ] Hover over an inactive mark — the hover halo still appears, and the ring color is not clobbered on the subsequent re-render.
- [ ] Drag the thumb across — marks toggle between active (filled black) and inactive (white center + gray ring) in sync.
- [ ] Perp trading panel slider: visual matches the native iOS/Android slider (white circle, gray ring).
- [ ] No regression on `centerOrigin`, `forceSnapToStep`, custom `renderMark` stories.

Re: OK-55214 follow-up.