### PR TITLE
fix(mobile): defer app tree render behind cold-start lock on low-end iOS

### DIFF
--- a/packages/kit/src/provider/Container/AppStateLockContainer/index.tsx
+++ b/packages/kit/src/provider/Container/AppStateLockContainer/index.tsx
@@ -6,6 +6,11 @@ import { ANIMATE_ONLY_OPACITY } from '@onekeyhq/components/src/utils/animationCo
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useAppIsLockedAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { IS_LOW_END_DEVICE } from '@onekeyhq/shared/src/utils/lowEndDevice';
+import {
+  isUnlockTransition,
+  shouldDeferColdStartLockRender,
+} from '@onekeyhq/shared/src/utils/lowEndDeviceUtils';
 
 import PasswordVerifyContainer from '../../../components/Password/container/PasswordVerifyContainer';
 
@@ -86,6 +91,32 @@ export function AppStateLockContainer({
 }: PropsWithChildren<unknown>) {
   const [isLocked] = useAppIsLockedAtom();
 
+  // Track whether this process has ever been unlocked. On low-end iOS devices we
+  // skip rendering the full app tree behind the lock screen ONLY for a
+  // cold-start lock (never unlocked yet) — so the single background JS thread
+  // is free to finish the 600k-iteration PBKDF2 `verifyPassword` before iOS
+  // jetsam kills the process. Once unlocked, we always render children again so
+  // an auto-lock-while-using never unmounts the user's current screen.
+  //
+  // The latch only flips on a real locked->unlocked transition (not on any
+  // `isLocked === false` render) so a transient/default `false` during early
+  // state hydration (e.g. the first cold start after upgrade) cannot
+  // permanently defeat the optimization on the riskiest boot.
+  const hasUnlockedOnceRef = useRef(false);
+  const prevLockedRef = useRef(isLocked);
+  if (isUnlockTransition(prevLockedRef.current, isLocked)) {
+    hasUnlockedOnceRef.current = true;
+  }
+  prevLockedRef.current = isLocked;
+  const deferColdStartChildren = shouldDeferColdStartLockRender({
+    // RAM-based low-end detection is also true on low-RAM Android, but the
+    // jetsam / dual-runtime PBKDF2-starvation problem this guards against is
+    // iOS-specific, so the defer behavior is gated to iOS.
+    isLowEndDevice: IS_LOW_END_DEVICE && platformEnv.isNativeIOS,
+    isLocked,
+    hasUnlockedOnce: hasUnlockedOnceRef.current,
+  });
+
   const handleUnlock = useCallback(async () => {
     await backgroundApiProxy.servicePassword.unLockApp();
   }, []);
@@ -118,7 +149,7 @@ export function AppStateLockContainer({
 
   return (
     <>
-      {children}
+      {deferColdStartChildren ? null : children}
       {!isLocked ? <AppStateUpdater /> : null}
       <AnimatePresence>
         {isLocked ? (

--- a/packages/shared/src/utils/lowEndDevice.native.ts
+++ b/packages/shared/src/utils/lowEndDevice.native.ts
@@ -1,0 +1,17 @@
+import { totalMemory } from 'expo-device';
+
+// Native low-end-device flag, computed once at module load from device RAM.
+//
+// `expo-device` `totalMemory` is in bytes. We use binary GiB (1024^3) so that
+// 3GB-class devices that report ~3.14e9 bytes (e.g. iPhone 7 Plus) are included.
+// Threshold 3.5 * GiB = 3_758_096_384 bytes.
+//
+// Used to defer rendering the full app tree behind the lock screen during a
+// cold-start lock, so the single background JS thread is free to finish the
+// 600k-iteration PBKDF2 `verifyPassword` before iOS jetsam kills the process.
+const GB = 1024 * 1024 * 1024;
+const LOW_END_MEMORY_THRESHOLD = 3.5 * GB; // 3_758_096_384 bytes
+
+const mem = typeof totalMemory === 'number' ? totalMemory : 0;
+
+export const IS_LOW_END_DEVICE = mem > 0 && mem <= LOW_END_MEMORY_THRESHOLD;

--- a/packages/shared/src/utils/lowEndDevice.ts
+++ b/packages/shared/src/utils/lowEndDevice.ts
@@ -1,0 +1,7 @@
+// Default (web / desktop / extension) variant.
+//
+// These platforms do not have the iOS jetsam cold-start-lock kill problem that
+// `IS_LOW_END_DEVICE` guards against, so the constant is always `false` here and
+// any low-end-only behavior is a no-op. See ./lowEndDevice.native.ts for the
+// native (RAM-tiered) computation.
+export const IS_LOW_END_DEVICE = false;

--- a/packages/shared/src/utils/lowEndDeviceUtils.test.ts
+++ b/packages/shared/src/utils/lowEndDeviceUtils.test.ts
@@ -1,0 +1,64 @@
+import {
+  isUnlockTransition,
+  shouldDeferColdStartLockRender,
+} from './lowEndDeviceUtils';
+
+describe('isUnlockTransition', () => {
+  it('latches only on a real locked -> unlocked transition', () => {
+    expect(isUnlockTransition(true, false)).toBe(true);
+  });
+
+  it('does NOT latch on a transient/default `false` (e.g. early hydration before locked is known)', () => {
+    expect(isUnlockTransition(false, false)).toBe(false);
+  });
+
+  it('does NOT latch while staying locked', () => {
+    expect(isUnlockTransition(true, true)).toBe(false);
+  });
+
+  it('does NOT latch on a unlocked -> locked (auto-lock) transition', () => {
+    expect(isUnlockTransition(false, true)).toBe(false);
+  });
+});
+
+describe('shouldDeferColdStartLockRender', () => {
+  it('defers children on a low-end device that is locked and never unlocked', () => {
+    expect(
+      shouldDeferColdStartLockRender({
+        isLowEndDevice: true,
+        isLocked: true,
+        hasUnlockedOnce: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('does NOT defer after the first unlock even if re-locked (auto-lock preserves children)', () => {
+    expect(
+      shouldDeferColdStartLockRender({
+        isLowEndDevice: true,
+        isLocked: true,
+        hasUnlockedOnce: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('does NOT defer on a non-low-end device', () => {
+    expect(
+      shouldDeferColdStartLockRender({
+        isLowEndDevice: false,
+        isLocked: true,
+        hasUnlockedOnce: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('does NOT defer when the app is unlocked', () => {
+    expect(
+      shouldDeferColdStartLockRender({
+        isLowEndDevice: true,
+        isLocked: false,
+        hasUnlockedOnce: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/lowEndDeviceUtils.ts
+++ b/packages/shared/src/utils/lowEndDeviceUtils.ts
@@ -1,0 +1,31 @@
+// Pure, platform-independent decision helpers for low-end-device cold-start
+// behavior. Kept separate from the platform-split `IS_LOW_END_DEVICE` constant
+// (see ./lowEndDevice.native.ts / ./lowEndDevice.ts) so the logic is
+// unit-testable without pulling in `expo-device`.
+
+// True only when the lock state goes locked -> unlocked, i.e. a real unlock.
+// Used to latch "this process has been unlocked once" WITHOUT being fooled by a
+// transient/default `isLocked=false` during early state hydration (e.g. the
+// first cold start after upgrade, before the persisted password state is read),
+// which would otherwise permanently defeat the cold-start defer optimization.
+export function isUnlockTransition(
+  prevLocked: boolean,
+  isLocked: boolean,
+): boolean {
+  return prevLocked && !isLocked;
+}
+
+export function shouldDeferColdStartLockRender({
+  isLowEndDevice,
+  isLocked,
+  hasUnlockedOnce,
+}: {
+  isLowEndDevice: boolean;
+  isLocked: boolean;
+  hasUnlockedOnce: boolean;
+}): boolean {
+  // Only on low-end devices, only while still locked, and only before the very
+  // first unlock of this process. After the first unlock we always render the
+  // app tree so an auto-lock-while-using never unmounts the user's screen.
+  return isLowEndDevice && isLocked && !hasUnlockedOnce;
+}


### PR DESCRIPTION
## Problem

On low-end iOS devices (≤3.5 GiB RAM, e.g. **iPhone 7 Plus**, app 6.4.0), cold-starting **while the app is locked** can make the app effectively **impossible to unlock** — the user enters the password / Face ID spins, but the app keeps restarting before it unlocks.

Diagnosed from a real device log (iPhone 7 Plus, iOS 15.8.8, 3.14 GB): ~50 cold starts in 44 min, the unlock `verifyPassword` dispatched 57× but completed only once.

## Root cause

This is dual: a memory/jetsam loop + bg-thread starvation, both rooted in the same thing.

- The lock screen is an **overlay** — `AppStateLockContainer` renders `{children}` (the entire `DetailRouter` app tree) **unconditionally**, *behind* the lock screen.
- So while locked, the whole app boots behind the lock: the home data cascade (token/defi/staking/account-value), the app-level `Bootstrap` fetches (market/perps/currency), and the `InAppNotification` swap-status loop — **~67 concurrent calls flooding the single background JS runtime thread**, plus the memory of the full tree.
- The only part of unlock that needs the bg is `servicePassword.verifyPassword` — a **600,000-iteration PBKDF2** (native quick-crypto) that needs the bg thread for ~5s. Starved by the flood + the device under memory pressure, the process is **jetsam-killed (~10–19s)** before verify finishes → relaunch → repeat.
- Lock screen + biometric (`isEnable`, `getPassword`/keychain) are main-thread/local — they do **not** need the bg. Only verify does.

## Fix

On **low-end iOS only**, for a **cold-start lock** (process never unlocked yet), do not render `AppStateLockContainer`'s `{children}`. This frees the bg thread and cuts memory so `verifyPassword` can finish before jetsam.

- The latch flips on a real **locked → unlocked transition** (not on any `isLocked === false` render), so after the first unlock children always render again — an **auto-lock-while-using never unmounts the user's current screen** — and a transient default-`unlocked` render during early state hydration (e.g. first cold start after upgrade) cannot permanently defeat the optimization.
- The **lock screen + verify are untouched** (the lock overlay is a sibling of `{children}`, with no dependency on the nav tree) — no path to "can never unlock".
- **Non-low-end and non-iOS behavior is byte-for-byte unchanged** (`IS_LOW_END_DEVICE` is `false` on web/desktop/ext; gated by `platformEnv.isNativeIOS`).
- Threshold `totalMemory ≤ 3.5 GiB` (binary), reusing the `expo-device` tiering precedent in `webviewAliveLimit.native.ts`; covers 2–3 GB-class iOS devices.

## Files

- `packages/shared/src/utils/lowEndDevice.native.ts` / `.ts` — platform-split `IS_LOW_END_DEVICE` constant.
- `packages/shared/src/utils/lowEndDeviceUtils.ts` (+ `.test.ts`) — pure `isUnlockTransition` / `shouldDeferColdStartLockRender` (8 unit tests).
- `packages/kit/src/provider/Container/AppStateLockContainer/index.tsx` — gate `{children}` for cold-start lock on low-end iOS.

## Adversarial review outcome

- **No catastrophic failure mode**: device can always unlock; children always render after unlock in steady state. Deep-link / cold-start-by-notification self-defer via `whenAppUnlocked()` (delayed, not lost); no `rootNavigationRef` NPE.
- The one HIGH finding (a transient default-`unlocked` first render could defeat the gate on the post-upgrade boot) is **fixed** by the transition-based latch.

## Verify on a real 3 GB iOS device before release

- [ ] Cold-start locked: confirm reliable unlock; bg in-flight count at verify drops from ~67 toward ~31.
- [ ] Post-unlock first paint: no lingering blank/white flash while the tree mounts.
- [ ] Auto-lock while using: unlocking returns to the same screen (children not unmounted).
- [ ] `expo-device.totalMemory` reads ~3.14 GB on the 7 Plus → lands in the low-end bucket.

Note: scoped to **iOS** by design; low-RAM Android is intentionally excluded from this hotfix (same architecture, but no evidence yet — can be a follow-up).

https://claude.ai/code/session_01FFUy2BJJ3BAi6nkwqahM45
