### PR TITLE
fix(web): unblock service worker install (drop full-app precache) + CacheFirst for immutable JS/CSS

### DIFF
--- a/apps/web/src/service-worker.js
+++ b/apps/web/src/service-worker.js
@@ -3,11 +3,7 @@
 import { ExpirationPlugin } from 'workbox-expiration';
 import { precacheAndRoute } from 'workbox-precaching';
 import { NavigationRoute, registerRoute } from 'workbox-routing';
-import {
-  CacheFirst,
-  NetworkFirst,
-  StaleWhileRevalidate,
-} from 'workbox-strategies';
+import { CacheFirst, NetworkFirst } from 'workbox-strategies';
 
 // Skip waiting immediately on install so existing users with old SW get
 // the fix without needing to confirm the update prompt or close all tabs.
@@ -50,16 +46,25 @@ registerRoute(
   }),
 );
 
-// JS/CSS chunks -> StaleWhileRevalidate
+// JS/CSS chunks -> CacheFirst.
+// These assets are immutable: they are served from app-assets.onekey.so under a
+// per-build path + contenthash filename, so a given URL's bytes never change
+// (new content -> new URL). StaleWhileRevalidate would re-fetch every cached
+// chunk in the background on each load — and because the asset host sends NO
+// `Cache-Control: immutable`, that revalidation costs a real network round-trip
+// for content that cannot have changed. CacheFirst serves from cache without
+// revalidating. It is safe here: the asset host returns a genuine 404 (not an
+// HTML fallback) for missing files, and CacheFirst caches only 200 responses, so
+// a missing chunk is never pinned. Old build URLs fall out via expiration.
 registerRoute(
   ({ request }) =>
     request.destination === 'script' || request.destination === 'style',
-  new StaleWhileRevalidate({
+  new CacheFirst({
     cacheName: 'static-resources',
     plugins: [
       new ExpirationPlugin({
-        maxEntries: 200,
-        maxAgeSeconds: 7 * 24 * 60 * 60,
+        maxEntries: 300,
+        maxAgeSeconds: 30 * 24 * 60 * 60,
       }),
     ],
   }),

--- a/development/webpack/webpack.web.config.js
+++ b/development/webpack/webpack.web.config.js
@@ -39,12 +39,17 @@ module.exports = ({
             new InjectManifest({
               swSrc: path.join(basePath, 'src/service-worker.js'),
               swDest: 'service-worker.js',
-              exclude: [
-                /\.map$/,
-                /asset-manifest\.json$/,
-                /LICENSE/,
-                /index\.html$/,
-              ],
+              // Precache NOTHING. This is a large SPA (~800+ chunks); the
+              // InjectManifest default precaches every emitted asset, which makes
+              // the SW `install` an ATOMIC all-or-nothing fetch of every file —
+              // one failed/blocked/throttled request leaves the SW stuck "trying
+              // to install" forever (observed in prod/test: #2500+ installs with
+              // ERR_CONNECTION_CLOSED bursts). Every asset is already covered by
+              // the runtime caching routes in service-worker.js (NetworkFirst
+              // navigations, StaleWhileRevalidate scripts/styles, CacheFirst
+              // images/fonts), so a full precache adds fragility with no benefit.
+              // `exclude: [/./]` matches every manifest URL -> empty precache.
+              exclude: [/./],
             }),
           ],
         },


### PR DESCRIPTION
## Summary

Targets `release/v6.4.0`. Fixes the web Service Worker getting stuck at `trying to install` (observed as `#2500+` install attempts on app.onekey.so / app.onekeytest.com), and optimizes static-asset caching. Two focused commits, **2 files** total — no rspack-migration content.

### 1. `fix`: stop full-app precache that blocks SW install
`InjectManifest` defaulted to precaching **every** emitted asset (~830 chunks). Workbox precache is atomic (`cache.addAll`): a single failed/blocked/throttled request fails the whole `install`, leaving the SW permanently stuck installing (seen with `ERR_CONNECTION_CLOSED` bursts).

- Set `exclude: [/./]` in the **webpack** web config (the bundler this release uses) → empty precache manifest. `install` no longer depends on fetching hundreds of files.
- Every asset is already covered by the SW's runtime routes (NetworkFirst navigations, CacheFirst images/fonts, CacheFirst scripts/styles), so a full precache added fragility with no benefit.
- Verified with an isolated webpack InjectManifest build: the entry chunk is precached by default and not precached after the change; build succeeds.

### 2. `perf`: CacheFirst for immutable hashed JS/CSS instead of SWR
Script/style assets are served from `app-assets.onekey.so/<build-id>/<name>.<contenthash>.bundle.js` — immutable URLs. The host sends an `etag` but **no `Cache-Control: immutable`**, so StaleWhileRevalidate did a real network round-trip per chunk on every load for content that can't change.

- Switch the script/style route to **CacheFirst**. Safe: the asset host returns a genuine 404 (not an HTML fallback) for missing files and CacheFirst caches only 200, so a missing chunk is never pinned; old build URLs age out via expiration.
- Verified by bundling the SW and exercising a script fetch in a mocked SW scope (200 → cached, 404 → not).

## Out of scope — infra/ops (cannot be fixed in this repo)
Found during investigation; these are CDN/host config, not code:
- [ ] **CSP `connect-src`** is missing `https://*.onekey-asset.com` (already in `img-src`/`font-src`/`worker-src`) → icons fetched via `expo-image` prefetch (which uses `fetch()`) are CSP-blocked. Sentry ingest domain is also missing → error reporting blocked. Add both to `connect-src`.
- [ ] **Prod `app.onekey.so/service-worker.js` returns `index.html` (text/html)** — the SW file isn't served as JS from the HTML host (SPA fallback). Even with this PR, prod can't install the SW until `/service-worker.js` is served as real JS (rewrite exclusion + correct MIME + purge CF cache).
- [ ] Some token icons genuinely 404 at the CDN (missing art) → app-layer `<img onerror>` fallback.

https://claude.ai/code/session_015y5xGwSzPdNdzpMumgrfEE