### PR TITLE
fix: run perps enable trading before order confirm and size validation

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -842,16 +842,6 @@ function SideButtonInternal({
       }
 
       const latestOrderPanelState = latestOrderPanelStateRef.current;
-      if (
-        !validateOrderPanelState({
-          orderPanelState: latestOrderPanelState,
-          validationSide: side,
-          shouldValidateBboPriceError: !shouldEnableTradingBeforeOrder,
-        })
-      ) {
-        return;
-      }
-
       const latestPerpsCustomSettings =
         latestOrderPanelState.perpsCustomSettings;
 
@@ -885,59 +875,10 @@ function SideButtonInternal({
             perpsAccountKeyRef.current !== enableTradingAccountKey,
           );
 
-        if (!latestPerpsCustomSettings.skipOrderConfirm) {
-          showOrderConfirmDialog({
-            overrideSide: side,
-            intl,
-            enableTradingAccountKey,
-            enableTradingBeforeConfirm: async ({
-              closeDialog,
-              shouldIgnoreResult,
-            }) => {
-              const result = await requestOrderPanelEnableTrading({
-                beforeDeposit: closeDialog,
-                shouldIgnoreResult,
-                showLoadingToast: false,
-              });
-              const postEnableState = latestOrderPanelStateRef.current;
-              const postEnableTradingResult =
-                getPerpsOrderPanelPostEnableTradingResult({
-                  enableTradingShouldContinue: result.shouldContinue,
-                  shouldIgnoreEnableTradingResult: shouldIgnoreResult(),
-                  isOrderContextChanged:
-                    postEnableState.side !== enableTradingSide ||
-                    postEnableState.orderContextKey !==
-                      enableTradingOrderContextKey,
-                  isNoEnoughMargin: postEnableState.isNoEnoughMargin,
-                });
-              if (postEnableTradingResult === 'stop') {
-                return { ...result, shouldContinue: false };
-              }
-              if (postEnableTradingResult === 'noEnoughMargin') {
-                Toast.message({
-                  title: intl.formatMessage({
-                    id: postEnableState.isSpot
-                      ? ETranslations.dexmarket_insufficient_balance
-                      : ETranslations.perp_trading_button_no_enough_margin,
-                  }),
-                });
-                return { ...result, shouldContinue: false };
-              }
-              if (
-                !validateOrderPanelState({
-                  orderPanelState: postEnableState,
-                  validationSide: side,
-                  shouldValidateBboPriceError: true,
-                })
-              ) {
-                return { ...result, shouldContinue: false };
-              }
-              return result;
-            },
-          });
-          return;
-        }
-
+        // Enable trading MUST run before the order confirm dialog: the order
+        // panel first resolves the trading-enabled state (auto-enable or the
+        // hardware steps dialog), then shows the order confirmation. Do not
+        // defer this into the confirm dialog's pre-confirm hook.
         const result = await requestOrderPanelEnableTrading({
           shouldIgnoreResult: shouldIgnoreEnableTradingResult,
           showLoadingToast: shouldAutoEnableTrading,
@@ -965,16 +906,23 @@ function SideButtonInternal({
           });
           return;
         }
+      }
 
-        if (
-          !validateOrderPanelState({
-            orderPanelState: postEnableState,
-            validationSide: side,
-            shouldValidateBboPriceError: true,
-          })
-        ) {
-          return;
-        }
+      // Validate the order only AFTER trading is enabled (matching the
+      // original flow): a not-yet-enabled account has no margin/leverage data
+      // yet, so computedSizeForSide is 0 and a pre-enable size check would
+      // wrongly raise the "minimum $10" toast and swallow the enable-trading
+      // dialog. Running validation here covers both the just-enabled path and
+      // accounts that can already trade.
+      const validationState = latestOrderPanelStateRef.current;
+      if (
+        !validateOrderPanelState({
+          orderPanelState: validationState,
+          validationSide: side,
+          shouldValidateBboPriceError: true,
+        })
+      ) {
+        return;
       }
 
       if (latestPerpsCustomSettings.skipOrderConfirm) {


### PR DESCRIPTION
## Summary
- Restore the perps order-panel flow so enabling trading happens **before** the order confirm dialog, not inside its pre-confirm hook.
- Move order validation (`validateOrderPanelState`) back to **after** trading is enabled, so a not-yet-enabled account no longer gets blocked by the "minimum $10" toast.

## Intent & Context
Follow-up fixes to #11820 ("update perps enable trading flow"). During self-testing two behavior deviations were found that did not match the PR's original intent:

1. Clicking Long/Short on an account that still needs to enable trading popped the **order confirm dialog first**, then the enable-trading dialog — the reverse of the intended "enable trading first, then confirm order" flow.
2. Clicking Long/Short on a **new account** raised a "minimum $10" toast instead of showing the enable-trading dialog.

Both were introduced by code-review changes layered on top of the PR's initial commit (`acc3fde1`), whose `handlePress` ordering was: enable trading → validate order → show order confirm.

## Root Cause
- **Issue 1**: Review moved the enable-trading call into `showOrderConfirmDialog`'s `enableTradingBeforeConfirm` hook, so it only ran *after* the user pressed Confirm in the order dialog.
- **Issue 2**: Review extracted validation into `validateOrderPanelState` and added a **pre-enable** validation pass. A not-yet-enabled account has no margin/leverage data, so `computedSizeForSide` is `0`; the pre-enable size check then fired the "minimum $10" toast and returned early, swallowing the enable-trading dialog.

## Design Decisions
- Reordered `handlePress` to match the PR's original (`acc3fde1`) intent:
  `early guard → enable trading (deposit-aware margin pre-check + post-enable stop/margin checks) → validate order → confirm order`.
- Removed the embedded `enableTradingBeforeConfirm` branch and the pre-enable `validateOrderPanelState` call; kept a single validation pass after enabling that covers both the just-enabled path and accounts that can already trade.
- Kept the deposit-aware `shouldBlockPerpsOrderPanelPreEnableTradingForMargin` guard (it is gated by `isDepositRequired` and does not cause the reported bug).

## Changes Detail
- `packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx`
  - `handlePress`: enable trading runs before the order confirm dialog; validation runs after enabling. Removed the order-confirm-embedded enable hook and the pre-enable validation pass.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Mobile / Web / Extension (shared perps order panel)
- **Risk Areas**: Order entry / enable-trading sequencing for software (auto-enable) and hardware (steps dialog) accounts; `skipOrderConfirm` path.

## Test plan
- [ ] New / not-yet-enabled account, click Long/Short → enable-trading dialog shows first (no "minimum $10" toast). Hardware: device signing steps; software: auto-enable + accept terms.
- [ ] After enabling, order is validated (size / price / TP-SL), then the order confirm dialog appears.
- [ ] Account that can already trade → order confirm dialog appears directly (unchanged).
- [ ] `skipOrderConfirm` enabled → after enabling, order is placed directly without the confirm dialog.
- [ ] Invalid size after enabling still raises the correct "minimum $10" / size toast.
- [ ] Verified on Desktop and iOS.
