### PR TITLE
test: add desktop e2e browser scaffold

### DIFF
--- a/apps/desktop/app/app.ts
+++ b/apps/desktop/app/app.ts
@@ -80,6 +80,7 @@ import { destroyTrayManager, initTrayManager } from './tray/TrayManager';
 initSentry();
 
 const isPerfCiMode = process.env.PERF_CI_MODE === '1';
+const isDesktopE2EMode = process.env.DESKTOP_E2E_MODE === 'true';
 const isDevServer = isDev && !isPerfCiMode;
 const isLocalUnpacked = isDev || isPerfCiMode;
 
@@ -98,13 +99,16 @@ function isWhitelistedMediaOrigin(
   return !!domainKey && whitelistDomainKeys.has(domainKey);
 }
 
-if (isPerfCiMode) {
-  // Keep prepared state in a stable location on perf machines.
+if (isPerfCiMode || isDesktopE2EMode) {
+  // Keep prepared state in a stable location on perf machines and isolate E2E.
   const userDataDir =
     process.env.PERF_DESKTOP_USER_DATA_DIR ||
-    path.join(os.homedir(), 'perf-profiles', 'desktop');
+    process.env.DESKTOP_E2E_USER_DATA_DIR ||
+    (isDesktopE2EMode
+      ? path.join(os.tmpdir(), 'onekey-desktop-e2e')
+      : path.join(os.homedir(), 'perf-profiles', 'desktop'));
   app.setPath('userData', userDataDir);
-  logger.info('[perf-ci] userDataDir:', userDataDir);
+  logger.info('[desktop-e2e] userDataDir:', userDataDir);
 }
 
 // https://github.com/sindresorhus/electron-context-menu
@@ -691,7 +695,7 @@ async function createMainWindow() {
         slashes: true,
       })
     : isDev
-      ? 'http://localhost:3001/'
+      ? process.env.DESKTOP_E2E_RENDERER_URL || 'http://localhost:3001/'
       : formatUrl({
           pathname: bundleIndexHtmlPath || 'index.html',
           protocol: PROTOCOL,
@@ -699,7 +703,7 @@ async function createMainWindow() {
         });
   /* eslint-enable no-nested-ternary */
 
-  if (isDevServer) {
+  if (isDevServer && !isDesktopE2EMode) {
     browserWindow.webContents.openDevTools();
   }
 

--- a/apps/desktop/e2e/open-url.e2e.js
+++ b/apps/desktop/e2e/open-url.e2e.js
@@ -1,0 +1,500 @@
+#!/usr/bin/env node
+
+const assert = require('node:assert/strict');
+const { spawn, spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const net = require('node:net');
+const os = require('node:os');
+const path = require('node:path');
+
+const { _electron: electron } = require('playwright-core');
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const desktopDir = path.join(repoRoot, 'apps', 'desktop');
+const mainPath = path.join(desktopDir, 'app', 'dist', 'app.js');
+const artifactDir =
+  process.env.DESKTOP_E2E_ARTIFACT_DIR ||
+  path.join(repoRoot, '.tmp', 'desktop-e2e');
+const targetInput = process.env.DESKTOP_E2E_OPEN_URL || 'apple.com';
+const targetUrl = toUrl(targetInput);
+const expectedHost = stripWww(new URL(targetUrl).hostname);
+const expectedContentText =
+  process.env.DESKTOP_E2E_EXPECT_TEXT ||
+  (expectedHost === 'apple.com' ? 'Apple' : expectedHost);
+
+const COPY_INJECT_TIMEOUT_MS =
+  Number(process.env.DESKTOP_E2E_COPY_INJECT_TIMEOUT_MS) || 60_000;
+const BUILD_MAIN_TIMEOUT_MS =
+  Number(process.env.DESKTOP_E2E_BUILD_MAIN_TIMEOUT_MS) || 120_000;
+const RENDERER_TIMEOUT_MS =
+  Number(process.env.DESKTOP_E2E_RENDERER_TIMEOUT_MS) || 180_000;
+const APP_TIMEOUT_MS = Number(process.env.DESKTOP_E2E_APP_TIMEOUT_MS) || 90_000;
+const PAGE_TIMEOUT_MS =
+  Number(process.env.DESKTOP_E2E_PAGE_TIMEOUT_MS) || 120_000;
+const DESKTOP_SHORTCUT_IPC_CHANNEL = 'app/shortcut';
+const DESKTOP_BROWSER_SHORTCUT_EVENT = 'TabBrowser';
+const desktopE2EEnv = {
+  DESKTOP_E2E_MODE: 'true',
+};
+
+function log(message) {
+  console.log(`[desktop-e2e] ${message}`);
+}
+
+function yarnBin() {
+  return process.platform === 'win32' ? 'yarn.cmd' : 'yarn';
+}
+
+function toUrl(input) {
+  return /^https?:\/\//i.test(input) ? input : `https://${input}`;
+}
+
+function stripWww(hostname) {
+  return hostname.replace(/^www\./i, '').toLowerCase();
+}
+
+function appendOutput(buffer, chunk) {
+  const value = `${buffer}${chunk.toString()}`;
+  return value.length > 8000 ? value.slice(value.length - 8000) : value;
+}
+
+function runYarn(args, { timeoutMs }) {
+  log(`run: yarn ${args.join(' ')}`);
+  const result = spawnSync(yarnBin(), args, {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: 'inherit',
+    timeout: timeoutMs,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`yarn ${args.join(' ')} exited with ${result.status}`);
+  }
+}
+
+function httpOk(url) {
+  return new Promise((resolve) => {
+    const request = http.get(url, (response) => {
+      response.resume();
+      resolve(
+        Boolean(response.statusCode) &&
+          response.statusCode >= 200 &&
+          response.statusCode < 500,
+      );
+    });
+    request.on('error', () => resolve(false));
+    request.setTimeout(1000, () => {
+      request.destroy();
+      resolve(false);
+    });
+  });
+}
+
+function isPortAvailable(port) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once('error', () => resolve(false));
+    server.once('listening', () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+async function findAvailablePort(startPort) {
+  for (let port = startPort; port < startPort + 50; port += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    if (await isPortAvailable(port)) {
+      return port;
+    }
+  }
+  throw new Error(`No available desktop E2E renderer port near ${startPort}`);
+}
+
+async function waitForRenderer(url, child, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (child?.exitCode !== null) {
+      throw new Error(
+        `Renderer dev server exited early with code ${child.exitCode}`,
+      );
+    }
+    // eslint-disable-next-line no-await-in-loop
+    if (await httpOk(url)) {
+      return;
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Timed out waiting for renderer dev server at ${url}`);
+}
+
+async function startRenderer() {
+  const preferredPort = Number(process.env.DESKTOP_E2E_PORT) || 3101;
+  const port = await findAvailablePort(preferredPort);
+  const rendererUrl = `http://localhost:${port}/`;
+
+  log(`start renderer on ${rendererUrl}`);
+  const child = spawn(
+    yarnBin(),
+    ['workspace', '@onekeyhq/desktop', 'exec', 'rspack', 'serve'],
+    {
+      cwd: repoRoot,
+      detached: process.platform !== 'win32',
+      env: {
+        ...process.env,
+        ...desktopE2EEnv,
+        BROWSER: 'none',
+        TRANSFORM_REGENERATOR_DISABLED: 'true',
+        WEB_PORT: String(port),
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+
+  let output = '';
+  child.stdout.on('data', (chunk) => {
+    output = appendOutput(output, chunk);
+    if (process.env.DESKTOP_E2E_VERBOSE) {
+      process.stdout.write(chunk);
+    }
+  });
+  child.stderr.on('data', (chunk) => {
+    output = appendOutput(output, chunk);
+    if (process.env.DESKTOP_E2E_VERBOSE) {
+      process.stderr.write(chunk);
+    }
+  });
+
+  try {
+    await waitForRenderer(rendererUrl, child, RENDERER_TIMEOUT_MS);
+  } catch (error) {
+    throw new Error(`${error.message}\n\nRenderer output tail:\n${output}`, {
+      cause: error,
+    });
+  }
+
+  return { child, rendererUrl };
+}
+
+async function stopProcess(child) {
+  if (!child || child.killed) {
+    return;
+  }
+
+  try {
+    if (process.platform === 'win32') {
+      child.kill();
+    } else {
+      process.kill(-child.pid, 'SIGTERM');
+    }
+  } catch (_) {
+    try {
+      child.kill('SIGTERM');
+    } catch (_e) {
+      // ignore cleanup errors
+    }
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  if (child.exitCode === null) {
+    try {
+      if (process.platform === 'win32') {
+        child.kill('SIGKILL');
+      } else {
+        process.kill(-child.pid, 'SIGKILL');
+      }
+    } catch (_) {
+      // ignore cleanup errors
+    }
+  }
+}
+
+async function waitForLocator(page, selectors, timeoutMs, label) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    for (const selector of selectors) {
+      const locator = page.locator(selector).first();
+      // eslint-disable-next-line no-await-in-loop
+      const visible = await locator
+        .isVisible({ timeout: 250 })
+        .catch(() => false);
+      if (visible) {
+        return locator;
+      }
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await page.waitForTimeout(250);
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+async function findVisibleLocator(page, selectors, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    for (const selector of selectors) {
+      const locator = page.locator(selector).first();
+      // eslint-disable-next-line no-await-in-loop
+      const visible = await locator
+        .isVisible({ timeout: 250 })
+        .catch(() => false);
+      if (visible) {
+        return locator;
+      }
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await page.waitForTimeout(250);
+  }
+  return null;
+}
+
+async function readWebviewStates(page) {
+  const handles = await page.locator('webview').elementHandles();
+  return Promise.all(
+    handles.map((handle) =>
+      handle
+        .evaluate(async (element) => {
+          let pageInfo = null;
+          let pageInfoError = '';
+          if (typeof element.executeJavaScript === 'function') {
+            try {
+              pageInfo = await element.executeJavaScript(`
+                (() => {
+                  const visibleText = (
+                    document.body?.innerText ||
+                    document.documentElement?.innerText ||
+                    ''
+                  ).replace(/\\s+/g, ' ').trim();
+                  return {
+                    bodyTextLength: visibleText.length,
+                    bodyTextSample: visibleText.slice(0, 1200),
+                    locationHref: window.location.href,
+                    readyState: document.readyState,
+                    title: document.title || ''
+                  };
+                })()
+              `);
+            } catch (error) {
+              pageInfoError =
+                error instanceof Error ? error.message : String(error);
+            }
+          }
+          return {
+            loading:
+              typeof element.isLoading === 'function'
+                ? element.isLoading()
+                : undefined,
+            pageInfo,
+            pageInfoError,
+            src: element.getAttribute('src') || '',
+            title:
+              typeof element.getTitle === 'function' ? element.getTitle() : '',
+            url: typeof element.getURL === 'function' ? element.getURL() : '',
+          };
+        })
+        .catch(() => ({ src: '', title: '', url: '' })),
+    ),
+  );
+}
+
+function matchesExpectedHost(value) {
+  if (!value) {
+    return false;
+  }
+  try {
+    const host = stripWww(new URL(value).hostname);
+    return host === expectedHost || host.endsWith(`.${expectedHost}`);
+  } catch (_) {
+    return false;
+  }
+}
+
+function includesExpectedContentText(value) {
+  return value.toLowerCase().includes(expectedContentText.toLowerCase());
+}
+
+function hasLoadedExpectedPageContent(state) {
+  const pageInfo = state.pageInfo;
+  if (!pageInfo) {
+    return false;
+  }
+  const ready =
+    pageInfo.readyState === 'complete' || pageInfo.readyState === 'interactive';
+  const hasBody = Number(pageInfo.bodyTextLength) > 0;
+  const hasExpectedText =
+    includesExpectedContentText(pageInfo.title || '') ||
+    includesExpectedContentText(pageInfo.bodyTextSample || '');
+  return ready && hasBody && hasExpectedText;
+}
+
+async function emitDesktopShortcut(app, eventName) {
+  await app.evaluate(
+    ({ BrowserWindow }, { channel, shortcutEvent }) => {
+      const window = BrowserWindow.getAllWindows().find(
+        (browserWindow) => !browserWindow.isDestroyed(),
+      );
+      if (!window) {
+        throw new Error('No desktop window available for E2E shortcut');
+      }
+      window.webContents.send(channel, shortcutEvent);
+    },
+    {
+      channel: DESKTOP_SHORTCUT_IPC_CHANNEL,
+      shortcutEvent: eventName,
+    },
+  );
+}
+
+async function openBrowserTab(app, page) {
+  await waitForLocator(
+    page,
+    ['[data-testid="Desktop-AppSideBar-Container"]'],
+    APP_TIMEOUT_MS,
+    'Desktop app sidebar',
+  );
+  await emitDesktopShortcut(app, DESKTOP_BROWSER_SHORTCUT_EVENT);
+}
+
+async function waitForLoadedWebviewPage(page) {
+  const deadline = Date.now() + PAGE_TIMEOUT_MS;
+  let lastStates = [];
+  while (Date.now() < deadline) {
+    // eslint-disable-next-line no-await-in-loop
+    lastStates = await readWebviewStates(page);
+    const match = lastStates.find(
+      (state) =>
+        matchesExpectedHost(state.url) || matchesExpectedHost(state.src),
+    );
+    if (match && hasLoadedExpectedPageContent(match)) {
+      return match;
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await page.waitForTimeout(500);
+  }
+  throw new Error(
+    `Timed out waiting for webview to load ${expectedHost}. Last states: ${JSON.stringify(
+      lastStates,
+    )}`,
+  );
+}
+
+async function runBrowserOpenUrlFlow(app, page) {
+  await page.waitForLoadState('domcontentloaded', { timeout: APP_TIMEOUT_MS });
+
+  await openBrowserTab(app, page);
+
+  const searchInput = await waitForLocator(
+    page,
+    [
+      'input[data-testid="search-input"]',
+      '[data-testid="search-input"] input',
+      'textarea[data-testid="search-input"]',
+      'input[placeholder*="Search dApps"]',
+      'input[placeholder*="enter URL"]',
+    ],
+    APP_TIMEOUT_MS,
+    'Browser home search input',
+  );
+
+  await searchInput.fill(targetUrl);
+  const directUrlResult = await findVisibleLocator(
+    page,
+    ['[data-testid="dapp-search0"]'],
+    5000,
+  );
+  if (directUrlResult) {
+    await directUrlResult.click({ force: true });
+  } else {
+    await searchInput.press('Enter');
+  }
+
+  const state = await waitForLoadedWebviewPage(page);
+  assert(
+    matchesExpectedHost(state.url) || matchesExpectedHost(state.src),
+    `Expected loaded webview host ${expectedHost}, got ${JSON.stringify(
+      state,
+    )}`,
+  );
+
+  log(
+    `loaded ${
+      state.pageInfo?.locationHref || state.url || state.src
+    } (${state.pageInfo?.title || state.title || 'untitled'}, ${
+      state.pageInfo?.bodyTextLength || 0
+    } chars)`,
+  );
+}
+
+async function main() {
+  fs.mkdirSync(artifactDir, { recursive: true });
+
+  if (!process.env.DESKTOP_E2E_SKIP_COPY_INJECT) {
+    runYarn(['copy:inject'], {
+      timeoutMs: COPY_INJECT_TIMEOUT_MS,
+    });
+  }
+
+  if (!process.env.DESKTOP_E2E_SKIP_BUILD_MAIN) {
+    runYarn(['workspace', '@onekeyhq/desktop', 'build:main:dev'], {
+      timeoutMs: BUILD_MAIN_TIMEOUT_MS,
+    });
+  }
+
+  if (!fs.existsSync(mainPath)) {
+    throw new Error(`Desktop main file not found: ${mainPath}`);
+  }
+
+  const { child: rendererProcess, rendererUrl } = await startRenderer();
+  const userDataDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'onekey-desktop-e2e-'),
+  );
+
+  let app;
+  let page;
+  try {
+    log('launch Electron');
+    app = await electron.launch({
+      executablePath: require('electron'),
+      args: [mainPath],
+      cwd: desktopDir,
+      env: {
+        ...process.env,
+        ...desktopE2EEnv,
+        DESKTOP_E2E_RENDERER_URL: rendererUrl,
+        DESKTOP_E2E_USER_DATA_DIR: userDataDir,
+      },
+      timeout: APP_TIMEOUT_MS,
+    });
+
+    page = await app.firstWindow({ timeout: APP_TIMEOUT_MS });
+    await page.waitForURL((url) => url.toString().startsWith(rendererUrl), {
+      timeout: APP_TIMEOUT_MS,
+    });
+
+    await runBrowserOpenUrlFlow(app, page);
+  } catch (error) {
+    if (page) {
+      const screenshotPath = path.join(artifactDir, 'open-url-failure.png');
+      await page
+        .screenshot({ path: screenshotPath, fullPage: true })
+        .catch(() => {});
+      log(`failure screenshot: ${screenshotPath}`);
+    }
+    throw error;
+  } finally {
+    if (app) {
+      await app.close().catch(() => {});
+    }
+    await stopProcess(rendererProcess);
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -34,7 +34,8 @@
     "build:winms": "cross-env NODE_ENV=production yarn clean:build && yarn build:renderer && yarn build:main && yarn install-app-deps && yarn build:electron:winms --publish never",
     "publish:all": "cross-env NODE_ENV=production yarn clean:build && yarn build:renderer && yarn build:main && yarn install-app-deps && yarn build:electron --publish always",
     "publish:winms": "cross-env NODE_ENV=production yarn clean:build && yarn build:renderer && yarn build:main && yarn install-app-deps && yarn build:electron:winms --publish always",
-    "build:JsBundle": "cross-env NODE_ENV=production BUILD_BUNDLE_UPDATE=true NODE_OPTIONS=--max-old-space-size=8192 webpack build"
+    "build:JsBundle": "cross-env NODE_ENV=production BUILD_BUNDLE_UPDATE=true NODE_OPTIONS=--max-old-space-size=8192 webpack build",
+    "test:e2e:browser": "node e2e/open-url.e2e.js"
   },
   "dependencies": {
     "@onekeyfe/electron-mac-icloud": "1.2.6",

--- a/development/rspack/rspack.base.config.ts
+++ b/development/rspack/rspack.base.config.ts
@@ -133,6 +133,10 @@ const buildBasePlugins: (
     'process.env.ONEKEY_PROXY': JSON.stringify(onekeyProxy),
     'process.env.ONEKEY_PLATFORM': JSON.stringify(platform),
     'process.env.NODE_ENV': JSON.stringify(nodeEnv),
+    'process.env.DESKTOP_E2E_MODE': JSON.stringify(
+      process.env.DESKTOP_E2E_MODE || '',
+    ),
+    'process.env.E2E_MODE': JSON.stringify(process.env.E2E_MODE || ''),
     'process.env.TAMAGUI_TARGET': JSON.stringify('web'),
     'process.env.PERF_MONITOR_ENABLED': JSON.stringify(
       process.env.PERF_MONITOR_ENABLED || '',

--- a/development/webpack/webpack.base.config.js
+++ b/development/webpack/webpack.base.config.js
@@ -107,6 +107,8 @@ const basePlugins = [
       env: {
         ONEKEY_PROXY: JSON.stringify(ONEKEY_PROXY),
         NODE_ENV: JSON.stringify(NODE_ENV),
+        DESKTOP_E2E_MODE: JSON.stringify(process.env.DESKTOP_E2E_MODE || ''),
+        E2E_MODE: JSON.stringify(process.env.E2E_MODE || ''),
         TAMAGUI_TARGET: JSON.stringify('web'),
         PERF_MONITOR_ENABLED: JSON.stringify(
           process.env.PERF_MONITOR_ENABLED || '',

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "tsc:only": "npx tsgo -p ./tsconfig.json --noEmit --tsBuildInfoFile \"$(yarn config get cacheFolder)\"/.app-mono-ts-cache --pretty",
     "tsc:staged": "npx tsgo -p ./tsconfig.json --noEmit --tsBuildInfoFile \"$(yarn config get cacheFolder)\"/.app-mono-ts-cache --pretty",
     "test": "yarn jest",
+    "test:e2e:desktop:browser": "node apps/desktop/e2e/open-url.e2e.js",
     "test:unit": "yarn workspace @onekeyfe/cli test:unit",
     "test:integration:cli": "yarn workspace @onekeyfe/cli test:integration:cli",
     "ci:gate": "yarn lint:staged && yarn tsc:staged && yarn test:unit && bash apps/cli/scripts/audit-persistence-fields.sh && yarn test:integration:cli",

--- a/packages/kit/src/views/Discovery/hooks/useSearchModalData.test.tsx
+++ b/packages/kit/src/views/Discovery/hooks/useSearchModalData.test.tsx
@@ -357,7 +357,7 @@ describe('useSearchModalData', () => {
     });
   });
 
-  it('keeps remote search enabled for long url queries when review control is enabled', async () => {
+  it('keeps remote search enabled for long url queries while showing the direct URL result', async () => {
     reviewControlMock.mockReturnValue(true);
     serviceDiscoveryMock.fetchDiscoveryHomePageData.mockResolvedValue({
       trending: [],
@@ -385,7 +385,8 @@ describe('useSearchModalData', () => {
         expect.objectContaining({
           type: 'dapp',
           source: 'remote',
-          title: 'Remote Uniswap Exact',
+          title: longUrl,
+          url: longUrl,
           isExactUrl: true,
         }),
         expect.objectContaining({
@@ -393,6 +394,33 @@ describe('useSearchModalData', () => {
         }),
       ]);
     });
+  });
+
+  it('adds an exact HTTPS URL result for bare domain input without relying on remote search', async () => {
+    const { result } = renderHook(() => useSearchModalData('apple.com'));
+
+    await waitFor(() => {
+      expect(result.current.searchList[0]).toEqual(
+        expect.objectContaining({
+          type: 'dapp',
+          source: 'remote',
+          title: 'https://apple.com',
+          url: 'https://apple.com',
+          isExactUrl: true,
+        }),
+      );
+    });
+
+    expect(serviceDiscoveryMock.searchDApp).not.toHaveBeenCalled();
+    expect(result.current.searchList).toEqual([
+      expect.objectContaining({
+        type: 'dapp',
+        url: 'https://apple.com',
+      }),
+      expect.objectContaining({
+        type: 'search-action',
+      }),
+    ]);
   });
 
   it('adds an exact local URL result for localhost input without relying on remote search', async () => {

--- a/packages/kit/src/views/Discovery/utils/searchDebugSnapshot.ts
+++ b/packages/kit/src/views/Discovery/utils/searchDebugSnapshot.ts
@@ -41,14 +41,16 @@ function buildSearchValueExactUrlDapp(searchValue: string): IDApp | undefined {
     return undefined;
   }
 
-  const shouldUseHttpPrefix =
-    uriUtils.isLocalhostUrl(trimmedSearchValue) ||
-    uriUtils.isIpAddressUrl(trimmedSearchValue);
-  if (!shouldUseHttpPrefix) {
+  if (!isWebUrlLikeSearchKeyword(trimmedSearchValue)) {
     return undefined;
   }
 
-  const normalizedUrl = uriUtils.ensureHttpPrefix(trimmedSearchValue);
+  const shouldUseHttpPrefix =
+    uriUtils.isLocalhostUrl(trimmedSearchValue) ||
+    uriUtils.isIpAddressUrl(trimmedSearchValue);
+  const normalizedUrl = shouldUseHttpPrefix
+    ? uriUtils.ensureHttpPrefix(trimmedSearchValue)
+    : uriUtils.ensureHttpsPrefix(trimmedSearchValue);
   const parsedUrl = uriUtils.safeParseURL(normalizedUrl);
   if (!parsedUrl || !['http:', 'https:'].includes(parsedUrl.protocol)) {
     return undefined;

--- a/packages/kit/src/views/Discovery/utils/searchResultRanking.ts
+++ b/packages/kit/src/views/Discovery/utils/searchResultRanking.ts
@@ -247,6 +247,22 @@ function getExactUrlVisitKey(url?: string) {
   return normalizeUrlLikeText(url);
 }
 
+function isSyntheticExactUrlDapp(dapp: IDApp) {
+  return Boolean(dapp.isExactUrl && dapp.dappId.startsWith('exact-url:'));
+}
+
+function isBareHostnameSearchKeyword(keyword: string) {
+  const trimmedKeyword = keyword.trim();
+  return Boolean(
+    trimmedKeyword &&
+    !/^https?:\/\//iu.test(trimmedKeyword) &&
+    !/[/?#]/u.test(trimmedKeyword) &&
+    !uriUtils.isLocalhostUrl(trimmedKeyword) &&
+    !uriUtils.isIpAddressUrl(trimmedKeyword) &&
+    uriUtils.isUrlWithoutProtocol(trimmedKeyword),
+  );
+}
+
 function isExactDappNameMatch({
   dapp,
   keyword,
@@ -1297,14 +1313,23 @@ export function mergeSearchResultsWithLocalData({
       keyword,
       localSupportCount: getLocalSupportCount(dapp),
     });
+  const shouldDeferExactUrlBehindLocal = (dapp: IDApp) =>
+    isSyntheticExactUrlDapp(dapp) &&
+    isBareHostnameSearchKeyword(keyword) &&
+    rankedLocalItems.length > 0;
 
-  const exactUrlResults: IDApp[] = [];
+  const leadingExactUrlResults: IDApp[] = [];
+  const deferredExactUrlResults: IDApp[] = [];
   const prioritizedRemoteResults: IDApp[] = [];
   const remainingRemoteResults: IDApp[] = [];
   let hasStartedRemainingRemoteResults = false;
   for (const item of rankedRemoteResults) {
     if (item.isExactUrl) {
-      exactUrlResults.push(item);
+      if (shouldDeferExactUrlBehindLocal(item)) {
+        deferredExactUrlResults.push(item);
+      } else {
+        leadingExactUrlResults.push(item);
+      }
     } else if (!hasStartedRemainingRemoteResults && shouldPrioritize(item)) {
       prioritizedRemoteResults.push(item);
     } else {
@@ -1326,7 +1351,7 @@ export function mergeSearchResultsWithLocalData({
   }
 
   appendDappSearchResults({
-    items: exactUrlResults,
+    items: leadingExactUrlResults,
     source: 'remote',
     keyword,
     mergedItems,
@@ -1399,6 +1424,19 @@ export function mergeSearchResultsWithLocalData({
       urlMatch: item.urlMatch,
       history: item,
     });
+  });
+
+  appendDappSearchResults({
+    items: deferredExactUrlResults.filter((item) => {
+      const urlKey = getExactUrlVisitKey(item.url);
+      return !urlKey || !urlDedupeKeySet.has(urlKey);
+    }),
+    source: 'remote',
+    keyword,
+    mergedItems,
+    originDedupeKeySet: dappOriginDedupeKeySet,
+    urlDedupeKeySet,
+    reserveLocalUrlKey: true,
   });
 
   appendDappSearchResults({

--- a/packages/kit/src/views/Onboarding/components/OnboardingOnMount.tsx
+++ b/packages/kit/src/views/Onboarding/components/OnboardingOnMount.tsx
@@ -140,6 +140,12 @@ function OnboardingOnMountCmp() {
       if (isOnboardingFromExtensionUrl()) {
         return;
       }
+      if (
+        platformEnv.isDesktop &&
+        (platformEnv.isE2E || process.env.DESKTOP_E2E_MODE === 'true')
+      ) {
+        return;
+      }
       const { isOnboardingDone } =
         await backgroundApiProxy.serviceOnboarding.isOnboardingDone();
       // dapp mode auto onboarding is conflict with url account landing page


### PR DESCRIPTION
## Summary
- Add a **desktop E2E** Playwright Electron runner for the desktop Browser open-URL flow.
- Add **desktop-only E2E** launch isolation for renderer URL, user data, and DevTools behavior.
- Keep the minimal Discovery search URL handling needed for `apple.com`/URL-like input to open directly in the desktop Browser E2E flow.

## Intent & Context
PR #11664 mixed a useful **desktop E2E** foundation with related Browser search behavior. The original PR has been closed. This PR keeps the Electron desktop E2E baseline so future desktop E2E tests can reuse the runner and launch setup, while limiting app behavior changes to the URL-like search path required by the desktop Browser E2E case.

## Root Cause
The desktop app did not have a reusable E2E launch path for Browser flows. A fresh desktop E2E profile also lands on onboarding by default, and URL-like input such as `apple.com` needs to produce a direct URL result for the automated desktop open-URL flow.

## Design Decisions
- Use `playwright-core` with Electron directly, avoiding a new test framework dependency.
- Start a desktop renderer dev server on an available local port and pass it to Electron using desktop E2E-only environment variables.
- Use an isolated temporary user data directory for desktop E2E runs.
- Run `copy:inject` before starting the desktop E2E app so generated injected assets exist in fresh worktrees.
- Use the existing desktop shortcut IPC path to switch to Browser during E2E, avoiding brittle sidebar icon click simulation.
- Scope onboarding bypass to desktop E2E mode only.
- Keep localhost/IP inputs on `http://`; default normal hostnames to `https://`.
- Preserve local bookmark/history ranking by deferring synthetic bare-host exact URL results behind local matches.

## Changes Detail
- `apps/desktop/e2e/open-url.e2e.js`: adds the desktop Browser E2E runner and page-load assertions.
- `apps/desktop/app/app.ts`: supports desktop E2E renderer URL, isolated userData, and suppressed DevTools in E2E mode.
- `apps/desktop/package.json` and root `package.json`: add desktop Browser E2E scripts.
- `development/rspack/rspack.base.config.ts` and `development/webpack/webpack.base.config.js`: expose `DESKTOP_E2E_MODE` to renderer builds.
- `OnboardingOnMount.tsx`: skips onboarding only for desktop E2E.
- Discovery search utilities/tests: synthesize exact URL results for URL-like input and preserve local ranking.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop E2E setup; Discovery Browser search behavior used by desktop/mobile
- **Risk Areas**: Desktop E2E-only startup behavior and search result ordering for URL-like inputs.

## Test plan
- [x] `node --check apps/desktop/e2e/open-url.e2e.js`
- [x] `yarn jest packages/kit/src/views/Discovery/hooks/useSearchModalData.test.tsx --runInBand`
- [x] `yarn lint:staged`
- [ ] `yarn tsc:staged` (fails on existing unrelated hardware/quick-crypto type errors outside this change)
- [x] `yarn test:e2e:desktop:browser` (passes without manual clicks; loaded `https://www.apple.com/`)
