### PR TITLE
perf: speed up perps order book visual updates

### DIFF
--- a/packages/kit/src/views/Perp/utils/orderBookVisualScheduler.ts
+++ b/packages/kit/src/views/Perp/utils/orderBookVisualScheduler.ts
@@ -1,4 +1,4 @@
-export const PERPS_ORDER_BOOK_MOBILE_VISUAL_FRAME_MS = 2000;
+export const PERPS_ORDER_BOOK_MOBILE_VISUAL_FRAME_MS = 1000;
 
 export function getPerpsOrderBookVisualSnapshotDelayMs({
   frameMs,


### PR DESCRIPTION
## Summary
- Reduce the mobile/tablet Perps order book visual snapshot interval from 2000ms to 1000ms.
- Keep the existing snapshot coalescing logic unchanged.
- Keep desktop behavior unchanged because desktop still publishes the visible book immediately.

## Intent & Context
PR #11886 introduced a mobile/tablet visual snapshot throttle for the Perps order book to reduce UI churn. During follow-up testing, the 2000ms visual cadence was too slow for fast-moving order book price updates.

The requested adjustment is to use a 1000ms visual publish interval for mobile/tablet. This improves visible price freshness while retaining the scheduler that coalesces frequent L2 updates before publishing them to the rendered order book.

## Root Cause
The mobile/tablet visual snapshot interval was set to 2000ms, so the visible order book could keep a snapshot for up to two seconds even while the raw L2 book continued updating. That was too conservative for price visibility.

## Design Decisions
- Chose 1000ms instead of 500ms based on the local iOS benchmark trade-off: 1000ms kept the CPU/RAM profile lower than 500ms while making the visible order book twice as fresh as 2000ms.
- Changed only the shared interval constant, so subscription frequency, WebSocket behavior, scheduler semantics, and desktop behavior remain unchanged.
- Kept the existing first-snapshot immediate publish behavior and same-coin coalescing behavior.

## Changes Detail
- `packages/kit/src/views/Perp/utils/orderBookVisualScheduler.ts`: changed `PERPS_ORDER_BOOK_MOBILE_VISUAL_FRAME_MS` from `2000` to `1000`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile and tablet Perps order book views
- **Risk Areas**: Mobile/tablet order book rendering cadence increases from every 2s to every 1s, so the main risk is a modest increase in render work while the order book is visible.

## Test plan
- [x] `yarn jest packages/kit/src/views/Perp/utils/orderBookVisualScheduler.test.ts`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/Perp/utils/orderBookVisualScheduler.ts --deny-warnings`
- [x] `yarn tsc:only`
- [x] `git diff --check`
- [x] `yarn lint --fix`
- [x] iOS Metro reload after the constant change
- [x] Desktop rspack rebuild after the constant change