### PR TITLE
fix: simplify perps algo order panels(OK-55898, OK-55900)

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OrderInfoSubTabs.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OrderInfoSubTabs.tsx
@@ -25,7 +25,7 @@ function OrderInfoSubTabs<T extends string>({
       >
         <XStack
           minWidth="100%"
-          pl={variant === 'underline' ? '$5' : '$2.5'}
+          pl="$5"
           pr="$5"
           py={variant === 'underline' ? '$0' : '$2.5'}
           gap={variant === 'underline' ? '$5' : '$2'}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -31,7 +31,7 @@ import type { IFill } from '@onekeyhq/shared/types/hyperliquid/sdk';
 import {
   calcCellAlign,
   getColumnStyle,
-  getPerpFillDirectionType,
+  getFillDirectionDisplayInfo,
 } from '../utils';
 
 import type { IColumnConfig, IRenderMode } from '../List/CommonTableListView';
@@ -113,40 +113,8 @@ const TradesHistoryRow = memo(
     }, [fill.time]);
 
     const directionInfo = useMemo(() => {
-      if (isSpotInstrument(fill.coin)) {
-        return {
-          directionStr:
-            fill.side === 'B'
-              ? intl.formatMessage({ id: ETranslations.global_buy })
-              : intl.formatMessage({ id: ETranslations.global_sell }),
-          directionColor: fill.side === 'B' ? '$green11' : '$red11',
-        };
-      }
-      const side = fill.side;
-      let directionColor = '$green11';
-      if (side === 'A') {
-        directionColor = '$red11';
-      }
-
-      const directionType = getPerpFillDirectionType(fill.dir);
-      let directionStr = fill.dir;
-      if (directionType === 'openLong') {
-        directionStr = intl.formatMessage({
-          id: ETranslations.perp_long,
-        });
-      } else if (directionType === 'openShort') {
-        directionStr = intl.formatMessage({
-          id: ETranslations.perp_short,
-        });
-      } else if (directionType === 'closeLong') {
-        directionStr = intl.formatMessage({
-          id: ETranslations.perp_order_close_long,
-        });
-      } else if (directionType === 'closeShort') {
-        directionStr = intl.formatMessage({
-          id: ETranslations.perp_order_close_short,
-        });
-      }
+      const { text, color } = getFillDirectionDisplayInfo({ fill, intl });
+      let directionStr = text;
 
       if (fill.liquidation) {
         const liqPrefix = intl.formatMessage({
@@ -158,8 +126,8 @@ const TradesHistoryRow = memo(
         directionStr = `${liqPrefix}: ${directionStr}`;
       }
 
-      return { directionStr, directionColor };
-    }, [fill.coin, fill.dir, fill.side, fill.liquidation, intl]);
+      return { directionStr, directionColor: color };
+    }, [fill, intl]);
 
     const tradeBaseInfo = useMemo(() => {
       const price = fill.px;

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
@@ -63,8 +63,9 @@ const TradesHistoryLoadingView = () => {
     <Stack
       flex={1}
       alignItems="flex-start"
-      justifyContent="center"
+      justifyContent="flex-start"
       p="$6"
+      pt="$10"
       gap="$2"
     >
       <Skeleton h="$8" w="$40" />

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpOpenOrdersList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpOpenOrdersList.tsx
@@ -3,13 +3,9 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import {
-  Button,
   type IDebugRenderTrackerProps,
-  Icon,
-  Illustration,
   SizableText,
   Toast,
-  XStack,
   YStack,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
@@ -65,57 +61,28 @@ type IOpenOrdersDisplayRow =
 
 function MobileTwapEmptyState() {
   const intl = useIntl();
-  const buttonHeight = 32;
   const handleGuidePress = useCallback(() => {
     openGuideUrl(buildHelpUrl('articles/13988742'));
   }, []);
-  const guideButton = (
-    <Button
-      testID={PerpTestIDs.TwapEmptyGuideButton}
-      width={180}
-      borderRadius="$full"
-      size="small"
-      h={buttonHeight}
-      px="$3"
-      variant="secondary"
-      onPress={handleGuidePress}
-      childrenAsText={false}
-    >
-      <XStack gap="$1.5" alignItems="center">
-        <Icon name="BookOpenOutline" size="$4" />
-        <SizableText size="$bodySmMedium">
-          {intl.formatMessage({
-            id: ETranslations.perp_twap_trading_guide__action,
-          })}
-        </SizableText>
-      </XStack>
-    </Button>
-  );
 
   return (
-    <YStack
-      flex={1}
-      alignItems="center"
-      justifyContent="flex-start"
-      minHeight={240}
-      px="$5"
-      pt="$16"
-      pb="$6"
-    >
-      <YStack width="100%" maxWidth={320} gap="$2" alignItems="center">
-        <YStack h={72} alignItems="center" overflow="visible">
-          <Illustration name="Orders" size={100} />
-        </YStack>
-        <SizableText
-          size="$bodyXs"
-          color="$textSubdued"
-          textAlign="center"
-          maxWidth={280}
-        >
-          {intl.formatMessage({ id: ETranslations.perp_no_active_twap__title })}
-        </SizableText>
-        {guideButton}
-      </YStack>
+    <YStack flex={1} alignItems="center" p="$6">
+      <SizableText size="$bodyMd" color="$textSubdued" textAlign="center">
+        {intl.formatMessage({ id: ETranslations.perp_no_active_twap__title })}
+      </SizableText>
+      <SizableText
+        testID={PerpTestIDs.TwapEmptyGuideButton}
+        size="$bodySm"
+        color="$textSubdued"
+        textAlign="center"
+        textDecorationLine="underline"
+        mt="$2"
+        onPress={handleGuidePress}
+      >
+        {intl.formatMessage({
+          id: ETranslations.perp_twap_trading_guide__action,
+        })}
+      </SizableText>
     </YStack>
   );
 }

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -603,9 +603,9 @@ function TwapHistoryRow({
         <XStack
           px="$3"
           pt="$3"
-          pb="$2"
+          pb="$1"
           justifyContent="space-between"
-          alignItems="flex-start"
+          alignItems="center"
           width="100%"
           gap="$3"
         >
@@ -624,14 +624,17 @@ function TwapHistoryRow({
               </SizableText>
             </XStack>
             <SizableText size="$bodySm" color="$textSubdued">
-              {intl.formatMessage({
-                id: ETranslations.perp_twap_order__title,
-              })}{' '}
-              · {creationTime.inline}
+              {creationTime.inline}
             </SizableText>
           </YStack>
-          <YStack alignItems="flex-end" gap="$1" maxWidth="42%">
-            <SizableText size="$bodySm" color="$textSubdued">
+          <YStack
+            alignItems="flex-end"
+            justifyContent="center"
+            gap="$1"
+            minWidth={72}
+            maxWidth="42%"
+          >
+            <SizableText size="$bodySm" color="$textSubdued" textAlign="right">
               {intl.formatMessage({ id: ETranslations.global_status })}
             </SizableText>
             <SizableText
@@ -647,7 +650,8 @@ function TwapHistoryRow({
         </XStack>
         <YStack
           px="$3"
-          py="$3"
+          pt="$2.5"
+          pb="$3"
           width="100%"
           gap="$2"
           borderTopWidth="$px"
@@ -658,14 +662,12 @@ function TwapHistoryRow({
               id: ETranslations.perp_position_position_size,
             })}
             value={baseInfo.sizeWithSymbol}
-            valueColor={sideInfo.color}
           />
           <MobileTwapHistoryInfoRow
             label={intl.formatMessage({
               id: ETranslations.perp_executed_size__title,
             })}
             value={baseInfo.executedSizeWithSymbol}
-            valueColor={sideInfo.color}
           />
           <MobileTwapHistoryInfoRow
             label={intl.formatMessage({
@@ -928,11 +930,10 @@ function TwapFillRow({
         <Divider width="100%" borderColor="$borderSubdued" />
         <XStack
           px="$3"
+          pt="$1"
           pb="$3"
-          pt="$3"
           width="100%"
-          flex={1}
-          alignItems="center"
+          alignItems="flex-start"
           justifyContent="space-around"
         >
           <YStack gap="$1" flex={1} alignItems="flex-start">

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -50,7 +50,7 @@ import { OrderInfoSubTabs } from '../Components/OrderInfoSubTabs';
 import {
   calcCellAlign,
   getColumnStyle,
-  getPerpFillDirectionType,
+  getFillDirectionDisplayInfo,
   getTwapAssetDisplayName,
 } from '../utils';
 
@@ -288,25 +288,7 @@ function sortTwapSliceFills(fills: ITwapSliceFill[]) {
 }
 
 function getFillDirectionInfo(fill: IFill, intl: IntlShape) {
-  let color = fill.side === 'B' ? '$green11' : '$red11';
-  const directionType = getPerpFillDirectionType(fill.dir);
-  let text = fill.dir;
-
-  if (directionType === 'openLong') {
-    text = intl.formatMessage({ id: ETranslations.perp_long });
-  } else if (directionType === 'openShort') {
-    text = intl.formatMessage({ id: ETranslations.perp_short });
-  } else if (directionType === 'closeLong') {
-    text = intl.formatMessage({ id: ETranslations.perp_order_close_long });
-  } else if (directionType === 'closeShort') {
-    text = intl.formatMessage({ id: ETranslations.perp_order_close_short });
-  }
-
-  if (fill.side === 'A') {
-    color = '$red11';
-  }
-
-  return { text, color };
+  return getFillDirectionDisplayInfo({ fill, intl });
 }
 
 function TwapEmptyState({

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -303,17 +303,50 @@ function TwapEmptyState({
   const intl = useIntl();
   const { gtMd } = useMedia();
   const isMobile = !gtMd;
-  const buttonHeight = isMobile ? 32 : 28;
   const handleGuidePress = useCallback(() => {
     openGuideUrl(buildHelpUrl('articles/13988742'));
   }, []);
+
+  if (isMobile) {
+    return (
+      <YStack flex={1} alignItems="center" p="$6">
+        <SizableText size="$bodyMd" color="$textSubdued" textAlign="center">
+          {intl.formatMessage({ id: titleId })}
+        </SizableText>
+        {description ? (
+          <SizableText
+            size="$bodySm"
+            color="$textSubdued"
+            textAlign="center"
+            mt="$2"
+          >
+            {description}
+          </SizableText>
+        ) : null}
+        <SizableText
+          testID={PerpTestIDs.TwapEmptyGuideButton}
+          size="$bodySm"
+          color="$textSubdued"
+          textAlign="center"
+          textDecorationLine="underline"
+          mt="$2"
+          onPress={handleGuidePress}
+        >
+          {intl.formatMessage({
+            id: ETranslations.perp_twap_trading_guide__action,
+          })}
+        </SizableText>
+      </YStack>
+    );
+  }
+
   const guideButton = (
     <Button
       testID={PerpTestIDs.TwapEmptyGuideButton}
       width={180}
       borderRadius="$full"
       size="small"
-      h={buttonHeight}
+      h={28}
       px="$3"
       variant="secondary"
       onPress={handleGuidePress}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -6,9 +6,11 @@ import { type IntlShape, useIntl } from 'react-intl';
 import {
   Button,
   DashText,
+  Divider,
   type IDebugRenderTrackerProps,
   Icon,
   Illustration,
+  Popover,
   SizableText,
   Toast,
   Tooltip,
@@ -803,6 +805,7 @@ function TwapFillRow({
   onHoverChange,
   spotDisplayMap,
   builderFeeRate,
+  isMobile,
 }: {
   record: ITwapSliceFill;
   cellMinWidth: number;
@@ -813,6 +816,7 @@ function TwapFillRow({
   onHoverChange?: (index: number | null) => void;
   spotDisplayMap: Record<string, string>;
   builderFeeRate?: number;
+  isMobile?: boolean;
 }) {
   const intl = useIntl();
   const { fill } = record;
@@ -880,6 +884,112 @@ function TwapFillRow({
   const bgColor = getTableRowBgColor({ isHovered, index });
   const shouldRenderLeft = renderMode === 'full' || renderMode === 'left';
   const shouldRenderRight = renderMode === 'full' || renderMode === 'right';
+
+  if (isMobile) {
+    return (
+      <ListItem
+        mx="$5"
+        my="$2"
+        p="$0"
+        backgroundColor="$bgSubdued"
+        flexDirection="column"
+        alignItems="flex-start"
+        borderRadius="$3"
+      >
+        <XStack
+          px="$3"
+          pt="$3"
+          justifyContent="space-between"
+          alignItems="center"
+          width="100%"
+        >
+          <YStack gap="$1">
+            <XStack gap="$2" alignItems="center">
+              <SizableText size="$bodyMdMedium">{assetSymbol}</SizableText>
+              <SizableText size="$bodySm" color={directionInfo.color}>
+                {directionInfo.text}
+              </SizableText>
+            </XStack>
+            <SizableText size="$bodySm" color="$textSubdued">
+              {dateInfo.date} {dateInfo.time}
+            </SizableText>
+          </YStack>
+          <YStack gap="$1" alignItems="flex-end">
+            <SizableText size="$bodySm" color="$textSubdued">
+              {intl.formatMessage({
+                id: ETranslations.perp_trades_close_pnl,
+              })}
+            </SizableText>
+            <SizableText size="$bodySm" color={fillInfo.closePnlColor}>
+              {`${fillInfo.closePnlPlusOrMinus}${fillInfo.closePnlFormatted}`}
+            </SizableText>
+          </YStack>
+        </XStack>
+        <Divider width="100%" borderColor="$borderSubdued" />
+        <XStack
+          px="$3"
+          pb="$3"
+          pt="$3"
+          width="100%"
+          flex={1}
+          alignItems="center"
+          justifyContent="space-around"
+        >
+          <YStack gap="$1" flex={1} alignItems="flex-start">
+            <SizableText size="$bodySm" color="$textSubdued">
+              {intl.formatMessage({
+                id: ETranslations.perp_trades_history_price,
+              })}
+            </SizableText>
+            <SizableText size="$bodySm">{fillInfo.priceFormatted}</SizableText>
+          </YStack>
+          <YStack gap="$1" flex={1} alignItems="flex-start">
+            <SizableText size="$bodySm" color="$textSubdued">
+              {intl.formatMessage({
+                id: ETranslations.perp_position_position_size,
+              })}
+            </SizableText>
+            <SizableText size="$bodySm">{fillInfo.sizeFormatted}</SizableText>
+          </YStack>
+          <YStack gap="$1" flex={1} alignItems="flex-start">
+            <SizableText size="$bodySm" color="$textSubdued">
+              {intl.formatMessage({
+                id: ETranslations.perp_trades_history_trade_value,
+              })}
+            </SizableText>
+            <SizableText size="$bodySm">{fillInfo.valueFormatted}</SizableText>
+          </YStack>
+          <YStack gap="$1" flex={1} alignItems="flex-end">
+            <SizableText size="$bodySm" color="$textSubdued">
+              {intl.formatMessage({
+                id: ETranslations.perp_trades_history_fee,
+              })}
+            </SizableText>
+            <Popover
+              title={intl.formatMessage({
+                id: ETranslations.perp_trades_history_fee,
+              })}
+              placement="top"
+              renderTrigger={
+                <DashText
+                  size="$bodySm"
+                  color="$textSubdued"
+                  dashThickness={0.3}
+                >
+                  {fillInfo.feeFormatted}
+                </DashText>
+              }
+              renderContent={() => (
+                <YStack px="$5" pb="$4">
+                  {feeTooltipContent}
+                </YStack>
+              )}
+            />
+          </YStack>
+        </XStack>
+      </ListItem>
+    );
+  }
 
   return (
     <XStack
@@ -1416,9 +1526,10 @@ function PerpTwapList({
         onHoverChange={onHoverChange}
         spotDisplayMap={spotDisplayMap}
         builderFeeRate={builderFeeRate}
+        isMobile={isMobile}
       />
     ),
-    [builderFeeRate, fillColumns, fillMinWidth, spotDisplayMap],
+    [builderFeeRate, fillColumns, fillMinWidth, isMobile, spotDisplayMap],
   );
 
   const emptyState = TWAP_EMPTY_STATE_MAP[activeTab];
@@ -1449,7 +1560,7 @@ function PerpTwapList({
           tabs={twapOrderSubTabs}
           activeTab={activeTab}
           onChange={setActiveTab}
-          variant="underline"
+          variant="pill"
         />
       ) : null}
       {activeTab === 'active' ? (

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpTradersHistoryListModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpTradersHistoryListModal.tsx
@@ -119,7 +119,7 @@ export function PerpTradersHistoryListModal() {
       <PageBody>
         <YStack flex={1}>
           <TabHeader activeTab={activeTab} onTabChange={setActiveTab} />
-          <YStack flex={1}>
+          <YStack flex={1} pt={activeTab === 'Trades' ? '$3' : '$0'}>
             {activeTab === 'Trades' ? (
               <PerpTradesHistoryList isMobile useTabsList={false} />
             ) : null}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/utils.ts
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/utils.ts
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js';
 
+import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
@@ -9,6 +10,7 @@ import {
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import type { IColumnConfig } from './List/CommonTableListView';
+import type { IntlShape } from 'react-intl';
 
 const spotHoldingPnlCurrencyFormatter: INumberFormatProps = {
   formatter: 'value',
@@ -89,6 +91,46 @@ export const getPerpFillDirectionType = (
   }
 
   return 'unknown';
+};
+
+export const getFillDirectionDisplayInfo = ({
+  fill,
+  intl,
+}: {
+  fill: { coin: string; dir?: string; side: string };
+  intl: IntlShape;
+}) => {
+  if (isSpotInstrument(fill.coin)) {
+    return {
+      text: intl.formatMessage({
+        id:
+          fill.side === 'B'
+            ? ETranslations.global_buy
+            : ETranslations.global_sell,
+      }),
+      color: fill.side === 'B' ? '$green11' : '$red11',
+    };
+  }
+
+  let color = fill.side === 'B' ? '$green11' : '$red11';
+  const directionType = getPerpFillDirectionType(fill.dir);
+  let text = fill.dir ?? '';
+
+  if (directionType === 'openLong') {
+    text = intl.formatMessage({ id: ETranslations.perp_long });
+  } else if (directionType === 'openShort') {
+    text = intl.formatMessage({ id: ETranslations.perp_short });
+  } else if (directionType === 'closeLong') {
+    text = intl.formatMessage({ id: ETranslations.perp_order_close_long });
+  } else if (directionType === 'closeShort') {
+    text = intl.formatMessage({ id: ETranslations.perp_order_close_short });
+  }
+
+  if (fill.side === 'A') {
+    color = '$red11';
+  }
+
+  return { text, color };
 };
 
 export const isSpotHoldingStableCoin = (coin: string) =>

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -22,7 +22,6 @@ import {
   usePerpsCustomSettingsAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import {} from '@onekeyhq/shared/src/utils/hyperliquidScaleOrderUtils';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   formatPriceToSignificantDigits,

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -4,7 +4,6 @@ import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
 import {
-  Badge,
   Button,
   Checkbox,
   Dialog,
@@ -23,8 +22,6 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
-  buildScaleOrderLegs,
-  getScaleOrderSizeSkew,
 } from '@onekeyhq/shared/src/utils/hyperliquidScaleOrderUtils';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
@@ -178,7 +175,6 @@ function OrderConfirmContent({
   const isLimitTrigger =
     formData.triggerOrderType === ETriggerOrderType.TRIGGER_LIMIT;
   const limitTifLabel = getTifLabel(formData.limitTif ?? 'Gtc') ?? 'GTC';
-  const scaleTifLabel = getTifLabel(formData.scaleTif ?? 'Gtc') ?? 'GTC';
   const shouldShowStandardLimitTif =
     !isSpot && !isTriggerMode && !isAlgoOrderMode && formData.type === 'limit';
 
@@ -199,32 +195,6 @@ function OrderConfirmContent({
         return null;
     }
   }, [isTriggerMode, formData.triggerOrderType, intl]);
-
-  const scaleLegPreview = useMemo(() => {
-    if (!isScaleMode) {
-      return [];
-    }
-    return buildScaleOrderLegs({
-      totalSize: computedSizeForSide.toFixed(),
-      lowerPrice: formData.scaleLowerPrice ?? '',
-      upperPrice: formData.scaleUpperPrice ?? '',
-      orderCount: Number(formData.scaleOrderCount ?? 0),
-      szDecimals,
-      side: effectiveSide,
-      sizeSkew: getScaleOrderSizeSkew(formData.scaleSizeDistribution),
-      assetType: isSpot ? 'spot' : 'perp',
-    });
-  }, [
-    isScaleMode,
-    isSpot,
-    computedSizeForSide,
-    formData.scaleLowerPrice,
-    formData.scaleUpperPrice,
-    formData.scaleOrderCount,
-    formData.scaleSizeDistribution,
-    szDecimals,
-    effectiveSide,
-  ]);
 
   const twapPreview = useMemo(() => {
     if (!isTwapMode) {
@@ -467,29 +437,39 @@ function OrderConfirmContent({
     ? orderTypeText
     : (triggerTypeLabel ?? orderTypeText);
   const shouldShowActionSide = isAlgoOrderMode || Boolean(triggerTypeLabel);
+  const scaleDistributionLabel =
+    formData.scaleSizeDistribution === 'increasing'
+      ? intl.formatMessage({
+          id: ETranslations.perp_scale_increasing_distribution__action,
+        })
+      : intl.formatMessage({
+          id: ETranslations.perp_scale_fixed_distribution__action,
+        });
 
   return (
     <YStack gap="$4" p="$1">
       {/* Order Details */}
       <YStack gap="$3">
         {/* Action */}
-        <XStack justifyContent="space-between" alignItems="center">
-          <SizableText size="$bodyMd" color="$textSubdued">
-            {intl.formatMessage({
-              id: ETranslations.perp_trade_order_type,
-            })}
-          </SizableText>
-          {shouldShowActionSide ? (
-            <SizableText size="$bodyMdMedium" color={actionColor}>
-              {actionLabel}
-              {' /'} {actionSideLabel}
+        {!isScaleMode ? (
+          <XStack justifyContent="space-between" alignItems="center">
+            <SizableText size="$bodyMd" color="$textSubdued">
+              {intl.formatMessage({
+                id: ETranslations.perp_trade_order_type,
+              })}
             </SizableText>
-          ) : (
-            <SizableText size="$bodyMdMedium" color={actionColor}>
-              {actionLabel}
-            </SizableText>
-          )}
-        </XStack>
+            {shouldShowActionSide ? (
+              <SizableText size="$bodyMdMedium" color={actionColor}>
+                {actionLabel}
+                {' /'} {actionSideLabel}
+              </SizableText>
+            ) : (
+              <SizableText size="$bodyMdMedium" color={actionColor}>
+                {actionLabel}
+              </SizableText>
+            )}
+          </XStack>
+        ) : null}
 
         {/* Trigger Price (trigger orders only) */}
         {isTriggerMode && formData.triggerPrice ? (
@@ -546,6 +526,41 @@ function OrderConfirmContent({
             <XStack justifyContent="space-between" alignItems="center">
               <SizableText size="$bodyMd" color="$textSubdued">
                 {intl.formatMessage({
+                  id: ETranslations.perp_trade_order_type,
+                })}
+              </SizableText>
+              <SizableText size="$bodyMdMedium" color={actionColor}>
+                {shouldShowActionSide
+                  ? `${actionLabel} / ${actionSideLabel}`
+                  : actionLabel}
+              </SizableText>
+            </XStack>
+            <XStack justifyContent="space-between" alignItems="center">
+              <SizableText size="$bodyMd" color="$textSubdued">
+                {intl.formatMessage({
+                  id: ETranslations.perp_position_position_size,
+                })}
+              </SizableText>
+              <SizableText size="$bodyMdMedium">{sizeDisplay}</SizableText>
+            </XStack>
+            {orderValue.isFinite() && orderValue.gt(0) ? (
+              <XStack justifyContent="space-between" alignItems="center">
+                <SizableText size="$bodyMd" color="$textSubdued">
+                  {intl.formatMessage({
+                    id: ETranslations.perp_trade_order_value,
+                  })}
+                </SizableText>
+                <SizableText size="$bodyMdMedium">
+                  {numberFormat(orderValue.toFixed(2), {
+                    formatter: 'value',
+                    formatterOptions: { currency: '$' },
+                  })}
+                </SizableText>
+              </XStack>
+            ) : null}
+            <XStack justifyContent="space-between" alignItems="center">
+              <SizableText size="$bodyMd" color="$textSubdued">
+                {intl.formatMessage({
                   id: ETranslations.perp_scale_lower_price_label__title,
                 })}
               </SizableText>
@@ -571,83 +586,18 @@ function OrderConfirmContent({
                 })}
               </SizableText>
             </XStack>
-            <XStack justifyContent="space-between" alignItems="center">
-              <SizableText size="$bodyMd" color="$textSubdued">
-                {intl.formatMessage({
-                  id: ETranslations.perp_scale_orders__title,
-                })}
-              </SizableText>
-              <SizableText size="$bodyMdMedium">
-                {formData.scaleOrderCount ?? '--'}
-              </SizableText>
-            </XStack>
-            <XStack justifyContent="space-between" alignItems="center">
-              <SizableText size="$bodyMd" color="$textSubdued">
-                {intl.formatMessage({
-                  id: ETranslations.perp_scale_amount_distribution__title,
-                })}
-              </SizableText>
-              <SizableText size="$bodyMdMedium">
-                {formData.scaleSizeDistribution === 'increasing'
-                  ? intl.formatMessage({
-                      id: ETranslations.perp_scale_increasing_distribution__action,
-                    })
-                  : intl.formatMessage({
-                      id: ETranslations.perp_scale_fixed_distribution__action,
-                    })}
-              </SizableText>
-            </XStack>
-            {isSpot ? null : (
-              <XStack justifyContent="space-between" alignItems="center">
-                <SizableText size="$bodyMd" color="$textSubdued">
-                  Time in Force
-                </SizableText>
-                <SizableText size="$bodyMdMedium">{scaleTifLabel}</SizableText>
-              </XStack>
-            )}
             {isSpot ? null : (
               <XStack justifyContent="space-between" alignItems="center">
                 <SizableText size="$bodyMd" color="$textSubdued">
                   {intl.formatMessage({
-                    id: ETranslations.perps_reduce_only,
+                    id: ETranslations.perp_scale_amount_distribution__title,
                   })}
                 </SizableText>
                 <SizableText size="$bodyMdMedium">
-                  {formData.scaleReduceOnly ? yesText : noText}
+                  {scaleDistributionLabel}
                 </SizableText>
               </XStack>
             )}
-            {scaleLegPreview.length > 0 ? (
-              <YStack gap="$1.5">
-                <SizableText size="$bodyMd" color="$textSubdued">
-                  Scale Preview
-                </SizableText>
-                {scaleLegPreview.slice(0, 5).map((leg) => (
-                  <XStack
-                    key={leg.index}
-                    justifyContent="space-between"
-                    alignItems="center"
-                  >
-                    <SizableText size="$bodySm" color="$textSubdued">
-                      #{leg.index + 1}
-                    </SizableText>
-                    <SizableText size="$bodySmMedium">
-                      {formatOrderPriceDisplay({
-                        price: leg.price,
-                        isSpot,
-                        szDecimals,
-                      })}{' '}
-                      × {leg.size}
-                    </SizableText>
-                  </XStack>
-                ))}
-                {scaleLegPreview.length > 5 ? (
-                  <SizableText size="$bodySm" color="$textSubdued">
-                    +{scaleLegPreview.length - 5} more
-                  </SizableText>
-                ) : null}
-              </YStack>
-            ) : null}
           </>
         ) : null}
 
@@ -663,49 +613,23 @@ function OrderConfirmContent({
                 {twapPreview.minutes} {minuteUnit}
               </SizableText>
             </XStack>
-            <XStack justifyContent="space-between" alignItems="center">
-              <SizableText size="$bodyMd" color="$textSubdued">
-                Execution
-              </SizableText>
-              <SizableText size="$bodyMdMedium">Market slices</SizableText>
-            </XStack>
-            {isSpot ? null : (
-              <XStack justifyContent="space-between" alignItems="center">
-                <SizableText size="$bodyMd" color="$textSubdued">
-                  {intl.formatMessage({
-                    id: ETranslations.perps_reduce_only,
-                  })}
-                </SizableText>
-                <SizableText size="$bodyMdMedium">
-                  {formData.twapReduceOnly ? yesText : noText}
-                </SizableText>
-              </XStack>
-            )}
-            <XStack justifyContent="space-between" alignItems="center">
-              <SizableText size="$bodyMd" color="$textSubdued">
-                {intl.formatMessage({
-                  id: ETranslations.perp_twap_randomize__title,
-                })}
-              </SizableText>
-              <SizableText size="$bodyMdMedium">
-                {formData.twapRandomize ? yesText : noText}
-              </SizableText>
-            </XStack>
           </>
         ) : null}
 
         {/* Position Size */}
-        <XStack justifyContent="space-between" alignItems="center">
-          <SizableText size="$bodyMd" color="$textSubdued">
-            {intl.formatMessage({
-              id: ETranslations.perp_position_position_size,
-            })}
-          </SizableText>
-          <SizableText size="$bodyMdMedium">{sizeDisplay}</SizableText>
-        </XStack>
+        {!isScaleMode ? (
+          <XStack justifyContent="space-between" alignItems="center">
+            <SizableText size="$bodyMd" color="$textSubdued">
+              {intl.formatMessage({
+                id: ETranslations.perp_position_position_size,
+              })}
+            </SizableText>
+            <SizableText size="$bodyMdMedium">{sizeDisplay}</SizableText>
+          </XStack>
+        ) : null}
 
         {/* Order Value */}
-        {orderValue.isFinite() && orderValue.gt(0) ? (
+        {!isScaleMode && orderValue.isFinite() && orderValue.gt(0) ? (
           <XStack justifyContent="space-between" alignItems="center">
             <SizableText size="$bodyMd" color="$textSubdued">
               {intl.formatMessage({
@@ -717,6 +641,19 @@ function OrderConfirmContent({
                 formatter: 'value',
                 formatterOptions: { currency: '$' },
               })}
+            </SizableText>
+          </XStack>
+        ) : null}
+
+        {isTwapMode ? (
+          <XStack justifyContent="space-between" alignItems="center">
+            <SizableText size="$bodyMd" color="$textSubdued">
+              {intl.formatMessage({
+                id: ETranslations.perp_twap_randomize__title,
+              })}
+            </SizableText>
+            <SizableText size="$bodyMdMedium">
+              {formData.twapRandomize ? yesText : noText}
             </SizableText>
           </XStack>
         ) : null}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
 import {
+  Badge,
   Button,
   Checkbox,
   Dialog,
@@ -21,8 +22,7 @@ import {
   usePerpsCustomSettingsAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import {
-} from '@onekeyhq/shared/src/utils/hyperliquidScaleOrderUtils';
+import {} from '@onekeyhq/shared/src/utils/hyperliquidScaleOrderUtils';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   formatPriceToSignificantDigits,

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -855,10 +855,7 @@ function PerpTradingForm({
       orderCount < SCALE_ORDER_MIN_COUNT ||
       orderCount > SCALE_ORDER_MAX_COUNT
     ) {
-      return {
-        text: `Enter ${SCALE_ORDER_MIN_COUNT}-${SCALE_ORDER_MAX_COUNT} orders`,
-        tone: 'error' as const,
-      };
+      return undefined;
     }
 
     const lowerPrice = new BigNumber(formData.scaleLowerPrice ?? 0);

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -873,12 +873,7 @@ function PerpTradingForm({
       if (!hasPriceInput) {
         return undefined;
       }
-      return {
-        text: intl.formatMessage({
-          id: ETranslations.perp_scale_price_range_required__msg,
-        }),
-        tone: 'error' as const,
-      };
+      return undefined;
     }
     if (lowerPrice.eq(upperPrice)) {
       return {
@@ -889,13 +884,7 @@ function PerpTradingForm({
       };
     }
     if (!hasSizeInput) {
-      return {
-        text: intl.formatMessage(
-          { id: ETranslations.perp_scale_order_size_required_hint__desc },
-          { min: `$${SCALE_ORDER_MIN_NOTIONAL}` },
-        ),
-        tone: 'helper' as const,
-      };
+      return undefined;
     }
 
     const legs = buildScaleOrderLegs({
@@ -922,13 +911,7 @@ function PerpTradingForm({
       };
     }
 
-    return {
-      text: intl.formatMessage(
-        { id: ETranslations.perp_scale_preview_summary_hint__desc },
-        { count: legs.length, min: `$${SCALE_ORDER_MIN_NOTIONAL}` },
-      ),
-      tone: 'helper' as const,
-    };
+    return undefined;
   }, [
     formData.scaleLowerPrice,
     formData.scaleOrderCount,

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -2350,8 +2350,9 @@ function PerpTradingForm({
                   flex={1}
                   numberOfLines={1}
                 >
-                  {/* TODO: replace hardcoded QA copy with ETranslations after the i18n key is added. */}
-                  Per child order size
+                  {intl.formatMessage({
+                    id: ETranslations.perp_twap_child_order_size__title,
+                  })}
                 </SizableText>
                 <SizableText
                   size={isMobile ? '$bodySmMedium' : '$bodyMdMedium'}

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -59,7 +59,6 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   SCALE_ORDER_MAX_COUNT,
   SCALE_ORDER_MIN_COUNT,
-  SCALE_ORDER_MIN_NOTIONAL,
   buildScaleOrderLegs,
   getScaleOrderReferencePrice,
   getScaleOrderSizeSkew,

--- a/packages/kit/src/views/Perp/layouts/PerpDesktopLayout.web.tsx
+++ b/packages/kit/src/views/Perp/layouts/PerpDesktopLayout.web.tsx
@@ -67,12 +67,10 @@ function PerpDesktopLayout() {
 
   const tradingPanel = useMemo(() => {
     return (
-      <YStack height={layout.marketContentHeight} overflow="hidden">
-        <Stack flex={1} style={{ overflowY: 'auto' }}>
-          <YStack pb="$4">
-            <PerpTradingPanel />
-          </YStack>
-        </Stack>
+      <YStack minHeight={layout.marketContentHeight}>
+        <YStack pb="$4">
+          <PerpTradingPanel />
+        </YStack>
       </YStack>
     );
   }, [layout.marketContentHeight]);

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -3291,6 +3291,7 @@ export enum ETranslations {
   perp_trading_adjust_margin_updated = 'perp_trading_adjust_margin_updated',
   perp_twap_active__title = 'perp_twap_active__title',
   perp_twap_avg_filled_price__title = 'perp_twap_avg_filled_price__title',
+  perp_twap_child_order_size__title = 'perp_twap_child_order_size__title',
   perp_twap_duration__title = 'perp_twap_duration__title',
   perp_twap_duration_helper__desc = 'perp_twap_duration_helper__desc',
   perp_twap_duration_range__msg = 'perp_twap_duration_range__msg',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "মার্জিন আপডেট করা হয়েছে",
   "perp_twap_active__title": "সক্রিয়",
   "perp_twap_avg_filled_price__title": "গড় সম্পাদিত মূল্য",
+  "perp_twap_child_order_size__title": "প্রতি চাইল্ড অর্ডারের পরিমাণ",
   "perp_twap_duration__title": "সময়কাল",
   "perp_twap_duration_helper__desc": "TWAP নির্বাচিত সময়কালের উপর মার্কেট স্লাইস সাবমিট করে। Hyperliquid স্লাইসের সময় নিয়ন্ত্রণ করে এবং খুব ছোট স্লাইস বাতিল করতে পারে।",
   "perp_twap_duration_range__msg": "TWAP সময়কালের দৈর্ঘ্য অবশ্যই {min}-{max} মিনিট হতে হবে",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "Marge aktualisiert",
   "perp_twap_active__title": "Aktiv",
   "perp_twap_avg_filled_price__title": "Durchschn. Ausführungspreis",
+  "perp_twap_child_order_size__title": "Groesse pro Teilorder",
   "perp_twap_duration__title": "Dauer",
   "perp_twap_duration_helper__desc": "TWAP sendet Markt-Slices über die gewählte Dauer. Hyperliquid steuert die Slice-Timing und kann sehr kleine Slices ablehnen.",
   "perp_twap_duration_range__msg": "TWAP-Dauer muss {min}-{max} Minuten betragen",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "Margin Updated",
   "perp_twap_active__title": "Active",
   "perp_twap_avg_filled_price__title": "Avg. Filled Price",
+  "perp_twap_child_order_size__title": "Per child order size",
   "perp_twap_duration__title": "Duration",
   "perp_twap_duration_helper__desc": "TWAP submits market slices over the selected duration. Hyperliquid controls slice timing and may reject very small slices.",
   "perp_twap_duration_range__msg": "TWAP duration must be {min}-{max} minutes",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "Margen actualizado",
   "perp_twap_active__title": "Activo",
   "perp_twap_avg_filled_price__title": "Precio medio ejecutado",
+  "perp_twap_child_order_size__title": "Tamano por suborden",
   "perp_twap_duration__title": "Duración",
   "perp_twap_duration_helper__desc": "TWAP envía porciones de mercado durante la duración seleccionada. Hyperliquid controla el tiempo de las porciones y puede rechazar porciones muy pequeñas.",
   "perp_twap_duration_range__msg": "La duración de TWAP debe ser de {min}-{max} minutos",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "Marge mise à jour",
   "perp_twap_active__title": "Actif",
   "perp_twap_avg_filled_price__title": "Prix moyen exécuté",
+  "perp_twap_child_order_size__title": "Taille par sous-ordre",
   "perp_twap_duration__title": "Durée",
   "perp_twap_duration_helper__desc": "TWAP soumet des fragments de marché sur la durée sélectionnée. Hyperliquid contrôle le timing des fragments et peut rejeter les fragments très petits.",
   "perp_twap_duration_range__msg": "La durée de TWAP doit être de {min}-{max} minutes",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "मार्जिन अपडेट किया गया",
   "perp_twap_active__title": "सक्रिय",
   "perp_twap_avg_filled_price__title": "औसत निष्पादन मूल्य",
+  "perp_twap_child_order_size__title": "प्रति चाइल्ड ऑर्डर आकार",
   "perp_twap_duration__title": "अवधि",
   "perp_twap_duration_helper__desc": "TWAP चयनित अवधि में मार्केट स्लाइस सबमिट करता है। Hyperliquid स्लाइस समय को नियंत्रित करता है और बहुत छोटे स्लाइस को अस्वीकार कर सकता है।",
   "perp_twap_duration_range__msg": "TWAP की अवधि {min}-{max} मिनट होनी चाहिए",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "Margin Diperbarui",
   "perp_twap_active__title": "Aktif",
   "perp_twap_avg_filled_price__title": "Harga eksekusi rata-rata",
+  "perp_twap_child_order_size__title": "Ukuran per order anak",
   "perp_twap_duration__title": "Durasi",
   "perp_twap_duration_helper__desc": "TWAP mengirimkan irisan pasar selama durasi yang dipilih. Hyperliquid mengontrol waktu irisan dan mungkin menolak irisan yang sangat kecil.",
   "perp_twap_duration_range__msg": "Durasi TWAP harus {min}-{max} menit",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "Margine aggiornato",
   "perp_twap_active__title": "Attivo",
   "perp_twap_avg_filled_price__title": "Prezzo medio eseguito",
+  "perp_twap_child_order_size__title": "Dimensione per sotto-ordine",
   "perp_twap_duration__title": "Durata",
   "perp_twap_duration_helper__desc": "TWAP invia frazioni di mercato durante la durata selezionata. Hyperliquid controlla il tempismo delle frazioni e può rifiutare frazioni molto piccole.",
   "perp_twap_duration_range__msg": "La durata di TWAP deve essere {min}-{max} minuti",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "マージンを更新しました",
   "perp_twap_active__title": "進行中",
   "perp_twap_avg_filled_price__title": "平均約定価格",
+  "perp_twap_child_order_size__title": "子注文ごとの注文サイズ",
   "perp_twap_duration__title": "期間",
   "perp_twap_duration_helper__desc": "TWAPは選択された期間にわたってマーケットスライスを送信します。Hyperliquidはスライスタイミングを制御し、非常に小さいスライスを拒否する場合があります。",
   "perp_twap_duration_range__msg": "TWAPの期間は{min}-{max}分である必要があります",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "마진이 업데이트됨",
   "perp_twap_active__title": "진행 중",
   "perp_twap_avg_filled_price__title": "평균 체결 가격",
+  "perp_twap_child_order_size__title": "하위 주문당 주문 규모",
   "perp_twap_duration__title": "기간",
   "perp_twap_duration_helper__desc": "TWAP는 선택한 기간 동안 시장 분할 주문을 제출합니다. Hyperliquid는 분할 시기를 제어하며 매우 작은 분할은 거부할 수 있습니다.",
   "perp_twap_duration_range__msg": "TWAP 기간은 {min}-{max} 분이어야 합니다",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "Margem Atualizada",
   "perp_twap_active__title": "Ativo",
   "perp_twap_avg_filled_price__title": "Preço médio executado",
+  "perp_twap_child_order_size__title": "Tamanho por subordem",
   "perp_twap_duration__title": "Duração",
   "perp_twap_duration_helper__desc": "TWAP envia fatias de mercado durante a duração selecionada. Hyperliquid controla o tempo das fatias e pode rejeitar fatias muito pequenas.",
   "perp_twap_duration_range__msg": "A duração de TWAP deve ser de {min}-{max} minutos",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "Margem Atualizada",
   "perp_twap_active__title": "Ativo",
   "perp_twap_avg_filled_price__title": "Preço médio executado",
+  "perp_twap_child_order_size__title": "Tamanho por subordem",
   "perp_twap_duration__title": "Duração",
   "perp_twap_duration_helper__desc": "TWAP envia fatias de mercado durante a duração selecionada. Hyperliquid controla o tempo das fatias e pode rejeitar fatias muito pequenas.",
   "perp_twap_duration_range__msg": "A duração de TWAP deve ser de {min}-{max} minutos",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "Маржа обновлена",
   "perp_twap_active__title": "Активно",
   "perp_twap_avg_filled_price__title": "Средняя цена исполнения",
+  "perp_twap_child_order_size__title": "Размер дочернего ордера",
   "perp_twap_duration__title": "Длительность",
   "perp_twap_duration_helper__desc": "TWAP отправляет рыночные сделки за выбранный период. Hyperliquid управляет временем сделок и может отклонять очень небольшие сделки.",
   "perp_twap_duration_range__msg": "Продолжительность для TWAP должна быть от {min} до {max} минут",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "อัปเดตมาร์จิ้นแล้ว",
   "perp_twap_active__title": "กำลังทำงาน",
   "perp_twap_avg_filled_price__title": "ราคาเฉลี่ยที่จับคู่",
+  "perp_twap_child_order_size__title": "ขนาดต่อคาสั่งย่อย",
   "perp_twap_duration__title": "ระยะเวลา",
   "perp_twap_duration_helper__desc": "TWAP ส่งชิ้นส่วนตลาดในระยะเวลาที่เลือก Hyperliquid ควบคุมเวลาชิ้นส่วนและอาจปฏิเสธชิ้นส่วนที่เล็กมาก",
   "perp_twap_duration_range__msg": "ระยะเวลา TWAP ต้องอยู่ระหว่าง {min}-{max} นาที",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "Маржу оновлено",
   "perp_twap_active__title": "Активно",
   "perp_twap_avg_filled_price__title": "Середня ціна виконання",
+  "perp_twap_child_order_size__title": "Розмір дочірнього ордера",
   "perp_twap_duration__title": "Тривалість",
   "perp_twap_duration_helper__desc": "TWAP надсилає ринкові порції протягом обраного періоду. Hyperliquid керує часом порцій і може відхилити дуже маленькі порції.",
   "perp_twap_duration_range__msg": "Тривалість TWAP повинна бути {min}-{max} хвилин",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "Đã cập nhật biên lợi nhuận",
   "perp_twap_active__title": "Đang hoạt động",
   "perp_twap_avg_filled_price__title": "Giá khớp trung bình",
+  "perp_twap_child_order_size__title": "Kich thuoc moi lenh con",
   "perp_twap_duration__title": "Thời lượng",
   "perp_twap_duration_helper__desc": "TWAP gửi các phân đoạn thị trường trong thời gian đã chọn. Hyperliquid điều khiển thời gian phân đoạn và có thể từ chối các phân đoạn rất nhỏ.",
   "perp_twap_duration_range__msg": "Thời lượng TWAP phải là {min}-{max} phút",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "保证金已更新",
   "perp_twap_active__title": "当前委托",
   "perp_twap_avg_filled_price__title": "成交均价",
+  "perp_twap_child_order_size__title": "每笔子订单金额",
   "perp_twap_duration__title": "执行时长",
   "perp_twap_duration_helper__desc": "分时委托会在所选时长内拆分市价委托提交。Hyperliquid 会控制分片时机，过小的分片可能被拒绝。",
   "perp_twap_duration_range__msg": "分时委托时长需为 {min}-{max} 分钟",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -3168,7 +3168,7 @@
   "perp_market_info_total_supply_tooltip__desc": "当前已发行的代币总量。",
   "perp_market_liquidation__title": "市价清算",
   "perp_no__title": "否",
-  "perp_no_active_twap__title": "暂无当前分时委托",
+  "perp_no_active_twap__title": "暂无分时委托",
   "perp_no_twap_fill_history__title": "暂无分时委托成交历史",
   "perp_no_twap_history__title": "暂无分时委托历史",
   "perp_order_trigger_limit": "限价止盈止损",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -3168,7 +3168,7 @@
   "perp_market_info_total_supply_tooltip__desc": "Total number of tokens currently issued.",
   "perp_market_liquidation__title": "市價清算",
   "perp_no__title": "No",
-  "perp_no_active_twap__title": "暫無當前分時委託",
+  "perp_no_active_twap__title": "暫無分時委託",
   "perp_no_twap_fill_history__title": "No TWAP fill history",
   "perp_no_twap_history__title": "No TWAP history",
   "perp_order_trigger_limit": "限價止盈止損",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "保证金已更新",
   "perp_twap_active__title": "進行中",
   "perp_twap_avg_filled_price__title": "平均成交價格",
+  "perp_twap_child_order_size__title": "每筆子訂單金額",
   "perp_twap_duration__title": "持續時間",
   "perp_twap_duration_helper__desc": "TWAP submits market slices over the selected duration. Hyperliquid controls slice timing and may reject very small slices.",
   "perp_twap_duration_range__msg": "TWAP duration must be {min}-{max} minutes",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -3168,7 +3168,7 @@
   "perp_market_info_total_supply_tooltip__desc": "Total number of tokens currently issued.",
   "perp_market_liquidation__title": "市價清算",
   "perp_no__title": "No",
-  "perp_no_active_twap__title": "暫無當前分時委託",
+  "perp_no_active_twap__title": "暫無分時委託",
   "perp_no_twap_fill_history__title": "No TWAP fill history",
   "perp_no_twap_history__title": "No TWAP history",
   "perp_order_trigger_limit": "限價止盈止損",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -3286,6 +3286,7 @@
   "perp_trading_adjust_margin_updated": "保证金已更新",
   "perp_twap_active__title": "進行中",
   "perp_twap_avg_filled_price__title": "平均成交價格",
+  "perp_twap_child_order_size__title": "每筆子訂單金額",
   "perp_twap_duration__title": "持續時間",
   "perp_twap_duration_helper__desc": "TWAP submits market slices over the selected duration. Hyperliquid controls slice timing and may reject very small slices.",
   "perp_twap_duration_range__msg": "TWAP duration must be {min}-{max} minutes",


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55898](https://onekeyhq.atlassian.net/browse/OK-55898) [OK-55900](https://onekeyhq.atlassian.net/browse/OK-55900)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- simplify the algo order confirm modal for scale and TWAP flows to better match the lighter HL-style information hierarchy
- remove non-essential scale form helper messages so the panel only surfaces actual validation errors
- remove the desktop perp trading panel's inner scroll so the page scroll stays unified
- polish the mobile TWAP/open-orders empty states and update the TWAP empty-state copy via i18n

## Intent & Context
The user wanted the scale and TWAP order surfaces to feel less noisy and closer to HL, with fewer non-essential fields and less helper copy blocking the flow. During follow-up verification, we also confirmed the desktop perp trading column was still scrolling internally, so this PR now includes the missing layout fix for that issue. In the later mobile pass, we also aligned the TWAP empty states with the simpler basic-order empty-state presentation.

## Root Cause
- The existing algo order confirmation and scale form surfaced too many secondary details at once, including helper summaries and preview hints that were technically correct but visually distracting.
- The earlier desktop perp layout refactor still kept an inner `overflowY: auto` container around the trading panel, so the right column could continue scrolling independently.
- The mobile TWAP-related empty states used heavier visuals and inconsistent spacing, which made them feel visually disconnected from the basic-order empty state.

## Design Decisions
- Kept the existing OneKey visual system instead of introducing new card structures or a new layout language.
- Reduced the scale confirm modal to core fields only and removed preview, order-count, and TIF display from confirmation.
- Simplified the scale form by suppressing helper-only hints while preserving real validation paths.
- Moved TWAP randomization to the final row in the confirm modal so the order reads more naturally.
- Fixed the desktop layout by removing the right-panel inner scroll container instead of redesigning the entire page structure.
- For mobile TWAP empty states, reused the lighter basic-order empty-state rhythm instead of keeping the illustration-and-button treatment.

## Changes Detail
- `OrderConfirmModal.tsx`: simplified scale and TWAP confirmation fields, removed extra preview/detail blocks, reordered TWAP randomization, and cleaned up an empty import that broke oxlint.
- `PerpTradingForm.tsx`: removed scale helper text for incomplete price range, missing size, preview summary states, and the order-count range hint.
- `PerpDesktopLayout.web.tsx`: removed the inner scroll container from the desktop trading panel and switched the panel wrapper to `minHeight` so the outer page handles scrolling.
- `PerpOpenOrdersList.tsx` / `PerpTwapList.tsx`: simplified mobile TWAP empty states, removed the illustration/button treatment on mobile, aligned spacing with the basic-order empty state, and kept the trading guide as a lightweight underlined action.
- `packages/shared/src/locale/json/zh_CN.json` / `zh_TW.json` / `zh_HK.json`: updated the TWAP empty-state copy to `暂无分时委托` / `暫無分時委託`.

## Related Issues
- [OK-55959](https://onekeyhq.atlassian.net/browse/OK-55959)
- [OK-55939](https://onekeyhq.atlassian.net/browse/OK-55939)
- [OK-55763](https://onekeyhq.atlassian.net/browse/OK-55763)
- [OK-55898](https://onekeyhq.atlassian.net/browse/OK-55898)
- [OK-55900](https://onekeyhq.atlassian.net/browse/OK-55900)

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web, Desktop, Mobile
- **Risk Areas**: Perps algo order form messaging, confirm-modal field ordering, desktop trading-column layout, mobile TWAP empty-state presentation

## Test plan
- [ ] Verify scale order form no longer shows helper-only hints for incomplete range, missing size, preview summary, or order-count range.
- [ ] Verify scale order confirm modal only shows the reduced field set requested by product.
- [ ] Verify TWAP confirm modal shows randomization on the last row and no longer shows the removed fields.
- [ ] Verify the desktop perp trading column no longer scrolls independently and the full page scroll remains unified.
- [ ] Verify mobile `当前委托 -> 分时委托` and `分时委托` empty states align with the basic-order empty-state spacing and interaction style.


[OK-55959]: https://onekeyhq.atlassian.net/browse/OK-55959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55939]: https://onekeyhq.atlassian.net/browse/OK-55939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55763]: https://onekeyhq.atlassian.net/browse/OK-55763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55898]: https://onekeyhq.atlassian.net/browse/OK-55898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55900]: https://onekeyhq.atlassian.net/browse/OK-55900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ