### PR TITLE
fix: guard exact BTC swap payments

### DIFF
--- a/packages/kit-bg/src/vaults/impls/btc/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/btc/Vault.ts
@@ -844,14 +844,11 @@ export default class VaultBtc extends VaultBase {
     } = await this._buildTransferParamsWithCoinSelector(params);
 
     if (!inputs || !outputs || isNil(fee)) {
-      const insufficientBalance = appLocale.intl.formatMessage({
-        id: ETranslations.earn_insufficient_balance,
-      });
       const description = appLocale.intl.formatMessage({
         id: ETranslations.send_toast_btc_fork_insufficient_fund,
       });
       throw new InsufficientBalance({
-        message: `${insufficientBalance} ${description}`,
+        message: description,
       });
     }
 

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -126,6 +126,7 @@ import {
 import { buildSwapApproveAndSendSteps } from '../utils/buildSwapReviewState';
 import {
   checkSwapLatestBalanceSufficient,
+  getSwapExactPaymentOutputMismatch,
   getSwapRequiredNativeBalanceAmount,
 } from '../utils/swapBalanceUtils';
 
@@ -792,6 +793,35 @@ export function useSwapBuildTx() {
           },
         });
       const txSize = updatedUnsignedTxItem.txSize ?? unsignedTxItem.txSize;
+      const exactPaymentMismatch = getSwapExactPaymentOutputMismatch({
+        encodedTx: updatedUnsignedTxItem.encodedTx,
+        transferInfo:
+          unsignedTxItem.transfersInfo?.[0] ??
+          updatedUnsignedTxItem.transfersInfo?.[0],
+      });
+      if (exactPaymentMismatch) {
+        const tokenSymbol =
+          updatedUnsignedTxItem.swapInfo?.sender.token.symbol ??
+          unsignedTxItem.swapInfo?.sender.token.symbol ??
+          gasInfo.common?.nativeSymbol ??
+          '';
+        Toast.error({
+          title: intl.formatMessage(
+            {
+              id: ETranslations.swap_page_toast_insufficient_balance_title,
+            },
+            { token: tokenSymbol },
+          ),
+          toastId: [
+            'swap-exact-payment-output-mismatch',
+            networkId,
+            tokenSymbol,
+            exactPaymentMismatch.expectedAmountBase,
+            exactPaymentMismatch.actualAmountBase,
+          ].join('-'),
+        });
+        throw new OneKeyAppError('swap exact payment output mismatch');
+      }
       const {
         totalNative,
         total,

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -126,6 +126,7 @@ import {
 import { buildSwapApproveAndSendSteps } from '../utils/buildSwapReviewState';
 import {
   checkSwapLatestBalanceSufficient,
+  getSwapEncodedTxSize,
   getSwapExactPaymentOutputMismatch,
   getSwapRequiredNativeBalanceAmount,
 } from '../utils/swapBalanceUtils';
@@ -792,8 +793,13 @@ export function useSwapBuildTx() {
             feeBudget: gasInfo.feeBudget,
           },
         });
-      const txSize = updatedUnsignedTxItem.txSize ?? unsignedTxItem.txSize;
+      const txSize =
+        getSwapEncodedTxSize(updatedUnsignedTxItem.encodedTx) ??
+        updatedUnsignedTxItem.txSize ??
+        getSwapEncodedTxSize(unsignedTxItem.encodedTx) ??
+        unsignedTxItem.txSize;
       const exactPaymentMismatch = getSwapExactPaymentOutputMismatch({
+        networkId,
         encodedTx: updatedUnsignedTxItem.encodedTx,
         transferInfo:
           unsignedTxItem.transfersInfo?.[0] ??
@@ -806,12 +812,9 @@ export function useSwapBuildTx() {
           gasInfo.common?.nativeSymbol ??
           '';
         Toast.error({
-          title: intl.formatMessage(
-            {
-              id: ETranslations.swap_page_toast_insufficient_balance_title,
-            },
-            { token: tokenSymbol },
-          ),
+          title: intl.formatMessage({
+            id: ETranslations.send_toast_btc_fork_insufficient_fund,
+          }),
           toastId: [
             'swap-exact-payment-output-mismatch',
             networkId,

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -128,8 +128,8 @@ import { buildSwapApproveAndSendSteps } from '../utils/buildSwapReviewState';
 import {
   checkSwapLatestBalanceSufficient,
   getSwapEncodedTxSize,
-  getSwapExactPaymentOutputMismatch,
   getSwapRequiredNativeBalanceAmount,
+  validateSwapBtcOutputs,
 } from '../utils/swapBalanceUtils';
 
 import { useSwapAddressInfo } from './useSwapAccount';
@@ -823,14 +823,14 @@ export function useSwapBuildTx() {
         updatedUnsignedTxItem.txSize ??
         getSwapEncodedTxSize(unsignedTxItem.encodedTx) ??
         unsignedTxItem.txSize;
-      const exactPaymentMismatch = getSwapExactPaymentOutputMismatch({
+      const btcOutputValidationError = validateSwapBtcOutputs({
         networkId,
         encodedTx: updatedUnsignedTxItem.encodedTx,
         transferInfo:
           unsignedTxItem.transfersInfo?.[0] ??
           updatedUnsignedTxItem.transfersInfo?.[0],
       });
-      if (exactPaymentMismatch) {
+      if (btcOutputValidationError) {
         const tokenSymbol =
           updatedUnsignedTxItem.swapInfo?.sender.token.symbol ??
           unsignedTxItem.swapInfo?.sender.token.symbol ??
@@ -842,14 +842,15 @@ export function useSwapBuildTx() {
             tokenSymbol,
           }),
           toastId: [
-            'swap-exact-payment-output-mismatch',
+            'swap-btc-output-validation',
             networkId,
             tokenSymbol,
-            exactPaymentMismatch.expectedAmountBase,
-            exactPaymentMismatch.actualAmountBase,
+            btcOutputValidationError.type,
+            btcOutputValidationError.expectedAmountBase ?? '',
+            btcOutputValidationError.actualAmountBase ?? '',
           ].join('-'),
         });
-        throw new OneKeyAppError('swap exact payment output mismatch');
+        throw new OneKeyAppError('swap btc output validation failed');
       }
       const {
         totalNative,

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -126,6 +126,7 @@ import {
 } from '../../../states/jotai/contexts/swap';
 import { buildSwapApproveAndSendSteps } from '../utils/buildSwapReviewState';
 import {
+  type ISwapBtcOutputValidationError,
   checkSwapLatestBalanceSufficient,
   getSwapEncodedTxSize,
   getSwapRequiredNativeBalanceAmount,
@@ -530,6 +531,35 @@ export function useSwapBuildTx() {
     [intl],
   );
 
+  const getSwapBtcOutputValidationToast = useCallback(
+    ({
+      networkId,
+      tokenSymbol,
+      validationError,
+    }: {
+      networkId?: string;
+      tokenSymbol: string;
+      validationError: ISwapBtcOutputValidationError;
+    }) => {
+      if (validationError.type === 'payment_output_less_than_order_amount') {
+        return getSwapBalanceInsufficientToast({
+          networkId,
+          tokenSymbol,
+        });
+      }
+
+      return {
+        title: intl.formatMessage({
+          id: ETranslations.swap_page_toast_swap_failed,
+        }),
+        message: intl.formatMessage({
+          id: ETranslations.global_unknown_error_retry_message,
+        }),
+      };
+    },
+    [getSwapBalanceInsufficientToast, intl],
+  );
+
   const checkOtherFee = useCallback(
     async (quoteResult: IFetchQuoteResult) => {
       const otherFeeInfo = quoteResult?.fee?.otherFeeInfos;
@@ -836,11 +866,13 @@ export function useSwapBuildTx() {
           unsignedTxItem.swapInfo?.sender.token.symbol ??
           gasInfo.common?.nativeSymbol ??
           '';
+        const validationToast = getSwapBtcOutputValidationToast({
+          networkId,
+          tokenSymbol,
+          validationError: btcOutputValidationError,
+        });
         Toast.error({
-          ...getSwapBalanceInsufficientToast({
-            networkId,
-            tokenSymbol,
-          }),
+          ...validationToast,
           toastId: [
             'swap-btc-output-validation',
             networkId,
@@ -850,7 +882,11 @@ export function useSwapBuildTx() {
             btcOutputValidationError.actualAmountBase ?? '',
           ].join('-'),
         });
-        throw new OneKeyAppError('swap btc output validation failed');
+        throw new OneKeyAppError(
+          [validationToast.title, validationToast.message]
+            .filter(Boolean)
+            .join(' '),
+        );
       }
       const {
         totalNative,
@@ -948,7 +984,7 @@ export function useSwapBuildTx() {
     },
     [
       checkLatestNativeTokenBalance,
-      getSwapBalanceInsufficientToast,
+      getSwapBtcOutputValidationToast,
       intl,
       setSwapSteps,
     ],

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -48,6 +48,7 @@ import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { calculateFeeForSend } from '@onekeyhq/shared/src/utils/feeUtils';
 import { createLazySdkLoader } from '@onekeyhq/shared/src/utils/lazySdkLoader';
 import { applyCustomPriorityFeeToGasInfo } from '@onekeyhq/shared/src/utils/marketPresetFeeUtils';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   numberFormat,
@@ -490,6 +491,45 @@ export function useSwapBuildTx() {
     [clearQuoteData, generateSwapHistoryItem, setSwapSteps, fromAccountId],
   );
 
+  const getSwapBalanceInsufficientToast = useCallback(
+    ({
+      networkId,
+      tokenSymbol,
+      reserveAmount,
+    }: {
+      networkId?: string;
+      tokenSymbol: string;
+      reserveAmount?: string;
+    }) => {
+      const isBtcNetwork = networkUtils.isBTCNetwork(networkId);
+      return {
+        title: isBtcNetwork
+          ? intl.formatMessage({
+              id: ETranslations.send_toast_btc_fork_insufficient_fund,
+            })
+          : intl.formatMessage(
+              {
+                id: ETranslations.swap_page_toast_insufficient_balance_title,
+              },
+              { token: tokenSymbol },
+            ),
+        message:
+          !isBtcNetwork && reserveAmount
+            ? intl.formatMessage(
+                {
+                  id: ETranslations.swap_page_toast_insufficient_balance_content,
+                },
+                {
+                  token: tokenSymbol,
+                  number: numberFormat(reserveAmount, formatter),
+                },
+              )
+            : undefined,
+      };
+    },
+    [intl],
+  );
+
   const checkOtherFee = useCallback(
     async (quoteResult: IFetchQuoteResult) => {
       const otherFeeInfo = quoteResult?.fee?.otherFeeInfos;
@@ -516,21 +556,11 @@ export function useSwapBuildTx() {
             });
             if (!checkResult.isSufficient) {
               Toast.error({
-                title: intl.formatMessage(
-                  {
-                    id: ETranslations.swap_page_toast_insufficient_balance_title,
-                  },
-                  { token: checkResult.tokenSymbol },
-                ),
-                message: intl.formatMessage(
-                  {
-                    id: ETranslations.swap_page_toast_insufficient_balance_content,
-                  },
-                  {
-                    token: checkResult.tokenSymbol,
-                    number: numberFormat(tokenAmountBN.toFixed(), formatter),
-                  },
-                ),
+                ...getSwapBalanceInsufficientToast({
+                  networkId: item.token.networkId,
+                  tokenSymbol: checkResult.tokenSymbol,
+                  reserveAmount: tokenAmountBN.toFixed(),
+                }),
               });
               checkRes = false;
             }
@@ -539,21 +569,25 @@ export function useSwapBuildTx() {
       }
       return checkRes;
     },
-    [fromToken, intl, selectQuote?.fromAmount, fromUserAddress, fromAccountId],
+    [
+      fromToken,
+      selectQuote?.fromAmount,
+      fromUserAddress,
+      fromAccountId,
+      getSwapBalanceInsufficientToast,
+    ],
   );
 
   const showLatestBalanceInsufficientToast = useCallback(
-    (tokenSymbol: string) => {
+    (networkId: string | undefined, tokenSymbol: string) => {
       Toast.error({
-        title: intl.formatMessage(
-          {
-            id: ETranslations.swap_page_toast_insufficient_balance_title,
-          },
-          { token: tokenSymbol },
-        ),
+        ...getSwapBalanceInsufficientToast({
+          networkId,
+          tokenSymbol,
+        }),
       });
     },
-    [intl],
+    [getSwapBalanceInsufficientToast],
   );
 
   const checkLatestFromTokenBalance = useCallback(
@@ -565,7 +599,10 @@ export function useSwapBuildTx() {
         accountId: fromAccountId,
       });
       if (!checkResult.isSufficient) {
-        showLatestBalanceInsufficientToast(checkResult.tokenSymbol);
+        showLatestBalanceInsufficientToast(
+          token.networkId,
+          checkResult.tokenSymbol,
+        );
         return false;
       }
       return true;
@@ -612,35 +649,23 @@ export function useSwapBuildTx() {
           checkResult.tokenSymbol,
           nativeBalanceRequirement.reserveAmount,
         ].join('-');
-        const reserveAmountMessage = nativeBalanceRequirement.includesFromAmount
-          ? undefined
-          : intl.formatMessage(
-              {
-                id: ETranslations.swap_page_toast_insufficient_balance_content,
-              },
-              {
-                token: checkResult.tokenSymbol,
-                number: numberFormat(
-                  nativeBalanceRequirement.reserveAmount,
-                  formatter,
-                ),
-              },
-            );
+        const { title, message } = getSwapBalanceInsufficientToast({
+          networkId: nativeBalanceRequirement.token.networkId,
+          tokenSymbol: checkResult.tokenSymbol,
+          reserveAmount: nativeBalanceRequirement.includesFromAmount
+            ? undefined
+            : nativeBalanceRequirement.reserveAmount,
+        });
         Toast.error({
-          title: intl.formatMessage(
-            {
-              id: ETranslations.swap_page_toast_insufficient_balance_title,
-            },
-            { token: checkResult.tokenSymbol },
-          ),
-          message: reserveAmountMessage,
+          title,
+          message,
           toastId,
         });
         return false;
       }
       return true;
     },
-    [fromAccountId, fromUserAddress, intl],
+    [fromAccountId, fromUserAddress, getSwapBalanceInsufficientToast],
   );
 
   const cancelLimitOrder = useCallback(
@@ -812,8 +837,9 @@ export function useSwapBuildTx() {
           gasInfo.common?.nativeSymbol ??
           '';
         Toast.error({
-          title: intl.formatMessage({
-            id: ETranslations.send_toast_btc_fork_insufficient_fund,
+          ...getSwapBalanceInsufficientToast({
+            networkId,
+            tokenSymbol,
           }),
           toastId: [
             'swap-exact-payment-output-mismatch',
@@ -919,7 +945,12 @@ export function useSwapBuildTx() {
         gasFeeInNative: totalNativeForDisplay,
       };
     },
-    [checkLatestNativeTokenBalance, intl, setSwapSteps],
+    [
+      checkLatestNativeTokenBalance,
+      getSwapBalanceInsufficientToast,
+      intl,
+      setSwapSteps,
+    ],
   );
 
   const swapEstimateFeeEvent = useCallback(

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -143,6 +143,12 @@ const formatter: INumberFormatProps = {
   formatter: 'balance',
 };
 
+type ISwapGasFeeInfo = {
+  encodeTx: IEncodedTx;
+  gasInfo: ISwapGasInfo;
+  txSize?: number;
+};
+
 type ISwapSendTxResult = ISignedTxPro & {
   gasFeeFiatValue?: string;
   gasFeeInNative?: string;
@@ -573,7 +579,7 @@ export function useSwapBuildTx() {
       amount,
       otherFeeInfos,
     }: {
-      gasInfos?: { gasInfo?: ISwapGasInfo }[];
+      gasInfos?: { gasInfo?: ISwapGasInfo; txSize?: number }[];
       networkId?: string;
       token?: ISwapToken;
       amount?: string;
@@ -785,6 +791,7 @@ export function useSwapBuildTx() {
             feeBudget: gasInfo.feeBudget,
           },
         });
+      const txSize = updatedUnsignedTxItem.txSize ?? unsignedTxItem.txSize;
       const {
         totalNative,
         total,
@@ -794,9 +801,10 @@ export function useSwapBuildTx() {
       } = calculateFeeForSend({
         feeInfo: gasInfo as IFeeInfoUnit,
         nativeTokenPrice: gasInfo.common?.nativeTokenPrice ?? 0,
+        txSize,
       });
       const checkLatestNativeBalanceRes = await checkLatestNativeTokenBalance({
-        gasInfos: [{ gasInfo }],
+        gasInfos: [{ gasInfo, txSize }],
         networkId,
         token: unsignedTxItem.swapInfo?.sender.token,
         amount: unsignedTxItem.swapInfo?.sender.amount,
@@ -1131,10 +1139,7 @@ export function useSwapBuildTx() {
   }, [goBackQrCodeModal, fromAccountId]);
 
   const findGasInfo = useCallback(
-    (
-      stepGasInfos: { encodeTx: IEncodedTx; gasInfo: ISwapGasInfo }[],
-      encodedTx: IEncodedTx,
-    ) => {
+    (stepGasInfos: ISwapGasFeeInfo[], encodedTx: IEncodedTx) => {
       return stepGasInfos?.find(
         (s) =>
           isEqual(s.encodeTx, encodedTx) ||
@@ -2866,7 +2871,7 @@ export function useSwapBuildTx() {
         buildUnsignedParamsCheckNonce.prevNonce =
           approveUnsignedTxArr[approveUnsignedTxArr.length - 1].nonce;
       }
-      let gasFeeInfos: { encodeTx: IEncodedTx; gasInfo: ISwapGasInfo }[] = [];
+      let gasFeeInfos: ISwapGasFeeInfo[] = [];
       const unsignedTx =
         await backgroundApiProxy.serviceSend.prepareSendConfirmUnsignedTx({
           ...buildUnsignedParamsCheckNonce,
@@ -2929,6 +2934,7 @@ export function useSwapBuildTx() {
               gasFeeInfos.push({
                 encodeTx: unsignedTxItem.encodedTx ?? {},
                 gasInfo,
+                txSize: unsignedTxItem.txSize,
               });
             }
           } catch (e: any) {
@@ -3026,6 +3032,7 @@ export function useSwapBuildTx() {
               gasFeeInfos.push({
                 encodeTx: unsignedTxItem.encodedTx,
                 gasInfo: lastTxGasInfo,
+                txSize: unsignedTxItem.txSize,
               });
             } else {
               const estimateFeeParams =
@@ -3056,6 +3063,7 @@ export function useSwapBuildTx() {
               gasFeeInfos.push({
                 encodeTx: unsignedTxItem.encodedTx,
                 gasInfo: gasParseInfo,
+                txSize: unsignedTxItem.txSize,
               });
             }
           }
@@ -3092,6 +3100,7 @@ export function useSwapBuildTx() {
               {
                 encodeTx: unsignedTx.encodedTx,
                 gasInfo: gasParseInfo,
+                txSize: unsignedTx.txSize,
               },
             ];
           } catch (e: any) {
@@ -3128,6 +3137,7 @@ export function useSwapBuildTx() {
             const feeResult = calculateFeeForSend({
               feeInfo: gasInfo as IFeeInfoUnit,
               nativeTokenPrice: common?.nativeTokenPrice ?? 0,
+              txSize: item.txSize,
             });
             return feeResult.totalFiatMinForDisplay;
           }),

--- a/packages/kit/src/views/Swap/hooks/useSwapState.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapState.ts
@@ -12,6 +12,7 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import {
   swapQuoteIntervalMaxCount,
@@ -448,12 +449,16 @@ export function useSwapActionState() {
         swapFromAddressInfo.address &&
         balanceBN.lt(fromTokenAmountBN)
       ) {
-        infoRes.label = intl.formatMessage(
-          {
-            id: ETranslations.swap_page_toast_insufficient_balance_title,
-          },
-          { token: fromToken.symbol },
-        );
+        infoRes.label = networkUtils.isBTCNetwork(fromToken.networkId)
+          ? intl.formatMessage({
+              id: ETranslations.send_toast_btc_fork_insufficient_fund,
+            })
+          : intl.formatMessage(
+              {
+                id: ETranslations.swap_page_toast_insufficient_balance_title,
+              },
+              { token: fromToken.symbol },
+            );
         infoRes.disable = true;
       }
 

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -5,8 +5,8 @@ import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 import {
   checkSwapLatestBalanceSufficient,
   getSwapEncodedTxSize,
-  getSwapExactPaymentOutputMismatch,
   getSwapRequiredNativeBalanceAmount,
+  validateSwapBtcOutputs,
 } from './swapBalanceUtils';
 
 type IFetchSwapTokenDetailsParams = {
@@ -266,7 +266,7 @@ describe('getSwapEncodedTxSize', () => {
   });
 });
 
-describe('getSwapExactPaymentOutputMismatch', () => {
+describe('validateSwapBtcOutputs', () => {
   const btcTransferInfo = {
     from: 'bc1from',
     to: 'bc1provider',
@@ -280,9 +280,32 @@ describe('getSwapExactPaymentOutputMismatch', () => {
     },
   } as ITransferInfo;
 
+  it('blocks UTXO swap transactions when the provider payment output is missing', () => {
+    expect(
+      validateSwapBtcOutputs({
+        networkId: 'btc--0',
+        encodedTx: {
+          outputs: [
+            {
+              address: 'bc1change',
+              value: '1000',
+            },
+          ],
+        } as IEncodedTx,
+        transferInfo: btcTransferInfo,
+      }),
+    ).toEqual({
+      type: 'payment_output_missing',
+      expectedAmount: '0.00179536',
+      actualAmount: '0',
+      expectedAmountBase: '179536',
+      actualAmountBase: '0',
+    });
+  });
+
   it('blocks UTXO swap transactions when SendMax reduces the provider output', () => {
     expect(
-      getSwapExactPaymentOutputMismatch({
+      validateSwapBtcOutputs({
         networkId: 'btc--0',
         encodedTx: {
           outputs: [
@@ -295,6 +318,7 @@ describe('getSwapExactPaymentOutputMismatch', () => {
         transferInfo: btcTransferInfo,
       }),
     ).toEqual({
+      type: 'payment_output_less_than_order_amount',
       expectedAmount: '0.00179536',
       actualAmount: '0.00179316',
       expectedAmountBase: '179536',
@@ -304,7 +328,7 @@ describe('getSwapExactPaymentOutputMismatch', () => {
 
   it('allows UTXO swap transactions when the provider output matches the order amount', () => {
     expect(
-      getSwapExactPaymentOutputMismatch({
+      validateSwapBtcOutputs({
         networkId: 'btc--0',
         encodedTx: {
           outputs: [
@@ -323,9 +347,59 @@ describe('getSwapExactPaymentOutputMismatch', () => {
     ).toBeUndefined();
   });
 
+  it('blocks BTC swap transactions when required OP_RETURN output is missing', () => {
+    expect(
+      validateSwapBtcOutputs({
+        networkId: 'btc--0',
+        encodedTx: {
+          outputs: [
+            {
+              address: 'bc1provider',
+              value: '179536',
+            },
+          ],
+        } as IEncodedTx,
+        transferInfo: {
+          ...btcTransferInfo,
+          opReturn: '=:BNB.BNB:bnb1recipient',
+        } as ITransferInfo,
+      }),
+    ).toEqual({
+      type: 'op_return_missing',
+      expectedOpReturn: '=:BNB.BNB:bnb1recipient',
+    });
+  });
+
+  it('allows BTC swap transactions when required OP_RETURN output exists', () => {
+    expect(
+      validateSwapBtcOutputs({
+        networkId: 'btc--0',
+        encodedTx: {
+          outputs: [
+            {
+              address: 'bc1provider',
+              value: '179536',
+            },
+            {
+              address: '',
+              value: '0',
+              payload: {
+                opReturn: '=:BNB.BNB:bnb1recipient',
+              },
+            },
+          ],
+        } as IEncodedTx,
+        transferInfo: {
+          ...btcTransferInfo,
+          opReturn: '=:BNB.BNB:bnb1recipient',
+        } as ITransferInfo,
+      }),
+    ).toBeUndefined();
+  });
+
   it('skips exact-output validation for non-BTC networks', () => {
     expect(
-      getSwapExactPaymentOutputMismatch({
+      validateSwapBtcOutputs({
         networkId: 'ada--0',
         encodedTx: {
           outputs: [

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -66,6 +66,26 @@ const evmGasInfo = {
   },
 };
 
+const btcToken = {
+  networkId: 'btc--0',
+  contractAddress: '',
+  symbol: 'BTC',
+  decimals: 8,
+  isNative: true,
+} as ISwapToken;
+
+const btcGasInfo = {
+  common: {
+    feeDecimals: 0,
+    feeSymbol: 'sat/vB',
+    nativeDecimals: 8,
+    nativeSymbol: 'BTC',
+  },
+  feeUTXO: {
+    feeRate: '1',
+  },
+};
+
 const aptosNativeAddress = '0x1::aptos_coin::AptosCoin';
 
 const aptosToken = {
@@ -173,6 +193,22 @@ describe('getSwapRequiredNativeBalanceAmount', () => {
       token: ethToken,
       amount: '0.100021',
       reserveAmount: '0.000021',
+      includesFromAmount: true,
+    });
+  });
+
+  it('adds UTXO fee-rate reserve using transaction size for native BTC swaps', () => {
+    expect(
+      getSwapRequiredNativeBalanceAmount({
+        gasInfos: [{ gasInfo: btcGasInfo, txSize: 220 }],
+        networkId: 'btc--0',
+        fromToken: btcToken,
+        fromAmount: '0.0018',
+      }),
+    ).toEqual({
+      token: btcToken,
+      amount: '0.0018022',
+      reserveAmount: '0.0000022',
       includesFromAmount: true,
     });
   });

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -4,6 +4,7 @@ import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
 import {
   checkSwapLatestBalanceSufficient,
+  getSwapEncodedTxSize,
   getSwapExactPaymentOutputMismatch,
   getSwapRequiredNativeBalanceAmount,
 } from './swapBalanceUtils';
@@ -256,6 +257,15 @@ describe('getSwapRequiredNativeBalanceAmount', () => {
   });
 });
 
+describe('getSwapEncodedTxSize', () => {
+  it('reads rebuilt UTXO txSize from encodedTx only when valid', () => {
+    expect(getSwapEncodedTxSize({ txSize: 220 } as IEncodedTx)).toBe(220);
+    expect(getSwapEncodedTxSize({ txSize: 0 } as IEncodedTx)).toBeUndefined();
+    expect(getSwapEncodedTxSize({ txSize: -1 } as IEncodedTx)).toBeUndefined();
+    expect(getSwapEncodedTxSize('raw-tx' as IEncodedTx)).toBeUndefined();
+  });
+});
+
 describe('getSwapExactPaymentOutputMismatch', () => {
   const btcTransferInfo = {
     from: 'bc1from',
@@ -273,6 +283,7 @@ describe('getSwapExactPaymentOutputMismatch', () => {
   it('blocks UTXO swap transactions when SendMax reduces the provider output', () => {
     expect(
       getSwapExactPaymentOutputMismatch({
+        networkId: 'btc--0',
         encodedTx: {
           outputs: [
             {
@@ -294,6 +305,7 @@ describe('getSwapExactPaymentOutputMismatch', () => {
   it('allows UTXO swap transactions when the provider output matches the order amount', () => {
     expect(
       getSwapExactPaymentOutputMismatch({
+        networkId: 'btc--0',
         encodedTx: {
           outputs: [
             {
@@ -303,6 +315,23 @@ describe('getSwapExactPaymentOutputMismatch', () => {
             {
               address: 'bc1change',
               value: '1000',
+            },
+          ],
+        } as IEncodedTx,
+        transferInfo: btcTransferInfo,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('skips exact-output validation for non-BTC networks', () => {
+    expect(
+      getSwapExactPaymentOutputMismatch({
+        networkId: 'ada--0',
+        encodedTx: {
+          outputs: [
+            {
+              address: 'bc1provider',
+              amount: '179536',
             },
           ],
         } as IEncodedTx,

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -1,7 +1,10 @@
+import type { IEncodedTx } from '@onekeyhq/core/src/types';
+import type { ITransferInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
 import {
   checkSwapLatestBalanceSufficient,
+  getSwapExactPaymentOutputMismatch,
   getSwapRequiredNativeBalanceAmount,
 } from './swapBalanceUtils';
 
@@ -250,5 +253,61 @@ describe('getSwapRequiredNativeBalanceAmount', () => {
       reserveAmount: '0.020021',
       includesFromAmount: true,
     });
+  });
+});
+
+describe('getSwapExactPaymentOutputMismatch', () => {
+  const btcTransferInfo = {
+    from: 'bc1from',
+    to: 'bc1provider',
+    amount: '0.00179536',
+    tokenInfo: {
+      networkId: 'btc--0',
+      address: '',
+      symbol: 'BTC',
+      decimals: 8,
+      isNative: true,
+    },
+  } as ITransferInfo;
+
+  it('blocks UTXO swap transactions when SendMax reduces the provider output', () => {
+    expect(
+      getSwapExactPaymentOutputMismatch({
+        encodedTx: {
+          outputs: [
+            {
+              address: 'bc1provider',
+              value: '179316',
+            },
+          ],
+        } as IEncodedTx,
+        transferInfo: btcTransferInfo,
+      }),
+    ).toEqual({
+      expectedAmount: '0.00179536',
+      actualAmount: '0.00179316',
+      expectedAmountBase: '179536',
+      actualAmountBase: '179316',
+    });
+  });
+
+  it('allows UTXO swap transactions when the provider output matches the order amount', () => {
+    expect(
+      getSwapExactPaymentOutputMismatch({
+        encodedTx: {
+          outputs: [
+            {
+              address: 'bc1provider',
+              value: '179536',
+            },
+            {
+              address: 'bc1change',
+              value: '1000',
+            },
+          ],
+        } as IEncodedTx,
+        transferInfo: btcTransferInfo,
+      }),
+    ).toBeUndefined();
   });
 });

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -75,6 +75,7 @@ async function getSwapTokenBalanceContractAddress(token: ISwapToken) {
 
 type ISwapGasInfoEntry = {
   gasInfo?: ISwapGasInfo;
+  txSize?: number;
 };
 
 type ISwapNativeBalanceRequirementParams = {
@@ -148,6 +149,7 @@ export function getSwapRequiredNativeBalanceAmount({
     const { totalNative } = calculateFeeForSend({
       feeInfo: item.gasInfo as IFeeInfoUnit,
       nativeTokenPrice: item.gasInfo.common.nativeTokenPrice ?? 0,
+      txSize: item.txSize,
     });
     const totalNativeBN = new BigNumber(totalNative);
 

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -1,5 +1,7 @@
 import BigNumber from 'bignumber.js';
 
+import type { IEncodedTx } from '@onekeyhq/core/src/types';
+import type { ITransferInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import { calculateFeeForSend } from '@onekeyhq/shared/src/utils/feeUtils';
 import type { IFeeInfoUnit } from '@onekeyhq/shared/types/fee';
 import type {
@@ -92,6 +94,91 @@ export type ISwapNativeBalanceRequirement = {
   reserveAmount: string;
   includesFromAmount: boolean;
 };
+
+type IEncodedTxWithOutputs = {
+  outputs?: {
+    address?: string;
+    value?: string | number;
+  }[];
+};
+
+export type ISwapExactPaymentOutputMismatch = {
+  expectedAmount: string;
+  actualAmount: string;
+  expectedAmountBase: string;
+  actualAmountBase: string;
+};
+
+function getEncodedTxOutputs(encodedTx?: IEncodedTx) {
+  if (!encodedTx || typeof encodedTx !== 'object') {
+    return undefined;
+  }
+
+  const { outputs } = encodedTx as IEncodedTxWithOutputs;
+  if (!Array.isArray(outputs)) {
+    return undefined;
+  }
+
+  return outputs;
+}
+
+export function getSwapExactPaymentOutputMismatch({
+  encodedTx,
+  transferInfo,
+}: {
+  encodedTx?: IEncodedTx;
+  transferInfo?: ITransferInfo;
+}): ISwapExactPaymentOutputMismatch | undefined {
+  const outputs = getEncodedTxOutputs(encodedTx);
+  const tokenDecimals = transferInfo?.tokenInfo?.decimals;
+  if (!outputs || !transferInfo?.to || tokenDecimals === undefined) {
+    return undefined;
+  }
+
+  const expectedAmountBN = new BigNumber(transferInfo.amount ?? '');
+  if (
+    expectedAmountBN.isNaN() ||
+    !expectedAmountBN.isFinite() ||
+    expectedAmountBN.lte(0)
+  ) {
+    return undefined;
+  }
+
+  const expectedAmountBaseBN = expectedAmountBN
+    .shiftedBy(tokenDecimals)
+    .decimalPlaces(0, BigNumber.ROUND_DOWN);
+  if (expectedAmountBaseBN.lte(0)) {
+    return undefined;
+  }
+
+  const actualAmountBaseBN = outputs.reduce((acc, output) => {
+    if (output.address !== transferInfo.to) {
+      return acc;
+    }
+
+    const outputValueBN = new BigNumber(output.value ?? '');
+    if (
+      outputValueBN.isNaN() ||
+      !outputValueBN.isFinite() ||
+      outputValueBN.lte(0)
+    ) {
+      return acc;
+    }
+
+    return acc.plus(outputValueBN);
+  }, new BigNumber(0));
+
+  if (actualAmountBaseBN.gte(expectedAmountBaseBN)) {
+    return undefined;
+  }
+
+  return {
+    expectedAmount: expectedAmountBN.toFixed(),
+    actualAmount: actualAmountBaseBN.shiftedBy(-tokenDecimals).toFixed(),
+    expectedAmountBase: expectedAmountBaseBN.toFixed(),
+    actualAmountBase: actualAmountBaseBN.toFixed(),
+  };
+}
 
 function buildNativeTokenFromGasInfo({
   gasInfo,

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -100,6 +100,10 @@ type IEncodedTxWithOutputs = {
   outputs?: {
     address?: string;
     value?: string | number;
+    script?: string;
+    payload?: {
+      opReturn?: string;
+    };
   }[];
 };
 
@@ -107,11 +111,18 @@ type IEncodedTxWithTxSize = {
   txSize?: number;
 };
 
-export type ISwapExactPaymentOutputMismatch = {
-  expectedAmount: string;
-  actualAmount: string;
-  expectedAmountBase: string;
-  actualAmountBase: string;
+export type ISwapBtcOutputValidationErrorType =
+  | 'payment_output_missing'
+  | 'payment_output_less_than_order_amount'
+  | 'op_return_missing';
+
+export type ISwapBtcOutputValidationError = {
+  type: ISwapBtcOutputValidationErrorType;
+  expectedAmount?: string;
+  actualAmount?: string;
+  expectedAmountBase?: string;
+  actualAmountBase?: string;
+  expectedOpReturn?: string;
 };
 
 function getEncodedTxOutputs(encodedTx?: IEncodedTx) {
@@ -140,7 +151,7 @@ export function getSwapEncodedTxSize(encodedTx?: IEncodedTx) {
   return txSize;
 }
 
-export function getSwapExactPaymentOutputMismatch({
+export function validateSwapBtcOutputs({
   networkId,
   encodedTx,
   transferInfo,
@@ -148,7 +159,7 @@ export function getSwapExactPaymentOutputMismatch({
   networkId?: string;
   encodedTx?: IEncodedTx;
   transferInfo?: ITransferInfo;
-}): ISwapExactPaymentOutputMismatch | undefined {
+}): ISwapBtcOutputValidationError | undefined {
   if (!networkUtils.isBTCNetwork(networkId)) {
     return undefined;
   }
@@ -175,11 +186,13 @@ export function getSwapExactPaymentOutputMismatch({
     return undefined;
   }
 
+  let hasPaymentOutput = false;
   const actualAmountBaseBN = outputs.reduce((acc, output) => {
     if (output.address !== transferInfo.to) {
       return acc;
     }
 
+    hasPaymentOutput = true;
     const outputValueBN = new BigNumber(output.value ?? '');
     if (
       outputValueBN.isNaN() ||
@@ -192,16 +205,41 @@ export function getSwapExactPaymentOutputMismatch({
     return acc.plus(outputValueBN);
   }, new BigNumber(0));
 
-  if (actualAmountBaseBN.gte(expectedAmountBaseBN)) {
-    return undefined;
+  if (!hasPaymentOutput) {
+    return {
+      type: 'payment_output_missing',
+      expectedAmount: expectedAmountBN.toFixed(),
+      actualAmount: actualAmountBaseBN.shiftedBy(-tokenDecimals).toFixed(),
+      expectedAmountBase: expectedAmountBaseBN.toFixed(),
+      actualAmountBase: actualAmountBaseBN.toFixed(),
+    };
   }
 
-  return {
-    expectedAmount: expectedAmountBN.toFixed(),
-    actualAmount: actualAmountBaseBN.shiftedBy(-tokenDecimals).toFixed(),
-    expectedAmountBase: expectedAmountBaseBN.toFixed(),
-    actualAmountBase: actualAmountBaseBN.toFixed(),
-  };
+  if (actualAmountBaseBN.lt(expectedAmountBaseBN)) {
+    return {
+      type: 'payment_output_less_than_order_amount',
+      expectedAmount: expectedAmountBN.toFixed(),
+      actualAmount: actualAmountBaseBN.shiftedBy(-tokenDecimals).toFixed(),
+      expectedAmountBase: expectedAmountBaseBN.toFixed(),
+      actualAmountBase: actualAmountBaseBN.toFixed(),
+    };
+  }
+
+  if (
+    transferInfo.opReturn &&
+    !outputs.some(
+      (output) =>
+        output.payload?.opReturn === transferInfo.opReturn ||
+        output.script === transferInfo.opReturn,
+    )
+  ) {
+    return {
+      type: 'op_return_missing',
+      expectedOpReturn: transferInfo.opReturn,
+    };
+  }
+
+  return undefined;
 }
 
 function buildNativeTokenFromGasInfo({

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -3,6 +3,7 @@ import BigNumber from 'bignumber.js';
 import type { IEncodedTx } from '@onekeyhq/core/src/types';
 import type { ITransferInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import { calculateFeeForSend } from '@onekeyhq/shared/src/utils/feeUtils';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import type { IFeeInfoUnit } from '@onekeyhq/shared/types/fee';
 import type {
   IQuoteResultFeeOtherFeeInfo,
@@ -102,6 +103,10 @@ type IEncodedTxWithOutputs = {
   }[];
 };
 
+type IEncodedTxWithTxSize = {
+  txSize?: number;
+};
+
 export type ISwapExactPaymentOutputMismatch = {
   expectedAmount: string;
   actualAmount: string;
@@ -122,13 +127,32 @@ function getEncodedTxOutputs(encodedTx?: IEncodedTx) {
   return outputs;
 }
 
+export function getSwapEncodedTxSize(encodedTx?: IEncodedTx) {
+  if (!encodedTx || typeof encodedTx !== 'object') {
+    return undefined;
+  }
+
+  const { txSize } = encodedTx as IEncodedTxWithTxSize;
+  if (typeof txSize !== 'number' || !Number.isFinite(txSize) || txSize <= 0) {
+    return undefined;
+  }
+
+  return txSize;
+}
+
 export function getSwapExactPaymentOutputMismatch({
+  networkId,
   encodedTx,
   transferInfo,
 }: {
+  networkId?: string;
   encodedTx?: IEncodedTx;
   transferInfo?: ITransferInfo;
 }): ISwapExactPaymentOutputMismatch | undefined {
+  if (!networkUtils.isBTCNetwork(networkId)) {
+    return undefined;
+  }
+
   const outputs = getEncodedTxOutputs(encodedTx);
   const tokenDecimals = transferInfo?.tokenInfo?.decimals;
   if (!outputs || !transferInfo?.to || tokenDecimals === undefined) {

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -540,7 +540,11 @@ export interface ISwapPreSwapData {
   supportPreBuild?: boolean;
   allowanceResult?: IAllowanceResult;
   netWorkFee?: {
-    gasInfos?: { encodeTx: IEncodedTx; gasInfo: ISwapGasInfo }[];
+    gasInfos?: {
+      encodeTx: IEncodedTx;
+      gasInfo: ISwapGasInfo;
+      txSize?: number;
+    }[];
     gasFeeFiatValue?: string;
   };
 }


### PR DESCRIPTION
## Summary
- Carry unsigned transaction `txSize` through Swap fee info so UTXO `feeRate` reserves are not treated as zero.
- Block BTC Swap sends when the final UTXO output to the provider is lower than the exact order payment amount.
- Reuse the existing BTC insufficient-fund prompt across BTC Swap balance checks and remove duplicated BTC Vault insufficient-balance wording.
- Add BTC regression coverage for fee reserve, SendMax output shrinkage, rebuilt encodedTx txSize, and non-BTC guard skipping.

## Intent & Context
This targets the BTC -> Hifi Swap exact-payment mismatch on `release/v6.4.0`. A user can manually input the full BTC balance instead of tapping Max. Hifi creates an order for the full amount, while the BTC vault may later build a SendMax transaction and deduct the miner fee from the provider output.

## Root Cause
Swap is an exact-payment flow, but BTC send semantics inferred SendMax when the requested amount equals the UTXO balance. In the affected path, Swap native balance validation also called `calculateFeeForSend` without a reliable `txSize`, so UTXO `feeRate * txSize` could become under-reserved when `feeValue` was absent or stale. That allowed the full-balance order to reach signing, where the actual provider output became `amount - fee`.

## Design Decisions
- Preserve existing BTC vault SendMax behavior for normal Send/Max flows.
- Fix Swap's balance reserve by passing `txSize` into UTXO fee calculations and preferring rebuilt `encodedTx.txSize` after `updateUnsignedTx`.
- Add a final BTC-only Swap exact-payment guard after `updateUnsignedTx`: if the encoded output to the provider is less than `transferInfo.amount`, show the existing BTC insufficient-fund prompt and stop before signing.
- Use the same BTC insufficient-fund prompt for BTC Swap latest-balance checks, native reserve checks, other-fee checks, exact-output guard, and the disabled action label so users do not see both `BTC balance insufficient` and `try a smaller amount` for the same class of issue.
- Keep the exact-output guard limited to BTC networks to avoid misclassifying other UTXO encodedTx output shapes.

## Changes Detail
- `packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts`: stores/uses Swap `txSize`, prefers rebuilt encodedTx txSize, blocks BTC exact-payment output shrinkage before signing, and centralizes BTC insufficient-balance toast copy.
- `packages/kit/src/views/Swap/hooks/useSwapState.ts`: uses the same BTC insufficient-fund copy for BTC disabled-action balance state.
- `packages/kit/src/views/Swap/utils/swapBalanceUtils.ts`: uses `txSize` for required native balance, exposes a valid encodedTx txSize reader, and keeps exact-output mismatch validation BTC-only.
- `packages/shared/types/swap/types.ts`: reflects `txSize` on stored Swap network fee info.
- `packages/kit-bg/src/vaults/impls/btc/Vault.ts`: stops concatenating two insufficient-balance strings into one duplicated message.
- `packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts`: covers BTC UTXO fee-rate reserve, rebuilt encodedTx txSize, BTC SendMax output shrinkage, and non-BTC skip behavior.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Mobile / Web / Extension
- **Risk Areas**: Swap native balance gating, UTXO fee reserve calculation, and final BTC Swap send gating for exact payments.

## Test plan
- [x] `yarn jest packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts --runInBand`
- [x] `yarn lint:staged`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [ ] `yarn tsc:staged` - blocked by existing unrelated release-branch errors in web-embed `react-router-dom`, Ledger keyring argument counts, and LightweightChart/Borrow/Market chart typings
