### PR TITLE
fix: improve perps portfolio display

### DIFF
--- a/packages/kit/src/views/Perp/components/HyperliquidTerms.tsx
+++ b/packages/kit/src/views/Perp/components/HyperliquidTerms.tsx
@@ -31,6 +31,8 @@ import {
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { usePerpsLogo } from '../hooks/usePerpsLogo';
 
+import { PERP_DIALOG_BUTTON_SIZE } from './PerpDialogLayout';
+
 function CustomCheckbox({
   value,
   onChange,
@@ -192,7 +194,7 @@ export function HyperliquidTermsContent({
                 <Button
                   testID="perp-btn"
                   variant="primary"
-                  size="medium"
+                  size={PERP_DIALOG_BUTTON_SIZE}
                   w="100%"
                   onPress={onConfirm}
                   disabled={

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/AdjustPositionMarginModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/AdjustPositionMarginModal.tsx
@@ -28,7 +28,10 @@ import {
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../PerpDialogLayout';
 import { TradingGuardWrapper } from '../TradingGuardWrapper';
 import { TradingFormInput } from '../TradingPanel/inputs/TradingFormInput';
 
@@ -332,10 +335,10 @@ const AdjustPositionMarginForm = memo(
           </YStack>
         </YStack>
 
-        <TradingGuardWrapper>
+        <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
           <Button
             testID="perp-btn"
-            size="medium"
+            size={PERP_DIALOG_BUTTON_SIZE}
             variant="primary"
             onPress={handleSubmit}
             disabled={!isValidAmount || isSubmitting}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/CancelAllOrdersModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/CancelAllOrdersModal.tsx
@@ -14,7 +14,10 @@ import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../PerpDialogLayout';
 import { TradingGuardWrapper } from '../TradingGuardWrapper';
 
 interface ICancelAllOrdersContentProps {
@@ -96,11 +99,11 @@ function CancelAllOrdersContent({
         })}
       </SizableText>
 
-      <TradingGuardWrapper>
+      <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
         <Button
           testID="perp-button-text-btn"
           variant="primary"
-          size="medium"
+          size={PERP_DIALOG_BUTTON_SIZE}
           disabled={isSubmitting}
           loading={isSubmitting}
           onPress={handleConfirm}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/CloseAllPositionsModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/CloseAllPositionsModal.tsx
@@ -15,7 +15,10 @@ import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../PerpDialogLayout';
 import { TradingGuardWrapper } from '../TradingGuardWrapper';
 
 type ICloseType = 'market' | 'limit';
@@ -117,11 +120,11 @@ function CloseAllPositionsContent({
         </XStack>
       </YStack>
 
-      <TradingGuardWrapper>
+      <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
         <Button
           testID="perp-btn"
           variant="primary"
-          size="medium"
+          size={PERP_DIALOG_BUTTON_SIZE}
           disabled={isSubmitting}
           loading={isSubmitting}
           onPress={handleConfirm}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
@@ -31,7 +31,10 @@ import {
 import type { IWsWebData2 } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../PerpDialogLayout';
 import { PerpsSlider } from '../PerpsSlider';
 import { TradingGuardWrapper } from '../TradingGuardWrapper';
 import { PriceInput } from '../TradingPanel/inputs/PriceInput';
@@ -503,10 +506,10 @@ const ClosePositionForm = memo(
             {estimatedProfit}
           </SizableText>
         </XStack>
-        <TradingGuardWrapper>
+        <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
           <Button
             testID="perp-processed-value-btn"
-            size="medium"
+            size={PERP_DIALOG_BUTTON_SIZE}
             variant="primary"
             onPress={handleSubmit}
             disabled={!isFormValid || isSubmitting}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
@@ -37,7 +37,10 @@ import type { IPerpsFrontendOrder } from '@onekeyhq/shared/types/hyperliquid/sdk
 
 import { usePerpsMidPrice } from '../../hooks/usePerpsMidPrice';
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../PerpDialogLayout';
 import { PerpsSlider } from '../PerpsSlider';
 import { TradingGuardWrapper } from '../TradingGuardWrapper';
 import { TpslInput } from '../TradingPanel/inputs/TpslInput';
@@ -53,7 +56,7 @@ export interface ISetTpslParams {
   isMobile?: boolean;
 }
 
-interface ISetTpslFormProps extends ISetTpslParams {
+interface ISetTpslFormProps extends Omit<ISetTpslParams, 'isMobile'> {
   onClose: () => void;
 }
 
@@ -65,13 +68,7 @@ function MarkPrice({ coin }: { coin: string }) {
 }
 
 const SetTpslForm = memo(
-  ({
-    coin,
-    szDecimals,
-    assetId,
-    isMobile,
-    onClose = () => {},
-  }: ISetTpslFormProps) => {
+  ({ coin, szDecimals, assetId, onClose = () => {} }: ISetTpslFormProps) => {
     const intl = useIntl();
     const hyperliquidActions = useHyperliquidActions();
     const { mid: midPrice } = usePerpsMidPrice({ coin });
@@ -650,10 +647,10 @@ const SetTpslForm = memo(
             ) : null}
           </YStack>
         </YStack>
-        <TradingGuardWrapper>
+        <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
           <Button
             testID="perp-processed-value-btn"
-            size={isMobile ? 'large' : 'medium'}
+            size={PERP_DIALOG_BUTTON_SIZE}
             variant="primary"
             onPress={handleSubmit}
             disabled={!isValidForm || isSubmitting}
@@ -676,7 +673,7 @@ function SetTpslModal() {
   const route =
     useRoute<RouteProp<IModalPerpParamList, EModalPerpRoutes.MobileSetTpsl>>();
 
-  const { coin, szDecimals, assetId, isMobile = true } = route.params;
+  const { coin, szDecimals, assetId } = route.params;
   const navigation = useNavigation();
   const handleClose = useCallback(() => {
     navigation.goBack();
@@ -696,7 +693,6 @@ function SetTpslModal() {
               szDecimals={szDecimals}
               assetId={assetId}
               onClose={handleClose}
-              isMobile={isMobile}
             />
           </YStack>
         </PerpsProviderMirror>

--- a/packages/kit/src/views/Perp/components/PerpDialogLayout.ts
+++ b/packages/kit/src/views/Perp/components/PerpDialogLayout.ts
@@ -3,3 +3,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 export const PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS = platformEnv.isNative
   ? ({ pb: '$8' } as const)
   : undefined;
+
+export const PERP_DIALOG_BUTTON_SIZE = platformEnv.isNative
+  ? ('large' as const)
+  : ('medium' as const);

--- a/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
+++ b/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
@@ -42,6 +42,7 @@ import {
 import type { IMarketTokenChart } from '@onekeyhq/shared/types/market';
 
 import { useShowDepositWithdrawModal } from '../../hooks/useShowDepositWithdrawModal';
+import { PERP_DIALOG_BUTTON_SIZE } from '../PerpDialogLayout';
 
 import {
   type IPortfolioChartType,
@@ -797,7 +798,7 @@ function PerpPortfolioContentComponent({
       {/* P&L + Win Rate summary */}
       <SectionBlock>
         <XStack alignItems="center">
-          <YStack flex={1} gap="$0.5">
+          <YStack flex={1} minWidth={0} gap="$0.5">
             <SizableText size="$bodyXs" color="$textDisabled">
               {intl.formatMessage({
                 id: ETranslations.perp_portfolio_unrealized_pnl,
@@ -807,12 +808,12 @@ function PerpPortfolioContentComponent({
               size="$headingSm"
               color={unrealizedColor}
               numberOfLines={1}
-              adjustsFontSizeToFit
+              minWidth={0}
             >
               {unrealizedPnl}
             </SizableText>
           </YStack>
-          <YStack flex={1} gap="$0.5" alignItems="center">
+          <YStack flex={1} minWidth={0} gap="$0.5" alignItems="center">
             <DashText
               size="$bodyXs"
               color="$textDisabled"
@@ -827,12 +828,14 @@ function PerpPortfolioContentComponent({
               size="$headingSm"
               color={realizedColor}
               numberOfLines={1}
-              adjustsFontSizeToFit
+              minWidth={0}
+              maxWidth="100%"
+              textAlign="center"
             >
               {realizedPnl}
             </SizableText>
           </YStack>
-          <YStack flex={1} gap="$0.5" alignItems="flex-end">
+          <YStack flex={1} minWidth={0} gap="$0.5" alignItems="flex-end">
             <SizableText size="$bodyXs" color="$textDisabled">
               {intl.formatMessage({
                 id: ETranslations.perp_portfolio_open_positions,
@@ -857,7 +860,7 @@ function PerpPortfolioContentComponent({
         testID="perp-portfolio-buttons-btn"
         flex={1}
         borderRadius="$full"
-        size="medium"
+        size={PERP_DIALOG_BUTTON_SIZE}
         bg="$brand8"
         hoverStyle={{ bg: '$brand9' }}
         pressStyle={{ bg: '$brand10' }}
@@ -874,7 +877,7 @@ function PerpPortfolioContentComponent({
         testID="perp-portfolio-buttons-btn"
         flex={1}
         borderRadius="$full"
-        size="medium"
+        size={PERP_DIALOG_BUTTON_SIZE}
         variant="secondary"
         icon="AlignTopOutline"
         onPress={() => showDepositWithdrawModal('withdraw')}
@@ -1033,13 +1036,13 @@ function PerpPortfolioContentComponent({
               {vlm}
             </SizableText>
           </YStack>
-          {mostTradedTokenDisplayName ? (
-            <YStack gap="$0.5" alignItems="flex-end">
-              <SizableText size="$bodyXs" color="$textDisabled">
-                {intl.formatMessage({
-                  id: ETranslations.perp_portfolio_most_traded,
-                })}
-              </SizableText>
+          <YStack gap="$0.5" alignItems="flex-end">
+            <SizableText size="$bodyXs" color="$textDisabled">
+              {intl.formatMessage({
+                id: ETranslations.perp_portfolio_most_traded,
+              })}
+            </SizableText>
+            {mostTradedTokenDisplayName ? (
               <XStack gap="$1.5" alignItems="center">
                 <Token
                   size="xxs"
@@ -1051,8 +1054,12 @@ function PerpPortfolioContentComponent({
                   {mostTradedTokenDisplayName}
                 </SizableText>
               </XStack>
-            </YStack>
-          ) : null}
+            ) : (
+              <SizableText size="$headingSm" color="$text">
+                --
+              </SizableText>
+            )}
+          </YStack>
         </XStack>
         <Divider />
         {/* Fees + Deposits — compact row */}

--- a/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
+++ b/packages/kit/src/views/Perp/components/Portfolio/usePerpPortfolioData.ts
@@ -46,6 +46,19 @@ export function usePerpPortfolioData(
     { watchLoading: true, checkIsFocused: false },
   );
 
+  usePromiseResult(
+    async () => {
+      if (!address) {
+        await backgroundApiProxy.serviceHyperliquid.resetTradesHistory();
+        return null;
+      }
+      await backgroundApiProxy.serviceHyperliquid.loadTradesHistory(address);
+      return null;
+    },
+    [address],
+    { watchLoading: false, checkIsFocused: false },
+  );
+
   const startTime = useMemo(
     () => getStartTimeForPeriod(timePeriod),
     [timePeriod],

--- a/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
+++ b/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
@@ -18,6 +18,7 @@ interface ITradingGuardWrapperProps {
   forceShowEnableTrading?: boolean;
   bypassEnableTradingGuard?: boolean;
   disabled?: boolean;
+  buttonSize?: 'medium' | 'large';
 }
 
 function TradingGuardWrapperInternal({
@@ -25,6 +26,7 @@ function TradingGuardWrapperInternal({
   forceShowEnableTrading = false,
   bypassEnableTradingGuard = false,
   disabled = false,
+  buttonSize = 'medium',
 }: ITradingGuardWrapperProps) {
   const intl = useIntl();
   const [perpsAccountLoading] = usePerpsAccountLoadingInfoAtom();
@@ -53,7 +55,7 @@ function TradingGuardWrapperInternal({
     return (
       <Button
         variant="primary"
-        size="medium"
+        size={buttonSize}
         disabled
         childrenAsText={false}
         testID="perp-is-disabled-btn"
@@ -67,7 +69,7 @@ function TradingGuardWrapperInternal({
     return (
       <Button
         variant="primary"
-        size="medium"
+        size={buttonSize}
         disabled
         childrenAsText={false}
         testID="perp-is-disabled-btn"
@@ -86,7 +88,7 @@ function TradingGuardWrapperInternal({
       <Button
         testID="perp-is-disabled-btn"
         variant="primary"
-        size="medium"
+        size={buttonSize}
         disabled={disabled || isEnableTradingLoading}
         loading={isEnableTradingLoading}
         onPress={disabled ? undefined : enableTrading}

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
@@ -9,7 +9,6 @@ import {
   Icon,
   IconButton,
   SizableText,
-  Skeleton,
   XStack,
   useMedia,
 } from '@onekeyhq/components';
@@ -303,7 +302,9 @@ function DepositButton() {
           return (
             <>
               <Icon name="ChartLine2Outline" size="$4" />
-              <Skeleton width={60} height={16} />
+              <SizableText size="$bodySmMedium" color="$textSubdued">
+                --
+              </SizableText>
             </>
           );
         }

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -86,7 +86,10 @@ import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
 
 import usePerpDeposit from '../../../hooks/usePerpDeposit';
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../../PerpDialogLayout';
 import { PerpsAccountNumberValue } from '../components/PerpsAccountNumberValue';
 import { InputAccessoryDoneButton } from '../inputs/TradingFormInput';
 
@@ -1896,7 +1899,7 @@ function DepositWithdrawContent({
         <Button
           testID="perp-btn"
           variant="primary"
-          size="medium"
+          size={PERP_DIALOG_BUTTON_SIZE}
           onPress={handleBuyPress}
         >
           {intl.formatMessage({ id: ETranslations.global_top_up })}
@@ -1905,7 +1908,7 @@ function DepositWithdrawContent({
         <Button
           testID="perp-btn"
           variant="primary"
-          size="medium"
+          size={PERP_DIALOG_BUTTON_SIZE}
           disabled={
             !isValidAmount ||
             isSubmitting ||

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/EnableTradingModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/EnableTradingModal.tsx
@@ -20,7 +20,10 @@ import {
   buildHelpUrl,
   openGuideUrl,
 } from '../../Guide/perpGuideData';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../../PerpDialogLayout';
 
 interface IEnableTradingContentProps {
   onClose?: () => void;
@@ -103,7 +106,7 @@ function EnableTradingContent({ onClose }: IEnableTradingContentProps) {
       <Button
         testID="perp-btn"
         variant="primary"
-        size="medium"
+        size={PERP_DIALOG_BUTTON_SIZE}
         disabled={loading || !isAgentNotReady}
         loading={loading}
         onPress={handleEnableTrading}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/LeverageAdjustModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/LeverageAdjustModal.tsx
@@ -41,7 +41,10 @@ import {
   buildHelpUrl,
   openGuideUrl,
 } from '../../Guide/perpGuideData';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../../PerpDialogLayout';
 import { TradingGuardWrapper } from '../../TradingGuardWrapper';
 import { InputAccessoryDoneButton } from '../inputs/TradingFormInput';
 
@@ -239,13 +242,13 @@ const LeverageContent = memo(
               })}
             </SizableText>
           </XStack>
-          <TradingGuardWrapper>
+          <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
             <Button
               testID={PerpTestIDs.LeverageConfirmButton}
               onPress={handleConfirm}
               disabled={isDisabled}
               loading={loading}
-              size="medium"
+              size={PERP_DIALOG_BUTTON_SIZE}
               variant="primary"
             >
               {intl.formatMessage({ id: ETranslations.global_confirm })}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/MarginModeModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/MarginModeModal.tsx
@@ -21,7 +21,10 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { parseDexCoin } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../../PerpDialogLayout';
 import { TradingGuardWrapper } from '../../TradingGuardWrapper';
 
 import type { IntlShape } from 'react-intl';
@@ -124,11 +127,11 @@ function MarginModeContent({ onClose }: IMarginModeContentProps) {
         </SizableText>
       </YStack>
 
-      <TradingGuardWrapper>
+      <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
         <Button
           testID="perp-btn"
           variant="primary"
-          size="medium"
+          size={PERP_DIALOG_BUTTON_SIZE}
           disabled={loading}
           loading={loading}
           onPress={handleConfirm}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -39,7 +39,10 @@ import {
   GetTradingButtonStyleProps,
   getTradingSideTextColor,
 } from '../../../utils/styleUtils';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../../PerpDialogLayout';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../../PerpDialogLayout';
 import { TradingGuardWrapper } from '../../TradingGuardWrapper';
 import { LiquidationPriceDisplay } from '../components/LiquidationPriceDisplay';
 
@@ -568,11 +571,12 @@ function OrderConfirmContent({
 
       <TradingGuardWrapper
         bypassEnableTradingGuard={Boolean(enableTradingBeforeConfirm)}
+        buttonSize={PERP_DIALOG_BUTTON_SIZE}
       >
         <Button
           testID="perp-btn"
           variant="primary"
-          size="medium"
+          size={PERP_DIALOG_BUTTON_SIZE}
           disabled={isConfirmLoading}
           loading={isConfirmLoading}
           onPress={handleConfirm}


### PR DESCRIPTION
## Summary
- improve Perps portfolio display fallbacks and cached data transitions
- standardize Perps dialog button sizing across mobile and desktop
- keep desktop dialog actions at medium size while using large actions on mobile

## Verification
- yarn lint:staged
- yarn tsc:staged