### PR TITLE
fix: preserve ip table request helper

### DIFF
--- a/packages/kit-bg/src/init/updateInterceptorRequestHelper.test.ts
+++ b/packages/kit-bg/src/init/updateInterceptorRequestHelper.test.ts
@@ -1,0 +1,75 @@
+import requestHelper from '@onekeyhq/shared/src/request/requestHelper';
+import type { IIpTableConfigWithRuntime } from '@onekeyhq/shared/src/request/types/ipTable';
+
+import { updateInterceptorRequestHelper } from './updateInterceptorRequestHelper';
+
+jest.mock('../endpoints', () => ({
+  checkIsOneKeyDomain: jest.fn(async () => true),
+}));
+
+jest.mock('../states/jotai/atoms/devSettings', () => ({
+  devSettingsPersistAtom: {
+    get: jest.fn(async () => ({
+      enabled: false,
+      settings: {},
+    })),
+  },
+}));
+
+jest.mock('../states/jotai/atoms/settings', () => ({
+  settingsPersistAtom: {
+    get: jest.fn(async () => ({})),
+  },
+  settingsValuePersistAtom: {
+    get: jest.fn(async () => ({})),
+  },
+}));
+
+function resetIpTableProvider(
+  getIpTableConfig: () => Promise<IIpTableConfigWithRuntime | null> = async () =>
+    null,
+) {
+  requestHelper.getIpTableConfig = getIpTableConfig;
+}
+
+describe('requestHelper IP Table provider', () => {
+  beforeEach(() => {
+    resetIpTableProvider();
+  });
+
+  it('returns null by default before the full IP Table helper is installed', async () => {
+    await jest.isolateModulesAsync(async () => {
+      const freshRequestHelper = (
+        await import('@onekeyhq/shared/src/request/requestHelper')
+      ).default;
+
+      await expect(freshRequestHelper.getIpTableConfig()).resolves.toBeNull();
+    });
+  });
+
+  it('keeps the full IP Table provider when the base helper is re-applied', async () => {
+    const config: IIpTableConfigWithRuntime = {
+      config: {
+        version: 1,
+        ttl_sec: 60,
+        generated_at: '2026-06-23T00:00:00.000Z',
+        signature: '0x',
+        domains: {},
+      },
+      runtime: {
+        enabled: true,
+        lastUpdated: 0,
+        lastRegionCheck: 0,
+        selections: {
+          'onekeytest.com': '216.19.2.116',
+        },
+      },
+    };
+
+    resetIpTableProvider(async () => config);
+
+    updateInterceptorRequestHelper();
+
+    await expect(requestHelper.getIpTableConfig()).resolves.toBe(config);
+  });
+});

--- a/packages/kit-bg/src/init/updateInterceptorRequestHelper.ts
+++ b/packages/kit-bg/src/init/updateInterceptorRequestHelper.ts
@@ -15,11 +15,13 @@ import {
  * separately via updateInterceptorRequestHelperWithIpTable (separate file).
  */
 export function updateInterceptorRequestHelper() {
+  const getIpTableConfig = requestHelper.getIpTableConfig;
+
   requestHelper.overrideMethods({
     checkIsOneKeyDomain,
     getDevSettingsPersistAtom: async () => devSettingsPersistAtom.get(),
     getSettingsPersistAtom: async () => settingsPersistAtom.get(),
     getSettingsValuePersistAtom: async () => settingsValuePersistAtom.get(),
-    getIpTableConfig: async () => null,
+    getIpTableConfig,
   });
 }

--- a/packages/shared/src/request/requestHelper.ts
+++ b/packages/shared/src/request/requestHelper.ts
@@ -41,9 +41,7 @@ class RequestHelper {
    */
   getIpTableConfig: () => Promise<IIpTableConfigWithRuntime | null> =
     async () => {
-      throw new OneKeyLocalError(
-        'Not implemented, please call overrideMethods',
-      );
+      return null;
     };
 
   overrideMethods(methods: {


### PR DESCRIPTION
## Summary
- Preserve the simpleDb-backed IP Table config provider when the base request helper setup is re-applied.
- Make the default IP Table config provider explicitly return `null` before the full helper is installed.
- Add regression coverage for re-applying the base helper after a full IP Table provider is already present.

## Intent & Context
The desktop DevSetting UI had developer mode enabled with `forceIpTableStrict` on and `disableIpTableInProd` off, and the IP Table runtime selection contained `onekeytest.com -> 216.19.2.116`. Even with that configuration, exported logs and runtime checks showed `serviceIpTable.getConnectionInfo()` returning `type=domain` for `onekeytest.com` instead of forcing the selected IP.

This change fixes the request helper initialization path so the desktop client keeps using the IP Table config provider after later UI/bootstrap imports run the base request-helper setup again.

## Root Cause
`updateInterceptorRequestHelperWithIpTable()` installs `requestHelper.getIpTableConfig` with the full simpleDb-backed implementation. However, `updateInterceptorRequestHelper()` was later called from kit bootstrap paths and always overwrote `getIpTableConfig` with `async () => null`.

Runtime validation in the desktop dev client reproduced the failure directly:
- With the full helper installed, `requestHelper.getIpTableConfig()` returned runtime config, `getSelectedIpForHost('wallet.onekeytest.com')` returned `216.19.2.116`, and `getConnectionInfo()` returned `type=ip`.
- After re-applying the base helper, `requestHelper.getIpTableConfig()` became `null`, the selected IP became `null`, and `getConnectionInfo()` fell back to `type=domain`.

## Design Decisions
The fix keeps `updateInterceptorRequestHelper()` safe for runtimes where simpleDb must not be imported, while preventing it from clearing an already-installed full provider. The base helper now captures and reuses the current `getIpTableConfig` function when it overrides the other request helper methods.

The default `RequestHelper.getIpTableConfig` now returns `null` directly. That preserves the intended fallback behavior for runtimes before the full provider is installed without relying on a thrown "not implemented" error.

## Changes Detail
- `packages/kit-bg/src/init/updateInterceptorRequestHelper.ts`: preserve the current `requestHelper.getIpTableConfig` implementation when applying the base helper.
- `packages/shared/src/request/requestHelper.ts`: make the default IP Table config provider return `null` instead of throwing.
- `packages/kit-bg/src/init/updateInterceptorRequestHelper.test.ts`: add regression tests for the default fallback and for preserving the full provider after the base helper is re-applied.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web / Extension / Mobile background request helper setup
- **Risk Areas**: Request helper initialization order. The change is intentionally scoped to preserving the existing IP Table provider and does not import simpleDb into the base helper module.

## Test plan
- [x] `yarn jest packages/kit-bg/src/init/updateInterceptorRequestHelper.test.ts packages/shared/src/request/customUA.test.ts --runInBand`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/shared/src/request/requestHelper.ts packages/kit-bg/src/init/updateInterceptorRequestHelper.ts packages/kit-bg/src/init/updateInterceptorRequestHelper.test.ts`
- [x] Desktop dev runtime validation: after applying the same DevSetting values and `onekeytest.com -> 216.19.2.116`, re-applying the base helper still returned `getConnectionInfo(): { type: 'ip', ip: '216.19.2.116', domain: 'onekeytest.com' }`.
