### PR TITLE
fix: release swap and DeFi fixes (OK-56351, OK-56326, OK-56242, OK-56277)

### DIFF
--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -383,14 +383,6 @@ function getSwapHistoryStateOrderId({
 
 @backgroundClass()
 export default class ServiceSwap extends ServiceBase {
-  private _quoteAbortControllerMap: Partial<
-    Record<EProtocolOfExchange, AbortController | undefined>
-  > = {
-    [EProtocolOfExchange.SWAP]: undefined,
-    [EProtocolOfExchange.LIMIT]: undefined,
-    [EProtocolOfExchange.PRIVATE_SEND]: undefined,
-  };
-
   private _speedSwapQuoteAbortController?: AbortController;
 
   private _checkTokenApproveAllowanceAbortController?: AbortController;
@@ -448,19 +440,6 @@ export default class ServiceSwap extends ServiceBase {
   }
 
   // --------------------- fetch
-  @backgroundMethod()
-  async cancelFetchQuotes(
-    protocol:
-      | ESwapTabSwitchType
-      | EProtocolOfExchange = ESwapTabSwitchType.SWAP,
-  ) {
-    const abortControllerKey = getProtocolOfExchangeFromSwapTab(protocol);
-    if (this._quoteAbortControllerMap[abortControllerKey]) {
-      this._quoteAbortControllerMap[abortControllerKey]?.abort();
-      this._quoteAbortControllerMap[abortControllerKey] = undefined;
-    }
-  }
-
   @backgroundMethod()
   async cancelCheckTokenApproveAllowance() {
     if (this._checkTokenApproveAllowanceAbortController) {
@@ -861,128 +840,6 @@ export default class ServiceSwap extends ServiceBase {
       console.error(e);
       return [];
     }
-  }
-
-  @backgroundMethod()
-  async fetchQuotes({
-    fromToken,
-    toToken,
-    fromTokenAmount,
-    userAddress,
-    slippagePercentage,
-    autoSlippage,
-    blockNumber,
-    receivingAddress,
-    incognito,
-    accountId,
-    protocol,
-    expirationTime,
-    limitPartiallyFillable,
-    kind,
-    toTokenAmount,
-    userMarketPriceRate,
-  }: {
-    fromToken: ISwapToken;
-    toToken: ISwapToken;
-    fromTokenAmount?: string;
-    userAddress?: string;
-    slippagePercentage: number;
-    autoSlippage?: boolean;
-    receivingAddress?: string;
-    incognito?: boolean;
-    blockNumber?: number;
-    accountId?: string;
-    expirationTime?: number;
-    protocol: ESwapTabSwitchType;
-    limitPartiallyFillable?: boolean;
-    kind?: ESwapQuoteKind;
-    toTokenAmount?: string;
-    userMarketPriceRate?: string;
-  }): Promise<IFetchQuoteResult[]> {
-    await this.cancelFetchQuotes(protocol);
-    const denyCrossChainProvider = await this.getDenyCrossChainProvider(
-      fromToken.networkId,
-      toToken.networkId,
-    );
-    const denySingleSwapProvider = await this.getDenySingleSwapProvider(
-      fromToken.networkId,
-      toToken.networkId,
-    );
-    const walletDevice =
-      await this.backgroundApi.serviceAccount.getAccountDeviceSafe({
-        accountId: accountId ?? '',
-      });
-    const params: IFetchQuotesParams = {
-      fromTokenAddress: fromToken.contractAddress,
-      toTokenAddress: toToken.contractAddress,
-      fromTokenAmount,
-      fromNetworkId: fromToken.networkId,
-      toNetworkId: toToken.networkId,
-      protocol: getProtocolOfExchangeFromSwapTab(protocol),
-      userAddress,
-      slippagePercentage,
-      autoSlippage,
-      blockNumber,
-      receivingAddress,
-      expirationTime,
-      limitPartiallyFillable,
-      kind,
-      toTokenAmount,
-      userMarketPriceRate,
-      denyCrossChainProvider,
-      denySingleSwapProvider,
-      walletDeviceType: walletDevice?.deviceType,
-      ...(incognito ? { incognito } : {}),
-    };
-    const quoteAbortControllerKey = getProtocolOfExchangeFromSwapTab(protocol);
-    const quoteAbortController = new AbortController();
-    this._quoteAbortControllerMap[quoteAbortControllerKey] =
-      quoteAbortController;
-    const client = await this.getClient(EServiceEndpointEnum.Swap);
-    const fetchUrl = '/swap/v1/quote';
-    try {
-      const { data } = await client.get<IFetchResponse<IFetchQuoteResult[]>>(
-        fetchUrl,
-        {
-          params,
-          signal: quoteAbortController.signal,
-          headers:
-            await this.backgroundApi.serviceAccountProfile._getWalletTypeHeader(
-              {
-                accountId,
-              },
-            ),
-        },
-      );
-
-      if (data?.code === 0 && data?.data?.length) {
-        return data?.data;
-      }
-    } catch (e) {
-      if (axios.isCancel(e)) {
-        // eslint-disable-next-line no-restricted-syntax, onekey/no-raw-error -- needs standard Error cause semantics
-        throw new Error('swap fetch quote cancel', {
-          cause: ESwapFetchCancelCause.SWAP_QUOTE_CANCEL,
-        });
-      }
-      if (isPrivateSendProtocol(protocol)) {
-        throw e;
-      }
-    } finally {
-      if (
-        this._quoteAbortControllerMap[quoteAbortControllerKey] ===
-        quoteAbortController
-      ) {
-        this._quoteAbortControllerMap[quoteAbortControllerKey] = undefined;
-      }
-    }
-    return [
-      {
-        info: { provider: '', providerName: '' },
-        fromTokenInfo: fromToken,
-        toTokenInfo: toToken,
-      },
-    ]; //  no support providers
   }
 
   @backgroundMethod()

--- a/packages/kit/src/states/jotai/contexts/deFiList/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/deFiList/actions.ts
@@ -96,6 +96,7 @@ class ContextJotaiActionsDeFiList extends ContextJotaiActionsBase {
       value: {
         isRefreshing?: boolean;
         initialized?: boolean;
+        loadedOwnerKey?: string;
       },
     ) => {
       set(deFiListStateAtom(), (v) => ({

--- a/packages/kit/src/states/jotai/contexts/deFiList/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/deFiList/atoms.ts
@@ -37,9 +37,11 @@ export const { atom: deFiListStateAtom, use: useDeFiListStateAtom } =
   contextAtom<{
     isRefreshing: boolean;
     initialized: boolean;
+    loadedOwnerKey?: string;
   }>({
     isRefreshing: true,
     initialized: false,
+    loadedOwnerKey: undefined,
   });
 
 export const { atom: deFiListSlicedAtom, use: useDeFiListSlicedAtom } =

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -589,116 +589,6 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
     },
   );
 
-  runQuote = contextAtomMethod(
-    async (
-      get,
-      set,
-      fromToken: ISwapToken,
-      toToken: ISwapToken,
-      slippagePercentage: number,
-      autoSlippage?: boolean,
-      address?: string,
-      accountId?: string,
-      loadingDelayEnable?: boolean,
-      blockNumber?: number,
-      kind?: ESwapQuoteKind,
-      fromTokenAmount?: string,
-      toTokenAmount?: string,
-      receivingAddress?: string,
-      incognito?: boolean,
-    ) => {
-      const shouldRefreshQuote = get(swapShouldRefreshQuoteAtom());
-      if (shouldRefreshQuote) {
-        this.cleanQuoteInterval();
-        set(swapQuoteActionLockAtom(), (v) => ({ ...v, actionLock: false }));
-        return;
-      }
-      await backgroundApiProxy.serviceSwap.closeApproving();
-      set(swapQuoteEventErrorAtom(), undefined);
-      try {
-        if (!loadingDelayEnable) {
-          set(swapQuoteFetchingAtom(), true);
-        }
-        const protocol = get(swapTypeSwitchAtom());
-        const { swapIncognitoMode } = await settingsAtom.get();
-        const incognitoEnabled =
-          protocol === ESwapTabSwitchType.LIMIT
-            ? false
-            : (incognito ?? swapIncognitoMode);
-        const limitPartiallyFillableObj = get(swapLimitPartiallyFillAtom());
-        const limitPartiallyFillable = limitPartiallyFillableObj.value;
-        const expirationTime = get(swapLimitExpirationTimeAtom());
-        const limitUserMarketPrice = get(swapLimitPriceUseRateAtom());
-        const userMarketPriceRate = getSelectedPairLimitPriceRate({
-          protocol,
-          limitPriceUseRate: limitUserMarketPrice,
-          fromToken,
-          toToken,
-        });
-        const res = await backgroundApiProxy.serviceSwap.fetchQuotes({
-          fromToken,
-          toToken,
-          fromTokenAmount,
-          toTokenAmount,
-          kind,
-          userAddress: address,
-          slippagePercentage,
-          autoSlippage,
-          blockNumber,
-          receivingAddress,
-          incognito: incognitoEnabled,
-          accountId,
-          protocol,
-          userMarketPriceRate,
-          ...(protocol === ESwapTabSwitchType.LIMIT
-            ? {
-                expirationTime: Number(expirationTime.value),
-                limitPartiallyFillable,
-              }
-            : {}),
-        });
-        const currentEventProviderKeys = res.map((quote) =>
-          buildSwapQuoteProviderKey(quote),
-        );
-        if (!loadingDelayEnable) {
-          set(swapQuoteFetchingAtom(), false);
-          set(swapQuoteListAtom(), res);
-          set(
-            swapQuoteCurrentEventProviderKeysAtom(),
-            currentEventProviderKeys,
-          );
-          set(swapQuoteCurrentEventReceivedCountAtom(), res.length);
-          set(swapQuoteEventCompletedAtom(), true);
-          set(swapQuoteEventTotalCountAtom(), {
-            count: res.length,
-          });
-        } else {
-          set(swapSilenceQuoteLoading(), true);
-          setTimeout(() => {
-            set(swapSilenceQuoteLoading(), false);
-            set(swapQuoteListAtom(), res);
-            set(
-              swapQuoteCurrentEventProviderKeysAtom(),
-              currentEventProviderKeys,
-            );
-            set(swapQuoteCurrentEventReceivedCountAtom(), res.length);
-            set(swapQuoteEventCompletedAtom(), true);
-            set(swapQuoteEventTotalCountAtom(), {
-              count: res.length,
-            });
-          }, 800);
-        }
-      } catch (e: any) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        if (e?.cause !== ESwapFetchCancelCause.SWAP_QUOTE_CANCEL) {
-          set(swapQuoteFetchingAtom(), false);
-        }
-      } finally {
-        set(swapQuoteActionLockAtom(), (v) => ({ ...v, actionLock: false }));
-      }
-    },
-  );
-
   quoteEventHandler = contextAtomMethod(
     (
       get,
@@ -1277,7 +1167,6 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       clearTimeout(this.quoteInterval);
       this.quoteInterval = undefined;
     }
-    void backgroundApiProxy.serviceSwap.cancelFetchQuotes();
   };
 
   closeQuoteEvent = () => {

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
@@ -333,6 +333,7 @@ function TokenDetailsHeaderContent({
     tokenDetailsKey,
     isLoadingTokenDetails,
   ]);
+  const tokenLogoURI = tokenDetails?.info?.logoURI ?? tokenInfo.logoURI;
 
   const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
 
@@ -605,7 +606,7 @@ function TokenDetailsHeaderContent({
           networkId={networkId}
           tokenAddress={tokenInfo.address}
           walletType={wallet?.type}
-          tokenLogoURI={tokenInfo.logoURI}
+          tokenLogoURI={tokenLogoURI}
         />
         <TokenDetailsAddressBlock
           shouldShow={shouldShowAddressBlock}

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.loading.test.ts
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.loading.test.ts
@@ -5,22 +5,34 @@ describe('deFiListLoadingReducer', () => {
     expect(deFiListLoadingReducer({ type: 'start' })).toEqual({
       isRefreshing: true,
       initialized: false,
+      loadedOwnerKey: undefined,
     });
   });
 
-  it('clears the flag on "settled"', () => {
-    expect(deFiListLoadingReducer({ type: 'settled' })).toEqual({
-      isRefreshing: false,
-      initialized: true,
-    });
-  });
-
-  it('clears the flag on "error"', () => {
+  it('clears the flag and keeps the loaded owner on "settled"', () => {
     expect(
-      deFiListLoadingReducer({ type: 'error', error: new Error('boom') }),
+      deFiListLoadingReducer({
+        type: 'settled',
+        loadedOwnerKey: 'account-1:network-1',
+      }),
     ).toEqual({
       isRefreshing: false,
       initialized: true,
+      loadedOwnerKey: 'account-1:network-1',
+    });
+  });
+
+  it('clears the flag and keeps the loaded owner on "error"', () => {
+    expect(
+      deFiListLoadingReducer({
+        type: 'error',
+        error: new Error('boom'),
+        loadedOwnerKey: 'account-1:network-1',
+      }),
+    ).toEqual({
+      isRefreshing: false,
+      initialized: true,
+      loadedOwnerKey: 'account-1:network-1',
     });
   });
 });

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -58,7 +58,10 @@ import type {
 
 import { RichBlock } from '../RichBlock/RichBlock';
 
-import { deFiListLoadingReducer } from './deFiListLoadingReducer';
+import {
+  deFiListLoadingReducer,
+  shouldShowDeFiEmptyState,
+} from './deFiListLoadingReducer';
 import { DeFiListSkeleton } from './DeFiListSkeleton';
 import { getOverviewCollapsedProtocolLimit } from './DeFiOverviewPlanner';
 import { formatPortfolioTotal } from './formatPortfolioTotal';
@@ -82,6 +85,17 @@ function buildSingleNetworkDeFiCacheKey({
   accountAddress?: string;
 }) {
   return `${accountId}:${networkId}:${accountAddress ?? ''}`;
+}
+
+function buildDeFiListOwnerKey({
+  accountId,
+  networkId,
+}: {
+  accountId?: string;
+  networkId?: string;
+}) {
+  if (!accountId || !networkId) return undefined;
+  return `${accountId}:${networkId}`;
 }
 
 function MobileProtocolDivider() {
@@ -201,7 +215,8 @@ function DeFiListBlock({
   const { isFocused, isHeaderRefreshing } = useTabIsRefreshingFocused();
 
   const [overview] = useAccountDeFiOverviewAtom();
-  const [{ isRefreshing, initialized }] = useDeFiListStateAtom();
+  const [{ isRefreshing, initialized, loadedOwnerKey }] =
+    useDeFiListStateAtom();
   const [{ protocols }] = useDeFiListProtocolsAtom();
   const [{ protocolMap }] = useDeFiListProtocolMapAtom();
   const [settingsValue] = useSettingsValuePersistAtom();
@@ -247,6 +262,14 @@ function DeFiListBlock({
   const {
     activeAccount: { account, network, wallet },
   } = useActiveAccount({ num: 0 });
+  const currentOwnerKey = useMemo(
+    () =>
+      buildDeFiListOwnerKey({
+        accountId: account?.id,
+        networkId: network?.id,
+      }),
+    [account?.id, network?.id],
+  );
 
   const isForceRefreshRef = useRef(false);
 
@@ -330,11 +353,16 @@ function DeFiListBlock({
         updateDeFiListState({
           initialized: true,
           isRefreshing: false,
+          loadedOwnerKey: currentOwnerKey,
         });
         return;
       }
 
       await backgroundApiProxy.serviceDeFi.abortFetchAccountDeFiPositions();
+      updateDeFiListState({
+        isRefreshing: true,
+        loadedOwnerKey: undefined,
+      });
 
       appEventBus.emit(EAppEventBusNames.TabListStateUpdate, {
         isRefreshing: true,
@@ -385,6 +413,11 @@ function DeFiListBlock({
         updateDeFiListProtocolMap({
           protocolMap: resp.protocolMap,
         });
+        updateDeFiListState({
+          initialized: true,
+          isRefreshing: false,
+          loadedOwnerKey: currentOwnerKey,
+        });
       } catch (e) {
         console.error(e);
       } finally {
@@ -407,6 +440,7 @@ function DeFiListBlock({
       updateDeFiListProtocols,
       updateDeFiListProtocolMap,
       updateDeFiListState,
+      currentOwnerKey,
       sourceCurrencyInfo,
       targetCurrencyInfo,
     ],
@@ -444,7 +478,10 @@ function DeFiListBlock({
       merge: true,
     });
     deFiDataRef.current = defiUtils.getEmptyDeFiData();
-    updateDeFiListState(deFiListLoadingReducer({ type: 'settled' }));
+    updateDeFiListState({
+      ...deFiListLoadingReducer({ type: 'settled' }),
+      loadedOwnerKey: currentOwnerKey,
+    });
   }, 1000);
 
   const handleAllNetworkRequests = useCallback(
@@ -526,6 +563,10 @@ function DeFiListBlock({
   );
 
   const handleClearAllNetworkData = useCallback(() => {
+    updateDeFiListState({
+      isRefreshing: true,
+      loadedOwnerKey: undefined,
+    });
     updateAccountDeFiOverview({
       currency: settings.currencyInfo.id,
       accountId: account?.id,
@@ -553,6 +594,7 @@ function DeFiListBlock({
     updateAccountDeFiOverview,
     updateDeFiListProtocols,
     updateDeFiListProtocolMap,
+    updateDeFiListState,
   ]);
 
   const handleAllNetworkRequestsStarted = useCallback(
@@ -583,13 +625,23 @@ function DeFiListBlock({
         accountId: accountId ?? '',
         networkId: networkId ?? '',
       });
+      updateDeFiListState({
+        isRefreshing: true,
+        loadedOwnerKey: undefined,
+      });
       updateOverviewDeFiDataState({
         accountId: account?.id,
         networkId: network?.id,
         isReady: undefined,
       });
     },
-    [account?.id, network?.id, refreshCacheOnly, updateOverviewDeFiDataState],
+    [
+      account?.id,
+      network?.id,
+      refreshCacheOnly,
+      updateDeFiListState,
+      updateOverviewDeFiDataState,
+    ],
   );
 
   const handleAllNetworkCacheRequests = useCallback(
@@ -781,6 +833,7 @@ function DeFiListBlock({
       updateDeFiListState({
         initialized: true,
         isRefreshing: false,
+        loadedOwnerKey: currentOwnerKey,
       });
       updateAccountDeFiOverview({
         currency: settings.currencyInfo.id,
@@ -809,6 +862,7 @@ function DeFiListBlock({
     network?.id,
     isEmptyAccount,
     network?.isAllNetworks,
+    currentOwnerKey,
     updateDeFiListState,
     updateAccountDeFiOverview,
     updateDeFiListProtocols,
@@ -1125,7 +1179,11 @@ function DeFiListBlock({
         });
         updateDeFiListProtocols({ protocols: payload.protocols });
         updateDeFiListProtocolMap({ protocolMap: payload.protocolMap });
-        updateDeFiListState({ initialized: true, isRefreshing: false });
+        updateDeFiListState({
+          initialized: true,
+          isRefreshing: false,
+          loadedOwnerKey: currentOwnerKey,
+        });
         return;
       }
 
@@ -1168,6 +1226,11 @@ function DeFiListBlock({
         },
         isReady: true,
       });
+      updateDeFiListState({
+        initialized: true,
+        isRefreshing: false,
+        loadedOwnerKey: currentOwnerKey,
+      });
     };
 
     appEventBus.on(
@@ -1185,6 +1248,7 @@ function DeFiListBlock({
     account?.indexedAccountId,
     network?.id,
     network?.isAllNetworks,
+    currentOwnerKey,
     refreshCacheOnly,
     settings.currencyInfo.id,
     updateAccountDeFiOverview,
@@ -1248,11 +1312,13 @@ function DeFiListBlock({
       updateDeFiListState({
         initialized: true,
         isRefreshing: false,
+        loadedOwnerKey: currentOwnerKey,
       });
     }
   }, [
     account?.id,
     network?.id,
+    currentOwnerKey,
     allNetworksResult,
     updateAccountDeFiOverview,
     updateDeFiListProtocols,
@@ -1461,6 +1527,13 @@ function DeFiListBlock({
     handleToggleSliced,
     registerProtocol,
   ]);
+  const shouldShowEmptyDeFi = shouldShowDeFiEmptyState({
+    protocolsLength: protocols.length,
+    initialized,
+    isRefreshing,
+    ownerKey: currentOwnerKey,
+    loadedOwnerKey,
+  });
 
   if (refreshCacheOnly) {
     return null;
@@ -1487,10 +1560,10 @@ function DeFiListBlock({
         contentContainerProps={tableLayout ? { px: '$pagePadding' } : undefined}
         plainContentContainer
         content={
-          !initialized || isRefreshing ? (
-            <DeFiListSkeleton tableLayout={tableLayout} />
-          ) : (
+          shouldShowEmptyDeFi ? (
             <EmptyDeFi tableLayout={tableLayout} />
+          ) : (
+            <DeFiListSkeleton tableLayout={tableLayout} />
           )
         }
       />

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -422,7 +422,12 @@ function DeFiListBlock({
         console.error(e);
       } finally {
         isForceRefreshRef.current = false;
-        updateDeFiListState(deFiListLoadingReducer({ type: 'settled' }));
+        updateDeFiListState(
+          deFiListLoadingReducer({
+            type: 'settled',
+            loadedOwnerKey: currentOwnerKey,
+          }),
+        );
         appEventBus.emit(EAppEventBusNames.TabListStateUpdate, {
           isRefreshing: false,
           type: EHomeTab.DEFI,
@@ -478,10 +483,12 @@ function DeFiListBlock({
       merge: true,
     });
     deFiDataRef.current = defiUtils.getEmptyDeFiData();
-    updateDeFiListState({
-      ...deFiListLoadingReducer({ type: 'settled' }),
-      loadedOwnerKey: currentOwnerKey,
-    });
+    updateDeFiListState(
+      deFiListLoadingReducer({
+        type: 'settled',
+        loadedOwnerKey: currentOwnerKey,
+      }),
+    );
   }, 1000);
 
   const handleAllNetworkRequests = useCallback(
@@ -771,7 +778,12 @@ function DeFiListBlock({
       // `useAllNetworkRequests` fires `onFinished` even when `resp` is
       // null (no positions), where the downstream `allNetworksResult`
       // effect would otherwise skip clearing the loading flag pair.
-      updateDeFiListState(deFiListLoadingReducer({ type: 'settled' }));
+      updateDeFiListState(
+        deFiListLoadingReducer({
+          type: 'settled',
+          loadedOwnerKey: buildDeFiListOwnerKey({ accountId, networkId }),
+        }),
+      );
     },
     [refreshCacheOnly, updateAllNetworkData, updateDeFiListState],
   );

--- a/packages/kit/src/views/Home/components/DeFiListBlock/deFiListLoadingReducer.ts
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/deFiListLoadingReducer.ts
@@ -1,6 +1,7 @@
 export type IDeFiListLoadingState = {
   isRefreshing: boolean;
   initialized: boolean;
+  loadedOwnerKey?: string;
 };
 
 export type IDeFiListLoadingEvent =
@@ -32,4 +33,26 @@ export function deFiListLoadingReducer(
       return _exhaustive;
     }
   }
+}
+
+export function shouldShowDeFiEmptyState({
+  initialized,
+  isRefreshing,
+  loadedOwnerKey,
+  ownerKey,
+  protocolsLength,
+}: {
+  initialized: boolean;
+  isRefreshing: boolean;
+  loadedOwnerKey?: string;
+  ownerKey?: string;
+  protocolsLength: number;
+}) {
+  return (
+    protocolsLength === 0 &&
+    initialized &&
+    !isRefreshing &&
+    Boolean(ownerKey) &&
+    loadedOwnerKey === ownerKey
+  );
 }

--- a/packages/kit/src/views/Home/components/DeFiListBlock/deFiListLoadingReducer.ts
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/deFiListLoadingReducer.ts
@@ -6,8 +6,8 @@ export type IDeFiListLoadingState = {
 
 export type IDeFiListLoadingEvent =
   | { type: 'start' }
-  | { type: 'settled' }
-  | { type: 'error'; error: unknown };
+  | { type: 'settled'; loadedOwnerKey?: string }
+  | { type: 'error'; error: unknown; loadedOwnerKey?: string };
 
 const TERMINAL: IDeFiListLoadingState = {
   isRefreshing: false,
@@ -17,6 +17,7 @@ const TERMINAL: IDeFiListLoadingState = {
 const LOADING: IDeFiListLoadingState = {
   isRefreshing: true,
   initialized: false,
+  loadedOwnerKey: undefined,
 };
 
 export function deFiListLoadingReducer(
@@ -27,7 +28,10 @@ export function deFiListLoadingReducer(
       return LOADING;
     case 'settled':
     case 'error':
-      return TERMINAL;
+      return {
+        ...TERMINAL,
+        loadedOwnerKey: event.loadedOwnerKey,
+      };
     default: {
       const _exhaustive: never = event;
       return _exhaustive;

--- a/packages/kit/src/views/Market/components/tradeHook.tsx
+++ b/packages/kit/src/views/Market/components/tradeHook.tsx
@@ -66,7 +66,7 @@ export const useMarketTradeNetworkId = (
   }, [network, symbol]);
 
 export const useMarketTradeActions = (token: IMarketTokenDetail | null) => {
-  const { symbol = '', name } = token || {};
+  const { symbol = '', name, image } = token || {};
   const intl = useIntl();
   const network = useMarketTradeNetwork(token);
   const networkId = useMarketTradeNetworkId(network, symbol);
@@ -294,10 +294,11 @@ export const useMarketTradeActions = (token: IMarketTokenDetail | null) => {
       // Navigate to protocols list page if multiple providers
       void EarnNavigation.pushToEarnProtocols(navigation, {
         symbol: normalizedSymbol,
+        logoURI: image ? encodeURIComponent(image) : undefined,
         // filterNetworkId: networkId,
       });
     }
-  }, [createAccountIfNotExists, navigation, networkId, symbol]);
+  }, [createAccountIfNotExists, image, navigation, networkId, symbol]);
   const canStaking = useMemo(() => isSupportStaking(symbol), [symbol]);
 
   return useMemo(

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -99,18 +99,25 @@ import { ENFTType } from '@onekeyhq/shared/types/nft';
 import {
   privateSendHelpCenterUrl,
   privateSendProvider,
+  swapQuoteFetchInterval,
   swapSlippageAutoValue,
 } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import type {
   IFetchQuoteInfo,
   IFetchQuoteResult,
+  IFetchQuotesParams,
+  ISwapQuoteEvent,
+  ISwapQuoteEventAutoSlippage,
+  ISwapQuoteEventData,
+  ISwapQuoteEventError,
+  ISwapQuoteEventInfo,
+  ISwapQuoteEventQuoteResult,
   ISwapToken,
   ISwapTxHistory,
   ISwapTxInfo,
 } from '@onekeyhq/shared/types/swap/types';
 import {
   EProtocolOfExchange,
-  ESwapFetchCancelCause,
   ESwapQuoteKind,
   ESwapTabSwitchType,
   ESwapTxHistoryStatus,
@@ -207,6 +214,41 @@ type IPrivateSendBuildCtx = {
   payinAddress?: unknown;
 };
 
+type IPrivateSendQuoteEvent = {
+  type: 'message' | 'done' | 'error' | 'close' | 'open';
+  event: ISwapQuoteEvent;
+  params: IFetchQuotesParams;
+  accountId?: string;
+  tokenPairs: { fromToken: ISwapToken; toToken: ISwapToken };
+};
+
+type IPrivateSendQuoteEventRequest = {
+  fromToken: ISwapToken;
+  toToken: ISwapToken;
+  fromTokenAmount: string;
+  userAddress: string;
+  receivingAddress: string;
+  accountId?: string;
+};
+
+type IPrivateSendQuoteEventsResult = {
+  quotes: IFetchQuoteResult[];
+  quoteError?: string;
+};
+
+let privateSendQuoteEventsSessionId = 0;
+let stopPrivateSendQuoteEventsSession: (() => void) | undefined;
+
+async function cancelPrivateSendQuoteEvents() {
+  const stopSession = stopPrivateSendQuoteEventsSession;
+  if (!stopSession) return;
+
+  privateSendQuoteEventsSessionId += 1;
+  stopPrivateSendQuoteEventsSession = undefined;
+  stopSession();
+  await backgroundApiProxy.serviceSwap.cancelFetchQuoteEvents();
+}
+
 const privateSendValueDropWarningPercent = 5;
 const privateSendValueDropCountdownSeconds = 5;
 
@@ -297,11 +339,304 @@ function isPrivateSendQuoteUsable(
   );
 }
 
-function isSwapQuoteCancelError(error: unknown) {
+function isPrivateSendQuoteEventMatched({
+  event,
+  request,
+}: {
+  event: IPrivateSendQuoteEvent;
+  request: IPrivateSendQuoteEventRequest;
+}) {
   return (
-    (error as { cause?: unknown } | undefined)?.cause ===
-    ESwapFetchCancelCause.SWAP_QUOTE_CANCEL
+    event.accountId === request.accountId &&
+    event.params.protocol === EProtocolOfExchange.PRIVATE_SEND &&
+    event.params.fromTokenAmount === request.fromTokenAmount &&
+    event.params.userAddress === request.userAddress &&
+    event.params.receivingAddress === request.receivingAddress &&
+    event.params.kind === ESwapQuoteKind.SELL &&
+    equalTokenNoCaseSensitive({
+      token1: event.tokenPairs.fromToken,
+      token2: request.fromToken,
+    }) &&
+    equalTokenNoCaseSensitive({
+      token1: event.tokenPairs.toToken,
+      token2: request.toToken,
+    })
   );
+}
+
+function parsePrivateSendQuoteEventData(event: ISwapQuoteEvent) {
+  const data = (event as { data?: unknown }).data;
+  if (typeof data !== 'string' || !data) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(data) as ISwapQuoteEventData;
+  } catch {
+    return undefined;
+  }
+}
+
+function applyPrivateSendAutoSlippage({
+  quote,
+  autoSlippage,
+}: {
+  quote: IFetchQuoteResult;
+  autoSlippage?: ISwapQuoteEventAutoSlippage;
+}) {
+  if (
+    !autoSlippage ||
+    quote.autoSuggestedSlippage ||
+    quote.eventId !== autoSlippage.eventId ||
+    !equalTokenNoCaseSensitive({
+      token1: quote.fromTokenInfo,
+      token2: {
+        networkId: autoSlippage.fromNetworkId,
+        contractAddress: autoSlippage.fromTokenAddress,
+      },
+    }) ||
+    !equalTokenNoCaseSensitive({
+      token1: quote.toTokenInfo,
+      token2: {
+        networkId: autoSlippage.toNetworkId,
+        contractAddress: autoSlippage.toTokenAddress,
+      },
+    })
+  ) {
+    return quote;
+  }
+  return {
+    ...quote,
+    autoSuggestedSlippage: autoSlippage.autoSuggestedSlippage,
+  };
+}
+
+function normalizePrivateSendQuoteEventResults({
+  quotes,
+  request,
+  eventId,
+  autoSlippage,
+}: {
+  quotes: IFetchQuoteResult[];
+  request: IPrivateSendQuoteEventRequest;
+  eventId?: string;
+  autoSlippage?: ISwapQuoteEventAutoSlippage;
+}) {
+  return quotes
+    .map((quote) => applyPrivateSendAutoSlippage({ quote, autoSlippage }))
+    .filter(
+      (quote) =>
+        quote.info.provider &&
+        quote.protocol === EProtocolOfExchange.PRIVATE_SEND &&
+        (!eventId || quote.eventId === eventId) &&
+        equalTokenNoCaseSensitive({
+          token1: quote.fromTokenInfo,
+          token2: request.fromToken,
+        }) &&
+        equalTokenNoCaseSensitive({
+          token1: quote.toTokenInfo,
+          token2: request.toToken,
+        }),
+    );
+}
+
+function mergePrivateSendQuoteEventResults({
+  current,
+  next,
+  request,
+  eventId,
+  autoSlippage,
+}: {
+  current: IFetchQuoteResult[];
+  next: IFetchQuoteResult[];
+  request: IPrivateSendQuoteEventRequest;
+  eventId?: string;
+  autoSlippage?: ISwapQuoteEventAutoSlippage;
+}) {
+  const normalizedNext = normalizePrivateSendQuoteEventResults({
+    quotes: next,
+    request,
+    eventId,
+    autoSlippage,
+  });
+  const updated = current.map((oldQuote) => {
+    const nextQuote = normalizedNext.find(
+      (quote) =>
+        quote.info.provider === oldQuote.info.provider &&
+        quote.info.providerName === oldQuote.info.providerName,
+    );
+    return nextQuote ?? oldQuote;
+  });
+  const additions = normalizedNext.filter(
+    (quote) =>
+      !current.some(
+        (oldQuote) =>
+          quote.info.provider === oldQuote.info.provider &&
+          quote.info.providerName === oldQuote.info.providerName,
+      ),
+  );
+  return normalizePrivateSendQuoteEventResults({
+    quotes: [...updated, ...additions],
+    request,
+    eventId,
+    autoSlippage,
+  });
+}
+
+async function fetchPrivateSendQuotesEvents({
+  request,
+  quoteError,
+}: {
+  request: IPrivateSendQuoteEventRequest;
+  quoteError: string;
+}): Promise<IPrivateSendQuoteEventsResult> {
+  await cancelPrivateSendQuoteEvents();
+
+  privateSendQuoteEventsSessionId += 1;
+  const sessionId = privateSendQuoteEventsSessionId;
+
+  await backgroundApiProxy.serviceSwap.cancelFetchQuoteEvents();
+
+  return new Promise<IPrivateSendQuoteEventsResult>((resolve) => {
+    let settled = false;
+    let quotes: IFetchQuoteResult[] = [];
+    let eventId: string | undefined;
+    let totalQuoteCount: number | undefined;
+    let autoSlippage: ISwapQuoteEventAutoSlippage | undefined;
+    let cleanup = (_cancelEventSource: boolean) => {};
+
+    const isCurrentSession = () =>
+      privateSendQuoteEventsSessionId === sessionId;
+
+    const settle = (
+      result: IPrivateSendQuoteEventsResult,
+      options?: { cancelEventSource?: boolean },
+    ) => {
+      if (settled) return;
+      settled = true;
+      cleanup((options?.cancelEventSource ?? true) && isCurrentSession());
+      resolve(result);
+    };
+
+    const maybeSetEventId = (nextEventId?: string) => {
+      if (!nextEventId) return true;
+      if (eventId && eventId !== nextEventId) return false;
+      eventId = nextEventId;
+      return true;
+    };
+
+    const quoteEventHandler = (event: IPrivateSendQuoteEvent) => {
+      if (!isCurrentSession()) {
+        return;
+      }
+      if (!isPrivateSendQuoteEventMatched({ event, request })) {
+        return;
+      }
+
+      if (event.type === 'message') {
+        const data = parsePrivateSendQuoteEventData(event.event);
+        if (!data) return;
+
+        const errorData = data as ISwapQuoteEventError;
+        if (errorData.errorMessage) {
+          if (!maybeSetEventId(errorData.eventId)) return;
+          settle({ quotes: [], quoteError: errorData.errorMessage });
+          return;
+        }
+
+        const autoSlippageData = data as ISwapQuoteEventAutoSlippage;
+        if (autoSlippageData.autoSuggestedSlippage !== undefined) {
+          if (!maybeSetEventId(autoSlippageData.eventId)) return;
+          autoSlippage = autoSlippageData;
+          quotes = normalizePrivateSendQuoteEventResults({
+            quotes,
+            request,
+            eventId,
+            autoSlippage,
+          });
+          return;
+        }
+
+        if (
+          (data as ISwapQuoteEventInfo).totalQuoteCount ||
+          (data as ISwapQuoteEventInfo).totalQuoteCount === 0
+        ) {
+          const infoData = data as ISwapQuoteEventInfo;
+          if (!maybeSetEventId(infoData.eventId)) return;
+          totalQuoteCount = infoData.totalQuoteCount;
+          if (totalQuoteCount === 0) {
+            settle({ quotes: [] });
+          }
+          return;
+        }
+
+        const quoteResultData = data as ISwapQuoteEventQuoteResult;
+        if (quoteResultData.data?.length) {
+          const quoteEventId = quoteResultData.data[0]?.eventId;
+          if (!maybeSetEventId(quoteEventId)) return;
+          quotes = mergePrivateSendQuoteEventResults({
+            current: quotes,
+            next: quoteResultData.data,
+            request,
+            eventId,
+            autoSlippage,
+          });
+          if (
+            totalQuoteCount !== undefined &&
+            quotes.length >= totalQuoteCount
+          ) {
+            settle({ quotes });
+          }
+        }
+        return;
+      }
+
+      if (event.type === 'done' || event.type === 'close') {
+        settle({ quotes });
+        return;
+      }
+
+      if (event.type === 'error') {
+        settle(quotes.length ? { quotes } : { quotes, quoteError });
+      }
+    };
+
+    const timeoutId = setTimeout(() => {
+      settle(quotes.length ? { quotes } : { quotes, quoteError });
+    }, swapQuoteFetchInterval);
+    const stopCurrentSession = () => {
+      settle({ quotes: [] }, { cancelEventSource: false });
+    };
+    cleanup = (cancelEventSource: boolean) => {
+      clearTimeout(timeoutId);
+      appEventBus.off(EAppEventBusNames.SwapQuoteEvent, quoteEventHandler);
+      if (stopPrivateSendQuoteEventsSession === stopCurrentSession) {
+        stopPrivateSendQuoteEventsSession = undefined;
+      }
+      if (cancelEventSource) {
+        void backgroundApiProxy.serviceSwap.cancelFetchQuoteEvents();
+      }
+    };
+    stopPrivateSendQuoteEventsSession = stopCurrentSession;
+
+    appEventBus.off(EAppEventBusNames.SwapQuoteEvent, quoteEventHandler);
+    appEventBus.on(EAppEventBusNames.SwapQuoteEvent, quoteEventHandler);
+
+    void backgroundApiProxy.serviceSwap
+      .fetchQuotesEvents({
+        fromToken: request.fromToken,
+        toToken: request.toToken,
+        fromTokenAmount: request.fromTokenAmount,
+        userAddress: request.userAddress,
+        receivingAddress: request.receivingAddress,
+        slippagePercentage: swapSlippageAutoValue,
+        protocol: ESwapTabSwitchType.PRIVATE_SEND,
+        kind: ESwapQuoteKind.SELL,
+        accountId: request.accountId,
+      })
+      .catch(() => {
+        settle({ quotes: [], quoteError });
+      });
+  });
 }
 
 function PrivateSendValueDropWarningContent({
@@ -946,17 +1281,27 @@ function SendAmountInputContainer() {
       }
       const scopeKey = privateSendQuoteRequestKey;
       try {
-        const quotes = await backgroundApiProxy.serviceSwap.fetchQuotes({
-          fromToken: privateSendToken,
-          toToken: privateSendToken,
-          fromTokenAmount: amountBN.toFixed(),
-          userAddress: account.address,
-          receivingAddress: privateSendQuoteRecipientAddress,
-          slippagePercentage: swapSlippageAutoValue,
-          protocol: ESwapTabSwitchType.PRIVATE_SEND,
-          kind: ESwapQuoteKind.SELL,
-          accountId: currentAccountId,
+        const { quotes, quoteError } = await fetchPrivateSendQuotesEvents({
+          request: {
+            fromToken: privateSendToken,
+            toToken: privateSendToken,
+            fromTokenAmount: amountBN.toFixed(),
+            userAddress: account.address,
+            receivingAddress: privateSendQuoteRecipientAddress,
+            accountId: currentAccountId,
+          },
+          quoteError: intl.formatMessage({
+            id: ETranslations.global_network_error,
+          }),
         });
+        if (quoteError) {
+          return {
+            selectedQuote: undefined,
+            quotes,
+            scopeKey,
+            quoteError,
+          };
+        }
         const selectedQuote =
           quotes.find((item) => isPrivateSendQuoteUsable(item)) ??
           quotes.find((item) => item.info.provider) ??
@@ -967,10 +1312,7 @@ function SendAmountInputContainer() {
           quotes,
           scopeKey,
         };
-      } catch (error) {
-        if (isSwapQuoteCancelError(error)) {
-          return undefined;
-        }
+      } catch {
         return {
           selectedQuote: undefined,
           quotes: [],
@@ -994,6 +1336,14 @@ function SendAmountInputContainer() {
     ],
     { watchLoading: true, alwaysSetState: true, debounced: 500 },
   );
+  useEffect(() => {
+    if (!canFetchPrivateSendQuote) {
+      void cancelPrivateSendQuoteEvents();
+    }
+    return () => {
+      void cancelPrivateSendQuoteEvents();
+    };
+  }, [canFetchPrivateSendQuote]);
   const isPrivateSendQuoteScopeMatched =
     !!privateSendQuoteResult &&
     privateSendQuoteResult.scopeKey === privateSendQuoteRequestKey;
@@ -3533,7 +3883,7 @@ function SendAmountInputContainer() {
               isRefreshQuote={isPrivateSendQuoteRefreshing}
               isLoading={isPrivateSendQuoteRefreshing}
               isFocused={isRouteFocused}
-              autoRefresh={!isSubmitting}
+              autoRefresh={false}
             />
           </XStack>
           <XStack

--- a/packages/kit/src/views/Swap/pages/modal/swapKLineTokenUtils.ts
+++ b/packages/kit/src/views/Swap/pages/modal/swapKLineTokenUtils.ts
@@ -1,4 +1,5 @@
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { normalizeTokenContractAddress } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 import { ETokenDappType } from '@onekeyhq/shared/types/token';
@@ -16,6 +17,20 @@ type ISwapKLineStableTokenIdentity = {
   isNative?: boolean;
 };
 
+function normalizeSwapKLineStableTokenAddress({
+  networkId,
+  contractAddress,
+}: {
+  networkId: string;
+  contractAddress?: string;
+}) {
+  const address = contractAddress?.trim();
+  if (!address) {
+    return undefined;
+  }
+  return normalizeTokenContractAddress({ networkId, contractAddress: address });
+}
+
 export function isKnownSwapKLineUnsupportedToken(token?: ISwapKLineToken) {
   if (!token) {
     return false;
@@ -29,11 +44,13 @@ export function isKnownSwapKLineUnsupportedToken(token?: ISwapKLineToken) {
 export function getSwapKLineStableTokenAddress(
   token?: ISwapKLineStableTokenIdentity,
 ) {
-  const address = token?.contractAddress?.trim();
-  if (!token?.networkId || token.isNative || !address) {
+  if (!token?.networkId || token.isNative) {
     return undefined;
   }
-  return address.startsWith('0x') ? address.toLowerCase() : address;
+  return normalizeSwapKLineStableTokenAddress({
+    networkId: token.networkId,
+    contractAddress: token.contractAddress,
+  });
 }
 
 export function getSwapKLineStableTokenKey(
@@ -76,13 +93,16 @@ export async function fetchSwapKLineTokenAddressesStableStatus(
 
     return new Map(
       stableCoinsList.flatMap((item) =>
-        item.results.map((result) => {
-          const contractAddress = result.contractAddress.startsWith('0x')
-            ? result.contractAddress.toLowerCase()
-            : result.contractAddress;
+        item.results.flatMap((result) => {
+          const contractAddress = normalizeSwapKLineStableTokenAddress({
+            networkId: item.networkId,
+            contractAddress: result.contractAddress,
+          });
+          if (!contractAddress) {
+            return [];
+          }
           return [
-            `${item.networkId}:${contractAddress}`,
-            result.isStableCoin,
+            [`${item.networkId}:${contractAddress}`, result.isStableCoin],
           ] as const;
         }),
       ),

--- a/packages/shared/src/request/customUA.test.ts
+++ b/packages/shared/src/request/customUA.test.ts
@@ -149,14 +149,6 @@ describe('shouldInjectUAForUrl', () => {
     );
   });
 
-  it('falls back to OneKey-official regex when requestHelper throws (CLI)', async () => {
-    __setCustomUARuntimeForTest('cli-node');
-    checkIsOneKeyDomainMock.mockRejectedValueOnce(new Error('not wired'));
-    expect(
-      await shouldInjectUAForUrl('https://swap.onekeycn.com/swap/v1/quote'),
-    ).toBe(true);
-  });
-
   it('CLI fallback strips port (uses hostname, not host)', async () => {
     __setCustomUARuntimeForTest('cli-node');
     checkIsOneKeyDomainMock.mockRejectedValueOnce(new Error('not wired'));
@@ -185,15 +177,6 @@ describe('shouldInjectUAForUrl', () => {
     (platformEnv as any).appPlatform = 'desktop';
     checkIsOneKeyDomainMock.mockRejectedValueOnce(new Error('not wired'));
     expect(await shouldInjectUAForUrl('https://example.com/foo')).toBe(false);
-  });
-
-  it('Native refuses to fall back when requestHelper throws (avoid mis-inject)', async () => {
-    (platformEnv as any).isNative = true;
-    (platformEnv as any).appPlatform = 'ios';
-    checkIsOneKeyDomainMock.mockRejectedValueOnce(new Error('flaky DI'));
-    expect(
-      await shouldInjectUAForUrl('https://swap.onekeycn.com/swap/v1/quote'),
-    ).toBe(false);
   });
 
   it('returns false on bad URL input', async () => {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56351](https://onekeyhq.atlassian.net/browse/OK-56351) [OK-56326](https://onekeyhq.atlassian.net/browse/OK-56326) [OK-56242](https://onekeyhq.atlassian.net/browse/OK-56242) [OK-56277](https://onekeyhq.atlassian.net/browse/OK-56277)

----------

<!-- github-pr-monitor:jira-links:end -->


## Issues
- Fixes OK-56351
- Fixes OK-56326
- Fixes OK-56242
- Fixes OK-56277

## Summary
- Prevent the DeFi tab from rendering the empty state before the current account/network DeFi request has produced an authoritative result.
- Pass token logo metadata into the Earn protocols route from Market and Token Details entries so the protocols page header does not fall back to the gray placeholder.
- Route Private Send quote requests through the quote events endpoint and remove the obsolete direct quote endpoint usage from the app side.
- Preserve case-sensitive Swap K-line stable-token addresses so SUI USDC can be recognized as a stablecoin.

## Intent & Context
OK-56351 reports that wallet DeFi assets briefly flash an empty state before the actual assets render. The short-term fix keeps the DeFi list loading state authoritative instead of caching protocol data.

OK-56326 reports that the Earn protocols list page can show a gray fallback icon for USDC after entering from Market/Token Details, even though protocol logos and network icons render correctly. Runtime inspection showed the bad page URL only had `symbol=USDC`, so the header had no token logo source.

OK-56242 reports Private Send quote requests returning 403. The Private Send quote path was still using the obsolete `/swap/v1/quote` endpoint; it should use `/swap/v1/quote/events` like the ordinary Swap quote flow.

OK-56277 reports that Swap K-line selection did not treat SUI USDC as a stablecoin. Jira confirms the backend stablecoin list API recognizes `0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC` as stable.

## Root Cause
For OK-56351, the DeFi UI used `protocols.length === 0`, `initialized`, and `isRefreshing` to decide between the skeleton and `EmptyDeFi`. During All Networks loading, the frontend clears the protocol list first, while local DeFi cache only restores overview totals, not protocol rows. `onFinished` can then mark the list as settled before the real protocol result is committed, so the UI can treat an intermediate empty list as a real empty DeFi result.

For OK-56326, the Earn protocols page renders its header token icon from the route `logoURI` param. The Market Earn action navigated with only the normalized symbol, and Token Details could pass the stale token-info logo instead of the loaded detail logo.

For OK-56242, Private Send had a separate quote implementation that still called the old direct quote API and lacked the quote-event session handling/cancellation shape used by regular Swap.

For OK-56277, the Swap K-line stable-token helper lowercased every `0x` contract address. That is safe for EVM-style addresses, but not for case-sensitive token identifiers such as SUI Move types where the module/type suffix `::USDC` must be preserved.

## Design Decisions
- Added an owner-scoped `loadedOwnerKey` to the DeFi list state, keyed by current account and network.
- Render `EmptyDeFi` only when the current owner has loaded and the protocol list is still empty.
- Pass the existing Market token `image` through `EarnNavigation.pushToEarnProtocols` instead of adding page-level async fallback or caching.
- Prefer `tokenDetails.info.logoURI` for the Token Details DeFi entry when detail data has loaded.
- Align Private Send quote fetching with `fetchQuotesEvents`, including active-session guards, provider/event filtering, and no-result timeout handling.
- Reuse the shared token contract normalization rule for Swap K-line stablecoin checks, preserving case-sensitive network identifiers while keeping EVM comparisons case-insensitive.

## Changes Detail
- `DeFiListBlock.tsx`: wires owner-scoped loaded state into single-network, All Networks, empty-account, and DeFi position refresh paths.
- `deFiListLoadingReducer.ts`: adds `loadedOwnerKey` support and a helper for the empty-state display predicate.
- `deFiList` atoms/actions: extends the list state shape to carry the loaded owner key.
- `tradeHook.tsx`: passes the Market token image as the Earn protocols route logo.
- `TokenDetailsHeader.tsx`: passes the loaded token detail logo to the DeFi block when available.
- `SendAmountInputContainer.tsx`: uses quote events for Private Send quotes and cleans the active Private Send quote session when the context changes.
- `ServiceSwap.ts`: removes the obsolete direct quote endpoint path and leaves the quote-events flow as the app-side quote source.
- `swapKLineTokenUtils.ts`: normalizes stablecoin-check addresses by network implementation instead of lowercasing all `0x` strings.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: DeFi tab loading transitions, All Networks refresh, account/network switching, Earn protocols navigation from Market and Token Details, Private Send quote lifecycle, Swap K-line default token selection for stablecoin pairs.

## Test plan
- [x] `yarn jest packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.loading.test.ts --runInBand`
- [x] `yarn jest packages/shared/src/request/customUA.test.ts --runInBand`
- [x] `yarn jest packages/kit/src/views/Swap/pages/modal/swapKLinePriceUtils.test.ts --runInBand`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/Swap/pages/modal/swapKLineTokenUtils.ts --deny-warnings`
- [x] `yarn lint:staged`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Earn/pages/EarnProtocols/index.tsx packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx packages/kit/src/views/Market/components/tradeHook.tsx`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] Desktop runtime: open `/market/tokens/usd-coin`, click `DeFi`, confirm the resulting Earn protocols URL includes `logoURI` and the header renders the blue USDC icon.
- [ ] `yarn tsc:staged` currently fails on unrelated existing `react-router-dom` missing type/module errors in `apps/web-embed/pages/PageIndex.tsx` and `packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.web-embed.ts`.
- [ ] Runtime verify DeFi tab with an account that has DeFi assets: no empty-state flash before protocols render.
- [ ] Runtime verify a true empty account: skeleton/loading first, then empty state after the request completes.
- [ ] Runtime verify Private Send quote on the target environment no longer calls `/swap/v1/quote` and receives quote-events results.
- [ ] Runtime verify Swap K-line for SUI/SUI.USDC defaults to the non-stable token after the stablecoin check resolves.

[OK-56351]: https://onekeyhq.atlassian.net/browse/OK-56351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-56326]: https://onekeyhq.atlassian.net/browse/OK-56326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-56242]: https://onekeyhq.atlassian.net/browse/OK-56242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-56277]: https://onekeyhq.atlassian.net/browse/OK-56277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ