### PR TITLE
fix: ext SES no-eval lockdown + enable prod patch-warning monitor with dedup

### DIFF
--- a/packages/shared/src/security/sesHarden/options.ts
+++ b/packages/shared/src/security/sesHarden/options.ts
@@ -1,5 +1,5 @@
 // cspell:ignore lockdown LOCKDOWN Lockdown
-import type { ISesHardenLevel } from './types';
+import type { ISesHardenLevel, ISesHardenRuntime } from './types';
 import type { LockdownOptions } from 'ses';
 
 export const SES_HARDEN_LOOSE_LOCKDOWN_OPTIONS = {
@@ -17,15 +17,33 @@ export const SES_HARDEN_LOOSE_LOCKDOWN_OPTIONS = {
   legacyRegeneratorRuntimeTaming: 'safe',
 } as const satisfies LockdownOptions;
 
+// Extension runtimes ship with a CSP of `script-src 'self' 'wasm-unsafe-eval'`
+// (see apps/ext/src/manifest/common.js). `'unsafe-eval'` is only injected for
+// dev + non-MV3 builds. Both SES `'unsafe-eval'` (L1) and `'safe-eval'` (L2)
+// rely on host `eval`/`new Function`, which that CSP forbids, so `lockdown()`
+// would throw a CSP `EvalError` at startup and brick every extension context.
+// Force `'no-eval'` for all extension runtimes regardless of the configured
+// level, while keeping the remaining (non-eval) taming dimensions intact.
+function isExtensionRuntime(runtime?: ISesHardenRuntime): boolean {
+  return runtime?.startsWith('ext-') === true;
+}
+
 export function getSesLockdownOptions(
   level: ISesHardenLevel,
+  runtime?: ISesHardenRuntime,
 ): LockdownOptions | undefined {
   if (level === 'L0') {
     return undefined;
   }
 
+  let evalTaming: LockdownOptions['evalTaming'] =
+    level === 'L2' ? 'safe-eval' : 'unsafe-eval';
+  if (isExtensionRuntime(runtime)) {
+    evalTaming = 'no-eval';
+  }
+
   return {
     ...SES_HARDEN_LOOSE_LOCKDOWN_OPTIONS,
-    evalTaming: level === 'L2' ? 'safe-eval' : 'unsafe-eval',
+    evalTaming,
   };
 }

--- a/packages/shared/src/security/sesHarden/runtime.ts
+++ b/packages/shared/src/security/sesHarden/runtime.ts
@@ -16,6 +16,20 @@ import type {
 import type { Harden, LockdownOptions } from 'ses';
 
 export const SES_HARDEN_PATCH_WARNING_LIMIT = 20;
+// Cap the emitted-fingerprint set so a pathological stream of unique
+// post-lockdown patch errors can never grow it without bound. Once the cap is
+// reached we stop tracking new fingerprints (and therefore stop emitting brand
+// new ones) instead of evicting, keeping the dedup guarantee deterministic.
+export const SES_HARDEN_PATCH_WARNING_EMIT_FINGERPRINT_LIMIT = 100;
+
+// Fingerprints we have already emitted (console.warn) during this session.
+// Recording into the in-memory warnings array is always deduped by fingerprint,
+// but emission must also be deduped so a repeated identical patch error cannot
+// spam the console / any downstream log sink with the same entry every time it
+// fires. This lives at module scope so it is shared across calls within the
+// same JS runtime (main / bg / each ext context keep their own copy, matching
+// the per-runtime JS-heap model).
+const sesHardenEmittedWarningFingerprints = new Set<string>();
 
 const SES_HARDEN_LEVELS = new Set<ISesHardenLevel>(['L0', 'L1', 'L2']);
 const SES_HARDEN_PATCH_ERROR_PATTERNS = [
@@ -95,11 +109,15 @@ function getPatchErrorStack(value: unknown): string | undefined {
 }
 
 export function isSesHardenPatchWarningMonitorEnabled(): boolean {
-  if (typeof process === 'undefined') {
-    return true;
-  }
-
-  return process.env?.NODE_ENV !== 'production';
+  // The monitor is install-once (two passive addEventListener registrations)
+  // plus an only-on-violation callback: it fires solely on uncaught `error` /
+  // `unhandledrejection` events, never on any hot/per-operation path, and the
+  // callback bails out immediately via a cheap regex check when the error is
+  // not a post-lockdown patch attempt. That makes it safe to keep enabled in
+  // production so we retain diagnostics there. Emission to the console is
+  // additionally deduped per fingerprint (see recordSesHardenPatchWarning) so
+  // production logs are not flooded by repeated identical warnings.
+  return true;
 }
 
 function isLikelyPostLockdownPatchError(value: unknown): boolean {
@@ -209,11 +227,30 @@ function recordSesHardenPatchWarning(
     // Best-effort diagnostics only.
   }
 
-  // Keep this visible in dev builds so engineers can decide whether the patch
-  // belongs before lockdown or indicates unexpected tampering.
-  console.warn('[OneKey SES Harden] Post-lockdown patch attempt detected', {
-    warning,
-  });
+  // Emit (console.warn) only the first time we see a given fingerprint this
+  // session. Repeated identical warnings still update the in-memory record's
+  // count/lastSeenAt above, but must not re-emit: re-emitting would flood the
+  // console and any downstream log sink with duplicate entries. We only emit
+  // once we have recorded the fingerprint in the dedup set, so once the set
+  // hits its cap any further brand-new fingerprints are dropped from emission
+  // rather than emitted unbounded (a pathological flood of unique fingerprints
+  // cannot spam the log).
+  if (!sesHardenEmittedWarningFingerprints.has(fingerprint)) {
+    if (
+      sesHardenEmittedWarningFingerprints.size <
+      SES_HARDEN_PATCH_WARNING_EMIT_FINGERPRINT_LIMIT
+    ) {
+      sesHardenEmittedWarningFingerprints.add(fingerprint);
+      // Keep this visible so engineers can decide whether the patch belongs
+      // before lockdown or indicates unexpected tampering. Enabled in
+      // production too (see isSesHardenPatchWarningMonitorEnabled), deduped
+      // per fingerprint.
+      console.warn(
+        '[OneKey SES Harden] Post-lockdown patch attempt detected',
+        { warning },
+      );
+    }
+  }
 }
 
 function installSesHardenPatchWarningMonitor(
@@ -300,7 +337,7 @@ export function maybeLockdownOneKeyRuntime(options: {
   lockdown?: (lockdownOptions?: LockdownOptions) => void;
 }): ISesHardenRuntimeState {
   const level = options.level ?? getSesHardenLevelFromRuntime(options.runtime);
-  const lockdownOptions = getSesLockdownOptions(level);
+  const lockdownOptions = getSesLockdownOptions(level, options.runtime);
 
   if (level === 'L0') {
     const state: ISesHardenRuntimeState = {
@@ -360,6 +397,7 @@ export function maybeLockdownOneKeyRuntime(options: {
 
 export function resetSesHardenRuntimeStateForTest(): void {
   appliedState = undefined;
+  sesHardenEmittedWarningFingerprints.clear();
   const g = getSesGlobal();
   try {
     delete g.__ONEKEY_SES_HARDEN_STATE__;

--- a/packages/shared/src/security/sesHarden/runtimeCheck.ts
+++ b/packages/shared/src/security/sesHarden/runtimeCheck.ts
@@ -1314,7 +1314,7 @@ export async function buildSesRuntimeCheckReport(): Promise<ISesRuntimeCheckRepo
     buildCheck(
       'Patch warning monitor',
       'runtime-state',
-      '确认 dev mode 下 L1/L2 已安装 harden 后 patch 失败提醒，L0 和生产环境不安装。',
+      '确认 L1/L2（含生产环境）已安装 harden 后 patch 失败提醒，L0 不安装；提醒按 fingerprint 去重，每个 fingerprint 每个会话只输出一次。',
       shouldInstallPatchWarningMonitor
         ? patchWarningMonitorInstalled
         : !patchWarningMonitorInstalled,

--- a/packages/shared/src/security/sesHarden/sesHarden.test.ts
+++ b/packages/shared/src/security/sesHarden/sesHarden.test.ts
@@ -183,6 +183,60 @@ test('only changes eval taming in L2', () => {
   expect(l2Options?.evalTaming).toBe('safe-eval');
 });
 
+test('forces no-eval for every extension runtime regardless of level', () => {
+  const extRuntimes = [
+    'ext-ui',
+    'ext-background',
+    'ext-offscreen',
+    'ext-passkey',
+  ] as const;
+
+  for (const runtime of extRuntimes) {
+    // The extension CSP (script-src 'self' 'wasm-unsafe-eval') forbids host
+    // eval, so both unsafe-eval (L1) and safe-eval (L2) must collapse to
+    // no-eval to avoid a CSP EvalError at lockdown() time.
+    expect(getSesLockdownOptions('L1', runtime)?.evalTaming).toBe('no-eval');
+    expect(getSesLockdownOptions('L2', runtime)?.evalTaming).toBe('no-eval');
+    // Non-eval taming dimensions stay aligned with the loose defaults.
+    expect(getSesLockdownOptions('L2', runtime)).toEqual({
+      ...getSesLockdownOptions('L2'),
+      evalTaming: 'no-eval',
+    });
+    // L0 stays a true no-lockdown path even for extension runtimes.
+    expect(getSesLockdownOptions('L0', runtime)).toBeUndefined();
+  }
+});
+
+test('does not change eval taming for web or desktop runtimes', () => {
+  expect(getSesLockdownOptions('L1', 'web')?.evalTaming).toBe('unsafe-eval');
+  expect(getSesLockdownOptions('L2', 'web')?.evalTaming).toBe('safe-eval');
+  expect(getSesLockdownOptions('L1', 'desktop-renderer')?.evalTaming).toBe(
+    'unsafe-eval',
+  );
+  expect(getSesLockdownOptions('L2', 'desktop-renderer')?.evalTaming).toBe(
+    'safe-eval',
+  );
+});
+
+test('threads runtime into lockdown options so ext locks down with no-eval', () => {
+  const lockdown = jest.fn();
+
+  const state = maybeLockdownOneKeyRuntime({
+    runtime: 'ext-background',
+    level: 'L2',
+    lockdown,
+  });
+
+  expect(lockdown).toHaveBeenCalledWith(
+    expect.objectContaining({ evalTaming: 'no-eval' }),
+  );
+  expect(state).toMatchObject({
+    runtime: 'ext-background',
+    lockdownApplied: true,
+    evalTaming: 'no-eval',
+  });
+});
+
 test('does not load SES when L0 is selected', () => {
   const loadSes = jest.fn();
 
@@ -270,7 +324,7 @@ test('records post-lockdown patch warning errors', () => {
   }
 });
 
-test('does not install post-lockdown patch warning monitor in production', () => {
+test('installs post-lockdown patch warning monitor in production', () => {
   const g = globalThis as unknown as ISesHardenGlobal;
   const originalAddEventListener = g.addEventListener;
   const originalNodeEnv = process.env.NODE_ENV;
@@ -285,11 +339,10 @@ test('does not install post-lockdown patch warning monitor in production', () =>
       lockdown: jest.fn(),
     });
 
-    expect(g.addEventListener).not.toHaveBeenCalled();
-    expect(
-      g.__ONEKEY_SES_HARDEN_PATCH_WARNING_MONITOR_INSTALLED__,
-    ).toBeUndefined();
-    expect(getSesHardenPatchWarnings()).toEqual([]);
+    // The monitor is install-once + only-on-violation, so it is safe to keep
+    // enabled in production to retain diagnostics there.
+    expect(g.addEventListener).toHaveBeenCalled();
+    expect(g.__ONEKEY_SES_HARDEN_PATCH_WARNING_MONITOR_INSTALLED__).toBe(true);
   } finally {
     if (originalAddEventListener) {
       g.addEventListener = originalAddEventListener;
@@ -301,6 +354,67 @@ test('does not install post-lockdown patch warning monitor in production', () =>
     } else {
       process.env.NODE_ENV = originalNodeEnv;
     }
+  }
+});
+
+test('emits each post-lockdown patch warning fingerprint only once', () => {
+  const g = globalThis as unknown as ISesHardenGlobal;
+  const originalAddEventListener = g.addEventListener;
+  const listeners = new Map<string, EventListenerOrEventListenerObject>();
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+  g.addEventListener = jest.fn((type, listener) => {
+    listeners.set(type, listener);
+  }) as typeof globalThis.addEventListener;
+
+  try {
+    maybeLockdownOneKeyRuntime({
+      runtime: 'web',
+      level: 'L1',
+      lockdown: jest.fn(),
+    });
+
+    const listener = listeners.get('error');
+    expect(listener).toBeDefined();
+
+    const event = {
+      error: new TypeError(
+        "Cannot assign to read only property 'push' of object '[object Array]'",
+      ),
+      filename: 'app.js',
+      lineno: 10,
+      colno: 20,
+    } as unknown as Event;
+
+    const dispatch = () => {
+      if (typeof listener === 'function') {
+        listener(event);
+      } else {
+        listener?.handleEvent(event);
+      }
+    };
+
+    dispatch();
+    dispatch();
+    dispatch();
+
+    // Recorded count keeps incrementing (dedup updates lastSeenAt/count)...
+    expect(getSesHardenPatchWarnings()).toEqual([
+      expect.objectContaining({ count: 3 }),
+    ]);
+    // ...but the console is only warned once per unique fingerprint per session.
+    const patchWarnCalls = warnSpy.mock.calls.filter(
+      ([message]) =>
+        message === '[OneKey SES Harden] Post-lockdown patch attempt detected',
+    );
+    expect(patchWarnCalls).toHaveLength(1);
+  } finally {
+    if (originalAddEventListener) {
+      g.addEventListener = originalAddEventListener;
+    } else {
+      delete g.addEventListener;
+    }
+    warnSpy.mockRestore();
   }
 });
 


### PR DESCRIPTION
Two changes on top of PR #12056 (`codex/ses-harden-web-desktop-ext`).

## 1. fix: force `no-eval` SES lockdown for all extension runtimes (P0)

The extension CSP is `script-src 'self' 'wasm-unsafe-eval'` in production and MV3 builds — `apps/ext/src/manifest/common.js` only injects `'unsafe-eval'` for dev + non-MV3. With `evalTaming` `'unsafe-eval'` (L1) or `'safe-eval'` (L2), SES `lockdown()` relies on host `eval`/`new Function`, which that CSP forbids, so `lockdown()` throws a CSP `EvalError` at startup and bricks all four extension contexts (background, ui, offscreen, passkey).

Fix: `getSesLockdownOptions(level, runtime)` now takes the runtime kind and forces `evalTaming: 'no-eval'` for every `ext-*` runtime, regardless of configured level, while keeping the remaining (non-eval) taming dimensions intact. `maybeLockdownOneKeyRuntime` threads its `runtime` into the call. Web and `desktop-renderer` eval behavior is unchanged.

No try/catch was added around the top-level `maybeLockdownOneKeyRuntime` call: the `no-eval` override is the actual remedy, and swallowing a lockdown failure would mask genuine startup security failures and contradict the existing fail-loud design. Left as-is intentionally.

## 2. feat: enable post-lockdown patch-warning monitor in production with dedup (P2)

`isSesHardenPatchWarningMonitorEnabled()` previously returned false in production, so post-lockdown intrinsic-patch attempts produced zero prod diagnostics.

Performance: the monitor is install-once (two passive `addEventListener` registrations) plus an only-on-violation callback. It fires solely on uncaught `error` / `unhandledrejection` events — never on a hot/per-operation path — and bails out immediately via a cheap regex check when the error is not a post-lockdown patch attempt. It adds no per-operation overhead, so it is safe to keep fully enabled in production (no sampling needed).

Log safety / dedup: emission is now deduped per fingerprint. `console.warn` fires only the first time a given fingerprint is seen this session; repeated identical warnings still update the in-memory record's `count`/`lastSeenAt` but do not re-emit. The emitted-fingerprint `Set` is capped (`SES_HARDEN_PATCH_WARNING_EMIT_FINGERPRINT_LIMIT = 100`) so a flood of unique fingerprints cannot grow it unbounded or spam the log. The monitor's only sink today is `console.warn` plus the existing in-memory diagnostics array (surfaced via the runtime-check report) — no new telemetry sink was introduced.

The runtime-check description and the test suite are updated accordingly (ext no-eval coverage, prod-install coverage, and per-fingerprint single-emit coverage), without weakening existing assertions.

## Files changed
- `packages/shared/src/security/sesHarden/options.ts`
- `packages/shared/src/security/sesHarden/runtime.ts`
- `packages/shared/src/security/sesHarden/runtimeCheck.ts`
- `packages/shared/src/security/sesHarden/sesHarden.test.ts`

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9x33NnaP9yB2jVxog2j9o)_