### PR TITLE
fix: expose rookie guide app locale

### DIFF
--- a/packages/kit-bg/src/services/ServiceRookieGuide.ts
+++ b/packages/kit-bg/src/services/ServiceRookieGuide.ts
@@ -36,12 +36,14 @@ class ServiceRookieGuide extends ServiceBase {
       oneKeyId,
       instanceId,
       hyperliquidReferral,
+      locale,
     ] = await Promise.all([
       this.getTaskProgress(),
       this._getActiveFiatBalance(),
       this._getOneKeyIdInfo(),
       this.backgroundApi.serviceSetting.getInstanceId(),
       this._getHyperliquidReferralEligibility(),
+      this.backgroundApi.serviceSetting.getCurrentLocale(),
     ]);
 
     const result: IRookieGuideInfo = {
@@ -51,6 +53,7 @@ class ServiceRookieGuide extends ServiceBase {
       instanceId,
       taskProgress,
       hyperliquidReferral,
+      locale,
     };
 
     defaultLogger.rookieGuide.guide.getInfo({

--- a/packages/shared/types/rookieGuide.ts
+++ b/packages/shared/types/rookieGuide.ts
@@ -40,6 +40,7 @@ export interface IRookieGuideInfo {
     reason: string;
     address?: string;
   };
+  locale: string;
 }
 
 // ============ Rookie Share Types ============


### PR DESCRIPTION
## Summary
- Add `locale` to the Rookie Guide bridge response type.
- Return the resolved App locale from `wallet_getRookieGuideInfo`.

## Intent & Context
Growth needs the Rookie Guide H5 page to follow the App language when opened inside the App. The H5 page already calls `wallet_getRookieGuideInfo` during initialization, so the bridge response is the narrowest place to expose the current App locale without adding a new bridge method or changing the SupportHub URL.

## Root Cause
The H5 page could not access the App's current language because the WebView URL did not include `locale`, and the private bridge did not expose a language getter. Reading `settingsPersistAtom.locale` directly would expose the internal `system` setting when the user follows the system language, which is not a BCP-47 locale usable by H5.

## Design Decisions
- Reused `serviceSetting.getCurrentLocale()` so `system` is resolved to an actual supported locale such as `zh-CN`, `en-US`, or `ja-JP`.
- Kept the change inside the existing Rookie Guide info bridge response to avoid adding another bridge API.
- Used `string` for the shared response type field to match the external bridge contract expected by H5.

## Changes Detail
- `packages/shared/types/rookieGuide.ts`: add `locale` to `IRookieGuideInfo`.
- `packages/kit-bg/src/services/ServiceRookieGuide.ts`: include the resolved current App locale in the returned info object.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Bridge response consumers should tolerate the additive field; the value is resolved through existing settings service behavior.

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit-bg/src/services/ServiceRookieGuide.ts packages/shared/types/rookieGuide.ts`
- [x] `yarn lint:staged`
- [x] `git diff --check`
- [ ] `yarn tsc:staged` currently fails on unrelated existing `origin/x` errors in quick-crypto and hardware error-code files.
