### PR TITLE
chore: sync release/v6.4.0 to x

### DIFF
--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -15,6 +15,7 @@ import {
   toastIfError,
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
+import { USD_CURRENCY_ID } from '@onekeyhq/shared/src/consts/currencyConsts';
 import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
 import { OneKeyError } from '@onekeyhq/shared/src/errors';
 import {
@@ -119,10 +120,12 @@ import {
   filterSwapHistoryPendingList,
   inAppNotificationAtom,
   perpsDepositOrderAtom,
+  settingsPersistAtom,
 } from '../states/jotai/atoms';
 import { vaultFactory } from '../vaults/factory';
 
 import ServiceBase from './ServiceBase';
+import { normalizeSwapTokenListCurrency } from './ServiceSwap.utils';
 import { buildSpeedSwapTxParams } from './utils/buildSpeedSwapTxParams';
 import {
   isSwapTxHistoryStatusTerminal,
@@ -574,6 +577,7 @@ export default class ServiceSwap extends ServiceBase {
     isAllNetworkFetchAccountTokens,
     protocol,
     lpToken,
+    currency,
   }: IFetchTokensParams): Promise<ISwapToken[]> {
     if (!isAllNetworkFetchAccountTokens) {
       await this.cancelFetchTokenList();
@@ -598,6 +602,10 @@ export default class ServiceSwap extends ServiceBase {
       this._tokenListAbortController = new AbortController();
     }
     const client = await this.getClient(EServiceEndpointEnum.Swap);
+    const requestCurrency =
+      currency ??
+      (await settingsPersistAtom.get())?.currencyInfo?.id ??
+      USD_CURRENCY_ID;
     if (accountId && accountAddress && networkId) {
       try {
         const accountAddressForAccountId =
@@ -642,15 +650,20 @@ export default class ServiceSwap extends ServiceBase {
           signal: !isAllNetworkFetchAccountTokens
             ? this._tokenListAbortController?.signal
             : undefined,
-          headers:
-            await this.backgroundApi.serviceAccountProfile._getWalletTypeHeader(
+          headers: {
+            ...(await this.backgroundApi.serviceAccountProfile._getWalletTypeHeader(
               {
                 accountId,
               },
-            ),
+            )),
+            'x-onekey-request-currency': requestCurrency,
+          },
         },
       );
-      return data?.data ?? [];
+      return normalizeSwapTokenListCurrency({
+        tokens: data?.data ?? [],
+        currency: requestCurrency,
+      });
     } catch (e) {
       if (axios.isCancel(e)) {
         // eslint-disable-next-line no-restricted-syntax, onekey/no-raw-error -- needs standard Error cause semantics

--- a/packages/kit-bg/src/services/ServiceSwap.utils.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.utils.ts
@@ -1,0 +1,20 @@
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+
+export function normalizeSwapTokenListCurrency({
+  tokens,
+  currency,
+}: {
+  tokens: ISwapToken[];
+  currency: string;
+}) {
+  return tokens.map((token) => {
+    if (!token.price && !token.fiatValue) {
+      return token;
+    }
+
+    return {
+      ...token,
+      currency,
+    };
+  });
+}

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -2044,6 +2044,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       isFirstFetch?: boolean,
       allNetAccountId?: string,
       lpToken?: boolean,
+      currency?: string,
     ) => {
       const protocol = get(swapTypeSwitchAtom());
       const result = await backgroundApiProxy.serviceSwap.fetchSwapTokens({
@@ -2055,6 +2056,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         isAllNetworkFetchAccountTokens: true,
         protocol,
         lpToken,
+        currency,
       });
       if (result?.length) {
         if (isFirstFetch && allNetAccountId) {
@@ -2113,6 +2115,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       indexedAccountId?: string,
       otherWalletTypeAccountId?: string,
       lpToken?: boolean,
+      currency?: string,
     ) => {
       const swapAllNetworkActionLock = get(swapAllNetworkActionLockAtom());
       const swapTypeSwitchValue = get(swapTypeSwitchAtom());
@@ -2136,6 +2139,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       const tokenListCacheKey = buildSwapAllNetworkTokenListCacheKey({
         accountId: accountIdKey,
         lpToken,
+        currency,
       });
       if (swapAllNetworkActionLock[tokenListCacheKey]) {
         return;
@@ -2170,6 +2174,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
               !currentSwapAllNetworkTokenList,
               tokenListCacheKey,
               lpToken,
+              currency,
             );
         });
 

--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
@@ -3,11 +3,14 @@ import { Fragment, memo, useCallback, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import {
+  Badge,
+  Dialog,
   Divider,
   Icon,
   IconButton,
   Image,
   Page,
+  ScrollView,
   SizableText,
   Stack,
   XStack,
@@ -50,6 +53,7 @@ import {
 import type {
   IEarnAlert,
   IEarnText,
+  IEarnTextTooltip,
   IEarnTokenInfo,
   IProtocolInfo,
   IStakeEarnDetail,
@@ -349,6 +353,37 @@ function ChartSection({
   );
 }
 
+const MARKET_INFO_DIALOG_CONTENT_MAX_HEIGHT = 512;
+
+function MarketInfoDialogContent({ tooltip }: { tooltip: IEarnTextTooltip }) {
+  return (
+    <ScrollView
+      maxHeight={MARKET_INFO_DIALOG_CONTENT_MAX_HEIGHT}
+      nestedScrollEnabled
+    >
+      <YStack px="$5" pb="$5" gap="$5">
+        {tooltip.data.description ? (
+          <EarnText text={tooltip.data.description} size="$bodyMd" />
+        ) : null}
+        {tooltip.data.items?.map((item, index) => (
+          <YStack key={`${item.title.text}-${index}`} gap="$1">
+            <EarnText
+              text={item.title}
+              size="$bodySm"
+              color={item.title.color ?? '$textSubdued'}
+            />
+            <EarnText
+              text={item.description}
+              size="$bodyMd"
+              color={item.description.color ?? '$text'}
+            />
+          </YStack>
+        ))}
+      </YStack>
+    </ScrollView>
+  );
+}
+
 function GridSection({
   data,
 }: {
@@ -357,6 +392,35 @@ function GridSection({
     | IStakeEarnDetail['rules']
     | IStakeEarnDetail['performance'];
 }) {
+  const intl = useIntl();
+  const marketInfoTooltip =
+    data && 'tooltip' in data && data.tooltip?.type === 'text'
+      ? data.tooltip
+      : undefined;
+  const handleShowMarketInfo = useCallback(() => {
+    if (!marketInfoTooltip) {
+      return;
+    }
+
+    Dialog.show({
+      title: marketInfoTooltip.data.title?.text ?? 'Market info',
+      disableDrag: true,
+      contentContainerProps: {
+        px: '$0',
+        pb: '$0',
+      },
+      floatingPanelProps: {
+        width: 400,
+      },
+      renderContent: <MarketInfoDialogContent tooltip={marketInfoTooltip} />,
+      onConfirmText: intl.formatMessage({ id: ETranslations.global_got_it }),
+      confirmButtonProps: {
+        variant: 'secondary',
+      },
+      showCancelButton: false,
+    });
+  }, [intl, marketInfoTooltip]);
+
   if (!data) {
     return null;
   }
@@ -365,7 +429,27 @@ function GridSection({
     <>
       {data.items?.length ? (
         <YStack gap="$6">
-          <EarnText text={data.title} size="$headingLg" />
+          <XStack alignItems="center" gap="$3">
+            <EarnText text={data.title} size="$headingLg" />
+            {marketInfoTooltip ? (
+              <Badge
+                badgeSize="lg"
+                badgeType="default"
+                gap="$1"
+                cursor="pointer"
+                onPress={handleShowMarketInfo}
+              >
+                <Badge.Text>
+                  {marketInfoTooltip.data.title?.text ?? 'Market info'}
+                </Badge.Text>
+                <Icon
+                  name="InfoCircleOutline"
+                  size="$3.5"
+                  color="$iconSubdued"
+                />
+              </Badge>
+            ) : null}
+          </XStack>
           <XStack flexWrap="wrap" m="$-5" p="$2">
             {data.items.map((cell, cellIndex) => (
               <GridItem

--- a/packages/kit/src/views/Earn/pages/EarnProtocols/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocols/index.tsx
@@ -56,6 +56,8 @@ enum EProtocolCategory {
   FixedRate = 'fixedRate',
 }
 
+const MOBILE_FIXED_RATE_YIELD_COLUMN_MIN_WIDTH = 112;
+
 const parseDaysRemaining = (rawDaysRemaining?: string | null) => {
   if (!rawDaysRemaining) {
     return undefined;
@@ -336,7 +338,12 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
               </Stack>
               <YStack mr="$2" flex={1} minWidth={0}>
                 <XStack ai="center" gap="$2" minWidth={0}>
-                  <SizableText size="$bodyLgMedium" flexShrink={0}>
+                  <SizableText
+                    size="$bodyLgMedium"
+                    numberOfLines={1}
+                    flexShrink={1}
+                    minWidth={0}
+                  >
                     {isFixedRateCategory ? maturityTitle : providerName}
                   </SizableText>
                   {!isFixedRateCategory
@@ -355,7 +362,11 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
                     : null}
                 </XStack>
                 {isFixedRateCategory ? (
-                  <SizableText size="$bodySmMedium" color="$textSubdued">
+                  <SizableText
+                    size="$bodySmMedium"
+                    color="$textSubdued"
+                    numberOfLines={1}
+                  >
                     {detailText}
                   </SizableText>
                 ) : (
@@ -439,6 +450,10 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
         key: 'yield',
         label: intl.formatMessage({ id: ETranslations.defi_apr_apy }),
         flex: 2,
+        minWidth:
+          isFixedRateCategory && !isDesktopLayout
+            ? MOBILE_FIXED_RATE_YIELD_COLUMN_MIN_WIDTH
+            : undefined,
         align: 'flex-end',
         sortable: true,
         comparator: (a, b) => {
@@ -451,17 +466,35 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
             isFixedRateCategory &&
             !isDesktopLayout &&
             Boolean(item.provider.liquidity);
+          const mobileLiquidityLabel = intl.formatMessage({
+            id: ETranslations.global_liquidity,
+          });
           const mobileLiquidity = showMobileLiquidity ? (
-            <SizableText size="$bodySmMedium" color="$textSubdued">
-              {`${intl.formatMessage({
-                id: ETranslations.global_liquidity,
-              })} ${item.provider.liquidity}`}
-            </SizableText>
+            <XStack ai="center" jc="flex-end" gap="$0.5" w="100%" minWidth={0}>
+              <SizableText
+                size="$bodySmMedium"
+                color="$textSubdued"
+                numberOfLines={1}
+                ellipsizeMode="tail"
+                flexShrink={1}
+                minWidth={0}
+              >
+                {mobileLiquidityLabel}
+              </SizableText>
+              <SizableText
+                size="$bodySmMedium"
+                color="$textSubdued"
+                numberOfLines={1}
+                flexShrink={0}
+              >
+                {item.provider.liquidity}
+              </SizableText>
+            </XStack>
           ) : null;
 
           if (item.aprInfo?.button?.type === 'redeem') {
             return (
-              <YStack ai="flex-end" gap="$0.5">
+              <YStack ai="flex-end" gap="$0.5" minWidth={0}>
                 <SizableText size="$bodyLgMedium" color="$textInfo">
                   {item.aprInfo.button.text?.text ||
                     intl.formatMessage({ id: ETranslations.defi_redeemable })}
@@ -471,7 +504,7 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
             );
           }
           return (
-            <YStack ai="flex-end" gap="$0.5">
+            <YStack ai="flex-end" gap="$0.5" minWidth={0}>
               <AprText
                 hideSuffix={isDesktopLayout}
                 asset={{

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -127,6 +127,33 @@ interface ITradingButtonGroupProps {
   enableTradingModeOverride?: IPerpsOrderPanelEnableTradingMode;
 }
 
+function IpRestrictedSingleButton({ isMobile }: { isMobile: boolean }) {
+  const intl = useIntl();
+
+  return (
+    <YStack {...(!isMobile && { mt: '$4' })}>
+      <Button
+        testID="perp-ip-restricted-button"
+        size="medium"
+        disabled
+        childrenAsText={false}
+        borderRadius="$full"
+        variant="secondary"
+        disabledStyle={{ opacity: 1 }}
+        h={isMobile ? 46 : 44}
+        iconAfter="LockOutline"
+        iconColor="$iconSubdued"
+      >
+        <SizableText size="$bodyMdMedium" color="$textSubdued">
+          {intl.formatMessage({
+            id: ETranslations.trading_unavailable__action,
+          })}
+        </SizableText>
+      </Button>
+    </YStack>
+  );
+}
+
 interface ISideButtonProps {
   side: 'long' | 'short';
   isMobile: boolean;
@@ -536,10 +563,6 @@ function SideButtonInternal({
       return intl.formatMessage({
         id: ETranslations.Perps_BBO_unavailable,
       });
-    if (perpConfigCommon?.ipDisablePerp)
-      return intl.formatMessage({
-        id: ETranslations.perp_button_ip_restricted,
-      });
     if (perpConfigCommon?.disablePerpActionPerp)
       return intl.formatMessage({
         id: ETranslations.perp_button_disable_perp,
@@ -578,7 +601,6 @@ function SideButtonInternal({
     side,
     spotTradeSymbol,
     intl,
-    perpConfigCommon?.ipDisablePerp,
     perpConfigCommon?.disablePerpActionPerp,
     shouldEnableTradingBeforeOrder,
   ]);
@@ -1722,10 +1744,6 @@ function EmptySizeSideButton({
   }, [activeTradeInstrument, isSpot]);
 
   const buttonText = useMemo(() => {
-    if (perpConfigCommon?.ipDisablePerp)
-      return intl.formatMessage({
-        id: ETranslations.perp_button_ip_restricted,
-      });
     if (perpConfigCommon?.disablePerpActionPerp)
       return intl.formatMessage({
         id: ETranslations.perp_button_disable_perp,
@@ -1761,7 +1779,6 @@ function EmptySizeSideButton({
     intl,
     isSpot,
     perpConfigCommon?.disablePerpActionPerp,
-    perpConfigCommon?.ipDisablePerp,
     side,
     spotTradeSymbol,
   ]);
@@ -2184,6 +2201,7 @@ function TradingButtonGroupLive({
   enableTradingModeOverride,
 }: ITradingButtonGroupProps) {
   const [tradingMode] = useTradingModeAtom();
+  const [{ perpConfigCommon }] = usePerpsCommonConfigPersistAtom();
   const tradingSide = useTradingFormSide();
   const marketDataFreshness = usePerpsMarketDataFreshness();
   const liveHandleConfirmRef = useRef(noopHandleConfirm);
@@ -2193,6 +2211,10 @@ function TradingButtonGroupLive({
     [],
   );
   const isSpot = tradingMode === 'spot';
+
+  if (perpConfigCommon?.ipDisablePerp) {
+    return <IpRestrictedSingleButton isMobile={isMobile} />;
+  }
 
   const renderSideButtons = () => {
     if (isSpot) {
@@ -2276,8 +2298,13 @@ function TradingButtonGroupEmptySize({
   enableTradingModeOverride,
 }: ITradingButtonGroupProps) {
   const [tradingMode] = useTradingModeAtom();
+  const [{ perpConfigCommon }] = usePerpsCommonConfigPersistAtom();
   const tradingSide = useTradingFormSide();
   const isSpot = tradingMode === 'spot';
+
+  if (perpConfigCommon?.ipDisablePerp) {
+    return <IpRestrictedSingleButton isMobile={isMobile} />;
+  }
 
   const renderSideButtons = () => {
     if (isSpot) {

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpIpRestrictionNotice.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpIpRestrictionNotice.tsx
@@ -1,0 +1,70 @@
+import { useCallback } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { Icon, SizableText, XStack, YStack } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { PERPS_IP_RESTRICTION_HELP_URL } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+
+import { openGuideUrl } from '../../Guide/perpGuideData';
+
+export function PerpIpRestrictionNotice({
+  isMobile = false,
+  isSpot = false,
+}: {
+  isMobile?: boolean;
+  isSpot?: boolean;
+}) {
+  const intl = useIntl();
+  const handleLearnMore = useCallback(() => {
+    openGuideUrl(PERPS_IP_RESTRICTION_HELP_URL);
+  }, []);
+
+  return (
+    <YStack
+      gap="$2"
+      p={isMobile ? '$3.5' : '$3'}
+      borderRadius="$4"
+      bg="$bgSubdued"
+    >
+      <XStack gap="$2" alignItems="center">
+        <YStack>
+          <Icon name="InfoCircleSolid" size="$3.5" color="$iconSubdued" />
+        </YStack>
+        <SizableText size="$bodySm" fontWeight="600" flex={1}>
+          {intl.formatMessage({
+            id: ETranslations.perp_ip_restriction__title,
+          })}
+        </SizableText>
+      </XStack>
+
+      <YStack gap="$1.5">
+        <SizableText size="$bodyXs" color="$textSubdued">
+          {intl.formatMessage({
+            id: isSpot
+              ? ETranslations.perp_ip_restriction_spot__desc
+              : ETranslations.perp_ip_restriction_perp__desc,
+          })}
+        </SizableText>
+
+        <XStack
+          gap="$1"
+          alignItems="center"
+          cursor="pointer"
+          onPress={handleLearnMore}
+        >
+          <SizableText size="$bodyXs" color="$textInteractive">
+            {intl.formatMessage({
+              id: ETranslations.global_learn_more,
+            })}
+          </SizableText>
+          <Icon
+            name="ChevronRightSmallOutline"
+            size="$4"
+            color="$textInteractive"
+          />
+        </XStack>
+      </YStack>
+    </YStack>
+  );
+}

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -48,6 +48,7 @@ import {
   usePerpsActiveAssetAtom,
   usePerpsActiveAssetCtxReadyAtom,
   usePerpsActiveAssetDataAtom,
+  usePerpsCommonConfigPersistAtom,
   usePerpsCustomSettingsAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
@@ -96,6 +97,7 @@ import {
   getTradingSideTextColor,
 } from '../../../utils/styleUtils';
 import { PerpsSlider } from '../../PerpsSlider';
+import { PerpIpRestrictionNotice } from '../components/PerpIpRestrictionNotice';
 import { PerpsAccountNumberValue } from '../components/PerpsAccountNumberValue';
 import { PriceInput } from '../inputs/PriceInput';
 import {
@@ -456,6 +458,7 @@ function PerpTradingForm({
   const [enableTradingMode] = usePerpsActiveAccountEnableTradingModeAtom();
   const [perpsAccountStatus] = usePerpsActiveAccountStatusAtom();
   const [perpsAbstractionMode] = usePerpsAbstractionModeAtom();
+  const [{ perpConfigCommon }] = usePerpsCommonConfigPersistAtom();
   const [displayReady] = usePerpsAccountDisplayReadyAtom();
   const [displaySnapshot] = usePerpsAccountDisplaySnapshotAtom();
   const { activeAccount: selectedWalletAccount } = useActiveAccount({ num: 0 });
@@ -1366,6 +1369,7 @@ function PerpTradingForm({
       !perpsAccountStatus.canTrade &&
       !perpsAccountStatus.accountNotSupport &&
       !perpsAccountStatus.canCreateAddress &&
+      !perpConfigCommon?.ipDisablePerp &&
       enableTradingMode.requiresExplicitEnableTrading,
     [
       displayReady.statusReady,
@@ -1374,8 +1378,14 @@ function PerpTradingForm({
       perpsAccountStatus.accountNotSupport,
       perpsAccountStatus.canCreateAddress,
       perpsAccountStatus.canTrade,
+      perpConfigCommon?.ipDisablePerp,
     ],
   );
+  const shouldShowIpRestrictionNotice = useMemo(
+    () => perpConfigCommon?.ipDisablePerp === true,
+    [perpConfigCommon?.ipDisablePerp],
+  );
+  const shouldHideMobileTpsl = isMobile && shouldShowIpRestrictionNotice;
 
   const spotMaxTradeLabel = useMemo(
     () =>
@@ -2624,52 +2634,54 @@ function PerpTradingForm({
 
     return (
       <YStack gap="$1" {...(isMobile && { mt: '$1' })} p="$0">
-        <XStack
-          width="100%"
-          alignItems="center"
-          justifyContent="space-between"
-          gap="$3"
-        >
-          <XStack alignItems="center" gap="$2">
-            <Checkbox
-              testID={PerpTestIDs.TpslCheckbox}
-              value={formData.hasTpsl}
-              onChange={handleTpslCheckboxChange}
-              disabled={isSubmitting}
-              containerProps={{
-                p: 0,
-                alignItems: 'center',
-                ...(!isMobile && { cursor: 'pointer' }),
-              }}
-              width={checkboxSizeVal}
-              height={checkboxSizeVal}
-              {...(isMobile && { p: '$0' })}
-            />
+        {shouldHideMobileTpsl ? null : (
+          <XStack
+            width="100%"
+            alignItems="center"
+            justifyContent="space-between"
+            gap="$3"
+          >
+            <XStack alignItems="center" gap="$2">
+              <Checkbox
+                testID={PerpTestIDs.TpslCheckbox}
+                value={formData.hasTpsl}
+                onChange={handleTpslCheckboxChange}
+                disabled={isSubmitting}
+                containerProps={{
+                  p: 0,
+                  alignItems: 'center',
+                  ...(!isMobile && { cursor: 'pointer' }),
+                }}
+                width={checkboxSizeVal}
+                height={checkboxSizeVal}
+                {...(isMobile && { p: '$0' })}
+              />
 
-            <XStack alignItems="center" pt="$0.5">
-              <DashText
-                size={isMobile ? '$bodySm' : '$bodyMd'}
-                dashColor="$textDisabled"
-                dashThickness={0.5}
-                tooltip={intl.formatMessage({
-                  id: ETranslations.perp_tp_sl_tooltip,
-                })}
-                tooltipDisplayMode={isMobile ? 'popover' : 'tooltip'}
-                tooltipTitle={intl.formatMessage({
-                  id: ETranslations.perp_position_tp_sl,
-                })}
-              >
-                {intl.formatMessage({
-                  id: ETranslations.perp_position_tp_sl,
-                })}
-              </DashText>
+              <XStack alignItems="center" pt="$0.5">
+                <DashText
+                  size={isMobile ? '$bodySm' : '$bodyMd'}
+                  dashColor="$textDisabled"
+                  dashThickness={0.5}
+                  tooltip={intl.formatMessage({
+                    id: ETranslations.perp_tp_sl_tooltip,
+                  })}
+                  tooltipDisplayMode={isMobile ? 'popover' : 'tooltip'}
+                  tooltipTitle={intl.formatMessage({
+                    id: ETranslations.perp_position_tp_sl,
+                  })}
+                >
+                  {intl.formatMessage({
+                    id: ETranslations.perp_position_tp_sl,
+                  })}
+                </DashText>
+              </XStack>
             </XStack>
+
+            {standardLimitTifSelector}
           </XStack>
+        )}
 
-          {standardLimitTifSelector}
-        </XStack>
-
-        {formData.hasTpsl ? (
+        {!shouldHideMobileTpsl && formData.hasTpsl ? (
           <YStack gap="$2">
             <TpSlFormInput
               type="tp"
@@ -2809,6 +2821,10 @@ function PerpTradingForm({
       pt={isMobile || isSpot ? '$0' : '$2.5'}
       flex={isSpot && isMobile ? 1 : undefined}
     >
+      {shouldShowIpRestrictionNotice ? (
+        <PerpIpRestrictionNotice isMobile={isMobile} isSpot={isSpot} />
+      ) : null}
+
       {isMobile ? (
         <YStack gap="$2.5" flexShrink={0}>
           {isSpot ? null : (

--- a/packages/kit/src/views/Swap/hooks/useSwapTokens.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapTokens.ts
@@ -6,7 +6,10 @@ import { debounce } from 'lodash';
 import { useIsOverlayPage } from '@onekeyhq/components';
 import { useRouteIsFocused as useIsFocused } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
 import type { IAllNetworkAccountInfo } from '@onekeyhq/kit-bg/src/services/ServiceAllNetwork/ServiceAllNetwork';
-import { useInAppNotificationAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  useInAppNotificationAtom,
+  useSettingsPersistAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -66,7 +69,9 @@ export function useSwapTokenList(
   const swapAddressInfo = useSwapAddressInfo(selectTokenModalType);
   const [swapTokenFetching] = useSwapTokenFetchingAtom();
   const [currentSelectNetwork] = useSwapSelectTokenNetworkAtom();
+  const [{ currencyInfo }] = useSettingsPersistAtom();
   const [lpTokenRequestLoading, setLpTokenRequestLoading] = useState(false);
+  const requestCurrency = currencyInfo.id;
   const latestLpTokenRef = useRef(lpToken);
   const searchLogStateRef = useRef<{
     key: string;
@@ -113,6 +118,7 @@ export function useSwapTokenList(
         accountNetworkId: findNetInfo.networkId,
         accountId: findNetInfo.accountId,
         lpToken,
+        currency: requestCurrency,
       };
     }
 
@@ -124,6 +130,7 @@ export function useSwapTokenList(
         accountNetworkId: swapAddressInfo?.networkId,
         accountId: swapAddressInfo?.accountInfo?.account?.id,
         lpToken,
+        currency: requestCurrency,
       };
     }
     return {
@@ -133,6 +140,7 @@ export function useSwapTokenList(
       accountNetworkId: findNetInfo?.networkId,
       accountId: findNetInfo?.accountId,
       lpToken,
+      currency: requestCurrency,
     };
   }, [
     currentNetworkId,
@@ -143,6 +151,7 @@ export function useSwapTokenList(
     keywords,
     currentSelectNetwork?.networkId,
     lpToken,
+    requestCurrency,
   ]);
   const isTokenFetchAllNetworks = networkUtils.isAllNetwork({
     networkId: tokenFetchParams.networkId,
@@ -196,9 +205,11 @@ export function useSwapTokenList(
           swapAddressInfo?.accountInfo?.dbAccount?.id ??
           'noAccountId',
         lpToken,
+        currency: requestCurrency,
       }),
     [
       lpToken,
+      requestCurrency,
       swapAddressInfo?.accountInfo?.indexedAccount?.id,
       swapAddressInfo?.accountInfo?.account?.id,
       swapAddressInfo?.accountInfo?.dbAccount?.id,
@@ -375,6 +386,7 @@ export function useSwapTokenList(
                       swapAddressInfo?.accountInfo?.dbAccount?.id)
                   : undefined,
                 lpToken,
+                requestCurrency,
               )
             : undefined,
           tokenListFetchAction(tokenFetchParams),
@@ -400,6 +412,7 @@ export function useSwapTokenList(
     tokenListFetchAction,
     keywords,
     lpToken,
+    requestCurrency,
   ]);
 
   useEffect(() => {

--- a/packages/shared/src/utils/tokenSelectorFilterUtils.ts
+++ b/packages/shared/src/utils/tokenSelectorFilterUtils.ts
@@ -140,11 +140,14 @@ export function filterTokenSelectorTokensByDappTokenFilterParams<
 export function buildSwapAllNetworkTokenListCacheKey({
   accountId,
   lpToken,
+  currency,
 }: {
   accountId: string;
   lpToken?: boolean;
+  currency?: string;
 }) {
-  return lpToken ? `${accountId}__lpToken` : accountId;
+  const currencyKey = currency ? `__${currency}` : '';
+  return `${accountId}${lpToken ? '__lpToken' : ''}${currencyKey}`;
 }
 
 export const SWAP_LP_TOKEN_FILTER_SERVER_SUPPORTED =

--- a/packages/shared/types/hyperliquid/perp.constants.ts
+++ b/packages/shared/types/hyperliquid/perp.constants.ts
@@ -32,6 +32,8 @@ export const TERMS_OF_SERVICE_URL =
   'https://help.onekey.so/articles/11461297-user-service-agreement';
 export const PRIVACY_POLICY_URL =
   'https://help.onekey.so/articles/11461298-privacy-policy';
+export const PERPS_IP_RESTRICTION_HELP_URL =
+  'https://help.onekey.so/articles/15533117';
 
 // Multi-DEX support constants
 export const DEX_PREFIXES = ['xyz'] as const;

--- a/packages/shared/types/staking.ts
+++ b/packages/shared/types/staking.ts
@@ -909,7 +909,7 @@ export interface IEarnTextTooltip {
   type: 'text';
   data: {
     title?: IEarnText;
-    description: IEarnText;
+    description?: IEarnText;
     items?: IEarnTooltipComparisonItem[];
   };
 }
@@ -1507,7 +1507,9 @@ export interface IStakeEarnDetail {
   };
   intro?: {
     title: IEarnText;
+    description?: IEarnText;
     items: IEarnGridItem[];
+    tooltip?: IEarnTooltip;
   };
   rules?: {
     title: IEarnText;

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -220,6 +220,7 @@ export interface IFetchTokensParams {
   onlyAccountTokens?: boolean;
   isAllNetworkFetchAccountTokens?: boolean;
   lpToken?: boolean;
+  currency?: string;
 }
 
 export interface IFetchTokenListParams {


### PR DESCRIPTION
Sync bundle release changes from `release/v6.4.0` to `x`.

This is an incremental sync on top of the prior sync #12101. It brings the 3 commits added to `release/v6.4.0` after that sync:

- **#12090** feat: support Pendle market info tooltip (OK-55227)
- **#12099** fix: update perp ip restriction trading panel ui
- **#12097** fix: correct swap fiat basis after currency switch (OK-56406)

## Notes
- 13 code files changed, 0 locale files (the new keys were already present on x).
- Release-tracking commits (`chore: release #1/#2`, `BUILD_NUMBER`, `RELEASES.json`) are excluded by design.
- Commits already on x via #12101 (incl. #12057 and 10 others) were skipped.