### PR TITLE
fix: stabilize Perps Scale and TWAP QA flows OK-55589 OK-55590 OK-55593 OK-55595 OK-55596 OK-55597 OK-55598 OK-55599 OK-55602 OK-55606 OK-55675 OK-55787 OK-55792 OK-55834

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -47,6 +47,7 @@ import {
   updateTokenSelectorFavoriteCoins,
 } from '@onekeyhq/shared/src/utils/perpsTokenSelectorFavorites';
 import perpsUtils, {
+  calculateSpotBalancesTotalUsd,
   parseDexCoin,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
@@ -1431,6 +1432,7 @@ export default class ServiceHyperliquid extends ServiceBase {
       }
     });
     this._flushSpotPrices(map);
+    void this.recalculateSpotTotalUsd({ force: true });
   }
 
   async extractSpotPricesFromAllMids(mids: Record<string, string>) {
@@ -1710,50 +1712,19 @@ export default class ServiceHyperliquid extends ServiceBase {
 
     await spotBalancesAtom.set({ balances, isLoaded: true });
 
-    // Calculate total USD value from spot balances
-    // Price lookup: USDC (token=0) → 1:1, others → allMids.mids[coin] (perp mid price by token name)
-    // Note: allMids["HYPE"]=36.20 is the correct USD price
-    //       allMids["@N"] is a spot universe pair index, NOT token index — do NOT use
+    await this._ensureSpotMappings();
+
+    // Calculate total USD value from spot balances.
+    // Price lookup order:
+    // 1. spot pair ctx markPx from spotAssetCtxs (e.g. BTC/USDC)
+    // 2. token/perp mid fallback from allMids (e.g. HYPE)
+    // Missing non-stable prices keep spotTotalUsd undefined so consumers show
+    // loading instead of a USDC-only account value.
     const mids = hyperLiquidCache.allMids?.mids;
-    const hasNonUsdcTokens = balances.some(
-      (b) => b.token !== 0 && parseFloat(b.total) > 0,
-    );
-    const midsReady = mids && Object.keys(mids).length > 0;
-
-    // Don't write spotTotalUsd if allMids hasn't loaded yet and we have non-USDC tokens
-    // This prevents briefly showing an artificially low value
-    if (hasNonUsdcTokens && !midsReady) {
-      await perpsSpotBalancesAtom.set({
-        accountAddress: activeAddress as IHex,
-        balances: balances.map((b) => ({
-          coin: b.coin,
-          token: b.token,
-          total: b.total,
-          hold: b.hold,
-          entryNtl: b.entryNtl,
-        })),
-        spotTotalUsd: undefined, // triggers isLoading in computed atom
-      });
-      return;
-    }
-
-    let totalUsd = new BigNumber(0);
-    for (const balance of balances) {
-      const amount = new BigNumber(balance.total);
-      if (amount.isZero()) {
-        // skip zero balances
-      } else if (balance.token === 0) {
-        // USDC — quote currency, 1:1 USD
-        totalUsd = totalUsd.plus(amount);
-      } else {
-        // Use token name to look up perp mid price (e.g., "HYPE" → 36.20)
-        const midPrice = mids?.[balance.coin];
-        if (midPrice) {
-          totalUsd = totalUsd.plus(amount.multipliedBy(midPrice));
-        }
-      }
-    }
-
+    const spotTotal = calculateSpotBalancesTotalUsd({
+      balances,
+      getMarkPrice: (coin) => this.getSpotBalanceMarkPrice(coin, mids),
+    });
     const normalizedBalances = balances.map((b) => ({
       coin: b.coin,
       token: b.token,
@@ -1761,7 +1732,17 @@ export default class ServiceHyperliquid extends ServiceBase {
       hold: b.hold,
       entryNtl: b.entryNtl,
     }));
-    const spotTotalUsd = totalUsd.toFixed();
+
+    if (spotTotal.missingPriceCoins.length > 0) {
+      await perpsSpotBalancesAtom.set({
+        accountAddress: activeAddress as IHex,
+        balances: normalizedBalances,
+        spotTotalUsd: undefined,
+      });
+      return;
+    }
+
+    const spotTotalUsd = spotTotal.totalUsd;
     await perpsSpotBalancesAtom.set({
       accountAddress: activeAddress as IHex,
       balances: normalizedBalances,
@@ -1791,41 +1772,41 @@ export default class ServiceHyperliquid extends ServiceBase {
       });
   }
 
-  // Re-calculate spotTotalUsd from cached balances when allMids becomes available
-  async recalculateSpotTotalUsd() {
+  // Re-calculate spotTotalUsd from cached balances when price data becomes available
+  async recalculateSpotTotalUsd({ force = false }: { force?: boolean } = {}) {
     const spotData = await perpsSpotBalancesAtom.get();
-    if (!spotData?.balances?.length || spotData.spotTotalUsd !== undefined)
+    if (
+      !spotData?.balances?.length ||
+      (!force && spotData.spotTotalUsd !== undefined)
+    ) {
       return;
+    }
 
     const activeAccount = await perpsActiveAccountAtom.get();
     const activeAddress = activeAccount?.accountAddress?.toLowerCase();
-    if (!activeAddress || activeAddress !== spotData.accountAddress) return;
+    const spotAddress = spotData.accountAddress?.toLowerCase();
+    if (!activeAddress || activeAddress !== spotAddress) return;
+
+    await this._ensureSpotMappings();
 
     const mids = hyperLiquidCache.allMids?.mids;
-    if (!mids || Object.keys(mids).length === 0) return;
-
     const { balances } = spotData;
-    let totalUsd = new BigNumber(0);
-    for (const balance of balances) {
-      const amount = new BigNumber(balance.total);
-      if (amount.isZero()) {
-        // skip zero balances
-      } else if (balance.token === 0) {
-        totalUsd = totalUsd.plus(amount);
-      } else {
-        const midPrice = mids[balance.coin];
-        if (midPrice) {
-          totalUsd = totalUsd.plus(amount.multipliedBy(midPrice));
-        }
-      }
+    const spotTotal = calculateSpotBalancesTotalUsd({
+      balances,
+      getMarkPrice: (coin) => this.getSpotBalanceMarkPrice(coin, mids),
+    });
+    if (spotTotal.missingPriceCoins.length > 0) {
+      return;
     }
 
-    const computed = totalUsd.toFixed();
+    const computed = spotTotal.totalUsd;
     // Functional updater: only write if spotTotalUsd is still undefined
     // (avoids overwriting fresher data from a concurrent SPOT_STATE event)
     let didWrite = false;
     await perpsSpotBalancesAtom.set((prev) => {
-      if (!prev || prev.spotTotalUsd !== undefined) return prev;
+      if (!prev || (!force && prev.spotTotalUsd !== undefined)) return prev;
+      if (prev.accountAddress?.toLowerCase() !== activeAddress) return prev;
+      if (prev.spotTotalUsd === computed) return prev;
       didWrite = true;
       return { ...prev, spotTotalUsd: computed };
     });
@@ -1909,6 +1890,18 @@ export default class ServiceHyperliquid extends ServiceBase {
   async getSpotPairName(tokenName: string): Promise<string | undefined> {
     await this._ensureSpotMappings();
     return this._spotMappings.baseNameToPairName[tokenName];
+  }
+
+  private getSpotBalanceMarkPrice(coin: string, mids?: Record<string, string>) {
+    const spotPairName = this._spotMappings.baseNameToPairName[coin];
+    const displayName = perpsUtils.getSpotTokenDisplayName(coin);
+
+    return (
+      (spotPairName ? this._spotPriceCache[spotPairName]?.markPx : undefined) ??
+      this._spotPriceCache[coin]?.markPx ??
+      mids?.[coin] ??
+      mids?.[displayName]
+    );
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -154,6 +154,7 @@ import type {
   IPerpsDepositNetworksAtom,
   IPerpsDepositToken,
   IPerpsDepositTokensAtom,
+  ISpotBalanceItem,
 } from '../../states/jotai/atoms';
 import type {
   ISpotActiveAssetCtxAtom,
@@ -180,6 +181,10 @@ type IChangeActiveAssetResult = {
 const HIDE_SELECT_ACCOUNT_LOADING_DELAY_MS = timerUtils.getTimeDurationMs({
   seconds: 0.3,
 });
+const SPOT_TOTAL_USD_MISSING_PRICE_FALLBACK_DELAY_MS =
+  timerUtils.getTimeDurationMs({
+    seconds: 3,
+  });
 const PERPS_ACTIVE_ASSET_CTX_DISPLAY_THROTTLE_MS = 500;
 
 let perpsActiveAssetCtxDisplayLastSetAt = 0;
@@ -416,6 +421,11 @@ export default class ServiceHyperliquid extends ServiceBase {
   private _spotPriceDirty = false;
 
   private _spotPriceFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private _spotTotalUsdFallbackTimer: ReturnType<typeof setTimeout> | null =
+    null;
+
+  private _spotTotalUsdFallbackAccountAddress: string | null = null;
 
   private _fetchSpotExternalMarketCaps = cacheUtils.memoizee(
     async (): Promise<Record<string, string>> => {
@@ -1718,8 +1728,9 @@ export default class ServiceHyperliquid extends ServiceBase {
     // Price lookup order:
     // 1. spot pair ctx markPx from spotAssetCtxs (e.g. BTC/USDC)
     // 2. token/perp mid fallback from allMids (e.g. HYPE)
-    // Missing non-stable prices keep spotTotalUsd undefined so consumers show
-    // loading instead of a USDC-only account value.
+    // Missing non-stable prices briefly keep spotTotalUsd undefined so
+    // consumers show loading instead of a USDC-only account value. A fallback
+    // timer below writes the known partial total if prices never arrive.
     const mids = hyperLiquidCache.allMids?.mids;
     const spotTotal = calculateSpotBalancesTotalUsd({
       balances,
@@ -1734,14 +1745,21 @@ export default class ServiceHyperliquid extends ServiceBase {
     }));
 
     if (spotTotal.missingPriceCoins.length > 0) {
+      const previousSpotData = await perpsSpotBalancesAtom.get();
+      const previousSpotTotalUsd =
+        previousSpotData?.accountAddress?.toLowerCase() === activeAddress
+          ? previousSpotData.spotTotalUsd
+          : undefined;
       await perpsSpotBalancesAtom.set({
         accountAddress: activeAddress as IHex,
         balances: normalizedBalances,
-        spotTotalUsd: undefined,
+        spotTotalUsd: previousSpotTotalUsd,
       });
+      this._scheduleSpotTotalUsdFallback(activeAddress);
       return;
     }
 
+    this._clearSpotTotalUsdFallbackTimer(activeAddress);
     const spotTotalUsd = spotTotal.totalUsd;
     await perpsSpotBalancesAtom.set({
       accountAddress: activeAddress as IHex,
@@ -1796,9 +1814,11 @@ export default class ServiceHyperliquid extends ServiceBase {
       getMarkPrice: (coin) => this.getSpotBalanceMarkPrice(coin, mids),
     });
     if (spotTotal.missingPriceCoins.length > 0) {
+      this._scheduleSpotTotalUsdFallback(activeAddress);
       return;
     }
 
+    this._clearSpotTotalUsdFallbackTimer(activeAddress);
     const computed = spotTotal.totalUsd;
     // Functional updater: only write if spotTotalUsd is still undefined
     // (avoids overwriting fresher data from a concurrent SPOT_STATE event)
@@ -1830,6 +1850,91 @@ export default class ServiceHyperliquid extends ServiceBase {
         .catch((error: unknown) => {
           console.warn(
             '[recalculateSpotTotalUsd] failed to persist display cache:',
+            error,
+          );
+        });
+    }
+  }
+
+  private _clearSpotTotalUsdFallbackTimer(accountAddress?: string) {
+    const normalizedAddress = accountAddress?.toLowerCase();
+    if (
+      normalizedAddress &&
+      this._spotTotalUsdFallbackAccountAddress !== normalizedAddress
+    ) {
+      return;
+    }
+    if (this._spotTotalUsdFallbackTimer) {
+      clearTimeout(this._spotTotalUsdFallbackTimer);
+    }
+    this._spotTotalUsdFallbackTimer = null;
+    this._spotTotalUsdFallbackAccountAddress = null;
+  }
+
+  private _scheduleSpotTotalUsdFallback(accountAddress: string) {
+    const normalizedAddress = accountAddress.toLowerCase();
+    if (
+      this._spotTotalUsdFallbackTimer &&
+      this._spotTotalUsdFallbackAccountAddress === normalizedAddress
+    ) {
+      return;
+    }
+
+    this._clearSpotTotalUsdFallbackTimer();
+    this._spotTotalUsdFallbackAccountAddress = normalizedAddress;
+    this._spotTotalUsdFallbackTimer = setTimeout(() => {
+      void this._applySpotTotalUsdFallback(normalizedAddress);
+    }, SPOT_TOTAL_USD_MISSING_PRICE_FALLBACK_DELAY_MS);
+  }
+
+  private async _applySpotTotalUsdFallback(accountAddress: string) {
+    this._clearSpotTotalUsdFallbackTimer(accountAddress);
+
+    const activeAccount = await perpsActiveAccountAtom.get();
+    const activeAddress = activeAccount?.accountAddress?.toLowerCase();
+    if (!activeAddress || activeAddress !== accountAddress) {
+      return;
+    }
+
+    await this._ensureSpotMappings();
+
+    const mids = hyperLiquidCache.allMids?.mids;
+    let computed: string | undefined;
+    let balancesToPersist: ISpotBalanceItem[] | undefined;
+    await perpsSpotBalancesAtom.set((prev) => {
+      if (!prev || prev.accountAddress?.toLowerCase() !== accountAddress) {
+        return prev;
+      }
+
+      const spotTotal = calculateSpotBalancesTotalUsd({
+        balances: prev.balances,
+        getMarkPrice: (coin) => this.getSpotBalanceMarkPrice(coin, mids),
+      });
+      computed = spotTotal.totalUsd;
+      balancesToPersist = prev.balances;
+      return { ...prev, spotTotalUsd: computed };
+    });
+
+    if (computed && balancesToPersist) {
+      void this.cacheService
+        .writePerpsAccountDisplaySnapshot({
+          accountAddress,
+        })
+        .catch((error: unknown) => {
+          console.warn(
+            '[applySpotTotalUsdFallback] failed to persist display snapshot:',
+            error,
+          );
+        });
+      void this.cacheService
+        .writePerpsAccountDisplaySpotBalances({
+          accountAddress,
+          balances: balancesToPersist,
+          spotTotalUsd: computed,
+        })
+        .catch((error: unknown) => {
+          console.warn(
+            '[applySpotTotalUsdFallback] failed to persist display cache:',
             error,
           );
         });

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -353,7 +353,7 @@ export const {
     if (isUnified) {
       // Unified/portfolio: all values from spotState
       // Per HL docs: "Individual perp dex user states are not meaningful"
-      if (!activeSpotData?.spotTotalUsd) {
+      if (activeSpotData?.spotTotalUsd === undefined) {
         // Spot data not yet loaded: return undefined for skeleton screen
         return {
           accountValue: undefined,
@@ -379,7 +379,7 @@ export const {
     return {
       accountValue: spotValue.plus(perpsValue).toFixed(),
       withdrawable: activeSummary?.withdrawable,
-      isLoading: !activeSpotData?.spotTotalUsd,
+      isLoading: activeSpotData?.spotTotalUsd === undefined,
     };
   },
 });

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -3186,6 +3186,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
           return result;
         },
         actionType: EActionType.CANCEL_ORDER,
+        args: [1],
       });
     },
   );

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -46,6 +46,7 @@ import { memoFn } from '@onekeyhq/shared/src/utils/cacheUtils';
 import {
   SCALE_ORDER_MIN_NOTIONAL,
   getReduceOnlyOrderGuardError,
+  getReduceOnlyPositionMaxSize,
   getReduceOnlyPositionSnapshotError,
   getScaleOrderReferencePrice,
   getScaleOrderSizeSkew,
@@ -2574,6 +2575,18 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
               throw new OneKeyLocalError('Invalid scale price range');
             }
 
+            const reduceOnly = isSpot
+              ? false
+              : Boolean(formData.scaleReduceOnly);
+            const position = activePositionsValue.activePositions.find(
+              (pos) => pos.position.coin === activeTradeInstrument.coin,
+            )?.position;
+            const reduceOnlyMaxSize = getReduceOnlyPositionMaxSize({
+              reduceOnly,
+              side: formData.side,
+              positionSize: position?.szi,
+              szDecimals,
+            });
             const resolvedSize = resolveTradingSize({
               sizeInputMode: formData.sizeInputMode,
               manualSize: formData.size,
@@ -2583,6 +2596,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
               markPrice: isSpot
                 ? (env.markPrice ?? referencePrice.toFixed())
                 : activeAssetCtxValue?.ctx?.markPrice,
+              maxSize: reduceOnlyMaxSize,
               maxTradeSzs: isSpot
                 ? env.maxTradeSzs
                 : activeAssetDataValue?.maxTradeSzs,
@@ -2592,9 +2606,6 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
                 : activeAssetValue?.universe?.maxLeverage,
               szDecimals,
             });
-            const reduceOnly = isSpot
-              ? false
-              : Boolean(formData.scaleReduceOnly);
             if (reduceOnly) {
               const snapshotError = getReduceOnlyPositionSnapshotError({
                 reduceOnly,
@@ -2604,9 +2615,6 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
               if (snapshotError) {
                 throw new OneKeyLocalError(snapshotError);
               }
-              const position = activePositionsValue.activePositions.find(
-                (pos) => pos.position.coin === activeTradeInstrument.coin,
-              )?.position;
               const reduceOnlyError = getReduceOnlyOrderGuardError({
                 reduceOnly,
                 side: formData.side,

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
@@ -4,7 +4,10 @@ import { selectAtom } from 'jotai/utils';
 import { createJotaiContext } from '@onekeyhq/kit/src/states/jotai/utils/createJotaiContext';
 import { perpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { CONTEXT_ATOM_COLD_START_CACHE_KEYS } from '@onekeyhq/shared/src/consts/jotaiConsts';
-import { getScaleOrderReferencePrice } from '@onekeyhq/shared/src/utils/hyperliquidScaleOrderUtils';
+import {
+  getReduceOnlyPositionMaxSize,
+  getScaleOrderReferencePrice,
+} from '@onekeyhq/shared/src/utils/hyperliquidScaleOrderUtils';
 import {
   computeMaxTradeSize,
   getTriggerEffectivePrice,
@@ -706,6 +709,9 @@ export const {
 } = contextAtomComputed((get) => {
   const form = get(tradingFormAtom());
   const env = get(tradingFormEnvAtom());
+  const activeTradeInstrument = get(activeTradeInstrumentAtom());
+  const activeAccount = get(perpsActiveAccountAtom.atom());
+  const activePositionsValue = get(perpsActivePositionAtom());
 
   const mode = form.sizeInputMode ?? EPerpsSizeInputMode.MANUAL;
   const percent = form.sizePercent ?? 0;
@@ -759,10 +765,34 @@ export const {
     }
   }
 
+  const activeAccountAddress = activeAccount?.accountAddress?.toLowerCase();
+  const positionsAccountAddress =
+    activePositionsValue.accountAddress?.toLowerCase();
+  const isPositionSnapshotReady = activeAccountAddress
+    ? positionsAccountAddress === activeAccountAddress
+    : !positionsAccountAddress;
+  const scaleReduceOnlyPositionSize = isPositionSnapshotReady
+    ? activePositionsValue.activePositions.find(
+        (pos) => pos.position.coin === activeTradeInstrument.coin,
+      )?.position.szi
+    : undefined;
+  const scaleReduceOnlyMaxSizeBN =
+    form.orderMode === 'scale' &&
+    form.scaleReduceOnly &&
+    activeTradeInstrument.mode !== 'spot'
+      ? getReduceOnlyPositionMaxSize({
+          reduceOnly: form.scaleReduceOnly,
+          side: form.side,
+          positionSize: scaleReduceOnlyPositionSize,
+          szDecimals: env.szDecimals,
+        })
+      : undefined;
+
   const maxSizeBN = computeMaxTradeSize({
     side: form.side,
     price,
     markPrice: env.markPrice,
+    maxSize: scaleReduceOnlyMaxSizeBN,
     maxTradeSzs: effectiveMaxTradeSzs,
     leverageValue: env.leverageValue,
     fallbackLeverage: env.fallbackLeverage,
@@ -776,6 +806,7 @@ export const {
     side: form.side,
     price,
     markPrice: env.markPrice,
+    maxSize: scaleReduceOnlyMaxSizeBN,
     maxTradeSzs: effectiveMaxTradeSzs,
     leverageValue: env.leverageValue,
     fallbackLeverage: env.fallbackLeverage,

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -4,7 +4,6 @@ import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
 import {
-  Badge,
   DashText,
   Divider,
   IconButton,
@@ -54,7 +53,6 @@ export type ITradesHistoryRowProps = {
   isHovered?: boolean;
   onHoverChange?: (index: number | null) => void;
   builderFeeRate?: number;
-  twapId?: number;
 };
 
 const TradesHistoryRow = memo(
@@ -69,7 +67,6 @@ const TradesHistoryRow = memo(
     isHovered,
     onHoverChange,
     builderFeeRate,
-    twapId,
   }: ITradesHistoryRowProps) => {
     const canShare = useMemo(() => {
       return (
@@ -264,11 +261,6 @@ const TradesHistoryRow = memo(
                 >
                   {directionInfo.directionStr}
                 </SizableText>
-                {twapId !== undefined ? (
-                  <Badge badgeType="info" badgeSize="sm">
-                    {`TWAP #${twapId}`}
-                  </Badge>
-                ) : null}
               </XStack>
               <SizableText size="$bodySm" color="$textSubdued">
                 {dateInfo.date} {dateInfo.time}
@@ -442,11 +434,6 @@ const TradesHistoryRow = memo(
                 >
                   {directionInfo.directionStr}
                 </SizableText>
-                {twapId !== undefined ? (
-                  <Badge badgeType="info" badgeSize="sm">
-                    {`TWAP #${twapId}`}
-                  </Badge>
-                ) : null}
               </XStack>
             </XStack>
 

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
@@ -350,6 +350,7 @@ export interface ICommonTableListViewProps<T = unknown> {
   disableListScroll?: boolean;
   listLoading?: boolean;
   paginationToBottom?: boolean;
+  enableDesktopVerticalScroll?: boolean;
   listViewDebugRenderTrackerProps?: IDebugRenderTrackerProps;
   onViewAll?: () => void;
   onPullToRefresh?: () => Promise<void>;
@@ -367,6 +368,7 @@ export function CommonTableListView<T>({
   listLoading,
   setCurrentListPage,
   paginationToBottom,
+  enableDesktopVerticalScroll,
   isMobile,
   emptyMessage = 'No data',
   emptySubMessage = 'Data will appear here',
@@ -749,131 +751,144 @@ export function CommonTableListView<T>({
       )}
     </XStack>
   );
+  const desktopTable = (
+    <XStack>
+      {/* Scrollable columns */}
+      <ScrollView
+        ref={scrollViewRef}
+        style={{
+          flex: 1,
+        }}
+        horizontal
+        showsHorizontalScrollIndicator
+        nestedScrollEnabled
+        onScroll={platformEnv.isNative ? handleNativeScroll : handleWebScroll}
+        scrollEventThrottle={16}
+        contentContainerStyle={{
+          minWidth: scrollableMinWidth,
+          flexGrow: 1,
+        }}
+      >
+        <YStack flex={1} minWidth={scrollableMinWidth} cursor="default">
+          <XStack
+            py="$2"
+            pl="$5"
+            pr="$3"
+            display="flex"
+            minWidth={scrollableMinWidth}
+            width="100%"
+            borderBottomWidth="$px"
+            borderBottomColor={borderColor}
+            bg={headerBgColor}
+          >
+            {scrollableColumns.map((column, index) =>
+              renderHeaderCell(column, index),
+            )}
+          </XStack>
+          <YStack flex={1} pb={enablePagination ? 0 : '$4'}>
+            {effectiveListLoading ? (
+              <YStack
+                flex={1}
+                justifyContent="center"
+                alignItems="center"
+                p="$20"
+              >
+                <Spinner size="large" />
+              </YStack>
+            ) : null}
+            {showDesktopEmptyState ? desktopEmptyComponent : null}
+            {!effectiveListLoading && paginatedData.length > 0
+              ? paginatedData.map((item, index) => (
+                  <Fragment key={keyExtractor?.(item, index) ?? String(index)}>
+                    {renderRow(
+                      item,
+                      index,
+                      hasFixedColumns ? 'left' : 'full',
+                      hoveredRowIndex === index,
+                      setHoveredRowIndex,
+                    )}
+                  </Fragment>
+                ))
+              : null}
+          </YStack>
+        </YStack>
+      </ScrollView>
+
+      {/* Fixed columns */}
+      {hasFixedColumns ? (
+        <YStack
+          minWidth={fixedMinWidth}
+          cursor="default"
+          bg="$bgApp"
+          $platform-web={{
+            boxShadow:
+              showFixedShadow && paginatedData.length > 0
+                ? getWebShadowStyle('right', isDark)
+                : 'none',
+            clipPath: getWebClipPath('right'),
+            transition: `box-shadow ${SHADOW_CONSTANTS.TRANSITION_DURATION} ease-in-out`,
+          }}
+        >
+          <FixedColumnShadowOverlay
+            position="right"
+            visible={showFixedShadow ? paginatedData.length > 0 : false}
+            isDark={isDark}
+          />
+          <XStack
+            py="$2"
+            px="$3"
+            display="flex"
+            borderBottomWidth="$px"
+            borderBottomColor={borderColor}
+            bg={headerBgColor}
+          >
+            {fixedColumns.map((column, index) =>
+              renderHeaderCell(column, index),
+            )}
+          </XStack>
+          <YStack flex={1} pb={enablePagination ? 0 : '$4'}>
+            {effectiveListLoading ? <YStack flex={1} p="$20" /> : null}
+            {!effectiveListLoading && paginatedData.length === 0 ? (
+              <YStack flex={1} p="$5" />
+            ) : null}
+            {!effectiveListLoading && paginatedData.length > 0
+              ? paginatedData.map((item, index) => (
+                  <Fragment key={keyExtractor?.(item, index) ?? String(index)}>
+                    {renderRow(
+                      item,
+                      index,
+                      'right',
+                      hoveredRowIndex === index,
+                      setHoveredRowIndex,
+                    )}
+                  </Fragment>
+                ))
+              : null}
+          </YStack>
+        </YStack>
+      ) : null}
+    </XStack>
+  );
+
+  const shouldEnableDesktopVerticalScroll =
+    enableDesktopVerticalScroll && !disableListScroll;
+
   return (
     <YStack flex={1}>
       <YStack flex={1}>
-        <XStack>
-          {/* Scrollable columns */}
+        {shouldEnableDesktopVerticalScroll ? (
           <ScrollView
-            ref={scrollViewRef}
             style={{
               flex: 1,
             }}
-            horizontal
-            showsHorizontalScrollIndicator
             nestedScrollEnabled
-            onScroll={
-              platformEnv.isNative ? handleNativeScroll : handleWebScroll
-            }
-            scrollEventThrottle={16}
-            contentContainerStyle={{
-              minWidth: scrollableMinWidth,
-              flexGrow: 1,
-            }}
+            showsVerticalScrollIndicator
           >
-            <YStack flex={1} minWidth={scrollableMinWidth} cursor="default">
-              <XStack
-                py="$2"
-                pl="$5"
-                pr="$3"
-                display="flex"
-                minWidth={scrollableMinWidth}
-                width="100%"
-                borderBottomWidth="$px"
-                borderBottomColor={borderColor}
-                bg={headerBgColor}
-              >
-                {scrollableColumns.map((column, index) =>
-                  renderHeaderCell(column, index),
-                )}
-              </XStack>
-              <YStack flex={1} pb={enablePagination ? 0 : '$4'}>
-                {effectiveListLoading ? (
-                  <YStack
-                    flex={1}
-                    justifyContent="center"
-                    alignItems="center"
-                    p="$20"
-                  >
-                    <Spinner size="large" />
-                  </YStack>
-                ) : null}
-                {showDesktopEmptyState ? desktopEmptyComponent : null}
-                {!effectiveListLoading && paginatedData.length > 0
-                  ? paginatedData.map((item, index) => (
-                      <Fragment
-                        key={keyExtractor?.(item, index) ?? String(index)}
-                      >
-                        {renderRow(
-                          item,
-                          index,
-                          hasFixedColumns ? 'left' : 'full',
-                          hoveredRowIndex === index,
-                          setHoveredRowIndex,
-                        )}
-                      </Fragment>
-                    ))
-                  : null}
-              </YStack>
-            </YStack>
+            {desktopTable}
           </ScrollView>
-
-          {/* Fixed columns */}
-          {hasFixedColumns ? (
-            <YStack
-              minWidth={fixedMinWidth}
-              cursor="default"
-              bg="$bgApp"
-              $platform-web={{
-                boxShadow:
-                  showFixedShadow && paginatedData.length > 0
-                    ? getWebShadowStyle('right', isDark)
-                    : 'none',
-                clipPath: getWebClipPath('right'),
-                transition: `box-shadow ${SHADOW_CONSTANTS.TRANSITION_DURATION} ease-in-out`,
-              }}
-            >
-              <FixedColumnShadowOverlay
-                position="right"
-                visible={showFixedShadow ? paginatedData.length > 0 : false}
-                isDark={isDark}
-              />
-              <XStack
-                py="$2"
-                px="$3"
-                display="flex"
-                borderBottomWidth="$px"
-                borderBottomColor={borderColor}
-                bg={headerBgColor}
-              >
-                {fixedColumns.map((column, index) =>
-                  renderHeaderCell(column, index),
-                )}
-              </XStack>
-              <YStack flex={1} pb={enablePagination ? 0 : '$4'}>
-                {effectiveListLoading ? <YStack flex={1} p="$20" /> : null}
-                {!effectiveListLoading && paginatedData.length === 0 ? (
-                  <YStack flex={1} p="$5" />
-                ) : null}
-                {!effectiveListLoading && paginatedData.length > 0
-                  ? paginatedData.map((item, index) => (
-                      <Fragment
-                        key={keyExtractor?.(item, index) ?? String(index)}
-                      >
-                        {renderRow(
-                          item,
-                          index,
-                          'right',
-                          hoveredRowIndex === index,
-                          setHoveredRowIndex,
-                        )}
-                      </Fragment>
-                    ))
-                  : null}
-              </YStack>
-            </YStack>
-          ) : null}
-        </XStack>
+        ) : (
+          desktopTable
+        )}
 
         {enablePagination && currentListPage ? (
           <PaginationFooter

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTradesHistoryList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTradesHistoryList.tsx
@@ -47,6 +47,14 @@ type IFillWithOid = IFill & {
   oid?: number;
 };
 
+type IFillWithTwapId = IFill & {
+  twapId?: number;
+};
+
+function isTwapTradeFill(fill: IFill): boolean {
+  return typeof (fill as IFillWithTwapId).twapId === 'number';
+}
+
 function getFillKey(fill: IFill): string {
   const fillWithOid = fill as IFillWithOid;
   if (typeof fill.tid === 'number') {
@@ -57,16 +65,7 @@ function getFillKey(fill: IFill): string {
   }-${fill.px}-${fill.sz}`;
 }
 
-function sortTradesHistoryFills(fills: IFill[]): IFill[] {
-  return fills.toSorted(
-    (a, b) =>
-      b.time - a.time ||
-      (b.tid ?? 0) - (a.tid ?? 0) ||
-      ((b as IFillWithOid).oid ?? 0) - ((a as IFillWithOid).oid ?? 0),
-  );
-}
-
-function mergeTradesWithTwapSliceFills({
+function filterTwapSliceFillsFromTrades({
   trades,
   twapSliceFills,
 }: {
@@ -74,26 +73,17 @@ function mergeTradesWithTwapSliceFills({
   twapSliceFills: ITwapSliceFill[];
 }): IFill[] {
   if (twapSliceFills.length === 0) {
-    return trades;
+    return trades.filter((fill) => !isTwapTradeFill(fill));
   }
 
-  const existingKeys = new Set<string>();
-  const mergedTrades: IFill[] = [];
-
-  trades.forEach((fill) => {
-    existingKeys.add(getFillKey(fill));
-    mergedTrades.push(fill);
-  });
-
+  const twapFillKeys = new Set<string>();
   twapSliceFills.forEach((record) => {
-    const key = getFillKey(record.fill);
-    if (!existingKeys.has(key)) {
-      existingKeys.add(key);
-      mergedTrades.push(record.fill);
-    }
+    twapFillKeys.add(getFillKey(record.fill));
   });
 
-  return sortTradesHistoryFills(mergedTrades);
+  return trades.filter(
+    (fill) => !isTwapTradeFill(fill) && !twapFillKeys.has(getFillKey(fill)),
+  );
 }
 
 interface IPerpTradesHistoryListProps {
@@ -148,22 +138,14 @@ function PerpTradesHistoryList({
     return rawTwapSliceFills;
   }, [currentAccountAddress, rawTwapSliceFills, twapSliceFillsAccountAddress]);
 
-  const tradesWithTwapSliceFills = useMemo(
+  const nonTwapTrades = useMemo(
     () =>
-      mergeTradesWithTwapSliceFills({
+      filterTwapSliceFillsFromTrades({
         trades,
         twapSliceFills,
       }),
     [trades, twapSliceFills],
   );
-
-  const twapIdByFillKey = useMemo(() => {
-    const map = new Map<string, number>();
-    twapSliceFills.forEach((record) => {
-      map.set(getFillKey(record.fill), record.twapId);
-    });
-    return map;
-  }, [twapSliceFills]);
 
   const getLeverage = useCallback(
     async (coin: string): Promise<number> => {
@@ -395,19 +377,9 @@ function PerpTradesHistoryList({
         isHovered={isHovered}
         onHoverChange={onHoverChange}
         builderFeeRate={builderFeeRate}
-        twapId={
-          twapIdByFillKey.get(getFillKey(item)) ?? item.twapId ?? undefined
-        }
       />
     ),
-    [
-      isMobile,
-      totalMinWidth,
-      columnsConfig,
-      handleShare,
-      builderFeeRate,
-      twapIdByFillKey,
-    ],
+    [isMobile, totalMinWidth, columnsConfig, handleShare, builderFeeRate],
   );
   const [isLocked] = useAppIsLockedAtom();
 
@@ -434,7 +406,7 @@ function PerpTradesHistoryList({
       currentListPage={currentListPage}
       setCurrentListPage={setCurrentListPage}
       columns={columnsConfig}
-      data={tradesWithTwapSliceFills}
+      data={nonTwapTrades}
       isMobile={isMobile}
       minTableWidth={totalMinWidth}
       renderRow={renderTradesHistoryRow}
@@ -449,7 +421,7 @@ function PerpTradesHistoryList({
       paginationToBottom={isMobile}
       listLoading={isLoading}
       onViewAll={
-        !isMobile && tradesWithTwapSliceFills.length > TRADES_HISTORY_PAGE_SIZE
+        !isMobile && nonTwapTrades.length > TRADES_HISTORY_PAGE_SIZE
           ? onViewAllUrl
           : undefined
       }

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -585,13 +585,20 @@ function TwapHistoryRow({
             justifyContent="center"
             alignItems={calcCellAlign(columnConfigs[0].align)}
           >
+            <SizableText size="$bodySm">{creationTime.inline}</SizableText>
+          </YStack>
+          <YStack
+            {...getColumnStyle(columnConfigs[1])}
+            justifyContent="center"
+            alignItems={calcCellAlign(columnConfigs[1].align)}
+          >
             <SizableText size="$bodySmMedium" color={sideInfo.color}>
               {baseInfo.assetSymbol}
             </SizableText>
           </YStack>
           <XStack
-            {...getColumnStyle(columnConfigs[1])}
-            justifyContent={calcCellAlign(columnConfigs[1].align)}
+            {...getColumnStyle(columnConfigs[2])}
+            justifyContent={calcCellAlign(columnConfigs[2].align)}
             alignItems="center"
           >
             <SizableText size="$bodySm" color={sideInfo.color}>
@@ -599,8 +606,8 @@ function TwapHistoryRow({
             </SizableText>
           </XStack>
           <XStack
-            {...getColumnStyle(columnConfigs[2])}
-            justifyContent={calcCellAlign(columnConfigs[2].align)}
+            {...getColumnStyle(columnConfigs[3])}
+            justifyContent={calcCellAlign(columnConfigs[3].align)}
             alignItems="center"
           >
             <SizableText size="$bodySm" color={sideInfo.color}>
@@ -608,8 +615,8 @@ function TwapHistoryRow({
             </SizableText>
           </XStack>
           <XStack
-            {...getColumnStyle(columnConfigs[3])}
-            justifyContent={calcCellAlign(columnConfigs[3].align)}
+            {...getColumnStyle(columnConfigs[4])}
+            justifyContent={calcCellAlign(columnConfigs[4].align)}
             alignItems="center"
           >
             <SizableText size="$bodySm">
@@ -617,33 +624,26 @@ function TwapHistoryRow({
             </SizableText>
           </XStack>
           <YStack
-            {...getColumnStyle(columnConfigs[4])}
+            {...getColumnStyle(columnConfigs[5])}
             justifyContent="center"
-            alignItems={calcCellAlign(columnConfigs[4].align)}
+            alignItems={calcCellAlign(columnConfigs[5].align)}
           >
             <SizableText size="$bodySm">{baseInfo.runningTimeText}</SizableText>
           </YStack>
-          <XStack
-            {...getColumnStyle(columnConfigs[5])}
-            justifyContent={calcCellAlign(columnConfigs[5].align)}
-            alignItems="center"
-          >
-            <SizableText size="$bodySm">{baseInfo.reduceOnlyText}</SizableText>
-          </XStack>
           <XStack
             {...getColumnStyle(columnConfigs[6])}
             justifyContent={calcCellAlign(columnConfigs[6].align)}
             alignItems="center"
           >
+            <SizableText size="$bodySm">{baseInfo.reduceOnlyText}</SizableText>
+          </XStack>
+          <XStack
+            {...getColumnStyle(columnConfigs[7])}
+            justifyContent={calcCellAlign(columnConfigs[7].align)}
+            alignItems="center"
+          >
             <SizableText size="$bodySm">{baseInfo.randomizeText}</SizableText>
           </XStack>
-          <YStack
-            {...getColumnStyle(columnConfigs[7])}
-            justifyContent="center"
-            alignItems={calcCellAlign(columnConfigs[7].align)}
-          >
-            <SizableText size="$bodySm">{creationTime.inline}</SizableText>
-          </YStack>
         </>
       ) : null}
       {shouldRenderRight ? (
@@ -865,7 +865,7 @@ function PerpTwapList() {
     return sortTwapSliceFills(Array.from(byKey.values()));
   }, [currentAccountAddress, fillsAccountAddress, rawSliceFills]);
 
-  const twapColumns: IColumnConfig[] = useMemo(
+  const twapBaseColumns: IColumnConfig[] = useMemo(
     () => [
       {
         key: 'coin',
@@ -930,30 +930,55 @@ function PerpTwapList() {
         flex: 1,
         align: 'left',
       },
+    ],
+    [intl],
+  );
+
+  const creationTimeColumn: IColumnConfig = useMemo(
+    () => ({
+      key: 'creationTime',
+      title: intl.formatMessage({
+        id: ETranslations.perp_creation_time__title,
+      }),
+      minWidth: 150,
+      flex: 1,
+      align: 'left',
+    }),
+    [intl],
+  );
+
+  const activeColumns: IColumnConfig[] = useMemo(
+    () => [
+      ...twapBaseColumns,
+      creationTimeColumn,
       {
-        key: 'creationTime',
+        key: 'terminate',
         title: intl.formatMessage({
-          id: ETranslations.perp_creation_time__title,
+          id: ETranslations.perp_twap_terminate__action,
         }),
-        minWidth: 150,
-        flex: 1,
-        align: 'left',
-      },
-      {
-        key: activeTab === 'active' ? 'terminate' : 'status',
-        title:
-          activeTab === 'active'
-            ? intl.formatMessage({
-                id: ETranslations.perp_twap_terminate__action,
-              })
-            : intl.formatMessage({ id: ETranslations.global_status }),
-        minWidth: activeTab === 'active' ? 100 : 130,
+        minWidth: 100,
         flex: 1,
         align: 'right',
         fixed: true,
       },
     ],
-    [activeTab, intl],
+    [creationTimeColumn, intl, twapBaseColumns],
+  );
+
+  const historyColumns: IColumnConfig[] = useMemo(
+    () => [
+      creationTimeColumn,
+      ...twapBaseColumns,
+      {
+        key: 'status',
+        title: intl.formatMessage({ id: ETranslations.global_status }),
+        minWidth: 130,
+        flex: 1,
+        align: 'right',
+        fixed: true,
+      },
+    ],
+    [creationTimeColumn, intl, twapBaseColumns],
   );
 
   const fillColumns: IColumnConfig[] = useMemo(
@@ -1028,11 +1053,19 @@ function PerpTwapList() {
 
   const activeMinWidth = useMemo(
     () =>
-      twapColumns.reduce(
+      activeColumns.reduce(
         (sum, col) => sum + (col.width || col.minWidth || 0),
         0,
       ),
-    [twapColumns],
+    [activeColumns],
+  );
+  const historyMinWidth = useMemo(
+    () =>
+      historyColumns.reduce(
+        (sum, col) => sum + (col.width || col.minWidth || 0),
+        0,
+      ),
+    [historyColumns],
   );
   const fillMinWidth = useMemo(
     () =>
@@ -1103,7 +1136,7 @@ function PerpTwapList() {
         order={item}
         now={now}
         cellMinWidth={activeMinWidth}
-        columnConfigs={twapColumns}
+        columnConfigs={activeColumns}
         onTerminate={() => void handleTerminate(item)}
         index={index}
         renderMode={renderMode}
@@ -1112,7 +1145,7 @@ function PerpTwapList() {
         spotDisplayMap={spotDisplayMap}
       />
     ),
-    [activeMinWidth, handleTerminate, now, spotDisplayMap, twapColumns],
+    [activeColumns, activeMinWidth, handleTerminate, now, spotDisplayMap],
   );
 
   const renderHistoryRow = useCallback(
@@ -1126,8 +1159,8 @@ function PerpTwapList() {
       <TwapHistoryRow
         record={item}
         now={now}
-        cellMinWidth={activeMinWidth}
-        columnConfigs={twapColumns}
+        cellMinWidth={historyMinWidth}
+        columnConfigs={historyColumns}
         index={index}
         renderMode={renderMode}
         isHovered={isHovered}
@@ -1135,7 +1168,7 @@ function PerpTwapList() {
         spotDisplayMap={spotDisplayMap}
       />
     ),
-    [activeMinWidth, now, spotDisplayMap, twapColumns],
+    [historyColumns, historyMinWidth, now, spotDisplayMap],
   );
 
   const renderFillRow = useCallback(
@@ -1196,7 +1229,7 @@ function PerpTwapList() {
           pageSize={TWAP_PAGE_SIZE}
           currentListPage={currentListPage}
           setCurrentListPage={setCurrentListPage}
-          columns={twapColumns}
+          columns={activeColumns}
           minTableWidth={activeMinWidth}
           data={twapOrders}
           renderRow={renderActiveRow}
@@ -1216,8 +1249,8 @@ function PerpTwapList() {
           pageSize={TWAP_PAGE_SIZE}
           currentListPage={currentListPage}
           setCurrentListPage={setCurrentListPage}
-          columns={twapColumns}
-          minTableWidth={activeMinWidth}
+          columns={historyColumns}
+          minTableWidth={historyMinWidth}
           data={historyRows}
           renderRow={renderHistoryRow}
           ListEmptyComponent={listEmptyComponent}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -17,6 +17,7 @@ import {
   useMedia,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import {
   type IPerpsActiveTwapOrder,
   useHyperliquidActions,
@@ -238,6 +239,34 @@ function getTwapBaseInfo({
       ? intl.formatMessage({ id: ETranslations.perp_yes__title })
       : intl.formatMessage({ id: ETranslations.perp_no__title }),
   };
+}
+
+function MobileTwapHistoryInfoRow({
+  label,
+  value,
+  valueColor,
+}: {
+  label: string;
+  value: string;
+  valueColor?: string;
+}) {
+  return (
+    <XStack width="100%" alignItems="center" justifyContent="space-between">
+      <SizableText size="$bodySm" color="$textSubdued">
+        {label}
+      </SizableText>
+      <SizableText
+        size="$bodySm"
+        color={valueColor}
+        numberOfLines={1}
+        ellipsizeMode="tail"
+        textAlign="right"
+        maxWidth="60%"
+      >
+        {value}
+      </SizableText>
+    </XStack>
+  );
 }
 
 function getFillKey(record: ITwapSliceFill) {
@@ -517,6 +546,7 @@ function TwapHistoryRow({
   isHovered,
   onHoverChange,
   spotDisplayMap,
+  isMobile,
 }: {
   record: ITwapHistoryRecord;
   now: number;
@@ -527,6 +557,7 @@ function TwapHistoryRow({
   isHovered?: boolean;
   onHoverChange?: (index: number | null) => void;
   spotDisplayMap: Record<string, string>;
+  isMobile?: boolean;
 }) {
   const intl = useIntl();
   const { state } = record;
@@ -566,6 +597,118 @@ function TwapHistoryRow({
   const bgColor = getTableRowBgColor({ isHovered, index });
   const shouldRenderLeft = renderMode === 'full' || renderMode === 'left';
   const shouldRenderRight = renderMode === 'full' || renderMode === 'right';
+
+  if (isMobile) {
+    let statusColor = '$textSubdued';
+    if (record.status.status === 'error') {
+      statusColor = '$red11';
+    } else if (record.status.status === 'finished') {
+      statusColor = '$green11';
+    }
+
+    return (
+      <ListItem
+        mx="$5"
+        my="$2"
+        p="$0"
+        backgroundColor="$bgSubdued"
+        flexDirection="column"
+        alignItems="flex-start"
+        borderRadius="$3"
+      >
+        <XStack
+          px="$3"
+          pt="$3"
+          pb="$2"
+          justifyContent="space-between"
+          alignItems="flex-start"
+          width="100%"
+          gap="$3"
+        >
+          <YStack flex={1} gap="$1">
+            <XStack gap="$2" alignItems="center" flexWrap="wrap">
+              <SizableText size="$bodyMdMedium" numberOfLines={1}>
+                {baseInfo.assetSymbol}
+              </SizableText>
+              <SizableText
+                size="$bodySm"
+                color={sideInfo.color}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {sideInfo.text}
+              </SizableText>
+            </XStack>
+            <SizableText size="$bodySm" color="$textSubdued">
+              {intl.formatMessage({
+                id: ETranslations.perp_twap_order__title,
+              })}{' '}
+              · {creationTime.inline}
+            </SizableText>
+          </YStack>
+          <YStack alignItems="flex-end" gap="$1" maxWidth="42%">
+            <SizableText size="$bodySm" color="$textSubdued">
+              {intl.formatMessage({ id: ETranslations.global_status })}
+            </SizableText>
+            <SizableText
+              size="$bodySmMedium"
+              color={statusColor}
+              numberOfLines={2}
+              ellipsizeMode="tail"
+              textAlign="right"
+            >
+              {statusText}
+            </SizableText>
+          </YStack>
+        </XStack>
+        <YStack
+          px="$3"
+          py="$3"
+          width="100%"
+          gap="$2"
+          borderTopWidth="$px"
+          borderTopColor="$borderSubdued"
+        >
+          <MobileTwapHistoryInfoRow
+            label={intl.formatMessage({
+              id: ETranslations.perp_position_position_size,
+            })}
+            value={baseInfo.sizeWithSymbol}
+            valueColor={sideInfo.color}
+          />
+          <MobileTwapHistoryInfoRow
+            label={intl.formatMessage({
+              id: ETranslations.perp_executed_size__title,
+            })}
+            value={baseInfo.executedSizeWithSymbol}
+            valueColor={sideInfo.color}
+          />
+          <MobileTwapHistoryInfoRow
+            label={intl.formatMessage({
+              id: ETranslations.perp_average_price__title,
+            })}
+            value={baseInfo.avgPriceFormatted}
+          />
+          <MobileTwapHistoryInfoRow
+            label={intl.formatMessage({
+              id: ETranslations.perp_twap_running_time_total__title,
+            })}
+            value={baseInfo.runningTimeText}
+          />
+          <MobileTwapHistoryInfoRow
+            label={intl.formatMessage({ id: ETranslations.perps_reduce_only })}
+            value={baseInfo.reduceOnlyText}
+          />
+          <MobileTwapHistoryInfoRow
+            label={intl.formatMessage({
+              id: ETranslations.perp_twap_random__title,
+            })}
+            value={baseInfo.randomizeText}
+          />
+        </YStack>
+      </ListItem>
+    );
+  }
 
   return (
     <XStack
@@ -859,7 +1002,21 @@ function TwapFillRow({
   );
 }
 
-function PerpTwapList() {
+interface IPerpTwapListProps {
+  isMobile?: boolean;
+  useTabsList?: boolean;
+  disableListScroll?: boolean;
+  initialTab?: ITwapPanelTab;
+  enabledTabs?: ITwapPanelTab[];
+}
+
+function PerpTwapList({
+  isMobile,
+  useTabsList,
+  disableListScroll,
+  initialTab = 'active',
+  enabledTabs,
+}: IPerpTwapListProps) {
   const actions = useHyperliquidActions();
   const intl = useIntl();
   const [
@@ -871,10 +1028,14 @@ function PerpTwapList() {
     usePerpsTwapSliceFillsAtom();
   const [currentUser] = usePerpsActiveAccountAtom();
   const [spotDisplayMap] = useSpotPairDisplayMapAtom();
-  const [activeTab, setActiveTab] = useState<ITwapPanelTab>('active');
+  const [activeTab, setActiveTab] = useState<ITwapPanelTab>(initialTab);
   const [currentListPage, setCurrentListPage] = useState(1);
   const [now, setNow] = useState(Date.now());
   const [builderFeeRate, setBuilderFeeRate] = useState<number | undefined>();
+  const enabledTabsSet = useMemo(
+    () => new Set(enabledTabs ?? TWAP_ORDERS_SUB_TABS.map((tab) => tab.key)),
+    [enabledTabs],
+  );
 
   useEffect(() => {
     void backgroundApiProxy.simpleDb.perp
@@ -887,6 +1048,17 @@ function PerpTwapList() {
   useEffect(() => {
     void actions.current.loadTwapData();
   }, [actions, currentUser?.accountAddress]);
+
+  useEffect(() => {
+    if (!enabledTabsSet.has(activeTab)) {
+      const firstEnabledTab = TWAP_ORDERS_SUB_TABS.find((tab) =>
+        enabledTabsSet.has(tab.key),
+      );
+      if (firstEnabledTab) {
+        setActiveTab(firstEnabledTab.key);
+      }
+    }
+  }, [activeTab, enabledTabsSet]);
 
   useEffect(() => {
     setCurrentListPage(1);
@@ -1238,9 +1410,10 @@ function PerpTwapList() {
         isHovered={isHovered}
         onHoverChange={onHoverChange}
         spotDisplayMap={spotDisplayMap}
+        isMobile={isMobile}
       />
     ),
-    [historyColumns, historyMinWidth, now, spotDisplayMap],
+    [historyColumns, historyMinWidth, isMobile, now, spotDisplayMap],
   );
 
   const renderFillRow = useCallback(
@@ -1269,11 +1442,13 @@ function PerpTwapList() {
   const emptyState = TWAP_EMPTY_STATE_MAP[activeTab];
   const twapOrderSubTabs = useMemo(
     () =>
-      TWAP_ORDERS_SUB_TABS.map((tab) => ({
-        key: tab.key,
-        label: intl.formatMessage({ id: tab.labelId }),
-      })),
-    [intl],
+      TWAP_ORDERS_SUB_TABS.filter((tab) => enabledTabsSet.has(tab.key)).map(
+        (tab) => ({
+          key: tab.key,
+          label: intl.formatMessage({ id: tab.labelId }),
+        }),
+      ),
+    [enabledTabsSet, intl],
   );
   const listEmptyComponent = useMemo(
     () => (
@@ -1287,17 +1462,20 @@ function PerpTwapList() {
 
   return (
     <YStack flex={1}>
-      <OrderInfoSubTabs
-        tabs={twapOrderSubTabs}
-        activeTab={activeTab}
-        onChange={setActiveTab}
-        variant="underline"
-      />
+      {twapOrderSubTabs.length > 1 ? (
+        <OrderInfoSubTabs
+          tabs={twapOrderSubTabs}
+          activeTab={activeTab}
+          onChange={setActiveTab}
+          variant="underline"
+        />
+      ) : null}
       {activeTab === 'active' ? (
         <CommonTableListView
           onPullToRefresh={refreshTwapData}
           listViewDebugRenderTrackerProps={trackerProps}
-          useTabsList
+          useTabsList={useTabsList}
+          disableListScroll={disableListScroll}
           enablePagination
           pageSize={TWAP_PAGE_SIZE}
           currentListPage={currentListPage}
@@ -1305,6 +1483,8 @@ function PerpTwapList() {
           columns={activeColumns}
           minTableWidth={activeMinWidth}
           data={twapOrders}
+          isMobile={isMobile}
+          paginationToBottom={isMobile}
           renderRow={renderActiveRow}
           ListEmptyComponent={listEmptyComponent}
           emptyMessage={intl.formatMessage({
@@ -1317,7 +1497,8 @@ function PerpTwapList() {
         <CommonTableListView
           onPullToRefresh={refreshTwapData}
           listViewDebugRenderTrackerProps={trackerProps}
-          useTabsList
+          useTabsList={useTabsList}
+          disableListScroll={disableListScroll}
           enablePagination
           pageSize={TWAP_PAGE_SIZE}
           currentListPage={currentListPage}
@@ -1325,6 +1506,8 @@ function PerpTwapList() {
           columns={historyColumns}
           minTableWidth={historyMinWidth}
           data={historyRows}
+          isMobile={isMobile}
+          paginationToBottom={isMobile}
           renderRow={renderHistoryRow}
           ListEmptyComponent={listEmptyComponent}
           emptyMessage={intl.formatMessage({
@@ -1337,7 +1520,8 @@ function PerpTwapList() {
         <CommonTableListView
           onPullToRefresh={refreshTwapData}
           listViewDebugRenderTrackerProps={trackerProps}
-          useTabsList
+          useTabsList={useTabsList}
+          disableListScroll={disableListScroll}
           enablePagination
           pageSize={TWAP_PAGE_SIZE}
           currentListPage={currentListPage}
@@ -1345,6 +1529,8 @@ function PerpTwapList() {
           columns={fillColumns}
           minTableWidth={fillMinWidth}
           data={sliceFills}
+          isMobile={isMobile}
+          paginationToBottom={isMobile}
           renderRow={renderFillRow}
           ListEmptyComponent={listEmptyComponent}
           emptyMessage={intl.formatMessage({

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -232,6 +232,9 @@ function getTwapBaseInfo({
     reduceOnlyText: state.reduceOnly
       ? intl.formatMessage({ id: ETranslations.perp_yes__title })
       : intl.formatMessage({ id: ETranslations.perp_no__title }),
+    randomizeText: state.randomize
+      ? intl.formatMessage({ id: ETranslations.perp_yes__title })
+      : intl.formatMessage({ id: ETranslations.perp_no__title }),
   };
 }
 
@@ -462,10 +465,17 @@ function TwapActiveRow({
           >
             <SizableText size="$bodySm">{baseInfo.reduceOnlyText}</SizableText>
           </XStack>
-          <YStack
+          <XStack
             {...getColumnStyle(columnConfigs[6])}
+            justifyContent={calcCellAlign(columnConfigs[6].align)}
+            alignItems="center"
+          >
+            <SizableText size="$bodySm">{baseInfo.randomizeText}</SizableText>
+          </XStack>
+          <YStack
+            {...getColumnStyle(columnConfigs[7])}
             justifyContent="center"
-            alignItems={calcCellAlign(columnConfigs[6].align)}
+            alignItems={calcCellAlign(columnConfigs[7].align)}
           >
             <SizableText size="$bodySm">{creationTime.inline}</SizableText>
           </YStack>
@@ -473,8 +483,8 @@ function TwapActiveRow({
       ) : null}
       {shouldRenderRight ? (
         <XStack
-          {...getColumnStyle(columnConfigs[7])}
-          justifyContent={calcCellAlign(columnConfigs[7].align)}
+          {...getColumnStyle(columnConfigs[8])}
+          justifyContent={calcCellAlign(columnConfigs[8].align)}
           alignItems="center"
           cursor="pointer"
         >
@@ -620,10 +630,17 @@ function TwapHistoryRow({
           >
             <SizableText size="$bodySm">{baseInfo.reduceOnlyText}</SizableText>
           </XStack>
-          <YStack
+          <XStack
             {...getColumnStyle(columnConfigs[6])}
+            justifyContent={calcCellAlign(columnConfigs[6].align)}
+            alignItems="center"
+          >
+            <SizableText size="$bodySm">{baseInfo.randomizeText}</SizableText>
+          </XStack>
+          <YStack
+            {...getColumnStyle(columnConfigs[7])}
             justifyContent="center"
-            alignItems={calcCellAlign(columnConfigs[6].align)}
+            alignItems={calcCellAlign(columnConfigs[7].align)}
           >
             <SizableText size="$bodySm">{creationTime.inline}</SizableText>
           </YStack>
@@ -631,8 +648,8 @@ function TwapHistoryRow({
       ) : null}
       {shouldRenderRight ? (
         <XStack
-          {...getColumnStyle(columnConfigs[7])}
-          justifyContent={calcCellAlign(columnConfigs[7].align)}
+          {...getColumnStyle(columnConfigs[8])}
+          justifyContent={calcCellAlign(columnConfigs[8].align)}
           alignItems="center"
         >
           <SizableText
@@ -901,6 +918,15 @@ function PerpTwapList() {
           id: ETranslations.perps_reduce_only,
         }),
         minWidth: 120,
+        flex: 1,
+        align: 'left',
+      },
+      {
+        key: 'randomize',
+        title: intl.formatMessage({
+          id: ETranslations.perp_twap_random__title,
+        }),
+        minWidth: 100,
         flex: 1,
         align: 'left',
       },

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -1476,6 +1476,7 @@ function PerpTwapList({
           listViewDebugRenderTrackerProps={trackerProps}
           useTabsList={useTabsList}
           disableListScroll={disableListScroll}
+          enableDesktopVerticalScroll={!isMobile}
           enablePagination
           pageSize={TWAP_PAGE_SIZE}
           currentListPage={currentListPage}
@@ -1499,6 +1500,7 @@ function PerpTwapList({
           listViewDebugRenderTrackerProps={trackerProps}
           useTabsList={useTabsList}
           disableListScroll={disableListScroll}
+          enableDesktopVerticalScroll={!isMobile}
           enablePagination
           pageSize={TWAP_PAGE_SIZE}
           currentListPage={currentListPage}
@@ -1522,6 +1524,7 @@ function PerpTwapList({
           listViewDebugRenderTrackerProps={trackerProps}
           useTabsList={useTabsList}
           disableListScroll={disableListScroll}
+          enableDesktopVerticalScroll={!isMobile}
           enablePagination
           pageSize={TWAP_PAGE_SIZE}
           currentListPage={currentListPage}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -108,9 +108,7 @@ function formatTwapDateTime(timestamp: number) {
   return {
     date,
     time,
-    inline: `${formatTime(timeDate, {
-      formatTemplate: 'M/d/yyyy',
-    })} - ${time}`,
+    inline: `${date} ${time}`,
   };
 }
 

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -5,11 +5,13 @@ import { type IntlShape, useIntl } from 'react-intl';
 
 import {
   Button,
+  DashText,
   type IDebugRenderTrackerProps,
   Icon,
   Illustration,
   SizableText,
   Toast,
+  Tooltip,
   XStack,
   YStack,
   useMedia,
@@ -675,6 +677,7 @@ function TwapFillRow({
   isHovered,
   onHoverChange,
   spotDisplayMap,
+  builderFeeRate,
 }: {
   record: ITwapSliceFill;
   cellMinWidth: number;
@@ -684,6 +687,7 @@ function TwapFillRow({
   isHovered?: boolean;
   onHoverChange?: (index: number | null) => void;
   spotDisplayMap: Record<string, string>;
+  builderFeeRate?: number;
 }) {
   const intl = useIntl();
   const { fill } = record;
@@ -699,6 +703,11 @@ function TwapFillRow({
   const fillInfo = useMemo(() => {
     const priceBN = new BigNumber(fill.px);
     const sizeBN = new BigNumber(fill.sz);
+    const closePnlBN = new BigNumber(fill.closedPnl).minus(
+      new BigNumber(fill.fee),
+    );
+    const closePnlColor = closePnlBN.lt(0) ? '$red11' : '$green11';
+    const closePnlPlusOrMinus = closePnlBN.lt(0) ? '-' : '';
     const priceFormatted = priceBN.isFinite()
       ? priceBN.toFixed(getValidPriceDecimals(fill.px))
       : fill.px;
@@ -710,10 +719,42 @@ function TwapFillRow({
         valueFormatter,
       ),
       feeFormatted: numberFormat(fill.fee, valueFormatter),
+      closePnlFormatted: numberFormat(closePnlBN.abs().toFixed(), {
+        formatter: 'value',
+        formatterOptions: {
+          currency: '$',
+        },
+      }),
+      closePnlColor,
+      closePnlPlusOrMinus,
     };
-  }, [fill.fee, fill.px, fill.sz]);
+  }, [fill.closedPnl, fill.fee, fill.px, fill.sz]);
+  const feeTooltipContent = useMemo(() => {
+    const feeRatePercentage =
+      builderFeeRate !== undefined
+        ? `${(builderFeeRate / 1000).toFixed(2)}%`
+        : '-';
+    return (
+      <YStack gap="$3">
+        <YStack gap="$1.5">
+          <SizableText size="$bodySm">
+            {intl.formatMessage({ id: ETranslations.perps_fee_title })}
+            {feeRatePercentage}
+          </SizableText>
+          <SizableText size="$bodySm">
+            {intl.formatMessage({ id: ETranslations.perps_fee_total })}
+            {fillInfo.feeFormatted}
+          </SizableText>
+        </YStack>
+        <SizableText size="$bodySm" color="$textSubdued">
+          {intl.formatMessage({ id: ETranslations.perps_fee_desc })}
+        </SizableText>
+      </YStack>
+    );
+  }, [builderFeeRate, fillInfo.feeFormatted, intl]);
   const bgColor = getTableRowBgColor({ isHovered, index });
   const shouldRenderLeft = renderMode === 'full' || renderMode === 'left';
+  const shouldRenderRight = renderMode === 'full' || renderMode === 'right';
 
   return (
     <XStack
@@ -782,18 +823,37 @@ function TwapFillRow({
             justifyContent={calcCellAlign(columnConfigs[6].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm" color="$textSubdued">
-              {fillInfo.feeFormatted}
-            </SizableText>
-          </XStack>
-          <XStack
-            {...getColumnStyle(columnConfigs[7])}
-            justifyContent={calcCellAlign(columnConfigs[7].align)}
-            alignItems="center"
-          >
-            <SizableText size="$bodySm">#{record.twapId}</SizableText>
+            <Tooltip
+              placement="top"
+              renderTrigger={
+                <DashText
+                  size="$bodySm"
+                  color="$textSubdued"
+                  dashThickness={0.3}
+                >
+                  {fillInfo.feeFormatted}
+                </DashText>
+              }
+              renderContent={feeTooltipContent}
+            />
           </XStack>
         </>
+      ) : null}
+      {shouldRenderRight ? (
+        <XStack
+          {...getColumnStyle(columnConfigs[7])}
+          justifyContent={calcCellAlign(columnConfigs[7].align)}
+          alignItems="center"
+        >
+          <SizableText
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            size="$bodySm"
+            color={fillInfo.closePnlColor}
+          >
+            {`${fillInfo.closePnlPlusOrMinus}${fillInfo.closePnlFormatted}`}
+          </SizableText>
+        </XStack>
       ) : null}
     </XStack>
   );
@@ -814,6 +874,15 @@ function PerpTwapList() {
   const [activeTab, setActiveTab] = useState<ITwapPanelTab>('active');
   const [currentListPage, setCurrentListPage] = useState(1);
   const [now, setNow] = useState(Date.now());
+  const [builderFeeRate, setBuilderFeeRate] = useState<number | undefined>();
+
+  useEffect(() => {
+    void backgroundApiProxy.simpleDb.perp
+      .getExpectMaxBuilderFee()
+      .then((fee) => {
+        setBuilderFeeRate(fee);
+      });
+  }, []);
 
   useEffect(() => {
     void actions.current.loadTwapData();
@@ -1035,17 +1104,20 @@ function PerpTwapList() {
       },
       {
         key: 'fee',
-        title: intl.formatMessage({ id: ETranslations.perp_fee__title }),
+        title: intl.formatMessage({
+          id: ETranslations.perp_trades_history_fee,
+        }),
         minWidth: 110,
         flex: 1,
         align: 'left',
       },
       {
-        key: 'twapId',
-        title: intl.formatMessage({ id: ETranslations.perp_twap_id__title }),
+        key: 'closePnl',
+        title: intl.formatMessage({ id: ETranslations.perp_trades_close_pnl }),
         minWidth: 100,
         flex: 1,
-        align: 'left',
+        align: 'right',
+        fixed: true,
       },
     ],
     [intl],
@@ -1188,9 +1260,10 @@ function PerpTwapList() {
         isHovered={isHovered}
         onHoverChange={onHoverChange}
         spotDisplayMap={spotDisplayMap}
+        builderFeeRate={builderFeeRate}
       />
     ),
-    [fillColumns, fillMinWidth, spotDisplayMap],
+    [builderFeeRate, fillColumns, fillMinWidth, spotDisplayMap],
   );
 
   const emptyState = TWAP_EMPTY_STATE_MAP[activeTab];

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpTradersHistoryListModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpTradersHistoryListModal.tsx
@@ -128,7 +128,7 @@ export function PerpTradersHistoryListModal() {
                 isMobile
                 useTabsList={false}
                 initialTab="history"
-                enabledTabs={['history']}
+                enabledTabs={['history', 'fills']}
               />
             ) : null}
             {activeTab === 'Account' ? (

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpTradersHistoryListModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpTradersHistoryListModal.tsx
@@ -22,8 +22,27 @@ import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 
 import { PerpAccountList } from './List/PerpAccountList';
 import { PerpTradesHistoryList } from './List/PerpTradesHistoryList';
+import { PerpTwapList } from './List/PerpTwapList';
 
-type ITabName = 'Trades' | 'Account';
+type ITabName = 'Trades' | 'Twap' | 'Account';
+
+const HISTORY_TABS: Array<{
+  name: ITabName;
+  labelId: ETranslations;
+}> = [
+  {
+    name: 'Trades',
+    labelId: ETranslations.perp_trades_history_title,
+  },
+  {
+    name: 'Twap',
+    labelId: ETranslations.perp_twap_order__title,
+  },
+  {
+    name: 'Account',
+    labelId: ETranslations.perp_account_history,
+  },
+];
 
 function TabHeader({
   activeTab,
@@ -40,31 +59,22 @@ function TabHeader({
       borderBottomWidth="$0.5"
       borderBottomColor="$borderSubdued"
     >
-      <XStack
-        py="$3"
-        ml="$5"
-        mr="$2"
-        borderBottomWidth={activeTab === 'Trades' ? '$0.5' : '$0'}
-        borderBottomColor="$borderActive"
-        onPress={() => onTabChange('Trades')}
-        mb={-2}
-      >
-        <SizableText size="$headingXs">
-          {intl.formatMessage({ id: ETranslations.perp_trades_history_title })}
-        </SizableText>
-      </XStack>
-      <XStack
-        py="$3"
-        mx="$2"
-        borderBottomWidth={activeTab === 'Account' ? '$0.5' : '$0'}
-        borderBottomColor="$borderActive"
-        onPress={() => onTabChange('Account')}
-        mb={-2}
-      >
-        <SizableText size="$headingXs">
-          {intl.formatMessage({ id: ETranslations.perp_account_history })}
-        </SizableText>
-      </XStack>
+      {HISTORY_TABS.map((tab, index) => (
+        <XStack
+          key={tab.name}
+          py="$3"
+          ml={index === 0 ? '$5' : '$2'}
+          mr="$2"
+          borderBottomWidth={activeTab === tab.name ? '$0.5' : '$0'}
+          borderBottomColor="$borderActive"
+          onPress={() => onTabChange(tab.name)}
+          mb={-2}
+        >
+          <SizableText size="$headingXs">
+            {intl.formatMessage({ id: tab.labelId })}
+          </SizableText>
+        </XStack>
+      ))}
     </XStack>
   );
 }
@@ -112,7 +122,16 @@ export function PerpTradersHistoryListModal() {
           <YStack flex={1}>
             {activeTab === 'Trades' ? (
               <PerpTradesHistoryList isMobile useTabsList={false} />
-            ) : (
+            ) : null}
+            {activeTab === 'Twap' ? (
+              <PerpTwapList
+                isMobile
+                useTabsList={false}
+                initialTab="history"
+                enabledTabs={['history']}
+              />
+            ) : null}
+            {activeTab === 'Account' ? (
               <PerpAccountList
                 isMobile
                 useTabsList={false}
@@ -122,7 +141,7 @@ export function PerpTradersHistoryListModal() {
                   </Stack>
                 }
               />
-            )}
+            ) : null}
           </YStack>
         </YStack>
       </PageBody>

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -1487,7 +1487,7 @@ function SideButtonInternal({
           disabledStyle={
             shouldPreserveDisabledButtonStyle ? { opacity: 1 } : undefined
           }
-          loading={shouldShowButtonLoading || isSubmitting}
+          loading={shouldShowButtonLoading}
           onPress={handlePress}
           h={36}
           py={
@@ -1534,7 +1534,7 @@ function SideButtonInternal({
         disabledStyle={
           shouldPreserveDisabledButtonStyle ? { opacity: 1 } : undefined
         }
-        loading={shouldShowButtonLoading || isSubmitting}
+        loading={shouldShowButtonLoading}
         onPress={handlePress}
         h={36}
         py={!orderValue.isZero() && orderValue.isFinite() ? '$0.5' : undefined}

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -173,8 +173,11 @@ function hasPerpsOrderSizeInput(
 function shouldUseEmptySizeTradingButtons(
   formData: ITradingFormEmptySizeParams,
 ) {
+  const isAlgoOrderMode =
+    formData.orderMode === 'scale' || formData.orderMode === 'twap';
   return (
     formData.orderMode !== 'trigger' &&
+    !isAlgoOrderMode &&
     !formData.bboPriceMode &&
     !hasPerpsOrderSizeInput(formData)
   );
@@ -496,7 +499,7 @@ function SideButtonInternal({
   }, [activeTradeInstrument, isSpot]);
 
   const buttonText = useMemo(() => {
-    if (isMobile && formData.orderMode === 'scale') {
+    if (formData.orderMode === 'scale') {
       return side === 'long'
         ? intl.formatMessage({
             id: ETranslations.perp_preview_buy__action,
@@ -553,7 +556,6 @@ function SideButtonInternal({
   }, [
     priceError,
     formData.orderMode,
-    isMobile,
     isNoEnoughMargin,
     isSpot,
     side,

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -2258,6 +2258,7 @@ function PerpTradingForm({
                   flex={1}
                   numberOfLines={1}
                 >
+                  {/* TODO: replace hardcoded QA copy with ETranslations after the i18n key is added. */}
                   Per child order size
                 </SizableText>
                 <SizableText

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -963,7 +963,7 @@ function PerpTradingForm({
     }
   }, [formData.twapDurationMinutes, intl, isTwapMode]);
 
-  const twapHelperMessage = useMemo(() => {
+  const twapEstimatedSliceNotional = useMemo(() => {
     if (!isTwapMode) {
       return undefined;
     }
@@ -987,22 +987,38 @@ function PerpTradingForm({
     const estimatedSliceNotional = advancedComputedSizeBN
       .multipliedBy(midPriceBN)
       .dividedBy(estimatedSlices);
-    if (
-      estimatedSliceNotional.isFinite() &&
-      estimatedSliceNotional.gt(0) &&
-      estimatedSliceNotional.lt(TWAP_MIN_SLICE_NOTIONAL_HINT)
-    ) {
-      return twapSmallSliceHelperText;
+    if (!estimatedSliceNotional.isFinite() || estimatedSliceNotional.lte(0)) {
+      return undefined;
     }
 
-    return undefined;
+    return estimatedSliceNotional;
   }, [
     formData.twapDurationMinutes,
     isTwapMode,
     midPriceBN,
     advancedComputedSizeBN,
-    twapSmallSliceHelperText,
   ]);
+
+  const twapEstimatedSliceNotionalDisplay = useMemo(() => {
+    if (!twapEstimatedSliceNotional) {
+      return undefined;
+    }
+
+    return `${numberFormat(twapEstimatedSliceNotional.toFixed(), {
+      formatter: 'balance',
+    })} ${USDC_TOKEN_SYMBOL}`;
+  }, [twapEstimatedSliceNotional]);
+
+  const twapHelperMessage = useMemo(() => {
+    if (
+      twapEstimatedSliceNotional &&
+      twapEstimatedSliceNotional.lt(TWAP_MIN_SLICE_NOTIONAL_HINT)
+    ) {
+      return twapSmallSliceHelperText;
+    }
+
+    return undefined;
+  }, [twapEstimatedSliceNotional, twapSmallSliceHelperText]);
 
   const [twapDurationHoursInput, setTwapDurationHoursInput] = useState('');
   const [twapDurationMinutesInput, setTwapDurationMinutesInput] = useState('');
@@ -2163,8 +2179,8 @@ function PerpTradingForm({
     }
     if (isTwapMode) {
       return (
-        <YStack gap="$1.5" {...(isMobile && { mt: '$1' })} p="$0">
-          <YStack alignItems="flex-start" gap="$2.5">
+        <YStack width="100%" gap="$1.5" {...(isMobile && { mt: '$1' })} p="$0">
+          <YStack width="100%" alignItems="flex-start" gap="$2.5">
             {isSpot ? null : (
               <XStack alignItems="center" gap="$2">
                 <Checkbox
@@ -2229,6 +2245,30 @@ function PerpTradingForm({
                 }
               />
             </XStack>
+            {twapEstimatedSliceNotionalDisplay ? (
+              <XStack
+                width="100%"
+                alignItems="center"
+                justifyContent="space-between"
+                gap="$3"
+              >
+                <SizableText
+                  size={isMobile ? '$bodySm' : '$bodyMdMedium'}
+                  color="$textSubdued"
+                  flex={1}
+                  numberOfLines={1}
+                >
+                  Per child order size
+                </SizableText>
+                <SizableText
+                  size={isMobile ? '$bodySmMedium' : '$bodyMdMedium'}
+                  color="$text"
+                  numberOfLines={1}
+                >
+                  {twapEstimatedSliceNotionalDisplay}
+                </SizableText>
+              </XStack>
+            ) : null}
           </YStack>
         </YStack>
       );

--- a/packages/kit/src/views/Perp/hooks/useTradingCalculationsForSide.ts
+++ b/packages/kit/src/views/Perp/hooks/useTradingCalculationsForSide.ts
@@ -11,6 +11,7 @@ import {
   usePerpsActiveAssetDataAtom,
   useSpotBalancesAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { getReduceOnlyPositionMaxSize } from '@onekeyhq/shared/src/utils/hyperliquidScaleOrderUtils';
 import {
   computeMaxTradeSize,
   resolveTradingSizeBN,
@@ -19,6 +20,7 @@ import {
 import { EPerpsSizeInputMode } from '@onekeyhq/shared/types/hyperliquid/types';
 
 import { useOrderPrice } from './useOrderPrice';
+import { usePerpsAccountScopedActivePositions } from './usePerpsAccountScopedActivePositions';
 import { useTradingPrice } from './useTradingPrice';
 
 export function useTradingCalculationsForSide(side: 'long' | 'short') {
@@ -27,6 +29,7 @@ export function useTradingCalculationsForSide(side: 'long' | 'short') {
   const [activeAsset] = usePerpsActiveAssetAtom();
   const [activeAssetData] = usePerpsActiveAssetDataAtom();
   const [{ balances: spotBalances }] = useSpotBalancesAtom();
+  const perpsPositions = usePerpsAccountScopedActivePositions();
 
   const orderPrice = useOrderPrice(side);
   const { midPriceBN } = useTradingPrice();
@@ -213,6 +216,31 @@ export function useTradingCalculationsForSide(side: 'long' | 'short') {
     [availableMarginBN],
   );
 
+  const scaleReduceOnlyMaxSizeBN = useMemo(() => {
+    if (isSpot || formData.orderMode !== 'scale' || !formData.scaleReduceOnly) {
+      return undefined;
+    }
+
+    const position = perpsPositions.find(
+      (pos) => pos.position.coin === activeTradeInstrument.coin,
+    )?.position;
+
+    return getReduceOnlyPositionMaxSize({
+      reduceOnly: formData.scaleReduceOnly,
+      side,
+      positionSize: position?.szi,
+      szDecimals: activeAsset?.universe?.szDecimals,
+    });
+  }, [
+    activeAsset?.universe?.szDecimals,
+    activeTradeInstrument.coin,
+    formData.orderMode,
+    formData.scaleReduceOnly,
+    isSpot,
+    perpsPositions,
+    side,
+  ]);
+
   const maxPositionSizeBN = useMemo(() => {
     if (isSpot) {
       return maxTradeSzBN.decimalPlaces(spotSzDecimals, BigNumber.ROUND_FLOOR);
@@ -221,6 +249,7 @@ export function useTradingCalculationsForSide(side: 'long' | 'short') {
       side,
       price: effectivePriceBN.isFinite() ? effectivePriceBN.toFixed() : '',
       markPrice: activeAssetData?.markPx,
+      maxSize: scaleReduceOnlyMaxSizeBN,
       maxTradeSzs: effectiveMaxTradeSzs,
       leverageValue: activeAssetData?.leverage?.value,
       fallbackLeverage: activeAsset?.universe?.maxLeverage,
@@ -230,6 +259,7 @@ export function useTradingCalculationsForSide(side: 'long' | 'short') {
     side,
     effectivePriceBN,
     activeAssetData?.markPx,
+    scaleReduceOnlyMaxSizeBN,
     effectiveMaxTradeSzs,
     activeAssetData?.leverage?.value,
     activeAsset?.universe?.maxLeverage,
@@ -270,6 +300,7 @@ export function useTradingCalculationsForSide(side: 'long' | 'short') {
       side,
       price: effectivePriceBN.isFinite() ? effectivePriceBN.toFixed() : '',
       markPrice: activeAssetData?.markPx,
+      maxSize: scaleReduceOnlyMaxSizeBN,
       maxTradeSzs: effectiveMaxTradeSzs,
       leverageValue: activeAssetData?.leverage?.value,
       fallbackLeverage: activeAsset?.universe?.maxLeverage,
@@ -282,6 +313,7 @@ export function useTradingCalculationsForSide(side: 'long' | 'short') {
     side,
     effectivePriceBN,
     activeAssetData?.markPx,
+    scaleReduceOnlyMaxSizeBN,
     effectiveMaxTradeSzs,
     activeAssetData?.leverage?.value,
     activeAsset?.universe?.maxLeverage,

--- a/packages/kit/src/views/Perp/layouts/PerpMobileLayout.tsx
+++ b/packages/kit/src/views/Perp/layouts/PerpMobileLayout.tsx
@@ -120,168 +120,6 @@ export const TabBarItem = memo(
 
 TabBarItem.displayName = 'TabBarItem';
 
-type IPerpMobileTabMetrics = {
-  openOrdersLength: number;
-  positionsLength: number;
-  holdingsCount: number;
-  isUnifiedAccountMode: boolean;
-  hasPerpsAccountSummary: boolean;
-  spotBalancesLength: number;
-};
-
-const DEFAULT_TAB_METRICS: IPerpMobileTabMetrics = {
-  openOrdersLength: 0,
-  positionsLength: 0,
-  holdingsCount: 0,
-  isUnifiedAccountMode: false,
-  hasPerpsAccountSummary: false,
-  spotBalancesLength: 0,
-};
-
-const PerpMobileTabBarItems = memo(
-  ({
-    activeTab,
-    onMetricsChange,
-    onPress,
-  }: {
-    activeTab: ETabName;
-    onMetricsChange: (metrics: IPerpMobileTabMetrics) => void;
-    onPress: (name: ETabName) => void;
-  }) => {
-    const [perpOpenOrdersState] = usePerpsActiveOpenOrdersAtom();
-    const [spotOpenOrdersState] = useSpotActiveOpenOrdersAtom();
-    const [positionsState] = usePerpsActivePositionAtom();
-    const [twapOrdersState] = usePerpsActiveTwapOrdersAtom();
-    const [{ balances, isLoaded: isSpotBalancesLoaded }] =
-      useSpotBalancesAtom();
-    const [cachedSpotBalances] = usePerpsSpotBalancesAtom();
-    const [accountSummary] = usePerpsActiveAccountSummaryAtom();
-    const [currentUser] = usePerpsActiveAccountAtom();
-    const accountScopedAddress = usePerpsAccountScopedCacheAddress();
-    const [abstractionMode] = usePerpsAbstractionModeAtom();
-    const isUnifiedAccountMode = isHyperLiquidUnifiedAccountMode(
-      abstractionMode,
-      currentUser?.accountAddress,
-    );
-    const currentUserAddress = accountScopedAddress;
-    const positionsLength = getPerpsAccountScopedListData({
-      activeAccountAddress: currentUserAddress,
-      dataAccountAddress: positionsState.accountAddress,
-      data: positionsState.activePositions,
-    }).length;
-    const openOrdersLength =
-      getPerpsAccountScopedListData({
-        activeAccountAddress: currentUserAddress,
-        dataAccountAddress: perpOpenOrdersState.accountAddress,
-        data: perpOpenOrdersState.openOrders.filter(
-          (order) => !isSpotInstrument(order.coin),
-        ),
-      }).length +
-      getPerpsAccountScopedListData({
-        activeAccountAddress: currentUserAddress,
-        dataAccountAddress: spotOpenOrdersState.accountAddress,
-        data: spotOpenOrdersState.openOrders,
-      }).length +
-      getPerpsAccountScopedListData({
-        activeAccountAddress: currentUserAddress,
-        dataAccountAddress: twapOrdersState.accountAddress,
-        data: twapOrdersState.twapOrders,
-      }).length;
-    const shouldUseCachedSpotBalances =
-      !isSpotBalancesLoaded &&
-      Boolean(currentUserAddress) &&
-      cachedSpotBalances?.accountAddress?.toLowerCase() ===
-        currentUserAddress?.toLowerCase();
-    const displayBalances = shouldUseCachedSpotBalances
-      ? (cachedSpotBalances?.balances ?? balances)
-      : balances;
-
-    const holdingsCount = useMemo(() => {
-      const nonUsdcSpotCount = displayBalances.filter(
-        (item) => item.coin !== 'USDC' && !new BigNumber(item.total).isZero(),
-      ).length;
-      const hasSpotUsdc = displayBalances.some(
-        (item) => item.coin === 'USDC' && !new BigNumber(item.total).isZero(),
-      );
-      const hasPerpsUsdc =
-        !isUnifiedAccountMode &&
-        !!accountSummary?.totalRawUsd &&
-        new BigNumber(accountSummary.totalRawUsd).gt(0);
-      return nonUsdcSpotCount + (hasSpotUsdc || hasPerpsUsdc ? 1 : 0);
-    }, [accountSummary?.totalRawUsd, displayBalances, isUnifiedAccountMode]);
-
-    const positionsTabCount = useMemo(() => {
-      if (positionsLength > 0) {
-        return `(${positionsLength})`;
-      }
-      return '';
-    }, [positionsLength]);
-
-    const openOrdersTabCount = useMemo(() => {
-      if (openOrdersLength > 0) {
-        return `(${openOrdersLength})`;
-      }
-      return '';
-    }, [openOrdersLength]);
-
-    const holdingsTabCount = useMemo(() => {
-      if (holdingsCount > 0) {
-        return `(${holdingsCount})`;
-      }
-      return '';
-    }, [holdingsCount]);
-
-    useEffect(() => {
-      const metrics = {
-        openOrdersLength,
-        positionsLength,
-        holdingsCount,
-        isUnifiedAccountMode,
-        hasPerpsAccountSummary: Boolean(accountSummary),
-        spotBalancesLength: balances.length,
-      };
-      onMetricsChange(metrics);
-      tracePerpsMobileLayout('perpTab.counts.state', {
-        activeTab,
-        ...metrics,
-      });
-    }, [
-      accountSummary,
-      activeTab,
-      balances.length,
-      holdingsCount,
-      isUnifiedAccountMode,
-      onMetricsChange,
-      openOrdersLength,
-      positionsLength,
-    ]);
-
-    return (
-      <XStack gap="$5">
-        <TabBarItem
-          name={ETabName.Positions}
-          isFocused={activeTab === ETabName.Positions}
-          onPress={onPress}
-          tabCount={positionsTabCount}
-        />
-        <TabBarItem
-          name={ETabName.OpenOrders}
-          isFocused={activeTab === ETabName.OpenOrders}
-          onPress={onPress}
-          tabCount={openOrdersTabCount}
-        />
-        <TabBarItem
-          name={ETabName.Balances}
-          isFocused={activeTab === ETabName.Balances}
-          onPress={onPress}
-          tabCount={holdingsTabCount}
-        />
-      </XStack>
-    );
-  },
-);
-PerpMobileTabBarItems.displayName = 'PerpMobileTabBarItems';
-
 export function PerpMobileLayout() {
   const tabBarHeight = useScrollContentTabBarOffset();
   const [activeTab, setActiveTab] = useState<ETabName>(ETabName.Positions);
@@ -289,7 +127,6 @@ export function PerpMobileLayout() {
   const layoutRectsRef = useRef<
     Record<string, IPerpsMobileLayoutTraceRect | undefined>
   >({});
-  const tabMetricsRef = useRef<IPerpMobileTabMetrics>(DEFAULT_TAB_METRICS);
   const contentHeightRef = useRef<number | undefined>(undefined);
 
   const navigation =
@@ -316,12 +153,87 @@ export function PerpMobileLayout() {
     }
   }, [actions]);
 
-  const handleTabMetricsChange = useCallback(
-    (metrics: IPerpMobileTabMetrics) => {
-      tabMetricsRef.current = metrics;
-    },
-    [],
+  const [perpOpenOrdersState] = usePerpsActiveOpenOrdersAtom();
+  const [spotOpenOrdersState] = useSpotActiveOpenOrdersAtom();
+  const [positionsState] = usePerpsActivePositionAtom();
+  const [twapOrdersState] = usePerpsActiveTwapOrdersAtom();
+  const [{ balances, isLoaded: isSpotBalancesLoaded }] = useSpotBalancesAtom();
+  const [cachedSpotBalances] = usePerpsSpotBalancesAtom();
+  const [accountSummary] = usePerpsActiveAccountSummaryAtom();
+  const [currentUser] = usePerpsActiveAccountAtom();
+  const accountScopedAddress = usePerpsAccountScopedCacheAddress();
+  const [abstractionMode] = usePerpsAbstractionModeAtom();
+  const isUnifiedAccountMode = isHyperLiquidUnifiedAccountMode(
+    abstractionMode,
+    currentUser?.accountAddress,
   );
+  const currentUserAddress = accountScopedAddress;
+  const positionsLength = getPerpsAccountScopedListData({
+    activeAccountAddress: currentUserAddress,
+    dataAccountAddress: positionsState.accountAddress,
+    data: positionsState.activePositions,
+  }).length;
+  const openOrdersLength =
+    getPerpsAccountScopedListData({
+      activeAccountAddress: currentUserAddress,
+      dataAccountAddress: perpOpenOrdersState.accountAddress,
+      data: perpOpenOrdersState.openOrders.filter(
+        (order) => !isSpotInstrument(order.coin),
+      ),
+    }).length +
+    getPerpsAccountScopedListData({
+      activeAccountAddress: currentUserAddress,
+      dataAccountAddress: spotOpenOrdersState.accountAddress,
+      data: spotOpenOrdersState.openOrders,
+    }).length +
+    getPerpsAccountScopedListData({
+      activeAccountAddress: currentUserAddress,
+      dataAccountAddress: twapOrdersState.accountAddress,
+      data: twapOrdersState.twapOrders,
+    }).length;
+  const shouldUseCachedSpotBalances =
+    !isSpotBalancesLoaded &&
+    Boolean(currentUserAddress) &&
+    cachedSpotBalances?.accountAddress?.toLowerCase() ===
+      currentUserAddress?.toLowerCase();
+  const displayBalances = shouldUseCachedSpotBalances
+    ? (cachedSpotBalances?.balances ?? balances)
+    : balances;
+
+  const holdingsCount = useMemo(() => {
+    const nonUsdcSpotCount = displayBalances.filter(
+      (item) => item.coin !== 'USDC' && !new BigNumber(item.total).isZero(),
+    ).length;
+    const hasSpotUsdc = displayBalances.some(
+      (item) => item.coin === 'USDC' && !new BigNumber(item.total).isZero(),
+    );
+    const hasPerpsUsdc =
+      !isUnifiedAccountMode &&
+      !!accountSummary?.totalRawUsd &&
+      new BigNumber(accountSummary.totalRawUsd).gt(0);
+    return nonUsdcSpotCount + (hasSpotUsdc || hasPerpsUsdc ? 1 : 0);
+  }, [accountSummary?.totalRawUsd, displayBalances, isUnifiedAccountMode]);
+
+  const positionsTabCount = useMemo(() => {
+    if (positionsLength > 0) {
+      return `(${positionsLength})`;
+    }
+    return '';
+  }, [positionsLength]);
+
+  const openOrdersTabCount = useMemo(() => {
+    if (openOrdersLength > 0) {
+      return `(${openOrdersLength})`;
+    }
+    return '';
+  }, [openOrdersLength]);
+
+  const holdingsTabCount = useMemo(() => {
+    if (holdingsCount > 0) {
+      return `(${holdingsCount})`;
+    }
+    return '';
+  }, [holdingsCount]);
 
   const handleTraceLayout = useCallback(
     (name: string, event: LayoutChangeEvent) => {
@@ -329,19 +241,24 @@ export function PerpMobileLayout() {
       if (
         isPerpsMobileLayoutTraceRectChanged(layoutRectsRef.current[name], rect)
       ) {
-        const tabMetrics = tabMetricsRef.current;
         tracePerpsMobileLayout(`perpTab.${name}.layout`, {
           rect,
           activeTab,
-          isUnifiedAccountMode: tabMetrics.isUnifiedAccountMode,
-          openOrdersLength: tabMetrics.openOrdersLength,
-          positionsLength: tabMetrics.positionsLength,
-          holdingsCount: tabMetrics.holdingsCount,
+          isUnifiedAccountMode,
+          openOrdersLength,
+          positionsLength,
+          holdingsCount,
         });
         layoutRectsRef.current[name] = rect;
       }
     },
-    [activeTab],
+    [
+      activeTab,
+      holdingsCount,
+      isUnifiedAccountMode,
+      openOrdersLength,
+      positionsLength,
+    ],
   );
 
   const handleContentSizeChange = useCallback(
@@ -372,6 +289,26 @@ export function PerpMobileLayout() {
     },
     [handleTraceLayout],
   );
+
+  useEffect(() => {
+    tracePerpsMobileLayout('perpTab.counts.state', {
+      activeTab,
+      openOrdersLength,
+      positionsLength,
+      holdingsCount,
+      isUnifiedAccountMode,
+      hasPerpsAccountSummary: Boolean(accountSummary),
+      spotBalancesLength: balances.length,
+    });
+  }, [
+    accountSummary,
+    activeTab,
+    balances.length,
+    holdingsCount,
+    isUnifiedAccountMode,
+    openOrdersLength,
+    positionsLength,
+  ]);
 
   return (
     <ScrollView
@@ -424,11 +361,26 @@ export function PerpMobileLayout() {
         pl="$4"
         onLayout={(event) => handleTraceLayout('positionsTabBar', event)}
       >
-        <PerpMobileTabBarItems
-          activeTab={activeTab}
-          onMetricsChange={handleTabMetricsChange}
-          onPress={setActiveTab}
-        />
+        <XStack gap="$5">
+          <TabBarItem
+            name={ETabName.Positions}
+            isFocused={activeTab === ETabName.Positions}
+            onPress={setActiveTab}
+            tabCount={positionsTabCount}
+          />
+          <TabBarItem
+            name={ETabName.OpenOrders}
+            isFocused={activeTab === ETabName.OpenOrders}
+            onPress={setActiveTab}
+            tabCount={openOrdersTabCount}
+          />
+          <TabBarItem
+            name={ETabName.Balances}
+            isFocused={activeTab === ETabName.Balances}
+            onPress={setActiveTab}
+            tabCount={holdingsTabCount}
+          />
+        </XStack>
         <IconButton
           testID="perp-icon-btn"
           variant="tertiary"
@@ -442,39 +394,32 @@ export function PerpMobileLayout() {
         flex={1}
         onLayout={(event) => handleTraceLayout('tabContent', event)}
       >
-        {activeTab === ETabName.Positions ? (
-          <YStack
-            flex={1}
-            onLayout={(event) => handleTraceLayout('positionsPanel', event)}
-          >
-            <PerpPositionsList
-              handleViewTpslOrders={handleViewTpslOrders}
-              isMobile
-              useTabsList={false}
-              disableListScroll
-            />
-          </YStack>
-        ) : null}
-        {activeTab === ETabName.OpenOrders ? (
-          <YStack
-            flex={1}
-            onLayout={(event) => handleTraceLayout('openOrdersPanel', event)}
-          >
-            <PerpOpenOrdersList
-              isMobile
-              useTabsList={false}
-              disableListScroll
-            />
-          </YStack>
-        ) : null}
-        {activeTab === ETabName.Balances ? (
-          <YStack
-            flex={1}
-            onLayout={(event) => handleTraceLayout('balancesPanel', event)}
-          >
-            <SpotBalanceList isMobile useTabsList={false} disableListScroll />
-          </YStack>
-        ) : null}
+        <YStack
+          display={activeTab === ETabName.Positions ? 'flex' : 'none'}
+          flex={1}
+          onLayout={(event) => handleTraceLayout('positionsPanel', event)}
+        >
+          <PerpPositionsList
+            handleViewTpslOrders={handleViewTpslOrders}
+            isMobile
+            useTabsList={false}
+            disableListScroll
+          />
+        </YStack>
+        <YStack
+          display={activeTab === ETabName.OpenOrders ? 'flex' : 'none'}
+          flex={1}
+          onLayout={(event) => handleTraceLayout('openOrdersPanel', event)}
+        >
+          <PerpOpenOrdersList isMobile useTabsList={false} disableListScroll />
+        </YStack>
+        <YStack
+          display={activeTab === ETabName.Balances ? 'flex' : 'none'}
+          flex={1}
+          onLayout={(event) => handleTraceLayout('balancesPanel', event)}
+        >
+          <SpotBalanceList isMobile useTabsList={false} disableListScroll />
+        </YStack>
       </YStack>
     </ScrollView>
   );

--- a/packages/shared/src/utils/hyperliquidScaleOrderUtils.test.ts
+++ b/packages/shared/src/utils/hyperliquidScaleOrderUtils.test.ts
@@ -2,6 +2,7 @@ import {
   assertValidScaleOrderLegs,
   buildScaleOrderLegs,
   getReduceOnlyOrderGuardError,
+  getReduceOnlyPositionMaxSize,
   getReduceOnlyPositionSnapshotError,
   getScaleOrderPriceBounds,
   getScaleOrderReferencePrice,
@@ -299,5 +300,43 @@ describe('hyperliquidScaleOrderUtils', () => {
         positionSize: '2',
       }),
     ).toBe('Reduce-only order size exceeds the current position');
+  });
+
+  test('resolves reduce-only slider max from the opposite position size', () => {
+    expect(
+      getReduceOnlyPositionMaxSize({
+        reduceOnly: true,
+        side: 'short',
+        positionSize: '37.123',
+        szDecimals: 2,
+      })?.toFixed(),
+    ).toBe('37.12');
+
+    expect(
+      getReduceOnlyPositionMaxSize({
+        reduceOnly: true,
+        side: 'long',
+        positionSize: '-12.345',
+        szDecimals: 2,
+      })?.toFixed(),
+    ).toBe('12.34');
+
+    expect(
+      getReduceOnlyPositionMaxSize({
+        reduceOnly: true,
+        side: 'long',
+        positionSize: '12.345',
+        szDecimals: 2,
+      }),
+    ).toBeUndefined();
+
+    expect(
+      getReduceOnlyPositionMaxSize({
+        reduceOnly: false,
+        side: 'short',
+        positionSize: '37.123',
+        szDecimals: 2,
+      }),
+    ).toBeUndefined();
   });
 });

--- a/packages/shared/src/utils/hyperliquidScaleOrderUtils.ts
+++ b/packages/shared/src/utils/hyperliquidScaleOrderUtils.ts
@@ -270,6 +270,34 @@ export function getReduceOnlyPositionSnapshotError({
   return undefined;
 }
 
+export function getReduceOnlyPositionMaxSize({
+  reduceOnly,
+  side,
+  positionSize,
+  szDecimals,
+}: {
+  reduceOnly?: boolean;
+  side: 'long' | 'short';
+  positionSize?: BigNumber.Value | null;
+  szDecimals?: number;
+}): BigNumber | undefined {
+  if (!reduceOnly) {
+    return undefined;
+  }
+
+  const positionSizeBN = new BigNumber(positionSize ?? 0);
+  const isReducing =
+    side === 'long' ? positionSizeBN.lt(0) : positionSizeBN.gt(0);
+
+  if (!positionSizeBN.isFinite() || !isReducing) {
+    return undefined;
+  }
+
+  return positionSizeBN
+    .abs()
+    .decimalPlaces(szDecimals ?? 2, BigNumber.ROUND_FLOOR);
+}
+
 export function getReduceOnlyOrderGuardError({
   reduceOnly,
   side,

--- a/packages/shared/src/utils/perpsUtils.test.ts
+++ b/packages/shared/src/utils/perpsUtils.test.ts
@@ -11,6 +11,7 @@ import {
   analyzeOrderBookPrecision,
   calculateLiquidationPrice,
   calculatePriceScale,
+  calculateSpotBalancesTotalUsd,
   compareSpotMarketCapValues,
   computeMaxTradeSize,
   countDecimalPlaces,
@@ -146,7 +147,6 @@ describe('isPredictionMarketInstrument', () => {
   });
 });
 
-
 describe('trading size helpers', () => {
   test('uses direct maxSize for slider sizing without mark/reference price conversion', () => {
     const maxSize = computeMaxTradeSize({
@@ -172,6 +172,50 @@ describe('trading size helpers', () => {
       szDecimals: 2,
     });
     expect(resolvedSize.toFixed()).toBe('18.56');
+  });
+});
+
+describe('calculateSpotBalancesTotalUsd', () => {
+  test('counts non-USDC spot holdings with spot mark prices', () => {
+    const result = calculateSpotBalancesTotalUsd({
+      balances: [
+        {
+          coin: 'USDC',
+          token: 0,
+          total: '236.786521',
+        },
+        {
+          coin: 'BTC',
+          token: 1,
+          total: '0.0040073065',
+        },
+      ],
+      getMarkPrice: (coin) => (coin === 'BTC' ? '62454' : undefined),
+    });
+
+    expect(result.missingPriceCoins).toEqual([]);
+    expect(new BigNumber(result.totalUsd).toFixed(2)).toBe('487.06');
+  });
+
+  test('keeps total unresolved when a positive non-stable token price is missing', () => {
+    const result = calculateSpotBalancesTotalUsd({
+      balances: [
+        {
+          coin: 'USDC',
+          token: 0,
+          total: '236.786521',
+        },
+        {
+          coin: 'BTC',
+          token: 1,
+          total: '0.0040073065',
+        },
+      ],
+      getMarkPrice: () => undefined,
+    });
+
+    expect(result.totalUsd).toBe('236.786521');
+    expect(result.missingPriceCoins).toEqual(['BTC']);
   });
 });
 

--- a/packages/shared/src/utils/perpsUtils.test.ts
+++ b/packages/shared/src/utils/perpsUtils.test.ts
@@ -5,11 +5,14 @@
 
 import BigNumber from 'bignumber.js';
 
+import { EPerpsSizeInputMode } from '@onekeyhq/shared/types/hyperliquid/types';
+
 import {
   analyzeOrderBookPrecision,
   calculateLiquidationPrice,
   calculatePriceScale,
   compareSpotMarketCapValues,
+  computeMaxTradeSize,
   countDecimalPlaces,
   formatHlPrice,
   formatHlSize,
@@ -24,6 +27,7 @@ import {
   getSpotTokenDisplayName,
   getValidPriceDecimals,
   isPredictionMarketInstrument,
+  resolveTradingSizeBN,
 } from './perpsUtils';
 
 describe('getValidPriceDecimals - HyperLiquid Perp Rules', () => {
@@ -139,6 +143,35 @@ describe('isPredictionMarketInstrument', () => {
     expect(isPredictionMarketInstrument('BTC')).toBe(false);
     expect(isPredictionMarketInstrument('@107')).toBe(false);
     expect(isPredictionMarketInstrument(undefined)).toBe(false);
+  });
+});
+
+
+describe('trading size helpers', () => {
+  test('uses direct maxSize for slider sizing without mark/reference price conversion', () => {
+    const maxSize = computeMaxTradeSize({
+      side: 'short',
+      price: '14',
+      markPrice: '20',
+      maxSize: '37.123',
+      maxTradeSzs: ['100', '100'],
+      leverageValue: 5,
+      szDecimals: 2,
+    });
+    expect(maxSize.toFixed()).toBe('37.12');
+
+    const resolvedSize = resolveTradingSizeBN({
+      sizeInputMode: EPerpsSizeInputMode.SLIDER,
+      sizePercent: 50,
+      side: 'short',
+      price: '14',
+      markPrice: '20',
+      maxSize: '37.123',
+      maxTradeSzs: ['100', '100'],
+      leverageValue: 5,
+      szDecimals: 2,
+    });
+    expect(resolvedSize.toFixed()).toBe('18.56');
   });
 });
 

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -1193,6 +1193,57 @@ interface ITradingSizeParams extends ITradingSizeContext {
   sizePercent?: number;
 }
 
+type ISpotBalanceValueItem = {
+  coin: string;
+  token: number;
+  total: string;
+  entryNtl?: string;
+};
+
+const HYPERLIQUID_SPOT_STABLE_COINS = new Set(['USDC', 'USDT', 'USDB', 'USDH']);
+
+const isHyperliquidSpotStableCoin = (coin: string) =>
+  HYPERLIQUID_SPOT_STABLE_COINS.has(coin.toUpperCase());
+
+function calculateSpotBalancesTotalUsd({
+  balances,
+  getMarkPrice,
+}: {
+  balances: ISpotBalanceValueItem[];
+  getMarkPrice: (coin: string) => string | undefined;
+}): {
+  totalUsd: string;
+  missingPriceCoins: string[];
+} {
+  let totalUsd = new BigNumber(0);
+  const missingPriceCoins: string[] = [];
+
+  for (const balance of balances) {
+    const amount = new BigNumber(balance.total);
+    if (!amount.isFinite() || amount.lte(0)) {
+      // skip invalid / empty balances
+    } else if (
+      balance.token === 0 ||
+      isHyperliquidSpotStableCoin(balance.coin)
+    ) {
+      totalUsd = totalUsd.plus(amount);
+    } else {
+      const markPrice = getMarkPrice(balance.coin);
+      const markPriceBN = new BigNumber(markPrice ?? 0);
+      if (markPriceBN.isFinite() && markPriceBN.gt(0)) {
+        totalUsd = totalUsd.plus(amount.multipliedBy(markPriceBN));
+      } else {
+        missingPriceCoins.push(balance.coin);
+      }
+    }
+  }
+
+  return {
+    totalUsd: totalUsd.toFixed(),
+    missingPriceCoins,
+  };
+}
+
 const computeEffectivePrice = (
   price?: string,
   markPrice?: string,
@@ -2014,6 +2065,8 @@ export {
   getTriggerEffectivePrice,
   getSpotMarketCapValue,
   compareSpotMarketCapValues,
+  isHyperliquidSpotStableCoin,
+  calculateSpotBalancesTotalUsd,
   getValidSpotPriceDecimals,
   formatSpotPriceToValid,
   formatSpotAssetCtx,
@@ -2073,6 +2126,8 @@ export default {
   formatChartUsdPrice,
   getSpotMarketCapValue,
   compareSpotMarketCapValues,
+  isHyperliquidSpotStableCoin,
+  calculateSpotBalancesTotalUsd,
   formatSpotAssetCtx,
   formatSpotPriceEntry,
   isSpotInstrument,

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -1179,6 +1179,7 @@ interface ITradingSizeContext {
   side: 'long' | 'short';
   price?: string;
   markPrice?: string;
+  maxSize?: BigNumber.Value | null;
   availableToTrade?: Array<number | string>;
   maxTradeSzs?: Array<number | string>;
   leverageValue?: number | string | null;
@@ -1225,11 +1226,22 @@ const computeMaxTradeSize = ({
   side,
   price,
   markPrice,
+  maxSize,
   maxTradeSzs,
   leverageValue,
   fallbackLeverage,
   szDecimals,
 }: ITradingSizeContext): BigNumber => {
+  if (maxSize !== undefined && maxSize !== null) {
+    const maxSizeBN = new BigNumber(maxSize);
+    if (!maxSizeBN.isFinite() || maxSizeBN.lte(0)) {
+      return new BigNumber(0);
+    }
+
+    const decimals = szDecimals ?? 2;
+    return maxSizeBN.decimalPlaces(decimals, BigNumber.ROUND_FLOOR);
+  }
+
   const effectivePrice = computeEffectivePrice(price, markPrice);
   if (!effectivePrice) {
     return new BigNumber(0);
@@ -1273,6 +1285,7 @@ const resolveTradingSizeBN = ({
   side,
   price,
   markPrice,
+  maxSize,
   maxTradeSzs,
   leverageValue,
   fallbackLeverage,
@@ -1292,23 +1305,24 @@ const resolveTradingSizeBN = ({
     return new BigNumber(0);
   }
 
-  const maxSize = computeMaxTradeSize({
+  const resolvedMaxSize = computeMaxTradeSize({
     side,
     price,
     markPrice,
+    maxSize,
     maxTradeSzs,
     leverageValue,
     fallbackLeverage,
     szDecimals,
   });
 
-  if (!maxSize.isFinite() || maxSize.lte(0)) {
+  if (!resolvedMaxSize.isFinite() || resolvedMaxSize.lte(0)) {
     return new BigNumber(0);
   }
 
   const percentBN = new BigNumber(percentValue);
   const decimals = szDecimals ?? 2;
-  return maxSize
+  return resolvedMaxSize
     .multipliedBy(percentBN)
     .dividedBy(100)
     .decimalPlaces(decimals, BigNumber.ROUND_FLOOR);


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55589](https://onekeyhq.atlassian.net/browse/OK-55589) [OK-55590](https://onekeyhq.atlassian.net/browse/OK-55590) [OK-55593](https://onekeyhq.atlassian.net/browse/OK-55593) [OK-55595](https://onekeyhq.atlassian.net/browse/OK-55595) [OK-55596](https://onekeyhq.atlassian.net/browse/OK-55596) [OK-55597](https://onekeyhq.atlassian.net/browse/OK-55597) [OK-55598](https://onekeyhq.atlassian.net/browse/OK-55598) [OK-55599](https://onekeyhq.atlassian.net/browse/OK-55599) [OK-55602](https://onekeyhq.atlassian.net/browse/OK-55602) [OK-55606](https://onekeyhq.atlassian.net/browse/OK-55606) [OK-55675](https://onekeyhq.atlassian.net/browse/OK-55675) [OK-55787](https://onekeyhq.atlassian.net/browse/OK-55787) [OK-55792](https://onekeyhq.atlassian.net/browse/OK-55792) [OK-55834](https://onekeyhq.atlassian.net/browse/OK-55834)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Stabilize Perps Scale/TWAP QA flows across order CTA behavior, TWAP history/list presentation, mobile history tabs, and order/fill formatting.
- Fix Scale reduce-only slider sizing to cap at the active opposite position, matching closable position behavior.
- Include priced spot holdings in Hyperliquid account asset totals instead of showing a misleading USDC-only value while prices are unresolved.

## Intent & Context
This PR batches the App-6.4.0 Perps QA fixes for Scale and TWAP. The work follows the QA/Jira pass where completed cards were moved to code review and fixes were split by issue number. The main goal is to make Scale/TWAP behavior consistent with product expectations and Hyperliquid reference behavior on both desktop and mobile.

Related issues: OK-55589 OK-55590 OK-55593 OK-55595 OK-55596 OK-55597 OK-55598 OK-55599 OK-55602 OK-55606 OK-55675 OK-55787 OK-55792 OK-55834

## Root Cause
- Scale/TWAP shared some standard order CTA and list/history paths, causing inconsistent button states, duplicated or misplaced TWAP records, and missing TWAP-specific fields.
- Desktop and mobile TWAP history had different tab/list assumptions, so desktop needed TWAP records removed from generic history while mobile needed an explicit TWAP history entry point.
- Reduce-only Scale sizing used general available/max trade size instead of the opposite active position size.
- Hyperliquid spot account totals only counted stable balances in some loading states and did not wait for required non-stable spot pricing.

## Design Decisions
- Keep Scale/TWAP CTA behavior in preview semantics instead of falling back to standard buy/sell CTA summaries when size input changes.
- Preserve the desktop standalone TWAP tab as the source for TWAP history and exclude TWAP fills/orders from generic trade history where appropriate.
- Add mobile TWAP history in the history modal rather than creating a mobile top-level TWAP tab.
- Use hardcoded English copy only where QA requested it and i18n was not yet available.
- Treat missing non-stable spot prices as unresolved instead of zero to avoid flickering or misleading account values.

## Changes Detail
- `TradingButtonGroup.tsx`: keeps algo order button area stable for Scale/TWAP.
- `PerpTradingForm.tsx`: shows estimated TWAP child order notional using the 30-second child-order cadence.
- Perps order/history list components: adjust TWAP history visibility, scroll behavior, mobile modal tab placement, and displayed TWAP fields.
- Hyperliquid jotai actions/atoms and trading calculation hook: pass reduce-only position max size into Scale sizing and submission flows.
- `hyperliquidScaleOrderUtils.ts` and tests: add reduce-only position max resolution.
- `perpsUtils.ts` and tests: support direct max-size slider calculations and spot balance USD total calculation.
- `ServiceHyperliquid.ts`: recompute spot account totals from stable balances plus priced non-stable holdings.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web
- **Risk Areas**: Perps order/history UI, Scale reduce-only sizing, Hyperliquid account asset calculation, TWAP list filtering.

## Test plan
- [x] `git diff --check origin/x...HEAD`
- [x] `yarn jest packages/shared/src/utils/perpsUtils.test.ts packages/shared/src/utils/hyperliquidScaleOrderUtils.test.ts --runInBand --testPathIgnorePatterns=.worktrees`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings <changed files>`
- [ ] Manually verify desktop Perps TWAP tab history can scroll and generic trade history excludes TWAP records.
- [ ] Manually verify mobile Perps history modal includes TWAP in the expected position and does not add a mobile top-level TWAP tab.
- [ ] Manually verify Scale reduce-only slider 100% matches the active opposite position size.
- [ ] Manually verify TWAP child order notional and Scale/TWAP CTA area remain stable before/after entering size.

## Validation Notes
`yarn tsc:only` still fails on existing baseline issues outside this Perps diff: mobile backgroundThread shared RPC typing, missing native module type declarations, and third-party hardware/Ledger adapter type mismatches.

[OK-55589]: https://onekeyhq.atlassian.net/browse/OK-55589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55590]: https://onekeyhq.atlassian.net/browse/OK-55590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55593]: https://onekeyhq.atlassian.net/browse/OK-55593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55595]: https://onekeyhq.atlassian.net/browse/OK-55595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55596]: https://onekeyhq.atlassian.net/browse/OK-55596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55597]: https://onekeyhq.atlassian.net/browse/OK-55597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55598]: https://onekeyhq.atlassian.net/browse/OK-55598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55599]: https://onekeyhq.atlassian.net/browse/OK-55599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55602]: https://onekeyhq.atlassian.net/browse/OK-55602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55606]: https://onekeyhq.atlassian.net/browse/OK-55606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55675]: https://onekeyhq.atlassian.net/browse/OK-55675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55787]: https://onekeyhq.atlassian.net/browse/OK-55787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55792]: https://onekeyhq.atlassian.net/browse/OK-55792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55834]: https://onekeyhq.atlassian.net/browse/OK-55834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ