### PR TITLE
feat: enable Perps account mode switch between unified and portfolio margin(OK-56893)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -138,11 +138,13 @@ import {
   createFetchUserAbstractionRawWithCache,
   invalidateUserAbstractionRawCache,
 } from './userAbstractionCache';
+import { shouldPreserveConfirmedUserAbstractionMode } from './userAbstractionMode';
 
 import type ServiceHyperliquidCache from './ServiceHyperliquidCache';
 import type { IPerpsActiveAssetCtxSnapshotCacheHydration } from './ServiceHyperliquidCache';
 import type ServiceHyperliquidExchange from './ServiceHyperliquidExchange';
 import type ServiceHyperliquidWallet from './ServiceHyperliquidWallet';
+import type { IConfirmedUserAbstractionMode } from './userAbstractionMode';
 import type { ISimpleDbPerpData } from '../../dbs/simple/entity/SimpleDbEntityPerp';
 import type {
   IPerpsAccountLoadingInfo,
@@ -2537,36 +2539,67 @@ export default class ServiceHyperliquid extends ServiceBase {
     }
   }
 
+  private async persistConfirmedUserAbstractionMode(
+    userAddress: IHex,
+    confirmedMode: IConfirmedUserAbstractionMode,
+  ): Promise<boolean> {
+    const lowerUserAddress = userAddress.toLowerCase() as IHex;
+    const activeAccount = await perpsActiveAccountAtom.get();
+    if (activeAccount?.accountAddress?.toLowerCase() !== lowerUserAddress) {
+      return false;
+    }
+
+    await this.backgroundApi.simpleDb.perp.setUserAbstractionMode(
+      lowerUserAddress,
+      confirmedMode,
+    );
+    await perpsAbstractionModeAtom.set({
+      accountAddress: lowerUserAddress,
+      mode: confirmedMode as EHyperLiquidAbstractionMode,
+      source: 'live',
+    });
+    return true;
+  }
+
   // Bust the cache before re-fetching, else the read returns the pre-switch mode.
   // `confirmedMode` is the mode just switched to on-chain (the switch already
   // succeeded): persist it first so a failed or eventually-consistent refetch —
-  // whose error path falls back to the stale SimpleDb value — can't revert the
-  // displayed/cold-start mode. WS (WEB_DATA3) still reconciles afterwards.
+  // whose error path falls back to SimpleDb, or whose success path still returns
+  // the pre-switch mode — can't revert the displayed/cold-start mode. WS
+  // (WEB_DATA3) still reconciles afterwards.
   @backgroundMethod()
   async refreshUserAbstractionMode(
     userAddress: IHex,
-    confirmedMode?: 'unifiedAccount' | 'portfolioMargin',
+    confirmedMode?: IConfirmedUserAbstractionMode,
   ): Promise<string | undefined> {
-    const lowerUserAddress = userAddress.toLowerCase() as IHex;
     if (confirmedMode) {
-      const activeAccount = await perpsActiveAccountAtom.get();
-      if (activeAccount?.accountAddress?.toLowerCase() === lowerUserAddress) {
-        await this.backgroundApi.simpleDb.perp.setUserAbstractionMode(
-          lowerUserAddress,
-          confirmedMode,
-        );
-        await perpsAbstractionModeAtom.set({
-          accountAddress: lowerUserAddress,
-          mode: confirmedMode as EHyperLiquidAbstractionMode,
-          source: 'live',
-        });
-      }
+      await this.persistConfirmedUserAbstractionMode(
+        userAddress,
+        confirmedMode,
+      );
     }
     invalidateUserAbstractionRawCache(
       this.fetchUserAbstractionRawWithCache,
       userAddress,
     );
-    return this.fetchUserAbstraction(userAddress);
+    const refreshedMode = await this.fetchUserAbstraction(userAddress);
+    if (
+      confirmedMode &&
+      shouldPreserveConfirmedUserAbstractionMode({
+        confirmedMode,
+        refreshedMode,
+      })
+    ) {
+      const didPersistConfirmedMode =
+        await this.persistConfirmedUserAbstractionMode(
+          userAddress,
+          confirmedMode,
+        );
+      if (didPersistConfirmedMode) {
+        return confirmedMode;
+      }
+    }
+    return refreshedMode;
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -2538,10 +2538,30 @@ export default class ServiceHyperliquid extends ServiceBase {
   }
 
   // Bust the cache before re-fetching, else the read returns the pre-switch mode.
+  // `confirmedMode` is the mode just switched to on-chain (the switch already
+  // succeeded): persist it first so a failed or eventually-consistent refetch —
+  // whose error path falls back to the stale SimpleDb value — can't revert the
+  // displayed/cold-start mode. WS (WEB_DATA3) still reconciles afterwards.
   @backgroundMethod()
   async refreshUserAbstractionMode(
     userAddress: IHex,
+    confirmedMode?: 'unifiedAccount' | 'portfolioMargin',
   ): Promise<string | undefined> {
+    const lowerUserAddress = userAddress.toLowerCase() as IHex;
+    if (confirmedMode) {
+      const activeAccount = await perpsActiveAccountAtom.get();
+      if (activeAccount?.accountAddress?.toLowerCase() === lowerUserAddress) {
+        await this.backgroundApi.simpleDb.perp.setUserAbstractionMode(
+          lowerUserAddress,
+          confirmedMode,
+        );
+        await perpsAbstractionModeAtom.set({
+          accountAddress: lowerUserAddress,
+          mode: confirmedMode as EHyperLiquidAbstractionMode,
+          source: 'live',
+        });
+      }
+    }
     invalidateUserAbstractionRawCache(
       this.fetchUserAbstractionRawWithCache,
       userAddress,

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquid.ts
@@ -48,12 +48,13 @@ import {
 } from '@onekeyhq/shared/src/utils/perpsTokenSelectorFavorites';
 import perpsUtils, {
   calculateSpotBalancesTotalUsd,
+  isHyperLiquidAbstractionModeEnabled,
   parseDexCoin,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import type { IApiClientResponse } from '@onekeyhq/shared/types/endpoint';
 import { EServiceEndpointEnum } from '@onekeyhq/shared/types/endpoint';
-import { EHyperLiquidAbstractionMode } from '@onekeyhq/shared/types/hyperliquid';
+import type { EHyperLiquidAbstractionMode } from '@onekeyhq/shared/types/hyperliquid';
 import {
   CACHE_TIME_QUANTIZE_MS,
   SPOT_ASSET_ID_OFFSET,
@@ -2536,6 +2537,18 @@ export default class ServiceHyperliquid extends ServiceBase {
     }
   }
 
+  // Bust the cache before re-fetching, else the read returns the pre-switch mode.
+  @backgroundMethod()
+  async refreshUserAbstractionMode(
+    userAddress: IHex,
+  ): Promise<string | undefined> {
+    invalidateUserAbstractionRawCache(
+      this.fetchUserAbstractionRawWithCache,
+      userAddress,
+    );
+    return this.fetchUserAbstraction(userAddress);
+  }
+
   @backgroundMethod()
   async checkPerpsAccountStatus({
     isEnableTradingTrigger = false,
@@ -2652,8 +2665,7 @@ export default class ServiceHyperliquid extends ServiceBase {
           // Placed after referralCodeOk so a signature rejection doesn't block other status
           const currentMode = await this.fetchUserAbstraction(accountAddress);
           const isAbstractionCorrect =
-            currentMode === EHyperLiquidAbstractionMode.UNIFIED_ACCOUNT ||
-            currentMode === EHyperLiquidAbstractionMode.PORTFOLIO_MARGIN;
+            isHyperLiquidAbstractionModeEnabled(currentMode);
           if (isAbstractionCorrect) {
             statusDetails.abstractionOk = true;
           } else if (isEnableTradingTrigger && selectedAccount.accountId) {
@@ -2671,8 +2683,7 @@ export default class ServiceHyperliquid extends ServiceBase {
             const verifiedMode =
               await this.fetchUserAbstraction(accountAddress);
             statusDetails.abstractionOk =
-              verifiedMode === EHyperLiquidAbstractionMode.UNIFIED_ACCOUNT ||
-              verifiedMode === EHyperLiquidAbstractionMode.PORTFOLIO_MARGIN;
+              isHyperLiquidAbstractionModeEnabled(verifiedMode);
           }
         }
       }

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/userAbstractionMode.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/userAbstractionMode.test.ts
@@ -1,0 +1,38 @@
+import { shouldPreserveConfirmedUserAbstractionMode } from './userAbstractionMode';
+
+describe('user abstraction mode refresh policy', () => {
+  it('does not preserve a confirmed mode for regular refreshes', () => {
+    expect(
+      shouldPreserveConfirmedUserAbstractionMode({
+        refreshedMode: 'unifiedAccount',
+      }),
+    ).toBe(false);
+  });
+
+  it('does not rewrite when the refetch already returned the confirmed mode', () => {
+    expect(
+      shouldPreserveConfirmedUserAbstractionMode({
+        confirmedMode: 'portfolioMargin',
+        refreshedMode: 'portfolioMargin',
+      }),
+    ).toBe(false);
+  });
+
+  it('preserves the confirmed mode when a refetch returns a stale mode', () => {
+    expect(
+      shouldPreserveConfirmedUserAbstractionMode({
+        confirmedMode: 'portfolioMargin',
+        refreshedMode: 'unifiedAccount',
+      }),
+    ).toBe(true);
+  });
+
+  it('preserves the confirmed mode when a refetch only hits the cache fallback', () => {
+    expect(
+      shouldPreserveConfirmedUserAbstractionMode({
+        confirmedMode: 'portfolioMargin',
+        refreshedMode: undefined,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/userAbstractionMode.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/userAbstractionMode.ts
@@ -1,0 +1,13 @@
+export type IConfirmedUserAbstractionMode =
+  | 'unifiedAccount'
+  | 'portfolioMargin';
+
+export function shouldPreserveConfirmedUserAbstractionMode({
+  confirmedMode,
+  refreshedMode,
+}: {
+  confirmedMode?: IConfirmedUserAbstractionMode;
+  refreshedMode?: string;
+}) {
+  return Boolean(confirmedMode && refreshedMode !== confirmedMode);
+}

--- a/packages/kit-bg/src/states/jotai/atoms/perps.test.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.test.ts
@@ -13,7 +13,10 @@ import {
   perpsActiveAccountEnableTradingModeAtom,
   perpsActiveAccountStatusAtom,
   perpsActiveAccountStatusInfoAtom,
+  perpsActiveAccountSummaryAtom,
+  perpsComputedAccountValueAtom,
   perpsShouldShowEnableTradingButtonAtom,
+  perpsSpotBalancesAtom,
 } from './perps';
 
 const now = 1_000_000;
@@ -578,5 +581,79 @@ describe('perpsShouldShowEnableTradingButtonAtom', () => {
     expect(
       jotaiDefaultStore.get(perpsShouldShowEnableTradingButtonAtom.atom()),
     ).toBe(false);
+  });
+});
+
+describe('perpsComputedAccountValueAtom withdrawable', () => {
+  const ADDR = '0xabc';
+
+  function seedAtoms(mode: EHyperLiquidAbstractionMode) {
+    jotaiDefaultStore.set(perpsActiveAccountAtom.atom(), {
+      accountId: 'account-1',
+      indexedAccountId: 'indexed-1',
+      deriveType: 'default',
+      accountAddress: ADDR,
+    });
+    jotaiDefaultStore.set(perpsAbstractionModeAtom.atom(), {
+      accountAddress: ADDR,
+      mode,
+      source: 'live',
+    });
+    jotaiDefaultStore.set(perpsActiveAccountSummaryAtom.atom(), {
+      accountAddress: ADDR,
+      accountValue: '900',
+      totalMarginUsed: undefined,
+      crossAccountValue: '900',
+      crossMaintenanceMarginUsed: undefined,
+      totalNtlPos: undefined,
+      totalRawUsd: undefined,
+      // Per-dex perp withdrawable (not meaningful in unified/PM); set != USDC
+      // available below to prove the computed value never reads it.
+      withdrawable: '500',
+      totalUnrealizedPnl: undefined,
+    });
+    jotaiDefaultStore.set(perpsSpotBalancesAtom.atom(), {
+      accountAddress: ADDR,
+      spotTotalUsd: '1000',
+      balances: [
+        { coin: 'USDC', token: 0, total: '200', hold: '50', entryNtl: '0' },
+      ],
+    });
+  }
+
+  afterEach(() => {
+    jotaiDefaultStore.set(perpsActiveAccountAtom.atom(), {
+      accountId: null,
+      indexedAccountId: null,
+      deriveType: 'default',
+      accountAddress: null,
+    });
+    jotaiDefaultStore.set(perpsAbstractionModeAtom.atom(), undefined);
+    jotaiDefaultStore.set(perpsActiveAccountSummaryAtom.atom(), undefined);
+    jotaiDefaultStore.set(perpsSpotBalancesAtom.atom(), undefined);
+  });
+
+  it('unified account: withdrawable = USDC available (total - hold)', () => {
+    seedAtoms(EHyperLiquidAbstractionMode.UNIFIED_ACCOUNT);
+    expect(jotaiDefaultStore.get(perpsComputedAccountValueAtom.atom())).toEqual(
+      {
+        accountValue: '1000',
+        withdrawable: '150',
+        isLoading: false,
+      },
+    );
+  });
+
+  // PM uses the same spot-side USDC proxy as unified; the per-dex
+  // summary.withdrawable (500) is not meaningful and must not be used.
+  it('portfolio margin: withdrawable = spot-side USDC, NOT per-dex summary', () => {
+    seedAtoms(EHyperLiquidAbstractionMode.PORTFOLIO_MARGIN);
+    expect(jotaiDefaultStore.get(perpsComputedAccountValueAtom.atom())).toEqual(
+      {
+        accountValue: '1000',
+        withdrawable: '150',
+        isLoading: false,
+      },
+    );
   });
 });

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -351,8 +351,11 @@ export const {
       mode === EHyperLiquidAbstractionMode.PORTFOLIO_MARGIN;
 
     if (isUnified) {
-      // Unified/portfolio: all values from spotState
-      // Per HL docs: "Individual perp dex user states are not meaningful"
+      // Unified/portfolio: account value + withdrawable come from spotState. The
+      // per-dex perp clearinghouse summaries (incl. the summed summary.withdrawable)
+      // are not meaningful when collateral is shared, and HL's true PM withdrawable
+      // is health-factor-capped — a value absent from every feed we fetch. So both
+      // modes fall back to the spot-side USDC proxy; do not swap in summary.withdrawable.
       if (activeSpotData?.spotTotalUsd === undefined) {
         // Spot data not yet loaded: return undefined for skeleton screen
         return {
@@ -361,7 +364,6 @@ export const {
           isLoading: true,
         };
       }
-      // Withdrawable = USDC available (total - hold)
       const usdcBalance = activeSpotData.balances?.find((b) => b.token === 0);
       const usdcWithdrawable = usdcBalance
         ? new BigNumber(usdcBalance.total).minus(usdcBalance.hold).toFixed()

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -3065,6 +3065,36 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     },
   );
 
+  // Account params come from the React layer: perpsActiveAccountAtom reads null
+  // here under PerpsProviderMirror.
+  updateAccountAbstractionMode = contextAtomMethod(
+    async (
+      _,
+      _set,
+      params: {
+        userAccountId: string;
+        userAddress: string;
+        abstraction: 'unifiedAccount' | 'portfolioMargin';
+      },
+    ): Promise<void> => {
+      return withToast({
+        asyncFn: async () => {
+          await backgroundApiProxy.serviceHyperliquidExchange.setAbstractionWithUserWallet(
+            {
+              userAccountId: params.userAccountId,
+              userAddress: params.userAddress,
+              abstraction: params.abstraction,
+            },
+          );
+          await backgroundApiProxy.serviceHyperliquid.refreshUserAbstractionMode(
+            params.userAddress as HL.IHex,
+          );
+        },
+        actionType: EActionType.SET_ACCOUNT_MODE,
+      });
+    },
+  );
+
   ordersClose = contextAtomMethod(
     async (
       get,
@@ -3607,6 +3637,8 @@ export function useHyperliquidActions() {
   const submitOrder = actions.submitOrder.use();
   const updateLeverage = actions.updateLeverage.use();
   const updateIsolatedMargin = actions.updateIsolatedMargin.use();
+  const updateAccountAbstractionMode =
+    actions.updateAccountAbstractionMode.use();
   const ordersClose = actions.ordersClose.use();
   const amendChartOrder = actions.amendChartOrder.use();
   const cancelChartOrder = actions.cancelChartOrder.use();
@@ -3680,6 +3712,7 @@ export function useHyperliquidActions() {
     submitOrder,
     updateLeverage,
     updateIsolatedMargin,
+    updateAccountAbstractionMode,
     ordersClose,
     amendChartOrder,
     cancelChartOrder,

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -3088,6 +3088,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
           );
           await backgroundApiProxy.serviceHyperliquid.refreshUserAbstractionMode(
             params.userAddress as HL.IHex,
+            params.abstraction,
           );
         },
         actionType: EActionType.SET_ACCOUNT_MODE,

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/utils/config.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/utils/config.ts
@@ -79,6 +79,13 @@ export const TOAST_CONFIGS: Record<EActionType, IToastConfig> = {
     successTitle: t(ETranslations.perp_trading_adjust_margin_updated),
   },
 
+  [EActionType.SET_ACCOUNT_MODE]: {
+    // TODO(i18n): swap for dedicated ETranslations keys once PM adds them.
+    loading: 'Updating account mode…',
+    // TODO(i18n): swap for dedicated ETranslations keys once PM adds them.
+    successTitle: 'Account mode updated',
+  },
+
   [EActionType.SET_POSITION_TPSL]: {
     loading: t(ETranslations.perp_toast_setting_tp_sl),
     successTitle: t(ETranslations.perp_toast_setting_tp_sl_sucess),

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/utils/types.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/utils/types.ts
@@ -7,6 +7,7 @@ export enum EActionType {
   LIMIT_ORDER_CLOSE = 'limitOrderClose',
   UPDATE_LEVERAGE = 'updateLeverage',
   UPDATE_ISOLATED_MARGIN = 'updateIsolatedMargin',
+  SET_ACCOUNT_MODE = 'setAccountMode',
   SET_POSITION_TPSL = 'setPositionTpsl',
   CANCEL_ORDER = 'cancelOrder',
   MODIFY_ORDER = 'modifyOrder',

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/AccountModeModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/AccountModeModal.tsx
@@ -9,10 +9,11 @@ import {
   Dialog,
   Image,
   SizableText,
-  Toast,
   XStack,
   YStack,
 } from '@onekeyhq/components';
+import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import { usePerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
@@ -212,21 +213,48 @@ function AccountModeContent({
   onSelect?: (mode: IPerpsAccountModeOption) => void;
 }) {
   const intl = useIntl();
+  const actions = useHyperliquidActions();
+  const [perpsActiveAccount] = usePerpsActiveAccountAtom();
   const [selectedMode, setSelectedMode] =
     useState<IPerpsAccountModeOption>(initialMode);
+  const [loading, setLoading] = useState(false);
 
-  const handleConfirm = useCallback(() => {
-    onSelect?.(selectedMode);
-    void onClose?.();
-    Toast.success({
-      title: intl.formatMessage({
-        id: ETranslations.perp_account_mode_ui_updated__msg,
-      }),
-      message: intl.formatMessage({
-        id: ETranslations.perp_account_mode_logic_pending__msg,
-      }),
-    });
-  }, [intl, onClose, onSelect, selectedMode]);
+  const handleConfirm = useCallback(async () => {
+    const accountId = perpsActiveAccount?.accountId;
+    const accountAddress = perpsActiveAccount?.accountAddress;
+    if (!accountId || !accountAddress) return;
+    if (selectedMode === initialMode) {
+      void onClose?.();
+      return;
+    }
+    const abstraction =
+      selectedMode === EHyperLiquidAbstractionMode.PORTFOLIO_MARGIN
+        ? 'portfolioMargin'
+        : 'unifiedAccount';
+    try {
+      setLoading(true);
+      await actions.current.updateAccountAbstractionMode({
+        userAccountId: accountId,
+        userAddress: accountAddress,
+        abstraction,
+      });
+      // Optimistic hint until the re-fetched live mode lands.
+      onSelect?.(selectedMode);
+      void onClose?.();
+    } catch {
+      // withToast already showed the error; stay open so the user can retry.
+      // TODO(i18n): localize PM switch errors via perp-config hyperLiquidErrorLocales.
+      setLoading(false);
+    }
+  }, [
+    actions,
+    initialMode,
+    onClose,
+    onSelect,
+    perpsActiveAccount?.accountAddress,
+    perpsActiveAccount?.accountId,
+    selectedMode,
+  ]);
 
   return (
     <YStack gap="$4">
@@ -275,6 +303,8 @@ function AccountModeContent({
           testID="perp-account-mode-confirm-button"
           variant="primary"
           size={PERP_DIALOG_BUTTON_SIZE}
+          loading={loading}
+          disabled={loading}
           onPress={handleConfirm}
         >
           {intl.formatMessage({ id: ETranslations.global_confirm })}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/AccountModeModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/AccountModeModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -218,6 +218,8 @@ function AccountModeContent({
   const [selectedMode, setSelectedMode] =
     useState<IPerpsAccountModeOption>(initialMode);
   const [loading, setLoading] = useState(false);
+  const activeAccountAddressRef = useRef(perpsActiveAccount?.accountAddress);
+  activeAccountAddressRef.current = perpsActiveAccount?.accountAddress;
 
   const handleConfirm = useCallback(async () => {
     const accountId = perpsActiveAccount?.accountId;
@@ -238,8 +240,11 @@ function AccountModeContent({
         userAddress: accountAddress,
         abstraction,
       });
-      // Optimistic hint until the re-fetched live mode lands.
-      onSelect?.(selectedMode);
+      // Optimistic hint until the re-fetched live mode lands. Skip if the active
+      // account changed during signing, so the draft can't land on another account.
+      if (activeAccountAddressRef.current === accountAddress) {
+        onSelect?.(selectedMode);
+      }
       void onClose?.();
     } catch {
       // withToast already showed the error; stay open so the user can retry.

--- a/packages/kit/src/views/Perp/components/TradingPanel/selectors/AccountModeSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/selectors/AccountModeSelector.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -67,6 +67,18 @@ const AccountModeSelector = memo(
       [abstractionMode, perpsActiveAccount.accountAddress],
     );
     const displayMode = draftMode ?? liveMode;
+
+    // Drafts are per-account; reset when the account changes.
+    useEffect(() => {
+      setDraftMode(undefined);
+    }, [perpsActiveAccount.accountAddress]);
+
+    // Drop the draft once live mode catches up, so live stays the source of truth.
+    useEffect(() => {
+      setDraftMode((prev) =>
+        prev !== undefined && prev === liveMode ? undefined : prev,
+      );
+    }, [liveMode]);
 
     const handlePress = useCallback(() => {
       if (disabled) return;

--- a/packages/kit/src/views/Perp/components/TradingPanel/selectors/AccountModeSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/selectors/AccountModeSelector.tsx
@@ -6,6 +6,7 @@ import { SizableText, XStack, useInPageDialog } from '@onekeyhq/components';
 import {
   usePerpsAbstractionModeAtom,
   usePerpsActiveAccountAtom,
+  usePerpsActiveAccountIsAgentReadyAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { EHyperLiquidAbstractionMode } from '@onekeyhq/shared/types/hyperliquid';
@@ -56,7 +57,13 @@ const AccountModeSelector = memo(
     const dialog = useInPageDialog();
     const [abstractionMode] = usePerpsAbstractionModeAtom();
     const [perpsActiveAccount] = usePerpsActiveAccountAtom();
+    const [{ isAgentReady }] = usePerpsActiveAccountIsAgentReadyAtom();
     const [draftMode, setDraftMode] = useState<IPerpsAccountModeOption>();
+
+    // Before trading is enabled the confirm button is replaced by an "Enable
+    // Trading" CTA whose flow force-sets unifiedAccount — so a PM pick here would
+    // be silently dropped. Gate the selector until the account is ready.
+    const isDisabled = disabled || !isAgentReady;
 
     const liveMode = useMemo(
       () =>
@@ -81,7 +88,7 @@ const AccountModeSelector = memo(
     }, [liveMode]);
 
     const handlePress = useCallback(() => {
-      if (disabled) return;
+      if (isDisabled) return;
       showAccountModeDialog({
         dialog,
         initialMode: displayMode,
@@ -90,12 +97,12 @@ const AccountModeSelector = memo(
           id: ETranslations.perp_account_mode__title,
         }),
       });
-    }, [dialog, disabled, displayMode, intl]);
+    }, [dialog, isDisabled, displayMode, intl]);
 
     return (
       <XStack
         onPress={handlePress}
-        disabled={disabled}
+        disabled={isDisabled}
         width="100%"
         height={isMobile ? 32 : 30}
         bg={isMobile ? '$bgSubdued' : '$bgStrong'}

--- a/packages/shared/src/utils/perpsUtils.test.ts
+++ b/packages/shared/src/utils/perpsUtils.test.ts
@@ -5,7 +5,10 @@
 
 import BigNumber from 'bignumber.js';
 
-import { EPerpsSizeInputMode } from '@onekeyhq/shared/types/hyperliquid/types';
+import {
+  EHyperLiquidAbstractionMode,
+  EPerpsSizeInputMode,
+} from '@onekeyhq/shared/types/hyperliquid/types';
 
 import {
   analyzeOrderBookPrecision,
@@ -28,6 +31,7 @@ import {
   getSpotMarketCapValue,
   getSpotTokenDisplayName,
   getValidPriceDecimals,
+  isHyperLiquidAbstractionModeEnabled,
   isPredictionMarketInstrument,
   resolveTradingSizeBN,
 } from './perpsUtils';
@@ -653,5 +657,36 @@ describe('calculateLiquidationPrice', () => {
     });
 
     expect(liquidationPrice?.toNumber()).toBeCloseTo(25.789_474, 6);
+  });
+});
+
+describe('isHyperLiquidAbstractionModeEnabled', () => {
+  // Guards against dropping PORTFOLIO_MARGIN — that would force-revert PM accounts.
+  it('accepts unified account and portfolio margin', () => {
+    expect(
+      isHyperLiquidAbstractionModeEnabled(
+        EHyperLiquidAbstractionMode.UNIFIED_ACCOUNT,
+      ),
+    ).toBe(true);
+    expect(
+      isHyperLiquidAbstractionModeEnabled(
+        EHyperLiquidAbstractionMode.PORTFOLIO_MARGIN,
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects disabled / default / dexAbstraction / unknown', () => {
+    expect(
+      isHyperLiquidAbstractionModeEnabled(EHyperLiquidAbstractionMode.DISABLED),
+    ).toBe(false);
+    expect(
+      isHyperLiquidAbstractionModeEnabled(EHyperLiquidAbstractionMode.DEFAULT),
+    ).toBe(false);
+    expect(
+      isHyperLiquidAbstractionModeEnabled(
+        EHyperLiquidAbstractionMode.DEX_ABSTRACTION,
+      ),
+    ).toBe(false);
+    expect(isHyperLiquidAbstractionModeEnabled(undefined)).toBe(false);
   });
 });

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -24,7 +24,10 @@ import type {
   ISpotUniverse,
   IWsActiveAssetCtx,
 } from '@onekeyhq/shared/types/hyperliquid/sdk';
-import { ETriggerOrderType } from '@onekeyhq/shared/types/hyperliquid/types';
+import {
+  EHyperLiquidAbstractionMode,
+  ETriggerOrderType,
+} from '@onekeyhq/shared/types/hyperliquid/types';
 import type {
   IPerpTokenSortDirection,
   IPerpTokenSortField,
@@ -1593,6 +1596,17 @@ export function parseSignatureToRSV(signatureHex: string): {
 
 export function normalizePerpsAccountAddress(address?: string | null) {
   return address?.toLowerCase() ?? null;
+}
+
+// Accepted modes — enable-trading force-switches only accounts outside this set.
+// PORTFOLIO_MARGIN must stay, or PM accounts get force-reverted to unified.
+export function isHyperLiquidAbstractionModeEnabled(
+  mode: EHyperLiquidAbstractionMode | string | undefined,
+): boolean {
+  return (
+    mode === EHyperLiquidAbstractionMode.UNIFIED_ACCOUNT ||
+    mode === EHyperLiquidAbstractionMode.PORTFOLIO_MARGIN
+  );
 }
 
 // Parse coin with dex prefix, e.g., "xyz:NVDA" -> { displayName: "NVDA", dexLabel: "xyz" }


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56893](https://onekeyhq.atlassian.net/browse/OK-56893)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Wire the account-mode selector (next to the leverage button) to a real on-chain switch between **unified account** and **portfolio margin**. Previously, confirming only updated local UI and showed a "Switching logic will be connected separately" toast — it never went on-chain.
- Add an `updateAccountAbstractionMode` action that signs `userSetAbstraction`, busts the abstraction cache, and refetches so `perpsAbstractionModeAtom` reflects the new mode.
- Extract `isHyperLiquidAbstractionModeEnabled` so the enable-trading force-switch keeps treating portfolio margin as an accepted mode (regression-tested).

## Intent & Context
The Perps account-mode feature already shipped its UI, types, read flow, and account-value recognition for `unifiedAccount` ↔ `portfolioMargin`. The only gap was that the confirm button in `AccountModeModal` was a stub. This PR connects that stub to the existing BG `setAbstractionWithUserWallet` path so users can actually opt into portfolio margin from the trading panel.

## Design Decisions
- **Reuse `userSetAbstraction`**, not the dedicated `userPortfolioMargin` SDK action — the BG method `setAbstractionWithUserWallet` already wraps it and was proven by the dev-only debug selector. Avoids a second code path.
- **Account params passed explicitly from the React layer** into the action — reading `perpsActiveAccountAtom` inside the context action returns null under `PerpsProviderMirror`.
- **Display side intentionally unchanged.** An earlier attempt routed the portfolio-margin `withdrawable` to `summary.withdrawable`. HL docs + a data-flow trace proved this wrong: under unified/portfolio margin the per-dex perp `withdrawable`/maintenance are "not meaningful" (the atom is fed by summed `ALL_DEXS_CLEARINGHOUSE_STATE`), and HL's real health-factor-capped value is not present in any feed the app fetches (`borrowLendUserState.healthFactor` is unimplemented/null and never called). So portfolio margin mirrors the unified spot-side proxy for both `withdrawable` and MMR — the same behavior already shipped for unified accounts. A guard comment + test lock this in to prevent re-introducing the per-dex value.
- **Force-switch logic unchanged.** `checkPerpsAccountStatus` already accepts unified OR portfolio margin and only force-switches other modes to unified. The duplicated inline check was extracted into a shared helper (behavior-preserving) purely to make it DRY and testable.

## Changes Detail
- `contexts/hyperliquid/actions.ts`, `utils/types.ts`, `utils/config.ts`: new `updateAccountAbstractionMode` action + `EActionType.SET_ACCOUNT_MODE` toast config (loading/success/error via `withToast`, English strings + `TODO(i18n)`).
- `ServiceHyperliquid.ts`: new `refreshUserAbstractionMode` (invalidate cache + refetch); two inline abstraction checks now call the extracted helper.
- `AccountModeModal.tsx`: real confirm — reads active account, calls the action, shows loading, stays open on failure (error surfaced by `withToast`); removed the stub toast.
- `AccountModeSelector.tsx`: per-account optimistic draft (reset on account change, cleared once live mode catches up).
- `shared/utils/perpsUtils.ts`: new `isHyperLiquidAbstractionModeEnabled` helper.
- `perps.ts`: guard comment documenting why portfolio margin must not use `summary.withdrawable` (no functional change).
- Tests: `perpsUtils.test.ts` (helper accept/reject), `perps.test.ts` (unified & PM both use spot-side USDC; PM does not read the per-dex `summary.withdrawable`).

## Risk Assessment
- **Risk Level**: Low–Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web (Perps only)
- **Risk Areas**:
  - The switch signs a **real user-wallet** EIP-712 tx (unlike sibling leverage/margin actions, which sign silently via the pre-authorized agent wallet). On native the signing UI stacks over the still-open `AccountModeModal` — consistent with the `EnableTradingStepsDialog` precedent, but the dialog-over-dialog z-index/dismissal needs device testing with both hardware and software wallets.
  - Portfolio-margin `withdrawable`/MMR are spot-side approximations (pre-existing for unified; not a new regression). Exact health-factor values require a real PM account to verify.
  - Scope is fully contained to Perps; display side has zero behavioral change.

## Test plan
- [ ] Desktop + mobile: tap the account-mode button (right of leverage) → select Portfolio Margin → confirm → real signing prompt → success toast → selector shows "Portfolio Margin"; switch back to Unified.
- [ ] Failure path: switch with open positions (HL rejects) → error toast shown, dialog stays open, Confirm re-enabled.
- [ ] Signing cancel/timeout → error toast + button re-enabled.
- [ ] Switch active account → optimistic draft resets (no leak across accounts).
- [ ] iOS + hardware wallet / Android + software wallet: signing UI stacks over the open dialog and is dismissible; cancel returns to the loading dialog without wedging.
- [ ] Regression: unified-account account value / withdrawable unchanged vs before.
- [ ] PM account: account value / withdrawable / MMR render with the same spot-side semantics as unified (no crash, no blank).
- [ ] Real PM account (cannot test locally): compare displayed withdrawable/MMR vs HL official UI; decide later whether to grey out approximations in PM.

[OK-56893]: https://onekeyhq.atlassian.net/browse/OK-56893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ