### PR TITLE
fix: use $textOnBrightColor token for Buy tab label (OK-57080)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/TradeTypeSelector.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/TradeTypeSelector.tsx
@@ -58,7 +58,7 @@ export function TradeTypeSelector({
   const isBuyActive = value === 'buy';
   const isSellActive = value === 'sell';
   const buyTextColor: IButtonProps['color'] = isBuyActive
-    ? '#000000'
+    ? '$textOnBrightColor'
     : '$textSubdued';
 
   const buttonSize = size ?? (gtMd ? 'small' : 'medium');


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57080](https://onekeyhq.atlassian.net/browse/OK-57080)

----------

<!-- github-pr-monitor:jira-links:end -->


### Summary

Follow-up fix for #12220 (OK-57080). That PR introduced a `buyTextColor` constant in the Market `TradeTypeSelector` that is explicitly typed as `IButtonProps['color']` (= `ColorTokens | undefined`) but assigned the raw hex `'#000000'`, which failed the CI TypeScript check:

```
TradeTypeSelector.tsx:60 — Type '"#000000"' is not assignable to type 'ColorTokens | undefined'.
```

### Fix

Replace the raw hex with the theme token `$textOnBrightColor` (`tamagui.config.ts` → `gray.gray12`, near-black, theme-aware). This is the **same token #12220 adopted for the Button `accent` variant** label, and the Buy tab now sits on the `$bgAccent` background — so it's the semantically correct, type-valid choice and keeps the dark-on-bright look intact.

```diff
   const buyTextColor: IButtonProps['color'] = isBuyActive
-    ? '#000000'
+    ? '$textOnBrightColor'
     : '$textSubdued';
```

### Verification

- `tsc --noEmit` → 0 errors
- `oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings` on the file → 0 warnings, 0 errors

[OK-57080]: https://onekeyhq.atlassian.net/browse/OK-57080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ