### PR TITLE
fix: adjust swap bridge title state(OK-56376)

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapOldSwapBridgeLimitContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapOldSwapBridgeLimitContainer.tsx
@@ -19,6 +19,7 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import type { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
 import type {
   ESwapDirectionType,
@@ -76,6 +77,46 @@ interface ISwapOldSwapBridgeLimitContainerProps {
   headerContent?: ReactNode;
 }
 
+const DESKTOP_SWAP_TITLE_TRANSITION =
+  'color 180ms ease, font-size 180ms ease, opacity 180ms ease';
+
+function SwapTitleText({
+  children,
+  isActive,
+  shouldUseDesktopLayoutTitleState,
+  inactiveOpacity = 0.8,
+}: {
+  children: ReactNode;
+  isActive: boolean;
+  shouldUseDesktopLayoutTitleState: boolean;
+  inactiveOpacity?: number;
+}) {
+  const shouldUseInactiveDesktopLayoutStyle =
+    shouldUseDesktopLayoutTitleState && !isActive;
+  let titleOpacity: number | undefined;
+
+  if (shouldUseDesktopLayoutTitleState) {
+    titleOpacity = isActive ? 1 : inactiveOpacity;
+  }
+
+  return (
+    <SizableText
+      size={shouldUseInactiveDesktopLayoutStyle ? '$headingMd' : '$headingLg'}
+      color={isActive ? '$text' : '$textSubdued'}
+      opacity={titleOpacity}
+      $platform-web={
+        shouldUseDesktopLayoutTitleState
+          ? {
+              transition: DESKTOP_SWAP_TITLE_TRANSITION,
+            }
+          : undefined
+      }
+    >
+      {children}
+    </SizableText>
+  );
+}
+
 const SwapOldSwapBridgeLimitContainer = ({
   pageType,
   storeName,
@@ -119,23 +160,31 @@ const SwapOldSwapBridgeLimitContainer = ({
   const isEffectiveBridge =
     effectiveSwapType === ESwapTabSwitchType.BRIDGE &&
     swapTypeSwitch !== ESwapTabSwitchType.LIMIT;
+  const shouldUseDesktopLayoutTitleState = Boolean(
+    platformEnv.isDesktop || platformEnv.isWeb,
+  );
+
   let swapTitleContent = (
     <XStack alignItems="baseline" flexShrink={1} minWidth={0} gap="$1">
-      <SizableText
-        size="$headingLg"
-        color={isEffectiveBridge ? '$textSubdued' : '$text'}
+      <SwapTitleText
+        isActive={!isEffectiveBridge}
+        shouldUseDesktopLayoutTitleState={shouldUseDesktopLayoutTitleState}
       >
         {swapLabel}
-      </SizableText>
-      <SizableText size="$headingLg" color="$textSubdued">
+      </SwapTitleText>
+      <SwapTitleText
+        isActive={false}
+        shouldUseDesktopLayoutTitleState={shouldUseDesktopLayoutTitleState}
+        inactiveOpacity={0.72}
+      >
         &
-      </SizableText>
-      <SizableText
-        size="$headingLg"
-        color={isEffectiveBridge ? '$text' : '$textSubdued'}
+      </SwapTitleText>
+      <SwapTitleText
+        isActive={isEffectiveBridge}
+        shouldUseDesktopLayoutTitleState={shouldUseDesktopLayoutTitleState}
       >
         {bridgeLabel}
-      </SizableText>
+      </SwapTitleText>
     </XStack>
   );
   if (swapTypeSwitch === ESwapTabSwitchType.STOCK) {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56376](https://onekeyhq.atlassian.net/browse/OK-56376)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Adjust the merged Swap & Bridge desktop title state so the inactive mode is slightly smaller and dimmer.
- Apply the desktop layout treatment to both Electron desktop and web, while keeping mobile behavior unchanged.
- Keep the transition subtle and avoid additional font-weight changes.

## Related Issue
- [OK-56376](https://onekeyhq.atlassian.net/browse/OK-56376)

## Intent & Context
The Swap and Bridge flows now share a merged title. The UI should hint at the current mode: same-chain swaps highlight "Swap", while cross-chain swaps highlight "Bridge". The previous color-only treatment was too subtle, so this change adds a small size and opacity difference for the inactive title in desktop layout.

## Root Cause
The title state only changed color, which made the selected mode insufficiently obvious in the desktop card layout.

## Design Decisions
- Use font size and opacity instead of font weight so the active state does not look overly bold.
- Apply the treatment to web and Electron desktop because both use the desktop layout.
- Keep the non-desktop fallback at the previous `$headingLg` size and subdued color behavior so mobile stays unchanged.
- Consolidate the title styling into a single helper to avoid duplicate branches for words and the separator.

## Changes Detail
- `SwapOldSwapBridgeLimitContainer.tsx`
  - Adds a shared `SwapTitleText` helper for active and inactive title segments.
  - Enables desktop-layout title styling for `platformEnv.isDesktop || platformEnv.isWeb`.
  - Adds a lightweight web transition for color, font size, and opacity.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop, Web
- **Risk Areas**: Visual regression in the Swap & Bridge desktop card title.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] Verified web preview at `http://localhost:3030/swap` in desktop viewport.
- [x] Verified active title uses `18px`, inactive title uses `16px/0.8`, and the separator uses `16px/0.72`.


[OK-56376]: https://onekeyhq.atlassian.net/browse/OK-56376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ