### PR TITLE
fix: align home market perps tab behavior (OK-56990)

### DIFF
--- a/packages/kit-bg/src/states/jotai/atoms/market.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/market.ts
@@ -7,6 +7,8 @@ export interface IMarketSelectedTabAtom {
   tab: IMarketSelectedTab;
   selectedSpotCategory?: string;
   spotCategoryToSelect?: string;
+  selectedPerpsCategory?: string;
+  perpsCategoryToSelect?: string;
 }
 
 export const { target: marketSelectedTabAtom, use: useMarketSelectedTabAtom } =

--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -209,7 +209,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
     IMarketWatchListItemV2[]
   >([]);
   const [selectedCategoryId, setSelectedCategoryId] = useState(
-    DEFAULT_MARKET_CATEGORY_ID,
+    FAVORITES_CATEGORY_ID,
   );
 
   const initializedRef = useRef(false);

--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -209,7 +209,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
     IMarketWatchListItemV2[]
   >([]);
   const [selectedCategoryId, setSelectedCategoryId] = useState(
-    HOME_PERPS_HOT_CATEGORY_ID,
+    DEFAULT_MARKET_CATEGORY_ID,
   );
 
   const initializedRef = useRef(false);

--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -267,12 +267,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
         return categories;
       }
 
-      const [firstCategory, ...restCategories] = categories;
-      if (firstCategory?.id === FAVORITES_CATEGORY_ID) {
-        return [firstCategory, homePerpsHotCategory, ...restCategories];
-      }
-
-      return [homePerpsHotCategory, ...categories];
+      return [...categories, homePerpsHotCategory];
     };
 
     if (apiHomeTabs.length > 0) {

--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -925,7 +925,10 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
   // Navigate to Market favorites tab
   const handleViewMore = useCallback(() => {
     if (selectedMarketCategoryId === HOME_PERPS_HOT_CATEGORY_ID) {
-      navigateToMarketTab({ tabToSelect: EMarketHomeTab.Perps });
+      navigateToMarketTab({
+        tabToSelect: EMarketHomeTab.Perps,
+        perpsCategoryToSelect: HOME_PERPS_HOT_REQUEST_CATEGORY_ID,
+      });
       return;
     }
 

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsTokenList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsTokenList.tsx
@@ -1,4 +1,4 @@
-import { memo, useContext, useEffect, useMemo, useState } from 'react';
+import { memo, useContext, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -14,14 +14,13 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
-import { useMarketBasicConfig } from '../../../hooks/useMarketBasicConfig';
 import { usePerpsNavigation } from '../../../hooks/usePerpsNavigation';
 import { DesktopStickyHeaderContext } from '../../layouts/DesktopStickyHeaderContext';
 import { StickyHeaderPortal } from '../StickyHeaderPortal';
 
-import { MARKET_PERPS_DEFAULT_CATEGORY_ID } from './constants';
 import { useMarketPerpsTokenList } from './hooks/useMarketPerpsTokenList';
 import { usePerpsColumns } from './hooks/usePerpsColumns';
+import { useSyncedMarketPerpsCategory } from './hooks/useSyncedMarketPerpsCategory';
 import { MarketPerpsCategorySelector } from './MarketPerpsCategorySelector';
 
 import type { IMarketPerpsToken } from './hooks/useMarketPerpsTokenList';
@@ -43,28 +42,11 @@ function MarketPerpsTokenListImpl({
   const intl = useIntl();
   const { md } = useMedia();
 
-  const { perpsCategories } = useMarketBasicConfig();
-
-  const initialCategoryId = useMemo(
-    () => perpsCategories[0]?.categoryId ?? MARKET_PERPS_DEFAULT_CATEGORY_ID,
-    [perpsCategories],
-  );
-  const [selectedCategoryId, setSelectedCategoryId] =
-    useState(initialCategoryId);
-
-  // Sync when categories load asynchronously after initial render
-  useEffect(() => {
-    const shouldSyncSelectedCategory =
-      !selectedCategoryId ||
-      (perpsCategories.length > 0 &&
-        !perpsCategories.some(
-          (category) => category.categoryId === selectedCategoryId,
-        ));
-
-    if (shouldSyncSelectedCategory && initialCategoryId) {
-      setSelectedCategoryId(initialCategoryId);
-    }
-  }, [initialCategoryId, perpsCategories, selectedCategoryId]);
+  const {
+    perpsCategories: categoryTabs,
+    selectedCategoryId,
+    handleSelectCategory,
+  } = useSyncedMarketPerpsCategory();
 
   const { tokens, isLoading, hasRealTimeData } = useMarketPerpsTokenList({
     selectedCategoryId,
@@ -74,21 +56,12 @@ function MarketPerpsTokenListImpl({
 
   const handleTokenPress = navigateToPerps;
 
-  const categoryTabs = useMemo(
-    () =>
-      perpsCategories.map((c) => ({
-        tabId: c.categoryId,
-        name: c.name,
-      })),
-    [perpsCategories],
-  );
-
   const CategorySelector = useMemo(
     () => (
       <MarketPerpsCategorySelector
         categories={categoryTabs}
         selectedCategoryId={selectedCategoryId}
-        onSelectCategory={setSelectedCategoryId}
+        onSelectCategory={handleSelectCategory}
         containerStyle={{
           px: '$4',
           pt: '$3',
@@ -96,7 +69,7 @@ function MarketPerpsTokenListImpl({
         }}
       />
     ),
-    [categoryTabs, selectedCategoryId],
+    [categoryTabs, handleSelectCategory, selectedCategoryId],
   );
 
   const showSkeleton = Boolean(isLoading) && tokens.length === 0;

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/useSyncedMarketPerpsCategory.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/useSyncedMarketPerpsCategory.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useMarketBasicConfig } from '@onekeyhq/kit/src/views/Market/hooks/useMarketBasicConfig';
+import { useMarketSelectedTabAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+
+import { MARKET_PERPS_DEFAULT_CATEGORY_ID } from '../constants';
+
+function useSyncedMarketPerpsCategory() {
+  const {
+    perpsCategories: rawPerpsCategories,
+    isLoading: isMarketBasicConfigLoading,
+  } = useMarketBasicConfig();
+  const [
+    { selectedPerpsCategory, perpsCategoryToSelect },
+    setMarketSelectedTab,
+  ] = useMarketSelectedTabAtom();
+
+  const perpsCategories = useMemo(
+    () =>
+      rawPerpsCategories.map((c) => ({
+        tabId: c.categoryId,
+        name: c.name,
+      })),
+    [rawPerpsCategories],
+  );
+
+  const fallbackCategoryId = useMemo(() => {
+    const hasSelectedCategory =
+      selectedPerpsCategory &&
+      (perpsCategories.length === 0 ||
+        perpsCategories.some(
+          (category) => category.tabId === selectedPerpsCategory,
+        ));
+
+    if (hasSelectedCategory) {
+      return selectedPerpsCategory;
+    }
+
+    return perpsCategories[0]?.tabId ?? MARKET_PERPS_DEFAULT_CATEGORY_ID;
+  }, [perpsCategories, selectedPerpsCategory]);
+
+  const [selectedCategoryId, setSelectedCategoryId] =
+    useState(fallbackCategoryId);
+
+  useEffect(() => {
+    if (!perpsCategoryToSelect) {
+      return;
+    }
+
+    const hasTargetCategory = perpsCategories.some(
+      (category) => category.tabId === perpsCategoryToSelect,
+    );
+
+    if (!hasTargetCategory) {
+      if (isMarketBasicConfigLoading !== false) {
+        return;
+      }
+
+      setMarketSelectedTab((prev) => ({
+        ...prev,
+        selectedPerpsCategory:
+          prev.selectedPerpsCategory === perpsCategoryToSelect
+            ? undefined
+            : prev.selectedPerpsCategory,
+        perpsCategoryToSelect: undefined,
+      }));
+      return;
+    }
+
+    if (selectedCategoryId !== perpsCategoryToSelect) {
+      setSelectedCategoryId(perpsCategoryToSelect);
+    }
+    setMarketSelectedTab((prev) => ({
+      ...prev,
+      selectedPerpsCategory: perpsCategoryToSelect,
+      perpsCategoryToSelect: undefined,
+    }));
+  }, [
+    isMarketBasicConfigLoading,
+    perpsCategories,
+    perpsCategoryToSelect,
+    selectedCategoryId,
+    setMarketSelectedTab,
+  ]);
+
+  useEffect(() => {
+    if (perpsCategoryToSelect) {
+      return;
+    }
+
+    const shouldSyncSelectedCategory =
+      !selectedCategoryId ||
+      (perpsCategories.length > 0 &&
+        !perpsCategories.some(
+          (category) => category.tabId === selectedCategoryId,
+        ));
+
+    if (shouldSyncSelectedCategory && fallbackCategoryId) {
+      setSelectedCategoryId(fallbackCategoryId);
+      setMarketSelectedTab((prev) => ({
+        ...prev,
+        selectedPerpsCategory: fallbackCategoryId,
+      }));
+    }
+  }, [
+    fallbackCategoryId,
+    perpsCategories,
+    perpsCategoryToSelect,
+    selectedCategoryId,
+    setMarketSelectedTab,
+  ]);
+
+  const handleSelectCategory = useCallback(
+    (categoryId: string) => {
+      setSelectedCategoryId(categoryId);
+      setMarketSelectedTab((prev) => ({
+        ...prev,
+        selectedPerpsCategory: categoryId,
+        perpsCategoryToSelect: undefined,
+      }));
+    },
+    [setMarketSelectedTab],
+  );
+
+  return {
+    perpsCategories,
+    selectedCategoryId,
+    handleSelectCategory,
+  };
+}
+
+export { useSyncedMarketPerpsCategory };

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
@@ -17,12 +17,11 @@ import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWid
 import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
-import { useMarketBasicConfig } from '../../hooks/useMarketBasicConfig';
 import { MarketBannerList } from '../components/MarketBanner';
 import { MarketFilterBarSmall } from '../components/MarketFilterBarSmall';
 import { MarketListColumnHeader } from '../components/MarketListColumnHeader';
 import { MobileMarketPerpsFlatList } from '../components/MarketPerpsList';
-import { MARKET_PERPS_DEFAULT_CATEGORY_ID } from '../components/MarketPerpsList/constants';
+import { useSyncedMarketPerpsCategory } from '../components/MarketPerpsList/hooks/useSyncedMarketPerpsCategory';
 import { MarketPerpsCategorySelector } from '../components/MarketPerpsList/MarketPerpsCategorySelector';
 import { useIsWatchlistTokenCacheReady } from '../components/MarketTokenList/hooks/useMarketWatchlistTokenList';
 import {
@@ -328,37 +327,8 @@ function MobileLayoutComponent({
     [],
   );
 
-  // Perps category state (lifted from MobileMarketPerpsFlatList)
-  const { perpsCategories: rawPerpsCategories } = useMarketBasicConfig();
-
-  const perpsCategories = useMemo(
-    () =>
-      rawPerpsCategories.map((c) => ({
-        tabId: c.categoryId,
-        name: c.name,
-      })),
-    [rawPerpsCategories],
-  );
-
-  const initialCategoryId = useMemo(
-    () => perpsCategories[0]?.tabId ?? MARKET_PERPS_DEFAULT_CATEGORY_ID,
-    [perpsCategories],
-  );
-  const [selectedCategoryId, setSelectedCategoryId] =
-    useState(initialCategoryId);
-
-  useEffect(() => {
-    const shouldSyncSelectedCategory =
-      !selectedCategoryId ||
-      (perpsCategories.length > 0 &&
-        !perpsCategories.some(
-          (category) => category.tabId === selectedCategoryId,
-        ));
-
-    if (shouldSyncSelectedCategory && initialCategoryId) {
-      setSelectedCategoryId(initialCategoryId);
-    }
-  }, [initialCategoryId, perpsCategories, selectedCategoryId]);
+  const { perpsCategories, selectedCategoryId, handleSelectCategory } =
+    useSyncedMarketPerpsCategory();
 
   const expectedTabChangeTargetRef = useRef<string | undefined>(undefined);
   const expectedTabChangeTargetStartedAtRef = useRef(0);
@@ -709,7 +679,7 @@ function MobileLayoutComponent({
       stockDataCategoryMap,
       perpsCategories,
       selectedCategoryId,
-      onSelectCategory: setSelectedCategoryId,
+      onSelectCategory: handleSelectCategory,
       activeTabName,
     }),
     [
@@ -722,6 +692,7 @@ function MobileLayoutComponent({
       stockDataCategoryMap,
       perpsCategories,
       selectedCategoryId,
+      handleSelectCategory,
       activeTabName,
     ],
   );

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx
@@ -3,7 +3,6 @@ import {
   memo,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -17,12 +16,11 @@ import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWid
 import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
-import { useMarketBasicConfig } from '../../hooks/useMarketBasicConfig';
 import { MarketBannerList } from '../components/MarketBanner';
 import { MarketFilterBarSmall } from '../components/MarketFilterBarSmall';
 import { MarketListColumnHeader } from '../components/MarketListColumnHeader';
 import { MobileMarketPerpsFlatList } from '../components/MarketPerpsList';
-import { MARKET_PERPS_DEFAULT_CATEGORY_ID } from '../components/MarketPerpsList/constants';
+import { useSyncedMarketPerpsCategory } from '../components/MarketPerpsList/hooks/useSyncedMarketPerpsCategory';
 import { MarketPerpsCategorySelector } from '../components/MarketPerpsList/MarketPerpsCategorySelector';
 import { useIsWatchlistTokenCacheReady } from '../components/MarketTokenList/hooks/useMarketWatchlistTokenList';
 import {
@@ -227,37 +225,8 @@ function MobileLayoutComponent({
     [],
   );
 
-  // Perps category state (lifted from MobileMarketPerpsFlatList)
-  const { perpsCategories: rawPerpsCategories } = useMarketBasicConfig();
-
-  const perpsCategories = useMemo(
-    () =>
-      rawPerpsCategories.map((c) => ({
-        tabId: c.categoryId,
-        name: c.name,
-      })),
-    [rawPerpsCategories],
-  );
-
-  const initialCategoryId = useMemo(
-    () => perpsCategories[0]?.tabId ?? MARKET_PERPS_DEFAULT_CATEGORY_ID,
-    [perpsCategories],
-  );
-  const [selectedCategoryId, setSelectedCategoryId] =
-    useState(initialCategoryId);
-
-  useEffect(() => {
-    const shouldSyncSelectedCategory =
-      !selectedCategoryId ||
-      (perpsCategories.length > 0 &&
-        !perpsCategories.some(
-          (category) => category.tabId === selectedCategoryId,
-        ));
-
-    if (shouldSyncSelectedCategory && initialCategoryId) {
-      setSelectedCategoryId(initialCategoryId);
-    }
-  }, [initialCategoryId, perpsCategories, selectedCategoryId]);
+  const { perpsCategories, selectedCategoryId, handleSelectCategory } =
+    useSyncedMarketPerpsCategory();
 
   const {
     activeTabName,
@@ -341,7 +310,7 @@ function MobileLayoutComponent({
       stockDataCategoryMap,
       perpsCategories,
       selectedCategoryId,
-      onSelectCategory: setSelectedCategoryId,
+      onSelectCategory: handleSelectCategory,
       activeTabName,
     }),
     [
@@ -354,6 +323,7 @@ function MobileLayoutComponent({
       stockDataCategoryMap,
       perpsCategories,
       selectedCategoryId,
+      handleSelectCategory,
       activeTabName,
     ],
   );

--- a/packages/kit/src/views/Market/hooks/useNavigateToMarketTab.ts
+++ b/packages/kit/src/views/Market/hooks/useNavigateToMarketTab.ts
@@ -23,6 +23,7 @@ import backgroundApiProxy from '../../../background/instance/backgroundApiProxy'
 interface INavigateToMarketTabOptions {
   tabToSelect?: IMarketSelectedTab;
   spotCategoryToSelect?: string;
+  perpsCategoryToSelect?: string;
 }
 
 export function useNavigateToMarketTab() {
@@ -30,17 +31,27 @@ export function useNavigateToMarketTab() {
 
   const navigateToMarketTab = useCallback(
     (options?: INavigateToMarketTabOptions) => {
-      const { tabToSelect, spotCategoryToSelect } = options ?? {};
-      const targetTab = spotCategoryToSelect ? 'trending' : tabToSelect;
+      const { tabToSelect, spotCategoryToSelect, perpsCategoryToSelect } =
+        options ?? {};
+      let targetTab = tabToSelect;
+      if (spotCategoryToSelect) {
+        targetTab = 'trending';
+      }
+      if (perpsCategoryToSelect) {
+        targetTab = 'perps';
+      }
 
       // Switch to specific tab inside Market (watchlist or trending)
-      if (targetTab || spotCategoryToSelect) {
+      if (targetTab || spotCategoryToSelect || perpsCategoryToSelect) {
         setMarketSelectedTab((prev) => ({
           ...prev,
           tab: targetTab ?? prev.tab,
           selectedSpotCategory:
             spotCategoryToSelect ?? prev.selectedSpotCategory,
           spotCategoryToSelect,
+          selectedPerpsCategory:
+            perpsCategoryToSelect ?? prev.selectedPerpsCategory,
+          perpsCategoryToSelect,
         }));
       }
 


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56990](https://onekeyhq.atlassian.net/browse/OK-56990)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Move the Home Market card Perps tab after the existing spot tabs so the card ordering matches Market.
- Preserve the `v6.4.0` Home Market default selection behavior: reload starts from the first tab, Favorites, while Perps remains available as the last tab.
- Route Home Market Perps `View more` into Market / Perps / Hot instead of only selecting the top-level Perps tab.

## Intent & Context
The Slack thread asked for the Home Market card ordering to align with the Market section, with the contract/Perps tab placed at the end. OK-56990 adds a follow-up requirement: when users click `View more` from the Home contract/Perps card, the destination should match the source list, which is Market Perps Hot.

## Root Cause
`PopularTrading` inserted the synthetic `home-perps-hot` category immediately after Favorites when the API returned a Perps hot category. That made the Home Market card render Perps before spot tabs such as Trending and Stocks.

For `View more`, Home only set the top-level Market tab to `perps`. Market Perps category selection lived as local component state, so the navigation could not explicitly target the Hot category and could preserve or fall back to a different Perps sub-tab.

A later draft changed the initial Home Market category to `trending`, but `v6.4.0` initializes the card with `favorites`. With user favorites, the first tab is selected and the favorites list is shown; without favorites, the same first tab shows the recommendation empty state. This PR keeps that original default.

## Design Decisions
Keep the existing `home-perps-hot` category construction, request data, rendering, and token interaction behavior unchanged. The Home card now appends Perps after the API-provided Home categories and keeps the original Favorites initial selection.

For navigation, extend the existing Market selected-tab atom with a Perps category pending-selection field, matching the existing `spotCategoryToSelect` pattern. A shared `useSyncedMarketPerpsCategory` hook applies the pending category after the async Perps config loads and is reused by desktop, web mobile, and native mobile layouts.

## Changes Detail
- `packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx`: append the Home Perps category after spot categories, preserve the Favorites default selection, and pass `perpsCategoryToSelect: hot` on Perps `View more`.
- `packages/kit/src/views/Market/hooks/useNavigateToMarketTab.ts`: support selecting a Perps sub-category when routing to Market.
- `packages/kit-bg/src/states/jotai/atoms/market.ts`: store selected/pending Perps category state alongside the existing Market tab state.
- `packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/useSyncedMarketPerpsCategory.ts`: centralize Perps category sync and pending-selection consumption.
- Market Perps desktop/web/native layouts now reuse the shared Perps category sync hook.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web / Mobile / Extension Home Market card and Market Perps list
- **Risk Areas**: Market tab state persistence and Perps category selection. Perps data fetching, token rendering, and token navigation behavior are unchanged.

## Test plan
- [x] `yarn lint:staged`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit-bg/src/states/jotai/atoms/market.ts packages/kit/src/views/Market/hooks/useNavigateToMarketTab.ts packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsTokenList.tsx packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/useSyncedMarketPerpsCategory.ts packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.tsx packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx`
- [x] `yarn jest packages/kit/src/views/Home/components/PopularTrading/utils.test.ts --runInBand`
- [x] `git diff --check`
- [x] `git diff --check --cached`
- [x] Static `v6.4.0` tag verification: `PopularTrading` initializes `selectedCategoryId` with `FAVORITES_CATEGORY_ID`; Favorites is the first tab and remains the default selection.
- [x] Runtime Electron verification at `http://localhost:3031/`: Home Market displayed `Favorites / Trending / Stocks / Perps` ordering, with Perps after spot tabs.
- [x] Runtime Electron reload verification at `http://localhost:3031/`: after `Page.reload(ignoreCache: true)`, the selected tab was the first Favorites tab; `Trending`, `Stocks`, and `Perps` were not selected.
- [x] Runtime Electron verification: after manually switching Market Perps to `New List`, going back Home and clicking Home Market Perps `View more` landed on Market / Perps / `Hot`, with `JPY`, `ORDI`, and `SPCX` visible.
- [ ] `yarn lint --fix` is blocked by an existing repository error: `development/rspack/rspack.web.config.ts:3:32 Cannot find module '@aaroon/workbox-rspack-plugin' or its corresponding type declarations.`
- [ ] `yarn tsc:staged` is blocked by the same existing `@aaroon/workbox-rspack-plugin` missing module/type error.

[OK-56990]: https://onekeyhq.atlassian.net/browse/OK-56990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ