### PR TITLE
fix: correct swap fiat conversion(OK-56330)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
@@ -152,6 +152,7 @@ describe('useSwapActions', () => {
       currency: 'usd',
     });
     expect(result.current.fromToken?.price).toBe('3000');
+    expect(result.current.fromToken?.currency).toBe('usd');
     expect(result.current.balance).toBe('1.23');
   });
 });

--- a/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
@@ -1,0 +1,157 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { act, renderHook } from '@testing-library/react';
+import { createStore } from 'jotai';
+
+import type { IAccountSelectorActiveAccountInfo } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import type { useSwapAddressInfo } from '@onekeyhq/kit/src/views/Swap/hooks/useSwapAccount';
+import type { INetworkAccount } from '@onekeyhq/shared/types/account';
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
+
+import { useSwapActions } from './actions';
+import {
+  ProviderJotaiContextSwap,
+  swapSelectFromTokenAtom,
+  useSwapSelectFromTokenAtom,
+  useSwapSelectedFromTokenBalanceAtom,
+} from './atoms';
+
+type IFetchSwapTokenDetailsParams = {
+  networkId: string;
+  accountAddress?: string;
+  accountId?: string;
+  contractAddress: string;
+  currency?: string;
+  direction?: ESwapDirectionType;
+};
+type ISwapAddressInfo = ReturnType<typeof useSwapAddressInfo>;
+
+const mockFetchSwapTokenDetails: jest.MockedFunction<
+  (
+    params: IFetchSwapTokenDetailsParams,
+  ) => Promise<{ balanceParsed?: string; price?: string; fiatValue?: string }[]>
+> = jest.fn();
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceSwap: {
+      fetchSwapTokenDetails: (params: IFetchSwapTokenDetailsParams) =>
+        mockFetchSwapTokenDetails(params),
+    },
+  },
+}));
+
+const ethToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '',
+  symbol: 'ETH',
+  decimals: 18,
+  isNative: true,
+};
+const evmAccount: INetworkAccount = {
+  id: 'hd-1--m/44/60/0/0/0',
+  name: 'Account 1',
+  type: undefined,
+  path: "m/44'/60'/0'/0/0",
+  coinType: '60',
+  impl: 'evm',
+  pub: '',
+  address: '0xabc',
+  addressDetail: {
+    isValid: true,
+    networkId: 'evm--1',
+    address: '0xabc',
+    baseAddress: '0xabc',
+    normalizedAddress: '0xabc',
+    displayAddress: '0xabc',
+    allowEmptyAddress: false,
+  },
+};
+const activeAccountInfo: IAccountSelectorActiveAccountInfo = {
+  ready: true,
+  account: evmAccount,
+  indexedAccount: undefined,
+  dbAccount: undefined,
+  accountName: 'Account 1',
+  wallet: undefined,
+  device: undefined,
+  network: undefined,
+  vaultSettings: undefined,
+  deriveType: undefined,
+  deriveInfoItems: [],
+};
+const fromAddressInfo: ISwapAddressInfo = {
+  address: '0xabc',
+  networkId: 'evm--1',
+  accountInfo: activeAccountInfo,
+  activeAccount: activeAccountInfo,
+  isAddressInfoReady: true,
+};
+
+function createWrapper() {
+  const store = createStore();
+  store.set(swapSelectFromTokenAtom(), ethToken);
+
+  return function Wrapper({ children }: { children?: ReactNode }) {
+    return (
+      <ProviderJotaiContextSwap store={store}>
+        {children}
+      </ProviderJotaiContextSwap>
+    );
+  };
+}
+
+describe('useSwapActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('pins selected token detail price fetches to USD for rate-difference math', async () => {
+    mockFetchSwapTokenDetails.mockResolvedValue([
+      {
+        balanceParsed: '1.23',
+        price: '3000',
+        fiatValue: '3690',
+      },
+    ]);
+
+    const { result } = renderHook(
+      () => {
+        const actions = useSwapActions().current;
+        const [fromToken] = useSwapSelectFromTokenAtom();
+        const [balance] = useSwapSelectedFromTokenBalanceAtom();
+
+        return {
+          actions,
+          fromToken,
+          balance,
+        };
+      },
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await act(async () => {
+      await result.current.actions.loadSwapSelectTokenDetail(
+        ESwapDirectionType.FROM,
+        fromAddressInfo,
+      );
+    });
+
+    expect(mockFetchSwapTokenDetails).toHaveBeenCalledWith({
+      networkId: 'evm--1',
+      accountAddress: '0xabc',
+      accountId: 'hd-1--m/44/60/0/0/0',
+      contractAddress: '',
+      direction: ESwapDirectionType.FROM,
+      currency: 'usd',
+    });
+    expect(result.current.fromToken?.price).toBe('3000');
+    expect(result.current.balance).toBe('1.23');
+  });
+});

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -5,12 +5,17 @@ import BigNumber from 'bignumber.js';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ESwapDirection } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
 import type { useSwapAddressInfo } from '@onekeyhq/kit/src/views/Swap/hooks/useSwapAccount';
+import { buildSwapRateDifference } from '@onekeyhq/kit/src/views/Swap/utils/swapRateDifferenceUtils';
 import {
   isUSMarketStatusStockTokenSource,
   shouldCheckSwapWarningUSMarketClosed,
 } from '@onekeyhq/kit/src/views/Swap/utils/usMarketStatusUtils';
 import { moveNetworkToFirst } from '@onekeyhq/kit/src/views/Swap/utils/utils';
-import { settingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  currencyPersistAtom,
+  settingsAtom,
+  settingsPersistAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { USD_CURRENCY_ID } from '@onekeyhq/shared/src/consts/currencyConsts';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import type { IEventSourceMessageEvent } from '@onekeyhq/shared/src/eventSource';
@@ -35,8 +40,6 @@ import {
   swapBridgeDefaultTokenConfigs,
   swapBridgeDefaultTokenExtraConfigs,
   swapDefaultSetTokens,
-  swapRateDifferenceMax,
-  swapRateDifferenceMin,
   swapTokenCatchMapMaxCount,
 } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import type {
@@ -47,6 +50,7 @@ import type {
   ISwapAlertState,
   ISwapLimitPriceInfo,
   ISwapNetwork,
+  ISwapPreSwapData,
   ISwapQuoteEvent,
   ISwapQuoteEventAutoSlippage,
   ISwapQuoteEventData,
@@ -64,7 +68,6 @@ import {
   ESwapLimitOrderMarketPriceUpdateInterval,
   ESwapProTradeType,
   ESwapQuoteKind,
-  ESwapRateDifferenceUnit,
   ESwapSlippageSegmentKey,
   ESwapTabSwitchType,
 } from '@onekeyhq/shared/types/swap/types';
@@ -1451,9 +1454,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       } else if (quoteEventError) {
         set(swapQuoteEventErrorAtom(), undefined);
       }
-      let rateDifferenceRes:
-        | { value: string; unit: ESwapRateDifferenceUnit }
-        | undefined;
+      let rateDifferenceRes: ISwapPreSwapData['rateDifference'];
       // current quote result  current token  not match
       if (quoteResult && fromToken && toToken && !isCurrentQuoteResult) {
         set(swapAlertsAtom(), {
@@ -1654,42 +1655,26 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           (limitPriceUseRate?.rate &&
             quoteResult?.protocol === EProtocolOfExchange.LIMIT))
       ) {
-        const fromTokenPrice = new BigNumber(fromToken.price);
-        const toTokenPrice = new BigNumber(toToken.price);
-        if (!fromTokenPrice.isZero() && !toTokenPrice.isZero()) {
-          const marketingRate = fromTokenPrice.dividedBy(toTokenPrice);
-          let instantRate = quoteResult?.instantRate;
-          if (
-            quoteResult?.protocol === EProtocolOfExchange.LIMIT &&
-            limitPriceUseRate.rate
-          ) {
-            instantRate = limitPriceUseRate.rate;
-          }
-          const quoteRateBN = new BigNumber(instantRate ?? 0);
-          const difference = quoteRateBN
-            .dividedBy(marketingRate)
-            .minus(1)
-            .multipliedBy(100);
-          if (difference.absoluteValue().gte(swapRateDifferenceMin)) {
-            let unit = ESwapRateDifferenceUnit.POSITIVE;
-            if (difference.isNegative()) {
-              if (difference.lte(swapRateDifferenceMax)) {
-                unit = ESwapRateDifferenceUnit.NEGATIVE;
-              } else {
-                unit = ESwapRateDifferenceUnit.DEFAULT;
-              }
-            }
-            rateDifferenceRes = {
-              value: `${difference.isPositive() ? '+' : ''}${numberFormat(
-                difference.toFixed(),
-                {
-                  formatter: 'priceChange',
-                },
-              )}`,
-              unit,
-            };
-          }
+        let instantRate = quoteResult?.instantRate;
+        if (
+          quoteResult?.protocol === EProtocolOfExchange.LIMIT &&
+          limitPriceUseRate.rate
+        ) {
+          instantRate = limitPriceUseRate.rate;
         }
+        const [{ currencyMap }, { currencyInfo }] = await Promise.all([
+          currencyPersistAtom.get(),
+          settingsPersistAtom.get(),
+        ]);
+        rateDifferenceRes = buildSwapRateDifference({
+          fromTokenPrice: fromToken.price,
+          toTokenPrice: toToken.price,
+          fromTokenCurrency: fromToken.currency,
+          toTokenCurrency: toToken.currency,
+          defaultTokenCurrency: currencyInfo.id,
+          currencyMap,
+          instantRate,
+        });
       }
 
       const fromTokenAmountBN = new BigNumber(fromTokenAmount.value);

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -1994,12 +1994,16 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
                 balanceParsed?: string;
                 reservationValue?: string;
                 logoURI?: string;
+                currency?: string;
               } = {};
               if (detailInfo[0].price) {
                 condition.price = detailInfo[0].price;
               }
               if (detailInfo[0].fiatValue) {
                 condition.fiatValue = detailInfo[0].fiatValue;
+              }
+              if (condition.price || condition.fiatValue) {
+                condition.currency = USD_CURRENCY_ID;
               }
               if (detailInfo[0].balanceParsed) {
                 condition.balanceParsed = detailInfo[0].balanceParsed;

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -11,6 +11,7 @@ import {
 } from '@onekeyhq/kit/src/views/Swap/utils/usMarketStatusUtils';
 import { moveNetworkToFirst } from '@onekeyhq/kit/src/views/Swap/utils/utils';
 import { settingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { USD_CURRENCY_ID } from '@onekeyhq/shared/src/consts/currencyConsts';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import type { IEventSourceMessageEvent } from '@onekeyhq/shared/src/eventSource';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -1978,6 +1979,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
                 accountId,
                 contractAddress: token.contractAddress,
                 direction: type,
+                currency: USD_CURRENCY_ID,
               });
             if (detailInfo?.[0]) {
               const balanceParsedBN = new BigNumber(

--- a/packages/kit/src/views/Swap/components/PreSwapTokenItem.tsx
+++ b/packages/kit/src/views/Swap/components/PreSwapTokenItem.tsx
@@ -1,7 +1,5 @@
 import { useMemo } from 'react';
 
-import BigNumber from 'bignumber.js';
-
 import {
   Icon,
   NumberSizeableText,
@@ -9,11 +7,15 @@ import {
   XStack,
   YStack,
 } from '@onekeyhq/components';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  useCurrencyPersistAtom,
+  useSettingsPersistAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
 import { Token } from '../../../components/Token';
+import { getSwapTokenDisplayFiatValue } from '../utils/swapDisplayFiatValue';
 
 import {
   type ISwapRateDifference,
@@ -35,12 +37,16 @@ const PreSwapTokenItem = ({
   isFloating,
   rateDifference,
 }: IPreSwapTokenItemProps) => {
-  const fiatValue = useMemo(() => {
-    return token?.price && amount
-      ? new BigNumber(token?.price ?? 0).multipliedBy(amount).toFixed()
-      : '0';
-  }, [token?.price, amount]);
   const [settings] = useSettingsPersistAtom();
+  const [{ currencyMap }] = useCurrencyPersistAtom();
+  const fiatValue = useMemo(() => {
+    return getSwapTokenDisplayFiatValue({
+      token,
+      amount,
+      targetCurrency: settings.currencyInfo.id,
+      currencyMap,
+    });
+  }, [amount, currencyMap, settings.currencyInfo.id, token]);
   const networkImageUri = useMemo(() => {
     if (token?.networkLogoURI) {
       return token.networkLogoURI;

--- a/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx
@@ -28,6 +28,7 @@ import {
   useSwapTypeSwitchAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import {
+  useCurrencyPersistAtom,
   useInAppNotificationAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -50,6 +51,7 @@ import { useSwapAddressInfo } from '../../hooks/useSwapAccount';
 import { useSwapColdStartDisplayTokens } from '../../hooks/useSwapColdStartDisplayTokens';
 import { useSwapSelectedTokenInfo } from '../../hooks/useSwapTokens';
 import { SwapTestIDs } from '../../testIDs';
+import { getSwapTokenDisplayFiatValue } from '../../utils/swapDisplayFiatValue';
 
 import SwapAccountAddressContainer from './SwapAccountAddressContainer';
 import SwapInputActions from './SwapInputActions';
@@ -150,19 +152,18 @@ const SwapInputContainer = ({
     type: direction,
   });
   const [settingsPersistAtom] = useSettingsPersistAtom();
+  const [{ currencyMap }] = useCurrencyPersistAtom();
   const [alerts] = useSwapAlertsAtom();
   const { address, accountInfo } = useSwapAddressInfo(direction);
   const [rateDifference] = useRateDifferenceAtom();
   const amountPrice = useMemo(() => {
-    if (!token?.price) return '0.0';
-    const tokenPriceBN = new BigNumber(token.price ?? 0);
-    const tokenFiatValueBN = new BigNumber(amountValue ?? 0).multipliedBy(
-      tokenPriceBN,
-    );
-    return tokenFiatValueBN.isNaN()
-      ? '0.0'
-      : tokenFiatValueBN.decimalPlaces(6, BigNumber.ROUND_DOWN).toFixed();
-  }, [amountValue, token?.price]);
+    return getSwapTokenDisplayFiatValue({
+      token,
+      amount: amountValue ?? '',
+      targetCurrency: settingsPersistAtom.currencyInfo.id,
+      currencyMap,
+    });
+  }, [amountValue, currencyMap, settingsPersistAtom.currencyInfo.id, token]);
 
   const [fromToken] = useSwapSelectFromTokenAtom();
   const [toToken] = useSwapSelectToTokenAtom();

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -53,6 +53,7 @@ import { validateAmountInput } from '@onekeyhq/kit/src/utils/validateAmountInput
 import { MarketWatchListProviderMirrorV2 } from '@onekeyhq/kit/src/views/Market/MarketWatchListProviderMirrorV2';
 import {
   EJotaiContextStoreNames,
+  useCurrencyPersistAtom,
   useInAppNotificationAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -158,6 +159,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
   const [rateDifference] = useRateDifferenceAtom();
   const [settingsPersistAtom] = useSettingsPersistAtom();
+  const [{ currencyMap }] = useCurrencyPersistAtom();
   const toAddressInfo = useSwapAddressInfo(ESwapDirectionType.TO);
   const swapFromAddressInfo = useSwapAddressInfo(ESwapDirectionType.FROM);
   // Check custom RPC availability for the from network
@@ -787,6 +789,10 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
         ? buildSwapRateDifference({
             fromTokenPrice: fromSelectToken?.price,
             toTokenPrice: toSelectToken?.price,
+            fromTokenCurrency: fromSelectToken?.currency,
+            toTokenCurrency: toSelectToken?.currency,
+            defaultTokenCurrency: settingsPersistAtom.currencyInfo.id,
+            currencyMap,
             instantRate: currentQuoteRes.instantRate,
           })
         : rateDifference;
@@ -811,6 +817,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
       supportPreBuild,
       slippage: swapSlippageRef.current.value,
       rateDifference: reviewRateDifference,
+      defaultTokenCurrency: settingsPersistAtom.currencyInfo.id,
+      currencyMap,
       texts: reviewStepTexts,
     });
 
@@ -833,6 +841,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     swapFromAddressInfo.accountInfo?.account?.id,
     swapFromAddressInfo.networkId,
     settingsPersistAtom.swapBatchApproveAndSwap,
+    settingsPersistAtom.currencyInfo.id,
+    currencyMap,
     supportPreBuild,
     isCustomRpcUnavailable,
     rateDifference,

--- a/packages/kit/src/views/Swap/utils/buildSwapReviewState.ts
+++ b/packages/kit/src/views/Swap/utils/buildSwapReviewState.ts
@@ -1,4 +1,5 @@
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import type { ICurrencyItem } from '@onekeyhq/shared/types';
 import type {
   ESwapTabSwitchType,
   IFetchQuoteResult,
@@ -218,6 +219,8 @@ export type IBuildSwapReviewStateInput = {
   supportPreBuild: boolean;
   slippage?: number;
   rateDifference?: ISwapPreSwapData['rateDifference'];
+  defaultTokenCurrency?: string;
+  currencyMap?: Record<string, ICurrencyItem>;
   texts: ISwapReviewStepTexts;
 };
 
@@ -235,6 +238,8 @@ export function buildSwapReviewState({
   supportPreBuild,
   slippage,
   rateDifference,
+  defaultTokenCurrency,
+  currencyMap,
   texts,
 }: IBuildSwapReviewStateInput): {
   batchTransferType: ESwapBatchTransferType;
@@ -266,6 +271,10 @@ export function buildSwapReviewState({
     buildSwapRateDifference({
       fromTokenPrice: fromToken?.price,
       toTokenPrice: toToken?.price,
+      fromTokenCurrency: fromToken?.currency,
+      toTokenCurrency: toToken?.currency,
+      defaultTokenCurrency,
+      currencyMap,
       instantRate: quoteResult?.instantRate,
     });
 

--- a/packages/kit/src/views/Swap/utils/swapDisplayFiatValue.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapDisplayFiatValue.test.ts
@@ -1,0 +1,49 @@
+import type { ICurrencyItem } from '@onekeyhq/shared/types';
+
+import { getSwapTokenDisplayFiatValue } from './swapDisplayFiatValue';
+
+const currencyMap: Record<string, ICurrencyItem> = {
+  usd: { id: 'usd', unit: '$', name: 'US Dollar', type: ['fiat'], value: '1' },
+  cny: {
+    id: 'cny',
+    unit: '¥',
+    name: 'Chinese Yuan',
+    type: ['fiat'],
+    value: '6.776',
+  },
+};
+
+describe('getSwapTokenDisplayFiatValue', () => {
+  it('converts a USD-basis swap token price into the selected currency', () => {
+    expect(
+      getSwapTokenDisplayFiatValue({
+        token: { price: '1', currency: 'usd' },
+        amount: '1',
+        targetCurrency: 'cny',
+        currencyMap,
+      }),
+    ).toBe('6.776');
+  });
+
+  it('keeps untagged token prices in the selected currency basis', () => {
+    expect(
+      getSwapTokenDisplayFiatValue({
+        token: { price: '1' },
+        amount: '1',
+        targetCurrency: 'cny',
+        currencyMap,
+      }),
+    ).toBe('1');
+  });
+
+  it('returns zero for missing or unusable token prices', () => {
+    expect(
+      getSwapTokenDisplayFiatValue({
+        token: { price: '--', currency: 'usd' },
+        amount: '1',
+        targetCurrency: 'cny',
+        currencyMap,
+      }),
+    ).toBe('0');
+  });
+});

--- a/packages/kit/src/views/Swap/utils/swapDisplayFiatValue.ts
+++ b/packages/kit/src/views/Swap/utils/swapDisplayFiatValue.ts
@@ -1,0 +1,29 @@
+import BigNumber from 'bignumber.js';
+
+import { convertFiat } from '@onekeyhq/kit/src/utils/fiatConvert';
+import type { ICurrencyItem } from '@onekeyhq/shared/types';
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+
+export function getSwapTokenDisplayFiatValue({
+  token,
+  amount,
+  targetCurrency,
+  currencyMap,
+}: {
+  token?: Pick<ISwapToken, 'price' | 'currency'>;
+  amount: string;
+  targetCurrency: string;
+  currencyMap: Record<string, ICurrencyItem>;
+}) {
+  if (!token?.price || !amount) return '0';
+
+  const fiatValueBN = new BigNumber(amount).multipliedBy(token.price);
+  if (!fiatValueBN.isFinite()) return '0';
+
+  return convertFiat({
+    value: fiatValueBN.decimalPlaces(6, BigNumber.ROUND_DOWN).toFixed(),
+    sourceCurrency: token.currency ?? targetCurrency,
+    targetCurrency,
+    currencyMap,
+  });
+}

--- a/packages/kit/src/views/Swap/utils/swapRateDifferenceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapRateDifferenceUtils.test.ts
@@ -1,0 +1,44 @@
+import type { ICurrencyItem } from '@onekeyhq/shared/types';
+import { ESwapRateDifferenceUnit } from '@onekeyhq/shared/types/swap/types';
+
+import { buildSwapRateDifference } from './swapRateDifferenceUtils';
+
+const currencyMap: Record<string, ICurrencyItem> = {
+  usd: { id: 'usd', unit: '$', name: 'US Dollar', type: ['fiat'], value: '1' },
+  cny: {
+    id: 'cny',
+    unit: '¥',
+    name: 'Chinese Yuan',
+    type: ['fiat'],
+    value: '6.75',
+  },
+};
+
+describe('buildSwapRateDifference', () => {
+  it('normalizes mixed fiat price bases before comparing the quote rate', () => {
+    const result = buildSwapRateDifference({
+      fromTokenPrice: '6.75',
+      toTokenPrice: '609.7560975609756',
+      toTokenCurrency: 'usd',
+      defaultTokenCurrency: 'cny',
+      currencyMap,
+      instantRate: '0.0016325761663555',
+    });
+
+    expect(result).toEqual({
+      value: '-0.45%',
+      unit: ESwapRateDifferenceUnit.DEFAULT,
+    });
+  });
+
+  it('does not compare prices when only one side has a known price basis', () => {
+    expect(
+      buildSwapRateDifference({
+        fromTokenPrice: '6.75',
+        toTokenPrice: '609.7560975609756',
+        toTokenCurrency: 'usd',
+        instantRate: '0.0016325761663555',
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/kit/src/views/Swap/utils/swapRateDifferenceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapRateDifferenceUtils.ts
@@ -1,6 +1,9 @@
 import BigNumber from 'bignumber.js';
 
+import { convertFiat } from '@onekeyhq/kit/src/utils/fiatConvert';
+import { USD_CURRENCY_ID } from '@onekeyhq/shared/src/consts/currencyConsts';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import type { ICurrencyItem } from '@onekeyhq/shared/types';
 import {
   swapRateDifferenceMax,
   swapRateDifferenceMin,
@@ -8,21 +11,93 @@ import {
 import type { ISwapPreSwapData } from '@onekeyhq/shared/types/swap/types';
 import { ESwapRateDifferenceUnit } from '@onekeyhq/shared/types/swap/types';
 
+function resolveRateDifferenceTokenPrice({
+  price,
+  sourceCurrency,
+  commonCurrency,
+  currencyMap,
+}: {
+  price?: string;
+  sourceCurrency?: string;
+  commonCurrency: string;
+  currencyMap?: Record<string, ICurrencyItem>;
+}) {
+  const priceBN = new BigNumber(price ?? '');
+  if (!priceBN.isFinite() || priceBN.isZero()) {
+    return undefined;
+  }
+
+  if (!sourceCurrency || sourceCurrency === commonCurrency) {
+    return priceBN.toFixed();
+  }
+
+  if (!currencyMap?.[sourceCurrency] || !currencyMap?.[commonCurrency]) {
+    return undefined;
+  }
+
+  const convertedPrice = new BigNumber(
+    convertFiat({
+      value: priceBN.toFixed(),
+      sourceCurrency,
+      targetCurrency: commonCurrency,
+      currencyMap,
+    }),
+  );
+
+  return convertedPrice.isFinite() && !convertedPrice.isZero()
+    ? convertedPrice.toFixed()
+    : undefined;
+}
+
 export function buildSwapRateDifference({
   fromTokenPrice,
   toTokenPrice,
+  fromTokenCurrency,
+  toTokenCurrency,
+  defaultTokenCurrency,
+  currencyMap,
   instantRate,
 }: {
   fromTokenPrice?: string;
   toTokenPrice?: string;
+  fromTokenCurrency?: string;
+  toTokenCurrency?: string;
+  defaultTokenCurrency?: string;
+  currencyMap?: Record<string, ICurrencyItem>;
   instantRate?: string;
 }): ISwapPreSwapData['rateDifference'] {
   if (!fromTokenPrice || !toTokenPrice || !instantRate) {
     return undefined;
   }
 
-  const fromTokenPriceBN = new BigNumber(fromTokenPrice);
-  const toTokenPriceBN = new BigNumber(toTokenPrice);
+  const fromPriceSourceCurrency = fromTokenCurrency ?? defaultTokenCurrency;
+  const toPriceSourceCurrency = toTokenCurrency ?? defaultTokenCurrency;
+  const hasOnlyOneKnownCurrency =
+    Boolean(fromPriceSourceCurrency) !== Boolean(toPriceSourceCurrency);
+  if (hasOnlyOneKnownCurrency) {
+    return undefined;
+  }
+
+  const commonCurrency =
+    fromPriceSourceCurrency ?? toPriceSourceCurrency ?? USD_CURRENCY_ID;
+  const resolvedFromTokenPrice = resolveRateDifferenceTokenPrice({
+    price: fromTokenPrice,
+    sourceCurrency: fromPriceSourceCurrency,
+    commonCurrency,
+    currencyMap,
+  });
+  const resolvedToTokenPrice = resolveRateDifferenceTokenPrice({
+    price: toTokenPrice,
+    sourceCurrency: toPriceSourceCurrency,
+    commonCurrency,
+    currencyMap,
+  });
+  if (!resolvedFromTokenPrice || !resolvedToTokenPrice) {
+    return undefined;
+  }
+
+  const fromTokenPriceBN = new BigNumber(resolvedFromTokenPrice);
+  const toTokenPriceBN = new BigNumber(resolvedToTokenPrice);
   const quoteRateBN = new BigNumber(instantRate);
   if (
     !fromTokenPriceBN.isFinite() ||

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -155,6 +155,7 @@ export interface ISwapTokenBase {
   fiatValue?: string;
   balanceParsed?: string;
   price?: string;
+  currency?: string;
   networkId: string;
   contractAddress: string;
   isNative?: boolean;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56330](https://onekeyhq.atlassian.net/browse/OK-56330)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Preserve the USD basis on selected Swap token detail prices by tagging the token currency.
- Convert Swap input and review fiat displays from the token price currency into the currently selected fiat currency.
- Add unit coverage for USD-to-CNY conversion and the existing untagged-price fallback behavior.

## Intent & Context
This fixes OK-56330 on the release/v6.4.0 branch. QA reported that the previous fix did not fully resolve the issue, and mobile was easier to reproduce. The requested validation path was the Swap tab transaction pair, not the Home page: switch fiat currency to CNY, set the Swap pair with FromToken = USDC, and verify that the fiat amount is correct.

Runtime verification reproduced the issue on desktop before this commit: in CNY, Swap From = USDC, amount = 1 displayed ¥1.00. After the fix, the same Swap tab path displays ¥6.76. The same path was also verified on an iOS Simulator with the Review section showing `You pay 1 USDC / ¥6.76`.

## Root Cause
The branch already changed selected Swap token detail loading to request token detail prices in USD so rate-difference math has a stable base. However, the selected token only carried the numeric price, not the currency basis. Swap UI display code then multiplied the USD price by the input amount and formatted that value with the current fiat symbol. In CNY mode, USDC price `1` was therefore rendered as `¥1.00` instead of being converted from USD to CNY first.

This is a main/UI display bug. The background service returns token detail data, but the incorrect calculation happened in the main Swap render path. Native shared resources are not part of this calculation; main and background JS heaps remain separate.

## Design Decisions
The fix keeps the existing USD price request for selected token details because that path is needed for consistent rate-difference calculations. Instead of changing the data source back to the selected fiat currency, selected token detail data is tagged with `currency: usd` when USD-based price or fiatValue is applied.

Display code now uses a small Swap-specific helper that converts from the token price currency into the selected fiat currency. Untagged token prices are treated as already being in the selected currency, preserving existing behavior for other token data paths that have not been explicitly marked with a source currency.

## Changes Detail
- `packages/shared/types/swap/types.ts`: adds optional `currency` metadata to Swap token data.
- `packages/kit/src/states/jotai/contexts/swap/actions.ts`: tags selected token detail price data as USD-based when it is loaded with the USD currency request.
- `packages/kit/src/views/Swap/utils/swapDisplayFiatValue.ts`: adds a reusable helper for Swap fiat display conversion.
- `packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx`: uses the helper for Swap input fiat display.
- `packages/kit/src/views/Swap/components/PreSwapTokenItem.tsx`: uses the helper for pre-swap and review token fiat display.
- `packages/kit/src/views/Swap/utils/swapDisplayFiatValue.test.ts`: covers USD-to-CNY conversion, untagged fallback behavior, and invalid price handling.
- `packages/kit/src/states/jotai/contexts/swap/actions.test.tsx`: verifies selected token detail data is tagged as USD-based.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile, Desktop, Web, Extension
- **Risk Areas**: Swap fiat display values for selected tokens. The helper preserves untagged price behavior to avoid changing display semantics for token paths that do not yet carry explicit currency metadata.

## Test plan
- [x] Desktop runtime: CNY, Swap tab, From = USDC, amount = 1 displays ¥6.76 after previously reproducing ¥1.00.
- [x] iOS Simulator runtime: CNY, Swap tab, From = USDC, amount = 1 displays ¥6.76; Review shows `You pay 1 USDC / ¥6.76`.
- [x] `yarn jest packages/kit/src/views/Swap/utils/swapDisplayFiatValue.test.ts packages/kit/src/states/jotai/contexts/swap/actions.test.tsx --runInBand`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/states/jotai/contexts/swap/actions.test.tsx packages/kit/src/states/jotai/contexts/swap/actions.ts packages/kit/src/views/Swap/components/PreSwapTokenItem.tsx packages/kit/src/views/Swap/pages/components/SwapInputContainer.tsx packages/shared/types/swap/types.ts packages/kit/src/views/Swap/utils/swapDisplayFiatValue.ts packages/kit/src/views/Swap/utils/swapDisplayFiatValue.test.ts`
- [x] `yarn lint:staged`
- [ ] `yarn tsc:staged` is blocked by existing unrelated `react-router-dom` type resolution errors in `apps/web-embed/pages/PageIndex.tsx` and `packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.web-embed.ts`.

[OK-56330]: https://onekeyhq.atlassian.net/browse/OK-56330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ