### PR TITLE
OK-55321: log Hyperliquid HTTP failures locally

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts
@@ -77,6 +77,8 @@ import {
 } from '../../states/jotai/atoms';
 import ServiceBase from '../ServiceBase';
 
+import { createLoggedHyperLiquidClient } from './utils/logHyperLiquidApiFailure';
+
 import type {
   WalletHyperliquidOnekey,
   WalletHyperliquidProxy,
@@ -141,6 +143,14 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       );
     }
     return this._exchangeClient;
+  }
+
+  private _createLoggedExchangeClient(client: ExchangeClient): ExchangeClient {
+    return createLoggedHyperLiquidClient(client, {
+      endpoint: 'exchange',
+      context: () => this._buildLogContext(),
+      extra: { source: 'ServiceHyperliquidExchange' },
+    });
   }
 
   private _calculateSlippagePrice(params: {
@@ -364,11 +374,13 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
         account = proxyWallet.address;
       }
 
-      this._exchangeClient = new ExchangeClient({
-        transport,
-        wallet,
-        signatureChainId: PERPS_EVM_CHAIN_ID_HEX,
-      });
+      this._exchangeClient = this._createLoggedExchangeClient(
+        new ExchangeClient({
+          transport,
+          wallet,
+          signatureChainId: PERPS_EVM_CHAIN_ID_HEX,
+        }),
+      );
 
       this._account = account;
       this._wallet = wallet;
@@ -1429,11 +1441,13 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       await this.backgroundApi.serviceHyperliquidWallet.getOnekeyWallet({
         userAccountId: params.userAccountId,
       });
-    const exchangeClient = new ExchangeClient({
-      transport: new HttpTransport(),
-      wallet,
-      signatureChainId: PERPS_EVM_CHAIN_ID_HEX,
-    });
+    const exchangeClient = this._createLoggedExchangeClient(
+      new ExchangeClient({
+        transport: new HttpTransport(),
+        wallet,
+        signatureChainId: PERPS_EVM_CHAIN_ID_HEX,
+      }),
+    );
     // TODO: i18n — HL returns English errors like "Cannot disable unified account with open positions..."
     // Need to add these to hyperliquidErrorLocales config for localization
     await convertHyperLiquidResponse(() =>
@@ -1451,11 +1465,13 @@ export default class ServiceHyperliquidExchange extends ServiceBase {
       await this.backgroundApi.serviceHyperliquidWallet.getOnekeyWallet({
         userAccountId: params.userAccountId,
       });
-    const exchangeClient = new ExchangeClient({
-      transport: new HttpTransport(),
-      wallet,
-      signatureChainId: PERPS_EVM_CHAIN_ID_HEX,
-    });
+    const exchangeClient = this._createLoggedExchangeClient(
+      new ExchangeClient({
+        transport: new HttpTransport(),
+        wallet,
+        signatureChainId: PERPS_EVM_CHAIN_ID_HEX,
+      }),
+    );
     const context = await this._buildLogContext();
     try {
       await convertHyperLiquidResponse(() => exchangeClient.withdraw3(params));

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidReferral.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidReferral.ts
@@ -16,6 +16,11 @@ import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 
 import ServiceBase from '../ServiceBase';
 
+import {
+  logHyperLiquidApiFailure,
+  requestLoggedHyperLiquidTransport,
+} from './utils/logHyperLiquidApiFailure';
+
 import type { IBackgroundApi } from '../../apis/IBackgroundApi';
 
 @backgroundClass()
@@ -401,14 +406,22 @@ export default class ServiceHyperliquidReferral extends ServiceBase {
 
     // Use SDK's HttpTransport to make the request
     const transport = new HttpTransport();
-    const result = await transport.request<{
+    const result = await requestLoggedHyperLiquidTransport<{
       status: string;
       response?: unknown;
-    }>('exchange', {
-      action,
-      signature,
-      nonce,
-    });
+    }>(
+      transport,
+      'exchange',
+      {
+        action,
+        signature,
+        nonce,
+      },
+      {
+        action: action.type,
+        extra: { source: 'ServiceHyperliquidReferral' },
+      },
+    );
 
     defaultLogger.perp.hyperliquid.referralBindingStep({
       step: 'complete',
@@ -570,7 +583,17 @@ export default class ServiceHyperliquidReferral extends ServiceBase {
         user: userAddress,
       });
       return result?.role ?? 'missing';
-    } catch {
+    } catch (error) {
+      await logHyperLiquidApiFailure({
+        endpoint: 'info',
+        action: 'userRole',
+        request: {
+          type: 'userRole',
+          user: userAddress,
+        },
+        error,
+        extra: { source: 'ServiceHyperliquidReferral' },
+      });
       return 'missing';
     }
   }
@@ -604,6 +627,16 @@ export default class ServiceHyperliquidReferral extends ServiceBase {
         cumVlm: result?.cumVlm ?? '0',
       };
     } catch (error) {
+      await logHyperLiquidApiFailure({
+        endpoint: 'info',
+        action: 'referral',
+        request: {
+          type: 'referral',
+          user: userAddress,
+        },
+        error,
+        extra: { source: 'ServiceHyperliquidReferral' },
+      });
       const errorMessage =
         error instanceof Error ? error.message : String(error);
       defaultLogger.perp.hyperliquid.referralConditionCheck({

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/hyperLiquidApiClients.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/hyperLiquidApiClients.ts
@@ -7,14 +7,22 @@ import {
   // WebSocketTransport,
 } from '@nktkas/hyperliquid';
 
+import { createLoggedHyperLiquidClient } from './utils/logHyperLiquidApiFailure';
+
 class HyperLiquidApiClients {
   private _infoClient: InfoClient | null = null;
 
   get infoClient(): InfoClient {
     if (!this._infoClient) {
-      this._infoClient = new InfoClient({
-        transport: new HttpTransport(),
-      });
+      this._infoClient = createLoggedHyperLiquidClient(
+        new InfoClient({
+          transport: new HttpTransport(),
+        }),
+        {
+          endpoint: 'info',
+          extra: { source: 'hyperLiquidApiClients.infoClient' },
+        },
+      );
     }
     return this._infoClient;
   }

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/hyperLiquidApiClients.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/hyperLiquidApiClients.ts
@@ -9,6 +9,11 @@ import {
 
 import { createLoggedHyperLiquidClient } from './utils/logHyperLiquidApiFailure';
 
+const INFO_CLIENT_SOFT_FALLBACK_ACTIONS = new Set([
+  'allMids',
+  'perpsAtOpenInterestCap',
+]);
+
 class HyperLiquidApiClients {
   private _infoClient: InfoClient | null = null;
 
@@ -21,6 +26,8 @@ class HyperLiquidApiClients {
         {
           endpoint: 'info',
           extra: { source: 'hyperLiquidApiClients.infoClient' },
+          shouldLogFailure: ({ action }) =>
+            !INFO_CLIENT_SOFT_FALLBACK_ACTIONS.has(action),
         },
       );
     }

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/logHyperLiquidApiFailure.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/logHyperLiquidApiFailure.test.ts
@@ -1,0 +1,121 @@
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import type { IHyperLiquidApiFailureEndpoint } from '@onekeyhq/shared/src/logger/scopes/perp/scenes/hyperliquid';
+
+import {
+  createLoggedHyperLiquidClient,
+  requestLoggedHyperLiquidTransport,
+} from './logHyperLiquidApiFailure';
+
+jest.mock('@onekeyhq/shared/src/logger/logger', () => ({
+  defaultLogger: {
+    perp: {
+      hyperliquid: {
+        apiRequestFailure: jest.fn(),
+      },
+    },
+  },
+}));
+
+function getApiRequestFailureMock() {
+  return (
+    defaultLogger.perp.hyperliquid as unknown as {
+      apiRequestFailure: jest.Mock;
+    }
+  ).apiRequestFailure;
+}
+
+describe('logHyperLiquidApiFailure', () => {
+  beforeEach(() => {
+    getApiRequestFailureMock().mockClear();
+  });
+
+  it('allows soft fallback client actions to opt out of failure logs', async () => {
+    const client = {
+      soft: jest.fn(async () => {
+        throw new OneKeyLocalError('soft read failed');
+      }),
+      hard: jest.fn(async () => {
+        throw new OneKeyLocalError('hard read failed');
+      }),
+    };
+    const loggedClient = createLoggedHyperLiquidClient(client, {
+      endpoint: 'info',
+      shouldLogFailure: ({ action }) => action !== 'soft',
+    });
+
+    await expect(loggedClient.soft()).rejects.toThrow('soft read failed');
+    expect(getApiRequestFailureMock()).not.toHaveBeenCalled();
+
+    await expect(loggedClient.hard()).rejects.toThrow('hard read failed');
+    expect(getApiRequestFailureMock()).toHaveBeenCalledTimes(1);
+    expect(getApiRequestFailureMock()).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: 'info',
+        action: 'hard',
+        message: 'hard read failed',
+      }),
+    );
+  });
+
+  it('logs direct transport error results without changing the result', async () => {
+    const result = {
+      status: 'err',
+      response: 'Price too far from oracle',
+    };
+    const transport = {
+      async request<TResult>(
+        _endpoint: IHyperLiquidApiFailureEndpoint,
+        _payload: unknown,
+      ) {
+        return result as TResult;
+      },
+    };
+
+    await expect(
+      requestLoggedHyperLiquidTransport(
+        transport,
+        'exchange',
+        { action: { type: 'setReferrer' } },
+        {
+          action: 'setReferrer',
+          extra: { source: 'test' },
+        },
+      ),
+    ).resolves.toBe(result);
+
+    expect(getApiRequestFailureMock()).toHaveBeenCalledTimes(1);
+    expect(getApiRequestFailureMock()).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: 'exchange',
+        action: 'setReferrer',
+        response: result,
+        message: 'Price too far from oracle',
+        extra: { source: 'test' },
+      }),
+    );
+  });
+
+  it('does not log direct transport success results', async () => {
+    const result = { status: 'ok', response: { type: 'default' } };
+    const transport = {
+      async request<TResult>(
+        _endpoint: IHyperLiquidApiFailureEndpoint,
+        _payload: unknown,
+      ) {
+        return result as TResult;
+      },
+    };
+
+    await expect(
+      requestLoggedHyperLiquidTransport(
+        transport,
+        'exchange',
+        { action: { type: 'setReferrer' } },
+        { action: 'setReferrer' },
+      ),
+    ).resolves.toBe(result);
+
+    expect(getApiRequestFailureMock()).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/logHyperLiquidApiFailure.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/logHyperLiquidApiFailure.ts
@@ -23,6 +23,12 @@ type ILogHyperLiquidApiFailureParams = {
   extra?: Record<string, unknown>;
 };
 
+type ILogHyperLiquidClientFailureParams = {
+  action: string;
+  request: unknown;
+  error: unknown;
+};
+
 const REDACTED = '[Redacted]';
 const MAX_SANITIZE_DEPTH = 8;
 const SENSITIVE_KEYS = new Set([
@@ -44,6 +50,19 @@ function getSingleRequestArg(args: unknown[]): unknown {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function isHyperLiquidErrorResult(
+  result: unknown,
+): result is { status: 'err'; response?: unknown } {
+  return isRecord(result) && result.status === 'err';
+}
+
+function createHyperLiquidErrorResultError(result: unknown) {
+  return new Error(
+    extractHyperLiquidErrorMessage({ response: result }) ||
+      'HyperLiquid API returned error status',
+  );
 }
 
 function sanitizePayload(
@@ -158,6 +177,7 @@ export function createLoggedHyperLiquidClient<T extends object>(
     endpoint: IHyperLiquidApiFailureEndpoint;
     context?: IContextProvider;
     extra?: Record<string, unknown>;
+    shouldLogFailure?: (params: ILogHyperLiquidClientFailureParams) => boolean;
   },
 ): T {
   const methodCache = new Map<PropertyKey, unknown>();
@@ -174,17 +194,23 @@ export function createLoggedHyperLiquidClient<T extends object>(
 
       const method = value as (this: T, ...args: unknown[]) => Promise<unknown>;
       const wrapped = async (...args: unknown[]) => {
+        const action = String(prop);
+        const request = getSingleRequestArg(args);
         try {
           return await method.apply(target, args);
         } catch (error) {
-          await logHyperLiquidApiFailure({
-            endpoint: options.endpoint,
-            action: String(prop),
-            request: getSingleRequestArg(args),
-            error,
-            context: options.context,
-            extra: options.extra,
-          });
+          if (
+            options.shouldLogFailure?.({ action, request, error }) !== false
+          ) {
+            await logHyperLiquidApiFailure({
+              endpoint: options.endpoint,
+              action,
+              request,
+              error,
+              context: options.context,
+              extra: options.extra,
+            });
+          }
           throw error;
         }
       };
@@ -210,7 +236,19 @@ export async function requestLoggedHyperLiquidTransport<T>(
   },
 ): Promise<T> {
   try {
-    return await transport.request<T>(endpoint, payload);
+    const result = await transport.request<T>(endpoint, payload);
+    if (isHyperLiquidErrorResult(result)) {
+      await logHyperLiquidApiFailure({
+        endpoint,
+        action: options.action,
+        request: payload,
+        response: result,
+        error: createHyperLiquidErrorResultError(result),
+        context: options.context,
+        extra: options.extra,
+      });
+    }
+    return result;
   } catch (error) {
     await logHyperLiquidApiFailure({
       endpoint,

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/logHyperLiquidApiFailure.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/logHyperLiquidApiFailure.ts
@@ -1,0 +1,225 @@
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import {
+  type IHyperLiquidAccountContext,
+  type IHyperLiquidApiFailureEndpoint,
+  extractHyperLiquidErrorResponse,
+  serializeHyperLiquidError,
+} from '@onekeyhq/shared/src/logger/scopes/perp/scenes/hyperliquid';
+import { extractHyperLiquidErrorMessage } from '@onekeyhq/shared/src/utils/hyperLiquidErrorResolver';
+
+type IContextProvider =
+  | Partial<IHyperLiquidAccountContext>
+  | (() =>
+      | Partial<IHyperLiquidAccountContext>
+      | Promise<Partial<IHyperLiquidAccountContext>>);
+
+type ILogHyperLiquidApiFailureParams = {
+  endpoint: IHyperLiquidApiFailureEndpoint;
+  action: string;
+  request?: unknown;
+  response?: unknown;
+  error: unknown;
+  context?: IContextProvider;
+  extra?: Record<string, unknown>;
+};
+
+const REDACTED = '[Redacted]';
+const MAX_SANITIZE_DEPTH = 8;
+const SENSITIVE_KEYS = new Set([
+  'signature',
+  'signedRequest',
+  'signedPayload',
+  'privateKey',
+  'mnemonic',
+  'seed',
+  'secret',
+]);
+
+function getSingleRequestArg(args: unknown[]): unknown {
+  if (args.length === 0) {
+    return undefined;
+  }
+  return args.length === 1 ? args[0] : args;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function sanitizePayload(
+  payload: unknown,
+  seen = new WeakSet<object>(),
+  depth = 0,
+): unknown {
+  if (!payload || typeof payload !== 'object') {
+    return payload;
+  }
+
+  if (depth >= MAX_SANITIZE_DEPTH) {
+    return '[MaxDepth]';
+  }
+
+  if (seen.has(payload)) {
+    return '[Circular]';
+  }
+  seen.add(payload);
+
+  if (Array.isArray(payload)) {
+    return payload.map((item) => sanitizePayload(item, seen, depth + 1));
+  }
+
+  const result: Record<string, unknown> = {};
+  Object.entries(payload as Record<string, unknown>).forEach(([key, value]) => {
+    if (SENSITIVE_KEYS.has(key)) {
+      result[key] = REDACTED;
+      return;
+    }
+    result[key] = sanitizePayload(value, seen, depth + 1);
+  });
+  return result;
+}
+
+function normalizeResponse(response: unknown): unknown {
+  if (!isRecord(response)) {
+    return response;
+  }
+
+  if (
+    'data' in response &&
+    ('status' in response || 'statusText' in response)
+  ) {
+    return {
+      status: response.status,
+      statusText: response.statusText,
+      data: response.data,
+    };
+  }
+
+  return response;
+}
+
+function serializeError(error: unknown) {
+  const serialized = serializeHyperLiquidError(error);
+  if (serialized?.response) {
+    serialized.response = normalizeResponse(serialized.response);
+  }
+  return serialized;
+}
+
+async function resolveContext(
+  context: IContextProvider | undefined,
+): Promise<Partial<IHyperLiquidAccountContext>> {
+  if (!context) {
+    return {};
+  }
+  if (typeof context === 'function') {
+    return context();
+  }
+  return context;
+}
+
+export async function logHyperLiquidApiFailure({
+  endpoint,
+  action,
+  request,
+  response,
+  error,
+  context,
+  extra,
+}: ILogHyperLiquidApiFailureParams) {
+  try {
+    const resolvedContext = await resolveContext(context);
+    const resolvedResponse =
+      response ?? normalizeResponse(extractHyperLiquidErrorResponse(error));
+    const message =
+      extractHyperLiquidErrorMessage(error) ||
+      (error instanceof Error ? error.message : String(error));
+
+    defaultLogger.perp.hyperliquid.apiRequestFailure({
+      ...resolvedContext,
+      endpoint,
+      action,
+      request: sanitizePayload(request),
+      response: sanitizePayload(resolvedResponse),
+      error: sanitizePayload(serializeError(error)) as
+        | Record<string, unknown>
+        | undefined,
+      message,
+      extra: sanitizePayload(extra) as Record<string, unknown> | undefined,
+    });
+  } catch (logError) {
+    console.error('[HyperLiquidApiFailureLog] failed to write log', logError);
+  }
+}
+
+export function createLoggedHyperLiquidClient<T extends object>(
+  client: T,
+  options: {
+    endpoint: IHyperLiquidApiFailureEndpoint;
+    context?: IContextProvider;
+    extra?: Record<string, unknown>;
+  },
+): T {
+  const methodCache = new Map<PropertyKey, unknown>();
+  return new Proxy(client, {
+    get(target, prop) {
+      const value = Reflect.get(target, prop, target);
+      if (typeof value !== 'function') {
+        return value;
+      }
+
+      if (methodCache.has(prop)) {
+        return methodCache.get(prop);
+      }
+
+      const method = value as (this: T, ...args: unknown[]) => Promise<unknown>;
+      const wrapped = async (...args: unknown[]) => {
+        try {
+          return await method.apply(target, args);
+        } catch (error) {
+          await logHyperLiquidApiFailure({
+            endpoint: options.endpoint,
+            action: String(prop),
+            request: getSingleRequestArg(args),
+            error,
+            context: options.context,
+            extra: options.extra,
+          });
+          throw error;
+        }
+      };
+      methodCache.set(prop, wrapped);
+      return wrapped;
+    },
+  });
+}
+
+export async function requestLoggedHyperLiquidTransport<T>(
+  transport: {
+    request: <TResult>(
+      endpoint: IHyperLiquidApiFailureEndpoint,
+      payload: unknown,
+    ) => Promise<TResult>;
+  },
+  endpoint: IHyperLiquidApiFailureEndpoint,
+  payload: unknown,
+  options: {
+    action: string;
+    context?: IContextProvider;
+    extra?: Record<string, unknown>;
+  },
+): Promise<T> {
+  try {
+    return await transport.request<T>(endpoint, payload);
+  } catch (error) {
+    await logHyperLiquidApiFailure({
+      endpoint,
+      action: options.action,
+      request: payload,
+      error,
+      context: options.context,
+      extra: options.extra,
+    });
+    throw error;
+  }
+}

--- a/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
@@ -38,6 +38,7 @@ import type {
 
 import { settingsPersistAtom } from '../../states/jotai/atoms';
 import ServiceBase from '../ServiceBase';
+import { logHyperLiquidApiFailure } from '../ServiceHyperLiquid/utils/logHyperLiquidApiFailure';
 
 import type { IHyperliquidCustomSettings } from '../../dbs/simple/entity/SimpleDbEntityPerp';
 import type {
@@ -48,6 +49,10 @@ import type {
   IJsBridgeMessagePayload,
   IJsonRpcRequest,
 } from '@onekeyfe/cross-inpage-provider-types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
 
 export interface IHyperliquidClearinghouseState {
   marginSummary: {
@@ -282,10 +287,30 @@ class ServiceWebviewPerp extends ServiceBase {
     // TODO init by server api
   }
 
+  private resolveHyperliquidRequestAction(
+    endpoint: string,
+    body: Record<string, unknown>,
+  ) {
+    if (typeof body.type === 'string') {
+      return body.type;
+    }
+    const { action } = body;
+    if (
+      isRecord(action) &&
+      'type' in action &&
+      typeof action.type === 'string'
+    ) {
+      return action.type;
+    }
+    return endpoint;
+  }
+
   private async hyperliquidRequestBase<T>(
     endpoint: string,
-    body: Record<string, any>,
+    body: Record<string, unknown>,
   ): Promise<T> {
+    const logEndpoint = endpoint === 'exchange' ? 'exchange' : 'info';
+    const action = this.resolveHyperliquidRequestAction(endpoint, body);
     try {
       const response = await axios.post<T>(
         `https://api.hyperliquid.xyz/${endpoint}`,
@@ -307,11 +332,27 @@ class ServiceWebviewPerp extends ServiceBase {
           typeof responseDataWithError.response === 'string'
             ? responseDataWithError.response
             : stringUtils.stableStringify(responseDataWithError.response);
-        throw new OneKeyError(errorMessage);
+        const err = new OneKeyError(errorMessage);
+        await logHyperLiquidApiFailure({
+          endpoint: logEndpoint,
+          action,
+          request: body,
+          response: responseDataWithError,
+          error: err,
+          extra: { source: 'ServiceWebviewPerp' },
+        });
+        throw err;
       }
       return response.data;
     } catch (error) {
       if (error && axios.isAxiosError(error)) {
+        await logHyperLiquidApiFailure({
+          endpoint: logEndpoint,
+          action,
+          request: body,
+          error,
+          extra: { source: 'ServiceWebviewPerp' },
+        });
         const extractedMessage = extractHyperLiquidErrorMessage(error);
         if (extractedMessage && extractedMessage !== error.message) {
           throw new OneKeyError(extractedMessage);
@@ -334,6 +375,13 @@ class ServiceWebviewPerp extends ServiceBase {
       if (e instanceof OneKeyError) {
         throw e;
       }
+      await logHyperLiquidApiFailure({
+        endpoint: logEndpoint,
+        action,
+        request: body,
+        error,
+        extra: { source: 'ServiceWebviewPerp' },
+      });
       throw new OneKeyError(
         `Hyperliquid API error 6632: ${[
           e?.name,
@@ -348,13 +396,13 @@ class ServiceWebviewPerp extends ServiceBase {
   }
 
   private async hyperliquidInfoRequest<T>(
-    body: Record<string, any>,
+    body: Record<string, unknown>,
   ): Promise<T> {
     return this.hyperliquidRequestBase<T>('info', body);
   }
 
   private async hyperliquidExchangeRequest<T>(
-    body: Record<string, any>,
+    body: Record<string, unknown>,
   ): Promise<T> {
     return this.hyperliquidRequestBase<T>('exchange', body);
   }

--- a/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
+++ b/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
@@ -38,6 +38,18 @@ export interface IHyperLiquidLogParams<
   isFirstTime?: boolean;
 }
 
+export type IHyperLiquidApiFailureEndpoint = 'info' | 'exchange';
+
+export interface IHyperLiquidApiFailureLogParams extends Partial<IHyperLiquidAccountContext> {
+  endpoint: IHyperLiquidApiFailureEndpoint;
+  action: string;
+  request?: unknown;
+  response?: unknown;
+  error?: Record<string, unknown>;
+  message?: string;
+  extra?: Record<string, unknown>;
+}
+
 function stripSensitiveFields<TRequest, TResponse>(
   params: IHyperLiquidLogParams<TRequest, TResponse>,
 ) {
@@ -57,6 +69,11 @@ export interface IHyperLiquidOrderRequestPayload {
 }
 
 export class HyperLiquidScene extends BaseScene {
+  @LogToLocal({ level: 'error' })
+  public apiRequestFailure(params: IHyperLiquidApiFailureLogParams) {
+    return params;
+  }
+
   @LogToServer()
   public setReferrer(
     params: IHyperLiquidLogParams<


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55321](https://onekeyhq.atlassian.net/browse/OK-55321)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Add a local-only Hyperliquid HTTP failure logger for `info` and `exchange` API calls.
- Wrap Hyperliquid `InfoClient`, `ExchangeClient`, direct `HttpTransport`, and direct axios HTTP requests so raw failure response context is available in exported local logs.
- Redact signed request material and secrets while keeping account addresses for local diagnostics.

## Intent & Context
This change came from debugging Perps order failures where the raw Hyperliquid response was visible in DevTools and UI toast, but not reliably available in OneKey local logs. The goal is to make Hyperliquid HTTP failure diagnostics available from exported logs without shipping any temporary mock order controls or margin bypass logic.

## Root Cause
Hyperliquid failures were handled across several paths: SDK clients, direct `HttpTransport` calls, and direct axios calls. Existing order log methods were primarily `@LogToServer`, while mock/debug paths and some HTTP paths used thrown errors or console output. That meant local exported logs did not consistently contain raw Hyperliquid HTTP failure responses.

## Design Decisions
- Added a dedicated `@LogToLocal({ level: 'error' })` event instead of adding `@LogToLocal` to existing success/failure server analytics methods, because those methods are shared by successful and failed requests.
- Limited logging to HTTP `info` and `exchange` endpoints. WebSocket subscribe/unsubscribe/ping failures are intentionally excluded to avoid noisy logs during reconnects or network instability.
- Kept `accountAddress` and `exchangeAccountAddress` in local logs because they are useful account context and not secrets.
- Redacted `signature`, `signedRequest`, `signedPayload`, `privateKey`, `mnemonic`, `seed`, and `secret` fields so logs do not contain reusable signed raw bodies or key material.

## Changes Detail
- `packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts`: adds the local-only `apiRequestFailure` logger event.
- `packages/kit-bg/src/services/ServiceHyperLiquid/utils/logHyperLiquidApiFailure.ts`: adds shared failure logging helpers, request/error normalization, and sensitive-field redaction.
- `packages/kit-bg/src/services/ServiceHyperLiquid/hyperLiquidApiClients.ts`: wraps shared Hyperliquid `InfoClient` calls.
- `packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts`: wraps Hyperliquid `ExchangeClient` instances.
- `packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidReferral.ts`: logs failures for direct `HttpTransport` referral info/exchange calls.
- `packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts`: logs failures for direct axios calls to Hyperliquid HTTP endpoints.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Mobile / Extension / Web
- **Risk Areas**: Local log payload size and sensitive data handling. The scope excludes WebSocket failures and redacts signed request fields to reduce these risks.

## Test plan
- [x] `git diff --check`
- [x] `npx oxlint packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts packages/kit-bg/src/services/ServiceHyperLiquid/utils/logHyperLiquidApiFailure.ts packages/kit-bg/src/services/ServiceHyperLiquid/hyperLiquidApiClients.ts packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidReferral.ts packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts`
- [x] `yarn lint --fix` attempted; blocked by pre-existing unrelated `HardwareErrorCode.DeviceOneDeviceOnly` TypeScript errors.
- [x] `yarn tsc:only` attempted; blocked by the same pre-existing unrelated `HardwareErrorCode.DeviceOneDeviceOnly` TypeScript errors.

[OK-55321]: https://onekeyhq.atlassian.net/browse/OK-55321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ