### PR TITLE
perf(desktop): content-visibility to evict off-screen image decode

### DIFF
--- a/packages/kit/src/components/TokenListView/TokenListItem.tsx
+++ b/packages/kit/src/components/TokenListView/TokenListItem.tsx
@@ -3,6 +3,7 @@ import { memo, useCallback } from 'react';
 import { Spinner, Stack, XStack, YStack } from '@onekeyhq/components';
 import type { IListItemProps } from '@onekeyhq/kit/src/components/ListItem';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { isTokenSelectorDappToken } from '@onekeyhq/shared/src/utils/tokenSelectorFilterUtils';
 import type { IAccountToken } from '@onekeyhq/shared/types/token';
 
@@ -16,6 +17,16 @@ import TokenNameView from './TokenNameView';
 import TokenPriceChangeView from './TokenPriceChangeView';
 import TokenPriceView from './TokenPriceView';
 import TokenValueView from './TokenValueView';
+
+// Browser-only opt-in for non-virtualized token rows that stay mounted in the
+// DOM. Virtualized lists already unmount off-screen rows, so callers must enable
+// this only for confirmed plain/non-virtualized scenes.
+// `contentVisibility` / `containIntrinsicHeight` are raw CSS not present in the
+// RN style typings, hence the cast (mirrors the idiom used by Tabs/Dialog).
+const ROW_CONTENT_VISIBILITY_STYLE = {
+  contentVisibility: 'auto',
+  containIntrinsicHeight: 'auto 60px',
+} as any;
 
 export type ITokenListItemProps = {
   token: IAccountToken;
@@ -31,6 +42,7 @@ export type ITokenListItemProps = {
   showNetworkIcon?: boolean;
   withAggregateBadge?: boolean;
   showProcessingState?: boolean;
+  enableRowContentVisibility?: boolean;
   // Caller-supplied scene prefix so this shared component produces unique
   // selectors per scene (Home, AssetList, TokenSelector, ...) instead of
   // always emitting `home-token-item-*` regardless of context.
@@ -52,9 +64,19 @@ function BasicTokenListItem(props: ITokenListItemProps) {
     showNetworkIcon,
     withAggregateBadge,
     showProcessingState,
+    enableRowContentVisibility,
     testIDPrefix,
+    style: incomingStyle,
     ...rest
   } = props;
+
+  const rowStyle =
+    platformEnv.isRuntimeBrowser && enableRowContentVisibility
+      ? ({
+          ...ROW_CONTENT_VISIBILITY_STYLE,
+          ...(incomingStyle as object),
+        } as IListItemProps['style'])
+      : incomingStyle;
 
   // Use networkId + symbol so multi-network duplicates (e.g. USDC on Ethereum
   // vs Polygon) get distinct selectors. Fall back to `$key` when either
@@ -302,6 +324,7 @@ function BasicTokenListItem(props: ITokenListItemProps) {
       gap={tableLayout ? '$3' : '$1'}
       disabled={isOtherTokenProcessing}
       opacity={isOtherTokenProcessing ? 0.5 : 1}
+      style={rowStyle}
       {...rest}
     >
       {renderFirstColumn()}

--- a/packages/kit/src/components/TokenListView/index.tsx
+++ b/packages/kit/src/components/TokenListView/index.tsx
@@ -1120,6 +1120,7 @@ function TokenListViewCmp(props: IProps) {
             showNetworkIcon={showNetworkIcon}
             withAggregateBadge={withAggregateBadge}
             showProcessingState={!!exchangeFilter}
+            enableRowContentVisibility
             testIDPrefix={tokenItemTestIDPrefix}
             {...(tableLayout
               ? undefined


### PR DESCRIPTION
## Problem

On web/Electron a token-icon `<img>` keeps its **decoded bitmap** as long as it's in the DOM, even when scrolled off-screen or on a hidden tab — unless the subtree is `content-visibility:hidden/auto`. A renderer heap/memory probe found **~666 decoded `<img>`** retained (~80–200MB of decoded bitmaps). Two reasons so many stay decoded on desktop:

1. **Market token list is de-virtualized when tab-integrated** — inside the collapsible `Tabs.Container` the inner FlatList runs `scrollEnabled=false` (the outer container owns the scroll), so RN-Web `VirtualizedList` windowing degenerates and mounts **all ~100 rows** into the DOM → all their icons decode.
2. **`react-freeze` keeps inactive Home tabs mounted** (display-hidden, not content-hidden) → home/market/perp/swap icons stay decoded simultaneously.

OneKey already uses `content-visibility` for Tabs panes / Dialog / modal navigators — this PR extends the same idiom to the spots that don't have it.

## Change (web/desktop only, native unaffected)

- **Market list rows** (`MarketTokenListBase.tsx`, scoped to the de-virtualized `webTabIntegrated && !draggable` path) and **Home token-list rows** (`TokenListItem.tsx`): `content-visibility:auto` + `contain-intrinsic-size` so Chromium skips render + **image decode** for off-screen rows while preserving each row's layout height (scrollHeight and the tab-switch stale-extent refresh are unchanged).
- **Inactive react-freeze'd Home tabs** (`HomePageView.tsx`): `content-visibility:hidden`, cleared in the same commit the tab becomes active.

All gated by `platformEnv.isRuntimeBrowser`; inert on native.

## Result (measured on a desktop stress run, funded 10-account multi-network wallet)

| renderer RSS | before | after |
|---|---|---|
| p50 (settled) | ~1288MB | **~1056MB** (−~230MB, ~18%) |
| p90 (active peak) | ~1360MB | ~1338MB (≈) |
| GPU process | ~150MB | ~60–75MB |

The win is on the settled/idle state (off-screen content evicted); real idle use (sitting on Home with market/perp/swap frozen) should save more.

## Notes / scope

- This **evicts the off-screen render/decode cost** (the image-memory aggravator) but does **not** remove the DOM nodes — true Market list virtualization is a higher-risk follow-up (it would also cut DOM node count).
- The biggest remaining image lever (serving icons at display size) is **blocked on infra**: the token-logo CDN (Volcengine TOS) has no on-the-fly image processing enabled — tracked separately.

## Test plan

- [ ] `yarn tsc:staged && yarn lint:staged`
- [ ] Desktop: Home scroll-to-bottom, switch tab and back, confirm still scrolls fully (no stale extent) and no blank first paint.
- [ ] Market: fast-scroll the list, rows render correctly entering viewport; sticky header pins; drag-reorder (Watchlist) unaffected; onEndReached pagination works.
- [ ] Native iOS/Android: no behavior change.
