### PR TITLE
fix: preserve private send metadata and display (OK-54514, OK-56093)

### DIFF
--- a/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
+++ b/packages/kit-bg/src/services/ServiceSignatureConfirm.ts
@@ -23,6 +23,7 @@ import {
 } from '@onekeyhq/shared/types/signatureConfirm';
 import type {
   IAfterSendTxActionParams,
+  IDisplayComponent,
   IParseMessageParams,
   IParseMessageResp,
   IParseTransactionParams,
@@ -154,29 +155,45 @@ function fixPrivateSendRecipientDisplay({
     }
   });
 
-  decodedTx.txDisplay.components = decodedTx.txDisplay.components.map(
-    (component) => {
-      if (component.type !== EParseTxComponentType.Address) {
-        return component;
-      }
-
+  let hasOriginalRecipientDisplay = false;
+  const components: IDisplayComponent[] = [];
+  for (const component of decodedTx.txDisplay.components) {
+    if (component.type !== EParseTxComponentType.Address) {
+      components.push(component);
+    } else {
+      const addressKey = getAddressKey(component.address);
+      const isRecipientAddress =
+        component.role === EParseTxComponentRole.SwapReceiver ||
+        (component.highlight === true && addressKey === originalRecipientKey);
       const shouldUseOriginalRecipient =
         component.role === EParseTxComponentRole.SwapReceiver ||
-        payinAddresses.has(getAddressKey(component.address));
-      if (!shouldUseOriginalRecipient) {
-        return component;
-      }
+        payinAddresses.has(addressKey);
 
-      return {
-        ...component,
-        label: appLocale.intl.formatMessage({ id: ETranslations.global_to }),
-        address: originalRecipient,
-        tags: [],
-        isNavigable: false,
-        highlight: true,
-      };
-    },
-  );
+      if (!shouldUseOriginalRecipient) {
+        if (!isRecipientAddress) {
+          components.push(component);
+        } else if (!hasOriginalRecipientDisplay) {
+          hasOriginalRecipientDisplay = true;
+          components.push(component);
+        }
+      } else if (!hasOriginalRecipientDisplay) {
+        // Private Send fallback displays the recipient once, then displays the
+        // provider pay-in address. After rewriting the pay-in row it becomes a
+        // duplicate recipient row, so keep only the first recipient display.
+        hasOriginalRecipientDisplay = true;
+        components.push({
+          ...component,
+          label: appLocale.intl.formatMessage({ id: ETranslations.global_to }),
+          address: originalRecipient,
+          tags: [],
+          isNavigable: false,
+          highlight: true,
+        });
+      }
+    }
+  }
+
+  decodedTx.txDisplay.components = components;
 }
 
 @backgroundClass()

--- a/packages/kit-bg/src/vaults/impls/bfc/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/bfc/Vault.ts
@@ -393,6 +393,7 @@ export default class Vault extends VaultBase {
       }
 
       const txid = await this.backgroundApi.serviceSend.broadcastTransaction({
+        ...params,
         accountId: this.accountId,
         networkId: this.networkId,
         signedTx: params.signedTx,

--- a/packages/kit-bg/src/vaults/impls/sui/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/sui/Vault.ts
@@ -425,6 +425,7 @@ export default class Vault extends VaultBase {
       }
 
       const txid = await this.backgroundApi.serviceSend.broadcastTransaction({
+        ...params,
         accountId: this.accountId,
         networkId: this.networkId,
         signedTx: params.signedTx,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-54514](https://onekeyhq.atlassian.net/browse/OK-54514) [OK-56093](https://onekeyhq.atlassian.net/browse/OK-56093)

----------

<!-- github-pr-monitor:jira-links:end -->


## Issues
- Fixes OK-54514
- Fixes OK-56093

## Summary
- Preserve incoming broadcast params when Sui and BFC vaults forward signed transactions to the wallet send endpoint.
- De-dupe Private Send confirmation recipient rows so the provider pay-in address is not rewritten into a second visible recipient address.

## Intent & Context
Sui Private Send had two related confirmation/send issues: submit metadata could lose the `isPrivateSend` flag in Move-chain vault broadcast overrides, and the transaction confirmation page could show the same recipient address twice after Private Send display normalization.

## Root Cause
`ServiceSend.signAndSendTransaction()` passes `isPrivateSend` into `vault.broadcastTransaction()`, and `ServiceSend.broadcastTransaction()` forwards it to `/wallet/v1/account/send-transaction`. Sui and BFC override `broadcastTransaction()` and manually rebuild the params for the service call, dropping caller metadata such as `isPrivateSend`.

For OK-56093, Private Send builds a send transfer to the provider pay-in address while `swapInfo.receivingAddress` keeps the user's original recipient. The local confirmation fallback first renders the recipient row from `swapInfo.receivingAddress`, then renders the pay-in/interact address. `fixPrivateSendRecipientDisplay()` rewrote that pay-in row to the original recipient as well, producing a duplicate bottom recipient row.

## Design Decisions
- Spread the original `IBroadcastTransactionParams` before applying vault-owned overrides, preserving caller-level broadcast metadata without changing vault-specific fields.
- Fix the duplicate recipient display in `ServiceSignatureConfirm`, where the Private Send normalization happens, so every Private Send chain using this confirmation path gets the same de-dupe behavior.

## Changes Detail
- `packages/kit-bg/src/vaults/impls/sui/Vault.ts`: preserve incoming broadcast params when forwarding to `ServiceSend`.
- `packages/kit-bg/src/vaults/impls/bfc/Vault.ts`: apply the same fix for the identical Move-chain broadcast override pattern.
- `packages/kit-bg/src/services/ServiceSignatureConfirm.ts`: keep the first explicit Private Send recipient row and drop later pay-in rows that would normalize to the same recipient.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Private Send transaction broadcast metadata and confirmation-page address display

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit-bg/src/vaults/impls/sui/Vault.ts packages/kit-bg/src/vaults/impls/bfc/Vault.ts`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit-bg/src/services/ServiceSignatureConfirm.ts`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `git diff --cached --check`

[OK-54514]: https://onekeyhq.atlassian.net/browse/OK-54514
[OK-56093]: https://onekeyhq.atlassian.net/browse/OK-56093