### PR TITLE
fix: enable referral address save after first selection(OK-56325)

### DIFF
--- a/packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx
@@ -153,16 +153,14 @@ function BasicEditAddress() {
   const { control } = form;
   const networkIdValue = useFormWatch({ control, name: 'networkId' });
   const addressValue = useFormWatch({ control, name: 'to' });
+  const { errors } = form.formState;
   const isEnable = useMemo(() => {
     // filter out error parameters from different segments.
-    const errors = Object.values(form.formState.errors);
-    if (errors.length) {
+    if (Object.values(errors).length) {
       return false;
     }
-    return (
-      !addressValue.pending && !!addressValue.resolved && form.formState.isValid
-    );
-  }, [addressValue.pending, addressValue.resolved, form.formState]);
+    return !addressValue.pending && !!addressValue.resolved;
+  }, [addressValue.pending, addressValue.resolved, errors]);
 
   const { result: addressBookEnabledNetworkIds } = usePromiseResult(
     async () => {


### PR DESCRIPTION
## Summary
- Enable the referral reward withdrawal address Save button immediately after the first valid address selection.
- Remove the stale `formState.isValid` dependency from the Save-button gate and rely on the address input resolved state plus field errors.

## Intent & Context
User feedback reported that on the referral reward address page, when no address was previously bound, selecting or entering an address left the bottom-right Save button disabled until a second interaction. Updating an already-bound address did not have the same problem.

This fix targets OK-56325 and keeps the page behavior unchanged after Save is pressed: `form.submit` still performs the final form validation before binding the rebate withdrawal address.

## Root Cause
This page runs in the main UI JS runtime. The background runtime is only involved after the user confirms Save and the binding request is sent; there is no shared native resource involved in this button state bug.

`AddressInput` resolves addresses asynchronously and writes `to.resolved` back into the React Hook Form field. On the first empty-address flow, `to.resolved` can already be set while `form.formState.isValid` is still stale from the previous empty state. Because the Save button depended on both `to.resolved` and `formState.isValid`, the button stayed disabled until another interaction forced form state to refresh.

## Design Decisions
- Keep the submit path unchanged and let `form.submit` remain the final validation guard.
- Gate the Save button on the current field error map, `addressValue.pending`, and `addressValue.resolved` instead of global `formState.isValid`.
- Limit the change to the referral EditAddress page instead of altering shared AddressInput behavior, reducing blast radius.

## Changes Detail
- `packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx`: updated `isEnable` calculation so the Save button follows the address input's resolved state and current field errors without relying on stale `formState.isValid`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web / Mobile shared kit UI
- **Risk Areas**: Save-button enablement on the referral reward address edit page. Final submit validation is still preserved.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `yarn tsc:only`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx --deny-warnings`
- [x] `yarn test`
- [ ] Manually verify a first-time empty referral reward address flow: select or enter a valid address once and confirm Save becomes enabled immediately.
- [ ] Manually verify updating an existing bound address still enables Save after selecting a new valid address.
