### PR TITLE
fix: handle private send solana rent history(OK-55859)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -110,6 +110,38 @@ function shouldPreferPrivateSendSwapHistory(
   );
 }
 
+function mergePrivateSendLocalDecodedTxFields({
+  localTx,
+  onChainHistoryTx,
+}: {
+  localTx: IAccountHistoryTx;
+  onChainHistoryTx: IAccountHistoryTx;
+}) {
+  if (!isPrivateSendAccountHistoryTx(localTx)) {
+    return onChainHistoryTx;
+  }
+
+  const localPayload = localTx.decodedTx.payload;
+  const localExtraInfo = localTx.decodedTx.extraInfo;
+  if (!localPayload && !localExtraInfo) {
+    return onChainHistoryTx;
+  }
+
+  return {
+    ...onChainHistoryTx,
+    decodedTx: {
+      ...onChainHistoryTx.decodedTx,
+      payload: localPayload
+        ? {
+            ...onChainHistoryTx.decodedTx.payload,
+            ...localPayload,
+          }
+        : onChainHistoryTx.decodedTx.payload,
+      extraInfo: onChainHistoryTx.decodedTx.extraInfo ?? localExtraInfo,
+    },
+  };
+}
+
 // Sentinel value stored inside a merge-derive opaque cursor map to mark a
 // deriveType that has finished paginating. Future pages skip it entirely
 // instead of issuing a request that would just return an empty page.
@@ -1205,13 +1237,27 @@ class ServiceHistory extends ServiceBase {
         pendingTxs,
         pendingTxsToModify,
       } = param;
+      const localHistoryTxs = [...confirmedTxs, ...pendingTxs];
+      const mergedOnChainHistoryTxs = onChainHistoryTxs.map(
+        (onChainHistoryTx) => {
+          const localHistoryTx = localHistoryTxs.find((tx) =>
+            this.isSameScopedHistoryTx(onChainHistoryTx, tx),
+          );
+          return localHistoryTx
+            ? mergePrivateSendLocalDecodedTxFields({
+                localTx: localHistoryTx,
+                onChainHistoryTx,
+              })
+            : onChainHistoryTx;
+        },
+      );
 
       // Find transactions confirmed through history details query but not in on-chain history, these need to be saved
       let confirmedTxsToSave: IAccountHistoryTx[] = [];
 
       confirmedTxsToSave = confirmedTxs
         .map((tx) => {
-          const onChainHistoryTx = onChainHistoryTxs.find((item) =>
+          const onChainHistoryTx = mergedOnChainHistoryTxs.find((item) =>
             this.isSameScopedHistoryTx(item, tx),
           );
           if (onChainHistoryTx) {
@@ -1222,7 +1268,7 @@ class ServiceHistory extends ServiceBase {
         .filter((tx) => tx.decodedTx.status !== EDecodedTxStatus.Pending);
 
       const resp = unionBy(
-        [...onChainHistoryTxs, ...confirmedTxsToSave],
+        [...mergedOnChainHistoryTxs, ...confirmedTxsToSave],
         (tx) => tx.id,
       );
 

--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -89,6 +89,10 @@ const PRIVATE_SEND_SWAP_HISTORY_TERMINAL_STATUSES = new Set([
   ESwapTxHistoryStatus.PARTIALLY_FILLED,
 ]);
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 function shouldPreferPrivateSendSwapHistory(
   next: ISwapTxHistory,
   current: ISwapTxHistory,
@@ -110,13 +114,98 @@ function shouldPreferPrivateSendSwapHistory(
   );
 }
 
+function mergeNullishRecordFields<T extends Record<string, unknown>>({
+  primary,
+  fallback,
+}: {
+  primary: T;
+  fallback: T;
+}) {
+  const result: Record<string, unknown> = { ...primary };
+  Object.entries(fallback).forEach(([key, fallbackValue]) => {
+    const primaryValue = result[key];
+    if (primaryValue === undefined || primaryValue === null) {
+      if (fallbackValue !== undefined && fallbackValue !== null) {
+        result[key] = fallbackValue;
+      }
+      return;
+    }
+    if (isRecord(primaryValue) && isRecord(fallbackValue)) {
+      result[key] = mergeNullishRecordFields({
+        primary: primaryValue,
+        fallback: fallbackValue,
+      });
+    }
+  });
+  return result as T;
+}
+
+function mergePrivateSendPayloadFields({
+  localPayload,
+  onChainPayload,
+}: {
+  localPayload: IAccountHistoryTx['decodedTx']['payload'];
+  onChainPayload: IAccountHistoryTx['decodedTx']['payload'];
+}): IAccountHistoryTx['decodedTx']['payload'] {
+  if (!localPayload) {
+    return onChainPayload;
+  }
+  if (!onChainPayload) {
+    return localPayload;
+  }
+
+  const nextPayload = mergeNullishRecordFields({
+    primary: onChainPayload as unknown as Record<string, unknown>,
+    fallback: localPayload as unknown as Record<string, unknown>,
+  }) as IAccountHistoryTx['decodedTx']['payload'];
+
+  const localPrivateSend = localPayload.privateSend;
+  const onChainPrivateSend = onChainPayload.privateSend;
+  if (localPrivateSend && onChainPrivateSend) {
+    return {
+      ...nextPayload,
+      privateSend: mergeNullishRecordFields({
+        primary: onChainPrivateSend as unknown as Record<string, unknown>,
+        fallback: localPrivateSend as unknown as Record<string, unknown>,
+      }) as NonNullable<
+        IAccountHistoryTx['decodedTx']['payload']
+      >['privateSend'],
+    } as IAccountHistoryTx['decodedTx']['payload'];
+  }
+
+  return nextPayload;
+}
+
+function mergePrivateSendExtraInfoFields({
+  localExtraInfo,
+  onChainExtraInfo,
+}: {
+  localExtraInfo: IAccountHistoryTx['decodedTx']['extraInfo'];
+  onChainExtraInfo: IAccountHistoryTx['decodedTx']['extraInfo'];
+}) {
+  if (!localExtraInfo) {
+    return onChainExtraInfo;
+  }
+  if (!onChainExtraInfo) {
+    return localExtraInfo;
+  }
+  if (!isRecord(localExtraInfo) || !isRecord(onChainExtraInfo)) {
+    return onChainExtraInfo;
+  }
+
+  return mergeNullishRecordFields({
+    primary: onChainExtraInfo,
+    fallback: localExtraInfo,
+  }) as IAccountHistoryTx['decodedTx']['extraInfo'];
+}
+
 function mergePrivateSendLocalDecodedTxFields({
   localTx,
   onChainHistoryTx,
 }: {
   localTx: IAccountHistoryTx;
   onChainHistoryTx: IAccountHistoryTx;
-}) {
+}): IAccountHistoryTx {
   if (!isPrivateSendAccountHistoryTx(localTx)) {
     return onChainHistoryTx;
   }
@@ -131,13 +220,14 @@ function mergePrivateSendLocalDecodedTxFields({
     ...onChainHistoryTx,
     decodedTx: {
       ...onChainHistoryTx.decodedTx,
-      payload: localPayload
-        ? {
-            ...onChainHistoryTx.decodedTx.payload,
-            ...localPayload,
-          }
-        : onChainHistoryTx.decodedTx.payload,
-      extraInfo: onChainHistoryTx.decodedTx.extraInfo ?? localExtraInfo,
+      payload: mergePrivateSendPayloadFields({
+        localPayload,
+        onChainPayload: onChainHistoryTx.decodedTx.payload,
+      }),
+      extraInfo: mergePrivateSendExtraInfoFields({
+        localExtraInfo,
+        onChainExtraInfo: onChainHistoryTx.decodedTx.extraInfo,
+      }),
     },
   };
 }
@@ -713,6 +803,7 @@ class ServiceHistory extends ServiceBase {
         await this.batchUpdateLocalHistoryTxs(allNetworksParams);
       finalPendingTxs = updateResult.allFinalPendingTxs;
       confirmedTxsToSave = updateResult.allConfirmedTxsToSave;
+      onChainHistoryTxs = updateResult.allMergedOnChainHistoryTxs;
     } else {
       let pendingTxsToModify: IAccountHistoryTx[] = [];
       try {
@@ -742,6 +833,7 @@ class ServiceHistory extends ServiceBase {
       ]);
       finalPendingTxs = updateResult.allFinalPendingTxs;
       confirmedTxsToSave = updateResult.allConfirmedTxsToSave;
+      onChainHistoryTxs = updateResult.allMergedOnChainHistoryTxs;
     }
 
     // Merge the locally pending transactions, confirmed transactions, and on-chain history to return
@@ -1214,6 +1306,7 @@ class ServiceHistory extends ServiceBase {
     }[],
   ) {
     const allConfirmedTxsToSave: IAccountHistoryTx[] = [];
+    const allMergedOnChainHistoryTxs: IAccountHistoryTx[] = [];
     const allNonceHasBeenUsedTxs: IAccountHistoryTx[] = [];
     const allFinalPendingTxs: IAccountHistoryTx[] = [];
 
@@ -1251,6 +1344,7 @@ class ServiceHistory extends ServiceBase {
             : onChainHistoryTx;
         },
       );
+      allMergedOnChainHistoryTxs.push(...mergedOnChainHistoryTxs);
 
       // Find transactions confirmed through history details query but not in on-chain history, these need to be saved
       let confirmedTxsToSave: IAccountHistoryTx[] = [];
@@ -1355,6 +1449,7 @@ class ServiceHistory extends ServiceBase {
 
     return {
       allConfirmedTxsToSave,
+      allMergedOnChainHistoryTxs,
       allNonceHasBeenUsedTxs,
       allFinalPendingTxs,
     };

--- a/packages/kit-bg/src/vaults/impls/sol/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/sol/Vault.ts
@@ -1013,14 +1013,15 @@ export default class Vault extends VaultBase {
     }
 
     let extraInfo: IDecodedTxExtraSol | null = null;
+    const hasCreateTokenAccountInstruction = instructions.some(
+      (instruction) =>
+        instruction.programId.toString() ===
+        ASSOCIATED_TOKEN_PROGRAM_ID.toString(),
+    );
     if (
-      !unsignedTx.swapInfo &&
       !unsignedTx.stakingInfo &&
-      instructions.some(
-        (instruction) =>
-          instruction.programId.toString() ===
-          ASSOCIATED_TOKEN_PROGRAM_ID.toString(),
-      ) &&
+      (!unsignedTx.swapInfo || transferPayload?.isPrivateSend === true) &&
+      hasCreateTokenAccountInstruction &&
       actions[0].assetTransfer
     ) {
       const network = await this.getNetwork();

--- a/packages/kit/src/components/TxAction/TxActionTransfer.tsx
+++ b/packages/kit/src/components/TxAction/TxActionTransfer.tsx
@@ -20,6 +20,7 @@ import { EOnChainHistoryTxType } from '@onekeyhq/shared/types/history';
 import {
   EDecodedTxDirection,
   EDecodedTxStatus,
+  type IDecodedTx,
   type IDecodedTxActionAssetTransfer,
   type IDecodedTxTransferInfo,
 } from '@onekeyhq/shared/types/tx';
@@ -47,11 +48,91 @@ type ITransferBlock = {
   direction: EDecodedTxDirection;
 };
 
+type IPrivateSendCreateTokenAccountFee = {
+  amount?: string;
+  symbol?: string;
+};
+
 function isSendLikeHistoryTxType(type?: EOnChainHistoryTxType) {
   return (
     type === EOnChainHistoryTxType.Send ||
     type === EOnChainHistoryTxType.PrivateSend
   );
+}
+
+function getPrivateSendCreateTokenAccountFee(decodedTx: IDecodedTx) {
+  const createTokenAccountFee = (
+    decodedTx.extraInfo as
+      | { createTokenAccountFee?: IPrivateSendCreateTokenAccountFee }
+      | null
+      | undefined
+  )?.createTokenAccountFee;
+  const feeAmountBN = new BigNumber(createTokenAccountFee?.amount ?? '');
+  if (
+    feeAmountBN.isNaN() ||
+    !feeAmountBN.isFinite() ||
+    !feeAmountBN.isGreaterThan(0)
+  ) {
+    return undefined;
+  }
+  return createTokenAccountFee;
+}
+
+function hasPrivateSendCreateTokenAccountFeeTransfer({
+  transfers,
+  createTokenAccountFee,
+}: {
+  transfers: IDecodedTxTransferInfo[];
+  createTokenAccountFee: IPrivateSendCreateTokenAccountFee;
+}) {
+  return transfers.some((transfer) => {
+    const amountBN = new BigNumber(transfer.amount ?? '');
+    const feeAmountBN = new BigNumber(createTokenAccountFee.amount ?? '');
+    return (
+      transfer.isNative &&
+      !amountBN.isNaN() &&
+      !feeAmountBN.isNaN() &&
+      amountBN.isEqualTo(feeAmountBN)
+    );
+  });
+}
+
+function buildPrivateSendDisplaySends({
+  decodedTx,
+  sends,
+  networkLogoURI,
+}: {
+  decodedTx: IDecodedTx;
+  sends: IDecodedTxTransferInfo[];
+  networkLogoURI?: string;
+}) {
+  const createTokenAccountFee = getPrivateSendCreateTokenAccountFee(decodedTx);
+  if (!createTokenAccountFee) {
+    return sends;
+  }
+  if (
+    hasPrivateSendCreateTokenAccountFeeTransfer({
+      transfers: sends,
+      createTokenAccountFee,
+    })
+  ) {
+    return sends;
+  }
+  return [
+    ...sends,
+    {
+      from: decodedTx.signer || decodedTx.owner,
+      to: '',
+      tokenIdOnNetwork: '',
+      icon: networkLogoURI ?? '',
+      name: createTokenAccountFee.symbol ?? '',
+      symbol: createTokenAccountFee.symbol ?? '',
+      amount: createTokenAccountFee.amount ?? '',
+      isNFT: false,
+      isNative: true,
+      networkId: decodedTx.networkId,
+    },
+  ];
 }
 
 function getTxActionTransferInfo(
@@ -417,6 +498,13 @@ function TxActionTransferListView(props: ITxActionProps) {
     intl,
     isUTXO,
   });
+  const privateSendDisplaySends = isPrivateSend
+    ? buildPrivateSendDisplaySends({
+        decodedTx,
+        sends,
+        networkLogoURI,
+      })
+    : sends;
   const isSendLikeHistory = isSendLikeHistoryTxType(type);
   const descriptionTarget = isPrivateSend
     ? (payload?.privateSend?.originalRecipient ?? transferTarget)
@@ -446,7 +534,7 @@ function TxActionTransferListView(props: ITxActionProps) {
 
     if (isPrivateSend) {
       change = buildExpandedTransferView({
-        sends: groupTransfersByToken(sends),
+        sends: groupTransfersByToken(privateSendDisplaySends),
         hideValue,
         currencySymbol,
       });
@@ -531,7 +619,7 @@ function TxActionTransferListView(props: ITxActionProps) {
     if (isPrivateSend) {
       const changeInfo = buildTransferChangeInfo({
         changePrefix: '-',
-        transfers: sends,
+        transfers: privateSendDisplaySends,
         intl,
       });
       change = changeInfo.change;

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
@@ -60,6 +60,7 @@ import {
   ESwapTxHistoryStatus,
 } from '@onekeyhq/shared/types/swap/types';
 import { EDecodedTxDirection } from '@onekeyhq/shared/types/tx';
+import type { IDecodedTxTransferInfo } from '@onekeyhq/shared/types/tx';
 
 import { AssetItem } from '../../../AssetDetails/pages/HistoryDetails';
 import {
@@ -395,7 +396,65 @@ function PrivateSendProgress({
 function isPrivateSendSwapTxHistory(item?: ISwapTxHistory) {
   return (
     item?.protocol === EProtocolOfExchange.PRIVATE_SEND ||
-    item?.swapInfo.provider.provider === privateSendProvider
+    item?.swapInfo?.provider?.provider === privateSendProvider
+  );
+}
+
+type IPrivateSendHistoryCtx = {
+  privateSendDisplayTransfers?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isPrivateSendDisplayTransfer(
+  value: unknown,
+): value is IDecodedTxTransferInfo {
+  return (
+    isRecord(value) &&
+    typeof value.amount === 'string' &&
+    typeof value.symbol === 'string'
+  );
+}
+
+function getPrivateSendDisplayTransfers(item?: ISwapTxHistory) {
+  const transfers = (item?.ctx as IPrivateSendHistoryCtx | undefined)
+    ?.privateSendDisplayTransfers;
+  return Array.isArray(transfers)
+    ? transfers.filter(isPrivateSendDisplayTransfer)
+    : [];
+}
+
+function normalizeTokenAddress(address?: string) {
+  const normalized = address?.trim();
+  return normalized ? normalized.toLowerCase() : '';
+}
+
+function isBasePrivateSendTransfer({
+  transfer,
+  txHistory,
+}: {
+  transfer: IDecodedTxTransferInfo;
+  txHistory?: ISwapTxHistory;
+}) {
+  const fromToken = txHistory?.baseInfo.fromToken;
+  if (!fromToken) {
+    return false;
+  }
+  if (transfer.networkId && transfer.networkId !== fromToken.networkId) {
+    return false;
+  }
+
+  const transferTokenAddress = normalizeTokenAddress(transfer.tokenIdOnNetwork);
+  const fromTokenAddress = normalizeTokenAddress(fromToken.contractAddress);
+  if (transferTokenAddress && fromTokenAddress) {
+    return transferTokenAddress === fromTokenAddress;
+  }
+
+  return Boolean(
+    (transfer.isNative || !transferTokenAddress) &&
+    (fromToken.isNative || !fromTokenAddress),
   );
 }
 
@@ -410,6 +469,43 @@ function getPositiveTokenPrice(value?: number | string) {
   }
 
   return valueBN.toFixed();
+}
+
+function getNativeTokenPriceFromGasFee(item?: ISwapTxHistory) {
+  const gasFeeInNativeBN = new BigNumber(item?.txInfo.gasFeeInNative ?? '');
+  const gasFeeFiatValueBN = new BigNumber(item?.txInfo.gasFeeFiatValue ?? '');
+
+  if (
+    gasFeeInNativeBN.isNaN() ||
+    !gasFeeInNativeBN.isFinite() ||
+    !gasFeeInNativeBN.isGreaterThan(0) ||
+    gasFeeFiatValueBN.isNaN() ||
+    !gasFeeFiatValueBN.isFinite() ||
+    !gasFeeFiatValueBN.isGreaterThan(0)
+  ) {
+    return undefined;
+  }
+
+  return gasFeeFiatValueBN.div(gasFeeInNativeBN).toFixed();
+}
+
+function getPrivateSendTransferPrice({
+  transfer,
+  isBaseToken,
+  fromAssetPrice,
+  nativeTokenPrice,
+}: {
+  transfer: IDecodedTxTransferInfo;
+  isBaseToken: boolean;
+  fromAssetPrice?: string;
+  nativeTokenPrice?: string;
+}) {
+  return (
+    getPositiveTokenPrice(transfer.price) ??
+    (isBaseToken ? getPositiveTokenPrice(fromAssetPrice) : undefined) ??
+    (transfer.isNative ? nativeTokenPrice : undefined) ??
+    '0'
+  );
 }
 
 function applyPrivateSendTokenPrice({
@@ -701,6 +797,68 @@ const SwapHistoryDetailModal = () => {
       });
     }
     if (isPrivateSendHistory) {
+      const privateSendDisplayTransfers =
+        getPrivateSendDisplayTransfers(txHistory);
+      if (privateSendDisplayTransfers.length) {
+        const nativeTokenPrice = getNativeTokenPriceFromGasFee(txHistory);
+        return (
+          <>
+            {privateSendDisplayTransfers.map((transfer, index) => {
+              const isBaseToken = isBasePrivateSendTransfer({
+                transfer,
+                txHistory,
+              });
+              const asset = {
+                name:
+                  transfer.name ||
+                  (isBaseToken
+                    ? (txHistory?.baseInfo.fromToken.name ?? '')
+                    : ''),
+                symbol:
+                  transfer.symbol ||
+                  (isBaseToken
+                    ? (txHistory?.baseInfo.fromToken.symbol ?? '')
+                    : ''),
+                icon:
+                  transfer.icon ||
+                  (isBaseToken
+                    ? (txHistory?.baseInfo.fromToken.logoURI ?? '')
+                    : ''),
+                isNFT: transfer.isNFT,
+                isNative: transfer.isNative,
+                price: getPrivateSendTransferPrice({
+                  transfer,
+                  isBaseToken,
+                  fromAssetPrice: fromAsset.price,
+                  nativeTokenPrice,
+                }),
+              };
+
+              return (
+                <AssetItem
+                  key={`${transfer.tokenIdOnNetwork || transfer.symbol}-${
+                    transfer.amount
+                  }-${index}`}
+                  index={index}
+                  direction={EDecodedTxDirection.OUT}
+                  asset={asset}
+                  isAllNetworks
+                  amount={transfer.amount}
+                  networkIcon={txHistory?.baseInfo.fromNetwork?.logoURI ?? ''}
+                  currencySymbol={
+                    txHistory?.currency ??
+                    settingsPersistAtom.currencyInfo.symbol
+                  }
+                  networkId={
+                    transfer.networkId ??
+                    txHistory?.baseInfo.fromNetwork?.networkId
+                  }
+                />
+              );
+            })}
+          </>
+        );
+      }
       return (
         <AssetItem
           index={0}

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
@@ -83,7 +83,7 @@ type ISwapHistoryDetailAssetItem = {
   icon: string;
   isNFT: boolean;
   isNative: boolean;
-  price: string;
+  price?: string;
   amount?: string;
 };
 
@@ -503,8 +503,7 @@ function getPrivateSendTransferPrice({
   return (
     getPositiveTokenPrice(transfer.price) ??
     (isBaseToken ? getPositiveTokenPrice(fromAssetPrice) : undefined) ??
-    (transfer.isNative ? nativeTokenPrice : undefined) ??
-    '0'
+    (transfer.isNative ? nativeTokenPrice : undefined)
   );
 }
 

--- a/packages/kit/src/views/Swap/utils/privateSendHistory.ts
+++ b/packages/kit/src/views/Swap/utils/privateSendHistory.ts
@@ -131,6 +131,52 @@ function getPrivateSendDisplayTransfersFromCtx(ctx: unknown) {
     : [];
 }
 
+function normalizePrivateSendTransferAmount(amount?: string) {
+  const amountBN = new BigNumber(amount ?? '');
+  return amountBN.isNaN() || !amountBN.isFinite()
+    ? (amount ?? '')
+    : amountBN.toFixed();
+}
+
+function getPrivateSendDisplayTransferIdentity(
+  transfer: IDecodedTxTransferInfo,
+) {
+  return {
+    amount: normalizePrivateSendTransferAmount(transfer.amount),
+    tokenIdOnNetwork: normalizePrivateSendTokenAddress(
+      transfer.tokenIdOnNetwork,
+    ),
+    symbol: transfer.symbol,
+    icon: transfer.icon,
+    isNative: transfer.isNative === true,
+  };
+}
+
+function areSamePrivateSendDisplayTransfers({
+  currentTransfers,
+  replayTransfers,
+}: {
+  currentTransfers: IDecodedTxTransferInfo[];
+  replayTransfers: IDecodedTxTransferInfo[];
+}) {
+  if (currentTransfers.length !== replayTransfers.length) {
+    return false;
+  }
+  return replayTransfers.every((transfer, index) => {
+    const replayIdentity = getPrivateSendDisplayTransferIdentity(transfer);
+    const currentIdentity = getPrivateSendDisplayTransferIdentity(
+      currentTransfers[index],
+    );
+    return (
+      replayIdentity.amount === currentIdentity.amount &&
+      replayIdentity.tokenIdOnNetwork === currentIdentity.tokenIdOnNetwork &&
+      replayIdentity.symbol === currentIdentity.symbol &&
+      replayIdentity.icon === currentIdentity.icon &&
+      replayIdentity.isNative === currentIdentity.isNative
+    );
+  });
+}
+
 function shouldMergePrivateSendDisplayTransfers({
   currentTransfers,
   replayTransfers,
@@ -142,18 +188,10 @@ function shouldMergePrivateSendDisplayTransfers({
     return false;
   }
 
-  const hasCurrentNativeTransfer = currentTransfers.some(
-    (transfer) => transfer.isNative,
-  );
-  const hasReplayNativeTransfer = replayTransfers.some(
-    (transfer) => transfer.isNative,
-  );
-
-  return (
-    !currentTransfers.length ||
-    replayTransfers.length > currentTransfers.length ||
-    (hasReplayNativeTransfer && !hasCurrentNativeTransfer)
-  );
+  return !areSamePrivateSendDisplayTransfers({
+    currentTransfers,
+    replayTransfers,
+  });
 }
 
 function shouldMergePrivateSendReplayBaseInfo({

--- a/packages/kit/src/views/Swap/utils/privateSendHistory.ts
+++ b/packages/kit/src/views/Swap/utils/privateSendHistory.ts
@@ -48,12 +48,18 @@ type IPrivateSendHistoryNetwork = {
 type IPrivateSendTxStateCtx = {
   rocketXOrderId?: unknown;
   payinAddress?: unknown;
+  privateSendDisplayTransfers?: unknown;
 };
 
 type IPrivateSendKnownToken = {
   address?: string;
   contractAddress?: string;
   isNative?: boolean;
+};
+
+type IPrivateSendCreateTokenAccountFee = {
+  amount?: string;
+  symbol?: string;
 };
 
 export function isPrivateSendHistoryTx(historyTx: IAccountHistoryTx) {
@@ -107,6 +113,49 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+function isPrivateSendDisplayTransfer(
+  value: unknown,
+): value is IDecodedTxTransferInfo {
+  return (
+    isRecord(value) &&
+    typeof value.amount === 'string' &&
+    typeof value.symbol === 'string'
+  );
+}
+
+function getPrivateSendDisplayTransfersFromCtx(ctx: unknown) {
+  const transfers = (ctx as IPrivateSendTxStateCtx | undefined)
+    ?.privateSendDisplayTransfers;
+  return Array.isArray(transfers)
+    ? transfers.filter(isPrivateSendDisplayTransfer)
+    : [];
+}
+
+function shouldMergePrivateSendDisplayTransfers({
+  currentTransfers,
+  replayTransfers,
+}: {
+  currentTransfers: IDecodedTxTransferInfo[];
+  replayTransfers: IDecodedTxTransferInfo[];
+}) {
+  if (!replayTransfers.length) {
+    return false;
+  }
+
+  const hasCurrentNativeTransfer = currentTransfers.some(
+    (transfer) => transfer.isNative,
+  );
+  const hasReplayNativeTransfer = replayTransfers.some(
+    (transfer) => transfer.isNative,
+  );
+
+  return (
+    !currentTransfers.length ||
+    replayTransfers.length > currentTransfers.length ||
+    (hasReplayNativeTransfer && !hasCurrentNativeTransfer)
+  );
+}
+
 function shouldMergePrivateSendReplayBaseInfo({
   item,
   replayItem,
@@ -147,6 +196,16 @@ function mergePrivateSendHistoryReplayFields({
   const replayPayinAddress = getPrivateSendPayinAddressFromCtx(replayItem.ctx);
   const currentRocketXOrderId = getPrivateSendRocketXOrderIdFromCtx(item.ctx);
   const currentPayinAddress = getPrivateSendPayinAddressFromCtx(item.ctx);
+  const replayDisplayTransfers = getPrivateSendDisplayTransfersFromCtx(
+    replayItem.ctx,
+  );
+  const currentDisplayTransfers = getPrivateSendDisplayTransfersFromCtx(
+    item.ctx,
+  );
+  const shouldMergeDisplayTransfers = shouldMergePrivateSendDisplayTransfers({
+    currentTransfers: currentDisplayTransfers,
+    replayTransfers: replayDisplayTransfers,
+  });
   const shouldMergeGasFeeInNative = shouldUsePrivateSendReplayFeeValue({
     currentValue: item.txInfo.gasFeeInNative,
     replayValue: replayItem.txInfo.gasFeeInNative,
@@ -161,7 +220,8 @@ function mergePrivateSendHistoryReplayFields({
 
   if (
     (replayRocketXOrderId && !currentRocketXOrderId) ||
-    (replayPayinAddress && !currentPayinAddress)
+    (replayPayinAddress && !currentPayinAddress) ||
+    shouldMergeDisplayTransfers
   ) {
     nextItem = {
       ...nextItem,
@@ -172,6 +232,9 @@ function mergePrivateSendHistoryReplayFields({
           : {}),
         ...(replayPayinAddress && !currentPayinAddress
           ? { payinAddress: replayPayinAddress }
+          : {}),
+        ...(shouldMergeDisplayTransfers
+          ? { privateSendDisplayTransfers: replayDisplayTransfers }
           : {}),
       },
     };
@@ -364,6 +427,111 @@ function getPrivateSendHistorySendTransfers(historyTx: IAccountHistoryTx) {
   );
 }
 
+function getPrivateSendCreateTokenAccountFee(historyTx: IAccountHistoryTx) {
+  const createTokenAccountFee = (
+    historyTx.decodedTx.extraInfo as
+      | { createTokenAccountFee?: IPrivateSendCreateTokenAccountFee }
+      | null
+      | undefined
+  )?.createTokenAccountFee;
+  const feeAmountBN = new BigNumber(createTokenAccountFee?.amount ?? '');
+  if (
+    feeAmountBN.isNaN() ||
+    !feeAmountBN.isFinite() ||
+    !feeAmountBN.isGreaterThan(0)
+  ) {
+    return undefined;
+  }
+  return createTokenAccountFee;
+}
+
+function hasPrivateSendCreateTokenAccountFeeTransfer({
+  transfers,
+  createTokenAccountFee,
+}: {
+  transfers: IDecodedTxTransferInfo[];
+  createTokenAccountFee: IPrivateSendCreateTokenAccountFee;
+}) {
+  return transfers.some(
+    (transfer) =>
+      transfer.isNative &&
+      isSamePrivateSendAmount(transfer.amount, createTokenAccountFee.amount),
+  );
+}
+
+function buildPrivateSendCreateTokenAccountFeeTransfer({
+  historyTx,
+  sender,
+  network,
+  nativeTokenInfo,
+  createTokenAccountFee,
+}: {
+  historyTx: IAccountHistoryTx;
+  sender: string;
+  network?: IPrivateSendHistoryNetwork;
+  nativeTokenInfo?: IToken;
+  createTokenAccountFee: IPrivateSendCreateTokenAccountFee;
+}): IDecodedTxTransferInfo {
+  return {
+    from: sender,
+    to: '',
+    tokenIdOnNetwork: getPrivateSendKnownTokenAddress(nativeTokenInfo),
+    icon: nativeTokenInfo?.logoURI ?? network?.logoURI ?? '',
+    name:
+      nativeTokenInfo?.name ??
+      network?.name ??
+      createTokenAccountFee.symbol ??
+      '',
+    symbol:
+      nativeTokenInfo?.symbol ??
+      createTokenAccountFee.symbol ??
+      network?.symbol ??
+      '',
+    amount: createTokenAccountFee.amount ?? '0',
+    isNFT: false,
+    isNative: true,
+    networkId: historyTx.decodedTx.networkId,
+  };
+}
+
+function buildPrivateSendDisplayTransfers({
+  historyTx,
+  sender,
+  network,
+  nativeTokenInfo,
+}: {
+  historyTx: IAccountHistoryTx;
+  sender: string;
+  network?: IPrivateSendHistoryNetwork;
+  nativeTokenInfo?: IToken;
+}) {
+  const sendTransfers = getPrivateSendHistorySendTransfers(historyTx);
+  const createTokenAccountFee = getPrivateSendCreateTokenAccountFee(historyTx);
+  if (!createTokenAccountFee) {
+    return sendTransfers;
+  }
+
+  if (
+    hasPrivateSendCreateTokenAccountFeeTransfer({
+      transfers: sendTransfers,
+      createTokenAccountFee,
+    })
+  ) {
+    return sendTransfers;
+  }
+
+  return [
+    ...sendTransfers,
+    buildPrivateSendCreateTokenAccountFeeTransfer({
+      historyTx,
+      sender,
+      network,
+      nativeTokenInfo,
+      createTokenAccountFee,
+    }),
+  ];
+}
+
 function getPrivateSendHistoryTransfer(
   historyTx: IAccountHistoryTx,
   tokenInfo?: IPrivateSendKnownToken,
@@ -545,6 +713,7 @@ function buildPrivateSendHistoryItemFromAccountHistory({
   tokenInfo,
   tokenDetails,
   currencySymbol,
+  nativeTokenInfo,
 }: {
   historyTx: IAccountHistoryTx;
   accountId: string;
@@ -553,6 +722,7 @@ function buildPrivateSendHistoryItemFromAccountHistory({
   tokenInfo?: IToken;
   tokenDetails?: IFetchTokenDetailItem;
   currencySymbol?: string;
+  nativeTokenInfo?: IToken;
 }): ISwapTxHistory {
   const transfer = getPrivateSendHistoryTransfer(historyTx, tokenInfo);
   const sender =
@@ -576,11 +746,20 @@ function buildPrivateSendHistoryItemFromAccountHistory({
       ? privateSendPayload.orderId
       : undefined;
   const orderId = backendOrderId ?? getPrivateSendFallbackOrderId(historyTx);
+  const privateSendDisplayTransfers = buildPrivateSendDisplayTransfers({
+    historyTx,
+    sender,
+    network,
+    nativeTokenInfo,
+  });
   const ctx =
-    rocketXOrderId || payinAddress
+    rocketXOrderId || payinAddress || privateSendDisplayTransfers.length
       ? {
           ...(rocketXOrderId ? { rocketXOrderId } : {}),
           ...(payinAddress ? { payinAddress } : {}),
+          ...(privateSendDisplayTransfers.length
+            ? { privateSendDisplayTransfers }
+            : {}),
         }
       : undefined;
 
@@ -689,6 +868,7 @@ export async function maybeOpenPrivateSendHistoryDetail({
   const knownTokenInfo = resolvedTokenInfo ?? txHistoryItem?.baseInfo.fromToken;
   const transfer = getPrivateSendHistoryTransfer(historyTx, knownTokenInfo);
   let resolvedTokenDetails: IFetchTokenDetailItem | undefined;
+  let resolvedNativeTokenInfo: IToken | undefined;
   try {
     resolvedTokenDetails = await fetchPrivateSendHistoryTokenDetails({
       historyTx,
@@ -714,6 +894,19 @@ export async function maybeOpenPrivateSendHistoryDetail({
       resolvedTokenInfo = tokenInfo;
     }
   }
+  if (getPrivateSendCreateTokenAccountFee(historyTx)) {
+    try {
+      const nativeToken = await backgroundApiProxy.serviceToken.getNativeToken({
+        accountId,
+        networkId: historyTx.decodedTx.networkId,
+      });
+      resolvedNativeTokenInfo = nativeToken ?? undefined;
+    } catch {
+      resolvedNativeTokenInfo = resolvedTokenInfo?.isNative
+        ? resolvedTokenInfo
+        : undefined;
+    }
+  }
 
   const shouldPersistFallbackHistory = !txHistoryItem;
   const replayTxHistoryItem = buildPrivateSendHistoryItemFromAccountHistory({
@@ -724,6 +917,7 @@ export async function maybeOpenPrivateSendHistoryDetail({
     tokenInfo: resolvedTokenInfo,
     tokenDetails: resolvedTokenDetails,
     currencySymbol,
+    nativeTokenInfo: resolvedNativeTokenInfo,
   });
   const { item: baseTxHistoryItem, updated: shouldPersistReplayFields } =
     txHistoryItem


### PR DESCRIPTION
## Summary
- Preserve Private Send local decoded metadata when on-chain history replaces local history rows.
- Build Private Send display transfers from Solana ATA create-account fee metadata and render multiple outgoing assets in the history detail modal.
- Keep Solana rent as extra fee metadata instead of adding it to action native amount.

## Intent & Context
OK-55859 covers Solana Private Send transactions sent to new token accounts. These transactions spend the token amount plus SOL rent for ATA activation, but the Private Send detail view could show only the SPL token or show SOL with incomplete fiat value.

## Root Cause
Server on-chain history does not return Solana ATA create-account rent as a separate asset transfer, and the client can replace local decoded transaction metadata with the on-chain history version during refresh or confirmation. The detail modal also only had a single-asset Private Send rendering path.

## Design Decisions
- Keep on-chain status and history data as the source of truth, but preserve local Private Send payload and extraInfo fields needed for display replay.
- Store Private Send display transfers in swap history ctx instead of passing them through route params, so refresh and replay paths can keep the same display data.
- Do not add SOL rent to assetTransfer.nativeAmount, avoiding double counting with existing extra fee handling.
- Match base token pricing by token identity/native identity instead of symbol-only matching.

## Changes Detail
- ServiceHistory preserves local Private Send decoded payload/extraInfo when matching on-chain history rows.
- Solana vault records ATA create-account rent for Private Send swap transactions through extraInfo.
- Private Send history helper generates and persists display transfers, including SOL rent when present.
- Swap history detail modal renders Private Send display transfers as multiple outgoing assets.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Mobile / Extension / Web
- **Risk Areas**: Private Send history refresh and Solana ATA activation display. Ordinary send and ordinary swap paths are gated out of the new display-transfer flow.

## Test plan
- [ ] Send Solana Private Send to a new token account and verify the detail view shows both the SPL token and SOL activation rent.
- [ ] Refresh/reopen history and verify the two-asset display persists.
- [ ] Verify ordinary send and ordinary swap history details still render normally.
- [x] Run oxlint on affected files.
- [x] Run yarn tsc:staged.