### PR TITLE
fix: prevent market chart crash from undefined chart in update effect

### DIFF
--- a/packages/kit/src/views/Market/components/Chart/ChartViewAdapter.tsx
+++ b/packages/kit/src/views/Market/components/Chart/ChartViewAdapter.tsx
@@ -6,7 +6,7 @@ import { createLazySdkLoader } from '@onekeyhq/shared/src/utils/lazySdkLoader';
 
 import { createChartDom, updateChartDom } from './chartUtils';
 
-import type { IChartViewAdapterProps } from './chartUtils';
+import type { IChartViewAdapterProps, IOnekeyChartApi } from './chartUtils';
 
 const getChartLib = createLazySdkLoader(() => import('lightweight-charts'));
 
@@ -19,6 +19,14 @@ const ChartViewAdapter: FC<IChartViewAdapterProps> = ({
   height,
 }) => {
   const chartContainerRef = useRef<HTMLDivElement>(null);
+  // Per-instance chart handle. The chart is created asynchronously (lazy lib
+  // load), so the data-update effect below can fire before it exists — guard on
+  // this ref instead of reading a global singleton.
+  const chartRef = useRef<IOnekeyChartApi | null>(null);
+  // Keep the latest data/colors so the async create path can render the current
+  // frame as soon as the chart is ready.
+  const latestPropsRef = useRef({ data, lineColor, topColor, bottomColor });
+  latestPropsRef.current = { data, lineColor, topColor, bottomColor };
   const theme = useTheme();
   const textSubduedColor = theme.textSubdued.val;
 
@@ -39,9 +47,14 @@ const ChartViewAdapter: FC<IChartViewAdapterProps> = ({
         height,
         textSubduedColor,
       );
+      chartRef.current = chart as IOnekeyChartApi;
+      // Render the current frame now that the chart exists, since the update
+      // effect may have already run (and no-op'd) before this resolved.
+      updateChartDom({ chart: chartRef.current, ...latestPropsRef.current });
       cleanup = () => {
         window.removeEventListener('resize', handleResize);
         chart.remove();
+        chartRef.current = null;
       };
     });
 
@@ -53,7 +66,13 @@ const ChartViewAdapter: FC<IChartViewAdapterProps> = ({
   }, [textSubduedColor]);
 
   useEffect(() => {
+    const chart = chartRef.current;
+    // Chart not created yet; the create effect will render the latest frame.
+    if (!chart) {
+      return;
+    }
     updateChartDom({
+      chart,
       bottomColor,
       topColor,
       lineColor,

--- a/packages/kit/src/views/Market/components/Chart/chartUtils.ts
+++ b/packages/kit/src/views/Market/components/Chart/chartUtils.ts
@@ -39,7 +39,7 @@ export interface IChartViewAdapterProps extends IChartViewProps {
   bottomColor: string;
 }
 
-interface IOnekeyChartApi extends IChartApi {
+export interface IOnekeyChartApi extends IChartApi {
   // eslint-disable-next-line camelcase
   _onekey_series?: ISeriesApi<'Area'>;
 }
@@ -113,11 +113,13 @@ export function createChartDom(
 }
 
 export function updateChartDom({
+  chart,
   lineColor,
   topColor,
   bottomColor,
   data,
 }: {
+  chart: IOnekeyChartApi;
   lineColor: string;
   topColor: string;
   bottomColor: string;
@@ -129,8 +131,6 @@ export function updateChartDom({
       value,
     }),
   );
-  // @ts-ignore
-  const chart = globalThis._onekey_chart as IOnekeyChartApi;
   if (!chart._onekey_series) {
     const newSeries = chart.addAreaSeries({
       lineColor,


### PR DESCRIPTION
## Problem

Opening a Market token detail whose chart uses the lightweight-charts area chart (`ChartViewAdapter`) crashes on first mount:

```
TypeError: Cannot read properties of undefined (reading '_onekey_series')
    at updateChartDom (chartUtils.ts:134)
    at ChartViewAdapter.tsx (data-update effect)
```

## Root cause

`ChartViewAdapter` has two effects:

- **create** (`getChartLib().then(() => createChartDom(...))`) — async; only sets the chart inside a `.then()` microtask.
- **update** (`updateChartDom(...)`) — sync; reads `globalThis._onekey_chart` then `chart._onekey_series`.

On first mount both passive effects flush synchronously (create then update), but the chart is created inside a microtask that always resolves **after** the synchronous update effect. So the update effect runs while `globalThis._onekey_chart` is still `undefined` → `chart._onekey_series` throws.

This was latent until #10969 switched `lightweight-charts` from a static import to `createLazySdkLoader` (lazy `import()`), moving chart creation into a `.then()` and exposing the race. Verified live over CDP: at crash time `'_onekey_chart' in globalThis === false`.

The shared `globalThis._onekey_chart` singleton also had two latent issues: it was never cleared on unmount (dangling pointer to a removed chart), and multiple chart instances would stomp each other.

## Fix

- `updateChartDom` now takes the `chart` instance as a parameter instead of reading the global singleton; the `_onekey_series` cache lives on the instance (per-instance, no cross-instance stomping).
- `ChartViewAdapter` holds the chart in a per-instance `chartRef`:
  - the update effect no-ops if the chart isn't created yet (no more undefined deref);
  - the async create path renders the latest frame as soon as the chart exists (so the first frame isn't dropped);
  - the chart ref is cleared on cleanup.

## Test

- `yarn tsc:staged` — pass
- `yarn lint:staged` — pass
- Reproduced the original crash live over CDP, applied the fix, and confirmed the Market detail no longer throws `_onekey_series`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/12039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->