### PR TITLE
feat: add hardware wallet enable trading steps

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -160,6 +160,12 @@ type ILoadTradesHistoryOptions = {
   force?: boolean;
 };
 
+export type IEnableTradingHardwareSigningStep =
+  | 'approveBuilderFee'
+  | 'removeAgent'
+  | 'approveAgent'
+  | 'setAbstraction';
+
 type IChangeActiveAssetResult = {
   coin: string;
   assetId: number | undefined;
@@ -2140,6 +2146,94 @@ export default class ServiceHyperliquid extends ServiceBase {
     });
     const status = await perpsActiveAccountStatusAtom.get();
     return status;
+  }
+
+  @backgroundMethod()
+  async getEnableTradingHardwareSigningSteps(): Promise<
+    IEnableTradingHardwareSigningStep[]
+  > {
+    const selectedAccount = await perpsActiveAccountAtom.get();
+    const accountAddress = selectedAccount.accountAddress?.toLowerCase() as
+      | IHex
+      | undefined;
+    const accountStatus = await perpsActiveAccountStatusAtom.get();
+    const details = accountStatus?.details;
+    const steps: IEnableTradingHardwareSigningStep[] = [];
+
+    if (!accountAddress) {
+      return steps;
+    }
+
+    let isActivated = false;
+    if (hyperLiquidCache?.activatedUser?.[accountAddress] === true) {
+      isActivated = true;
+    } else {
+      const { infoClient } = hyperLiquidApiClients;
+      const userRoleResult = await infoClient.userRole({
+        user: accountAddress,
+      });
+      isActivated = userRoleResult.role !== 'missing';
+    }
+    if (!isActivated) {
+      return steps;
+    }
+
+    if (!details?.builderFeeOk) {
+      const { expectBuilderAddress, expectMaxBuilderFee } =
+        await this.getBuilderFeeConfig();
+      if (expectBuilderAddress) {
+        const maxBuilderFee = await this.getUserApprovedMaxBuilderFeeWithCache({
+          userAddress: accountAddress,
+          builderAddress: expectBuilderAddress,
+        });
+        if (maxBuilderFee !== expectMaxBuilderFee) {
+          steps.push('approveBuilderFee');
+        }
+      }
+    }
+
+    if (!details?.agentOk || !details.internalRebateBoundOk) {
+      const extraAgents =
+        (await this.fetchExtraAgentsWithCache({
+          user: accountAddress,
+        })) ?? [];
+      const onekeyAgentNames = new Set([
+        EHyperLiquidAgentName.OneKeyAgent1,
+        EHyperLiquidAgentName.OneKeyAgent2,
+        EHyperLiquidAgentName.OneKeyAgent3,
+      ]);
+      if (extraAgents.length === 3) {
+        const nonOneKeyAgents = extraAgents.filter(
+          (agent) => !onekeyAgentNames.has(agent.name as EHyperLiquidAgentName),
+        );
+        const agentToRemove = (
+          nonOneKeyAgents.length ? nonOneKeyAgents : extraAgents
+        ).toSorted((a, b) => a.validUntil - b.validUntil)?.[0];
+        const agentNameToRemove = agentToRemove?.name as
+          | EHyperLiquidAgentName
+          | undefined;
+        if (
+          agentToRemove &&
+          agentNameToRemove &&
+          !onekeyAgentNames.has(agentNameToRemove)
+        ) {
+          steps.push('removeAgent');
+        }
+      }
+      steps.push('approveAgent');
+    }
+
+    if (!details?.abstractionOk) {
+      const currentMode = await this.fetchUserAbstraction(accountAddress);
+      const isAbstractionCorrect =
+        currentMode === EHyperLiquidAbstractionMode.UNIFIED_ACCOUNT ||
+        currentMode === EHyperLiquidAbstractionMode.PORTFOLIO_MARGIN;
+      if (!isAbstractionCorrect) {
+        steps.push('setAbstraction');
+      }
+    }
+
+    return steps;
   }
 
   hideEnableTradingLoadingTimer: ReturnType<typeof setTimeout> | undefined;

--- a/packages/kit/src/views/Perp/components/HyperliquidTerms.tsx
+++ b/packages/kit/src/views/Perp/components/HyperliquidTerms.tsx
@@ -31,6 +31,8 @@ import {
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { usePerpsLogo } from '../hooks/usePerpsLogo';
 
+import { PERP_DIALOG_BUTTON_SIZE } from './PerpDialogLayout';
+
 function CustomCheckbox({
   value,
   onChange,
@@ -192,7 +194,7 @@ export function HyperliquidTermsContent({
                 <Button
                   testID="perp-btn"
                   variant="primary"
-                  size="medium"
+                  size={PERP_DIALOG_BUTTON_SIZE}
                   w="100%"
                   onPress={onConfirm}
                   disabled={

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/AdjustPositionMarginModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/AdjustPositionMarginModal.tsx
@@ -28,7 +28,10 @@ import {
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../PerpDialogLayout';
 import { TradingGuardWrapper } from '../TradingGuardWrapper';
 import { TradingFormInput } from '../TradingPanel/inputs/TradingFormInput';
 
@@ -332,10 +335,10 @@ const AdjustPositionMarginForm = memo(
           </YStack>
         </YStack>
 
-        <TradingGuardWrapper>
+        <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
           <Button
             testID="perp-btn"
-            size="medium"
+            size={PERP_DIALOG_BUTTON_SIZE}
             variant="primary"
             onPress={handleSubmit}
             disabled={!isValidAmount || isSubmitting}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/CancelAllOrdersModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/CancelAllOrdersModal.tsx
@@ -14,7 +14,10 @@ import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../PerpDialogLayout';
 import { TradingGuardWrapper } from '../TradingGuardWrapper';
 
 interface ICancelAllOrdersContentProps {
@@ -96,11 +99,11 @@ function CancelAllOrdersContent({
         })}
       </SizableText>
 
-      <TradingGuardWrapper>
+      <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
         <Button
           testID="perp-button-text-btn"
           variant="primary"
-          size="medium"
+          size={PERP_DIALOG_BUTTON_SIZE}
           disabled={isSubmitting}
           loading={isSubmitting}
           onPress={handleConfirm}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/CloseAllPositionsModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/CloseAllPositionsModal.tsx
@@ -15,7 +15,10 @@ import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../PerpDialogLayout';
 import { TradingGuardWrapper } from '../TradingGuardWrapper';
 
 type ICloseType = 'market' | 'limit';
@@ -117,11 +120,11 @@ function CloseAllPositionsContent({
         </XStack>
       </YStack>
 
-      <TradingGuardWrapper>
+      <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
         <Button
           testID="perp-btn"
           variant="primary"
-          size="medium"
+          size={PERP_DIALOG_BUTTON_SIZE}
           disabled={isSubmitting}
           loading={isSubmitting}
           onPress={handleConfirm}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
@@ -31,7 +31,10 @@ import {
 import type { IWsWebData2 } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../PerpDialogLayout';
 import { PerpsSlider } from '../PerpsSlider';
 import { TradingGuardWrapper } from '../TradingGuardWrapper';
 import { PriceInput } from '../TradingPanel/inputs/PriceInput';
@@ -503,10 +506,10 @@ const ClosePositionForm = memo(
             {estimatedProfit}
           </SizableText>
         </XStack>
-        <TradingGuardWrapper>
+        <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
           <Button
             testID="perp-processed-value-btn"
-            size="medium"
+            size={PERP_DIALOG_BUTTON_SIZE}
             variant="primary"
             onPress={handleSubmit}
             disabled={!isFormValid || isSubmitting}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
@@ -37,7 +37,10 @@ import type { IPerpsFrontendOrder } from '@onekeyhq/shared/types/hyperliquid/sdk
 
 import { usePerpsMidPrice } from '../../hooks/usePerpsMidPrice';
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../PerpDialogLayout';
 import { PerpsSlider } from '../PerpsSlider';
 import { TradingGuardWrapper } from '../TradingGuardWrapper';
 import { TpslInput } from '../TradingPanel/inputs/TpslInput';
@@ -53,7 +56,7 @@ export interface ISetTpslParams {
   isMobile?: boolean;
 }
 
-interface ISetTpslFormProps extends ISetTpslParams {
+interface ISetTpslFormProps extends Omit<ISetTpslParams, 'isMobile'> {
   onClose: () => void;
 }
 
@@ -65,13 +68,7 @@ function MarkPrice({ coin }: { coin: string }) {
 }
 
 const SetTpslForm = memo(
-  ({
-    coin,
-    szDecimals,
-    assetId,
-    isMobile,
-    onClose = () => {},
-  }: ISetTpslFormProps) => {
+  ({ coin, szDecimals, assetId, onClose = () => {} }: ISetTpslFormProps) => {
     const intl = useIntl();
     const hyperliquidActions = useHyperliquidActions();
     const { mid: midPrice } = usePerpsMidPrice({ coin });
@@ -650,10 +647,10 @@ const SetTpslForm = memo(
             ) : null}
           </YStack>
         </YStack>
-        <TradingGuardWrapper>
+        <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
           <Button
             testID="perp-processed-value-btn"
-            size={isMobile ? 'large' : 'medium'}
+            size={PERP_DIALOG_BUTTON_SIZE}
             variant="primary"
             onPress={handleSubmit}
             disabled={!isValidForm || isSubmitting}
@@ -676,7 +673,7 @@ function SetTpslModal() {
   const route =
     useRoute<RouteProp<IModalPerpParamList, EModalPerpRoutes.MobileSetTpsl>>();
 
-  const { coin, szDecimals, assetId, isMobile = true } = route.params;
+  const { coin, szDecimals, assetId } = route.params;
   const navigation = useNavigation();
   const handleClose = useCallback(() => {
     navigation.goBack();
@@ -696,7 +693,6 @@ function SetTpslModal() {
               szDecimals={szDecimals}
               assetId={assetId}
               onClose={handleClose}
-              isMobile={isMobile}
             />
           </YStack>
         </PerpsProviderMirror>

--- a/packages/kit/src/views/Perp/components/PerpDialogLayout.ts
+++ b/packages/kit/src/views/Perp/components/PerpDialogLayout.ts
@@ -3,3 +3,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 export const PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS = platformEnv.isNative
   ? ({ pb: '$8' } as const)
   : undefined;
+
+export const PERP_DIALOG_BUTTON_SIZE = platformEnv.isNative
+  ? ('large' as const)
+  : ('medium' as const);

--- a/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
+++ b/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
@@ -42,6 +42,7 @@ import {
 import type { IMarketTokenChart } from '@onekeyhq/shared/types/market';
 
 import { useShowDepositWithdrawModal } from '../../hooks/useShowDepositWithdrawModal';
+import { PERP_DIALOG_BUTTON_SIZE } from '../PerpDialogLayout';
 
 import {
   type IPortfolioChartType,
@@ -797,7 +798,7 @@ function PerpPortfolioContentComponent({
       {/* P&L + Win Rate summary */}
       <SectionBlock>
         <XStack alignItems="center">
-          <YStack flex={1} gap="$0.5">
+          <YStack flex={1} minWidth={0} gap="$0.5">
             <SizableText size="$bodyXs" color="$textDisabled">
               {intl.formatMessage({
                 id: ETranslations.perp_portfolio_unrealized_pnl,
@@ -807,12 +808,12 @@ function PerpPortfolioContentComponent({
               size="$headingSm"
               color={unrealizedColor}
               numberOfLines={1}
-              adjustsFontSizeToFit
+              minWidth={0}
             >
               {unrealizedPnl}
             </SizableText>
           </YStack>
-          <YStack flex={1} gap="$0.5" alignItems="center">
+          <YStack flex={1} minWidth={0} gap="$0.5" alignItems="center">
             <DashText
               size="$bodyXs"
               color="$textDisabled"
@@ -827,12 +828,14 @@ function PerpPortfolioContentComponent({
               size="$headingSm"
               color={realizedColor}
               numberOfLines={1}
-              adjustsFontSizeToFit
+              minWidth={0}
+              maxWidth="100%"
+              textAlign="center"
             >
               {realizedPnl}
             </SizableText>
           </YStack>
-          <YStack flex={1} gap="$0.5" alignItems="flex-end">
+          <YStack flex={1} minWidth={0} gap="$0.5" alignItems="flex-end">
             <SizableText size="$bodyXs" color="$textDisabled">
               {intl.formatMessage({
                 id: ETranslations.perp_portfolio_open_positions,
@@ -857,7 +860,7 @@ function PerpPortfolioContentComponent({
         testID="perp-portfolio-buttons-btn"
         flex={1}
         borderRadius="$full"
-        size="medium"
+        size={PERP_DIALOG_BUTTON_SIZE}
         bg="$brand8"
         hoverStyle={{ bg: '$brand9' }}
         pressStyle={{ bg: '$brand10' }}
@@ -874,7 +877,7 @@ function PerpPortfolioContentComponent({
         testID="perp-portfolio-buttons-btn"
         flex={1}
         borderRadius="$full"
-        size="medium"
+        size={PERP_DIALOG_BUTTON_SIZE}
         variant="secondary"
         icon="AlignTopOutline"
         onPress={() => showDepositWithdrawModal('withdraw')}
@@ -1033,13 +1036,13 @@ function PerpPortfolioContentComponent({
               {vlm}
             </SizableText>
           </YStack>
-          {mostTradedTokenDisplayName ? (
-            <YStack gap="$0.5" alignItems="flex-end">
-              <SizableText size="$bodyXs" color="$textDisabled">
-                {intl.formatMessage({
-                  id: ETranslations.perp_portfolio_most_traded,
-                })}
-              </SizableText>
+          <YStack gap="$0.5" alignItems="flex-end">
+            <SizableText size="$bodyXs" color="$textDisabled">
+              {intl.formatMessage({
+                id: ETranslations.perp_portfolio_most_traded,
+              })}
+            </SizableText>
+            {mostTradedTokenDisplayName ? (
               <XStack gap="$1.5" alignItems="center">
                 <Token
                   size="xxs"
@@ -1051,8 +1054,12 @@ function PerpPortfolioContentComponent({
                   {mostTradedTokenDisplayName}
                 </SizableText>
               </XStack>
-            </YStack>
-          ) : null}
+            ) : (
+              <SizableText size="$headingSm" color="$text">
+                --
+              </SizableText>
+            )}
+          </YStack>
         </XStack>
         <Divider />
         {/* Fees + Deposits — compact row */}

--- a/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
+++ b/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
@@ -46,6 +46,19 @@ export function usePerpPortfolioData(
     { watchLoading: true, checkIsFocused: false },
   );
 
+  usePromiseResult(
+    async () => {
+      if (!address) {
+        await backgroundApiProxy.serviceHyperliquid.resetTradesHistory();
+        return null;
+      }
+      await backgroundApiProxy.serviceHyperliquid.loadTradesHistory(address);
+      return null;
+    },
+    [address],
+    { watchLoading: false, checkIsFocused: false },
+  );
+
   const startTime = useMemo(
     () => getStartTimeForPeriod(timePeriod),
     [timePeriod],

--- a/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
+++ b/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
@@ -18,6 +18,7 @@ interface ITradingGuardWrapperProps {
   forceShowEnableTrading?: boolean;
   bypassEnableTradingGuard?: boolean;
   disabled?: boolean;
+  buttonSize?: 'medium' | 'large';
 }
 
 function TradingGuardWrapperInternal({
@@ -25,6 +26,7 @@ function TradingGuardWrapperInternal({
   forceShowEnableTrading = false,
   bypassEnableTradingGuard = false,
   disabled = false,
+  buttonSize = 'medium',
 }: ITradingGuardWrapperProps) {
   const intl = useIntl();
   const [perpsAccountLoading] = usePerpsAccountLoadingInfoAtom();
@@ -53,7 +55,7 @@ function TradingGuardWrapperInternal({
     return (
       <Button
         variant="primary"
-        size="medium"
+        size={buttonSize}
         disabled
         childrenAsText={false}
         testID="perp-is-disabled-btn"
@@ -67,7 +69,7 @@ function TradingGuardWrapperInternal({
     return (
       <Button
         variant="primary"
-        size="medium"
+        size={buttonSize}
         disabled
         childrenAsText={false}
         testID="perp-is-disabled-btn"
@@ -86,7 +88,7 @@ function TradingGuardWrapperInternal({
       <Button
         testID="perp-is-disabled-btn"
         variant="primary"
-        size="medium"
+        size={buttonSize}
         disabled={disabled || isEnableTradingLoading}
         loading={isEnableTradingLoading}
         onPress={disabled ? undefined : enableTrading}

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
@@ -9,7 +9,6 @@ import {
   Icon,
   IconButton,
   SizableText,
-  Skeleton,
   XStack,
   useMedia,
 } from '@onekeyhq/components';
@@ -248,7 +247,9 @@ function DepositButton() {
           return (
             <>
               <Icon name="ChartLine2Outline" size="$4" />
-              <Skeleton width={60} height={16} />
+              <SizableText size="$bodySmMedium" color="$textSubdued">
+                --
+              </SizableText>
             </>
           );
         }
@@ -269,7 +270,7 @@ function DepositButton() {
               value={accountValue ?? ''}
               skeletonWidth={60}
               textSize="$bodySmMedium"
-              allowValueDuringAccountLoading={isUsingSnapshotValue}
+              allowValueDuringAccountLoading
               skipAccountSummaryCheck={isUsingSnapshotValue}
             />
           </>

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -86,7 +86,10 @@ import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
 
 import usePerpDeposit from '../../../hooks/usePerpDeposit';
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../../PerpDialogLayout';
 import { PerpsAccountNumberValue } from '../components/PerpsAccountNumberValue';
 import { InputAccessoryDoneButton } from '../inputs/TradingFormInput';
 
@@ -1896,7 +1899,7 @@ function DepositWithdrawContent({
         <Button
           testID="perp-btn"
           variant="primary"
-          size="medium"
+          size={PERP_DIALOG_BUTTON_SIZE}
           onPress={handleBuyPress}
         >
           {intl.formatMessage({ id: ETranslations.global_top_up })}
@@ -1905,7 +1908,7 @@ function DepositWithdrawContent({
         <Button
           testID="perp-btn"
           variant="primary"
-          size="medium"
+          size={PERP_DIALOG_BUTTON_SIZE}
           disabled={
             !isValidAmount ||
             isSubmitting ||

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/EnableTradingModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/EnableTradingModal.tsx
@@ -20,7 +20,10 @@ import {
   buildHelpUrl,
   openGuideUrl,
 } from '../../Guide/perpGuideData';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../../PerpDialogLayout';
 
 interface IEnableTradingContentProps {
   onClose?: () => void;
@@ -103,7 +106,7 @@ function EnableTradingContent({ onClose }: IEnableTradingContentProps) {
       <Button
         testID="perp-btn"
         variant="primary"
-        size="medium"
+        size={PERP_DIALOG_BUTTON_SIZE}
         disabled={loading || !isAgentNotReady}
         loading={loading}
         onPress={handleEnableTrading}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/EnableTradingModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/EnableTradingModal.tsx
@@ -11,9 +11,20 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { usePerpsActiveAccountStatusAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import PreSwapStep from '@onekeyhq/kit/src/views/Swap/components/PreSwapStep';
+import type { IPerpsActiveAccountStatusAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  usePerpsActiveAccountAtom,
+  usePerpsActiveAccountStatusAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import {
+  ESwapStepStatus,
+  type ISwapStep,
+} from '@onekeyhq/shared/types/swap/types';
 
 import {
   CONTEXTUAL_ARTICLE_IDS,
@@ -27,34 +38,203 @@ import {
 
 interface IEnableTradingContentProps {
   onClose?: () => void;
+  onComplete?: (status: IPerpsActiveAccountStatusAtom | undefined) => void;
 }
 
-function EnableTradingContent({ onClose }: IEnableTradingContentProps) {
+type IHardwareSigningStepKey =
+  | 'approveBuilderFee'
+  | 'removeAgent'
+  | 'approveAgent'
+  | 'setAbstraction';
+
+function getHardwareStepStatus({
+  completed,
+  isCurrent,
+  isFailed,
+  isLoading,
+}: {
+  completed: boolean;
+  isCurrent: boolean;
+  isFailed: boolean;
+  isLoading: boolean;
+}): ESwapStepStatus {
+  if (completed) {
+    return ESwapStepStatus.SUCCESS;
+  }
+  if (isFailed && isCurrent) {
+    return ESwapStepStatus.FAILED;
+  }
+  if (isLoading && isCurrent) {
+    return ESwapStepStatus.LOADING;
+  }
+  return ESwapStepStatus.READY;
+}
+
+function buildHardwareEnableTradingSteps(
+  steps: ISwapStep[],
+  {
+    failed,
+    loading,
+  }: {
+    failed: boolean;
+    loading: boolean;
+  },
+): ISwapStep[] {
+  const currentStepIndex = steps.findIndex(
+    (step) => step.status !== ESwapStepStatus.SUCCESS,
+  );
+  return steps.map((step, index) => {
+    const isCurrent = index === currentStepIndex;
+    const completed = step.status === ESwapStepStatus.SUCCESS;
+    return {
+      ...step,
+      status: getHardwareStepStatus({
+        completed,
+        isCurrent,
+        isFailed: failed,
+        isLoading: loading,
+      }),
+      canRetry: failed && isCurrent,
+    };
+  });
+}
+
+function EnableTradingContent({
+  onClose,
+  onComplete,
+}: IEnableTradingContentProps) {
   const intl = useIntl();
   const [loading, setLoading] = useState(false);
+  const [enableTradingFailed, setEnableTradingFailed] = useState(false);
+  const [plannedHardwareStepKeys, setPlannedHardwareStepKeys] = useState<
+    IHardwareSigningStepKey[] | undefined
+  >();
+  const [activeAccount] = usePerpsActiveAccountAtom();
   const [accountStatus] = usePerpsActiveAccountStatusAtom();
+  const activeAccountId = activeAccount.accountId;
+
+  const isHardwareWallet = useMemo(
+    () =>
+      accountUtils.isHwAccount({
+        accountId: activeAccountId ?? '',
+      }),
+    [activeAccountId],
+  );
 
   const isAgentNotReady = useMemo(
     () => !accountStatus?.details?.agentOk || !accountStatus?.canTrade,
     [accountStatus?.details?.agentOk, accountStatus?.canTrade],
   );
 
-  const handleEnableTrading = useCallback(async () => {
-    if (!isAgentNotReady) return;
+  const {
+    result: requiredHardwareSigningSteps,
+    isLoading: isHardwareSigningStepsLoading,
+  } = usePromiseResult(
+    async () => {
+      void activeAccountId;
+      if (!isHardwareWallet) {
+        return [];
+      }
+      return backgroundApiProxy.serviceHyperliquid.getEnableTradingHardwareSigningSteps();
+    },
+    [activeAccountId, isHardwareWallet],
+    {
+      watchLoading: true,
+    },
+  );
 
+  const hardwareSteps = useMemo<ISwapStep[]>(() => {
+    const details = accountStatus?.details;
+    const confirmOnDeviceText = '在硬件钱包上确认';
+    const visibleStepKeys =
+      plannedHardwareStepKeys ?? requiredHardwareSigningSteps ?? [];
+    const allSteps: Record<IHardwareSigningStepKey, ISwapStep> = {
+      approveBuilderFee: {
+        type: 'approveBuilderFee' as ISwapStep['type'],
+        status: details?.builderFeeOk
+          ? ESwapStepStatus.SUCCESS
+          : ESwapStepStatus.READY,
+        stepTitle: '签名授权手续费设置',
+        stepSubTitle: confirmOnDeviceText,
+      },
+      removeAgent: {
+        type: 'removeAgent' as ISwapStep['type'],
+        status: ESwapStepStatus.READY,
+        stepTitle: '签名移除旧交易代理',
+        stepSubTitle: confirmOnDeviceText,
+      },
+      approveAgent: {
+        type: 'approveAgent' as ISwapStep['type'],
+        status:
+          details?.agentOk && details?.internalRebateBoundOk
+            ? ESwapStepStatus.SUCCESS
+            : ESwapStepStatus.READY,
+        stepTitle: '签名授权交易代理',
+        stepSubTitle: confirmOnDeviceText,
+      },
+      setAbstraction: {
+        type: 'setAbstraction' as ISwapStep['type'],
+        status: details?.abstractionOk
+          ? ESwapStepStatus.SUCCESS
+          : ESwapStepStatus.READY,
+        stepTitle: '签名启用统一账户',
+        stepSubTitle: confirmOnDeviceText,
+      },
+    };
+    const visibleSteps = visibleStepKeys.map((key) => allSteps[key]);
+    return buildHardwareEnableTradingSteps(visibleSteps, {
+      failed: enableTradingFailed,
+      loading,
+    });
+  }, [
+    accountStatus?.details,
+    enableTradingFailed,
+    loading,
+    plannedHardwareStepKeys,
+    requiredHardwareSigningSteps,
+  ]);
+
+  const isCheckingHardwareSigningSteps =
+    isHardwareWallet &&
+    plannedHardwareStepKeys === undefined &&
+    requiredHardwareSigningSteps === undefined;
+
+  const handleEnableTrading = useCallback(async () => {
+    if (!isAgentNotReady || isCheckingHardwareSigningSteps) return;
+
+    setEnableTradingFailed(false);
+    setPlannedHardwareStepKeys((current) => {
+      if (current) return current;
+      return hardwareSteps.map(
+        (step) => step.type as unknown as IHardwareSigningStepKey,
+      );
+    });
     setLoading(true);
     try {
       const result =
         await backgroundApiProxy.serviceHyperliquid.enableTrading();
       if (result?.details?.agentOk && result?.canTrade) {
+        onComplete?.(result);
         onClose?.();
+      } else if (result?.details?.activatedOk === false) {
+        onComplete?.(result);
+        onClose?.();
+      } else {
+        setEnableTradingFailed(true);
       }
     } catch (error) {
+      setEnableTradingFailed(true);
       console.error('[EnableTradingModal] Failed to enable trading:', error);
     } finally {
       setLoading(false);
     }
-  }, [isAgentNotReady, onClose]);
+  }, [
+    hardwareSteps,
+    isAgentNotReady,
+    isCheckingHardwareSigningSteps,
+    onClose,
+    onComplete,
+  ]);
 
   const buttonText = useMemo(() => {
     if (loading) {
@@ -68,13 +248,20 @@ function EnableTradingContent({ onClose }: IEnableTradingContentProps) {
   }, [loading, intl]);
 
   return (
-    <YStack gap="$4" p="$1">
-      <YStack gap="$3">
+    <YStack gap="$6" p="$1">
+      <YStack gap={isHardwareWallet ? '$5' : '$3'}>
         <SizableText size="$bodyMd" color="$textSubdued">
-          {intl.formatMessage({
-            id: ETranslations.perp_enable_trading_desc,
-          })}
+          {isHardwareWallet
+            ? '启用交易会为当前账户建立安全的合约交易通道，之后即可下单且无需每次都连接设备。本次不会发起交易或转出资产；如果需要硬件钱包确认，我们会在下方展示本次签名步骤。'
+            : intl.formatMessage({
+                id: ETranslations.perp_enable_trading_desc,
+              })}
         </SizableText>
+        {isHardwareWallet && hardwareSteps.length > 0 ? (
+          <YStack py="$1">
+            <PreSwapStep steps={hardwareSteps} onRetry={handleEnableTrading} />
+          </YStack>
+        ) : null}
         <XStack
           gap="$1"
           alignItems="center"
@@ -103,44 +290,88 @@ function EnableTradingContent({ onClose }: IEnableTradingContentProps) {
         </XStack>
       </YStack>
 
-      <Button
-        testID="perp-btn"
-        variant="primary"
-        size={PERP_DIALOG_BUTTON_SIZE}
-        disabled={loading || !isAgentNotReady}
-        loading={loading}
-        onPress={handleEnableTrading}
-        bg="#18794E"
-        hoverStyle={{ bg: '$green8' }}
-        pressStyle={{ bg: '$green8' }}
-        color="$textOnColor"
-      >
-        {buttonText}
-      </Button>
+      {isHardwareWallet ? (
+        <XStack gap="$3">
+          <Button
+            testID="perp-enable-trading-cancel-btn"
+            flex={1}
+            variant="secondary"
+            size={PERP_DIALOG_BUTTON_SIZE}
+            disabled={loading}
+            onPress={onClose}
+          >
+            {intl.formatMessage({ id: ETranslations.global_cancel })}
+          </Button>
+          <Button
+            testID="perp-btn"
+            flex={1}
+            variant="primary"
+            size={PERP_DIALOG_BUTTON_SIZE}
+            disabled={
+              loading || !isAgentNotReady || isCheckingHardwareSigningSteps
+            }
+            loading={loading || isHardwareSigningStepsLoading}
+            onPress={handleEnableTrading}
+            bg="#18794E"
+            hoverStyle={{ bg: '$green8' }}
+            pressStyle={{ bg: '$green8' }}
+            color="$textOnColor"
+          >
+            {buttonText}
+          </Button>
+        </XStack>
+      ) : (
+        <Button
+          testID="perp-btn"
+          variant="primary"
+          size={PERP_DIALOG_BUTTON_SIZE}
+          disabled={loading || !isAgentNotReady}
+          loading={loading}
+          onPress={handleEnableTrading}
+          bg="#18794E"
+          hoverStyle={{ bg: '$green8' }}
+          pressStyle={{ bg: '$green8' }}
+          color="$textOnColor"
+        >
+          {buttonText}
+        </Button>
+      )}
     </YStack>
   );
 }
 
-export function showEnableTradingDialog() {
-  const dialogInstance = Dialog.show({
-    // Called from jotai action without React context; safe at invocation time
-    // eslint-disable-next-line onekey/no-app-locale-main-thread
-    title: appLocale.intl.formatMessage({
-      id: ETranslations.perp_trade_button_enable_trading,
-    }),
-    renderContent: (
-      <EnableTradingContent
-        onClose={() => {
-          void dialogInstance.close();
-        }}
-      />
-    ),
-    contentContainerProps: PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
-    showFooter: false,
-    onClose: () => {
-      void dialogInstance.close();
-    },
-  });
+export function showEnableTradingDialog(): Promise<
+  IPerpsActiveAccountStatusAtom | undefined
+> {
+  return new Promise((resolve) => {
+    let resolved = false;
+    const resolveOnce = (status: IPerpsActiveAccountStatusAtom | undefined) => {
+      if (resolved) return;
+      resolved = true;
+      resolve(status);
+    };
 
-  return dialogInstance;
+    const dialogInstance = Dialog.show({
+      // Called from jotai action without React context; safe at invocation time
+      // eslint-disable-next-line onekey/no-app-locale-main-thread
+      title: appLocale.intl.formatMessage({
+        id: ETranslations.perp_trade_button_enable_trading,
+      }),
+      renderContent: (
+        <EnableTradingContent
+          onComplete={resolveOnce}
+          onClose={() => {
+            resolveOnce(undefined);
+            void dialogInstance.close();
+          }}
+        />
+      ),
+      contentContainerProps: PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+      showFooter: false,
+      onClose: () => {
+        resolveOnce(undefined);
+        void dialogInstance.close();
+      },
+    });
+  });
 }

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/LeverageAdjustModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/LeverageAdjustModal.tsx
@@ -36,7 +36,10 @@ import {
   buildHelpUrl,
   openGuideUrl,
 } from '../../Guide/perpGuideData';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../../PerpDialogLayout';
 import { TradingGuardWrapper } from '../../TradingGuardWrapper';
 import { InputAccessoryDoneButton } from '../inputs/TradingFormInput';
 
@@ -234,13 +237,13 @@ const LeverageContent = memo(
               })}
             </SizableText>
           </XStack>
-          <TradingGuardWrapper>
+          <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
             <Button
               testID={PerpTestIDs.LeverageConfirmButton}
               onPress={handleConfirm}
               disabled={isDisabled}
               loading={loading}
-              size="medium"
+              size={PERP_DIALOG_BUTTON_SIZE}
               variant="primary"
             >
               {intl.formatMessage({ id: ETranslations.global_confirm })}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/MarginModeModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/MarginModeModal.tsx
@@ -21,7 +21,10 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { parseDexCoin } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../../PerpDialogLayout';
 import { TradingGuardWrapper } from '../../TradingGuardWrapper';
 
 import type { IntlShape } from 'react-intl';
@@ -124,11 +127,11 @@ function MarginModeContent({ onClose }: IMarginModeContentProps) {
         </SizableText>
       </YStack>
 
-      <TradingGuardWrapper>
+      <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
         <Button
           testID="perp-btn"
           variant="primary"
-          size="medium"
+          size={PERP_DIALOG_BUTTON_SIZE}
           disabled={loading}
           loading={loading}
           onPress={handleConfirm}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -39,7 +39,10 @@ import {
   GetTradingButtonStyleProps,
   getTradingSideTextColor,
 } from '../../../utils/styleUtils';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../../PerpDialogLayout';
 import { TradingGuardWrapper } from '../../TradingGuardWrapper';
 import { LiquidationPriceDisplay } from '../components/LiquidationPriceDisplay';
 
@@ -568,11 +571,12 @@ function OrderConfirmContent({
 
       <TradingGuardWrapper
         bypassEnableTradingGuard={Boolean(enableTradingBeforeConfirm)}
+        buttonSize={PERP_DIALOG_BUTTON_SIZE}
       >
         <Button
           testID="perp-btn"
           variant="primary"
-          size="medium"
+          size={PERP_DIALOG_BUTTON_SIZE}
           disabled={isConfirmLoading}
           loading={isConfirmLoading}
           onPress={handleConfirm}

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -644,12 +644,6 @@ function PerpTradingForm({
     spotAvailableBaseBN,
     spotAvailableQuoteBN,
   ]);
-  const isUsingCachedAvailableToTrade = Boolean(
-    !isSpot &&
-    !activeAssetData?.availableToTrade &&
-    snapshotEntry?.availableToTrade?.coin === activeAsset?.coin,
-  );
-
   // Spot: display raw token balance with symbol
   const spotAvailableDisplay = useMemo(() => {
     if (!isSpot) return '';
@@ -1595,10 +1589,8 @@ function PerpTradingForm({
                   <PerpsAccountNumberValue
                     value={availableToTrade}
                     skeletonWidth={60}
-                    allowValueDuringAccountLoading={
-                      isUsingCachedAvailableToTrade
-                    }
-                    skipAccountSummaryCheck={isUsingCachedAvailableToTrade}
+                    allowValueDuringAccountLoading
+                    skipAccountSummaryCheck
                   />
                   <MobileDepositButton onPress={handleDepositPress} />
                 </XStack>

--- a/packages/kit/src/views/Perp/hooks/useEnableTradingWithDepositFallback.ts
+++ b/packages/kit/src/views/Perp/hooks/useEnableTradingWithDepositFallback.ts
@@ -5,8 +5,10 @@ import {
   type IPerpsActiveAccountStatusAtom,
   usePerpsActiveAccountAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 
 import { showHyperliquidTermsDialog } from '../components/HyperliquidTerms';
+import { showEnableTradingDialog } from '../components/TradingPanel/modals/EnableTradingModal';
 import { getEnableTradingDialogConfirmDecision } from '../utils/enableTradingDialogConfirm';
 
 import { useShowDepositWithdrawModal } from './useShowDepositWithdrawModal';
@@ -71,6 +73,7 @@ export function useHandleEnableTradingPostStatus() {
 export function useRequestEnableTradingWithDepositFallback() {
   const requestEnableTrading = useRequestEnableTrading();
   const handleEnableTradingPostStatus = useHandleEnableTradingPostStatus();
+  const [perpsAccount] = usePerpsActiveAccountAtom();
 
   return useCallback(
     async (
@@ -79,10 +82,19 @@ export function useRequestEnableTradingWithDepositFallback() {
       if (options?.shouldIgnoreResult?.()) {
         return { shouldContinue: false, status: undefined };
       }
-      const status = await requestEnableTrading();
+      const isHardwareWallet = accountUtils.isHwAccount({
+        accountId: perpsAccount.accountId ?? '',
+      });
+      const status = isHardwareWallet
+        ? await showEnableTradingDialog()
+        : await requestEnableTrading();
       return handleEnableTradingPostStatus(status, options);
     },
-    [handleEnableTradingPostStatus, requestEnableTrading],
+    [
+      handleEnableTradingPostStatus,
+      perpsAccount.accountId,
+      requestEnableTrading,
+    ],
   );
 }
 


### PR DESCRIPTION
## Summary
- add a hardware-wallet-specific enable trading dialog flow for Perps
- estimate and show only the actual signing steps required for the current account
- keep the existing enable trading execution flow and deposit fallback behavior unchanged
- avoid step/text flicker by waiting for signing-step estimation before rendering step progress

## Verification
- yarn lint:staged
- yarn tsc:staged