### PR TITLE
fix(send): fiat auto-switch, re-prompt insufficient & amount-error flicker (OK-55640 OK-55641 OK-55683)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -93,6 +93,14 @@ import type { RouteProp } from '@react-navigation/core';
 
 export const amountInputAccessoryViewID = 'send-amount-input-accessory-view';
 
+// Neutral, non-empty hint used to keep the amount error suppressed while the
+// user is typing on chains/tokens that have no min-amount hint (most EVM
+// tokens, or BTC before tokenMinAmount loads). Form.Field only renders the
+// subdued hint in place of the red error when `hint` is truthy, so an empty
+// string would not work — a non-breaking space renders blank while reserving
+// the row height (OK-55683).
+const NEUTRAL_AMOUNT_HINT = '\u00A0';
+
 interface IAmountFormValues {
   accountId: string;
   networkId: string;
@@ -724,8 +732,14 @@ function SendAmountInputContainer() {
     !!vaultSettings?.mergeDeriveAssetsEnabled &&
     !isNFT &&
     !isLightningNetwork &&
-    // Fiat mode needs a usable price to convert the input to a token amount.
-    (!isUseFiat || hasUsablePrice) &&
+    // Intentionally NOT gated on `hasUsablePrice` in fiat mode. The 0-balance
+    // entry-case (land on an empty deriveType → switch to a funded sibling) is
+    // price-independent and is the primary path this feature targets — on an
+    // empty-balance BTC format `fetchTokensDetails()` returns [], so price is
+    // missing exactly when we most need the switch. The amount-driven cascade
+    // still can't misfire without a price: `linkedAmount.originalAmount` (fed
+    // in as the token amount) collapses to '0' when price is 0, and a 0 amount
+    // self-skips the cascade (it only runs the entry-case).
     // With coin control the user has hand-picked UTXOs and `maxBalance` is
     // the selected-UTXO subtotal, not the account balance — a subset
     // shortfall must not trigger a switch that also discards their selection.
@@ -763,6 +777,12 @@ function SendAmountInputContainer() {
     allFormatsInsufficient,
   } = useAutoSwitchDeriveType({
     amount: autoSwitchAmount,
+    // Raw form input + display mode, used only as the manual-switch lock basis.
+    // The lock must release on a real user edit but NOT when the token-priced
+    // `autoSwitchAmount` shifts on its own (async price load, account switch) —
+    // so it compares the untouched input, not the derived value.
+    userInputAmount: amount,
+    isUseFiat,
     isInsufficientBalance,
     enabled: autoSwitchEnabled,
     currentAccountId,
@@ -1550,10 +1570,17 @@ function SendAmountInputContainer() {
   // stays live (submit gating unaffected); only the display is debounced — the
   // Field renders the neutral hint in place of the error until input settles.
   const isAmountTyping = amount !== useDebounce(amount, 400);
-  const amountHint =
-    isAmountTyping || isAmountZeroOrEmpty || !hasAmountError
-      ? minAmountHint
-      : undefined;
+  const shouldDeferAmountError =
+    isAmountTyping || isAmountZeroOrEmpty || !hasAmountError;
+  // While deferring, show the real min-amount hint when the chain has one.
+  // When it doesn't (most EVM tokens, or BTC before tokenMinAmount loads),
+  // `minAmountHint` is undefined and Form.Field would fall back to rendering
+  // the red error anyway — so substitute a neutral placeholder to actually
+  // keep the error suppressed. Only do this when there is an error to defer;
+  // otherwise leave the hint empty so valid input shows no extra row.
+  const amountHint = shouldDeferAmountError
+    ? (minAmountHint ?? (hasAmountError ? NEUTRAL_AMOUNT_HINT : undefined))
+    : undefined;
 
   const renderAmountInput = useMemo(
     () => (

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -678,6 +678,13 @@ function SendAmountInputContainer() {
     ],
   );
 
+  // Fiat input needs a usable price to convert it to a token amount. Single
+  // source of truth for the fiat-mode guards below.
+  const hasUsablePrice = useMemo(
+    () => new BigNumber(tokenDetails?.price ?? 0).isGreaterThan(0),
+    [tokenDetails?.price],
+  );
+
   // Check if balance is insufficient (show on button instead of form error)
   const isInsufficientBalance = useMemo(() => {
     if (!amount || amount === '0') return false;
@@ -685,12 +692,28 @@ function SendAmountInputContainer() {
     if (valueBN.isNaN() || valueBN.isNegative()) return false;
 
     if (isUseFiat) {
-      const fiatValue = new BigNumber(maxBalanceFiat);
-      return valueBN.isGreaterThan(fiatValue);
+      // No usable price → fiat can't convert to a sendable amount; block.
+      if (!hasUsablePrice) {
+        return true;
+      }
+      // Judge on the floored token amount actually submitted (same basis as
+      // validation and the sibling comparison), not the raw fiat value — they
+      // disagree at the sub-unit boundary. Both `originalAmount` and
+      // `maxBalance` follow the same unit (incl. Lightning: sats when
+      // lnUnit=SATS, BTC when lnUnit=BTC), so the comparison is unit-consistent.
+      return new BigNumber(linkedAmount.originalAmount).isGreaterThan(
+        maxBalance,
+      );
     }
     const balance = new BigNumber(maxBalance);
     return valueBN.isGreaterThan(balance);
-  }, [amount, isUseFiat, maxBalanceFiat, maxBalance]);
+  }, [
+    amount,
+    isUseFiat,
+    hasUsablePrice,
+    linkedAmount.originalAmount,
+    maxBalance,
+  ]);
 
   // Skip the `tokenInfo.address` truthiness check: for chains where
   // `vaultSettings.isNativeTokenContractAddressEmpty` is true (e.g. BTC), the
@@ -699,8 +722,9 @@ function SendAmountInputContainer() {
   const autoSwitchEnabled =
     !!vaultSettings?.mergeDeriveAssetsEnabled &&
     !isNFT &&
-    !isUseFiat &&
     !isLightningNetwork &&
+    // Fiat mode needs a usable price to convert the input to a token amount.
+    (!isUseFiat || hasUsablePrice) &&
     // With coin control the user has hand-picked UTXOs and `maxBalance` is
     // the selected-UTXO subtotal, not the account balance — a subset
     // shortfall must not trigger a switch that also discards their selection.
@@ -727,13 +751,17 @@ function SendAmountInputContainer() {
     [sendConfirmActions],
   );
 
+  // Auto-switch compares against sibling token balances, so feed token units:
+  // the converted originalAmount in fiat mode, the raw amount in token mode.
+  const autoSwitchAmount = isUseFiat ? linkedAmount.originalAmount : amount;
+
   const {
     autoSwitchInfo,
     dismissAutoSwitchInfo,
     pulseSignal,
     allFormatsInsufficient,
   } = useAutoSwitchDeriveType({
-    amount,
+    amount: autoSwitchAmount,
     isInsufficientBalance,
     enabled: autoSwitchEnabled,
     currentAccountId,

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -34,6 +34,7 @@ import { useReviewControl } from '@onekeyhq/kit/src/components/ReviewControl';
 import { LightningUnitSwitch } from '@onekeyhq/kit/src/components/UnitSwitch';
 import { useAccountData } from '@onekeyhq/kit/src/hooks/useAccountData';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useSignatureConfirm } from '@onekeyhq/kit/src/hooks/useSignatureConfirm';
 import {
@@ -1544,8 +1545,15 @@ function SendAmountInputContainer() {
   ]);
 
   const isAmountZeroOrEmpty = !amount || new BigNumber(amount).isZero();
+  // Defer the red error while the user is still typing/deleting so transient
+  // values ("0.000", below-min, empty) don't flash red (OK-55683). Validation
+  // stays live (submit gating unaffected); only the display is debounced — the
+  // Field renders the neutral hint in place of the error until input settles.
+  const isAmountTyping = amount !== useDebounce(amount, 400);
   const amountHint =
-    isAmountZeroOrEmpty || !hasAmountError ? minAmountHint : undefined;
+    isAmountTyping || isAmountZeroOrEmpty || !hasAmountError
+      ? minAmountHint
+      : undefined;
 
   const renderAmountInput = useMemo(
     () => (

--- a/packages/kit/src/views/Send/pages/SendAmountInput/hooks/useAutoSwitchDeriveType.ts
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/hooks/useAutoSwitchDeriveType.ts
@@ -92,6 +92,8 @@ export type IAutoSwitchInfo = {
 };
 
 type IParams = {
+  // Token-denominated: compared directly against sibling token balances (the
+  // caller converts fiat input to token units before passing it).
   amount: string;
   isInsufficientBalance: boolean;
   enabled: boolean;
@@ -180,9 +182,9 @@ export function useAutoSwitchDeriveType({
   const amountRef = useRef(amount);
   amountRef.current = amount;
   // Mirrors `enabled` so the async closure can detect a mid-flight disable
-  // (e.g. user toggled fiat or coin-control during the fetch). The main
-  // effect early-returns on `!enabled` without incrementing the generation,
-  // so generation alone won't catch this.
+  // (e.g. user enabled coin-control during the fetch). The main effect
+  // early-returns on `!enabled` without incrementing the generation, so
+  // generation alone won't catch this.
   const enabledRef = useRef(enabled);
   enabledRef.current = enabled;
   // Tripped on hook unmount. In-flight closures must bail before touching
@@ -230,13 +232,11 @@ export function useAutoSwitchDeriveType({
 
   useEffect(() => {
     if (!enabled) {
-      // Feature got disabled mid-flow (user toggled fiat or enabled
-      // coin-control). Drop the cached "no format covers" verdict so the
-      // alert doesn't survive into a context that uses different units or
-      // a different balance basis. We intentionally leave `triedDeriveTypes`
-      // and the manual-lock refs alone — they describe lifetime intent and
-      // staying valid across a brief disable→enable toggle is the right
-      // default.
+      // Feature got disabled mid-flow (e.g. user enabled coin-control). Drop
+      // the cached "no format covers" verdict so the alert doesn't survive
+      // into a context with a different balance basis. We intentionally leave
+      // `triedDeriveTypes` and the manual-lock refs alone — they describe
+      // lifetime intent and stay valid across a brief disable→enable toggle.
       if (allFormatsInsufficientAmount) setAllFormatsInsufficientAmount(null);
       return;
     }
@@ -259,14 +259,25 @@ export function useAutoSwitchDeriveType({
       return;
     }
     if (userManuallySwitchedRef.current) {
-      // Stay locked until the live amount differs from the snapshot taken
-      // when the manual switch happened. Once it does, treat the new input
-      // as a fresh evaluation: clear the lock, the tried-set (which referred
-      // to a prior account's lineage), and the "all formats short" threshold.
-      if (
-        manualSwitchAtAmountRef.current === null ||
-        amount === manualSwitchAtAmountRef.current
-      ) {
+      // Stay locked until the live amount differs from the snapshot taken at
+      // the manual switch; only then treat it as a fresh evaluation and clear
+      // the lock, the tried-set, and the "all formats short" threshold.
+      //
+      // `amount` is always token-denominated (see `autoSwitchAmount` at the
+      // call site), but its representation differs across a fiat/token display
+      // toggle — token mode passes the raw input, fiat mode the re-derived
+      // value — so the same amount can read as "1.0" vs "1". Compare
+      // numerically so a display toggle isn't mistaken for a real edit;
+      // the string check is a fast path that also keeps empty/empty equal.
+      const snapshot = manualSwitchAtAmountRef.current;
+      // `sameAmount` requires a non-null snapshot, so the numeric compare can
+      // never read a null snapshot as 0 (which would hold the lock forever at
+      // amount '0'); the null case is handled by the early return.
+      const sameAmount =
+        snapshot !== null &&
+        (amount === snapshot ||
+          new BigNumber(amount || 0).isEqualTo(new BigNumber(snapshot || 0)));
+      if (snapshot === null || sameAmount) {
         return;
       }
       userManuallySwitchedRef.current = false;
@@ -313,7 +324,7 @@ export function useAutoSwitchDeriveType({
       try {
         const { siblings, hadError } = await fetchSiblings();
         // Bail if the hook unmounted, the effect re-ran while we were
-        // fetching, the feature got disabled (fiat/coin-control toggle), the
+        // fetching, the feature got disabled (e.g. coin-control toggle), the
         // user typed a fresh amount, or manually switched.
         if (cancelledRef.current) return;
         if (generation !== fetchGenerationRef.current) return;
@@ -329,11 +340,15 @@ export function useAutoSwitchDeriveType({
         });
 
         if (!target) {
-          // Entry case (no amount typed): silently bail, nothing to surface.
-          // Cascade case: surface "all formats combined are still not
-          // enough" — but only when every sibling balance was actually
-          // fetched. A failed RPC must not masquerade as "no funds".
+          // Entry case (amount 0): silently bail. Otherwise act only when every
+          // sibling was actually fetched — a failed RPC must not look like
+          // "no funds": clear any stale "auto-switched" banner so it can't mask
+          // the warning, and raise the all-formats-insufficient warning. On a
+          // fetch error we leave prior state untouched (conservative — we can't
+          // tell "no covering format" from "couldn't check", and silently
+          // dropping the success banner on a transient blip would be worse).
           if (!amountBN.isZero() && !hadError) {
+            setAutoSwitchInfo(null);
             setAllFormatsInsufficientAmount(amountBN);
           }
           return;

--- a/packages/kit/src/views/Send/pages/SendAmountInput/hooks/useAutoSwitchDeriveType.ts
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/hooks/useAutoSwitchDeriveType.ts
@@ -95,6 +95,12 @@ type IParams = {
   // Token-denominated: compared directly against sibling token balances (the
   // caller converts fiat input to token units before passing it).
   amount: string;
+  // Raw form input (fiat string in fiat mode, token string in token mode) plus
+  // the current display mode. Used ONLY as the manual-switch lock basis — the
+  // raw input is invariant to async price changes/account switches that move
+  // the derived `amount`, so the lock releases only on a genuine user edit.
+  userInputAmount: string;
+  isUseFiat: boolean;
   isInsufficientBalance: boolean;
   enabled: boolean;
   currentAccountId: string;
@@ -134,6 +140,8 @@ type IParams = {
 // amount that fits or hit "max".
 export function useAutoSwitchDeriveType({
   amount,
+  userInputAmount,
+  isUseFiat,
   isInsufficientBalance,
   enabled,
   currentAccountId,
@@ -156,12 +164,17 @@ export function useAutoSwitchDeriveType({
     useState<BigNumber | null>(null);
 
   const userManuallySwitchedRef = useRef(false);
-  // Snapshot of `amount` at the moment of the most recent manual switch.
-  // The manual lock is lifted as soon as the live amount differs from this
-  // — i.e. one keystroke of "real" new input is required before auto-switch
-  // can fire again. Stale value left over from before the switch will not
-  // trigger immediately.
-  const manualSwitchAtAmountRef = useRef<string | null>(null);
+  // Snapshot of the user's raw input (+ display mode) at the moment of the most
+  // recent manual switch. The manual lock is lifted as soon as the raw input
+  // differs from this — i.e. one keystroke of "real" new input is required
+  // before auto-switch can fire again. We snapshot the raw input rather than
+  // the token-denominated `amount` so an async price load / account switch that
+  // moves the derived value (without any user edit) can't silently release the
+  // lock and undo the user's manual choice.
+  const manualSwitchSnapshotRef = useRef<{
+    amount: string;
+    isUseFiat: boolean;
+  } | null>(null);
   // DeriveTypes we have auto-switched _away from_ in this form lifetime.
   // Used to prevent ping-ponging between two accounts as the user adjusts
   // the amount up and down.
@@ -181,6 +194,12 @@ export function useAutoSwitchDeriveType({
   // captured at effect-fire time and may be stale by resolution).
   const amountRef = useRef(amount);
   amountRef.current = amount;
+  // Mirror the raw input + mode for the manual-switch detection effect, which
+  // snapshots them synchronously when an external account change is observed.
+  const userInputAmountRef = useRef(userInputAmount);
+  userInputAmountRef.current = userInputAmount;
+  const isUseFiatRef = useRef(isUseFiat);
+  isUseFiatRef.current = isUseFiat;
   // Mirrors `enabled` so the async closure can detect a mid-flight disable
   // (e.g. user enabled coin-control during the fetch). The main effect
   // early-returns on `!enabled` without incrementing the generation, so
@@ -220,15 +239,36 @@ export function useAutoSwitchDeriveType({
       lastAutoSwitchAccountIdRef.current = null;
     } else {
       userManuallySwitchedRef.current = true;
-      // Snapshot the live amount so the main effect can detect the next
-      // keystroke as the trigger to re-engage auto-switch.
-      manualSwitchAtAmountRef.current = amountRef.current;
+      // Snapshot the live raw input + mode so the main effect can detect the
+      // next real edit as the trigger to re-engage auto-switch.
+      manualSwitchSnapshotRef.current = {
+        amount: userInputAmountRef.current,
+        isUseFiat: isUseFiatRef.current,
+      };
       // Hide the auto-switch alert if user picked a different format
       // (including reverting back to the original).
       setAutoSwitchInfo(null);
     }
     previousAccountIdRef.current = currentAccountId;
   }, [currentAccountId]);
+
+  // A pure fiat/token display toggle re-derives the raw input's representation
+  // (e.g. "10" fiat ↔ "5" token) without being a real amount edit. When a
+  // manual lock is held, re-baseline its snapshot to the new mode's raw input
+  // so the toggle isn't mistaken for an edit (which would release the lock) yet
+  // a later genuine edit in the new mode is still detected. Declared before the
+  // main effect so the snapshot is up to date by the time that effect reads it.
+  const prevIsUseFiatRef = useRef(isUseFiat);
+  useEffect(() => {
+    if (prevIsUseFiatRef.current === isUseFiat) return;
+    prevIsUseFiatRef.current = isUseFiat;
+    if (userManuallySwitchedRef.current && manualSwitchSnapshotRef.current) {
+      manualSwitchSnapshotRef.current = {
+        amount: userInputAmountRef.current,
+        isUseFiat,
+      };
+    }
+  }, [isUseFiat]);
 
   useEffect(() => {
     if (!enabled) {
@@ -259,29 +299,41 @@ export function useAutoSwitchDeriveType({
       return;
     }
     if (userManuallySwitchedRef.current) {
-      // Stay locked until the live amount differs from the snapshot taken at
-      // the manual switch; only then treat it as a fresh evaluation and clear
-      // the lock, the tried-set, and the "all formats short" threshold.
+      // Stay locked until the user's raw input differs from the snapshot taken
+      // at the manual switch; only then treat it as a fresh evaluation and
+      // clear the lock, the tried-set, and the "all formats short" threshold.
       //
-      // `amount` is always token-denominated (see `autoSwitchAmount` at the
-      // call site), but its representation differs across a fiat/token display
-      // toggle — token mode passes the raw input, fiat mode the re-derived
-      // value — so the same amount can read as "1.0" vs "1". Compare
-      // numerically so a display toggle isn't mistaken for a real edit;
-      // the string check is a fast path that also keeps empty/empty equal.
-      const snapshot = manualSwitchAtAmountRef.current;
+      // We compare the raw input (`userInputAmount`), not the token-denominated
+      // `amount`: the latter is re-derived from price in fiat mode, so an async
+      // price load or account switch would move it with no user action and
+      // falsely release the lock. The raw input only changes on a real edit.
+      const snapshot = manualSwitchSnapshotRef.current;
+      // Defensive: the toggle effect re-baselines on a mode flip, so by here
+      // the snapshot mode normally matches. If it lags (effect ordering), a
+      // mode mismatch means the difference is a pure display toggle, not an
+      // edit — re-baseline and stay locked instead of reading it as an edit.
+      if (snapshot !== null && snapshot.isUseFiat !== isUseFiat) {
+        manualSwitchSnapshotRef.current = {
+          amount: userInputAmount,
+          isUseFiat,
+        };
+        return;
+      }
       // `sameAmount` requires a non-null snapshot, so the numeric compare can
       // never read a null snapshot as 0 (which would hold the lock forever at
-      // amount '0'); the null case is handled by the early return.
+      // amount '0'); the null case is handled by the early return. The string
+      // check is a fast path that also keeps empty/empty equal.
       const sameAmount =
         snapshot !== null &&
-        (amount === snapshot ||
-          new BigNumber(amount || 0).isEqualTo(new BigNumber(snapshot || 0)));
+        (userInputAmount === snapshot.amount ||
+          new BigNumber(userInputAmount || 0).isEqualTo(
+            new BigNumber(snapshot.amount || 0),
+          ));
       if (snapshot === null || sameAmount) {
         return;
       }
       userManuallySwitchedRef.current = false;
-      manualSwitchAtAmountRef.current = null;
+      manualSwitchSnapshotRef.current = null;
       triedDeriveTypesRef.current.clear();
       setAllFormatsInsufficientAmount(null);
     }
@@ -387,6 +439,8 @@ export function useAutoSwitchDeriveType({
     isCurrentBalanceLoaded,
     currentMaxBalance,
     amount,
+    userInputAmount,
+    isUseFiat,
     currentAccountId,
     currentDeriveType,
     currentDeriveInfo,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55640](https://onekeyhq.atlassian.net/browse/OK-55640) [OK-55641](https://onekeyhq.atlassian.net/browse/OK-55641) [OK-55683](https://onekeyhq.atlassian.net/browse/OK-55683)

----------

<!-- github-pr-monitor:jira-links:end -->


## Background

Follow-up fixes for the BTC "auto-switch derive type" feature (OK-54146), plus a related amount-input flicker fix.

Jira:
- https://onekeyhq.atlassian.net/browse/OK-55640
- https://onekeyhq.atlassian.net/browse/OK-55641
- https://onekeyhq.atlassian.net/browse/OK-55683

## Changes

### OK-55640 — Trigger auto-switch on fiat input too
Previously only typing a token amount triggered auto-switch; typing in fiat did not. In fiat mode we now feed the converted token amount (`linkedAmount.originalAmount`) to the hook (the hook stays unit-agnostic and compares against sibling token balances), and only enable it when a usable price is available.

### OK-55641 — Re-surface the "no format has enough" warning after a switch
Once an "auto-switched to X" banner had been shown, bumping the amount past every derive type no longer surfaced the all-formats-insufficient warning — `autoSwitchInfo` out-ranked it in the render. We now clear that stale banner once no sibling can cover the amount (only when every sibling was fetched successfully, so a transient RPC error is not mistaken for "no funds").

### OK-55683 — Stop the amount-error flicker while typing/deleting
On mobile, deleting the amount through transient values ("0.000", below-min, empty) flashed the red "cannot send 0" / minimum-amount errors and the neutral hint flickered with them. The amount error display is now debounced (400ms via the shared `useDebounce`): validation still runs live (submit stays gated), but the Field shows the neutral hint in place of the red error until the input settles.

### Consistency hardening (found during review)
- `isInsufficientBalance` (fiat) judges on the floored token amount actually submitted (same basis as validation and the sibling comparison), removing the sub-unit-boundary mismatch; an unusable price is treated as insufficient so the form stays blocked.
- The manual-switch lock compares amounts numerically, so a pure fiat/token display toggle no longer lifts it and undoes a hand-picked derive type.
- Extracted a single `hasUsablePrice` memo to consolidate the price-availability checks.

## Testing
- [x] `tsc` / `eslint` (incl. prettier)
- [x] `useAutoSwitchDeriveType.test.ts` (10 `pickBestSibling` cases)
- Suggested manual checks:
  1. Fiat input triggers auto-switch.
  2. After a switch, increasing the amount surfaces the all-formats warning.
  3. Entering fiat mode on a token with no price → submit button disabled.
  4. Manual switch with an empty amount, then toggle the display unit → not auto-switched away.
  5. BTC mobile: delete the amount down to 0 / type a below-min value → no red flicker; the error appears only after input settles.
  6. Price briefly drops to 0 then restores → no stuck/incorrect auto-switch state.
  7. Lightning fiat (sats / BTC) unit consistency.

## Self-review
- No secrets/auth/crypto/dependency changes; import hierarchy respected.
- Multiple rounds of `1k-code-review-pr` (with Codex cross-validation) + `/simplify`; review caught and fixed a fund-safety regression introduced mid-review (the price=0 fiat gate), and the flicker fix reuses the shared `useDebounce` hook instead of a hand-rolled timer.

[OK-55640]: https://onekeyhq.atlassian.net/browse/OK-55640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55641]: https://onekeyhq.atlassian.net/browse/OK-55641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55683]: https://onekeyhq.atlassian.net/browse/OK-55683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ