### PR TITLE
chore: respect Earn disable auto toast

### DIFF
--- a/packages/kit-bg/src/services/ServiceStaking.ts
+++ b/packages/kit-bg/src/services/ServiceStaking.ts
@@ -1462,10 +1462,11 @@ class ServiceStaking extends ServiceBase {
     code?: string | number;
     message?: string;
     requestId?: string;
+    disableAutoToast?: boolean;
   }) {
     if (data.code !== undefined && Number(data.code) !== 0 && data.message) {
       throw new OneKeyServerApiError({
-        autoToast: true,
+        autoToast: !data.disableAutoToast,
         disableFallbackMessage: true,
         code: Number(data.code),
         message: data.message,


### PR DESCRIPTION
## Summary
- Respect the Earn API `disableAutoToast` response flag when `ServiceStaking` manually converts raw-client non-zero responses into `OneKeyServerApiError`.
- Keep normal `getClient` endpoints unchanged because the shared axios interceptor already handles `disableAutoToast`.

## Intent & Context
Slack thread: https://onekeygroup.slack.com/archives/C065ZNS5NJU/p1780909583638349

The thread asks app startup, polling, and tab/list APIs to avoid disruptive error toasts when backend or network failures happen in passive UI states. The agreed response-side flag is `disableAutoToast`. Server-side Earn handling was added in https://github.com/OneKeyHQ/server-service-earn/pull/761.

## Root Cause
Most frontend API calls use `getClient`, so the shared axios interceptor reads `disableAutoToast` and sets `autoToast` accordingly. Earn available-assets uses `getRawDataClient`, which disables automatic non-zero response handling, then calls `ServiceStaking.handleServerError` manually. That manual path previously hardcoded `autoToast: true`, dropping the server response flag.

## Design Decisions
- Keep the fix in `ServiceStaking.handleServerError` instead of changing Earn UI hooks. The issue is response-to-error mapping, not tab visibility or UI state.
- Do not change `/earn/v1/borrow/markets` or `/earn/v1/faq/list` call sites because they already use the normal `getClient` interceptor path.
- Preserve existing fallback behavior when `disableAutoToast` is absent.

## Changes Detail
- `packages/kit-bg/src/services/ServiceStaking.ts`: include `disableAutoToast` in the manual server error payload and map it to `OneKeyServerApiError.autoToast`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop, Mobile, Web, Extension
- **Risk Areas**: Earn raw-client non-zero response handling for available assets and related reused raw-client Earn calls.

## Test plan
- [x] `git diff --check`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit-bg/src/services/ServiceStaking.ts --deny-warnings`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `yarn tsc:only`