### PR TITLE
fix: localize perp limit order confirm tif label(OK-56238)

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -672,7 +672,9 @@ function OrderConfirmContent({
         {shouldShowStandardLimitTif ? (
           <XStack justifyContent="space-between" alignItems="center">
             <SizableText size="$bodyMd" color="$textSubdued">
-              Time in Force
+              {intl.formatMessage({
+                id: ETranslations.perp_time_in_force__title,
+              })}
             </SizableText>
             <SizableText size="$bodyMdMedium">{limitTifLabel}</SizableText>
           </XStack>


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56238](https://onekeyhq.atlassian.net/browse/OK-56238)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- localize the Perps limit-order confirmation modal label for Time in Force
- reuse the existing Perps TIF translation key instead of hardcoded English copy

## Intent & Context
This fixes the untranslated field on the Perps limit-order confirmation page reported in OK-56238. The confirmation modal still showed the raw English label `Time in Force` even though the rest of the Perps limit-order flow already used localized TIF copy.

## Root Cause
`OrderConfirmModal.tsx` hardcoded the `Time in Force` label in the confirmation row instead of reading the existing `ETranslations.perp_time_in_force__title` translation key already used by the TIF selector.

## Design Decisions
- Kept the fix at the UI display layer because the issue was a hardcoded label in the confirmation modal.
- Reused the existing `perp_time_in_force__title` key to stay consistent with the rest of the Perps order form and avoid introducing any new i18n assets.

## Changes Detail
- `OrderConfirmModal.tsx`: replaced the hardcoded `Time in Force` label with `intl.formatMessage({ id: ETranslations.perp_time_in_force__title })`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web / Desktop / Mobile / Extension
- **Risk Areas**: Perps limit-order confirmation modal label rendering

## Test plan
- [ ] Open the Perps limit-order flow in a non-English locale.
- [ ] Submit a limit order and verify the confirmation modal shows the localized TIF field label instead of `Time in Force`.
- [ ] Verify the TIF value itself still renders correctly as `GTC` / `IOC` / `ALO`.

[OK-56238]: https://onekeyhq.atlassian.net/browse/OK-56238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ