### PR TITLE
fix: use 24h stock price change(OK-56541)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts
@@ -81,6 +81,30 @@ describe('stock metadata values', () => {
     expect(token.marketCap).toBe(3000);
     expect(token.turnover).toBe(4000);
   });
+
+  test('uses 24h price change for stock rows regardless of selected time range', () => {
+    const token = transformApiItemToToken(
+      {
+        address: '0x390a684ef9cade28a7ad0dfa61ab1eb3842618c4',
+        name: 'Stock Token',
+        symbol: 'STOCK',
+        decimals: 18,
+        priceChange1hPercent: '12.34',
+        priceChange24hPercent: '-0.62',
+        stock: {
+          subtitle: 'Stock Token Inc.',
+          sourceLogoUri: '',
+        },
+      },
+      {
+        chainId: 'evm--1',
+        networkLogoUri: '',
+        timeRange: '1h',
+      },
+    );
+
+    expect(token.change24h).toBe(-0.62);
+  });
 });
 
 describe('shouldShowStockSubtitleForTokens', () => {

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
@@ -164,11 +164,12 @@ export function transformApiItemToToken(
     ? getNetworkLogoUri(item.networkId)
     : networkLogoUri;
 
-  const priceChange = safeNumber(
-    getMetricValueByTimeRange(item, timeRange, 'priceChange', 'Percent') as
-      | string
-      | undefined,
-  );
+  const priceChangeValue = item.stock
+    ? item.priceChange24hPercent
+    : (getMetricValueByTimeRange(item, timeRange, 'priceChange', 'Percent') as
+        | string
+        | undefined);
+  const priceChange = safeNumber(priceChangeValue);
   const transactions = safeNumber(
     getMetricValueByTimeRange(item, timeRange, 'trade', 'Count') as
       | string


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56541](https://onekeyhq.atlassian.net/browse/OK-56541)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Use priceChange24hPercent for stock rows in the Market token list change field.
- Keep non-stock Market rows on the existing selected time-range change logic.
- Add a regression test for stock rows ignoring the selected time range.

## Intent & Context
OK-56541 fixes the stock tab change column shown in Market Home V2. The stock UI should display the stock asset's 24h change, and the highlighted desktop change column plus mobile badge both read from the same IMarketToken.change24h field.

## Root Cause
The Market token list converter populated change24h through the generic time-range helper for every token. Stock categories hide the time-range controls, but the list can still inherit the current timeRange, so stock rows could display a 1h or 4h percentage instead of priceChange24hPercent.

## Design Decisions
The fix is in transformApiItemToToken instead of the desktop cell renderer so desktop, mobile, and any other Market token list consumer stay consistent. Non-stock rows continue using the existing time-range based behavior.

## Changes Detail
- packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts: stock rows now map change24h from priceChange24hPercent.
- packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts: adds a regression test where a stock row with timeRange 1h still uses the 24h value.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web
- **Risk Areas**: Market Home V2 stock list value mapping only. Runtime impact is main/UI JS only; background API fetches, native resources, and bg/main shared native state are unchanged. The displayed token objects remain per-runtime JS-heap copies.

## Test plan
- [x] yarn jest packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts --runInBand
- [x] yarn lint:staged
- [x] yarn tsc:staged

[OK-56541]: https://onekeyhq.atlassian.net/browse/OK-56541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ