### PR TITLE
fix: improve keyless backend share migration OK-55471

### DIFF
--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
@@ -290,7 +290,7 @@ function mockResetPinHappyPath(
     ownerId:
       (params.canonicalFormat ?? 'v2') === 'v1'
         ? undefined
-        : params.backendOwnerId ?? OWNER_ID,
+        : (params.backendOwnerId ?? OWNER_ID),
     ownerProvider: EOAuthSocialLoginProvider.Google,
   }));
   serviceAny.buildKeylessProviderFromSocialToken = jest.fn(

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
@@ -1360,6 +1360,11 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       expectedHashId: HASH_ID,
       expectedBackendShareData: resetBackendShareData,
     });
+    // The owner rewrite runs before any local persistence / pin-confirm reset,
+    // so its failure must not leave a mixed local(new owner)/server(old owner)
+    // state.
+    expect(localDb.updateKeylessWalletDetailsInfo).not.toHaveBeenCalled();
+    expect(serviceAny.apiResetPinConfirmStatus).not.toHaveBeenCalled();
   });
 
   test('does not reject reset pin when v1 background migration fails (owner unchanged)', async () => {

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
@@ -285,7 +285,12 @@ function mockResetPinHappyPath(
     revision: 2,
     canonicalFormat: params.canonicalFormat ?? 'v2',
     backendShareData: resetBackendShareData,
-    ownerId: params.backendOwnerId ?? OWNER_ID,
+    // Mirror apiGetKeylessBackendShare: only v2 shares carry an ownerId; v1
+    // shares leave it undefined.
+    ownerId:
+      (params.canonicalFormat ?? 'v2') === 'v1'
+        ? undefined
+        : params.backendOwnerId ?? OWNER_ID,
     ownerProvider: EOAuthSocialLoginProvider.Google,
   }));
   serviceAny.buildKeylessProviderFromSocialToken = jest.fn(
@@ -1367,7 +1372,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
     expect(serviceAny.apiResetPinConfirmStatus).not.toHaveBeenCalled();
   });
 
-  test('does not reject reset pin when v1 background migration fails (owner unchanged)', async () => {
+  test('keeps v1 backend migration non-blocking even though v1 has no ownerId', async () => {
     const { serviceAny } = createService();
     const resetBackendShareData = mockResetPinHappyPath(serviceAny, {
       canonicalFormat: 'v1',
@@ -1377,9 +1382,9 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       throw new OneKeyLocalError('migration failed');
     });
 
-    // A pure v1 -> v2 upgrade with an unchanged owner is best-effort background
-    // work that self-heals via passive migration, so its failure must not block
-    // reset success.
+    // A v1 share has no ownerId, so it must not be misclassified as an owner
+    // change. A pure v1 -> v2 upgrade is best-effort background work that
+    // self-heals via passive migration, so its failure must not block reset.
     await expect(
       serviceAny.resetKeylessWalletPin({
         token: TOKEN,

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
@@ -141,6 +141,7 @@ jest.mock('@onekeyhq/shared/src/keylessWallet/shamirUtils', () => ({
   __esModule: true,
   default: {
     combine: jest.fn(async () => new Uint8Array([1, 2, 3])),
+    split: jest.fn(async () => [new Uint8Array([1]), new Uint8Array([2])]),
   },
 }));
 
@@ -148,6 +149,7 @@ const {
   decryptRevealableSeed,
   decryptStringAsync,
   encryptStringAsync,
+  generateMnemonic,
   revealEntropyToMnemonic,
 } =
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -204,6 +206,12 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
+function waitForScheduledBackgroundTask(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
 function createKeylessWallet(overrides: Record<string, unknown> = {}) {
   return {
     id: WALLET_ID,
@@ -218,7 +226,7 @@ function createKeylessWallet(overrides: Record<string, unknown> = {}) {
 }
 
 function createService(params: { wallet?: any; password?: string } = {}) {
-  const wallet = params.wallet ?? createKeylessWallet();
+  const wallet = 'wallet' in params ? params.wallet : createKeylessWallet();
   const backgroundApi: any = {
     serviceAccount: {
       getKeylessWallet: jest.fn(async () => wallet),
@@ -919,6 +927,61 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
     });
   });
 
+  test('uses server revision as base revision when creating keyless wallet', async () => {
+    const { service, serviceAny } = createService({ wallet: null });
+    generateMnemonic.mockReturnValue('mnemonic');
+    serviceAny.apiAcquireCreationLock = jest.fn(async () => ({
+      lockId: 'lock-1',
+      hashId: HASH_ID,
+      expiresAt: NOW + 60_000,
+    }));
+    serviceAny.apiReleaseCreationLock = jest.fn(async () => undefined);
+    serviceAny.apiGetKeylessBackendShareMeta = jest.fn(async () => ({
+      backendShare: '',
+      hashId: HASH_ID,
+      revision: 5,
+      canonicalFormat: 'v2',
+    }));
+    serviceAny.buildKeylessOwnerIdFromSocialToken = jest.fn(
+      async () => OWNER_ID,
+    );
+    serviceAny.encryptKeylessMnemonic = jest.fn(
+      async () => backendShareData.encryptedMnemonic,
+    );
+    serviceAny.apiUploadKeylessJuiceboxShare = jest.fn(async () => undefined);
+    serviceAny.encryptKeylessBackendSharePayloadV1 = jest.fn(
+      async () => 'backend-share-raw-v1-mirror',
+    );
+    serviceAny.uploadKeylessBackendShare = jest.fn(
+      async () => backendShareData,
+    );
+    serviceAny.buildKeylessProviderFromSocialToken = jest.fn(
+      () => EOAuthSocialLoginProvider.Google,
+    );
+    serviceAny.buildKeylessSocialUserIdFromToken = jest.fn(() => 'social-id');
+    keylessMnemonicPasswordStorage.saveMnemonicPasswordToStorage.mockResolvedValue(
+      undefined,
+    );
+
+    await expect(
+      service.createKeylessWalletToServer({
+        token: TOKEN,
+        refreshToken: REFRESH_TOKEN,
+        pin: PIN,
+      }),
+    ).resolves.toMatchObject({
+      ownerId: OWNER_ID,
+      mnemonic: 'mnemonic',
+    });
+
+    expect(serviceAny.uploadKeylessBackendShare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseRevision: 5,
+        keylessBackendShareV1Mirror: 'backend-share-raw-v1-mirror',
+      }),
+    );
+  });
+
   test('encrypts backend share v2 with owner password and fixed uuid', async () => {
     const { serviceAny } = createService();
     encryptStringAsync.mockResolvedValue('encrypted-payload');
@@ -966,7 +1029,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
     );
   });
 
-  test('submits v1 mirror when uploading keyless backend share v2', async () => {
+  test('submits caller-provided v1 mirror when uploading keyless backend share v2', async () => {
     const { serviceAny } = createService();
     const post = jest.fn(async () => ({
       data: {
@@ -988,8 +1051,8 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       ownerId: OWNER_ID,
       ownerProvider: EOAuthSocialLoginProvider.Google,
     }));
-    serviceAny.encryptKeylessBackendSharePayloadV1 = jest.fn(
-      async () => 'backend-share-raw-v1-mirror',
+    serviceAny.decryptKeylessBackendSharePayloadV1 = jest.fn(
+      async () => backendShareData,
     );
 
     await expect(
@@ -1002,6 +1065,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
         encryptedMnemonic: backendShareData.encryptedMnemonic,
         backendShare: backendShareData.backendShare,
         juiceboxShareX: backendShareData.juiceboxShareX,
+        keylessBackendShareV1Mirror: 'backend-share-raw-v1-mirror',
       }),
     ).resolves.toEqual(backendShareData);
 
@@ -1086,8 +1150,8 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       ownerId: OWNER_ID,
       ownerProvider: EOAuthSocialLoginProvider.Google,
     }));
-    serviceAny.encryptKeylessBackendSharePayloadV1 = jest.fn(
-      async () => 'backend-share-raw-v1-mirror',
+    serviceAny.decryptKeylessBackendSharePayloadV1 = jest.fn(
+      async () => backendShareData,
     );
 
     const params = {
@@ -1099,6 +1163,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       encryptedMnemonic: backendShareData.encryptedMnemonic,
       backendShare: backendShareData.backendShare,
       juiceboxShareX: backendShareData.juiceboxShareX,
+      keylessBackendShareV1Mirror: 'backend-share-raw-v1-mirror',
     };
 
     await expect(serviceAny.uploadKeylessBackendShare(params)).rejects.toThrow(
@@ -1141,6 +1206,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
 
     expect(serviceAny.uploadKeylessBackendShare).toHaveBeenCalledWith(
       expect.objectContaining({
+        baseRevision: 2,
         keylessBackendShareV1Mirror: 'backend-share-raw-v1',
       }),
     );
@@ -1244,7 +1310,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
     ).rejects.toThrow('reset pin confirm status failed');
   });
 
-  test('rewrites backend share v2 when reset pin target owner changes', async () => {
+  test('schedules backend share v2 rewrite when reset pin target owner changes', async () => {
     const { serviceAny } = createService();
     const resetBackendShareData = mockResetPinHappyPath(serviceAny, {
       backendOwnerId: 'legacy-owner-id',
@@ -1258,6 +1324,36 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
         newPin: PIN,
       }),
     ).resolves.toEqual({ success: true });
+
+    await waitForScheduledBackgroundTask();
+
+    expect(serviceAny.migrateKeylessBackendShareToV2).toHaveBeenCalledWith({
+      token: TOKEN,
+      ownerId: OWNER_ID,
+      expectedHashId: HASH_ID,
+      expectedBackendShareData: resetBackendShareData,
+    });
+  });
+
+  test('does not reject reset pin when backend share v2 migration fails', async () => {
+    const { serviceAny } = createService();
+    const resetBackendShareData = mockResetPinHappyPath(serviceAny, {
+      backendOwnerId: 'legacy-owner-id',
+    });
+    serviceAny.apiResetPinConfirmStatus = jest.fn(async () => undefined);
+    serviceAny.migrateKeylessBackendShareToV2 = jest.fn(async () => {
+      throw new OneKeyLocalError('migration failed');
+    });
+
+    await expect(
+      serviceAny.resetKeylessWalletPin({
+        token: TOKEN,
+        refreshToken: REFRESH_TOKEN,
+        newPin: PIN,
+      }),
+    ).resolves.toEqual({ success: true });
+
+    await waitForScheduledBackgroundTask();
 
     expect(serviceAny.migrateKeylessBackendShareToV2).toHaveBeenCalledWith({
       token: TOKEN,
@@ -1362,5 +1458,57 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
     expect(
       serviceAny.updatePinConfirmStatusAfterSuccessfulPin,
     ).toHaveBeenCalledWith({ token: TOKEN });
+  });
+
+  test('does not reject restore when backend share v2 migration fails', async () => {
+    const { serviceAny } = createService();
+    const restoreBackendShareData: IKeylessBackendShare = {
+      ...backendShareData,
+      backendShare: 'AQ==',
+    };
+
+    serviceAny.apiGetKeylessBackendShare = jest.fn(async () => ({
+      backendShare: 'backend-share-raw-v1',
+      hashId: HASH_ID,
+      revision: 1,
+      canonicalFormat: 'v1',
+      backendShareData: restoreBackendShareData,
+      ownerId: OWNER_ID,
+      ownerProvider: EOAuthSocialLoginProvider.Google,
+    }));
+    serviceAny.apiGetKeylessJuiceboxShare = jest.fn(async () => ({
+      ownerId: OWNER_ID,
+      pin: PIN,
+      juiceboxShare: 'Ag==',
+      backendShareX: 1,
+    }));
+    serviceAny.decryptKeylessMnemonic = jest.fn(async () => 'mnemonic');
+    serviceAny.buildKeylessSocialUserIdFromToken = jest.fn(() => 'social-id');
+    serviceAny.migrateKeylessBackendShareToV2 = jest.fn(async () => {
+      throw new OneKeyLocalError('migration failed');
+    });
+
+    await expect(
+      serviceAny.restoreKeylessWalletFromServer({
+        token: TOKEN,
+        refreshToken: REFRESH_TOKEN,
+        pin: PIN,
+        pinConfirmStatusAlreadyUpdated: true,
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        ownerId: OWNER_ID,
+        mnemonic: 'mnemonic',
+      }),
+    );
+
+    await waitForScheduledBackgroundTask();
+
+    expect(serviceAny.migrateKeylessBackendShareToV2).toHaveBeenCalledWith({
+      token: TOKEN,
+      ownerId: OWNER_ID,
+      expectedHashId: HASH_ID,
+      expectedBackendShareData: restoreBackendShareData,
+    });
   });
 });

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
@@ -1310,7 +1310,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
     ).rejects.toThrow('reset pin confirm status failed');
   });
 
-  test('schedules backend share v2 rewrite when reset pin target owner changes', async () => {
+  test('awaits backend share owner rewrite when reset pin target owner changes', async () => {
     const { serviceAny } = createService();
     const resetBackendShareData = mockResetPinHappyPath(serviceAny, {
       backendOwnerId: 'legacy-owner-id',
@@ -1325,8 +1325,6 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       }),
     ).resolves.toEqual({ success: true });
 
-    await waitForScheduledBackgroundTask();
-
     expect(serviceAny.migrateKeylessBackendShareToV2).toHaveBeenCalledWith({
       token: TOKEN,
       ownerId: OWNER_ID,
@@ -1335,7 +1333,7 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
     });
   });
 
-  test('does not reject reset pin when backend share v2 migration fails', async () => {
+  test('rejects reset pin when backend share owner rewrite fails (owner changed)', async () => {
     const { serviceAny } = createService();
     const resetBackendShareData = mockResetPinHappyPath(serviceAny, {
       backendOwnerId: 'legacy-owner-id',
@@ -1345,6 +1343,38 @@ describe('ServiceKeylessWallet passive backend share v2 migration', () => {
       throw new OneKeyLocalError('migration failed');
     });
 
+    // When the backend share owner changes, the rewrite is a consistency
+    // requirement (juicebox is already under the new owner), so a failure must
+    // surface and fail reset rather than being swallowed as background work.
+    await expect(
+      serviceAny.resetKeylessWalletPin({
+        token: TOKEN,
+        refreshToken: REFRESH_TOKEN,
+        newPin: PIN,
+      }),
+    ).rejects.toThrow('migration failed');
+
+    expect(serviceAny.migrateKeylessBackendShareToV2).toHaveBeenCalledWith({
+      token: TOKEN,
+      ownerId: OWNER_ID,
+      expectedHashId: HASH_ID,
+      expectedBackendShareData: resetBackendShareData,
+    });
+  });
+
+  test('does not reject reset pin when v1 background migration fails (owner unchanged)', async () => {
+    const { serviceAny } = createService();
+    const resetBackendShareData = mockResetPinHappyPath(serviceAny, {
+      canonicalFormat: 'v1',
+    });
+    serviceAny.apiResetPinConfirmStatus = jest.fn(async () => undefined);
+    serviceAny.migrateKeylessBackendShareToV2 = jest.fn(async () => {
+      throw new OneKeyLocalError('migration failed');
+    });
+
+    // A pure v1 -> v2 upgrade with an unchanged owner is best-effort background
+    // work that self-heals via passive migration, so its failure must not block
+    // reset success.
     await expect(
       serviceAny.resetKeylessWalletPin({
         token: TOKEN,

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -3270,7 +3270,14 @@ class ServiceKeylessWallet extends ServiceBase {
       backendShareX,
     });
 
+    // Only a v2 backend share carries an ownerId. A v1 share has no ownerId
+    // (apiGetKeylessBackendShare leaves it undefined), so it must NOT be
+    // treated as an owner change: doing so would force the blocking rewrite
+    // path and let a routine v1 -> v2 upgrade reject reset PIN on a transient
+    // failure. v1 is handled by the best-effort upgrade scheduled below.
     const shouldRewriteKeylessBackendShareOwner =
+      backendShareResult.canonicalFormat === 'v2' &&
+      backendShareResult.ownerId != null &&
       backendShareResult.ownerId !== targetOwnerId;
     const shouldUpgradeKeylessBackendShareFormat =
       backendShareResult.canonicalFormat === 'v1';

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -1854,11 +1854,11 @@ class ServiceKeylessWallet extends ServiceBase {
     const backendShareMeta = await this.apiGetKeylessBackendShareMeta({
       token,
     });
+    // apiGetKeylessBackendShareMeta already validates revision and throws when
+    // it is not a finite number, so no fallback is needed here.
     return {
       isCreated: backendShareMeta.backendShare !== '',
-      baseRevision: Number.isFinite(backendShareMeta.revision)
-        ? backendShareMeta.revision
-        : 0,
+      baseRevision: backendShareMeta.revision,
     };
   }
 

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -3275,6 +3275,24 @@ class ServiceKeylessWallet extends ServiceBase {
     const shouldUpgradeKeylessBackendShareFormat =
       backendShareResult.canonicalFormat === 'v1';
 
+    if (shouldRewriteKeylessBackendShareOwner) {
+      // The juicebox share has already been re-uploaded under targetOwnerId
+      // above, so rewriting the backend share owner is a consistency
+      // requirement. Run it before persisting any local state (tokens /
+      // mnemonic password / keylessDetailsInfo) and before resetting
+      // pin-confirm status: if it fails we throw here, leaving local state
+      // still pointing at the previous owner instead of committing a mixed
+      // local(new owner)/server(old owner) state that passive migration cannot
+      // reconcile (it only handles v1 -> v2, not a v2 owner mismatch). Revision
+      // conflicts are still retried inside migrateKeylessBackendShareToV2.
+      await this.migrateKeylessBackendShareToV2({
+        token,
+        ownerId: targetOwnerId,
+        expectedHashId: backendShareResult.hashId,
+        expectedBackendShareData: backendShareData,
+      });
+    }
+
     // Save tokens to secure storage (refreshToken with passcode, token without)
     if (refreshToken) {
       await keylessRefreshTokenStorage.saveTokensToStorage({
@@ -3320,27 +3338,15 @@ class ServiceKeylessWallet extends ServiceBase {
     defaultLogger.wallet.keyless.resetKeylessPinConfirmStatusUpdated();
 
     this.fixedKeylessProviderMap = {};
-    if (shouldRewriteKeylessBackendShareOwner) {
-      // The juicebox share has already been re-uploaded under targetOwnerId
-      // above, so rewriting the backend share owner is a consistency
-      // requirement rather than an opportunistic migration: it must finish
-      // before reset is confirmed. Otherwise the server is left with the
-      // backend share under the previous owner while the juicebox share lives
-      // under the new owner, and a later restore reads the stale
-      // backendShareResult.ownerId and fails to locate the juicebox share.
-      // Keep it blocking; revision conflicts are still retried inside
-      // migrateKeylessBackendShareToV2.
-      await this.migrateKeylessBackendShareToV2({
-        token,
-        ownerId: targetOwnerId,
-        expectedHashId: backendShareResult.hashId,
-        expectedBackendShareData: backendShareData,
-      });
-    } else if (shouldUpgradeKeylessBackendShareFormat) {
+    if (
+      !shouldRewriteKeylessBackendShareOwner &&
+      shouldUpgradeKeylessBackendShareFormat
+    ) {
       // A pure v1 -> v2 upgrade with an unchanged owner keeps both shares under
       // the same owner, so a failure is harmless and self-heals via passive
       // migration on the next launch. Keep it as background best-effort work so
-      // it never blocks reset success.
+      // it never blocks reset success. (The owner-change rewrite, which also
+      // covers v1 -> v2, is handled blocking above before local persistence.)
       this.scheduleKeylessBackendShareV2Migration({
         source: 'resetPin',
         token,

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -164,9 +164,16 @@ type IKeylessBackendShareV2MigrationResult = {
     | 'upgrade_failed';
 };
 
+type IKeylessBackendShareV2MigrationSource = 'restore' | 'resetPin';
+
 type IKeylessAccessTokenWithoutPromptResult = {
   accessToken: string;
   refreshToken?: string;
+};
+
+type IKeylessWalletCreatedOnServerInfo = {
+  isCreated: boolean;
+  baseRevision: number;
 };
 
 type IKeylessBackendShareUploadParams = {
@@ -178,7 +185,7 @@ type IKeylessBackendShareUploadParams = {
   encryptedMnemonic: string;
   backendShare: string;
   juiceboxShareX: number;
-  keylessBackendShareV1Mirror?: string;
+  keylessBackendShareV1Mirror: string;
 };
 
 type IKeylessBackendShareCreationLock = {
@@ -1840,6 +1847,21 @@ class ServiceKeylessWallet extends ServiceBase {
     }
   }
 
+  private async getKeylessWalletCreatedOnServerInfo(params: {
+    token: string;
+  }): Promise<IKeylessWalletCreatedOnServerInfo> {
+    const { token } = params;
+    const backendShareMeta = await this.apiGetKeylessBackendShareMeta({
+      token,
+    });
+    return {
+      isCreated: backendShareMeta.backendShare !== '',
+      baseRevision: Number.isFinite(backendShareMeta.revision)
+        ? backendShareMeta.revision
+        : 0,
+    };
+  }
+
   private async apiAcquireCreationLock(params: {
     token: string;
   }): Promise<IKeylessBackendShareCreationLock> {
@@ -2014,23 +2036,13 @@ class ServiceKeylessWallet extends ServiceBase {
         'Keyless backend share v2 verification mismatch',
       );
     }
-    let encryptedPayloadV1Mirror: string;
-    if (keylessBackendShareV1Mirror !== undefined) {
-      const mirrorBackendShareData =
-        await this.decryptKeylessBackendSharePayloadV1({
-          backendShare: keylessBackendShareV1Mirror,
-        });
-      if (!isEqual(mirrorBackendShareData, backendShareData)) {
-        throw new OneKeyLocalError(
-          'Keyless backend share v1 mirror verification mismatch',
-        );
-      }
-      encryptedPayloadV1Mirror = keylessBackendShareV1Mirror;
-    } else {
-      encryptedPayloadV1Mirror = await this.encryptKeylessBackendSharePayloadV1(
-        {
-          backendShareData,
-        },
+    const mirrorBackendShareData =
+      await this.decryptKeylessBackendSharePayloadV1({
+        backendShare: keylessBackendShareV1Mirror,
+      });
+    if (!isEqual(mirrorBackendShareData, backendShareData)) {
+      throw new OneKeyLocalError(
+        'Keyless backend share v1 mirror verification mismatch',
       );
     }
 
@@ -2046,7 +2058,7 @@ class ServiceKeylessWallet extends ServiceBase {
       lockId,
       baseRevision,
       keylessBackendShareV2: encryptedPayloadWithPrefix,
-      keylessBackendShareV1Mirror: encryptedPayloadV1Mirror,
+      keylessBackendShareV1Mirror,
     });
 
     const isSuccess = res?.data?.code === 0 && res?.data?.message === 'success';
@@ -2103,6 +2115,12 @@ class ServiceKeylessWallet extends ServiceBase {
             ) {
               return;
             }
+            const keylessBackendShareV1Mirror =
+              current.canonicalFormat === 'v1'
+                ? current.backendShare
+                : await this.encryptKeylessBackendSharePayloadV1({
+                    backendShareData: current.backendShareData,
+                  });
             await this.uploadKeylessBackendShare({
               token,
               lockId,
@@ -2112,10 +2130,7 @@ class ServiceKeylessWallet extends ServiceBase {
               encryptedMnemonic: current.backendShareData.encryptedMnemonic,
               backendShare: current.backendShareData.backendShare,
               juiceboxShareX: current.backendShareData.juiceboxShareX,
-              keylessBackendShareV1Mirror:
-                current.canonicalFormat === 'v1'
-                  ? current.backendShare
-                  : undefined,
+              keylessBackendShareV1Mirror,
             });
           },
         );
@@ -2135,6 +2150,32 @@ class ServiceKeylessWallet extends ServiceBase {
     throw lastError instanceof Error
       ? lastError
       : new OneKeyLocalError('Failed to migrate keyless backend share to v2');
+  }
+
+  private scheduleKeylessBackendShareV2Migration(params: {
+    source: IKeylessBackendShareV2MigrationSource;
+    token: string;
+    ownerId: string;
+    expectedBackendShareData?: IKeylessBackendShare;
+    expectedHashId?: string;
+  }) {
+    const { source, token, ownerId, expectedBackendShareData, expectedHashId } =
+      params;
+
+    setTimeout(() => {
+      void this.migrateKeylessBackendShareToV2({
+        token,
+        ownerId,
+        expectedBackendShareData,
+        expectedHashId,
+      }).catch(() => {
+        if (source === 'restore') {
+          defaultLogger.wallet.keyless.restoreKeylessBackendShareV2MigrationFailed();
+          return;
+        }
+        defaultLogger.wallet.keyless.resetKeylessBackendShareV2MigrationFailed();
+      });
+    }, 0);
   }
 
   private isKeylessAccessTokenValid(token: string | null): token is string {
@@ -3229,17 +3270,9 @@ class ServiceKeylessWallet extends ServiceBase {
       backendShareX,
     });
 
-    if (
+    const shouldScheduleKeylessBackendShareV2Migration =
       backendShareResult.canonicalFormat === 'v1' ||
-      backendShareResult.ownerId !== targetOwnerId
-    ) {
-      await this.migrateKeylessBackendShareToV2({
-        token,
-        ownerId: targetOwnerId,
-        expectedHashId: backendShareResult.hashId,
-        expectedBackendShareData: backendShareData,
-      });
-    }
+      backendShareResult.ownerId !== targetOwnerId;
 
     // Save tokens to secure storage (refreshToken with passcode, token without)
     if (refreshToken) {
@@ -3286,6 +3319,15 @@ class ServiceKeylessWallet extends ServiceBase {
     defaultLogger.wallet.keyless.resetKeylessPinConfirmStatusUpdated();
 
     this.fixedKeylessProviderMap = {};
+    if (shouldScheduleKeylessBackendShareV2Migration) {
+      this.scheduleKeylessBackendShareV2Migration({
+        source: 'resetPin',
+        token,
+        ownerId: targetOwnerId,
+        expectedHashId: backendShareResult.hashId,
+        expectedBackendShareData: backendShareData,
+      });
+    }
     return { success: true };
   }
 
@@ -3451,31 +3493,37 @@ class ServiceKeylessWallet extends ServiceBase {
       defaultLogger.wallet.keyless.restorePinConfirmStatusUpdated();
     }
 
-    if (backendShareResult.canonicalFormat === 'v1') {
-      await this.migrateKeylessBackendShareToV2({
+    const shouldScheduleKeylessBackendShareV2Migration =
+      backendShareResult.canonicalFormat === 'v1';
+
+    const keylessProvider =
+      backendShareResult.ownerProvider ??
+      this.buildKeylessProviderFromSocialToken({ token });
+    const encodedMnemonic =
+      await this.backgroundApi.servicePassword.encodeSensitiveText({
+        text: mnemonic,
+      });
+    const socialUserIdHash = await accountUtils.hashKeylessSocialUserId({
+      socialUserId: this.buildKeylessSocialUserIdFromToken({ token }),
+    });
+
+    this.fixedKeylessProviderMap = {};
+    if (shouldScheduleKeylessBackendShareV2Migration) {
+      this.scheduleKeylessBackendShareV2Migration({
+        source: 'restore',
         token,
         ownerId,
         expectedHashId: backendShareResult.hashId,
         expectedBackendShareData: backendShareData,
       });
     }
-
-    const keylessProvider =
-      backendShareResult.ownerProvider ??
-      this.buildKeylessProviderFromSocialToken({ token });
-
-    this.fixedKeylessProviderMap = {};
     return {
       ownerId,
-      mnemonic: await this.backgroundApi.servicePassword.encodeSensitiveText({
-        text: mnemonic,
-      }),
+      mnemonic: encodedMnemonic,
       keylessDetailsInfo: {
         keylessOwnerId: ownerId,
         keylessProvider,
-        socialUserIdHash: await accountUtils.hashKeylessSocialUserId({
-          socialUserId: this.buildKeylessSocialUserIdFromToken({ token }),
-        }),
+        socialUserIdHash,
       },
     };
   }
@@ -3527,7 +3575,10 @@ class ServiceKeylessWallet extends ServiceBase {
         defaultLogger.wallet.keyless.createKeylessLockAcquired({ lockId });
 
         // 2. Double-check if already created (check inside lock for safety)
-        const isCreated = await this.isKeylessWalletCreatedOnServer({ token });
+        const { isCreated, baseRevision } =
+          await this.getKeylessWalletCreatedOnServerInfo({
+            token,
+          });
 
         if (isCreated) {
           throw new OneKeyLocalError('Keyless wallet already created');
@@ -3602,6 +3653,15 @@ class ServiceKeylessWallet extends ServiceBase {
           juiceboxShareX,
         });
 
+        const keylessBackendShareV1Mirror =
+          await this.encryptKeylessBackendSharePayloadV1({
+            backendShareData: {
+              encryptedMnemonic,
+              backendShare,
+              juiceboxShareX,
+            },
+          });
+
         // Make sure juiceboxShare is uploaded successfully before uploading backend share
         const _backendShareData: IKeylessBackendShare =
           await this.uploadKeylessBackendShare({
@@ -3609,10 +3669,11 @@ class ServiceKeylessWallet extends ServiceBase {
             lockId,
             hashId,
             ownerId,
-            baseRevision: 0,
+            baseRevision,
             encryptedMnemonic,
             backendShare,
             juiceboxShareX, // Store the other share's x-coordinate for recovery
+            keylessBackendShareV1Mirror,
           });
         defaultLogger.wallet.keyless.createKeylessBackendShareUploaded({
           backendShareX,
@@ -3664,11 +3725,8 @@ class ServiceKeylessWallet extends ServiceBase {
   async isKeylessWalletCreatedOnServer(params: {
     token: string;
   }): Promise<boolean> {
-    const { token } = params;
-    const { backendShare } = await this.apiGetKeylessBackendShareMeta({
-      token,
-    });
-    const isCreated = backendShare !== '';
+    const { isCreated } =
+      await this.getKeylessWalletCreatedOnServerInfo(params);
     return isCreated;
   }
 

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -3270,9 +3270,10 @@ class ServiceKeylessWallet extends ServiceBase {
       backendShareX,
     });
 
-    const shouldScheduleKeylessBackendShareV2Migration =
-      backendShareResult.canonicalFormat === 'v1' ||
+    const shouldRewriteKeylessBackendShareOwner =
       backendShareResult.ownerId !== targetOwnerId;
+    const shouldUpgradeKeylessBackendShareFormat =
+      backendShareResult.canonicalFormat === 'v1';
 
     // Save tokens to secure storage (refreshToken with passcode, token without)
     if (refreshToken) {
@@ -3319,7 +3320,27 @@ class ServiceKeylessWallet extends ServiceBase {
     defaultLogger.wallet.keyless.resetKeylessPinConfirmStatusUpdated();
 
     this.fixedKeylessProviderMap = {};
-    if (shouldScheduleKeylessBackendShareV2Migration) {
+    if (shouldRewriteKeylessBackendShareOwner) {
+      // The juicebox share has already been re-uploaded under targetOwnerId
+      // above, so rewriting the backend share owner is a consistency
+      // requirement rather than an opportunistic migration: it must finish
+      // before reset is confirmed. Otherwise the server is left with the
+      // backend share under the previous owner while the juicebox share lives
+      // under the new owner, and a later restore reads the stale
+      // backendShareResult.ownerId and fails to locate the juicebox share.
+      // Keep it blocking; revision conflicts are still retried inside
+      // migrateKeylessBackendShareToV2.
+      await this.migrateKeylessBackendShareToV2({
+        token,
+        ownerId: targetOwnerId,
+        expectedHashId: backendShareResult.hashId,
+        expectedBackendShareData: backendShareData,
+      });
+    } else if (shouldUpgradeKeylessBackendShareFormat) {
+      // A pure v1 -> v2 upgrade with an unchanged owner keeps both shares under
+      // the same owner, so a failure is harmless and self-heals via passive
+      // migration on the next launch. Keep it as background best-effort work so
+      // it never blocks reset success.
       this.scheduleKeylessBackendShareV2Migration({
         source: 'resetPin',
         token,

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -3277,7 +3277,7 @@ class ServiceKeylessWallet extends ServiceBase {
     // failure. v1 is handled by the best-effort upgrade scheduled below.
     const shouldRewriteKeylessBackendShareOwner =
       backendShareResult.canonicalFormat === 'v2' &&
-      backendShareResult.ownerId != null &&
+      backendShareResult.ownerId !== undefined &&
       backendShareResult.ownerId !== targetOwnerId;
     const shouldUpgradeKeylessBackendShareFormat =
       backendShareResult.canonicalFormat === 'v1';

--- a/packages/kit/src/views/Onboardingv2/hooks/useKeylessLocalExistenceLogin.ts
+++ b/packages/kit/src/views/Onboardingv2/hooks/useKeylessLocalExistenceLogin.ts
@@ -3,12 +3,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import type { IDialogInstance } from '@onekeyhq/components';
-import { Dialog } from '@onekeyhq/components';
+import { Dialog, Toast } from '@onekeyhq/components';
 import { EOAuthSocialLoginProvider } from '@onekeyhq/shared/src/consts/authConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 
+import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { useKeylessWallet } from '../../../components/KeylessWallet/useKeylessWallet';
+import { useOneKeyAuth } from '../../../components/OneKeyAuth/useOneKeyAuth';
 
 const PROVIDER_PLATFORM_NAME: Record<EOAuthSocialLoginProvider, string> = {
   [EOAuthSocialLoginProvider.Google]: 'Google',
@@ -21,12 +23,17 @@ const PROVIDER_PLATFORM_NAME: Record<EOAuthSocialLoginProvider, string> = {
 // OAuth round-trip so the user sees progress even though they didn't click.
 export function useKeylessLocalExistenceLogin({
   autoLoginKeylessProvider,
+  isResetMode,
+  onResetModeChange,
 }: {
   autoLoginKeylessProvider?: EOAuthSocialLoginProvider;
+  isResetMode?: boolean;
+  onResetModeChange?: (val: boolean) => void;
 } = {}) {
   const intl = useIntl();
   const { enableKeylessWalletLoading, checkKeylessWalletLocalExistence } =
     useKeylessWallet();
+  const { signInWithSocialLogin } = useOneKeyAuth();
 
   const [loadingProvider, setLoadingProvider] =
     useState<EOAuthSocialLoginProvider | null>(null);
@@ -43,9 +50,11 @@ export function useKeylessLocalExistenceLogin({
     async (provider: EOAuthSocialLoginProvider) => {
       setLoadingProvider(provider);
       try {
-        defaultLogger.account.wallet.onboard({
-          onboardMethod: 'createKeylessWallet',
-        });
+        if (!isResetMode) {
+          defaultLogger.account.wallet.onboard({
+            onboardMethod: 'createKeylessWallet',
+          });
+        }
         if (autoLoginKeylessProvider) {
           const platform = PROVIDER_PLATFORM_NAME[provider];
           loadingDialogRef.current = Dialog.loading({
@@ -59,13 +68,35 @@ export function useKeylessLocalExistenceLogin({
             ),
           });
         }
+        if (isResetMode) {
+          const result = await signInWithSocialLogin(provider);
+          if (result?.session?.accessToken) {
+            await backgroundApiProxy.serviceKeylessWallet.apiResetKeylessBackendShare(
+              {
+                token: result.session.accessToken,
+              },
+            );
+            Toast.success({
+              title: 'Reset Success',
+            });
+            onResetModeChange?.(false);
+          }
+          return;
+        }
         await checkKeylessWalletLocalExistence({ signInProvider: provider });
       } finally {
         setLoadingProvider(null);
         void loadingDialogRef.current?.close();
       }
     },
-    [checkKeylessWalletLocalExistence, intl, autoLoginKeylessProvider],
+    [
+      autoLoginKeylessProvider,
+      checkKeylessWalletLocalExistence,
+      intl,
+      isResetMode,
+      onResetModeChange,
+      signInWithSocialLogin,
+    ],
   );
 
   const handleGoogleLogin = useCallback(

--- a/packages/kit/src/views/Onboardingv2/hooks/useKeylessLocalExistenceLogin.ts
+++ b/packages/kit/src/views/Onboardingv2/hooks/useKeylessLocalExistenceLogin.ts
@@ -38,6 +38,12 @@ export function useKeylessLocalExistenceLogin({
   const [loadingProvider, setLoadingProvider] =
     useState<EOAuthSocialLoginProvider | null>(null);
   const loadingDialogRef = useRef<IDialogInstance | null>(null);
+  // Synchronous re-entrancy guard. setLoadingProvider is async React state, so
+  // a same-frame double click or a click on the other provider before the
+  // state commits could otherwise launch two concurrent OAuth round-trips (or
+  // two concurrent destructive resets) and let the later response overwrite the
+  // earlier success / reset-mode UI state.
+  const isHandlingLoginRef = useRef(false);
 
   useEffect(
     () => () => {
@@ -48,6 +54,10 @@ export function useKeylessLocalExistenceLogin({
 
   const handleLogin = useCallback(
     async (provider: EOAuthSocialLoginProvider) => {
+      if (isHandlingLoginRef.current) {
+        return;
+      }
+      isHandlingLoginRef.current = true;
       setLoadingProvider(provider);
       try {
         if (!isResetMode) {
@@ -85,6 +95,7 @@ export function useKeylessLocalExistenceLogin({
         }
         await checkKeylessWalletLocalExistence({ signInProvider: provider });
       } finally {
+        isHandlingLoginRef.current = false;
         setLoadingProvider(null);
         void loadingDialogRef.current?.close();
       }

--- a/packages/kit/src/views/Onboardingv2/pages/CreateNewWallet.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/CreateNewWallet.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 import { useRoute } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
@@ -34,6 +34,8 @@ import {
 import { useAutoStartKeylessProvider } from '../hooks/useAutoStartKeylessProvider';
 import { useKeylessLocalExistenceLogin } from '../hooks/useKeylessLocalExistenceLogin';
 import { OnboardingTestIDs } from '../testIDs';
+
+import { KeylessOnboardingDebugPanel } from './KeylessOnboardingDebugPanel';
 
 import type { RouteProp } from '@react-navigation/core';
 
@@ -73,13 +75,18 @@ function CreateNewWallet() {
     route?.params?.fromExt && autoLoginKeylessProvider,
   );
   const isKeylessWalletEnabled = useKeylessWalletFeatureIsEnabled();
+  const [isResetMode, setIsResetMode] = useState(false);
 
   const {
     enableKeylessWalletLoading,
     loadingProvider,
     handleGoogleLogin,
     handleAppleLogin,
-  } = useKeylessLocalExistenceLogin({ autoLoginKeylessProvider });
+  } = useKeylessLocalExistenceLogin({
+    autoLoginKeylessProvider,
+    isResetMode,
+    onResetModeChange: setIsResetMode,
+  });
 
   const handleCreateSeedPhraseWallet = useCallback(async () => {
     const mnemonic = await backgroundApiProxy.serviceAccount.generateMnemonic();
@@ -250,6 +257,12 @@ function CreateNewWallet() {
                 </SizableText>
               </Button>
             </>
+          )}
+          {isWebKeylessSidePanelMode ? null : (
+            <KeylessOnboardingDebugPanel
+              isResetMode={isResetMode}
+              onResetModeChange={setIsResetMode}
+            />
           )}
         </YStack>
       </YStack>

--- a/packages/kit/src/views/Onboardingv2/pages/CreateNewWallet.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/CreateNewWallet.tsx
@@ -121,11 +121,14 @@ function CreateNewWallet() {
   });
 
   const isGoogleLoading =
-    enableKeylessWalletLoading &&
     loadingProvider === EOAuthSocialLoginProvider.Google;
   const isAppleLoading =
-    enableKeylessWalletLoading &&
     loadingProvider === EOAuthSocialLoginProvider.Apple;
+  // Disable both provider buttons whenever any keyless login/reset is in
+  // flight. enableKeylessWalletLoading covers the create/restore path; reset
+  // mode only sets loadingProvider, so include it here too.
+  const isKeylessLoginInProgress =
+    enableKeylessWalletLoading || loadingProvider !== null;
 
   const { md } = useMedia();
 
@@ -193,7 +196,7 @@ function CreateNewWallet() {
             size="large"
             alignSelf="stretch"
             childrenAsText={false}
-            disabled={enableKeylessWalletLoading || isGoogleLoading}
+            disabled={isKeylessLoginInProgress}
             onPress={handleGoogleLogin}
           >
             <YStack position="absolute" left="$5">
@@ -216,7 +219,7 @@ function CreateNewWallet() {
             size="large"
             alignSelf="stretch"
             childrenAsText={false}
-            disabled={enableKeylessWalletLoading || isAppleLoading}
+            disabled={isKeylessLoginInProgress}
             onPress={handleAppleLogin}
           >
             <YStack position="absolute" left="$5">

--- a/packages/kit/src/views/Onboardingv2/pages/CreateNewWallet.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/CreateNewWallet.tsx
@@ -120,10 +120,8 @@ function CreateNewWallet() {
     onAppleLogin: handleAppleLogin,
   });
 
-  const isGoogleLoading =
-    loadingProvider === EOAuthSocialLoginProvider.Google;
-  const isAppleLoading =
-    loadingProvider === EOAuthSocialLoginProvider.Apple;
+  const isGoogleLoading = loadingProvider === EOAuthSocialLoginProvider.Google;
+  const isAppleLoading = loadingProvider === EOAuthSocialLoginProvider.Apple;
   // Disable both provider buttons whenever any keyless login/reset is in
   // flight. enableKeylessWalletLoading covers the create/restore path; reset
   // mode only sets loadingProvider, so include it here too.

--- a/packages/shared/src/logger/scopes/wallet/scenes/keyless.ts
+++ b/packages/shared/src/logger/scopes/wallet/scenes/keyless.ts
@@ -135,6 +135,16 @@ export class KeylessScene extends BaseScene {
     return {};
   }
 
+  @LogToLocal({ level: 'error' })
+  public resetKeylessBackendShareV2MigrationFailed() {
+    return {};
+  }
+
+  @LogToLocal({ level: 'error' })
+  public restoreKeylessBackendShareV2MigrationFailed() {
+    return {};
+  }
+
   @LogToLocal({ level: 'info' })
   public restoreKeylessBackendShareRetrieved() {
     return {};


### PR DESCRIPTION
[Claude session ↗](https://claude.ai/code/session_01KTyd4vHZLPzmHjAqzqbsNG)

## Summary
- Add the hidden keyless onboarding debug panel to the Create New Wallet page so reset mode is reachable from that entry.
- Require callers to provide the v1 backend share mirror when uploading v2 data, and keep create/migration callers explicit about how the mirror is produced.
- Run v1-to-v2 backend share migration as a background best-effort task for restore/reset flows so migration failures do not block the main keyless flow.

## Intent &amp; Context
This change addresses keyless wallet onboarding and backend-share migration behavior found while testing reset/create/restore flows. The reset debug panel previously existed on the OneKey ID login page but was not reachable from Create New Wallet. During reset testing, restore/create behavior showed that v1-to-v2 migration could be coupled into the main finalize path and block the user if migration failed.

The desired behavior is to keep the existing passcode-to-finalize flow unchanged from v6.3.0, while decoupling only the v1-to-v2 migration work from restore/reset success. The user also clarified that create flows still need a v1 mirror for old-client compatibility.

## Root Cause
The passcode callback has historically awaited keyless finalization, including in v6.3.0. The regression risk came from adding v1-to-v2 backend share migration into service methods awaited by finalization. When migration failed, errors propagated back through restore/reset and could block otherwise successful keyless flows.

## Design Decisions
- Keep passcode callback behavior unchanged: CreatePasscode still awaits `finalizeKeylessWalletV2`, matching v6.3.0 behavior.
- Decouple only backend share migration: restore/reset now schedule v1-to-v2 migration after critical business work has completed.
- Preserve migration correctness: migration still retries revision conflicts immediately and still uses server-provided revision, not the temporary hard-coded revision.
- Keep legacy compatibility explicit: upload requires a caller-provided v1 mirror, so create and migration code explicitly decide how to construct or reuse the mirror.
- Log background migration failures locally instead of surfacing them as blocking UI errors.

## Changes Detail
- `CreateNewWallet.tsx`: renders `KeylessOnboardingDebugPanel` at the bottom of the Create New Wallet page outside web keyless side panel mode.
- `useKeylessLocalExistenceLogin.ts`: supports reset mode for Google/Apple login and calls the backend-share reset API in that mode.
- `ServiceKeylessWallet.ts`: makes v1 mirror upload explicit, uses server revision for create/migration uploads, and schedules restore/reset v1-to-v2 migration as background best-effort work.
- `keyless.ts`: adds a local logger event for background v2 migration failures.
- `ServiceKeylessWallet.test.ts`: adds coverage for server revision usage, explicit v1 mirror behavior, async migration scheduling, and migration failure not rejecting restore/reset flows.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Keyless wallet create/restore/reset flows, backend share v1/v2 compatibility, debug reset entry behavior.

## Test plan
- [x] `yarn jest packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts --runInBand`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts packages/shared/src/logger/scopes/wallet/scenes/keyless.ts --deny-warnings`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
