### PR TITLE
chore(ada): diagnostic logs for Android sw-wallet address creation hang

### DIFF
--- a/apps/mobile/background.ts
+++ b/apps/mobile/background.ts
@@ -25,6 +25,44 @@ const bgEntryLog = (msg: string) => {
 const bgEntryStart: number = (globalThis as any).__ONEKEY_BG_ENTRY_START__;
 bgEntryLog(`polyfills loaded (+${Date.now() - bgEntryStart}ms)`);
 
+// OK-55xxx ADA-create-address hang fix — scoped to THIS Android background
+// runtime entry (the file only runs on the background thread).
+//
+// The npm `process` polyfill drives its private nextTick queue via a
+// `setTimeout` it caches at module-load time. On the Android background JS
+// runtime that load precedes RN wiring up timers, so the first
+// `runTimeout(drainQueue)` fails and the queue never drains again (verified on
+// device: queue grows monotonically, drainQueue never runs, while
+// setTimeout / setImmediate / queueMicrotask / Promise.then all work). Any code
+// relying on `process.nextTick` to deliver a result then hangs forever — e.g.
+// npm `pbkdf2`'s async callback (cardano-crypto.js `mnemonicToRootKeypair`),
+// which is why software-wallet Cardano address creation kept loading on Android
+// while iOS / hardware wallet were fine.
+//
+// Redirect nextTick to the (verified-working) `setImmediate` — but only on
+// Android, only when a `process.nextTick` actually exists to replace, and right
+// here, before anything calls nextTick, so the broken queue is never used.
+{
+  const { Platform } = require('react-native') as typeof import('react-native');
+  const g = globalThis as any;
+  if (
+    Platform.OS === 'android' &&
+    g.process &&
+    typeof g.process.nextTick === 'function' &&
+    typeof g.setImmediate === 'function'
+  ) {
+    g.process.nextTick = function nextTickViaSetImmediate(
+      callback: (...args: any[]) => void,
+      ...args: any[]
+    ) {
+      g.setImmediate(() => {
+        callback(...args);
+      });
+    };
+    bgEntryLog('process.nextTick -> setImmediate (android background runtime)');
+  }
+}
+
 // Install production split bundle loader for background runtime (Phase 3).
 // Uses BackgroundThread.loadSegmentInBackground to register segments
 // with the background Hermes runtime.

--- a/packages/core/src/chains/ada/CoreChainSoftware.ts
+++ b/packages/core/src/chains/ada/CoreChainSoftware.ts
@@ -1,4 +1,5 @@
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { checkIsDefined } from '@onekeyhq/shared/src/utils/assertUtils';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
@@ -224,12 +225,22 @@ export default class CoreChainSoftware extends CoreChainApiBase {
     //   pathSuffix.replace('{index}', index.toString()),
     // );
 
+    defaultLogger.account.adaDebug.step({
+      tag: 'CoreChainSoftware.getAddressesFromHd',
+      phase: 'start',
+      info: `indexes=${indexes.join(',')}`,
+    });
     const addressInfos = await batchGetShelleyAddresses(
       hdCredential,
       password,
       indexes,
       EAdaNetworkId.MAINNET,
     );
+    defaultLogger.account.adaDebug.step({
+      tag: 'CoreChainSoftware.getAddressesFromHd',
+      phase: 'done',
+      info: `addressInfos=${addressInfos.length}`,
+    });
 
     const addresses = addressInfos.map((info) => {
       const { baseAddress, stakingAddress } = info;

--- a/packages/core/src/chains/ada/sdkAda/bip32.ts
+++ b/packages/core/src/chains/ada/sdkAda/bip32.ts
@@ -6,6 +6,7 @@
 import { bech32, mnemonicToRootKeypair, toPublic } from 'cardano-crypto.js';
 
 import { mnemonicFromEntropy } from '@onekeyhq/core/src/secret';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 
 import { DERIVATION_SCHEME, HARDENED_THRESHOLD } from './constants';
 
@@ -30,8 +31,47 @@ export async function getRootKey(
   password: string,
   hdCredential: ICoreHdCredentialEncryptHex,
 ): Promise<Buffer> {
-  const mnemonic: string = await mnemonicFromEntropy(hdCredential, password);
-  const rootKey = await mnemonicToRootKeypair(mnemonic, DERIVATION_SCHEME);
+  defaultLogger.account.adaDebug.step({
+    tag: 'getRootKey.mnemonicFromEntropy',
+    phase: 'start',
+  });
+  let mnemonic: string;
+  try {
+    mnemonic = await mnemonicFromEntropy(hdCredential, password);
+  } catch (e) {
+    defaultLogger.account.adaDebug.step({
+      tag: 'getRootKey.mnemonicFromEntropy',
+      phase: 'error',
+      info: String((e as Error)?.message || e),
+    });
+    throw e;
+  }
+  defaultLogger.account.adaDebug.step({
+    tag: 'getRootKey.mnemonicFromEntropy',
+    phase: 'done',
+    info: `mnemonicWords=${mnemonic ? mnemonic.split(' ').length : 0}`,
+  });
+
+  defaultLogger.account.adaDebug.step({
+    tag: 'getRootKey.mnemonicToRootKeypair',
+    phase: 'start',
+  });
+  let rootKey: Buffer;
+  try {
+    rootKey = await mnemonicToRootKeypair(mnemonic, DERIVATION_SCHEME);
+  } catch (e) {
+    defaultLogger.account.adaDebug.step({
+      tag: 'getRootKey.mnemonicToRootKeypair',
+      phase: 'error',
+      info: String((e as Error)?.message || e),
+    });
+    throw e;
+  }
+  defaultLogger.account.adaDebug.step({
+    tag: 'getRootKey.mnemonicToRootKeypair',
+    phase: 'done',
+    info: `rootKeyLen=${rootKey ? rootKey.length : 0}`,
+  });
   return rootKey;
 }
 

--- a/packages/core/src/chains/ada/sdkAda/bip32.ts
+++ b/packages/core/src/chains/ada/sdkAda/bip32.ts
@@ -29,6 +29,58 @@ import type { IAdaBIP32Path } from '../types';
   }
 };
 
+// One-shot diagnostic: snapshot the bg-runtime environment and fire every
+// async-deferral primitive once. Whichever logs 'start' but never 'done' is
+// the scheduler that's dead on this runtime (that's why pbkdf2's async
+// callback never returns). Also flips __adaProcTrace so the patched npm
+// `process` polyfill logs its internal nextTick/runTimeout/drainQueue flow.
+function __adaProbeDeferrals() {
+  const g: any = globalThis;
+  const L = g.__adaDebugLog || (() => {});
+  g.__adaProcTrace = true;
+  g.__adaProcTraceN = 0;
+  try {
+    const c = g.crypto;
+    L(
+      'probe.env',
+      'done',
+      `crypto=${typeof c} subtle=${typeof c?.subtle} digest=${typeof c?.subtle
+        ?.digest} importKey=${typeof c?.subtle?.importKey} deriveBits=${typeof c
+        ?.subtle
+        ?.deriveBits} setTimeout=${typeof g.setTimeout} setImmediate=${typeof g.setImmediate} queueMicrotask=${typeof g.queueMicrotask} process=${typeof g.process} nextTick=${typeof g
+        .process?.nextTick} browser=${String(g.process?.browser)}`,
+    );
+  } catch (e) {
+    L('probe.env', 'error', String(e));
+  }
+  const fire = (tag: string, schedule: (cb: () => void) => void) => {
+    try {
+      L(tag, 'start');
+      schedule(() => L(tag, 'done'));
+    } catch (e) {
+      L(tag, 'error', String(e));
+    }
+  };
+  const g2: any = globalThis;
+  fire('probe.setTimeout', (cb) => g2.setTimeout(cb, 0));
+  fire('probe.promiseThen', (cb) => {
+    void Promise.resolve().then(cb);
+  });
+  fire('probe.queueMicrotask', (cb) =>
+    g2.queueMicrotask ? g2.queueMicrotask(cb) : cb(),
+  );
+  fire('probe.setImmediate', (cb) =>
+    g2.setImmediate
+      ? g2.setImmediate(cb)
+      : L('probe.setImmediate', 'error', 'absent'),
+  );
+  fire('probe.processNextTick', (cb) =>
+    g2.process && g2.process.nextTick
+      ? g2.process.nextTick(cb)
+      : L('probe.processNextTick', 'error', 'absent'),
+  );
+}
+
 export function toBip32StringPath(derivationPath: IAdaBIP32Path) {
   return `m/${derivationPath
     .map(
@@ -47,6 +99,7 @@ export async function getRootKey(
   password: string,
   hdCredential: ICoreHdCredentialEncryptHex,
 ): Promise<Buffer> {
+  __adaProbeDeferrals();
   defaultLogger.account.adaDebug.step({
     tag: 'getRootKey.mnemonicFromEntropy',
     phase: 'start',

--- a/packages/core/src/chains/ada/sdkAda/bip32.ts
+++ b/packages/core/src/chains/ada/sdkAda/bip32.ts
@@ -13,6 +13,22 @@ import { DERIVATION_SCHEME, HARDENED_THRESHOLD } from './constants';
 import type { ICoreHdCredentialEncryptHex } from '../../../types';
 import type { IAdaBIP32Path } from '../types';
 
+// Diagnostic hook so the (node_modules) cardano-crypto.js patch can log the
+// internal steps of mnemonicToRootKeypair through our persisted logger
+// (@LogToLocal). Registered at module load of the ada CoreChainHd segment,
+// which runs before any derivation call. Keep it crash-safe.
+(globalThis as any).__adaDebugLog = (
+  tag: string,
+  phase: 'start' | 'done' | 'error',
+  info?: string,
+) => {
+  try {
+    defaultLogger.account.adaDebug.step({ tag, phase, info });
+  } catch {
+    // logger unavailable — never let diagnostics break derivation
+  }
+};
+
 export function toBip32StringPath(derivationPath: IAdaBIP32Path) {
   return `m/${derivationPath
     .map(

--- a/packages/core/src/chains/ada/sdkAda/shelley-address.ts
+++ b/packages/core/src/chains/ada/sdkAda/shelley-address.ts
@@ -4,6 +4,8 @@
 // @ts-expect-error
 import { derivePrivate, toPublic } from 'cardano-crypto.js';
 
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+
 import { baseAddressFromXpub, stakingAddressFromXpub } from './addresses';
 import { getRootKey, toBip32StringPath } from './bip32';
 import { DERIVATION_SCHEME, HARDENED_THRESHOLD } from './constants';
@@ -121,6 +123,21 @@ export const batchGetShelleyAddresses = async (
   indexes: number[],
   networkId: EAdaNetworkId,
 ) => {
+  defaultLogger.account.adaDebug.step({
+    tag: 'batchGetShelleyAddresses',
+    phase: 'start',
+    info: `indexes=${indexes.join(',')}`,
+  });
   const rootKey = await getRootKey(password, hdCredential);
-  return batchGetShelleyAddressByRootKey(rootKey, indexes, networkId);
+  defaultLogger.account.adaDebug.step({
+    tag: 'batchGetShelleyAddresses.deriveAddresses',
+    phase: 'start',
+  });
+  const result = batchGetShelleyAddressByRootKey(rootKey, indexes, networkId);
+  defaultLogger.account.adaDebug.step({
+    tag: 'batchGetShelleyAddresses',
+    phase: 'done',
+    info: `addresses=${result.length}`,
+  });
+  return result;
 };

--- a/packages/core/src/secret/encryptors/aes256.ts
+++ b/packages/core/src/secret/encryptors/aes256.ts
@@ -331,6 +331,11 @@ async function decryptAsync({
     const webembedApiProxy = (
       await import('@onekeyhq/kit-bg/src/webembeds/instance/webembedApiProxy')
     ).default;
+    defaultLogger.account.adaDebug.step({
+      tag: 'secret.decryptAsync(webembed)',
+      phase: 'start',
+      info: `dataLen=${data.length}`,
+    });
     const str = await webembedApiProxy.secret.decryptAsync({
       password,
       // data,
@@ -338,6 +343,11 @@ async function decryptAsync({
       allowRawPassword,
       ignoreLogger,
       iterations,
+    });
+    defaultLogger.account.adaDebug.step({
+      tag: 'secret.decryptAsync(webembed)',
+      phase: 'done',
+      info: `resultDefined=${str !== undefined}`,
     });
     return bufferUtils.toBuffer(str, 'hex');
   }

--- a/packages/kit-bg/src/vaults/impls/ada/KeyringHd.ts
+++ b/packages/kit-bg/src/vaults/impls/ada/KeyringHd.ts
@@ -1,5 +1,6 @@
 import coreChainApi from '@onekeyhq/core/src/instance/coreChainApi';
 import type { ISignedTxPro } from '@onekeyhq/core/src/types';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 
 import { KeyringHdBase } from '../../base/KeyringHdBase';
 
@@ -32,9 +33,29 @@ export class KeyringHd extends KeyringHdBase {
   override async prepareAccounts(
     params: IPrepareHdAccountsParams,
   ): Promise<IDBAccount[]> {
-    return this.basePrepareAccountsHdUtxo(params, {
-      checkIsAccountUsed: () => Promise.resolve({ isUsed: true }),
+    defaultLogger.account.adaDebug.step({
+      tag: 'ada.KeyringHd.prepareAccounts',
+      phase: 'start',
+      info: `indexes=${params?.indexes?.join(',') ?? ''}`,
     });
+    try {
+      const accounts = await this.basePrepareAccountsHdUtxo(params, {
+        checkIsAccountUsed: () => Promise.resolve({ isUsed: true }),
+      });
+      defaultLogger.account.adaDebug.step({
+        tag: 'ada.KeyringHd.prepareAccounts',
+        phase: 'done',
+        info: `accounts=${accounts.length}`,
+      });
+      return accounts;
+    } catch (e) {
+      defaultLogger.account.adaDebug.step({
+        tag: 'ada.KeyringHd.prepareAccounts',
+        phase: 'error',
+        info: String((e as Error)?.message || e),
+      });
+      throw e;
+    }
   }
 
   override async signTransaction(

--- a/packages/kit-bg/src/webembeds/instance/webembedApiProxy.ts
+++ b/packages/kit-bg/src/webembeds/instance/webembedApiProxy.ts
@@ -74,13 +74,37 @@ class WebembedApiProxy extends RemoteApiProxyBase implements IWebembedApi {
       .__onekeyCallWebEmbedBridgeViaMainThread as
       | ((data: unknown) => Promise<unknown>)
       | undefined;
-    if (callViaMainThread) {
-      result = await callViaMainThread(message);
-    } else {
-      // Single-thread: existing flow through background serviceDApp
-      result = await checkIsDefined(
-        appGlobals?.$backgroundApiProxy,
-      ).serviceDApp.callWebEmbedApiProxy(message);
+    defaultLogger.app.webembed.webEmbedRemoteCall({
+      module: String(module),
+      method,
+      phase: 'start',
+      viaMainThread: !!callViaMainThread,
+    });
+    try {
+      if (callViaMainThread) {
+        result = await callViaMainThread(message);
+      } else {
+        // Single-thread: existing flow through background serviceDApp
+        result = await checkIsDefined(
+          appGlobals?.$backgroundApiProxy,
+        ).serviceDApp.callWebEmbedApiProxy(message);
+      }
+      defaultLogger.app.webembed.webEmbedRemoteCall({
+        module: String(module),
+        method,
+        phase: 'done',
+        viaMainThread: !!callViaMainThread,
+        resultDefined: result !== undefined,
+      });
+    } catch (e) {
+      defaultLogger.app.webembed.webEmbedRemoteCall({
+        module: String(module),
+        method,
+        phase: 'error',
+        viaMainThread: !!callViaMainThread,
+        error: String((e as Error)?.message || e),
+      });
+      throw e;
     }
 
     if (

--- a/packages/kit/src/components/WebViewWebEmbed/index.tsx
+++ b/packages/kit/src/components/WebViewWebEmbed/index.tsx
@@ -29,7 +29,10 @@ import type { JsBridgeBase } from '@onekeyfe/cross-inpage-provider-core';
 import type { IJsBridgeReceiveHandler } from '@onekeyfe/cross-inpage-provider-types';
 import type { IWebViewWrapperRef } from '@onekeyfe/onekey-cross-webview';
 import type { WebViewMessageEvent } from 'react-native-webview';
-import type { WebViewErrorEvent } from 'react-native-webview/lib/WebViewTypes';
+import type {
+  WebViewErrorEvent,
+  WebViewNavigationEvent,
+} from 'react-native-webview/lib/WebViewTypes';
 
 const initTop = '15%';
 // /onboarding/auto_typing
@@ -232,7 +235,40 @@ export function WebViewWebEmbed({
       description: description || 'unknown',
       url: url || 'unknown',
     });
+    defaultLogger.app.webembed.webEmbedWebViewLoadEvent({
+      event: 'onError',
+      url: url || 'unknown',
+      error: `code=${code ?? ''} ${description ?? ''}`.trim(),
+    });
   }, []);
+
+  const handleLoadStart = useCallback((event: WebViewNavigationEvent) => {
+    defaultLogger.app.webembed.webEmbedWebViewLoadEvent({
+      event: 'onLoadStart',
+      url: event?.nativeEvent?.url || 'unknown',
+    });
+  }, []);
+
+  const handleLoad = useCallback((event: WebViewNavigationEvent) => {
+    defaultLogger.app.webembed.webEmbedWebViewLoadEvent({
+      event: 'onLoad',
+      url: event?.nativeEvent?.url || 'unknown',
+    });
+  }, []);
+
+  const handleLoadEnd = useCallback(
+    (event: WebViewNavigationEvent | WebViewErrorEvent) => {
+      const ne = event?.nativeEvent as
+        | { url?: string; description?: string }
+        | undefined;
+      defaultLogger.app.webembed.webEmbedWebViewLoadEvent({
+        event: 'onLoadEnd',
+        url: ne?.url || 'unknown',
+        error: ne?.description,
+      });
+    },
+    [],
+  );
 
   const allowFileAccessByUrl = useMemo(() => {
     const webEmbedPath = BundleUpdate.getWebEmbedPath();
@@ -271,6 +307,12 @@ export function WebViewWebEmbed({
     }
 
     defaultLogger.app.webembed.renderWebview();
+    // Log the exact HTML entry the webembed WebView will load, so we can
+    // verify the OTA/builtin path and catch a wrong/missing url on Android.
+    defaultLogger.app.webembed.webEmbedWebViewLoadEvent({
+      event: 'renderWebViewSrc',
+      url: remoteUrl || nativeWebviewSource?.uri || 'empty',
+    });
 
     return (
       <WebView
@@ -287,6 +329,9 @@ export function WebViewWebEmbed({
         customReceiveHandler={customReceiveHandler}
         onMessage={handleMessage}
         onError={handleError}
+        onLoadStart={handleLoadStart}
+        onLoad={handleLoad}
+        onLoadEnd={handleLoadEnd}
         nativeInjectedJavaScriptBeforeContentLoaded={`
             window.location.hash = "${fullHash}";
             const WEB_EMBED_ONEKEY_APP_SETTINGS = ${JSON.stringify(
@@ -323,6 +368,9 @@ export function WebViewWebEmbed({
     customReceiveHandler,
     handleMessage,
     handleError,
+    handleLoadStart,
+    handleLoad,
+    handleLoadEnd,
   ]);
 
   useEffect(() => {

--- a/packages/shared/src/logger/scopes/account/index.ts
+++ b/packages/shared/src/logger/scopes/account/index.ts
@@ -3,6 +3,7 @@ import { EScopeName } from '../../types';
 
 import { AccountScene } from './scenes/account';
 import { CreateAccountPerfScene } from './scenes/accountCreatePerf';
+import { AdaDebugScene } from './scenes/adaDebug';
 import { AllNetworkAccountPerf } from './scenes/allNetworkAccountPerf';
 import { BatchCreateAccountPerfScene } from './scenes/batchCreatePerf';
 import { SecretPerfScene } from './scenes/secretPerf';
@@ -31,4 +32,7 @@ export class AccountScope extends BaseScope {
   );
 
   account = this.createScene('account', AccountScene);
+
+  // Diagnostic-only: ADA software-wallet address creation flow tracing.
+  adaDebug = this.createScene('adaDebug', AdaDebugScene);
 }

--- a/packages/shared/src/logger/scopes/account/scenes/adaDebug.ts
+++ b/packages/shared/src/logger/scopes/account/scenes/adaDebug.ts
@@ -1,0 +1,26 @@
+import { BaseScene } from '../../../base/baseScene';
+import { LogToLocal } from '../../../base/decorators';
+
+// Diagnostic-only scene for tracing the Cardano(ADA) software-wallet
+// address-creation flow on native dual-thread runtime (Android keeps loading
+// while iOS / hardware wallet work). All methods log to the persisted local
+// file logger so the trace survives on disk for QA log collection.
+//
+// `phase` convention:
+//   - 'start'  : right before a potentially-blocking step
+//   - 'done'   : right after it returned
+//   - 'error'  : the step threw
+export class AdaDebugScene extends BaseScene {
+  @LogToLocal()
+  public step({
+    tag,
+    phase,
+    info,
+  }: {
+    tag: string;
+    phase: 'start' | 'done' | 'error';
+    info?: string;
+  }) {
+    return { tag, phase, info: info ?? '' };
+  }
+}

--- a/packages/shared/src/logger/scopes/app/scenes/webembed.ts
+++ b/packages/shared/src/logger/scopes/app/scenes/webembed.ts
@@ -298,4 +298,27 @@ export class WebembedScene extends BaseScene {
   }) {
     return { hasBridge };
   }
+
+  // ---- Diagnostic: trace the actual webembed remote call round-trip ----
+  // Catches a webembed secret/chainAda call that never resolves (e.g. ADA
+  // address derivation decrypt). `phase`: 'start' before dispatch, 'done'
+  // after it returned, 'error' if it threw.
+  @LogToLocal()
+  public webEmbedRemoteCall({
+    module,
+    method,
+    phase,
+    viaMainThread,
+    resultDefined,
+    error,
+  }: {
+    module: string;
+    method: string;
+    phase: 'start' | 'done' | 'error';
+    viaMainThread?: boolean;
+    resultDefined?: boolean;
+    error?: string;
+  }) {
+    return { module, method, phase, viaMainThread, resultDefined, error };
+  }
 }

--- a/patches/cardano-crypto.js+6.1.2.patch
+++ b/patches/cardano-crypto.js+6.1.2.patch
@@ -1,0 +1,92 @@
+diff --git a/node_modules/cardano-crypto.js/features/key-derivation.js b/node_modules/cardano-crypto.js/features/key-derivation.js
+index 33dbb17..f633b96 100644
+--- a/node_modules/cardano-crypto.js/features/key-derivation.js
++++ b/node_modules/cardano-crypto.js/features/key-derivation.js
+@@ -88,10 +88,18 @@ function trySeedChainCodeToKeypairV1(seed, chainCode) {
+ }
+ 
+ async function mnemonicToRootKeypairV2(mnemonic, password) {
++  const __log = (globalThis.__adaDebugLog || function () {})
++  __log('cc.mnemonicToRootKeypairV2', 'start')
+   const seed = mnemonicToSeedV2(mnemonic)
++  __log('cc.mnemonicToSeedV2', 'done', 'seedLen=' + (seed ? seed.length : -1))
++  __log('cc.seedToKeypairV2#1', 'start')
+   const rootSecret = await seedToKeypairV2(seed, password)
++  __log('cc.seedToKeypairV2#1', 'done', 'len=' + (rootSecret ? rootSecret.length : -1))
+ 
+-  return seedToKeypairV2(seed, password)
++  __log('cc.seedToKeypairV2#2', 'start')
++  const result = await seedToKeypairV2(seed, password)
++  __log('cc.seedToKeypairV2#2', 'done', 'len=' + (result ? result.length : -1))
++  return result
+ }
+ 
+ function mnemonicToSeedV2(mnemonic) {
+@@ -100,13 +108,24 @@ function mnemonicToSeedV2(mnemonic) {
+ }
+ 
+ async function seedToKeypairV2(seed, password) {
+-  const xprv = await pbkdf2(password, seed, 4096, 96, 'sha512')
++  const __log = (globalThis.__adaDebugLog || function () {})
++  __log('cc.pbkdf2', 'start', 'iter=4096 len=96 sha512')
++  let xprv
++  try {
++    xprv = await pbkdf2(password, seed, 4096, 96, 'sha512')
++  } catch (e) {
++    __log('cc.pbkdf2', 'error', String((e && e.message) || e))
++    throw e
++  }
++  __log('cc.pbkdf2', 'done', 'xprvLen=' + (xprv ? xprv.length : -1))
+ 
+   xprv[0] &= 248
+   xprv[31] &= 31
+   xprv[31] |= 64
+ 
++  __log('cc.toPublic', 'start')
+   const publicKey = toPublic(xprv.slice(0, 64))
++  __log('cc.toPublic', 'done', 'pubLen=' + (publicKey ? publicKey.length : -1))
+ 
+   return Buffer.concat([xprv.slice(0, 64), publicKey, xprv.slice(64,)])
+ }
+diff --git a/node_modules/cardano-crypto.js/utils/pbkdf2.js b/node_modules/cardano-crypto.js/utils/pbkdf2.js
+index 91aef0f..fa85972 100644
+--- a/node_modules/cardano-crypto.js/utils/pbkdf2.js
++++ b/node_modules/cardano-crypto.js/utils/pbkdf2.js
+@@ -1,22 +1,36 @@
+ const {pbkdf2: pbkdf2Async, pbkdf2Sync} = require('pbkdf2')
+ 
++const __log = (tag, phase, info) => {
++  try {
++    (globalThis.__adaDebugLog || function () {})(tag, phase, info)
++  } catch (e) { /* noop */ }
++}
++
+ const promisifiedPbkdf2 = (password, salt, iterations, length, algo) =>
+   new Promise((resolveFunction, rejectFunction) => {
++    __log('cc.pbkdf2.async.call', 'start')
+     pbkdf2Async(password, salt, iterations, length, algo, (error, response) => {
++      __log('cc.pbkdf2.async.callback', error ? 'error' : 'done', error ? String((error && error.message) || error) : ('len=' + (response ? response.length : -1)))
+       if (error) {
+         rejectFunction(error)
+       }
+       resolveFunction(response)
+     })
++    __log('cc.pbkdf2.async.call', 'done', 'dispatched (callback pending)')
+   })
+ 
+ const pbkdf2 = async (password, salt, iterations, length, algo) => {
++  __log('cc.pbkdf2.wrapper', 'start')
+   try {
+     const result = await promisifiedPbkdf2(password, salt, iterations, length, algo)
++    __log('cc.pbkdf2.wrapper', 'done', 'async len=' + (result ? result.length : -1))
+     return result
+   } catch (e) {
+     // falback to sync since on Firefox promisifiedPbkdf2 fails for empty password
+-    return pbkdf2Sync(password, salt, iterations, length, algo)
++    __log('cc.pbkdf2.syncFallback', 'start', String((e && e.message) || e))
++    const r = pbkdf2Sync(password, salt, iterations, length, algo)
++    __log('cc.pbkdf2.syncFallback', 'done', 'len=' + (r ? r.length : -1))
++    return r
+   }
+ }
+ 

--- a/patches/pbkdf2+3.1.3.patch
+++ b/patches/pbkdf2+3.1.3.patch
@@ -1,0 +1,118 @@
+diff --git a/node_modules/pbkdf2/lib/async.js b/node_modules/pbkdf2/lib/async.js
+index a24bb58..0208d52 100644
+--- a/node_modules/pbkdf2/lib/async.js
++++ b/node_modules/pbkdf2/lib/async.js
+@@ -7,6 +7,13 @@ var defaultEncoding = require('./default-encoding');
+ var sync = require('./sync');
+ var toBuffer = require('./to-buffer');
+ 
++function __pb(tag, phase, info) {
++	try {
++		var g = typeof global !== 'undefined' ? global : globalThis;
++		(g.__adaDebugLog || function () {})(tag, phase, info);
++	} catch (e) { /* noop */ }
++}
++
+ var ZERO_BUF;
+ var subtle = global.crypto && global.crypto.subtle;
+ var toBrowser = {
+@@ -28,12 +35,16 @@ function getNextTick() {
+ 	}
+ 	if (global.process && global.process.nextTick) {
+ 		nextTick = global.process.nextTick;
++		__pb('pb.getNextTick', 'done', 'process.nextTick');
+ 	} else if (global.queueMicrotask) {
+ 		nextTick = global.queueMicrotask;
++		__pb('pb.getNextTick', 'done', 'queueMicrotask');
+ 	} else if (global.setImmediate) {
+ 		nextTick = global.setImmediate;
++		__pb('pb.getNextTick', 'done', 'setImmediate');
+ 	} else {
+ 		nextTick = global.setTimeout;
++		__pb('pb.getNextTick', 'done', 'setTimeout');
+ 	}
+ 	return nextTick;
+ }
+@@ -53,19 +64,23 @@ function browserPbkdf2(password, salt, iterations, length, algo) {
+ }
+ function checkNative(algo) {
+ 	if (global.process && !global.process.browser) {
++		__pb('pb.checkNative', 'done', 'false:process.!browser');
+ 		return Promise.resolve(false);
+ 	}
+ 	if (!subtle || !subtle.importKey || !subtle.deriveBits) {
++		__pb('pb.checkNative', 'done', 'false:noSubtle subtle=' + (typeof subtle) + ' importKey=' + (subtle && typeof subtle.importKey) + ' deriveBits=' + (subtle && typeof subtle.deriveBits));
+ 		return Promise.resolve(false);
+ 	}
+ 	if (checks[algo] !== undefined) {
++		__pb('pb.checkNative', 'done', 'cached');
+ 		return checks[algo];
+ 	}
++	__pb('pb.checkNative', 'start', 'probing subtle.deriveBits (WebCrypto)');
+ 	ZERO_BUF = ZERO_BUF || Buffer.alloc(8);
+ 	var prom = browserPbkdf2(ZERO_BUF, ZERO_BUF, 10, 128, algo)
+ 		.then(
+-			function () { return true; },
+-			function () { return false; }
++			function () { __pb('pb.checkNative.probe', 'done', 'subtle ok'); return true; },
++			function () { __pb('pb.checkNative.probe', 'error', 'subtle rejected'); return false; }
+ 		);
+ 	checks[algo] = prom;
+ 	return prom;
+@@ -73,11 +88,16 @@ function checkNative(algo) {
+ 
+ function resolvePromise(promise, callback) {
+ 	promise.then(function (out) {
++		__pb('pb.resolvePromise.then', 'done', 'outLen=' + (out ? out.length : -1) + ' -> scheduling callback via getNextTick');
+ 		getNextTick()(function () {
++			__pb('pb.resolvePromise.deferred', 'done', 'deferred fired -> calling callback(null,out)');
+ 			callback(null, out);
+ 		});
++		__pb('pb.resolvePromise.scheduled', 'done', 'getNextTick scheduled (callback pending)');
+ 	}, function (e) {
++		__pb('pb.resolvePromise.then', 'error', String((e && e.message) || e));
+ 		getNextTick()(function () {
++			__pb('pb.resolvePromise.deferred', 'error', 'deferred fired -> calling callback(e)');
+ 			callback(e);
+ 		});
+ 	});
+@@ -90,16 +110,20 @@ module.exports = function (password, salt, iterations, keylen, digest, callback)
+ 
+ 	digest = digest || 'sha1';
+ 	var algo = toBrowser[digest.toLowerCase()];
++	__pb('pb.async.entry', 'start', 'digest=' + digest + ' algo=' + algo + ' PromiseType=' + (typeof global.Promise));
+ 
+ 	if (!algo || typeof global.Promise !== 'function') {
++		__pb('pb.async.branch', 'done', 'noAlgoOrPromise -> getNextTick(sync)');
+ 		getNextTick()(function () {
+ 			var out;
+ 			try {
+ 				out = sync(password, salt, iterations, keylen, digest);
+ 			} catch (e) {
++				__pb('pb.async.syncInline', 'error', String((e && e.message) || e));
+ 				callback(e);
+ 				return;
+ 			}
++			__pb('pb.async.syncInline', 'done', 'len=' + (out ? out.length : -1));
+ 			callback(null, out);
+ 		});
+ 		return;
+@@ -112,11 +136,17 @@ module.exports = function (password, salt, iterations, keylen, digest, callback)
+ 		throw new Error('No callback provided to pbkdf2');
+ 	}
+ 
++	__pb('pb.async.branch', 'done', 'main -> checkNative + sync/browser');
+ 	resolvePromise(checkNative(algo).then(function (resp) {
++		__pb('pb.async.afterCheckNative', 'done', 'resp=' + resp);
+ 		if (resp) {
++			__pb('pb.async.browserPbkdf2', 'start', 'using WebCrypto subtle.deriveBits');
+ 			return browserPbkdf2(password, salt, iterations, keylen, algo);
+ 		}
+ 
+-		return sync(password, salt, iterations, keylen, digest);
++		__pb('pb.async.sync', 'start', 'using JS pbkdf2 sync');
++		var r = sync(password, salt, iterations, keylen, digest);
++		__pb('pb.async.sync', 'done', 'len=' + (r ? r.length : -1));
++		return r;
+ 	}), callback);
+ };

--- a/patches/process+0.11.10.patch
+++ b/patches/process+0.11.10.patch
@@ -1,0 +1,59 @@
+diff --git a/node_modules/process/browser.js b/node_modules/process/browser.js
+index d059362..0a33149 100644
+--- a/node_modules/process/browser.js
++++ b/node_modules/process/browser.js
+@@ -1,6 +1,19 @@
+ // shim for using process in browser
+ var process = module.exports = {};
+ 
++// --- OneKey ADA diagnostic (gated): only logs while __adaProcTrace is set
++// (flipped on by ada getRootKey), and hard-capped to avoid flooding. Traces
++// whether process.nextTick's queue actually drains on the bg runtime. ---
++function __pl(tag, phase, info) {
++	try {
++		var g = typeof global !== 'undefined' ? global : globalThis;
++		if (!g.__adaProcTrace) { return; }
++		g.__adaProcTraceN = (g.__adaProcTraceN || 0) + 1;
++		if (g.__adaProcTraceN > 80) { return; }
++		(g.__adaDebugLog || function () {})(tag, phase, info);
++	} catch (e) { /* noop */ }
++}
++
+ // cached from whatever global is present so that test runners that stub it
+ // don't break things.  But we need to wrap it in a try catch in case it is
+ // wrapped in strict mode code which doesn't define any globals.  It's inside a
+@@ -36,6 +49,7 @@ function defaultClearTimeout () {
+     }
+ } ())
+ function runTimeout(fun) {
++    __pl('proc.runTimeout', 'start', 'cached==setTimeout?' + (cachedSetTimeout === setTimeout) + ' cached==default?' + (cachedSetTimeout === defaultSetTimout) + ' globalSetTimeout=' + (typeof setTimeout));
+     if (cachedSetTimeout === setTimeout) {
+         //normal enviroments in sane situations
+         return setTimeout(fun, 0);
+@@ -109,8 +123,10 @@ function cleanUpNextTick() {
+ 
+ function drainQueue() {
+     if (draining) {
++        __pl('proc.drainQueue', 'done', 'already draining, skip');
+         return;
+     }
++    __pl('proc.drainQueue', 'start', 'queueLen=' + queue.length);
+     var timeout = runTimeout(cleanUpNextTick);
+     draining = true;
+ 
+@@ -128,6 +144,7 @@ function drainQueue() {
+     }
+     currentQueue = null;
+     draining = false;
++    __pl('proc.drainQueue', 'done', 'finished');
+     runClearTimeout(timeout);
+ }
+ 
+@@ -139,6 +156,7 @@ process.nextTick = function (fun) {
+         }
+     }
+     queue.push(new Item(fun, args));
++    __pl('proc.nextTick', 'start', 'pushed, queueLen=' + queue.length + ' draining=' + draining + ' willSchedule=' + (queue.length === 1 && !draining));
+     if (queue.length === 1 && !draining) {
+         runTimeout(drainQueue);
+     }


### PR DESCRIPTION
## 背景

QA 反馈:**Android 软件钱包 Cardano 创建地址一直 loading**;硬件钱包正常;**iOS 正常**。

日志分析结论(基于 app-latest.log):
- `serviceAccount.addHDOrHWAccounts`(callId=72)在 bg runtime `exec-start` 后**永不返回**,无任何 30s 超时报错 → 卡在一个**没有超时的本地 await**。
- 软件钱包路径需要解密助记词(webembed secret)+ 本地跑 `cardano-crypto.js` 派生;硬件钱包都不需要 → 解释了 SW/HW 差异。
- webembed 本身**没失败**(本次流程 ready 两次),但中途经历 teardown→remount。
- iOS 正常 + Android 卡 + 同为 Hermes/双线程 → 怀疑后台 runtime 的**平台相关绑定/环境**差异(#10969 新增的 native background runtime)。

`secretPerf` 那组埋点用的是 `@LogToConsole`,**不落盘**,所以现网日志看不到派生过程。

## 改动

**纯诊断埋点,无逻辑变更。** 全部用 `defaultLogger`(`@LogToLocal`)→ 落盘到 app-latest.log(后台 runtime 也能写)。

新增 `account.adaDebug` 诊断 scene,instrument:
- ada `KeyringHd.prepareAccounts` / `CoreChainSoftware.getAddressesFromHd`
- `batchGetShelleyAddresses` + `getRootKey`(`mnemonicFromEntropy` / `mnemonicToRootKeypair`)
- secret `decryptAsync` 的 webembed 分支
- `webembedApiProxy.callRemoteApi` 往返(start/done/error,区分 viaMainThread)
- webembed WebView 加载事件:解析后的 html url、`onLoadStart` / `onLoad` / `onLoadEnd` / `onError`

## 验证方式

装到 Android 复现「创建 Cardano 地址」,抓 app-latest.log,看 `account => adaDebug => step` 与 `app => webembed => *` 序列**最后停在哪一步**,即可定位卡点。

tsc:staged ✅ / lint:staged ✅