### PR TITLE
fix: prevent mobile popular trading overflow(OK-56140)

### DIFF
--- a/packages/kit/src/views/Home/components/PopularTrading/MarketCategoryTokenList.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/MarketCategoryTokenList.tsx
@@ -51,13 +51,14 @@ function MarketCategoryTokenList({
 }: IMarketCategoryTokenListProps) {
   const intl = useIntl();
   const { md } = useMedia();
+  const shouldUseTableLayout = Boolean(tableLayout && !md);
   const useStockMetadataColumns = useMemo(
     () => shouldUseStockMetadataColumnsForTokens(tokens),
     [tokens],
   );
 
   const columns = useMemo<ITableProps<IFavoriteTokenDisplay>['columns']>(() => {
-    if (tableLayout) {
+    if (shouldUseTableLayout) {
       return [
         {
           dataIndex: 'symbol',
@@ -69,7 +70,7 @@ function MarketCategoryTokenList({
           ) => {
             const checked = isTokenInWatchList(record);
             return (
-              <XStack alignItems="center" gap="$2">
+              <XStack alignItems="center" gap="$2" minWidth={0} width="100%">
                 <IconButton
                   testID={HomeTestIDs.popularTokenStarBtnMobile(record.symbol)}
                   title={intl.formatMessage({
@@ -83,9 +84,10 @@ function MarketCategoryTokenList({
                   iconProps={{
                     color: checked ? '$iconActive' : '$iconSubdued',
                   }}
+                  m="$0"
                   onPress={() => void onStarPress(record)}
                 />
-                <XStack alignItems="center" gap="$2">
+                <XStack alignItems="center" gap="$2" flex={1} minWidth={0}>
                   <Token
                     size="md"
                     tokenImageUri={record.logoUrl}
@@ -93,8 +95,13 @@ function MarketCategoryTokenList({
                     networkId={record.chainId}
                     showNetworkIcon
                   />
-                  <YStack minWidth={0}>
-                    <XStack alignItems="center" gap="$1" minWidth={0}>
+                  <YStack flex={1} minWidth={0}>
+                    <XStack
+                      alignItems="center"
+                      gap="$1"
+                      minWidth={0}
+                      overflow="hidden"
+                    >
                       <SizableText
                         size="$bodyLgMedium"
                         numberOfLines={1}
@@ -109,7 +116,9 @@ function MarketCategoryTokenList({
                       size="$bodyMd"
                       color="$textSubdued"
                       numberOfLines={1}
-                      maxWidth={200}
+                      ellipsizeMode="tail"
+                      flexShrink={1}
+                      maxWidth="100%"
                     >
                       {record.name}
                     </SizableText>
@@ -130,10 +139,11 @@ function MarketCategoryTokenList({
       {
         dataIndex: 'symbol',
         title: intl.formatMessage({ id: ETranslations.global_name }),
+        columnProps: { flex: 1.35, flexBasis: 0, minWidth: 0 },
         render: (_: unknown, record: IFavoriteTokenDisplay, _index: number) => {
           const checked = isTokenInWatchList(record);
           return (
-            <XStack alignItems="center" gap="$2" justifyContent="flex-end">
+            <XStack alignItems="center" gap="$2" minWidth={0} width="100%">
               <IconButton
                 testID={HomeTestIDs.popularTokenStarBtnDesktop(record.symbol)}
                 title={intl.formatMessage({
@@ -147,11 +157,12 @@ function MarketCategoryTokenList({
                 iconProps={{
                   color: checked ? '$iconActive' : '$iconSubdued',
                 }}
+                m="$0"
                 onPress={() => void onStarPress(record)}
                 hoverStyle={{ bg: 'transparent' }}
                 pressStyle={{ bg: 'transparent' }}
               />
-              <XStack alignItems="center" gap="$2">
+              <XStack alignItems="center" gap="$2" flex={1} minWidth={0}>
                 <Token
                   size="lg"
                   tokenImageUri={record.logoUrl}
@@ -159,8 +170,13 @@ function MarketCategoryTokenList({
                   networkId={record.chainId}
                   showNetworkIcon
                 />
-                <YStack minWidth={0}>
-                  <XStack alignItems="center" gap="$1" minWidth={0}>
+                <YStack flex={1} minWidth={0}>
+                  <XStack
+                    alignItems="center"
+                    gap="$1"
+                    minWidth={0}
+                    overflow="hidden"
+                  >
                     <SizableText
                       size="$bodyLgMedium"
                       numberOfLines={1}
@@ -181,6 +197,7 @@ function MarketCategoryTokenList({
       {
         dataIndex: 'price',
         title: intl.formatMessage({ id: ETranslations.global_price }),
+        columnProps: { flex: 0.85, flexBasis: 0, minWidth: 0 },
         render: (_: unknown, record: IFavoriteTokenDisplay) =>
           renderPopularTradingRightMetrics(record, useStockMetadataColumns),
       },
@@ -189,7 +206,7 @@ function MarketCategoryTokenList({
     intl,
     isTokenInWatchList,
     onStarPress,
-    tableLayout,
+    shouldUseTableLayout,
     useStockMetadataColumns,
   ]);
 
@@ -218,7 +235,7 @@ function MarketCategoryTokenList({
   return (
     <YStack>
       <RichTable<IFavoriteTokenDisplay>
-        showHeader={!!tableLayout}
+        showHeader={shouldUseTableLayout}
         dataSource={tokens}
         columns={columns}
         keyExtractor={(item) => `${item.chainId}-${item.contractAddress}`}

--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -13,6 +13,7 @@ import {
   YStack,
   getSharedButtonStyles,
   rootNavigationRef,
+  useMedia,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ListLoading } from '@onekeyhq/kit/src/components/Loading';
@@ -183,6 +184,8 @@ function RecommendCardItem({
 
 function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
   const intl = useIntl();
+  const { md } = useMedia();
+  const shouldUseTableLayout = Boolean(tableLayout && !md);
   const navigation = useAppNavigation();
   const navigateToMarketTab = useNavigateToMarketTab();
   const {
@@ -364,7 +367,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
 
   // Columns for table layout (only used when user has favorites)
   const columns = useMemo(() => {
-    if (tableLayout) {
+    if (shouldUseTableLayout) {
       return [
         {
           dataIndex: 'symbol',
@@ -374,7 +377,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
             record: IFavoriteTokenDisplay,
             _index: number,
           ) => (
-            <XStack alignItems="center" gap="$2">
+            <XStack alignItems="center" gap="$2" minWidth={0} width="100%">
               <IconButton
                 testID="home-columns-icon-btn"
                 icon="StarSolid"
@@ -384,9 +387,10 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
                 title={intl.formatMessage({
                   id: ETranslations.market_remove_from_favorites,
                 })}
+                m="$0"
                 onPress={() => handleRemoveFromWatchlistRef.current(record)}
               />
-              <XStack alignItems="center" gap="$2">
+              <XStack alignItems="center" gap="$2" flex={1} minWidth={0}>
                 <Token
                   size="md"
                   tokenImageUri={record.logoUrl}
@@ -394,8 +398,13 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
                   networkId={record.perpsCoin ? undefined : record.chainId}
                   showNetworkIcon={!record.perpsCoin}
                 />
-                <YStack minWidth={0}>
-                  <XStack alignItems="center" gap="$1" minWidth={0}>
+                <YStack flex={1} minWidth={0}>
+                  <XStack
+                    alignItems="center"
+                    gap="$1"
+                    minWidth={0}
+                    overflow="hidden"
+                  >
                     <SizableText
                       size="$bodyLgMedium"
                       numberOfLines={1}
@@ -413,7 +422,9 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
                     size="$bodyMd"
                     color="$textSubdued"
                     numberOfLines={1}
-                    maxWidth={200}
+                    ellipsizeMode="tail"
+                    flexShrink={1}
+                    maxWidth="100%"
                   >
                     {record.name}
                   </SizableText>
@@ -433,8 +444,9 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
       {
         dataIndex: 'symbol',
         title: intl.formatMessage({ id: ETranslations.global_name }),
+        columnProps: { flex: 1.35, flexBasis: 0, minWidth: 0 },
         render: (_: unknown, record: IFavoriteTokenDisplay, _index: number) => (
-          <XStack alignItems="center" gap="$2" justifyContent="flex-end">
+          <XStack alignItems="center" gap="$2" minWidth={0} width="100%">
             <IconButton
               testID="home-icon-btn"
               icon="StarSolid"
@@ -444,11 +456,12 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
               title={intl.formatMessage({
                 id: ETranslations.market_remove_from_favorites,
               })}
+              m="$0"
               onPress={() => handleRemoveFromWatchlistRef.current(record)}
               hoverStyle={{ bg: 'transparent' }}
               pressStyle={{ bg: 'transparent' }}
             />
-            <XStack alignItems="center" gap="$2">
+            <XStack alignItems="center" gap="$2" flex={1} minWidth={0}>
               <Token
                 size="lg"
                 tokenImageUri={record.logoUrl}
@@ -456,8 +469,13 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
                 networkId={record.perpsCoin ? undefined : record.chainId}
                 showNetworkIcon={!record.perpsCoin}
               />
-              <YStack minWidth={0}>
-                <XStack alignItems="center" gap="$1" minWidth={0}>
+              <YStack flex={1} minWidth={0}>
+                <XStack
+                  alignItems="center"
+                  gap="$1"
+                  minWidth={0}
+                  overflow="hidden"
+                >
                   <SizableText
                     size="$bodyLgMedium"
                     numberOfLines={1}
@@ -480,11 +498,12 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
       {
         dataIndex: 'price',
         title: intl.formatMessage({ id: ETranslations.global_price }),
+        columnProps: { flex: 0.85, flexBasis: 0, minWidth: 0 },
         render: (_: unknown, record: IFavoriteTokenDisplay) =>
           renderPopularTradingRightMetrics(record, useStockMetadataColumns),
       },
     ];
-  }, [intl, tableLayout, useStockMetadataColumns]);
+  }, [intl, shouldUseTableLayout, useStockMetadataColumns]);
 
   const { isLoading, run: refreshData } = usePromiseResult(
     async () => {
@@ -884,7 +903,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
       />
     );
 
-    if (!tableLayout) {
+    if (!shouldUseTableLayout) {
       return (
         <YStack gap="$2.5" width="100%">
           {[0, 1].map((rowIndex) => (
@@ -903,7 +922,12 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
         {favoriteTokens.map(renderCardItem)}
       </XStack>
     );
-  }, [favoriteTokens, selectedTokens, handleRecommendItemChange, tableLayout]);
+  }, [
+    favoriteTokens,
+    selectedTokens,
+    handleRecommendItemChange,
+    shouldUseTableLayout,
+  ]);
 
   // Navigate to Market favorites tab
   const handleViewMore = useCallback(() => {
@@ -923,7 +947,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
     return (
       <YStack>
         <RichTable<IFavoriteTokenDisplay>
-          showHeader={!!tableLayout}
+          showHeader={shouldUseTableLayout}
           dataSource={favoriteTokens}
           columns={columns}
           keyExtractor={(item) =>
@@ -973,7 +997,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
     handleTokenPress,
     handleViewMore,
     intl,
-    tableLayout,
+    shouldUseTableLayout,
     totalFavoritesCount,
   ]);
 
@@ -1019,7 +1043,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
           <MarketCategoryTokenList
             tokens={categoryTokens}
             isLoading={isCategoryLoading}
-            tableLayout={tableLayout}
+            tableLayout={shouldUseTableLayout}
             isTokenInWatchList={isTokenInWatchList}
             onStarPress={handleMarketCategoryStarPress}
             onTokenPress={handleTokenPress}
@@ -1061,7 +1085,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
 
     return (
       <YStack>
-        <YStack px={tableLayout ? '$pagePadding' : undefined}>
+        <YStack px={shouldUseTableLayout ? '$pagePadding' : undefined}>
           <CategorySelector
             categories={homeCategories}
             selectedCategoryId={resolvedSelectedCategoryId}
@@ -1090,7 +1114,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
     renderUserFavoritesList,
     selectedMarketCategoryId,
     resolvedSelectedCategoryId,
-    tableLayout,
+    shouldUseTableLayout,
   ]);
 
   return (


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56140](https://onekeyhq.atlassian.net/browse/OK-56140)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Prevent the Home PopularTrading market list from using the desktop multi-column table layout on small screens.
- Tighten token-name cell flex constraints so stock symbols, subtitles, and favorite icons shrink within the row instead of pushing past the viewport.
- Apply the same compact mobile behavior to both the market category list and the user's favorites list.

## Intent & Context
The user reported that the `/` page overflows horizontally on a 396px mobile viewport. The screenshot showed the Home market section with category tabs (`Favorites`, `Trending`, `Stocks`) and token rows like `AAPLon @ Apple`, where the favorite star column was clipped off the left edge and row content exceeded the visible screen.

## Root Cause
`PopularTrading` accepted a parent-provided `tableLayout` flag and used `RichTable` desktop-style columns when that flag was true. On a narrow viewport this could still render the table path, keeping multiple metric columns and a name cell that included the star button, token icon, long stock symbol, and subtitle. The name cell did not consistently enforce `minWidth=0` / overflow constraints, and the tertiary star `IconButton` negative margin made the left edge clipping more visible.

## Design Decisions
- Added a local `shouldUseTableLayout = tableLayout && !md` guard inside `PopularTrading` and `MarketCategoryTokenList` so the Home market section cannot render the desktop table layout on mobile-sized screens even if the parent flag is stale or platform-specific.
- Kept the desktop multi-column table behavior unchanged for larger viewports.
- Kept the mobile layout as a compact two-column row (`symbol` + right-side metrics) and gave the token identity column more flex space than the right metric column.
- Fixed the row internals with `minWidth={0}`, `overflow="hidden"`, and `maxWidth="100%"` so long stock names and badges truncate instead of expanding the row.
- Removed the star button's tertiary negative margin in these rows with `m="$0"` to keep the favorite icon inside the row bounds.

## Changes Detail
- `packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx`: adds the small-screen table guard and updates favorites table/list row flex constraints.
- `packages/kit/src/views/Home/components/PopularTrading/MarketCategoryTokenList.tsx`: applies the same layout guard and row constraints to category token lists such as Trending and Stocks.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web, Desktop responsive layouts, Extension UI where the Home market section is shown
- **Risk Areas**: Visual layout in the Home PopularTrading market section, especially narrow responsive widths and stock-token rows with long labels.

## Test plan
- [x] `NODE_OPTIONS=--max-old-space-size=8192 yarn tsc --noEmit --pretty false --incremental false --project packages/kit/tsconfig.json`
- [x] `node_modules/.bin/eslint packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx packages/kit/src/views/Home/components/PopularTrading/MarketCategoryTokenList.tsx --max-warnings=0`
- [ ] Open `/` at a ~396px wide viewport and confirm the favorite star, token icon, token title, and right-side price/change remain inside the screen.

[OK-56140]: https://onekeyhq.atlassian.net/browse/OK-56140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ