### PR TITLE
fix: prevent TradingView WebView white flash(OK-56262)

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { LottieView, Stack } from '@onekeyhq/components';
+import { LottieView, Stack, useTheme } from '@onekeyhq/components';
 import type { IStackStyle } from '@onekeyhq/components';
 import TradingViewChartLoadingAnimation from '@onekeyhq/kit/assets/animations/swap_order_pending.json';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
@@ -280,6 +280,8 @@ export function TradingViewPerpsV2(
   const [, setMounted] = usePerpsCandlesWebviewMountedAtom();
   const webRef = useRef<IWebViewRef | null>(null);
   const theme = useThemeVariant();
+  const themeColors = useTheme();
+  const tradingViewBackgroundColor = themeColors.bgApp.val;
   const actions = useHyperliquidActions();
   const { restoreNonce } = useNetworkRestore();
 
@@ -346,6 +348,13 @@ export function TradingViewPerpsV2(
   });
   const isSpotDisplayNameSyncRequired =
     reloadOnSymbolChange && (!!displayPair || !!displayCoin);
+  const tradingViewWebViewStyleProps = useMemo(
+    () => ({
+      containerStyle: { backgroundColor: tradingViewBackgroundColor },
+      style: { backgroundColor: tradingViewBackgroundColor },
+    }),
+    [tradingViewBackgroundColor],
+  );
 
   // Optimization: Dynamic symbol parameter sync mechanism
   useSymbolSync({
@@ -539,6 +548,9 @@ export function TradingViewPerpsV2(
       <WebViewMemoized
         key={_webviewKey}
         src={staticTradingViewUrl}
+        containerProps={{ bg: '$bgApp' }}
+        containerStyle={tradingViewWebViewStyleProps.containerStyle}
+        style={tradingViewWebViewStyleProps.style}
         customReceiveHandler={customReceiveHandler}
         onWebViewRef={onWebViewRef}
         onLoadEnd={onLoadEnd}

--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { SizableText, Stack } from '@onekeyhq/components';
+import { SizableText, Stack, useTheme } from '@onekeyhq/components';
 import type { IStackStyle } from '@onekeyhq/components';
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import type { ITradingViewKLineMockEmptyInterval } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
@@ -89,6 +89,8 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     DEFAULT_TRADING_VIEW_KLINE_RESOLUTION,
   );
   const theme = useThemeVariant();
+  const themeColors = useTheme();
+  const tradingViewBackgroundColor = themeColors.bgApp.val;
   const isVisible = useRouteIsFocused();
   const [devSettings] = useDevSettingsPersistAtom();
   const [
@@ -194,6 +196,13 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     additionalParams,
     disabledFeatures,
   });
+  const tradingViewWebViewStyleProps = useMemo(
+    () => ({
+      containerStyle: { backgroundColor: tradingViewBackgroundColor },
+      style: { backgroundColor: tradingViewBackgroundColor },
+    }),
+    [tradingViewBackgroundColor],
+  );
 
   // OneKey realtime hooks only apply to app-served market candles.
   useAutoKLineUpdate({
@@ -361,6 +370,9 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     () => (
       <WebView
         key={`${theme}:${tradingViewUrlWithParams}`}
+        containerProps={{ bg: '$bgApp' }}
+        containerStyle={tradingViewWebViewStyleProps.containerStyle}
+        style={tradingViewWebViewStyleProps.style}
         customReceiveHandler={async (data) => {
           const receiveData = data as ICustomReceiveHandlerData;
           await customReceiveHandler(receiveData);
@@ -387,6 +399,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
       onShouldStartLoadWithRequest,
       theme,
       tradingViewUrlWithParams,
+      tradingViewWebViewStyleProps,
     ],
   );
 

--- a/packages/kit/src/components/WebView/InpageProviderWebView.native.tsx
+++ b/packages/kit/src/components/WebView/InpageProviderWebView.native.tsx
@@ -44,7 +44,10 @@ const injectedMetaJavaScript = `
 
 const defaultOnMessage = (_event: any) => {};
 
-const InpageProviderWebView: FC<IInpageProviderWebViewProps> = forwardRef(
+type INativeInpageProviderWebViewProps = IInpageProviderWebViewProps &
+  Pick<WebViewProps, 'containerStyle' | 'style'>;
+
+const InpageProviderWebView: FC<INativeInpageProviderWebViewProps> = forwardRef(
   (
     {
       src = '',
@@ -54,6 +57,8 @@ const InpageProviderWebView: FC<IInpageProviderWebViewProps> = forwardRef(
       onShouldStartLoadWithRequest,
       nativeWebviewSource,
       nativeInjectedJavaScriptBeforeContentLoaded,
+      style,
+      containerStyle: webViewContainerStyle,
       isSpinnerLoading,
       onContentLoaded,
       onOpenWindow,
@@ -78,7 +83,7 @@ const InpageProviderWebView: FC<IInpageProviderWebViewProps> = forwardRef(
       onError,
       onHttpError,
       disableBridge,
-    }: IInpageProviderWebViewProps,
+    }: INativeInpageProviderWebViewProps,
     ref: any,
   ) => {
     const [progress, setProgress] = useState(5);
@@ -208,6 +213,8 @@ const InpageProviderWebView: FC<IInpageProviderWebViewProps> = forwardRef(
           receiveHandler={disableBridge ? undefined : receiveHandler}
           disableBridge={disableBridge}
           injectedJavaScriptBeforeContentLoaded={nativeInjectedJsCode}
+          style={style}
+          containerStyle={webViewContainerStyle}
           onLoadProgress={({ nativeEvent }) => {
             const p = Math.ceil(nativeEvent.progress * 100);
             onProgress?.(p);

--- a/packages/kit/src/components/WebView/NativeWebView.tsx
+++ b/packages/kit/src/components/WebView/NativeWebView.tsx
@@ -53,6 +53,8 @@ const NativeWebView = forwardRef(
       onLoad,
       onLoadEnd,
       onScroll,
+      style,
+      containerStyle,
       pullToRefreshEnabled = true,
       webviewDebuggingEnabled,
       useGeckoView,
@@ -311,7 +313,7 @@ const NativeWebView = forwardRef(
       if (useGeckoView) {
         return (
           <GeckoView
-            style={styles.container}
+            style={[styles.container, style]}
             ref={webviewRef as any}
             injectedJavaScriptBeforeContentLoaded={
               injectedJavaScriptBeforeContentLoaded || ''
@@ -330,7 +332,8 @@ const NativeWebView = forwardRef(
         <WebView
           key={webViewKey}
           cacheEnabled={false}
-          style={styles.container}
+          style={[styles.container, style]}
+          containerStyle={[styles.container, containerStyle]}
           originWhitelist={['*']}
           allowsBackForwardNavigationGestures={
             allowsBackForwardNavigationGestures
@@ -368,6 +371,8 @@ const NativeWebView = forwardRef(
       safeOnLoadEnd,
       safeOnLoadProgress,
       safeOnScroll,
+      style,
+      containerStyle,
       props,
       pullToRefreshEnabled,
       renderError,


### PR DESCRIPTION
## Summary
- Set the native TradingView WebView container and content background to the app background color.
- Apply the same background handling to both Perps TradingView and Market TradingView surfaces.
- Keep the fix narrow by avoiding DOM injection, iframe mutation handling, and tab animation changes.

## Intent & Context
The user reported that in Perps dark mode, switching between the K-line chart and Info tab can flash white. During debugging, disabling tab switch animation was tested but the user correctly questioned whether animation was the root cause. The investigation then shifted to the TradingView WebView itself as a possible white-flash source.

The final implementation is intentionally scoped to the WebView background layer. It keeps the existing tab behavior and avoids changing TradingView page internals.

## Root Cause
The observed flicker was consistent with a native WebView backing/background color being exposed during tab transitions. The TradingView URL already carries the theme, but that only controls the chart after it loads. It does not guarantee that the native WebView backing view uses the dark app background while the chart page is transparent or still rendering.

## Design Decisions
- Use `$bgApp` from the current theme for the native WebView `style` and `containerStyle`.
- Forward `style` and `containerStyle` through the native WebView wrappers instead of changing shared desktop/web WebView typing.
- Apply the fix to both `TradingViewPerpsV2` and `TradingViewV2` because both use the same TradingView WebView surface.
- Do not inject CSS or JavaScript into the TradingView document. A previous broader approach was narrowed after review because controlling the native WebView background is the simpler and lower-risk fix.
- Preserve the existing Android-only TradingView built-in loading hide script in Perps.

## Changes Detail
- `TradingViewPerpsV2.tsx`: reads `$bgApp` from `useTheme()` and passes it as WebView `style` and `containerStyle`.
- `TradingViewV2.tsx`: mirrors the same WebView background handling for Market TradingView.
- `InpageProviderWebView.native.tsx`: allows native-only `style` and `containerStyle` props through to `NativeWebView`.
- `NativeWebView.tsx`: merges caller-provided WebView `style` and `containerStyle` with the existing base container style.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile
- **Risk Areas**: Native WebView rendering on iOS and Android, and shared TradingView surfaces used by Perps and Market.

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx packages/kit/src/components/WebView/InpageProviderWebView.native.tsx packages/kit/src/components/WebView/NativeWebView.tsx`
- [x] `yarn tsc:only`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer yarn app:ios`
- [x] iOS simulator: opened Perps mobile market page, confirmed K-line loads, switched `Chart -> Info -> Chart -> Info` via the real tab `onChange` callbacks.
- [x] iOS simulator recording check: sampled 457 frames during tab switching; no large white flash frame was detected.

Note: `yarn lint --fix` was also run. TypeScript, Oxlint, language, font, and Electron checks passed, but the package version consistency step failed because an ignored local `.worktrees/revert-tradingview-app-20260611` directory contains stale package versions. That directory is outside this PR diff.
