### PR TITLE
fix: restore perps orderbook cold-start cache

### DIFF
--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -43,6 +43,11 @@ import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
 import { memoFn } from '@onekeyhq/shared/src/utils/cacheUtils';
 import {
+  getPerpsOrderBookTickOptionWithCache,
+  getPerpsOrderBookTickOptionsWithCache,
+  setPerpsOrderBookTickOptionsCache,
+} from '@onekeyhq/shared/src/utils/perpsOrderBookTickOptionsCache';
+import {
   findTokensByAlias,
   formatPriceToSignificantDigits,
   formatSpotAssetCtx,
@@ -277,7 +282,9 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       return;
     }
 
-    const stored = params.orderBookTickOptions[params.instrument.coin];
+    const stored = getPerpsOrderBookTickOptionsWithCache(
+      params.orderBookTickOptions,
+    )[params.instrument.coin];
     const nextOrderBookOptions = {
       coin: params.instrument.coin,
       assetId: params.instrument.assetId,
@@ -1006,6 +1013,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       const stored =
         await backgroundApiProxy.simpleDb.perp.getOrderBookTickOptions();
       set(orderBookTickOptionsAtom(), stored);
+      setPerpsOrderBookTickOptionsCache(stored);
     } catch (error) {
       console.error('Failed to load order book tick options:', error);
     } finally {
@@ -1054,6 +1062,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       }
 
       set(orderBookTickOptionsAtom(), next);
+      setPerpsOrderBookTickOptionsCache(next);
 
       try {
         await backgroundApiProxy.simpleDb.perp.setOrderBookTickOption({
@@ -1099,7 +1108,10 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         universe: undefined,
       };
       const hydrateL2BookFromSwr = (targetCoin: string) => {
-        const storedTickOptions = get(orderBookTickOptionsAtom())[targetCoin];
+        const storedTickOptions = getPerpsOrderBookTickOptionWithCache({
+          coin: targetCoin,
+          options: get(orderBookTickOptionsAtom()),
+        });
         const cachedBook = getFreshL2BookSnapshotFromSwr({
           coin: targetCoin,
           nSigFigs: storedTickOptions?.nSigFigs ?? null,

--- a/packages/kit/src/views/Perp/components/OrderBook/useTickOptions.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/useTickOptions.ts
@@ -6,6 +6,7 @@ import {
   useHyperliquidActions,
   useOrderBookTickOptionsAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import { getPerpsOrderBookTickOptionsWithCache } from '@onekeyhq/shared/src/utils/perpsOrderBookTickOptionsCache';
 import {
   analyzeOrderBookPrecision,
   getDisplayPriceScaleDecimals,
@@ -46,6 +47,10 @@ export function useTickOptions({
   } | null>(null);
 
   const [persistedTickOptions] = useOrderBookTickOptionsAtom();
+  const persistedTickOptionsForRender = useMemo(
+    () => getPerpsOrderBookTickOptionsWithCache(persistedTickOptions),
+    [persistedTickOptions],
+  );
   const actions = useHyperliquidActions();
 
   useEffect(() => {
@@ -128,7 +133,7 @@ export function useTickOptions({
 
     if (!symbol) return defaultTickOption;
 
-    const saved = persistedTickOptions[symbol];
+    const saved = persistedTickOptionsForRender[symbol];
     if (saved) {
       const byValue = tickOptions.find(
         (option) => option.value === saved.value,
@@ -147,7 +152,7 @@ export function useTickOptions({
     }
 
     return defaultTickOption;
-  }, [baseTickOptionsData, persistedTickOptions, symbol]);
+  }, [baseTickOptionsData, persistedTickOptionsForRender, symbol]);
 
   useEffect(() => {
     if (!symbol) return;

--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -25,6 +25,7 @@ import { usePerpsShouldShowEnableTradingButtonAtom } from '@onekeyhq/kit-bg/src/
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { markPerpsColdStartPerfOnce } from '@onekeyhq/shared/src/performance/perpsColdStartPerf';
+import { getPerpsOrderBookTickOptionWithCache } from '@onekeyhq/shared/src/utils/perpsOrderBookTickOptionsCache';
 
 import { useFundingCountdown } from '../hooks/useFundingCountdown';
 import { useL2Book } from '../hooks/usePerpMarketData';
@@ -408,7 +409,10 @@ export function PerpOrderBook({
     if (!coin) {
       return { nSigFigs: null, mantissa: undefined };
     }
-    const stored = orderBookTickOptions[coin];
+    const stored = getPerpsOrderBookTickOptionWithCache({
+      coin,
+      options: orderBookTickOptions,
+    });
     const nSigFigs = stored?.nSigFigs ?? null;
     const mantissa =
       stored?.mantissa === undefined ? undefined : stored.mantissa;
@@ -437,8 +441,18 @@ export function PerpOrderBook({
     }
     let cancelled = false;
     const getRequestOptions = async () => {
-      if (orderBookTickOptions[coin]) {
-        return l2SubscriptionOptions;
+      const cachedStored = getPerpsOrderBookTickOptionWithCache({
+        coin,
+        options: orderBookTickOptions,
+      });
+      if (cachedStored) {
+        return {
+          nSigFigs: cachedStored.nSigFigs ?? null,
+          mantissa:
+            cachedStored.mantissa === undefined
+              ? undefined
+              : cachedStored.mantissa,
+        };
       }
       const storedOptions =
         await backgroundApiProxy.simpleDb.perp.getOrderBookTickOptions();

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -42,6 +42,7 @@ import {
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { useDebugHooksDepsChangedChecker } from '@onekeyhq/shared/src/utils/debug/debugUtils';
+import { getPerpsOrderBookTickOptionsWithCache } from '@onekeyhq/shared/src/utils/perpsOrderBookTickOptionsCache';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import type {
   IBook,
@@ -159,13 +160,15 @@ function useSyncContextOrderBookOptionsToGlobal() {
       }
       const prev = await perpsActiveOrderBookOptionsAtom.get();
       const _activeInstrument = activeTradeInstrumentRef.current;
+      const effectiveOrderBookTickOptions =
+        getPerpsOrderBookTickOptionsWithCache(_orderBookTickOptions);
 
       const l2SubscriptionOptions = (() => {
         const coin = _activeInstrument?.coin;
         if (!coin) {
           return { nSigFigs: null, mantissa: null };
         }
-        const stored = _orderBookTickOptions[coin];
+        const stored = effectiveOrderBookTickOptions[coin];
         const nSigFigs = stored?.nSigFigs ?? null;
         const mantissa =
           stored?.mantissa === undefined ? undefined : stored.mantissa;
@@ -821,7 +824,6 @@ function WebSocketSubscriptionUpdate() {
         }
 
         if (
-          !isLoading &&
           subscriptionPlan.shouldSyncSubscriptions &&
           isInstrumentBackedBySubscriptionState
         ) {

--- a/packages/shared/src/storage/instance/syncStorageInstance.desktop.ts
+++ b/packages/shared/src/storage/instance/syncStorageInstance.desktop.ts
@@ -11,55 +11,82 @@ import resetUtils from '../../utils/resetUtils';
 import type { ISyncStorage } from './syncStorageInstance';
 import type { EAppSyncStorageKeys } from '../syncStorageKeys';
 
-const MMKV_ID = 'onekey-app-setting';
-
-function ipc(method: string, key?: string, value?: unknown): any {
+function ipc(id: string, method: string, key?: string, value?: unknown): any {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
-  return (globalThis as any).$mmkvSync({ method, id: MMKV_ID, key, value });
+  return (globalThis as any).$mmkvSync({ method, id, key, value });
 }
 
-const syncStorageDesktop: ISyncStorage = {
-  set(key: EAppSyncStorageKeys, value: boolean | string | number) {
-    resetUtils.checkNotInResetting();
-    ipc('set', key, value);
-  },
-  setObject<T extends Record<string, any>>(key: EAppSyncStorageKeys, value: T) {
-    resetUtils.checkNotInResetting();
-    if (!isPlainObject(value)) {
-      throw new OneKeyLocalError('value must be a plain object');
+function createDesktopSyncStorage({
+  id,
+  checkResetting,
+}: {
+  id: string;
+  checkResetting?: boolean;
+}): ISyncStorage {
+  const maybeCheckResetting = () => {
+    if (checkResetting) {
+      resetUtils.checkNotInResetting();
     }
-    ipc('set', key, JSON.stringify(value));
-  },
-  getObject<T>(key: EAppSyncStorageKeys): T | undefined {
-    try {
-      const value = ipc('getString', key) as string | undefined;
-      if (!value) {
+  };
+
+  return {
+    set(key: EAppSyncStorageKeys, value: boolean | string | number) {
+      maybeCheckResetting();
+      ipc(id, 'set', key, value);
+    },
+    setObject<T extends Record<string, any>>(
+      key: EAppSyncStorageKeys,
+      value: T,
+    ) {
+      maybeCheckResetting();
+      if (!isPlainObject(value)) {
+        throw new OneKeyLocalError('value must be a plain object');
+      }
+      ipc(id, 'set', key, JSON.stringify(value));
+    },
+    getObject<T>(key: EAppSyncStorageKeys): T | undefined {
+      try {
+        const value = ipc(id, 'getString', key) as string | undefined;
+        if (!value) {
+          return undefined;
+        }
+        return JSON.parse(value) as T;
+      } catch (_e) {
         return undefined;
       }
-      return JSON.parse(value) as T;
-    } catch (_e) {
-      return undefined;
-    }
-  },
-  getString(key: EAppSyncStorageKeys) {
-    return ipc('getString', key) as string | undefined;
-  },
-  getNumber(key: EAppSyncStorageKeys) {
-    return ipc('getNumber', key) as number | undefined;
-  },
-  getBoolean(key: EAppSyncStorageKeys) {
-    return ipc('getBoolean', key) as boolean | undefined;
-  },
-  delete(key: EAppSyncStorageKeys) {
-    ipc('remove', key);
-  },
-  clearAll() {
-    ipc('clearAll');
-  },
-  getAllKeys() {
-    return (ipc('getAllKeys') as string[]) || [];
-  },
-};
+    },
+    getString(key: EAppSyncStorageKeys) {
+      return ipc(id, 'getString', key) as string | undefined;
+    },
+    getNumber(key: EAppSyncStorageKeys) {
+      return ipc(id, 'getNumber', key) as number | undefined;
+    },
+    getBoolean(key: EAppSyncStorageKeys) {
+      return ipc(id, 'getBoolean', key) as boolean | undefined;
+    },
+    delete(key: EAppSyncStorageKeys) {
+      ipc(id, 'remove', key);
+    },
+    clearAll() {
+      ipc(id, 'clearAll');
+    },
+    getAllKeys() {
+      return (ipc(id, 'getAllKeys') as string[]) || [];
+    },
+  };
+}
 
-export { syncStorageDesktop as syncStorage };
+const syncStorageDesktop = createDesktopSyncStorage({
+  id: 'onekey-app-setting',
+  checkResetting: true,
+});
+
+const coldStartCacheStorageDesktop = createDesktopSyncStorage({
+  id: 'onekey-cold-start-cache',
+});
+
+export {
+  coldStartCacheStorageDesktop as coldStartCacheStorage,
+  syncStorageDesktop as syncStorage,
+};
 export type { ISyncStorage };

--- a/packages/shared/src/utils/perpsOrderBookTickOptionsCache.ts
+++ b/packages/shared/src/utils/perpsOrderBookTickOptionsCache.ts
@@ -1,0 +1,50 @@
+import {
+  swrCacheUtils,
+  swrKeys,
+} from '@onekeyhq/shared/src/utils/swrCacheUtils';
+import type { IPerpOrderBookTickOptionPersist } from '@onekeyhq/shared/types/hyperliquid/types';
+
+export type IPerpsOrderBookTickOptionsCache = Record<
+  string,
+  IPerpOrderBookTickOptionPersist
+>;
+
+const ORDER_BOOK_TICK_OPTIONS_CACHE_KEY = swrKeys.perpsOrderBookTickOptions();
+
+export function getPerpsOrderBookTickOptionsCache(): IPerpsOrderBookTickOptionsCache {
+  return (
+    swrCacheUtils.get<IPerpsOrderBookTickOptionsCache>(
+      ORDER_BOOK_TICK_OPTIONS_CACHE_KEY,
+    ) ?? {}
+  );
+}
+
+export function setPerpsOrderBookTickOptionsCache(
+  options: IPerpsOrderBookTickOptionsCache,
+) {
+  swrCacheUtils.set(ORDER_BOOK_TICK_OPTIONS_CACHE_KEY, options);
+  swrCacheUtils.flushNow();
+}
+
+export function getPerpsOrderBookTickOptionsWithCache(
+  options: IPerpsOrderBookTickOptionsCache,
+): IPerpsOrderBookTickOptionsCache {
+  const cached = getPerpsOrderBookTickOptionsCache();
+  return {
+    ...cached,
+    ...options,
+  };
+}
+
+export function getPerpsOrderBookTickOptionWithCache({
+  coin,
+  options,
+}: {
+  coin: string | undefined;
+  options: IPerpsOrderBookTickOptionsCache;
+}) {
+  if (!coin) {
+    return undefined;
+  }
+  return getPerpsOrderBookTickOptionsWithCache(options)[coin];
+}

--- a/packages/shared/src/utils/swrCacheUtils.test.ts
+++ b/packages/shared/src/utils/swrCacheUtils.test.ts
@@ -1,6 +1,10 @@
 import { getPerpsL2BookSnapshotCacheKeys, swrKeys } from './swrCacheUtils';
 
 describe('perps L2 book SWR cache keys', () => {
+  it('uses a stable key for cached order book tick options', () => {
+    expect(swrKeys.perpsOrderBookTickOptions()).toBe('perpsOrderBookTicks:v1');
+  });
+
   it('uses only the default key when no tick option is requested', () => {
     expect(
       getPerpsL2BookSnapshotCacheKeys({

--- a/packages/shared/src/utils/swrCacheUtils.ts
+++ b/packages/shared/src/utils/swrCacheUtils.ts
@@ -161,6 +161,7 @@ const NS = {
   recentNetworks: 'recentNets',
   walletListSideBar: 'walletList',
   accountSelectorList: 'accSelList',
+  perpsOrderBookTickOptions: 'perpsOrderBookTicks',
   perpsL2BookSnapshot: 'perpsL2Book',
 } as const;
 export type ISwrCacheNamespace = (typeof NS)[keyof typeof NS];
@@ -311,6 +312,8 @@ export const swrKeys = {
       selectedNetworkId ?? '',
       keepAllOtherAccounts ? '1' : '0',
     ].join(':'),
+  perpsOrderBookTickOptions: () =>
+    [NS.perpsOrderBookTickOptions, 'v1'].join(':'),
   perpsL2BookSnapshot: ({
     coin,
     nSigFigs,


### PR DESCRIPTION
## Summary
- Restore desktop access to the dedicated cold-start cache storage used by perps SWR snapshots.
- Persist and synchronously read perps order book tick options through the SWR cache so first-frame L2 book hydration uses the correct tick key.
- Allow subscription sync during account loading so the order book request path is not blocked on initial render.

## Intent & Context
The branch was merged into `x`, then desktop and iOS were started for self-testing. During desktop self-test, the order book area showed a loading spinner instead of rendering cached order book rows on the first visible Perps frame. The goal of this change is to restore first-frame order book data for desktop and preserve the iOS/mobile behavior.

## Root Cause
The first investigation showed L2 book websocket data arriving only after the page was already visible, so the desktop first frame depended on cold-start cache hydration. The missing piece was platform-specific storage: mobile can use the native MMKV-backed `coldStartCacheStorage`, but the desktop resolver only exported `syncStorage` from `syncStorageInstance.desktop.ts`. As a result, `swrCacheUtils` could not synchronously read/write the dedicated cold-start cache on desktop, so the renderer-side SWR path missed and the page fell back to waiting for background/simpleDb or websocket data.

## Design Decisions
- Reused the existing desktop `$mmkvSync` IPC bridge and added a small `createDesktopSyncStorage` factory so both `onekey-app-setting` and `onekey-cold-start-cache` use the same synchronous storage contract.
- Kept reset-state checks only on the app settings storage, matching the native factory behavior where cold-start cache is best-effort and independent.
- Cached order book tick options in SWR as a small synchronous key-value payload, then merged it with Jotai/simpleDb state when building L2 book request options. This avoids requesting a cached L2 book with the wrong tick key before simpleDb has loaded.
- Kept the L2 book fallback scoped to perps order book data instead of changing general loading UI behavior.

## Changes Detail
- `packages/shared/src/storage/instance/syncStorageInstance.desktop.ts`: exports desktop `coldStartCacheStorage` backed by `onekey-cold-start-cache`, alongside the existing app settings storage.
- `packages/shared/src/utils/swrCacheUtils.ts`: adds a stable SWR key namespace for perps order book tick options.
- `packages/shared/src/utils/perpsOrderBookTickOptionsCache.ts`: adds helpers to read/write/merge cached order book tick options.
- `packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts`: writes loaded/updated tick options to SWR and hydrates L2 book snapshots using cached tick options.
- `packages/kit/src/views/Perp/components/PerpOrderBook.tsx`, `OrderBook/useTickOptions.ts`, and `PerpsGlobalEffects.tsx`: consume cached tick options before async simpleDb state is available.
- `packages/shared/src/utils/swrCacheUtils.test.ts`: covers the new stable tick-options SWR key.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop, Mobile
- **Risk Areas**: Desktop storage IPC behavior, perps order book cache key selection, early subscription timing during account loading.

## Test plan
- [x] `npx oxlint packages/shared/src/storage/instance/syncStorageInstance.desktop.ts packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts packages/kit/src/views/Perp/components/OrderBook/useTickOptions.ts packages/kit/src/views/Perp/components/PerpOrderBook.tsx packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx packages/shared/src/utils/perpsOrderBookTickOptionsCache.ts packages/shared/src/utils/swrCacheUtils.ts packages/shared/src/utils/swrCacheUtils.test.ts`
- [x] `yarn jest packages/shared/src/utils/swrCacheUtils.test.ts --runInBand`
- [x] `git diff --check`
- [x] Desktop runtime: clean restart, open `/perps`, confirmed `action_l2_book_swr_hydrated_first` at ~446ms and `ui_order_book_ready` at ~501ms; `service_l2_book_cache_hit` reported `swrLevels:20`.
- [x] iOS runtime: build installed and opened on iPhone 16 Pro simulator before PR creation; Metro served the development bundle.
- [x] `yarn lint:staged`
- [ ] `yarn tsc:staged` currently blocked by pre-existing unrelated `HardwareErrorCode.DeviceOneDeviceOnly` errors in `packages/shared/src/errors/errors/thirdPartyHardwareErrors.ts` and `packages/shared/src/errors/utils/thirdPartyDeviceErrorUtils.ts`.
- [ ] `yarn lint --fix` currently blocked by the same pre-existing unrelated type errors.
