### PR TITLE
fix: add swap kline fallback (OK-55523)

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
@@ -28,6 +28,7 @@ import {
   useTradingViewMessageHandler,
 } from './messageHandlers';
 
+import type { ITradingViewV2KLineDataFallback } from './hooks/useTradingViewV2';
 import type { IMarksTimeRange } from './messageHandlers';
 import type { ICustomReceiveHandlerData } from './types';
 import type { IWebViewRef } from '../../WebView/types';
@@ -68,6 +69,7 @@ interface IBaseTradingViewV2Props {
   storageNamespace?: string;
   forceEmptyKLineData?: boolean;
   emptyKLineDataOnError?: boolean;
+  kLineDataFallback?: ITradingViewV2KLineDataFallback;
 }
 
 export type ITradingViewV2Props = IBaseTradingViewV2Props & IStackStyle;
@@ -98,6 +100,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     storageNamespace,
     forceEmptyKLineData,
     emptyKLineDataOnError,
+    kLineDataFallback,
     onLoadStart,
     ...stackStyle
   } = props;
@@ -116,6 +119,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     onIndicatorsDialogOpenChange,
     forceEmptyKLineData,
     emptyKLineDataOnError,
+    kLineDataFallback,
   });
 
   const { isHyperLiquidSource, symbol: hyperLiquidSymbol } =

--- a/packages/kit/src/components/TradingView/TradingViewV2/hooks/useTradingViewV2.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/hooks/useTradingViewV2.test.ts
@@ -103,4 +103,71 @@ describe('fetchTradingViewV2DataWithSlicing', () => {
       ],
     );
   });
+
+  it('uses fallback data when sliced primary data has no points', async () => {
+    const fallback = jest.fn().mockResolvedValue({
+      points: [buildPoint(1020, 3)],
+      total: 1,
+    });
+    mockSliceRequest.mockReturnValue([
+      { from: 1000, to: 1120, interval: '1m' },
+    ]);
+    mockFetchMarketTokenKline.mockResolvedValueOnce({
+      points: [],
+      total: 0,
+    });
+
+    const result = await fetchTradingViewV2DataWithSlicing({
+      tokenAddress: '0x123',
+      networkId: 'evm--1',
+      interval: '1m',
+      timeFrom: 1000,
+      timeTo: 1120,
+      kLineDataFallback: fallback,
+    });
+
+    expect(fallback).toHaveBeenCalledWith({
+      tokenAddress: '0x123',
+      networkId: 'evm--1',
+      interval: '1m',
+      timeFrom: 1000,
+      timeTo: 1120,
+    });
+    expect(result?.points).toEqual([buildPoint(1020, 3)]);
+  });
+
+  it('uses fallback data when sliced primary data rejects', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const fallback = jest.fn().mockResolvedValue({
+      points: [buildPoint(1020, 3)],
+      total: 1,
+    });
+    mockSliceRequest.mockReturnValue([
+      { from: 1000, to: 1120, interval: '1m' },
+    ]);
+    mockFetchMarketTokenKline.mockRejectedValueOnce(
+      new Error('primary failed'),
+    );
+
+    const result = await fetchTradingViewV2DataWithSlicing({
+      tokenAddress: '0x123',
+      networkId: 'evm--1',
+      interval: '1m',
+      timeFrom: 1000,
+      timeTo: 1120,
+      kLineDataFallback: fallback,
+    });
+
+    expect(fallback).toHaveBeenCalledWith({
+      tokenAddress: '0x123',
+      networkId: 'evm--1',
+      interval: '1m',
+      timeFrom: 1000,
+      timeTo: 1120,
+    });
+    expect(result?.points).toEqual([buildPoint(1020, 3)]);
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/packages/kit/src/components/TradingView/TradingViewV2/hooks/useTradingViewV2.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/hooks/useTradingViewV2.ts
@@ -8,6 +8,23 @@ import { sliceRequest } from '../sliceRequest';
 
 const MIN_TRADING_VIEW_KLINE_TIME_SPAN_SECONDS = 2 * 24 * 60 * 60;
 
+export type ITradingViewV2KLineDataFallback = (params: {
+  tokenAddress: string;
+  networkId: string;
+  interval: string;
+  timeFrom: number;
+  timeTo: number;
+}) => Promise<IMarketTokenKLineResponse | null | undefined>;
+
+interface IFetchKLineDataFallbackParams {
+  tokenAddress: string;
+  networkId: string;
+  interval: string;
+  timeFrom: number;
+  timeTo: number;
+  kLineDataFallback?: ITradingViewV2KLineDataFallback;
+}
+
 interface ITradingViewV2Params {
   tokenAddress: string;
   networkId: string;
@@ -15,6 +32,7 @@ interface ITradingViewV2Params {
   timeFrom: number;
   timeTo: number;
   autoHandleError?: boolean;
+  kLineDataFallback?: ITradingViewV2KLineDataFallback;
 }
 
 function normalizeKLinePoints({
@@ -37,6 +55,82 @@ function normalizeKLinePoints({
   return Array.from(pointsByTimestamp.values()).toSorted((a, b) => a.t - b.t);
 }
 
+function hasKLinePoints(data?: IMarketTokenKLineResponse | null) {
+  return Boolean(data?.points?.length);
+}
+
+async function fetchKLineDataFallback({
+  tokenAddress,
+  networkId,
+  interval,
+  timeFrom,
+  timeTo,
+  kLineDataFallback,
+}: IFetchKLineDataFallbackParams): Promise<IMarketTokenKLineResponse | null> {
+  if (!kLineDataFallback) {
+    return null;
+  }
+
+  try {
+    return (
+      (await kLineDataFallback({
+        tokenAddress,
+        networkId,
+        interval,
+        timeFrom,
+        timeTo,
+      })) ?? null
+    );
+  } catch (error) {
+    console.error('Failed to fetch fallback kline data:', error);
+    return null;
+  }
+}
+
+async function fetchFallbackIfNeeded({
+  data,
+  tokenAddress,
+  networkId,
+  interval,
+  timeFrom,
+  timeTo,
+  kLineDataFallback,
+}: IFetchKLineDataFallbackParams & {
+  data?: IMarketTokenKLineResponse | null;
+}): Promise<IMarketTokenKLineResponse | null> {
+  if (hasKLinePoints(data)) {
+    return data ?? null;
+  }
+
+  const fallbackData = await fetchKLineDataFallback({
+    tokenAddress,
+    networkId,
+    interval,
+    timeFrom,
+    timeTo,
+    kLineDataFallback,
+  });
+  return fallbackData ?? data ?? null;
+}
+
+async function fetchFallbackOnError({
+  tokenAddress,
+  networkId,
+  interval,
+  timeFrom,
+  timeTo,
+  kLineDataFallback,
+}: IFetchKLineDataFallbackParams): Promise<IMarketTokenKLineResponse | null> {
+  return fetchKLineDataFallback({
+    tokenAddress,
+    networkId,
+    interval,
+    timeFrom,
+    timeTo,
+    kLineDataFallback,
+  });
+}
+
 export async function fetchTradingViewV2Data({
   tokenAddress,
   networkId,
@@ -44,6 +138,7 @@ export async function fetchTradingViewV2Data({
   timeFrom,
   timeTo,
   autoHandleError,
+  kLineDataFallback,
 }: ITradingViewV2Params): Promise<IMarketTokenKLineResponse | null> {
   try {
     const data = await backgroundApiProxy.serviceMarketV2.fetchMarketTokenKline(
@@ -57,10 +152,25 @@ export async function fetchTradingViewV2Data({
       },
     );
 
-    return data ?? null;
+    return fetchFallbackIfNeeded({
+      data,
+      tokenAddress,
+      networkId,
+      interval,
+      timeFrom,
+      timeTo,
+      kLineDataFallback,
+    });
   } catch (error) {
     console.error('Failed to fetch kline data:', error);
-    return null;
+    return fetchFallbackOnError({
+      tokenAddress,
+      networkId,
+      interval,
+      timeFrom,
+      timeTo,
+      kLineDataFallback,
+    });
   }
 }
 
@@ -71,6 +181,7 @@ export async function fetchTradingViewV2DataWithSlicing({
   timeFrom,
   timeTo,
   autoHandleError,
+  kLineDataFallback,
 }: ITradingViewV2Params): Promise<IMarketTokenKLineResponse | null> {
   try {
     // Check if the token is a native token
@@ -122,9 +233,24 @@ export async function fetchTradingViewV2DataWithSlicing({
       };
     }
 
-    return mergedData;
+    return fetchFallbackIfNeeded({
+      data: mergedData,
+      tokenAddress,
+      networkId,
+      interval,
+      timeFrom,
+      timeTo,
+      kLineDataFallback,
+    });
   } catch (error) {
     console.error('Failed to fetch sliced kline data:', error);
-    return null;
+    return fetchFallbackOnError({
+      tokenAddress,
+      networkId,
+      interval,
+      timeFrom,
+      timeTo,
+      kLineDataFallback,
+    });
   }
 }

--- a/packages/kit/src/components/TradingView/TradingViewV2/hooks/useTradingViewV2.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/hooks/useTradingViewV2.ts
@@ -152,7 +152,7 @@ export async function fetchTradingViewV2Data({
       },
     );
 
-    return fetchFallbackIfNeeded({
+    return await fetchFallbackIfNeeded({
       data,
       tokenAddress,
       networkId,
@@ -233,7 +233,7 @@ export async function fetchTradingViewV2DataWithSlicing({
       };
     }
 
-    return fetchFallbackIfNeeded({
+    return await fetchFallbackIfNeeded({
       data: mergedData,
       tokenAddress,
       networkId,

--- a/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/klineDataHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/klineDataHandler.ts
@@ -301,6 +301,7 @@ export async function handleKLineDataRequest({
             timeFrom: from,
             timeTo: to,
             autoHandleError: shouldSuppressKLineError ? false : undefined,
+            kLineDataFallback: context.kLineDataFallback,
           });
       const shouldUseEmptyKLineData =
         shouldForceEmptyKLineData ||

--- a/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/types.ts
@@ -1,4 +1,5 @@
 import type { IWebViewRef } from '../../../WebView/types';
+import type { ITradingViewV2KLineDataFallback } from '../hooks/useTradingViewV2';
 import type { ICustomReceiveHandlerData } from '../types';
 
 export interface IKLineDataRequest {
@@ -29,6 +30,7 @@ export interface IMessageHandlerContext {
   currentKLineResolution?: React.MutableRefObject<string>;
   forceEmptyKLineData?: boolean;
   emptyKLineDataOnError?: boolean;
+  kLineDataFallback?: ITradingViewV2KLineDataFallback;
 }
 
 export interface IMessageHandlerParams {

--- a/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
@@ -15,6 +15,7 @@ import { handleLayoutUpdate } from './layoutUpdateHandler';
 
 import type { IMarksTimeRange, IMessageHandlerContext } from './types';
 import type { IWebViewRef } from '../../../WebView/types';
+import type { ITradingViewV2KLineDataFallback } from '../hooks/useTradingViewV2';
 import type {
   ICustomReceiveHandlerData,
   ITradingViewIndicatorsDialogData,
@@ -36,6 +37,7 @@ interface IUseTradingViewMessageHandlerParams {
   onIndicatorsDialogOpenChange?: (isOpen: boolean) => void;
   forceEmptyKLineData?: boolean;
   emptyKLineDataOnError?: boolean;
+  kLineDataFallback?: ITradingViewV2KLineDataFallback;
 }
 
 async function handleGetHyperliquidPriceScale({
@@ -240,6 +242,7 @@ export function useTradingViewMessageHandler({
   onIndicatorsDialogOpenChange,
   forceEmptyKLineData,
   emptyKLineDataOnError,
+  kLineDataFallback,
 }: IUseTradingViewMessageHandlerParams) {
   const customReceiveHandler = useCallback(
     async ({ data }: ICustomReceiveHandlerData) => {
@@ -263,6 +266,7 @@ export function useTradingViewMessageHandler({
         currentKLineResolution,
         forceEmptyKLineData,
         emptyKLineDataOnError,
+        kLineDataFallback,
       };
 
       // Handle TradingView private API requests
@@ -361,6 +365,7 @@ export function useTradingViewMessageHandler({
       onIndicatorsDialogOpenChange,
       forceEmptyKLineData,
       emptyKLineDataOnError,
+      kLineDataFallback,
     ],
   );
 

--- a/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
@@ -38,12 +38,7 @@ import { PriceChangePercentage } from '@onekeyhq/kit/src/views/Market/components
 import type { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
-import type { IMarketTokenChart } from '@onekeyhq/shared/types/market';
-import type {
-  IMarketTokenDetail,
-  IMarketTokenKLineDataPoint,
-  IMarketTokenKLineResponse,
-} from '@onekeyhq/shared/types/marketV2';
+import type { IMarketTokenDetail } from '@onekeyhq/shared/types/marketV2';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 import { ETokenDappType } from '@onekeyhq/shared/types/token';
@@ -55,8 +50,12 @@ import type {
 import { SwapTestIDs } from '../../testIDs';
 import { SwapProviderMirror } from '../SwapProviderMirror';
 
+import {
+  convertSwapKLineWalletChartToKLineResponse,
+  getSwapKLineWalletChartDays,
+} from './swapKLineChartUtils';
+
 const SWAP_KLINE_TRADING_VIEW_STORAGE_NAMESPACE = 'swap-kline';
-const SWAP_KLINE_WALLET_CHART_ONE_DAY_SECONDS = 24 * 60 * 60;
 const SWAP_KLINE_DESKTOP_DISABLED_TRADING_VIEW_FEATURES = [
   TRADING_VIEW_DISABLED_FEATURES.TIME_SCALE,
   TRADING_VIEW_DISABLED_FEATURES.PRICE_SCALE,
@@ -143,92 +142,6 @@ function getNormalizedPrice(value?: number | string | null) {
 
 function getNormalizedPercent(value?: number | string | null) {
   return getNormalizedValueText(value);
-}
-
-function getSwapKLineWalletChartDays({
-  timeFrom,
-  timeTo,
-}: {
-  timeFrom: number;
-  timeTo: number;
-}) {
-  const timeSpan = Math.max(0, timeTo - timeFrom);
-
-  if (timeSpan <= SWAP_KLINE_WALLET_CHART_ONE_DAY_SECONDS) {
-    return '1';
-  }
-  if (timeSpan <= 7 * SWAP_KLINE_WALLET_CHART_ONE_DAY_SECONDS) {
-    return '7';
-  }
-  if (timeSpan <= 30 * SWAP_KLINE_WALLET_CHART_ONE_DAY_SECONDS) {
-    return '30';
-  }
-  if (timeSpan <= 365 * SWAP_KLINE_WALLET_CHART_ONE_DAY_SECONDS) {
-    return '365';
-  }
-  return 'max';
-}
-
-function normalizeSwapKLineWalletChartTimestamp(timestamp: number) {
-  if (timestamp > 10_000_000_000) {
-    return Math.floor(timestamp / 1000);
-  }
-  return Math.floor(timestamp);
-}
-
-function convertSwapKLineWalletChartToKLineResponse({
-  chartData,
-  timeFrom,
-  timeTo,
-}: {
-  chartData?: IMarketTokenChart;
-  timeFrom: number;
-  timeTo: number;
-}): IMarketTokenKLineResponse | null {
-  const pointsByTimestamp = new Map<number, { t: number; c: number }>();
-
-  for (const [timestamp, price] of chartData ?? []) {
-    const point = {
-      t: normalizeSwapKLineWalletChartTimestamp(timestamp),
-      c: Number(price),
-    };
-
-    if (
-      Number.isFinite(point.t) &&
-      Number.isFinite(point.c) &&
-      point.t >= timeFrom &&
-      point.t <= timeTo
-    ) {
-      pointsByTimestamp.set(point.t, point);
-    }
-  }
-
-  const normalizedPoints = Array.from(pointsByTimestamp.values()).toSorted(
-    (a, b) => a.t - b.t,
-  );
-
-  if (!normalizedPoints.length) {
-    return null;
-  }
-
-  const points = normalizedPoints.map<IMarketTokenKLineDataPoint>(
-    (point, index) => {
-      const open = index === 0 ? point.c : normalizedPoints[index - 1].c;
-      return {
-        o: open,
-        h: Math.max(open, point.c),
-        l: Math.min(open, point.c),
-        c: point.c,
-        v: 0,
-        t: point.t,
-      };
-    },
-  );
-
-  return {
-    points,
-    total: points.length,
-  };
 }
 
 function useSwapKLineTokenMarketInfo(token?: ISwapToken, enabled = true) {
@@ -741,7 +654,7 @@ function SwapKLineContentBody({
       <TradingViewV2
         key={`${chartNetworkId}:${chartTokenAddress}:${
           selectedToken?.symbol ?? ''
-        }:${state.walletMarketInfo?.coinGeckoId ?? ''}`}
+        }`}
         symbol={selectedToken?.symbol ?? ''}
         tokenAddress={chartTokenAddress}
         networkId={chartNetworkId}

--- a/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
@@ -27,6 +27,7 @@ import {
   TRADING_VIEW_DISABLED_FEATURES,
   TradingViewV2,
 } from '@onekeyhq/kit/src/components/TradingView/TradingViewV2';
+import type { ITradingViewV2KLineDataFallback } from '@onekeyhq/kit/src/components/TradingView/TradingViewV2/hooks/useTradingViewV2';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { ProviderJotaiContextMarketV2 } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import {
@@ -37,16 +38,25 @@ import { PriceChangePercentage } from '@onekeyhq/kit/src/views/Market/components
 import type { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
-import type { IMarketTokenDetail } from '@onekeyhq/shared/types/marketV2';
+import type { IMarketTokenChart } from '@onekeyhq/shared/types/market';
+import type {
+  IMarketTokenDetail,
+  IMarketTokenKLineDataPoint,
+  IMarketTokenKLineResponse,
+} from '@onekeyhq/shared/types/marketV2';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 import { ETokenDappType } from '@onekeyhq/shared/types/token';
-import type { ITokenDappType } from '@onekeyhq/shared/types/token';
+import type {
+  IFetchTokenDetailItem,
+  ITokenDappType,
+} from '@onekeyhq/shared/types/token';
 
 import { SwapTestIDs } from '../../testIDs';
 import { SwapProviderMirror } from '../SwapProviderMirror';
 
 const SWAP_KLINE_TRADING_VIEW_STORAGE_NAMESPACE = 'swap-kline';
+const SWAP_KLINE_WALLET_CHART_ONE_DAY_SECONDS = 24 * 60 * 60;
 const SWAP_KLINE_DESKTOP_DISABLED_TRADING_VIEW_FEATURES = [
   TRADING_VIEW_DISABLED_FEATURES.TIME_SCALE,
   TRADING_VIEW_DISABLED_FEATURES.PRICE_SCALE,
@@ -67,6 +77,12 @@ type ISwapKLineToken = ISwapToken & {
   defiMarked?: boolean;
   dappName?: string | null;
   dappType?: ITokenDappType;
+};
+
+type ISwapKLineWalletMarketInfo = {
+  coinGeckoId?: string;
+  price?: string;
+  priceChange24hPercent?: string;
 };
 
 function isKnownSwapKLineUnsupportedToken(token?: ISwapKLineToken) {
@@ -101,20 +117,8 @@ function getDefaultKLineSide({
   return ESwapDirectionType.TO;
 }
 
-function getNormalizedPrice(value?: string | null) {
-  const normalized = value?.trim();
-  if (!normalized) {
-    return undefined;
-  }
-  const numericValue = Number(normalized);
-  if (!Number.isFinite(numericValue) || numericValue === 0) {
-    return undefined;
-  }
-  return normalized;
-}
-
-function getNormalizedPercent(value?: string | null) {
-  const normalized = value?.trim();
+function getNormalizedValueText(value?: number | string | null) {
+  const normalized = typeof value === 'number' ? String(value) : value?.trim();
   if (!normalized) {
     return undefined;
   }
@@ -125,12 +129,114 @@ function getNormalizedPercent(value?: string | null) {
   return normalized;
 }
 
-function useSwapKLineTokenMarketInfo(token?: ISwapToken) {
-  const tokenAddress = token?.contractAddress ?? '';
+function getNormalizedPrice(value?: number | string | null) {
+  const normalized = getNormalizedValueText(value);
+  if (!normalized) {
+    return undefined;
+  }
+  const numericValue = Number(normalized);
+  if (numericValue === 0) {
+    return undefined;
+  }
+  return normalized;
+}
+
+function getNormalizedPercent(value?: number | string | null) {
+  return getNormalizedValueText(value);
+}
+
+function getSwapKLineWalletChartDays({
+  timeFrom,
+  timeTo,
+}: {
+  timeFrom: number;
+  timeTo: number;
+}) {
+  const timeSpan = Math.max(0, timeTo - timeFrom);
+
+  if (timeSpan <= SWAP_KLINE_WALLET_CHART_ONE_DAY_SECONDS) {
+    return '1';
+  }
+  if (timeSpan <= 7 * SWAP_KLINE_WALLET_CHART_ONE_DAY_SECONDS) {
+    return '7';
+  }
+  if (timeSpan <= 30 * SWAP_KLINE_WALLET_CHART_ONE_DAY_SECONDS) {
+    return '30';
+  }
+  if (timeSpan <= 365 * SWAP_KLINE_WALLET_CHART_ONE_DAY_SECONDS) {
+    return '365';
+  }
+  return 'max';
+}
+
+function normalizeSwapKLineWalletChartTimestamp(timestamp: number) {
+  if (timestamp > 10_000_000_000) {
+    return Math.floor(timestamp / 1000);
+  }
+  return Math.floor(timestamp);
+}
+
+function convertSwapKLineWalletChartToKLineResponse({
+  chartData,
+  timeFrom,
+  timeTo,
+}: {
+  chartData?: IMarketTokenChart;
+  timeFrom: number;
+  timeTo: number;
+}): IMarketTokenKLineResponse | null {
+  const pointsByTimestamp = new Map<number, { t: number; c: number }>();
+
+  for (const [timestamp, price] of chartData ?? []) {
+    const point = {
+      t: normalizeSwapKLineWalletChartTimestamp(timestamp),
+      c: Number(price),
+    };
+
+    if (
+      Number.isFinite(point.t) &&
+      Number.isFinite(point.c) &&
+      point.t >= timeFrom &&
+      point.t <= timeTo
+    ) {
+      pointsByTimestamp.set(point.t, point);
+    }
+  }
+
+  const normalizedPoints = Array.from(pointsByTimestamp.values()).toSorted(
+    (a, b) => a.t - b.t,
+  );
+
+  if (!normalizedPoints.length) {
+    return null;
+  }
+
+  const points = normalizedPoints.map<IMarketTokenKLineDataPoint>(
+    (point, index) => {
+      const open = index === 0 ? point.c : normalizedPoints[index - 1].c;
+      return {
+        o: open,
+        h: Math.max(open, point.c),
+        l: Math.min(open, point.c),
+        c: point.c,
+        v: 0,
+        t: point.t,
+      };
+    },
+  );
+
+  return {
+    points,
+    total: points.length,
+  };
+}
+
+function useSwapKLineTokenMarketInfo(token?: ISwapToken, enabled = true) {
+  const tokenAddress = token?.contractAddress?.trim() ?? '';
   const networkId = token?.networkId ?? '';
   const { result } = usePromiseResult<IMarketTokenDetail | undefined>(
     async () => {
-      if (!networkId) {
+      if (!enabled || !networkId || !tokenAddress) {
         return undefined;
       }
       const response =
@@ -140,7 +246,7 @@ function useSwapKLineTokenMarketInfo(token?: ISwapToken) {
         );
       return response?.data?.token;
     },
-    [networkId, tokenAddress],
+    [enabled, networkId, tokenAddress],
     {
       checkIsFocused: false,
       revalidateOnFocus: true,
@@ -151,6 +257,77 @@ function useSwapKLineTokenMarketInfo(token?: ISwapToken) {
   );
 
   return result;
+}
+
+function buildSwapKLineWalletMarketInfo(
+  tokenInfo?: IFetchTokenDetailItem,
+): ISwapKLineWalletMarketInfo | undefined {
+  const coinGeckoId = tokenInfo?.info?.coingeckoId?.trim();
+  const price = getNormalizedPrice(tokenInfo?.price);
+  const priceChange24hPercent = getNormalizedPercent(tokenInfo?.price24h);
+
+  if (!coinGeckoId && !price && !priceChange24hPercent) {
+    return undefined;
+  }
+
+  return {
+    coinGeckoId,
+    price,
+    priceChange24hPercent,
+  };
+}
+
+function useSwapKLineWalletMarketInfo(
+  token?: ISwapToken,
+): ISwapKLineWalletMarketInfo | undefined {
+  const tokenAddress = token?.contractAddress ?? '';
+  const networkId = token?.networkId ?? '';
+  const { result: tokenInfo } = usePromiseResult<
+    IFetchTokenDetailItem | undefined
+  >(
+    async () => {
+      if (!networkId) {
+        return undefined;
+      }
+
+      const fetchedTokenInfo =
+        await backgroundApiProxy.serviceToken.fetchTokenInfoOnly({
+          networkId,
+          tokenAddress,
+        });
+      return fetchedTokenInfo;
+    },
+    [networkId, tokenAddress],
+    {
+      checkIsFocused: false,
+      undefinedResultIfError: true,
+      undefinedResultIfReRun: true,
+    },
+  );
+
+  return useMemo(() => buildSwapKLineWalletMarketInfo(tokenInfo), [tokenInfo]);
+}
+
+function useSwapKLineDataFallback(
+  coinGeckoId?: string,
+): ITradingViewV2KLineDataFallback | undefined {
+  return useMemo(() => {
+    if (!coinGeckoId) {
+      return undefined;
+    }
+
+    return async ({ timeFrom, timeTo }) => {
+      const chartData = await backgroundApiProxy.serviceMarket.fetchTokenChart(
+        coinGeckoId,
+        getSwapKLineWalletChartDays({ timeFrom, timeTo }),
+      );
+      return convertSwapKLineWalletChartToKLineResponse({
+        chartData,
+        timeFrom,
+        timeTo,
+      });
+    };
+  }, [coinGeckoId]);
 }
 
 function useSwapKLineNetworkName(networkId?: string) {
@@ -298,6 +475,8 @@ type ISwapKLineContentState = {
   fromToken?: ISwapToken;
   toToken?: ISwapToken;
   selectedToken?: ISwapToken;
+  walletMarketInfo?: ISwapKLineWalletMarketInfo;
+  kLineDataFallback?: ITradingViewV2KLineDataFallback;
   resolvedSelectedSide: ESwapDirectionType;
   shouldForceEmptyKLineData: boolean;
   tokenMarketDetail?: IMarketTokenDetail;
@@ -332,6 +511,10 @@ function useSwapKLineContentState(): ISwapKLineContentState {
 
   const selectedToken =
     resolvedSelectedSide === ESwapDirectionType.FROM ? fromToken : toToken;
+  const walletMarketInfo = useSwapKLineWalletMarketInfo(selectedToken);
+  const kLineDataFallback = useSwapKLineDataFallback(
+    walletMarketInfo?.coinGeckoId,
+  );
   const shouldForceEmptyKLineData =
     isKnownSwapKLineUnsupportedToken(selectedToken);
   const tokenMarketDetail = useSwapKLineTokenMarketInfo(selectedToken);
@@ -376,6 +559,8 @@ function useSwapKLineContentState(): ISwapKLineContentState {
       fromToken,
       toToken,
       selectedToken,
+      walletMarketInfo,
+      kLineDataFallback,
       resolvedSelectedSide,
       shouldForceEmptyKLineData,
       tokenMarketDetail,
@@ -384,11 +569,13 @@ function useSwapKLineContentState(): ISwapKLineContentState {
     [
       fromToken,
       handleSelectedSideChange,
+      kLineDataFallback,
       resolvedSelectedSide,
       selectedToken,
       shouldForceEmptyKLineData,
       toToken,
       tokenMarketDetail,
+      walletMarketInfo,
     ],
   );
 }
@@ -411,16 +598,19 @@ function SwapKLineHeaderRight({ state }: { state: ISwapKLineContentState }) {
 function SwapKLineTokenPriceInfo({
   token,
   tokenMarketDetail,
+  walletMarketInfo,
 }: {
   token: ISwapToken;
   tokenMarketDetail?: IMarketTokenDetail;
+  walletMarketInfo?: ISwapKLineWalletMarketInfo;
 }) {
   const price =
     getNormalizedPrice(tokenMarketDetail?.price) ??
+    walletMarketInfo?.price ??
     getNormalizedPrice(token.price);
-  const priceChange = getNormalizedPercent(
-    tokenMarketDetail?.priceChange24hPercent,
-  );
+  const priceChange =
+    getNormalizedPercent(tokenMarketDetail?.priceChange24hPercent) ??
+    walletMarketInfo?.priceChange24hPercent;
 
   return (
     <YStack ai="flex-end" gap="$0.5" minWidth="$20" maxWidth="$32">
@@ -475,9 +665,11 @@ function SwapKLineTokenPriceInfo({
 function SwapKLineTokenInfoRow({
   token,
   tokenMarketDetail,
+  walletMarketInfo,
 }: {
   token: ISwapToken;
   tokenMarketDetail?: IMarketTokenDetail;
+  walletMarketInfo?: ISwapKLineWalletMarketInfo;
 }) {
   const tokenName = tokenMarketDetail?.name || token.name;
   const networkName = useSwapKLineNetworkName(token.networkId);
@@ -512,6 +704,7 @@ function SwapKLineTokenInfoRow({
       <SwapKLineTokenPriceInfo
         token={token}
         tokenMarketDetail={tokenMarketDetail}
+        walletMarketInfo={walletMarketInfo}
       />
     </XStack>
   );
@@ -546,7 +739,9 @@ function SwapKLineContentBody({
       borderTopColor="$borderSubdued"
     >
       <TradingViewV2
-        key={`${chartNetworkId}:${chartTokenAddress}:${selectedToken?.symbol ?? ''}`}
+        key={`${chartNetworkId}:${chartTokenAddress}:${
+          selectedToken?.symbol ?? ''
+        }:${state.walletMarketInfo?.coinGeckoId ?? ''}`}
         symbol={selectedToken?.symbol ?? ''}
         tokenAddress={chartTokenAddress}
         networkId={chartNetworkId}
@@ -556,6 +751,7 @@ function SwapKLineContentBody({
         storageNamespace={SWAP_KLINE_TRADING_VIEW_STORAGE_NAMESPACE}
         forceEmptyKLineData={state.shouldForceEmptyKLineData}
         emptyKLineDataOnError
+        kLineDataFallback={state.kLineDataFallback}
         w="100%"
         h="100%"
       />
@@ -569,6 +765,7 @@ function SwapKLineContentBody({
           <SwapKLineTokenInfoRow
             token={selectedToken}
             tokenMarketDetail={state.tokenMarketDetail}
+            walletMarketInfo={state.walletMarketInfo}
           />
 
           {chartContent}

--- a/packages/kit/src/views/Swap/pages/modal/swapKLineChartUtils.test.ts
+++ b/packages/kit/src/views/Swap/pages/modal/swapKLineChartUtils.test.ts
@@ -1,0 +1,70 @@
+import {
+  convertSwapKLineWalletChartToKLineResponse,
+  getSwapKLineWalletChartDays,
+} from './swapKLineChartUtils';
+
+const ONE_DAY_SECONDS = 24 * 60 * 60;
+
+describe('swapKLineChartUtils', () => {
+  describe('getSwapKLineWalletChartDays', () => {
+    it('covers historical request windows from now instead of only the span', () => {
+      const nowSeconds = 1_700_000_000;
+
+      expect(
+        getSwapKLineWalletChartDays({
+          timeFrom: nowSeconds - 20 * ONE_DAY_SECONDS,
+          timeTo: nowSeconds - 19 * ONE_DAY_SECONDS,
+          nowSeconds,
+        }),
+      ).toBe('30');
+    });
+
+    it('uses max for windows older than one year', () => {
+      const nowSeconds = 1_700_000_000;
+
+      expect(
+        getSwapKLineWalletChartDays({
+          timeFrom: nowSeconds - 400 * ONE_DAY_SECONDS,
+          timeTo: nowSeconds - 399 * ONE_DAY_SECONDS,
+          nowSeconds,
+        }),
+      ).toBe('max');
+    });
+  });
+
+  describe('convertSwapKLineWalletChartToKLineResponse', () => {
+    it('normalizes timestamps, filters to request window, and builds OHLC points', () => {
+      const baseTime = 1_700_000_000;
+      const result = convertSwapKLineWalletChartToKLineResponse({
+        chartData: [
+          [(baseTime - 1) * 1000, 5],
+          [baseTime * 1000, 10],
+          [(baseTime + 1) * 1000, 12],
+          [baseTime + 2, 8],
+          [(baseTime + 3) * 1000, Number.NaN],
+        ],
+        timeFrom: baseTime,
+        timeTo: baseTime + 2,
+      });
+
+      expect(result).toEqual({
+        points: [
+          { o: 10, h: 10, l: 10, c: 10, v: 0, t: baseTime },
+          { o: 10, h: 12, l: 10, c: 12, v: 0, t: baseTime + 1 },
+          { o: 12, h: 12, l: 8, c: 8, v: 0, t: baseTime + 2 },
+        ],
+        total: 3,
+      });
+    });
+
+    it('returns null when the wallet chart has no points inside the request window', () => {
+      expect(
+        convertSwapKLineWalletChartToKLineResponse({
+          chartData: [[900_000, 5]],
+          timeFrom: 1000,
+          timeTo: 1002,
+        }),
+      ).toBeNull();
+    });
+  });
+});

--- a/packages/kit/src/views/Swap/pages/modal/swapKLineChartUtils.ts
+++ b/packages/kit/src/views/Swap/pages/modal/swapKLineChartUtils.ts
@@ -1,0 +1,96 @@
+import type { IMarketTokenChart } from '@onekeyhq/shared/types/market';
+import type {
+  IMarketTokenKLineDataPoint,
+  IMarketTokenKLineResponse,
+} from '@onekeyhq/shared/types/marketV2';
+
+const SWAP_KLINE_WALLET_CHART_ONE_DAY_SECONDS = 24 * 60 * 60;
+
+export function getSwapKLineWalletChartDays({
+  timeFrom,
+  timeTo,
+  nowSeconds = Math.floor(Date.now() / 1000),
+}: {
+  timeFrom: number;
+  timeTo: number;
+  nowSeconds?: number;
+}) {
+  const requestEnd = Math.max(timeTo, nowSeconds);
+  const timeSpan = Math.max(0, requestEnd - timeFrom);
+
+  if (timeSpan <= SWAP_KLINE_WALLET_CHART_ONE_DAY_SECONDS) {
+    return '1';
+  }
+  if (timeSpan <= 7 * SWAP_KLINE_WALLET_CHART_ONE_DAY_SECONDS) {
+    return '7';
+  }
+  if (timeSpan <= 30 * SWAP_KLINE_WALLET_CHART_ONE_DAY_SECONDS) {
+    return '30';
+  }
+  if (timeSpan <= 365 * SWAP_KLINE_WALLET_CHART_ONE_DAY_SECONDS) {
+    return '365';
+  }
+  return 'max';
+}
+
+export function normalizeSwapKLineWalletChartTimestamp(timestamp: number) {
+  if (timestamp > 10_000_000_000) {
+    return Math.floor(timestamp / 1000);
+  }
+  return Math.floor(timestamp);
+}
+
+export function convertSwapKLineWalletChartToKLineResponse({
+  chartData,
+  timeFrom,
+  timeTo,
+}: {
+  chartData?: IMarketTokenChart;
+  timeFrom: number;
+  timeTo: number;
+}): IMarketTokenKLineResponse | null {
+  const pointsByTimestamp = new Map<number, { t: number; c: number }>();
+
+  for (const [timestamp, price] of chartData ?? []) {
+    const point = {
+      t: normalizeSwapKLineWalletChartTimestamp(timestamp),
+      c: Number(price),
+    };
+
+    if (
+      Number.isFinite(point.t) &&
+      Number.isFinite(point.c) &&
+      point.t >= timeFrom &&
+      point.t <= timeTo
+    ) {
+      pointsByTimestamp.set(point.t, point);
+    }
+  }
+
+  const normalizedPoints = Array.from(pointsByTimestamp.values()).toSorted(
+    (a, b) => a.t - b.t,
+  );
+
+  if (!normalizedPoints.length) {
+    return null;
+  }
+
+  const points = normalizedPoints.map<IMarketTokenKLineDataPoint>(
+    (point, index) => {
+      const open = index === 0 ? point.c : normalizedPoints[index - 1].c;
+      return {
+        o: open,
+        h: Math.max(open, point.c),
+        l: Math.min(open, point.c),
+        c: point.c,
+        v: 0,
+        t: point.t,
+      };
+    },
+  );
+
+  return {
+    points,
+    total: points.length,
+  };
+}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55523](https://onekeyhq.atlassian.net/browse/OK-55523)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Add a Swap-scoped K-line fallback path that uses Wallet token chart data when Market V2 K-line data is empty or unavailable.
- Keep TradingViewV2 shared behavior unchanged unless a caller explicitly passes `kLineDataFallback`.
- Prevent empty token-address Market detail requests while preserving Swap K-line header price and 24h fallback data from Wallet token info.

## Intent & Context
OK-55523 reports that Swap has no K-line data on some networks, such as HyperEVM, because Market coverage is incomplete. Wallet already has per-token chart data, and the requested behavior is to use that chart data as a fallback for Swap.

## Root Cause
Swap K-line only relied on Market V2 K-line data. For networks/tokens not covered by Market V2, the chart fell back to empty data. Empty token addresses also caused invalid Market detail requests in some cases.

## Design Decisions
- Scope the Wallet chart fallback to Swap by passing a `kLineDataFallback` callback only from `SwapKLineContent`.
- Keep `TradingViewV2` generic: it only invokes an optional callback when primary K-line data is empty or fails, and it does not know about Wallet, CoinGecko, or Swap-specific rules.
- Convert Wallet chart price points into minimal OHLC K-line points for TradingViewV2.
- Use Wallet token info as a fallback for header price and 24h change when Market detail is unavailable.

## Changes Detail
- `SwapKLineContent.tsx`: fetches Wallet token info, builds Swap-only K-line fallback, restores price/24h fallback, and blocks empty-address Market detail calls.
- `useTradingViewV2.ts`: adds an optional generic fallback callback for empty/failed K-line data.
- TradingView message handler files: thread the optional fallback callback through the existing K-line request path.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Mobile / Web / Extension where Swap K-line is available
- **Risk Areas**: TradingViewV2 K-line request path and Swap token metadata fallback. Other TradingViewV2 callers do not pass the fallback callback, so their behavior should remain unchanged.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `yarn jest packages/kit/src/components/TradingView/TradingViewV2/hooks/useTradingViewV2.test.ts`
- [x] `NODE_OPTIONS=--max-old-space-size=8192 yarn tsc --noEmit --pretty false --project packages/kit/tsconfig.json`
- [x] `yarn prettier --check packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx packages/kit/src/components/TradingView/TradingViewV2/hooks/useTradingViewV2.ts packages/kit/src/components/TradingView/TradingViewV2/hooks/useTradingViewV2.test.ts packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/klineDataHandler.ts packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/types.ts packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/useTradingViewMessageHandler.ts packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx`
- [x] `git diff --check`

[OK-55523]: https://onekeyhq.atlassian.net/browse/OK-55523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ