### PR TITLE
feat: surface mobile private-send mode toggle as inline tab (OK-56912)

### DIFF
--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -28,7 +28,6 @@ import {
   NumberSizeableText,
   Page,
   ScrollView,
-  Select,
   SizableText,
   Skeleton,
   Stack,
@@ -808,7 +807,7 @@ function SendAmountInputContainer() {
   const [isUseFiat, setIsUseFiat] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isMaxSend, setIsMaxSend] = useState(false);
-  const [settings, setSettings] = useSettingsPersistAtom();
+  const [settings] = useSettingsPersistAtom();
   const [{ currencyMap }] = useCurrencyPersistAtom();
   const [selectedUTXOs] = useSelectedUTXOsAtom();
   const sendConfirmActions = useSendConfirmActions();
@@ -3224,224 +3223,139 @@ function SendAmountInputContainer() {
           tokenSymbol,
         });
       }
-      if (
-        nextMode === ESendMode.PRIVATE &&
-        platformEnv.isNative &&
-        !settings.isPrivateSendGuideClicked
-      ) {
-        setSettings((prev) => ({
-          ...prev,
-          isPrivateSendGuideClicked: true,
-        }));
-      }
       setSendMode(nextMode);
     },
-    [
-      networkId,
-      sendMode,
-      settings.isPrivateSendGuideClicked,
-      setSettings,
-      tokenSymbol,
-    ],
+    [networkId, sendMode, tokenSymbol],
   );
 
-  const handlePrivateSendGuideClick = useCallback(() => {
-    if (settings.isPrivateSendGuideClicked) return;
-    setSettings((prev) => ({
-      ...prev,
-      isPrivateSendGuideClicked: true,
-    }));
-  }, [settings.isPrivateSendGuideClicked, setSettings]);
+  // Shared Public | Private segmented control, reused by the desktop
+  // header-right and the mobile tab band so both stay visually consistent.
+  const renderPrivateSendModeSegmented = useCallback(
+    (publicLabel: string) => {
+      const privateLabel = intl.formatMessage({
+        id: ETranslations.private_send_private_option,
+      });
+      const publicActive = sendMode === ESendMode.PUBLIC;
+      const privateActive = sendMode === ESendMode.PRIVATE;
 
-  const renderPrivateSendHeaderRight = useCallback(() => {
-    if (!showPrivateSendModeSwitch) return null;
-
-    const regularLabel = intl.formatMessage({
-      id: ETranslations.send_regular,
-    });
-    const privateLabel = intl.formatMessage({
-      id: ETranslations.private_send_private_option,
-    });
-    const isPrivateMode = sendMode === ESendMode.PRIVATE;
-
-    if (!media.gtMd) {
-      const showPrivateSendGuideDot = !settings.isPrivateSendGuideClicked;
-      return (
-        <Select
-          testID="send-private-mode-select"
-          title={intl.formatMessage({
-            id: ETranslations.private_send_select_mode_title,
-          })}
-          value={sendMode}
-          onChange={handleSendModeChange}
-          items={[
-            {
-              label: regularLabel,
-              value: ESendMode.PUBLIC,
-            },
-            {
-              label: privateLabel,
-              value: ESendMode.PRIVATE,
-            },
-          ]}
-          renderTrigger={({ onPress }) => (
-            <XStack
-              w={112}
-              h={30}
-              px="$1.5"
-              alignItems="center"
-              justifyContent="center"
-              gap="$1"
-              bg="$bgStrong"
-              borderRadius="$full"
-              borderCurve="continuous"
-              cursor="pointer"
-              hoverStyle={{ bg: '$bgHover' }}
-              pressStyle={{ bg: '$bgActive' }}
-              onPress={(event) => {
-                handlePrivateSendGuideClick();
-                if (platformEnv.isNative) {
-                  event.persist();
-                  event.stopPropagation();
-                  amountInputRef.current?.blur();
-                  void Keyboard.dismissWithDelay(80).finally(() => {
-                    onPress?.(event);
-                  });
-                  return;
-                }
-                onPress?.(event);
-              }}
-            >
-              <Icon
-                name={isPrivateMode ? 'AnonymousHiddenOutline' : 'SendOutline'}
-                size="$4"
-                color="$icon"
-              />
-              <SizableText
-                size="$bodySmMedium"
-                color="$text"
-                numberOfLines={1}
-                flexShrink={1}
-              >
-                {isPrivateMode ? privateLabel : regularLabel}
-              </SizableText>
-              <Icon
-                name="ChevronDownSmallOutline"
-                size="$4"
-                color="$iconSubdued"
-              />
-              {showPrivateSendGuideDot ? (
-                <Stack
-                  position="absolute"
-                  top="$0.5"
-                  right="$1.5"
-                  w="$1.5"
-                  h="$1.5"
-                  borderRadius="$full"
-                  bg="$iconCritical"
-                />
-              ) : null}
-            </XStack>
-          )}
-        />
+      const renderModeButton = ({
+        active,
+        children,
+        value,
+        minWidth,
+      }: {
+        active: boolean;
+        children: React.ReactNode;
+        value: ESendMode;
+        minWidth: number;
+      }) => (
+        <XStack
+          minWidth={minWidth}
+          h={28}
+          px="$2"
+          alignItems="center"
+          justifyContent="center"
+          borderRadius="$2"
+          borderCurve="continuous"
+          cursor="pointer"
+          userSelect="none"
+          bg={active ? '$bg' : 'transparent'}
+          borderWidth={active ? 1 : 0}
+          borderColor="$borderSubdued"
+          hoverStyle={active ? undefined : { bg: '$bgHover' }}
+          pressStyle={{ bg: '$bgActive' }}
+          onPress={() => handleSendModeChange(value)}
+        >
+          {children}
+        </XStack>
       );
-    }
 
-    const publicActive = sendMode === ESendMode.PUBLIC;
-    const privateActive = sendMode === ESendMode.PRIVATE;
+      return (
+        <XStack
+          h={32}
+          p={2}
+          alignItems="center"
+          bg="$bgStrong"
+          borderRadius="$3"
+          borderCurve="continuous"
+        >
+          {renderModeButton({
+            active: publicActive,
+            value: ESendMode.PUBLIC,
+            minWidth: 92,
+            children: (
+              <XStack alignItems="center" justifyContent="center" gap="$1">
+                <Icon
+                  name="SendOutline"
+                  size="$4"
+                  color={publicActive ? '$icon' : '$iconSubdued'}
+                />
+                <SizableText
+                  size="$bodyMdMedium"
+                  color={publicActive ? '$text' : '$textSubdued'}
+                  numberOfLines={1}
+                >
+                  {publicLabel}
+                </SizableText>
+              </XStack>
+            ),
+          })}
+          {renderModeButton({
+            active: privateActive,
+            value: ESendMode.PRIVATE,
+            minWidth: 92,
+            children: (
+              <XStack alignItems="center" justifyContent="center" gap="$1">
+                <Icon
+                  name="AnonymousHiddenOutline"
+                  size="$4"
+                  color={privateActive ? '$icon' : '$iconSubdued'}
+                />
+                <SizableText
+                  size="$bodyMdMedium"
+                  color={privateActive ? '$text' : '$textSubdued'}
+                  numberOfLines={1}
+                >
+                  {privateLabel}
+                </SizableText>
+              </XStack>
+            ),
+          })}
+        </XStack>
+      );
+    },
+    [handleSendModeChange, intl, sendMode],
+  );
 
-    const renderModeButton = ({
-      active,
-      children,
-      value,
-      minWidth,
-    }: {
-      active: boolean;
-      children: React.ReactNode;
-      value: ESendMode;
-      minWidth: number;
-    }) => (
-      <XStack
-        minWidth={minWidth}
-        h={28}
-        px="$2"
-        alignItems="center"
-        justifyContent="center"
-        borderRadius="$2"
-        borderCurve="continuous"
-        cursor="pointer"
-        userSelect="none"
-        bg={active ? '$bg' : 'transparent'}
-        borderWidth={active ? 1 : 0}
-        borderColor="$borderSubdued"
-        hoverStyle={active ? undefined : { bg: '$bgHover' }}
-        pressStyle={{ bg: '$bgActive' }}
-        onPress={() => handleSendModeChange(value)}
-      >
-        {children}
-      </XStack>
+  // Desktop/tablet: segmented control stays in the header-right.
+  const renderPrivateSendHeaderRight = useCallback(() => {
+    if (!showPrivateSendModeSwitch || !media.gtMd) return null;
+    return renderPrivateSendModeSegmented(
+      intl.formatMessage({ id: ETranslations.send_regular }),
     );
+  }, [
+    intl,
+    media.gtMd,
+    renderPrivateSendModeSegmented,
+    showPrivateSendModeSwitch,
+  ]);
 
+  // Mobile: a directly-visible Public | Private tab pinned below the title.
+  // Rendered as a fixed band (outside the vertically-centered amount area),
+  // so the keyboard never overlaps it and the layout doesn't jump on toggle.
+  const renderPrivateSendModeBand = useCallback(() => {
+    if (!showPrivateSendModeSwitch || media.gtMd) return null;
     return (
-      <XStack
-        h={32}
-        p={2}
-        alignItems="center"
-        bg="$bgStrong"
-        borderRadius="$3"
-        borderCurve="continuous"
-      >
-        {renderModeButton({
-          active: publicActive,
-          value: ESendMode.PUBLIC,
-          minWidth: 92,
-          children: (
-            <XStack alignItems="center" justifyContent="center" gap="$1">
-              <Icon
-                name="SendOutline"
-                size="$4"
-                color={publicActive ? '$icon' : '$iconSubdued'}
-              />
-              <SizableText
-                size="$bodyMdMedium"
-                color={publicActive ? '$text' : '$textSubdued'}
-                numberOfLines={1}
-              >
-                {regularLabel}
-              </SizableText>
-            </XStack>
-          ),
-        })}
-        {renderModeButton({
-          active: privateActive,
-          value: ESendMode.PRIVATE,
-          minWidth: 92,
-          children: (
-            <XStack alignItems="center" justifyContent="center" gap="$1">
-              <Icon
-                name="AnonymousHiddenOutline"
-                size="$4"
-                color={privateActive ? '$icon' : '$iconSubdued'}
-              />
-              <SizableText
-                size="$bodyMdMedium"
-                color={privateActive ? '$text' : '$textSubdued'}
-                numberOfLines={1}
-              >
-                {privateLabel}
-              </SizableText>
-            </XStack>
-          ),
-        })}
+      <XStack px="$5" pb="$3" justifyContent="center">
+        {renderPrivateSendModeSegmented(
+          intl.formatMessage({ id: ETranslations.send_regular }),
+        )}
       </XStack>
     );
   }, [
-    handlePrivateSendGuideClick,
-    handleSendModeChange,
     intl,
     media.gtMd,
-    sendMode,
-    settings.isPrivateSendGuideClicked,
+    renderPrivateSendModeSegmented,
     showPrivateSendModeSwitch,
   ]);
 
@@ -4464,9 +4378,9 @@ function SendAmountInputContainer() {
   }
 
   const pageTitleTranslationId =
-    sendMode === ESendMode.PRIVATE
-      ? ETranslations.private_send_private_send
-      : ETranslations.enter_amount__title;
+    !media.gtMd || sendMode !== ESendMode.PRIVATE
+      ? ETranslations.enter_amount__title
+      : ETranslations.private_send_private_send;
 
   const renderAmountFormContent = (
     <Form form={form}>
@@ -4644,6 +4558,8 @@ function SendAmountInputContainer() {
         headerRight={renderPrivateSendHeaderRight}
         headerRightNoGlass
       />
+
+      {renderPrivateSendModeBand()}
 
       {renderPageBody}
 


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56912](https://onekeyhq.atlassian.net/browse/OK-56912)

----------

<!-- github-pr-monitor:jira-links:end -->


## 背景
移动端转账「Enter Amount」页,发送模式(Regular / Private 隐私发送)的切换原本藏在标题右上角的下拉(Select 药丸),不够显眼,点开要多一步且会收起键盘。本次按 OK-56912 把它改成**直接可见的内联分段 Tab**(Regular | Private),放在标题正下方,与桌面端控件保持一致。

## 改动(仅移动端;`packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx`)
- 移动端移除右上角的 `Select` 下拉,改为标题下方内联的 **Regular | Private** 分段 Tab。
- 抽出共用的分段控件渲染,桌面 header-right 与移动 band 复用(视觉一致;图标不变,仍为 SendOutline / AnonymousHiddenOutline)。
- Tab 作为 header 与 body 之间的**固定带**,不参与金额垂直居中、不随滚动/键盘移动 → 键盘弹起时不被遮、不跳动。
- 移动端标题固定为「Enter Amount」(模式由 Tab 表达);桌面端不变。
- 去掉首次引导红点,以及下拉打开时的键盘 dismiss 逻辑。

## 测试
- iPhone 17 Pro 模拟器:Tab 显示在标题下方;键盘弹起时 Tab 稳定、金额居中、布局不跳;Regular ↔ Private 切换平滑。
- `yarn tsc:staged`、`yarn lint:staged` 均通过。

Jira: OK-56912(隐私发送 - 移动端入口展开)
https://onekeyhq.atlassian.net/browse/OK-56912

[OK-56912]: https://onekeyhq.atlassian.net/browse/OK-56912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ