### PR TITLE
fix: harden coverage threshold checks

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,6 +22,7 @@ concurrency:
 env:
   YARN_ENABLE_GLOBAL_CACHE: true
   JEST_SHARD_TOTAL: 3
+  JEST_COVERAGE_THRESHOLD_JSON: '{"statements":10,"branches":35,"functions":10}'
 
 permissions:
   contents: read

--- a/development/scripts/merge-jest-coverage.js
+++ b/development/scripts/merge-jest-coverage.js
@@ -67,11 +67,15 @@ function readCoverageMap(coverageFiles) {
   return coverageMap;
 }
 
-function percent(covered, total) {
+function rawPercent(covered, total) {
   if (total === 0) {
     return 100;
   }
-  return Number(((covered / total) * 100).toFixed(2));
+  return (covered / total) * 100;
+}
+
+function percent(covered, total) {
+  return Number(rawPercent(covered, total).toFixed(2));
 }
 
 function createMetricSummary(total, covered) {
@@ -158,10 +162,40 @@ function summarizeCoverageMap(coverageMap) {
   return summary;
 }
 
+function normalizeCoverageThresholds(value, sourceName) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${sourceName} must be an object`);
+  }
+
+  const thresholds = {};
+  for (const metric of metrics) {
+    const threshold = value[metric];
+    if (threshold !== undefined) {
+      if (typeof threshold !== 'number' || Number.isNaN(threshold)) {
+        throw new Error(
+          `Invalid coverage threshold for ${metric} in ${sourceName}: ${threshold}`,
+        );
+      }
+      thresholds[metric] = threshold;
+    }
+  }
+
+  if (Object.keys(thresholds).length === 0) {
+    throw new Error(
+      `${sourceName} did not contain any global coverage thresholds`,
+    );
+  }
+
+  return thresholds;
+}
+
 function readGlobalCoverageThreshold() {
   const envValue = process.env.JEST_COVERAGE_THRESHOLD_JSON;
   if (envValue) {
-    return JSON.parse(envValue);
+    return normalizeCoverageThresholds(
+      JSON.parse(envValue),
+      'JEST_COVERAGE_THRESHOLD_JSON',
+    );
   }
 
   const configPath = path.join(rootDir, 'jest.config.js');
@@ -171,7 +205,9 @@ function readGlobalCoverageThreshold() {
   );
 
   if (!thresholdMatch) {
-    return {};
+    throw new Error(
+      'Unable to find coverageThreshold.global in jest.config.js. Set JEST_COVERAGE_THRESHOLD_JSON to avoid disabling coverage thresholds.',
+    );
   }
 
   const thresholds = {};
@@ -183,7 +219,10 @@ function readGlobalCoverageThreshold() {
     propertyMatch = propertyPattern.exec(thresholdBlock);
   }
 
-  return thresholds;
+  return normalizeCoverageThresholds(
+    thresholds,
+    'jest.config.js coverageThreshold.global',
+  );
 }
 
 function recreateDir(dir) {
@@ -289,8 +328,8 @@ function writeCoverageReports(coverageMap, summary, outputDir) {
   writeLcov(coverageMap, outputDir);
 }
 
-function formatPercent(value) {
-  return `${value.toFixed(2).replace(/\.00$/, '')}%`;
+function formatPercent(value, fractionDigits = 2) {
+  return `${value.toFixed(fractionDigits).replace(/\.?0+$/, '')}%`;
 }
 
 function checkCoverageThresholds(summary, thresholds) {
@@ -300,9 +339,13 @@ function checkCoverageThresholds(summary, thresholds) {
     const threshold = thresholds[metric];
     if (typeof threshold === 'number') {
       const metricSummary = summary.total[metric];
-      if (threshold >= 0 && metricSummary.pct < threshold) {
+      const metricPercent = rawPercent(
+        metricSummary.covered,
+        metricSummary.total,
+      );
+      if (threshold >= 0 && metricPercent < threshold) {
         failures.push(
-          `${metric}: ${formatPercent(metricSummary.pct)} is below ${threshold}%`,
+          `${metric}: ${formatPercent(metricPercent, 4)} (${metricSummary.covered}/${metricSummary.total}) is below ${threshold}%`,
         );
       } else if (threshold < 0) {
         const uncovered = metricSummary.total - metricSummary.covered;


### PR DESCRIPTION
## Summary
- Pass coverage thresholds explicitly to the merged coverage job through `JEST_COVERAGE_THRESHOLD_JSON`.
- Fail loudly when coverage thresholds cannot be parsed instead of silently disabling the gate.
- Compare coverage thresholds with unrounded percentages while keeping report output rounded.

## Intent & Context
Follow-up for PR #11904 code review. The sharded unittest workflow moved coverage threshold enforcement from Jest shard runs into `development/scripts/merge-jest-coverage.js`, and two review comments pointed out that the new merge-time gate could be weaker than Jest's original behavior.

## Root Cause
`readGlobalCoverageThreshold()` used a regex fallback against `jest.config.js` and returned `{}` on parse failure. That made threshold enforcement optional by accident: `checkCoverageThresholds(summary, {})` exits green.

The threshold comparison also reused the rounded `pct` value from `coverage-summary.json`, so a raw value just below a threshold could round up and pass.

## Design Decisions
The GitHub Actions coverage merge job intentionally does not install dependencies. Because `jest.config.js` is async and imports `jest-config`, requiring it from the merge job would reintroduce dependency setup work. Instead, the workflow passes the current global thresholds as JSON, and the script validates that at least one known threshold is present.

The script still supports the existing `jest.config.js` fallback for local/manual use, but it now fails loudly if the global threshold block is missing or contains no supported metrics.

## Changes Detail
- `.github/workflows/unittest.yml`: adds `JEST_COVERAGE_THRESHOLD_JSON` with the current global thresholds.
- `development/scripts/merge-jest-coverage.js`: validates threshold input, fails on empty/unparseable threshold config, and uses raw coverage percentages for positive threshold checks.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: CI only
- **Risk Areas**: Coverage gate behavior in the unittest workflow

## Test plan
- [x] `npx prettier --check .github/workflows/unittest.yml development/scripts/merge-jest-coverage.js`
- [x] `node --check development/scripts/merge-jest-coverage.js`
- [x] `npx oxlint development/scripts/merge-jest-coverage.js --deny-warnings`
- [x] YAML parse check for `.github/workflows/unittest.yml`
- [x] `git diff --check`
- [x] Temporary coverage fixture: passing threshold succeeds
- [x] Temporary coverage fixture: raw `34.996%` fails a `35%` threshold even though summary output rounds to `35%`
- [x] Temporary coverage fixture: empty threshold JSON fails loudly
- [x] Temporary coverage fixture: current `jest.config.js` fallback still parses successfully
- [x] `yarn lint:staged`
- [ ] `yarn tsc:staged` currently fails on unrelated existing hardware/Ledger/Perp dependency type errors (`@onekeyfe/hwk-adapter-core` exports, Ledger UI enum/payload types, and `@onekeyfe/react-native-perp-depth-bar` types). This PR only changes workflow YAML and a JS CI script.
