### PR TITLE
fix: add market banner detail change sorting(OK-55439)

### DIFF
--- a/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
+++ b/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useRoute } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
@@ -16,14 +16,9 @@ import {
 } from '@onekeyhq/components';
 import { HeaderButtonGroup } from '@onekeyhq/components/src/layouts/Navigation/Header';
 import { useTabBarHeight } from '@onekeyhq/components/src/layouts/Page/hooks';
-import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { HeaderNotificationIconButton } from '@onekeyhq/kit/src/components/TabPageHeader/components/HeaderNotificationIconButton';
-import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
-import {
-  EJotaiContextStoreNames,
-  useMarketBannerListSortAtom,
-} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   ECopyFrom,
@@ -46,14 +41,11 @@ import { TokenListItem } from '../MarketHomeV2/components/MarketTokenList/compon
 import { TokenListSkeleton } from '../MarketHomeV2/components/MarketTokenList/components/TokenListSkeleton';
 import { useToDetailPage } from '../MarketHomeV2/components/MarketTokenList/hooks/useToMarketDetailPage';
 import { MarketTokenListBase } from '../MarketHomeV2/components/MarketTokenList/MarketTokenListBase';
-import {
-  getNetworkLogoUri,
-  transformApiItemToToken,
-} from '../MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers';
 import { MarketWatchListProviderMirrorV2 } from '../MarketWatchListProviderMirrorV2';
 import { MarketTestIDs } from '../testIDs';
 
 import { PerpsTokenListSection } from './PerpsTokenListSection';
+import { useMarketBannerDetail } from './useMarketBannerDetail';
 
 import type { IMarketToken } from '../MarketHomeV2/components/MarketTokenList/MarketTokenData';
 import type { EModalMarketRoutes, IModalMarketParamList } from '../router';
@@ -76,11 +68,14 @@ function MarketBannerDetailContent({ title }: { title: string }) {
   const tabBarHeight = useTabBarHeight();
   const { gtMd } = useMedia();
 
-  const [bannerSort, setBannerSort] = useMarketBannerListSortAtom();
-  const sortRef = useRef(bannerSort);
-  sortRef.current = bannerSort;
-
   const isWebDesktop = (platformEnv.isWeb || platformEnv.isDesktop) && gtMd;
+  const {
+    changeSortType,
+    handleChangeSortPress,
+    listResult,
+    mobileSortedData,
+    tickerIsLoading,
+  } = useMarketBannerDetail({ tokenListId, isPerps });
 
   const renderHeaderLeft = useCallback(
     () => <NavBackButton onPress={handleBackPress} />,
@@ -107,35 +102,6 @@ function MarketBannerDetailContent({ title }: { title: string }) {
     [],
   );
 
-  // Ticker (spot) data fetching
-  const { result: tickerResult, isLoading: tickerIsLoading } = usePromiseResult(
-    async () => {
-      if (isPerps) return null;
-      const data =
-        await backgroundApiProxy.serviceMarketV2.fetchMarketBannerTokenList({
-          tokenListId,
-        });
-      return data;
-    },
-    [tokenListId, isPerps],
-    {
-      watchLoading: true,
-    },
-  );
-
-  const transformedData = useMemo(() => {
-    if (!tickerResult) return [];
-    return tickerResult.map((item, index) => {
-      const chainId = item.networkId || '';
-      const networkLogoUri = getNetworkLogoUri(chainId);
-      return transformApiItemToToken(item, {
-        chainId,
-        networkLogoUri,
-        sortIndex: index,
-      });
-    });
-  }, [tickerResult]);
-
   const handleItemPress = useCallback(
     (item: IMarketToken) => {
       void toDetailPage({
@@ -156,43 +122,6 @@ function MarketBannerDetailContent({ title }: { title: string }) {
   );
 
   const bannerKeyExtractor = useCallback((item: IMarketToken) => item.id, []);
-
-  const setSortBy = useCallback(
-    (val: string | undefined) => {
-      const next = { ...sortRef.current, sortBy: val };
-      sortRef.current = next;
-      setBannerSort(next);
-    },
-    [setBannerSort],
-  );
-
-  const setSortType = useCallback(
-    (val: 'asc' | 'desc' | undefined) => {
-      const next = { ...sortRef.current, sortType: val };
-      sortRef.current = next;
-      setBannerSort(next);
-    },
-    [setBannerSort],
-  );
-
-  const listResult = useMemo(
-    () => ({
-      data: transformedData,
-      isLoading: tickerIsLoading,
-      setSortBy,
-      setSortType,
-      currentSortBy: bannerSort.sortBy,
-      currentSortType: bannerSort.sortType,
-    }),
-    [
-      transformedData,
-      tickerIsLoading,
-      setSortBy,
-      setSortType,
-      bannerSort.sortBy,
-      bannerSort.sortType,
-    ],
-  );
 
   const renderPageHeader = useMemo(() => {
     if (isWebDesktop) {
@@ -246,20 +175,28 @@ function MarketBannerDetailContent({ title }: { title: string }) {
     }
     // Native mobile: use FlatList + TokenListItem to match watchlist layout
     if (platformEnv.isNative && !gtMd) {
-      if (tickerIsLoading && transformedData.length === 0) {
+      if (tickerIsLoading && mobileSortedData.length === 0) {
         return (
           <Stack flex={1}>
-            <MarketListColumnHeader />
+            <MarketListColumnHeader
+              changeSortType={changeSortType}
+              changeSortTestID={MarketTestIDs.sortByChange}
+              onChangeSortPress={handleChangeSortPress}
+            />
             <TokenListSkeleton count={15} />
           </Stack>
         );
       }
       return (
         <Stack flex={1}>
-          <MarketListColumnHeader />
+          <MarketListColumnHeader
+            changeSortType={changeSortType}
+            changeSortTestID={MarketTestIDs.sortByChange}
+            onChangeSortPress={handleChangeSortPress}
+          />
           <FlatList<IMarketToken>
             style={{ flex: 1 }}
-            data={transformedData}
+            data={mobileSortedData}
             renderItem={renderBannerItem}
             keyExtractor={bannerKeyExtractor}
             showsVerticalScrollIndicator={false}
@@ -279,7 +216,7 @@ function MarketBannerDetailContent({ title }: { title: string }) {
               </Stack>
             }
             ListFooterComponent={
-              transformedData.length > 0 ? <ListEndIndicator /> : null
+              mobileSortedData.length > 0 ? <ListEndIndicator /> : null
             }
           />
         </Stack>
@@ -321,7 +258,9 @@ function MarketBannerDetailContent({ title }: { title: string }) {
     handleItemPress,
     gtMd,
     tickerIsLoading,
-    transformedData,
+    mobileSortedData,
+    changeSortType,
+    handleChangeSortPress,
     renderBannerItem,
     bannerKeyExtractor,
     tabBarHeight,

--- a/packages/kit/src/views/Market/MarketBannerDetail/useMarketBannerDetail/index.ts
+++ b/packages/kit/src/views/Market/MarketBannerDetail/useMarketBannerDetail/index.ts
@@ -1,0 +1,137 @@
+import { useCallback, useMemo, useRef } from 'react';
+
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { useMarketBannerListSortAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+
+import {
+  getNetworkLogoUri,
+  transformApiItemToToken,
+} from '../../MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers';
+
+import type { IMarketTokenListResult } from '../../MarketHomeV2/components/MarketTokenList/MarketTokenListBase';
+
+const BANNER_DETAIL_CHANGE_SORT_BY = 'change24h';
+
+type IUseMarketBannerDetailParams = {
+  tokenListId: string;
+  isPerps: boolean;
+};
+
+export function useMarketBannerDetail({
+  tokenListId,
+  isPerps,
+}: IUseMarketBannerDetailParams) {
+  const [bannerSort, setBannerSort] = useMarketBannerListSortAtom();
+  const sortRef = useRef(bannerSort);
+  sortRef.current = bannerSort;
+
+  const { result: tickerResult, isLoading: tickerIsLoading } = usePromiseResult(
+    async () => {
+      if (isPerps) return null;
+      const data =
+        await backgroundApiProxy.serviceMarketV2.fetchMarketBannerTokenList({
+          tokenListId,
+        });
+      return data;
+    },
+    [tokenListId, isPerps],
+    {
+      watchLoading: true,
+    },
+  );
+
+  const transformedData = useMemo(() => {
+    if (!tickerResult) return [];
+    return tickerResult.map((item, index) => {
+      const chainId = item.networkId || '';
+      const networkLogoUri = getNetworkLogoUri(chainId);
+      return transformApiItemToToken(item, {
+        chainId,
+        networkLogoUri,
+        sortIndex: index,
+      });
+    });
+  }, [tickerResult]);
+
+  const changeSortType =
+    bannerSort.sortBy === BANNER_DETAIL_CHANGE_SORT_BY
+      ? bannerSort.sortType
+      : undefined;
+
+  const mobileSortedData = useMemo(() => {
+    if (!changeSortType) {
+      return transformedData;
+    }
+
+    return transformedData.toSorted((a, b) =>
+      changeSortType === 'asc'
+        ? a.change24h - b.change24h
+        : b.change24h - a.change24h,
+    );
+  }, [changeSortType, transformedData]);
+
+  const setSortBy = useCallback(
+    (val: string | undefined) => {
+      const next = { ...sortRef.current, sortBy: val };
+      sortRef.current = next;
+      setBannerSort(next);
+    },
+    [setBannerSort],
+  );
+
+  const setSortType = useCallback(
+    (val: 'asc' | 'desc' | undefined) => {
+      const next = { ...sortRef.current, sortType: val };
+      sortRef.current = next;
+      setBannerSort(next);
+    },
+    [setBannerSort],
+  );
+
+  const handleChangeSortPress = useCallback(() => {
+    const currentSortType =
+      sortRef.current.sortBy === BANNER_DETAIL_CHANGE_SORT_BY
+        ? sortRef.current.sortType
+        : undefined;
+    let nextSortType: 'asc' | 'desc' | undefined = 'desc';
+    if (currentSortType === 'desc') {
+      nextSortType = 'asc';
+    } else if (currentSortType === 'asc') {
+      nextSortType = undefined;
+    }
+    const next = {
+      sortBy: nextSortType ? BANNER_DETAIL_CHANGE_SORT_BY : undefined,
+      sortType: nextSortType,
+    };
+    sortRef.current = next;
+    setBannerSort(next);
+  }, [setBannerSort]);
+
+  const listResult = useMemo<IMarketTokenListResult>(
+    () => ({
+      data: transformedData,
+      isLoading: tickerIsLoading,
+      setSortBy,
+      setSortType,
+      currentSortBy: bannerSort.sortBy,
+      currentSortType: bannerSort.sortType,
+    }),
+    [
+      transformedData,
+      tickerIsLoading,
+      setSortBy,
+      setSortType,
+      bannerSort.sortBy,
+      bannerSort.sortType,
+    ],
+  );
+
+  return {
+    changeSortType,
+    handleChangeSortPress,
+    listResult,
+    mobileSortedData,
+    tickerIsLoading,
+  };
+}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketListColumnHeader.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketListColumnHeader.tsx
@@ -2,21 +2,35 @@ import { memo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { SizableText, XStack } from '@onekeyhq/components';
+import { Icon, SizableText, XStack } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
-function MarketListColumnHeaderBase() {
+type IMarketListColumnHeaderProps = {
+  changeSortType?: 'asc' | 'desc';
+  changeSortTestID?: string;
+  onChangeSortPress?: () => void;
+};
+
+function MarketListColumnHeaderBase({
+  changeSortType,
+  changeSortTestID,
+  onChangeSortPress,
+}: IMarketListColumnHeaderProps) {
   const intl = useIntl();
+  let sortIconName:
+    | 'ChevronDownSmallOutline'
+    | 'ChevronTopSmallOutline'
+    | 'ChevronGrabberVerOutline' = 'ChevronGrabberVerOutline';
+  if (changeSortType === 'desc') {
+    sortIconName = 'ChevronDownSmallOutline';
+  } else if (changeSortType === 'asc') {
+    sortIconName = 'ChevronTopSmallOutline';
+  }
 
   return (
-    <XStack mx="$2">
+    <XStack px="$5">
       <XStack jc="flex-start" ai="center" width="50%">
-        <SizableText
-          color="$textSubdued"
-          size="$bodySmMedium"
-          py="$2"
-          paddingLeft="$5"
-        >
+        <SizableText color="$textSubdued" size="$bodySmMedium" py="$2">
           {`${intl.formatMessage({
             id: ETranslations.global_name,
           })} / ${intl.formatMessage({
@@ -29,7 +43,6 @@ function MarketListColumnHeaderBase() {
           justifyContent="flex-end"
           alignItems="center"
           gap="$2"
-          pr="$5"
           py="$2"
           width="100%"
         >
@@ -41,16 +54,30 @@ function MarketListColumnHeaderBase() {
           >
             {intl.formatMessage({ id: ETranslations.global_price })}
           </SizableText>
-          <SizableText
-            color="$textSubdued"
-            size="$bodySmMedium"
+          <XStack
+            alignItems="center"
+            justifyContent="flex-end"
             width="$20"
-            textAlign="center"
+            onPress={onChangeSortPress}
+            pressStyle={onChangeSortPress ? { opacity: 0.8 } : undefined}
+            cursor={onChangeSortPress ? 'pointer' : undefined}
+            testID={changeSortTestID}
           >
-            {intl.formatMessage({
-              id: ETranslations.dexmarket_token_change,
-            })}
-          </SizableText>
+            <SizableText
+              color="$textSubdued"
+              size="$bodySmMedium"
+              textAlign="right"
+              numberOfLines={1}
+              flexShrink={1}
+            >
+              {intl.formatMessage({
+                id: ETranslations.dexmarket_token_change,
+              })}
+            </SizableText>
+            {onChangeSortPress ? (
+              <Icon name={sortIconName} color="$iconSubdued" size="$4" />
+            ) : null}
+          </XStack>
         </XStack>
       </XStack>
     </XStack>


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55439](https://onekeyhq.atlassian.net/browse/OK-55439)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Add local Change sorting to the native mobile Market banner detail token list.
- Keep the mobile banner detail header aligned with token rows.
- Move banner detail fetch, transform, and sort state into `useMarketBannerDetail`.

## Intent & Context
The mobile Market banner detail page uses a token table where the Change column should be clickable for local sorting. The header also needed alignment fixes so `Name / Turnover` starts with the row content and `Change` aligns with the right edge of the value column.

## Root Cause
Native mobile banner detail uses a custom `FlatList` and `MarketListColumnHeader`, so the existing `MarketTokenListBase` client sort path did not apply. The header also had extra outer margin plus inner left and right padding, causing it to drift from the row content.

## Design Decisions
- Keep the native mobile `FlatList` path to preserve the existing watchlist-style row layout.
- Make only `Change` clickable as requested and reuse `useMarketBannerListSortAtom` for banner sort state.
- Sort locally by transformed `change24h` values; reset restores the backend order.
- Extract banner detail data and sort logic into `MarketBannerDetail/useMarketBannerDetail` so the page stays UI-focused.

## Changes Detail
- `MarketBannerDetail/useMarketBannerDetail/index.ts`: fetches banner spot tokens, transforms API rows, manages banner sort state, computes mobile sorted data, and returns the table `listResult`.
- `MarketBannerDetail.tsx`: consumes `useMarketBannerDetail`, wires mobile header sorting, and feeds sorted data into the native `FlatList`.
- `MarketListColumnHeader.tsx`: adds optional Change sort props, sort icon handling, click handling, and header alignment updates.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile primarily; shared header component is also used by Market mobile layouts.
- **Risk Areas**: Header spacing should be visually checked on both iOS and Android; persisted banner sort state can carry between banner detail visits as before.

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx packages/kit/src/views/Market/MarketBannerDetail/useMarketBannerDetail/index.ts packages/kit/src/views/Market/MarketHomeV2/components/MarketListColumnHeader.tsx --deny-warnings`
- [x] `yarn lint:staged`
- [ ] `yarn tsc:staged` (blocked by existing base errors unrelated to this change: quick-crypto types, hardware error enum names, and implicit-any callbacks in crypto files)
- [ ] `yarn test` (blocked by unrelated `packages/core/src/secret/encryptors/__tests__/aes256.test.ts` custom-iterations mismatch failure)
- [ ] Manual mobile verification: open a Market banner detail page, tap Change to cycle descending, ascending, and reset, and confirm Name/Turnover and Change headers align with token rows.

[OK-55439]: https://onekeyhq.atlassian.net/browse/OK-55439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ