### PR TITLE
fix: notification account manage avatars for variant-address accounts (OK-56150)

### DIFF
--- a/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
@@ -65,6 +65,7 @@ import type {
   IDBDevice,
   IDBIndexedAccount,
   IDBWallet,
+  IDBWalletIdSingleton,
 } from '../../dbs/local/types';
 import type {
   IAccountActivityNotificationSettings,
@@ -732,10 +733,12 @@ export default class ServiceNotification extends ServiceBase {
     allIndexedAccounts,
     allWallets,
     allDevices,
+    resolveOthersWalletAccountsAddress,
   }: {
     allIndexedAccounts?: IDBIndexedAccount[] | undefined;
     allWallets?: IDBWallet[] | undefined;
     allDevices?: IDBDevice[] | undefined;
+    resolveOthersWalletAccountsAddress?: boolean;
   } = {}) {
     const result = await this.backgroundApi.serviceAccount.getWallets({
       nestedHiddenWallets: true,
@@ -746,9 +749,31 @@ export default class ServiceNotification extends ServiceBase {
       allDevices,
     });
     // Bot wallets must not occupy notification quota.
-    return result.wallets.filter(
+    const wallets = result.wallets.filter(
       (wallet) => !accountUtils.isBotWallet({ walletId: wallet.id }),
     );
+    if (resolveOthersWalletAccountsAddress) {
+      // Variant-address accounts (cosmos/dot/cfx/fil) keep db `address` empty,
+      // resolve network address by the same path as the account selector,
+      // so that UI consumers can render address-based avatars
+      await Promise.all(
+        wallets.map(async (wallet) => {
+          if (
+            accountUtils.isOthersWallet({ walletId: wallet.id }) &&
+            wallet.dbAccounts?.length
+          ) {
+            const { accounts } =
+              await this.backgroundApi.serviceAccount.getSingletonAccountsOfWallet(
+                {
+                  walletId: wallet.id as IDBWalletIdSingleton,
+                },
+              );
+            wallet.dbAccounts = accounts;
+          }
+        }),
+      );
+    }
+    return wallets;
   }
 
   getNotificationWalletName({

--- a/packages/kit/src/views/Setting/pages/Notifications/ManageAccountActivity.tsx
+++ b/packages/kit/src/views/Setting/pages/Notifications/ManageAccountActivity.tsx
@@ -820,7 +820,13 @@ function ManageAccountActivity() {
 
   const { result: wallets = [], isLoading } = usePromiseResult(
     () =>
-      backgroundApiProxy.serviceNotification.getNotificationWalletsWithAccounts(),
+      backgroundApiProxy.serviceNotification.getNotificationWalletsWithAccounts(
+        {
+          // variant-address accounts (cosmos/dot/cfx/fil) keep db `address`
+          // empty, resolve it for address-based avatars (same as account selector)
+          resolveOthersWalletAccountsAddress: true,
+        },
+      ),
     [],
     {
       watchLoading: true,


### PR DESCRIPTION
## Problem

[OK-56150](https://onekeyhq.atlassian.net/browse/OK-56150): In Notifications → Manage account activity, avatars of private key accounts on certain networks (cosmos series / dot series / cfx / filecoin) failed to load (the empty-avatar placeholder was rendered instead), inconsistent with how the same accounts appear in the account selector.

## Root cause

These four impls are exactly the ones using `EDBAccountType.VARIANT` (the same private key yields different address encodings per sub-chain). For VARIANT accounts the local DB **keeps the base `address` field empty by design** (`KeyringBase.ts` even throws if it is set); the real addresses live in the `addresses: { [networkId]: address }` map and are recalculated from the pubkey per sub-chain by the vault's `buildAccountAddressDetail` inside `getAccount()`.

- Account selector: data flows through `getSingletonAccountsOfWallet` → `getAccountCompatibleNetwork` → `getAccount`, returning `INetworkAccount` objects with the address resolved → blockie avatar renders fine
- Notification manage page: `getNotificationWalletsWithAccounts` returned raw `IDBAccount` records straight from localDb with an empty `address` → `AccountAvatar` fell back to the `DefaultEmptyAccount` placeholder

## Fix

Add an opt-in `resolveOthersWalletAccountsAddress` parameter to `getNotificationWalletsWithAccounts`: when enabled, accounts of others wallets (private key / watch-only / external) are resolved through the exact same path the account selector uses (`serviceAccount.getSingletonAccountsOfWallet`), so the avatars are now unified with the account selector. Only the notification manage page enables the flag; push-sync paths (`convertToSyncAccounts` / `fixAccountActivityNotificationSettings`) pass nothing and keep their previous behavior and cost.

Client-side change only; no server changes involved.

## Verification

- `tsc --noEmit` (scoped to the two changed files + tamagui type augmentation): 0 errors
- `yarn lint:staged`: 0 warnings, 0 errors
- `jest accountUtils.test.ts`: 14/14 passed

## Suggested QA steps

1. Import private key accounts for cosmos / osmosis / polkadot / cfx / filecoin
2. Settings → Notifications → Account activity → Manage, expand the "Private key" group
3. Confirm the avatars match the same accounts' avatars in the account selector (no more empty placeholder)
4. Regression: HD/hardware wallet account avatars, wallet/account toggles, and the max-account-count alert are unaffected

https://claude.ai/code/session_01DuwD1vppfBaf4gQi4ZzrrW

[OK-56150]: https://onekeyhq.atlassian.net/browse/OK-56150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ