### PR TITLE
fix: show community badge in market recommendations(OK-56223)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketRecommendList/MarketRecommendList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketRecommendList/MarketRecommendList.tsx
@@ -4,6 +4,8 @@ import { useIntl } from 'react-intl';
 import { useWindowDimensions } from 'react-native';
 
 import { Button, SizableText, XStack, YStack } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EWatchlistFrom } from '@onekeyhq/shared/src/logger/scopes/dex';
@@ -17,6 +19,8 @@ import { RecommendItem } from './RecommendItem';
 function getTokenKey(token: { chainId: string; contractAddress: string }) {
   return `${token.chainId}:${token.contractAddress}`;
 }
+
+const EMPTY_COMMUNITY_RECOGNIZED_MAP: Record<string, boolean> = {};
 
 interface IMarketRecommendListProps {
   recommendedTokens: IMarketBasicConfigToken[];
@@ -58,6 +62,41 @@ export function MarketRecommendList({
   const defaultTokens = useMemo(
     () => uniqueTokens.slice(0, maxSize),
     [uniqueTokens, maxSize],
+  );
+
+  const { result: communityRecognizedMap } = usePromiseResult(
+    async () => {
+      if (!defaultTokens.length) {
+        return EMPTY_COMMUNITY_RECOGNIZED_MAP;
+      }
+
+      const response =
+        await backgroundApiProxy.serviceMarketV2.fetchMarketTokenListBatch({
+          tokenAddressList: defaultTokens.map((token) => ({
+            chainId: token.chainId,
+            contractAddress: token.contractAddress,
+            isNative: token.isNative,
+          })),
+        });
+
+      return defaultTokens.reduce<Record<string, boolean>>(
+        (acc, token, index) => {
+          const tokenKey = getTokenKey(token);
+          if (
+            token.communityRecognized ||
+            response.list?.[index]?.communityRecognized
+          ) {
+            acc[tokenKey] = true;
+          }
+          return acc;
+        },
+        {},
+      );
+    },
+    [defaultTokens],
+    {
+      initResult: EMPTY_COMMUNITY_RECOGNIZED_MAP,
+    },
   );
 
   const [selectedTokens, setSelectedTokens] = useState<
@@ -176,7 +215,7 @@ export function MarketRecommendList({
           gap: '$2',
         }}
       >
-        {new Array(Math.ceil(maxSize / 2)).fill(0).map((_, i) => (
+        {new Array(Math.ceil(defaultTokens.length / 2)).fill(0).map((_, i) => (
           <XStack
             gap="$2.5"
             key={i}
@@ -185,7 +224,7 @@ export function MarketRecommendList({
             }}
           >
             {new Array(2).fill(0).map((__, j) => {
-              const item = uniqueTokens[i * 2 + j];
+              const item = defaultTokens[i * 2 + j];
               if (!item) return null;
               const tokenKey = getTokenKey(item);
               const isChecked =
@@ -200,6 +239,10 @@ export function MarketRecommendList({
                   symbol={item.symbol}
                   tokenName={item.name}
                   networkId={item.chainId}
+                  communityRecognized={Boolean(
+                    item.communityRecognized ||
+                    communityRecognizedMap[tokenKey],
+                  )}
                   onChange={handleRecommendItemChange}
                 />
               );

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketRecommendList/RecommendItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketRecommendList/RecommendItem.tsx
@@ -10,6 +10,7 @@ import {
 } from '@onekeyhq/components';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
+import { CommunityRecognizedBadge } from '../../../components/CommunityRecognizedBadge';
 import { MarketTokenIcon } from '../../../components/MarketTokenIcon';
 
 export function RecommendItem({
@@ -20,6 +21,7 @@ export function RecommendItem({
   symbol,
   address,
   networkId,
+  communityRecognized,
 }: {
   icon: string;
   tokenName: string;
@@ -27,6 +29,7 @@ export function RecommendItem({
   symbol: string;
   address: string;
   networkId?: string;
+  communityRecognized?: boolean;
   onChange: (checked: boolean, address: string) => void;
 }) {
   const { sharedFrameStyles } = useMemo(
@@ -70,16 +73,18 @@ export function RecommendItem({
               }
             : {})}
         >
-          <XStack>
+          <XStack alignItems="center" gap="$1">
             <SizableText
               size="$bodyLgMedium"
               numberOfLines={1}
+              flexShrink={1}
               $sm={{
                 size: '$bodyMdMedium',
               }}
             >
               {symbol}
             </SizableText>
+            {communityRecognized ? <CommunityRecognizedBadge /> : null}
           </XStack>
           <XStack>
             <SizableText

--- a/packages/shared/types/marketV2.ts
+++ b/packages/shared/types/marketV2.ts
@@ -419,6 +419,7 @@ export interface IMarketBasicConfigToken {
   name: string;
   symbol: string;
   logo?: string;
+  communityRecognized?: boolean;
 }
 
 export interface IMarketBasicConfigNetworkFeature {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56223](https://onekeyhq.atlassian.net/browse/OK-56223)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Show the existing community-recognized badge on Market watchlist empty-state recommendation items.
- Enrich recommendation tokens through the Market batch token API so badge metadata is available even when basic config only provides token identities.
- Extend the basic-config token type with optional community-recognized metadata for typed passthrough.

## Intent & Context
The user reported that Market watchlist recommendation items should also display the community recommendation/recognized indicator when a token has it. The screenshot and page feedback pointed to the `/market` Favorites empty state rendered by `MarketWatchlistTokenList > MarketRecommendList`.

## Root Cause
The first pass only passed `communityRecognized` from `basic-config.recommendTokens` into `RecommendItem`, but the empty-state recommendation source is the basic config token list, which may not include full Market token metadata. The badge branch therefore had no true value to render. Existing Market list/search rows get this field from richer token-list responses.

## Design Decisions
- Keep the existing `CommunityRecognizedBadge` component and placement pattern instead of adding a new visual style.
- Enrich only the currently displayed recommendation tokens via `fetchMarketTokenListBatch`, keeping the extra request limited to the visible empty-state recommendations.
- Preserve the original recommendation ordering and selection behavior while using batch metadata only for display enrichment.

## Changes Detail
- `MarketRecommendList.tsx`: fetches batch token metadata for displayed recommendation tokens and passes the resolved community-recognized flag to each item.
- `RecommendItem.tsx`: renders `CommunityRecognizedBadge` next to the token symbol when present.
- `marketV2.ts`: adds optional `communityRecognized` typing to basic-config recommendation tokens.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web / Desktop / Extension / Mobile Market empty watchlist recommendation UI
- **Risk Areas**: Empty-state recommendations now make one small batch metadata request for visible tokens; cached service behavior should keep repeated renders cheap.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] Opened `http://localhost:3000/market`, switched to Favorites empty state, and verified recommendation cards display the green community-recognized badge beside token symbols.

[OK-56223]: https://onekeyhq.atlassian.net/browse/OK-56223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ