### PR TITLE
fix: adjust browser header spacing(OK-55500)

### DIFF
--- a/packages/kit/src/views/Discovery/components/HeaderRightToolBar/index.tsx
+++ b/packages/kit/src/views/Discovery/components/HeaderRightToolBar/index.tsx
@@ -324,7 +324,6 @@ function HeaderRightToolBar() {
     if (connectedAccountsInfo.length === 1) {
       return (
         <Stack
-          ml="$6"
           gap="$6"
           $gtMd={{
             width: platformEnv.isNative ? undefined : '100%',
@@ -363,7 +362,7 @@ function HeaderRightToolBar() {
       );
     }
     return (
-      <Stack ml="$6">
+      <Stack>
         <Popover
           key={`popover-${connectedAccountsInfo.length}-${connectedAccountsInfo
             .map((a) => a.num)


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55500](https://onekeyhq.atlassian.net/browse/OK-55500)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Remove the extra 24px left margin from the desktop Discovery browser connected-account toolbar.
- Keep the internal spacing between the network selector, account selector, and shortcut action unchanged.

## Intent & Context
Page feedback on the desktop browser module highlighted the top-right connected account area. The selected DOM node mapped through the shared desktop drag-zone wrapper, but the actual spacing came from the Discovery browser HeaderRightToolBar. The user asked why there was an internal 24px margin-left, then requested that the margin be removed.

## Root Cause
HeaderRightToolBar added ml="" on the outer wrapper for both single-account and multi-account connected dApp states. That token maps to 24px and pushed the connected account controls away from the address/header area. There was no functional dependency on this margin; it was a visual spacing value.

## Design Decisions
- Remove only the outer margin-left so the right-side content no longer gets the extra offset.
- Preserve gap="" inside the toolbar so the network selector and account selector keep their existing spacing.
- Temporarily forced the multi-account branch during review to confirm the multi-account trigger still looked acceptable, then reverted that preview-only mock.

## Changes Detail
- packages/kit/src/views/Discovery/components/HeaderRightToolBar/index.tsx: removes the outer ml="" from both single-account and multi-account connected-account wrappers.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop
- **Risk Areas**: Desktop Discovery browser header spacing for connected dApp account controls.

## Test plan
- [x] Run yarn lint:staged.
- [x] Run yarn tsc:staged.
- [x] Preview the desktop browser single-account header spacing.
- [x] Temporarily force the multi-account branch and confirm the trigger spacing remains acceptable.

[OK-55500]: https://onekeyhq.atlassian.net/browse/OK-55500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ