### PR TITLE
ci: fix desktop win/linux packaging on drifted runner images

### DIFF
--- a/.github/workflows/release-desktop-all.yml
+++ b/.github/workflows/release-desktop-all.yml
@@ -362,7 +362,11 @@ jobs:
   # ═══════════════════════════════════════════════════
   package-win:
     needs: renderer
-    runs-on: windows-2025
+    # Pin to windows-2022 (VS 2022 / v17). The windows-2025 runner image now
+    # ships Visual Studio 18, which the bundled node-gyp cannot detect
+    # ("find VS unknown version undefined found at ...\Visual Studio\18"),
+    # breaking every native module rebuild during `install-app-deps`.
+    runs-on: windows-2022
     strategy:
       matrix:
         node-version: [24.x]
@@ -646,7 +650,13 @@ jobs:
           echo "::warning::GPG verification is SKIPPED for this build. This should only be used in CI/dev builds."
 
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
+        # Pin to the 8.x track. snapcraft 9.0.0 removed the `snap` subcommand
+        # (renamed to `pack`), which electron-builder's app-builder still calls,
+        # causing `exit status 64`. 8.x keeps `snap` and still supports the
+        # core24 base used by this snap config.
+        run: |
+          sudo snap install snapcraft --classic --channel=8.x/stable \
+            || sudo snap refresh snapcraft --classic --channel=8.x/stable
 
       - name: Install snap dependencies for snapcraft build
         run: |


### PR DESCRIPTION
## Problem

Desktop release packaging (`release-desktop-all`) started failing on **windows** and **linux** between 06-11 11:22 (green) and 06-11 20:18 (red) — a GitHub runner-image / toolchain rollout, **unrelated to any app code change** (mac builds stay green).

### release-win — runner upgraded Visual Studio to v18, node-gyp can't detect it
```
gyp ERR! find VS unknown version "undefined" found at "C:\Program Files\Microsoft Visual Studio\18\Enterprise"
gyp ERR! find VS could not find a version of Visual Studio 2017 or newer to use
```
The `windows-2025` image now ships VS 18 (path `\18\Enterprise`). The bundled node-gyp parses it as `unknown version undefined` → **all** native module rebuilds fail. The job dies in `install-app-deps` while rebuilding `@onekeyfe/electron-mac-icloud` (just the first fatal casualty; keccak/secp256k1/etc. fail too).

**Fix:** pin `runs-on: windows-2022` (VS 2022 / v17, confirmed by runner-images docs).

### release-linux — snapcraft 9.0.0 removed the `snap` subcommand
```
The 'snap' command was renamed to 'pack'.  →  exit status 64
```
Last green build used snapcraft **8.14.5**; the failing run pulled **9.0.0**, which renamed `snap` → `pack`. electron-builder's app-builder still calls `snapcraft snap`. (Can't pin to 7.x — the snap config uses `base: core24`, which needs 8.x.)

**Fix:** pin snapcraft to the `8.x/stable` channel (keeps `snap`, supports core24).

## Notes
- Both pins are **temporary**. Long-term: upgrade node-gyp to recognize VS 18, and move off the deprecated `snapcraft snap` command. windows-2022 is also slated for eventual retirement.
- Verified via a `workflow_dispatch` run on this branch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/12038" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->