### PR TITLE
fix(ada): Android software-wallet Cardano address creation stuck loading

### DIFF
--- a/apps/mobile/background.ts
+++ b/apps/mobile/background.ts
@@ -46,20 +46,30 @@ bgEntryLog(`polyfills loaded (+${Date.now() - bgEntryStart}ms)`);
 // never used.
 function applyAndroidBgNextTickFix() {
   const { Platform } = require('react-native') as typeof import('react-native');
-  const g = globalThis as any;
+  const g = globalThis as unknown as {
+    process?: {
+      nextTick?: (
+        callback: (...args: unknown[]) => void,
+        ...args: unknown[]
+      ) => void;
+    };
+    setImmediate?: (callback: () => void) => void;
+  };
+  const proc = g.process;
+  const setImmediateFn = g.setImmediate;
   if (
     Platform.OS !== 'android' ||
-    !g.process ||
-    typeof g.process.nextTick !== 'function' ||
-    typeof g.setImmediate !== 'function'
+    !proc ||
+    typeof proc.nextTick !== 'function' ||
+    typeof setImmediateFn !== 'function'
   ) {
     return;
   }
-  g.process.nextTick = function nextTickViaSetImmediate(
-    callback: (...args: any[]) => void,
-    ...args: any[]
+  proc.nextTick = function nextTickViaSetImmediate(
+    callback: (...args: unknown[]) => void,
+    ...args: unknown[]
   ) {
-    g.setImmediate(() => {
+    setImmediateFn(() => {
       callback(...args);
     });
   };

--- a/apps/mobile/background.ts
+++ b/apps/mobile/background.ts
@@ -25,6 +25,48 @@ const bgEntryLog = (msg: string) => {
 const bgEntryStart: number = (globalThis as any).__ONEKEY_BG_ENTRY_START__;
 bgEntryLog(`polyfills loaded (+${Date.now() - bgEntryStart}ms)`);
 
+// Android background-runtime `process.nextTick` fix.
+//
+// The npm `process` polyfill drives its private nextTick queue via a
+// `setTimeout` it caches at module-load time. On the Android background JS
+// runtime that load precedes RN wiring up timers, so the first
+// `runTimeout(drainQueue)` fails and the queue never drains again — verified on
+// device: the queue grows monotonically and drainQueue never runs, while
+// setTimeout / setImmediate / queueMicrotask / Promise.then all work. Any code
+// relying on `process.nextTick` to deliver a result then hangs forever — e.g.
+// npm `pbkdf2`'s async callback used by cardano-crypto.js `mnemonicToRootKeypair`,
+// which made software-wallet Cardano address creation load forever on Android
+// (iOS / hardware wallet were unaffected: hardware derives on-device, and the
+// iOS background runtime drains nextTick normally).
+//
+// Redirect `process.nextTick` to the verified-working `setImmediate`. Scoped to
+// Android, applied here in the background-thread entry (so the main thread is
+// untouched), and only when a `process.nextTick` exists — done right after the
+// polyfill loads and before anything uses nextTick, so the broken queue is
+// never used.
+function applyAndroidBgNextTickFix() {
+  const { Platform } = require('react-native') as typeof import('react-native');
+  const g = globalThis as any;
+  if (
+    Platform.OS !== 'android' ||
+    !g.process ||
+    typeof g.process.nextTick !== 'function' ||
+    typeof g.setImmediate !== 'function'
+  ) {
+    return;
+  }
+  g.process.nextTick = function nextTickViaSetImmediate(
+    callback: (...args: any[]) => void,
+    ...args: any[]
+  ) {
+    g.setImmediate(() => {
+      callback(...args);
+    });
+  };
+  bgEntryLog('process.nextTick -> setImmediate (android background runtime)');
+}
+applyAndroidBgNextTickFix();
+
 // Install production split bundle loader for background runtime (Phase 3).
 // Uses BackgroundThread.loadSegmentInBackground to register segments
 // with the background Hermes runtime.


### PR DESCRIPTION
## Problem

On Android, **software-wallet** Cardano (ADA) address creation hangs on a
loading spinner forever. Hardware wallet is fine; iOS is fine.

## Root cause (confirmed with on-device tracing)

On the v6.3.0 native **background JS runtime** (#10969), the npm `process`
polyfill's `process.nextTick` queue **never drains**. The polyfill caches
`setTimeout` into a private `cachedSetTimeout` at module-load time, but on the
background runtime that load happens **before RN has wired up timers**, so the
very first `runTimeout(drainQueue)` fails and the queue never recovers
(on-device trace: the queue grows monotonically `52→120`, `drainQueue` never
runs, while `setTimeout` / `setImmediate` / `queueMicrotask` / `Promise.then`
all work).

Any code that relies on `process.nextTick` to deliver a result then hangs
forever — here it is npm `pbkdf2`'s async callback used by `cardano-crypto.js`
`mnemonicToRootKeypair`: the PBKDF2 result is actually computed (96 bytes), but
delivering the callback through `process.nextTick` is lost, so the `await`
never resolves and address creation spins forever.

Hardware wallet derives on-device and never runs this path; the iOS background
runtime drains nextTick normally — hence both are unaffected.

## Fix

In the **Android background-thread entry** (`apps/mobile/background.ts`), right
after the polyfills load and before anything calls nextTick, redirect
`process.nextTick` to the **verified-working** `setImmediate`. Tightly scoped:

- Android only (the iOS background runtime drains nextTick fine);
- background-thread entry only (the main thread is untouched);
- only when a `process.nextTick` actually exists to replace.

## Verification

Reproduced both before and after the fix on device (diagnostic instrumentation
was kept on a separate branch and is **not** part of this PR):

- Before: `probe.processNextTick` logged `start` with no `done`; the pbkdf2
  callback never fired → hang.
- After: `probe.processNextTick` logs both `start` and `done`;
  `mnemonicToRootKeypair` completes in ~400ms; address creation succeeds
  instantly across repeated attempts.

Single-file change (`apps/mobile/background.ts`). tsc / lint pass.