### PR TITLE
feat: split TradingView footer controls(OK-55530)

### DIFF
--- a/packages/kit/src/components/TradingView/constants.ts
+++ b/packages/kit/src/components/TradingView/constants.ts
@@ -1,5 +1,7 @@
 export const TRADING_VIEW_DISABLED_FEATURES = {
-  FOOTER: 'footer',
+  TIMEFRAME_SELECTOR: 'timeframeSelector',
+  TIME_SCALE: 'timeScale',
+  PRICE_SCALE: 'priceScale',
   PRICE_MARKET_CAP_TOGGLE: 'priceMarketCapToggle',
   INDICATORS: 'indicators',
   SETTINGS: 'settings',

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/TradingViewV2.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/TradingViewV2.tsx
@@ -21,7 +21,12 @@ const DISABLED_FEATURE_OPTIONS: {
   label: string;
   value: ITradingViewDisabledFeature;
 }[] = [
-  { label: 'Footer', value: TRADING_VIEW_DISABLED_FEATURES.FOOTER },
+  {
+    label: 'Timeframe Selector',
+    value: TRADING_VIEW_DISABLED_FEATURES.TIMEFRAME_SELECTOR,
+  },
+  { label: 'Time Scale', value: TRADING_VIEW_DISABLED_FEATURES.TIME_SCALE },
+  { label: 'Price Scale', value: TRADING_VIEW_DISABLED_FEATURES.PRICE_SCALE },
   {
     label: 'Price / Market Cap',
     value: TRADING_VIEW_DISABLED_FEATURES.PRICE_MARKET_CAP_TOGGLE,

--- a/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
@@ -18,10 +18,12 @@ import {
   Stack,
   XStack,
   YStack,
+  useMedia,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import {
+  type ITradingViewDisabledFeature,
   TRADING_VIEW_DISABLED_FEATURES,
   TradingViewV2,
 } from '@onekeyhq/kit/src/components/TradingView/TradingViewV2';
@@ -45,17 +47,21 @@ import { SwapTestIDs } from '../../testIDs';
 import { SwapProviderMirror } from '../SwapProviderMirror';
 
 const SWAP_KLINE_TRADING_VIEW_STORAGE_NAMESPACE = 'swap-kline';
-const SWAP_KLINE_DISABLED_TRADING_VIEW_FEATURES = [
-  TRADING_VIEW_DISABLED_FEATURES.FOOTER,
-  TRADING_VIEW_DISABLED_FEATURES.PRICE_MARKET_CAP_TOGGLE,
+const SWAP_KLINE_DESKTOP_DISABLED_TRADING_VIEW_FEATURES = [
+  TRADING_VIEW_DISABLED_FEATURES.TIME_SCALE,
+  TRADING_VIEW_DISABLED_FEATURES.PRICE_SCALE,
   TRADING_VIEW_DISABLED_FEATURES.INDICATORS,
   TRADING_VIEW_DISABLED_FEATURES.SETTINGS,
   TRADING_VIEW_DISABLED_FEATURES.CHART_TYPE,
-  TRADING_VIEW_DISABLED_FEATURES.RESET_LAYOUT,
   TRADING_VIEW_DISABLED_FEATURES.FULLSCREEN,
   TRADING_VIEW_DISABLED_FEATURES.LAYOUT_TOGGLE,
   TRADING_VIEW_DISABLED_FEATURES.DRAWING_TOOLBAR,
-] as const;
+] as const satisfies readonly ITradingViewDisabledFeature[];
+
+const SWAP_KLINE_MOBILE_DISABLED_TRADING_VIEW_FEATURES = [
+  TRADING_VIEW_DISABLED_FEATURES.TIMEFRAME_SELECTOR,
+  ...SWAP_KLINE_DESKTOP_DISABLED_TRADING_VIEW_FEATURES,
+] as const satisfies readonly ITradingViewDisabledFeature[];
 
 type ISwapKLineToken = ISwapToken & {
   defiMarked?: boolean;
@@ -523,9 +529,13 @@ function SwapKLineContentBody({
   chartMinHeight?: number;
 } & ISwapKLineContentSpacingProps) {
   const intl = useIntl();
+  const { gtMd } = useMedia();
   const selectedToken = state.selectedToken;
   const chartNetworkId = selectedToken?.networkId ?? '';
   const chartTokenAddress = selectedToken?.contractAddress ?? '';
+  const disabledTradingViewFeatures = gtMd
+    ? SWAP_KLINE_DESKTOP_DISABLED_TRADING_VIEW_FEATURES
+    : SWAP_KLINE_MOBILE_DISABLED_TRADING_VIEW_FEATURES;
 
   const chartContent = (
     <Stack
@@ -542,7 +552,7 @@ function SwapKLineContentBody({
         networkId={chartNetworkId}
         decimal={selectedToken?.decimals ?? 0}
         dataSource="polling"
-        disabledFeatures={SWAP_KLINE_DISABLED_TRADING_VIEW_FEATURES}
+        disabledFeatures={disabledTradingViewFeatures}
         storageNamespace={SWAP_KLINE_TRADING_VIEW_STORAGE_NAMESPACE}
         forceEmptyKLineData={state.shouldForceEmptyKLineData}
         emptyKLineDataOnError


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55530](https://onekeyhq.atlassian.net/browse/OK-55530)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Split the TradingView footer disabled feature into granular controls for timeframe selector, time scale, and price scale.
- Updated the TradingView gallery story to expose the new granular disabled feature options.
- Updated Swap KLine to hide the timeframe selector only on mobile while keeping non-footer chart controls enabled.

## Intent & Context
The goal is to make TradingView footer controls configurable at a finer level instead of using one broad footer disabled feature. The legacy footer parameter does not need compatibility handling because this chart disabled feature change has not shipped yet.

During review, Price/Market Cap toggle and Reset Layout were discussed. Those controls are intentionally no longer disabled in Swap KLine so the chart can restore its default controls in that embedded surface.

## Design Decisions
The app-side disabled feature constants now match the granular chart-side feature names. Swap KLine uses separate desktop and mobile disabled feature lists because only the mobile layout needs to hide the timeframe selector along with the footer scale controls.

Price/Market Cap toggle and Reset Layout were left out of the Swap KLine disabled list on purpose. This keeps the chart default behavior for non-footer controls instead of preserving the previous suppression.

## Changes Detail
- packages/kit/src/components/TradingView/constants.ts: replaced the broad footer disabled feature with timeframeSelector, timeScale, and priceScale.
- packages/kit/src/views/Developer/pages/Gallery/Components/stories/TradingViewV2.tsx: replaced the Footer option with the new granular footer control options.
- packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx: added desktop and mobile disabled feature lists and selected the list through media size.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web
- **Risk Areas**: TradingView URL parameters and Swap KLine embedded chart UI. The main behavior to verify is that desktop and mobile hide the intended footer controls without suppressing Price/Market Cap toggle or Reset Layout.

## Test plan
- [x] yarn lint:staged
- [x] yarn tsc:staged
- [ ] Verify Swap KLine desktop chart footer controls and default chart controls.
- [ ] Verify Swap KLine mobile chart footer controls and default chart controls.

[OK-55530]: https://onekeyhq.atlassian.net/browse/OK-55530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ