### PR TITLE
fix: refresh history labels after private send(OK-55958)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -1145,7 +1145,9 @@ class ServiceHistory extends ServiceBase {
         ),
       );
     const privateSendDisplayStatusTxById = new Map(
-      privateSendDisplayStatusTxs.map((tx) => [tx.id, tx]),
+      privateSendDisplayStatusTxs
+        .filter((tx) => isPrivateSendAccountHistoryTx(tx))
+        .map((tx) => [tx.id, tx]),
     );
     const withPrivateSendDisplayStatus = (txsToMap: IAccountHistoryTx[]) =>
       txsToMap.map((tx) => privateSendDisplayStatusTxById.get(tx.id) ?? tx);


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55958](https://onekeyhq.atlassian.net/browse/OK-55958)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Fix history label localization after switching language for transactions affected by Private Send history merging.
- Limit Private Send display-status replacement to actual Private Send transactions.
- Keep normal on-chain history entries using the fresh server response for the current locale.

## Intent & Context
Issue: OK-55958

After Private Send changes, history entries created or cached under one language could keep that language's title after switching app language, even after refresh. The affected surface was the wallet history list on desktop, where normal transactions such as Send/Receive/Redeem could continue showing stale localized labels.

## Root Cause
`fetchAccountHistory` calls `attachPrivateSendDisplayStatus` with a `unionBy` list ordered as confirmed/local/on-chain. The resulting map was then applied back to `confirmedTxs`, `localHistoryConfirmedTxs`, and `onChainHistoryTxs` for every transaction type.

For non-Private Send transactions, `attachPrivateSendDisplayStatus` returns the original object unchanged. Because local confirmed history appeared before fresh on-chain history in the union, stale local objects with old-language `decodedTx.payload.label` could replace the current-locale server objects.

## Design Decisions
- Apply the display-status replacement map only to `PrivateSend` history rows.
- Do not rewrite stored history labels or broaden history matching logic.
- Keep the fix narrow so ordinary transaction merging continues to prefer fresh on-chain data while Private Send status enrichment still works.

## Changes Detail
- `packages/kit-bg/src/services/ServiceHistory.ts`
  - Filter `privateSendDisplayStatusTxById` to only include `isPrivateSendAccountHistoryTx(tx)`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Mobile / Web / Extension history service consumers
- **Risk Areas**: Private Send history status display. The change is constrained to which transactions can be replaced by Private Send display-status enrichment.

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --fix --deny-warnings packages/kit-bg/src/services/ServiceHistory.ts`
- [x] `npx tsgo -p ./tsconfig.json --noEmit --tsBuildInfoFile "$(yarn config get cacheFolder)"/.app-mono-ts-cache --pretty false`
- [x] `git diff --check`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] Verified through local Electron desktop dev environment that `fetchAccountHistory` now returns current-locale labels matching `fetchAccountOnChainHistory` for the reported Ethereum account.

[OK-55958]: https://onekeyhq.atlassian.net/browse/OK-55958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ