### PR TITLE
fix: stamp server dataTime for fresh cloud-sync writes (OK-55438)

### DIFF
--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -2594,11 +2594,14 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     items,
     skipUpdate,
     skipUploadToServer,
+    useServerDataTime,
     fn,
   }: {
     items: IDBCloudSyncItem[];
     skipUpdate?: boolean;
     skipUploadToServer?: boolean;
+    // OK-55438: forward to the upload so genuine "now" writes get a server stamp
+    useServerDataTime?: boolean;
     fn?: () => Promise<void>;
   }) {
     if (items?.length) {
@@ -2610,6 +2613,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
           items,
           skipUpdate,
           skipUploadToServer,
+          useServerDataTime,
         });
 
         await fn?.();
@@ -2624,11 +2628,14 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     items,
     skipUpdate,
     skipUploadToServer,
+    useServerDataTime,
   }: {
     tx: ILocalDBTransaction;
     items: IDBCloudSyncItem[];
     skipUpdate?: boolean;
     skipUploadToServer?: boolean;
+    // OK-55438: forward to the upload so genuine "now" writes get a server stamp
+    useServerDataTime?: boolean;
   }) {
     // add new item
     await this.txAddRecords({
@@ -2661,6 +2668,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     if (!skipUploadToServer) {
       void this.backgroundApi?.servicePrimeCloudSync.apiUploadItems({
         localItems: items,
+        useServerDataTime,
       });
     }
   }
@@ -4536,6 +4544,9 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
         await this.txAddAndUpdateSyncItems({
           tx,
           items: [syncItem],
+          // OK-55438: rename is a genuine "now" write; let the server stamp
+          // dataTime so a fast local clock can't push it into the future.
+          useServerDataTime: true,
         });
       }
 
@@ -5901,6 +5912,9 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
         await this.txAddAndUpdateSyncItems({
           tx,
           items: [syncItem],
+          // OK-55438: account/indexedAccount rename is a genuine "now" write;
+          // let the server stamp dataTime to avoid future timestamps.
+          useServerDataTime: true,
         });
       }
 

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -3904,6 +3904,9 @@ class ServiceAccount extends ServiceBase {
         await this.backgroundApi.servicePrimeCloudSync.apiUploadItems({
           localItems: [latestSyncItem],
           noDebounceUpload: true,
+          // OK-55438: tombstone/create is a genuine "now" write; let the server
+          // stamp dataTime (it only clamps timestamps ahead of its own clock).
+          useServerDataTime: true,
         });
       })().catch((error) => {
         errorUtils.autoPrintErrorIgnore(error);
@@ -4013,6 +4016,9 @@ class ServiceAccount extends ServiceBase {
       await this.backgroundApi.servicePrimeCloudSync.apiUploadItems({
         localItems: [latestSyncItem],
         noDebounceUpload: true,
+        // OK-55438: deletion tombstone is a genuine "now" write; let the server
+        // stamp dataTime (it only clamps timestamps ahead of its own clock).
+        useServerDataTime: true,
       });
     })().catch((error) => {
       errorUtils.autoPrintErrorIgnore(error);

--- a/packages/kit-bg/src/services/ServicePrimeCloudSync/ServicePrimeCloudSync.tsx
+++ b/packages/kit-bg/src/services/ServicePrimeCloudSync/ServicePrimeCloudSync.tsx
@@ -558,6 +558,7 @@ class ServicePrimeCloudSync extends ServiceBase {
     syncCredential,
     encryptedSecurityPasswordR1ForServer,
     noDebounceUpload,
+    useServerDataTime,
   }: {
     localItems: IDBCloudSyncItem[];
     isFlush?: boolean;
@@ -567,7 +568,15 @@ class ServicePrimeCloudSync extends ServiceBase {
     syncCredential?: ICloudSyncCredential | undefined;
     encryptedSecurityPasswordR1ForServer?: string;
     noDebounceUpload?: boolean;
+    // OK-55438: opt-in flag for genuine "now" writes (rename / delete tombstone).
+    // Records these item ids so the upload payload asks the server to
+    // authoritatively stamp dataTime. Server only clamps when the submitted time
+    // is ahead of its own clock, so this can never move a past timestamp forward.
+    useServerDataTime?: boolean;
   }) {
+    if (useServerDataTime) {
+      localItems.forEach((item) => this.useServerDataTimeIds.add(item.id));
+    }
     const devSettings = await devSettingsPersistAtom.get();
     const activeMode = await this.getActiveSyncMode();
     if (!skipPrimeStatusCheck) {
@@ -678,6 +687,7 @@ class ServicePrimeCloudSync extends ServiceBase {
         const serverItem = this.convertLocalItemToServerItem({
           localItem: item,
           dataTimestamp,
+          useServerDataTime: this.useServerDataTimeIds.has(item.id),
         });
         if (process.env.NODE_ENV !== 'production') {
           // @ts-ignore
@@ -688,6 +698,10 @@ class ServicePrimeCloudSync extends ServiceBase {
         return serverItem;
       })
       .filter(Boolean);
+
+    // OK-55438: one-shot consume — clear the server-time flags for this batch so
+    // a later re-upload of the same id (e.g. obsoleted re-sync) is never stamped.
+    localItems.forEach((item) => this.useServerDataTimeIds.delete(item.id));
 
     const filteredLocalData = localData.filter((item) => {
       const pwdMatched = item.pwdHash === pwdHash && pwdHash;
@@ -747,6 +761,14 @@ class ServicePrimeCloudSync extends ServiceBase {
   };
 
   uploadItemsToMerge: IDBCloudSyncItem[] = [];
+
+  // OK-55438: item ids whose dataTime should be authoritatively rewritten by the
+  // server (genuine "now" writes such as rename / delete tombstone). Populated by
+  // apiUploadItems({ useServerDataTime: true }) and consumed (cleared) when the
+  // upload payload is built in `_callApiUploadItems`. The flag is carried per
+  // item (not per request) because the debounced merge buffer mixes fresh writes
+  // with historical re-uploads (obsoleted re-sync, uploadAllLocalItems, ...).
+  useServerDataTimeIds: Set<string> = new Set();
 
   _callApiUploadItemsDebounceMerge({
     localItems,
@@ -2376,9 +2398,11 @@ class ServicePrimeCloudSync extends ServiceBase {
   convertLocalItemToServerItem({
     localItem,
     dataTimestamp,
+    useServerDataTime,
   }: {
     localItem: IDBCloudSyncItem;
     dataTimestamp?: number;
+    useServerDataTime?: boolean;
   }): ICloudSyncServerItem | null {
     // Skip Lock items with keyless pwdHash
     if (
@@ -2395,6 +2419,11 @@ class ServicePrimeCloudSync extends ServiceBase {
       isDeleted: localItem.isDeleted,
       pwdHash: localItem.pwdHash,
     };
+    // OK-55438: ask the server to authoritatively stamp dataTime for genuine
+    // "now" writes (it only clamps when the submitted time is ahead of server).
+    if (useServerDataTime) {
+      serverItem.useServerDataTime = true;
+    }
     return serverItem;
   }
 

--- a/packages/shared/src/utils/systemTimeUtils.ts
+++ b/packages/shared/src/utils/systemTimeUtils.ts
@@ -33,7 +33,11 @@ const intervalTimeout = timerUtils.getTimeDurationMs({
   minute: 5,
 });
 const localServerTimeDiff = timerUtils.getTimeDurationMs({
-  minute: 30,
+  // OK-55438: tightened 30m -> 10m. Cross-device LWW ordering for cloud sync
+  // needs a tighter local-clock trust window than display/expiry logic: within
+  // this window getTimeNow() returns the raw local clock unmodified, so too
+  // loose a window lets a fast clock leak future dataTime into sync items.
+  minute: 10,
 });
 
 function isTimeValid({ time }: { time: number | undefined }): boolean {

--- a/packages/shared/types/prime/primeCloudSyncTypes.ts
+++ b/packages/shared/types/prime/primeCloudSyncTypes.ts
@@ -66,6 +66,12 @@ export type ICloudSyncServerItem = {
   isDeleted: boolean;
   pwdHash: string; // TODO server should return pwdHash
   key: string;
+  // OK-55438: when true, this item is a genuine "now" write (e.g. rename /
+  // delete tombstone) and the server should overwrite dataTimestamp with its
+  // own clock. The server MUST only do so when the submitted dataTimestamp is
+  // ahead of server time (clamp future -> now), never raise a past value, so a
+  // mis-flagged old item can never be pushed forward.
+  useServerDataTime?: boolean;
   // nonce: number;
   // userId: string; supabase user id
 };


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55438](https://onekeyhq.atlassian.net/browse/OK-55438)

----------

<!-- github-pr-monitor:jira-links:end -->


## Background — OK-55438

Jira: https://onekeyhq.atlassian.net/browse/OK-55438

Deleted wallets/accounts can **resurrect** across devices (keyless cloud sync) when a device clock runs fast.

**Root cause.** The existing future-time clamp lives only in the **check** phase (`apiCheckServerStatus`, `ServicePrimeCloudSync.tsx`). But "now" writes — wallet/account **rename** and **delete tombstones** — upload through the **direct** `apiUploadItems` path (via `txAddAndUpdateSyncItems` auto-upload, or a delayed `apiUploadItems({ noDebounceUpload: true })`) and **never go through `apiCheckServerStatus`**, so the clamp never runs. The timestamp comes from `systemTimeUtils.getTimeNow()`, which returns the **raw local clock unmodified** whenever the offset is within the trust window — so a fast clock leaks a future `dataTime`, which then wins last-write-wins ordering against a later, correctly-timed delete on another device → resurrection.

## Approach

Let the **server** authoritatively stamp `dataTime` for genuine "now" writes, instead of trusting the client clock. A new optional per-item flag `useServerDataTime` is attached only to items we are 100% sure are "just modified, about to upload". The flag is **per item** (not per request) because the debounced upload buffer (`uploadItemsToMerge`) mixes fresh writes with historical re-uploads (obsoleted re-sync, `uploadAllLocalItems`, …) — a request-level flag would corrupt those.

## Client changes (this PR)

- **`ICloudSyncServerItem`**: add optional `useServerDataTime?: boolean` (plaintext metadata — server needs no decryption).
- **`ServicePrimeCloudSync.tsx`**:
  - `apiUploadItems({ useServerDataTime })` records the batch's item ids into an instance `Set<string> useServerDataTimeIds`.
  - `_callApiUploadItems` sets `useServerDataTime: true` on each payload item whose id is in the Set, then **one-shot clears** those ids (so a later re-upload of the same id is never stamped).
  - `convertLocalItemToServerItem` propagates the flag onto the server payload.
- **Opt-in points (narrow, verified "now" writes only):**
  - Wallet rename — `setWalletNameAndAvatar`
  - Account / indexedAccount rename — `setAccountName`
  - Keyless wallet & bot-wallet **delete tombstones** — `ServiceAccount` (`apiUploadItems({ noDebounceUpload: true })`)
  - Threaded through `addAndUpdateSyncItems` / `txAddAndUpdateSyncItems` so the DB-layer auto-upload can opt in.
- **`systemTimeUtils`**: tighten the local-clock trust window **30m → 10m** (`localServerTimeDiff`). Within this window `getTimeNow()` returns the raw local clock, so a looser window leaks larger future skews into LWW.

**Explicitly NOT flagged** (carry historical `dataTime`, must never be rewritten): obsoleted re-upload, `uploadAllLocalItems`, reset/flush, restore/migration.

## ⚠️ Server contract required (separate backend work)

This client change is inert until the upload endpoints honor the flag.

**Endpoints:** `/prime/v1/sync/upload` and the keyless upload endpoint.

**Per-item field:** `localData[].useServerDataTime?: boolean` (plaintext; no decryption needed).

**Rule (clamp future → now, never raise a past value):**

```
if (item.useServerDataTime === true && item.dataTimestamp > serverNow) {
    item.dataTimestamp = serverNow;
}
// otherwise keep the submitted dataTimestamp unchanged
```

- Genuine "now" write on a fast clock → submitted time is ahead → set to `serverNow` ("authoritative current time").
- A mis-flagged **old** item → submitted time ≤ `serverNow` → **left untouched** (never pushed forward). This "only-descend" guard means even an over-broad client flag cannot move history forward.
- The rewritten `dataTimestamp` must be used for both persistence and conflict comparison.
- *(Optional enhancement: return the stamped timestamp in the upload response so the client can align local `dataTime` immediately instead of on the next check/download.)*

## Scope / follow-ups

- Existing **future timestamps already on the server** are out of scope here; they are still fixed by the check-phase clamp on the next check.
- Other sync data types (address book / market watchlist / custom RPC / custom token / browser bookmark) share the same delete-tombstone pattern and can opt in with the same one-line `useServerDataTime: true` — left as follow-up to keep this PR focused on the reported wallet/account issue.

## Validation

- ✅ `tsgo` full-project type-check — 0 errors.
- ✅ `jest` (ServicePrimeCloudSync + LocalDbBase suites) — 5 suites / 24 tests passed.
- ✅ CI: lint / CodeQL / Socket Security / Supply-chain / Bugbot / Snyk green (unittest + bundle-architecture still running at time of writing, no failures).
- Change is additive (new optional network DTO field + opt-in flag); **no DB schema change → no `LOCAL_DB_VERSION` bump**.

> Note: history has two commits (mechanism + wiring) because a mid-work commit was already pushed and force-push was intentionally avoided; squash on merge.

https://claude.ai/code/session_01NH37w3mn9NkVBWvhe7YSXy

[OK-55438]: https://onekeyhq.atlassian.net/browse/OK-55438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ