### PR TITLE
fix: stabilize stock detail and selector flows (OK-56922 OK-56920 OK-56923)

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/TradingViewV2.tsx
@@ -413,6 +413,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
       !forceEmptyKLineData,
     chartType: activeKLineResolution,
     symbol: chartSymbol,
+    onPriceUpdate,
   });
 
   // Load marks on page enter and refresh when swap transaction succeeds

--- a/packages/kit/src/components/TradingView/TradingViewV2/hooks/useTradingViewV2WebSocket.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/hooks/useTradingViewV2WebSocket.ts
@@ -12,6 +12,7 @@ import type { IMarketTokenKLineResponse } from '@onekeyhq/shared/types/marketV2'
 import { sendVolumeVisibilityUpdate } from '../messageHandlers/volumeVisibilityHandler';
 
 import type { IWebViewRef } from '../../../WebView/types';
+import type { ITradingViewPriceUpdateData } from '../types';
 
 interface IUseTradingViewV2WebSocketProps {
   networkId: string;
@@ -21,6 +22,7 @@ interface IUseTradingViewV2WebSocketProps {
   chartType?: string;
   currency?: string;
   symbol?: string;
+  onPriceUpdate?: (data: ITradingViewPriceUpdateData) => void;
 }
 
 interface IMarketPriceUpdatePayload {
@@ -76,6 +78,20 @@ function isMarketTokenKLineResponse(
   );
 }
 
+function isWsPriceData(data: unknown): data is IWsPriceData {
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+
+  const candidate = data as Partial<IWsPriceData>;
+  return (
+    typeof candidate.address === 'string' &&
+    typeof candidate.c === 'number' &&
+    typeof candidate.type === 'string' &&
+    typeof candidate.unixTime === 'number'
+  );
+}
+
 export function useTradingViewV2WebSocket({
   networkId,
   tokenAddress,
@@ -84,6 +100,7 @@ export function useTradingViewV2WebSocket({
   chartType = '1m',
   currency = 'usd',
   symbol,
+  onPriceUpdate,
 }: IUseTradingViewV2WebSocketProps): void {
   const lastUpdateTime = useRef<number>(0);
   const wsChartType = normalizeMarketWsKLineInterval(chartType);
@@ -160,9 +177,14 @@ export function useTradingViewV2WebSocket({
       const receivedData = payload.data as
         | IWsPriceData
         | IMarketTokenKLineResponse;
+      const isKLineResponse = isMarketTokenKLineResponse(receivedData);
+      const isPriceData = isWsPriceData(receivedData);
+      if (!isKLineResponse && !isPriceData) {
+        return;
+      }
+
       if (
-        receivedData &&
-        !isMarketTokenKLineResponse(receivedData) &&
+        isPriceData &&
         receivedData.type &&
         normalizeMarketWsKLineInterval(receivedData.type) !== wsChartType
       ) {
@@ -181,20 +203,19 @@ export function useTradingViewV2WebSocket({
         return;
       }
 
-      const dataForWebView: IMarketTokenKLineResponse =
-        isMarketTokenKLineResponse(receivedData)
-          ? receivedData
-          : {
-              points: [
-                {
-                  ...receivedData,
+      const dataForWebView: IMarketTokenKLineResponse = isKLineResponse
+        ? receivedData
+        : {
+            points: [
+              {
+                ...receivedData,
 
-                  // oxlint-disable-next-line @cspell/spellchecker
-                  t: receivedData.unixTime,
-                },
-              ],
-              total: 1,
-            };
+                // oxlint-disable-next-line @cspell/spellchecker
+                t: receivedData.unixTime,
+              },
+            ],
+            total: 1,
+          };
 
       webView.sendMessageViaInjectedScript({
         type: 'autoKLineUpdate',
@@ -204,6 +225,18 @@ export function useTradingViewV2WebSocket({
           timestamp: now,
         },
       });
+      if (isPriceData) {
+        onPriceUpdate?.({
+          symbol,
+          tokenAddress,
+          networkId,
+          price: receivedData.c,
+          timestamp: receivedData.unixTime,
+          interval: receivedData.type,
+          source: 'realtime',
+        });
+      }
+      lastUpdateTime.current = now;
       sendVolumeVisibilityUpdate({
         allowHide: false,
         kLineData: dataForWebView,
@@ -219,8 +252,6 @@ export function useTradingViewV2WebSocket({
         chartType: wsChartType,
         currency,
       });
-
-      lastUpdateTime.current = now;
     }
 
     appEventBus.on(
@@ -244,5 +275,6 @@ export function useTradingViewV2WebSocket({
     enabled,
     wsChartType,
     symbol,
+    onPriceUpdate,
   ]);
 }

--- a/packages/kit/src/states/jotai/contexts/marketV2/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/marketV2/actions.ts
@@ -35,6 +35,7 @@ import {
   tokenDetailLoadingAtom,
   tokenDetailWebsocketAtom,
 } from './atoms';
+import { buildRealtimePriceChange24hPercent } from './realtimePriceUtils';
 
 export const homeResettingFlags: Record<string, number> = {};
 
@@ -149,12 +150,20 @@ class ContextJotaiActionsMarketV2 extends ContextJotaiActionsBase {
       const chartPriceUpdatedAt = Date.now();
       const lastUpdated =
         payload.lastUpdated ?? tokenDetail.lastUpdated ?? chartPriceUpdatedAt;
+      const priceChange24hPercent = buildRealtimePriceChange24hPercent({
+        currentPrice: tokenDetail.price,
+        currentPriceChange24hPercent: tokenDetail.priceChange24hPercent,
+        realtimePrice: payload.price,
+      });
 
       if (tokenDetail.price === payload.price) {
         set(tokenDetailAtom(), {
           ...tokenDetail,
           lastUpdated,
           chartPriceUpdatedAt,
+          ...(priceChange24hPercent !== undefined
+            ? { priceChange24hPercent }
+            : {}),
         });
         return;
       }
@@ -164,6 +173,9 @@ class ContextJotaiActionsMarketV2 extends ContextJotaiActionsBase {
         price: payload.price,
         lastUpdated,
         chartPriceUpdatedAt,
+        ...(priceChange24hPercent !== undefined
+          ? { priceChange24hPercent }
+          : {}),
       });
     },
   );
@@ -319,6 +331,7 @@ class ContextJotaiActionsMarketV2 extends ContextJotaiActionsBase {
           ? {
               ...tokenData,
               price: currentTokenDetail.price,
+              priceChange24hPercent: currentTokenDetail.priceChange24hPercent,
               lastUpdated: currentTokenDetail.lastUpdated,
               chartPriceUpdatedAt,
             }

--- a/packages/kit/src/states/jotai/contexts/marketV2/realtimePriceUtils.ts
+++ b/packages/kit/src/states/jotai/contexts/marketV2/realtimePriceUtils.ts
@@ -1,0 +1,59 @@
+import BigNumber from 'bignumber.js';
+
+function toPositiveBigNumber(value?: string | number) {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  const valueBN = new BigNumber(value);
+  return valueBN.isFinite() && valueBN.gt(0) ? valueBN : undefined;
+}
+
+function toFiniteBigNumber(value?: string | number) {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  const valueBN = new BigNumber(value);
+  return valueBN.isFinite() ? valueBN : undefined;
+}
+
+export function buildRealtimePriceChange24hPercent({
+  currentPrice,
+  currentPriceChange24hPercent,
+  realtimePrice,
+}: {
+  currentPrice?: string | number;
+  currentPriceChange24hPercent?: string | number;
+  realtimePrice: string | number;
+}) {
+  const currentPriceBN = toPositiveBigNumber(currentPrice);
+  const currentPriceChange24hPercentBN = toFiniteBigNumber(
+    currentPriceChange24hPercent,
+  );
+  const realtimePriceBN = toPositiveBigNumber(realtimePrice);
+  if (!currentPriceBN || !currentPriceChange24hPercentBN || !realtimePriceBN) {
+    return undefined;
+  }
+
+  const previous24hPriceDenominator = new BigNumber(1).plus(
+    currentPriceChange24hPercentBN.div(100),
+  );
+  if (
+    !previous24hPriceDenominator.isFinite() ||
+    previous24hPriceDenominator.lte(0)
+  ) {
+    return undefined;
+  }
+
+  const previous24hPrice = currentPriceBN.div(previous24hPriceDenominator);
+  if (!previous24hPrice.isFinite() || previous24hPrice.lte(0)) {
+    return undefined;
+  }
+
+  return realtimePriceBN
+    .minus(previous24hPrice)
+    .div(previous24hPrice)
+    .multipliedBy(100)
+    .toFixed();
+}

--- a/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.test.ts
+++ b/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.test.ts
@@ -1,10 +1,18 @@
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
 import {
+  ESwapStockTradeSide,
+  buildStockChannelEntryKey,
   buildStockSwapTokenFromMarketDetail,
   buildStockSwapTokenFromMarketListToken,
+  buildStockSwapTokenFromTokenIdentity,
   filterStockPayTokenCandidates,
+  findTokenFromCandidates,
+  getMarketPresetTokenKey,
+  isCurrentStockMarketDetail,
+  isStockMarketDetailMatchedTokenParams,
   resolveStockChannelToken,
+  resolveStockExecutionTokenSelection,
 } from './swapStockChannelUtils';
 
 const usdcToken: ISwapToken = {
@@ -34,9 +42,31 @@ const appleStockToken: ISwapToken = {
   contractAddress: '0xaapl',
   symbol: 'AAPL',
   decimals: 18,
+  isStock: true,
 };
 
 describe('swapStockChannelUtils', () => {
+  it('builds a distinct entry key for route and market preset identities', () => {
+    expect(
+      buildStockChannelEntryKey({
+        routeStockTokenKey: 'evm--56:0xaapl:token',
+        marketPresetTokenKey: '',
+      }),
+    ).toBe('evm--56:0xaapl:token__');
+    expect(
+      buildStockChannelEntryKey({
+        routeStockTokenKey: 'evm--56:0xmsft:token',
+        marketPresetTokenKey: '',
+      }),
+    ).toBe('evm--56:0xmsft:token__');
+    expect(
+      buildStockChannelEntryKey({
+        routeStockTokenKey: '',
+        marketPresetTokenKey: 'evm--56:0xaapl:token',
+      }),
+    ).toBe('__evm--56:0xaapl:token');
+  });
+
   it('does not resolve an ordinary swap pair token as the stock token', () => {
     expect(
       resolveStockChannelToken({
@@ -64,6 +94,69 @@ describe('swapStockChannelUtils', () => {
     ).toBe(appleStockToken);
   });
 
+  it('falls back to the requested stock identity before detail is available', () => {
+    const fallbackStockToken = buildStockSwapTokenFromTokenIdentity({
+      networkId: 'evm--56',
+      contractAddress: '0xaapl',
+      isNative: false,
+    });
+
+    expect(fallbackStockToken).toMatchObject({
+      networkId: 'evm--56',
+      contractAddress: '0xaapl',
+      decimals: 0,
+      symbol: '',
+      isStock: true,
+    });
+    expect(
+      resolveStockChannelToken({
+        fallbackStockToken,
+        stockTokenState: undefined,
+        marketStockToken: undefined,
+      }),
+    ).toBe(fallbackStockToken);
+  });
+
+  it('does not treat an unresolved non-native preset as a stock identity', () => {
+    expect(
+      getMarketPresetTokenKey({
+        networkId: 'evm--56',
+        contractAddress: '',
+        isNative: false,
+      }),
+    ).toBe('');
+    expect(
+      buildStockSwapTokenFromTokenIdentity({
+        networkId: 'evm--56',
+        contractAddress: '',
+        isNative: false,
+      }),
+    ).toBeUndefined();
+    expect(
+      getMarketPresetTokenKey({
+        networkId: 'evm--56',
+        contractAddress: '',
+        isNative: true,
+      }),
+    ).toBe('evm--56::native');
+  });
+
+  it('prefers fetched stock detail over a requested identity fallback', () => {
+    const fallbackStockToken = buildStockSwapTokenFromTokenIdentity({
+      networkId: 'evm--56',
+      contractAddress: '0xaapl',
+      isNative: false,
+    });
+
+    expect(
+      resolveStockChannelToken({
+        fallbackStockToken,
+        stockTokenState: undefined,
+        marketStockToken: appleStockToken,
+      }),
+    ).toBe(appleStockToken);
+  });
+
   it('filters stock pay token candidates to USDC and USDT only', () => {
     expect(
       filterStockPayTokenCandidates([ethToken, usdcToken, usdtToken]).map(
@@ -74,6 +167,68 @@ describe('swapStockChannelUtils', () => {
 
   it('fails closed when the speed config has no USDC or USDT pay token', () => {
     expect(filterStockPayTokenCandidates([ethToken])).toEqual([]);
+  });
+
+  it('matches the active pay token only inside current selectable candidates', () => {
+    const currentUsdcToken = {
+      ...usdcToken,
+      contractAddress: '0xUSDC',
+    };
+
+    expect(
+      findTokenFromCandidates({
+        candidates: [currentUsdcToken],
+        token: usdcToken,
+      }),
+    ).toBe(currentUsdcToken);
+
+    expect(
+      findTokenFromCandidates({
+        candidates: [usdtToken],
+        token: usdcToken,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('restores a buy stock execution pair only when the stock side is explicit', () => {
+    expect(
+      resolveStockExecutionTokenSelection({
+        fromToken: usdcToken,
+        toToken: appleStockToken,
+      }),
+    ).toEqual({
+      tradeSide: ESwapStockTradeSide.Buy,
+      stockToken: appleStockToken,
+      payToken: usdcToken,
+    });
+  });
+
+  it('restores a sell stock execution pair only when the stock side is explicit', () => {
+    expect(
+      resolveStockExecutionTokenSelection({
+        fromToken: appleStockToken,
+        toToken: usdtToken,
+      }),
+    ).toEqual({
+      tradeSide: ESwapStockTradeSide.Sell,
+      stockToken: appleStockToken,
+      payToken: usdtToken,
+    });
+  });
+
+  it('does not restore ordinary swap pairs as stock execution pairs', () => {
+    expect(
+      resolveStockExecutionTokenSelection({
+        fromToken: usdcToken,
+        toToken: ethToken,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveStockExecutionTokenSelection({
+        fromToken: usdcToken,
+        toToken: usdtToken,
+      }),
+    ).toBeUndefined();
   });
 
   it('marks only stock market tokens as stock swap tokens', () => {
@@ -149,5 +304,144 @@ describe('swapStockChannelUtils', () => {
       price: '100',
       currency: 'usd',
     });
+  });
+
+  it('falls back to market detail address when route token address is empty', () => {
+    expect(
+      buildStockSwapTokenFromMarketDetail({
+        tokenAddress: '',
+        tokenDetail: {
+          address: '0xaapl',
+          networkId: 'evm--56',
+          symbol: 'AAPL',
+          name: 'Apple',
+          decimals: 18,
+          logoUrl: '',
+          stock: {
+            subtitle: 'Stock',
+            sourceLogoUri: '',
+            underlyingAssetTicker: 'AAPL',
+          },
+        },
+      }),
+    ).toMatchObject({
+      contractAddress: '0xaapl',
+      symbol: 'AAPL',
+    });
+  });
+
+  it('does not treat a stale non-stock market detail as the current stock detail', () => {
+    expect(
+      isCurrentStockMarketDetail({
+        currentStockToken: {
+          networkId: 'evm--56',
+          contractAddress: '0xaapl',
+          isNative: false,
+        },
+        networkId: 'btc--0',
+        tokenAddress: '',
+        isNative: true,
+        tokenDetail: {
+          networkId: 'btc--0',
+          address: '',
+          isNative: true,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('requires the active stock market detail to match the selected stock token', () => {
+    expect(
+      isCurrentStockMarketDetail({
+        currentStockToken: {
+          networkId: 'evm--56',
+          contractAddress: '0xaapl',
+          isNative: false,
+        },
+        networkId: 'evm--56',
+        tokenAddress: '0xother',
+        isNative: false,
+        tokenDetail: {
+          networkId: 'evm--56',
+          address: '0xother',
+          isNative: false,
+          stock: { underlyingAssetTicker: 'OTHER' },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('accepts the active stock market detail with case-insensitive address match', () => {
+    expect(
+      isCurrentStockMarketDetail({
+        currentStockToken: {
+          networkId: 'evm--56',
+          contractAddress: '0xAaPl',
+          isNative: false,
+        },
+        networkId: 'evm--56',
+        tokenAddress: '0xaapl',
+        isNative: false,
+        tokenDetail: {
+          networkId: 'evm--56',
+          address: '0xAAPL',
+          isNative: false,
+          stock: { underlyingAssetTicker: 'AAPL' },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('falls back to token detail address when route token address is empty', () => {
+    expect(
+      isCurrentStockMarketDetail({
+        currentStockToken: {
+          networkId: 'evm--56',
+          contractAddress: '0xaapl',
+          isNative: false,
+        },
+        networkId: 'evm--56',
+        tokenAddress: '',
+        isNative: false,
+        tokenDetail: {
+          networkId: 'evm--56',
+          address: '0xaapl',
+          isNative: false,
+          stock: { underlyingAssetTicker: 'AAPL' },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('does not derive a stock token from stale detail after route switches to a native market token', () => {
+    expect(
+      isStockMarketDetailMatchedTokenParams({
+        networkId: 'btc--0',
+        tokenAddress: '',
+        isNative: true,
+        tokenDetail: {
+          networkId: 'evm--56',
+          address: '0xaapl',
+          isNative: false,
+          stock: { underlyingAssetTicker: 'AAPL' },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('allows route token address fallback when stock detail identity otherwise matches', () => {
+    expect(
+      isStockMarketDetailMatchedTokenParams({
+        networkId: 'evm--56',
+        tokenAddress: '',
+        isNative: false,
+        tokenDetail: {
+          networkId: 'evm--56',
+          address: '0xaapl',
+          isNative: false,
+          stock: { underlyingAssetTicker: 'AAPL' },
+        },
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.ts
+++ b/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.ts
@@ -39,6 +39,13 @@ export enum ESwapStockTradeSide {
 
 const STOCK_DEFAULT_PAY_SYMBOLS = new Set(['USDC', 'USDT']);
 
+type IStockMarketDetailIdentity = {
+  address?: string;
+  isNative?: boolean;
+  networkId?: string;
+  stock?: unknown;
+};
+
 function buildUsdPriceFields(price?: number | string) {
   if (price === undefined || price === null || price === '') {
     return {};
@@ -50,21 +57,27 @@ function buildUsdPriceFields(price?: number | string) {
 }
 
 export function getTokenIdentityKey(token?: Partial<ISwapTokenBase>) {
-  if (!token?.networkId) {
+  const networkId = token?.networkId;
+  if (!networkId || (!token.contractAddress && !token.isNative)) {
     return '';
   }
-  return `${token.networkId}:${token.contractAddress ?? ''}:${
+  return `${networkId}:${token.contractAddress ?? ''}:${
     token.isNative ? 'native' : 'token'
   }`;
 }
 
 export function getMarketPresetTokenKey(token?: IMarketPresetTokenContext) {
-  if (!token?.networkId) {
-    return '';
-  }
-  return `${token.networkId}:${token.contractAddress ?? ''}:${
-    token.isNative ? 'native' : 'token'
-  }`;
+  return getTokenIdentityKey(token);
+}
+
+export function buildStockChannelEntryKey({
+  marketPresetTokenKey,
+  routeStockTokenKey,
+}: {
+  marketPresetTokenKey?: string;
+  routeStockTokenKey?: string;
+}) {
+  return `${routeStockTokenKey ?? ''}__${marketPresetTokenKey ?? ''}`;
 }
 
 export function getMarketListTokenKey(token?: IMarketTokenListItem) {
@@ -124,7 +137,7 @@ export function buildStockSwapTokenFromMarketDetail({
   isNative?: boolean;
 }): ISwapToken | undefined {
   const resolvedNetworkId = tokenDetail?.networkId ?? networkId;
-  const resolvedTokenAddress = tokenAddress ?? tokenDetail?.address;
+  const resolvedTokenAddress = tokenAddress || tokenDetail?.address;
   if (!tokenDetail || !resolvedNetworkId || !resolvedTokenAddress) {
     return undefined;
   }
@@ -135,20 +148,119 @@ export function buildStockSwapTokenFromMarketDetail({
     symbol: tokenDetail.symbol,
     name: tokenDetail.name,
     logoURI: tokenDetail.logoUrl,
-    isNative: !!(isNative ?? tokenDetail.isNative),
+    isNative: !!(tokenDetail.isNative ?? isNative),
     ...buildUsdPriceFields(tokenDetail.price),
     isStock: Boolean(tokenDetail.stock),
   };
 }
 
+export function buildStockSwapTokenFromTokenIdentity(
+  token?: Partial<ISwapTokenBase>,
+): ISwapToken | undefined {
+  if (!token?.networkId || (!token.contractAddress && !token.isNative)) {
+    return undefined;
+  }
+
+  return {
+    networkId: token.networkId,
+    contractAddress: token.contractAddress ?? '',
+    decimals: token.decimals ?? 0,
+    symbol: token.symbol ?? '',
+    name: token.name,
+    logoURI: token.logoURI,
+    isNative: !!token.isNative,
+    price: token.price,
+    currency: token.currency,
+    isStock: true,
+  };
+}
+
+function normalizeAddress(address?: string) {
+  return address?.toLowerCase() ?? '';
+}
+
+export function isCurrentStockMarketDetail({
+  currentStockToken,
+  isNative,
+  networkId,
+  tokenAddress,
+  tokenDetail,
+}: {
+  currentStockToken?: Partial<ISwapTokenBase>;
+  isNative?: boolean;
+  networkId?: string;
+  tokenAddress?: string;
+  tokenDetail?: IStockMarketDetailIdentity;
+}) {
+  if (!tokenDetail?.stock || !currentStockToken?.networkId) {
+    return false;
+  }
+
+  const detailNetworkId = tokenDetail.networkId ?? networkId;
+  if (!detailNetworkId) {
+    return false;
+  }
+
+  return (
+    detailNetworkId === currentStockToken.networkId &&
+    normalizeAddress(tokenAddress || tokenDetail.address) ===
+      normalizeAddress(currentStockToken.contractAddress) &&
+    Boolean(isNative ?? tokenDetail.isNative) ===
+      Boolean(currentStockToken.isNative)
+  );
+}
+
+export function isStockMarketDetailMatchedTokenParams({
+  isNative,
+  networkId,
+  tokenAddress,
+  tokenDetail,
+}: {
+  isNative?: boolean;
+  networkId?: string;
+  tokenAddress?: string;
+  tokenDetail?: IStockMarketDetailIdentity;
+}) {
+  if (!tokenDetail?.stock) {
+    return false;
+  }
+
+  const detailNetworkId = tokenDetail.networkId ?? networkId;
+  if (!detailNetworkId) {
+    return false;
+  }
+
+  if (networkId && detailNetworkId !== networkId) {
+    return false;
+  }
+
+  if (
+    tokenAddress &&
+    normalizeAddress(tokenAddress) !== normalizeAddress(tokenDetail.address)
+  ) {
+    return false;
+  }
+
+  if (
+    isNative !== undefined &&
+    Boolean(isNative) !== Boolean(tokenDetail.isNative)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
 export function resolveStockChannelToken({
+  fallbackStockToken,
   stockTokenState,
   marketStockToken,
 }: {
+  fallbackStockToken?: ISwapToken;
   stockTokenState?: ISwapToken;
   marketStockToken?: ISwapToken;
 }) {
-  return stockTokenState ?? marketStockToken;
+  return stockTokenState ?? marketStockToken ?? fallbackStockToken;
 }
 
 export function filterStockPayTokenCandidates<
@@ -159,11 +271,42 @@ export function filterStockPayTokenCandidates<
   );
 }
 
-export function findTokenFromCandidates({
+export function resolveStockExecutionTokenSelection({
+  fromToken,
+  toToken,
+}: {
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+}) {
+  if (!fromToken || !toToken) {
+    return undefined;
+  }
+  const isFromTokenPayToken =
+    filterStockPayTokenCandidates([fromToken]).length > 0;
+  const isToTokenPayToken = filterStockPayTokenCandidates([toToken]).length > 0;
+
+  if (fromToken.isStock && isToTokenPayToken) {
+    return {
+      tradeSide: ESwapStockTradeSide.Sell,
+      stockToken: fromToken,
+      payToken: toToken,
+    };
+  }
+  if (toToken.isStock && isFromTokenPayToken) {
+    return {
+      tradeSide: ESwapStockTradeSide.Buy,
+      stockToken: toToken,
+      payToken: fromToken,
+    };
+  }
+  return undefined;
+}
+
+export function findTokenFromCandidates<T extends Partial<ISwapTokenBase>>({
   candidates,
   token,
 }: {
-  candidates: IToken[];
+  candidates: T[];
   token?: Partial<ISwapTokenBase>;
 }) {
   if (!token) {

--- a/packages/kit/src/views/Swap/hooks/useSwapStockChannel.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapStockChannel.ts
@@ -1,16 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { useTokenDetailActions } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import {
   useSwapActions,
   useSwapFromTokenAmountAtom,
   useSwapSelectFromTokenAtom,
   useSwapSelectToTokenAtom,
+  useSwapStockExecutionTokensAtom,
   useSwapToTokenAmountAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
+import { isOndoStockSource } from '@onekeyhq/kit/src/views/Market/components/utils/stockSource';
 import { useMarketBasicConfig } from '@onekeyhq/kit/src/views/Market/hooks';
 import type { IToken } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/types';
-import { useTokenDetail } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/hooks/useTokenDetail';
 import type { IMarketToken } from '@onekeyhq/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenData';
 import {
   EAppEventBusNames,
@@ -19,10 +21,13 @@ import {
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type {
+  IMarketPerpsInfo,
+  IMarketTokenDetail,
+} from '@onekeyhq/shared/types/marketV2';
+import type {
   IFetchUSMarketStatusResult,
   IMarketPresetTokenContext,
   ISwapToken,
-  ISwapTokenBase,
 } from '@onekeyhq/shared/types/swap/types';
 import { ESwapSelectTokenSource } from '@onekeyhq/shared/types/swap/types';
 
@@ -37,12 +42,16 @@ import {
   ESwapStockChannelAsyncStatus,
   ESwapStockChannelStage,
   ESwapStockTradeSide,
+  buildStockChannelEntryKey,
   buildStockSwapTokenFromMarketDetail,
   buildStockSwapTokenFromMarketToken,
+  buildStockSwapTokenFromTokenIdentity,
   filterStockPayTokenCandidates,
   getMarketPresetTokenKey,
   getTokenIdentityKey,
+  isCurrentStockMarketDetail,
   resolveStockChannelToken,
+  resolveStockExecutionTokenSelection,
 } from './swapStockChannelUtils';
 import { useSwapStockDefaultToken } from './useSwapStockDefaultToken';
 import { useSwapStockPayTokens } from './useSwapStockPayTokens';
@@ -76,98 +85,217 @@ function buildStockExecutionTokens({
   return { fromToken, toToken };
 }
 
+type IStockTokenDetailState = {
+  perpsInfo?: IMarketPerpsInfo;
+  tokenDetail?: IMarketTokenDetail;
+  tokenKey: string;
+};
+
 export function useSwapStockChannel({
   marketPresetToken,
-  disableNativePayToken,
+  routeStockToken,
 }: {
   marketPresetToken?: IMarketPresetTokenContext;
-  disableNativePayToken?: boolean;
+  routeStockToken?: ISwapToken;
 }) {
-  const tokenDetailActions = useTokenDetailActions();
-  const { tokenDetail, tokenAddress, networkId, isNative } = useTokenDetail();
   const [fromToken] = useSwapSelectFromTokenAtom();
   const [toToken] = useSwapSelectToTokenAtom();
+  const [stockExecutionTokens] = useSwapStockExecutionTokensAtom();
   const [, setFromTokenAmount] = useSwapFromTokenAmountAtom();
   const [, setToTokenAmount] = useSwapToTokenAmountAtom();
   const { selectStockExecutionTokens } = useSwapActions().current;
   const { spotCategories } = useMarketBasicConfig();
-  const [tradeSide, setTradeSide] = useState(ESwapStockTradeSide.Buy);
+  const marketPresetTokenKey = getMarketPresetTokenKey(marketPresetToken);
+  const resolvedMarketPresetToken = marketPresetTokenKey
+    ? marketPresetToken
+    : undefined;
+  const routeStockTokenKey = getTokenIdentityKey(routeStockToken);
+  const stockEntryTokenKey = buildStockChannelEntryKey({
+    marketPresetTokenKey,
+    routeStockTokenKey,
+  });
+  const canRestoreStockExecutionSelection =
+    !routeStockTokenKey && !marketPresetTokenKey;
+  const stockExecutionSelection = useMemo(
+    () =>
+      canRestoreStockExecutionSelection
+        ? resolveStockExecutionTokenSelection({
+            fromToken: stockExecutionTokens?.fromToken,
+            toToken: stockExecutionTokens?.toToken,
+          })
+        : undefined,
+    [
+      canRestoreStockExecutionSelection,
+      stockExecutionTokens?.fromToken,
+      stockExecutionTokens?.toToken,
+    ],
+  );
+  const [tradeSide, setTradeSide] = useState(
+    stockExecutionSelection?.tradeSide ?? ESwapStockTradeSide.Buy,
+  );
   const [stockTokenState, setStockTokenState] = useState<
     ISwapToken | undefined
   >(undefined);
   const [payTokenState, setPayTokenState] = useState<ISwapToken | undefined>(
     undefined,
   );
-  const requestedStockTokenKeyRef = useRef('');
   const manualStockPayTokenKeyRef = useRef('');
   const stockTokenSnapshotRef = useRef<ISwapToken | undefined>(undefined);
   const payTokenSnapshotRef = useRef<ISwapToken | undefined>(undefined);
+  const localStateEntryKeyRef = useRef(stockEntryTokenKey);
+  const isLocalStateEntryCurrent =
+    localStateEntryKeyRef.current === stockEntryTokenKey;
+  const scopedTradeSide = isLocalStateEntryCurrent
+    ? tradeSide
+    : (stockExecutionSelection?.tradeSide ?? ESwapStockTradeSide.Buy);
+  const scopedStockTokenState = isLocalStateEntryCurrent
+    ? stockTokenState
+    : undefined;
+  const scopedPayTokenState = isLocalStateEntryCurrent
+    ? payTokenState
+    : undefined;
 
-  const isBuySide = tradeSide === ESwapStockTradeSide.Buy;
-  const marketPresetTokenKey = getMarketPresetTokenKey(marketPresetToken);
-  const activeMarketTokenKey = getTokenIdentityKey({
-    networkId: networkId ?? '',
-    contractAddress: tokenAddress ?? '',
-    isNative: !!isNative,
-  });
-  const marketStockToken = useMemo(
+  const stockDetailRequestToken = useMemo(
     () =>
-      tokenDetail?.stock
+      scopedStockTokenState ??
+      (routeStockTokenKey ? routeStockToken : undefined) ??
+      resolvedMarketPresetToken ??
+      stockExecutionSelection?.stockToken,
+    [
+      resolvedMarketPresetToken,
+      routeStockToken,
+      routeStockTokenKey,
+      scopedStockTokenState,
+      stockExecutionSelection?.stockToken,
+    ],
+  );
+  const stockDetailRequestTokenKey = getTokenIdentityKey(
+    stockDetailRequestToken,
+  );
+  const { result: stockDetailState } = usePromiseResult(
+    async (): Promise<IStockTokenDetailState> => {
+      if (!stockDetailRequestToken?.networkId || !stockDetailRequestTokenKey) {
+        return {
+          perpsInfo: undefined,
+          tokenDetail: undefined,
+          tokenKey: stockDetailRequestTokenKey,
+        };
+      }
+      try {
+        const response =
+          await backgroundApiProxy.serviceMarketV2.fetchMarketTokenDetailByTokenAddress(
+            stockDetailRequestToken.contractAddress ?? '',
+            stockDetailRequestToken.networkId,
+            { autoHandleError: false },
+          );
+        return {
+          perpsInfo: response?.data.perpsInfo,
+          tokenDetail: response?.data.token,
+          tokenKey: stockDetailRequestTokenKey,
+        };
+      } catch {
+        return {
+          perpsInfo: undefined,
+          tokenDetail: undefined,
+          tokenKey: stockDetailRequestTokenKey,
+        };
+      }
+    },
+    [
+      stockDetailRequestToken?.contractAddress,
+      stockDetailRequestToken?.networkId,
+      stockDetailRequestTokenKey,
+    ],
+    {
+      initResult: {
+        perpsInfo: undefined,
+        tokenDetail: undefined,
+        tokenKey: '',
+      },
+      watchLoading: !!stockDetailRequestTokenKey,
+      pollingInterval: stockDetailRequestTokenKey ? 6000 : undefined,
+      revalidateOnFocus: true,
+      revalidateOnReconnect: true,
+      checkIsFocused: false,
+    },
+  );
+  const fetchedStockTokenDetail =
+    stockDetailState.tokenKey === stockDetailRequestTokenKey &&
+    isCurrentStockMarketDetail({
+      currentStockToken: stockDetailRequestToken,
+      isNative: stockDetailRequestToken?.isNative,
+      networkId: stockDetailRequestToken?.networkId,
+      tokenAddress: stockDetailRequestToken?.contractAddress,
+      tokenDetail: stockDetailState.tokenDetail,
+    })
+      ? stockDetailState.tokenDetail
+      : undefined;
+  const fetchedStockToken = useMemo(
+    () =>
+      fetchedStockTokenDetail
         ? buildStockSwapTokenFromMarketDetail({
-            tokenDetail,
-            tokenAddress: tokenAddress ?? undefined,
-            networkId: networkId ?? undefined,
-            isNative: isNative ?? undefined,
+            tokenDetail: fetchedStockTokenDetail,
+            tokenAddress: stockDetailRequestToken?.contractAddress,
+            networkId: stockDetailRequestToken?.networkId,
+            isNative: stockDetailRequestToken?.isNative,
           })
         : undefined,
-    [isNative, networkId, tokenAddress, tokenDetail],
+    [
+      fetchedStockTokenDetail,
+      stockDetailRequestToken?.contractAddress,
+      stockDetailRequestToken?.isNative,
+      stockDetailRequestToken?.networkId,
+    ],
   );
-  const swapPairPayToken = isBuySide ? fromToken : toToken;
+  const fallbackStockToken = useMemo(() => {
+    if (!stockDetailRequestTokenKey) {
+      return undefined;
+    }
+    const snapshotStockToken = stockTokenSnapshotRef.current;
+    if (
+      getTokenIdentityKey(snapshotStockToken) === stockDetailRequestTokenKey
+    ) {
+      return snapshotStockToken;
+    }
+    return buildStockSwapTokenFromTokenIdentity(stockDetailRequestToken);
+  }, [stockDetailRequestToken, stockDetailRequestTokenKey]);
   const selectedStockToken = resolveStockChannelToken({
-    stockTokenState,
-    marketStockToken,
+    fallbackStockToken,
+    stockTokenState: scopedStockTokenState,
+    marketStockToken: fetchedStockToken,
   });
   const selectedStockTokenKey = getTokenIdentityKey(selectedStockToken);
   const currentStockToken = selectedStockToken;
   const currentStockTokenKey = getTokenIdentityKey(currentStockToken);
-  const swapPairStockPayToken = useMemo(
-    () =>
-      filterStockPayTokenCandidates(
-        swapPairPayToken ? [swapPairPayToken] : [],
-      )[0],
-    [swapPairPayToken],
-  );
-  const payToken = payTokenState ?? swapPairStockPayToken;
-  const stockNetworkId = currentStockToken?.networkId ?? networkId ?? '';
-  const isActiveMarketStockDetail =
-    !!currentStockTokenKey &&
-    activeMarketTokenKey === currentStockTokenKey &&
-    !!tokenDetail?.stock;
-
-  const requestMarketActiveToken = useCallback(
-    (token?: Partial<ISwapTokenBase>) => {
-      const tokenKey = getTokenIdentityKey(token);
-      if (!token?.networkId || !tokenKey) {
-        return;
-      }
-      requestedStockTokenKeyRef.current = tokenKey;
-      if (tokenKey === activeMarketTokenKey) {
-        return;
-      }
-      void tokenDetailActions.current.changeActiveToken({
-        tokenAddress: token.contractAddress ?? '',
-        networkId: token.networkId,
-        isNative: !!token.isNative,
-      });
-    },
-    [activeMarketTokenKey, tokenDetailActions],
+  const payToken = scopedPayTokenState ?? stockExecutionSelection?.payToken;
+  const stockNetworkId = currentStockToken?.networkId ?? '';
+  const activeStockTokenDetail =
+    fetchedStockTokenDetail &&
+    isCurrentStockMarketDetail({
+      currentStockToken,
+      isNative: currentStockToken?.isNative,
+      networkId: currentStockToken?.networkId,
+      tokenAddress: currentStockToken?.contractAddress,
+      tokenDetail: fetchedStockTokenDetail,
+    })
+      ? fetchedStockTokenDetail
+      : undefined;
+  const activeStockPerpsInfo = activeStockTokenDetail
+    ? stockDetailState.perpsInfo
+    : undefined;
+  const disableNativePayToken = isOndoStockSource(
+    activeStockTokenDetail?.stock?.source,
   );
 
   const syncStockExecutionTokens = useCallback(
     async ({
-      nextTradeSide = tradeSide,
-      stockToken = stockTokenSnapshotRef.current ?? currentStockToken,
-      payToken: nextPayToken = payTokenSnapshotRef.current ?? payToken,
+      nextTradeSide = scopedTradeSide,
+      stockToken = (isLocalStateEntryCurrent
+        ? stockTokenSnapshotRef.current
+        : undefined) ?? currentStockToken,
+      payToken: nextPayToken = (isLocalStateEntryCurrent
+        ? payTokenSnapshotRef.current
+        : undefined) ?? payToken,
     }: {
       nextTradeSide?: ESwapStockTradeSide;
       stockToken?: ISwapToken;
@@ -184,25 +312,51 @@ export function useSwapStockChannel({
         syncId: nextStockExecutionTokenSyncId(),
       });
     },
-    [currentStockToken, payToken, selectStockExecutionTokens, tradeSide],
+    [
+      currentStockToken,
+      isLocalStateEntryCurrent,
+      payToken,
+      scopedTradeSide,
+      selectStockExecutionTokens,
+    ],
   );
 
   useEffect(() => {
-    if (currentStockToken) {
+    if (currentStockToken && isLocalStateEntryCurrent) {
       stockTokenSnapshotRef.current = currentStockToken;
     }
-  }, [currentStockToken, tokenDetail?.stock]);
+  }, [currentStockToken, isLocalStateEntryCurrent]);
 
   useEffect(() => {
-    if (payToken) {
+    if (payToken && isLocalStateEntryCurrent) {
       payTokenSnapshotRef.current = payToken;
     }
-  }, [payToken]);
+  }, [isLocalStateEntryCurrent, payToken]);
 
   const resetStockTradeAmounts = useCallback(() => {
     setFromTokenAmount({ value: '', isInput: false });
     setToTokenAmount({ value: '', isInput: false });
   }, [setFromTokenAmount, setToTokenAmount]);
+
+  useEffect(() => {
+    if (localStateEntryKeyRef.current === stockEntryTokenKey) {
+      return;
+    }
+    localStateEntryKeyRef.current = stockEntryTokenKey;
+    setStockTokenState(undefined);
+    setPayTokenState(undefined);
+    manualStockPayTokenKeyRef.current = '';
+    stockTokenSnapshotRef.current = currentStockToken;
+    payTokenSnapshotRef.current = payToken;
+    setTradeSide(stockExecutionSelection?.tradeSide ?? ESwapStockTradeSide.Buy);
+    resetStockTradeAmounts();
+  }, [
+    currentStockToken,
+    payToken,
+    resetStockTradeAmounts,
+    stockEntryTokenKey,
+    stockExecutionSelection?.tradeSide,
+  ]);
 
   const selectStockSwapToken = useCallback(
     (
@@ -223,13 +377,14 @@ export function useSwapStockChannel({
       ) {
         resetStockTradeAmounts();
       }
+      localStateEntryKeyRef.current = stockEntryTokenKey;
       setStockTokenState(token);
       stockTokenSnapshotRef.current = token;
       void syncStockExecutionTokens({
         stockToken: token,
       });
     },
-    [resetStockTradeAmounts, syncStockExecutionTokens],
+    [resetStockTradeAmounts, stockEntryTokenKey, syncStockExecutionTokens],
   );
 
   useEffect(() => {
@@ -242,7 +397,6 @@ export function useSwapStockChannel({
         tokenRole: SWAP_STOCK_ANALYTICS_TOKEN_ROLE_STOCK,
         tokenListType: SWAP_STOCK_ANALYTICS_TOKEN_LIST_TYPE_STOCK,
       });
-      requestMarketActiveToken(token);
       selectStockSwapToken(token, { resetAmounts: true });
     };
     appEventBus.on(
@@ -255,47 +409,36 @@ export function useSwapStockChannel({
         handleSwapStockTokenSelected,
       );
     };
-  }, [requestMarketActiveToken, selectStockSwapToken]);
-
-  useEffect(() => {
-    if (!selectedStockTokenKey || !selectedStockToken?.networkId) {
-      return;
-    }
-    if (requestedStockTokenKeyRef.current === selectedStockTokenKey) {
-      return;
-    }
-    requestMarketActiveToken(selectedStockToken);
-  }, [requestMarketActiveToken, selectedStockToken, selectedStockTokenKey]);
+  }, [selectStockSwapToken]);
 
   const {
     defaultStockTokenLoading,
     shouldLoadDefaultStockToken,
     stockCategoryType,
   } = useSwapStockDefaultToken({
-    marketPresetToken,
     marketPresetTokenKey,
-    marketStockToken,
-    requestMarketActiveToken,
+    marketStockToken: fetchedStockToken,
     selectStockSwapToken,
     selectedStockTokenKey,
     spotCategories,
-    tokenDetailHasStock: !!tokenDetail?.stock,
+    tokenDetailHasStock: !!fetchedStockToken,
   });
 
   const stockMarketStatus = useMemo<
     IFetchUSMarketStatusResult | undefined
   >(() => {
-    if (!isActiveMarketStockDetail || !tokenDetail?.stock) {
+    const stock = activeStockTokenDetail?.stock;
+    if (!stock) {
       return undefined;
     }
-    const isOpen = tokenDetail.stock.isOpen;
+    const isOpen = stock.isOpen;
     return {
       open: isOpen === true,
       session: isOpen === true ? 'REGULAR' : 'CLOSED',
-      reason: tokenDetail.stock.description ?? null,
+      reason: stock.description ?? null,
       unavailable: typeof isOpen === 'boolean' ? undefined : true,
     };
-  }, [isActiveMarketStockDetail, tokenDetail?.stock]);
+  }, [activeStockTokenDetail?.stock]);
   const stockMarketStatusOpen = stockMarketStatus?.open === true;
 
   const selectPayToken = useCallback(
@@ -309,21 +452,26 @@ export function useSwapStockChannel({
         });
       }
       const nextPayToken = token as ISwapToken;
+      localStateEntryKeyRef.current = stockEntryTokenKey;
       setPayTokenState(nextPayToken);
       payTokenSnapshotRef.current = nextPayToken;
       void syncStockExecutionTokens({
         payToken: nextPayToken,
       });
     },
-    [syncStockExecutionTokens],
+    [stockEntryTokenKey, syncStockExecutionTokens],
   );
 
-  const syncPayTokenDetail = useCallback((token: IToken) => {
-    // Detail-only refreshes should not rotate the Stock execution token sync id.
-    const nextPayToken = token as ISwapToken;
-    setPayTokenState(nextPayToken);
-    payTokenSnapshotRef.current = nextPayToken;
-  }, []);
+  const syncPayTokenDetail = useCallback(
+    (token: IToken) => {
+      // Detail-only refreshes should not rotate the Stock execution token sync id.
+      const nextPayToken = token as ISwapToken;
+      localStateEntryKeyRef.current = stockEntryTokenKey;
+      setPayTokenState(nextPayToken);
+      payTokenSnapshotRef.current = nextPayToken;
+    },
+    [stockEntryTokenKey],
+  );
 
   const {
     payTokenStatus,
@@ -345,31 +493,31 @@ export function useSwapStockChannel({
   const selectStockToken = useCallback(
     (token: IMarketToken) => {
       const nextSwapToken = buildStockSwapTokenFromMarketToken(token);
-      requestedStockTokenKeyRef.current = getTokenIdentityKey(nextSwapToken);
       defaultLogger.swap.selectToken.selectToken({
         selectFrom: ESwapSelectTokenSource.NORMAL_SELECT,
         tokenRole: SWAP_STOCK_ANALYTICS_TOKEN_ROLE_STOCK,
         tokenListType: SWAP_STOCK_ANALYTICS_TOKEN_LIST_TYPE_STOCK,
       });
-      requestMarketActiveToken(nextSwapToken);
       selectStockSwapToken(nextSwapToken, { resetAmounts: true });
     },
-    [requestMarketActiveToken, selectStockSwapToken],
+    [selectStockSwapToken],
   );
 
   const switchTradeSide = useCallback(
     async (nextTradeSide: ESwapStockTradeSide) => {
-      if (nextTradeSide === tradeSide) {
+      if (nextTradeSide === scopedTradeSide) {
         return;
       }
       const stockTokenForSwitch =
-        stockTokenSnapshotRef.current ?? currentStockToken;
-      const payTokenForSwitch = payTokenSnapshotRef.current ?? payToken;
+        (isLocalStateEntryCurrent
+          ? stockTokenSnapshotRef.current
+          : undefined) ?? currentStockToken;
+      const payTokenForSwitch =
+        (isLocalStateEntryCurrent ? payTokenSnapshotRef.current : undefined) ??
+        payToken;
+      localStateEntryKeyRef.current = stockEntryTokenKey;
       setTradeSide(nextTradeSide);
       resetStockTradeAmounts();
-      if (stockTokenForSwitch?.networkId) {
-        requestMarketActiveToken(stockTokenForSwitch);
-      }
       await syncStockExecutionTokens({
         nextTradeSide,
         stockToken: stockTokenForSwitch,
@@ -378,11 +526,12 @@ export function useSwapStockChannel({
     },
     [
       currentStockToken,
+      isLocalStateEntryCurrent,
       payToken,
-      requestMarketActiveToken,
       resetStockTradeAmounts,
+      scopedTradeSide,
+      stockEntryTokenKey,
       syncStockExecutionTokens,
-      tradeSide,
     ],
   );
 
@@ -408,24 +557,20 @@ export function useSwapStockChannel({
       const nextPayToken = shouldUseSellSide ? pairToToken : pairFromToken;
 
       resetStockTradeAmounts();
+      localStateEntryKeyRef.current = stockEntryTokenKey;
       setTradeSide(nextTradeSide);
       setStockTokenState(nextStockToken);
       stockTokenSnapshotRef.current = nextStockToken;
       manualStockPayTokenKeyRef.current = getTokenIdentityKey(nextPayToken);
       setPayTokenState(nextPayToken);
       payTokenSnapshotRef.current = nextPayToken;
-      requestMarketActiveToken(nextStockToken);
       await syncStockExecutionTokens({
         nextTradeSide,
         stockToken: nextStockToken,
         payToken: nextPayToken,
       });
     },
-    [
-      requestMarketActiveToken,
-      resetStockTradeAmounts,
-      syncStockExecutionTokens,
-    ],
+    [resetStockTradeAmounts, stockEntryTokenKey, syncStockExecutionTokens],
   );
 
   const stockTokenStatus = useMemo(() => {
@@ -450,19 +595,14 @@ export function useSwapStockChannel({
     if (!currentStockTokenKey) {
       return ESwapStockChannelAsyncStatus.Idle;
     }
-    if (!isActiveMarketStockDetail || !tokenDetail?.stock) {
+    if (!activeStockTokenDetail?.stock) {
       return ESwapStockChannelAsyncStatus.Initializing;
     }
     if (stockMarketStatus) {
       return ESwapStockChannelAsyncStatus.Ready;
     }
     return ESwapStockChannelAsyncStatus.Empty;
-  }, [
-    currentStockTokenKey,
-    isActiveMarketStockDetail,
-    stockMarketStatus,
-    tokenDetail?.stock,
-  ]);
+  }, [activeStockTokenDetail?.stock, currentStockTokenKey, stockMarketStatus]);
 
   const channelStage = useMemo(() => {
     if (stockTokenStatus === ESwapStockChannelAsyncStatus.Initializing) {
@@ -511,7 +651,7 @@ export function useSwapStockChannel({
     } = buildStockExecutionTokens({
       payToken,
       stockToken: currentStockToken,
-      tradeSide,
+      tradeSide: scopedTradeSide,
     });
     const executionPairSynced = Boolean(
       stockExecutionFromToken &&
@@ -537,8 +677,8 @@ export function useSwapStockChannel({
     currentStockToken,
     payToken,
     readyForQuote,
+    scopedTradeSide,
     syncStockExecutionTokens,
-    tradeSide,
     fromToken,
     toToken,
   ]);
@@ -550,9 +690,11 @@ export function useSwapStockChannel({
       payTokenStatus,
       channelStage,
       readyForQuote,
-      tradeSide,
+      tradeSide: scopedTradeSide,
       stockNetworkId,
       stockMarketStatus,
+      activeStockPerpsInfo,
+      activeStockTokenDetail,
       currentStockToken,
       payToken,
       fromToken,
@@ -585,11 +727,13 @@ export function useSwapStockChannel({
       selectStockToken,
       switchTradeSide,
       speedConfigReady,
+      scopedTradeSide,
       stockMarketStatus,
+      activeStockPerpsInfo,
+      activeStockTokenDetail,
       stockNetworkId,
       stockTokenStatus,
       toToken,
-      tradeSide,
       disableNativePayToken,
     ],
   );

--- a/packages/kit/src/views/Swap/hooks/useSwapStockDefaultToken.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapStockDefaultToken.ts
@@ -4,11 +4,7 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { isMarketStockCategory } from '@onekeyhq/kit/src/views/Market/MarketHomeV2/utils';
 import type { IMarketTokenListItem } from '@onekeyhq/shared/types/marketV2';
-import type {
-  IMarketPresetTokenContext,
-  ISwapToken,
-  ISwapTokenBase,
-} from '@onekeyhq/shared/types/swap/types';
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
 import {
   buildStockSwapTokenFromMarketListToken,
@@ -16,19 +12,15 @@ import {
 } from './swapStockChannelUtils';
 
 export function useSwapStockDefaultToken({
-  marketPresetToken,
   marketPresetTokenKey,
   marketStockToken,
-  requestMarketActiveToken,
   selectStockSwapToken,
   selectedStockTokenKey,
   spotCategories,
   tokenDetailHasStock,
 }: {
-  marketPresetToken?: IMarketPresetTokenContext;
   marketPresetTokenKey: string;
   marketStockToken?: ISwapToken;
-  requestMarketActiveToken: (token?: Partial<ISwapTokenBase>) => void;
   selectStockSwapToken: (token: ISwapToken) => void;
   selectedStockTokenKey: string;
   spotCategories: {
@@ -46,22 +38,6 @@ export function useSwapStockDefaultToken({
     );
     return stockCategory?.type;
   }, [spotCategories]);
-
-  useEffect(() => {
-    if (
-      selectedStockTokenKey ||
-      !marketPresetTokenKey ||
-      !marketPresetToken?.networkId
-    ) {
-      return;
-    }
-    requestMarketActiveToken(marketPresetToken);
-  }, [
-    marketPresetToken,
-    marketPresetTokenKey,
-    requestMarketActiveToken,
-    selectedStockTokenKey,
-  ]);
 
   const shouldLoadDefaultStockToken =
     !selectedStockTokenKey && !marketPresetTokenKey && !marketStockToken;
@@ -120,11 +96,6 @@ export function useSwapStockDefaultToken({
     ) {
       return;
     }
-    requestMarketActiveToken({
-      contractAddress: defaultStockToken.address,
-      networkId: defaultStockNetworkId,
-      isNative: defaultStockToken.isNative,
-    });
     const nextSwapToken =
       buildStockSwapTokenFromMarketListToken(defaultStockToken);
     if (nextSwapToken) {
@@ -133,7 +104,6 @@ export function useSwapStockDefaultToken({
   }, [
     defaultStockToken,
     defaultStockTokenKey,
-    requestMarketActiveToken,
     selectStockSwapToken,
     shouldLoadDefaultStockToken,
   ]);

--- a/packages/kit/src/views/Swap/hooks/useSwapStockTradeInputs.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapStockTradeInputs.ts
@@ -30,6 +30,7 @@ import type {
 
 import { buildSwapRateDifference } from '../utils/swapRateDifferenceUtils';
 
+import { findTokenFromCandidates } from './swapStockChannelUtils';
 import {
   STOCK_PRICE_SOURCE_CURRENCY,
   getStockTokenFiatValue,
@@ -433,26 +434,27 @@ export function useSwapStockAmountInputState({
     selectablePayTokens,
     payTokenOptionsLoading,
     disableNativePayToken,
-    marketStatusStatus,
     selectPayToken,
-    speedConfigReady,
+    payTokenStatus,
     stockTokenStatus,
     tradeSide,
   } = stockChannel;
   const isBuySide = tradeSide === ESwapStockTradeSide.Buy;
+  const activeSelectablePayToken = useMemo(() => {
+    return findTokenFromCandidates({
+      candidates: selectablePayTokens,
+      token: payToken,
+    });
+  }, [payToken, selectablePayTokens]);
   const inputToken = isBuySide ? payToken : currentStockToken;
   const stockIdentityReady =
-    stockTokenStatus === ESwapStockChannelAsyncStatus.Ready &&
-    marketStatusStatus === ESwapStockChannelAsyncStatus.Ready;
+    stockTokenStatus === ESwapStockChannelAsyncStatus.Ready;
   const payTokenReady =
     !isBuySide ||
     Boolean(
       stockIdentityReady &&
-      speedConfigReady &&
-      payToken &&
-      selectablePayTokens.some((token) =>
-        equalTokenNoCaseSensitive({ token1: token, token2: payToken }),
-      ),
+      payTokenStatus === ESwapStockChannelAsyncStatus.Ready &&
+      activeSelectablePayToken,
     );
   const inputTokenReady = isBuySide
     ? payTokenReady

--- a/packages/kit/src/views/Swap/hooks/useSwapTokens.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapTokens.ts
@@ -41,7 +41,6 @@ import {
   useSwapNetworksAtom,
   useSwapNetworksIncludeAllNetworkAtom,
   useSwapSelectTokenNetworkAtom,
-  useSwapTokenFetchingAtom,
   useSwapTokenMapAtom,
 } from '../../../states/jotai/contexts/swap';
 import {
@@ -58,6 +57,8 @@ import { buildSwapTokenFetchParams } from './swapTokenFetchParamsUtils';
 import { useSwapAddressInfo } from './useSwapAccount';
 import { shouldUseSwapAddressForTokenFetch } from './useSwapAccount.utils';
 
+const EMPTY_SWAP_SUPPORT_ALL_ACCOUNTS: IAllNetworkAccountInfo[] = [];
+
 export function useSwapTokenList(
   selectTokenModalType: ESwapDirectionType,
   currentNetworkId?: string,
@@ -69,10 +70,23 @@ export function useSwapTokenList(
     tokenListType?: string;
   },
   supportNetworksOverride?: ISwapNetwork[],
+  options?: {
+    enabled?: boolean;
+  },
 ) {
+  const enabled = options?.enabled ?? true;
   const [{ tokenCatch }] = useSwapTokenMapAtom();
   const [swapAllNetworkTokenListMap] = useSwapAllNetworkTokenListMapAtom();
-  const swapSupportAllAccountsRef = useRef<IAllNetworkAccountInfo[]>([]);
+  const [swapSupportAllAccountsState, setSwapSupportAllAccountsState] =
+    useState<{
+      requestKey: string;
+      accounts: IAllNetworkAccountInfo[];
+    }>({
+      requestKey: '',
+      accounts: EMPTY_SWAP_SUPPORT_ALL_ACCOUNTS,
+    });
+  const [swapSupportAllAccountsLoading, setSwapSupportAllAccountsLoading] =
+    useState(true);
   const [swapNetworks] = useSwapNetworksAtom();
   const [swapSupportAllNetworksBase] = useSwapNetworksIncludeAllNetworkAtom();
   const swapSupportAllNetworks =
@@ -80,41 +94,88 @@ export function useSwapTokenList(
   const { tokenListFetchAction, swapLoadAllNetworkTokenList } =
     useSwapActions().current;
   const swapAddressInfo = useSwapAddressInfo(selectTokenModalType);
-  const [swapTokenFetching] = useSwapTokenFetchingAtom();
   const [currentSelectNetwork] = useSwapSelectTokenNetworkAtom();
   const [{ currencyInfo }] = useSettingsPersistAtom();
   const [lpTokenRequestLoading, setLpTokenRequestLoading] = useState(false);
   const requestCurrency = currencyInfo.id;
   const latestLpTokenRef = useRef(lpToken);
+  const indexedAccountId = swapAddressInfo?.accountInfo?.indexedAccount?.id;
+  const otherWalletTypeAccountId = !indexedAccountId
+    ? (swapAddressInfo?.accountInfo?.account?.id ??
+      swapAddressInfo?.accountInfo?.dbAccount?.id)
+    : undefined;
+  const swapSupportAllAccountsRequestKey = useMemo(
+    () =>
+      [
+        indexedAccountId ?? '',
+        otherWalletTypeAccountId ?? '',
+        swapSupportAllNetworks.map((network) => network.networkId).join(','),
+      ].join('__'),
+    [indexedAccountId, otherWalletTypeAccountId, swapSupportAllNetworks],
+  );
+  const isSwapSupportAllAccountsReady =
+    !swapSupportAllAccountsLoading &&
+    swapSupportAllAccountsState.requestKey === swapSupportAllAccountsRequestKey;
+  const swapSupportAllAccounts = isSwapSupportAllAccountsReady
+    ? swapSupportAllAccountsState.accounts
+    : EMPTY_SWAP_SUPPORT_ALL_ACCOUNTS;
   const searchLogStateRef = useRef<{
     key: string;
     phase: 'idle' | 'fetching' | 'done';
   } | null>(null);
 
   useEffect(() => {
+    if (!enabled) {
+      setSwapSupportAllAccountsState({
+        requestKey: swapSupportAllAccountsRequestKey,
+        accounts: EMPTY_SWAP_SUPPORT_ALL_ACCOUNTS,
+      });
+      setSwapSupportAllAccountsLoading(false);
+      return;
+    }
+    let isCancelled = false;
+    setSwapSupportAllAccountsLoading(true);
     void (async () => {
-      const { swapSupportAccounts } =
-        await backgroundApiProxy.serviceSwap.getSupportSwapAllAccounts({
-          indexedAccountId: swapAddressInfo?.accountInfo?.indexedAccount?.id,
-          otherWalletTypeAccountId: !swapAddressInfo?.accountInfo
-            ?.indexedAccount?.id
-            ? (swapAddressInfo?.accountInfo?.account?.id ??
-              swapAddressInfo?.accountInfo?.dbAccount?.id)
-            : undefined,
-          swapSupportNetworks: swapNetworks,
-        });
-      swapSupportAllAccountsRef.current = swapSupportAccounts;
+      try {
+        const { swapSupportAccounts } =
+          await backgroundApiProxy.serviceSwap.getSupportSwapAllAccounts({
+            indexedAccountId,
+            otherWalletTypeAccountId,
+            swapSupportNetworks: swapSupportAllNetworks,
+          });
+        if (!isCancelled) {
+          setSwapSupportAllAccountsState({
+            requestKey: swapSupportAllAccountsRequestKey,
+            accounts: swapSupportAccounts,
+          });
+        }
+      } catch {
+        if (!isCancelled) {
+          setSwapSupportAllAccountsState({
+            requestKey: swapSupportAllAccountsRequestKey,
+            accounts: EMPTY_SWAP_SUPPORT_ALL_ACCOUNTS,
+          });
+        }
+      } finally {
+        if (!isCancelled) {
+          setSwapSupportAllAccountsLoading(false);
+        }
+      }
     })();
+    return () => {
+      isCancelled = true;
+    };
   }, [
-    swapAddressInfo?.accountInfo?.account?.id,
-    swapAddressInfo?.accountInfo?.dbAccount?.id,
-    swapAddressInfo?.accountInfo?.indexedAccount?.id,
-    swapNetworks,
+    indexedAccountId,
+    otherWalletTypeAccountId,
+    swapSupportAllAccountsRequestKey,
+    swapSupportAllNetworks,
+    enabled,
   ]);
 
   const tokenFetchParams = useMemo(() => {
     const targetNetworkId = currentSelectNetwork?.networkId ?? currentNetworkId;
-    const findNetInfo = swapSupportAllAccountsRef.current.find(
+    const findNetInfo = swapSupportAllAccounts.find(
       (net) => net.networkId === targetNetworkId,
     );
     const shouldUseCurrentAccountAddress = shouldUseSwapAddressForTokenFetch({
@@ -147,6 +208,7 @@ export function useSwapTokenList(
     currentSelectNetwork?.networkId,
     lpToken,
     requestCurrency,
+    swapSupportAllAccounts,
   ]);
   const isTokenFetchAllNetworks = networkUtils.isAllNetwork({
     networkId: tokenFetchParams.networkId,
@@ -192,6 +254,14 @@ export function useSwapTokenList(
     tokenFetchParams,
   ]);
   const latestTokenListFetchEffectKeyRef = useRef('');
+  const [tokenListFetchLoadingState, setTokenListFetchLoadingState] = useState({
+    key: '',
+    loading: false,
+  });
+  const tokenListFetchLoading =
+    enabled &&
+    tokenListFetchLoadingState.loading &&
+    tokenListFetchLoadingState.key === tokenListFetchEffectKey;
 
   const swapAllNetworkTokenListCacheKey = useMemo(
     () =>
@@ -359,6 +429,12 @@ export function useSwapTokenList(
   }
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    if (!isSwapSupportAllAccountsReady) {
+      return;
+    }
     if (latestTokenListFetchEffectKeyRef.current === tokenListFetchEffectKey) {
       return;
     }
@@ -368,6 +444,10 @@ export function useSwapTokenList(
     if (isLpTokenSwitchRequest) {
       setLpTokenRequestLoading(true);
     }
+    setTokenListFetchLoadingState({
+      key: tokenListFetchEffectKey,
+      loading: true,
+    });
 
     void (async () => {
       try {
@@ -377,11 +457,8 @@ export function useSwapTokenList(
           isTokenFetchAllNetworks &&
           allNetworkTokenListReady
             ? swapLoadAllNetworkTokenList(
-                swapAddressInfo?.accountInfo?.indexedAccount?.id,
-                !swapAddressInfo?.accountInfo?.indexedAccount?.id
-                  ? (swapAddressInfo?.accountInfo?.account?.id ??
-                      swapAddressInfo?.accountInfo?.dbAccount?.id)
-                  : undefined,
+                indexedAccountId,
+                otherWalletTypeAccountId,
                 lpToken,
                 requestCurrency,
               )
@@ -389,6 +466,14 @@ export function useSwapTokenList(
           tokenListFetchAction(tokenFetchParams),
         ]);
       } finally {
+        if (
+          latestTokenListFetchEffectKeyRef.current === tokenListFetchEffectKey
+        ) {
+          setTokenListFetchLoadingState({
+            key: tokenListFetchEffectKey,
+            loading: false,
+          });
+        }
         if (
           isLpTokenSwitchRequest &&
           latestTokenListFetchEffectKeyRef.current === tokenListFetchEffectKey
@@ -398,9 +483,8 @@ export function useSwapTokenList(
       }
     })();
   }, [
-    swapAddressInfo?.accountInfo?.account?.id,
-    swapAddressInfo?.accountInfo?.dbAccount?.id,
-    swapAddressInfo?.accountInfo?.indexedAccount?.id,
+    indexedAccountId,
+    otherWalletTypeAccountId,
     allNetworkTokenListReady,
     isTokenFetchAllNetworks,
     swapLoadAllNetworkTokenList,
@@ -410,10 +494,12 @@ export function useSwapTokenList(
     keywords,
     lpToken,
     requestCurrency,
+    isSwapSupportAllAccountsReady,
+    enabled,
   ]);
 
   useEffect(() => {
-    if (!keywords) {
+    if (!enabled || !keywords) {
       searchLogStateRef.current = null;
       return;
     }
@@ -441,7 +527,7 @@ export function useSwapTokenList(
       return;
     }
 
-    if (swapTokenFetching) {
+    if (tokenListFetchLoading) {
       if (state.phase !== 'fetching') {
         searchLogStateRef.current = { key, phase: 'fetching' };
       }
@@ -483,10 +569,17 @@ export function useSwapTokenList(
     analyticsOverride?.tokenListType,
     analyticsOverride?.tokenRole,
     selectTokenModalType,
-    swapTokenFetching,
+    tokenListFetchLoading,
+    enabled,
   ]);
 
   const currentTokens = useMemo(() => {
+    if (!enabled) {
+      return [];
+    }
+    if (!isSwapSupportAllAccountsReady) {
+      return [];
+    }
     if (keywords) {
       return fuseRemoteTokensSearch.search(keywords);
     }
@@ -503,13 +596,17 @@ export function useSwapTokenList(
     mergedAllNetworkTokenList,
     tokenCatch,
     tokenFetchParams,
+    isSwapSupportAllAccountsReady,
+    enabled,
   ]);
 
   return {
     fetchLoading:
-      (swapTokenFetching && currentTokens.length === 0) ||
-      (networkUtils.isAllNetwork({ networkId: tokenFetchParams.networkId }) &&
-        (!allNetworkTokenListReady || !swapAllNetworkTokenList)),
+      enabled &&
+      (!isSwapSupportAllAccountsReady ||
+        (tokenListFetchLoading && currentTokens.length === 0) ||
+        (networkUtils.isAllNetwork({ networkId: tokenFetchParams.networkId }) &&
+          (!allNetworkTokenListReady || !swapAllNetworkTokenList))),
     lpTokenRequestLoading,
     currentTokens,
   };

--- a/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
@@ -43,7 +43,6 @@ import {
   useSwapSelectToTokenAtom,
   useSwapTypeSwitchAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
-import { useTokenDetail } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/hooks/useTokenDetail';
 import {
   EJotaiContextStoreNames,
   filterSwapHistoryPendingList,
@@ -85,6 +84,7 @@ import { SwapKLineContentWithProvider } from '../modal/SwapKLineContent';
 import { SwapProviderMirror } from '../SwapProviderMirror';
 
 import ProviderManageContainer from './ProviderManageContainer';
+import { useOptionalSwapStockTradeContext } from './SwapStockTradeProvider';
 
 import type { IMarketPresetSettingsState } from '../../../Market/MarketDetailV2/components/SwapPanel/hooks/useMarketPresetSettings';
 
@@ -505,14 +505,14 @@ const StockKLineHeaderButton = ({
   buttonSize: 'small' | 'medium';
 }) => {
   const navigation = useAppNavigation();
-  const {
-    isNative,
-    networkId: networkIdFromHook,
-    tokenAddress: tokenAddressFromHook,
-    tokenDetail,
-  } = useTokenDetail();
-  const networkId = networkIdFromHook ?? tokenDetail?.networkId ?? '';
-  const tokenAddress = tokenAddressFromHook ?? tokenDetail?.address ?? '';
+  const stockChannel = useOptionalSwapStockTradeContext();
+  const currentStockToken = stockChannel?.currentStockToken;
+  const tokenDetail = stockChannel?.activeStockTokenDetail;
+  const isNative = currentStockToken?.isNative ?? false;
+  const networkId =
+    currentStockToken?.networkId ?? tokenDetail?.networkId ?? '';
+  const tokenAddress =
+    currentStockToken?.contractAddress ?? tokenDetail?.address ?? '';
   const network = useMemo(
     () =>
       networkUtils.getNetworkShortCode({

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -142,6 +142,7 @@ import {
   SwapStockDesktopContainer,
   SwapStockMobileContainer,
 } from './SwapStockDesktopContainer';
+import { SwapStockTradeProviderBoundary } from './SwapStockTradeProvider';
 import SwapSwapMbContainer from './SwapSwapMbContainer';
 
 import type { ScrollView as ScrollViewNative } from 'react-native';
@@ -150,6 +151,19 @@ interface ISwapMainLoadProps {
   children?: React.ReactNode;
   swapInitParams?: ISwapInitParams;
   pageType?: EPageType.modal;
+}
+
+function hasResolvableSwapTokenIdentity(
+  token?: ISwapToken,
+): token is ISwapToken {
+  return Boolean(token?.networkId && (token.contractAddress || token.isNative));
+}
+
+function resolveRouteStockToken(swapInitParams?: ISwapInitParams) {
+  return [swapInitParams?.importToToken, swapInitParams?.importFromToken].find(
+    (token): token is ISwapToken =>
+      hasResolvableSwapTokenIdentity(token) && token.isStock === true,
+  );
 }
 
 const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
@@ -224,6 +238,12 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   );
   const incomingMarketPresetToken =
     swapInitParams?.marketPresetToken ?? swapProJumpToken.marketPresetToken;
+  const routeStockToken = resolveRouteStockToken(swapInitParams);
+  const stockMarketPresetTokenContext =
+    swapInitParams?.swapTabSwitchType === ESwapTabSwitchType.STOCK ||
+    routeStockToken
+      ? marketPresetTokenContext
+      : undefined;
   const {
     isLoading,
     speedConfig,
@@ -1200,7 +1220,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
       return (
         <SwapStockDesktopContainer
           storeName={storeName}
-          marketPresetToken={marketPresetTokenContext}
+          marketPresetToken={stockMarketPresetTokenContext}
+          routeStockToken={routeStockToken}
           onSelectToken={onSelectToken}
           onTokenPress={onTokenPress}
           supportNetworksList={swapBridgeSupportNetworksFilterAllNet}
@@ -1231,7 +1252,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
       return (
         <SwapStockMobileContainer
           storeName={storeName}
-          marketPresetToken={marketPresetTokenContext}
+          marketPresetToken={stockMarketPresetTokenContext}
+          routeStockToken={routeStockToken}
           onSelectToken={onSelectToken}
           onTokenPress={onTokenPress}
           supportNetworksList={swapBridgeSupportNetworksFilterAllNet}
@@ -1331,7 +1353,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     swapRecentTokenPairs,
     swapBridgeSupportNetworksFilterAllNet,
     storeName,
-    marketPresetTokenContext,
+    stockMarketPresetTokenContext,
+    routeStockToken,
     isWrapped,
     swapInitParams?.swapTabSwitchType,
     swapInitParams?.swapSource,
@@ -1384,7 +1407,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     contentTopPadding = '$0';
   }
 
-  return (
+  const pageContent = (
     <>
       <Page.Container flex={1} layout={containerLayout} padded={false}>
         <YStack
@@ -1447,6 +1470,19 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
       </Page.Container>
     </>
   );
+
+  if (swapTypeSwitch === ESwapTabSwitchType.STOCK) {
+    return (
+      <SwapStockTradeProviderBoundary
+        marketPresetToken={stockMarketPresetTokenContext}
+        routeStockToken={routeStockToken}
+      >
+        {pageContent}
+      </SwapStockTradeProviderBoundary>
+    );
+  }
+
+  return pageContent;
 };
 
 const SwapMainLandWithPageType = (props: ISwapMainLoadProps) => {

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -53,12 +53,10 @@ import {
   StockSourceLogo,
 } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
 import { PriceChangePercentage } from '@onekeyhq/kit/src/views/Market/components/PriceChangePercentage';
-import { isOndoStockSource } from '@onekeyhq/kit/src/views/Market/components/utils/stockSource';
 import { TokenList } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/TokenInputSection/TokenList';
 import { TradeTypeSelector } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/TradeTypeSelector';
 import { ESwapDirection } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
 import type { IToken } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/types';
-import { useTokenDetail } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/hooks/useTokenDetail';
 import {
   formatCurrencyStatValue,
   formatMarketCapValue,
@@ -85,7 +83,10 @@ import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import type { IMarketTokenChart } from '@onekeyhq/shared/types/market';
-import type { IMarketBasicConfigNetwork } from '@onekeyhq/shared/types/marketV2';
+import type {
+  IMarketBasicConfigNetwork,
+  IMarketTokenDetail,
+} from '@onekeyhq/shared/types/marketV2';
 import {
   EProtocolOfExchange,
   ESwapDirectionType,
@@ -142,7 +143,7 @@ import {
 } from './SwapStockDesktopContainer.utils';
 import { SwapStockTradeAlert } from './SwapStockTradeAlert';
 import {
-  SwapStockTradeProvider,
+  SwapStockTradeProviderBoundary,
   useSwapStockTradeContext,
 } from './SwapStockTradeProvider';
 
@@ -151,6 +152,7 @@ import type { KeyboardAwareScrollViewRef } from 'react-native-keyboard-controlle
 interface ISwapStockDesktopContainerProps {
   headerContent?: ReactNode;
   marketPresetToken?: IMarketPresetTokenContext;
+  routeStockToken?: ISwapToken;
   storeName: EJotaiContextStoreNames;
   onSelectToken: (type: ESwapDirectionType) => void;
   onTokenPress?: (token: ISwapToken) => void;
@@ -171,7 +173,7 @@ interface ISwapStockDesktopContainerProps {
   };
 }
 
-type IStockMarketTokenDetail = ReturnType<typeof useTokenDetail>['tokenDetail'];
+type IStockMarketTokenDetail = IMarketTokenDetail | undefined;
 type IStockMarketDataRow = {
   label: string;
   value: string;
@@ -225,10 +227,12 @@ function getStockChartTokenDetailCoinGeckoId(
 }
 
 function useStockChartCoinGeckoId({
+  isNative,
   networkId,
   tokenAddress,
   tokenDetail,
 }: {
+  isNative?: boolean;
   networkId?: string;
   tokenAddress?: string;
   tokenDetail?: IStockMarketTokenDetail;
@@ -236,7 +240,7 @@ function useStockChartCoinGeckoId({
   const tokenDetailCoinGeckoId =
     getStockChartTokenDetailCoinGeckoId(tokenDetail);
   const tokenScope = `${networkId ?? ''}:${tokenAddress ?? ''}`;
-  const { result } = usePromiseResult<
+  const { result, isLoading } = usePromiseResult<
     | {
         tokenScope: string;
         coinGeckoId?: string;
@@ -244,32 +248,48 @@ function useStockChartCoinGeckoId({
     | undefined
   >(
     async () => {
-      if (tokenDetailCoinGeckoId || !networkId) {
+      if (
+        tokenDetailCoinGeckoId ||
+        !networkId ||
+        (!tokenAddress && !isNative)
+      ) {
         return undefined;
       }
 
-      const tokenInfo =
-        await backgroundApiProxy.serviceToken.fetchTokenInfoOnly({
-          networkId,
-          tokenAddress: tokenAddress ?? '',
-        });
-      return {
-        tokenScope,
-        coinGeckoId: tokenInfo?.info?.coingeckoId?.trim() || undefined,
-      };
+      try {
+        const tokenInfo =
+          await backgroundApiProxy.serviceToken.fetchTokenInfoOnly({
+            networkId,
+            tokenAddress: tokenAddress ?? '',
+          });
+        return {
+          tokenScope,
+          coinGeckoId: tokenInfo?.info?.coingeckoId?.trim() || undefined,
+        };
+      } catch {
+        return {
+          tokenScope,
+        };
+      }
     },
-    [networkId, tokenAddress, tokenDetailCoinGeckoId, tokenScope],
+    [isNative, networkId, tokenAddress, tokenDetailCoinGeckoId, tokenScope],
     {
       checkIsFocused: false,
-      undefinedResultIfError: true,
       undefinedResultIfReRun: true,
     },
   );
 
-  return (
-    tokenDetailCoinGeckoId ||
-    (result?.tokenScope === tokenScope ? result.coinGeckoId : undefined)
+  const isTokenInfoResultForCurrentScope = result?.tokenScope === tokenScope;
+  const shouldLookupTokenInfo = Boolean(
+    !tokenDetailCoinGeckoId && networkId && (tokenAddress || isNative),
   );
+  return {
+    coinGeckoId:
+      tokenDetailCoinGeckoId ||
+      (isTokenInfoResultForCurrentScope ? result.coinGeckoId : undefined),
+    loading:
+      shouldLookupTokenInfo && (isLoading || !isTokenInfoResultForCurrentScope),
+  };
 }
 
 function StockMarketDataItem({
@@ -432,14 +452,14 @@ function StockMarketDataGridContent({
 
 function StockMarketDataGrid() {
   const intl = useIntl();
-  const { tokenDetail } = useTokenDetail();
+  const stockChannel = useSwapStockTradeContext();
   const rows = useMemo(
     () =>
       buildStockMarketDataRows({
         intl,
-        tokenDetail,
+        tokenDetail: stockChannel.activeStockTokenDetail,
       }),
-    [intl, tokenDetail],
+    [intl, stockChannel.activeStockTokenDetail],
   );
 
   return (
@@ -1205,30 +1225,45 @@ function StockMarketHeaderSkeleton() {
 
 function StockMarketTokenHeader({
   storeName,
+  stockChannel,
 }: {
   storeName: EJotaiContextStoreNames;
+  stockChannel: IUseSwapStockChannelReturn;
 }) {
-  const { tokenDetail, networkId } = useTokenDetail();
-  const stockTokenNetworkId = tokenDetail?.networkId ?? networkId;
+  const activeStockTokenDetail = stockChannel.activeStockTokenDetail;
+  const displayStockToken = stockChannel.currentStockToken;
+  const stockTokenNetworkId =
+    activeStockTokenDetail?.networkId ?? displayStockToken?.networkId;
   const effectiveNetworkLogoUri = useNetworkLogoUri({
     logoUri: undefined,
     networkId: stockTokenNetworkId,
   });
-  const stock = tokenDetail?.stock;
+  const stock = activeStockTokenDetail?.stock;
+  const tokenSymbol =
+    activeStockTokenDetail?.symbol ?? displayStockToken?.symbol ?? '';
+  const tokenName =
+    activeStockTokenDetail?.name ?? displayStockToken?.name ?? tokenSymbol;
+  const tokenLogoUri =
+    activeStockTokenDetail?.logoUrl ?? displayStockToken?.logoURI;
+  const tokenPrice =
+    activeStockTokenDetail?.price ??
+    activeStockTokenDetail?.priceConverted ??
+    displayStockToken?.price ??
+    '';
   const handleOpenStockTokenSelector = useOpenStockTokenSelector({
     defaultNetworkId: stockTokenNetworkId,
     storeName,
   });
 
-  if (!tokenDetail) {
+  if (!activeStockTokenDetail && !tokenSymbol && !tokenName && !tokenLogoUri) {
     return <StockMarketHeaderSkeleton />;
   }
 
   const tokenIcon = (
     <Token
       size="md"
-      tokenImageUri={tokenDetail.logoUrl}
-      tokenImageUris={tokenDetail.logoUrls}
+      tokenImageUri={tokenLogoUri}
+      tokenImageUris={activeStockTokenDetail?.logoUrls}
       networkImageUri={effectiveNetworkLogoUri}
       showNetworkIconBorder={false}
       bg="$transparent"
@@ -1245,7 +1280,7 @@ function StockMarketTokenHeader({
         maxWidth={132}
         flexShrink={1}
       >
-        {tokenDetail.symbol}
+        {tokenSymbol || tokenName}
       </SizableText>
       <Icon
         name="ChevronDownSmallOutline"
@@ -1322,14 +1357,14 @@ function StockMarketTokenHeader({
           color="$text"
           numberOfLines={1}
           textAlign="right"
-          price={tokenDetail.price ?? tokenDetail.priceConverted ?? ''}
-          tokenName={tokenDetail.name}
-          tokenSymbol={tokenDetail.symbol}
-          lastUpdated={String(tokenDetail.lastUpdated ?? '')}
+          price={tokenPrice}
+          tokenName={tokenName}
+          tokenSymbol={tokenSymbol}
+          lastUpdated={String(activeStockTokenDetail?.lastUpdated ?? '')}
           currency="$"
         />
         <PriceChangePercentage size="$bodySm">
-          {tokenDetail.priceChange24hPercent}
+          {activeStockTokenDetail?.priceChange24hPercent}
         </PriceChangePercentage>
       </YStack>
     </XStack>
@@ -1766,22 +1801,52 @@ function StockMobilePositionsSection({
 
 function StockMarketContextPanel({
   storeName,
+  stockChannel,
 }: {
   storeName: EJotaiContextStoreNames;
+  stockChannel: IUseSwapStockChannelReturn;
 }) {
-  const { tokenDetail, tokenAddress, networkId, isNative } = useTokenDetail();
-  const stockChannel = useSwapStockTradeContext();
-  const coinGeckoId = useStockChartCoinGeckoId({
-    networkId,
-    tokenAddress,
-    tokenDetail,
-  });
+  const activeStockTokenDetail = stockChannel.activeStockTokenDetail;
+  const displayStockToken = stockChannel.currentStockToken;
+  const activeStockNetworkId =
+    activeStockTokenDetail?.networkId ?? displayStockToken?.networkId;
+  const activeStockTokenAddress =
+    activeStockTokenDetail?.address ?? displayStockToken?.contractAddress ?? '';
+  const activeStockIsNative =
+    activeStockTokenDetail?.isNative ?? displayStockToken?.isNative;
+  const { coinGeckoId, loading: coinGeckoIdLoading } = useStockChartCoinGeckoId(
+    {
+      isNative: activeStockIsNative,
+      networkId: activeStockNetworkId,
+      tokenAddress: activeStockTokenAddress,
+      tokenDetail: activeStockTokenDetail,
+    },
+  );
   const [range, setRange] = useState<IStockChartRange>(
     STOCK_CHART_DEFAULT_RANGE,
   );
-  const chartReady = !!networkId && !!tokenDetail?.symbol;
-  // Only pulse the chart tail while the market is open (live updating).
+  const chartHasTokenIdentity = Boolean(
+    activeStockNetworkId && (activeStockTokenAddress || activeStockIsNative),
+  );
+  const chartReady = Boolean(
+    chartHasTokenIdentity &&
+    (activeStockTokenDetail?.symbol || displayStockToken?.symbol),
+  );
   const isMarketOpen = stockChannel.stockMarketStatus?.open === true;
+  const chartContent =
+    chartReady && !coinGeckoIdLoading ? (
+      <StockPriceChart
+        coinGeckoId={coinGeckoId}
+        tokenAddress={activeStockTokenAddress}
+        networkId={activeStockNetworkId ?? ''}
+        isNative={!!activeStockIsNative}
+        range={range}
+        onRangeChange={setRange}
+        pulseLastPoint={isMarketOpen}
+      />
+    ) : (
+      <Skeleton w="100%" h={274} />
+    );
 
   return (
     <YStack
@@ -1805,23 +1870,12 @@ function StockMarketContextPanel({
         shadowRadius: 24,
       }}
     >
-      <StockMarketTokenHeader storeName={storeName} />
+      <StockMarketTokenHeader
+        storeName={storeName}
+        stockChannel={stockChannel}
+      />
 
-      <Stack mt="$6">
-        {chartReady ? (
-          <StockPriceChart
-            coinGeckoId={coinGeckoId}
-            tokenAddress={tokenAddress ?? ''}
-            networkId={networkId ?? ''}
-            isNative={isNative}
-            range={range}
-            onRangeChange={setRange}
-            pulseLastPoint={isMarketOpen}
-          />
-        ) : (
-          <Skeleton w="100%" h={274} />
-        )}
-      </Stack>
+      <Stack mt="$6">{chartContent}</Stack>
 
       <Divider mt="$2.5" mb="$3" />
       <StockMarketDataGrid />
@@ -2036,7 +2090,10 @@ function SwapStockDesktopContent({
               </YStack>
             </YStack>
             <YStack p="$5" flexBasis="50%" minWidth={0}>
-              <StockMarketContextPanel storeName={storeName} />
+              <StockMarketContextPanel
+                storeName={storeName}
+                stockChannel={stockChannel}
+              />
             </YStack>
           </XStack>
         </YStack>
@@ -2048,15 +2105,13 @@ function SwapStockDesktopContent({
 export function SwapStockDesktopContainer(
   props: ISwapStockDesktopContainerProps,
 ) {
-  const { tokenDetail } = useTokenDetail();
-
   return (
-    <SwapStockTradeProvider
+    <SwapStockTradeProviderBoundary
       marketPresetToken={props.marketPresetToken}
-      disableNativePayToken={isOndoStockSource(tokenDetail?.stock?.source)}
+      routeStockToken={props.routeStockToken}
     >
       <SwapStockDesktopContent {...props} />
-    </SwapStockTradeProvider>
+    </SwapStockTradeProviderBoundary>
   );
 }
 
@@ -2108,7 +2163,10 @@ function SwapStockMobileContent(props: ISwapStockDesktopContainerProps) {
         gap="$2"
         flex={1}
       >
-        <StockMarketTokenHeader storeName={props.storeName} />
+        <StockMarketTokenHeader
+          storeName={props.storeName}
+          stockChannel={stockChannel}
+        />
         <StockTradeTicket
           onSelectToken={props.onSelectToken}
           fetchLoading={props.fetchLoading}
@@ -2147,14 +2205,12 @@ function SwapStockMobileContent(props: ISwapStockDesktopContainerProps) {
 export function SwapStockMobileContainer(
   props: ISwapStockDesktopContainerProps,
 ) {
-  const { tokenDetail } = useTokenDetail();
-
   return (
-    <SwapStockTradeProvider
+    <SwapStockTradeProviderBoundary
       marketPresetToken={props.marketPresetToken}
-      disableNativePayToken={isOndoStockSource(tokenDetail?.stock?.source)}
+      routeStockToken={props.routeStockToken}
     >
       <SwapStockMobileContent {...props} />
-    </SwapStockTradeProvider>
+    </SwapStockTradeProviderBoundary>
   );
 }

--- a/packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.tsx
@@ -13,7 +13,6 @@ import {
   resolveStockMarketStatusCase,
 } from '@onekeyhq/kit/src/views/Market/components/StockMarketStatusAlert';
 import { usePerpsNavigation } from '@onekeyhq/kit/src/views/Market/hooks/usePerpsNavigation';
-import { useTokenDetail } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/hooks/useTokenDetail';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EPerpPageEnterSource } from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
@@ -119,8 +118,7 @@ function BasicSwapStockTradeAlert({
   // The same underlying may have a Perps (contract) equivalent we can hand off
   // to while the stock market is closed — `perpsInfo.hlTicker` from the token
   // detail tells us, and drives the "with Perps" cases (1 & 4).
-  const { perpsInfo } = useTokenDetail();
-  const hlTicker = perpsInfo?.hlTicker;
+  const hlTicker = stockChannel.activeStockPerpsInfo?.hlTicker;
   const hasPerps = Boolean(hlTicker);
   // Attribute the perps handoff to the Trade tab for analytics.
   const { navigateToPerps } = usePerpsNavigation(EPerpPageEnterSource.Trade);

--- a/packages/kit/src/views/Swap/pages/components/SwapStockTradeProvider.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockTradeProvider.tsx
@@ -1,10 +1,11 @@
 import { createContext, useContext } from 'react';
 import type { PropsWithChildren } from 'react';
 
-import { useAutoRefreshTokenDetail } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/hooks/useAutoRefreshTokenDetail';
-import { useTokenDetail } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/hooks/useTokenDetail';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
-import type { IMarketPresetTokenContext } from '@onekeyhq/shared/types/swap/types';
+import type {
+  IMarketPresetTokenContext,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
 
 import {
   type IUseSwapStockChannelReturn,
@@ -15,57 +16,45 @@ const SwapStockTradeContext = createContext<
   IUseSwapStockChannelReturn | undefined
 >(undefined);
 
-function StockTokenDetailAutoRefreshContent({
-  isNative,
-  networkId,
-  tokenAddress,
-}: {
-  isNative: boolean;
-  networkId: string;
-  tokenAddress: string;
-}) {
-  useAutoRefreshTokenDetail({
-    tokenAddress,
-    networkId,
-    isNative,
-  });
-
-  return null;
-}
-
-function StockTokenDetailAutoRefresh() {
-  const { tokenAddress, networkId, isNative } = useTokenDetail();
-  if (!networkId || (!tokenAddress && !isNative)) {
-    return null;
-  }
-
-  return (
-    <StockTokenDetailAutoRefreshContent
-      tokenAddress={tokenAddress ?? ''}
-      networkId={networkId}
-      isNative={!!isNative}
-    />
-  );
-}
-
 export function SwapStockTradeProvider({
   children,
-  disableNativePayToken,
   marketPresetToken,
+  routeStockToken,
 }: PropsWithChildren<{
   marketPresetToken?: IMarketPresetTokenContext;
-  disableNativePayToken?: boolean;
+  routeStockToken?: ISwapToken;
 }>) {
   const stockChannel = useSwapStockChannel({
     marketPresetToken,
-    disableNativePayToken,
+    routeStockToken,
   });
 
   return (
     <SwapStockTradeContext.Provider value={stockChannel}>
-      <StockTokenDetailAutoRefresh />
       {children}
     </SwapStockTradeContext.Provider>
+  );
+}
+
+export function SwapStockTradeProviderBoundary({
+  children,
+  marketPresetToken,
+  routeStockToken,
+}: PropsWithChildren<{
+  marketPresetToken?: IMarketPresetTokenContext;
+  routeStockToken?: ISwapToken;
+}>) {
+  const context = useContext(SwapStockTradeContext);
+  if (context) {
+    return <>{children}</>;
+  }
+  return (
+    <SwapStockTradeProvider
+      marketPresetToken={marketPresetToken}
+      routeStockToken={routeStockToken}
+    >
+      {children}
+    </SwapStockTradeProvider>
   );
 }
 
@@ -77,4 +66,8 @@ export function useSwapStockTradeContext() {
     );
   }
   return context;
+}
+
+export function useOptionalSwapStockTradeContext() {
+  return useContext(SwapStockTradeContext);
 }

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
@@ -98,7 +98,9 @@ import {
   buildSwapTokenSelectorDisableNetworks,
   getSwapStockTokenDisplayName,
   isSwapStockMetadataPending,
+  isSwapStockTokenSearchMatch,
   isSwapTokenSelectorFromNetworkBridgeOnly,
+  shouldUseSwapStockSearchBaseTokens,
 } from './SwapTokenSelectModal.utils';
 
 import type { RouteProp } from '@react-navigation/core';
@@ -153,6 +155,7 @@ const SwapTokenSelectPage = ({
   const requestedSearchKeyword = searchKeyword
     ? searchKeywordDebounce
     : searchKeyword;
+  const isSearchKeywordSettling = searchKeyword !== requestedSearchKeyword;
   const [rawSwapNetworks] = useSwapNetworksAtom();
   const [swapNetworksIncludeAllNetworkBase] =
     useSwapNetworksIncludeAllNetworkAtom();
@@ -392,10 +395,34 @@ const SwapTokenSelectPage = ({
     searchAnalyticsOverride,
     swapNetworksIncludeAllNetwork,
   );
+  const shouldUseStockSearchBaseTokens = shouldUseSwapStockSearchBaseTokens({
+    currentTokensLength: currentTokens.length,
+    fetchLoading,
+    isSwapStockSelectTarget,
+    requestedSearchKeyword,
+  });
+  const {
+    fetchLoading: stockSearchBaseFetchLoading,
+    currentTokens: stockSearchBaseTokens,
+  } = useSwapTokenList(
+    type,
+    currentSelectNetwork?.networkId,
+    '',
+    swapTypeSwitch,
+    requestLpToken,
+    searchAnalyticsOverride,
+    swapNetworksIncludeAllNetwork,
+    {
+      enabled: shouldUseStockSearchBaseTokens,
+    },
+  );
   const stockMetadataRequestSnapshot = useMemo<IStockMetadataRequest>(() => {
     if (!isSwapStockSelectTarget) {
       return { tokenAddressEntries: [], tokenKey: '' };
     }
+    const metadataSourceTokens = shouldUseStockSearchBaseTokens
+      ? stockSearchBaseTokens
+      : currentTokens;
     const tokenAddressMap = new Map<
       string,
       {
@@ -404,7 +431,7 @@ const SwapTokenSelectPage = ({
         isNative: boolean;
       }
     >();
-    for (const item of currentTokens) {
+    for (const item of metadataSourceTokens) {
       const rawItem = getRawSwapToken(item);
       const key = buildSwapStockMetadataKey({
         contractAddress: rawItem.contractAddress,
@@ -423,7 +450,12 @@ const SwapTokenSelectPage = ({
       tokenAddressEntries,
       tokenKey: tokenAddressEntries.map(([key]) => key).join(','),
     };
-  }, [currentTokens, isSwapStockSelectTarget]);
+  }, [
+    currentTokens,
+    isSwapStockSelectTarget,
+    shouldUseStockSearchBaseTokens,
+    stockSearchBaseTokens,
+  ]);
   const stockMetadataRequestRef = useRef<IStockMetadataRequest>(
     stockMetadataRequestSnapshot,
   );
@@ -492,10 +524,52 @@ const SwapTokenSelectPage = ({
     stockMetadataLoading,
     stockMetadataTokenKey,
   });
+  const stockSearchFallbackTokens = useMemo(() => {
+    if (
+      !isSwapStockSelectTarget ||
+      !requestedSearchKeyword ||
+      currentTokens.length > 0 ||
+      stockMetadataPending
+    ) {
+      return EMPTY_SWAP_TOKEN_LIST;
+    }
+
+    return stockSearchBaseTokens.filter((item) => {
+      const rawItem = getRawSwapToken(item);
+      const stock =
+        rawItem.contractAddress && rawItem.networkId
+          ? stockMetadataMap?.[
+              buildSwapStockMetadataKey({
+                contractAddress: rawItem.contractAddress,
+                networkId: rawItem.networkId,
+              })
+            ]
+          : undefined;
+      return isSwapStockTokenSearchMatch({
+        keyword: requestedSearchKeyword,
+        stock,
+      });
+    });
+  }, [
+    currentTokens.length,
+    isSwapStockSelectTarget,
+    requestedSearchKeyword,
+    stockSearchBaseTokens,
+    stockMetadataMap,
+    stockMetadataPending,
+  ]);
+  const tokensForDisplay =
+    stockSearchFallbackTokens.length > 0
+      ? stockSearchFallbackTokens
+      : currentTokens;
   const displayTokens = stockMetadataPending
     ? EMPTY_SWAP_TOKEN_LIST
-    : currentTokens;
-  const tokenListLoading = fetchLoading || stockMetadataPending;
+    : tokensForDisplay;
+  const tokenListLoading =
+    fetchLoading ||
+    (shouldUseStockSearchBaseTokens && stockSearchBaseFetchLoading) ||
+    stockMetadataPending ||
+    isSearchKeywordSettling;
   const alertIndex = useMemo(
     () =>
       displayTokens.findIndex((item) => {

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.utils.test.ts
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.utils.test.ts
@@ -10,7 +10,9 @@ import {
   buildSwapTokenSelectorDisableNetworks,
   getSwapStockTokenDisplayName,
   isSwapStockMetadataPending,
+  isSwapStockTokenSearchMatch,
   isSwapTokenSelectorFromNetworkBridgeOnly,
+  shouldUseSwapStockSearchBaseTokens,
 } from './SwapTokenSelectModal.utils';
 
 const fromToken = {
@@ -129,6 +131,35 @@ describe('SwapTokenSelectModal.utils', () => {
     ).toBe(false);
   });
 
+  it('waits for the main Stock search before enabling base-token fallback', () => {
+    expect(
+      shouldUseSwapStockSearchBaseTokens({
+        currentTokensLength: 0,
+        fetchLoading: true,
+        isSwapStockSelectTarget: true,
+        requestedSearchKeyword: 'apple',
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldUseSwapStockSearchBaseTokens({
+        currentTokensLength: 0,
+        fetchLoading: false,
+        isSwapStockSelectTarget: true,
+        requestedSearchKeyword: 'apple',
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldUseSwapStockSearchBaseTokens({
+        currentTokensLength: 1,
+        fetchLoading: false,
+        isSwapStockSelectTarget: true,
+        requestedSearchKeyword: 'apple',
+      }),
+    ).toBe(false);
+  });
+
   it('does not insert unsupported default networks into Stock selector', () => {
     const stockNetworksBase = [
       buildSwapNetwork({ isAllNetworks: true, networkId: 'onekeyall--0' }),
@@ -185,5 +216,37 @@ describe('SwapTokenSelectModal.utils', () => {
         tokenName: 'Robinhood (Ondo Tokenized)',
       }),
     ).toBe('Robinhood');
+  });
+
+  it('only matches Stock search fallback rows with Stock metadata', () => {
+    expect(
+      isSwapStockTokenSearchMatch({
+        keyword: 'usdc',
+      }),
+    ).toBe(false);
+
+    expect(
+      isSwapStockTokenSearchMatch({
+        keyword: 'aapl',
+        stock: {
+          title: 'Apple',
+          subtitle: 'Apple Inc.',
+          underlyingAssetName: 'Apple Inc.',
+          underlyingAssetTicker: 'AAPL',
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      isSwapStockTokenSearchMatch({
+        keyword: '0x1234',
+        stock: {
+          title: 'Apple',
+          subtitle: 'Apple Inc.',
+          underlyingAssetName: 'Apple Inc.',
+          underlyingAssetTicker: 'AAPL',
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.utils.ts
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.utils.ts
@@ -37,6 +37,33 @@ export function getSwapStockTokenDisplayName({
   );
 }
 
+export function isSwapStockTokenSearchMatch({
+  keyword,
+  stock,
+}: {
+  keyword?: string;
+  stock?: Pick<
+    IMarketStockInfo,
+    'subtitle' | 'title' | 'underlyingAssetName' | 'underlyingAssetTicker'
+  >;
+}) {
+  if (!stock) {
+    return false;
+  }
+
+  const normalizedKeyword = keyword?.trim().toLowerCase();
+  if (!normalizedKeyword) {
+    return true;
+  }
+
+  return [
+    stock?.title,
+    stock?.subtitle,
+    stock?.underlyingAssetName,
+    stock?.underlyingAssetTicker,
+  ].some((value) => value?.toLowerCase().includes(normalizedKeyword));
+}
+
 export function isSwapStockMetadataPending({
   isSwapStockSelectTarget,
   resolvedStockMetadataTokenKey,
@@ -53,6 +80,25 @@ export function isSwapStockMetadataPending({
     stockMetadataTokenKey &&
     (stockMetadataLoading ||
       resolvedStockMetadataTokenKey !== stockMetadataTokenKey),
+  );
+}
+
+export function shouldUseSwapStockSearchBaseTokens({
+  currentTokensLength,
+  fetchLoading,
+  isSwapStockSelectTarget,
+  requestedSearchKeyword,
+}: {
+  currentTokensLength: number;
+  fetchLoading: boolean;
+  isSwapStockSelectTarget: boolean;
+  requestedSearchKeyword?: string;
+}) {
+  return Boolean(
+    isSwapStockSelectTarget &&
+    requestedSearchKeyword &&
+    !fetchLoading &&
+    currentTokensLength === 0,
   );
 }
 


### PR DESCRIPTION
## Issues
- Fixes OK-56922
- OK-56920
- OK-56923

## Summary
- Rebuild the closed PR #12192 Stock fixes on top of #12193's branch as a clean product-only stacked PR.
- Isolate Stock detail/display state from generic Market detail state while keeping quote and submit readiness gated by fresh Stock channel data.
- Harden Stock selector fallback, pay-token readiness, chart fallback, and token-list loading ownership to avoid stale or non-Stock state leaking into Stock trading.

## Intent & Context
The previous PR #12192 accumulated repeated review feedback because it fixed Stock websocket price refresh, Market-detail Stock identity isolation, and Stock selector first-load behavior through several local guards. This draft keeps the useful implementation direction but reworks the state boundaries so display identity, detail readiness, pay-token readiness, chart readiness, and selector request loading are not all driven by one broad loading state.

This PR is stacked on #12193 because the requested base branch is `codex/skill-architecture-guards`.

## Root Cause
Stock mode was still depending on shared or overly broad readiness signals:
- Market detail token state could seed or block Stock display after entering Stock from a Market detail page.
- Stock first-frame display, chart display, quote readiness, market status, and pay-token readiness were coupled too tightly.
- Stock selector fallback could use ordinary token fields without requiring Stock metadata.
- `useSwapTokenList` used a shared global fetching atom, so concurrent main-search and fallback-search hook instances could affect each other's loading and empty states.

## Design Decisions
- Keep a Stock-owned channel state for route/default/current Stock identity and use it as the owner for desktop Stock UI, instead of reading generic Market active-token state directly.
- Allow first-frame display to seed from route/import/current Stock identity, but keep quote/submission behavior gated by Stock detail, market status, and pay-token readiness.
- Treat Stock selector fallback as Stock-metadata-only. Ordinary token symbol/name/address matches are not enough for a row to enter Stock selection.
- Scope token-list loading inside each `useSwapTokenList` hook instance by request key so fallback searches cannot flip the main Stock search back into loading.
- Let chart fallback failure settle as a completed current-scope lookup with no CoinGecko id, so the chart can render its empty state instead of an infinite skeleton.

## Changes Detail
- `useSwapStockChannel` and Stock channel utilities now own Stock entry identity, display seed, current Stock token, market status, pay token, and recent execution pair restoration.
- `SwapStockDesktopContainer` consumes Stock channel state for Stock header/chart/form display and uses Market websocket OHLCV updates for Stock price/chart data.
- `useSwapStockTradeInputs` only enables Buy input after the current pay token exists in the current selectable pay-token set and `payTokenStatus` is ready.
- `SwapTokenSelectModal` and its utils require Stock metadata before fallback search rows can match and be selected in Stock mode.
- `useSwapTokens` uses request-key-scoped local loading for each token-list hook instance.
- Tests cover Stock channel identity helpers, pay-token candidate matching, Stock selector fallback readiness, and Stock-metadata-only fallback search.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop, Web, Extension, Mobile where Swap/Stock selector or Stock trade UI is used.
- **Risk Areas**: Stock first-frame behavior, Market-to-Stock entry, token selector search/fallback, chart empty/fallback state, and Buy-side pay-token readiness.

## Test plan
- [x] `yarn install --immutable` (completed with existing peer-dependency warnings)
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] `yarn jest packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.utils.test.ts packages/kit/src/views/Swap/hooks/swapStockChannelUtils.test.ts --runInBand`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
