### PR TITLE
chore: sync release/v6.4.0 to x

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -399,6 +399,7 @@ focusable
 Formatjs
 formatter
 frontend
+frontmost
 fs
 fucntion
 func

--- a/packages/components/src/composite/Dialog/index.tsx
+++ b/packages/components/src/composite/Dialog/index.tsx
@@ -146,7 +146,15 @@ const useSafeKeyboardAnimationStyle = () => {
       keyboardHeightValue.value = 0;
     },
   });
-  return platformEnv.isNative ? animatedStyles : undefined;
+  // On web there is no reanimated keyboard tracking, but notched iOS
+  // Safari/PWA still reports a bottom inset via env(safe-area-inset-bottom).
+  // The frame must apply it as a static paddingBottom so bottom-sheet dialogs
+  // clear the home indicator there too — footers only carry their design
+  // padding now, and rely on the frame for the inset on every platform.
+  if (!platformEnv.isNative) {
+    return bottom ? { paddingBottom: bottom } : undefined;
+  }
+  return animatedStyles;
 };
 
 /**
@@ -342,7 +350,11 @@ function DialogFrame({
           testID={testID}
           borderTopLeftRadius="$6"
           borderTopRightRadius="$6"
-          bg="$bg"
+          // Match the sheet frame to the content surface so the bottom
+          // safe-area inset region (applied as paddingBottom on the wrapper,
+          // below the footer) doesn't reveal the default `$bg` as a seam when a
+          // dialog overrides its content background (e.g. Prime feature intro).
+          bg={(contentContainerProps as { bg?: IColorTokens })?.bg ?? '$bg'}
           borderCurve="continuous"
           disableHideBottomOverflow
           // Fix width issue for portrait iPad mini - ensure proper dialog width

--- a/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
+++ b/packages/components/src/layouts/DesktopDragZoneBox/index.desktop.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
@@ -11,12 +11,47 @@ const dragZoneStyle = {
   cursor: 'default',
 } as const;
 
-// Selectors for descendants that should remain clickable inside an
-// app-region:drag container. Chromium's region calculator unreliably honours
-// such descendants once they live deep inside Tamagui-generated trees (see
-// electron/electron#41695, #27149, #20926), so for every match we mirror a
-// fresh fixed-position no-drag ghost element at body level. Ghosts are
-// pointer-events:none so real clicks still reach the underlying control.
+// =============================================================================
+// macOS title-bar draggable region: imperative synthesized approach
+//
+// Problem: on macOS (Electron, upstream electron#21034) the native NSWindow
+// draggable region is NOT recomputed after the `-webkit-app-region: drag`
+// layout changes — window resize, monitor/DPI change, tab switch (the header
+// subtree is swapped), modal open/close, docked DevTools. The DOM stays correct
+// but the top bar can no longer drag the window. Any fix that pulls the
+// *visible* header node out of the DOM and back to force a recompute flickers a
+// frame; toggling the app-region value in place (or adding a throwaway probe
+// element) does not refresh the native region at all; the only reliable levers
+// (window focus/reorder) live in the main process and are not hot-updatable.
+//
+// Approach (renderer-only, hot-updatable, flicker-free):
+//   1. Header elements keep `app-region-drag` purely as a MARKER. Their real
+//      app-region (and that of everything inside them) is neutralized by the
+//      injected style below, so they never produce a stale native region.
+//   2. A single global imperative manager reads those markers and synthesizes,
+//      from the current geometry, fresh invisible overlays:
+//        - a `drag` overlay covering each visible marker zone;
+//        - `no-drag` holes covering the clickable controls inside it.
+//      All overlays are body-level, position:fixed, opacity:0,
+//      pointer-events:none.
+//   3. On resize / DPI change / aria-hidden (tab, modal) flips and zone
+//      mount/unmount the overlays are cleared, recomputed and re-attached
+//      (debounced, with a max-wait guard).
+//   Fresh overlays => never stale; invisible => no flicker; one central place
+//   => replaces (and removes) the previous per-instance ghost-mirror.
+// =============================================================================
+
+const MARKER_CLASS = 'app-region-drag';
+const SYN_ATTR = 'data-onekey-syn-region';
+const NEUTRALIZE_STYLE_ID = 'onekey-drag-region-neutralize';
+const RECOMPUTE_DEBOUNCE = 200;
+// A continuous stream of triggers (e.g. live window resizing fires `resize`
+// rapidly) keeps resetting the debounce timer. MAX_WAIT guarantees a recompute
+// fires at least this often so the draggable region is never starved while the
+// events keep coming.
+const RECOMPUTE_MAX_WAIT = 600;
+
+// Descendants of a drag zone that must stay clickable → punched as no-drag holes.
 const NO_DRAG_SELECTOR = [
   '.app-region-no-drag',
   'input',
@@ -29,203 +64,211 @@ const NO_DRAG_SELECTOR = [
   '[class*="is_GroupFrame"]',
 ].join(',');
 
-const GHOST_ATTR = 'data-onekey-drag-mask-ghost';
+// The manager is a process-wide singleton: it starts once (on the first
+// DesktopDragZoneBox mount) and intentionally never stops. A desktop window
+// always has a title bar, so there is nothing to tear down; keeping it as a
+// plain singleton avoids ref-counting that is fragile under React StrictMode's
+// double-invoked effects and the ~11 simultaneously-mounted tab headers.
+let started = false;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingSince = 0;
 
-function useDragMaskMirror(
-  rootRef: React.MutableRefObject<HTMLElement | null>,
-  enabled: boolean,
-) {
-  useEffect(() => {
+// Neutralize the real app-region of every marker zone AND everything inside it
+// (drag, no-drag controls, `.app-region-no-drag`, is_GroupFrame, …). Inside a
+// drag zone no element keeps a real native region — drag and no-drag are both
+// provided by the synthesized overlays, so nothing can go stale. The shared CSS
+// rules in index.css are intentionally left untouched: they still apply to
+// app-region elements OUTSIDE any drag zone (e.g. desktop menus).
+function ensureNeutralizeStyle() {
+  if (document.getElementById(NEUTRALIZE_STYLE_ID)) {
+    return;
+  }
+  const style = document.createElement('style');
+  style.id = NEUTRALIZE_STYLE_ID;
+  style.textContent = `
+.${MARKER_CLASS},
+.${MARKER_CLASS} * {
+  -webkit-app-region: none !important;
+}
+[${SYN_ATTR}] { pointer-events: none; }
+`;
+  document.head.appendChild(style);
+}
+
+// Whether a marker zone is actually visible. LOAD-BEARING — do not drop this
+// filter (see OK-55535, the inactive-tab drag-region leak / cross-monitor bug):
+// react-navigation keeps inactive tab screens mounted via react-freeze and only
+// marks them `aria-hidden="true"` (NOT display:none), so a frozen header keeps
+// its layout. If we synthesized a drag overlay for such a hidden zone, its stale
+// (e.g. narrow two-row) rect would overlap and swallow clicks on controls in the
+// ACTIVE screen — which surfaced especially on external monitors (dpr=1). Only
+// visible zones get overlays; hidden ones contribute nothing.
+function isZoneShown(el: Element): boolean {
+  let cur: Element | null = el;
+  while (cur && cur !== document.body) {
+    const cs = globalThis.getComputedStyle(cur);
     if (
-      !enabled ||
-      // SSR guard: this hook never runs server-side, but be defensive in
-      // case the bundle is imported from a non-DOM context.
-      // eslint-disable-next-line unicorn/prefer-global-this
-      typeof window === 'undefined'
+      cs.display === 'none' ||
+      cs.visibility === 'hidden' ||
+      cs.visibility === 'collapse'
     ) {
-      return undefined;
+      return false;
     }
-    const root = rootRef.current;
-    if (!root) {
-      return undefined;
+    if (cur.getAttribute('aria-hidden') === 'true') {
+      return false;
     }
+    cur = cur.parentElement;
+  }
+  return true;
+}
 
-    const ghosts = new Map<Element, HTMLDivElement>();
-    let rafId = 0;
-    let scheduled = false;
+function makeRegionEl(
+  rect: DOMRect,
+  region: 'drag' | 'no-drag',
+): HTMLDivElement {
+  const el = document.createElement('div');
+  el.setAttribute(SYN_ATTR, region);
+  el.style.cssText =
+    `position:fixed;pointer-events:none;opacity:0;z-index:0;` +
+    `left:${Math.round(rect.left)}px;top:${Math.round(rect.top)}px;` +
+    `width:${Math.round(rect.width)}px;height:${Math.round(rect.height)}px;` +
+    `-webkit-app-region:${region};`;
+  return el;
+}
 
-    const applyRect = (el: Element, ghost: HTMLDivElement) => {
-      const r = (el as HTMLElement).getBoundingClientRect();
-      if (r.width === 0 || r.height === 0) {
-        // hidden / collapsed → contribute nothing to the mask
-        ghost.style.width = '0px';
-        ghost.style.height = '0px';
-        return;
+function clearSynRegions() {
+  document.querySelectorAll(`[${SYN_ATTR}]`).forEach((el) => el.remove());
+}
+
+// Imperative recompute: drop the old overlays → rebuild the drag overlay +
+// no-drag holes from the current geometry → re-attach. The drag overlays are
+// appended first and the no-drag holes after: the native region is built in DOM
+// order (drag = union, no-drag = difference), so the later no-drag holes carve
+// the clickable controls back out of the drag overlay.
+function recompute() {
+  if (!document.body || !document.body.isConnected) {
+    return;
+  }
+  clearSynRegions();
+  const zones = Array.from(
+    document.querySelectorAll(`.${MARKER_CLASS}`),
+  ).filter((z) => {
+    const r = z.getBoundingClientRect();
+    return r.width > 0 && r.height > 0 && isZoneShown(z);
+  });
+  const drags: HTMLDivElement[] = [];
+  const holes: HTMLDivElement[] = [];
+  for (const zone of zones) {
+    drags.push(makeRegionEl(zone.getBoundingClientRect(), 'drag'));
+    zone.querySelectorAll(NO_DRAG_SELECTOR).forEach((nd) => {
+      const r = (nd as HTMLElement).getBoundingClientRect();
+      if (r.width > 0 && r.height > 0) {
+        holes.push(makeRegionEl(r, 'no-drag'));
       }
-      ghost.style.left = `${r.left}px`;
-      ghost.style.top = `${r.top}px`;
-      ghost.style.width = `${r.width}px`;
-      ghost.style.height = `${r.height}px`;
-    };
-
-    const ensureGhost = (el: Element) => {
-      let ghost = ghosts.get(el);
-      if (!ghost) {
-        ghost = document.createElement('div');
-        ghost.className = 'app-region-no-drag';
-        ghost.setAttribute(GHOST_ATTR, '');
-        ghost.style.cssText =
-          'position:fixed;pointer-events:none;z-index:2147483647;left:0;top:0;width:0;height:0;';
-        document.body.appendChild(ghost);
-        ghosts.set(el, ghost);
-      }
-      applyRect(el, ghost);
-    };
-
-    const clearGhosts = () => {
-      ghosts.forEach((ghost) => ghost.remove());
-      ghosts.clear();
-    };
-
-    // react-navigation on web marks inactive tab containers with
-    // `aria-hidden="true"` (often paired with `z-index: -1` to push them
-    // behind the active screen). The hidden container still has layout, so
-    // width/height/visibility/display alone do not detect it. Walk up the
-    // ancestor chain and treat any of those signals as "this root lives in
-    // a stale background tab" — skip the entire sync and clear ghosts.
-    const isRootShown = () => {
-      let cur: Element | null = root;
-      while (cur && cur !== document.body) {
-        const cs = globalThis.getComputedStyle(cur);
-        if (
-          cs.display === 'none' ||
-          cs.visibility === 'hidden' ||
-          cs.visibility === 'collapse'
-        ) {
-          return false;
-        }
-        if (cur.getAttribute('aria-hidden') === 'true') {
-          return false;
-        }
-        cur = cur.parentElement;
-      }
-      return true;
-    };
-
-    // Toggle whether this drag zone contributes to the window's native
-    // draggable region, by adding/removing the `app-region-drag` class.
-    //
-    // Why the class and not an inline `-webkit-app-region` value: Chromium
-    // computes the region as `union(drag rects) − union(no-drag rects)`, where a
-    // `no-drag` rect subtracts from EVERY overlapping drag rect, not just its
-    // own zone. The inactive tab headers sit at the SAME full-width position as
-    // the active header, so the inactive zone must contribute *nothing* — not
-    // `drag` (it would overlap and swallow active controls; the original bug),
-    // and not `no-drag` (it would carve a full-width hole out of the active
-    // header, leaving only the sidebar draggable). The only neutral state is the
-    // ABSENCE of any `-webkit-app-region` declaration: an explicit
-    // `-webkit-app-region: none` is coerced to `no-drag` by Chromium, so it is
-    // NOT neutral. Removing the `app-region-drag` class drops both the root's
-    // `drag` and the CSS-driven `no-drag` on its descendants
-    // (`.app-region-drag button`, …), making the whole inactive subtree neutral.
-    //
-    // React won't fight this: the `className` prop value is the constant
-    // `'app-region-drag'` (when enabled), so React only writes className when
-    // that value changes — never on a plain re-render — leaving our classList
-    // edits intact (the same contract the body-level ghosts rely on).
-    const setRootDraggable = (draggable: boolean) => {
-      root.classList.toggle('app-region-drag', draggable);
-    };
-
-    const sync = () => {
-      scheduled = false;
-      if (!document.body.isConnected) return;
-      if (!isRootShown()) {
-        // ---- Inactive-tab drag-region leak fix (OK-55535) ----
-        // react-navigation keeps inactive tab/screen containers mounted (via
-        // react-freeze) and marks them `aria-hidden="true"`. That is NOT
-        // `display:none`, so a frozen header keeps its layout and Chromium
-        // still unions its `-webkit-app-region: drag` rect into the window's
-        // native draggable region. A header frozen in its narrow two-row form
-        // (104px tall) then overlaps controls in the ACTIVE screen — e.g. the
-        // account selector — that are NOT this zone's DOM descendants, so the
-        // body-level ghost mask (which mirrors descendants only) can't protect
-        // them and their clicks get eaten as window drags. This surfaces on
-        // displays where the active layout doesn't also cover them (typically
-        // devicePixelRatio = 1, i.e. an external monitor at native/high
-        // resolution). Drop the drag region while hidden so the frozen zone
-        // stops swallowing clicks; the active zone keeps its drag region, so
-        // window dragging is unaffected.
-        setRootDraggable(false);
-        clearGhosts();
-        return;
-      }
-      setRootDraggable(true);
-      const rootRect = root.getBoundingClientRect();
-      if (rootRect.width === 0 || rootRect.height === 0) {
-        clearGhosts();
-        return;
-      }
-      const matches = root.querySelectorAll(NO_DRAG_SELECTOR);
-      const seen = new Set<Element>();
-      matches.forEach((el) => {
-        const rect = (el as HTMLElement).getBoundingClientRect();
-        if (rect.width === 0 || rect.height === 0) return;
-        seen.add(el);
-        ensureGhost(el);
-      });
-      // Drop ghosts whose source vanished or was removed from the subtree.
-      ghosts.forEach((ghost, el) => {
-        if (!seen.has(el)) {
-          ghost.remove();
-          ghosts.delete(el);
-        }
-      });
-    };
-
-    const schedule = () => {
-      if (scheduled) return;
-      scheduled = true;
-      rafId = globalThis.requestAnimationFrame(sync);
-    };
-
-    // Initial pass — handles the common case where children are already in
-    // the tree at mount time. The follow-up observers cover later mutations.
-    sync();
-
-    const subtreeObserver = new MutationObserver(schedule);
-    subtreeObserver.observe(root, { childList: true, subtree: true });
-
-    // react-navigation toggles aria-hidden on ancestor tab containers when
-    // the user switches tabs. Those mutations live OUTSIDE this root subtree
-    // so the subtree observer above won't see them. Watch document-wide for
-    // aria-hidden attribute flips so each instance can re-evaluate whether
-    // it still belongs to the active tab and clear its ghosts when not.
-    const ancestorObserver = new MutationObserver(schedule);
-    ancestorObserver.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['aria-hidden'],
-      subtree: true,
     });
+  }
+  drags.forEach((d) => document.body.appendChild(d));
+  holes.forEach((h) => document.body.appendChild(h));
+}
 
-    const resizeObserver = new ResizeObserver(schedule);
-    resizeObserver.observe(root);
+function runRecompute() {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+  pendingSince = 0;
+  // Call recompute directly (no requestAnimationFrame): rAF is paused by
+  // Electron's backgroundThrottling whenever the window is occluded/backgrounded,
+  // which would leave the draggable region stale until the window is frontmost
+  // again. The debounce already lets layout settle, and recompute's
+  // getBoundingClientRect forces a synchronous layout anyway.
+  recompute();
+}
 
-    globalThis.addEventListener('resize', schedule);
-    // Use capture so inner scroll containers also trigger a resync.
-    globalThis.addEventListener('scroll', schedule, true);
+function scheduleRecompute() {
+  const now = Date.now();
+  if (pendingSince === 0) {
+    pendingSince = now;
+  }
+  // Continuous churn reached MAX_WAIT: recompute now instead of waiting more.
+  if (now - pendingSince >= RECOMPUTE_MAX_WAIT) {
+    runRecompute();
+    return;
+  }
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+  }
+  debounceTimer = setTimeout(runRecompute, RECOMPUTE_DEBOUNCE);
+}
 
+// Start the singleton manager once. Idempotent: the `started` guard makes every
+// call after the first a no-op, so it is safe to call from every mount.
+function startManager() {
+  if (started || typeof document === 'undefined') {
+    return;
+  }
+  started = true;
+  ensureNeutralizeStyle();
+
+  // Window geometry: resize, maximize, fullscreen toggle and docked-DevTools
+  // open/close (all change the renderer's CSS-pixel viewport).
+  globalThis.addEventListener('resize', scheduleRecompute);
+
+  // devicePixelRatio change — i.e. the window moved to a monitor with a
+  // different scale factor. A pure dpr change does NOT reliably fire `resize`
+  // (the CSS-pixel size is unchanged), so watch the output resolution
+  // explicitly. `matchMedia('(resolution: <dpr>dppx)')` flips when the dpr
+  // changes; re-arm it each time against the new dpr.
+  let dprQuery: MediaQueryList | null = null;
+  let onDprChange: () => void = () => undefined;
+  const armDprQuery = () => {
+    dprQuery?.removeEventListener('change', onDprChange);
+    dprQuery = globalThis.matchMedia(
+      `(resolution: ${globalThis.devicePixelRatio}dppx)`,
+    );
+    dprQuery.addEventListener('change', onDprChange);
+  };
+  onDprChange = () => {
+    scheduleRecompute();
+    armDprQuery();
+  };
+  armDprQuery();
+
+  // react-navigation keeps inactive tab screens mounted and only flips
+  // aria-hidden on their ancestors when switching tabs / opening a modal — that
+  // does NOT mount/unmount the zones, so it must be observed explicitly. The
+  // filter keeps this cheap: the callback only runs on aria-hidden changes
+  // (rare), not on general DOM churn. (Other layout changes are covered by the
+  // resize listener and by per-instance mount/unmount in the hook below.)
+  const mo = new MutationObserver(scheduleRecompute);
+  mo.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['aria-hidden'],
+    subtree: true,
+  });
+
+  // Initial pass — run it synchronously (not debounced) so the draggable region
+  // exists on the first commit instead of ~200ms later, otherwise the title bar
+  // is briefly non-draggable right after app load.
+  recompute();
+}
+
+function useDesktopDragRegionManager(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled || typeof document === 'undefined') {
+      return undefined;
+    }
+    // Ensure the singleton is running, then resync — a drag zone (re)mounted,
+    // e.g. in-tab navigation pushed a screen with a different header. This is
+    // the targeted replacement for a document-wide childList observer.
+    startManager();
+    scheduleRecompute();
     return () => {
-      subtreeObserver.disconnect();
-      ancestorObserver.disconnect();
-      resizeObserver.disconnect();
-      globalThis.removeEventListener('resize', schedule);
-      globalThis.removeEventListener('scroll', schedule, true);
-      if (rafId) globalThis.cancelAnimationFrame(rafId);
-      ghosts.forEach((ghost) => ghost.remove());
-      ghosts.clear();
+      // A drag zone unmounted — resync the remaining ones. The manager itself
+      // is never torn down (singleton for the window's lifetime).
+      scheduleRecompute();
     };
-  }, [enabled, rootRef]);
+  }, [enabled]);
 }
 
 function BaseDesktopDragZoneBox({
@@ -245,21 +288,16 @@ function DesktopDragZoneBoxMac({
   disabled,
   ...rest
 }: IDesktopDragZoneBoxProps) {
-  const rootRef = useRef<HTMLElement | null>(null);
-  useDragMaskMirror(rootRef, !disabled);
+  // Start the global imperative drag-region manager (idempotent + ref-counted).
+  useDesktopDragRegionManager(!disabled);
 
-  // Toggle className/style instead of swapping keys so Chromium can
-  // incrementally update its non-client drag mask without tearing down the
-  // subtree mid-drag. The mirror hook above creates body-level no-drag
-  // ghosts to compensate for Chromium's unreliable in-tree mask calculation.
-  // Tamagui's Stack types its ref as TamaguiElement which on web resolves to
-  // the underlying HTMLDivElement; cast through `any` to bridge the gap.
+  // Only carry the marker class (its real app-region is neutralized by the
+  // injected style); the actual drag / no-drag regions are synthesized by the
+  // manager.
   return (
     <Stack
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ref={rootRef as any}
       {...rest}
-      className={disabled ? undefined : 'app-region-drag'}
+      className={disabled ? undefined : MARKER_CLASS}
       style={disabled ? style : dragZoneStyle}
     >
       {children}

--- a/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
@@ -2,7 +2,6 @@ import type { MutableRefObject, RefObject } from 'react';
 import {
   createContext,
   createRef,
-  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -21,7 +20,6 @@ import type { GetProps } from '@onekeyhq/components/src/shared/tamagui';
 import appGlobals from '@onekeyhq/shared/src/appGlobals';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { updateRootViewBackgroundColor } from '@onekeyhq/shared/src/modules3rdParty/rootview-background';
-import { navigationIntegration } from '@onekeyhq/shared/src/modules3rdParty/sentry';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import {
@@ -107,11 +105,6 @@ const useNativeDevTools =
 
 export function NavigationContainer(props: IBasicNavigationContainerProps) {
   const isTabletMainView = useSplitMainView();
-  const handleReady = useCallback(() => {
-    navigationIntegration.registerNavigationContainer(
-      isTabletMainView ? tabletMainViewNavigationRef : rootNavigationRef,
-    );
-  }, [isTabletMainView]);
   const { theme: themeName, themeSetting } = useSettingConfig();
   const theme = useTheme();
 
@@ -139,7 +132,6 @@ export function NavigationContainer(props: IBasicNavigationContainerProps) {
       {...props}
       theme={themeOptions}
       ref={isTabletMainView ? tabletMainViewNavigationRef : rootNavigationRef}
-      onReady={handleReady}
     />
   );
 }

--- a/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
@@ -7,11 +7,13 @@ import { createStore } from 'jotai';
 
 import type { IAccountSelectorActiveAccountInfo } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import type { useSwapAddressInfo } from '@onekeyhq/kit/src/views/Swap/hooks/useSwapAccount';
+import { settingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { globalJotaiStorageReadyHandler } from '@onekeyhq/kit-bg/src/states/jotai/jotaiStorage';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
 import type {
   IFetchQuoteResult,
   IFetchQuotesParams,
+  ISwapNetwork,
   ISwapQuoteEvent,
   ISwapToken,
 } from '@onekeyhq/shared/types/swap/types';
@@ -138,6 +140,11 @@ const appleStockToken: ISwapToken = {
   isNative: false,
   isStock: true,
 };
+const evmSwapNetwork: ISwapNetwork = {
+  networkId: 'evm--1',
+  name: 'Ethereum',
+  symbol: 'ETH',
+};
 const evmAccount: INetworkAccount = {
   id: 'hd-1--m/44/60/0/0/0',
   name: 'Account 1',
@@ -232,6 +239,13 @@ describe('useSwapActions', () => {
     mockCloseApproving.mockResolvedValue(undefined);
     mockCancelFetchQuoteEvents.mockResolvedValue(undefined);
     mockFetchQuotesEvents.mockResolvedValue(undefined);
+    jest.spyOn(settingsAtom, 'get').mockResolvedValue({
+      swapEnableRecipientAddress: false,
+      swapIncognitoMode: false,
+      swapSlippagePercentageCustomValue: 0,
+      swapSlippagePercentageMode: ESwapSlippageSegmentKey.AUTO,
+      swapToAnotherAccountSwitchOn: false,
+    });
   });
 
   it('pins selected token detail price fetches to USD for rate-difference math', async () => {
@@ -796,5 +810,47 @@ describe('useSwapActions', () => {
         fromAmount: '1',
       }),
     );
+  });
+
+  it('does not keep noConnectWallet warning when native wallet readiness is not proven', async () => {
+    const { store, Wrapper } = createWrapperWithStore();
+    store.set(swapNetworks(), [evmSwapNetwork]);
+    store.set(swapAlertsAtom(), {
+      states: [{ message: 'keep me' }, { noConnectWallet: true }],
+      quoteId: 'old-quote',
+    });
+
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.checkSwapWarning(fromAddressInfo, fromAddressInfo, {
+        allowNoConnectWallet: false,
+      });
+    });
+
+    expect(store.get(swapAlertsAtom()).states).toEqual([
+      { message: 'keep me' },
+    ]);
+  });
+
+  it('keeps noConnectWallet warning when the caller proves a real no-wallet state', async () => {
+    const { store, Wrapper } = createWrapperWithStore();
+    store.set(swapNetworks(), [evmSwapNetwork]);
+
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.checkSwapWarning(fromAddressInfo, fromAddressInfo, {
+        allowNoConnectWallet: true,
+      });
+    });
+
+    expect(store.get(swapAlertsAtom()).states).toEqual([
+      { noConnectWallet: true },
+    ]);
   });
 });

--- a/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
@@ -443,6 +443,7 @@ describe('useSwapActions', () => {
       await result.current.actions.checkSwapWarning(
         fromAddressInfo,
         fromAddressInfo,
+        { allowNoConnectWallet: true },
       );
     });
 

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -6,6 +6,7 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { ESwapDirection } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
 import type { useSwapAddressInfo } from '@onekeyhq/kit/src/views/Swap/hooks/useSwapAccount';
 import { buildSwapDefaultSelectedTokensForNetwork } from '@onekeyhq/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils';
+import { removeSwapNoConnectWalletAlerts } from '@onekeyhq/kit/src/views/Swap/utils/swapNoWalletWarningGuard';
 import { buildSwapRateDifference } from '@onekeyhq/kit/src/views/Swap/utils/swapRateDifferenceUtils';
 import {
   isUSMarketStatusStockTokenSource,
@@ -1530,6 +1531,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       set,
       swapFromAddressInfo: ReturnType<typeof useSwapAddressInfo>,
       swapToAddressInfo: ReturnType<typeof useSwapAddressInfo>,
+      options?: {
+        allowNoConnectWallet?: boolean;
+      },
     ) => {
       const fromToken = get(swapSelectFromTokenAtom());
       const toToken = get(swapSelectToTokenAtom());
@@ -1615,11 +1619,28 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
             states: alertsRes,
             quoteId: '',
           });
+        } else {
+          const alerts = get(swapAlertsAtom());
+          const nextAlerts = removeSwapNoConnectWalletAlerts(alerts.states);
+          if (nextAlerts.length !== alerts.states.length) {
+            set(swapAlertsAtom(), {
+              states: nextAlerts,
+              quoteId: alerts.quoteId,
+            });
+          }
         }
         return;
       }
       // check account
       if (!swapFromAddressInfo.accountInfo?.wallet) {
+        if (!options?.allowNoConnectWallet) {
+          const alerts = get(swapAlertsAtom());
+          set(swapAlertsAtom(), {
+            states: removeSwapNoConnectWalletAlerts(alerts.states),
+            quoteId: alerts.quoteId,
+          });
+          return;
+        }
         // Set noConnectWallet flag without showing alert message
         set(swapAlertsAtom(), {
           states: [...alertsRes, { noConnectWallet: true }],

--- a/packages/kit/src/views/AddressRiskCheck/components/RiskCheckShared.tsx
+++ b/packages/kit/src/views/AddressRiskCheck/components/RiskCheckShared.tsx
@@ -3,7 +3,13 @@ import { useIntl } from 'react-intl';
 import { StyleSheet } from 'react-native';
 
 import type { ColorTokens } from '@onekeyhq/components';
-import { Divider, SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  Divider,
+  Popover,
+  SizableText,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import type { IBadgeType } from '@onekeyhq/components/src/content/Badge';
 import { formatKytRiskFactorCategory } from '@onekeyhq/kit/src/utils/kytRiskFactorUtils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -69,15 +75,27 @@ export const LEVEL_TITLE: Record<EKytRiskLevel, ETranslations> = {
 export function CardRow({
   label,
   children,
+  tooltip,
 }: {
   label: string;
   children: React.ReactNode;
+  tooltip?: string;
 }) {
   return (
     <XStack px="$4" py="$2.5" ai="center" jc="space-between" gap="$2">
-      <SizableText size="$bodyMd" color="$textSubdued" flexShrink={0}>
-        {label}
-      </SizableText>
+      <XStack ai="center" gap="$1" flexShrink={0}>
+        <SizableText size="$bodyMd" color="$textSubdued">
+          {label}
+        </SizableText>
+        {tooltip ? (
+          <Popover.Tooltip
+            title={label}
+            tooltip={tooltip}
+            placement="bottom"
+            iconSize="$4"
+          />
+        ) : null}
+      </XStack>
       {children}
     </XStack>
   );
@@ -85,7 +103,7 @@ export function CardRow({
 
 export function RiskFactorCard({ factor }: { factor: IKytRiskFactor }) {
   const intl = useIntl();
-  const rows: { label: string; value: string }[] = [];
+  const rows: { label: string; value: string; tooltip?: string }[] = [];
   if (factor.entity) {
     rows.push({
       label: intl.formatMessage({
@@ -100,6 +118,9 @@ export function RiskFactorCard({ factor }: { factor: IKytRiskFactor }) {
         id: ETranslations.kyt_risk_factor_exposure__title,
       }),
       value: factor.exposureType,
+      tooltip: intl.formatMessage({
+        id: ETranslations.address_risk_check_exposure_type_tooltip__desc,
+      }),
     });
   }
   if (factor.hops !== undefined) {
@@ -111,6 +132,9 @@ export function RiskFactorCard({ factor }: { factor: IKytRiskFactor }) {
         { id: ETranslations.kyt_risk_factor_distance_hops__msg },
         { count: factor.hops },
       ),
+      tooltip: intl.formatMessage({
+        id: ETranslations.address_risk_check_distance_tooltip__desc,
+      }),
     });
   }
   // Exposure amount and share are shown together on one "Exposure / Share" row.
@@ -131,6 +155,9 @@ export function RiskFactorCard({ factor }: { factor: IKytRiskFactor }) {
         id: ETranslations.address_risk_check_exposure_share__title,
       }),
       value: exposureShareValue,
+      tooltip: intl.formatMessage({
+        id: ETranslations.address_risk_check_exposure_share_tooltip__desc,
+      }),
     });
   }
 
@@ -149,7 +176,7 @@ export function RiskFactorCard({ factor }: { factor: IKytRiskFactor }) {
       {rows.map((row) => (
         <YStack key={row.label}>
           <Divider />
-          <CardRow label={row.label}>
+          <CardRow label={row.label} tooltip={row.tooltip}>
             <SizableText size="$bodyMdMedium" textAlign="right">
               {row.value}
             </SizableText>

--- a/packages/kit/src/views/AddressRiskCheck/pages/AddressRiskCheckInput.tsx
+++ b/packages/kit/src/views/AddressRiskCheck/pages/AddressRiskCheckInput.tsx
@@ -4,10 +4,12 @@ import { useRoute } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
 
 import {
+  Badge,
   Button,
   Icon,
   Page,
   ScrollView,
+  Select,
   SizableText,
   Spinner,
   Stack,
@@ -18,6 +20,7 @@ import {
 import { useClipboard } from '@onekeyhq/components/src/hooks/useClipboard';
 import HeaderIconButton from '@onekeyhq/components/src/layouts/Navigation/Header/HeaderIconButton';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { queryAddressWithFallback } from '@onekeyhq/kit/src/components/AddressInput/utils';
 import { NetworkAvatar } from '@onekeyhq/kit/src/components/NetworkAvatar';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useDebounce } from '@onekeyhq/kit/src/hooks/useDebounce';
@@ -27,12 +30,14 @@ import {
   EModalAddressRiskCheckRoutes,
   type IModalAddressRiskCheckParamList,
 } from '@onekeyhq/shared/src/routes/addressRiskCheck';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import type { IAddressRiskCheckRecentItem } from '@onekeyhq/shared/types/addressRiskCheck';
 
 import useConfigurableChainSelector from '../../ChainSelector/hooks/useChainSelector';
 import { RecentCheckItem } from '../components/RecentCheckItem';
 import { useCheckAddressRisk } from '../hooks/useCheckAddressRisk';
 import { useRecentChecks } from '../hooks/useRecentChecks';
+import { getAddressRiskCheckInputState } from '../utils/addressRiskCheckInputUtils';
 
 import type { RouteProp } from '@react-navigation/core';
 
@@ -57,6 +62,9 @@ function AddressRiskCheckInput() {
     { id: string; name: string } | undefined
   >();
   const [address, setAddress] = useState('');
+  const [selectedResolvedAddress, setSelectedResolvedAddress] = useState<
+    string | undefined
+  >();
 
   const networkId = selectedNetwork?.id;
   const trimmedAddress = address.trim();
@@ -77,54 +85,53 @@ function AddressRiskCheckInput() {
     [supportedNetworks],
   );
 
-  // Identifies the {network, address} combination the latest validation refers
-  // to. Recomputed synchronously from current state, so it flips the instant
-  // the user switches network — unlike the async re-validation below.
-  const validationKey =
+  const queryKey =
     networkId && debouncedAddress ? `${networkId}:${debouncedAddress}` : '';
 
-  // Real-time, debounced address validation against the selected network. The
-  // result carries the key it was validated against so a stale verdict (e.g.
-  // right after switching networks without editing the address) can be
-  // detected and ignored.
-  const { result: validation, isLoading: isValidating } = usePromiseResult(
-    async () => {
-      if (!networkId || !debouncedAddress) {
-        return { key: '', status: 'idle' as const };
-      }
-      const status = await backgroundApiProxy.serviceValidator.validateAddress({
-        networkId,
-        address: debouncedAddress,
-      });
-      return { key: `${networkId}:${debouncedAddress}`, status };
-    },
-    [networkId, debouncedAddress],
-    { initResult: { key: '', status: 'idle' as const }, watchLoading: true },
-  );
+  const { result: addressQuery, isLoading: isQueryingAddress } =
+    usePromiseResult(
+      async () => {
+        if (!networkId || !debouncedAddress) {
+          return { key: '', result: undefined };
+        }
+        const result = await queryAddressWithFallback({
+          networkId,
+          address: debouncedAddress,
+          enableNameResolve: true,
+        });
+        return { key: `${networkId}:${debouncedAddress}`, result };
+      },
+      [networkId, debouncedAddress],
+      { initResult: { key: '', result: undefined }, watchLoading: true },
+    );
 
-  // Pending while the debounce hasn't caught up with the latest input.
   const isPendingValidation = trimmedAddress !== debouncedAddress;
-  // `usePromiseResult` keeps the previous result while re-running, and schedules
-  // its re-run asynchronously in an effect — so when only the network changes
-  // (address unchanged), `isValidating` can still be false for one render frame
-  // while `validation` still holds the previous network's verdict. Treat the
-  // status as `idle` until its key matches the current {network, address}, so
-  // `canCheck` never trusts a verdict computed for a different network.
-  const validateStatus =
-    validation.key === validationKey ? validation.status : 'idle';
-  // Only surface the error once validation has settled, so it doesn't flash a
-  // stale "invalid" while the user is still editing.
+  const currentAddressQuery =
+    addressQuery.key === queryKey ? addressQuery.result : undefined;
+  const addressState = useMemo(
+    () =>
+      getAddressRiskCheckInputState({
+        rawAddress: trimmedAddress,
+        query: currentAddressQuery,
+        selectedResolvedAddress,
+      }),
+    [currentAddressQuery, selectedResolvedAddress, trimmedAddress],
+  );
   const isAddressInvalid =
     Boolean(trimmedAddress) &&
     !isPendingValidation &&
-    !isValidating &&
-    validateStatus === 'invalid';
+    !isQueryingAddress &&
+    addressState.isInvalid;
   const canCheck =
     Boolean(networkId) &&
     Boolean(trimmedAddress) &&
     !isPendingValidation &&
-    !isValidating &&
-    (validateStatus === 'valid' || validateStatus === 'unknown');
+    !isQueryingAddress &&
+    Boolean(addressState.checkAddress);
+
+  useEffect(() => {
+    setSelectedResolvedAddress(undefined);
+  }, [queryKey]);
 
   // Pre-select the active network once, if it is supported.
   const didPreselectRef = useRef(false);
@@ -201,10 +208,16 @@ function AddressRiskCheckInput() {
     }
     void checkRisk({
       networkId,
-      address: trimmedAddress,
+      address: addressState.checkAddress ?? trimmedAddress,
       entryPoint: 'inputManual',
     });
-  }, [networkId, canCheck, trimmedAddress, checkRisk]);
+  }, [
+    networkId,
+    canCheck,
+    addressState.checkAddress,
+    trimmedAddress,
+    checkRisk,
+  ]);
 
   const headerRight = useCallback(
     () => (
@@ -319,6 +332,57 @@ function AddressRiskCheckInput() {
                     id: ETranslations.form_address_error_invalid,
                   })}
                 </SizableText>
+              ) : null}
+              {!isAddressInvalid &&
+              !isPendingValidation &&
+              !isQueryingAddress &&
+              addressState.resolvedOptions.length ? (
+                <XStack gap="$2" ai="center" flexWrap="wrap">
+                  <SizableText size="$bodyMd" color="$textSubdued">
+                    {intl.formatMessage({
+                      id: ETranslations.address_risk_check_resolved_address__title,
+                    })}
+                  </SizableText>
+                  {addressState.resolvedOptions.length > 1 ? (
+                    <Select
+                      testID="address-risk-check-resolved-address-select"
+                      title={intl.formatMessage({
+                        id: ETranslations.send_ens_choose_address_title,
+                      })}
+                      placeholder={intl.formatMessage({
+                        id: ETranslations.send_ens_choose_address_title,
+                      })}
+                      renderTrigger={({ label, placeholder }) => (
+                        <Badge badgeSize="sm" userSelect="none">
+                          <Badge.Text>{label || placeholder}</Badge.Text>
+                          <Icon
+                            name="ChevronDownSmallOutline"
+                            color="$iconSubdued"
+                            size="$4"
+                          />
+                        </Badge>
+                      )}
+                      items={addressState.resolvedOptions.map((option) => ({
+                        label: accountUtils.shortenAddress({ address: option }),
+                        value: option,
+                        description: option,
+                      }))}
+                      value={selectedResolvedAddress}
+                      onChange={(value) => setSelectedResolvedAddress(value)}
+                      floatingPanelProps={{
+                        width: '$80',
+                      }}
+                    />
+                  ) : (
+                    <Badge badgeSize="sm">
+                      <Badge.Text>
+                        {accountUtils.shortenAddress({
+                          address: addressState.resolvedOptions[0] ?? '',
+                        })}
+                      </Badge.Text>
+                    </Badge>
+                  )}
+                </XStack>
               ) : null}
             </YStack>
           </YStack>

--- a/packages/kit/src/views/AddressRiskCheck/utils/addressRiskCheckInputUtils.test.ts
+++ b/packages/kit/src/views/AddressRiskCheck/utils/addressRiskCheckInputUtils.test.ts
@@ -1,0 +1,137 @@
+import { getAddressRiskCheckInputState } from './addressRiskCheckInputUtils';
+
+describe('getAddressRiskCheckInputState', () => {
+  test('allows a valid plain address', () => {
+    expect(
+      getAddressRiskCheckInputState({
+        rawAddress: '0xabc',
+        query: {
+          input: '0xabc',
+          validStatus: 'valid',
+          validAddress: '0xABC',
+        },
+      }).checkAddress,
+    ).toBe('0xABC');
+  });
+
+  test('allows a single resolved domain address', () => {
+    expect(
+      getAddressRiskCheckInputState({
+        rawAddress: 'onekey.eth',
+        query: {
+          input: 'onekey.eth',
+          validStatus: 'valid',
+          resolveAddress: '0xresolved',
+          resolveOptions: ['0xresolved'],
+        },
+      }).checkAddress,
+    ).toBe('0xresolved');
+  });
+
+  test('requires a user choice for multiple resolved addresses', () => {
+    const query = {
+      input: 'onekey.eth',
+      validStatus: 'valid' as const,
+      resolveAddress: '0xfirst',
+      resolveOptions: ['0xfirst', '0xsecond'],
+    };
+
+    expect(
+      getAddressRiskCheckInputState({
+        rawAddress: 'onekey.eth',
+        query,
+      }),
+    ).toMatchObject({
+      checkAddress: undefined,
+      needsResolvedAddressSelection: true,
+    });
+
+    expect(
+      getAddressRiskCheckInputState({
+        rawAddress: 'onekey.eth',
+        query,
+        selectedResolvedAddress: '0xsecond',
+      }),
+    ).toMatchObject({
+      checkAddress: '0xsecond',
+      needsResolvedAddressSelection: false,
+    });
+  });
+
+  test('blocks an unresolved domain', () => {
+    expect(
+      getAddressRiskCheckInputState({
+        rawAddress: 'onekey.eth',
+        query: {
+          input: 'onekey.eth',
+          validStatus: 'invalid',
+        },
+      }),
+    ).toMatchObject({
+      checkAddress: undefined,
+      isInvalid: true,
+    });
+  });
+
+  test('blocks a resolved domain when final validation is invalid', () => {
+    expect(
+      getAddressRiskCheckInputState({
+        rawAddress: 'onekey.eth',
+        query: {
+          input: 'onekey.eth',
+          validStatus: 'invalid',
+          resolveAddress: '0xresolved',
+          resolveOptions: ['0xresolved'],
+        },
+      }),
+    ).toMatchObject({
+      checkAddress: undefined,
+      isInvalid: true,
+    });
+  });
+
+  test('does not fall back to the raw domain without a resolved address', () => {
+    expect(
+      getAddressRiskCheckInputState({
+        rawAddress: 'onekey.eth',
+        query: {
+          input: 'onekey.eth',
+          validStatus: 'valid',
+        },
+      }),
+    ).toMatchObject({
+      checkAddress: undefined,
+      isInvalid: true,
+    });
+  });
+
+  test('keeps unknown plain-address validation checkable', () => {
+    expect(
+      getAddressRiskCheckInputState({
+        rawAddress: '0xabc',
+        query: {
+          input: '0xabc',
+          validStatus: 'unknown',
+        },
+      }),
+    ).toMatchObject({
+      checkAddress: '0xabc',
+      isInvalid: false,
+    });
+  });
+
+  test('does not send an unknown domain-like input to risk check', () => {
+    expect(
+      getAddressRiskCheckInputState({
+        rawAddress: 'onekey.eth',
+        query: {
+          input: 'onekey.eth',
+          validStatus: 'unknown',
+        },
+      }),
+    ).toMatchObject({
+      checkAddress: undefined,
+      isInvalid: true,
+    });
+  });
+});

--- a/packages/kit/src/views/AddressRiskCheck/utils/addressRiskCheckInputUtils.ts
+++ b/packages/kit/src/views/AddressRiskCheck/utils/addressRiskCheckInputUtils.ts
@@ -1,0 +1,132 @@
+import type { IAddressValidateStatus } from '@onekeyhq/shared/types/address';
+
+export type IAddressRiskCheckAddressQuery = {
+  input?: string;
+  validStatus?: IAddressValidateStatus;
+  resolveAddress?: string;
+  validAddress?: string;
+  resolveOptions?: string[];
+};
+
+export function isAddressRiskCheckDomainLike(value: string) {
+  const input = value.trim();
+  return (
+    Boolean(input) &&
+    !input.toLowerCase().startsWith('0x') &&
+    /\./u.test(input) &&
+    !/\s/u.test(input)
+  );
+}
+
+export function getAddressRiskCheckResolvedOptions(
+  query: IAddressRiskCheckAddressQuery | undefined,
+) {
+  if (!query) {
+    return [];
+  }
+  const options = [...new Set(query.resolveOptions?.filter(Boolean) ?? [])];
+  if (query.resolveAddress && !options.includes(query.resolveAddress)) {
+    options.unshift(query.resolveAddress);
+  }
+  return options;
+}
+
+export function getAddressRiskCheckInputState({
+  rawAddress,
+  query,
+  selectedResolvedAddress,
+}: {
+  rawAddress: string;
+  query: IAddressRiskCheckAddressQuery | undefined;
+  selectedResolvedAddress?: string;
+}) {
+  const input = rawAddress.trim();
+  const resolvedOptions = getAddressRiskCheckResolvedOptions(query);
+  const isDomainInput = isAddressRiskCheckDomainLike(input);
+  const isBlockedStatus =
+    query?.validStatus !== undefined &&
+    query.validStatus !== 'valid' &&
+    query.validStatus !== 'unknown';
+  const selectedAddress =
+    selectedResolvedAddress && resolvedOptions.includes(selectedResolvedAddress)
+      ? selectedResolvedAddress
+      : undefined;
+
+  if (!input || !query) {
+    return {
+      checkAddress: undefined,
+      isInvalid: false,
+      needsResolvedAddressSelection: false,
+      resolvedOptions,
+    };
+  }
+
+  if (isBlockedStatus) {
+    return {
+      checkAddress: undefined,
+      isInvalid: true,
+      needsResolvedAddressSelection: false,
+      resolvedOptions,
+    };
+  }
+
+  if (resolvedOptions.length > 1) {
+    return {
+      checkAddress: selectedAddress,
+      isInvalid: false,
+      needsResolvedAddressSelection: !selectedAddress,
+      resolvedOptions,
+    };
+  }
+
+  if (query.resolveAddress) {
+    return {
+      checkAddress: query.resolveAddress,
+      isInvalid: false,
+      needsResolvedAddressSelection: false,
+      resolvedOptions,
+    };
+  }
+
+  if (query.validAddress) {
+    return {
+      checkAddress: query.validAddress,
+      isInvalid: false,
+      needsResolvedAddressSelection: false,
+      resolvedOptions,
+    };
+  }
+
+  if (query.validStatus === 'valid') {
+    if (isDomainInput) {
+      return {
+        checkAddress: undefined,
+        isInvalid: true,
+        needsResolvedAddressSelection: false,
+        resolvedOptions,
+      };
+    }
+    return {
+      checkAddress: query.input?.trim() || input,
+      isInvalid: false,
+      needsResolvedAddressSelection: false,
+      resolvedOptions,
+    };
+  }
+
+  if (query.validStatus === 'unknown' && !isDomainInput) {
+    return {
+      checkAddress: input,
+      isInvalid: false,
+      needsResolvedAddressSelection: false,
+      resolvedOptions,
+    };
+  }
+
+  return {
+    checkAddress: undefined,
+    isInvalid: query.validStatus === 'unknown' && isDomainInput,
+    needsResolvedAddressSelection: false,
+    resolvedOptions,
+  };
+}

--- a/packages/kit/src/views/AppUpdate/components/FeaturedFooter.tsx
+++ b/packages/kit/src/views/AppUpdate/components/FeaturedFooter.tsx
@@ -2,14 +2,7 @@ import { useCallback } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import {
-  Button,
-  Stack,
-  XStack,
-  YStack,
-  useMedia,
-  useSafeAreaInsets,
-} from '@onekeyhq/components';
+import { Button, Stack, XStack, YStack, useMedia } from '@onekeyhq/components';
 import { appUpdatePersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { jotaiDefaultStore } from '@onekeyhq/kit-bg/src/states/jotai/utils/jotaiDefaultStore';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -41,10 +34,10 @@ function FeaturedFooter({
   const navigation = useAppNavigation();
   const intl = useIntl();
   const { md } = useMedia();
-  const { bottom } = useSafeAreaInsets();
-  // 20 = "$5" default. Use the system safe-area inset when larger so the
-  // footer clears the iOS home indicator on bottom-sheet dialogs.
-  const paddingBottom = Math.max(bottom, 20);
+  // The Dialog frame now applies the bottom safe-area inset itself (the outer
+  // Animated.View in Dialog/index.tsx pads by max(keyboardHeight, safeBottom)),
+  // so the footer must only carry its own design padding ("$5") — adding the
+  // inset here again would double-stack and push the buttons up (OK-…).
 
   const handleViewChangelog = useCallback(async () => {
     await closeDialog();
@@ -69,12 +62,7 @@ function FeaturedFooter({
 
   if (md) {
     return (
-      <YStack
-        px="$5"
-        gap="$4"
-        paddingBottom={paddingBottom + 20}
-        onLayout={onLayout}
-      >
+      <YStack px="$5" gap="$4" pb="$5" onLayout={onLayout}>
         <Button
           testID={AppUpdateTestIDs.featuredFooterCtaBtn}
           size="large"
@@ -100,7 +88,7 @@ function FeaturedFooter({
   return (
     <XStack
       px="$5"
-      paddingBottom={paddingBottom}
+      pb="$5"
       justifyContent="space-between"
       alignItems="center"
       onLayout={onLayout}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
@@ -11,6 +11,7 @@ import {
   useIsOverlayPage,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { useCurrency } from '@onekeyhq/kit/src/components/Currency';
 import { useCustomRpcAvailability } from '@onekeyhq/kit/src/hooks/useCustomRpcAvailability';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
@@ -66,6 +67,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
     isReady,
   } = useTokenDetail();
   const intl = useIntl();
+  const currencyInfo = useCurrency();
   const isModalPage = useIsOverlayPage();
   const inPageDialog = useInPageDialog(
     isModalPage ? EInPageDialogType.inModalPage : EInPageDialogType.inTabPages,
@@ -211,6 +213,14 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
   const effectiveCustomPriorityFee = marketPresetSettings.enabled
     ? marketPresetSettings.selectedPriorityFeeOverride
     : undefined;
+  const shouldUseConvertedMarketPrice =
+    currencyInfo.id !== 'usd' && Boolean(tokenDetail?.priceConverted);
+  const marketTokenPrice = shouldUseConvertedMarketPrice
+    ? tokenDetail?.priceConverted
+    : tokenDetail?.price;
+  const marketTokenCurrency = shouldUseConvertedMarketPrice
+    ? currencyInfo.id
+    : 'usd';
   const currentFromTokenAmount =
     tradeType === ESwapDirection.BUY
       ? paymentAmount.toFixed()
@@ -224,7 +234,8 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
       symbol: tokenDetail?.symbol || '',
       decimals: tokenDetail?.decimals || 0,
       logoURI: tokenDetail?.logoUrl || '',
-      price: tokenDetail?.priceConverted || tokenDetail?.price || '',
+      price: marketTokenPrice || '',
+      currency: marketTokenCurrency,
       isNative: !!tokenDetail?.isNative,
     },
     tradeToken: {
@@ -234,6 +245,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
       decimals: paymentToken?.decimals || 0,
       logoURI: paymentToken?.logoURI || '',
       price: paymentToken?.price || '',
+      currency: paymentToken?.currency,
       isNative: paymentToken?.isNative || false,
     },
     provider,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
@@ -84,9 +84,12 @@ export function ActionButton({
     num: 0,
     showConnectWalletModalInDappMode: true,
   });
+  const paymentTokenNetworkId =
+    tradeType === ESwapDirection.BUY ? paymentToken?.networkId : undefined;
   const { price: paymentTokenPrice } = usePaymentTokenPrice(
     tradeType === ESwapDirection.BUY ? paymentToken : undefined,
-    networkId,
+    paymentTokenNetworkId,
+    currencyInfo.id,
   );
   const [createAddressLoading, setCreateAddressLoading] = useState(false);
   const actionText =
@@ -104,7 +107,17 @@ export function ActionButton({
     }
 
     if (tradeType === ESwapDirection.BUY) {
-      const buyPrice = paymentTokenPrice ?? new BigNumber(token?.price || '0');
+      const fallbackCurrency = paymentToken?.currency ?? token?.currency;
+      const canUseFallbackPrice =
+        !fallbackCurrency || fallbackCurrency === currencyInfo.id;
+      const buyPrice =
+        paymentTokenPrice ??
+        (canUseFallbackPrice
+          ? new BigNumber(paymentToken?.price || token?.price || '0')
+          : undefined);
+      if (!buyPrice) {
+        return undefined;
+      }
       if (!buyPrice.isFinite() || buyPrice.isNaN() || !buyPrice.gt(0)) {
         return undefined;
       }
@@ -119,7 +132,11 @@ export function ActionButton({
     return amountBN.multipliedBy(sellPrice).toNumber();
   }, [
     tradeType,
+    currencyInfo.id,
+    paymentToken?.currency,
+    paymentToken?.price,
     paymentTokenPrice,
+    token?.currency,
     token?.price,
     amount,
     isValidAmount,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewExecutionUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketReviewExecutionUtils.ts
@@ -5,6 +5,7 @@ import {
 } from '@onekeyhq/kit/src/views/Swap/utils/buildSwapReviewState';
 import { buildSwapRateDifference } from '@onekeyhq/kit/src/views/Swap/utils/swapRateDifferenceUtils';
 import { getSwapExecutionTypeFromQuoteResult } from '@onekeyhq/kit/src/views/Swap/utils/swapTypeUtils';
+import type { ICurrencyItem } from '@onekeyhq/shared/types/currency';
 import type { IFeeInfoUnit } from '@onekeyhq/shared/types/fee';
 import type {
   IFetchQuoteResult,
@@ -85,16 +86,24 @@ export function buildMarketReviewState({
 export function buildMarketReviewRateDifference({
   quoteResult,
   swapInfo,
+  defaultTokenCurrency,
+  currencyMap,
 }: {
   quoteResult?: Pick<IFetchQuoteResult, 'instantRate'>;
   swapInfo?: {
-    sender?: { token?: Pick<ISwapToken, 'price'> };
-    receiver?: { token?: Pick<ISwapToken, 'price'> };
+    sender?: { token?: Pick<ISwapToken, 'price' | 'currency'> };
+    receiver?: { token?: Pick<ISwapToken, 'price' | 'currency'> };
   };
+  defaultTokenCurrency?: string;
+  currencyMap?: Record<string, ICurrencyItem>;
 }): ISwapPreSwapData['rateDifference'] {
   return buildSwapRateDifference({
     fromTokenPrice: swapInfo?.sender?.token?.price,
     toTokenPrice: swapInfo?.receiver?.token?.price,
+    fromTokenCurrency: swapInfo?.sender?.token?.currency,
+    toTokenCurrency: swapInfo?.receiver?.token?.currency,
+    defaultTokenCurrency,
+    currencyMap,
     instantRate: quoteResult?.instantRate,
   });
 }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/usePaymentTokenPrice.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/usePaymentTokenPrice.test.tsx
@@ -1,0 +1,129 @@
+/** @jest-environment jsdom */
+
+import { renderHook } from '@testing-library/react';
+
+import type {
+  ISwapToken,
+  ISwapTokenBase,
+} from '@onekeyhq/shared/types/swap/types';
+
+import { usePaymentTokenPrice } from './usePaymentTokenPrice';
+
+type IFetchSwapTokenDetailsParams = {
+  networkId?: string;
+  contractAddress?: string;
+  currency?: string;
+};
+
+type IPaymentTokenPriceResult = {
+  tokenDetail?: ISwapToken;
+  tokenKey: string;
+};
+
+const mockFetchSwapTokenDetails: jest.MockedFunction<
+  (params: IFetchSwapTokenDetailsParams) => Promise<ISwapToken[]>
+> = jest.fn();
+const mockRun = jest.fn();
+let mockPromiseResult: IPaymentTokenPriceResult | undefined;
+let mockCapturedMethod:
+  | (() => Promise<IPaymentTokenPriceResult | undefined>)
+  | undefined;
+let mockCapturedDeps: unknown[] = [];
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceSwap: {
+      fetchSwapTokenDetails: (params: IFetchSwapTokenDetailsParams) =>
+        mockFetchSwapTokenDetails(params),
+    },
+  },
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => ({
+  usePromiseResult: (
+    method: () => Promise<IPaymentTokenPriceResult | undefined>,
+    deps: unknown[],
+  ) => {
+    mockCapturedMethod = method;
+    mockCapturedDeps = deps;
+    return {
+      result: mockPromiseResult,
+      isLoading: false,
+      run: mockRun,
+    };
+  },
+}));
+
+const paymentToken: ISwapTokenBase = {
+  networkId: 'evm--1',
+  contractAddress: '0xusdc',
+  symbol: 'USDC',
+  decimals: 6,
+  isNative: false,
+};
+
+describe('usePaymentTokenPrice', () => {
+  beforeEach(() => {
+    mockFetchSwapTokenDetails.mockReset();
+    mockRun.mockReset();
+    mockPromiseResult = undefined;
+    mockCapturedMethod = undefined;
+    mockCapturedDeps = [];
+  });
+
+  it('requests token detail with the selected currency and returns a currency-aware key', async () => {
+    mockFetchSwapTokenDetails.mockResolvedValue([
+      {
+        ...paymentToken,
+        price: '7',
+      },
+    ]);
+
+    renderHook(() => usePaymentTokenPrice(paymentToken, 'evm--1', 'cny'));
+
+    const result = await mockCapturedMethod?.();
+
+    expect(mockFetchSwapTokenDetails).toHaveBeenCalledWith({
+      networkId: 'evm--1',
+      contractAddress: '0xusdc',
+      currency: 'cny',
+    });
+    expect(result).toEqual({
+      tokenDetail: expect.objectContaining({
+        price: '7',
+        currency: 'cny',
+      }),
+      tokenKey: 'evm--1:0xusdc:cny',
+    });
+    expect(mockCapturedDeps).toContain('cny');
+    expect(mockCapturedDeps).toContain('evm--1:0xusdc:cny');
+  });
+
+  it('does not fetch until a currency id is available', async () => {
+    renderHook(() => usePaymentTokenPrice(paymentToken, 'evm--1'));
+
+    const result = await mockCapturedMethod?.();
+
+    expect(result).toBeUndefined();
+    expect(mockFetchSwapTokenDetails).not.toHaveBeenCalled();
+  });
+
+  it('exposes the current currency-scoped price result', () => {
+    mockPromiseResult = {
+      tokenDetail: {
+        ...paymentToken,
+        price: '9',
+        currency: 'cny',
+      },
+      tokenKey: 'evm--1:0xusdc:cny',
+    };
+
+    const { result } = renderHook(() =>
+      usePaymentTokenPrice(paymentToken, 'evm--1', 'cny'),
+    );
+
+    expect(result.current.price?.toFixed()).toBe('9');
+    expect(result.current.tokenKey).toBe('evm--1:0xusdc:cny');
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/usePaymentTokenPrice.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/usePaymentTokenPrice.ts
@@ -24,17 +24,20 @@ type IPaymentTokenPriceResult = {
 export function usePaymentTokenPrice(
   paymentToken?: ISwapTokenBase,
   networkId?: string,
+  currencyId?: string,
 ): IUsePaymentTokenPriceResult {
   const hasPaymentToken = Boolean(paymentToken);
   const paymentContractAddress = paymentToken?.contractAddress ?? '';
-  const paymentTokenKey = `${networkId ?? ''}:${paymentContractAddress}`;
+  const paymentTokenKey = `${networkId ?? ''}:${paymentContractAddress}:${
+    currencyId ?? ''
+  }`;
   const {
     result: paymentTokenPriceResult,
     isLoading,
     run: refetch,
   } = usePromiseResult(
     async (): Promise<IPaymentTokenPriceResult | undefined> => {
-      if (!networkId || !hasPaymentToken) {
+      if (!networkId || !currencyId || !hasPaymentToken) {
         return undefined;
       }
 
@@ -42,15 +45,27 @@ export function usePaymentTokenPrice(
         {
           networkId,
           contractAddress: paymentContractAddress,
+          currency: currencyId,
         },
       );
 
       return {
-        tokenDetail: detail?.[0],
+        tokenDetail: detail?.[0]
+          ? {
+              ...detail[0],
+              currency: currencyId,
+            }
+          : undefined,
         tokenKey: paymentTokenKey,
       };
     },
-    [hasPaymentToken, networkId, paymentContractAddress, paymentTokenKey],
+    [
+      currencyId,
+      hasPaymentToken,
+      networkId,
+      paymentContractAddress,
+      paymentTokenKey,
+    ],
     {
       watchLoading: true,
       pollingInterval: 5000, // 5 seconds

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
@@ -46,6 +46,7 @@ type IUsePaymentTokenPriceResult = {
 type IUsePaymentTokenPriceMock = (
   paymentToken?: ISwapTokenBase & { price?: string },
   networkId?: string,
+  currencyId?: string,
 ) => IUsePaymentTokenPriceResult;
 
 const mockFetchSwapTokenDetails: jest.MockedFunction<
@@ -86,6 +87,10 @@ let mockInAppNotificationAtomState: {
     status?: string;
   };
 } = {};
+let mockCurrencyInfo = {
+  id: 'usd',
+  symbol: '$',
+};
 
 jest.mock('react-intl', () => ({
   useIntl: () => ({
@@ -149,11 +154,13 @@ jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
   ],
   useSettingsPersistAtom: () => [
     {
-      currencyInfo: {
-        id: 'usd',
-        symbol: '$',
-      },
+      currencyInfo: mockCurrencyInfo,
       isFirstTimeSwap: false,
+    },
+  ],
+  useCurrencyPersistAtom: () => [
+    {
+      currencyMap: {},
     },
   ],
 }));
@@ -176,8 +183,9 @@ jest.mock('./usePaymentTokenPrice', () => ({
   usePaymentTokenPrice: (
     paymentToken?: ISwapTokenBase & { price?: string },
     networkId?: string,
+    currencyId?: string,
   ): IUsePaymentTokenPriceResult =>
-    mockUsePaymentTokenPrice(paymentToken, networkId),
+    mockUsePaymentTokenPrice(paymentToken, networkId, currencyId),
 }));
 
 function createDeferred<T>() {
@@ -255,8 +263,14 @@ const solToken: ISwapTokenBase = {
   isNative: false,
 };
 
-function getTokenKey(token?: ISwapTokenBase, networkId?: string) {
-  return `${networkId ?? token?.networkId ?? ''}:${token?.contractAddress ?? ''}`;
+function getTokenKey(
+  token?: ISwapTokenBase,
+  networkId?: string,
+  currencyId = 'usd',
+) {
+  return `${networkId ?? token?.networkId ?? ''}:${
+    token?.contractAddress ?? ''
+  }:${currencyId}`;
 }
 
 function createHookProps({
@@ -267,8 +281,14 @@ function createHookProps({
   tradeToken?: ISwapTokenBase;
 } = {}) {
   return {
-    marketToken,
-    tradeToken,
+    marketToken: {
+      ...marketToken,
+      currency: marketToken.currency ?? 'usd',
+    },
+    tradeToken: {
+      ...tradeToken,
+      currency: tradeToken.currency ?? 'usd',
+    },
     tradeType: ESwapDirection.BUY,
     fromTokenAmount: '0',
     provider: 'onekey',
@@ -294,6 +314,7 @@ describe('useSpeedSwapActions', () => {
       (
         paymentToken?: ISwapTokenBase & { price?: string },
         networkId?: string,
+        currencyId?: string,
       ) => {
         const priceValue = paymentToken?.price;
         let price: BigNumber | undefined;
@@ -306,12 +327,16 @@ describe('useSpeedSwapActions', () => {
         }
         return {
           price,
-          tokenKey: getTokenKey(paymentToken, networkId),
+          tokenKey: getTokenKey(paymentToken, networkId, currencyId),
           isLoading: false,
           refetch: jest.fn(),
         };
       },
     );
+    mockCurrencyInfo = {
+      id: 'usd',
+      symbol: '$',
+    };
     mockFetchSwapNativeTokenConfig.mockResolvedValue({
       networkId: 'evm--1',
       reserveGas: '0.01',
@@ -773,6 +798,143 @@ describe('useSpeedSwapActions', () => {
     });
 
     expect(mockFetchSwapTokenDetails).not.toHaveBeenCalled();
+  });
+
+  it('ignores live payment token prices from a stale currency scope', async () => {
+    mockCurrencyInfo = {
+      id: 'cny',
+      symbol: 'CNY',
+    };
+    mockNetAccountPromiseResult = {
+      result: undefined,
+      run: mockNetAccountRun,
+    };
+    mockUsePaymentTokenPrice.mockReturnValue({
+      price: new BigNumber(2),
+      tokenKey: getTokenKey(usdcToken, undefined, 'usd'),
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+
+    const { result } = renderHook(() =>
+      useSpeedSwapActions(
+        createHookProps({
+          marketToken: {
+            ...tonMarketToken,
+            price: '5',
+            currency: 'cny',
+          },
+          tradeToken: {
+            ...usdcToken,
+            price: '10',
+            currency: 'cny',
+          },
+        }),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(mockUsePaymentTokenPrice).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contractAddress: usdcToken.contractAddress,
+        }),
+        usdcToken.networkId,
+        'cny',
+      );
+      expect(result.current.priceRate?.rate).toBeCloseTo(2);
+    });
+
+    expect(mockFetchSwapTokenDetails).not.toHaveBeenCalled();
+  });
+
+  it('falls back to same-currency fetched prices when inline price currencies differ', async () => {
+    mockCurrencyInfo = {
+      id: 'cny',
+      symbol: 'CNY',
+    };
+    mockNetAccountPromiseResult = {
+      result: undefined,
+      run: mockNetAccountRun,
+    };
+    mockUsePaymentTokenPrice.mockReturnValue({
+      price: new BigNumber(10),
+      tokenKey: getTokenKey(usdcToken, undefined, 'cny'),
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+    mockFetchSwapTokenDetails.mockImplementation(
+      ({
+        accountId,
+        networkId,
+        contractAddress,
+      }: IFetchSwapTokenDetailsParams) => {
+        if (accountId) {
+          return Promise.resolve([]);
+        }
+
+        const requestKey = `${networkId ?? ''}:${contractAddress ?? ''}`;
+        switch (requestKey) {
+          case `${usdcToken.networkId}:${usdcToken.contractAddress}`:
+            return Promise.resolve(
+              createTokenDetail({
+                networkId: usdcToken.networkId,
+                contractAddress: usdcToken.contractAddress,
+                symbol: usdcToken.symbol,
+                decimals: usdcToken.decimals,
+                price: '2',
+              }),
+            );
+          case `${tonMarketToken.networkId}:${tonMarketToken.contractAddress}`:
+            return Promise.resolve(
+              createTokenDetail({
+                networkId: tonMarketToken.networkId,
+                contractAddress: tonMarketToken.contractAddress,
+                symbol: tonMarketToken.symbol,
+                decimals: tonMarketToken.decimals,
+                price: '4',
+              }),
+            );
+          default:
+            return Promise.resolve([]);
+        }
+      },
+    );
+
+    const { result } = renderHook(() =>
+      useSpeedSwapActions(
+        createHookProps({
+          marketToken: {
+            ...tonMarketToken,
+            price: '5',
+            currency: 'usd',
+          },
+          tradeToken: {
+            ...usdcToken,
+            price: '10',
+            currency: 'cny',
+          },
+        }),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.priceRate?.rate).toBeCloseTo(0.5);
+    });
+
+    expect(mockFetchSwapTokenDetails).toHaveBeenCalledWith(
+      expect.objectContaining({
+        networkId: usdcToken.networkId,
+        contractAddress: usdcToken.contractAddress,
+        currency: 'usd',
+      }),
+    );
+    expect(mockFetchSwapTokenDetails).toHaveBeenCalledWith(
+      expect.objectContaining({
+        networkId: tonMarketToken.networkId,
+        contractAddress: tonMarketToken.contractAddress,
+        currency: 'usd',
+      }),
+    );
   });
 });
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -28,6 +28,7 @@ import type {
 } from '@onekeyhq/kit/src/views/Swap/utils/swapReviewState';
 import { getSwapExecutionTypeFromQuoteResult } from '@onekeyhq/kit/src/views/Swap/utils/swapTypeUtils';
 import {
+  useCurrencyPersistAtom,
   useInAppNotificationAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -164,11 +165,13 @@ export function buildMarketReviewTokens({
   fromToken,
   toToken,
   tradeTokenPrice,
+  tradeTokenCurrency,
 }: {
   tradeType: ESwapDirection;
   fromToken: ISwapToken;
   toToken: ISwapToken;
   tradeTokenPrice?: BigNumber;
+  tradeTokenCurrency?: string;
 }) {
   if (!tradeTokenPrice || tradeTokenPrice.isNaN() || !tradeTokenPrice.gt(0)) {
     return { fromToken, toToken };
@@ -181,6 +184,7 @@ export function buildMarketReviewTokens({
       fromToken: {
         ...fromToken,
         price: resolvedPrice,
+        currency: tradeTokenCurrency ?? fromToken.currency,
       },
       toToken,
     };
@@ -191,6 +195,7 @@ export function buildMarketReviewTokens({
     toToken: {
       ...toToken,
       price: resolvedPrice,
+      currency: tradeTokenCurrency ?? toToken.currency,
     },
   };
 }
@@ -345,6 +350,7 @@ export function useSpeedSwapActions(props: {
   const [inAppNotificationAtom, setInAppNotificationAtom] =
     useInAppNotificationAtom();
   const [settingsAtom] = useSettingsPersistAtom();
+  const [{ currencyMap }] = useCurrencyPersistAtom();
   const { activeAccount: account } = useActiveAccount({ num: 0 });
   const [shouldApprove, setShouldApprove] = useState(false);
   const [shouldResetApprove, setShouldResetApprove] = useState(false);
@@ -398,19 +404,28 @@ export function useSpeedSwapActions(props: {
       balanceToken: marketToken,
     };
   }, [tradeType, marketToken, tradeToken]);
-  const tradeTokenPriceKey = `${tradeToken.networkId ?? ''}:${tradeToken.contractAddress ?? ''}`;
+  const currentCurrencyId = settingsAtom.currencyInfo.id;
+  const tradeTokenPriceKey = `${tradeToken.networkId ?? ''}:${
+    tradeToken.contractAddress ?? ''
+  }:${currentCurrencyId}`;
   const { price: liveTradeTokenPrice, tokenKey: liveTradeTokenPriceKey } =
-    usePaymentTokenPrice(tradeToken, tradeToken.networkId);
+    usePaymentTokenPrice(tradeToken, tradeToken.networkId, currentCurrencyId);
+  const fallbackTradeTokenPrice = useMemo(() => {
+    if (tradeToken.currency && tradeToken.currency !== currentCurrencyId) {
+      return new BigNumber(0);
+    }
+    return new BigNumber(tradeToken.price || 0);
+  }, [currentCurrencyId, tradeToken.currency, tradeToken.price]);
   const effectiveTradeTokenPrice = useMemo(() => {
     if (liveTradeTokenPriceKey === tradeTokenPriceKey) {
-      return liveTradeTokenPrice ?? new BigNumber(tradeToken.price || 0);
+      return liveTradeTokenPrice ?? fallbackTradeTokenPrice;
     }
 
-    return new BigNumber(tradeToken.price || 0);
+    return fallbackTradeTokenPrice;
   }, [
+    fallbackTradeTokenPrice,
     liveTradeTokenPrice,
     liveTradeTokenPriceKey,
-    tradeToken.price,
     tradeTokenPriceKey,
   ]);
 
@@ -1164,6 +1179,8 @@ export function useSpeedSwapActions(props: {
         rateDifference: buildMarketReviewRateDifference({
           quoteResult: snapshot.quoteResult,
           swapInfo: snapshot.swapInfo,
+          defaultTokenCurrency: settingsAtom.currencyInfo.id,
+          currencyMap,
         }),
         texts: buildReviewStepTexts(snapshot.quoteResult.info.providerName),
       });
@@ -1246,7 +1263,13 @@ export function useSpeedSwapActions(props: {
         quoteResult: snapshot.quoteResult,
       };
     },
-    [buildMarketApproveUnsignedTxArr, buildReviewStepTexts, slippage],
+    [
+      buildMarketApproveUnsignedTxArr,
+      buildReviewStepTexts,
+      currencyMap,
+      settingsAtom.currencyInfo.id,
+      slippage,
+    ],
   );
 
   const estimateMarketPresetNetworkFees = useCallback(
@@ -1326,6 +1349,7 @@ export function useSpeedSwapActions(props: {
           fromToken: fromTokenFinal,
           toToken: toTokenFinal,
           tradeTokenPrice: effectiveTradeTokenPrice,
+          tradeTokenCurrency: currentCurrencyId,
         });
 
       if (isWrap || isWrapped) {
@@ -1443,7 +1467,9 @@ export function useSpeedSwapActions(props: {
       buildMarketReviewStateFromSnapshot,
       buildSpeedSwapTxData,
       buildWrappedSwapData,
+      currentCurrencyId,
       effectiveSpenderAddress,
+      effectiveTradeTokenPrice,
       fromToken,
       fromTokenAmountDebounced,
       isCustomRpcUnavailable,
@@ -1453,7 +1479,6 @@ export function useSpeedSwapActions(props: {
       shouldApprove,
       shouldResetApprove,
       slippage,
-      effectiveTradeTokenPrice,
       tradeType,
       toToken,
     ],
@@ -2643,7 +2668,17 @@ export function useSpeedSwapActions(props: {
       tradeType === ESwapDirection.SELL
         ? effectiveTradeTokenPrice
         : new BigNumber(toToken.price || 0);
+    const fromTokenPriceCurrency =
+      tradeType === ESwapDirection.BUY ? currentCurrencyId : fromToken.currency;
+    const toTokenPriceCurrency =
+      tradeType === ESwapDirection.SELL ? currentCurrencyId : toToken.currency;
+    const canUseInlinePriceCurrencies =
+      (!fromTokenPriceCurrency && !toTokenPriceCurrency) ||
+      (!!fromTokenPriceCurrency &&
+        !!toTokenPriceCurrency &&
+        fromTokenPriceCurrency === toTokenPriceCurrency);
     const canUseInlineTokenPrices =
+      canUseInlinePriceCurrencies &&
       !fromTokenPriceBN.isNaN() &&
       !toTokenPriceBN.isNaN() &&
       fromTokenPriceBN.gt(0) &&
@@ -2737,11 +2772,14 @@ export function useSpeedSwapActions(props: {
     });
   }, [
     effectiveTradeTokenPrice,
+    currentCurrencyId,
     tradeType,
+    fromToken.currency,
     fromToken.price,
     fromToken.symbol,
     fromToken.networkId,
     fromToken.contractAddress,
+    toToken.currency,
     toToken.price,
     toToken.symbol,
     toToken.networkId,

--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/useAutoRefreshTokenDetail.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/useAutoRefreshTokenDetail.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 
+import { useCurrency } from '@onekeyhq/kit/src/components/Currency';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useTokenDetailActions } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import { useTokenDetail } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/hooks/useTokenDetail';
@@ -19,6 +20,7 @@ function toFiniteNumber(value?: string | number) {
 
 export function useAutoRefreshTokenDetail(data: IUseMarketDetailDataProps) {
   const { current: tokenDetailActions } = useTokenDetailActions();
+  const currencyInfo = useCurrency();
   const { tokenDetail, networkId } = useTokenDetail();
   const [, setCurrentTokenLiveData] = useMarketCurrentTokenLiveDataAtom();
 
@@ -57,19 +59,25 @@ export function useAutoRefreshTokenDetail(data: IUseMarketDetailDataProps) {
     [setCurrentTokenLiveData],
   );
 
-  // Track previous token to detect when switching to a different token
-  const prevTokenRef = useRef<{ tokenAddress: string; networkId: string }>({
+  // Track previous price scope to avoid showing stale token or currency data.
+  const prevTokenRef = useRef<{
+    tokenAddress: string;
+    networkId: string;
+    currencyId: string;
+  }>({
     tokenAddress: '',
     networkId: '',
+    currencyId: '',
   });
 
-  // Clear cached token detail when switching to a different token
-  // This prevents showing stale data from the previous token
+  // Clear cached token detail when switching token or display currency.
+  // This prevents showing stale data from the previous price scope.
   useEffect(() => {
     const prevToken = prevTokenRef.current;
     const isTokenChanged =
       prevToken.tokenAddress !== data.tokenAddress ||
-      prevToken.networkId !== data.networkId;
+      prevToken.networkId !== data.networkId ||
+      prevToken.currencyId !== currencyInfo.id;
 
     if (isTokenChanged && prevToken.tokenAddress !== '') {
       // Only clear display-related atoms when switching tokens.
@@ -85,8 +93,9 @@ export function useAutoRefreshTokenDetail(data: IUseMarketDetailDataProps) {
     prevTokenRef.current = {
       tokenAddress: data.tokenAddress,
       networkId: data.networkId,
+      currencyId: currencyInfo.id,
     };
-  }, [data.tokenAddress, data.networkId, tokenDetailActions]);
+  }, [currencyInfo.id, data.tokenAddress, data.networkId, tokenDetailActions]);
 
   // Set tokenAddress/networkId/isNative synchronously on prop change,
   // NOT inside the polling callback. This prevents stale polling responses
@@ -99,13 +108,16 @@ export function useAutoRefreshTokenDetail(data: IUseMarketDetailDataProps) {
 
   return usePromiseResult(
     async () => {
+      if (!currencyInfo.id) {
+        return;
+      }
       // Only fetch token detail data; atom identity is set synchronously above
       await tokenDetailActions.fetchTokenDetail(
         data.tokenAddress,
         data.networkId,
       );
     },
-    [data.tokenAddress, data.networkId, tokenDetailActions],
+    [currencyInfo.id, data.tokenAddress, data.networkId, tokenDetailActions],
     {
       pollingInterval: 6000, // Changed from 5000 to 6000 to avoid race condition with K-line updates
       revalidateOnFocus: true,

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts
@@ -81,6 +81,30 @@ describe('stock metadata values', () => {
     expect(token.marketCap).toBe(3000);
     expect(token.turnover).toBe(4000);
   });
+
+  test('uses 24h price change for stock rows regardless of selected time range', () => {
+    const token = transformApiItemToToken(
+      {
+        address: '0x390a684ef9cade28a7ad0dfa61ab1eb3842618c4',
+        name: 'Stock Token',
+        symbol: 'STOCK',
+        decimals: 18,
+        priceChange1hPercent: '12.34',
+        priceChange24hPercent: '-0.62',
+        stock: {
+          subtitle: 'Stock Token Inc.',
+          sourceLogoUri: '',
+        },
+      },
+      {
+        chainId: 'evm--1',
+        networkLogoUri: '',
+        timeRange: '1h',
+      },
+    );
+
+    expect(token.change24h).toBe(-0.62);
+  });
 });
 
 describe('shouldShowStockSubtitleForTokens', () => {

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
@@ -164,11 +164,12 @@ export function transformApiItemToToken(
     ? getNetworkLogoUri(item.networkId)
     : networkLogoUri;
 
-  const priceChange = safeNumber(
-    getMetricValueByTimeRange(item, timeRange, 'priceChange', 'Percent') as
-      | string
-      | undefined,
-  );
+  const priceChangeValue = item.stock
+    ? item.priceChange24hPercent
+    : (getMetricValueByTimeRange(item, timeRange, 'priceChange', 'Percent') as
+        | string
+        | undefined);
+  const priceChange = safeNumber(priceChangeValue);
   const transactions = safeNumber(
     getMetricValueByTimeRange(item, timeRange, 'trade', 'Count') as
       | string

--- a/packages/kit/src/views/Prime/pages/PrimeFeatures/PrimeFeatureIntroContent.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeFeatures/PrimeFeatureIntroContent.tsx
@@ -26,7 +26,6 @@ import {
   XStack,
   YStack,
   useMedia,
-  useSafeAreaInsets,
 } from '@onekeyhq/components';
 import type { IVideoRef } from '@onekeyhq/components';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
@@ -471,7 +470,6 @@ export function PrimeFeatureIntroContent({
   const intl = useIntl();
   const navigation = useAppNavigation();
   const { gtMd } = useMedia();
-  const { bottom: safeAreaBottom } = useSafeAreaInsets();
   const {
     isReady: isAuthReady,
     isLoggedIn,
@@ -875,10 +873,10 @@ export function PrimeFeatureIntroContent({
   }
   const contentMaxWidth = usePageFooter || !gtMd ? undefined : 640;
   const shouldSquareBottomContentCorners = useDialogFooter && !gtMd;
-  const dialogFooterBottomPadding =
-    useDialogFooter && !gtMd && safeAreaBottom
-      ? safeAreaBottom + DIALOG_FOOTER_BOTTOM_PADDING
-      : DIALOG_FOOTER_BOTTOM_PADDING;
+  // The Dialog frame applies the bottom safe-area inset itself, so the footer
+  // only needs its design padding — adding safeAreaBottom here too would
+  // double-stack the inset on notched iOS.
+  const dialogFooterBottomPadding = DIALOG_FOOTER_BOTTOM_PADDING;
   const shouldShowFooterAction = ctaKind !== 'none';
   const isFooterActionDisabled =
     shouldUseComingSoonCta ||

--- a/packages/kit/src/views/Prime/pages/PrimeFeatures/PrimeFeatureIntroContent.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeFeatures/PrimeFeatureIntroContent.tsx
@@ -96,6 +96,7 @@ const DIALOG_FOOTER_BOTTOM_PADDING = 20;
 const MOBILE_DIALOG_VIDEO_LOAD_DELAY_MS = 300;
 const VIDEO_END_PAUSE_MS = 1000;
 const VIDEO_POSTER_FADE_DURATION_MS = 220;
+const ANDROID_VIDEO_ACTIVATE_DELAY_MS = 120;
 const DIALOG_CONTENT_SWIPE_THRESHOLD = 32;
 const primeFeatureOverlayButtonIconProps = { color: '$whiteA10' } as const;
 const primeFeatureOverlayButtonHoverStyle = { bg: '$whiteA4' } as const;
@@ -237,6 +238,10 @@ const PrimeFeatureMedia = memo(
 
       setShouldPlayVideo(true);
       posterOpacity.stopAnimation();
+      if (platformEnv.isNativeAndroid) {
+        posterOpacity.setValue(0);
+        return;
+      }
       Animated.timing(posterOpacity, {
         toValue: 0,
         duration: VIDEO_POSTER_FADE_DURATION_MS,
@@ -249,6 +254,7 @@ const PrimeFeatureMedia = memo(
         return;
       }
 
+      let loadVideoTimer: ReturnType<typeof setTimeout> | undefined;
       const controller = videoLoopControllerRef.current;
       const wasActive = controller.isActive;
       controller.isActive = isActive;
@@ -256,18 +262,35 @@ const PrimeFeatureMedia = memo(
       resetVideoToPoster();
       controller.hasHandledEnd = false;
 
-      if (isActive && canLoadVideo) {
+      const loadActiveVideo = () => {
         setShouldLoadVideo(true);
         if (!wasActive && videoRef.current) {
           videoRef.current.seek(0);
           videoRef.current.resume();
           showVideo();
         }
-      } else if (!canLoadVideo) {
+      };
+
+      if (isActive && canLoadVideo) {
+        if (platformEnv.isNativeAndroid && !wasActive) {
+          setShouldLoadVideo(false);
+          loadVideoTimer = setTimeout(
+            loadActiveVideo,
+            ANDROID_VIDEO_ACTIVATE_DELAY_MS,
+          );
+        } else {
+          loadActiveVideo();
+        }
+      } else if (!canLoadVideo || platformEnv.isNativeAndroid) {
         setShouldLoadVideo(false);
       }
 
-      return clearVideoEndTimer;
+      return () => {
+        if (loadVideoTimer) {
+          clearTimeout(loadVideoTimer);
+        }
+        clearVideoEndTimer();
+      };
     }, [
       canLoadVideo,
       clearVideoEndTimer,

--- a/packages/kit/src/views/Setting/pages/Protection/KYTIntroDialog.tsx
+++ b/packages/kit/src/views/Setting/pages/Protection/KYTIntroDialog.tsx
@@ -11,7 +11,6 @@ import {
   getDialogInstances,
   rootNavigationRef,
   useMedia,
-  useSafeAreaInsets,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useOneKeyAuthMethods } from '@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth';
@@ -130,11 +129,9 @@ function useKYTIntroDialog() {
   const intl = useIntl();
   const navigation = useAppNavigation();
   const { md } = useMedia();
-  const { bottom } = useSafeAreaInsets();
   const { isPrimeSubscriptionActive } = useOneKeyAuthMethods();
   const [{ onekeyUserId }] = usePrimePersistAtom();
   const [appUpdateInfo] = useAppUpdatePersistAtom();
-  const mobileFooterBottomPadding = Math.max(bottom, 20) + 20;
   // Authoritative "Home is the focused tab" signal, written by the tab listener.
   const isHomeTabFocusedRef = useRef(false);
   // Becomes true once the Home token list has finished its first load (or a
@@ -180,7 +177,8 @@ function useKYTIntroDialog() {
         ? {
             flexDirection: 'column-reverse',
             gap: '$2.5',
-            pb: mobileFooterBottomPadding,
+            // No bottom safe-area inset here: the Dialog frame already pads by
+            // the safe-area bottom, so the footer keeps only its default "$5".
           }
         : undefined,
       confirmButtonProps: md
@@ -232,7 +230,7 @@ function useKYTIntroDialog() {
         }
       },
     });
-  }, [intl, md, mobileFooterBottomPadding, navigation, onekeyUserId]);
+  }, [intl, md, navigation, onekeyUserId]);
 
   // "Ready" = Home is the foreground tab, Home has finished its first load, and
   // the app-update flow is settled — everything except transient overlays. Both

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -48,6 +48,7 @@ import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { calculateFeeForSend } from '@onekeyhq/shared/src/utils/feeUtils';
 import { createLazySdkLoader } from '@onekeyhq/shared/src/utils/lazySdkLoader';
 import { applyCustomPriorityFeeToGasInfo } from '@onekeyhq/shared/src/utils/marketPresetFeeUtils';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   numberFormat,
@@ -125,8 +126,11 @@ import {
 } from '../../../states/jotai/contexts/swap';
 import { buildSwapApproveAndSendSteps } from '../utils/buildSwapReviewState';
 import {
+  type ISwapBtcOutputValidationError,
   checkSwapLatestBalanceSufficient,
+  getSwapEncodedTxSize,
   getSwapRequiredNativeBalanceAmount,
+  validateSwapBtcOutputs,
 } from '../utils/swapBalanceUtils';
 import {
   SWAP_STOCK_ANALYTICS_ORDER_TYPE,
@@ -146,6 +150,12 @@ const getEthers = createLazySdkLoader(() => import('ethers'));
 
 const formatter: INumberFormatProps = {
   formatter: 'balance',
+};
+
+type ISwapGasFeeInfo = {
+  encodeTx: IEncodedTx;
+  gasInfo: ISwapGasInfo;
+  txSize?: number;
 };
 
 type ISwapSendTxResult = ISignedTxPro & {
@@ -487,6 +497,74 @@ export function useSwapBuildTx() {
     [clearQuoteData, generateSwapHistoryItem, setSwapSteps, fromAccountId],
   );
 
+  const getSwapBalanceInsufficientToast = useCallback(
+    ({
+      networkId,
+      tokenSymbol,
+      reserveAmount,
+    }: {
+      networkId?: string;
+      tokenSymbol: string;
+      reserveAmount?: string;
+    }) => {
+      const isBtcNetwork = networkUtils.isBTCNetwork(networkId);
+      return {
+        title: isBtcNetwork
+          ? intl.formatMessage({
+              id: ETranslations.send_toast_btc_fork_insufficient_fund,
+            })
+          : intl.formatMessage(
+              {
+                id: ETranslations.swap_page_toast_insufficient_balance_title,
+              },
+              { token: tokenSymbol },
+            ),
+        message:
+          !isBtcNetwork && reserveAmount
+            ? intl.formatMessage(
+                {
+                  id: ETranslations.swap_page_toast_insufficient_balance_content,
+                },
+                {
+                  token: tokenSymbol,
+                  number: numberFormat(reserveAmount, formatter),
+                },
+              )
+            : undefined,
+      };
+    },
+    [intl],
+  );
+
+  const getSwapBtcOutputValidationToast = useCallback(
+    ({
+      networkId,
+      tokenSymbol,
+      validationError,
+    }: {
+      networkId?: string;
+      tokenSymbol: string;
+      validationError: ISwapBtcOutputValidationError;
+    }) => {
+      if (validationError.type === 'payment_output_less_than_order_amount') {
+        return getSwapBalanceInsufficientToast({
+          networkId,
+          tokenSymbol,
+        });
+      }
+
+      return {
+        title: intl.formatMessage({
+          id: ETranslations.swap_page_toast_swap_failed,
+        }),
+        message: intl.formatMessage({
+          id: ETranslations.global_unknown_error_retry_message,
+        }),
+      };
+    },
+    [getSwapBalanceInsufficientToast, intl],
+  );
+
   const checkOtherFee = useCallback(
     async (quoteResult: IFetchQuoteResult) => {
       const otherFeeInfo = quoteResult?.fee?.otherFeeInfos;
@@ -513,21 +591,11 @@ export function useSwapBuildTx() {
             });
             if (!checkResult.isSufficient) {
               Toast.error({
-                title: intl.formatMessage(
-                  {
-                    id: ETranslations.swap_page_toast_insufficient_balance_title,
-                  },
-                  { token: checkResult.tokenSymbol },
-                ),
-                message: intl.formatMessage(
-                  {
-                    id: ETranslations.swap_page_toast_insufficient_balance_content,
-                  },
-                  {
-                    token: checkResult.tokenSymbol,
-                    number: numberFormat(tokenAmountBN.toFixed(), formatter),
-                  },
-                ),
+                ...getSwapBalanceInsufficientToast({
+                  networkId: item.token.networkId,
+                  tokenSymbol: checkResult.tokenSymbol,
+                  reserveAmount: tokenAmountBN.toFixed(),
+                }),
               });
               checkRes = false;
             }
@@ -536,21 +604,25 @@ export function useSwapBuildTx() {
       }
       return checkRes;
     },
-    [fromToken, intl, selectQuote?.fromAmount, fromUserAddress, fromAccountId],
+    [
+      fromToken,
+      selectQuote?.fromAmount,
+      fromUserAddress,
+      fromAccountId,
+      getSwapBalanceInsufficientToast,
+    ],
   );
 
   const showLatestBalanceInsufficientToast = useCallback(
-    (tokenSymbol: string) => {
+    (networkId: string | undefined, tokenSymbol: string) => {
       Toast.error({
-        title: intl.formatMessage(
-          {
-            id: ETranslations.swap_page_toast_insufficient_balance_title,
-          },
-          { token: tokenSymbol },
-        ),
+        ...getSwapBalanceInsufficientToast({
+          networkId,
+          tokenSymbol,
+        }),
       });
     },
-    [intl],
+    [getSwapBalanceInsufficientToast],
   );
 
   const checkLatestFromTokenBalance = useCallback(
@@ -562,7 +634,10 @@ export function useSwapBuildTx() {
         accountId: fromAccountId,
       });
       if (!checkResult.isSufficient) {
-        showLatestBalanceInsufficientToast(checkResult.tokenSymbol);
+        showLatestBalanceInsufficientToast(
+          token.networkId,
+          checkResult.tokenSymbol,
+        );
         return false;
       }
       return true;
@@ -578,7 +653,7 @@ export function useSwapBuildTx() {
       amount,
       otherFeeInfos,
     }: {
-      gasInfos?: { gasInfo?: ISwapGasInfo }[];
+      gasInfos?: { gasInfo?: ISwapGasInfo; txSize?: number }[];
       networkId?: string;
       token?: ISwapToken;
       amount?: string;
@@ -609,35 +684,23 @@ export function useSwapBuildTx() {
           checkResult.tokenSymbol,
           nativeBalanceRequirement.reserveAmount,
         ].join('-');
-        const reserveAmountMessage = nativeBalanceRequirement.includesFromAmount
-          ? undefined
-          : intl.formatMessage(
-              {
-                id: ETranslations.swap_page_toast_insufficient_balance_content,
-              },
-              {
-                token: checkResult.tokenSymbol,
-                number: numberFormat(
-                  nativeBalanceRequirement.reserveAmount,
-                  formatter,
-                ),
-              },
-            );
+        const { title, message } = getSwapBalanceInsufficientToast({
+          networkId: nativeBalanceRequirement.token.networkId,
+          tokenSymbol: checkResult.tokenSymbol,
+          reserveAmount: nativeBalanceRequirement.includesFromAmount
+            ? undefined
+            : nativeBalanceRequirement.reserveAmount,
+        });
         Toast.error({
-          title: intl.formatMessage(
-            {
-              id: ETranslations.swap_page_toast_insufficient_balance_title,
-            },
-            { token: checkResult.tokenSymbol },
-          ),
-          message: reserveAmountMessage,
+          title,
+          message,
           toastId,
         });
         return false;
       }
       return true;
     },
-    [fromAccountId, fromUserAddress, intl],
+    [fromAccountId, fromUserAddress, getSwapBalanceInsufficientToast],
   );
 
   const cancelLimitOrder = useCallback(
@@ -790,6 +853,46 @@ export function useSwapBuildTx() {
             feeBudget: gasInfo.feeBudget,
           },
         });
+      const txSize =
+        getSwapEncodedTxSize(updatedUnsignedTxItem.encodedTx) ??
+        updatedUnsignedTxItem.txSize ??
+        getSwapEncodedTxSize(unsignedTxItem.encodedTx) ??
+        unsignedTxItem.txSize;
+      const btcOutputValidationError = validateSwapBtcOutputs({
+        networkId,
+        encodedTx: updatedUnsignedTxItem.encodedTx,
+        transferInfo:
+          unsignedTxItem.transfersInfo?.[0] ??
+          updatedUnsignedTxItem.transfersInfo?.[0],
+      });
+      if (btcOutputValidationError) {
+        const tokenSymbol =
+          updatedUnsignedTxItem.swapInfo?.sender.token.symbol ??
+          unsignedTxItem.swapInfo?.sender.token.symbol ??
+          gasInfo.common?.nativeSymbol ??
+          '';
+        const validationToast = getSwapBtcOutputValidationToast({
+          networkId,
+          tokenSymbol,
+          validationError: btcOutputValidationError,
+        });
+        Toast.error({
+          ...validationToast,
+          toastId: [
+            'swap-btc-output-validation',
+            networkId,
+            tokenSymbol,
+            btcOutputValidationError.type,
+            btcOutputValidationError.expectedAmountBase ?? '',
+            btcOutputValidationError.actualAmountBase ?? '',
+          ].join('-'),
+        });
+        throw new OneKeyAppError(
+          [validationToast.title, validationToast.message]
+            .filter(Boolean)
+            .join(' '),
+        );
+      }
       const {
         totalNative,
         total,
@@ -799,9 +902,10 @@ export function useSwapBuildTx() {
       } = calculateFeeForSend({
         feeInfo: gasInfo as IFeeInfoUnit,
         nativeTokenPrice: gasInfo.common?.nativeTokenPrice ?? 0,
+        txSize,
       });
       const checkLatestNativeBalanceRes = await checkLatestNativeTokenBalance({
-        gasInfos: [{ gasInfo }],
+        gasInfos: [{ gasInfo, txSize }],
         networkId,
         token: unsignedTxItem.swapInfo?.sender.token,
         amount: unsignedTxItem.swapInfo?.sender.amount,
@@ -883,7 +987,12 @@ export function useSwapBuildTx() {
         gasFeeInNative: totalNativeForDisplay,
       };
     },
-    [checkLatestNativeTokenBalance, intl, setSwapSteps],
+    [
+      checkLatestNativeTokenBalance,
+      getSwapBtcOutputValidationToast,
+      intl,
+      setSwapSteps,
+    ],
   );
 
   const swapEstimateFeeEvent = useCallback(
@@ -1126,10 +1235,7 @@ export function useSwapBuildTx() {
   }, [goBackQrCodeModal, fromAccountId]);
 
   const findGasInfo = useCallback(
-    (
-      stepGasInfos: { encodeTx: IEncodedTx; gasInfo: ISwapGasInfo }[],
-      encodedTx: IEncodedTx,
-    ) => {
+    (stepGasInfos: ISwapGasFeeInfo[], encodedTx: IEncodedTx) => {
       return stepGasInfos?.find(
         (s) =>
           isEqual(s.encodeTx, encodedTx) ||
@@ -2875,7 +2981,7 @@ export function useSwapBuildTx() {
         buildUnsignedParamsCheckNonce.prevNonce =
           approveUnsignedTxArr[approveUnsignedTxArr.length - 1].nonce;
       }
-      let gasFeeInfos: { encodeTx: IEncodedTx; gasInfo: ISwapGasInfo }[] = [];
+      let gasFeeInfos: ISwapGasFeeInfo[] = [];
       const unsignedTx =
         await backgroundApiProxy.serviceSend.prepareSendConfirmUnsignedTx({
           ...buildUnsignedParamsCheckNonce,
@@ -2938,6 +3044,7 @@ export function useSwapBuildTx() {
               gasFeeInfos.push({
                 encodeTx: unsignedTxItem.encodedTx ?? {},
                 gasInfo,
+                txSize: unsignedTxItem.txSize,
               });
             }
           } catch (e: any) {
@@ -3035,6 +3142,7 @@ export function useSwapBuildTx() {
               gasFeeInfos.push({
                 encodeTx: unsignedTxItem.encodedTx,
                 gasInfo: lastTxGasInfo,
+                txSize: unsignedTxItem.txSize,
               });
             } else {
               const estimateFeeParams =
@@ -3065,6 +3173,7 @@ export function useSwapBuildTx() {
               gasFeeInfos.push({
                 encodeTx: unsignedTxItem.encodedTx,
                 gasInfo: gasParseInfo,
+                txSize: unsignedTxItem.txSize,
               });
             }
           }
@@ -3101,6 +3210,7 @@ export function useSwapBuildTx() {
               {
                 encodeTx: unsignedTx.encodedTx,
                 gasInfo: gasParseInfo,
+                txSize: unsignedTx.txSize,
               },
             ];
           } catch (e: any) {
@@ -3137,6 +3247,7 @@ export function useSwapBuildTx() {
             const feeResult = calculateFeeForSend({
               feeInfo: gasInfo as IFeeInfoUnit,
               nativeTokenPrice: common?.nativeTokenPrice ?? 0,
+              txSize: item.txSize,
             });
             return feeResult.totalFiatMinForDisplay;
           }),

--- a/packages/kit/src/views/Swap/hooks/useSwapState.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapState.ts
@@ -12,6 +12,7 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { sortSwapQuotes } from '@onekeyhq/shared/src/utils/swapQuoteSortUtils';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import {
@@ -597,12 +598,16 @@ export function useSwapActionState() {
         swapFromAddressInfo.address &&
         balanceBN.lt(fromTokenAmountBN)
       ) {
-        infoRes.label = intl.formatMessage(
-          {
-            id: ETranslations.swap_page_toast_insufficient_balance_title,
-          },
-          { token: fromToken.symbol },
-        );
+        infoRes.label = networkUtils.isBTCNetwork(fromToken.networkId)
+          ? intl.formatMessage({
+              id: ETranslations.send_toast_btc_fork_insufficient_fund,
+            })
+          : intl.formatMessage(
+              {
+                id: ETranslations.swap_page_toast_insufficient_balance_title,
+              },
+              { token: fromToken.symbol },
+            );
         infoRes.disable = true;
       }
 

--- a/packages/kit/src/views/Swap/hooks/useSwapState.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapState.ts
@@ -33,7 +33,13 @@ import {
   ESwapTabSwitchType,
 } from '@onekeyhq/shared/types/swap/types';
 
+import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { useDebounce } from '../../../hooks/useDebounce';
+import { usePromiseResult } from '../../../hooks/usePromiseResult';
+import {
+  useAccountSelectorStorageInitDoneAtom,
+  useIsAccountSelectorActiveAccountInitDone,
+} from '../../../states/jotai/contexts/accountSelector';
 import {
   useSwapActions,
   useSwapAlertsAtom,
@@ -70,6 +76,7 @@ import {
   selectSwapPreviousActionableQuote,
 } from '../../../states/jotai/contexts/swap/quoteProgress';
 import { buildSwapBatchTransferType } from '../utils/buildSwapReviewState';
+import { shouldAllowSwapNoConnectWalletWarning } from '../utils/swapNoWalletWarningGuard';
 import { getStockQuoteTradeControl } from '../utils/swapStockTradeControl';
 
 import { useSwapAddressInfo } from './useSwapAccount';
@@ -87,6 +94,39 @@ function useSwapWarningCheck() {
   const [fromTokenBalance] = useSwapSelectedFromTokenBalanceAtom();
   const { checkSwapWarning } = useSwapActions().current;
   const [swapLimitUseRate] = useSwapLimitPriceUseRateAtom();
+  const [accountSelectorStorageInitDone] =
+    useAccountSelectorStorageInitDoneAtom();
+  const accountSelectorActiveAccountInitDone =
+    useIsAccountSelectorActiveAccountInitDone(0);
+  const { result: walletListResult } = usePromiseResult(
+    () =>
+      backgroundApiProxy.serviceAccount.getWallets({
+        ignoreEmptySingletonWalletAccounts: true,
+      }),
+    [],
+    {
+      checkIsFocused: false,
+      watchLoading: false,
+    },
+  );
+  const allowNoConnectWallet = useMemo(
+    () =>
+      shouldAllowSwapNoConnectWalletWarning({
+        accountInfoReady: swapFromAddressInfo.accountInfo?.ready,
+        accountSelectorActiveAccountInitDone,
+        accountSelectorStorageInitDone,
+        hasAccountWallet: Boolean(swapFromAddressInfo.accountInfo?.wallet),
+        isWebDappMode: Boolean(platformEnv.isWebDappMode),
+        walletListResolvedNoWallet: walletListResult?.wallets.length === 0,
+      }),
+    [
+      accountSelectorActiveAccountInitDone,
+      accountSelectorStorageInitDone,
+      swapFromAddressInfo.accountInfo?.ready,
+      swapFromAddressInfo.accountInfo?.wallet,
+      walletListResult?.wallets.length,
+    ],
+  );
   const refContainer = useRef<ISwapCheckWarningDef>({
     swapFromAddressInfo: {
       address: undefined,
@@ -115,8 +155,10 @@ function useSwapWarningCheck() {
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const checkSwapWarningDeb = useCallback(
-    debounce((fromAddressInfo, toAddressInfo) => {
-      void checkSwapWarning(fromAddressInfo, toAddressInfo);
+    debounce((fromAddressInfo, toAddressInfo, allowNoConnect: boolean) => {
+      void checkSwapWarning(fromAddressInfo, toAddressInfo, {
+        allowNoConnectWallet: allowNoConnect,
+      });
     }, 300),
     [],
   );
@@ -127,9 +169,11 @@ function useSwapWarningCheck() {
       checkSwapWarningDeb(
         refContainer.current.swapFromAddressInfo,
         refContainer.current.swapToAddressInfo,
+        allowNoConnectWallet,
       );
     }
   }, [
+    allowNoConnectWallet,
     asyncRefContainer,
     checkSwapWarningDeb,
     fromToken,

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -1,8 +1,12 @@
+import type { IEncodedTx } from '@onekeyhq/core/src/types';
+import type { ITransferInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
 import {
   checkSwapLatestBalanceSufficient,
+  getSwapEncodedTxSize,
   getSwapRequiredNativeBalanceAmount,
+  validateSwapBtcOutputs,
 } from './swapBalanceUtils';
 
 type IFetchSwapTokenDetailsParams = {
@@ -63,6 +67,26 @@ const evmGasInfo = {
   gas: {
     gasLimit: '21000',
     gasPrice: '1',
+  },
+};
+
+const btcToken = {
+  networkId: 'btc--0',
+  contractAddress: '',
+  symbol: 'BTC',
+  decimals: 8,
+  isNative: true,
+} as ISwapToken;
+
+const btcGasInfo = {
+  common: {
+    feeDecimals: 0,
+    feeSymbol: 'sat/vB',
+    nativeDecimals: 8,
+    nativeSymbol: 'BTC',
+  },
+  feeUTXO: {
+    feeRate: '1',
   },
 };
 
@@ -177,6 +201,22 @@ describe('getSwapRequiredNativeBalanceAmount', () => {
     });
   });
 
+  it('adds UTXO fee-rate reserve using transaction size for native BTC swaps', () => {
+    expect(
+      getSwapRequiredNativeBalanceAmount({
+        gasInfos: [{ gasInfo: btcGasInfo, txSize: 220 }],
+        networkId: 'btc--0',
+        fromToken: btcToken,
+        fromAmount: '0.0018',
+      }),
+    ).toEqual({
+      token: btcToken,
+      amount: '0.0018022',
+      reserveAmount: '0.0000022',
+      includesFromAmount: true,
+    });
+  });
+
   it('adds native other fees to the same native balance requirement', () => {
     expect(
       getSwapRequiredNativeBalanceAmount({
@@ -214,5 +254,163 @@ describe('getSwapRequiredNativeBalanceAmount', () => {
       reserveAmount: '0.020021',
       includesFromAmount: true,
     });
+  });
+});
+
+describe('getSwapEncodedTxSize', () => {
+  it('reads rebuilt UTXO txSize from encodedTx only when valid', () => {
+    expect(getSwapEncodedTxSize({ txSize: 220 } as IEncodedTx)).toBe(220);
+    expect(getSwapEncodedTxSize({ txSize: 0 } as IEncodedTx)).toBeUndefined();
+    expect(getSwapEncodedTxSize({ txSize: -1 } as IEncodedTx)).toBeUndefined();
+    expect(getSwapEncodedTxSize('raw-tx' as IEncodedTx)).toBeUndefined();
+  });
+});
+
+describe('validateSwapBtcOutputs', () => {
+  const btcTransferInfo = {
+    from: 'bc1from',
+    to: 'bc1provider',
+    amount: '0.00179536',
+    tokenInfo: {
+      networkId: 'btc--0',
+      address: '',
+      symbol: 'BTC',
+      decimals: 8,
+      isNative: true,
+    },
+  } as ITransferInfo;
+
+  it('blocks UTXO swap transactions when the provider payment output is missing', () => {
+    expect(
+      validateSwapBtcOutputs({
+        networkId: 'btc--0',
+        encodedTx: {
+          outputs: [
+            {
+              address: 'bc1change',
+              value: '1000',
+            },
+          ],
+        } as IEncodedTx,
+        transferInfo: btcTransferInfo,
+      }),
+    ).toEqual({
+      type: 'payment_output_missing',
+      expectedAmount: '0.00179536',
+      actualAmount: '0',
+      expectedAmountBase: '179536',
+      actualAmountBase: '0',
+    });
+  });
+
+  it('blocks UTXO swap transactions when SendMax reduces the provider output', () => {
+    expect(
+      validateSwapBtcOutputs({
+        networkId: 'btc--0',
+        encodedTx: {
+          outputs: [
+            {
+              address: 'bc1provider',
+              value: '179316',
+            },
+          ],
+        } as IEncodedTx,
+        transferInfo: btcTransferInfo,
+      }),
+    ).toEqual({
+      type: 'payment_output_less_than_order_amount',
+      expectedAmount: '0.00179536',
+      actualAmount: '0.00179316',
+      expectedAmountBase: '179536',
+      actualAmountBase: '179316',
+    });
+  });
+
+  it('allows UTXO swap transactions when the provider output matches the order amount', () => {
+    expect(
+      validateSwapBtcOutputs({
+        networkId: 'btc--0',
+        encodedTx: {
+          outputs: [
+            {
+              address: 'bc1provider',
+              value: '179536',
+            },
+            {
+              address: 'bc1change',
+              value: '1000',
+            },
+          ],
+        } as IEncodedTx,
+        transferInfo: btcTransferInfo,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('blocks BTC swap transactions when required OP_RETURN output is missing', () => {
+    expect(
+      validateSwapBtcOutputs({
+        networkId: 'btc--0',
+        encodedTx: {
+          outputs: [
+            {
+              address: 'bc1provider',
+              value: '179536',
+            },
+          ],
+        } as IEncodedTx,
+        transferInfo: {
+          ...btcTransferInfo,
+          opReturn: '=:BNB.BNB:bnb1recipient',
+        } as ITransferInfo,
+      }),
+    ).toEqual({
+      type: 'op_return_missing',
+      expectedOpReturn: '=:BNB.BNB:bnb1recipient',
+    });
+  });
+
+  it('allows BTC swap transactions when required OP_RETURN output exists', () => {
+    expect(
+      validateSwapBtcOutputs({
+        networkId: 'btc--0',
+        encodedTx: {
+          outputs: [
+            {
+              address: 'bc1provider',
+              value: '179536',
+            },
+            {
+              address: '',
+              value: '0',
+              payload: {
+                opReturn: '=:BNB.BNB:bnb1recipient',
+              },
+            },
+          ],
+        } as IEncodedTx,
+        transferInfo: {
+          ...btcTransferInfo,
+          opReturn: '=:BNB.BNB:bnb1recipient',
+        } as ITransferInfo,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('skips exact-output validation for non-BTC networks', () => {
+    expect(
+      validateSwapBtcOutputs({
+        networkId: 'ada--0',
+        encodedTx: {
+          outputs: [
+            {
+              address: 'bc1provider',
+              amount: '179536',
+            },
+          ],
+        } as IEncodedTx,
+        transferInfo: btcTransferInfo,
+      }),
+    ).toBeUndefined();
   });
 });

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -1,6 +1,9 @@
 import BigNumber from 'bignumber.js';
 
+import type { IEncodedTx } from '@onekeyhq/core/src/types';
+import type { ITransferInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import { calculateFeeForSend } from '@onekeyhq/shared/src/utils/feeUtils';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import type { IFeeInfoUnit } from '@onekeyhq/shared/types/fee';
 import type {
   IQuoteResultFeeOtherFeeInfo,
@@ -75,6 +78,7 @@ async function getSwapTokenBalanceContractAddress(token: ISwapToken) {
 
 type ISwapGasInfoEntry = {
   gasInfo?: ISwapGasInfo;
+  txSize?: number;
 };
 
 type ISwapNativeBalanceRequirementParams = {
@@ -91,6 +95,152 @@ export type ISwapNativeBalanceRequirement = {
   reserveAmount: string;
   includesFromAmount: boolean;
 };
+
+type IEncodedTxWithOutputs = {
+  outputs?: {
+    address?: string;
+    value?: string | number;
+    script?: string;
+    payload?: {
+      opReturn?: string;
+    };
+  }[];
+};
+
+type IEncodedTxWithTxSize = {
+  txSize?: number;
+};
+
+export type ISwapBtcOutputValidationErrorType =
+  | 'payment_output_missing'
+  | 'payment_output_less_than_order_amount'
+  | 'op_return_missing';
+
+export type ISwapBtcOutputValidationError = {
+  type: ISwapBtcOutputValidationErrorType;
+  expectedAmount?: string;
+  actualAmount?: string;
+  expectedAmountBase?: string;
+  actualAmountBase?: string;
+  expectedOpReturn?: string;
+};
+
+function getEncodedTxOutputs(encodedTx?: IEncodedTx) {
+  if (!encodedTx || typeof encodedTx !== 'object') {
+    return undefined;
+  }
+
+  const { outputs } = encodedTx as IEncodedTxWithOutputs;
+  if (!Array.isArray(outputs)) {
+    return undefined;
+  }
+
+  return outputs;
+}
+
+export function getSwapEncodedTxSize(encodedTx?: IEncodedTx) {
+  if (!encodedTx || typeof encodedTx !== 'object') {
+    return undefined;
+  }
+
+  const { txSize } = encodedTx as IEncodedTxWithTxSize;
+  if (typeof txSize !== 'number' || !Number.isFinite(txSize) || txSize <= 0) {
+    return undefined;
+  }
+
+  return txSize;
+}
+
+export function validateSwapBtcOutputs({
+  networkId,
+  encodedTx,
+  transferInfo,
+}: {
+  networkId?: string;
+  encodedTx?: IEncodedTx;
+  transferInfo?: ITransferInfo;
+}): ISwapBtcOutputValidationError | undefined {
+  if (!networkUtils.isBTCNetwork(networkId)) {
+    return undefined;
+  }
+
+  const outputs = getEncodedTxOutputs(encodedTx);
+  const tokenDecimals = transferInfo?.tokenInfo?.decimals;
+  if (!outputs || !transferInfo?.to || tokenDecimals === undefined) {
+    return undefined;
+  }
+
+  const expectedAmountBN = new BigNumber(transferInfo.amount ?? '');
+  if (
+    expectedAmountBN.isNaN() ||
+    !expectedAmountBN.isFinite() ||
+    expectedAmountBN.lte(0)
+  ) {
+    return undefined;
+  }
+
+  const expectedAmountBaseBN = expectedAmountBN
+    .shiftedBy(tokenDecimals)
+    .decimalPlaces(0, BigNumber.ROUND_DOWN);
+  if (expectedAmountBaseBN.lte(0)) {
+    return undefined;
+  }
+
+  let hasPaymentOutput = false;
+  const actualAmountBaseBN = outputs.reduce((acc, output) => {
+    if (output.address !== transferInfo.to) {
+      return acc;
+    }
+
+    hasPaymentOutput = true;
+    const outputValueBN = new BigNumber(output.value ?? '');
+    if (
+      outputValueBN.isNaN() ||
+      !outputValueBN.isFinite() ||
+      outputValueBN.lte(0)
+    ) {
+      return acc;
+    }
+
+    return acc.plus(outputValueBN);
+  }, new BigNumber(0));
+
+  if (!hasPaymentOutput) {
+    return {
+      type: 'payment_output_missing',
+      expectedAmount: expectedAmountBN.toFixed(),
+      actualAmount: actualAmountBaseBN.shiftedBy(-tokenDecimals).toFixed(),
+      expectedAmountBase: expectedAmountBaseBN.toFixed(),
+      actualAmountBase: actualAmountBaseBN.toFixed(),
+    };
+  }
+
+  if (actualAmountBaseBN.lt(expectedAmountBaseBN)) {
+    return {
+      type: 'payment_output_less_than_order_amount',
+      expectedAmount: expectedAmountBN.toFixed(),
+      actualAmount: actualAmountBaseBN.shiftedBy(-tokenDecimals).toFixed(),
+      expectedAmountBase: expectedAmountBaseBN.toFixed(),
+      actualAmountBase: actualAmountBaseBN.toFixed(),
+    };
+  }
+
+  if (
+    transferInfo.opReturn &&
+    !outputs.some(
+      (output) =>
+        output.payload?.opReturn === transferInfo.opReturn ||
+        output.script === transferInfo.opReturn,
+    )
+  ) {
+    return {
+      type: 'op_return_missing',
+      expectedOpReturn: transferInfo.opReturn,
+    };
+  }
+
+  return undefined;
+}
 
 function buildNativeTokenFromGasInfo({
   gasInfo,
@@ -148,6 +298,7 @@ export function getSwapRequiredNativeBalanceAmount({
     const { totalNative } = calculateFeeForSend({
       feeInfo: item.gasInfo as IFeeInfoUnit,
       nativeTokenPrice: item.gasInfo.common.nativeTokenPrice ?? 0,
+      txSize: item.txSize,
     });
     const totalNativeBN = new BigNumber(totalNative);
 

--- a/packages/kit/src/views/Swap/utils/swapNoWalletWarningGuard.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapNoWalletWarningGuard.test.ts
@@ -1,0 +1,82 @@
+import {
+  removeSwapNoConnectWalletAlerts,
+  shouldAllowSwapNoConnectWalletWarning,
+} from './swapNoWalletWarningGuard';
+
+describe('shouldAllowSwapNoConnectWalletWarning', () => {
+  it('blocks the warning before account info is ready', () => {
+    expect(
+      shouldAllowSwapNoConnectWalletWarning({
+        accountInfoReady: false,
+        accountSelectorActiveAccountInitDone: true,
+        accountSelectorStorageInitDone: true,
+        hasAccountWallet: false,
+        isWebDappMode: false,
+        walletListResolvedNoWallet: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('blocks the warning when a wallet exists', () => {
+    expect(
+      shouldAllowSwapNoConnectWalletWarning({
+        accountInfoReady: true,
+        accountSelectorActiveAccountInitDone: true,
+        accountSelectorStorageInitDone: true,
+        hasAccountWallet: true,
+        isWebDappMode: false,
+        walletListResolvedNoWallet: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('blocks the warning during native cold-start init even when account info has no wallet', () => {
+    expect(
+      shouldAllowSwapNoConnectWalletWarning({
+        accountInfoReady: true,
+        accountSelectorActiveAccountInitDone: false,
+        accountSelectorStorageInitDone: true,
+        hasAccountWallet: false,
+        isWebDappMode: false,
+        walletListResolvedNoWallet: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('allows the warning for a native real no-wallet state after init and wallet-list proof', () => {
+    expect(
+      shouldAllowSwapNoConnectWalletWarning({
+        accountInfoReady: true,
+        accountSelectorActiveAccountInitDone: true,
+        accountSelectorStorageInitDone: true,
+        hasAccountWallet: false,
+        isWebDappMode: false,
+        walletListResolvedNoWallet: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('allows the warning in web dapp mode after account info is ready and no wallet is connected', () => {
+    expect(
+      shouldAllowSwapNoConnectWalletWarning({
+        accountInfoReady: true,
+        accountSelectorActiveAccountInitDone: false,
+        accountSelectorStorageInitDone: false,
+        hasAccountWallet: false,
+        isWebDappMode: true,
+        walletListResolvedNoWallet: false,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('removeSwapNoConnectWalletAlerts', () => {
+  it('removes only noConnectWallet alerts', () => {
+    expect(
+      removeSwapNoConnectWalletAlerts([
+        { message: 'keep me' },
+        { noConnectWallet: true },
+      ]),
+    ).toEqual([{ message: 'keep me' }]);
+  });
+});

--- a/packages/kit/src/views/Swap/utils/swapNoWalletWarningGuard.ts
+++ b/packages/kit/src/views/Swap/utils/swapNoWalletWarningGuard.ts
@@ -1,0 +1,35 @@
+import type { ISwapAlertState } from '@onekeyhq/shared/types/swap/types';
+
+export function shouldAllowSwapNoConnectWalletWarning({
+  accountInfoReady,
+  accountSelectorActiveAccountInitDone,
+  accountSelectorStorageInitDone,
+  hasAccountWallet,
+  isWebDappMode,
+  walletListResolvedNoWallet,
+}: {
+  accountInfoReady: boolean | undefined;
+  accountSelectorActiveAccountInitDone: boolean;
+  accountSelectorStorageInitDone: boolean;
+  hasAccountWallet: boolean;
+  isWebDappMode: boolean;
+  walletListResolvedNoWallet: boolean;
+}) {
+  if (!accountInfoReady || hasAccountWallet) {
+    return false;
+  }
+
+  if (isWebDappMode) {
+    return true;
+  }
+
+  return (
+    accountSelectorStorageInitDone &&
+    accountSelectorActiveAccountInitDone &&
+    walletListResolvedNoWallet
+  );
+}
+
+export function removeSwapNoConnectWalletAlerts(states: ISwapAlertState[]) {
+  return states.filter((item) => !item.noConnectWallet);
+}

--- a/packages/shared/src/modules3rdParty/sentry/basicOptions.ts
+++ b/packages/shared/src/modules3rdParty/sentry/basicOptions.ts
@@ -1,7 +1,3 @@
-import {
-  reactNativeTracingIntegration,
-  reactNavigationIntegration,
-} from '@sentry/react-native';
 import wordLists from 'bip39/src/wordlists/english.json';
 
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -26,10 +22,6 @@ const checkPrivateKey = (text: string): boolean => {
 };
 
 const lazyLoadWordSet = memoizee(() => new Set(wordLists));
-
-export const navigationIntegration = reactNavigationIntegration({
-  enableTimeToInitialDisplay: true,
-});
 
 // Minimum consecutive mnemonic words to trigger redaction (12-word mnemonic could partially leak)
 const MIN_MNEMONIC_SEQUENCE_LENGTH = 3;
@@ -216,8 +208,14 @@ export const buildBasicOptions = ({
   ({
     enabled: true,
     maxBreadcrumbs: 100,
-    tracesSampleRate: 0.1,
-    profilesSampleRate: 0.1,
+    // Performance tracing/profiling disabled: in the long-lived renderer the
+    // browser/idle-span tracing leaks unboundedly (heap snapshots show ~300K
+    // retained SentryNonRecordingSpan pinning React fibers; renderer RSS climbs
+    // ~240MB/h with no plateau). Error reporting + breadcrumbs are unaffected.
+    // The tracing integrations are also removed from buildIntegrations below;
+    // zeroing the sample rate alone does NOT stop span creation.
+    tracesSampleRate: 0,
+    profilesSampleRate: 0,
     beforeSend: (event) => {
       if (Array.isArray(event.exception?.values)) {
         for (let index = 0; index < event.exception.values.length; index += 1) {
@@ -265,10 +263,9 @@ export const buildSentryOptions = (Sentry: typeof import('@sentry/react')) => ({
 });
 
 export const buildIntegrations = (Sentry: typeof import('@sentry/react')) => [
-  navigationIntegration,
-  reactNativeTracingIntegration(),
-  Sentry.browserProfilingIntegration(),
-  Sentry.browserTracingIntegration(),
+  // Performance-tracing integrations intentionally removed — they create a span
+  // per navigation/interaction that leaks in the long-lived renderer (see the
+  // tracesSampleRate note above). Only error reporting + breadcrumbs remain.
   Sentry.breadcrumbsIntegration({
     console: false,
     dom: true,

--- a/packages/shared/src/modules3rdParty/sentry/index.native.test.ts
+++ b/packages/shared/src/modules3rdParty/sentry/index.native.test.ts
@@ -8,7 +8,6 @@ jest.mock('@sentry/react-native', () => ({
   init: initMock,
   nativeCrash: jest.fn(),
   reactNavigationIntegration: jest.fn(() => 'navigationIntegration'),
-  reactNativeTracingIntegration: jest.fn(() => 'reactNativeTracingIntegration'),
   withErrorBoundary: jest.fn(passthrough),
   withProfiler: jest.fn(passthrough),
   wrap: jest.fn(passthrough),
@@ -27,7 +26,7 @@ describe('initSentry', () => {
     process.env.NODE_ENV = originalNodeEnv;
   });
 
-  test('omits profilesSampleRate for React Native production init', () => {
+  test('omits tracesSampleRate and profilesSampleRate for React Native production init', () => {
     jest.isolateModules(() => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
       const {
@@ -40,11 +39,7 @@ describe('initSentry', () => {
     });
 
     expect(initMock).toHaveBeenCalledTimes(1);
-    expect(initMock.mock.calls[0][0]).toEqual(
-      expect.objectContaining({
-        tracesSampleRate: 0.1,
-      }),
-    );
+    expect(initMock.mock.calls[0][0].tracesSampleRate).toBeUndefined();
     expect(initMock.mock.calls[0][0].profilesSampleRate).toBeUndefined();
   });
 });

--- a/packages/shared/src/modules3rdParty/sentry/index.native.ts
+++ b/packages/shared/src/modules3rdParty/sentry/index.native.ts
@@ -2,7 +2,6 @@ import type { ComponentType } from 'react';
 
 import {
   init,
-  reactNativeTracingIntegration,
   nativeCrash as sentryNativeCrash,
   withErrorBoundary,
   withProfiler,
@@ -11,7 +10,7 @@ import {
 
 import appGlobals from '../../appGlobals';
 
-import { buildBasicOptions, navigationIntegration } from './basicOptions';
+import { buildBasicOptions } from './basicOptions';
 
 import type { FallbackRender } from '@sentry/react';
 
@@ -24,12 +23,24 @@ export const initSentry = () => {
   if (process.env.NODE_ENV !== 'production') {
     return;
   }
-  const { profilesSampleRate: _profilesSampleRate, ...basicOptions } =
-    buildBasicOptions({
-      onError: (errorMessage, stacktrace) => {
-        appGlobals.$defaultLogger?.app.error.log(errorMessage, stacktrace);
-      },
-    });
+  // Strip tracesSampleRate AND profilesSampleRate before handing options to the
+  // RN SDK. @sentry/react-native's getDefaultIntegrations treats tracing as
+  // ENABLED whenever `typeof tracesSampleRate === 'number'` (0 included), and
+  // `integrations: []` only MERGES with — does not override — the default set.
+  // So a leftover `tracesSampleRate: 0` would re-install the default tracing
+  // integrations (appStart / nativeFrames / stallTracking / timeToDisplay)
+  // regardless of `enableAutoPerformanceTracing: false`. Removing the key makes
+  // hasTracingEnabled=false so none of them are installed. profilesSampleRate is
+  // likewise stripped to keep hermesProfilingIntegration off.
+  const {
+    tracesSampleRate: _tracesSampleRate,
+    profilesSampleRate: _profilesSampleRate,
+    ...basicOptions
+  } = buildBasicOptions({
+    onError: (errorMessage, stacktrace) => {
+      appGlobals.$defaultLogger?.app.error.log(errorMessage, stacktrace);
+    },
+  });
 
   init({
     dsn: process.env.SENTRY_DSN_REACT_NATIVE || '',
@@ -37,8 +48,11 @@ export const initSentry = () => {
     maxCacheItems: 60,
     enableAppHangTracking: true,
     appHangTimeoutInterval: 5,
-    integrations: [navigationIntegration, reactNativeTracingIntegration()],
-    enableAutoPerformanceTracing: true,
+    // Performance tracing fully disabled on native — tracesSampleRate is
+    // stripped above so the SDK installs none of its default tracing
+    // integrations; error reporting + breadcrumbs are unaffected.
+    integrations: [],
+    enableAutoPerformanceTracing: false,
     // Disable Hermes profiling on React Native. With multiple Hermes runtimes
     // in the iOS release smoke test, native stopProfiling can throw on a
     // background queue and crash during TurboModule error conversion.

--- a/packages/shared/src/modules3rdParty/sentry/sentry.test.ts
+++ b/packages/shared/src/modules3rdParty/sentry/sentry.test.ts
@@ -470,8 +470,8 @@ describe('buildBasicOptions', () => {
 
     expect(options.enabled).toBe(true);
     expect(options.maxBreadcrumbs).toBe(100);
-    expect(options.tracesSampleRate).toBe(0.1);
-    expect(options.profilesSampleRate).toBe(0.1);
+    expect(options.tracesSampleRate).toBe(0);
+    expect(options.profilesSampleRate).toBe(0);
     expect(typeof options.beforeSend).toBe('function');
   });
 

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -544,7 +544,11 @@ export interface ISwapPreSwapData {
   supportPreBuild?: boolean;
   allowanceResult?: IAllowanceResult;
   netWorkFee?: {
-    gasInfos?: { encodeTx: IEncodedTx; gasInfo: ISwapGasInfo }[];
+    gasInfos?: {
+      encodeTx: IEncodedTx;
+      gasInfo: ISwapGasInfo;
+      txSize?: number;
+    }[];
     gasFeeFiatValue?: string;
   };
 }


### PR DESCRIPTION
Sync bundle release changes from `release/v6.4.0` to `x` (release #5 / seq #5 delta).

## Synced commits (8)
- fix(desktop): recompute macOS title-bar draggable region on layout changes (#12166)
- fix: correct market buy fiat value OK-56738 (#12152)
- fix: android prime intro video clipping (#12144)
- fix: use 24h stock price change (#12142)
- feat: optimize address risk check OK-56757 (#12163)
- fix: guard exact BTC swap payments (#12177)
- fix: dialog bottom safe-area double-padding and color seam on iOS (#12138)
- fix: disable Sentry performance tracing to stop renderer memory leak (#12186)

## Skipped (1)
- **#12154 (keep restored wallet account on cold start)** — already superseded on `x`. `x` carries a more evolved version of this exact fix (`initFromStorageFillEmptyNumsFromDB` + field-level `buildMergedSelectedAccount` merge). Cherry-picking it would regress `x` and import tests written against the old `initFromStorageRepairCurrentCache` implementation. `x` loses nothing by skipping it.

> Note: seq #1–#4 were already on `x` from prior syncs (different commit hashes), so `git cherry` flagged them as unsynced; this PR only brings the genuinely-new seq #5 work.

## Conflicts resolved
- **#12152** — swap `actions.ts` / `useSwapState.ts` / `marketReviewExecutionUtils.ts`: import-collision unions (kept both sides). `actions.test.tsx`: unioned x's Stock-execution tests with the release's no-wallet-warning tests (kept x's superset `createWrapperWithStore(setup?)` helper).
- **#12144** — `PrimeFeatureIntroContent.tsx`: applied the Android video-activation fix onto x's (deeper-nested) component structure.
- **#12177** — btc `Vault.ts`: kept x's equivalent inlined `InsufficientBalance` message (release's change was already effectively present); `useSwapState.ts`: import union.

## Integration fix
- `test: align swap warning test with #12152 checkSwapWarning API` — x's pre-existing "current-event quote" warning test now passes `{ allowNoConnectWallet: true }` to match #12152's new API.

## Validation
- ESLint clean on all resolved files.
- All affected test suites pass (swap actions 12/12; speed-swap / payment-token / no-wallet-guard 20/20).
- Type check (`tsgo`) clean for synced code (one pre-existing, unrelated error on `x` in `development/rspack/rspack.web.config.ts`).
