### PR TITLE
fix: preserve private send sender address

### DIFF
--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -155,6 +155,7 @@ type IPrivateSendOrderDetail = {
   fromToken?: ISwapTokenBase;
   toToken?: ISwapTokenBase;
   toAmount?: string;
+  userAddress?: string;
   receivingAddress?: string;
   percentageFee?: number;
   protocolFee?: number;
@@ -277,6 +278,7 @@ function mergePrivateSendOrderDetailToSwapHistory({
       txId: orderDetail.txId ?? item.txInfo.txId,
       orderId: orderDetail.orderId ?? item.txInfo.orderId,
       useOrderId: item.txInfo.useOrderId,
+      sender: orderDetail.userAddress || item.txInfo.sender,
       receiver: orderDetail.receivingAddress ?? item.txInfo.receiver,
     },
     swapInfo: {


### PR DESCRIPTION
## Summary
- Merge PrivateSend order-detail userAddress into swap history txInfo.sender.
- Keep receivingAddress as the receiver source so the detail modal uses order-detail as the higher-priority business source.

## Issues
- No Jira issue ID was provided in this thread.

## Test Plan
- yarn lint:staged
- yarn tsc:staged
- yarn test --findRelatedTests packages/kit-bg/src/services/ServiceSwap.ts --runInBand

## Notes
- Branch created from origin/x.
