### PR TITLE
fix: sync perps token navigation(OK-56309)

### DIFF
--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -27,10 +27,7 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EWatchlistFrom } from '@onekeyhq/shared/src/logger/scopes/dex';
-import {
-  EPerpPageEnterSource,
-  setPerpPageEnterSource,
-} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
+import { EPerpPageEnterSource } from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   ERootRoutes,
@@ -47,6 +44,7 @@ import { LeverageBadge } from '../../../Market/components/PerpsBadges';
 import {
   useMarketBasicConfig,
   useNavigateToMarketTab,
+  usePerpsNavigation,
 } from '../../../Market/hooks';
 import { CategorySelector } from '../../../Market/MarketHomeV2/components/CategorySelector';
 import { getNativeTokenInfo } from '../../../Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers';
@@ -191,6 +189,9 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
   const shouldUseTableLayout = Boolean(tableLayout && !md);
   const navigation = useAppNavigation();
   const navigateToMarketTab = useNavigateToMarketTab();
+  const { navigateToPerps } = usePerpsNavigation(
+    EPerpPageEnterSource.PopularTrading,
+  );
   const {
     isLoading: isMarketBasicConfigLoading,
     minLiquidity,
@@ -879,11 +880,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
           });
           return;
         }
-        setPerpPageEnterSource(EPerpPageEnterSource.PopularTrading);
-        navigation.switchTab(ETabRoutes.Perp);
-        void backgroundApiProxy.serviceHyperliquid.changeActiveAsset({
-          coin: record.perpsCoin,
-        });
+        navigateToPerps(record.perpsCoin);
         return;
       }
 
@@ -919,7 +916,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
         });
       }, 300);
     },
-    [navigation, marketTab],
+    [marketTab, navigateToPerps, navigation],
   );
 
   const renderEmptyStateCards = useCallback(() => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/PerpetualTradingBanner/PerpetualTradingBanner.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/PerpetualTradingBanner/PerpetualTradingBanner.tsx
@@ -12,6 +12,10 @@ import {
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useBannerClosePersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import {
@@ -62,6 +66,10 @@ export function PerpetualTradingBanner({
       navigation.switchTab(ETabRoutes.Perp);
       try {
         await backgroundApiProxy.serviceHyperliquid.changeActiveAsset({
+          coin: hlTicker,
+        });
+        appEventBus.emit(EAppEventBusNames.PerpSwitchActiveInstrument, {
+          mode: 'perp',
           coin: hlTicker,
         });
       } catch (error) {

--- a/packages/kit/src/views/Market/hooks/index.ts
+++ b/packages/kit/src/views/Market/hooks/index.ts
@@ -2,3 +2,4 @@ export { useMarketBasicConfig } from './useMarketBasicConfig';
 export { useMarketEnterAnalytics } from './useMarketEnterAnalytics';
 export { useMarketNetworks } from './useMarketNetworks';
 export { useNavigateToMarketTab } from './useNavigateToMarketTab';
+export { usePerpsNavigation } from './usePerpsNavigation';


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56309](https://onekeyhq.atlassian.net/browse/OK-56309)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Route Wallet home Perps favorites through the shared Perps navigation helper so the mounted Perps page receives the instrument switch request.
- Emit `PerpSwitchActiveInstrument` from the Market detail Perps banner after updating the background active asset.
- Export the shared `usePerpsNavigation` hook from Market hooks for reuse.

## Intent & Context
The bug report was that clicking a Perps favorite from the Wallet home page navigated to `/perps?token=BNB`, but the already-open Perps page still showed the previous token such as ETH. The page URL could be correct initially, while the visible Perps instrument did not update.

This fixes OK-56309 by aligning the Wallet home favorite entry path with the existing Market Perps navigation behavior.

## Root Cause
The Wallet home Perps favorite click path called `serviceHyperliquid.changeActiveAsset({ coin })`, which updates the background/global Perps active asset. When the Perps page was already mounted, its UI context `activeTradeInstrumentAtom` stayed on the previous coin. The Perps URL sync effect then continued to reflect that stale UI context, so the page could keep rendering ETH after navigating from a BNB favorite.

The existing Market navigation helper already updates background state and emits `PerpSwitchActiveInstrument`, which `PerpsGlobalEffects` consumes to update the mounted Perps UI context. The Wallet home path was missing that second step.

Runtime note: on web this is a single UI runtime issue. On native, main and bg JS contexts have separate JS heaps; the background/global active asset and the main/UI active trade instrument must be bridged explicitly. This change keeps that bridge explicit and does not touch shared native resources such as MMKV or DB handles.

## Design Decisions
- Reuse `usePerpsNavigation` instead of duplicating the tab switch, background update, and event emission logic in Wallet home.
- Keep extension popup/side-panel behavior unchanged because it opens the expanded tab path directly.
- Add the same mounted-page event emission to the Market detail Perps banner, which had the same direct background update pattern.

## Changes Detail
- `packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx`: uses `usePerpsNavigation(EPerpPageEnterSource.PopularTrading)` for Perps favorite row clicks.
- `packages/kit/src/views/Market/MarketDetailV2/components/PerpetualTradingBanner/PerpetualTradingBanner.tsx`: emits `PerpSwitchActiveInstrument` after `changeActiveAsset`.
- `packages/kit/src/views/Market/hooks/index.ts`: exports `usePerpsNavigation`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web, Desktop, Mobile Perps navigation entry points
- **Risk Areas**: Perps navigation timing when the Perps page is already mounted. The change reuses an existing helper and event path already used by Market lists and universal search.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `yarn test`

[OK-56309]: https://onekeyhq.atlassian.net/browse/OK-56309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ