### PR TITLE
fix(history): prevent multi-token transfer row overflow in web list(OK-55494)

### DIFF
--- a/packages/kit/src/components/TxAction/TxActionTransfer.tsx
+++ b/packages/kit/src/components/TxAction/TxActionTransfer.tsx
@@ -295,6 +295,12 @@ function buildExpandedTransferView({
   hideValue?: boolean;
   currencySymbol?: string;
 }) {
+  // INVARIANT: each transfer line is a single fixed-height row — the token icon
+  // (xs) and the amount/fiat texts share one horizontal XStack and are all
+  // numberOfLines={1}, so a line never wraps. TxHistoryListView relies on this
+  // (CHANGE_LINE_HEIGHT) to pin an exact fast-path row height without
+  // CellMeasurer. If you make a line wrap or stack vertically, update
+  // CHANGE_LINE_HEIGHT in TxHistoryListView/index.tsx accordingly.
   const renderTransferLine = (
     transfer: IDecodedTxTransferInfo,
     prefix: string,

--- a/packages/kit/src/components/TxHistoryListView/index.tsx
+++ b/packages/kit/src/components/TxHistoryListView/index.tsx
@@ -106,12 +106,9 @@ function getTransferChangeLineCount(item: IAccountHistoryTx): number {
     action.assetTransfer
   ) {
     const { sends, receives } = action.assetTransfer;
-    const sendTokenCount = new Set((sends ?? []).map((t) => t.tokenIdOnNetwork))
-      .size;
-    const receiveTokenCount = new Set(
-      (receives ?? []).map((t) => t.tokenIdOnNetwork),
-    ).size;
-    changeLineCount = sendTokenCount + receiveTokenCount;
+    const distinctTokenCount = (transfers: typeof sends) =>
+      new Set((transfers ?? []).map((t) => t.tokenIdOnNetwork)).size;
+    changeLineCount = distinctTokenCount(sends) + distinctTokenCount(receives);
   }
   transferChangeLineCountCache.set(item, changeLineCount);
   return changeLineCount;

--- a/packages/kit/src/components/TxHistoryListView/index.tsx
+++ b/packages/kit/src/components/TxHistoryListView/index.tsx
@@ -54,22 +54,37 @@ import { TxHistoryListItem } from './TxHistoryListItem';
 // Measured on web/desktop. Drives react-virtualized's CellMeasurer bypass so
 // rows are positioned synchronously with scroll instead of via async layout.
 // No-op on native (List.tsx Web fast path is not on the native code path).
+//
+// Geometry (tableLayout, see TxActionCommon.tsx): 68 = py top ($3 = 12) + py
+// bottom ($3 = 12) + 44, where 44 is the taller of the left column (title
+// $bodyMdMedium lineHeight 20 + gap $1 = 4 + subtitle $bodyMd lineHeight 20) and
+// a 1–2 line changes column. So a row with <= MAX_FIXED_HEIGHT_CHANGE_LINES
+// change lines is always 68.
+// IMPORTANT: if the row padding, the left column, or renderTransferLine's
+// per-line layout changes, update TX_ROW_HEIGHT / CHANGE_LINE_HEIGHT below.
 const TX_ROW_HEIGHT = 68;
 const SECTION_HEADER_HEIGHT_FIRST = 32; // mt=$0 on first section
 const SECTION_HEADER_HEIGHT_NEXT = 52; // mt=$5 (~20px) on subsequent sections
 
 // In tableLayout, an ASSET_TRANSFER row renders one change line per grouped
 // token (grouped sends + grouped receives — see `buildExpandedTransferView` in
-// TxActionTransfer.tsx). TX_ROW_HEIGHT only fits up to this many lines; rows
-// with more would overflow into the next row, so we measure them instead of
-// pinning a fixed height (see getWebRowHeight below).
+// TxActionTransfer.tsx). TX_ROW_HEIGHT fits up to this many change lines.
 const MAX_FIXED_HEIGHT_CHANGE_LINES = 2;
+
+// Height contributed by each change line beyond MAX_FIXED_HEIGHT_CHANGE_LINES:
+// one $bodyMd line (lineHeight 20) plus the changes column's row gap ($1 = 4) —
+// see the `<Stack gap="$1">` changes column in TxActionCommon.tsx. This lets
+// getWebRowHeight return an exact, taller fixed height for multi-token rows
+// instead of falling back to CellMeasurer, preserving the fast-scroll path.
+const CHANGE_LINE_HEIGHT = 24;
 
 // Count how many change lines the expanded transfer view will render for a row.
 // Returns 1 for non-transfer actions (approve / function call / unknown only
 // ever render a single change line in tableLayout). Distinct send + receive
-// token counts are a safe upper bound on the rendered lines: over-counting only
-// pushes a row onto the (correct) measured path, never the other way around.
+// token counts are a safe upper bound on the rendered lines (UTXO single-token
+// and send-to-self rows collapse to fewer): over-counting only reserves a
+// slightly taller fixed height (a harmless trailing gap), never a shorter one
+// (which would clip the row into the next).
 function getTransferChangeLineCount(item: IAccountHistoryTx): number {
   const action = getDisplayedActions({ decodedTx: item.decodedTx })[0];
   if (
@@ -452,16 +467,20 @@ function BaseTxHistoryListView(props: IProps) {
               if (info.item?.decodedTx?.status === EDecodedTxStatus.Pending) {
                 return undefined;
               }
-              // A multi-token transfer renders more change lines than the fixed
-              // height can hold (tableLayout only). Let CellMeasurer measure it
-              // so the row expands naturally instead of overflowing the next.
-              if (
-                tableLayout &&
-                info.item &&
-                getTransferChangeLineCount(info.item) >
-                  MAX_FIXED_HEIGHT_CHANGE_LINES
-              ) {
-                return undefined;
+              // A multi-token transfer renders more change lines than the base
+              // height can hold (tableLayout only). Stay on the CellMeasurer-free
+              // fast path by returning the exact taller height — each extra line
+              // adds CHANGE_LINE_HEIGHT — so the row expands without overflowing
+              // the next instead of falling back to async measurement.
+              if (tableLayout && info.item) {
+                const changeLineCount = getTransferChangeLineCount(info.item);
+                if (changeLineCount > MAX_FIXED_HEIGHT_CHANGE_LINES) {
+                  return (
+                    TX_ROW_HEIGHT +
+                    (changeLineCount - MAX_FIXED_HEIGHT_CHANGE_LINES) *
+                      CHANGE_LINE_HEIGHT
+                  );
+                }
               }
               return TX_ROW_HEIGHT;
             }

--- a/packages/kit/src/components/TxHistoryListView/index.tsx
+++ b/packages/kit/src/components/TxHistoryListView/index.tsx
@@ -85,21 +85,36 @@ const CHANGE_LINE_HEIGHT = 24;
 // and send-to-self rows collapse to fewer): over-counting only reserves a
 // slightly taller fixed height (a harmless trailing gap), never a shorter one
 // (which would clip the row into the next).
+// getWebRowHeight runs in the scroll measurement hot path and may query the
+// same row repeatedly; cache the line count by tx object identity so
+// getDisplayedActions + Set construction run at most once per tx. The count is
+// intrinsic to the tx's transfers (independent of tableLayout) and the tx's
+// token set is stable across pending -> confirmed, so sharing one cache is
+// safe. Keyed by the IAccountHistoryTx reference, entries are GC'd when the
+// list data is replaced.
+const transferChangeLineCountCache = new WeakMap<IAccountHistoryTx, number>();
+
 function getTransferChangeLineCount(item: IAccountHistoryTx): number {
-  const action = getDisplayedActions({ decodedTx: item.decodedTx })[0];
-  if (
-    action?.type !== EDecodedTxActionType.ASSET_TRANSFER ||
-    !action.assetTransfer
-  ) {
-    return 1;
+  const cached = transferChangeLineCountCache.get(item);
+  if (cached !== undefined) {
+    return cached;
   }
-  const { sends, receives } = action.assetTransfer;
-  const sendTokenCount = new Set((sends ?? []).map((t) => t.tokenIdOnNetwork))
-    .size;
-  const receiveTokenCount = new Set(
-    (receives ?? []).map((t) => t.tokenIdOnNetwork),
-  ).size;
-  return sendTokenCount + receiveTokenCount;
+  const action = getDisplayedActions({ decodedTx: item.decodedTx })[0];
+  let changeLineCount = 1;
+  if (
+    action?.type === EDecodedTxActionType.ASSET_TRANSFER &&
+    action.assetTransfer
+  ) {
+    const { sends, receives } = action.assetTransfer;
+    const sendTokenCount = new Set((sends ?? []).map((t) => t.tokenIdOnNetwork))
+      .size;
+    const receiveTokenCount = new Set(
+      (receives ?? []).map((t) => t.tokenIdOnNetwork),
+    ).size;
+    changeLineCount = sendTokenCount + receiveTokenCount;
+  }
+  transferChangeLineCountCache.set(item, changeLineCount);
+  return changeLineCount;
 }
 
 type IProps = {

--- a/packages/kit/src/components/TxHistoryListView/index.tsx
+++ b/packages/kit/src/components/TxHistoryListView/index.tsx
@@ -23,12 +23,16 @@ import {
   convertToSectionGroups,
   getFilteredHistoryBySearchKey,
 } from '@onekeyhq/shared/src/utils/historyUtils';
+import { getDisplayedActions } from '@onekeyhq/shared/src/utils/txActionUtils';
 import type {
   IAccountHistoryTx,
   IHistoryListSectionGroup,
 } from '@onekeyhq/shared/types/history';
 import type { ITokenFiat } from '@onekeyhq/shared/types/token';
-import { EDecodedTxStatus } from '@onekeyhq/shared/types/tx';
+import {
+  EDecodedTxActionType,
+  EDecodedTxStatus,
+} from '@onekeyhq/shared/types/tx';
 
 import { useAccountData } from '../../hooks/useAccountData';
 import { useBlockExplorerNavigation } from '../../hooks/useBlockExplorerNavigation';
@@ -53,6 +57,35 @@ import { TxHistoryListItem } from './TxHistoryListItem';
 const TX_ROW_HEIGHT = 68;
 const SECTION_HEADER_HEIGHT_FIRST = 32; // mt=$0 on first section
 const SECTION_HEADER_HEIGHT_NEXT = 52; // mt=$5 (~20px) on subsequent sections
+
+// In tableLayout, an ASSET_TRANSFER row renders one change line per grouped
+// token (grouped sends + grouped receives — see `buildExpandedTransferView` in
+// TxActionTransfer.tsx). TX_ROW_HEIGHT only fits up to this many lines; rows
+// with more would overflow into the next row, so we measure them instead of
+// pinning a fixed height (see getWebRowHeight below).
+const MAX_FIXED_HEIGHT_CHANGE_LINES = 2;
+
+// Count how many change lines the expanded transfer view will render for a row.
+// Returns 1 for non-transfer actions (approve / function call / unknown only
+// ever render a single change line in tableLayout). Distinct send + receive
+// token counts are a safe upper bound on the rendered lines: over-counting only
+// pushes a row onto the (correct) measured path, never the other way around.
+function getTransferChangeLineCount(item: IAccountHistoryTx): number {
+  const action = getDisplayedActions({ decodedTx: item.decodedTx })[0];
+  if (
+    action?.type !== EDecodedTxActionType.ASSET_TRANSFER ||
+    !action.assetTransfer
+  ) {
+    return 1;
+  }
+  const { sends, receives } = action.assetTransfer;
+  const sendTokenCount = new Set((sends ?? []).map((t) => t.tokenIdOnNetwork))
+    .size;
+  const receiveTokenCount = new Set(
+    (receives ?? []).map((t) => t.tokenIdOnNetwork),
+  ).size;
+  return sendTokenCount + receiveTokenCount;
+}
 
 type IProps = {
   data: IAccountHistoryTx[];
@@ -419,6 +452,17 @@ function BaseTxHistoryListView(props: IProps) {
               if (info.item?.decodedTx?.status === EDecodedTxStatus.Pending) {
                 return undefined;
               }
+              // A multi-token transfer renders more change lines than the fixed
+              // height can hold (tableLayout only). Let CellMeasurer measure it
+              // so the row expands naturally instead of overflowing the next.
+              if (
+                tableLayout &&
+                info.item &&
+                getTransferChangeLineCount(info.item) >
+                  MAX_FIXED_HEIGHT_CHANGE_LINES
+              ) {
+                return undefined;
+              }
               return TX_ROW_HEIGHT;
             }
             // header / footer (loading / "load more" buttons) aren't a fixed
@@ -426,7 +470,7 @@ function BaseTxHistoryListView(props: IProps) {
             return undefined;
           }
         : undefined,
-    [inTabList],
+    [inTabList, tableLayout],
   );
 
   const itemCounts = useMemo(() => {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55494](https://onekeyhq.atlassian.net/browse/OK-55494)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Multi-token `ASSET_TRANSFER` rows (e.g. a swap with 1 receive + 2 sends) rendered more change lines than the fixed web/desktop history row height could hold, so they overflowed into the next row.
- On the web/desktop `tableLayout` fast path, `getWebRowHeight` now returns an exact taller height for these rows (`TX_ROW_HEIGHT + (changeLineCount - 2) * CHANGE_LINE_HEIGHT`) instead of pinning a too-short fixed height — keeping rows on the CellMeasurer-free fast-scroll path.
- The per-row change-line count is memoized (`WeakMap` keyed by tx identity) so the hot measurement path stays cheap.

## Intent & Context
The web/desktop history list uses a fixed-height fast path (`getWebRowHeight`) to bypass react-virtualized's `CellMeasurer`, positioning rows synchronously during scroll to avoid blank/oscillation jank. The fixed `TX_ROW_HEIGHT = 68` only fits up to 2 change lines. An `ASSET_TRANSFER` row renders one change line per grouped token (grouped sends + grouped receives), so transfers touching 3+ tokens (commonly swaps or multi-asset sends) exceeded the fixed height and visually overflowed into the following row.

## Root Cause
`getWebRowHeight` pinned every confirmed row to `TX_ROW_HEIGHT` regardless of how many change lines its transfer would actually render. Rows whose expanded transfer view exceeds 2 lines need more vertical space than the constant provides.

## Design Decisions
- **Exact fixed height over async measurement**: An earlier iteration returned `undefined` for multi-token rows so `CellMeasurer` would measure them, but that reintroduced the fast-scroll blank/oscillation the fixed-height path exists to avoid. The row geometry is linear and predictable (each extra change line = one `$bodyMd` line, lineHeight 20, plus the changes column's `$1` gap of 4 = `CHANGE_LINE_HEIGHT = 24`), so we compute the exact taller height and keep every confirmed row on the CellMeasurer-free path. Pending rows still measure (variable speed-up buttons).
- **Safe upper-bound count**: `getTransferChangeLineCount` counts distinct send + receive tokens, which is an upper bound on rendered lines (send-to-self and UTXO single-token rows collapse to fewer). Over-counting only reserves a slightly taller height (a harmless trailing gap) and never clips a row into the next.
- **Locked invariants via comments**: `renderTransferLine` must stay one line per token (documented in `TxActionTransfer.tsx`), and the geometry constants are tied to the `TxActionCommon` / `TxActionTransfer` layout.
- **Memoization**: `getWebRowHeight` runs on every virtualized row measurement (including full-list content-height passes), so the count is cached in a `WeakMap` keyed by the tx object identity; entries are GC'd when the list data is replaced.

## Changes Detail
- `packages/kit/src/components/TxHistoryListView/index.tsx`:
  - Add `MAX_FIXED_HEIGHT_CHANGE_LINES` and `CHANGE_LINE_HEIGHT` geometry constants (documented against the `TxActionCommon` layout).
  - Add `getTransferChangeLineCount(item)` (memoized via `WeakMap`) to count the change lines a row will render.
  - In `getWebRowHeight`, return the exact taller height for multi-token transfer rows on `tableLayout`; add `tableLayout` to the callback deps.
- `packages/kit/src/components/TxAction/TxActionTransfer.tsx`:
  - Add an INVARIANT comment to `buildExpandedTransferView` documenting that each transfer line is single-height (the assumption `CHANGE_LINE_HEIGHT` depends on).

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web, Desktop (only the `tableLayout` web fast path; native is unaffected — the `List.tsx` web fast path is not on the native code path)
- **Risk Areas**: The geometry constants (`TX_ROW_HEIGHT = 68`, `CHANGE_LINE_HEIGHT = 24`) are coupled by comment to the `TxActionCommon` / `TxActionTransfer` layout; if that padding / line-height changes, these must be updated. Mis-estimation degrades gracefully (over-count → trailing gap); clipping only occurs if a new change-line category is added without updating the count.

## Test plan
- [ ] Web/Desktop: open a wallet with a 3+ token transfer in history (e.g. a swap with 1 receive + 2 sends); confirm the row expands fully and does not overlap the next row.
- [ ] Fast-scroll a long history list containing multi-token rows; confirm no blank/oscillation and stable row positions (no fallback to async measurement).
- [ ] Verify single / 2-token rows keep the standard 68px height.
- [ ] Edge cases: send-to-self, UTXO (BTC) single-token, pure NFT, approve / contract-call rows render at correct height with no overlap.
- [ ] Regression: native (iOS/Android) history list unaffected.

[OK-55494]: https://onekeyhq.atlassian.net/browse/OK-55494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ