### PR TITLE
fix: prevent token manager modal context crash

### DIFF
--- a/packages/kit/src/views/AssetList/pages/TokenManagerModal.tsx
+++ b/packages/kit/src/views/AssetList/pages/TokenManagerModal.tsx
@@ -14,6 +14,7 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EModalAssetListRoutes } from '@onekeyhq/shared/src/routes';
 import type { IModalAssetListParamList } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import {
   ECustomTokenStatus,
   type IAccountToken,
@@ -21,9 +22,10 @@ import {
 } from '@onekeyhq/shared/types/token';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
+import { AccountSelectorProviderMirror } from '../../../components/AccountSelector';
 import useAppNavigation from '../../../hooks/useAppNavigation';
 import { useHomeTokenListOwnerKey } from '../../../states/jotai/contexts/tokenList/cells';
-import { HomeTokenListProviderMirror } from '../../Home/components/HomeTokenListProvider/HomeTokenListProviderMirror';
+import { HomeTokenListProviderMirrorWrapper } from '../../Home/components/HomeTokenListProvider';
 import { TokenManagerList } from '../components/TokenManager/TokenManagerList';
 import { useAccountInfoForManageToken } from '../hooks/useAddToken';
 import { useTokenManagement } from '../hooks/useTokenManagement';
@@ -291,10 +293,27 @@ function TokenManagerModal() {
 }
 
 function TokenManagerModalContainer() {
+  const route =
+    useRoute<
+      RouteProp<
+        IModalAssetListParamList,
+        EModalAssetListRoutes.TokenManagerModal
+      >
+    >();
+  const { accountId } = route.params;
+
   return (
-    <HomeTokenListProviderMirror>
-      <TokenManagerModal />
-    </HomeTokenListProviderMirror>
+    <AccountSelectorProviderMirror
+      config={{
+        sceneName: EAccountSelectorSceneName.home,
+        sceneUrl: '',
+      }}
+      enabledNum={[0]}
+    >
+      <HomeTokenListProviderMirrorWrapper accountId={accountId}>
+        <TokenManagerModal />
+      </HomeTokenListProviderMirrorWrapper>
+    </AccountSelectorProviderMirror>
   );
 }
 


### PR DESCRIPTION
## Summary
- Wrap the token manager modal with the required account selector provider mirror.
- Use the account-aware home token list provider wrapper for the modal route.
- Prevent the Manage Tokens modal from entering the React error boundary when opened from the Home token list settings icon.

## Intent & Context
The bug was reported as a desktop crash after clicking the sliders icon on the Home token list, specifically `home-render-header-actions-icon-btn`. The first CDP session was accidentally connected through a local `9222` SSH tunnel to a Windows target, so the issue was re-verified against the Mac desktop Electron instance through the main-process inspector on `5858`.

On the correct Mac desktop target, clicking the Home token list settings icon opened the token manager route and triggered a renderer-side React error boundary with `useContextStore ERROR: store not initialized`.

## Root Cause
`TokenManagerModal` calls `useHomeTokenListOwnerKey()`, which depends on `useActiveAccount()`. That hook requires the AccountSelector Jotai context, but `TokenManagerModalContainer` only mounted `HomeTokenListProviderMirror`. When the modal route mounted outside the Home page provider tree, the UI renderer did not have the required AccountSelector context store and threw `useContextStore ERROR: store not initialized`.

Runtime scope: this is a main/UI renderer JS runtime issue. The background runtime is not involved in the reproduced stack. There is no MMKV, DB, file handle, or native singleton sharing issue here; the missing state is a per-renderer JS-heap Jotai context store.

## Design Decisions
- Follow the existing provider pattern used by token selector modal routes: `AccountSelectorProviderMirror` outside, token-list provider inside.
- Read `accountId` from the modal route in the container and pass it to `HomeTokenListProviderMirrorWrapper`, preserving URL-account handling.
- Keep the fix scoped to provider wiring only; token management logic and background services are unchanged.

## Changes Detail
- `packages/kit/src/views/AssetList/pages/TokenManagerModal.tsx`
  - Adds `AccountSelectorProviderMirror` with the Home account-selector scene.
  - Replaces the raw `HomeTokenListProviderMirror` with `HomeTokenListProviderMirrorWrapper accountId={accountId}`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop, Web, Mobile
- **Risk Areas**: Provider lifecycle for the token manager modal route. The change uses established mirror-provider wiring already used by similar token selector routes.

## Test plan
- [x] Reproduced the original Mac desktop renderer error by clicking `home-render-header-actions-icon-btn` through Electron inspector `5858`.
- [x] Verified the same click opens the visible `管理代币` modal after the fix.
- [x] Verified `hasStoreError=false` and `webContents.isCrashed=false` after the click.
- [x] Ran `yarn lint:staged`.
- [x] Ran `yarn tsc:staged`.
