### PR TITLE
fix(browser): persist tab closes immediately to survive process kill

### DIFF
--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -99,6 +99,23 @@ function isNewTabPositionTop() {
   );
 }
 
+// How a tab-array persist should reach SimpleDb.
+// - Debounced: coalesce high-frequency churn (navigate/reorder/title updates).
+// - Immediate: discrete, high-intent actions (closing a tab / all tabs) must
+//   land synchronously so a hard quit right after cannot restore a stale,
+//   larger snapshot.
+export enum EBrowserTabPersistMode {
+  Immediate = 'immediate',
+  Debounced = 'debounced',
+}
+
+// Raw, non-debounced persist of the full tab array to SimpleDb. Returns the
+// underlying setRawData promise so callers (and the debounced wrapper's
+// `.flush()`) can await durability before the JS runtime is suspended.
+function persistTabsToSimpleDb(tabs: IWebTab[]) {
+  return backgroundApiProxy.simpleDb.browserTabs.setRawData({ tabs });
+}
+
 // Coalesce rapid persistence of browser-tab state. Each user action (open,
 // close, reorder, navigate) used to flush the full tab array to SimpleDb
 // immediately; in iPad logs we saw ~65 writes in 4 minutes, every one
@@ -110,10 +127,11 @@ function isNewTabPositionTop() {
 // least the user-visible action. trailing:true covers the last frame of
 // a continuing burst; maxWait caps lag during sustained activity. Worst-
 // case loss is now a mid-burst intermediate frame, not the final action.
+//
+// The body returns the setRawData promise so `.flush()` returns it too,
+// letting the visibility handler await the final write.
 const persistTabsToSimpleDbDebounced = debounce(
-  (tabs: IWebTab[]) => {
-    void backgroundApiProxy.simpleDb.browserTabs.setRawData({ tabs });
-  },
+  (tabs: IWebTab[]) => persistTabsToSimpleDb(tabs),
   500,
   { leading: true, trailing: true, maxWait: 2000 },
 );
@@ -126,9 +144,11 @@ const persistTabsToSimpleDbDebounced = debounce(
 //
 // iOS in particular may freeze the bridge in <500ms after backgrounding,
 // which would otherwise drop the last user action (open/close/reorder tab).
-onVisibilityStateChange((visible) => {
+// `await` the flushed write so the persist has a chance to commit on the
+// background thread before suspension.
+onVisibilityStateChange(async (visible) => {
   if (!visible) {
-    persistTabsToSimpleDbDebounced.flush();
+    await persistTabsToSimpleDbDebounced.flush();
   }
 });
 
@@ -198,7 +218,12 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
       set,
       payload: {
         data: IWebTab[];
-        options?: { forceUpdate?: boolean; isInitFromStorage?: boolean };
+        options?: {
+          forceUpdate?: boolean;
+          isInitFromStorage?: boolean;
+          // Defaults to Debounced to preserve existing caller behavior.
+          persist?: EBrowserTabPersistMode;
+        };
       },
     ) => {
       const { data, options } = payload;
@@ -224,7 +249,16 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
 
       set(webTabsMapAtom(), () => result.map);
       loggerForEmptyData(result.data, 'buildWebTabs->saveToSimpleDB');
-      persistTabsToSimpleDbDebounced(result.data);
+      if (options?.persist === EBrowserTabPersistMode.Immediate) {
+        // Cancel any pending trailing debounced write so it cannot later
+        // overwrite this authoritative snapshot, then persist immediately.
+        persistTabsToSimpleDbDebounced.cancel();
+        void persistTabsToSimpleDb(result.data);
+      } else {
+        // Debounced wrapper now returns the inner persist promise; the
+        // trailing/leading writes remain fire-and-forget here.
+        void persistTabsToSimpleDbDebounced(result.data);
+      }
     },
   );
 
@@ -508,7 +542,14 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
         }, 50);
       }
       loggerForEmptyData([...tabs], 'closeWebTab');
-      this.buildWebTabs.call(set, { data: [...tabs] });
+      // Closing a tab is a discrete, high-intent action. Persist the final
+      // tab array immediately (and cancel any pending debounced write from
+      // the adjacent-tab activation above) so a hard quit right after cannot
+      // restore the stale, larger snapshot.
+      this.buildWebTabs.call(set, {
+        data: [...tabs],
+        options: { persist: EBrowserTabPersistMode.Immediate },
+      });
       defaultLogger.discovery.browser.closeTab({
         closeMethod: entry,
       });
@@ -564,7 +605,12 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
       }
 
       loggerForEmptyData(pinnedTabs, 'closeAllWebTabs');
-      this.buildWebTabs.call(set, { data: pinnedTabs });
+      // Same rationale as closeWebTab: persist the final (pinned-only) array
+      // immediately so closing all tabs cannot be lost to a pending debounce.
+      this.buildWebTabs.call(set, {
+        data: pinnedTabs,
+        options: { persist: EBrowserTabPersistMode.Immediate },
+      });
 
       setTimeout(() => {
         this.saveLastClosedTab.call(set, tabsToClose);

--- a/packages/kit/src/states/jotai/contexts/discovery/closeTabPersist.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/discovery/closeTabPersist.test.tsx
@@ -1,0 +1,232 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { act, renderHook } from '@testing-library/react';
+import { createStore } from 'jotai';
+
+import type { IWebTab } from '@onekeyhq/kit/src/views/Discovery/types';
+import { jotaiDefaultStore } from '@onekeyhq/kit-bg/src/states/jotai/utils/jotaiDefaultStore';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import { useBrowserTabActions } from './actions';
+import {
+  ProviderJotaiContextDiscovery,
+  activeTabIdAtom,
+  browserDataReadyAtom,
+  displayHomePageAtom,
+  useWebTabsAtom,
+  webTabsAtom,
+} from './atoms';
+
+const mockSetBrowserTabsRawData = jest.fn();
+const mockSetBrowserHistoryRawData = jest.fn();
+const mockSetBrowserClosedTabsRawData = jest.fn();
+
+jest.mock('@onekeyhq/components', () => ({
+  Toast: {
+    message: jest.fn(),
+  },
+  rootNavigationRef: {
+    current: {
+      getRootState: jest.fn(),
+    },
+  },
+  switchTabAsync: jest.fn(async () => undefined),
+}));
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: {
+    isDesktop: false,
+    isNative: true,
+    isNativeAndroid: false,
+    isNativeIOS: false,
+    isJest: true,
+  },
+}));
+
+// `actions.ts` registers an AppState 'change' listener at module load to flush
+// the debounced tab-persist on background/inactive. jsdom doesn't ship a usable
+// AppState, so stub the minimal surface the listener touches.
+jest.mock('react-native', () => ({
+  AppState: {
+    addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+  },
+}));
+
+// IMPORTANT: do NOT passthrough-mock lodash here. This test deliberately
+// exercises the REAL lodash debounce together with jest fake timers, so it
+// reproduces the production timing of the bug: several tab closes in rapid
+// succession followed by a hard quit before the trailing debounce can fire.
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    simpleDb: {
+      browserTabs: {
+        setRawData: (payload: unknown) => {
+          mockSetBrowserTabsRawData(payload);
+          return Promise.resolve();
+        },
+      },
+      browserHistory: {
+        getRawData: jest.fn(async () => ({ data: [] })),
+        setRawData: (payload: unknown) => {
+          mockSetBrowserHistoryRawData(payload);
+          return Promise.resolve();
+        },
+      },
+      browserBookmarks: {
+        getRawData: jest.fn(async () => ({ data: [] })),
+      },
+      browserClosedTabs: {
+        setRawData: (payload: unknown) => {
+          mockSetBrowserClosedTabsRawData(payload);
+          return Promise.resolve();
+        },
+      },
+    },
+    serviceDiscovery: {
+      buildWebsiteIconUrl: jest.fn(async () => ''),
+    },
+  },
+}));
+
+// `actions.ts` imports `deeplink/index.ts`, which transitively pulls in
+// `expo-linking` (ESM, untransformed by jest). Stub it out.
+jest.mock('@onekeyhq/kit/src/routes/config/deeplink', () => ({
+  handleDeepLinkUrl: jest.fn(),
+}));
+
+jest.mock('@onekeyhq/kit/src/views/Discovery/utils/explorerUtils', () => ({
+  browserTypeHandler: 'MultiTabBrowser',
+  crossWebviewLoadUrl: jest.fn(),
+  injectToPauseWebsocket: '',
+  injectToResumeWebsocket: '',
+  webviewRefs: {},
+}));
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
+  devSettingsPersistAtom: {
+    atom: jest.fn(),
+  },
+  settingsPersistAtom: {
+    atom: jest.fn(),
+  },
+}));
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/utils/jotaiDefaultStore', () => ({
+  jotaiDefaultStore: {
+    get: jest.fn(() => ({})),
+  },
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/openUrlUtils', () => ({
+  clearPendingDiscoveryUrl: jest.fn(),
+  openUrlInApp: jest.fn(),
+}));
+
+function makeTab(id: string): IWebTab {
+  return {
+    id,
+    url: `https://example.com/${id}`,
+    title: id,
+    canGoBack: false,
+    loading: false,
+    favicon: '',
+    timestamp: Number(id.replace(/\D/g, '')) || 1,
+  };
+}
+
+function createWrapper(tabs: IWebTab[]) {
+  const store = createStore();
+  store.set(browserDataReadyAtom(), true);
+  store.set(activeTabIdAtom(), null);
+  store.set(displayHomePageAtom(), false);
+  store.set(webTabsAtom(), {
+    keys: tabs.map((t) => t.id),
+    tabs: tabs.map((t) => ({ ...t })),
+  });
+  return function Wrapper({ children }: { children?: ReactNode }) {
+    return (
+      <ProviderJotaiContextDiscovery store={store}>
+        {children}
+      </ProviderJotaiContextDiscovery>
+    );
+  };
+}
+
+function lastPersistedTabIds(): string[] | null {
+  if (mockSetBrowserTabsRawData.mock.calls.length === 0) {
+    return null;
+  }
+  const lastCall =
+    mockSetBrowserTabsRawData.mock.calls[
+      mockSetBrowserTabsRawData.mock.calls.length - 1
+    ];
+  return (lastCall[0].tabs as IWebTab[]).map((t) => t.id);
+}
+
+describe('closeWebTab immediate persistence (bg cascade fix)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (jotaiDefaultStore.get as jest.Mock).mockReturnValue({});
+    Object.assign(platformEnv, {
+      isDesktop: false,
+      isNative: true,
+      isNativeAndroid: false,
+      isNativeIOS: false,
+      isJest: true,
+    });
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('persists the FINAL tab array immediately when tabs are closed rapidly, before the debounce window elapses', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useBrowserTabActions().current;
+        const [webTabs] = useWebTabsAtom();
+        return { actions, tabs: webTabs.tabs };
+      },
+      {
+        wrapper: createWrapper([
+          makeTab('1'),
+          makeTab('2'),
+          makeTab('3'),
+          makeTab('4'),
+        ]),
+      },
+    );
+
+    // Only observe writes caused by the closes below; the seeded state was set
+    // directly on the store (no persist call happened for it).
+    mockSetBrowserTabsRawData.mockClear();
+
+    // Rapidly close tabs WITHOUT advancing timers past the debounce window.
+    act(() => {
+      result.current.actions.closeWebTab({ tabId: '4', entry: 'Menu' });
+      result.current.actions.closeWebTab({ tabId: '3', entry: 'Menu' });
+      result.current.actions.closeWebTab({ tabId: '2', entry: 'Menu' });
+    });
+
+    // The final close must already be persisted immediately. With the old
+    // debounced-only behavior, the post-all-closes array would still be sitting
+    // in the debounce and `setRawData` would only ever have the leading-edge
+    // (stale, larger) snapshot.
+    expect(mockSetBrowserTabsRawData).toHaveBeenCalled();
+    expect(lastPersistedTabIds()).toEqual(['1']);
+
+    // A stale pending debounced trailing write must NOT later overwrite the
+    // immediate snapshot (the `.cancel()` guarantee). Flush all pending timers
+    // and re-check the last persisted snapshot is still the final array.
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(lastPersistedTabIds()).toEqual(['1']);
+  });
+});


### PR DESCRIPTION
## Problem

QA: open 6 browser tabs, rapidly close 3, kill the app, relaunch → 4–5 tabs still there (the closes didn't stick).

`buildWebTabs` persists tab state through a 500ms debounce (`leading:true, trailing:true, maxWait:2000`):

- A burst of closes persists the **leading** (stale, larger) array; the **trailing** write carrying the final array fires ~500ms later.
- That trailing write is fire-and-forget (`void setRawData`) across the bg bridge with no completion barrier (observed `elapsedMs` up to ~2.4s in iOS logs). On a process kill it's abandoned, so SimpleDb keeps the pre-close snapshot.
- The visibility `flush()` only synchronously kicks the fire-and-forget body — it never awaits the actual bg-thread write.

## Fix

- Add `EBrowserTabPersistMode { Immediate, Debounced }`.
- `buildWebTabs` gains a `persist?` option (defaults to `Debounced`, so existing callers are unchanged).
- `closeWebTab` / `closeAllWebTabs` persist the **final** tab array **immediately** and `cancel()` any pending debounced write so a stale trailing write can't overwrite it. Closing is a discrete, high-intent action and must never be coalesced.
- High-frequency churn (navigate / reorder / title) stays debounced — the perf win is preserved.
- The debounced body now returns the `setRawData` promise and the visibility handler `await`s `flush()`, so the final write can commit before suspension.

## Test

New `closeTabPersist.test.tsx` uses the **real** lodash debounce + fake timers to reproduce production timing: closes 3 tabs rapidly without advancing past the debounce window, asserts the final array is persisted immediately, then runs pending timers and asserts no stale trailing write overwrites it.

- New test: fails on old code, passes now.
- `actions.test.tsx`: 8 existing tests still pass.
- `2 suites / 9 tests passed`; `lint:staged` clean.