### PR TITLE
feat: stock trade UX polish — K-line dot, order history clear (OK-56988)(OK-56992)(OK-56994)

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntitySwapHistory.test.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntitySwapHistory.test.ts
@@ -97,6 +97,23 @@ const swapSuccess = createHistoryItem({
   fromToken: usdc,
   toToken: createToken('ETH'),
 });
+// A stock token traded through a non-market channel: isStock is true, but the
+// row lives in the limit / private-send surfaces and is hidden from the stock
+// Order History list, so a stock "Clear" must not delete it.
+const stockPrivateSend = createHistoryItem({
+  id: 'stock-private-send',
+  protocol: EProtocolOfExchange.PRIVATE_SEND,
+  status: ESwapTxHistoryStatus.SUCCESS,
+  fromToken: stockToken,
+  toToken: usdc,
+});
+const stockLimit = createHistoryItem({
+  id: 'stock-limit',
+  protocol: EProtocolOfExchange.LIMIT,
+  status: ESwapTxHistoryStatus.SUCCESS,
+  fromToken: usdc,
+  toToken: stockToken,
+});
 
 async function runDelete(
   histories: ISwapTxHistory[],
@@ -133,5 +150,23 @@ describe('SimpleDbEntitySwapHistory.deleteSwapHistoryItem onlyStock', () => {
   it('excludeStock stays the mirror: clears swap, keeps every stock trade', async () => {
     const kept = await runDelete(all, undefined, { excludeStock: true });
     expect(kept).toEqual([stockPending, stockSuccess]);
+  });
+
+  it('onlyStock + excludeProtocols keeps stock-token limit/private-send rows', async () => {
+    // Mirrors the stock Order History guards: only the visible market-stock set
+    // is cleared; stock-token limit / private-send rows (hidden on that panel)
+    // survive instead of being silently deleted.
+    const kept = await runDelete(
+      [stockSuccess, stockPrivateSend, stockLimit, swapSuccess],
+      undefined,
+      {
+        onlyStock: true,
+        excludeProtocols: [
+          EProtocolOfExchange.LIMIT,
+          EProtocolOfExchange.PRIVATE_SEND,
+        ],
+      },
+    );
+    expect(kept).toEqual([stockPrivateSend, stockLimit, swapSuccess]);
   });
 });

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntitySwapHistory.test.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntitySwapHistory.test.ts
@@ -1,0 +1,137 @@
+import type {
+  ISwapToken,
+  ISwapTxHistory,
+} from '@onekeyhq/shared/types/swap/types';
+import {
+  EProtocolOfExchange,
+  ESwapTxHistoryStatus,
+} from '@onekeyhq/shared/types/swap/types';
+
+import { SimpleDbEntitySwapHistory } from './SimpleDbEntitySwapHistory';
+
+const baseToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xtoken',
+  decimals: 18,
+  symbol: 'TOKEN',
+};
+
+function createToken(
+  symbol: string,
+  contractAddress = `0x${symbol}`,
+  extra?: Partial<ISwapToken>,
+): ISwapToken {
+  return { ...baseToken, contractAddress, symbol, ...extra };
+}
+
+const usdc = createToken('USDC', '0xUSDC');
+const stockToken = createToken('AAPLon', '0xAAPLon', { isStock: true });
+
+function createHistoryItem({
+  id,
+  protocol,
+  status,
+  fromToken = usdc,
+  toToken = usdc,
+}: {
+  id: string;
+  protocol: EProtocolOfExchange;
+  status: ESwapTxHistoryStatus;
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+}): ISwapTxHistory {
+  return {
+    protocol,
+    status,
+    currency: '$',
+    accountInfo: {
+      sender: { networkId: baseToken.networkId },
+      receiver: { networkId: baseToken.networkId },
+    },
+    baseInfo: {
+      fromToken,
+      toToken,
+      fromAmount: '1',
+      toAmount: '1',
+    },
+    txInfo: {
+      sender: '0xsender',
+      receiver: '0xreceiver',
+      txId: id,
+    },
+    date: { created: 1, updated: 1 },
+    swapInfo: {
+      instantRate: '',
+      provider: { provider: 'onekey', providerName: 'OneKey' },
+      orderId: id,
+    },
+  };
+}
+
+// Buy stock = pay stablecoin -> receive stock token (protocol echoed as SWAP).
+const stockPending = createHistoryItem({
+  id: 'stock-pending',
+  protocol: EProtocolOfExchange.SWAP,
+  status: ESwapTxHistoryStatus.PENDING,
+  fromToken: usdc,
+  toToken: stockToken,
+});
+const stockSuccess = createHistoryItem({
+  id: 'stock-success',
+  protocol: EProtocolOfExchange.STOCK,
+  status: ESwapTxHistoryStatus.SUCCESS,
+  fromToken: stockToken,
+  toToken: usdc,
+});
+const swapPending = createHistoryItem({
+  id: 'swap-pending',
+  protocol: EProtocolOfExchange.SWAP,
+  status: ESwapTxHistoryStatus.PENDING,
+  fromToken: usdc,
+  toToken: createToken('ETH'),
+});
+const swapSuccess = createHistoryItem({
+  id: 'swap-success',
+  protocol: EProtocolOfExchange.SWAP,
+  status: ESwapTxHistoryStatus.SUCCESS,
+  fromToken: usdc,
+  toToken: createToken('ETH'),
+});
+
+async function runDelete(
+  histories: ISwapTxHistory[],
+  ...args: Parameters<SimpleDbEntitySwapHistory['deleteSwapHistoryItem']>
+): Promise<ISwapTxHistory[]> {
+  const entity = new SimpleDbEntitySwapHistory();
+  jest.spyOn(entity, 'getRawData').mockResolvedValue({ histories });
+  const setRawData = jest
+    .spyOn(entity, 'setRawData')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockResolvedValue(undefined as any);
+  await entity.deleteSwapHistoryItem(...args);
+  const written = setRawData.mock.calls[0]?.[0] as {
+    histories: ISwapTxHistory[];
+  };
+  return written.histories;
+}
+
+describe('SimpleDbEntitySwapHistory.deleteSwapHistoryItem onlyStock', () => {
+  const all = [stockPending, stockSuccess, swapPending, swapSuccess];
+
+  it('onlyStock clears every stock trade and keeps swap/bridge history', async () => {
+    const kept = await runDelete(all, undefined, { onlyStock: true });
+    expect(kept).toEqual([swapPending, swapSuccess]);
+  });
+
+  it('onlyStock + PENDING clears only pending stock, keeps the rest', async () => {
+    const kept = await runDelete(all, [ESwapTxHistoryStatus.PENDING], {
+      onlyStock: true,
+    });
+    expect(kept).toEqual([stockSuccess, swapPending, swapSuccess]);
+  });
+
+  it('excludeStock stays the mirror: clears swap, keeps every stock trade', async () => {
+    const kept = await runDelete(all, undefined, { excludeStock: true });
+    expect(kept).toEqual([stockPending, stockSuccess]);
+  });
+});

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntitySwapHistory.test.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntitySwapHistory.test.ts
@@ -114,6 +114,15 @@ const stockLimit = createHistoryItem({
   fromToken: usdc,
   toToken: stockToken,
 });
+// Canceling rows are grouped under "Pending" in the list, so a pending clear
+// must remove them too.
+const stockCanceling = createHistoryItem({
+  id: 'stock-canceling',
+  protocol: EProtocolOfExchange.STOCK,
+  status: ESwapTxHistoryStatus.CANCELING,
+  fromToken: stockToken,
+  toToken: usdc,
+});
 
 async function runDelete(
   histories: ISwapTxHistory[],
@@ -168,5 +177,14 @@ describe('SimpleDbEntitySwapHistory.deleteSwapHistoryItem onlyStock', () => {
       },
     );
     expect(kept).toEqual([stockPrivateSend, stockLimit, swapSuccess]);
+  });
+
+  it('pending clear with [PENDING, CANCELING] also removes canceling stock', async () => {
+    const kept = await runDelete(
+      [stockPending, stockCanceling, stockSuccess, swapSuccess],
+      [ESwapTxHistoryStatus.PENDING, ESwapTxHistoryStatus.CANCELING],
+      { onlyStock: true },
+    );
+    expect(kept).toEqual([stockSuccess, swapSuccess]);
   });
 });

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntitySwapHistory.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntitySwapHistory.ts
@@ -122,6 +122,9 @@ export class SimpleDbEntitySwapHistory extends SimpleDbEntityBase<ISwapTxHistory
       // isStock flag, so clearing it must use the same rule (protocol exclusion
       // alone would delete stock orders the user can't see on that tab).
       excludeStock?: boolean;
+      // Mirror of excludeStock for the Stock history surface: only clear stock
+      // trades, keeping everything the Swap/Bridge list owns.
+      onlyStock?: boolean;
     },
   ) {
     const shouldKeepHistory = (history: ISwapTxHistory) => {
@@ -134,6 +137,9 @@ export class SimpleDbEntitySwapHistory extends SimpleDbEntityBase<ISwapTxHistory
         return true;
       }
       if (options?.excludeStock && isStockSwapHistoryItem(history)) {
+        return true;
+      }
+      if (options?.onlyStock && !isStockSwapHistoryItem(history)) {
         return true;
       }
       return statuses ? !statuses.includes(history.status) : false;

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -2068,6 +2068,9 @@ export default class ServiceSwap extends ServiceBase {
       // Keep stock trades (the Swap/Bridge tab hides them via the token-level
       // isStock flag, so clearing it must not delete stock orders).
       excludeStock?: boolean;
+      // Mirror of excludeStock for the Stock history surface: only clear stock
+      // trades, keeping everything the Swap/Bridge list owns.
+      onlyStock?: boolean;
     },
   ) {
     await this.backgroundApi.simpleDb.swapHistory.deleteSwapHistoryItem(
@@ -2088,6 +2091,9 @@ export default class ServiceSwap extends ServiceBase {
           return false;
         }
         if (options?.excludeStock && isStockSwapHistoryItem(item)) {
+          return false;
+        }
+        if (options?.onlyStock && !isStockSwapHistoryItem(item)) {
           return false;
         }
         return statuses ? statuses.includes(item.status) : true;
@@ -2111,12 +2117,19 @@ export default class ServiceSwap extends ServiceBase {
         if (options?.excludeStock && isStockSwapHistoryItem(item)) {
           return true;
         }
+        if (options?.onlyStock && !isStockSwapHistoryItem(item)) {
+          return true;
+        }
         return statuses ? !statuses.includes(item.status) : false;
       }),
     }));
     await Promise.all(
       deleteHistoryIds.map((id) => this.cleanHistoryStateIntervals(id)),
     );
+    // The history list refreshes off the pending-status key, which does not
+    // change when only finished orders are removed. Signal list views to
+    // re-fetch so a clear is reflected immediately instead of leaving stale rows.
+    appEventBus.emit(EAppEventBusNames.RefreshSwapHistoryList, undefined);
   }
 
   @backgroundMethod()
@@ -2140,6 +2153,11 @@ export default class ServiceSwap extends ServiceBase {
       ),
     }));
     await this.cleanHistoryStateIntervals(deleteHistoryId);
+    // Deleting a finished order does not change the pending-status key the list
+    // refreshes off, so signal list views to re-fetch (same reason as the
+    // batch clean above) — otherwise the deleted row lingers until a pending
+    // order transitions.
+    appEventBus.emit(EAppEventBusNames.RefreshSwapHistoryList, undefined);
   }
 
   @backgroundMethod()

--- a/packages/kit/src/components/LightweightChart/LightweightChart.tsx
+++ b/packages/kit/src/components/LightweightChart/LightweightChart.tsx
@@ -117,6 +117,7 @@ export function LightweightChart({
     let chart: IChartApi | undefined;
     let lastPointPositionUpdater: (() => void) | undefined;
     let lastPointRafId: number | undefined;
+    let resizeRafId: number | undefined;
 
     // Capture container for cleanup
     const container = chartContainerRef.current;
@@ -311,7 +312,19 @@ export function LightweightChart({
           if (entries.length === 0 || entries[0].target !== container) return;
           const { width: newWidth } = entries[0].contentRect;
           chart?.applyOptions({ width: newWidth });
-          lastPointPositionUpdater?.();
+          // applyOptions relays out the chart (bar spacing / right-edge anchor)
+          // on the next paint frame; reading coordinates synchronously here
+          // returns the pre-resize layout, so the pulse dot would freeze at its
+          // old x. lockVisibleTimeRangeOnResize also means the visible-range
+          // subscription never fires on resize to correct it. Recompute after
+          // the frame settles, mirroring the init path's rAF fallback.
+          if (resizeRafId !== undefined) {
+            cancelAnimationFrame(resizeRafId);
+          }
+          resizeRafId = requestAnimationFrame(() => {
+            if (cancelled) return;
+            lastPointPositionUpdater?.();
+          });
         });
 
         resizeObserver.observe(container);
@@ -323,6 +336,9 @@ export function LightweightChart({
       // Cleanup in correct order
       if (lastPointRafId !== undefined) {
         cancelAnimationFrame(lastPointRafId);
+      }
+      if (resizeRafId !== undefined) {
+        cancelAnimationFrame(resizeRafId);
       }
       resizeObserver?.disconnect();
       chart?.remove();

--- a/packages/kit/src/views/Swap/hooks/useSwapMarketHistoryList.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapMarketHistoryList.ts
@@ -1,0 +1,41 @@
+import { useEffect, useMemo } from 'react';
+
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { useInAppNotificationAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
+import type { EProtocolOfExchange } from '@onekeyhq/shared/types/swap/types';
+
+import { getSwapMarketPendingHistoryKey } from '../utils/swapMarketHistory';
+
+// Reads the persisted swap history and keeps it fresh on the two signals that
+// can change it: a pending order transitioning (via the derived key, which also
+// drives pending-status polling) and the explicit RefreshSwapHistoryList event
+// cleanSwapHistoryItems emits — the pending key cannot detect a finished-order
+// clear, so the event covers that gap. Shared by the list view and the clear
+// control so the fetch + subscription is defined once.
+export function useSwapMarketHistoryList(protocol?: EProtocolOfExchange) {
+  const [{ swapHistoryPendingList }] = useInAppNotificationAtom();
+  const marketPendingKey = useMemo(
+    () => getSwapMarketPendingHistoryKey(swapHistoryPendingList, protocol),
+    [protocol, swapHistoryPendingList],
+  );
+  const { result, isLoading, run } = usePromiseResult(
+    async () => backgroundApiProxy.serviceSwap.fetchSwapHistoryListFromSimple(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [marketPendingKey],
+    { watchLoading: true },
+  );
+  useEffect(() => {
+    const handleRefresh = () => {
+      void run();
+    };
+    appEventBus.on(EAppEventBusNames.RefreshSwapHistoryList, handleRefresh);
+    return () => {
+      appEventBus.off(EAppEventBusNames.RefreshSwapHistoryList, handleRefresh);
+    };
+  }, [run]);
+
+  return { swapTxHistoryList: result, isLoading };
+}

--- a/packages/kit/src/views/Swap/hooks/useSwapMarketHistoryList.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapMarketHistoryList.ts
@@ -29,7 +29,11 @@ export function useSwapMarketHistoryList(protocol?: EProtocolOfExchange) {
   );
   useEffect(() => {
     const handleRefresh = () => {
-      void run();
+      // Force the refetch past usePromiseResult's focus gate: a clear/delete
+      // from a detail modal fires this while the list underneath is blurred,
+      // and a plain run() would be dropped on blur with no refocus retry,
+      // leaving the deleted finished row (and savings/guards) stale.
+      void run({ alwaysSetState: true });
     };
     appEventBus.on(EAppEventBusNames.RefreshSwapHistoryList, handleRefresh);
     return () => {

--- a/packages/kit/src/views/Swap/pages/components/SwapHistoryClearButton.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHistoryClearButton.tsx
@@ -9,12 +9,12 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import {
   EProtocolOfExchange,
   ESwapCleanHistorySource,
-  ESwapTxHistoryStatus,
 } from '@onekeyhq/shared/types/swap/types';
 
 import { useSwapMarketHistoryList } from '../../hooks/useSwapMarketHistoryList';
 import {
   SWAP_CLEAN_EXCLUDE_PROTOCOLS,
+  SWAP_HISTORY_PENDING_STATUSES,
   filterSwapMarketHistoryItems,
   isStockSwapHistoryItem,
 } from '../../utils/swapMarketHistory';
@@ -64,8 +64,8 @@ function SwapHistoryClearButton({
   const hasHistory = scopedHistoryList.length > 0;
   const hasPending = useMemo(
     () =>
-      scopedHistoryList.some(
-        (item) => item.status === ESwapTxHistoryStatus.PENDING,
+      scopedHistoryList.some((item) =>
+        SWAP_HISTORY_PENDING_STATUSES.includes(item.status),
       ),
     [scopedHistoryList],
   );
@@ -92,7 +92,7 @@ function SwapHistoryClearButton({
           : undefined,
         onConfirm: async () => {
           await backgroundApiProxy.serviceSwap.cleanSwapHistoryItems(
-            isPending ? [ESwapTxHistoryStatus.PENDING] : undefined,
+            isPending ? SWAP_HISTORY_PENDING_STATUSES : undefined,
             getCleanOptions(scope),
           );
           if (!isPending) {

--- a/packages/kit/src/views/Swap/pages/components/SwapHistoryClearButton.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHistoryClearButton.tsx
@@ -31,12 +31,12 @@ import {
 type ISwapHistoryClearScope = 'swap' | 'stock';
 
 function getCleanOptions(scope: ISwapHistoryClearScope) {
+  // Both scopes exclude limit / private-send: those live in their own surfaces
+  // and are filtered out of the list/guards here (filterSwapMarketHistoryItems),
+  // so clearing must not physically delete rows the user can't see on this panel.
   return scope === 'stock'
-    ? { onlyStock: true }
-    : {
-        excludeStock: true,
-        excludeProtocols: SWAP_CLEAN_EXCLUDE_PROTOCOLS,
-      };
+    ? { onlyStock: true, excludeProtocols: SWAP_CLEAN_EXCLUDE_PROTOCOLS }
+    : { excludeStock: true, excludeProtocols: SWAP_CLEAN_EXCLUDE_PROTOCOLS };
 }
 
 function SwapHistoryClearButton({

--- a/packages/kit/src/views/Swap/pages/components/SwapHistoryClearButton.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHistoryClearButton.tsx
@@ -1,0 +1,158 @@
+import { useCallback, useMemo } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { ActionList, Button, Dialog, IconButton } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import {
+  EProtocolOfExchange,
+  ESwapCleanHistorySource,
+  ESwapTxHistoryStatus,
+} from '@onekeyhq/shared/types/swap/types';
+
+import { useSwapMarketHistoryList } from '../../hooks/useSwapMarketHistoryList';
+import {
+  SWAP_CLEAN_EXCLUDE_PROTOCOLS,
+  filterSwapMarketHistoryItems,
+  isStockSwapHistoryItem,
+} from '../../utils/swapMarketHistory';
+
+// Clear control for the Order History surfaces. The Swap & Bridge and Pro tabs
+// share one dataset (non-stock trades), and Stocks owns a separate one, so the
+// scope decides both which rows count as "history here" and which slice
+// cleanSwapHistoryItems removes:
+//   - swap:  every non-stock market trade (excludeStock), minus limit/private
+//            send which live in their own surfaces.
+//   - stock: only stock trades (onlyStock).
+// Mirrors the Swap & Bridge clear menu: both menu items stay enabled and the
+// handlers no-op when there is nothing to clear.
+type ISwapHistoryClearScope = 'swap' | 'stock';
+
+function getCleanOptions(scope: ISwapHistoryClearScope) {
+  return scope === 'stock'
+    ? { onlyStock: true }
+    : {
+        excludeStock: true,
+        excludeProtocols: SWAP_CLEAN_EXCLUDE_PROTOCOLS,
+      };
+}
+
+function SwapHistoryClearButton({
+  scope,
+  triggerVariant = 'text',
+}: {
+  scope: ISwapHistoryClearScope;
+  triggerVariant?: 'text' | 'icon';
+}) {
+  const intl = useIntl();
+  const { swapTxHistoryList } = useSwapMarketHistoryList(
+    EProtocolOfExchange.SWAP,
+  );
+
+  const scopedHistoryList = useMemo(() => {
+    const marketList = filterSwapMarketHistoryItems({
+      items: swapTxHistoryList ?? [],
+      protocol: EProtocolOfExchange.SWAP,
+    });
+    return scope === 'stock'
+      ? marketList.filter(isStockSwapHistoryItem)
+      : marketList.filter((item) => !isStockSwapHistoryItem(item));
+  }, [scope, swapTxHistoryList]);
+
+  const hasHistory = scopedHistoryList.length > 0;
+  const hasPending = useMemo(
+    () =>
+      scopedHistoryList.some(
+        (item) => item.status === ESwapTxHistoryStatus.PENDING,
+      ),
+    [scopedHistoryList],
+  );
+
+  // Clear-all and clear-pending share the same dialog shape; only the status
+  // filter, the description copy, and the success toast differ.
+  const showClearDialog = useCallback(
+    (variant: 'all' | 'pending') => {
+      const isPending = variant === 'pending';
+      if (isPending ? !hasPending : !hasHistory) {
+        return;
+      }
+      Dialog.show({
+        icon: 'BroomOutline',
+        title: intl.formatMessage({
+          id: isPending
+            ? ETranslations.swap_history_pending_history_title
+            : ETranslations.swap_history_all_history_title,
+        }),
+        description: isPending
+          ? intl.formatMessage({
+              id: ETranslations.swap_history_pending_history_content,
+            })
+          : undefined,
+        onConfirm: async () => {
+          await backgroundApiProxy.serviceSwap.cleanSwapHistoryItems(
+            isPending ? [ESwapTxHistoryStatus.PENDING] : undefined,
+            getCleanOptions(scope),
+          );
+          if (!isPending) {
+            void backgroundApiProxy.serviceApp.showToast({
+              method: 'success',
+              title: intl.formatMessage({
+                id: ETranslations.settings_clear_successful,
+              }),
+            });
+          }
+          defaultLogger.swap.cleanSwapOrder.cleanSwapOrder({
+            cleanFrom: ESwapCleanHistorySource.LIST,
+          });
+        },
+        onConfirmText: intl.formatMessage({ id: ETranslations.global_clear }),
+        onCancelText: intl.formatMessage({ id: ETranslations.global_cancel }),
+      });
+    },
+    [hasHistory, hasPending, intl, scope],
+  );
+
+  const items = useMemo(
+    () => [
+      {
+        label: intl.formatMessage({
+          id: ETranslations.swap_history_pending_history,
+        }),
+        onPress: () => showClearDialog('pending'),
+      },
+      {
+        label: intl.formatMessage({
+          id: ETranslations.swap_history_all_history,
+        }),
+        onPress: () => showClearDialog('all'),
+      },
+    ],
+    [intl, showClearDialog],
+  );
+
+  return (
+    <ActionList
+      title={intl.formatMessage({ id: ETranslations.global_clear })}
+      items={items}
+      renderTrigger={
+        triggerVariant === 'icon' ? (
+          <IconButton
+            icon="BroomOutline"
+            variant="tertiary"
+            size="small"
+            title={intl.formatMessage({ id: ETranslations.global_clear })}
+            testID={`swap-history-clear-icon-${scope}`}
+          />
+        ) : (
+          <Button variant="tertiary" testID={`swap-history-clear-btn-${scope}`}>
+            {intl.formatMessage({ id: ETranslations.global_clear })}
+          </Button>
+        )
+      }
+    />
+  );
+}
+
+export default SwapHistoryClearButton;

--- a/packages/kit/src/views/Swap/pages/components/SwapMarketHistoryList.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMarketHistoryList.tsx
@@ -35,6 +35,7 @@ import {
 import SwapTxHistoryListCell from '../../components/SwapTxHistoryListCell';
 import { useSwapMarketHistoryList } from '../../hooks/useSwapMarketHistoryList';
 import {
+  SWAP_HISTORY_PENDING_STATUSES,
   filterSwapMarketHistoryItems,
   isStockSwapHistoryItem,
 } from '../../utils/swapMarketHistory';
@@ -123,16 +124,12 @@ const SwapMarketHistoryList = ({
       );
     }
     const pendingData =
-      filterData?.filter(
-        (item) =>
-          item.status === ESwapTxHistoryStatus.PENDING ||
-          item.status === ESwapTxHistoryStatus.CANCELING,
+      filterData?.filter((item) =>
+        SWAP_HISTORY_PENDING_STATUSES.includes(item.status),
       ) ?? [];
     const otherData =
       filterData?.filter(
-        (item) =>
-          item.status !== ESwapTxHistoryStatus.PENDING &&
-          item.status !== ESwapTxHistoryStatus.CANCELING,
+        (item) => !SWAP_HISTORY_PENDING_STATUSES.includes(item.status),
       ) ?? [];
     const groupByDay = otherData.reduce<Record<string, ISwapTxHistory[]>>(
       (acc, item) => {

--- a/packages/kit/src/views/Swap/pages/components/SwapMarketHistoryList.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMarketHistoryList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import type { ReactNode } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -13,15 +14,10 @@ import {
   YStack,
   useSafeAreaInsets,
 } from '@onekeyhq/components';
-import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { NotificationEnableAlert } from '@onekeyhq/kit/src/components/NotificationEnableAlert';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
-import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
-import {
-  useInAppNotificationAtom,
-  useNotificationsAtom,
-} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { useNotificationsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IModalSwapParamList } from '@onekeyhq/shared/src/routes';
 import { EModalRoutes, EModalSwapRoutes } from '@onekeyhq/shared/src/routes';
@@ -37,9 +33,9 @@ import {
 } from '@onekeyhq/shared/types/swap/types';
 
 import SwapTxHistoryListCell from '../../components/SwapTxHistoryListCell';
+import { useSwapMarketHistoryList } from '../../hooks/useSwapMarketHistoryList';
 import {
   filterSwapMarketHistoryItems,
-  getSwapMarketPendingHistoryKey,
   isStockSwapHistoryItem,
 } from '../../utils/swapMarketHistory';
 
@@ -54,6 +50,10 @@ interface ISwapMarketHistoryListProps {
   isPushModal?: boolean;
   filterToken?: ISwapToken[];
   protocol?: EProtocolOfExchange;
+  // Rendered on the right of the FIRST section header (the latest date / pending
+  // row), so a list-level action like Clear shares the date's row instead of
+  // taking a dedicated line above the list.
+  firstSectionRightAction?: ReactNode;
 }
 
 const SwapMarketHistoryList = ({
@@ -61,10 +61,10 @@ const SwapMarketHistoryList = ({
   filterToken,
   isPushModal,
   protocol,
+  firstSectionRightAction,
 }: ISwapMarketHistoryListProps) => {
   const intl = useIntl();
   const { bottom } = useSafeAreaInsets();
-  const [{ swapHistoryPendingList }] = useInAppNotificationAtom();
   const [{ swapHistoryAlertDismissed }] = useNotificationsAtom();
   const navigation =
     useAppNavigation<IPageNavigationProp<IModalSwapParamList>>();
@@ -76,21 +76,8 @@ const SwapMarketHistoryList = ({
     protocol === EProtocolOfExchange.STOCK
       ? EProtocolOfExchange.SWAP
       : protocol;
-  const marketPendingKey = useMemo(
-    () =>
-      getSwapMarketPendingHistoryKey(swapHistoryPendingList, effectiveProtocol),
-    [effectiveProtocol, swapHistoryPendingList],
-  );
-  const { result: swapTxHistoryList, isLoading } = usePromiseResult(
-    async () => {
-      const histories =
-        await backgroundApiProxy.serviceSwap.fetchSwapHistoryListFromSimple();
-      return histories;
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [marketPendingKey],
-    { watchLoading: true },
-  );
+  const { swapTxHistoryList, isLoading } =
+    useSwapMarketHistoryList(effectiveProtocol);
   const sectionData = useMemo(() => {
     let filterData = filterSwapMarketHistoryItems({
       items: swapTxHistoryList ?? [],
@@ -238,28 +225,46 @@ const SwapMarketHistoryList = ({
       renderItem={renderItem}
       sections={sectionData}
       py="$2"
-      renderSectionHeader={({ section: { title, status } }) => (
-        <XStack px="$6" py="$2" gap="$3" alignItems="center">
-          {status === ESwapTxHistoryStatus.PENDING ? (
-            <Stack
-              w="$2"
-              h="$2"
-              backgroundColor="$textInfo"
-              borderRadius="$full"
-            />
-          ) : null}
-          <Heading
-            size="$headingXs"
-            color={
-              status === ESwapTxHistoryStatus.PENDING
-                ? '$textInfo'
-                : '$textSubdued'
-            }
+      renderSectionHeader={({ section }) => {
+        const { title, status } = section;
+        // Section titles are unique (per-day dates + a single "Pending"), so
+        // match by title rather than object identity, which can change when
+        // sectionData is rebuilt.
+        const isFirstSection = sectionData[0]?.title === title;
+        return (
+          <XStack
+            px="$6"
+            py="$2"
+            gap="$3"
+            alignItems="center"
+            justifyContent="space-between"
           >
-            {title}
-          </Heading>
-        </XStack>
-      )}
+            <XStack gap="$3" alignItems="center" flex={1} minWidth={0}>
+              {status === ESwapTxHistoryStatus.PENDING ? (
+                <Stack
+                  w="$2"
+                  h="$2"
+                  backgroundColor="$textInfo"
+                  borderRadius="$full"
+                />
+              ) : null}
+              <Heading
+                size="$headingXs"
+                color={
+                  status === ESwapTxHistoryStatus.PENDING
+                    ? '$textInfo'
+                    : '$textSubdued'
+                }
+              >
+                {title}
+              </Heading>
+            </XStack>
+            {isFirstSection && firstSectionRightAction
+              ? firstSectionRightAction
+              : null}
+          </XStack>
+        );
+      }}
       estimatedItemSize="$10"
       ListHeaderComponent={
         sectionData.length > 0 && !showType ? (

--- a/packages/kit/src/views/Swap/pages/components/SwapProTabListContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProTabListContainer.tsx
@@ -23,6 +23,7 @@ import { ETabName, TabBarItem } from '../../../Perp/layouts/PerpMobileLayout';
 import { useSwapProSupportNetworksTokenList } from '../../hooks/useSwapPro';
 
 import LimitOrderList from './LimitOrderList';
+import SwapHistoryClearButton from './SwapHistoryClearButton';
 import SwapMarketHistoryList from './SwapMarketHistoryList';
 import SwapProCurrentSymbolEnable from './SwapProCurrentSymbolEnable';
 import SwapProPositionsList from './SwapProPositionsList';
@@ -206,10 +207,22 @@ const SwapProTabListContainer = memo(
             display={activeTab === ETabName.SwapOrderHistory ? 'flex' : 'none'}
             flex={1}
           >
-            <SwapProCurrentSymbolEnable />
+            {/* Order history is not scoped to the current token: no
+                "Current tokens" toggle here, and the list shows every order
+                regardless of the shared current-symbol filter. Swap & Bridge
+                and Pro share this surface, so they clear the same (non-stock)
+                dataset. */}
             {shouldRenderListContent ? (
               <XStack mx="$-6">
-                <SwapMarketHistoryList filterToken={filterToken} isPushModal />
+                <SwapMarketHistoryList
+                  isPushModal
+                  firstSectionRightAction={
+                    <SwapHistoryClearButton
+                      scope="swap"
+                      triggerVariant="icon"
+                    />
+                  }
+                />
               </XStack>
             ) : (
               <SwapProTabListSkeleton />

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -126,6 +126,7 @@ import {
 } from '../modal/swapKLineChartUtils';
 
 import SwapActionsState from './SwapActionsState';
+import SwapHistoryClearButton from './SwapHistoryClearButton';
 import SwapInputActions from './SwapInputActions';
 import { PercentageStageOnKeyboard } from './SwapInputContainer';
 import SwapMarketHistoryList from './SwapMarketHistoryList';
@@ -1757,6 +1758,9 @@ function StockMobilePositionsSection({
           <SwapMarketHistoryList
             protocol={EProtocolOfExchange.STOCK}
             isPushModal
+            firstSectionRightAction={
+              <SwapHistoryClearButton scope="stock" triggerVariant="icon" />
+            }
           />
         </XStack>
       </YStack>

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
@@ -41,6 +41,7 @@ import {
 import { useSwapMarketHistoryList } from '../../hooks/useSwapMarketHistoryList';
 import {
   SWAP_CLEAN_EXCLUDE_PROTOCOLS,
+  SWAP_HISTORY_PENDING_STATUSES,
   filterSwapMarketHistoryItems,
   getSwapHistoryListTitleId,
   getSwapMarketPendingHistoryList,
@@ -378,8 +379,8 @@ const SwapHistoryListModal = ({
   const onDeletePendingHistory = useCallback(() => {
     // dialog
     if (
-      !swapMarketTxHistoryList.some(
-        (item) => item.status === ESwapTxHistoryStatus.PENDING,
+      !swapMarketTxHistoryList.some((item) =>
+        SWAP_HISTORY_PENDING_STATUSES.includes(item.status),
       )
     )
       return;
@@ -393,7 +394,7 @@ const SwapHistoryListModal = ({
       }),
       onConfirm: () => {
         void backgroundApiProxy.serviceSwap.cleanSwapHistoryItems(
-          [ESwapTxHistoryStatus.PENDING],
+          SWAP_HISTORY_PENDING_STATUSES,
           {
             excludeProtocols: SWAP_CLEAN_EXCLUDE_PROTOCOLS,
             excludeStock: true,

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
@@ -21,7 +21,6 @@ import {
   useMedia,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import type { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { useInAppNotificationAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -39,13 +38,15 @@ import {
   ESwapTxHistoryStatus,
 } from '@onekeyhq/shared/types/swap/types';
 
+import { useSwapMarketHistoryList } from '../../hooks/useSwapMarketHistoryList';
 import {
+  SWAP_CLEAN_EXCLUDE_PROTOCOLS,
   filterSwapMarketHistoryItems,
   getSwapHistoryListTitleId,
-  getSwapMarketPendingHistoryKey,
   getSwapMarketPendingHistoryList,
   isStockSwapHistoryItem,
 } from '../../utils/swapMarketHistory';
+import SwapHistoryClearButton from '../components/SwapHistoryClearButton';
 import SwapMarketHistoryList from '../components/SwapMarketHistoryList';
 import { SwapProviderMirror } from '../SwapProviderMirror';
 
@@ -73,27 +74,15 @@ const SwapHistoryListModal = ({
     useState<EProtocolOfExchange>(initialHistoryType);
   const [{ swapHistoryPendingList, swapLimitOrders }] =
     useInAppNotificationAtom();
-  const marketPendingKey = useMemo(
-    () =>
-      getSwapMarketPendingHistoryKey(
-        swapHistoryPendingList,
-        EProtocolOfExchange.SWAP,
-      ),
-    [swapHistoryPendingList],
-  );
-
   useEffect(() => {
     void backgroundApiProxy.serviceSwap.refreshSwapHistoryPendingStatusOnce();
   }, []);
 
-  const { result: swapTxHistoryList } = usePromiseResult(
-    async () => {
-      const histories =
-        await backgroundApiProxy.serviceSwap.fetchSwapHistoryListFromSimple();
-      return histories;
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [marketPendingKey],
+  // Shares the list view's hook so the savings total and clear-button guards
+  // below re-fetch on the RefreshSwapHistoryList signal too — otherwise they
+  // would go stale after a finished-order clear while the rendered list updates.
+  const { swapTxHistoryList } = useSwapMarketHistoryList(
+    EProtocolOfExchange.SWAP,
   );
   const swapMarketTxHistoryList = useMemo(
     () =>
@@ -192,11 +181,6 @@ const SwapHistoryListModal = ({
   const historyTypeTitle = useMemo(
     () => intl.formatMessage({ id: getSwapHistoryListTitleId(historyType) }),
     [historyType, intl],
-  );
-
-  const cleanExcludeProtocols = useMemo(
-    () => [EProtocolOfExchange.LIMIT, EProtocolOfExchange.PRIVATE_SEND],
-    [],
   );
 
   const renderHistoryTypeBadge = useCallback((count: number) => {
@@ -369,7 +353,7 @@ const SwapHistoryListModal = ({
       }),
       onConfirm: async () => {
         await backgroundApiProxy.serviceSwap.cleanSwapHistoryItems(undefined, {
-          excludeProtocols: cleanExcludeProtocols,
+          excludeProtocols: SWAP_CLEAN_EXCLUDE_PROTOCOLS,
           // The Swap & Bridge tab hides stock trades, so its Clear must not
           // delete stock history the user can't see here.
           excludeStock: true,
@@ -389,7 +373,7 @@ const SwapHistoryListModal = ({
       }),
       onCancelText: intl.formatMessage({ id: ETranslations.global_cancel }),
     });
-  }, [cleanExcludeProtocols, intl, swapMarketTxHistoryList.length]);
+  }, [intl, swapMarketTxHistoryList.length]);
 
   const onDeletePendingHistory = useCallback(() => {
     // dialog
@@ -410,7 +394,10 @@ const SwapHistoryListModal = ({
       onConfirm: () => {
         void backgroundApiProxy.serviceSwap.cleanSwapHistoryItems(
           [ESwapTxHistoryStatus.PENDING],
-          { excludeProtocols: cleanExcludeProtocols, excludeStock: true },
+          {
+            excludeProtocols: SWAP_CLEAN_EXCLUDE_PROTOCOLS,
+            excludeStock: true,
+          },
         );
         defaultLogger.swap.cleanSwapOrder.cleanSwapOrder({
           cleanFrom: ESwapCleanHistorySource.LIST,
@@ -421,7 +408,7 @@ const SwapHistoryListModal = ({
       }),
       onCancelText: intl.formatMessage({ id: ETranslations.global_cancel }),
     });
-  }, [cleanExcludeProtocols, intl, swapMarketTxHistoryList]);
+  }, [intl, swapMarketTxHistoryList]);
 
   const savingsPopoverContent = useMemo(
     () => (
@@ -587,6 +574,22 @@ const SwapHistoryListModal = ({
     ],
   );
 
+  const stockDeleteButton = useCallback(
+    () => <SwapHistoryClearButton scope="stock" triggerVariant="text" />,
+    [],
+  );
+
+  // Limit has no clear; Stock clears its own dataset; everything else (Swap &
+  // Bridge) uses the savings-aware clear button.
+  const headerRightButton = useMemo(() => {
+    if (historyType === EProtocolOfExchange.LIMIT) {
+      return undefined;
+    }
+    return historyType === EProtocolOfExchange.STOCK
+      ? stockDeleteButton
+      : deleteButton;
+  }, [deleteButton, historyType, stockDeleteButton]);
+
   const headerSelectType = useCallback(
     () => (
       // Render the ActionList directly (not via LazyHeaderTitle): on iOS the
@@ -672,12 +675,7 @@ const SwapHistoryListModal = ({
   return (
     <Page>
       <Page.Header
-        headerRight={
-          historyType === EProtocolOfExchange.LIMIT ||
-          historyType === EProtocolOfExchange.STOCK
-            ? undefined
-            : deleteButton
-        }
+        headerRight={headerRightButton}
         headerRightNoGlass
         headerTitleAlign={gtMd ? 'left' : 'center'}
         headerTitle={headerSelectType}

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
@@ -85,12 +85,16 @@ const SwapHistoryListModal = ({
   const { swapTxHistoryList } = useSwapMarketHistoryList(
     EProtocolOfExchange.SWAP,
   );
+  // Non-stock Swap & Bridge history only: the SWAP bucket also carries stock
+  // orders, but the visible Swap & Bridge list hides them and the clear uses
+  // excludeStock. Drive savings and the clear guards off the same scoped set so
+  // an all-stock state doesn't show savings or pop a clear that deletes nothing.
   const swapMarketTxHistoryList = useMemo(
     () =>
       filterSwapMarketHistoryItems({
         items: swapTxHistoryList ?? [],
         protocol: EProtocolOfExchange.SWAP,
-      }),
+      }).filter((item) => !isStockSwapHistoryItem(item)),
     [swapTxHistoryList],
   );
 

--- a/packages/kit/src/views/Swap/utils/swapMarketHistory.ts
+++ b/packages/kit/src/views/Swap/utils/swapMarketHistory.ts
@@ -29,6 +29,14 @@ export const SWAP_CLEAN_EXCLUDE_PROTOCOLS = [
   EProtocolOfExchange.PRIVATE_SEND,
 ];
 
+// What the history list groups under "Pending" — both in-flight and canceling
+// orders. Single source of truth so the list, the clear guards, and the clear
+// status array agree (clearing "pending" must cover what the list shows there).
+export const SWAP_HISTORY_PENDING_STATUSES = [
+  ESwapTxHistoryStatus.PENDING,
+  ESwapTxHistoryStatus.CANCELING,
+];
+
 export function isSwapMarketHistoryItem(item: ISwapTxHistory) {
   return (
     item.protocol !== EProtocolOfExchange.LIMIT &&

--- a/packages/kit/src/views/Swap/utils/swapMarketHistory.ts
+++ b/packages/kit/src/views/Swap/utils/swapMarketHistory.ts
@@ -21,6 +21,14 @@ export type ISwapRecentTokenPair = {
   toToken: ISwapToken;
 };
 
+// Protocols a Swap/Bridge-side "Clear history" must never touch: limit orders
+// and PrivateSend-like channels own their own surfaces. Single source of truth
+// for both the history modal and the shared clear control.
+export const SWAP_CLEAN_EXCLUDE_PROTOCOLS = [
+  EProtocolOfExchange.LIMIT,
+  EProtocolOfExchange.PRIVATE_SEND,
+];
+
 export function isSwapMarketHistoryItem(item: ISwapTxHistory) {
   return (
     item.protocol !== EProtocolOfExchange.LIMIT &&

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -344,6 +344,7 @@ export interface IAppEventBusPayload {
     fromToken?: ISwapToken;
     toToken?: ISwapToken;
   };
+  [EAppEventBusNames.RefreshSwapHistoryList]: undefined;
   // De-facto "network list changed, refresh" signal. Emitted not only when a
   // custom network is added/removed, but also after a server-network sync that
   // changes the set (e.g. a network delisted to TRASH). All network selectors

--- a/packages/shared/src/eventBus/appEventBusNames.ts
+++ b/packages/shared/src/eventBus/appEventBusNames.ts
@@ -77,6 +77,10 @@ export enum EAppEventBusNames {
   SwapQuoteEvent = 'SwapQuoteEvent',
   ShowSystemDiskFullWarning = 'ShowSystemDiskFullWarning',
   SwapTxHistoryStatusUpdate = 'SwapTxHistoryStatusUpdate',
+  // Fired after the swap history store is mutated in a way the pending-status
+  // refresh key cannot detect (e.g. clearing finished orders), so list views
+  // re-fetch instead of showing stale rows.
+  RefreshSwapHistoryList = 'RefreshSwapHistoryList',
   SwapApprovingSuccess = 'SwapApprovingSuccess',
   SwapSpeedApprovingReset = 'SwapSpeedApprovingReset',
   SwapSpeedBalanceUpdate = 'SwapSpeedBalanceUpdate',


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56988](https://onekeyhq.atlassian.net/browse/OK-56988) [OK-56992](https://onekeyhq.atlassian.net/browse/OK-56992) [OK-56994](https://onekeyhq.atlassian.net/browse/OK-56994)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

Stock/Swap trade UX polish across three issues:

- **[OK-56988]** Desktop K-line "live" pulse dot drifted off the line tail when resizing the window. The resize handler now recomputes the dot's pixel position on the next animation frame (mirroring the init path), so it stays pinned to the latest price. `lockVisibleTimeRangeOnResize` suppressed the range-change event that would otherwise have corrected it.
- **[OK-56992]** Stock Order History had no Clear action. Added a shared `SwapHistoryClearButton` (Clear pending / Clear all) to the Order History of **Swap & Bridge, Pro, and Stocks**, plus the desktop history modal. Swap & Bridge + Pro clear the same (non-stock) dataset via `excludeStock`; Stocks clears its own via a new `onlyStock` option. On mobile the clear icon sits on the first date row.
- **[OK-56994]** Removed the non-functional "Current tokens" filter from Order History (it had no effect there); the list now always shows all orders.

### Stale-list fix (found in review)

The history list only refreshed when a pending order's status changed, so clearing/deleting *finished* orders left stale rows. `cleanSwapHistoryItems` and `cleanOneSwapHistory` now emit a `RefreshSwapHistoryList` event that history views (`useSwapMarketHistoryList`) re-fetch on.

## Testing

- Unit tests for the `onlyStock` / `excludeStock` clean filters (3 cases).
- oxlint (type-aware) + `tsc` pass.
- Desktop verified via CDP: K-line dot stays glued across window widths (gap spread 1px vs 129px before the fix); stock Order History Clear renders with both menu options.
- Mobile (iOS) Order History clear / broom layout: to be confirmed on simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[OK-56988]: https://onekeyhq.atlassian.net/browse/OK-56988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-56992]: https://onekeyhq.atlassian.net/browse/OK-56992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-56994]: https://onekeyhq.atlassian.net/browse/OK-56994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ