### PR TITLE
fix: hide referral blocking toast close action on tablets

### DIFF
--- a/packages/kit/src/routes/config/deeplink/__tests__/referralLandingOverlayGuard.test.tsx
+++ b/packages/kit/src/routes/config/deeplink/__tests__/referralLandingOverlayGuard.test.tsx
@@ -9,6 +9,7 @@ import {
   closeAllDialogInstances,
   getDialogInstances,
   getFormInstances,
+  isNativeTablet,
   rootNavigationRef,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -43,6 +44,7 @@ jest.mock('@onekeyhq/components', () => ({
   closeAllDialogInstances: jest.fn(() => Promise.resolve()),
   getFormInstances: jest.fn(() => []),
   getDialogInstances: jest.fn(() => []),
+  isNativeTablet: jest.fn(() => false),
   rootNavigationRef: {
     current: {
       dispatch: jest.fn(),
@@ -99,6 +101,9 @@ const mockedRootNavigationRef =
 const mockedCommonActionsReset = CommonActions.reset as jest.MockedFunction<
   typeof CommonActions.reset
 >;
+const mockedIsNativeTablet = isNativeTablet as jest.MockedFunction<
+  typeof isNativeTablet
+>;
 
 function setRootRoutes(
   routes: Array<ERootRoutes | IRootRoute>,
@@ -147,6 +152,7 @@ describe('referralLandingOverlayGuard', () => {
     mockedCloseAllDialogInstances.mockResolvedValue(undefined);
     mockedGetFormInstances.mockReturnValue([]);
     mockedGetDialogInstances.mockReturnValue([]);
+    mockedIsNativeTablet.mockReturnValue(false);
     mockedRootNavigationRef.current.dispatch.mockReset();
     mockedRootNavigationRef.current.dispatch.mockImplementation((action) => {
       const payload = (action as { payload?: IRootState }).payload;
@@ -252,6 +258,19 @@ describe('referralLandingOverlayGuard', () => {
       'wait',
       'continue',
     ]);
+  });
+
+  it('hides the close action on tablets', () => {
+    setRootRoutes([ERootRoutes.Main, ERootRoutes.Modal]);
+    mockedIsNativeTablet.mockReturnValue(true);
+
+    expect(showReferralBlockingOverlayToast({ onContinue: jest.fn() })).toBe(
+      true,
+    );
+
+    const toastProps = mockedToastMessage.mock.calls.at(-1)?.[0];
+    expect(toastProps?.actions).toBeUndefined();
+    expect(toastProps?.actionsAlign).toBeUndefined();
   });
 
   it('asks for confirmation before closing dirty form dialogs', async () => {

--- a/packages/kit/src/routes/config/deeplink/referralLandingOverlayGuard.tsx
+++ b/packages/kit/src/routes/config/deeplink/referralLandingOverlayGuard.tsx
@@ -9,6 +9,7 @@ import {
   closeAllDialogInstances,
   getDialogInstances,
   getFormInstances,
+  isNativeTablet,
   rootNavigationRef,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -251,6 +252,7 @@ export function showReferralBlockingOverlayToast({
   };
   const canContinue = () =>
     currentToken === referralBlockingToastToken && (shouldContinue?.() ?? true);
+  const shouldShowCloseAction = !isNativeTablet();
   const handleCloseAndContinue = () => {
     if (isHandlingContinue) {
       return;
@@ -291,7 +293,6 @@ export function showReferralBlockingOverlayToast({
     message: appLocale.intl.formatMessage({
       id: ETranslations.referral_close_current_popup_desc,
     }),
-    actionsAlign: 'left',
     onClose: () => {
       if (
         currentToken === referralBlockingToastToken &&
@@ -300,9 +301,16 @@ export function showReferralBlockingOverlayToast({
         referralBlockingToast = undefined;
       }
     },
-    actions: (
-      <ReferralBlockingOverlayToastAction onPress={handleCloseAndContinue} />
-    ),
+    ...(shouldShowCloseAction
+      ? {
+          actionsAlign: 'left' as const,
+          actions: (
+            <ReferralBlockingOverlayToastAction
+              onPress={handleCloseAndContinue}
+            />
+          ),
+        }
+      : {}),
   });
   referralBlockingToast = currentToastRef.current;
 


### PR DESCRIPTION
## Summary
- Hide the "Close all" action button on the referral blocking overlay toast when running on a native tablet / dual-screen (split view) device.
- Drop the now-unneeded `actionsAlign: 'left'` prop on tablets so the toast renders cleanly without the action row.
- Add a unit test asserting the toast omits `actions`/`actionsAlign` on tablets.

## Intent & Context
Follow-up to the referral binding overlay guard (OK-54336). On phones the referral blocking toast shows a "Close all" button that lets the user dismiss the active dialog/modal and continue the referral binding flow. On native tablets and dual-screen devices in split view, that close action does not render/behave correctly, so it is hidden on those form factors.

## Root Cause
`showReferralBlockingOverlayToast` unconditionally rendered the `ReferralBlockingOverlayToastAction` button together with `actionsAlign: 'left'`. On native tablet / split-view layouts that action row was not appropriate, leaving the toast in a broken state.

## Design Decisions
- Reused the existing `isNativeTablet()` helper from `@onekeyhq/components` (native AND (dual-screen device OR TABLET device type)) instead of introducing a new layout check.
- Conditionally spread the `actions`/`actionsAlign` props only when `!isNativeTablet()`, keeping the non-tablet path byte-for-byte unchanged rather than branching the whole `Toast.message` call.

## Changes Detail
- `packages/kit/src/routes/config/deeplink/referralLandingOverlayGuard.tsx`: compute `shouldShowCloseAction = !isNativeTablet()` and only attach the close action + `actionsAlign` when true.
- `packages/kit/src/routes/config/deeplink/__tests__/referralLandingOverlayGuard.test.tsx`: mock and reset `isNativeTablet`, add a "hides the close action on tablets" case verifying `actions`/`actionsAlign` are undefined.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (native tablet / dual-screen split view only)
- **Risk Areas**: Only the conditional toast actions in the referral blocking overlay guard; phone behavior is unchanged.

## Test plan
- [ ] Phone: trigger referral deep link while a dialog/modal is open → toast shows the left-aligned "Close all" button and tapping it continues the flow.
- [ ] Tablet / dual-screen split view: same trigger → toast shows title + message with no close action button.
- [ ] `referralLandingOverlayGuard` unit tests pass, including the new tablet case.
