### PR TITLE
fix: enable watch-only DeFi action UI

### DIFF
--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -92,7 +92,8 @@ export interface IDevSettings {
   forceIpTableStrict?: boolean;
   // Enable mock market banner data for UI testing
   enableMockMarketBanner?: boolean;
-  // Show DeFi action buttons that are protocol-supported but not currently actionable
+  // Show DeFi action buttons that are protocol-supported but not currently actionable,
+  // and allow watch-only accounts to render/click the action UI.
   showUnavailableDeFiActionButtons?: boolean;
   // Test accounts for OneKey ID login testing
   testAccounts?: ITestAccount[];

--- a/packages/kit/src/components/DeFi/ProtocolPositionActionButton.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionButton.tsx
@@ -415,40 +415,51 @@ const ProtocolPositionActionButton = memo(
     const [submittingActionKey, setSubmittingActionKey] = useState<
       string | undefined
     >(undefined);
-    const isActionAccount =
-      !!accountId &&
-      !accountUtils.isUrlAccountFn({ accountId }) &&
-      !accountUtils.isWatchingAccount({ accountId });
+    const isUrlAccount =
+      !!accountId && accountUtils.isUrlAccountFn({ accountId });
+    const isWatchingAccount =
+      !!accountId && accountUtils.isWatchingAccount({ accountId });
+    const isActionAccount = !!accountId && !isUrlAccount && !isWatchingAccount;
+    const shouldShowUnavailableDeFiActionButtons = Boolean(
+      devSettings.enabled &&
+      devSettings.settings?.showUnavailableDeFiActionButtons,
+    );
+    // Dev-only mode: watch-only accounts can render and click the action UI,
+    // while the background build-transaction guard still blocks submission.
+    const shouldAllowWatchingAccountActionButtons =
+      shouldShowUnavailableDeFiActionButtons && isWatchingAccount;
+    const shouldResolveActionButtons =
+      isActionAccount || shouldAllowWatchingAccountActionButtons;
     const actions = useMemo(
       () =>
-        isActionAccount
+        shouldResolveActionButtons
           ? defiActionUtils.resolveDeFiPositionActions({
               protocol,
               position,
               supportedActions,
             })
           : [],
-      [isActionAccount, position, protocol, supportedActions],
-    );
-    const shouldShowUnavailableDeFiActionButtons = Boolean(
-      devSettings.enabled &&
-      devSettings.settings?.showUnavailableDeFiActionButtons,
+      [position, protocol, shouldResolveActionButtons, supportedActions],
     );
     const unavailableActions = useMemo<IRenderedDeFiPositionAction[]>(
       () =>
-        isActionAccount && shouldShowUnavailableDeFiActionButtons
+        shouldResolveActionButtons && shouldShowUnavailableDeFiActionButtons
           ? defiActionUtils
               .resolveDeFiPositionActionDebugCandidates({
                 protocol,
                 position,
                 supportedActions,
               })
-              .map((action) => ({ ...action, disabled: true }))
+              .map((action) => ({
+                ...action,
+                disabled: !shouldAllowWatchingAccountActionButtons,
+              }))
           : [],
       [
-        isActionAccount,
         position,
         protocol,
+        shouldAllowWatchingAccountActionButtons,
+        shouldResolveActionButtons,
         shouldShowUnavailableDeFiActionButtons,
         supportedActions,
       ],
@@ -462,8 +473,9 @@ const ProtocolPositionActionButton = memo(
       [manageAsset, position, protocol],
     );
     const fallbackBlockingActions = useMemo(
-      () => (isActionAccount ? [...actions, ...unavailableActions] : []),
-      [actions, isActionAccount, unavailableActions],
+      () =>
+        shouldResolveActionButtons ? [...actions, ...unavailableActions] : [],
+      [actions, shouldResolveActionButtons, unavailableActions],
     );
     const visibleActions = useMemo(
       () =>
@@ -579,7 +591,7 @@ const ProtocolPositionActionButton = memo(
     );
 
     if (
-      !isActionAccount ||
+      !shouldResolveActionButtons ||
       (renderedActions.length === 0 && !shouldShowManage)
     ) {
       return null;

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -1570,7 +1570,7 @@ const BaseDevSettingsSection = () => {
                         icon="ChartColumnarOutline"
                         name="showUnavailableDeFiActionButtons"
                         title="Show unavailable DeFi action buttons"
-                        subtitle="Use supported-protocols to render unavailable actions as disabled buttons"
+                        subtitle="Use supported-protocols to show hidden actions, and let watch-only accounts open action UI"
                         searchKeywords="DeFi Earn Portfolio supported-protocols actions disabled buttons"
                       >
                         <Switch size={ESwitchSize.small} />


### PR DESCRIPTION
## Summary
- Extend the DeFi unavailable-action developer setting to let watch-only accounts render and open DeFi action UI.
- Keep URL accounts blocked and preserve the background build-transaction guard for watch-only submissions.
- Update the developer setting description to match the broader behavior.

## Issues
- No Jira issue provided.

## Test Plan
- yarn lint:staged
- yarn tsc:staged
- yarn jest packages/shared/src/utils/defiActionUtils.test.ts --runInBand
- yarn tsc:only
- git diff --check
- git diff --cached --check

## Risk
- Dev-setting scoped; normal DeFi action availability remains unchanged when the setting is off.
- Watch-only accounts can open the action UI with the setting on, but transaction building remains blocked in background service.