### PR TITLE
fix: reduce market mobile header spacing(OK-56111)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
@@ -577,7 +577,7 @@ function MarketTokenListBase({
 
   const tableContentContainerStyle = tabIntegrated
     ? {
-        paddingTop: 8 + (platformEnv.isNative ? 195 : 0),
+        paddingTop: 4 + (platformEnv.isNative ? 195 : 0),
         paddingBottom: integratedContentPaddingBottom,
       }
     : {

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketTokenFlatList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketTokenFlatList.tsx
@@ -164,7 +164,7 @@ function MobileMarketTokenFlatListBase({
       ListFooterComponent={ListFooterComponent}
       ListEmptyComponent={ListEmptyComponent}
       contentContainerStyle={{
-        ...(platformEnv.isNative ? {} : { paddingTop: 8 }),
+        ...(platformEnv.isNative ? {} : { paddingTop: 4 }),
         paddingBottom: platformEnv.isNativeAndroid
           ? listContainerProps.paddingBottom
           : tabBarHeight,

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketWatchlistFlatList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketWatchlistFlatList.tsx
@@ -391,7 +391,7 @@ function MobileMarketWatchlistFlatListImpl({
   const tabBarHeight = useScrollContentTabBarOffset();
   const contentContainerStyle = useMemo(
     () => ({
-      ...(platformEnv.isNative ? {} : { paddingTop: 8 }),
+      ...(platformEnv.isNative ? {} : { paddingTop: 4 }),
       paddingBottom: platformEnv.isNativeAndroid
         ? listContainerProps.paddingBottom
         : tabBarHeight,

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
@@ -83,8 +83,8 @@ interface IMarketHomeTabBarProps extends TabBarProps<string> {
   perpsTabName: string;
 }
 
-const MARKET_ANDROID_SECONDARY_HEADER_HEIGHT = 85;
-const MARKET_ANDROID_COLUMN_HEADER_HEIGHT = 36;
+const MARKET_ANDROID_SECONDARY_HEADER_HEIGHT = 76;
+const MARKET_ANDROID_COLUMN_HEADER_HEIGHT = 30;
 const MARKET_TAB_CHANGE_TARGET_GUARD_MS = platformEnv.isNativeIOS ? 1000 : 350;
 const MARKET_TAB_SYNC_JUMP_DEFER_MS = platformEnv.isNativeIOS ? 180 : 0;
 const MARKET_TAB_USER_DRAG_ACCEPT_MS = platformEnv.isNativeIOS ? 700 : 350;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56111](https://onekeyhq.atlassian.net/browse/OK-56111)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Reduced Market token list top spacing from 8px to 4px in table and mobile list containers.
- Reduced Android Market secondary header fixed heights to bring the list closer to the header.
- Kept token row item padding unchanged so row density and touch targets remain stable.

## Intent & Context
The request was to make the Market home list sit closer to the tab/header area. During review, the issue was clarified as list/table header spacing rather than padding inside `market-token-item-*` rows. Favorites/watchlist needed the same treatment because it uses a separate mobile list path.

## Root Cause
The visible gap came from container/header spacing: Market list/table content had an 8px top padding, and Android native Market tabs used fixed secondary-header heights that were larger than the rendered header needed. The token item component itself was not the right layer to adjust.

## Design Decisions
- Changed list/table top padding from 8px to 4px instead of removing it, preserving a small visual gap.
- Applied the same 8px to 4px adjustment to normal token lists and favorites/watchlist mobile lists for consistency.
- Reduced Android fixed secondary header height constants instead of changing item padding, so the header measurement better matches the visual layout.

## Changes Detail
- `MarketTokenListBase.tsx`: reduced tab-integrated table content top padding from 8px to 4px.
- `MobileMarketTokenFlatList.tsx`: reduced non-native mobile token list top padding from 8px to 4px.
- `MobileMarketWatchlistFlatList.tsx`: reduced favorites/watchlist list top padding from 8px to 4px.
- `MobileLayout.native.tsx`: reduced Android secondary header fixed heights.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile Android, Web, Desktop
- **Risk Areas**: Market tab header/list spacing may need visual confirmation across normal, favorites/watchlist, stock-style, and perps tabs.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged --pretty false`
- [x] `yarn tsc:only --pretty false`
- [ ] Visually verify Market home normal list, favorites/watchlist, and perps tabs on Android native.
- [ ] Visually verify Market home list spacing on desktop/web.

[OK-56111]: https://onekeyhq.atlassian.net/browse/OK-56111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ