### PR TITLE
fix: quarantine failed IP Table endpoints(OK-56653)

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityIpTable.test.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityIpTable.test.ts
@@ -1,0 +1,107 @@
+import { DEFAULT_IP_TABLE_CONFIG } from '@onekeyhq/shared/src/request/constants/ipTableDefaults';
+import { clearSelectedIpForHostCache } from '@onekeyhq/shared/src/request/helpers/ipTableAdapter';
+
+import { SimpleDbEntityIpTable } from './SimpleDbEntityIpTable';
+
+import type { ISimpleDbIpTableData } from './SimpleDbEntityIpTable';
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundMethod:
+    () =>
+    (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+}));
+
+jest.mock('@onekeyhq/shared/src/request/helpers/ipTableAdapter', () => ({
+  clearSelectedIpForHostCache: jest.fn(),
+}));
+
+const clearSelectedIpForHostCacheMock =
+  clearSelectedIpForHostCache as jest.Mock;
+
+describe('SimpleDbEntityIpTable.markIpQuarantined', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('stores the failed IP quarantine and prunes expired entries', async () => {
+    const entity = new SimpleDbEntityIpTable();
+    const setRawData = jest
+      .spyOn(entity, 'setRawData')
+      .mockResolvedValue({} as ISimpleDbIpTableData);
+    const timestamp = 1_800_000_000_000;
+
+    await entity.markIpQuarantined('onekeycn.com', '216.19.4.106', {
+      hostname: 'utility.onekeycn.com',
+      error: 'Request timeout',
+      timestamp,
+    });
+
+    expect(setRawData).toHaveBeenCalledWith(expect.any(Function));
+
+    const updater = setRawData.mock.calls[0]?.[0];
+    expect(typeof updater).toBe('function');
+
+    const nextData = (
+      updater as (data: ISimpleDbIpTableData) => ISimpleDbIpTableData
+    )({
+      config: DEFAULT_IP_TABLE_CONFIG,
+      currentRegion: 'CN',
+      runtime: {
+        enabled: true,
+        lastUpdated: 123,
+        lastRegionCheck: 456,
+        selections: {
+          'onekeycn.com': '216.19.4.106',
+        },
+        quarantinedIps: {
+          'onekeycn.com': {
+            '104.18.20.233': {
+              lastFailureTime: timestamp - 1000,
+              hostname: 'wallet.onekeycn.com',
+              error: 'Temporary failure',
+            },
+            '104.18.21.233': {
+              lastFailureTime: timestamp - 31 * 60 * 1000,
+              hostname: 'utility.onekeycn.com',
+              error: 'Expired failure',
+            },
+          },
+        },
+      },
+      version: 1,
+    });
+
+    expect(nextData).toMatchObject({
+      config: DEFAULT_IP_TABLE_CONFIG,
+      currentRegion: 'CN',
+      runtime: {
+        enabled: true,
+        lastUpdated: 123,
+        lastRegionCheck: 456,
+        selections: {
+          'onekeycn.com': '216.19.4.106',
+        },
+        quarantinedIps: {
+          'onekeycn.com': {
+            '104.18.20.233': {
+              lastFailureTime: timestamp - 1000,
+              hostname: 'wallet.onekeycn.com',
+              error: 'Temporary failure',
+            },
+            '216.19.4.106': {
+              lastFailureTime: timestamp,
+              hostname: 'utility.onekeycn.com',
+              error: 'Request timeout',
+            },
+          },
+        },
+      },
+      version: 1,
+    });
+    expect(
+      nextData.runtime?.quarantinedIps?.['onekeycn.com']?.['104.18.21.233'],
+    ).toBeUndefined();
+    expect(clearSelectedIpForHostCacheMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityIpTable.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityIpTable.ts
@@ -1,5 +1,9 @@
 import { backgroundMethod } from '@onekeyhq/shared/src/background/backgroundDecorators';
-import { DEFAULT_IP_TABLE_CONFIG } from '@onekeyhq/shared/src/request/constants/ipTableDefaults';
+import {
+  DEFAULT_IP_TABLE_CONFIG,
+  IP_TABLE_SNI_FAILURE_QUARANTINE_MS,
+} from '@onekeyhq/shared/src/request/constants/ipTableDefaults';
+import { clearSelectedIpForHostCache } from '@onekeyhq/shared/src/request/helpers/ipTableAdapter';
 import type {
   IIpTableConfigWithRuntime,
   IIpTableRemoteConfig,
@@ -43,6 +47,7 @@ export class SimpleDbEntityIpTable extends SimpleDbEntityBase<ISimpleDbIpTableDa
       ...data,
       version: 1,
     }));
+    clearSelectedIpForHostCache();
   }
 
   /**
@@ -74,6 +79,7 @@ export class SimpleDbEntityIpTable extends SimpleDbEntityBase<ISimpleDbIpTableDa
         lastUpdated: Date.now(),
       },
     }));
+    clearSelectedIpForHostCache();
   }
 
   /**
@@ -103,6 +109,58 @@ export class SimpleDbEntityIpTable extends SimpleDbEntityBase<ISimpleDbIpTableDa
         version: data?.version ?? 1,
       };
     });
+    clearSelectedIpForHostCache();
+  }
+
+  @backgroundMethod()
+  async markIpQuarantined(
+    domain: string,
+    ip: string,
+    params?: {
+      hostname?: string;
+      error?: string;
+      timestamp?: number;
+    },
+  ): Promise<void> {
+    const timestamp = params?.timestamp ?? Date.now();
+    await this.setRawData((data) => {
+      const runtime = data?.runtime ?? {
+        enabled: true,
+        lastUpdated: 0,
+        lastRegionCheck: 0,
+        selections: {},
+      };
+      const domainQuarantines = runtime.quarantinedIps?.[domain] ?? {};
+      const activeDomainQuarantines = Object.fromEntries(
+        Object.entries(domainQuarantines).filter(
+          ([, quarantine]) =>
+            timestamp - quarantine.lastFailureTime <
+            IP_TABLE_SNI_FAILURE_QUARANTINE_MS,
+        ),
+      );
+
+      return {
+        ...data,
+        config: data?.config ?? null,
+        currentRegion: data?.currentRegion ?? 'AUTO',
+        runtime: {
+          ...runtime,
+          quarantinedIps: {
+            ...runtime.quarantinedIps,
+            [domain]: {
+              ...activeDomainQuarantines,
+              [ip]: {
+                lastFailureTime: timestamp,
+                hostname: params?.hostname,
+                error: params?.error,
+              },
+            },
+          },
+        },
+        version: data?.version ?? 1,
+      };
+    });
+    clearSelectedIpForHostCache();
   }
 
   @backgroundMethod()
@@ -119,6 +177,7 @@ export class SimpleDbEntityIpTable extends SimpleDbEntityBase<ISimpleDbIpTableDa
         enabled,
       },
     }));
+    clearSelectedIpForHostCache();
   }
 
   @backgroundMethod()
@@ -151,5 +210,12 @@ export class SimpleDbEntityIpTable extends SimpleDbEntityBase<ISimpleDbIpTableDa
       },
       version: 1,
     });
+    clearSelectedIpForHostCache();
+  }
+
+  @backgroundMethod()
+  override async clearRawData(): Promise<void> {
+    await super.clearRawData();
+    clearSelectedIpForHostCache();
   }
 }

--- a/packages/kit-bg/src/services/ServiceIpTable.test.ts
+++ b/packages/kit-bg/src/services/ServiceIpTable.test.ts
@@ -1,0 +1,293 @@
+import {
+  testDomainSpeed,
+  testIpSpeed,
+} from '@onekeyhq/shared/src/request/helpers/ipTableAdapter';
+import type { IIpTableConfigWithRuntime } from '@onekeyhq/shared/src/request/types/ipTable';
+
+import { devSettingsPersistAtom } from '../states/jotai/atoms';
+
+import ServiceIpTable from './ServiceIpTable';
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundClass: () => (target: unknown) => target,
+  backgroundMethod:
+    () =>
+    (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+}));
+
+jest.mock('@onekeyhq/shared/src/request/constants/ipTableDefaults', () => ({
+  IP_TABLE_INITIAL_SPEED_TEST_DELAY_MS: 0,
+  IP_TABLE_PERFORMANCE_IMPROVEMENT_THRESHOLD: 0.3,
+  IP_TABLE_SELECTED_IP_CACHE_MS: 1000,
+  IP_TABLE_SNI_FAILURE_IN_MEMORY_QUARANTINE_MS: 10 * 1000,
+  IP_TABLE_SNI_FAILURE_QUARANTINE_MS: 30 * 60 * 1000,
+  IP_TABLE_SNI_QUARANTINE_FAILURE_THRESHOLD: 2,
+  IP_TABLE_SNI_FAILURE_THRESHOLD: 10,
+  IP_TABLE_SPEED_TEST_COOLDOWN_MS: 0,
+  IP_TABLE_SPEED_TEST_DELAY_MS: 0,
+  IP_TABLE_SPEED_TEST_ITERATIONS: 1,
+  IP_TABLE_SPEED_TEST_TIMEOUT_MS: 3000,
+}));
+
+jest.mock('@onekeyhq/shared/src/request/helpers/ipTableAdapter', () => ({
+  getSelectedIpForHost: jest.fn(),
+  setReportRequestFailureCallback: jest.fn(),
+  testDomainSpeed: jest.fn(),
+  testIpSpeed: jest.fn(),
+}));
+
+jest.mock('@onekeyhq/shared/src/request/helpers/sniRequest', () => ({
+  isSniSupported: jest.fn(() => true),
+}));
+
+jest.mock('@onekeyhq/shared/src/request/Interceptor', () => ({
+  getRequestHeaders: jest.fn(async () => ({})),
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/ipTableUtils', () => ({
+  isSupportIpTablePlatform: jest.fn(() => true),
+  mergeIpTableConfigs: jest.fn(),
+  verifyIpTableConfigSignature: jest.fn(),
+}));
+
+jest.mock('@onekeyhq/shared/src/logger/logger', () => ({
+  defaultLogger: {
+    ipTable: {
+      request: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      },
+    },
+  },
+}));
+
+jest.mock('../states/jotai/atoms', () => ({
+  devSettingsPersistAtom: {
+    get: jest.fn(async () => ({ enabled: true, settings: {} })),
+  },
+}));
+
+jest.mock('./ServiceBase', () => ({
+  __esModule: true,
+  default: class ServiceBase {
+    constructor({ backgroundApi }: { backgroundApi: unknown }) {
+      this.backgroundApi = backgroundApi;
+    }
+
+    backgroundApi: unknown;
+  },
+}));
+
+const testDomainSpeedMock = testDomainSpeed as jest.MockedFunction<
+  typeof testDomainSpeed
+>;
+const testIpSpeedMock = testIpSpeed as jest.MockedFunction<typeof testIpSpeed>;
+const devSettingsPersistAtomGetMock = devSettingsPersistAtom.get as jest.Mock;
+
+const DOMAIN = 'onekeycn.com';
+const BAD_IP = '216.19.4.106';
+const GOOD_IP = '104.18.20.233';
+
+function buildConfig(): IIpTableConfigWithRuntime {
+  return {
+    config: {
+      version: 1,
+      ttl_sec: 3600,
+      generated_at: '2026-06-23T00:00:00.000Z',
+      signature: 'test-signature',
+      domains: {
+        [DOMAIN]: {
+          endpoints: [
+            {
+              ip: BAD_IP,
+              provider: 'volcengine',
+              region: 'CN',
+              weight: 100,
+            },
+            {
+              ip: GOOD_IP,
+              provider: 'cloudflare',
+              region: 'GLOBAL',
+              weight: 100,
+            },
+          ],
+        },
+      },
+    },
+    runtime: {
+      enabled: true,
+      lastUpdated: 0,
+      lastRegionCheck: 0,
+      selections: {},
+    },
+  };
+}
+
+function buildService(config: IIpTableConfigWithRuntime = buildConfig()) {
+  const backgroundApi = {
+    simpleDb: {
+      ipTable: {
+        getConfig: jest.fn(async () => config),
+        markIpQuarantined: jest.fn(async () => undefined),
+        updateSelection: jest.fn(async () => undefined),
+      },
+    },
+  };
+
+  return {
+    backgroundApi,
+    service: new ServiceIpTable({ backgroundApi }),
+  };
+}
+
+describe('ServiceIpTable IP quarantine', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    devSettingsPersistAtomGetMock.mockResolvedValue({
+      enabled: true,
+      settings: {},
+    });
+    testDomainSpeedMock.mockResolvedValue(1000);
+    testIpSpeedMock.mockImplementation(async (ip) => {
+      if (ip === BAD_IP) {
+        return 100;
+      }
+      return 200;
+    });
+  });
+
+  it('keeps the original wallet-health selection flow when no IP is quarantined', async () => {
+    const { backgroundApi, service } = buildService();
+
+    await service.selectBestEndpointForDomain(DOMAIN);
+
+    expect(testIpSpeedMock).toHaveBeenCalledWith(
+      BAD_IP,
+      DOMAIN,
+      '/wallet/v1/health',
+      3000,
+    );
+    expect(backgroundApi.simpleDb.ipTable.updateSelection).toHaveBeenCalledWith(
+      DOMAIN,
+      BAD_IP,
+    );
+  });
+
+  it('skips active quarantined IPs during speed test', async () => {
+    const config = buildConfig();
+    config.runtime = {
+      enabled: true,
+      lastUpdated: 0,
+      lastRegionCheck: 0,
+      selections: {},
+      quarantinedIps: {
+        [DOMAIN]: {
+          [BAD_IP]: {
+            lastFailureTime: Date.now(),
+            hostname: `utility.${DOMAIN}`,
+            error: 'Request timeout',
+          },
+        },
+      },
+    };
+    const { backgroundApi, service } = buildService(config);
+
+    await service.selectBestEndpointForDomain(DOMAIN);
+
+    expect(testIpSpeedMock).not.toHaveBeenCalledWith(
+      BAD_IP,
+      DOMAIN,
+      '/wallet/v1/health',
+      3000,
+    );
+    expect(backgroundApi.simpleDb.ipTable.updateSelection).toHaveBeenCalledWith(
+      DOMAIN,
+      GOOD_IP,
+    );
+  });
+
+  it('quarantines a failed IP after consecutive SNI failures', async () => {
+    const config = buildConfig();
+    config.runtime = {
+      enabled: true,
+      lastUpdated: 0,
+      lastRegionCheck: 0,
+      selections: {
+        [DOMAIN]: BAD_IP,
+      },
+    };
+    const { backgroundApi, service } = buildService(config);
+    const selectBestEndpointSpy = jest
+      .spyOn(service, 'selectBestEndpointForDomain')
+      .mockResolvedValue(undefined);
+
+    await service.reportRequestFailure(DOMAIN, 'ip', BAD_IP, {
+      hostname: `utility.${DOMAIN}`,
+      error: 'Request timeout',
+    });
+
+    expect(
+      backgroundApi.simpleDb.ipTable.markIpQuarantined,
+    ).not.toHaveBeenCalled();
+    expect(
+      backgroundApi.simpleDb.ipTable.updateSelection,
+    ).not.toHaveBeenCalled();
+    expect(selectBestEndpointSpy).not.toHaveBeenCalled();
+
+    await service.reportRequestFailure(DOMAIN, 'ip', BAD_IP, {
+      hostname: `utility.${DOMAIN}`,
+      error: 'Request timeout',
+    });
+
+    expect(
+      backgroundApi.simpleDb.ipTable.markIpQuarantined,
+    ).toHaveBeenCalledWith(
+      DOMAIN,
+      BAD_IP,
+      expect.objectContaining({
+        hostname: `utility.${DOMAIN}`,
+        error: 'Request timeout',
+      }),
+    );
+    expect(backgroundApi.simpleDb.ipTable.updateSelection).toHaveBeenCalledWith(
+      DOMAIN,
+      '',
+    );
+    expect(selectBestEndpointSpy).toHaveBeenCalledWith(DOMAIN);
+  });
+
+  it('allows expired quarantined IPs to participate in speed test again', async () => {
+    const config = buildConfig();
+    config.runtime = {
+      enabled: true,
+      lastUpdated: 0,
+      lastRegionCheck: 0,
+      selections: {},
+      quarantinedIps: {
+        [DOMAIN]: {
+          [BAD_IP]: {
+            lastFailureTime: Date.now() - 31 * 60 * 1000,
+            hostname: `utility.${DOMAIN}`,
+            error: 'Request timeout',
+          },
+        },
+      },
+    };
+    const { backgroundApi, service } = buildService(config);
+
+    await service.selectBestEndpointForDomain(DOMAIN);
+
+    expect(testIpSpeedMock).toHaveBeenCalledWith(
+      BAD_IP,
+      DOMAIN,
+      '/wallet/v1/health',
+      3000,
+    );
+    expect(backgroundApi.simpleDb.ipTable.updateSelection).toHaveBeenCalledWith(
+      DOMAIN,
+      BAD_IP,
+    );
+  });
+});

--- a/packages/kit-bg/src/services/ServiceIpTable.ts
+++ b/packages/kit-bg/src/services/ServiceIpTable.ts
@@ -16,7 +16,9 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import {
   IP_TABLE_INITIAL_SPEED_TEST_DELAY_MS,
   IP_TABLE_PERFORMANCE_IMPROVEMENT_THRESHOLD,
+  IP_TABLE_SNI_FAILURE_QUARANTINE_MS,
   IP_TABLE_SNI_FAILURE_THRESHOLD,
+  IP_TABLE_SNI_QUARANTINE_FAILURE_THRESHOLD,
   IP_TABLE_SPEED_TEST_COOLDOWN_MS,
   IP_TABLE_SPEED_TEST_DELAY_MS,
   IP_TABLE_SPEED_TEST_ITERATIONS,
@@ -33,6 +35,7 @@ import { getRequestHeaders } from '@onekeyhq/shared/src/request/Interceptor';
 import type {
   IIpTableConfigWithRuntime,
   IIpTableRemoteConfig,
+  IIpTableRuntime,
 } from '@onekeyhq/shared/src/request/types/ipTable';
 import {
   isSupportIpTablePlatform,
@@ -441,6 +444,27 @@ class ServiceIpTable extends ServiceBase {
     return avgLatency;
   }
 
+  private getActiveQuarantinedIps(
+    runtime: IIpTableRuntime | undefined,
+    domain: string,
+    now = Date.now(),
+  ): Set<string> {
+    const domainQuarantines = runtime?.quarantinedIps?.[domain];
+    if (!domainQuarantines) {
+      return new Set();
+    }
+
+    return new Set(
+      Object.entries(domainQuarantines)
+        .filter(
+          ([, quarantine]) =>
+            now - quarantine.lastFailureTime <
+            IP_TABLE_SNI_FAILURE_QUARANTINE_MS,
+        )
+        .map(([ip]) => ip),
+    );
+  }
+
   /**
    * Clean up health statistics after speed test
    * Removes health data for IPs that are no longer selected (memory optimization)
@@ -532,29 +556,40 @@ class ServiceIpTable extends ServiceBase {
 
       // 2. Test all IPs with SNI
       const ipResults = new Map<string, number>();
+      const activeQuarantinedIps = this.getActiveQuarantinedIps(
+        configWithRuntime.runtime,
+        domain,
+      );
 
       for (const endpoint of domainConfig.endpoints) {
-        defaultLogger.ipTable.request.info({
-          info: `[IpTable] Testing IP: ${endpoint.ip} for ${domain}`,
-        });
+        if (activeQuarantinedIps.has(endpoint.ip)) {
+          defaultLogger.ipTable.request.warn({
+            info: `[IpTable] Skipping quarantined IP during speed test: ${domain} -> ${endpoint.ip}`,
+          });
+          ipResults.set(endpoint.ip, Infinity);
+        } else {
+          defaultLogger.ipTable.request.info({
+            info: `[IpTable] Testing IP: ${endpoint.ip} for ${domain}`,
+          });
 
-        const ipLatency = await this.testMultipleTimes(() =>
-          testIpSpeed(
-            endpoint.ip,
-            domain,
-            ONEKEY_HEALTH_CHECK_URL,
-            IP_TABLE_SPEED_TEST_TIMEOUT_MS,
-          ),
-        );
+          const ipLatency = await this.testMultipleTimes(() =>
+            testIpSpeed(
+              endpoint.ip,
+              domain,
+              ONEKEY_HEALTH_CHECK_URL,
+              IP_TABLE_SPEED_TEST_TIMEOUT_MS,
+            ),
+          );
 
-        ipResults.set(endpoint.ip, ipLatency);
+          ipResults.set(endpoint.ip, ipLatency);
 
-        defaultLogger.ipTable.request.info({
-          info: `[IpTable] IP test result: ${endpoint.ip} -> ${ipLatency}ms`,
-        });
+          defaultLogger.ipTable.request.info({
+            info: `[IpTable] IP test result: ${endpoint.ip} -> ${ipLatency}ms`,
+          });
+        }
       }
 
-      // 3. Find best IP
+      // 3. Find the fastest non-quarantined IP
       let bestIp = '';
       let bestIpLatency = Infinity;
 
@@ -580,16 +615,17 @@ class ServiceIpTable extends ServiceBase {
         } else {
           // All tests failed
           defaultLogger.ipTable.request.info({
-            info: `[IpTable] All tests failed for ${domain}`,
+            info: `[IpTable] All tests failed for ${domain}, using domain`,
           });
+          await this.backgroundApi.simpleDb.ipTable.updateSelection(domain, '');
         }
         return;
       }
 
       if (bestIpLatency === Infinity) {
-        // All IP tests failed, use domain
+        // All IP tests failed or all candidate IPs are quarantined, use domain
         defaultLogger.ipTable.request.info({
-          info: `[IpTable] All IP tests failed, using domain: ${domain}`,
+          info: `[IpTable] No available IP passed speed test, using domain: ${domain}`,
         });
         await this.backgroundApi.simpleDb.ipTable.updateSelection(domain, '');
         return;
@@ -691,6 +727,10 @@ class ServiceIpTable extends ServiceBase {
     domain: string,
     requestType: 'ip' | 'domain',
     target: string,
+    params?: {
+      hostname?: string;
+      error?: string;
+    },
   ): Promise<void> {
     // Check if IP Table is enabled
     if (!(await this.isIpTableEnabled())) {
@@ -717,6 +757,38 @@ class ServiceIpTable extends ServiceBase {
         endpointHealth.consecutiveFailures
       }) for ${domain} (${target})`,
     });
+
+    if (requestType === 'ip') {
+      if (
+        endpointHealth.consecutiveFailures <
+        IP_TABLE_SNI_QUARANTINE_FAILURE_THRESHOLD
+      ) {
+        defaultLogger.ipTable.request.info({
+          info: `[IpTable] IP quarantine not triggered: ${endpointHealth.consecutiveFailures}/${IP_TABLE_SNI_QUARANTINE_FAILURE_THRESHOLD} consecutive failures for ${domain} (${target})`,
+        });
+        return;
+      }
+
+      await this.backgroundApi.simpleDb.ipTable.markIpQuarantined(
+        domain,
+        target,
+        {
+          hostname: params?.hostname,
+          error: params?.error,
+          timestamp: now,
+        },
+      );
+      await this.backgroundApi.simpleDb.ipTable.updateSelection(domain, '');
+
+      defaultLogger.ipTable.request.warn({
+        info: `[IpTable] Quarantined failed IP and switched to domain: ${domain} -> ${target}`,
+      });
+
+      stats.lastSpeedTestTime = now;
+      endpointHealth.consecutiveFailures = 0;
+      void this.selectBestEndpointForDomain(domain);
+      return;
+    }
 
     // Check if speed test should be triggered
     const shouldTrigger = await this.shouldTriggerSpeedTest(domain, stats);
@@ -767,9 +839,17 @@ class ServiceIpTable extends ServiceBase {
     }, IP_TABLE_INITIAL_SPEED_TEST_DELAY_MS);
   }
 
-  private async hasRuntimeSelections(): Promise<boolean> {
+  private async hasRuntimeSelectionForDomain(domain: string): Promise<boolean> {
     const configWithRuntime = await this.getConfig();
-    return Object.keys(configWithRuntime.runtime?.selections ?? {}).length > 0;
+    return configWithRuntime.runtime?.selections?.[domain] !== undefined;
+  }
+
+  private async getCurrentDomain(): Promise<string> {
+    const { enabled: devSettingEnabled, settings } =
+      await devSettingsPersistAtom.get();
+    return devSettingEnabled && settings?.enableTestEndpoint
+      ? ONEKEY_TEST_API_HOST
+      : ONEKEY_API_HOST;
   }
 
   @backgroundMethod()
@@ -785,9 +865,16 @@ class ServiceIpTable extends ServiceBase {
     });
 
     // Register request failure callback (handles both IP and domain failures)
-    setReportRequestFailureCallback(({ domain, requestType, target }) => {
-      void this.reportRequestFailure(domain, requestType, target);
-    });
+    setReportRequestFailureCallback(
+      ({ domain, requestType, target, hostname, error }) => {
+        void this.reportRequestFailure(domain, requestType, target, {
+          hostname,
+          error,
+        });
+      },
+    );
+
+    const domain = await this.getCurrentDomain();
 
     // Try to refresh CDN config if needed
     const shouldRefresh = await this.shouldRefreshConfig();
@@ -813,7 +900,7 @@ class ServiceIpTable extends ServiceBase {
       defaultLogger.ipTable.request.info({
         info: '[IpTable] CDN config is up to date',
       });
-      needSpeedTest = !(await this.hasRuntimeSelections());
+      needSpeedTest = !(await this.hasRuntimeSelectionForDomain(domain));
     }
 
     // Execute speed test if needed

--- a/packages/shared/src/request/constants/ipTableDefaults.ts
+++ b/packages/shared/src/request/constants/ipTableDefaults.ts
@@ -12,6 +12,21 @@ export const CDN_SIGNER_ADDRESS = '0x3eaf57d1aD767CA3aFeDbF8D82C1De610c6F6519';
  */
 export const IP_TABLE_SNI_FAILURE_THRESHOLD = 10;
 
+export const IP_TABLE_SNI_QUARANTINE_FAILURE_THRESHOLD = 2;
+
+export const IP_TABLE_SNI_FAILURE_QUARANTINE_MS = timerUtils.getTimeDurationMs({
+  minute: 30,
+});
+
+export const IP_TABLE_SNI_FAILURE_IN_MEMORY_QUARANTINE_MS =
+  timerUtils.getTimeDurationMs({
+    seconds: 10,
+  });
+
+export const IP_TABLE_SELECTED_IP_CACHE_MS = timerUtils.getTimeDurationMs({
+  seconds: 1,
+});
+
 export const IP_TABLE_SPEED_TEST_COOLDOWN_MS = timerUtils.getTimeDurationMs({
   minute: 2,
 });

--- a/packages/shared/src/request/helpers/ipTableAdapter.test.ts
+++ b/packages/shared/src/request/helpers/ipTableAdapter.test.ts
@@ -1,0 +1,400 @@
+import axios from 'axios';
+
+import { DEFAULT_IP_TABLE_CONFIG } from '../constants/ipTableDefaults';
+import requestHelper from '../requestHelper';
+
+import {
+  clearInMemoryQuarantinedIps,
+  clearSelectedIpForHostCache,
+  createAxiosWithIpTable,
+  createIpTableAdapter,
+  getSelectedIpForHost,
+  setReportRequestFailureCallback,
+  testIpHostSpeed,
+} from './ipTableAdapter';
+import { sniRequest } from './sniRequest';
+
+import type { IIpTableConfigWithRuntime } from '../types/ipTable';
+
+jest.mock('../Interceptor', () => ({
+  getRequestHeaders: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../../logger/logger', () => ({
+  defaultLogger: {
+    ipTable: {
+      request: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      },
+    },
+  },
+}));
+
+jest.mock('./sniRequest', () => ({
+  isSniSupported: jest.fn(() => true),
+  sniRequest: jest.fn(),
+}));
+
+const sniRequestMock = sniRequest as jest.MockedFunction<typeof sniRequest>;
+
+type ITestDevSettingsPersistAtom = Awaited<
+  ReturnType<typeof requestHelper.getDevSettingsPersistAtom>
+>;
+type ITestSettingsPersistAtom = Awaited<
+  ReturnType<typeof requestHelper.getSettingsPersistAtom>
+>;
+type ITestSettingsValuePersistAtom = Awaited<
+  ReturnType<typeof requestHelper.getSettingsValuePersistAtom>
+>;
+
+let devSettingsPersistAtomMock: ITestDevSettingsPersistAtom;
+let ipTableConfigMock: IIpTableConfigWithRuntime | null;
+const originalAxiosDefaultAdapter = axios.defaults.adapter;
+
+beforeAll(() => {
+  requestHelper.overrideMethods({
+    checkIsOneKeyDomain: async () => false,
+    getDevSettingsPersistAtom: async () => devSettingsPersistAtomMock,
+    getSettingsPersistAtom: async () => ({}) as ITestSettingsPersistAtom,
+    getSettingsValuePersistAtom: async () =>
+      ({}) as ITestSettingsValuePersistAtom,
+    getIpTableConfig: async () => ipTableConfigMock,
+  });
+});
+
+describe('testIpHostSpeed', () => {
+  afterEach(() => {
+    axios.defaults.adapter = originalAxiosDefaultAdapter;
+  });
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    sniRequestMock.mockReset();
+    clearInMemoryQuarantinedIps();
+    clearSelectedIpForHostCache();
+    devSettingsPersistAtomMock = {
+      enabled: true,
+      settings: {},
+    } as ITestDevSettingsPersistAtom;
+    ipTableConfigMock = {
+      config: DEFAULT_IP_TABLE_CONFIG,
+      runtime: {
+        enabled: true,
+        lastUpdated: 0,
+        lastRegionCheck: 0,
+        selections: {},
+      },
+    };
+  });
+
+  it('returns latency when the SNI host probe returns 2xx', async () => {
+    jest.spyOn(Date, 'now').mockReturnValueOnce(1000).mockReturnValueOnce(1234);
+    sniRequestMock.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: '',
+    });
+
+    await expect(
+      testIpHostSpeed(
+        '216.19.4.106',
+        'utility.onekeycn.com',
+        '/utility/v1/app-update',
+        3000,
+      ),
+    ).resolves.toBe(234);
+
+    expect(sniRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ip: '216.19.4.106',
+        hostname: 'utility.onekeycn.com',
+        path: '/utility/v1/app-update',
+        method: 'GET',
+        timeout: 3000,
+      }),
+    );
+  });
+
+  it('rejects non-2xx SNI host probe responses', async () => {
+    sniRequestMock.mockResolvedValue({
+      statusCode: 404,
+      headers: {},
+      body: '',
+    });
+
+    await expect(
+      testIpHostSpeed(
+        '216.19.4.106',
+        'utility.onekeycn.com',
+        '/utility/v1/app-update',
+        3000,
+      ),
+    ).resolves.toBe(Infinity);
+  });
+
+  it('overrides explicit domain selection in strict mode', async () => {
+    devSettingsPersistAtomMock = {
+      enabled: true,
+      settings: {
+        forceIpTableStrict: true,
+      },
+    } as ITestDevSettingsPersistAtom;
+    ipTableConfigMock = {
+      config: DEFAULT_IP_TABLE_CONFIG,
+      runtime: {
+        enabled: true,
+        lastUpdated: 0,
+        lastRegionCheck: 0,
+        selections: {
+          'onekeycn.com': '',
+        },
+      },
+    };
+
+    await expect(getSelectedIpForHost('wallet.onekeycn.com')).resolves.toBe(
+      '104.18.20.233',
+    );
+  });
+
+  it('uses runtime IP selections', async () => {
+    ipTableConfigMock = {
+      config: DEFAULT_IP_TABLE_CONFIG,
+      runtime: {
+        enabled: true,
+        lastUpdated: 0,
+        lastRegionCheck: 0,
+        selections: {
+          'onekeycn.com': '104.18.20.233',
+        },
+      },
+    };
+
+    await expect(getSelectedIpForHost('wallet.onekeycn.com')).resolves.toBe(
+      '104.18.20.233',
+    );
+  });
+
+  it('ignores quarantined runtime IP selections', async () => {
+    ipTableConfigMock = {
+      config: DEFAULT_IP_TABLE_CONFIG,
+      runtime: {
+        enabled: true,
+        lastUpdated: 0,
+        lastRegionCheck: 0,
+        selections: {
+          'onekeycn.com': '216.19.4.106',
+        },
+        quarantinedIps: {
+          'onekeycn.com': {
+            '216.19.4.106': {
+              lastFailureTime: Date.now(),
+              hostname: 'utility.onekeycn.com',
+              error: 'Request timeout',
+            },
+          },
+        },
+      },
+    };
+
+    await expect(
+      getSelectedIpForHost('utility.onekeycn.com'),
+    ).resolves.toBeNull();
+  });
+
+  it('uses mapped lookup domain when a shared-domain SNI request fails', async () => {
+    const requestFailureCallback = jest.fn();
+    const fallbackAdapter = jest.fn(async (config) => ({
+      data: { ok: true },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+      request: {},
+    }));
+    axios.defaults.adapter = fallbackAdapter;
+    setReportRequestFailureCallback(requestFailureCallback);
+    ipTableConfigMock = {
+      config: DEFAULT_IP_TABLE_CONFIG,
+      runtime: {
+        enabled: true,
+        lastUpdated: 0,
+        lastRegionCheck: 0,
+        selections: {
+          'onekeycn.com': '216.19.4.106',
+        },
+      },
+    };
+    sniRequestMock.mockRejectedValue(new Error('Request timeout'));
+
+    const client = axios.create({
+      adapter: createIpTableAdapter({}),
+      baseURL: 'https://swap.onekey.so',
+    });
+
+    await expect(client.get('/swap/v1/quote')).resolves.toMatchObject({
+      status: 200,
+      data: { ok: true },
+    });
+
+    expect(requestFailureCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: 'onekeycn.com',
+        requestType: 'ip',
+        target: '216.19.4.106',
+        hostname: 'swap.onekey.so',
+        error: 'Request timeout',
+      }),
+    );
+  });
+
+  it('adds failed SNI IPs to in-memory quarantine before background persistence completes', async () => {
+    const fallbackAdapter = jest.fn(async (config) => ({
+      data: { ok: true },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+      request: {},
+    }));
+    axios.defaults.adapter = fallbackAdapter;
+    setReportRequestFailureCallback(jest.fn());
+    ipTableConfigMock = {
+      config: DEFAULT_IP_TABLE_CONFIG,
+      runtime: {
+        enabled: true,
+        lastUpdated: 0,
+        lastRegionCheck: 0,
+        selections: {
+          'onekeycn.com': '216.19.4.106',
+        },
+      },
+    };
+    sniRequestMock.mockRejectedValue(new Error('Request timeout'));
+
+    const client = axios.create({
+      adapter: createIpTableAdapter({}),
+      baseURL: 'https://utility.onekeycn.com',
+    });
+
+    await client.get('/utility/v1/app-update');
+
+    await expect(
+      getSelectedIpForHost('utility.onekeycn.com'),
+    ).resolves.toBeNull();
+  });
+
+  it('reports null SNI responses for quarantine', async () => {
+    const requestFailureCallback = jest.fn();
+    const fallbackAdapter = jest.fn(async (config) => ({
+      data: { ok: true },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+      request: {},
+    }));
+    axios.defaults.adapter = fallbackAdapter;
+    setReportRequestFailureCallback(requestFailureCallback);
+    ipTableConfigMock = {
+      config: DEFAULT_IP_TABLE_CONFIG,
+      runtime: {
+        enabled: true,
+        lastUpdated: 0,
+        lastRegionCheck: 0,
+        selections: {
+          'onekeycn.com': '216.19.4.106',
+        },
+      },
+    };
+    sniRequestMock.mockResolvedValue(null);
+
+    const client = axios.create({
+      adapter: createIpTableAdapter({}),
+      baseURL: 'https://utility.onekeycn.com',
+    });
+
+    await client.get('/utility/v1/app-update');
+
+    expect(requestFailureCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: 'onekeycn.com',
+        requestType: 'ip',
+        target: '216.19.4.106',
+        hostname: 'utility.onekeycn.com',
+        error: 'SNI response null',
+      }),
+    );
+  });
+
+  it('skips quarantined strict-mode fallback IPs', async () => {
+    devSettingsPersistAtomMock = {
+      enabled: true,
+      settings: {
+        forceIpTableStrict: true,
+      },
+    } as ITestDevSettingsPersistAtom;
+    ipTableConfigMock = {
+      config: DEFAULT_IP_TABLE_CONFIG,
+      runtime: {
+        enabled: true,
+        lastUpdated: 0,
+        lastRegionCheck: 0,
+        selections: {},
+        quarantinedIps: {
+          'onekeycn.com': {
+            '104.18.20.233': {
+              lastFailureTime: Date.now(),
+              hostname: 'utility.onekeycn.com',
+              error: 'Request timeout',
+            },
+          },
+        },
+      },
+    };
+
+    await expect(getSelectedIpForHost('wallet.onekeycn.com')).resolves.toBe(
+      '104.18.21.233',
+    );
+  });
+
+  it('rejects real SNI adapter HTTP errors with axios validateStatus semantics', async () => {
+    ipTableConfigMock = {
+      config: DEFAULT_IP_TABLE_CONFIG,
+      runtime: {
+        enabled: true,
+        lastUpdated: 0,
+        lastRegionCheck: 0,
+        selections: {
+          'onekeycn.com': '104.18.20.233',
+        },
+      },
+    };
+    sniRequestMock.mockResolvedValue({
+      statusCode: 500,
+      headers: {},
+      body: '{"error":"server error"}',
+    });
+
+    const client = createAxiosWithIpTable({
+      baseURL: 'https://utility.onekeycn.com',
+    });
+
+    const request = client.get('/utility/v1/app-update');
+
+    await expect(request).rejects.toMatchObject({
+      code: 'ERR_BAD_RESPONSE',
+      response: {
+        status: 500,
+        data: {
+          error: 'server error',
+        },
+      },
+    });
+
+    await request.catch((error: unknown) => {
+      expect(axios.isAxiosError(error)).toBe(true);
+    });
+  });
+});

--- a/packages/shared/src/request/helpers/ipTableAdapter.ts
+++ b/packages/shared/src/request/helpers/ipTableAdapter.ts
@@ -1,13 +1,19 @@
-import axios, { AxiosHeaders } from 'axios';
+import axios, { AxiosError, AxiosHeaders } from 'axios';
 
 import { OneKeyLocalError } from '../../errors';
 import { defaultLogger } from '../../logger/logger';
 import { memoizee } from '../../utils/cacheUtils';
+import {
+  IP_TABLE_SELECTED_IP_CACHE_MS,
+  IP_TABLE_SNI_FAILURE_IN_MEMORY_QUARANTINE_MS,
+  IP_TABLE_SNI_FAILURE_QUARANTINE_MS,
+} from '../constants/ipTableDefaults';
 import { getRequestHeaders } from '../Interceptor';
 import requestHelper from '../requestHelper';
 
 import { isSniSupported, sniRequest } from './sniRequest';
 
+import type { IIpTableRuntime } from '../types/ipTable';
 import type {
   AxiosAdapter,
   AxiosRequestConfig,
@@ -44,13 +50,23 @@ interface IRequestFailureParams {
   requestType: 'ip' | 'domain';
   /** IP address for SNI request, or hostname for domain request */
   target: string;
+  /** Actual request hostname that failed */
+  hostname?: string;
   /** Error message */
   error: string;
+}
+
+interface ISelectedIpInfo {
+  ip: string;
+  lookupDomain: string;
+  rootDomain: string;
 }
 
 let reportRequestFailureCallback:
   | ((params: IRequestFailureParams) => void)
   | null = null;
+
+const inMemoryQuarantinedIps = new Map<string, Map<string, number>>();
 
 /**
  * Extract root domain from hostname
@@ -95,6 +111,36 @@ async function getMappedDomainForIpLookup(
   }
 }
 
+function isIpQuarantined(
+  runtime: IIpTableRuntime | undefined,
+  domain: string,
+  ip: string,
+): boolean {
+  const inMemoryQuarantineTime = inMemoryQuarantinedIps.get(domain)?.get(ip);
+  if (
+    inMemoryQuarantineTime &&
+    Date.now() - inMemoryQuarantineTime <
+      IP_TABLE_SNI_FAILURE_IN_MEMORY_QUARANTINE_MS
+  ) {
+    return true;
+  }
+
+  const quarantine = runtime?.quarantinedIps?.[domain]?.[ip];
+  if (!quarantine) {
+    return false;
+  }
+  return (
+    Date.now() - quarantine.lastFailureTime < IP_TABLE_SNI_FAILURE_QUARANTINE_MS
+  );
+}
+
+function markIpQuarantinedInMemory(domain: string, ip: string): void {
+  const domainQuarantines = inMemoryQuarantinedIps.get(domain) ?? new Map();
+  domainQuarantines.set(ip, Date.now());
+  inMemoryQuarantinedIps.set(domain, domainQuarantines);
+  clearSelectedIpForHostCache();
+}
+
 /**
  * Check if IP Table should be used based on environment and dev settings
  * @returns true if IP Table should be used, false otherwise
@@ -130,14 +176,14 @@ async function shouldUseIpTable(): Promise<boolean> {
  *
  * Selection priority:
  * 1. runtime.selections[domain] - User selected IP or explicit domain choice (empty string)
- * 2. Strict mode fallback - First IP from config.domains[domain].endpoints (if forceIpTableStrict enabled)
+ * 2. Strict mode fallback - First non-quarantined IP from config.domains[domain].endpoints
  * 3. null - Use original axios adapter (domain request)
  *
- * @returns IP address if found and enabled, null otherwise (empty string in selections means use domain directly)
+ * @returns IP selection info if found and enabled, null otherwise (empty string in selections means use domain directly)
  */
-async function getSelectedIpForHostInternal(
+async function getSelectedIpInfoForHostInternal(
   hostname: string,
-): Promise<string | null> {
+): Promise<ISelectedIpInfo | null> {
   try {
     // Check environment-based permission first
     const hasPermission = await shouldUseIpTable();
@@ -166,7 +212,7 @@ async function getSelectedIpForHostInternal(
       );
     }
 
-    // Check strict mode first
+    // Check strict mode before selection handling because it can override explicit domain choice.
     const devSettings = await requestHelper.getDevSettingsPersistAtom();
     const strictMode = devSettings?.settings?.forceIpTableStrict;
 
@@ -175,14 +221,24 @@ async function getSelectedIpForHostInternal(
 
     // If selectedIp exists (not undefined), use it
     if (selectedIp) {
-      debugLog(
-        `[IpTableAdapter] Using selected IP from runtime: ${lookupDomain} -> ${selectedIp}`,
-      );
-      return selectedIp;
+      if (isIpQuarantined(runtime, lookupDomain, selectedIp)) {
+        debugLog(
+          `[IpTableAdapter] Selected IP is quarantined, using fallback: ${lookupDomain} -> ${selectedIp}`,
+        );
+      } else {
+        debugLog(
+          `[IpTableAdapter] Using selected IP from runtime: ${lookupDomain} -> ${selectedIp}`,
+        );
+        return {
+          ip: selectedIp,
+          lookupDomain,
+          rootDomain,
+        };
+      }
     }
 
     // Empty string means explicitly use domain (not IP)
-    // In strict mode, override this and use fallback IP from config
+    // In strict mode, override this and use fallback IP from config.
     if (selectedIp === '') {
       if (!strictMode) {
         debugLog(
@@ -193,15 +249,20 @@ async function getSelectedIpForHostInternal(
       debugLog(
         `[IpTableAdapter] Strict mode: overriding domain choice for ${lookupDomain}`,
       );
-      // Fall through to strict mode fallback logic below
     }
 
-    // If no selection (or strict mode overriding domain choice), fallback to first available IP from config
+    // If no selection (or strict mode overriding domain choice), fallback to the first non-quarantined IP.
     if (strictMode && config.domains[lookupDomain]) {
       const endpoints = config.domains[lookupDomain].endpoints;
-      if (endpoints && endpoints.length > 0) {
-        const fallbackIp = endpoints[0].ip;
-        return fallbackIp;
+      const fallbackEndpoint = endpoints.find(
+        (endpoint) => !isIpQuarantined(runtime, lookupDomain, endpoint.ip),
+      );
+      if (fallbackEndpoint) {
+        return {
+          ip: fallbackEndpoint.ip,
+          lookupDomain,
+          rootDomain,
+        };
       }
     }
 
@@ -217,12 +278,26 @@ async function getSelectedIpForHostInternal(
   }
 }
 
-const getSelectedIpForHost = memoizee(getSelectedIpForHostInternal, {
+const getSelectedIpInfoForHost = memoizee(getSelectedIpInfoForHostInternal, {
   promise: true,
-  maxAge: 5000, // 5 seconds cache
+  maxAge: IP_TABLE_SELECTED_IP_CACHE_MS,
   max: 100, // Max 100 hostname cached
   primitive: true, // hostname is a string primitive, use simple equality check
 });
+
+export function clearSelectedIpForHostCache(): void {
+  getSelectedIpInfoForHost.clear();
+}
+
+export function clearInMemoryQuarantinedIps(): void {
+  inMemoryQuarantinedIps.clear();
+  clearSelectedIpForHostCache();
+}
+
+async function getSelectedIpForHost(hostname: string): Promise<string | null> {
+  const selectedIpInfo = await getSelectedIpInfoForHost(hostname);
+  return selectedIpInfo?.ip ?? null;
+}
 
 /**
  * Convert AxiosHeaders to plain object
@@ -267,6 +342,28 @@ function axiosHeadersToPlainObject(
   }
 
   return {};
+}
+
+function settleAxiosResponse(response: AxiosResponse): AxiosResponse {
+  const validateStatus = response.config.validateStatus;
+  if (!response.status || !validateStatus || validateStatus(response.status)) {
+    return response;
+  }
+
+  let errorCode: string | undefined;
+  if (response.status >= 500) {
+    errorCode = AxiosError.ERR_BAD_RESPONSE;
+  } else if (response.status >= 400) {
+    errorCode = AxiosError.ERR_BAD_REQUEST;
+  }
+
+  throw new AxiosError(
+    `Request failed with status code ${response.status}`,
+    errorCode,
+    response.config,
+    response.request,
+    response,
+  );
 }
 
 /**
@@ -446,7 +543,8 @@ export function createIpTableAdapter(
     const rootDomain = extractRootDomain(hostname);
 
     // Get selected IP for this hostname (async call)
-    const selectedIp = await getSelectedIpForHost(hostname);
+    const selectedIpInfo = await getSelectedIpInfoForHost(hostname);
+    const selectedIp = selectedIpInfo?.ip;
 
     // If no IP mapping found, use original adapter (direct domain request, not fallback)
     if (!selectedIp) {
@@ -543,107 +641,125 @@ export function createIpTableAdapter(
       requestBody ? requestBody.substring(0, 200) : 'null',
     );
 
-    try {
-      const sniResponse = await sniRequest({
-        ip: selectedIp,
-        hostname,
-        path: fullPath,
-        headers: requestHeaders,
-        method: (config.method || 'GET').toUpperCase(),
-        body: requestBody,
-        timeout: config.timeout || 60_000,
-        port: 443, // HTTPS port
-      });
-
-      // If SNI request fails, use original adapter
-      if (!sniResponse) {
-        debugLog('[IpTableAdapter] SNI request returned null, using fallback');
-        // Report IP failure
+    const sniResponse = await (async () => {
+      try {
+        return await sniRequest({
+          ip: selectedIp,
+          hostname,
+          path: fullPath,
+          headers: requestHeaders,
+          method: (config.method || 'GET').toUpperCase(),
+          body: requestBody,
+          timeout: config.timeout || 60_000,
+          port: 443, // HTTPS port
+        });
+      } catch (error) {
+        // Report IP failure if callback is registered
+        if (selectedIpInfo) {
+          markIpQuarantinedInMemory(selectedIpInfo.lookupDomain, selectedIp);
+        } else {
+          clearSelectedIpForHostCache();
+        }
         if (reportRequestFailureCallback) {
           reportRequestFailureCallback({
-            domain: rootDomain,
+            domain: selectedIpInfo?.lookupDomain ?? rootDomain,
             requestType: 'ip',
             target: selectedIp,
-            error: 'SNI response null',
+            hostname,
+            error: error instanceof Error ? error.message : String(error),
           });
         }
+
+        // If SNI request throws error, use original adapter
+        debugWarn(
+          '[IpTableAdapter] SNI request failed, falling back to original adapter:',
+          error,
+        );
+        defaultLogger.ipTable.request.error({
+          info: `[IpTableAdapter] SNI request failed for ${hostname} (${selectedIp}), falling back: ${
+            error instanceof Error ? error.message : 'Unknown error'
+          }`,
+        });
         // Fallback to domain (isFallback = true, so domain failure won't be counted)
-        return await callOriginalAdapter({
+        return callOriginalAdapter({
           config,
           isFallback: true,
           hostname,
           rootDomain,
         });
       }
+    })();
 
-      // Convert SNI response to Axios response format
-      debugLog(
-        `[IpTableAdapter] SNI request successful: ${sniResponse.statusCode}`,
-      );
-
-      // Parse response body
-      let responseData: any = null;
-      if (sniResponse.body) {
-        try {
-          // Check if body is already an object or a string
-          if (typeof sniResponse.body === 'string') {
-            responseData = JSON.parse(sniResponse.body);
-          } else {
-            responseData = sniResponse.body;
-          }
-        } catch (parseError) {
-          debugWarn(
-            '[IpTableAdapter] Failed to parse response body:',
-            parseError,
-          );
-          defaultLogger.ipTable.request.warn({
-            info: `[IpTableAdapter] Failed to parse response body: ${
-              parseError instanceof Error ? parseError.message : 'Unknown error'
-            }`,
-          });
-          responseData = sniResponse.body;
-        }
+    // If SNI request fails, use original adapter
+    if (!sniResponse) {
+      debugLog('[IpTableAdapter] SNI request returned null, using fallback');
+      if (selectedIpInfo) {
+        markIpQuarantinedInMemory(selectedIpInfo.lookupDomain, selectedIp);
+      } else {
+        clearSelectedIpForHostCache();
       }
-
-      debugLog('[IpTableAdapter] Response data:', responseData);
-
-      return {
-        data: responseData,
-        status: sniResponse.statusCode,
-        statusText: '', // SNI response doesn't provide statusText
-        headers: sniResponse.headers,
-        config,
-        request: {},
-      };
-    } catch (error) {
-      // Report IP failure if callback is registered
+      // Report IP failure
       if (reportRequestFailureCallback) {
         reportRequestFailureCallback({
-          domain: rootDomain,
+          domain: selectedIpInfo?.lookupDomain ?? rootDomain,
           requestType: 'ip',
           target: selectedIp,
-          error: error instanceof Error ? error.message : String(error),
+          hostname,
+          error: 'SNI response null',
         });
       }
-
-      // If SNI request throws error, use original adapter
-      debugWarn(
-        '[IpTableAdapter] SNI request failed, falling back to original adapter:',
-        error,
-      );
-      defaultLogger.ipTable.request.error({
-        info: `[IpTableAdapter] SNI request failed for ${hostname} (${selectedIp}), falling back: ${
-          error instanceof Error ? error.message : 'Unknown error'
-        }`,
-      });
       // Fallback to domain (isFallback = true, so domain failure won't be counted)
-      return callOriginalAdapter({
+      return await callOriginalAdapter({
         config,
         isFallback: true,
         hostname,
         rootDomain,
       });
     }
+
+    if ('status' in sniResponse && 'config' in sniResponse) {
+      return sniResponse;
+    }
+
+    // Convert SNI response to Axios response format
+    debugLog(
+      `[IpTableAdapter] SNI request successful: ${sniResponse.statusCode}`,
+    );
+
+    // Parse response body
+    let responseData: any = null;
+    if (sniResponse.body) {
+      try {
+        // Check if body is already an object or a string
+        if (typeof sniResponse.body === 'string') {
+          responseData = JSON.parse(sniResponse.body);
+        } else {
+          responseData = sniResponse.body;
+        }
+      } catch (parseError) {
+        debugWarn(
+          '[IpTableAdapter] Failed to parse response body:',
+          parseError,
+        );
+        defaultLogger.ipTable.request.warn({
+          info: `[IpTableAdapter] Failed to parse response body: ${
+            parseError instanceof Error ? parseError.message : 'Unknown error'
+          }`,
+        });
+        responseData = sniResponse.body;
+      }
+    }
+
+    debugLog('[IpTableAdapter] Response data:', responseData);
+
+    return settleAxiosResponse({
+      data: responseData,
+      status: sniResponse.statusCode,
+      statusText: '', // SNI response doesn't provide statusText
+      headers: sniResponse.headers,
+      config,
+      request: {},
+    });
   };
 }
 
@@ -661,11 +777,8 @@ export function createAxiosWithIpTable(axiosConfig: AxiosRequestConfig = {}) {
 
 // ========== Speed Test Utilities ==========
 
-/**
- * Test endpoint speed using domain directly (no IP Table)
- */
-export async function testDomainSpeed(
-  domain: string,
+export async function testHostSpeed(
+  hostname: string,
   path: string,
   timeout = 3000,
 ): Promise<number> {
@@ -677,8 +790,7 @@ export async function testDomainSpeed(
 
     const headers = await getRequestHeaders();
 
-    // Build full URL: https://wallet.{domain}/wallet/v1/health
-    const fullUrl = `https://wallet.${domain}${path}`;
+    const fullUrl = `https://${hostname}${path}`;
 
     await plainAxios.get(fullUrl, {
       timeout,
@@ -692,9 +804,9 @@ export async function testDomainSpeed(
     });
     return latency;
   } catch (error) {
-    debugWarn(`[IpTableAdapter] Domain test failed for ${domain}:`, error);
+    debugWarn(`[IpTableAdapter] Domain test failed for ${hostname}:`, error);
     defaultLogger.ipTable.request.warn({
-      info: `[IpTable] Domain speed test failed for ${domain}: ${
+      info: `[IpTable] Domain speed test failed for ${hostname}: ${
         error instanceof Error ? error.message : 'Unknown error'
       }`,
     });
@@ -703,11 +815,19 @@ export async function testDomainSpeed(
 }
 
 /**
- * Test endpoint speed using IP with SNI
+ * Test endpoint speed using domain directly (no IP Table)
  */
-export async function testIpSpeed(
-  ip: string,
+export async function testDomainSpeed(
   domain: string,
+  path: string,
+  timeout = 3000,
+): Promise<number> {
+  return testHostSpeed(`wallet.${domain}`, path, timeout);
+}
+
+export async function testIpHostSpeed(
+  ip: string,
+  hostname: string,
   path: string,
   timeout = 3000,
 ): Promise<number> {
@@ -723,12 +843,9 @@ export async function testIpSpeed(
     // Get OneKey request headers
     const headers = await getRequestHeaders();
 
-    // SNI hostname should be: wallet.{domain}
-    const sniHostname = `wallet.${domain}`;
-
     const response = await sniRequest({
       ip,
-      hostname: sniHostname,
+      hostname,
       path,
       method: 'GET',
       timeout,
@@ -745,12 +862,22 @@ export async function testIpSpeed(
       return Infinity;
     }
 
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      debugWarn(
+        `[IpTableAdapter] IP test returned HTTP ${response.statusCode} for ${ip}`,
+      );
+      defaultLogger.ipTable.request.warn({
+        info: `[IpTable] IP speed test failed for ${ip}: HTTP ${response.statusCode}`,
+      });
+      return Infinity;
+    }
+
     const latency = Date.now() - startTime;
     debugLog(
-      `[IpTableAdapter] IP test: ${ip} -> ${sniHostname}${path} -> ${latency}ms`,
+      `[IpTableAdapter] IP test: ${ip} -> ${hostname}${path} -> ${latency}ms`,
     );
     defaultLogger.ipTable.request.info({
-      info: `[IpTable] IP speed test successful: ${ip} -> ${sniHostname}${path} : ${latency} ms`,
+      info: `[IpTable] IP speed test successful: ${ip} -> ${hostname}${path} : ${latency} ms`,
     });
     return latency;
   } catch (error) {
@@ -762,6 +889,18 @@ export async function testIpSpeed(
     });
     return Infinity;
   }
+}
+
+/**
+ * Test endpoint speed using IP with SNI
+ */
+export async function testIpSpeed(
+  ip: string,
+  domain: string,
+  path: string,
+  timeout = 3000,
+): Promise<number> {
+  return testIpHostSpeed(ip, `wallet.${domain}`, path, timeout);
 }
 
 // ========== Request Failure Reporting ==========

--- a/packages/shared/src/request/types/ipTable.ts
+++ b/packages/shared/src/request/types/ipTable.ts
@@ -43,12 +43,23 @@ export interface IIpTableRemoteConfig {
 /**
  * IP Table runtime state
  */
+export interface IIpTableQuarantinedIp {
+  lastFailureTime: number;
+  hostname?: string;
+  error?: string;
+}
+
 export interface IIpTableRuntime {
   enabled: boolean;
   lastUpdated: number;
   lastRegionCheck: number;
   selections: {
     [domain: string]: string; // Currently selected IP for each domain
+  };
+  quarantinedIps?: {
+    [domain: string]: {
+      [ip: string]: IIpTableQuarantinedIp;
+    };
   };
 }
 


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56653](https://onekeyhq.atlassian.net/browse/OK-56653)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Add an IP Table quarantine table for IPs that repeatedly fail real SNI requests.
- Keep the normal wallet-health speed test flow unchanged, but skip active quarantined IPs during re-selection.
- Preserve axios `validateStatus` behavior for SNI HTTP responses and add focused adapter/service/storage tests.

## Intent & Context
This fixes OK-56653, where Android logs showed `IpTableAdapter` timing out when requesting `utility.onekeycn.com` through a selected IP such as `216.19.4.106`.

The review concern was valid: probing business hosts such as `utility` and `earn` during every normal IP selection would couple service availability into the startup/speed-test path and slow it down. This update keeps the original selection flow and adds a reactive safety mechanism only after a real SNI failure is observed.

## Root Cause
The old IP Table flow selected a root-domain IP using `wallet.${domain}/wallet/v1/health`. The shared request adapter then reused that same root-domain selection for service hosts such as `utility.onekeycn.com`.

If an IP is healthy for the wallet health check but fails SNI for a service host, the old retry path could eventually run another wallet-only speed test and select the same IP again.

## Design Decisions
- Keep normal selection behavior wallet-health based. No extra `utility`/`earn` probes are added to the normal speed-test path.
- When the same selected IP reaches `IP_TABLE_SNI_QUARANTINE_FAILURE_THRESHOLD` consecutive real SNI failures, write it to `runtime.quarantinedIps[domain][ip]`, switch the current selection to domain, and trigger async re-selection.
- During speed tests, skip active quarantined IPs. This prevents the same IP from being selected again while the quarantine TTL is active.
- The adapter also reads the shared quarantine table. If the current selection is quarantined, normal mode falls back to domain; strict mode uses the first non-quarantined configured IP.
- Shared-domain requests such as `*.onekey.so` use the mapped IP Table lookup domain for quarantine writes, so the runtime key matches the key used for selection reads.
- The adapter records a short 10-second in-memory quarantine immediately when SNI throws or returns null. This closes the same-runtime retry loop without turning one transient failure into a 30-minute persisted quarantine.
- The quarantine state is runtime data in SimpleDB, not user data and not a Realm/IndexedDB schema change.
- Runtime model: `ServiceIpTable` runs in `bg` and writes shared persisted/native storage. The request adapter can run in `bg` and, depending on platform wiring, possibly `main`; JS heaps and memo caches are per-runtime, while the persisted quarantine table is shared. The runtime where the SNI failure happens clears its adapter memo immediately; other runtimes are protected once they read the shared quarantine state, with the selected-IP memo TTL shortened to 1 second as the upper bound for already-cached selections.
- Preserve axios semantics in the real SNI adapter path. Transport-level SNI failures still fall back to the original adapter, but HTTP responses now respect `validateStatus`.

## Changes Detail
- `ServiceIpTable`: quarantine failed IPs after consecutive real SNI failures reach the IP quarantine threshold, switch selection to domain, trigger re-selection, and skip active quarantined IPs during speed tests.
- `SimpleDbEntityIpTable`: persist `runtime.quarantinedIps` and clear adapter selection cache after IP Table state mutations.
- `ipTableAdapter`: read quarantine state before using a selected IP or strict-mode fallback; report failed hostname/error with IP failure callbacks; keep non-2xx speed probes unavailable.
- `ipTable` shared types/defaults: add quarantine runtime shape and TTL constant.
- Tests: cover wallet-only normal selection, quarantine skip/retry behavior, adapter quarantine reads, shared-domain failure mapping, same-runtime in-memory quarantine, storage pruning, strict-mode quarantine fallback, and SNI HTTP error semantics.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile/native IP Table request path, especially Android; shared request adapter consumers on platforms where IP Table is enabled.
- **Risk Areas**: Request fallback behavior after SNI failures, persisted runtime quarantine compatibility, and strict-mode fallback selection.

## Test plan
- [x] `npx jest packages/kit-bg/src/services/ServiceIpTable.test.ts packages/shared/src/request/helpers/ipTableAdapter.test.ts packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityIpTable.test.ts --runInBand`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityIpTable.test.ts packages/kit-bg/src/services/ServiceIpTable.test.ts packages/shared/src/request/constants/ipTableDefaults.ts packages/shared/src/request/helpers/ipTableAdapter.ts packages/shared/src/request/helpers/ipTableAdapter.test.ts packages/kit-bg/src/services/ServiceIpTable.ts packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityIpTable.ts packages/shared/src/request/types/ipTable.ts`
- [x] `git diff --check origin/x...HEAD`
- [x] `npx tsgo -p ./tsconfig.json --noEmit --tsBuildInfoFile /tmp/app-mono-ts-cache-iptable-quarantine-x --pretty false`

[OK-56653]: https://onekeyhq.atlassian.net/browse/OK-56653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ