### PR TITLE
fix: provide account selector mirror for perps order dialogs (OK-55541)

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/AdjustPositionMarginModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/AdjustPositionMarginModal.tsx
@@ -25,6 +25,7 @@ import {
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { usePerpsAccountScopedActivePositions } from '../../hooks/usePerpsAccountScopedActivePositions';
+import { PerpsAccountSelectorProviderMirror } from '../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 import {
   PERP_DIALOG_BUTTON_SIZE,
@@ -364,14 +365,16 @@ export function showAdjustPositionMarginDialog({
     }),
 
     renderContent: (
-      <PerpsProviderMirror>
-        <AdjustPositionMarginForm
-          coin={coin}
-          onClose={() => {
-            void dialogInstance.close();
-          }}
-        />
-      </PerpsProviderMirror>
+      <PerpsAccountSelectorProviderMirror>
+        <PerpsProviderMirror>
+          <AdjustPositionMarginForm
+            coin={coin}
+            onClose={() => {
+              void dialogInstance.close();
+            }}
+          />
+        </PerpsProviderMirror>
+      </PerpsAccountSelectorProviderMirror>
     ),
     contentContainerProps: PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
     showFooter: false,

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/CancelAllOrdersModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/CancelAllOrdersModal.tsx
@@ -17,6 +17,7 @@ import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 
 import { usePerpsAccountScopedCacheAddress } from '../../hooks/usePerpsAccountScopedCacheAddress';
+import { PerpsAccountSelectorProviderMirror } from '../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 import {
   getPerpsAccountScopedListData,
@@ -170,15 +171,17 @@ export function showCancelAllOrdersDialog(
       id: ETranslations.perp_cacenl_all_order_title,
     }),
     renderContent: (
-      <PerpsProviderMirror>
-        <CancelAllOrdersContent
-          onClose={() => {
-            void dialogInstance.close();
-          }}
-          filterByCoin={filterByCoin}
-          scopedAccountAddress={scopedAccountAddress}
-        />
-      </PerpsProviderMirror>
+      <PerpsAccountSelectorProviderMirror>
+        <PerpsProviderMirror>
+          <CancelAllOrdersContent
+            onClose={() => {
+              void dialogInstance.close();
+            }}
+            filterByCoin={filterByCoin}
+            scopedAccountAddress={scopedAccountAddress}
+          />
+        </PerpsProviderMirror>
+      </PerpsAccountSelectorProviderMirror>
     ),
     contentContainerProps: PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
     showFooter: false,

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/CloseAllPositionsModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/CloseAllPositionsModal.tsx
@@ -16,6 +16,7 @@ import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 
 import { usePerpsAccountScopedCacheAddress } from '../../hooks/usePerpsAccountScopedCacheAddress';
+import { PerpsAccountSelectorProviderMirror } from '../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 import { isPerpsAccountAddressMatched } from '../../utils/accountScopedData';
 import {
@@ -159,15 +160,17 @@ export function showCloseAllPositionsDialog(
       id: ETranslations.perp_position_close,
     }),
     renderContent: (
-      <PerpsProviderMirror>
-        <CloseAllPositionsContent
-          onClose={() => {
-            void dialogInstance.close();
-          }}
-          filterByCoin={filterByCoin}
-          scopedAccountAddress={scopedAccountAddress}
-        />
-      </PerpsProviderMirror>
+      <PerpsAccountSelectorProviderMirror>
+        <PerpsProviderMirror>
+          <CloseAllPositionsContent
+            onClose={() => {
+              void dialogInstance.close();
+            }}
+            filterByCoin={filterByCoin}
+            scopedAccountAddress={scopedAccountAddress}
+          />
+        </PerpsProviderMirror>
+      </PerpsAccountSelectorProviderMirror>
     ),
     contentContainerProps: PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
     showFooter: false,

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
@@ -36,6 +36,7 @@ import type { IPerpsFrontendOrder } from '@onekeyhq/shared/types/hyperliquid/sdk
 import { usePerpsAccountScopedActivePositions } from '../../hooks/usePerpsAccountScopedActivePositions';
 import { usePerpsAccountScopedCacheAddress } from '../../hooks/usePerpsAccountScopedCacheAddress';
 import { usePerpsMidPrice } from '../../hooks/usePerpsMidPrice';
+import { PerpsAccountSelectorProviderMirror } from '../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 import {
   getPerpsAccountScopedListData,
@@ -727,16 +728,18 @@ function SetTpslModal() {
         })}
       />
       <Page.Body>
-        <PerpsProviderMirror>
-          <YStack px="$4" flex={1}>
-            <SetTpslForm
-              coin={coin}
-              szDecimals={szDecimals}
-              assetId={assetId}
-              onClose={handleClose}
-            />
-          </YStack>
-        </PerpsProviderMirror>
+        <PerpsAccountSelectorProviderMirror>
+          <PerpsProviderMirror>
+            <YStack px="$4" flex={1}>
+              <SetTpslForm
+                coin={coin}
+                szDecimals={szDecimals}
+                assetId={assetId}
+                onClose={handleClose}
+              />
+            </YStack>
+          </PerpsProviderMirror>
+        </PerpsAccountSelectorProviderMirror>
       </Page.Body>
     </Page>
   );
@@ -757,16 +760,18 @@ export function showSetTpslDialog({
       id: ETranslations.perp_tp_sl_position_desc,
     }),
     renderContent: (
-      <PerpsProviderMirror>
-        <SetTpslForm
-          coin={coin}
-          szDecimals={szDecimals}
-          assetId={assetId}
-          onClose={() => {
-            void dialogInstance.close();
-          }}
-        />
-      </PerpsProviderMirror>
+      <PerpsAccountSelectorProviderMirror>
+        <PerpsProviderMirror>
+          <SetTpslForm
+            coin={coin}
+            szDecimals={szDecimals}
+            assetId={assetId}
+            onClose={() => {
+              void dialogInstance.close();
+            }}
+          />
+        </PerpsProviderMirror>
+      </PerpsAccountSelectorProviderMirror>
     ),
     contentContainerProps: PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
     showFooter: false,

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -34,6 +34,7 @@ import { ETriggerOrderType } from '@onekeyhq/shared/types/hyperliquid/types';
 
 import { useOrderConfirm, useTradingCalculationsForSide } from '../../../hooks';
 import { useTradingPrice } from '../../../hooks/useTradingPrice';
+import { PerpsAccountSelectorProviderMirror } from '../../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
 import {
   GetTradingButtonStyleProps,
@@ -610,16 +611,18 @@ export function showOrderConfirmDialog({
       id: ETranslations.perp_confirm_order,
     }),
     renderContent: (
-      <PerpsProviderMirror>
-        <OrderConfirmContent
-          onClose={() => {
-            void dialogInstance.close();
-          }}
-          overrideSide={overrideSide}
-          enableTradingBeforeConfirm={enableTradingBeforeConfirm}
-          enableTradingAccountKey={enableTradingAccountKey}
-        />
-      </PerpsProviderMirror>
+      <PerpsAccountSelectorProviderMirror>
+        <PerpsProviderMirror>
+          <OrderConfirmContent
+            onClose={() => {
+              void dialogInstance.close();
+            }}
+            overrideSide={overrideSide}
+            enableTradingBeforeConfirm={enableTradingBeforeConfirm}
+            enableTradingAccountKey={enableTradingAccountKey}
+          />
+        </PerpsProviderMirror>
+      </PerpsAccountSelectorProviderMirror>
     ),
     contentContainerProps: PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
     showFooter: false,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55541](https://onekeyhq.atlassian.net/browse/OK-55541)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Wrap perps dialogs/pages that render in a portal/route tree with `PerpsAccountSelectorProviderMirror` (outer) in addition to `PerpsProviderMirror`, so the account-selector Jotai context is available inside them.
- Fixes the order-confirm dialog crash reported in OK-55541, plus 4 sibling dialogs that share the same latent crash.

## Intent & Context
OK-55541 reported "perps - 下单时会报错" (error when placing a perps order). The attached screenshot showed it was not an API error but a React render crash caught by the ErrorBoundary:

```
OneKeyLocalError: useContextStore ERROR: store not initialized
  at useActiveAccount (accountSelector/atoms.ts)
  at usePerpsAccountScopedCacheAddress
  at usePerpsAccountScopedActivePositions
  at useLiquidationPrice
  at useTradingCalculationsForSide
  at OrderConfirmContent (OrderConfirmModal.tsx)
```

The `<OrderConfirmContent>` shown via `Dialog.show` renders in a root portal tree wrapped only by `PerpsProviderMirror` (Hyperliquid context). After #11840 it transitively calls `useActiveAccount({ num: 0 })` from the account-selector context, which has no provider in that portal tree — hence "store not initialized".

## Root Cause
PR #11840 ("fix: preserve perps cold start cache") introduced `usePerpsAccountScopedCacheAddress` / `usePerpsAccountScopedActivePositions`. These scope cached positions/liquidation-price to the correct account during cold start. To resolve "current account address" before perps' own active-account atom is populated, the hook falls back to `useActiveAccount({ num: 0 })` (account-selector context) + display snapshot. That wired the account-selector context into the `useLiquidationPrice → useTradingCalculationsForSide` chain.

The main trading panel works because it lives inside the page tree that has the account-selector provider. But `Dialog.show` content renders in the root portal tree, which only mirrors the Hyperliquid context — so the new dependency crashes there.

## Design Decisions
- Chose to add `PerpsAccountSelectorProviderMirror` to the affected portal/route trees rather than removing `useActiveAccount` from the hook chain. This preserves #11840's account-isolation intent (cached data stays scoped to the active account inside dialogs too) and follows the existing repo convention (`PerpTradersHistoryListModal`, `MoblieTokenSelector`, `InviteeRewardModal` already nest `PerpsAccountSelectorProviderMirror` > `PerpsProviderMirror`).
- No logic changes — purely provider wrapping.

## Changes Detail
Cross-referenced all consumers of the `useActiveAccount`-dependent hooks against files that wrap with `PerpsProviderMirror` but not the account-selector mirror. The matches (all `Dialog.show`/route entry points) were fixed:
- `TradingPanel/modals/OrderConfirmModal.tsx` — the dialog from the Jira report.
- `OrderInfoPanel/SetTpslModal.tsx` — both the `Dialog.show` variant and the `MobileSetTpsl` route Page variant.
- `OrderInfoPanel/AdjustPositionMarginModal.tsx`, `CloseAllPositionsModal.tsx`, `CancelAllOrdersModal.tsx` — same latent crash.

Files that wrap with `PerpsProviderMirror` but do not touch the hook chain (e.g. `PositionShareModal`, `PerpSettingsDialog`, `ClosePositionModal`) were verified unaffected and left unchanged.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web / Desktop / Mobile / Extension (crash was most visible on Web; mobile route variant also covered)
- **Risk Areas**: Provider nesting only; mirrors are designed to nest safely. No behavioral/logic change.

## Test plan
- [ ] Web: open a perps market, tap Long/Short → order confirm dialog opens without crash; place order succeeds.
- [ ] Web: open Set TP/SL, Adjust Margin, Close All Positions, Cancel All Orders dialogs from the order info panel → no "store not initialized" crash.
- [ ] Mobile: open the Set TP/SL screen (MobileSetTpsl route) → renders correctly.
- [ ] Cold start: verify cached positions/liquidation price inside dialogs are still scoped to the active account (no cross-account leakage).

[OK-55541]: https://onekeyhq.atlassian.net/browse/OK-55541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ