### PR TITLE
fix: correct private send fiat display

### DIFF
--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -94,7 +94,6 @@ type IHistoryDecodedAction = IAccountHistoryTx['decodedTx']['actions'][number];
 type IHistoryDecodedTransfer = NonNullable<
   IHistoryDecodedAction['assetTransfer']
 >['sends'][number];
-type IPrivateSendSwapHistoryToken = ISwapTxHistory['baseInfo']['fromToken'];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -223,42 +222,8 @@ function hasPrivateSendTransferPrice(transfer?: IHistoryDecodedTransfer) {
   return !!getPrivateSendPositivePriceValue(transfer?.price);
 }
 
-function hasPrivateSendSwapHistoryTokenPrice(
-  token?: IPrivateSendSwapHistoryToken,
-) {
-  return !!getPrivateSendPositivePriceValue(token?.price);
-}
-
 function normalizePrivateSendTransferTokenId(tokenId?: string) {
   return tokenId?.trim().toLowerCase() ?? '';
-}
-
-function isSamePrivateSendTransferSwapToken({
-  transfer,
-  token,
-}: {
-  transfer: IHistoryDecodedTransfer;
-  token?: IPrivateSendSwapHistoryToken;
-}) {
-  if (!token) {
-    return false;
-  }
-
-  if (
-    normalizePrivateSendTransferTokenId(transfer.tokenIdOnNetwork) &&
-    normalizePrivateSendTransferTokenId(transfer.tokenIdOnNetwork) ===
-      normalizePrivateSendTransferTokenId(token.contractAddress)
-  ) {
-    return true;
-  }
-
-  return Boolean(
-    (!transfer.networkId ||
-      !token.networkId ||
-      transfer.networkId === token.networkId) &&
-    (transfer.isNative || !transfer.tokenIdOnNetwork) &&
-    (token.isNative || !token.contractAddress),
-  );
 }
 
 function isSamePrivateSendTransferForPrice({
@@ -396,111 +361,6 @@ function mergePrivateSendActionTransferPrices({
   });
 
   return { actions, updated };
-}
-
-function applyPrivateSendSwapHistoryTokenPriceToTransfers({
-  transfers,
-  token,
-}: {
-  transfers: IHistoryDecodedTransfer[];
-  token: IPrivateSendSwapHistoryToken;
-}) {
-  if (!hasPrivateSendSwapHistoryTokenPrice(token)) {
-    return { transfers, updated: false };
-  }
-
-  let updated = false;
-  const nextTransfers = transfers.map((transfer) => {
-    if (
-      hasPrivateSendTransferPrice(transfer) ||
-      !isSamePrivateSendTransferSwapToken({ transfer, token })
-    ) {
-      return transfer;
-    }
-
-    updated = true;
-    return {
-      ...transfer,
-      price: token.price,
-    };
-  });
-
-  return { transfers: nextTransfers, updated };
-}
-
-function applyPrivateSendSwapHistoryTokenPricesToActions({
-  actions,
-  swapHistory,
-}: {
-  actions?: IHistoryDecodedAction[];
-  swapHistory: ISwapTxHistory;
-}) {
-  if (!actions?.length) {
-    return { actions, updated: false };
-  }
-
-  let updated = false;
-  const nextActions = actions.map((action) => {
-    const { assetTransfer } = action;
-    if (!assetTransfer) {
-      return action;
-    }
-
-    const sendsResult = applyPrivateSendSwapHistoryTokenPriceToTransfers({
-      transfers: assetTransfer.sends,
-      token: swapHistory.baseInfo.fromToken,
-    });
-    const receivesResult = applyPrivateSendSwapHistoryTokenPriceToTransfers({
-      transfers: assetTransfer.receives,
-      token: swapHistory.baseInfo.toToken,
-    });
-    if (!sendsResult.updated && !receivesResult.updated) {
-      return action;
-    }
-
-    updated = true;
-    return {
-      ...action,
-      assetTransfer: {
-        ...assetTransfer,
-        sends: sendsResult.transfers,
-        receives: receivesResult.transfers,
-      },
-    };
-  });
-
-  return { actions: nextActions, updated };
-}
-
-function applyPrivateSendSwapHistoryTokenPricesToHistoryTx({
-  tx,
-  swapHistory,
-}: {
-  tx: IAccountHistoryTx;
-  swapHistory: ISwapTxHistory;
-}) {
-  const actionsResult = applyPrivateSendSwapHistoryTokenPricesToActions({
-    actions: tx.decodedTx.actions,
-    swapHistory,
-  });
-  const outputActionsResult = applyPrivateSendSwapHistoryTokenPricesToActions({
-    actions: tx.decodedTx.outputActions,
-    swapHistory,
-  });
-  if (!actionsResult.updated && !outputActionsResult.updated) {
-    return tx;
-  }
-
-  return {
-    ...tx,
-    decodedTx: {
-      ...tx.decodedTx,
-      ...(actionsResult.updated ? { actions: actionsResult.actions } : {}),
-      ...(outputActionsResult.updated
-        ? { outputActions: outputActionsResult.actions }
-        : {}),
-    },
-  };
 }
 
 function normalizePrivateSendHistoryAddress(address?: string) {
@@ -682,23 +542,18 @@ class ServiceHistory extends ServiceBase {
           tx,
           swapHistory,
         });
-      const txWithSwapHistoryTokenPrices =
-        applyPrivateSendSwapHistoryTokenPricesToHistoryTx({
-          tx: txWithSwapHistoryRecipient,
-          swapHistory,
-        });
 
       const displayStatus = getPrivateSendHistoryDisplayStatus({
-        historyTx: txWithSwapHistoryTokenPrices,
+        historyTx: txWithSwapHistoryRecipient,
         swapHistory,
       });
 
       if (!displayStatus || displayStatus === tx.decodedTx.status) {
-        return this.clearHistoryTxDisplayStatus(txWithSwapHistoryTokenPrices);
+        return this.clearHistoryTxDisplayStatus(txWithSwapHistoryRecipient);
       }
 
       return {
-        ...txWithSwapHistoryTokenPrices,
+        ...txWithSwapHistoryRecipient,
         displayStatus,
         displayStatusSource: 'privateSendOrder',
       };

--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -8,6 +8,7 @@ import {
   backgroundMethod,
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
+import { USD_CURRENCY_ID } from '@onekeyhq/shared/src/consts/currencyConsts';
 import { HISTORY_TIME_RANGE_MONTHS } from '@onekeyhq/shared/src/consts/walletConsts';
 import type { OneKeyServerApiError } from '@onekeyhq/shared/src/errors';
 import {
@@ -94,6 +95,12 @@ type IHistoryDecodedAction = IAccountHistoryTx['decodedTx']['actions'][number];
 type IHistoryDecodedTransfer = NonNullable<
   IHistoryDecodedAction['assetTransfer']
 >['sends'][number];
+type IPrivateSendDisplayPriceTarget = {
+  accountId: string;
+  networkId: string;
+  tokenAddress?: string;
+  isNative?: boolean;
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -220,6 +227,13 @@ function getPrivateSendPositivePriceValue(value?: number | string) {
 
 function hasPrivateSendTransferPrice(transfer?: IHistoryDecodedTransfer) {
   return !!getPrivateSendPositivePriceValue(transfer?.price);
+}
+
+function getPrivateSendPositiveNumberValue(value?: number | string) {
+  const valueBN = new BigNumber(value ?? '');
+  return valueBN.isNaN() || !valueBN.isFinite() || !valueBN.isGreaterThan(0)
+    ? undefined
+    : valueBN;
 }
 
 function normalizePrivateSendTransferTokenId(tokenId?: string) {
@@ -361,6 +375,181 @@ function mergePrivateSendActionTransferPrices({
   });
 
   return { actions, updated };
+}
+
+function getPrivateSendDisplayPriceKey({
+  networkId,
+  tokenAddress,
+  isNative,
+}: {
+  networkId?: string;
+  tokenAddress?: string;
+  isNative?: boolean;
+}) {
+  if (!networkId) {
+    return undefined;
+  }
+  if (isNative) {
+    return `${networkId}:native`;
+  }
+  const normalizedTokenAddress =
+    normalizePrivateSendTransferTokenId(tokenAddress);
+  if (!normalizedTokenAddress) {
+    return undefined;
+  }
+  return `${networkId}:${normalizedTokenAddress}`;
+}
+
+function getPrivateSendTargetPriceKey({
+  accountId,
+  networkId,
+  tokenAddress,
+  isNative,
+}: IPrivateSendDisplayPriceTarget) {
+  const displayPriceKey = getPrivateSendDisplayPriceKey({
+    networkId,
+    tokenAddress,
+    isNative,
+  });
+  return displayPriceKey ? `${accountId}:${displayPriceKey}` : undefined;
+}
+
+function buildPrivateSendTransferDisplayPriceTarget({
+  tx,
+  transfer,
+}: {
+  tx: IAccountHistoryTx;
+  transfer: IHistoryDecodedTransfer;
+}): IPrivateSendDisplayPriceTarget | undefined {
+  if (transfer.isNFT) {
+    return undefined;
+  }
+
+  const accountId = tx.decodedTx.accountId;
+  const networkId = transfer.networkId ?? tx.decodedTx.networkId;
+  if (!accountId || !networkId) {
+    return undefined;
+  }
+
+  const tokenAddress = transfer.tokenIdOnNetwork;
+  return {
+    accountId,
+    networkId,
+    tokenAddress,
+    isNative: transfer.isNative || !tokenAddress,
+  };
+}
+
+function buildPrivateSendNativeDisplayPriceTarget(
+  tx: IAccountHistoryTx,
+): IPrivateSendDisplayPriceTarget | undefined {
+  const accountId = tx.decodedTx.accountId;
+  const networkId = tx.decodedTx.networkId;
+  if (!accountId || !networkId) {
+    return undefined;
+  }
+  return {
+    accountId,
+    networkId,
+    isNative: true,
+  };
+}
+
+function collectPrivateSendTransfersFromActions(
+  actions?: IHistoryDecodedAction[],
+) {
+  return (
+    actions?.flatMap((action) => {
+      const { assetTransfer } = action;
+      return assetTransfer
+        ? [...assetTransfer.sends, ...assetTransfer.receives]
+        : [];
+    }) ?? []
+  );
+}
+
+function convertPrivateSendDisplayPrice({
+  price,
+  sourceCurrency,
+  targetCurrency,
+  currencyMap,
+}: {
+  price?: number | string;
+  sourceCurrency?: string;
+  targetCurrency: string;
+  currencyMap: Record<string, ICurrencyItem>;
+}) {
+  const priceBN = getPrivateSendPositiveNumberValue(price);
+  if (!priceBN) {
+    return undefined;
+  }
+
+  const resolvedSourceCurrency = sourceCurrency || USD_CURRENCY_ID;
+  if (resolvedSourceCurrency === targetCurrency) {
+    return priceBN.toFixed();
+  }
+
+  const sourceCurrencyInfo = currencyMap[resolvedSourceCurrency];
+  const targetCurrencyInfo = currencyMap[targetCurrency];
+  const sourceRate = new BigNumber(sourceCurrencyInfo?.value ?? NaN);
+  const targetRate = new BigNumber(targetCurrencyInfo?.value ?? NaN);
+  if (!sourceRate.isFinite() || sourceRate.isZero() || !targetRate.isFinite()) {
+    return undefined;
+  }
+
+  return priceBN.div(sourceRate).times(targetRate).toFixed();
+}
+
+function applyPrivateSendDisplayPricesToActions({
+  actions,
+  tx,
+  priceMap,
+}: {
+  actions?: IHistoryDecodedAction[];
+  tx: IAccountHistoryTx;
+  priceMap: Map<string, string>;
+}) {
+  if (!actions?.length) {
+    return { actions, updated: false };
+  }
+
+  let updated = false;
+  const nextActions = actions.map((action) => {
+    const { assetTransfer } = action;
+    if (!assetTransfer) {
+      return action;
+    }
+
+    const updateTransfer = (transfer: IHistoryDecodedTransfer) => {
+      const target = buildPrivateSendTransferDisplayPriceTarget({
+        tx,
+        transfer,
+      });
+      const priceKey = target
+        ? getPrivateSendTargetPriceKey(target)
+        : undefined;
+      const price = priceKey ? priceMap.get(priceKey) : undefined;
+      if (transfer.price === price) {
+        return transfer;
+      }
+      updated = true;
+      return {
+        ...transfer,
+        price,
+      };
+    };
+
+    return {
+      ...action,
+      assetTransfer: {
+        ...assetTransfer,
+        sends: assetTransfer.sends.map(updateTransfer),
+        receives: assetTransfer.receives.map(updateTransfer),
+      },
+    };
+  });
+
+  return { actions: nextActions, updated };
 }
 
 function normalizePrivateSendHistoryAddress(address?: string) {
@@ -560,6 +749,191 @@ class ServiceHistory extends ServiceBase {
     });
   }
 
+  private async attachPrivateSendDisplayPrices({
+    txs,
+    targetCurrency,
+    currencyMap,
+  }: {
+    txs: IAccountHistoryTx[];
+    targetCurrency?: string;
+    currencyMap?: Record<string, ICurrencyItem>;
+  }): Promise<IAccountHistoryTx[]> {
+    const privateSendTxs = txs.filter((tx) =>
+      isPrivateSendAccountHistoryTx(tx),
+    );
+    if (!privateSendTxs.length || !targetCurrency || !currencyMap) {
+      return txs;
+    }
+
+    const groupedTargets = new Map<
+      string,
+      Map<string, IPrivateSendDisplayPriceTarget>
+    >();
+    const addTarget = (target?: IPrivateSendDisplayPriceTarget) => {
+      if (!target) {
+        return;
+      }
+      const priceKey = getPrivateSendTargetPriceKey(target);
+      if (!priceKey) {
+        return;
+      }
+      const groupKey = `${target.accountId}:${target.networkId}`;
+      const group = groupedTargets.get(groupKey) ?? new Map();
+      group.set(priceKey, target);
+      groupedTargets.set(groupKey, group);
+    };
+
+    privateSendTxs.forEach((tx) => {
+      [
+        ...collectPrivateSendTransfersFromActions(tx.decodedTx.actions),
+        ...collectPrivateSendTransfersFromActions(tx.decodedTx.outputActions),
+      ].forEach((transfer) => {
+        addTarget(buildPrivateSendTransferDisplayPriceTarget({ tx, transfer }));
+      });
+
+      if (getPrivateSendPositiveNumberValue(tx.decodedTx.totalFeeInNative)) {
+        addTarget(buildPrivateSendNativeDisplayPriceTarget(tx));
+      }
+    });
+
+    const priceMap = new Map<string, string>();
+    await Promise.all(
+      [...groupedTargets.values()].map(async (group) => {
+        const targets = [...group.values()];
+        const firstTarget = targets[0];
+        if (!firstTarget) {
+          return;
+        }
+        const { accountId, networkId } = firstTarget;
+        try {
+          const resolvedTargets = await Promise.all(
+            targets.map(async (target) => {
+              let tokenAddress = target.tokenAddress;
+              if (target.isNative || !tokenAddress) {
+                tokenAddress =
+                  await this.backgroundApi.serviceToken.getNativeTokenAddress({
+                    networkId,
+                  });
+              }
+              return tokenAddress ? { ...target, tokenAddress } : undefined;
+            }),
+          );
+          const validTargets = resolvedTargets.filter(
+            (
+              target,
+            ): target is IPrivateSendDisplayPriceTarget & {
+              tokenAddress: string;
+            } => !!target?.tokenAddress,
+          );
+          if (!validTargets.length) {
+            return;
+          }
+
+          const uniqueTokenAddresses = [
+            ...new Set(validTargets.map((target) => target.tokenAddress)),
+          ];
+          const tokenDetails =
+            await this.backgroundApi.serviceToken.fetchTokensDetails({
+              accountId,
+              networkId,
+              contractList: uniqueTokenAddresses,
+            });
+          const tokenDetailsByAddress = new Map<
+            string,
+            (typeof tokenDetails)[number]
+          >();
+          tokenDetails.forEach((tokenDetail) => {
+            const address = tokenDetail.info.address;
+            if (address) {
+              tokenDetailsByAddress.set(address.toLowerCase(), tokenDetail);
+            }
+          });
+
+          uniqueTokenAddresses.forEach((tokenAddress, index) => {
+            const tokenAddressKey = tokenAddress.toLowerCase();
+            const tokenDetail =
+              tokenDetailsByAddress.get(tokenAddressKey) ?? tokenDetails[index];
+            const price = convertPrivateSendDisplayPrice({
+              price: tokenDetail?.price,
+              sourceCurrency: tokenDetail?.currency ?? USD_CURRENCY_ID,
+              targetCurrency,
+              currencyMap,
+            });
+            if (!price) {
+              return;
+            }
+            validTargets
+              .filter(
+                (target) =>
+                  target.tokenAddress.toLowerCase() === tokenAddressKey,
+              )
+              .forEach((target) => {
+                const priceKey = getPrivateSendTargetPriceKey(target);
+                if (priceKey) {
+                  priceMap.set(priceKey, price);
+                }
+              });
+          });
+        } catch {
+          // Display-price repair is best effort; unknown is better than stale.
+        }
+      }),
+    );
+
+    return txs.map((tx) => {
+      if (!isPrivateSendAccountHistoryTx(tx)) {
+        return tx;
+      }
+
+      const actionsResult = applyPrivateSendDisplayPricesToActions({
+        actions: tx.decodedTx.actions,
+        tx,
+        priceMap,
+      });
+      const outputActionsResult = applyPrivateSendDisplayPricesToActions({
+        actions: tx.decodedTx.outputActions,
+        tx,
+        priceMap,
+      });
+      const nativeTarget = buildPrivateSendNativeDisplayPriceTarget(tx);
+      const nativePriceKey = nativeTarget
+        ? getPrivateSendTargetPriceKey(nativeTarget)
+        : undefined;
+      const nativePrice = nativePriceKey
+        ? priceMap.get(nativePriceKey)
+        : undefined;
+      const totalFeeInNativeBN = getPrivateSendPositiveNumberValue(
+        tx.decodedTx.totalFeeInNative,
+      );
+      const totalFeeFiatValue =
+        totalFeeInNativeBN && nativePrice
+          ? totalFeeInNativeBN.times(nativePrice).toFixed()
+          : undefined;
+      const shouldUpdateFeeFiatValue =
+        tx.decodedTx.totalFeeFiatValue !== totalFeeFiatValue;
+
+      if (
+        !actionsResult.updated &&
+        !outputActionsResult.updated &&
+        !shouldUpdateFeeFiatValue
+      ) {
+        return tx;
+      }
+
+      return {
+        ...tx,
+        decodedTx: {
+          ...tx.decodedTx,
+          ...(actionsResult.updated ? { actions: actionsResult.actions } : {}),
+          ...(outputActionsResult.updated
+            ? { outputActions: outputActionsResult.actions }
+            : {}),
+          totalFeeFiatValue,
+        },
+      };
+    });
+  }
+
   private clearHistoryTxDisplayStatus(tx: IAccountHistoryTx) {
     if (!tx.displayStatus && !tx.displayStatusSource) {
       return tx;
@@ -746,13 +1120,19 @@ class ServiceHistory extends ServiceBase {
     });
     const txsWithPrivateSendDisplayStatus =
       await this.attachPrivateSendDisplayStatus(filtered);
+    const txsWithPrivateSendDisplayPrices =
+      await this.attachPrivateSendDisplayPrices({
+        txs: txsWithPrivateSendDisplayStatus,
+        targetCurrency: sourceCurrency,
+        currencyMap,
+      });
 
     // Load-more is single-network (the AllNetworks branch never reaches here),
     // so resolve the logo once and stamp every tx instead of per-tx fetching.
     const logoNetwork = await this.backgroundApi.serviceNetwork.getNetwork({
       networkId,
     });
-    for (const tx of txsWithPrivateSendDisplayStatus) {
+    for (const tx of txsWithPrivateSendDisplayPrices) {
       tx.decodedTx.networkLogoURI = logoNetwork.logoURI;
     }
 
@@ -765,7 +1145,7 @@ class ServiceHistory extends ServiceBase {
       isIndexer: !!onChainResult.isIndexer,
       accounts: [] as IAllNetworkAccountInfo[],
       allAccounts: [] as IAllNetworkAccountInfo[],
-      txs: txsWithPrivateSendDisplayStatus,
+      txs: txsWithPrivateSendDisplayPrices,
       addressMap: onChainResult.addressMap,
       accountsWithChangedPendingTxs: [] as {
         accountId: string;
@@ -1153,6 +1533,11 @@ class ServiceHistory extends ServiceBase {
     }
 
     result = await this.attachPrivateSendDisplayStatus(result);
+    result = await this.attachPrivateSendDisplayPrices({
+      txs: result,
+      targetCurrency: sourceCurrency,
+      currencyMap,
+    });
 
     const accountsWithChangedPendingTxs = new Set<string>(); // accountId_networkId
     const accountsWithChangedConfirmedTxs = new Set<string>(); // accountId_networkId
@@ -1503,9 +1888,15 @@ class ServiceHistory extends ServiceBase {
 
       const resultWithPrivateSendDisplayStatus =
         await this.attachPrivateSendDisplayStatus(result);
+      const resultWithPrivateSendDisplayPrices =
+        await this.attachPrivateSendDisplayPrices({
+          txs: resultWithPrivateSendDisplayStatus,
+          targetCurrency: sourceCurrency,
+          currencyMap,
+        });
 
       return filterHistoryTxs({
-        txs: resultWithPrivateSendDisplayStatus,
+        txs: resultWithPrivateSendDisplayPrices,
         sourceCurrency,
         targetCurrency,
         currencyMap,
@@ -1548,9 +1939,15 @@ class ServiceHistory extends ServiceBase {
 
     const resultWithPrivateSendDisplayStatus =
       await this.attachPrivateSendDisplayStatus(result);
+    const resultWithPrivateSendDisplayPrices =
+      await this.attachPrivateSendDisplayPrices({
+        txs: resultWithPrivateSendDisplayStatus,
+        targetCurrency: sourceCurrency,
+        currencyMap,
+      });
 
     return filterHistoryTxs({
-      txs: resultWithPrivateSendDisplayStatus,
+      txs: resultWithPrivateSendDisplayPrices,
       filterScam,
       filterLowValue,
       sourceCurrency,

--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -815,7 +815,9 @@ class ServiceHistory extends ServiceBase {
                     networkId,
                   });
               }
-              return tokenAddress ? { ...target, tokenAddress } : undefined;
+              return target.isNative || tokenAddress
+                ? { ...target, tokenAddress: tokenAddress ?? '' }
+                : undefined;
             }),
           );
           const validTargets = resolvedTargets.filter(
@@ -823,7 +825,7 @@ class ServiceHistory extends ServiceBase {
               target,
             ): target is IPrivateSendDisplayPriceTarget & {
               tokenAddress: string;
-            } => !!target?.tokenAddress,
+            } => !!target && (target.isNative || !!target.tokenAddress),
           );
           if (!validTargets.length) {
             return;

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -216,9 +216,7 @@ function mergePrivateSendOrderDetailToken({
   return {
     ...currentToken,
     ...orderDetailToken,
-    price: isSameToken
-      ? (orderDetailToken.price ?? currentToken.price)
-      : orderDetailToken.price,
+    price: isSameToken ? currentToken.price : undefined,
   };
 }
 

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
@@ -1,11 +1,4 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useRoute } from '@react-navigation/core';
 import BigNumber from 'bignumber.js';
@@ -33,11 +26,14 @@ import { AddressInfo } from '@onekeyhq/kit/src/components/AddressInfo';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import useFormatDate from '@onekeyhq/kit/src/hooks/useFormatDate';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { convertFiat } from '@onekeyhq/kit/src/utils/fiatConvert';
 import {
+  useCurrencyPersistAtom,
   useInAppNotificationAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { SUPPORT_URL } from '@onekeyhq/shared/src/config/appConfig';
+import { USD_CURRENCY_ID } from '@onekeyhq/shared/src/consts/currencyConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { showIntercom } from '@onekeyhq/shared/src/modules3rdParty/intercom';
@@ -47,6 +43,7 @@ import type {
 } from '@onekeyhq/shared/src/routes/swap';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
+import type { ICurrencyItem } from '@onekeyhq/shared/types/currency';
 import { privateSendProvider } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import type {
   IExplorersInfo,
@@ -86,6 +83,13 @@ type ISwapHistoryDetailAssetItem = {
   isNative: boolean;
   price?: string;
   amount?: string;
+};
+
+type IPrivateSendDisplayPriceTarget = {
+  key?: string;
+  networkId?: string;
+  tokenAddress?: string;
+  isNative?: boolean;
 };
 
 type IPrivateSendProgressStepStatus = 'todo' | 'process' | 'done' | 'error';
@@ -559,129 +563,266 @@ function getPositiveTokenPrice(value?: number | string) {
   return valueBN.toFixed();
 }
 
-function getNativeTokenPriceFromGasFee(item?: ISwapTxHistory) {
-  const gasFeeInNativeBN = new BigNumber(item?.txInfo.gasFeeInNative ?? '');
-  const gasFeeFiatValueBN = new BigNumber(item?.txInfo.gasFeeFiatValue ?? '');
+function getPrivateSendTransferPrice({
+  transfer,
+}: {
+  transfer: IDecodedTxTransferInfo;
+}) {
+  return getPositiveTokenPrice(transfer.price);
+}
 
+function getPrivateSendDisplayPriceKey({
+  networkId,
+  tokenAddress,
+  isNative,
+}: {
+  networkId?: string;
+  tokenAddress?: string;
+  isNative?: boolean;
+}) {
+  if (!networkId) {
+    return undefined;
+  }
+  if (isNative) {
+    return `${networkId}:native`;
+  }
+  if (!tokenAddress) {
+    return undefined;
+  }
+  return `${networkId}:${tokenAddress.toLowerCase()}`;
+}
+
+function getPrivateSendBaseTokenPriceKey(item?: ISwapTxHistory) {
+  return getPrivateSendDisplayPriceKey({
+    networkId:
+      item?.baseInfo.fromToken.networkId ??
+      item?.baseInfo.fromNetwork?.networkId ??
+      item?.accountInfo.sender.networkId,
+    tokenAddress: item?.baseInfo.fromToken.contractAddress,
+    isNative: item?.baseInfo.fromToken.isNative,
+  });
+}
+
+function getPrivateSendNetworkNativePriceKey(item?: ISwapTxHistory) {
+  return getPrivateSendDisplayPriceKey({
+    networkId:
+      item?.baseInfo.fromNetwork?.networkId ??
+      item?.accountInfo.sender.networkId,
+    isNative: true,
+  });
+}
+
+function getPrivateSendTransferPriceKey({
+  transfer,
+  item,
+}: {
+  transfer: IDecodedTxTransferInfo;
+  item?: ISwapTxHistory;
+}) {
+  const isBaseToken = isBasePrivateSendTransfer({
+    transfer,
+    txHistory: item,
+  });
+  return getPrivateSendDisplayPriceKey({
+    networkId:
+      transfer.networkId ??
+      item?.baseInfo.fromNetwork?.networkId ??
+      item?.accountInfo.sender.networkId,
+    tokenAddress:
+      transfer.tokenIdOnNetwork ||
+      (isBaseToken ? item?.baseInfo.fromToken.contractAddress : undefined),
+    isNative:
+      transfer.isNative || (isBaseToken && item?.baseInfo.fromToken.isNative),
+  });
+}
+
+function convertPrivateSendTokenDisplayPrice({
+  price,
+  sourceCurrency,
+  targetCurrency,
+  currencyMap,
+}: {
+  price?: number | string;
+  sourceCurrency?: string;
+  targetCurrency: string;
+  currencyMap: Record<string, ICurrencyItem>;
+}) {
+  const validPrice = getPositiveTokenPrice(price);
+  if (!validPrice) {
+    return undefined;
+  }
+
+  const resolvedSourceCurrency = sourceCurrency || USD_CURRENCY_ID;
   if (
-    gasFeeInNativeBN.isNaN() ||
-    !gasFeeInNativeBN.isFinite() ||
-    !gasFeeInNativeBN.isGreaterThan(0) ||
-    gasFeeFiatValueBN.isNaN() ||
-    !gasFeeFiatValueBN.isFinite() ||
-    !gasFeeFiatValueBN.isGreaterThan(0)
+    resolvedSourceCurrency !== targetCurrency &&
+    (!currencyMap[resolvedSourceCurrency] || !currencyMap[targetCurrency])
   ) {
     return undefined;
   }
 
-  return gasFeeFiatValueBN.div(gasFeeInNativeBN).toFixed();
-}
-
-function getPrivateSendTransferPrice({
-  transfer,
-  isBaseToken,
-  fromAssetPrice,
-  nativeTokenPrice,
-}: {
-  transfer: IDecodedTxTransferInfo;
-  isBaseToken: boolean;
-  fromAssetPrice?: string;
-  nativeTokenPrice?: string;
-}) {
-  return (
-    getPositiveTokenPrice(transfer.price) ??
-    (isBaseToken ? getPositiveTokenPrice(fromAssetPrice) : undefined) ??
-    (transfer.isNative ? nativeTokenPrice : undefined)
-  );
-}
-
-function applyPrivateSendTokenPrice({
-  item,
-  price,
-  force,
-}: {
-  item: ISwapTxHistory;
-  price: string;
-  force?: boolean;
-}) {
-  const hasFromTokenPrice = !!getPositiveTokenPrice(
-    item.baseInfo.fromToken.price,
-  );
-  const hasToTokenPrice = !!getPositiveTokenPrice(item.baseInfo.toToken.price);
-
-  return {
-    ...item,
-    baseInfo: {
-      ...item.baseInfo,
-      fromToken:
-        hasFromTokenPrice && !force
-          ? item.baseInfo.fromToken
-          : { ...item.baseInfo.fromToken, price },
-      toToken:
-        hasToTokenPrice && !force
-          ? item.baseInfo.toToken
-          : { ...item.baseInfo.toToken, price },
-    },
-  };
-}
-
-function isSamePrivateSendHistoryToken({
-  source,
-  target,
-}: {
-  source?: ISwapTxHistory;
-  target?: ISwapTxHistory;
-}) {
-  if (!source || !target) {
-    return false;
-  }
-  return equalTokenNoCaseSensitive({
-    token1: source.baseInfo.fromToken,
-    token2: target.baseInfo.fromToken,
+  return convertFiat({
+    value: validPrice,
+    sourceCurrency: resolvedSourceCurrency,
+    targetCurrency,
+    currencyMap,
   });
 }
 
-function getPrivateSendPriceBackfillKey(item?: ISwapTxHistory) {
-  if (!item) {
-    return undefined;
-  }
-  const accountId = item.accountInfo.sender.accountId;
-  const networkId =
-    item.baseInfo.fromToken.networkId ?? item.accountInfo.sender.networkId;
-  const tokenAddress = item.baseInfo.fromToken.isNative
-    ? 'native'
-    : item.baseInfo.fromToken.contractAddress;
-  if (!accountId || !networkId || !tokenAddress) {
-    return undefined;
-  }
-  return `${item.swapInfo.orderId ?? item.txInfo.txId ?? ''}:${accountId}:${networkId}:${tokenAddress}`;
-}
-
-async function fetchPrivateSendTokenPrice(item: ISwapTxHistory) {
+async function fetchPrivateSendTokenDisplayPriceMap({
+  item,
+  targetCurrency,
+  currencyMap,
+}: {
+  item: ISwapTxHistory;
+  targetCurrency: string;
+  currencyMap: Record<string, ICurrencyItem>;
+}) {
   const accountId = item.accountInfo.sender.accountId;
   if (!accountId) {
-    return undefined;
+    return {};
   }
 
-  const networkId =
-    item.baseInfo.fromToken.networkId ?? item.accountInfo.sender.networkId;
-  let tokenAddress = item.baseInfo.fromToken.contractAddress;
+  const displayTransfers = getPrivateSendDisplayTransfers(item);
+  const displayTargets: IPrivateSendDisplayPriceTarget[] =
+    displayTransfers.length
+      ? displayTransfers.map((transfer) => {
+          const isBaseToken = isBasePrivateSendTransfer({
+            transfer,
+            txHistory: item,
+          });
+          return {
+            key: getPrivateSendTransferPriceKey({ transfer, item }),
+            networkId:
+              transfer.networkId ??
+              item.baseInfo.fromNetwork?.networkId ??
+              item.accountInfo.sender.networkId,
+            tokenAddress:
+              transfer.tokenIdOnNetwork ||
+              (isBaseToken
+                ? item.baseInfo.fromToken.contractAddress
+                : undefined),
+            isNative:
+              transfer.isNative ||
+              (isBaseToken && item.baseInfo.fromToken.isNative),
+          };
+        })
+      : [
+          {
+            key: getPrivateSendBaseTokenPriceKey(item),
+            networkId:
+              item.baseInfo.fromToken.networkId ??
+              item.baseInfo.fromNetwork?.networkId ??
+              item.accountInfo.sender.networkId,
+            tokenAddress: item.baseInfo.fromToken.contractAddress,
+            isNative: item.baseInfo.fromToken.isNative,
+          },
+        ];
+  const nativePriceKey = getPrivateSendNetworkNativePriceKey(item);
+  const nativeNetworkId =
+    item.baseInfo.fromNetwork?.networkId ?? item.accountInfo.sender.networkId;
+  const targets =
+    nativePriceKey && nativeNetworkId
+      ? [
+          ...displayTargets,
+          {
+            key: nativePriceKey,
+            networkId: nativeNetworkId,
+            isNative: true,
+          },
+        ]
+      : displayTargets;
 
-  if (item.baseInfo.fromToken.isNative || !tokenAddress) {
-    tokenAddress = await backgroundApiProxy.serviceToken.getNativeTokenAddress({
-      networkId,
-    });
+  const priceMap: Record<string, string> = {};
+  const targetsByNetwork = new Map<
+    string,
+    { key: string; tokenAddress?: string; isNative?: boolean }[]
+  >();
+
+  for (const target of targets) {
+    if (target.key && target.networkId) {
+      const list = targetsByNetwork.get(target.networkId) ?? [];
+      list.push({
+        key: target.key,
+        tokenAddress: target.tokenAddress,
+        isNative: target.isNative,
+      });
+      targetsByNetwork.set(target.networkId, list);
+    }
   }
 
-  const tokenDetails = await backgroundApiProxy.serviceToken.fetchTokensDetails(
-    {
-      accountId,
-      networkId,
-      contractList: [tokenAddress],
-    },
+  await Promise.all(
+    [...targetsByNetwork.entries()].map(async ([networkId, networkTargets]) => {
+      const resolvedTargets = await Promise.all(
+        networkTargets.map(async (target) => {
+          let tokenAddress = target.tokenAddress;
+          if (target.isNative || !tokenAddress) {
+            tokenAddress =
+              await backgroundApiProxy.serviceToken.getNativeTokenAddress({
+                networkId,
+              });
+          }
+          return tokenAddress ? { ...target, tokenAddress } : undefined;
+        }),
+      );
+      const validTargets = resolvedTargets.filter(
+        (
+          target,
+        ): target is {
+          key: string;
+          tokenAddress: string;
+          isNative?: boolean;
+        } => !!target?.tokenAddress,
+      );
+      if (!validTargets.length) {
+        return;
+      }
+
+      const uniqueTokenAddresses = [
+        ...new Set(validTargets.map((target) => target.tokenAddress)),
+      ];
+      const tokenDetails =
+        await backgroundApiProxy.serviceToken.fetchTokensDetails({
+          accountId,
+          networkId,
+          contractList: uniqueTokenAddresses,
+        });
+
+      const tokenDetailsByAddress = new Map<
+        string,
+        (typeof tokenDetails)[number]
+      >();
+      tokenDetails.forEach((tokenDetail) => {
+        const address = tokenDetail.info.address;
+        if (address) {
+          tokenDetailsByAddress.set(address.toLowerCase(), tokenDetail);
+        }
+      });
+
+      uniqueTokenAddresses.forEach((tokenAddress, index) => {
+        const tokenAddressKey = tokenAddress.toLowerCase();
+        const tokenDetail =
+          tokenDetailsByAddress.get(tokenAddressKey) ?? tokenDetails[index];
+        const price = convertPrivateSendTokenDisplayPrice({
+          price: tokenDetail?.price,
+          sourceCurrency: tokenDetail?.currency ?? USD_CURRENCY_ID,
+          targetCurrency,
+          currencyMap,
+        });
+        if (!price) {
+          return;
+        }
+        validTargets
+          .filter(
+            (target) => target.tokenAddress.toLowerCase() === tokenAddressKey,
+          )
+          .forEach((target) => {
+            priceMap[target.key] = price;
+          });
+      });
+    }),
   );
 
-  return getPositiveTokenPrice(tokenDetails?.[0]?.price);
+  return priceMap;
 }
 
 const SwapHistoryDetailModal = () => {
@@ -694,8 +835,8 @@ const SwapHistoryDetailModal = () => {
   const intl = useIntl();
   const { txHistoryOrderId, txHistoryList } = route.params ?? {};
   const [txHistoryListState, setTxHistoryListState] = useState(txHistoryList);
-  const privateSendPriceBackfillKeysRef = useRef(new Set<string>());
   const [{ swapHistoryPendingList }] = useInAppNotificationAtom();
+  const [{ currencyMap }] = useCurrencyPersistAtom();
   const { result: swapTxHistoryList } = usePromiseResult(
     async () => {
       const histories =
@@ -751,29 +892,7 @@ const SwapHistoryDetailModal = () => {
               : item,
           )
         : rawNextTxHistoryList;
-    const currentTxHistory = txHistoryListState?.find(
-      (item) => item.swapInfo.orderId === txHistoryOrderId,
-    );
-    const currentPrivateSendPrice =
-      currentTxHistory && isPrivateSendSwapTxHistory(currentTxHistory)
-        ? (getPositiveTokenPrice(currentTxHistory.baseInfo.fromToken.price) ??
-          getPositiveTokenPrice(currentTxHistory.baseInfo.toToken.price))
-        : undefined;
-    const nextTxHistoryList = currentPrivateSendPrice
-      ? nextRawTxHistoryList.map((item) =>
-          item.swapInfo.orderId === txHistoryOrderId &&
-          isPrivateSendSwapTxHistory(item) &&
-          isSamePrivateSendHistoryToken({
-            source: currentTxHistory,
-            target: item,
-          })
-            ? applyPrivateSendTokenPrice({
-                item,
-                price: currentPrivateSendPrice,
-              })
-            : item,
-        )
-      : nextRawTxHistoryList;
+    const nextTxHistoryList = nextRawTxHistoryList;
     if (
       JSON.stringify(nextTxHistoryList) !== JSON.stringify(txHistoryListState)
     ) {
@@ -791,58 +910,22 @@ const SwapHistoryDetailModal = () => {
     () => isPrivateSendSwapTxHistory(txHistory),
     [txHistory],
   );
-  useEffect(() => {
-    if (!txHistory || !isPrivateSendHistory) {
-      return;
-    }
-
-    const priceBackfillKey = getPrivateSendPriceBackfillKey(txHistory);
-    if (
-      !priceBackfillKey ||
-      privateSendPriceBackfillKeysRef.current.has(priceBackfillKey)
-    ) {
-      return;
-    }
-    privateSendPriceBackfillKeysRef.current.add(priceBackfillKey);
-
-    let cancelled = false;
-    void (async () => {
-      try {
-        const price = await fetchPrivateSendTokenPrice(txHistory);
-        if (!price || cancelled) {
-          privateSendPriceBackfillKeysRef.current.delete(priceBackfillKey);
-          return;
-        }
-
-        const nextTxHistory = applyPrivateSendTokenPrice({
-          item: txHistory,
-          price,
-          force: true,
-        });
-        if (JSON.stringify(nextTxHistory) === JSON.stringify(txHistory)) {
-          return;
-        }
-        setTxHistoryListState((prev) =>
-          prev?.map((item) =>
-            item.swapInfo.orderId === nextTxHistory.swapInfo.orderId
-              ? nextTxHistory
-              : item,
-          ),
-        );
-        await backgroundApiProxy.serviceSwap.updateSwapHistoryItem(
-          nextTxHistory,
-          { shouldShowToast: false },
-        );
-      } catch {
-        privateSendPriceBackfillKeysRef.current.delete(priceBackfillKey);
-        // Price backfill is best-effort and should not affect history details.
+  const displayCurrencyId = settingsPersistAtom.currencyInfo.id;
+  const currentCurrencySymbol = settingsPersistAtom.currencyInfo.symbol;
+  const displayCurrencySymbol = isPrivateSendHistory
+    ? currentCurrencySymbol
+    : (txHistory?.currency ?? currentCurrencySymbol);
+  const { result: privateSendTokenDisplayPriceMap } =
+    usePromiseResult(async () => {
+      if (!txHistory || !isPrivateSendHistory) {
+        return undefined;
       }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isPrivateSendHistory, txHistory]);
+      return fetchPrivateSendTokenDisplayPriceMap({
+        item: txHistory,
+        targetCurrency: displayCurrencyId,
+        currencyMap,
+      });
+    }, [currencyMap, displayCurrencyId, isPrivateSendHistory, txHistory]);
   const shouldRenderOrderId =
     !!txHistory?.txInfo.orderId && !isPrivateSendHistory;
 
@@ -900,7 +983,6 @@ const SwapHistoryDetailModal = () => {
       const privateSendDisplayTransfers =
         getPrivateSendDisplayTransfers(txHistory);
       if (privateSendDisplayTransfers.length) {
-        const nativeTokenPrice = getNativeTokenPriceFromGasFee(txHistory);
         return (
           <>
             {privateSendDisplayTransfers.map((transfer, index) => {
@@ -908,6 +990,13 @@ const SwapHistoryDetailModal = () => {
                 transfer,
                 txHistory,
               });
+              const displayPriceKey = getPrivateSendTransferPriceKey({
+                transfer,
+                item: txHistory,
+              });
+              const displayPrice = displayPriceKey
+                ? privateSendTokenDisplayPriceMap?.[displayPriceKey]
+                : undefined;
               const asset = {
                 name:
                   transfer.name ||
@@ -926,12 +1015,11 @@ const SwapHistoryDetailModal = () => {
                     : ''),
                 isNFT: transfer.isNFT,
                 isNative: transfer.isNative,
-                price: getPrivateSendTransferPrice({
-                  transfer,
-                  isBaseToken,
-                  fromAssetPrice: fromAsset.price,
-                  nativeTokenPrice,
-                }),
+                price:
+                  displayPrice ??
+                  (privateSendTokenDisplayPriceMap
+                    ? getPrivateSendTransferPrice({ transfer })
+                    : undefined),
               };
 
               return (
@@ -945,10 +1033,7 @@ const SwapHistoryDetailModal = () => {
                   isAllNetworks
                   amount={transfer.amount}
                   networkIcon={txHistory?.baseInfo.fromNetwork?.logoURI ?? ''}
-                  currencySymbol={
-                    txHistory?.currency ??
-                    settingsPersistAtom.currencyInfo.symbol
-                  }
+                  currencySymbol={displayCurrencySymbol}
                   networkId={
                     transfer.networkId ??
                     txHistory?.baseInfo.fromNetwork?.networkId
@@ -959,17 +1044,22 @@ const SwapHistoryDetailModal = () => {
           </>
         );
       }
+      const baseTokenPriceKey = getPrivateSendBaseTokenPriceKey(txHistory);
+      const privateSendFromAsset: ISwapHistoryDetailAssetItem = {
+        ...fromAsset,
+        price: baseTokenPriceKey
+          ? privateSendTokenDisplayPriceMap?.[baseTokenPriceKey]
+          : undefined,
+      };
       return (
         <AssetItem
           index={0}
           direction={EDecodedTxDirection.OUT}
-          asset={fromAsset}
+          asset={privateSendFromAsset}
           isAllNetworks
           amount={fromTokenAmount ?? '0'}
           networkIcon={txHistory?.baseInfo.fromNetwork?.logoURI ?? ''}
-          currencySymbol={
-            txHistory?.currency ?? settingsPersistAtom.currencyInfo.symbol
-          }
+          currencySymbol={displayCurrencySymbol}
         />
       );
     }
@@ -982,9 +1072,7 @@ const SwapHistoryDetailModal = () => {
           isAllNetworks
           amount={txHistory?.baseInfo.toAmount ?? '0'}
           networkIcon={txHistory?.baseInfo.toNetwork?.logoURI ?? ''}
-          currencySymbol={
-            txHistory?.currency ?? settingsPersistAtom.currencyInfo.symbol
-          }
+          currencySymbol={displayCurrencySymbol}
         />
         <AssetItem
           index={1}
@@ -993,9 +1081,7 @@ const SwapHistoryDetailModal = () => {
           isAllNetworks
           amount={fromTokenAmount ?? '0'}
           networkIcon={txHistory?.baseInfo.fromNetwork?.logoURI ?? ''}
-          currencySymbol={
-            txHistory?.currency ?? settingsPersistAtom.currencyInfo.symbol
-          }
+          currencySymbol={displayCurrencySymbol}
         />
         {otherAsset.map((item, index) => (
           <AssetItem
@@ -1006,16 +1092,15 @@ const SwapHistoryDetailModal = () => {
             isAllNetworks
             amount={item.amount ?? '0'}
             networkIcon={txHistory?.baseInfo.fromNetwork?.logoURI ?? ''}
-            currencySymbol={
-              txHistory?.currency ?? settingsPersistAtom.currencyInfo.symbol
-            }
+            currencySymbol={displayCurrencySymbol}
           />
         ))}
       </>
     );
   }, [
+    displayCurrencySymbol,
     isPrivateSendHistory,
-    settingsPersistAtom.currencyInfo.symbol,
+    privateSendTokenDisplayPriceMap,
     txHistory,
   ]);
 
@@ -1217,7 +1302,6 @@ const SwapHistoryDetailModal = () => {
   const renderNetworkFee = useCallback(() => {
     const { gasFeeFiatValue, gasFeeInNative } = txHistory?.txInfo ?? {};
     const gasFeeInNativeBN = new BigNumber(gasFeeInNative ?? '');
-    const gasFeeFiatValueBN = new BigNumber(gasFeeFiatValue ?? '');
     if (gasFeeInNativeBN.isNaN() || !gasFeeInNativeBN.isFinite()) {
       return (
         <SizableText size="$bodyMd" color="$textSubdued">
@@ -1226,8 +1310,21 @@ const SwapHistoryDetailModal = () => {
       );
     }
     const gasFeeDisplay = gasFeeInNativeBN.toFixed();
+    const nativePriceKey = getPrivateSendNetworkNativePriceKey(txHistory);
+    let privateSendGasFeeFiatValue: string | undefined;
+    if (isPrivateSendHistory && nativePriceKey) {
+      const nativeTokenPrice =
+        privateSendTokenDisplayPriceMap?.[nativePriceKey];
+      if (nativeTokenPrice) {
+        privateSendGasFeeFiatValue = gasFeeInNativeBN
+          .times(nativeTokenPrice)
+          .toFixed();
+      }
+    }
+    const finalGasFeeFiatValue = privateSendGasFeeFiatValue ?? gasFeeFiatValue;
+    const finalGasFeeFiatValueBN = new BigNumber(finalGasFeeFiatValue ?? '');
     const shouldRenderGasFeeFiatValue =
-      !gasFeeFiatValueBN.isNaN() && gasFeeFiatValueBN.isFinite();
+      !finalGasFeeFiatValueBN.isNaN() && finalGasFeeFiatValueBN.isFinite();
     return (
       <SizableText size="$bodyMd" color="$textSubdued">
         <NumberSizeableText
@@ -1243,20 +1340,19 @@ const SwapHistoryDetailModal = () => {
           size="$bodyMd"
           formatter="value"
           formatterOptions={{
-            currency:
-              txHistory?.currency ?? settingsPersistAtom.currencyInfo.symbol,
+            currency: displayCurrencySymbol,
           }}
         >
-          {shouldRenderGasFeeFiatValue ? gasFeeFiatValue : '--'}
+          {shouldRenderGasFeeFiatValue ? finalGasFeeFiatValue : '--'}
         </NumberSizeableText>
         )
       </SizableText>
     );
   }, [
-    settingsPersistAtom.currencyInfo.symbol,
-    txHistory?.baseInfo.fromNetwork?.symbol,
-    txHistory?.currency,
-    txHistory?.txInfo,
+    displayCurrencySymbol,
+    isPrivateSendHistory,
+    privateSendTokenDisplayPriceMap,
+    txHistory,
   ]);
 
   const renderRate = useCallback(
@@ -1317,16 +1413,14 @@ const SwapHistoryDetailModal = () => {
         color="$textSubdued"
         formatter="value"
         formatterOptions={{
-          currency:
-            txHistory?.currency ?? settingsPersistAtom.currencyInfo.symbol,
+          currency: displayCurrencySymbol,
         }}
       >
         {protocolFee.toString()}
       </NumberSizeableText>
     );
   }, [
-    settingsPersistAtom.currencyInfo.symbol,
-    txHistory?.currency,
+    displayCurrencySymbol,
     txHistory?.swapInfo.otherFeeInfos,
     txHistory?.swapInfo.protocolFee,
   ]);

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
@@ -761,7 +761,9 @@ async function fetchPrivateSendTokenDisplayPriceMap({
                 networkId,
               });
           }
-          return tokenAddress ? { ...target, tokenAddress } : undefined;
+          return target.isNative || tokenAddress
+            ? { ...target, tokenAddress: tokenAddress ?? '' }
+            : undefined;
         }),
       );
       const validTargets = resolvedTargets.filter(
@@ -771,7 +773,7 @@ async function fetchPrivateSendTokenDisplayPriceMap({
           key: string;
           tokenAddress: string;
           isNative?: boolean;
-        } => !!target?.tokenAddress,
+        } => !!target && (target.isNative || !!target.tokenAddress),
       );
       if (!validTargets.length) {
         return;

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
@@ -563,14 +563,6 @@ function getPositiveTokenPrice(value?: number | string) {
   return valueBN.toFixed();
 }
 
-function getPrivateSendTransferPrice({
-  transfer,
-}: {
-  transfer: IDecodedTxTransferInfo;
-}) {
-  return getPositiveTokenPrice(transfer.price);
-}
-
 function getPrivateSendDisplayPriceKey({
   networkId,
   tokenAddress,
@@ -1017,11 +1009,7 @@ const SwapHistoryDetailModal = () => {
                     : ''),
                 isNFT: transfer.isNFT,
                 isNative: transfer.isNative,
-                price:
-                  displayPrice ??
-                  (privateSendTokenDisplayPriceMap
-                    ? getPrivateSendTransferPrice({ transfer })
-                    : undefined),
+                price: displayPrice,
               };
 
               return (
@@ -1323,7 +1311,9 @@ const SwapHistoryDetailModal = () => {
           .toFixed();
       }
     }
-    const finalGasFeeFiatValue = privateSendGasFeeFiatValue ?? gasFeeFiatValue;
+    const finalGasFeeFiatValue = isPrivateSendHistory
+      ? privateSendGasFeeFiatValue
+      : gasFeeFiatValue;
     const finalGasFeeFiatValueBN = new BigNumber(finalGasFeeFiatValue ?? '');
     const shouldRenderGasFeeFiatValue =
       !finalGasFeeFiatValueBN.isNaN() && finalGasFeeFiatValueBN.isFinite();

--- a/packages/kit/src/views/Swap/utils/privateSendHistory.ts
+++ b/packages/kit/src/views/Swap/utils/privateSendHistory.ts
@@ -169,81 +169,6 @@ function areSamePrivateSendDisplayTransferContents({
   );
 }
 
-function areSamePrivateSendDisplayTransferTokens({
-  currentIdentity,
-  replayIdentity,
-}: {
-  currentIdentity: ReturnType<typeof getPrivateSendDisplayTransferIdentity>;
-  replayIdentity: ReturnType<typeof getPrivateSendDisplayTransferIdentity>;
-}) {
-  return (
-    replayIdentity.tokenIdOnNetwork === currentIdentity.tokenIdOnNetwork &&
-    replayIdentity.symbol === currentIdentity.symbol &&
-    replayIdentity.icon === currentIdentity.icon &&
-    replayIdentity.isNative === currentIdentity.isNative
-  );
-}
-
-function findPrivateSendDisplayTransferWithPrice({
-  currentTransfers,
-  replayTransfer,
-  index,
-}: {
-  currentTransfers: IDecodedTxTransferInfo[];
-  replayTransfer: IDecodedTxTransferInfo;
-  index: number;
-}) {
-  const replayIdentity = getPrivateSendDisplayTransferIdentity(replayTransfer);
-  const sameIndexTransfer = currentTransfers[index];
-  if (sameIndexTransfer) {
-    const sameIndexIdentity =
-      getPrivateSendDisplayTransferIdentity(sameIndexTransfer);
-    if (
-      sameIndexIdentity.price &&
-      areSamePrivateSendDisplayTransferTokens({
-        currentIdentity: sameIndexIdentity,
-        replayIdentity,
-      })
-    ) {
-      return sameIndexTransfer;
-    }
-  }
-
-  return currentTransfers.find((currentTransfer) => {
-    const currentIdentity =
-      getPrivateSendDisplayTransferIdentity(currentTransfer);
-    return (
-      currentIdentity.price &&
-      areSamePrivateSendDisplayTransferTokens({
-        currentIdentity,
-        replayIdentity,
-      })
-    );
-  });
-}
-
-function mergePrivateSendDisplayTransferPrices({
-  currentTransfers,
-  replayTransfers,
-}: {
-  currentTransfers: IDecodedTxTransferInfo[];
-  replayTransfers: IDecodedTxTransferInfo[];
-}) {
-  return replayTransfers.map((replayTransfer, index) => {
-    if (getPositivePriceValue(replayTransfer.price)) {
-      return replayTransfer;
-    }
-
-    const currentTransfer = findPrivateSendDisplayTransferWithPrice({
-      currentTransfers,
-      replayTransfer,
-      index,
-    });
-    const price = getPositivePriceValue(currentTransfer?.price);
-    return price ? { ...replayTransfer, price } : replayTransfer;
-  });
-}
-
 function areSamePrivateSendDisplayTransfers({
   currentTransfers,
   replayTransfers,
@@ -263,8 +188,7 @@ function areSamePrivateSendDisplayTransfers({
       areSamePrivateSendDisplayTransferContents({
         currentIdentity,
         replayIdentity,
-      }) &&
-      (!replayIdentity.price || replayIdentity.price === currentIdentity.price)
+      }) && replayIdentity.price === currentIdentity.price
     );
   });
 }
@@ -336,12 +260,6 @@ function mergePrivateSendHistoryReplayFields({
     currentTransfers: currentDisplayTransfers,
     replayTransfers: replayDisplayTransfers,
   });
-  const mergedReplayDisplayTransfers = shouldMergeDisplayTransfers
-    ? mergePrivateSendDisplayTransferPrices({
-        currentTransfers: currentDisplayTransfers,
-        replayTransfers: replayDisplayTransfers,
-      })
-    : replayDisplayTransfers;
   const shouldMergeGasFeeInNative = shouldUsePrivateSendReplayFeeValue({
     currentValue: item.txInfo.gasFeeInNative,
     replayValue: replayItem.txInfo.gasFeeInNative,
@@ -370,7 +288,7 @@ function mergePrivateSendHistoryReplayFields({
           ? { payinAddress: replayPayinAddress }
           : {}),
         ...(shouldMergeDisplayTransfers
-          ? { privateSendDisplayTransfers: mergedReplayDisplayTransfers }
+          ? { privateSendDisplayTransfers: replayDisplayTransfers }
           : {}),
       },
     };
@@ -406,10 +324,14 @@ function mergePrivateSendHistoryReplayFields({
 
   if (
     shouldMergeReplayBaseInfo &&
-    shouldMergePrivateSendReplayBaseInfo({
+    (shouldMergePrivateSendReplayBaseInfo({
       item: nextItem,
       replayItem,
-    })
+    }) ||
+      getPositivePriceValue(nextItem.baseInfo.fromToken.price) !==
+        getPositivePriceValue(replayItem.baseInfo.fromToken.price) ||
+      getPositivePriceValue(nextItem.baseInfo.toToken.price) !==
+        getPositivePriceValue(replayItem.baseInfo.toToken.price))
   ) {
     nextItem = {
       ...nextItem,
@@ -638,18 +560,13 @@ function buildPrivateSendDisplayTransfers({
   sender,
   network,
   nativeTokenInfo,
-  token,
 }: {
   historyTx: IAccountHistoryTx;
   sender: string;
   network?: IPrivateSendHistoryNetwork;
   nativeTokenInfo?: IToken;
-  token?: ISwapToken;
 }) {
-  const sendTransfers = applyPrivateSendDisplayTransferPrice({
-    transfers: getPrivateSendHistorySendTransfers(historyTx),
-    token,
-  });
+  const sendTransfers = getPrivateSendHistorySendTransfers(historyTx);
   const createTokenAccountFee = getPrivateSendCreateTokenAccountFee(historyTx);
   if (!createTokenAccountFee) {
     return sendTransfers;
@@ -758,56 +675,6 @@ function getPrivateSendNativePriceFromFee(historyTx: IAccountHistoryTx) {
   return new BigNumber(totalFeeFiatValue).div(totalFeeInNative).toFixed();
 }
 
-function getPrivateSendDisplayTransferPriceFromToken({
-  transfer,
-  token,
-}: {
-  transfer: IDecodedTxTransferInfo;
-  token?: ISwapToken;
-}) {
-  const price = getPositivePriceValue(token?.price);
-  if (!price) {
-    return undefined;
-  }
-  if (!token) {
-    return undefined;
-  }
-
-  if (isSameTokenAddress(transfer.tokenIdOnNetwork, token.contractAddress)) {
-    return price;
-  }
-
-  if (
-    (!transfer.networkId || token.networkId === transfer.networkId) &&
-    (token.isNative || !token.contractAddress) &&
-    (transfer.isNative || !transfer.tokenIdOnNetwork)
-  ) {
-    return price;
-  }
-
-  return undefined;
-}
-
-function applyPrivateSendDisplayTransferPrice({
-  transfers,
-  token,
-}: {
-  transfers: IDecodedTxTransferInfo[];
-  token?: ISwapToken;
-}) {
-  return transfers.map((transfer) => {
-    if (getPositivePriceValue(transfer.price)) {
-      return transfer;
-    }
-
-    const price = getPrivateSendDisplayTransferPriceFromToken({
-      transfer,
-      token,
-    });
-    return price ? { ...transfer, price } : transfer;
-  });
-}
-
 async function fetchPrivateSendHistoryTokenDetails({
   historyTx,
   accountId,
@@ -857,9 +724,7 @@ function buildSwapToken({
 }): ISwapToken {
   const transfer = getPrivateSendHistoryTransfer(historyTx, tokenInfo);
   const token = tokenInfo ?? tokenDetails?.info;
-  const price =
-    getPositivePriceValue(transfer?.price) ??
-    getPositivePriceValue(tokenDetails?.price);
+  const price = getPositivePriceValue(transfer?.price);
 
   return {
     networkId: historyTx.decodedTx.networkId,
@@ -874,43 +739,6 @@ function buildSwapToken({
     name: token?.name ?? transfer?.name ?? '',
     logoURI: token?.logoURI ?? transfer?.icon,
     price,
-  };
-}
-
-function applyPrivateSendTokenDetailsPrice({
-  item,
-  tokenDetails,
-}: {
-  item: ISwapTxHistory;
-  tokenDetails?: IFetchTokenDetailItem;
-}) {
-  const price = getPositivePriceValue(tokenDetails?.price);
-  if (!price) {
-    return { item, updated: false };
-  }
-
-  const hasFromTokenPrice = !!getPositivePriceValue(
-    item.baseInfo.fromToken.price,
-  );
-  const hasToTokenPrice = !!getPositivePriceValue(item.baseInfo.toToken.price);
-  if (hasFromTokenPrice && hasToTokenPrice) {
-    return { item, updated: false };
-  }
-
-  return {
-    item: {
-      ...item,
-      baseInfo: {
-        ...item.baseInfo,
-        fromToken: hasFromTokenPrice
-          ? item.baseInfo.fromToken
-          : { ...item.baseInfo.fromToken, price },
-        toToken: hasToTokenPrice
-          ? item.baseInfo.toToken
-          : { ...item.baseInfo.toToken, price },
-      },
-    },
-    updated: true,
   };
 }
 
@@ -960,7 +788,6 @@ function buildPrivateSendHistoryItemFromAccountHistory({
     sender,
     network,
     nativeTokenInfo,
-    token,
   });
   const ctx =
     rocketXOrderId || payinAddress || privateSendDisplayTransfers.length
@@ -1137,13 +964,8 @@ export async function maybeOpenPrivateSendHistoryDetail({
           shouldMergeReplayBaseInfo: !!resolvedTokenInfo,
         })
       : { item: replayTxHistoryItem, updated: false };
-  const {
-    item: resolvedTxHistoryItem,
-    updated: shouldPersistResolvedTokenDetails,
-  } = applyPrivateSendTokenDetailsPrice({
-    item: baseTxHistoryItem,
-    tokenDetails: resolvedTokenDetails,
-  });
+  const resolvedTxHistoryItem = baseTxHistoryItem;
+  const shouldPersistResolvedTokenDetails = false;
 
   let orderDetailTxHistoryItem = resolvedTxHistoryItem;
   if (canFetchPrivateSendOrderDetail(resolvedTxHistoryItem)) {


### PR DESCRIPTION
## Summary
- Fix Private Send history detail and history-list fiat display to follow the current selected currency.
- Convert token detail prices from their recorded currency basis before rendering fiat values.
- Stop stale Private Send swap-history prices from being written back into account history, replayed display transfers, or list rows.

## Intent & Context
Private Send rows could show inconsistent fiat values under CNY: detail rows could display a CNY symbol with a USD-like amount, another detail row could keep `$`, and the history list could still show values like `-52 USDC ¥44.90`. Normal transaction details were correct, so the fix keeps normal swap/history rendering behavior and narrows the change to the Private Send data path.

## Root Cause
Private Send reconstructs display data from account history and persisted swap history. That path was reusing token prices from swap history, order detail, token details, account-history transfers, and display-transfer replay without preserving the currency basis. The detail modal also preferred persisted `txHistory.currency`, while the history list directly multiplied `decodedTx.actions[].assetTransfer.*.price` by amount and formatted it with the current settings symbol.

Native tokens such as SOL exposed an extra edge case: some networks resolve native token address to an empty string. The display-price repair originally filtered those native targets out, so only contract tokens like USDT/USDC showed fiat values.

## Design Decisions
- Use current settings as the display currency only for Private Send detail rows; normal swap history keeps using its existing `txHistory.currency` fallback behavior.
- Fetch Private Send display prices at render/detail time and convert from `tokenDetail.currency` to the current selected currency before passing prices to UI rows.
- Keep native token price targets even when `nativeTokenAddress` is empty, so SOL/native rows and network fees can still resolve current fiat values.
- Repair Private Send account-history rows in `ServiceHistory` before returning history data, so Home history, token history, local history, load-more, and All Networks share the same corrected list data.
- Avoid persisting display-only price repairs into swap history or local DB so switching fiat currency later does not reuse stale values.
- Recalculate Private Send network fee fiat from the current native token display price instead of trusting historical fee fiat values.

## Changes Detail
- `SwapHistoryDetailModal.tsx`: adds Private Send display-price resolution, current-currency symbol selection, current-currency network fee calculation, and native token price target preservation.
- `ServiceHistory.ts`: stops applying swap-history token prices back onto account-history transfers, and now repairs Private Send returned history rows with current-currency token/native prices for list display.
- `privateSendHistory.ts`: removes token-detail price backfill and display-transfer price carryover from Private Send history replay.
- `ServiceSwap.ts`: stops order-detail token merge from overwriting current Private Send token price fields.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Mobile / Web / Extension
- **Risk Areas**: Private Send history detail and history-list fiat rendering, especially native-token rows, multi-asset display transfers, local pending/confirmed rows, All Networks history, load-more, and network-fee fiat display.

## Test plan
- [x] `npx oxlint --type-aware packages/kit-bg/src/services/ServiceHistory.ts packages/kit-bg/src/services/ServiceSwap.ts packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx packages/kit/src/views/Swap/utils/privateSendHistory.ts`
- [x] `yarn lint:staged`
- [x] `git diff --check`
- [ ] `yarn tsc:staged` fails on existing unrelated native type baseline: `packages/components/src/composite/SegmentSlider/index.native.tsx` and `packages/shared/src/modules3rdParty/auto-update/index.native.ts`
