### PR TITLE
fix(market): block TradingView chart logo redirect on mobile (OK-56059)

### DIFF
--- a/packages/kit/src/components/TradingView/hooks/useNavigationHandler.ts
+++ b/packages/kit/src/components/TradingView/hooks/useNavigationHandler.ts
@@ -1,7 +1,5 @@
 import { useCallback } from 'react';
 
-import openUrlUtils from '@onekeyhq/shared/src/utils/openUrlUtils';
-
 import type { WebViewNavigation } from 'react-native-webview/lib/WebViewTypes';
 
 interface IUseNavigationHandlerReturn {
@@ -9,30 +7,22 @@ interface IUseNavigationHandlerReturn {
 }
 
 /**
- * Custom hook for handling WebView navigation in TradingView
- * @returns Navigation handler function that redirects external URLs to system browser
+ * Custom hook for handling WebView navigation in TradingView.
+ *
+ * Tapping the chart's TradingView logo navigates to www.tradingview.com.
+ * Block that redirect entirely (instead of opening it in an external browser),
+ * since the jump is annoying on mobile. All other navigation is allowed.
  */
 export const useNavigationHandler = (): IUseNavigationHandlerReturn => {
   const handleNavigation = useCallback((event: WebViewNavigation): boolean => {
     try {
       const requestUrl = new URL(event.url);
-      const isBlockedTradingViewUrl =
-        requestUrl.hostname === 'www.tradingview.com';
-
-      if (isBlockedTradingViewUrl) {
-        console.log(
-          'Blocked navigation to www.tradingview.com, opening in external browser:',
-          event.url,
-        );
-        // Open the blocked URL in external browser
-        openUrlUtils.openUrlExternal(event.url);
+      if (requestUrl.hostname === 'www.tradingview.com') {
         return false;
       }
-
       return true;
     } catch (_error) {
       // If URL parsing fails, allow the request
-      console.log('Failed to parse URL, allowing navigation:', event.url);
       return true;
     }
   }, []);


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56059](https://onekeyhq.atlassian.net/browse/OK-56059)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

On the mobile chart, the TradingView logo sits inside the interactive chart area. While the user is panning/zooming or tapping around the chart, an accidental tap on the logo expands it and redirects to an external browser (`www.tradingview.com`) — **yanking the user out of the app mid-interaction and interrupting whatever they were doing**. This change blocks that redirect entirely so the chart interaction is never broken.

## Change

`useNavigationHandler` — shared by the V2 spot chart (`TradingViewV2`) and the Perps chart (`TradingViewPerpsV2`) WebViews — now simply returns `false` for `www.tradingview.com` navigations instead of calling `openUrlExternal`. The logo tap becomes a no-op (logo stays visible, attribution preserved); all other in-chart navigation is unchanged. Also drops two `console.log`s and the now-unused `openUrlUtils` import.

## Jira

[OK-56059](https://onekeyhq.atlassian.net/browse/OK-56059)

## Test

- iPhone 17 Pro simulator: open a token detail chart → tap the circular TradingView logo → no expand, no external redirect, the user stays in the app. ✅
- Regression: other in-chart navigation unaffected (the `www.tradingview.com` block is the only branch; everything else still returns `true`).

## Platforms

Mobile (iOS / Android). Web / Extension load a cross-origin iframe and are unaffected.


[OK-56059]: https://onekeyhq.atlassian.net/browse/OK-56059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ