### PR TITLE
fix: show community badge in home market tokens

### DIFF
--- a/packages/kit/src/views/Home/components/PopularTrading/MarketCategoryTokenList.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/MarketCategoryTokenList.tsx
@@ -22,6 +22,7 @@ import { RichTable } from '../RichTable';
 import { HOME_MARKET_CATEGORY_REQUEST_LIMIT } from './constants';
 import {
   getPopularTradingMetricColumns,
+  renderPopularTradingCommunityBadge,
   renderPopularTradingRightMetrics,
   renderPopularTradingStockBadges,
   renderPopularTradingTokenSubtitle,
@@ -104,6 +105,7 @@ function MarketCategoryTokenList({
                         {record.symbol}
                       </SizableText>
                       {renderPopularTradingStockBadges(record)}
+                      {renderPopularTradingCommunityBadge(record)}
                     </XStack>
                     <SizableText
                       size="$bodyMd"
@@ -170,6 +172,7 @@ function MarketCategoryTokenList({
                       {record.symbol}
                     </SizableText>
                     {renderPopularTradingStockBadges(record)}
+                    {renderPopularTradingCommunityBadge(record)}
                   </XStack>
                   {renderPopularTradingTokenSubtitle(record)}
                 </YStack>

--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -62,6 +62,7 @@ import {
 import { MarketCategoryTokenList } from './MarketCategoryTokenList';
 import {
   getPopularTradingMetricColumns,
+  renderPopularTradingCommunityBadge,
   renderPopularTradingRightMetrics,
   renderPopularTradingStockBadges,
   renderPopularTradingTokenSubtitle,
@@ -148,6 +149,7 @@ function RecommendCardItem({
               {token.symbol}
             </SizableText>
             {renderPopularTradingStockBadges(token)}
+            {renderPopularTradingCommunityBadge(token)}
           </XStack>
           <XStack>
             <SizableText
@@ -408,6 +410,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
                       <LeverageBadge leverage={record.maxLeverage} />
                     ) : null}
                     {renderPopularTradingStockBadges(record)}
+                    {renderPopularTradingCommunityBadge(record)}
                   </XStack>
                   <SizableText
                     size="$bodyMd"
@@ -470,6 +473,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
                     <LeverageBadge leverage={record.maxLeverage} />
                   ) : null}
                   {renderPopularTradingStockBadges(record)}
+                  {renderPopularTradingCommunityBadge(record)}
                 </XStack>
                 {renderPopularTradingTokenSubtitle(record)}
               </YStack>
@@ -607,6 +611,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
               priceChange24h: getMarketTokenDisplayPriceChange24h(item),
               marketCap: getMarketTokenDisplayMarketCap(item),
               volume24h: getMarketTokenDisplayVolume24h(item),
+              communityRecognized: item.communityRecognized,
               stock: item.stock,
             };
           })
@@ -682,6 +687,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
               priceChange24h: getMarketTokenDisplayPriceChange24h(item),
               marketCap: getMarketTokenDisplayMarketCap(item),
               volume24h: getMarketTokenDisplayVolume24h(item),
+              communityRecognized: item.communityRecognized,
               stock: item.stock,
             };
           })

--- a/packages/kit/src/views/Home/components/PopularTrading/metricColumns.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/metricColumns.tsx
@@ -1,5 +1,6 @@
 import { NumberSizeableText, SizableText, YStack } from '@onekeyhq/components';
 import type { ITableProps } from '@onekeyhq/components';
+import { CommunityRecognizedBadge } from '@onekeyhq/kit/src/views/Market/components/CommunityRecognizedBadge';
 import {
   StockSourceLogo,
   SubtitleBadge,
@@ -164,6 +165,10 @@ function renderPopularTradingStockBadges(record: IFavoriteTokenDisplay) {
   );
 }
 
+function renderPopularTradingCommunityBadge(record: IFavoriteTokenDisplay) {
+  return record.communityRecognized ? <CommunityRecognizedBadge /> : null;
+}
+
 function renderPopularTradingRightMetrics(
   record: IFavoriteTokenDisplay,
   useStockMetadataColumns: boolean,
@@ -215,6 +220,7 @@ function renderPopularTradingRightMetrics(
 
 export {
   getPopularTradingMetricColumns,
+  renderPopularTradingCommunityBadge,
   renderPopularTradingRightMetrics,
   renderPopularTradingStockBadges,
   renderPopularTradingTokenSubtitle,

--- a/packages/kit/src/views/Home/components/PopularTrading/types.ts
+++ b/packages/kit/src/views/Home/components/PopularTrading/types.ts
@@ -14,6 +14,7 @@ interface IFavoriteTokenDisplay {
   volume24h: number;
   perpsCoin?: string;
   maxLeverage?: number;
+  communityRecognized?: boolean;
   stock?: IMarketStockInfo;
 }
 

--- a/packages/kit/src/views/Home/components/PopularTrading/utils.test.ts
+++ b/packages/kit/src/views/Home/components/PopularTrading/utils.test.ts
@@ -19,6 +19,7 @@ describe('PopularTrading market token display utils', () => {
       price: '0.00137840543892581329',
       priceChange24hPercent: '-',
       volume24h: '-',
+      communityRecognized: true,
     };
 
     expect(getMarketTokenDisplayPrice(item)).toBe(
@@ -31,5 +32,6 @@ describe('PopularTrading market token display utils', () => {
     expect(displayToken?.priceChange24h).toBe(0);
     expect(Number.isNaN(displayToken?.priceChange24h)).toBe(false);
     expect(displayToken?.logoUrls).toEqual(item.logoUrls);
+    expect(displayToken?.communityRecognized).toBe(true);
   });
 });

--- a/packages/kit/src/views/Home/components/PopularTrading/utils.ts
+++ b/packages/kit/src/views/Home/components/PopularTrading/utils.ts
@@ -126,6 +126,7 @@ function mapMarketTokenToDisplay(
     priceChange24h: getMarketTokenDisplayPriceChange24h(item),
     marketCap: getMarketTokenDisplayMarketCap(item),
     volume24h: getMarketTokenDisplayVolume24h(item),
+    communityRecognized: item.communityRecognized,
     stock: item.stock,
   };
 }


### PR DESCRIPTION
## Summary
- Preserve the market `communityRecognized` flag in Home Popular Trading display tokens.
- Render the existing community recognized badge beside token symbols in Home favorites, recommended-token cards, and market category/trending lists.
- Add test coverage so the display mapper keeps the community flag.

## Intent & Context
The page feedback on `/` pointed at the Home market table and requested that token items show the community recommendation icon the same way Market Home does. The follow-up clarified that both favorites and trending/category lists need the badge.

## Root Cause
Home Popular Trading does not reuse the Market Home token identity row. It builds its own token cells, and its local `IFavoriteTokenDisplay` model dropped `communityRecognized` while mapping Market API responses and watchlist batch results. Because the flag was not preserved, the row renderers had no signal to show the icon.

## Design Decisions
- Reused the existing `CommunityRecognizedBadge` component to keep icon behavior and tooltip/popover behavior consistent with Market Home.
- Added a small renderer helper in the existing Popular Trading metric module so favorites, recommended cards, and category lists share the same badge rendering.
- Kept the change scoped to Home Popular Trading and did not refactor the token row into Market Home components, avoiding a broader UI/layout change.

## Changes Detail
- `types.ts`: added optional `communityRecognized` to the Home token display model.
- `utils.ts`: preserved `communityRecognized` from `IMarketTokenListItem` in `mapMarketTokenToDisplay`.
- `PopularTrading.tsx`: passed batch-result community flags into favorite/recommended display tokens and rendered the badge in favorites and recommended cards.
- `MarketCategoryTokenList.tsx`: rendered the badge in market category/trending list rows.
- `metricColumns.tsx`: added a shared Popular Trading community badge renderer.
- `utils.test.ts`: verified the mapper keeps the community flag.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web / Extension / Mobile
- **Risk Areas**: Home Popular Trading token row layout spacing around symbol badges. Data flow is read-only and uses an existing optional API field.

## Test plan
- [x] `yarn lint --fix`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `yarn tsc:only`
- [x] `npx jest packages/kit/src/views/Home/components/PopularTrading/utils.test.ts`
- [ ] Verify on Home that favorites and trending/category token rows show the community recognized badge when `communityRecognized` is true