### PR TITLE
fix: align btc reward address validation gate

### DIFF
--- a/packages/kit/src/views/Redemption/pages/BtcReward/SelectAddress.tsx
+++ b/packages/kit/src/views/Redemption/pages/BtcReward/SelectAddress.tsx
@@ -270,12 +270,12 @@ function ManualInputContent() {
   const form = useForm<IManualInputFormValues>(MANUAL_INPUT_FORM_OPTIONS);
   const { control } = form;
   const addressValue = useFormWatch({ control, name: 'to' });
-  const { errors, isValid } = form.formState;
+  const { errors } = form.formState;
 
   const canProceed = useMemo(() => {
     if (Object.values(errors).length) return false;
-    return !addressValue.pending && !!addressValue.resolved && isValid;
-  }, [addressValue.pending, addressValue.resolved, errors, isValid]);
+    return !addressValue.pending && !!addressValue.resolved;
+  }, [addressValue.pending, addressValue.resolved, errors]);
 
   const handleNext = useCallback(() => {
     const resolved = form.getValues('to').resolved;


### PR DESCRIPTION
## Summary
- Align the BTC reward manual address page with the referral edit-address Save-button gate.
- Remove the stale `formState.isValid` dependency from `canProceed`, relying on current field errors plus address pending/resolved state.

## Intent & Context
This addresses the unresolved review thread on #12074. The original PR fixed stale React Hook Form `isValid` gating in the referral reward edit-address page; the review pointed out the same AddressInput-driven pattern existed in `BtcReward/SelectAddress`.

## Root Cause
This is a main UI JS runtime form-state issue. The bg runtime is not involved until after the user proceeds/submits, and there is no shared native resource involved. `AddressInput` updates resolved address state asynchronously in the main runtime JS heap, while global `formState.isValid` can lag behind the current resolved field value.

## Changes Detail
- `packages/kit/src/views/Redemption/pages/BtcReward/SelectAddress.tsx`: remove `isValid` from the manual input `canProceed` gate and hook dependencies.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web / Mobile shared kit UI
- **Risk Areas**: BTC reward manual address Next-button enablement. The final navigation path still checks both `canProceed` and the resolved address.

## Test plan
- [x] `yarn lint:staged`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/Redemption/pages/BtcReward/SelectAddress.tsx --deny-warnings`
- [x] `git diff --cached --check`
- [ ] `yarn tsc:staged` / `npx tsgo -p packages/kit/tsconfig.json --noEmit --pretty` are blocked by existing unrelated baseline errors in `apps/web-embed`, `packages/kit-bg/src/vaults/impls/*/KeyringHardwareLedger.ts`, and `packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.web-embed.ts`.