### PR TITLE
fix: add long pending swap warning(OK-53842)

### DIFF
--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
@@ -1,4 +1,11 @@
-import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { useRoute } from '@react-navigation/core';
 import BigNumber from 'bignumber.js';
@@ -8,6 +15,7 @@ import Svg, { Line } from 'react-native-svg';
 
 import type { IPageNavigationProp } from '@onekeyhq/components';
 import {
+  Alert,
   Button,
   Dialog,
   Divider,
@@ -42,6 +50,10 @@ import type {
   IModalSwapParamList,
 } from '@onekeyhq/shared/src/routes/swap';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
+import {
+  getSwapHistoryLongPendingWarningDelayMs,
+  shouldShowSwapHistoryLongPendingWarning,
+} from '@onekeyhq/shared/src/utils/swapHistoryUtils';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { ICurrencyItem } from '@onekeyhq/shared/types/currency';
 import { privateSendProvider } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
@@ -842,6 +854,7 @@ const SwapHistoryDetailModal = () => {
   );
   const [settingsPersistAtom] = useSettingsPersistAtom();
   const { formatDate } = useFormatDate();
+  const longPendingWarningLoggedKeysRef = useRef(new Set<string>());
   useEffect(() => {
     if (!swapTxHistoryList?.length) return;
     const routeTxHistory = txHistoryList?.find(
@@ -900,6 +913,61 @@ const SwapHistoryDetailModal = () => {
       ),
     [txHistoryListState, txHistoryOrderId],
   );
+  const [longPendingWarningNow, setLongPendingWarningNow] = useState(() =>
+    Date.now(),
+  );
+  const shouldShowLongPendingWarning = useMemo(
+    () =>
+      shouldShowSwapHistoryLongPendingWarning({
+        item: txHistory,
+        now: longPendingWarningNow,
+      }),
+    [longPendingWarningNow, txHistory],
+  );
+  useEffect(() => {
+    const now = Date.now();
+    const delayMs = getSwapHistoryLongPendingWarningDelayMs({
+      item: txHistory,
+      now,
+    });
+    if (delayMs === undefined) {
+      return undefined;
+    }
+    setLongPendingWarningNow(now);
+    if (delayMs === 0) {
+      return undefined;
+    }
+    const timer = setTimeout(() => {
+      setLongPendingWarningNow(Date.now());
+    }, delayMs);
+    return () => clearTimeout(timer);
+  }, [txHistory]);
+  useEffect(() => {
+    if (!shouldShowLongPendingWarning || !txHistory) {
+      return;
+    }
+    const logKey = [
+      txHistory.date.created,
+      txHistory.status,
+      txHistory.swapInfo.provider.provider,
+    ].join(':');
+    if (longPendingWarningLoggedKeysRef.current.has(logKey)) {
+      return;
+    }
+    longPendingWarningLoggedKeysRef.current.add(logKey);
+    defaultLogger.swap.swapOrderLongPendingWarning.swapOrderLongPendingWarning({
+      pendingMinutes: Math.floor(
+        Math.max(longPendingWarningNow - txHistory.date.created, 0) /
+          (60 * 1000),
+      ),
+      protocol: txHistory.protocol ?? EProtocolOfExchange.SWAP,
+      receivedChain: txHistory.baseInfo.toToken.networkId,
+      sourceChain: txHistory.baseInfo.fromToken.networkId,
+      status: txHistory.status,
+      swapProvider: txHistory.swapInfo.provider.provider,
+      swapProviderName: txHistory.swapInfo.provider.providerName,
+    });
+  }, [longPendingWarningNow, shouldShowLongPendingWarning, txHistory]);
   const isPrivateSendHistory = useMemo(
     () => isPrivateSendSwapTxHistory(txHistory),
     [txHistory],
@@ -1254,6 +1322,23 @@ const SwapHistoryDetailModal = () => {
     );
   }, [formatDate, txHistory?.date]);
 
+  const renderSwapLongPendingWarning = useCallback(() => {
+    if (!shouldShowLongPendingWarning) {
+      return null;
+    }
+    return (
+      <Stack flex={1} flexBasis="100%" p="$2.5">
+        <Alert
+          type="warning"
+          icon="HourglassOutline"
+          title={intl.formatMessage({
+            id: ETranslations.trade_taking_longer_than_usual,
+          })}
+        />
+      </Stack>
+    );
+  }, [intl, shouldShowLongPendingWarning]);
+
   const renderSwapProvider = useCallback(
     () => (
       <XStack alignItems="center" gap="$1">
@@ -1451,6 +1536,7 @@ const SwapHistoryDetailModal = () => {
               renderContent={renderSwapDate()}
               compactAll
             />
+            {renderSwapLongPendingWarning()}
             {txHistory?.crossChainStatus ? (
               <InfoItem
                 label={intl.formatMessage({
@@ -1580,6 +1666,7 @@ const SwapHistoryDetailModal = () => {
     renderSwapAssetsChange,
     renderSwapCrossChainStatus,
     renderSwapDate,
+    renderSwapLongPendingWarning,
     renderSwapOrderStatus,
     renderSwapProvider,
     shouldRenderOrderId,

--- a/packages/shared/src/logger/scopes/swap/index.ts
+++ b/packages/shared/src/logger/scopes/swap/index.ts
@@ -10,6 +10,7 @@ import { SelectTokenScene } from './scenes/selectToken';
 import { StockTokenCheckScene } from './scenes/stockTokenCheck';
 import { SwapEstimateFeeScene } from './scenes/swapEstimateFee';
 import { SwapKlineScene } from './scenes/swapKline';
+import { SwapOrderLongPendingWarningScene } from './scenes/swapOrderLongPendingWarning';
 import { SwapQuoteScene } from './scenes/swapQuote';
 import { SwapSendTxScene } from './scenes/swapSendTx';
 import { TokenSelectorSearchScene } from './scenes/tokenSelectorSearch';
@@ -49,4 +50,9 @@ export class SwapScope extends BaseScope {
   swapSendTx = this.createScene('swapSendTx', SwapSendTxScene);
 
   valueDropTip = this.createScene('valueDropTip', ValueDropTipScene);
+
+  swapOrderLongPendingWarning = this.createScene(
+    'swapOrderLongPendingWarning',
+    SwapOrderLongPendingWarningScene,
+  );
 }

--- a/packages/shared/src/logger/scopes/swap/scenes/swapOrderLongPendingWarning.ts
+++ b/packages/shared/src/logger/scopes/swap/scenes/swapOrderLongPendingWarning.ts
@@ -1,0 +1,39 @@
+import type {
+  EProtocolOfExchange,
+  ESwapTxHistoryStatus,
+} from '@onekeyhq/shared/types/swap/types';
+
+import { BaseScene } from '../../../base/baseScene';
+import { LogToLocal, LogToServer } from '../../../base/decorators';
+
+export class SwapOrderLongPendingWarningScene extends BaseScene {
+  @LogToServer({ level: 'info' })
+  @LogToLocal({ level: 'info' })
+  public swapOrderLongPendingWarning({
+    pendingMinutes,
+    protocol,
+    receivedChain,
+    sourceChain,
+    status,
+    swapProvider,
+    swapProviderName,
+  }: {
+    pendingMinutes: number;
+    protocol: EProtocolOfExchange;
+    receivedChain: string;
+    sourceChain: string;
+    status: ESwapTxHistoryStatus;
+    swapProvider: string;
+    swapProviderName: string;
+  }) {
+    return {
+      pendingMinutes,
+      protocol,
+      receivedChain,
+      sourceChain,
+      status,
+      swapProvider,
+      swapProviderName,
+    };
+  }
+}

--- a/packages/shared/src/utils/swapHistoryUtils.test.ts
+++ b/packages/shared/src/utils/swapHistoryUtils.test.ts
@@ -1,0 +1,154 @@
+import { privateSendProvider } from '../../types/swap/SwapProvider.constants';
+import {
+  EProtocolOfExchange,
+  ESwapTxHistoryStatus,
+  type ISwapToken,
+  type ISwapTxHistory,
+} from '../../types/swap/types';
+
+import {
+  SWAP_HISTORY_LONG_PENDING_WARNING_THRESHOLD_MS,
+  getSwapHistoryLongPendingWarningDelayMs,
+  shouldShowSwapHistoryLongPendingWarning,
+} from './swapHistoryUtils';
+
+const now = 1_000_000_000;
+
+const token: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '',
+  symbol: 'ETH',
+  decimals: 18,
+};
+
+function makeHistory(overrides: Partial<ISwapTxHistory> = {}): ISwapTxHistory {
+  return {
+    protocol: EProtocolOfExchange.SWAP,
+    status: ESwapTxHistoryStatus.PENDING,
+    accountInfo: {
+      sender: {
+        networkId: 'evm--1',
+      },
+      receiver: {
+        networkId: 'evm--1',
+      },
+    },
+    baseInfo: {
+      fromToken: token,
+      toToken: token,
+      fromAmount: '1',
+      toAmount: '1',
+    },
+    txInfo: {
+      sender: '0xsender',
+      receiver: '0xreceiver',
+    },
+    swapInfo: {
+      provider: {
+        provider: 'test-provider',
+        providerName: 'Test Provider',
+      },
+      instantRate: '1',
+      orderId: 'order-1',
+    },
+    date: {
+      created: now - SWAP_HISTORY_LONG_PENDING_WARNING_THRESHOLD_MS,
+      updated: now - SWAP_HISTORY_LONG_PENDING_WARNING_THRESHOLD_MS,
+    },
+    ...overrides,
+  };
+}
+
+describe('swapHistoryUtils long pending warning', () => {
+  it('shows the warning at the 90 minute boundary', () => {
+    expect(
+      shouldShowSwapHistoryLongPendingWarning({
+        item: makeHistory(),
+        now,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not show before the 90 minute boundary', () => {
+    expect(
+      shouldShowSwapHistoryLongPendingWarning({
+        item: makeHistory({
+          date: {
+            created: now - SWAP_HISTORY_LONG_PENDING_WARNING_THRESHOLD_MS + 1,
+            updated: now - SWAP_HISTORY_LONG_PENDING_WARNING_THRESHOLD_MS + 1,
+          },
+        }),
+        now,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns the remaining delay before the warning boundary', () => {
+    expect(
+      getSwapHistoryLongPendingWarningDelayMs({
+        item: makeHistory({
+          date: {
+            created:
+              now - SWAP_HISTORY_LONG_PENDING_WARNING_THRESHOLD_MS + 12_345,
+            updated:
+              now - SWAP_HISTORY_LONG_PENDING_WARNING_THRESHOLD_MS + 12_345,
+          },
+        }),
+        now,
+      }),
+    ).toBe(12_345);
+  });
+
+  it('does not show for terminal or canceling statuses', () => {
+    expect(
+      shouldShowSwapHistoryLongPendingWarning({
+        item: makeHistory({ status: ESwapTxHistoryStatus.SUCCESS }),
+        now,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowSwapHistoryLongPendingWarning({
+        item: makeHistory({ status: ESwapTxHistoryStatus.CANCELING }),
+        now,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not show for Private Send histories', () => {
+    expect(
+      shouldShowSwapHistoryLongPendingWarning({
+        item: makeHistory({ protocol: EProtocolOfExchange.PRIVATE_SEND }),
+        now,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowSwapHistoryLongPendingWarning({
+        item: makeHistory({
+          swapInfo: {
+            provider: {
+              provider: privateSendProvider,
+              providerName: 'Private Send',
+            },
+            instantRate: '1',
+            orderId: 'order-1',
+          },
+        }),
+        now,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not show when the creation timestamp is invalid', () => {
+    expect(
+      shouldShowSwapHistoryLongPendingWarning({
+        item: makeHistory({
+          date: {
+            created: 0,
+            updated: 0,
+          },
+        }),
+        now,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/swapHistoryUtils.ts
+++ b/packages/shared/src/utils/swapHistoryUtils.ts
@@ -36,6 +36,8 @@ const PRIVATE_SEND_FAILED_CROSS_CHAIN_STATUSES = new Set<ESwapCrossChainStatus>(
   ],
 );
 
+export const SWAP_HISTORY_LONG_PENDING_WARNING_THRESHOLD_MS = 90 * 60 * 1000;
+
 export function isPrivateSendSwapHistoryItem(
   item?: ISwapTxHistory | null,
 ): boolean {
@@ -158,4 +160,40 @@ export function isSwapHistoryProtocolExcluded({
     return true;
   }
   return Boolean(item.protocol && excludeProtocols.includes(item.protocol));
+}
+
+export function getSwapHistoryLongPendingWarningDelayMs({
+  item,
+  now = Date.now(),
+}: {
+  item?: ISwapTxHistory | null;
+  now?: number;
+}): number | undefined {
+  if (
+    !item ||
+    item.status !== ESwapTxHistoryStatus.PENDING ||
+    isPrivateSendSwapHistoryItem(item)
+  ) {
+    return undefined;
+  }
+
+  const created = item.date.created;
+  if (!Number.isFinite(created) || created <= 0 || !Number.isFinite(now)) {
+    return undefined;
+  }
+
+  return Math.max(
+    created + SWAP_HISTORY_LONG_PENDING_WARNING_THRESHOLD_MS - now,
+    0,
+  );
+}
+
+export function shouldShowSwapHistoryLongPendingWarning({
+  item,
+  now = Date.now(),
+}: {
+  item?: ISwapTxHistory | null;
+  now?: number;
+}): boolean {
+  return getSwapHistoryLongPendingWarningDelayMs({ item, now }) === 0;
 }


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-53842](https://onekeyhq.atlassian.net/browse/OK-53842)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Show a warning in Swap history details when a non-Private Send order stays pending for at least 90 minutes.
- Add a focused long-pending helper with boundary coverage and a dedicated analytics event.
- Keep provider-owned order status unchanged; the client only adds display guidance.

## Intent & Context
OK-53842 tracks a provider-delayed Swap order that can stay pending in the client for a long time even when on-chain completion may happen before provider status updates. The client should not privately mark the order as final; it should keep the provider status as the source of truth and show an extra prompt after 90 minutes.

## Root Cause
The app already stores pending Swap history and polls provider status, but there was no client-side display state for orders that remain pending beyond the 90-minute UX threshold. The existing i18n key `trade.taking_longer_than_usual` was generated but unused.

## Design Decisions
- Use `ISwapTxHistory.date.created` as the age source because `date.updated` can change when status data is refreshed.
- Scope the warning to non-Private Send `pending` histories only; terminal, canceling, and Private Send progress states keep their existing UI.
- Add a local timer in the detail modal so an order opened just before 90 minutes can show the alert at the threshold without relying on another polling writeback.
- Keep analytics payload minimal and avoid raw order IDs, transaction hashes, or addresses.

## Changes Detail
- `swapHistoryUtils.ts`: adds the 90-minute threshold helper and delay calculator.
- `SwapHistoryDetailModal.tsx`: renders the warning alert after Date and logs the visible warning once per opened order.
- `swapOrderLongPendingWarning.ts`: adds a dedicated Swap logger scene.
- `swapHistoryUtils.test.ts`: covers threshold, delay, status, Private Send, and invalid timestamp cases.

## Risk Assessment
- Risk Level: Low
- Affected Platforms: Desktop / Web / Extension / Mobile
- Risk Areas: History detail rendering and analytics event emission. Provider status, polling, and local pending cleanup are intentionally unchanged.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `yarn jest packages/shared/src/utils/swapHistoryUtils.test.ts --runInBand`
- [x] `git diff --cached --check`
- [ ] Runtime visual check with a real or safely seeded pending Swap history older than 90 minutes

[OK-53842]: https://onekeyhq.atlassian.net/browse/OK-53842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ