### PR TITLE
fix: polish perps portfolio chart and mobile dialogs

### DIFF
--- a/packages/kit/src/views/Perp/components/PerpDialogLayout.ts
+++ b/packages/kit/src/views/Perp/components/PerpDialogLayout.ts
@@ -1,7 +1,7 @@
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 export const PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS = platformEnv.isNative
-  ? ({ pb: '$8' } as const)
+  ? ({ pb: '$5' } as const)
   : undefined;
 
 export const PERP_DIALOG_BUTTON_SIZE = platformEnv.isNative

--- a/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
+++ b/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
@@ -784,17 +784,23 @@ function PerpPortfolioContentComponent({
             height={chartHeight}
             onHover={handleHover}
             lineColor="#2EAA40"
+            secondaryLineData={isPnl ? undefined : chartSeriesData}
+            secondaryLineColor="#2EAA40"
+            secondaryLineWidth={3}
             topColor="#2EAA4026"
             bottomColor="#2EAA4000"
             lineWidth={3}
             showPriceScale
-            showHorzGridLines
+            showHorzGridLines={isPnl}
             priceScaleMargins={CHART_PRICE_SCALE_MARGINS}
+            priceScaleEntireTextOnly={!isPnl}
             priceFormatter={formatChartUsdPrice}
             fontSize={11}
-            seriesType={isPnl ? 'baseline' : 'area'}
+            seriesType={isPnl ? 'baseline' : 'dotted-area'}
             baselineOptions={isPnl ? baselineOptions : undefined}
-            showLastValue
+            showLastValue={isPnl}
+            showLastPointMarker={isPnl ? undefined : false}
+            pulseLastPoint={!isPnl}
           />
         </YStack>
       )}


### PR DESCRIPTION
## Summary
- Update the Perps portfolio account value chart to use the stock-style dotted area treatment while keeping PnL on the existing baseline chart.
- Reduce the shared Perps native mobile dialog bottom padding from `$8` to `$5` so bottom sheets no longer add extra spacing beyond the default dialog content padding.

## Intent & Context
The Perps portfolio account value chart needed to visually match the stock chart style more closely, specifically the dotted fill, hidden horizontal grid/current value line, pulse tail marker, and preserved green line weight. The mobile Perps enable-trading related dialogs also showed excessive bottom whitespace, suggesting an extra Perps-level padding was being layered on top of the dialog/sheet default spacing.

## Root Cause
The portfolio account value chart was still using the default area-series treatment, while the stock chart uses the dotted-area series with a pulse tail and no last-value price line. For mobile dialogs, Perps overrode native dialog content bottom padding to `$8`; the shared native Dialog content already provides its own bottom padding, so Perps was making those sheets visibly taller at the bottom.

## Design Decisions
- Kept PnL charts on the existing baseline series so positive/negative PnL behavior remains unchanged.
- Applied the stock-style chart props only when `chartType` is account value.
- Kept the line width at `3` to preserve the previous Perps chart stroke weight.
- Changed the shared Perps mobile dialog content padding to `$5`, matching the component default instead of adding a larger Perps-specific bottom space.
- Reverted the earlier attempt to add custom chart time-scale padding, since it did not visibly improve the spacing.

## Changes Detail
- `PerpPortfolioContent.tsx`: switches account value charts to `dotted-area`, hides grid/last-value marker for account value, adds pulse tail marker, and preserves the thicker green stroke.
- `PerpDialogLayout.ts`: reduces native Perps dialog content bottom padding from `$8` to `$5` for dialogs that share `PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile and Web/Desktop Perps portfolio chart; native mobile Perps dialogs
- **Risk Areas**: Shared Perps mobile dialog padding affects all dialogs that use `PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS`, including margin mode, account mode, leverage, order confirm, and related order-management dialogs.

## Test plan
- [x] Run `yarn lint:staged`
- [x] Run `yarn tsc:staged`
- [x] Run `yarn app:ios` and confirm the iOS development build installs and launches
- [ ] Verify Perps portfolio account value chart visually matches the stock-style dotted chart
- [ ] Verify Perps mobile dialogs no longer show excessive bottom whitespace
