### PR TITLE
ci: split Android RN harness nightly by test path scope

### DIFF
--- a/.github/workflows/react-native-unittest.yml
+++ b/.github/workflows/react-native-unittest.yml
@@ -18,13 +18,26 @@ env:
 
 jobs:
   harness-android:
-    name: Harness Tests (Android)
+    name: Harness Tests (Android / ${{ matrix.test-scope }})
     runs-on: ubuntu-24.04
     timeout-minutes: 90
 
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [24.x]
+        include:
+          - node-version: 24.x
+            test-scope: mobile-shared-core
+            test-path-pattern: 'apps/mobile|packages/shared/src|packages/core/src'
+          - node-version: 24.x
+            test-scope: kit-bg
+            test-path-pattern: 'packages/kit-bg/src'
+          - node-version: 24.x
+            test-scope: kit-market-perp
+            test-path-pattern: 'packages/kit/src/views/(Market|Perp)'
+          - node-version: 24.x
+            test-scope: kit-rest
+            test-path-pattern: 'packages/kit/src/(?!views/(Market|Perp))'
 
     steps:
       - uses: actions/checkout@v4
@@ -177,7 +190,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HARNESS_ANDROID_AVD: test_avd
         working-directory: apps/mobile
-        run: yarn harness:test:android
+        run: yarn harness:test:android --testPathPatterns='${{ matrix.test-path-pattern }}'
 
       - name: Dump logcat on failure
         if: failure()

--- a/.github/workflows/react-native-unittest.yml
+++ b/.github/workflows/react-native-unittest.yml
@@ -190,7 +190,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HARNESS_ANDROID_AVD: test_avd
         working-directory: apps/mobile
-        run: yarn harness:test:android --testPathPatterns='${{ matrix.test-path-pattern }}'
+        run: yarn harness:test:android --testPathPattern='${{ matrix.test-path-pattern }}'
 
       - name: Dump logcat on failure
         if: failure()


### PR DESCRIPTION
## Summary
- split the scheduled Android RN harness workflow into path-scoped matrix jobs
- keep fail-fast disabled so each scope can produce independent diagnostics
- use Jest `--testPathPattern` rather than `--shard` because react-native-harness CLI removes the shard option

## Why
The open `rn-unittest-failure` issue shows repeated nightly failures, and the latest inspected run reports:

> The action 'Run Harness Tests (Android)' has timed out after 60 minutes.

The harness config currently keeps roughly 252 test files for an on-device Android run. Splitting by path scope should reduce per-job wall time while preserving coverage and making failures easier to localize.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/react-native-unittest.yml"); puts "YAML parse ok"'`
- `git diff --check`
- local regex coverage over the harness test set: 252 kept files, 0 overlap/gap errors across the four patterns
- static check of `@react-native-harness/cli@1.0.0-alpha.25`: CLI removes `--shard`, but does not remove `--testPathPattern`

Refs #11792

