### PR TITLE
chore: sync release/v6.3.0 to x

### DIFF
--- a/apps/mobile/background.ts
+++ b/apps/mobile/background.ts
@@ -25,6 +25,58 @@ const bgEntryLog = (msg: string) => {
 const bgEntryStart: number = (globalThis as any).__ONEKEY_BG_ENTRY_START__;
 bgEntryLog(`polyfills loaded (+${Date.now() - bgEntryStart}ms)`);
 
+// Android background-runtime `process.nextTick` fix.
+//
+// The npm `process` polyfill drives its private nextTick queue via a
+// `setTimeout` it caches at module-load time. On the Android background JS
+// runtime that load precedes RN wiring up timers, so the first
+// `runTimeout(drainQueue)` fails and the queue never drains again — verified on
+// device: the queue grows monotonically and drainQueue never runs, while
+// setTimeout / setImmediate / queueMicrotask / Promise.then all work. Any code
+// relying on `process.nextTick` to deliver a result then hangs forever — e.g.
+// npm `pbkdf2`'s async callback used by cardano-crypto.js `mnemonicToRootKeypair`,
+// which made software-wallet Cardano address creation load forever on Android
+// (iOS / hardware wallet were unaffected: hardware derives on-device, and the
+// iOS background runtime drains nextTick normally).
+//
+// Redirect `process.nextTick` to the verified-working `setImmediate`. Scoped to
+// Android, applied here in the background-thread entry (so the main thread is
+// untouched), and only when a `process.nextTick` exists — done right after the
+// polyfill loads and before anything uses nextTick, so the broken queue is
+// never used.
+function applyAndroidBgNextTickFix() {
+  const { Platform } = require('react-native') as typeof import('react-native');
+  const g = globalThis as unknown as {
+    process?: {
+      nextTick?: (
+        callback: (...args: unknown[]) => void,
+        ...args: unknown[]
+      ) => void;
+    };
+    setImmediate?: (callback: () => void) => void;
+  };
+  const proc = g.process;
+  const setImmediateFn = g.setImmediate;
+  if (
+    Platform.OS !== 'android' ||
+    !proc ||
+    typeof proc.nextTick !== 'function' ||
+    typeof setImmediateFn !== 'function'
+  ) {
+    return;
+  }
+  proc.nextTick = function nextTickViaSetImmediate(
+    callback: (...args: unknown[]) => void,
+    ...args: unknown[]
+  ) {
+    setImmediateFn(() => {
+      callback(...args);
+    });
+  };
+  bgEntryLog('process.nextTick -> setImmediate (android background runtime)');
+}
+applyAndroidBgNextTickFix();
+
 // Install production split bundle loader for background runtime (Phase 3).
 // Uses BackgroundThread.loadSegmentInBackground to register segments
 // with the background Hermes runtime.

--- a/apps/mobile/src/backgroundThread/rpcProtocol.test.ts
+++ b/apps/mobile/src/backgroundThread/rpcProtocol.test.ts
@@ -1,5 +1,9 @@
 import {
+  parseBackgroundThreadJotaiStateBroadcastBatchPayload,
+  parseBackgroundThreadMainCapabilitiesPayload,
   parseBackgroundThreadResponse,
+  serializeBackgroundThreadJotaiStateBroadcastBatchPayload,
+  serializeBackgroundThreadMainCapabilitiesPayload,
   serializeBackgroundThreadResponse,
 } from './rpcProtocol';
 
@@ -28,5 +32,147 @@ describe('background thread RPC protocol', () => {
     );
 
     expect(response?.error?.payload).toEqual(payload);
+  });
+
+  describe('jotai batch broadcast payload', () => {
+    it('round-trips a multi-item batch preserving order and payload shape', () => {
+      const batch = {
+        items: [
+          { name: 'atomA', payload: { value: 1 } },
+          { name: 'atomB', payload: 'string-payload' },
+          { name: 'atomC', payload: null },
+          { name: 'atomD', payload: [1, 2, 3] },
+        ],
+      };
+
+      const parsed = parseBackgroundThreadJotaiStateBroadcastBatchPayload(
+        serializeBackgroundThreadJotaiStateBroadcastBatchPayload(batch),
+      );
+
+      expect(parsed).toEqual(batch);
+      // Order matters — derived UI subscribers depend on insertion-order
+      // semantics that JotaiBgSync.flushBroadcastMicroBatch promises.
+      expect(parsed?.items.map((item) => item.name)).toEqual([
+        'atomA',
+        'atomB',
+        'atomC',
+        'atomD',
+      ]);
+    });
+
+    it('rejects payloads where any item is missing the `name` field', () => {
+      // Manually serialize to skip the typed `serialize` helper, which
+      // would refuse to compile a malformed payload at the type layer.
+      const malformed = JSON.stringify({
+        items: [{ name: 'atomA', payload: 1 }, { payload: 'missing name' }],
+      });
+
+      expect(
+        parseBackgroundThreadJotaiStateBroadcastBatchPayload(malformed),
+      ).toBeUndefined();
+    });
+
+    it('rejects payloads where items is not an array', () => {
+      const malformed = JSON.stringify({ items: 'not-an-array' });
+
+      expect(
+        parseBackgroundThreadJotaiStateBroadcastBatchPayload(malformed),
+      ).toBeUndefined();
+    });
+
+    it('accepts an empty batch (no-op flush case)', () => {
+      const batch = { items: [] };
+
+      const parsed = parseBackgroundThreadJotaiStateBroadcastBatchPayload(
+        serializeBackgroundThreadJotaiStateBroadcastBatchPayload(batch),
+      );
+
+      expect(parsed).toEqual(batch);
+    });
+
+    // bg → main e2e contract: when JotaiBgSync emits N atom writes in a
+    // specific order, the main runtime must fan them out to
+    // jotaiUpdateFromUiByBgBroadcast in the same order. This simulates the
+    // full path (serialize on bg, parse on main, iterate-and-fanOut on
+    // main) without bringing up the RN runtime — it locks down the
+    // insertion-order contract that JotaiBgSync.flushBroadcastMicroBatch +
+    // setupMainThreadBackgroundRunner.handleBackgroundThreadJotaiStateBatchUpdate
+    // promise to derived UI subscribers.
+    // bg side opts into the new wire protocol only after main side has
+    // advertised support via BACKGROUND_THREAD_MAIN_CAPABILITIES_KEY. This
+    // test locks down the round-trip so a future refactor of the wire
+    // format can't silently break the capability handshake (and therefore
+    // strand the batched bursts on partial-OTA runtimes).
+    it('round-trips a main capabilities payload', () => {
+      const advertised = { jotaiStateBatch: true };
+
+      const parsed = parseBackgroundThreadMainCapabilitiesPayload(
+        serializeBackgroundThreadMainCapabilitiesPayload(advertised),
+      );
+
+      expect(parsed).toEqual(advertised);
+      expect(parsed?.jotaiStateBatch).toBe(true);
+    });
+
+    it('treats a malformed main capabilities payload as undefined', () => {
+      expect(
+        parseBackgroundThreadMainCapabilitiesPayload('null'),
+      ).toBeUndefined();
+      expect(
+        parseBackgroundThreadMainCapabilitiesPayload('not-json'),
+      ).toBeUndefined();
+      expect(
+        parseBackgroundThreadMainCapabilitiesPayload(undefined),
+      ).toBeUndefined();
+    });
+
+    it('fans out a batch in insertion order on the main runtime', () => {
+      const bgEmittedOrder = [
+        { name: 'walletStatusAtom', payload: { connected: true } },
+        { name: 'tokenListAtom', payload: { count: 7 } },
+        { name: 'accountWorthAtom', payload: { value: '42.0' } },
+        { name: 'overviewDeFiDataStateAtom', payload: { isLoading: false } },
+      ];
+
+      // bg side: serialize the batch the same way JotaiBgSync's
+      // deliverBroadcastBatch → setupBackgroundThreadRPCHandler's
+      // broadcastJotaiStateUpdateBatchFromBgToUi would.
+      const wireFormat =
+        serializeBackgroundThreadJotaiStateBroadcastBatchPayload({
+          items: bgEmittedOrder,
+        });
+
+      // main side: parse the wire payload (this is what
+      // setupMainThreadBackgroundRunner does after sharedRPC.read).
+      const parsed =
+        parseBackgroundThreadJotaiStateBroadcastBatchPayload(wireFormat);
+
+      expect(parsed).toBeDefined();
+
+      // main side: simulate handleBackgroundThreadJotaiStateBatchUpdate's
+      // fan-out loop. The real implementation calls
+      // jotaiUpdateFromUiByBgBroadcast for each item — here we capture the
+      // call order via a jest.fn proxy.
+      const fanOut = jest.fn();
+      for (const item of parsed!.items) {
+        fanOut({
+          $$isFromBgStatesSyncBroadcast: true,
+          name: item.name,
+          payload: item.payload,
+        });
+      }
+
+      const fanOutOrder = fanOut.mock.calls.map(
+        ([call]) => call.name as string,
+      );
+      expect(fanOutOrder).toEqual(bgEmittedOrder.map((item) => item.name));
+
+      // Spot-check that the payload survives intact on the last item too,
+      // not just the name — guards against silent payload swap if anyone
+      // refactors the wire format and breaks the parse-by-position invariant.
+      expect(fanOut.mock.calls[fanOutOrder.length - 1][0].payload).toEqual(
+        bgEmittedOrder[bgEmittedOrder.length - 1].payload,
+      );
+    });
   });
 });

--- a/apps/mobile/src/backgroundThread/rpcProtocol.ts
+++ b/apps/mobile/src/backgroundThread/rpcProtocol.ts
@@ -50,6 +50,20 @@ export type IBackgroundThreadJotaiStateBroadcastPayload = {
   payload: any;
 };
 
+/**
+ * Batched payload for jotai state broadcasts. Coalesces multiple atom writes
+ * into a single SharedRPC slot to reduce main JS thread task pressure during
+ * cascade bursts (e.g. when a slow service response triggers dozens of
+ * downstream setAtomValue calls in the same microtask).
+ *
+ * Items are pre-deduplicated by name on the bg side (last value wins) and
+ * iteration order matches first-insertion order — see
+ * jotaiBgSync.flushBroadcastMicroBatch.
+ */
+export type IBackgroundThreadJotaiStateBroadcastBatchPayload = {
+  items: Array<IBackgroundThreadJotaiStateBroadcastPayload>;
+};
+
 export type IBackgroundThreadAppEventBroadcastPayload = {
   eventName: string;
   payload: unknown;
@@ -95,10 +109,49 @@ export type IBackgroundThreadResponsePayload = {
 export const BACKGROUND_THREAD_REQUEST_KEY_PREFIX = 'onekey:bg:req:';
 export const BACKGROUND_THREAD_RESPONSE_KEY_PREFIX = 'onekey:bg:res:';
 export const BACKGROUND_THREAD_JOTAI_STATE_KEY_PREFIX = 'onekey:bg:jotai:';
+export const BACKGROUND_THREAD_JOTAI_STATE_BATCH_KEY_PREFIX =
+  'onekey:bg:jotai-batch:';
 export const BACKGROUND_THREAD_APP_EVENT_KEY_PREFIX = 'onekey:bg:event:';
 export const BACKGROUND_THREAD_BRIDGE_SEND_KEY_PREFIX = 'onekey:bg:bridge:';
 export const WEBEMBED_BRIDGE_REQUEST_KEY_PREFIX = 'onekey:webembed:req:';
 export const WEBEMBED_BRIDGE_RESPONSE_KEY_PREFIX = 'onekey:webembed:resp:';
+
+// Static (single-slot) key the main runtime writes once on observer install
+// to advertise which optional wire protocols it understands. The bg runtime
+// reads / observes this slot and only switches to opt-in protocols (jotai
+// batch broadcast etc.) after the matching capability bit is set, so a
+// partial OTA / split-runtime mismatch can't silently drop batched updates.
+export const BACKGROUND_THREAD_MAIN_CAPABILITIES_KEY = 'onekey:bg:main-caps';
+
+export type IBackgroundThreadMainCapabilitiesPayload = {
+  jotaiStateBatch?: boolean;
+};
+
+export function serializeBackgroundThreadMainCapabilitiesPayload(
+  payload: IBackgroundThreadMainCapabilitiesPayload,
+) {
+  return JSON.stringify(payload);
+}
+
+export function parseBackgroundThreadMainCapabilitiesPayload(
+  value: string | number | boolean | undefined,
+): IBackgroundThreadMainCapabilitiesPayload | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  try {
+    const payload = JSON.parse(
+      value,
+    ) as Partial<IBackgroundThreadMainCapabilitiesPayload>;
+    if (typeof payload !== 'object' || payload === null) {
+      return undefined;
+    }
+    return payload as IBackgroundThreadMainCapabilitiesPayload;
+  } catch {
+    return undefined;
+  }
+}
 
 export function buildBackgroundThreadRequestKey(callId: string) {
   return `${BACKGROUND_THREAD_REQUEST_KEY_PREFIX}${callId}`;
@@ -110,6 +163,10 @@ export function buildBackgroundThreadResponseKey(callId: string) {
 
 export function buildBackgroundThreadJotaiStateKey(callId: string) {
   return `${BACKGROUND_THREAD_JOTAI_STATE_KEY_PREFIX}${callId}`;
+}
+
+export function buildBackgroundThreadJotaiStateBatchKey(callId: string) {
+  return `${BACKGROUND_THREAD_JOTAI_STATE_BATCH_KEY_PREFIX}${callId}`;
 }
 
 export function buildBackgroundThreadAppEventKey(callId: string) {
@@ -257,6 +314,38 @@ export function parseBackgroundThreadJotaiStateBroadcastPayload(
     }
 
     return payload as IBackgroundThreadJotaiStateBroadcastPayload;
+  } catch {
+    return undefined;
+  }
+}
+
+export function serializeBackgroundThreadJotaiStateBroadcastBatchPayload(
+  payload: IBackgroundThreadJotaiStateBroadcastBatchPayload,
+) {
+  return JSON.stringify(payload);
+}
+
+export function parseBackgroundThreadJotaiStateBroadcastBatchPayload(
+  value: string | number | boolean | undefined,
+): IBackgroundThreadJotaiStateBroadcastBatchPayload | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  try {
+    const payload = JSON.parse(
+      value,
+    ) as Partial<IBackgroundThreadJotaiStateBroadcastBatchPayload>;
+    if (!Array.isArray(payload.items)) {
+      return undefined;
+    }
+    // Each item must carry a string `name`; payload is opaque.
+    for (const item of payload.items) {
+      if (!item || typeof (item as { name?: unknown }).name !== 'string') {
+        return undefined;
+      }
+    }
+    return payload as IBackgroundThreadJotaiStateBroadcastBatchPayload;
   } catch {
     return undefined;
   }

--- a/apps/mobile/src/backgroundThread/setupBackgroundThreadRPCHandler.ts
+++ b/apps/mobile/src/backgroundThread/setupBackgroundThreadRPCHandler.ts
@@ -9,6 +9,7 @@ import {
 } from '@onekeyhq/shared/src/modules3rdParty/react-native-file-logger';
 
 import {
+  BACKGROUND_THREAD_MAIN_CAPABILITIES_KEY,
   BACKGROUND_THREAD_REQUEST_KEY_PREFIX,
   type IBackgroundThreadAppEventRequest,
   type IBackgroundThreadBridgeCallRequest,
@@ -16,19 +17,23 @@ import {
   type IBackgroundThreadBridgeConnectRequest,
   type IBackgroundThreadBridgeSendPayload,
   type IBackgroundThreadBridgeStatePayload,
+  type IBackgroundThreadJotaiStateBroadcastBatchPayload,
   type IBackgroundThreadJotaiStateBroadcastPayload,
   type IBackgroundThreadRequest,
   type IBackgroundThreadServiceCallRequest,
   WEBEMBED_BRIDGE_RESPONSE_KEY_PREFIX,
   buildBackgroundThreadAppEventKey,
   buildBackgroundThreadBridgeSendKey,
+  buildBackgroundThreadJotaiStateBatchKey,
   buildBackgroundThreadJotaiStateKey,
   buildBackgroundThreadResponseKey,
   buildWebEmbedBridgeRequestKey,
   parseBackgroundThreadCallId,
+  parseBackgroundThreadMainCapabilitiesPayload,
   parseBackgroundThreadRequest,
   serializeBackgroundThreadAppEventBroadcastPayload,
   serializeBackgroundThreadBridgeSendPayload,
+  serializeBackgroundThreadJotaiStateBroadcastBatchPayload,
   serializeBackgroundThreadJotaiStateBroadcastPayload,
   serializeBackgroundThreadResponse,
 } from './rpcProtocol';
@@ -45,6 +50,15 @@ type IBackgroundRuntimeGlobal = typeof globalThis & {
     broadcastStateUpdateFromBgToUi: (
       payload: IBackgroundThreadJotaiStateBroadcastPayload,
     ) => boolean;
+    broadcastStateUpdateBatchFromBgToUi: (
+      payload: IBackgroundThreadJotaiStateBroadcastBatchPayload,
+    ) => boolean;
+    // Reported as `true` once the main runtime has written its
+    // capability advertisement to SharedRPC. `JotaiBgSync` consults this
+    // predicate before emitting on the new `onekey:bg:jotai-batch:` keys
+    // — otherwise a partial OTA / split-runtime mismatch (new bg + old
+    // main) would silently drop every batched update.
+    isMainBatchProtocolReady: () => boolean;
   };
   __onekeyNativeBackgroundThreadBridgeRelay?: {
     emitAppEventToUi: (payload: {
@@ -81,6 +95,12 @@ let handlerRetryTimer: ReturnType<typeof setTimeout> | undefined;
 let handlerInstalled = false;
 let readySignalEmitted = false;
 let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+// Tracks the main runtime's current advertised support for the batched
+// jotai broadcast wire protocol. Mirrors whatever main last published so
+// an OTA rollback (new bg bundle + older main bundle that no longer
+// advertises batch support) flips us back to the legacy per-item path
+// instead of writing keys the main observer can't decode.
+let mainBatchProtocolReady = false;
 // Ring buffer size for broadcast sequences (#48).
 // If the producer wraps before the consumer reads a slot, the old message is lost.
 // 4096 slots gives ~4K messages of headroom before overwrite.
@@ -89,6 +109,7 @@ let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
 // from a legitimate broadcast.
 const BROADCAST_RING_SIZE = 4096;
 let jotaiStateBroadcastSequence = 0;
+let jotaiStateBroadcastBatchSequence = 0;
 let appEventBroadcastSequence = 0;
 let bridgeSendSequence = 0;
 
@@ -243,6 +264,37 @@ function broadcastJotaiStateUpdateFromBgToUi(
   sharedRPC.write(
     buildBackgroundThreadJotaiStateKey(`${jotaiStateBroadcastSequence}`),
     serializeBackgroundThreadJotaiStateBroadcastPayload(payload),
+  );
+  return true;
+}
+
+/**
+ * Batched jotai broadcast: writes a single SharedRPC slot containing N atom
+ * updates. Used by `JotaiBgSync` after coalescing same-microtask writes —
+ * 2395 setAtomValue → ~150 micro-batch flushes per OK-perp/swap cascade burst.
+ *
+ * Wire format mirrors the single-broadcast path; the main runtime listens
+ * for `BACKGROUND_THREAD_JOTAI_STATE_BATCH_KEY_PREFIX` keys and fan-out the
+ * batch via `jotaiUpdateFromUiByBgBroadcast` in insertion order.
+ */
+function broadcastJotaiStateUpdateBatchFromBgToUi(
+  payload: IBackgroundThreadJotaiStateBroadcastBatchPayload,
+) {
+  if (!payload.items || payload.items.length === 0) {
+    return true;
+  }
+  const sharedRPC = getSharedRPC();
+  if (!sharedRPC) {
+    return false;
+  }
+
+  jotaiStateBroadcastBatchSequence =
+    (jotaiStateBroadcastBatchSequence % BROADCAST_RING_SIZE) + 1;
+  sharedRPC.write(
+    buildBackgroundThreadJotaiStateBatchKey(
+      `${jotaiStateBroadcastBatchSequence}`,
+    ),
+    serializeBackgroundThreadJotaiStateBroadcastBatchPayload(payload),
   );
   return true;
 }
@@ -461,6 +513,27 @@ async function handleRequest(callId: string) {
   }
 }
 
+function applyMainCapabilitiesFromSharedRPC(
+  sharedRPC: ReturnType<typeof getSharedRPC>,
+) {
+  if (!sharedRPC) {
+    return;
+  }
+  try {
+    const raw = sharedRPC.read(BACKGROUND_THREAD_MAIN_CAPABILITIES_KEY);
+    const payload = parseBackgroundThreadMainCapabilitiesPayload(raw);
+    // Reflect main's currently advertised capability (bidirectional). Don't
+    // latch — an OTA rollback can drop batch support and we must follow it
+    // back down to the legacy path on the very next capability read.
+    mainBatchProtocolReady = payload?.jotaiStateBatch === true;
+  } catch (error) {
+    logBgRpcTrace(
+      `failed to read main capabilities: ${(error as Error)?.message || String(error)}`,
+      'error',
+    );
+  }
+}
+
 function installBackgroundRequestHandler() {
   const sharedRPC = getSharedRPC();
   if (!sharedRPC) {
@@ -476,6 +549,11 @@ function installBackgroundRequestHandler() {
         return;
       }
 
+      if (callId === BACKGROUND_THREAD_MAIN_CAPABILITIES_KEY) {
+        applyMainCapabilitiesFromSharedRPC(sharedRPC);
+        return;
+      }
+
       const requestCallId = parseBackgroundThreadCallId(
         callId,
         BACKGROUND_THREAD_REQUEST_KEY_PREFIX,
@@ -486,6 +564,12 @@ function installBackgroundRequestHandler() {
 
       void handleRequest(requestCallId);
     });
+
+    // Catch the case where the main runtime advertised its capabilities
+    // before this handler was installed (handler retry path on bg startup,
+    // or main thread came up first). The onWrite hook covers future
+    // writes; this synchronous read covers the already-published value.
+    applyMainCapabilitiesFromSharedRPC(sharedRPC);
   }
 
   return true;
@@ -622,6 +706,9 @@ export function setupBackgroundThreadRPCHandler() {
   };
   runtimeGlobal.__onekeyNativeBackgroundThreadJotaiBridge = {
     broadcastStateUpdateFromBgToUi: broadcastJotaiStateUpdateFromBgToUi,
+    broadcastStateUpdateBatchFromBgToUi:
+      broadcastJotaiStateUpdateBatchFromBgToUi,
+    isMainBatchProtocolReady: () => mainBatchProtocolReady,
   };
   runtimeGlobal.__onekeyNativeBackgroundThreadBridgeRelay = {
     emitAppEventToUi: emitAppEventFromBgToUi,

--- a/apps/mobile/src/backgroundThread/setupMainThreadBackgroundRunner.ts
+++ b/apps/mobile/src/backgroundThread/setupMainThreadBackgroundRunner.ts
@@ -21,7 +21,9 @@ import { registerImageEmbedBridge } from '@onekeyhq/shared/src/utils/imageUtils.
 import {
   BACKGROUND_THREAD_APP_EVENT_KEY_PREFIX,
   BACKGROUND_THREAD_BRIDGE_SEND_KEY_PREFIX,
+  BACKGROUND_THREAD_JOTAI_STATE_BATCH_KEY_PREFIX,
   BACKGROUND_THREAD_JOTAI_STATE_KEY_PREFIX,
+  BACKGROUND_THREAD_MAIN_CAPABILITIES_KEY,
   BACKGROUND_THREAD_RESPONSE_KEY_PREFIX,
   type IBackgroundThreadBridgeCallRequest,
   type IBackgroundThreadBridgeChannel,
@@ -34,8 +36,10 @@ import {
   parseBackgroundThreadAppEventBroadcastPayload,
   parseBackgroundThreadBridgeSendPayload,
   parseBackgroundThreadCallId,
+  parseBackgroundThreadJotaiStateBroadcastBatchPayload,
   parseBackgroundThreadJotaiStateBroadcastPayload,
   parseBackgroundThreadResponse,
+  serializeBackgroundThreadMainCapabilitiesPayload,
   serializeBackgroundThreadRequest,
 } from './rpcProtocol';
 import {
@@ -481,6 +485,33 @@ function handleBackgroundThreadJotaiStateUpdate(
   });
 }
 
+/**
+ * Apply a batched jotai broadcast. Bg side coalesces same-microtask atom
+ * writes into one SharedRPC slot to keep main JS thread task pressure low
+ * during cascade bursts. Items are iterated in insertion order so derived
+ * subscribers observe values in the same order as if each item had been
+ * delivered via the single-broadcast path.
+ */
+function handleBackgroundThreadJotaiStateBatchUpdate(
+  sharedRPC: ISharedRPC,
+  key: string,
+) {
+  const payload = parseBackgroundThreadJotaiStateBroadcastBatchPayload(
+    sharedRPC.read(key),
+  );
+  if (!payload) {
+    return;
+  }
+
+  for (const item of payload.items) {
+    void jotaiUpdateFromUiByBgBroadcast({
+      $$isFromBgStatesSyncBroadcast: true,
+      name: item.name,
+      payload: item.payload,
+    });
+  }
+}
+
 function handleBackgroundThreadAppEventUpdate(
   sharedRPC: ISharedRPC,
   key: string,
@@ -575,6 +606,11 @@ function installBackgroundRuntimeObserver(sharedRPC: ISharedRPC) {
         return;
       }
 
+      if (callId.startsWith(BACKGROUND_THREAD_JOTAI_STATE_BATCH_KEY_PREFIX)) {
+        handleBackgroundThreadJotaiStateBatchUpdate(sharedRPC, callId);
+        return;
+      }
+
       if (callId.startsWith(BACKGROUND_THREAD_JOTAI_STATE_KEY_PREFIX)) {
         handleBackgroundThreadJotaiStateUpdate(sharedRPC, callId);
         return;
@@ -594,6 +630,24 @@ function installBackgroundRuntimeObserver(sharedRPC: ISharedRPC) {
         void handleWebEmbedBridgeRequest(sharedRPC, callId);
       }
     });
+
+    // Advertise that this main runtime knows how to consume opt-in wire
+    // protocols (batched jotai broadcasts at the moment). Bg side reads /
+    // observes this slot before switching to the new protocols; without
+    // the bit set bg falls back to the legacy `onekey:bg:jotai:` keys
+    // every release/v6.3.0 main bundle already supports.
+    try {
+      sharedRPC.write(
+        BACKGROUND_THREAD_MAIN_CAPABILITIES_KEY,
+        serializeBackgroundThreadMainCapabilitiesPayload({
+          jotaiStateBatch: true,
+        }),
+      );
+    } catch (error) {
+      transportLog(
+        `failed to advertise main capabilities: ${(error as Error)?.message || String(error)}`,
+      );
+    }
   }
 
   if (transportState === 'idle') {

--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -151,6 +151,7 @@ Axios
 babylon
 backends
 backgrounded
+backgrounding
 backuped
 bassed
 bch

--- a/packages/components/src/hooks/useVisibilityChange.ts
+++ b/packages/components/src/hooks/useVisibilityChange.ts
@@ -1,64 +1,14 @@
 import { useEffect } from 'react';
 
-import { AppState } from 'react-native';
+import {
+  getCurrentVisibilityState,
+  onVisibilityStateChange,
+} from '@onekeyhq/shared/src/utils/appVisibility';
 
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
-
-export const getCurrentVisibilityState = (): boolean => {
-  if (platformEnv.isNative) {
-    // currentState will be null at launch while AppState retrieves it over the bridge.
-    // https://reactnative.dev/docs/appstate
-    return AppState.currentState === 'active' || AppState.currentState === null;
-  }
-  if (platformEnv.isDesktop) {
-    return globalThis.desktopApi.isFocused();
-  }
-  return document.visibilityState === 'visible';
-};
-export const onVisibilityStateChange = (
-  callback: (visible: boolean) => void,
-) => {
-  if (platformEnv.isNative) {
-    const subscription = AppState.addEventListener('change', (nextAppState) => {
-      callback(nextAppState === 'active');
-    });
-    return () => {
-      subscription.remove();
-    };
-  }
-
-  if (platformEnv.isDesktop) {
-    const removeSubscription = globalThis.desktopApi.onAppState((state) => {
-      callback(state === 'active');
-    });
-    return removeSubscription;
-  }
-  const handleVisibilityStateChange = () => {
-    callback(document.visibilityState === 'visible');
-  };
-  const windowFocus = () => {
-    callback(true);
-  };
-  const windowBlur = () => {
-    callback(false);
-  };
-  document.addEventListener(
-    'visibilitychange',
-    handleVisibilityStateChange,
-    false,
-  );
-  window.addEventListener('focus', windowFocus);
-  window.addEventListener('blur', windowBlur);
-  return () => {
-    document.removeEventListener(
-      'visibilitychange',
-      handleVisibilityStateChange,
-      false,
-    );
-    window.removeEventListener('focus', windowFocus);
-    window.removeEventListener('blur', windowBlur);
-  };
-};
+// Re-exported for backwards compatibility — implementations live in shared/
+// so kit-bg and other non-UI layers can subscribe without an illegal import
+// up into components.
+export { getCurrentVisibilityState, onVisibilityStateChange };
 
 export const useVisibilityChange = (onChange: (visible: boolean) => void) => {
   useEffect(() => {

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -4766,6 +4766,47 @@ class ServiceAccount extends ServiceBase {
     return info.address;
   }
 
+  // Batched variant: callers like useStakingPendingTxsByInfo iterate
+  // `accountMetaByNetwork` to resolve xpub + accountAddress for every
+  // (accountId, networkId) pair. The legacy pattern paid 2N BgTransport
+  // round-trips per dependency change (one per metric per network); this
+  // batch method collapses it to 1 bridge call regardless of pair count.
+  // Failures are isolated per pair so one bad network does not poison the
+  // whole batch — missing keys in the result indicate the pair couldn't be
+  // resolved (same semantics as the prior per-call `.catch(() => undefined)`).
+  @backgroundMethod()
+  async getAccountMetaForNetworksBatch({
+    pairs,
+  }: {
+    pairs: Array<{ accountId: string; networkId: string }>;
+  }): Promise<
+    Record<string, { xpub: string | undefined; accountAddress: string }>
+  > {
+    const result: Record<
+      string,
+      { xpub: string | undefined; accountAddress: string }
+    > = {};
+    await Promise.all(
+      pairs.map(async ({ accountId, networkId }) => {
+        try {
+          const xpubPromise = this.getAccountXpub({ accountId, networkId });
+          const addressInfoPromise = this.getAccountAddressInfoForApi({
+            accountId,
+            networkId,
+          });
+          const [xpub, info] = await Promise.all([
+            xpubPromise,
+            addressInfoPromise,
+          ]);
+          result[networkId] = { xpub, accountAddress: info.address };
+        } catch {
+          // Pair fails silently; caller checks for presence in the map.
+        }
+      }),
+    );
+    return result;
+  }
+
   @backgroundMethod()
   async getAccountAddressInfoForApi({
     dbAccount,

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -1937,21 +1937,13 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         this._emitHyperliquidDataUpdate(subscriptionType, data);
       }
 
-      // Restart ping loop if not running (e.g. after transport auto-reconnect
-      // where socketOpenHandler doesn't fire on the new internal socket)
-      if (!this._pingIntervalTimer) {
-        this._startPingLoop();
-      }
-
-      void perpsNetworkStatusAtom.set(
-        (prev): IPerpsNetworkStatus => ({
-          ...prev,
-          connected: true,
-          lastMessageAt: messageTimestamp,
-        }),
-      );
-
-      this._scheduleNetworkTimeout(messageTimestamp);
+      // Route default-case messages through the same liveness path used by
+      // ALL_MIDS / SPOT_STATE / SPOT_ASSET_CTXS etc. The throttled
+      // _updateNetworkLiveness() variant updates perpsNetworkStatusAtom at
+      // most once per 5 s — the prior unconditional set() here fired on
+      // every WS message (10+/s for high-frequency streams), generating a
+      // setAtomValue storm across the bg→ui bridge.
+      this._updateNetworkLiveness();
     } catch (error) {
       console.error(
         `[ServiceHyperliquidSubscription.handleSubscriptionData] Failed to handle data for ${subscriptionType}:`,

--- a/packages/kit-bg/src/services/ServiceMarketV2.ts
+++ b/packages/kit-bg/src/services/ServiceMarketV2.ts
@@ -74,12 +74,18 @@ class ServiceMarketV2 extends ServiceBase {
     // critical memory pressure. These are the largest known per-route
     // cache footprints (token logos + pricing for 218 batch fetches in
     // 27 min in observed sessions).
+    //
+    // Intentionally NOT clearing memoizedFetchMarketChains /
+    // memoizedFetchMarketBasicConfig: both are KB-sized constant configs
+    // with a 1 h TTL. Previously these were dropped here too, which made
+    // every critical-memory event force a network refetch of small
+    // constants — observed as 16+ basicConfig RPCs per 4 min window in
+    // iPad logs (cleared 3× by 3 critical warnings, then immediately
+    // re-fetched by 5 active components).
     appEventBus.on(EAppEventBusNames.MemoryPressureWarning, (event) => {
       if (event.level !== 'critical') return;
       this._marketTokenBatchCache.clear();
       void this.memoizedFetchMarketTokenList.clear();
-      void this.memoizedFetchMarketChains.clear();
-      void this.memoizedFetchMarketBasicConfig.clear();
     });
   }
 

--- a/packages/kit-bg/src/services/ServiceStaking.ts
+++ b/packages/kit-bg/src/services/ServiceStaking.ts
@@ -2117,6 +2117,33 @@ class ServiceStaking extends ServiceBase {
     return vaultSettings.stakingResultPollingInterval ?? 30;
   }
 
+  // Batched variant: callers iterating `effectiveNetworkIds` (see
+  // useStakingPendingTxsByInfo) MUST prefer this over N parallel
+  // `getFetchHistoryPollingInterval` calls. Single-item method retained for
+  // legacy callers; the cascade hot path collapses N RPCs into 1.
+  @backgroundMethod()
+  async getFetchHistoryPollingIntervalsBatch({
+    networkIds,
+  }: {
+    networkIds: string[];
+  }): Promise<Record<string, number>> {
+    const result: Record<string, number> = {};
+    await Promise.all(
+      networkIds.map(async (networkId) => {
+        try {
+          const vaultSettings =
+            await this.backgroundApi.serviceNetwork.getVaultSettings({
+              networkId,
+            });
+          result[networkId] = vaultSettings.stakingResultPollingInterval ?? 30;
+        } catch {
+          result[networkId] = 30;
+        }
+      }),
+    );
+    return result;
+  }
+
   @backgroundMethod()
   async queryInviteCodeByAddress(params: {
     networkId: string;

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -73,6 +73,7 @@ import type {
   IFetchTokenDetailParams,
   IFetchTokenListParams,
   IFetchTokensParams,
+  IFetchUSMarketStatusResult,
   ILMTronObject,
   IOKXTransactionObject,
   IPerpDepositQuoteResponse,
@@ -250,18 +251,22 @@ export default class ServiceSwap extends ServiceBase {
 
   @backgroundMethod()
   @toastIfError()
-  async fetchSwapNetworks(): Promise<ISwapNetwork[]> {
+  async fetchSwapNetworks(options?: {
+    refreshClientNetworks?: boolean;
+  }): Promise<ISwapNetwork[]> {
     const protocol = EProtocolOfExchange.ALL;
-    const params = {
+    const requestParams = {
       protocol,
     };
     const client = await this.getClient(EServiceEndpointEnum.Swap);
     const { data } = await client.get<IFetchResponse<ISwapNetworkBase[]>>(
       '/swap/v1/networks',
-      { params },
+      { params: requestParams },
     );
     const allClientSupportNetworks =
-      await this.backgroundApi.serviceNetwork.getAllNetworks();
+      await this.backgroundApi.serviceNetwork.getAllNetworks({
+        clearCache: options?.refreshClientNetworks,
+      });
     const swapNetworks = data?.data
       ?.map((network) => {
         const clientNetwork = allClientSupportNetworks.networks.find(
@@ -273,7 +278,7 @@ export default class ServiceSwap extends ServiceBase {
             symbol: clientNetwork.symbol,
             shortcode: clientNetwork.shortcode,
             logoURI: clientNetwork.logoURI,
-            backendIndex: clientNetwork.backendIndex,
+            backendIndex: clientNetwork.backendIndex ?? false,
             networkId: network.networkId,
             defaultSelectToken: network.defaultSelectToken,
             supportCrossChainSwap: network.supportCrossChainSwap,
@@ -2419,6 +2424,26 @@ export default class ServiceSwap extends ServiceBase {
     } catch (error) {
       console.error(error);
       return defaultConfig;
+    }
+  }
+
+  @backgroundMethod()
+  async fetchCheckUSMarketStatus(): Promise<IFetchUSMarketStatusResult> {
+    const unavailableStatus: IFetchUSMarketStatusResult = {
+      open: false,
+      session: 'CLOSED',
+      reason: 'market-status-unavailable',
+      unavailable: true,
+    };
+    try {
+      const client = await this.getClient(EServiceEndpointEnum.Swap);
+      const { data } = await client.get<
+        IFetchResponse<IFetchUSMarketStatusResult>
+      >('/swap/v1/check/us-market-status');
+      return data?.data ?? unavailableStatus;
+    } catch (error) {
+      console.error(error);
+      return unavailableStatus;
     }
   }
 

--- a/packages/kit-bg/src/services/ServiceToken.ts
+++ b/packages/kit-bg/src/services/ServiceToken.ts
@@ -558,6 +558,33 @@ class ServiceToken extends ServiceBase {
     return Promise.resolve(this.mergeTokenMetadataWithCustomDataSync(params));
   }
 
+  /**
+   * Batched variant: callers that need to merge metadata across a whole
+   * token list (e.g. `useTokenManagement`) MUST use this instead of N
+   * parallel `mergeTokenMetadataWithCustomData` calls. The single-item
+   * bridge method is a `Promise.resolve()` wrap around a sync function —
+   * each call pays the full BgTransport round-trip cost (one
+   * dispatchRemoteRequest + one handleResponse + one JSON.parse on the main
+   * runtime) for zero real async work, which is exactly the N+1 pattern
+   * that shows up as 808 mergeTokenMetadataWithCustomData calls in the
+   * OK-perp/swap freeze trace. Batching collapses it to 1 bridge call.
+   */
+  @backgroundMethod()
+  async mergeTokenMetadataWithCustomDataBatch<T extends IToken>(params: {
+    tokens: T[];
+    customTokens: IAccountToken[];
+    networkId: string;
+  }): Promise<T[]> {
+    const { tokens, customTokens, networkId } = params;
+    return tokens.map((token) =>
+      this.mergeTokenMetadataWithCustomDataSync({
+        token,
+        customTokens,
+        networkId,
+      }),
+    );
+  }
+
   private mergeTokenMetadataWithCustomDataSync<T extends IToken>({
     token,
     customTokens,

--- a/packages/kit-bg/src/states/jotai/jotaiBgSync.ts
+++ b/packages/kit-bg/src/states/jotai/jotaiBgSync.ts
@@ -21,6 +21,26 @@ export class JotaiBgSync {
 
   private pendingBroadcasts: Array<{ name: EAtomNames; payload: any }> = [];
 
+  // Micro-batch broadcast: same-microtask atom writes coalesce into one
+  // SharedRPC slot via the native batch broadcast bridge. This is the
+  // primary lever for the bg→main cascade storm — see OK-perp/swap freeze
+  // case where 2395 setAtomValue + their reverse broadcasts saturated the
+  // main JS thread.
+  //
+  // Each item carries its own `resolve` / `reject` so that callers awaiting
+  // `broadcastStateUpdateFromBgToUi` settle on the actual flush outcome —
+  // a flush exception (bridge unavailable, sharedRPC missing, serialize
+  // failure) propagates back through every awaiter in the same batch
+  // instead of becoming an orphan microtask rejection.
+  private microBatchBuffer: Array<{
+    name: EAtomNames;
+    payload: any;
+    resolve: () => void;
+    reject: (reason: unknown) => void;
+  }> = [];
+
+  private microBatchFlushScheduled = false;
+
   pauseBroadcast() {
     this.broadcastPaused = true;
     this.pendingBroadcasts = [];
@@ -36,6 +56,61 @@ export class JotaiBgSync {
     // the saving is from not triggering UI-side parse+set for identical values).
     for (const item of pending) {
       await this.broadcastStateUpdateFromBgToUi(item);
+    }
+  }
+
+  /**
+   * Drain `microBatchBuffer` and either:
+   *   - noop (empty buffer),
+   *   - emit a single broadcast via the legacy path (size 1), or
+   *   - emit a batch broadcast (size >1).
+   *
+   * Same-named writes are deduplicated last-write-wins; the surviving write's
+   * position follows the LAST occurrence of each atom so derived UI subscribers
+   * observe values in the same sequence as without micro-batch coalescing.
+   * `Map#set` alone preserves first-insertion position, which would re-order
+   * sequences like `A1 -> B -> A2` into `[A2, B]` instead of `[B, A2]`; delete
+   * before set to refresh the insertion slot.
+   */
+  private flushBroadcastMicroBatch() {
+    this.microBatchFlushScheduled = false;
+    const buffer = this.microBatchBuffer.splice(0);
+    if (buffer.length === 0) {
+      return;
+    }
+
+    const dedup = new Map<EAtomNames, any>();
+    for (const item of buffer) {
+      dedup.delete(item.name);
+      dedup.set(item.name, item.payload);
+    }
+
+    try {
+      if (dedup.size === 1) {
+        const [name, payload] = dedup.entries().next().value as [
+          EAtomNames,
+          any,
+        ];
+        this.deliverBroadcast({ name, payload });
+      } else if (dedup.size > 1) {
+        const items: Array<{ name: EAtomNames; payload: any }> = [];
+        dedup.forEach((payload, name) => {
+          items.push({ name, payload });
+        });
+        this.deliverBroadcastBatch(items);
+      }
+      for (const item of buffer) {
+        item.resolve();
+      }
+    } catch (error) {
+      // Surface delivery failure to every caller awaiting this batch flush.
+      // `deliverBroadcast` throws OneKeyLocalError when the native bridge
+      // isn't ready; without this propagation the rejection becomes an
+      // orphan microtask and the original awaiters resolve on a phantom
+      // success path while bg/main state silently diverges.
+      for (const item of buffer) {
+        item.reject(error);
+      }
     }
   }
 
@@ -161,6 +236,52 @@ export class JotaiBgSync {
       this.pendingBroadcasts.push({ name, payload });
       return;
     }
+
+    // Native dual-thread: enqueue into a same-microtask micro-batch so the N
+    // setAtomValue writes triggered by a single service response collapse
+    // into one (or a few) SharedRPC slot writes. Cross-tab cascade storms
+    // (e.g. 2395 setAtomValue in 13s during the OK-perp/swap freeze case)
+    // pay the bridge cost ~once instead of N times.
+    //
+    // The returned Promise settles only after `flushBroadcastMicroBatch`
+    // has actually delivered (or attempted to deliver) the broadcast.
+    // Callers like `wrapAtomPro.doSet` that `await` this method therefore
+    // observe the original await-barrier semantics: an in-flight write
+    // continues past the await only on real success, and bridge failures
+    // surface back through the original call site instead of as an
+    // orphan microtask rejection.
+    //
+    // Extension background path keeps the immediate-send behavior: the
+    // ext bridge already supports requestToAllUi batching internally and
+    // we have no measured cascade pressure there yet.
+    if (
+      platformEnv.isNativeBackgroundThread &&
+      platformEnv.enableNativeBackgroundThread
+    ) {
+      return new Promise<void>((resolve, reject) => {
+        this.microBatchBuffer.push({ name, payload, resolve, reject });
+        if (!this.microBatchFlushScheduled) {
+          this.microBatchFlushScheduled = true;
+          queueMicrotask(() => this.flushBroadcastMicroBatch());
+        }
+      });
+    }
+
+    this.deliverBroadcast({ name, payload });
+  }
+
+  /**
+   * Send one atom broadcast to all UI runtimes. Equivalent to the
+   * pre-micro-batch behavior — used both for non-native bridge mode and as
+   * the single-item flush path.
+   */
+  private deliverBroadcast({
+    name,
+    payload,
+  }: {
+    name: EAtomNames;
+    payload: any;
+  }) {
     const p: IGlobalStatesSyncBroadcastParams = {
       $$isFromBgStatesSyncBroadcast: true,
       name,
@@ -198,6 +319,57 @@ export class JotaiBgSync {
       method: GLOBAL_STATES_SYNC_BROADCAST_METHOD_NAME,
       params: p,
     });
+  }
+
+  /**
+   * Native batch broadcast — only invoked from `flushBroadcastMicroBatch`
+   * once it has accumulated >1 deduped items.
+   *
+   * Two independent capabilities have to be satisfied before the batch wire
+   * protocol is safe to use:
+   *
+   *   1. `broadcastStateUpdateBatchFromBgToUi` exists on this bg runtime's
+   *      bridge object (i.e. the writer can produce the new `onekey:bg:
+   *      jotai-batch:` keys at all).
+   *   2. The main runtime has advertised that it knows how to consume those
+   *      keys via `isMainBatchProtocolReady()`. Without this handshake a
+   *      partial OTA / split-runtime mismatch (new bg bundle + old main
+   *      bundle that only listens on `onekey:bg:jotai:`) would silently
+   *      drop every batched update and freeze the UI on stale state.
+   *
+   * If either check fails we fan out via the per-item `deliverBroadcast`
+   * path — that path uses the legacy `onekey:bg:jotai:` keys that every
+   * release/v6.3.0 main runtime supports.
+   */
+  private deliverBroadcastBatch(
+    items: Array<{ name: EAtomNames; payload: any }>,
+  ) {
+    const runtimeGlobal = globalThis as typeof globalThis & {
+      __onekeyNativeBackgroundThreadJotaiBridge?: {
+        broadcastStateUpdateBatchFromBgToUi?: (params: {
+          items: Array<{ name: string; payload: any }>;
+        }) => boolean;
+        isMainBatchProtocolReady?: () => boolean;
+      };
+    };
+
+    const bridge = runtimeGlobal.__onekeyNativeBackgroundThreadJotaiBridge;
+    if (
+      bridge?.broadcastStateUpdateBatchFromBgToUi &&
+      bridge.isMainBatchProtocolReady?.()
+    ) {
+      bridge.broadcastStateUpdateBatchFromBgToUi({ items });
+      return;
+    }
+
+    // Capability not (yet) confirmed on main side — emit each broadcast via
+    // the legacy single-broadcast key so the older observer keeps working.
+    // Bursts that happen before the handshake completes therefore pay the
+    // full bridge cost per item; once main advertises support every later
+    // burst collapses into a single batch slot again.
+    for (const item of items) {
+      this.deliverBroadcast(item);
+    }
   }
 }
 

--- a/packages/kit/src/components/TxAction/TxActionTransfer.tsx
+++ b/packages/kit/src/components/TxAction/TxActionTransfer.tsx
@@ -310,6 +310,12 @@ function buildExpandedTransferView({
   hideValue?: boolean;
   currencySymbol?: string;
 }) {
+  // INVARIANT: each transfer line is a single fixed-height row — the token icon
+  // (xs) and the amount/fiat texts share one horizontal XStack and are all
+  // numberOfLines={1}, so a line never wraps. TxHistoryListView relies on this
+  // (CHANGE_LINE_HEIGHT) to pin an exact fast-path row height without
+  // CellMeasurer. If you make a line wrap or stack vertically, update
+  // CHANGE_LINE_HEIGHT in TxHistoryListView/index.tsx accordingly.
   const renderTransferLine = (
     transfer: IDecodedTxTransferInfo,
     prefix: string,

--- a/packages/kit/src/components/TxHistoryListView/index.tsx
+++ b/packages/kit/src/components/TxHistoryListView/index.tsx
@@ -23,12 +23,16 @@ import {
   convertToSectionGroups,
   getFilteredHistoryBySearchKey,
 } from '@onekeyhq/shared/src/utils/historyUtils';
+import { getDisplayedActions } from '@onekeyhq/shared/src/utils/txActionUtils';
 import type {
   IAccountHistoryTx,
   IHistoryListSectionGroup,
 } from '@onekeyhq/shared/types/history';
 import type { ITokenFiat } from '@onekeyhq/shared/types/token';
-import { EDecodedTxStatus } from '@onekeyhq/shared/types/tx';
+import {
+  EDecodedTxActionType,
+  EDecodedTxStatus,
+} from '@onekeyhq/shared/types/tx';
 
 import { useAccountData } from '../../hooks/useAccountData';
 import { useBlockExplorerNavigation } from '../../hooks/useBlockExplorerNavigation';
@@ -47,9 +51,65 @@ import { TxHistoryListItem } from './TxHistoryListItem';
 // Measured on web/desktop. Drives react-virtualized's CellMeasurer bypass so
 // rows are positioned synchronously with scroll instead of via async layout.
 // No-op on native (List.tsx Web fast path is not on the native code path).
+//
+// Geometry (tableLayout, see TxActionCommon.tsx): 68 = py top ($3 = 12) + py
+// bottom ($3 = 12) + 44, where 44 is the taller of the left column (title
+// $bodyMdMedium lineHeight 20 + gap $1 = 4 + subtitle $bodyMd lineHeight 20) and
+// a 1–2 line changes column. So a row with <= MAX_FIXED_HEIGHT_CHANGE_LINES
+// change lines is always 68.
+// IMPORTANT: if the row padding, the left column, or renderTransferLine's
+// per-line layout changes, update TX_ROW_HEIGHT / CHANGE_LINE_HEIGHT below.
 const TX_ROW_HEIGHT = 68;
 const SECTION_HEADER_HEIGHT_FIRST = 32; // mt=$0 on first section
 const SECTION_HEADER_HEIGHT_NEXT = 52; // mt=$5 (~20px) on subsequent sections
+
+// In tableLayout, an ASSET_TRANSFER row renders one change line per grouped
+// token (grouped sends + grouped receives — see `buildExpandedTransferView` in
+// TxActionTransfer.tsx). TX_ROW_HEIGHT fits up to this many change lines.
+const MAX_FIXED_HEIGHT_CHANGE_LINES = 2;
+
+// Height contributed by each change line beyond MAX_FIXED_HEIGHT_CHANGE_LINES:
+// one $bodyMd line (lineHeight 20) plus the changes column's row gap ($1 = 4) —
+// see the `<Stack gap="$1">` changes column in TxActionCommon.tsx. This lets
+// getWebRowHeight return an exact, taller fixed height for multi-token rows
+// instead of falling back to CellMeasurer, preserving the fast-scroll path.
+const CHANGE_LINE_HEIGHT = 24;
+
+// Count how many change lines the expanded transfer view will render for a row.
+// Returns 1 for non-transfer actions (approve / function call / unknown only
+// ever render a single change line in tableLayout). Distinct send + receive
+// token counts are a safe upper bound on the rendered lines (UTXO single-token
+// and send-to-self rows collapse to fewer): over-counting only reserves a
+// slightly taller fixed height (a harmless trailing gap), never a shorter one
+// (which would clip the row into the next).
+// getWebRowHeight runs in the scroll measurement hot path and may query the
+// same row repeatedly; cache the line count by tx object identity so
+// getDisplayedActions + Set construction run at most once per tx. The count is
+// intrinsic to the tx's transfers (independent of tableLayout) and the tx's
+// token set is stable across pending -> confirmed, so sharing one cache is
+// safe. Keyed by the IAccountHistoryTx reference, entries are GC'd when the
+// list data is replaced.
+const transferChangeLineCountCache = new WeakMap<IAccountHistoryTx, number>();
+
+function getTransferChangeLineCount(item: IAccountHistoryTx): number {
+  const cached = transferChangeLineCountCache.get(item);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const action = getDisplayedActions({ decodedTx: item.decodedTx })[0];
+  let changeLineCount = 1;
+  if (
+    action?.type === EDecodedTxActionType.ASSET_TRANSFER &&
+    action.assetTransfer
+  ) {
+    const { sends, receives } = action.assetTransfer;
+    const distinctTokenCount = (transfers: typeof sends) =>
+      new Set((transfers ?? []).map((t) => t.tokenIdOnNetwork)).size;
+    changeLineCount = distinctTokenCount(sends) + distinctTokenCount(receives);
+  }
+  transferChangeLineCountCache.set(item, changeLineCount);
+  return changeLineCount;
+}
 
 type IProps = {
   data: IAccountHistoryTx[];
@@ -442,6 +502,21 @@ function BaseTxHistoryListView(props: IProps) {
               if (info.item?.decodedTx?.status === EDecodedTxStatus.Pending) {
                 return undefined;
               }
+              // A multi-token transfer renders more change lines than the base
+              // height can hold (tableLayout only). Stay on the CellMeasurer-free
+              // fast path by returning the exact taller height — each extra line
+              // adds CHANGE_LINE_HEIGHT — so the row expands without overflowing
+              // the next instead of falling back to async measurement.
+              if (tableLayout && info.item) {
+                const changeLineCount = getTransferChangeLineCount(info.item);
+                if (changeLineCount > MAX_FIXED_HEIGHT_CHANGE_LINES) {
+                  return (
+                    TX_ROW_HEIGHT +
+                    (changeLineCount - MAX_FIXED_HEIGHT_CHANGE_LINES) *
+                      CHANGE_LINE_HEIGHT
+                  );
+                }
+              }
               return TX_ROW_HEIGHT;
             }
             // header / footer (loading / "load more" buttons) aren't a fixed
@@ -449,7 +524,7 @@ function BaseTxHistoryListView(props: IProps) {
             return undefined;
           }
         : undefined,
-    [inTabList],
+    [inTabList, tableLayout],
   );
 
   const itemCounts = useMemo(() => {

--- a/packages/kit/src/hooks/useReferFriends.tsx
+++ b/packages/kit/src/hooks/useReferFriends.tsx
@@ -16,7 +16,6 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { FormatHyperlinkText } from '@onekeyhq/kit/src/components/HyperlinkText';
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import {
-  PERPS_CAMPAIGN_HELP_LINK,
   REFERRAL_HELP_LINK,
   buildReferralUrl,
 } from '@onekeyhq/shared/src/config/appConfig';
@@ -432,12 +431,10 @@ export const useReferFriends = () => {
           id: ETranslations.referral_intro_learn_more,
         }),
         onCancel: () => {
-          const learnMoreUrl =
-            source === 'Perps' ? PERPS_CAMPAIGN_HELP_LINK : REFERRAL_HELP_LINK;
           if (platformEnv.isDesktop || platformEnv.isNative) {
-            openUrlInDiscovery({ url: learnMoreUrl });
+            openUrlInDiscovery({ url: REFERRAL_HELP_LINK });
           } else {
-            openUrlExternal(learnMoreUrl);
+            openUrlExternal(REFERRAL_HELP_LINK);
           }
         },
         onConfirmText: intl.formatMessage({

--- a/packages/kit/src/states/jotai/contexts/discovery/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.test.tsx
@@ -70,6 +70,38 @@ jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
   },
 }));
 
+// `actions.ts` registers an AppState 'change' listener at module load to flush
+// the debounced tab-persist on background/inactive. jsdom doesn't ship a usable
+// AppState, so stub the minimal surface the listener touches.
+jest.mock('react-native', () => ({
+  AppState: {
+    addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+  },
+}));
+
+// `buildWebTabs` now persists tab snapshots via a lodash debounce wrapper
+// (500ms trailing / 2s maxWait). The atom state still updates synchronously,
+// but the mocked `setRawData` would fire after the assertions complete and
+// observe a stale state. Replace `debounce` with a passthrough so persistence
+// stays synchronous within `act()` — every other lodash export is untouched.
+//
+// WARNING: This mock applies to EVERY test in this file. Any future test
+// added here that depends on real `debounce` (trailing/maxWait timing,
+// `.flush()` queuing semantics, etc.) must either `jest.unmock('lodash')`
+// or override `debounce` per-test — otherwise it will silently misbehave.
+jest.mock('lodash', () => {
+  const actualLodash = jest.requireActual('lodash') as Record<string, unknown>;
+  return {
+    ...actualLodash,
+    debounce: (fn: (...args: unknown[]) => unknown) => {
+      const wrapper = (...args: unknown[]) => fn(...args);
+      wrapper.flush = () => undefined;
+      wrapper.cancel = () => undefined;
+      return wrapper;
+    },
+  };
+});
+
 jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
   __esModule: true,
   default: {

--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -100,6 +100,23 @@ function isNewTabPositionTop() {
   );
 }
 
+// How a tab-array persist should reach SimpleDb.
+// - Debounced: coalesce high-frequency churn (navigate/reorder/title updates).
+// - Immediate: discrete, high-intent actions (closing a tab / all tabs) must
+//   land synchronously so a hard quit right after cannot restore a stale,
+//   larger snapshot.
+export enum EBrowserTabPersistMode {
+  Immediate = 'immediate',
+  Debounced = 'debounced',
+}
+
+// Raw, non-debounced persist of the full tab array to SimpleDb. Returns the
+// underlying setRawData promise so callers (and the debounced wrapper's
+// `.flush()`) can await durability before the JS runtime is suspended.
+function persistTabsToSimpleDb(tabs: IWebTab[]) {
+  return backgroundApiProxy.simpleDb.browserTabs.setRawData({ tabs });
+}
+
 // Coalesce rapid persistence of browser-tab state. Each user action (open,
 // close, reorder, navigate) used to flush the full tab array to SimpleDb
 // immediately; in iPad logs we saw ~65 writes in 4 minutes, every one
@@ -111,10 +128,11 @@ function isNewTabPositionTop() {
 // least the user-visible action. trailing:true covers the last frame of
 // a continuing burst; maxWait caps lag during sustained activity. Worst-
 // case loss is now a mid-burst intermediate frame, not the final action.
+//
+// The body returns the setRawData promise so `.flush()` returns it too,
+// letting the visibility handler await the final write.
 const persistTabsToSimpleDbDebounced = debounce(
-  (tabs: IWebTab[]) => {
-    void backgroundApiProxy.simpleDb.browserTabs.setRawData({ tabs });
-  },
+  (tabs: IWebTab[]) => persistTabsToSimpleDb(tabs),
   500,
   { leading: true, trailing: true, maxWait: 2000 },
 );
@@ -127,9 +145,11 @@ const persistTabsToSimpleDbDebounced = debounce(
 //
 // iOS in particular may freeze the bridge in <500ms after backgrounding,
 // which would otherwise drop the last user action (open/close/reorder tab).
-onVisibilityStateChange((visible) => {
+// `await` the flushed write so the persist has a chance to commit on the
+// background thread before suspension.
+onVisibilityStateChange(async (visible) => {
   if (!visible) {
-    persistTabsToSimpleDbDebounced.flush();
+    await persistTabsToSimpleDbDebounced.flush();
   }
 });
 
@@ -199,7 +219,12 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
       set,
       payload: {
         data: IWebTab[];
-        options?: { forceUpdate?: boolean; isInitFromStorage?: boolean };
+        options?: {
+          forceUpdate?: boolean;
+          isInitFromStorage?: boolean;
+          // Defaults to Debounced to preserve existing caller behavior.
+          persist?: EBrowserTabPersistMode;
+        };
       },
     ) => {
       const { data, options } = payload;
@@ -225,7 +250,16 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
 
       set(webTabsMapAtom(), () => result.map);
       loggerForEmptyData(result.data, 'buildWebTabs->saveToSimpleDB');
-      persistTabsToSimpleDbDebounced(result.data);
+      if (options?.persist === EBrowserTabPersistMode.Immediate) {
+        // Cancel any pending trailing debounced write so it cannot later
+        // overwrite this authoritative snapshot, then persist immediately.
+        persistTabsToSimpleDbDebounced.cancel();
+        void persistTabsToSimpleDb(result.data);
+      } else {
+        // Debounced wrapper now returns the inner persist promise; the
+        // trailing/leading writes remain fire-and-forget here.
+        void persistTabsToSimpleDbDebounced(result.data);
+      }
     },
   );
 
@@ -551,7 +585,14 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
         }, 50);
       }
       loggerForEmptyData([...tabs], 'closeWebTab');
-      this.buildWebTabs.call(set, { data: [...tabs] });
+      // Closing a tab is a discrete, high-intent action. Persist the final
+      // tab array immediately (and cancel any pending debounced write from
+      // the adjacent-tab activation above) so a hard quit right after cannot
+      // restore the stale, larger snapshot.
+      this.buildWebTabs.call(set, {
+        data: [...tabs],
+        options: { persist: EBrowserTabPersistMode.Immediate },
+      });
       defaultLogger.discovery.browser.closeTab({
         closeMethod: entry,
       });
@@ -607,7 +648,12 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
       }
 
       loggerForEmptyData(pinnedTabs, 'closeAllWebTabs');
-      this.buildWebTabs.call(set, { data: pinnedTabs });
+      // Same rationale as closeWebTab: persist the final (pinned-only) array
+      // immediately so closing all tabs cannot be lost to a pending debounce.
+      this.buildWebTabs.call(set, {
+        data: pinnedTabs,
+        options: { persist: EBrowserTabPersistMode.Immediate },
+      });
 
       setTimeout(() => {
         this.saveLastClosedTab.call(set, tabsToClose);

--- a/packages/kit/src/states/jotai/contexts/discovery/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/discovery/actions.ts
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 
-import { isEqual } from 'lodash';
+import { debounce, isEqual } from 'lodash';
 
 import { Toast, rootNavigationRef, switchTabAsync } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
@@ -40,6 +40,7 @@ import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ERootRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
+import { onVisibilityStateChange } from '@onekeyhq/shared/src/utils/appVisibility';
 import { memoFn } from '@onekeyhq/shared/src/utils/cacheUtils';
 import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
 import {
@@ -98,6 +99,39 @@ function isNewTabPositionTop() {
       'top'
   );
 }
+
+// Coalesce rapid persistence of browser-tab state. Each user action (open,
+// close, reorder, navigate) used to flush the full tab array to SimpleDb
+// immediately; in iPad logs we saw ~65 writes in 4 minutes, every one
+// crossing the bg bridge and re-serializing.
+//
+// leading:true persists the first change in a burst immediately so an
+// open/close/reorder followed by a hard quit (desktop window close, iOS
+// background freeze that lands inside the 500ms window) still lands at
+// least the user-visible action. trailing:true covers the last frame of
+// a continuing burst; maxWait caps lag during sustained activity. Worst-
+// case loss is now a mid-burst intermediate frame, not the final action.
+const persistTabsToSimpleDbDebounced = debounce(
+  (tabs: IWebTab[]) => {
+    void backgroundApiProxy.simpleDb.browserTabs.setRawData({ tabs });
+  },
+  500,
+  { leading: true, trailing: true, maxWait: 2000 },
+);
+
+// Flush the pending debounced persist before the JS runtime can be suspended
+// or the window closes. Routed through `onVisibilityStateChange` so we cover
+// all four platforms uniformly (mobile AppState, desktop Electron focus,
+// web document.hidden + window blur) — a bare RN `AppState.addEventListener`
+// is silent dead code on desktop and incomplete on web.
+//
+// iOS in particular may freeze the bridge in <500ms after backgrounding,
+// which would otherwise drop the last user action (open/close/reorder tab).
+onVisibilityStateChange((visible) => {
+  if (!visible) {
+    persistTabsToSimpleDbDebounced.flush();
+  }
+});
 
 function isLocalhostUrlAllowedInDAppBrowser() {
   const devSettings = jotaiDefaultStore.get(devSettingsPersistAtom.atom());
@@ -191,9 +225,7 @@ class ContextJotaiActionsDiscovery extends ContextJotaiActionsBase {
 
       set(webTabsMapAtom(), () => result.map);
       loggerForEmptyData(result.data, 'buildWebTabs->saveToSimpleDB');
-      void backgroundApiProxy.simpleDb.browserTabs.setRawData({
-        tabs: result.data,
-      });
+      persistTabsToSimpleDbDebounced(result.data);
     },
   );
 

--- a/packages/kit/src/states/jotai/contexts/discovery/closeTabPersist.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/discovery/closeTabPersist.test.tsx
@@ -1,0 +1,232 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { act, renderHook } from '@testing-library/react';
+import { createStore } from 'jotai';
+
+import type { IWebTab } from '@onekeyhq/kit/src/views/Discovery/types';
+import { jotaiDefaultStore } from '@onekeyhq/kit-bg/src/states/jotai/utils/jotaiDefaultStore';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import { useBrowserTabActions } from './actions';
+import {
+  ProviderJotaiContextDiscovery,
+  activeTabIdAtom,
+  browserDataReadyAtom,
+  displayHomePageAtom,
+  useWebTabsAtom,
+  webTabsAtom,
+} from './atoms';
+
+const mockSetBrowserTabsRawData = jest.fn();
+const mockSetBrowserHistoryRawData = jest.fn();
+const mockSetBrowserClosedTabsRawData = jest.fn();
+
+jest.mock('@onekeyhq/components', () => ({
+  Toast: {
+    message: jest.fn(),
+  },
+  rootNavigationRef: {
+    current: {
+      getRootState: jest.fn(),
+    },
+  },
+  switchTabAsync: jest.fn(async () => undefined),
+}));
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: {
+    isDesktop: false,
+    isNative: true,
+    isNativeAndroid: false,
+    isNativeIOS: false,
+    isJest: true,
+  },
+}));
+
+// `actions.ts` registers an AppState 'change' listener at module load to flush
+// the debounced tab-persist on background/inactive. jsdom doesn't ship a usable
+// AppState, so stub the minimal surface the listener touches.
+jest.mock('react-native', () => ({
+  AppState: {
+    addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+  },
+}));
+
+// IMPORTANT: do NOT passthrough-mock lodash here. This test deliberately
+// exercises the REAL lodash debounce together with jest fake timers, so it
+// reproduces the production timing of the bug: several tab closes in rapid
+// succession followed by a hard quit before the trailing debounce can fire.
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    simpleDb: {
+      browserTabs: {
+        setRawData: (payload: unknown) => {
+          mockSetBrowserTabsRawData(payload);
+          return Promise.resolve();
+        },
+      },
+      browserHistory: {
+        getRawData: jest.fn(async () => ({ data: [] })),
+        setRawData: (payload: unknown) => {
+          mockSetBrowserHistoryRawData(payload);
+          return Promise.resolve();
+        },
+      },
+      browserBookmarks: {
+        getRawData: jest.fn(async () => ({ data: [] })),
+      },
+      browserClosedTabs: {
+        setRawData: (payload: unknown) => {
+          mockSetBrowserClosedTabsRawData(payload);
+          return Promise.resolve();
+        },
+      },
+    },
+    serviceDiscovery: {
+      buildWebsiteIconUrl: jest.fn(async () => ''),
+    },
+  },
+}));
+
+// `actions.ts` imports `deeplink/index.ts`, which transitively pulls in
+// `expo-linking` (ESM, untransformed by jest). Stub it out.
+jest.mock('@onekeyhq/kit/src/routes/config/deeplink', () => ({
+  handleDeepLinkUrl: jest.fn(),
+}));
+
+jest.mock('@onekeyhq/kit/src/views/Discovery/utils/explorerUtils', () => ({
+  browserTypeHandler: 'MultiTabBrowser',
+  crossWebviewLoadUrl: jest.fn(),
+  injectToPauseWebsocket: '',
+  injectToResumeWebsocket: '',
+  webviewRefs: {},
+}));
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
+  devSettingsPersistAtom: {
+    atom: jest.fn(),
+  },
+  settingsPersistAtom: {
+    atom: jest.fn(),
+  },
+}));
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/utils/jotaiDefaultStore', () => ({
+  jotaiDefaultStore: {
+    get: jest.fn(() => ({})),
+  },
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/openUrlUtils', () => ({
+  clearPendingDiscoveryUrl: jest.fn(),
+  openUrlInApp: jest.fn(),
+}));
+
+function makeTab(id: string): IWebTab {
+  return {
+    id,
+    url: `https://example.com/${id}`,
+    title: id,
+    canGoBack: false,
+    loading: false,
+    favicon: '',
+    timestamp: Number(id.replace(/\D/g, '')) || 1,
+  };
+}
+
+function createWrapper(tabs: IWebTab[]) {
+  const store = createStore();
+  store.set(browserDataReadyAtom(), true);
+  store.set(activeTabIdAtom(), null);
+  store.set(displayHomePageAtom(), false);
+  store.set(webTabsAtom(), {
+    keys: tabs.map((t) => t.id),
+    tabs: tabs.map((t) => ({ ...t })),
+  });
+  return function Wrapper({ children }: { children?: ReactNode }) {
+    return (
+      <ProviderJotaiContextDiscovery store={store}>
+        {children}
+      </ProviderJotaiContextDiscovery>
+    );
+  };
+}
+
+function lastPersistedTabIds(): string[] | null {
+  if (mockSetBrowserTabsRawData.mock.calls.length === 0) {
+    return null;
+  }
+  const lastCall =
+    mockSetBrowserTabsRawData.mock.calls[
+      mockSetBrowserTabsRawData.mock.calls.length - 1
+    ];
+  return (lastCall[0].tabs as IWebTab[]).map((t) => t.id);
+}
+
+describe('closeWebTab immediate persistence (bg cascade fix)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (jotaiDefaultStore.get as jest.Mock).mockReturnValue({});
+    Object.assign(platformEnv, {
+      isDesktop: false,
+      isNative: true,
+      isNativeAndroid: false,
+      isNativeIOS: false,
+      isJest: true,
+    });
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('persists the FINAL tab array immediately when tabs are closed rapidly, before the debounce window elapses', () => {
+    const { result } = renderHook(
+      () => {
+        const actions = useBrowserTabActions().current;
+        const [webTabs] = useWebTabsAtom();
+        return { actions, tabs: webTabs.tabs };
+      },
+      {
+        wrapper: createWrapper([
+          makeTab('1'),
+          makeTab('2'),
+          makeTab('3'),
+          makeTab('4'),
+        ]),
+      },
+    );
+
+    // Only observe writes caused by the closes below; the seeded state was set
+    // directly on the store (no persist call happened for it).
+    mockSetBrowserTabsRawData.mockClear();
+
+    // Rapidly close tabs WITHOUT advancing timers past the debounce window.
+    act(() => {
+      result.current.actions.closeWebTab({ tabId: '4', entry: 'Menu' });
+      result.current.actions.closeWebTab({ tabId: '3', entry: 'Menu' });
+      result.current.actions.closeWebTab({ tabId: '2', entry: 'Menu' });
+    });
+
+    // The final close must already be persisted immediately. With the old
+    // debounced-only behavior, the post-all-closes array would still be sitting
+    // in the debounce and `setRawData` would only ever have the leading-edge
+    // (stale, larger) snapshot.
+    expect(mockSetBrowserTabsRawData).toHaveBeenCalled();
+    expect(lastPersistedTabIds()).toEqual(['1']);
+
+    // A stale pending debounced trailing write must NOT later overwrite the
+    // immediate snapshot (the `.cancel()` guarantee). Flush all pending timers
+    // and re-check the last persisted snapshot is still the final array.
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(lastPersistedTabIds()).toEqual(['1']);
+  });
+});

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -5,6 +5,10 @@ import BigNumber from 'bignumber.js';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ESwapDirection } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
 import type { useSwapAddressInfo } from '@onekeyhq/kit/src/views/Swap/hooks/useSwapAccount';
+import {
+  isUSMarketStatusStockTokenSource,
+  shouldCheckSwapWarningUSMarketClosed,
+} from '@onekeyhq/kit/src/views/Swap/utils/usMarketStatusUtils';
 import { moveNetworkToFirst } from '@onekeyhq/kit/src/views/Swap/utils/utils';
 import { settingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IEventSourceMessageEvent } from '@onekeyhq/shared/src/eventSource';
@@ -30,6 +34,7 @@ import {
   swapTokenCatchMapMaxCount,
 } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import type {
+  IFetchQuoteResult,
   IFetchQuotesParams,
   IFetchTokensParams,
   ISwapAlertActionData,
@@ -61,6 +66,7 @@ import {
 import { ContextJotaiActionsBase } from '../../utils/ContextJotaiActionsBase';
 
 import {
+  type ISwapQuoteEventErrorState,
   contextAtomMethod,
   limitOrderMarketPriceAtom,
   rateDifferenceAtom,
@@ -117,6 +123,7 @@ import {
   buildSwapQuoteProviderKey,
   getSwapQuoteEventProgressTotalCount,
   getSwapQuoteProgressState,
+  hasSwapZeroProviderQuoteEvent,
   isSwapQuoteEventFetching,
 } from './quoteProgress';
 
@@ -148,8 +155,67 @@ function getSelectedPairLimitPriceRate({
   return isSelectedPair ? limitPriceUseRate.rate : undefined;
 }
 
+function isQuoteResultSelectedTokenPair({
+  quoteResult,
+  fromToken,
+  toToken,
+}: {
+  quoteResult?: IFetchQuoteResult;
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+}) {
+  return Boolean(
+    quoteResult &&
+    fromToken &&
+    toToken &&
+    equalTokenNoCaseSensitive({
+      token1: quoteResult.fromTokenInfo,
+      token2: fromToken,
+    }) &&
+    equalTokenNoCaseSensitive({
+      token1: quoteResult.toTokenInfo,
+      token2: toToken,
+    }),
+  );
+}
+
+function isQuoteEventErrorSelectedTokenPair({
+  quoteEventError,
+  fromToken,
+  toToken,
+}: {
+  quoteEventError?: ISwapQuoteEventErrorState;
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+}) {
+  return Boolean(
+    quoteEventError &&
+    fromToken &&
+    toToken &&
+    equalTokenNoCaseSensitive({
+      token1: quoteEventError.fromToken,
+      token2: fromToken,
+    }) &&
+    equalTokenNoCaseSensitive({
+      token1: quoteEventError.toToken,
+      token2: toToken,
+    }),
+  );
+}
+
 class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
   private quoteInterval: ReturnType<typeof setTimeout> | undefined;
+
+  private stockTokenCheckCache = new Map<string, Promise<boolean>>();
+
+  private usMarketStatusCache:
+    | {
+        expiresAt: number;
+        promise: ReturnType<
+          typeof backgroundApiProxy.serviceSwap.fetchCheckUSMarketStatus
+        >;
+      }
+    | undefined;
 
   private limitOrderMarketPriceInterval:
     | ReturnType<typeof setTimeout>
@@ -541,7 +607,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         return;
       }
       await backgroundApiProxy.serviceSwap.closeApproving();
-      set(swapQuoteEventErrorAtom(), '');
+      set(swapQuoteEventErrorAtom(), undefined);
       try {
         if (!loadingDelayEnable) {
           set(swapQuoteFetchingAtom(), true);
@@ -648,13 +714,28 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
             const dataJson = JSON.parse(data) as ISwapQuoteEventData;
             const errorData = dataJson as ISwapQuoteEventError;
             if (errorData?.errorMessage) {
+              const errorAlert: ISwapAlertState = {
+                message: errorData.errorMessage,
+                alertLevel: ESwapAlertLevel.ERROR,
+              };
               set(swapQuoteListAtom(), []);
               set(swapQuoteCurrentEventProviderKeysAtom(), []);
               set(swapQuoteCurrentEventReceivedCountAtom(), 0);
               set(swapQuoteEventCompletedAtom(), true);
-              set(swapQuoteEventTotalCountAtom(), { count: 0 });
+              set(swapQuoteEventTotalCountAtom(), {
+                eventId: errorData.eventId,
+                count: 0,
+              });
               set(swapQuoteFetchingAtom(), false);
-              set(swapQuoteEventErrorAtom(), errorData.errorMessage);
+              set(swapQuoteEventErrorAtom(), {
+                message: errorData.errorMessage,
+                fromToken: event.tokenPairs.fromToken,
+                toToken: event.tokenPairs.toToken,
+              });
+              set(swapAlertsAtom(), {
+                states: [errorAlert],
+                quoteId: '',
+              });
               this.reconcileManualSelectQuoteProviders.call(set);
               set(swapQuoteActionLockAtom(), (v) => ({
                 ...v,
@@ -711,17 +792,36 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
               (dataJson as ISwapQuoteEventInfo).totalQuoteCount ||
               (dataJson as ISwapQuoteEventInfo).totalQuoteCount === 0
             ) {
-              const { totalQuoteCount } = dataJson as ISwapQuoteEventInfo;
+              const { totalQuoteCount, eventId } =
+                dataJson as ISwapQuoteEventInfo;
+              const quoteEventError = get(swapQuoteEventErrorAtom());
               set(swapQuoteCurrentEventProviderKeysAtom(), []);
               set(swapQuoteCurrentEventReceivedCountAtom(), 0);
-              set(swapQuoteEventCompletedAtom(), false);
               set(swapQuoteEventTotalCountAtom(), {
-                eventId: (dataJson as ISwapQuoteEventInfo).eventId,
+                eventId,
                 count: totalQuoteCount,
+              });
+              const isZeroProviderQuoteEvent = hasSwapZeroProviderQuoteEvent({
+                quoteEventTotalCount: {
+                  eventId,
+                  count: totalQuoteCount,
+                },
               });
               if (totalQuoteCount === 0) {
                 set(swapQuoteListAtom(), []);
               }
+              if (quoteEventError || isZeroProviderQuoteEvent) {
+                this.reconcileManualSelectQuoteProviders.call(set);
+                set(swapQuoteEventCompletedAtom(), true);
+                set(swapQuoteFetchingAtom(), false);
+                set(swapQuoteActionLockAtom(), (v) => ({
+                  ...v,
+                  actionLock: false,
+                }));
+                this.closeQuoteEvent();
+                break;
+              }
+              set(swapQuoteEventCompletedAtom(), false);
             } else {
               const quoteResultData = dataJson as ISwapQuoteEventQuoteResult;
               const swapAutoSlippageSuggestedValue = get(
@@ -889,7 +989,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         return;
       }
       await backgroundApiProxy.serviceSwap.closeApproving();
-      set(swapQuoteEventErrorAtom(), '');
+      set(swapQuoteEventErrorAtom(), undefined);
       set(swapQuoteFetchingAtom(), true);
       set(swapQuoteEventCompletedAtom(), false);
       const limitUserMarketPrice = get(swapLimitPriceUseRateAtom());
@@ -930,6 +1030,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
     const fromTokenAmount = get(swapFromTokenAmountAtom());
     const toTokenAmount = get(swapToTokenAmountAtom());
     set(swapQuoteFetchingAtom(), false);
+    set(swapQuoteEventErrorAtom(), undefined);
     set(swapQuoteCurrentEventProviderKeysAtom(), []);
     set(swapQuoteCurrentEventReceivedCountAtom(), 0);
     set(swapQuoteEventCompletedAtom(), false);
@@ -972,6 +1073,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       const toTokenAmount = get(swapToTokenAmountAtom());
       const swapProTradeType = get(swapProTradeTypeAtom());
       const swapProDirection = get(swapProDirectionAtom());
+      set(swapQuoteEventErrorAtom(), undefined);
       if (
         swapTabSwitchType === ESwapTabSwitchType.LIMIT &&
         swapProTradeType === ESwapProTradeType.MARKET &&
@@ -1282,6 +1384,95 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
     return undefined;
   };
 
+  private async checkSwapTokenIsStock(token?: ISwapToken) {
+    if (!token?.networkId) {
+      return false;
+    }
+
+    const cacheKey = `${token.networkId}:${token.contractAddress}`;
+    const cached = this.stockTokenCheckCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const checkPromise = backgroundApiProxy.serviceMarketV2
+      .fetchMarketTokenDetailByTokenAddress(
+        token.contractAddress,
+        token.networkId,
+      )
+      .then((tokenDetail) =>
+        isUSMarketStatusStockTokenSource(
+          tokenDetail?.data?.token?.stock?.source,
+        ),
+      )
+      .catch(() => {
+        this.stockTokenCheckCache.delete(cacheKey);
+        return false;
+      });
+    this.stockTokenCheckCache.set(cacheKey, checkPromise);
+    return checkPromise;
+  }
+
+  private async fetchCheckUSMarketStatus() {
+    const now = Date.now();
+    if (this.usMarketStatusCache && this.usMarketStatusCache.expiresAt > now) {
+      return this.usMarketStatusCache.promise;
+    }
+
+    const promise = backgroundApiProxy.serviceSwap
+      .fetchCheckUSMarketStatus()
+      .then((marketStatus) => {
+        if (!marketStatus || marketStatus.unavailable) {
+          this.usMarketStatusCache = undefined;
+        }
+        return marketStatus;
+      })
+      .catch(() => {
+        this.usMarketStatusCache = undefined;
+        return {
+          open: false,
+          session: 'CLOSED' as const,
+          reason: 'market-status-unavailable',
+          unavailable: true,
+        };
+      });
+    this.usMarketStatusCache = {
+      expiresAt: now + 30_000,
+      promise,
+    };
+    return promise;
+  }
+
+  private async checkSwapPairUSMarketClosed({
+    fromToken,
+    toToken,
+  }: {
+    fromToken?: ISwapToken;
+    toToken?: ISwapToken;
+  }) {
+    const [fromTokenIsStock, toTokenIsStock] = await Promise.all([
+      this.checkSwapTokenIsStock(fromToken),
+      this.checkSwapTokenIsStock(toToken),
+    ]);
+
+    if (!fromTokenIsStock && !toTokenIsStock) {
+      return false;
+    }
+
+    const marketStatus = await this.fetchCheckUSMarketStatus();
+    return marketStatus?.open === false && marketStatus.unavailable !== true;
+  }
+
+  private getUSMarketClosedAlert(): ISwapAlertState & { message: string } {
+    return {
+      // eslint-disable-next-line onekey/no-app-locale-main-thread
+      message: appLocale.intl.formatMessage({
+        id: ETranslations.dexmarket_stock_status_closed_error,
+      }),
+      alertLevel: ESwapAlertLevel.ERROR,
+    };
+  }
+
   checkSwapWarning = contextAtomMethod(
     async (
       get,
@@ -1324,35 +1515,38 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       const fromTokenAmount = get(swapFromTokenAmountAtom());
       let alertsRes: ISwapAlertState[] = [];
       const quoteEventError = get(swapQuoteEventErrorAtom());
-      if (quoteEventError) {
+      const isCurrentQuoteResult = isQuoteResultSelectedTokenPair({
+        quoteResult,
+        fromToken,
+        toToken,
+      });
+      const isCurrentQuoteEventError = isQuoteEventErrorSelectedTokenPair({
+        quoteEventError,
+        fromToken,
+        toToken,
+      });
+      if (
+        quoteEventError &&
+        (isCurrentQuoteResult || isCurrentQuoteEventError)
+      ) {
         alertsRes = [
           {
-            message: quoteEventError,
+            message: quoteEventError.message,
             alertLevel: ESwapAlertLevel.ERROR,
           },
         ];
+      } else if (quoteEventError) {
+        set(swapQuoteEventErrorAtom(), undefined);
       }
       let rateDifferenceRes:
         | { value: string; unit: ESwapRateDifferenceUnit }
         | undefined;
       // current quote result  current token  not match
-      if (
-        quoteResult &&
-        fromToken &&
-        toToken &&
-        (quoteResult?.fromTokenInfo?.networkId !== fromToken?.networkId ||
-          quoteResult?.toTokenInfo?.networkId !== toToken?.networkId ||
-          quoteResult?.fromTokenInfo?.contractAddress !==
-            fromToken?.contractAddress ||
-          quoteResult?.toTokenInfo?.contractAddress !==
-            toToken?.contractAddress)
-      ) {
-        if (quoteEventError) {
-          set(swapAlertsAtom(), {
-            states: alertsRes,
-            quoteId: quoteResult?.quoteId ?? '',
-          });
-        }
+      if (quoteResult && fromToken && toToken && !isCurrentQuoteResult) {
+        set(swapAlertsAtom(), {
+          states: alertsRes,
+          quoteId: '',
+        });
         set(rateDifferenceAtom(), rateDifferenceRes);
         return;
       }
@@ -1362,7 +1556,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         !swapFromAddressInfo.accountInfo?.ready ||
         isWaitingActionableQuote
       ) {
-        if (quoteEventError) {
+        if (alertsRes.length) {
           set(swapAlertsAtom(), {
             states: alertsRes,
             quoteId: '',
@@ -1378,6 +1572,42 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           quoteId: quoteResult?.quoteId ?? '',
         });
         return;
+      }
+      if (
+        shouldCheckSwapWarningUSMarketClosed({
+          alerts: alertsRes,
+          swapTypeSwitch,
+          fromToken,
+          toToken,
+          accountReady: swapFromAddressInfo.accountInfo?.ready,
+          isWaitingActionableQuote,
+          hasFromAccountWallet: Boolean(
+            swapFromAddressInfo.accountInfo?.wallet,
+          ),
+        })
+      ) {
+        const isUSMarketClosed = await this.checkSwapPairUSMarketClosed({
+          fromToken,
+          toToken,
+        });
+        const latestFromToken = get(swapSelectFromTokenAtom());
+        const latestToToken = get(swapSelectToTokenAtom());
+        const latestSwapTypeSwitch = get(swapTypeSwitchAtom());
+        const isSameTokenPair =
+          equalTokenNoCaseSensitive({
+            token1: latestFromToken,
+            token2: fromToken,
+          }) &&
+          equalTokenNoCaseSensitive({
+            token1: latestToToken,
+            token2: toToken,
+          });
+        if (!isSameTokenPair || latestSwapTypeSwitch !== swapTypeSwitch) {
+          return;
+        }
+        if (isUSMarketClosed) {
+          alertsRes = [this.getUSMarketClosedAlert()];
+        }
       }
       // eslint-disable-next-line onekey/no-app-locale-main-thread
       const notSupportSwapMessage = appLocale.intl.formatMessage({

--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -64,6 +64,12 @@ const {
 } = createJotaiContext();
 export { ProviderJotaiContextSwap, contextAtomMethod };
 
+export type ISwapQuoteEventErrorState = {
+  message: string;
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+};
+
 // swap mev config
 export const { atom: swapMevConfigAtom, use: useSwapMevConfigAtom } =
   contextAtom<{
@@ -447,7 +453,7 @@ export const { atom: swapAlertsAtom, use: useSwapAlertsAtom } = contextAtom<{
 export const {
   atom: swapQuoteEventErrorAtom,
   use: useSwapQuoteEventErrorAtom,
-} = contextAtom<string>('');
+} = contextAtom<ISwapQuoteEventErrorState | undefined>(undefined);
 
 export const { atom: rateDifferenceAtom, use: useRateDifferenceAtom } =
   contextAtom<{ value: string; unit: ESwapRateDifferenceUnit } | undefined>(

--- a/packages/kit/src/views/AssetList/hooks/useTokenManagement.ts
+++ b/packages/kit/src/views/AssetList/hooks/useTokenManagement.ts
@@ -112,15 +112,20 @@ export function useTokenManagement({
         ),
       );
 
-      const allTokens = await Promise.all(
-        [...tokenList.tokens, ...customTokens].map((token) =>
-          backgroundApiProxy.serviceToken.mergeTokenMetadataWithCustomData({
-            token,
+      // One bridge round-trip for the whole list. The single-item bg method
+      // is `Promise.resolve(syncMerge)` so a Promise.all over .map paid 1
+      // BgTransport round-trip per token for zero real async work — this
+      // pattern shows up as 808 mergeTokenMetadataWithCustomData calls in
+      // the OK-perp/swap freeze trace. See ServiceToken
+      // .mergeTokenMetadataWithCustomDataBatch for the contract.
+      const allTokens =
+        await backgroundApiProxy.serviceToken.mergeTokenMetadataWithCustomDataBatch(
+          {
+            tokens: [...tokenList.tokens, ...customTokens],
             customTokens,
             networkId,
-          }),
-        ),
-      );
+          },
+        );
 
       const uniqueTokens = uniqBy(
         allTokens,

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -511,7 +511,7 @@ function MobileBrowser() {
             earnContent={
               <EarnHomeWithProvider
                 showHeader={false}
-                showContent
+                showContent={selectedHeaderTab === ETranslations.global_earn}
                 defaultTab={earnTab}
                 tabsRef={earnTabsRef}
                 useSwipePager={useOuterPager}

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -51,7 +51,10 @@ import { useBlockRegion } from './hooks/useBlockRegion';
 import { useEarnHideSmallAssets } from './hooks/useEarnHideSmallAssets';
 import { useEarnPortfolio } from './hooks/useEarnPortfolio';
 import { useFAQListInfo } from './hooks/useFAQListInfo';
-import { useStakingPendingTxsByInfo } from './hooks/useStakingPendingTxs';
+import {
+  useEarnPendingTxsSharedMeta,
+  useStakingPendingTxsByInfo,
+} from './hooks/useStakingPendingTxs';
 
 import type { IEarnBorrowPagerViewRef } from './components/EarnBorrowPagerView';
 import type { IStakePendingTx } from './hooks/useStakingPendingTxs';
@@ -90,7 +93,13 @@ function BasicEarnHome({
   const wasFocusedRef = useRef(false);
   const wasHiddenByModalRef = useRef(false);
   const shouldLogEnterEarnRef = useRef(false);
-  const portfolioData = useEarnPortfolio({ isActive: isEarnDataActive });
+  // On native, Discovery hosts Earn as a sub-tab, so isEarnDataActive is
+  // true whenever the Discovery top-level tab is focused — even when the
+  // user is on the Browser or Market sub-tab. Also gate on showContent so
+  // the per-asset portfolio fan-out only fires when Earn is actually visible.
+  const portfolioData = useEarnPortfolio({
+    isActive: isEarnDataActive && showContent !== false,
+  });
   const { refresh: refreshEarnDataRaw, isLoading: portfolioLoading } =
     portfolioData;
 
@@ -226,8 +235,20 @@ function BasicEarnHome({
       tx.stakingInfo.label,
     );
   }, []);
+
+  const [borrowNetworkIds, setBorrowNetworkIds] = useState<string[]>([]);
+
+  // Resolve the (earn ∪ borrow) network meta ONCE for both hook instances
+  // below. Without this, EarnHome paid 6 BgTransport RPCs per dep change
+  // (3 per instance: network-account map + account-meta batch + polling
+  // intervals batch). The shared resolver collapses it to 3.
+  const sharedPendingTxsMeta = useEarnPendingTxsSharedMeta({
+    extraNetworkIds: borrowNetworkIds,
+  });
+
   const { filteredTxs } = useStakingPendingTxsByInfo({
     filter: pendingTxsFilter,
+    precomputed: sharedPendingTxsMeta,
   });
   const isPending = useMemo(() => {
     return filteredTxs.length > 0;
@@ -241,7 +262,6 @@ function BasicEarnHome({
     previousIsPendingRef.current = isPending;
   }, [isPending, refreshEarnData]);
 
-  const [borrowNetworkIds, setBorrowNetworkIds] = useState<string[]>([]);
   const borrowRefreshHandlerRef = useRef<(() => Promise<void>) | null>(null);
 
   const handleRegisterBorrowRefresh = useCallback(
@@ -277,6 +297,7 @@ function BasicEarnHome({
     tagMatcher: borrowPendingTagMatcher,
     onRefresh: handleBorrowPendingRefresh,
     onRefreshDelayMs: BORROW_PENDING_REFRESH_DELAY,
+    precomputed: sharedPendingTxsMeta,
   });
   const prevBorrowPendingIdsRef = useRef<string | null>(null);
 

--- a/packages/kit/src/views/Earn/hooks/useStakingPendingTxs.ts
+++ b/packages/kit/src/views/Earn/hooks/useStakingPendingTxs.ts
@@ -22,6 +22,25 @@ type INetworkAccountMeta = {
   xpub?: string;
 };
 
+// Precomputed inputs from a co-located parent (e.g. EarnHome) so two
+// hook instances do not independently resolve the same data. When omitted
+// the hook resolves everything itself — single-caller pages (PortfolioTab,
+// useRecommendedRefreshPendingTx) keep the legacy behavior unchanged.
+//
+// `pollingIntervalsByNetwork` is the raw `Record<networkId, seconds>` map
+// (NOT the min) so each hook instance computes the min over its own
+// `effectiveNetworkIds` subset — necessary because Earn and Borrow may
+// pick different subsets of the union.
+//
+// All three fields are keyed by the union of the parent-resolved networks;
+// hook instances pick their subset. When a key is missing the hook falls
+// back to its own resolution path for the affected resolution only.
+export type IStakingPendingTxsPrecomputed = {
+  networkAccountMap?: Record<string, string>;
+  pollingIntervalsByNetwork?: Record<string, number>;
+  accountMetaByNetwork?: Record<string, INetworkAccountMeta>;
+};
+
 const DEFAULT_POLLING_INTERVAL = timerUtils.getTimeDurationMs({ seconds: 30 });
 
 export const useStakingPendingTxs = ({
@@ -129,12 +148,14 @@ export const useStakingPendingTxsByInfo = ({
   networkIds,
   tagMatcher,
   onRefreshDelayMs = 0,
+  precomputed,
 }: {
   filter?: (tx: IStakePendingTx) => boolean;
   onRefresh?: () => void;
   networkIds?: string[];
   tagMatcher?: (tag: string) => boolean;
   onRefreshDelayMs?: number;
+  precomputed?: IStakingPendingTxsPrecomputed;
 }) => {
   const { activeAccount } = useActiveAccount({ num: 0 });
   const { account, indexedAccount } = activeAccount;
@@ -255,31 +276,77 @@ export const useStakingPendingTxsByInfo = ({
     return derivedNetworkIds;
   }, [derivedNetworkIds, networkIds]);
 
-  // Get the minimum polling interval across all networks
+  // Get the minimum polling interval across all networks. One batched
+  // bridge call instead of N — the legacy `.map(networkId => RPC)` pattern
+  // was the 10+/s freeze amplifier called out in the OK-perp/swap trace.
   const { result: pollingInterval } = usePromiseResult(
     async () => {
       if (effectiveNetworkIds.length === 0) return DEFAULT_POLLING_INTERVAL;
-      const intervals = await Promise.all(
-        effectiveNetworkIds.map((networkId: string) =>
-          backgroundApiProxy.serviceStaking
-            .getFetchHistoryPollingInterval({
-              networkId,
-            })
-            .catch(() => 30),
-        ),
+      const shared = precomputed?.pollingIntervalsByNetwork;
+      // Use shared map when the parent has resolved every network we need;
+      // otherwise fall back to a batched RPC for the full set (avoid a
+      // partial-cache-miss split that would still cost a bridge call).
+      const haveAll =
+        shared !== undefined &&
+        effectiveNetworkIds.every((nid) => shared[nid] !== undefined);
+      const intervalsMap = haveAll
+        ? shared
+        : await backgroundApiProxy.serviceStaking.getFetchHistoryPollingIntervalsBatch(
+            { networkIds: effectiveNetworkIds },
+          );
+      const intervals = effectiveNetworkIds.map(
+        (networkId) => intervalsMap[networkId] ?? 30,
       );
-      const minInterval = Math.min(...intervals);
+      const minInterval = intervals.length > 0 ? Math.min(...intervals) : 30;
       return timerUtils.getTimeDurationMs({ seconds: minInterval });
     },
-    [effectiveNetworkIds],
+    [effectiveNetworkIds, precomputed?.pollingIntervalsByNetwork],
     { initResult: DEFAULT_POLLING_INTERVAL },
   );
 
-  // Resolve network-specific accountIds for the active indexed account
+  // Resolve network-specific accountIds for the active indexed account.
+  // Short-circuit to the parent-precomputed union map when present —
+  // EarnHome's earn + borrow hook instances share one resolution this way.
   const { result: networkAccountMap } = usePromiseResult<
     Record<string, string>
   >(
     async () => {
+      const sharedMap = precomputed?.networkAccountMap;
+      if (sharedMap) {
+        const subset: Record<string, string> = {};
+        for (const networkId of effectiveNetworkIds) {
+          const accountForNetwork = sharedMap[networkId];
+          if (accountForNetwork) {
+            subset[networkId] = accountForNetwork;
+          }
+        }
+        // Parent must cover every effectiveNetworkId for the short-circuit
+        // to be safe; falling back to per-instance resolution preserves the
+        // legacy "best-effort" contract when the union missed a network.
+        if (Object.keys(subset).length === effectiveNetworkIds.length) {
+          // Mirror the fallback path's synchronous activeAccount override so
+          // account switches converge one tick faster — without this, the
+          // short-circuit would briefly hold the OLD accountId for the
+          // current network until the shared resolver re-runs.
+          //
+          // Skip BTC: sharedMap entries are already normalized to taproot via
+          // getEarnAccount({ btcOnlyTaproot: true }) in the precomputed
+          // resolver. The active accountId is whichever derivation the user
+          // selected (often BIP44/BIP49/BIP84), so overwriting here would
+          // undo the taproot normalization and make pending tx fetch +
+          // history polling query the wrong account (OK-51703 regression).
+          if (
+            accountId &&
+            currentNetworkId &&
+            effectiveNetworkIds.includes(currentNetworkId) &&
+            !networkUtils.isBTCNetwork(currentNetworkId)
+          ) {
+            subset[currentNetworkId] = accountId;
+          }
+          return subset;
+        }
+      }
+
       const map: Record<string, string> = {};
 
       if (
@@ -336,10 +403,20 @@ export const useStakingPendingTxsByInfo = ({
 
       return map;
     },
-    [accountId, currentNetworkId, indexedAccount?.id, effectiveNetworkIds],
+    [
+      accountId,
+      currentNetworkId,
+      indexedAccount?.id,
+      effectiveNetworkIds,
+      precomputed?.networkAccountMap,
+    ],
     { initResult: {} },
   );
 
+  // Resolve xpub + accountAddress for every (accountId, networkId) pair.
+  // One batched bridge call replaces the prior 2N per-pair fan-out
+  // (getAccountXpub + getAccountAddressForApi) — see ServiceAccount
+  // .getAccountMetaForNetworksBatch for the contract.
   const { result: accountMetaByNetwork } = usePromiseResult<
     Record<string, INetworkAccountMeta>
   >(
@@ -349,35 +426,46 @@ export const useStakingPendingTxsByInfo = ({
         return {} as Record<string, INetworkAccountMeta>;
       }
 
+      // Reuse precomputed parent meta where available so two co-located
+      // hook instances (EarnHome's earn + borrow) share one batch RPC.
+      // We still derive the per-instance `meta` map keyed by accountId
+      // so downstream pendingTx fetch picks the right account per network.
+      const sharedMeta = precomputed?.accountMetaByNetwork;
+      const missingPairs: Array<{ accountId: string; networkId: string }> = [];
       const meta: Record<string, INetworkAccountMeta> = {};
-      await Promise.all(
-        entries.map(async ([networkId, accountForNetwork]) => {
-          try {
-            const [xpub, accountAddress] = await Promise.all([
-              backgroundApiProxy.serviceAccount.getAccountXpub({
-                accountId: accountForNetwork,
-                networkId,
-              }),
-              backgroundApiProxy.serviceAccount.getAccountAddressForApi({
-                accountId: accountForNetwork,
-                networkId,
-              }),
-            ]);
 
+      for (const [networkId, accountForNetwork] of entries) {
+        const hit = sharedMeta?.[networkId];
+        if (hit && hit.accountId === accountForNetwork) {
+          meta[networkId] = hit;
+        } else {
+          missingPairs.push({ accountId: accountForNetwork, networkId });
+        }
+      }
+
+      if (missingPairs.length > 0) {
+        const batchResult =
+          await backgroundApiProxy.serviceAccount.getAccountMetaForNetworksBatch(
+            { pairs: missingPairs },
+          );
+        for (const {
+          accountId: accountForNetwork,
+          networkId,
+        } of missingPairs) {
+          const entry = batchResult[networkId];
+          if (entry) {
             meta[networkId] = {
               accountId: accountForNetwork,
-              accountAddress,
-              xpub,
+              accountAddress: entry.accountAddress,
+              xpub: entry.xpub,
             };
-          } catch {
-            // Skip networks we cannot resolve
           }
-        }),
-      );
+        }
+      }
 
       return meta;
     },
-    [networkAccountMap],
+    [networkAccountMap, precomputed?.accountMetaByNetwork],
     { initResult: {} as Record<string, INetworkAccountMeta> },
   );
 
@@ -556,4 +644,187 @@ export const useStakingPendingTxsByInfo = ({
     pendingCount: filteredTxs.length,
     refreshPending: refreshPendingWithHistory,
   };
+};
+
+/**
+ * Parent-side resolver that batches the three RPCs every
+ * `useStakingPendingTxsByInfo` instance independently issues:
+ * - `getNetworkAccountsInSameIndexedAccountId` (account map for union)
+ * - `getAccountMetaForNetworksBatch` (xpub + accountAddress for union)
+ * - `getFetchHistoryPollingIntervalsBatch` (polling intervals for union)
+ *
+ * When EarnHome renders both an Earn and a Borrow instance side-by-side,
+ * each was previously paying its own 3 round-trips on the same union of
+ * networks. Calling this hook once at the EarnHome level and forwarding
+ * the result via `precomputed` collapses 6 RPCs → 3 RPCs per dep change.
+ *
+ * Single-instance callers (PortfolioTab, useRecommendedRefreshPendingTx)
+ * MUST NOT use this — they already pay only one set of RPCs and adding
+ * the wrapper would double the work.
+ */
+export const useEarnPendingTxsSharedMeta = ({
+  extraNetworkIds = [],
+}: {
+  extraNetworkIds?: string[];
+} = {}): IStakingPendingTxsPrecomputed => {
+  const { activeAccount } = useActiveAccount({ num: 0 });
+  const { account, indexedAccount } = activeAccount;
+  const accountId = account?.id;
+  const currentNetworkId = activeAccount.network?.id;
+  const [{ availableAssetsByType = {} }] = useEarnAtom();
+
+  // Same derivation chain as inside useStakingPendingTxsByInfo's Earn
+  // branch — kept in sync so the union is a strict superset of what
+  // either instance will look up.
+  const derivedNetworkIds = useMemo<string[]>(() => {
+    const groupedAssets = [
+      EAvailableAssetsTypeEnum.SimpleEarn,
+      EAvailableAssetsTypeEnum.FixedRate,
+      EAvailableAssetsTypeEnum.Staking,
+    ].flatMap((type) => availableAssetsByType?.[type] ?? []);
+    const mergedAssets =
+      groupedAssets.length > 0
+        ? groupedAssets
+        : Object.values(availableAssetsByType).flat();
+    const set = new Set<string>();
+    mergedAssets.forEach((asset) => {
+      asset.protocols?.forEach((protocol) => {
+        if (protocol.networkId) {
+          set.add(protocol.networkId);
+        }
+      });
+    });
+    return [...set];
+  }, [availableAssetsByType]);
+
+  const stableExtraKey = useMemo(
+    () => [...new Set(extraNetworkIds.filter(Boolean))].toSorted().join('|'),
+    [extraNetworkIds],
+  );
+
+  const unionNetworkIds = useMemo<string[]>(() => {
+    const cleanedExtras = stableExtraKey ? stableExtraKey.split('|') : [];
+    return [...new Set([...derivedNetworkIds, ...cleanedExtras])];
+  }, [derivedNetworkIds, stableExtraKey]);
+
+  // Resolve account-per-network for the union. Mirrors the in-hook
+  // resolver — kept aligned so subset short-circuits in
+  // useStakingPendingTxsByInfo are byte-identical to a per-instance run.
+  const { result: networkAccountMap } = usePromiseResult<
+    Record<string, string>
+  >(
+    async () => {
+      const map: Record<string, string> = {};
+
+      if (
+        accountId &&
+        currentNetworkId &&
+        unionNetworkIds.includes(currentNetworkId)
+      ) {
+        map[currentNetworkId] = accountId;
+      }
+
+      if (!indexedAccount?.id || unionNetworkIds.length === 0) {
+        return map;
+      }
+
+      try {
+        const accounts =
+          await backgroundApiProxy.serviceAccount.getNetworkAccountsInSameIndexedAccountId(
+            {
+              indexedAccountId: indexedAccount.id,
+              networkIds: unionNetworkIds,
+            },
+          );
+        accounts.forEach(({ network, account: networkAccount }) => {
+          if (network?.id && networkAccount?.id) {
+            map[network.id] = networkAccount.id;
+          }
+        });
+      } catch {
+        // Best-effort; downstream consumer falls back to per-instance path
+        // for any missing entry.
+      }
+
+      await Promise.all(
+        Object.keys(map).map(async (netId) => {
+          if (networkUtils.isBTCNetwork(netId)) {
+            try {
+              const earnAccount =
+                await backgroundApiProxy.serviceStaking.getEarnAccount({
+                  accountId: map[netId],
+                  networkId: netId,
+                  indexedAccountId: indexedAccount.id,
+                  btcOnlyTaproot: true,
+                });
+              if (earnAccount?.accountId) {
+                map[netId] = earnAccount.accountId;
+              }
+            } catch {
+              // Keep existing account if taproot resolution fails
+            }
+          }
+        }),
+      );
+
+      return map;
+    },
+    [accountId, currentNetworkId, indexedAccount?.id, unionNetworkIds],
+    { initResult: {} },
+  );
+
+  const { result: accountMetaByNetwork } = usePromiseResult<
+    Record<string, INetworkAccountMeta>
+  >(
+    async () => {
+      const entries = Object.entries(networkAccountMap);
+      if (entries.length === 0) {
+        return {} as Record<string, INetworkAccountMeta>;
+      }
+      const pairs = entries.map(([networkId, accountForNetwork]) => ({
+        accountId: accountForNetwork,
+        networkId,
+      }));
+      const batchResult =
+        await backgroundApiProxy.serviceAccount.getAccountMetaForNetworksBatch({
+          pairs,
+        });
+      const meta: Record<string, INetworkAccountMeta> = {};
+      for (const [networkId, accountForNetwork] of entries) {
+        const entry = batchResult[networkId];
+        if (entry) {
+          meta[networkId] = {
+            accountId: accountForNetwork,
+            accountAddress: entry.accountAddress,
+            xpub: entry.xpub,
+          };
+        }
+      }
+      return meta;
+    },
+    [networkAccountMap],
+    { initResult: {} as Record<string, INetworkAccountMeta> },
+  );
+
+  const { result: pollingIntervalsByNetwork } = usePromiseResult<
+    Record<string, number>
+  >(
+    async () => {
+      if (unionNetworkIds.length === 0) return {};
+      return backgroundApiProxy.serviceStaking.getFetchHistoryPollingIntervalsBatch(
+        { networkIds: unionNetworkIds },
+      );
+    },
+    [unionNetworkIds],
+    { initResult: {} as Record<string, number> },
+  );
+
+  return useMemo<IStakingPendingTxsPrecomputed>(
+    () => ({
+      networkAccountMap,
+      accountMetaByNetwork,
+      pollingIntervalsByNetwork,
+    }),
+    [networkAccountMap, accountMetaByNetwork, pollingIntervalsByNetwork],
+  );
 };

--- a/packages/kit/src/views/Swap/components/SwapProviderListItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProviderListItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState } from 'react';
+import { memo, useLayoutEffect, useMemo, useState } from 'react';
 
 import BigNumber from 'bignumber.js';
 import { MotiView } from 'moti';
@@ -43,6 +43,9 @@ export type ISwapProviderListItemProps = {
   toToken?: ISwapToken;
   selected?: boolean;
   disabled?: boolean;
+  autoOpenRoute?: boolean;
+  autoOpenRouteTrigger?: unknown;
+  routeCollapseTrigger?: unknown;
 } & IListItemProps;
 const SwapProviderListItem = ({
   providerResult,
@@ -52,6 +55,9 @@ const SwapProviderListItem = ({
   toToken,
   selected,
   disabled,
+  autoOpenRoute,
+  autoOpenRouteTrigger,
+  routeCollapseTrigger,
   ...rest
 }: ISwapProviderListItemProps) => {
   const intl = useIntl();
@@ -206,7 +212,20 @@ const SwapProviderListItem = ({
     toToken?.symbol,
   ]);
 
-  const [routeOpen, setRouteOpen] = useState(false);
+  const providerKey = `${providerResult.info.provider}-${providerResult.info.providerName}`;
+  const [routeOpen, setRouteOpen] = useState(Boolean(autoOpenRoute));
+
+  useLayoutEffect(() => {
+    if (autoOpenRoute) {
+      setRouteOpen(true);
+    }
+  }, [autoOpenRoute, autoOpenRouteTrigger, providerKey]);
+
+  useLayoutEffect(() => {
+    if (!autoOpenRoute) {
+      setRouteOpen(false);
+    }
+  }, [autoOpenRoute, providerKey, routeCollapseTrigger]);
 
   const routeContent = useMemo<IRouteRows>(() => {
     const routeRows: IRouteRows =
@@ -242,15 +261,12 @@ const SwapProviderListItem = ({
 
   const routeComponents = useMemo(() => {
     const routesData = providerResult.routesData;
-    if (providerResult.protocolNoRouterInfo) {
-      return (
-        <SizableText size="$bodySm" color="$textSubdued" mt="$3.5">
-          {providerResult.protocolNoRouterInfo}
-        </SizableText>
-      );
-    }
-    if (!routesData?.[0]?.subRoutes?.[0]?.length) {
-      return (
+    const hasRouteData = Boolean(routesData?.[0]?.subRoutes?.[0]?.length);
+    let routeContentComponent = null;
+    if (hasRouteData) {
+      routeContentComponent = <SwapRoutePaths routeContent={routeContent} />;
+    } else if (!providerResult.protocolNoRouterInfo) {
+      routeContentComponent = (
         <SizableText size="$bodySm" color="$textSubdued" mt="$3.5">
           {intl.formatMessage({
             id: ETranslations.provider_route_no_information,
@@ -258,7 +274,16 @@ const SwapProviderListItem = ({
         </SizableText>
       );
     }
-    return <SwapRoutePaths routeContent={routeContent} />;
+    return (
+      <Stack>
+        {routeContentComponent}
+        {providerResult.protocolNoRouterInfo ? (
+          <SizableText size="$bodySm" color="$textSubdued" mt="$3.5">
+            {providerResult.protocolNoRouterInfo}
+          </SizableText>
+        ) : null}
+      </Stack>
+    );
   }, [
     intl,
     providerResult.protocolNoRouterInfo,

--- a/packages/kit/src/views/Swap/components/SwapProviderListPanel.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProviderListPanel.tsx
@@ -157,6 +157,9 @@ const SwapProviderListPanel = ({
   const [currentSelectQuote] = useSwapQuoteCurrentSelectAtom();
   const selectedProviderInfo =
     currentSelectQuote?.info ?? manualSelectQuoteProvider?.info;
+  const selectedProviderKey = selectedProviderInfo
+    ? `${selectedProviderInfo.provider}-${selectedProviderInfo.providerName}`
+    : undefined;
   const quoteLoading = useSwapQuoteLoading();
   const quoteEventFetching = useSwapQuoteEventFetching();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
@@ -405,8 +408,20 @@ const SwapProviderListPanel = ({
           }
         }
       }
-      const itemKey = `${item.info.provider}-${item.info.providerName}`;
+      const itemKey = buildSwapQuoteProviderKey(item);
       const isNewItem = isNewItemRef.current.has(itemKey);
+      const selected = Boolean(
+        item.info.provider === selectedProviderInfo?.provider &&
+        item.info.providerName === selectedProviderInfo?.providerName,
+      );
+      const selectedByManual = Boolean(
+        item.info.provider === manualSelectQuoteProvider?.info.provider &&
+        item.info.providerName === manualSelectQuoteProvider?.info.providerName,
+      );
+      const autoOpenRoute = Boolean(selected && item.openRouterInfo);
+      const autoOpenRouteTrigger = selectedByManual
+        ? manualSelectQuoteProvider
+        : selectedProviderKey;
       return (
         <AnimatedProviderItem
           key={itemKey}
@@ -421,10 +436,10 @@ const SwapProviderListPanel = ({
                   }
                 : undefined
             }
-            selected={Boolean(
-              item.info.provider === selectedProviderInfo?.provider &&
-              item.info.providerName === selectedProviderInfo?.providerName,
-            )}
+            selected={selected}
+            autoOpenRoute={autoOpenRoute}
+            autoOpenRouteTrigger={autoOpenRouteTrigger}
+            routeCollapseTrigger={selectedProviderKey}
             fromTokenAmount={fromTokenAmount.value}
             fromToken={fromToken}
             toToken={toToken}
@@ -439,6 +454,8 @@ const SwapProviderListPanel = ({
       fromToken,
       fromTokenAmount,
       onSelectQuote,
+      manualSelectQuoteProvider,
+      selectedProviderKey,
       selectedProviderInfo?.provider,
       selectedProviderInfo?.providerName,
       settingsPersist.currencyInfo.symbol,

--- a/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
@@ -41,6 +41,12 @@ import {
   useSwapTipsAtom,
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
+import {
+  canUseSwapNetworkCacheAsSortSource,
+  isSwapNetworkCacheCompatible,
+  isSwapNetworkCacheReadyForBasicList,
+  mergeSwapNetworksWithCachedSort,
+} from '../utils/swapNetworkCacheUtils';
 
 import { useSwapAddressInfo } from './useSwapAccount';
 import { useSwapProInputToken } from './useSwapPro';
@@ -108,66 +114,86 @@ export function useSwapInit(params?: ISwapInitParams) {
   if (fromTokenAmountRef.current?.value !== fromTokenAmount?.value) {
     fromTokenAmountRef.current = fromTokenAmount;
   }
+  const hasRefreshedSwapNetworksRef = useRef(false);
+  const refreshSwapNetworksPromiseRef = useRef<Promise<void> | undefined>(
+    undefined,
+  );
 
   const fetchSwapNetworks = useCallback(async () => {
-    if (swapNetworks.length) {
-      setNetworkListFetching(false);
+    const currentSwapNetworks = swapNetworksRef.current;
+    if (currentSwapNetworks.length) {
+      if (isSwapNetworkCacheCompatible(currentSwapNetworks)) {
+        setNetworkListFetching(false);
+        if (hasRefreshedSwapNetworksRef.current) {
+          return;
+        }
+      } else {
+        setNetworkListFetching(
+          !isSwapNetworkCacheReadyForBasicList(currentSwapNetworks),
+        );
+      }
+    }
+
+    if (refreshSwapNetworksPromiseRef.current) {
+      await refreshSwapNetworksPromiseRef.current;
       return;
     }
-    let swapNetworksSortList =
-      await backgroundApiProxy.simpleDb.swapNetworksSort.getRawData();
-    if (swapNetworksSortList?.data?.length) {
-      const noSupportInfo = swapNetworksSortList?.data.every(
-        (net) =>
-          (isNil(net.supportCrossChainSwap) && isNil(net.supportSingleSwap)) ||
-          isNil(net.supportLimit),
-      );
-      if (!noSupportInfo) {
-        setSwapNetworks(swapNetworksSortList.data);
-        setNetworkListFetching(false);
-      } else {
-        swapNetworksSortList = null;
-        void backgroundApiProxy.simpleDb.swapNetworksSort.setRawData({
-          data: [],
-        });
+
+    const refreshPromise = (async () => {
+      let swapNetworksSortList =
+        await backgroundApiProxy.simpleDb.swapNetworksSort.getRawData();
+      if (swapNetworksSortList?.data?.length) {
+        const cachedSwapNetworks = swapNetworksSortList.data;
+        const canUseCachedSwapNetworks =
+          isSwapNetworkCacheCompatible(cachedSwapNetworks);
+        if (canUseCachedSwapNetworks) {
+          setSwapNetworks(cachedSwapNetworks);
+          setNetworkListFetching(false);
+        } else if (isSwapNetworkCacheReadyForBasicList(cachedSwapNetworks)) {
+          setSwapNetworks(cachedSwapNetworks);
+          setNetworkListFetching(false);
+        } else if (!canUseSwapNetworkCacheAsSortSource(cachedSwapNetworks)) {
+          await backgroundApiProxy.simpleDb.swapNetworksSort.setRawData({
+            data: [],
+          });
+          swapNetworksSortList = null;
+        }
       }
-    }
-    let networks: ISwapNetwork[] = [];
-    const fetchNetworks =
-      await backgroundApiProxy.serviceSwap.fetchSwapNetworks();
-    networks = [...fetchNetworks];
-    if (swapNetworksSortList?.data?.length && fetchNetworks?.length) {
-      const sortNetworks = swapNetworksSortList.data;
-      networks = sortNetworks
-        .filter((network) =>
-          fetchNetworks.find((n) => n.networkId === network.networkId),
-        )
-        .map((net) => {
-          const serverNetwork = fetchNetworks.find(
-            (n) => n.networkId === net.networkId,
-          );
-          return { ...net, ...serverNetwork };
-        })
-        .concat(
-          fetchNetworks.filter(
-            (network) =>
-              !sortNetworks.find((n) => n.networkId === network.networkId),
-          ),
-        );
-    }
-    if (networks.length) {
-      await backgroundApiProxy.simpleDb.swapNetworksSort.setRawData({
-        data: networks,
-      });
-      if (
-        !swapNetworksSortList?.data?.length ||
-        swapNetworksSortList?.data?.length !== networks.length
-      ) {
-        setSwapNetworks(networks);
+
+      // Older network caches can preserve user sorting, but selector state needs
+      // the refreshed schema, especially backendIndex.
+      let networks: ISwapNetwork[] = [];
+      try {
+        const fetchNetworks =
+          await backgroundApiProxy.serviceSwap.fetchSwapNetworks({
+            refreshClientNetworks: true,
+          });
+        networks = [...fetchNetworks];
+        if (swapNetworksSortList?.data?.length && fetchNetworks?.length) {
+          networks = mergeSwapNetworksWithCachedSort({
+            cachedNetworks: swapNetworksSortList.data,
+            fetchedNetworks: fetchNetworks,
+          });
+        }
+        if (networks.length) {
+          await backgroundApiProxy.simpleDb.swapNetworksSort.setRawData({
+            data: networks,
+          });
+          setSwapNetworks(networks);
+          hasRefreshedSwapNetworksRef.current = true;
+        }
+      } catch {
+        // The background method shows its own toast. Keep cached networks usable.
+      } finally {
         setNetworkListFetching(false);
       }
-    }
-  }, [setSwapNetworks, swapNetworks.length]);
+    })().finally(() => {
+      refreshSwapNetworksPromiseRef.current = undefined;
+    });
+
+    refreshSwapNetworksPromiseRef.current = refreshPromise;
+    await refreshPromise;
+  }, [setSwapNetworks]);
 
   const fetchSyncSwapProviderManager = useCallback(
     async (noFetch?: boolean) => {
@@ -673,6 +699,9 @@ export function useSwapInit(params?: ISwapInitParams) {
         }
       }
       if (isFocus) {
+        if (!swapNetworksRef.current.length) {
+          void fetchSwapNetworks();
+        }
         if (swapFromMarketJumpTokenRef.current?.token) {
           void swapTypeSwitchAction(swapFromMarketJumpTokenRef.current.type);
           if (swapFromMarketJumpTokenRef.current.direction === 'from') {

--- a/packages/kit/src/views/Swap/hooks/useSwapTokens.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapTokens.ts
@@ -39,6 +39,11 @@ import {
   useSwapTokenFetchingAtom,
   useSwapTokenMapAtom,
 } from '../../../states/jotai/contexts/swap';
+import {
+  buildSwapNetworkReadyKey,
+  isSwapNetworkCacheCompatible,
+  isSwapNetworkCacheReadyForBasicList,
+} from '../utils/swapNetworkCacheUtils';
 
 import { useSwapAddressInfo } from './useSwapAccount';
 import { shouldUseSwapAddressForTokenFetch } from './useSwapAccount.utils';
@@ -141,10 +146,27 @@ export function useSwapTokenList(
   const isTokenFetchAllNetworks = networkUtils.isAllNetwork({
     networkId: tokenFetchParams.networkId,
   });
+  const allNetworkTokenListReady = useMemo(() => {
+    if (!isTokenFetchAllNetworks) {
+      return true;
+    }
+    if (lpToken) {
+      return isSwapNetworkCacheCompatible(swapNetworks);
+    }
+    return isSwapNetworkCacheReadyForBasicList(swapNetworks);
+  }, [isTokenFetchAllNetworks, lpToken, swapNetworks]);
+  const allNetworkSwapNetworksReadyKey = useMemo(
+    () =>
+      isTokenFetchAllNetworks ? buildSwapNetworkReadyKey(swapNetworks) : '',
+    [isTokenFetchAllNetworks, swapNetworks],
+  );
   const tokenListFetchEffectKey = useMemo(
     () =>
       JSON.stringify({
         tokenFetchParams,
+        allNetworkSwapNetworksReadyKey: isTokenFetchAllNetworks
+          ? allNetworkSwapNetworksReadyKey
+          : undefined,
         allNetworkIndexedAccountId: isTokenFetchAllNetworks
           ? swapAddressInfo?.accountInfo?.indexedAccount?.id
           : undefined,
@@ -154,6 +176,7 @@ export function useSwapTokenList(
           : undefined,
       }),
     [
+      allNetworkSwapNetworksReadyKey,
       isTokenFetchAllNetworks,
       swapAddressInfo?.accountInfo?.account?.id,
       swapAddressInfo?.accountInfo?.dbAccount?.id,
@@ -340,7 +363,10 @@ export function useSwapTokenList(
     void (async () => {
       try {
         await Promise.all([
-          tokenFetchParams.networkId && !keywords && isTokenFetchAllNetworks
+          tokenFetchParams.networkId &&
+          !keywords &&
+          isTokenFetchAllNetworks &&
+          allNetworkTokenListReady
             ? swapLoadAllNetworkTokenList(
                 swapAddressInfo?.accountInfo?.indexedAccount?.id,
                 !swapAddressInfo?.accountInfo?.indexedAccount?.id
@@ -365,6 +391,7 @@ export function useSwapTokenList(
     swapAddressInfo?.accountInfo?.account?.id,
     swapAddressInfo?.accountInfo?.dbAccount?.id,
     swapAddressInfo?.accountInfo?.indexedAccount?.id,
+    allNetworkTokenListReady,
     isTokenFetchAllNetworks,
     swapLoadAllNetworkTokenList,
     tokenFetchParams,
@@ -454,7 +481,7 @@ export function useSwapTokenList(
     fetchLoading:
       (swapTokenFetching && currentTokens.length === 0) ||
       (networkUtils.isAllNetwork({ networkId: tokenFetchParams.networkId }) &&
-        !swapAllNetworkTokenList),
+        (!allNetworkTokenListReady || !swapAllNetworkTokenList)),
     lpTokenRequestLoading,
     currentTokens,
   };

--- a/packages/kit/src/views/Swap/pages/modal/SwapProviderSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapProviderSelectModal.tsx
@@ -84,6 +84,9 @@ const SwapProviderSelectModal = () => {
   const [currentSelectQuote] = useSwapQuoteCurrentSelectAtom();
   const selectedProviderInfo =
     currentSelectQuote?.info ?? manualSelectQuoteProvider?.info;
+  const selectedProviderKey = selectedProviderInfo
+    ? `${selectedProviderInfo.provider}-${selectedProviderInfo.providerName}`
+    : undefined;
   const [quoteEventTotalCount] = useSwapQuoteEventTotalCountAtom();
   const [currentEventProviderKeys] = useSwapQuoteCurrentEventProviderKeysAtom();
   const currentEventProviderKeySet = useMemo(
@@ -191,6 +194,18 @@ const SwapProviderSelectModal = () => {
           }
         }
       }
+      const selected = Boolean(
+        item.info.provider === selectedProviderInfo?.provider &&
+        item.info.providerName === selectedProviderInfo?.providerName,
+      );
+      const selectedByManual = Boolean(
+        item.info.provider === manualSelectQuoteProvider?.info.provider &&
+        item.info.providerName === manualSelectQuoteProvider?.info.providerName,
+      );
+      const autoOpenRoute = Boolean(selected && item.openRouterInfo);
+      const autoOpenRouteTrigger = selectedByManual
+        ? manualSelectQuoteProvider
+        : selectedProviderKey;
       return (
         <SwapProviderListItem
           testID={SwapTestIDs.providerItem(item.info.providerName)}
@@ -201,10 +216,10 @@ const SwapProviderSelectModal = () => {
                 }
               : undefined
           }
-          selected={Boolean(
-            item.info.provider === selectedProviderInfo?.provider &&
-            item.info.providerName === selectedProviderInfo?.providerName,
-          )}
+          selected={selected}
+          autoOpenRoute={autoOpenRoute}
+          autoOpenRouteTrigger={autoOpenRouteTrigger}
+          routeCollapseTrigger={selectedProviderKey}
           fromTokenAmount={fromTokenAmount.value}
           fromToken={fromToken}
           toToken={toToken}
@@ -217,7 +232,9 @@ const SwapProviderSelectModal = () => {
     [
       fromToken,
       fromTokenAmount,
+      manualSelectQuoteProvider,
       onSelectQuote,
+      selectedProviderKey,
       selectedProviderInfo?.provider,
       selectedProviderInfo?.providerName,
       settingsPersist.currencyInfo.symbol,

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
@@ -143,6 +143,7 @@ const SwapTokenSelectPage = ({
     : false;
   const fromTokenRef = useRef<ISwapToken | undefined>(fromToken);
   const toTokenRef = useRef<ISwapToken | undefined>(toToken);
+  const hasUserSelectedNetworkRef = useRef(false);
   if (fromTokenRef.current !== fromToken) {
     fromTokenRef.current = fromToken;
   }
@@ -212,12 +213,31 @@ const SwapTokenSelectPage = ({
   );
 
   useEffect(() => {
-    setCurrentSelectNetwork(syncDefaultNetworkSelect);
-    return () => {
+    if (hasUserSelectedNetworkRef.current) {
+      return;
+    }
+    const nextNetwork = syncDefaultNetworkSelect();
+    if (!nextNetwork) {
+      return;
+    }
+    setCurrentSelectNetwork((prev) => {
+      if (
+        !prev ||
+        prev.isAllNetworks ||
+        prev.networkId === nextNetwork.networkId
+      ) {
+        return nextNetwork;
+      }
+      return prev;
+    });
+  }, [setCurrentSelectNetwork, syncDefaultNetworkSelect]);
+
+  useEffect(
+    () => () => {
       setCurrentSelectNetwork(undefined);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setCurrentSelectNetwork]);
+    },
+    [setCurrentSelectNetwork],
+  );
 
   useEffect(() => {
     const accountNet =
@@ -334,6 +354,7 @@ const SwapTokenSelectPage = ({
 
   const onSelectCurrentNetwork = useCallback(
     (network: ISwapNetwork) => {
+      hasUserSelectedNetworkRef.current = true;
       setCurrentSelectNetwork(network);
       listViewRef.current?.scrollToOffset({
         offset: 0,

--- a/packages/kit/src/views/Swap/utils/swapNetworkCacheUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapNetworkCacheUtils.ts
@@ -1,0 +1,93 @@
+import { isNil } from 'lodash';
+
+import type { ISwapNetwork } from '@onekeyhq/shared/types/swap/types';
+
+function hasSwapNetworkSupportFields(network: ISwapNetwork) {
+  return (
+    (!isNil(network.supportCrossChainSwap) ||
+      !isNil(network.supportSingleSwap)) &&
+    !isNil(network.supportLimit)
+  );
+}
+
+export function isSwapNetworkReadyForTokenSelector(network: ISwapNetwork) {
+  return (
+    hasSwapNetworkSupportFields(network) &&
+    typeof network.backendIndex === 'boolean'
+  );
+}
+
+export function isSwapNetworkCacheCompatible(networks?: ISwapNetwork[] | null) {
+  return (
+    !!networks?.length && networks.every(isSwapNetworkReadyForTokenSelector)
+  );
+}
+
+export function isSwapNetworkCacheReadyForBasicList(
+  networks?: ISwapNetwork[] | null,
+) {
+  return (
+    !!networks?.length &&
+    networks.every(
+      (network) =>
+        typeof network.networkId === 'string' &&
+        network.networkId.length > 0 &&
+        hasSwapNetworkSupportFields(network),
+    )
+  );
+}
+
+export function canUseSwapNetworkCacheAsSortSource(
+  networks?: ISwapNetwork[] | null,
+) {
+  return (
+    !!networks?.length &&
+    networks.every(
+      (network) =>
+        typeof network.networkId === 'string' && network.networkId.length > 0,
+    )
+  );
+}
+
+export function mergeSwapNetworksWithCachedSort({
+  cachedNetworks,
+  fetchedNetworks,
+}: {
+  cachedNetworks?: ISwapNetwork[] | null;
+  fetchedNetworks: ISwapNetwork[];
+}) {
+  if (!cachedNetworks?.length || !fetchedNetworks.length) {
+    return fetchedNetworks;
+  }
+
+  return cachedNetworks
+    .filter((network) =>
+      fetchedNetworks.find((item) => item.networkId === network.networkId),
+    )
+    .map((network) => {
+      const fetchedNetwork = fetchedNetworks.find(
+        (item) => item.networkId === network.networkId,
+      );
+      return { ...network, ...fetchedNetwork };
+    })
+    .concat(
+      fetchedNetworks.filter(
+        (network) =>
+          !cachedNetworks.find((item) => item.networkId === network.networkId),
+      ),
+    );
+}
+
+export function buildSwapNetworkReadyKey(networks: ISwapNetwork[]) {
+  return networks
+    .map((network) =>
+      [
+        network.networkId,
+        network.supportSingleSwap,
+        network.supportCrossChainSwap,
+        network.supportLimit,
+        network.backendIndex,
+      ].join(':'),
+    )
+    .join('|');
+}

--- a/packages/kit/src/views/Swap/utils/usMarketStatusUtils.ts
+++ b/packages/kit/src/views/Swap/utils/usMarketStatusUtils.ts
@@ -1,0 +1,38 @@
+import type {
+  ISwapAlertState,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
+import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
+
+import { isOndoStockSource } from '../../Market/components/utils/stockSource';
+
+export function isUSMarketStatusStockTokenSource(source?: string) {
+  return isOndoStockSource(source);
+}
+
+export function shouldCheckSwapWarningUSMarketClosed({
+  alerts,
+  swapTypeSwitch,
+  fromToken,
+  toToken,
+  accountReady,
+  isWaitingActionableQuote,
+  hasFromAccountWallet,
+}: {
+  alerts: ISwapAlertState[];
+  swapTypeSwitch: ESwapTabSwitchType;
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+  accountReady?: boolean;
+  isWaitingActionableQuote: boolean;
+  hasFromAccountWallet: boolean;
+}) {
+  return (
+    !alerts.length &&
+    swapTypeSwitch === ESwapTabSwitchType.SWAP &&
+    Boolean(fromToken && toToken) &&
+    accountReady === true &&
+    !isWaitingActionableQuote &&
+    hasFromAccountWallet
+  );
+}

--- a/packages/shared/src/config/appConfig.ts
+++ b/packages/shared/src/config/appConfig.ts
@@ -36,7 +36,6 @@ export const DOWNLOAD_MOBILE_APP_URL =
   'https://onekey.so/download?client=mobile';
 export const REFERRAL_HELP_LINK = 'https://help.onekey.so/articles/11461266';
 export const CREATOR_PROGRAM_URL = 'https://creator.onekey.so/';
-export const PERPS_CAMPAIGN_HELP_LINK = 'https://campaign.onekey.so/perps-s1';
 export const COIN_CONTROL_HELP_LINK =
   'https://help.onekey.so/articles/13050014';
 export const HARDWARE_TROUBLESHOOTING_URL =

--- a/packages/shared/src/modules/LaunchOptionsManager/LaunchOptionsManager.native.ts
+++ b/packages/shared/src/modules/LaunchOptionsManager/LaunchOptionsManager.native.ts
@@ -17,6 +17,13 @@ const getUIVisibleTimeAt = () => {
   return globalThis.$$onekeyUIVisibleAt || 0;
 };
 
+// `__BUNDLE_START_TIME__` is injected by the Metro/RN bundle. In test harness,
+// bg-thread runtime, or partial OTA boot it may not be declared at all — and
+// `__BUNDLE_START_TIME__ || 0` would throw `ReferenceError` on an undeclared
+// identifier, not fall back to 0. `typeof` is the only safe probe.
+const getBundleStartTimeSafe = (): number =>
+  typeof __BUNDLE_START_TIME__ !== 'undefined' ? __BUNDLE_START_TIME__ : 0;
+
 const LaunchOptionsManagerModule: ILaunchOptionsManagerInterface = {
   getLaunchOptions: () =>
     ReactNativeDeviceUtils.getLaunchOptions() as Promise<ILaunchOptions | null>,
@@ -38,33 +45,46 @@ const LaunchOptionsManagerModule: ILaunchOptionsManagerInterface = {
   getJSReadyTime: async () => {
     const jsReadyAt = getJSReadyTimeAt();
     const startupAt = await getStartupTimeAt();
-    return jsReadyAt && startupAt
-      ? Promise.resolve(jsReadyAt - startupAt)
-      : Promise.resolve(0);
+    if (startupAt && jsReadyAt && jsReadyAt > startupAt) {
+      return jsReadyAt - startupAt;
+    }
+    // Fallback: when native startupTime is unavailable, anchor on
+    // __BUNDLE_START_TIME__ (same performance.now() base as $$…FromPerformanceNow).
+    const jsReadyPerf = globalThis.$$onekeyJsReadyFromPerformanceNow || 0;
+    const bundleStart = getBundleStartTimeSafe();
+    return jsReadyPerf && bundleStart
+      ? Math.round(jsReadyPerf - bundleStart)
+      : 0;
   },
   getUIVisibleTime: async () => {
-    const startupAt = await getStartupTimeAt();
     const uiVisibleAt = getUIVisibleTimeAt();
-    return startupAt && uiVisibleAt
-      ? Promise.resolve(uiVisibleAt - startupAt)
-      : Promise.resolve(0);
+    if (!uiVisibleAt) return 0;
+    const startupAt = await getStartupTimeAt();
+    if (startupAt && uiVisibleAt > startupAt) {
+      return uiVisibleAt - startupAt;
+    }
+    const uiVisiblePerf = globalThis.$$onekeyUIVisibleFromPerformanceNow || 0;
+    const bundleStart = getBundleStartTimeSafe();
+    return uiVisiblePerf && bundleStart
+      ? Math.round(uiVisiblePerf - bundleStart)
+      : 0;
   },
   getBundleStartTime: () => {
-    return Promise.resolve(Math.round(__BUNDLE_START_TIME__ || 0));
+    return Promise.resolve(Math.round(getBundleStartTimeSafe()));
   },
   getJsReadyFromPerformanceNow: () => {
+    const bundleStart = getBundleStartTimeSafe();
     return Promise.resolve(
       Math.round(
-        (globalThis.$$onekeyJsReadyFromPerformanceNow || 0) -
-          __BUNDLE_START_TIME__,
+        (globalThis.$$onekeyJsReadyFromPerformanceNow || 0) - bundleStart,
       ),
     );
   },
   getUIVisibleFromPerformanceNow: () => {
+    const bundleStart = getBundleStartTimeSafe();
     return Promise.resolve(
       Math.round(
-        (globalThis.$$onekeyUIVisibleFromPerformanceNow || 0) -
-          __BUNDLE_START_TIME__,
+        (globalThis.$$onekeyUIVisibleFromPerformanceNow || 0) - bundleStart,
       ),
     );
   },

--- a/packages/shared/src/utils/appVisibility.ts
+++ b/packages/shared/src/utils/appVisibility.ts
@@ -1,61 +1,28 @@
 import platformEnv from '../platformEnv';
 
-// Single cached boolean fed by platform-native visibility/focus signals.
-// Cheap to read from hot paths (no sync IPC, no DOM query per call).
+// Cross-platform visibility signal. Three entry points:
 //
-// Web / desktop renderer → document.visibilitychange + window focus/blur
-// Mobile (RN)            → AppState 'change' event
-// Extension service worker / unknown → defaults to visible (no signal)
+//   isAppVisible()              — cached boolean for hot paths
+//   getCurrentVisibilityState() — live per-call read
+//   onVisibilityStateChange(cb) — subscribe to transitions
+//
+// Platform signals:
+//   Web / desktop renderer → document.visibilitychange + window focus/blur
+//   Desktop (Electron)     → desktopApi.onAppState (main-process focus)
+//   Mobile (RN)            → AppState 'change' event
+//   Extension service worker / unknown → defaults to visible (no signal)
+
 let _visible = true;
 let _initialized = false;
 
 function _initOnce(): void {
   if (_initialized) return;
   _initialized = true;
-
   try {
-    if (platformEnv.isNative) {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { AppState } =
-        require('react-native') as typeof import('react-native');
-      _visible =
-        AppState.currentState === 'active' || AppState.currentState === null;
-      AppState.addEventListener('change', (state) => {
-        _visible = state === 'active';
-      });
-      return;
-    }
-
-    if (
-      platformEnv.isDesktop &&
-      typeof globalThis !== 'undefined' &&
-      globalThis.desktopApi?.onAppState
-    ) {
-      try {
-        _visible = globalThis.desktopApi.isFocused?.() ?? true;
-      } catch {
-        _visible = true;
-      }
-      globalThis.desktopApi.onAppState((state) => {
-        _visible = state === 'active';
-      });
-      return;
-    }
-
-    if (typeof document !== 'undefined') {
-      _visible = document.visibilityState === 'visible';
-      document.addEventListener('visibilitychange', () => {
-        _visible = document.visibilityState === 'visible';
-      });
-      if (typeof globalThis.window !== 'undefined') {
-        globalThis.window.addEventListener('focus', () => {
-          _visible = true;
-        });
-        globalThis.window.addEventListener('blur', () => {
-          _visible = false;
-        });
-      }
-    }
+    onVisibilityStateChange((visible) => {
+      _visible = visible;
+    });
+    _visible = getCurrentVisibilityState();
   } catch {
     // Any subscription failure → never accidentally suppress work.
     _visible = true;
@@ -65,4 +32,76 @@ function _initOnce(): void {
 export function isAppVisible(): boolean {
   _initOnce();
   return _visible;
+}
+
+export function getCurrentVisibilityState(): boolean {
+  if (platformEnv.isNative) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { AppState } =
+      require('react-native') as typeof import('react-native');
+    // currentState is null at launch while AppState retrieves it over the
+    // bridge — treat null as active to avoid suppressing work during boot.
+    // https://reactnative.dev/docs/appstate
+    return AppState.currentState === 'active' || AppState.currentState === null;
+  }
+  if (platformEnv.isDesktop) {
+    try {
+      return globalThis.desktopApi?.isFocused?.() ?? true;
+    } catch {
+      return true;
+    }
+  }
+  if (typeof document !== 'undefined') {
+    return document.visibilityState === 'visible';
+  }
+  return true;
+}
+
+export function onVisibilityStateChange(
+  callback: (visible: boolean) => void,
+): () => void {
+  if (platformEnv.isNative) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { AppState } =
+      require('react-native') as typeof import('react-native');
+    const subscription = AppState.addEventListener('change', (nextAppState) => {
+      callback(nextAppState === 'active');
+    });
+    return () => {
+      subscription.remove();
+    };
+  }
+  if (platformEnv.isDesktop && globalThis.desktopApi?.onAppState) {
+    return globalThis.desktopApi.onAppState((state) => {
+      callback(state === 'active');
+    });
+  }
+  if (typeof document !== 'undefined') {
+    const handleVisibilityStateChange = () => {
+      callback(document.visibilityState === 'visible');
+    };
+    const windowFocus = () => callback(true);
+    const windowBlur = () => callback(false);
+    document.addEventListener(
+      'visibilitychange',
+      handleVisibilityStateChange,
+      false,
+    );
+    if (typeof globalThis.window !== 'undefined') {
+      globalThis.window.addEventListener('focus', windowFocus);
+      globalThis.window.addEventListener('blur', windowBlur);
+    }
+    return () => {
+      document.removeEventListener(
+        'visibilitychange',
+        handleVisibilityStateChange,
+        false,
+      );
+      if (typeof globalThis.window !== 'undefined') {
+        globalThis.window.removeEventListener('focus', windowFocus);
+        globalThis.window.removeEventListener('blur', windowBlur);
+      }
+    };
+  }
+  return () => {};
 }

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -581,6 +581,7 @@ export interface IFetchQuoteResult {
   isWrapped?: boolean;
   unSupportReceiveAddressDifferent?: boolean;
   routesData?: IQuoteRoutePath[];
+  openRouterInfo?: boolean;
   quoteExtraData?: IQuoteExtraData;
   autoSuggestedSlippage?: number;
   unSupportSlippage?: boolean;
@@ -1106,6 +1107,13 @@ export interface IFetchSpeedCheckResult {
   };
   fromTokenInfo?: ISwapTokenBase;
   toTokenInfo?: ISwapTokenBase;
+}
+
+export interface IFetchUSMarketStatusResult {
+  open: boolean;
+  session: 'PRE_MARKET' | 'REGULAR' | 'POST_MARKET' | 'OVERNIGHT' | 'CLOSED';
+  reason: string | null;
+  unavailable?: boolean;
 }
 
 export enum ESwapLimitOrderStatus {


### PR DESCRIPTION
Sync bundle release changes from `release/v6.3.0` to `x`.

## Commits synced (6)
- fix: address swap issues (OK-55160, OK-55212, OK-55270, OK-55273, OK-55302) (#11773)
- perf(v6.3.0): coalesce bg→main atom broadcasts + batch token merge bridge calls (#11740)
- fix(browser): persist tab closes immediately to survive process kill (#11827)
- fix: update perps referral learn more link (#11842)
- fix(history): prevent multi-token transfer row overflow in web list (OK-55494) (#11838)
- fix(ada): Android software-wallet Cardano address creation stuck loading (#11839)

## Notes
- Only the **6 commits genuinely missing from `x`** were cherry-picked. The other ~31 release commits (seq #1–#3) already reached `x` via prior syncs (#11752, #11771) and the #11806 merge; their patch-ids no longer match, so a full rebase was deliberately avoided.
- **#11710** (history/overview spinner fix) was **skipped**: `x` already contains an evolved/superseded version of the same logic (newer `fetchAccountHistoryForMergeDerive` service path, refactored `Tabs/Container` + `Tabs/List`). Re-applying it would regress `x`.
- One conflict resolved in `ServiceHyperliquid.ts` (#11740): kept both `x`'s `markPerpsColdStartPerf` instrumentation and the commit's split-assignment refactor.
- Release-tracking files (`RELEASES.json`, `.env.version` BUILD_NUMBER) excluded from the sync by design.