### PR TITLE
fix(app-update): auto-start mid-session OTA downloads and apply silent updates on restart (OK-55397)

### DIFF
--- a/packages/kit-bg/src/services/ServiceAppUpdate.test.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.test.ts
@@ -1852,6 +1852,132 @@ describe('ServiceAppUpdate state transitions', () => {
       expect(atomValue.updateStrategy).toBe(EUpdateStrategy.silent);
     });
 
+    // -----------------------------------------------------------------------
+    // Mid-session auto-download for silent/seamless strategies (OK-55397).
+    // Without this, an update discovered while the app is already running
+    // only flips status to `notify`; the silent download never starts until
+    // the next cold start re-runs the once-per-launch first-launch dispatch.
+    // The download is scheduled via setTimeout(0), so tests flush fake timers
+    // before asserting.
+    // -----------------------------------------------------------------------
+    test('auto-starts download for a silent jsBundle upgrade discovered mid-session', async () => {
+      resetAtom({ status: EAppUpdateStatus.done, updateAt: 0 });
+      mockLatestInfo({
+        version: '1.0.0', // same app version
+        jsBundleVersion: '5', // higher than installed bundleVersion '1'
+        jsBundle: {
+          downloadUrl: 'https://cdn.onekey.so/bundle-v5.zip',
+          sha256: 'abc',
+          fileSize: 2048,
+        },
+        updateStrategy: EUpdateStrategy.silent,
+      });
+      jest.spyOn(service, 'isNeedSyncAppUpdateInfo').mockResolvedValue(true);
+      jest.spyOn(service, 'refreshUpdateStatus').mockResolvedValue(undefined);
+      const downloadSpy = jest.spyOn(service, 'downloadPackage');
+
+      await service.fetchAppUpdateInfo(true);
+      expect(atomValue.status).toBe(EAppUpdateStatus.notify);
+
+      // Flush the deferred auto-download.
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(downloadSpy).toHaveBeenCalledTimes(1);
+      expect(atomValue.status).toBe(EAppUpdateStatus.downloadPackage);
+    });
+
+    test('auto-starts download for a seamless appShell upgrade discovered mid-session', async () => {
+      resetAtom({ status: EAppUpdateStatus.done, updateAt: 0 });
+      mockLatestInfo({
+        version: '2.0.0', // newer app version than installed '1.0.0'
+        downloadUrl: 'https://cdn.onekey.so/app-v2.zip',
+        updateStrategy: EUpdateStrategy.seamless,
+      });
+      jest.spyOn(service, 'isNeedSyncAppUpdateInfo').mockResolvedValue(true);
+      jest.spyOn(service, 'refreshUpdateStatus').mockResolvedValue(undefined);
+      const downloadSpy = jest.spyOn(service, 'downloadPackage');
+
+      await service.fetchAppUpdateInfo(true);
+      expect(atomValue.status).toBe(EAppUpdateStatus.notify);
+
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(downloadSpy).toHaveBeenCalledTimes(1);
+      expect(atomValue.status).toBe(EAppUpdateStatus.downloadPackage);
+    });
+
+    test('does NOT auto-start download for a manual upgrade (waits for user)', async () => {
+      resetAtom({ status: EAppUpdateStatus.done, updateAt: 0 });
+      mockLatestInfo({
+        version: '1.0.0',
+        jsBundleVersion: '5',
+        jsBundle: {
+          downloadUrl: 'https://cdn.onekey.so/bundle-v5.zip',
+          sha256: 'abc',
+          fileSize: 2048,
+        },
+        updateStrategy: EUpdateStrategy.manual,
+      });
+      jest.spyOn(service, 'isNeedSyncAppUpdateInfo').mockResolvedValue(true);
+      jest.spyOn(service, 'refreshUpdateStatus').mockResolvedValue(undefined);
+      const downloadSpy = jest.spyOn(service, 'downloadPackage');
+
+      await service.fetchAppUpdateInfo(true);
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(downloadSpy).not.toHaveBeenCalled();
+      expect(atomValue.status).toBe(EAppUpdateStatus.notify);
+    });
+
+    test('does NOT auto-start download when the target is frozen/ignored', async () => {
+      resetAtom({ status: EAppUpdateStatus.done, updateAt: 0 });
+      mockLatestInfo({
+        version: '1.0.0',
+        jsBundleVersion: '5',
+        jsBundle: {
+          downloadUrl: 'https://cdn.onekey.so/bundle-v5.zip',
+          sha256: 'abc',
+          fileSize: 2048,
+        },
+        updateStrategy: EUpdateStrategy.silent,
+      });
+      jest.spyOn(service, 'isNeedSyncAppUpdateInfo').mockResolvedValue(true);
+      jest.spyOn(service, 'refreshUpdateStatus').mockResolvedValue(undefined);
+      // Both the pre-notify freeze gate and the auto-download gate consult
+      // this; returning true keeps the upgrade out of `notify` entirely.
+      jest.spyOn(service, 'shouldSkipTargetByControl').mockResolvedValue(true);
+      const downloadSpy = jest.spyOn(service, 'downloadPackage');
+
+      await service.fetchAppUpdateInfo(true);
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(downloadSpy).not.toHaveBeenCalled();
+      expect(atomValue.status).not.toBe(EAppUpdateStatus.downloadPackage);
+    });
+
+    test('auto-starts download for a jsBundle rollback regardless of strategy', async () => {
+      resetAtom({ status: EAppUpdateStatus.done, updateAt: 0 });
+      mockLatestInfo({
+        version: '1.0.0', // same app version
+        jsBundleVersion: '0', // lower than installed bundleVersion '1' → rollback
+        jsBundle: {
+          downloadUrl: 'https://cdn.onekey.so/bundle-v0.zip',
+          sha256: 'abc',
+          fileSize: 2048,
+        },
+        updateStrategy: EUpdateStrategy.manual, // rollback ignores strategy
+      });
+      jest.spyOn(service, 'isNeedSyncAppUpdateInfo').mockResolvedValue(true);
+      jest.spyOn(service, 'refreshUpdateStatus').mockResolvedValue(undefined);
+      const downloadSpy = jest.spyOn(service, 'downloadPackage');
+
+      await service.fetchAppUpdateInfo(true);
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(downloadSpy).toHaveBeenCalledTimes(1);
+      expect(atomValue.status).toBe(EAppUpdateStatus.downloadPackage);
+    });
+
     test('jsBundle update clears stale storeUrl and downloadUrl from previous config', async () => {
       resetAtom({
         status: EAppUpdateStatus.done,

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -12,6 +12,7 @@ import {
   EPendingInstallTaskType,
   EUpdateFileType,
   EUpdateStrategy,
+  isAutoUpdateStrategy,
   isFirstLaunchAfterUpdated,
   normalizeFeaturedChangelog,
   resolveUpdateDecision,
@@ -1563,30 +1564,56 @@ class ServiceAppUpdate extends ServiceBase {
         };
       });
 
-      // Auto-trigger silent download for rollback decisions so the user does
-      // not need to manually initiate the update.  The download flow will
-      // eventually call readyToInstall → syncPendingInstallTask → relaunch.
+      // Auto-trigger the background download so the user does not need to
+      // manually initiate the update. Two cases qualify:
+      //   1. jsBundleRollback — always auto-downloaded; a rollback is a
+      //      corrective action, independent of the server-provided strategy.
+      //   2. A normal upgrade (jsBundleUpgrade / appShellUpdate) whose server
+      //      strategy is silent/seamless (isAutoUpdateStrategy). Without this,
+      //      an update discovered mid-session only flips status to `notify`
+      //      and the silent download never starts until the next cold start
+      //      re-runs the once-per-launch first-launch dispatch in
+      //      AppUpdateForeground — i.e. "must restart the app before the
+      //      download begins" (OK-55397). This mirrors that cold-start
+      //      auto-download path so mid-session discovery is handled the same
+      //      way. (Store-based app-shell updates are shipped as `manual` by
+      //      the server, so isAutoUpdateStrategy excludes them here.)
+      // The download flow eventually calls readyToInstall →
+      // syncPendingInstallTask → relaunch.
+      const shouldAutoDownload =
+        decision.decision === 'jsBundleRollback' ||
+        (isAutoUpdateStrategy(releaseInfo.updateStrategy) &&
+          (decision.decision === 'jsBundleUpgrade' ||
+            decision.decision === 'appShellUpdate'));
       if (
-        decision.decision === 'jsBundleRollback' &&
+        shouldAutoDownload &&
         (await appUpdatePersistAtom.get()).status === EAppUpdateStatus.notify
       ) {
-        // Verify target is not frozen/ignored before auto-triggering download
-        const rollbackTargetKey =
-          releaseInfo.version && releaseInfo.jsBundleVersion
+        // Verify target is not frozen/ignored before auto-triggering download.
+        // Mirror the freeze-check target key built above (line ~1442) so the
+        // app-shell fallback to the current bundleVersion stays consistent.
+        const autoDownloadTargetKey =
+          releaseInfo.version &&
+          (releaseInfo.jsBundleVersion ||
+            decision.decision === 'appShellUpdate')
             ? this.getTargetKey({
                 targetAppVersion: releaseInfo.version,
-                targetBundleVersion: releaseInfo.jsBundleVersion,
+                targetBundleVersion:
+                  decision.decision === 'appShellUpdate'
+                    ? releaseInfo.jsBundleVersion ||
+                      String(platformEnv.bundleVersion || '')
+                    : releaseInfo.jsBundleVersion!,
               })
             : null;
-        const rollbackBlocked = rollbackTargetKey
+        const autoDownloadBlocked = autoDownloadTargetKey
           ? await this.shouldSkipTargetByControl(
-              rollbackTargetKey,
+              autoDownloadTargetKey,
               traceId,
               requestSeq,
               false,
             )
           : false;
-        if (!rollbackBlocked) {
+        if (!autoDownloadBlocked) {
           // Use setTimeout to avoid blocking the current fetch flow.
           // Re-check status inside the callback: if the UI hook already
           // called downloadPackage(), status will be 'downloadPackage'
@@ -1598,7 +1625,7 @@ class ServiceAppUpdate extends ServiceBase {
                 return;
               }
               defaultLogger.app.appUpdate.log(
-                'fetchAppUpdateInfo: auto-starting silent download for jsBundleRollback',
+                `fetchAppUpdateInfo: auto-starting silent download for ${decision.decision}`,
               );
               void this.downloadPackage();
             })();

--- a/packages/kit-bg/src/services/servicePendingInstallTask.ts
+++ b/packages/kit-bg/src/services/servicePendingInstallTask.ts
@@ -667,9 +667,16 @@ class ServicePendingInstallTask {
 
     // Rollback always creates a pending task regardless of server strategy —
     // it is a corrective action that should not require user confirmation.
+    // OK-55397: silent now also queues a pending install task instead of
+    // showing a "ready" dialog, so the downloaded update is applied on the
+    // next restart (or immediately when the user taps the update button).
+    // silent + seamless together == isAutoUpdateStrategy, mirroring the
+    // shouldAutoDownload gate in ServiceAppUpdate.fetchAppUpdateInfo (kept
+    // inline here to avoid coupling to the shared helper's import path).
     if (
       decision.decision !== 'jsBundleRollback' &&
-      releaseInfo.updateStrategy !== EUpdateStrategy.seamless
+      releaseInfo.updateStrategy !== EUpdateStrategy.seamless &&
+      releaseInfo.updateStrategy !== EUpdateStrategy.silent
     ) {
       defaultLogger.app.appUpdate.pendingTaskUpsertDecision({
         traceId,

--- a/packages/kit/src/components/AppUpdate/AppUpdateForeground.tsx
+++ b/packages/kit/src/components/AppUpdate/AppUpdateForeground.tsx
@@ -29,7 +29,9 @@ import { whenAppUnlocked } from '../../utils/passwordUtils';
 import { tryShowFeaturedDialog } from '../../views/AppUpdate/dialogs/tryShowFeaturedDialog';
 
 import { buildSoftwareUpdateParams } from './updateAnalytics';
-import { showSilentUpdateDialogUI, showUpdateDialogUI } from './updateDialogs';
+// OK-55397: showSilentUpdateDialogUI no longer used — silent updates are
+// applied via a pending install task on restart instead of a "ready" dialog.
+import { showUpdateDialogUI } from './updateDialogs';
 import { isAutoUpdateStrategy, isForceUpdateStrategy } from './updateStrategy';
 import { useDownloadPackage } from './useDownloadPackage';
 
@@ -141,23 +143,29 @@ export function useAppUpdateForegroundEffects(enabled = true) {
     [appUpdateInfo.updateStrategy, navigation],
   );
 
-  const showSilentUpdateDialog = useCallback(() => {
-    setTimeout(async () => {
-      const currentUpdateInfo =
-        await backgroundApiProxy.serviceAppUpdate.getUpdateInfo();
-      await whenAppUnlocked();
-      await showSilentUpdateDialogUI({
-        intl,
-        summary: currentUpdateInfo.summary || '',
-        themeVariant,
-        onConfirm: () => {
-          navigation.pushModal(EModalRoutes.AppUpdateModal, {
-            screen: EAppUpdateRoutes.DownloadVerify,
-          });
-        },
-      });
-    }, 0);
-  }, [intl, navigation, themeVariant]);
+  // OK-55397: silent updates no longer show a "ready" dialog. The downloaded
+  // package is queued as a pending install task in
+  // ServiceAppUpdate.readyToInstall → syncPendingInstallTaskWithReleaseInfo
+  // (silent is now allowed past the strategy gate) and applied on the next
+  // restart; the header / reminder update button lets the user restart-install
+  // immediately. Dialog plumbing kept commented out for an easy revert.
+  // const showSilentUpdateDialog = useCallback(() => {
+  //   setTimeout(async () => {
+  //     const currentUpdateInfo =
+  //       await backgroundApiProxy.serviceAppUpdate.getUpdateInfo();
+  //     await whenAppUnlocked();
+  //     await showSilentUpdateDialogUI({
+  //       intl,
+  //       summary: currentUpdateInfo.summary || '',
+  //       themeVariant,
+  //       onConfirm: () => {
+  //         navigation.pushModal(EModalRoutes.AppUpdateModal, {
+  //           screen: EAppUpdateRoutes.DownloadVerify,
+  //         });
+  //       },
+  //     });
+  //   }, 0);
+  // }, [intl, navigation, themeVariant]);
 
   const showUpdateDialog = useCallback(
     (
@@ -399,12 +407,13 @@ export function useAppUpdateForegroundEffects(enabled = true) {
             );
           }
         } else if (info.updateStrategy === EUpdateStrategy.silent) {
-          // Consume the module-level guard shared with the silent-ready
-          // watcher effect below, so the watcher skips on the same render
-          // tick (prevents a duplicate dialog when the persisted atom is
-          // already hydrated at first launch).
+          // OK-55397: silent no longer pops a dialog here. readyToInstall has
+          // already queued a pending install task (silent is allowed past the
+          // strategy gate), applied on the next restart; the update button
+          // offers an immediate restart-install. Keep the guard set so the
+          // (now no-op) silent-ready watcher below stays consistent.
           silentReadyDialogShown = true;
-          showSilentUpdateDialog();
+          // showSilentUpdateDialog();
         } else {
           showUpdateDialog();
         }
@@ -436,11 +445,12 @@ export function useAppUpdateForegroundEffects(enabled = true) {
     if (appUpdateInfo.status !== EAppUpdateStatus.ready) return;
     if (isFirstLaunchAfterUpdated(appUpdateInfo)) return;
     silentReadyDialogShown = true;
-    showSilentUpdateDialog();
+    // OK-55397: silent-ready dialog removed — apply-on-restart is handled by
+    // the pending install task queued in readyToInstall. Nothing to show here.
+    // showSilentUpdateDialog();
     // deps: only re-run on status / strategy transitions.
     // appUpdateInfo is omitted intentionally — including the object ref
     // would re-fire on every unrelated field mutation.
-    // showSilentUpdateDialog is a stable callback ref, safe to omit.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, appUpdateInfo.status, appUpdateInfo.updateStrategy]);
 

--- a/packages/kit/src/components/AppUpdate/updateStrategy.ts
+++ b/packages/kit/src/components/AppUpdate/updateStrategy.ts
@@ -14,22 +14,19 @@ import {
   EAppUpdateStatus,
   EUpdateFileType,
   EUpdateStrategy,
+  isAutoUpdateStrategy,
 } from '@onekeyhq/shared/src/appUpdate';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+// Canonical `isAutoUpdateStrategy` now lives in `shared` so kit-bg services
+// can reuse it; re-export here so existing UI callers keep their import path.
+export { isAutoUpdateStrategy };
 
 /** Returns true when the strategy means "no user-visible toast on failure". */
 export const isShowToastError = (updateStrategy: EUpdateStrategy) => {
   return (
     updateStrategy !== EUpdateStrategy.silent &&
     updateStrategy !== EUpdateStrategy.seamless
-  );
-};
-
-/** Strategies that auto-download in the background without confirming. */
-export const isAutoUpdateStrategy = (updateStrategy: EUpdateStrategy) => {
-  return (
-    updateStrategy === EUpdateStrategy.silent ||
-    updateStrategy === EUpdateStrategy.seamless
   );
 };
 

--- a/packages/kit/src/components/AppUpdate/useAppUpdate.test.ts
+++ b/packages/kit/src/components/AppUpdate/useAppUpdate.test.ts
@@ -298,8 +298,8 @@ import {
   isAutoUpdateStrategy,
   isForceUpdateStrategy,
   isShowAppUpdateUIWhenUpdating,
-  isUnrecoverableDownloadError,
   isToolboxUpdateIndicatorRedundant,
+  isUnrecoverableDownloadError,
   runDownloadWithRetry,
   sanitizeUpdateErrorMessage,
   useDownloadPackage,
@@ -2349,7 +2349,13 @@ describe('useAppUpdateInfo useEffect', () => {
       );
     });
 
-    test('ready + silent strategy → shows silent update dialog', async () => {
+    test('ready + silent strategy → no dialog (applied on restart via pending task)', async () => {
+      // OK-55397: silent updates no longer pop a "ready" dialog. Once the
+      // silent download reaches `ready`, ServiceAppUpdate.readyToInstall has
+      // already queued a pending install task (silent is allowed past the
+      // strategy gate), which is applied on the next restart; the header /
+      // reminder update button offers an immediate restart-install. So the
+      // first-launch dispatch must NOT surface any dialog or navigation here.
       setAtom({
         status: EAppUpdateStatus.ready,
         updateStrategy: EUpdateStrategy.silent,
@@ -2361,19 +2367,13 @@ describe('useAppUpdateInfo useEffect', () => {
       const hooks = requireFreshHooks();
       renderHook(() => hooks.useAppUpdateInfo(false, true));
 
-      // showSilentUpdateDialog wraps three awaits inside a setTimeout
-      // (getUpdateInfo → whenAppUnlocked → showSilentUpdateDialogUI).
-      // jest.runAllTimers() is synchronous, so awaits inside the timer
-      // callback resolve outside the act() scope and React emits
-      // "act(async () => ...) without await". runAllTimersAsync awaits
-      // each scheduled microtask between fires, keeping every state
-      // update inside the act boundary.
       await act(async () => {
         await jest.runAllTimersAsync();
       });
 
-      // showSilentUpdateDialog uses setTimeout → Dialog.show
-      expect(mockDialogShow).toHaveBeenCalled();
+      expect(mockDialogShow).not.toHaveBeenCalled();
+      expect(nav.pushModal).not.toHaveBeenCalled();
+      expect(nav.pushFullModal).not.toHaveBeenCalled();
     });
 
     test('ready + manual strategy → shows regular update dialog', async () => {

--- a/packages/shared/src/appUpdate/index.ts
+++ b/packages/shared/src/appUpdate/index.ts
@@ -4,12 +4,22 @@ import platformEnv from '../platformEnv';
 import { syncStorage } from '../storage/instance/syncStorageInstance';
 import { EAppSyncStorageKeys } from '../storage/syncStorageKeys';
 
-import { EAppUpdateStatus, EUpdateFileType } from './type';
+import { EAppUpdateStatus, EUpdateFileType, EUpdateStrategy } from './type';
 
 import type { IAppUpdateInfo, IResolvedUpdateDecision } from './type';
 
 export * from './utils';
 export * from './type';
+
+/**
+ * Strategies that auto-download in the background without user confirmation
+ * (silent / seamless). Lives in `shared` so kit-bg services can gate
+ * auto-download decisions on it without importing from `kit`. The kit-side
+ * `updateStrategy.ts` re-exports this so UI callers keep their import path.
+ */
+export const isAutoUpdateStrategy = (updateStrategy: EUpdateStrategy) =>
+  updateStrategy === EUpdateStrategy.silent ||
+  updateStrategy === EUpdateStrategy.seamless;
 export {
   type IFeaturedItem,
   type IFeaturedChangelog,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55397](https://onekeyhq.atlassian.net/browse/OK-55397)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

This PR fixes two distinct facets of the same "must restart before an update happens" report (OK-55397):

1. **Download won't auto-start mid-session** — a server-pushed silent/seamless update discovered while the app is already running now starts downloading automatically, instead of stalling at `notify` until the next cold start.
2. **Silent install UX** — once a silent update finishes downloading, it is applied on the next restart via a pending install task (and an immediate restart-install button), instead of popping a "ready" dialog.

## Background / Problem

After the client detects a server-pushed update, **the download does not start immediately** — the app must be restarted before it begins downloading the install package.

Desktop log evidence (`desktop-macosStore`, `updateStrategy: 3 = seamless`): the cold-start `/utility/v1/app-update` check returned empty (`missing_release_versions`); the update was only discovered mid-session (after cold start) → status sat at `notify` but the download never started; `builtinBundleVersion` only incremented across restart boundaries.

## Root cause

The automatic background download is only ever triggered by the single cold-start check:

- The only automatic `downloadPackage()` is wired into the first-launch dispatch in `AppUpdateForeground.tsx`, guarded by the module-level `didRunFirstLaunchDispatch` flag, so it runs **exactly once per app process lifetime**.
- Nothing re-triggers it mid-session: the `AppState 'active'` listener only calls `shouldResumeStalledDownload()` (which resumes only `downloadPackageFailed`/`downloadASCFailed`); `fetchAppUpdateInfo` only auto-downloads for `jsBundleRollback`, while a normal `jsBundleUpgrade`/seamless upgrade just sets status to `notify`.
- Desktop works around this only via the manual menu (`onCheckUpdate`, gated by `isDesktop`); **native has no equivalent automatic trigger** → it is affected the same way (confirmed via a parallel investigation).

The `Bootstrap.tsx` comment already acknowledges this: "the auto useEffect only runs once at startup, so mid-session OTA discovery would otherwise stall".

## Changes

### 1. Auto-start the download mid-session (service layer; covers both desktop & native)
- `ServiceAppUpdate.fetchAppUpdateInfo`: after the status transitions to `notify`, auto-trigger `downloadPackage()` for `isAutoUpdateStrategy` (silent/seamless) `jsBundleUpgrade`/`appShellUpdate` decisions, symmetric to the existing `jsBundleRollback` auto-download (including the frozen/ignored target check and a `setTimeout` re-check of `notify` to avoid duplicate concurrent downloads). This mirrors the cold-start dispatch so mid-session discovery is handled identically.
- Added a shared `isAutoUpdateStrategy` (`shared/appUpdate`) and re-export it from kit's `updateStrategy.ts`, so kit-bg does not need to import from kit. Store-based app-shell updates are shipped as `manual` by the server, so they are naturally excluded.

### 2. Apply silent updates on restart instead of a "ready" dialog
- Silent updates no longer pop a "ready" dialog: `readyToInstall` already queues a pending install task (the `servicePendingInstallTask` strategy gate now allows `silent`), which is applied on the next restart; the header / reminder update button lets the user restart-install immediately.

## Testing / Validation

- ✅ `ServiceAppUpdate.test.ts` +5 cases (silent/seamless auto-download, manual does NOT download, frozen target does NOT download, rollback regression)
- ✅ Updated the affected silent-dialog case (`useAppUpdate.test.ts`) → asserts no dialog / no navigation
- ✅ All affected suites: 503 passed / 4 suites
- ✅ tsgo full-project type check: 0 errors
- ✅ eslint clean on changed files

[OK-55397]: https://onekeyhq.atlassian.net/browse/OK-55397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ