### PR TITLE
fix: use dark text on accent buttons and align market Buy tab styling (OK-57080)

### DIFF
--- a/packages/components/src/primitives/Button/index.tsx
+++ b/packages/components/src/primitives/Button/index.tsx
@@ -107,8 +107,8 @@ const BUTTON_VARIANTS: Record<
     focusRingColor: '$focusRing',
   },
   accent: {
-    color: '$textInverse',
-    iconColor: '$iconInverse',
+    color: '$textOnBrightColor',
+    iconColor: '$iconOnBrightColor',
     bg: '$bgAccent',
     hoverBg: '$bgAccentHover',
     activeBg: '$bgAccentActive',

--- a/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebConnectButton.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebConnectButton.tsx
@@ -27,7 +27,7 @@ export function WebConnectButton() {
       role="button"
       testID="web-connect-button"
     >
-      <SizableText size="$bodyLgMedium" color="$textOnColor">
+      <SizableText size="$bodyLgMedium" color="#000000">
         {intl.formatMessage({ id: ETranslations.global_connect })}
       </SizableText>
     </XStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/TradeTypeSelector.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/TradeTypeSelector.tsx
@@ -57,6 +57,9 @@ export function TradeTypeSelector({
   const { gtMd } = useMedia();
   const isBuyActive = value === 'buy';
   const isSellActive = value === 'sell';
+  const buyTextColor: IButtonProps['color'] = isBuyActive
+    ? '#000000'
+    : '$textSubdued';
 
   const buttonSize = size ?? (gtMd ? 'small' : 'medium');
   const renderButtonText = (text: string, color: IButtonProps['color']) =>
@@ -83,14 +86,14 @@ export function TradeTypeSelector({
             onChange(ESwapDirection.BUY);
           }}
           {...getButtonInteractiveStyleProps(isBuyActive)}
-          bg={isBuyActive ? '$bgSuccessStrong' : '$transparent'}
-          color={isBuyActive ? '$textOnColor' : '$textSubdued'}
+          bg={isBuyActive ? '$bgAccent' : '$transparent'}
+          color={buyTextColor}
           size={buttonSize}
           childrenAsText={!preventTextWrap}
         >
           {renderButtonText(
             intl.formatMessage({ id: ETranslations.global_buy }),
-            isBuyActive ? '$textOnColor' : '$textSubdued',
+            buyTextColor,
           )}
         </Button>
       ),


### PR DESCRIPTION
## Summary

Styling fixes for accent-colored buttons across the app.

- **`Button` accent variant** — switch the label/icon color from `$textInverse`/`$iconInverse` to the theme-aware `$textOnBrightColor`/`$iconOnBrightColor` tokens. Previously, in light (day) theme the label rendered near-white on the bright-green accent background, producing low contrast; it now renders dark and readable in both light and dark themes. This affects every `variant="accent"` consumer (e.g. referral landing, redeem-voucher landing, Perps deposit panel).
- **`WebConnectButton`** — the web header "Connect" button label is now pure black (`#000000`) instead of `$textOnColor` (white) on its brand-green background.
- **Market `TradeTypeSelector` (token-detail Buy/Sell selector)** — when the **Buy** tab is active, its background uses the accent color (`$bgAccent`) and its label is pure black. The **Sell** tab is unchanged. The duplicated active-color expression was also hoisted into a single local to keep the two render paths in sync.

## Testing

- `yarn lint:staged` — 0 warnings, 0 errors
- `yarn tsc:staged` — passes

## Notes

- These are visual-only changes; no functional/logic changes.
- The accent-variant change lives in the shared `@onekeyhq/components` `Button`, so it is a design-system-wide adjustment — worth a quick regression pass on pages that use accent buttons.

Jira: OK-57080
