### PR TITLE
fix: hide duplicate private send address(OK-56093)

### DIFF
--- a/packages/kit-bg/src/services/ServiceSignatureConfirm.privateSend.test.ts
+++ b/packages/kit-bg/src/services/ServiceSignatureConfirm.privateSend.test.ts
@@ -1,0 +1,200 @@
+import type { IUnsignedTxPro } from '@onekeyhq/core/src/types';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
+import {
+  EParseTxComponentRole,
+  EParseTxComponentType,
+  type IDisplayComponentAddress,
+} from '@onekeyhq/shared/types/signatureConfirm';
+import {
+  EProtocolOfExchange,
+  type ISwapTxInfo,
+} from '@onekeyhq/shared/types/swap/types';
+import {
+  EDecodedTxActionType,
+  EDecodedTxStatus,
+  type IDecodedTx,
+} from '@onekeyhq/shared/types/tx';
+
+import { fixPrivateSendRecipientDisplay } from './ServiceSignatureConfirm';
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundClass: () => (target: unknown) => target,
+  backgroundMethod:
+    () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+  backgroundMethodForDev:
+    () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+  toastIfError:
+    () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+}));
+
+const defaultLocal = appLocale.intl.locale;
+const defaultMessages = appLocale.intl.messages;
+
+const originalRecipient = '0xrecipient';
+const payinAddress = '0xpayin';
+
+function buildAddressComponent({
+  address,
+  label,
+  role,
+}: {
+  address: string;
+  label: string;
+  role?: EParseTxComponentRole;
+}): IDisplayComponentAddress {
+  return {
+    type: EParseTxComponentType.Address,
+    role,
+    label,
+    address,
+    tags: [],
+  };
+}
+
+function buildDecodedTx(components: IDisplayComponentAddress[]): IDecodedTx {
+  return {
+    txid: '',
+    owner: '0xsender',
+    signer: '0xsender',
+    nonce: 0,
+    actions: [
+      {
+        type: EDecodedTxActionType.ASSET_TRANSFER,
+        assetTransfer: {
+          from: '0xsender',
+          to: payinAddress,
+          sends: [
+            {
+              from: '0xsender',
+              to: payinAddress,
+              amount: '1',
+              icon: '',
+              name: 'Sui',
+              symbol: 'SUI',
+              tokenIdOnNetwork: '0x2::sui::SUI',
+              isNative: true,
+            },
+          ],
+          receives: [],
+        },
+      },
+    ],
+    status: EDecodedTxStatus.Pending,
+    networkId: 'sui--mainnet',
+    accountId: 'account-id',
+    extraInfo: null,
+    txDisplay: {
+      title: '',
+      alerts: [],
+      components,
+    },
+  };
+}
+
+function buildUnsignedTx(): IUnsignedTxPro {
+  return {
+    swapInfo: {
+      protocol: EProtocolOfExchange.PRIVATE_SEND,
+      receivingAddress: originalRecipient,
+      swapBuildResData: {
+        changellyOrder: {
+          payinAddress,
+        },
+      },
+    } as ISwapTxInfo,
+  } as IUnsignedTxPro;
+}
+
+function buildTransferPayload(): NonNullable<
+  Parameters<typeof fixPrivateSendRecipientDisplay>[0]['transferPayload']
+> {
+  return {
+    isPrivateSend: true,
+    originalRecipient,
+    privateSend: {
+      payinAddress,
+    },
+  } as NonNullable<
+    Parameters<typeof fixPrivateSendRecipientDisplay>[0]['transferPayload']
+  >;
+}
+
+describe('fixPrivateSendRecipientDisplay', () => {
+  beforeEach(() => {
+    appLocale.setLocale('en-US', {
+      [ETranslations.global_to]: 'To',
+      [ETranslations.private_send_private_send]: 'Private Send',
+      [ETranslations.swap_history_detail_received_address]: 'Received address',
+    } as Parameters<typeof appLocale.setLocale>[1]);
+  });
+
+  afterEach(() => {
+    appLocale.setLocale(defaultLocal, defaultMessages);
+  });
+
+  it('removes the payin address row when the private send receiver is already shown', () => {
+    const decodedTx = buildDecodedTx([
+      buildAddressComponent({
+        label: 'Received address',
+        address: originalRecipient,
+        role: EParseTxComponentRole.SwapReceiver,
+      }),
+      buildAddressComponent({
+        label: 'Interact with',
+        address: payinAddress,
+      }),
+    ]);
+
+    fixPrivateSendRecipientDisplay({
+      decodedTx,
+      unsignedTx: buildUnsignedTx(),
+      transferPayload: buildTransferPayload(),
+    });
+
+    const addressComponents = decodedTx.txDisplay?.components.filter(
+      (component): component is IDisplayComponentAddress =>
+        component.type === EParseTxComponentType.Address,
+    );
+
+    expect(addressComponents).toEqual([
+      expect.objectContaining({
+        role: EParseTxComponentRole.SwapReceiver,
+        address: originalRecipient,
+        label: 'Received address',
+      }),
+    ]);
+  });
+
+  it('keeps the fallback recipient display when no receiver row exists', () => {
+    const decodedTx = buildDecodedTx([
+      buildAddressComponent({
+        label: 'Interact with',
+        address: payinAddress,
+      }),
+    ]);
+
+    fixPrivateSendRecipientDisplay({
+      decodedTx,
+      unsignedTx: buildUnsignedTx(),
+      transferPayload: buildTransferPayload(),
+    });
+
+    const addressComponents = decodedTx.txDisplay?.components.filter(
+      (component): component is IDisplayComponentAddress =>
+        component.type === EParseTxComponentType.Address,
+    );
+
+    expect(addressComponents).toEqual([
+      expect.objectContaining({
+        address: originalRecipient,
+        label: 'To',
+        isNavigable: false,
+        highlight: true,
+      }),
+    ]);
+  });
+});

--- a/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
+++ b/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
@@ -23,6 +23,7 @@ import {
 } from '@onekeyhq/shared/types/signatureConfirm';
 import type {
   IAfterSendTxActionParams,
+  IDisplayComponent,
   IParseMessageParams,
   IParseMessageResp,
   IParseTransactionParams,
@@ -104,7 +105,7 @@ function getPrivateSendTxDisplayTitle() {
   });
 }
 
-function fixPrivateSendRecipientDisplay({
+export function fixPrivateSendRecipientDisplay({
   decodedTx,
   unsignedTx,
   transferPayload,
@@ -154,29 +155,55 @@ function fixPrivateSendRecipientDisplay({
     }
   });
 
-  decodedTx.txDisplay.components = decodedTx.txDisplay.components.map(
-    (component) => {
-      if (component.type !== EParseTxComponentType.Address) {
-        return component;
-      }
+  const hasReceiverAddressComponent = decodedTx.txDisplay.components.some(
+    (component) =>
+      component.type === EParseTxComponentType.Address &&
+      (component.role === EParseTxComponentRole.SwapReceiver ||
+        getAddressKey(component.address) === originalRecipientKey),
+  );
 
-      const shouldUseOriginalRecipient =
-        component.role === EParseTxComponentRole.SwapReceiver ||
-        payinAddresses.has(getAddressKey(component.address));
-      if (!shouldUseOriginalRecipient) {
-        return component;
-      }
+  const nextComponents: IDisplayComponent[] = [];
 
-      return {
+  decodedTx.txDisplay.components.forEach((component) => {
+    if (component.type !== EParseTxComponentType.Address) {
+      nextComponents.push(component);
+      return;
+    }
+
+    const isPayinAddress = payinAddresses.has(getAddressKey(component.address));
+    if (isPayinAddress && hasReceiverAddressComponent) {
+      return;
+    }
+
+    const shouldUseOriginalRecipient =
+      component.role === EParseTxComponentRole.SwapReceiver || isPayinAddress;
+    if (!shouldUseOriginalRecipient) {
+      nextComponents.push(component);
+      return;
+    }
+
+    if (component.role === EParseTxComponentRole.SwapReceiver) {
+      nextComponents.push({
         ...component,
-        label: appLocale.intl.formatMessage({ id: ETranslations.global_to }),
         address: originalRecipient,
         tags: [],
         isNavigable: false,
         highlight: true,
-      };
-    },
-  );
+      });
+      return;
+    }
+
+    nextComponents.push({
+      ...component,
+      label: appLocale.intl.formatMessage({ id: ETranslations.global_to }),
+      address: originalRecipient,
+      tags: [],
+      isNavigable: false,
+      highlight: true,
+    });
+  });
+
+  decodedTx.txDisplay.components = nextComponents;
 }
 
 @backgroundClass()

--- a/packages/shared/src/utils/txActionUtils.test.ts
+++ b/packages/shared/src/utils/txActionUtils.test.ts
@@ -1,4 +1,7 @@
+import type { IUnsignedTxPro } from '@onekeyhq/core/src/types';
+
 import {
+  EParseTxComponentRole,
   EParseTxComponentType,
   type IDisplayComponentAddress,
   type IDisplayComponentInternalAssets,
@@ -58,7 +61,10 @@ describe('txActionUtils', () => {
   beforeEach(() => {
     appLocale.setLocale('en-US', {
       [ETranslations.global_asset]: 'Asset',
+      [ETranslations.global_pay]: 'Pay',
       [ETranslations.global_to]: 'To',
+      [ETranslations.sign_swap_estimate_receive]: 'Est. receive',
+      [ETranslations.swap_history_detail_received_address]: 'Received address',
     } as Parameters<typeof appLocale.setLocale>[1]);
   });
 
@@ -110,5 +116,30 @@ describe('txActionUtils', () => {
     expect(addressComponents.map((component) => component.address)).toEqual([
       '0xrecipient1',
     ]);
+  });
+
+  it('marks internal swap receiver address components', () => {
+    const components =
+      convertDecodedTxActionsToSignatureConfirmTxDisplayComponents({
+        decodedTx: buildDecodedTx([buildTransfer('0xpayin')]),
+        unsignedTx: {
+          swapInfo: {
+            receivingAddress: '0xrecipient',
+            receiver: {
+              accountInfo: {
+                networkId: 'sui--mainnet',
+              },
+            },
+          },
+        } as unknown as IUnsignedTxPro,
+      });
+
+    const receiverComponent = components.find(
+      (component): component is IDisplayComponentAddress =>
+        component.type === EParseTxComponentType.Address &&
+        component.address === '0xrecipient',
+    );
+
+    expect(receiverComponent?.role).toBe(EParseTxComponentRole.SwapReceiver);
   });
 });

--- a/packages/shared/src/utils/txActionUtils.ts
+++ b/packages/shared/src/utils/txActionUtils.ts
@@ -18,6 +18,7 @@ import {
 } from '@onekeyhq/shared/types/tx';
 
 import {
+  EParseTxComponentRole,
   EParseTxComponentType,
   ETransferDirection,
 } from '../../types/signatureConfirm';
@@ -381,6 +382,7 @@ function convertAssetTransferActionToSignatureConfirmComponent({
   if (isInternalSwap && unsignedTx.swapInfo) {
     const receiveAddressComponent: IDisplayComponentAddress = {
       type: EParseTxComponentType.Address,
+      role: EParseTxComponentRole.SwapReceiver,
       label: appLocale.intl.formatMessage({
         id: ETranslations.swap_history_detail_received_address,
       }),


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56093](https://onekeyhq.atlassian.net/browse/OK-56093)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Mark internal swap receiver address rows explicitly so Private Send display logic can identify the final recipient.
- Hide duplicate Private Send payin-derived address rows when the final receiver address is already shown.
- Add focused tests for receiver role tagging and Private Send address display fallback.

## Intent & Context
Fixes OK-56093: the Private Send confirmation page on SUI showed the same final recipient address twice. Private Send is special because the actual on-chain transfer targets the provider payin address, while the user-facing final recipient is stored separately in `originalRecipient` / `swapInfo.receivingAddress`.

## Root Cause
The confirmation display generated both:
- a `Received address` row from `swapInfo.receivingAddress`
- a generic address row from the internal swap action target / payin address

Private Send display repair then rewrote the payin-derived row to the original recipient, making both rows show the same address.

## Design Decisions
- Keep transaction construction untouched: `transfersInfo`, `encodedTx`, `payinAddress`, and `swapInfo.receivingAddress` remain unchanged.
- Filter only the duplicated display row when a receiver row already exists.
- Preserve the old fallback behavior when no receiver row exists, so the final recipient is still shown.

## Changes Detail
- `txActionUtils.ts`: adds `SwapReceiver` role to internal swap receiver address components.
- `ServiceSignatureConfirm.ts`: filters duplicate Private Send payin-derived address rows while preserving final recipient display.
- Tests: cover receiver role tagging, duplicate payin-row removal, and fallback recipient display.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Mobile / Web / Extension
- **Risk Areas**: Private Send confirmation display only. Transaction payload, signing, broadcasting, and history persistence are not changed.

## Test plan
- [x] `yarn jest packages/shared/src/utils/txActionUtils.test.ts packages/kit-bg/src/services/ServiceSignatureConfirm.privateSend.test.ts --runInBand`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/shared/src/utils/txActionUtils.ts packages/shared/src/utils/txActionUtils.test.ts packages/kit-bg/src/services/ServiceSignatureConfirm.ts packages/kit-bg/src/services/ServiceSignatureConfirm.privateSend.test.ts --deny-warnings`
- [x] `yarn tsc:staged`
- [x] `git diff --check`

[OK-56093]: https://onekeyhq.atlassian.net/browse/OK-56093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ