### PR TITLE
fix: stabilize swap cold start tokens

### DIFF
--- a/packages/kit/src/components/TokenListView/TokenActionsView.tsx
+++ b/packages/kit/src/components/TokenListView/TokenActionsView.tsx
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 
 import { Button, XStack } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EModalRoutes, EModalSwapRoutes } from '@onekeyhq/shared/src/routes';
@@ -83,9 +84,28 @@ function TokenActionsView(props: IProps) {
   const navigation = useAppNavigation();
 
   const handleTokenOnSwap = useCallback(() => {
+    const networkId = activeToken.networkId ?? activeAccount?.network?.id ?? '';
+    const isBtcNativeToken =
+      networkId === getNetworkIdsMap().btc &&
+      activeToken.isNative &&
+      activeToken.symbol?.toUpperCase() === 'BTC' &&
+      !activeToken.address;
+    const importFromToken = !isBtcNativeToken
+      ? {
+          contractAddress: activeToken.address,
+          symbol: activeToken.symbol,
+          networkId,
+          isNative: activeToken.isNative,
+          decimals: activeToken.decimals,
+          name: activeToken.name,
+          logoURI: activeToken.logoURI,
+          networkLogoURI: network?.logoURI ?? activeAccount?.network?.logoURI,
+        }
+      : undefined;
+
     defaultLogger.wallet.walletActions.actionTrade({
       walletType: activeAccount?.wallet?.type ?? '',
-      networkId: activeToken.networkId ?? activeAccount?.network?.id ?? '',
+      networkId,
       source: 'homeTokenList',
       tradeType: ESwapTabSwitchType.SWAP,
       isSoftwareWalletOnlyUser,
@@ -93,18 +113,8 @@ function TokenActionsView(props: IProps) {
     navigation.pushModal(EModalRoutes.SwapModal, {
       screen: EModalSwapRoutes.SwapMainLand,
       params: {
-        importNetworkId:
-          activeToken.networkId ?? activeAccount?.network?.id ?? '',
-        importFromToken: {
-          contractAddress: activeToken.address,
-          symbol: activeToken.symbol,
-          networkId: activeToken.networkId ?? activeAccount?.network?.id ?? '',
-          isNative: activeToken.isNative,
-          decimals: activeToken.decimals,
-          name: activeToken.name,
-          logoURI: activeToken.logoURI,
-          networkLogoURI: network?.logoURI ?? activeAccount?.network?.logoURI,
-        },
+        importNetworkId: networkId,
+        importFromToken,
         importDeriveType: deriveType,
         swapTabSwitchType: ESwapTabSwitchType.SWAP,
         swapSource: ESwapSource.WALLET_HOME_TOKEN_LIST,

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -508,7 +508,6 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         toToken,
       });
       if (needChangeToToken !== null && !disableCheckToToken) {
-        set(swapSelectToTokenAtom(), undefined);
         set(swapSelectFromTokenAtom(), token);
         set(swapSelectToTokenAtom(), needChangeToToken);
       } else {

--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -164,6 +164,11 @@ export const {
 });
 
 export const {
+  atom: swapInitialSelectedTokensSyncedAtom,
+  use: useSwapInitialSelectedTokensSyncedAtom,
+} = contextAtom<boolean>(false);
+
+export const {
   atom: swapSwapModalSelectFromTokenAtom,
   use: useSwapModalSelectFromTokenAtom,
 } = contextAtom<ISwapToken | undefined>(undefined);

--- a/packages/kit/src/views/Swap/hooks/useSwapColdStartDisplayTokens.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapColdStartDisplayTokens.test.ts
@@ -1,0 +1,118 @@
+import { CONTEXT_ATOM_COLD_START_CACHE_KEYS } from '@onekeyhq/shared/src/consts/jotaiConsts';
+import { EAppSyncStorageKeys } from '@onekeyhq/shared/src/storage/syncStorageKeys';
+import type { ISwapSelectedTokensColdStartContext } from '@onekeyhq/shared/src/utils/swapColdStartCacheSnapshotUtils';
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
+
+import { getSwapColdStartDisplayTokensFromGlobalSnapshot } from './useSwapColdStartDisplayTokens';
+
+const SWAP_STORE_SCOPE_KEY = 'store:swap';
+const ACCOUNT_SELECTOR_HOME_SCOPE_KEY = 'store:accountSelector@home';
+
+function scopedKey(scopeKey: string, cacheKey: string) {
+  return `${scopeKey}::${cacheKey}`;
+}
+
+function setGlobalSnapshot(snapshot: Record<string, unknown>) {
+  const globalCache = globalThis as typeof globalThis & {
+    __ONEKEY_COLD_START_CACHE_MAP__?: Map<string, unknown>;
+    __ONEKEY_CTX_ATOM_SNAPSHOT__?: Record<string, unknown>;
+  };
+
+  globalCache.__ONEKEY_COLD_START_CACHE_MAP__ = new Map([
+    [EAppSyncStorageKeys.onekey_jotai_context_atoms_snapshot, snapshot],
+  ]);
+  globalCache.__ONEKEY_CTX_ATOM_SNAPSHOT__ = undefined;
+}
+
+function clearGlobalSnapshot() {
+  const globalCache = globalThis as typeof globalThis & {
+    __ONEKEY_COLD_START_CACHE_MAP__?: Map<string, unknown>;
+    __ONEKEY_CTX_ATOM_SNAPSHOT__?: Record<string, unknown>;
+  };
+
+  delete globalCache.__ONEKEY_COLD_START_CACHE_MAP__;
+  delete globalCache.__ONEKEY_CTX_ATOM_SNAPSHOT__;
+}
+
+function buildHomeSelectedAccount(networkId: string) {
+  return {
+    walletId: 'wallet-1',
+    indexedAccountId: 'indexed-account-1',
+    networkId,
+    deriveType: 'default',
+  };
+}
+
+describe('getSwapColdStartDisplayTokensFromGlobalSnapshot', () => {
+  afterEach(() => {
+    clearGlobalSnapshot();
+  });
+
+  it('uses home-network defaults when no selected token snapshot exists yet', () => {
+    setGlobalSnapshot({
+      [scopedKey(
+        ACCOUNT_SELECTOR_HOME_SCOPE_KEY,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+      )]: {
+        0: buildHomeSelectedAccount('sol--101'),
+      },
+    });
+
+    expect(getSwapColdStartDisplayTokensFromGlobalSnapshot()).toEqual({
+      fromToken: expect.objectContaining({
+        networkId: 'sol--101',
+        symbol: 'SOL',
+      }),
+      toToken: expect.objectContaining({
+        networkId: 'sol--101',
+        symbol: 'USDC',
+      }),
+    });
+  });
+
+  it('falls back to home-network defaults when stale selected tokens are invalidated', () => {
+    setGlobalSnapshot({
+      [scopedKey(
+        ACCOUNT_SELECTOR_HOME_SCOPE_KEY,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+      )]: {
+        0: buildHomeSelectedAccount('sol--101'),
+      },
+      [scopedKey(
+        SWAP_STORE_SCOPE_KEY,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectedTokensColdStartContextAtom,
+      )]: {
+        accountKey: 'wallet-1|indexed-account-1|default',
+        networkId: 'evm--1',
+        swapType: ESwapTabSwitchType.SWAP,
+        updatedAt: 1,
+      } satisfies ISwapSelectedTokensColdStartContext,
+      [scopedKey(
+        SWAP_STORE_SCOPE_KEY,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectFromTokenAtom,
+      )]: {
+        networkId: 'evm--1',
+        symbol: 'ETH',
+      } satisfies Partial<ISwapToken>,
+      [scopedKey(
+        SWAP_STORE_SCOPE_KEY,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectToTokenAtom,
+      )]: {
+        networkId: 'evm--1',
+        symbol: 'USDC',
+      } satisfies Partial<ISwapToken>,
+    });
+
+    expect(getSwapColdStartDisplayTokensFromGlobalSnapshot()).toEqual({
+      fromToken: expect.objectContaining({
+        networkId: 'sol--101',
+        symbol: 'SOL',
+      }),
+      toToken: expect.objectContaining({
+        networkId: 'sol--101',
+        symbol: 'USDC',
+      }),
+    });
+  });
+});

--- a/packages/kit/src/views/Swap/hooks/useSwapColdStartDisplayTokens.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapColdStartDisplayTokens.ts
@@ -1,0 +1,341 @@
+import { useRef } from 'react';
+
+import { CONTEXT_ATOM_COLD_START_CACHE_KEYS } from '@onekeyhq/shared/src/consts/jotaiConsts';
+import { EAppSyncStorageKeys } from '@onekeyhq/shared/src/storage/syncStorageKeys';
+import { parseColdStartSnapshotRaw } from '@onekeyhq/shared/src/utils/coldStartCacheSnapshotUtils';
+import {
+  getSwapColdStartSelectedTokensFromSnapshot,
+  isSwapColdStartAllNetworkContextNetworkId,
+} from '@onekeyhq/shared/src/utils/swapColdStartCacheSnapshotUtils';
+import type { ISwapSelectedTokensColdStartContext } from '@onekeyhq/shared/src/utils/swapColdStartCacheSnapshotUtils';
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+
+import { buildSwapDefaultSelectedTokensFromHomeAccount } from '../utils/swapColdStartTokenCacheUtils';
+
+const COLD_START_SCOPED_KEY_SEPARATOR = '::';
+const SWAP_STORE_SCOPE_KEY = 'store:swap';
+const ACCOUNT_SELECTOR_HOME_SCOPE_KEY = 'store:accountSelector@home';
+const ACCOUNT_SELECTOR_SWAP_SCOPE_KEY = 'store:accountSelector@swap';
+
+type IGlobalColdStartCache = typeof globalThis & {
+  __ONEKEY_COLD_START_CACHE_MAP__?: Map<string, unknown>;
+  __ONEKEY_CTX_ATOM_SNAPSHOT__?: Record<string, unknown>;
+};
+
+type ISelectedAccountSnapshot = {
+  walletId?: string;
+  indexedAccountId?: string;
+  othersWalletAccountId?: string;
+  deriveType?: string;
+  networkId?: string;
+};
+
+type ISelectedAccountsSnapshot = Record<
+  string | number,
+  ISelectedAccountSnapshot | undefined
+>;
+
+type IDisplayTokens = {
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+};
+
+function isSnapshotRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function buildContextAtomSnapshotKey({
+  coldStartScopeKey,
+  coldStartCacheKey,
+}: {
+  coldStartScopeKey: string;
+  coldStartCacheKey: string;
+}) {
+  return `${coldStartScopeKey}${COLD_START_SCOPED_KEY_SEPARATOR}${coldStartCacheKey}`;
+}
+
+function getSnapshotValue<T>({
+  snapshot,
+  coldStartScopeKey,
+  coldStartCacheKey,
+}: {
+  snapshot: Record<string, unknown>;
+  coldStartScopeKey: string;
+  coldStartCacheKey: string;
+}) {
+  return snapshot[
+    buildContextAtomSnapshotKey({
+      coldStartScopeKey,
+      coldStartCacheKey,
+    })
+  ] as T | null | undefined;
+}
+
+function getSelectedAccountFromSnapshot({
+  snapshot,
+  coldStartScopeKey,
+}: {
+  snapshot: Record<string, unknown>;
+  coldStartScopeKey: string;
+}) {
+  const selectedAccounts = getSnapshotValue<ISelectedAccountsSnapshot>({
+    snapshot,
+    coldStartScopeKey,
+    coldStartCacheKey: CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+  });
+  return selectedAccounts?.[0] ?? selectedAccounts?.['0'];
+}
+
+function buildSelectedAccountKey(selectedAccount?: ISelectedAccountSnapshot) {
+  const walletId = selectedAccount?.walletId ?? '';
+  const accountId =
+    selectedAccount?.indexedAccountId ??
+    selectedAccount?.othersWalletAccountId ??
+    '';
+  const deriveType = selectedAccount?.deriveType ?? '';
+
+  if (!walletId && !accountId) {
+    return undefined;
+  }
+
+  return [walletId, accountId, deriveType].join('|');
+}
+
+function hasSwapSelectedTokenSnapshot(snapshot: Record<string, unknown>) {
+  return Object.keys(snapshot).some(
+    (key) =>
+      key.endsWith(
+        `::${CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectFromTokenAtom}`,
+      ) ||
+      key.endsWith(
+        `::${CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectToTokenAtom}`,
+      ),
+  );
+}
+
+function hasHomeSelectedAccountSnapshot(snapshot: Record<string, unknown>) {
+  return Boolean(
+    getSelectedAccountFromSnapshot({
+      snapshot,
+      coldStartScopeKey: ACCOUNT_SELECTOR_HOME_SCOPE_KEY,
+    })?.networkId,
+  );
+}
+
+function getColdStartSnapshotCandidatesFromGlobal() {
+  const globalCache = globalThis as IGlobalColdStartCache;
+  const snapshots: Record<string, unknown>[] = [];
+
+  const rawSnapshot = globalCache.__ONEKEY_COLD_START_CACHE_MAP__?.get(
+    EAppSyncStorageKeys.onekey_jotai_context_atoms_snapshot,
+  );
+  if (typeof rawSnapshot === 'string') {
+    const snapshot = parseColdStartSnapshotRaw(rawSnapshot);
+    if (
+      isSnapshotRecord(snapshot) &&
+      (hasSwapSelectedTokenSnapshot(snapshot) ||
+        hasHomeSelectedAccountSnapshot(snapshot))
+    ) {
+      snapshots.push(snapshot);
+    }
+  } else if (
+    isSnapshotRecord(rawSnapshot) &&
+    (hasSwapSelectedTokenSnapshot(rawSnapshot) ||
+      hasHomeSelectedAccountSnapshot(rawSnapshot))
+  ) {
+    snapshots.push(rawSnapshot);
+  }
+
+  if (
+    isSnapshotRecord(globalCache.__ONEKEY_CTX_ATOM_SNAPSHOT__) &&
+    (hasSwapSelectedTokenSnapshot(globalCache.__ONEKEY_CTX_ATOM_SNAPSHOT__) ||
+      hasHomeSelectedAccountSnapshot(globalCache.__ONEKEY_CTX_ATOM_SNAPSHOT__))
+  ) {
+    snapshots.push(globalCache.__ONEKEY_CTX_ATOM_SNAPSHOT__);
+  }
+
+  return snapshots;
+}
+
+function shouldUseRawSwapSelectedTokens(snapshot: Record<string, unknown>) {
+  const homeSelectedAccount = getSelectedAccountFromSnapshot({
+    snapshot,
+    coldStartScopeKey: ACCOUNT_SELECTOR_HOME_SCOPE_KEY,
+  });
+  const swapSelectedAccount = getSelectedAccountFromSnapshot({
+    snapshot,
+    coldStartScopeKey: ACCOUNT_SELECTOR_SWAP_SCOPE_KEY,
+  });
+  const cachedContext = getSnapshotValue<ISwapSelectedTokensColdStartContext>({
+    snapshot,
+    coldStartScopeKey: SWAP_STORE_SCOPE_KEY,
+    coldStartCacheKey:
+      CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectedTokensColdStartContextAtom,
+  });
+  const homeAccountKey = buildSelectedAccountKey(homeSelectedAccount);
+  if (!homeSelectedAccount?.networkId || !homeAccountKey) {
+    return false;
+  }
+
+  if (
+    cachedContext?.accountKey === homeAccountKey &&
+    cachedContext.networkId === homeSelectedAccount.networkId
+  ) {
+    return true;
+  }
+
+  const swapAccountKey = buildSelectedAccountKey(swapSelectedAccount);
+  const isSameOwnerAllNetworksHome =
+    isSwapColdStartAllNetworkContextNetworkId(homeSelectedAccount.networkId) &&
+    homeAccountKey === swapAccountKey;
+  if (!isSameOwnerAllNetworksHome) {
+    return false;
+  }
+
+  if (!cachedContext) {
+    return true;
+  }
+
+  return (
+    cachedContext.accountKey === swapAccountKey &&
+    cachedContext.networkId === swapSelectedAccount?.networkId
+  );
+}
+
+function getRawSwapSelectedTokensFromSnapshot(
+  snapshot: Record<string, unknown>,
+): IDisplayTokens {
+  if (!shouldUseRawSwapSelectedTokens(snapshot)) {
+    return {};
+  }
+
+  return {
+    fromToken:
+      getSnapshotValue<ISwapToken>({
+        snapshot,
+        coldStartScopeKey: SWAP_STORE_SCOPE_KEY,
+        coldStartCacheKey:
+          CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectFromTokenAtom,
+      }) ?? undefined,
+    toToken:
+      getSnapshotValue<ISwapToken>({
+        snapshot,
+        coldStartScopeKey: SWAP_STORE_SCOPE_KEY,
+        coldStartCacheKey:
+          CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectToTokenAtom,
+      }) ?? undefined,
+  };
+}
+
+function getDefaultSwapSelectedTokensFromHomeSnapshot(
+  snapshot: Record<string, unknown>,
+): IDisplayTokens {
+  const homeSelectedAccount = getSelectedAccountFromSnapshot({
+    snapshot,
+    coldStartScopeKey: ACCOUNT_SELECTOR_HOME_SCOPE_KEY,
+  });
+  const defaultTokens = buildSwapDefaultSelectedTokensFromHomeAccount({
+    homeSelectedAccount,
+  });
+
+  return {
+    fromToken: defaultTokens?.fromToken,
+    toToken: defaultTokens?.toToken,
+  };
+}
+
+function hasDisplayToken(tokens: IDisplayTokens) {
+  return Boolean(tokens.fromToken?.symbol || tokens.toToken?.symbol);
+}
+
+export function getSwapColdStartDisplayTokensFromGlobalSnapshot() {
+  const displayTokens: {
+    fromToken?: ISwapToken;
+    toToken?: ISwapToken;
+  } = {};
+
+  for (const snapshot of getColdStartSnapshotCandidatesFromGlobal()) {
+    const normalizedTokens =
+      getSwapColdStartSelectedTokensFromSnapshot<ISwapToken>(snapshot);
+    const rawTokens = getRawSwapSelectedTokensFromSnapshot(snapshot);
+    const defaultTokens =
+      getDefaultSwapSelectedTokensFromHomeSnapshot(snapshot);
+    let candidateTokens: IDisplayTokens = defaultTokens;
+    if (hasDisplayToken(normalizedTokens)) {
+      candidateTokens = normalizedTokens;
+    } else if (hasDisplayToken(rawTokens)) {
+      candidateTokens = rawTokens;
+    }
+
+    if (!displayTokens.fromToken && candidateTokens.fromToken?.symbol) {
+      displayTokens.fromToken = candidateTokens.fromToken;
+    }
+    if (!displayTokens.toToken && candidateTokens.toToken?.symbol) {
+      displayTokens.toToken = candidateTokens.toToken;
+    }
+    if (displayTokens.fromToken && displayTokens.toToken) {
+      break;
+    }
+  }
+
+  return displayTokens;
+}
+
+export function useSwapColdStartDisplayTokens({
+  fromToken,
+  toToken,
+}: {
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+}) {
+  const hasResolvedFromTokenRef = useRef(Boolean(fromToken?.symbol));
+  const hasResolvedToTokenRef = useRef(Boolean(toToken?.symbol));
+  const coldStartDisplayTokensRef = useRef<
+    | ReturnType<typeof getSwapColdStartDisplayTokensFromGlobalSnapshot>
+    | undefined
+  >(undefined);
+
+  if (fromToken?.symbol) {
+    hasResolvedFromTokenRef.current = true;
+  }
+  if (toToken?.symbol) {
+    hasResolvedToTokenRef.current = true;
+  }
+
+  if (
+    !coldStartDisplayTokensRef.current ||
+    (!fromToken?.symbol &&
+      !hasResolvedFromTokenRef.current &&
+      !coldStartDisplayTokensRef.current.fromToken) ||
+    (!toToken?.symbol &&
+      !hasResolvedToTokenRef.current &&
+      !coldStartDisplayTokensRef.current.toToken)
+  ) {
+    coldStartDisplayTokensRef.current =
+      getSwapColdStartDisplayTokensFromGlobalSnapshot();
+  }
+  const coldStartDisplayTokens = coldStartDisplayTokensRef.current;
+
+  const displayTokens = {
+    displayFromToken:
+      (fromToken?.symbol ? fromToken : undefined) ||
+      (hasResolvedFromTokenRef.current
+        ? undefined
+        : coldStartDisplayTokens.fromToken),
+    displayToToken:
+      (toToken?.symbol ? toToken : undefined) ||
+      (hasResolvedToTokenRef.current
+        ? undefined
+        : coldStartDisplayTokens.toToken),
+  };
+  const isInitialFromTokenSelectionPending =
+    !hasResolvedFromTokenRef.current && !displayTokens.displayFromToken?.symbol;
+  const isInitialToTokenSelectionPending =
+    !hasResolvedToTokenRef.current && !displayTokens.displayToToken?.symbol;
+
+  return {
+    ...displayTokens,
+    isInitialFromTokenSelectionPending,
+    isInitialToTokenSelectionPending,
+  };
+}

--- a/packages/kit/src/views/Swap/hooks/useSwapColdStartDisplayTokens.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapColdStartDisplayTokens.ts
@@ -283,9 +283,11 @@ export function getSwapColdStartDisplayTokensFromGlobalSnapshot() {
 
 export function useSwapColdStartDisplayTokens({
   fromToken,
+  initialSelectedTokensSynced = false,
   toToken,
 }: {
   fromToken?: ISwapToken;
+  initialSelectedTokensSynced?: boolean;
   toToken?: ISwapToken;
 }) {
   const hasResolvedFromTokenRef = useRef(Boolean(fromToken?.symbol));
@@ -299,6 +301,10 @@ export function useSwapColdStartDisplayTokens({
     hasResolvedFromTokenRef.current = true;
   }
   if (toToken?.symbol) {
+    hasResolvedToTokenRef.current = true;
+  }
+  if (initialSelectedTokensSynced) {
+    hasResolvedFromTokenRef.current = true;
     hasResolvedToTokenRef.current = true;
   }
 

--- a/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
@@ -62,7 +62,6 @@ import {
   isSwapColdStartAllNetworkContextNetworkId,
   isSwapSelectedTokensColdStartContextMatched,
   shouldClearSwapSelectedTokensBeforeHomeAccountSync,
-  shouldHandleSwapColdStartHomeAccountUpdate,
   shouldSyncSwapSelectedAccountOnHomeAccountUpdate,
 } from '../utils/swapColdStartTokenCacheUtils';
 import {
@@ -385,7 +384,16 @@ export function useSwapInit(params?: ISwapInitParams) {
         })
       ) {
         clearedSelectedTokens = true;
-        clearSelectedTokensColdStartCache({ resetSwapType: true });
+        const homeNetworkDefaultTokens = homeSelectedAccount.networkId
+          ? swapDefaultSetTokens[homeSelectedAccount.networkId]
+          : undefined;
+        const shouldPreserveLimitTabWithoutDefaultTokens =
+          swapTypeSwitchRef.current === ESwapTabSwitchType.LIMIT &&
+          !homeNetworkDefaultTokens?.limitFromToken &&
+          !homeNetworkDefaultTokens?.limitToToken;
+        clearSelectedTokensColdStartCache({
+          resetSwapType: !shouldPreserveLimitTabWithoutDefaultTokens,
+        });
       }
       await updateSelectedAccount({
         updateMeta: {
@@ -416,7 +424,7 @@ export function useSwapInit(params?: ISwapInitParams) {
   useEffect(() => {
     const handleAccountSelectorSelectedAccountUpdate = (
       eventPayload: Parameters<
-        typeof shouldHandleSwapColdStartHomeAccountUpdate
+        typeof shouldSyncSwapSelectedAccountOnHomeAccountUpdate
       >[0]['eventPayload'],
     ) => {
       if (
@@ -425,15 +433,24 @@ export function useSwapInit(params?: ISwapInitParams) {
       ) {
         return;
       }
-      if (
-        shouldHandleSwapColdStartHomeAccountUpdate({
-          cachedContext: selectedTokensColdStartContextRef.current,
-          eventPayload,
-          initialSelectedTokensSynced: initialSelectedTokensSyncedRef.current,
-        })
-      ) {
-        void syncSwapSelectedAccountFromHome(eventPayload.selectedAccount);
-      }
+      void syncSwapSelectedAccountFromHome(eventPayload.selectedAccount).then(
+        (result) => {
+          if (!result.synced) {
+            return;
+          }
+          const homeNetworkDefaultTokens = result.homeSelectedAccount.networkId
+            ? swapDefaultSetTokens[result.homeSelectedAccount.networkId]
+            : undefined;
+          if (
+            result.clearedSelectedTokens &&
+            swapTypeSwitchRef.current === ESwapTabSwitchType.LIMIT &&
+            !homeNetworkDefaultTokens?.limitFromToken &&
+            !homeNetworkDefaultTokens?.limitToToken
+          ) {
+            markInitialSelectedTokensSynced();
+          }
+        },
+      );
     };
 
     appEventBus.on(
@@ -446,7 +463,7 @@ export function useSwapInit(params?: ISwapInitParams) {
         handleAccountSelectorSelectedAccountUpdate,
       );
     };
-  }, [syncSwapSelectedAccountFromHome]);
+  }, [markInitialSelectedTokensSynced, syncSwapSelectedAccountFromHome]);
 
   useEffect(() => {
     if (hasSyncedSwapSelectedAccountFromHomeStorageRef.current) {

--- a/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
@@ -60,8 +60,10 @@ import {
   buildSwapSelectedTokensColdStartContext,
   getSelectedTokensColdStartLimitSupport,
   getSwapSelectedTokensColdStartContextNetworkId,
+  getSwapTokenSupportTypes,
   isSwapColdStartAllNetworkContextNetworkId,
   isSwapSelectedTokensColdStartContextMatched,
+  isSwapTokenSupportedBySwapType,
   shouldClearSwapSelectedTokensBeforeHomeAccountSync,
   shouldSyncSwapSelectedAccountOnHomeAccountUpdate,
 } from '../utils/swapColdStartTokenCacheUtils';
@@ -788,21 +790,7 @@ export function useSwapInit(params?: ISwapInitParams) {
 
   const checkSupportTokenSwapType = useCallback(
     (token: ISwapToken, enableSwitchAction?: boolean) => {
-      const supportNet = swapNetworks.find(
-        (net) => net.networkId === token.networkId,
-      );
-      let supportTypes: ESwapTabSwitchType[] = [];
-      if (supportNet) {
-        if (supportNet.supportSingleSwap) {
-          supportTypes = [...supportTypes, ESwapTabSwitchType.SWAP];
-        }
-        if (supportNet.supportCrossChainSwap) {
-          supportTypes = [...supportTypes, ESwapTabSwitchType.BRIDGE];
-        }
-        if (supportNet.supportLimit) {
-          supportTypes = [...supportTypes, ESwapTabSwitchType.LIMIT];
-        }
-      }
+      const supportTypes = getSwapTokenSupportTypes({ token, swapNetworks });
       if (!params?.swapTabSwitchType && enableSwitchAction) {
         if (
           supportTypes.length > 0 &&
@@ -905,41 +893,47 @@ export function useSwapInit(params?: ISwapInitParams) {
           (net) => net.networkId === params?.importToToken?.networkId,
         ))
     ) {
+      const importSwapType =
+        params?.swapTabSwitchType ?? ESwapTabSwitchType.SWAP;
+      const isImportFromTokenSupported = isSwapTokenSupportedBySwapType({
+        token: params?.importFromToken,
+        swapNetworks: swapNetworksRef.current,
+        swapType: importSwapType,
+      });
+      const isImportToTokenSupported = isSwapTokenSupportedBySwapType({
+        token: params?.importToToken,
+        swapNetworks: swapNetworksRef.current,
+        swapType: importSwapType,
+      });
+      const hasUnsupportedImportToken =
+        (Boolean(params?.importFromToken) && !isImportFromTokenSupported) ||
+        (Boolean(params?.importToToken) && !isImportToTokenSupported);
+      if (hasUnsupportedImportToken) {
+        clearSelectedTokensColdStartCache();
+      }
       if (params?.importFromToken) {
-        const fromTokenSupportTypes = checkSupportTokenSwapType(
-          params?.importFromToken,
-        );
-        if (
-          params?.swapTabSwitchType &&
-          fromTokenSupportTypes.includes(params?.swapTabSwitchType)
-        ) {
+        if (isImportFromTokenSupported) {
           setSwapFromToken(params?.importFromToken);
         }
       }
       if (params?.importToToken) {
-        const toTokenSupportTypes = checkSupportTokenSwapType(
-          params?.importToToken,
-        );
-        if (
-          params?.swapTabSwitchType &&
-          toTokenSupportTypes.includes(params?.swapTabSwitchType)
-        ) {
+        if (isImportToTokenSupported) {
           setToToken(params?.importToToken);
         }
       }
-      if (params?.importFromToken && !params?.importToToken) {
+      if (
+        params?.importFromToken &&
+        !params?.importToToken &&
+        !hasUnsupportedImportToken
+      ) {
         const needSetToToken = needChangeToken({
           token: params.importFromToken,
-          swapTypeSwitchValue:
-            params?.swapTabSwitchType ?? ESwapTabSwitchType.SWAP,
+          swapTypeSwitchValue: importSwapType,
         });
         if (needSetToToken) {
           const defaultTokenSupportTypes =
             checkSupportTokenSwapType(needSetToToken);
-          if (
-            params?.swapTabSwitchType &&
-            defaultTokenSupportTypes.includes(params?.swapTabSwitchType)
-          ) {
+          if (defaultTokenSupportTypes.includes(importSwapType)) {
             setToToken(needSetToToken);
           }
         }

--- a/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
@@ -941,11 +941,30 @@ export function useSwapInit(params?: ISwapInitParams) {
     if (netInfo && netId) {
       if (
         !isNil(swapDefaultSetTokens[netId]?.fromToken) ||
-        !isNil(swapDefaultSetTokens[netId]?.toToken)
+        !isNil(swapDefaultSetTokens[netId]?.toToken) ||
+        !isNil(swapDefaultSetTokens[netId]?.limitFromToken) ||
+        !isNil(swapDefaultSetTokens[netId]?.limitToToken)
       ) {
+        const shouldUseLimitDefaults =
+          (params?.swapTabSwitchType ?? swapTypeSwitchRef.current) ===
+          ESwapTabSwitchType.LIMIT;
+        if (shouldUseLimitDefaults && !netInfo.supportLimit) {
+          clearSelectedTokensColdStartCache();
+          markInitialSelectedTokensSynced();
+          return;
+        }
         let didSetDefaultSelectedTokens = false;
-        const defaultFromToken = swapDefaultSetTokens[netId]?.fromToken;
-        const defaultToToken = swapDefaultSetTokens[netId]?.toToken;
+        const defaultFromToken = shouldUseLimitDefaults
+          ? swapDefaultSetTokens[netId]?.limitFromToken
+          : swapDefaultSetTokens[netId]?.fromToken;
+        const defaultToToken = shouldUseLimitDefaults
+          ? swapDefaultSetTokens[netId]?.limitToToken
+          : swapDefaultSetTokens[netId]?.toToken;
+        if (shouldUseLimitDefaults && !defaultFromToken && !defaultToToken) {
+          clearSelectedTokensColdStartCache();
+          markInitialSelectedTokensSynced();
+          return;
+        }
         const defaultFromTokenWithLogo = defaultFromToken
           ? {
               ...defaultFromToken,

--- a/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
@@ -65,6 +65,7 @@ import {
   isSwapSelectedTokensColdStartContextMatched,
   isSwapTokenSupportedBySwapType,
   shouldClearSwapSelectedTokensBeforeHomeAccountSync,
+  shouldSkipSwapDefaultSelectedTokenSync,
   shouldSyncSwapSelectedAccountOnHomeAccountUpdate,
 } from '../utils/swapColdStartTokenCacheUtils';
 import {
@@ -393,6 +394,7 @@ export function useSwapInit(params?: ISwapInitParams) {
           cachedContext: selectedTokensColdStartContextRef.current,
           hasSelectedTokens,
           homeSelectedAccount,
+          initialSelectedTokensSynced: initialSelectedTokensSyncedRef.current,
           swapSelectedAccount: swapSelectedAccountRef.current,
         })
       ) {
@@ -825,7 +827,13 @@ export function useSwapInit(params?: ISwapInitParams) {
       params?.importNetworkId,
     );
     let hasSelectedTokens = Boolean(fromTokenRef.current || toTokenRef.current);
-    if (initialSelectedTokensSyncedRef.current && !hasImportParams) {
+    if (
+      shouldSkipSwapDefaultSelectedTokenSync({
+        hasImportParams,
+        hasSelectedTokens,
+        initialSelectedTokensSynced: initialSelectedTokensSyncedRef.current,
+      })
+    ) {
       if (
         hasSelectedTokens &&
         getSelectedTokensColdStartLimitSupport({

--- a/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
@@ -43,6 +43,7 @@ import {
 import {
   useSwapActions,
   useSwapFromTokenAmountAtom,
+  useSwapInitialSelectedTokensSyncedAtom,
   useSwapMevConfigAtom,
   useSwapNativeTokenReserveGasAtom,
   useSwapNetworksAtom,
@@ -57,9 +58,11 @@ import {
   SWAP_COLD_START_HOME_SCENE_NAME,
   buildSwapSelectedAccountSyncedFromHome,
   buildSwapSelectedTokensColdStartContext,
+  getSwapSelectedTokensColdStartContextNetworkId,
   isSwapColdStartAllNetworkContextNetworkId,
   isSwapSelectedTokensColdStartContextMatched,
-  shouldClearSwapSelectedTokensOnHomeAccountUpdate,
+  shouldClearSwapSelectedTokensBeforeHomeAccountSync,
+  shouldHandleSwapColdStartHomeAccountUpdate,
   shouldSyncSwapSelectedAccountOnHomeAccountUpdate,
 } from '../utils/swapColdStartTokenCacheUtils';
 import {
@@ -157,6 +160,8 @@ export function useSwapInit(params?: ISwapInitParams) {
   const [, setSwapTips] = useSwapTipsAtom();
   const [selectedTokensColdStartContext, setSelectedTokensColdStartContext] =
     useSwapSelectedTokensColdStartContextAtom();
+  const [initialSelectedTokensSynced, setInitialSelectedTokensSynced] =
+    useSwapInitialSelectedTokensSyncedAtom();
   const fromToken = useMemo(() => {
     if (platformEnv.isNative && swapTypeSwitch === ESwapTabSwitchType.LIMIT) {
       return swapProFromToken;
@@ -190,6 +195,10 @@ export function useSwapInit(params?: ISwapInitParams) {
   ) {
     selectedTokensColdStartContextRef.current = selectedTokensColdStartContext;
   }
+  const initialSelectedTokensSyncedRef = useRef(initialSelectedTokensSynced);
+  if (initialSelectedTokensSyncedRef.current !== initialSelectedTokensSynced) {
+    initialSelectedTokensSyncedRef.current = initialSelectedTokensSynced;
+  }
   const swapNetworksRef = useRef<ISwapNetwork[]>([]);
   if (swapNetworksRef.current !== swapNetworks) {
     swapNetworksRef.current = swapNetworks;
@@ -218,7 +227,10 @@ export function useSwapInit(params?: ISwapInitParams) {
     () =>
       buildSwapSelectedTokensColdStartContext({
         activeAccount: swapActiveAccountRef.current,
-        networkId: swapActiveAccountRef.current?.network?.id,
+        networkId: getSwapSelectedTokensColdStartContextNetworkId({
+          accountNetworkId: swapActiveAccountRef.current?.network?.id,
+          fromTokenNetworkId: fromTokenRef.current?.networkId,
+        }),
         swapType: getSelectedTokensColdStartSwapType({
           currentSwapType: swapTypeSwitchRef.current,
           fromToken: fromTokenRef.current,
@@ -293,6 +305,7 @@ export function useSwapInit(params?: ISwapInitParams) {
       return;
     }
 
+    selectedTokensColdStartContextRef.current = currentContext;
     setSelectedTokensColdStartContext(currentContext);
   }, [
     getCurrentSelectedTokensColdStartContext,
@@ -324,14 +337,22 @@ export function useSwapInit(params?: ISwapInitParams) {
     ],
   );
 
+  const markInitialSelectedTokensSynced = useCallback(() => {
+    if (initialSelectedTokensSyncedRef.current) {
+      return;
+    }
+    initialSelectedTokensSyncedRef.current = true;
+    setInitialSelectedTokensSynced(true);
+  }, [setInitialSelectedTokensSynced]);
+
   const syncSwapSelectedAccountFromHome = useCallback(
-    (
+    async (
       homeSelectedAccount?: Parameters<
         typeof shouldSyncSwapSelectedAccountOnHomeAccountUpdate
       >[0]['eventPayload']['selectedAccount'],
     ) => {
       if (!homeSelectedAccount) {
-        return false;
+        return { synced: false as const };
       }
 
       const eventPayload = {
@@ -351,13 +372,22 @@ export function useSwapInit(params?: ISwapInitParams) {
           swapSelectedAccount: swapSelectedAccountRef.current,
         })
       ) {
-        return false;
+        return { synced: false as const };
       }
 
-      if (hasSelectedTokens) {
+      let clearedSelectedTokens = false;
+      if (
+        shouldClearSwapSelectedTokensBeforeHomeAccountSync({
+          cachedContext: selectedTokensColdStartContextRef.current,
+          hasSelectedTokens,
+          homeSelectedAccount,
+          swapSelectedAccount: swapSelectedAccountRef.current,
+        })
+      ) {
+        clearedSelectedTokens = true;
         clearSelectedTokensColdStartCache({ resetSwapType: true });
       }
-      void updateSelectedAccount({
+      await updateSelectedAccount({
         updateMeta: {
           eventEmitDisabled: true,
           updatedAt: Date.now(),
@@ -369,7 +399,11 @@ export function useSwapInit(params?: ISwapInitParams) {
             swapSelectedAccount: currentSelectedAccount,
           }),
       });
-      return true;
+      return {
+        synced: true as const,
+        clearedSelectedTokens,
+        homeSelectedAccount,
+      };
     },
     [clearSelectedTokensColdStartCache, updateSelectedAccount],
   );
@@ -382,7 +416,7 @@ export function useSwapInit(params?: ISwapInitParams) {
   useEffect(() => {
     const handleAccountSelectorSelectedAccountUpdate = (
       eventPayload: Parameters<
-        typeof shouldClearSwapSelectedTokensOnHomeAccountUpdate
+        typeof shouldHandleSwapColdStartHomeAccountUpdate
       >[0]['eventPayload'],
     ) => {
       if (
@@ -392,14 +426,14 @@ export function useSwapInit(params?: ISwapInitParams) {
         return;
       }
       if (
-        shouldClearSwapSelectedTokensOnHomeAccountUpdate({
+        shouldHandleSwapColdStartHomeAccountUpdate({
           cachedContext: selectedTokensColdStartContextRef.current,
           eventPayload,
+          initialSelectedTokensSynced: initialSelectedTokensSyncedRef.current,
         })
       ) {
-        clearSelectedTokensColdStartCache({ resetSwapType: true });
+        void syncSwapSelectedAccountFromHome(eventPayload.selectedAccount);
       }
-      syncSwapSelectedAccountFromHome(eventPayload.selectedAccount);
     };
 
     appEventBus.on(
@@ -412,7 +446,7 @@ export function useSwapInit(params?: ISwapInitParams) {
         handleAccountSelectorSelectedAccountUpdate,
       );
     };
-  }, [clearSelectedTokensColdStartCache, syncSwapSelectedAccountFromHome]);
+  }, [syncSwapSelectedAccountFromHome]);
 
   useEffect(() => {
     if (hasSyncedSwapSelectedAccountFromHomeStorageRef.current) {
@@ -769,12 +803,31 @@ export function useSwapInit(params?: ISwapInitParams) {
   );
 
   const syncDefaultSelectedToken = useCallback(async () => {
-    if (await syncSwapSelectedAccountFromLatestHome()) {
+    const hasImportParams = Boolean(
+      params?.importFromToken ||
+      params?.importToToken ||
+      params?.importNetworkId,
+    );
+    let hasSelectedTokens = Boolean(fromTokenRef.current || toTokenRef.current);
+    if (
+      initialSelectedTokensSyncedRef.current &&
+      hasSelectedTokens &&
+      !hasImportParams
+    ) {
       return;
+    }
+    const homeAccountSyncResult = await syncSwapSelectedAccountFromLatestHome();
+    if (homeAccountSyncResult.synced) {
+      if (homeAccountSyncResult.clearedSelectedTokens) {
+        hasSelectedTokens = false;
+      } else if (hasSelectedTokens && !hasImportParams) {
+        markInitialSelectedTokensSynced();
+        return;
+      }
     }
 
     let shouldResetInvalidColdStartSwapType = false;
-    if (fromTokenRef.current || toTokenRef.current) {
+    if (hasSelectedTokens) {
       const isSelectedTokensColdStartContextValid =
         validateSelectedTokensColdStartContext();
       if (isSelectedTokensColdStartContextValid === undefined) {
@@ -782,6 +835,7 @@ export function useSwapInit(params?: ISwapInitParams) {
       }
       if (isSelectedTokensColdStartContextValid) {
         syncSelectedTokensColdStartSwapType();
+        markInitialSelectedTokensSynced();
         return;
       }
 
@@ -848,24 +902,31 @@ export function useSwapInit(params?: ISwapInitParams) {
           params?.importToToken?.networkId ??
           getNetworkIdsMap().onekeyall,
       );
+      markInitialSelectedTokensSynced();
       return;
     }
+    const defaultTokenNetworkId = homeAccountSyncResult.synced
+      ? homeAccountSyncResult.homeSelectedAccount.networkId
+      : swapAddressInfoRef.current?.networkId;
+    const hasAccountReadyForDefaultToken =
+      swapAddressInfoRef.current?.accountInfo?.ready ||
+      Boolean(homeAccountSyncResult.synced);
     if (
-      !swapAddressInfoRef.current?.accountInfo?.ready ||
-      !swapAddressInfoRef.current?.networkId ||
+      !hasAccountReadyForDefaultToken ||
+      !defaultTokenNetworkId ||
       !swapNetworksRef.current.length ||
       (params?.importNetworkId &&
-        swapAddressInfoRef.current?.networkId &&
-        params?.importNetworkId !== swapAddressInfoRef.current?.networkId) ||
+        defaultTokenNetworkId &&
+        params?.importNetworkId !== defaultTokenNetworkId) ||
       skipSyncDefaultSelectedToken
     ) {
       return;
     }
     const isAllNet = networkUtils.isAllNetwork({
-      networkId: swapAddressInfoRef.current?.networkId,
+      networkId: defaultTokenNetworkId,
     });
     const accountNetwork = swapNetworksRef.current.find(
-      (net) => net.networkId === swapAddressInfoRef.current?.networkId,
+      (net) => net.networkId === defaultTokenNetworkId,
     );
     let netInfo = accountNetwork;
     let netId = accountNetwork?.networkId;
@@ -882,6 +943,7 @@ export function useSwapInit(params?: ISwapInitParams) {
         !isNil(swapDefaultSetTokens[netId]?.fromToken) ||
         !isNil(swapDefaultSetTokens[netId]?.toToken)
       ) {
+        let didSetDefaultSelectedTokens = false;
         const defaultFromToken = swapDefaultSetTokens[netId]?.fromToken;
         const defaultToToken = swapDefaultSetTokens[netId]?.toToken;
         const defaultFromTokenWithLogo = defaultFromToken
@@ -894,6 +956,7 @@ export function useSwapInit(params?: ISwapInitParams) {
           : undefined;
         if (defaultFromToken) {
           setSwapFromToken(defaultFromTokenWithLogo);
+          didSetDefaultSelectedTokens = true;
           void syncNetworksSort(defaultFromToken.networkId);
         }
         if (defaultToToken) {
@@ -903,6 +966,7 @@ export function useSwapInit(params?: ISwapInitParams) {
               ? defaultToToken.networkLogoURI
               : netInfo?.logoURI,
           });
+          didSetDefaultSelectedTokens = true;
           void syncNetworksSort(defaultToToken.networkId);
           if (shouldResetInvalidColdStartSwapType) {
             switchSwapTypeIfNeeded(
@@ -942,6 +1006,7 @@ export function useSwapInit(params?: ISwapInitParams) {
           });
           if (needChangeToToken) {
             setToToken(needChangeToToken);
+            didSetDefaultSelectedTokens = true;
             void syncNetworksSort(needChangeToToken.networkId);
             if (
               !params?.swapTabSwitchType &&
@@ -957,6 +1022,9 @@ export function useSwapInit(params?: ISwapInitParams) {
         }
         if (defaultFromToken) {
           checkSupportTokenSwapType(defaultFromToken, true);
+        }
+        if (didSetDefaultSelectedTokens) {
+          markInitialSelectedTokensSynced();
         }
       } else if (shouldResetInvalidColdStartSwapType) {
         switchSwapTypeIfNeeded(
@@ -986,6 +1054,7 @@ export function useSwapInit(params?: ISwapInitParams) {
     validateSelectedTokensColdStartContext,
     syncSelectedTokensColdStartSwapType,
     clearSelectedTokensColdStartCache,
+    markInitialSelectedTokensSynced,
     switchSwapTypeIfNeeded,
     syncSwapSelectedAccountFromLatestHome,
   ]);
@@ -1089,12 +1158,9 @@ export function useSwapInit(params?: ISwapInitParams) {
     params?.importFromToken,
     params?.importToToken,
     params?.importNetworkId,
-    // syncDefaultSelectedToken() bails early after kicking off an async home->swap
-    // account write-back (syncSwapSelectedAccountFromLatestHome). When swap and home
-    // share the same network, networkId above does not change, so without watching
-    // the account identity the init would never re-run and a deeplink/Market import
-    // token would be swallowed. The home-sync path pre-clears tokens, so the rerun
-    // lands cleanly in the default/import init branch.
+    // The initial home->swap account write-back can keep the same networkId while
+    // changing account identity, so import/default token init must also watch the
+    // resolved account fields.
     swapActiveAccount.wallet?.id,
     swapActiveAccount.indexedAccount?.id,
     swapActiveAccount.account?.id,

--- a/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
@@ -58,6 +58,7 @@ import {
   SWAP_COLD_START_HOME_SCENE_NAME,
   buildSwapSelectedAccountSyncedFromHome,
   buildSwapSelectedTokensColdStartContext,
+  getSelectedTokensColdStartLimitSupport,
   getSwapSelectedTokensColdStartContextNetworkId,
   isSwapColdStartAllNetworkContextNetworkId,
   isSwapSelectedTokensColdStartContextMatched,
@@ -210,6 +211,16 @@ export function useSwapInit(params?: ISwapInitParams) {
   if (toTokenRef.current !== toToken) {
     toTokenRef.current = toToken;
   }
+  const selectedTokensRuntimeLimitSupport = useMemo(
+    () =>
+      getSelectedTokensColdStartLimitSupport({
+        swapType: swapTypeSwitch,
+        fromToken: swapFromToken,
+        toToken,
+        swapNetworks,
+      }),
+    [swapFromToken, swapTypeSwitch, swapNetworks, toToken],
+  );
   const fromTokenAmountRef = useRef<{ value: string; isInput: boolean }>(
     fromTokenAmount,
   );
@@ -826,20 +837,24 @@ export function useSwapInit(params?: ISwapInitParams) {
       params?.importNetworkId,
     );
     let hasSelectedTokens = Boolean(fromTokenRef.current || toTokenRef.current);
-    if (
-      initialSelectedTokensSyncedRef.current &&
-      hasSelectedTokens &&
-      !hasImportParams
-    ) {
+    if (initialSelectedTokensSyncedRef.current && !hasImportParams) {
+      if (
+        hasSelectedTokens &&
+        getSelectedTokensColdStartLimitSupport({
+          swapType: swapTypeSwitchRef.current,
+          fromToken: fromTokenRef.current,
+          toToken: toTokenRef.current,
+          swapNetworks: swapNetworksRef.current,
+        }) === false
+      ) {
+        clearSelectedTokensColdStartCache();
+      }
       return;
     }
     const homeAccountSyncResult = await syncSwapSelectedAccountFromLatestHome();
     if (homeAccountSyncResult.synced) {
       if (homeAccountSyncResult.clearedSelectedTokens) {
         hasSelectedTokens = false;
-      } else if (hasSelectedTokens && !hasImportParams) {
-        markInitialSelectedTokensSynced();
-        return;
       }
     }
 
@@ -851,6 +866,21 @@ export function useSwapInit(params?: ISwapInitParams) {
         return;
       }
       if (isSelectedTokensColdStartContextValid) {
+        const selectedTokensColdStartLimitSupport =
+          getSelectedTokensColdStartLimitSupport({
+            swapType: swapTypeSwitchRef.current,
+            fromToken: fromTokenRef.current,
+            toToken: toTokenRef.current,
+            swapNetworks: swapNetworksRef.current,
+          });
+        if (selectedTokensColdStartLimitSupport === undefined) {
+          return;
+        }
+        if (!selectedTokensColdStartLimitSupport) {
+          clearSelectedTokensColdStartCache();
+          markInitialSelectedTokensSynced();
+          return;
+        }
         syncSelectedTokensColdStartSwapType();
         markInitialSelectedTokensSynced();
         return;
@@ -1067,6 +1097,9 @@ export function useSwapInit(params?: ISwapInitParams) {
           params?.swapTabSwitchType ?? ESwapTabSwitchType.SWAP,
           netId,
         );
+        markInitialSelectedTokensSynced();
+      } else {
+        markInitialSelectedTokensSynced();
       }
     } else if (shouldResetInvalidColdStartSwapType) {
       switchSwapTypeIfNeeded(
@@ -1202,6 +1235,7 @@ export function useSwapInit(params?: ISwapInitParams) {
     swapActiveAccount.account?.id,
     swapActiveAccount.dbAccount?.id,
     swapActiveAccount.deriveType,
+    selectedTokensRuntimeLimitSupport,
   ]);
   const [swapFromMarketJumpToken, setSwapFromMarketJumpToken] =
     useSwapFromMarketJumpTokenAtom();

--- a/packages/kit/src/views/Swap/pages/SwapProviderMirror.tsx
+++ b/packages/kit/src/views/Swap/pages/SwapProviderMirror.tsx
@@ -1,19 +1,59 @@
-import { type PropsWithChildren, memo } from 'react';
+import { type PropsWithChildren, memo, useRef } from 'react';
 
 import type { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  ESwapTabSwitchType,
+  type ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
 
-import { ProviderJotaiContextSwap } from '../../../states/jotai/contexts/swap';
+import {
+  ProviderJotaiContextSwap,
+  swapFromTokenAmountAtom,
+  swapInitialSelectedTokensSyncedAtom,
+  swapSelectFromTokenAtom,
+  swapSelectToTokenAtom,
+  swapSelectedTokensColdStartContextAtom,
+  swapTypeSwitchAtom,
+} from '../../../states/jotai/contexts/swap';
 import { jotaiContextStore } from '../../../states/jotai/utils/jotaiContextStore';
 import { JotaiContextStoreMirrorTracker } from '../../../states/jotai/utils/JotaiContextStoreMirrorTracker';
 
 import { useSwapContextStoreInitData } from './SwapRootProvider';
 
 export const SwapProviderMirror = memo(
-  (props: PropsWithChildren & { storeName: EJotaiContextStoreNames }) => {
-    const { children, storeName } = props;
+  (
+    props: PropsWithChildren & {
+      storeName: EJotaiContextStoreNames;
+      initialSelectedTokensOnInit?: {
+        fromToken?: ISwapToken;
+        toToken?: ISwapToken;
+        swapType?: ESwapTabSwitchType;
+      };
+    },
+  ) => {
+    const { children, initialSelectedTokensOnInit, storeName } = props;
 
     const data = useSwapContextStoreInitData(storeName);
     const store = jotaiContextStore.getOrCreateStore(data);
+    const hasInitializedSelectedTokensRef = useRef(false);
+    if (
+      initialSelectedTokensOnInit &&
+      !hasInitializedSelectedTokensRef.current
+    ) {
+      hasInitializedSelectedTokensRef.current = true;
+      store.set(
+        swapSelectFromTokenAtom(),
+        initialSelectedTokensOnInit.fromToken,
+      );
+      store.set(swapSelectToTokenAtom(), initialSelectedTokensOnInit.toToken);
+      store.set(swapSelectedTokensColdStartContextAtom(), undefined);
+      store.set(swapInitialSelectedTokensSyncedAtom(), true);
+      store.set(swapFromTokenAmountAtom(), { value: '', isInput: false });
+      store.set(
+        swapTypeSwitchAtom(),
+        initialSelectedTokensOnInit.swapType ?? ESwapTabSwitchType.SWAP,
+      );
+    }
 
     return (
       <>

--- a/packages/kit/src/views/Swap/pages/SwapRootProvider.tsx
+++ b/packages/kit/src/views/Swap/pages/SwapRootProvider.tsx
@@ -7,7 +7,6 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import type { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
-import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
 
 import {
   ProviderJotaiContextSwap,
@@ -24,10 +23,10 @@ import {
 } from '../utils/swapColdStartTokenCacheUtils';
 
 function SwapColdStartCacheSync() {
-  const [, setSwapTypeSwitch] = useSwapTypeSwitchAtom();
+  const [swapTypeSwitch, setSwapTypeSwitch] = useSwapTypeSwitchAtom();
   const [, setSwapFromToken] = useSwapSelectFromTokenAtom();
   const [, setSwapToToken] = useSwapSelectToTokenAtom();
-  const [initialSelectedTokensSynced] =
+  const [initialSelectedTokensSynced, setInitialSelectedTokensSynced] =
     useSwapInitialSelectedTokensSyncedAtom();
   const [selectedTokensColdStartContext, setSelectedTokensColdStartContext] =
     useSwapSelectedTokensColdStartContextAtom();
@@ -37,13 +36,23 @@ function SwapColdStartCacheSync() {
   selectedTokensColdStartContextRef.current = selectedTokensColdStartContext;
   const initialSelectedTokensSyncedRef = useRef(initialSelectedTokensSynced);
   initialSelectedTokensSyncedRef.current = initialSelectedTokensSynced;
+  const swapTypeSwitchRef = useRef(swapTypeSwitch);
+  swapTypeSwitchRef.current = swapTypeSwitch;
 
   useEffect(() => {
+    const markInitialSelectedTokensSynced = () => {
+      if (initialSelectedTokensSyncedRef.current) {
+        return;
+      }
+      initialSelectedTokensSyncedRef.current = true;
+      setInitialSelectedTokensSynced(true);
+    };
+
     const clearSelectedTokens = () => {
       setSwapFromToken(undefined);
       setSwapToToken(undefined);
       setSelectedTokensColdStartContext(undefined);
-      setSwapTypeSwitch(ESwapTabSwitchType.SWAP);
+      markInitialSelectedTokensSynced();
     };
 
     const setDefaultSelectedTokensFromHomeAccount = (
@@ -51,6 +60,7 @@ function SwapColdStartCacheSync() {
     ) => {
       const defaultTokens = buildSwapDefaultSelectedTokensFromHomeAccount({
         homeSelectedAccount: selectedAccount,
+        swapType: swapTypeSwitchRef.current,
       });
       if (!defaultTokens) {
         return false;
@@ -60,6 +70,7 @@ function SwapColdStartCacheSync() {
       setSwapToToken(defaultTokens.toToken);
       setSelectedTokensColdStartContext(defaultTokens.context);
       setSwapTypeSwitch(defaultTokens.swapType);
+      markInitialSelectedTokensSynced();
       return true;
     };
 
@@ -94,6 +105,7 @@ function SwapColdStartCacheSync() {
       );
     };
   }, [
+    setInitialSelectedTokensSynced,
     setSelectedTokensColdStartContext,
     setSwapFromToken,
     setSwapToToken,

--- a/packages/kit/src/views/Swap/pages/SwapRootProvider.tsx
+++ b/packages/kit/src/views/Swap/pages/SwapRootProvider.tsx
@@ -11,24 +11,32 @@ import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
 
 import {
   ProviderJotaiContextSwap,
+  useSwapInitialSelectedTokensSyncedAtom,
   useSwapSelectFromTokenAtom,
   useSwapSelectToTokenAtom,
   useSwapSelectedTokensColdStartContextAtom,
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
 import { useJotaiContextRootStore } from '../../../states/jotai/utils/useJotaiContextRootStore';
-import { shouldClearSwapSelectedTokensOnHomeAccountUpdate } from '../utils/swapColdStartTokenCacheUtils';
+import {
+  buildSwapDefaultSelectedTokensFromHomeAccount,
+  shouldHandleSwapColdStartHomeAccountUpdate,
+} from '../utils/swapColdStartTokenCacheUtils';
 
 function SwapColdStartCacheSync() {
   const [, setSwapTypeSwitch] = useSwapTypeSwitchAtom();
   const [, setSwapFromToken] = useSwapSelectFromTokenAtom();
   const [, setSwapToToken] = useSwapSelectToTokenAtom();
+  const [initialSelectedTokensSynced] =
+    useSwapInitialSelectedTokensSyncedAtom();
   const [selectedTokensColdStartContext, setSelectedTokensColdStartContext] =
     useSwapSelectedTokensColdStartContextAtom();
   const selectedTokensColdStartContextRef = useRef(
     selectedTokensColdStartContext,
   );
   selectedTokensColdStartContextRef.current = selectedTokensColdStartContext;
+  const initialSelectedTokensSyncedRef = useRef(initialSelectedTokensSynced);
+  initialSelectedTokensSyncedRef.current = initialSelectedTokensSynced;
 
   useEffect(() => {
     const clearSelectedTokens = () => {
@@ -38,18 +46,40 @@ function SwapColdStartCacheSync() {
       setSwapTypeSwitch(ESwapTabSwitchType.SWAP);
     };
 
+    const setDefaultSelectedTokensFromHomeAccount = (
+      selectedAccount?: IAccountSelectorSelectedAccount,
+    ) => {
+      const defaultTokens = buildSwapDefaultSelectedTokensFromHomeAccount({
+        homeSelectedAccount: selectedAccount,
+      });
+      if (!defaultTokens) {
+        return false;
+      }
+
+      setSwapFromToken(defaultTokens.fromToken);
+      setSwapToToken(defaultTokens.toToken);
+      setSelectedTokensColdStartContext(defaultTokens.context);
+      setSwapTypeSwitch(defaultTokens.swapType);
+      return true;
+    };
+
     const handleHomeSelectedAccountUpdate = (eventPayload: {
       selectedAccount?: IAccountSelectorSelectedAccount;
       sceneName: EAccountSelectorSceneName;
       num: number;
     }) => {
       if (
-        shouldClearSwapSelectedTokensOnHomeAccountUpdate({
+        shouldHandleSwapColdStartHomeAccountUpdate({
           cachedContext: selectedTokensColdStartContextRef.current,
           eventPayload,
+          initialSelectedTokensSynced: initialSelectedTokensSyncedRef.current,
         })
       ) {
-        clearSelectedTokens();
+        if (
+          !setDefaultSelectedTokensFromHomeAccount(eventPayload.selectedAccount)
+        ) {
+          clearSelectedTokens();
+        }
       }
     };
 
@@ -99,6 +129,10 @@ SwapRootProvider.displayName = 'SwapRootProvider';
 export const SwapModalRootProvider = memo(() => {
   const data = useSwapContextStoreInitData(EJotaiContextStoreNames.swapModal);
   const store = useJotaiContextRootStore(data);
-  return <ProviderJotaiContextSwap store={store} />;
+  return (
+    <ProviderJotaiContextSwap store={store}>
+      <SwapColdStartCacheSync />
+    </ProviderJotaiContextSwap>
+  );
 });
 SwapModalRootProvider.displayName = 'SwapModalRootProvider';

--- a/packages/kit/src/views/Swap/pages/SwapRootProvider.tsx
+++ b/packages/kit/src/views/Swap/pages/SwapRootProvider.tsx
@@ -70,7 +70,6 @@ function SwapColdStartCacheSync() {
       setSwapToToken(defaultTokens.toToken);
       setSelectedTokensColdStartContext(defaultTokens.context);
       setSwapTypeSwitch(defaultTokens.swapType);
-      markInitialSelectedTokensSynced();
       return true;
     };
 

--- a/packages/kit/src/views/Swap/pages/components/SwapAccountAddressContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapAccountAddressContainer.tsx
@@ -2,7 +2,13 @@ import { useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { Image, SizableText, XStack } from '@onekeyhq/components';
+import {
+  Image,
+  SizableText,
+  Skeleton,
+  Stack,
+  XStack,
+} from '@onekeyhq/components';
 import { DeriveTypeSelectorTriggerIconRenderer } from '@onekeyhq/kit/src/components/AccountSelector/DeriveTypeSelectorTrigger';
 import AddressTypeSelector from '@onekeyhq/kit/src/components/AddressTypeSelector/AddressTypeSelector';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
@@ -13,14 +19,19 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 
 interface ISwapAccountAddressContainerProps {
   type: ESwapDirectionType;
+  displayToken?: ISwapToken;
+  networkLoading?: boolean;
   onClickNetwork?: (type: ESwapDirectionType) => void;
 }
 const SwapAccountAddressContainer = ({
   type,
+  displayToken,
+  networkLoading,
   onClickNetwork,
 }: ISwapAccountAddressContainerProps) => {
   const intl = useIntl();
@@ -31,7 +42,8 @@ const SwapAccountAddressContainer = ({
   const { activeAccount } = useActiveAccount({ num: 0 });
   const { activeAccount: activeToAccount } = useActiveAccount({ num: 1 });
   const networkComponent = useMemo(() => {
-    const token = type === ESwapDirectionType.FROM ? fromToken : toToken;
+    const token =
+      displayToken ?? (type === ESwapDirectionType.FROM ? fromToken : toToken);
     const networkInfo = swapSupportAllNetwork.find(
       (net) => net.networkId === token?.networkId,
     );
@@ -44,25 +56,44 @@ const SwapAccountAddressContainer = ({
       token?.networkLogoURI ??
       localNetworkInfo?.logoURI;
 
-    return networkName ? (
-      <XStack
-        key="network-component"
-        gap="$1"
-        alignItems="center"
-        cursor="pointer"
-        onPress={() => {
-          onClickNetwork?.(type);
-        }}
-      >
-        {networkLogoURI ? (
-          <Image w={16} h={16} source={{ uri: networkLogoURI }} />
-        ) : null}
-        <SizableText size="$bodyMd" color="$text">
-          {networkName}
-        </SizableText>
+    if (networkName) {
+      return (
+        <XStack
+          key="network-component"
+          gap="$1"
+          alignItems="center"
+          cursor="pointer"
+          onPress={() => {
+            onClickNetwork?.(type);
+          }}
+        >
+          {networkLogoURI ? (
+            <Image w={16} h={16} source={{ uri: networkLogoURI }} />
+          ) : null}
+          <SizableText size="$bodyMd" color="$text">
+            {networkName}
+          </SizableText>
+        </XStack>
+      );
+    }
+
+    return networkLoading ? (
+      <XStack key="network-component" gap="$1" alignItems="center">
+        <Skeleton w={16} h={16} radius="round" />
+        <Stack py="$1">
+          <Skeleton h="$3" w="$16" />
+        </Stack>
       </XStack>
     ) : null;
-  }, [swapSupportAllNetwork, onClickNetwork, type, fromToken, toToken]);
+  }, [
+    displayToken,
+    networkLoading,
+    swapSupportAllNetwork,
+    onClickNetwork,
+    type,
+    fromToken,
+    toToken,
+  ]);
 
   return (
     <XStack alignItems="center" gap="$1">

--- a/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
@@ -46,6 +46,7 @@ import {
 import SwapPercentageStageBadge from '../../components/SwapPercentageStageBadge';
 import { SwapRateDifferenceText } from '../../components/SwapRateDifferenceText';
 import { useSwapAddressInfo } from '../../hooks/useSwapAccount';
+import { useSwapColdStartDisplayTokens } from '../../hooks/useSwapColdStartDisplayTokens';
 import { useSwapSelectedTokenInfo } from '../../hooks/useSwapTokens';
 import { SwapTestIDs } from '../../testIDs';
 
@@ -168,9 +169,27 @@ const SwapInputContainer = ({
   const [fromTokenBalance] = useSwapSelectedFromTokenBalanceAtom();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
   const [swapQuoteActionLock] = useSwapQuoteActionLockAtom();
+  const {
+    displayFromToken,
+    displayToToken,
+    isInitialFromTokenSelectionPending,
+    isInitialToTokenSelectionPending,
+  } = useSwapColdStartDisplayTokens({
+    fromToken,
+    toToken,
+  });
+  const tokenSelectorDisplayToken =
+    (token?.symbol ? token : undefined) ??
+    (direction === ESwapDirectionType.FROM ? displayFromToken : displayToToken);
+  const isInitialTokenSelectionPending =
+    direction === ESwapDirectionType.FROM
+      ? isInitialFromTokenSelectionPending
+      : isInitialToTokenSelectionPending;
   const [, setInAppNotification] = useInAppNotificationAtom();
   const tokenSelectorMinWidth = platformEnv.isNative ? 112 : 132;
-  const showTokenSelectorSkeleton = selectTokenLoading && !token?.symbol;
+  const showTokenSelectorSkeleton =
+    !tokenSelectorDisplayToken?.symbol &&
+    (selectTokenLoading || isInitialTokenSelectionPending);
   const displayBalance = useMemo(() => {
     if (balance) {
       return balance;
@@ -310,6 +329,8 @@ const SwapInputContainer = ({
       <XStack justifyContent="space-between" pt="$2.5" px="$3.5">
         <SwapAccountAddressContainer
           type={direction}
+          displayToken={tokenSelectorDisplayToken}
+          networkLoading={showTokenSelectorSkeleton}
           onClickNetwork={onSelectToken}
         />
         <SwapInputActions
@@ -380,8 +401,8 @@ const SwapInputContainer = ({
           minWidth: tokenSelectorMinWidth,
           justifyContent: 'flex-end',
           loading: showTokenSelectorSkeleton,
-          selectedTokenImageUri: token?.logoURI,
-          selectedTokenSymbol: token?.symbol,
+          selectedTokenImageUri: tokenSelectorDisplayToken?.logoURI,
+          selectedTokenSymbol: tokenSelectorDisplayToken?.symbol,
           onPress: () => {
             onSelectToken(direction);
           },

--- a/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
@@ -20,6 +20,7 @@ import {
   useRateDifferenceAtom,
   useSwapAlertsAtom,
   useSwapFromTokenAmountAtom,
+  useSwapInitialSelectedTokensSyncedAtom,
   useSwapQuoteActionLockAtom,
   useSwapSelectFromTokenAtom,
   useSwapSelectToTokenAtom,
@@ -169,6 +170,8 @@ const SwapInputContainer = ({
   const [fromTokenBalance] = useSwapSelectedFromTokenBalanceAtom();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
   const [swapQuoteActionLock] = useSwapQuoteActionLockAtom();
+  const [initialSelectedTokensSynced] =
+    useSwapInitialSelectedTokensSyncedAtom();
   const {
     displayFromToken,
     displayToToken,
@@ -176,6 +179,7 @@ const SwapInputContainer = ({
     isInitialToTokenSelectionPending,
   } = useSwapColdStartDisplayTokens({
     fromToken,
+    initialSelectedTokensSynced,
     toToken,
   });
   const tokenSelectorDisplayToken =

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -92,6 +92,7 @@ import {
   ESwapProTradeType,
   ESwapQuoteKind,
   ESwapSelectTokenSource,
+  ESwapSource,
   ESwapTabSwitchType,
   LIMIT_PRICE_DEFAULT_DECIMALS,
   SwapBuildShouldFallBackNetworkIds,
@@ -1332,6 +1333,17 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
 };
 
 const SwapMainLandWithPageType = (props: ISwapMainLoadProps) => {
+  const initialSelectedTokensOnInit =
+    props.swapInitParams?.swapSource === ESwapSource.WALLET_HOME_TOKEN_LIST &&
+    Boolean(props.swapInitParams?.importNetworkId)
+      ? {
+          fromToken: props.swapInitParams?.importFromToken,
+          toToken: props.swapInitParams?.importToToken,
+          swapType:
+            props.swapInitParams?.swapTabSwitchType ?? ESwapTabSwitchType.SWAP,
+        }
+      : undefined;
+
   return (
     <SwapProviderMirror
       storeName={
@@ -1339,6 +1351,7 @@ const SwapMainLandWithPageType = (props: ISwapMainLoadProps) => {
           ? EJotaiContextStoreNames.swapModal
           : EJotaiContextStoreNames.swap
       }
+      initialSelectedTokensOnInit={initialSelectedTokensOnInit}
     >
       <MarketWatchListProviderMirrorV2
         storeName={EJotaiContextStoreNames.marketWatchListV2}

--- a/packages/kit/src/views/Swap/pages/modal/SwapMainLandModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapMainLandModal.tsx
@@ -80,6 +80,7 @@ const SwapMainLandModalPage = () => {
           swapTabSwitchType,
           fromAmount,
           marketPresetToken,
+          swapSource,
         }}
       />
     </Page>

--- a/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts
@@ -14,7 +14,9 @@ import {
   buildSwapSelectedTokensColdStartContext,
   getSelectedTokensColdStartLimitSupport,
   getSwapSelectedTokensColdStartContextNetworkId,
+  getSwapTokenSupportTypes,
   isSwapSelectedTokensColdStartContextMatched,
+  isSwapTokenSupportedBySwapType,
   shouldClearSwapSelectedTokensBeforeHomeAccountSync,
   shouldClearSwapSelectedTokensOnHomeAccountUpdate,
   shouldHandleSwapColdStartHomeAccountUpdate,
@@ -74,14 +76,20 @@ function buildSwapToken(networkId: string): ISwapToken {
 
 function buildSwapNetwork({
   networkId,
+  supportCrossChainSwap,
   supportLimit,
+  supportSingleSwap,
 }: {
   networkId: string;
-  supportLimit: boolean;
+  supportCrossChainSwap?: boolean;
+  supportLimit?: boolean;
+  supportSingleSwap?: boolean;
 }): ISwapNetwork {
   return {
     networkId,
+    supportCrossChainSwap,
     supportLimit,
+    supportSingleSwap,
   } as ISwapNetwork;
 }
 
@@ -441,6 +449,48 @@ describe('swap cold-start selected token context', () => {
         ],
       }),
     ).toBe(true);
+  });
+
+  it('detects token support from its swap network capabilities', () => {
+    const swapNetworks = [
+      buildSwapNetwork({
+        networkId: 'btc--0',
+        supportCrossChainSwap: true,
+        supportSingleSwap: false,
+      }),
+      buildSwapNetwork({
+        networkId: 'evm--1',
+        supportLimit: true,
+        supportSingleSwap: true,
+      }),
+    ];
+
+    expect(
+      getSwapTokenSupportTypes({
+        token: buildSwapToken('btc--0'),
+        swapNetworks,
+      }),
+    ).toEqual([ESwapTabSwitchType.BRIDGE]);
+    expect(
+      isSwapTokenSupportedBySwapType({
+        token: buildSwapToken('btc--0'),
+        swapNetworks,
+        swapType: ESwapTabSwitchType.SWAP,
+      }),
+    ).toBe(false);
+    expect(
+      isSwapTokenSupportedBySwapType({
+        token: buildSwapToken('btc--0'),
+        swapNetworks,
+        swapType: ESwapTabSwitchType.BRIDGE,
+      }),
+    ).toBe(true);
+    expect(
+      getSwapTokenSupportTypes({
+        token: buildSwapToken('evm--1'),
+        swapNetworks,
+      }),
+    ).toEqual([ESwapTabSwitchType.SWAP, ESwapTabSwitchType.LIMIT]);
   });
 
   it('handles home network changes only before the first swap token sync completes', () => {

--- a/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts
@@ -1,5 +1,9 @@
 import type { IAccountSelectorSelectedAccount } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountSelector';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
+import type {
+  ISwapNetwork,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
 import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
 
 import {
@@ -8,6 +12,7 @@ import {
   buildSwapSelectedTokensColdStartAccountKey,
   buildSwapSelectedTokensColdStartAccountKeyFromSelectedAccount,
   buildSwapSelectedTokensColdStartContext,
+  getSelectedTokensColdStartLimitSupport,
   getSwapSelectedTokensColdStartContextNetworkId,
   isSwapSelectedTokensColdStartContextMatched,
   shouldClearSwapSelectedTokensBeforeHomeAccountSync,
@@ -59,6 +64,25 @@ function buildSelectedAccount(
     focusedWallet: 'wallet-1',
     ...overrides,
   };
+}
+
+function buildSwapToken(networkId: string): ISwapToken {
+  return {
+    networkId,
+  } as ISwapToken;
+}
+
+function buildSwapNetwork({
+  networkId,
+  supportLimit,
+}: {
+  networkId: string;
+  supportLimit: boolean;
+}): ISwapNetwork {
+  return {
+    networkId,
+    supportLimit,
+  } as ISwapNetwork;
 }
 
 describe('swap cold-start selected token context', () => {
@@ -362,6 +386,61 @@ describe('swap cold-start selected token context', () => {
       }),
       swapType: ESwapTabSwitchType.LIMIT,
     });
+  });
+
+  it('waits for runtime networks before completing a Limit cold-start token sync', () => {
+    expect(
+      getSelectedTokensColdStartLimitSupport({
+        swapType: ESwapTabSwitchType.LIMIT,
+        fromToken: buildSwapToken('evm--1'),
+        swapNetworks: [],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('clears prefilled Limit defaults when runtime support is disabled', () => {
+    expect(
+      getSelectedTokensColdStartLimitSupport({
+        swapType: ESwapTabSwitchType.LIMIT,
+        fromToken: buildSwapToken('evm--1'),
+        swapNetworks: [
+          buildSwapNetwork({
+            networkId: 'evm--1',
+            supportLimit: false,
+          }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps synced Limit tokens when the current runtime list omits their network', () => {
+    expect(
+      getSelectedTokensColdStartLimitSupport({
+        swapType: ESwapTabSwitchType.LIMIT,
+        fromToken: buildSwapToken('evm--1'),
+        swapNetworks: [
+          buildSwapNetwork({
+            networkId: 'tron--0x2b6653dc',
+            supportLimit: false,
+          }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('does not apply Limit runtime support checks outside the Limit tab', () => {
+    expect(
+      getSelectedTokensColdStartLimitSupport({
+        swapType: ESwapTabSwitchType.SWAP,
+        fromToken: buildSwapToken('evm--1'),
+        swapNetworks: [
+          buildSwapNetwork({
+            networkId: 'evm--1',
+            supportLimit: false,
+          }),
+        ],
+      }),
+    ).toBe(true);
   });
 
   it('handles home network changes only before the first swap token sync completes', () => {

--- a/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts
@@ -324,6 +324,46 @@ describe('swap cold-start selected token context', () => {
     });
   });
 
+  it('does not preselect Tron tokens when initializing Limit', () => {
+    expect(
+      buildSwapDefaultSelectedTokensFromHomeAccount({
+        homeSelectedAccount: buildSelectedAccount({
+          networkId: 'tron--0x2b6653dc',
+        }),
+        swapType: ESwapTabSwitchType.LIMIT,
+        now: 1,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('uses limit defaults when initializing a supported Limit network', () => {
+    const defaultTokens = buildSwapDefaultSelectedTokensFromHomeAccount({
+      homeSelectedAccount: buildSelectedAccount({
+        networkId: 'evm--1',
+      }),
+      swapType: ESwapTabSwitchType.LIMIT,
+      now: 1,
+    });
+
+    expect(defaultTokens).toEqual({
+      fromToken: expect.objectContaining({
+        networkId: 'evm--1',
+        symbol: 'WETH',
+      }),
+      toToken: expect.objectContaining({
+        networkId: 'evm--1',
+        symbol: 'USDC',
+      }),
+      context: expect.objectContaining({
+        accountKey: 'wallet-1|indexed-account-1|default',
+        networkId: 'evm--1',
+        swapType: ESwapTabSwitchType.LIMIT,
+        updatedAt: 1,
+      }),
+      swapType: ESwapTabSwitchType.LIMIT,
+    });
+  });
+
   it('handles home network changes only before the first swap token sync completes', () => {
     const cachedContext = buildSwapSelectedTokensColdStartContext({
       activeAccount: buildActiveAccount({

--- a/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts
@@ -3,12 +3,16 @@ import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
 
 import {
+  buildSwapDefaultSelectedTokensFromHomeAccount,
   buildSwapSelectedAccountSyncedFromHome,
   buildSwapSelectedTokensColdStartAccountKey,
   buildSwapSelectedTokensColdStartAccountKeyFromSelectedAccount,
   buildSwapSelectedTokensColdStartContext,
+  getSwapSelectedTokensColdStartContextNetworkId,
   isSwapSelectedTokensColdStartContextMatched,
+  shouldClearSwapSelectedTokensBeforeHomeAccountSync,
   shouldClearSwapSelectedTokensOnHomeAccountUpdate,
+  shouldHandleSwapColdStartHomeAccountUpdate,
   shouldSyncSwapSelectedAccountOnHomeAccountUpdate,
 } from './swapColdStartTokenCacheUtils';
 
@@ -187,6 +191,32 @@ describe('swap cold-start selected token context', () => {
     expect(activeKey).toBe(selectedKey);
   });
 
+  it('uses the from-token network while single-network account sync is pending', () => {
+    expect(
+      getSwapSelectedTokensColdStartContextNetworkId({
+        accountNetworkId: 'btc--0',
+        fromTokenNetworkId: 'evm--1',
+      }),
+    ).toBe('evm--1');
+  });
+
+  it('keeps the All Networks sentinel for selected-token context', () => {
+    expect(
+      getSwapSelectedTokensColdStartContextNetworkId({
+        accountNetworkId: 'onekeyall--0',
+        fromTokenNetworkId: 'evm--1',
+      }),
+    ).toBe('onekeyall--0');
+  });
+
+  it('falls back to the account network when no from-token network exists', () => {
+    expect(
+      getSwapSelectedTokensColdStartContextNetworkId({
+        accountNetworkId: 'btc--0',
+      }),
+    ).toBe('btc--0');
+  });
+
   it('clears cached selected tokens when home network changes', () => {
     const cachedContext = buildSwapSelectedTokensColdStartContext({
       activeAccount: buildActiveAccount({
@@ -211,6 +241,122 @@ describe('swap cold-start selected token context', () => {
         },
       }),
     ).toBe(true);
+  });
+
+  it('uses home network default tokens while the first swap token sync is pending', () => {
+    const defaultTokens = buildSwapDefaultSelectedTokensFromHomeAccount({
+      homeSelectedAccount: buildSelectedAccount({
+        networkId: 'sol--101',
+      }),
+      now: 1,
+    });
+
+    expect(defaultTokens).toEqual({
+      fromToken: expect.objectContaining({
+        networkId: 'sol--101',
+        symbol: 'SOL',
+      }),
+      toToken: expect.objectContaining({
+        networkId: 'sol--101',
+        symbol: 'USDC',
+      }),
+      context: expect.objectContaining({
+        accountKey: 'wallet-1|indexed-account-1|default',
+        networkId: 'sol--101',
+        swapType: ESwapTabSwitchType.SWAP,
+        updatedAt: 1,
+      }),
+      swapType: ESwapTabSwitchType.SWAP,
+    });
+  });
+
+  it('keeps the all-networks context when preselecting default tokens before first sync', () => {
+    const defaultTokens = buildSwapDefaultSelectedTokensFromHomeAccount({
+      homeSelectedAccount: buildSelectedAccount({
+        networkId: 'onekeyall--0',
+      }),
+      now: 1,
+    });
+
+    expect(defaultTokens).toEqual({
+      fromToken: expect.objectContaining({
+        networkId: 'evm--1',
+        symbol: 'ETH',
+      }),
+      toToken: expect.objectContaining({
+        networkId: 'evm--1',
+        symbol: 'USDC',
+      }),
+      context: expect.objectContaining({
+        accountKey: 'wallet-1|indexed-account-1|default',
+        networkId: 'onekeyall--0',
+        swapType: ESwapTabSwitchType.SWAP,
+        updatedAt: 1,
+      }),
+      swapType: ESwapTabSwitchType.SWAP,
+    });
+  });
+
+  it('preselects the BTC cold-start default pair on bridge', () => {
+    const defaultTokens = buildSwapDefaultSelectedTokensFromHomeAccount({
+      homeSelectedAccount: buildSelectedAccount({
+        networkId: 'btc--0',
+      }),
+      now: 1,
+    });
+
+    expect(defaultTokens).toEqual({
+      fromToken: expect.objectContaining({
+        networkId: 'btc--0',
+        symbol: 'BTC',
+      }),
+      toToken: expect.objectContaining({
+        networkId: 'evm--1',
+        symbol: 'ETH',
+      }),
+      context: expect.objectContaining({
+        accountKey: 'wallet-1|indexed-account-1|default',
+        networkId: 'btc--0',
+        swapType: ESwapTabSwitchType.BRIDGE,
+        updatedAt: 1,
+      }),
+      swapType: ESwapTabSwitchType.BRIDGE,
+    });
+  });
+
+  it('handles home network changes only before the first swap token sync completes', () => {
+    const cachedContext = buildSwapSelectedTokensColdStartContext({
+      activeAccount: buildActiveAccount({
+        network: {
+          id: 'btc--0',
+        } as IAccountSelectorActiveAccountInfo['network'],
+      }),
+      networkId: 'btc--0',
+      swapType: ESwapTabSwitchType.BRIDGE,
+      now: 1,
+    });
+    const eventPayload = {
+      sceneName: EAccountSelectorSceneName.home,
+      num: 0,
+      selectedAccount: buildSelectedAccount({
+        networkId: 'evm--1',
+      }),
+    };
+
+    expect(
+      shouldHandleSwapColdStartHomeAccountUpdate({
+        cachedContext,
+        eventPayload,
+        initialSelectedTokensSynced: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldHandleSwapColdStartHomeAccountUpdate({
+        cachedContext,
+        eventPayload,
+        initialSelectedTokensSynced: true,
+      }),
+    ).toBe(false);
   });
 
   it('clears cached selected tokens when home account is disconnected or reset', () => {
@@ -394,6 +540,110 @@ describe('swap cold-start selected token context', () => {
           num: 0,
           selectedAccount: buildSelectedAccount(),
         },
+      }),
+    ).toBe(true);
+  });
+
+  it('preserves restored tokens when syncing the same account into All Networks without token context', () => {
+    const homeSelectedAccount = buildSelectedAccount({
+      networkId: 'onekeyall--0',
+    });
+    const swapSelectedAccount = buildSelectedAccount({
+      networkId: 'evm--1',
+    });
+
+    expect(
+      shouldSyncSwapSelectedAccountOnHomeAccountUpdate({
+        cachedContext: undefined,
+        hasSelectedTokens: true,
+        swapSelectedAccount,
+        eventPayload: {
+          sceneName: EAccountSelectorSceneName.home,
+          num: 0,
+          selectedAccount: homeSelectedAccount,
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldClearSwapSelectedTokensBeforeHomeAccountSync({
+        cachedContext: undefined,
+        hasSelectedTokens: true,
+        homeSelectedAccount,
+        swapSelectedAccount,
+      }),
+    ).toBe(false);
+  });
+
+  it('preserves restored tokens when syncing the same account into All Networks with concrete swap context', () => {
+    const cachedContext = buildSwapSelectedTokensColdStartContext({
+      activeAccount: buildActiveAccount({
+        network: {
+          id: 'evm--1',
+        } as IAccountSelectorActiveAccountInfo['network'],
+      }),
+      networkId: 'evm--1',
+      swapType: ESwapTabSwitchType.SWAP,
+      now: 1,
+    });
+    const homeSelectedAccount = buildSelectedAccount({
+      networkId: 'onekeyall--0',
+    });
+    const swapSelectedAccount = buildSelectedAccount({
+      networkId: 'evm--1',
+    });
+
+    expect(
+      shouldSyncSwapSelectedAccountOnHomeAccountUpdate({
+        cachedContext,
+        hasSelectedTokens: true,
+        swapSelectedAccount,
+        eventPayload: {
+          sceneName: EAccountSelectorSceneName.home,
+          num: 0,
+          selectedAccount: homeSelectedAccount,
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldClearSwapSelectedTokensBeforeHomeAccountSync({
+        cachedContext,
+        hasSelectedTokens: true,
+        homeSelectedAccount,
+        swapSelectedAccount,
+      }),
+    ).toBe(false);
+  });
+
+  it('clears restored tokens when syncing a single-network account without token context', () => {
+    expect(
+      shouldClearSwapSelectedTokensBeforeHomeAccountSync({
+        cachedContext: undefined,
+        hasSelectedTokens: true,
+        homeSelectedAccount: buildSelectedAccount({
+          networkId: 'btc--0',
+        }),
+        swapSelectedAccount: buildSelectedAccount({
+          networkId: 'evm--1',
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it('clears restored tokens when syncing All Networks for another account without token context', () => {
+    expect(
+      shouldClearSwapSelectedTokensBeforeHomeAccountSync({
+        cachedContext: undefined,
+        hasSelectedTokens: true,
+        homeSelectedAccount: buildSelectedAccount({
+          indexedAccountId: 'indexed-account-2',
+          networkId: 'onekeyall--0',
+        }),
+        swapSelectedAccount: buildSelectedAccount({
+          indexedAccountId: 'indexed-account-1',
+          networkId: 'evm--1',
+        }),
       }),
     ).toBe(true);
   });

--- a/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts
@@ -20,6 +20,7 @@ import {
   shouldClearSwapSelectedTokensBeforeHomeAccountSync,
   shouldClearSwapSelectedTokensOnHomeAccountUpdate,
   shouldHandleSwapColdStartHomeAccountUpdate,
+  shouldSkipSwapDefaultSelectedTokenSync,
   shouldSyncSwapSelectedAccountOnHomeAccountUpdate,
 } from './swapColdStartTokenCacheUtils';
 
@@ -798,6 +799,66 @@ describe('swap cold-start selected token context', () => {
         }),
       }),
     ).toBe(true);
+  });
+
+  it('preserves selected tokens after initial sync when the same account switches networks', () => {
+    expect(
+      shouldClearSwapSelectedTokensBeforeHomeAccountSync({
+        cachedContext: undefined,
+        hasSelectedTokens: true,
+        homeSelectedAccount: buildSelectedAccount({
+          networkId: 'sol--101',
+        }),
+        initialSelectedTokensSynced: true,
+        swapSelectedAccount: buildSelectedAccount({
+          networkId: 'evm--1',
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it('clears selected tokens after initial sync when the home account owner changes', () => {
+    expect(
+      shouldClearSwapSelectedTokensBeforeHomeAccountSync({
+        cachedContext: undefined,
+        hasSelectedTokens: true,
+        homeSelectedAccount: buildSelectedAccount({
+          indexedAccountId: 'indexed-account-2',
+          networkId: 'sol--101',
+        }),
+        initialSelectedTokensSynced: true,
+        swapSelectedAccount: buildSelectedAccount({
+          indexedAccountId: 'indexed-account-1',
+          networkId: 'evm--1',
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it('continues default token sync after initial sync when selected tokens are empty', () => {
+    expect(
+      shouldSkipSwapDefaultSelectedTokenSync({
+        hasImportParams: false,
+        hasSelectedTokens: false,
+        initialSelectedTokensSynced: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSkipSwapDefaultSelectedTokenSync({
+        hasImportParams: false,
+        hasSelectedTokens: true,
+        initialSelectedTokensSynced: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSkipSwapDefaultSelectedTokenSync({
+        hasImportParams: true,
+        hasSelectedTokens: true,
+        initialSelectedTokensSynced: true,
+      }),
+    ).toBe(false);
   });
 
   it('clears restored tokens when syncing All Networks for another account without token context', () => {

--- a/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.ts
@@ -13,7 +13,10 @@ import {
   swapBridgeDefaultTokenExtraConfigs,
   swapDefaultSetTokens,
 } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
-import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+import type {
+  ISwapNetwork,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
 import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
 
 export {
@@ -269,6 +272,40 @@ export function buildSwapDefaultSelectedTokensFromHomeAccount({
     },
     swapType,
   };
+}
+
+export function getSelectedTokensColdStartLimitSupport({
+  swapType,
+  fromToken,
+  toToken,
+  swapNetworks,
+}: {
+  swapType: ESwapTabSwitchType;
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+  swapNetworks: ISwapNetwork[];
+}) {
+  if (swapType !== ESwapTabSwitchType.LIMIT) {
+    return true;
+  }
+
+  const selectedTokenNetworkId = fromToken?.networkId ?? toToken?.networkId;
+  if (!selectedTokenNetworkId) {
+    return true;
+  }
+
+  if (!swapNetworks.length) {
+    return undefined;
+  }
+
+  const selectedTokenNetwork = swapNetworks.find(
+    (net) => net.networkId === selectedTokenNetworkId,
+  );
+  if (!selectedTokenNetwork) {
+    return true;
+  }
+
+  return Boolean(selectedTokenNetwork?.supportLimit);
 }
 
 function isSelectedAccountMatched(

--- a/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.ts
@@ -379,14 +379,23 @@ export function shouldClearSwapSelectedTokensBeforeHomeAccountSync({
   cachedContext,
   hasSelectedTokens,
   homeSelectedAccount,
+  initialSelectedTokensSynced,
   swapSelectedAccount,
 }: {
   cachedContext?: ISwapSelectedTokensColdStartContext;
   hasSelectedTokens: boolean;
   homeSelectedAccount?: IAccountSelectorSelectedAccount;
+  initialSelectedTokensSynced?: boolean;
   swapSelectedAccount?: IAccountSelectorSelectedAccount;
 }) {
   if (!hasSelectedTokens) {
+    return false;
+  }
+
+  if (
+    initialSelectedTokensSynced &&
+    isSelectedAccountOwnerMatched(homeSelectedAccount, swapSelectedAccount)
+  ) {
     return false;
   }
 
@@ -414,6 +423,18 @@ export function shouldClearSwapSelectedTokensBeforeHomeAccountSync({
   }
 
   return true;
+}
+
+export function shouldSkipSwapDefaultSelectedTokenSync({
+  hasImportParams,
+  hasSelectedTokens,
+  initialSelectedTokensSynced,
+}: {
+  hasImportParams: boolean;
+  hasSelectedTokens: boolean;
+  initialSelectedTokensSynced: boolean;
+}) {
+  return initialSelectedTokensSynced && !hasImportParams && hasSelectedTokens;
 }
 
 export function getSwapSelectedTokensColdStartContextNetworkId({

--- a/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.ts
@@ -6,7 +6,15 @@ import {
   isSwapSelectedTokensColdStartContextMatched,
 } from '@onekeyhq/shared/src/utils/swapColdStartCacheSnapshotUtils';
 import type { ISwapSelectedTokensColdStartContext } from '@onekeyhq/shared/src/utils/swapColdStartCacheSnapshotUtils';
+import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
+import {
+  swapBridgeDefaultTokenConfigs,
+  swapBridgeDefaultTokenExtraConfigs,
+  swapDefaultSetTokens,
+} from '@onekeyhq/shared/types/swap/SwapProvider.constants';
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
 
 export {
   buildSwapSelectedTokensColdStartAccountKey,
@@ -18,11 +26,19 @@ export {
 export const SWAP_COLD_START_HOME_SCENE_NAME =
   'home' as EAccountSelectorSceneName;
 
+type ISwapSelectedAccountKeySource = {
+  walletId?: string;
+  indexedAccountId?: string;
+  othersWalletAccountId?: string;
+  deriveType?: string;
+};
+
+type ISwapHomeSelectedAccountForDefaults = ISwapSelectedAccountKeySource & {
+  networkId?: string;
+};
+
 export function buildSwapSelectedTokensColdStartAccountKeyFromSelectedAccount(
-  selectedAccount?: Pick<
-    IAccountSelectorSelectedAccount,
-    'walletId' | 'indexedAccountId' | 'othersWalletAccountId' | 'deriveType'
-  >,
+  selectedAccount?: ISwapSelectedAccountKeySource,
 ) {
   // Delegate to the single shared key builder so the persisted selected-account
   // key always matches the runtime active-account key. othersWalletAccountId is a
@@ -123,6 +139,129 @@ export function shouldClearSwapSelectedTokensOnHomeAccountUpdate({
   );
 }
 
+export function shouldHandleSwapColdStartHomeAccountUpdate({
+  cachedContext,
+  eventPayload,
+  initialSelectedTokensSynced,
+}: {
+  cachedContext?: ISwapSelectedTokensColdStartContext;
+  eventPayload: {
+    selectedAccount?: IAccountSelectorSelectedAccount;
+    sceneName: EAccountSelectorSceneName;
+    num: number;
+  };
+  initialSelectedTokensSynced: boolean;
+}) {
+  if (initialSelectedTokensSynced) {
+    return false;
+  }
+
+  return shouldClearSwapSelectedTokensOnHomeAccountUpdate({
+    cachedContext,
+    eventPayload,
+  });
+}
+
+function getDefaultSelectedTokensSwapType({
+  fromToken,
+  toToken,
+}: {
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+}) {
+  if (
+    fromToken?.networkId &&
+    toToken?.networkId &&
+    fromToken.networkId !== toToken.networkId
+  ) {
+    return ESwapTabSwitchType.BRIDGE;
+  }
+
+  return ESwapTabSwitchType.SWAP;
+}
+
+function getBridgeDefaultToTokenForFromToken(fromToken?: ISwapToken) {
+  if (!fromToken) {
+    return undefined;
+  }
+
+  let defaultToToken: ISwapToken | undefined;
+  swapBridgeDefaultTokenConfigs.some((config) => {
+    const matchedToken = config.fromTokens.find((token) =>
+      equalTokenNoCaseSensitive({
+        token1: {
+          networkId: token.networkId,
+          contractAddress: token.contractAddress,
+        },
+        token2: {
+          networkId: fromToken.networkId,
+          contractAddress: fromToken.contractAddress,
+        },
+      }),
+    );
+    if (matchedToken) {
+      defaultToToken = config.toTokenDefaultMatch;
+    }
+    return Boolean(matchedToken);
+  });
+
+  if (defaultToToken) {
+    return defaultToToken;
+  }
+
+  return fromToken.networkId ===
+    swapBridgeDefaultTokenExtraConfigs.mainNetDefaultToTokenConfig.networkId
+    ? swapBridgeDefaultTokenExtraConfigs.mainNetDefaultToTokenConfig
+        .defaultToToken
+    : swapBridgeDefaultTokenExtraConfigs.defaultToToken;
+}
+
+export function buildSwapDefaultSelectedTokensFromHomeAccount({
+  homeSelectedAccount,
+  now = Date.now(),
+}: {
+  homeSelectedAccount?: ISwapHomeSelectedAccountForDefaults;
+  now?: number;
+}) {
+  const accountKey =
+    buildSwapSelectedTokensColdStartAccountKeyFromSelectedAccount(
+      homeSelectedAccount,
+    );
+  const homeNetworkId = homeSelectedAccount?.networkId;
+  if (!accountKey || !homeNetworkId) {
+    return undefined;
+  }
+
+  const defaultTokens = swapDefaultSetTokens[homeNetworkId];
+  const fromToken = defaultTokens?.fromToken;
+  const toToken =
+    defaultTokens?.toToken ?? getBridgeDefaultToTokenForFromToken(fromToken);
+  if (!fromToken && !toToken) {
+    return undefined;
+  }
+
+  const swapType = getDefaultSelectedTokensSwapType({ fromToken, toToken });
+  const contextNetworkId = getSwapSelectedTokensColdStartContextNetworkId({
+    accountNetworkId: homeNetworkId,
+    fromTokenNetworkId: fromToken?.networkId,
+  });
+  if (!contextNetworkId) {
+    return undefined;
+  }
+
+  return {
+    fromToken,
+    toToken,
+    context: {
+      accountKey,
+      networkId: contextNetworkId,
+      swapType,
+      updatedAt: now,
+    },
+    swapType,
+  };
+}
+
 function isSelectedAccountMatched(
   accountA?: IAccountSelectorSelectedAccount,
   accountB?: IAccountSelectorSelectedAccount,
@@ -134,6 +273,75 @@ function isSelectedAccountMatched(
     accountA?.networkId === accountB?.networkId &&
     accountA?.deriveType === accountB?.deriveType
   );
+}
+
+function isSelectedAccountOwnerMatched(
+  accountA?: IAccountSelectorSelectedAccount,
+  accountB?: IAccountSelectorSelectedAccount,
+) {
+  const accountKeyA =
+    buildSwapSelectedTokensColdStartAccountKeyFromSelectedAccount(accountA);
+  const accountKeyB =
+    buildSwapSelectedTokensColdStartAccountKeyFromSelectedAccount(accountB);
+  return Boolean(accountKeyA && accountKeyA === accountKeyB);
+}
+
+export function shouldClearSwapSelectedTokensBeforeHomeAccountSync({
+  cachedContext,
+  hasSelectedTokens,
+  homeSelectedAccount,
+  swapSelectedAccount,
+}: {
+  cachedContext?: ISwapSelectedTokensColdStartContext;
+  hasSelectedTokens: boolean;
+  homeSelectedAccount?: IAccountSelectorSelectedAccount;
+  swapSelectedAccount?: IAccountSelectorSelectedAccount;
+}) {
+  if (!hasSelectedTokens) {
+    return false;
+  }
+
+  const isMatched =
+    isSwapSelectedTokensColdStartContextMatchedWithSelectedAccount({
+      cachedContext,
+      selectedAccount: homeSelectedAccount,
+    });
+  if (isMatched === true) {
+    return false;
+  }
+
+  const isSameOwnerAllNetworksHome =
+    isSwapColdStartAllNetworkContextNetworkId(homeSelectedAccount?.networkId) &&
+    isSelectedAccountOwnerMatched(homeSelectedAccount, swapSelectedAccount);
+  if (
+    isSameOwnerAllNetworksHome &&
+    (!cachedContext ||
+      isSwapSelectedTokensColdStartContextMatchedWithSelectedAccount({
+        cachedContext,
+        selectedAccount: swapSelectedAccount,
+      }) === true)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export function getSwapSelectedTokensColdStartContextNetworkId({
+  accountNetworkId,
+  fromTokenNetworkId,
+}: {
+  accountNetworkId?: string;
+  fromTokenNetworkId?: string;
+}) {
+  if (
+    accountNetworkId &&
+    isSwapColdStartAllNetworkContextNetworkId(accountNetworkId)
+  ) {
+    return accountNetworkId;
+  }
+
+  return fromTokenNetworkId ?? accountNetworkId;
 }
 
 export function shouldSyncSwapSelectedAccountOnHomeAccountUpdate({

--- a/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.ts
@@ -218,9 +218,11 @@ function getBridgeDefaultToTokenForFromToken(fromToken?: ISwapToken) {
 
 export function buildSwapDefaultSelectedTokensFromHomeAccount({
   homeSelectedAccount,
+  swapType: preferredSwapType,
   now = Date.now(),
 }: {
   homeSelectedAccount?: ISwapHomeSelectedAccountForDefaults;
+  swapType?: ESwapTabSwitchType;
   now?: number;
 }) {
   const accountKey =
@@ -233,14 +235,21 @@ export function buildSwapDefaultSelectedTokensFromHomeAccount({
   }
 
   const defaultTokens = swapDefaultSetTokens[homeNetworkId];
-  const fromToken = defaultTokens?.fromToken;
-  const toToken =
-    defaultTokens?.toToken ?? getBridgeDefaultToTokenForFromToken(fromToken);
+  const useLimitDefaults = preferredSwapType === ESwapTabSwitchType.LIMIT;
+  const fromToken = useLimitDefaults
+    ? defaultTokens?.limitFromToken
+    : defaultTokens?.fromToken;
+  const toToken = useLimitDefaults
+    ? defaultTokens?.limitToToken
+    : (defaultTokens?.toToken ??
+      getBridgeDefaultToTokenForFromToken(fromToken));
   if (!fromToken && !toToken) {
     return undefined;
   }
 
-  const swapType = getDefaultSelectedTokensSwapType({ fromToken, toToken });
+  const swapType = useLimitDefaults
+    ? ESwapTabSwitchType.LIMIT
+    : getDefaultSelectedTokensSwapType({ fromToken, toToken });
   const contextNetworkId = getSwapSelectedTokensColdStartContextNetworkId({
     accountNetworkId: homeNetworkId,
     fromTokenNetworkId: fromToken?.networkId,

--- a/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.ts
@@ -308,6 +308,49 @@ export function getSelectedTokensColdStartLimitSupport({
   return Boolean(selectedTokenNetwork?.supportLimit);
 }
 
+export function getSwapTokenSupportTypes({
+  token,
+  swapNetworks,
+}: {
+  token?: ISwapToken;
+  swapNetworks: ISwapNetwork[];
+}) {
+  const supportNet = swapNetworks.find(
+    (net) => net.networkId === token?.networkId,
+  );
+  const supportTypes: ESwapTabSwitchType[] = [];
+  if (!supportNet) {
+    return supportTypes;
+  }
+
+  if (supportNet.supportSingleSwap) {
+    supportTypes.push(ESwapTabSwitchType.SWAP);
+  }
+  if (supportNet.supportCrossChainSwap) {
+    supportTypes.push(ESwapTabSwitchType.BRIDGE);
+  }
+  if (supportNet.supportLimit) {
+    supportTypes.push(ESwapTabSwitchType.LIMIT);
+  }
+
+  return supportTypes;
+}
+
+export function isSwapTokenSupportedBySwapType({
+  token,
+  swapNetworks,
+  swapType,
+}: {
+  token?: ISwapToken;
+  swapNetworks: ISwapNetwork[];
+  swapType?: ESwapTabSwitchType;
+}) {
+  return Boolean(
+    swapType &&
+    getSwapTokenSupportTypes({ token, swapNetworks }).includes(swapType),
+  );
+}
+
 function isSelectedAccountMatched(
   accountA?: IAccountSelectorSelectedAccount,
   accountB?: IAccountSelectorSelectedAccount,

--- a/packages/shared/src/utils/swapColdStartCacheSnapshotUtils.test.ts
+++ b/packages/shared/src/utils/swapColdStartCacheSnapshotUtils.test.ts
@@ -4,6 +4,7 @@ import { CONTEXT_ATOM_COLD_START_CACHE_KEYS } from '../consts/jotaiConsts';
 import {
   buildSwapSelectedTokensColdStartAccountKey,
   buildSwapSelectedTokensColdStartContext,
+  getSwapColdStartSelectedTokensFromSnapshot,
   isSwapColdStartAllNetworkContextNetworkId,
   normalizeSwapColdStartCacheSnapshot,
 } from './swapColdStartCacheSnapshotUtils';
@@ -14,6 +15,7 @@ function buildSnapshotKey(scope: string, key: string) {
 
 const swapScope = 'store:swap';
 const homeScope = 'store:accountSelector@home';
+const swapAccountSelectorScope = 'store:accountSelector@swap';
 
 function buildActiveAccount({
   networkId = 'btc--0',
@@ -32,16 +34,28 @@ function buildSwapSnapshot({
   contextNetworkId = 'btc--0',
   activeNetworkId = 'btc--0',
   activeIndexedAccountId = 'indexed-account-1',
+  swapActiveNetworkId,
+  swapActiveIndexedAccountId = activeIndexedAccountId,
   contextSwapType = ESwapTabSwitchType.BRIDGE,
   snapshotSwapType = ESwapTabSwitchType.BRIDGE,
   fromTokenNetworkId = 'btc--0',
   toTokenNetworkId = 'evm--1',
+}: {
+  contextNetworkId?: string;
+  activeNetworkId?: string;
+  activeIndexedAccountId?: string;
+  swapActiveNetworkId?: string;
+  swapActiveIndexedAccountId?: string;
+  contextSwapType?: ESwapTabSwitchType;
+  snapshotSwapType?: ESwapTabSwitchType;
+  fromTokenNetworkId?: string;
+  toTokenNetworkId?: string;
 } = {}) {
   const activeAccount = buildActiveAccount({
     networkId: activeNetworkId,
     indexedAccountId: activeIndexedAccountId,
   });
-  return {
+  const snapshot: Record<string, unknown> = {
     [buildSnapshotKey(
       homeScope,
       CONTEXT_ATOM_COLD_START_CACHE_KEYS.activeAccountsAtom,
@@ -70,6 +84,20 @@ function buildSwapSnapshot({
       CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectToTokenAtom,
     )]: { networkId: toTokenNetworkId, symbol: 'ETH' },
   };
+  if (swapActiveNetworkId) {
+    snapshot[
+      buildSnapshotKey(
+        swapAccountSelectorScope,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.activeAccountsAtom,
+      )
+    ] = {
+      0: buildActiveAccount({
+        networkId: swapActiveNetworkId,
+        indexedAccountId: swapActiveIndexedAccountId,
+      }),
+    };
+  }
+  return snapshot;
 }
 
 describe('swapColdStartCacheSnapshotUtils', () => {
@@ -177,6 +205,256 @@ describe('swapColdStartCacheSnapshotUtils', () => {
         )
       ],
     ).toBeDefined();
+  });
+
+  it('keeps a concrete swap context when home is all-network for the same account', () => {
+    const snapshot = buildSwapSnapshot({
+      contextNetworkId: 'evm--1',
+      activeNetworkId: 'onekeyall--0',
+      swapActiveNetworkId: 'evm--1',
+      contextSwapType: ESwapTabSwitchType.SWAP,
+      snapshotSwapType: ESwapTabSwitchType.SWAP,
+      fromTokenNetworkId: 'evm--1',
+      toTokenNetworkId: 'evm--1',
+    });
+
+    normalizeSwapColdStartCacheSnapshot(snapshot);
+
+    expect(
+      snapshot[
+        buildSnapshotKey(
+          swapScope,
+          CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectFromTokenAtom,
+        )
+      ],
+    ).toEqual({ networkId: 'evm--1', symbol: 'BTC' });
+    expect(
+      snapshot[
+        buildSnapshotKey(
+          swapScope,
+          CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectedTokensColdStartContextAtom,
+        )
+      ],
+    ).toEqual(
+      expect.objectContaining({
+        networkId: 'evm--1',
+        swapType: ESwapTabSwitchType.SWAP,
+      }),
+    );
+  });
+
+  it('backfills missing all-network context for same-account selected token snapshots', () => {
+    const snapshot = buildSwapSnapshot({
+      contextNetworkId: 'onekeyall--0',
+      activeNetworkId: 'onekeyall--0',
+      contextSwapType: ESwapTabSwitchType.SWAP,
+      snapshotSwapType: ESwapTabSwitchType.SWAP,
+      fromTokenNetworkId: 'evm--1',
+      toTokenNetworkId: 'evm--1',
+    });
+    delete snapshot[
+      buildSnapshotKey(
+        swapScope,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectedTokensColdStartContextAtom,
+      )
+    ];
+    snapshot[
+      buildSnapshotKey(
+        homeScope,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+      )
+    ] = {
+      0: {
+        walletId: 'wallet-1',
+        indexedAccountId: 'indexed-account-1',
+        networkId: 'onekeyall--0',
+        deriveType: 'default',
+      },
+    };
+    snapshot[
+      buildSnapshotKey(
+        swapAccountSelectorScope,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+      )
+    ] = {
+      0: {
+        walletId: 'wallet-1',
+        indexedAccountId: 'indexed-account-1',
+        networkId: 'evm--1',
+        deriveType: 'default',
+      },
+    };
+
+    normalizeSwapColdStartCacheSnapshot(snapshot);
+
+    expect(
+      snapshot[
+        buildSnapshotKey(
+          swapScope,
+          CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectFromTokenAtom,
+        )
+      ],
+    ).toEqual({ networkId: 'evm--1', symbol: 'BTC' });
+    expect(
+      snapshot[
+        buildSnapshotKey(
+          swapScope,
+          CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectedTokensColdStartContextAtom,
+        )
+      ],
+    ).toEqual(
+      expect.objectContaining({
+        accountKey: 'wallet-1|indexed-account-1|default',
+        networkId: 'onekeyall--0',
+        swapType: ESwapTabSwitchType.SWAP,
+      }),
+    );
+  });
+
+  it('drops missing-context selected token snapshots when the all-network account owner differs', () => {
+    const snapshot = buildSwapSnapshot({
+      contextNetworkId: 'onekeyall--0',
+      activeNetworkId: 'onekeyall--0',
+      fromTokenNetworkId: 'evm--1',
+      toTokenNetworkId: 'evm--1',
+    });
+    delete snapshot[
+      buildSnapshotKey(
+        swapScope,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectedTokensColdStartContextAtom,
+      )
+    ];
+    snapshot[
+      buildSnapshotKey(
+        homeScope,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+      )
+    ] = {
+      0: {
+        walletId: 'wallet-1',
+        indexedAccountId: 'indexed-account-2',
+        networkId: 'onekeyall--0',
+        deriveType: 'default',
+      },
+    };
+    snapshot[
+      buildSnapshotKey(
+        swapAccountSelectorScope,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+      )
+    ] = {
+      0: {
+        walletId: 'wallet-1',
+        indexedAccountId: 'indexed-account-1',
+        networkId: 'evm--1',
+        deriveType: 'default',
+      },
+    };
+
+    normalizeSwapColdStartCacheSnapshot(snapshot);
+
+    expect(
+      snapshot[
+        buildSnapshotKey(
+          swapScope,
+          CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectFromTokenAtom,
+        )
+      ],
+    ).toBeUndefined();
+  });
+
+  it('extracts normalized selected tokens from a same-account all-network snapshot without context', () => {
+    const snapshot = buildSwapSnapshot({
+      contextNetworkId: 'onekeyall--0',
+      activeNetworkId: 'onekeyall--0',
+      contextSwapType: ESwapTabSwitchType.SWAP,
+      snapshotSwapType: ESwapTabSwitchType.SWAP,
+      fromTokenNetworkId: 'evm--1',
+      toTokenNetworkId: 'evm--1',
+    });
+    delete snapshot[
+      buildSnapshotKey(
+        swapScope,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectedTokensColdStartContextAtom,
+      )
+    ];
+    snapshot[
+      buildSnapshotKey(
+        homeScope,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+      )
+    ] = {
+      0: {
+        walletId: 'wallet-1',
+        indexedAccountId: 'indexed-account-1',
+        networkId: 'onekeyall--0',
+        deriveType: 'default',
+      },
+    };
+    snapshot[
+      buildSnapshotKey(
+        swapAccountSelectorScope,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+      )
+    ] = {
+      0: {
+        walletId: 'wallet-1',
+        indexedAccountId: 'indexed-account-1',
+        networkId: 'evm--1',
+        deriveType: 'default',
+      },
+    };
+
+    expect(getSwapColdStartSelectedTokensFromSnapshot(snapshot)).toEqual({
+      fromToken: { networkId: 'evm--1', symbol: 'BTC' },
+      toToken: { networkId: 'evm--1', symbol: 'ETH' },
+    });
+  });
+
+  it('does not extract selected tokens when the normalized snapshot drops them', () => {
+    const snapshot = buildSwapSnapshot({
+      contextNetworkId: 'onekeyall--0',
+      activeNetworkId: 'onekeyall--0',
+      fromTokenNetworkId: 'evm--1',
+      toTokenNetworkId: 'evm--1',
+    });
+    delete snapshot[
+      buildSnapshotKey(
+        swapScope,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectedTokensColdStartContextAtom,
+      )
+    ];
+    snapshot[
+      buildSnapshotKey(
+        homeScope,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+      )
+    ] = {
+      0: {
+        walletId: 'wallet-1',
+        indexedAccountId: 'indexed-account-2',
+        networkId: 'onekeyall--0',
+        deriveType: 'default',
+      },
+    };
+    snapshot[
+      buildSnapshotKey(
+        swapAccountSelectorScope,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+      )
+    ] = {
+      0: {
+        walletId: 'wallet-1',
+        indexedAccountId: 'indexed-account-1',
+        networkId: 'evm--1',
+        deriveType: 'default',
+      },
+    };
+
+    expect(getSwapColdStartSelectedTokensFromSnapshot(snapshot)).toEqual({
+      fromToken: undefined,
+      toToken: undefined,
+    });
   });
 
   it('drops swap type and token snapshot when home network changes', () => {

--- a/packages/shared/src/utils/swapColdStartCacheSnapshotUtils.ts
+++ b/packages/shared/src/utils/swapColdStartCacheSnapshotUtils.ts
@@ -21,9 +21,22 @@ type IColdStartActiveAccountsValue = Record<
   IColdStartAccountLike | undefined
 >;
 
-type IColdStartSwapTokenLike = {
+export type IColdStartSwapTokenLike = {
   networkId?: string;
 };
+
+type IColdStartSelectedAccountLike = {
+  walletId?: string;
+  indexedAccountId?: string;
+  othersWalletAccountId?: string;
+  deriveType?: string;
+  networkId?: string;
+};
+
+type IColdStartSelectedAccountsValue = Record<
+  string | number,
+  IColdStartSelectedAccountLike | undefined
+>;
 
 export type ISwapSelectedTokensColdStartContext = {
   accountKey: string;
@@ -66,6 +79,23 @@ export function buildSwapSelectedTokensColdStartAccountKey(
     activeAccount?.account?.id ??
     '';
   const deriveType = activeAccount?.deriveType ?? '';
+
+  if (!walletId && !accountId) {
+    return undefined;
+  }
+
+  return [walletId, accountId, deriveType].join('|');
+}
+
+function buildSwapSelectedTokensColdStartAccountKeyFromSelectedAccount(
+  selectedAccount?: IColdStartSelectedAccountLike,
+) {
+  const walletId = selectedAccount?.walletId ?? '';
+  const accountId =
+    selectedAccount?.indexedAccountId ??
+    selectedAccount?.othersWalletAccountId ??
+    '';
+  const deriveType = selectedAccount?.deriveType ?? '';
 
   if (!walletId && !accountId) {
     return undefined;
@@ -119,6 +149,56 @@ export function isSwapSelectedTokensColdStartContextMatched({
   );
 }
 
+function isSwapSelectedTokensColdStartContextMatchedWithHomeAndSwapAccounts({
+  cachedContext,
+  homeActiveAccount,
+  swapActiveAccount,
+}: {
+  cachedContext: ISwapSelectedTokensColdStartContext;
+  homeActiveAccount?: IColdStartAccountLike;
+  swapActiveAccount?: IColdStartAccountLike;
+}) {
+  const homeContext = buildSwapSelectedTokensColdStartContext({
+    activeAccount: homeActiveAccount,
+    networkId: homeActiveAccount?.network?.id,
+  });
+  if (
+    isSwapSelectedTokensColdStartContextMatched({
+      cachedContext,
+      currentContext: homeContext,
+    })
+  ) {
+    return true;
+  }
+
+  const swapContext = buildSwapSelectedTokensColdStartContext({
+    activeAccount: swapActiveAccount,
+    networkId: swapActiveAccount?.network?.id,
+  });
+  if (
+    !homeContext &&
+    isSwapSelectedTokensColdStartContextMatched({
+      cachedContext,
+      currentContext: swapContext,
+    })
+  ) {
+    return true;
+  }
+
+  const isSameOwnerAllNetworksHome =
+    isSwapColdStartAllNetworkContextNetworkId(homeContext?.networkId) &&
+    homeContext?.accountKey &&
+    homeContext.accountKey === swapContext?.accountKey;
+
+  return Boolean(
+    isSameOwnerAllNetworksHome &&
+    isSwapSelectedTokensColdStartContextMatched({
+      cachedContext,
+      currentContext: swapContext,
+    }),
+  );
+}
+
 function getActiveAccountFromSnapshot(
   snapshot: Record<string, unknown>,
   scopeKey: string,
@@ -132,6 +212,21 @@ function getActiveAccountFromSnapshot(
     | null
     | undefined;
   return activeAccounts?.[0] ?? activeAccounts?.['0'];
+}
+
+function getSelectedAccountFromSnapshot(
+  snapshot: Record<string, unknown>,
+  scopeKey: string,
+) {
+  const selectedAccountsKey = buildContextAtomSnapshotKey({
+    coldStartScopeKey: scopeKey,
+    coldStartCacheKey: CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+  });
+  const selectedAccounts = snapshot[selectedAccountsKey] as
+    | IColdStartSelectedAccountsValue
+    | null
+    | undefined;
+  return selectedAccounts?.[0] ?? selectedAccounts?.['0'];
 }
 
 function deleteSwapSelectedTokensColdStartSnapshot(
@@ -262,6 +357,68 @@ function normalizeSwapTypeSnapshot({
   };
 }
 
+function backfillAllNetworkSwapSelectedTokensContext({
+  contextKey,
+  snapshot,
+}: {
+  contextKey: string;
+  snapshot: Record<string, unknown>;
+}) {
+  const homeSelectedAccount = getSelectedAccountFromSnapshot(
+    snapshot,
+    ACCOUNT_SELECTOR_HOME_SCOPE_KEY,
+  );
+  const swapSelectedAccount = getSelectedAccountFromSnapshot(
+    snapshot,
+    ACCOUNT_SELECTOR_SWAP_SCOPE_KEY,
+  );
+  const homeNetworkId = homeSelectedAccount?.networkId;
+  if (
+    !homeNetworkId ||
+    !isSwapColdStartAllNetworkContextNetworkId(homeNetworkId)
+  ) {
+    return undefined;
+  }
+
+  const homeAccountKey =
+    buildSwapSelectedTokensColdStartAccountKeyFromSelectedAccount(
+      homeSelectedAccount,
+    );
+  const swapAccountKey =
+    buildSwapSelectedTokensColdStartAccountKeyFromSelectedAccount(
+      swapSelectedAccount,
+    );
+  if (!homeAccountKey || homeAccountKey !== swapAccountKey) {
+    return undefined;
+  }
+
+  const fromToken = getSwapSnapshotValue<IColdStartSwapTokenLike>(
+    snapshot,
+    CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectFromTokenAtom,
+  );
+  if (!fromToken?.networkId) {
+    return undefined;
+  }
+
+  const snapshotSwapType = getSwapSnapshotValue<ESwapTabSwitchType>(
+    snapshot,
+    CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapTypeSwitchAtom,
+  );
+  const cachedContext: ISwapSelectedTokensColdStartContext = {
+    accountKey: homeAccountKey,
+    networkId: homeNetworkId,
+    swapType: snapshotSwapType ?? undefined,
+    updatedAt: Date.now(),
+  };
+  snapshot[contextKey] = cachedContext;
+  normalizeSwapTypeSnapshot({
+    snapshot,
+    contextKey,
+    cachedContext,
+  });
+  return cachedContext;
+}
+
 export function normalizeSwapColdStartCacheSnapshot(
   snapshot: Record<string, unknown>,
 ) {
@@ -279,28 +436,33 @@ export function normalizeSwapColdStartCacheSnapshot(
     coldStartCacheKey:
       CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectedTokensColdStartContextAtom,
   });
-  const cachedContext = snapshot[contextKey] as
+  let cachedContext = snapshot[contextKey] as
     | ISwapSelectedTokensColdStartContext
     | null
     | undefined;
 
   if (!cachedContext) {
-    deleteSwapSelectedTokensColdStartSnapshot(snapshot);
-    return snapshot;
+    cachedContext = backfillAllNetworkSwapSelectedTokensContext({
+      contextKey,
+      snapshot,
+    });
+    if (!cachedContext) {
+      deleteSwapSelectedTokensColdStartSnapshot(snapshot);
+      return snapshot;
+    }
   }
 
-  const activeAccount =
-    getActiveAccountFromSnapshot(snapshot, ACCOUNT_SELECTOR_HOME_SCOPE_KEY) ??
-    getActiveAccountFromSnapshot(snapshot, ACCOUNT_SELECTOR_SWAP_SCOPE_KEY);
-  const currentContext = buildSwapSelectedTokensColdStartContext({
-    activeAccount,
-    networkId: activeAccount?.network?.id,
-  });
-
   if (
-    !isSwapSelectedTokensColdStartContextMatched({
+    !isSwapSelectedTokensColdStartContextMatchedWithHomeAndSwapAccounts({
       cachedContext,
-      currentContext,
+      homeActiveAccount: getActiveAccountFromSnapshot(
+        snapshot,
+        ACCOUNT_SELECTOR_HOME_SCOPE_KEY,
+      ),
+      swapActiveAccount: getActiveAccountFromSnapshot(
+        snapshot,
+        ACCOUNT_SELECTOR_SWAP_SCOPE_KEY,
+      ),
     }) ||
     !isSwapSelectedTokenSnapshotMatchedContext({ snapshot, cachedContext })
   ) {
@@ -315,4 +477,25 @@ export function normalizeSwapColdStartCacheSnapshot(
   });
 
   return snapshot;
+}
+
+export function getSwapColdStartSelectedTokensFromSnapshot<
+  TSwapToken extends IColdStartSwapTokenLike = IColdStartSwapTokenLike,
+>(snapshot: Record<string, unknown>) {
+  const normalizedSnapshot = normalizeSwapColdStartCacheSnapshot({
+    ...snapshot,
+  });
+
+  return {
+    fromToken:
+      getSwapSnapshotValue<TSwapToken>(
+        normalizedSnapshot,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectFromTokenAtom,
+      ) ?? undefined,
+    toToken:
+      getSwapSnapshotValue<TSwapToken>(
+        normalizedSnapshot,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectToTokenAtom,
+      ) ?? undefined,
+  };
 }

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -127,6 +127,7 @@ export interface ISwapInitParams {
   swapTabSwitchType?: ESwapTabSwitchType;
   fromAmount?: string;
   marketPresetToken?: IMarketPresetTokenContext;
+  swapSource?: ESwapSource;
 }
 
 // token & network


### PR DESCRIPTION
## Summary
- Preserve Swap cold-start token and swap-type snapshots with an account/network context so stale tokens are dropped while valid All Networks snapshots survive launch normalization.
- Add a cold-start display-token fallback for the Swap input and network row so token/network icons can render from the boot snapshot before Jotai hydration finishes.
- Gate the first home-account-to-swap sync so default tokens are brought in once for the initial network, while later network switches no longer clear an already initialized pair.

## Intent & Context
The Swap tab had two cold-start regressions. First, launching the app, switching Home to All Networks, and immediately opening Swap caused the network icon and token icon to flicker through skeleton/empty states several times. On iOS, the same path showed a visibly long skeleton window, which hurt the cold-start impression.

The second regression appeared after the first pair was initialized. For example, after Swap rendered the expected ETH - USDC pair on the ETH network, switching Home to Solana and entering Swap could show "Select Token" instead of preserving the initialized pair. The intended behavior is that the first entry into a network can bring in that network's expected default tokens, including the BTC-to-ETH cold-start path, but once that initial import has happened, later network switches should not keep replacing or clearing the Swap pair.

## Root Cause
The flicker came from the Swap UI depending only on hydrated runtime atoms for the token selector and network row. During cold start, those atoms can be temporarily empty while the persisted context-atom snapshot and account/network sync settle, so the UI rendered skeletons or empty token labels before the real selected tokens arrived.

The "Select Token" regression came from treating home network changes as token invalidation too broadly. The previous logic did not separate the first default-token sync from subsequent network changes, so a later Home network switch could clear Swap selected tokens even when the user already had a valid initialized Swap pair.

## Design Decisions
- Keep a persisted selected-token cold-start context keyed by account owner and context network. This lets launch normalization preserve valid tokens, including All Networks contexts, while still dropping stale tokens after account or concrete-network mismatches.
- Add `useSwapColdStartDisplayTokens` as a UI-only bridge from the global boot snapshot to the Swap input rows. It only fills display tokens until the runtime atoms resolve, so it avoids changing quote/build behavior while removing the visible empty/skeleton gap.
- Track whether the initial selected-token sync has completed. Home account/network updates may bring in default tokens before that point, but after the first sync, network changes no longer clear an already selected token pair.
- Normalize swap type from the selected token pair when needed, so cross-network cached pairs restore as Bridge and same-network pairs restore as Swap.

## Changes Detail
- `packages/shared/src/utils/swapColdStartCacheSnapshotUtils.ts`: normalize Swap token snapshots with account/network context, support All Networks sentinel contexts, backfill older All Networks snapshots when safe, and infer swap type from cached tokens.
- `packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.ts`: centralize account-key matching, default-token construction, one-time initial sync checks, and selected-account sync helpers.
- `packages/kit/src/views/Swap/hooks/useSwapColdStartDisplayTokens.ts`: read display-safe token fallbacks from the global cold-start snapshot before runtime atoms finish hydrating.
- `packages/kit/src/views/Swap/hooks/useSwapGlobal.ts`: store selected-token cold-start context, sync default tokens only during the initial path, and preserve initialized tokens across later network switches.
- `packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx` and `SwapAccountAddressContainer.tsx`: render token/network display from the cold-start fallback and only show skeletons when no display token is available.
- Tests were added or expanded for single-network restore, All Networks restore, account/network mismatch invalidation, default-token sync, and post-initialization network switching.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web
- **Risk Areas**: Swap cold-start snapshot compatibility, All Networks account context matching, and first-entry default-token sync behavior. The runtime quote/build path still uses the real selected token atoms; the new fallback is display-only.

## Test plan
- [x] `yarn lint:staged`
- [x] `git diff --check`
- [x] `yarn jest packages/kit/src/views/Swap/hooks/useSwapColdStartDisplayTokens.test.ts --runInBand`
- [x] `yarn jest packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts --runInBand`
- [x] `yarn jest packages/shared/src/utils/swapColdStartCacheSnapshotUtils.test.ts --runInBand`
- [x] Desktop self-test: cold start, All Networks, Swap tab, token switch stability
- [x] iOS self-test: cold start, All Networks, Swap tab, token switch stability
- [ ] `yarn tsc:staged` is currently blocked by unrelated existing type errors in `packages/kit/src/views/Perp/components/OrderBook/AnimatedDepthBlock.native.tsx` and `packages/shared/src/errors/utils/thirdPartyDeviceErrorUtils.ts`; these files are not modified by this PR.
