### PR TITLE
fix: support fallback token logos on home popular trading(OK-56023)

### DIFF
--- a/packages/kit/src/views/Home/components/PopularTrading/MarketCategoryTokenList.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/MarketCategoryTokenList.tsx
@@ -89,6 +89,7 @@ function MarketCategoryTokenList({
                   <Token
                     size="md"
                     tokenImageUri={record.logoUrl}
+                    tokenImageUris={record.logoUrls}
                     networkId={record.chainId}
                     showNetworkIcon
                   />
@@ -154,6 +155,7 @@ function MarketCategoryTokenList({
                 <Token
                   size="lg"
                   tokenImageUri={record.logoUrl}
+                  tokenImageUris={record.logoUrls}
                   networkId={record.chainId}
                   showNetworkIcon
                 />

--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -121,6 +121,7 @@ function RecommendCardItem({
         <Token
           size="md"
           tokenImageUri={token.logoUrl}
+          tokenImageUris={token.logoUrls}
           networkId={token.chainId}
           showNetworkIcon
         />
@@ -389,6 +390,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
                 <Token
                   size="md"
                   tokenImageUri={record.logoUrl}
+                  tokenImageUris={record.logoUrls}
                   networkId={record.perpsCoin ? undefined : record.chainId}
                   showNetworkIcon={!record.perpsCoin}
                 />
@@ -450,6 +452,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
               <Token
                 size="lg"
                 tokenImageUri={record.logoUrl}
+                tokenImageUris={record.logoUrls}
                 networkId={record.perpsCoin ? undefined : record.chainId}
                 showNetworkIcon={!record.perpsCoin}
               />
@@ -599,6 +602,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
               symbol: item.symbol,
               name: item.name,
               logoUrl: item.logoUrl ?? '',
+              logoUrls: item.logoUrls,
               price: getMarketTokenDisplayPrice(item),
               priceChange24h: getMarketTokenDisplayPriceChange24h(item),
               marketCap: getMarketTokenDisplayMarketCap(item),
@@ -673,6 +677,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
               symbol: item.symbol,
               name: item.name,
               logoUrl: item.logoUrl ?? '',
+              logoUrls: item.logoUrls,
               price: getMarketTokenDisplayPrice(item),
               priceChange24h: getMarketTokenDisplayPriceChange24h(item),
               marketCap: getMarketTokenDisplayMarketCap(item),

--- a/packages/kit/src/views/Home/components/PopularTrading/types.ts
+++ b/packages/kit/src/views/Home/components/PopularTrading/types.ts
@@ -7,6 +7,7 @@ interface IFavoriteTokenDisplay {
   symbol: string;
   name: string;
   logoUrl: string;
+  logoUrls?: string[];
   price: number;
   priceChange24h: number;
   marketCap: number;

--- a/packages/kit/src/views/Home/components/PopularTrading/utils.test.ts
+++ b/packages/kit/src/views/Home/components/PopularTrading/utils.test.ts
@@ -14,6 +14,7 @@ describe('PopularTrading market token display utils', () => {
       address: '0x44f161ae29361e332dea039dfa2f404e0bc5b5cc',
       name: 'Humanity',
       symbol: 'H',
+      logoUrls: ['primary.png', 'fallback.png'],
       decimals: 18,
       price: '0.00137840543892581329',
       priceChange24hPercent: '-',
@@ -29,5 +30,6 @@ describe('PopularTrading market token display utils', () => {
     const displayToken = mapMarketTokenToDisplay(item);
     expect(displayToken?.priceChange24h).toBe(0);
     expect(Number.isNaN(displayToken?.priceChange24h)).toBe(false);
+    expect(displayToken?.logoUrls).toEqual(item.logoUrls);
   });
 });

--- a/packages/kit/src/views/Home/components/PopularTrading/utils.ts
+++ b/packages/kit/src/views/Home/components/PopularTrading/utils.ts
@@ -121,6 +121,7 @@ function mapMarketTokenToDisplay(
     symbol: item.symbol,
     name: item.name,
     logoUrl: item.logoUrl ?? '',
+    logoUrls: item.logoUrls,
     price: getMarketTokenDisplayPrice(item),
     priceChange24h: getMarketTokenDisplayPriceChange24h(item),
     marketCap: getMarketTokenDisplayMarketCap(item),


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56023](https://onekeyhq.atlassian.net/browse/OK-56023)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Adds multi-source logo fallback support to Home PopularTrading token renders.
- Carries `logoUrls` from the market token list response into the Home display model.
- Covers the mapping behavior with the existing PopularTrading unit test.

## Intent & Context
OK-56023 reports missing token icons on the Home PopularTrading market/token lists when the primary logo URL is unavailable. The market token list payload already includes `logoUrls`, so the Home surface should pass those fallback URLs to the existing Token image fallback path.

## Root Cause
Home PopularTrading mapped only `logoUrl` into `logoURI`, then rendered `Token` without `tokenImageUris`. If the primary image failed, the shared image fallback component had no alternate URLs to try.

## Design Decisions
- Keep the change scoped to Home PopularTrading rather than shared token list/base components.
- Reuse the existing `Token` `tokenImageUris` prop so fallback behavior stays centralized.
- Preserve API values in the Home display type instead of deriving fallback URLs in render code.

## Changes Detail
- Added `logoUrls` to `IFavoriteTokenDisplay`.
- Preserved `logoUrls` in `mapMarketTokenToDisplay` and spot-token mappings.
- Passed `tokenImageUris` into Home PopularTrading card, table, mobile, and category list token renders.
- Extended the PopularTrading utils test to assert fallback URLs are preserved.

## Risk Assessment
Low. This only adds optional fallback image URLs to existing Home PopularTrading renders and does not alter token selection, sorting, pricing, or shared base components.

## Test Plan
- `yarn lint:staged`
- `yarn tsc:staged`
- `npx jest packages/kit/src/views/Home/components/PopularTrading/utils.test.ts --runInBand`

[OK-56023]: https://onekeyhq.atlassian.net/browse/OK-56023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ