### PR TITLE
fix: use css color name for black text(OK-57080)

### DIFF
--- a/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebConnectButton.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebConnectButton.tsx
@@ -27,7 +27,7 @@ export function WebConnectButton() {
       role="button"
       testID="web-connect-button"
     >
-      <SizableText size="$bodyLgMedium" color="#000000">
+      <SizableText size="$bodyLgMedium" color="black">
         {intl.formatMessage({ id: ETranslations.global_connect })}
       </SizableText>
     </XStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/TradeTypeSelector.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/TradeTypeSelector.tsx
@@ -58,7 +58,7 @@ export function TradeTypeSelector({
   const isBuyActive = value === 'buy';
   const isSellActive = value === 'sell';
   const buyTextColor: IButtonProps['color'] = isBuyActive
-    ? '#000000'
+    ? 'black'
     : '$textSubdued';
 
   const buttonSize = size ?? (gtMd ? 'small' : 'medium');


### PR DESCRIPTION
## Summary
- Replace raw hex black text values with the CSS color name `black`.
- Keep the intended black label color for the web Connect button and the active Market Buy tab.

## Intent & Context
PR #12220 changed bright accent button labels to black, but one of the Market button colors used `#000000` through `IButtonProps['color']`. The lint CI failed during the TypeScript phase for that value.

## Root Cause
`IButtonProps['color']` is typed as Tamagui `ColorTokens`. The hex literal `#000000` is not assignable to that type, while CSS color names are included through `CSSColorNames`.

## Design Decisions
Use `black` instead of adding a cast or widening the button prop type. This preserves the requested visual color and keeps the existing component type contract intact.

## Changes Detail
- `WebConnectButton.tsx`: changed Connect button text color from `#000000` to `black`.
- `TradeTypeSelector.tsx`: changed the active Buy tab text color from `#000000` to `black`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web, Desktop, Mobile
- **Risk Areas**: Visual contrast for accent button labels remains intentionally black.

## Test plan
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebConnectButton.tsx packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/TradeTypeSelector.tsx`
- [x] `yarn lint:staged`
