### PR TITLE
fix: improve perps tradingview loading

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -1,7 +1,8 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { Spinner, Stack } from '@onekeyhq/components';
+import { LottieView, Stack } from '@onekeyhq/components';
 import type { IStackStyle } from '@onekeyhq/components';
+import TradingViewChartLoadingAnimation from '@onekeyhq/kit/assets/animations/swap_order_pending.json';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import {
   useHyperliquidActions,
@@ -189,6 +190,17 @@ const WebViewMemoized = memo(
 
 WebViewMemoized.displayName = 'WebViewMemoized';
 
+function TradingViewChartLoading() {
+  return (
+    <LottieView
+      width={110}
+      height={110}
+      autoPlay
+      source={TradingViewChartLoadingAnimation}
+    />
+  );
+}
+
 const hideTradingViewBuiltInLoadingScript = `
   ;(function() {
     var styleText = [
@@ -270,10 +282,15 @@ export function TradingViewPerpsV2(
       reloadOnSymbolChange ? `-${symbol}` : ''
     }`;
   }, [reloadOnSymbolChange, symbol, theme, webviewKey]);
-  const [isChartLinesReady, setIsChartLinesReady] = useState(false);
-  const [isChartContentReady, setIsChartContentReady] = useState(false);
+  const [chartLinesReadyWebviewKey, setChartLinesReadyWebviewKey] = useState<
+    string | null
+  >(null);
+  const [chartContentReadyWebviewKey, setChartContentReadyWebviewKey] =
+    useState<string | null>(null);
   const hasPerpsReadyRef = useRef(false);
   const lastHandledRestoreNonceRef = useRef(0);
+  const isChartLinesReady = chartLinesReadyWebviewKey === _webviewKey;
+  const isChartContentReady = chartContentReadyWebviewKey === _webviewKey;
 
   const prevWebviewKeyRef = useRef(_webviewKey);
   useEffect(() => {
@@ -281,8 +298,8 @@ export function TradingViewPerpsV2(
       // A new WebView instance must prove perpsReady before app-side recovery
       // can stay hands-off.
       hasPerpsReadyRef.current = false;
-      setIsChartLinesReady(false);
-      setIsChartContentReady(false);
+      setChartLinesReadyWebviewKey(null);
+      setChartContentReadyWebviewKey(null);
       prevWebviewKeyRef.current = _webviewKey;
     }
   }, [_webviewKey]);
@@ -373,21 +390,21 @@ export function TradingViewPerpsV2(
     lastHandledRestoreNonceRef.current = restoreNonce;
 
     if (!hasPerpsReadyRef.current) {
-      setIsChartLinesReady(false);
-      setIsChartContentReady(false);
+      setChartLinesReadyWebviewKey(null);
+      setChartContentReadyWebviewKey(null);
       webRef.current?.reload();
     }
   }, [restoreNonce]);
 
   const onChartLinesReady = useCallback(() => {
     hasPerpsReadyRef.current = true;
-    setIsChartContentReady(true);
-    setIsChartLinesReady(true);
-  }, []);
+    setChartContentReadyWebviewKey(_webviewKey);
+    setChartLinesReadyWebviewKey(_webviewKey);
+  }, [_webviewKey]);
 
   const onChartReady = useCallback(() => {
-    setIsChartContentReady(true);
-  }, []);
+    setChartContentReadyWebviewKey(_webviewKey);
+  }, [_webviewKey]);
 
   const onOrderCancel = useCallback(
     async (payload: ITVOrderCancelPayload) => {
@@ -507,7 +524,7 @@ export function TradingViewPerpsV2(
     (event: WebViewNavigation) => handleNavigation(event),
     [handleNavigation],
   );
-  const showSymbolReloadMask = reloadOnSymbolChange && !isChartContentReady;
+  const showChartLoadingMask = !isChartContentReady;
 
   return (
     <Stack position="relative" flex={1} {...stackStyle}>
@@ -534,7 +551,7 @@ export function TradingViewPerpsV2(
         decelerationRate="normal"
       />
 
-      {showSymbolReloadMask ? (
+      {showChartLoadingMask ? (
         <Stack
           position="absolute"
           left={0}
@@ -547,7 +564,7 @@ export function TradingViewPerpsV2(
           justifyContent="center"
           pointerEvents="none"
         >
-          <Spinner size="large" />
+          <TradingViewChartLoading />
         </Stack>
       ) : null}
 


### PR DESCRIPTION
## Summary
- Replace the Perps TradingView loading spinner with the requested pending-order Lottie animation.
- Scope Perps chart readiness to the current webview key so reload and restore flows show the loading mask consistently.
- Keep the change limited to Perps TradingView; Market TradingView uses a separate wrapper/loading path and is intentionally left unchanged.

## Intent & Context
The PM requested replacing the Perps TradingView loading state with the animation shown in the reference screenshot. The implementation targets the Perps chart surface only, because Market/mkt TradingView scenes use a different wrapper and loading contract.

## Root Cause
The previous Perps chart loading UI used a generic spinner and its content-ready state was tracked as a plain boolean. That did not match the requested visual treatment and could also let stale readiness from a previous webview instance hide the loading mask after reload or restore.

## Design Decisions
- Reused the existing `swap_order_pending.json` Lottie asset instead of adding a new duplicated animation file.
- Added a small Perps-local loading component instead of changing shared TradingView primitives, keeping the regression surface narrow.
- Keyed chart readiness by the active webview key and reset readiness on webview-key changes to avoid stale ready state.
- Did not update Market/mkt TradingView in this PR because it uses `TradingViewV2` and page-level loading paths rather than the Perps `chartReady/perpsReady` flow.

## Changes Detail
- `packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx`: replaces the loading spinner with a centered Lottie animation and scopes readiness state to the active webview key.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop, Web, Mobile app surfaces that render Perps TradingView
- **Risk Areas**: Perps chart initial load, symbol change reloads, and webview restore/reload handling. Market TradingView is not affected by this PR.

## Test plan
- [x] `git diff --check origin/x...HEAD`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx`
- [x] `yarn lint:staged`
- [x] `yarn app:web:rspack`
- [x] `yarn app:desktop:rspack` after clearing the stale desktop rspack cache
- [x] Browser verification with TradingView iframe requests blocked to confirm the Perps loading mask renders the requested animation
- [ ] `yarn tsc:staged` currently fails on existing `origin/x` hardware enum errors outside this PR: `DeviceOutOfMemory` / `DeviceOneDeviceOnly` missing on `HardwareErrorCode`.