### PR TITLE
fix: suppress swap stock check detail toast(OK-55668)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -15,6 +15,7 @@ import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import type { IEventSourceMessageEvent } from '@onekeyhq/shared/src/eventSource';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { memoFn } from '@onekeyhq/shared/src/utils/cacheUtils';
@@ -1406,13 +1407,23 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       )
       .then((tokenDetail) => {
         if (tokenDetail?.code !== 0 || !tokenDetail?.data?.token) {
-          throw new OneKeyLocalError('Market token detail is not available');
+          throw new OneKeyLocalError(
+            `Market token detail is not available: ${
+              tokenDetail?.code ?? 'empty'
+            }`,
+          );
         }
         return isUSMarketStatusStockTokenSource(
           tokenDetail.data.token.stock?.source,
         );
       })
-      .catch(() => {
+      .catch((error) => {
+        defaultLogger.swap.stockTokenCheck.stockTokenCheckUnavailable({
+          cacheKey,
+          networkId: token.networkId,
+          tokenSymbol: token.symbol,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
         this.stockTokenCheckCache.delete(cacheKey);
         return false;
       });

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -11,6 +11,7 @@ import {
 } from '@onekeyhq/kit/src/views/Swap/utils/usMarketStatusUtils';
 import { moveNetworkToFirst } from '@onekeyhq/kit/src/views/Swap/utils/utils';
 import { settingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import type { IEventSourceMessageEvent } from '@onekeyhq/shared/src/eventSource';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
@@ -1399,12 +1400,18 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       .fetchMarketTokenDetailByTokenAddress(
         token.contractAddress,
         token.networkId,
+        {
+          autoHandleError: false,
+        },
       )
-      .then((tokenDetail) =>
-        isUSMarketStatusStockTokenSource(
-          tokenDetail?.data?.token?.stock?.source,
-        ),
-      )
+      .then((tokenDetail) => {
+        if (tokenDetail?.code !== 0 || !tokenDetail?.data?.token) {
+          throw new OneKeyLocalError('Market token detail is not available');
+        }
+        return isUSMarketStatusStockTokenSource(
+          tokenDetail.data.token.stock?.source,
+        );
+      })
       .catch(() => {
         this.stockTokenCheckCache.delete(cacheKey);
         return false;

--- a/packages/shared/src/logger/scopes/swap/index.ts
+++ b/packages/shared/src/logger/scopes/swap/index.ts
@@ -7,6 +7,7 @@ import { CreateOrderScene } from './scenes/createOrder';
 import { EnterSwapScene } from './scenes/enterSwap';
 import { ProviderChangeScene } from './scenes/providerChange';
 import { SelectTokenScene } from './scenes/selectToken';
+import { StockTokenCheckScene } from './scenes/stockTokenCheck';
 import { SwapEstimateFeeScene } from './scenes/swapEstimateFee';
 import { SwapKlineScene } from './scenes/swapKline';
 import { SwapQuoteScene } from './scenes/swapQuote';
@@ -42,6 +43,8 @@ export class SwapScope extends BaseScope {
   swapEstimateFee = this.createScene('swapEstimateFee', SwapEstimateFeeScene);
 
   swapKline = this.createScene('swapKline', SwapKlineScene);
+
+  stockTokenCheck = this.createScene('stockTokenCheck', StockTokenCheckScene);
 
   swapSendTx = this.createScene('swapSendTx', SwapSendTxScene);
 

--- a/packages/shared/src/logger/scopes/swap/scenes/stockTokenCheck.ts
+++ b/packages/shared/src/logger/scopes/swap/scenes/stockTokenCheck.ts
@@ -1,0 +1,16 @@
+import { BaseScene } from '../../../base/baseScene';
+import { LogToLocal } from '../../../base/decorators';
+
+interface IStockTokenCheckUnavailableParams {
+  cacheKey: string;
+  networkId: string;
+  tokenSymbol?: string;
+  errorMessage?: string;
+}
+
+export class StockTokenCheckScene extends BaseScene {
+  @LogToLocal({ level: 'debug' })
+  public stockTokenCheckUnavailable(params: IStockTokenCheckUnavailableParams) {
+    return params;
+  }
+}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55668](https://onekeyhq.atlassian.net/browse/OK-55668)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Suppress auto-handled server toasts for the Swap stock-token detection request.
- Treat non-zero market token detail responses as unavailable and avoid caching failed stock checks.
- Keep the existing fallback behavior: failed stock detection resolves to non-stock for the optional US market closed warning.

## Intent & Context
OK-55668 reports that opening the Swap K-line chart for the HyperEVM USD₮0 -> USDC pair renders the chart, but closing the modal shows a generic `Something went wrong. Try again.` toast from `/utility/v2/market/token/detail`.

The user observed that the error appears on modal close, not while the chart is open. Runtime CDP tracing on the local desktop dev app confirmed that the K-line header detail request is already silent, while closing the modal triggers Swap warning refreshes that call token detail for both selected tokens.

## Root Cause
`checkSwapWarning` refreshes after returning to the Swap page and calls `checkSwapPairUSMarketClosed`. That helper calls `checkSwapTokenIsStock` for the from/to tokens to decide whether to show a US market closed warning.

`checkSwapTokenIsStock` already catches failures and returns `false`, but the request used the default `autoHandleError: true`. When the backend returned `code: 30011`, the axios interceptor emitted the global toast before the local catch converted the result to `false`.

## Design Decisions
- This request is optional warning metadata, not the Swap quote or execution path, so it should not show a generic backend error toast.
- Use `autoHandleError: false` only for this stock detection request to keep the change narrow.
- Explicitly throw `OneKeyLocalError` for non-zero code or missing token data so the existing catch clears the cache and returns `false`; this prevents transient backend failures from being cached as stable non-stock results.

## Changes Detail
- `packages/kit/src/states/jotai/contexts/swap/actions.ts`
  - Passes `autoHandleError: false` to `fetchMarketTokenDetailByTokenAddress` inside `checkSwapTokenIsStock`.
  - Validates the silent response before reading `token.stock.source`.
  - Keeps the existing catch path that deletes the cache entry and returns `false`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop, Web, Extension, Mobile Swap flows that run the same Jotai Swap warning logic
- **Risk Areas**: US market closed warning detection for stock tokens when token-detail metadata is unavailable. The previous behavior already returned `false` after catch; this change only removes the misleading global toast and avoids caching failed responses.

## Test plan
- [x] Runtime CDP trace on local desktop dev app: reproduced the close-modal toast and confirmed the failing requests are triggered after returning to Swap via `checkSwapWarning` stock detection.
- [x] `yarn lint:staged`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/states/jotai/contexts/swap/actions.ts --deny-warnings`
- [x] `git diff --check`
- [ ] `yarn tsc:staged` currently fails on existing unrelated `@onekeyfe/hwk-adapter-core` / Ledger adapter type drift in hardware files, not in this change.

[OK-55668]: https://onekeyhq.atlassian.net/browse/OK-55668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ