### PR TITLE
fix: android prime intro video clipping(OK-56464)

### DIFF
--- a/packages/kit/src/views/Prime/pages/PrimeFeatures/PrimeFeatureIntroContent.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeFeatures/PrimeFeatureIntroContent.tsx
@@ -96,6 +96,7 @@ const DIALOG_FOOTER_BOTTOM_PADDING = 20;
 const MOBILE_DIALOG_VIDEO_LOAD_DELAY_MS = 300;
 const VIDEO_END_PAUSE_MS = 1000;
 const VIDEO_POSTER_FADE_DURATION_MS = 220;
+const ANDROID_VIDEO_ACTIVATE_DELAY_MS = 120;
 const DIALOG_CONTENT_SWIPE_THRESHOLD = 32;
 const primeFeatureOverlayButtonIconProps = { color: '$whiteA10' } as const;
 const primeFeatureOverlayButtonHoverStyle = { bg: '$whiteA4' } as const;
@@ -236,6 +237,10 @@ const PrimeFeatureMedia = memo(function PrimeFeatureMedia({
 
     setShouldPlayVideo(true);
     posterOpacity.stopAnimation();
+    if (platformEnv.isNativeAndroid) {
+      posterOpacity.setValue(0);
+      return;
+    }
     Animated.timing(posterOpacity, {
       toValue: 0,
       duration: VIDEO_POSTER_FADE_DURATION_MS,
@@ -248,6 +253,7 @@ const PrimeFeatureMedia = memo(function PrimeFeatureMedia({
       return;
     }
 
+    let loadVideoTimer: ReturnType<typeof setTimeout> | undefined;
     const controller = videoLoopControllerRef.current;
     const wasActive = controller.isActive;
     controller.isActive = isActive;
@@ -255,18 +261,35 @@ const PrimeFeatureMedia = memo(function PrimeFeatureMedia({
     resetVideoToPoster();
     controller.hasHandledEnd = false;
 
-    if (isActive && canLoadVideo) {
+    const loadActiveVideo = () => {
       setShouldLoadVideo(true);
       if (!wasActive && videoRef.current) {
         videoRef.current.seek(0);
         videoRef.current.resume();
         showVideo();
       }
-    } else if (!canLoadVideo) {
+    };
+
+    if (isActive && canLoadVideo) {
+      if (platformEnv.isNativeAndroid && !wasActive) {
+        setShouldLoadVideo(false);
+        loadVideoTimer = setTimeout(
+          loadActiveVideo,
+          ANDROID_VIDEO_ACTIVATE_DELAY_MS,
+        );
+      } else {
+        loadActiveVideo();
+      }
+    } else if (!canLoadVideo || platformEnv.isNativeAndroid) {
       setShouldLoadVideo(false);
     }
 
-    return clearVideoEndTimer;
+    return () => {
+      if (loadVideoTimer) {
+        clearTimeout(loadVideoTimer);
+      }
+      clearVideoEndTimer();
+    };
   }, [
     canLoadVideo,
     clearVideoEndTimer,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56464](https://onekeyhq.atlassian.net/browse/OK-56464)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Fix Android-only Prime feature intro video clipping after horizontal swipes.
- Delay Android video mounting until the swiper cell has settled, while keeping the poster visible.
- Hide the Android poster overlay immediately once the video is ready to avoid a dim first frame.

## Intent & Context
OK-56464 reports that the Prime recording intro screen can show only the center portion of the video after swiping left or right. The issue was reproduced on a real Android device but not consistently on the emulator. The Address Risk Check feature branch is already included in the release branch, so this PR only extracts the Android video rendering fix for the hot-update branch.

## Root Cause
The RN view hierarchy and swiper clipping were ruled out with overlay probes: both inner and outer RN overlays remained fully visible while only the video content was clipped. The failure is Android-specific and appears after swiping, which points to ExoPlayer/PlayerView calculating its internal `cover` viewport while the horizontal FlashList/Swiper cell is still settling.

## Design Decisions
- Keep the fix local to `PrimeFeatureIntroContent.tsx` instead of changing global `Video`, `Swiper`, or `ListView` behavior.
- Gate the behavior with `platformEnv.isNativeAndroid` so iOS, desktop, web, and extension keep the existing behavior.
- Unmount inactive Android videos and mount the newly active Android video after a short delay so PlayerView calculates its viewport after the cell settles.
- Keep the poster visible during the delay, then hide it immediately on Android when the video is ready to avoid the previous dim fade effect.

## Changes Detail
- Added `ANDROID_VIDEO_ACTIVATE_DELAY_MS` for Android video activation after swiper changes.
- Updated the video activation effect to unload inactive Android videos and delay active Android video mounting.
- Updated Android poster overlay handling to hide immediately on `onReadyForDisplay`.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Android mobile only
- **Risk Areas**: The 120ms delay is a targeted workaround for Android native video timing. It has been verified on the reproducing device, but Android device timing can vary.

## Test plan
- [x] Reproduced the clipping on a real Android device before the fix.
- [x] Verified the clipping no longer appears after repeated left/right swipes on the same device.
- [x] Verified the temporary dim video effect is removed by hiding the Android poster immediately on video ready.
- [x] Ran `yarn lint:staged`.
- [x] Ran `yarn tsc:staged`.

[OK-56464]: https://onekeyhq.atlassian.net/browse/OK-56464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ