### PR TITLE
feat: add native TradingView interval preferences

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewNativeChartControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewNativeChartControls.tsx
@@ -130,6 +130,35 @@ const MAIN_CHART_INDICATOR_LABEL_SET = new Set<string>(
   MAIN_CHART_INDICATOR_LABELS,
 );
 
+function getAppNativeIndicatorValue(indicator: ITradingViewIndicatorOption) {
+  if (APP_NATIVE_INDICATOR_VALUE_SET.has(indicator.label)) {
+    return indicator.label;
+  }
+
+  if (APP_NATIVE_INDICATOR_VALUE_SET.has(indicator.value)) {
+    return indicator.value;
+  }
+
+  return null;
+}
+
+function getActiveIndicatorValueSet(
+  indicators: ITradingViewIndicatorOption[] | undefined,
+) {
+  const activeValues = new Set<string>();
+  indicators?.forEach((indicator) => {
+    if (!indicator.active) {
+      return;
+    }
+
+    const indicatorValue = getAppNativeIndicatorValue(indicator);
+    if (indicatorValue) {
+      activeValues.add(indicatorValue);
+    }
+  });
+  return activeValues;
+}
+
 function getIndicatorSections(indicators: ITradingViewIndicatorOption[]) {
   const mainIndicators: ITradingViewIndicatorOption[] = [];
   const subIndicators: ITradingViewIndicatorOption[] = [];
@@ -552,20 +581,23 @@ export const TradingViewNativeChartControls = memo(
     const [activeIndicatorValues, setActiveIndicatorValues] = useState(
       () => new Set<string>(),
     );
+    const pendingIndicatorActiveStateRef = useRef(new Map<string, boolean>());
     useEffect(() => {
-      const activeValues = new Set<string>();
-      nativeChartControlsConfig?.indicators.forEach((indicator) => {
-        if (!indicator.active) {
-          return;
+      const activeValues = getActiveIndicatorValueSet(
+        nativeChartControlsConfig?.indicators,
+      );
+      const pendingActiveState = pendingIndicatorActiveStateRef.current;
+      pendingActiveState.forEach((desiredActive, indicatorValue) => {
+        if (activeValues.has(indicatorValue) === desiredActive) {
+          pendingActiveState.delete(indicatorValue);
         }
+      });
 
-        if (APP_NATIVE_INDICATOR_VALUE_SET.has(indicator.label)) {
-          activeValues.add(indicator.label);
-          return;
-        }
-
-        if (APP_NATIVE_INDICATOR_VALUE_SET.has(indicator.value)) {
-          activeValues.add(indicator.value);
+      pendingActiveState.forEach((desiredActive, indicatorValue) => {
+        if (desiredActive) {
+          activeValues.add(indicatorValue);
+        } else {
+          activeValues.delete(indicatorValue);
         }
       });
       setActiveIndicatorValues(activeValues);
@@ -633,6 +665,10 @@ export const TradingViewNativeChartControls = memo(
 
     const handleNativeIndicatorSelect = useCallback(
       (indicatorName: string, desiredActive: boolean) => {
+        pendingIndicatorActiveStateRef.current.set(
+          indicatorName,
+          desiredActive,
+        );
         setActiveIndicatorValues((currentValues) => {
           const nextValues = new Set(currentValues);
           if (desiredActive) {

--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewNativeChartControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewNativeChartControls.tsx
@@ -418,12 +418,13 @@ function ChartSettingsSegmentedControl<
             borderWidth={1}
             borderRadius="$full"
             borderCurve="continuous"
-            borderColor={isActive ? '$borderStrong' : 'transparent'}
+            borderColor={isActive ? '$bgReverse' : 'transparent'}
             alignItems="center"
             justifyContent="center"
-            bg={isActive ? '$bgStrong' : '$transparent'}
-            hoverStyle={{ bg: isActive ? '$bgStrongHover' : '$bgHover' }}
-            pressStyle={{ bg: isActive ? '$bgStrongActive' : '$bgActive' }}
+            bg="$bgStrong"
+            overflow="hidden"
+            hoverStyle={{ bg: '$bgStrongHover' }}
+            pressStyle={{ bg: '$bgStrongActive' }}
             cursor="pointer"
             userSelect="none"
             onPress={() => {

--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewNativeChartControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewNativeChartControls.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 
 import { useIntl } from 'react-intl';
@@ -27,7 +27,6 @@ import type {
   ITradingViewPriceScaleMode,
 } from './types';
 
-const EMPTY_INDICATORS: ITradingViewIndicatorOption[] = [];
 type IChartSettingsSegmentValue = number | string;
 
 interface ITradingViewNativeChartControlsProps {
@@ -95,6 +94,183 @@ const HEADER_ICON_BUTTON_STYLE_PROPS = {
   },
 } as const;
 
+const INDICATOR_GRID_COLUMN_COUNT = 4;
+const INDICATOR_GRID_ITEM_LAYOUT_PROPS = {
+  flex: 1,
+  flexBasis: 0,
+  h: 32,
+  minWidth: 0,
+  px: '$2',
+  borderWidth: 1,
+} as const;
+const APP_NATIVE_INDICATOR_OPTIONS: ITradingViewIndicatorOption[] = [
+  { label: 'MA', value: 'MA' },
+  { label: 'EMA', value: 'EMA' },
+  { label: 'BOLL', value: 'BOLL' },
+  { label: 'SAR', value: 'SAR' },
+  { label: 'VOL', value: 'VOL' },
+  { label: 'MACD', value: 'MACD' },
+  { label: 'RSI', value: 'RSI' },
+  { label: 'StochRSI', value: 'StochRSI' },
+  { label: 'OBV', value: 'OBV' },
+  { label: 'MFI', value: 'MFI' },
+  { label: 'TRIX', value: 'TRIX' },
+  { label: 'EMV', value: 'EMV' },
+  { label: 'WR', value: 'WR' },
+  { label: 'ROC', value: 'ROC' },
+  { label: 'MTM', value: 'MTM' },
+  { label: 'DMI', value: 'DMI' },
+  { label: 'CCI', value: 'CCI' },
+];
+const APP_NATIVE_INDICATOR_VALUE_SET = new Set(
+  APP_NATIVE_INDICATOR_OPTIONS.map((indicator) => indicator.value),
+);
+const MAIN_CHART_INDICATOR_LABELS = ['MA', 'EMA', 'BOLL', 'SAR'];
+const MAIN_CHART_INDICATOR_LABEL_SET = new Set<string>(
+  MAIN_CHART_INDICATOR_LABELS,
+);
+
+function getIndicatorSections(indicators: ITradingViewIndicatorOption[]) {
+  const mainIndicators: ITradingViewIndicatorOption[] = [];
+  const subIndicators: ITradingViewIndicatorOption[] = [];
+
+  indicators.forEach((indicator) => {
+    if (MAIN_CHART_INDICATOR_LABEL_SET.has(indicator.label)) {
+      mainIndicators.push(indicator);
+    } else {
+      subIndicators.push(indicator);
+    }
+  });
+
+  return {
+    mainIndicators,
+    subIndicators,
+  };
+}
+
+function IndicatorPill({
+  indicator,
+  isActive,
+  onPress,
+}: {
+  indicator: ITradingViewIndicatorOption;
+  isActive: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <XStack
+      key={indicator.value}
+      testID={buildIndicatorItemTestID(indicator.value)}
+      {...INDICATOR_GRID_ITEM_LAYOUT_PROPS}
+      borderRadius="$full"
+      borderCurve="continuous"
+      borderColor={isActive ? '$bgReverse' : 'transparent'}
+      alignItems="center"
+      justifyContent="center"
+      bg="$bgStrong"
+      hoverStyle={{
+        bg: '$bgStrongHover',
+      }}
+      pressStyle={{
+        bg: '$bgStrongActive',
+      }}
+      cursor="pointer"
+      userSelect="none"
+      onPress={onPress}
+    >
+      <SizableText
+        size="$bodyMdMedium"
+        numberOfLines={1}
+        adjustsFontSizeToFit
+        minimumFontScale={0.82}
+        color={isActive ? '$text' : '$textSubdued'}
+      >
+        {indicator.label}
+      </SizableText>
+    </XStack>
+  );
+}
+
+function IndicatorGrid({
+  indicators,
+  activeIndicatorValues,
+  onIndicatorPress,
+}: {
+  indicators: ITradingViewIndicatorOption[];
+  activeIndicatorValues: Set<string>;
+  onIndicatorPress: (indicator: ITradingViewIndicatorOption) => void;
+}) {
+  const rows = useMemo(() => {
+    const result: ITradingViewIndicatorOption[][] = [];
+    for (
+      let index = 0;
+      index < indicators.length;
+      index += INDICATOR_GRID_COLUMN_COUNT
+    ) {
+      result.push(indicators.slice(index, index + INDICATOR_GRID_COLUMN_COUNT));
+    }
+    return result;
+  }, [indicators]);
+
+  return (
+    <YStack gap="$2">
+      {rows.map((row, rowIndex) => {
+        const placeholderCount = INDICATOR_GRID_COLUMN_COUNT - row.length;
+        return (
+          <XStack key={`indicator-row-${rowIndex}`} gap="$2">
+            {row.map((indicator) => (
+              <IndicatorPill
+                key={indicator.value}
+                indicator={indicator}
+                isActive={activeIndicatorValues.has(indicator.value)}
+                onPress={() => onIndicatorPress(indicator)}
+              />
+            ))}
+            {Array.from({ length: placeholderCount }).map((_, index) => (
+              <Stack
+                key={`indicator-placeholder-${rowIndex}-${index}`}
+                {...INDICATOR_GRID_ITEM_LAYOUT_PROPS}
+                borderColor="transparent"
+                opacity={0}
+                pointerEvents="none"
+              />
+            ))}
+          </XStack>
+        );
+      })}
+    </YStack>
+  );
+}
+
+function IndicatorSection({
+  title,
+  indicators,
+  activeIndicatorValues,
+  onIndicatorPress,
+}: {
+  title: string;
+  indicators: ITradingViewIndicatorOption[];
+  activeIndicatorValues: Set<string>;
+  onIndicatorPress: (indicator: ITradingViewIndicatorOption) => void;
+}) {
+  if (!indicators.length) {
+    return null;
+  }
+
+  return (
+    <YStack gap="$3">
+      <SizableText size="$bodyMd" color="$textSubdued">
+        {title}
+      </SizableText>
+      <IndicatorGrid
+        indicators={indicators}
+        activeIndicatorValues={activeIndicatorValues}
+        onIndicatorPress={onIndicatorPress}
+      />
+    </YStack>
+  );
+}
+
 function IndicatorListDialogContent({
   indicators,
   resetLayout,
@@ -118,6 +294,10 @@ function IndicatorListDialogContent({
   );
   const originalActiveIndicatorValuesRef = useRef(activeIndicatorValues);
   const activeIndicatorValuesRef = useRef(activeIndicatorValues);
+  const { mainIndicators, subIndicators } = useMemo(
+    () => getIndicatorSections(indicators),
+    [indicators],
+  );
 
   const handleIndicatorPress = useCallback(
     (indicator: ITradingViewIndicatorOption) => {
@@ -141,7 +321,7 @@ function IndicatorListDialogContent({
     indicators.forEach((indicator) => {
       const desiredActive = nextValues.has(indicator.value);
       if (originalValues.has(indicator.value) !== desiredActive) {
-        onSelect(indicator.value, desiredActive);
+        onSelect(indicator.label, desiredActive);
       }
     });
     void dialog.close();
@@ -150,20 +330,22 @@ function IndicatorListDialogContent({
   const confirmText = intl.formatMessage({
     id: ETranslations.global_confirm,
   });
+  const resetText = intl.formatMessage({
+    id: ETranslations.global_reset,
+  });
 
   const resetButton = resetLayout?.enabled ? (
     <Button
       flex={1}
       testID="trading-view-native-indicators-reset-layout-button"
       variant="secondary"
-      size="medium"
-      icon="RefreshCcwOutline"
+      size="large"
       onPress={() => {
         onResetLayout();
         void dialog.close();
       }}
     >
-      {resetLayout.label}
+      {resetText}
     </Button>
   ) : null;
 
@@ -172,7 +354,7 @@ function IndicatorListDialogContent({
       flex={1}
       testID="trading-view-native-indicators-confirm-button"
       variant="primary"
-      size="medium"
+      size="large"
       onPress={handleConfirmPress}
     >
       {confirmText}
@@ -180,52 +362,28 @@ function IndicatorListDialogContent({
   );
 
   return (
-    <Stack gap="$3">
-      <ScrollView maxHeight={240} showsVerticalScrollIndicator>
-        <XStack flexWrap="wrap" gap="$2" pb="$2">
-          {indicators.map((indicator) => {
-            const isActive = activeIndicatorValues.has(indicator.value);
-            return (
-              <XStack
-                key={indicator.value}
-                testID={buildIndicatorItemTestID(indicator.value)}
-                h={30}
-                minWidth={72}
-                px="$3"
-                borderRadius="$full"
-                borderCurve="continuous"
-                borderWidth={1}
-                borderColor={isActive ? '$borderStrong' : 'transparent'}
-                alignItems="center"
-                justifyContent="center"
-                bg={isActive ? '$bgStrong' : '$transparent'}
-                hoverStyle={{
-                  bg: isActive ? '$bgStrongHover' : '$bgHover',
-                }}
-                pressStyle={{
-                  bg: isActive ? '$bgStrongActive' : '$bgActive',
-                }}
-                cursor="pointer"
-                userSelect="none"
-                onPress={() => handleIndicatorPress(indicator)}
-              >
-                <SizableText
-                  size="$bodyMdMedium"
-                  numberOfLines={1}
-                  color={isActive ? '$text' : '$textSubdued'}
-                >
-                  {indicator.label}
-                </SizableText>
-              </XStack>
-            );
-          })}
-        </XStack>
+    <YStack gap="$6" pb="$2">
+      <ScrollView maxHeight={320} showsVerticalScrollIndicator={false}>
+        <YStack gap="$6">
+          <IndicatorSection
+            title="Main-chart indicators"
+            indicators={mainIndicators}
+            activeIndicatorValues={activeIndicatorValues}
+            onIndicatorPress={handleIndicatorPress}
+          />
+          <IndicatorSection
+            title="Sub-chart indicators"
+            indicators={subIndicators}
+            activeIndicatorValues={activeIndicatorValues}
+            onIndicatorPress={handleIndicatorPress}
+          />
+        </YStack>
       </ScrollView>
-      <XStack gap="$2">
+      <XStack gap="$3" pt="$2">
         {resetButton}
         {confirmButton}
       </XStack>
-    </Stack>
+    </YStack>
   );
 }
 
@@ -390,6 +548,27 @@ export const TradingViewNativeChartControls = memo(
     onPriceScaleModeChange,
     onPriceMarketCapModeChange,
   }: ITradingViewNativeChartControlsProps) => {
+    const [activeIndicatorValues, setActiveIndicatorValues] = useState(
+      () => new Set<string>(),
+    );
+    useEffect(() => {
+      const activeValues = new Set<string>();
+      nativeChartControlsConfig?.indicators.forEach((indicator) => {
+        if (!indicator.active) {
+          return;
+        }
+
+        if (APP_NATIVE_INDICATOR_VALUE_SET.has(indicator.label)) {
+          activeValues.add(indicator.label);
+          return;
+        }
+
+        if (APP_NATIVE_INDICATOR_VALUE_SET.has(indicator.value)) {
+          activeValues.add(indicator.value);
+        }
+      });
+      setActiveIndicatorValues(activeValues);
+    }, [nativeChartControlsConfig?.indicators]);
     const chartTypesEnabled =
       nativeChartControlsConfig?.chartTypesEnabled !== false;
     const chartTypes = useMemo(
@@ -411,8 +590,14 @@ export const TradingViewNativeChartControls = memo(
     const chartTypeToggleIcon = isLineChartType
       ? 'TradingViewLineOutline'
       : 'TradingViewCandlesOutline';
-    const indicators =
-      nativeChartControlsConfig?.indicators ?? EMPTY_INDICATORS;
+    const indicators = useMemo(
+      () =>
+        APP_NATIVE_INDICATOR_OPTIONS.map((indicator) => ({
+          ...indicator,
+          active: activeIndicatorValues.has(indicator.value),
+        })),
+      [activeIndicatorValues],
+    );
     const indicatorsEnabled =
       nativeChartControlsConfig?.indicatorsEnabled !== false;
     const resetLayout = nativeChartControlsConfig?.resetLayout;
@@ -435,13 +620,31 @@ export const TradingViewNativeChartControls = memo(
     const hasVisibleIntervalSelector =
       getValidIntervalOptionCount(intervalConfig) > 1;
     const hasVisibleIndicators = Boolean(
-      nativeChartControlsConfig && indicatorsEnabled && indicators.length,
+      nativeChartControlsConfig &&
+      indicatorsEnabled &&
+      APP_NATIVE_INDICATOR_OPTIONS.length,
     );
     const hasVisibleControls =
       hasVisibleIntervalSelector ||
       canToggleChartType ||
       settingsEnabled ||
       hasVisibleIndicators;
+
+    const handleNativeIndicatorSelect = useCallback(
+      (indicatorName: string, desiredActive: boolean) => {
+        setActiveIndicatorValues((currentValues) => {
+          const nextValues = new Set(currentValues);
+          if (desiredActive) {
+            nextValues.add(indicatorName);
+          } else {
+            nextValues.delete(indicatorName);
+          }
+          return nextValues;
+        });
+        onIndicatorSelect(indicatorName, desiredActive);
+      },
+      [onIndicatorSelect],
+    );
 
     const showIndicatorsDialog = useCallback(() => {
       Dialog.show({
@@ -452,12 +655,12 @@ export const TradingViewNativeChartControls = memo(
           <IndicatorListDialogContent
             indicators={indicators}
             resetLayout={resetLayout}
-            onSelect={onIndicatorSelect}
+            onSelect={handleNativeIndicatorSelect}
             onResetLayout={onResetLayout}
           />
         ),
       });
-    }, [indicators, onIndicatorSelect, onResetLayout, resetLayout]);
+    }, [handleNativeIndicatorSelect, indicators, onResetLayout, resetLayout]);
 
     const showChartSettingsDialog = useCallback(() => {
       if (!settingsEnabled) {

--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewNativeIntervalSelector.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewNativeIntervalSelector.tsx
@@ -1,16 +1,21 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import type { ISelectItem } from '@onekeyhq/components';
 import {
+  Button,
+  Dialog,
   Icon,
   SegmentControl,
-  Select,
   SizableText,
+  Stack,
   XStack,
+  YStack,
+  useDialogInstance,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import appStorage from '@onekeyhq/shared/src/storage/appStorage';
 
 import type {
   ITradingViewIntervalConfigData,
@@ -18,18 +23,45 @@ import type {
 } from './types';
 
 const MAX_VISIBLE_INTERVAL_COUNT = 3;
-
-const INTERVAL_UNIT_LABELS = {
-  m: 'minute',
-  h: 'hour',
-  d: 'day',
-  w: 'week',
-  M: 'month',
+const MAX_PREFERRED_INTERVAL_COUNT = 4;
+const INTERVAL_GRID_COLUMN_COUNT = 4;
+const INTERVAL_GRID_ITEM_LAYOUT_PROPS = {
+  flex: 1,
+  flexBasis: 0,
+  h: 32,
+  minWidth: 0,
+  px: '$3',
+  borderWidth: 1,
 } as const;
+const PREFERRED_INTERVAL_STORAGE_KEY =
+  'trading_view_native_preferred_intervals_v1';
+const DEFAULT_PREFERRED_INTERVAL_LABELS = ['1m', '15m', '1H', '4H'];
+const ALL_INTERVAL_OPTION_TEMPLATES = [
+  { label: '1m', fallbackValue: '1' },
+  { label: '3m', fallbackValue: '3' },
+  { label: '5m', fallbackValue: '5' },
+  { label: '15m', fallbackValue: '15' },
+  { label: '30m', fallbackValue: '30' },
+  { label: '1H', fallbackValue: '60' },
+  { label: '2H', fallbackValue: '120' },
+  { label: '4H', fallbackValue: '240' },
+  { label: '8H', fallbackValue: '480' },
+  { label: '12H', fallbackValue: '720' },
+  { label: '1D', fallbackValue: '1D' },
+  { label: '3D', fallbackValue: '3D' },
+  { label: '1W', fallbackValue: '1W' },
+  { label: '1M', fallbackValue: '1M' },
+] as const;
 
 interface ITradingViewNativeIntervalSelectorProps {
   intervalConfig: ITradingViewIntervalConfigData | null;
   onIntervalChange: (interval: string) => void;
+}
+
+function buildIntervalItemTestID(section: string, value: string): string {
+  return `trading-view-native-interval-${section}-${value
+    .replace(/[^a-zA-Z0-9_-]/g, '-')
+    .slice(0, 80)}`;
 }
 
 function normalizeIntervalOptions(
@@ -45,73 +77,586 @@ function normalizeIntervalOptions(
       }
 
       seenValues.add(value);
-      result.push({ label, value });
+      result.push({
+        label,
+        value,
+        ...(option.disabled === undefined ? {} : { disabled: option.disabled }),
+      });
       return result;
     },
     [],
   );
 }
 
-function getPluralizedIntervalUnit(
-  unit: keyof typeof INTERVAL_UNIT_LABELS,
-  count: number,
-) {
-  const unitLabel = INTERVAL_UNIT_LABELS[unit];
-  return count === 1 ? unitLabel : `${unitLabel}s`;
+function isIntervalOptionDisabled(option: ITradingViewIntervalOption) {
+  return option.disabled === true;
 }
 
-function getIntervalLabelParts(option: ITradingViewIntervalOption) {
-  const labelMatch = option.label.match(/^(\d+)\s*([mhdwHDWM])$/);
-  if (labelMatch) {
-    const count = Number(labelMatch[1]);
-    const rawUnit = labelMatch[2];
-    const unit = (
-      rawUnit === 'M' ? rawUnit : rawUnit.toLowerCase()
-    ) as keyof typeof INTERVAL_UNIT_LABELS;
-    if (Number.isFinite(count) && count > 0 && unit in INTERVAL_UNIT_LABELS) {
-      return { count, unit };
+function normalizeIntervalLabel(label: string) {
+  const normalizedLabel = label.replace(/\s/g, '');
+  const labelMatch = normalizedLabel.match(/^(\d+)([a-zA-Z]+)$/);
+  if (!labelMatch) {
+    return normalizedLabel;
+  }
+
+  const [, count, unit] = labelMatch;
+  if (unit === 'M') {
+    return `${count}M`;
+  }
+
+  const normalizedUnit = unit.toLowerCase();
+  if (normalizedUnit === 'm') {
+    return `${count}m`;
+  }
+  if (normalizedUnit === 'h') {
+    return `${count}H`;
+  }
+  if (normalizedUnit === 'd') {
+    return `${count}D`;
+  }
+  if (normalizedUnit === 'w') {
+    return `${count}W`;
+  }
+
+  return normalizedLabel;
+}
+
+function getAllIntervalOptions(options: ITradingViewIntervalOption[]) {
+  const optionsByLabel = new Map<string, ITradingViewIntervalOption>();
+  const optionsByValue = new Map<string, ITradingViewIntervalOption>();
+  options.forEach((option) => {
+    const normalizedLabel = normalizeIntervalLabel(option.label);
+    const existingOption = optionsByLabel.get(normalizedLabel);
+    if (!existingOption || isIntervalOptionDisabled(existingOption)) {
+      optionsByLabel.set(normalizedLabel, option);
     }
-  }
 
-  const valueMatch = option.value.match(/^(\d+)([HDWM])?$/);
-  if (!valueMatch) {
-    return null;
-  }
+    const existingValueOption = optionsByValue.get(option.value);
+    if (!existingValueOption || isIntervalOptionDisabled(existingValueOption)) {
+      optionsByValue.set(option.value, option);
+    }
+  });
 
-  const rawCount = Number(valueMatch[1]);
-  if (!Number.isFinite(rawCount) || rawCount <= 0) {
-    return null;
-  }
+  const seenValues = new Set<string>();
+  const seenLabels = new Set<string>();
+  const allOptions: ITradingViewIntervalOption[] =
+    ALL_INTERVAL_OPTION_TEMPLATES.map((template) => {
+      const normalizedLabel = normalizeIntervalLabel(template.label);
+      const matchedOption =
+        optionsByLabel.get(normalizedLabel) ??
+        optionsByValue.get(template.fallbackValue);
+      const option = matchedOption
+        ? {
+            ...matchedOption,
+            label: template.label,
+          }
+        : {
+            label: template.label,
+            value: template.fallbackValue,
+            disabled: true,
+          };
 
-  const valueUnit = valueMatch[2];
-  if (valueUnit === 'D') {
-    return { count: rawCount, unit: 'd' as const };
-  }
-  if (valueUnit === 'W') {
-    return { count: rawCount, unit: 'w' as const };
-  }
-  if (valueUnit === 'M') {
-    return { count: rawCount, unit: 'M' as const };
-  }
-  if (valueUnit === 'H') {
-    return { count: rawCount, unit: 'h' as const };
-  }
-  if (rawCount >= 60 && rawCount % 60 === 0) {
-    return { count: rawCount / 60, unit: 'h' as const };
-  }
-  return { count: rawCount, unit: 'm' as const };
+      seenLabels.add(normalizedLabel);
+      seenValues.add(option.value);
+      return option;
+    });
+
+  options.forEach((option) => {
+    const normalizedLabel = normalizeIntervalLabel(option.label);
+    if (seenLabels.has(normalizedLabel) || seenValues.has(option.value)) {
+      return;
+    }
+    seenLabels.add(normalizedLabel);
+    seenValues.add(option.value);
+    allOptions.push(option);
+  });
+
+  return allOptions;
 }
 
-function getFullIntervalLabel(option: ITradingViewIntervalOption) {
-  const labelParts = getIntervalLabelParts(option);
-  if (!labelParts) {
-    return option.label;
+function getDefaultPreferredIntervalValues(
+  options: ITradingViewIntervalOption[],
+) {
+  const defaultValues = DEFAULT_PREFERRED_INTERVAL_LABELS.reduce<string[]>(
+    (result, label) => {
+      const normalizedLabel = normalizeIntervalLabel(label);
+      const matchedOption = options.find(
+        (option) =>
+          !isIntervalOptionDisabled(option) &&
+          normalizeIntervalLabel(option.label) === normalizedLabel,
+      );
+      if (matchedOption && !result.includes(matchedOption.value)) {
+        result.push(matchedOption.value);
+      }
+      return result;
+    },
+    [],
+  );
+
+  options.forEach((option) => {
+    if (
+      defaultValues.length < MAX_PREFERRED_INTERVAL_COUNT &&
+      !isIntervalOptionDisabled(option) &&
+      !defaultValues.includes(option.value)
+    ) {
+      defaultValues.push(option.value);
+    }
+  });
+
+  return defaultValues.slice(0, MAX_PREFERRED_INTERVAL_COUNT);
+}
+
+function reconcileIntervalValues(
+  values: string[] | null | undefined,
+  options: ITradingViewIntervalOption[],
+) {
+  if (!values?.length) {
+    return [];
   }
 
-  return `${labelParts.count} ${getPluralizedIntervalUnit(
-    labelParts.unit,
-    labelParts.count,
-  )}`;
+  const optionValueSet = new Set(
+    options
+      .filter((option) => !isIntervalOptionDisabled(option))
+      .map((option) => option.value),
+  );
+  const seenValues = new Set<string>();
+  return values.reduce<string[]>((result, value) => {
+    const normalizedValue = value.trim();
+    if (
+      !normalizedValue ||
+      seenValues.has(normalizedValue) ||
+      !optionValueSet.has(normalizedValue)
+    ) {
+      return result;
+    }
+
+    seenValues.add(normalizedValue);
+    result.push(normalizedValue);
+    return result;
+  }, []);
+}
+
+function sortIntervalValues(
+  values: string[],
+  options: ITradingViewIntervalOption[],
+) {
+  const optionOrderMap = new Map<string, number>();
+  options.forEach((option, index) => {
+    optionOrderMap.set(option.value, index);
+  });
+
+  return values.toSorted(
+    (valueA, valueB) =>
+      (optionOrderMap.get(valueA) ?? Number.MAX_SAFE_INTEGER) -
+      (optionOrderMap.get(valueB) ?? Number.MAX_SAFE_INTEGER),
+  );
+}
+
+function parseStoredPreferredIntervalValues(rawValue: string | null) {
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsedValue = JSON.parse(rawValue) as
+      | { values?: unknown }
+      | unknown[];
+    const values = Array.isArray(parsedValue)
+      ? parsedValue
+      : parsedValue.values;
+    if (!Array.isArray(values)) {
+      return null;
+    }
+
+    return values.filter((value): value is string => typeof value === 'string');
+  } catch {
+    return null;
+  }
+}
+
+async function readStoredPreferredIntervalValues() {
+  try {
+    const rawValue = await appStorage.getItem(PREFERRED_INTERVAL_STORAGE_KEY);
+    return parseStoredPreferredIntervalValues(rawValue);
+  } catch {
+    return null;
+  }
+}
+
+async function saveStoredPreferredIntervalValues(values: string[]) {
+  try {
+    await appStorage.setItem(
+      PREFERRED_INTERVAL_STORAGE_KEY,
+      JSON.stringify({
+        values,
+      }),
+    );
+  } catch {
+    // UI preference only; keep the in-memory state if storage is unavailable.
+  }
+}
+
+function getOptionsByValues(
+  values: string[],
+  options: ITradingViewIntervalOption[],
+) {
+  return values
+    .map((value) => options.find((option) => option.value === value))
+    .filter((option): option is ITradingViewIntervalOption => Boolean(option));
+}
+
+function IntervalPill({
+  option,
+  section,
+  isActive,
+  isSelected,
+  showCheckMark,
+  disabled,
+  onPress,
+}: {
+  option: ITradingViewIntervalOption;
+  section: string;
+  isActive: boolean;
+  isSelected?: boolean;
+  showCheckMark?: boolean;
+  disabled?: boolean;
+  onPress: () => void;
+}) {
+  const isHighlighted = isActive || Boolean(isSelected);
+  let textColor = '$textSubdued';
+  if (disabled) {
+    textColor = '$textDisabled';
+  } else if (isHighlighted) {
+    textColor = '$text';
+  }
+
+  return (
+    <Stack
+      key={option.value}
+      testID={buildIntervalItemTestID(section, option.value)}
+      position="relative"
+      {...INTERVAL_GRID_ITEM_LAYOUT_PROPS}
+      borderRadius="$full"
+      borderCurve="continuous"
+      borderColor={isHighlighted && !disabled ? '$bgReverse' : 'transparent'}
+      alignItems="center"
+      justifyContent="center"
+      bg="$bgStrong"
+      overflow="hidden"
+      hoverStyle={{
+        bg: '$bgStrongHover',
+      }}
+      pressStyle={{
+        bg: '$bgStrongActive',
+      }}
+      opacity={disabled ? 0.5 : 1}
+      cursor={disabled ? 'not-allowed' : 'pointer'}
+      userSelect="none"
+      onPress={disabled ? undefined : onPress}
+    >
+      <SizableText
+        size="$bodyLgMedium"
+        color={textColor}
+        numberOfLines={1}
+        adjustsFontSizeToFit
+        minimumFontScale={0.82}
+      >
+        {option.label}
+      </SizableText>
+      {showCheckMark && !disabled ? (
+        <Stack
+          position="absolute"
+          right={-1}
+          top={-1}
+          w={19}
+          h={19}
+          borderBottomLeftRadius={12}
+          borderCurve="continuous"
+          bg="$bgReverse"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Icon name="Checkmark1SmallOutline" size="$4" color="$iconInverse" />
+        </Stack>
+      ) : null}
+    </Stack>
+  );
+}
+
+function IntervalGrid({
+  options,
+  activeInterval,
+  selectedValues,
+  section,
+  showSelectedCheckMarks,
+  highlightActiveInterval = true,
+  maxSelectedCount,
+  onIntervalPress,
+}: {
+  options: ITradingViewIntervalOption[];
+  activeInterval: string;
+  selectedValues?: Set<string>;
+  section: string;
+  showSelectedCheckMarks?: boolean;
+  highlightActiveInterval?: boolean;
+  maxSelectedCount?: number;
+  onIntervalPress: (option: ITradingViewIntervalOption) => void;
+}) {
+  const isSelectionLimitReached =
+    maxSelectedCount !== undefined &&
+    (selectedValues?.size ?? 0) >= maxSelectedCount;
+  const rows = useMemo(() => {
+    const result: ITradingViewIntervalOption[][] = [];
+    for (
+      let index = 0;
+      index < options.length;
+      index += INTERVAL_GRID_COLUMN_COUNT
+    ) {
+      result.push(options.slice(index, index + INTERVAL_GRID_COLUMN_COUNT));
+    }
+    return result;
+  }, [options]);
+
+  return (
+    <YStack gap="$2.5">
+      {rows.map((row, rowIndex) => {
+        const placeholderCount = INTERVAL_GRID_COLUMN_COUNT - row.length;
+        return (
+          <XStack key={`${section}-row-${rowIndex}`} gap="$2.5">
+            {row.map((option) => {
+              const isSelected = selectedValues?.has(option.value) ?? false;
+              const isDisabled =
+                isIntervalOptionDisabled(option) ||
+                (isSelectionLimitReached && !isSelected);
+              return (
+                <IntervalPill
+                  key={option.value}
+                  option={option}
+                  section={section}
+                  isActive={
+                    highlightActiveInterval && option.value === activeInterval
+                  }
+                  isSelected={isSelected}
+                  showCheckMark={showSelectedCheckMarks && isSelected}
+                  disabled={isDisabled}
+                  onPress={() => {
+                    if (!isDisabled) {
+                      onIntervalPress(option);
+                    }
+                  }}
+                />
+              );
+            })}
+            {Array.from({ length: placeholderCount }).map((_, index) => (
+              <Stack
+                key={`${section}-placeholder-${rowIndex}-${index}`}
+                {...INTERVAL_GRID_ITEM_LAYOUT_PROPS}
+                borderColor="transparent"
+                opacity={0}
+                pointerEvents="none"
+              />
+            ))}
+          </XStack>
+        );
+      })}
+    </YStack>
+  );
+}
+
+function IntervalsDialogSection({
+  title,
+  children,
+  action,
+}: {
+  title: string;
+  children: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <YStack gap="$3">
+      <XStack alignItems="center" justifyContent="space-between">
+        <SizableText size="$bodyLg" color="$textSubdued">
+          {title}
+        </SizableText>
+        {action}
+      </XStack>
+      {children}
+    </YStack>
+  );
+}
+
+function IntervalsDialogContent({
+  options,
+  editableOptions,
+  activeInterval,
+  preferredValues,
+  defaultPreferredValues,
+  onIntervalChange,
+  onPreferredValuesChange,
+}: {
+  options: ITradingViewIntervalOption[];
+  editableOptions: ITradingViewIntervalOption[];
+  activeInterval: string;
+  preferredValues: string[];
+  defaultPreferredValues: string[];
+  onIntervalChange: (interval: string) => void;
+  onPreferredValuesChange: (values: string[]) => void;
+}) {
+  const intl = useIntl();
+  const dialog = useDialogInstance();
+  const [isEditing, setIsEditing] = useState(false);
+  const [draftPreferredValues, setDraftPreferredValues] =
+    useState(preferredValues);
+  const draftPreferredValueSet = useMemo(
+    () => new Set(draftPreferredValues),
+    [draftPreferredValues],
+  );
+  const preferredOptions = useMemo(
+    () => getOptionsByValues(preferredValues, options),
+    [options, preferredValues],
+  );
+
+  const handleIntervalPress = useCallback(
+    (option: ITradingViewIntervalOption) => {
+      if (isIntervalOptionDisabled(option)) {
+        return;
+      }
+      onIntervalChange(option.value);
+      void dialog.close();
+    },
+    [dialog, onIntervalChange],
+  );
+
+  const handleDraftIntervalPress = useCallback(
+    (option: ITradingViewIntervalOption) => {
+      if (isIntervalOptionDisabled(option)) {
+        return;
+      }
+      setDraftPreferredValues((currentValues) => {
+        if (currentValues.includes(option.value)) {
+          return currentValues.filter((value) => value !== option.value);
+        }
+
+        if (currentValues.length >= MAX_PREFERRED_INTERVAL_COUNT) {
+          return currentValues;
+        }
+
+        return [...currentValues, option.value];
+      });
+    },
+    [],
+  );
+
+  const handleResetPress = useCallback(() => {
+    setDraftPreferredValues(defaultPreferredValues);
+  }, [defaultPreferredValues]);
+
+  const handleConfirmPress = useCallback(() => {
+    const reconciledValues = reconcileIntervalValues(
+      draftPreferredValues,
+      editableOptions,
+    );
+    if (reconciledValues.length) {
+      onPreferredValuesChange(
+        sortIntervalValues(reconciledValues, editableOptions).slice(
+          0,
+          MAX_PREFERRED_INTERVAL_COUNT,
+        ),
+      );
+      void dialog.close();
+    }
+  }, [dialog, draftPreferredValues, editableOptions, onPreferredValuesChange]);
+
+  if (isEditing) {
+    return (
+      <YStack gap="$5">
+        <SizableText size="$bodyLg" color="$text">
+          {`Select preferred intervals ${draftPreferredValues.length}/${MAX_PREFERRED_INTERVAL_COUNT}`}
+        </SizableText>
+        <IntervalGrid
+          options={editableOptions}
+          activeInterval={activeInterval}
+          selectedValues={draftPreferredValueSet}
+          section="edit"
+          showSelectedCheckMarks
+          highlightActiveInterval={false}
+          maxSelectedCount={MAX_PREFERRED_INTERVAL_COUNT}
+          onIntervalPress={handleDraftIntervalPress}
+        />
+        <XStack gap="$3" pt="$2">
+          <Button
+            flex={1}
+            size="large"
+            variant="secondary"
+            testID="trading-view-native-intervals-reset-button"
+            onPress={handleResetPress}
+          >
+            {intl.formatMessage({ id: ETranslations.global_reset })}
+          </Button>
+          <Button
+            flex={1}
+            size="large"
+            variant="primary"
+            testID="trading-view-native-intervals-confirm-button"
+            disabled={!draftPreferredValues.length}
+            onPress={handleConfirmPress}
+          >
+            {intl.formatMessage({ id: ETranslations.global_confirm })}
+          </Button>
+        </XStack>
+      </YStack>
+    );
+  }
+
+  return (
+    <YStack gap="$6">
+      {preferredOptions.length ? (
+        <IntervalsDialogSection title="Preferred intervals">
+          <IntervalGrid
+            options={preferredOptions}
+            activeInterval={activeInterval}
+            section="preferred"
+            onIntervalPress={handleIntervalPress}
+          />
+        </IntervalsDialogSection>
+      ) : null}
+
+      <IntervalsDialogSection
+        title="All intervals"
+        action={
+          <XStack
+            testID="trading-view-native-intervals-edit-button"
+            alignItems="center"
+            gap="$1"
+            px="$1"
+            py="$1"
+            cursor="pointer"
+            userSelect="none"
+            onPress={() => {
+              setDraftPreferredValues(preferredValues);
+              setIsEditing(true);
+            }}
+          >
+            <SizableText size="$bodyLg" color="$textSubdued">
+              {intl.formatMessage({ id: ETranslations.global_edit })}
+            </SizableText>
+            <Icon
+              name="ChevronRightSmallOutline"
+              size="$5"
+              color="$iconSubdued"
+            />
+          </XStack>
+        }
+      >
+        <IntervalGrid
+          options={options}
+          activeInterval={activeInterval}
+          section="all"
+          onIntervalPress={handleIntervalPress}
+        />
+      </IntervalsDialogSection>
+    </YStack>
+  );
 }
 
 export const TradingViewNativeIntervalSelector = memo(
@@ -120,11 +665,46 @@ export const TradingViewNativeIntervalSelector = memo(
     onIntervalChange,
   }: ITradingViewNativeIntervalSelectorProps) => {
     const intl = useIntl();
+    const [storedPreferredIntervalValues, setStoredPreferredIntervalValues] =
+      useState<string[] | null>(null);
+    const [
+      hasLoadedStoredPreferredIntervals,
+      setHasLoadedStoredPreferredIntervals,
+    ] = useState(false);
+    const hasUpdatedPreferredIntervalsRef = useRef(false);
+    const intervalsDialogRef = useRef<ReturnType<typeof Dialog.show> | null>(
+      null,
+    );
+
+    const closeIntervalsDialog = useCallback(() => {
+      const dialogInstance = intervalsDialogRef.current;
+      intervalsDialogRef.current = null;
+      void dialogInstance?.close();
+    }, []);
 
     const options = useMemo(
       () => normalizeIntervalOptions(intervalConfig?.intervals),
       [intervalConfig?.intervals],
     );
+
+    useEffect(() => {
+      let isMounted = true;
+      void readStoredPreferredIntervalValues()
+        .then((values) => {
+          if (isMounted && !hasUpdatedPreferredIntervalsRef.current) {
+            setStoredPreferredIntervalValues(values);
+          }
+        })
+        .finally(() => {
+          if (isMounted) {
+            setHasLoadedStoredPreferredIntervals(true);
+          }
+        });
+
+      return () => {
+        isMounted = false;
+      };
+    }, []);
 
     const activeInterval = useMemo(() => {
       const configuredInterval = intervalConfig?.activeInterval?.trim();
@@ -138,118 +718,192 @@ export const TradingViewNativeIntervalSelector = memo(
       return options[0]?.value ?? '';
     }, [intervalConfig?.activeInterval, options]);
 
+    const defaultPreferredIntervalValues = useMemo(
+      () => getDefaultPreferredIntervalValues(options),
+      [options],
+    );
+
+    const dialogOptions = useMemo(
+      () => getAllIntervalOptions(options),
+      [options],
+    );
+
+    const preferredIntervalValues = useMemo(() => {
+      const storedValues = hasLoadedStoredPreferredIntervals
+        ? storedPreferredIntervalValues
+        : null;
+      const reconciledStoredValues = reconcileIntervalValues(
+        storedValues,
+        options,
+      );
+      return reconciledStoredValues.length
+        ? sortIntervalValues(reconciledStoredValues, dialogOptions).slice(
+            0,
+            MAX_PREFERRED_INTERVAL_COUNT,
+          )
+        : defaultPreferredIntervalValues;
+    }, [
+      defaultPreferredIntervalValues,
+      hasLoadedStoredPreferredIntervals,
+      dialogOptions,
+      options,
+      storedPreferredIntervalValues,
+    ]);
+
+    const preferredOptions = useMemo(
+      () => getOptionsByValues(preferredIntervalValues, options),
+      [options, preferredIntervalValues],
+    );
+
     const segmentOptions = useMemo(
       () =>
-        options.slice(0, MAX_VISIBLE_INTERVAL_COUNT).map((option) => ({
+        preferredOptions.slice(0, MAX_VISIBLE_INTERVAL_COUNT).map((option) => ({
           label: option.label,
           value: option.value,
+          disabled: isIntervalOptionDisabled(option),
         })),
-      [options],
+      [preferredOptions],
     );
 
-    const dropdownShortOptions = useMemo(
-      () => options.slice(MAX_VISIBLE_INTERVAL_COUNT),
-      [options],
+    const visibleSegmentValueSet = useMemo(
+      () => new Set(segmentOptions.map((option) => option.value)),
+      [segmentOptions],
     );
 
-    const dropdownOptions = useMemo<ISelectItem[]>(
-      () =>
-        dropdownShortOptions.map((option) => ({
-          label: getFullIntervalLabel(option),
-          value: option.value,
-        })),
-      [dropdownShortOptions],
+    const activeOption = useMemo(
+      () => options.find((option) => option.value === activeInterval) ?? null,
+      [activeInterval, options],
     );
 
-    const activeDropdownOption = useMemo(
-      () =>
-        dropdownShortOptions.find(
-          (option) => option.value === activeInterval,
-        ) ?? null,
-      [activeInterval, dropdownShortOptions],
+    const handlePreferredValuesChange = useCallback(
+      (values: string[]) => {
+        const reconciledValues = reconcileIntervalValues(values, options);
+        const sortedValues = sortIntervalValues(
+          reconciledValues,
+          dialogOptions,
+        ).slice(0, MAX_PREFERRED_INTERVAL_COUNT);
+        hasUpdatedPreferredIntervalsRef.current = true;
+        setStoredPreferredIntervalValues(sortedValues);
+        setHasLoadedStoredPreferredIntervals(true);
+        void saveStoredPreferredIntervalValues(sortedValues);
+      },
+      [dialogOptions, options],
     );
 
     const moreLabel = intl.formatMessage({ id: ETranslations.global_more });
-    const hasDropdownOptions = dropdownOptions.length > 0;
-    const isDropdownActive = Boolean(activeDropdownOption);
+    const isMoreTriggerActive =
+      Boolean(activeOption) && !visibleSegmentValueSet.has(activeInterval);
+    const moreTriggerLabel = isMoreTriggerActive
+      ? (activeOption?.label ?? moreLabel)
+      : moreLabel;
 
-    if (segmentOptions.length <= 1 || !activeInterval) {
+    const showIntervalsDialog = useCallback(() => {
+      closeIntervalsDialog();
+      const dialogInstance = Dialog.show({
+        title: 'Intervals',
+        showFooter: false,
+        testID: 'trading-view-native-intervals-dialog',
+        onClose: () => {
+          if (intervalsDialogRef.current === dialogInstance) {
+            intervalsDialogRef.current = null;
+          }
+        },
+        renderContent: (
+          <IntervalsDialogContent
+            options={options}
+            editableOptions={dialogOptions}
+            activeInterval={activeInterval}
+            preferredValues={preferredIntervalValues}
+            defaultPreferredValues={defaultPreferredIntervalValues}
+            onIntervalChange={onIntervalChange}
+            onPreferredValuesChange={handlePreferredValuesChange}
+          />
+        ),
+      });
+      intervalsDialogRef.current = dialogInstance;
+    }, [
+      activeInterval,
+      closeIntervalsDialog,
+      defaultPreferredIntervalValues,
+      dialogOptions,
+      handlePreferredValuesChange,
+      onIntervalChange,
+      options,
+      preferredIntervalValues,
+    ]);
+
+    useEffect(() => closeIntervalsDialog, [closeIntervalsDialog]);
+
+    if (options.length <= 1 || !activeInterval) {
       return null;
     }
 
     return (
       <XStack gap="$0" alignItems="center">
-        <SegmentControl
-          value={isDropdownActive ? '' : activeInterval}
-          options={segmentOptions}
-          onChange={(value) => {
-            if (typeof value === 'string') {
-              onIntervalChange(value);
-            }
-          }}
-          slotBackgroundColor="$transparent"
-          activeBackgroundColor="$bgStrong"
-          activeTextColor="$text"
-          inactiveTextColor="$textSubdued"
-          h={30}
-          p="$0.5"
-          segmentControlItemStyleProps={{
-            minWidth: 42,
-            px: '$2.5',
-            py: '$1',
-          }}
-        />
-        {hasDropdownOptions ? (
-          <Select
-            testID="trading-view-native-interval-selector-more-select"
-            title={moreLabel}
-            items={dropdownOptions}
+        {segmentOptions.length ? (
+          <SegmentControl
             value={
-              typeof activeDropdownOption?.value === 'string'
-                ? activeDropdownOption.value
-                : undefined
+              visibleSegmentValueSet.has(activeInterval) ? activeInterval : ''
             }
+            options={segmentOptions}
             onChange={(value) => {
-              if (typeof value === 'string') {
+              const nextOption = options.find(
+                (option) => option.value === value,
+              );
+              if (
+                typeof value === 'string' &&
+                nextOption &&
+                !isIntervalOptionDisabled(nextOption)
+              ) {
                 onIntervalChange(value);
               }
             }}
-            placement="bottom-start"
-            floatingPanelProps={{ width: '$32' }}
-            renderTrigger={({ onPress }) => (
-              <XStack
-                h={30}
-                px="$2.5"
-                gap="$1"
-                alignItems="center"
-                borderRadius="$full"
-                borderCurve="continuous"
-                bg={isDropdownActive ? '$bgStrong' : '$transparent'}
-                hoverStyle={{
-                  bg: isDropdownActive ? '$bgStrongHover' : '$bgHover',
-                }}
-                pressStyle={{
-                  bg: isDropdownActive ? '$bgStrongActive' : '$bgActive',
-                }}
-                onPress={onPress}
-                cursor="pointer"
-                userSelect="none"
-              >
-                <SizableText
-                  size="$bodyMdMedium"
-                  numberOfLines={1}
-                  color={isDropdownActive ? '$text' : '$textSubdued'}
-                >
-                  {activeDropdownOption?.label ?? moreLabel}
-                </SizableText>
-                <Icon
-                  name="ChevronDownSmallOutline"
-                  size="$4"
-                  color={isDropdownActive ? '$icon' : '$iconSubdued'}
-                />
-              </XStack>
-            )}
+            slotBackgroundColor="$transparent"
+            activeBackgroundColor="$bgStrong"
+            activeTextColor="$text"
+            inactiveTextColor="$textSubdued"
+            h={30}
+            p="$0.5"
+            segmentControlItemStyleProps={{
+              minWidth: 42,
+              px: '$2.5',
+              py: '$1',
+            }}
           />
+        ) : null}
+        {options.length > segmentOptions.length ? (
+          <XStack
+            testID="trading-view-native-interval-selector-more-select"
+            h={30}
+            px="$2.5"
+            gap="$1"
+            alignItems="center"
+            borderRadius="$full"
+            borderCurve="continuous"
+            bg={isMoreTriggerActive ? '$bgStrong' : '$transparent'}
+            hoverStyle={{
+              bg: isMoreTriggerActive ? '$bgStrongHover' : '$bgHover',
+            }}
+            pressStyle={{
+              bg: isMoreTriggerActive ? '$bgStrongActive' : '$bgActive',
+            }}
+            onPress={showIntervalsDialog}
+            cursor="pointer"
+            userSelect="none"
+          >
+            <SizableText
+              size="$bodyMdMedium"
+              numberOfLines={1}
+              color={isMoreTriggerActive ? '$text' : '$textSubdued'}
+            >
+              {moreTriggerLabel}
+            </SizableText>
+            <Icon
+              name="ChevronDownSmallOutline"
+              size="$4"
+              color={isMoreTriggerActive ? '$icon' : '$iconSubdued'}
+            />
+          </XStack>
         ) : null}
       </XStack>
     );

--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewNativeIntervalSelector.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewNativeIntervalSelector.tsx
@@ -515,6 +515,10 @@ function IntervalsDialogContent({
     () => getOptionsByValues(preferredValues, options),
     [options, preferredValues],
   );
+  const reconciledDraftPreferredValues = useMemo(
+    () => reconcileIntervalValues(draftPreferredValues, editableOptions),
+    [draftPreferredValues, editableOptions],
+  );
 
   const handleIntervalPress = useCallback(
     (option: ITradingViewIntervalOption) => {
@@ -552,20 +556,21 @@ function IntervalsDialogContent({
   }, [defaultPreferredValues]);
 
   const handleConfirmPress = useCallback(() => {
-    const reconciledValues = reconcileIntervalValues(
-      draftPreferredValues,
-      editableOptions,
-    );
-    if (reconciledValues.length) {
+    if (reconciledDraftPreferredValues.length) {
       onPreferredValuesChange(
-        sortIntervalValues(reconciledValues, editableOptions).slice(
-          0,
-          MAX_PREFERRED_INTERVAL_COUNT,
-        ),
+        sortIntervalValues(
+          reconciledDraftPreferredValues,
+          editableOptions,
+        ).slice(0, MAX_PREFERRED_INTERVAL_COUNT),
       );
       void dialog.close();
     }
-  }, [dialog, draftPreferredValues, editableOptions, onPreferredValuesChange]);
+  }, [
+    dialog,
+    editableOptions,
+    onPreferredValuesChange,
+    reconciledDraftPreferredValues,
+  ]);
 
   if (isEditing) {
     return (
@@ -598,7 +603,7 @@ function IntervalsDialogContent({
             size="large"
             variant="primary"
             testID="trading-view-native-intervals-confirm-button"
-            disabled={!draftPreferredValues.length}
+            disabled={!reconciledDraftPreferredValues.length}
             onPress={handleConfirmPress}
           >
             {intl.formatMessage({ id: ETranslations.global_confirm })}

--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
@@ -200,21 +200,6 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
   );
   const handleNativeIndicatorSelect = useCallback(
     (indicatorName: string, desiredActive: boolean) => {
-      setNativeChartControlsConfig((prev) =>
-        prev
-          ? {
-              ...prev,
-              indicators: prev.indicators.map((indicator) =>
-                indicator.value === indicatorName
-                  ? {
-                      ...indicator,
-                      active: desiredActive,
-                    }
-                  : indicator,
-              ),
-            }
-          : prev,
-      );
       webRef.current?.sendMessageViaInjectedScript({
         type: TRADINGVIEW_INDICATOR_SELECT_MESSAGE,
         payload: {

--- a/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
@@ -21,6 +21,7 @@ import type {
   ITradingViewIndicatorsDialogData,
   ITradingViewInteractionOverlayData,
   ITradingViewIntervalConfigData,
+  ITradingViewIntervalOption,
   ITradingViewNativeChartControlsConfigData,
   ITradingViewPriceUpdateData,
   ITradingViewTouchScrollData,
@@ -265,6 +266,22 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+function normalizeStringOptionDisabled(option: Record<string, unknown>) {
+  if (typeof option.disabled === 'boolean') {
+    return option.disabled;
+  }
+  if (typeof option.enabled === 'boolean') {
+    return !option.enabled;
+  }
+  if (typeof option.available === 'boolean') {
+    return !option.available;
+  }
+  if (typeof option.selectable === 'boolean') {
+    return !option.selectable;
+  }
+  return undefined;
+}
+
 function normalizeStringOptions(
   options: unknown,
 ): { label: string; value: string }[] | null {
@@ -290,6 +307,26 @@ function normalizeStringOptions(
   return normalizedOptions;
 }
 
+function normalizeIntervalOptions(
+  options: unknown,
+): ITradingViewIntervalOption[] | null {
+  const normalizedOptions = normalizeStringOptions(options);
+  if (!normalizedOptions) {
+    return null;
+  }
+
+  return normalizedOptions.map((option, index) => {
+    const rawOption = Array.isArray(options) ? options[index] : null;
+    const disabled = isRecord(rawOption)
+      ? normalizeStringOptionDisabled(rawOption)
+      : undefined;
+    return {
+      ...option,
+      ...(disabled === undefined ? {} : { disabled }),
+    };
+  });
+}
+
 function normalizeIntervalConfig(
   data: unknown,
 ): ITradingViewIntervalConfigData | null {
@@ -297,7 +334,7 @@ function normalizeIntervalConfig(
     return null;
   }
 
-  const intervals = normalizeStringOptions(data.intervals);
+  const intervals = normalizeIntervalOptions(data.intervals);
   const activeInterval =
     typeof data.activeInterval === 'string' ? data.activeInterval.trim() : '';
   if (!intervals?.length || !activeInterval) {
@@ -514,7 +551,7 @@ function normalizeNativeChartControlsConfig(
   const intervals =
     data.intervals === undefined
       ? undefined
-      : normalizeStringOptions(data.intervals);
+      : normalizeIntervalOptions(data.intervals);
   if (data.intervals !== undefined && !intervals) {
     return null;
   }

--- a/packages/kit/src/components/TradingView/TradingViewV2/types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/types.ts
@@ -39,6 +39,7 @@ export interface ITradingViewPriceUpdateData {
 export interface ITradingViewIntervalOption {
   label: string;
   value: string;
+  disabled?: boolean;
 }
 
 export interface ITradingViewIntervalConfigData {


### PR DESCRIPTION

## Summary
- Adds a native intervals dialog with editable preferred intervals for TradingView V2.
- Persists preferred intervals in app storage only and keeps unavailable intervals disabled.
- Normalizes interval availability from both interval config and native chart controls config.

## Intent & Context
Users need a native intervals dialog matching the provided design, with preferred interval customization stored only in the app. The dialog must distinguish 1m from 1M, respect TradingView-provided interval availability, and avoid syncing favorite data back to TradingView.

## Root Cause
The existing native selector only exposed a segment control and more selector. It did not provide editable preferred intervals or app-local persistence, and interval availability from native chart controls was not preserved.

## Design Decisions
- Store preferred interval values under appStorage, not chart storage, to avoid syncing favorites with TradingView.
- Keep browse mode All intervals limited to TradingView-provided options, while edit mode uses the app-defined full interval set and disables unavailable items.
- Sort preferred intervals by the app interval order so selection order cannot create 1m, 1H, 15m.
- Use equal 4-column rows with transparent placeholders for strict grid alignment.
- Keep dialog lifecycle simple: close an existing dialog before opening a new one and close on unmount.

## Changes Detail
- TradingViewNativeIntervalSelector.tsx: implements native intervals dialog, edit mode, app-local persistence, sorted preferred intervals, disabled handling, strict grid layout, and theme-aware selected badges.
- useTradingViewMessageHandler.ts: parses interval disabled/enabled/available/selectable fields for both interval config and native chart controls config.
- types.ts: adds optional disabled flag to interval options.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Desktop, Web
- **Risk Areas**: Native dialog lifecycle, interval availability parsing, persisted UI preferences.

## Test plan
- [x] yarn lint:staged
- [x] yarn tsc:staged
- [x] tsgo -p ./tsconfig.json --noEmit --pretty false
- [x] oxlint --tsconfig ./tsconfig.json --type-aware changed files
- [x] git diff --check
- [ ] Manually verify light/dark selected badge style.
- [ ] Manually verify edit mode can clear all selections and Confirm is disabled while empty.
- [ ] Manually verify preferred intervals are sorted as 1m, 15m, 1H, 4H.
- [ ] Manually verify disabled intervals cannot be selected.
