### PR TITLE
fix: stabilize wallet cold start token list cache

### DIFF
--- a/packages/kit-bg/src/states/jotai/utils/index.ts
+++ b/packages/kit-bg/src/states/jotai/utils/index.ts
@@ -490,6 +490,60 @@ function scheduleColdStartSave(name: string) {
   }, 2000);
 }
 
+async function flushWebColdStartCacheNowIfNeeded() {
+  if (!platformEnv.isWeb && !platformEnv.isDesktop) {
+    return;
+  }
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { flushColdStartCacheNow } =
+      require('@onekeyhq/shared/src/storage/instance/webColdStartStorage') as typeof import('@onekeyhq/shared/src/storage/instance/webColdStartStorage');
+    await flushColdStartCacheNow();
+  } catch {
+    /* webColdStartStorage may not be loaded on extension UI */
+  }
+}
+
+export async function writeContextAtomColdStartCacheValues({
+  entries,
+  flushImmediately,
+}: {
+  entries: {
+    coldStartScopeKey: string;
+    coldStartCacheKey: IContextAtomColdStartCacheKey;
+    value: unknown;
+  }[];
+  flushImmediately?: boolean;
+}) {
+  if (entries.length === 0) {
+    return;
+  }
+
+  let lastScopedKey = '';
+  for (const { coldStartScopeKey, coldStartCacheKey, value } of entries) {
+    const scopedKey = buildColdStartScopedKey({
+      coldStartScopeKey,
+      coldStartCacheKey,
+    });
+    lastScopedKey = scopedKey;
+    coldStartValuesMap.set(scopedKey, value);
+    coldStartDirtyKeys.add(scopedKey);
+    coldStartLog(`writeNow: ${scopedKey}`);
+  }
+
+  if (flushImmediately) {
+    if (coldStartSaveTimer) {
+      clearTimeout(coldStartSaveTimer);
+      coldStartSaveTimer = undefined;
+    }
+    flushColdStartCache();
+    await flushWebColdStartCacheNowIfNeeded();
+    return;
+  }
+
+  scheduleColdStartSave(lastScopedKey);
+}
+
 let coldStartAppStateListenerRegistered = false;
 function ensureColdStartAppStateListener() {
   if (coldStartAppStateListenerRegistered) return;

--- a/packages/kit-bg/src/states/jotai/utils/index.ts
+++ b/packages/kit-bg/src/states/jotai/utils/index.ts
@@ -434,6 +434,87 @@ const coldStartDirtyKeys = new Set<string>();
 /** Debounce timer for batched MMKV writes */
 let coldStartSaveTimer: ReturnType<typeof setTimeout> | undefined;
 
+const ACCOUNT_SELECTOR_COLD_START_SCOPE_PREFIX = 'store:accountSelector@';
+const RECENT_ACCOUNT_SWITCH_COLD_START_MS = 5 * 60 * 1000;
+const ACCOUNT_SELECTOR_RECENT_SELECTION_CACHE_VERSION = 1;
+
+type IAccountSelectorRecentSelectionCacheItem = {
+  version: typeof ACCOUNT_SELECTOR_RECENT_SELECTION_CACHE_VERSION;
+  updatedAt: number;
+  selectedAccountsMap?: unknown;
+  updateMeta?: unknown;
+};
+
+type IAccountSelectorRecentSelectionCache = Record<
+  string,
+  IAccountSelectorRecentSelectionCacheItem | undefined
+>;
+
+function getRecentAccountSelectorColdStartValue({
+  coldStartScopeKey,
+  coldStartCacheKey,
+}: {
+  coldStartScopeKey: string;
+  coldStartCacheKey: IContextAtomColdStartCacheKey;
+}) {
+  if (!coldStartScopeKey.startsWith(ACCOUNT_SELECTOR_COLD_START_SCOPE_PREFIX)) {
+    return undefined;
+  }
+  const sceneId = coldStartScopeKey.slice(
+    ACCOUNT_SELECTOR_COLD_START_SCOPE_PREFIX.length,
+  );
+  if (!sceneId) {
+    return undefined;
+  }
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { coldStartCacheStorage } =
+      require('@onekeyhq/shared/src/storage/instance/syncStorageInstance') as typeof import('@onekeyhq/shared/src/storage/instance/syncStorageInstance');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { EAppSyncStorageKeys } =
+      require('@onekeyhq/shared/src/storage/syncStorageKeys') as typeof import('@onekeyhq/shared/src/storage/syncStorageKeys');
+
+    const cache =
+      coldStartCacheStorage.getObject<IAccountSelectorRecentSelectionCache>(
+        EAppSyncStorageKeys.onekey_account_selector_recent_selection,
+      );
+    const item = cache?.[sceneId];
+    const now = Date.now();
+    if (
+      item?.version !== ACCOUNT_SELECTOR_RECENT_SELECTION_CACHE_VERSION ||
+      !item.updatedAt ||
+      now - item.updatedAt < 0 ||
+      now - item.updatedAt > RECENT_ACCOUNT_SWITCH_COLD_START_MS
+    ) {
+      return undefined;
+    }
+
+    if (
+      coldStartCacheKey ===
+      CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom
+    ) {
+      return item.selectedAccountsMap;
+    }
+    if (
+      coldStartCacheKey ===
+      CONTEXT_ATOM_COLD_START_CACHE_KEYS.accountSelectorUpdateMetaAtom
+    ) {
+      return item.updateMeta;
+    }
+    if (
+      coldStartCacheKey ===
+      CONTEXT_ATOM_COLD_START_CACHE_KEYS.accountSelectorStorageReadyAtom
+    ) {
+      return true;
+    }
+  } catch {
+    /* best-effort */
+  }
+
+  return undefined;
+}
+
 function flushColdStartCache() {
   if (coldStartDirtyKeys.size === 0) return;
   coldStartLog(
@@ -597,20 +678,26 @@ export function hydrateContextColdStartCacheForProvider({
     const snapshot = (globalThis as any).__ONEKEY_CTX_ATOM_SNAPSHOT__ as
       | Record<string, unknown>
       | undefined;
-    if (!snapshot) {
-      return;
-    }
 
     for (const [
       cacheKey,
       { atom: atomBuilder },
     ] of contextAtomSnapshotRegistry) {
       const typedCacheKey = cacheKey as IContextAtomColdStartCacheKey;
-      const cached = getScopedColdStartSnapshotValue({
-        snapshot,
-        coldStartScopeKey: scope,
-        coldStartCacheKey: typedCacheKey,
-      });
+      const recentAccountSelectorCached =
+        getRecentAccountSelectorColdStartValue({
+          coldStartScopeKey: scope,
+          coldStartCacheKey: typedCacheKey,
+        });
+      const cached =
+        recentAccountSelectorCached ??
+        (snapshot
+          ? getScopedColdStartSnapshotValue({
+              snapshot,
+              coldStartScopeKey: scope,
+              coldStartCacheKey: typedCacheKey,
+            })
+          : undefined);
       if (cached !== undefined && cached !== null) {
         const scopedCacheKey = buildColdStartScopedKey({
           coldStartScopeKey: scope,

--- a/packages/kit/src/components/AccountSelector/AccountSelectorEffects.tsx
+++ b/packages/kit/src/components/AccountSelector/AccountSelectorEffects.tsx
@@ -142,6 +142,11 @@ function AccountSelectorEffectsCmp({ num }: { num: number }) {
             num,
             selectedAccount: selectedAccountRef.current,
           });
+          await actions.current.flushCurrentAccountSelectorColdStartSnapshot({
+            sceneName: sceneNameRef.current,
+            sceneUrl: sceneUrlRef.current,
+            includeActiveAccounts: true,
+          });
           if (activeAccount.account && activeAccount.network?.id) {
             void backgroundApiProxy.serviceAccount.saveAccountAddresses({
               account: activeAccount.account,

--- a/packages/kit/src/components/TokenListView/coldStartDisplayUtils.test.ts
+++ b/packages/kit/src/components/TokenListView/coldStartDisplayUtils.test.ts
@@ -1,7 +1,10 @@
 import { sortTokensByFiatValue } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { IAccountToken, ITokenFiat } from '@onekeyhq/shared/types/token';
 
-import { getColdStartTokenListDisplayMaps } from './coldStartDisplayUtils';
+import {
+  getColdStartTokenListDisplayMaps,
+  isRenderedTokenListCacheEntrySame,
+} from './coldStartDisplayUtils';
 
 function makeToken($key: string, symbol: string): IAccountToken {
   return {
@@ -95,5 +98,64 @@ describe('getColdStartTokenListDisplayMaps', () => {
     expect(displayMaps.tokenListMap).toBe(liveTokenMap);
     expect(displayMaps.aggregateTokenMap).toBe(liveAggregateMap);
     expect(displayMaps.contextTokenListMap).toBe(liveTokenMap);
+  });
+});
+
+describe('isRenderedTokenListCacheEntrySame', () => {
+  it('treats a new token array with the same keys and map references as unchanged', () => {
+    const tokenMap = {
+      'btc--0_native': makeFiat('8'),
+    };
+    const aggregateTokensMap = {
+      aggregate_ETH_: {
+        'evm--1': makeFiat('11'),
+      },
+    };
+    const btc = makeToken('btc--0_native', 'BTC');
+    const eth = makeToken('aggregate_ETH_', 'ETH');
+
+    expect(
+      isRenderedTokenListCacheEntrySame(
+        {
+          tokens: [btc, eth],
+          tokenListMap: tokenMap,
+          aggregateTokensMap,
+          accountId: 'hd-1--0000/0',
+          networkId: 'onekeyall--0',
+        },
+        {
+          tokens: [{ ...btc }, { ...eth }],
+          tokenListMap: tokenMap,
+          aggregateTokensMap,
+          accountId: 'hd-1--0000/0',
+          networkId: 'onekeyall--0',
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it('detects token order changes as cache changes', () => {
+    const tokenMap = {
+      'btc--0_native': makeFiat('8'),
+    };
+    const btc = makeToken('btc--0_native', 'BTC');
+    const eth = makeToken('aggregate_ETH_', 'ETH');
+
+    expect(
+      isRenderedTokenListCacheEntrySame(
+        {
+          tokens: [btc, eth],
+          tokenListMap: tokenMap,
+          accountId: 'hd-1--0000/0',
+          networkId: 'onekeyall--0',
+        },
+        {
+          tokens: [eth, btc],
+          tokenListMap: tokenMap,
+          accountId: 'hd-1--0000/0',
+          networkId: 'onekeyall--0',
+        },
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/kit/src/components/TokenListView/coldStartDisplayUtils.test.ts
+++ b/packages/kit/src/components/TokenListView/coldStartDisplayUtils.test.ts
@@ -1,0 +1,99 @@
+import { sortTokensByFiatValue } from '@onekeyhq/shared/src/utils/tokenUtils';
+import type { IAccountToken, ITokenFiat } from '@onekeyhq/shared/types/token';
+
+import { getColdStartTokenListDisplayMaps } from './coldStartDisplayUtils';
+
+function makeToken($key: string, symbol: string): IAccountToken {
+  return {
+    $key,
+    address: '',
+    decimals: 18,
+    isNative: true,
+    logoURI: '',
+    name: symbol,
+    symbol,
+  } as IAccountToken;
+}
+
+function makeFiat(fiatValue: string, balanceParsed = '1'): ITokenFiat {
+  return {
+    price: Number(fiatValue),
+    price24h: 0,
+    balance: balanceParsed,
+    balanceParsed,
+    fiatValue,
+    currency: 'usd',
+  };
+}
+
+describe('getColdStartTokenListDisplayMaps', () => {
+  it('uses cached token and aggregate maps for first-frame sorting and row values', () => {
+    const btc = makeToken('btc--0_native', 'BTC');
+    const eth = makeToken('aggregate_ETH_', 'ETH');
+
+    const displayMaps = getColdStartTokenListDisplayMaps({
+      shouldUseCachedMaps: true,
+      cachedEntry: {
+        tokens: [btc, eth],
+        tokenListMap: {
+          [btc.$key]: makeFiat('8', '0.0001265'),
+        },
+        aggregateTokensMap: {
+          [eth.$key]: {
+            'evm--1': makeFiat('11', '0.006786'),
+          },
+        },
+        accountId: 'hd-1--0000/0',
+        networkId: 'onekeyall--0',
+      },
+      currentTokenListMap: {},
+      currentAggregateTokenMap: {},
+    });
+
+    expect(displayMaps.isUsingCachedMaps).toBe(true);
+    expect(displayMaps.contextTokenListMap[btc.$key]?.balanceParsed).toBe(
+      '0.0001265',
+    );
+    expect(displayMaps.contextTokenListMap[eth.$key]?.balanceParsed).toBe(
+      '0.006786',
+    );
+
+    const sorted = sortTokensByFiatValue({
+      tokens: [btc, eth],
+      map: {
+        ...displayMaps.tokenListMap,
+        ...displayMaps.aggregateTokenMap,
+      },
+    });
+
+    expect(sorted.map((token) => token.$key)).toEqual([eth.$key, btc.$key]);
+  });
+
+  it('keeps current maps when cached maps should not drive the rendered frame', () => {
+    const liveTokenMap = {
+      'btc--0_native': makeFiat('9'),
+    };
+    const liveAggregateMap = {
+      aggregate_ETH_: makeFiat('12'),
+    };
+
+    const displayMaps = getColdStartTokenListDisplayMaps({
+      shouldUseCachedMaps: false,
+      cachedEntry: {
+        tokens: [makeToken('btc--0_native', 'BTC')],
+        tokenListMap: {
+          'btc--0_native': makeFiat('8'),
+        },
+        accountId: 'hd-1--0000/0',
+        networkId: 'onekeyall--0',
+      },
+      currentTokenListMap: liveTokenMap,
+      currentAggregateTokenMap: liveAggregateMap,
+    });
+
+    expect(displayMaps.isUsingCachedMaps).toBe(false);
+    expect(displayMaps.tokenListMap).toBe(liveTokenMap);
+    expect(displayMaps.aggregateTokenMap).toBe(liveAggregateMap);
+    expect(displayMaps.contextTokenListMap).toBe(liveTokenMap);
+  });
+});

--- a/packages/kit/src/components/TokenListView/coldStartDisplayUtils.ts
+++ b/packages/kit/src/components/TokenListView/coldStartDisplayUtils.ts
@@ -1,0 +1,52 @@
+import { flattenAggregateTokensMap } from '@onekeyhq/shared/src/utils/tokenUtils';
+import type { IAccountToken, ITokenFiat } from '@onekeyhq/shared/types/token';
+
+export type IRenderedTokenListCacheEntry = {
+  tokens: IAccountToken[];
+  tokenListMap?: Record<string, ITokenFiat>;
+  aggregateTokensMap?: Record<string, Record<string, ITokenFiat>>;
+  accountId: string;
+  networkId: string;
+};
+
+export function isRenderedTokenListCacheEntryReady(
+  cachedEntry: IRenderedTokenListCacheEntry | undefined,
+): cachedEntry is IRenderedTokenListCacheEntry & {
+  tokenListMap: Record<string, ITokenFiat>;
+} {
+  return Boolean(cachedEntry?.tokens.length && cachedEntry.tokenListMap);
+}
+
+export function getColdStartTokenListDisplayMaps({
+  shouldUseCachedMaps,
+  cachedEntry,
+  currentTokenListMap,
+  currentAggregateTokenMap,
+}: {
+  shouldUseCachedMaps: boolean;
+  cachedEntry: IRenderedTokenListCacheEntry | undefined;
+  currentTokenListMap: Record<string, ITokenFiat>;
+  currentAggregateTokenMap: Record<string, ITokenFiat>;
+}) {
+  if (shouldUseCachedMaps && isRenderedTokenListCacheEntryReady(cachedEntry)) {
+    const aggregateTokenMap = flattenAggregateTokensMap(
+      cachedEntry.aggregateTokensMap ?? {},
+    );
+    return {
+      aggregateTokenMap,
+      contextTokenListMap: {
+        ...cachedEntry.tokenListMap,
+        ...aggregateTokenMap,
+      },
+      isUsingCachedMaps: true,
+      tokenListMap: cachedEntry.tokenListMap,
+    };
+  }
+
+  return {
+    aggregateTokenMap: currentAggregateTokenMap,
+    contextTokenListMap: currentTokenListMap,
+    isUsingCachedMaps: false,
+    tokenListMap: currentTokenListMap,
+  };
+}

--- a/packages/kit/src/components/TokenListView/coldStartDisplayUtils.ts
+++ b/packages/kit/src/components/TokenListView/coldStartDisplayUtils.ts
@@ -17,6 +17,26 @@ export function isRenderedTokenListCacheEntryReady(
   return Boolean(cachedEntry?.tokens.length && cachedEntry.tokenListMap);
 }
 
+export function isRenderedTokenListCacheEntrySame(
+  currentEntry: IRenderedTokenListCacheEntry | undefined,
+  nextEntry: IRenderedTokenListCacheEntry,
+) {
+  if (
+    !currentEntry ||
+    currentEntry.accountId !== nextEntry.accountId ||
+    currentEntry.networkId !== nextEntry.networkId ||
+    currentEntry.tokenListMap !== nextEntry.tokenListMap ||
+    currentEntry.aggregateTokensMap !== nextEntry.aggregateTokensMap ||
+    currentEntry.tokens.length !== nextEntry.tokens.length
+  ) {
+    return false;
+  }
+
+  return currentEntry.tokens.every(
+    (token, index) => token.$key === nextEntry.tokens[index]?.$key,
+  );
+}
+
 export function getColdStartTokenListDisplayMaps({
   shouldUseCachedMaps,
   cachedEntry,

--- a/packages/kit/src/components/TokenListView/index.tsx
+++ b/packages/kit/src/components/TokenListView/index.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps, ReactElement, ReactNode } from 'react';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
@@ -66,6 +66,11 @@ import { EmptySearch } from '../Empty';
 import { EmptyToken } from '../Empty/EmptyToken';
 import { ListLoading } from '../Loading';
 
+import {
+  type IRenderedTokenListCacheEntry,
+  getColdStartTokenListDisplayMaps,
+  isRenderedTokenListCacheEntryReady,
+} from './coldStartDisplayUtils';
 import { perfTokenListView } from './perfTokenListView';
 import { TokenListFooter } from './TokenListFooter';
 import { TokenListHeader } from './TokenListHeader';
@@ -222,9 +227,6 @@ function TokenListViewCmp(props: IProps) {
   const [searchKey] = useSearchKeyAtom();
   const [renderedTokenListCache, setRenderedTokenListCache] =
     useRenderedTokenListCacheAtom();
-  // Use ref to avoid useMemo→useEffect→setState cycle
-  const renderedTokenListCacheRef = useRef(renderedTokenListCache);
-  renderedTokenListCacheRef.current = renderedTokenListCache;
   const [activeAccountTokenListStateAtomValue] =
     useActiveAccountTokenListStateAtom();
   const activeAccountTokenList =
@@ -234,7 +236,7 @@ function TokenListViewCmp(props: IProps) {
     activeAccountTokenListStateAtomValue;
   const activeAccountTokenListMap =
     props.scopedActiveAccountTokenListMap ?? tokenListMap;
-  const visibleTokenListMap = showActiveAccountTokenList
+  const baseVisibleTokenListMap = showActiveAccountTokenList
     ? activeAccountTokenListMap
     : tokenListMap;
 
@@ -275,16 +277,45 @@ function TokenListViewCmp(props: IProps) {
       ? `${ownerCacheAccountId}__${networkId}`
       : '';
 
+  const ownerCachedTokenListEntry = useMemo(() => {
+    return ownerCacheKey
+      ? ((renderedTokenListCache.byOwner?.[ownerCacheKey] as
+          | IRenderedTokenListCacheEntry
+          | undefined) ?? undefined)
+      : undefined;
+  }, [ownerCacheKey, renderedTokenListCache]);
+
+  const shouldUseColdStartCachedMaps =
+    !showActiveAccountTokenList &&
+    isRenderedTokenListCacheEntryReady(ownerCachedTokenListEntry) &&
+    (ownerMismatch || !tokenListState.initialized);
+
+  const tokenListDisplayMaps = useMemo(
+    () =>
+      getColdStartTokenListDisplayMaps({
+        shouldUseCachedMaps: shouldUseColdStartCachedMaps,
+        cachedEntry: ownerCachedTokenListEntry,
+        currentTokenListMap: baseVisibleTokenListMap,
+        currentAggregateTokenMap: aggregateTokenMap,
+      }),
+    [
+      aggregateTokenMap,
+      baseVisibleTokenListMap,
+      ownerCachedTokenListEntry,
+      shouldUseColdStartCachedMaps,
+    ],
+  );
+
+  const visibleTokenListMap = tokenListDisplayMaps.tokenListMap;
+  const effectiveAggregateTokenMap = tokenListDisplayMaps.aggregateTokenMap;
+
   const tokens = useMemo(() => {
     if (ownerMismatch && !showActiveAccountTokenList) {
-      const cached =
-        ownerCacheKey &&
-        renderedTokenListCacheRef.current.byOwner?.[ownerCacheKey];
       // Require a paired `tokenListMap` — otherwise we'd render tokens
       // against the previous owner's map (no balance/price). Legacy cache
       // entries from an earlier build don't carry it; treat them as misses.
-      if (cached && cached.tokens.length > 0 && cached.tokenListMap) {
-        return cached.tokens;
+      if (isRenderedTokenListCacheEntryReady(ownerCachedTokenListEntry)) {
+        return ownerCachedTokenListEntry.tokens;
       }
       return [];
     }
@@ -308,7 +339,7 @@ function TokenListViewCmp(props: IProps) {
       resultTokens = resultTokens.filter((item) => {
         const tokenBalance = new BigNumber(
           visibleTokenListMap[item.$key]?.balance ??
-            aggregateTokenMap[item.$key]?.balance ??
+            effectiveAggregateTokenMap[item.$key]?.balance ??
             0,
         );
 
@@ -374,24 +405,21 @@ function TokenListViewCmp(props: IProps) {
 
     // Cold-start fallback: when atoms haven't loaded yet for the current
     // owner, reuse the per-owner cache so the user sees their last known list
-    // immediately. Read from ref to avoid useMemo→useEffect→setState cycle.
+    // immediately.
     if (
       !showActiveAccountTokenList &&
       resultTokens.length === 0 &&
       !tokenListState.initialized
     ) {
-      const cached =
-        ownerCacheKey &&
-        renderedTokenListCacheRef.current.byOwner?.[ownerCacheKey];
-      if (cached && cached.tokens.length > 0 && cached.tokenListMap) {
-        return cached.tokens;
+      if (isRenderedTokenListCacheEntryReady(ownerCachedTokenListEntry)) {
+        return ownerCachedTokenListEntry.tokens;
       }
     }
 
     return resultTokens;
   }, [
     ownerMismatch,
-    ownerCacheKey,
+    ownerCachedTokenListEntry,
     showActiveAccountTokenList,
     isTokenSelector,
     searchKey,
@@ -401,7 +429,7 @@ function TokenListViewCmp(props: IProps) {
     tokenList.tokens,
     smallBalanceTokenList.smallBalanceTokens,
     visibleTokenListMap,
-    aggregateTokenMap,
+    effectiveAggregateTokenMap,
     keepDefaultZeroBalanceTokens,
     homeDefaultTokenMap,
     customTokens,
@@ -521,7 +549,8 @@ function TokenListViewCmp(props: IProps) {
 
   const [{ sortType, sortDirection }] = useTokenListSortAtom();
 
-  const { networksMap } = useTokenListViewContext();
+  const { allAggregateTokenMap: contextAllAggregateTokenMap, networksMap } =
+    useTokenListViewContext();
   const [localAggregateTokensListMap] = useAggregateTokensListMapAtom();
 
   const filteredTokens = useMemo(() => {
@@ -538,7 +567,7 @@ function TokenListViewCmp(props: IProps) {
       networksMap: useNetworkSearch ? networksMap : undefined,
       enableNetworkSearch: useNetworkSearch,
       tokenFiatMap: useNetworkSearch
-        ? { ...visibleTokenListMap, ...aggregateTokenMap }
+        ? { ...visibleTokenListMap, ...effectiveAggregateTokenMap }
         : undefined,
       localAggregateTokenListMap:
         useNetworkSearch && !showActiveAccountTokenList
@@ -553,7 +582,7 @@ function TokenListViewCmp(props: IProps) {
           sortDirection,
           map: {
             ...visibleTokenListMap,
-            ...aggregateTokenMap,
+            ...effectiveAggregateTokenMap,
           },
         });
       } else if (sortType === ETokenListSortType.Value) {
@@ -562,7 +591,7 @@ function TokenListViewCmp(props: IProps) {
           sortDirection,
           map: {
             ...visibleTokenListMap,
-            ...aggregateTokenMap,
+            ...effectiveAggregateTokenMap,
           },
         });
       } else if (sortType === ETokenListSortType.Name) {
@@ -590,7 +619,19 @@ function TokenListViewCmp(props: IProps) {
     sortType,
     sortDirection,
     visibleTokenListMap,
-    aggregateTokenMap,
+    effectiveAggregateTokenMap,
+  ]);
+
+  const tokenListViewContextValue = useMemo(() => {
+    return {
+      allAggregateTokenMap: contextAllAggregateTokenMap,
+      networksMap,
+      tokenListMap: tokenListDisplayMaps.contextTokenListMap,
+    };
+  }, [
+    contextAllAggregateTokenMap,
+    networksMap,
+    tokenListDisplayMaps.contextTokenListMap,
   ]);
 
   const limitedTokens = useMemo(() => {
@@ -645,14 +686,9 @@ function TokenListViewCmp(props: IProps) {
     // back to a previously-rendered network/account. Require a paired
     // `tokenListMap` so we don't suppress the skeleton over a legacy entry
     // that would render tokens against the previous owner's map.
-    const cached =
-      ownerCacheKey &&
-      renderedTokenListCacheRef.current.byOwner?.[ownerCacheKey];
     if (
       !showActiveAccountTokenList &&
-      cached &&
-      cached.tokens.length > 0 &&
-      cached.tokenListMap
+      isRenderedTokenListCacheEntryReady(ownerCachedTokenListEntry)
     ) {
       return false;
     }
@@ -670,7 +706,7 @@ function TokenListViewCmp(props: IProps) {
     );
   }, [
     ownerMismatch,
-    ownerCacheKey,
+    ownerCachedTokenListEntry,
     isTokenSelector,
     searchAll,
     tokenSelectorSearchKey,
@@ -874,121 +910,125 @@ function TokenListViewCmp(props: IProps) {
     }
 
     return (
-      <YStack testID={testID}>
-        {withHeader ? (
-          <TokenListHeader
-            onManageToken={onManageToken}
-            manageTokenEnabled={manageTokenEnabled}
-            {...(tokens.length > 0 && {
-              tableLayout,
-            })}
-          />
-        ) : null}
-        {limitedTokens.map((item) => (
-          <TokenListItem
-            hideValue={hideValue}
-            hideBalanceAndValue={hideBalanceAndValue}
-            token={item}
-            key={item.$key}
-            onPress={onPressToken}
-            tableLayout={tableLayout}
-            withPrice={withPrice}
-            isAllNetworks={isAllNetworks}
-            withNetwork={withNetwork}
-            isTokenSelector={isTokenSelector}
-            withSwapAction={withSwapAction}
-            showNetworkIcon={showNetworkIcon}
-            withAggregateBadge={withAggregateBadge}
-            showProcessingState={!!exchangeFilter}
-            testIDPrefix={tokenItemTestIDPrefix}
-            {...(tableLayout
-              ? undefined
-              : {
-                  mx: '$2',
-                  px: '$3',
-                })}
-          />
-        ))}
-        {renderPlainModeFooter()}
-      </YStack>
+      <TokenListViewContext.Provider value={tokenListViewContextValue}>
+        <YStack testID={testID}>
+          {withHeader ? (
+            <TokenListHeader
+              onManageToken={onManageToken}
+              manageTokenEnabled={manageTokenEnabled}
+              {...(tokens.length > 0 && {
+                tableLayout,
+              })}
+            />
+          ) : null}
+          {limitedTokens.map((item) => (
+            <TokenListItem
+              hideValue={hideValue}
+              hideBalanceAndValue={hideBalanceAndValue}
+              token={item}
+              key={item.$key}
+              onPress={onPressToken}
+              tableLayout={tableLayout}
+              withPrice={withPrice}
+              isAllNetworks={isAllNetworks}
+              withNetwork={withNetwork}
+              isTokenSelector={isTokenSelector}
+              withSwapAction={withSwapAction}
+              showNetworkIcon={showNetworkIcon}
+              withAggregateBadge={withAggregateBadge}
+              showProcessingState={!!exchangeFilter}
+              testIDPrefix={tokenItemTestIDPrefix}
+              {...(tableLayout
+                ? undefined
+                : {
+                    mx: '$2',
+                    px: '$3',
+                  })}
+            />
+          ))}
+          {renderPlainModeFooter()}
+        </YStack>
+      </TokenListViewContext.Provider>
     );
   }
 
   return (
-    <ListComponent
-      testID={testID}
-      // @ts-ignore
-      estimatedItemSize={tableLayout ? undefined : 60}
-      showsVerticalScrollIndicator={false}
-      refreshControl={
-        onRefresh ? <PullToRefresh onRefresh={onRefresh} /> : undefined
-      }
-      extraData={limitedTokens.length}
-      data={limitedTokens}
-      windowSize={platformEnv.isNativeAndroid && inTabList ? 3 : undefined}
-      contentContainerStyle={resolvedContentContainerStyle as any}
-      ListHeaderComponentStyle={resolvedListHeaderComponentStyle as any}
-      ListFooterComponentStyle={resolvedListFooterComponentStyle as any}
-      ListHeaderComponent={
-        withHeader ? (
-          <TokenListHeader
-            onManageToken={onManageToken}
-            manageTokenEnabled={manageTokenEnabled}
-            {...(tokens.length > 0 && {
-              tableLayout,
-            })}
-          />
-        ) : null
-      }
-      ListEmptyComponent={EmptyComponentElement}
-      renderItem={({ item, index }) => (
-        <>
-          <TokenListItem
-            hideValue={hideValue}
-            hideBalanceAndValue={hideBalanceAndValue}
-            token={item}
-            key={item.$key}
-            onPress={onPressToken}
-            tableLayout={tableLayout}
-            withPrice={withPrice}
-            isAllNetworks={isAllNetworks}
-            withNetwork={withNetwork}
-            isTokenSelector={isTokenSelector}
-            withSwapAction={withSwapAction}
-            showNetworkIcon={showNetworkIcon}
-            withAggregateBadge={withAggregateBadge}
-            showProcessingState={!!exchangeFilter}
-            testIDPrefix={tokenItemTestIDPrefix}
-          />
-          {isTokenSelector &&
-          tokenSelectorSearchTokenState.isSearching &&
-          index === limitedTokens.length - 1 ? (
-            <ListLoading isTokenSelectorView={!tableLayout} />
-          ) : null}
-        </>
-      )}
-      ListFooterComponent={
-        <Stack pb="$5">
-          {withFooter ? (
-            <TokenListFooter
-              tableLayout={tableLayout}
-              hideZeroBalanceTokens={hideZeroBalanceTokens}
-              hasTokens={filteredTokens.length > 0}
+    <TokenListViewContext.Provider value={tokenListViewContextValue}>
+      <ListComponent
+        testID={testID}
+        // @ts-ignore
+        estimatedItemSize={tableLayout ? undefined : 60}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          onRefresh ? <PullToRefresh onRefresh={onRefresh} /> : undefined
+        }
+        extraData={limitedTokens.length}
+        data={limitedTokens}
+        windowSize={platformEnv.isNativeAndroid && inTabList ? 3 : undefined}
+        contentContainerStyle={resolvedContentContainerStyle as any}
+        ListHeaderComponentStyle={resolvedListHeaderComponentStyle as any}
+        ListFooterComponentStyle={resolvedListFooterComponentStyle as any}
+        ListHeaderComponent={
+          withHeader ? (
+            <TokenListHeader
+              onManageToken={onManageToken}
               manageTokenEnabled={manageTokenEnabled}
-              plainMode={plainMode}
+              {...(tokens.length > 0 && {
+                tableLayout,
+              })}
             />
-          ) : null}
-          {!tokenSelectorSearchKey && footerTipText ? (
-            <Stack jc="center" ai="center" pt="$3">
-              <SizableText size="$bodySm" color="$textSubdued">
-                {footerTipText}
-              </SizableText>
-            </Stack>
-          ) : null}
-          {addPaddingOnListFooter ? <Stack h="$16" /> : null}
-        </Stack>
-      }
-    />
+          ) : null
+        }
+        ListEmptyComponent={EmptyComponentElement}
+        renderItem={({ item, index }) => (
+          <>
+            <TokenListItem
+              hideValue={hideValue}
+              hideBalanceAndValue={hideBalanceAndValue}
+              token={item}
+              key={item.$key}
+              onPress={onPressToken}
+              tableLayout={tableLayout}
+              withPrice={withPrice}
+              isAllNetworks={isAllNetworks}
+              withNetwork={withNetwork}
+              isTokenSelector={isTokenSelector}
+              withSwapAction={withSwapAction}
+              showNetworkIcon={showNetworkIcon}
+              withAggregateBadge={withAggregateBadge}
+              showProcessingState={!!exchangeFilter}
+              testIDPrefix={tokenItemTestIDPrefix}
+            />
+            {isTokenSelector &&
+            tokenSelectorSearchTokenState.isSearching &&
+            index === limitedTokens.length - 1 ? (
+              <ListLoading isTokenSelectorView={!tableLayout} />
+            ) : null}
+          </>
+        )}
+        ListFooterComponent={
+          <Stack pb="$5">
+            {withFooter ? (
+              <TokenListFooter
+                tableLayout={tableLayout}
+                hideZeroBalanceTokens={hideZeroBalanceTokens}
+                hasTokens={filteredTokens.length > 0}
+                manageTokenEnabled={manageTokenEnabled}
+                plainMode={plainMode}
+              />
+            ) : null}
+            {!tokenSelectorSearchKey && footerTipText ? (
+              <Stack jc="center" ai="center" pt="$3">
+                <SizableText size="$bodySm" color="$textSubdued">
+                  {footerTipText}
+                </SizableText>
+              </Stack>
+            ) : null}
+            {addPaddingOnListFooter ? <Stack h="$16" /> : null}
+          </Stack>
+        }
+      />
+    </TokenListViewContext.Provider>
   );
 }
 

--- a/packages/kit/src/components/TokenListView/index.tsx
+++ b/packages/kit/src/components/TokenListView/index.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps, ReactElement, ReactNode } from 'react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
@@ -70,6 +70,7 @@ import {
   type IRenderedTokenListCacheEntry,
   getColdStartTokenListDisplayMaps,
   isRenderedTokenListCacheEntryReady,
+  isRenderedTokenListCacheEntrySame,
 } from './coldStartDisplayUtils';
 import { perfTokenListView } from './perfTokenListView';
 import { TokenListFooter } from './TokenListFooter';
@@ -227,6 +228,11 @@ function TokenListViewCmp(props: IProps) {
   const [searchKey] = useSearchKeyAtom();
   const [renderedTokenListCache, setRenderedTokenListCache] =
     useRenderedTokenListCacheAtom();
+  // Keep cache reads out of the token-list memo dependency graph. The cache
+  // write effect depends on `tokens`, so making `tokens` react to cache writes
+  // can recreate a useMemo -> useEffect -> setState loop.
+  const renderedTokenListCacheRef = useRef(renderedTokenListCache);
+  renderedTokenListCacheRef.current = renderedTokenListCache;
   const [activeAccountTokenListStateAtomValue] =
     useActiveAccountTokenListStateAtom();
   const activeAccountTokenList =
@@ -277,13 +283,15 @@ function TokenListViewCmp(props: IProps) {
       ? `${ownerCacheAccountId}__${networkId}`
       : '';
 
-  const ownerCachedTokenListEntry = useMemo(() => {
+  const getOwnerCachedTokenListEntry = useCallback(() => {
     return ownerCacheKey
-      ? ((renderedTokenListCache.byOwner?.[ownerCacheKey] as
+      ? ((renderedTokenListCacheRef.current.byOwner?.[ownerCacheKey] as
           | IRenderedTokenListCacheEntry
           | undefined) ?? undefined)
       : undefined;
-  }, [ownerCacheKey, renderedTokenListCache]);
+  }, [ownerCacheKey]);
+
+  const ownerCachedTokenListEntry = getOwnerCachedTokenListEntry();
 
   const shouldUseColdStartCachedMaps =
     !showActiveAccountTokenList &&
@@ -294,14 +302,14 @@ function TokenListViewCmp(props: IProps) {
     () =>
       getColdStartTokenListDisplayMaps({
         shouldUseCachedMaps: shouldUseColdStartCachedMaps,
-        cachedEntry: ownerCachedTokenListEntry,
+        cachedEntry: getOwnerCachedTokenListEntry(),
         currentTokenListMap: baseVisibleTokenListMap,
         currentAggregateTokenMap: aggregateTokenMap,
       }),
     [
       aggregateTokenMap,
       baseVisibleTokenListMap,
-      ownerCachedTokenListEntry,
+      getOwnerCachedTokenListEntry,
       shouldUseColdStartCachedMaps,
     ],
   );
@@ -314,8 +322,9 @@ function TokenListViewCmp(props: IProps) {
       // Require a paired `tokenListMap` — otherwise we'd render tokens
       // against the previous owner's map (no balance/price). Legacy cache
       // entries from an earlier build don't carry it; treat them as misses.
-      if (isRenderedTokenListCacheEntryReady(ownerCachedTokenListEntry)) {
-        return ownerCachedTokenListEntry.tokens;
+      const cachedEntry = getOwnerCachedTokenListEntry();
+      if (isRenderedTokenListCacheEntryReady(cachedEntry)) {
+        return cachedEntry.tokens;
       }
       return [];
     }
@@ -411,15 +420,16 @@ function TokenListViewCmp(props: IProps) {
       resultTokens.length === 0 &&
       !tokenListState.initialized
     ) {
-      if (isRenderedTokenListCacheEntryReady(ownerCachedTokenListEntry)) {
-        return ownerCachedTokenListEntry.tokens;
+      const cachedEntry = getOwnerCachedTokenListEntry();
+      if (isRenderedTokenListCacheEntryReady(cachedEntry)) {
+        return cachedEntry.tokens;
       }
     }
 
     return resultTokens;
   }, [
     ownerMismatch,
-    ownerCachedTokenListEntry,
+    getOwnerCachedTokenListEntry,
     showActiveAccountTokenList,
     isTokenSelector,
     searchKey,
@@ -498,11 +508,7 @@ function TokenListViewCmp(props: IProps) {
           }
         }
 
-        // MRU re-insertion: delete first so the spread below puts the
-        // current owner at the end of the key order. Combined with the
-        // size cap below, this keeps the most recently used entries.
-        delete nextByOwner[ownerCacheKey];
-        nextByOwner[ownerCacheKey] = {
+        const nextEntry: IRenderedTokenListCacheEntry = {
           tokens,
           tokenListMap,
           // Persist the raw aggregate-token map alongside `tokenListMap`
@@ -513,6 +519,24 @@ function TokenListViewCmp(props: IProps) {
           accountId,
           networkId,
         };
+        const currentKeys = Object.keys(nextByOwner);
+        const isCurrentOwnerMostRecent =
+          currentKeys[currentKeys.length - 1] === ownerCacheKey;
+        if (
+          isCurrentOwnerMostRecent &&
+          isRenderedTokenListCacheEntrySame(
+            nextByOwner[ownerCacheKey],
+            nextEntry,
+          )
+        ) {
+          return prev;
+        }
+
+        // MRU re-insertion: delete first so the spread below puts the
+        // current owner at the end of the key order. Combined with the
+        // size cap below, this keeps the most recently used entries.
+        delete nextByOwner[ownerCacheKey];
+        nextByOwner[ownerCacheKey] = nextEntry;
 
         const keys = Object.keys(nextByOwner);
         if (keys.length > RENDERED_TOKEN_LIST_CACHE_MAX_OWNERS) {
@@ -688,7 +712,7 @@ function TokenListViewCmp(props: IProps) {
     // that would render tokens against the previous owner's map.
     if (
       !showActiveAccountTokenList &&
-      isRenderedTokenListCacheEntryReady(ownerCachedTokenListEntry)
+      isRenderedTokenListCacheEntryReady(getOwnerCachedTokenListEntry())
     ) {
       return false;
     }
@@ -706,7 +730,7 @@ function TokenListViewCmp(props: IProps) {
     );
   }, [
     ownerMismatch,
-    ownerCachedTokenListEntry,
+    getOwnerCachedTokenListEntry,
     isTokenSelector,
     searchAll,
     tokenSelectorSearchKey,

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -28,6 +28,7 @@ import type {
   IAccountSelectorSelectedAccountsMap,
 } from '@onekeyhq/kit-bg/src/dbs/simple/entity/SimpleDbEntityAccountSelector';
 import type { IJotaiSetter } from '@onekeyhq/kit-bg/src/states/jotai/types';
+import { writeContextAtomColdStartCacheValues } from '@onekeyhq/kit-bg/src/states/jotai/utils';
 import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import {
@@ -35,6 +36,10 @@ import {
   WALLET_TYPE_IMPORTED,
   WALLET_TYPE_WATCHING,
 } from '@onekeyhq/shared/src/consts/dbConsts';
+import {
+  CONTEXT_ATOM_COLD_START_CACHE_KEYS,
+  type IContextAtomColdStartCacheKey,
+} from '@onekeyhq/shared/src/consts/jotaiConsts';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { type IOneKeyError } from '@onekeyhq/shared/src/errors/types/errorTypes';
 import { isHardwareErrorByCode } from '@onekeyhq/shared/src/errors/utils/deviceErrorUtils';
@@ -151,6 +156,75 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
       }
       return newValue;
     });
+  }
+
+  buildAccountSelectorColdStartScopeKey({
+    sceneName,
+    sceneUrl,
+  }: {
+    sceneName: EAccountSelectorSceneName | undefined;
+    sceneUrl?: string;
+  }) {
+    if (!sceneName) {
+      return undefined;
+    }
+    const sceneId = accountSelectorUtils.buildAccountSelectorSceneId({
+      sceneName,
+      sceneUrl,
+    });
+    return `store:accountSelector@${sceneId}`;
+  }
+
+  async flushAccountSelectorColdStartSnapshot({
+    sceneName,
+    sceneUrl,
+    selectedAccounts,
+    activeAccounts,
+  }: {
+    sceneName: EAccountSelectorSceneName | undefined;
+    sceneUrl?: string;
+    selectedAccounts?: ISelectedAccountsAtomMap;
+    activeAccounts?: Partial<{
+      [num: number]: IAccountSelectorActiveAccountInfo;
+    }>;
+  }) {
+    try {
+      const coldStartScopeKey = this.buildAccountSelectorColdStartScopeKey({
+        sceneName,
+        sceneUrl,
+      });
+      if (!coldStartScopeKey) {
+        return;
+      }
+
+      await writeContextAtomColdStartCacheValues({
+        flushImmediately: true,
+        entries: [
+          selectedAccounts
+            ? {
+                coldStartScopeKey,
+                coldStartCacheKey:
+                  CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom,
+                value: selectedAccounts,
+              }
+            : undefined,
+          activeAccounts
+            ? {
+                coldStartScopeKey,
+                coldStartCacheKey:
+                  CONTEXT_ATOM_COLD_START_CACHE_KEYS.activeAccountsAtom,
+                value: activeAccounts,
+              }
+            : undefined,
+        ].filter(Boolean) as {
+          coldStartScopeKey: string;
+          coldStartCacheKey: IContextAtomColdStartCacheKey;
+          value: unknown;
+        }[],
+      });
+    } catch {
+      // Cold-start snapshots are a best-effort fast path; simpleDb remains the source of truth.
+    }
   }
 
   mutex = new Semaphore(1);
@@ -585,6 +659,33 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
           indexedAccountId: indexedAccount?.id,
         }),
       });
+
+      const sceneInfo = await this.getCurrentSceneInfo.call(set);
+      const selectedAccount = this.getSelectedAccount.call(set, { num });
+
+      await this.reloadActiveAccountInfo.call(set, {
+        num,
+        selectedAccount,
+      });
+
+      const activeAccounts = get(activeAccountsAtom());
+      await this.flushAccountSelectorColdStartSnapshot({
+        sceneName: sceneInfo?.sceneName,
+        sceneUrl: sceneInfo?.sceneUrl,
+        selectedAccounts: get(selectedAccountsAtom()),
+        activeAccounts,
+      });
+
+      if (sceneInfo?.sceneName) {
+        await this.saveToStorage.call(set, {
+          selectedAccount,
+          sceneName: sceneInfo.sceneName,
+          sceneUrl: sceneInfo.sceneUrl,
+          num,
+          selectedAccountUpdatedAt: get(accountSelectorUpdateMetaAtom())[num]
+            ?.updatedAt,
+        });
+      }
 
       appEventBus.emit(EAppEventBusNames.ConfirmAccountSelected, {
         num,

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -106,6 +106,8 @@ import type {
 
 const { serviceAccount } = backgroundApiProxy;
 
+const RECENT_ACCOUNT_SWITCH_COLD_START_MS = 5 * 60 * 1000;
+
 export type IAccountSelectorSyncFromSceneParams = {
   from: {
     sceneName: EAccountSelectorSceneName;
@@ -180,12 +182,16 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
     sceneUrl,
     selectedAccounts,
     activeAccounts,
+    updateMeta,
   }: {
     sceneName: EAccountSelectorSceneName | undefined;
     sceneUrl?: string;
     selectedAccounts?: ISelectedAccountsAtomMap;
     activeAccounts?: Partial<{
       [num: number]: IAccountSelectorActiveAccountInfo;
+    }>;
+    updateMeta?: Partial<{
+      [num: number]: IAccountSelectorUpdateMeta;
     }>;
   }) {
     try {
@@ -216,6 +222,14 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
                 value: activeAccounts,
               }
             : undefined,
+          updateMeta
+            ? {
+                coldStartScopeKey,
+                coldStartCacheKey:
+                  CONTEXT_ATOM_COLD_START_CACHE_KEYS.accountSelectorUpdateMetaAtom,
+                value: updateMeta,
+              }
+            : undefined,
         ].filter(Boolean) as {
           coldStartScopeKey: string;
           coldStartCacheKey: IContextAtomColdStartCacheKey;
@@ -225,6 +239,62 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
     } catch {
       // Cold-start snapshots are a best-effort fast path; simpleDb remains the source of truth.
     }
+  }
+
+  flushCurrentAccountSelectorColdStartSnapshot = contextAtomMethod(
+    async (
+      get,
+      _set,
+      {
+        sceneName,
+        sceneUrl,
+        includeActiveAccounts,
+      }: {
+        sceneName: EAccountSelectorSceneName | undefined;
+        sceneUrl?: string;
+        includeActiveAccounts?: boolean;
+      },
+    ) => {
+      await this.flushAccountSelectorColdStartSnapshot({
+        sceneName,
+        sceneUrl,
+        selectedAccounts: get(selectedAccountsAtom()),
+        updateMeta: get(accountSelectorUpdateMetaAtom()),
+        activeAccounts: includeActiveAccounts
+          ? get(activeAccountsAtom())
+          : undefined,
+      });
+    },
+  );
+
+  shouldKeepColdStartSelectedAccounts({
+    selectedAccountsMap,
+    selectedAccountsMapInDB,
+    updateMeta,
+  }: {
+    selectedAccountsMap: ISelectedAccountsAtomMap;
+    selectedAccountsMapInDB: IAccountSelectorSelectedAccountsMap | undefined;
+    updateMeta: Partial<{
+      [num: number]: IAccountSelectorUpdateMeta;
+    }>;
+  }) {
+    if (isEqual(selectedAccountsMapInDB, selectedAccountsMap)) {
+      return false;
+    }
+    const hasSelectedAccount = Object.values(selectedAccountsMap).some(
+      (selectedAccount) =>
+        selectedAccount && !isEqual(selectedAccount, defaultSelectedAccount()),
+    );
+    if (!hasSelectedAccount) {
+      return false;
+    }
+    const now = Date.now();
+    return Object.values(updateMeta).some(
+      (meta) =>
+        meta?.updatedAt &&
+        now - meta.updatedAt >= 0 &&
+        now - meta.updatedAt <= RECENT_ACCOUNT_SWITCH_COLD_START_MS,
+    );
   }
 
   mutex = new Semaphore(1);
@@ -663,28 +733,22 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
       const sceneInfo = await this.getCurrentSceneInfo.call(set);
       const selectedAccount = this.getSelectedAccount.call(set, { num });
 
-      await this.reloadActiveAccountInfo.call(set, {
-        num,
-        selectedAccount,
-      });
-
-      const activeAccounts = get(activeAccountsAtom());
-      await this.flushAccountSelectorColdStartSnapshot({
+      await this.flushCurrentAccountSelectorColdStartSnapshot.call(set, {
         sceneName: sceneInfo?.sceneName,
         sceneUrl: sceneInfo?.sceneUrl,
-        selectedAccounts: get(selectedAccountsAtom()),
-        activeAccounts,
       });
 
       if (sceneInfo?.sceneName) {
-        await this.saveToStorage.call(set, {
-          selectedAccount,
-          sceneName: sceneInfo.sceneName,
-          sceneUrl: sceneInfo.sceneUrl,
-          num,
-          selectedAccountUpdatedAt: get(accountSelectorUpdateMetaAtom())[num]
-            ?.updatedAt,
-        });
+        void this.saveToStorage
+          .call(set, {
+            selectedAccount,
+            sceneName: sceneInfo.sceneName,
+            sceneUrl: sceneInfo.sceneUrl,
+            num,
+            selectedAccountUpdatedAt: get(accountSelectorUpdateMetaAtom())[num]
+              ?.updatedAt,
+          })
+          .catch(() => undefined);
       }
 
       appEventBus.emit(EAppEventBusNames.ConfirmAccountSelected, {
@@ -1879,6 +1943,18 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
       }
 
       const selectedAccountsMap = get(selectedAccountsAtom());
+      const updateMeta = get(accountSelectorUpdateMetaAtom());
+      if (
+        this.shouldKeepColdStartSelectedAccounts({
+          selectedAccountsMap,
+          selectedAccountsMapInDB,
+          updateMeta,
+        })
+      ) {
+        set(accountSelectorStorageReadyAtom(), () => true);
+        return;
+      }
+
       if (
         selectedAccountsMapInDB &&
         !isEqual(selectedAccountsMapInDB, selectedAccountsMap)
@@ -2620,6 +2696,8 @@ export function useAccountSelectorActions() {
   const getActiveAccount = actions.getActiveAccount.use();
   const initFromStorage = actions.initFromStorage.use();
   const saveToStorage = actions.saveToStorage.use();
+  const flushCurrentAccountSelectorColdStartSnapshot =
+    actions.flushCurrentAccountSelectorColdStartSnapshot.use();
 
   const clearSelectedAccount = actions.clearSelectedAccount.use();
   const updateSelectedAccountFocusedWallet =
@@ -2669,6 +2747,7 @@ export function useAccountSelectorActions() {
     refresh,
     initFromStorage,
     saveToStorage,
+    flushCurrentAccountSelectorColdStartSnapshot,
     clearSelectedAccount,
     updateSelectedAccountNetwork,
     updateSelectedAccountDeriveType,

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -68,6 +68,8 @@ import {
   EModalRoutes,
   EOnboardingPages,
 } from '@onekeyhq/shared/src/routes';
+import { coldStartCacheStorage } from '@onekeyhq/shared/src/storage/instance/syncStorageInstance';
+import { EAppSyncStorageKeys } from '@onekeyhq/shared/src/storage/syncStorageKeys';
 import accountSelectorUtils from '@onekeyhq/shared/src/utils/accountSelectorUtils';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
@@ -107,6 +109,21 @@ import type {
 const { serviceAccount } = backgroundApiProxy;
 
 const RECENT_ACCOUNT_SWITCH_COLD_START_MS = 5 * 60 * 1000;
+const ACCOUNT_SELECTOR_RECENT_SELECTION_CACHE_VERSION = 1;
+
+type IAccountSelectorRecentSelectionCacheItem = {
+  version: typeof ACCOUNT_SELECTOR_RECENT_SELECTION_CACHE_VERSION;
+  updatedAt: number;
+  selectedAccountsMap: ISelectedAccountsAtomMap;
+  updateMeta: Partial<{
+    [num: number]: IAccountSelectorUpdateMeta;
+  }>;
+};
+
+type IAccountSelectorRecentSelectionCache = Record<
+  string,
+  IAccountSelectorRecentSelectionCacheItem
+>;
 
 export type IAccountSelectorSyncFromSceneParams = {
   from: {
@@ -175,6 +192,178 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
       sceneUrl,
     });
     return `store:accountSelector@${sceneId}`;
+  }
+
+  buildAccountSelectorRecentSelectionCacheSceneId({
+    sceneName,
+    sceneUrl,
+  }: {
+    sceneName: EAccountSelectorSceneName | undefined;
+    sceneUrl?: string;
+  }) {
+    if (!sceneName) {
+      return undefined;
+    }
+    return accountSelectorUtils.buildAccountSelectorSceneId({
+      sceneName,
+      sceneUrl,
+    });
+  }
+
+  getRecentAccountSelectorSelectionCache({
+    sceneName,
+    sceneUrl,
+  }: {
+    sceneName: EAccountSelectorSceneName | undefined;
+    sceneUrl?: string;
+  }): IAccountSelectorRecentSelectionCacheItem | undefined {
+    try {
+      const sceneId = this.buildAccountSelectorRecentSelectionCacheSceneId({
+        sceneName,
+        sceneUrl,
+      });
+      if (!sceneId) {
+        return undefined;
+      }
+      const cache =
+        coldStartCacheStorage.getObject<IAccountSelectorRecentSelectionCache>(
+          EAppSyncStorageKeys.onekey_account_selector_recent_selection,
+        );
+      const item = cache?.[sceneId];
+      const now = Date.now();
+      if (
+        item?.version !== ACCOUNT_SELECTOR_RECENT_SELECTION_CACHE_VERSION ||
+        !item.updatedAt ||
+        now - item.updatedAt < 0 ||
+        now - item.updatedAt > RECENT_ACCOUNT_SWITCH_COLD_START_MS
+      ) {
+        return undefined;
+      }
+      return cloneDeep(item);
+    } catch {
+      return undefined;
+    }
+  }
+
+  setRecentAccountSelectorSelectionCache({
+    sceneName,
+    sceneUrl,
+    num,
+    selectedAccountsMap,
+    updateMeta,
+  }: {
+    sceneName: EAccountSelectorSceneName | undefined;
+    sceneUrl?: string;
+    num?: number;
+    selectedAccountsMap: ISelectedAccountsAtomMap;
+    updateMeta: Partial<{
+      [num: number]: IAccountSelectorUpdateMeta;
+    }>;
+  }) {
+    try {
+      const sceneId = this.buildAccountSelectorRecentSelectionCacheSceneId({
+        sceneName,
+        sceneUrl,
+      });
+      if (!sceneId) {
+        return;
+      }
+      const now = Date.now();
+      const cache =
+        coldStartCacheStorage.getObject<IAccountSelectorRecentSelectionCache>(
+          EAppSyncStorageKeys.onekey_account_selector_recent_selection,
+        ) ?? {};
+      const nextCache: IAccountSelectorRecentSelectionCache = {};
+      Object.entries(cache).forEach(([key, item]) => {
+        if (
+          item?.version === ACCOUNT_SELECTOR_RECENT_SELECTION_CACHE_VERSION &&
+          item.updatedAt &&
+          now - item.updatedAt >= 0 &&
+          now - item.updatedAt <= RECENT_ACCOUNT_SWITCH_COLD_START_MS
+        ) {
+          nextCache[key] = item;
+        }
+      });
+      const setCacheItem = ({
+        targetSceneId,
+        targetSelectedAccountsMap,
+        targetUpdateMeta,
+      }: {
+        targetSceneId: string;
+        targetSelectedAccountsMap: ISelectedAccountsAtomMap;
+        targetUpdateMeta: Partial<{
+          [targetNum: number]: IAccountSelectorUpdateMeta;
+        }>;
+      }) => {
+        nextCache[targetSceneId] = {
+          version: ACCOUNT_SELECTOR_RECENT_SELECTION_CACHE_VERSION,
+          updatedAt: now,
+          selectedAccountsMap: cloneDeep(targetSelectedAccountsMap),
+          updateMeta: cloneDeep(targetUpdateMeta),
+        };
+      };
+
+      setCacheItem({
+        targetSceneId: sceneId,
+        targetSelectedAccountsMap: selectedAccountsMap,
+        targetUpdateMeta: updateMeta,
+      });
+
+      const selectedAccountForHomeSync = selectedAccountsMap[0];
+      const updateMetaForHomeSync = updateMeta[0];
+      if (
+        num === 0 &&
+        selectedAccountForHomeSync &&
+        updateMetaForHomeSync &&
+        (sceneName === EAccountSelectorSceneName.home ||
+          sceneName === EAccountSelectorSceneName.swap)
+      ) {
+        const homeSyncSceneName =
+          sceneName === EAccountSelectorSceneName.home
+            ? EAccountSelectorSceneName.swap
+            : EAccountSelectorSceneName.home;
+        const homeSyncSceneId =
+          this.buildAccountSelectorRecentSelectionCacheSceneId({
+            sceneName: homeSyncSceneName,
+          });
+        if (homeSyncSceneId) {
+          const homeSyncSelectedAccountsMap = cloneDeep(
+            nextCache[homeSyncSceneId]?.selectedAccountsMap ?? {},
+          );
+          const homeSyncUpdateMeta = cloneDeep(
+            nextCache[homeSyncSceneId]?.updateMeta ?? {},
+          );
+          homeSyncSelectedAccountsMap[0] = selectedAccountForHomeSync;
+          homeSyncUpdateMeta[0] = updateMetaForHomeSync;
+          setCacheItem({
+            targetSceneId: homeSyncSceneId,
+            targetSelectedAccountsMap: homeSyncSelectedAccountsMap,
+            targetUpdateMeta: homeSyncUpdateMeta,
+          });
+        }
+      }
+
+      coldStartCacheStorage.setObject(
+        EAppSyncStorageKeys.onekey_account_selector_recent_selection,
+        nextCache,
+      );
+    } catch {
+      // The recent selection cache only protects the quick-kill window.
+    }
+  }
+
+  async flushRecentAccountSelectorSelectionCacheNowIfNeeded() {
+    if (!platformEnv.isWeb && !platformEnv.isDesktop) {
+      return;
+    }
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { flushColdStartCacheNow } =
+        require('@onekeyhq/shared/src/storage/instance/webColdStartStorage') as typeof import('@onekeyhq/shared/src/storage/instance/webColdStartStorage');
+      await flushColdStartCacheNow();
+    } catch {
+      // Native MMKV writes are synchronous; extension background has no cache.
+    }
   }
 
   async flushAccountSelectorColdStartSnapshot({
@@ -719,24 +908,96 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
           autoChangeToAccountMatchedNetworkId,
         });
 
-      await this.updateSelectedAccount.call(set, {
-        num,
-        builder: (v) => ({
-          ...v,
-          networkId: accountNetworkId || v.networkId,
-          walletId,
-          othersWalletAccountId: othersWalletAccount?.id,
-          indexedAccountId: indexedAccount?.id,
-        }),
-      });
+      const oldSelectedAccount: IAccountSelectorSelectedAccount = cloneDeep(
+        this.getSelectedAccount.call(set, { num }) || defaultSelectedAccount(),
+      );
+      const newSelectedAccount: IAccountSelectorSelectedAccount = {
+        ...oldSelectedAccount,
+        networkId: accountNetworkId || oldSelectedAccount.networkId,
+        walletId,
+        othersWalletAccountId: othersWalletAccount?.id,
+        indexedAccountId: indexedAccount?.id,
+      };
+      const shouldUseFastConfirm =
+        !accountNetworkId || accountNetworkId === oldSelectedAccount.networkId;
 
-      const sceneInfo = await this.getCurrentSceneInfo.call(set);
+      if (shouldUseFastConfirm) {
+        if (platformEnv.isWebDappMode) {
+          const oldIsNotAllNetwork =
+            oldSelectedAccount.networkId &&
+            oldSelectedAccount.networkId !== getNetworkIdsMap().onekeyall;
+          const newIsNotAllNetwork =
+            newSelectedAccount.networkId &&
+            newSelectedAccount.networkId !== getNetworkIdsMap().onekeyall;
+          if (newIsNotAllNetwork || oldIsNotAllNetwork) {
+            newSelectedAccount.networkId = getNetworkIdsMap().onekeyall;
+            newSelectedAccount.deriveType = 'default';
+          }
+        }
+        if (
+          newSelectedAccount.indexedAccountId &&
+          newSelectedAccount.othersWalletAccountId &&
+          newSelectedAccount.walletId &&
+          !accountUtils.isOthersWallet({
+            walletId: newSelectedAccount.walletId,
+          })
+        ) {
+          newSelectedAccount.othersWalletAccountId = undefined;
+        }
+        if (
+          !isEqual(
+            omitBy(oldSelectedAccount, isUndefined),
+            omitBy(newSelectedAccount, isUndefined),
+          ) &&
+          !isEmpty(newSelectedAccount)
+        ) {
+          this.setSelectedAccountsAtom(
+            set,
+            (v) => ({
+              ...v,
+              [num]: newSelectedAccount,
+            }),
+            'confirmAccountSelect',
+          );
+          set(accountSelectorUpdateMetaAtom(), (v) => ({
+            ...v,
+            [num]: {
+              eventEmitDisabled: false,
+              updatedAt: Date.now(),
+            },
+          }));
+        }
+      } else {
+        await this.updateSelectedAccount.call(set, {
+          num,
+          builder: (v) => ({
+            ...v,
+            networkId: accountNetworkId || v.networkId,
+            walletId,
+            othersWalletAccountId: othersWalletAccount?.id,
+            indexedAccountId: indexedAccount?.id,
+          }),
+        });
+      }
+
+      const sceneInfo = get(accountSelectorContextDataAtom());
       const selectedAccount = this.getSelectedAccount.call(set, { num });
 
-      await this.flushCurrentAccountSelectorColdStartSnapshot.call(set, {
+      this.setRecentAccountSelectorSelectionCache({
         sceneName: sceneInfo?.sceneName,
         sceneUrl: sceneInfo?.sceneUrl,
+        num,
+        selectedAccountsMap: get(selectedAccountsAtom()),
+        updateMeta: get(accountSelectorUpdateMetaAtom()),
       });
+      await this.flushRecentAccountSelectorSelectionCacheNowIfNeeded();
+
+      void this.flushCurrentAccountSelectorColdStartSnapshot
+        .call(set, {
+          sceneName: sceneInfo?.sceneName,
+          sceneUrl: sceneInfo?.sceneUrl,
+        })
+        .catch(() => undefined);
 
       if (sceneInfo?.sceneName) {
         void this.saveToStorage
@@ -1940,6 +2201,50 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
             selectedAccountsMap: selectedAccountsMapInDB,
           },
         );
+      }
+
+      const recentSelectionCache = this.getRecentAccountSelectorSelectionCache({
+        sceneName,
+        sceneUrl,
+      });
+      if (
+        recentSelectionCache &&
+        this.shouldKeepColdStartSelectedAccounts({
+          selectedAccountsMap: recentSelectionCache.selectedAccountsMap,
+          selectedAccountsMapInDB,
+          updateMeta: recentSelectionCache.updateMeta,
+        })
+      ) {
+        this.setSelectedAccountsAtom(
+          set,
+          () => recentSelectionCache.selectedAccountsMap,
+          'initFromRecentSelectionCache',
+        );
+        set(accountSelectorUpdateMetaAtom(), (v) => ({
+          ...v,
+          ...recentSelectionCache.updateMeta,
+        }));
+        set(accountSelectorStorageReadyAtom(), () => true);
+        Object.entries(recentSelectionCache.selectedAccountsMap).forEach(
+          ([num, selectedAccount]) => {
+            if (
+              selectedAccount &&
+              !isEqual(selectedAccount, defaultSelectedAccount())
+            ) {
+              void this.saveToStorage
+                .call(set, {
+                  selectedAccount,
+                  sceneName,
+                  sceneUrl,
+                  num: Number(num),
+                  selectedAccountUpdatedAt:
+                    recentSelectionCache.updateMeta[Number(num)]?.updatedAt,
+                })
+                .catch(() => undefined);
+            }
+          },
+        );
+        return;
       }
 
       const selectedAccountsMap = get(selectedAccountsAtom());

--- a/packages/kit/src/states/jotai/contexts/accountSelector/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/atoms.ts
@@ -150,7 +150,14 @@ export const {
   Partial<{
     [num: number]: IAccountSelectorUpdateMeta;
   }>
->({});
+>(
+  {},
+  {
+    coldStartCache: true,
+    coldStartCacheKey:
+      CONTEXT_ATOM_COLD_START_CACHE_KEYS.accountSelectorUpdateMetaAtom,
+  },
+);
 
 export type IAccountSelectorSyncLoadingMeta = {
   isLoading: boolean;

--- a/packages/shared/src/consts/jotaiConsts.ts
+++ b/packages/shared/src/consts/jotaiConsts.ts
@@ -5,6 +5,7 @@ export const CONTEXT_ATOM_COLD_START_CACHE_KEYS = {
   overviewDeFiDataStateAtom: 'ctx:overviewDeFiDataStateAtom',
   walletTopBannersAtom: 'ctx:walletTopBannersAtom',
   selectedAccountsAtom: 'ctx:selectedAccountsAtom',
+  accountSelectorUpdateMetaAtom: 'ctx:accountSelectorUpdateMetaAtom',
   accountSelectorStorageReadyAtom: 'ctx:accountSelectorStorageReadyAtom',
   activeAccountsAtom: 'ctx:activeAccountsAtom',
   renderedTokenListCacheAtom: 'ctx:renderedTokenListCacheAtom',

--- a/packages/shared/src/storage/syncStorageKeys.ts
+++ b/packages/shared/src/storage/syncStorageKeys.ts
@@ -16,6 +16,7 @@ export enum EAppSyncStorageKeys {
   last_valid_server_time = 'last_valid_server_time',
   last_valid_local_time = 'last_valid_local_time',
   onekey_jotai_context_atoms_snapshot = 'onekey_jotai_context_atoms_snapshot',
+  onekey_account_selector_recent_selection = 'onekey_account_selector_recent_selection',
   onekey_swr_cache = 'onekey_swr_cache',
 }
 


### PR DESCRIPTION
## Summary
- Reuse the cached token fiat maps together with cached token rows during Wallet home cold start.
- Keep first-frame token sorting, filtering, and row values on the same cached data source until the current owner token state is initialized.
- Add focused coverage for cached aggregate-token maps driving first-frame values and value-based sorting.

## Intent & Context
The Wallet home cold-start cache had already been added, but iOS frame-by-frame validation showed two regressions on the first visible token-list frames:

- Cached token rows appeared before their price, balance, and fiat value were available, so rows showed placeholders.
- The token order changed in later frames even when no new API result should have forced a user-visible reorder.

The requested behavior was that the first frame should render the full cached asset-list data and that sorting should remain stable unless newer API/local data actually changes the ordering.

## Root Cause
`renderedTokenListCacheAtom` persisted enough data for cold start: cached `tokens`, `tokenListMap`, and `aggregateTokensMap`. The consumer path in `TokenListView` only reused cached `tokens` on the first frame, while sorting/filtering and row components still read the live atom maps. During cold start those live maps can be empty or still reflect the previous owner, which caused rows to render without values and then reorder when the maps became available.

## Design Decisions
- Use the current owner cache entry synchronously inside `TokenListView` when the owner mismatches or the token-list state is not initialized.
- Reuse cached `tokenListMap` and a flattened cached aggregate-token map for filtering, sorting, and the row context, so the first visible frame is internally consistent.
- Keep the existing guard that requires cached rows to be paired with a `tokenListMap`; legacy cache entries without maps are still treated as misses to avoid rendering rows against the wrong owner map.
- Limit the change to the TokenListView cold-start display path. Active-account token-list rendering continues to use the current scoped/live maps.

## Changes Detail
- `packages/kit/src/components/TokenListView/index.tsx`: derives owner-specific cold-start display maps and provides them to sorting/filtering and `TokenListViewContext` while cached data is driving the first frame.
- `packages/kit/src/components/TokenListView/coldStartDisplayUtils.ts`: adds a small helper to select cached versus current token maps and flatten cached aggregate maps.
- `packages/kit/src/components/TokenListView/coldStartDisplayUtils.test.ts`: covers cached map usage for first-frame row values and value sorting, plus the non-cached live-map path.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, especially iOS Wallet home cold start. The touched component is shared, but the guarded path only uses cached maps during cold-start cache fallback.
- **Risk Areas**: Token-list sorting/value display during the transition from cached data to initialized live data; aggregate-token map flattening for cached aggregate rows.

## Test plan
- [x] `yarn jest packages/kit/src/components/TokenListView/coldStartDisplayUtils.test.ts --runInBand`
- [x] `yarn lint:staged`
- [x] iOS cold-start frame-by-frame verification from a 28.3s simulator recording sampled at 5fps: the first visible token-list frame shows `ETH -> BTC -> USDC` with price, balance, and fiat value already present, and subsequent frames keep the same order.
- [ ] `yarn tsc:staged` is currently blocked by existing unrelated baseline errors in `packages/components/src/composite/SegmentSlider/index.native.tsx` and `packages/shared/src/modules3rdParty/auto-update/index.native.ts`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/app-monorepo/pull/12047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->