### PR TITLE
fix: enable referral address save after first selection(OK-56325)

### DIFF
--- a/packages/kit/src/views/Redemption/pages/BtcReward/SelectAddress.tsx
+++ b/packages/kit/src/views/Redemption/pages/BtcReward/SelectAddress.tsx
@@ -270,12 +270,12 @@ function ManualInputContent() {
   const form = useForm<IManualInputFormValues>(MANUAL_INPUT_FORM_OPTIONS);
   const { control } = form;
   const addressValue = useFormWatch({ control, name: 'to' });
-  const { errors, isValid } = form.formState;
+  const { errors } = form.formState;
 
   const canProceed = useMemo(() => {
     if (Object.values(errors).length) return false;
-    return !addressValue.pending && !!addressValue.resolved && isValid;
-  }, [addressValue.pending, addressValue.resolved, errors, isValid]);
+    return !addressValue.pending && !!addressValue.resolved;
+  }, [addressValue.pending, addressValue.resolved, errors]);
 
   const handleNext = useCallback(() => {
     const resolved = form.getValues('to').resolved;

--- a/packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx
@@ -153,16 +153,14 @@ function BasicEditAddress() {
   const { control } = form;
   const networkIdValue = useFormWatch({ control, name: 'networkId' });
   const addressValue = useFormWatch({ control, name: 'to' });
+  const { errors } = form.formState;
   const isEnable = useMemo(() => {
     // filter out error parameters from different segments.
-    const errors = Object.values(form.formState.errors);
-    if (errors.length) {
+    if (Object.values(errors).length) {
       return false;
     }
-    return (
-      !addressValue.pending && !!addressValue.resolved && form.formState.isValid
-    );
-  }, [addressValue.pending, addressValue.resolved, form.formState]);
+    return !addressValue.pending && !!addressValue.resolved;
+  }, [addressValue.pending, addressValue.resolved, errors]);
 
   const { result: addressBookEnabledNetworkIds } = usePromiseResult(
     async () => {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56325](https://onekeyhq.atlassian.net/browse/OK-56325)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Enable the referral reward withdrawal address Save button immediately after the first valid address selection.
- Align the BTC reward manual address Next button with the same AddressInput resolved-state gate.
- Remove stale `formState.isValid` dependencies from both button enablement checks.

## Intent & Context
This replaces the earlier hotfix-named PR branch with a normal `fix/*` branch and includes the review fix requested on #12074. The user-reported issue was that when no referral reward address was previously bound, selecting or entering a valid address left the Save button disabled until a second interaction.

## Root Cause
These pages run in the main UI JS runtime. The bg runtime is only involved after the user confirms Save or proceeds to the next BTC reward step; there is no shared native resource involved in this button state bug. `AddressInput` resolves addresses asynchronously and writes the resolved value back into the main runtime React Hook Form state. The global `formState.isValid` value can lag behind the current resolved address field state, while the field error map and `pending`/`resolved` values already reflect the current input.

## Design Decisions
- Keep final submit/navigation guards intact; submit still performs final form validation and BTC reward navigation still checks both `canProceed` and the resolved address.
- Gate buttons on current field errors plus `addressValue.pending` and `addressValue.resolved` instead of stale global `formState.isValid`.
- Apply the same pattern to the similar BTC reward manual address page per code review feedback.

## Changes Detail
- `packages/kit/src/views/ReferFriends/pages/EditAddress/index.tsx`: update Save-button enablement to avoid stale `formState.isValid`.
- `packages/kit/src/views/Redemption/pages/BtcReward/SelectAddress.tsx`: update manual address Next-button enablement with the same gate.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web / Mobile shared kit UI
- **Risk Areas**: Referral address Save-button and BTC reward manual address Next-button enablement. Final validation/submission behavior remains guarded.

## Test plan
- [x] `yarn lint:staged`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/Redemption/pages/BtcReward/SelectAddress.tsx --deny-warnings`
- [x] `git diff --cached --check`
- [ ] `yarn tsc:staged` / `npx tsgo -p packages/kit/tsconfig.json --noEmit --pretty` are blocked by existing unrelated baseline errors in `apps/web-embed`, `packages/kit-bg/src/vaults/impls/*/KeyringHardwareLedger.ts`, and `packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.web-embed.ts`.
- [ ] Manually verify a first-time empty referral reward address flow: select or enter a valid address once and confirm Save becomes enabled immediately.
- [ ] Manually verify BTC reward manual address flow: enter/select a valid address once and confirm Next becomes enabled immediately.

[OK-56325]: https://onekeyhq.atlassian.net/browse/OK-56325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ