### PR TITLE
fix: disable Sentry performance tracing to stop renderer memory leak

### DIFF
--- a/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
@@ -2,7 +2,6 @@ import type { MutableRefObject, RefObject } from 'react';
 import {
   createContext,
   createRef,
-  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -21,7 +20,6 @@ import type { GetProps } from '@onekeyhq/components/src/shared/tamagui';
 import appGlobals from '@onekeyhq/shared/src/appGlobals';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { updateRootViewBackgroundColor } from '@onekeyhq/shared/src/modules3rdParty/rootview-background';
-import { navigationIntegration } from '@onekeyhq/shared/src/modules3rdParty/sentry';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import {
@@ -107,11 +105,6 @@ const useNativeDevTools =
 
 export function NavigationContainer(props: IBasicNavigationContainerProps) {
   const isTabletMainView = useSplitMainView();
-  const handleReady = useCallback(() => {
-    navigationIntegration.registerNavigationContainer(
-      isTabletMainView ? tabletMainViewNavigationRef : rootNavigationRef,
-    );
-  }, [isTabletMainView]);
   const { theme: themeName, themeSetting } = useSettingConfig();
   const theme = useTheme();
 
@@ -139,7 +132,6 @@ export function NavigationContainer(props: IBasicNavigationContainerProps) {
       {...props}
       theme={themeOptions}
       ref={isTabletMainView ? tabletMainViewNavigationRef : rootNavigationRef}
-      onReady={handleReady}
     />
   );
 }

--- a/packages/shared/src/modules3rdParty/sentry/basicOptions.ts
+++ b/packages/shared/src/modules3rdParty/sentry/basicOptions.ts
@@ -1,7 +1,3 @@
-import {
-  reactNativeTracingIntegration,
-  reactNavigationIntegration,
-} from '@sentry/react-native';
 import wordLists from 'bip39/src/wordlists/english.json';
 
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -26,10 +22,6 @@ const checkPrivateKey = (text: string): boolean => {
 };
 
 const lazyLoadWordSet = memoizee(() => new Set(wordLists));
-
-export const navigationIntegration = reactNavigationIntegration({
-  enableTimeToInitialDisplay: true,
-});
 
 // Minimum consecutive mnemonic words to trigger redaction (12-word mnemonic could partially leak)
 const MIN_MNEMONIC_SEQUENCE_LENGTH = 3;
@@ -216,8 +208,14 @@ export const buildBasicOptions = ({
   ({
     enabled: true,
     maxBreadcrumbs: 100,
-    tracesSampleRate: 0.1,
-    profilesSampleRate: 0.1,
+    // Performance tracing/profiling disabled: in the long-lived renderer the
+    // browser/idle-span tracing leaks unboundedly (heap snapshots show ~300K
+    // retained SentryNonRecordingSpan pinning React fibers; renderer RSS climbs
+    // ~240MB/h with no plateau). Error reporting + breadcrumbs are unaffected.
+    // The tracing integrations are also removed from buildIntegrations below;
+    // zeroing the sample rate alone does NOT stop span creation.
+    tracesSampleRate: 0,
+    profilesSampleRate: 0,
     beforeSend: (event) => {
       if (Array.isArray(event.exception?.values)) {
         for (let index = 0; index < event.exception.values.length; index += 1) {
@@ -265,10 +263,9 @@ export const buildSentryOptions = (Sentry: typeof import('@sentry/react')) => ({
 });
 
 export const buildIntegrations = (Sentry: typeof import('@sentry/react')) => [
-  navigationIntegration,
-  reactNativeTracingIntegration(),
-  Sentry.browserProfilingIntegration(),
-  Sentry.browserTracingIntegration(),
+  // Performance-tracing integrations intentionally removed — they create a span
+  // per navigation/interaction that leaks in the long-lived renderer (see the
+  // tracesSampleRate note above). Only error reporting + breadcrumbs remain.
   Sentry.breadcrumbsIntegration({
     console: false,
     dom: true,

--- a/packages/shared/src/modules3rdParty/sentry/index.native.test.ts
+++ b/packages/shared/src/modules3rdParty/sentry/index.native.test.ts
@@ -27,7 +27,7 @@ describe('initSentry', () => {
     process.env.NODE_ENV = originalNodeEnv;
   });
 
-  test('omits profilesSampleRate for React Native production init', () => {
+  test('omits tracesSampleRate and profilesSampleRate for React Native production init', () => {
     jest.isolateModules(() => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
       const {
@@ -40,11 +40,10 @@ describe('initSentry', () => {
     });
 
     expect(initMock).toHaveBeenCalledTimes(1);
-    expect(initMock.mock.calls[0][0]).toEqual(
-      expect.objectContaining({
-        tracesSampleRate: 0.1,
-      }),
-    );
+    // Both sample rates must be stripped: a numeric tracesSampleRate (even 0)
+    // makes @sentry/react-native treat tracing as enabled and re-add its
+    // default tracing integrations despite `integrations: []`.
+    expect(initMock.mock.calls[0][0].tracesSampleRate).toBeUndefined();
     expect(initMock.mock.calls[0][0].profilesSampleRate).toBeUndefined();
   });
 });

--- a/packages/shared/src/modules3rdParty/sentry/index.native.ts
+++ b/packages/shared/src/modules3rdParty/sentry/index.native.ts
@@ -2,7 +2,6 @@ import type { ComponentType } from 'react';
 
 import {
   init,
-  reactNativeTracingIntegration,
   nativeCrash as sentryNativeCrash,
   withErrorBoundary,
   withProfiler,
@@ -11,7 +10,7 @@ import {
 
 import appGlobals from '../../appGlobals';
 
-import { buildBasicOptions, navigationIntegration } from './basicOptions';
+import { buildBasicOptions } from './basicOptions';
 
 import type { FallbackRender } from '@sentry/react';
 
@@ -24,12 +23,24 @@ export const initSentry = () => {
   if (process.env.NODE_ENV !== 'production') {
     return;
   }
-  const { profilesSampleRate: _profilesSampleRate, ...basicOptions } =
-    buildBasicOptions({
-      onError: (errorMessage, stacktrace) => {
-        appGlobals.$defaultLogger?.app.error.log(errorMessage, stacktrace);
-      },
-    });
+  // Strip tracesSampleRate AND profilesSampleRate before handing options to the
+  // RN SDK. @sentry/react-native's getDefaultIntegrations treats tracing as
+  // ENABLED whenever `typeof tracesSampleRate === 'number'` (0 included), and
+  // `integrations: []` only MERGES with — does not override — the default set.
+  // So a leftover `tracesSampleRate: 0` would re-install the default tracing
+  // integrations (appStart / nativeFrames / stallTracking / timeToDisplay)
+  // regardless of `enableAutoPerformanceTracing: false`. Removing the key makes
+  // hasTracingEnabled=false so none of them are installed. profilesSampleRate is
+  // likewise stripped to keep hermesProfilingIntegration off.
+  const {
+    tracesSampleRate: _tracesSampleRate,
+    profilesSampleRate: _profilesSampleRate,
+    ...basicOptions
+  } = buildBasicOptions({
+    onError: (errorMessage, stacktrace) => {
+      appGlobals.$defaultLogger?.app.error.log(errorMessage, stacktrace);
+    },
+  });
 
   init({
     dsn: process.env.SENTRY_DSN_REACT_NATIVE || '',
@@ -37,8 +48,11 @@ export const initSentry = () => {
     maxCacheItems: 60,
     enableAppHangTracking: true,
     appHangTimeoutInterval: 5,
-    integrations: [navigationIntegration, reactNativeTracingIntegration()],
-    enableAutoPerformanceTracing: true,
+    // Performance tracing fully disabled on native — tracesSampleRate is
+    // stripped above so the SDK installs none of its default tracing
+    // integrations; error reporting + breadcrumbs are unaffected.
+    integrations: [],
+    enableAutoPerformanceTracing: false,
     // Disable Hermes profiling on React Native. With multiple Hermes runtimes
     // in the iOS release smoke test, native stopProfiling can throw on a
     // background queue and crash during TurboModule error conversion.

--- a/packages/shared/src/modules3rdParty/sentry/sentry.test.ts
+++ b/packages/shared/src/modules3rdParty/sentry/sentry.test.ts
@@ -470,8 +470,8 @@ describe('buildBasicOptions', () => {
 
     expect(options.enabled).toBe(true);
     expect(options.maxBreadcrumbs).toBe(100);
-    expect(options.tracesSampleRate).toBe(0.1);
-    expect(options.profilesSampleRate).toBe(0.1);
+    expect(options.tracesSampleRate).toBe(0);
+    expect(options.profilesSampleRate).toBe(0);
     expect(typeof options.beforeSend).toBe('function');
   });
 


### PR DESCRIPTION
## Problem

Sentry's performance **tracing/profiling** integrations leak unboundedly in the long-lived desktop renderer.

A heap snapshot taken after a 1000-action desktop stress run (funded multi-network wallet, repeatedly switching accounts + cycling Market/Perps/Swap + opening/closing dapps) shows:

- **~300K retained `SentryNonRecordingSpan`** objects (created per navigation/interaction even though sampled-out), pinning
- **~116K React `FiberNode`s** + their DOM (the spans hold references to the interaction targets), and
- thousands of idle-span timer closures (`_restartIdleTimeout`, `onIdleSpanEnded`, …).

Result: **renderer RSS climbs ~240MB/h with no plateau** (1.5GB → 4GB+ over a few hours), and the JS event-listener count grows from ~10K to ~89K. Over a long user session this drives the renderer toward OOM.

Forced GC does **not** reclaim any of it (the spans are still referenced), confirming a real retention leak rather than GC pacing.

## Why not just lower the sample rate

`tracesSampleRate: 0.1` was already in effect — the 300K spans are exactly the *non-recording* (sampled-out) ones. Sampling decides whether a span is **recorded**, not whether it is **created/retained**. So zeroing the rate alone does not stop the leak; the tracing integrations themselves must be removed.

## Fix

Disable performance tracing/profiling across **all platforms** (error reporting + breadcrumbs are unaffected):

- `basicOptions.ts`: remove `browserTracingIntegration`, `browserProfilingIntegration`, `reactNativeTracingIntegration`, `reactNavigationIntegration` from `buildIntegrations`; set `tracesSampleRate`/`profilesSampleRate` to `0`; drop the now-unused imports/definition.
- `index.native.ts`: `integrations: []` + `enableAutoPerformanceTracing: false`.

## Verification

Re-built the desktop release with this change and re-ran the **same 200-action stress** with the same instrumentation:

| | before (tracing on) | after (this PR) |
|---|---|---|
| renderer RSS | 1.5GB → 4GB+, +240MB/h, no plateau | **flat ~1.3GB** (p50 1288 / p90 1360MB over 2h) |
| `SentryNonRecordingSpan` (heap snapshot) | 308,511 | **0** |
| JS event listeners | ~89,000 | ~6,900 |
| renderer JS heap | climbing to 1221MB | stable 595MB |

Main/browser-process heap was flat (~50MB) in both runs — this leak is renderer-only.

## Tradeoff / notes

- We lose Sentry **performance** monitoring (transactions/spans/profiles) and native navigation-transaction naming. Error reporting, crash capture, and breadcrumbs are kept.
- If performance tracing is wanted later, it should be re-enabled only with a bounded/short-lived span strategy that does not retain spans for the lifetime of the renderer.

## Test plan

- [ ] `yarn tsc:staged && yarn lint:staged`
- [ ] Confirm errors still report to Sentry (desktop/web/ext/native).
