### PR TITLE
fix: review follow-ups for legacy keyless removal (#12113)

### DIFF
--- a/apps/cli/src/core/prime-transfer/e2ee-client-to-client-runtime.ts
+++ b/apps/cli/src/core/prime-transfer/e2ee-client-to-client-runtime.ts
@@ -281,6 +281,11 @@ function clearTransferData(transferData: unknown): void {
   transferData.privateData.credentials = undefined;
   transferData.privateData.decryptedCredentials = undefined;
   transferData.privateData.decryptedCredentialsHex = undefined;
+  // Defensive scrub for legacy senders that still ship deviceKeyPack in the
+  // JSON payload: the field was removed from the TS type but JSON.parse keeps
+  // it, so wipe it explicitly to preserve the previous secret-scrubbing behavior.
+  (transferData.privateData as { deviceKeyPack?: unknown }).deviceKeyPack =
+    undefined;
 }
 
 export function createE2EEClientToClientRuntime({

--- a/packages/kit/src/views/Prime/pages/PagePrimeTransfer/components/PrimeTransferDirection.tsx
+++ b/packages/kit/src/views/Prime/pages/PagePrimeTransfer/components/PrimeTransferDirection.tsx
@@ -162,14 +162,11 @@ export function PrimeTransferDirection({
   const [waitingAlertVisible, setWaitingAlertVisible] = useState(false);
   const [isSendingData, setIsSendingData] = useState(false);
 
-  // Reset self transfer type when this screen unmounts.
-  useEffect(() => {
-    return () => {
-      void backgroundApiProxy.servicePrimeTransfer.updateSelfTransferType({
-        transferType: undefined,
-      });
-    };
-  }, []);
+  // Self transfer type lifecycle is owned by the parent PagePrimeTransfer
+  // (set on mount, reset on page unmount). Intentionally NOT reset here: this
+  // screen unmounts on a paired -> init transition (e.g. disconnect), and a
+  // local reset would clear the parent-managed type without it being re-applied
+  // on re-pairing, leaving the peer with a missing transfer type.
 
   const getRoomUsers = useCallback(async () => {
     let result: IE2EESocketUserInfo[] = [];


### PR DESCRIPTION
Superseded — the two fix commits (`e842844c`, `8d58218e`) were pushed directly onto #12113's branch (`prague13/remove-legacy-keyless-3share`) at the author's request, so they now ride along with #12113 itself. Closing this stacked PR.