### PR TITLE
fix: align private send value drop dialog

### DIFF
--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -280,11 +280,9 @@ function isSwapQuoteCancelError(error: unknown) {
 
 function PrivateSendValueDropWarningContent({
   valueDropPercent,
-  onCancel,
   onConfirm,
 }: {
   valueDropPercent?: number;
-  onCancel: () => void;
   onConfirm: () => void;
 }) {
   const intl = useIntl();
@@ -300,15 +298,8 @@ function PrivateSendValueDropWarningContent({
   }, []);
 
   return (
-    <YStack gap="$4">
-      <YStack
-        gap="$2"
-        p="$3"
-        borderRadius="$3"
-        bg="$bgCritical"
-        borderWidth="$px"
-        borderColor="$borderCritical"
-      >
+    <YStack gap="$6">
+      <YStack gap="$3">
         <SizableText size="$bodyMdMedium" color="$textCritical">
           {intl.formatMessage(
             { id: ETranslations.private_send_value_drop_amount },
@@ -326,29 +317,18 @@ function PrivateSendValueDropWarningContent({
           })}
         </SizableText>
       </YStack>
-      <XStack gap="$2.5">
-        <Button
-          testID="private-send-value-drop-cancel"
-          flex={1}
-          variant="secondary"
-          onPress={onCancel}
-        >
-          {intl.formatMessage({ id: ETranslations.global_cancel })}
-        </Button>
-        <Button
-          testID="private-send-value-drop-confirm"
-          flex={1}
-          variant="destructive"
-          disabled={countdown > 0}
-          onPress={onConfirm}
-        >
-          {countdown > 0
-            ? `${intl.formatMessage({
-                id: ETranslations.global_continue,
-              })} (${countdown})`
-            : intl.formatMessage({ id: ETranslations.global_continue })}
-        </Button>
-      </XStack>
+      <Button
+        testID="private-send-value-drop-confirm"
+        variant="primary"
+        disabled={countdown > 0}
+        onPress={onConfirm}
+      >
+        {countdown > 0
+          ? `${intl.formatMessage({
+              id: ETranslations.global_continue,
+            })} (${countdown})`
+          : intl.formatMessage({ id: ETranslations.global_continue })}
+      </Button>
     </YStack>
   );
 }
@@ -1695,26 +1675,18 @@ function SendAmountInputContainer() {
           title: intl.formatMessage({
             id: ETranslations.private_send_high_value_drop_title,
           }),
-          tone: 'destructive',
           showFooter: false,
           trapFocus: true,
           dismissOnOverlayPress: false,
-          disableDrag: true,
           onClose: () => settle(false),
           renderContent: (
-            <Stack p="$4">
-              <PrivateSendValueDropWarningContent
-                valueDropPercent={valueDropPercent}
-                onCancel={() => {
-                  settle(false);
-                  void dialog.close();
-                }}
-                onConfirm={() => {
-                  settle(true);
-                  void dialog.close();
-                }}
-              />
-            </Stack>
+            <PrivateSendValueDropWarningContent
+              valueDropPercent={valueDropPercent}
+              onConfirm={() => {
+                settle(true);
+                void dialog.close();
+              }}
+            />
           ),
         });
       });


### PR DESCRIPTION
## Summary
- Align the Private Send high value drop dialog with the Figma bottom-sheet layout.
- Remove the extra warning card and cancel action from the dialog body.
- Keep the single primary Continue button with the existing countdown gate.

## Issues
- No Jira issue provided; scoped Figma alignment fix.

## Test Plan
- PASS: yarn lint:staged
- PASS: git diff --check
- BLOCKED: yarn tsc:staged fails on existing @onekeyfe/hwk-adapter-core / Ledger type drift outside this change (OffscreenApiThirdPartyHardware, LedgerAdapter, thirdPartyHardwareAdapterRegistry, ledger keyrings, ThirdPartyHardwareUiStateContainer).