### PR TITLE
fix(perps): don't block trading when rebate wallet bind fails

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -1962,8 +1962,10 @@ export default class ServiceHyperliquid extends ServiceBase {
           }),
         ]);
 
-        // Clear local credentials to force new agent creation for rebate binding
-        if (!isRebateBound) {
+        // Clear local credentials to force new agent creation for rebate binding.
+        // Gate on isEnableTradingTrigger: rebate binding is best-effort and must
+        // not clear a working agent on background refreshes (would block trading).
+        if (!isRebateBound && isEnableTradingTrigger) {
           await this.clearLocalAgentCredentials({
             userAddress: accountAddress,
           });


### PR DESCRIPTION
## Problem
When the rebate wallet binding (`bind-wallet`) fails to persist server-side, the client treated the wallet as "not bound" on **every** `checkPerpsAccountStatus` call — including background refreshes. Each time it would clear the working agent credential to force a re-bind, which:

- cleared a valid agent on background refreshes → `canTrade` dropped → trade button greyed out
- re-prompted the agent-approval signature in a loop ("sign → cleared → sign → cleared …")
- repeatedly hit `/rebate/v1/wallet/batch-check`

Net effect: affected accounts (non-first EVM address whose binding never lands server-side) **could not trade**.

## Fix
Gate the forced agent-credential clear on `isEnableTradingTrigger`:

```ts
// before
if (!isRebateBound) { ... clearLocalAgentCredentials ... }
// after
if (!isRebateBound && isEnableTradingTrigger) { ... }
```

Rebate binding becomes **best-effort**: it still runs when the user explicitly clicks **Enable Trading** (they're already in a signing flow), but a background status refresh never clears an active agent.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Background refresh, not bound | clears agent → blocks trading, re-prompts signatures | agent untouched, trading continues ✅ |
| User clicks Enable Trading, not bound | clears agent → re-bind | unchanged (still binds) ✅ |
| Already bound | unaffected | unaffected |

Trade-off: while the server-side bind bug persists, affected existing accounts won't be force re-bound (short-term attribution gap), but trading is never blocked. They bind naturally on first agent creation / once the server is fixed.

## Test plan
- Reproduced by forcing the rebate check to always return `false`: confirmed the sign→clear loop and greyed-out trade button.
- With the fix: background refreshes no longer clear the agent; trading stays enabled; clicking Enable Trading still triggers binding.

## Scope
1 file, core change is a single condition. No funds/signing-security/DB logic touched.