### PR TITLE
fix: adjust market mobile network selector height(OK-56139)

### DIFF
--- a/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorListView.tsx
+++ b/packages/kit/src/views/ChainSelector/components/PureChainSelector/ChainSelectorListView.tsx
@@ -47,6 +47,7 @@ type IChainSelectorListViewProps = {
   networkId?: string;
   isOpen?: boolean;
   onPressItem?: (network: IServerNetworkMatch) => void;
+  onSearchFocusChange?: (isFocused: boolean) => void;
   accountNetworkValues?: Record<string, string>;
   accountNetworkValueCurrency?: string;
   hideLowValueNetworkValue?: boolean;
@@ -172,6 +173,7 @@ export const ChainSelectorListView: FC<IChainSelectorListViewProps> = ({
   networkId,
   isOpen,
   onPressItem,
+  onSearchFocusChange,
   accountNetworkValues,
   accountNetworkValueCurrency,
   hideLowValueNetworkValue,
@@ -181,6 +183,12 @@ export const ChainSelectorListView: FC<IChainSelectorListViewProps> = ({
   const onChangeText = useCallback((value: string) => {
     setText(value);
   }, []);
+  const handleSearchFocus = useCallback(() => {
+    onSearchFocusChange?.(true);
+  }, [onSearchFocusChange]);
+  const handleSearchBlur = useCallback(() => {
+    onSearchFocusChange?.(false);
+  }, [onSearchFocusChange]);
 
   const networkFuseSearch = useFuseSearch(networks);
 
@@ -208,6 +216,8 @@ export const ChainSelectorListView: FC<IChainSelectorListViewProps> = ({
           placeholder={intl.formatMessage({ id: ETranslations.global_search })}
           value={text}
           onChangeText={onChangeText}
+          onFocus={handleSearchFocus}
+          onBlur={handleSearchBlur}
         />
       </Stack>
       <Stack flex={1} minHeight={0}>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenListNetworkSelector/NetworksSearchPanel.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenListNetworkSelector/NetworksSearchPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { ComponentProps, FC } from 'react';
 
 import { Stack } from '@onekeyhq/components';
@@ -10,14 +10,16 @@ import {
 import type { IServerNetwork } from '@onekeyhq/shared/types';
 
 export const NETWORKS_SEARCH_PANEL_MAX_HEIGHT = 420;
+export const NETWORKS_SEARCH_PANEL_FOCUSED_HEIGHT_REDUCTION = 100;
 
 const NETWORKS_SEARCH_PANEL_BASE_HEIGHT = 92;
 
 export interface INetworksSearchPanelProps extends Omit<
   ComponentProps<typeof ChainSelectorListView>,
-  'networks'
+  'networks' | 'onSearchFocusChange'
 > {
   networks?: IServerNetwork[];
+  focusedPanelHeightReduction?: number;
   onNetworkSelect?: (network: IServerNetwork) => void;
 }
 
@@ -25,8 +27,10 @@ export const NetworksSearchPanel: FC<INetworksSearchPanelProps> = ({
   networks: networksProp,
   networkId,
   isOpen,
+  focusedPanelHeightReduction = 0,
   onNetworkSelect,
 }) => {
+  const [isSearchFocused, setIsSearchFocused] = useState(false);
   const networksForListView = useMemo(() => {
     if (!networksProp?.length) return [];
     return networksProp.filter(
@@ -34,15 +38,24 @@ export const NetworksSearchPanel: FC<INetworksSearchPanelProps> = ({
     ) as IServerNetworkMatch[];
   }, [networksProp]);
 
+  const panelMaxHeight =
+    isSearchFocused && focusedPanelHeightReduction > 0
+      ? NETWORKS_SEARCH_PANEL_MAX_HEIGHT - focusedPanelHeightReduction
+      : NETWORKS_SEARCH_PANEL_MAX_HEIGHT;
+
   const panelHeight = useMemo(
     () =>
       Math.min(
-        NETWORKS_SEARCH_PANEL_MAX_HEIGHT,
+        panelMaxHeight,
         NETWORKS_SEARCH_PANEL_BASE_HEIGHT +
           networksForListView.length * CELL_HEIGHT,
       ),
-    [networksForListView.length],
+    [panelMaxHeight, networksForListView.length],
   );
+
+  const handleSearchFocusChange = useCallback((isFocused: boolean) => {
+    setIsSearchFocused(isFocused);
+  }, []);
 
   const handleNetworkPress = (network: IServerNetworkMatch) => {
     // Find the original ISwapNetwork to pass back
@@ -62,6 +75,7 @@ export const NetworksSearchPanel: FC<INetworksSearchPanelProps> = ({
         networkId={networkId}
         networks={networksForListView}
         onPressItem={handleNetworkPress}
+        onSearchFocusChange={handleSearchFocusChange}
       />
     </Stack>
   );

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MobileNetworkDropdown/MobileNetworkDropdown.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MobileNetworkDropdown/MobileNetworkDropdown.tsx
@@ -10,11 +10,13 @@ import {
   XStack,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import type { IServerNetwork } from '@onekeyhq/shared/types';
 
 import { useMarketNetworks } from '../../../hooks/useMarketNetworks';
 import {
+  NETWORKS_SEARCH_PANEL_FOCUSED_HEIGHT_REDUCTION,
   NETWORKS_SEARCH_PANEL_MAX_HEIGHT,
   NetworksSearchPanel,
 } from '../MarketTokenListNetworkSelector/NetworksSearchPanel';
@@ -30,6 +32,9 @@ function MobileNetworkDropdownImpl({
 }: IMobileNetworkDropdownProps) {
   const intl = useIntl();
   const { marketNetworks } = useMarketNetworks();
+  const focusedPanelHeightReduction = platformEnv.isNative
+    ? NETWORKS_SEARCH_PANEL_FOCUSED_HEIGHT_REDUCTION
+    : 0;
 
   const selectedNetwork = useMemo(
     () => marketNetworks.find((n) => n.id === selectedNetworkId),
@@ -83,13 +88,19 @@ function MobileNetworkDropdownImpl({
         isOpen={isOpen}
         networks={marketNetworks}
         networkId={selectedNetworkId}
+        focusedPanelHeightReduction={focusedPanelHeightReduction}
         onNetworkSelect={(network) => {
           handleNetworkSelect(network);
           closePopover();
         }}
       />
     ),
-    [marketNetworks, selectedNetworkId, handleNetworkSelect],
+    [
+      focusedPanelHeightReduction,
+      marketNetworks,
+      selectedNetworkId,
+      handleNetworkSelect,
+    ],
   );
 
   return (


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56139](https://onekeyhq.atlassian.net/browse/OK-56139)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Reduce the native mobile Market network selector panel height by 100 only while its search input is focused.
- Keep the default panel height unchanged for normal native mobile usage and all web usage.
- Expose search focus state from the shared chain selector list so the Market panel can react without keyboard-height logic.

## Intent & Context
The Market Home mobile tab content has a network selector dialog. When the user focuses the network search input on native mobile, the soft keyboard pushes the sheet upward and the original list height is too tall. The requested behavior was refined to use input focus, not keyboard height, and to avoid affecting web.

## Root Cause
The network selector panel height was derived from a fixed maximum of 420 plus content sizing. On native mobile, focusing the search field brings up the keyboard, but the panel kept the same maximum height and visually occupied too much space.

## Design Decisions
- Use the search input focus state instead of keyboard visibility or keyboard height.
- Reduce only the maximum panel height from 420 to 320 while focused; short lists still use their natural content height.
- Gate the reduction with `platformEnv.isNative` in `MobileNetworkDropdown`, so web mobile and desktop behavior stays unchanged.
- Avoid minimum-height fallback logic because the requested behavior only needs a smaller max height.

## Changes Detail
- `ChainSelectorListView.tsx`: adds an optional `onSearchFocusChange` callback and wires it to the search bar focus and blur events.
- `NetworksSearchPanel.tsx`: tracks the search focus state and applies an optional focused height reduction to the panel maximum height.
- `MobileNetworkDropdown.tsx`: enables the 100px focused height reduction only on native platforms.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile native only
- **Risk Areas**: Shared `ChainSelectorListView` receives a new optional callback, but existing call sites are unaffected unless they pass the prop.

## Test plan
- [x] `yarn lint:staged`
- [ ] `yarn tsc:staged` (blocked by unrelated baseline native type errors in `SegmentSlider` and `ChartWebView` on current `origin/x`)
- [ ] On native mobile, open Market Home, open the network selector, focus the search input, and verify the panel height is reduced.
- [ ] Blur the search input and verify the panel returns to its normal height.
- [ ] Verify web Market network selector height is unchanged.

[OK-56139]: https://onekeyhq.atlassian.net/browse/OK-56139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ