### PR TITLE
fix: sort perp hot and new tabs(OK-56817)

### DIFF
--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -783,6 +783,7 @@ export const {
     direction: 'desc',
     activeTab: DEFAULT_PERP_TOKEN_ACTIVE_TAB,
     sortSource: 'default',
+    sortSourceTab: undefined,
   },
 });
 

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -782,6 +782,7 @@ export const {
     field: 'volume24h',
     direction: 'desc',
     activeTab: DEFAULT_PERP_TOKEN_ACTIVE_TAB,
+    sortSource: 'default',
   },
 });
 

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -103,13 +103,16 @@ import {
   buildPerpTokenSelectorCategoryTabs,
   buildPerpTokenSelectorTabs,
   buildPrimaryTabs,
+  getNextPerpTokenSelectorSortConfig,
+  getPerpTokenSelectorDynamicTabItems,
   getPerpTokenSelectorFallbackTabId,
   getPerpTokenSelectorPrimaryTabId,
+  getPerpTokenSelectorSortAssetCtxsByDex,
   isPerpTokenSelectorFavoritesTab,
   isPerpTokenSelectorPerpsTab,
+  isPerpTokenSelectorSortFieldActive,
   isPerpTokenSelectorSpotTab,
   shouldRefreshPerpTokenSelectorSortSnapshot,
-  sortPerpTokenSelectorItemsByServerOrder,
 } from '../../utils/tokenSelectorTabs';
 
 import { FavoritesEmptyState } from './FavoritesEmptyState';
@@ -540,13 +543,16 @@ function MobileTokenSelectorModal({
   // Freeze sort order; only refresh on sort config change or first data arrival.
   // Does NOT track activeTab — tab switches should not refresh the snapshot.
   const ctxSnapshotRef = useRef(assetCtxsByDex);
+  const [perpSortSnapshot, setPerpSortSnapshot] = useState(assetCtxsByDex);
   const lastSortRef = useRef<{
     field?: string;
     direction?: string;
+    sortSource?: IPerpTokenSelectorConfig['sortSource'];
   } | null>(null);
   useEffect(() => {
     const field = selectorConfig?.field;
     const direction = selectorConfig?.direction;
+    const sortSource = selectorConfig?.sortSource;
     const last = lastSortRef.current;
     // Also refresh when snapshot is empty (first WS data arrival after mount)
     const snapshotEmpty = !ctxSnapshotRef.current?.some(
@@ -556,19 +562,26 @@ function MobileTokenSelectorModal({
       lastSort: last,
       field,
       direction,
+      sortSource,
       snapshotEmpty,
     });
     if (!shouldRefresh) {
       return;
     }
-    lastSortRef.current = { field, direction };
+    lastSortRef.current = { field, direction, sortSource };
     ctxSnapshotRef.current = assetCtxsByDex;
-    if (last?.field !== field || last?.direction !== direction) {
+    setPerpSortSnapshot(assetCtxsByDex);
+    if (
+      last?.field !== field ||
+      last?.direction !== direction ||
+      last?.sortSource !== sortSource
+    ) {
       scrollListToTop();
     }
   }, [
     selectorConfig?.direction,
     selectorConfig?.field,
+    selectorConfig?.sortSource,
     assetCtxsByDex,
     scrollListToTop,
   ]);
@@ -625,6 +638,7 @@ function MobileTokenSelectorModal({
           field: prev?.field ?? DEFAULT_PERP_TOKEN_SORT_FIELD,
           direction: prev?.direction ?? DEFAULT_PERP_TOKEN_SORT_DIRECTION,
           activeTab: tab,
+          sortSource: prev?.sortSource ?? 'default',
         }));
       });
       actions.current.setTradeRouteViewState({
@@ -718,11 +732,16 @@ function MobileTokenSelectorModal({
 
   // Layer 1: sort — only reruns when sort config or underlying assets change.
   // Does NOT depend on activeTab, so tab switches never retrigger the sort.
+  const perpSortAssetCtxsByDex = getPerpTokenSelectorSortAssetCtxsByDex({
+    liveAssetCtxsByDex: assetCtxsByDex,
+    snapshotAssetCtxsByDex: perpSortSnapshot,
+    sortSource: selectorConfig?.sortSource,
+  });
   const perpSortedList = useMemo(() => {
     const perfStartTime = startTokenSelectorPerfMeasure();
     const assetsByDexTyped: IPerpsUniverse[][] = assetsByDex || [];
     const assetCtxsByDexTyped: IPerpsAssetCtx[][] =
-      ctxSnapshotRef.current || [];
+      perpSortAssetCtxsByDex || [];
 
     const combinedEntries = assetsByDexTyped.flatMap(
       (assets: IPerpsUniverse[], dexIndex: number) => {
@@ -751,6 +770,7 @@ function MobileTokenSelectorModal({
 
     const sortField = selectorConfig?.field ?? '';
     const sortDirection = selectorConfig?.direction ?? 'desc';
+    const sortSource = selectorConfig?.sortSource;
     const result = sortField
       ? combinedEntries
           .toSorted((a, b) =>
@@ -768,6 +788,7 @@ function MobileTokenSelectorModal({
         phase: 'perp-sort',
         sortField,
         sortDirection,
+        sortSource,
         perpCount: combinedEntries.length,
         resultCount: result.length,
       });
@@ -777,9 +798,11 @@ function MobileTokenSelectorModal({
   }, [
     assetsByDex,
     computeSortValues,
+    perpSortAssetCtxsByDex,
     sortCompare,
     selectorConfig?.direction,
     selectorConfig?.field,
+    selectorConfig?.sortSource,
     tokenSearchAliases,
   ]);
 
@@ -958,22 +981,10 @@ function MobileTokenSelectorModal({
     } else {
       const dynamicTab = categoryTabs.find((t) => t.tabId === displayActiveTab);
       if (dynamicTab) {
-        const tokenSet = new Set(dynamicTab.tokens);
-        const tokenNameById = new Map<string, string>();
-        (assetsByDex || []).forEach((assets, dexIndex) => {
-          assets?.forEach((asset) => {
-            if (tokenSet.has(asset.name)) {
-              tokenNameById.set(`${dexIndex}-${asset.assetId}`, asset.name);
-            }
-          });
-        });
-        result = sortPerpTokenSelectorItemsByServerOrder({
-          items: perpSortedList.filter((item) =>
-            tokenNameById.has(`${item.dexIndex}-${item.assetId}`),
-          ),
-          tokenOrder: dynamicTab.tokens,
-          getTokenName: (item) =>
-            tokenNameById.get(`${item.dexIndex}-${item.assetId}`),
+        result = getPerpTokenSelectorDynamicTabItems({
+          items: perpSortedList,
+          tokens: dynamicTab.tokens,
+          useSortedItemsOrder: selectorConfig?.sortSource === 'user',
         });
       } else {
         result = perpSortedList;
@@ -1000,7 +1011,6 @@ function MobileTokenSelectorModal({
   }, [
     displayActiveTab,
     displayPrimaryTab,
-    assetsByDex,
     categoryTabs,
     favoritesOrder.sequence,
     favoriteItems,
@@ -1008,6 +1018,7 @@ function MobileTokenSelectorModal({
     perpSortedList,
     selectorConfig?.direction,
     selectorConfig?.field,
+    selectorConfig?.sortSource,
     spotFavoriteSortedList,
     spotMarketCaps,
     spotPriceSnapshot,
@@ -1115,36 +1126,29 @@ function MobileTokenSelectorModal({
   const handleSortPress = useCallback(
     (field: IPerpTokenSortField) => {
       setSelectorConfig((prev: IPerpTokenSelectorConfig | null) => {
-        if (prev?.field === field) {
-          if (prev.direction === 'asc') {
-            return {
-              field: DEFAULT_PERP_TOKEN_SORT_FIELD,
-              direction: DEFAULT_PERP_TOKEN_SORT_DIRECTION,
-              activeTab: prev.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB,
-            };
-          }
-          return {
-            field,
-            direction: 'asc',
-            activeTab: prev.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB,
-          };
-        }
-        return {
-          field,
-          direction: DEFAULT_PERP_TOKEN_SORT_DIRECTION,
-          activeTab: prev?.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB,
-        };
+        return getNextPerpTokenSelectorSortConfig({ prev, field });
       });
     },
     [setSelectorConfig],
   );
+  const activeSortTab =
+    selectorConfig?.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB;
+  const isVolumeSortActive = isPerpTokenSelectorSortFieldActive({
+    activeTab: activeSortTab,
+    field: 'volume24h',
+    sortField: selectorConfig?.field,
+    sortSource: selectorConfig?.sortSource,
+  });
+  const isChangeSortActive = isPerpTokenSelectorSortFieldActive({
+    activeTab: activeSortTab,
+    field: 'change24hPercent',
+    sortField: selectorConfig?.field,
+    sortSource: selectorConfig?.sortSource,
+  });
   let iconName: string;
-  if (
-    selectorConfig?.field === 'volume24h' &&
-    selectorConfig?.direction === 'asc'
-  ) {
+  if (isVolumeSortActive && selectorConfig?.direction === 'asc') {
     iconName = 'ChevronTopOutline';
-  } else if (selectorConfig?.field === 'volume24h') {
+  } else if (isVolumeSortActive) {
     iconName = 'ChevronBottomOutline';
   } else {
     iconName = 'ChevronGrabberVerOutline';
@@ -1289,9 +1293,7 @@ function MobileTokenSelectorModal({
         >
           <SizableText
             size="$bodyXs"
-            color={
-              selectorConfig?.field === 'volume24h' ? '$text' : '$textSubdued'
-            }
+            color={isVolumeSortActive ? '$text' : '$textSubdued'}
           >
             {intl.formatMessage({
               id: ETranslations.perp_token_selector_asset,
@@ -1312,11 +1314,7 @@ function MobileTokenSelectorModal({
         >
           <SizableText
             size="$bodyXs"
-            color={
-              selectorConfig?.field === 'change24hPercent'
-                ? '$text'
-                : '$textSubdued'
-            }
+            color={isChangeSortActive ? '$text' : '$textSubdued'}
           >
             {intl.formatMessage({
               id: ETranslations.perp_token_selector_last_price,
@@ -1326,10 +1324,10 @@ function MobileTokenSelectorModal({
               id: ETranslations.perp_token_selector_24h_change,
             })}
           </SizableText>
-          {selectorConfig?.field === 'change24hPercent' ? (
+          {isChangeSortActive ? (
             <Icon
               name={
-                selectorConfig.direction === 'asc'
+                selectorConfig?.direction === 'asc'
                   ? 'ChevronTopOutline'
                   : 'ChevronBottomOutline'
               }

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -734,14 +734,10 @@ function MobileTokenSelectorModal({
     [selectorConfig?.direction, selectorConfig?.field],
   );
 
-  // Layer 1: sort — only reruns when sort config or underlying assets change.
-  // Does NOT depend on activeTab, so tab switches never retrigger the sort.
+  // Layer 1: perp sort — always sorts against the frozen snapshot so live WS
+  // ticks do not re-sort the full perp universe.
   const perpSortAssetCtxsByDex = getPerpTokenSelectorSortAssetCtxsByDex({
-    activeTab: displayActiveTab,
-    liveAssetCtxsByDex: assetCtxsByDex,
     snapshotAssetCtxsByDex: perpSortSnapshot,
-    sortSource: selectorConfig?.sortSource,
-    sortSourceTab: selectorConfig?.sortSourceTab,
   });
   const perpSortedList = useMemo(() => {
     const perfStartTime = startTokenSelectorPerfMeasure();
@@ -935,8 +931,18 @@ function MobileTokenSelectorModal({
     selectorConfig?.direction,
   ]);
 
-  // Layer 2: filter — cheap O(n) filter; never runs sort.
-  // Tab switches and favorites changes only reach here, not the sort layer.
+  const activeDynamicTabUserSort = isPerpTokenSelectorDynamicTabUserSort({
+    activeTab: displayActiveTab,
+    sortSource: selectorConfig?.sortSource,
+    sortSourceTab: selectorConfig?.sortSourceTab,
+  });
+  const dynamicSortAssetCtxsByDex = activeDynamicTabUserSort
+    ? assetCtxsByDex
+    : undefined;
+
+  // Layer 2: filter — cheap O(n) filter; only dynamic user sort sorts the
+  // filtered dynamic-token subset against live values.
+  // Tab switches and favorites changes only reach here, not the full sort layer.
   const mockedListData = useMemo(() => {
     const perfStartTime = startTokenSelectorPerfMeasure();
     const sortField = selectorConfig?.field ?? '';
@@ -990,15 +996,45 @@ function MobileTokenSelectorModal({
     } else {
       const dynamicTab = categoryTabs.find((t) => t.tabId === displayActiveTab);
       if (dynamicTab) {
-        result = getPerpTokenSelectorDynamicTabItems({
+        const dynamicItems = getPerpTokenSelectorDynamicTabItems({
           items: perpSortedList,
           tokens: dynamicTab.tokens,
-          useSortedItemsOrder: isPerpTokenSelectorDynamicTabUserSort({
-            activeTab: displayActiveTab,
-            sortSource: selectorConfig?.sortSource,
-            sortSourceTab: selectorConfig?.sortSourceTab,
-          }),
         });
+        if (activeDynamicTabUserSort && sortField) {
+          result = dynamicItems
+            .map((item, index) => {
+              const asset = assetsByDex?.[item.dexIndex]?.[item.index];
+              const normalizedAssetId =
+                item.dexIndex === 1 && item.assetId !== undefined
+                  ? item.assetId - XYZ_ASSET_ID_OFFSET
+                  : item.assetId;
+              const assetCtx =
+                normalizedAssetId !== undefined
+                  ? dynamicSortAssetCtxsByDex?.[item.dexIndex]?.[
+                      normalizedAssetId
+                    ]
+                  : undefined;
+              return {
+                item,
+                index,
+                sortEntry: asset
+                  ? {
+                      asset,
+                      sortValues: computeSortValues(assetCtx),
+                    }
+                  : undefined,
+              };
+            })
+            .toSorted((a, b) => {
+              if (!a.sortEntry || !b.sortEntry) {
+                return a.index - b.index;
+              }
+              return sortCompare(a.sortEntry, b.sortEntry) || a.index - b.index;
+            })
+            .map(({ item }) => item);
+        } else {
+          result = dynamicItems;
+        }
       } else {
         result = perpSortedList;
       }
@@ -1024,15 +1060,17 @@ function MobileTokenSelectorModal({
   }, [
     displayActiveTab,
     displayPrimaryTab,
+    activeDynamicTabUserSort,
+    assetsByDex,
     categoryTabs,
     favoritesOrder.sequence,
     favoriteItems,
     computeSortValues,
+    dynamicSortAssetCtxsByDex,
     perpSortedList,
     selectorConfig?.direction,
     selectorConfig?.field,
-    selectorConfig?.sortSource,
-    selectorConfig?.sortSourceTab,
+    sortCompare,
     spotFavoriteSortedList,
     spotMarketCaps,
     spotPriceSnapshot,

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -103,11 +103,13 @@ import {
   buildPerpTokenSelectorCategoryTabs,
   buildPerpTokenSelectorTabs,
   buildPrimaryTabs,
+  getNextPerpTokenSelectorActiveTabConfig,
   getNextPerpTokenSelectorSortConfig,
   getPerpTokenSelectorDynamicTabItems,
   getPerpTokenSelectorFallbackTabId,
   getPerpTokenSelectorPrimaryTabId,
   getPerpTokenSelectorSortAssetCtxsByDex,
+  isPerpTokenSelectorDynamicTabUserSort,
   isPerpTokenSelectorFavoritesTab,
   isPerpTokenSelectorPerpsTab,
   isPerpTokenSelectorSortFieldActive,
@@ -548,11 +550,13 @@ function MobileTokenSelectorModal({
     field?: string;
     direction?: string;
     sortSource?: IPerpTokenSelectorConfig['sortSource'];
+    sortSourceTab?: IPerpTokenSelectorConfig['sortSourceTab'];
   } | null>(null);
   useEffect(() => {
     const field = selectorConfig?.field;
     const direction = selectorConfig?.direction;
     const sortSource = selectorConfig?.sortSource;
+    const sortSourceTab = selectorConfig?.sortSourceTab;
     const last = lastSortRef.current;
     // Also refresh when snapshot is empty (first WS data arrival after mount)
     const snapshotEmpty = !ctxSnapshotRef.current?.some(
@@ -563,18 +567,20 @@ function MobileTokenSelectorModal({
       field,
       direction,
       sortSource,
+      sortSourceTab,
       snapshotEmpty,
     });
     if (!shouldRefresh) {
       return;
     }
-    lastSortRef.current = { field, direction, sortSource };
+    lastSortRef.current = { field, direction, sortSource, sortSourceTab };
     ctxSnapshotRef.current = assetCtxsByDex;
     setPerpSortSnapshot(assetCtxsByDex);
     if (
       last?.field !== field ||
       last?.direction !== direction ||
-      last?.sortSource !== sortSource
+      last?.sortSource !== sortSource ||
+      last?.sortSourceTab !== sortSourceTab
     ) {
       scrollListToTop();
     }
@@ -582,6 +588,7 @@ function MobileTokenSelectorModal({
     selectorConfig?.direction,
     selectorConfig?.field,
     selectorConfig?.sortSource,
+    selectorConfig?.sortSourceTab,
     assetCtxsByDex,
     scrollListToTop,
   ]);
@@ -634,12 +641,9 @@ function MobileTokenSelectorModal({
         return;
       }
       startTransition(() => {
-        setSelectorConfig((prev) => ({
-          field: prev?.field ?? DEFAULT_PERP_TOKEN_SORT_FIELD,
-          direction: prev?.direction ?? DEFAULT_PERP_TOKEN_SORT_DIRECTION,
-          activeTab: tab,
-          sortSource: prev?.sortSource ?? 'default',
-        }));
+        setSelectorConfig((prev) =>
+          getNextPerpTokenSelectorActiveTabConfig({ prev, tab }),
+        );
       });
       actions.current.setTradeRouteViewState({
         tokenSelectorTab: tab,
@@ -733,9 +737,11 @@ function MobileTokenSelectorModal({
   // Layer 1: sort — only reruns when sort config or underlying assets change.
   // Does NOT depend on activeTab, so tab switches never retrigger the sort.
   const perpSortAssetCtxsByDex = getPerpTokenSelectorSortAssetCtxsByDex({
+    activeTab: displayActiveTab,
     liveAssetCtxsByDex: assetCtxsByDex,
     snapshotAssetCtxsByDex: perpSortSnapshot,
     sortSource: selectorConfig?.sortSource,
+    sortSourceTab: selectorConfig?.sortSourceTab,
   });
   const perpSortedList = useMemo(() => {
     const perfStartTime = startTokenSelectorPerfMeasure();
@@ -771,6 +777,7 @@ function MobileTokenSelectorModal({
     const sortField = selectorConfig?.field ?? '';
     const sortDirection = selectorConfig?.direction ?? 'desc';
     const sortSource = selectorConfig?.sortSource;
+    const sortSourceTab = selectorConfig?.sortSourceTab;
     const result = sortField
       ? combinedEntries
           .toSorted((a, b) =>
@@ -789,6 +796,7 @@ function MobileTokenSelectorModal({
         sortField,
         sortDirection,
         sortSource,
+        sortSourceTab,
         perpCount: combinedEntries.length,
         resultCount: result.length,
       });
@@ -803,6 +811,7 @@ function MobileTokenSelectorModal({
     selectorConfig?.direction,
     selectorConfig?.field,
     selectorConfig?.sortSource,
+    selectorConfig?.sortSourceTab,
     tokenSearchAliases,
   ]);
 
@@ -984,7 +993,11 @@ function MobileTokenSelectorModal({
         result = getPerpTokenSelectorDynamicTabItems({
           items: perpSortedList,
           tokens: dynamicTab.tokens,
-          useSortedItemsOrder: selectorConfig?.sortSource === 'user',
+          useSortedItemsOrder: isPerpTokenSelectorDynamicTabUserSort({
+            activeTab: displayActiveTab,
+            sortSource: selectorConfig?.sortSource,
+            sortSourceTab: selectorConfig?.sortSourceTab,
+          }),
         });
       } else {
         result = perpSortedList;
@@ -1019,6 +1032,7 @@ function MobileTokenSelectorModal({
     selectorConfig?.direction,
     selectorConfig?.field,
     selectorConfig?.sortSource,
+    selectorConfig?.sortSourceTab,
     spotFavoriteSortedList,
     spotMarketCaps,
     spotPriceSnapshot,
@@ -1138,12 +1152,14 @@ function MobileTokenSelectorModal({
     field: 'volume24h',
     sortField: selectorConfig?.field,
     sortSource: selectorConfig?.sortSource,
+    sortSourceTab: selectorConfig?.sortSourceTab,
   });
   const isChangeSortActive = isPerpTokenSelectorSortFieldActive({
     activeTab: activeSortTab,
     field: 'change24hPercent',
     sortField: selectorConfig?.field,
     sortSource: selectorConfig?.sortSource,
+    sortSourceTab: selectorConfig?.sortSourceTab,
   });
   let iconName: string;
   if (isVolumeSortActive && selectorConfig?.direction === 'asc') {

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -766,14 +766,10 @@ function BasePerpTokenSelectorContent({
     [selectorConfig?.direction, selectorConfig?.field],
   );
 
-  // Layer 1a: perp sort — only reruns when sort config or perp assets change.
-  // Never reruns on tab switch, spot WS updates, search, or favorites changes.
+  // Layer 1a: perp sort — always sorts against the frozen snapshot so live WS
+  // ticks do not re-sort the full perp universe.
   const perpSortAssetCtxsByDex = getPerpTokenSelectorSortAssetCtxsByDex({
-    activeTab: displayActiveTab,
-    liveAssetCtxsByDex: assetCtxsByDex,
     snapshotAssetCtxsByDex: perpSortSnapshot,
-    sortSource: selectorConfig?.sortSource,
-    sortSourceTab: selectorConfig?.sortSourceTab,
   });
   const perpSortedList = useMemo((): ITokenSelectorListItem[] => {
     const perfStartTime = startTokenSelectorPerfMeasure();
@@ -956,7 +952,17 @@ function BasePerpTokenSelectorContent({
     spotMarketCaps,
   ]);
 
-  // Layer 2: filter — cheap O(n); no sort computation.
+  const activeDynamicTabUserSort = isPerpTokenSelectorDynamicTabUserSort({
+    activeTab: displayActiveTab,
+    sortSource: selectorConfig?.sortSource,
+    sortSourceTab: selectorConfig?.sortSourceTab,
+  });
+  const dynamicSortAssetCtxsByDex = activeDynamicTabUserSort
+    ? assetCtxsByDex
+    : undefined;
+
+  // Layer 2: filter — cheap O(n); only dynamic user sort sorts the filtered
+  // dynamic-token subset against live values.
   // Tab switches, search, and favorites changes only reach here.
   // perpSortedList reference is stable unless sort config changes, so ListView
   // bails out of re-rendering rows when spot WS updates trigger a component render.
@@ -1013,15 +1019,45 @@ function BasePerpTokenSelectorContent({
     } else {
       const dynamicTab = categoryTabs.find((t) => t.tabId === displayActiveTab);
       if (dynamicTab) {
-        result = getPerpTokenSelectorDynamicTabItems({
+        const dynamicItems = getPerpTokenSelectorDynamicTabItems({
           items: perpSortedList,
           tokens: dynamicTab.tokens,
-          useSortedItemsOrder: isPerpTokenSelectorDynamicTabUserSort({
-            activeTab: displayActiveTab,
-            sortSource: selectorConfig?.sortSource,
-            sortSourceTab: selectorConfig?.sortSourceTab,
-          }),
         });
+        if (activeDynamicTabUserSort && sortField) {
+          result = dynamicItems
+            .map((item, index) => {
+              const asset = assetsByDex?.[item.dexIndex]?.[item.index];
+              const normalizedAssetId =
+                item.dexIndex === 1 && item.assetId !== undefined
+                  ? item.assetId - XYZ_ASSET_ID_OFFSET
+                  : item.assetId;
+              const assetCtx =
+                normalizedAssetId !== undefined
+                  ? dynamicSortAssetCtxsByDex?.[item.dexIndex]?.[
+                      normalizedAssetId
+                    ]
+                  : undefined;
+              return {
+                item,
+                index,
+                sortEntry: asset
+                  ? {
+                      asset,
+                      sortValues: computeSortValues(assetCtx),
+                    }
+                  : undefined,
+              };
+            })
+            .toSorted((a, b) => {
+              if (!a.sortEntry || !b.sortEntry) {
+                return a.index - b.index;
+              }
+              return sortCompare(a.sortEntry, b.sortEntry) || a.index - b.index;
+            })
+            .map(({ item }) => item);
+        } else {
+          result = dynamicItems;
+        }
       } else {
         result = perpSortedList;
       }
@@ -1047,11 +1083,15 @@ function BasePerpTokenSelectorContent({
   }, [
     displayActiveTab,
     displayPrimaryTab,
+    activeDynamicTabUserSort,
+    assetsByDex,
     categoryTabs,
     computeSortValues,
+    dynamicSortAssetCtxsByDex,
     favoritesOrder.sequence,
     favoriteItems,
     perpSortedList,
+    sortCompare,
     spotFavoriteSortedList,
     spotMarketCaps,
     spotPriceSnapshot,
@@ -1059,8 +1099,6 @@ function BasePerpTokenSelectorContent({
     searchQuery,
     selectorConfig?.direction,
     selectorConfig?.field,
-    selectorConfig?.sortSource,
-    selectorConfig?.sortSourceTab,
   ]);
 
   useEffect(() => {

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -67,6 +67,7 @@ import {
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import type {
+  IPerpTokenSelectorConfig,
   IPerpTokenSortDirection,
   IPerpTokenSortField,
   IPerpsAssetCtx,
@@ -104,12 +105,13 @@ import {
   buildPerpTokenSelectorCategoryTabs,
   buildPerpTokenSelectorTabs,
   buildPrimaryTabs,
+  getPerpTokenSelectorDynamicTabItems,
   getPerpTokenSelectorFallbackTabId,
   getPerpTokenSelectorPrimaryTabId,
+  getPerpTokenSelectorSortAssetCtxsByDex,
   isPerpTokenSelectorFavoritesTab,
   isPerpTokenSelectorPerpsTab,
   isPerpTokenSelectorSpotTab,
-  sortPerpTokenSelectorItemsByServerOrder,
 } from '../../utils/tokenSelectorTabs';
 
 import { FavoritesEmptyState } from './FavoritesEmptyState';
@@ -484,15 +486,12 @@ function BasePerpTokenSelectorContent({
   const updateActiveTab = useCallback(
     (tab: string) => {
       startTransition(() => {
-        setSelectorConfig(
-          (prev) =>
-            ({
-              field: prev?.field ?? DEFAULT_PERP_TOKEN_SORT_FIELD,
-              direction: prev?.direction ?? DEFAULT_PERP_TOKEN_SORT_DIRECTION,
-              activeTab: tab,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            }) as any,
-        );
+        setSelectorConfig((prev) => ({
+          field: prev?.field ?? DEFAULT_PERP_TOKEN_SORT_FIELD,
+          direction: prev?.direction ?? DEFAULT_PERP_TOKEN_SORT_DIRECTION,
+          activeTab: tab,
+          sortSource: prev?.sortSource ?? 'default',
+        }));
       });
       actions.current.setTradeRouteViewState({
         tokenSelectorTab: tab,
@@ -585,14 +584,21 @@ function BasePerpTokenSelectorContent({
 
   // Freeze sort order while popover is open; refreshed on sort change or first data arrival.
   const ctxSnapshotRef = useRef(assetCtxsByDex);
-  const lastSortRef = useRef<{ field?: string; direction?: string } | null>(
-    null,
-  );
+  const [perpSortSnapshot, setPerpSortSnapshot] = useState(assetCtxsByDex);
+  const lastSortRef = useRef<{
+    field?: string;
+    direction?: string;
+    sortSource?: IPerpTokenSelectorConfig['sortSource'];
+  } | null>(null);
   useEffect(() => {
     const field = selectorConfig?.field;
     const direction = selectorConfig?.direction;
+    const sortSource = selectorConfig?.sortSource;
     const last = lastSortRef.current;
-    const sortChanged = last?.field !== field || last?.direction !== direction;
+    const sortChanged =
+      last?.field !== field ||
+      last?.direction !== direction ||
+      last?.sortSource !== sortSource;
     // Also refresh when snapshot is empty (first WS data arrival after mount)
     const snapshotEmpty = !ctxSnapshotRef.current?.some(
       (arr) => arr?.length > 0,
@@ -600,12 +606,18 @@ function BasePerpTokenSelectorContent({
     if (!sortChanged && !snapshotEmpty) {
       return;
     }
-    lastSortRef.current = { field, direction };
+    lastSortRef.current = { field, direction, sortSource };
     ctxSnapshotRef.current = assetCtxsByDex;
+    setPerpSortSnapshot(assetCtxsByDex);
     if (sortChanged) {
       listRef.current?.scrollToOffset?.({ offset: 0, animated: false });
     }
-  }, [selectorConfig?.direction, selectorConfig?.field, assetCtxsByDex]);
+  }, [
+    selectorConfig?.direction,
+    selectorConfig?.field,
+    selectorConfig?.sortSource,
+    assetCtxsByDex,
+  ]);
 
   // Snapshot held in state (not ref) so the sort memo only re-runs when we
   // explicitly bump it — sort-config change or first non-empty data arrival.
@@ -755,11 +767,16 @@ function BasePerpTokenSelectorContent({
 
   // Layer 1a: perp sort — only reruns when sort config or perp assets change.
   // Never reruns on tab switch, spot WS updates, search, or favorites changes.
+  const perpSortAssetCtxsByDex = getPerpTokenSelectorSortAssetCtxsByDex({
+    liveAssetCtxsByDex: assetCtxsByDex,
+    snapshotAssetCtxsByDex: perpSortSnapshot,
+    sortSource: selectorConfig?.sortSource,
+  });
   const perpSortedList = useMemo((): ITokenSelectorListItem[] => {
     const perfStartTime = startTokenSelectorPerfMeasure();
     const assetsByDexTyped: IPerpsUniverse[][] = assetsByDex || [];
     const assetCtxsByDexTyped: IPerpsAssetCtx[][] =
-      ctxSnapshotRef.current || [];
+      perpSortAssetCtxsByDex || [];
 
     const combinedEntries = assetsByDexTyped.flatMap(
       (assets: IPerpsUniverse[], dexIndex: number) => {
@@ -788,6 +805,7 @@ function BasePerpTokenSelectorContent({
 
     const sortField = selectorConfig?.field ?? '';
     const sortDirection = selectorConfig?.direction ?? 'desc';
+    const sortSource = selectorConfig?.sortSource;
     const result = sortField
       ? combinedEntries
           .toSorted((a, b) =>
@@ -805,6 +823,7 @@ function BasePerpTokenSelectorContent({
         phase: 'perp-sort',
         sortField,
         sortDirection,
+        sortSource,
         perpCount: combinedEntries.length,
         resultCount: result.length,
       });
@@ -814,9 +833,11 @@ function BasePerpTokenSelectorContent({
   }, [
     assetsByDex,
     computeSortValues,
+    perpSortAssetCtxsByDex,
     sortCompare,
     selectorConfig?.direction,
     selectorConfig?.field,
+    selectorConfig?.sortSource,
     tokenSearchAliases,
   ]);
 
@@ -986,22 +1007,10 @@ function BasePerpTokenSelectorContent({
     } else {
       const dynamicTab = categoryTabs.find((t) => t.tabId === displayActiveTab);
       if (dynamicTab) {
-        const tokenSet = new Set(dynamicTab.tokens);
-        const tokenNameById = new Map<string, string>();
-        (assetsByDex || []).forEach((assets, dexIndex) => {
-          assets?.forEach((asset) => {
-            if (tokenSet.has(asset.name)) {
-              tokenNameById.set(`${dexIndex}-${asset.assetId}`, asset.name);
-            }
-          });
-        });
-        result = sortPerpTokenSelectorItemsByServerOrder({
-          items: perpSortedList.filter((item) =>
-            tokenNameById.has(`${item.dexIndex}-${item.assetId}`),
-          ),
-          tokenOrder: dynamicTab.tokens,
-          getTokenName: (item) =>
-            tokenNameById.get(`${item.dexIndex}-${item.assetId}`),
+        result = getPerpTokenSelectorDynamicTabItems({
+          items: perpSortedList,
+          tokens: dynamicTab.tokens,
+          useSortedItemsOrder: selectorConfig?.sortSource === 'user',
         });
       } else {
         result = perpSortedList;
@@ -1028,7 +1037,6 @@ function BasePerpTokenSelectorContent({
   }, [
     displayActiveTab,
     displayPrimaryTab,
-    assetsByDex,
     categoryTabs,
     computeSortValues,
     favoritesOrder.sequence,
@@ -1041,6 +1049,7 @@ function BasePerpTokenSelectorContent({
     searchQuery,
     selectorConfig?.direction,
     selectorConfig?.field,
+    selectorConfig?.sortSource,
   ]);
 
   useEffect(() => {

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -76,8 +76,6 @@ import type {
 } from '@onekeyhq/shared/types/hyperliquid';
 import {
   DEFAULT_PERP_TOKEN_ACTIVE_TAB,
-  DEFAULT_PERP_TOKEN_SORT_DIRECTION,
-  DEFAULT_PERP_TOKEN_SORT_FIELD,
   XYZ_ASSET_ID_OFFSET,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 
@@ -105,10 +103,12 @@ import {
   buildPerpTokenSelectorCategoryTabs,
   buildPerpTokenSelectorTabs,
   buildPrimaryTabs,
+  getNextPerpTokenSelectorActiveTabConfig,
   getPerpTokenSelectorDynamicTabItems,
   getPerpTokenSelectorFallbackTabId,
   getPerpTokenSelectorPrimaryTabId,
   getPerpTokenSelectorSortAssetCtxsByDex,
+  isPerpTokenSelectorDynamicTabUserSort,
   isPerpTokenSelectorFavoritesTab,
   isPerpTokenSelectorPerpsTab,
   isPerpTokenSelectorSpotTab,
@@ -486,12 +486,9 @@ function BasePerpTokenSelectorContent({
   const updateActiveTab = useCallback(
     (tab: string) => {
       startTransition(() => {
-        setSelectorConfig((prev) => ({
-          field: prev?.field ?? DEFAULT_PERP_TOKEN_SORT_FIELD,
-          direction: prev?.direction ?? DEFAULT_PERP_TOKEN_SORT_DIRECTION,
-          activeTab: tab,
-          sortSource: prev?.sortSource ?? 'default',
-        }));
+        setSelectorConfig((prev) =>
+          getNextPerpTokenSelectorActiveTabConfig({ prev, tab }),
+        );
       });
       actions.current.setTradeRouteViewState({
         tokenSelectorTab: tab,
@@ -589,16 +586,19 @@ function BasePerpTokenSelectorContent({
     field?: string;
     direction?: string;
     sortSource?: IPerpTokenSelectorConfig['sortSource'];
+    sortSourceTab?: IPerpTokenSelectorConfig['sortSourceTab'];
   } | null>(null);
   useEffect(() => {
     const field = selectorConfig?.field;
     const direction = selectorConfig?.direction;
     const sortSource = selectorConfig?.sortSource;
+    const sortSourceTab = selectorConfig?.sortSourceTab;
     const last = lastSortRef.current;
     const sortChanged =
       last?.field !== field ||
       last?.direction !== direction ||
-      last?.sortSource !== sortSource;
+      last?.sortSource !== sortSource ||
+      last?.sortSourceTab !== sortSourceTab;
     // Also refresh when snapshot is empty (first WS data arrival after mount)
     const snapshotEmpty = !ctxSnapshotRef.current?.some(
       (arr) => arr?.length > 0,
@@ -606,7 +606,7 @@ function BasePerpTokenSelectorContent({
     if (!sortChanged && !snapshotEmpty) {
       return;
     }
-    lastSortRef.current = { field, direction, sortSource };
+    lastSortRef.current = { field, direction, sortSource, sortSourceTab };
     ctxSnapshotRef.current = assetCtxsByDex;
     setPerpSortSnapshot(assetCtxsByDex);
     if (sortChanged) {
@@ -616,6 +616,7 @@ function BasePerpTokenSelectorContent({
     selectorConfig?.direction,
     selectorConfig?.field,
     selectorConfig?.sortSource,
+    selectorConfig?.sortSourceTab,
     assetCtxsByDex,
   ]);
 
@@ -768,9 +769,11 @@ function BasePerpTokenSelectorContent({
   // Layer 1a: perp sort — only reruns when sort config or perp assets change.
   // Never reruns on tab switch, spot WS updates, search, or favorites changes.
   const perpSortAssetCtxsByDex = getPerpTokenSelectorSortAssetCtxsByDex({
+    activeTab: displayActiveTab,
     liveAssetCtxsByDex: assetCtxsByDex,
     snapshotAssetCtxsByDex: perpSortSnapshot,
     sortSource: selectorConfig?.sortSource,
+    sortSourceTab: selectorConfig?.sortSourceTab,
   });
   const perpSortedList = useMemo((): ITokenSelectorListItem[] => {
     const perfStartTime = startTokenSelectorPerfMeasure();
@@ -806,6 +809,7 @@ function BasePerpTokenSelectorContent({
     const sortField = selectorConfig?.field ?? '';
     const sortDirection = selectorConfig?.direction ?? 'desc';
     const sortSource = selectorConfig?.sortSource;
+    const sortSourceTab = selectorConfig?.sortSourceTab;
     const result = sortField
       ? combinedEntries
           .toSorted((a, b) =>
@@ -824,6 +828,7 @@ function BasePerpTokenSelectorContent({
         sortField,
         sortDirection,
         sortSource,
+        sortSourceTab,
         perpCount: combinedEntries.length,
         resultCount: result.length,
       });
@@ -838,6 +843,7 @@ function BasePerpTokenSelectorContent({
     selectorConfig?.direction,
     selectorConfig?.field,
     selectorConfig?.sortSource,
+    selectorConfig?.sortSourceTab,
     tokenSearchAliases,
   ]);
 
@@ -1010,7 +1016,11 @@ function BasePerpTokenSelectorContent({
         result = getPerpTokenSelectorDynamicTabItems({
           items: perpSortedList,
           tokens: dynamicTab.tokens,
-          useSortedItemsOrder: selectorConfig?.sortSource === 'user',
+          useSortedItemsOrder: isPerpTokenSelectorDynamicTabUserSort({
+            activeTab: displayActiveTab,
+            sortSource: selectorConfig?.sortSource,
+            sortSourceTab: selectorConfig?.sortSourceTab,
+          }),
         });
       } else {
         result = perpSortedList;
@@ -1050,6 +1060,7 @@ function BasePerpTokenSelectorContent({
     selectorConfig?.direction,
     selectorConfig?.field,
     selectorConfig?.sortSource,
+    selectorConfig?.sortSourceTab,
   ]);
 
   useEffect(() => {

--- a/packages/kit/src/views/Perp/components/TokenSelector/SortableHeaderCell.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/SortableHeaderCell.tsx
@@ -7,11 +7,12 @@ import type {
   IPerpTokenSelectorConfig,
   IPerpTokenSortField,
 } from '@onekeyhq/shared/types/hyperliquid';
+import { DEFAULT_PERP_TOKEN_ACTIVE_TAB } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+
 import {
-  DEFAULT_PERP_TOKEN_ACTIVE_TAB,
-  DEFAULT_PERP_TOKEN_SORT_DIRECTION,
-  DEFAULT_PERP_TOKEN_SORT_FIELD,
-} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+  getNextPerpTokenSelectorSortConfig,
+  isPerpTokenSelectorSortFieldActive,
+} from '../../utils/tokenSelectorTabs';
 
 interface ISortableHeaderCellProps {
   field: IPerpTokenSortField;
@@ -30,61 +31,39 @@ function BaseSortableHeaderCell({
 }: ISortableHeaderCellProps) {
   const [selectorConfig, setSelectorConfig] =
     usePerpTokenSelectorConfigPersistAtom();
+  const headerActiveTab =
+    selectorConfig?.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB;
+  const isCurrentFieldActive = isPerpTokenSelectorSortFieldActive({
+    activeTab: headerActiveTab,
+    field,
+    sortField: selectorConfig?.field,
+    sortSource: selectorConfig?.sortSource,
+  });
 
   const handlePress = useCallback(() => {
     const previousField = selectorConfig?.field ?? '';
     const previousDirection = selectorConfig?.direction ?? '';
-    const activeTab =
+    const currentActiveTab =
       selectorConfig?.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB;
-    let nextField = field;
-    let nextDirection = DEFAULT_PERP_TOKEN_SORT_DIRECTION;
-
-    if (selectorConfig?.field === field) {
-      if (selectorConfig.direction === 'asc') {
-        nextField = DEFAULT_PERP_TOKEN_SORT_FIELD;
-        nextDirection = DEFAULT_PERP_TOKEN_SORT_DIRECTION;
-      } else {
-        nextDirection = 'asc';
-      }
-    }
+    const nextConfig = getNextPerpTokenSelectorSortConfig({
+      prev: selectorConfig,
+      field,
+    });
 
     defaultLogger.perp.tokenSelector.perpTokenSelectorSortClick({
-      activeTab,
-      field: nextField,
-      direction: nextDirection,
+      activeTab: currentActiveTab,
+      field: nextConfig.field,
+      direction: nextConfig.direction,
       previousField,
       previousDirection,
     });
 
     setSelectorConfig((prev: IPerpTokenSelectorConfig | null) => {
-      if (prev?.field === field) {
-        // Same field: toggle direction, or reset to default sort if already ascending
-        if (prev.direction === 'asc') {
-          // Reset to default sort but preserve activeTab
-          return {
-            field: DEFAULT_PERP_TOKEN_SORT_FIELD,
-            direction: DEFAULT_PERP_TOKEN_SORT_DIRECTION,
-            activeTab: prev.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB,
-          };
-        }
-        // Toggle to ascending
-        return {
-          field,
-          direction: 'asc',
-          activeTab: prev.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB,
-        };
-      }
-
-      // New field, default to descending
-      return {
-        field,
-        direction: DEFAULT_PERP_TOKEN_SORT_DIRECTION,
-        activeTab: prev?.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB,
-      };
+      return getNextPerpTokenSelectorSortConfig({ prev, field });
     });
   }, [field, selectorConfig, setSelectorConfig]);
 
-  const isActive = selectorConfig?.field === field;
+  const isActive = isCurrentFieldActive;
   let iconName: string;
   if (isActive && selectorConfig?.direction === 'asc') {
     iconName = 'ChevronTopOutline';

--- a/packages/kit/src/views/Perp/components/TokenSelector/SortableHeaderCell.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/SortableHeaderCell.tsx
@@ -38,6 +38,7 @@ function BaseSortableHeaderCell({
     field,
     sortField: selectorConfig?.field,
     sortSource: selectorConfig?.sortSource,
+    sortSourceTab: selectorConfig?.sortSourceTab,
   });
 
   const handlePress = useCallback(() => {

--- a/packages/kit/src/views/Perp/utils/tokenSelectorPerf.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorPerf.ts
@@ -11,6 +11,7 @@ type ITokenSelectorPerfDetail = {
   primaryTab?: string;
   sortField?: string;
   sortDirection?: string;
+  sortSource?: string;
   perpCount?: number;
   spotCount?: number;
   resultCount?: number;

--- a/packages/kit/src/views/Perp/utils/tokenSelectorPerf.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorPerf.ts
@@ -12,6 +12,7 @@ type ITokenSelectorPerfDetail = {
   sortField?: string;
   sortDirection?: string;
   sortSource?: string;
+  sortSourceTab?: string;
   perpCount?: number;
   spotCount?: number;
   resultCount?: number;

--- a/packages/kit/src/views/Perp/utils/tokenSelectorTabs.test.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorTabs.test.ts
@@ -455,49 +455,11 @@ describe('tokenSelectorTabs', () => {
     ).toBe(true);
   });
 
-  it('only uses live asset ctxs for a matching dynamic tab user sort', () => {
-    const liveAssetCtxsByDex = [[{ volume: '12' }]];
+  it('always uses snapshot asset ctxs for the full perp list sort', () => {
     const snapshotAssetCtxsByDex = [[{ volume: '8' }]];
 
     expect(
       getPerpTokenSelectorSortAssetCtxsByDex({
-        activeTab: 'hot',
-        liveAssetCtxsByDex,
-        snapshotAssetCtxsByDex,
-        sortSource: 'user',
-        sortSourceTab: 'hot',
-      }),
-    ).toBe(liveAssetCtxsByDex);
-    expect(
-      getPerpTokenSelectorSortAssetCtxsByDex({
-        activeTab: 'perps',
-        liveAssetCtxsByDex,
-        snapshotAssetCtxsByDex,
-        sortSource: 'user',
-        sortSourceTab: 'perps',
-      }),
-    ).toBe(snapshotAssetCtxsByDex);
-    expect(
-      getPerpTokenSelectorSortAssetCtxsByDex({
-        activeTab: 'hot',
-        liveAssetCtxsByDex,
-        snapshotAssetCtxsByDex,
-        sortSource: 'user',
-        sortSourceTab: 'perps',
-      }),
-    ).toBe(snapshotAssetCtxsByDex);
-    expect(
-      getPerpTokenSelectorSortAssetCtxsByDex({
-        activeTab: 'hot',
-        liveAssetCtxsByDex,
-        snapshotAssetCtxsByDex,
-        sortSource: 'default',
-      }),
-    ).toBe(snapshotAssetCtxsByDex);
-    expect(
-      getPerpTokenSelectorSortAssetCtxsByDex({
-        activeTab: 'hot',
-        liveAssetCtxsByDex,
         snapshotAssetCtxsByDex,
       }),
     ).toBe(snapshotAssetCtxsByDex);

--- a/packages/kit/src/views/Perp/utils/tokenSelectorTabs.test.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorTabs.test.ts
@@ -3,12 +3,14 @@ import {
   buildPerpTokenSelectorTabs,
   buildPrimaryTabs,
   comparePerpTokenSelectorSortValues,
+  getNextPerpTokenSelectorActiveTabConfig,
   getNextPerpTokenSelectorSortConfig,
   getPerpTokenSelectorDynamicTabItems,
   getPerpTokenSelectorFallbackTabId,
   getPerpTokenSelectorPrimaryTabId,
   getPerpTokenSelectorSortAssetCtxsByDex,
   isPerpTokenSelectorAllTab,
+  isPerpTokenSelectorDynamicTabUserSort,
   isPerpTokenSelectorFavoritesTab,
   isPerpTokenSelectorPerpsTab,
   isPerpTokenSelectorPrimaryTab,
@@ -306,6 +308,15 @@ describe('tokenSelectorTabs', () => {
         sortField: 'volume24h',
         sortSource: 'user',
       }),
+    ).toBe(false);
+    expect(
+      isPerpTokenSelectorSortFieldActive({
+        activeTab: 'hot',
+        field: 'volume24h',
+        sortField: 'volume24h',
+        sortSource: 'user',
+        sortSourceTab: 'hot',
+      }),
     ).toBe(true);
     expect(
       isPerpTokenSelectorSortFieldActive({
@@ -315,6 +326,57 @@ describe('tokenSelectorTabs', () => {
         sortSource: 'default',
       }),
     ).toBe(true);
+  });
+
+  it('scopes dynamic tab user sorting to the clicked tab', () => {
+    expect(
+      isPerpTokenSelectorDynamicTabUserSort({
+        activeTab: 'hot',
+        sortSource: 'user',
+        sortSourceTab: 'perps',
+      }),
+    ).toBe(false);
+    expect(
+      isPerpTokenSelectorDynamicTabUserSort({
+        activeTab: 'hot',
+        sortSource: 'user',
+      }),
+    ).toBe(false);
+    expect(
+      isPerpTokenSelectorDynamicTabUserSort({
+        activeTab: 'hot',
+        sortSource: 'user',
+        sortSourceTab: 'hot',
+      }),
+    ).toBe(true);
+    expect(
+      isPerpTokenSelectorDynamicTabUserSort({
+        activeTab: 'perps',
+        sortSource: 'user',
+        sortSourceTab: 'perps',
+      }),
+    ).toBe(false);
+  });
+
+  it('resets user sort source when switching tabs', () => {
+    expect(
+      getNextPerpTokenSelectorActiveTabConfig({
+        prev: {
+          field: 'volume24h',
+          direction: 'asc',
+          activeTab: 'perps',
+          sortSource: 'user',
+          sortSourceTab: 'perps',
+        },
+        tab: 'hot',
+      }),
+    ).toEqual({
+      field: 'volume24h',
+      direction: 'asc',
+      activeTab: 'hot',
+      sortSource: 'default',
+      sortSourceTab: undefined,
+    });
   });
 
   it('starts user sorting from descending on a dynamic tab default order', () => {
@@ -333,6 +395,7 @@ describe('tokenSelectorTabs', () => {
       direction: 'desc',
       activeTab: 'hot',
       sortSource: 'user',
+      sortSourceTab: 'hot',
     });
   });
 
@@ -344,6 +407,7 @@ describe('tokenSelectorTabs', () => {
           direction: 'desc',
           activeTab: 'hot',
           sortSource: 'user',
+          sortSourceTab: 'hot',
         },
         field: 'volume24h',
       }),
@@ -352,6 +416,7 @@ describe('tokenSelectorTabs', () => {
       direction: 'asc',
       activeTab: 'hot',
       sortSource: 'user',
+      sortSourceTab: 'hot',
     });
     expect(
       getNextPerpTokenSelectorSortConfig({
@@ -360,6 +425,7 @@ describe('tokenSelectorTabs', () => {
           direction: 'asc',
           activeTab: 'hot',
           sortSource: 'user',
+          sortSourceTab: 'hot',
         },
         field: 'volume24h',
       }),
@@ -368,6 +434,7 @@ describe('tokenSelectorTabs', () => {
       direction: 'desc',
       activeTab: 'hot',
       sortSource: 'default',
+      sortSourceTab: undefined,
     });
   });
 
@@ -382,24 +449,46 @@ describe('tokenSelectorTabs', () => {
         field: 'volume24h',
         direction: 'desc',
         sortSource: 'user',
+        sortSourceTab: 'hot',
         snapshotEmpty: false,
       }),
     ).toBe(true);
   });
 
-  it('uses live asset ctxs for user sort and snapshot ctxs for default order', () => {
+  it('only uses live asset ctxs for a matching dynamic tab user sort', () => {
     const liveAssetCtxsByDex = [[{ volume: '12' }]];
     const snapshotAssetCtxsByDex = [[{ volume: '8' }]];
 
     expect(
       getPerpTokenSelectorSortAssetCtxsByDex({
+        activeTab: 'hot',
         liveAssetCtxsByDex,
         snapshotAssetCtxsByDex,
         sortSource: 'user',
+        sortSourceTab: 'hot',
       }),
     ).toBe(liveAssetCtxsByDex);
     expect(
       getPerpTokenSelectorSortAssetCtxsByDex({
+        activeTab: 'perps',
+        liveAssetCtxsByDex,
+        snapshotAssetCtxsByDex,
+        sortSource: 'user',
+        sortSourceTab: 'perps',
+      }),
+    ).toBe(snapshotAssetCtxsByDex);
+    expect(
+      getPerpTokenSelectorSortAssetCtxsByDex({
+        activeTab: 'hot',
+        liveAssetCtxsByDex,
+        snapshotAssetCtxsByDex,
+        sortSource: 'user',
+        sortSourceTab: 'perps',
+      }),
+    ).toBe(snapshotAssetCtxsByDex);
+    expect(
+      getPerpTokenSelectorSortAssetCtxsByDex({
+        activeTab: 'hot',
         liveAssetCtxsByDex,
         snapshotAssetCtxsByDex,
         sortSource: 'default',
@@ -407,6 +496,7 @@ describe('tokenSelectorTabs', () => {
     ).toBe(snapshotAssetCtxsByDex);
     expect(
       getPerpTokenSelectorSortAssetCtxsByDex({
+        activeTab: 'hot',
         liveAssetCtxsByDex,
         snapshotAssetCtxsByDex,
       }),

--- a/packages/kit/src/views/Perp/utils/tokenSelectorTabs.test.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorTabs.test.ts
@@ -3,12 +3,16 @@ import {
   buildPerpTokenSelectorTabs,
   buildPrimaryTabs,
   comparePerpTokenSelectorSortValues,
+  getNextPerpTokenSelectorSortConfig,
+  getPerpTokenSelectorDynamicTabItems,
   getPerpTokenSelectorFallbackTabId,
   getPerpTokenSelectorPrimaryTabId,
+  getPerpTokenSelectorSortAssetCtxsByDex,
   isPerpTokenSelectorAllTab,
   isPerpTokenSelectorFavoritesTab,
   isPerpTokenSelectorPerpsTab,
   isPerpTokenSelectorPrimaryTab,
+  isPerpTokenSelectorSortFieldActive,
   isPerpTokenSelectorSpotTab,
   shouldRefreshPerpTokenSelectorSortSnapshot,
   sortPerpTokenSelectorItemsByServerOrder,
@@ -225,6 +229,188 @@ describe('tokenSelectorTabs', () => {
         getTokenName: (item) => item.name,
       }).map((item) => item.id),
     ).toEqual(['sol', 'btc', 'eth', 'unknown']);
+  });
+
+  it('keeps dynamic tab items in server token order instead of sorted-list order', () => {
+    const volumeSortedItems = [
+      { tokenName: 'BTC', volume24h: 100 },
+      { tokenName: 'ETH', volume24h: 80 },
+      { tokenName: 'MU', volume24h: 60 },
+      { tokenName: 'SOL', volume24h: 40 },
+    ];
+
+    expect(
+      getPerpTokenSelectorDynamicTabItems({
+        items: volumeSortedItems,
+        tokens: ['SOL', 'BTC', 'MU'],
+      }).map((item) => item.tokenName),
+    ).toEqual(['SOL', 'BTC', 'MU']);
+  });
+
+  it('uses sorted-list order for dynamic tab items after a header sort', () => {
+    const volumeSortedItems = [
+      { tokenName: 'BTC', volume24h: 100 },
+      { tokenName: 'ETH', volume24h: 80 },
+      { tokenName: 'MU', volume24h: 60 },
+      { tokenName: 'SOL', volume24h: 40 },
+    ];
+
+    expect(
+      getPerpTokenSelectorDynamicTabItems({
+        items: volumeSortedItems,
+        tokens: ['SOL', 'BTC', 'MU'],
+        useSortedItemsOrder: true,
+      }).map((item) => item.tokenName),
+    ).toEqual(['BTC', 'MU', 'SOL']);
+  });
+
+  it('keeps dynamic tab user sort aligned with the sorted volume order', () => {
+    const defaultHotTokens = ['ZRO', 'AAVE', 'JUP', 'BTC'];
+    const volumeDescItems = [
+      { tokenName: 'BTC', volume24h: 3_690_000_000 },
+      { tokenName: 'AAVE', volume24h: 52_520_000 },
+      { tokenName: 'JUP', volume24h: 11_850_000 },
+      { tokenName: 'ZRO', volume24h: 5_950_000 },
+    ];
+
+    const result = getPerpTokenSelectorDynamicTabItems({
+      items: volumeDescItems,
+      tokens: defaultHotTokens,
+      useSortedItemsOrder: true,
+    });
+
+    expect(result.map((item) => item.tokenName)).toEqual([
+      'BTC',
+      'AAVE',
+      'JUP',
+      'ZRO',
+    ]);
+    expect(result.map((item) => item.volume24h)).toEqual(
+      result.map((item) => item.volume24h).toSorted((a, b) => b - a),
+    );
+  });
+
+  it('does not treat the default dynamic tab order as an active header sort', () => {
+    expect(
+      isPerpTokenSelectorSortFieldActive({
+        activeTab: 'hot',
+        field: 'volume24h',
+        sortField: 'volume24h',
+        sortSource: 'default',
+      }),
+    ).toBe(false);
+    expect(
+      isPerpTokenSelectorSortFieldActive({
+        activeTab: 'hot',
+        field: 'volume24h',
+        sortField: 'volume24h',
+        sortSource: 'user',
+      }),
+    ).toBe(true);
+    expect(
+      isPerpTokenSelectorSortFieldActive({
+        activeTab: 'perps',
+        field: 'volume24h',
+        sortField: 'volume24h',
+        sortSource: 'default',
+      }),
+    ).toBe(true);
+  });
+
+  it('starts user sorting from descending on a dynamic tab default order', () => {
+    expect(
+      getNextPerpTokenSelectorSortConfig({
+        prev: {
+          field: 'volume24h',
+          direction: 'desc',
+          activeTab: 'hot',
+          sortSource: 'default',
+        },
+        field: 'volume24h',
+      }),
+    ).toEqual({
+      field: 'volume24h',
+      direction: 'desc',
+      activeTab: 'hot',
+      sortSource: 'user',
+    });
+  });
+
+  it('toggles and resets user sorting on dynamic tabs', () => {
+    expect(
+      getNextPerpTokenSelectorSortConfig({
+        prev: {
+          field: 'volume24h',
+          direction: 'desc',
+          activeTab: 'hot',
+          sortSource: 'user',
+        },
+        field: 'volume24h',
+      }),
+    ).toEqual({
+      field: 'volume24h',
+      direction: 'asc',
+      activeTab: 'hot',
+      sortSource: 'user',
+    });
+    expect(
+      getNextPerpTokenSelectorSortConfig({
+        prev: {
+          field: 'volume24h',
+          direction: 'asc',
+          activeTab: 'hot',
+          sortSource: 'user',
+        },
+        field: 'volume24h',
+      }),
+    ).toEqual({
+      field: 'volume24h',
+      direction: 'desc',
+      activeTab: 'hot',
+      sortSource: 'default',
+    });
+  });
+
+  it('refreshes the sort snapshot when only sort source changes', () => {
+    expect(
+      shouldRefreshPerpTokenSelectorSortSnapshot({
+        lastSort: {
+          field: 'volume24h',
+          direction: 'desc',
+          sortSource: 'default',
+        },
+        field: 'volume24h',
+        direction: 'desc',
+        sortSource: 'user',
+        snapshotEmpty: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('uses live asset ctxs for user sort and snapshot ctxs for default order', () => {
+    const liveAssetCtxsByDex = [[{ volume: '12' }]];
+    const snapshotAssetCtxsByDex = [[{ volume: '8' }]];
+
+    expect(
+      getPerpTokenSelectorSortAssetCtxsByDex({
+        liveAssetCtxsByDex,
+        snapshotAssetCtxsByDex,
+        sortSource: 'user',
+      }),
+    ).toBe(liveAssetCtxsByDex);
+    expect(
+      getPerpTokenSelectorSortAssetCtxsByDex({
+        liveAssetCtxsByDex,
+        snapshotAssetCtxsByDex,
+        sortSource: 'default',
+      }),
+    ).toBe(snapshotAssetCtxsByDex);
+    expect(
+      getPerpTokenSelectorSortAssetCtxsByDex({
+        liveAssetCtxsByDex,
+        snapshotAssetCtxsByDex,
+      }),
+    ).toBe(snapshotAssetCtxsByDex);
   });
 
   it('only refreshes sort snapshots on sort changes or first data arrival', () => {

--- a/packages/kit/src/views/Perp/utils/tokenSelectorTabs.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorTabs.ts
@@ -1,5 +1,14 @@
 import type { IPerpDynamicTab } from '@onekeyhq/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp';
-import type { IPerpTokenSortDirection } from '@onekeyhq/shared/types/hyperliquid';
+import type {
+  IPerpTokenSelectorConfig,
+  IPerpTokenSortDirection,
+  IPerpTokenSortField,
+} from '@onekeyhq/shared/types/hyperliquid';
+import {
+  DEFAULT_PERP_TOKEN_ACTIVE_TAB,
+  DEFAULT_PERP_TOKEN_SORT_DIRECTION,
+  DEFAULT_PERP_TOKEN_SORT_FIELD,
+} from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 
 type IFixedTabNames = Record<'favorites' | 'all' | 'perps' | 'spot', string>;
 type ITokenSelectorSortValue = string | number | null | undefined;
@@ -7,6 +16,10 @@ type IPerpTokenSelectorPrimaryTabId = 'favorites' | 'perps' | 'spot';
 type IPerpTokenSelectorSortSnapshotKey = {
   field?: string;
   direction?: string;
+  sortSource?: IPerpTokenSelectorConfig['sortSource'];
+};
+type IPerpTokenSelectorDynamicTabItem = {
+  tokenName?: string;
 };
 
 const PRIMARY_TAB_IDS = ['favorites', 'perps', 'spot'] as const;
@@ -231,20 +244,137 @@ function sortPerpTokenSelectorItemsByServerOrder<T>({
     .map(({ item }) => item);
 }
 
+function getPerpTokenSelectorDynamicTabItems<
+  T extends IPerpTokenSelectorDynamicTabItem,
+>({
+  items,
+  tokens,
+  useSortedItemsOrder,
+}: {
+  items: T[];
+  tokens: string[];
+  useSortedItemsOrder?: boolean;
+}) {
+  const tokenNameSet = new Set(
+    tokens.map((token) => token.trim()).filter(Boolean),
+  );
+  if (useSortedItemsOrder) {
+    return items.filter((item) => {
+      const tokenName = item.tokenName?.trim();
+      return tokenName ? tokenNameSet.has(tokenName) : false;
+    });
+  }
+
+  const itemsByTokenName = new Map<string, T[]>();
+  items.forEach((item) => {
+    const tokenName = item.tokenName?.trim();
+    if (!tokenName) {
+      return;
+    }
+    const tokenItems = itemsByTokenName.get(tokenName) ?? [];
+    tokenItems.push(item);
+    itemsByTokenName.set(tokenName, tokenItems);
+  });
+
+  const usedItems = new Set<T>();
+  return tokens.reduce<T[]>((result, token) => {
+    const tokenName = token.trim();
+    const tokenItems = tokenName ? itemsByTokenName.get(tokenName) : undefined;
+    tokenItems?.forEach((item) => {
+      if (!usedItems.has(item)) {
+        usedItems.add(item);
+        result.push(item);
+      }
+    });
+    return result;
+  }, []);
+}
+
+function isPerpTokenSelectorSortFieldActive({
+  activeTab,
+  field,
+  sortField,
+  sortSource,
+}: {
+  activeTab?: string;
+  field: IPerpTokenSortField;
+  sortField?: IPerpTokenSortField;
+  sortSource?: IPerpTokenSelectorConfig['sortSource'];
+}) {
+  const currentActiveTab = activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB;
+  const isDynamicTab = !isPerpTokenSelectorPrimaryTab(currentActiveTab);
+  return sortField === field && (!isDynamicTab || sortSource === 'user');
+}
+
+function getNextPerpTokenSelectorSortConfig({
+  prev,
+  field,
+}: {
+  prev: IPerpTokenSelectorConfig | null;
+  field: IPerpTokenSortField;
+}): IPerpTokenSelectorConfig {
+  const activeTab = prev?.activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB;
+  const isCurrentFieldActive = isPerpTokenSelectorSortFieldActive({
+    activeTab,
+    field,
+    sortField: prev?.field,
+    sortSource: prev?.sortSource,
+  });
+
+  if (isCurrentFieldActive) {
+    if (prev?.direction === 'asc') {
+      return {
+        field: DEFAULT_PERP_TOKEN_SORT_FIELD,
+        direction: DEFAULT_PERP_TOKEN_SORT_DIRECTION,
+        activeTab,
+        sortSource: 'default',
+      };
+    }
+    return {
+      field,
+      direction: 'asc',
+      activeTab,
+      sortSource: 'user',
+    };
+  }
+
+  return {
+    field,
+    direction: DEFAULT_PERP_TOKEN_SORT_DIRECTION,
+    activeTab,
+    sortSource: 'user',
+  };
+}
+
+function getPerpTokenSelectorSortAssetCtxsByDex<T>({
+  liveAssetCtxsByDex,
+  snapshotAssetCtxsByDex,
+  sortSource,
+}: {
+  liveAssetCtxsByDex: T;
+  snapshotAssetCtxsByDex: T;
+  sortSource?: IPerpTokenSelectorConfig['sortSource'];
+}) {
+  return sortSource === 'user' ? liveAssetCtxsByDex : snapshotAssetCtxsByDex;
+}
+
 function shouldRefreshPerpTokenSelectorSortSnapshot({
   lastSort,
   field,
   direction,
+  sortSource,
   snapshotEmpty,
 }: {
   lastSort: IPerpTokenSelectorSortSnapshotKey | null;
   field?: string;
   direction?: string;
+  sortSource?: IPerpTokenSelectorConfig['sortSource'];
   snapshotEmpty: boolean;
 }) {
   return (
     lastSort?.field !== field ||
     lastSort?.direction !== direction ||
+    lastSort?.sortSource !== sortSource ||
     snapshotEmpty
   );
 }
@@ -254,12 +384,16 @@ export {
   buildPerpTokenSelectorCategoryTabs,
   buildPerpTokenSelectorTabs,
   comparePerpTokenSelectorSortValues,
+  getPerpTokenSelectorDynamicTabItems,
   getPerpTokenSelectorFallbackTabId,
+  getNextPerpTokenSelectorSortConfig,
   getPerpTokenSelectorPrimaryTabId,
+  getPerpTokenSelectorSortAssetCtxsByDex,
   isPerpTokenSelectorAllTab,
   isPerpTokenSelectorFavoritesTab,
   isPerpTokenSelectorPerpsTab,
   isPerpTokenSelectorPrimaryTab,
+  isPerpTokenSelectorSortFieldActive,
   isPerpTokenSelectorSpotTab,
   shouldRefreshPerpTokenSelectorSortSnapshot,
   sortPerpTokenSelectorItemsByServerOrder,

--- a/packages/kit/src/views/Perp/utils/tokenSelectorTabs.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorTabs.ts
@@ -17,6 +17,7 @@ type IPerpTokenSelectorSortSnapshotKey = {
   field?: string;
   direction?: string;
   sortSource?: IPerpTokenSelectorConfig['sortSource'];
+  sortSourceTab?: IPerpTokenSelectorConfig['sortSourceTab'];
 };
 type IPerpTokenSelectorDynamicTabItem = {
   tokenName?: string;
@@ -151,6 +152,26 @@ function getPerpTokenSelectorPrimaryTabId(
 
 function isPerpTokenSelectorPrimaryTab(tabId: string) {
   return PRIMARY_TAB_ID_SET.has(normalizeTabId(tabId));
+}
+
+function isPerpTokenSelectorDynamicTabUserSort({
+  activeTab,
+  sortSource,
+  sortSourceTab,
+}: {
+  activeTab?: string;
+  sortSource?: IPerpTokenSelectorConfig['sortSource'];
+  sortSourceTab?: IPerpTokenSelectorConfig['sortSourceTab'];
+}) {
+  const currentActiveTab = activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB;
+  if (isPerpTokenSelectorPrimaryTab(currentActiveTab)) {
+    return false;
+  }
+  return (
+    sortSource === 'user' &&
+    sortSourceTab !== undefined &&
+    normalizeTabId(sortSourceTab) === normalizeTabId(currentActiveTab)
+  );
 }
 
 function isMissingSortValue(value: ITokenSelectorSortValue) {
@@ -295,15 +316,41 @@ function isPerpTokenSelectorSortFieldActive({
   field,
   sortField,
   sortSource,
+  sortSourceTab,
 }: {
   activeTab?: string;
   field: IPerpTokenSortField;
   sortField?: IPerpTokenSortField;
   sortSource?: IPerpTokenSelectorConfig['sortSource'];
+  sortSourceTab?: IPerpTokenSelectorConfig['sortSourceTab'];
 }) {
   const currentActiveTab = activeTab ?? DEFAULT_PERP_TOKEN_ACTIVE_TAB;
   const isDynamicTab = !isPerpTokenSelectorPrimaryTab(currentActiveTab);
-  return sortField === field && (!isDynamicTab || sortSource === 'user');
+  return (
+    sortField === field &&
+    (!isDynamicTab ||
+      isPerpTokenSelectorDynamicTabUserSort({
+        activeTab: currentActiveTab,
+        sortSource,
+        sortSourceTab,
+      }))
+  );
+}
+
+function getNextPerpTokenSelectorActiveTabConfig({
+  prev,
+  tab,
+}: {
+  prev: IPerpTokenSelectorConfig | null;
+  tab: string;
+}): IPerpTokenSelectorConfig {
+  return {
+    field: prev?.field ?? DEFAULT_PERP_TOKEN_SORT_FIELD,
+    direction: prev?.direction ?? DEFAULT_PERP_TOKEN_SORT_DIRECTION,
+    activeTab: tab,
+    sortSource: 'default',
+    sortSourceTab: undefined,
+  };
 }
 
 function getNextPerpTokenSelectorSortConfig({
@@ -319,6 +366,7 @@ function getNextPerpTokenSelectorSortConfig({
     field,
     sortField: prev?.field,
     sortSource: prev?.sortSource,
+    sortSourceTab: prev?.sortSourceTab,
   });
 
   if (isCurrentFieldActive) {
@@ -328,6 +376,7 @@ function getNextPerpTokenSelectorSortConfig({
         direction: DEFAULT_PERP_TOKEN_SORT_DIRECTION,
         activeTab,
         sortSource: 'default',
+        sortSourceTab: undefined,
       };
     }
     return {
@@ -335,6 +384,7 @@ function getNextPerpTokenSelectorSortConfig({
       direction: 'asc',
       activeTab,
       sortSource: 'user',
+      sortSourceTab: activeTab,
     };
   }
 
@@ -343,19 +393,30 @@ function getNextPerpTokenSelectorSortConfig({
     direction: DEFAULT_PERP_TOKEN_SORT_DIRECTION,
     activeTab,
     sortSource: 'user',
+    sortSourceTab: activeTab,
   };
 }
 
 function getPerpTokenSelectorSortAssetCtxsByDex<T>({
+  activeTab,
   liveAssetCtxsByDex,
   snapshotAssetCtxsByDex,
   sortSource,
+  sortSourceTab,
 }: {
+  activeTab?: string;
   liveAssetCtxsByDex: T;
   snapshotAssetCtxsByDex: T;
   sortSource?: IPerpTokenSelectorConfig['sortSource'];
+  sortSourceTab?: IPerpTokenSelectorConfig['sortSourceTab'];
 }) {
-  return sortSource === 'user' ? liveAssetCtxsByDex : snapshotAssetCtxsByDex;
+  return isPerpTokenSelectorDynamicTabUserSort({
+    activeTab,
+    sortSource,
+    sortSourceTab,
+  })
+    ? liveAssetCtxsByDex
+    : snapshotAssetCtxsByDex;
 }
 
 function shouldRefreshPerpTokenSelectorSortSnapshot({
@@ -363,18 +424,21 @@ function shouldRefreshPerpTokenSelectorSortSnapshot({
   field,
   direction,
   sortSource,
+  sortSourceTab,
   snapshotEmpty,
 }: {
   lastSort: IPerpTokenSelectorSortSnapshotKey | null;
   field?: string;
   direction?: string;
   sortSource?: IPerpTokenSelectorConfig['sortSource'];
+  sortSourceTab?: IPerpTokenSelectorConfig['sortSourceTab'];
   snapshotEmpty: boolean;
 }) {
   return (
     lastSort?.field !== field ||
     lastSort?.direction !== direction ||
     lastSort?.sortSource !== sortSource ||
+    lastSort?.sortSourceTab !== sortSourceTab ||
     snapshotEmpty
   );
 }
@@ -386,9 +450,11 @@ export {
   comparePerpTokenSelectorSortValues,
   getPerpTokenSelectorDynamicTabItems,
   getPerpTokenSelectorFallbackTabId,
+  getNextPerpTokenSelectorActiveTabConfig,
   getNextPerpTokenSelectorSortConfig,
   getPerpTokenSelectorPrimaryTabId,
   getPerpTokenSelectorSortAssetCtxsByDex,
+  isPerpTokenSelectorDynamicTabUserSort,
   isPerpTokenSelectorAllTab,
   isPerpTokenSelectorFavoritesTab,
   isPerpTokenSelectorPerpsTab,

--- a/packages/kit/src/views/Perp/utils/tokenSelectorTabs.ts
+++ b/packages/kit/src/views/Perp/utils/tokenSelectorTabs.ts
@@ -398,25 +398,11 @@ function getNextPerpTokenSelectorSortConfig({
 }
 
 function getPerpTokenSelectorSortAssetCtxsByDex<T>({
-  activeTab,
-  liveAssetCtxsByDex,
   snapshotAssetCtxsByDex,
-  sortSource,
-  sortSourceTab,
 }: {
-  activeTab?: string;
-  liveAssetCtxsByDex: T;
   snapshotAssetCtxsByDex: T;
-  sortSource?: IPerpTokenSelectorConfig['sortSource'];
-  sortSourceTab?: IPerpTokenSelectorConfig['sortSourceTab'];
 }) {
-  return isPerpTokenSelectorDynamicTabUserSort({
-    activeTab,
-    sortSource,
-    sortSourceTab,
-  })
-    ? liveAssetCtxsByDex
-    : snapshotAssetCtxsByDex;
+  return snapshotAssetCtxsByDex;
 }
 
 function shouldRefreshPerpTokenSelectorSortSnapshot({

--- a/packages/shared/types/hyperliquid/types.ts
+++ b/packages/shared/types/hyperliquid/types.ts
@@ -412,6 +412,7 @@ export interface IPerpTokenSelectorConfig {
   field: IPerpTokenSortField;
   direction: IPerpTokenSortDirection;
   activeTab: IPerpTokenSelectorTab | string; // string for dynamic tabs
+  sortSource?: 'default' | 'user';
 }
 
 // Deprecated: Use IPerpTokenSelectorConfig instead

--- a/packages/shared/types/hyperliquid/types.ts
+++ b/packages/shared/types/hyperliquid/types.ts
@@ -413,6 +413,7 @@ export interface IPerpTokenSelectorConfig {
   direction: IPerpTokenSortDirection;
   activeTab: IPerpTokenSelectorTab | string; // string for dynamic tabs
   sortSource?: 'default' | 'user';
+  sortSourceTab?: IPerpTokenSelectorTab | string;
 }
 
 // Deprecated: Use IPerpTokenSelectorConfig instead


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56817](https://onekeyhq.atlassian.net/browse/OK-56817)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Preserve backend token order for dynamic Perps selector tabs, such as Hot and New List, until the user actively clicks a sortable header.
- Track default vs user-initiated sorting and use live asset values for user sorting so Volume/Open Interest order matches the displayed rows.
- Share dynamic-tab sort behavior across desktop and mobile token selectors and add regression coverage.

## Intent & Context
Related issue: [OK-56817](https://onekeyhq.atlassian.net/browse/OK-56817) - Perps - 新上架/热门 tab 的排序点击无效.

A runtime report on the Perps trading page showed that the token selector dynamic tabs did not reorder correctly when clicking sortable column headers such as Volume. The first symptom was that the newly added Hot list visually kept its original order when the sort arrow changed. After that path was corrected, the list could still be numerically inaccurate because displayed Volume values update live while the sort source could remain based on a previous snapshot.

The requested scope was limited to this Perps token selector sorting bug, without unrelated desktop build or route changes.

## Root Cause
The token selector did not distinguish dynamic tabs' backend/default token order from an explicit user header sort. Dynamic tabs should initially respect the backend-configured token order, but once a user clicks a column header, the rows must be sorted from the same live asset context used to render the column values. Without that separation, the UI could show a sort arrow while rows were still derived from server order or stale snapshot values.

## Design Decisions
- Add `sortSource` to distinguish backend/default tab ordering from explicit user sorting.
- Keep dynamic tabs in backend token order until a header interaction; the first user click starts descending sort instead of toggling from an invisible default.
- Use live asset contexts for user-initiated sorting, while keeping default ordering based on the stable snapshot to avoid unnecessary reorder churn before the user requests sorting.
- Centralize sort transitions and dynamic-tab filtering in shared helpers so desktop and mobile selectors stay aligned.

## Changes Detail
- `tokenSelectorTabs.ts`: adds dynamic-tab ordering helpers, sort source transitions, active-header detection, and live/snapshot sort-source selection.
- `PerpTokenSelector.tsx` and `MoblieTokenSelector.tsx`: use the shared helpers for dynamic tab filtering and user sorting.
- `SortableHeaderCell.tsx`: delegates active state and next-sort calculation to shared helpers.
- `perps.ts`, `types.ts`, and `tokenSelectorPerf.ts`: persist and surface the new `sortSource` field.
- `tokenSelectorTabs.test.ts`: adds regression tests for dynamic default order, user sorting, header state, source changes, and live Volume alignment.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web / Mobile
- **Risk Areas**: Perps token selector row ordering and persisted selector sort config. This does not affect order placement, signing, wallet balance, or transaction paths.

## Test plan
- [x] `yarn lint --fix`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `yarn jest packages/kit/src/views/Perp/utils/tokenSelectorTabs.test.ts --runInBand`
- [x] Verify desktop Perps Hot tab Volume descending/ascending order remains monotonic after live updates.

[OK-56817]: https://onekeyhq.atlassian.net/browse/OK-56817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ