### PR TITLE
fix: align Prime badge colors and feedback(OK-55423)

### DIFF
--- a/packages/kit/src/components/MoreActionButton/index.tsx
+++ b/packages/kit/src/components/MoreActionButton/index.tsx
@@ -110,6 +110,8 @@ function MoreActionProvider({ children }: PropsWithChildren) {
   );
 }
 
+const ONE_KEY_ID_ROW_PRESS_STYLE = { opacity: 0.7 } as const;
+
 function MoreActionContentHeaderItem({ onPress, ...props }: IIconButtonProps) {
   const { closePopover } = usePopoverContext();
   const handlePress = useCallback(
@@ -617,12 +619,7 @@ function MoreActionOneKeyId() {
         justifyContent="space-between"
         onPress={handlePress}
         borderRadius="$2"
-        hoverStyle={{
-          bg: '$bgHover',
-        }}
-        pressStyle={{
-          bg: '$bgActive',
-        }}
+        pressStyle={ONE_KEY_ID_ROW_PRESS_STYLE}
       >
         <XStack alignItems="center" gap="$3" flex={1}>
           <OneKeyIdAvatar size="$10" />
@@ -667,12 +664,7 @@ function MoreActionOneKeyId() {
       justifyContent="space-between"
       onPress={handleNavigateToOneKeyId}
       borderRadius="$2"
-      hoverStyle={{
-        bg: '$bgHover',
-      }}
-      pressStyle={{
-        bg: '$bgActive',
-      }}
+      pressStyle={ONE_KEY_ID_ROW_PRESS_STYLE}
     >
       <XStack alignItems="center" gap="$3" flex={1}>
         <OneKeyIdAvatar size="$14" />

--- a/packages/kit/src/views/Prime/components/PrimeUserBadge.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeUserBadge.tsx
@@ -1,4 +1,9 @@
-import { type ComponentProps, useCallback, useMemo } from 'react';
+import {
+  type ComponentProps,
+  type ReactElement,
+  useCallback,
+  useMemo,
+} from 'react';
 
 import { useIntl } from 'react-intl';
 import { type GestureResponderEvent, StyleSheet } from 'react-native';
@@ -56,6 +61,7 @@ export function PrimeBadge({
   ...props
 }: IPrimeBadgeProps) {
   const intl = useIntl();
+  const themeName = useThemeName() as 'light' | 'dark';
   const isFree = status === 'free' && !isDeviceLimitExceeded;
 
   let displayIcon = icon ?? 'PrimeOutline';
@@ -68,7 +74,7 @@ export function PrimeBadge({
   let borderColor: ColorTokens = '$brand4';
   let bg: ColorTokens = '$brand2';
   let iconColor: ColorTokens = '$brand11';
-  let textColor: ColorTokens = '$brand12';
+  let textColor: ColorTokens = themeName === 'light' ? '$brand12' : '$brand11';
 
   if (isDeviceLimitExceeded) {
     borderColor = '$borderCautionSubdued';
@@ -123,14 +129,23 @@ export function PrimeBadge({
   );
 }
 
-type IPrimeStatusMeta = {
+type IPrimeStatusMetaBase = {
   title?: string;
   dialogTitle: string;
   lines: string[];
-  icon: IKeyOfIcons;
-  tone: 'warning' | 'info';
   isDeviceLimitExceeded?: boolean;
 };
+
+type IPrimeStatusMeta =
+  | (IPrimeStatusMetaBase & {
+      type: 'warning';
+      icon: IKeyOfIcons;
+      tone: 'warning';
+    })
+  | (IPrimeStatusMetaBase & {
+      type: 'prime';
+      renderIcon: ReactElement;
+    });
 
 function PrimeStatusTooltipContent({ status }: { status: IPrimeStatusMeta }) {
   return (
@@ -201,6 +216,7 @@ export function PrimeUserBadge({
       }
 
       return {
+        type: 'warning',
         title,
         dialogTitle: title,
         lines,
@@ -215,6 +231,7 @@ export function PrimeUserBadge({
     }
 
     return {
+      type: 'prime',
       dialogTitle: intl.formatMessage({
         id: ETranslations.prime_status_prime,
       }),
@@ -228,10 +245,9 @@ export function PrimeUserBadge({
           },
         ),
       ],
-      icon: 'PrimeOutline',
-      tone: 'info',
+      renderIcon: <Icon name={primeIcon} size="$8" />,
     };
-  }, [intl, isDeviceLimitExceeded, isPrime, primeExpiredAt]);
+  }, [intl, isDeviceLimitExceeded, isPrime, primeExpiredAt, primeIcon]);
 
   const canShowPrimeStatus = Boolean(statusMeta);
   const shouldOpenStatusDialog =
@@ -243,9 +259,13 @@ export function PrimeUserBadge({
       if (!statusMeta) {
         return;
       }
+      const dialogIconProps =
+        statusMeta.type === 'warning'
+          ? { icon: statusMeta.icon, tone: statusMeta.tone }
+          : { renderIcon: statusMeta.renderIcon };
+
       Dialog.show({
-        icon: statusMeta.icon,
-        tone: statusMeta.tone,
+        ...dialogIconProps,
         title: statusMeta.dialogTitle,
         description: statusMeta.lines.join('\n'),
         showCancelButton: false,


### PR DESCRIPTION
## Summary
- Use the branded Prime icon in the Prime status dialog instead of the blue info-tone icon.
- Keep Prime badge colors consistent across light and dark themes, while preserving warning styling for device-limit state.
- Remove the misaligned hover background from the More panel OneKey ID row and use opacity feedback on press.

## Intent & Context
OK-55423 reported inconsistent Prime brand colors: the mobile Prime status dialog showed a blue icon, the Prime page badge looked washed out in dark mode, and the More panel OneKey ID hover background did not align well.

## Root Cause
The normal Prime status dialog used `PrimeOutline` with `tone: 'info'`, which applies the blue info color, while the More panel OneKey ID row applied hover background inside a narrower row container.

## Design Decisions
Normal Prime status now passes a branded rendered icon, warning/device-limit status remains on warning tone, light mode keeps the previous Prime text token, dark mode uses the stronger Prime brand text token, and row hover was removed in favor of press opacity.

## Changes Detail
- `PrimeUserBadge.tsx`: split Prime status metadata into branded Prime and warning states, and make Dialog payloads match those states.
- `MoreActionButton/index.tsx`: remove the OneKey ID row hover background and reuse a shared press opacity style.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web
- **Risk Areas**: Shared Prime badge rendering and More panel OneKey ID interaction feedback.

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/components/MoreActionButton/index.tsx packages/kit/src/views/Prime/components/PrimeUserBadge.tsx`
- [x] `yarn tsc:only`
- [x] `yarn lint --fix`
