### PR TITLE
fix: use swap token detail as kline default price (OK-56260)

### DIFF
--- a/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
@@ -179,7 +179,6 @@ function useSwapKLineTokenMarketInfo(
 
 function useSwapKLineTokenUsdFallbackPrice(
   token?: ISwapToken,
-  enabled = true,
 ): ISwapKLineTokenUsdFallbackPriceResult {
   const tokenAddress = token?.contractAddress?.trim() ?? '';
   const networkId = token?.networkId ?? '';
@@ -193,7 +192,7 @@ function useSwapKLineTokenUsdFallbackPrice(
     | undefined
   >(
     async () => {
-      if (!enabled || !networkId) {
+      if (!networkId) {
         return undefined;
       }
 
@@ -209,10 +208,10 @@ function useSwapKLineTokenUsdFallbackPrice(
         updatedAt: Date.now(),
       };
     },
-    [enabled, networkId, tokenAddress, tokenKey],
+    [networkId, tokenAddress, tokenKey],
     {
       checkIsFocused: false,
-      pollingInterval: enabled
+      pollingInterval: networkId
         ? SWAP_KLINE_TOKEN_DETAIL_POLLING_INTERVAL
         : undefined,
       revalidateOnFocus: true,
@@ -222,7 +221,7 @@ function useSwapKLineTokenUsdFallbackPrice(
   );
 
   return useMemo(() => {
-    if (!enabled || !result || result.tokenKey !== tokenKey) {
+    if (!result || result.tokenKey !== tokenKey) {
       return {};
     }
 
@@ -230,7 +229,7 @@ function useSwapKLineTokenUsdFallbackPrice(
       tokenUsdFallbackPrice: result.tokenUsdFallbackPrice,
       updatedAt: result.updatedAt,
     };
-  }, [enabled, result, tokenKey]);
+  }, [result, tokenKey]);
 }
 
 function buildSwapKLineWalletMarketInfo(
@@ -663,10 +662,7 @@ function useSwapKLineContentState(): ISwapKLineContentState {
   const shouldForceEmptyKLineData =
     isKnownSwapKLineUnsupportedToken(selectedToken);
   const { tokenUsdFallbackPrice, updatedAt: tokenUsdFallbackPriceUpdatedAt } =
-    useSwapKLineTokenUsdFallbackPrice(
-      selectedToken,
-      !getNormalizedSwapKLinePrice(tokenMarketDetail?.price),
-    );
+    useSwapKLineTokenUsdFallbackPrice(selectedToken);
   const validChartRealtimePrice =
     chartRealtimePrice?.tokenKey === selectedTokenKey
       ? chartRealtimePrice

--- a/packages/kit/src/views/Swap/pages/modal/swapKLinePriceUtils.test.ts
+++ b/packages/kit/src/views/Swap/pages/modal/swapKLinePriceUtils.test.ts
@@ -30,6 +30,32 @@ const createSwapToken = (overrides: Partial<ISwapToken> = {}): ISwapToken => ({
 
 describe('swapKLinePriceUtils', () => {
   describe('getSwapKLineDisplayPrice', () => {
+    it('uses the USD token detail fallback when Market detail has no price', () => {
+      const now = 100_000;
+
+      expect(
+        getSwapKLineDisplayPrice({
+          tokenUsdFallbackPrice: '58.06',
+          tokenUsdFallbackPriceUpdatedAt: now,
+          now,
+        }),
+      ).toBe('58.06');
+    });
+
+    it('uses the USD token detail fallback before the chart price updates', () => {
+      const now = 100_000;
+
+      expect(
+        getSwapKLineDisplayPrice({
+          tokenMarketDetail: createMarketTokenDetail('101'),
+          tokenMarketDetailUpdatedAt: now - 100,
+          tokenUsdFallbackPrice: '100',
+          tokenUsdFallbackPriceUpdatedAt: now - 200,
+          now,
+        }),
+      ).toBe('100');
+    });
+
     it('keeps a fresh chart price authoritative over later polling completion time', () => {
       const now = 100_000;
 
@@ -37,6 +63,8 @@ describe('swapKLinePriceUtils', () => {
         getSwapKLineDisplayPrice({
           tokenMarketDetail: createMarketTokenDetail('100'),
           tokenMarketDetailUpdatedAt: now - 100,
+          tokenUsdFallbackPrice: '99',
+          tokenUsdFallbackPriceUpdatedAt: now - 50,
           chartRealtimePrice: {
             tokenKey: 'evm--1:0xabc:contract',
             price: '101',
@@ -48,7 +76,7 @@ describe('swapKLinePriceUtils', () => {
       ).toBe('101');
     });
 
-    it('allows REST or fallback prices to take over after the chart price is stale', () => {
+    it('uses the USD token detail fallback after the chart price is stale', () => {
       const now = 100_000;
 
       expect(
@@ -65,7 +93,7 @@ describe('swapKLinePriceUtils', () => {
           },
           now,
         }),
-      ).toBe('100');
+      ).toBe('99');
     });
 
     it('ignores invalid chart prices and falls back to normalized REST price', () => {

--- a/packages/kit/src/views/Swap/pages/modal/swapKLinePriceUtils.ts
+++ b/packages/kit/src/views/Swap/pages/modal/swapKLinePriceUtils.ts
@@ -121,20 +121,26 @@ export function getSwapKLineDisplayPrice({
 
   const candidates = [
     {
-      price: getNormalizedSwapKLinePrice(tokenMarketDetail?.price),
-      updatedAt: tokenMarketDetailUpdatedAt ?? 0,
-    },
-    {
       price: getNormalizedSwapKLinePrice(tokenUsdFallbackPrice),
       updatedAt: tokenUsdFallbackPriceUpdatedAt ?? 0,
+      priority: 3,
+    },
+    {
+      price: getNormalizedSwapKLinePrice(tokenMarketDetail?.price),
+      updatedAt: tokenMarketDetailUpdatedAt ?? 0,
+      priority: 2,
     },
     {
       price: chartPrice,
       updatedAt: chartRealtimePrice?.updatedAt ?? 0,
+      priority: 1,
     },
-  ].filter((item): item is { price: string; updatedAt: number } =>
-    Boolean(item.price),
+  ].filter(
+    (item): item is { price: string; updatedAt: number; priority: number } =>
+      Boolean(item.price),
   );
 
-  return candidates.toSorted((a, b) => b.updatedAt - a.updatedAt)[0]?.price;
+  return candidates.toSorted(
+    (a, b) => b.priority - a.priority || b.updatedAt - a.updatedAt,
+  )[0]?.price;
 }


### PR DESCRIPTION
## Issues

Fixes OK-56260

## Summary

- Use `/swap/v1/token/detail` with `currency: 'usd'` as the Swap K-line default USD price source as soon as a token is selected.
- Keep TradingView fresh price callbacks authoritative when they arrive.
- Keep Market detail as a supplemental price source only when the USD token-detail fallback is not available.
- Do not use `selectedToken.price` for the K-line USD header because it can be in the user's selected fiat currency.

## Test Plan

- [x] `yarn jest packages/kit/src/views/Swap/pages/modal/swapKLinePriceUtils.test.ts --runInBand --watchAll=false`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx packages/kit/src/views/Swap/pages/modal/swapKLinePriceUtils.ts packages/kit/src/views/Swap/pages/modal/swapKLinePriceUtils.test.ts`
- [x] `git diff --check`
- [x] `yarn lint:staged`
- [ ] `yarn tsc:staged` is currently blocked by existing unrelated native type errors:
  - `packages/components/src/composite/SegmentSlider/index.native.tsx`: `setValue` / `defaultValue` type errors
  - `packages/shared/src/modules3rdParty/auto-update/index.native.ts`: `pruneStaleAppVersionBundles` type error
