### PR TITLE
fix: unify market banner change label(OK-55440)

### DIFF
--- a/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
+++ b/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
@@ -173,6 +173,9 @@ function MarketBannerDetailContent({ title }: { title: string }) {
     if (isPerps) {
       return <PerpsTokenListSection tokenListId={tokenListId} />;
     }
+    const change24hColumnTitle = intl.formatMessage({
+      id: ETranslations.dexmarket_banner_token_24hchange,
+    });
     // Native mobile: use FlatList + TokenListItem to match watchlist layout
     if (platformEnv.isNative && !gtMd) {
       if (tickerIsLoading && mobileSortedData.length === 0) {
@@ -180,6 +183,7 @@ function MarketBannerDetailContent({ title }: { title: string }) {
           <Stack flex={1}>
             <MarketListColumnHeader
               changeSortType={changeSortType}
+              change24hColumnTitle={change24hColumnTitle}
               changeSortTestID={MarketTestIDs.sortByChange}
               onChangeSortPress={handleChangeSortPress}
             />
@@ -191,6 +195,7 @@ function MarketBannerDetailContent({ title }: { title: string }) {
         <Stack flex={1}>
           <MarketListColumnHeader
             changeSortType={changeSortType}
+            change24hColumnTitle={change24hColumnTitle}
             changeSortTestID={MarketTestIDs.sortByChange}
             onChangeSortPress={handleChangeSortPress}
           />
@@ -232,9 +237,7 @@ function MarketBannerDetailContent({ title }: { title: string }) {
         watchlistFrom={EWatchlistFrom.BannerList}
         copyFrom={ECopyFrom.BannerList}
         showEndReachedIndicator
-        change24hColumnTitle={intl.formatMessage({
-          id: ETranslations.dexmarket_banner_token_24hchange,
-        })}
+        change24hColumnTitle={change24hColumnTitle}
       />
     );
     if (platformEnv.isNative) {

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketListColumnHeader.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketListColumnHeader.tsx
@@ -8,12 +8,14 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 type IMarketListColumnHeaderProps = {
   changeSortType?: 'asc' | 'desc';
   changeSortTestID?: string;
+  change24hColumnTitle?: string;
   onChangeSortPress?: () => void;
 };
 
 function MarketListColumnHeaderBase({
   changeSortType,
   changeSortTestID,
+  change24hColumnTitle,
   onChangeSortPress,
 }: IMarketListColumnHeaderProps) {
   const intl = useIntl();
@@ -70,9 +72,10 @@ function MarketListColumnHeaderBase({
               numberOfLines={1}
               flexShrink={1}
             >
-              {intl.formatMessage({
-                id: ETranslations.dexmarket_token_change,
-              })}
+              {change24hColumnTitle ??
+                intl.formatMessage({
+                  id: ETranslations.dexmarket_token_change,
+                })}
             </SizableText>
             {onChangeSortPress ? (
               <Icon name={sortIconName} color="$iconSubdued" size="$4" />


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55440](https://onekeyhq.atlassian.net/browse/OK-55440)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Added an optional 24h change column title override to the mobile market list header.
- Reused `dexmarket_banner_token_24hchange` for both mobile and desktop banner detail token lists.

## Intent & Context
The banner detail page had already been updated to use `banner_token_24hchange`, but the change only affected the desktop-style token table. The user reported that the label was only changed on desktop and asked to unify `banner_token_24hchange` across the banner detail UI.

## Root Cause
The banner detail page uses different list implementations by platform/layout. Desktop and wider layouts render `MarketTokenListBase`, which accepts `change24hColumnTitle`. Native mobile small-screen layout returns earlier with `FlatList + MarketListColumnHeader`, and `MarketListColumnHeader` still hardcoded `dexmarket_token_change`, so the banner-specific label was never applied there.

## Design Decisions
The fix keeps the existing list split intact and adds a narrow optional prop to `MarketListColumnHeader`. Existing callers keep the previous `dexmarket_token_change` fallback, while the banner detail page passes the same `dexmarket_banner_token_24hchange` value into both the mobile header and desktop table. This avoids duplicating banner-specific logic inside the shared header component.

## Changes Detail
- `MarketListColumnHeader.tsx`: added `change24hColumnTitle?: string` with the previous translation as the default fallback.
- `MarketBannerDetail.tsx`: formats `dexmarket_banner_token_24hchange` once and passes it to both native mobile `MarketListColumnHeader` and `MarketTokenListBase`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web
- **Risk Areas**: Market banner detail column header copy. Existing non-banner market list headers keep the original default label.

## Test plan
- [x] `node_modules/.bin/oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx packages/kit/src/views/Market/MarketHomeV2/components/MarketListColumnHeader.tsx`
- [x] `node_modules/.bin/tsgo -p ./tsconfig.json --noEmit --pretty false`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `yarn test`

[OK-55440]: https://onekeyhq.atlassian.net/browse/OK-55440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ