### PR TITLE
fix: improve perps tooltip interactions(OK-55591 OK-55592)

### DIFF
--- a/packages/components/src/actions/Tooltip/index.tsx
+++ b/packages/components/src/actions/Tooltip/index.tsx
@@ -167,6 +167,7 @@ export function Tooltip({
   shortcutKey,
   hovering,
   contentProps,
+  triggerAsChild,
   ref,
   ...props
 }: ITooltipProps) {
@@ -276,7 +277,7 @@ export function Tooltip({
         {...props}
       >
         <TMTooltip.Trigger
-          asChild="except-style"
+          asChild={triggerAsChild}
           onHoverIn={handleHoverIn}
           onHoverOut={handleHoverOut}
         >

--- a/packages/components/src/actions/Tooltip/index.tsx
+++ b/packages/components/src/actions/Tooltip/index.tsx
@@ -276,6 +276,7 @@ export function Tooltip({
         {...props}
       >
         <TMTooltip.Trigger
+          asChild="except-style"
           onHoverIn={handleHoverIn}
           onHoverOut={handleHoverOut}
         >

--- a/packages/components/src/actions/Tooltip/type.ts
+++ b/packages/components/src/actions/Tooltip/type.ts
@@ -15,5 +15,6 @@ export interface ITooltipProps extends TMTooltipProps {
   shortcutKey?: EShortcutEvents | string[];
   hovering?: boolean;
   contentProps?: PopoverContentProps;
+  triggerAsChild?: boolean | 'except-style';
   ref?: React.RefObject<ITooltipRef>;
 }

--- a/packages/components/src/content/DashText/index.tsx
+++ b/packages/components/src/content/DashText/index.tsx
@@ -8,6 +8,8 @@ import { useMedia } from '../../hooks/useStyle';
 import { SizableText } from '../../primitives/SizeableText';
 import { XStack, YStack } from '../../primitives/Stack';
 
+import type { IPopoverProps } from '../../actions/Popover';
+import type { ITooltipProps } from '../../actions/Tooltip';
 import type { ISizableTextProps } from '../../primitives';
 import type { LayoutChangeEvent } from 'react-native';
 
@@ -23,6 +25,12 @@ export interface IDashTextProps extends ISizableTextProps {
   tooltip?: string;
   /** Title for the mobile Popover sheet. Defaults to children text. */
   tooltipTitle?: string;
+  /** Force tooltip or popover behavior instead of relying on media queries. */
+  tooltipDisplayMode?: 'auto' | 'tooltip' | 'popover';
+  /** Controls the placement used by the tooltip/popover. */
+  tooltipPlacement?: ITooltipProps['placement'];
+  /** Opt into tighter tooltip trigger hit testing when needed. */
+  tooltipTriggerAsChild?: ITooltipProps['triggerAsChild'];
 }
 
 function DashTextCore({
@@ -34,7 +42,14 @@ function DashTextCore({
   dashColor = '$borderStrong',
   length = 200,
   ...textProps
-}: Omit<IDashTextProps, 'tooltip' | 'tooltipTitle'>) {
+}: Omit<
+  IDashTextProps,
+  | 'tooltip'
+  | 'tooltipTitle'
+  | 'tooltipDisplayMode'
+  | 'tooltipPlacement'
+  | 'tooltipTriggerAsChild'
+>) {
   const [textWidth, setTextWidth] = useState(0);
   const resolvedDashThickness = platformEnv.isNative
     ? dashThickness
@@ -133,8 +148,19 @@ function DashTextCore({
   );
 }
 
-export function DashText({ tooltip, tooltipTitle, ...rest }: IDashTextProps) {
+export function DashText({
+  tooltip,
+  tooltipTitle,
+  tooltipDisplayMode = 'auto',
+  tooltipPlacement = 'top',
+  tooltipTriggerAsChild = 'except-style',
+  ...rest
+}: IDashTextProps) {
   const { gtMd } = useMedia();
+  let displayMode = tooltipDisplayMode;
+  if (displayMode === 'auto') {
+    displayMode = gtMd ? 'tooltip' : 'popover';
+  }
 
   const trigger = useMemo(
     () => (tooltip ? <DashTextCore {...rest} cursor="help" /> : null),
@@ -156,10 +182,11 @@ export function DashText({ tooltip, tooltipTitle, ...rest }: IDashTextProps) {
     return <DashTextCore {...rest} />;
   }
 
-  if (!platformEnv.isNative && gtMd) {
+  if (!platformEnv.isNative && displayMode === 'tooltip') {
     return (
       <Tooltip
-        placement="top"
+        placement={tooltipPlacement as ITooltipProps['placement']}
+        triggerAsChild={tooltipTriggerAsChild}
         renderContent={tooltip}
         renderTrigger={trigger}
       />
@@ -169,6 +196,7 @@ export function DashText({ tooltip, tooltipTitle, ...rest }: IDashTextProps) {
   return (
     <Popover
       title={tooltipTitle ?? rest.children}
+      placement={tooltipPlacement as IPopoverProps['placement']}
       renderTrigger={trigger}
       renderContent={popoverContent}
     />

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -1308,7 +1308,6 @@ function BasePerpTokenSelector() {
         onOpenChange={(open) => {
           if (open) {
             defaultLogger.perp.tokenSelector.perpTokenSelectorOpen({
-              source: 'desktop',
               currentToken: baseName,
               tradeMode: mode === 'spot' ? 'spot' : 'perp',
             });
@@ -1477,7 +1476,6 @@ function BasePerpTokenSelectorMobile() {
 
   const onPressTokenSelector = useCallback(() => {
     defaultLogger.perp.tokenSelector.perpTokenSelectorOpen({
-      source: 'mobileTicker',
       currentToken: coin,
       tradeMode: mode === 'spot' ? 'spot' : 'perp',
     });

--- a/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
+++ b/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
@@ -12,6 +12,7 @@ import {
   usePerpsActiveAccountIsAgentReadyAtom,
   usePerpsActiveAccountStatusAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import errorToastUtils from '@onekeyhq/shared/src/errors/utils/errorToastUtils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import {
@@ -20,6 +21,7 @@ import {
 } from '../hooks/useEnableTradingWithDepositFallback';
 import { useShowDepositWithdrawModal } from '../hooks/useShowDepositWithdrawModal';
 import { getEnableTradingDialogConfirmDecision } from '../utils/enableTradingDialogConfirm';
+
 import { showEnableTradingStepsDialog } from './TradingPanel/modals/EnableTradingStepsDialog';
 
 interface ITradingGuardWrapperProps {
@@ -74,8 +76,13 @@ function TradingGuardWrapperInternal({
     if (shouldShowEnableTradingStepsDialog) {
       // The dialog must use a fresh status snapshot so the predicted
       // confirmations stay aligned with the enable-trading execution path.
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      await backgroundApiProxy.serviceHyperliquid.checkPerpsAccountStatus();
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        await backgroundApiProxy.serviceHyperliquid.checkPerpsAccountStatus();
+      } catch (error) {
+        errorToastUtils.toastIfError(error);
+        return;
+      }
       const latestPerpsAccountStatus =
         (await perpsActiveAccountStatusAtom.get()) ?? perpsAccountStatus;
       if (

--- a/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
+++ b/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
@@ -1,17 +1,24 @@
 import type { ReactNode } from 'react';
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
 import { Button, SizableText, Spinner } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import {
+  perpsActiveAccountStatusAtom,
   usePerpsAccountLoadingInfoAtom,
+  usePerpsActiveAccountEnableTradingModeAtom,
   usePerpsActiveAccountIsAgentReadyAtom,
   usePerpsActiveAccountStatusAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
-import { useEnableTradingWithDepositFallback } from '../hooks/useEnableTradingWithDepositFallback';
+import {
+  useConfirmHyperliquidTerms,
+  useRequestEnableTradingWithDepositFallback,
+} from '../hooks/useEnableTradingWithDepositFallback';
+import { showEnableTradingStepsDialog } from './TradingPanel/modals/EnableTradingStepsDialog';
 
 interface ITradingGuardWrapperProps {
   children?: ReactNode;
@@ -31,8 +38,11 @@ function TradingGuardWrapperInternal({
   const intl = useIntl();
   const [perpsAccountLoading] = usePerpsAccountLoadingInfoAtom();
   const [perpsAccountStatus] = usePerpsActiveAccountStatusAtom();
+  const [enableTradingMode] = usePerpsActiveAccountEnableTradingModeAtom();
   const [{ isAgentReady }] = usePerpsActiveAccountIsAgentReadyAtom();
-  const enableTrading = useEnableTradingWithDepositFallback();
+  const confirmHyperliquidTerms = useConfirmHyperliquidTerms();
+  const requestEnableTradingWithDepositFallback =
+    useRequestEnableTradingWithDepositFallback();
 
   const shouldShowEnableTrading = useMemo(() => {
     if (bypassEnableTradingGuard) {
@@ -42,6 +52,8 @@ function TradingGuardWrapperInternal({
   }, [bypassEnableTradingGuard, forceShowEnableTrading, isAgentReady]);
 
   const isEnableTradingLoading = perpsAccountLoading.enableTradingLoading;
+  const shouldShowEnableTradingStepsDialog =
+    enableTradingMode.requiresExplicitEnableTrading;
 
   const buttonStyles = useMemo(() => {
     const isDisabled = disabled || isEnableTradingLoading;
@@ -50,6 +62,52 @@ function TradingGuardWrapperInternal({
       pressStyle: isDisabled ? undefined : { bg: '$green8' },
     };
   }, [disabled, isEnableTradingLoading]);
+
+  const handleEnableTrading = useCallback(async () => {
+    if (disabled || isEnableTradingLoading) {
+      return;
+    }
+
+    if (shouldShowEnableTradingStepsDialog) {
+      // The dialog must use a fresh status snapshot so the predicted
+      // confirmations stay aligned with the enable-trading execution path.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      await backgroundApiProxy.serviceHyperliquid.checkPerpsAccountStatus();
+      const latestPerpsAccountStatus =
+        (await perpsActiveAccountStatusAtom.get()) ?? perpsAccountStatus;
+
+      await showEnableTradingStepsDialog({
+        accountStatus: latestPerpsAccountStatus,
+        onConfirm: async ({ closeDialog }) => {
+          const didAcceptTerms = await confirmHyperliquidTerms();
+          if (!didAcceptTerms) {
+            return {
+              shouldContinue: false,
+              status: undefined,
+            };
+          }
+          return requestEnableTradingWithDepositFallback({
+            beforeDeposit: closeDialog,
+          });
+        },
+      });
+      return;
+    }
+
+    const didAcceptTerms = await confirmHyperliquidTerms();
+    if (!didAcceptTerms) {
+      return;
+    }
+
+    await requestEnableTradingWithDepositFallback();
+  }, [
+    confirmHyperliquidTerms,
+    disabled,
+    isEnableTradingLoading,
+    perpsAccountStatus,
+    requestEnableTradingWithDepositFallback,
+    shouldShowEnableTradingStepsDialog,
+  ]);
 
   if (perpsAccountLoading.selectAccountLoading) {
     return (
@@ -91,7 +149,7 @@ function TradingGuardWrapperInternal({
         size={buttonSize}
         disabled={disabled || isEnableTradingLoading}
         loading={isEnableTradingLoading}
-        onPress={disabled ? undefined : enableTrading}
+        onPress={disabled ? undefined : handleEnableTrading}
         bg="#18794E"
         hoverStyle={buttonStyles.hoverStyle}
         pressStyle={buttonStyles.pressStyle}

--- a/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
+++ b/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
@@ -18,6 +18,8 @@ import {
   useConfirmHyperliquidTerms,
   useRequestEnableTradingWithDepositFallback,
 } from '../hooks/useEnableTradingWithDepositFallback';
+import { useShowDepositWithdrawModal } from '../hooks/useShowDepositWithdrawModal';
+import { getEnableTradingDialogConfirmDecision } from '../utils/enableTradingDialogConfirm';
 import { showEnableTradingStepsDialog } from './TradingPanel/modals/EnableTradingStepsDialog';
 
 interface ITradingGuardWrapperProps {
@@ -43,6 +45,7 @@ function TradingGuardWrapperInternal({
   const confirmHyperliquidTerms = useConfirmHyperliquidTerms();
   const requestEnableTradingWithDepositFallback =
     useRequestEnableTradingWithDepositFallback();
+  const { showDepositWithdrawModal } = useShowDepositWithdrawModal();
 
   const shouldShowEnableTrading = useMemo(() => {
     if (bypassEnableTradingGuard) {
@@ -75,6 +78,13 @@ function TradingGuardWrapperInternal({
       await backgroundApiProxy.serviceHyperliquid.checkPerpsAccountStatus();
       const latestPerpsAccountStatus =
         (await perpsActiveAccountStatusAtom.get()) ?? perpsAccountStatus;
+      if (
+        getEnableTradingDialogConfirmDecision(latestPerpsAccountStatus) ===
+        'deposit'
+      ) {
+        await showDepositWithdrawModal('deposit');
+        return;
+      }
 
       await showEnableTradingStepsDialog({
         accountStatus: latestPerpsAccountStatus,
@@ -106,6 +116,7 @@ function TradingGuardWrapperInternal({
     isEnableTradingLoading,
     perpsAccountStatus,
     requestEnableTradingWithDepositFallback,
+    showDepositWithdrawModal,
     shouldShowEnableTradingStepsDialog,
   ]);
 

--- a/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingPanel.tsx
@@ -243,9 +243,9 @@ function PerpTradingPanel({ isMobile = false }: { isMobile?: boolean }) {
       isLiveStatusPending &&
       coldStartEnableTradingMode &&
       (coldStartEnableTradingMode.canAutoEnableInOrderPanel ||
-        coldStartEnableTradingMode.requiresEnableTradingDialogInOrderPanel) &&
+        coldStartEnableTradingMode.requiresExplicitEnableTrading) &&
       !enableTradingMode.canAutoEnableInOrderPanel &&
-      !enableTradingMode.requiresEnableTradingDialogInOrderPanel
+      !enableTradingMode.requiresExplicitEnableTrading
     ) {
       return coldStartEnableTradingMode;
     }

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -15,6 +15,7 @@ import {
   XStack,
   YStack,
 } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
 import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import {
@@ -24,6 +25,7 @@ import {
   useTradingLoadingAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
+  perpsActiveAccountStatusAtom,
   usePerpsAccountLoadingInfoAtom,
   usePerpsActiveAccountAtom,
   usePerpsActiveAccountEnableTradingModeAtom,
@@ -274,9 +276,9 @@ function SideButtonInternal({
   const shouldShowEnableTradingDialog = useMemo(
     () =>
       !perpsAccountStatus.canTrade &&
-      effectiveEnableTradingMode.requiresEnableTradingDialogInOrderPanel,
+      effectiveEnableTradingMode.requiresExplicitEnableTrading,
     [
-      effectiveEnableTradingMode.requiresEnableTradingDialogInOrderPanel,
+      effectiveEnableTradingMode.requiresExplicitEnableTrading,
       perpsAccountStatus.canTrade,
     ],
   );
@@ -918,8 +920,15 @@ function SideButtonInternal({
         status: undefined,
       };
       if (shouldShowEnableTradingDialog) {
+        // The dialog must reflect a fresh account-status snapshot; the
+        // background enable flow revalidates immediately and can otherwise
+        // require more signatures than the stale UI predicted.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        await backgroundApiProxy.serviceHyperliquid.checkPerpsAccountStatus();
+        const latestPerpsAccountStatus =
+          (await perpsActiveAccountStatusAtom.get()) ?? perpsAccountStatus;
         const result = await showEnableTradingStepsDialog({
-          accountStatus: perpsAccountStatus,
+          accountStatus: latestPerpsAccountStatus,
           onConfirm: async ({ closeDialog }) => {
             if (shouldIgnoreResult()) {
               return stopResult;

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -786,7 +786,9 @@ function SideButtonInternal({
           averageSliceNotional.lt(SCALE_ORDER_MIN_NOTIONAL)
         ) {
           Toast.message({
-            title: 'TWAP order size is too small for this duration',
+            title: intl.formatMessage({
+              id: ETranslations.perp_twap_small_slice__msg,
+            }),
           });
           return false;
         }
@@ -946,10 +948,19 @@ function SideButtonInternal({
         }
         const latestPerpsAccountStatus =
           (await perpsActiveAccountStatusAtom.get()) ?? perpsAccountStatus;
-        if (
-          getEnableTradingDialogConfirmDecision(latestPerpsAccountStatus) ===
-          'deposit'
-        ) {
+        if (shouldIgnoreResult()) {
+          return stopResult;
+        }
+        const confirmDecision = getEnableTradingDialogConfirmDecision(
+          latestPerpsAccountStatus,
+        );
+        if (confirmDecision === 'continue') {
+          return {
+            shouldContinue: true,
+            status: latestPerpsAccountStatus,
+          };
+        }
+        if (confirmDecision === 'deposit') {
           beforeDeposit?.();
           await showDepositWithdrawModal('deposit');
           return stopResult;

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -8,7 +8,6 @@ import {
   Button,
   DashText,
   NumberSizeableText,
-  Popover,
   SizableText,
   Toast,
   Tooltip,
@@ -68,6 +67,7 @@ import { useTradingCalculationsForSide } from '../../hooks/useTradingCalculation
 import { useTradingPrice } from '../../hooks/useTradingPrice';
 import { PerpTestIDs } from '../../testIDs';
 import { shouldPreserveColdStartButtonVisualState } from '../../utils/accountScopedData';
+import { getEnableTradingDialogConfirmDecision } from '../../utils/enableTradingDialogConfirm';
 import { shouldApplyMinimumOrderGuard } from '../../utils/minimumOrderGuard';
 import {
   type IPerpsMobileLayoutTraceRect,
@@ -87,7 +87,6 @@ import {
   shouldDisablePerpsOrderPanelTradingButtonForAccountLoading,
   shouldSkipPerpsOrderPanelComputedSizeValidation,
 } from '../../utils/perpsOrderPanelEnableTrading';
-import { getEnableTradingDialogConfirmDecision } from '../../utils/enableTradingDialogConfirm';
 import { PERP_TRADE_BUTTON_COLORS } from '../../utils/styleUtils';
 
 import { showEnableTradingStepsDialog } from './modals/EnableTradingStepsDialog';
@@ -1261,6 +1260,50 @@ function SideButtonInternal({
       side,
     ],
   );
+  const desktopCostTooltipContent = useMemo(
+    () =>
+      intl.formatMessage({
+        id: ETranslations.perp_trade_margin_tooltip,
+      }),
+    [intl],
+  );
+  const desktopCostTooltipTrigger = useMemo(
+    () => (
+      <DashText
+        size="$bodySm"
+        color="$textSubdued"
+        cursor="default"
+        dashThickness={0.5}
+      >
+        {intl.formatMessage({
+          id: ETranslations.perp_cost,
+        })}
+      </DashText>
+    ),
+    [intl],
+  );
+  const desktopLiqPriceTooltipContent = useMemo(
+    () =>
+      intl.formatMessage({
+        id: ETranslations.perp_est_liq_price_tooltip,
+      }),
+    [intl],
+  );
+  const desktopLiqPriceTooltipTrigger = useMemo(
+    () => (
+      <DashText
+        size="$bodySm"
+        color="$textSubdued"
+        cursor="default"
+        dashThickness={0.5}
+      >
+        {intl.formatMessage({
+          id: ETranslations.perp_est_liq_price,
+        })}
+      </DashText>
+    ),
+    [intl],
+  );
 
   if (isMobile) {
     return (
@@ -1282,31 +1325,21 @@ function SideButtonInternal({
         </XStack> */}
 
             <XStack justifyContent="space-between">
-              <Popover
-                title={intl.formatMessage({
+              <DashText
+                size="$bodySm"
+                color="$textSubdued"
+                dashThickness={0.3}
+                tooltip={intl.formatMessage({
+                  id: ETranslations.perp_trade_margin_tooltip,
+                })}
+                tooltipTitle={intl.formatMessage({
                   id: ETranslations.perp_trade_margin_required,
                 })}
-                renderTrigger={
-                  <DashText
-                    size="$bodySm"
-                    color="$textSubdued"
-                    dashThickness={0.3}
-                  >
-                    {intl.formatMessage({
-                      id: ETranslations.perp_cost,
-                    })}
-                  </DashText>
-                }
-                renderContent={
-                  <YStack px="$5" pb="$4">
-                    <SizableText>
-                      {intl.formatMessage({
-                        id: ETranslations.perp_trade_margin_tooltip,
-                      })}
-                    </SizableText>
-                  </YStack>
-                }
-              />
+              >
+                {intl.formatMessage({
+                  id: ETranslations.perp_cost,
+                })}
+              </DashText>
 
               <NumberSizeableText
                 size="$bodySm"
@@ -1319,31 +1352,21 @@ function SideButtonInternal({
             </XStack>
 
             <XStack justifyContent="space-between">
-              <Popover
-                title={intl.formatMessage({
+              <DashText
+                size="$bodySm"
+                color="$textSubdued"
+                dashThickness={0.5}
+                tooltip={intl.formatMessage({
+                  id: ETranslations.perp_est_liq_price_tooltip,
+                })}
+                tooltipTitle={intl.formatMessage({
                   id: ETranslations.perp_est_liq_price,
                 })}
-                renderTrigger={
-                  <DashText
-                    size="$bodySm"
-                    color="$textSubdued"
-                    dashThickness={0.5}
-                  >
-                    {intl.formatMessage({
-                      id: ETranslations.perp_est_liq_price,
-                    })}
-                  </DashText>
-                }
-                renderContent={
-                  <YStack px="$5" pb="$4">
-                    <SizableText>
-                      {intl.formatMessage({
-                        id: ETranslations.perp_est_liq_price_tooltip,
-                      })}
-                    </SizableText>
-                  </YStack>
-                }
-              />
+              >
+                {intl.formatMessage({
+                  id: ETranslations.perp_est_liq_price,
+                })}
+              </DashText>
 
               {renderLiquidationPrice()}
             </XStack>
@@ -1459,21 +1482,8 @@ function SideButtonInternal({
           <XStack gap="$2" justifyContent={justifyContent}>
             <Tooltip
               placement="top"
-              renderContent={intl.formatMessage({
-                id: ETranslations.perp_trade_margin_tooltip,
-              })}
-              renderTrigger={
-                <DashText
-                  size="$bodySm"
-                  color="$textSubdued"
-                  cursor="default"
-                  dashThickness={0.5}
-                >
-                  {intl.formatMessage({
-                    id: ETranslations.perp_cost,
-                  })}
-                </DashText>
-              }
+              renderContent={desktopCostTooltipContent}
+              renderTrigger={desktopCostTooltipTrigger}
             />
 
             <NumberSizeableText
@@ -1489,21 +1499,8 @@ function SideButtonInternal({
           <XStack gap="$2" justifyContent={justifyContent}>
             <Tooltip
               placement="top"
-              renderContent={intl.formatMessage({
-                id: ETranslations.perp_est_liq_price_tooltip,
-              })}
-              renderTrigger={
-                <DashText
-                  size="$bodySm"
-                  color="$textSubdued"
-                  cursor="default"
-                  dashThickness={0.5}
-                >
-                  {intl.formatMessage({
-                    id: ETranslations.perp_est_liq_price,
-                  })}
-                </DashText>
-              }
+              renderContent={desktopLiqPriceTooltipContent}
+              renderTrigger={desktopLiqPriceTooltipTrigger}
             />
 
             {renderLiquidationPrice()}

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -63,6 +63,7 @@ import {
   useConfirmHyperliquidTerms,
   useRequestEnableTradingWithDepositFallback,
 } from '../../hooks/useEnableTradingWithDepositFallback';
+import { useShowDepositWithdrawModal } from '../../hooks/useShowDepositWithdrawModal';
 import { useTradingCalculationsForSide } from '../../hooks/useTradingCalculationsForSide';
 import { useTradingPrice } from '../../hooks/useTradingPrice';
 import { PerpTestIDs } from '../../testIDs';
@@ -86,6 +87,7 @@ import {
   shouldDisablePerpsOrderPanelTradingButtonForAccountLoading,
   shouldSkipPerpsOrderPanelComputedSizeValidation,
 } from '../../utils/perpsOrderPanelEnableTrading';
+import { getEnableTradingDialogConfirmDecision } from '../../utils/enableTradingDialogConfirm';
 import { PERP_TRADE_BUTTON_COLORS } from '../../utils/styleUtils';
 
 import { showEnableTradingStepsDialog } from './modals/EnableTradingStepsDialog';
@@ -189,6 +191,7 @@ function SideButtonInternal({
   const confirmHyperliquidTerms = useConfirmHyperliquidTerms();
   const requestEnableTradingWithDepositFallback =
     useRequestEnableTradingWithDepositFallback();
+  const { showDepositWithdrawModal } = useShowDepositWithdrawModal();
   const perpsAccountKey = useMemo(
     () => getPerpsAccountKey(perpsAccount),
     [perpsAccount],
@@ -411,7 +414,13 @@ function SideButtonInternal({
 
   const buttonText = useMemo(() => {
     if (isMobile && formData.orderMode === 'scale') {
-      return side === 'long' ? 'Preview Buy' : 'Preview Sell';
+      return side === 'long'
+        ? intl.formatMessage({
+            id: ETranslations.perp_preview_buy__action,
+          })
+        : intl.formatMessage({
+            id: ETranslations.perp_preview_sell__action,
+          });
     }
     if (priceError === 'bbo_unavailable' && !shouldEnableTradingBeforeOrder)
       return intl.formatMessage({
@@ -927,6 +936,14 @@ function SideButtonInternal({
         await backgroundApiProxy.serviceHyperliquid.checkPerpsAccountStatus();
         const latestPerpsAccountStatus =
           (await perpsActiveAccountStatusAtom.get()) ?? perpsAccountStatus;
+        if (
+          getEnableTradingDialogConfirmDecision(latestPerpsAccountStatus) ===
+          'deposit'
+        ) {
+          beforeDeposit?.();
+          await showDepositWithdrawModal('deposit');
+          return stopResult;
+        }
         const result = await showEnableTradingStepsDialog({
           accountStatus: latestPerpsAccountStatus,
           onConfirm: async ({ closeDialog }) => {
@@ -976,6 +993,7 @@ function SideButtonInternal({
       intl,
       perpsAccountStatus,
       requestEnableTradingWithDepositFallback,
+      showDepositWithdrawModal,
       shouldShowEnableTradingDialog,
     ],
   );

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -35,6 +35,7 @@ import {
   usePerpsTradingPreferencesAtom,
   useTradingModeAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import errorToastUtils from '@onekeyhq/shared/src/errors/utils/errorToastUtils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   SCALE_ORDER_MAX_COUNT,
@@ -87,6 +88,7 @@ import {
   shouldDisablePerpsOrderPanelTradingButtonForAccountLoading,
   shouldSkipPerpsOrderPanelComputedSizeValidation,
 } from '../../utils/perpsOrderPanelEnableTrading';
+import { getScaleOrderValidationErrorMessage } from '../../utils/scaleOrderValidation';
 import { PERP_TRADE_BUTTON_COLORS } from '../../utils/styleUtils';
 
 import { showEnableTradingStepsDialog } from './modals/EnableTradingStepsDialog';
@@ -759,7 +761,11 @@ function SideButtonInternal({
         const validation = validateScaleOrderLegs({ legs });
         if (!validation.isValid) {
           Toast.message({
-            title: validation.errors[0] ?? 'Invalid scale order',
+            title: getScaleOrderValidationErrorMessage({
+              intl,
+              validation,
+              fallback: 'Invalid scale order',
+            }),
           });
           return false;
         }
@@ -931,8 +937,13 @@ function SideButtonInternal({
         // The dialog must reflect a fresh account-status snapshot; the
         // background enable flow revalidates immediately and can otherwise
         // require more signatures than the stale UI predicted.
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        await backgroundApiProxy.serviceHyperliquid.checkPerpsAccountStatus();
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+          await backgroundApiProxy.serviceHyperliquid.checkPerpsAccountStatus();
+        } catch (error) {
+          errorToastUtils.toastIfError(error);
+          return stopResult;
+        }
         const latestPerpsAccountStatus =
           (await perpsActiveAccountStatusAtom.get()) ?? perpsAccountStatus;
         if (
@@ -1332,6 +1343,7 @@ function SideButtonInternal({
                 tooltip={intl.formatMessage({
                   id: ETranslations.perp_trade_margin_tooltip,
                 })}
+                tooltipDisplayMode="popover"
                 tooltipTitle={intl.formatMessage({
                   id: ETranslations.perp_trade_margin_required,
                 })}
@@ -1359,6 +1371,7 @@ function SideButtonInternal({
                 tooltip={intl.formatMessage({
                   id: ETranslations.perp_est_liq_price_tooltip,
                 })}
+                tooltipDisplayMode="popover"
                 tooltipTitle={intl.formatMessage({
                   id: ETranslations.perp_est_liq_price,
                 })}
@@ -1482,6 +1495,7 @@ function SideButtonInternal({
           <XStack gap="$2" justifyContent={justifyContent}>
             <Tooltip
               placement="top"
+              triggerAsChild="except-style"
               renderContent={desktopCostTooltipContent}
               renderTrigger={desktopCostTooltipTrigger}
             />
@@ -1499,6 +1513,7 @@ function SideButtonInternal({
           <XStack gap="$2" justifyContent={justifyContent}>
             <Tooltip
               placement="top"
+              triggerAsChild="except-style"
               renderContent={desktopLiqPriceTooltipContent}
               renderTrigger={desktopLiqPriceTooltipTrigger}
             />

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/EnableTradingStepsDialog.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/EnableTradingStepsDialog.tsx
@@ -77,9 +77,11 @@ function renderEnableTradingSummaryUnderline(chunks: ReactNode) {
 
 function EnableTradingStepsContent({
   initialAccountStatus,
+  onOpenGuide,
   onConfirm,
 }: {
   initialAccountStatus: IPerpsActiveAccountStatusAtom;
+  onOpenGuide: () => void;
   onConfirm: () => Promise<void>;
 }) {
   const intl = useIntl();
@@ -151,15 +153,7 @@ function EnableTradingStepsContent({
         <XStack
           gap="$1"
           alignItems="center"
-          onPress={() => {
-            setTimeout(() => {
-              openGuideUrl(
-                buildHelpUrl(
-                  `articles/${CONTEXTUAL_ARTICLE_IDS.enableTrading}`,
-                ),
-              );
-            }, 150);
-          }}
+          onPress={onOpenGuide}
           cursor="default"
         >
           <Icon name="QuestionmarkOutline" size="$3.5" color="$iconSubdued" />
@@ -260,6 +254,16 @@ export function showEnableTradingStepsDialog({
           <EnableTradingStepsHeader initialAccountStatus={accountStatus} />
           <EnableTradingStepsContent
             initialAccountStatus={accountStatus}
+            onOpenGuide={() => {
+              void dialogInstance.close();
+              setTimeout(() => {
+                openGuideUrl(
+                  buildHelpUrl(
+                    `articles/${CONTEXTUAL_ARTICLE_IDS.enableTrading}`,
+                  ),
+                );
+              }, 150);
+            }}
             onConfirm={async () => {
               const closeDialog = () => {
                 void dialogInstance.close();
@@ -277,7 +281,10 @@ export function showEnableTradingStepsDialog({
               if (result) {
                 settle(result);
                 closeDialog();
+                return;
               }
+              settle(undefined);
+              closeDialog();
             }}
           />
         </>

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/EnableTradingStepsDialog.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/EnableTradingStepsDialog.tsx
@@ -5,21 +5,31 @@ import { useIntl } from 'react-intl';
 import {
   Button,
   Dialog,
+  Icon,
   SizableText,
   XStack,
   YStack,
 } from '@onekeyhq/components';
+import {
+  usePerpsAbstractionModeAtom as usePerpsAbstractionMode,
+  usePerpsActiveAccountStatusAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IPerpsActiveAccountStatusAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 
+import { getPerpsOrderPanelEnableTradingSteps } from '../../../utils/perpsOrderPanelEnableTrading';
 import {
-  getPerpsOrderPanelEnableTradingSignatureCount,
-  getPerpsOrderPanelEnableTradingSteps,
-} from '../../../utils/perpsOrderPanelEnableTrading';
-import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../../PerpDialogLayout';
+  CONTEXTUAL_ARTICLE_IDS,
+  buildHelpUrl,
+  openGuideUrl,
+} from '../../Guide/perpGuideData';
+import {
+  PERP_DIALOG_BUTTON_SIZE,
+  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+} from '../../PerpDialogLayout';
 
 import type { IEnableTradingWithDepositFallbackResult } from '../../../hooks/useEnableTradingWithDepositFallback';
+import type { IPerpsOrderPanelEnableTradingStep } from '../../../utils/perpsOrderPanelEnableTrading';
 
 type IEnableTradingStepsDialogConfirmContext = {
   closeDialog: () => void;
@@ -29,27 +39,63 @@ type IEnableTradingStepsDialogConfirm = (
   context: IEnableTradingStepsDialogConfirmContext,
 ) => Promise<IEnableTradingWithDepositFallbackResult | undefined>;
 
+function getEnableTradingSignatureDescription(
+  step: IPerpsOrderPanelEnableTradingStep,
+): string {
+  switch (step.key) {
+    case 'builderFee':
+      return 'Confirm OneKey service access';
+    case 'agentRemoval':
+      return 'Replace previous trading agent';
+    case 'agent':
+      return 'Authorize OneKey trading agent';
+    case 'abstraction':
+      return 'Enable unified trading account';
+    default:
+      return '';
+  }
+}
+
+function isEnableTradingConfirmationStep(
+  step: IPerpsOrderPanelEnableTradingStep,
+) {
+  return step.requiresSignature;
+}
+
+function getHardwareConfirmationCountLabel(count: number) {
+  if (count === 1) {
+    return 'One';
+  }
+  if (count === 2) {
+    return 'Two';
+  }
+  if (count === 3) {
+    return 'Three';
+  }
+  return String(count);
+}
+
 function EnableTradingStepsContent({
-  accountStatus,
-  onCancel,
+  initialAccountStatus,
   onConfirm,
 }: {
-  accountStatus: IPerpsActiveAccountStatusAtom;
-  onCancel: () => void;
+  initialAccountStatus: IPerpsActiveAccountStatusAtom;
   onConfirm: () => Promise<void>;
 }) {
   const intl = useIntl();
   const [isConfirming, setIsConfirming] = useState(false);
+  const [liveAccountStatus] = usePerpsActiveAccountStatusAtom();
+  const [abstractionMode] = usePerpsAbstractionMode();
+  const accountStatus = liveAccountStatus ?? initialAccountStatus;
   const steps = useMemo(
-    () => getPerpsOrderPanelEnableTradingSteps(accountStatus),
-    [accountStatus],
+    () =>
+      getPerpsOrderPanelEnableTradingSteps(accountStatus, {
+        abstractionMode,
+      }),
+    [abstractionMode, accountStatus],
   );
   const signatureSteps = useMemo(
-    () => steps.filter((step) => step.requiresSignature),
-    [steps],
-  );
-  const signatureCount = useMemo(
-    () => getPerpsOrderPanelEnableTradingSignatureCount(steps),
+    () => steps.filter(isEnableTradingConfirmationStep),
     [steps],
   );
   const handleConfirm = useCallback(async () => {
@@ -57,59 +103,75 @@ function EnableTradingStepsContent({
       return;
     }
     setIsConfirming(true);
-    await onConfirm();
+    try {
+      await onConfirm();
+    } finally {
+      setIsConfirming(false);
+    }
   }, [isConfirming, onConfirm]);
 
   return (
-    <YStack gap="$4" p="$1">
-      <SizableText size="$bodyMd" color="$textSubdued">
-        {intl.formatMessage({
-          id: ETranslations.perp_enable_trading_desc,
-        })}
-      </SizableText>
+    <YStack gap="$6" p="$1">
+      <YStack gap="$4">
+        {signatureSteps.length ? (
+          <YStack gap="$3">
+            {signatureSteps.map((step, index) => (
+              <XStack key={step.key} gap="$2.5" alignItems="center">
+                <XStack
+                  width={18}
+                  height={18}
+                  borderRadius={999}
+                  alignItems="center"
+                  justifyContent="center"
+                  bg="$bgStrong"
+                  flexShrink={0}
+                >
+                  <SizableText size="$bodyXsMedium" color="$text">
+                    {index + 1}
+                  </SizableText>
+                </XStack>
+                <SizableText size="$bodyMd" color="$text">
+                  {getEnableTradingSignatureDescription(step)}
+                </SizableText>
+              </XStack>
+            ))}
+          </YStack>
+        ) : null}
+      </YStack>
 
-      {signatureCount > 0 ? (
-        <YStack gap="$2">
-          <XStack justifyContent="space-between" alignItems="center">
-            <SizableText size="$bodyMdMedium" color="$text">
-              {intl.formatMessage({
-                id: ETranslations.global_confirm_on_device,
-              })}
-            </SizableText>
-            <SizableText size="$bodyMdMedium" color="$text">
-              {signatureCount}
-            </SizableText>
-          </XStack>
-
-          {signatureSteps.map((step, index) => (
-            <XStack key={step.key} gap="$2" alignItems="center">
-              <SizableText size="$bodySm" color="$textSubdued">
-                {index + 1}.
-              </SizableText>
-              <SizableText size="$bodySm" color="$textSubdued">
-                {intl.formatMessage({ id: step.labelId })}
-              </SizableText>
-            </XStack>
-          ))}
-        </YStack>
-      ) : null}
-
-      <XStack gap="$2">
-        <Button
-          testID="perp-enable-trading-steps-cancel"
-          flex={1}
-          variant="secondary"
-          onPress={onCancel}
-          disabled={isConfirming}
+      <YStack gap="$3">
+        <XStack
+          gap="$1"
+          alignItems="center"
+          onPress={() => {
+            setTimeout(() => {
+              openGuideUrl(
+                buildHelpUrl(
+                  `articles/${CONTEXTUAL_ARTICLE_IDS.enableTrading}`,
+                ),
+              );
+            }, 150);
+          }}
+          cursor="default"
         >
-          {intl.formatMessage({
-            id: ETranslations.global_cancel,
-          })}
-        </Button>
+          <Icon name="QuestionmarkOutline" size="$3.5" color="$iconSubdued" />
+          <SizableText
+            size="$bodySm"
+            color="$textSubdued"
+            hoverStyle={{ opacity: 0.8 }}
+            pressStyle={{ opacity: 0.7 }}
+          >
+            {intl.formatMessage({
+              id: ETranslations.perp_guide_article_introduction,
+            })}
+          </SizableText>
+        </XStack>
+
         <Button
           testID="perp-enable-trading-steps-continue"
-          flex={1}
+          width="100%"
           variant="primary"
+          size={PERP_DIALOG_BUTTON_SIZE}
           onPress={handleConfirm}
           loading={isConfirming}
           disabled={isConfirming}
@@ -118,8 +180,46 @@ function EnableTradingStepsContent({
             id: ETranslations.global_continue,
           })}
         </Button>
-      </XStack>
+      </YStack>
     </YStack>
+  );
+}
+
+function EnableTradingStepsHeader() {
+  const intl = useIntl();
+  const [liveAccountStatus] = usePerpsActiveAccountStatusAtom();
+  const [abstractionMode] = usePerpsAbstractionMode();
+  const steps = useMemo(
+    () =>
+      liveAccountStatus
+        ? getPerpsOrderPanelEnableTradingSteps(liveAccountStatus, {
+            abstractionMode,
+          })
+        : [],
+    [abstractionMode, liveAccountStatus],
+  );
+  const signatureCount = steps.filter((step) => step.requiresSignature).length;
+
+  return (
+    <Dialog.Header>
+      <Dialog.Title>
+        {intl.formatMessage({
+          id: ETranslations.perp_trade_button_enable_trading,
+        })}
+      </Dialog.Title>
+      <SizableText size="$bodyMd" color="$textSubdued" mt="$1.5" mr={-44}>
+        Enable trading for instant, gas-free Perps orders. Requires{' '}
+        <SizableText
+          display="inline-flex"
+          size="$bodyMd"
+          color="$textSubdued"
+          textDecorationLine="underline"
+        >
+          {getHardwareConfirmationCountLabel(signatureCount)}
+        </SizableText>{' '}
+        wallet confirmation{signatureCount > 1 ? 's' : ''}.
+      </SizableText>
+    </Dialog.Header>
   );
 }
 
@@ -144,33 +244,33 @@ export function showEnableTradingStepsDialog({
     const dialogInstance = Dialog.show({
       disableDrag: true,
       dismissOnOverlayPress: false,
-      showExitButton: false,
-      // eslint-disable-next-line onekey/no-app-locale-main-thread
-      title: appLocale.intl.formatMessage({
-        id: ETranslations.perp_trade_button_enable_trading,
-      }),
+      showExitButton: true,
       renderContent: (
-        <EnableTradingStepsContent
-          accountStatus={accountStatus}
-          onCancel={() => {
-            settle(undefined);
-            void dialogInstance.close();
-          }}
-          onConfirm={async () => {
-            const closeDialog = () => {
-              void dialogInstance.close();
-            };
-            let result: IEnableTradingWithDepositFallbackResult | undefined;
-            try {
-              result = await onConfirm({ closeDialog });
-            } catch {
-              result = undefined;
-            } finally {
-              settle(result);
-              closeDialog();
-            }
-          }}
-        />
+        <>
+          <EnableTradingStepsHeader />
+          <EnableTradingStepsContent
+            initialAccountStatus={accountStatus}
+            onConfirm={async () => {
+              const closeDialog = () => {
+                void dialogInstance.close();
+              };
+              let result: IEnableTradingWithDepositFallbackResult | undefined;
+              try {
+                result = await onConfirm({ closeDialog });
+              } catch {
+                result = undefined;
+              }
+              if (result?.shouldContinue === false) {
+                settle(result);
+                return;
+              }
+              if (result) {
+                settle(result);
+                closeDialog();
+              }
+            }}
+          />
+        </>
       ),
       contentContainerProps: PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
       showFooter: false,

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/EnableTradingStepsDialog.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/EnableTradingStepsDialog.tsx
@@ -41,18 +41,18 @@ type IEnableTradingStepsDialogConfirm = (
 
 function getEnableTradingSignatureDescription(
   step: IPerpsOrderPanelEnableTradingStep,
-): string {
+): ETranslations | undefined {
   switch (step.key) {
     case 'builderFee':
-      return 'Confirm OneKey service access';
+      return ETranslations.perp_enable_trading_steps_builder_fee__desc;
     case 'agentRemoval':
-      return 'Replace previous trading agent';
+      return ETranslations.perp_enable_trading_steps_agent_removal__desc;
     case 'agent':
-      return 'Authorize OneKey trading agent';
+      return ETranslations.perp_enable_trading_steps_agent__desc;
     case 'abstraction':
-      return 'Enable unified trading account';
+      return ETranslations.perp_enable_trading_steps_abstraction__desc;
     default:
-      return '';
+      return undefined;
   }
 }
 
@@ -63,16 +63,13 @@ function isEnableTradingConfirmationStep(
 }
 
 function getHardwareConfirmationCountLabel(count: number) {
-  if (count === 1) {
-    return 'One';
-  }
-  if (count === 2) {
-    return 'Two';
-  }
-  if (count === 3) {
-    return 'Three';
-  }
   return String(count);
+}
+
+function getEnableTradingConfirmationLabelId(count: number) {
+  return count === 1
+    ? ETranslations.perp_enable_trading_steps_wallet_confirmation__desc
+    : ETranslations.perp_enable_trading_steps_wallet_confirmations__desc;
 }
 
 function EnableTradingStepsContent({
@@ -115,26 +112,34 @@ function EnableTradingStepsContent({
       <YStack gap="$4">
         {signatureSteps.length ? (
           <YStack gap="$3">
-            {signatureSteps.map((step, index) => (
-              <XStack key={step.key} gap="$2.5" alignItems="center">
-                <XStack
-                  width={18}
-                  height={18}
-                  borderRadius={999}
-                  alignItems="center"
-                  justifyContent="center"
-                  bg="$bgStrong"
-                  flexShrink={0}
-                >
-                  <SizableText size="$bodyXsMedium" color="$text">
-                    {index + 1}
-                  </SizableText>
+            {signatureSteps.map((step, index) => {
+              const descriptionId = getEnableTradingSignatureDescription(step);
+
+              return (
+                <XStack key={step.key} gap="$2.5" alignItems="center">
+                  <XStack
+                    width={18}
+                    height={18}
+                    borderRadius={999}
+                    alignItems="center"
+                    justifyContent="center"
+                    bg="$bgStrong"
+                    flexShrink={0}
+                  >
+                    <SizableText size="$bodyXsMedium" color="$text">
+                      {index + 1}
+                    </SizableText>
+                  </XStack>
+                  {descriptionId ? (
+                    <SizableText size="$bodyMd" color="$text">
+                      {intl.formatMessage({
+                        id: descriptionId,
+                      })}
+                    </SizableText>
+                  ) : null}
                 </XStack>
-                <SizableText size="$bodyMd" color="$text">
-                  {getEnableTradingSignatureDescription(step)}
-                </SizableText>
-              </XStack>
-            ))}
+              );
+            })}
           </YStack>
         ) : null}
       </YStack>
@@ -208,7 +213,9 @@ function EnableTradingStepsHeader() {
         })}
       </Dialog.Title>
       <SizableText size="$bodyMd" color="$textSubdued" mt="$1.5" mr={-44}>
-        Enable trading for instant, gas-free Perps orders. Requires{' '}
+        {intl.formatMessage({
+          id: ETranslations.perp_enable_trading_steps_summary__desc,
+        })}{' '}
         <SizableText
           display="inline-flex"
           size="$bodyMd"
@@ -217,7 +224,9 @@ function EnableTradingStepsHeader() {
         >
           {getHardwareConfirmationCountLabel(signatureCount)}
         </SizableText>{' '}
-        wallet confirmation{signatureCount > 1 ? 's' : ''}.
+        {intl.formatMessage({
+          id: getEnableTradingConfirmationLabelId(signatureCount),
+        })}
       </SizableText>
     </Dialog.Header>
   );

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/EnableTradingStepsDialog.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/EnableTradingStepsDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { type ReactNode, useCallback, useMemo, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -62,14 +62,17 @@ function isEnableTradingConfirmationStep(
   return step.requiresSignature;
 }
 
-function getHardwareConfirmationCountLabel(count: number) {
-  return String(count);
-}
-
-function getEnableTradingConfirmationLabelId(count: number) {
-  return count === 1
-    ? ETranslations.perp_enable_trading_steps_wallet_confirmation__desc
-    : ETranslations.perp_enable_trading_steps_wallet_confirmations__desc;
+function renderEnableTradingSummaryUnderline(chunks: ReactNode) {
+  return (
+    <SizableText
+      display="inline-flex"
+      size="$bodyMd"
+      color="$textSubdued"
+      textDecorationLine="underline"
+    >
+      {chunks}
+    </SizableText>
+  );
 }
 
 function EnableTradingStepsContent({
@@ -190,18 +193,21 @@ function EnableTradingStepsContent({
   );
 }
 
-function EnableTradingStepsHeader() {
+function EnableTradingStepsHeader({
+  initialAccountStatus,
+}: {
+  initialAccountStatus: IPerpsActiveAccountStatusAtom;
+}) {
   const intl = useIntl();
   const [liveAccountStatus] = usePerpsActiveAccountStatusAtom();
   const [abstractionMode] = usePerpsAbstractionMode();
+  const accountStatus = liveAccountStatus ?? initialAccountStatus;
   const steps = useMemo(
     () =>
-      liveAccountStatus
-        ? getPerpsOrderPanelEnableTradingSteps(liveAccountStatus, {
-            abstractionMode,
-          })
-        : [],
-    [abstractionMode, liveAccountStatus],
+      getPerpsOrderPanelEnableTradingSteps(accountStatus, {
+        abstractionMode,
+      }),
+    [abstractionMode, accountStatus],
   );
   const signatureCount = steps.filter((step) => step.requiresSignature).length;
 
@@ -212,21 +218,16 @@ function EnableTradingStepsHeader() {
           id: ETranslations.perp_trade_button_enable_trading,
         })}
       </Dialog.Title>
-      <SizableText size="$bodyMd" color="$textSubdued" mt="$1.5" mr={-44}>
-        {intl.formatMessage({
-          id: ETranslations.perp_enable_trading_steps_summary__desc,
-        })}{' '}
-        <SizableText
-          display="inline-flex"
-          size="$bodyMd"
-          color="$textSubdued"
-          textDecorationLine="underline"
-        >
-          {getHardwareConfirmationCountLabel(signatureCount)}
-        </SizableText>{' '}
-        {intl.formatMessage({
-          id: getEnableTradingConfirmationLabelId(signatureCount),
-        })}
+      <SizableText size="$bodyMd" color="$textSubdued" mt="$1.5">
+        {intl.formatMessage(
+          {
+            id: ETranslations.perp_enable_trading_steps_summary_v2__desc,
+          },
+          {
+            count: signatureCount,
+            underline: renderEnableTradingSummaryUnderline,
+          },
+        )}
       </SizableText>
     </Dialog.Header>
   );
@@ -256,7 +257,7 @@ export function showEnableTradingStepsDialog({
       showExitButton: true,
       renderContent: (
         <>
-          <EnableTradingStepsHeader />
+          <EnableTradingStepsHeader initialAccountStatus={accountStatus} />
           <EnableTradingStepsContent
             initialAccountStatus={accountStatus}
             onConfirm={async () => {

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/LeverageAdjustModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/LeverageAdjustModal.tsx
@@ -183,7 +183,7 @@ const LeverageContent = memo(
               />
             </XStack>
           </YStack>
-          <YStack gap="$2" pb="$4">
+          <YStack gap="$2">
             <XStack gap="$1" alignItems="center" justifyContent="flex-start">
               <Icon
                 name="InfoCircleSolid"
@@ -217,43 +217,49 @@ const LeverageContent = memo(
               </SizableText>
             </XStack>
           </YStack>
-          <XStack
-            gap="$1"
-            alignItems="center"
-            justifyContent="flex-start"
-            onPress={() => {
-              void dialogInstance.close();
-              setTimeout(() => {
-                openGuideUrl(
-                  buildHelpUrl(`articles/${CONTEXTUAL_ARTICLE_IDS.leverage}`),
-                );
-              }, 150);
-            }}
-            cursor="default"
-          >
-            <Icon name="QuestionmarkOutline" size="$3.5" color="$iconSubdued" />
-            <SizableText
-              size="$bodySm"
-              color="$textSubdued"
-              hoverStyle={{ color: '$text' }}
+          <YStack gap="$3" pb="$4">
+            <XStack
+              gap="$1"
+              alignItems="center"
+              justifyContent="flex-start"
+              onPress={() => {
+                void dialogInstance.close();
+                setTimeout(() => {
+                  openGuideUrl(
+                    buildHelpUrl(`articles/${CONTEXTUAL_ARTICLE_IDS.leverage}`),
+                  );
+                }, 150);
+              }}
+              cursor="default"
             >
-              {intl.formatMessage({
-                id: ETranslations.perp_guide_article_basic_concepts,
-              })}
-            </SizableText>
-          </XStack>
-          <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
-            <Button
-              testID={PerpTestIDs.LeverageConfirmButton}
-              onPress={handleConfirm}
-              disabled={isDisabled}
-              loading={loading}
-              size={PERP_DIALOG_BUTTON_SIZE}
-              variant="primary"
-            >
-              {intl.formatMessage({ id: ETranslations.global_confirm })}
-            </Button>
-          </TradingGuardWrapper>
+              <Icon
+                name="QuestionmarkOutline"
+                size="$3.5"
+                color="$iconSubdued"
+              />
+              <SizableText
+                size="$bodySm"
+                color="$textSubdued"
+                hoverStyle={{ color: '$text' }}
+              >
+                {intl.formatMessage({
+                  id: ETranslations.perp_guide_article_basic_concepts,
+                })}
+              </SizableText>
+            </XStack>
+            <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
+              <Button
+                testID={PerpTestIDs.LeverageConfirmButton}
+                onPress={handleConfirm}
+                disabled={isDisabled}
+                loading={loading}
+                size={PERP_DIALOG_BUTTON_SIZE}
+                variant="primary"
+              >
+                {intl.formatMessage({ id: ETranslations.global_confirm })}
+              </Button>
+            </TradingGuardWrapper>
+          </YStack>
         </YStack>
         {platformEnv.isNativeIOS ? (
           <InputAccessoryView nativeID="leverage-adjust-input-accessory-view">

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
@@ -57,27 +57,36 @@ function PerpAccountMMRView() {
     if (pct <= 70) return '$yellow11';
     return '$red11';
   })();
+  const mmrTooltipContent = useMemo(
+    () =>
+      intl.formatMessage({
+        id: ETranslations.perp_account_cross_margin_ration_tip,
+      }),
+    [intl],
+  );
+  const mmrTooltipTrigger = useMemo(
+    () => (
+      <DashText
+        size="$bodySm"
+        color="$textSubdued"
+        cursor="help"
+        dashThickness={1}
+      >
+        {intl.formatMessage({
+          id: ETranslations.perp_account_cross_margin_ration,
+        })}
+      </DashText>
+    ),
+    [intl],
+  );
 
   if (mmrPercent) {
     return (
       <XStack justifyContent="space-between">
         <Tooltip
           placement="top"
-          renderContent={intl.formatMessage({
-            id: ETranslations.perp_account_cross_margin_ration_tip,
-          })}
-          renderTrigger={
-            <DashText
-              size="$bodySm"
-              color="$textSubdued"
-              cursor="help"
-              dashThickness={1}
-            >
-              {intl.formatMessage({
-                id: ETranslations.perp_account_cross_margin_ration,
-              })}
-            </DashText>
-          }
+          renderContent={mmrTooltipContent}
+          renderTrigger={mmrTooltipTrigger}
         />
         <SizableText size="$bodySmMedium" color={mmrColor}>
           {mmrPercent}%
@@ -117,6 +126,50 @@ function PerpAccountPanel() {
     }
     return { pnlFormatted, pnlColor, pnlPlusOrMinus };
   }, [accountSummary?.totalUnrealizedPnl]);
+  const portfolioValueTooltipContent = useMemo(
+    () =>
+      intl.formatMessage({
+        id: ETranslations.perp_portfolio_value_tooltip,
+      }),
+    [intl],
+  );
+  const portfolioValueTooltipTrigger = useMemo(
+    () => (
+      <DashText
+        size="$bodySm"
+        color="$textSubdued"
+        cursor="help"
+        dashThickness={1}
+      >
+        {intl.formatMessage({
+          id: ETranslations.perp_portfolio_value,
+        })}
+      </DashText>
+    ),
+    [intl],
+  );
+  const maintenanceMarginTooltipContent = useMemo(
+    () =>
+      intl.formatMessage({
+        id: ETranslations.perp_account_panel_account_maintenance_margin_tooltip,
+      }),
+    [intl],
+  );
+  const maintenanceMarginTooltipTrigger = useMemo(
+    () => (
+      <DashText
+        size="$bodySm"
+        color="$textSubdued"
+        cursor="help"
+        dashThickness={1}
+      >
+        {intl.formatMessage({
+          id: ETranslations.perp_account_panel_account_maintenance_margin,
+        })}
+      </DashText>
+    ),
+    [intl],
+  );
 
   const content = (
     <YStack flex={1} gap="$4" px="$2.5" pb="$4">
@@ -125,21 +178,8 @@ function PerpAccountPanel() {
         <XStack justifyContent="space-between">
           <Tooltip
             placement="top"
-            renderContent={intl.formatMessage({
-              id: ETranslations.perp_portfolio_value_tooltip,
-            })}
-            renderTrigger={
-              <DashText
-                size="$bodySm"
-                color="$textSubdued"
-                cursor="help"
-                dashThickness={1}
-              >
-                {intl.formatMessage({
-                  id: ETranslations.perp_portfolio_value,
-                })}
-              </DashText>
-            }
+            renderContent={portfolioValueTooltipContent}
+            renderTrigger={portfolioValueTooltipTrigger}
           />
           <PerpsAccountNumberValue
             value={computedValue?.accountValue ?? ''}
@@ -170,21 +210,8 @@ function PerpAccountPanel() {
         <XStack justifyContent="space-between">
           <Tooltip
             placement="top"
-            renderContent={intl.formatMessage({
-              id: ETranslations.perp_account_panel_account_maintenance_margin_tooltip,
-            })}
-            renderTrigger={
-              <DashText
-                size="$bodySm"
-                color="$textSubdued"
-                cursor="help"
-                dashThickness={1}
-              >
-                {intl.formatMessage({
-                  id: ETranslations.perp_account_panel_account_maintenance_margin,
-                })}
-              </DashText>
-            }
+            renderContent={maintenanceMarginTooltipContent}
+            renderTrigger={maintenanceMarginTooltipTrigger}
           />
           <PerpsAccountNumberValue
             value={accountSummary?.crossMaintenanceMarginUsed ?? ''}

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -87,6 +87,7 @@ import {
   type ITradeSide,
   getTradingSideTextColor,
 } from '../../../utils/styleUtils';
+import { getScaleOrderValidationErrorMessage } from '../../../utils/scaleOrderValidation';
 import { PerpsSlider } from '../../PerpsSlider';
 import { PerpsAccountNumberValue } from '../components/PerpsAccountNumberValue';
 import { PriceInput } from '../inputs/PriceInput';
@@ -799,11 +800,13 @@ function PerpTradingForm({
     const validation = validateScaleOrderLegs({ legs });
     if (!validation.isValid) {
       return {
-        text:
-          validation.errors[0] ??
-          intl.formatMessage({
+        text: getScaleOrderValidationErrorMessage({
+          intl,
+          validation,
+          fallback: intl.formatMessage({
             id: ETranslations.perp_invalid_scale_order__msg,
           }),
+        }),
         tone: 'error' as const,
       };
     }
@@ -1518,6 +1521,8 @@ function PerpTradingForm({
             dashColor="$textDisabled"
             dashThickness={0.5}
             tooltip={scaleAmountDistributionHelperText}
+            tooltipDisplayMode={isMobile ? 'popover' : 'tooltip'}
+            tooltipPlacement="bottom-start"
             tooltipTitle={intl.formatMessage({
               id: ETranslations.perp_scale_amount_distribution__title,
             })}
@@ -1986,6 +1991,8 @@ function PerpTradingForm({
           dashColor="$textDisabled"
           dashThickness={0.5}
           tooltip={twapHelperText}
+          tooltipDisplayMode={isMobile ? 'popover' : 'tooltip'}
+          tooltipPlacement="bottom-start"
           tooltipTitle={intl.formatMessage({
             id: ETranslations.perp_twap_duration__title,
           })}
@@ -2105,6 +2112,7 @@ function PerpTradingForm({
               />
               <Tooltip
                 placement="top"
+                triggerAsChild="except-style"
                 renderContent={intl.formatMessage({
                   id: ETranslations.perp_twap_randomize__desc,
                 })}
@@ -2235,6 +2243,7 @@ function PerpTradingForm({
               tooltip={intl.formatMessage({
                 id: ETranslations.perp_tp_sl_tooltip,
               })}
+              tooltipDisplayMode={isMobile ? 'popover' : 'tooltip'}
               tooltipTitle={intl.formatMessage({
                 id: ETranslations.perp_position_tp_sl,
               })}
@@ -2347,6 +2356,8 @@ function PerpTradingForm({
           color="$textSubdued"
           dashThickness={0.5}
           tooltip={spotMaxTradeTooltip}
+          tooltipDisplayMode={isMobile ? 'popover' : 'tooltip'}
+          tooltipPlacement="top"
           tooltipTitle={spotMaxTradeLabel}
         >
           {spotMaxTradeLabel}

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -83,11 +83,11 @@ import { useSpotMetaMaps } from '../../../hooks/useSpotMetaMaps';
 import { useTradingPrice } from '../../../hooks/useTradingPrice';
 import { PerpTestIDs } from '../../../testIDs';
 import { getPerpsFormLeverage } from '../../../utils/leverageDisplay';
+import { getScaleOrderValidationErrorMessage } from '../../../utils/scaleOrderValidation';
 import {
   type ITradeSide,
   getTradingSideTextColor,
 } from '../../../utils/styleUtils';
-import { getScaleOrderValidationErrorMessage } from '../../../utils/scaleOrderValidation';
 import { PerpsSlider } from '../../PerpsSlider';
 import { PerpsAccountNumberValue } from '../components/PerpsAccountNumberValue';
 import { PriceInput } from '../inputs/PriceInput';

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -14,6 +14,7 @@ import {
   Select,
   SizableText,
   Skeleton,
+  Stack,
   Tooltip,
   XStack,
   YStack,
@@ -1511,51 +1512,20 @@ function PerpTradingForm({
       const scaleSizeDistribution = formData.scaleSizeDistribution ?? 'fixed';
       return (
         <YStack gap="$1.5">
-          {isMobile ? (
-            <Popover
-              renderContent={() => (
-                <YStack px="$5" pt="$2" pb="$4">
-                  <SizableText size="$bodyMd">
-                    {scaleAmountDistributionHelperText}
-                  </SizableText>
-                </YStack>
-              )}
-              renderTrigger={
-                <DashText
-                  size="$bodySmMedium"
-                  color="$textSubdued"
-                  dashColor="$textDisabled"
-                  dashThickness={0.5}
-                >
-                  {intl.formatMessage({
-                    id: ETranslations.perp_scale_amount_distribution__title,
-                  })}
-                </DashText>
-              }
-              title={intl.formatMessage({
-                id: ETranslations.perp_scale_amount_distribution__title,
-              })}
-              placement="bottom-start"
-            />
-          ) : (
-            <Tooltip
-              renderContent={scaleAmountDistributionHelperText}
-              renderTrigger={
-                <DashText
-                  size="$bodySmMedium"
-                  color="$textSubdued"
-                  dashColor="$textDisabled"
-                  dashThickness={0.5}
-                  cursor="help"
-                >
-                  {intl.formatMessage({
-                    id: ETranslations.perp_scale_amount_distribution__title,
-                  })}
-                </DashText>
-              }
-              placement="bottom-start"
-            />
-          )}
+          <DashText
+            size="$bodySmMedium"
+            color="$textSubdued"
+            dashColor="$textDisabled"
+            dashThickness={0.5}
+            tooltip={scaleAmountDistributionHelperText}
+            tooltipTitle={intl.formatMessage({
+              id: ETranslations.perp_scale_amount_distribution__title,
+            })}
+          >
+            {intl.formatMessage({
+              id: ETranslations.perp_scale_amount_distribution__title,
+            })}
+          </DashText>
           <XStack gap="$4" alignItems="center" flexWrap="wrap">
             {scaleAmountDistributionOptions.map((option) => {
               const checked = scaleSizeDistribution === option.value;
@@ -2010,45 +1980,18 @@ function PerpTradingForm({
 
     return (
       <YStack gap="$3">
-        {isMobile ? (
-          <Popover
-            renderContent={() => (
-              <YStack px="$5" pt="$2" pb="$4">
-                <SizableText size="$bodyMd">{twapHelperText}</SizableText>
-              </YStack>
-            )}
-            renderTrigger={
-              <DashText
-                size="$bodySm"
-                color="$textSubdued"
-                dashColor="$textDisabled"
-                dashThickness={0.5}
-              >
-                {twapDurationLabel}
-              </DashText>
-            }
-            title={intl.formatMessage({
-              id: ETranslations.perp_twap_duration__title,
-            })}
-            placement="bottom-start"
-          />
-        ) : (
-          <Tooltip
-            renderContent={twapHelperText}
-            renderTrigger={
-              <DashText
-                size="$bodySm"
-                color="$textSubdued"
-                dashColor="$textDisabled"
-                dashThickness={0.5}
-                cursor="help"
-              >
-                {twapDurationLabel}
-              </DashText>
-            }
-            placement="bottom-start"
-          />
-        )}
+        <DashText
+          size="$bodySm"
+          color="$textSubdued"
+          dashColor="$textDisabled"
+          dashThickness={0.5}
+          tooltip={twapHelperText}
+          tooltipTitle={intl.formatMessage({
+            id: ETranslations.perp_twap_duration__title,
+          })}
+        >
+          {twapDurationLabel}
+        </DashText>
         <XStack gap="$2.5">
           {renderTwapDurationInput({
             field: 'hours',
@@ -2166,17 +2109,19 @@ function PerpTradingForm({
                   id: ETranslations.perp_twap_randomize__desc,
                 })}
                 renderTrigger={
-                  <DashText
-                    size={isMobile ? '$bodyMd' : '$bodyMdMedium'}
-                    color="$text"
-                    dashColor="$textDisabled"
-                    dashThickness={0.5}
-                    cursor="help"
-                  >
-                    {intl.formatMessage({
-                      id: ETranslations.perp_twap_randomize__title,
-                    })}
-                  </DashText>
+                  <Stack display="inline-flex" alignSelf="flex-start">
+                    <DashText
+                      size={isMobile ? '$bodyMd' : '$bodyMdMedium'}
+                      color="$text"
+                      dashColor="$textDisabled"
+                      dashThickness={0.5}
+                      cursor="help"
+                    >
+                      {intl.formatMessage({
+                        id: ETranslations.perp_twap_randomize__title,
+                      })}
+                    </DashText>
+                  </Stack>
                 }
               />
             </XStack>
@@ -2283,46 +2228,21 @@ function PerpTradingForm({
               {...(isMobile && { p: '$0' })}
             />
 
-            {isMobile ? (
-              <Popover
-                renderContent={() => (
-                  <YStack px="$5" pt="$2" pb="$4">
-                    <SizableText size="$bodyMd">
-                      {intl.formatMessage({
-                        id: ETranslations.perp_tp_sl_tooltip,
-                      })}
-                    </SizableText>
-                  </YStack>
-                )}
-                renderTrigger={
-                  <DashText
-                    size="$bodySm"
-                    dashColor="$textSubdued"
-                    dashThickness={0.5}
-                  >
-                    {intl.formatMessage({
-                      id: ETranslations.perp_position_tp_sl,
-                    })}
-                  </DashText>
-                }
-                title={intl.formatMessage({
-                  id: ETranslations.perp_position_tp_sl,
-                })}
-              />
-            ) : (
-              <Tooltip
-                renderContent={intl.formatMessage({
-                  id: ETranslations.perp_tp_sl_tooltip,
-                })}
-                renderTrigger={
-                  <DashText size="$bodyMd" dashThickness={0.5} cursor="help">
-                    {intl.formatMessage({
-                      id: ETranslations.perp_position_tp_sl,
-                    })}
-                  </DashText>
-                }
-              />
-            )}
+            <DashText
+              size={isMobile ? '$bodySm' : '$bodyMd'}
+              dashColor="$textSubdued"
+              dashThickness={0.5}
+              tooltip={intl.formatMessage({
+                id: ETranslations.perp_tp_sl_tooltip,
+              })}
+              tooltipTitle={intl.formatMessage({
+                id: ETranslations.perp_position_tp_sl,
+              })}
+            >
+              {intl.formatMessage({
+                id: ETranslations.perp_position_tp_sl,
+              })}
+            </DashText>
           </XStack>
 
           {standardLimitTifSelector}
@@ -2422,38 +2342,15 @@ function PerpTradingForm({
       </XStack>
 
       <XStack justifyContent="space-between" alignItems="center" gap="$3">
-        {isMobile ? (
-          <Popover
-            title={spotMaxTradeLabel}
-            renderTrigger={
-              <DashText size="$bodySm" color="$textSubdued" dashThickness={0.5}>
-                {spotMaxTradeLabel}
-              </DashText>
-            }
-            renderContent={() => (
-              <YStack px="$5" pt="$2" pb="$4">
-                <SizableText size="$bodyMd">{spotMaxTradeTooltip}</SizableText>
-              </YStack>
-            )}
-          />
-        ) : (
-          <Tooltip
-            placement="top"
-            renderTrigger={
-              <DashText
-                size="$bodySm"
-                color="$textSubdued"
-                dashThickness={0.5}
-                cursor="help"
-              >
-                {spotMaxTradeLabel}
-              </DashText>
-            }
-            renderContent={
-              <SizableText size="$bodySm">{spotMaxTradeTooltip}</SizableText>
-            }
-          />
-        )}
+        <DashText
+          size="$bodySm"
+          color="$textSubdued"
+          dashThickness={0.5}
+          tooltip={spotMaxTradeTooltip}
+          tooltipTitle={spotMaxTradeLabel}
+        >
+          {spotMaxTradeLabel}
+        </DashText>
         <SizableText size="$bodySmMedium">{spotMaxTradeDisplay}</SizableText>
       </XStack>
     </>

--- a/packages/kit/src/views/Perp/hooks/useOrderConfirm.ts
+++ b/packages/kit/src/views/Perp/hooks/useOrderConfirm.ts
@@ -35,6 +35,7 @@ import {
   type IPerpsMarketDataFreshness,
   shouldBlockPerpsTradingForMarketData,
 } from '../utils/perpsMarketDataFreshness';
+import { getScaleOrderValidationErrorMessage } from '../utils/scaleOrderValidation';
 
 import { useOrderPrice } from './useOrderPrice';
 import { usePerpsMarketDataFreshness } from './usePerpsMarketDataFreshness';
@@ -236,7 +237,11 @@ function useOrderConfirmWithMarketDataFreshness({
         if (!scaleValidation.isValid) {
           Toast.error({
             title: 'Order Failed',
-            message: scaleValidation.errors[0] ?? 'Invalid scale order',
+            message: getScaleOrderValidationErrorMessage({
+              intl,
+              validation: scaleValidation,
+              fallback: 'Invalid scale order',
+            }),
           });
           return;
         }

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -289,7 +289,6 @@ function MobilePerpMarket() {
 
   const onPressTokenSelector = useCallback(() => {
     defaultLogger.perp.tokenSelector.perpTokenSelectorOpen({
-      source: 'mobileMarketHeader',
       currentToken: activeTradeInstrument.coin,
       tradeMode: mode === 'spot' ? 'spot' : 'perp',
     });

--- a/packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.test.ts
+++ b/packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.test.ts
@@ -1,4 +1,5 @@
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { EHyperLiquidAbstractionMode } from '@onekeyhq/shared/types/hyperliquid';
 
 import {
   getPerpsOrderPanelEnableTradingModeByAccount,
@@ -23,6 +24,7 @@ describe('getPerpsOrderPanelEnableTradingModeByAccount', () => {
     ).toEqual({
       canAutoEnableInOrderPanel: true,
       requiresEnableTradingDialogInOrderPanel: false,
+      requiresExplicitEnableTrading: false,
     });
   });
 
@@ -35,10 +37,11 @@ describe('getPerpsOrderPanelEnableTradingModeByAccount', () => {
     ).toEqual({
       canAutoEnableInOrderPanel: false,
       requiresEnableTradingDialogInOrderPanel: true,
+      requiresExplicitEnableTrading: true,
     });
   });
 
-  it('keeps cached external accounts on the explicit fallback path', () => {
+  it('routes cached external accounts through explicit enable-trading confirmation', () => {
     expect(
       getPerpsOrderPanelEnableTradingModeByAccount({
         accountId: 'external--60--injected--wallet',
@@ -47,6 +50,7 @@ describe('getPerpsOrderPanelEnableTradingModeByAccount', () => {
     ).toEqual({
       canAutoEnableInOrderPanel: false,
       requiresEnableTradingDialogInOrderPanel: false,
+      requiresExplicitEnableTrading: true,
     });
   });
 });
@@ -75,12 +79,13 @@ describe('shouldShowPerpsOrderPanelTradingButtons', () => {
         enableTradingMode: {
           canAutoEnableInOrderPanel: false,
           requiresEnableTradingDialogInOrderPanel: true,
+          requiresExplicitEnableTrading: true,
         },
       }),
     ).toBe(true);
   });
 
-  it('keeps non-auto-enable accounts on the fallback CTA path', () => {
+  it('shows trading buttons for explicit-enable non-software accounts', () => {
     expect(
       shouldShowPerpsOrderPanelTradingButtons({
         canShowCachedTradingButtons: false,
@@ -103,9 +108,10 @@ describe('shouldShowPerpsOrderPanelTradingButtons', () => {
         enableTradingMode: {
           canAutoEnableInOrderPanel: false,
           requiresEnableTradingDialogInOrderPanel: false,
+          requiresExplicitEnableTrading: true,
         },
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('keeps the fallback button for unsupported or address-creation states', () => {
@@ -124,6 +130,7 @@ describe('shouldShowPerpsOrderPanelTradingButtons', () => {
         enableTradingMode: {
           canAutoEnableInOrderPanel: true,
           requiresEnableTradingDialogInOrderPanel: false,
+          requiresExplicitEnableTrading: false,
         },
       }),
     ).toBe(false);
@@ -143,6 +150,7 @@ describe('shouldShowPerpsOrderPanelTradingButtons', () => {
         enableTradingMode: {
           canAutoEnableInOrderPanel: true,
           requiresEnableTradingDialogInOrderPanel: false,
+          requiresExplicitEnableTrading: false,
         },
       }),
     ).toBe(false);
@@ -239,6 +247,81 @@ describe('getPerpsOrderPanelEnableTradingSteps', () => {
       {
         key: 'agent',
         labelId: ETranslations.global_sign,
+        requiresSignature: true,
+      },
+    ]);
+    expect(getPerpsOrderPanelEnableTradingSignatureCount(steps)).toBe(2);
+  });
+
+  it('skips abstraction step when live abstraction mode is already ready', () => {
+    const steps = getPerpsOrderPanelEnableTradingSteps(
+      {
+        accountAddress: '0xabc',
+        accountNotSupport: false,
+        canCreateAddress: false,
+        canTrade: false,
+        details: {
+          activatedOk: true,
+          agentOk: false,
+          builderFeeOk: true,
+          referralCodeOk: true,
+          internalRebateBoundOk: true,
+          abstractionOk: false,
+        },
+      },
+      {
+        abstractionMode: {
+          accountAddress: '0xabc',
+          mode: EHyperLiquidAbstractionMode.UNIFIED_ACCOUNT,
+          source: 'live',
+        },
+      },
+    );
+
+    expect(steps).toEqual([
+      {
+        key: 'agent',
+        labelId: ETranslations.global_sign,
+        requiresSignature: true,
+      },
+    ]);
+    expect(getPerpsOrderPanelEnableTradingSignatureCount(steps)).toBe(1);
+  });
+
+  it('keeps abstraction step when only cached abstraction mode is available', () => {
+    const steps = getPerpsOrderPanelEnableTradingSteps(
+      {
+        accountAddress: '0xabc',
+        accountNotSupport: false,
+        canCreateAddress: false,
+        canTrade: false,
+        details: {
+          activatedOk: true,
+          agentOk: false,
+          builderFeeOk: true,
+          referralCodeOk: true,
+          internalRebateBoundOk: true,
+          abstractionOk: false,
+        },
+      },
+      {
+        abstractionMode: {
+          accountAddress: '0xabc',
+          mode: EHyperLiquidAbstractionMode.UNIFIED_ACCOUNT,
+          source: 'cache',
+        },
+      },
+    );
+
+    expect(steps).toEqual([
+      {
+        key: 'agent',
+        labelId: ETranslations.global_sign,
+        requiresSignature: true,
+      },
+      {
+        key: 'abstraction',
+        labelId: ETranslations.perp_trade_button_enable_trading,
         requiresSignature: true,
       },
     ]);

--- a/packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.ts
+++ b/packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.ts
@@ -1,5 +1,9 @@
-import type { IPerpsActiveAccountStatusAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import type {
+  IPerpsAbstractionModeSource,
+  IPerpsActiveAccountStatusAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { EHyperLiquidAbstractionMode } from '@onekeyhq/shared/types/hyperliquid';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 
 export type IPerpsOrderPanelEnableTradingStepKey =
@@ -18,7 +22,37 @@ export type IPerpsOrderPanelEnableTradingStep = {
 export type IPerpsOrderPanelEnableTradingMode = {
   canAutoEnableInOrderPanel: boolean;
   requiresEnableTradingDialogInOrderPanel: boolean;
+  requiresExplicitEnableTrading: boolean;
 };
+
+type IPerpsEnableTradingAbstractionMode = {
+  accountAddress?: string;
+  mode?: EHyperLiquidAbstractionMode;
+  source?: IPerpsAbstractionModeSource;
+};
+
+function resolveAbstractionOk({
+  status,
+  abstractionMode,
+}: {
+  status: IPerpsActiveAccountStatusAtom;
+  abstractionMode?: IPerpsEnableTradingAbstractionMode;
+}) {
+  const liveModeMatchesAccount =
+    abstractionMode &&
+    abstractionMode.source !== 'cache' &&
+    abstractionMode.accountAddress?.toLowerCase() ===
+      status.accountAddress?.toLowerCase();
+
+  if (liveModeMatchesAccount) {
+    return (
+      abstractionMode.mode === EHyperLiquidAbstractionMode.UNIFIED_ACCOUNT ||
+      abstractionMode.mode === EHyperLiquidAbstractionMode.PORTFOLIO_MARGIN
+    );
+  }
+
+  return status.details?.abstractionOk === true;
+}
 
 export function getPerpsOrderPanelEnableTradingModeByAccount({
   accountId,
@@ -32,6 +66,7 @@ export function getPerpsOrderPanelEnableTradingModeByAccount({
     return {
       canAutoEnableInOrderPanel: false,
       requiresEnableTradingDialogInOrderPanel: false,
+      requiresExplicitEnableTrading: true,
     };
   }
 
@@ -45,6 +80,7 @@ export function getPerpsOrderPanelEnableTradingModeByAccount({
   return {
     canAutoEnableInOrderPanel: isSoftwareAccount,
     requiresEnableTradingDialogInOrderPanel: isHardwareAccount,
+    requiresExplicitEnableTrading: !isSoftwareAccount,
   };
 }
 
@@ -73,7 +109,7 @@ export function shouldShowPerpsOrderPanelTradingButtons({
     !accountStatus.canCreateAddress &&
     (Boolean(accountStatus.canTrade) ||
       enableTradingMode.canAutoEnableInOrderPanel ||
-      enableTradingMode.requiresEnableTradingDialogInOrderPanel)
+      enableTradingMode.requiresExplicitEnableTrading)
   );
 }
 
@@ -89,6 +125,11 @@ export function shouldReservePerpsMobileEnableTradingLayout({
 
 export function getPerpsOrderPanelEnableTradingSteps(
   status: IPerpsActiveAccountStatusAtom,
+  {
+    abstractionMode,
+  }: {
+    abstractionMode?: IPerpsEnableTradingAbstractionMode;
+  } = {},
 ): IPerpsOrderPanelEnableTradingStep[] {
   const { details } = status;
 
@@ -128,7 +169,13 @@ export function getPerpsOrderPanelEnableTradingSteps(
       requiresSignature: true,
     });
   }
-  if (!details || details.abstractionOk !== true) {
+  if (
+    !details ||
+    !resolveAbstractionOk({
+      status,
+      abstractionMode,
+    })
+  ) {
     steps.push({
       key: 'abstraction',
       labelId: ETranslations.perp_trade_button_enable_trading,

--- a/packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.ts
+++ b/packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.ts
@@ -3,8 +3,8 @@ import type {
   IPerpsActiveAccountStatusAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { EHyperLiquidAbstractionMode } from '@onekeyhq/shared/types/hyperliquid';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import { EHyperLiquidAbstractionMode } from '@onekeyhq/shared/types/hyperliquid';
 
 export type IPerpsOrderPanelEnableTradingStepKey =
   | 'deposit'

--- a/packages/kit/src/views/Perp/utils/scaleOrderValidation.test.ts
+++ b/packages/kit/src/views/Perp/utils/scaleOrderValidation.test.ts
@@ -1,0 +1,70 @@
+import { createIntl, createIntlCache } from 'react-intl';
+
+import { formatScaleOrderValidationError } from './scaleOrderValidation';
+
+const cache = createIntlCache();
+
+describe('formatScaleOrderValidationError', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  const intl = createIntl(
+    {
+      locale: 'en-US',
+      messages: {
+        perp_scale_order_size_too_small__msg: 'Order size is too small',
+        perp_scale_order_min_notional__msg:
+          'Each scale order must be at least {amount}. Reduce order count or increase size.',
+      } as Record<string, string>,
+    },
+    cache,
+  );
+  const zhIntl = createIntl(
+    {
+      locale: 'zh-CN',
+      messages: {
+        perp_scale_order_size_too_small__msg: '订单数量过小',
+      } as Record<string, string>,
+    },
+    cache,
+  );
+
+  it('formats scale size too small errors', () => {
+    expect(
+      formatScaleOrderValidationError(
+        intl,
+        { code: 'sizeTooSmall', legIndex: 0 },
+        'Leg 1: size is too small',
+      ),
+    ).toBe('Order size is too small');
+  });
+
+  it('formats scale min notional errors', () => {
+    expect(
+      formatScaleOrderValidationError(
+        intl,
+        { code: 'minNotionalTooSmall', legIndex: 0, minNotional: '10' },
+        'Leg 1: notional must be at least $10',
+      ),
+    ).toBe(
+      'Each scale order must be at least $10. Reduce order count or increase size.',
+    );
+  });
+
+  it('falls back to zh message when lokalise pull is unavailable locally', () => {
+    expect(
+      formatScaleOrderValidationError(
+        zhIntl,
+        { code: 'minNotionalTooSmall', legIndex: 0, minNotional: '10' },
+        'Leg 1: notional must be at least $10',
+      ),
+    ).toBe('每笔分段委托金额至少为 $10。请减少委托笔数或增加数量。');
+  });
+});

--- a/packages/kit/src/views/Perp/utils/scaleOrderValidation.ts
+++ b/packages/kit/src/views/Perp/utils/scaleOrderValidation.ts
@@ -1,0 +1,37 @@
+import type { IntlShape } from 'react-intl';
+
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type { IScaleOrderValidationResult } from '@onekeyhq/shared/types/hyperliquid/types';
+
+const SCALE_ORDER_SIZE_TOO_SMALL_PATTERN = /^Leg \d+: size is too small$/;
+
+export function formatScaleOrderValidationError(
+  intl: IntlShape,
+  error?: string,
+) {
+  if (!error) {
+    return undefined;
+  }
+
+  if (SCALE_ORDER_SIZE_TOO_SMALL_PATTERN.test(error)) {
+    return intl.formatMessage({
+      id: ETranslations.perp_scale_order_size_too_small__msg,
+    });
+  }
+
+  return error;
+}
+
+export function getScaleOrderValidationErrorMessage({
+  intl,
+  validation,
+  fallback,
+}: {
+  intl: IntlShape;
+  validation: IScaleOrderValidationResult;
+  fallback: string;
+}) {
+  return (
+    formatScaleOrderValidationError(intl, validation.errors[0]) ?? fallback
+  );
+}

--- a/packages/kit/src/views/Perp/utils/scaleOrderValidation.ts
+++ b/packages/kit/src/views/Perp/utils/scaleOrderValidation.ts
@@ -1,24 +1,41 @@
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import type { IScaleOrderValidationResult } from '@onekeyhq/shared/types/hyperliquid/types';
+import type {
+  IScaleOrderValidationIssue,
+  IScaleOrderValidationResult,
+} from '@onekeyhq/shared/types/hyperliquid/types';
 import type { IntlShape } from 'react-intl';
 
-const SCALE_ORDER_SIZE_TOO_SMALL_PATTERN = /^Leg \d+: size is too small$/;
+const SCALE_ORDER_MIN_NOTIONAL_I18N_KEY =
+  'perp_scale_order_min_notional__msg' as ETranslations;
+
+function getScaleOrderMinNotionalDefaultMessage(locale?: string) {
+  if (locale?.toLowerCase().startsWith('zh')) {
+    return '每笔分段委托金额至少为 {amount}。请减少委托笔数或增加数量。';
+  }
+  return 'Each scale order must be at least {amount}. Reduce order count or increase size.';
+}
 
 export function formatScaleOrderValidationError(
   intl: IntlShape,
+  issue?: IScaleOrderValidationIssue,
   error?: string,
 ) {
-  if (!error) {
-    return undefined;
+  switch (issue?.code) {
+    case 'sizeTooSmall':
+      return intl.formatMessage({
+        id: ETranslations.perp_scale_order_size_too_small__msg,
+      });
+    case 'minNotionalTooSmall':
+      return intl.formatMessage(
+        {
+          id: SCALE_ORDER_MIN_NOTIONAL_I18N_KEY,
+          defaultMessage: getScaleOrderMinNotionalDefaultMessage(intl.locale),
+        },
+        { amount: `$${issue.minNotional ?? '10'}` },
+      );
+    default:
+      return error;
   }
-
-  if (SCALE_ORDER_SIZE_TOO_SMALL_PATTERN.test(error)) {
-    return intl.formatMessage({
-      id: ETranslations.perp_scale_order_size_too_small__msg,
-    });
-  }
-
-  return error;
 }
 
 export function getScaleOrderValidationErrorMessage({
@@ -31,6 +48,10 @@ export function getScaleOrderValidationErrorMessage({
   fallback: string;
 }) {
   return (
-    formatScaleOrderValidationError(intl, validation.errors[0]) ?? fallback
+    formatScaleOrderValidationError(
+      intl,
+      validation.issues[0],
+      validation.errors[0],
+    ) ?? fallback
   );
 }

--- a/packages/kit/src/views/Perp/utils/scaleOrderValidation.ts
+++ b/packages/kit/src/views/Perp/utils/scaleOrderValidation.ts
@@ -3,6 +3,7 @@ import type {
   IScaleOrderValidationIssue,
   IScaleOrderValidationResult,
 } from '@onekeyhq/shared/types/hyperliquid/types';
+
 import type { IntlShape } from 'react-intl';
 
 const SCALE_ORDER_MIN_NOTIONAL_I18N_KEY =

--- a/packages/kit/src/views/Perp/utils/scaleOrderValidation.ts
+++ b/packages/kit/src/views/Perp/utils/scaleOrderValidation.ts
@@ -1,7 +1,6 @@
-import type { IntlShape } from 'react-intl';
-
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IScaleOrderValidationResult } from '@onekeyhq/shared/types/hyperliquid/types';
+import type { IntlShape } from 'react-intl';
 
 const SCALE_ORDER_SIZE_TOO_SMALL_PATTERN = /^Leg \d+: size is too small$/;
 

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -3134,6 +3134,7 @@ export enum ETranslations {
   perp_enable_trading_steps_agent_removal__desc = 'perp_enable_trading_steps_agent_removal__desc',
   perp_enable_trading_steps_builder_fee__desc = 'perp_enable_trading_steps_builder_fee__desc',
   perp_enable_trading_steps_summary__desc = 'perp_enable_trading_steps_summary__desc',
+  perp_enable_trading_steps_summary_v2__desc = 'perp_enable_trading_steps_summary_v2__desc',
   perp_enable_trading_steps_wallet_confirmation__desc = 'perp_enable_trading_steps_wallet_confirmation__desc',
   perp_enable_trading_steps_wallet_confirmations__desc = 'perp_enable_trading_steps_wallet_confirmations__desc',
   perp_executed_size__title = 'perp_executed_size__title',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "替换此前的交易代理",
   "perp_enable_trading_steps_builder_fee__desc": "确认 OneKey 服务访问",
   "perp_enable_trading_steps_summary__desc": "开启交易即可使用即时、免 Gas 的 Perps 订单。需要",
+  "perp_enable_trading_steps_summary_v2__desc": "启用交易即可即时下单，无需 Gas。需要 <underline>{count}</underline> 次钱包确认。",
   "perp_enable_trading_steps_wallet_confirmation__desc": "次钱包确认。",
   "perp_enable_trading_steps_wallet_confirmations__desc": "次钱包确认。",
   "perp_executed_size__title": "已成交数量",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -3129,6 +3129,7 @@
   "perp_enable_trading_steps_agent_removal__desc": "Replace previous trading agent",
   "perp_enable_trading_steps_builder_fee__desc": "Confirm OneKey service access",
   "perp_enable_trading_steps_summary__desc": "Enable trading for instant, gas-free Perps orders. Requires",
+  "perp_enable_trading_steps_summary_v2__desc": "Enable trading for instant, gas-free Perps orders. Requires <underline>{count}</underline> {count, plural, one {wallet confirmation.} other {wallet confirmations.}}",
   "perp_enable_trading_steps_wallet_confirmation__desc": "wallet confirmation.",
   "perp_enable_trading_steps_wallet_confirmations__desc": "wallet confirmations.",
   "perp_executed_size__title": "Executed Size",

--- a/packages/shared/src/logger/scopes/perp/scenes/tokenSelector.ts
+++ b/packages/shared/src/logger/scopes/perp/scenes/tokenSelector.ts
@@ -5,7 +5,6 @@ export class PerpTokenSelectorScene extends BaseScene {
   @LogToServer()
   @LogToLocal({ level: 'info' })
   public perpTokenSelectorOpen(params: {
-    source: 'desktop' | 'mobileTicker' | 'mobileMarketHeader';
     currentToken: string;
     tradeMode: 'perp' | 'spot';
   }) {

--- a/packages/shared/src/utils/hyperliquidScaleOrderUtils.test.ts
+++ b/packages/shared/src/utils/hyperliquidScaleOrderUtils.test.ts
@@ -186,6 +186,11 @@ describe('hyperliquidScaleOrderUtils', () => {
     expect(validateScaleOrderLegs({ legs: tinyLegs }).errors[0]).toBe(
       'Leg 1: notional must be at least $10',
     );
+    expect(validateScaleOrderLegs({ legs: tinyLegs }).issues[0]).toEqual({
+      code: 'minNotionalTooSmall',
+      legIndex: 0,
+      minNotional: '10',
+    });
 
     const collapsedPriceLegs = buildScaleOrderLegs({
       totalSize: '100',
@@ -198,6 +203,7 @@ describe('hyperliquidScaleOrderUtils', () => {
     expect(validateScaleOrderLegs({ legs: collapsedPriceLegs })).toEqual({
       isValid: false,
       errors: ['Price range is too tight for this market precision'],
+      issues: [{ code: 'priceRangeTooTight', legIndex: 1 }],
     });
   });
 
@@ -209,6 +215,7 @@ describe('hyperliquidScaleOrderUtils', () => {
     ).toEqual({
       isValid: false,
       errors: ['Leg 1: invalid price'],
+      issues: [{ code: 'invalidPrice', legIndex: 0 }],
     });
     expect(
       validateScaleOrderLegs({
@@ -217,6 +224,7 @@ describe('hyperliquidScaleOrderUtils', () => {
     ).toEqual({
       isValid: false,
       errors: ['Leg 1: size is too small'],
+      issues: [{ code: 'sizeTooSmall', legIndex: 0 }],
     });
   });
 

--- a/packages/shared/src/utils/hyperliquidScaleOrderUtils.ts
+++ b/packages/shared/src/utils/hyperliquidScaleOrderUtils.ts
@@ -9,6 +9,7 @@ import type {
   IScaleOrderBuildParams,
   IScaleOrderLeg,
   IScaleOrderSizeDistribution,
+  IScaleOrderValidationIssue,
   IScaleOrderValidationResult,
 } from '@onekeyhq/shared/types/hyperliquid/types';
 
@@ -161,10 +162,15 @@ export function validateScaleOrderLegs({
   minNotional?: string;
 }): IScaleOrderValidationResult {
   if (legs.length === 0) {
-    return { isValid: false, errors: ['Invalid scale order parameters'] };
+    return {
+      isValid: false,
+      errors: ['Invalid scale order parameters'],
+      issues: [{ code: 'invalidParams' }],
+    };
   }
 
   const errors: string[] = [];
+  const issues: IScaleOrderValidationIssue[] = [];
   const priceSet = new Set<string>();
   const minNotionalBN = new BigNumber(minNotional);
 
@@ -173,12 +179,24 @@ export function validateScaleOrderLegs({
     const sizeBN = new BigNumber(leg.size);
     if (!priceBN.isFinite() || priceBN.lte(0)) {
       errors.push(`Leg ${leg.index + 1}: invalid price`);
+      issues.push({
+        code: 'invalidPrice',
+        legIndex: leg.index,
+      });
     }
     if (!sizeBN.isFinite() || sizeBN.lte(0)) {
       errors.push(`Leg ${leg.index + 1}: size is too small`);
+      issues.push({
+        code: 'sizeTooSmall',
+        legIndex: leg.index,
+      });
     }
     if (priceSet.has(leg.price)) {
       errors.push('Price range is too tight for this market precision');
+      issues.push({
+        code: 'priceRangeTooTight',
+        legIndex: leg.index,
+      });
     }
     priceSet.add(leg.price);
     if (
@@ -189,12 +207,27 @@ export function validateScaleOrderLegs({
       errors.push(
         `Leg ${leg.index + 1}: notional must be at least $${minNotional}`,
       );
+      issues.push({
+        code: 'minNotionalTooSmall',
+        legIndex: leg.index,
+        minNotional,
+      });
     }
   });
 
   return {
     isValid: errors.length === 0,
     errors: [...new Set(errors)],
+    issues: issues.filter(
+      (issue, index, array) =>
+        array.findIndex(
+          (item) =>
+            item.code === issue.code &&
+            (item.code === 'priceRangeTooTight' ||
+              item.legIndex === issue.legIndex) &&
+            item.minNotional === issue.minNotional,
+        ) === index,
+    ),
   };
 }
 

--- a/packages/shared/src/utils/hyperliquidScaleOrderUtils.ts
+++ b/packages/shared/src/utils/hyperliquidScaleOrderUtils.ts
@@ -1,8 +1,6 @@
 import BigNumber from 'bignumber.js';
 
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
-import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import {
   formatHlPrice,
   formatHlSize,
@@ -177,11 +175,7 @@ export function validateScaleOrderLegs({
       errors.push(`Leg ${leg.index + 1}: invalid price`);
     }
     if (!sizeBN.isFinite() || sizeBN.lte(0)) {
-      errors.push(
-        appLocale.intl.formatMessage?.({
-          id: ETranslations.perp_scale_order_size_too_small__msg,
-        }) ?? 'Order size is too small',
-      );
+      errors.push(`Leg ${leg.index + 1}: size is too small`);
     }
     if (priceSet.has(leg.price)) {
       errors.push('Price range is too tight for this market precision');

--- a/packages/shared/src/utils/hyperliquidScaleOrderUtils.ts
+++ b/packages/shared/src/utils/hyperliquidScaleOrderUtils.ts
@@ -1,6 +1,8 @@
 import BigNumber from 'bignumber.js';
 
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import {
   formatHlPrice,
   formatHlSize,
@@ -175,7 +177,11 @@ export function validateScaleOrderLegs({
       errors.push(`Leg ${leg.index + 1}: invalid price`);
     }
     if (!sizeBN.isFinite() || sizeBN.lte(0)) {
-      errors.push(`Leg ${leg.index + 1}: size is too small`);
+      errors.push(
+        appLocale.intl.formatMessage?.({
+          id: ETranslations.perp_scale_order_size_too_small__msg,
+        }) ?? 'Order size is too small',
+      );
     }
     if (priceSet.has(leg.price)) {
       errors.push('Price range is too tight for this market precision');

--- a/packages/shared/types/hyperliquid/types.ts
+++ b/packages/shared/types/hyperliquid/types.ts
@@ -214,9 +214,23 @@ export interface IScaleOrderLeg {
   size: string;
 }
 
+export type IScaleOrderValidationIssueCode =
+  | 'invalidParams'
+  | 'invalidPrice'
+  | 'sizeTooSmall'
+  | 'priceRangeTooTight'
+  | 'minNotionalTooSmall';
+
+export interface IScaleOrderValidationIssue {
+  code: IScaleOrderValidationIssueCode;
+  legIndex?: number;
+  minNotional?: string;
+}
+
 export interface IScaleOrderValidationResult {
   isValid: boolean;
   errors: string[];
+  issues: IScaleOrderValidationIssue[];
 }
 
 export interface IPlaceScaleOrderParams {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55591](https://onekeyhq.atlassian.net/browse/OK-55591) [OK-55592](https://onekeyhq.atlassian.net/browse/OK-55592)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- improve Perps tooltip trigger hit areas on desktop so hover only follows the real text node
- unify several Perps text hints to use `DashText` built-in tooltip/popover flow for more consistent mobile behavior
- remove `source` from `perpTokenSelectorOpen` tracking params

## Intent & Context
This PR wraps up the Perps enable-trading / tooltip polish work and addresses two user-reported issues in the Perps trading panel.

## Root Cause
- `OK-55591`: desktop tooltips were mounted through a trigger wrapper that could enlarge the hover hit area beyond the actual dashed text, so moving the cursor into adjacent blank space could still open the tooltip.
- `OK-55592`: `perpTokenSelectorOpen` still reported a `source` field that should no longer be sent.
- On mobile, several dashed-text hints were not consistently using the shared `DashText` tooltip/popover path, which made behavior differ by callsite.

## Design Decisions
- Set Tamagui tooltip trigger to `asChild="except-style"` so the hover/click hitbox follows the real trigger node.
- Prefer `DashText.tooltip` / `tooltipTitle` for simple text hints instead of duplicating `isMobile ? Popover : Tooltip` logic in each Perps form section.
- Keep the analytics schema change minimal by only removing `source` and leaving the remaining event payload stable.

## Changes Detail
- update shared tooltip trigger behavior in `packages/components/src/actions/Tooltip/index.tsx`
- remove `source` from Perps token selector analytics schema and callsites
- refactor Perps trading form / button text hints to use shared `DashText` tooltip behavior
- keep desktop-only Perps account/button tooltips stable via memoized trigger/content where needed

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web
- **Risk Areas**: shared tooltip trigger behavior, Perps trading panel hint interactions, Perps analytics payload shape

## Test plan
- [ ] On desktop Perps, hover dashed hint text and verify adjacent blank area no longer opens tooltip
- [ ] On mobile Perps, tap dashed hint text for TWAP/TP-SL/cost/liq-price related labels and verify popover content opens
- [ ] Open Perps token selector and confirm `perpTokenSelectorOpen` no longer sends `source`
- [ ] Sanity check enable-trading dialog / deposit shortcut flow still behaves as expected

[OK-55591]: https://onekeyhq.atlassian.net/browse/OK-55591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55592]: https://onekeyhq.atlassian.net/browse/OK-55592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ