### PR TITLE
fix: improve stock trade selector UX(OK-56496, OK-56552, OK-56576)

### DIFF
--- a/packages/kit-bg/src/services/ServiceMarketV2.ts
+++ b/packages/kit-bg/src/services/ServiceMarketV2.ts
@@ -8,6 +8,7 @@ import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { getDefaultLocale } from '@onekeyhq/shared/src/locale/getDefaultLocale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { memoizee } from '@onekeyhq/shared/src/utils/cacheUtils';
 import { dedupeTokenSelectorFavoriteCoins } from '@onekeyhq/shared/src/utils/perpsTokenSelectorFavorites';
@@ -111,6 +112,16 @@ class ServiceMarketV2 extends ServiceBase {
         this._marketTokenBatchCache.delete(key);
       }
     }
+  }
+
+  private async _getMarketTokenBatchCacheLocale(requestLocale?: string) {
+    const localeFromRequest = requestLocale?.trim();
+    if (localeFromRequest) {
+      return localeFromRequest.toLowerCase();
+    }
+
+    const { locale } = await settingsPersistAtom.get();
+    return (locale === 'system' ? getDefaultLocale() : locale).toLowerCase();
   }
 
   private _normalizeMarketTokenListParams({
@@ -454,6 +465,7 @@ class ServiceMarketV2 extends ServiceBase {
   @backgroundMethod()
   async fetchMarketTokenListBatch({
     tokenAddressList,
+    requestLocale,
     skipCache = false,
   }: {
     tokenAddressList: {
@@ -461,19 +473,22 @@ class ServiceMarketV2 extends ServiceBase {
       chainId: string;
       isNative: boolean;
     }[];
+    requestLocale?: string;
     skipCache?: boolean;
   }) {
     // Clean expired cache entries periodically
     this._cleanExpiredMarketTokenBatchCache();
 
     const now = Date.now();
+    const cacheLocale =
+      await this._getMarketTokenBatchCacheLocale(requestLocale);
     const cachedResults: IMarketTokenListItem[] = [];
     const missingTokens: typeof tokenAddressList = [];
     const tokenIndexMap = new Map<string, number>();
 
     // Check cache for each token
     tokenAddressList.forEach((token, index) => {
-      const cacheKey = `${
+      const cacheKey = `${cacheLocale}:${
         token.chainId
       }:${token.contractAddress.toLowerCase()}`;
       tokenIndexMap.set(cacheKey, index);
@@ -509,7 +524,10 @@ class ServiceMarketV2 extends ServiceBase {
         currency: 'usd',
       },
       {
-        headers: { 'x-onekey-request-currency': 'usd' },
+        headers: {
+          'x-onekey-request-currency': 'usd',
+          'x-onekey-request-locale': cacheLocale,
+        },
       },
     );
 
@@ -533,7 +551,7 @@ class ServiceMarketV2 extends ServiceBase {
     data.list.forEach((item, apiIndex) => {
       const token = missingTokens[apiIndex];
       if (!token) return;
-      const cacheKey = `${
+      const cacheKey = `${cacheLocale}:${
         token.chainId
       }:${token.contractAddress.toLowerCase()}`;
       const originalIndex = tokenIndexMap.get(cacheKey);

--- a/packages/kit-bg/src/services/ServiceMarketV2.ts
+++ b/packages/kit-bg/src/services/ServiceMarketV2.ts
@@ -115,12 +115,12 @@ class ServiceMarketV2 extends ServiceBase {
   }
 
   private async _getMarketTokenBatchCacheLocale(requestLocale?: string) {
-    const localeFromRequest = requestLocale?.trim();
-    if (localeFromRequest) {
-      return localeFromRequest.toLowerCase();
+    let locale = requestLocale?.trim();
+    if (!locale) {
+      const settings = await settingsPersistAtom.get();
+      locale = settings.locale;
     }
 
-    const { locale } = await settingsPersistAtom.get();
     return (locale === 'system' ? getDefaultLocale() : locale).toLowerCase();
   }
 

--- a/packages/kit/src/components/TokenListItem/index.tsx
+++ b/packages/kit/src/components/TokenListItem/index.tsx
@@ -28,6 +28,7 @@ export type ITokenListItemProps = {
   disabled?: boolean;
   titleMatchStr?: IFuseResultMatch;
   moreComponent?: React.ReactNode;
+  tokenSymbolAccessory?: React.ReactNode;
   badgeText?: string;
   tokenSize?: 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 } & IListItemProps &
@@ -46,10 +47,33 @@ export function TokenListItem({
   disabled,
   titleMatchStr,
   moreComponent,
+  tokenSymbolAccessory,
   badgeText,
   tokenSize,
   ...rest
 }: ITokenListItemProps) {
+  const primaryContent =
+    badgeText || tokenSymbolAccessory ? (
+      <XStack alignItems="center" gap="$1" minWidth={0}>
+        <SizableText
+          size="$bodyLgMedium"
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          flexShrink={1}
+        >
+          {tokenSymbol}
+        </SizableText>
+        {badgeText ? (
+          <Badge badgeType="success" badgeSize="sm">
+            {badgeText}
+          </Badge>
+        ) : null}
+        {tokenSymbolAccessory}
+      </XStack>
+    ) : (
+      tokenSymbol
+    );
+
   return (
     <ListItem
       userSelect="none"
@@ -76,18 +100,7 @@ export function TokenListItem({
           opacity: 0.5,
         })}
         flex={1}
-        primary={
-          badgeText ? (
-            <XStack alignItems="center" gap="$2">
-              <SizableText size="$bodyLgMedium">{tokenSymbol}</SizableText>
-              <Badge badgeType="success" badgeSize="sm">
-                {badgeText}
-              </Badge>
-            </XStack>
-          ) : (
-            tokenSymbol
-          )
-        }
+        primary={primaryContent}
         primaryMatch={titleMatchStr}
         primaryTextProps={{
           numberOfLines: 1,

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -157,6 +157,28 @@ type IStockChartHoverData = {
   y: number;
 };
 
+function useOpenStockTokenSelector({
+  defaultNetworkId,
+  storeName,
+}: {
+  defaultNetworkId?: string;
+  storeName: EJotaiContextStoreNames;
+}) {
+  const navigation = useAppNavigation();
+  return useCallback(() => {
+    dismissKeyboard();
+    navigation.pushModal(EModalRoutes.SwapModal, {
+      screen: EModalSwapRoutes.SwapTokenSelect,
+      params: {
+        type: ESwapDirectionType.FROM,
+        storeName,
+        selectTarget: 'swapStock',
+        defaultNetworkId,
+      },
+    });
+  }, [defaultNetworkId, navigation, storeName]);
+}
+
 function normalizeStockChartData(points?: { t: number; c: number }[]) {
   const pointsByTime = new Map<number, number>();
   for (const point of points ?? []) {
@@ -692,9 +714,10 @@ function StockAmountInput({
   fetchLoading,
   onBalanceMaxPress,
   stockChannel,
+  storeName,
 }: Pick<
   ISwapStockDesktopContainerProps,
-  'fetchLoading' | 'onBalanceMaxPress'
+  'fetchLoading' | 'onBalanceMaxPress' | 'storeName'
 > & {
   stockChannel: IUseSwapStockChannelReturn;
 }) {
@@ -718,6 +741,14 @@ function StockAmountInput({
     selectPayToken,
     shouldRenderSkeleton,
   } = amountInputState;
+  const canOpenSellStockTokenSelector =
+    stockChannel.tradeSide === ESwapStockTradeSide.Sell && Boolean(inputToken);
+  const canOpenBuyPayTokenSelector =
+    isBuySide && selectablePayTokens.length > 1;
+  const handleOpenStockTokenSelector = useOpenStockTokenSelector({
+    defaultNetworkId: inputToken?.networkId,
+    storeName,
+  });
 
   if (shouldRenderSkeleton) {
     return <StockAmountInputSkeleton isBuySide={isBuySide} />;
@@ -763,7 +794,11 @@ function StockAmountInput({
           selectedNetworkImageUri: inputTokenNetworkLogoURI,
           selectedTokenSymbol: inputToken?.symbol,
           showNetworkIconBorder: false,
-          disabled: !isBuySide || selectablePayTokens.length <= 1,
+          disabled:
+            !canOpenBuyPayTokenSelector && !canOpenSellStockTokenSelector,
+          onPress: canOpenSellStockTokenSelector
+            ? handleOpenStockTokenSelector
+            : undefined,
           popover:
             isBuySide && payTokens.length > 1
               ? {
@@ -789,6 +824,7 @@ function StockAmountInput({
 
 function StockTradeTicket({
   fetchLoading,
+  storeName,
   onSelectPercentageStage,
   onBalanceMaxPress,
   onPreSwap,
@@ -805,7 +841,10 @@ function StockTradeTicket({
   compact,
 }: Omit<
   ISwapStockDesktopContainerProps,
-  'headerContent' | 'marketPresetToken' | 'storeName' | 'supportNetworksList'
+  | 'headerContent'
+  | 'marketPresetToken'
+  | 'onSelectToken'
+  | 'supportNetworksList'
 > & {
   stockChannel: IUseSwapStockChannelReturn;
   tradeSide: ESwapStockTradeSide;
@@ -819,6 +858,7 @@ function StockTradeTicket({
         fetchLoading={fetchLoading}
         onBalanceMaxPress={onBalanceMaxPress}
         stockChannel={stockChannel}
+        storeName={storeName}
       />
       <StockEstimatedReceive
         quoteResult={quoteResult}
@@ -874,25 +914,16 @@ function StockMarketTokenHeader({
   storeName: EJotaiContextStoreNames;
 }) {
   const { tokenDetail, networkId } = useTokenDetail();
-  const navigation = useAppNavigation();
   const stockTokenNetworkId = tokenDetail?.networkId ?? networkId;
   const effectiveNetworkLogoUri = useNetworkLogoUri({
     logoUri: undefined,
     networkId: stockTokenNetworkId,
   });
   const stock = tokenDetail?.stock;
-  const handleOpenStockTokenSelector = useCallback(() => {
-    dismissKeyboard();
-    navigation.pushModal(EModalRoutes.SwapModal, {
-      screen: EModalSwapRoutes.SwapTokenSelect,
-      params: {
-        type: ESwapDirectionType.FROM,
-        storeName,
-        selectTarget: 'swapStock',
-        defaultNetworkId: stockTokenNetworkId,
-      },
-    });
-  }, [navigation, stockTokenNetworkId, storeName]);
+  const handleOpenStockTokenSelector = useOpenStockTokenSelector({
+    defaultNetworkId: stockTokenNetworkId,
+    storeName,
+  });
 
   if (!tokenDetail) {
     return <StockMarketHeaderSkeleton />;
@@ -906,20 +937,20 @@ function StockMarketTokenHeader({
       h="$13"
       w="100%"
       gap="$3"
+      cursor="pointer"
+      borderRadius="$full"
+      hoverStyle={{ bg: '$bgHover' }}
+      pressStyle={{ bg: '$bgActive' }}
+      onPress={handleOpenStockTokenSelector}
     >
       <XStack
         flex={1}
         minWidth={0}
         gap="$2.5"
         alignItems="center"
-        cursor="pointer"
         bg="$transparent"
         px="$0"
         py="$0"
-        borderRadius="$full"
-        hoverStyle={{ bg: '$bgHover' }}
-        pressStyle={{ bg: '$bgActive' }}
-        onPress={handleOpenStockTokenSelector}
       >
         <Token
           size="md"
@@ -991,14 +1022,12 @@ function StockPriceChart({
   onRangeChange,
   range,
   tokenAddress,
-  tokenSymbol,
 }: {
   isNative?: boolean;
   networkId?: string;
   onRangeChange: (range: IStockChartRange) => void;
   range: IStockChartRange;
   tokenAddress?: string;
-  tokenSymbol?: string;
 }) {
   const intl = useIntl();
   const theme = useTheme();
@@ -1021,12 +1050,6 @@ function StockPriceChart({
     },
     [onRangeChange],
   );
-  const chartTitle = useMemo(() => {
-    const chartLabel = intl.formatMessage({
-      id: ETranslations.market_chart,
-    });
-    return tokenSymbol ? `${tokenSymbol} ${chartLabel}` : chartLabel;
-  }, [intl, tokenSymbol]);
   const activeRange = useMemo(
     () => STOCK_CHART_RANGE_ITEMS.find((item) => item.label === range),
     [range],
@@ -1232,18 +1255,9 @@ function StockPriceChart({
         pl="$5"
         pr={30}
         alignItems="center"
-        justifyContent="space-between"
+        justifyContent="flex-end"
         gap="$3"
       >
-        <SizableText
-          size="$bodyLgMedium"
-          color="$text"
-          numberOfLines={1}
-          w={180}
-          flexShrink={1}
-        >
-          {chartTitle}
-        </SizableText>
         <SegmentControl
           w={156}
           h="$5"
@@ -1384,7 +1398,6 @@ function StockMarketContextPanel({
             isNative={isNative}
             range={range}
             onRangeChange={setRange}
-            tokenSymbol={tokenDetail?.symbol}
           />
         ) : (
           <Skeleton w="100%" h={274} />
@@ -1400,7 +1413,6 @@ function StockMarketContextPanel({
 function SwapStockDesktopContent({
   headerContent,
   storeName,
-  onSelectToken,
   fetchLoading,
   onSelectPercentageStage,
   onBalanceMaxPress,
@@ -1544,7 +1556,7 @@ function SwapStockDesktopContent({
                 )}
               </XStack>
               <StockTradeTicket
-                onSelectToken={onSelectToken}
+                storeName={storeName}
                 fetchLoading={fetchLoading}
                 onSelectPercentageStage={onSelectPercentageStage}
                 onBalanceMaxPress={onBalanceMaxPress}
@@ -1625,7 +1637,7 @@ function SwapStockMobileContent(props: ISwapStockDesktopContainerProps) {
       >
         <StockMarketTokenHeader storeName={props.storeName} />
         <StockTradeTicket
-          onSelectToken={props.onSelectToken}
+          storeName={props.storeName}
           fetchLoading={props.fetchLoading}
           onSelectPercentageStage={props.onSelectPercentageStage}
           onBalanceMaxPress={props.onBalanceMaxPress}

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
@@ -476,7 +476,7 @@ const SwapTokenSelectPage = ({
         response.list.forEach((token, index) => {
           const requestKey =
             stockMetadataRequest.tokenAddressEntries[index]?.[0];
-          if (requestKey && token.stock) {
+          if (requestKey && token?.stock) {
             metadataMap[requestKey] = token.stock;
           }
         });

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
@@ -30,6 +30,7 @@ import { TokenListItem } from '@onekeyhq/kit/src/components/TokenListItem';
 import { TokenSelectorLpTokenSwitch } from '@onekeyhq/kit/src/components/TokenSelectorFilter';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useAccountSelectorActions } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import {
   useSwapActions,
@@ -40,6 +41,7 @@ import {
   useSwapSelectTokenNetworkAtom,
   useSwapTypeSwitchAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
+import { StockSourceLogo } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
 import {
   useSettingsPersistAtom,
   useTokenSelectorFilterPersistAtom,
@@ -62,6 +64,7 @@ import {
 } from '@onekeyhq/shared/src/utils/tokenSelectorFilterUtils';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
+import type { IMarketStockInfo } from '@onekeyhq/shared/types/marketV2';
 import {
   swapNetworksCommonCount,
   swapNetworksCommonCountMD,
@@ -90,12 +93,26 @@ import {
 import { SwapProviderMirror } from '../SwapProviderMirror';
 
 import {
+  buildSwapStockMetadataKey,
   buildSwapTokenSelectorDisableNetworks,
+  getSwapStockTokenDisplayName,
+  isSwapStockMetadataPending,
   isSwapTokenSelectorFromNetworkBridgeOnly,
 } from './SwapTokenSelectModal.utils';
 
 import type { RouteProp } from '@react-navigation/core';
 import type { FlatList } from 'react-native';
+
+type ISwapTokenWithStock = ISwapToken & {
+  stock?: IMarketStockInfo;
+};
+
+const getRawSwapToken = (item: ISwapToken | IFuseResult<ISwapToken>) =>
+  (item as IFuseResult<ISwapToken>).item
+    ? (item as IFuseResult<ISwapToken>).item
+    : (item as ISwapToken);
+
+const EMPTY_SWAP_TOKEN_LIST: (ISwapToken | IFuseResult<ISwapToken>)[] = [];
 
 const SwapTokenSelectPage = ({
   autoSearch = false,
@@ -377,15 +394,109 @@ const SwapTokenSelectPage = ({
     searchAnalyticsOverride,
     swapNetworksIncludeAllNetwork,
   );
+  const stockMetadataTokenKey = useMemo(() => {
+    if (!isSwapStockSelectTarget) {
+      return '';
+    }
+    return currentTokens
+      .map((item) => {
+        const rawItem = getRawSwapToken(item);
+        return buildSwapStockMetadataKey({
+          contractAddress: rawItem.contractAddress,
+          networkId: rawItem.networkId,
+        });
+      })
+      .filter(Boolean)
+      .join(',');
+  }, [currentTokens, isSwapStockSelectTarget]);
+  const { result: stockMetadataResult, isLoading: stockMetadataLoading } =
+    usePromiseResult(
+      async () => {
+        if (!isSwapStockSelectTarget || !stockMetadataTokenKey) {
+          return {
+            metadataMap: {},
+            tokenKey: stockMetadataTokenKey,
+          };
+        }
+        const tokenAddressMap = new Map<
+          string,
+          {
+            contractAddress: string;
+            chainId: string;
+            isNative: boolean;
+          }
+        >();
+        for (const item of currentTokens) {
+          const rawItem = getRawSwapToken(item);
+          const key = buildSwapStockMetadataKey({
+            contractAddress: rawItem.contractAddress,
+            networkId: rawItem.networkId,
+          });
+          if (key && !tokenAddressMap.has(key)) {
+            tokenAddressMap.set(key, {
+              chainId: rawItem.networkId,
+              contractAddress: rawItem.contractAddress,
+              isNative: rawItem.isNative ?? false,
+            });
+          }
+        }
+        const tokenAddressEntries = Array.from(tokenAddressMap.entries());
+        const response = await (async () => {
+          try {
+            return await backgroundApiProxy.serviceMarketV2.fetchMarketTokenListBatch(
+              {
+                requestLocale: intl.locale,
+                tokenAddressList: tokenAddressEntries.map(([, token]) => token),
+              },
+            );
+          } catch {
+            return { list: [] };
+          }
+        })();
+        const metadataMap: Record<string, IMarketStockInfo> = {};
+        response.list.forEach((token, index) => {
+          const requestKey = tokenAddressEntries[index]?.[0];
+          if (requestKey && token.stock) {
+            metadataMap[requestKey] = token.stock;
+          }
+        });
+        return {
+          metadataMap,
+          tokenKey: stockMetadataTokenKey,
+        };
+      },
+      [
+        currentTokens,
+        intl.locale,
+        isSwapStockSelectTarget,
+        stockMetadataTokenKey,
+      ],
+      {
+        initResult: {
+          metadataMap: {},
+          tokenKey: '',
+        },
+        watchLoading: isSwapStockSelectTarget,
+      },
+    );
+  const stockMetadataMap = stockMetadataResult.metadataMap;
+  const stockMetadataPending = isSwapStockMetadataPending({
+    isSwapStockSelectTarget,
+    resolvedStockMetadataTokenKey: stockMetadataResult.tokenKey,
+    stockMetadataLoading,
+    stockMetadataTokenKey,
+  });
+  const displayTokens = stockMetadataPending
+    ? EMPTY_SWAP_TOKEN_LIST
+    : currentTokens;
+  const tokenListLoading = fetchLoading || stockMetadataPending;
   const alertIndex = useMemo(
     () =>
-      currentTokens.findIndex((item) => {
-        const rawItem = (item as IFuseResult<ISwapToken>).item
-          ? (item as IFuseResult<ISwapToken>).item
-          : (item as ISwapToken);
+      displayTokens.findIndex((item) => {
+        const rawItem = getRawSwapToken(item);
         return !rawItem.price || new BigNumber(rawItem.price).isZero();
       }),
-    [currentTokens],
+    [displayTokens],
   );
 
   const checkRiskToken = useCallback(
@@ -532,9 +643,20 @@ const SwapTokenSelectPage = ({
       item: ISwapToken | IFuseResult<ISwapToken>;
       index: number;
     }) => {
-      const rawItem = (item as IFuseResult<ISwapToken>).item
-        ? (item as IFuseResult<ISwapToken>).item
-        : (item as ISwapToken);
+      const rawItem = getRawSwapToken(item);
+      const stock =
+        isSwapStockSelectTarget && rawItem.contractAddress
+          ? ((rawItem as ISwapTokenWithStock).stock ??
+            stockMetadataMap?.[
+              buildSwapStockMetadataKey({
+                contractAddress: rawItem.contractAddress,
+                networkId: rawItem.networkId,
+              })
+            ])
+          : undefined;
+      const displayItem: ISwapTokenWithStock = stock
+        ? { ...rawItem, stock }
+        : rawItem;
       const balanceBN = new BigNumber(rawItem.balanceParsed ?? 0);
       const fiatValueBN = new BigNumber(rawItem.fiatValue ?? 0);
       const contractAddressDisplay = md
@@ -566,14 +688,24 @@ const SwapTokenSelectPage = ({
       }
 
       const tokenItem: ITokenListItemProps = {
-        isSearch: !!requestedSearchKeyword,
+        isSearch: isSwapStockSelectTarget ? false : !!requestedSearchKeyword,
         tokenImageSrc: rawItem.logoURI,
-        tokenName: rawItem.name,
+        tokenName: isSwapStockSelectTarget
+          ? getSwapStockTokenDisplayName({
+              stock,
+              tokenName: rawItem.name,
+            })
+          : rawItem.name,
         tokenSymbol: rawItem.symbol,
         networkImageSrc: rawItem.networkLogoURI,
-        tokenContrastAddress: requestedSearchKeyword
-          ? contractAddressDisplay
-          : undefined,
+        tokenSymbolAccessory:
+          isSwapStockSelectTarget && stock?.sourceLogoUri ? (
+            <StockSourceLogo stock={stock} />
+          ) : undefined,
+        tokenContrastAddress:
+          requestedSearchKeyword && !isSwapStockSelectTarget
+            ? contractAddressDisplay
+            : undefined,
         balance: !balanceBN.isZero() ? rawItem.balanceParsed : undefined,
         valueProps:
           rawItem.fiatValue && !fiatValueBN.isZero()
@@ -583,7 +715,7 @@ const SwapTokenSelectPage = ({
               }
             : undefined,
         onPress: !disableNetworks.includes(rawItem.networkId)
-          ? () => onSelectToken(rawItem)
+          ? () => onSelectToken(displayItem)
           : () => disableNetworksOnClick(),
         disabled: disableNetworks.includes(rawItem.networkId),
         titleMatchStr: (item as IFuseResult<ISwapToken>).matches?.find(
@@ -665,6 +797,8 @@ const SwapTokenSelectPage = ({
       onSelectToken,
       requestedSearchKeyword,
       settingsPersistAtom.currencyInfo.symbol,
+      isSwapStockSelectTarget,
+      stockMetadataMap,
       type,
     ],
   );
@@ -829,7 +963,7 @@ const SwapTokenSelectPage = ({
           <ListView
             useFlashList={platformEnv.isNative}
             ref={listViewRef}
-            data={currentTokens}
+            data={displayTokens}
             renderItem={renderItem}
             estimatedItemSize={60}
             ListHeaderComponent={
@@ -849,7 +983,7 @@ const SwapTokenSelectPage = ({
             }
             ListFooterComponent={<Stack h={bottom || '$2'} />}
             ListEmptyComponent={
-              fetchLoading ? (
+              tokenListLoading ? (
                 <>
                   {Array.from({ length: 5 }).map((_, index) => (
                     <ListItem key={String(index)}>

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
@@ -107,6 +107,18 @@ type ISwapTokenWithStock = ISwapToken & {
   stock?: IMarketStockInfo;
 };
 
+type IStockMetadataRequest = {
+  tokenAddressEntries: [
+    string,
+    {
+      contractAddress: string;
+      chainId: string;
+      isNative: boolean;
+    },
+  ][];
+  tokenKey: string;
+};
+
 const getRawSwapToken = (item: ISwapToken | IFuseResult<ISwapToken>) =>
   (item as IFuseResult<ISwapToken>).item
     ? (item as IFuseResult<ISwapToken>).item
@@ -394,21 +406,49 @@ const SwapTokenSelectPage = ({
     searchAnalyticsOverride,
     swapNetworksIncludeAllNetwork,
   );
-  const stockMetadataTokenKey = useMemo(() => {
+  const stockMetadataRequestSnapshot = useMemo<IStockMetadataRequest>(() => {
     if (!isSwapStockSelectTarget) {
-      return '';
+      return { tokenAddressEntries: [], tokenKey: '' };
     }
-    return currentTokens
-      .map((item) => {
-        const rawItem = getRawSwapToken(item);
-        return buildSwapStockMetadataKey({
+    const tokenAddressMap = new Map<
+      string,
+      {
+        contractAddress: string;
+        chainId: string;
+        isNative: boolean;
+      }
+    >();
+    for (const item of currentTokens) {
+      const rawItem = getRawSwapToken(item);
+      const key = buildSwapStockMetadataKey({
+        contractAddress: rawItem.contractAddress,
+        networkId: rawItem.networkId,
+      });
+      if (key && !tokenAddressMap.has(key)) {
+        tokenAddressMap.set(key, {
+          chainId: rawItem.networkId,
           contractAddress: rawItem.contractAddress,
-          networkId: rawItem.networkId,
+          isNative: rawItem.isNative ?? false,
         });
-      })
-      .filter(Boolean)
-      .join(',');
+      }
+    }
+    const tokenAddressEntries = Array.from(tokenAddressMap.entries());
+    return {
+      tokenAddressEntries,
+      tokenKey: tokenAddressEntries.map(([key]) => key).join(','),
+    };
   }, [currentTokens, isSwapStockSelectTarget]);
+  const stockMetadataRequestRef = useRef<IStockMetadataRequest>(
+    stockMetadataRequestSnapshot,
+  );
+  if (
+    stockMetadataRequestRef.current.tokenKey !==
+    stockMetadataRequestSnapshot.tokenKey
+  ) {
+    stockMetadataRequestRef.current = stockMetadataRequestSnapshot;
+  }
+  const stockMetadataRequest = stockMetadataRequestRef.current;
+  const stockMetadataTokenKey = stockMetadataRequest.tokenKey;
   const { result: stockMetadataResult, isLoading: stockMetadataLoading } =
     usePromiseResult(
       async () => {
@@ -418,35 +458,14 @@ const SwapTokenSelectPage = ({
             tokenKey: stockMetadataTokenKey,
           };
         }
-        const tokenAddressMap = new Map<
-          string,
-          {
-            contractAddress: string;
-            chainId: string;
-            isNative: boolean;
-          }
-        >();
-        for (const item of currentTokens) {
-          const rawItem = getRawSwapToken(item);
-          const key = buildSwapStockMetadataKey({
-            contractAddress: rawItem.contractAddress,
-            networkId: rawItem.networkId,
-          });
-          if (key && !tokenAddressMap.has(key)) {
-            tokenAddressMap.set(key, {
-              chainId: rawItem.networkId,
-              contractAddress: rawItem.contractAddress,
-              isNative: rawItem.isNative ?? false,
-            });
-          }
-        }
-        const tokenAddressEntries = Array.from(tokenAddressMap.entries());
         const response = await (async () => {
           try {
             return await backgroundApiProxy.serviceMarketV2.fetchMarketTokenListBatch(
               {
-                requestLocale: intl.locale,
-                tokenAddressList: tokenAddressEntries.map(([, token]) => token),
+                requestLocale: settingsPersistAtom.locale,
+                tokenAddressList: stockMetadataRequest.tokenAddressEntries.map(
+                  ([, token]) => token,
+                ),
               },
             );
           } catch {
@@ -455,7 +474,8 @@ const SwapTokenSelectPage = ({
         })();
         const metadataMap: Record<string, IMarketStockInfo> = {};
         response.list.forEach((token, index) => {
-          const requestKey = tokenAddressEntries[index]?.[0];
+          const requestKey =
+            stockMetadataRequest.tokenAddressEntries[index]?.[0];
           if (requestKey && token.stock) {
             metadataMap[requestKey] = token.stock;
           }
@@ -466,9 +486,9 @@ const SwapTokenSelectPage = ({
         };
       },
       [
-        currentTokens,
-        intl.locale,
         isSwapStockSelectTarget,
+        settingsPersistAtom.locale,
+        stockMetadataRequest,
         stockMetadataTokenKey,
       ],
       {

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.utils.test.ts
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.utils.test.ts
@@ -7,6 +7,8 @@ import {
 
 import {
   buildSwapTokenSelectorDisableNetworks,
+  getSwapStockTokenDisplayName,
+  isSwapStockMetadataPending,
   isSwapTokenSelectorFromNetworkBridgeOnly,
 } from './SwapTokenSelectModal.utils';
 
@@ -79,5 +81,49 @@ describe('SwapTokenSelectModal.utils', () => {
         swapNetworksIncludeAllNetwork,
       }),
     ).toEqual(['onekeyall--0', 'evm--137']);
+  });
+
+  it('keeps stock token rows pending until matching metadata is ready', () => {
+    expect(
+      isSwapStockMetadataPending({
+        isSwapStockSelectTarget: true,
+        stockMetadataTokenKey: 'evm--56:0x123',
+        stockMetadataLoading: false,
+        resolvedStockMetadataTokenKey: '',
+      }),
+    ).toBe(true);
+
+    expect(
+      isSwapStockMetadataPending({
+        isSwapStockSelectTarget: true,
+        stockMetadataTokenKey: 'evm--56:0x123',
+        stockMetadataLoading: true,
+        resolvedStockMetadataTokenKey: 'evm--56:0x123',
+      }),
+    ).toBe(true);
+
+    expect(
+      isSwapStockMetadataPending({
+        isSwapStockSelectTarget: true,
+        stockMetadataTokenKey: 'evm--56:0x123',
+        stockMetadataLoading: false,
+        resolvedStockMetadataTokenKey: 'evm--56:0x123',
+      }),
+    ).toBe(false);
+  });
+
+  it('uses stock subtitle before token source suffix fallback', () => {
+    expect(
+      getSwapStockTokenDisplayName({
+        stock: { subtitle: '罗宾汉' },
+        tokenName: 'Robinhood (Ondo Tokenized)',
+      }),
+    ).toBe('罗宾汉');
+
+    expect(
+      getSwapStockTokenDisplayName({
+        tokenName: 'Robinhood (Ondo Tokenized)',
+      }),
+    ).toBe('Robinhood');
   });
 });

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.utils.ts
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.utils.ts
@@ -1,9 +1,60 @@
+import type { IMarketStockInfo } from '@onekeyhq/shared/types/marketV2';
 import {
   ESwapDirectionType,
   ESwapTabSwitchType,
   type ISwapNetwork,
   type ISwapToken,
 } from '@onekeyhq/shared/types/swap/types';
+
+export const TOKENIZED_STOCK_SOURCE_NAME_PATTERN = /\s*\(Ondo Tokenized\)\s*$/i;
+
+export function buildSwapStockMetadataKey({
+  contractAddress,
+  networkId,
+}: {
+  contractAddress?: string;
+  networkId?: string;
+}) {
+  if (!contractAddress || !networkId) {
+    return '';
+  }
+  return `${networkId}:${contractAddress.toLowerCase()}`;
+}
+
+export function getSwapStockTokenDisplayName({
+  stock,
+  tokenName,
+}: {
+  stock?: Pick<IMarketStockInfo, 'subtitle'>;
+  tokenName?: string;
+}) {
+  const stockSubtitle = stock?.subtitle?.trim();
+  if (stockSubtitle) {
+    return stockSubtitle;
+  }
+  return (
+    tokenName?.replace(TOKENIZED_STOCK_SOURCE_NAME_PATTERN, '') ?? tokenName
+  );
+}
+
+export function isSwapStockMetadataPending({
+  isSwapStockSelectTarget,
+  resolvedStockMetadataTokenKey,
+  stockMetadataLoading,
+  stockMetadataTokenKey,
+}: {
+  isSwapStockSelectTarget: boolean;
+  resolvedStockMetadataTokenKey?: string;
+  stockMetadataLoading?: boolean;
+  stockMetadataTokenKey?: string;
+}) {
+  return Boolean(
+    isSwapStockSelectTarget &&
+    stockMetadataTokenKey &&
+    (stockMetadataLoading ||
+      resolvedStockMetadataTokenKey !== stockMetadataTokenKey),
+  );
+}
 
 export function isSwapNetworkBridgeOnly(
   network?: Pick<ISwapNetwork, 'supportCrossChainSwap' | 'supportSingleSwap'>,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56496](https://onekeyhq.atlassian.net/browse/OK-56496) [OK-56552](https://onekeyhq.atlassian.net/browse/OK-56552) [OK-56576](https://onekeyhq.atlassian.net/browse/OK-56576)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Remove the redundant stock chart title and keep the range selector aligned with the chart.
- Update the stock token selector rows to show issuer/source logos and localized stock labels while preserving the right-side token menu.
- Make the sell-side stock token trigger clickable and open the same stock token selector as the chart/header trigger.

## Intent & Context
This PR addresses three stock trading UX issues reported from desktop and mobile preview:

- OK-56496: the chart title duplicated the selected token context and should be removed.
- OK-56552: stock selector rows should display issuer/source identity and localized company labels without showing contract-address copy affordances in the row.
- OK-56576: when selling a stock token, the selected stock token area should behave like the buy-side token trigger and open the stock selector.

## Root Cause
The stock trading UI had several one-off presentation paths:

- The chart kept its own title even though the selected stock header already provided token context.
- The stock selector used generic swap token row data, so localized stock metadata could arrive after the base token list and cause an English-to-localized label flicker.
- The sell-side amount token trigger did not route to the stock selector, so the dropdown affordance did not match the expected interaction.

## Design Decisions
- Keep the stock selector opening path on the standard `navigation.pushModal(EModalRoutes.SwapModal, ...)` flow so desktop and mobile modal behavior matches the rest of Swap.
- Fetch localized stock metadata in batch for the visible selector rows and hold the list in a loading state until matching metadata is ready, preventing the English-to-localized label flash.
- Extend `TokenListItem` with an optional symbol accessory slot instead of creating a separate stock-only list row.
- Keep the selector row action menu available and hide only the inline contract-address display for the stock selector search case.

## Changes Detail
- `SwapStockDesktopContainer.tsx`: removes the chart title, opens the stock selector from both stock header and sell-side token trigger, and keeps the standard Swap modal navigation path.
- `SwapTokenSelectModal.tsx`: enriches stock selector rows with localized stock metadata, source logo accessory, stable loading behavior, and stock-specific row display rules.
- `SwapTokenSelectModal.utils.ts`: adds small pure helpers for stock metadata keys, display labels, and pending-state calculation.
- `TokenListItem/index.tsx`: adds an optional `tokenSymbolAccessory` slot used by the stock source logo.
- `ServiceMarketV2.ts`: keys token batch cache by locale and sends the locale header for localized stock metadata.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web
- **Risk Areas**: stock selector loading timing, localized metadata cache keys, and modal navigation from the stock trading surface.

## Related Issue
- [OK-56496](https://onekeyhq.atlassian.net/browse/OK-56496)
- [OK-56552](https://onekeyhq.atlassian.net/browse/OK-56552)
- [OK-56576](https://onekeyhq.atlassian.net/browse/OK-56576)

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `npx oxlint --deny-warnings packages/kit-bg/src/services/ServiceMarketV2.ts packages/kit/src/components/TokenListItem/index.tsx packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.utils.test.ts packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.utils.ts`
- [x] `npx tsgo -p ./tsconfig.json --noEmit --pretty false`
- [x] `yarn jest packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.utils.test.ts --runInBand --modulePathIgnorePatterns='<rootDir>/.worktrees' --testPathIgnorePatterns='<rootDir>/.worktrees'`
- [x] Desktop manual check: stock header trigger and sell-side token trigger open the stock token selector.


[OK-56496]: https://onekeyhq.atlassian.net/browse/OK-56496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OK-56552]: https://onekeyhq.atlassian.net/browse/OK-56552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-56576]: https://onekeyhq.atlassian.net/browse/OK-56576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ