### PR TITLE
fix: dismiss keyboard before address selector(OK-55639)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -2500,8 +2500,7 @@ function SendAmountInputContainer() {
   const dismissAmountInputKeyboardBeforeSelectorOpen = useCallback(async () => {
     if (!platformEnv.isNative) return;
     amountInputRef.current?.blur();
-    Keyboard.dismiss();
-    await new Promise((resolve) => setTimeout(resolve, 32));
+    await Keyboard.dismissWithDelay(80);
   }, []);
 
   const renderPrivateSendHeaderRight = useCallback(() => {

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -1507,16 +1507,6 @@ function SendAmountInputContainer() {
     [vaultSettings?.coinControlEnabled],
   );
 
-  const handleCoinControlPress = useCallback(() => {
-    navigation.pushModal(EModalRoutes.SendModal, {
-      screen: EModalSendRoutes.CoinControl,
-      params: {
-        accountId: currentAccountId,
-        networkId,
-      },
-    });
-  }, [navigation, currentAccountId, networkId]);
-
   const normalizeAmountInputValue = useCallback(
     (rawValue: string) => {
       let inputValue = (rawValue ?? '').replace(/\s/g, '');
@@ -1600,6 +1590,30 @@ function SendAmountInputContainer() {
 
   // Ref for AmountInput to trigger button focus
   const amountInputRef = useRef<ISendAmountAutoSizeInputRef>(null);
+
+  const dismissAmountInputKeyboardBeforeOverlayOpen = useCallback(async () => {
+    if (!platformEnv.isNative) return;
+    amountInputRef.current?.blur();
+    await Keyboard.dismissWithDelay(80);
+  }, []);
+
+  const handleCoinControlPress = useCallback(() => {
+    void (async () => {
+      await dismissAmountInputKeyboardBeforeOverlayOpen();
+      navigation.pushModal(EModalRoutes.SendModal, {
+        screen: EModalSendRoutes.CoinControl,
+        params: {
+          accountId: currentAccountId,
+          networkId,
+        },
+      });
+    })();
+  }, [
+    currentAccountId,
+    dismissAmountInputKeyboardBeforeOverlayOpen,
+    navigation,
+    networkId,
+  ]);
 
   // Ref to track submit disabled state for keyboard shortcuts
   const isSubmitDisabledRef = useRef(true);
@@ -1689,36 +1703,40 @@ function SendAmountInputContainer() {
 
   const showTxMessageRawData = useCallback(() => {
     if (!txMessage) return;
-    let content = txMessageLinkedString;
-    if (isHexTxMessage) {
-      try {
-        content = Buffer.from(txMessage.replace(/^0x/i, ''), 'hex').toString(
-          'utf-8',
-        );
-      } catch {
-        content = txMessageLinkedString;
+    void (async () => {
+      await dismissAmountInputKeyboardBeforeOverlayOpen();
+      let content = txMessageLinkedString;
+      if (isHexTxMessage) {
+        try {
+          content = Buffer.from(txMessage.replace(/^0x/i, ''), 'hex').toString(
+            'utf-8',
+          );
+        } catch {
+          content = txMessageLinkedString;
+        }
       }
-    }
-    Dialog.show({
-      title: txMessageViewActionLabel,
-      renderContent: (
-        <ScrollView maxHeight="$96">
-          <SizableText
-            size="$bodyLg"
-            color="$textSubdued"
-            selectable
-            style={
-              platformEnv.isNative ? undefined : { wordBreak: 'break-all' }
-            }
-          >
-            {content}
-          </SizableText>
-        </ScrollView>
-      ),
-      showCancelButton: false,
-      onConfirmText: intl.formatMessage({ id: ETranslations.global_ok }),
-    });
+      Dialog.show({
+        title: txMessageViewActionLabel,
+        renderContent: (
+          <ScrollView maxHeight="$96">
+            <SizableText
+              size="$bodyLg"
+              color="$textSubdued"
+              selectable
+              style={
+                platformEnv.isNative ? undefined : { wordBreak: 'break-all' }
+              }
+            >
+              {content}
+            </SizableText>
+          </ScrollView>
+        ),
+        showCancelButton: false,
+        onConfirmText: intl.formatMessage({ id: ETranslations.global_ok }),
+      });
+    })();
   }, [
+    dismissAmountInputKeyboardBeforeOverlayOpen,
     intl,
     isHexTxMessage,
     txMessage,
@@ -1727,22 +1745,25 @@ function SendAmountInputContainer() {
   ]);
 
   const showTxMessageFaq = useCallback(() => {
-    Dialog.show({
-      title: intl.formatMessage({
-        id: recipientIsContract
-          ? ETranslations.global_hex_data_default
-          : ETranslations.global_hex_data,
-      }),
-      icon: 'ConsoleOutline',
-      description: intl.formatMessage({
-        id: ETranslations.global_hex_data_faq_desc,
-      }),
-      showCancelButton: false,
-      onConfirmText: intl.formatMessage({
-        id: ETranslations.global_ok,
-      }),
-    });
-  }, [intl, recipientIsContract]);
+    void (async () => {
+      await dismissAmountInputKeyboardBeforeOverlayOpen();
+      Dialog.show({
+        title: intl.formatMessage({
+          id: recipientIsContract
+            ? ETranslations.global_hex_data_default
+            : ETranslations.global_hex_data,
+        }),
+        icon: 'ConsoleOutline',
+        description: intl.formatMessage({
+          id: ETranslations.global_hex_data_faq_desc,
+        }),
+        showCancelButton: false,
+        onConfirmText: intl.formatMessage({
+          id: ETranslations.global_ok,
+        }),
+      });
+    })();
+  }, [dismissAmountInputKeyboardBeforeOverlayOpen, intl, recipientIsContract]);
 
   const getRecipientValidateMessage = useCallback(
     (status?: Exclude<IAddressValidateStatus, 'valid'>) => {
@@ -2454,12 +2475,15 @@ function SendAmountInputContainer() {
         ml="$2"
         p="$0.5"
         onPress={() => {
-          showBalanceDetailsDialog({
-            accountId: currentAccountId,
-            networkId,
-            mergeDeriveAssetsEnabled: false,
-            intl,
-          });
+          void (async () => {
+            await dismissAmountInputKeyboardBeforeOverlayOpen();
+            showBalanceDetailsDialog({
+              accountId: currentAccountId,
+              networkId,
+              mergeDeriveAssetsEnabled: false,
+              intl,
+            });
+          })();
         }}
         hoverStyle={{ opacity: 0.7 }}
         pressStyle={{ opacity: 0.5 }}
@@ -2468,7 +2492,13 @@ function SendAmountInputContainer() {
         <Icon name="InfoCircleOutline" size="$4.5" color="$iconSubdued" />
       </XStack>
     );
-  }, [hasFrozenBalance, currentAccountId, networkId, intl]);
+  }, [
+    currentAccountId,
+    dismissAmountInputKeyboardBeforeOverlayOpen,
+    hasFrozenBalance,
+    intl,
+    networkId,
+  ]);
 
   const handleSendModeChange = useCallback(
     (value: string | number) => {
@@ -2496,12 +2526,6 @@ function SendAmountInputContainer() {
       isPrivateSendGuideClicked: true,
     }));
   }, [settings.isPrivateSendGuideClicked, setSettings]);
-
-  const dismissAmountInputKeyboardBeforeSelectorOpen = useCallback(async () => {
-    if (!platformEnv.isNative) return;
-    amountInputRef.current?.blur();
-    await Keyboard.dismissWithDelay(80);
-  }, []);
 
   const renderPrivateSendHeaderRight = useCallback(() => {
     if (!showPrivateSendModeSwitch) return null;
@@ -2715,7 +2739,7 @@ function SendAmountInputContainer() {
             refreshOnOpen
             renderSelectorTrigger={
               deriveInfo ? (
-                <Stack onPress={dismissAmountInputKeyboardBeforeSelectorOpen}>
+                <Stack onPress={dismissAmountInputKeyboardBeforeOverlayOpen}>
                   <AddressTypeSelectorTrigger activeDeriveInfo={deriveInfo} />
                 </Stack>
               ) : undefined
@@ -2759,7 +2783,7 @@ function SendAmountInputContainer() {
     deriveInfo,
     deriveType,
     displayCoinControlButton,
-    dismissAmountInputKeyboardBeforeSelectorOpen,
+    dismissAmountInputKeyboardBeforeOverlayOpen,
     handleCoinControlPress,
     networkId,
     pulseSignal,
@@ -3289,8 +3313,11 @@ function SendAmountInputContainer() {
     const handleTogglePrivateSendQuoteDetails = () => {
       if (!shouldUsePrivateSendQuoteCollapse) return;
       if (!isPrivateSendQuoteDetailsExpanded) {
-        amountInputRef.current?.blur();
-        Keyboard.dismiss();
+        void (async () => {
+          await dismissAmountInputKeyboardBeforeOverlayOpen();
+          setIsPrivateSendQuoteDetailsExpanded((expanded) => !expanded);
+        })();
+        return;
       }
       setIsPrivateSendQuoteDetailsExpanded((expanded) => !expanded);
     };
@@ -3353,6 +3380,7 @@ function SendAmountInputContainer() {
               dashThickness={0.5}
               tooltip={estimatedReceivedTooltip}
               tooltipTitle={estimatedReceivedTitle}
+              onPress={dismissAmountInputKeyboardBeforeOverlayOpen}
             >
               {estimatedReceivedTitle}
             </DashText>
@@ -3464,6 +3492,7 @@ function SendAmountInputContainer() {
     );
   }, [
     currencySymbol,
+    dismissAmountInputKeyboardBeforeOverlayOpen,
     intl,
     isLoadingAssets,
     isNFT,

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -41,6 +41,7 @@ import {
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import AddressTypeSelector from '@onekeyhq/kit/src/components/AddressTypeSelector/AddressTypeSelector';
+import AddressTypeSelectorTrigger from '@onekeyhq/kit/src/components/AddressTypeSelector/AddressTypeSelectorTrigger';
 import { calcPercentBalance } from '@onekeyhq/kit/src/components/PercentageStageOnKeyboard';
 import { useReviewControl } from '@onekeyhq/kit/src/components/ReviewControl';
 import { LightningUnitSwitch } from '@onekeyhq/kit/src/components/UnitSwitch';
@@ -2496,6 +2497,13 @@ function SendAmountInputContainer() {
     }));
   }, [settings.isPrivateSendGuideClicked, setSettings]);
 
+  const dismissAmountInputKeyboardBeforeSelectorOpen = useCallback(async () => {
+    if (!platformEnv.isNative) return;
+    amountInputRef.current?.blur();
+    Keyboard.dismiss();
+    await new Promise((resolve) => setTimeout(resolve, 32));
+  }, []);
+
   const renderPrivateSendHeaderRight = useCallback(() => {
     if (!showPrivateSendModeSwitch) return null;
 
@@ -2706,6 +2714,13 @@ function SendAmountInputContainer() {
             // currently selected derive type and would show wrong balances
             // for other types (e.g. Taproot).
             refreshOnOpen
+            renderSelectorTrigger={
+              deriveInfo ? (
+                <Stack onPress={dismissAmountInputKeyboardBeforeSelectorOpen}>
+                  <AddressTypeSelectorTrigger activeDeriveInfo={deriveInfo} />
+                </Stack>
+              ) : undefined
+            }
             onSelect={async ({ account: a }) => {
               if (a) {
                 setCurrentAccountId(a.id);
@@ -2745,6 +2760,7 @@ function SendAmountInputContainer() {
     deriveInfo,
     deriveType,
     displayCoinControlButton,
+    dismissAmountInputKeyboardBeforeSelectorOpen,
     handleCoinControlPress,
     networkId,
     pulseSignal,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55639](https://onekeyhq.atlassian.net/browse/OK-55639)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Blur and dismiss the send amount input before opening the address type selector on native.
- Keep the fix scoped to the send amount page trigger for OK-55639.

## Intent & Context
Fixes the iOS send amount page issue where the numeric keyboard stays up and covers the address type selector popover on first entry.

## Root Cause
The address type selector trigger used the generic popover open path, so the focused amount input was not blurred before the popover opened. The mode selector already clears focus first, which is why switching modes once made the address selector work afterward.

## Design Decisions
- Reused the existing AddressTypeSelector trigger UI and only wrapped the send-page trigger with pre-open keyboard dismissal.
- Kept the change local to SendAmountInputContainer instead of changing shared selector or keyboard components.

## Changes Detail
- packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx: blurs the amount input, dismisses the native keyboard, then opens the address type selector.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile native send amount page
- **Risk Areas**: Address type selector open timing on native

## Test plan
- [x] yarn lint:staged
- [x] yarn tsc:staged
- [x] yarn test

## Issues
- Fixes OK-55639
- https://onekeyhq.atlassian.net/browse/OK-55639

[OK-55639]: https://onekeyhq.atlassian.net/browse/OK-55639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ