### PR TITLE
fix: adjust private send mobile amount layout

### DIFF
--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -3468,8 +3468,18 @@ function SendAmountInputContainer() {
     canFetchPrivateSendQuote,
   ]);
 
+  const isPrivateSendMode = sendMode === ESendMode.PRIVATE;
+  const isMobilePrivateSendLayout =
+    isPrivateSendMode && platformEnv.isNative && !media.gtMd;
+  const shouldUseScrollablePrivateSendBody =
+    isPrivateSendMode && !isMobilePrivateSendLayout;
+  const shouldHidePrivateSendFooterHelp =
+    isMobilePrivateSendLayout && isAmountInputFocused;
+
   const renderPrivateSendFooterHelp = useMemo(() => {
-    if (sendMode !== ESendMode.PRIVATE) return null;
+    if (sendMode !== ESendMode.PRIVATE || shouldHidePrivateSendFooterHelp) {
+      return null;
+    }
     return (
       <XStack
         width="100%"
@@ -3495,7 +3505,7 @@ function SendAmountInputContainer() {
         </DashText>
       </XStack>
     );
-  }, [intl, sendMode]);
+  }, [intl, sendMode, shouldHidePrivateSendFooterHelp]);
 
   const footerConfirmText = isInsufficientBalance
     ? intl.formatMessage({
@@ -3648,12 +3658,6 @@ function SendAmountInputContainer() {
       ? ETranslations.private_send_private_send
       : ETranslations.enter_amount__title;
 
-  const isPrivateSendMode = sendMode === ESendMode.PRIVATE;
-  const shouldUseMobilePrivateSendFixedLayout =
-    isPrivateSendMode && platformEnv.isNative && !media.gtMd;
-  const shouldUseScrollablePrivateSendBody =
-    isPrivateSendMode && !shouldUseMobilePrivateSendFixedLayout;
-
   const renderAmountFormContent = (
     <Form form={form}>
       {isNFT ? renderNFTAmountInput : renderAmountInput}
@@ -3761,39 +3765,40 @@ function SendAmountInputContainer() {
       {renderQuoteInfoContent}
     </>
   );
-
-  const renderMobilePrivateSendPageBody = (
-    <Page.Body minHeight={0} overflow="hidden">
-      <YStack flex={1} minHeight={0}>
-        <Keyboard.AwareScrollView
-          keyboardShouldPersistTaps="handled"
-          keyboardDismissMode="none"
-          showsVerticalScrollIndicator={false}
-          style={{ flex: 1 }}
-          contentContainerStyle={{ flexGrow: 1 }}
-          bottomOffset={KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET}
-        >
-          <YStack flexGrow={1} justifyContent="center" px="$5" py="$5" gap="$3">
-            {renderAmountFormContent}
-            {renderInputRelatedInfoContent}
-          </YStack>
-        </Keyboard.AwareScrollView>
-        <Keyboard.StickyView>
-          <YStack bg="$bgApp" px="$5" pt="$2.5" pb="$2" gap="$2.5">
-            <YStack gap="$2.5">{renderQuoteInfoContent}</YStack>
-            <XStack gap="$2.5" width="100%">
-              {renderPrivateSendFooterButtons}
-            </XStack>
-            {renderPrivateSendFooterHelp}
-          </YStack>
-        </Keyboard.StickyView>
-      </YStack>
-    </Page.Body>
+  const renderMobilePrivateSendFooterInfoContent = (
+    <>
+      {extraContent}
+      {renderPrivateSendQuoteCard}
+      {renderNFTInfoCard}
+    </>
+  );
+  const renderMobilePrivateSendAmountBodyContent = renderAutoSwitchAlert ? (
+    <YStack width="100%" gap="$3">
+      {renderAmountFormContent}
+      {renderAutoSwitchAlert}
+    </YStack>
+  ) : (
+    renderAmountFormContent
   );
 
   let renderPageBody: ReactNode;
-  if (shouldUseMobilePrivateSendFixedLayout) {
-    renderPageBody = renderMobilePrivateSendPageBody;
+  if (isMobilePrivateSendLayout) {
+    renderPageBody = (
+      <Page.Body minHeight={0} overflow="hidden">
+        <ScrollView
+          automaticallyAdjustKeyboardInsets={false}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="none"
+          showsVerticalScrollIndicator={false}
+          flex={1}
+          contentContainerStyle={{ flexGrow: 1 }}
+        >
+          <YStack flexGrow={1} justifyContent="center" px="$5" py="$5" gap="$3">
+            {renderMobilePrivateSendAmountBodyContent}
+          </YStack>
+        </ScrollView>
+      </Page.Body>
+    );
   } else if (shouldUseScrollablePrivateSendBody) {
     renderPageBody = (
       <Page.Body minHeight={0} overflow="hidden">
@@ -3831,16 +3836,16 @@ function SendAmountInputContainer() {
 
       {renderPageBody}
 
-      {shouldUseMobilePrivateSendFixedLayout ? null : (
-        <Page.Footer>
-          {shouldUseScrollablePrivateSendBody ? null : (
-            <Stack px="$5" gap="$3">
-              {renderBottomInfoContent}
-            </Stack>
-          )}
-          {renderFooterActions}
-        </Page.Footer>
-      )}
+      <Page.Footer>
+        {shouldUseScrollablePrivateSendBody ? null : (
+          <Stack px="$5" gap="$3">
+            {isMobilePrivateSendLayout
+              ? renderMobilePrivateSendFooterInfoContent
+              : renderBottomInfoContent}
+          </Stack>
+        )}
+        {renderFooterActions}
+      </Page.Footer>
     </Page>
   );
 }


### PR DESCRIPTION
## Summary
- Adjust the mobile Private Send amount page so the amount/error/alert area stays in the page body while quote and action controls stay in the footer.
- Keep the expected received section visible above the keyboard and hide only the How it works help link while editing.
- Use a regular scroll container for the upper amount area so users can manually reveal alerts without keyboard-aware auto-scrolling moving the amount input away.

## Intent & Context
This fixes an iOS Private Send layout regression where the keyboard state made Private Send differ from Regular Send: the amount area was not visually centered, the address/coin controls were separated from the lower operation area, and the alert/error layer could be pushed or hidden in the wrong place.

## Root Cause
The mobile Private Send path used a custom fixed body plus `Keyboard.StickyView` split. Combined with keyboard-aware scrolling, the upper amount region and lower controls were handled by different interaction layers, causing auto-scroll and footer behavior to diverge from Regular Send.

## Design Decisions
- Keep the mobile-specific fix scoped to Private Send on native small screens.
- Put derived-address and quote-related controls in `Page.Footer`, matching the lower interaction layer used by the normal amount page.
- Keep amount validation and auto-switch alert in the body, with vertical padding and manual scroll only.
- Disable automatic keyboard inset adjustment on the inner scroll view to prevent the keyboard from scrolling the amount section away.

## Changes Detail
- `packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx`: refactors the mobile Private Send body/footer split and preserves existing desktop/wide Private Send behavior.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile iOS primarily; native small-screen Private Send layout only
- **Risk Areas**: Keyboard interaction, footer positioning, and Private Send alert visibility

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx --deny-warnings`
- [x] `git diff --check origin/x..HEAD`
- [x] `yarn lint:staged`
- [ ] `yarn tsc:staged` currently fails on unrelated baseline errors in Perp native refs and third-party hardware error enum, not in the changed Send file.