### PR TITLE
fix: show empty market price change as placeholder(OK-56973)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenData.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenData.ts
@@ -6,6 +6,7 @@ export interface IMarketToken {
   decimals: number;
   price: number;
   change24h: number;
+  priceChangeRaw?: string;
   marketCap: number;
   liquidity: number;
   transactions: number;

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenListItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenListItem.tsx
@@ -62,6 +62,9 @@ const BasicTokenListItem: FC<ITokenListItemProps> = ({
   const themeName = useThemeName();
   const isDarkMode = themeName?.includes('dark');
   const isHighlighted = Boolean(isPrimed || (isDragging && isDarkMode));
+  const priceChange =
+    item.priceChangeRaw === '-' ? item.priceChangeRaw : item.change24h;
+
   return (
     <XStack
       testID={MarketTestIDs.tokenListItem(item.symbol)}
@@ -108,7 +111,7 @@ const BasicTokenListItem: FC<ITokenListItemProps> = ({
         >
           {item.price}
         </NumberSizeableText>
-        <PriceChangeBadge change={item.change24h} />
+        <PriceChangeBadge change={priceChange} />
       </XStack>
     </XStack>
   );

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
@@ -192,7 +192,15 @@ export const useColumnsDesktop = (
         })}(%)`,
       dataIndex: 'change24h',
       columnProps: { flex: 1 },
-      render: (text: number) => {
+      render: (text: number, record: IMarketToken) => {
+        if (record.priceChangeRaw === '-') {
+          return (
+            <SizableText size="$bodyMd" color="$textSubdued">
+              --
+            </SizableText>
+          );
+        }
+
         const { changeColor, showPlusMinusSigns } = getTokenPriceChangeStyle({
           priceChange: text,
         });

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsMobile.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsMobile.tsx
@@ -164,23 +164,35 @@ export const useColumnsMobile = (
       dataIndex: 'change24h',
       columnWidth: '50%',
       align: 'right',
-      render: (_, record: IMarketToken) => (
-        <XStack justifyContent="flex-end" alignItems="center" gap="$2" mr="$5">
-          <NumberSizeableText
-            userSelect="none"
-            flexShrink={1}
-            numberOfLines={1}
-            size="$bodyLgMedium"
-            formatter="price"
-            formatterOptions={{
-              currency: '$',
-            }}
+      render: (_, record: IMarketToken) => {
+        const priceChange =
+          record.priceChangeRaw === '-'
+            ? record.priceChangeRaw
+            : record.change24h;
+
+        return (
+          <XStack
+            justifyContent="flex-end"
+            alignItems="center"
+            gap="$2"
+            mr="$5"
           >
-            {record.price}
-          </NumberSizeableText>
-          <PriceChangeBadge change={record.change24h} />
-        </XStack>
-      ),
+            <NumberSizeableText
+              userSelect="none"
+              flexShrink={1}
+              numberOfLines={1}
+              size="$bodyLgMedium"
+              formatter="price"
+              formatterOptions={{
+                currency: '$',
+              }}
+            >
+              {record.price}
+            </NumberSizeableText>
+            <PriceChangeBadge change={priceChange} />
+          </XStack>
+        );
+      },
       renderSkeleton: () => (
         <XStack
           justifyContent="flex-end"

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts
@@ -104,6 +104,63 @@ describe('stock metadata values', () => {
     );
 
     expect(token.change24h).toBe(-0.62);
+    expect(token.priceChangeRaw).toBe('-0.62');
+  });
+
+  test('keeps raw dash price change without treating zero as missing', () => {
+    const baseToken = {
+      address: '0x390a684ef9cade28a7ad0dfa61ab1eb3842618c4',
+      name: 'Token',
+      symbol: 'TOKEN',
+      decimals: 18,
+    };
+
+    const missingChangeToken = transformApiItemToToken(
+      {
+        ...baseToken,
+        priceChange24hPercent: '-',
+      },
+      {
+        chainId: 'evm--1',
+        networkLogoUri: '',
+      },
+    );
+    const zeroChangeToken = transformApiItemToToken(
+      {
+        ...baseToken,
+        priceChange24hPercent: '0',
+      },
+      {
+        chainId: 'evm--1',
+        networkLogoUri: '',
+      },
+    );
+
+    expect(missingChangeToken.change24h).toBe(0);
+    expect(missingChangeToken.priceChangeRaw).toBe('-');
+    expect(zeroChangeToken.change24h).toBe(0);
+    expect(zeroChangeToken.priceChangeRaw).toBe('0');
+  });
+
+  test('keeps raw dash price change in selected time range', () => {
+    const token = transformApiItemToToken(
+      {
+        address: '0x390a684ef9cade28a7ad0dfa61ab1eb3842618c4',
+        name: 'Token',
+        symbol: 'TOKEN',
+        decimals: 18,
+        priceChange1hPercent: '-',
+        priceChange24hPercent: '1',
+      },
+      {
+        chainId: 'evm--1',
+        networkLogoUri: '',
+        timeRange: '1h',
+      },
+    );
+
+    expect(token.change24h).toBe(0);
+    expect(token.priceChangeRaw).toBe('-');
   });
 });
 

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
@@ -204,6 +204,7 @@ export function transformApiItemToToken(
     address: item.address,
     price: safeNumber(item.price),
     change24h: priceChange,
+    priceChangeRaw: priceChangeValue,
     marketCap: safeNumber(getStockMarketCapValue(item) ?? item.marketCap),
     liquidity: safeNumber(item.liquidity),
     transactions,

--- a/packages/kit/src/views/Market/MarketHomeV2/components/PriceChangeBadge.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/PriceChangeBadge.tsx
@@ -1,14 +1,15 @@
 import type { FC } from 'react';
 import { useMemo } from 'react';
 
-import { NumberSizeableText, XStack } from '@onekeyhq/components';
+import { NumberSizeableText, SizableText, XStack } from '@onekeyhq/components';
 
 interface IPriceChangeBadgeProps {
   change: number | string;
 }
 
 export const PriceChangeBadge: FC<IPriceChangeBadgeProps> = ({ change }) => {
-  const changeNum = Number(change);
+  const isPlaceholder = change === '-';
+  const changeNum = isPlaceholder ? 0 : Number(change);
 
   const backgroundColor = useMemo(() => {
     if (changeNum > 0) return '$bgSuccessStrong';
@@ -25,19 +26,25 @@ export const PriceChangeBadge: FC<IPriceChangeBadgeProps> = ({ change }) => {
       backgroundColor={backgroundColor}
       borderRadius="$2"
     >
-      <NumberSizeableText
-        userSelect="none"
-        numberOfLines={1}
-        size="$bodyMdMedium"
-        fontSize={Math.abs(changeNum) >= 10_000 ? 13 : undefined}
-        color="white"
-        formatter="priceChangeCapped"
-        formatterOptions={{
-          showPlusMinusSigns: true,
-        }}
-      >
-        {change}
-      </NumberSizeableText>
+      {isPlaceholder ? (
+        <SizableText userSelect="none" size="$bodyMdMedium" color="white">
+          --
+        </SizableText>
+      ) : (
+        <NumberSizeableText
+          userSelect="none"
+          numberOfLines={1}
+          size="$bodyMdMedium"
+          fontSize={Math.abs(changeNum) >= 10_000 ? 13 : undefined}
+          color="white"
+          formatter="priceChangeCapped"
+          formatterOptions={{
+            showPlusMinusSigns: true,
+          }}
+        >
+          {change}
+        </NumberSizeableText>
+      )}
     </XStack>
   );
 };


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56973](https://onekeyhq.atlassian.net/browse/OK-56973)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Limit the fix to the Market Home V2 token list/table price-change display.
- Keep `change24h` as the existing numeric value so sorting, live overrides, and other numeric consumers stay unchanged.
- Preserve the selected raw price-change field and render API `"-"` values as `--` on desktop and mobile, while real `0` still displays as `0.00%`.

## Intent & Context
The Market page can receive price-change fields such as `priceChange1hPercent` or `priceChange24hPercent` as `"-"` when the backend has no data. The Market Home V2 token list/table should display `--` for this missing state without broadening behavior changes across Market detail or selector surfaces.

## Design Decisions
- Preserve the release branch `change24h: number` contract and fallback behavior.
- Carry the selected raw price-change string as `priceChangeRaw` so display code can distinguish backend `"-"` from a real numeric zero.
- Keep table column `dataIndex` as `change24h`; only desktop/mobile cell rendering checks whether `priceChangeRaw === "-"`.
- Avoid changes to Market detail, TokenSelector, banner detail, and WebSocket override handling.

## Changes Detail
- Added optional `IMarketToken.priceChangeRaw`.
- Preserve the selected raw price-change field in `tokenListHelpers.ts`.
- Updated the Market Home V2 desktop table change column to render `--` when `priceChangeRaw === "-"`.
- Updated mobile token list rows and the mobile price-change badge to render `--` for the same raw dash state.
- Added regression tests for missing `"-"` versus real `"0"` and selected time range display handling.

## Risk Assessment
- **Risk Level**: Low
- **Affected Area**: Market Home V2 desktop/mobile token list price-change display.
- **Non-Goals**: No behavior changes for Market detail, TokenSelector, banner detail, live override merging, or existing numeric `change24h` consumers.

## Test plan
- [x] `yarn jest packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts`
- [x] `yarn lint:staged`
- [ ] `yarn tsc:staged` (blocked by existing unrelated release branch type errors in web-embed, Sui/jsonRpc, Ledger, lightweight-charts, Borrow chart, Market chartUtils, and Prime web-embed paths)

[OK-56973]: https://onekeyhq.atlassian.net/browse/OK-56973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ