### PR TITLE
fix: preserve private send fiat values

### DIFF
--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -89,6 +89,12 @@ const PRIVATE_SEND_SWAP_HISTORY_TERMINAL_STATUSES = new Set([
   ESwapTxHistoryStatus.PARTIALLY_FILLED,
 ]);
 
+type IHistoryDecodedAction = IAccountHistoryTx['decodedTx']['actions'][number];
+type IHistoryDecodedTransfer = NonNullable<
+  IHistoryDecodedAction['assetTransfer']
+>['sends'][number];
+type IPrivateSendSwapHistoryToken = ISwapTxHistory['baseInfo']['fromToken'];
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -199,6 +205,290 @@ function mergePrivateSendExtraInfoFields({
   }) as IAccountHistoryTx['decodedTx']['extraInfo'];
 }
 
+function hasPrivateSendTransferPrice(transfer?: IHistoryDecodedTransfer) {
+  return !isNil(transfer?.price) && transfer?.price !== '';
+}
+
+function hasPrivateSendSwapHistoryTokenPrice(
+  token?: IPrivateSendSwapHistoryToken,
+) {
+  return !isNil(token?.price) && token?.price !== '';
+}
+
+function normalizePrivateSendTransferTokenId(tokenId?: string) {
+  return tokenId?.trim().toLowerCase() ?? '';
+}
+
+function isSamePrivateSendTransferSwapToken({
+  transfer,
+  token,
+}: {
+  transfer: IHistoryDecodedTransfer;
+  token?: IPrivateSendSwapHistoryToken;
+}) {
+  if (!token) {
+    return false;
+  }
+
+  if (
+    normalizePrivateSendTransferTokenId(transfer.tokenIdOnNetwork) &&
+    normalizePrivateSendTransferTokenId(transfer.tokenIdOnNetwork) ===
+      normalizePrivateSendTransferTokenId(token.contractAddress)
+  ) {
+    return true;
+  }
+
+  return Boolean(
+    (!transfer.networkId ||
+      !token.networkId ||
+      transfer.networkId === token.networkId) &&
+    (transfer.isNative || !transfer.tokenIdOnNetwork) &&
+    (token.isNative || !token.contractAddress),
+  );
+}
+
+function isSamePrivateSendTransferForPrice({
+  localTransfer,
+  onChainTransfer,
+}: {
+  localTransfer: IHistoryDecodedTransfer;
+  onChainTransfer: IHistoryDecodedTransfer;
+}) {
+  return (
+    localTransfer.amount === onChainTransfer.amount &&
+    localTransfer.symbol === onChainTransfer.symbol &&
+    localTransfer.isNative === onChainTransfer.isNative &&
+    normalizePrivateSendTransferTokenId(localTransfer.tokenIdOnNetwork) ===
+      normalizePrivateSendTransferTokenId(onChainTransfer.tokenIdOnNetwork)
+  );
+}
+
+function findPrivateSendLocalTransferWithPrice({
+  localTransfers,
+  onChainTransfer,
+  index,
+}: {
+  localTransfers: IHistoryDecodedTransfer[];
+  onChainTransfer: IHistoryDecodedTransfer;
+  index: number;
+}) {
+  const sameIndexTransfer = localTransfers[index];
+  if (
+    sameIndexTransfer &&
+    hasPrivateSendTransferPrice(sameIndexTransfer) &&
+    isSamePrivateSendTransferForPrice({
+      localTransfer: sameIndexTransfer,
+      onChainTransfer,
+    })
+  ) {
+    return sameIndexTransfer;
+  }
+
+  return localTransfers.find(
+    (localTransfer) =>
+      hasPrivateSendTransferPrice(localTransfer) &&
+      isSamePrivateSendTransferForPrice({
+        localTransfer,
+        onChainTransfer,
+      }),
+  );
+}
+
+function mergePrivateSendTransferPrices({
+  localTransfers,
+  onChainTransfers,
+}: {
+  localTransfers: IHistoryDecodedTransfer[];
+  onChainTransfers: IHistoryDecodedTransfer[];
+}) {
+  let updated = false;
+  const transfers = onChainTransfers.map((onChainTransfer, index) => {
+    if (hasPrivateSendTransferPrice(onChainTransfer)) {
+      return onChainTransfer;
+    }
+
+    const localTransfer = findPrivateSendLocalTransferWithPrice({
+      localTransfers,
+      onChainTransfer,
+      index,
+    });
+    if (!localTransfer?.price) {
+      return onChainTransfer;
+    }
+
+    updated = true;
+    return {
+      ...onChainTransfer,
+      price: localTransfer.price,
+    };
+  });
+
+  return { transfers, updated };
+}
+
+function getPrivateSendAssetTransferActions(actions?: IHistoryDecodedAction[]) {
+  return actions?.filter((action) => !!action.assetTransfer) ?? [];
+}
+
+function mergePrivateSendActionTransferPrices({
+  localActions,
+  onChainActions,
+}: {
+  localActions?: IHistoryDecodedAction[];
+  onChainActions?: IHistoryDecodedAction[];
+}) {
+  if (!onChainActions?.length) {
+    return { actions: onChainActions, updated: false };
+  }
+
+  let assetTransferActionIndex = 0;
+  let updated = false;
+  const localAssetTransferActions =
+    getPrivateSendAssetTransferActions(localActions);
+  const actions = onChainActions.map((action) => {
+    const { assetTransfer } = action;
+    if (!assetTransfer) {
+      return action;
+    }
+
+    const localAssetTransfer =
+      localAssetTransferActions[assetTransferActionIndex]?.assetTransfer;
+    assetTransferActionIndex += 1;
+    if (!localAssetTransfer) {
+      return action;
+    }
+
+    const sendsResult = mergePrivateSendTransferPrices({
+      localTransfers: localAssetTransfer.sends,
+      onChainTransfers: assetTransfer.sends,
+    });
+    const receivesResult = mergePrivateSendTransferPrices({
+      localTransfers: localAssetTransfer.receives,
+      onChainTransfers: assetTransfer.receives,
+    });
+    if (!sendsResult.updated && !receivesResult.updated) {
+      return action;
+    }
+
+    updated = true;
+    return {
+      ...action,
+      assetTransfer: {
+        ...assetTransfer,
+        sends: sendsResult.transfers,
+        receives: receivesResult.transfers,
+      },
+    };
+  });
+
+  return { actions, updated };
+}
+
+function applyPrivateSendSwapHistoryTokenPriceToTransfers({
+  transfers,
+  token,
+}: {
+  transfers: IHistoryDecodedTransfer[];
+  token: IPrivateSendSwapHistoryToken;
+}) {
+  if (!hasPrivateSendSwapHistoryTokenPrice(token)) {
+    return { transfers, updated: false };
+  }
+
+  let updated = false;
+  const nextTransfers = transfers.map((transfer) => {
+    if (
+      hasPrivateSendTransferPrice(transfer) ||
+      !isSamePrivateSendTransferSwapToken({ transfer, token })
+    ) {
+      return transfer;
+    }
+
+    updated = true;
+    return {
+      ...transfer,
+      price: token.price,
+    };
+  });
+
+  return { transfers: nextTransfers, updated };
+}
+
+function applyPrivateSendSwapHistoryTokenPricesToActions({
+  actions,
+  swapHistory,
+}: {
+  actions?: IHistoryDecodedAction[];
+  swapHistory: ISwapTxHistory;
+}) {
+  if (!actions?.length) {
+    return { actions, updated: false };
+  }
+
+  let updated = false;
+  const nextActions = actions.map((action) => {
+    const { assetTransfer } = action;
+    if (!assetTransfer) {
+      return action;
+    }
+
+    const sendsResult = applyPrivateSendSwapHistoryTokenPriceToTransfers({
+      transfers: assetTransfer.sends,
+      token: swapHistory.baseInfo.fromToken,
+    });
+    const receivesResult = applyPrivateSendSwapHistoryTokenPriceToTransfers({
+      transfers: assetTransfer.receives,
+      token: swapHistory.baseInfo.toToken,
+    });
+    if (!sendsResult.updated && !receivesResult.updated) {
+      return action;
+    }
+
+    updated = true;
+    return {
+      ...action,
+      assetTransfer: {
+        ...assetTransfer,
+        sends: sendsResult.transfers,
+        receives: receivesResult.transfers,
+      },
+    };
+  });
+
+  return { actions: nextActions, updated };
+}
+
+function applyPrivateSendSwapHistoryTokenPricesToHistoryTx({
+  tx,
+  swapHistory,
+}: {
+  tx: IAccountHistoryTx;
+  swapHistory: ISwapTxHistory;
+}) {
+  const actionsResult = applyPrivateSendSwapHistoryTokenPricesToActions({
+    actions: tx.decodedTx.actions,
+    swapHistory,
+  });
+  const outputActionsResult = applyPrivateSendSwapHistoryTokenPricesToActions({
+    actions: tx.decodedTx.outputActions,
+    swapHistory,
+  });
+  if (!actionsResult.updated && !outputActionsResult.updated) {
+    return tx;
+  }
+
+  return {
+    ...tx,
+    decodedTx: {
+      ...tx.decodedTx,
+      ...(actionsResult.updated ? { actions: actionsResult.actions } : {}),
+      ...(outputActionsResult.updated
+        ? { outputActions: outputActionsResult.actions }
+        : {}),
+    },
+  };
+}
+
 function mergePrivateSendLocalDecodedTxFields({
   localTx,
   onChainHistoryTx,
@@ -212,7 +502,20 @@ function mergePrivateSendLocalDecodedTxFields({
 
   const localPayload = localTx.decodedTx.payload;
   const localExtraInfo = localTx.decodedTx.extraInfo;
-  if (!localPayload && !localExtraInfo) {
+  const actionsResult = mergePrivateSendActionTransferPrices({
+    localActions: localTx.decodedTx.actions,
+    onChainActions: onChainHistoryTx.decodedTx.actions,
+  });
+  const outputActionsResult = mergePrivateSendActionTransferPrices({
+    localActions: localTx.decodedTx.outputActions,
+    onChainActions: onChainHistoryTx.decodedTx.outputActions,
+  });
+  if (
+    !localPayload &&
+    !localExtraInfo &&
+    !actionsResult.updated &&
+    !outputActionsResult.updated
+  ) {
     return onChainHistoryTx;
   }
 
@@ -228,6 +531,10 @@ function mergePrivateSendLocalDecodedTxFields({
         localExtraInfo,
         onChainExtraInfo: onChainHistoryTx.decodedTx.extraInfo,
       }),
+      ...(actionsResult.updated ? { actions: actionsResult.actions } : {}),
+      ...(outputActionsResult.updated
+        ? { outputActions: outputActionsResult.actions }
+        : {}),
     },
   };
 }
@@ -278,18 +585,23 @@ class ServiceHistory extends ServiceBase {
       if (!swapHistory) {
         return this.clearHistoryTxDisplayStatus(tx);
       }
+      const txWithSwapHistoryTokenPrices =
+        applyPrivateSendSwapHistoryTokenPricesToHistoryTx({
+          tx,
+          swapHistory,
+        });
 
       const displayStatus = getPrivateSendHistoryDisplayStatus({
-        historyTx: tx,
+        historyTx: txWithSwapHistoryTokenPrices,
         swapHistory,
       });
 
       if (!displayStatus || displayStatus === tx.decodedTx.status) {
-        return this.clearHistoryTxDisplayStatus(tx);
+        return this.clearHistoryTxDisplayStatus(txWithSwapHistoryTokenPrices);
       }
 
       return {
-        ...tx,
+        ...txWithSwapHistoryTokenPrices,
         displayStatus,
         displayStatusSource: 'privateSendOrder',
       };

--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js';
 import { isNil, unionBy, uniqBy } from 'lodash';
 
 import type { IEncodedTx } from '@onekeyhq/core/src/types';
@@ -205,14 +206,27 @@ function mergePrivateSendExtraInfoFields({
   }) as IAccountHistoryTx['decodedTx']['extraInfo'];
 }
 
+function getPrivateSendPositivePriceValue(value?: number | string) {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const valueBN = new BigNumber(value);
+  if (valueBN.isNaN() || !valueBN.isFinite() || !valueBN.isGreaterThan(0)) {
+    return undefined;
+  }
+
+  return valueBN.toFixed();
+}
+
 function hasPrivateSendTransferPrice(transfer?: IHistoryDecodedTransfer) {
-  return !isNil(transfer?.price) && transfer?.price !== '';
+  return !!getPrivateSendPositivePriceValue(transfer?.price);
 }
 
 function hasPrivateSendSwapHistoryTokenPrice(
   token?: IPrivateSendSwapHistoryToken,
 ) {
-  return !isNil(token?.price) && token?.price !== '';
+  return !!getPrivateSendPositivePriceValue(token?.price);
 }
 
 function normalizePrivateSendTransferTokenId(tokenId?: string) {

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -2006,7 +2006,15 @@ export default class ServiceSwap extends ServiceBase {
           swapHistoryPendingList: newPendingList,
         };
       });
-      if (shouldShowToast && item.status !== ESwapTxHistoryStatus.PENDING) {
+      const isPrivateSendHistory = isPrivateSendSwapHistoryItem(item);
+      if (
+        shouldShowToast &&
+        item.status !== ESwapTxHistoryStatus.PENDING &&
+        !isPrivateSendHistory
+      ) {
+        const isSuccessStatus =
+          item.status === ESwapTxHistoryStatus.SUCCESS ||
+          item.status === ESwapTxHistoryStatus.PARTIALLY_FILLED;
         let fromAmountFinal = item.baseInfo.fromAmount;
         if (item.swapInfo.otherFeeInfos?.length) {
           item.swapInfo.otherFeeInfos.forEach((extraFeeInfo) => {
@@ -2023,17 +2031,11 @@ export default class ServiceSwap extends ServiceBase {
           });
         }
         void this.backgroundApi.serviceApp.showToast({
-          method:
-            item.status === ESwapTxHistoryStatus.SUCCESS ||
-            item.status === ESwapTxHistoryStatus.PARTIALLY_FILLED
-              ? 'success'
-              : 'error',
+          method: isSuccessStatus ? 'success' : 'error',
           title: appLocale.intl.formatMessage({
-            id:
-              item.status === ESwapTxHistoryStatus.SUCCESS ||
-              item.status === ESwapTxHistoryStatus.PARTIALLY_FILLED
-                ? ETranslations.swap_page_toast_swap_successful
-                : ETranslations.swap_page_toast_swap_failed,
+            id: isSuccessStatus
+              ? ETranslations.swap_page_toast_swap_successful
+              : ETranslations.swap_page_toast_swap_failed,
           }),
           message: `${numberFormat(item.baseInfo.fromAmount, formatter)} ${
             item.baseInfo.fromToken.symbol

--- a/packages/kit-bg/src/vaults/base/VaultBase.ts
+++ b/packages/kit-bg/src/vaults/base/VaultBase.ts
@@ -1088,6 +1088,7 @@ export abstract class VaultBase extends VaultBaseChainOnly {
         isNFT: false,
         isNative: swapSendToken.isNative,
         networkId: swapInfo.sender.accountInfo.networkId,
+        price: swapSendToken.price,
       },
       {
         from: '',
@@ -1100,6 +1101,7 @@ export abstract class VaultBase extends VaultBaseChainOnly {
         isNFT: false,
         isNative: swapReceiveToken.isNative,
         networkId: swapInfo.receiver.accountInfo.networkId,
+        price: swapReceiveToken.price,
       },
     ];
 
@@ -1121,6 +1123,7 @@ export abstract class VaultBase extends VaultBaseChainOnly {
             isNFT: false,
             isNative: feeInfo.token.isNative,
             networkId: swapInfo.sender.accountInfo.networkId,
+            price: feeInfo.token.price,
           });
         }
       });

--- a/packages/kit/src/components/TxAction/TxActionTransfer.tsx
+++ b/packages/kit/src/components/TxAction/TxActionTransfer.tsx
@@ -78,6 +78,25 @@ function getPrivateSendCreateTokenAccountFee(decodedTx: IDecodedTx) {
   return createTokenAccountFee;
 }
 
+function getPositiveNumberValue(value?: string) {
+  const valueBN = new BigNumber(value ?? '');
+  return valueBN.isNaN() || !valueBN.isFinite() || !valueBN.isGreaterThan(0)
+    ? undefined
+    : valueBN;
+}
+
+function getPrivateSendNativePriceFromFee(decodedTx: IDecodedTx) {
+  const totalFeeInNativeBN = getPositiveNumberValue(decodedTx.totalFeeInNative);
+  const totalFeeFiatValueBN = getPositiveNumberValue(
+    decodedTx.totalFeeFiatValue,
+  );
+  if (!totalFeeInNativeBN || !totalFeeFiatValueBN) {
+    return undefined;
+  }
+
+  return totalFeeFiatValueBN.div(totalFeeInNativeBN).toFixed();
+}
+
 function hasPrivateSendCreateTokenAccountFeeTransfer({
   transfers,
   createTokenAccountFee,
@@ -118,6 +137,7 @@ function buildPrivateSendDisplaySends({
   ) {
     return sends;
   }
+  const nativePrice = getPrivateSendNativePriceFromFee(decodedTx);
   return [
     ...sends,
     {
@@ -131,6 +151,7 @@ function buildPrivateSendDisplaySends({
       isNFT: false,
       isNative: true,
       networkId: decodedTx.networkId,
+      price: nativePrice,
     },
   ];
 }

--- a/packages/kit/src/views/Swap/utils/privateSendHistory.ts
+++ b/packages/kit/src/views/Swap/utils/privateSendHistory.ts
@@ -153,6 +153,97 @@ function getPrivateSendDisplayTransferIdentity(
   };
 }
 
+function areSamePrivateSendDisplayTransferContents({
+  currentIdentity,
+  replayIdentity,
+}: {
+  currentIdentity: ReturnType<typeof getPrivateSendDisplayTransferIdentity>;
+  replayIdentity: ReturnType<typeof getPrivateSendDisplayTransferIdentity>;
+}) {
+  return (
+    replayIdentity.amount === currentIdentity.amount &&
+    replayIdentity.tokenIdOnNetwork === currentIdentity.tokenIdOnNetwork &&
+    replayIdentity.symbol === currentIdentity.symbol &&
+    replayIdentity.icon === currentIdentity.icon &&
+    replayIdentity.isNative === currentIdentity.isNative
+  );
+}
+
+function areSamePrivateSendDisplayTransferTokens({
+  currentIdentity,
+  replayIdentity,
+}: {
+  currentIdentity: ReturnType<typeof getPrivateSendDisplayTransferIdentity>;
+  replayIdentity: ReturnType<typeof getPrivateSendDisplayTransferIdentity>;
+}) {
+  return (
+    replayIdentity.tokenIdOnNetwork === currentIdentity.tokenIdOnNetwork &&
+    replayIdentity.symbol === currentIdentity.symbol &&
+    replayIdentity.icon === currentIdentity.icon &&
+    replayIdentity.isNative === currentIdentity.isNative
+  );
+}
+
+function findPrivateSendDisplayTransferWithPrice({
+  currentTransfers,
+  replayTransfer,
+  index,
+}: {
+  currentTransfers: IDecodedTxTransferInfo[];
+  replayTransfer: IDecodedTxTransferInfo;
+  index: number;
+}) {
+  const replayIdentity = getPrivateSendDisplayTransferIdentity(replayTransfer);
+  const sameIndexTransfer = currentTransfers[index];
+  if (sameIndexTransfer) {
+    const sameIndexIdentity =
+      getPrivateSendDisplayTransferIdentity(sameIndexTransfer);
+    if (
+      sameIndexIdentity.price &&
+      areSamePrivateSendDisplayTransferTokens({
+        currentIdentity: sameIndexIdentity,
+        replayIdentity,
+      })
+    ) {
+      return sameIndexTransfer;
+    }
+  }
+
+  return currentTransfers.find((currentTransfer) => {
+    const currentIdentity =
+      getPrivateSendDisplayTransferIdentity(currentTransfer);
+    return (
+      currentIdentity.price &&
+      areSamePrivateSendDisplayTransferTokens({
+        currentIdentity,
+        replayIdentity,
+      })
+    );
+  });
+}
+
+function mergePrivateSendDisplayTransferPrices({
+  currentTransfers,
+  replayTransfers,
+}: {
+  currentTransfers: IDecodedTxTransferInfo[];
+  replayTransfers: IDecodedTxTransferInfo[];
+}) {
+  return replayTransfers.map((replayTransfer, index) => {
+    if (getPositivePriceValue(replayTransfer.price)) {
+      return replayTransfer;
+    }
+
+    const currentTransfer = findPrivateSendDisplayTransferWithPrice({
+      currentTransfers,
+      replayTransfer,
+      index,
+    });
+    const price = getPositivePriceValue(currentTransfer?.price);
+    return price ? { ...replayTransfer, price } : replayTransfer;
+  });
+}
+
 function areSamePrivateSendDisplayTransfers({
   currentTransfers,
   replayTransfers,
@@ -169,12 +260,11 @@ function areSamePrivateSendDisplayTransfers({
       currentTransfers[index],
     );
     return (
-      replayIdentity.amount === currentIdentity.amount &&
-      replayIdentity.tokenIdOnNetwork === currentIdentity.tokenIdOnNetwork &&
-      replayIdentity.symbol === currentIdentity.symbol &&
-      replayIdentity.icon === currentIdentity.icon &&
-      replayIdentity.isNative === currentIdentity.isNative &&
-      replayIdentity.price === currentIdentity.price
+      areSamePrivateSendDisplayTransferContents({
+        currentIdentity,
+        replayIdentity,
+      }) &&
+      (!replayIdentity.price || replayIdentity.price === currentIdentity.price)
     );
   });
 }
@@ -246,6 +336,12 @@ function mergePrivateSendHistoryReplayFields({
     currentTransfers: currentDisplayTransfers,
     replayTransfers: replayDisplayTransfers,
   });
+  const mergedReplayDisplayTransfers = shouldMergeDisplayTransfers
+    ? mergePrivateSendDisplayTransferPrices({
+        currentTransfers: currentDisplayTransfers,
+        replayTransfers: replayDisplayTransfers,
+      })
+    : replayDisplayTransfers;
   const shouldMergeGasFeeInNative = shouldUsePrivateSendReplayFeeValue({
     currentValue: item.txInfo.gasFeeInNative,
     replayValue: replayItem.txInfo.gasFeeInNative,
@@ -274,7 +370,7 @@ function mergePrivateSendHistoryReplayFields({
           ? { payinAddress: replayPayinAddress }
           : {}),
         ...(shouldMergeDisplayTransfers
-          ? { privateSendDisplayTransfers: replayDisplayTransfers }
+          ? { privateSendDisplayTransfers: mergedReplayDisplayTransfers }
           : {}),
       },
     };

--- a/packages/kit/src/views/Swap/utils/privateSendHistory.ts
+++ b/packages/kit/src/views/Swap/utils/privateSendHistory.ts
@@ -149,6 +149,7 @@ function getPrivateSendDisplayTransferIdentity(
     symbol: transfer.symbol,
     icon: transfer.icon,
     isNative: transfer.isNative === true,
+    price: getPositivePriceValue(transfer.price),
   };
 }
 
@@ -172,7 +173,8 @@ function areSamePrivateSendDisplayTransfers({
       replayIdentity.tokenIdOnNetwork === currentIdentity.tokenIdOnNetwork &&
       replayIdentity.symbol === currentIdentity.symbol &&
       replayIdentity.icon === currentIdentity.icon &&
-      replayIdentity.isNative === currentIdentity.isNative
+      replayIdentity.isNative === currentIdentity.isNative &&
+      replayIdentity.price === currentIdentity.price
     );
   });
 }
@@ -503,12 +505,14 @@ function buildPrivateSendCreateTokenAccountFeeTransfer({
   network,
   nativeTokenInfo,
   createTokenAccountFee,
+  nativeTokenPrice,
 }: {
   historyTx: IAccountHistoryTx;
   sender: string;
   network?: IPrivateSendHistoryNetwork;
   nativeTokenInfo?: IToken;
   createTokenAccountFee: IPrivateSendCreateTokenAccountFee;
+  nativeTokenPrice?: string;
 }): IDecodedTxTransferInfo {
   return {
     from: sender,
@@ -529,6 +533,7 @@ function buildPrivateSendCreateTokenAccountFeeTransfer({
     isNFT: false,
     isNative: true,
     networkId: historyTx.decodedTx.networkId,
+    price: nativeTokenPrice,
   };
 }
 
@@ -537,13 +542,18 @@ function buildPrivateSendDisplayTransfers({
   sender,
   network,
   nativeTokenInfo,
+  token,
 }: {
   historyTx: IAccountHistoryTx;
   sender: string;
   network?: IPrivateSendHistoryNetwork;
   nativeTokenInfo?: IToken;
+  token?: ISwapToken;
 }) {
-  const sendTransfers = getPrivateSendHistorySendTransfers(historyTx);
+  const sendTransfers = applyPrivateSendDisplayTransferPrice({
+    transfers: getPrivateSendHistorySendTransfers(historyTx),
+    token,
+  });
   const createTokenAccountFee = getPrivateSendCreateTokenAccountFee(historyTx);
   if (!createTokenAccountFee) {
     return sendTransfers;
@@ -566,6 +576,7 @@ function buildPrivateSendDisplayTransfers({
       network,
       nativeTokenInfo,
       createTokenAccountFee,
+      nativeTokenPrice: getPrivateSendNativePriceFromFee(historyTx),
     }),
   ];
 }
@@ -635,6 +646,70 @@ function getPositivePriceValue(value?: number | string) {
   }
 
   return valueBN.toFixed();
+}
+
+function getPrivateSendNativePriceFromFee(historyTx: IAccountHistoryTx) {
+  const totalFeeInNative = getPositivePriceValue(
+    historyTx.decodedTx.totalFeeInNative,
+  );
+  const totalFeeFiatValue = getPositivePriceValue(
+    historyTx.decodedTx.totalFeeFiatValue,
+  );
+  if (!totalFeeInNative || !totalFeeFiatValue) {
+    return undefined;
+  }
+
+  return new BigNumber(totalFeeFiatValue).div(totalFeeInNative).toFixed();
+}
+
+function getPrivateSendDisplayTransferPriceFromToken({
+  transfer,
+  token,
+}: {
+  transfer: IDecodedTxTransferInfo;
+  token?: ISwapToken;
+}) {
+  const price = getPositivePriceValue(token?.price);
+  if (!price) {
+    return undefined;
+  }
+  if (!token) {
+    return undefined;
+  }
+
+  if (isSameTokenAddress(transfer.tokenIdOnNetwork, token.contractAddress)) {
+    return price;
+  }
+
+  if (
+    (!transfer.networkId || token.networkId === transfer.networkId) &&
+    (token.isNative || !token.contractAddress) &&
+    (transfer.isNative || !transfer.tokenIdOnNetwork)
+  ) {
+    return price;
+  }
+
+  return undefined;
+}
+
+function applyPrivateSendDisplayTransferPrice({
+  transfers,
+  token,
+}: {
+  transfers: IDecodedTxTransferInfo[];
+  token?: ISwapToken;
+}) {
+  return transfers.map((transfer) => {
+    if (getPositivePriceValue(transfer.price)) {
+      return transfer;
+    }
+
+    const price = getPrivateSendDisplayTransferPriceFromToken({
+      transfer,
+      token,
+    });
+    return price ? { ...transfer, price } : transfer;
+  });
 }
 
 async function fetchPrivateSendHistoryTokenDetails({
@@ -789,6 +864,7 @@ function buildPrivateSendHistoryItemFromAccountHistory({
     sender,
     network,
     nativeTokenInfo,
+    token,
   });
   const ctx =
     rocketXOrderId || payinAddress || privateSendDisplayTransfers.length


### PR DESCRIPTION
## Summary
- Preserve token prices on Private Send decoded transfers so the history list can render fiat values after the amount.
- Backfill Private Send transfer prices from swap history and local pending history when on-chain history does not include price data.
- Add price support for synthetic Solana create-token-account fee rows by deriving the native token price from existing fee fiat/native values.

## Intent & Context
The Private Send history list no longer showed fiat amounts after sent token amounts. The issue was visible on Solana Private Send rows, while previous ETH flows appeared to have shown fiat values in some cases. The history list renderer only displays fiat value when `IDecodedTxTransferInfo.price` exists, so the fix keeps price data in the decoded transfer path instead of adding a UI-only fallback.

## Root Cause
Private Send builds swap token data with price, but the internal swap decoded transfer construction did not copy that price into `assetTransfer.sends/receives`. For confirmed/on-chain history, the chain history merge also kept payload and extra info from the local Private Send record but did not preserve decoded transfer prices, so fiat display could disappear after the transaction moved from local pending to on-chain history. Solana create-token-account fee display rows were synthetic native transfers and also had no price.

## Design Decisions
- Keep the display contract unchanged: fiat values are still rendered from `transfer.amount * transfer.price`.
- Propagate existing token prices into decoded transfers at the data source instead of calculating token fiat values in the UI.
- Preserve local Private Send transfer prices when merging on-chain history so confirmed rows do not regress.
- Use swap history token prices to backfill already confirmed Private Send rows when available.
- Derive only native fee-row price from existing `totalFeeFiatValue / totalFeeInNative`; if either value is missing or non-positive, keep price undefined.

## Changes Detail
- `packages/kit-bg/src/vaults/base/VaultBase.ts`: copy swap sender, receiver, and other-fee token prices into internal swap decoded transfers.
- `packages/kit-bg/src/services/ServiceHistory.ts`: preserve Private Send transfer prices during local-to-on-chain history merge and apply swap history token prices to returned Private Send history rows.
- `packages/kit/src/components/TxAction/TxActionTransfer.tsx`: add price to synthetic Private Send native fee transfers when fee fiat/native values allow derivation.
- `packages/kit/src/views/Swap/utils/privateSendHistory.ts`: include price in Private Send display transfer replay/merge identity and backfill display transfer prices from resolved swap token data.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Mobile / Web / Extension
- **Risk Areas**: Private Send history rendering and history merge behavior. The changes are scoped to Private Send/internal swap transfer price propagation and should not affect normal send rows unless they already use the internal swap transfer builder.

## Test plan
- [x] `git diff --check`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit-bg/src/services/ServiceHistory.ts packages/kit-bg/src/vaults/base/VaultBase.ts packages/kit/src/components/TxAction/TxActionTransfer.tsx packages/kit/src/views/Swap/utils/privateSendHistory.ts --deny-warnings`
- [x] `NODE_OPTIONS=--max-old-space-size=8192 yarn tsc:staged`
- [ ] Runtime verify a Solana Private Send history row shows fiat value after the sent amount.
