### PR TITLE
fix: align DeFi action account gating(OK-57016)

### DIFF
--- a/packages/kit-bg/src/services/ServiceDeFi.ts
+++ b/packages/kit-bg/src/services/ServiceDeFi.ts
@@ -379,14 +379,6 @@ class ServiceDeFi extends ServiceBase {
   @backgroundMethod()
   public async buildDeFiTransaction(params: IDeFiBuildTransactionParams) {
     const { accountId, ...rest } = params;
-    if (
-      accountUtils.isUrlAccountFn({ accountId }) ||
-      accountUtils.isWatchingAccount({ accountId })
-    ) {
-      throw new OneKeyLocalError(
-        'DeFi actions are not available for URL or watch-only accounts',
-      );
-    }
 
     const accountAddress =
       await this.backgroundApi.serviceAccount.getAccountAddressForApi({

--- a/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useManagePositionState.test.ts
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useManagePositionState.test.ts
@@ -1,0 +1,34 @@
+import { isSamePositiveAmount, resolveRepayAllAmountValue } from '../utils';
+
+describe('useManagePositionState utils', () => {
+  it('uses full debt balance instead of wallet max balance for repayAll', () => {
+    const repayAllAmount = resolveRepayAllAmountValue({
+      action: 'repay',
+      maxAmountValue: '0.000000000000000001',
+      repayAllBalance: '0.000057570716602455',
+    });
+
+    expect(repayAllAmount).toBe('0.000057570716602455');
+    expect(
+      isSamePositiveAmount({
+        amount: '0.000000000000000001',
+        targetAmount: repayAllAmount,
+      }),
+    ).toBe(false);
+  });
+
+  it('detects repayAll only when the positive amount equals the target amount', () => {
+    expect(
+      isSamePositiveAmount({
+        amount: '0.000057570716602455',
+        targetAmount: '0.000057570716602455',
+      }),
+    ).toBe(true);
+    expect(
+      isSamePositiveAmount({
+        amount: '0',
+        targetAmount: '0',
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useManagePositionState.ts
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useManagePositionState.ts
@@ -7,6 +7,8 @@ import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IToken } from '@onekeyhq/shared/types/token';
 
+import { isSamePositiveAmount, resolveRepayAllAmountValue } from '../utils';
+
 import type { IManagePositionProps, IManagePositionState } from '../types';
 
 export function useManagePositionState(props: IManagePositionProps): {
@@ -94,19 +96,29 @@ export function useManagePositionState(props: IManagePositionProps): {
   // Action-specific "all" flags
   const isWithdrawAll = useMemo(() => {
     if (props.action !== 'withdraw') return false;
-    const amountBN = new BigNumber(amountValue);
-    const maxAmountBN = new BigNumber(maxAmountValue);
-    if (amountBN.isNaN() || maxAmountBN.isNaN()) return false;
-    return amountBN.gt(0) && amountBN.eq(maxAmountBN);
+    return isSamePositiveAmount({
+      amount: amountValue,
+      targetAmount: maxAmountValue,
+    });
   }, [props.action, amountValue, maxAmountValue]);
+
+  const repayAllAmountValue = useMemo(
+    () =>
+      resolveRepayAllAmountValue({
+        action: props.action,
+        maxAmountValue,
+        repayAllBalance: props.repayAllBalance,
+      }),
+    [props.action, maxAmountValue, props.repayAllBalance],
+  );
 
   const isRepayAll = useMemo(() => {
     if (props.action !== 'repay') return false;
-    const amountBN = new BigNumber(amountValue);
-    const maxAmountBN = new BigNumber(maxAmountValue);
-    if (amountBN.isNaN() || maxAmountBN.isNaN()) return false;
-    return amountBN.gt(0) && amountBN.eq(maxAmountBN);
-  }, [props.action, amountValue, maxAmountValue]);
+    return isSamePositiveAmount({
+      amount: amountValue,
+      targetAmount: repayAllAmountValue,
+    });
+  }, [props.action, amountValue, repayAllAmountValue]);
 
   const state: Omit<
     IManagePositionState,

--- a/packages/kit/src/views/Borrow/components/ManagePosition/types.ts
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/types.ts
@@ -50,6 +50,7 @@ export interface IManagePositionProps {
   // Token info
   balance: string;
   maxBalance?: string;
+  repayAllBalance?: string;
   tokenSymbol?: string;
   tokenImageUri?: string;
   decimals?: number;

--- a/packages/kit/src/views/Borrow/components/ManagePosition/utils.ts
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/utils.ts
@@ -1,0 +1,30 @@
+import BigNumber from 'bignumber.js';
+
+import type { IManagePositionProps } from './types';
+
+export function isSamePositiveAmount({
+  amount,
+  targetAmount,
+}: {
+  amount: string;
+  targetAmount?: string;
+}) {
+  const amountBN = new BigNumber(amount);
+  const targetAmountBN = new BigNumber(targetAmount ?? '0');
+  if (amountBN.isNaN() || targetAmountBN.isNaN()) return false;
+  return amountBN.gt(0) && amountBN.eq(targetAmountBN);
+}
+
+export function resolveRepayAllAmountValue({
+  action,
+  maxAmountValue,
+  repayAllBalance,
+}: {
+  action: IManagePositionProps['action'];
+  maxAmountValue: string;
+  repayAllBalance?: string;
+}) {
+  return action === 'repay'
+    ? (repayAllBalance ?? maxAmountValue)
+    : maxAmountValue;
+}

--- a/packages/kit/src/views/Staking/pages/ManagePosition/components/WithdrawSection.tsx
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/components/WithdrawSection.tsx
@@ -46,6 +46,26 @@ import {
 
 import type { IManagePageV2ReceiveInputConfig } from '../../../components/ManagePageV2ReceiveInput';
 
+function normalizeBorrowAssetAddress(address?: string) {
+  return (address ?? '').toLowerCase();
+}
+
+function isWrappedNativeDebtToken({
+  debtReserveAddress,
+  debtTokenAddress,
+  debtTokenSymbol,
+  repayTokenSymbol,
+}: {
+  debtReserveAddress: string;
+  debtTokenAddress: string;
+  debtTokenSymbol: string;
+  repayTokenSymbol: string;
+}) {
+  if (debtReserveAddress || debtTokenAddress) return false;
+  if (!debtTokenSymbol || !repayTokenSymbol) return false;
+  return repayTokenSymbol === `W${debtTokenSymbol}`;
+}
+
 export const WithdrawSection = ({
   accountId,
   networkId,
@@ -838,6 +858,57 @@ export const WithdrawSection = ({
       { watchLoading: true },
     );
 
+  const effectiveRepayAllBalance = useMemo(() => {
+    if (borrowAction !== 'repay') {
+      return undefined;
+    }
+    const selectedDebtBalance =
+      selectedAsset?.borrowed?.amount ?? selectedAsset?.borrowed?.title?.text;
+    if (selectedDebtBalance) {
+      return selectedDebtBalance;
+    }
+    if (protocolInfo?.debtBalance) {
+      return protocolInfo.debtBalance;
+    }
+
+    const reserveAddress = normalizeBorrowAssetAddress(effectiveReserveAddress);
+    const tokenAddress = normalizeBorrowAssetAddress(token?.address);
+    const repayTokenSymbol = effectiveTokenSymbol.toUpperCase();
+    const borrowedAsset = freshBorrowReserves?.borrowed?.assets.find((item) => {
+      const debtReserveAddress = normalizeBorrowAssetAddress(
+        item.reserveAddress,
+      );
+      const debtTokenAddress = normalizeBorrowAssetAddress(item.token.address);
+      if (
+        (reserveAddress &&
+          (debtReserveAddress === reserveAddress ||
+            debtTokenAddress === reserveAddress)) ||
+        (tokenAddress &&
+          (debtReserveAddress === tokenAddress ||
+            debtTokenAddress === tokenAddress))
+      ) {
+        return true;
+      }
+
+      return isWrappedNativeDebtToken({
+        debtReserveAddress,
+        debtTokenAddress,
+        debtTokenSymbol: item.token.symbol.toUpperCase(),
+        repayTokenSymbol,
+      });
+    });
+    return borrowedAsset?.borrowedAmount.amount;
+  }, [
+    borrowAction,
+    effectiveReserveAddress,
+    effectiveTokenSymbol,
+    freshBorrowReserves?.borrowed?.assets,
+    protocolInfo?.debtBalance,
+    selectedAsset?.borrowed?.amount,
+    selectedAsset?.borrowed?.title?.text,
+    token?.address,
+  ]);
+
   const collateralAssets = useMemo(() => {
     const suppliedAssets = freshBorrowReserves?.supplied?.assets ?? [];
     return suppliedAssets
@@ -981,6 +1052,7 @@ export const WithdrawSection = ({
           decimals={effectiveDecimals}
           balance={effectiveBalance}
           maxBalance={effectiveMaxBalance}
+          repayAllBalance={effectiveRepayAllBalance ?? '0'}
           tokenSymbol={effectiveTokenSymbol}
           tokenImageUri={effectiveTokenImageUri}
           onWalletConfirm={onBorrowConfirm}


### PR DESCRIPTION
## Summary
- Remove the URL / watch-only account preflight guard from `ServiceDeFi.buildDeFiTransaction`.
- Keep DeFi action UI / build behavior aligned with the #12187 review-thread decision that URL and watch-only accounts may resolve and show DeFi actions, same as Earn.
- Leave unsupported-account failure to the shared signature/send capability layer instead of showing the DeFi-specific build-stage toast.

## Context
PR #12187 intentionally allowed DeFi action UI to resolve for URL / watch-only accounts, but a later review-follow-up commit restored a background guard in `ServiceDeFi.buildDeFiTransaction`, producing `DeFi actions are not available for URL or watch-only accounts`. That makes the background build path inconsistent with the intended Earn-like behavior.

## Changes Detail
- `packages/kit-bg/src/services/ServiceDeFi.ts`: remove the URL / watch-only guard before `/earn/v1/defi/build-transaction`.

## Risk Assessment
- **Risk Level**: Low to medium
- **Affected Platforms**: Desktop / Mobile / Web / Extension
- **Runtime boundary**: `ServiceDeFi` runs in the background runtime. This change only removes a background preflight guard; signing is still handled by the normal transaction/signature flow, where watch-only / URL account capability remains enforced. No main/bg JS heap state is shared.

## Test plan
- [x] `git diff --check`
- [x] `npx oxlint --type-aware packages/kit-bg/src/services/ServiceDeFi.ts`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [ ] Runtime verify watch-only DeFi action no longer shows the build-stage toast and reaches the normal signature-layer unsupported-account handling

Jira: https://onekeyhq.atlassian.net/browse/OK-57016