### PR TITLE
fix: web dapp account panel, perps & connect modal fixes (OK-55583 OK-55580 OK-55581 OK-55584 OK-55582 OK-55552 OK-55586)

### DIFF
--- a/packages/kit/src/components/AccountSelector/hooks/useAccountSelectorTrigger.tsx
+++ b/packages/kit/src/components/AccountSelector/hooks/useAccountSelectorTrigger.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import type { IAccountSelectorRouteParamsExtraConfig } from '@onekeyhq/shared/src/routes';
 
@@ -7,7 +7,6 @@ import {
   useAccountSelectorActions,
   useAccountSelectorSceneInfo,
   useActiveAccount,
-  useSelectedAccount,
 } from '../../../states/jotai/contexts/accountSelector';
 
 export function useAccountSelectorTrigger({
@@ -21,30 +20,10 @@ export function useAccountSelectorTrigger({
 } & IAccountSelectorRouteParamsExtraConfig) {
   const navigation = useAppNavigation();
   const { activeAccount } = useActiveAccount({ num });
-  const { selectedAccount } = useSelectedAccount({ num });
   const { sceneName, sceneUrl } = useAccountSelectorSceneInfo();
   const actions = useAccountSelectorActions();
 
-  const activeAccountRef = useRef(activeAccount);
-  activeAccountRef.current = activeAccount;
-  const selectedAccountRef = useRef(selectedAccount);
-  selectedAccountRef.current = selectedAccount;
-
   const showAccountSelector = useCallback(() => {
-    console.log(
-      'showAccountSelector>>>>',
-      activeAccountRef.current,
-      selectedAccountRef.current,
-      {
-        activeWallet: activeAccount.wallet,
-        num,
-        sceneName,
-        sceneUrl,
-        showConnectWalletModalInDappMode,
-        linkNetworkId,
-        ...others,
-      },
-    );
     void actions.current.showAccountSelector({
       activeWallet: activeAccount.wallet,
       num,

--- a/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelMain.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelMain.tsx
@@ -28,19 +28,27 @@ import {
   usePerpsActiveAccountAtom,
   usePerpsComputedAccountValueAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
+import { buildTokenSelectorDappTokenFilterParams } from '@onekeyhq/shared/src/utils/tokenSelectorFilterUtils';
+import { calculateAccountTotalValue } from '@onekeyhq/shared/src/utils/tokenUtils';
 import { sumTokenGroupsFiatValueIgnoringUnavailable } from '@onekeyhq/shared/src/utils/tokenValueUtils';
 
 import { WebAccountPanelFooter } from './atoms/WebAccountPanelFooter';
 import { useWebDappRealAddress } from './useWebDappRealAddress';
 
-// Session-only (in-memory) cache for the portfolio total, keyed by accountId.
-// It survives the panel closing/reopening so reopening shows the last value
-// instantly with no spinner; it is intentionally not persisted, so a full page
-// reload starts fresh. A value older than PORTFOLIO_STALE_MS is refreshed
-// silently in the background on the next open.
+// Session-only (in-memory) cache for the portfolio total, keyed by
+// accountId + the resolved EVM address. Including the address means switching
+// the connected account on the extension (which changes the Provider address
+// in place, often without changing accountId) re-fetches this address's total
+// instead of showing the previous address's value. It survives the panel
+// closing/reopening so reopening shows the last value instantly with no
+// spinner; it is intentionally not persisted, so a full page reload starts
+// fresh. A value older than PORTFOLIO_STALE_MS is refreshed silently in the
+// background on the next open.
 const PORTFOLIO_STALE_MS = 60 * 1000;
 const portfolioCache = new Map<
   string,
@@ -268,36 +276,49 @@ export function WebAccountPanelMain({
     indexedAccountId: indexedAccount?.id,
   });
 
-  // Portfolio total. The home page is the only place that computes account
-  // worth (its page-scoped token-list flow), so on routes like /perps nothing
-  // populates the cached worth. Fetch it regardless of route: enumerate the
-  // networks this account is compatible with, fan out a live token fetch per
-  // network, and sum the fiat values (already in the user's display currency).
+  // Portfolio = the wallet home page headline for the connected address: spot
+  // tokens + DeFi net worth. The home page is the only place that computes &
+  // caches that worth, so on routes like /perps we recompute it live here.
+  // Keyed on the resolved EVM address so it tracks the currently connected
+  // address, not the account's other derived addresses.
+  const portfolioCacheKey =
+    account?.id && realAddress ? `${account.id}:${realAddress}` : undefined;
   const [portfolio, setPortfolio] = useState<string | undefined>(() =>
-    account?.id ? portfolioCache.get(account.id)?.value : undefined,
+    portfolioCacheKey
+      ? portfolioCache.get(portfolioCacheKey)?.value
+      : undefined,
   );
   // The currency the summed fiatValue is expressed in (fetchAccountTokens
   // normalizes to 'usd'). Carried through so <Currency> converts it to the
   // user's display currency instead of mislabeling a USD total as e.g. EUR.
   const [portfolioCurrency, setPortfolioCurrency] = useState<
     string | undefined
-  >(() => (account?.id ? portfolioCache.get(account.id)?.currency : undefined));
+  >(() =>
+    portfolioCacheKey
+      ? portfolioCache.get(portfolioCacheKey)?.currency
+      : undefined,
+  );
   const [isLoadingPortfolio, setIsLoadingPortfolio] = useState(false);
 
-  // Ignore a fan-out result that resolves after the active account changed.
-  const latestAccountIdRef = useRef(account?.id);
-  latestAccountIdRef.current = account?.id;
+  // Ignore a fan-out result that resolves after the active address changed.
+  const latestCacheKeyRef = useRef(portfolioCacheKey);
+  latestCacheKeyRef.current = portfolioCacheKey;
 
   const fetchPortfolio = useCallback(
     async (force?: boolean) => {
       const accountId = account?.id;
-      if (!accountId) {
+      // Need both the account and its resolved single EVM address before we can
+      // fetch or key the cache. Until the address resolves the value is
+      // genuinely unknown — renderPortfolioValue shows "--" for this state.
+      const cacheKey =
+        accountId && realAddress ? `${accountId}:${realAddress}` : undefined;
+      if (!accountId || !cacheKey) {
         setPortfolio(undefined);
         return;
       }
-      const cached = portfolioCache.get(accountId);
-      // Reflect this account's cached value immediately — instant on reopen and
-      // on account switch, with no spinner when we already have something.
+      const cached = portfolioCache.get(cacheKey);
+      // Reflect this address's cached value immediately — instant on reopen and
+      // on address switch, with no spinner when we already have something.
       setPortfolio(cached?.value);
       setPortfolioCurrency(cached?.currency);
       const isFresh =
@@ -315,62 +336,56 @@ export function WebAccountPanelMain({
         setIsLoadingPortfolio(true);
       }
       try {
-        // Intentionally EVM-only (product requirement): enumerate the EVM
-        // mainnet networks this account is compatible with and fan out a live
-        // token fetch per network. The chain selector returns networks matching
-        // the (EVM-resolved) account, so non-EVM chains are excluded by design —
-        // do NOT broaden this to all networks.
-        const { mainnetItems } =
-          await backgroundApiProxy.serviceNetwork.getChainSelectorNetworksCompatibleWithAccountId(
-            { accountId, excludeTestNetwork: true },
-          );
-        // For an indexed account the all-networks accountId is a mock that fails
-        // per-network token fetches, so resolve the real per-network account(s)
-        // first (same as the Home token list). External/others accounts already
-        // carry a real per-network accountId, so fetch with it directly.
+        // Match the wallet home page's "Portfolio" headline = spot tokens +
+        // DeFi net worth. Use the SAME per-network account set the wallet uses
+        // (serviceAllNetwork.getAllNetworkAccounts) instead of brute-forcing
+        // every compatible EVM mainnet — the latter over-counts dust/tokens on
+        // long-tail chains the wallet excludes. Every call below is per-network
+        // (no isAllNetworks flag), so it avoids the all-networks aggregation
+        // gate that returns empty off the home route. EVM-only: the panel sits
+        // in an EVM/perps context and the connected address is an EVM address.
+        const allNetworkId = getNetworkIdsMap().onekeyall;
         const indexedAccountId = indexedAccount?.id;
-        const resultsByNetwork = await Promise.all(
-          mainnetItems.map(async (net) => {
-            if (indexedAccountId) {
-              try {
-                const { networkAccounts } =
-                  await backgroundApiProxy.serviceAccount.getNetworkAccountsInSameIndexedAccountIdWithDeriveTypes(
-                    {
-                      networkId: net.id,
-                      indexedAccountId,
-                      excludeEmptyAccount: true,
-                    },
-                  );
-                return Promise.all(
-                  networkAccounts.map((networkAccount) =>
-                    backgroundApiProxy.serviceToken
-                      .fetchAccountTokens({
-                        accountId: networkAccount.account?.id ?? '',
-                        networkId: net.id,
-                        indexedAccountId,
-                        flag: 'web-account-panel-portfolio',
-                      })
-                      .catch(() => null),
-                  ),
-                );
-              } catch {
-                return [null];
-              }
-            }
-            return [
-              await backgroundApiProxy.serviceToken
+        const isOthers = accountUtils.isOthersAccount({ accountId });
+        // Track the wallet page's token-filter flag exactly (excludes dApp/DeFi
+        // protocol tokens from the wallet token sum when the flag is enabled).
+        const walletTokenFilterParams = buildTokenSelectorDappTokenFilterParams(
+          { lpToken: false },
+        );
+
+        // 1) Spot token worth over the wallet's network/account set (EVM only).
+        // getAllNetworkAccounts already resolves the real per-network account
+        // for the connected address, so each entry.accountId is fetchable as-is.
+        const { accountsInfo } =
+          await backgroundApiProxy.serviceAllNetwork.getAllNetworkAccounts({
+            accountId: indexedAccountId ?? accountId,
+            indexedAccountId,
+            networkId: allNetworkId,
+            networksEnabledOnly: !isOthers,
+            excludeTestNetwork: true,
+            skipCache: !!force,
+          });
+        const results = await Promise.all(
+          accountsInfo
+            .filter(
+              (a) =>
+                a.accountId &&
+                networkUtils.isEvmNetwork({ networkId: a.networkId }),
+            )
+            .map((a) =>
+              backgroundApiProxy.serviceToken
                 .fetchAccountTokens({
-                  accountId,
-                  networkId: net.id,
+                  accountId: a.accountId,
+                  networkId: a.networkId,
+                  indexedAccountId,
                   flag: 'web-account-panel-portfolio',
+                  ...walletTokenFilterParams,
                 })
                 .catch(() => null),
-            ];
-          }),
+            ),
         );
-        const results = resultsByNetwork.flat();
-        // Ignore a result that resolved after the active account changed.
-        if (latestAccountIdRef.current !== accountId) {
+        // Ignore a result that resolved after the active address changed.
+        if (latestCacheKeyRef.current !== cacheKey) {
           return;
         }
         const okResults = results.filter(
@@ -387,22 +402,80 @@ export function WebAccountPanelMain({
         // Use the shared helper (same one Home uses) so an unavailable/non-finite
         // group value from a partial provider failure is skipped instead of
         // poisoning the whole total to NaN.
-        const total = okResults.reduce(
+        const spotTotal = okResults.reduce(
           (acc, r) =>
             acc.plus(
               new BigNumber(sumTokenGroupsFiatValueIgnoringUnavailable(r)),
             ),
           new BigNumber(0),
         );
-        // Every per-network fetch uses the same display currency, so the
-        // returned token-group currency is uniform; carry it so the total is
-        // rendered in the basis it was actually summed in.
+        // Token fiat is normalized to USD when the rate resolves; carry the
+        // group currency so <Currency> renders in the basis it was summed in.
         const sourceCurrency =
           okResults.find((r) => r?.tokens?.currency)?.tokens?.currency ??
           okResults.find((r) => r?.smallBalanceTokens?.currency)
             ?.smallBalanceTokens?.currency;
-        const value = total.toFixed();
-        portfolioCache.set(accountId, {
+
+        // 2) DeFi net worth (best-effort): fetch positions live per DeFi-enabled
+        // network and sum overview.netWorth (already raw USD, so it adds
+        // directly to the USD-normalized spot total). On any failure keep the
+        // spot-only total.
+        let deFiNetWorthUsd = '0';
+        try {
+          const { accountsInfo: defiAccountsInfo } =
+            await backgroundApiProxy.serviceAllNetwork.getAllNetworkAccounts({
+              accountId: indexedAccountId ?? accountId,
+              indexedAccountId,
+              networkId: allNetworkId,
+              networksEnabledOnly: !isOthers,
+              excludeTestNetwork: true,
+              DeFiEnabledOnly: true,
+              skipCache: !!force,
+            });
+          const defiResults = await Promise.all(
+            defiAccountsInfo
+              .filter(
+                (a) =>
+                  a.accountId &&
+                  networkUtils.isEvmNetwork({ networkId: a.networkId }),
+              )
+              .map((a) =>
+                backgroundApiProxy.serviceDeFi
+                  .fetchAccountDeFiPositions({
+                    accountId: a.accountId,
+                    networkId: a.networkId,
+                    accountAddress: a.apiAddress,
+                    xpub: a.accountXpub,
+                    excludeLowValueProtocols: true,
+                    saveToLocal: false,
+                    abortable: false,
+                  })
+                  .catch(() => null),
+              ),
+          );
+          deFiNetWorthUsd = defiResults
+            .reduce((acc, r) => {
+              const netWorth = r?.overview?.netWorth;
+              return typeof netWorth === 'number'
+                ? acc.plus(new BigNumber(netWorth))
+                : acc;
+            }, new BigNumber(0))
+            .toFixed();
+        } catch {
+          // best-effort: keep the spot-only total on DeFi failure
+        }
+        // The active address may have changed during the DeFi fetch.
+        if (latestCacheKeyRef.current !== cacheKey) {
+          return;
+        }
+
+        // Portfolio = spot tokens + DeFi net worth, mirroring the wallet headline.
+        const value =
+          calculateAccountTotalValue({
+            tokensValue: spotTotal.toFixed(),
+            deFiNetWorth: deFiNetWorthUsd,
+          }) ?? spotTotal.toFixed();
+        portfolioCache.set(cacheKey, {
           value,
           currency: sourceCurrency,
           fetchedAt: Date.now(),
@@ -415,7 +488,7 @@ export function WebAccountPanelMain({
         setIsLoadingPortfolio(false);
       }
     },
-    [account?.id, indexedAccount?.id],
+    [account?.id, indexedAccount?.id, realAddress],
   );
 
   useEffect(() => {
@@ -512,6 +585,26 @@ export function WebAccountPanelMain({
           color="$text"
         >
           {portfolio}
+        </Currency>
+      );
+    }
+    // A resolved account whose settled fetch produced no value (empty EVM
+    // portfolio, or every per-network fetch failed without a cache) should read
+    // as "$0", not "--". "--" is reserved for the genuinely-unknown state: no
+    // account, or the indexed account's real address still resolving. The
+    // spinner above already covers the in-flight first load, so this $0 only
+    // appears once the fetch has settled; the empty path doesn't cache, so the
+    // next open/refresh replaces it with the real total.
+    if (account?.id && realAddress) {
+      return (
+        <Currency
+          sourceCurrency={portfolioCurrency}
+          formatter="value"
+          hideValue
+          size="$bodyMdMedium"
+          color="$text"
+        >
+          0
         </Currency>
       );
     }

--- a/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelMain.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelMain.tsx
@@ -310,8 +310,8 @@ export function WebAccountPanelMain({
       // Need both the account and its resolved single EVM address before we can
       // fetch or key the cache. Until the address resolves the value is
       // genuinely unknown — renderPortfolioValue shows "--" for this state.
-      const cacheKey =
-        accountId && realAddress ? `${accountId}:${realAddress}` : undefined;
+      // Reuse the component-scoped key; latestCacheKeyRef tracks the same value.
+      const cacheKey = portfolioCacheKey;
       if (!accountId || !cacheKey) {
         setPortfolio(undefined);
         return;
@@ -352,37 +352,40 @@ export function WebAccountPanelMain({
         const walletTokenFilterParams = buildTokenSelectorDappTokenFilterParams(
           { lpToken: false },
         );
+        // Same network/account set for both the spot and DeFi enumerations; the
+        // DeFi call just adds DeFiEnabledOnly to narrow to DeFi-enabled networks.
+        const allNetworkAccountsParams = {
+          accountId: indexedAccountId ?? accountId,
+          indexedAccountId,
+          networkId: allNetworkId,
+          networksEnabledOnly: !isOthers,
+          excludeTestNetwork: true,
+          skipCache: !!force,
+        };
 
         // 1) Spot token worth over the wallet's network/account set (EVM only).
         // getAllNetworkAccounts already resolves the real per-network account
         // for the connected address, so each entry.accountId is fetchable as-is.
         const { accountsInfo } =
-          await backgroundApiProxy.serviceAllNetwork.getAllNetworkAccounts({
-            accountId: indexedAccountId ?? accountId,
-            indexedAccountId,
-            networkId: allNetworkId,
-            networksEnabledOnly: !isOthers,
-            excludeTestNetwork: true,
-            skipCache: !!force,
-          });
+          await backgroundApiProxy.serviceAllNetwork.getAllNetworkAccounts(
+            allNetworkAccountsParams,
+          );
+        // Only EVM networks with a resolved per-network account are fetchable.
+        const isFetchableEvmAccount = (a: (typeof accountsInfo)[number]) =>
+          !!a.accountId &&
+          networkUtils.isEvmNetwork({ networkId: a.networkId });
         const results = await Promise.all(
-          accountsInfo
-            .filter(
-              (a) =>
-                a.accountId &&
-                networkUtils.isEvmNetwork({ networkId: a.networkId }),
-            )
-            .map((a) =>
-              backgroundApiProxy.serviceToken
-                .fetchAccountTokens({
-                  accountId: a.accountId,
-                  networkId: a.networkId,
-                  indexedAccountId,
-                  flag: 'web-account-panel-portfolio',
-                  ...walletTokenFilterParams,
-                })
-                .catch(() => null),
-            ),
+          accountsInfo.filter(isFetchableEvmAccount).map((a) =>
+            backgroundApiProxy.serviceToken
+              .fetchAccountTokens({
+                accountId: a.accountId,
+                networkId: a.networkId,
+                indexedAccountId,
+                flag: 'web-account-panel-portfolio',
+                ...walletTokenFilterParams,
+              })
+              .catch(() => null),
+          ),
         );
         // Ignore a result that resolved after the active address changed.
         if (latestCacheKeyRef.current !== cacheKey) {
@@ -424,34 +427,23 @@ export function WebAccountPanelMain({
         try {
           const { accountsInfo: defiAccountsInfo } =
             await backgroundApiProxy.serviceAllNetwork.getAllNetworkAccounts({
-              accountId: indexedAccountId ?? accountId,
-              indexedAccountId,
-              networkId: allNetworkId,
-              networksEnabledOnly: !isOthers,
-              excludeTestNetwork: true,
+              ...allNetworkAccountsParams,
               DeFiEnabledOnly: true,
-              skipCache: !!force,
             });
           const defiResults = await Promise.all(
-            defiAccountsInfo
-              .filter(
-                (a) =>
-                  a.accountId &&
-                  networkUtils.isEvmNetwork({ networkId: a.networkId }),
-              )
-              .map((a) =>
-                backgroundApiProxy.serviceDeFi
-                  .fetchAccountDeFiPositions({
-                    accountId: a.accountId,
-                    networkId: a.networkId,
-                    accountAddress: a.apiAddress,
-                    xpub: a.accountXpub,
-                    excludeLowValueProtocols: true,
-                    saveToLocal: false,
-                    abortable: false,
-                  })
-                  .catch(() => null),
-              ),
+            defiAccountsInfo.filter(isFetchableEvmAccount).map((a) =>
+              backgroundApiProxy.serviceDeFi
+                .fetchAccountDeFiPositions({
+                  accountId: a.accountId,
+                  networkId: a.networkId,
+                  accountAddress: a.apiAddress,
+                  xpub: a.accountXpub,
+                  excludeLowValueProtocols: true,
+                  saveToLocal: false,
+                  abortable: false,
+                })
+                .catch(() => null),
+            ),
           );
           deFiNetWorthUsd = defiResults
             .reduce((acc, r) => {
@@ -488,7 +480,7 @@ export function WebAccountPanelMain({
         setIsLoadingPortfolio(false);
       }
     },
-    [account?.id, indexedAccount?.id, realAddress],
+    [account?.id, indexedAccount?.id, portfolioCacheKey],
   );
 
   useEffect(() => {
@@ -575,7 +567,16 @@ export function WebAccountPanelMain({
     if (isLoadingPortfolio) {
       return <Spinner size="small" />;
     }
-    if (portfolio !== undefined) {
+    // The resolved value, or "0" once a resolved account settles with no value
+    // (empty EVM portfolio, or every per-network fetch failed without a cache).
+    // "--" is reserved for the genuinely-unknown state: no account, or the
+    // indexed account's real address still resolving. The spinner above already
+    // covers the in-flight first load, so "0" only appears once the fetch has
+    // settled; the empty path doesn't cache, so the next open/refresh replaces
+    // it with the real total.
+    const displayValue =
+      portfolio ?? (account?.id && realAddress ? '0' : undefined);
+    if (displayValue !== undefined) {
       return (
         <Currency
           sourceCurrency={portfolioCurrency}
@@ -584,27 +585,7 @@ export function WebAccountPanelMain({
           size="$bodyMdMedium"
           color="$text"
         >
-          {portfolio}
-        </Currency>
-      );
-    }
-    // A resolved account whose settled fetch produced no value (empty EVM
-    // portfolio, or every per-network fetch failed without a cache) should read
-    // as "$0", not "--". "--" is reserved for the genuinely-unknown state: no
-    // account, or the indexed account's real address still resolving. The
-    // spinner above already covers the in-flight first load, so this $0 only
-    // appears once the fetch has settled; the empty path doesn't cache, so the
-    // next open/refresh replaces it with the real total.
-    if (account?.id && realAddress) {
-      return (
-        <Currency
-          sourceCurrency={portfolioCurrency}
-          formatter="value"
-          hideValue
-          size="$bodyMdMedium"
-          color="$text"
-        >
-          0
+          {displayValue}
         </Currency>
       );
     }

--- a/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelPopover.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelPopover.tsx
@@ -35,6 +35,11 @@ export interface IWebAccountPanelPopoverProps {
 
 const PANEL_WIDTH = 352;
 
+// Stable identity so the memoized renderContent below doesn't hand
+// AccountSelectorProviderMirror a fresh array every call (which would re-run its
+// store-data memo and the mirror tracker effect on every content re-render).
+const PANEL_ENABLED_NUM = [0];
+
 const ANIMATE_ONLY_HEIGHT: string[] = ['height'];
 
 const FLOATING_PANEL_PROPS = {
@@ -234,6 +239,30 @@ export function WebAccountPanelPopover({
   connected = true,
 }: IWebAccountPanelPopoverProps) {
   const { config } = useAccountSelectorContextData();
+  // Popover renders `renderContent` as a component (<RenderContent/> in
+  // RawPopover), so React keys the whole panel subtree by this function's
+  // identity. An inline arrow would be a brand-new identity on every
+  // WebAccountPanelPopover re-render, remounting PanelContent + everything under
+  // it each time. On busy routes (DeFi/Earn) the header re-renders repeatedly
+  // while the panel is open, so the panel visibly vanished and reappeared
+  // several times. Memoizing keeps the identity (and the mounted subtree) stable
+  // across those re-renders.
+  const renderContent = useCallback(
+    ({ closePopover }: { isOpen?: boolean; closePopover: () => void }) =>
+      config ? (
+        <AccountSelectorProviderMirror
+          enabledNum={PANEL_ENABLED_NUM}
+          config={config}
+        >
+          <PanelContent
+            initialView={initialView}
+            connected={connected}
+            closePopover={closePopover}
+          />
+        </AccountSelectorProviderMirror>
+      ) : null,
+    [config, initialView, connected],
+  );
   return (
     <Popover
       title=""
@@ -242,17 +271,7 @@ export function WebAccountPanelPopover({
       offset={6}
       floatingPanelProps={FLOATING_PANEL_PROPS}
       renderTrigger={renderTrigger}
-      renderContent={({ closePopover }) =>
-        config ? (
-          <AccountSelectorProviderMirror enabledNum={[0]} config={config}>
-            <PanelContent
-              initialView={initialView}
-              connected={connected}
-              closePopover={closePopover}
-            />
-          </AccountSelectorProviderMirror>
-        ) : null
-      }
+      renderContent={renderContent}
     />
   );
 }

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -615,18 +615,17 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
 
       const activeAccountInfo = this.getActiveAccount.call(set, { num });
 
-      // In dapp mode, if no wallet exists, conditionally show connect wallet options
+      // In dapp mode, show the connect-wallet options whenever there is no
+      // connected account. Key on the account (not the wallet record): a
+      // just-disconnected external/keyless wallet can briefly linger as a wallet
+      // with no account during the async reload, so matching DappHeader's
+      // account-based "connected" check keeps the Connect button and its tap
+      // target in sync — it always reopens the reconnect modal.
       const isWebDappMode = platformEnv.isWebDappMode;
-      const hasWallet = activeAccountInfo?.wallet?.id;
       const hasAccount =
         activeAccountInfo?.account || activeAccountInfo?.indexedAccount;
 
-      if (
-        isWebDappMode &&
-        !hasWallet &&
-        !hasAccount &&
-        showConnectWalletModalInDappMode
-      ) {
+      if (isWebDappMode && !hasAccount && showConnectWalletModalInDappMode) {
         navigation.pushModal(EModalRoutes.OnboardingModal, {
           screen: EOnboardingPages.ConnectWalletOptions,
         });

--- a/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioModal.tsx
+++ b/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioModal.tsx
@@ -4,6 +4,7 @@ import { Page, ScrollView } from '@onekeyhq/components';
 import type { useInTabDialog } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
+import { PerpsAccountSelectorProviderMirror } from '../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 
 import { PerpPortfolioContent } from './PerpPortfolioContent';
@@ -25,9 +26,17 @@ export function showPerpPortfolioDialog(
     showFooter: false,
     floatingPanelProps: { width: 960 },
     renderContent: (
-      <PerpsProviderMirror>
-        <PerpPortfolioContent isMobile={false} />
-      </PerpsProviderMirror>
+      // In-tab dialogs render through the IN_PAGE_TAB_CONTAINER portal at the
+      // TabNavigator root, so they do NOT inherit the page/header providers.
+      // Web-dapp /perps opens this from the header pill (no perps page tree), so
+      // the accountSelector context must be mirrored here too — PerpPortfolioContent
+      // reads useActiveAccount via usePerpsAccountScopedActivePositions. Mirror the
+      // native page nesting (PerpsAccountSelectorProviderMirror > PerpsProviderMirror).
+      <PerpsAccountSelectorProviderMirror>
+        <PerpsProviderMirror>
+          <PerpPortfolioContent isMobile={false} />
+        </PerpsProviderMirror>
+      </PerpsAccountSelectorProviderMirror>
     ),
   });
   return dialogRef;

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -85,6 +85,7 @@ import { ESwapSource } from '@onekeyhq/shared/types/swap/types';
 import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
 
 import usePerpDeposit from '../../../hooks/usePerpDeposit';
+import { PerpsAccountSelectorProviderMirror } from '../../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
 import {
   PERP_DIALOG_BUTTON_SIZE,
@@ -2042,15 +2043,21 @@ export async function showDepositWithdrawDialog(
 
   const dialogInTabRef = dialogInTab.show({
     renderContent: (
-      <PerpsProviderMirror>
-        <DepositWithdrawContent
-          params={params}
-          selectedAccount={selectedAccount}
-          onClose={() => {
-            void dialogInTabRef.close();
-          }}
-        />
-      </PerpsProviderMirror>
+      // In-tab dialogs render through the IN_PAGE_TAB_CONTAINER portal at the
+      // TabNavigator root and do not inherit the page/header providers. Mirror the
+      // accountSelector context here (as the native perps page does) so any nested
+      // useActiveAccount consumer resolves when opened from the web-dapp header pill.
+      <PerpsAccountSelectorProviderMirror>
+        <PerpsProviderMirror>
+          <DepositWithdrawContent
+            params={params}
+            selectedAccount={selectedAccount}
+            onClose={() => {
+              void dialogInTabRef.close();
+            }}
+          />
+        </PerpsProviderMirror>
+      </PerpsAccountSelectorProviderMirror>
     ),
     contentContainerProps: PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
     showFooter: false,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55583](https://onekeyhq.atlassian.net/browse/OK-55583) [OK-55580](https://onekeyhq.atlassian.net/browse/OK-55580) [OK-55581](https://onekeyhq.atlassian.net/browse/OK-55581) [OK-55584](https://onekeyhq.atlassian.net/browse/OK-55584) [OK-55582](https://onekeyhq.atlassian.net/browse/OK-55582) [OK-55552](https://onekeyhq.atlassian.net/browse/OK-55552)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

Web-dapp account panel / header fixes (`/perps`, `/earn`, and other web-dapp routes).

- **Stop the account panel remounting on header re-render.** `Popover` renders `renderContent` as a component, keying the whole panel subtree by the function's identity. The inline arrow was a fresh identity on every re-render, so on busy routes (DeFi/Earn) the panel visibly vanished and reappeared several times while open. Memoized `renderContent` so the mounted subtree stays stable.
- **Align the panel "Portfolio" value with the wallet home page headline** (spot tokens + DeFi net worth) for the connected address, recomputed live per-network, and render `$0` (not `--`) once a resolved account settles with no value.
- **Provide the accountSelector context to the perps Portfolio/Deposit in-tab dialogs**, so opening them from the web-dapp header (off the perps page tree) no longer throws `store not initialized`.
- **Show the Connect Wallet modal after disconnecting** a web-dapp account, instead of briefly flashing the wrong modal during the transient `{wallet, no-account}` state.

## Tickets

OK-55583 · OK-55580 · OK-55581 · OK-55584 · OK-55582 · OK-55552

## Testing

- `yarn oxlint` on changed files: 0 warnings / 0 errors
- `yarn tsc:staged`: pass
- Verified on web-dapp DeFi/Earn page: opening the account panel no longer flickers.

[OK-55583]: https://onekeyhq.atlassian.net/browse/OK-55583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55580]: https://onekeyhq.atlassian.net/browse/OK-55580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55581]: https://onekeyhq.atlassian.net/browse/OK-55581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55584]: https://onekeyhq.atlassian.net/browse/OK-55584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55582]: https://onekeyhq.atlassian.net/browse/OK-55582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55552]: https://onekeyhq.atlassian.net/browse/OK-55552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ