### PR TITLE
fix: improve market web tab table height(OK-55551 OK-55499)

### DIFF
--- a/packages/components/src/composite/Table/index.tsx
+++ b/packages/components/src/composite/Table/index.tsx
@@ -1,5 +1,5 @@
 import type { RefObject } from 'react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Pressable, StyleSheet } from 'react-native';
 import { globalRef } from 'react-native-draggable-flatlist/src/context/globalRef';
@@ -19,6 +19,8 @@ import { ListView } from '../../layouts/ListView';
 import { SortableListView } from '../../layouts/SortableListView';
 import { SizableText, Stack, XStack, YStack } from '../../primitives';
 import { Haptics, ImpactFeedbackStyle } from '../../primitives/Haptics';
+import { useTabsContext } from '../Tabs/context';
+import { useTabNameContext } from '../Tabs/TabNameContext';
 
 import { Column, MemoHeaderColumn } from './components';
 
@@ -34,6 +36,26 @@ import type {
 
 const DEFAULT_ROW_HEIGHT = 60;
 const defaultEstimatedListSize = { width: 370, height: 525 };
+
+const resolveNumericStyleValue = (value: unknown) => {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value !== 'string') {
+    return 0;
+  }
+
+  if (value.startsWith('$')) {
+    const tokenValue = getTokenValue(
+      value as Parameters<typeof getTokenValue>[0],
+      'space',
+    );
+    return typeof tokenValue === 'number' ? tokenValue : 0;
+  }
+
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
 
 const renderContent = (text?: string) => (
   <SizableText size="$bodyMd" color="$textSubdued" userSelect="none">
@@ -304,9 +326,12 @@ function BasicTable<T>({
   const { gtMd } = useMedia();
   const [isShowBackToTopButton, setIsShowBackToTopButton] = useState(false);
   const listViewRef = useRef<IListViewRef<unknown> | null>(null);
+  const tableRootRef = useRef<HTMLElement | null>(null);
   const isShowBackToTopButtonRef = useRef(isShowBackToTopButton);
   isShowBackToTopButtonRef.current = isShowBackToTopButton;
   const scrollAtRef = useRef(0);
+  const currentTabName = useTabNameContext();
+  const { requestRemeasure, scrollTabElementsRef } = useTabsContext();
 
   const dataSource = useMemo(() => {
     if (showSkeleton) {
@@ -388,6 +413,124 @@ function BasicTable<T>({
       ? estimatedItemSize
       : (getTokenValue(estimatedItemSize, 'size') as number);
   }, [estimatedItemSize]);
+  const resolvedRowHeight = useMemo(() => {
+    const rowStyle = rowProps as Record<string, unknown> | undefined;
+    const rowStyleHeight = resolveNumericStyleValue(
+      rowStyle?.height ?? rowStyle?.minHeight,
+    );
+    return Math.max(
+      itemSize ?? DEFAULT_ROW_HEIGHT,
+      rowStyleHeight || DEFAULT_ROW_HEIGHT,
+    );
+  }, [itemSize, rowProps]);
+
+  // On native, when tabIntegrated the header row MUST be inside the list
+  // (as ListHeaderComponent) so it participates in the collapsible tab scroll.
+  // On web, the header must stay outside the list because SortableListView uses
+  // absolute positioning for items, which would overlap ListHeaderComponent.
+  const effectiveStickyHeader =
+    stickyHeader && (!tabIntegrated || !platformEnv.isNative);
+
+  const webTabIntegratedListHeight = useMemo(() => {
+    if (!tabIntegrated || platformEnv.isNative || scrollEnabled) {
+      return undefined;
+    }
+
+    const contentStyle = contentContainerStyle as
+      | Record<string, unknown>
+      | undefined;
+    const paddingTop = resolveNumericStyleValue(
+      contentStyle?.paddingTop ?? contentStyle?.paddingVertical,
+    );
+    const paddingBottom = resolveNumericStyleValue(
+      contentStyle?.paddingBottom ?? contentStyle?.paddingVertical,
+    );
+    const headerHeight =
+      TableHeaderComponent || (!effectiveStickyHeader && showHeader)
+        ? DEFAULT_ROW_HEIGHT
+        : 0;
+    const footerHeight = TableFooterComponent
+      ? DEFAULT_ROW_HEIGHT + resolvedRowHeight
+      : 0;
+    const emptyHeight =
+      dataSource.length === 0 && TableEmptyComponent ? DEFAULT_ROW_HEIGHT : 0;
+    const dataHeight = dataSource.length * resolvedRowHeight;
+
+    return Math.max(
+      400,
+      paddingTop +
+        paddingBottom +
+        headerHeight +
+        footerHeight +
+        emptyHeight +
+        dataHeight,
+    );
+  }, [
+    TableEmptyComponent,
+    TableFooterComponent,
+    TableHeaderComponent,
+    contentContainerStyle,
+    dataSource.length,
+    effectiveStickyHeader,
+    resolvedRowHeight,
+    scrollEnabled,
+    showHeader,
+    tabIntegrated,
+  ]);
+  const webTabIntegratedRootHeight = useMemo(() => {
+    if (!webTabIntegratedListHeight) {
+      return undefined;
+    }
+    const stickyHeaderHeight =
+      effectiveStickyHeader && showHeader ? DEFAULT_ROW_HEIGHT : 0;
+    return webTabIntegratedListHeight + stickyHeaderHeight;
+  }, [effectiveStickyHeader, showHeader, webTabIntegratedListHeight]);
+
+  useEffect(() => {
+    if (
+      !tabIntegrated ||
+      platformEnv.isNative ||
+      scrollEnabled ||
+      !currentTabName ||
+      !webTabIntegratedRootHeight
+    ) {
+      return undefined;
+    }
+
+    const element = tableRootRef.current;
+    const refStore = scrollTabElementsRef?.current;
+    if (!element || !refStore) {
+      return undefined;
+    }
+
+    if (!refStore[currentTabName]) {
+      refStore[currentTabName] = {} as {
+        element: HTMLElement;
+        height?: number;
+      };
+    }
+    const entry = refStore[currentTabName];
+    entry.element = element;
+    entry.height = webTabIntegratedRootHeight;
+
+    requestRemeasure?.();
+
+    return () => {
+      const currentEntry = refStore[currentTabName];
+      if (currentEntry?.element === element) {
+        delete refStore[currentTabName];
+        requestRemeasure?.();
+      }
+    };
+  }, [
+    currentTabName,
+    dataSource.length,
+    requestRemeasure,
+    scrollEnabled,
+    scrollTabElementsRef,
+    tabIntegrated,
+    webTabIntegratedRootHeight,
+  ]);
 
   const renderSortableItem = useCallback(
     ({ item, drag, dragProps, index, isActive }: IRenderItemParams<T>) => {
@@ -418,20 +561,14 @@ function BasicTable<T>({
     },
     [columns, draggable, onRow, rowProps, showSkeleton],
   );
-  // On native, when tabIntegrated the header row MUST be inside the list
-  // (as ListHeaderComponent) so it participates in the collapsible tab scroll.
-  // On web, the header must stay outside the list because SortableListView uses
-  // absolute positioning for items, which would overlap ListHeaderComponent.
-  const effectiveStickyHeader =
-    stickyHeader && (!tabIntegrated || !platformEnv.isNative);
 
   const getItemLayout = useCallback(
     (_: any, index: number) => ({
-      length: itemSize || DEFAULT_ROW_HEIGHT,
-      offset: index * (itemSize || DEFAULT_ROW_HEIGHT),
+      length: resolvedRowHeight,
+      offset: index * resolvedRowHeight,
       index,
     }),
-    [itemSize],
+    [resolvedRowHeight],
   );
 
   const listHeaderComponent = useMemo(
@@ -452,6 +589,7 @@ function BasicTable<T>({
           tabIntegrated={tabIntegrated}
           useFlashList={useFlashList}
           scrollEnabled={scrollEnabled}
+          height={webTabIntegratedListHeight}
           ref={listViewRef as any}
           contentContainerStyle={contentContainerStyle}
           stickyHeaderHiddenOnScroll={stickyHeaderHiddenOnScroll}
@@ -479,6 +617,7 @@ function BasicTable<T>({
         <ListView
           useFlashList={useFlashList}
           scrollEnabled={scrollEnabled}
+          height={webTabIntegratedListHeight}
           ref={listViewRef as any}
           contentContainerStyle={contentContainerStyle}
           stickyHeaderHiddenOnScroll={stickyHeaderHiddenOnScroll}
@@ -524,11 +663,12 @@ function BasicTable<T>({
       estimatedItemSize,
       handleRenderItem,
       tabIntegrated,
+      webTabIntegratedListHeight,
     ],
   );
 
   return effectiveStickyHeader ? (
-    <YStack flex={1}>
+    <YStack ref={tableRootRef as any} flex={1}>
       {headerRow}
       {list}
       {enableBackToTopButton ? (

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -357,22 +357,26 @@ export function Container({
       tabIndex >= 0 ? listContainerRef.current.children.item(tabIndex) : null;
     const element = (registeredElement ??
       fallbackElement) as HTMLElement | null;
-    // Same element + already observing -> nothing to do.
-    if (element && observedElementRef.current === element) {
-      return;
-    }
-    if (resizeObserverRef.current) {
-      resizeObserverRef.current.disconnect();
-      resizeObserverRef.current = null;
-    }
-    observedElementRef.current = element;
-    if (!element) return;
-    const apply = () => {
-      if (!listContainerRef.current) return;
-      const h = getTabContentHeight(element);
+    const apply = (targetElement: HTMLElement) => {
+      const containerElement = listContainerRef.current as HTMLElement | null;
+      if (!containerElement) return;
+      const currentRegisteredElement =
+        scrollTabElementsRef.current?.[focusedTab.value]?.element;
+      const registeredHeight =
+        scrollTabElementsRef.current?.[focusedTab.value]?.height;
+      const shouldMeasureFallbackNaturalHeight =
+        !currentRegisteredElement && targetElement === fallbackElement;
+      if (shouldMeasureFallbackNaturalHeight) {
+        containerElement.style.height = '';
+      }
+      const h =
+        typeof registeredHeight === 'number' &&
+        Number.isFinite(registeredHeight)
+          ? registeredHeight
+          : getTabContentHeight(targetElement);
       if (h > 0) {
         const grew = h > lastListContainerHeightRef.current;
-        (listContainerRef.current as HTMLElement).style.height = `${h}px`;
+        containerElement.style.height = `${h}px`;
         lastListContainerHeightRef.current = h;
         // Any growth that follows a tab switch can strand the stale compositor
         // extent (arriving at a tab taller than the one just left — for any
@@ -390,12 +394,27 @@ export function Container({
             refreshScrollExtent();
           }, 150);
         }
+      } else {
+        containerElement.style.height = '';
       }
     };
+    // Same element + already observing -> nothing to do.
+    if (element && observedElementRef.current === element) {
+      apply(element);
+      return;
+    }
+    if (resizeObserverRef.current) {
+      resizeObserverRef.current.disconnect();
+      resizeObserverRef.current = null;
+    }
+    observedElementRef.current = element;
+    if (!element) {
+      return;
+    }
     // Synchronous initial measurement so the container doesn't flicker
     // between 0-height and the first observer callback.
-    apply();
-    const ro = new ResizeObserver(apply);
+    apply(element);
+    const ro = new ResizeObserver(() => apply(element));
     ro.observe(element);
     resizeObserverRef.current = ro;
   }, [focusedTab, getTabContentHeight, tabNames, refreshScrollExtent]);

--- a/packages/components/src/composite/Tabs/List.tsx
+++ b/packages/components/src/composite/Tabs/List.tsx
@@ -558,8 +558,9 @@ export function List<Item>({
           virtualizedInnerElement.getBoundingClientRect().height || 0,
         )
       : 0;
+    const estimatedHeight = estimateContentHeight();
     const nextHeight =
-      Math.max(virtualizedHeight, estimateContentHeight()) + verticalSpacing;
+      Math.max(virtualizedHeight, estimatedHeight) + verticalSpacing;
 
     setContentHeight((previousHeight) =>
       Math.abs((previousHeight ?? 0) - nextHeight) > 1

--- a/packages/components/src/composite/Tabs/context.ts
+++ b/packages/components/src/composite/Tabs/context.ts
@@ -55,7 +55,7 @@ export const TabsContext = createContext<
         string,
         {
           element: HTMLElement;
-          height?: string;
+          height?: number;
         }
       >
     >;

--- a/packages/components/src/layouts/SortableListView/index.tsx
+++ b/packages/components/src/layouts/SortableListView/index.tsx
@@ -247,13 +247,17 @@ function BaseSortableListView<T>(
 
   const startAutoScroll = useCallback(() => {
     stopAutoScroll(); // Clean up any previous session defensively
-    if (scrollEnabled) return; // built-in auto-scroll works when scroll is enabled
+    if (scrollEnabled) {
+      return;
+    } // built-in auto-scroll works when scroll is enabled
 
     // Only auto-scroll if a real scrollable ancestor exists (e.g. Tabs.Container).
     // Do NOT fall back to document.documentElement — that would scroll the entire
     // page for lists that are simply non-scrollable (e.g. overflow:hidden pinned tabs).
     const container = findScrollableAncestor(listContainerRef.current);
-    if (!container) return;
+    if (!container) {
+      return;
+    }
     autoScrollRef.current.mouseY = -1; // Reset stale position from previous session
     autoScrollRef.current.scrollContainer = container;
 

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsTokenList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsTokenList.tsx
@@ -142,6 +142,23 @@ function MarketPerpsTokenListImpl({
     perpsColumns,
   ]);
 
+  let integratedContentPaddingBottom = tabBarHeight;
+  if (platformEnv.isNativeAndroid) {
+    integratedContentPaddingBottom = listContainerProps?.paddingBottom ?? 104;
+  } else if (webTabIntegrated) {
+    integratedContentPaddingBottom =
+      listContainerProps?.paddingBottom ?? tabBarHeight;
+  }
+
+  const tableContentContainerStyle = tabIntegrated
+    ? {
+        paddingTop: 8 + (platformEnv.isNative ? 150 : 0),
+        paddingBottom: integratedContentPaddingBottom,
+      }
+    : {
+        paddingBottom: platformEnv.isNativeAndroid ? 104 : tabBarHeight,
+      };
+
   return (
     <Stack flex={1} width="100%">
       {portalContent}
@@ -164,20 +181,7 @@ function MarketPerpsTokenListImpl({
             />
           ) : (
             <Table<IMarketPerpsToken>
-              contentContainerStyle={
-                tabIntegrated
-                  ? {
-                      paddingTop: 8 + (platformEnv.isNative ? 150 : 0),
-                      paddingBottom: platformEnv.isNativeAndroid
-                        ? (listContainerProps?.paddingBottom ?? 104)
-                        : tabBarHeight,
-                    }
-                  : {
-                      paddingBottom: platformEnv.isNativeAndroid
-                        ? 104
-                        : tabBarHeight,
-                    }
-              }
+              contentContainerStyle={tableContentContainerStyle}
               stickyHeader
               showHeader={!useDesktopPortal}
               tabIntegrated={tabIntegrated}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
@@ -447,6 +447,14 @@ function MarketTokenListBase({
     );
   }, [isLoading, intl]);
 
+  const tabBarHeight = useScrollContentTabBarOffset();
+
+  // On web with tabIntegrated, disable FlatList's own scroll so the outer
+  // Tabs.Container handles scrolling (allows header to scroll away naturally).
+  // Use IntersectionObserver as a replacement for onEndReached.
+  const webTabIntegrated = tabIntegrated && !platformEnv.isNative;
+  const endSentinelRef = useRef<HTMLDivElement>(null);
+
   const TableFooterComponent = useMemo(() => {
     if (isLoadingMore) {
       return (
@@ -456,10 +464,11 @@ function MarketTokenListBase({
       );
     }
 
-    // End indicator is rendered outside the Table when draggable,
-    // so it doesn't participate in absolute positioning during drag.
+    // On native draggable lists the end indicator stays outside the Table so it
+    // doesn't participate in absolute positioning during drag. On web tab
+    // integration it must be inside the Table so height registration includes it.
     if (
-      !draggable &&
+      (!draggable || webTabIntegrated) &&
       showEndReachedIndicator &&
       !canLoadMore &&
       data.length > 0
@@ -467,21 +476,19 @@ function MarketTokenListBase({
       return <ListEndIndicator />;
     }
 
+    if (webTabIntegrated && canLoadMore) {
+      return <div ref={endSentinelRef} style={{ height: 1 }} />;
+    }
+
     return null;
   }, [
     isLoadingMore,
+    webTabIntegrated,
     showEndReachedIndicator,
     canLoadMore,
     data.length,
     draggable,
   ]);
-  const tabBarHeight = useScrollContentTabBarOffset();
-
-  // On web with tabIntegrated, disable FlatList's own scroll so the outer
-  // Tabs.Container handles scrolling (allows header to scroll away naturally).
-  // Use IntersectionObserver as a replacement for onEndReached.
-  const webTabIntegrated = tabIntegrated && !platformEnv.isNative;
-  const endSentinelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!webTabIntegrated) return;
@@ -533,6 +540,26 @@ function MarketTokenListBase({
     stableHandleHeaderRow,
   ]);
 
+  let integratedContentPaddingBottom = tabBarHeight;
+  if (platformEnv.isNativeAndroid) {
+    integratedContentPaddingBottom =
+      listContainerProps?.paddingBottom ?? SPINNER_HEIGHT * 2;
+  } else if (webTabIntegrated) {
+    integratedContentPaddingBottom =
+      listContainerProps?.paddingBottom ?? tabBarHeight;
+  }
+
+  const tableContentContainerStyle = tabIntegrated
+    ? {
+        paddingTop: 8 + (platformEnv.isNative ? 195 : 0),
+        paddingBottom: integratedContentPaddingBottom,
+      }
+    : {
+        paddingBottom: platformEnv.isNativeAndroid
+          ? SPINNER_HEIGHT * 2
+          : tabBarHeight,
+      };
+
   return (
     <Stack flex={1} width="100%" testID={testID}>
       {portalContent}
@@ -572,21 +599,7 @@ function MarketTokenListBase({
             />
           ) : (
             <Table<IMarketToken>
-              contentContainerStyle={
-                tabIntegrated
-                  ? {
-                      paddingTop: 8 + (platformEnv.isNative ? 195 : 0),
-                      paddingBottom: platformEnv.isNativeAndroid
-                        ? (listContainerProps?.paddingBottom ??
-                          SPINNER_HEIGHT * 2)
-                        : tabBarHeight,
-                    }
-                  : {
-                      paddingBottom: platformEnv.isNativeAndroid
-                        ? SPINNER_HEIGHT * 2
-                        : tabBarHeight,
-                    }
-              }
+              contentContainerStyle={tableContentContainerStyle}
               stickyHeader
               showHeader={showTableHeader ? !useDesktopPortal : false}
               scrollEnabled={!webTabIntegrated}
@@ -594,7 +607,7 @@ function MarketTokenListBase({
               tabIntegrated={tabIntegrated}
               onDragEnd={onDragEnd}
               columns={marketTokenColumns}
-              onEndReached={handleEndReached}
+              onEndReached={webTabIntegrated ? undefined : handleEndReached}
               dataSource={data}
               keyExtractor={(item) => item.id}
               extraData={networkId}
@@ -606,12 +619,10 @@ function MarketTokenListBase({
               {...(rowBg ? { rowProps: { bg: rowBg } } : undefined)}
             />
           )}
-          {webTabIntegrated ? (
-            <div ref={endSentinelRef} style={{ height: 1 }} />
-          ) : null}
           {/* Render end indicator outside the Table for draggable lists
               so it doesn't participate in absolute positioning during drag. */}
           {draggable &&
+          !webTabIntegrated &&
           showEndReachedIndicator &&
           !canLoadMore &&
           data.length > 0 ? (

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
@@ -187,6 +187,11 @@ export function useMarketTokenList({
   const totalPages = useMemo(() => {
     return totalCount > 0 ? Math.ceil(totalCount / pageSize) : 1;
   }, [totalCount, pageSize]);
+  const loadedPageCount = useMemo(
+    () =>
+      Math.max(currentPage, Math.ceil(transformedData.length / pageSize) || 1),
+    [currentPage, pageSize, transformedData.length],
+  );
 
   const refresh = useCallback(() => {
     // Don't clear data immediately - let new data load first
@@ -197,7 +202,9 @@ export function useMarketTokenList({
     // Check if we can load more pages
     if (
       isLoadingMore ||
-      currentPage >= maxPages ||
+      loadedPageCount >= maxPages ||
+      loadedPageCount >= totalPages ||
+      (totalCount > 0 && transformedData.length >= totalCount) ||
       !hasNetworkId ||
       effectiveIsLoading ||
       hasReachedEnd
@@ -205,7 +212,7 @@ export function useMarketTokenList({
       return;
     }
 
-    const nextPage = currentPage + 1;
+    const nextPage = loadedPageCount + 1;
     const requestQueryKey = currentQueryKeyRef.current;
 
     setIsLoadingMore(true);
@@ -255,7 +262,10 @@ export function useMarketTokenList({
     }
   }, [
     isLoadingMore,
-    currentPage,
+    loadedPageCount,
+    totalCount,
+    totalPages,
+    transformedData.length,
     effectiveIsLoading,
     hasReachedEnd,
     hasNetworkId,
@@ -273,7 +283,9 @@ export function useMarketTokenList({
 
   const canLoadMore =
     hasNetworkId &&
-    currentPage < maxPages &&
+    loadedPageCount < maxPages &&
+    loadedPageCount < totalPages &&
+    (totalCount === 0 || transformedData.length < totalCount) &&
     !effectiveIsLoading &&
     !isLoadingMore &&
     !hasReachedEnd;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55551](https://onekeyhq.atlassian.net/browse/OK-55551) [OK-55499](https://onekeyhq.atlassian.net/browse/OK-55499)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Register explicit web tab-integrated table heights so the outer Tabs container can scroll to the real table bottom.
- Fix Market Spot/Favorites/Perps end-indicator visibility by aligning row-height estimates, footer height, and web sentinel placement.
- Preserve web drag behavior while keeping native draggable end indicators outside the table.

## Intent & Context
The Market web page at /market could reach the apparent scroll bottom without showing the table end indicator. The issue was reproduced from MKT-TAB logs and localhost testing across Spot, Favorites, and Perps. The user also requested enough bottom space because the table has an end-of-list indicator.

## Root Cause
The web tab-integrated layout disables the inner list scroll and relies on Tabs.Container for vertical scrolling. Several measurements were out of sync: Perps estimated rows as 56px while Table rows have a 60px minimum, Spot could keep canLoadMore true after the first 100 loaded items, and Favorites rendered the draggable end indicator outside the table height registration. The fallback tab measurement could also reuse stale stretched heights before the focused table registered its own height.

## Design Decisions
- Compute a resolved table row height with the real Table row minimum and use it for getItemLayout and web height estimates.
- Keep the list height separate from the root registered height so an external sticky header is counted only for Tabs.Container registration.
- Move web tab-integrated end sentinels and draggable end indicators into the table footer so registered height includes them.
- Keep native draggable behavior unchanged by leaving native draggable end indicators outside the table.

## Changes Detail
- packages/components/src/composite/Table/index.tsx: adds web tab-integrated list/root height calculation, resolved row height, and table height registration with Tabs context.
- packages/components/src/composite/Tabs/Container.tsx: applies registered tab heights and clears stale fallback heights before natural measurement.
- packages/components/src/composite/Tabs/List.tsx and context.ts: supports numeric registered tab heights.
- packages/components/src/layouts/SortableListView/index.tsx: keeps web disabled-scroll drag autoscroll using the real scroll ancestor.
- packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx: keeps web sentinel/end indicator inside the Table footer and preserves tab padding.
- packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts: stops load-more state when loaded items already reach the known total/page limit.
- packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsTokenList.tsx: preserves web tab-integrated bottom padding in table content.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Web, Desktop
- **Risk Areas**: Shared Table/Tabs measurement, web disabled-scroll lists, Market desktop tab integration, draggable watchlist footer placement.

## Test plan
- [x] Run yarn lint:staged.
- [x] Run yarn tsc:staged.
- [x] Run oxlint --deny-warnings on touched shared files.
- [x] Run tsgo -p ./tsconfig.json --noEmit.
- [x] Verify http://localhost:3000/market in Chrome for Spot and Perps bottom indicators.
- [x] Confirm Favorites web table path includes the end indicator in TableFooterComponent when watchlist data exists.

[OK-55551]: https://onekeyhq.atlassian.net/browse/OK-55551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55499]: https://onekeyhq.atlassian.net/browse/OK-55499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ