### PR TITLE
fix: stabilize Swap cold-start defaults

### DIFF
--- a/.skillshare/skills/1k-trade-swap-market/references/swap-cold-start-frame-checklist.md
+++ b/.skillshare/skills/1k-trade-swap-market/references/swap-cold-start-frame-checklist.md
@@ -30,6 +30,13 @@ checkout.
   capture simulator screenshots during navigation.
 - Android: include it when the change touches native mobile behavior or the user
   explicitly requests Android.
+- Reload proof: after starting or restarting a runtime, trigger one reload and
+  verify the same target reconnects. For desktop, the Electron CDP target must
+  still list `OneKey` at `http://localhost:3001/`. For iOS, Metro must still
+  report `packager-status:running`, React Native inspector must list
+  `so.onekey.wallet (<simulator name>)`, and a post-reload screenshot must not
+  show a red screen, white screen, or unresolved `Select Token` first-frame
+  placeholder.
 
 Prefer `iPhone 17 Pro` for iOS simulator runs on this machine family when it is
 available. If native startup fails with a red screen, rebuild and reinstall the
@@ -59,19 +66,24 @@ was inspected.
 
 | ID | Path | Expected result |
 | --- | --- | --- |
-| SWAP-AN-001 | Cold start -> Home switch to All Networks -> enter Swap | Network icon and token icon do not flicker; no long Select Token skeleton. |
+| SWAP-AN-001 | Cold start -> Home switch to All Networks -> enter Swap | First visible Swap frame initializes ordinary Swap ETH -> USDC; it must not first expose Select Token, Bridge, or a concrete-network stale pair. Network icon and token icon do not flicker. |
+| SWAP-AN-PERSISTED-001 | Home is already on All Networks -> kill/restart app -> enter Swap | First visible Swap frame initializes ordinary Swap ETH -> USDC from the pre-read Home snapshot; it must not wait for a later account-sync pass or show Select Token first. |
 | SWAP-SINGLE-001 | Select ETH network -> first entry to Swap | Expected ETH pair is brought in, for example ETH -> USDC, and the first frames are stable. |
 | SWAP-BTC-ETH-001 | Cold start on BTC -> switch Home network to ETH -> first entry to Swap | ETH default token is brought in; the form does not stay at Select Token. |
 | SWAP-PRESERVE-001 | After ETH default pair is initialized -> switch Home to Solana or another network -> re-enter Swap | Existing Swap tokens are preserved; Home network sync does not clear them. |
 | SWAP-PRESERVE-BTC-001 | After Swap is initialized with a BTC-involved pair -> switch Home to ETH/Solana/another single network -> re-enter Swap | Existing Swap tokens are preserved even if the Home account derive type changes; Home network sync does not rewrite the pair. |
+| SWAP-PRESERVE-RACE-001 | Cold start -> enter Swap and see default tokens -> immediately return Home, switch networks, and re-enter Swap before another restart | Root/provider listeners must wait for latest Home storage before marking selected tokens initially synced, then preserve the initialized Swap pair after that first sync completes. |
 | BRIDGE-BTC-001 | Cold start on BTC -> enter Swap area | BTC entry lands in Bridge when the entry is bridge-only; it does not remain on ordinary Swap by accident. |
 | HOME-BTC-001 | Wallet Home under All Networks -> click the BTC row swap button | Stay on Swap tab, but From and To both display Select Token because BTC is unsupported for ordinary Swap. |
 | LIMIT-TRON-001 | Home select Tron -> Trade Limit -> choose a token from the Limit network selector | Stay on Limit tab; unsupported tokens show Select Token; no forced Swap tab and no infinite skeleton. |
 | LIMIT-STABLE-001 | Enter Limit on a supported network | Supported default tokens render normally, and later unrelated network switches do not clear initialized Limit state. |
 | SWAP-FAST-TAP-001 | Cold start -> immediately tap Trade/Swap | No long blank white screen; a meaningful cached UI or bounded skeleton is visible quickly. |
 | SWAP-PERPS-CACHE-001 | Cold start with both Perps and Swap cold-start snapshots present -> enter Perps first -> enter Swap | Perps settles to a usable trading view, then Swap opens to a meaningful cached/default UI without a white screen or duplicate root-provider crash. |
+| SWAP-IOS-KILL-BTC-001 | iOS cold start -> Home switch to Tron -> enter Swap and wait for Tron tokens -> Home switch to Bitcoin -> kill app without entering Swap -> cold start -> wait 5s -> enter Swap | Swap must discard the stale Tron selected-token cache and initialize the Bitcoin Bridge pair; the first visible Swap frame must not show the old Tron pair. |
+| SWAP-ALLNETWORK-BTC-BRIDGE-001 | Select BTC network -> enter Swap and initialize the BTC Bridge pair -> switch Home to All Networks -> cold start -> enter Swap | All Networks must discard the stale BTC Bridge selected-token cache and initialize the ordinary Swap ETH -> USDC pair; the first visible Swap frame must not stay on Bridge or BTC. |
 | TOKEN-SWITCH-001 | Switch From/To tokens repeatedly on single-network and All Networks contexts | Token and network icons do not flicker or fall back to Select Token during valid switches. |
 | TAB-STABILITY-001 | Move among Swap, Bridge, and Limit, then change Home network and return | Unsupported token handling never causes an unintended tab switch; initialized selections are not reset by unrelated sync. |
+| RUNTIME-RELOAD-001 | Start desktop and iOS -> verify ports/targets -> trigger Reload -> verify targets and capture the first post-reload frame | Desktop and iOS are genuinely running from the current checkout; reload does not leave Metro/CDP disconnected, red screen, white screen, or a stale Select Token first frame. |
 
 ## Required Assertions
 
@@ -91,6 +103,21 @@ For every run, report:
 8. For `SWAP-PERPS-CACHE-001`, whether both cold-start snapshots were present
    and whether any duplicate provider, red screen, LogBox, or white-screen state
    appeared while moving Perps -> Swap.
+9. For `SWAP-IOS-KILL-BTC-001`, the pre-kill Swap pair, the Home network at
+   kill time, the post-restart first-frame pair, and whether the stale
+   selected-token cache was cleared before Bitcoin Bridge defaults rendered.
+10. For `SWAP-ALLNETWORK-BTC-BRIDGE-001`, the pre-restart BTC Bridge pair, the
+   Home network at restart time, the first All Networks Swap pair, and whether
+   the stale Bridge tab or BTC token appeared.
+11. For `RUNTIME-RELOAD-001`, the exact listener ports, Electron CDP target,
+   Metro status, React Native inspector target, simulator name, and first
+   post-reload screenshot result.
+12. For `SWAP-AN-PERSISTED-001`, whether the Swap root provider was mounted
+   from the All Networks Home snapshot before entering Swap, the first-frame
+   pair, and whether any delayed Select Token placeholder appeared.
+13. For `SWAP-PRESERVE-RACE-001`, the initialized pair, the network switched
+   from/to, whether the initial selected-token synced flag was already committed,
+   and whether any root/provider listener rewrote or cleared the pair.
 
 ## Failure Triage
 

--- a/packages/kit/src/states/jotai/utils/JotaiContextStoreMirrorTracker.tsx
+++ b/packages/kit/src/states/jotai/utils/JotaiContextStoreMirrorTracker.tsx
@@ -17,6 +17,7 @@ import { CONTEXT_ATOM_COLD_START_CACHE_KEYS } from '@onekeyhq/shared/src/consts/
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { useDebugComponentRemountLog } from '@onekeyhq/shared/src/utils/debug/debugUtils';
+import { isSwapColdStartAllNetworkContextNetworkId } from '@onekeyhq/shared/src/utils/swapColdStartCacheSnapshotUtils';
 
 import { AccountSelectorRootProvider } from '../../../components/AccountSelector/AccountSelectorRootProvider';
 import { DiscoveryBrowserRootProvider } from '../../../views/Discovery/components/DiscoveryBrowserRootProvider';
@@ -43,8 +44,47 @@ type IGlobalColdStartSnapshot = typeof globalThis & {
   __ONEKEY_CTX_ATOM_SNAPSHOT__?: Record<string, unknown>;
 };
 
+type ISelectedAccountSnapshot = {
+  networkId?: string;
+};
+
+type ISelectedAccountsSnapshot = Record<
+  string | number,
+  ISelectedAccountSnapshot | undefined
+>;
+
+const COLD_START_SCOPED_KEY_SEPARATOR = '::';
+const ACCOUNT_SELECTOR_HOME_SCOPE_KEY = 'store:accountSelector@home';
+
 function getColdStartSnapshot() {
   return (globalThis as IGlobalColdStartSnapshot).__ONEKEY_CTX_ATOM_SNAPSHOT__;
+}
+
+function buildContextAtomSnapshotKey({
+  coldStartScopeKey,
+  coldStartCacheKey,
+}: {
+  coldStartScopeKey: string;
+  coldStartCacheKey: string;
+}) {
+  return `${coldStartScopeKey}${COLD_START_SCOPED_KEY_SEPARATOR}${coldStartCacheKey}`;
+}
+
+function hasAllNetworkHomeSelectedAccountSnapshot() {
+  const snapshot = getColdStartSnapshot();
+  if (!snapshot) {
+    return false;
+  }
+
+  const selectedAccounts = snapshot[
+    buildContextAtomSnapshotKey({
+      coldStartScopeKey: ACCOUNT_SELECTOR_HOME_SCOPE_KEY,
+      coldStartCacheKey:
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+    })
+  ] as ISelectedAccountsSnapshot | null | undefined;
+  const selectedAccount = selectedAccounts?.[0] ?? selectedAccounts?.['0'];
+  return isSwapColdStartAllNetworkContextNetworkId(selectedAccount?.networkId);
 }
 
 function hasPerpsColdStartSnapshot() {
@@ -85,8 +125,10 @@ function hasSwapColdStartSnapshot() {
     CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapSelectedTokensColdStartContextAtom,
     CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapProPositionsCacheAtom,
   ];
-  return Object.keys(snapshot).some((key) =>
-    swapColdStartCacheKeys.some((cacheKey) => key.endsWith(`::${cacheKey}`)),
+  return (
+    Object.keys(snapshot).some((key) =>
+      swapColdStartCacheKeys.some((cacheKey) => key.endsWith(`::${cacheKey}`)),
+    ) || hasAllNetworkHomeSelectedAccountSnapshot()
   );
 }
 

--- a/packages/kit/src/views/Swap/hooks/useSwapColdStartDisplayTokens.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapColdStartDisplayTokens.test.ts
@@ -4,7 +4,10 @@ import type { ISwapSelectedTokensColdStartContext } from '@onekeyhq/shared/src/u
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
 
-import { getSwapColdStartDisplayTokensFromGlobalSnapshot } from './useSwapColdStartDisplayTokens';
+import {
+  getSwapColdStartDisplayTokensFromGlobalSnapshot,
+  getSwapDefaultSelectedTokensFromGlobalHomeSnapshot,
+} from './useSwapColdStartDisplayTokens';
 
 const SWAP_STORE_SCOPE_KEY = 'store:swap';
 const ACCOUNT_SELECTOR_HOME_SCOPE_KEY = 'store:accountSelector@home';
@@ -23,6 +26,16 @@ function setGlobalSnapshot(snapshot: Record<string, unknown>) {
     [EAppSyncStorageKeys.onekey_jotai_context_atoms_snapshot, snapshot],
   ]);
   globalCache.__ONEKEY_CTX_ATOM_SNAPSHOT__ = undefined;
+}
+
+function setGlobalContextSnapshot(snapshot: Record<string, unknown>) {
+  const globalCache = globalThis as typeof globalThis & {
+    __ONEKEY_COLD_START_CACHE_MAP__?: Map<string, unknown>;
+    __ONEKEY_CTX_ATOM_SNAPSHOT__?: Record<string, unknown>;
+  };
+
+  delete globalCache.__ONEKEY_COLD_START_CACHE_MAP__;
+  globalCache.__ONEKEY_CTX_ATOM_SNAPSHOT__ = snapshot;
 }
 
 function clearGlobalSnapshot() {
@@ -69,6 +82,87 @@ describe('getSwapColdStartDisplayTokensFromGlobalSnapshot', () => {
         symbol: 'USDC',
       }),
     });
+  });
+
+  it('exposes all-networks home defaults for provider cold-start bootstrap', () => {
+    setGlobalSnapshot({
+      [scopedKey(
+        ACCOUNT_SELECTOR_HOME_SCOPE_KEY,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+      )]: {
+        0: buildHomeSelectedAccount('onekeyall--0'),
+      },
+    });
+
+    expect(
+      getSwapDefaultSelectedTokensFromGlobalHomeSnapshot({
+        allNetworksOnly: true,
+      }),
+    ).toEqual({
+      fromToken: expect.objectContaining({
+        networkId: 'evm--1',
+        symbol: 'ETH',
+      }),
+      toToken: expect.objectContaining({
+        networkId: 'evm--1',
+        symbol: 'USDC',
+      }),
+      context: expect.objectContaining({
+        accountKey: 'wallet-1|indexed-account-1|default',
+        networkId: 'onekeyall--0',
+        swapType: ESwapTabSwitchType.SWAP,
+      }),
+      swapType: ESwapTabSwitchType.SWAP,
+    });
+  });
+
+  it('reads all-networks home defaults from the pre-read context snapshot', () => {
+    setGlobalContextSnapshot({
+      [scopedKey(
+        ACCOUNT_SELECTOR_HOME_SCOPE_KEY,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+      )]: {
+        0: buildHomeSelectedAccount('onekeyall--0'),
+      },
+    });
+
+    expect(
+      getSwapDefaultSelectedTokensFromGlobalHomeSnapshot({
+        allNetworksOnly: true,
+      }),
+    ).toEqual({
+      fromToken: expect.objectContaining({
+        networkId: 'evm--1',
+        symbol: 'ETH',
+      }),
+      toToken: expect.objectContaining({
+        networkId: 'evm--1',
+        symbol: 'USDC',
+      }),
+      context: expect.objectContaining({
+        accountKey: 'wallet-1|indexed-account-1|default',
+        networkId: 'onekeyall--0',
+        swapType: ESwapTabSwitchType.SWAP,
+      }),
+      swapType: ESwapTabSwitchType.SWAP,
+    });
+  });
+
+  it('does not expose single-network defaults when the bootstrap is all-networks only', () => {
+    setGlobalSnapshot({
+      [scopedKey(
+        ACCOUNT_SELECTOR_HOME_SCOPE_KEY,
+        CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+      )]: {
+        0: buildHomeSelectedAccount('sol--101'),
+      },
+    });
+
+    expect(
+      getSwapDefaultSelectedTokensFromGlobalHomeSnapshot({
+        allNetworksOnly: true,
+      }),
+    ).toBeUndefined();
   });
 
   it('falls back to home-network defaults when stale selected tokens are invalidated', () => {

--- a/packages/kit/src/views/Swap/hooks/useSwapColdStartDisplayTokens.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapColdStartDisplayTokens.ts
@@ -8,7 +8,10 @@ import {
   isSwapColdStartAllNetworkContextNetworkId,
 } from '@onekeyhq/shared/src/utils/swapColdStartCacheSnapshotUtils';
 import type { ISwapSelectedTokensColdStartContext } from '@onekeyhq/shared/src/utils/swapColdStartCacheSnapshotUtils';
-import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+import type {
+  ESwapTabSwitchType,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
 
 import { buildSwapDefaultSelectedTokensFromHomeAccount } from '../utils/swapColdStartTokenCacheUtils';
 
@@ -229,7 +232,7 @@ function getRawSwapSelectedTokensFromSnapshot(
 
 function getDefaultSwapSelectedTokensFromHomeSnapshot(
   snapshot: Record<string, unknown>,
-): IDisplayTokens {
+) {
   const homeSelectedAccount = getSelectedAccountFromSnapshot({
     snapshot,
     coldStartScopeKey: ACCOUNT_SELECTOR_HOME_SCOPE_KEY,
@@ -242,6 +245,35 @@ function getDefaultSwapSelectedTokensFromHomeSnapshot(
     fromToken: defaultTokens?.fromToken,
     toToken: defaultTokens?.toToken,
   };
+}
+
+export function getSwapDefaultSelectedTokensFromGlobalHomeSnapshot({
+  allNetworksOnly = false,
+  swapType,
+}: {
+  allNetworksOnly?: boolean;
+  swapType?: ESwapTabSwitchType;
+} = {}) {
+  for (const snapshot of getColdStartSnapshotCandidatesFromGlobal()) {
+    const homeSelectedAccount = getSelectedAccountFromSnapshot({
+      snapshot,
+      coldStartScopeKey: ACCOUNT_SELECTOR_HOME_SCOPE_KEY,
+    });
+    const shouldUseSnapshot =
+      !allNetworksOnly ||
+      isSwapColdStartAllNetworkContextNetworkId(homeSelectedAccount?.networkId);
+    if (shouldUseSnapshot) {
+      const defaultTokens = buildSwapDefaultSelectedTokensFromHomeAccount({
+        homeSelectedAccount,
+        swapType,
+      });
+      if (defaultTokens?.fromToken?.symbol || defaultTokens?.toToken?.symbol) {
+        return defaultTokens;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 function hasDisplayToken(tokens: IDisplayTokens) {

--- a/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
@@ -65,6 +65,7 @@ import {
   isSwapSelectedTokensColdStartContextMatched,
   isSwapTokenSupportedBySwapType,
   shouldClearSwapSelectedTokensBeforeHomeAccountSync,
+  shouldMarkSwapInitialSelectedTokensSynced,
   shouldSkipSwapDefaultSelectedTokenSync,
   shouldSyncSwapSelectedAccountOnHomeAccountUpdate,
 } from '../utils/swapColdStartTokenCacheUtils';
@@ -437,6 +438,23 @@ export function useSwapInit(params?: ISwapInitParams) {
     return syncSwapSelectedAccountFromHome(homeSelectedAccount);
   }, [syncSwapSelectedAccountFromHome]);
 
+  const syncSwapSelectedAccountFromHomeStoragePromiseRef = useRef<
+    ReturnType<typeof syncSwapSelectedAccountFromLatestHome> | undefined
+  >(undefined);
+
+  const syncSwapSelectedAccountFromLatestHomeStorage = useCallback(async () => {
+    if (syncSwapSelectedAccountFromHomeStoragePromiseRef.current) {
+      return syncSwapSelectedAccountFromHomeStoragePromiseRef.current;
+    }
+
+    const promise = syncSwapSelectedAccountFromLatestHome().finally(() => {
+      hasSyncedSwapSelectedAccountFromHomeStorageRef.current = true;
+      syncSwapSelectedAccountFromHomeStoragePromiseRef.current = undefined;
+    });
+    syncSwapSelectedAccountFromHomeStoragePromiseRef.current = promise;
+    return promise;
+  }, [syncSwapSelectedAccountFromLatestHome]);
+
   useEffect(() => {
     const handleAccountSelectorSelectedAccountUpdate = (
       eventPayload: Parameters<
@@ -485,9 +503,8 @@ export function useSwapInit(params?: ISwapInitParams) {
     if (hasSyncedSwapSelectedAccountFromHomeStorageRef.current) {
       return;
     }
-    hasSyncedSwapSelectedAccountFromHomeStorageRef.current = true;
-    void syncSwapSelectedAccountFromLatestHome();
-  }, [syncSwapSelectedAccountFromLatestHome]);
+    void syncSwapSelectedAccountFromLatestHomeStorage();
+  }, [syncSwapSelectedAccountFromLatestHomeStorage]);
 
   const fetchSwapNetworks = useCallback(async () => {
     const currentSwapNetworks = swapNetworksRef.current;
@@ -848,7 +865,8 @@ export function useSwapInit(params?: ISwapInitParams) {
       }
       return;
     }
-    const homeAccountSyncResult = await syncSwapSelectedAccountFromLatestHome();
+    const homeAccountSyncResult =
+      await syncSwapSelectedAccountFromLatestHomeStorage();
     if (homeAccountSyncResult.synced) {
       if (homeAccountSyncResult.clearedSelectedTokens) {
         hasSelectedTokens = false;
@@ -1128,17 +1146,28 @@ export function useSwapInit(params?: ISwapInitParams) {
     clearSelectedTokensColdStartCache,
     markInitialSelectedTokensSynced,
     switchSwapTypeIfNeeded,
-    syncSwapSelectedAccountFromLatestHome,
+    syncSwapSelectedAccountFromLatestHomeStorage,
   ]);
 
   useEffect(() => {
     if (initialSelectedTokensSyncedRef.current) {
       return;
     }
-    if (!fromTokenRef.current && !toTokenRef.current) {
+    const hasSelectedTokens = Boolean(
+      fromTokenRef.current || toTokenRef.current,
+    );
+    if (!hasSelectedTokens) {
       return;
     }
-    if (validateSelectedTokensColdStartContext()) {
+    if (
+      shouldMarkSwapInitialSelectedTokensSynced({
+        hasSelectedTokens,
+        hasSyncedSwapSelectedAccountFromHomeStorage:
+          hasSyncedSwapSelectedAccountFromHomeStorageRef.current,
+        selectedTokensColdStartContextValid:
+          validateSelectedTokensColdStartContext(),
+      })
+    ) {
       markInitialSelectedTokensSynced();
     }
   }, [

--- a/packages/kit/src/views/Swap/pages/SwapProviderMirror.tsx
+++ b/packages/kit/src/views/Swap/pages/SwapProviderMirror.tsx
@@ -18,7 +18,10 @@ import {
 import { jotaiContextStore } from '../../../states/jotai/utils/jotaiContextStore';
 import { JotaiContextStoreMirrorTracker } from '../../../states/jotai/utils/JotaiContextStoreMirrorTracker';
 
-import { useSwapContextStoreInitData } from './SwapRootProvider';
+import {
+  hydrateSwapAllNetworkDefaultTokensFromGlobalHomeSnapshot,
+  useSwapContextStoreInitData,
+} from './SwapRootProvider';
 
 export const SwapProviderMirror = memo(
   (
@@ -36,23 +39,25 @@ export const SwapProviderMirror = memo(
     const data = useSwapContextStoreInitData(storeName);
     const store = jotaiContextStore.getOrCreateStore(data);
     const hasInitializedSelectedTokensRef = useRef(false);
-    if (
-      initialSelectedTokensOnInit &&
-      !hasInitializedSelectedTokensRef.current
-    ) {
-      hasInitializedSelectedTokensRef.current = true;
-      store.set(
-        swapSelectFromTokenAtom(),
-        initialSelectedTokensOnInit.fromToken,
-      );
-      store.set(swapSelectToTokenAtom(), initialSelectedTokensOnInit.toToken);
-      store.set(swapSelectedTokensColdStartContextAtom(), undefined);
-      store.set(swapInitialSelectedTokensSyncedAtom(), true);
-      store.set(swapFromTokenAmountAtom(), { value: '', isInput: false });
-      store.set(
-        swapTypeSwitchAtom(),
-        initialSelectedTokensOnInit.swapType ?? ESwapTabSwitchType.SWAP,
-      );
+    if (!hasInitializedSelectedTokensRef.current) {
+      if (initialSelectedTokensOnInit) {
+        hasInitializedSelectedTokensRef.current = true;
+        store.set(
+          swapSelectFromTokenAtom(),
+          initialSelectedTokensOnInit.fromToken,
+        );
+        store.set(swapSelectToTokenAtom(), initialSelectedTokensOnInit.toToken);
+        store.set(swapSelectedTokensColdStartContextAtom(), undefined);
+        store.set(swapInitialSelectedTokensSyncedAtom(), true);
+        store.set(swapFromTokenAmountAtom(), { value: '', isInput: false });
+        store.set(
+          swapTypeSwitchAtom(),
+          initialSelectedTokensOnInit.swapType ?? ESwapTabSwitchType.SWAP,
+        );
+      } else {
+        hasInitializedSelectedTokensRef.current =
+          hydrateSwapAllNetworkDefaultTokensFromGlobalHomeSnapshot(store);
+      }
     }
 
     return (

--- a/packages/kit/src/views/Swap/pages/SwapRootProvider.tsx
+++ b/packages/kit/src/views/Swap/pages/SwapRootProvider.tsx
@@ -10,6 +10,11 @@ import type { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import {
   ProviderJotaiContextSwap,
+  swapInitialSelectedTokensSyncedAtom,
+  swapSelectFromTokenAtom,
+  swapSelectToTokenAtom,
+  swapSelectedTokensColdStartContextAtom,
+  swapTypeSwitchAtom,
   useSwapInitialSelectedTokensSyncedAtom,
   useSwapSelectFromTokenAtom,
   useSwapSelectToTokenAtom,
@@ -17,10 +22,38 @@ import {
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
 import { useJotaiContextRootStore } from '../../../states/jotai/utils/useJotaiContextRootStore';
+import { getSwapDefaultSelectedTokensFromGlobalHomeSnapshot } from '../hooks/useSwapColdStartDisplayTokens';
 import {
   buildSwapDefaultSelectedTokensFromHomeAccount,
   shouldHandleSwapColdStartHomeAccountUpdate,
 } from '../utils/swapColdStartTokenCacheUtils';
+
+type ISwapContextStore = ReturnType<typeof useJotaiContextRootStore>;
+
+export function hydrateSwapAllNetworkDefaultTokensFromGlobalHomeSnapshot(
+  store: ISwapContextStore,
+) {
+  const hasSelectedTokens = Boolean(
+    store.get(swapSelectFromTokenAtom()) || store.get(swapSelectToTokenAtom()),
+  );
+  if (hasSelectedTokens || store.get(swapInitialSelectedTokensSyncedAtom())) {
+    return false;
+  }
+
+  const defaultTokens = getSwapDefaultSelectedTokensFromGlobalHomeSnapshot({
+    allNetworksOnly: true,
+    swapType: store.get(swapTypeSwitchAtom()),
+  });
+  if (!defaultTokens) {
+    return false;
+  }
+
+  store.set(swapSelectFromTokenAtom(), defaultTokens.fromToken);
+  store.set(swapSelectToTokenAtom(), defaultTokens.toToken);
+  store.set(swapSelectedTokensColdStartContextAtom(), defaultTokens.context);
+  store.set(swapTypeSwitchAtom(), defaultTokens.swapType);
+  return true;
+}
 
 function SwapColdStartCacheSync() {
   const [swapTypeSwitch, setSwapTypeSwitch] = useSwapTypeSwitchAtom();
@@ -136,6 +169,11 @@ export function useSwapContextStoreInitData(
 export const SwapRootProvider = memo(() => {
   const data = useSwapContextStoreInitData(EJotaiContextStoreNames.swap);
   const store = useJotaiContextRootStore(data);
+  const hasHydratedAllNetworkDefaultsRef = useRef(false);
+  if (!hasHydratedAllNetworkDefaultsRef.current) {
+    hasHydratedAllNetworkDefaultsRef.current = true;
+    hydrateSwapAllNetworkDefaultTokensFromGlobalHomeSnapshot(store);
+  }
   return (
     <ProviderJotaiContextSwap store={store}>
       <SwapColdStartCacheSync />

--- a/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts
@@ -21,6 +21,7 @@ import {
   shouldClearSwapSelectedTokensBeforeHomeAccountSync,
   shouldClearSwapSelectedTokensOnHomeAccountUpdate,
   shouldHandleSwapColdStartHomeAccountUpdate,
+  shouldMarkSwapInitialSelectedTokensSynced,
   shouldSkipSwapDefaultSelectedTokenSync,
   shouldSyncSwapSelectedAccountOnHomeAccountUpdate,
 } from './swapColdStartTokenCacheUtils';
@@ -360,6 +361,34 @@ describe('swap cold-start selected token context', () => {
       homeSelectedAccount: buildSelectedAccount({
         networkId: 'onekeyall--0',
       }),
+      now: 1,
+    });
+
+    expect(defaultTokens).toEqual({
+      fromToken: expect.objectContaining({
+        networkId: 'evm--1',
+        symbol: 'ETH',
+      }),
+      toToken: expect.objectContaining({
+        networkId: 'evm--1',
+        symbol: 'USDC',
+      }),
+      context: expect.objectContaining({
+        accountKey: 'wallet-1|indexed-account-1|default',
+        networkId: 'onekeyall--0',
+        swapType: ESwapTabSwitchType.SWAP,
+        updatedAt: 1,
+      }),
+      swapType: ESwapTabSwitchType.SWAP,
+    });
+  });
+
+  it('uses Swap ETH-USDC defaults for All Networks even when the previous tab was Bridge', () => {
+    const defaultTokens = buildSwapDefaultSelectedTokensFromHomeAccount({
+      homeSelectedAccount: buildSelectedAccount({
+        networkId: 'onekeyall--0',
+      }),
+      swapType: ESwapTabSwitchType.BRIDGE,
       now: 1,
     });
 
@@ -766,7 +795,7 @@ describe('swap cold-start selected token context', () => {
     ).toBe(true);
   });
 
-  it('preserves restored tokens when syncing the same account into All Networks without token context', () => {
+  it('clears restored tokens when syncing the same account into All Networks without token context', () => {
     const homeSelectedAccount = buildSelectedAccount({
       networkId: 'onekeyall--0',
     });
@@ -794,10 +823,10 @@ describe('swap cold-start selected token context', () => {
         homeSelectedAccount,
         swapSelectedAccount,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  it('preserves restored tokens when syncing the same account into All Networks with concrete swap context', () => {
+  it('clears restored tokens when syncing the same account into All Networks with concrete swap context', () => {
     const cachedContext = buildSwapSelectedTokensColdStartContext({
       activeAccount: buildActiveAccount({
         network: {
@@ -833,6 +862,120 @@ describe('swap cold-start selected token context', () => {
         cachedContext,
         hasSelectedTokens: true,
         homeSelectedAccount,
+        swapSelectedAccount,
+      }),
+    ).toBe(true);
+  });
+
+  it('preserves restored tokens when syncing the same account into All Networks with all-network context', () => {
+    const cachedContext = buildSwapSelectedTokensColdStartContext({
+      activeAccount: buildActiveAccount({
+        network: {
+          id: 'onekeyall--0',
+        } as IAccountSelectorActiveAccountInfo['network'],
+      }),
+      networkId: 'onekeyall--0',
+      swapType: ESwapTabSwitchType.SWAP,
+      now: 1,
+    });
+    const homeSelectedAccount = buildSelectedAccount({
+      networkId: 'onekeyall--0',
+    });
+    const swapSelectedAccount = buildSelectedAccount({
+      networkId: 'onekeyall--0',
+    });
+
+    expect(
+      shouldSyncSwapSelectedAccountOnHomeAccountUpdate({
+        cachedContext,
+        hasSelectedTokens: true,
+        swapSelectedAccount,
+        eventPayload: {
+          sceneName: EAccountSelectorSceneName.home,
+          num: 0,
+          selectedAccount: homeSelectedAccount,
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldClearSwapSelectedTokensBeforeHomeAccountSync({
+        cachedContext,
+        hasSelectedTokens: true,
+        homeSelectedAccount,
+        swapSelectedAccount,
+      }),
+    ).toBe(false);
+  });
+
+  it('clears stale BTC Bridge tokens when cold-starting into All Networks', () => {
+    const cachedContext = buildSwapSelectedTokensColdStartContext({
+      activeAccount: buildActiveAccount({
+        network: {
+          id: 'btc--0',
+        } as IAccountSelectorActiveAccountInfo['network'],
+      }),
+      networkId: 'btc--0',
+      swapType: ESwapTabSwitchType.BRIDGE,
+      now: 1,
+    });
+    const homeSelectedAccount = buildSelectedAccount({
+      networkId: 'onekeyall--0',
+    });
+    const swapSelectedAccount = buildSelectedAccount({
+      deriveType: 'BIP44',
+      networkId: 'btc--0',
+    });
+    const eventPayload = {
+      sceneName: EAccountSelectorSceneName.home,
+      num: 0,
+      selectedAccount: homeSelectedAccount,
+    };
+
+    expect(
+      shouldHandleSwapColdStartHomeAccountUpdate({
+        cachedContext,
+        eventPayload,
+        hasSelectedTokens: true,
+        initialSelectedTokensSynced: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSyncSwapSelectedAccountOnHomeAccountUpdate({
+        cachedContext,
+        eventPayload,
+        hasSelectedTokens: true,
+        initialSelectedTokensSynced: false,
+        swapSelectedAccount,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldClearSwapSelectedTokensBeforeHomeAccountSync({
+        cachedContext,
+        hasSelectedTokens: true,
+        homeSelectedAccount,
+        initialSelectedTokensSynced: false,
+        swapSelectedAccount,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldHandleSwapColdStartHomeAccountUpdate({
+        cachedContext,
+        eventPayload,
+        hasSelectedTokens: true,
+        initialSelectedTokensSynced: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldClearSwapSelectedTokensBeforeHomeAccountSync({
+        cachedContext,
+        hasSelectedTokens: true,
+        homeSelectedAccount,
+        initialSelectedTokensSynced: true,
         swapSelectedAccount,
       }),
     ).toBe(false);
@@ -1007,6 +1150,24 @@ describe('swap cold-start selected token context', () => {
     ).toBe(false);
   });
 
+  it('does not mark restored tokens as initially synced before latest Home storage is checked', () => {
+    expect(
+      shouldMarkSwapInitialSelectedTokensSynced({
+        hasSelectedTokens: true,
+        hasSyncedSwapSelectedAccountFromHomeStorage: false,
+        selectedTokensColdStartContextValid: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldMarkSwapInitialSelectedTokensSynced({
+        hasSelectedTokens: true,
+        hasSyncedSwapSelectedAccountFromHomeStorage: true,
+        selectedTokensColdStartContextValid: true,
+      }),
+    ).toBe(true);
+  });
+
   it('clears restored tokens when syncing All Networks for another account without token context', () => {
     expect(
       shouldClearSwapSelectedTokensBeforeHomeAccountSync({
@@ -1052,6 +1213,50 @@ describe('swap cold-start selected token context', () => {
             deriveType: 'default',
           }),
         },
+      }),
+    ).toBe(true);
+  });
+
+  it('syncs and clears stale Tron tokens when iOS cold-starts after Home changed to Bitcoin while Swap was not open', () => {
+    const cachedContext = buildSwapSelectedTokensColdStartContext({
+      activeAccount: buildActiveAccount({
+        network: {
+          id: 'tron--0x2b6653dc',
+        } as IAccountSelectorActiveAccountInfo['network'],
+      }),
+      networkId: 'tron--0x2b6653dc',
+      swapType: ESwapTabSwitchType.SWAP,
+      now: 1,
+    });
+    const homeSelectedAccount = buildSelectedAccount({
+      networkId: 'btc--0',
+      deriveType: 'BIP44',
+    });
+    const swapSelectedAccount = buildSelectedAccount({
+      networkId: 'tron--0x2b6653dc',
+      deriveType: 'default',
+    });
+
+    expect(
+      shouldSyncSwapSelectedAccountOnHomeAccountUpdate({
+        cachedContext,
+        hasSelectedTokens: true,
+        initialSelectedTokensSynced: false,
+        swapSelectedAccount,
+        eventPayload: {
+          sceneName: EAccountSelectorSceneName.home,
+          num: 0,
+          selectedAccount: homeSelectedAccount,
+        },
+      }),
+    ).toBe(true);
+    expect(
+      shouldClearSwapSelectedTokensBeforeHomeAccountSync({
+        cachedContext,
+        hasSelectedTokens: true,
+        homeSelectedAccount,
+        initialSelectedTokensSynced: false,
+        swapSelectedAccount,
       }),
     ).toBe(true);
   });

--- a/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.ts
@@ -158,6 +158,23 @@ function isHomeMainAccountUpdate({
   );
 }
 
+function shouldResetSelectedTokensForAllNetworkHome({
+  cachedContext,
+  selectedAccount,
+}: {
+  cachedContext?: ISwapSelectedTokensColdStartContext;
+  selectedAccount?: IAccountSelectorSelectedAccount;
+}) {
+  if (!isSwapColdStartAllNetworkContextNetworkId(selectedAccount?.networkId)) {
+    return false;
+  }
+
+  return (
+    !cachedContext ||
+    !isSwapColdStartAllNetworkContextNetworkId(cachedContext.networkId)
+  );
+}
+
 export function shouldClearSwapSelectedTokensOnHomeAccountUpdate({
   cachedContext,
   eventPayload,
@@ -217,6 +234,16 @@ export function shouldHandleSwapColdStartHomeAccountUpdate({
 }) {
   if (initialSelectedTokensSynced) {
     return false;
+  }
+
+  if (
+    hasSelectedTokens &&
+    shouldResetSelectedTokensForAllNetworkHome({
+      cachedContext,
+      selectedAccount: eventPayload.selectedAccount,
+    })
+  ) {
+    return true;
   }
 
   if (
@@ -474,6 +501,15 @@ export function shouldClearSwapSelectedTokensBeforeHomeAccountSync({
     return false;
   }
 
+  if (
+    shouldResetSelectedTokensForAllNetworkHome({
+      cachedContext,
+      selectedAccount: homeSelectedAccount,
+    })
+  ) {
+    return true;
+  }
+
   const isMatched =
     isSwapSelectedTokensColdStartContextMatchedWithSelectedAccount({
       cachedContext,
@@ -510,6 +546,22 @@ export function shouldSkipSwapDefaultSelectedTokenSync({
   initialSelectedTokensSynced: boolean;
 }) {
   return initialSelectedTokensSynced && !hasImportParams && hasSelectedTokens;
+}
+
+export function shouldMarkSwapInitialSelectedTokensSynced({
+  hasSelectedTokens,
+  hasSyncedSwapSelectedAccountFromHomeStorage,
+  selectedTokensColdStartContextValid,
+}: {
+  hasSelectedTokens: boolean;
+  hasSyncedSwapSelectedAccountFromHomeStorage: boolean;
+  selectedTokensColdStartContextValid: boolean | undefined;
+}) {
+  return Boolean(
+    hasSelectedTokens &&
+    hasSyncedSwapSelectedAccountFromHomeStorage &&
+    selectedTokensColdStartContextValid === true,
+  );
 }
 
 export function getSwapSelectedTokensColdStartContextNetworkId({


### PR DESCRIPTION
## Summary
- Stabilize Swap cold-start selected-token restoration across All Networks and single-network contexts.
- Prevent stale Bridge/previous-network tokens from rendering before the latest Home account selector state is synced.
- Extend unit coverage and the Swap cold-start frame checklist for the newly reproduced regressions.

## Intent & Context
This fixes a set of Swap cold-start regressions found during frame-by-frame validation. The key user-facing failures were:

- All Networks cold-start into Swap could briefly expose an empty `Select Token` state before settling on `ETH -> USDC`.
- iOS could cold-start after Home changed from Tron to Bitcoin and still render the stale Tron Swap pair when entering Trade/Swap.
- Same-account runtime network switches after Swap was already initialized should preserve the first initialized pair instead of rewriting it repeatedly.

The intended behavior is cache-first, but only when the cached selected-token context still belongs to the current Home account/network owner. All Networks should enter the normal Swap default pair (`ETH -> USDC`) without flashing `Select Token` or a stale Bridge pair.

## Root Cause
Swap cold-start bootstrap had multiple independent readers for restored selected tokens, Home account selector storage, and Swap account selector sync. During cold start, the Swap provider could initialize from a stale selected-token cache before the newest Home account selector snapshot was available. In some paths the initial-sync marker was committed too early, so later Home storage reconciliation was treated as a normal runtime network switch and preserved stale tokens that should have been cleared.

All Networks was especially fragile because stale concrete network token context, such as BTC Bridge or Tron Swap, could win before the Home snapshot-derived All Networks default pair was applied.

## Design Decisions
- Keep cache-first rendering, but validate restored selected tokens against owner metadata before treating them as usable.
- Separate first cold-start account sync from later same-account runtime network switches: before initial sync completes, stale tokens can be cleared; after initial sync, same-account network switches preserve the initialized pair.
- Bootstrap All Networks Swap from the pre-read Home snapshot default pair instead of showing empty selectors or reusing stale concrete-network Bridge tokens.
- Keep the fix scoped to Swap cold-start synchronization and tests; no unrelated route or visual behavior was changed.

## Changes Detail
- `swapColdStartTokenCacheUtils.ts`: adds cold-start owner/context helpers for Home-to-Swap sync, All Networks handling, stale token clearing, and initial-sync decisions.
- `useSwapColdStartDisplayTokens.ts`: exposes Home snapshot defaults for provider bootstrap and filters All Networks bootstrap to All Networks-only Home context.
- `useSwapGlobal.ts`, `SwapRootProvider.tsx`, `SwapProviderMirror.tsx`: apply the new initial-sync and provider bootstrap rules so stale tokens are cleared before first sync but preserved after initialization when appropriate.
- `JotaiContextStoreMirrorTracker.tsx`: supports the snapshot/read path required by cold-start provider bootstrap.
- `*.test.ts`: adds coverage for All Networks ETH/USDC defaults, stale BTC/Bridge cleanup, iOS Tron-to-Bitcoin cold start, and same-account runtime network preservation.
- `swap-cold-start-frame-checklist.md`: adds checklist cases for All Networks cold start, persisted All Networks cold start, and the Home switch race case.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Desktop, Web, Extension
- **Risk Areas**: Swap cold-start token restoration, Home account selector synchronization, All Networks default selection, same-account runtime network switching.

## Test plan
- [x] `yarn lint --fix`
- [x] `yarn jest packages/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils.test.ts packages/kit/src/views/Swap/hooks/useSwapColdStartDisplayTokens.test.ts --runInBand`
- [x] `yarn tsc --noEmit --pretty false --project packages/kit/tsconfig.json`
- [x] `git diff --check`
- [x] Desktop frame check: All Networks cold-start, enter Swap, first visible frame / 250ms / 1.5s / 5s show `ETH -> USDC`, with no `Select Token` and no stale BTC/Bridge state.
- [x] iOS frame check: cold-start to Home, open `More -> Trade`, 250ms / 1.5s / 5s show `ETH -> USDC`, with no `Select Token` and no stale BTC/Bridge state.
