### PR TITLE
fix: clamp import progress to prevent exceeding 100%

### DIFF
--- a/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
+++ b/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
@@ -2589,11 +2589,15 @@ class ServicePrimeTransfer extends ServiceBase {
       | IPrimeTransferAtomData['importProgress']
       | undefined;
     await primeTransferAtom.set((prev) => {
-      nextImportProgress = prev?.importProgress
+      const prevProgress = prev?.importProgress;
+      nextImportProgress = prevProgress
         ? {
-            ...prev?.importProgress,
+            ...prevProgress,
             isImporting: true,
-            current: (prev?.importProgress?.current || 0) + 1,
+            current: Math.min(
+              (prevProgress.current || 0) + 1,
+              prevProgress.total,
+            ),
           }
         : undefined;
       return {

--- a/packages/shared/src/utils/primeTransferImportProgressUtils.test.ts
+++ b/packages/shared/src/utils/primeTransferImportProgressUtils.test.ts
@@ -34,13 +34,20 @@ describe('primeTransferImportProgressUtils', () => {
       }),
     ).toBe(100);
     expect(getPrimeTransferImportProgressPercent(undefined)).toBeUndefined();
+    expect(
+      getPrimeTransferImportProgressPercent({
+        current: 120,
+        total: 100,
+        isImporting: true,
+      }),
+    ).toBe(100);
   });
 
   test('builds the trace progress range from the shared percentage', () => {
     expect(getPrimeTransferImportProgressRange(undefined)).toBeUndefined();
     expect(getPrimeTransferImportProgressRange(79)).toBe('70-80');
     expect(getPrimeTransferImportProgressRange(80)).toBe('80-90');
-    expect(getPrimeTransferImportProgressRange(90)).toBe('80-90');
+    expect(getPrimeTransferImportProgressRange(90)).toBe('90-100');
     expect(getPrimeTransferImportProgressRange(91)).toBe('90-100');
     expect(getPrimeTransferImportProgressRange(100)).toBe('100');
   });

--- a/packages/shared/src/utils/primeTransferImportProgressUtils.ts
+++ b/packages/shared/src/utils/primeTransferImportProgressUtils.ts
@@ -11,7 +11,7 @@ function getPrimeTransferImportProgressPercent(
     return undefined;
   }
   if (progress.total > 0) {
-    return Math.ceil((progress.current / progress.total) * 100);
+    return Math.min(100, Math.ceil((progress.current / progress.total) * 100));
   }
   return progress.isImporting ? 0 : 100;
 }
@@ -20,7 +20,7 @@ function getPrimeTransferImportProgressRange(percentage: number | undefined) {
   if (percentage === undefined) {
     return undefined;
   }
-  if (percentage >= 80 && percentage <= 90) {
+  if (percentage >= 80 && percentage < 90) {
     return '80-90';
   }
   if (percentage >= 100) {


### PR DESCRIPTION
## Summary
- Clamp `getPrimeTransferImportProgressPercent` return value to max 100 via `Math.min`
- Fix asymmetric range boundary: change `percentage <= 90` to `percentage < 90` so 90 falls into `'90-100'` consistently with other ranges
- Clamp `current` to `total` in `updateImportProgress` — HD batch creation emits events per-network-per-account while `initImportProgress` counts per-account, causing `current > total`
- Add test case for `current > total` scenario

## Test plan
- [x] `yarn test packages/shared/src/utils/primeTransferImportProgressUtils.test.ts` — 2/2 passed

https://claude.ai/code/session_019kzb2egCErG3GB1tzDsJLq

---
_Generated by [Claude Code](https://claude.ai/code/session_019kzb2egCErG3GB1tzDsJLq)_