### PR TITLE
fix: hide MEV badge for gas-account transactions(OK-55649)

### DIFF
--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmHeader/TxConfirmHeaderRight.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmHeader/TxConfirmHeaderRight.tsx
@@ -28,8 +28,9 @@ function TxConfirmHeaderRight(props: {
   decodedTxs: IDecodedTx[] | undefined;
   unsignedTxs: IUnsignedTxPro[] | undefined;
   effectiveFeePayer?: IGasPayer;
+  txFeeInfoInit?: boolean;
 }) {
-  const { decodedTxs, unsignedTxs, effectiveFeePayer } = props;
+  const { decodedTxs, unsignedTxs, effectiveFeePayer, txFeeInfoInit } = props;
   const intl = useIntl();
   const { gtMd } = useMedia();
   const theme = useThemeName();
@@ -38,6 +39,15 @@ function TxConfirmHeaderRight(props: {
 
   const mevProtectionProvider = useMemo(() => {
     if (!unsignedTxs) return null;
+
+    // Wait until fee info is initialized before deciding on the badge.
+    // `effectiveFeePayer` defaults to `'user'` and is only updated once the
+    // async fee estimation completes, so rendering the badge earlier would
+    // briefly show MEV for sponsored txs (and could leak the previous tx's
+    // payer in queue mode). Hiding it until init avoids that flicker.
+    if (!txFeeInfoInit) {
+      return null;
+    }
 
     // Hide the MEV badge whenever the fee is sponsored (gas account or BNB
     // gas-free / megafuel). Sponsored transactions are relayed through a
@@ -87,6 +97,7 @@ function TxConfirmHeaderRight(props: {
     unsignedTxs,
     decodedTx?.txDisplay?.mevProtectionProvider,
     effectiveFeePayer,
+    txFeeInfoInit,
   ]);
 
   const imageUri = useMemo(() => {
@@ -116,6 +127,10 @@ function TxConfirmHeaderRight(props: {
           });
         }
       });
+    } else {
+      // Reset stale size when the badge is hidden so a later provider with a
+      // different logo does not render with the previous provider's dimensions.
+      setProviderImageSize(undefined);
     }
   }, [imageUri]);
 

--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmHeader/TxConfirmHeaderRight.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmHeader/TxConfirmHeaderRight.tsx
@@ -39,12 +39,15 @@ function TxConfirmHeaderRight(props: {
   const mevProtectionProvider = useMemo(() => {
     if (!unsignedTxs) return null;
 
-    // Hide the MEV badge only when the fee is paid by a gas account. Gas
-    // account transactions are relayed through a quote-bound RPC rather than
-    // the MEV-protected RPC, so the badge would be misleading. BNB gas-free
-    // (megafuel) transactions are still broadcast through the MEV-protected
-    // RPC, so the badge must remain for them.
-    if (effectiveFeePayer === 'gasAccount') {
+    // Hide the MEV badge whenever the fee is sponsored (gas account or BNB
+    // gas-free / megafuel). Sponsored transactions are relayed through a
+    // sponsor-bound RPC rather than the MEV-protected RPC, so the badge would
+    // be misleading. Only user-paid transactions go through the MEV-protected
+    // RPC and keep the badge.
+    if (
+      effectiveFeePayer === 'gasAccount' ||
+      effectiveFeePayer === 'megafuel'
+    ) {
       return null;
     }
 

--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmHeader/TxConfirmHeaderRight.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmHeader/TxConfirmHeaderRight.tsx
@@ -17,6 +17,7 @@ import {
 import type { IUnsignedTxPro } from '@onekeyhq/core/src/types';
 import { getNetworksSupportMevProtection } from '@onekeyhq/shared/src/config/presetNetworks';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type { IGasPayer } from '@onekeyhq/shared/types/fee';
 import type { IDecodedTx } from '@onekeyhq/shared/types/tx';
 
 const mevProtectionProviders = getNetworksSupportMevProtection();
@@ -26,8 +27,9 @@ const DEFAULT_IMAGE_HEIGHT = 40;
 function TxConfirmHeaderRight(props: {
   decodedTxs: IDecodedTx[] | undefined;
   unsignedTxs: IUnsignedTxPro[] | undefined;
+  effectiveFeePayer?: IGasPayer;
 }) {
-  const { decodedTxs, unsignedTxs } = props;
+  const { decodedTxs, unsignedTxs, effectiveFeePayer } = props;
   const intl = useIntl();
   const { gtMd } = useMedia();
   const theme = useThemeName();
@@ -36,6 +38,15 @@ function TxConfirmHeaderRight(props: {
 
   const mevProtectionProvider = useMemo(() => {
     if (!unsignedTxs) return null;
+
+    // Hide the MEV badge only when the fee is paid by a gas account. Gas
+    // account transactions are relayed through a quote-bound RPC rather than
+    // the MEV-protected RPC, so the badge would be misleading. BNB gas-free
+    // (megafuel) transactions are still broadcast through the MEV-protected
+    // RPC, so the badge must remain for them.
+    if (effectiveFeePayer === 'gasAccount') {
+      return null;
+    }
 
     const unsignedTx = unsignedTxs[0];
 
@@ -69,7 +80,11 @@ function TxConfirmHeaderRight(props: {
         ];
       }
     }
-  }, [unsignedTxs, decodedTx?.txDisplay?.mevProtectionProvider]);
+  }, [
+    unsignedTxs,
+    decodedTx?.txDisplay?.mevProtectionProvider,
+    effectiveFeePayer,
+  ]);
 
   const imageUri = useMemo(() => {
     if (!mevProtectionProvider) {

--- a/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
+++ b/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
@@ -14,6 +14,7 @@ import {
   useDecodedTxsInitAtom,
   useEffectiveFeePayerAtom,
   useSignatureConfirmActions,
+  useTxFeeInfoInitAtom,
   useUnsignedTxsAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/signatureConfirm';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -89,6 +90,7 @@ function TxConfirm() {
   const [reactiveUnsignedTxs] = useUnsignedTxsAtom();
   const [decodedTxsInit] = useDecodedTxsInitAtom();
   const [effectiveFeePayer] = useEffectiveFeePayerAtom();
+  const [txFeeInfoInit] = useTxFeeInfoInitAtom();
   const txConfirmParamsInit = useRef(false);
   const visitReceiveSelectorRef = useRef<boolean>(false);
 
@@ -451,9 +453,10 @@ function TxConfirm() {
         decodedTxs={decodedTxs}
         unsignedTxs={unsignedTxs}
         effectiveFeePayer={effectiveFeePayer}
+        txFeeInfoInit={txFeeInfoInit}
       />
     ),
-    [decodedTxs, unsignedTxs, effectiveFeePayer],
+    [decodedTxs, unsignedTxs, effectiveFeePayer, txFeeInfoInit],
   );
 
   return (

--- a/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
+++ b/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
@@ -12,6 +12,7 @@ import useDappApproveAction from '@onekeyhq/kit/src/hooks/useDappApproveAction';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import {
   useDecodedTxsInitAtom,
+  useEffectiveFeePayerAtom,
   useSignatureConfirmActions,
   useUnsignedTxsAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/signatureConfirm';
@@ -87,6 +88,7 @@ function TxConfirm() {
   const [settings] = useSettingsPersistAtom();
   const [reactiveUnsignedTxs] = useUnsignedTxsAtom();
   const [decodedTxsInit] = useDecodedTxsInitAtom();
+  const [effectiveFeePayer] = useEffectiveFeePayerAtom();
   const txConfirmParamsInit = useRef(false);
   const visitReceiveSelectorRef = useRef<boolean>(false);
 
@@ -445,9 +447,13 @@ function TxConfirm() {
 
   const renderHeaderRight = useCallback(
     () => (
-      <TxConfirmHeaderRight decodedTxs={decodedTxs} unsignedTxs={unsignedTxs} />
+      <TxConfirmHeaderRight
+        decodedTxs={decodedTxs}
+        unsignedTxs={unsignedTxs}
+        effectiveFeePayer={effectiveFeePayer}
+      />
     ),
-    [decodedTxs, unsignedTxs],
+    [decodedTxs, unsignedTxs, effectiveFeePayer],
   );
 
   return (


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55649](https://onekeyhq.atlassian.net/browse/OK-55649)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Hide the MEV-protection badge in the tx confirm header when the fee is paid by a gas account.
- Thread the authoritative `effectiveFeePayer` display signal into `TxConfirmHeaderRight` and short-circuit the badge for `'gasAccount'`.
- BNB gas-free (megafuel) transactions are unaffected — the badge still shows for them.

## Intent & Context
The MEV-protection badge was rendering in the signature-confirm header even for gas-account-paid transactions. That is misleading: gas account transactions are relayed through a quote-bound RPC (attached `quoteId` / `idempotencyKey`), not the MEV-protected RPC, so they are not actually MEV-protected. The badge should only appear when the transaction really is broadcast through the MEV-protected path.

## Root Cause
The badge's visibility (`mevProtectionProvider` memo in `TxConfirmHeaderRight`) was derived only from `unsignedTx.disableMev`, the server-provided `decodedTx.txDisplay.mevProtectionProvider`, and a swap-receiver-network lookup. None of those reflect the *fee payer*. When a gas account pays, the broadcast is rerouted by `quoteId` independent of the anti-MEV flag, so the existing inputs still resolved a provider and the badge stayed visible.

## Design Decisions
- **Gate on `effectiveFeePayer`, not `disableMev`.** `disableMev` is the broadcast/RPC-routing (security) flag and is orthogonal to who pays the fee — folding gas-account logic into it would corrupt the broadcast contract. `effectiveFeePayer` is the codebase's documented *display* authority (drives sponsor badges, free copy, fee hiding), making it the correct seam for a display-only rule. This is consistent with existing `effectiveFeePayer === 'gasAccount'` checks in `TxFeeInfo` and `TxConfirmActions`.
- **Only `'gasAccount'` hides the badge; `'megafuel'` does not.** BNB gas-free (megafuel) transactions are still broadcast through the MEV-protected RPC, so the badge must remain for them.
- **Pass `effectiveFeePayer` as a prop instead of reading the atom in the header.** `TxConfirmHeaderRight` is rendered via `Page.Header`'s `headerRight`, which mounts at the navigator level — outside the `SignatureConfirmProviderMirror`. A direct `useEffectiveFeePayerAtom()` read there would return the context default (`'user'`), so the value is read in `TxConfirm` (inside the provider) and threaded down.

## Changes Detail
- `TxConfirmHeaderRight.tsx`: add optional `effectiveFeePayer?: IGasPayer` prop; early-return `null` from the `mevProtectionProvider` memo when payer is `'gasAccount'`; add it to the memo deps.
- `TxConfirm.tsx`: read `useEffectiveFeePayerAtom()` and pass `effectiveFeePayer` into `TxConfirmHeaderRight` via `renderHeaderRight`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web (shared kit UI)
- **Risk Areas**: Display-only change; no broadcast, signing, or RPC-routing behavior is altered. The only logic is hiding a header badge based on the existing display-authority atom.

## Test plan
- [ ] Build a swap/transaction on an MEV-supported network with the fee paid by a **gas account** → MEV badge is hidden in the tx confirm header.
- [ ] Same transaction with the fee paid by the user (native fee) → MEV badge still shows.
- [ ] BNB gas-free (megafuel) sponsored transaction → MEV badge still shows.
- [ ] Verify on Mobile, Desktop, and Extension.

[OK-55649]: https://onekeyhq.atlassian.net/browse/OK-55649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ