### PR TITLE
fix: adjust swap mobile slippage rate row

### DIFF
--- a/packages/kit/src/views/Swap/components/SwapQuoteResultRate.tsx
+++ b/packages/kit/src/views/Swap/components/SwapQuoteResultRate.tsx
@@ -5,6 +5,8 @@ import { useIntl } from 'react-intl';
 
 import {
   Badge,
+  type ColorTokens,
+  Divider,
   Icon,
   Image,
   LottieView,
@@ -25,6 +27,10 @@ import SwapRefreshButton from './SwapRefreshButton';
 interface ISwapQuoteResultRateProps {
   rate?: string;
   isBest?: boolean;
+  showBestBadge?: boolean;
+  customSlippageValue?: string;
+  customSlippageTextColor?: ColorTokens;
+  customSlippageIconColor?: ColorTokens;
   fromToken?: ISwapToken;
   toToken?: ISwapToken;
   providerIcon?: string;
@@ -38,6 +44,10 @@ interface ISwapQuoteResultRateProps {
 const SwapQuoteResultRate = ({
   rate,
   isBest,
+  showBestBadge = true,
+  customSlippageValue,
+  customSlippageTextColor = '$textSubdued',
+  customSlippageIconColor = '$iconSubdued',
   quoting,
   fromToken,
   toToken,
@@ -56,7 +66,7 @@ const SwapQuoteResultRate = ({
   const rateContent = useMemo(() => {
     if (!onOpenResult || !fromToken || !toToken) {
       return (
-        <SizableText size="$bodyMdMedium">
+        <SizableText size="$bodyMdMedium" flexShrink={1} minWidth={0}>
           {intl.formatMessage({
             id: ETranslations.swap_page_provider_provider_insufficient_liquidity,
           })}
@@ -65,7 +75,7 @@ const SwapQuoteResultRate = ({
     }
     if (!rateIsExit) {
       return (
-        <SizableText ml="$1" size="$bodyMd">
+        <SizableText ml="$1" size="$bodyMd" flexShrink={1} minWidth={0}>
           {intl.formatMessage({
             id: ETranslations.swap_page_provider_rate_unavailable,
           })}
@@ -77,6 +87,9 @@ const SwapQuoteResultRate = ({
       <XStack
         gap="$2"
         alignItems="center"
+        flex={1}
+        flexBasis={0}
+        minWidth={0}
         hoverStyle={{
           opacity: 0.5,
         }}
@@ -86,14 +99,7 @@ const SwapQuoteResultRate = ({
         }}
         cursor="pointer"
       >
-        <SizableText
-          size="$bodyMd"
-          maxWidth={240}
-          $gtMd={{
-            maxWidth: 240,
-          }}
-          textAlign="right"
-        >
+        <SizableText size="$bodyMd" flex={1} flexBasis={0} minWidth={0}>
           {`1 ${
             isReverse
               ? (toToken?.symbol?.toUpperCase() ?? '-')
@@ -115,7 +121,7 @@ const SwapQuoteResultRate = ({
     );
   }, [fromToken, intl, isReverse, onOpenResult, rate, rateIsExit, toToken]);
   return (
-    <XStack alignItems="center" gap="$5">
+    <XStack alignItems="center" gap="$2" width="100%">
       {isLoading ? (
         <XStack gap="$2">
           <SizableText size="$bodyMd" color="$text">
@@ -125,33 +131,62 @@ const SwapQuoteResultRate = ({
           </SizableText>
         </XStack>
       ) : (
-        <XStack gap="$1" alignItems="center">
-          <SwapRefreshButton refreshAction={refreshAction} />
+        <XStack
+          gap="$1"
+          alignItems="center"
+          flexGrow={1}
+          flexShrink={1}
+          flexBasis={0}
+          minWidth={0}
+        >
+          <Stack flexShrink={0}>
+            <SwapRefreshButton refreshAction={refreshAction} />
+          </Stack>
           {rateContent}
         </XStack>
       )}
 
-      <XStack alignItems="center" userSelect="none" gap="$1" flex={1}>
+      <XStack alignItems="center" userSelect="none" gap="$1" flexShrink={0}>
         {!providerIcon ||
         !fromToken ||
         !toToken ||
         !onOpenResult ||
         quoting ? null : (
           <XStack
-            flex={1}
-            justifyContent="flex-end"
+            alignItems="center"
+            gap="$2"
+            flexShrink={0}
             animation="quick"
             animateOnly={ANIMATE_ONLY_OPACITY_TRANSFORM}
             y={openResult ? '$1' : '$0'}
             opacity={openResult ? 0 : 1}
-            // gap="$2"
           >
-            {isBest ? (
-              <Badge badgeSize="sm" marginRight="$2" badgeType="success">
+            {isBest && showBestBadge ? (
+              <Badge badgeSize="sm" badgeType="success">
                 {intl.formatMessage({
                   id: ETranslations.global_best,
                 })}
               </Badge>
+            ) : null}
+            {customSlippageValue ? (
+              <>
+                <XStack gap="$1" alignItems="center" flexShrink={0}>
+                  <Icon
+                    name="SliderVerOutline"
+                    size="$5"
+                    color={customSlippageIconColor}
+                  />
+                  <SizableText
+                    size="$bodyMdMedium"
+                    color={customSlippageTextColor}
+                    flexShrink={0}
+                    numberOfLines={1}
+                  >
+                    {customSlippageValue}
+                  </SizableText>
+                </XStack>
+                <Divider vertical h="$5" borderColor="$border" flexShrink={0} />
+              </>
             ) : null}
             <Stack position="relative" w="$5" h="$5">
               <Image
@@ -187,7 +222,7 @@ const SwapQuoteResultRate = ({
             />
           </Stack>
         ) : (
-          <XStack flex={1} justifyContent="flex-end">
+          <XStack justifyContent="flex-end" flexShrink={0}>
             {quoting ? (
               <LottieView
                 source={require('@onekeyhq/kit/assets/animations/swap_loading.json')}

--- a/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
@@ -537,7 +537,8 @@ const SwapHeaderRightActionContainer = ({
     (!marketPresetSettings ||
       (!marketPresetSettings.enabled && !marketPresetSettings.isLoading));
   const showHeaderSlippageValue =
-    swapTypeSwitch !== ESwapTabSwitchType.LIMIT || showSwapProSlippageSetting;
+    !compact &&
+    (swapTypeSwitch !== ESwapTabSwitchType.LIMIT || showSwapProSlippageSetting);
   const slippageTitle = useMemo(() => {
     if (!showHeaderSlippageValue) {
       return null;

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
@@ -31,9 +31,15 @@ import {
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { formatSwapQuoteDuration } from '@onekeyhq/shared/src/utils/swapQuoteDurationUtils';
 import {
+  swapSlippageDecimal,
+  swapSlippageWillAheadMinValue,
+} from '@onekeyhq/shared/types/swap/SwapProvider.constants';
+import {
   EProtocolOfExchange,
+  ESwapSlippageSegmentKey,
   ESwapTabSwitchType,
   type IFetchQuoteResult,
   type ISwapToken,
@@ -95,6 +101,27 @@ const SwapQuoteResult = ({
     estTime: quoteResult?.estTime,
     estimatedTime: quoteResult?.estimatedTime,
   });
+  const mobileCustomSlippageInfo = useMemo(() => {
+    if (
+      !platformEnv.isNative ||
+      slippageItem.key !== ESwapSlippageSegmentKey.CUSTOM
+    ) {
+      return undefined;
+    }
+
+    const displaySlippage = new BigNumber(slippageItem.value)
+      .decimalPlaces(swapSlippageDecimal, BigNumber.ROUND_DOWN)
+      .toFixed();
+    const isCaution = slippageItem.value > swapSlippageWillAheadMinValue;
+
+    return {
+      value: `${displaySlippage}%`,
+      textColor: isCaution ? ('$textCaution' as const) : ('$text' as const),
+      iconColor: isCaution
+        ? ('$iconCaution' as const)
+        : ('$iconSubdued' as const),
+    };
+  }, [slippageItem.key, slippageItem.value]);
 
   const calculateTaxItem = useCallback(
     (
@@ -305,6 +332,10 @@ const SwapQuoteResult = ({
                 fromToken={fromToken}
                 toToken={toToken}
                 isBest={quoteResult?.isBest}
+                showBestBadge={!platformEnv.isNative}
+                customSlippageValue={mobileCustomSlippageInfo?.value}
+                customSlippageTextColor={mobileCustomSlippageInfo?.textColor}
+                customSlippageIconColor={mobileCustomSlippageInfo?.iconColor}
                 providerIcon={quoteResult?.info.providerLogo ?? ''}
                 isLoading={swapQuoteLoading}
                 refreshAction={refreshAction}


### PR DESCRIPTION
## Summary
- Move mobile custom slippage display into the collapsed swap quote rate row and hide it from the compact header.
- Add caution coloring, divider, and provider spacing for the mobile custom slippage indicator.
- Use flex row chunks so long exchange rates wrap without covering slippage/provider controls.

## Test
- npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Swap/components/SwapQuoteResultRate.tsx packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
- git diff --check
- iOS Simulator visual check for long token/rate custom slippage layout
- yarn tsc:staged (fails on existing unrelated native type errors in SegmentSlider, ChartWebView, and auto-update)