### PR TITLE
fix: update DeFi action badges (OK-56905)

### DIFF
--- a/packages/kit/src/components/DeFi/ProtocolPositionActionButton.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionButton.tsx
@@ -479,6 +479,12 @@ const ProtocolPositionActionButton = memo(
       () => isAaveProtocol(protocol.protocol) && hasDebt(position),
       [position, protocol.protocol],
     );
+    // Removing an LP that holds rewards also claims them — drives the
+    // "Remove" vs "Remove & Claim rewards" label.
+    const hasRewards = useMemo(
+      () => defiActionUtils.positionHasRewards(position),
+      [position],
+    );
     const borrowManageParams = useMemo(
       () => getAaveBorrowManageParams({ protocol, position, manageAsset }),
       [manageAsset, position, protocol],
@@ -587,10 +593,17 @@ const ProtocolPositionActionButton = memo(
           accountId,
           networkId: protocol.networkId,
           action,
+          hasRewards,
           onSuccess,
         });
       },
-      [accountId, onSuccess, protocol.networkId, submitProtocolPositionAction],
+      [
+        accountId,
+        hasRewards,
+        onSuccess,
+        protocol.networkId,
+        submitProtocolPositionAction,
+      ],
     );
     const handleManagePress = useCallback(
       (type: EManagePositionType) => {
@@ -670,7 +683,11 @@ const ProtocolPositionActionButton = memo(
               {renderActionButtonLabel({
                 isInfo,
                 isBlock,
-                label: getActionLabel({ action: action.action, intl }),
+                label: getActionLabel({
+                  action: action.action,
+                  intl,
+                  hasRewards,
+                }),
               })}
             </Button>
           );

--- a/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
@@ -84,9 +84,13 @@ function isPercentageAction(action: EDeFiPositionAction) {
 function getActionLabel({
   action,
   intl,
+  hasRewards = false,
 }: {
   action: EDeFiPositionAction;
   intl: ReturnType<typeof useIntl>;
+  // Remove-liquidity only "& Claim rewards" when the position holds rewards;
+  // a plain LP with no rewards stays "Remove".
+  hasRewards?: boolean;
 }) {
   if (action === EDeFiPositionAction.Withdraw) {
     return intl.formatMessage({ id: ETranslations.global_withdraw });
@@ -102,7 +106,9 @@ function getActionLabel({
   }
   if (action === EDeFiPositionAction.RemoveLiquidity) {
     return intl.formatMessage({
-      id: ETranslations.dexmarket_details_liquidity_change_remove,
+      id: hasRewards
+        ? ETranslations.earn_remove_and_claim_rewards__action
+        : ETranslations.dexmarket_details_liquidity_change_remove,
     });
   }
   return action;
@@ -616,6 +622,7 @@ function buildDeFiActionTxConfirmInfo({
   percent,
   amount,
   intl,
+  hasRewards,
 }: {
   action: IResolvedDeFiPositionAction;
   selectedAsset: IResolvedDeFiPositionActionAsset;
@@ -624,6 +631,7 @@ function buildDeFiActionTxConfirmInfo({
   // absent, the amount is derived from `percent`.
   amount?: string;
   intl: ReturnType<typeof useIntl>;
+  hasRewards?: boolean;
 }): IDeFiActionTxConfirmInfo {
   const explicitAmount = amount !== undefined && amount.trim() !== '';
   let assetAmount: string;
@@ -636,7 +644,7 @@ function buildDeFiActionTxConfirmInfo({
   }
 
   return {
-    actionLabel: getActionLabel({ action: action.action, intl }),
+    actionLabel: getActionLabel({ action: action.action, intl, hasRewards }),
     protocolId: action.protocolId,
     assetAmount,
     assetSymbol: selectedAsset.symbol,
@@ -728,6 +736,8 @@ type IProtocolPositionActionSubmitParams = {
   amount?: string;
   // Full close via Max: send bps=10000 so an accruing balance can't leave dust.
   isMaxAmount?: boolean;
+  // Position holds rewards — drives the "Remove & Claim rewards" tx label.
+  hasRewards?: boolean;
   onBeforeNavigateConfirm?: () => void | Promise<void>;
 };
 
@@ -790,6 +800,7 @@ function useProtocolPositionActionSubmit({
       percent,
       amount,
       isMaxAmount,
+      hasRewards,
       onBeforeNavigateConfirm,
     }: IProtocolPositionActionSubmitParams) => {
       if (selectedAssets.length === 0) {
@@ -925,6 +936,7 @@ function useProtocolPositionActionSubmit({
                 percent,
                 amount: displayAmount,
                 intl,
+                hasRewards,
               }),
             }),
           );
@@ -1338,11 +1350,13 @@ function ProtocolPositionActionDialogContent({
   accountId,
   networkId,
   action,
+  hasRewards,
   onSuccess,
 }: {
   accountId: string;
   networkId: string;
   action: IResolvedDeFiPositionAction;
+  hasRewards?: boolean;
   onSuccess?: (
     params: IProtocolPositionActionSuccessParams,
   ) => void | Promise<void>;
@@ -1390,7 +1404,11 @@ function ProtocolPositionActionDialogContent({
         ),
     [action.assets, selectedAssetIndexes],
   );
-  const actionLabel = getActionLabel({ action: action.action, intl });
+  const actionLabel = getActionLabel({
+    action: action.action,
+    intl,
+    hasRewards,
+  });
   const priceUnavailableLabel = intl.formatMessage({
     id: ETranslations.wallet_price_unavailable,
   });
@@ -1551,6 +1569,7 @@ function ProtocolPositionActionDialogContent({
       await submitProtocolPositionAction({
         action,
         selectedAssets,
+        hasRewards,
         percent: isPercentAction ? actionPercent : undefined,
         amount: useManualAmountInput ? amount : undefined,
         isMaxAmount: useManualAmountInput ? isMaxAmount : undefined,
@@ -1739,11 +1758,13 @@ function showProtocolPositionActionDialog({
   accountId,
   networkId,
   action,
+  hasRewards,
   onSuccess,
 }: {
   accountId: string;
   networkId: string;
   action: IResolvedDeFiPositionAction;
+  hasRewards?: boolean;
   onSuccess?: (
     params: IProtocolPositionActionSuccessParams,
   ) => void | Promise<void>;
@@ -1755,6 +1776,7 @@ function showProtocolPositionActionDialog({
         accountId={accountId}
         networkId={networkId}
         action={action}
+        hasRewards={hasRewards}
         onSuccess={onSuccess}
       />
     ),

--- a/packages/kit/src/components/DeFi/ProtocolPositionSection.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionSection.tsx
@@ -78,41 +78,9 @@ const ProtocolPositionSection = memo(
             {amountLabel}
           </SizableText>
         </XStack>
-        {section.assets.map((asset, assetIndex) => (
-          <YStack
-            key={`${itemKeyPrefix}-${section.key}-${asset.address}-${assetIndex}`}
-            gap="$1"
-          >
-            <XStack alignItems="center" gap="$3" minHeight={44}>
-              <XStack alignItems="center" gap="$2" flex={1} minWidth={0}>
-                <Token
-                  size={tokenSize}
-                  tokenImageUri={asset.meta?.logoUrl}
-                  bg="$bgStrong"
-                />
-                <SizableText size="$bodyMdMedium" numberOfLines={1} flex={1}>
-                  {asset.symbol}
-                </SizableText>
-              </XStack>
-              <YStack alignItems="flex-end" minWidth={0} flexShrink={1}>
-                <ProtocolValueCell
-                  value={asset.value}
-                  currencySymbol={currencySymbol}
-                  priceUnavailableLabel={priceUnavailableLabel}
-                  isUnavailable={isProtocolAssetValueUnavailable(asset)}
-                />
-                <NumberSizeableTextWrapper
-                  hideValue
-                  size="$bodyMd"
-                  color="$textSubdued"
-                  formatter="balance"
-                  textAlign="right"
-                >
-                  {asset.amount}
-                </NumberSizeableTextWrapper>
-              </YStack>
-            </XStack>
-            {showAssetActions && actionProps ? (
+        {section.assets.map((asset, assetIndex) => {
+          const actionNode =
+            showAssetActions && actionProps ? (
               <ProtocolPositionActionButton
                 accountId={actionProps.accountId}
                 indexedAccountId={actionProps.indexedAccountId}
@@ -123,12 +91,77 @@ const ProtocolPositionSection = memo(
                 manageAsset={asset}
                 visualVariant="info"
                 actionMinWidth={PER_ASSET_ACTION_MIN_WIDTH}
-                containerProps={{ width: '100%', justifyContent: 'flex-end' }}
+                containerProps={{ justifyContent: 'flex-start' }}
                 onSuccess={actionProps.onActionSuccess}
               />
-            ) : null}
-          </YStack>
-        ))}
+            ) : null;
+          const tokenLabel = (
+            <XStack alignItems="center" gap="$2" flex={1} minWidth={0}>
+              <Token
+                size={tokenSize}
+                tokenImageUri={asset.meta?.logoUrl}
+                bg="$bgStrong"
+              />
+              <SizableText size="$bodyMdMedium" numberOfLines={1} flex={1}>
+                {asset.symbol}
+              </SizableText>
+            </XStack>
+          );
+          const valueCell = (
+            <ProtocolValueCell
+              value={asset.value}
+              currencySymbol={currencySymbol}
+              priceUnavailableLabel={priceUnavailableLabel}
+              isUnavailable={isProtocolAssetValueUnavailable(asset)}
+            />
+          );
+          const amountText = (
+            <NumberSizeableTextWrapper
+              hideValue
+              size="$bodyMd"
+              color="$textSubdued"
+              formatter="balance"
+              textAlign="right"
+            >
+              {asset.amount}
+            </NumberSizeableTextWrapper>
+          );
+          return (
+            <YStack
+              key={`${itemKeyPrefix}-${section.key}-${asset.address}-${assetIndex}`}
+              gap="$1"
+            >
+              {actionNode ? (
+                // Per-asset action sits on the left of the second line, level
+                // with the amount on the right: it reuses the value/amount
+                // column's two-line height instead of adding a third
+                // full-width row, and balances visual weight left↔right.
+                <>
+                  <XStack alignItems="center" gap="$3">
+                    {tokenLabel}
+                    {valueCell}
+                  </XStack>
+                  <XStack
+                    alignItems="center"
+                    gap="$3"
+                    justifyContent="space-between"
+                  >
+                    {actionNode}
+                    {amountText}
+                  </XStack>
+                </>
+              ) : (
+                <XStack alignItems="center" gap="$3" minHeight={44}>
+                  {tokenLabel}
+                  <YStack alignItems="flex-end" minWidth={0} flexShrink={1}>
+                    {valueCell}
+                    {amountText}
+                  </YStack>
+                </XStack>
+              )}
+            </YStack>
+          );
+        })}
       </YStack>
     );
   },

--- a/packages/kit/src/utils/defiPositionUtils.ts
+++ b/packages/kit/src/utils/defiPositionUtils.ts
@@ -2,9 +2,12 @@ import BigNumber from 'bignumber.js';
 
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import defiActionUtils from '@onekeyhq/shared/src/utils/defiActionUtils';
 import {
   EDeFiAssetType,
+  EDeFiPositionAction,
   type IDeFiProtocol,
+  type IDeFiSupportedProtocolAction,
   type IProtocolSummary,
 } from '@onekeyhq/shared/types/defi';
 
@@ -798,6 +801,72 @@ function collectDeFiImageUrls({
   return Array.from(urls);
 }
 
+// Badge label id for a resolved action, in the same wording the detail page
+// uses. `Permit` is an internal approval step (omitted → undefined); Claim and
+// ClaimWithdrawal collapse to one "Claim". RemoveLiquidity reads "Remove &
+// Claim rewards" only when the position holds rewards, otherwise plain "Remove".
+function getProtocolActionBadgeLabelId(
+  action: EDeFiPositionAction,
+  hasRewards: boolean,
+): ETranslations | undefined {
+  switch (action) {
+    case EDeFiPositionAction.Withdraw:
+      return ETranslations.global_withdraw;
+    case EDeFiPositionAction.Repay:
+      return ETranslations.defi_repay;
+    case EDeFiPositionAction.Claim:
+    case EDeFiPositionAction.ClaimWithdrawal:
+      return ETranslations.earn_claim;
+    case EDeFiPositionAction.RemoveLiquidity:
+      return hasRewards
+        ? ETranslations.earn_remove_and_claim_rewards__action
+        : ETranslations.dexmarket_details_liquidity_change_remove;
+    default:
+      return undefined;
+  }
+}
+
+// Badge display order, deduped by label id. A protocol with both a reward LP
+// and a plain LP can surface both Remove variants, hence both are listed.
+const DEFI_ACTION_BADGE_LABEL_ORDER: ETranslations[] = [
+  ETranslations.global_withdraw,
+  ETranslations.defi_repay,
+  ETranslations.earn_claim,
+  ETranslations.earn_remove_and_claim_rewards__action,
+  ETranslations.dexmarket_details_liquidity_change_remove,
+];
+
+// Distinct, ordered i18n label ids for the actions a protocol's positions can
+// perform (union across positions). Empty when nothing is actionable or the
+// supported-actions config hasn't loaded yet.
+function getProtocolActionBadgeLabelIds({
+  protocol,
+  supportedActions,
+}: {
+  protocol: IDeFiProtocol;
+  supportedActions: IDeFiSupportedProtocolAction[];
+}): ETranslations[] {
+  if (!supportedActions.length) return [];
+  const available = new Set<ETranslations>();
+  for (const position of protocol.positions) {
+    const hasRewards = defiActionUtils.positionHasRewards(position);
+    for (const resolved of defiActionUtils.resolveDeFiPositionActions({
+      protocol,
+      position,
+      supportedActions,
+    })) {
+      const labelId = getProtocolActionBadgeLabelId(
+        resolved.action,
+        hasRewards,
+      );
+      if (labelId) available.add(labelId);
+    }
+  }
+  return DEFI_ACTION_BADGE_LABEL_ORDER.filter((labelId) =>
+    available.has(labelId),
+  );
+}
+
 export {
   buildLocalizedProtocolCategoryGroups,
   buildLocalizedProtocolPositionItems,
@@ -805,6 +874,7 @@ export {
   buildProtocolDisplayInfo,
   buildProtocolPositionItems,
   collectDeFiImageUrls,
+  getProtocolActionBadgeLabelIds,
   getProtocolPositionDisplayName,
   getPositionModuleLabel,
   isSectionedPosition,

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolRow.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolRow.tsx
@@ -2,12 +2,22 @@ import { memo, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { SizableText, Stack, YStack } from '@onekeyhq/components';
+import {
+  Badge,
+  SizableText,
+  Stack,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { ProtocolValueCell } from '@onekeyhq/kit/src/components/DeFi/ProtocolValueCell';
 import { getProtocolValueState } from '@onekeyhq/kit/src/components/DeFi/protocolValueUtils';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { Token } from '@onekeyhq/kit/src/components/Token';
-import { buildProtocolDisplayInfo } from '@onekeyhq/kit/src/utils/defiPositionUtils';
+import { useDeFiListSupportedActionsAtom } from '@onekeyhq/kit/src/states/jotai/contexts/deFiList';
+import {
+  buildProtocolDisplayInfo,
+  getProtocolActionBadgeLabelIds,
+} from '@onekeyhq/kit/src/utils/defiPositionUtils';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type {
@@ -26,6 +36,7 @@ const ProtocolRow = memo(
   ({ protocol, protocolInfo, onPress, isAllNetworks }: IProtocolRowProps) => {
     const intl = useIntl();
     const [settings] = useSettingsPersistAtom();
+    const [{ supportedActions }] = useDeFiListSupportedActionsAtom();
     const currencySymbol = settings.currencyInfo.symbol;
 
     const protocolDisplayInfo = useMemo(
@@ -39,6 +50,11 @@ const ProtocolRow = memo(
     const protocolValueState = useMemo(
       () => getProtocolValueState(protocol),
       [protocol],
+    );
+    // The actions this protocol's detail page can perform, previewed as badges.
+    const actionLabelIds = useMemo(
+      () => getProtocolActionBadgeLabelIds({ protocol, supportedActions }),
+      [protocol, supportedActions],
     );
     const hasPartialUnavailableValue =
       protocolValueState.hasAvailableValue &&
@@ -83,19 +99,36 @@ const ProtocolRow = memo(
             {positionCountText}
           </SizableText>
         </YStack>
-        <Stack flexShrink={0} maxWidth={120} alignItems="flex-end">
-          <ProtocolValueCell
-            value={protocolValueState.value}
-            currencySymbol={currencySymbol}
-            priceUnavailableLabel={priceUnavailableLabel}
-            partialPriceUnavailableLabel={partialPriceUnavailableLabel}
-            isUnavailable={!protocolValueState.hasAvailableValue}
-            showPriceUnavailableTooltip={hasPartialUnavailableValue}
-            size="$bodyLgMedium"
-            textAlign="right"
-            numberOfLines={1}
-          />
-        </Stack>
+        <YStack flexShrink={0} alignItems="flex-end" gap="$1">
+          <Stack maxWidth={120} alignItems="flex-end">
+            <ProtocolValueCell
+              value={protocolValueState.value}
+              currencySymbol={currencySymbol}
+              priceUnavailableLabel={priceUnavailableLabel}
+              partialPriceUnavailableLabel={partialPriceUnavailableLabel}
+              isUnavailable={!protocolValueState.hasAvailableValue}
+              showPriceUnavailableTooltip={hasPartialUnavailableValue}
+              size="$bodyLgMedium"
+              textAlign="right"
+              numberOfLines={1}
+            />
+          </Stack>
+          {actionLabelIds.length > 0 ? (
+            <XStack
+              justifyContent="flex-end"
+              alignItems="center"
+              gap="$1"
+              flexWrap="wrap"
+              maxWidth={180}
+            >
+              {actionLabelIds.map((labelId) => (
+                <Badge key={labelId} badgeType="info" badgeSize="sm">
+                  {intl.formatMessage({ id: labelId })}
+                </Badge>
+              ))}
+            </XStack>
+          ) : null}
+        </YStack>
       </ListItem>
     );
   },

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -1248,6 +1248,7 @@ export enum ETranslations {
   earn_claim_redemption__action = 'earn_claim_redemption__action',
   earn_claim_rewards__action = 'earn_claim_rewards__action',
   earn_no_assets_deposited = 'earn_no_assets_deposited',
+  earn_remove_and_claim_rewards__action = 'earn_remove_and_claim_rewards__action',
   earn_reward_distribution_schedule = 'earn_reward_distribution_schedule',
   edit_fee_custom_set_as_default_description = 'edit_fee_custom_set_as_default_description',
   email_verification_rate_limit = 'email_verification_rate_limit',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "রিডেম্পশন গ্রহণ করুন",
   "earn_claim_rewards__action": "পুরস্কার গ্রহণ করুন",
   "earn_no_assets_deposited": "এখনও কোনও সম্পদ জমা দেওয়া হয়নি।",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "আগামী মাসের ১০ তারিখের মধ্যে আপনার Arbitrum ওয়ালেটে (Ethereum এর ঠিকানায়) পুরষ্কার বিতরণ করা হবে।",
   "edit_fee_custom_set_as_default_description": "সমস্ত ভবিষ্যৎ লেনদেনের জন্য {network}-এ ডিফল্ট হিসাবে সেট করুন",
   "email_verification_rate_limit": "অনুগ্রহ করে নতুন যাচাইকরণ কোডের অনুরোধ করার আগে {rest} সেকেন্ড অপেক্ষা করুন",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "Einlösung einfordern",
   "earn_claim_rewards__action": "Belohnungen einfordern",
   "earn_no_assets_deposited": "Bisher wurden keine Vermögenswerte eingezahlt.",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "Die Belohnungen werden bis zum 10. des nächsten Monats an Ihr Arbitrum-Wallet (dieselbe Adresse wie Ethereum) verteilt.",
   "edit_fee_custom_set_as_default_description": "Als Standard für alle zukünftigen Transaktionen auf {network} festlegen",
   "email_verification_rate_limit": "Bitte warte {rest} Sekunden, bevor du einen neuen Bestätigungscode anforderst",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "Claim redemption",
   "earn_claim_rewards__action": "Claim rewards",
   "earn_no_assets_deposited": "No assets deposited yet",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "Rewards will be distributed to your Arbitrum wallet (same address as Ethereum) by the 10th of next month.",
   "edit_fee_custom_set_as_default_description": "Set as default for all future transactions on {network}",
   "email_verification_rate_limit": "Please wait {rest} seconds before requesting a new verification code",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "Reclamar canje",
   "earn_claim_rewards__action": "Reclamar recompensas",
   "earn_no_assets_deposited": "Aún no se han depositado activos.",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "Las recompensas se distribuirán a su billetera Arbitrum (la misma dirección que Ethereum) el día 10 del próximo mes.",
   "edit_fee_custom_set_as_default_description": "Establecer como predeterminado para todas las transacciones futuras en {network}",
   "email_verification_rate_limit": "Espera {rest} segundos antes de solicitar un nuevo código de verificación",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "Réclamer le remboursement",
   "earn_claim_rewards__action": "Réclamer les récompenses",
   "earn_no_assets_deposited": "Aucun actif déposé pour le moment",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "Les récompenses seront distribuées sur votre portefeuille Arbitrum (même adresse qu'Ethereum) d'ici le 10 du mois prochain.",
   "edit_fee_custom_set_as_default_description": "Définir comme valeur par défaut pour toutes les transactions futures sur {network}",
   "email_verification_rate_limit": "Veuillez patienter {rest} secondes avant de demander un nouveau code de vérification",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "रिडेम्पशन प्राप्त करें",
   "earn_claim_rewards__action": "इनाम प्राप्त करें",
   "earn_no_assets_deposited": "अभी तक कोई संपत्ति जमा नहीं की गई",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "पुरस्कार अगले महीने की 10 तारीख तक आपके आर्बिट्रम वॉलेट (इथेरियम के समान पता) में वितरित कर दिए जाएंगे।",
   "edit_fee_custom_set_as_default_description": "{network} पर सभी भविष्य के लेनदेन के लिए डिफ़ॉल्ट के रूप में सेट करें",
   "email_verification_rate_limit": "नया सत्यापन कोड का अनुरोध करने से पहले कृपया {rest} सेकंड प्रतीक्षा करें",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "Klaim penebusan",
   "earn_claim_rewards__action": "Klaim hadiah",
   "earn_no_assets_deposited": "Belum ada aset yang disetorkan",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "Hadiah akan didistribusikan ke dompet Arbitrum Anda (alamat yang sama dengan Ethereum) paling lambat tanggal 10 bulan depan.",
   "edit_fee_custom_set_as_default_description": "Tetapkan sebagai default untuk semua transaksi di masa mendatang pada {network}",
   "email_verification_rate_limit": "Harap tunggu {rest} detik sebelum meminta kode verifikasi baru",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "Richiedi riscatto",
   "earn_claim_rewards__action": "Richiedi ricompense",
   "earn_no_assets_deposited": "Nessun bene depositato ancora",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "Le ricompense verranno distribuite sul tuo portafoglio Arbitrum (stesso indirizzo di Ethereum) entro il 10 del mese prossimo.",
   "edit_fee_custom_set_as_default_description": "Imposta come predefinito per tutte le future transazioni su {network}",
   "email_verification_rate_limit": "Attendi {rest} secondi prima di richiedere un nuovo codice di verifica",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "償還を受け取る",
   "earn_claim_rewards__action": "報酬を受け取る",
   "earn_no_assets_deposited": "まだ資産は預けられていません",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "報酬は来月10日までにArbitrumウォレット（Ethereumと同じアドレス）に配布されます。",
   "edit_fee_custom_set_as_default_description": "{network}での今後すべてのトランザクションのデフォルトとして設定",
   "email_verification_rate_limit": "新しい確認コードをリクエストする前に{rest}秒お待ちください",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "상환 수령",
   "earn_claim_rewards__action": "보상 수령",
   "earn_no_assets_deposited": "아직 예치된 자산이 없습니다",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "보상은 다음 달 10일까지 귀하의 Arbitrum 지갑(이더리움과 동일한 주소)으로 분배됩니다.",
   "edit_fee_custom_set_as_default_description": "{network}에서 모든 향후 거래에 대해 기본값으로 설정",
   "email_verification_rate_limit": "새 인증 코드를 요청하기 전에 {rest}초 동안 기다려 주세요",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "Reclamar resgate",
   "earn_claim_rewards__action": "Reclamar recompensas",
   "earn_no_assets_deposited": "Nenhum ativo foi depositado ainda.",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "As recompensas serão distribuídas para sua carteira Arbitrum (mesmo endereço do Ethereum) até o dia 10 do mês que vem.",
   "edit_fee_custom_set_as_default_description": "Definir como padrão para todas as transações futuras na {network}",
   "email_verification_rate_limit": "Aguarde {rest} segundos antes de solicitar um novo código de verificação",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "Receber resgate",
   "earn_claim_rewards__action": "Resgatar recompensas",
   "earn_no_assets_deposited": "Nenhum ativo foi depositado ainda.",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "As recompensas serão distribuídas para sua carteira Arbitrum (mesmo endereço do Ethereum) até o dia 10 do mês que vem.",
   "edit_fee_custom_set_as_default_description": "Definir como padrão para todas as transações futuras na {network}",
   "email_verification_rate_limit": "Aguarde {rest} segundos antes de solicitar um novo código de verificação",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "Получить погашение",
   "earn_claim_rewards__action": "Получить вознаграждения",
   "earn_no_assets_deposited": "Активы еще не депонированы",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "Вознаграждения будут зачислены на ваш кошелек Arbitrum (тот же адрес, что и Ethereum) до 10 числа следующего месяца.",
   "edit_fee_custom_set_as_default_description": "Установить по умолчанию для всех будущих транзакций в {network}",
   "email_verification_rate_limit": "Пожалуйста, подождите {rest} секунд перед запросом нового кода подтверждения",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "รับสิทธิ์แลกรางวัล",
   "earn_claim_rewards__action": "รับรางวัล",
   "earn_no_assets_deposited": "ยังไม่มีการฝากทรัพย์สิน",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "รางวัลจะถูกแจกจ่ายไปยังกระเป๋าเงิน Arbitrum ของคุณ (ที่อยู่เดียวกับ Ethereum) ภายในวันที่ 10 ของเดือนหน้า",
   "edit_fee_custom_set_as_default_description": "ตั้งเป็นค่าเริ่มต้นสำหรับธุรกรรมทั้งหมดในอนาคตบน {network}",
   "email_verification_rate_limit": "โปรดรอ {rest} วินาทีก่อนที่จะขอรหัสยืนยันใหม่",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "Отримати погашення",
   "earn_claim_rewards__action": "Отримати винагороду",
   "earn_no_assets_deposited": "Активів ще немає внесено",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "Винагороди будуть розподілені на ваш гаманець Arbitrum (та сама адреса, що й Ethereum) до 10-го числа наступного місяця.",
   "edit_fee_custom_set_as_default_description": "Встановити як типове для всіх майбутніх транзакцій у мережі {network}",
   "email_verification_rate_limit": "Будь ласка, зачекайте {rest} секунд перед запитом нового коду підтвердження",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "Nhận quy đổi",
   "earn_claim_rewards__action": "Nhận phần thưởng",
   "earn_no_assets_deposited": "Chưa có tài sản nào được gửi",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "Phần thưởng sẽ được phân phối vào ví Arbitrum của bạn (cùng địa chỉ với Ethereum) vào ngày 10 tháng sau.",
   "edit_fee_custom_set_as_default_description": "Đặt làm mặc định cho tất cả các giao dịch trong tương lai trên {network}",
   "email_verification_rate_limit": "Vui lòng đợi {rest} giây trước khi yêu cầu mã xác minh mới",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "领取赎回",
   "earn_claim_rewards__action": "领取收益",
   "earn_no_assets_deposited": "目前尚未认购任何资产",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "奖励将于下个月 10 号之前发放到您的 Arbitrum 钱包（与以太坊相同的地址）。",
   "edit_fee_custom_set_as_default_description": "设为 {network} 网络未来交易的默认值",
   "email_verification_rate_limit": "请等待 {rest} 秒后再请求新的验证码",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "領取贖回",
   "earn_claim_rewards__action": "領取收益",
   "earn_no_assets_deposited": "目前尚未認購任何資產",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "獎勵將於下個月 10 號之前發放到您的 Arbitrum 錢包（與以太坊相同的地址）。",
   "edit_fee_custom_set_as_default_description": "設為 {network} 網絡今後所有交易的預設值",
   "email_verification_rate_limit": "請等待 {rest} 秒後再請求新的驗證碼",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -1243,6 +1243,7 @@
   "earn_claim_redemption__action": "領取贖回",
   "earn_claim_rewards__action": "領取收益",
   "earn_no_assets_deposited": "目前尚未認購任何資產",
+  "earn_remove_and_claim_rewards__action": "Remove & Claim rewards",
   "earn_reward_distribution_schedule": "獎勵將於下個月 10 號之前發放到您的 Arbitrum 錢包（與以太坊相同的地址）。",
   "edit_fee_custom_set_as_default_description": "設為 {network} 網路日後所有交易的預設值",
   "email_verification_rate_limit": "請等待 {rest} 秒後再請求新的驗證碼",

--- a/packages/shared/src/utils/defiActionUtils.ts
+++ b/packages/shared/src/utils/defiActionUtils.ts
@@ -186,6 +186,24 @@ function isPositiveAmount(amount?: string) {
   return value.isFinite() && value.gt(0);
 }
 
+// Whether the position currently holds claimable rewards (a positive reward
+// balance on the position itself or any of its source positions). Drives the
+// "Remove" vs "Remove & Claim rewards" labelling: removing an LP that has
+// rewards also claims them, so the label says so only when rewards exist.
+function positionHasRewards(
+  position: IDeFiProtocol['positions'][number],
+): boolean {
+  const hasPositiveReward = (rewards: IDeFiAsset[] | undefined) =>
+    rewards?.some((reward) => isPositiveAmount(reward.amount)) ?? false;
+  return (
+    hasPositiveReward(position.rewards) ||
+    (position.sourcePositions?.some((sourcePosition) =>
+      hasPositiveReward(sourcePosition.rewards),
+    ) ??
+      false)
+  );
+}
+
 function asRecord(value: unknown): IDeFiUnknownRecord | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined;
@@ -277,9 +295,9 @@ function omitClientOnlyExtraParams(params?: IDeFiActionExtraParams) {
   const result: IDeFiActionExtraParams = { ...params };
   // Polygon claimWithdrawal is identified by groupId on the service side.
   // oxlint-disable-next-line @cspell/spellchecker
-  delete result['unbondNonces'];
+  delete result.unbondNonces;
   // oxlint-disable-next-line @cspell/spellchecker
-  delete result['unbond_nonces'];
+  delete result.unbond_nonces;
 
   return Object.keys(result).length > 0 ? result : undefined;
 }
@@ -845,6 +863,7 @@ export function resolveDeFiActionTxAmount({
 
 export default {
   buildDeFiActionBps,
+  positionHasRewards,
   resolveDeFiActionTxAmount,
   resolveDeFiPositionActionDebugCandidates,
   resolveDeFiPositionActions,
@@ -857,6 +876,7 @@ export {
   buildDeFiActionBps,
   normalizeCategoryForAction,
   normalizeDeFiActionPercent,
+  positionHasRewards,
   resolveDeFiPositionActionDebugCandidates,
   resolveDeFiPositionActions,
   scopeResolvedActionToAsset,


### PR DESCRIPTION
## Summary

Cherry-picks the remaining DeFi follow-up changes from labrinyang's `fix/batch-issues-20260626` branch onto the latest `x` branch.

Included scope:
- compact debt position rows with inline per-asset actions
- label LP remove actions as `Remove & Claim rewards` only when the position has claimable rewards
- add localized `Remove & Claim rewards` action text
- surface available DeFi actions as protocol-row badges

Already present on latest `x` and skipped as empty patches:
- title-case DeFi position table and section headers
- DeFi action dialog empty state: `Select crypto`
- DeFi portfolio overview spacing loosened

## Issues
- Fixes OK-56905
- Refs OK-56837, OK-56834, OK-56833, OK-56829

## Source
- Source branch: https://github.com/labrinyang/app-monorepo/tree/fix/batch-issues-20260626
- Previous related merged PR: #12187
- Current base: `origin/x` at `606de4e475dfbd3eb80ce7ffec7dfdc59620a53c`

## Checks
- `git diff --check origin/x...HEAD`
- `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/components/DeFi/ProtocolPositionActionButton.tsx packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx packages/kit/src/components/DeFi/ProtocolPositionSection.tsx packages/kit/src/utils/defiPositionUtils.ts packages/kit/src/views/Home/components/DeFiListBlock/ProtocolRow.tsx packages/shared/src/utils/defiActionUtils.ts`
- `yarn jest --runTestsByPath packages/shared/src/utils/defiActionUtils.test.ts packages/kit/src/utils/defiPositionUtils.test.ts --runInBand`
- `yarn tsc:only`

Notes:
- Focused Jest passed 2 suites / 55 tests.
- Worktree dependency setup required a local `yarn install --immutable --mode=skip-build`; the install afterInstall hook was interrupted after web-embed webpack printed `compiled with 5 warnings` and stayed alive. The worktree had no git drift after cleanup.
