### PR TITLE
chore: remove react-render-tracker; bound dbPerfMonitor recent-calls

### DIFF
--- a/apps/ext/src/manifest/common.js
+++ b/apps/ext/src/manifest/common.js
@@ -1,7 +1,7 @@
 const isDev = process.env.NODE_ENV !== 'production';
 const isManifestV3 = !!process.env.EXT_MANIFEST_V3;
 const isPerfMonitorEnabled = process.env.PERF_MONITOR_ENABLED === '1';
-// for react-render-tracker.js
+// dev-only CSP relaxations (eval/inline for HMR & dev tooling)
 const devCSP = [
   "'unsafe-eval'",
   "'unsafe-inline'",

--- a/development/rspack/rspack.development.config.ts
+++ b/development/rspack/rspack.development.config.ts
@@ -57,36 +57,6 @@ export function createDevelopmentConfig({
       //     next();
       //   });
 
-      //   // proxy react-render-tracker
-      //   devServer.app.get(
-      //     '/react-render-tracker@0.7.3/dist/react-render-tracker.js',
-      //     (req, res) => {
-      //       const sendResponse = (text: string) => {
-      //         res.setHeader(
-      //           'Cache-Control',
-      //           'no-store, no-cache, must-revalidate, proxy-revalidate',
-      //         );
-      //         res.setHeader('Age', '0');
-      //         res.setHeader('Expires', '0');
-      //         res.setHeader('Content-Type', 'text/javascript');
-      //         res.write(text);
-      //         res.end();
-      //       };
-      //       const filePath = path.join(
-      //         __dirname,
-      //         '../../node_modules/react-render-tracker/dist/react-render-tracker.js',
-      //       );
-      //       fs.readFile(filePath, 'utf8', (err, data) => {
-      //         if (err) {
-      //           console.error(err);
-      //           res.status(500).send(`Error reading file:  ${filePath}`);
-      //           return;
-      //         }
-      //         sendResponse(data);
-      //       });
-      //     },
-      //   );
-
       //   return middlewares;
       // },
     } as RspackOptions['devServer'],

--- a/development/webpack/ext/htmlLazyScript.js
+++ b/development/webpack/ext/htmlLazyScript.js
@@ -33,10 +33,7 @@ function doTaskInFolder({ folder }) {
     $('html head script').each((idx, ele) => {
       const $ele = $(ele);
       const src = $ele.attr('src');
-      if (
-        !src.includes('preload-html-head.js') &&
-        !src.includes('react-render-tracker')
-      ) {
+      if (!src.includes('preload-html-head.js')) {
         srcList.push(src);
         $ele.remove();
       }

--- a/development/webpack/webpack.development.config.js
+++ b/development/webpack/webpack.development.config.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const path = require('path');
 
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');

--- a/development/webpack/webpack.development.config.js
+++ b/development/webpack/webpack.development.config.js
@@ -49,37 +49,6 @@ module.exports = ({ basePath }) => ({
         }
         next();
       });
-
-      // proxy react-render-tracker
-      devServer.app.get(
-        '/react-render-tracker@0.7.3/dist/react-render-tracker.js',
-        (req, res) => {
-          const sendResponse = (text) => {
-            res.setHeader(
-              'Cache-Control',
-              'no-store, no-cache, must-revalidate, proxy-revalidate',
-            );
-            res.setHeader('Age', '0');
-            res.setHeader('Expires', '0');
-            res.setHeader('Content-Type', 'text/javascript');
-            res.write(text);
-            res.end();
-          };
-          // read node_modules/react-render-tracker/dist/react-render-tracker.js content
-          const filePath = path.join(
-            __dirname,
-            '../../node_modules/react-render-tracker/dist/react-render-tracker.js',
-          );
-          fs.readFile(filePath, 'utf8', (err, data) => {
-            if (err) {
-              console.error(err);
-              res.status(500).send(`Error reading file:  ${filePath}`);
-              return;
-            }
-            sendResponse(data);
-          });
-        },
-      );
     },
   },
   cache: {

--- a/package.json
+++ b/package.json
@@ -229,7 +229,6 @@
     "react-native-screens": "4.23.0",
     "react-native-web": "0.21.2",
     "react-native-worklets": "0.7.1",
-    "react-render-tracker": "^0.7.6",
     "react-router-dom": "^7.12.0",
     "react-virtualized": "^9.22.6",
     "rlp": "^3.0.0",

--- a/packages/kit/src/components/AccountSelector/AccountSelectorActiveAccount.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorActiveAccount.tsx
@@ -89,6 +89,7 @@ const AllNetworkAccountSelector = ({
       placement="bottom"
       renderTrigger={
         <XStack
+          testID="account-selector-copy-address-btn"
           gap="$2"
           p="$1"
           m="$-1"

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/NavigatorRoute/Tab/View/DemoRootHome.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/NavigatorRoute/Tab/View/DemoRootHome.tsx
@@ -1,12 +1,8 @@
-import { useCallback, useLayoutEffect, useState } from 'react';
+import { useCallback, useLayoutEffect } from 'react';
 
 import { Button, SizableText, Stack, YStack } from '@onekeyhq/components';
 import type { IPageNavigationProp } from '@onekeyhq/components/src/layouts/Navigation';
 import HeaderIconButton from '@onekeyhq/components/src/layouts/Navigation/Header/HeaderIconButton';
-import useCookie from '@onekeyhq/kit/src/hooks/useCookie';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import appStorage from '@onekeyhq/shared/src/storage/appStorage';
-import { EAppSyncStorageKeys } from '@onekeyhq/shared/src/storage/syncStorage';
 
 import { Layout } from '../../../utils/Layout';
 import { NavigationFocusTools } from '../../../utils/NavigationTools';
@@ -16,25 +12,9 @@ import { EDemoHomeTabRoutes } from '../Routes';
 
 import type { IDemoHomeTabParamList } from '../RouteParamTypes';
 
-const useStorage = platformEnv.isNative
-  ? (key: EAppSyncStorageKeys, initialValue?: boolean) => {
-      const [data, setData] = useState(
-        initialValue || appStorage.syncStorage.getBoolean(key),
-      );
-      const setNewData = (value: boolean) => {
-        appStorage.syncStorage.set(key, value);
-        setData(value);
-      };
-      return [data, setNewData];
-    }
-  : useCookie;
-
 const DemoRootHome = () => {
   const navigation =
     useDemoAppNavigation<IPageNavigationProp<IDemoHomeTabParamList>>();
-
-  // @ts-expect-error
-  const [rrtStatus, changeRRTStatus] = useStorage(EAppSyncStorageKeys.rrt);
 
   const renderHeaderTitle = useCallback(
     () => (
@@ -143,37 +123,6 @@ const DemoRootHome = () => {
               <FreezeProbe componentName="DemoRootHome" />
               <NavigationFocusTools componentName="DemoRootHome" />
             </Stack>
-          ),
-        },
-        {
-          title: '开启 ReactRenderTracker',
-          element: (
-            <Button
-              onPress={() => {
-                if (platformEnv.isNative) {
-                  (changeRRTStatus as (value: boolean) => void)(!rrtStatus);
-                  alert('Please manually restart the app.');
-                } else {
-                  const status = rrtStatus === '1' ? '0' : '1';
-                  (changeRRTStatus as (value: string) => void)(status);
-                  if (platformEnv.isRuntimeBrowser) {
-                    if (status === '0') {
-                      localStorage.removeItem(
-                        '$$OnekeyReactRenderTrackerEnabled',
-                      );
-                    } else {
-                      localStorage.setItem(
-                        '$$OnekeyReactRenderTrackerEnabled',
-                        'true',
-                      );
-                    }
-                  }
-                  globalThis.location.reload();
-                }
-              }}
-            >
-              开关 ReactRenderTracker
-            </Button>
           ),
         },
       ]}

--- a/packages/kit/src/views/Developer/pages/TabDeveloper.tsx
+++ b/packages/kit/src/views/Developer/pages/TabDeveloper.tsx
@@ -26,31 +26,15 @@ import {
   ETabDeveloperRoutes,
   ETabRoutes,
 } from '@onekeyhq/shared/src/routes';
-import appStorage from '@onekeyhq/shared/src/storage/appStorage';
-import { EAppSyncStorageKeys } from '@onekeyhq/shared/src/storage/syncStorage';
 import extUtils, { EXT_HTML_FILES } from '@onekeyhq/shared/src/utils/extUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { AccountSelectorProviderMirror } from '../../../components/AccountSelector';
 import useAppNavigation from '../../../hooks/useAppNavigation';
-import useCookie from '../../../hooks/useCookie';
 import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector';
 import { useV4MigrationActions } from '../../Onboarding/pages/V4Migration/hooks/useV4MigrationActions';
 import { DeveloperTestIDs } from '../testIDs';
-
-const useStorage = platformEnv.isNative
-  ? (key: EAppSyncStorageKeys, initialValue?: boolean) => {
-      const [data, setData] = useState(
-        initialValue || appStorage.syncStorage.getBoolean(key),
-      );
-      const setNewData = (value: boolean) => {
-        appStorage.syncStorage.set(key, value);
-        setData(value);
-      };
-      return [data, setNewData];
-    }
-  : useCookie;
 
 function PartContainer({
   title,
@@ -187,9 +171,6 @@ const TabDeveloper = () => {
   const navigation =
     useAppNavigation<IPageNavigationProp<ITabDeveloperParamList>>();
 
-  // @ts-expect-error
-  const [rrtStatus, changeRRTStatus] = useStorage(EAppSyncStorageKeys.rrt);
-
   return (
     <AccountSelectorProviderMirror
       config={{
@@ -251,45 +232,6 @@ const TabDeveloper = () => {
             </PartContainer>
 
             <PartContainer title="Debug Tools">
-              <Button
-                onPress={() => {
-                  if (platformEnv.isNative) {
-                    (changeRRTStatus as (value: boolean) => void)(!rrtStatus);
-                    alert('Please manually restart the app.');
-                  } else {
-                    const status = rrtStatus === '1' ? '0' : '1';
-                    (changeRRTStatus as (value: string) => void)(status);
-                    if (platformEnv.isRuntimeBrowser) {
-                      if (status === '0') {
-                        localStorage.removeItem(
-                          '$$OnekeyReactRenderTrackerEnabled',
-                        );
-                      } else {
-                        localStorage.setItem(
-                          '$$OnekeyReactRenderTrackerEnabled',
-                          'true',
-                        );
-                      }
-                    }
-                    globalThis.location.reload();
-                  }
-                }}
-              >
-                {platformEnv.isNative ? (
-                  <>
-                    {rrtStatus
-                      ? 'Disabled react-render-tracker'
-                      : 'Enabled react-render-tracker'}
-                  </>
-                ) : (
-                  <>
-                    {rrtStatus === '1'
-                      ? 'Disabled react-render-tracker'
-                      : 'Enabled react-render-tracker'}
-                  </>
-                )}
-              </Button>
-
               {platformEnv.isSupportDesktopBle ? (
                 <Button
                   onPress={async () => {

--- a/packages/shared/src/storage/syncStorageKeys.ts
+++ b/packages/shared/src/storage/syncStorageKeys.ts
@@ -2,7 +2,6 @@
 // development, but some (e.g. onekey_pending_install_task) are used in
 // production on mobile/desktop.
 export enum EAppSyncStorageKeys {
-  rrt = 'rrt',
   perf_switch = 'perf_switch',
   onekey_webembed_config = 'onekey_webembed_config',
   onekey_disable_bg_api_serializable_checking = 'onekey_disable_bg_api_serializable_checking',

--- a/packages/shared/src/utils/debug/dbPerfMonitor.ts
+++ b/packages/shared/src/utils/debug/dbPerfMonitor.ts
@@ -145,6 +145,19 @@ let localDbCallDetails: {
 
 let globalRecentCalls: Array<[string, string, any[]] | [string, string]> = [];
 
+// Bounded push for globalRecentCalls. Previously the array was only trimmed
+// inside the IDBDatabase.transaction wrapper, so simpleDb/appStorage calls (and
+// localDb reads between transactions) accumulated unbounded — each logLocalDbCall
+// entry retains a full captured call stack. On account switches over large
+// wallet sets this leaked millions of stack-trace objects and froze the renderer
+// (GC thrash). Trim on every push with a little headroom to amortize the splice.
+function pushRecentCall(entry: [string, string, any[]] | [string, string]) {
+  globalRecentCalls.push(entry);
+  if (globalRecentCalls.length > maxRecentCallsSize + 512) {
+    globalRecentCalls.splice(0, globalRecentCalls.length - maxRecentCallsSize);
+  }
+}
+
 let indexedDBResult: {
   [key: string]: number;
 } = {};
@@ -367,7 +380,7 @@ function logLocalDbCall(method: string, table: string, params: any[]) {
     }
     localDbCallDetails[method][table].total += 1;
 
-    globalRecentCalls.push([getNowString(), `${method}__${table}`, params]);
+    pushRecentCall([getNowString(), `${method}__${table}`, params]);
 
     if (
       shouldLocalDbDebuggerRule[`${method}__${table}`] &&
@@ -398,7 +411,7 @@ function logSimpleDbCall(method: string, entity: string) {
     simpleDbCallDetails[method].details[entity] += 1;
     simpleDbCallDetails[method].total += 1;
 
-    globalRecentCalls.push([getNowString(), `${method}__${entity}`]);
+    pushRecentCall([getNowString(), `${method}__${entity}`]);
   }
 }
 
@@ -418,7 +431,7 @@ function logAppStorageCall(method: string, key: string) {
     appStorageCallDetails[method].details[key] += 1;
     appStorageCallDetails[method].total += 1;
 
-    globalRecentCalls.push([getNowString(), `${method}__${key}`]);
+    pushRecentCall([getNowString(), `${method}__${key}`]);
 
     if (
       shouldLocalDbDebuggerRule[`${method}__${key}`] &&

--- a/packages/shared/src/web/index.html.ejs
+++ b/packages/shared/src/web/index.html.ejs
@@ -18,17 +18,6 @@
     />
     <title>OneKey</title>
     <meta name="theme-color" content="#ffffff" />
-      <% if ( isDev ) { %>
-        <script
-        <% if ( platform === 'ext'  ) { %>
-          src="http://localhost:3180/react-render-tracker@0.7.3/dist/react-render-tracker.js"
-        <% } else { %>
-          src="/react-render-tracker@0.7.3/dist/react-render-tracker.js"
-        <% } %>
-          data-config="inpage:false"
-        /></script>
-        <meta name="rempl:server" content="localhost:8177" />
-    <% } %>
     <style>
       /* add global styles to packages/shared/src/web/index.css */
     </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9792,7 +9792,6 @@ __metadata:
     react-native-web: "npm:0.21.2"
     react-native-worklets: "npm:0.7.1"
     react-refresh: "npm:^0.14.0"
-    react-render-tracker: "npm:^0.7.6"
     react-router-dom: "npm:^7.12.0"
     react-test-renderer: "npm:19.1.0"
     react-virtualized: "npm:^9.22.6"
@@ -42198,13 +42197,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/9fac79e1c2ed2c85729bfe82f61ef4ae5ce51f478736a13892a9a11e05cbd4e9599f9f0e012cb5fc0719e18dc1dd687ab61f516193228615df636db8b851245e
-  languageName: node
-  linkType: hard
-
-"react-render-tracker@npm:^0.7.6":
-  version: 0.7.6
-  resolution: "react-render-tracker@npm:0.7.6"
-  checksum: 10/dc998bc191e8c2e08e7840b61fb64e5f318a0510d3beedebd72f957207cff5723b6897aa3ddb6669fc82d610b410f93df301340dc2e59ca23547f442802ca52a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Two self-contained cleanups surfaced while investigating the desktop renderer memory growth. **Neither is the user-facing freeze fix** (log analysis points that at the home-page main-renderer RSS, tracked separately) — these are safe standalone improvements.

## 1. Remove react-render-tracker (`chore`)
`react-render-tracker` was an unused dev profiling tool that hooks React internals and **retains references to every mounted/unmounted component** for its render-tree UI, holding detached subtrees alive during profiling and inflating dev heap. Removed entirely:
- drop injected `<script>` + `rempl:server` meta from `index.html(.ejs)`
- remove the webpack dev-server proxy that served the bundle
- remove the Debug-Tools / Gallery toggle UI + now-dead `useStorage`/`useCookie`/`appStorage` glue + the `EAppSyncStorageKeys.rrt` key
- drop the dependency and stale ext CSP / `htmlLazyScript` references

OneKey's own `DebugRenderTracker` (`onekey_debug_render_tracker`) is unrelated and left intact.

## 2. Bound dbPerfMonitor recent-calls + copy-address testID (`fix(perf)`)
`dbPerfMonitor.globalRecentCalls` was only trimmed inside the `IDBDatabase.transaction` wrapper, so `simpleDb`/`appStorage` calls and `localDb` reads **between** transactions accumulated unbounded — each `logLocalDbCall` entry retains a full captured stack. Now bounded on every push (gated by dev / developer-mode, so no prod impact). Also adds a `testID` to the all-networks copy-address button for QA/CDP automation.

## Testing
- `yarn tsc` clean on touched files; dev build verified to boot without RRT.