### PR TITLE
fix: prioritize perps trading and portfolio context(OK-55444 OK-55688)

### DIFF
--- a/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
+++ b/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
@@ -22,6 +22,7 @@ import { LightweightChart } from '@onekeyhq/kit/src/components/LightweightChart'
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import { deferHeavyWorkUntilUIIdle } from '@onekeyhq/kit/src/utils/deferHeavyWork';
 import {
+  usePerpsActiveAccountAtom,
   usePerpsActiveAccountMmrAtom,
   usePerpsComputedAccountValueAtom,
   useSpotPairDisplayMapAtom,
@@ -40,7 +41,7 @@ import {
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { IMarketTokenChart } from '@onekeyhq/shared/types/market';
 
-import { usePerpsAccountScopedActivePositions } from '../../hooks/usePerpsAccountScopedActivePositions';
+import { usePerpsActivePositionsByAddress } from '../../hooks/usePerpsActivePositionsByAddress';
 import { useShowDepositWithdrawModal } from '../../hooks/useShowDepositWithdrawModal';
 import { PERP_DIALOG_BUTTON_SIZE } from '../PerpDialogLayout';
 
@@ -308,8 +309,11 @@ function PerpPortfolioContentComponent({
       },
     ];
   }, [intl]);
+  const [activeAccount] = usePerpsActiveAccountAtom();
   const [mmrData] = usePerpsActiveAccountMmrAtom();
-  const positionsLength = usePerpsAccountScopedActivePositions().length;
+  const positionsLength = usePerpsActivePositionsByAddress(
+    activeAccount?.accountAddress,
+  ).length;
 
   const [timePeriod, setTimePeriod] = useState<IPortfolioTimePeriod>('allTime');
   const [chartType, setChartType] =

--- a/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioModal.tsx
+++ b/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioModal.tsx
@@ -29,9 +29,7 @@ export function showPerpPortfolioDialog(
       // In-tab dialogs render through the IN_PAGE_TAB_CONTAINER portal at the
       // TabNavigator root, so they do NOT inherit the page/header providers.
       // Web-dapp /perps opens this from the header pill (no perps page tree), so
-      // the accountSelector context must be mirrored here too — PerpPortfolioContent
-      // reads useActiveAccount via usePerpsAccountScopedActivePositions. Mirror the
-      // native page nesting (PerpsAccountSelectorProviderMirror > PerpsProviderMirror).
+      // mirror the native page nesting for dialog flows started from this content.
       <PerpsAccountSelectorProviderMirror>
         <PerpsProviderMirror>
           <PerpPortfolioContent isMobile={false} />

--- a/packages/kit/src/views/Perp/hooks/usePerpsActivePositionsByAddress.test.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpsActivePositionsByAddress.test.ts
@@ -1,0 +1,56 @@
+/* eslint-disable import/first */
+
+import { renderHook } from '@testing-library/react-native';
+
+import { usePerpsActivePositionsByAddress } from './usePerpsActivePositionsByAddress';
+
+type IMockPosition = {
+  position: {
+    coin: string;
+  };
+};
+
+let mockPositionsAccountAddress: string | undefined;
+let mockPositions: IMockPosition[];
+
+jest.mock('@onekeyhq/kit/src/states/jotai/contexts/hyperliquid', () => ({
+  usePerpsActivePositionAtom: () => [
+    {
+      accountAddress: mockPositionsAccountAddress,
+      activePositions: mockPositions,
+    },
+  ],
+}));
+
+const resetMocks = () => {
+  mockPositionsAccountAddress = '0xABC';
+  mockPositions = [
+    {
+      position: {
+        coin: 'BTC',
+      },
+    },
+  ];
+};
+
+describe('usePerpsActivePositionsByAddress', () => {
+  beforeEach(() => {
+    resetMocks();
+  });
+
+  it('returns positions for the explicit active account without reading account selector context', () => {
+    const { result } = renderHook(() =>
+      usePerpsActivePositionsByAddress('0xabc'),
+    );
+
+    expect(result.current).toBe(mockPositions);
+  });
+
+  it('drops positions from a different account', () => {
+    const { result } = renderHook(() =>
+      usePerpsActivePositionsByAddress('0xdef'),
+    );
+
+    expect(result.current).toEqual([]);
+  });
+});

--- a/packages/kit/src/views/Perp/hooks/usePerpsActivePositionsByAddress.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpsActivePositionsByAddress.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+
+import { usePerpsActivePositionAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+
+import { getPerpsAccountScopedListData } from '../utils/accountScopedData';
+
+export function usePerpsActivePositionsByAddress(
+  activeAccountAddress?: string | null,
+) {
+  const [positionsState] = usePerpsActivePositionAtom();
+
+  return useMemo(
+    () =>
+      getPerpsAccountScopedListData({
+        activeAccountAddress,
+        dataAccountAddress: positionsState.accountAddress,
+        data: positionsState.activePositions,
+      }),
+    [
+      activeAccountAddress,
+      positionsState.accountAddress,
+      positionsState.activePositions,
+    ],
+  );
+}

--- a/packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.test.ts
+++ b/packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.test.ts
@@ -420,14 +420,14 @@ describe('getPerpsOrderPanelPostEnableTradingResult', () => {
 });
 
 describe('shouldBlockPerpsOrderPanelPreEnableTradingForMargin', () => {
-  it('blocks enable side effects for known insufficient margin orders', () => {
+  it('keeps enable trading first when the current margin snapshot is insufficient', () => {
     expect(
       shouldBlockPerpsOrderPanelPreEnableTradingForMargin({
         shouldEnableTradingBeforeOrder: true,
         isNoEnoughMargin: true,
         isDepositRequired: false,
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('keeps deposit fallback reachable when the account is not activated', () => {

--- a/packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.ts
+++ b/packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.ts
@@ -249,17 +249,17 @@ export function shouldDisablePerpsOrderPanelTradingButtonForAccountLoading({
 }
 
 export function shouldBlockPerpsOrderPanelPreEnableTradingForMargin({
-  shouldEnableTradingBeforeOrder,
-  isNoEnoughMargin,
-  isDepositRequired,
+  shouldEnableTradingBeforeOrder: _shouldEnableTradingBeforeOrder,
+  isNoEnoughMargin: _isNoEnoughMargin,
+  isDepositRequired: _isDepositRequired,
 }: {
   shouldEnableTradingBeforeOrder: boolean;
   isNoEnoughMargin: boolean;
   isDepositRequired: boolean;
 }) {
-  return (
-    shouldEnableTradingBeforeOrder && isNoEnoughMargin && !isDepositRequired
-  );
+  // Pre-enable margin snapshots are not authoritative. Always resolve the
+  // trading-enabled state first, then recheck margin with the latest account data.
+  return false;
 }
 
 export function shouldSkipPerpsOrderPanelComputedSizeValidation({


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55444](https://onekeyhq.atlassian.net/browse/OK-55444) [OK-55688](https://onekeyhq.atlassian.net/browse/OK-55688)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Make Perps enable-trading startup state take priority over close-position callbacks.
- Prevent Perps Portfolio content from reading account-selector context when rendered outside that provider.
- Add focused coverage for enable-trading precedence and address-scoped active positions.

## Intent & Context
This PR covers two related Perps fixes requested from Jira/Slack investigation:

- OK-55444: keep the new startup logic consistent, with starting a trade as the first priority.
- OK-55688: continue the same branch to fix the mobile Perps Portfolio crash reported in Jira.

The intent is to keep Perps entry and Portfolio rendering stable across desktop and mobile without adding new product behavior.

## Root Cause
OK-55444: the order panel state selection could allow close-position context to win before the enable-trading startup path, which conflicted with the requested priority that starting a trade should be handled first.

OK-55688: the mobile Portfolio page rendered `PerpPortfolioContent` with `PerpsProviderMirror`, but the content still indirectly called account-selector-context hooks through `usePerpsAccountScopedActivePositions`. On mobile, that account-selector store was not initialized in this rendering path, causing `useContextStore ERROR: store not initialized`.

## Design Decisions
- Keep the enable-trading priority change narrowly scoped to the order panel state utility.
- Add `usePerpsActivePositionsByAddress` so Portfolio content can filter active positions by the active Perps account address without depending on the account selector provider.
- Keep the Portfolio modal provider mirror wrapper in place for modal-specific paths, and update the comment so it reflects the actual context dependency.

## Changes Detail
- `packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.ts`: prioritizes the enable-trading startup state before close-position context.
- `packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.test.ts`: updates expectations for the new priority order.
- `packages/kit/src/views/Perp/hooks/usePerpsActivePositionsByAddress.ts`: adds address-scoped active-position filtering based on the Perps active-position atom.
- `packages/kit/src/views/Perp/hooks/usePerpsActivePositionsByAddress.test.ts`: verifies same-address data is returned and different-address data is hidden.
- `packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx`: removes the hidden account-selector context dependency from the Portfolio positions count.
- `packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioModal.tsx`: clarifies the remaining provider mirror comment.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web
- **Risk Areas**: Perps order panel startup state priority and Portfolio active-position counts.

## Test plan
- [x] `jest packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.test.ts packages/kit/src/views/Perp/hooks/usePerpsActivePositionsByAddress.test.ts --runInBand`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.ts packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.test.ts packages/kit/src/views/Perp/hooks/usePerpsActivePositionsByAddress.ts packages/kit/src/views/Perp/hooks/usePerpsActivePositionsByAddress.test.ts packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioModal.tsx`
- [x] `yarn lint:staged`
- [x] Desktop: started `yarn app:desktop:rspack`, opened `/perps`, clicked Portfolio, and verified no `useContextStore ERROR` / `store not initialized`.
- [x] iOS: ran `yarn app:ios:pod-install` and `yarn app:ios`, built and launched on iPhone 16 Pro simulator, entered Perps, and verified the Perps screen rendered without the context-store crash.
- [ ] `yarn tsc:staged` was attempted but is currently blocked by existing unrelated hardware adapter type errors outside this Perps change.

[OK-55444]: https://onekeyhq.atlassian.net/browse/OK-55444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55688]: https://onekeyhq.atlassian.net/browse/OK-55688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ