### PR TITLE
fix: adjust discovery ad badge placement

### DIFF
--- a/packages/components/src/content/AdCornerBadge/index.tsx
+++ b/packages/components/src/content/AdCornerBadge/index.tsx
@@ -9,7 +9,7 @@ import { SizableText, Stack } from '../../primitives';
 import type { IStackProps } from '../../primitives';
 
 type IAdCornerBadgeSize = 'sm' | 'lg';
-type IAdCornerBadgePlacement = 'top-left' | 'top-right';
+type IAdCornerBadgePlacement = 'top-left' | 'top-right' | 'bottom-right';
 
 const adCornerBadgeSizeMap: Record<
   IAdCornerBadgeSize,
@@ -19,14 +19,18 @@ const adCornerBadgeSizeMap: Record<
     paddingY: number;
     fontSize: number;
     lineHeight: number;
+    bg: string;
+    color: string;
   }
 > = {
   sm: {
-    offset: 3,
-    paddingX: 4,
-    paddingY: 1,
-    fontSize: 9,
-    lineHeight: 11,
+    offset: 2,
+    paddingX: 3,
+    paddingY: 0,
+    fontSize: 8,
+    lineHeight: 10,
+    bg: 'rgba(255, 255, 255, 0.5)',
+    color: 'rgba(0, 0, 0, 0.5)',
   },
   lg: {
     offset: 6,
@@ -34,6 +38,8 @@ const adCornerBadgeSizeMap: Record<
     paddingY: 2,
     fontSize: 11,
     lineHeight: 13,
+    bg: 'rgba(255, 255, 255, 0.65)',
+    color: 'rgba(0, 0, 0, 0.65)',
   },
 };
 
@@ -49,26 +55,28 @@ function BasicAdCornerBadge({
   const label = intl.formatMessage({ id: ETranslations.discovery_ad_label });
   const config = adCornerBadgeSizeMap[badgeSize];
   const isTopLeft = placement === 'top-left';
+  const isBottomRight = placement === 'bottom-right';
 
   return (
     <Stack
       role="img"
       aria-label={label}
       position="absolute"
-      top={config.offset}
+      top={isBottomRight ? undefined : config.offset}
+      bottom={isBottomRight ? config.offset : undefined}
       left={isTopLeft ? config.offset : undefined}
       right={isTopLeft ? undefined : config.offset}
       paddingHorizontal={config.paddingX}
       paddingVertical={config.paddingY}
       borderRadius="$full"
-      bg="rgba(255, 255, 255, 0.65)"
+      bg={config.bg}
       pointerEvents="none"
       zIndex={1}
       {...rest}
     >
       <SizableText
         allowFontScaling={false}
-        color="rgba(0, 0, 0, 0.65)"
+        color={config.color}
         fontWeight="500"
         fontSize={config.fontSize}
         lineHeight={config.lineHeight}

--- a/packages/kit/src/views/Discovery/components/DiscoveryItemCard.tsx
+++ b/packages/kit/src/views/Discovery/components/DiscoveryItemCard.tsx
@@ -113,7 +113,9 @@ export function DiscoveryItemCard({
             }
           />
           <InnerStroke borderRadius="$3" />
-          {isAd ? <AdCornerBadge badgeSize="sm" /> : null}
+          {isAd ? (
+            <AdCornerBadge badgeSize="sm" placement="bottom-right" />
+          ) : null}
         </Stack>
         <SizableText
           px="$2"


### PR DESCRIPTION
## Summary
- Move the small Discovery DApp ad badge from the icon top-right corner to the bottom-right corner.
- Reduce the small badge visual weight by lowering its size, padding, and opacity.
- Keep the large banner ad badge behavior unchanged.

## Intent & Context
The user provided a screenshot of the Discovery hot DApp grid and asked to place the ad label at the icon bottom-right while making it less prominent.

## Root Cause
The shared ad badge component only supported top-left and top-right placement, and DiscoveryItemCard used the default top-right placement for small DApp icons.

## Design Decisions
Added a bottom-right placement option to the shared badge component, then applied it only in DiscoveryItemCard so banner ads keep their existing top-left large badge presentation.

## Changes Detail
- packages/components/src/content/AdCornerBadge/index.tsx: added bottom-right placement and separate small/large badge color values.
- packages/kit/src/views/Discovery/components/DiscoveryItemCard.tsx: uses the bottom-right small badge for sponsored DApp icons.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Shared badge styling, limited by preserving existing large badge placement and only changing the Discovery item call site.

## Test plan
- [x] npx oxlint --tsconfig ./tsconfig.json --type-aware packages/components/src/content/AdCornerBadge/index.tsx packages/kit/src/views/Discovery/components/DiscoveryItemCard.tsx --deny-warnings
- [x] yarn lint:staged
- [x] yarn tsc:staged