### PR TITLE
fix: update perps referral learn more link

### DIFF
--- a/packages/kit/src/hooks/useReferFriends.tsx
+++ b/packages/kit/src/hooks/useReferFriends.tsx
@@ -16,7 +16,6 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { FormatHyperlinkText } from '@onekeyhq/kit/src/components/HyperlinkText';
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import {
-  PERPS_CAMPAIGN_HELP_LINK,
   REFERRAL_HELP_LINK,
   buildReferralUrl,
 } from '@onekeyhq/shared/src/config/appConfig';
@@ -432,12 +431,10 @@ export const useReferFriends = () => {
           id: ETranslations.referral_intro_learn_more,
         }),
         onCancel: () => {
-          const learnMoreUrl =
-            source === 'Perps' ? PERPS_CAMPAIGN_HELP_LINK : REFERRAL_HELP_LINK;
           if (platformEnv.isDesktop || platformEnv.isNative) {
-            openUrlInDiscovery({ url: learnMoreUrl });
+            openUrlInDiscovery({ url: REFERRAL_HELP_LINK });
           } else {
-            openUrlExternal(learnMoreUrl);
+            openUrlExternal(REFERRAL_HELP_LINK);
           }
         },
         onConfirmText: intl.formatMessage({

--- a/packages/shared/src/config/appConfig.ts
+++ b/packages/shared/src/config/appConfig.ts
@@ -36,7 +36,6 @@ export const DOWNLOAD_MOBILE_APP_URL =
   'https://onekey.so/download?client=mobile';
 export const REFERRAL_HELP_LINK = 'https://help.onekey.so/articles/11461266';
 export const CREATOR_PROGRAM_URL = 'https://creator.onekey.so/';
-export const PERPS_CAMPAIGN_HELP_LINK = 'https://campaign.onekey.so/perps-s1';
 export const COIN_CONTROL_HELP_LINK =
   'https://help.onekey.so/articles/13050014';
 export const HARDWARE_TROUBLESHOOTING_URL =


### PR DESCRIPTION
## Summary
- Point Perps Referral Learn more to the existing referral help center article instead of the stopped perps-s1 campaign page.
- Remove the obsolete Perps campaign help link constant.

## Test
- rg "PERPS_CAMPAIGN_HELP_LINK|perps-s1|campaign\.onekey\.so" packages apps --glob "!**/assets/**" --glob "!**/locale/json/**"
- npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/hooks/useReferFriends.tsx packages/shared/src/config/appConfig.ts
- yarn tsc:staged