### PR TITLE
fix: stabilize swap selector flicker(OK-55966 OK-56173)

### DIFF
--- a/packages/kit-bg/src/services/ServiceDeFi.ts
+++ b/packages/kit-bg/src/services/ServiceDeFi.ts
@@ -29,12 +29,17 @@ import ServiceBase from './ServiceBase';
 
 import type { IDeFiDBStruct } from '../dbs/simple/entity/SimpleDbEntityDeFi';
 
+type IDeFiEnabledNetworksMapState = {
+  enabledNetworksMap: Record<string, boolean>;
+  isReady: boolean;
+};
+
 @backgroundClass()
 class ServiceDeFi extends ServiceBase {
   private enabledNetworksMapEmptyCacheExpiresAt = 0;
 
   private ensureEnabledNetworksMapPromise:
-    | Promise<Record<string, boolean>>
+    | Promise<IDeFiEnabledNetworksMapState>
     | undefined
     | null = null;
 
@@ -473,16 +478,28 @@ class ServiceDeFi extends ServiceBase {
 
   @backgroundMethod()
   public async getDeFiEnabledNetworksMap() {
+    const { enabledNetworksMap } = await this.getDeFiEnabledNetworksMapState();
+    return enabledNetworksMap;
+  }
+
+  @backgroundMethod()
+  public async getDeFiEnabledNetworksMapState(): Promise<IDeFiEnabledNetworksMapState> {
     const existing =
       (await this.backgroundApi.simpleDb.deFi.getEnabledNetworksMap()) ?? {};
     if (!isEmpty(existing)) {
       this.enabledNetworksMapEmptyCacheExpiresAt = 0;
-      return existing;
+      return {
+        enabledNetworksMap: existing,
+        isReady: true,
+      };
     }
 
     const now = Date.now();
     if (this.enabledNetworksMapEmptyCacheExpiresAt > now) {
-      return existing;
+      return {
+        enabledNetworksMap: existing,
+        isReady: false,
+      };
     }
 
     if (this.ensureEnabledNetworksMapPromise) {
@@ -497,13 +514,17 @@ class ServiceDeFi extends ServiceBase {
       }
       const refreshed =
         await this.backgroundApi.simpleDb.deFi.getEnabledNetworksMap();
-      const result = refreshed ?? {};
-      if (isEmpty(result)) {
+      const enabledNetworksMap = refreshed ?? {};
+      const isReady = !isEmpty(enabledNetworksMap);
+      if (!isReady) {
         this.enabledNetworksMapEmptyCacheExpiresAt = Date.now() + 30_000;
       } else {
         this.enabledNetworksMapEmptyCacheExpiresAt = 0;
       }
-      return result;
+      return {
+        enabledNetworksMap,
+        isReady,
+      };
     })().finally(() => {
       this.ensureEnabledNetworksMapPromise = null;
     });

--- a/packages/kit-bg/src/services/ServiceDeFi.ts
+++ b/packages/kit-bg/src/services/ServiceDeFi.ts
@@ -34,6 +34,10 @@ type IDeFiEnabledNetworksMapState = {
   isReady: boolean;
 };
 
+type IGetDeFiEnabledNetworksMapStateOptions = {
+  syncIfEmpty?: boolean;
+};
+
 @backgroundClass()
 class ServiceDeFi extends ServiceBase {
   private enabledNetworksMapEmptyCacheExpiresAt = 0;
@@ -483,7 +487,9 @@ class ServiceDeFi extends ServiceBase {
   }
 
   @backgroundMethod()
-  public async getDeFiEnabledNetworksMapState(): Promise<IDeFiEnabledNetworksMapState> {
+  public async getDeFiEnabledNetworksMapState(
+    options?: IGetDeFiEnabledNetworksMapStateOptions,
+  ): Promise<IDeFiEnabledNetworksMapState> {
     const existing =
       (await this.backgroundApi.simpleDb.deFi.getEnabledNetworksMap()) ?? {};
     if (!isEmpty(existing)) {
@@ -502,10 +508,21 @@ class ServiceDeFi extends ServiceBase {
       };
     }
 
+    if (options?.syncIfEmpty === false) {
+      void this._syncDeFiEnabledNetworksMapState();
+      return {
+        enabledNetworksMap: existing,
+        isReady: false,
+      };
+    }
+
+    return this._syncDeFiEnabledNetworksMapState();
+  }
+
+  private _syncDeFiEnabledNetworksMapState(): Promise<IDeFiEnabledNetworksMapState> {
     if (this.ensureEnabledNetworksMapPromise) {
       return this.ensureEnabledNetworksMapPromise;
     }
-
     this.ensureEnabledNetworksMapPromise = (async () => {
       try {
         await this.syncDeFiEnabledNetworks();

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -542,7 +542,9 @@ export default class ServiceSwap extends ServiceBase {
         clearCache: options?.refreshClientNetworks,
       });
     const deFiEnabledNetworksMapState =
-      await this.backgroundApi.serviceDeFi.getDeFiEnabledNetworksMapState();
+      await this.backgroundApi.serviceDeFi.getDeFiEnabledNetworksMapState({
+        syncIfEmpty: false,
+      });
     const swapNetworks = data?.data
       ?.map((network) => {
         const clientNetwork = allClientSupportNetworks.networks.find(

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -541,6 +541,8 @@ export default class ServiceSwap extends ServiceBase {
       await this.backgroundApi.serviceNetwork.getAllNetworks({
         clearCache: options?.refreshClientNetworks,
       });
+    const deFiEnabledNetworksMapState =
+      await this.backgroundApi.serviceDeFi.getDeFiEnabledNetworksMapState();
     const swapNetworks = data?.data
       ?.map((network) => {
         const clientNetwork = allClientSupportNetworks.networks.find(
@@ -553,6 +555,14 @@ export default class ServiceSwap extends ServiceBase {
             shortcode: clientNetwork.shortcode,
             logoURI: clientNetwork.logoURI,
             backendIndex: clientNetwork.backendIndex ?? false,
+            ...(deFiEnabledNetworksMapState.isReady
+              ? {
+                  isDeFiEnabled:
+                    !!deFiEnabledNetworksMapState.enabledNetworksMap[
+                      network.networkId
+                    ],
+                }
+              : {}),
             networkId: network.networkId,
             defaultSelectToken: network.defaultSelectToken,
             supportCrossChainSwap: network.supportCrossChainSwap,

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -22,7 +22,10 @@ import { memoFn } from '@onekeyhq/shared/src/utils/cacheUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import { equalsIgnoreCase } from '@onekeyhq/shared/src/utils/stringUtils';
-import { buildSwapAllNetworkTokenListCacheKey } from '@onekeyhq/shared/src/utils/tokenSelectorFilterUtils';
+import {
+  buildSwapAllNetworkTokenListCacheKey,
+  isTokenSelectorDappTokenFilterSupportedNetworkBase,
+} from '@onekeyhq/shared/src/utils/tokenSelectorFilterUtils';
 import {
   checkWrappedTokenPair,
   equalTokenNoCaseSensitive,
@@ -2268,7 +2271,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           ? swapSupportNetworks
           : swapSupportNetworks.filter((item) => item.supportLimit);
       const tokenListSupportNetworks = lpToken
-        ? currentTypeSupportNetworks.filter((item) => item.backendIndex)
+        ? currentTypeSupportNetworks.filter(
+            isTokenSelectorDappTokenFilterSupportedNetworkBase,
+          )
         : currentTypeSupportNetworks;
       const { accountIdKey, swapSupportAccounts } =
         await backgroundApiProxy.serviceSwap.getSupportSwapAllAccounts({

--- a/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
@@ -82,6 +82,8 @@ import {
 import { useSwapAddressInfo } from './useSwapAccount';
 import { useSwapProInputToken } from './useSwapPro';
 
+const SWAP_NETWORK_SCHEMA_RETRY_DELAY = 30_000;
+
 function getSelectedTokensColdStartSwapType({
   currentSwapType,
   fromToken,
@@ -617,7 +619,8 @@ export function useSwapInit(params?: ISwapInitParams) {
             data: networks,
           });
           setSwapNetworks(networks);
-          hasRefreshedSwapNetworksRef.current = true;
+          hasRefreshedSwapNetworksRef.current =
+            isSwapNetworkCacheCompatible(networks);
         }
       } catch {
         // The background method shows its own toast. Keep cached networks usable.
@@ -631,6 +634,18 @@ export function useSwapInit(params?: ISwapInitParams) {
     refreshSwapNetworksPromiseRef.current = refreshPromise;
     await refreshPromise;
   }, [setSwapNetworks]);
+
+  useEffect(() => {
+    if (!swapNetworks.length || isSwapNetworkCacheCompatible(swapNetworks)) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      void fetchSwapNetworks();
+    }, SWAP_NETWORK_SCHEMA_RETRY_DELAY);
+
+    return () => clearTimeout(timer);
+  }, [fetchSwapNetworks, swapNetworks]);
 
   const fetchSyncSwapProviderManager = useCallback(
     async (noFetch?: boolean) => {
@@ -1404,7 +1419,10 @@ export function useSwapInit(params?: ISwapInitParams) {
         }
       }
       if (isFocus) {
-        if (!swapNetworksRef.current.length) {
+        if (
+          !swapNetworksRef.current.length ||
+          !isSwapNetworkCacheCompatible(swapNetworksRef.current)
+        ) {
           void fetchSwapNetworks();
         }
         if (swapFromMarketJumpTokenRef.current?.token) {

--- a/packages/kit/src/views/Swap/hooks/useSwapTokens.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapTokens.ts
@@ -18,6 +18,7 @@ import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import {
   buildSwapAllNetworkTokenListCacheKey,
   filterTokenSelectorTokensByBackendIndexedNetworks,
+  isTokenSelectorDappTokenFilterSupportedNetworkBase,
 } from '@onekeyhq/shared/src/utils/tokenSelectorFilterUtils';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type {
@@ -242,7 +243,7 @@ export function useSwapTokenList(
       return filterTokenSelectorTokensByBackendIndexedNetworks({
         tokens: supportedTokens,
         backendIndexedNetworkIds: swapSupportAllNetworks
-          .filter((net) => net.backendIndex)
+          .filter(isTokenSelectorDappTokenFilterSupportedNetworkBase)
           .map((net) => net.networkId),
       });
     },

--- a/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
@@ -210,8 +210,11 @@ const SwapInputContainer = ({
     return cachedBalanceBN.isNaN() ? '' : cachedBalanceBN.toFixed();
   }, [address, balance, token?.accountAddress, token?.balanceParsed]);
   const showBalanceSkeleton = useMemo(
-    () => Boolean(token && !displayBalance && (balanceLoading || !balance)),
-    [balance, balanceLoading, displayBalance, token],
+    () =>
+      Boolean(
+        token && address && !displayBalance && (balanceLoading || !balance),
+      ),
+    [address, balance, balanceLoading, displayBalance, token],
   );
 
   const fromInputHasError = useMemo(() => {

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
@@ -227,6 +227,30 @@ const SwapTokenSelectPage = ({
     });
   }, [setCurrentSelectNetwork, syncDefaultNetworkSelect]);
 
+  useEffect(() => {
+    if (!currentSelectNetwork?.networkId) {
+      return;
+    }
+
+    const latestNetwork = swapNetworksIncludeAllNetwork.find(
+      (network) => network.networkId === currentSelectNetwork.networkId,
+    );
+    if (!latestNetwork || latestNetwork === currentSelectNetwork) {
+      return;
+    }
+
+    setCurrentSelectNetwork((prev) => {
+      if (!prev || prev.networkId !== latestNetwork.networkId) {
+        return prev;
+      }
+      return latestNetwork;
+    });
+  }, [
+    currentSelectNetwork,
+    setCurrentSelectNetwork,
+    swapNetworksIncludeAllNetwork,
+  ]);
+
   useEffect(
     () => () => {
       setCurrentSelectNetwork(undefined);

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
@@ -30,7 +30,6 @@ import { TokenListItem } from '@onekeyhq/kit/src/components/TokenListItem';
 import { TokenSelectorLpTokenSwitch } from '@onekeyhq/kit/src/components/TokenSelectorFilter';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
-import { useIsDeFiEnabled } from '@onekeyhq/kit/src/hooks/useIsDeFiEnabled';
 import { useAccountSelectorActions } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import {
   useSwapActions,
@@ -117,36 +116,26 @@ const SwapTokenSelectPage = ({
     useTokenSelectorFilterPersistAtom();
   const [currentSelectNetwork, setCurrentSelectNetwork] =
     useSwapSelectTokenNetworkAtom();
-  const currentSelectNetworkForDappTokenFilter = useMemo(() => {
-    if (!currentSelectNetwork) {
-      return undefined;
+  const showLpTokenFilterSwitch = useMemo(() => {
+    if (!SWAP_LP_TOKEN_FILTER_SERVER_SUPPORTED || !currentSelectNetwork) {
+      return false;
     }
 
-    if (currentSelectNetwork.isAllNetworks) {
-      return {
+    return isTokenSelectorDappTokenFilterSupportedNetwork({
+      network: {
         id: currentSelectNetwork.networkId,
-        isAllNetworks: true,
-      };
-    }
-
-    return {
-      id: currentSelectNetwork.networkId,
-      backendIndex: currentSelectNetwork.backendIndex,
-    };
-  }, [currentSelectNetwork]);
-  const isDeFiEnabled = useIsDeFiEnabled(
-    currentSelectNetwork?.networkId,
-    SWAP_LP_TOKEN_FILTER_SERVER_SUPPORTED,
-  );
-  const showLpTokenFilterSwitch =
-    SWAP_LP_TOKEN_FILTER_SERVER_SUPPORTED &&
-    isTokenSelectorDappTokenFilterSupportedNetwork({
-      network: currentSelectNetworkForDappTokenFilter,
-      isDeFiEnabled,
+        isAllNetworks: currentSelectNetwork.isAllNetworks,
+        backendIndex: currentSelectNetwork.backendIndex,
+      },
+      isDeFiEnabled: currentSelectNetwork.isAllNetworks
+        ? true
+        : currentSelectNetwork.isDeFiEnabled,
     });
+  }, [currentSelectNetwork]);
   const showLpTokensOnly = showLpTokenFilterSwitch
     ? tokenSelectorFilter.swapShowLpTokensOnly
     : false;
+  const requestLpToken = showLpTokenFilterSwitch ? showLpTokensOnly : undefined;
   const fromTokenRef = useRef<ISwapToken | undefined>(fromToken);
   const toTokenRef = useRef<ISwapToken | undefined>(toToken);
   const hasUserSelectedNetworkRef = useRef(false);
@@ -267,7 +256,7 @@ const SwapTokenSelectPage = ({
     currentSelectNetwork?.networkId,
     requestedSearchKeyword,
     swapTypeSwitch,
-    showLpTokenFilterSwitch ? showLpTokensOnly : undefined,
+    requestLpToken,
   );
   const alertIndex = useMemo(
     () =>

--- a/packages/kit/src/views/Swap/utils/swapNetworkCacheUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapNetworkCacheUtils.ts
@@ -13,7 +13,8 @@ function hasSwapNetworkSupportFields(network: ISwapNetwork) {
 export function isSwapNetworkReadyForTokenSelector(network: ISwapNetwork) {
   return (
     hasSwapNetworkSupportFields(network) &&
-    typeof network.backendIndex === 'boolean'
+    typeof network.backendIndex === 'boolean' &&
+    typeof network.isDeFiEnabled === 'boolean'
   );
 }
 
@@ -26,15 +27,7 @@ export function isSwapNetworkCacheCompatible(networks?: ISwapNetwork[] | null) {
 export function isSwapNetworkCacheReadyForBasicList(
   networks?: ISwapNetwork[] | null,
 ) {
-  return (
-    !!networks?.length &&
-    networks.every(
-      (network) =>
-        typeof network.networkId === 'string' &&
-        network.networkId.length > 0 &&
-        hasSwapNetworkSupportFields(network),
-    )
-  );
+  return isSwapNetworkCacheCompatible(networks);
 }
 
 export function canUseSwapNetworkCacheAsSortSource(
@@ -68,7 +61,11 @@ export function mergeSwapNetworksWithCachedSort({
       const fetchedNetwork = fetchedNetworks.find(
         (item) => item.networkId === network.networkId,
       );
-      return { ...network, ...fetchedNetwork };
+      const mergedNetwork = { ...network, ...fetchedNetwork };
+      if (typeof fetchedNetwork?.isDeFiEnabled !== 'boolean') {
+        delete mergedNetwork.isDeFiEnabled;
+      }
+      return mergedNetwork;
     })
     .concat(
       fetchedNetworks.filter(
@@ -87,6 +84,7 @@ export function buildSwapNetworkReadyKey(networks: ISwapNetwork[]) {
         network.supportCrossChainSwap,
         network.supportLimit,
         network.backendIndex,
+        network.isDeFiEnabled,
       ].join(':'),
     )
     .join('|');

--- a/packages/kit/src/views/Swap/utils/swapNetworkCacheUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapNetworkCacheUtils.ts
@@ -27,7 +27,15 @@ export function isSwapNetworkCacheCompatible(networks?: ISwapNetwork[] | null) {
 export function isSwapNetworkCacheReadyForBasicList(
   networks?: ISwapNetwork[] | null,
 ) {
-  return isSwapNetworkCacheCompatible(networks);
+  return (
+    !!networks?.length &&
+    networks.every(
+      (network) =>
+        typeof network.networkId === 'string' &&
+        network.networkId.length > 0 &&
+        hasSwapNetworkSupportFields(network),
+    )
+  );
 }
 
 export function canUseSwapNetworkCacheAsSortSource(

--- a/packages/shared/src/utils/tokenSelectorFilterUtils.test.ts
+++ b/packages/shared/src/utils/tokenSelectorFilterUtils.test.ts
@@ -1,6 +1,32 @@
-import { filterTokenSelectorTokensByBackendIndexedNetworks } from './tokenSelectorFilterUtils';
+import {
+  filterTokenSelectorTokensByBackendIndexedNetworks,
+  isTokenSelectorDappTokenFilterSupportedNetworkBase,
+} from './tokenSelectorFilterUtils';
 
 describe('tokenSelectorFilterUtils', () => {
+  describe('isTokenSelectorDappTokenFilterSupportedNetworkBase', () => {
+    it('requires backend indexing and DeFi support', () => {
+      expect(
+        isTokenSelectorDappTokenFilterSupportedNetworkBase({
+          backendIndex: true,
+          isDeFiEnabled: true,
+        }),
+      ).toBe(true);
+      expect(
+        isTokenSelectorDappTokenFilterSupportedNetworkBase({
+          backendIndex: true,
+          isDeFiEnabled: false,
+        }),
+      ).toBe(false);
+      expect(
+        isTokenSelectorDappTokenFilterSupportedNetworkBase({
+          backendIndex: false,
+          isDeFiEnabled: true,
+        }),
+      ).toBe(false);
+    });
+  });
+
   describe('filterTokenSelectorTokensByBackendIndexedNetworks', () => {
     it('keeps only tokens from backend-indexed networks', () => {
       expect(

--- a/packages/shared/src/utils/tokenSelectorFilterUtils.ts
+++ b/packages/shared/src/utils/tokenSelectorFilterUtils.ts
@@ -2,6 +2,16 @@ import type { IServerNetwork } from '../../types';
 
 export const TOKEN_SELECTOR_LP_TOKEN_FILTER_ENABLED = true;
 
+export function isTokenSelectorDappTokenFilterSupportedNetworkBase({
+  backendIndex,
+  isDeFiEnabled,
+}: {
+  backendIndex?: boolean;
+  isDeFiEnabled?: boolean;
+}) {
+  return backendIndex === true && isDeFiEnabled === true;
+}
+
 export function isTokenSelectorDappTokenFilterSupportedNetwork({
   network,
   isDeFiEnabled,
@@ -18,7 +28,10 @@ export function isTokenSelectorDappTokenFilterSupportedNetwork({
   if (network.isAllNetworks) {
     return true;
   }
-  return network.backendIndex === true && isDeFiEnabled === true;
+  return isTokenSelectorDappTokenFilterSupportedNetworkBase({
+    backendIndex: network.backendIndex,
+    isDeFiEnabled,
+  });
 }
 
 export function filterTokenSelectorTokensByBackendIndexedNetworks<

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -147,6 +147,7 @@ export interface ISwapNetwork extends ISwapNetworkBase {
   shortcode?: string;
   logoURI?: string;
   backendIndex?: boolean;
+  isDeFiEnabled?: boolean;
   isAllNetworks?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Move Swap LP filter capability into the swap network data model so the token selector can decide synchronously.
- Preserve the single-network support contract: LP filter is shown only when the network is backend-indexed and DeFi-enabled.
- Harden swap network cache migration so transient DeFi capability failures do not persist an incorrect all-false state.
- Remove the no-address balance loading skeleton in Swap input rows.

## Related Issues
- OK-55966: All Networks token selector flicker while switching same-chain / cross-chain selectors.
- OK-56173: Swap balance shows loading when no address exists.

## Intent & Context
The token selector LP filter was still flashing. The modal previously depended on an async DeFi-enabled hook, so the switch and token-list request parameters could change after the modal had already rendered. That caused visible switch flicker and token-list loading resets.

The same investigation also touched the Swap input balance loading issue: when there is no address, the balance skeleton should not be shown because there is no valid balance request to wait for.

Swap is a core revenue path, so the fix keeps the behavioral surface narrow: it does not touch quotes, provider selection, slippage, approval, risk checks, transaction building, or sending.

## Root Cause
LP filter visibility was derived from asynchronous DeFi capability state inside the token selector modal. The modal could render before that state resolved, then re-render with a different `lpToken` request parameter. Old or transiently incomplete network cache data could also make the selector render with an imprecise support state.

The no-address balance loading issue came from showing the balance skeleton whenever a token existed and balance was empty/loading, even when there was no address for that side of the Swap input.

## Design Decisions
- Add `isDeFiEnabled` to `ISwapNetwork` and populate it in `ServiceSwap.fetchSwapNetworks()` from `ServiceDeFi` so the modal has a stable synchronous capability signal.
- Keep the shared support rule for single networks: `backendIndex === true && isDeFiEnabled === true`. All Networks keeps the existing broad support behavior.
- Treat an empty DeFi-enabled map as unknown, not as confirmed false, when it cannot be proven ready.
- Mark swap network caches as selector-ready only when the new capability schema is complete.
- Add retry/focus recovery for incomplete network schemas, using the existing refresh promise guard to avoid concurrent request amplification.
- Require `address` before showing the Swap input balance skeleton.

## Changes Detail
- `ServiceDeFi`: adds a stateful DeFi-enabled network map getter that distinguishes ready vs unknown.
- `ServiceSwap`: attaches `isDeFiEnabled` to swap network results only when the DeFi map is ready.
- `swapNetworkCacheUtils`: requires `isDeFiEnabled` for selector-ready network cache, includes it in ready keys, and prevents old bad cached values from surviving merges.
- `useSwapGlobal`: only marks a network refresh complete when the refreshed schema is compatible, and retries incomplete schemas on focus or after the DeFi empty-cache TTL.
- `SwapTokenSelectModal`: removes the async DeFi hook and computes LP filter visibility synchronously from the selected network.
- `SwapInputContainer`: prevents balance skeleton display before an address exists.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Web / Mobile / Extension token selector surfaces that share Swap modal logic
- **Risk Areas**: Swap token selector cache migration, LP filter visibility, all-network token loading, no-address balance display
- **Mitigations**: Kept transaction execution paths untouched, preserved the shared LP support contract, added cache readiness guards, and reviewed the change with multiple static passes focused on Swap regressions.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged` before rebase
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings <changed files>` after rebase
- [x] `git diff --check`
- [x] Desktop runtime verification through Electron CDP: Ethereum, BNB Chain, and All Networks show the LP filter; HyperEVM does not.
- [x] Desktop runtime request verification: supported networks send `lpToken=false` when the LP switch is off; HyperEVM single-network token requests omit `lpToken`.
- [x] Desktop runtime sampling: no token-list loading or empty-state flicker was observed while switching Ethereum / All Networks / HyperEVM / BNB Chain.
- [ ] `yarn tsc:staged` after rebase is currently blocked by unrelated existing type errors in `packages/components/src/composite/SegmentSlider/index.native.tsx` and `packages/kit/src/components/TradingView/ChartWebView/index.native.tsx`; these files are not part of this PR diff.