### PR TITLE
docs: add OneKey Perps module skill

### DIFF
--- a/.skillshare/skills/1k-perps-module/SKILL.md
+++ b/.skillshare/skills/1k-perps-module/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: 1k-perps-module
+description: Use only for explicit OneKey Perps/Hyperliquid (`views/Perp`, ServiceHyperLiquid, perpetuals, 永续/合约, Perps trading). Covers orderbook/L2/BBO, TWAP, scale/TIF/trigger/reduce-only, Perps TradingView/K-line, Perps Relay deposit, token selector, positions/account state/PnL/funding/margin/liquidation. Exclude generic Swap/Market/TradingView; Swap Relay quote/status/pending/requestId alone is not enough unless Perps deposit/Hyperliquid/`views/Perp`/`usePerpDeposit`/`fetchPerpDeposit*`/`perpsDepositOrderAtom` is explicit.
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# Perps / Hyperliquid Domain Guide
+
+Use this as a **Perps/Hyperliquid domain router** for order semantics, realtime subscriptions, and UI/background state races. Choose the owner and proof path; verify anchors with `rg` before editing.
+
+## 60-Second Triage
+
+1. **Gate**: use only when OneKey Perps/Hyperliquid is explicit in the prompt or file path.
+2. **Infer scope**: asset type (`perp`/`spot`), account/dex, order mode, and platform. Ask only if missing scope blocks correctness or creates trading risk.
+3. **Pick owner** from the matrix; avoid downstream display shims for trading/realtime contracts.
+4. **Load minimum refs**: one matching reference first; add [code-map.md](references/rules/code-map.md) / [validation-recipes.md](references/rules/validation-recipes.md) only for owner/proof/implementation.
+
+## Trigger Boundary
+
+| Prompt/file signal | Use this skill? | First move |
+| --- | --- | --- |
+| `views/Perp`, ServiceHyperLiquid, Hyperliquid, Perps/永续/合约 trading | Yes | Pick owner below, then one reference |
+| Generic Market K-line, generic TradingView bridge, generic token selector | No | Use adjacent Market/TradingView/token-selector skill or repo search |
+| Generic Swap Relay quote/status/pending/requestId | No | Use `$1k-trade-swap-market` unless Perps deposit is explicit |
+| Perps deposit, `usePerpDeposit`, `fetchPerpDeposit*`, `perpsDepositOrderAtom`, `perp-deposit` endpoint | Yes | Open [deposit-relay.md](references/rules/deposit-relay.md) |
+
+If Perps/Hyperliquid is only a guess, do **not** load all references; verify the file/surface with `rg` or use the adjacent skill.
+
+## Owner Matrix
+
+| Surface | Primary owner | Usual proof |
+| --- | --- | --- |
+| Order submit/cancel/TWAP/scale/TIF | `ServiceHyperliquidExchange.ts`, Hyperliquid `actions.ts`, shared Perps utils/types | SDK type/source check + targeted order utility/action tests |
+| L2/BBO/orderbook subscriptions | `ServiceHyperliquidSubscription.ts`, Hyperliquid context actions, freshness utils | rapid switch/reconnect + L2/BBO freshness proof |
+| Deposit quote/status | `packages/kit-bg/src/services/ServiceSwap.ts`, `perpsDepositOrderAtom` | active `fromTxId`; `requestId` only when backend/Relay exposes it |
+| Positions/account state/funding/margin/liquidation | `ServiceHyperliquid.ts`, Hyperliquid context atoms/actions, account-scoped Perps hooks/utils | account/dex/asset scoped proof; no stale positions/account summary |
+| Perps TradingView/K-line/chart lines | `packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx` | readiness/message/reconnect scenarios |
+| UI-only display | Perps component/list/row files | display proof only; do not mutate trading contracts here |
+
+## Quick Reference
+
+| Topic | Guide | Start With |
+| --- | --- | --- |
+| Code map | [code-map.md](references/rules/code-map.md) | `views/Perp`, Hyperliquid context, BG service, shared types/utils |
+| Order contracts | [order-contracts.md](references/rules/order-contracts.md) | TWAP, scale, TIF, trigger, reduce-only, precision |
+| State and subscriptions | [state-subscriptions.md](references/rules/state-subscriptions.md) | account/dex/asset scoping, L2/BBO, active target, cleanup |
+| Perps TradingView bridge | [tradingview-bridge.md](references/rules/tradingview-bridge.md) | `TradingViewPerpsV2`, Perps K-line readiness, chart lines |
+| Relay deposit | [deposit-relay.md](references/rules/deposit-relay.md) | Perps deposit address flow, requestId tracking, pending cards |
+| Positions/account state | [positions-account-state.md](references/rules/positions-account-state.md) | positions, balances, PnL/PNL/P&L, funding, margin, liquidation |
+| Failure patterns | [failure-patterns.md](references/rules/failure-patterns.md) | recurring bugs and hard-to-see regressions |
+| Validation recipes | [validation-recipes.md](references/rules/validation-recipes.md) | targeted tests and runtime paths |
+| Review checklist | [review-checklist.md](references/rules/review-checklist.md) | PR/source checks and release risk gates |
+| Source index | [source-index.md](references/rules/source-index.md) | volatile SDK/API/docs/vault lookup points |
+
+## Agent Routing Examples
+
+| User asks about | Load first | Then verify |
+| --- | --- | --- |
+| "TWAP cancel/list/history is wrong" | order contracts + code map | TWAP state/cancel/history recipes |
+| "Scale order children/precision/TIF" | order contracts | scale utility tests + partial-failure runtime path |
+| "Orderbook flashes old BTC after ETH switch" | state/subscriptions + code map | rapid asset/account switch; L2/BBO freshness |
+| "Perps K-line blank after offline/reconnect" | TradingView bridge | ready-state/reconnect scenarios, native if touched |
+| "Perps deposit pending/completed wrong" | Relay deposit | active tx/request scope and stale quote cases |
+| "Perps positions/PnL/funding/margin/liquidation/account summary stale" | positions/account state | account/dex/asset scope; no stale position/account display |
+| "Review a Perps PR" | changed-surface reference first; review checklist second | use failure patterns to challenge findings and validation gaps |
+
+## Output Defaults
+
+- Implementation: report surface, state owner, order/subscription contract touched, files changed, targeted validation, and runtime proof gaps.
+- Review: lead with findings; separate correctness blockers, release blockers, and follow-up improvements.
+- Research: distinguish stable module rules from volatile backend/API/business facts that must be rechecked.
+
+## Hard Stops
+
+- Do not log private keys, signatures, mnemonics, raw sensitive payloads, or user secrets while debugging Perps.
+- Do not bypass enable-trading, account bind, signing, or risk validation just to make a UI submit succeed.
+- Do not use production live order placement/cancel/withdraw/deposit as validation unless the user explicitly authorizes that exact action and account.
+- Do not change the owner of truth through a downstream display shim; edit the owner itself.
+- Do not use ticker/mid recovery as proof that orderbook, token selector, or TradingView recovered — verify each surface's own freshness/readiness.
+- Do not leave old L2/BBO/orderbook/chart-line data visible after an asset/account/dex switch.
+- Do not couple K-line WebView recovery to global WS recovery.
+- Do not trust Relay deposit status by deposit address alone when a request/requestId scope exists.
+
+## Verify Against the Source
+
+Order semantics, TIF, TWAP, scale, trigger, and reduce-only are **volatile, SDK-versioned contract facts** — confirm them against the source, do not trust memory:
+
+- SDK types (type-enforced, in repo): the action method files under `node_modules/@nktkas/hyperliquid/src/api/exchange/_methods/`.
+- Official docs: <https://hyperliquid.gitbook.io/hyperliquid-docs> (API → Exchange endpoint).
+- Recheck on every `@nktkas/hyperliquid` bump; new fields/TIF values (e.g. `FrontendMarket`) appear over time.
+
+## Related Skills
+
+- `$1k-tradingview-communication` - TradingView message contracts and iframe bridge.
+- `$1k-state-management` - Jotai atom/context conventions.
+- `$1k-performance` - Render, subscription, and hot-path performance.
+- `$1k-trade-swap-market` - Adjacent trade/review/history patterns; do not copy swap provider semantics blindly.
+- `$1k-cross-platform` - Platform-specific RN/Web/Desktop behavior.
+- `$1k-analytics` - Perps analytics/logging changes.

--- a/.skillshare/skills/1k-perps-module/agents/openai.yaml
+++ b/.skillshare/skills/1k-perps-module/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "OneKey Perps / Hyperliquid"
+  short_description: "Perps routing, contracts, state, validation"
+  default_prompt: "Use $1k-perps-module to route OneKey Perps/Hyperliquid work such as TWAP, scale orders, orderbook, K-line, Relay deposit, positions/account state, or Perps subscriptions."

--- a/.skillshare/skills/1k-perps-module/references/rules/code-map.md
+++ b/.skillshare/skills/1k-perps-module/references/rules/code-map.md
@@ -1,0 +1,54 @@
+# Perps Code Map
+
+Use this map as starting anchors, then confirm current paths/usages with `rg` before editing. Open only the files that own the requested behavior.
+
+## UI entry and layouts
+
+- Pages/layouts: `packages/kit/src/views/Perp/pages/Perp.tsx`, `packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx`, `packages/kit/src/views/Perp/pages/ExtPerp.tsx`, `packages/kit/src/views/Perp/layouts/`.
+- Routing/providers: `packages/kit/src/views/Perp/router/index.ts`, `packages/kit/src/views/Perp/PerpsProvider.tsx`, `PerpsProviderMirror.tsx`, `PerpsAccountSelectorProviderMirror.tsx`.
+
+## Trading and order UI
+
+- Form/submit: `packages/kit/src/views/Perp/components/TradingPanel/PerpTradingPanel.tsx`, `packages/kit/src/views/Perp/components/TradingPanel/PerpTradingButton.tsx`.
+- Confirm/price: `packages/kit/src/views/Perp/hooks/useOrderConfirm.ts`, `packages/kit/src/views/Perp/hooks/useOrderPrice.ts`, `packages/kit/src/views/Perp/hooks/useTradingPrice.ts`.
+- Guards: `packages/kit/src/views/Perp/utils/timeInForce.ts`, `packages/kit/src/views/Perp/utils/minimumOrderGuard.ts`, `packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.ts`.
+
+## Positions, orders, and activity
+
+- Panel/modals: `packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx`, `CancelAllOrdersModal.tsx`, `CloseAllPositionsModal.tsx`, `ClosePositionModal.tsx`, `SetTpslModal.tsx`.
+- Lists/rows: `packages/kit/src/views/Perp/components/OrderInfoPanel/List/` and `Components/`; TWAP rows live in `PerpTwapList.tsx`, trade history in `PerpTradesHistoryList.tsx`.
+- Helpers/state: `packages/kit/src/views/Perp/components/OrderInfoPanel/utils.ts`, `packages/kit/src/views/Perp/hooks/usePerpsAccountScopedActivePositions.ts`, `packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts`.
+
+## Orderbook, ticker, token selector
+
+- Orderbook: `packages/kit/src/views/Perp/components/PerpOrderBook.tsx`, `packages/kit/src/views/Perp/components/OrderBook/index.tsx`, `useAggregatedBook.tsx`, `useTickOptions.ts`, `tickSizeUtils.ts`.
+- Ticker/selector: `packages/kit/src/views/Perp/components/TickerBar/`, `packages/kit/src/views/Perp/components/TokenSelector/`, `packages/kit/src/views/Perp/hooks/usePerpTokenSelector.ts`, `packages/kit/src/views/Perp/hooks/usePerpMarketData.ts`.
+- Freshness guards: `packages/kit/src/views/Perp/utils/l2BookFreshness.ts`, `perpsMarketDataFreshness.ts`.
+
+## TradingView and K-line
+
+- Chart surface: `packages/kit/src/views/Perp/components/PerpCandles.tsx`.
+- Bridge: `packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx`; owns `SYMBOL_CHANGE` and chart-line postMessage.
+- Message constants: `packages/kit/src/components/TradingView/TradingViewPerpsV2/constants/messageTypes.ts`.
+- Display/signing helpers: `packages/shared/src/utils/perpsUtils.ts`; EIP712 webview types are in `packages/shared/types/hyperliquid/webview.ts` and are **not** TradingView messages.
+
+## State and actions
+
+- Context: `packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts`, `packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts`, `packages/kit/src/states/jotai/contexts/hyperliquid/utils/`.
+- Persisted/background atoms: `packages/kit-bg/src/states/jotai/atoms/perps.ts`.
+
+## Background services
+
+- Deposit quote/status: `packages/kit-bg/src/services/ServiceSwap.ts` (`fetchPerpDepositQuote`, `fetchPerpDepositOrderStatus`, `perpDepositOrderFetchLoop`).
+- Account/info/cache: `packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts`, `ServiceHyperliquidCache.ts`, `hyperLiquidApiClients.ts`.
+- Orders: `packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts`.
+- Subscriptions: `packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts`, `packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionMutationQueue.ts`, `SubscriptionConfig.ts`.
+
+## Shared contracts and utilities
+
+- Types/constants: `packages/shared/types/hyperliquid/sdk.ts`, `packages/shared/types/hyperliquid/types.ts`, `packages/shared/types/hyperliquid/perp.constants.ts`.
+- Utilities: `packages/shared/src/utils/perpsUtils.ts`, `packages/shared/src/utils/hyperliquidScaleOrderUtils.ts`.
+
+## Source-of-truth rule
+
+Display files should not become the source of trading behavior. Trading behavior belongs in shared types/utils, `actions.ts`, `ServiceSwap.ts`, or `ServiceHyperliquidExchange.ts`; realtime behavior belongs in `ServiceHyperliquidSubscription.ts`, context atoms/actions, or L2/BBO helpers.

--- a/.skillshare/skills/1k-perps-module/references/rules/deposit-relay.md
+++ b/.skillshare/skills/1k-perps-module/references/rules/deposit-relay.md
@@ -1,0 +1,46 @@
+# Relay Deposit for Perps
+
+Open this for Perps deposit, Hyperliquid enable-trading fallback, Relay quote/deposit-address flow, pending cards, or deposit status bugs.
+
+## Code anchors
+
+- `packages/kit/src/views/Perp/hooks/usePerpDeposit.ts` - deposit flow/state.
+- `packages/kit/src/views/Perp/hooks/usePerpDeposit.ts` (`usePerpDepositOrder`) - pending deposit filtering and polling kickoff.
+- `packages/kit/src/views/Perp/hooks/useEnableTradingWithDepositFallback.ts` - enable-trading + deposit fallback orchestration.
+- `packages/kit/src/views/Perp/hooks/useShowDepositWithdrawModal.ts` - modal entry/visibility.
+- `packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx` - deposit/withdraw UI surface.
+- `packages/kit-bg/src/services/ServiceSwap.ts` - Perps deposit quote/status owner on BG (`fetchPerpDepositQuote`, `fetchPerpDepositOrderStatus`, `perpDepositOrderFetchLoop`).
+- `packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts` - Perps account/session and server deposit-token config parsing; not the quote/status owner.
+- `packages/kit-bg/src/states/jotai/atoms/perps.ts` - `perpsDepositOrderAtom` pending deposit storage.
+
+## Stable contract
+
+- Do not client-index all chains to discover Perps deposits.
+- Use Relay-supported quote/status paths for the current deposit flow.
+- Current app-side owner asks the swap backend for `/swap/v1/perp-deposit-quote`; recheck backend/Relay request fields before changing quote shape.
+- If a deposit-address Relay response is used, trust deposit addresses only from explicit deposit-address fields such as `step.depositAddress` or `item.data.depositAddress`.
+- Do not fallback to generic `item.data.to` as a deposit address.
+- Current persisted pending status is tx-scoped by `fromTxId`. Treat backend/Relay `requestId` as a stronger scope only when the current API response exposes it.
+- If the same deposit address gets a new explicit request scope, do not reuse old completed/refund/failure state.
+
+## UX boundaries
+
+- Closing a deposit modal must not make a pending deposit disappear if the user still needs tracking.
+- Pending tracking cards should survive modal close where product expects continued visibility.
+- Copy-address UX must be tied to the currently selected quote/request, not a stale quote.
+- Amount/source-chain changes invalidate quote-dependent address/status assumptions.
+
+## Risk gates
+
+- Non-EVM origin chains need explicit refund UX before enabling if origin-native refund is not handled.
+- Relay error strings are not a stable protocol guarantee; do not encode business logic only from text matching.
+- Recheck current backend/API expectations before changing quote fields, `requestId`, refund, or failure-state handling.
+
+## Validation focus
+
+- Change amount after quote: no stale deposit address/request reused.
+- Copy address after quote refresh: copied address matches visible active request.
+- Close modal with pending deposit: pending card remains if required.
+- Same deposit address with a new explicit request scope if available: old terminal status does not override new request.
+- Pending tx polling: status update matches the active `fromTxId` and account/indexedAccount scope.
+- Refund/failure/completed paths: visible status matches active request.

--- a/.skillshare/skills/1k-perps-module/references/rules/failure-patterns.md
+++ b/.skillshare/skills/1k-perps-module/references/rules/failure-patterns.md
@@ -1,0 +1,57 @@
+# Perps Failure Patterns
+
+Use this as a checklist for debugging and PR review.
+
+## Order semantics
+
+- Treating TWAP as a normal open order: wrong list, wrong cancel, wrong lifecycle.
+- Adding TIF controls to unsupported modes: market/trigger/TWAP bugs.
+- Treating scale as a native group: wrong history/status expectations.
+- Validating only total scale amount: child leg can fail min notional or precision.
+- Ignoring partial child-order failure: UI reports success while some legs failed.
+- Reusing stale positions for reduce-only validation after account/symbol switch.
+
+## State races
+
+- UI active asset changes before BG subscription target; old L2/BBO arrives into new UI.
+- Stale subscription create overwrites a newer active subscription map.
+- Account switch clears positions but not TWAP/orders/balances for the old account.
+- A selector/ticker surface updates quickly while orderbook/chart remains stale.
+- Cached L2 displays without proving target/freshness.
+
+## Performance
+
+- L2 tick writes a broad atom consumed by page-level components.
+- Orderbook rows format strings/BN values on every render.
+- Token selector re-sorts/re-filters every tick instead of using stable derived data.
+- Adding logs or debug state to hot websocket paths causes visible latency.
+- Fixing a performance issue with only `memo` while atom write granularity remains broad.
+
+## TradingView/K-line
+
+- Assuming `chartReady` means Perps iframe is ready.
+- Reloading already-ready chart on every reconnect.
+- Not remounting native WebView after initial offline failure when reload is insufficient.
+- Keeping old chart lines after symbol/account switch.
+- Treating ticker/orderbook recovery as proof K-line recovered.
+
+## Relay deposit
+
+- Matching terminal status by depositAddress only.
+- Reusing old request status for a new quote/request.
+- Falling back to generic `to` field as deposit address.
+- Hiding pending tracking when modal closes.
+- Enabling origin chains without refund UX.
+
+## Cross-platform
+
+- Fixing a `.web.tsx` path while native mobile uses a different file.
+- Assuming desktop web layout behavior applies to extension surface.
+- Changing WebView recovery without verifying native iOS/Android behavior.
+- Using platform-generic styles for a Perps layout bug that is platform-specific.
+
+## Security/logging
+
+- Logging signed payloads, private account identifiers beyond allowed diagnostic scope, or raw API payloads containing sensitive data.
+- Adding debug logs in order payload/signing paths without redaction.
+- Bypassing enable-trading, account bind, or risk validation to make UI submit succeed.

--- a/.skillshare/skills/1k-perps-module/references/rules/order-contracts.md
+++ b/.skillshare/skills/1k-perps-module/references/rules/order-contracts.md
@@ -1,0 +1,86 @@
+# Perps Order Contracts
+
+Open this before changing order submission, cancel, validation, display, history, or order-mode UI.
+
+## Source of truth (verify, do not trust memory)
+
+These contracts are **SDK-typed and volatile**. Confirm against source before relying on a field/value:
+
+- SDK action types (type-enforced, in repo): `node_modules/@nktkas/hyperliquid/src/api/exchange/_methods/` — `order.ts`, `twapOrder.ts`, `twapCancel.ts`, `modify.ts`, `batchModify.ts`, `cancel.ts`.
+- OneKey re-exports: `packages/shared/types/hyperliquid/sdk.ts` (`import * as HL from '@nktkas/hyperliquid'`).
+- Official exchange docs: <https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint>.
+- Recheck on every SDK bump; let the SDK type be the arbiter.
+
+## Shared invariants
+
+- Asset type matters: `perp` and `spot` can share UI but not every order contract.
+- Keep price/size precision in shared utilities and service validation; do not reimplement formatting in a component.
+- Validate reduce-only against current position side/size before submit.
+- Treat mixed child-order outcomes as possible for batched orders; inspect returned statuses and thrown SDK/service errors instead of assuming all-or-nothing.
+- Do not assume missing fee/rate/slippage fields mean zero.
+
+## TIF
+
+- `tif` exists only on the `limit` order variant; `trigger` and `twapOrder` have no `tif`.
+- Read `order.ts` / `modify.ts` / `batchModify.ts` `t.limit.tif` for the raw SDK list; OneKey user-facing TIF is narrower and must not expose internal market TIF such as `FrontendMarket`.
+- Scale child limit orders carry TIF; spot scale currently uses `Gtc`, perp may use normalized user limit TIF.
+
+Key anchors:
+- `node_modules/@nktkas/hyperliquid/src/api/exchange/_methods/order.ts`, `modify.ts`, `batchModify.ts` (`t.limit.tif` picklist — raw SDK source of truth).
+- `packages/shared/types/hyperliquid/sdk.ts` (`ITIF`).
+- `packages/kit/src/views/Perp/utils/timeInForce.ts`.
+- `packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidExchange.ts` (`normalizeUserLimitTif`, order placement methods).
+
+## TWAP
+
+- TWAP is Hyperliquid native `twapOrder` / `twapCancel`.
+- TWAP is not a limit order: no price, no tif; read `twapOrder.ts` for exact fields/duration.
+- It is not a normal open order and must not use ordinary oid cancel.
+- Active TWAP state comes from `twapStates` / `webData2.twapStates`.
+- History/details come from `userTwapHistory` and `userTwapSliceFills`.
+- Cancel by `{ a: assetId, t: twapId }`.
+- Do not show limit price, TP/SL, or TIF controls for TWAP unless product/API contracts change.
+- TWAP can underfill; slice fills must be labeled so users do not confuse them with one manual order.
+- Recheck builder-fee behavior before promising it.
+
+Key anchors:
+- `node_modules/@nktkas/hyperliquid/src/api/exchange/_methods/twapOrder.ts`, `twapCancel.ts` (SDK payload source of truth).
+- `ServiceHyperliquidExchange.ts` (`twapOrder`, `twapCancel`).
+- `contexts/hyperliquid/actions.ts` (`twapStates`, TWAP maps, cancel filtering).
+- `packages/shared/types/hyperliquid/types.ts` (`TWAP_STATES`, `USER_TWAP_HISTORY`, `USER_TWAP_SLICE_FILLS`).
+
+## Scale orders
+
+- Scale is not a native Hyperliquid order group — the SDK has no scale action/primitive (check the `_methods/` directory if unsure). It is built client-side.
+- OneKey builds multiple child limit orders locally and submits them through ordinary batch `order`.
+- Validate every child leg: price, size, precision, min notional, and reduce-only constraints.
+- Mixed child statuses or thrown child errors are possible; UI/toast must not collapse every scale submission into one guaranteed-success result.
+- Do not fake a native group or rely on group metadata surviving across devices.
+- Handle rounding remainder intentionally, usually on the last leg; map product distributions through shared scale utilities.
+
+Key anchors:
+- `packages/shared/src/utils/hyperliquidScaleOrderUtils.ts` (`buildScaleOrderLegs`, `validateScaleOrderLegs`, `assertValidScaleOrderLegs`).
+- `ServiceHyperliquidExchange.ts` (`placeScaleOrder`).
+- `contexts/hyperliquid/actions.ts` (`placeScaleOrder`, order mode routing).
+- `packages/shared/types/hyperliquid/types.ts` (`IPlaceScaleOrderParams`, scale types).
+
+## Trigger / TP-SL
+
+- Trigger and TP/SL share some visual concepts with limit orders but not all execution semantics.
+- Trigger has no tif field. TP/SL is driven by `order` action `grouping`; read `order.ts` for exact trigger fields/grouping.
+- Trigger state/list display must be checked separately from open-order display.
+- Position TP/SL modal changes must validate selected position, side, asset, and account scope.
+
+## Reduce-only
+
+- Reduce-only order side must oppose an existing position.
+- Reduce-only size must not exceed the current position unless the current contract handles it safely.
+- For scale reduce-only, validate aggregate and per-leg implications before submit.
+- Do not allow stale position state to pass reduce-only validation after account/asset switch.
+
+## Precision and display
+
+- Use `perpsUtils.ts` and scale utilities for precision/formatting.
+- Price scale for TradingView display is not necessarily the same as order payload precision.
+- Avoid `Number` conversions in hot trading paths if string/BN precision is already preserved upstream.
+- Do not use `JSON.stringify()` for cryptographic/hash/signature paths; use stable serialization where required by repo rules.

--- a/.skillshare/skills/1k-perps-module/references/rules/positions-account-state.md
+++ b/.skillshare/skills/1k-perps-module/references/rules/positions-account-state.md
@@ -1,0 +1,27 @@
+# Perps Positions and Account State
+
+Open for Perps/Hyperliquid positions, account summary, balances, PnL/P&L, funding, margin, liquidation, withdrawable/account value, or stale account-scoped state. Do **not** use for generic wallet portfolio, token balances, or non-Perps topics.
+
+## Starting anchors
+
+- Account summary: `packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts`, `packages/kit-bg/src/states/jotai/atoms/perps.ts` (`perpsActiveAccountSummaryAtom`).
+- Hyperliquid context state/actions: `packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts`, `actions.ts`, `utils/`.
+- Account-scoped helpers: `packages/kit/src/views/Perp/utils/accountScopedData.ts`, `packages/kit/src/views/Perp/hooks/usePerpsAccountScopedCacheAddress.ts`, `usePerpsAccountScopedActivePositions.ts`, `usePerpsActivePositionsByAddress.ts`.
+- Positions/orders panel: `packages/kit/src/views/Perp/components/OrderInfoPanel/PerpOrderInfoPanel.tsx`, `List/`, `Components/`, `ClosePositionModal.tsx`, `SetTpslModal.tsx`.
+- Funding/liquidation display helpers: `packages/kit/src/views/Perp/hooks/useFundingCountdown.ts`, `useLiquidationPrice.ts`, `packages/kit/src/views/Perp/utils/leverageDisplay.ts`.
+- Source/API: `packages/shared/types/hyperliquid/sdk.ts`, `packages/shared/types/hyperliquid/types.ts`, [source-index.md](source-index.md).
+
+## Owner rules
+
+- Treat accountId/indexed account, account address, dex, asset/coin, and asset type as query/cache/state key dimensions.
+- Account/position truth belongs in Hyperliquid account/webData/service/context owners; list rows and modals may format or filter but must not invent truth.
+- During account/asset/dex switches, hide/empty or clear stale positions, balances, PnL, margin, funding, liquidation, open orders, and TP/SL references until scoped data is valid.
+- Reduce-only, close-position, and TP/SL flows must validate against the currently selected scoped position, not a cached row from a previous account/symbol.
+- Funding, margin, and liquidation fields are API/product-versioned; recheck source/business contract before hardcoding.
+
+## Validation focus
+
+- Account switch replay: A has positions -> switch to B -> address mismatch hides A positions, PnL, summary, margin, and liquidation until B data is valid.
+- Asset/dex switch: selected position and TP/SL/close modal still match the visible instrument.
+- Funding/liquidation display: existing tests first (`useLiquidationPrice.test.ts`, `leverageDisplay.test.ts`), then missing/undefined API-field scenarios.
+- Account-scoped helpers: run or extend `packages/kit/src/views/Perp/utils/accountScopedData.test.ts` and `usePerpsActivePositionsByAddress.test.ts` when changing scoping behavior.

--- a/.skillshare/skills/1k-perps-module/references/rules/review-checklist.md
+++ b/.skillshare/skills/1k-perps-module/references/rules/review-checklist.md
@@ -1,0 +1,53 @@
+# Perps Review Checklist
+
+Use this for PR review, risk assessment, and pre-release checks.
+
+## Intake
+
+- Identify issue source: Jira/Slack/Figma/attachment/PR description/user report.
+- Confirm platform: desktop, web, extension, iOS, Android, or all.
+- Confirm surface: trade panel, orderbook, chart, positions/orders, deposit, session/account, token selector, or BG service.
+- Confirm asset type and account/dex scope.
+
+## Correctness
+
+- Does the change modify the owner of truth rather than a display symptom?
+- Are order contracts respected for market/limit/trigger/scale/TWAP?
+- Are scale child legs individually valid?
+- Is TWAP state/cancel/history handled through TWAP-specific paths?
+- Are account/dex/asset switches clearing stale data safely?
+- Are subscription create/destroy races handled?
+- Are chart readiness and iframe readiness distinguished?
+- Is Relay/deposit status scoped by the active tx/request (`fromTxId` now, `requestId` when available) instead of deposit address alone?
+
+## Performance
+
+- Does any websocket tick write a broad atom?
+- Does any large component subscribe to high-frequency data it does not need?
+- Are orderbook/token selector transforms memoized at the right level?
+- Did debug logging enter a hot path?
+- Did the change add cross-platform render cost unintentionally?
+
+## Security and safety
+
+- No secrets, signatures, private keys, mnemonics, or raw sensitive payloads in logs.
+- No bypass of enable-trading, account bind, signing, or risk checks.
+- No unsafe fallback to ambiguous Relay fields.
+- No transaction/order payload mutation outside existing validation paths.
+
+## Tests and runtime proof
+
+- Targeted unit tests added/updated for changed pure logic.
+- Existing relevant tests run.
+- Runtime path verified for user-visible behavior.
+- If runtime validation is impossible, note exact blocker and next-best evidence.
+
+## Release risk gates
+
+Escalate before approval if:
+
+- Order submit/cancel payload changed without runtime/API proof.
+- Subscription lifecycle changed without rapid-switch/reconnect validation.
+- K-line recovery changed without native WebView consideration.
+- Relay deposit status changed without requestId/stale quote cases.
+- A volatile business/API assumption is encoded as permanent behavior.

--- a/.skillshare/skills/1k-perps-module/references/rules/source-index.md
+++ b/.skillshare/skills/1k-perps-module/references/rules/source-index.md
@@ -1,0 +1,30 @@
+# Perps Source Index
+
+Open when a fact may be stale, SDK/API-versioned, or external to stable rules.
+
+## SDK and official docs
+
+- SDK version: `node -e "console.log(require('./node_modules/@nktkas/hyperliquid/package.json').version)"`
+- SDK action source: `node_modules/@nktkas/hyperliquid/src/api/exchange/_methods/`
+- OneKey SDK re-export: `packages/shared/types/hyperliquid/sdk.ts`
+- Official exchange docs: <https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint>
+
+## SDK bump checklist
+
+Raw SDK source/version -> OneKey narrowed types -> service adapters -> targeted utility/action tests before broad runtime claims.
+
+## Repo verification
+
+- Perps app surface: `packages/kit/src/views/Perp/`
+- Hyperliquid context: `packages/kit/src/states/jotai/contexts/hyperliquid/`
+- Hyperliquid services: `packages/kit-bg/src/services/ServiceHyperLiquid/`
+- Perps deposit quote/status owner: `packages/kit-bg/src/services/ServiceSwap.ts`
+- Shared Perps utilities/types: `packages/shared/src/utils/perpsUtils.ts`, `packages/shared/types/hyperliquid/`
+
+## Vault decisions
+
+- `Resources/tech/onekey-perps-skill-stable-content-strategy-2026-06-03.md`
+- `Resources/tech/onekey-perps-skill-cross-tool-best-practices-2026-06-03.md`
+- `Resources/tech/onekey-perps-skill-review-2026-06-06.md`
+
+Do not copy volatile Jira/PR/branch state into this skill. Recheck those at task time.

--- a/.skillshare/skills/1k-perps-module/references/rules/state-subscriptions.md
+++ b/.skillshare/skills/1k-perps-module/references/rules/state-subscriptions.md
@@ -1,0 +1,75 @@
+# Perps State and Subscriptions
+
+Open this for account switching, active token changes, L2/BBO/orderbook issues, stale data, performance, or background subscription bugs.
+
+## State owner model
+
+Common owners:
+
+- Background service: SDK/API calls, subscriptions, account binding, cache, signing/session.
+- Hyperliquid context actions: UI-triggered actions, atom writes, submit/cancel orchestration.
+- Context atoms: current UI/runtime market/account/orderbook state.
+- Persisted perps atom/simpleDb: durable preferences and settings.
+- Component state: temporary interaction only.
+- TradingView iframe: chart-ready and chart-line internals.
+
+Do not fix owner bugs with downstream display patches.
+
+## Account/dex/asset scoping
+
+- Scope Perps data by account, dex, and asset type where relevant.
+- On account switch, clear or merge only the data that is valid for the next account.
+- Do not show previous account positions, open orders, TWAP, or balances during transition.
+- Token selector, orderbook, ticker, and chart may transition at different speeds; the slowest surface should not inherit old data.
+
+Key anchors:
+- `contexts/hyperliquid/utils/accountSwitchCleanup.ts`.
+- `views/Perp/utils/accountScopedData.ts`.
+- `contexts/hyperliquid/actions.ts` cleanup and merge paths.
+
+## Subscription target rule
+
+- Background active subscription target is the source of truth for websocket data.
+- On symbol switch, push the new BG target before slow UI cleanup when stale subscription races are possible.
+- Create/destroy subscription mutations must be serialized by key; stale create must not overwrite active maps.
+- Treat UI/BG target mismatch as a correctness bug, not just a latency bug.
+
+Key anchors:
+- `ServiceHyperliquidSubscription.ts`.
+- `utils/SubscriptionMutationQueue.ts`.
+- `utils/SubscriptionConfig.ts` and tests.
+- `views/Perp/utils/subscriptionPlanner.ts`.
+
+## L2/BBO/orderbook
+
+- Clear old L2/BBO on asset/dex/account switch if the new target has not produced fresh data.
+- Ticker recovery does not prove L2/BBO/orderbook recovery.
+- BBO freshness and L2 freshness are separate checks.
+- Cached L2 can improve cold start, but it must not display as fresh for the wrong target.
+- Aggregation, tick options, and row rendering are hot-path code; prefer memoized derived data and narrow atom reads.
+
+Key anchors:
+- `contexts/hyperliquid/actions.ts` L2/BBO handlers.
+- `contexts/hyperliquid/utils/l2BookUtils.ts`.
+- `views/Perp/utils/l2BookFreshness.ts`.
+- `components/OrderBook/useAggregatedBook.tsx`.
+- `ServiceHyperliquidCache.ts` L2 snapshot cache.
+
+## Performance rule
+
+Repeated Perps performance regressions usually come from broad atom writes and broad consumers, not from a missing `memo` in one row.
+
+Check before optimizing:
+
+1. Which atom is written on every tick?
+2. How many components subscribe to that atom?
+3. Is derived formatting computed per row/per render?
+4. Does the component need all fields or one selected slice?
+5. Are native and web doing the same amount of JS work?
+
+Use `/1k-performance` when the change touches render hot paths, websocket tick volume, list virtualization, or expensive derived data.
+
+## Persistence boundaries
+
+Persist preferences such as display settings, favorite/tick options, or panel visibility only through existing atom/simpleDb paths.
+Do not persist transient websocket data, active orderbook snapshots, or pending UI-only state unless there is an explicit recovery requirement.

--- a/.skillshare/skills/1k-perps-module/references/rules/tradingview-bridge.md
+++ b/.skillshare/skills/1k-perps-module/references/rules/tradingview-bridge.md
@@ -1,0 +1,48 @@
+# TradingView and K-line Bridge
+
+Open this for Perps chart, K-line, TradingView iframe, chart lines, offline recovery, or symbol switching.
+
+## Code anchors
+
+- `packages/kit/src/views/Perp/components/PerpCandles.tsx` - Perps chart surface.
+- `packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx` - Perps TradingView bridge; `SYMBOL_CHANGE` and chart-line messages live here.
+- `packages/kit/src/components/TradingView/TradingViewPerpsV2/constants/messageTypes.ts` - message type constants (`tradingview_perpsReady`, `tradingview_chartReady`).
+- `packages/shared/src/utils/perpsUtils.ts` - price scale and display helpers.
+- Use `/1k-tradingview-communication` for shared TradingView message contracts.
+
+## Readiness states
+
+- `chartReady` is not enough for Perps iframe readiness.
+- `tradingview_perpsReady` / chart-lines readiness represent deeper iframe readiness.
+- Already-ready chart should recover without unnecessary reload.
+- Not-ready chart after network recovery may need local reload/remount.
+- Native WebView initial offline failure can need key remount; plain `reload()` may not recover.
+
+## Symbol switching
+
+- Symbol-only changes should go through `SYMBOL_CHANGE` when the bridge supports it.
+- Do not rebuild the whole chart for every symbol change if a bridge message is sufficient.
+- Asset switch must align chart symbol, orderbook target, ticker data, and active order form asset.
+- Old chart lines for the previous symbol must not survive into the next symbol.
+
+## Chart lines
+
+- Position/order/TWAP/trigger lines must be scoped by account, dex, symbol, and order type.
+- Drag-to-modify must use the owning order contract; do not reuse normal limit modify behavior for TWAP.
+- Line recovery should wait for chart-lines readiness, not just WebView load.
+- Missing chart lines after reload are not fixed by ticker/orderbook recovery; inspect bridge messages.
+
+## Offline and recovery
+
+- K-line recovery must not be coupled to global Hyperliquid websocket recovery.
+- Global WS recovery can restore ticker/orderbook while the iframe remains dead.
+- Recovery path should distinguish initial offline load, reconnect after ready, and reconnect before ready.
+- Avoid reload loops: guard by readiness, network state, and last attempted recovery.
+
+## Validation focus
+
+- Symbol switch: BTC -> ETH -> BTC; no stale lines, no old candle data, order form matches symbol.
+- Offline before chart ready: reconnect should recover K-line.
+- Offline after chart ready: reconnect should not force destructive reload unless needed.
+- Native WebView: verify reload/remount behavior on iOS/Android if changed.
+- Drag/edit lines: verify payload and visible result for limit/trigger/position line types separately.

--- a/.skillshare/skills/1k-perps-module/references/rules/validation-recipes.md
+++ b/.skillshare/skills/1k-perps-module/references/rules/validation-recipes.md
@@ -1,0 +1,94 @@
+# Perps Validation Recipes
+
+Prefer the smallest validation that proves the changed owner. Add runtime proof for user-visible trading behavior.
+
+## Targeted tests to look for first
+
+- `packages/kit/src/views/Perp/utils/timeInForce.test.ts`
+- `packages/kit/src/views/Perp/utils/minimumOrderGuard.test.ts`
+- `packages/kit/src/views/Perp/utils/subscriptionPlanner.test.ts`
+- `packages/kit/src/views/Perp/utils/l2BookFreshness.test.ts`
+- `packages/kit/src/views/Perp/utils/perpsMarketDataFreshness.test.ts`
+- `packages/kit/src/views/Perp/utils/accountScopedData.test.ts`
+- `packages/kit/src/views/Perp/components/PerpsGlobalEffects.utils.test.ts`
+- `packages/kit/src/views/Perp/components/OrderBook/tickSizeUtils.test.ts`
+- `packages/kit/src/states/jotai/contexts/hyperliquid/utils/l2BookUtils.test.ts`
+- `packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.test.ts`
+- `packages/kit-bg/src/services/ServiceHyperLiquid/userAbstractionCache.test.ts`
+- `packages/shared/src/utils/hyperliquidScaleOrderUtils.test.ts`
+- `packages/kit/src/views/Perp/utils/scaleOrderValidation.test.ts`
+
+## Command pattern
+
+Use repo-standard targeted commands where possible, then staged checks before commit:
+
+```bash
+yarn jest <changed-test-file>
+yarn tsc:staged
+yarn lint:staged
+```
+
+If touching broad Perps/shared/kit-bg code, consider the relevant package typecheck/test command from `/1k-dev-commands`.
+
+## Runtime scenarios
+
+### Scale
+
+- 2, 20, and high-count legs.
+- Fixed and increasing distributions.
+- Long and short price ordering.
+- Per-leg min notional and precision failure.
+- Partial child-order failure display/toast.
+- Spot vs perp TIF behavior.
+- Reduce-only with opposite position, no position, and oversize.
+
+### TWAP
+
+- Duration lower/upper bounds currently supported by product/API.
+- Randomize on/off.
+- Reduce-only protection.
+- Active TWAP appears from TWAP state, not ordinary open orders.
+- Cancel by twapId.
+- Slice fills/history labeling.
+
+### TIF and ordinary orders
+
+- Limit `Gtc`, `Ioc`, `Alo` availability.
+- Market submit does not expose user TIF.
+- Trigger/TP-SL flow unaffected by limit TIF changes.
+- Existing limit modify/cancel still works.
+
+### Orderbook/subscriptions
+
+- Perp -> Perp rapid switch.
+- Spot -> Spot rapid switch if spot Perps surface is enabled.
+- Spot -> Perp and Perp -> Spot switch.
+- Account switch while L2 updates are arriving.
+- Disconnect/reconnect and app foreground/background.
+- No old L2/BBO flash after switch.
+
+### TradingView/K-line
+
+- Initial offline load then reconnect.
+- Reconnect before iframe ready.
+- Reconnect after iframe ready.
+- Symbol switch with chart lines visible.
+- Drag/edit chart lines for supported order types.
+- Native iOS/Android WebView if recovery code changes.
+
+### Relay deposit
+
+- Amount/source-chain change after quote.
+- Copy address after quote refresh.
+- Close modal with pending deposit.
+- Same depositAddress with a new requestId.
+- Completed/refund/failure terminal states.
+
+## Evidence standard
+
+When reporting completion, include:
+
+- The owner validated: shared utility, action, background service, subscription, chart bridge, or visible UI.
+- The exact command/test run.
+- Runtime path verified or why it could not be verified.
+- Remaining volatile facts that were rechecked or still need product/backend confirmation.


### PR DESCRIPTION
## Summary
- Add the `1k-perps-module` skill as a OneKey Perps/Hyperliquid domain router for Claude and Codex/OpenAI agents.
- Provide focused references for order contracts, subscriptions, deposit relay, TradingView Perps, positions/account state, source checks, and validation recipes.
- Add explicit trigger boundaries to avoid stealing generic Swap Relay, Market K-line, generic TradingView, or token selector tasks.

## Intent & Context
This PR adds a shared agent skill for OneKey Perps work so teammates and AI agents can consistently route Perps/Hyperliquid issues to the right owner and proof path.

The work was driven by repeated review/debug needs around Perps order semantics, realtime state races, Relay deposit status, TradingView Perps behavior, SDK-versioned Hyperliquid contracts, and account-scoped positions state. The skill is intentionally a domain router rather than a single-module document: it starts with trigger boundaries, then points agents to one focused reference at a time.

## Design Decisions
- Keep the skill name as `1k-perps-module` to match existing module-style skills while using the UI display name `OneKey Perps / Hyperliquid`.
- Use English as the primary language for agent routing stability, with Chinese Perps trigger terms such as 永续/合约 included in metadata.
- Keep volatile SDK/API facts behind source checks and `source-index.md` instead of hardcoding stale task-specific details.
- Use progressive disclosure: a thin `SKILL.md` router plus focused references, so agents should normally load only the relevant reference(s).
- Add hard trigger exclusions for generic Swap Relay quote/status/pending/requestId issues unless Perps deposit or Hyperliquid anchors are explicit.
- Add `positions-account-state.md` because positions, PnL, funding, margin, liquidation, and account summary stale-state bugs are high-risk Perps surfaces.

## Changes Detail
- `.skillshare/skills/1k-perps-module/SKILL.md`: skill metadata, trigger boundary, owner matrix, quick reference, hard stops, and related skills.
- `agents/openai.yaml`: Codex/OpenAI-facing display metadata.
- `references/rules/code-map.md`: repo anchors for Perps UI, state, services, and shared contracts.
- `references/rules/order-contracts.md`: SDK-versioned order/TIF/TWAP/scale/trigger/reduce-only guidance.
- `references/rules/state-subscriptions.md`: account/dex/asset scoping, L2/BBO freshness, and subscription race guidance.
- `references/rules/deposit-relay.md`: Perps deposit Relay owner guidance, including `ServiceSwap.ts` and active transaction scoping.
- `references/rules/tradingview-bridge.md`: TradingView Perps readiness, symbol changes, K-line recovery, and chart-line guidance.
- `references/rules/positions-account-state.md`: account-scoped positions, PnL, funding, margin, liquidation, and summary guidance.
- `references/rules/source-index.md`: SDK/API/source verification entry points and SDK bump checklist.
- `references/rules/failure-patterns.md`, `review-checklist.md`, `validation-recipes.md`: recurring failure classes, review gates, and targeted validation paths.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: No direct runtime platform impact; this is agent skill/documentation content for repository workflows.
- **Risk Areas**: Skill routing precision, future SDK/API drift, and keeping the router under the urgent split threshold.

## Test plan
- [x] `python3 /Users/minnzen/.codex/skills/.system/skill-creator/scripts/quick_validate.py .skillshare/skills/1k-perps-module`
- [x] Markdown link check: `missing_links 0`
- [x] Repo path anchor check: `missing_or_symbolic_paths 0`
- [x] Token analyzer: `9,921` estimated tokens, below the `>10k` urgent split threshold
- [x] Low-effort replay checks for Perps order/TIF, generic Market K-line, Perps orderbook review, generic Swap Relay, Perps positions/account state, and Hyperliquid SDK bump routing
- [x] `yarn lint:staged`
- [ ] `yarn tsc:staged` failed on existing unrelated TypeScript/package errors outside this docs-only change, including background thread shared RPC typings, hardware adapter typings, and missing native module declarations
- [ ] Full `yarn test` not run because this PR only adds skill documentation/metadata; targeted skill validation and replay checks were run instead
