### PR TITLE
fix: stamp server dataTime for fresh sync writes(OK-55438)

### DIFF
--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -185,6 +185,34 @@ type IPreparedCredentialPasswordUpdate = {
   originalCredential: string;
 };
 
+type IAddAndUpdateSyncItemsParams = {
+  items: IDBCloudSyncItem[];
+  skipUpdate?: boolean;
+  skipUploadToServer?: boolean;
+  // OK-55438: forward to the upload so genuine "now" writes get a server stamp
+  useServerDataTime?: boolean;
+  fn?: () => Promise<void>;
+};
+
+type IAddAndUpdateFreshSyncItemsParams = Omit<
+  IAddAndUpdateSyncItemsParams,
+  'useServerDataTime'
+>;
+
+type ITxAddAndUpdateSyncItemsParams = {
+  tx: ILocalDBTransaction;
+  items: IDBCloudSyncItem[];
+  skipUpdate?: boolean;
+  skipUploadToServer?: boolean;
+  // OK-55438: forward to the upload so genuine "now" writes get a server stamp
+  useServerDataTime?: boolean;
+};
+
+type ITxAddAndUpdateFreshSyncItemsParams = Omit<
+  ITxAddAndUpdateSyncItemsParams,
+  'useServerDataTime'
+>;
+
 function getLocalPasswordKdfParams(): ILocalPasswordKdfParams {
   if (
     !platformEnv.isNative &&
@@ -2596,14 +2624,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     skipUploadToServer,
     useServerDataTime,
     fn,
-  }: {
-    items: IDBCloudSyncItem[];
-    skipUpdate?: boolean;
-    skipUploadToServer?: boolean;
-    // OK-55438: forward to the upload so genuine "now" writes get a server stamp
-    useServerDataTime?: boolean;
-    fn?: () => Promise<void>;
-  }) {
+  }: IAddAndUpdateSyncItemsParams) {
     if (items?.length) {
       // EIndexedDBBucketNames.cloudSync
 
@@ -2623,20 +2644,28 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     }
   }
 
+  async addAndUpdateFreshSyncItems({
+    items,
+    skipUpdate,
+    skipUploadToServer,
+    fn,
+  }: IAddAndUpdateFreshSyncItemsParams) {
+    await this.addAndUpdateSyncItems({
+      items,
+      skipUpdate,
+      skipUploadToServer,
+      useServerDataTime: true,
+      fn,
+    });
+  }
+
   async txAddAndUpdateSyncItems({
     tx,
     items,
     skipUpdate,
     skipUploadToServer,
     useServerDataTime,
-  }: {
-    tx: ILocalDBTransaction;
-    items: IDBCloudSyncItem[];
-    skipUpdate?: boolean;
-    skipUploadToServer?: boolean;
-    // OK-55438: forward to the upload so genuine "now" writes get a server stamp
-    useServerDataTime?: boolean;
-  }) {
+  }: ITxAddAndUpdateSyncItemsParams) {
     // add new item
     await this.txAddRecords({
       tx,
@@ -2671,6 +2700,21 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
         useServerDataTime,
       });
     }
+  }
+
+  async txAddAndUpdateFreshSyncItems({
+    tx,
+    items,
+    skipUpdate,
+    skipUploadToServer,
+  }: ITxAddAndUpdateFreshSyncItemsParams) {
+    await this.txAddAndUpdateSyncItems({
+      tx,
+      items,
+      skipUpdate,
+      skipUploadToServer,
+      useServerDataTime: true,
+    });
   }
 
   async removeCloudSyncPoolItems({ keys }: { keys: string[] }) {
@@ -4541,12 +4585,11 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     await this.withTransaction(EIndexedDBBucketNames.account, async (tx) => {
       // add or update sync item
       if (syncItem) {
-        await this.txAddAndUpdateSyncItems({
+        // OK-55438: rename is a genuine "now" write; let the server stamp
+        // dataTime so a fast local clock can't push it into the future.
+        await this.txAddAndUpdateFreshSyncItems({
           tx,
           items: [syncItem],
-          // OK-55438: rename is a genuine "now" write; let the server stamp
-          // dataTime so a fast local clock can't push it into the future.
-          useServerDataTime: true,
         });
       }
 
@@ -5909,12 +5952,11 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     await this.withTransaction(EIndexedDBBucketNames.account, async (tx) => {
       // add or update sync item
       if (syncItem) {
-        await this.txAddAndUpdateSyncItems({
+        // OK-55438: account/indexedAccount rename is a genuine "now" write;
+        // let the server stamp dataTime to avoid future timestamps.
+        await this.txAddAndUpdateFreshSyncItems({
           tx,
           items: [syncItem],
-          // OK-55438: account/indexedAccount rename is a genuine "now" write;
-          // let the server stamp dataTime to avoid future timestamps.
-          useServerDataTime: true,
         });
       }
 

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -3901,12 +3901,11 @@ class ServiceAccount extends ServiceBase {
         if (!latestSyncItem) {
           return;
         }
-        await this.backgroundApi.servicePrimeCloudSync.apiUploadItems({
+        // OK-55438: tombstone/create is a genuine "now" write; let the server
+        // stamp dataTime to serverNow.
+        await this.backgroundApi.servicePrimeCloudSync.apiUploadFreshItems({
           localItems: [latestSyncItem],
           noDebounceUpload: true,
-          // OK-55438: tombstone/create is a genuine "now" write; let the server
-          // stamp dataTime (it only clamps timestamps ahead of its own clock).
-          useServerDataTime: true,
         });
       })().catch((error) => {
         errorUtils.autoPrintErrorIgnore(error);
@@ -4013,12 +4012,11 @@ class ServiceAccount extends ServiceBase {
       if (!latestSyncItem) {
         return;
       }
-      await this.backgroundApi.servicePrimeCloudSync.apiUploadItems({
+      // OK-55438: deletion tombstone is a genuine "now" write; let the server
+      // stamp dataTime to serverNow.
+      await this.backgroundApi.servicePrimeCloudSync.apiUploadFreshItems({
         localItems: [latestSyncItem],
         noDebounceUpload: true,
-        // OK-55438: deletion tombstone is a genuine "now" write; let the server
-        // stamp dataTime (it only clamps timestamps ahead of its own clock).
-        useServerDataTime: true,
       });
     })().catch((error) => {
       errorUtils.autoPrintErrorIgnore(error);

--- a/packages/kit-bg/src/services/ServiceAddressBook.ts
+++ b/packages/kit-bg/src/services/ServiceAddressBook.ts
@@ -224,7 +224,7 @@ class ServiceAddressBook extends ServiceBase {
         isDeleted,
       });
     }
-    await this.backgroundApi.localDb.addAndUpdateSyncItems({
+    await this.backgroundApi.localDb.addAndUpdateFreshSyncItems({
       items: syncItems,
       fn,
     });

--- a/packages/kit-bg/src/services/ServiceCustomRpc.ts
+++ b/packages/kit-bg/src/services/ServiceCustomRpc.ts
@@ -135,7 +135,7 @@ class ServiceCustomRpc extends ServiceBase {
         isDeleted,
       });
     }
-    await this.backgroundApi.localDb.addAndUpdateSyncItems({
+    await this.backgroundApi.localDb.addAndUpdateFreshSyncItems({
       items: syncItems,
       fn,
     });
@@ -161,7 +161,7 @@ class ServiceCustomRpc extends ServiceBase {
         isDeleted,
       });
     }
-    await this.backgroundApi.localDb.addAndUpdateSyncItems({
+    await this.backgroundApi.localDb.addAndUpdateFreshSyncItems({
       items: syncItems,
       fn,
     });

--- a/packages/kit-bg/src/services/ServiceCustomToken.ts
+++ b/packages/kit-bg/src/services/ServiceCustomToken.ts
@@ -55,6 +55,7 @@ class ServiceCustomToken extends ServiceBase {
     customTokens,
     isDeleted,
     skipSaveLocalSyncItem,
+    useServerDataTime,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     skipEventEmit,
   }: {
@@ -62,6 +63,7 @@ class ServiceCustomToken extends ServiceBase {
     customTokens: ICloudSyncCustomToken[];
     isDeleted: boolean;
     skipSaveLocalSyncItem?: boolean;
+    useServerDataTime?: boolean;
     skipEventEmit?: boolean;
   }) {
     let syncItems: IDBCloudSyncItem[] = [];
@@ -70,6 +72,13 @@ class ServiceCustomToken extends ServiceBase {
         customTokens,
         isDeleted,
       });
+    }
+    if (useServerDataTime) {
+      await this.backgroundApi.localDb.addAndUpdateFreshSyncItems({
+        items: syncItems,
+        fn,
+      });
+      return;
     }
     await this.backgroundApi.localDb.addAndUpdateSyncItems({
       items: syncItems,
@@ -91,6 +100,7 @@ class ServiceCustomToken extends ServiceBase {
       tokens: [token],
       skipSaveLocalSyncItem,
       skipEventEmit,
+      useServerDataTime: true,
     });
   }
 
@@ -99,10 +109,12 @@ class ServiceCustomToken extends ServiceBase {
     tokens,
     skipSaveLocalSyncItem,
     skipEventEmit,
+    useServerDataTime,
   }: {
     tokens: ICloudSyncCustomToken[];
     skipSaveLocalSyncItem?: boolean;
     skipEventEmit?: boolean;
+    useServerDataTime?: boolean;
   }) {
     return this.withCustomTokenCloudSync({
       fn: () =>
@@ -119,6 +131,7 @@ class ServiceCustomToken extends ServiceBase {
       isDeleted: false,
       skipSaveLocalSyncItem,
       skipEventEmit,
+      useServerDataTime,
     });
   }
 
@@ -147,6 +160,7 @@ class ServiceCustomToken extends ServiceBase {
       isDeleted: false,
       skipSaveLocalSyncItem,
       skipEventEmit,
+      useServerDataTime: true,
     });
   }
 

--- a/packages/kit-bg/src/services/ServiceDiscovery.ts
+++ b/packages/kit-bg/src/services/ServiceDiscovery.ts
@@ -390,11 +390,13 @@ class ServiceDiscovery extends ServiceBase {
     isRemove,
     skipSaveLocalSyncItem,
     skipEventEmit,
+    useServerDataTime,
   }: {
     bookmarks: IBrowserBookmark[];
     isRemove?: boolean;
     skipSaveLocalSyncItem?: boolean;
     skipEventEmit?: boolean;
+    useServerDataTime?: boolean;
   }) {
     console.log('setBrowserBookmarks', bookmarks);
     // debugger;
@@ -429,23 +431,32 @@ class ServiceDiscovery extends ServiceBase {
 
     let savedSuccess = false;
 
-    await this.backgroundApi.localDb.addAndUpdateSyncItems({
-      items: syncItems,
-      fn: async () => {
-        if (isRemove) {
-          await this.backgroundApi.simpleDb.browserBookmarks.removeBookmarks({
-            urls: bookmarks.map((i) => i.url),
-          });
-        } else {
-          // Save the updated bookmarks
-          await this.backgroundApi.simpleDb.browserBookmarks.saveBookmarks({
-            bookmarks,
-          });
-        }
+    const saveBookmarks = async () => {
+      if (isRemove) {
+        await this.backgroundApi.simpleDb.browserBookmarks.removeBookmarks({
+          urls: bookmarks.map((i) => i.url),
+        });
+      } else {
+        // Save the updated bookmarks
+        await this.backgroundApi.simpleDb.browserBookmarks.saveBookmarks({
+          bookmarks,
+        });
+      }
 
-        savedSuccess = true;
-      },
-    });
+      savedSuccess = true;
+    };
+
+    if (useServerDataTime) {
+      await this.backgroundApi.localDb.addAndUpdateFreshSyncItems({
+        items: syncItems,
+        fn: saveBookmarks,
+      });
+    } else {
+      await this.backgroundApi.localDb.addAndUpdateSyncItems({
+        items: syncItems,
+        fn: saveBookmarks,
+      });
+    }
 
     if (!skipEventEmit) {
       setTimeout(() => {

--- a/packages/kit-bg/src/services/ServiceMarket.ts
+++ b/packages/kit-bg/src/services/ServiceMarket.ts
@@ -274,7 +274,7 @@ class ServiceMarket extends ServiceBase {
         isDeleted,
       });
     }
-    await this.backgroundApi.localDb.addAndUpdateSyncItems({
+    await this.backgroundApi.localDb.addAndUpdateFreshSyncItems({
       items: syncItems,
       fn,
     });

--- a/packages/kit-bg/src/services/ServiceMarketV2.ts
+++ b/packages/kit-bg/src/services/ServiceMarketV2.ts
@@ -579,7 +579,7 @@ class ServiceMarketV2 extends ServiceBase {
         isDeleted,
       });
     }
-    await this.backgroundApi.localDb.addAndUpdateSyncItems({
+    await this.backgroundApi.localDb.addAndUpdateFreshSyncItems({
       items: syncItems,
       fn,
     });

--- a/packages/kit-bg/src/services/ServicePrimeCloudSync/ServicePrimeCloudSync.tsx
+++ b/packages/kit-bg/src/services/ServicePrimeCloudSync/ServicePrimeCloudSync.tsx
@@ -106,6 +106,26 @@ import type { AxiosResponse } from 'axios';
 
 const nonceZero = 0;
 
+type IApiUploadItemsParams = {
+  localItems: IDBCloudSyncItem[];
+  isFlush?: boolean;
+  isReset?: boolean;
+  skipPrimeStatusCheck?: boolean;
+  setUndefinedTimeToNow?: boolean;
+  syncCredential?: ICloudSyncCredential | undefined;
+  encryptedSecurityPasswordR1ForServer?: string;
+  noDebounceUpload?: boolean;
+  // OK-55438: opt-in flag for genuine "now" writes (rename / delete tombstone).
+  // Records these item ids so the upload payload asks the server to
+  // authoritatively stamp dataTime to serverNow.
+  useServerDataTime?: boolean;
+};
+
+type IApiUploadFreshItemsParams = Omit<
+  IApiUploadItemsParams,
+  'useServerDataTime'
+>;
+
 // Guard for the first-enable window: server pwdHash can be temporarily empty
 // before initial flush/lock upload finishes.
 let oneKeyIdCloudSyncEnableFlowCount = 0;
@@ -559,21 +579,7 @@ class ServicePrimeCloudSync extends ServiceBase {
     encryptedSecurityPasswordR1ForServer,
     noDebounceUpload,
     useServerDataTime,
-  }: {
-    localItems: IDBCloudSyncItem[];
-    isFlush?: boolean;
-    isReset?: boolean;
-    skipPrimeStatusCheck?: boolean;
-    setUndefinedTimeToNow?: boolean;
-    syncCredential?: ICloudSyncCredential | undefined;
-    encryptedSecurityPasswordR1ForServer?: string;
-    noDebounceUpload?: boolean;
-    // OK-55438: opt-in flag for genuine "now" writes (rename / delete tombstone).
-    // Records these item ids so the upload payload asks the server to
-    // authoritatively stamp dataTime. Server only clamps when the submitted time
-    // is ahead of its own clock, so this can never move a past timestamp forward.
-    useServerDataTime?: boolean;
-  }) {
+  }: IApiUploadItemsParams) {
     if (useServerDataTime) {
       localItems.forEach((item) => this.useServerDataTimeIds.add(item.id));
     }
@@ -635,6 +641,14 @@ class ServicePrimeCloudSync extends ServiceBase {
       pwdHash,
       setUndefinedTimeToNow,
       noDebounceUpload,
+    });
+  }
+
+  @backgroundMethod()
+  async apiUploadFreshItems(params: IApiUploadFreshItemsParams) {
+    return this.apiUploadItems({
+      ...params,
+      useServerDataTime: true,
     });
   }
 
@@ -764,10 +778,11 @@ class ServicePrimeCloudSync extends ServiceBase {
 
   // OK-55438: item ids whose dataTime should be authoritatively rewritten by the
   // server (genuine "now" writes such as rename / delete tombstone). Populated by
-  // apiUploadItems({ useServerDataTime: true }) and consumed (cleared) when the
-  // upload payload is built in `_callApiUploadItems`. The flag is carried per
-  // item (not per request) because the debounced merge buffer mixes fresh writes
-  // with historical re-uploads (obsoleted re-sync, uploadAllLocalItems, ...).
+  // addAndUpdateFreshSyncItems / apiUploadFreshItems and consumed (cleared)
+  // when the upload payload is built in `_callApiUploadItems`. The flag is
+  // carried per item (not per request) because the debounced merge buffer mixes
+  // fresh writes with historical re-uploads (obsoleted re-sync,
+  // uploadAllLocalItems, ...).
   useServerDataTimeIds: Set<string> = new Set();
 
   _callApiUploadItemsDebounceMerge({
@@ -2419,8 +2434,8 @@ class ServicePrimeCloudSync extends ServiceBase {
       isDeleted: localItem.isDeleted,
       pwdHash: localItem.pwdHash,
     };
-    // OK-55438: ask the server to authoritatively stamp dataTime for genuine
-    // "now" writes (it only clamps when the submitted time is ahead of server).
+    // OK-55438: ask the server to authoritatively stamp dataTime to serverNow
+    // for genuine "now" writes.
     if (useServerDataTime) {
       serverItem.useServerDataTime = true;
     }

--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -666,9 +666,16 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
         isRemove?: boolean; // remove payload.data
         options?: { isInitFromStorage?: boolean };
         skipSaveLocalSyncItem?: boolean;
+        useServerDataTime?: boolean;
       },
     ) => {
-      const { data, isRemove, options, skipSaveLocalSyncItem } = payload;
+      const {
+        data,
+        isRemove,
+        options,
+        skipSaveLocalSyncItem,
+        useServerDataTime,
+      } = payload;
       const isReady = get(browserDataReadyAtom());
       // web always ready
       const isBrowserDataReady =
@@ -686,6 +693,7 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
         bookmarks: data,
         isRemove,
         skipSaveLocalSyncItem,
+        useServerDataTime,
       });
     },
   );
@@ -702,7 +710,10 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
         sortIndex: payload.sortIndex ?? undefined,
       };
       const updatedBookmarks = [newBookmark];
-      this.buildBookmarkData.call(set, { data: updatedBookmarks });
+      this.buildBookmarkData.call(set, {
+        data: updatedBookmarks,
+        useServerDataTime: true,
+      });
       this.syncBookmark.call(set, { url: payload.url, isBookmark: true });
       void backgroundApiProxy.serviceCloudBackup.requestAutoBackup();
 
@@ -722,6 +733,7 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
     this.buildBookmarkData.call(set, {
       data: [removedBookmark],
       isRemove: true,
+      useServerDataTime: true,
     });
     this.syncBookmark.call(set, { url, isBookmark: false });
 

--- a/packages/shared/types/prime/primeCloudSyncTypes.ts
+++ b/packages/shared/types/prime/primeCloudSyncTypes.ts
@@ -67,10 +67,9 @@ export type ICloudSyncServerItem = {
   pwdHash: string; // TODO server should return pwdHash
   key: string;
   // OK-55438: when true, this item is a genuine "now" write (e.g. rename /
-  // delete tombstone) and the server should overwrite dataTimestamp with its
-  // own clock. The server MUST only do so when the submitted dataTimestamp is
-  // ahead of server time (clamp future -> now), never raise a past value, so a
-  // mis-flagged old item can never be pushed forward.
+  // delete tombstone) and the server should overwrite dataTimestamp with
+  // serverNow. Unflagged historical items must keep their submitted timestamp
+  // unless it is ahead of serverNow, in which case the server should clamp it.
   useServerDataTime?: boolean;
   // nonce: number;
   // userId: string; supabase user id


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55438](https://onekeyhq.atlassian.net/browse/OK-55438)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Add fresh cloud-sync helpers that automatically mark newly created sync items with `useServerDataTime`.
- Route confirmed fresh-write paths through the helpers while keeping migration, restore, reset, flush, and historical re-upload paths unmarked.
- Document the updated server timestamp contract for `useServerDataTime`.

## Intent & Context
OK-55438 tracks cloud-sync items whose client-generated `dataTime` can be ahead of, or behind, server time when the local clock is unreliable. The agreed client responsibility is to mark only "business layer just generated sync item + direct upload" paths as fresh writes, so the server can stamp those items with server time.

## Root Cause
Existing client-side future-time correction is tied to the normal check/update sync flow. Several fresh operations, such as rename, deletion tombstones, custom data updates, watchlist changes, and bookmarks, can generate a sync item and upload it directly. Those direct uploads previously carried the local `timeNow()` result, so bad client clocks could affect LWW ordering.

## Design Decisions
- Added explicit helper APIs instead of scattering `useServerDataTime: true` at individual upload calls.
- Kept the normal `addAndUpdateSyncItems` and `apiUploadItems` paths for historical data so restore/migration/re-upload data is not promoted to current server time.
- Kept the upload marker per item id because debounced upload batches can mix fresh writes and historical items.
- Treat the marker as one-shot for the current fresh upload; a later full sync flow should not inherit fresh-write semantics.

## Changes Detail
- `LocalDbBase`: added `addAndUpdateFreshSyncItems` and `txAddAndUpdateFreshSyncItems`, and migrated wallet/account rename writes to them.
- `ServicePrimeCloudSync`: added `apiUploadFreshItems`, maintained per-item server-time markers, and forwarded `useServerDataTime` into upload payloads.
- Fresh-write services: routed address book, market watchlist, custom RPC/network, custom token, deletion tombstones, and bookmark writes through fresh helpers.
- Discovery state actions: pass fresh-write intent for bookmark add/remove while leaving init/migration paths unmarked.
- Shared prime sync types: documented the updated server-side timestamp rule.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Mobile / Web / Extension
- **Risk Areas**: Cloud-sync conflict ordering, debounced upload batching, and ensuring historical sync items are not stamped as fresh writes.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `git diff --check`
- [ ] Manual QA: set local clock ahead and verify rename/delete/custom/bookmark fresh writes do not resurrect old data on another device.
- [ ] Manual QA: set local clock behind and verify fresh writes sync as new operations using server time.
- [ ] Manual QA: verify migration/restore/re-upload data is not promoted to current server time.

[OK-55438]: https://onekeyhq.atlassian.net/browse/OK-55438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ