### PR TITLE
fix: home shows Send/Swap when fiat value is 0 but tokens are held (OK-56112)

### DIFF
--- a/packages/components/src/primitives/Button/index.tsx
+++ b/packages/components/src/primitives/Button/index.tsx
@@ -104,7 +104,7 @@ const BUTTON_VARIANTS: Record<
   },
   accent: {
     color: '$textInverse',
-    iconColor: '$iconOnColor',
+    iconColor: '$iconInverse',
     bg: '$bgAccent',
     hoverBg: '$bgAccentHover',
     activeBg: '$bgAccentActive',

--- a/packages/components/src/primitives/Button/index.tsx
+++ b/packages/components/src/primitives/Button/index.tsx
@@ -103,7 +103,7 @@ const BUTTON_VARIANTS: Record<
     focusRingColor: '$focusRing',
   },
   accent: {
-    color: '$textOnColor',
+    color: '$textInverse',
     iconColor: '$iconOnColor',
     bg: '$bgAccent',
     hoverBg: '$bgAccentHover',

--- a/packages/kit/src/components/MoreActionButton/index.tsx
+++ b/packages/kit/src/components/MoreActionButton/index.tsx
@@ -1465,7 +1465,7 @@ function MoreButtonWithDot({
     if (isShowUpgradeDot) {
       return (
         <Dot
-          color="$bgAccent"
+          color="$blue8"
           top={isDesktopMode ? 0 : '$-2'}
           right={isDesktopMode ? undefined : '$-2.5'}
         />
@@ -1481,7 +1481,7 @@ function MoreButtonWithDot({
       <Stack
         width="$3"
         height="$3"
-        bg={isShowUpgradeDot ? '$bgAccent' : '$bgCriticalStrong'}
+        bg={isShowUpgradeDot ? '$iconInfo' : '$bgCriticalStrong'}
         borderRadius="$full"
         position="absolute"
         right={-4}

--- a/packages/kit/src/components/TabPageHeader/components/HeaderUpdateButton.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/HeaderUpdateButton.tsx
@@ -37,13 +37,20 @@ function BasicHeaderUpdateButton() {
   return (
     <Button
       testID="header-update-button"
-      variant="accent"
       size="small"
       // Right gap so the button doesn't sit flush against the notification
       // bell. Self-contained (rather than parent spacing) so it disappears
       // with the button when there's no update.
       mr="$3"
       onPress={onUpdateActionDirect}
+      bg="$bgInfoStrong"
+      color="$textOnColor"
+      hoverStyle={{
+        bg: '$info10',
+      }}
+      pressStyle={{
+        bg: '$info11',
+      }}
     >
       {intl.formatMessage({ id: ETranslations.update_update_now })}
     </Button>

--- a/packages/kit/src/hooks/useHomeBalanceState.ts
+++ b/packages/kit/src/hooks/useHomeBalanceState.ts
@@ -2,31 +2,61 @@ import { useMemo, useRef } from 'react';
 
 import BigNumber from 'bignumber.js';
 
+import type { IAccountToken, ITokenFiat } from '@onekeyhq/shared/types/token';
+
 import {
   buildOverviewOwnerKey,
   useAccountWorthAtom,
   useLastConfirmedOverviewBalanceAtom,
 } from '../states/jotai/contexts/accountOverview';
 import { useActiveAccount } from '../states/jotai/contexts/accountSelector';
+import {
+  useAllTokenListAtom,
+  useFlattenAggregateTokensMapAtom,
+  useSmallBalanceTokenListAtom,
+  useSmallBalanceTokenListMapAtom,
+  useTokenListAtom,
+  useTokenListMapAtom,
+} from '../states/jotai/contexts/tokenList';
 
 export type IHomeBalanceState = 'unknown' | 'zero' | 'positive';
 
-// Two sources, in order of preference:
-//   1. `byOwner[ownerKey]` — per-account confirmed snapshot, MMKV-persisted, so
+// Module-scoped so every hook instance shares one latch — WalletActions
+// remounts when a wallet's backup state flips, and a per-instance latch
+// would let the header (still latched) and a freshly mounted action row
+// disagree mid-refresh. Keyed by `${accountId}__${networkId}`.
+const fundedOwners = new Set<string>();
+
+// Three sources:
+//   1. Held tokens (risk-filtered token list) — a "funded" override, latched
+//      per owner for the session. Fiat worth is a partial sum: tokens without
+//      price data contribute nothing (custom networks hardcode fiatValue '0',
+//      long-tail tokens may have no price feed), so worth === 0 does NOT mean
+//      the wallet is empty. `zero` (the Add-money onboarding state, which
+//      also replaces Send/Swap) requires BOTH worth == 0 AND no held tokens.
+//   2. `byOwner[ownerKey]` — per-account confirmed snapshot, MMKV-persisted, so
 //      a returning session has the right answer on the first render.
-//   2. `accountWorth` (live, sum of worth values) — needed because the balance
+//   3. `accountWorth` (live, sum of worth values) — needed because the balance
 //      number on screen reads from this atom in real time, while `byOwner` is
 //      only written after the "fully ready" signal. Without this fallback, the
 //      header can show a real balance number while we still report `unknown`,
 //      hiding the action row and banner until the slow confirmation completes.
 // A `sticky` ref keeps the last non-`unknown` state for the brief moment
 // during account switches when neither source has data for the new owner yet.
+//
+// Requires the tokenList jotai context (HomeTokenListProviderMirror) in scope.
 export function useHomeBalanceState(): IHomeBalanceState {
   const {
     activeAccount: { wallet, account, network, indexedAccount },
   } = useActiveAccount({ num: 0 });
   const [{ byOwner }] = useLastConfirmedOverviewBalanceAtom();
   const [accountWorth] = useAccountWorthAtom();
+  const [tokenList] = useTokenListAtom();
+  const [smallBalanceTokenList] = useSmallBalanceTokenListAtom();
+  const [tokenListMap] = useTokenListMapAtom();
+  const [smallBalanceTokenListMap] = useSmallBalanceTokenListMapAtom();
+  const [aggregateTokensMap] = useFlattenAggregateTokensMapAtom();
+  const [allTokenList] = useAllTokenListAtom();
 
   const ownerKey = buildOverviewOwnerKey(account?.id, network?.id);
   const cached = ownerKey ? byOwner[ownerKey] : undefined;
@@ -56,14 +86,82 @@ export function useHomeBalanceState(): IHomeBalanceState {
     indexedAccount?.id,
   ]);
 
+  // Any held token (balance > 0) counts as funded, regardless of valuation.
+  // Scans the `tokenList` + `smallBalanceTokenList` buckets (which exclude
+  // risk tokens — unlike `allTokenList`, which merges the risk bucket back
+  // in, so a spam airdrop alone would read as funded) with the same
+  // balance-resolution rule as TokenListView's zero-balance filter: per-token
+  // map first, aggregate (All Networks) map as fallback. Guarded by
+  // `allTokenList`'s owner stamp: the token list atoms live in a singleton
+  // store and briefly carry the previous owner's data after an account
+  // switch, and an unguarded scan would report the old account's holdings
+  // for a freshly-switched empty one.
+  const hasHoldingsNow = useMemo<boolean>(() => {
+    if (!account?.id || !network?.id) return false;
+    if (
+      allTokenList.accountId !== account.id ||
+      allTokenList.networkId !== network.id
+    ) {
+      return false;
+    }
+    const holdsPositiveBalance = (
+      token: IAccountToken,
+      map: Record<string, ITokenFiat>,
+    ) => {
+      const balance =
+        map[token.$key]?.balance ?? aggregateTokensMap[token.$key]?.balance;
+      return !!balance && balance !== '0' && new BigNumber(balance).gt(0);
+    };
+    return (
+      tokenList.tokens.some((token) =>
+        holdsPositiveBalance(token, tokenListMap),
+      ) ||
+      smallBalanceTokenList.smallBalanceTokens.some((token) =>
+        holdsPositiveBalance(token, smallBalanceTokenListMap),
+      )
+    );
+  }, [
+    account?.id,
+    network?.id,
+    allTokenList.accountId,
+    allTokenList.networkId,
+    tokenList.tokens,
+    smallBalanceTokenList.smallBalanceTokens,
+    tokenListMap,
+    smallBalanceTokenListMap,
+    aggregateTokensMap,
+  ]);
+
+  // Session latch: once an owner is seen holding tokens, keep reporting
+  // funded for that owner. The live scan cannot be trusted to go false —
+  // every All-Networks init (owner switch, polling re-init, enabled-networks
+  // change) wipes `tokenListAtom` while stamping the current owner, and
+  // `tokenListState` reads "settled" after the FIRST per-chain response, so
+  // there is no reliable mid-session "list complete and genuinely empty"
+  // signal. Without the latch, a worth-0 wallet holding unpriced tokens
+  // would flap positive→zero→positive on every refresh, resurfacing the
+  // Add-money state (and hiding Send/Swap) for the whole multi-second init.
+  // Trade-off: a wallet genuinely emptied mid-session keeps the full action
+  // row until an app restart — mild and rare, vs. a recurring flap for the
+  // exact population this override targets.
+  const holdingsOwnerKey =
+    account?.id && network?.id ? `${account.id}__${network.id}` : undefined;
+  if (hasHoldingsNow && holdingsOwnerKey) {
+    fundedOwners.add(holdingsOwnerKey);
+  }
+  const hasHoldings =
+    hasHoldingsNow ||
+    (!!holdingsOwnerKey && fundedOwners.has(holdingsOwnerKey));
+
   const computed = useMemo<IHomeBalanceState>(() => {
     if (!wallet) return 'unknown';
+    if (hasHoldings) return 'positive';
     if (cached !== undefined) {
       return new BigNumber(cached).isZero() ? 'zero' : 'positive';
     }
     if (liveIsPositive === undefined) return 'unknown';
     return liveIsPositive ? 'positive' : 'zero';
-  }, [wallet, cached, liveIsPositive]);
+  }, [wallet, hasHoldings, cached, liveIsPositive]);
 
   // Sticky must be wallet-scoped. Without the key check, switching from a
   // funded wallet to a freshly-imported $0 wallet keeps reporting 'positive'

--- a/packages/kit/src/hooks/useHomeBalanceState.ts
+++ b/packages/kit/src/hooks/useHomeBalanceState.ts
@@ -2,6 +2,8 @@ import { useMemo, useRef } from 'react';
 
 import BigNumber from 'bignumber.js';
 
+import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
 import type { IAccountToken, ITokenFiat } from '@onekeyhq/shared/types/token';
 
 import {
@@ -26,6 +28,20 @@ export type IHomeBalanceState = 'unknown' | 'zero' | 'positive';
 // would let the header (still latched) and a freshly mounted action row
 // disagree mid-refresh. Keyed by `${accountId}__${networkId}`.
 const fundedOwners = new Set<string>();
+
+// `account.id` is deterministically derived from key material (HD:
+// `${walletId}--${path}`, imported: `imported--${coinType}--${publicKey}`), so
+// deleting a wallet and re-importing the same seed in one session reuses the
+// identical id. Without eviction, an address emptied before that re-import
+// would hit a stale "funded" latch and wrongly show Send/Swap instead of the
+// Add-money state — the opposite of this hook's intent. Clear wholesale on
+// removal (cheap; still-funded owners re-latch on their next render where the
+// live scan sees their balance). Registered once at module load; mirrors the
+// cache-eviction pattern in ServiceFreshAddress / ServiceNotification. NOT
+// cleared on WalletUpdate — that fires on renames etc. and would defeat the
+// anti-flap latch during routine refreshes.
+appEventBus.on(EAppEventBusNames.WalletRemove, () => fundedOwners.clear());
+appEventBus.on(EAppEventBusNames.AccountRemove, () => fundedOwners.clear());
 
 // Three sources:
 //   1. Held tokens (risk-filtered token list) — a "funded" override, latched

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -146,6 +146,13 @@ type ITokenSelectorFilterMode = 'wallet-token' | 'lp-dapp-token';
 type IAllNetworkTokenListResp = IFetchAccountTokensResp & {
   tokenSelectorFilterMode: ITokenSelectorFilterMode;
   syncTokenFilterToOverview: boolean;
+  // Active owner at request time. `updateAllNetworksTokenList` reprocesses
+  // the retained `allNetworksResult` whenever its identity changes — which
+  // includes owner switches, where the result still belongs to the PREVIOUS
+  // owner (usePromiseResult keeps the last resolved value). These fields let
+  // it refuse to stamp the new owner over another owner's data.
+  ownerAccountId?: string;
+  ownerNetworkId?: string;
 };
 
 type IActiveAccountTokenListRequestContext = {
@@ -830,6 +837,29 @@ function TokenListBlock({
 
   const isAllNetworkManualRefresh = useRef(false);
 
+  // Active-owner snapshot as of this instance's LAST RENDER (stale while the
+  // tab is frozen — matching the equally stale closures it is compared
+  // against, so the guard never misfires under freeze). In-flight async
+  // writers' closures capture the owner a request was issued FOR; comparing
+  // them against this ref lets post-await write paths drop stale cross-owner
+  // responses (detached history-loop refreshes, un-aborted fetches from a
+  // previous owner) instead of writing over atoms already cleared and
+  // re-stamped for the new owner.
+  const activeOwnerRef = useRef<{ accountId?: string; networkId?: string }>({});
+  activeOwnerRef.current = { accountId: account?.id, networkId: network?.id };
+
+  // Mirror of `allTokenListAtom`'s owner stamp, kept in a ref so callbacks
+  // (e.g. `handleClearAllNetworkData`) can consult it without taking the
+  // atom value — whose identity changes on every write — as a dependency.
+  const allTokenListStampRef = useRef<{
+    accountId?: string;
+    networkId?: string;
+  }>({});
+  allTokenListStampRef.current = {
+    accountId: allTokenListAtomValue.accountId,
+    networkId: allTokenListAtomValue.networkId,
+  };
+
   const updateAllNetworkData = useThrottledCallback(() => {
     refreshTokenList({
       keys: tokenListRef.current.keys,
@@ -895,6 +925,10 @@ function TokenListBlock({
         ...response,
         tokenSelectorFilterMode: 'wallet-token',
         syncTokenFilterToOverview,
+        // Closure values — this callback is recreated per owner, so these are
+        // the owner this request was issued for.
+        ownerAccountId: account?.id,
+        ownerNetworkId: network?.id,
       };
 
       const aggregateTokenConfigMapRawData =
@@ -993,7 +1027,20 @@ function TokenListBlock({
       }
       r.allTokens = allTokens;
 
-      if (!allNetworkDataInit && r.isSameAllNetworksAccountData) {
+      // The active owner may have changed during the awaits above (detached
+      // history-loop refresh, un-aborted fetch from a previous owner). Writing
+      // would land this owner's data on atoms already cleared and re-stamped
+      // for the new owner — and the next same-owner stamp write would then
+      // vouch for it.
+      const isStaleOwnerRequest = () =>
+        activeOwnerRef.current.accountId !== account?.id ||
+        activeOwnerRef.current.networkId !== network?.id;
+
+      if (
+        !allNetworkDataInit &&
+        r.isSameAllNetworksAccountData &&
+        !isStaleOwnerRequest()
+      ) {
         const accountWorth = sumTokenGroupsFiatValueIgnoringUnavailable(r);
         let createAtNetworkWorth = '0';
 
@@ -1040,6 +1087,12 @@ function TokenListBlock({
             networkId,
           })
         ).mergeDeriveAssetsEnabled;
+
+        // Re-check after the await above — the owner can switch mid-flight.
+        if (isStaleOwnerRequest()) {
+          isAllNetworkManualRefresh.current = false;
+          return r;
+        }
 
         tokenListRef.current.tokens = tokenListRef.current.tokens.concat([
           ...r.tokens.data,
@@ -1151,6 +1204,40 @@ function TokenListBlock({
   const handleClearAllNetworkData = useCallback(() => {
     const emptyTokens = getEmptyTokenData();
 
+    // Cancel the pending throttled flush and discard its accumulation —
+    // otherwise a trailing `updateAllNetworkData` fires after this clear and
+    // merges the previous owner's tokens into the freshly stamped-empty list
+    // (the owner stamp written below would then claim that data is current).
+    updateAllNetworkData.cancel();
+    tokenListRef.current.tokens = [];
+    tokenListRef.current.keys = '';
+    tokenListRef.current.map = {};
+    riskyTokenListRef.current.tokens = [];
+    riskyTokenListRef.current.keys = '';
+    riskyTokenListRef.current.map = {};
+
+    // Aggregate-token keys are owner-independent (commonSymbol-based), so a
+    // leftover map from ANOTHER owner would resolve that owner's balances for
+    // the new owner's aggregate rows until the first fresh response replaces
+    // it. Only clear on a true owner mismatch: when the stamp already matches
+    // (same-owner re-init via the useAllNetwork runner) the maps hold this
+    // owner's own values, and wiping them would only blank aggregate-row
+    // balances until the refetch lands. Note the stamp ref is a render
+    // snapshot, one commit stale at the first post-switch clear — so that
+    // first clear always sees a mismatch and clears; the failure direction
+    // is an extra clear, never a false skip.
+    if (
+      allTokenListStampRef.current.accountId !== account?.id ||
+      allTokenListStampRef.current.networkId !== network?.id
+    ) {
+      refreshAggregateTokensMap({
+        tokens: {},
+      });
+      refreshAggregateTokensListMap({
+        tokens: {},
+      });
+    }
+
     refreshSmallBalanceTokensFiatValue({
       value: '0',
     });
@@ -1192,6 +1279,8 @@ function TokenListBlock({
   }, [
     account?.id,
     network?.id,
+    refreshAggregateTokensListMap,
+    refreshAggregateTokensMap,
     refreshAllTokenList,
     refreshAllTokenListMap,
     refreshRiskyTokenList,
@@ -1201,6 +1290,7 @@ function TokenListBlock({
     refreshSmallBalanceTokensFiatValue,
     refreshTokenList,
     refreshTokenListMap,
+    updateAllNetworkData,
   ]);
 
   const handleAllNetworkRequestsFinished = useCallback(
@@ -1692,6 +1782,18 @@ function TokenListBlock({
       ) {
         return;
       }
+      // This callback's identity changes on owner switch, re-firing the
+      // consuming effect while `allNetworksResult` still holds the PREVIOUS
+      // owner's completed fan-out (usePromiseResult keeps the last resolved
+      // value). Reprocessing it would replace every token atom with that
+      // owner's data, write its worth under the new owner's accountId, and
+      // stamp `allTokenList` with the new owner — vouching for foreign data.
+      if (
+        allNetworksResult[0].ownerAccountId !== account?.id ||
+        allNetworksResult[0].ownerNetworkId !== network?.id
+      ) {
+        return;
+      }
       const shouldSyncTokenFilterToOverview =
         allNetworksResult[0].syncTokenFilterToOverview;
 
@@ -2128,11 +2230,12 @@ function TokenListBlock({
     refreshAllTokenListMap({ tokens: cached.tokenListMap });
     // Restore the aggregate-token source map so cached aggregate tokens
     // render against their own balances/prices instead of the previous
-    // owner's map. Older entries without it leave the atom alone — the
-    // async fetch below will refill it.
-    if (cached.aggregateTokensMap) {
-      refreshAggregateTokensMap({ tokens: cached.aggregateTokensMap });
-    }
+    // owner's map. Legacy entries persisted without it must CLEAR the atom
+    // rather than leave it alone: aggregate keys are owner-independent
+    // (commonSymbol-based), so the previous owner's balances would otherwise
+    // resolve under the fresh owner stamp written above until the async
+    // fetch refills the map.
+    refreshAggregateTokensMap({ tokens: cached.aggregateTokensMap ?? {} });
     // The cache only stores the high-value `tokens` and `tokenListMap`.
     // Reset small-balance and risky atoms here so the footer counts/value
     // and risky list don't briefly mirror the previous owner until the

--- a/packages/kit/src/views/Home/pages/HomeHeaderContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeHeaderContainer.tsx
@@ -88,49 +88,59 @@ function BaseHomeHeaderContainer() {
   }, [wallet?.id, wallet?.type, isWalletNotBackedUp, homeBalanceState]);
 
   return (
-    <HomeTokenListProviderMirror>
-      <YStack
-        pb="$8"
+    <YStack
+      pb="$8"
+      gap="$5"
+      minHeight={nativeMinHeight}
+      $gtMd={{ gap: '$8' }}
+      bg="$bgApp"
+      pointerEvents="box-none"
+    >
+      <Stack
+        testID={HomeTestIDs.headerContainer}
         gap="$5"
-        minHeight={nativeMinHeight}
-        $gtMd={{ gap: '$8' }}
+        pt="$5"
+        $gtMd={{
+          pt: '$8',
+        }}
+        px="$pagePadding"
         bg="$bgApp"
         pointerEvents="box-none"
       >
-        <Stack
-          testID={HomeTestIDs.headerContainer}
-          gap="$5"
-          pt="$5"
-          $gtMd={{
-            pt: '$8',
-          }}
-          px="$pagePadding"
-          bg="$bgApp"
-          pointerEvents="box-none"
-        >
+        <HeaderScrollGestureWrapper onRefresh={onHomePageRefresh}>
+          <Stack gap="$2.5">
+            <HomeOverviewContainer />
+          </Stack>
+        </HeaderScrollGestureWrapper>
+        {isWalletNotBackedUp ? null : (
           <HeaderScrollGestureWrapper onRefresh={onHomePageRefresh}>
-            <Stack gap="$2.5">
-              <HomeOverviewContainer />
-            </Stack>
+            <WalletActions />
           </HeaderScrollGestureWrapper>
-          {isWalletNotBackedUp ? null : (
-            <HeaderScrollGestureWrapper onRefresh={onHomePageRefresh}>
-              <WalletActions />
-            </HeaderScrollGestureWrapper>
-          )}
-        </Stack>
-        {/* Always mount so initLocalBanners + remote fetch effects run.
-            Without this, gating on `shouldShowBanner` (which requires
-            banners.length > 0) creates a deadlock — banner data is only
-            written to the atom from WalletBanner's own useEffect, so the
-            atom would stay empty and the banner would never appear after
-            a fresh install + first import. The visual hide on
-            zero-balance / not-backed-up still works via the `hidden`
-            prop. */}
-        <WalletBanner hidden={!shouldShowBanner} />
-      </YStack>
-    </HomeTokenListProviderMirror>
+        )}
+      </Stack>
+      {/* Always mount so initLocalBanners + remote fetch effects run.
+          Without this, gating on `shouldShowBanner` (which requires
+          banners.length > 0) creates a deadlock — banner data is only
+          written to the atom from WalletBanner's own useEffect, so the
+          atom would stay empty and the banner would never appear after
+          a fresh install + first import. The visual hide on
+          zero-balance / not-backed-up still works via the `hidden`
+          prop. */}
+      <WalletBanner hidden={!shouldShowBanner} />
+    </YStack>
   );
 }
 
-export const HomeHeaderContainer = memo(BaseHomeHeaderContainer);
+// The provider mirror must wrap the component (not live inside its return):
+// `useHomeBalanceState` reads tokenList context atoms, so the hook call in
+// `BaseHomeHeaderContainer`'s body has to sit inside the provider.
+// Note: on the URL-account page (which reuses HomePageView) the token list is
+// written to the separate urlAccountHomeTokenList store, not this mirror's
+// homeTokenList store — the hook's owner-stamp guard absorbs the mismatch and
+// the holdings override simply stays inactive there (worth-only behavior).
+export const HomeHeaderContainer = memo(() => (
+  <HomeTokenListProviderMirror>
+    <BaseHomeHeaderContainer />
+  </HomeTokenListProviderMirror>
+));
+HomeHeaderContainer.displayName = 'HomeHeaderContainer';


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56112](https://onekeyhq.atlassian.net/browse/OK-56112)

----------

<!-- github-pr-monitor:jira-links:end -->


## OK-56112

**Bug:** wallet - when an account's fiat worth is 0 but it actually holds tokens, the home page showed the "Add money to get started" zero state and hid Send/Swap.

### Root cause
Home worth is a **partial sum**: tokens with no price contribute 0 (custom networks hardcode `fiatValue: '0'`, long-tail tokens have no price feed, NFTs aren't counted). So `worth === 0` does **not** mean the wallet is empty — but the zero state keyed only on worth.

### Fix
`useHomeBalanceState` now requires **both worth == 0 AND no held tokens** to report `zero`. Any held token (balance > 0) → `positive`, regardless of valuation.

- Scans the `tokenList` + `smallBalanceTokenList` buckets (which exclude risk tokens — `allTokenList` merges spam airdrops back in), resolving balances with the same rule as TokenListView's zero-balance filter (`tokenListMap[$key] ?? flattenAggregateTokensMap[$key]`).
- **Owner-stamp guard:** the token-list atoms live in a singleton store and briefly carry the previous owner's data after an account switch; the scan only trusts data when `allTokenList`'s `accountId/networkId` stamp matches the active account.
- **Per-owner session latch** (module-scoped): All-Networks init wipes `tokenListAtom` on every refresh while re-stamping the current owner, so a naive scan would flap `positive→zero→positive` (resurfacing Add money / hiding Send/Swap for the whole multi-second init). Once an owner is seen holding tokens, it stays funded for the session.

### Supporting changes in `TokenListBlock`
Hardening the owner correctness the latch depends on:
- Responses carry the request-time owner; `updateAllNetworksTokenList` refuses to reprocess a retained result belonging to a previous owner (this previously wrote owner A's worth under owner B's accountId — a real cross-owner bug).
- In-flight responses re-check the active owner after their awaits and drop stale cross-owner writes.
- `handleClearAllNetworkData` cancels the pending throttled flush, discards its accumulation, and clears the owner-independent aggregate maps only on a true owner mismatch (so same-owner re-inits don't blank aggregate balances).

`HomeHeaderContainer` hoists `HomeTokenListProviderMirror` to wrap the component so the hook's token-list reads sit inside the provider.

### Also included
- `fix: recolor toolbox update indicators and header update button to blue` — reverts the update dot/badge and header update button from brand green back to blue (follow-up to the OK-55006 update-prompt work).

### Validation
- root `tsc --noEmit`: 0 errors
- eslint clean on changed files
- adjacent unit tests pass (41/41)
- Three rounds of adversarial multi-agent review; fixed 1 critical + 2 major cross-owner data issues surfaced during review.

### Known accepted edges
- URL-account page: override stays inactive (separate token-list store); degrades to prior worth-only behavior.
- Pure-NFT wallets still show Add money (NFTs aren't counted as holdings).

[OK-56112]: https://onekeyhq.atlassian.net/browse/OK-56112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ