### PR TITLE
docs: add swap cold start frame checklist

### DIFF
--- a/.skillshare/skills/1k-trade-swap-market/SKILL.md
+++ b/.skillshare/skills/1k-trade-swap-market/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: 1k-trade-swap-market
-description: App-side OneKey Trade/Swap/Market guide for Swap core, Swap Pro, Market speed-swap, K-line/chart, token selectors, quote/build/send flows, history/status, provider channels, PrivateSend-like channels, stock-trading channels, limit/order flows, fees, slippage, ETA, and cross-module funding handoffs.
+description: App-side OneKey Trade/Swap/Market guide for Swap core, Swap Pro, Market speed-swap, K-line/chart, token selectors, cold-start frame-by-frame validation, quote/build/send flows, history/status, provider channels, PrivateSend-like channels, stock-trading channels, limit/order flows, fees, slippage, ETA, and cross-module funding handoffs.
 ---
 
 # Trade, Swap, Market
 
-Use this skill when App code touches Trade, Swap, Market swap panels, provider/channel integrations, order-style execution, K-line data, transaction history, or funding handoffs into Swap.
+Use this skill when App code touches Trade, Swap, Market swap panels, provider/channel integrations, order-style execution, K-line data, transaction history, token selection, cold-start rendering, or funding handoffs into Swap.
 
 This is an App development skill. Use current repository code, runtime payloads, and visible App behavior as evidence. Do not bake external workflow details into the skill.
 
@@ -46,6 +46,9 @@ PrivateSend-like channels and future stock-trading channels should be evaluated 
    especially async identity, token/account identity, frozen review data, and
    history/status.
 7. Validate with [validation.md](references/validation.md), including a readiness drill when the change is a new channel.
+8. For cold start, token selector flicker, default-token bring-in, tab stability,
+   or Wallet handoff regressions, run
+   [swap-cold-start-frame-checklist.md](references/swap-cold-start-frame-checklist.md).
 
 ## Reference Map
 
@@ -57,6 +60,7 @@ PrivateSend-like channels and future stock-trading channels should be evaluated 
 | Define channel listening, writeback, replay, and repair | [channel-state-model.md](references/channel-state-model.md) |
 | Prevent known failure classes | [checklists.md](references/checklists.md) |
 | Prove the change works | [validation.md](references/validation.md) |
+| Validate Swap cold-start frames, default tokens, tab stability, and Wallet handoffs | [swap-cold-start-frame-checklist.md](references/swap-cold-start-frame-checklist.md) |
 
 ## Readiness Drills
 
@@ -86,6 +90,7 @@ If a drill cannot be completed from the references, update the abstraction inste
 - Do not treat Wallet/Receive DeFi-token list regressions as Swap selector bugs unless the failing owner is the Swap/Market selector or handoff state.
 - Do not collapse account, network, provider, token, and receiver resets into one path without checking dependents.
 - Do not mark transaction behavior validated from static diff alone; inspect the actual App path, payload, pending row, or visible state.
+- Do not validate cold-start or flicker fixes from the final settled screenshot only; inspect the first frames and tab/token transitions.
 - Do not edit generated locale files directly; use the repository i18n workflow.
 
 ## Related Skills

--- a/.skillshare/skills/1k-trade-swap-market/agents/openai.yaml
+++ b/.skillshare/skills/1k-trade-swap-market/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "OneKey Trade Swap Market"
-  short_description: "App-side Swap, Market, provider channel, history/status, and order-flow guidance"
-  default_prompt: "Use $1k-trade-swap-market for OneKey Swap, Swap Pro, Market speed-swap, Bridge, Limit, K-line/chart, token selectors, quote/build/send flows, provider channels, PrivateSend-like channels, stock/order channels, history/status, local writeback, replay/repair, fees, slippage, ETA, or funding handoffs into Swap."
+  short_description: "App-side Swap, Market, provider channel, cold-start, history/status, and order-flow guidance"
+  default_prompt: "Use $1k-trade-swap-market for OneKey Swap, Swap Pro, Market speed-swap, Bridge, Limit, K-line/chart, token selectors, cold-start frame-by-frame validation, quote/build/send flows, provider channels, PrivateSend-like channels, stock/order channels, history/status, local writeback, replay/repair, fees, slippage, ETA, or funding handoffs into Swap."

--- a/.skillshare/skills/1k-trade-swap-market/references/swap-cold-start-frame-checklist.md
+++ b/.skillshare/skills/1k-trade-swap-market/references/swap-cold-start-frame-checklist.md
@@ -1,0 +1,101 @@
+# Swap Cold-Start Frame Checklist
+
+Use this checklist for Swap, Bridge, Limit, token selector, default-token,
+Wallet handoff, skeleton, blank-screen, or icon-flicker regressions. The goal is
+to validate visible first-frame behavior and state transitions, not only the
+final settled screen.
+
+## Invocation Examples
+
+Use the skill directly and name the subset:
+
+```text
+$1k-trade-swap-market 只跑 Swap 冷启动逐帧自测：Desktop + iOS，覆盖 All Networks、ETH、BTC->ETH、BTC Bridge、Home BTC 兑换入口，不改代码，输出每个 case 的首帧/稳定帧结论。
+```
+
+For a narrow run:
+
+```text
+$1k-trade-swap-market 使用 references/swap-cold-start-frame-checklist.md，只验证 SWAP-AN-001 和 SWAP-FAST-TAP-001，逐帧检查 skeleton、白屏、network icon 和 token icon 是否闪烁。
+```
+
+## Runtime Evidence
+
+Before testing, prove the target runtimes are live and belong to the current
+checkout.
+
+- Desktop: verify the dev server and Electron CDP ports, then capture frames
+  through the browser/DevTools target.
+- iOS: verify the simulator, Metro, and React Native inspector targets, then
+  capture simulator screenshots during navigation.
+- Android: include it when the change touches native mobile behavior or the user
+  explicitly requests Android.
+
+Prefer `iPhone 17 Pro` for iOS simulator runs on this machine family when it is
+available. If native startup fails with a red screen, rebuild and reinstall the
+current app before recording product behavior.
+
+## Frame Capture Rules
+
+For each case, capture the first 1-3 seconds after the triggering action.
+Record both the first visible frame and the settled frame.
+
+Track these fields per frame:
+
+- active tab: Swap, Bridge, or Limit
+- From and To token symbols
+- From and To network labels and icons
+- Select Token count
+- skeleton/loading/blank-screen count
+- visible token and network image count
+- icon completeness, such as empty image, broken image, or natural size zero
+- transition count for token symbol, network label, and icon source
+- time from trigger to stable frame
+
+Do not mark a cold-start or flicker fix verified if only the final settled frame
+was inspected.
+
+## Test Matrix
+
+| ID | Path | Expected result |
+| --- | --- | --- |
+| SWAP-AN-001 | Cold start -> Home switch to All Networks -> enter Swap | Network icon and token icon do not flicker; no long Select Token skeleton. |
+| SWAP-SINGLE-001 | Select ETH network -> first entry to Swap | Expected ETH pair is brought in, for example ETH -> USDC, and the first frames are stable. |
+| SWAP-BTC-ETH-001 | Cold start on BTC -> switch Home network to ETH -> first entry to Swap | ETH default token is brought in; the form does not stay at Select Token. |
+| SWAP-PRESERVE-001 | After ETH default pair is initialized -> switch Home to Solana or another network -> re-enter Swap | Existing Swap tokens are preserved; Home network sync does not clear them. |
+| BRIDGE-BTC-001 | Cold start on BTC -> enter Swap area | BTC entry lands in Bridge when the entry is bridge-only; it does not remain on ordinary Swap by accident. |
+| HOME-BTC-001 | Wallet Home under All Networks -> click the BTC row swap button | Stay on Swap tab, but From and To both display Select Token because BTC is unsupported for ordinary Swap. |
+| LIMIT-TRON-001 | Home select Tron -> Trade Limit -> choose a token from the Limit network selector | Stay on Limit tab; unsupported tokens show Select Token; no forced Swap tab and no infinite skeleton. |
+| LIMIT-STABLE-001 | Enter Limit on a supported network | Supported default tokens render normally, and later unrelated network switches do not clear initialized Limit state. |
+| SWAP-FAST-TAP-001 | Cold start -> immediately tap Trade/Swap | No long blank white screen; a meaningful cached UI or bounded skeleton is visible quickly. |
+| TOKEN-SWITCH-001 | Switch From/To tokens repeatedly on single-network and All Networks contexts | Token and network icons do not flicker or fall back to Select Token during valid switches. |
+| TAB-STABILITY-001 | Move among Swap, Bridge, and Limit, then change Home network and return | Unsupported token handling never causes an unintended tab switch; initialized selections are not reset by unrelated sync. |
+
+## Required Assertions
+
+For every run, report:
+
+1. Platforms tested.
+2. Runtime proof, such as active port, inspector target, simulator, or browser
+   target.
+3. Case IDs covered.
+4. First-frame state and settled state for each case.
+5. Whether skeleton, blank screen, icon flicker, token clearing, or tab switching
+   occurred.
+6. Any unsupported-token behavior and whether it showed Select Token without
+   changing tabs.
+
+## Failure Triage
+
+If a case fails, identify the state owner before changing code:
+
+- route params or entry source for tab selection
+- Swap atoms for selected tokens and token loading
+- Home/account selector sync for account or network propagation
+- imported token payload for Wallet, Market, Earn, Buy, or token-list handoffs
+- provider capability checks for unsupported Swap, Bridge, or Limit routes
+- cold-start cache or snapshot pre-read for first-frame display
+
+Fix the owner that performs the wrong transition. Do not hide flicker by adding
+generic delays or by forcing a settled final state after the bad frame has
+already appeared.


### PR DESCRIPTION
## Summary
- Add a dedicated Swap cold-start frame-by-frame checklist under the existing Trade/Swap/Market skill.
- Wire the checklist into `1k-trade-swap-market` so future Swap cold-start, token selector flicker, default-token, tab stability, and Wallet handoff work can find it.
- Update the skill UI metadata to expose cold-start frame validation as part of the skill scope.

## Intent & Context
This PR documents the concrete Swap regression cases accumulated during the recent cold-start and token-stability work. The user asked to organize the complex case matrix so Codex can rerun the same frame-by-frame self-tests in future sessions, and asked whether the repo already had a Swap-related skill for this type of task.

## Root Cause
The existing `1k-trade-swap-market` skill covered Swap architecture, provider/channel contracts, and general validation, but it did not include a concrete first-frame regression matrix for cold-start rendering, default-token bring-in, unsupported-token behavior, tab stability, and Wallet handoff entries. That made future self-tests depend too much on conversation memory.

## Design Decisions
- Extend the existing `1k-trade-swap-market` skill instead of creating a separate skill, keeping Swap-related workflows under one entry point.
- Put the detailed case matrix in a reference file to keep `SKILL.md` concise while still discoverable.
- Include explicit invocation examples so future requests can narrow the run to cold-start-only validation or selected case IDs.

## Changes Detail
- `.skillshare/skills/1k-trade-swap-market/SKILL.md`: adds cold-start frame validation to the skill scope, workflow, reference map, and hard stops.
- `.skillshare/skills/1k-trade-swap-market/references/swap-cold-start-frame-checklist.md`: adds runtime evidence rules, frame capture fields, required assertions, failure triage, and the Swap/Bridge/Limit/Wallet handoff case matrix.
- `.skillshare/skills/1k-trade-swap-market/agents/openai.yaml`: updates UI-facing metadata so cold-start validation is visible from the skill chip/default prompt.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop, Mobile, Web validation workflows only
- **Risk Areas**: Skill discoverability and prompt wording. No product runtime code is changed.

## Test plan
- [x] Ran `git diff --check` for the modified skill files.
- [x] Ran `git diff --no-index --check` for the newly added checklist file.
- [ ] `yarn lint --fix` was attempted but failed on existing unrelated TypeScript errors in Perp depth bar and third-party hardware error files, outside this docs-only change.