### PR TITLE
fix: resolve perps QA issues OK-56181 OK-56179 OK-56177

### DIFF
--- a/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
@@ -783,7 +783,6 @@ class ServiceWebviewPerp extends ServiceBase {
     }
     const customLocalStorage: Record<string, any> = {
       'hyperliquid.coin_selector.tab': `"perps"`, // "perps", "all", "spot"
-      'activeCoin': 'BTC', // do not use `"BTC"`
       ...hyperliquidCustomLocalStorage,
     };
     if (localeStr) {

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/CommonTableListView.tsx
@@ -753,7 +753,7 @@ export function CommonTableListView<T>({
     </XStack>
   );
   const desktopTable = (
-    <XStack>
+    <XStack flex={1}>
       {/* Scrollable columns */}
       <ScrollView
         ref={scrollViewRef}
@@ -822,17 +822,16 @@ export function CommonTableListView<T>({
           cursor="default"
           bg="$bgApp"
           $platform-web={{
-            boxShadow:
-              showFixedShadow && paginatedData.length > 0
-                ? getWebShadowStyle('right', isDark)
-                : 'none',
+            boxShadow: showFixedShadow
+              ? getWebShadowStyle('right', isDark)
+              : 'none',
             clipPath: getWebClipPath('right'),
             transition: `box-shadow ${SHADOW_CONSTANTS.TRANSITION_DURATION} ease-in-out`,
           }}
         >
           <FixedColumnShadowOverlay
             position="right"
-            visible={showFixedShadow ? paginatedData.length > 0 : false}
+            visible={showFixedShadow}
             isDark={isDark}
           />
           <XStack

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
@@ -209,6 +209,11 @@ export const SizeInput = memo(
         setUsdAmount('');
         setMarginAmount('');
         setIsUserTyping(false);
+        onDisplayValueChange?.({
+          inputMode,
+          displayValue: '',
+          tokenValue: '',
+        });
         return;
       }
 
@@ -234,6 +239,7 @@ export const SizeInput = memo(
       marginAmount,
       calcUsdFromToken,
       calcMarginFromToken,
+      onDisplayValueChange,
     ]);
 
     // Effect: Leverage change handling

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
@@ -20,11 +20,20 @@ import { TradingFormInput } from './TradingFormInput';
 
 import type { ISide } from '../selectors/TradeSideToggle';
 
+type ISizeInputUnit = 'token' | 'usd' | 'margin';
+
+export type ISizeInputDisplayValueChangePayload = {
+  inputMode: ISizeInputUnit;
+  displayValue: string;
+  tokenValue: string;
+};
+
 interface ISizeInputProps {
   value: string;
   side: ISide;
   symbol: string;
   onChange: (value: string) => void;
+  onDisplayValueChange?: (payload: ISizeInputDisplayValueChangePayload) => void;
   activeAsset: IPerpsActiveAssetAtom;
   isAssetCtxReady: boolean;
   referencePrice: string;
@@ -43,6 +52,7 @@ export const SizeInput = memo(
   ({
     value,
     onChange,
+    onDisplayValueChange,
     symbol,
     activeAsset,
     isAssetCtxReady,
@@ -64,8 +74,9 @@ export const SizeInput = memo(
 
     const [tradingPreferences, setTradingPreferences] =
       usePerpsTradingPreferencesAtom();
-    const rawInputMode = tradingPreferences.sizeInputUnit ?? 'usd';
-    const inputMode =
+    const rawInputMode: ISizeInputUnit =
+      tradingPreferences.sizeInputUnit ?? 'usd';
+    const inputMode: ISizeInputUnit =
       !allowMarginInput && rawInputMode === 'margin' ? 'usd' : rawInputMode;
     const setInputMode = useCallback(
       (mode: 'token' | 'usd' | 'margin') => {
@@ -85,6 +96,9 @@ export const SizeInput = memo(
     const prevValueRef = useRef(value);
     const prevPriceRef = useRef(referencePrice);
     const prevLeverageRef = useRef(leverage);
+    const preserveRawInputOnEmptyValueRef = useRef<'usd' | 'margin' | null>(
+      null,
+    );
 
     const isSliderMode = sizeInputMode === 'slider';
 
@@ -177,6 +191,21 @@ export const SizeInput = memo(
       prevValueRef.current = value;
 
       if (!value) {
+        const preserveRawInputMode = preserveRawInputOnEmptyValueRef.current;
+        preserveRawInputOnEmptyValueRef.current = null;
+
+        if (
+          isUserTyping &&
+          ((preserveRawInputMode === 'usd' &&
+            inputMode === 'usd' &&
+            usdAmount) ||
+            (preserveRawInputMode === 'margin' &&
+              inputMode === 'margin' &&
+              marginAmount))
+        ) {
+          return;
+        }
+
         setUsdAmount('');
         setMarginAmount('');
         setIsUserTyping(false);
@@ -197,7 +226,15 @@ export const SizeInput = memo(
           if (usdValue) setUsdAmount(usdValue);
         }
       }
-    }, [value, inputMode, isUserTyping, calcUsdFromToken, calcMarginFromToken]);
+    }, [
+      value,
+      inputMode,
+      isUserTyping,
+      usdAmount,
+      marginAmount,
+      calcUsdFromToken,
+      calcMarginFromToken,
+    ]);
 
     // Effect: Leverage change handling
     useEffect(() => {
@@ -320,16 +357,35 @@ export const SizeInput = memo(
 
         if (inputMode === 'token') {
           setTokenAmount(newValue);
+          onDisplayValueChange?.({
+            inputMode,
+            displayValue: newValue,
+            tokenValue: newValue,
+          });
           onChange(newValue);
         } else if (inputMode === 'usd') {
           setUsdAmount(newValue);
           const tokenValue = calcTokenFromUsd(newValue);
+          preserveRawInputOnEmptyValueRef.current =
+            newValue && !tokenValue ? 'usd' : null;
           setTokenAmount(tokenValue);
+          onDisplayValueChange?.({
+            inputMode,
+            displayValue: newValue,
+            tokenValue,
+          });
           onChange(tokenValue);
         } else {
           setMarginAmount(newValue);
           const tokenValue = calcTokenFromMargin(newValue);
+          preserveRawInputOnEmptyValueRef.current =
+            newValue && !tokenValue ? 'margin' : null;
           setTokenAmount(tokenValue);
+          onDisplayValueChange?.({
+            inputMode,
+            displayValue: newValue,
+            tokenValue,
+          });
           onChange(tokenValue);
         }
       },
@@ -337,6 +393,7 @@ export const SizeInput = memo(
         isSliderMode,
         inputMode,
         onChange,
+        onDisplayValueChange,
         calcTokenFromUsd,
         calcTokenFromMargin,
         onRequestManualMode,
@@ -352,25 +409,38 @@ export const SizeInput = memo(
         setInputMode(mode);
         setIsUserTyping(false);
 
+        let displayValue = '';
         if (mode === 'usd' && tokenAmount) {
           const usdValue = calcUsdFromToken(tokenAmount);
           if (usdValue) setUsdAmount(usdValue);
+          displayValue = usdValue || usdAmount;
           const marginValue = calcMarginFromToken(tokenAmount);
           if (marginValue) setMarginAmount(marginValue);
         } else if (mode === 'token' && tokenAmount) {
+          displayValue = tokenAmount;
           const marginValue = calcMarginFromToken(tokenAmount);
           if (marginValue) setMarginAmount(marginValue);
         } else if (mode === 'margin' && tokenAmount) {
           const marginValue = calcMarginFromToken(tokenAmount);
           if (marginValue) setMarginAmount(marginValue);
+          displayValue = marginValue || marginAmount;
         }
+
+        onDisplayValueChange?.({
+          inputMode: mode,
+          displayValue,
+          tokenValue: tokenAmount,
+        });
       },
       [
         inputMode,
         tokenAmount,
+        usdAmount,
+        marginAmount,
         calcUsdFromToken,
         calcMarginFromToken,
         onRequestManualMode,
+        onDisplayValueChange,
         setInputMode,
       ],
     );

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -98,7 +98,10 @@ import {
 import { PerpsSlider } from '../../PerpsSlider';
 import { PerpsAccountNumberValue } from '../components/PerpsAccountNumberValue';
 import { PriceInput } from '../inputs/PriceInput';
-import { SizeInput } from '../inputs/SizeInput';
+import {
+  type ISizeInputDisplayValueChangePayload,
+  SizeInput,
+} from '../inputs/SizeInput';
 import { TpSlFormInput } from '../inputs/TpSlFormInput';
 import { TradingFormInput } from '../inputs/TradingFormInput';
 import { LeverageAdjustModal } from '../modals/LeverageAdjustModal';
@@ -118,6 +121,7 @@ type IPrimaryOrderType = 'market' | 'limit' | 'trigger';
 type ITriggerDropdownValue = ETriggerOrderType | 'scale' | 'twap';
 type ITwapDurationInputField = 'hours' | 'minutes';
 type IOrderTypeInfoValue = IPrimaryOrderType | ITriggerDropdownValue;
+type ISizeInputDraft = ISizeInputDisplayValueChangePayload;
 type IOrderTypeInfoItem = {
   description: string;
   helpUrl?: string;
@@ -462,6 +466,9 @@ function PerpTradingForm({
   const [, setTradingFormEnv] = useTradingFormEnvAtom();
   const tradingComputed = useTradingFormSizeInputComputed();
   const advancedComputedSizeBN = useTradingFormComputedSize();
+  const [sizeInputDraft, setSizeInputDraft] = useState<
+    ISizeInputDraft | undefined
+  >();
   const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const isSpot = activeTradeInstrument.mode === 'spot';
   const shouldUseLiveTradingPrice = Boolean(
@@ -560,6 +567,27 @@ function PerpTradingForm({
   const isSelectedTradeAssetCtxReady = isSpot
     ? isSpotActiveAssetCtxReady
     : isPerpsActiveAssetCtxReady;
+  const handleSizeInputDisplayValueChange = useCallback(
+    (payload: ISizeInputDraft) => {
+      setSizeInputDraft(payload);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    setSizeInputDraft(undefined);
+  }, [
+    activeTradeInstrument.assetId,
+    activeTradeInstrument.mode,
+    formData.side,
+    selectedTradeAsset?.coin,
+  ]);
+
+  useEffect(() => {
+    if (formData.sizeInputMode === EPerpsSizeInputMode.SLIDER) {
+      setSizeInputDraft(undefined);
+    }
+  }, [formData.sizeInputMode]);
 
   const spotAvailableBaseBN = useMemo(() => {
     if (!spotUniverse?.baseName) {
@@ -1049,6 +1077,45 @@ function PerpTradingForm({
     }
   }, [formData.twapDurationMinutes, intl, isTwapMode]);
 
+  const twapEstimatedOrderNotional = useMemo(() => {
+    if (!isTwapMode) {
+      return undefined;
+    }
+    if (!midPriceBN.isFinite() || midPriceBN.lte(0)) {
+      return undefined;
+    }
+
+    const draft = sizeInputDraft;
+    const draftDisplayValue = draft?.displayValue?.trim();
+    if (draft && draftDisplayValue) {
+      const draftDisplayValueBN = new BigNumber(draftDisplayValue);
+      if (draftDisplayValueBN.isFinite() && draftDisplayValueBN.gt(0)) {
+        if (draft.inputMode === 'usd') {
+          return draftDisplayValueBN;
+        }
+        if (draft.inputMode === 'margin') {
+          const leverageBN = new BigNumber(formData.leverage ?? 1);
+          return draftDisplayValueBN.multipliedBy(
+            leverageBN.isFinite() && leverageBN.gt(0) ? leverageBN : 1,
+          );
+        }
+        return draftDisplayValueBN.multipliedBy(midPriceBN);
+      }
+    }
+
+    if (!advancedComputedSizeBN.isFinite() || advancedComputedSizeBN.lte(0)) {
+      return undefined;
+    }
+
+    return advancedComputedSizeBN.multipliedBy(midPriceBN);
+  }, [
+    advancedComputedSizeBN,
+    formData.leverage,
+    isTwapMode,
+    midPriceBN,
+    sizeInputDraft,
+  ]);
+
   const twapEstimatedSliceNotional = useMemo(() => {
     if (!isTwapMode) {
       return undefined;
@@ -1058,10 +1125,9 @@ function PerpTradingForm({
       !Number.isInteger(duration) ||
       duration < TWAP_MIN_DURATION_MINUTES ||
       duration > TWAP_MAX_DURATION_MINUTES ||
-      !advancedComputedSizeBN.isFinite() ||
-      advancedComputedSizeBN.lte(0) ||
-      !midPriceBN.isFinite() ||
-      midPriceBN.lte(0)
+      !twapEstimatedOrderNotional ||
+      !twapEstimatedOrderNotional.isFinite() ||
+      twapEstimatedOrderNotional.lte(0)
     ) {
       return undefined;
     }
@@ -1070,20 +1136,14 @@ function PerpTradingForm({
       1,
       Math.ceil(duration / TWAP_ESTIMATED_SLICE_INTERVAL_MINUTES),
     );
-    const estimatedSliceNotional = advancedComputedSizeBN
-      .multipliedBy(midPriceBN)
-      .dividedBy(estimatedSlices);
+    const estimatedSliceNotional =
+      twapEstimatedOrderNotional.dividedBy(estimatedSlices);
     if (!estimatedSliceNotional.isFinite() || estimatedSliceNotional.lte(0)) {
       return undefined;
     }
 
     return estimatedSliceNotional;
-  }, [
-    formData.twapDurationMinutes,
-    isTwapMode,
-    midPriceBN,
-    advancedComputedSizeBN,
-  ]);
+  }, [formData.twapDurationMinutes, isTwapMode, twapEstimatedOrderNotional]);
 
   const twapEstimatedSliceNotionalDisplay = useMemo(() => {
     if (!twapEstimatedSliceNotional) {
@@ -3016,6 +3076,7 @@ function PerpTradingForm({
         symbol={activeBaseName || perpsSelectedDisplayName}
         value={formData.size}
         onChange={handleManualSizeChange}
+        onDisplayValueChange={handleSizeInputDisplayValueChange}
         sizeInputMode={tradingComputed.sizeInputMode}
         sliderPercent={tradingComputed.sizePercent}
         onRequestManualMode={switchToManual}

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -569,7 +569,7 @@ function PerpTradingForm({
     : isPerpsActiveAssetCtxReady;
   const handleSizeInputDisplayValueChange = useCallback(
     (payload: ISizeInputDraft) => {
-      setSizeInputDraft(payload);
+      setSizeInputDraft(payload.displayValue.trim() ? payload : undefined);
     },
     [],
   );


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56181](https://onekeyhq.atlassian.net/browse/OK-56181) [OK-56179](https://onekeyhq.atlassian.net/browse/OK-56179) [OK-56177](https://onekeyhq.atlassian.net/browse/OK-56177)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Preserve the selected Perps chart coin when developer mode changes the TradingView URL.
- Keep the TWAP order list empty state stable and restore the fixed-column shadow when the list is empty.
- Stabilize TWAP sizing display for assets whose USD or margin input truncates below the Hyperliquid lot size.

## Intent & Context
This PR handles three Jira QA issues created in the Perps batch. The requested workflow was to fix the issues one pass at a time, let QA compare against the old version, and keep the final branch as three commits corresponding to the three issues: OK-56181, OK-56179, and OK-56177.

## Root Cause
- OK-56181: When developer mode changed the TradingView URL, the Perps WebView reloaded and the service-created chart state supplied a default BTC active coin, so the K-line could fall back to BTC instead of staying on the selected market.
- OK-56179: The desktop TWAP list empty state did not consistently fill the table body area, and the fixed-column shadow was skipped when the list had no rows.
- OK-56177: TWAP display math depended only on the submitted token size. For assets such as MRVL, a USD or margin input can convert to a token size below the Hyperliquid lot-size precision and become an empty wire-safe size. That made the TWAP helper and child-order-size display mount and unmount while the user was still editing.

## Design Decisions
- The chart fix removes the unintended BTC default instead of preventing the WebView reload. Reloading is expected when the TradingView base URL changes; the fix is to avoid resetting the selected market during that reload.
- The TWAP empty-state fix keeps the table layout behavior local to the list view and preserves the fixed-column visual affordance even when there are no rows.
- The TWAP sizing fix keeps order submission strict: submitted sizes still use the floor-truncated Hyperliquid token size. The display layer now also receives the raw size-input draft so TWAP estimates can remain stable while the actual order size is still invalid or empty.
- A helper debounce was rejected because it hid the flicker without fixing the unstable source of truth. The final implementation removes the debounce and derives display state from stable draft notional data.

## Changes Detail
- `packages/kit-bg/src/services/ServiceWebviewPerp.ts`: stop seeding a default BTC active coin for newly created Perps chart state.
- `packages/kit/src/components/Table/ListView/CommonTableListView.tsx`: let the desktop empty state fill the table body and keep the fixed-column shadow visible for empty tables.
- `packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx`: report the raw size input draft alongside the wire-safe token size, and preserve raw USD or margin input while the converted token size truncates to empty.
- `packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx`: compute TWAP display notional from the raw size draft when available, fall back to computed token size otherwise, and render the helper directly without debounce.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Desktop, Web, Extension
- **Risk Areas**: Perps order panel display math, TWAP helper display, Perps TradingView reload behavior, and shared table empty-state rendering.

## Test plan
- [ ] Verify OK-56181: enable/disable developer mode and confirm the Perps K-line stays on the selected market instead of resetting to BTC.
- [ ] Verify OK-56179: open the TWAP order list empty state and confirm the empty content remains visually stable with the fixed-column shadow present.
- [ ] Verify OK-56177: on MRVL with TWAP duration 10 min, enter and delete values such as 200 -> 20 -> 2 in USD or margin mode and confirm the input and TWAP display do not flicker while invalid lot-size values remain unsubmitable.
- [x] Ran `yarn lint:staged`.
- [x] Ran targeted `oxlint --type-aware` for the changed Perps form files.
- [x] Ran targeted `tsgo` filtering for `SizeInput.tsx` and `PerpTradingForm.tsx` with no errors from these files.
- [x] Reloaded the iPhone 16 Pro Simulator through Metro and confirmed no red screen or JS fatal error.

## Known Verification Gap
`yarn tsc:staged` is currently blocked by pre-existing unrelated TypeScript errors in `AnimatedDepthBlock.native.tsx` and `thirdPartyHardwareErrors` / `thirdPartyDeviceErrorUtils` around `ThirdPartyHwErrorCode.NetworkError`.

[OK-56181]: https://onekeyhq.atlassian.net/browse/OK-56181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-56179]: https://onekeyhq.atlassian.net/browse/OK-56179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-56177]: https://onekeyhq.atlassian.net/browse/OK-56177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ