### PR TITLE
fix(desktop): recompute macOS title-bar draggable region on layout changes

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -398,6 +398,7 @@ focusable
 Formatjs
 formatter
 frontend
+frontmost
 fs
 fucntion
 func

--- a/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
+++ b/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
@@ -246,8 +246,10 @@ function startManager() {
     subtree: true,
   });
 
-  // Initial pass.
-  scheduleRecompute();
+  // Initial pass — run it synchronously (not debounced) so the draggable region
+  // exists on the first commit instead of ~200ms later, otherwise the title bar
+  // is briefly non-draggable right after app load.
+  recompute();
 }
 
 function useDesktopDragRegionManager(enabled: boolean) {

--- a/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
+++ b/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
@@ -12,31 +12,42 @@ const dragZoneStyle = {
 } as const;
 
 // =============================================================================
-// macOS 顶栏拖拽区:命令式合成方案
+// macOS title-bar draggable region: imperative synthesized approach
 //
-// 背景:macOS(Electron 39 / upstream electron#21034)上,直接写在 DOM 上的
-// `-webkit-app-region: drag` 在窗口 resize、显示器/DPI 变化、tab 切换(header 内容
-// 变更)、modal 开关等"拖拽区布局变化"之后,原生 NSWindow 的拖拽区不会重新计算 →
-// 出现"DOM 正确但拖不动"。且任何把【可见】节点移出 DOM 再放回的修法都会闪一帧。
+// Problem: on macOS (Electron, upstream electron#21034) the native NSWindow
+// draggable region is NOT recomputed after the `-webkit-app-region: drag`
+// layout changes — window resize, monitor/DPI change, tab switch (the header
+// subtree is swapped), modal open/close, docked DevTools. The DOM stays correct
+// but the top bar can no longer drag the window. Any fix that pulls the
+// *visible* header node out of the DOM and back to force a recompute flickers a
+// frame; toggling the app-region value in place (or adding a throwaway probe
+// element) does not refresh the native region at all; the only reliable levers
+// (window focus/reorder) live in the main process and are not hot-updatable.
 //
-// 方案:
-//   1. header 元素只保留 `app-region-drag` 类作【标记】,本身的真实 app-region 被
-//      下面注入的 style 中和(永不产生陈旧的原生区域);
-//   2. 一个全局命令式管理器读取这些标记,按当前几何【新鲜地】合成:
-//        - 覆盖标记区的不可见 drag 蒙层
-//        - 覆盖其中各 no-drag 控件(按钮/输入框…)的不可见 no-drag 洞
-//      全部是 body 级、position:fixed、opacity:0、pointer-events:none 的元素;
-//   3. resize / scroll / tab(aria-hidden)/ 内容变化 时,debounce 后【清→重算→重贴】。
-//   合成元素全程不可见 ⇒ 不闪;每次都是全新元素 ⇒ 永不陈旧;集中一处 ⇒ 取代旧的
-//   per-instance ghost 机制,简化。
+// Approach (renderer-only, hot-updatable, flicker-free):
+//   1. Header elements keep `app-region-drag` purely as a MARKER. Their real
+//      app-region (and that of everything inside them) is neutralized by the
+//      injected style below, so they never produce a stale native region.
+//   2. A single global imperative manager reads those markers and synthesizes,
+//      from the current geometry, fresh invisible overlays:
+//        - a `drag` overlay covering each visible marker zone;
+//        - `no-drag` holes covering the clickable controls inside it.
+//      All overlays are body-level, position:fixed, opacity:0,
+//      pointer-events:none.
+//   3. On resize / scroll / aria-hidden (tab, modal) / DOM mutations the
+//      overlays are cleared, recomputed and re-attached (debounced, with a
+//      max-wait guard).
+//   Fresh overlays => never stale; invisible => no flicker; one central place
+//   => replaces (and removes) the previous per-instance ghost-mirror.
 // =============================================================================
 
 const MARKER_CLASS = 'app-region-drag';
 const SYN_ATTR = 'data-onekey-syn-region';
 const NEUTRALIZE_STYLE_ID = 'onekey-drag-region-neutralize';
 const RECOMPUTE_DEBOUNCE = 200;
-// 连续 DOM 变动(列表滚动、动画…)会不停重置 debounce。MAX_WAIT 保证最多等这么久
-// 就强制重算一次,避免拖拽区在持续抖动期间一直得不到刷新。
+// Continuous DOM activity (list scrolling, animations, …) keeps resetting the
+// debounce timer. MAX_WAIT guarantees a recompute fires at least this often so
+// the draggable region is never starved while the page keeps churning.
 const RECOMPUTE_MAX_WAIT = 600;
 
 // Descendants of a drag zone that must stay clickable → punched as no-drag holes.
@@ -52,15 +63,21 @@ const NO_DRAG_SELECTOR = [
   '[class*="is_GroupFrame"]',
 ].join(',');
 
-let refCount = 0;
+// The manager is a process-wide singleton: it starts once (on the first
+// DesktopDragZoneBox mount) and intentionally never stops. A desktop window
+// always has a title bar, so there is nothing to tear down; keeping it as a
+// plain singleton avoids ref-counting that is fragile under React StrictMode's
+// double-invoked effects and the ~11 simultaneously-mounted tab headers.
 let started = false;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-let rafId = 0;
 let pendingSince = 0;
-let cleanupFns: Array<() => void> = [];
 
-// 中和所有 .app-region-drag 标记的真实 app-region —— 让它们只当标记,不产生原生区域。
-// 控件的 no-drag 也一并中和(改由合成洞负责),避免与合成区域顺序冲突。
+// Neutralize the real app-region of every marker zone AND everything inside it
+// (drag, no-drag controls, `.app-region-no-drag`, is_GroupFrame, …). Inside a
+// drag zone no element keeps a real native region — drag and no-drag are both
+// provided by the synthesized overlays, so nothing can go stale. The shared CSS
+// rules in index.css are intentionally left untouched: they still apply to
+// app-region elements OUTSIDE any drag zone (e.g. desktop menus).
 function ensureNeutralizeStyle() {
   if (document.getElementById(NEUTRALIZE_STYLE_ID)) {
     return;
@@ -69,11 +86,7 @@ function ensureNeutralizeStyle() {
   style.id = NEUTRALIZE_STYLE_ID;
   style.textContent = `
 .${MARKER_CLASS},
-.${MARKER_CLASS} button,
-.${MARKER_CLASS} input,
-.${MARKER_CLASS} textarea,
-.${MARKER_CLASS} a,
-.${MARKER_CLASS} [role="button"] {
+.${MARKER_CLASS} * {
   -webkit-app-region: none !important;
 }
 [${SYN_ATTR}] { pointer-events: none; }
@@ -81,12 +94,14 @@ function ensureNeutralizeStyle() {
   document.head.appendChild(style);
 }
 
-function removeNeutralizeStyle() {
-  document.getElementById(NEUTRALIZE_STYLE_ID)?.remove();
-}
-
-// 标记区是否真正可见(react-navigation 把非活跃 tab 留在 DOM 里,用 aria-hidden /
-// display / visibility 标隐藏 —— 这些区不能贡献拖拽区)。
+// Whether a marker zone is actually visible. LOAD-BEARING — do not drop this
+// filter (see OK-55535, the inactive-tab drag-region leak / cross-monitor bug):
+// react-navigation keeps inactive tab screens mounted via react-freeze and only
+// marks them `aria-hidden="true"` (NOT display:none), so a frozen header keeps
+// its layout. If we synthesized a drag overlay for such a hidden zone, its stale
+// (e.g. narrow two-row) rect would overlap and swallow clicks on controls in the
+// ACTIVE screen — which surfaced especially on external monitors (dpr=1). Only
+// visible zones get overlays; hidden ones contribute nothing.
 function isZoneShown(el: Element): boolean {
   let cur: Element | null = el;
   while (cur && cur !== document.body) {
@@ -124,9 +139,11 @@ function clearSynRegions() {
   document.querySelectorAll(`[${SYN_ATTR}]`).forEach((el) => el.remove());
 }
 
-// 命令式重算:清掉旧合成区 → 按当前几何重建 drag 蒙层 + no-drag 洞 → 重新贴上。
-// drag 先 append、no-drag 后 append(原生区域按 DOM 顺序 union/difference,
-// 后面的 no-drag 才能从前面的 drag 上减出可点击的洞)。
+// Imperative recompute: drop the old overlays → rebuild the drag overlay +
+// no-drag holes from the current geometry → re-attach. The drag overlays are
+// appended first and the no-drag holes after: the native region is built in DOM
+// order (drag = union, no-drag = difference), so the later no-drag holes carve
+// the clickable controls back out of the drag overlay.
 function recompute() {
   if (!document.body || !document.body.isConnected) {
     return;
@@ -159,14 +176,12 @@ function runRecompute() {
     debounceTimer = null;
   }
   pendingSince = 0;
-  if (rafId) {
-    globalThis.cancelAnimationFrame(rafId);
-  }
-  // rAF:等布局/样式结算后再读 rect 重算。
-  rafId = globalThis.requestAnimationFrame(() => {
-    rafId = 0;
-    recompute();
-  });
+  // Call recompute directly (no requestAnimationFrame): rAF is paused by
+  // Electron's backgroundThrottling whenever the window is occluded/backgrounded,
+  // which would leave the draggable region stale until the window is frontmost
+  // again. The debounce already lets layout settle, and recompute's
+  // getBoundingClientRect forces a synchronous layout anyway.
+  recompute();
 }
 
 function scheduleRecompute() {
@@ -174,7 +189,7 @@ function scheduleRecompute() {
   if (pendingSince === 0) {
     pendingSince = now;
   }
-  // 持续抖动到达 MAX_WAIT:立即重算,不再等待。
+  // Continuous churn reached MAX_WAIT: recompute now instead of waiting more.
   if (now - pendingSince >= RECOMPUTE_MAX_WAIT) {
     runRecompute();
     return;
@@ -185,6 +200,8 @@ function scheduleRecompute() {
   debounceTimer = setTimeout(runRecompute, RECOMPUTE_DEBOUNCE);
 }
 
+// Start the singleton manager once. Idempotent: the `started` guard makes every
+// call after the first a no-op, so it is safe to call from every mount.
 function startManager() {
   if (started || typeof document === 'undefined') {
     return;
@@ -192,68 +209,45 @@ function startManager() {
   started = true;
   ensureNeutralizeStyle();
 
+  // Window geometry: resize, maximize, fullscreen toggle and docked-DevTools
+  // open/close (all change the renderer's CSS-pixel viewport).
   globalThis.addEventListener('resize', scheduleRecompute);
-  // 捕获阶段:内部滚动容器(如吸顶 header)滚动也要重算。
-  globalThis.addEventListener('scroll', scheduleRecompute, true);
 
-  // tab / modal 切换会翻转祖先的 aria-hidden;内容变化(header 重渲染、控件增删)
-  // 会改 childList —— 都要重算。忽略我们自己合成元素引起的 mutation,避免自触发。
-  const mo = new MutationObserver((records) => {
-    for (const m of records) {
-      if (m.type === 'attributes') {
-        scheduleRecompute();
-        return;
-      }
-      const nodes = [
-        ...Array.from(m.addedNodes),
-        ...Array.from(m.removedNodes),
-      ];
-      const onlySyn =
-        nodes.length > 0 &&
-        nodes.every(
-          (n) => n.nodeType === 1 && (n as Element).hasAttribute?.(SYN_ATTR),
-        );
-      if (!onlySyn) {
-        scheduleRecompute();
-        return;
-      }
-    }
-  });
+  // devicePixelRatio change — i.e. the window moved to a monitor with a
+  // different scale factor. A pure dpr change does NOT reliably fire `resize`
+  // (the CSS-pixel size is unchanged), so watch the output resolution
+  // explicitly. `matchMedia('(resolution: <dpr>dppx)')` flips when the dpr
+  // changes; re-arm it each time against the new dpr.
+  let dprQuery: MediaQueryList | null = null;
+  let onDprChange: () => void = () => undefined;
+  const armDprQuery = () => {
+    dprQuery?.removeEventListener('change', onDprChange);
+    dprQuery = globalThis.matchMedia(
+      `(resolution: ${globalThis.devicePixelRatio}dppx)`,
+    );
+    dprQuery.addEventListener('change', onDprChange);
+  };
+  onDprChange = () => {
+    scheduleRecompute();
+    armDprQuery();
+  };
+  armDprQuery();
+
+  // react-navigation keeps inactive tab screens mounted and only flips
+  // aria-hidden on their ancestors when switching tabs / opening a modal — that
+  // does NOT mount/unmount the zones, so it must be observed explicitly. The
+  // filter keeps this cheap: the callback only runs on aria-hidden changes
+  // (rare), not on general DOM churn. (Other layout changes are covered by the
+  // resize listener and by per-instance mount/unmount in the hook below.)
+  const mo = new MutationObserver(scheduleRecompute);
   mo.observe(document.documentElement, {
     attributes: true,
     attributeFilter: ['aria-hidden'],
-    childList: true,
     subtree: true,
   });
 
-  cleanupFns = [
-    () => globalThis.removeEventListener('resize', scheduleRecompute),
-    () => globalThis.removeEventListener('scroll', scheduleRecompute, true),
-    () => mo.disconnect(),
-  ];
-
-  // 首帧立即算一次。
+  // Initial pass.
   scheduleRecompute();
-}
-
-function stopManager() {
-  if (!started) {
-    return;
-  }
-  started = false;
-  if (debounceTimer) {
-    clearTimeout(debounceTimer);
-    debounceTimer = null;
-  }
-  if (rafId) {
-    globalThis.cancelAnimationFrame(rafId);
-    rafId = 0;
-  }
-  pendingSince = 0;
-  cleanupFns.forEach((fn) => fn());
-  cleanupFns = [];
-  clearSynRegions();
-  removeNeutralizeStyle();
 }
 
 function useDesktopDragRegionManager(enabled: boolean) {
@@ -261,14 +255,15 @@ function useDesktopDragRegionManager(enabled: boolean) {
     if (!enabled || typeof document === 'undefined') {
       return undefined;
     }
-    refCount += 1;
+    // Ensure the singleton is running, then resync — a drag zone (re)mounted,
+    // e.g. in-tab navigation pushed a screen with a different header. This is
+    // the targeted replacement for a document-wide childList observer.
     startManager();
+    scheduleRecompute();
     return () => {
-      refCount -= 1;
-      if (refCount <= 0) {
-        refCount = 0;
-        stopManager();
-      }
+      // A drag zone unmounted — resync the remaining ones. The manager itself
+      // is never torn down (singleton for the window's lifetime).
+      scheduleRecompute();
     };
   }, [enabled]);
 }
@@ -290,11 +285,12 @@ function DesktopDragZoneBoxMac({
   disabled,
   ...rest
 }: IDesktopDragZoneBoxProps) {
-  // 启动全局命令式拖拽区管理器(idempotent + ref-count)。
+  // Start the global imperative drag-region manager (idempotent + ref-counted).
   useDesktopDragRegionManager(!disabled);
 
-  // 只挂 marker 类(其真实 app-region 已被 neutralize style 中和),不直接产生原生
-  // 拖拽区 —— 拖拽/no-drag 全部由管理器命令式合成。
+  // Only carry the marker class (its real app-region is neutralized by the
+  // injected style); the actual drag / no-drag regions are synthesized by the
+  // manager.
   return (
     <Stack
       {...rest}

--- a/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
+++ b/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
@@ -11,12 +11,35 @@ const dragZoneStyle = {
   cursor: 'default',
 } as const;
 
-// Selectors for descendants that should remain clickable inside an
-// app-region:drag container. Chromium's region calculator unreliably honours
-// such descendants once they live deep inside Tamagui-generated trees (see
-// electron/electron#41695, #27149, #20926), so for every match we mirror a
-// fresh fixed-position no-drag ghost element at body level. Ghosts are
-// pointer-events:none so real clicks still reach the underlying control.
+// =============================================================================
+// macOS 顶栏拖拽区:命令式合成方案
+//
+// 背景:macOS(Electron 39 / upstream electron#21034)上,直接写在 DOM 上的
+// `-webkit-app-region: drag` 在窗口 resize、显示器/DPI 变化、tab 切换(header 内容
+// 变更)、modal 开关等"拖拽区布局变化"之后,原生 NSWindow 的拖拽区不会重新计算 →
+// 出现"DOM 正确但拖不动"。且任何把【可见】节点移出 DOM 再放回的修法都会闪一帧。
+//
+// 方案:
+//   1. header 元素只保留 `app-region-drag` 类作【标记】,本身的真实 app-region 被
+//      下面注入的 style 中和(永不产生陈旧的原生区域);
+//   2. 一个全局命令式管理器读取这些标记,按当前几何【新鲜地】合成:
+//        - 覆盖标记区的不可见 drag 蒙层
+//        - 覆盖其中各 no-drag 控件(按钮/输入框…)的不可见 no-drag 洞
+//      全部是 body 级、position:fixed、opacity:0、pointer-events:none 的元素;
+//   3. resize / scroll / tab(aria-hidden)/ 内容变化 时,debounce 后【清→重算→重贴】。
+//   合成元素全程不可见 ⇒ 不闪;每次都是全新元素 ⇒ 永不陈旧;集中一处 ⇒ 取代旧的
+//   per-instance ghost 机制,简化。
+// =============================================================================
+
+const MARKER_CLASS = 'app-region-drag';
+const SYN_ATTR = 'data-onekey-syn-region';
+const NEUTRALIZE_STYLE_ID = 'onekey-drag-region-neutralize';
+const RECOMPUTE_DEBOUNCE = 200;
+// 连续 DOM 变动(列表滚动、动画…)会不停重置 debounce。MAX_WAIT 保证最多等这么久
+// 就强制重算一次,避免拖拽区在持续抖动期间一直得不到刷新。
+const RECOMPUTE_MAX_WAIT = 600;
+
+// Descendants of a drag zone that must stay clickable → punched as no-drag holes.
 const NO_DRAG_SELECTOR = [
   '.app-region-no-drag',
   'input',
@@ -29,203 +52,225 @@ const NO_DRAG_SELECTOR = [
   '[class*="is_GroupFrame"]',
 ].join(',');
 
-const GHOST_ATTR = 'data-onekey-drag-mask-ghost';
+let refCount = 0;
+let started = false;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let rafId = 0;
+let pendingSince = 0;
+let cleanupFns: Array<() => void> = [];
 
-function useDragMaskMirror(
-  rootRef: React.MutableRefObject<HTMLElement | null>,
-  enabled: boolean,
-) {
-  useEffect(() => {
+// 中和所有 .app-region-drag 标记的真实 app-region —— 让它们只当标记,不产生原生区域。
+// 控件的 no-drag 也一并中和(改由合成洞负责),避免与合成区域顺序冲突。
+function ensureNeutralizeStyle() {
+  if (document.getElementById(NEUTRALIZE_STYLE_ID)) {
+    return;
+  }
+  const style = document.createElement('style');
+  style.id = NEUTRALIZE_STYLE_ID;
+  style.textContent = `
+.${MARKER_CLASS},
+.${MARKER_CLASS} button,
+.${MARKER_CLASS} input,
+.${MARKER_CLASS} textarea,
+.${MARKER_CLASS} a,
+.${MARKER_CLASS} [role="button"] {
+  -webkit-app-region: none !important;
+}
+[${SYN_ATTR}] { pointer-events: none; }
+`;
+  document.head.appendChild(style);
+}
+
+function removeNeutralizeStyle() {
+  document.getElementById(NEUTRALIZE_STYLE_ID)?.remove();
+}
+
+// 标记区是否真正可见(react-navigation 把非活跃 tab 留在 DOM 里,用 aria-hidden /
+// display / visibility 标隐藏 —— 这些区不能贡献拖拽区)。
+function isZoneShown(el: Element): boolean {
+  let cur: Element | null = el;
+  while (cur && cur !== document.body) {
+    const cs = globalThis.getComputedStyle(cur);
     if (
-      !enabled ||
-      // SSR guard: this hook never runs server-side, but be defensive in
-      // case the bundle is imported from a non-DOM context.
-      // eslint-disable-next-line unicorn/prefer-global-this
-      typeof window === 'undefined'
+      cs.display === 'none' ||
+      cs.visibility === 'hidden' ||
+      cs.visibility === 'collapse'
     ) {
-      return undefined;
+      return false;
     }
-    const root = rootRef.current;
-    if (!root) {
-      return undefined;
+    if (cur.getAttribute('aria-hidden') === 'true') {
+      return false;
     }
+    cur = cur.parentElement;
+  }
+  return true;
+}
 
-    const ghosts = new Map<Element, HTMLDivElement>();
-    let rafId = 0;
-    let scheduled = false;
+function makeRegionEl(
+  rect: DOMRect,
+  region: 'drag' | 'no-drag',
+): HTMLDivElement {
+  const el = document.createElement('div');
+  el.setAttribute(SYN_ATTR, region);
+  el.style.cssText =
+    `position:fixed;pointer-events:none;opacity:0;z-index:0;` +
+    `left:${Math.round(rect.left)}px;top:${Math.round(rect.top)}px;` +
+    `width:${Math.round(rect.width)}px;height:${Math.round(rect.height)}px;` +
+    `-webkit-app-region:${region};`;
+  return el;
+}
 
-    const applyRect = (el: Element, ghost: HTMLDivElement) => {
-      const r = (el as HTMLElement).getBoundingClientRect();
-      if (r.width === 0 || r.height === 0) {
-        // hidden / collapsed → contribute nothing to the mask
-        ghost.style.width = '0px';
-        ghost.style.height = '0px';
-        return;
+function clearSynRegions() {
+  document.querySelectorAll(`[${SYN_ATTR}]`).forEach((el) => el.remove());
+}
+
+// 命令式重算:清掉旧合成区 → 按当前几何重建 drag 蒙层 + no-drag 洞 → 重新贴上。
+// drag 先 append、no-drag 后 append(原生区域按 DOM 顺序 union/difference,
+// 后面的 no-drag 才能从前面的 drag 上减出可点击的洞)。
+function recompute() {
+  if (!document.body || !document.body.isConnected) {
+    return;
+  }
+  clearSynRegions();
+  const zones = Array.from(
+    document.querySelectorAll(`.${MARKER_CLASS}`),
+  ).filter((z) => {
+    const r = z.getBoundingClientRect();
+    return r.width > 0 && r.height > 0 && isZoneShown(z);
+  });
+  const drags: HTMLDivElement[] = [];
+  const holes: HTMLDivElement[] = [];
+  for (const zone of zones) {
+    drags.push(makeRegionEl(zone.getBoundingClientRect(), 'drag'));
+    zone.querySelectorAll(NO_DRAG_SELECTOR).forEach((nd) => {
+      const r = (nd as HTMLElement).getBoundingClientRect();
+      if (r.width > 0 && r.height > 0) {
+        holes.push(makeRegionEl(r, 'no-drag'));
       }
-      ghost.style.left = `${r.left}px`;
-      ghost.style.top = `${r.top}px`;
-      ghost.style.width = `${r.width}px`;
-      ghost.style.height = `${r.height}px`;
-    };
-
-    const ensureGhost = (el: Element) => {
-      let ghost = ghosts.get(el);
-      if (!ghost) {
-        ghost = document.createElement('div');
-        ghost.className = 'app-region-no-drag';
-        ghost.setAttribute(GHOST_ATTR, '');
-        ghost.style.cssText =
-          'position:fixed;pointer-events:none;z-index:2147483647;left:0;top:0;width:0;height:0;';
-        document.body.appendChild(ghost);
-        ghosts.set(el, ghost);
-      }
-      applyRect(el, ghost);
-    };
-
-    const clearGhosts = () => {
-      ghosts.forEach((ghost) => ghost.remove());
-      ghosts.clear();
-    };
-
-    // react-navigation on web marks inactive tab containers with
-    // `aria-hidden="true"` (often paired with `z-index: -1` to push them
-    // behind the active screen). The hidden container still has layout, so
-    // width/height/visibility/display alone do not detect it. Walk up the
-    // ancestor chain and treat any of those signals as "this root lives in
-    // a stale background tab" — skip the entire sync and clear ghosts.
-    const isRootShown = () => {
-      let cur: Element | null = root;
-      while (cur && cur !== document.body) {
-        const cs = globalThis.getComputedStyle(cur);
-        if (
-          cs.display === 'none' ||
-          cs.visibility === 'hidden' ||
-          cs.visibility === 'collapse'
-        ) {
-          return false;
-        }
-        if (cur.getAttribute('aria-hidden') === 'true') {
-          return false;
-        }
-        cur = cur.parentElement;
-      }
-      return true;
-    };
-
-    // Toggle whether this drag zone contributes to the window's native
-    // draggable region, by adding/removing the `app-region-drag` class.
-    //
-    // Why the class and not an inline `-webkit-app-region` value: Chromium
-    // computes the region as `union(drag rects) − union(no-drag rects)`, where a
-    // `no-drag` rect subtracts from EVERY overlapping drag rect, not just its
-    // own zone. The inactive tab headers sit at the SAME full-width position as
-    // the active header, so the inactive zone must contribute *nothing* — not
-    // `drag` (it would overlap and swallow active controls; the original bug),
-    // and not `no-drag` (it would carve a full-width hole out of the active
-    // header, leaving only the sidebar draggable). The only neutral state is the
-    // ABSENCE of any `-webkit-app-region` declaration: an explicit
-    // `-webkit-app-region: none` is coerced to `no-drag` by Chromium, so it is
-    // NOT neutral. Removing the `app-region-drag` class drops both the root's
-    // `drag` and the CSS-driven `no-drag` on its descendants
-    // (`.app-region-drag button`, …), making the whole inactive subtree neutral.
-    //
-    // React won't fight this: the `className` prop value is the constant
-    // `'app-region-drag'` (when enabled), so React only writes className when
-    // that value changes — never on a plain re-render — leaving our classList
-    // edits intact (the same contract the body-level ghosts rely on).
-    const setRootDraggable = (draggable: boolean) => {
-      root.classList.toggle('app-region-drag', draggable);
-    };
-
-    const sync = () => {
-      scheduled = false;
-      if (!document.body.isConnected) return;
-      if (!isRootShown()) {
-        // ---- Inactive-tab drag-region leak fix (OK-55535) ----
-        // react-navigation keeps inactive tab/screen containers mounted (via
-        // react-freeze) and marks them `aria-hidden="true"`. That is NOT
-        // `display:none`, so a frozen header keeps its layout and Chromium
-        // still unions its `-webkit-app-region: drag` rect into the window's
-        // native draggable region. A header frozen in its narrow two-row form
-        // (104px tall) then overlaps controls in the ACTIVE screen — e.g. the
-        // account selector — that are NOT this zone's DOM descendants, so the
-        // body-level ghost mask (which mirrors descendants only) can't protect
-        // them and their clicks get eaten as window drags. This surfaces on
-        // displays where the active layout doesn't also cover them (typically
-        // devicePixelRatio = 1, i.e. an external monitor at native/high
-        // resolution). Drop the drag region while hidden so the frozen zone
-        // stops swallowing clicks; the active zone keeps its drag region, so
-        // window dragging is unaffected.
-        setRootDraggable(false);
-        clearGhosts();
-        return;
-      }
-      setRootDraggable(true);
-      const rootRect = root.getBoundingClientRect();
-      if (rootRect.width === 0 || rootRect.height === 0) {
-        clearGhosts();
-        return;
-      }
-      const matches = root.querySelectorAll(NO_DRAG_SELECTOR);
-      const seen = new Set<Element>();
-      matches.forEach((el) => {
-        const rect = (el as HTMLElement).getBoundingClientRect();
-        if (rect.width === 0 || rect.height === 0) return;
-        seen.add(el);
-        ensureGhost(el);
-      });
-      // Drop ghosts whose source vanished or was removed from the subtree.
-      ghosts.forEach((ghost, el) => {
-        if (!seen.has(el)) {
-          ghost.remove();
-          ghosts.delete(el);
-        }
-      });
-    };
-
-    const schedule = () => {
-      if (scheduled) return;
-      scheduled = true;
-      rafId = globalThis.requestAnimationFrame(sync);
-    };
-
-    // Initial pass — handles the common case where children are already in
-    // the tree at mount time. The follow-up observers cover later mutations.
-    sync();
-
-    const subtreeObserver = new MutationObserver(schedule);
-    subtreeObserver.observe(root, { childList: true, subtree: true });
-
-    // react-navigation toggles aria-hidden on ancestor tab containers when
-    // the user switches tabs. Those mutations live OUTSIDE this root subtree
-    // so the subtree observer above won't see them. Watch document-wide for
-    // aria-hidden attribute flips so each instance can re-evaluate whether
-    // it still belongs to the active tab and clear its ghosts when not.
-    const ancestorObserver = new MutationObserver(schedule);
-    ancestorObserver.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['aria-hidden'],
-      subtree: true,
     });
+  }
+  drags.forEach((d) => document.body.appendChild(d));
+  holes.forEach((h) => document.body.appendChild(h));
+}
 
-    const resizeObserver = new ResizeObserver(schedule);
-    resizeObserver.observe(root);
+function runRecompute() {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+  pendingSince = 0;
+  if (rafId) {
+    globalThis.cancelAnimationFrame(rafId);
+  }
+  // rAF:等布局/样式结算后再读 rect 重算。
+  rafId = globalThis.requestAnimationFrame(() => {
+    rafId = 0;
+    recompute();
+  });
+}
 
-    globalThis.addEventListener('resize', schedule);
-    // Use capture so inner scroll containers also trigger a resync.
-    globalThis.addEventListener('scroll', schedule, true);
+function scheduleRecompute() {
+  const now = Date.now();
+  if (pendingSince === 0) {
+    pendingSince = now;
+  }
+  // 持续抖动到达 MAX_WAIT:立即重算,不再等待。
+  if (now - pendingSince >= RECOMPUTE_MAX_WAIT) {
+    runRecompute();
+    return;
+  }
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+  }
+  debounceTimer = setTimeout(runRecompute, RECOMPUTE_DEBOUNCE);
+}
 
+function startManager() {
+  if (started || typeof document === 'undefined') {
+    return;
+  }
+  started = true;
+  ensureNeutralizeStyle();
+
+  globalThis.addEventListener('resize', scheduleRecompute);
+  // 捕获阶段:内部滚动容器(如吸顶 header)滚动也要重算。
+  globalThis.addEventListener('scroll', scheduleRecompute, true);
+
+  // tab / modal 切换会翻转祖先的 aria-hidden;内容变化(header 重渲染、控件增删)
+  // 会改 childList —— 都要重算。忽略我们自己合成元素引起的 mutation,避免自触发。
+  const mo = new MutationObserver((records) => {
+    for (const m of records) {
+      if (m.type === 'attributes') {
+        scheduleRecompute();
+        return;
+      }
+      const nodes = [
+        ...Array.from(m.addedNodes),
+        ...Array.from(m.removedNodes),
+      ];
+      const onlySyn =
+        nodes.length > 0 &&
+        nodes.every(
+          (n) => n.nodeType === 1 && (n as Element).hasAttribute?.(SYN_ATTR),
+        );
+      if (!onlySyn) {
+        scheduleRecompute();
+        return;
+      }
+    }
+  });
+  mo.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['aria-hidden'],
+    childList: true,
+    subtree: true,
+  });
+
+  cleanupFns = [
+    () => globalThis.removeEventListener('resize', scheduleRecompute),
+    () => globalThis.removeEventListener('scroll', scheduleRecompute, true),
+    () => mo.disconnect(),
+  ];
+
+  // 首帧立即算一次。
+  scheduleRecompute();
+}
+
+function stopManager() {
+  if (!started) {
+    return;
+  }
+  started = false;
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+  if (rafId) {
+    globalThis.cancelAnimationFrame(rafId);
+    rafId = 0;
+  }
+  pendingSince = 0;
+  cleanupFns.forEach((fn) => fn());
+  cleanupFns = [];
+  clearSynRegions();
+  removeNeutralizeStyle();
+}
+
+function useDesktopDragRegionManager(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled || typeof document === 'undefined') {
+      return undefined;
+    }
+    refCount += 1;
+    startManager();
     return () => {
-      subtreeObserver.disconnect();
-      ancestorObserver.disconnect();
-      resizeObserver.disconnect();
-      globalThis.removeEventListener('resize', schedule);
-      globalThis.removeEventListener('scroll', schedule, true);
-      if (rafId) globalThis.cancelAnimationFrame(rafId);
-      ghosts.forEach((ghost) => ghost.remove());
-      ghosts.clear();
+      refCount -= 1;
+      if (refCount <= 0) {
+        refCount = 0;
+        stopManager();
+      }
     };
-  }, [enabled, rootRef]);
+  }, [enabled]);
 }
 
 function BaseDesktopDragZoneBox({
@@ -245,21 +290,15 @@ function DesktopDragZoneBoxMac({
   disabled,
   ...rest
 }: IDesktopDragZoneBoxProps) {
-  const rootRef = useRef<HTMLElement | null>(null);
-  useDragMaskMirror(rootRef, !disabled);
+  // 启动全局命令式拖拽区管理器(idempotent + ref-count)。
+  useDesktopDragRegionManager(!disabled);
 
-  // Toggle className/style instead of swapping keys so Chromium can
-  // incrementally update its non-client drag mask without tearing down the
-  // subtree mid-drag. The mirror hook above creates body-level no-drag
-  // ghosts to compensate for Chromium's unreliable in-tree mask calculation.
-  // Tamagui's Stack types its ref as TamaguiElement which on web resolves to
-  // the underlying HTMLDivElement; cast through `any` to bridge the gap.
+  // 只挂 marker 类(其真实 app-region 已被 neutralize style 中和),不直接产生原生
+  // 拖拽区 —— 拖拽/no-drag 全部由管理器命令式合成。
   return (
     <Stack
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ref={rootRef as any}
       {...rest}
-      className={disabled ? undefined : 'app-region-drag'}
+      className={disabled ? undefined : MARKER_CLASS}
       style={disabled ? style : dragZoneStyle}
     >
       {children}

--- a/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
+++ b/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
@@ -34,9 +34,9 @@ const dragZoneStyle = {
 //        - `no-drag` holes covering the clickable controls inside it.
 //      All overlays are body-level, position:fixed, opacity:0,
 //      pointer-events:none.
-//   3. On resize / scroll / aria-hidden (tab, modal) / DOM mutations the
-//      overlays are cleared, recomputed and re-attached (debounced, with a
-//      max-wait guard).
+//   3. On resize / DPI change / aria-hidden (tab, modal) flips and zone
+//      mount/unmount the overlays are cleared, recomputed and re-attached
+//      (debounced, with a max-wait guard).
 //   Fresh overlays => never stale; invisible => no flicker; one central place
 //   => replaces (and removes) the previous per-instance ghost-mirror.
 // =============================================================================
@@ -45,9 +45,10 @@ const MARKER_CLASS = 'app-region-drag';
 const SYN_ATTR = 'data-onekey-syn-region';
 const NEUTRALIZE_STYLE_ID = 'onekey-drag-region-neutralize';
 const RECOMPUTE_DEBOUNCE = 200;
-// Continuous DOM activity (list scrolling, animations, …) keeps resetting the
-// debounce timer. MAX_WAIT guarantees a recompute fires at least this often so
-// the draggable region is never starved while the page keeps churning.
+// A continuous stream of triggers (e.g. live window resizing fires `resize`
+// rapidly) keeps resetting the debounce timer. MAX_WAIT guarantees a recompute
+// fires at least this often so the draggable region is never starved while the
+// events keep coming.
 const RECOMPUTE_MAX_WAIT = 600;
 
 // Descendants of a drag zone that must stay clickable → punched as no-drag holes.


### PR DESCRIPTION
## 问题

macOS 桌面端,多次 resize 窗口 / 切换 tab / 开关 modal 后,**顶栏拖不动窗口**(右上空白区等)。DOM 里 `-webkit-app-region: drag` 始终正确,但 Electron 没把拖拽区重新下发给原生 NSWindow → "DOM 对、却拖不动"。属上游 [electron/electron#21034](https://github.com/electron/electron/issues/21034)(自 v7.1.0 起的回归,至今未修)。

触发场景:window resize、显示器/DPI 变化、tab 切换(header 内容变更)、modal 开关、docked DevTools。

## 排查结论(真实事件验证)

- 用真实 OS 鼠标事件复现并定位:Blink 区域正确,**原生区域陈旧**。
- `focus()/moveTop()/setAlwaysOnTop()` 能修但是**主进程**(不可热更新);
- remove+readd **可见** header 节点能修但**闪一帧**;
- class toggle / 探针等不碰真实节点的手段**修不好**。

## 方案(纯渲染层、可热更新、不闪)

把 per-instance 的 ghost-mirror 换成**单一命令式管理器**:

- header 区只保留 `app-region-drag` 类作**标记**,其真实 app-region 被中和 → 永不产生陈旧原生区域;
- 拖拽区 + 控件 no-drag 洞 → 按标记几何**命令式合成**为 body 级、`position:fixed`、`opacity:0`、`pointer-events:none` 的**不可见 overlay**;
- 在 resize / scroll / aria-hidden / DOM 变化时 **debounce(带 maxWait 兜底)→ 清→重算→重贴**。

全新鲜 ⇒ 永不陈旧;不可见 ⇒ 不闪;纯渲染层 ⇒ **可热更新**。顺带移除了复杂的 ghost 机制。

## 验证(本地真机)

- ✅ 拖顶栏空白可拖、搜索框/按钮可点
- ✅ **缩到最小再拉大**后仍可拖(原回归点)
- ✅ 切 tab(钱包↔合约↔市场)后可拖可点
- ✅ resize / 全屏切换 / 最大化均正常
- ✅ 全程不闪、不卡;红/蓝可视化确认蒙层与洞对齐

## 影响面

仅 `DesktopDragZoneBox/index.desktop.tsx`(macOS 自定义标题栏路径);非桌面端走 `BaseDesktopDragZoneBox` 不受影响。

https://claude.ai/code/session_01GWwrRY3mZUR1sUQge17qPV
