### PR TITLE
fix: eliminate two desktop renderer freeze render storms

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -674,7 +674,7 @@
     },
     {
       // JS/JSX files - disable TypeScript-specific rules
-      "files": ["**/*.js", "**/*.jsx"],
+      "files": ["**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs"],
       "rules": {
         "typescript/no-floating-promises": "off",
         "typescript/consistent-type-imports": "off",

--- a/apps/desktop/scripts/cdp-repro-gift-storm.mjs
+++ b/apps/desktop/scripts/cdp-repro-gift-storm.mjs
@@ -1,0 +1,246 @@
+/* eslint-disable no-console */
+/**
+ * cdp-repro-gift-storm.mjs — reproduce the FocusScope `Maximum update depth`
+ * freeze by storming away while a FocusScope overlay is OPEN.
+ *
+ * Insight (confirmed): unmounting a page alone is clean. The error stack is
+ * `safelyDetachRef` — a FocusScope overlay must be MOUNTED/OPEN when the storm
+ * unmounts its subtree. The DeFi/Earn header GIFT icon (GiftAction →
+ * HeaderIconButton with a `title` → wrapped in a tamagui <Tooltip>, and onPress
+ * opens the referral <Dialog>) is a FocusScope overlay: hover mounts the
+ * tooltip, click opens the dialog. (Requires testID="header-gift-action" on
+ * GiftAction.)
+ *
+ * Round: go to Earn → open the gift overlay (hover tooltip + click dialog) →
+ *        WITHOUT closing it, tab-storm → the open FocusScope subtree unmounts
+ *        mid-open → setContainer(null) storm → Maximum update depth → freeze.
+ *
+ * Prerequisite: yarn app:desktop (CDP 9222) + heavy wallet + DevTools closed.
+ * RUN: node apps/desktop/scripts/cdp-repro-gift-storm.mjs
+ *      REGRESSION=1 node ...   # after fix: PASS only if 0 hits
+ */
+
+import { chromium } from 'playwright-core';
+
+const CDP = process.env.CDP_URL || 'http://127.0.0.1:9222';
+const REGRESSION = process.env.REGRESSION === '1';
+const ROUNDS = Number(process.env.ROUNDS || 80);
+const FREEZE_RTT = Number(process.env.FREEZE_RTT || 2500);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const hhmmss = () => new Date().toTimeString().slice(0, 8);
+const log = (...a) => console.log(`[${hhmmss()}]`, ...a);
+
+const browser = await chromium.connectOverCDP(CDP);
+let page = null;
+for (const c of browser.contexts()) {
+  for (const p of c.pages()) {
+    try {
+      if ((await p.locator('[data-testid^="tab-modal"]').count()) > 0) {
+        page = p;
+        break;
+      }
+    } catch {
+      /* */
+    }
+  }
+  if (page) break;
+}
+if (!page) {
+  console.error('main window not found');
+  process.exit(1);
+}
+log('driving', page.url().slice(0, 50));
+
+const ERR_RE = /Maximum update depth|FocusScope|compose-refs/i;
+let errTotal = 0;
+let firstErr = '';
+page.on('console', (m) => {
+  const t = m.text();
+  if (ERR_RE.test(t)) {
+    errTotal += 1;
+    if (!firstErr) firstErr = t.split('\n')[0];
+  }
+});
+page.on('pageerror', (e) => {
+  const t = e.message || String(e);
+  if (ERR_RE.test(t)) {
+    errTotal += 1;
+    if (!firstErr) firstErr = t.split('\n')[0];
+  }
+});
+
+async function ping() {
+  const t = Date.now();
+  try {
+    await Promise.race([
+      page.evaluate('1'),
+      sleep(FREEZE_RTT + 1500).then(() => Promise.reject(new Error('to'))),
+    ]);
+    return Date.now() - t;
+  } catch {
+    return Infinity;
+  }
+}
+async function heapMB() {
+  try {
+    return await page.evaluate(
+      '(performance.memory?Math.round(performance.memory.usedJSHeapSize/1048576):0)',
+    );
+  } catch {
+    return -1;
+  }
+}
+
+const ICON = {
+  home: 'Wallet4',
+  market: 'TradingViewCandles',
+  swap: 'SwitchHor',
+  perp: 'Trade',
+  earn: 'Coins',
+};
+async function tab(name) {
+  try {
+    await page
+      .locator(`[data-testid^="tab-modal"][data-testid*="${ICON[name]}"]`)
+      .first()
+      .click({ force: true, timeout: 2500 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// PROVEN recipe (hit 13%/round; fast timing MISSES the window — the dialog's
+// FocusScope teardown is a deferred startTransition, so tab switches must be
+// HUMAN-SPACED to land while it's in-flight). Each round = one human-paced
+// cycle; run many rounds for stability. Matches prod: gift→Confirm→ReferFriends
+// →Home = freeze.
+// timing halved vs the original human pace (~2× faster), but still far slower
+// than the failed 50ms burst. Adds account-selector open/close (a Popover/Sheet
+// = another FocusScope overlay) interleaved into the nav storm.
+// Timing ALIGNED to the two prod freeze logs (renderer second-resolution):
+//   L1: confirm→ReferFriends +3s→Home +10s→Settings +5s→freeze
+//   L2: Earn +3s→ReferFriends +3s→Swap +1s→Perp +6s→Home +9s→Settings +7s→freeze
+// Consistent trigger: land on Home, dwell ~9s, then SETTINGS modal (a FocusScope
+// Dialog) opens → freeze ~5-7s later. ~3s between tab switches (not 850ms).
+const STEP = Number(process.env.STEP_MS || 3000); // ~3s between tab switches (real avg)
+const HOME_DWELL = Number(process.env.HOME_DWELL_MS || 9000); // real: 9-10s on Home before settings
+
+async function openSettings() {
+  for (const sel of [
+    '[data-testid="me-settings"]',
+    '[data-testid="web-settings-trigger"]',
+    '[data-testid="web-account-panel-footer-settings"]',
+  ]) {
+    try {
+      if (await page.locator(sel).count()) {
+        await page.locator(sel).first().click({ force: true, timeout: 2500 });
+        return true;
+      }
+    } catch {
+      /* next */
+    }
+  }
+  return false;
+}
+
+async function round(i) {
+  const before = errTotal;
+  // --- lead-up at REAL cadence ---
+  await tab('earn');
+  await sleep(STEP);
+  // reach ReferFriends via the gift dialog confirm (L1's path; FocusScope Dialog
+  // teardown during the switchTab nav)
+  const g = page.locator('[data-testid="header-gift-action"]').first();
+  const box = await g.boundingBox().catch(() => null);
+  if (box) {
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await sleep(700);
+  }
+  await g.click({ force: true, timeout: 2500 }).catch(() => {});
+  try {
+    await page
+      .locator('[data-testid="dialog-confirm-btn"]')
+      .first()
+      .waitFor({ state: 'visible', timeout: 4000 });
+  } catch {
+    /* */
+  }
+  await sleep(2000); // read dialog
+  await page
+    .locator('[data-testid="dialog-confirm-btn"]')
+    .first()
+    .click({ force: true, timeout: 2500 })
+    .catch(() => {}); // → ReferFriends
+  await sleep(STEP);
+  await tab('swap');
+  await sleep(STEP);
+  await tab('perp');
+  await sleep(1000);
+  // --- land on Home and DWELL (the real precursor) ---
+  await tab('home');
+  await sleep(HOME_DWELL);
+  // --- open Settings (FocusScope modal) on the heavy Home page → the trigger ---
+  const setOpened = await openSettings();
+  // watch ~9s (freeze hit ~5-7s after settings in both logs)
+  let frozen = false;
+  for (let k = 0; k < 9; k += 1) {
+    if (errTotal > before) break;
+    const rtt = await ping();
+    if (rtt >= FREEZE_RTT) {
+      frozen = true;
+      break;
+    }
+    await sleep(1000);
+  }
+  const hit = errTotal > before || frozen;
+  const heap = await heapMB();
+  log(
+    `round ${String(i).padStart(2)}: settingsOpened=${setOpened} | ${
+      hit ? '🔴 HIT' : '🟢 clean'
+    } errors+${errTotal - before} heap=${heap === -1 ? 'FROZEN' : `${heap}MB`}`,
+  );
+  if (frozen || heap === -1) return { hit, frozen: true };
+  await page.keyboard.press('Escape').catch(() => {});
+  await sleep(500);
+  return { hit, frozen: false };
+}
+
+let hits = 0;
+let ran = 0;
+let frozeAt = 0;
+log(`start heap=${await heapMB()}MB, rounds=${ROUNDS}`);
+for (let i = 1; i <= ROUNDS; i += 1) {
+  ran = i;
+  const r = await round(i);
+  if (r.hit) hits += 1;
+  if (r.frozen) {
+    frozeAt = i;
+    break;
+  }
+}
+
+console.log('\n===== RESULT =====');
+console.log(
+  `hits ${hits}/${ran}${
+    frozeAt ? ` (froze at round ${frozeAt})` : ''
+  } | total Maximum-update-depth errors=${errTotal}`,
+);
+if (firstErr) console.log(`first error: ${firstErr}`);
+const reproduced = hits > 0;
+console.log(
+  reproduced
+    ? `🔴 REPRODUCED (hit rate ${Math.round((hits / ran) * 100)}%)`
+    : '🟢 not reproduced this run',
+);
+try {
+  await browser.close();
+} catch {
+  /* */
+}
+if (REGRESSION) {
+  console.log(reproduced ? 'REGRESSION FAIL ❌' : 'REGRESSION PASS ✅');
+  process.exit(reproduced ? 1 : 0);
+}
+process.exit(reproduced ? 0 : 3);

--- a/packages/components/src/layouts/Page/PageHeader.tsx
+++ b/packages/components/src/layouts/Page/PageHeader.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useMemo } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef } from 'react';
 
 import { useNavigation } from '@react-navigation/native';
 import { useIntl } from 'react-intl';
@@ -17,6 +17,30 @@ import type {
 
 export type IPageHeaderProps = IStackNavigationOptions &
   IModalNavigationOptions;
+
+// `reload()` returns a flat options object whose values are reference-stable by
+// convention (callers wrap header render functions in `useCallback`). A shallow
+// own-key comparison is therefore enough to detect real changes, and avoids the
+// cost of a recursive deep-equal on this hot, every-page render path.
+function shallowEqualHeaderOptions(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): boolean {
+  if (a === b) {
+    return true;
+  }
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  for (const key of aKeys) {
+    if (!Object.is(a[key], b[key])) {
+      return false;
+    }
+  }
+  return true;
+}
 
 const usePageHeaderReloadOptions = () => {
   const intl = useIntl();
@@ -68,7 +92,27 @@ const usePageHeaderReloadOptions = () => {
  */
 function PageHeader(props: IPageHeaderProps) {
   const pageHeaderReload = usePageHeaderReloadOptions();
-  const reloadOptions = pageHeaderReload.reload(props);
+  const nextReloadOptions = pageHeaderReload.reload(props);
+
+  // `reload()` returns a brand-new object on every render. Feeding that fresh
+  // reference into the layout effect below (and into `navigation.setOptions`)
+  // makes the effect run on every render → setOptions → navigator re-render →
+  // this screen re-renders → effect runs again. On heavy, frequently
+  // re-rendering pages (e.g. Earn) that self-sustaining loop trips React's
+  // "Maximum update depth exceeded". Keep the previous reference whenever the
+  // resolved options are shallowly equal, so the effect dependency only changes
+  // when the options actually change.
+  const reloadOptionsRef = useRef(nextReloadOptions);
+  if (
+    !shallowEqualHeaderOptions(
+      reloadOptionsRef.current as Record<string, unknown>,
+      nextReloadOptions as Record<string, unknown>,
+    )
+  ) {
+    reloadOptionsRef.current = nextReloadOptions;
+  }
+  const reloadOptions = reloadOptionsRef.current;
+
   const navigation = useNavigation();
   useLayoutEffect(() => {
     if (reloadOptions.headerShown === false) {

--- a/packages/kit/src/components/TabPageHeader/components/GiftAction.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/GiftAction.tsx
@@ -24,6 +24,7 @@ export function GiftAction({
   const intl = useIntl();
   return (
     <HeaderIconButton
+      testID="header-gift-action"
       title={intl.formatMessage({ id: ETranslations.referral_title })}
       icon="GiftOutline"
       size={size}

--- a/patches/@tamagui+focus-scope+1.108.0.patch
+++ b/patches/@tamagui+focus-scope+1.108.0.patch
@@ -1,0 +1,108 @@
+diff --git a/node_modules/@tamagui/focus-scope/dist/cjs/FocusScope.js b/node_modules/@tamagui/focus-scope/dist/cjs/FocusScope.js
+index b029312..24fe25a 100644
+--- a/node_modules/@tamagui/focus-scope/dist/cjs/FocusScope.js
++++ b/node_modules/@tamagui/focus-scope/dist/cjs/FocusScope.js
+@@ -43,11 +43,11 @@ function useFocusScope(props, forwardedRef) {
+     forceUnmount,
+     children,
+     ...scopeProps
+-  } = props, [container, setContainer] = React.useState(null), onMountAutoFocus = (0, import_use_event.useEvent)(onMountAutoFocusProp), onUnmountAutoFocus = (0, import_use_event.useEvent)(onUnmountAutoFocusProp), lastFocusedElementRef = React.useRef(null), composedRefs = (0, import_compose_refs.useComposedRefs)(forwardedRef, (node) => {
++  } = props, [container, setContainer] = React.useState(null), onMountAutoFocus = (0, import_use_event.useEvent)(onMountAutoFocusProp), onUnmountAutoFocus = (0, import_use_event.useEvent)(onUnmountAutoFocusProp), lastFocusedElementRef = React.useRef(null), composedRefs = (0, import_compose_refs.useComposedRefs)(forwardedRef, React.useCallback((node) => {
+     React.startTransition(() => {
+       setContainer(node);
+     });
+-  }), focusScope = React.useRef({
++  }, [])), focusScope = React.useRef({
+     paused: !1,
+     pause() {
+       this.paused = !0;
+diff --git a/node_modules/@tamagui/focus-scope/dist/esm/FocusScope.js b/node_modules/@tamagui/focus-scope/dist/esm/FocusScope.js
+index 0ceee7f..917e660 100644
+--- a/node_modules/@tamagui/focus-scope/dist/esm/FocusScope.js
++++ b/node_modules/@tamagui/focus-scope/dist/esm/FocusScope.js
+@@ -18,11 +18,11 @@ function useFocusScope(props, forwardedRef) {
+     forceUnmount,
+     children,
+     ...scopeProps
+-  } = props, [container, setContainer] = React.useState(null), onMountAutoFocus = useEvent(onMountAutoFocusProp), onUnmountAutoFocus = useEvent(onUnmountAutoFocusProp), lastFocusedElementRef = React.useRef(null), composedRefs = useComposedRefs(forwardedRef, (node) => {
++  } = props, [container, setContainer] = React.useState(null), onMountAutoFocus = useEvent(onMountAutoFocusProp), onUnmountAutoFocus = useEvent(onUnmountAutoFocusProp), lastFocusedElementRef = React.useRef(null), composedRefs = useComposedRefs(forwardedRef, React.useCallback((node) => {
+     React.startTransition(() => {
+       setContainer(node);
+     });
+-  }), focusScope = React.useRef({
++  }, [])), focusScope = React.useRef({
+     paused: !1,
+     pause() {
+       this.paused = !0;
+diff --git a/node_modules/@tamagui/focus-scope/dist/esm/FocusScope.mjs b/node_modules/@tamagui/focus-scope/dist/esm/FocusScope.mjs
+index 882a822..b8da710 100644
+--- a/node_modules/@tamagui/focus-scope/dist/esm/FocusScope.mjs
++++ b/node_modules/@tamagui/focus-scope/dist/esm/FocusScope.mjs
+@@ -29,11 +29,11 @@ function useFocusScope(props, forwardedRef) {
+     onMountAutoFocus = useEvent(onMountAutoFocusProp),
+     onUnmountAutoFocus = useEvent(onUnmountAutoFocusProp),
+     lastFocusedElementRef = React.useRef(null),
+-    composedRefs = useComposedRefs(forwardedRef, node => {
++    composedRefs = useComposedRefs(forwardedRef, React.useCallback(node => {
+       React.startTransition(() => {
+         setContainer(node);
+       });
+-    }),
++    }, [])),
+     focusScope = React.useRef({
+       paused: !1,
+       pause() {
+diff --git a/node_modules/@tamagui/focus-scope/dist/jsx/FocusScope.js b/node_modules/@tamagui/focus-scope/dist/jsx/FocusScope.js
+index 0ceee7f..917e660 100644
+--- a/node_modules/@tamagui/focus-scope/dist/jsx/FocusScope.js
++++ b/node_modules/@tamagui/focus-scope/dist/jsx/FocusScope.js
+@@ -18,11 +18,11 @@ function useFocusScope(props, forwardedRef) {
+     forceUnmount,
+     children,
+     ...scopeProps
+-  } = props, [container, setContainer] = React.useState(null), onMountAutoFocus = useEvent(onMountAutoFocusProp), onUnmountAutoFocus = useEvent(onUnmountAutoFocusProp), lastFocusedElementRef = React.useRef(null), composedRefs = useComposedRefs(forwardedRef, (node) => {
++  } = props, [container, setContainer] = React.useState(null), onMountAutoFocus = useEvent(onMountAutoFocusProp), onUnmountAutoFocus = useEvent(onUnmountAutoFocusProp), lastFocusedElementRef = React.useRef(null), composedRefs = useComposedRefs(forwardedRef, React.useCallback((node) => {
+     React.startTransition(() => {
+       setContainer(node);
+     });
+-  }), focusScope = React.useRef({
++  }, [])), focusScope = React.useRef({
+     paused: !1,
+     pause() {
+       this.paused = !0;
+diff --git a/node_modules/@tamagui/focus-scope/dist/jsx/FocusScope.mjs b/node_modules/@tamagui/focus-scope/dist/jsx/FocusScope.mjs
+index 882a822..b8da710 100644
+--- a/node_modules/@tamagui/focus-scope/dist/jsx/FocusScope.mjs
++++ b/node_modules/@tamagui/focus-scope/dist/jsx/FocusScope.mjs
+@@ -29,11 +29,11 @@ function useFocusScope(props, forwardedRef) {
+     onMountAutoFocus = useEvent(onMountAutoFocusProp),
+     onUnmountAutoFocus = useEvent(onUnmountAutoFocusProp),
+     lastFocusedElementRef = React.useRef(null),
+-    composedRefs = useComposedRefs(forwardedRef, node => {
++    composedRefs = useComposedRefs(forwardedRef, React.useCallback(node => {
+       React.startTransition(() => {
+         setContainer(node);
+       });
+-    }),
++    }, [])),
+     focusScope = React.useRef({
+       paused: !1,
+       pause() {
+diff --git a/node_modules/@tamagui/focus-scope/src/FocusScope.tsx b/node_modules/@tamagui/focus-scope/src/FocusScope.tsx
+index 155a652..eceff05 100644
+--- a/node_modules/@tamagui/focus-scope/src/FocusScope.tsx
++++ b/node_modules/@tamagui/focus-scope/src/FocusScope.tsx
+@@ -50,11 +50,11 @@ export function useFocusScope(
+   const onMountAutoFocus = useEvent(onMountAutoFocusProp)
+   const onUnmountAutoFocus = useEvent(onUnmountAutoFocusProp)
+   const lastFocusedElementRef = React.useRef<HTMLElement | null>(null)
+-  const composedRefs = useComposedRefs(forwardedRef, (node) => {
++  const composedRefs = useComposedRefs(forwardedRef, React.useCallback((node) => {
+     React.startTransition(() => {
+       setContainer(node)
+     })
+-  })
++  }, []))
+ 
+   const focusScope = React.useRef({
+     paused: false,


### PR DESCRIPTION
## Summary

Fixes desktop renderer freezes caused by **two independent React render storms**, both surfacing as `Maximum update depth exceeded`. When either storm ignites, the renderer's main thread pins at 100% (V8 JS + GC), the heap balloons, and the window becomes unresponsive.

The two storms are unrelated in mechanism but produce the same symptom, so they are fixed together here.

---

## Storm A — `@tamagui/focus-scope` ref-detach loop

**Where:** `@tamagui/focus-scope` `useFocusScope` (FocusScope.* / compose-refs).

**Root cause:** the ref callback passed to `useComposedRefs` was an **inline arrow function**, so it had a new identity on every render. `compose-refs` treats an identity change as "the ref changed" and, during commit, detaches the old ref (`safelyDetachRef`) then attaches the new one. The detach path runs `setContainer(null)` inside a `startTransition`, which re-renders, which produces **another new inline callback**, which is again seen as a changed ref → detach → `setContainer(null)` → … a self-feeding render storm.

It ignites in practice when a FocusScope overlay (Tooltip / Dialog / Popover / Sheet) is **open while its subtree gets unmounted** (e.g. navigating away with the overlay still mounted).

**Fix:** wrap the ref callback in `React.useCallback(…, [])` so its identity is stable across renders. `compose-refs` no longer sees a phantom ref change, the detach/attach thrash stops, and the loop is eliminated. Applied via `patch-package` to all build outputs (cjs/esm/jsx) and `src`.

---

## Storm B — `PageHeader` → `navigation.setOptions` loop

**Where:** `packages/components/src/layouts/Page/PageHeader.tsx` → `@react-navigation/core` `useNavigationCache.setOptions`.

**Root cause:** `PageHeader` resolves header options with `reload(props)`, which returns a **brand-new object on every render**. That fresh object is used as a `useLayoutEffect` dependency that calls `navigation.setOptions(...)`:

```
reload(props) → new object every render
  → useLayoutEffect dep changes every render
  → navigation.setOptions(...)            // setState in @react-navigation
  → navigator re-renders → descriptor rebuilt
  → screen (PageHeader) re-renders
  → reload(props) → new object again → …  // Maximum update depth
```

Most pages have stable enough option content that React bails out after a render or two. On heavy, frequently re-rendering pages — **Earn** is the reproducible case (`EarnHome → EarnPageContainer → TabPageHeader → Page.Header`, re-rendering under jotai/refresh churn) — the loop crosses the threshold and runs away.

This is long-standing code, not a recent regression; it only tips over under sufficient re-render pressure.

**Fix:** keep a stable reference for the resolved options and only swap it when the content actually changes, so the layout-effect dependency stops churning. `reload()`'s output is a **flat** object whose values are reference-stable by convention (callers wrap header render functions in `useCallback`), so a cheap **shallow own-key comparison** is sufficient — no recursive deep-equal on this hot, every-page path. The effect now calls `setOptions` only when options genuinely change, breaking the self-sustaining loop.

`reload()`'s generic pass-through design is intentionally left untouched: it forwards arbitrary navigation options across ~240 `Page.Header` call sites, so explicitly enumerating fields would risk silently dropping options. The shallow compare is conservative — it can never skip a real change (it only reuses the old reference when every own key is `Object.is`-identical).

---

## Reproduction & verification

A CDP repro harness is included: `apps/desktop/scripts/cdp-repro-gift-storm.mjs`. It drives the running desktop app — opens the Earn gift overlay (a FocusScope overlay), tab-storms at human cadence while it is open, then lands on Home → opens Settings — and counts `Maximum update depth` / FocusScope console errors and freeze (RTT timeout) hits per round. The `header-gift-action` testID added to `GiftAction` lets the harness locate and open the gift overlay.

```bash
# prereq: yarn app:desktop (CDP on 9222), heavy wallet, DevTools closed
REGRESSION=1 ROUNDS=300 node apps/desktop/scripts/cdp-repro-gift-storm.mjs
# REGRESSION=1 → exits non-zero if any storm reproduces
```

Findings:
- Before the focus-scope patch: Storm A reproduced reliably (~13%/round).
- With the focus-scope patch alone: a 655-round soak fully suppressed Storm A; Storm B still leaked once (round 228) — a transient `Maximum update depth` burst on the Earn header, heap spiking ~1.7GB.
- With both fixes: the Earn `PageHeader` self-loop no longer occurs.

## Scope

- `patches/@tamagui+focus-scope+1.108.0.patch` (new) — Storm A fix
- `packages/components/src/layouts/Page/PageHeader.tsx` — Storm B fix
- `apps/desktop/scripts/cdp-repro-gift-storm.mjs` (new) — repro harness
- `packages/kit/src/components/TabPageHeader/components/GiftAction.tsx` — `header-gift-action` testID for the harness

No existing behavior removed. `tsc` and `eslint` pass on the changed source.