### PR TITLE
fix: swap amount shortcuts and kline price fallback (OK-56125, OK-56109)

### DIFF
--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
@@ -590,6 +590,7 @@ const ManagePositionPart = ({
   tokenImageUri,
   accountId,
   indexedAccountId,
+  suppressPlatformBonus,
   onCreateAddress,
   onStakeWithdrawSuccess,
 }: {
@@ -600,6 +601,7 @@ const ManagePositionPart = ({
   tokenImageUri?: string;
   accountId: string;
   indexedAccountId?: string;
+  suppressPlatformBonus?: boolean;
   onCreateAddress?: () => Promise<void>;
   onStakeWithdrawSuccess?: () => void;
 }) => {
@@ -615,6 +617,7 @@ const ManagePositionPart = ({
           accountId={accountId}
           indexedAccountId={indexedAccountId}
           fallbackTokenImageUri={tokenImageUri}
+          suppressPlatformBonus={suppressPlatformBonus}
           onCreateAddress={onCreateAddress}
           onStakeWithdrawSuccess={onStakeWithdrawSuccess}
         />
@@ -884,6 +887,7 @@ const EarnProtocolDetailsPage = ({ route }: { route: IRouteProps }) => {
               tokenImageUri={tokenInfo?.token?.logoURI}
               accountId={accountId}
               indexedAccountId={indexedAccountId}
+              suppressPlatformBonus={Boolean(detailInfo?.platformBonus)}
               onCreateAddress={onCreateAddress}
               onStakeWithdrawSuccess={handleStakeWithdrawSuccess}
             />

--- a/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
@@ -373,6 +373,7 @@ type IUniversalStakeProps = {
   beforeFooter?: ReactElement | null;
   protocolSwitchConfig?: IManagePositionProtocolSwitchConfig;
   showApyDetail?: boolean;
+  suppressPlatformBonus?: boolean;
   isInModalContext?: boolean;
   ongoingValidator?: IEarnSelectField;
   receiveInputConfig?: IManagePageV2ReceiveInputConfig;
@@ -414,6 +415,7 @@ export function UniversalStake({
   beforeFooter,
   protocolSwitchConfig,
   showApyDetail = false,
+  suppressPlatformBonus = false,
   isInModalContext = false,
   ongoingValidator,
   receiveInputConfig,
@@ -1997,13 +1999,14 @@ export function UniversalStake({
     />
   );
 
-  const shouldShowPlatformBonus = Boolean(
-    transactionConfirmation?.platformBonus,
-  );
+  const platformBonus = suppressPlatformBonus
+    ? undefined
+    : transactionConfirmation?.platformBonus;
+  const shouldShowPlatformBonus = Boolean(platformBonus);
 
-  const platformBonusContent = transactionConfirmation?.platformBonus ? (
+  const platformBonusContent = platformBonus ? (
     <EarnPlatformBonusSection
-      platformBonus={transactionConfirmation.platformBonus}
+      platformBonus={platformBonus}
       protocolInfo={protocolInfo}
       tokenInfo={tokenInfo}
       footer={tradeOrBuyContent}

--- a/packages/kit/src/views/Staking/pages/ManagePosition/components/ManagePositionContent.tsx
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/components/ManagePositionContent.tsx
@@ -59,6 +59,7 @@ export interface IManagePositionContentProps {
   fallbackTokenImageUri?: string;
   providerLogoUri?: string;
   stakeProtocolSwitchConfig?: IManagePositionProtocolSwitchConfig;
+  suppressPlatformBonus?: boolean;
 
   // Optional callbacks
   onCreateAddress?: () => Promise<void>;
@@ -122,6 +123,7 @@ export function ManagePositionContent({
   fallbackTokenImageUri,
   providerLogoUri,
   stakeProtocolSwitchConfig,
+  suppressPlatformBonus,
   onCreateAddress,
   onStakeWithdrawSuccess,
   isInModalContext = false,
@@ -549,6 +551,7 @@ export function ManagePositionContent({
       appNavigation={appNavigation}
       showApyDetail={showApyDetail}
       stakeProtocolSwitchConfig={stakeProtocolSwitchConfig}
+      suppressPlatformBonus={suppressPlatformBonus}
       ongoingValidator={ongoingValidator}
       managePageData={managePageData}
     />

--- a/packages/kit/src/views/Staking/pages/ManagePosition/components/NormalManageContent.tsx
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/components/NormalManageContent.tsx
@@ -68,6 +68,7 @@ interface INormalManageContentProps {
   showApyDetail?: boolean;
   fallbackTokenImageUri?: string;
   stakeProtocolSwitchConfig?: IManagePositionProtocolSwitchConfig;
+  suppressPlatformBonus?: boolean;
   ongoingValidator?: IEarnSelectField;
   managePageData?: IEarnManagePageResponse;
   type?: EManagePositionType;
@@ -102,6 +103,7 @@ export function NormalManageContent({
   showApyDetail,
   fallbackTokenImageUri,
   stakeProtocolSwitchConfig,
+  suppressPlatformBonus,
   ongoingValidator,
   managePageData,
   type = EManagePositionType.Staking,
@@ -716,6 +718,7 @@ export function NormalManageContent({
           onSuccess={onSuccess}
           beforeFooter={stakeBeforeFooter}
           showApyDetail={showApyDetail}
+          suppressPlatformBonus={suppressPlatformBonus}
           isInModalContext={isInModalContext}
           fallbackTokenImageUri={fallbackTokenImageUri}
           protocolSwitchConfig={stakeProtocolSwitchConfig}

--- a/packages/kit/src/views/Staking/pages/ManagePosition/components/StakeSection.tsx
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/components/StakeSection.tsx
@@ -58,6 +58,7 @@ export const StakeSection = ({
   onSuccess,
   beforeFooter,
   showApyDetail,
+  suppressPlatformBonus,
   isInModalContext,
   fallbackTokenImageUri,
   protocolSwitchConfig,
@@ -82,6 +83,7 @@ export const StakeSection = ({
   onSuccess?: () => void;
   beforeFooter?: ReactElement | null;
   showApyDetail?: boolean;
+  suppressPlatformBonus?: boolean;
   isInModalContext?: boolean;
   fallbackTokenImageUri?: string;
   protocolSwitchConfig?: IManagePositionProtocolSwitchConfig;
@@ -755,6 +757,7 @@ export const StakeSection = ({
           }
           beforeFooter={beforeFooter}
           showApyDetail={showApyDetail}
+          suppressPlatformBonus={suppressPlatformBonus}
           isInModalContext={isInModalContext}
           protocolSwitchConfig={protocolSwitchConfig}
           ongoingValidator={ongoingValidator}

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -72,6 +72,7 @@ import {
 } from '@onekeyhq/shared/src/routes/swap';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import { equalsIgnoreCase } from '@onekeyhq/shared/src/utils/stringUtils';
 import {
   checkWrappedTokenPair,
   equalTokenNoCaseSensitive,
@@ -126,6 +127,7 @@ import {
 } from '../../hooks/useSwapState';
 import { SwapTestIDs } from '../../testIDs';
 import { buildSwapReviewState } from '../../utils/buildSwapReviewState';
+import { getSwapSafeInputBalanceAmount } from '../../utils/swapBalanceUtils';
 import { buildSwapRateDifference } from '../../utils/swapRateDifferenceUtils';
 import { SwapProviderMirror } from '../SwapProviderMirror';
 
@@ -369,6 +371,38 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     }
     return swapFromTokenBalance;
   }, [focusSwapPro, swapFromTokenBalance, swapProFromToken?.balanceParsed]);
+  const fromSelectTokenAccountAddress = useMemo(() => {
+    if (!fromSelectToken || !('accountAddress' in fromSelectToken)) {
+      return undefined;
+    }
+    return fromSelectToken.accountAddress;
+  }, [fromSelectToken]);
+  const fallbackFromTokenBalance = useMemo(() => {
+    if (
+      !fromSelectToken?.balanceParsed ||
+      !fromSelectTokenAccountAddress ||
+      !swapFromAddressInfo.address ||
+      !equalsIgnoreCase(
+        fromSelectTokenAccountAddress,
+        swapFromAddressInfo.address,
+      )
+    ) {
+      return undefined;
+    }
+    return fromSelectToken.balanceParsed;
+  }, [
+    fromSelectTokenAccountAddress,
+    fromSelectToken?.balanceParsed,
+    swapFromAddressInfo.address,
+  ]);
+  const safeFromTokenBalanceAmount = useMemo(
+    () =>
+      getSwapSafeInputBalanceAmount({
+        balance: fromTokenBalance,
+        fallbackBalance: fallbackFromTokenBalance,
+      }),
+    [fallbackFromTokenBalance, fromTokenBalance],
+  );
   const [swapNativeTokenReserveGas] = useSwapNativeTokenReserveGasAtom();
   const swapSlippageRef = useRef(slippageItem);
   if (swapSlippageRef.current !== slippageItem) {
@@ -545,15 +579,23 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   }, [fromSelectToken?.symbol]);
 
   const checkNativeTokenGasToast = useCallback(() => {
-    let maxAmount = new BigNumber(fromTokenBalance ?? 0);
+    let maxAmount = safeFromTokenBalanceAmount;
+    if (!maxAmount) {
+      return undefined;
+    }
     if (fromSelectToken?.isNative) {
       const reserveGas = swapNativeTokenReserveGas.find(
         (item) => item.networkId === fromSelectToken.networkId,
       )?.reserveGas;
-      if (reserveGas) {
+      const reserveGasBN = new BigNumber(reserveGas ?? '');
+      if (
+        reserveGasBN.isFinite() &&
+        !reserveGasBN.isNaN() &&
+        reserveGasBN.gt(0)
+      ) {
         maxAmount = BigNumber.max(
           0,
-          maxAmount.minus(new BigNumber(reserveGas)),
+          maxAmount.minus(reserveGasBN),
         ).decimalPlaces(
           Number(fromSelectToken?.decimals ?? 6),
           BigNumber.ROUND_DOWN,
@@ -582,7 +624,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     }
     return maxAmount;
   }, [
-    fromTokenBalance,
+    safeFromTokenBalanceAmount,
     fromSelectToken?.isNative,
     fromSelectToken?.networkId,
     fromSelectToken?.decimals,
@@ -593,17 +635,25 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
 
   const onBalanceMaxPress = useCallback(() => {
     const maxAmount = checkNativeTokenGasToast();
+    if (!maxAmount || maxAmount.isNaN() || !maxAmount.isFinite()) {
+      return;
+    }
+    const maxAmountValue = maxAmount.toFixed();
+    if (!validateAmountInput(maxAmountValue, fromSelectToken?.decimals)) {
+      return;
+    }
     if (focusSwapPro && swapProTradeType === ESwapProTradeType.MARKET) {
-      setSwapProInputAmount(maxAmount?.toFixed() ?? '');
+      setSwapProInputAmount(maxAmountValue);
     } else {
       setFromInputAmount({
-        value: maxAmount?.toFixed() ?? '',
+        value: maxAmountValue,
         isInput: true,
       });
     }
   }, [
     checkNativeTokenGasToast,
     focusSwapPro,
+    fromSelectToken?.decimals,
     setFromInputAmount,
     setSwapProInputAmount,
     swapProTradeType,
@@ -611,8 +661,14 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
 
   const onSelectPercentageStage = useCallback(
     (stage: number) => {
-      const fromTokenBalanceBN = new BigNumber(fromTokenBalance ?? 0);
-      const amountBN = fromTokenBalanceBN.multipliedBy(stage / 100);
+      if (stage === 100) {
+        onBalanceMaxPress();
+        return;
+      }
+      if (!safeFromTokenBalanceAmount) {
+        return;
+      }
+      const amountBN = safeFromTokenBalanceAmount.multipliedBy(stage / 100);
       const amountAfterDecimal = amountBN.decimalPlaces(
         Number(fromSelectToken?.decimals ?? 6),
         BigNumber.ROUND_DOWN,
@@ -624,10 +680,6 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
           fromSelectToken?.decimals,
         )
       ) {
-        if (stage === 100) {
-          onBalanceMaxPress();
-          return;
-        }
         if (focusSwapPro && swapProTradeType === ESwapProTradeType.MARKET) {
           setSwapProInputAmount(amountAfterDecimal.toFixed());
         } else {
@@ -639,7 +691,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
       }
     },
     [
-      fromTokenBalance,
+      safeFromTokenBalanceAmount,
       fromSelectToken?.decimals,
       focusSwapPro,
       swapProTradeType,

--- a/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
@@ -672,13 +672,17 @@ function SwapKLineHeaderRight({
 function SwapKLineTokenPriceInfo({
   tokenMarketDetail,
   walletMarketInfo,
+  fallbackPrice,
   compact,
 }: {
   tokenMarketDetail?: IMarketTokenDetail;
   walletMarketInfo?: ISwapKLineWalletMarketInfo;
+  fallbackPrice?: string;
   compact?: boolean;
 }) {
-  const price = getNormalizedPrice(tokenMarketDetail?.price);
+  const price =
+    getNormalizedPrice(tokenMarketDetail?.price) ??
+    getNormalizedPrice(fallbackPrice);
   const priceChange =
     getNormalizedPercent(tokenMarketDetail?.priceChange24hPercent) ??
     walletMarketInfo?.priceChange24hPercent;
@@ -787,6 +791,7 @@ function SwapKLineTokenInfoRow({
         <SwapKLineTokenPriceInfo
           tokenMarketDetail={tokenMarketDetail}
           walletMarketInfo={walletMarketInfo}
+          fallbackPrice={token.price}
           compact={compact}
         />
       </XStack>

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -28,6 +28,35 @@ export type ISwapLatestBalanceCheckResult =
       tokenSymbol: string;
     };
 
+function toFiniteNonNegativeBigNumber(value?: string) {
+  const valueBN = new BigNumber(value ?? '');
+  if (valueBN.isNaN() || !valueBN.isFinite() || valueBN.lt(0)) {
+    return undefined;
+  }
+  return valueBN;
+}
+
+export function getSwapSafeInputBalanceAmount({
+  balance,
+  fallbackBalance,
+  fallbackBalanceMatchesAccount = true,
+}: {
+  balance?: string;
+  fallbackBalance?: string;
+  fallbackBalanceMatchesAccount?: boolean;
+}) {
+  const balanceBN = toFiniteNonNegativeBigNumber(balance);
+  if (balanceBN) {
+    return balanceBN;
+  }
+
+  if (!fallbackBalanceMatchesAccount) {
+    return undefined;
+  }
+
+  return toFiniteNonNegativeBigNumber(fallbackBalance);
+}
+
 async function getSwapTokenBalanceContractAddress(token: ISwapToken) {
   if (!token.isNative || token.contractAddress) {
     return token.contractAddress ?? '';


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56125](https://onekeyhq.atlassian.net/browse/OK-56125) [OK-56109](https://onekeyhq.atlassian.net/browse/OK-56109)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Prevent Swap max/percentage amount flows from producing invalid `NaN` amounts when the live balance is unavailable or malformed.
- Hide duplicate Earn platform bonus content when the protocol detail page already renders the bonus.
- Add a Swap K-line price fallback so tokens like HYPE can show the swap token price when market detail lookup is unavailable.

## Intent & Context
This branch fixes several UI/data edge cases in the current Swap and Earn flows. The latest request investigated OK-56109, where HYPE and similar Hyperliquid native tokens did not show a price in the Swap K-line header even though Swap token search returned a valid price. The branch also contains the earlier OK-56125 Earn bonus duplication fix and a Swap max amount guard.

## Root Cause
- Swap K-line header only read `tokenMarketDetail.price`. For Hyperliquid native tokens with an empty contract address, the market detail endpoint can fail to resolve the token, while the Swap token payload already includes `price`.
- Swap max/percentage paths constructed `BigNumber` values from potentially empty, invalid, or stale balance strings, which could propagate `NaN` into the input amount.
- Earn protocol details could render a platform bonus at the page level and again inside the staking transaction confirmation flow.

## Design Decisions
- Keep backend/provider contracts unchanged and add a UI-only fallback from `selectedToken.price` for the K-line header price.
- Do not infer or synthesize 24h price change when market detail is unavailable; the existing detail/wallet fallback remains unchanged.
- Normalize Swap input balances through a shared helper that only returns finite non-negative values, and only uses selected-token fallback balance when it matches the active account address.
- Add an explicit `suppressPlatformBonus` prop through the Earn staking component chain so the detail page can opt out of duplicate nested bonus rendering.

## Changes Detail
- `SwapMainLand.tsx`: uses safe balance normalization, validates native reserve gas, prevents invalid max values, and routes 100% percentage selection through the same max path.
- `swapBalanceUtils.ts`: adds `getSwapSafeInputBalanceAmount` for finite non-negative balance parsing and guarded fallback balance usage.
- `EarnProtocolDetails` / `UniversalStake` / manage-position components: propagate `suppressPlatformBonus` to avoid duplicate platform bonus sections.
- `SwapKLineContent.tsx`: falls back from market detail price to the selected swap token price.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Mobile / Extension / Web surfaces that render Swap or Earn flows
- **Risk Areas**: Swap max amount calculation, native-token reserve gas handling, Earn platform bonus visibility, and Swap K-line token header display

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx --deny-warnings`
- [x] `yarn prettier --check packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx`
- [x] `yarn tsc:only`
- [ ] Verify HYPE on Hyperliquid in the Swap K-line modal shows the fallback price.
- [ ] Verify Swap max and 25/50/75/100% amount shortcuts with normal, unavailable, and native-token balances.
- [ ] Verify Earn protocol details do not show duplicate platform bonus content.

[OK-56125]: https://onekeyhq.atlassian.net/browse/OK-56125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-56109]: https://onekeyhq.atlassian.net/browse/OK-56109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ