### PR TITLE
fix: resolve Perps notification and order issues OK-55542 OK-55590 OK-55597 OK-55644 OK-55681 OK-55809 OK-55897 OK-55899 OK-55901 OK-55903 OK-55904 OK-55906 OK-55936 OK-55937

### DIFF
--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -357,6 +357,18 @@ export function Container({
       tabIndex >= 0 ? listContainerRef.current.children.item(tabIndex) : null;
     const element = (registeredElement ??
       fallbackElement) as HTMLElement | null;
+    // Fallback-measured tabs (no registered Tabs.List/ScrollView element)
+    // observe the page div, but that div is a flex item stretched to the
+    // pinned container height — its border box never resizes when inner
+    // content grows (sub-tab switches, async data), so the observer stays
+    // silent and the container keeps a stale, too-small height that clips
+    // the content. Observe the content child instead: the page div is a
+    // block container, so the child's height stays content-driven and the
+    // observer fires on growth. Measurement still reads the page div.
+    const observedElement =
+      !registeredElement && element
+        ? ((element.firstElementChild as HTMLElement | null) ?? element)
+        : element;
     const apply = (targetElement: HTMLElement) => {
       const containerElement = listContainerRef.current as HTMLElement | null;
       if (!containerElement) return;
@@ -399,7 +411,7 @@ export function Container({
       }
     };
     // Same element + already observing -> nothing to do.
-    if (element && observedElementRef.current === element) {
+    if (element && observedElementRef.current === observedElement) {
       apply(element);
       return;
     }
@@ -407,15 +419,15 @@ export function Container({
       resizeObserverRef.current.disconnect();
       resizeObserverRef.current = null;
     }
-    observedElementRef.current = element;
-    if (!element) {
+    observedElementRef.current = observedElement;
+    if (!element || !observedElement) {
       return;
     }
     // Synchronous initial measurement so the container doesn't flicker
     // between 0-height and the first observer callback.
     apply(element);
     const ro = new ResizeObserver(() => apply(element));
-    ro.observe(element);
+    ro.observe(observedElement);
     resizeObserverRef.current = ro;
   }, [focusedTab, getTabContentHeight, tabNames, refreshScrollExtent]);
 

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -2602,41 +2602,17 @@ export default class ServiceHyperliquid extends ServiceBase {
         // So account value displays correctly before enable trading
         void this.fetchUserAbstraction(accountAddress);
 
-        // Builder fee check and rebate binding check are independent — run in parallel.
-        // Both must complete before checkAgentStatus (builder fee must be approved,
-        // and credentials may be cleared based on rebate result).
-        const [, isRebateBound] = await Promise.all([
-          this.checkBuilderFeeStatus({
-            accountAddress,
-            accountId: selectedAccount.accountId,
-            isEnableTradingTrigger,
-            statusDetails,
-          }),
-          this.checkInternalRebateBindingStatusWithCache({
-            accountId: selectedAccount.accountId,
-            accountAddress,
-          }),
-        ]);
+        await this.checkBuilderFeeStatus({
+          accountAddress,
+          accountId: selectedAccount.accountId,
+          isEnableTradingTrigger,
+          statusDetails,
+        });
 
-        // Clear local credentials to force new agent creation for rebate binding.
-        // Gate on isEnableTradingTrigger: rebate binding is best-effort and must
-        // not clear a working agent on background refreshes (would block trading).
-        if (!isRebateBound && isEnableTradingTrigger) {
-          await this.clearLocalAgentCredentials({
-            userAddress: accountAddress,
-          });
-          // Binding triggered via reportAgentApprovalToBackend after agent creation
-          statusDetails.internalRebateBoundOk = false;
-          defaultLogger.perp.agentLifeCycle.trackReason({
-            reason: 'internal_rebate_not_bound',
-            accountAddress,
-            accountId: selectedAccount.accountId,
-            isEnableTradingTrigger,
-            statusDetails: { ...statusDetails },
-          });
-        } else {
-          statusDetails.internalRebateBoundOk = true;
-        }
+        // Perps no longer gates account status on the legacy rebate batch-check
+        // result. Keep bind-wallet reporting in reportAgentApprovalToBackend,
+        // but do not issue that request while entering Perps.
+        statusDetails.internalRebateBoundOk = true;
 
         agentCredential = await this.checkAgentStatus({
           accountAddress,
@@ -2770,7 +2746,6 @@ export default class ServiceHyperliquid extends ServiceBase {
       if (credentialsToDelete.length > 0) {
         await localDb.removeCredentials({ credentials: credentialsToDelete });
         this.fetchExtraAgentsWithCache.clear();
-        this.checkInternalRebateBindingStatusWithCache.clear();
       }
     } catch (error) {
       console.error('[clearLocalAgentCredentials] Error:', error);
@@ -3192,86 +3167,6 @@ export default class ServiceHyperliquid extends ServiceBase {
     return { walletId, referenceAddress, referenceNetworkId };
   }
 
-  checkInternalRebateBindingStatusWithCache = cacheUtils.memoizee(
-    async ({
-      accountId,
-      accountAddress,
-    }: {
-      accountId: string | null;
-      accountAddress: IHex;
-    }) => {
-      return this.checkInternalRebateBindingStatus({
-        accountId,
-        accountAddress,
-      });
-    },
-    {
-      max: 20,
-      maxAge: timerUtils.getTimeDurationMs({ minute: 1 }),
-      promise: true,
-    },
-  );
-
-  private async checkInternalRebateBindingStatus({
-    accountId,
-    accountAddress,
-  }: {
-    accountId: string | null;
-    accountAddress: IHex;
-  }): Promise<boolean> {
-    const refInfo = await this.getRebateBindingReferenceInfo({
-      accountId,
-      signerAddress: accountAddress,
-    });
-
-    if (!refInfo) {
-      return true;
-    }
-
-    const { referenceAddress, referenceNetworkId } = refInfo;
-    const isFirstAccount =
-      referenceAddress.toLowerCase() === accountAddress.toLowerCase();
-
-    try {
-      // First account: skip binding check
-      if (isFirstAccount) {
-        return true;
-      }
-
-      // Non-first account: batch check both current and first account binding status
-      const batchResult =
-        await this.backgroundApi.serviceReferralCode.batchCheckWalletsBoundReferralCode(
-          [
-            { address: accountAddress, networkId: referenceNetworkId },
-            { address: referenceAddress, networkId: referenceNetworkId },
-          ],
-        );
-
-      const currentAccountKey = `${referenceNetworkId}:${accountAddress}`;
-      const firstAccountKey = `${referenceNetworkId}:${referenceAddress}`;
-      const isCurrentAccountBound = batchResult[currentAccountKey] ?? false;
-      const isFirstAccountBound = batchResult[firstAccountKey] ?? false;
-
-      if (isCurrentAccountBound) {
-        return true;
-      }
-
-      if (isFirstAccountBound) {
-        // First account is bound, current account needs binding too
-        return false;
-      }
-
-      // First account is not bound, skip binding for current account
-      return true;
-    } catch (error) {
-      console.error(
-        '[checkInternalRebateBindingStatus] Failed to check binding status',
-        error,
-      );
-      return true;
-    }
-  }
-
   private async checkBuilderFeeStatus({
     accountAddress,
     accountId,
@@ -3391,9 +3286,6 @@ export default class ServiceHyperliquid extends ServiceBase {
         referenceAddress: refInfo.referenceAddress,
         signerAddress: signatureInfo.signerAddress,
       });
-
-      // Clear cache after successful binding
-      this.checkInternalRebateBindingStatusWithCache.clear();
     } catch (error) {
       console.error('[reportAgentApprovalToBackend] Error:', error);
     }

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -1946,9 +1946,14 @@ export default class ServiceHyperliquid extends ServiceBase {
     const baseNameToAssetId: Record<string, number> = {};
     const baseNameToSzDecimals: Record<string, number> = {};
     const baseNameToPairName: Record<string, string> = {};
+    const preferredUniverseByBaseName =
+      perpsUtils.buildPreferredSpotUniverseByBaseNameMap(universes);
 
     for (const u of universes) {
       pairToBaseName[u.name] = u.baseName;
+    }
+
+    for (const u of Object.values(preferredUniverseByBaseName)) {
       baseNameToAssetId[u.baseName] = u.assetId;
       baseNameToSzDecimals[u.baseName] = u.baseSzDecimals;
       baseNameToPairName[u.baseName] = u.name;

--- a/packages/kit-bg/src/services/ServiceReferralCode.ts
+++ b/packages/kit-bg/src/services/ServiceReferralCode.ts
@@ -19,7 +19,6 @@ import { EBtcRewardErrorCode } from '@onekeyhq/shared/src/referralCode/type';
 import type {
   EExportTimeRange,
   IBatchCheckWalletItem,
-  IBatchCheckWalletResponse,
   IBatchCheckWalletV2Response,
   IBtcRewardCommitData,
   IBtcRewardCommitParams,
@@ -588,15 +587,6 @@ class ServiceReferralCode extends ServiceBase {
       return postConfig;
     }
     return this.fetchPostConfig();
-  }
-
-  @backgroundMethod()
-  async batchCheckWalletsBoundReferralCode(items: IBatchCheckWalletItem[]) {
-    const client = await this.getClient(EServiceEndpointEnum.Rebate);
-    const response = await client.post<{
-      data: IBatchCheckWalletResponse;
-    }>('/rebate/v1/wallet/batch-check', { items });
-    return response.data.data;
   }
 
   @backgroundMethod()

--- a/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
+++ b/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
@@ -14,7 +14,11 @@ import {
   ETabRoutes,
   type IWebViewPageParams,
 } from '@onekeyhq/shared/src/routes';
-import { navigateToNotificationDetailByLocalParams } from '@onekeyhq/shared/src/utils/notificationsUtils';
+import {
+  type INotificationPageNavigationEvent,
+  navigateToNotificationDetailByLocalParams,
+  registerNotificationPageNavigationProcessor,
+} from '@onekeyhq/shared/src/utils/notificationsUtils';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import {
@@ -115,20 +119,7 @@ function BaseNotificationHandlerContainer() {
     const handleShowNotificationPageNavigation = async ({
       payload: payloadObj,
       extras,
-    }: {
-      payload: {
-        screen: string;
-        params: Record<string, any>;
-      };
-      extras?: {
-        params?: {
-          coin?: string;
-          type?: string;
-          [key: string]: any;
-        };
-        [key: string]: any;
-      };
-    }) => {
+    }: INotificationPageNavigationEvent) => {
       const localParams = getLocalParams();
 
       const isPerpNavigation =
@@ -147,6 +138,13 @@ function BaseNotificationHandlerContainer() {
       if (perpToken) {
         try {
           await backgroundApiProxy.serviceHyperliquid.changeActiveAsset({
+            coin: perpToken,
+          });
+          // Notify an already-mounted Perp page (via PerpsGlobalEffects) to
+          // switch its active instrument; without this the coin switch is a
+          // no-op when the Perp page was already opened (banner deep-link case).
+          appEventBus.emit(EAppEventBusNames.PerpSwitchActiveInstrument, {
+            mode: 'perp',
             coin: perpToken,
           });
         } catch (error) {
@@ -186,10 +184,13 @@ function BaseNotificationHandlerContainer() {
     ) => {
       openWebView(params);
     };
-    appEventBus.on(
-      EAppEventBusNames.ShowNotificationPageNavigation,
-      handleShowNotificationPageNavigation,
-    );
+    // Durable registration: drains any intent buffered before this UI mounted
+    // (cold-start safe), instead of a transient appEventBus.on that drops
+    // events emitted before the handler was registered.
+    const unregisterPageNavigationProcessor =
+      registerNotificationPageNavigationProcessor(
+        handleShowNotificationPageNavigation,
+      );
     appEventBus.on(
       EAppEventBusNames.ShowNotificationInDappPage,
       handleShowNotificationDappNavigation,
@@ -226,10 +227,7 @@ function BaseNotificationHandlerContainer() {
         EAppEventBusNames.ShowNotificationViewDialog,
         handleShowNotificationViewDialog,
       );
-      appEventBus.off(
-        EAppEventBusNames.ShowNotificationPageNavigation,
-        handleShowNotificationPageNavigation,
-      );
+      unregisterPageNavigationProcessor();
       appEventBus.off(
         EAppEventBusNames.ShowNotificationInDappPage,
         handleShowNotificationDappNavigation,

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -167,10 +167,10 @@ type ITwapSliceFillsLoadResult =
       ok: false;
     };
 
-type ITwapDataLoadResult = {
-  webData2?: HL.IWsWebData2;
-  historyResult: ITwapHistoryLoadResult;
-  fillsResult: ITwapSliceFillsLoadResult;
+type ITwapDataLoadPromises = {
+  webData2Promise: Promise<HL.IWsWebData2 | undefined>;
+  historyPromise: Promise<ITwapHistoryLoadResult>;
+  fillsPromise: Promise<ITwapSliceFillsLoadResult>;
 };
 
 function resolveSubmitOrderTradeInstrument({
@@ -394,7 +394,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
 
   private loadTwapDataInFlightByAccount = new Map<
     string,
-    Promise<ITwapDataLoadResult>
+    ITwapDataLoadPromises
   >();
 
   private beginActiveInstrumentChange(): number {
@@ -412,33 +412,36 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     return orders.filter((order) => !this.canceledTwapIds.has(order.twapId));
   }
 
-  private getTwapDataLoadPromise(
+  private getTwapDataLoadPromises(
     accountAddress: string,
-  ): Promise<ITwapDataLoadResult> {
+  ): ITwapDataLoadPromises {
     const inFlight = this.loadTwapDataInFlightByAccount.get(accountAddress);
     if (inFlight) {
       return inFlight;
     }
 
-    const promise = this.fetchTwapData(accountAddress).finally(() => {
-      if (this.loadTwapDataInFlightByAccount.get(accountAddress) === promise) {
+    const promises = this.fetchTwapData(accountAddress);
+    void Promise.all([
+      promises.webData2Promise,
+      promises.historyPromise,
+      promises.fillsPromise,
+    ]).finally(() => {
+      if (this.loadTwapDataInFlightByAccount.get(accountAddress) === promises) {
         this.loadTwapDataInFlightByAccount.delete(accountAddress);
       }
     });
-    this.loadTwapDataInFlightByAccount.set(accountAddress, promise);
-    return promise;
+    this.loadTwapDataInFlightByAccount.set(accountAddress, promises);
+    return promises;
   }
 
-  private async fetchTwapData(
-    accountAddress: string,
-  ): Promise<ITwapDataLoadResult> {
-    const [webData2, historyResult, fillsResult] = await Promise.all([
-      backgroundApiProxy.serviceHyperliquid
+  private fetchTwapData(accountAddress: string): ITwapDataLoadPromises {
+    return {
+      webData2Promise: backgroundApiProxy.serviceHyperliquid
         .getWebData2({
           user: accountAddress as HL.IHex,
         })
         .catch(() => undefined),
-      backgroundApiProxy.serviceHyperliquid
+      historyPromise: backgroundApiProxy.serviceHyperliquid
         .getTwapHistory({
           user: accountAddress as HL.IHex,
         })
@@ -449,7 +452,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         .catch(() => ({
           ok: false as const,
         })),
-      backgroundApiProxy.serviceHyperliquid
+      fillsPromise: backgroundApiProxy.serviceHyperliquid
         .getUserTwapSliceFills({
           user: accountAddress as HL.IHex,
         })
@@ -460,12 +463,6 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         .catch(() => ({
           ok: false as const,
         })),
-    ]);
-
-    return {
-      webData2,
-      historyResult,
-      fillsResult,
     };
   }
 
@@ -1098,9 +1095,10 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         return;
       }
       const prev = get(perpsTwapHistoryAtom());
+      // Merge: WS snapshots only carry the ~30 most recent records, replacing
+      // would discard the full HTTP-loaded history.
       const previousHistory =
-        prev.accountAddress?.toLowerCase() === activeAccountAddress &&
-        !data.isSnapshot
+        prev.accountAddress?.toLowerCase() === activeAccountAddress
           ? prev.history
           : [];
       set(perpsTwapHistoryAtom(), {
@@ -1132,9 +1130,10 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         return;
       }
       const prev = get(perpsTwapSliceFillsAtom());
+      // Merge: WS snapshots only carry the ~30 most recent fills, replacing
+      // would discard the full HTTP-loaded history.
       const previousFills =
-        prev.accountAddress?.toLowerCase() === activeAccountAddress &&
-        !data.isSnapshot
+        prev.accountAddress?.toLowerCase() === activeAccountAddress
           ? prev.fills
           : [];
       const fills = sortAndDedupeTwapSliceFills([
@@ -2051,85 +2050,103 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       return;
     }
 
-    const { webData2, historyResult, fillsResult } =
-      await this.getTwapDataLoadPromise(accountAddress);
-    const latestActiveAccount = await perpsActiveAccountAtom.get();
-    if (
-      requestId !== this.loadTwapDataRequestId ||
-      normalizePerpsAccountAddress(latestActiveAccount?.accountAddress) !==
+    const { webData2Promise, historyPromise, fillsPromise } =
+      this.getTwapDataLoadPromises(accountAddress);
+
+    const isStillCurrent = async () => {
+      if (requestId !== this.loadTwapDataRequestId) {
+        return false;
+      }
+      const latestActiveAccount = await perpsActiveAccountAtom.get();
+      return (
+        normalizePerpsAccountAddress(latestActiveAccount?.accountAddress) ===
         accountAddress
-    ) {
-      return;
-    }
-    const currentTwapOrders = get(perpsActiveTwapOrdersAtom());
-    const currentHistory = get(perpsTwapHistoryAtom());
-    const currentSliceFills = get(perpsTwapSliceFillsAtom());
-    const canReuseCurrentHistory =
-      currentHistory.accountAddress?.toLowerCase() === accountAddress;
-    const canReuseCurrentSliceFills =
-      currentSliceFills.accountAddress?.toLowerCase() === accountAddress;
-
-    if (webData2?.user?.toLowerCase() === accountAddress) {
-      const twapOrders = this.filterCanceledTwapOrders(
-        sortTwapOrders([
-          ...(currentTwapOrders.accountAddress?.toLowerCase() === accountAddress
-            ? currentTwapOrders.twapOrders.filter(
-                (order) => (order.dex ?? '') !== '',
-              )
-            : []),
-          ...(webData2.twapStates ?? []).map(
-            ([twapId, state]): IPerpsActiveTwapOrder => ({
-              twapId,
-              state,
-              dex: '',
-            }),
-          ),
-        ]),
       );
-      set(perpsActiveTwapOrdersAtom(), {
-        accountAddress,
-        twapOrders,
-        twapOrdersByCoin: buildTwapOrdersByCoinMap(twapOrders),
-      });
-    } else if (
-      webData2 ||
-      currentTwapOrders.accountAddress?.toLowerCase() !== accountAddress
-    ) {
-      set(perpsActiveTwapOrdersAtom(), {
-        accountAddress,
-        twapOrders: [],
-        twapOrdersByCoin: {},
-      });
-    }
-    let history: typeof currentHistory.history = [];
-    if (historyResult.ok) {
-      history = historyResult.data;
-    } else if (canReuseCurrentHistory) {
-      history = currentHistory.history;
-    }
+    };
 
-    let fills: typeof currentSliceFills.fills = [];
-    if (fillsResult.ok) {
-      fills = fillsResult.data;
-    } else if (canReuseCurrentSliceFills) {
-      fills = currentSliceFills.fills;
-    }
+    // Apply per request so history/fills don't wait for the much larger
+    // webData2 payload.
+    const applyWebData2 = webData2Promise.then(async (webData2) => {
+      if (!(await isStillCurrent())) {
+        return;
+      }
+      const currentTwapOrders = get(perpsActiveTwapOrdersAtom());
+      if (webData2?.user?.toLowerCase() === accountAddress) {
+        const twapOrders = this.filterCanceledTwapOrders(
+          sortTwapOrders([
+            ...(currentTwapOrders.accountAddress?.toLowerCase() ===
+            accountAddress
+              ? currentTwapOrders.twapOrders.filter(
+                  (order) => (order.dex ?? '') !== '',
+                )
+              : []),
+            ...(webData2.twapStates ?? []).map(
+              ([twapId, state]): IPerpsActiveTwapOrder => ({
+                twapId,
+                state,
+                dex: '',
+              }),
+            ),
+          ]),
+        );
+        set(perpsActiveTwapOrdersAtom(), {
+          accountAddress,
+          twapOrders,
+          twapOrdersByCoin: buildTwapOrdersByCoinMap(twapOrders),
+        });
+      } else if (
+        webData2 ||
+        currentTwapOrders.accountAddress?.toLowerCase() !== accountAddress
+      ) {
+        set(perpsActiveTwapOrdersAtom(), {
+          accountAddress,
+          twapOrders: [],
+          twapOrdersByCoin: {},
+        });
+      }
+    });
 
-    const sortedFills = sortAndDedupeTwapSliceFills(fills);
-    set(perpsTwapHistoryAtom(), {
-      accountAddress,
-      history: sortAndDedupeTwapHistory(history),
-      isLoaded:
-        historyResult.ok || (canReuseCurrentHistory && currentHistory.isLoaded),
+    const applyHistory = historyPromise.then(async (historyResult) => {
+      if (!(await isStillCurrent())) {
+        return;
+      }
+      const currentHistory = get(perpsTwapHistoryAtom());
+      const canReuseCurrentHistory =
+        currentHistory.accountAddress?.toLowerCase() === accountAddress;
+      set(perpsTwapHistoryAtom(), {
+        accountAddress,
+        history: sortAndDedupeTwapHistory([
+          ...(canReuseCurrentHistory ? currentHistory.history : []),
+          ...(historyResult.ok ? historyResult.data : []),
+        ]),
+        isLoaded:
+          historyResult.ok ||
+          (canReuseCurrentHistory && currentHistory.isLoaded),
+      });
     });
-    set(perpsTwapSliceFillsAtom(), {
-      accountAddress,
-      fills: sortedFills,
-      isLoaded:
-        fillsResult.ok ||
-        (canReuseCurrentSliceFills && currentSliceFills.isLoaded),
-      latestTime: sortedFills[0]?.fill.time ?? 0,
+
+    const applyFills = fillsPromise.then(async (fillsResult) => {
+      if (!(await isStillCurrent())) {
+        return;
+      }
+      const currentSliceFills = get(perpsTwapSliceFillsAtom());
+      const canReuseCurrentSliceFills =
+        currentSliceFills.accountAddress?.toLowerCase() === accountAddress;
+      const sortedFills = sortAndDedupeTwapSliceFills([
+        ...(canReuseCurrentSliceFills ? currentSliceFills.fills : []),
+        ...(fillsResult.ok ? fillsResult.data : []),
+      ]);
+      set(perpsTwapSliceFillsAtom(), {
+        accountAddress,
+        fills: sortedFills,
+        isLoaded:
+          fillsResult.ok ||
+          (canReuseCurrentSliceFills && currentSliceFills.isLoaded),
+        latestTime: sortedFills[0]?.fill.time ?? 0,
+      });
     });
+
+    await Promise.all([applyWebData2, applyHistory, applyFills]);
   });
 
   clearActiveAssetData = contextAtomMethod(async (get, set) => {

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -147,6 +147,7 @@ const TWAP_MIN_DURATION_MINUTES = 5;
 const TWAP_MAX_DURATION_MINUTES = 1440;
 const TWAP_MIN_ORDER_NOTIONAL = Number(SCALE_ORDER_MIN_NOTIONAL);
 const TWAP_ESTIMATED_SLICE_INTERVAL_SECONDS = 30;
+const TWAP_SLICE_FILLS_MAX_COUNT = 2000;
 let lastL2BookColdCacheWriteAt = 0;
 
 type ITwapHistoryLoadResult =
@@ -330,12 +331,14 @@ function sortAndDedupeTwapSliceFills(
   for (const record of records) {
     map.set(getTwapSliceFillKey(record), record);
   }
-  return Array.from(map.values()).toSorted(
-    (a, b) =>
-      b.fill.time - a.fill.time ||
-      (b.fill.tid ?? 0) - (a.fill.tid ?? 0) ||
-      b.twapId - a.twapId,
-  );
+  return Array.from(map.values())
+    .toSorted(
+      (a, b) =>
+        b.fill.time - a.fill.time ||
+        (b.fill.tid ?? 0) - (a.fill.tid ?? 0) ||
+        b.twapId - a.twapId,
+    )
+    .slice(0, TWAP_SLICE_FILLS_MAX_COUNT);
 }
 
 async function clearMatchedDepositOrders(

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpOpenOrdersList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpOpenOrdersList.tsx
@@ -500,6 +500,10 @@ function PerpOpenOrdersList({
       />
     );
   };
+  const mobileHeaderTotalOrderCount =
+    activeOpenOrdersSubTab === 'twap'
+      ? scopedTwapOrders.length
+      : openOrders.length;
   const mobileListHeader = isMobile ? (
     <YStack>
       <OrderInfoSubTabs
@@ -507,8 +511,10 @@ function PerpOpenOrdersList({
         activeTab={activeOpenOrdersSubTab}
         onChange={setActiveOpenOrdersSubTab}
       />
+      {/* Keep the filter checkbox visible after "hide other pairs" filters
+          the current sub-tab to an empty list. */}
       <MobileOpenOrdersListHeader
-        totalOrderCount={filteredOrders.length + filteredTwapOrders.length}
+        totalOrderCount={mobileHeaderTotalOrderCount}
         cancelableOrderCount={
           canMutateScopedOrders && activeOpenOrdersSubTab === 'basic'
             ? filteredOrders.length

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -759,7 +759,10 @@ function TwapHistoryRow({
             justifyContent="center"
             alignItems={calcCellAlign(columnConfigs[0].align)}
           >
-            <SizableText size="$bodySm">{historyTime.inline}</SizableText>
+            <SizableText size="$bodySm">{historyTime.date}</SizableText>
+            <SizableText size="$bodySm" color="$textSubdued">
+              {historyTime.time}
+            </SizableText>
           </YStack>
           <YStack
             {...getColumnStyle(columnConfigs[1])}
@@ -1334,7 +1337,7 @@ function PerpTwapList({
     () => ({
       key: 'time',
       title: intl.formatMessage({ id: ETranslations.global_time }),
-      minWidth: 150,
+      minWidth: 130,
       flex: 1,
       align: 'left',
     }),

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -46,6 +46,7 @@ import type {
   ITwapState,
 } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
+import { usePerpTwapHistoryViewAllUrl } from '../../../hooks/usePerpOrderInfoPanel';
 import { PerpTestIDs } from '../../../testIDs';
 import { buildHelpUrl, openGuideUrl } from '../../Guide/perpGuideData';
 import { OrderInfoSubTabs } from '../Components/OrderInfoSubTabs';
@@ -62,7 +63,7 @@ import {
   type IRenderMode,
 } from './CommonTableListView';
 
-const TWAP_PAGE_SIZE = 40;
+const TWAP_PAGE_SIZE = 20;
 const TWAP_TABLE_ROW_MIN_HEIGHT = 48;
 
 type ITwapPanelTab = 'active' | 'history' | 'fills';
@@ -1158,6 +1159,7 @@ function PerpTwapList({
   const [currentListPage, setCurrentListPage] = useState(1);
   const [now, setNow] = useState(Date.now());
   const [builderFeeRate, setBuilderFeeRate] = useState<number | undefined>();
+  const { onViewAllUrl } = usePerpTwapHistoryViewAllUrl();
   const enabledTabsSet = useMemo(
     () => new Set(enabledTabs ?? TWAP_ORDERS_SUB_TABS.map((tab) => tab.key)),
     [enabledTabs],
@@ -1577,6 +1579,10 @@ function PerpTwapList({
       ),
     [enabledTabsSet, intl],
   );
+  const historyViewAll = historyRows.length > 0 ? onViewAllUrl : undefined;
+  const fillsViewAll =
+    sliceFills.length > TWAP_PAGE_SIZE ? onViewAllUrl : undefined;
+
   const listEmptyComponent = useMemo(
     () => (
       <TwapEmptyState
@@ -1604,10 +1610,7 @@ function PerpTwapList({
           useTabsList={useTabsList}
           disableListScroll={disableListScroll}
           enableDesktopVerticalScroll={!isMobile}
-          enablePagination
-          pageSize={TWAP_PAGE_SIZE}
-          currentListPage={currentListPage}
-          setCurrentListPage={setCurrentListPage}
+          enablePagination={false}
           columns={activeColumns}
           minTableWidth={activeMinWidth}
           data={twapOrders}
@@ -1638,6 +1641,7 @@ function PerpTwapList({
           isMobile={isMobile}
           paginationToBottom={isMobile}
           renderRow={renderHistoryRow}
+          onViewAll={historyViewAll}
           ListEmptyComponent={listEmptyComponent}
           emptyMessage={intl.formatMessage({
             id: ETranslations.perp_no_twap_history__title,
@@ -1662,6 +1666,7 @@ function PerpTwapList({
           isMobile={isMobile}
           paginationToBottom={isMobile}
           renderRow={renderFillRow}
+          onViewAll={fillsViewAll}
           ListEmptyComponent={listEmptyComponent}
           emptyMessage={intl.formatMessage({
             id: ETranslations.perp_no_twap_fill_history__title,

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -154,15 +154,18 @@ function formatTotalDuration(minutes: number, intl: IntlShape) {
 
 function getTwapHistoryStatusText(
   status: ITwapHistoryRecord['status']['status'],
+  intl: IntlShape,
 ) {
-  const statusTextMap: Record<ITwapHistoryRecord['status']['status'], string> =
-    {
-      activated: 'Activated',
-      error: 'Error',
-      finished: 'Finished',
-      terminated: 'Terminated',
-    };
-  return statusTextMap[status];
+  const statusTextMap: Record<
+    ITwapHistoryRecord['status']['status'],
+    ETranslations
+  > = {
+    activated: ETranslations.perp_twap_status_activated__title,
+    error: ETranslations.perp_twap_status_error__title,
+    finished: ETranslations.perp_twap_status_finished__title,
+    terminated: ETranslations.perp_twap_status_terminated__title,
+  };
+  return intl.formatMessage({ id: statusTextMap[status] });
 }
 
 function getTableRowBgColor({
@@ -615,12 +618,15 @@ function TwapHistoryRow({
   const statusText = useMemo(() => {
     const statusDescription =
       record.status.status === 'error' ? record.status.description : undefined;
-    const translatedStatus = getTwapHistoryStatusText(record.status.status);
+    const translatedStatus = getTwapHistoryStatusText(
+      record.status.status,
+      intl,
+    );
     if (statusDescription) {
       return `${translatedStatus}: ${statusDescription}`;
     }
     return translatedStatus;
-  }, [record.status]);
+  }, [intl, record.status]);
   const bgColor = getTableRowBgColor({ isHovered, index });
   const shouldRenderLeft = renderMode === 'full' || renderMode === 'left';
   const shouldRenderRight = renderMode === 'full' || renderMode === 'right';

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -55,6 +55,8 @@ import {
   getColumnStyle,
   getFillDirectionDisplayInfo,
   getTwapAssetDisplayName,
+  getTwapHistoryEventTimeMs,
+  normalizeEpochMs,
 } from '../utils';
 
 import {
@@ -118,13 +120,6 @@ function formatTwapDateTime(timestamp: number) {
   };
 }
 
-function normalizeEpochMs(timestamp: number | undefined) {
-  if (!timestamp) {
-    return undefined;
-  }
-  return timestamp > 1_000_000_000_000 ? timestamp : timestamp * 1000;
-}
-
 function formatElapsedDuration(ms: number) {
   const totalSeconds = Math.max(0, Math.floor(ms / 1000));
   const hours = Math.floor(totalSeconds / 3600);
@@ -155,6 +150,19 @@ function formatTotalDuration(minutes: number, intl: IntlShape) {
     return hourText;
   }
   return `${hourText} ${remainingMinutes} ${minuteUnit}`;
+}
+
+function getTwapHistoryStatusText(
+  status: ITwapHistoryRecord['status']['status'],
+) {
+  const statusTextMap: Record<ITwapHistoryRecord['status']['status'], string> =
+    {
+      activated: 'Activated',
+      error: 'Error',
+      finished: 'Finished',
+      terminated: 'Terminated',
+    };
+  return statusTextMap[status];
 }
 
 function getTableRowBgColor({
@@ -579,39 +587,40 @@ function TwapHistoryRow({
 }) {
   const intl = useIntl();
   const { state } = record;
-  const endTime =
-    record.status.status === 'activated'
-      ? undefined
-      : normalizeEpochMs(record.time);
+  const isActivated = record.status.status === 'activated';
+  const endTime = isActivated ? undefined : normalizeEpochMs(record.time);
   const sideInfo = useMemo(() => getTwapSideInfo(state, intl), [intl, state]);
   const baseInfo = useMemo(
     () => getTwapBaseInfo({ state, now, endTime, spotDisplayMap, intl }),
     [endTime, intl, now, spotDisplayMap, state],
   );
-  const creationTime = useMemo(
-    () => formatTwapDateTime(state.timestamp),
-    [state.timestamp],
+  const historyTime = useMemo(
+    () => formatTwapDateTime(getTwapHistoryEventTimeMs(record)),
+    [record],
+  );
+  const historyDisplayInfo = useMemo(
+    () => ({
+      executedSize: isActivated ? '--' : baseInfo.executedSizeWithSymbol,
+      averagePrice: isActivated ? '--' : baseInfo.avgPriceFormatted,
+      totalRuntime: formatTotalDuration(state.minutes, intl),
+    }),
+    [
+      baseInfo.avgPriceFormatted,
+      baseInfo.executedSizeWithSymbol,
+      intl,
+      isActivated,
+      state.minutes,
+    ],
   );
   const statusText = useMemo(() => {
     const statusDescription =
       record.status.status === 'error' ? record.status.description : undefined;
-    const statusTextMap: Record<
-      ITwapHistoryRecord['status']['status'],
-      ETranslations
-    > = {
-      activated: ETranslations.perp_twap_status_activated__title,
-      error: ETranslations.perp_twap_status_error__title,
-      finished: ETranslations.perp_twap_status_finished__title,
-      terminated: ETranslations.perp_twap_status_terminated__title,
-    };
-    const translatedStatus = intl.formatMessage({
-      id: statusTextMap[record.status.status],
-    });
+    const translatedStatus = getTwapHistoryStatusText(record.status.status);
     if (statusDescription) {
       return `${translatedStatus}: ${statusDescription}`;
     }
     return translatedStatus;
-  }, [intl, record.status]);
+  }, [record.status]);
   const bgColor = getTableRowBgColor({ isHovered, index });
   const shouldRenderLeft = renderMode === 'full' || renderMode === 'left';
   const shouldRenderRight = renderMode === 'full' || renderMode === 'right';
@@ -658,7 +667,7 @@ function TwapHistoryRow({
               </SizableText>
             </XStack>
             <SizableText size="$bodySm" color="$textSubdued">
-              {creationTime.inline}
+              {historyTime.inline}
             </SizableText>
           </YStack>
           <YStack
@@ -693,7 +702,7 @@ function TwapHistoryRow({
         >
           <MobileTwapHistoryInfoRow
             label={intl.formatMessage({
-              id: ETranslations.perp_position_position_size,
+              id: ETranslations.defi_total_size,
             })}
             value={baseInfo.sizeWithSymbol}
           />
@@ -701,19 +710,19 @@ function TwapHistoryRow({
             label={intl.formatMessage({
               id: ETranslations.perp_executed_size__title,
             })}
-            value={baseInfo.executedSizeWithSymbol}
+            value={historyDisplayInfo.executedSize}
           />
           <MobileTwapHistoryInfoRow
             label={intl.formatMessage({
               id: ETranslations.perp_average_price__title,
             })}
-            value={baseInfo.avgPriceFormatted}
+            value={historyDisplayInfo.averagePrice}
           />
           <MobileTwapHistoryInfoRow
             label={intl.formatMessage({
-              id: ETranslations.perp_twap_running_time_total__title,
+              id: ETranslations.perp_twap_running_time__title,
             })}
-            value={baseInfo.runningTimeText}
+            value={historyDisplayInfo.totalRuntime}
           />
           <MobileTwapHistoryInfoRow
             label={intl.formatMessage({ id: ETranslations.perps_reduce_only })}
@@ -750,7 +759,7 @@ function TwapHistoryRow({
             justifyContent="center"
             alignItems={calcCellAlign(columnConfigs[0].align)}
           >
-            <SizableText size="$bodySm">{creationTime.inline}</SizableText>
+            <SizableText size="$bodySm">{historyTime.inline}</SizableText>
           </YStack>
           <YStack
             {...getColumnStyle(columnConfigs[1])}
@@ -775,8 +784,11 @@ function TwapHistoryRow({
             justifyContent={calcCellAlign(columnConfigs[3].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm" color={sideInfo.color}>
-              {baseInfo.executedSizeWithSymbol}
+            <SizableText
+              size="$bodySm"
+              color={isActivated ? undefined : sideInfo.color}
+            >
+              {historyDisplayInfo.executedSize}
             </SizableText>
           </XStack>
           <XStack
@@ -785,7 +797,7 @@ function TwapHistoryRow({
             alignItems="center"
           >
             <SizableText size="$bodySm">
-              {baseInfo.avgPriceFormatted}
+              {historyDisplayInfo.averagePrice}
             </SizableText>
           </XStack>
           <YStack
@@ -793,7 +805,9 @@ function TwapHistoryRow({
             justifyContent="center"
             alignItems={calcCellAlign(columnConfigs[5].align)}
           >
-            <SizableText size="$bodySm">{baseInfo.runningTimeText}</SizableText>
+            <SizableText size="$bodySm">
+              {historyDisplayInfo.totalRuntime}
+            </SizableText>
           </YStack>
           <XStack
             {...getColumnStyle(columnConfigs[6])}
@@ -1219,7 +1233,7 @@ function PerpTwapList({
     ) {
       return [];
     }
-    return rawHistory.filter((record) => record.status.status !== 'activated');
+    return rawHistory;
   }, [currentAccountAddress, historyAccountAddress, rawHistory]);
 
   const sliceFills = useMemo(() => {
@@ -1316,6 +1330,17 @@ function PerpTwapList({
     [intl],
   );
 
+  const historyTimeColumn: IColumnConfig = useMemo(
+    () => ({
+      key: 'time',
+      title: intl.formatMessage({ id: ETranslations.global_time }),
+      minWidth: 150,
+      flex: 1,
+      align: 'left',
+    }),
+    [intl],
+  );
+
   const activeColumns: IColumnConfig[] = useMemo(
     () => [
       ...twapBaseColumns,
@@ -1336,8 +1361,70 @@ function PerpTwapList({
 
   const historyColumns: IColumnConfig[] = useMemo(
     () => [
-      creationTimeColumn,
-      ...twapBaseColumns,
+      historyTimeColumn,
+      {
+        key: 'coin',
+        title: intl.formatMessage({
+          id: ETranslations.perp_token_selector_asset,
+        }),
+        minWidth: 120,
+        flex: 1,
+        align: 'left',
+      },
+      {
+        key: 'sz',
+        title: intl.formatMessage({
+          id: ETranslations.defi_total_size,
+        }),
+        minWidth: 110,
+        flex: 1,
+        align: 'left',
+      },
+      {
+        key: 'executedSz',
+        title: intl.formatMessage({
+          id: ETranslations.perp_executed_size__title,
+        }),
+        minWidth: 130,
+        flex: 1,
+        align: 'left',
+      },
+      {
+        key: 'avgPx',
+        title: intl.formatMessage({
+          id: ETranslations.perp_average_price__title,
+        }),
+        minWidth: 140,
+        flex: 1,
+        align: 'left',
+      },
+      {
+        key: 'totalRuntime',
+        title: intl.formatMessage({
+          id: ETranslations.perp_twap_running_time__title,
+        }),
+        minWidth: 140,
+        flex: 1,
+        align: 'left',
+      },
+      {
+        key: 'reduceOnly',
+        title: intl.formatMessage({
+          id: ETranslations.perps_reduce_only,
+        }),
+        minWidth: 120,
+        flex: 1,
+        align: 'left',
+      },
+      {
+        key: 'randomize',
+        title: intl.formatMessage({
+          id: ETranslations.perp_twap_randomize__title,
+        }),
+        minWidth: 100,
+        flex: 1,
+        align: 'left',
+      },
       {
         key: 'status',
         title: intl.formatMessage({ id: ETranslations.global_status }),
@@ -1347,7 +1434,7 @@ function PerpTwapList({
         fixed: true,
       },
     ],
-    [creationTimeColumn, intl, twapBaseColumns],
+    [historyTimeColumn, intl],
   );
 
   const fillColumns: IColumnConfig[] = useMemo(

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -1696,7 +1696,6 @@ function PerpTwapList({
           listViewDebugRenderTrackerProps={trackerProps}
           useTabsList={useTabsList}
           disableListScroll={disableListScroll}
-          enableDesktopVerticalScroll={!isMobile}
           enablePagination={false}
           columns={activeColumns}
           minTableWidth={activeMinWidth}
@@ -1717,7 +1716,6 @@ function PerpTwapList({
           listViewDebugRenderTrackerProps={trackerProps}
           useTabsList={useTabsList}
           disableListScroll={disableListScroll}
-          enableDesktopVerticalScroll={!isMobile}
           enablePagination
           pageSize={TWAP_PAGE_SIZE}
           currentListPage={currentListPage}
@@ -1742,7 +1740,6 @@ function PerpTwapList({
           listViewDebugRenderTrackerProps={trackerProps}
           useTabsList={useTabsList}
           disableListScroll={disableListScroll}
-          enableDesktopVerticalScroll={!isMobile}
           enablePagination
           pageSize={TWAP_PAGE_SIZE}
           currentListPage={currentListPage}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpTradersHistoryListModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/PerpTradersHistoryListModal.tsx
@@ -106,7 +106,7 @@ export function PerpTradersHistoryListModal() {
         })}
       </Button>
     );
-  }, [onViewAllUrl, intl, activeTab]);
+  }, [activeTab, intl, onViewAllUrl]);
 
   return (
     <Page>

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/utils.test.ts
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/utils.test.ts
@@ -2,7 +2,9 @@ import {
   calculateSpotHoldingPnl,
   formatSpotHoldingPnlText,
   getTwapAssetDisplayName,
+  getTwapHistoryEventTimeMs,
   isSpotHoldingStableCoin,
+  normalizeEpochMs,
 } from './utils';
 
 describe('calculateSpotHoldingPnl', () => {
@@ -57,5 +59,29 @@ describe('getTwapAssetDisplayName', () => {
 
   it('falls back to the shared spot token map for canonical pair names', () => {
     expect(getTwapAssetDisplayName('UETH/USDC', {})).toBe('ETH');
+  });
+});
+
+describe('TWAP history time helpers', () => {
+  it('normalizes seconds and milliseconds timestamps', () => {
+    expect(normalizeEpochMs(1_718_000_000)).toBe(1_718_000_000_000);
+    expect(normalizeEpochMs(1_718_000_000_123)).toBe(1_718_000_000_123);
+  });
+
+  it('uses Hyperliquid history record time ahead of TWAP start time', () => {
+    expect(
+      getTwapHistoryEventTimeMs({
+        time: 1_718_000_000,
+        state: { timestamp: 1_717_999_000_000 },
+      }),
+    ).toBe(1_718_000_000_000);
+  });
+
+  it('falls back to TWAP start time when the history record time is missing', () => {
+    expect(
+      getTwapHistoryEventTimeMs({
+        state: { timestamp: 1_717_999_000_000 },
+      }),
+    ).toBe(1_717_999_000_000);
   });
 });

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/utils.ts
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/utils.ts
@@ -69,6 +69,22 @@ export const getTwapAssetDisplayName = (
   return coin;
 };
 
+export function normalizeEpochMs(timestamp: number | undefined) {
+  if (!timestamp) {
+    return undefined;
+  }
+  return timestamp > 1_000_000_000_000 ? timestamp : timestamp * 1000;
+}
+
+export function getTwapHistoryEventTimeMs(record: {
+  time?: number;
+  state: { timestamp: number };
+}) {
+  // Hyperliquid TWAP History displays the history record time, not the
+  // TWAP state's start timestamp.
+  return normalizeEpochMs(record.time) ?? record.state.timestamp;
+}
+
 export const getPerpFillDirectionType = (
   direction?: string,
 ): IPerpFillDirectionType => {

--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -655,15 +655,10 @@ export function PerpOrderBook({
     [],
   );
 
-  useEffect(() => {
-    setRenderL2Book(null);
-    setIsOrderBookInteractive(false);
-  }, [
-    activeTradeInstrument.coin,
-    activeTradeInstrument.mode,
-    l2SubscriptionOptions.mantissa,
-    l2SubscriptionOptions.nSigFigs,
-  ]);
+  // Do NOT reset renderL2Book/isOrderBookInteractive on coin/options change:
+  // the bridge only re-reports isInteractive on a boolean flip, so a reset
+  // landing after a `true` report leaves it stuck out of sync. Render-time gates
+  // (activeRenderL2Book coin filter + freshness checks) already cover staleness.
 
   useEffect(() => {
     const coin = activeTradeInstrument.coin;

--- a/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingButton.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingButton.tsx
@@ -8,7 +8,6 @@ import type { IButtonProps } from '@onekeyhq/components';
 import {
   Button,
   SizableText,
-  Spinner,
   Toast,
   XStack,
   YStack,
@@ -65,7 +64,7 @@ const PerpTradingButtonMidPriceRef = memo(
 PerpTradingButtonMidPriceRef.displayName = 'PerpTradingButtonMidPriceRef';
 
 export function PerpTradingButton({
-  loading,
+  disabledForAccountLoading,
   handleShowConfirm,
   formData,
   computedSize,
@@ -73,7 +72,7 @@ export function PerpTradingButton({
   isSubmitting,
   isNoEnoughMargin,
 }: {
-  loading: boolean;
+  disabledForAccountLoading: boolean;
   handleShowConfirm: () => void;
   formData: ITradingFormData;
   computedSize: BigNumber;
@@ -332,7 +331,7 @@ export function PerpTradingButton({
   const isWaitingForLiveStatus =
     !perpsAccountStatus.details && Boolean(perpsAccount?.accountAddress);
   if (
-    loading ||
+    disabledForAccountLoading ||
     perpsAccountLoading?.selectAccountLoading ||
     isWaitingForLiveStatus
   ) {
@@ -343,7 +342,9 @@ export function PerpTradingButton({
         childrenAsText={false}
         testID="perp-order-confirm-btn"
       >
-        <Spinner />
+        <SizableText color="$textDisabled" size="$bodyMdMedium">
+          {buttonText}
+        </SizableText>
       </Button>
     );
   }
@@ -408,7 +409,7 @@ export function PerpTradingButton({
           {...sharedButtonProps}
           testID={PerpTestIDs.EnableTradingButton}
           variant="primary"
-          loading={isAccountLoading}
+          disabled={isAccountLoading}
           onPress={async () => {
             await enableTrading();
           }}
@@ -441,7 +442,6 @@ export function PerpTradingButton({
             ? { bg: buttonStyles.pressBg }
             : undefined
         }
-        loading={perpsAccountLoading?.enableTradingLoading || isSubmitting}
         onPress={orderConfirm}
         disabled={buttonDisabled}
         childrenAsText={false}

--- a/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingPanel.tsx
@@ -91,7 +91,7 @@ function PerpEnableTradingButtonLite() {
         borderRadius="$full"
         testID={PerpTestIDs.EnableTradingButton}
         variant="primary"
-        loading={isAccountLoading}
+        disabled={isAccountLoading}
         onPress={async () => {
           await enableTrading();
         }}
@@ -120,7 +120,7 @@ function PerpTradingDisabledPlaceOrderButton() {
   const [perpsCustomSettings] = usePerpsCustomSettingsAtom();
   const [tradingMode] = useTradingModeAtom();
 
-  const universalLoading = useMemo(() => {
+  const disabledForAccountLoading = useMemo(() => {
     return perpsAccountLoading?.selectAccountLoading;
   }, [perpsAccountLoading?.selectAccountLoading]);
 
@@ -226,7 +226,7 @@ function PerpTradingDisabledPlaceOrderButton() {
 
   return (
     <PerpTradingButton
-      loading={universalLoading}
+      disabledForAccountLoading={disabledForAccountLoading}
       handleShowConfirm={handleShowConfirm}
       formData={formData}
       computedSize={computedSizeBN}

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -1508,7 +1508,6 @@ function SideButtonInternal({
           disabledStyle={
             shouldPreserveDisabledButtonStyle ? { opacity: 1 } : undefined
           }
-          loading={shouldShowButtonLoading}
           onPress={handlePress}
           h={36}
           py={
@@ -1555,7 +1554,6 @@ function SideButtonInternal({
         disabledStyle={
           shouldPreserveDisabledButtonStyle ? { opacity: 1 } : undefined
         }
-        loading={shouldShowButtonLoading}
         onPress={handlePress}
         h={36}
         py={!orderValue.isZero() && orderValue.isFinite() ? '$0.5' : undefined}
@@ -1998,7 +1996,6 @@ function EmptySizeSideButton({
       disabledStyle={
         shouldPreserveDisabledButtonStyle ? { opacity: 1 } : undefined
       }
-      loading={shouldShowButtonLoading || isSubmitting}
       onPress={handlePress}
       h={36}
     >

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -280,6 +280,33 @@ function SideButtonInternal({
   const requestEnableTradingWithDepositFallback =
     useRequestEnableTradingWithDepositFallback();
   const { showDepositWithdrawModal } = useShowDepositWithdrawModal();
+  const handleDepositFromToast = useCallback(() => {
+    void showDepositWithdrawModal('deposit');
+  }, [showDepositWithdrawModal]);
+  const showNoEnoughMarginToast = useCallback(
+    (latestIsSpot: boolean) => {
+      Toast.error({
+        title: intl.formatMessage({
+          id: latestIsSpot
+            ? ETranslations.dexmarket_insufficient_balance
+            : ETranslations.perp_insufficient_margin__title,
+        }),
+        actions: (
+          <Button
+            testID={PerpTestIDs.MarginToastDepositButton}
+            size="small"
+            variant="primary"
+            onPress={handleDepositFromToast}
+          >
+            {intl.formatMessage({ id: ETranslations.perp_trade_deposit })}
+          </Button>
+        ),
+        actionsAlign: 'left',
+        toastId: `perp-no-enough-margin-${latestIsSpot ? 'spot' : 'perp'}`,
+      });
+    },
+    [handleDepositFromToast, intl],
+  );
   const perpsAccountKey = useMemo(
     () => getPerpsAccountKey(perpsAccount),
     [perpsAccount],
@@ -403,7 +430,6 @@ function SideButtonInternal({
   const hasNonColdStartDisabledReason = useMemo(
     () =>
       Boolean(
-        (!shouldAutoEnableTrading && isNoEnoughMargin) ||
         (!perpsAccountStatus.canTrade && !shouldEnableTradingBeforeOrder) ||
         isSubmitting ||
         priceError === 'bbo_unavailable' ||
@@ -411,11 +437,9 @@ function SideButtonInternal({
       ),
     [
       perpsAccountStatus.canTrade,
-      isNoEnoughMargin,
       isServerActionDisabled,
       isSubmitting,
       priceError,
-      shouldAutoEnableTrading,
       shouldEnableTradingBeforeOrder,
     ],
   );
@@ -520,12 +544,6 @@ function SideButtonInternal({
       return intl.formatMessage({
         id: ETranslations.perp_button_disable_perp,
       });
-    if (!shouldEnableTradingBeforeOrder && isNoEnoughMargin)
-      return intl.formatMessage({
-        id: isSpot
-          ? ETranslations.dexmarket_insufficient_balance
-          : ETranslations.perp_trading_button_no_enough_margin,
-      });
     if (isSpot) {
       if (!spotTradeSymbol) {
         return side === 'long'
@@ -556,7 +574,6 @@ function SideButtonInternal({
   }, [
     priceError,
     formData.orderMode,
-    isNoEnoughMargin,
     isSpot,
     side,
     spotTradeSymbol,
@@ -641,6 +658,7 @@ function SideButtonInternal({
         effectivePriceBN: latestEffectivePriceBN,
         formData: latestFormData,
         isMinimumOrderNotMetForSide: latestIsMinimumOrderNotMetForSide,
+        isNoEnoughMargin: latestIsNoEnoughMargin,
         isSpot: latestIsSpot,
         isScaleMode: latestIsScaleMode,
         isTriggerMode: latestIsTriggerMode,
@@ -841,6 +859,11 @@ function SideButtonInternal({
         return false;
       }
 
+      if (latestIsNoEnoughMargin) {
+        showNoEnoughMarginToast(latestIsSpot);
+        return false;
+      }
+
       if (latestIsScaleMode) {
         const legs = buildScaleOrderLegs({
           totalSize: latestComputedSizeForSide.toFixed(),
@@ -1014,7 +1037,7 @@ function SideButtonInternal({
 
       return true;
     },
-    [intl],
+    [intl, showNoEnoughMarginToast],
   );
 
   const requestOrderPanelEnableTrading = useCallback(
@@ -1163,13 +1186,7 @@ function SideButtonInternal({
             isDepositRequired,
           })
         ) {
-          Toast.message({
-            title: intl.formatMessage({
-              id: preEnableOrderPanelState.isSpot
-                ? ETranslations.dexmarket_insufficient_balance
-                : ETranslations.perp_trading_button_no_enough_margin,
-            }),
-          });
+          showNoEnoughMarginToast(preEnableOrderPanelState.isSpot);
           return;
         }
 
@@ -1205,13 +1222,7 @@ function SideButtonInternal({
           return;
         }
         if (postEnableTradingResult === 'noEnoughMargin') {
-          Toast.message({
-            title: intl.formatMessage({
-              id: postEnableState.isSpot
-                ? ETranslations.dexmarket_insufficient_balance
-                : ETranslations.perp_trading_button_no_enough_margin,
-            }),
-          });
+          showNoEnoughMarginToast(postEnableState.isSpot);
           return;
         }
       }

--- a/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpOrderInfoPanel.ts
@@ -8,7 +8,10 @@ import {
   usePerpsTradesHistoryDataAtom,
   usePerpsTradesHistoryRefreshHookAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { PERPS_HISTORY_FILLS_URL } from '@onekeyhq/shared/src/consts/perp';
+import {
+  PERPS_HISTORY_FILLS_URL,
+  PERPS_TWAP_HISTORY_URL,
+} from '@onekeyhq/shared/src/consts/perp';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { openUrlInApp } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import type { IFill } from '@onekeyhq/shared/types/hyperliquid';
@@ -103,16 +106,22 @@ export function usePerpTradesHistory() {
   };
 }
 
-export function usePerpTradesHistoryViewAllUrl() {
+function usePerpViewAllUrl(baseUrl: string) {
   const [currentAccount] = usePerpsActiveAccountAtom();
   const onViewAllUrl = useCallback(() => {
     if (currentAccount?.accountAddress) {
-      openUrlInApp(
-        `${PERPS_HISTORY_FILLS_URL}${currentAccount?.accountAddress}`,
-      );
+      openUrlInApp(`${baseUrl}${currentAccount.accountAddress}`);
     }
-  }, [currentAccount?.accountAddress]);
+  }, [baseUrl, currentAccount?.accountAddress]);
   return {
     onViewAllUrl,
   };
+}
+
+export function usePerpTradesHistoryViewAllUrl() {
+  return usePerpViewAllUrl(PERPS_HISTORY_FILLS_URL);
+}
+
+export function usePerpTwapHistoryViewAllUrl() {
+  return usePerpViewAllUrl(PERPS_TWAP_HISTORY_URL);
 }

--- a/packages/kit/src/views/Perp/hooks/useSpotMetaMaps.ts
+++ b/packages/kit/src/views/Perp/hooks/useSpotMetaMaps.ts
@@ -1,7 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { getSpotTokenDisplayName } from '@onekeyhq/shared/src/utils/perpsUtils';
+import {
+  buildPreferredSpotUniverseByBaseNameMap,
+  getSpotTokenDisplayName,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { ISpotUniverse } from '@onekeyhq/shared/types/hyperliquid';
 
 export function useSpotMetaMaps() {
@@ -60,20 +63,7 @@ export function useSpotMetaMaps() {
   }, []);
 
   const universeByBaseName = useMemo(() => {
-    // Two passes so USDC-quoted pairs win the default mapping when a base
-    // coin has multiple quotes.
-    const map: Record<string, ISpotUniverse> = {};
-    for (const u of spotUniverses) {
-      if (u.quoteName === 'USDC') {
-        map[u.baseName] = u;
-      }
-    }
-    for (const u of spotUniverses) {
-      if (!map[u.baseName]) {
-        map[u.baseName] = u;
-      }
-    }
-    return map;
+    return buildPreferredSpotUniverseByBaseNameMap(spotUniverses);
   }, [spotUniverses]);
 
   return {

--- a/packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.test.ts
+++ b/packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.test.ts
@@ -563,6 +563,20 @@ describe('shouldDisablePerpsOrderPanelTradingButton', () => {
       }),
     ).toBe(true);
   });
+
+  it('keeps insufficient-margin buttons pressable so the press can show a toast', () => {
+    expect(
+      shouldDisablePerpsOrderPanelTradingButton({
+        isTradingStatusDisabled: false,
+        shouldEnableTradingBeforeOrder: false,
+        isNoEnoughMargin: true,
+        isAccountLoading: false,
+        isSubmitting: false,
+        hasBboPriceError: false,
+        isServerActionDisabled: false,
+      }),
+    ).toBe(false);
+  });
 });
 
 describe('shouldSkipPerpsOrderPanelComputedSizeValidation', () => {

--- a/packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.ts
+++ b/packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.ts
@@ -199,7 +199,7 @@ export type IPerpsOrderPanelPostEnableTradingResult =
 export function shouldDisablePerpsOrderPanelTradingButton({
   isTradingStatusDisabled,
   shouldEnableTradingBeforeOrder,
-  isNoEnoughMargin,
+  isNoEnoughMargin: _isNoEnoughMargin,
   isAccountLoading,
   isSubmitting,
   hasBboPriceError,
@@ -215,7 +215,6 @@ export function shouldDisablePerpsOrderPanelTradingButton({
 }) {
   return (
     isTradingStatusDisabled ||
-    (!shouldEnableTradingBeforeOrder && isNoEnoughMargin) ||
     isAccountLoading ||
     isSubmitting ||
     (!shouldEnableTradingBeforeOrder && hasBboPriceError) ||

--- a/packages/shared/src/consts/perp.ts
+++ b/packages/shared/src/consts/perp.ts
@@ -58,6 +58,7 @@ export const PERPS_USER_FILLS_TIME_RANGE = timerUtils.getTimeDurationMs({
 });
 
 export const PERPS_HISTORY_FILLS_URL = 'https://hypurrscan.io/address/';
+export const PERPS_TWAP_HISTORY_URL = `${HYPER_LIQUID_ORIGIN}/twapHistory/`;
 
 /**
  * Filtered transaction types in account ledger history

--- a/packages/shared/src/referralCode/type.ts
+++ b/packages/shared/src/referralCode/type.ts
@@ -546,13 +546,6 @@ export interface IBatchCheckWalletItem {
   address: string;
 }
 
-export interface IBatchCheckWalletParams {
-  items: IBatchCheckWalletItem[];
-}
-
-// Response is a map where key is "networkId:address" and value is boolean
-export type IBatchCheckWalletResponse = Record<string, boolean>;
-
 // V2 batch check - includes bind window status
 export interface IBatchCheckWalletV2Item {
   bound: boolean;

--- a/packages/shared/src/utils/notificationsUtils.ts
+++ b/packages/shared/src/utils/notificationsUtils.ts
@@ -8,7 +8,11 @@ import {
   ENotificationPushMessageMode,
 } from '../../types/notification';
 import appGlobals from '../appGlobals';
-import { EAppEventBusNames, appEventBus } from '../eventBus/appEventBus';
+import {
+  EAppEventBusNames,
+  type IAppEventBusPayload,
+  appEventBus,
+} from '../eventBus/appEventBus';
 import { ETranslations } from '../locale';
 import { defaultLogger } from '../logger/logger';
 import platformEnv from '../platformEnv';
@@ -259,8 +263,99 @@ export interface INavigateToNotificationDetailParams {
   isRead?: boolean;
 }
 
+export type INotificationPageNavigationEvent =
+  IAppEventBusPayload[EAppEventBusNames.ShowNotificationPageNavigation];
+
+// --- Durable page-navigation delivery -------------------------------------
+// Notification page-navigation (e.g. Perps deep-link) is emitted via
+// appEventBus. On native, the click is processed in the BACKGROUND runtime
+// (system push / cold start) and reaches the foreground via the cross-process
+// bus — but during a cold start the foreground UI handler is mounted LATE, so a
+// plain emit is dropped (the race that broke OK-55681).
+//
+// To make it cold-start safe we register a PERMANENT foreground listener at
+// module load that BUFFERS the latest intent, and let the UI register a
+// processor that drains the buffer whenever it mounts. The intent therefore
+// survives until the UI is ready, regardless of ordering.
+type INotificationPageNavigationProcessor = (
+  event: INotificationPageNavigationEvent,
+) => void;
+
+let notificationPageNavigationProcessor: INotificationPageNavigationProcessor | null =
+  null;
+let pendingNotificationPageNavigationEvent: INotificationPageNavigationEvent | null =
+  null;
+
+function deliverNotificationPageNavigation(
+  event: INotificationPageNavigationEvent,
+) {
+  if (notificationPageNavigationProcessor) {
+    pendingNotificationPageNavigationEvent = null;
+    notificationPageNavigationProcessor(event);
+    return;
+  }
+  pendingNotificationPageNavigationEvent = event;
+}
+
+export function registerNotificationPageNavigationProcessor(
+  processor: INotificationPageNavigationProcessor,
+) {
+  notificationPageNavigationProcessor = processor;
+  const pending = pendingNotificationPageNavigationEvent;
+  if (pending) {
+    pendingNotificationPageNavigationEvent = null;
+    processor(pending);
+  }
+  return () => {
+    if (notificationPageNavigationProcessor === processor) {
+      notificationPageNavigationProcessor = null;
+    }
+  };
+}
+
+// Register the permanent foreground capture listener once at module load.
+// Skipped on the native background runtime (no UI processor lives there; the
+// foreground copy of this module receives the cross-process broadcast).
+if (!platformEnv.isNativeBackgroundThread) {
+  appEventBus.on(
+    EAppEventBusNames.ShowNotificationPageNavigation,
+    deliverNotificationPageNavigation,
+  );
+}
+
+// Push notification `mode` arrives as a NUMBER from the in-app bell list
+// (server JSON) but as a STRING (e.g. "1") from JPush system-push extras on
+// native. The enum values are numeric, so a strict `switch(mode)` silently
+// misses every case for the system-push path (the OK-55681 regression). Coerce
+// to the numeric enum before switching.
+export function normalizeNotificationMode(
+  mode: ENotificationPushMessageMode | string | number | undefined | null,
+): ENotificationPushMessageMode | undefined {
+  if (mode === null || mode === undefined || mode === '') {
+    return undefined;
+  }
+  const numericMode = Number(mode);
+  if (Number.isFinite(numericMode)) {
+    return numericMode as ENotificationPushMessageMode;
+  }
+  if (typeof mode === 'string') {
+    const name = mode.toLowerCase().replace(/[^a-z]/g, '');
+    if (name === 'page' || name === 'navigate' || name === 'navigation') {
+      return ENotificationPushMessageMode.page;
+    }
+    if (name === 'dialog') return ENotificationPushMessageMode.dialog;
+    if (name === 'openinbrowser') {
+      return ENotificationPushMessageMode.openInBrowser;
+    }
+    if (name === 'openinapp') return ENotificationPushMessageMode.openInApp;
+    if (name === 'openindapp') return ENotificationPushMessageMode.openInDapp;
+    if (name === 'command') return ENotificationPushMessageMode.command;
+  }
+  return undefined;
+}
+
 export function parseNotificationPayload(
-  mode: ENotificationPushMessageMode,
+  mode: ENotificationPushMessageMode | string | number,
   payload: string | undefined,
   fallbackHandler: () => void,
   extras?: {
@@ -272,7 +367,8 @@ export function parseNotificationPayload(
     [key: string]: any;
   },
 ) {
-  switch (mode) {
+  const normalizedMode = normalizeNotificationMode(mode);
+  switch (normalizedMode) {
     case ENotificationPushMessageMode.page:
       try {
         const payloadObj = JSON.parse(payload || '');
@@ -437,9 +533,14 @@ async function navigateToNotificationDetail({
   }
 
   if (isFromNotificationClick) {
+    // `$navigationRef` only exists in the foreground runtime. On native this
+    // function also runs in the BACKGROUND runtime (system-push click), where
+    // `appGlobals.$navigationRef` is undefined — guard every hop so we don't
+    // throw before reaching the page-mode emit (OK-55681). The real navigation
+    // happens later in the foreground via ShowNotificationPageNavigation.
     const statusRoutes = platformEnv.isExtensionBackground
       ? []
-      : appGlobals.$navigationRef.current?.getState().routes;
+      : appGlobals.$navigationRef?.current?.getState()?.routes;
     const currentRoute = statusRoutes?.length
       ? statusRoutes?.[statusRoutes.length - 1]
       : undefined;

--- a/packages/shared/src/utils/perpsUtils.test.ts
+++ b/packages/shared/src/utils/perpsUtils.test.ts
@@ -9,6 +9,7 @@ import { EPerpsSizeInputMode } from '@onekeyhq/shared/types/hyperliquid/types';
 
 import {
   analyzeOrderBookPrecision,
+  buildPreferredSpotUniverseByBaseNameMap,
   calculateLiquidationPrice,
   calculatePriceScale,
   calculateSpotBalancesTotalUsd,
@@ -216,6 +217,42 @@ describe('calculateSpotBalancesTotalUsd', () => {
 
     expect(result.totalUsd).toBe('236.786521');
     expect(result.missingPriceCoins).toEqual(['BTC']);
+  });
+});
+
+describe('buildPreferredSpotUniverseByBaseNameMap', () => {
+  test('prefers USDC-quoted universes when the same spot token has multiple quotes', () => {
+    const result = buildPreferredSpotUniverseByBaseNameMap([
+      {
+        baseName: 'UBTC',
+        quoteName: 'USDH',
+        name: '@234',
+      },
+      {
+        baseName: 'UBTC',
+        quoteName: 'USDC',
+        name: '@142',
+      },
+      {
+        baseName: 'KHYPE',
+        quoteName: 'USDH',
+        name: '@250',
+      },
+      {
+        baseName: 'KHYPE',
+        quoteName: 'USDC',
+        name: '@336',
+      },
+      {
+        baseName: 'ONLYUSDH',
+        quoteName: 'USDH',
+        name: '@999',
+      },
+    ]);
+
+    expect(result['UBTC'].name).toBe('@142');
+    expect(result['KHYPE'].name).toBe('@336');
+    expect(result['ONLYUSDH'].name).toBe('@999');
   });
 });
 

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -1992,6 +1992,29 @@ function formatSpotPairDisplayName(
   return `${getSpotTokenDisplayName(baseName)}/${quoteName}`;
 }
 
+function buildPreferredSpotUniverseByBaseNameMap<
+  T extends Pick<ISpotUniverse, 'baseName' | 'quoteName'>,
+>(spotUniverses: T[]): Record<string, T> {
+  const map: Record<string, T> = {};
+
+  // Hyperliquid can list the same spot base token against multiple quotes.
+  // Account USD values should use the USDC-quoted universe first so background
+  // totals match the holdings list.
+  for (const universe of spotUniverses) {
+    if (universe.quoteName === 'USDC') {
+      map[universe.baseName] = universe;
+    }
+  }
+
+  for (const universe of spotUniverses) {
+    if (!map[universe.baseName]) {
+      map[universe.baseName] = universe;
+    }
+  }
+
+  return map;
+}
+
 function getOrderBookSizeDisplaySymbol({
   coin,
   isSpot,
@@ -2075,6 +2098,7 @@ export {
   isPredictionMarketInstrument,
   getSpotTokenDisplayName,
   formatSpotPairDisplayName,
+  buildPreferredSpotUniverseByBaseNameMap,
   getOrderBookSizeDisplaySymbol,
   filterSpotTokensStrict,
   SPOT_TOKEN_DISPLAY_MAP,
@@ -2134,6 +2158,7 @@ export default {
   isPredictionMarketInstrument,
   getSpotTokenDisplayName,
   formatSpotPairDisplayName,
+  buildPreferredSpotUniverseByBaseNameMap,
   getOrderBookSizeDisplaySymbol,
   filterSpotTokensStrict,
   SPOT_TOKEN_DISPLAY_MAP,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55542](https://onekeyhq.atlassian.net/browse/OK-55542) [OK-55590](https://onekeyhq.atlassian.net/browse/OK-55590) [OK-55597](https://onekeyhq.atlassian.net/browse/OK-55597) [OK-55644](https://onekeyhq.atlassian.net/browse/OK-55644) [OK-55681](https://onekeyhq.atlassian.net/browse/OK-55681) [OK-55809](https://onekeyhq.atlassian.net/browse/OK-55809) [OK-55897](https://onekeyhq.atlassian.net/browse/OK-55897) [OK-55899](https://onekeyhq.atlassian.net/browse/OK-55899) [OK-55901](https://onekeyhq.atlassian.net/browse/OK-55901) [OK-55903](https://onekeyhq.atlassian.net/browse/OK-55903) [OK-55904](https://onekeyhq.atlassian.net/browse/OK-55904) [OK-55906](https://onekeyhq.atlassian.net/browse/OK-55906) [OK-55936](https://onekeyhq.atlassian.net/browse/OK-55936) [OK-55937](https://onekeyhq.atlassian.net/browse/OK-55937)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- **OK-55681**: Fix Perps notification/banner token entries so system-push and banner/deeplink paths can navigate to Perps and switch the mounted UI instrument.
- **OK-55809**: Stop Perps account-status flow from using the legacy rebate batch-check request/gating.
- **OK-55542**: Keep Perps long/short buttons pressable on insufficient margin and show an error Toast with Deposit action on submit.
- **OK-55644**: Keep the mobile TWAP order filter header visible after hide-other-pairs filters the current tab empty.
- **OK-55897**: Prefer USDC quote when computing Perps spot account totals.
- **OK-55936**: Remove long/short order button loading state on submit.
- **OK-55906**: Add View All entry at the bottom of TWAP history / fill history with local pagination.
- **OK-55597**: Align TWAP history columns and data with Hyperliquid.
- **OK-55590 / OK-55903 / OK-55901**: Remeasure web tab content height when it changes after focus. Root cause: Tabs.Container pinned the tab page height from a one-shot fallback measurement and observed a flex-stretched page div that never resizes, so TWAP sub-tab switches, async data and pagination left the panel clipped/unscrollable (OK-55590) or with large blank space (OK-55903, OK-55901). Also removes the per-list desktop vertical ScrollView workaround so TWAP lists render like Trades History.
- **OK-55937**: Keep orderbook prices selectable for the limit order form after coin switch.
- **OK-55904**: Keep full TWAP fill history when the WS snapshot arrives instead of truncating it.
- **OK-55899**: Wrap the TWAP history time column into date + time lines, matching fill history.

## Scope Notes
- The iOS killed-app local-notification cold launch case is **not** covered here: the tapped notification payload is not reliably delivered to JS and is tracked as a native-layer follow-up.
- Non-killed-app iOS system push navigation and Banner/deeplink asset switching are covered by this PR.
- The tab height remeasure change touches the shared web Tabs.Container fallback path; registered Tabs.FlatList/ScrollView tabs are unaffected.

## Commits
- `9b39d286e2` OK-55681 Perps system-push/Banner navigation and active instrument switch
- `a7afb7d0e4` OK-55809 remove Perps legacy rebate batch-check gating
- `596caed572` OK-55542 insufficient-margin Toast on submit
- `1a542cace2` OK-55644 mobile TWAP filter header visibility
- `0426502bbc` OK-55897 USDC quote for Perps spot totals
- `121c818124` OK-55936 remove order button loading
- `c94311c250` OK-55906 TWAP history bottom View All
- `86e19a76d0` OK-55597 align TWAP history with Hyperliquid
- `21492b30c5` OK-55590 OK-55903 OK-55901 remeasure web tab height on content growth
- `e748445921` OK-55937 keep orderbook prices selectable after coin switch
- `36dcd3de9c` OK-55904 keep full TWAP history on WS snapshot
- `16e81b5d84` OK-55899 wrap TWAP history time like fill history

## Verification
- `git diff --check`
- `yarn lint:staged` — passed per commit
- targeted `oxlint --type-aware` on changed files — passed
- `yarn jest packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.test.ts --runInBand` — passed, 31 tests
- `rg` confirmed no exact legacy `/rebate/v1/wallet/batch-check` endpoint/method/type refs remain
- Desktop dev build user-verified: TWAP history/fill history expand fully, page-scroll after sub-tab switches, wrapped time column

## Known Validation Gap
- `yarn tsc:staged` is currently blocked by unrelated current-`x` errors in `AnimatedDepthBlock.native.tsx` and `ThirdPartyHwErrorCode.NetworkError` files.
- Runtime mobile checks still needed for OK-55542/OK-55644.
- Runtime iOS killed-app notification tap is deferred to native follow-up.
- Home/Market web tab surfaces share the Tabs.Container fallback path; quick regression pass recommended.

## Manual Test Plan
- OK-55681: app not killed, tap iOS system push with Perps SPCX payload; confirm Perps opens and active coin is SPCX. Open Perps first, then click Banner/deeplink; confirm mounted Perps page switches coin.
- OK-55809: enter Perps / trigger Enable Trading and confirm no legacy `/rebate/v1/wallet/batch-check` request; account status and agent flow still work.
- OK-55542: with insufficient margin, confirm long/short button remains pressable; tapping shows insufficient-margin Toast with Deposit action.
- OK-55644: on mobile TWAP tab, enable hide-other-pairs so current tab becomes empty; confirm filter header/checkbox remains visible and can be unchecked.
- OK-55590/OK-55903/OK-55901: on desktop/web Perps, switch TWAP sub-tabs between active/history/fill history with >20 records; lists must expand fully with no clipping or blank space; with sticky tab, jump to a short last page and confirm no large blank area.
- OK-55899: TWAP history time column shows date and time on two lines, same as fill history.
- OK-55904/OK-55937: fill history stays complete after WS snapshot; orderbook price click fills the limit order form after switching coins.

[OK-55542]: https://onekeyhq.atlassian.net/browse/OK-55542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55590]: https://onekeyhq.atlassian.net/browse/OK-55590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55597]: https://onekeyhq.atlassian.net/browse/OK-55597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55644]: https://onekeyhq.atlassian.net/browse/OK-55644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55681]: https://onekeyhq.atlassian.net/browse/OK-55681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55809]: https://onekeyhq.atlassian.net/browse/OK-55809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55897]: https://onekeyhq.atlassian.net/browse/OK-55897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55899]: https://onekeyhq.atlassian.net/browse/OK-55899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55901]: https://onekeyhq.atlassian.net/browse/OK-55901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55903]: https://onekeyhq.atlassian.net/browse/OK-55903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55904]: https://onekeyhq.atlassian.net/browse/OK-55904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55906]: https://onekeyhq.atlassian.net/browse/OK-55906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55936]: https://onekeyhq.atlassian.net/browse/OK-55936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-55937]: https://onekeyhq.atlassian.net/browse/OK-55937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ