### PR TITLE
fix: restore perps TradingView loading

### DIFF
--- a/packages/kit/src/components/TradingView/ChartWebView/index.native.tsx
+++ b/packages/kit/src/components/TradingView/ChartWebView/index.native.tsx
@@ -32,6 +32,8 @@ import type { IWebViewRef } from '../../WebView/types';
 const IS_UNIFIED =
   CHART_WEBVIEW_MODE !== 'online' && CHART_WEBVIEW_SCENE === 'unified';
 
+let hasUnifiedChartLoadEnded = false;
+
 // The constant unified source: keep ONLY app-global keys (in a fixed order) and
 // inject the fixed unified scene + boot symbol. Token/business-independent and
 // deterministic, so market and perps hosts produce a byte-identical source and
@@ -157,6 +159,12 @@ export function ChartWebView({
       onWebViewRef?.(null);
     };
   }, [onWebViewRef]);
+
+  useEffect(() => {
+    if (IS_UNIFIED && hasUnifiedChartLoadEnded) {
+      onLoadEndRef.current?.();
+    }
+  }, []);
 
   // (1) Eager: push our symbol the moment the transport is ready — BEFORE this
   // screen finishes focusing — so the chart switches during the navigation
@@ -294,6 +302,9 @@ export function ChartWebView({
           type: paramsRef.current.type,
           sourceKind,
         });
+        if (IS_UNIFIED) {
+          hasUnifiedChartLoadEnded = true;
+        }
         // Cold first load: the page's SYMBOL_CHANGE listener wasn't up for the
         // eager send, so re-assert now that it is.
         if (autoDriveSymbolRef.current && isFocusedRef.current) {

--- a/packages/kit/src/components/TradingView/ChartWebView/types.ts
+++ b/packages/kit/src/components/TradingView/ChartWebView/types.ts
@@ -18,7 +18,8 @@ export interface IChartWebViewBaseProps {
   // reload) backed by the chart-webview module, so existing hooks work unchanged.
   onWebViewRef?: (ref: IWebViewRef | null) => void;
   // Fired when the underlying page finishes loading (forwarded from the module).
-  // For the shared unified WebView this only fires on the first (cold) load.
+  // For the shared unified WebView this fires on the first cold load, or
+  // immediately when the shared pool has already finished loading.
   onLoadEnd?: () => void;
   // Opt out of the host's automatic unified SYMBOL_CHANGE so the consumer can
   // drive its own (e.g. perps: source:'hyperliquid' + displayNames + ready

--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -293,14 +293,16 @@ export function TradingViewPerpsV2(
   >(null);
   const [chartContentReadyWebviewKey, setChartContentReadyWebviewKey] =
     useState<string | null>(null);
+  const [chartLoadingReadyWebviewKey, setChartLoadingReadyWebviewKey] =
+    useState<string | null>(null);
   const hasPerpsReadyRef = useRef(false);
   const lastHandledRestoreNonceRef = useRef(0);
 
-  // Unified: perps shares the single warm pooled WebView (no cold load, no
-  // spinner) and the host auto-drives SYMBOL_CHANGE (source:'hyperliquid', from
-  // params.type='perps'). The shared page is loaded once globally, so per-load
-  // chartReady/perpsReady don't re-fire for a later perps host — treat the chart
-  // as ready (the page's listeners are already up) so lines still sync.
+  // Unified: perps shares the single warm pooled WebView and the host auto-drives
+  // SYMBOL_CHANGE (source:'hyperliquid', from params.type='perps'). The shared
+  // page is loaded once globally, so per-load chartReady/perpsReady don't re-fire
+  // for a later perps host — treat the chart as ready (the page's listeners are
+  // already up) so lines still sync.
   const useUnifiedHost =
     (platformEnv.isNative &&
       CHART_WEBVIEW_MODE !== 'legacy' &&
@@ -340,6 +342,7 @@ export function TradingViewPerpsV2(
       hasPerpsReadyRef.current = false;
       setChartLinesReadyWebviewKey(null);
       setChartContentReadyWebviewKey(null);
+      setChartLoadingReadyWebviewKey(null);
       prevWebviewKeyRef.current = _webviewKey;
     }
   }, [_webviewKey]);
@@ -445,25 +448,38 @@ export function TradingViewPerpsV2(
     if (!hasPerpsReadyRef.current) {
       setChartLinesReadyWebviewKey(null);
       setChartContentReadyWebviewKey(null);
+      setChartLoadingReadyWebviewKey(null);
       webRef.current?.reload();
     }
   }, [restoreNonce]);
+
+  const markChartLoadingReady = useCallback(() => {
+    setChartLoadingReadyWebviewKey(_webviewKey);
+  }, [_webviewKey]);
+
+  useEffect(() => {
+    if (useUnifiedHost && unifiedReadyConfirmation > 0) {
+      markChartLoadingReady();
+    }
+  }, [markChartLoadingReady, unifiedReadyConfirmation, useUnifiedHost]);
 
   const onChartLinesReady = useCallback(() => {
     hasPerpsReadyRef.current = true;
     setChartContentReadyWebviewKey(_webviewKey);
     setChartLinesReadyWebviewKey(_webviewKey);
+    markChartLoadingReady();
     // Unified mode gates line sync on the optimistic unifiedReady; a real READY
     // ACK from the page confirms its perps listener is up, so force a full
     // resend to recover any cold-start sync the page dropped before it was ready.
     if (useUnifiedHost) {
       confirmUnifiedReady();
     }
-  }, [_webviewKey, useUnifiedHost, confirmUnifiedReady]);
+  }, [_webviewKey, useUnifiedHost, confirmUnifiedReady, markChartLoadingReady]);
 
   const onChartReady = useCallback(() => {
     setChartContentReadyWebviewKey(_webviewKey);
-  }, [_webviewKey]);
+    markChartLoadingReady();
+  }, [_webviewKey, markChartLoadingReady]);
 
   const onOrderCancel = useCallback(
     async (payload: ITVOrderCancelPayload) => {
@@ -603,18 +619,16 @@ export function TradingViewPerpsV2(
   // Cold first load of the shared page; mark ready (covers the rare case where
   // the optimistic mount-time ready guessed wrong) and forward to the caller.
   const handleUnifiedLoadEnd = useCallback(() => {
+    markChartLoadingReady();
     confirmUnifiedReady();
     onLoadEnd?.();
-  }, [confirmUnifiedReady, onLoadEnd]);
+  }, [confirmUnifiedReady, markChartLoadingReady, onLoadEnd]);
 
   const onShouldStartLoadWithRequest = useCallback(
     (event: WebViewNavigation) => handleNavigation(event),
     [handleNavigation],
   );
-  // Unified shares a warm pooled WebView, so there's no cold load to mask (the
-  // native module reveals via snapshot on switch). The spinner only applies to
-  // the legacy per-instance WebView.
-  const showChartLoadingMask = !useUnifiedHost && !isChartContentReady;
+  const showChartLoadingMask = chartLoadingReadyWebviewKey !== _webviewKey;
 
   return (
     <Stack position="relative" flex={1} {...stackStyle}>


### PR DESCRIPTION
## Summary
- Restore the Perps TradingView loading mask when the unified pooled chart WebView is reused.
- Replay unified chart load completion for later hosts after the shared WebView has already finished its cold load.
- Track loading readiness separately from content/line readiness so the mask clears only after the active chart host is ready.

## Intent & Context
The latest `x` branch dropped the loading optimization that was previously added for the Perps TradingView chart. The goal of this change is to restore that loading effect without giving up the unified pooled WebView behavior that keeps chart switching warm and fast.

## Root Cause
The native unified chart host uses a shared pooled WebView. Its underlying `onLoadEnd` only fires during the first cold load, and later Perps hosts can mount after the page is already loaded. At the same time, the unified host path no longer showed the loading mask, so later Perps chart transitions could appear without the expected loading feedback and consumers could miss load completion.

## Design Decisions
- Keep the shared unified WebView instead of falling back to per-instance WebViews, preserving the existing warm-chart performance path.
- Record unified chart load completion in the ChartWebView module and replay `onLoadEnd` for later unified hosts when the shared pool is already loaded.
- Add a dedicated loading-readiness key in `TradingViewPerpsV2` instead of coupling the loading mask to content or chart-line readiness. This lets the mask cover cold loads, restore reloads, and warm unified host mounts while still clearing on the first reliable ready signal.

## Changes Detail
- `ChartWebView/index.native.tsx`: tracks whether the unified pooled chart has completed loading and immediately forwards `onLoadEnd` for later unified mounts.
- `ChartWebView/types.ts`: documents the unified `onLoadEnd` replay behavior.
- `TradingViewPerpsV2.tsx`: adds loading-readiness state, resets it on WebView key changes and restore reloads, marks it ready from chart-ready/load-end/unified confirmation paths, and uses it to control the chart loading mask.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Desktop
- **Risk Areas**: Perps TradingView mount/reuse timing, unified WebView readiness replay, restore/reload behavior.

## Test plan
- [x] `yarn lint:staged && yarn tsc:staged`
- [x] `yarn app:ios --device 597DE7BC-BAAB-48B6-B67C-91BCFFD37009` builds, installs, and opens on iPhone 17 Pro.
- [x] Verified iPhone 17 Pro reaches the Wallet home screen through XcodeBuildMCP screenshot and UI snapshot.
- [x] Desktop Rspack dev process is running for manual verification.