### PR TITLE
fix: restore perp chart expanded height on web

### DIFF
--- a/packages/kit/src/views/Perp/layouts/PerpDesktopLayout.web.tsx
+++ b/packages/kit/src/views/Perp/layouts/PerpDesktopLayout.web.tsx
@@ -118,7 +118,11 @@ function PerpDesktopLayout() {
         >
           <PerpTickerBar />
 
-          <XStack alignItems="stretch" overflow="visible">
+          <XStack
+            flex={chartExpanded ? 1 : undefined}
+            alignItems="stretch"
+            overflow="visible"
+          >
             <YStack flex={1} minWidth={PERP_LAYOUT_CONFIG.main.marketMinWidth}>
               <XStack
                 h={chartExpanded ? undefined : layout.marketContentHeight}


### PR DESCRIPTION
## Summary
- Restore vertical fill of the Perps chart area when the TradingView chart is expanded (maximize button) on web/desktop.

## Intent & Context
On the Perps page (desktop/web), clicking the TradingView maximize button collapses the chart to ~150px tall instead of filling the viewport, leaving the rest of the page blank.

## Root Cause
PR #11932 (e53f4f5eab) restructured `PerpDesktopLayout.web.tsx` and moved `flex={chartExpanded ? 1 : undefined}` from the outer row `XStack` (direct child of the height-owning flex column) to an inner `XStack`. The outer row was left with no `flex`/`h`, so its height resolves to `auto`. In expanded mode the inner `flex: 1` (flex-basis 0%) then has no space to grow into, every descendant `flex: 1` / `h="100%"` fails to resolve, and the TradingView `<iframe height="100%">` falls back to the 150px replaced-element default height — exactly the observed 1168×150.

Non-expanded mode was unaffected because the inner `XStack` keeps an explicit `h={layout.marketContentHeight}`. The native layout (`PerpDesktopLayout.tsx`) kept the original structure and is not affected.

## Design Decisions
Minimal one-prop fix: add `flex={chartExpanded ? 1 : undefined}` back to the outer row `XStack`, mirroring the pre-#11932 web code and the current native layout. When expanded, the row fills the remaining height below the ticker bar and `alignItems="stretch"` propagates the definite height down the chain. When not expanded, `flex` is `undefined` so the layout is byte-for-byte identical to current behavior.

## Changes Detail
- `packages/kit/src/views/Perp/layouts/PerpDesktopLayout.web.tsx`: add `flex={chartExpanded ? 1 : undefined}` to the row `XStack` wrapping the chart/orderbook/trading columns.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web / Extension (web layout only; native untouched)
- **Risk Areas**: Only the `chartExpanded` branch changes; collapsed layout receives `flex={undefined}` as before.

## Test plan
- [ ] On desktop/web Perps page, click the TradingView maximize button: chart fills the full area below the ticker bar.
- [ ] Click restore: normal layout returns (order book, trading panel, bottom order info intact).
- [ ] While expanded, switch the workspace tab to Info: chart auto-collapses and layout stays correct.
- [ ] Sanity-check non-expanded layout at gtXl and smaller widths (order book toggle still works).