### PR TITLE
fix: restore bottom safe-area inset for native dialog

### DIFF
--- a/.cursor/rules/self-testing.mdc
+++ b/.cursor/rules/self-testing.mdc
@@ -14,6 +14,7 @@ After completing any non-trivial task (feature, bug fix, refactor), execute this
 - [ ] No duplicated logic — shared code extracted
 - [ ] Error cases handled with try/catch or error boundaries
 - [ ] Semantic naming (no `tmp`, `data1`, `doStuff`)
+- [ ] No split-across-statements `- X … + X` cancellation of the **same** value (e.g. subtract `inset` when setting a value, add `inset` back when consuming it) — express as one `Math.max`/`Math.min`/clamp so a later move can't drop one half. (Only when the two terms are genuinely the same quantity; `- tabBarHeight … + safeAreaBottom` are different and must NOT be collapsed.)
 
 ## 2. React Check (skip if no component code touched)
 
@@ -25,6 +26,7 @@ After completing any non-trivial task (feature, bug fix, refactor), execute this
 
 - [ ] Identified which platforms consume modified code
 - [ ] UI changes verified on mobile (narrowest) and desktop (widest)
+- [ ] Safe-area / keyboard padding verified on notched iOS in BOTH keyboard-hidden and keyboard-shown states (regression risk: content hugging the home indicator)
 - [ ] Stated: "Affects: [platforms]" and "Does NOT affect: [platforms]"
 
 ## 4. Business Logic & Regression
@@ -35,6 +37,8 @@ After completing any non-trivial task (feature, bug fix, refactor), execute this
 - [ ] Shared hook/utility modified → checked all consumers
 - [ ] Type definitions changed → all consumers updated
 - [ ] State atoms modified → verified all readers/writers
+- [ ] Every file touched maps to the stated task / PR title — incidental refactors outside scope are split out or explicitly called out for review (a focused title makes reviewers skip unrelated diffs)
+- [ ] Logic moved between files carries its surrounding guard/condition and scope (e.g. a `showFooter` / `isNative` gate, or a captured inset), not just the function body
 
 ## 5. Potential Bugs (skip for docs/config-only changes)
 

--- a/packages/components/src/composite/Dialog/index.tsx
+++ b/packages/components/src/composite/Dialog/index.tsx
@@ -49,6 +49,7 @@ import {
   useKeyboardEventWithoutNavigation,
   useModalNavigatorContextPortalId,
   useOverlayZIndex,
+  useSafeAreaInsets,
 } from '../../hooks';
 import { usePageContext } from '../../layouts/Page/PageContext';
 import { ScrollView } from '../../layouts/ScrollView';
@@ -124,9 +125,16 @@ const EMPTY_DIALOG_STYLE = {} as const;
 
 const DEFAULT_KEYBOARD_HEIGHT = 330;
 const useSafeKeyboardAnimationStyle = () => {
+  const { bottom } = useSafeAreaInsets();
   const keyboardHeightValue = useSharedValue(0);
+  // Keep the dialog clear of both the home indicator and the keyboard.
+  // These are two independent concerns collapsed into one paddingBottom:
+  //   - bottom safe-area inset: always required (static)
+  //   - keyboard height: only while the keyboard is shown (dynamic)
+  // They must not stack — once the keyboard is up it already covers the
+  // safe area, so take the larger of the two instead of summing them.
   const animatedStyles = useAnimatedStyle(() => ({
-    paddingBottom: keyboardHeightValue.value,
+    paddingBottom: Math.max(keyboardHeightValue.value, bottom),
   }));
 
   useKeyboardEventWithoutNavigation({


### PR DESCRIPTION
## Problem

A previous refactor (#10610, commit d323a56f42) moved the dialog keyboard-avoidance logic out of `Dialog/Footer.tsx` and into `DialogFrame` (`Dialog/index.tsx`). During the move, the bottom safe-area inset (`+ bottom`) was dropped.

Result: on native, **every dialog lost its bottom safe-area padding whenever the keyboard was hidden** — dialog content hugs the home indicator on notched iOS devices.

### Before vs after the regression

Old (`Footer.tsx`):
```js
const { bottom } = useSafeAreaInsets();
paddingBottom: keyboardHeightValue.value + bottom   // hidden → bottom (safe area)
keyboardWillShow: value = keyboardHeight - bottom    // shown  → keyboardHeight
```

Regressed (`index.tsx`):
```js
paddingBottom: keyboardHeightValue.value             // hidden → 0  ❌ no safe area
keyboardWillShow: value = keyboardHeight             // shown  → keyboardHeight
```

## Fix

Reinstate the safe-area inset, but express the intent directly with `max` instead of the old `- bottom … + bottom` cancellation arithmetic that made the inset easy to drop:

```js
paddingBottom: Math.max(keyboardHeightValue.value, bottom)
```

- keyboard hidden → `max(0, bottom)` = safe area ✅
- keyboard shown  → `max(keyboardHeight, bottom)` = keyboardHeight ✅ (keyboard already covers the safe area, so the two never stack)

## Scope

`packages/components/src/composite/Dialog/index.tsx` — affects all native dialogs globally. Web is unaffected (`useSafeKeyboardAnimationStyle` returns `undefined` off-native).

## Testing

- `yarn tsc:staged` ✅
- `yarn lint:staged` ✅
- Manual: verify on a notched iOS device that dialogs (with and without footer) clear the home indicator, and that keyboard-up behavior is unchanged.