### PR TITLE
fix: improve stock tab UX(OK-56475)

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 
 import { useTheme } from '@tamagui/core';
@@ -99,6 +99,13 @@ import SwapActionsState from './SwapActionsState';
 import SwapProCurrentSymbolEnable from './SwapProCurrentSymbolEnable';
 import SwapProPositionsList from './SwapProPositionsList';
 import SwapQuoteResult from './SwapQuoteResult';
+import {
+  type IStockChartRange,
+  STOCK_CHART_DEFAULT_RANGE,
+  STOCK_CHART_RANGE_ITEMS,
+  STOCK_DESKTOP_HEADER_SLOT_PROPS,
+  getStockDisabledActionButtonProps,
+} from './SwapStockDesktopContainer.utils';
 import { SwapStockTradeAlert } from './SwapStockTradeAlert';
 import {
   SwapStockTradeProvider,
@@ -130,7 +137,6 @@ interface ISwapStockDesktopContainerProps {
   };
 }
 
-type IStockChartRange = '1D' | '1W' | '1M' | '1Y';
 type IStockMarketTokenDetail = ReturnType<typeof useTokenDetail>['tokenDetail'];
 type IStockMarketDataRow = {
   label: string;
@@ -138,16 +144,6 @@ type IStockMarketDataRow = {
   tooltip?: string;
 };
 
-const STOCK_CHART_RANGE_ITEMS: {
-  label: IStockChartRange;
-  interval: string;
-  seconds: number;
-}[] = [
-  { label: '1D', interval: '1m', seconds: 24 * 60 * 60 },
-  { label: '1W', interval: '1H', seconds: 7 * 24 * 60 * 60 },
-  { label: '1M', interval: '4H', seconds: 30 * 24 * 60 * 60 },
-  { label: '1Y', interval: '1D', seconds: 365 * 24 * 60 * 60 },
-];
 const STOCK_CHART_VISIBLE_HEIGHT = 174;
 const STOCK_CHART_PRICE_SCALE_MARGINS = { top: 0.12, bottom: 0.1 } as const;
 const STOCK_CHART_HOVER_TOOLTIP_WIDTH = 112;
@@ -210,6 +206,11 @@ function StockMarketDataItem({
             title={label}
             tooltip={tooltip}
             placement="top"
+            renderContent={
+              <YStack p="$5">
+                <SizableText size="$bodyMd">{tooltip}</SizableText>
+              </YStack>
+            }
           />
         ) : null}
       </XStack>
@@ -602,6 +603,10 @@ function StockActionGate({
     );
   }
 
+  const disabledButtonProps = getStockDisabledActionButtonProps(
+    stockChannel.tradeSide,
+  );
+
   return (
     <Button
       testID={SwapTestIDs.swapButton}
@@ -609,6 +614,7 @@ function StockActionGate({
       variant="primary"
       disabled
       borderRadius="$full"
+      {...disabledButtonProps}
     >
       {disabledLabel}
     </Button>
@@ -982,17 +988,20 @@ function StockMarketTokenHeader({
 function StockPriceChart({
   isNative,
   networkId,
+  onRangeChange,
+  range,
   tokenAddress,
   tokenSymbol,
 }: {
   isNative?: boolean;
   networkId?: string;
+  onRangeChange: (range: IStockChartRange) => void;
+  range: IStockChartRange;
   tokenAddress?: string;
   tokenSymbol?: string;
 }) {
   const intl = useIntl();
   const theme = useTheme();
-  const [range, setRange] = useState<IStockChartRange>('1D');
   const [hoverData, setHoverData] = useState<IStockChartHoverData | null>(null);
   const [chartWidth, setChartWidth] = useState(0);
   const chartLineColor = theme.textSuccess.val;
@@ -1005,10 +1014,13 @@ function StockPriceChart({
       })),
     [],
   );
-  const handleRangeChange = useCallback((value: string | number) => {
-    setRange(value as IStockChartRange);
-    setHoverData(null);
-  }, []);
+  const handleRangeChange = useCallback(
+    (value: string | number) => {
+      onRangeChange(value as IStockChartRange);
+      setHoverData(null);
+    },
+    [onRangeChange],
+  );
   const chartTitle = useMemo(() => {
     const chartLabel = intl.formatMessage({
       id: ETranslations.market_chart,
@@ -1022,6 +1034,9 @@ function StockPriceChart({
   const chartScope = `${networkId ?? ''}:${tokenAddress ?? ''}:${
     isNative ? 'native' : 'token'
   }:${range}`;
+  useEffect(() => {
+    setHoverData(null);
+  }, [chartScope]);
   const { result: chartState, isLoading } = usePromiseResult(
     async () => {
       if (!networkId || (!tokenAddress && !isNative) || !activeRange) {
@@ -1129,9 +1144,26 @@ function StockPriceChart({
   }, [hoverData, intl]);
 
   let chartContent: ReactNode = (
-    <YStack flex={1} alignItems="center" justifyContent="center">
-      <SizableText size="$bodySm" color="$textSubdued">
-        --
+    <YStack flex={1} alignItems="center" justifyContent="center" gap="$2">
+      <YStack
+        w="$10"
+        h="$10"
+        borderRadius="$full"
+        bg="$bgStrong"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Icon name="ChartLine2Outline" size="$5" color="$iconSubdued" />
+      </YStack>
+      <SizableText
+        size="$bodySm"
+        color="$textSubdued"
+        textAlign="center"
+        numberOfLines={2}
+      >
+        {intl.formatMessage({
+          id: ETranslations.dexmarket_k_line_no_recent_transactions,
+        })}
       </SizableText>
     </YStack>
   );
@@ -1315,6 +1347,9 @@ function StockMarketContextPanel({
   storeName: EJotaiContextStoreNames;
 }) {
   const { tokenDetail, tokenAddress, networkId, isNative } = useTokenDetail();
+  const [range, setRange] = useState<IStockChartRange>(
+    STOCK_CHART_DEFAULT_RANGE,
+  );
   const chartReady = !!networkId && !!tokenDetail?.symbol;
 
   return (
@@ -1347,6 +1382,8 @@ function StockMarketContextPanel({
             tokenAddress={tokenAddress ?? ''}
             networkId={networkId ?? ''}
             isNative={isNative}
+            range={range}
+            onRangeChange={setRange}
             tokenSymbol={tokenDetail?.symbol}
           />
         ) : (
@@ -1428,13 +1465,16 @@ function SwapStockDesktopContent({
   }, [navigation, storeName]);
 
   return (
-    <YStack width="100%" alignItems="center" pt="$5" pb="$5">
-      <YStack width="100%" maxWidth={960} gap="$7">
-        {headerContent ? (
-          <XStack h="$14" alignItems="center" justifyContent="center">
-            {headerContent}
-          </XStack>
-        ) : null}
+    <YStack
+      width="100%"
+      alignItems="center"
+      pb="$5"
+      pt={headerContent ? undefined : '$5'}
+    >
+      {headerContent ? (
+        <YStack {...STOCK_DESKTOP_HEADER_SLOT_PROPS}>{headerContent}</YStack>
+      ) : null}
+      <YStack width="100%" maxWidth={960}>
         <XStack width="100%" gap="$6" alignItems="flex-start">
           <YStack
             w={410}

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
@@ -1,0 +1,51 @@
+import { ESwapStockTradeSide } from '../../hooks/swapStockChannelUtils';
+
+import {
+  STOCK_CHART_DEFAULT_RANGE,
+  STOCK_CHART_RANGE_ITEMS,
+  STOCK_DESKTOP_HEADER_SLOT_PROPS,
+  getStockDisabledActionButtonProps,
+} from './SwapStockDesktopContainer.utils';
+
+describe('SwapStockDesktopContainer utils', () => {
+  it('defaults the stock chart range to one week', () => {
+    expect(STOCK_CHART_DEFAULT_RANGE).toBe('1W');
+  });
+
+  it('keeps one month as a selectable stock chart range', () => {
+    expect(
+      STOCK_CHART_RANGE_ITEMS.some((item) => item.label === '1M'),
+    ).toBeTruthy();
+  });
+
+  it('uses the shared desktop header slot spacing for stock layout', () => {
+    expect(STOCK_DESKTOP_HEADER_SLOT_PROPS).toEqual({
+      width: '100%',
+      alignItems: 'center',
+      pt: '$8',
+      pb: '$4',
+    });
+  });
+
+  it('keeps disabled buy actions in the buy color family', () => {
+    expect(getStockDisabledActionButtonProps(ESwapStockTradeSide.Buy)).toEqual({
+      bg: '$bgSuccessStrong',
+      color: '$textOnColor',
+      disabledStyle: {
+        opacity: 0.6,
+      },
+    });
+  });
+
+  it('keeps disabled sell actions in the sell color family', () => {
+    expect(getStockDisabledActionButtonProps(ESwapStockTradeSide.Sell)).toEqual(
+      {
+        bg: '$bgCriticalStrong',
+        color: '$textOnColor',
+        disabledStyle: {
+          opacity: 0.6,
+        },
+      },
+    );
+  });
+});

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
@@ -1,0 +1,38 @@
+import { ESwapStockTradeSide } from '../../hooks/swapStockChannelUtils';
+
+export type IStockChartRange = '1D' | '1W' | '1M' | '1Y';
+
+export const STOCK_CHART_DEFAULT_RANGE: IStockChartRange = '1W';
+
+export const STOCK_DESKTOP_HEADER_SLOT_PROPS = {
+  width: '100%',
+  alignItems: 'center',
+  pt: '$8',
+  pb: '$4',
+} as const;
+
+export const STOCK_CHART_RANGE_ITEMS: {
+  label: IStockChartRange;
+  interval: string;
+  seconds: number;
+}[] = [
+  { label: '1D', interval: '1m', seconds: 24 * 60 * 60 },
+  { label: '1W', interval: '1H', seconds: 7 * 24 * 60 * 60 },
+  { label: '1M', interval: '4H', seconds: 30 * 24 * 60 * 60 },
+  { label: '1Y', interval: '1D', seconds: 365 * 24 * 60 * 60 },
+];
+
+export function getStockDisabledActionButtonProps(
+  tradeSide: ESwapStockTradeSide,
+) {
+  return {
+    bg:
+      tradeSide === ESwapStockTradeSide.Sell
+        ? '$bgCriticalStrong'
+        : '$bgSuccessStrong',
+    color: '$textOnColor',
+    disabledStyle: {
+      opacity: 0.6,
+    },
+  } as const;
+}

--- a/packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.tsx
@@ -1,18 +1,14 @@
-import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import { memo, useEffect, useMemo, useRef } from 'react';
 
 import { useIntl } from 'react-intl';
 
 import { Alert, YStack } from '@onekeyhq/components';
-import { usePerpTabConfig } from '@onekeyhq/kit/src/hooks/usePerpTabConfig';
 import {
   useSwapFromTokenAmountAtom,
   useSwapQuoteEventErrorAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
-import { usePerpsNavigation } from '@onekeyhq/kit/src/views/Market/hooks/usePerpsNavigation';
-import { useTokenDetail } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/hooks/useTokenDetail';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
-import { EPerpPageEnterSource } from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type {
   IFetchQuoteResult,
@@ -29,6 +25,7 @@ import { getStockTradeAlertAnalyticsPayload } from '../../utils/swapStockAnalyti
 import { getStockQuoteTradeControl } from '../../utils/swapStockTradeControl';
 
 import SwapAlertContainer from './SwapAlertContainer';
+import { getStockMarketClosedDescription } from './SwapStockTradeAlert.utils';
 
 type IStockTradeAlerts = {
   states: ISwapAlertState[];
@@ -111,19 +108,12 @@ function BasicSwapStockTradeAlert({
   stockChannel,
 }: ISwapStockTradeAlertProps) {
   const intl = useIntl();
-  const { perpsInfo } = useTokenDetail();
-  const { perpDisabled } = usePerpTabConfig();
-  const { navigateToPerps } = usePerpsNavigation(
-    EPerpPageEnterSource.MarketList,
-  );
   const [quoteEventError] = useSwapQuoteEventErrorAtom();
   const stockAlertShownKeysRef = useRef(new Set<string>());
   const stockQuoteAlert = useStockQuoteAlert({ quoteResult, stockChannel });
   const notAvailableInRegionMessage = intl.formatMessage({
     id: ETranslations.trade_stock_not_available_in_region,
   });
-  const perpsTicker = perpsInfo?.hlTicker;
-  const canOpenPerps = Boolean(perpsTicker && !perpDisabled);
 
   const isCurrentStockQuoteEventError = useMemo(
     () =>
@@ -173,29 +163,6 @@ function BasicSwapStockTradeAlert({
     notAvailableInRegionMessage,
     quoteEventError?.isStock,
     quoteEventError?.message,
-  ]);
-
-  const onOpenPerps = useCallback(() => {
-    if (!canOpenPerps || !perpsTicker) {
-      return;
-    }
-    defaultLogger.swap.stockTradeAlert.stockTradeAlertActionClick({
-      ...getStockTradeAlertAnalyticsPayload({
-        alertType: 'marketClosed',
-        alertLevel: ESwapAlertLevel.WARNING,
-        tradeDisabled: true,
-        tradeSide: stockChannel.tradeSide,
-        stockToken: stockChannel.currentStockToken,
-      }),
-      action: 'perps',
-    });
-    navigateToPerps(perpsTicker);
-  }, [
-    canOpenPerps,
-    navigateToPerps,
-    perpsTicker,
-    stockChannel.currentStockToken,
-    stockChannel.tradeSide,
   ]);
 
   const shouldShowSwapAlerts =
@@ -297,10 +264,9 @@ function BasicSwapStockTradeAlert({
   ]);
 
   if (isStockMarketClosed) {
-    const description = canOpenPerps
-      ? intl.formatMessage({ id: ETranslations.trade_stock_trade_in_perps })
-      : (stockChannel.stockMarketStatus?.reason ??
-        intl.formatMessage({ id: ETranslations.trade_stock_wait_for_reopen }));
+    const description =
+      getStockMarketClosedDescription(stockChannel.stockMarketStatus?.reason) ??
+      intl.formatMessage({ id: ETranslations.trade_stock_wait_for_reopen });
 
     return (
       <Alert
@@ -311,17 +277,6 @@ function BasicSwapStockTradeAlert({
           id: ETranslations.trade_stock_market_closed,
         })}
         description={description}
-        action={
-          canOpenPerps
-            ? {
-                primary: intl.formatMessage({
-                  id: ETranslations.global_perp,
-                }),
-                primaryVariant: 'secondary',
-                onPrimaryPress: onOpenPerps,
-              }
-            : undefined
-        }
       />
     );
   }

--- a/packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.utils.test.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.utils.test.ts
@@ -1,0 +1,27 @@
+import { getStockMarketClosedDescription } from './SwapStockTradeAlert.utils';
+
+describe('SwapStockTradeAlert utils', () => {
+  it('keeps only the reopen time from a closed-market description', () => {
+    expect(
+      getStockMarketClosedDescription(
+        '交易将在 1天 13 小时 16 分钟后开放\n\nOndo 的代币化证券支持 24/5 交易。',
+      ),
+    ).toBe('交易将在 1天 13 小时 16 分钟后开放');
+  });
+
+  it('trims empty lines before the reopen time', () => {
+    expect(
+      getStockMarketClosedDescription(
+        '\n\r\n  Market reopens in 1D 13H 16M\r\n\r\nOndo supports 24/5 trading.',
+      ),
+    ).toBe('Market reopens in 1D 13H 16M');
+  });
+
+  it('does not show the stock mechanism explanation as a fallback', () => {
+    expect(
+      getStockMarketClosedDescription(
+        "Ondo's tokenized securities support 24/5 trading.",
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.utils.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.utils.ts
@@ -1,0 +1,12 @@
+export function getStockMarketClosedDescription(reason?: string | null) {
+  const firstLine = reason
+    ?.split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+
+  if (!firstLine || /\bondo\b/i.test(firstLine)) {
+    return undefined;
+  }
+
+  return firstLine;
+}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56475](https://onekeyhq.atlassian.net/browse/OK-56475)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Refined the Trade Stock desktop market data tooltip, chart empty state, and default chart range behavior.
- Preserved the user-selected chart range across stock token switches while defaulting the initial desktop chart range to 1W.
- Simplified stock market-closed messaging, preserved buy/sell color semantics for disabled stock action buttons, and aligned the desktop stock tab header spacing with Swap/Limit.

## Intent & Context
This PR addresses a set of Trade Stock tab UX polish requests from desktop and mobile preview feedback:

- https://onekeyhq.atlassian.net/browse/OK-56475
- https://onekeyhq.atlassian.net/browse/OK-56477
- https://onekeyhq.atlassian.net/browse/OK-56478
- https://onekeyhq.atlassian.net/browse/OK-56473

The requested behavior was to reduce oversized stock metric tooltip text, make desktop stock charts less likely to show an empty 1D weekend chart by default, use a clearer chart empty state, keep a manually selected chart range when switching stock tokens, remove the Ondo mechanism explanation from the market-closed alert, keep disabled stock action buttons visually tied to buy/sell direction, and prevent the desktop top tab area from jumping when switching into Stocks.

## Root Cause
- The stock metric tooltip used the default tooltip content size, which was visually too large for short metric explanations.
- The desktop stock chart owned its range state inside the chart component and defaulted to 1D, so weekend market closures could render a poor empty chart and token switches reset the user's selected range.
- The chart empty state rendered only `--`, without matching existing market empty-state copy.
- The market-closed stock alert displayed the backend description wholesale, including the Ondo mechanism explanation, instead of only showing the market-closed state and reopening time.
- The disabled stock action button used the generic primary disabled style, which turned both buy and sell states gray.
- The desktop stock layout used a separate header slot spacing from Swap/Limit, causing the top segmented tab area to shift vertically when switching tabs.

## Design Decisions
- Kept chart range state at the stock market context panel level so the default is 1W only on initial entry, while user changes persist across selected stock tokens.
- Reused the existing market/TradingView no-recent-transactions translation key for the chart empty state instead of adding a new key.
- Preserved only the first non-empty line of the market-closed description so dynamic reopen timing is retained while the Ondo mechanism text is not shown.
- Used existing success/critical strong color tokens for disabled stock action buttons, with reduced opacity to communicate disabled state.
- Matched the desktop stock header slot spacing to the existing Swap/Limit desktop header slot spacing to stabilize the top tab area.

## Changes Detail
- `SwapStockDesktopContainer.tsx`: updates tooltip rendering, chart range ownership, chart empty state, disabled action button styling, and desktop stock header slot layout.
- `SwapStockDesktopContainer.utils.ts`: extracts chart range constants, stock disabled action button style selection, and the desktop header slot spacing contract.
- `SwapStockDesktopContainer.utils.test.ts`: covers the 1W default range, selectable 1M range, disabled buy/sell color styles, and desktop header slot spacing.
- `SwapStockTradeAlert.tsx`: removes the Perps CTA/description from the market-closed stock alert and uses a sanitized market-closed description.
- `SwapStockTradeAlert.utils.ts`: extracts market-closed description sanitization.
- `SwapStockTradeAlert.utils.test.ts`: covers reopen-time extraction and Ondo mechanism text filtering.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop, Mobile
- **Risk Areas**: Stock tab UI rendering only; no quote/build/send logic changed.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn jest packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.utils.test.ts --runInBand --no-cache --modulePathIgnorePatterns='<rootDir>/.worktrees' --modulePathIgnorePatterns='<rootDir>/.claude/worktrees'`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.tsx packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.utils.ts packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.utils.test.ts`
- [x] `git diff --cached --check`
- [ ] `yarn tsc:staged` is currently blocked by an existing unrelated error in `packages/components/src/composite/Tabs/TabsDraggableFlatList.tsx`, where `react-native-collapsible-tab-view` no longer exports several imported members.

[OK-56475]: https://onekeyhq.atlassian.net/browse/OK-56475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ