### PR TITLE
feat: add earn platform bonus UI

### DIFF
--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
@@ -51,6 +51,7 @@ import type {
   IEarnAlert,
   IEarnText,
   IEarnTokenInfo,
+  IProtocolInfo,
   IStakeEarnDetail,
 } from '@onekeyhq/shared/types/staking';
 
@@ -63,6 +64,7 @@ import {
 import { EarnActionIcon } from '../../../Staking/components/ProtocolDetails/EarnActionIcon';
 import { EarnAlert } from '../../../Staking/components/ProtocolDetails/EarnAlert';
 import { EarnIcon } from '../../../Staking/components/ProtocolDetails/EarnIcon';
+import { EarnPlatformBonusSection } from '../../../Staking/components/ProtocolDetails/EarnPlatformBonusSection';
 import { EarnText } from '../../../Staking/components/ProtocolDetails/EarnText';
 import { GridItem } from '../../../Staking/components/ProtocolDetails/GridItemV2';
 import { PendleRulesSection } from '../../../Staking/components/ProtocolDetails/PendleRulesSection';
@@ -482,6 +484,7 @@ function RiskSection({ risk }: { risk?: IStakeEarnDetail['risk'] }) {
 const DetailsPartComponent = ({
   detailInfo,
   tokenInfo,
+  protocolInfo,
   isLoading,
   keepSkeletonVisible,
   onRefresh,
@@ -493,6 +496,7 @@ const DetailsPartComponent = ({
 }: {
   detailInfo: IStakeEarnDetail | undefined;
   tokenInfo?: IEarnTokenInfo;
+  protocolInfo?: IProtocolInfo;
   isLoading: boolean;
   keepSkeletonVisible: boolean;
   onRefresh: () => void;
@@ -533,6 +537,11 @@ const DetailsPartComponent = ({
                 vault={vault}
               />
             </YStack>
+            <EarnPlatformBonusSection
+              platformBonus={detailInfo.platformBonus}
+              protocolInfo={protocolInfo}
+              tokenInfo={tokenInfo}
+            />
             <GridSection data={detailInfo.intro} />
             <ProtocolIntroSection protocolInfo={detailInfo.protocolInfo} />
             {earnUtils.isPendleProvider({
@@ -682,15 +691,21 @@ const EarnProtocolDetailsPage = ({ route }: { route: IRouteProps }) => {
     selectedAccount.indexedAccountId || indexedAccount?.id;
   const { networkId, symbol, provider, vault } = resolvedParams;
 
-  const { detailInfo, tokenInfo, isLoading, refreshData, refreshAccount } =
-    useProtocolDetailData({
-      accountId,
-      networkId,
-      indexedAccountId,
-      symbol,
-      provider,
-      vault,
-    });
+  const {
+    detailInfo,
+    tokenInfo,
+    protocolInfo,
+    isLoading,
+    refreshData,
+    refreshAccount,
+  } = useProtocolDetailData({
+    accountId,
+    networkId,
+    indexedAccountId,
+    symbol,
+    provider,
+    vault,
+  });
 
   useUnsupportedProtocol({
     detailInfo,
@@ -847,6 +862,7 @@ const EarnProtocolDetailsPage = ({ route }: { route: IRouteProps }) => {
           <DetailsPart
             detailInfo={detailInfo}
             tokenInfo={tokenInfo}
+            protocolInfo={protocolInfo}
             isLoading={isLoading ?? false}
             keepSkeletonVisible={keepSkeletonVisible}
             onRefresh={refreshData}

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/EarnPlatformBonusSection.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/EarnPlatformBonusSection.tsx
@@ -1,0 +1,364 @@
+import type { ReactNode } from 'react';
+import { useCallback } from 'react';
+
+import { StyleSheet } from 'react-native';
+
+import {
+  Button,
+  Dialog,
+  Divider,
+  Icon,
+  Image,
+  SizableText,
+  XStack,
+  YStack,
+  useMedia,
+} from '@onekeyhq/components';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { EarnNavigation } from '@onekeyhq/kit/src/views/Earn/earnUtils';
+import type {
+  IEarnActionIcon,
+  IEarnPlatformBonus,
+  IEarnPopupActionIcon,
+  IEarnText,
+  IEarnTokenInfo,
+  IProtocolInfo,
+} from '@onekeyhq/shared/types/staking';
+
+import { EarnIcon } from './EarnIcon';
+import { EarnText } from './EarnText';
+
+function getVisibleEarnText(text?: Partial<IEarnText>): IEarnText | undefined {
+  if (!text?.text?.trim()) {
+    return undefined;
+  }
+  return {
+    ...text,
+    text: text.text,
+  };
+}
+
+function BonusRulesInfoRow({
+  item,
+}: {
+  item: NonNullable<IEarnPopupActionIcon['data']['items']>[number];
+}) {
+  return (
+    <XStack gap="$3" ai="center" jc="space-between">
+      <XStack gap="$2" ai="center" flex={1} minWidth={0}>
+        <EarnIcon icon={item.icon} size="$4" color="$iconSubdued" />
+        {item.token?.info.logoURI ? (
+          <Image src={item.token.info.logoURI} w="$4" h="$4" />
+        ) : null}
+        <EarnText
+          text={item.title}
+          size="$bodyMd"
+          color={item.title.color ?? '$textSubdued'}
+          flexShrink={1}
+        />
+      </XStack>
+      <SizableText size="$bodyMdMedium" color="$text" textAlign="right">
+        {item.value}
+      </SizableText>
+    </XStack>
+  );
+}
+
+function EarnPlatformBonusDialogFooter({
+  actionIcon,
+  onClose,
+  protocolInfo,
+  tokenInfo,
+}: {
+  actionIcon?: IEarnActionIcon;
+  onClose: () => Promise<void> | void;
+  protocolInfo?: IProtocolInfo;
+  tokenInfo?: IEarnTokenInfo;
+}) {
+  const navigation = useAppNavigation();
+
+  if (!actionIcon) {
+    return null;
+  }
+
+  const actionText = getVisibleEarnText(actionIcon.text);
+  if (!actionText) {
+    return null;
+  }
+
+  if (actionIcon.type === 'close') {
+    return (
+      <Button
+        testID="earn-platform-bonus-rules-close"
+        variant="primary"
+        w="100%"
+        disabled={actionIcon.disabled}
+        onPress={() => {
+          void onClose();
+        }}
+      >
+        {actionText.text}
+      </Button>
+    );
+  }
+
+  if (actionIcon.type === 'portfolio') {
+    const networkId = protocolInfo?.networkId ?? tokenInfo?.networkId;
+    const symbol = protocolInfo?.symbol ?? tokenInfo?.token.symbol;
+    const provider = protocolInfo?.provider ?? tokenInfo?.provider;
+    const vault = protocolInfo?.vault ?? tokenInfo?.vault;
+    const isDisabled =
+      actionIcon.disabled || !networkId || !symbol || !provider;
+
+    return (
+      <Button
+        testID="earn-platform-bonus-rules-portfolio"
+        variant="primary"
+        w="100%"
+        disabled={isDisabled}
+        onPress={() => {
+          void Promise.resolve(onClose()).then(() =>
+            EarnNavigation.pushToEarnProtocolDetails(navigation, {
+              networkId: networkId ?? '',
+              symbol: symbol ?? '',
+              provider: provider ?? '',
+              vault,
+            }),
+          );
+        }}
+      >
+        {actionText.text}
+      </Button>
+    );
+  }
+
+  return null;
+}
+
+function EarnPlatformBonusRulesDialogContent({
+  data,
+  onClose,
+  protocolInfo,
+  tokenInfo,
+}: {
+  data: IEarnPopupActionIcon['data'];
+  onClose: () => Promise<void> | void;
+  protocolInfo?: IProtocolInfo;
+  tokenInfo?: IEarnTokenInfo;
+}) {
+  const platformBonusInfos = data.platformBonusInfos?.filter(
+    (item) =>
+      getVisibleEarnText(item.title) || getVisibleEarnText(item.description),
+  );
+
+  return (
+    <YStack gap="$5">
+      {data.items?.length ? (
+        <YStack gap="$2.5">
+          {data.items.map((item, index) => (
+            <BonusRulesInfoRow
+              key={`${item.title.text || 'item'}-${index}`}
+              item={item}
+            />
+          ))}
+        </YStack>
+      ) : null}
+      {platformBonusInfos?.length ? (
+        <YStack gap="$4">
+          {data.items?.length ? <Divider /> : null}
+          {platformBonusInfos.map((item, index) => (
+            <YStack key={`${item.title.text || 'info'}-${index}`} gap="$2">
+              {getVisibleEarnText(item.title) ? (
+                <EarnText
+                  text={item.title}
+                  size="$bodyMdMedium"
+                  color={item.title.color ?? '$text'}
+                />
+              ) : null}
+              {getVisibleEarnText(item.description) ? (
+                <EarnText
+                  text={item.description}
+                  size="$bodyMd"
+                  color={item.description.color ?? '$textSubdued'}
+                />
+              ) : null}
+            </YStack>
+          ))}
+        </YStack>
+      ) : null}
+      <EarnPlatformBonusDialogFooter
+        actionIcon={data.button}
+        onClose={onClose}
+        protocolInfo={protocolInfo}
+        tokenInfo={tokenInfo}
+      />
+    </YStack>
+  );
+}
+
+export function EarnPlatformBonusSection({
+  platformBonus,
+  footer,
+  protocolInfo,
+  tokenInfo,
+}: {
+  platformBonus?: IEarnPlatformBonus;
+  footer?: ReactNode;
+  protocolInfo?: IProtocolInfo;
+  tokenInfo?: IEarnTokenInfo;
+}) {
+  const media = useMedia();
+  const dialogData = platformBonus?.button?.data;
+  const rulesButtonText =
+    getVisibleEarnText(platformBonus?.button?.text) ??
+    getVisibleEarnText(dialogData?.title);
+  const hasRulesButton = Boolean(rulesButtonText?.text && dialogData);
+  const summary = platformBonus?.summary.filter((item) =>
+    getVisibleEarnText(item),
+  );
+  const shouldInlineRulesButton = Boolean(media.gtSm && hasRulesButton);
+
+  const showRulesDialog = useCallback(() => {
+    if (!dialogData) {
+      return;
+    }
+
+    const dialogRef: {
+      close?: () => Promise<void> | void;
+    } = {};
+    const dialog = Dialog.show({
+      title: dialogData.title?.text,
+      showFooter: false,
+      floatingPanelProps: {
+        w: 400,
+      },
+      renderContent: (
+        <EarnPlatformBonusRulesDialogContent
+          data={dialogData}
+          onClose={() => dialogRef.close?.()}
+          protocolInfo={protocolInfo}
+          tokenInfo={tokenInfo}
+        />
+      ),
+    });
+    dialogRef.close = dialog.close;
+  }, [dialogData, protocolInfo, tokenInfo]);
+
+  if (!platformBonus) {
+    return null;
+  }
+
+  let rulesButton: ReactNode = null;
+  if (hasRulesButton) {
+    if (media.gtSm) {
+      rulesButton = (
+        <XStack
+          gap="$1"
+          ai="center"
+          flexShrink={0}
+          cursor="pointer"
+          hoverStyle={{ opacity: 0.8 }}
+          pressStyle={{ opacity: 0.6 }}
+          onPress={showRulesDialog}
+        >
+          <EarnText
+            text={rulesButtonText}
+            size="$bodyMdMedium"
+            color={rulesButtonText?.color ?? '$textSubdued'}
+          />
+          <Icon
+            name="ChevronRightSmallOutline"
+            size="$4"
+            color="$iconSubdued"
+          />
+        </XStack>
+      );
+    } else {
+      rulesButton = (
+        <Button
+          testID="earn-platform-bonus-view-rules"
+          variant="secondary"
+          w="100%"
+          onPress={showRulesDialog}
+        >
+          {rulesButtonText?.text}
+        </Button>
+      );
+    }
+  }
+
+  const summaryItems = summary ?? [];
+  const summaryLeadItems = shouldInlineRulesButton
+    ? summaryItems.slice(0, Math.max(summaryItems.length - 1, 0))
+    : summaryItems;
+  const summaryInlineItem = shouldInlineRulesButton
+    ? summaryItems[summaryItems.length - 1]
+    : undefined;
+
+  const summaryContent =
+    summaryLeadItems.length || summaryInlineItem || rulesButton ? (
+      <YStack gap="$1.5">
+        {summaryLeadItems.map((item, index) => (
+          <EarnText
+            key={`${item.text}-${index}`}
+            text={item}
+            size="$bodyMd"
+            color={item.color ?? '$text'}
+          />
+        ))}
+        {shouldInlineRulesButton ? (
+          <XStack gap="$3" ai="center" jc="space-between">
+            {summaryInlineItem ? (
+              <EarnText
+                text={summaryInlineItem}
+                size="$bodyMd"
+                color={summaryInlineItem.color ?? '$text'}
+                flex={1}
+              />
+            ) : (
+              <XStack flex={1} />
+            )}
+            {rulesButton}
+          </XStack>
+        ) : (
+          rulesButton
+        )}
+      </YStack>
+    ) : null;
+
+  return (
+    <YStack
+      p="$3.5"
+      gap="$4"
+      borderRadius="$3"
+      borderWidth={StyleSheet.hairlineWidth}
+      borderColor="$borderSubdued"
+    >
+      <XStack gap="$2" ai="center" flexWrap="wrap">
+        <XStack gap="$1.5" ai="center">
+          <EarnIcon icon={platformBonus.icon} size="$4" color="$iconSuccess" />
+          <EarnText
+            text={platformBonus.title}
+            size="$bodyMdMedium"
+            color={platformBonus.title.color ?? '$text'}
+          />
+        </XStack>
+        <Divider vertical h="$4" />
+        <EarnText
+          text={platformBonus.period}
+          size="$bodyMd"
+          color={platformBonus.period.color ?? '$textSubdued'}
+        />
+      </XStack>
+
+      {summaryContent}
+
+      {footer ? (
+        <>
+          <Divider />
+          {footer}
+        </>
+      ) : null}
+    </YStack>
+  );
+}

--- a/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
@@ -92,6 +92,7 @@ import {
   ManagePageV2ReceiveInput,
 } from '../ManagePageV2ReceiveInput';
 import { EarnActionIcon } from '../ProtocolDetails/EarnActionIcon';
+import { EarnPlatformBonusSection } from '../ProtocolDetails/EarnPlatformBonusSection';
 import { EarnText } from '../ProtocolDetails/EarnText';
 import { EarnTooltip } from '../ProtocolDetails/EarnTooltip';
 import { EarnValidatorSelect } from '../ProtocolDetails/EarnValidatorSelect';
@@ -1985,6 +1986,30 @@ export function UniversalStake({
     showPendleTransactionSection,
   });
 
+  const tradeOrBuyContent = isPendleProvider ? null : (
+    <TradeOrBuy
+      token={tokenInfo?.token as IToken}
+      accountId={accountId}
+      networkId={networkId}
+      containerStyle={{
+        pt: '$0',
+      }}
+    />
+  );
+
+  const shouldShowPlatformBonus = Boolean(
+    transactionConfirmation?.platformBonus,
+  );
+
+  const platformBonusContent = transactionConfirmation?.platformBonus ? (
+    <EarnPlatformBonusSection
+      platformBonus={transactionConfirmation.platformBonus}
+      protocolInfo={protocolInfo}
+      tokenInfo={tokenInfo}
+      footer={tradeOrBuyContent}
+    />
+  ) : null;
+
   return (
     <StakingFormWrapper>
       <Stack position="relative">
@@ -2234,19 +2259,11 @@ export function UniversalStake({
                 </Accordion.Item>
               </Accordion>
             ) : null}
-            {isPendleProvider ? null : (
-              <TradeOrBuy
-                token={tokenInfo?.token as IToken}
-                accountId={accountId}
-                networkId={networkId}
-                containerStyle={{
-                  pt: '$0',
-                }}
-              />
-            )}
+            {shouldShowPlatformBonus ? null : tradeOrBuyContent}
           </YStack>
         </YStack>
       ) : null}
+      {platformBonusContent}
       {beforeFooter}
       {isInModalContext ? (
         <Page.Footer>

--- a/packages/shared/types/staking.ts
+++ b/packages/shared/types/staking.ts
@@ -800,6 +800,7 @@ export interface IEarnProtocolIntroInfo {
 
 export interface IEarnPopupActionIcon {
   type: 'popup';
+  text?: IEarnText;
   data: {
     title?: IEarnText;
     bulletList?: IEarnText[];
@@ -818,6 +819,11 @@ export interface IEarnPopupActionIcon {
       title: IEarnText;
       value: string;
     }[];
+    platformBonusInfos?: {
+      title: IEarnText;
+      description: IEarnText;
+    }[];
+    button?: IEarnActionIcon;
   };
 }
 
@@ -1114,6 +1120,16 @@ export type IEarnActionIcon =
   | IEarnCloseActionIcon
   | IEarnCancelWithdrawalActionIcon
   | IEarnListaCheckActionIcon;
+
+export interface IEarnPlatformBonus {
+  icon: IEarnIcon;
+  title: IEarnText;
+  period: IEarnText;
+  summary: IEarnText[];
+  button: IEarnPopupActionIcon & {
+    text: IEarnText;
+  };
+}
 
 interface IEarnGridItem {
   title: IEarnText;
@@ -1462,6 +1478,7 @@ export interface IStakeEarnDetail {
   };
   actions?: IEarnDetailActions[];
   subscriptionValue?: ISubscriptionValue;
+  platformBonus?: IEarnPlatformBonus;
   tags?: IStakeBadgeTag[];
   protocol?: IProtocolInfo;
   withdrawApprove?: IEarnWithdrawApproveInfo;
@@ -1604,6 +1621,7 @@ export interface IStakeTransactionConfirmation {
   tooltip?: IEarnTooltip;
   apyDetail?: IStakeEarnDetail['apyDetail'];
   effectiveApy?: string | number;
+  platformBonus?: IEarnPlatformBonus;
   rewards?: Array<{
     title: IEarnText;
     description: IEarnText;


### PR DESCRIPTION
## Summary
- Add shared Earn platform bonus types matching the server `platformBonus` payload.
- Render the Native Earn platform bonus card and rules dialog on protocol details and Stake transaction confirmation.
- Follow the backend nested button contract for `close` vs `portfolio` actions, and keep Trade/Buy inside the deposit bonus card when present.

## Intent & Context
Native Earn needs to surface a campaign bonus in the protocol details page and deposit transaction confirmation modal. The requirement came from the Earn Slack/Figma discussion, while the backend source of truth is `server-service-earn` branch `fix/catchUpNativeInfo`, which returns `platformBonus` from panel details and Stake transaction confirmation.

## Design Decisions
- Added an Earn-specific `EarnPlatformBonusSection` instead of reusing Borrow platform bonus UI because the payload and rules UX are different.
- Render all card, rules, and footer copy from the remote `IText` payload instead of adding frontend-only translation keys.
- Delegate the Rules footer behavior to the backend nested action type: `close` closes the dialog, `portfolio` reuses the existing Earn portfolio action.
- Keep the UI hidden when `platformBonus` is absent so campaign windows and unsupported providers degrade to the existing flow.

## Changes Detail
- `packages/shared/types/staking.ts`: adds Earn platform bonus types and extends popup action data with bonus rules fields.
- `packages/kit/src/views/Staking/components/ProtocolDetails/EarnPlatformBonusSection.tsx`: adds the reusable bonus card and rules dialog.
- `packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx`: renders protocol-detail `platformBonus`.
- `packages/kit/src/views/Staking/components/UniversalStake/index.tsx`: renders Stake transaction-confirmation `platformBonus` and moves Trade/Buy into the bonus card footer when shown.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web / Extension Earn surfaces
- **Risk Areas**: Remote optional payload shape, responsive card/dialog layout, and nested `portfolio` action behavior from transaction confirmation.

## Test plan
- [x] `yarn lint:staged`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/shared/types/staking.ts packages/kit/src/views/Staking/components/ProtocolDetails/EarnPlatformBonusSection.tsx packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx packages/kit/src/views/Staking/components/UniversalStake/index.tsx`
- [x] `git diff --check`
- [ ] `NODE_OPTIONS=--max-old-space-size=8192 yarn tsc:staged` is currently blocked by unrelated existing errors in `packages/kit/src/views/Perp/components/OrderBook/AnimatedDepthBlock.native.tsx` and third-party hardware `NetworkError` typing files. The Earn changed files no longer report TS errors.
- [ ] Runtime verify protocol details and deposit modal against a test environment returning `platformBonus`.
