### PR TITLE
fix: market swap fiat value and wallet readiness(OK-56738, OK-56741, OK-56794)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
@@ -7,13 +7,22 @@ import { createStore } from 'jotai';
 
 import type { IAccountSelectorActiveAccountInfo } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import type { useSwapAddressInfo } from '@onekeyhq/kit/src/views/Swap/hooks/useSwapAccount';
+import { settingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
-import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
-import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
+import type {
+  ISwapNetwork,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
+import {
+  ESwapDirectionType,
+  ESwapSlippageSegmentKey,
+} from '@onekeyhq/shared/types/swap/types';
 
 import { useSwapActions } from './actions';
 import {
   ProviderJotaiContextSwap,
+  swapAlertsAtom,
+  swapNetworks,
   swapSelectFromTokenAtom,
   useSwapSelectFromTokenAtom,
   useSwapSelectedFromTokenBalanceAtom,
@@ -51,6 +60,11 @@ const ethToken: ISwapToken = {
   symbol: 'ETH',
   decimals: 18,
   isNative: true,
+};
+const evmSwapNetwork: ISwapNetwork = {
+  networkId: 'evm--1',
+  name: 'Ethereum',
+  symbol: 'ETH',
 };
 const evmAccount: INetworkAccount = {
   id: 'hd-1--m/44/60/0/0/0',
@@ -92,22 +106,35 @@ const fromAddressInfo: ISwapAddressInfo = {
   isAddressInfoReady: true,
 };
 
-function createWrapper() {
+function createWrapperWithStore() {
   const store = createStore();
   store.set(swapSelectFromTokenAtom(), ethToken);
 
-  return function Wrapper({ children }: { children?: ReactNode }) {
+  function Wrapper({ children }: { children?: ReactNode }) {
     return (
       <ProviderJotaiContextSwap store={store}>
         {children}
       </ProviderJotaiContextSwap>
     );
-  };
+  }
+
+  return { store, Wrapper };
+}
+
+function createWrapper() {
+  return createWrapperWithStore().Wrapper;
 }
 
 describe('useSwapActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(settingsAtom, 'get').mockResolvedValue({
+      swapEnableRecipientAddress: false,
+      swapIncognitoMode: false,
+      swapSlippagePercentageCustomValue: 0,
+      swapSlippagePercentageMode: ESwapSlippageSegmentKey.AUTO,
+      swapToAnotherAccountSwitchOn: false,
+    });
   });
 
   it('pins selected token detail price fetches to USD for rate-difference math', async () => {
@@ -154,5 +181,47 @@ describe('useSwapActions', () => {
     expect(result.current.fromToken?.price).toBe('3000');
     expect(result.current.fromToken?.currency).toBe('usd');
     expect(result.current.balance).toBe('1.23');
+  });
+
+  it('does not keep noConnectWallet warning when native wallet readiness is not proven', async () => {
+    const { store, Wrapper } = createWrapperWithStore();
+    store.set(swapNetworks(), [evmSwapNetwork]);
+    store.set(swapAlertsAtom(), {
+      states: [{ message: 'keep me' }, { noConnectWallet: true }],
+      quoteId: 'old-quote',
+    });
+
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.checkSwapWarning(fromAddressInfo, fromAddressInfo, {
+        allowNoConnectWallet: false,
+      });
+    });
+
+    expect(store.get(swapAlertsAtom()).states).toEqual([
+      { message: 'keep me' },
+    ]);
+  });
+
+  it('keeps noConnectWallet warning when the caller proves a real no-wallet state', async () => {
+    const { store, Wrapper } = createWrapperWithStore();
+    store.set(swapNetworks(), [evmSwapNetwork]);
+
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.checkSwapWarning(fromAddressInfo, fromAddressInfo, {
+        allowNoConnectWallet: true,
+      });
+    });
+
+    expect(store.get(swapAlertsAtom()).states).toEqual([
+      { noConnectWallet: true },
+    ]);
   });
 });

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -5,6 +5,7 @@ import BigNumber from 'bignumber.js';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ESwapDirection } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
 import type { useSwapAddressInfo } from '@onekeyhq/kit/src/views/Swap/hooks/useSwapAccount';
+import { removeSwapNoConnectWalletAlerts } from '@onekeyhq/kit/src/views/Swap/utils/swapNoWalletWarningGuard';
 import { buildSwapRateDifference } from '@onekeyhq/kit/src/views/Swap/utils/swapRateDifferenceUtils';
 import {
   isUSMarketStatusStockTokenSource,
@@ -1395,6 +1396,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       set,
       swapFromAddressInfo: ReturnType<typeof useSwapAddressInfo>,
       swapToAddressInfo: ReturnType<typeof useSwapAddressInfo>,
+      options?: {
+        allowNoConnectWallet?: boolean;
+      },
     ) => {
       const fromToken = get(swapSelectFromTokenAtom());
       const toToken = get(swapSelectToTokenAtom());
@@ -1475,11 +1479,28 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
             states: alertsRes,
             quoteId: '',
           });
+        } else {
+          const alerts = get(swapAlertsAtom());
+          const nextAlerts = removeSwapNoConnectWalletAlerts(alerts.states);
+          if (nextAlerts.length !== alerts.states.length) {
+            set(swapAlertsAtom(), {
+              states: nextAlerts,
+              quoteId: alerts.quoteId,
+            });
+          }
         }
         return;
       }
       // check account
       if (!swapFromAddressInfo.accountInfo?.wallet) {
+        if (!options?.allowNoConnectWallet) {
+          const alerts = get(swapAlertsAtom());
+          set(swapAlertsAtom(), {
+            states: removeSwapNoConnectWalletAlerts(alerts.states),
+            quoteId: alerts.quoteId,
+          });
+          return;
+        }
         // Set noConnectWallet flag without showing alert message
         set(swapAlertsAtom(), {
           states: [...alertsRes, { noConnectWallet: true }],

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
@@ -11,6 +11,7 @@ import {
   useIsOverlayPage,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { useCurrency } from '@onekeyhq/kit/src/components/Currency';
 import { useCustomRpcAvailability } from '@onekeyhq/kit/src/hooks/useCustomRpcAvailability';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
@@ -57,6 +58,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
     isReady,
   } = useTokenDetail();
   const intl = useIntl();
+  const currencyInfo = useCurrency();
   const isModalPage = useIsOverlayPage();
   const inPageDialog = useInPageDialog(
     isModalPage ? EInPageDialogType.inModalPage : EInPageDialogType.inTabPages,
@@ -211,6 +213,14 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
   const effectiveCustomPriorityFee = marketPresetSettings.enabled
     ? marketPresetSettings.selectedPriorityFeeOverride
     : undefined;
+  const shouldUseConvertedMarketPrice =
+    currencyInfo.id !== 'usd' && Boolean(tokenDetail?.priceConverted);
+  const marketTokenPrice = shouldUseConvertedMarketPrice
+    ? tokenDetail?.priceConverted
+    : tokenDetail?.price;
+  const marketTokenCurrency = shouldUseConvertedMarketPrice
+    ? currencyInfo.id
+    : 'usd';
   const currentFromTokenAmount =
     tradeType === ESwapDirection.BUY
       ? paymentAmount.toFixed()
@@ -224,7 +234,8 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
       symbol: tokenDetail?.symbol || '',
       decimals: tokenDetail?.decimals || 0,
       logoURI: tokenDetail?.logoUrl || '',
-      price: tokenDetail?.priceConverted || tokenDetail?.price || '',
+      price: marketTokenPrice || '',
+      currency: marketTokenCurrency,
       isNative: !!tokenDetail?.isNative,
     },
     tradeToken: {
@@ -234,6 +245,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
       decimals: paymentToken?.decimals || 0,
       logoURI: paymentToken?.logoURI || '',
       price: paymentToken?.price || '',
+      currency: paymentToken?.currency,
       isNative: paymentToken?.isNative || false,
     },
     provider,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
@@ -85,6 +85,7 @@ export function ActionButton({
   const { price: paymentTokenPrice } = usePaymentTokenPrice(
     tradeType === ESwapDirection.BUY ? paymentToken : undefined,
     paymentTokenNetworkId,
+    currencyInfo.id,
   );
   const [createAddressLoading, setCreateAddressLoading] = useState(false);
   const actionText =
@@ -102,7 +103,17 @@ export function ActionButton({
     }
 
     if (tradeType === ESwapDirection.BUY) {
-      const buyPrice = paymentTokenPrice ?? new BigNumber(token?.price || '0');
+      const fallbackCurrency = paymentToken?.currency ?? token?.currency;
+      const canUseFallbackPrice =
+        !fallbackCurrency || fallbackCurrency === currencyInfo.id;
+      const buyPrice =
+        paymentTokenPrice ??
+        (canUseFallbackPrice
+          ? new BigNumber(paymentToken?.price || token?.price || '0')
+          : undefined);
+      if (!buyPrice) {
+        return undefined;
+      }
       if (!buyPrice.isFinite() || buyPrice.isNaN() || !buyPrice.gt(0)) {
         return undefined;
       }
@@ -117,7 +128,11 @@ export function ActionButton({
     return amountBN.multipliedBy(sellPrice).toNumber();
   }, [
     tradeType,
+    currencyInfo.id,
+    paymentToken?.currency,
+    paymentToken?.price,
     paymentTokenPrice,
+    token?.currency,
     token?.price,
     amount,
     isValidAmount,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
@@ -80,9 +80,11 @@ export function ActionButton({
     num: 0,
     showConnectWalletModalInDappMode: true,
   });
+  const paymentTokenNetworkId =
+    tradeType === ESwapDirection.BUY ? paymentToken?.networkId : undefined;
   const { price: paymentTokenPrice } = usePaymentTokenPrice(
     tradeType === ESwapDirection.BUY ? paymentToken : undefined,
-    networkId,
+    paymentTokenNetworkId,
   );
   const [createAddressLoading, setCreateAddressLoading] = useState(false);
   const actionText =

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewExecutionUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewExecutionUtils.ts
@@ -4,6 +4,7 @@ import {
   buildSwapReviewState,
 } from '@onekeyhq/kit/src/views/Swap/utils/buildSwapReviewState';
 import { buildSwapRateDifference } from '@onekeyhq/kit/src/views/Swap/utils/swapRateDifferenceUtils';
+import type { ICurrencyItem } from '@onekeyhq/shared/types/currency';
 import type { IFeeInfoUnit } from '@onekeyhq/shared/types/fee';
 import type {
   IFetchQuoteResult,
@@ -85,16 +86,24 @@ export function buildMarketReviewState({
 export function buildMarketReviewRateDifference({
   quoteResult,
   swapInfo,
+  defaultTokenCurrency,
+  currencyMap,
 }: {
   quoteResult?: Pick<IFetchQuoteResult, 'instantRate'>;
   swapInfo?: {
-    sender?: { token?: Pick<ISwapToken, 'price'> };
-    receiver?: { token?: Pick<ISwapToken, 'price'> };
+    sender?: { token?: Pick<ISwapToken, 'price' | 'currency'> };
+    receiver?: { token?: Pick<ISwapToken, 'price' | 'currency'> };
   };
+  defaultTokenCurrency?: string;
+  currencyMap?: Record<string, ICurrencyItem>;
 }): ISwapPreSwapData['rateDifference'] {
   return buildSwapRateDifference({
     fromTokenPrice: swapInfo?.sender?.token?.price,
     toTokenPrice: swapInfo?.receiver?.token?.price,
+    fromTokenCurrency: swapInfo?.sender?.token?.currency,
+    toTokenCurrency: swapInfo?.receiver?.token?.currency,
+    defaultTokenCurrency,
+    currencyMap,
     instantRate: quoteResult?.instantRate,
   });
 }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/usePaymentTokenPrice.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/usePaymentTokenPrice.test.tsx
@@ -1,0 +1,129 @@
+/** @jest-environment jsdom */
+
+import { renderHook } from '@testing-library/react';
+
+import type {
+  ISwapToken,
+  ISwapTokenBase,
+} from '@onekeyhq/shared/types/swap/types';
+
+import { usePaymentTokenPrice } from './usePaymentTokenPrice';
+
+type IFetchSwapTokenDetailsParams = {
+  networkId?: string;
+  contractAddress?: string;
+  currency?: string;
+};
+
+type IPaymentTokenPriceResult = {
+  tokenDetail?: ISwapToken;
+  tokenKey: string;
+};
+
+const mockFetchSwapTokenDetails: jest.MockedFunction<
+  (params: IFetchSwapTokenDetailsParams) => Promise<ISwapToken[]>
+> = jest.fn();
+const mockRun = jest.fn();
+let mockPromiseResult: IPaymentTokenPriceResult | undefined;
+let mockCapturedMethod:
+  | (() => Promise<IPaymentTokenPriceResult | undefined>)
+  | undefined;
+let mockCapturedDeps: unknown[] = [];
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceSwap: {
+      fetchSwapTokenDetails: (params: IFetchSwapTokenDetailsParams) =>
+        mockFetchSwapTokenDetails(params),
+    },
+  },
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => ({
+  usePromiseResult: (
+    method: () => Promise<IPaymentTokenPriceResult | undefined>,
+    deps: unknown[],
+  ) => {
+    mockCapturedMethod = method;
+    mockCapturedDeps = deps;
+    return {
+      result: mockPromiseResult,
+      isLoading: false,
+      run: mockRun,
+    };
+  },
+}));
+
+const paymentToken: ISwapTokenBase = {
+  networkId: 'evm--1',
+  contractAddress: '0xusdc',
+  symbol: 'USDC',
+  decimals: 6,
+  isNative: false,
+};
+
+describe('usePaymentTokenPrice', () => {
+  beforeEach(() => {
+    mockFetchSwapTokenDetails.mockReset();
+    mockRun.mockReset();
+    mockPromiseResult = undefined;
+    mockCapturedMethod = undefined;
+    mockCapturedDeps = [];
+  });
+
+  it('requests token detail with the selected currency and returns a currency-aware key', async () => {
+    mockFetchSwapTokenDetails.mockResolvedValue([
+      {
+        ...paymentToken,
+        price: '7',
+      },
+    ]);
+
+    renderHook(() => usePaymentTokenPrice(paymentToken, 'evm--1', 'cny'));
+
+    const result = await mockCapturedMethod?.();
+
+    expect(mockFetchSwapTokenDetails).toHaveBeenCalledWith({
+      networkId: 'evm--1',
+      contractAddress: '0xusdc',
+      currency: 'cny',
+    });
+    expect(result).toEqual({
+      tokenDetail: expect.objectContaining({
+        price: '7',
+        currency: 'cny',
+      }),
+      tokenKey: 'evm--1:0xusdc:cny',
+    });
+    expect(mockCapturedDeps).toContain('cny');
+    expect(mockCapturedDeps).toContain('evm--1:0xusdc:cny');
+  });
+
+  it('does not fetch until a currency id is available', async () => {
+    renderHook(() => usePaymentTokenPrice(paymentToken, 'evm--1'));
+
+    const result = await mockCapturedMethod?.();
+
+    expect(result).toBeUndefined();
+    expect(mockFetchSwapTokenDetails).not.toHaveBeenCalled();
+  });
+
+  it('exposes the current currency-scoped price result', () => {
+    mockPromiseResult = {
+      tokenDetail: {
+        ...paymentToken,
+        price: '9',
+        currency: 'cny',
+      },
+      tokenKey: 'evm--1:0xusdc:cny',
+    };
+
+    const { result } = renderHook(() =>
+      usePaymentTokenPrice(paymentToken, 'evm--1', 'cny'),
+    );
+
+    expect(result.current.price?.toFixed()).toBe('9');
+    expect(result.current.tokenKey).toBe('evm--1:0xusdc:cny');
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/usePaymentTokenPrice.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/usePaymentTokenPrice.ts
@@ -24,17 +24,20 @@ type IPaymentTokenPriceResult = {
 export function usePaymentTokenPrice(
   paymentToken?: ISwapTokenBase,
   networkId?: string,
+  currencyId?: string,
 ): IUsePaymentTokenPriceResult {
   const hasPaymentToken = Boolean(paymentToken);
   const paymentContractAddress = paymentToken?.contractAddress ?? '';
-  const paymentTokenKey = `${networkId ?? ''}:${paymentContractAddress}`;
+  const paymentTokenKey = `${networkId ?? ''}:${paymentContractAddress}:${
+    currencyId ?? ''
+  }`;
   const {
     result: paymentTokenPriceResult,
     isLoading,
     run: refetch,
   } = usePromiseResult(
     async (): Promise<IPaymentTokenPriceResult | undefined> => {
-      if (!networkId || !hasPaymentToken) {
+      if (!networkId || !currencyId || !hasPaymentToken) {
         return undefined;
       }
 
@@ -42,15 +45,27 @@ export function usePaymentTokenPrice(
         {
           networkId,
           contractAddress: paymentContractAddress,
+          currency: currencyId,
         },
       );
 
       return {
-        tokenDetail: detail?.[0],
+        tokenDetail: detail?.[0]
+          ? {
+              ...detail[0],
+              currency: currencyId,
+            }
+          : undefined,
         tokenKey: paymentTokenKey,
       };
     },
-    [hasPaymentToken, networkId, paymentContractAddress, paymentTokenKey],
+    [
+      currencyId,
+      hasPaymentToken,
+      networkId,
+      paymentContractAddress,
+      paymentTokenKey,
+    ],
     {
       watchLoading: true,
       pollingInterval: 5000, // 5 seconds

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
@@ -40,6 +40,7 @@ type IUsePaymentTokenPriceResult = {
 type IUsePaymentTokenPriceMock = (
   paymentToken?: ISwapTokenBase & { price?: string },
   networkId?: string,
+  currencyId?: string,
 ) => IUsePaymentTokenPriceResult;
 
 const mockFetchSwapTokenDetails: jest.MockedFunction<
@@ -80,6 +81,10 @@ let mockInAppNotificationAtomState: {
     status?: string;
   };
 } = {};
+let mockCurrencyInfo = {
+  id: 'usd',
+  symbol: '$',
+};
 
 jest.mock('react-intl', () => ({
   useIntl: () => ({
@@ -143,10 +148,13 @@ jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
   ],
   useSettingsPersistAtom: () => [
     {
-      currencyInfo: {
-        symbol: '$',
-      },
+      currencyInfo: mockCurrencyInfo,
       isFirstTimeSwap: false,
+    },
+  ],
+  useCurrencyPersistAtom: () => [
+    {
+      currencyMap: {},
     },
   ],
 }));
@@ -169,8 +177,9 @@ jest.mock('./usePaymentTokenPrice', () => ({
   usePaymentTokenPrice: (
     paymentToken?: ISwapTokenBase & { price?: string },
     networkId?: string,
+    currencyId?: string,
   ): IUsePaymentTokenPriceResult =>
-    mockUsePaymentTokenPrice(paymentToken, networkId),
+    mockUsePaymentTokenPrice(paymentToken, networkId, currencyId),
 }));
 
 function createDeferred<T>() {
@@ -248,8 +257,14 @@ const solToken: ISwapTokenBase = {
   isNative: false,
 };
 
-function getTokenKey(token?: ISwapTokenBase, networkId?: string) {
-  return `${networkId ?? token?.networkId ?? ''}:${token?.contractAddress ?? ''}`;
+function getTokenKey(
+  token?: ISwapTokenBase,
+  networkId?: string,
+  currencyId = 'usd',
+) {
+  return `${networkId ?? token?.networkId ?? ''}:${
+    token?.contractAddress ?? ''
+  }:${currencyId}`;
 }
 
 function createHookProps({
@@ -260,8 +275,14 @@ function createHookProps({
   tradeToken?: ISwapTokenBase;
 } = {}) {
   return {
-    marketToken,
-    tradeToken,
+    marketToken: {
+      ...marketToken,
+      currency: marketToken.currency ?? 'usd',
+    },
+    tradeToken: {
+      ...tradeToken,
+      currency: tradeToken.currency ?? 'usd',
+    },
     tradeType: ESwapDirection.BUY,
     fromTokenAmount: '0',
     provider: 'onekey',
@@ -287,6 +308,7 @@ describe('useSpeedSwapActions', () => {
       (
         paymentToken?: ISwapTokenBase & { price?: string },
         networkId?: string,
+        currencyId?: string,
       ) => {
         const priceValue = paymentToken?.price;
         let price: BigNumber | undefined;
@@ -299,12 +321,16 @@ describe('useSpeedSwapActions', () => {
         }
         return {
           price,
-          tokenKey: getTokenKey(paymentToken, networkId),
+          tokenKey: getTokenKey(paymentToken, networkId, currencyId),
           isLoading: false,
           refetch: jest.fn(),
         };
       },
     );
+    mockCurrencyInfo = {
+      id: 'usd',
+      symbol: '$',
+    };
     mockFetchSwapNativeTokenConfig.mockResolvedValue({
       networkId: 'evm--1',
       reserveGas: '0.01',
@@ -766,6 +792,143 @@ describe('useSpeedSwapActions', () => {
     });
 
     expect(mockFetchSwapTokenDetails).not.toHaveBeenCalled();
+  });
+
+  it('ignores live payment token prices from a stale currency scope', async () => {
+    mockCurrencyInfo = {
+      id: 'cny',
+      symbol: 'CNY',
+    };
+    mockNetAccountPromiseResult = {
+      result: undefined,
+      run: mockNetAccountRun,
+    };
+    mockUsePaymentTokenPrice.mockReturnValue({
+      price: new BigNumber(2),
+      tokenKey: getTokenKey(usdcToken, undefined, 'usd'),
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+
+    const { result } = renderHook(() =>
+      useSpeedSwapActions(
+        createHookProps({
+          marketToken: {
+            ...tonMarketToken,
+            price: '5',
+            currency: 'cny',
+          },
+          tradeToken: {
+            ...usdcToken,
+            price: '10',
+            currency: 'cny',
+          },
+        }),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(mockUsePaymentTokenPrice).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contractAddress: usdcToken.contractAddress,
+        }),
+        usdcToken.networkId,
+        'cny',
+      );
+      expect(result.current.priceRate?.rate).toBeCloseTo(2);
+    });
+
+    expect(mockFetchSwapTokenDetails).not.toHaveBeenCalled();
+  });
+
+  it('falls back to same-currency fetched prices when inline price currencies differ', async () => {
+    mockCurrencyInfo = {
+      id: 'cny',
+      symbol: 'CNY',
+    };
+    mockNetAccountPromiseResult = {
+      result: undefined,
+      run: mockNetAccountRun,
+    };
+    mockUsePaymentTokenPrice.mockReturnValue({
+      price: new BigNumber(10),
+      tokenKey: getTokenKey(usdcToken, undefined, 'cny'),
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+    mockFetchSwapTokenDetails.mockImplementation(
+      ({
+        accountId,
+        networkId,
+        contractAddress,
+      }: IFetchSwapTokenDetailsParams) => {
+        if (accountId) {
+          return Promise.resolve([]);
+        }
+
+        const requestKey = `${networkId ?? ''}:${contractAddress ?? ''}`;
+        switch (requestKey) {
+          case `${usdcToken.networkId}:${usdcToken.contractAddress}`:
+            return Promise.resolve(
+              createTokenDetail({
+                networkId: usdcToken.networkId,
+                contractAddress: usdcToken.contractAddress,
+                symbol: usdcToken.symbol,
+                decimals: usdcToken.decimals,
+                price: '2',
+              }),
+            );
+          case `${tonMarketToken.networkId}:${tonMarketToken.contractAddress}`:
+            return Promise.resolve(
+              createTokenDetail({
+                networkId: tonMarketToken.networkId,
+                contractAddress: tonMarketToken.contractAddress,
+                symbol: tonMarketToken.symbol,
+                decimals: tonMarketToken.decimals,
+                price: '4',
+              }),
+            );
+          default:
+            return Promise.resolve([]);
+        }
+      },
+    );
+
+    const { result } = renderHook(() =>
+      useSpeedSwapActions(
+        createHookProps({
+          marketToken: {
+            ...tonMarketToken,
+            price: '5',
+            currency: 'usd',
+          },
+          tradeToken: {
+            ...usdcToken,
+            price: '10',
+            currency: 'cny',
+          },
+        }),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.priceRate?.rate).toBeCloseTo(0.5);
+    });
+
+    expect(mockFetchSwapTokenDetails).toHaveBeenCalledWith(
+      expect.objectContaining({
+        networkId: usdcToken.networkId,
+        contractAddress: usdcToken.contractAddress,
+        currency: 'usd',
+      }),
+    );
+    expect(mockFetchSwapTokenDetails).toHaveBeenCalledWith(
+      expect.objectContaining({
+        networkId: tonMarketToken.networkId,
+        contractAddress: tonMarketToken.contractAddress,
+        currency: 'usd',
+      }),
+    );
   });
 });
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -27,6 +27,7 @@ import type {
   ISwapReviewState,
 } from '@onekeyhq/kit/src/views/Swap/utils/swapReviewState';
 import {
+  useCurrencyPersistAtom,
   useInAppNotificationAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -163,11 +164,13 @@ export function buildMarketReviewTokens({
   fromToken,
   toToken,
   tradeTokenPrice,
+  tradeTokenCurrency,
 }: {
   tradeType: ESwapDirection;
   fromToken: ISwapToken;
   toToken: ISwapToken;
   tradeTokenPrice?: BigNumber;
+  tradeTokenCurrency?: string;
 }) {
   if (!tradeTokenPrice || tradeTokenPrice.isNaN() || !tradeTokenPrice.gt(0)) {
     return { fromToken, toToken };
@@ -180,6 +183,7 @@ export function buildMarketReviewTokens({
       fromToken: {
         ...fromToken,
         price: resolvedPrice,
+        currency: tradeTokenCurrency ?? fromToken.currency,
       },
       toToken,
     };
@@ -190,6 +194,7 @@ export function buildMarketReviewTokens({
     toToken: {
       ...toToken,
       price: resolvedPrice,
+      currency: tradeTokenCurrency ?? toToken.currency,
     },
   };
 }
@@ -225,6 +230,7 @@ export function useSpeedSwapActions(props: {
   const [inAppNotificationAtom, setInAppNotificationAtom] =
     useInAppNotificationAtom();
   const [settingsAtom] = useSettingsPersistAtom();
+  const [{ currencyMap }] = useCurrencyPersistAtom();
   const { activeAccount: account } = useActiveAccount({ num: 0 });
   const [shouldApprove, setShouldApprove] = useState(false);
   const [shouldResetApprove, setShouldResetApprove] = useState(false);
@@ -278,19 +284,28 @@ export function useSpeedSwapActions(props: {
       balanceToken: marketToken,
     };
   }, [tradeType, marketToken, tradeToken]);
-  const tradeTokenPriceKey = `${tradeToken.networkId ?? ''}:${tradeToken.contractAddress ?? ''}`;
+  const currentCurrencyId = settingsAtom.currencyInfo.id;
+  const tradeTokenPriceKey = `${tradeToken.networkId ?? ''}:${
+    tradeToken.contractAddress ?? ''
+  }:${currentCurrencyId}`;
   const { price: liveTradeTokenPrice, tokenKey: liveTradeTokenPriceKey } =
-    usePaymentTokenPrice(tradeToken, tradeToken.networkId);
+    usePaymentTokenPrice(tradeToken, tradeToken.networkId, currentCurrencyId);
+  const fallbackTradeTokenPrice = useMemo(() => {
+    if (tradeToken.currency && tradeToken.currency !== currentCurrencyId) {
+      return new BigNumber(0);
+    }
+    return new BigNumber(tradeToken.price || 0);
+  }, [currentCurrencyId, tradeToken.currency, tradeToken.price]);
   const effectiveTradeTokenPrice = useMemo(() => {
     if (liveTradeTokenPriceKey === tradeTokenPriceKey) {
-      return liveTradeTokenPrice ?? new BigNumber(tradeToken.price || 0);
+      return liveTradeTokenPrice ?? fallbackTradeTokenPrice;
     }
 
-    return new BigNumber(tradeToken.price || 0);
+    return fallbackTradeTokenPrice;
   }, [
+    fallbackTradeTokenPrice,
     liveTradeTokenPrice,
     liveTradeTokenPriceKey,
-    tradeToken.price,
     tradeTokenPriceKey,
   ]);
 
@@ -1127,6 +1142,8 @@ export function useSpeedSwapActions(props: {
         rateDifference: buildMarketReviewRateDifference({
           quoteResult: snapshot.quoteResult,
           swapInfo: snapshot.swapInfo,
+          defaultTokenCurrency: settingsAtom.currencyInfo.id,
+          currencyMap,
         }),
         texts: buildReviewStepTexts(snapshot.quoteResult.info.providerName),
       });
@@ -1209,7 +1226,13 @@ export function useSpeedSwapActions(props: {
         quoteResult: snapshot.quoteResult,
       };
     },
-    [buildMarketApproveUnsignedTxArr, buildReviewStepTexts, slippage],
+    [
+      buildMarketApproveUnsignedTxArr,
+      buildReviewStepTexts,
+      currencyMap,
+      settingsAtom.currencyInfo.id,
+      slippage,
+    ],
   );
 
   const estimateMarketPresetNetworkFees = useCallback(
@@ -1289,6 +1312,7 @@ export function useSpeedSwapActions(props: {
           fromToken: fromTokenFinal,
           toToken: toTokenFinal,
           tradeTokenPrice: effectiveTradeTokenPrice,
+          tradeTokenCurrency: currentCurrencyId,
         });
 
       if (isWrap || isWrapped) {
@@ -1406,7 +1430,9 @@ export function useSpeedSwapActions(props: {
       buildMarketReviewStateFromSnapshot,
       buildSpeedSwapTxData,
       buildWrappedSwapData,
+      currentCurrencyId,
       effectiveSpenderAddress,
+      effectiveTradeTokenPrice,
       fromToken,
       fromTokenAmountDebounced,
       isCustomRpcUnavailable,
@@ -1416,7 +1442,6 @@ export function useSpeedSwapActions(props: {
       shouldApprove,
       shouldResetApprove,
       slippage,
-      effectiveTradeTokenPrice,
       tradeType,
       toToken,
     ],
@@ -2606,7 +2631,17 @@ export function useSpeedSwapActions(props: {
       tradeType === ESwapDirection.SELL
         ? effectiveTradeTokenPrice
         : new BigNumber(toToken.price || 0);
+    const fromTokenPriceCurrency =
+      tradeType === ESwapDirection.BUY ? currentCurrencyId : fromToken.currency;
+    const toTokenPriceCurrency =
+      tradeType === ESwapDirection.SELL ? currentCurrencyId : toToken.currency;
+    const canUseInlinePriceCurrencies =
+      (!fromTokenPriceCurrency && !toTokenPriceCurrency) ||
+      (!!fromTokenPriceCurrency &&
+        !!toTokenPriceCurrency &&
+        fromTokenPriceCurrency === toTokenPriceCurrency);
     const canUseInlineTokenPrices =
+      canUseInlinePriceCurrencies &&
       !fromTokenPriceBN.isNaN() &&
       !toTokenPriceBN.isNaN() &&
       fromTokenPriceBN.gt(0) &&
@@ -2700,11 +2735,14 @@ export function useSpeedSwapActions(props: {
     });
   }, [
     effectiveTradeTokenPrice,
+    currentCurrencyId,
     tradeType,
+    fromToken.currency,
     fromToken.price,
     fromToken.symbol,
     fromToken.networkId,
     fromToken.contractAddress,
+    toToken.currency,
     toToken.price,
     toToken.symbol,
     toToken.networkId,

--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/useAutoRefreshTokenDetail.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/useAutoRefreshTokenDetail.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 
+import { useCurrency } from '@onekeyhq/kit/src/components/Currency';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useTokenDetailActions } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import { useTokenDetail } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/hooks/useTokenDetail';
@@ -19,6 +20,7 @@ function toFiniteNumber(value?: string | number) {
 
 export function useAutoRefreshTokenDetail(data: IUseMarketDetailDataProps) {
   const { current: tokenDetailActions } = useTokenDetailActions();
+  const currencyInfo = useCurrency();
   const { tokenDetail, networkId } = useTokenDetail();
   const [, setCurrentTokenLiveData] = useMarketCurrentTokenLiveDataAtom();
 
@@ -57,19 +59,25 @@ export function useAutoRefreshTokenDetail(data: IUseMarketDetailDataProps) {
     [setCurrentTokenLiveData],
   );
 
-  // Track previous token to detect when switching to a different token
-  const prevTokenRef = useRef<{ tokenAddress: string; networkId: string }>({
+  // Track previous price scope to avoid showing stale token or currency data.
+  const prevTokenRef = useRef<{
+    tokenAddress: string;
+    networkId: string;
+    currencyId: string;
+  }>({
     tokenAddress: '',
     networkId: '',
+    currencyId: '',
   });
 
-  // Clear cached token detail when switching to a different token
-  // This prevents showing stale data from the previous token
+  // Clear cached token detail when switching token or display currency.
+  // This prevents showing stale data from the previous price scope.
   useEffect(() => {
     const prevToken = prevTokenRef.current;
     const isTokenChanged =
       prevToken.tokenAddress !== data.tokenAddress ||
-      prevToken.networkId !== data.networkId;
+      prevToken.networkId !== data.networkId ||
+      prevToken.currencyId !== currencyInfo.id;
 
     if (isTokenChanged && prevToken.tokenAddress !== '') {
       // Only clear display-related atoms when switching tokens.
@@ -85,8 +93,9 @@ export function useAutoRefreshTokenDetail(data: IUseMarketDetailDataProps) {
     prevTokenRef.current = {
       tokenAddress: data.tokenAddress,
       networkId: data.networkId,
+      currencyId: currencyInfo.id,
     };
-  }, [data.tokenAddress, data.networkId, tokenDetailActions]);
+  }, [currencyInfo.id, data.tokenAddress, data.networkId, tokenDetailActions]);
 
   // Set tokenAddress/networkId/isNative synchronously on prop change,
   // NOT inside the polling callback. This prevents stale polling responses
@@ -99,13 +108,16 @@ export function useAutoRefreshTokenDetail(data: IUseMarketDetailDataProps) {
 
   return usePromiseResult(
     async () => {
+      if (!currencyInfo.id) {
+        return;
+      }
       // Only fetch token detail data; atom identity is set synchronously above
       await tokenDetailActions.fetchTokenDetail(
         data.tokenAddress,
         data.networkId,
       );
     },
-    [data.tokenAddress, data.networkId, tokenDetailActions],
+    [currencyInfo.id, data.tokenAddress, data.networkId, tokenDetailActions],
     {
       pollingInterval: 6000, // Changed from 5000 to 6000 to avoid race condition with K-line updates
       revalidateOnFocus: true,

--- a/packages/kit/src/views/Swap/hooks/useSwapState.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapState.ts
@@ -31,7 +31,13 @@ import {
   ESwapTabSwitchType,
 } from '@onekeyhq/shared/types/swap/types';
 
+import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { useDebounce } from '../../../hooks/useDebounce';
+import { usePromiseResult } from '../../../hooks/usePromiseResult';
+import {
+  useAccountSelectorStorageInitDoneAtom,
+  useIsAccountSelectorActiveAccountInitDone,
+} from '../../../states/jotai/contexts/accountSelector';
 import {
   useSwapActions,
   useSwapAlertsAtom,
@@ -64,6 +70,7 @@ import {
   isSwapZeroProviderQuoteCompleted,
 } from '../../../states/jotai/contexts/swap/quoteProgress';
 import { buildSwapBatchTransferType } from '../utils/buildSwapReviewState';
+import { shouldAllowSwapNoConnectWalletWarning } from '../utils/swapNoWalletWarningGuard';
 
 import { useSwapAddressInfo } from './useSwapAccount';
 
@@ -77,6 +84,39 @@ function useSwapWarningCheck() {
   const [fromTokenBalance] = useSwapSelectedFromTokenBalanceAtom();
   const { checkSwapWarning } = useSwapActions().current;
   const [swapLimitUseRate] = useSwapLimitPriceUseRateAtom();
+  const [accountSelectorStorageInitDone] =
+    useAccountSelectorStorageInitDoneAtom();
+  const accountSelectorActiveAccountInitDone =
+    useIsAccountSelectorActiveAccountInitDone(0);
+  const { result: walletListResult } = usePromiseResult(
+    () =>
+      backgroundApiProxy.serviceAccount.getWallets({
+        ignoreEmptySingletonWalletAccounts: true,
+      }),
+    [],
+    {
+      checkIsFocused: false,
+      watchLoading: false,
+    },
+  );
+  const allowNoConnectWallet = useMemo(
+    () =>
+      shouldAllowSwapNoConnectWalletWarning({
+        accountInfoReady: swapFromAddressInfo.accountInfo?.ready,
+        accountSelectorActiveAccountInitDone,
+        accountSelectorStorageInitDone,
+        hasAccountWallet: Boolean(swapFromAddressInfo.accountInfo?.wallet),
+        isWebDappMode: Boolean(platformEnv.isWebDappMode),
+        walletListResolvedNoWallet: walletListResult?.wallets.length === 0,
+      }),
+    [
+      accountSelectorActiveAccountInitDone,
+      accountSelectorStorageInitDone,
+      swapFromAddressInfo.accountInfo?.ready,
+      swapFromAddressInfo.accountInfo?.wallet,
+      walletListResult?.wallets.length,
+    ],
+  );
   const refContainer = useRef<ISwapCheckWarningDef>({
     swapFromAddressInfo: {
       address: undefined,
@@ -105,8 +145,10 @@ function useSwapWarningCheck() {
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const checkSwapWarningDeb = useCallback(
-    debounce((fromAddressInfo, toAddressInfo) => {
-      void checkSwapWarning(fromAddressInfo, toAddressInfo);
+    debounce((fromAddressInfo, toAddressInfo, allowNoConnect: boolean) => {
+      void checkSwapWarning(fromAddressInfo, toAddressInfo, {
+        allowNoConnectWallet: allowNoConnect,
+      });
     }, 300),
     [],
   );
@@ -117,9 +159,11 @@ function useSwapWarningCheck() {
       checkSwapWarningDeb(
         refContainer.current.swapFromAddressInfo,
         refContainer.current.swapToAddressInfo,
+        allowNoConnectWallet,
       );
     }
   }, [
+    allowNoConnectWallet,
     asyncRefContainer,
     checkSwapWarningDeb,
     fromToken,

--- a/packages/kit/src/views/Swap/utils/swapNoWalletWarningGuard.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapNoWalletWarningGuard.test.ts
@@ -1,0 +1,82 @@
+import {
+  removeSwapNoConnectWalletAlerts,
+  shouldAllowSwapNoConnectWalletWarning,
+} from './swapNoWalletWarningGuard';
+
+describe('shouldAllowSwapNoConnectWalletWarning', () => {
+  it('blocks the warning before account info is ready', () => {
+    expect(
+      shouldAllowSwapNoConnectWalletWarning({
+        accountInfoReady: false,
+        accountSelectorActiveAccountInitDone: true,
+        accountSelectorStorageInitDone: true,
+        hasAccountWallet: false,
+        isWebDappMode: false,
+        walletListResolvedNoWallet: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('blocks the warning when a wallet exists', () => {
+    expect(
+      shouldAllowSwapNoConnectWalletWarning({
+        accountInfoReady: true,
+        accountSelectorActiveAccountInitDone: true,
+        accountSelectorStorageInitDone: true,
+        hasAccountWallet: true,
+        isWebDappMode: false,
+        walletListResolvedNoWallet: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('blocks the warning during native cold-start init even when account info has no wallet', () => {
+    expect(
+      shouldAllowSwapNoConnectWalletWarning({
+        accountInfoReady: true,
+        accountSelectorActiveAccountInitDone: false,
+        accountSelectorStorageInitDone: true,
+        hasAccountWallet: false,
+        isWebDappMode: false,
+        walletListResolvedNoWallet: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('allows the warning for a native real no-wallet state after init and wallet-list proof', () => {
+    expect(
+      shouldAllowSwapNoConnectWalletWarning({
+        accountInfoReady: true,
+        accountSelectorActiveAccountInitDone: true,
+        accountSelectorStorageInitDone: true,
+        hasAccountWallet: false,
+        isWebDappMode: false,
+        walletListResolvedNoWallet: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('allows the warning in web dapp mode after account info is ready and no wallet is connected', () => {
+    expect(
+      shouldAllowSwapNoConnectWalletWarning({
+        accountInfoReady: true,
+        accountSelectorActiveAccountInitDone: false,
+        accountSelectorStorageInitDone: false,
+        hasAccountWallet: false,
+        isWebDappMode: true,
+        walletListResolvedNoWallet: false,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('removeSwapNoConnectWalletAlerts', () => {
+  it('removes only noConnectWallet alerts', () => {
+    expect(
+      removeSwapNoConnectWalletAlerts([
+        { message: 'keep me' },
+        { noConnectWallet: true },
+      ]),
+    ).toEqual([{ message: 'keep me' }]);
+  });
+});

--- a/packages/kit/src/views/Swap/utils/swapNoWalletWarningGuard.ts
+++ b/packages/kit/src/views/Swap/utils/swapNoWalletWarningGuard.ts
@@ -1,0 +1,35 @@
+import type { ISwapAlertState } from '@onekeyhq/shared/types/swap/types';
+
+export function shouldAllowSwapNoConnectWalletWarning({
+  accountInfoReady,
+  accountSelectorActiveAccountInitDone,
+  accountSelectorStorageInitDone,
+  hasAccountWallet,
+  isWebDappMode,
+  walletListResolvedNoWallet,
+}: {
+  accountInfoReady: boolean | undefined;
+  accountSelectorActiveAccountInitDone: boolean;
+  accountSelectorStorageInitDone: boolean;
+  hasAccountWallet: boolean;
+  isWebDappMode: boolean;
+  walletListResolvedNoWallet: boolean;
+}) {
+  if (!accountInfoReady || hasAccountWallet) {
+    return false;
+  }
+
+  if (isWebDappMode) {
+    return true;
+  }
+
+  return (
+    accountSelectorStorageInitDone &&
+    accountSelectorActiveAccountInitDone &&
+    walletListResolvedNoWallet
+  );
+}
+
+export function removeSwapNoConnectWalletAlerts(states: ISwapAlertState[]) {
+  return states.filter((item) => !item.noConnectWallet);
+}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56738](https://onekeyhq.atlassian.net/browse/OK-56738) [OK-56741](https://onekeyhq.atlassian.net/browse/OK-56741) [OK-56794](https://onekeyhq.atlassian.net/browse/OK-56794)

----------

<!-- github-pr-monitor:jira-links:end -->


## Issues
- Fixes OK-56738
- Fixes OK-56794

## Summary
- Correct the Market detail buy button fiat-value lookup to use the selected payment token network.
- Prevent BTC detail pages from pricing ETH/USDC payment amounts against the BTC market network.
- Avoid showing the Swap connect-wallet action during cold start before account-selector and wallet data have finished initializing.

## Intent & Context
OK-56738 reported incorrect fiat-value display in the built-in Market trading panel: ETH showed a BTC-derived value on the BTC detail page, and USDC could miss the fiat suffix. The user asked to move the fix onto `release/v6.4.0` and create a PR for review.

OK-56794 covers the Swap cold-start state where account data is not fully initialized yet, but the action button can incorrectly enter the no-wallet / connect-wallet path. The fix keeps the no-wallet action disabled until native wallet readiness is proven, while preserving the real no-wallet behavior after initialization.

## Root Cause
`ActionButton` receives the Market detail page `networkId`, which represents the current market token network. In BUY mode, the fiat suffix should price the selected payment token, but the code passed the Market page `networkId` into `usePaymentTokenPrice`. On a BTC detail page this made native ETH lookups resolve as BTC-native pricing, while contract tokens such as USDC could fail to find a valid price on the BTC network.

Swap warning state previously treated `accountInfo.ready && !accountInfo.wallet` as enough proof for `noConnectWallet`. During cold start that can be a transient state before account selector storage and wallet list data have settled, so the UI may show the connect-wallet action too early.

## Design Decisions
- Keep the Market fiat-value fix local to the display layer in `ActionButton` instead of changing swap execution or the shared pricing hook.
- Use `paymentToken.networkId` only for BUY payment-token price lookup.
- Preserve SELL behavior, which continues to price the displayed sell token from `token.price`.
- Gate Swap `noConnectWallet` on account-selector init completion plus wallet-list proof on native, while keeping web dapp mode behavior unchanged.
- Remove stale `noConnectWallet` alerts when readiness is not proven, without clearing unrelated warning/error alerts.

## Changes Detail
- `packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx`: derive `paymentTokenNetworkId` from the selected payment token in BUY mode and pass it to `usePaymentTokenPrice`.
- `packages/kit/src/views/Swap/hooks/useSwapState.ts`: compute whether the no-wallet warning is allowed from account-selector init state, active account readiness, platform mode, and wallet-list result.
- `packages/kit/src/states/jotai/contexts/swap/actions.ts`: accept the no-wallet allowance from the caller and clear stale `noConnectWallet` alerts when the state is not proven.
- `packages/kit/src/views/Swap/utils/swapNoWalletWarningGuard.ts`: extract the guard and stale-alert filtering helpers.
- Added focused tests for the guard and Swap warning action behavior.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Market detail built-in trading panel button display; Swap cold-start action-button state; no swap execution payloads are changed.
- **Release Notes**: PR targets `release/v6.4.0`; verify both OK-56738 and OK-56794 before adding `release-ready`.

## Test plan
- [x] `git diff --check`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/states/jotai/contexts/swap/actions.test.tsx packages/kit/src/states/jotai/contexts/swap/actions.ts packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx packages/kit/src/views/Swap/hooks/useSwapState.ts packages/kit/src/views/Swap/utils/swapNoWalletWarningGuard.test.ts packages/kit/src/views/Swap/utils/swapNoWalletWarningGuard.ts --deny-warnings`
- [x] `yarn jest --runTestsByPath packages/kit/src/views/Swap/utils/swapNoWalletWarningGuard.test.ts packages/kit/src/states/jotai/contexts/swap/actions.test.tsx --runInBand`
- [x] `yarn tsc:only`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [ ] QA: OK-56738 Market BTC detail BUY with ETH and USDC payment tokens shows fiat value from the payment token network.
- [ ] QA: OK-56794 cold start does not show the Swap connect-wallet action before account-selector and wallet data have initialized.
- [ ] QA: Real no-wallet state still shows the connect-wallet action after initialization.

[OK-56738]: https://onekeyhq.atlassian.net/browse/OK-56738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-56794]: https://onekeyhq.atlassian.net/browse/OK-56794

[OK-56741]: https://onekeyhq.atlassian.net/browse/OK-56741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ