### PR TITLE
fix: keep protection unlocked for supported assets dialog

### DIFF
--- a/packages/kit/src/views/Setting/pages/Protection/ReceiveRiskSupportedAssets.tsx
+++ b/packages/kit/src/views/Setting/pages/Protection/ReceiveRiskSupportedAssets.tsx
@@ -3,10 +3,13 @@ import { useCallback, useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { StyleSheet } from 'react-native';
 
+import type { IYStackProps } from '@onekeyhq/components';
 import {
   Button,
+  Dialog,
   Divider,
   Empty,
+  IconButton,
   Page,
   ScrollView,
   SizableText,
@@ -126,7 +129,26 @@ function NetworkAssetSection({
   );
 }
 
-const ReceiveRiskSupportedAssetsPage = () => {
+type IReceiveRiskSupportedAssetsContentProps = {
+  maxHeight?: number;
+  minHeight?: number;
+  contentContainerProps?: IYStackProps;
+};
+
+function openReceiveRiskMonitoringHelpLink(intl: ReturnType<typeof useIntl>) {
+  openUrlInApp(
+    RECEIVE_RISK_MONITORING_HELP_LINK,
+    intl.formatMessage({
+      id: ETranslations.prime_feature_receive_risk_monitoring__title,
+    }),
+  );
+}
+
+export function ReceiveRiskSupportedAssetsContent({
+  maxHeight,
+  minHeight,
+  contentContainerProps,
+}: IReceiveRiskSupportedAssetsContentProps) {
   const intl = useIntl();
   const [sections, setSections] = useState<ISupportedNetworkSection[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -150,34 +172,25 @@ const ReceiveRiskSupportedAssetsPage = () => {
     void fetchSupportedAssets();
   }, [fetchSupportedAssets]);
 
-  const headerRight = useCallback(
-    () => (
-      <HeaderIconButton
-        icon="QuestionmarkOutline"
-        onPress={() => {
-          openUrlInApp(
-            RECEIVE_RISK_MONITORING_HELP_LINK,
-            intl.formatMessage({
-              id: ETranslations.prime_feature_receive_risk_monitoring__title,
-            }),
-          );
-        }}
-      />
-    ),
-    [intl],
-  );
-
   const renderBody = useCallback(() => {
     if (isLoading) {
       return (
-        <Stack flex={1} alignItems="center" justifyContent="center">
+        <Stack
+          {...(maxHeight ? { minHeight: minHeight ?? maxHeight } : { flex: 1 })}
+          alignItems="center"
+          justifyContent="center"
+        >
           <Spinner size="large" />
         </Stack>
       );
     }
     if (isError) {
       return (
-        <Stack flex={1} alignItems="center" justifyContent="center">
+        <Stack
+          {...(maxHeight ? { minHeight: minHeight ?? maxHeight } : { flex: 1 })}
+          alignItems="center"
+          justifyContent="center"
+        >
           <Empty
             icon="BrokenLinkOutline"
             title={intl.formatMessage({
@@ -202,15 +215,76 @@ const ReceiveRiskSupportedAssetsPage = () => {
       );
     }
     return (
-      <ScrollView>
-        <YStack py="$4" pb="$10" gap="$3">
+      <ScrollView
+        maxHeight={maxHeight}
+        nestedScrollEnabled={Boolean(maxHeight)}
+      >
+        <YStack py="$4" pb="$10" gap="$3" {...contentContainerProps}>
           {sections.map((section) => (
             <NetworkAssetSection key={section.networkId} section={section} />
           ))}
         </YStack>
       </ScrollView>
     );
-  }, [fetchSupportedAssets, intl, isError, isLoading, sections]);
+  }, [
+    fetchSupportedAssets,
+    intl,
+    isError,
+    isLoading,
+    maxHeight,
+    minHeight,
+    contentContainerProps,
+    sections,
+  ]);
+
+  return renderBody();
+}
+
+export function ReceiveRiskSupportedAssetsDialogContent(
+  props: IReceiveRiskSupportedAssetsContentProps,
+) {
+  const intl = useIntl();
+  const handleOpenHelp = useCallback(() => {
+    openReceiveRiskMonitoringHelpLink(intl);
+  }, [intl]);
+
+  return (
+    <>
+      <Dialog.Header>
+        <XStack alignItems="center" gap="$2">
+          <Dialog.Title flex={1} numberOfLines={1}>
+            {intl.formatMessage({
+              id: ETranslations.kyt_supported_assets__title,
+            })}
+          </Dialog.Title>
+          <IconButton
+            icon="QuestionmarkOutline"
+            iconProps={{ color: '$iconSubdued' }}
+            size="small"
+            testID="receive-risk-supported-assets-help"
+            variant="tertiary"
+            onPress={handleOpenHelp}
+          />
+        </XStack>
+      </Dialog.Header>
+      <ReceiveRiskSupportedAssetsContent {...props} />
+    </>
+  );
+}
+
+const ReceiveRiskSupportedAssetsPage = () => {
+  const intl = useIntl();
+  const headerRight = useCallback(
+    () => (
+      <HeaderIconButton
+        icon="QuestionmarkOutline"
+        onPress={() => {
+          openReceiveRiskMonitoringHelpLink(intl);
+        }}
+      />
+    ),
+    [intl],
+  );
 
   return (
     <Page>
@@ -220,7 +294,9 @@ const ReceiveRiskSupportedAssetsPage = () => {
         })}
         headerRight={headerRight}
       />
-      <Page.Body>{renderBody()}</Page.Body>
+      <Page.Body>
+        <ReceiveRiskSupportedAssetsContent />
+      </Page.Body>
     </Page>
   );
 };

--- a/packages/kit/src/views/Setting/pages/Protection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Protection/index.tsx
@@ -17,6 +17,7 @@ import {
   Switch,
   YStack,
   startViewTransition,
+  useInModalDialog,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useIsEnableTransferAllowList } from '@onekeyhq/kit/src/components/AddressInput/hooks';
@@ -29,11 +30,15 @@ import { usePrimePersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/settings';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
-import { EModalRoutes, EModalSettingRoutes } from '@onekeyhq/shared/src/routes';
+import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EPrimeFeatures, EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import { EReasonForNeedPassword } from '@onekeyhq/shared/types/setting';
 
+import { ReceiveRiskSupportedAssetsDialogContent } from './ReceiveRiskSupportedAssets';
 import { promptKytNotificationPermissionIfNeeded } from './showKytNotificationPermissionDialog';
+
+const SUPPORTED_ASSETS_DIALOG_MAX_HEIGHT = 560;
+const SUPPORTED_ASSETS_DIALOG_MIN_HEIGHT = 360;
 
 const SettingProtectionModal = () => {
   const intl = useIntl();
@@ -54,6 +59,7 @@ const SettingProtectionModal = () => {
   const [isUpdatingReceiveRiskMonitoring, setIsUpdatingReceiveRiskMonitoring] =
     useState(false);
   const navigation = useAppNavigation();
+  const dialog = useInModalDialog();
 
   const useIsFocused = useRouteIsFocused();
 
@@ -106,6 +112,35 @@ const SettingProtectionModal = () => {
     },
     [intl, navigation, updateLockTimer],
   );
+
+  const handleOpenReceiveRiskSupportedAssets = useCallback(() => {
+    updateLockTimer();
+    dialog.show({
+      title: intl.formatMessage({
+        id: ETranslations.kyt_supported_assets__title,
+      }),
+      showFooter: false,
+      contentContainerProps: {
+        px: '$0',
+        pb: '$0',
+      },
+      floatingPanelProps: {
+        width: 480,
+      },
+      renderContent: (
+        <ReceiveRiskSupportedAssetsDialogContent
+          maxHeight={SUPPORTED_ASSETS_DIALOG_MAX_HEIGHT}
+          minHeight={SUPPORTED_ASSETS_DIALOG_MIN_HEIGHT}
+          contentContainerProps={{
+            pt: '$2',
+          }}
+        />
+      ),
+      onClose: () => {
+        updateLockTimer();
+      },
+    });
+  }, [dialog, intl, updateLockTimer]);
 
   useEffect(() => {
     if (useIsFocused) {
@@ -286,11 +321,7 @@ const SettingProtectionModal = () => {
               id: ETranslations.kyt_supported_assets__desc,
             })}
             drillIn
-            onPress={() => {
-              navigation.push(
-                EModalSettingRoutes.SettingReceiveRiskSupportedAssets,
-              );
-            }}
+            onPress={handleOpenReceiveRiskSupportedAssets}
           />
           <Divider my="$5" mx="$5" />
           <SectionList.SectionHeader
@@ -368,6 +399,7 @@ const SettingProtectionModal = () => {
   }, [
     checkEnableProtection,
     enableProtection,
+    handleOpenReceiveRiskSupportedAssets,
     handleToggleReceiveRiskMonitoring,
     handleTransition,
     intl,


### PR DESCRIPTION
## Summary
- Open the supported assets list from Protection in an in-modal dialog instead of pushing a separate route.
- Extract the supported assets list into shared content for the existing page and the new dialog.
- Add the original help entry back to the dialog header next to the close action.

## Intent & Context
The Protection settings page requires password verification for security. Opening Assets covered / Supported assets as a separate route caused the Protection page to lock again after returning, which adds extra friction, especially on devices without biometric unlock.

This change keeps the supported assets experience inside the current modal context so users can inspect and close it without refreshing or navigating away from Protection.

## Root Cause
Protection locks itself when `useRouteIsFocused()` becomes false. The previous `navigation.push(EModalSettingRoutes.SettingReceiveRiskSupportedAssets)` flow made the Protection route lose focus, so closing the supported assets page returned to a locked Protection screen.

## Design Decisions
- Use `useInModalDialog()` so supported assets are displayed inside the current modal context instead of pushing a new route.
- Keep `ReceiveRiskSupportedAssetsContent` reusable so the existing full-page route still works.
- Put the help action in the dialog header action area, matching the original page `headerRight` behavior without taking space from the list.
- Keep the dialog height unchanged and only adjust the dialog content top padding.

## Changes Detail
- `packages/kit/src/views/Setting/pages/Protection/index.tsx`: replaces the supported assets route push with an in-modal dialog and refreshes the lock timer on open/close.
- `packages/kit/src/views/Setting/pages/Protection/ReceiveRiskSupportedAssets.tsx`: extracts reusable content, adds the dialog wrapper with help action, and keeps the original page route intact.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Settings/Protection surfaces across app platforms
- **Risk Areas**: Dialog header spacing and supported assets list scrolling on smaller screens

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `git diff --check upstream/x...HEAD`
- [x] Reviewed the final PR diff scope
- [ ] Open Protection, unlock it, open Assets covered, close it, and verify Protection stays unlocked
- [ ] Tap the dialog help icon and verify it opens the KYT help article