### PR TITLE
fix: enable Android TradingView quickbar scroll(OK-56896)

### DIFF
--- a/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.native.tsx
+++ b/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.native.tsx
@@ -1,7 +1,12 @@
 import type { PropsWithChildren } from 'react';
 import { useCallback, useContext, useMemo, useState } from 'react';
 
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import {
+  Gesture,
+  GestureDetector,
+  type GestureStateManager,
+  type GestureTouchEvent,
+} from 'react-native-gesture-handler';
 import Animated, {
   cancelAnimation,
   runOnJS,
@@ -84,6 +89,8 @@ export function HeaderScrollGestureWrapper({
         ? measuredWidth * safeExcludeRightEdgeRatio
         : 0;
     const safeExcludeBottomEdgeHeight = Math.max(0, excludeBottomEdgeHeight);
+    const shouldFailExcludedTouches =
+      safeExcludeRightEdgeRatio > 0 || safeExcludeBottomEdgeHeight > 0;
     const gestureHitSlop =
       excludedRightEdgeWidth > 0 || safeExcludeBottomEdgeHeight > 0
         ? {
@@ -115,6 +122,18 @@ export function HeaderScrollGestureWrapper({
 
       return false;
     };
+    const failIfStartPointExcluded = (
+      event: GestureTouchEvent,
+      stateManager: GestureStateManager,
+    ) => {
+      'worklet';
+
+      const touch = event.changedTouches[0] ?? event.allTouches[0];
+      if (touch && shouldIgnoreByStartPoint(touch.x, touch.y)) {
+        isGestureEnabled.value = false;
+        stateManager.fail();
+      }
+    };
 
     let verticalPanGesture = Gesture.Pan()
       .enabled(!disabled)
@@ -125,8 +144,14 @@ export function HeaderScrollGestureWrapper({
       verticalPanGesture = verticalPanGesture.hitSlop(gestureHitSlop);
     }
 
+    verticalPanGesture =
+      verticalPanGesture.cancelsTouchesInView(cancelChildTouches);
+    if (shouldFailExcludedTouches) {
+      verticalPanGesture = verticalPanGesture.onTouchesDown(
+        failIfStartPointExcluded,
+      );
+    }
     verticalPanGesture = verticalPanGesture
-      .cancelsTouchesInView(cancelChildTouches)
       .onStart((e) => {
         'worklet';
 
@@ -192,8 +217,14 @@ export function HeaderScrollGestureWrapper({
       horizontalPanGesture = horizontalPanGesture.hitSlop(gestureHitSlop);
     }
 
+    horizontalPanGesture =
+      horizontalPanGesture.cancelsTouchesInView(cancelChildTouches);
+    if (shouldFailExcludedTouches) {
+      horizontalPanGesture = horizontalPanGesture.onTouchesDown(
+        failIfStartPointExcluded,
+      );
+    }
     horizontalPanGesture = horizontalPanGesture
-      .cancelsTouchesInView(cancelChildTouches)
       .onStart((e) => {
         'worklet';
 

--- a/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.native.tsx
+++ b/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.native.tsx
@@ -1,12 +1,7 @@
 import type { PropsWithChildren } from 'react';
 import { useCallback, useContext, useMemo, useState } from 'react';
 
-import {
-  Gesture,
-  GestureDetector,
-  type GestureStateManager,
-  type GestureTouchEvent,
-} from 'react-native-gesture-handler';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   cancelAnimation,
   runOnJS,
@@ -39,7 +34,6 @@ export function HeaderScrollGestureWrapper({
   cancelChildTouches = true,
   onGestureActiveChange,
   excludeBottomEdgeHeight = 0,
-  failExcludedBottomEdgeTouchesOnTouchDown = false,
 }: PropsWithChildren<IHeaderScrollGestureWrapperProps>) {
   const tabsContext = useContext(CollapsibleTabContext);
   const refMap = tabsContext?.refMap;
@@ -90,9 +84,6 @@ export function HeaderScrollGestureWrapper({
         ? measuredWidth * safeExcludeRightEdgeRatio
         : 0;
     const safeExcludeBottomEdgeHeight = Math.max(0, excludeBottomEdgeHeight);
-    const shouldFailExcludedBottomEdgeTouches =
-      failExcludedBottomEdgeTouchesOnTouchDown &&
-      safeExcludeBottomEdgeHeight > 0;
     const gestureHitSlop =
       excludedRightEdgeWidth > 0 || safeExcludeBottomEdgeHeight > 0
         ? {
@@ -104,18 +95,6 @@ export function HeaderScrollGestureWrapper({
               : {}),
           }
         : undefined;
-    const shouldIgnoreByBottomEdgeStartPoint = (y: number) => {
-      'worklet';
-
-      if (
-        safeExcludeBottomEdgeHeight > 0 &&
-        containerHeight.value > safeExcludeBottomEdgeHeight
-      ) {
-        return y >= containerHeight.value - safeExcludeBottomEdgeHeight;
-      }
-
-      return false;
-    };
     const shouldIgnoreByStartPoint = (x: number, y: number) => {
       'worklet';
 
@@ -127,19 +106,14 @@ export function HeaderScrollGestureWrapper({
         }
       }
 
-      return shouldIgnoreByBottomEdgeStartPoint(y);
-    };
-    const failIfStartPointExcluded = (
-      event: GestureTouchEvent,
-      stateManager: GestureStateManager,
-    ) => {
-      'worklet';
-
-      const touch = event.changedTouches[0] ?? event.allTouches[0];
-      if (touch && shouldIgnoreByBottomEdgeStartPoint(touch.y)) {
-        isGestureEnabled.value = false;
-        stateManager.fail();
+      if (
+        safeExcludeBottomEdgeHeight > 0 &&
+        containerHeight.value > safeExcludeBottomEdgeHeight
+      ) {
+        return y >= containerHeight.value - safeExcludeBottomEdgeHeight;
       }
+
+      return false;
     };
 
     let verticalPanGesture = Gesture.Pan()
@@ -153,11 +127,6 @@ export function HeaderScrollGestureWrapper({
 
     verticalPanGesture =
       verticalPanGesture.cancelsTouchesInView(cancelChildTouches);
-    if (shouldFailExcludedBottomEdgeTouches) {
-      verticalPanGesture = verticalPanGesture.onTouchesDown(
-        failIfStartPointExcluded,
-      );
-    }
     verticalPanGesture = verticalPanGesture
       .onStart((e) => {
         'worklet';
@@ -226,11 +195,6 @@ export function HeaderScrollGestureWrapper({
 
     horizontalPanGesture =
       horizontalPanGesture.cancelsTouchesInView(cancelChildTouches);
-    if (shouldFailExcludedBottomEdgeTouches) {
-      horizontalPanGesture = horizontalPanGesture.onTouchesDown(
-        failIfStartPointExcluded,
-      );
-    }
     horizontalPanGesture = horizontalPanGesture
       .onStart((e) => {
         'worklet';
@@ -278,7 +242,6 @@ export function HeaderScrollGestureWrapper({
     panFailOffsetX,
     excludeRightEdgeRatio,
     excludeBottomEdgeHeight,
-    failExcludedBottomEdgeTouchesOnTouchDown,
     scrollScale,
     onHorizontalSwipe,
     horizontalSwipeThreshold,

--- a/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.native.tsx
+++ b/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.native.tsx
@@ -39,6 +39,7 @@ export function HeaderScrollGestureWrapper({
   cancelChildTouches = true,
   onGestureActiveChange,
   excludeBottomEdgeHeight = 0,
+  failExcludedBottomEdgeTouchesOnTouchDown = false,
 }: PropsWithChildren<IHeaderScrollGestureWrapperProps>) {
   const tabsContext = useContext(CollapsibleTabContext);
   const refMap = tabsContext?.refMap;
@@ -89,8 +90,9 @@ export function HeaderScrollGestureWrapper({
         ? measuredWidth * safeExcludeRightEdgeRatio
         : 0;
     const safeExcludeBottomEdgeHeight = Math.max(0, excludeBottomEdgeHeight);
-    const shouldFailExcludedTouches =
-      safeExcludeRightEdgeRatio > 0 || safeExcludeBottomEdgeHeight > 0;
+    const shouldFailExcludedBottomEdgeTouches =
+      failExcludedBottomEdgeTouchesOnTouchDown &&
+      safeExcludeBottomEdgeHeight > 0;
     const gestureHitSlop =
       excludedRightEdgeWidth > 0 || safeExcludeBottomEdgeHeight > 0
         ? {
@@ -102,6 +104,18 @@ export function HeaderScrollGestureWrapper({
               : {}),
           }
         : undefined;
+    const shouldIgnoreByBottomEdgeStartPoint = (y: number) => {
+      'worklet';
+
+      if (
+        safeExcludeBottomEdgeHeight > 0 &&
+        containerHeight.value > safeExcludeBottomEdgeHeight
+      ) {
+        return y >= containerHeight.value - safeExcludeBottomEdgeHeight;
+      }
+
+      return false;
+    };
     const shouldIgnoreByStartPoint = (x: number, y: number) => {
       'worklet';
 
@@ -113,14 +127,7 @@ export function HeaderScrollGestureWrapper({
         }
       }
 
-      if (
-        safeExcludeBottomEdgeHeight > 0 &&
-        containerHeight.value > safeExcludeBottomEdgeHeight
-      ) {
-        return y >= containerHeight.value - safeExcludeBottomEdgeHeight;
-      }
-
-      return false;
+      return shouldIgnoreByBottomEdgeStartPoint(y);
     };
     const failIfStartPointExcluded = (
       event: GestureTouchEvent,
@@ -129,7 +136,7 @@ export function HeaderScrollGestureWrapper({
       'worklet';
 
       const touch = event.changedTouches[0] ?? event.allTouches[0];
-      if (touch && shouldIgnoreByStartPoint(touch.x, touch.y)) {
+      if (touch && shouldIgnoreByBottomEdgeStartPoint(touch.y)) {
         isGestureEnabled.value = false;
         stateManager.fail();
       }
@@ -146,7 +153,7 @@ export function HeaderScrollGestureWrapper({
 
     verticalPanGesture =
       verticalPanGesture.cancelsTouchesInView(cancelChildTouches);
-    if (shouldFailExcludedTouches) {
+    if (shouldFailExcludedBottomEdgeTouches) {
       verticalPanGesture = verticalPanGesture.onTouchesDown(
         failIfStartPointExcluded,
       );
@@ -219,7 +226,7 @@ export function HeaderScrollGestureWrapper({
 
     horizontalPanGesture =
       horizontalPanGesture.cancelsTouchesInView(cancelChildTouches);
-    if (shouldFailExcludedTouches) {
+    if (shouldFailExcludedBottomEdgeTouches) {
       horizontalPanGesture = horizontalPanGesture.onTouchesDown(
         failIfStartPointExcluded,
       );
@@ -271,6 +278,7 @@ export function HeaderScrollGestureWrapper({
     panFailOffsetX,
     excludeRightEdgeRatio,
     excludeBottomEdgeHeight,
+    failExcludedBottomEdgeTouchesOnTouchDown,
     scrollScale,
     onHorizontalSwipe,
     horizontalSwipeThreshold,

--- a/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.tsx
+++ b/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.tsx
@@ -15,7 +15,6 @@ export interface IHeaderScrollGestureWrapperProps {
   cancelChildTouches?: boolean;
   onGestureActiveChange?: (active: boolean) => void;
   excludeBottomEdgeHeight?: number;
-  failExcludedBottomEdgeTouchesOnTouchDown?: boolean;
 }
 
 export function HeaderScrollGestureWrapper({

--- a/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.tsx
+++ b/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.tsx
@@ -15,6 +15,7 @@ export interface IHeaderScrollGestureWrapperProps {
   cancelChildTouches?: boolean;
   onGestureActiveChange?: (active: boolean) => void;
   excludeBottomEdgeHeight?: number;
+  failExcludedBottomEdgeTouchesOnTouchDown?: boolean;
 }
 
 export function HeaderScrollGestureWrapper({

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
@@ -31,6 +31,7 @@ import type {
   ITradingViewNativeChartControlsConfigData,
 } from '../../types';
 import type {
+  GestureResponderEvent,
   LayoutChangeEvent,
   NativeScrollEvent,
   NativeSyntheticEvent,
@@ -52,6 +53,20 @@ type IQuickBarItemLayout = {
   x: number;
   width: number;
 };
+
+function isQuickBarTouchPressEvent(event?: GestureResponderEvent): boolean {
+  const nativeEvent = event?.nativeEvent;
+  if (!nativeEvent) {
+    return false;
+  }
+  const hasTouchIdentifier =
+    nativeEvent.identifier !== null && nativeEvent.identifier !== undefined;
+  return Boolean(
+    hasTouchIdentifier ||
+    nativeEvent.touches?.length ||
+    nativeEvent.changedTouches?.length,
+  );
+}
 
 function buildIndicatorItemTestID(value: string): string {
   return `trading-view-native-indicator-item-${value
@@ -196,7 +211,7 @@ function IndicatorQuickBarItem({
 }: {
   indicator: ITradingViewIndicatorOption;
   isActive: boolean;
-  onPress: () => void;
+  onPress: (event?: GestureResponderEvent) => void;
   onLayout?: (event: LayoutChangeEvent) => void;
 }) {
   const content = (
@@ -276,8 +291,11 @@ export const TradingViewNativeIndicatorQuickBar = memo(
     }, []);
 
     const handleQuickBarIndicatorPress = useCallback(
-      (indicator: ITradingViewIndicatorOption) => {
-        if (platformEnv.isNativeAndroid) {
+      (
+        indicator: ITradingViewIndicatorOption,
+        shouldUseTouchGuard: boolean,
+      ) => {
+        if (platformEnv.isNativeAndroid && shouldUseTouchGuard) {
           if (quickBarPressHandledRef.current) {
             return;
           }
@@ -302,7 +320,7 @@ export const TradingViewNativeIndicatorQuickBar = memo(
         });
 
         if (indicator) {
-          handleQuickBarIndicatorPress(indicator);
+          handleQuickBarIndicatorPress(indicator, true);
         }
       },
       [handleQuickBarIndicatorPress, mainIndicators, subIndicators],
@@ -341,7 +359,12 @@ export const TradingViewNativeIndicatorQuickBar = memo(
             key={indicator.value}
             indicator={indicator}
             isActive={activeIndicatorValues.has(indicator.value)}
-            onPress={() => handleQuickBarIndicatorPress(indicator)}
+            onPress={(event) =>
+              handleQuickBarIndicatorPress(
+                indicator,
+                isQuickBarTouchPressEvent(event),
+              )
+            }
             onLayout={(event) =>
               handleQuickBarItemLayout(indicator.value, event)
             }
@@ -355,7 +378,12 @@ export const TradingViewNativeIndicatorQuickBar = memo(
             key={indicator.value}
             indicator={indicator}
             isActive={activeIndicatorValues.has(indicator.value)}
-            onPress={() => handleQuickBarIndicatorPress(indicator)}
+            onPress={(event) =>
+              handleQuickBarIndicatorPress(
+                indicator,
+                isQuickBarTouchPressEvent(event),
+              )
+            }
             onLayout={(event) =>
               handleQuickBarItemLayout(indicator.value, event)
             }

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
@@ -1,7 +1,6 @@
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
-import { ScrollView as GestureHandlerScrollView } from 'react-native-gesture-handler';
 
 import {
   Button,
@@ -15,7 +14,6 @@ import {
   useDialogInstance,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { HEADER_ICON_BUTTON_STYLE_PROPS } from '../utils/NativeChartControlsShared';
 
@@ -276,19 +274,9 @@ export const TradingViewNativeIndicatorQuickBar = memo(
         bg="$bgApp"
         zIndex={3}
       >
-        {platformEnv.isNativeAndroid ? (
-          <GestureHandlerScrollView
-            horizontal
-            nestedScrollEnabled
-            showsHorizontalScrollIndicator={false}
-          >
-            {quickBarContent}
-          </GestureHandlerScrollView>
-        ) : (
-          <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-            {quickBarContent}
-          </ScrollView>
-        )}
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          {quickBarContent}
+        </ScrollView>
       </Stack>
     );
   },

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
@@ -199,13 +199,11 @@ function IndicatorQuickBarItem({
   indicator,
   isActive,
   onPress,
-  onPressIn,
   onLayout,
 }: {
   indicator: ITradingViewIndicatorOption;
   isActive: boolean;
   onPress: () => void;
-  onPressIn?: () => void;
   onLayout?: (event: LayoutChangeEvent) => void;
 }) {
   const content = (
@@ -232,7 +230,6 @@ function IndicatorQuickBarItem({
       accessibilityState={{ selected: isActive }}
       onLayout={onLayout}
       onPress={onPress}
-      onPressIn={onPressIn}
     >
       {content}
     </XStack>
@@ -285,38 +282,32 @@ export const TradingViewNativeIndicatorQuickBar = memo(
       [],
     );
 
-    const resetQuickBarPressState = useCallback((sequence: number) => {
-      quickBarPressStateRef.current = {
-        sequence,
-        source: null,
-      };
-    }, []);
-
-    const resetQuickBarPressSource = useCallback(() => {
-      quickBarPressStateRef.current = {
-        ...quickBarPressStateRef.current,
-        source: null,
-      };
-    }, []);
-
     const handleQuickBarIndicatorPress = useCallback(
       (
         indicator: ITradingViewIndicatorOption,
         source: IQuickBarPressSource,
-        sequence?: number,
+        sequence: number,
       ) => {
         if (platformEnv.isNativeAndroid) {
           const state = quickBarPressStateRef.current;
-          if (typeof sequence === 'number' && sequence !== state.sequence) {
+          if (sequence < state.sequence) {
             return;
           }
 
-          if (state.source) {
+          const nextState =
+            sequence > state.sequence
+              ? {
+                  sequence,
+                  source: null,
+                }
+              : state;
+
+          if (nextState.source) {
             return;
           }
 
           quickBarPressStateRef.current = {
-            ...state,
+            sequence,
             source,
           };
         }
@@ -355,7 +346,6 @@ export const TradingViewNativeIndicatorQuickBar = memo(
               'worklet';
 
               quickBarGestureSequence.value += 1;
-              runOnJS(resetQuickBarPressState)(quickBarGestureSequence.value);
             })
             .onEnd((event, success) => {
               'worklet';
@@ -368,7 +358,7 @@ export const TradingViewNativeIndicatorQuickBar = memo(
               }
             }),
         ),
-      [handleQuickBarTap, quickBarGestureSequence, resetQuickBarPressState],
+      [handleQuickBarTap, quickBarGestureSequence],
     );
 
     if (!hasVisibleIndicators) {
@@ -387,8 +377,13 @@ export const TradingViewNativeIndicatorQuickBar = memo(
             key={indicator.value}
             indicator={indicator}
             isActive={activeIndicatorValues.has(indicator.value)}
-            onPress={() => handleQuickBarIndicatorPress(indicator, 'item')}
-            onPressIn={resetQuickBarPressSource}
+            onPress={() =>
+              handleQuickBarIndicatorPress(
+                indicator,
+                'item',
+                quickBarGestureSequence.value,
+              )
+            }
             onLayout={(event) =>
               handleQuickBarItemLayout(indicator.value, event)
             }
@@ -402,8 +397,13 @@ export const TradingViewNativeIndicatorQuickBar = memo(
             key={indicator.value}
             indicator={indicator}
             isActive={activeIndicatorValues.has(indicator.value)}
-            onPress={() => handleQuickBarIndicatorPress(indicator, 'item')}
-            onPressIn={resetQuickBarPressSource}
+            onPress={() =>
+              handleQuickBarIndicatorPress(
+                indicator,
+                'item',
+                quickBarGestureSequence.value,
+              )
+            }
             onLayout={(event) =>
               handleQuickBarItemLayout(indicator.value, event)
             }

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { runOnJS } from 'react-native-reanimated';
+import { runOnJS, useSharedValue } from 'react-native-reanimated';
 
 import {
   Button,
@@ -47,16 +47,17 @@ const INDICATOR_GRID_ITEM_LAYOUT_PROPS = {
 } as const;
 export const TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT = 31;
 const QUICK_BAR_TAP_MOVE_THRESHOLD = 8;
-const QUICK_BAR_DUPLICATE_PRESS_THRESHOLD_MS = 120;
 
 type IQuickBarItemLayout = {
   x: number;
   width: number;
 };
 
-type IQuickBarLastPress = {
-  indicatorValue: string;
-  timestamp: number;
+type IQuickBarPressSource = 'item' | 'fallback';
+
+type IQuickBarPressState = {
+  sequence: number;
+  source: IQuickBarPressSource | null;
 };
 
 function buildIndicatorItemTestID(value: string): string {
@@ -198,11 +199,13 @@ function IndicatorQuickBarItem({
   indicator,
   isActive,
   onPress,
+  onPressIn,
   onLayout,
 }: {
   indicator: ITradingViewIndicatorOption;
   isActive: boolean;
   onPress: () => void;
+  onPressIn?: () => void;
   onLayout?: (event: LayoutChangeEvent) => void;
 }) {
   const content = (
@@ -229,6 +232,7 @@ function IndicatorQuickBarItem({
       accessibilityState={{ selected: isActive }}
       onLayout={onLayout}
       onPress={onPress}
+      onPressIn={onPressIn}
     >
       {content}
     </XStack>
@@ -257,10 +261,14 @@ export const TradingViewNativeIndicatorQuickBar = memo(
       onIndicatorSelect,
     });
     const quickBarScrollXRef = useRef(0);
+    const quickBarGestureSequence = useSharedValue(0);
     const quickBarItemLayoutsRef = useRef(
       new Map<string, IQuickBarItemLayout>(),
     );
-    const lastQuickBarPressRef = useRef<IQuickBarLastPress | null>(null);
+    const quickBarPressStateRef = useRef<IQuickBarPressState>({
+      sequence: 0,
+      source: null,
+    });
 
     const handleQuickBarScroll = useCallback(
       (event: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -277,29 +285,49 @@ export const TradingViewNativeIndicatorQuickBar = memo(
       [],
     );
 
+    const resetQuickBarPressState = useCallback((sequence: number) => {
+      quickBarPressStateRef.current = {
+        sequence,
+        source: null,
+      };
+    }, []);
+
+    const resetQuickBarPressSource = useCallback(() => {
+      quickBarPressStateRef.current = {
+        ...quickBarPressStateRef.current,
+        source: null,
+      };
+    }, []);
+
     const handleQuickBarIndicatorPress = useCallback(
-      (indicator: ITradingViewIndicatorOption) => {
-        const timestamp = Date.now();
-        const lastPress = lastQuickBarPressRef.current;
-        if (
-          lastPress?.indicatorValue === indicator.value &&
-          timestamp - lastPress.timestamp <
-            QUICK_BAR_DUPLICATE_PRESS_THRESHOLD_MS
-        ) {
-          return;
+      (
+        indicator: ITradingViewIndicatorOption,
+        source: IQuickBarPressSource,
+        sequence?: number,
+      ) => {
+        if (platformEnv.isNativeAndroid) {
+          const state = quickBarPressStateRef.current;
+          if (typeof sequence === 'number' && sequence !== state.sequence) {
+            return;
+          }
+
+          if (state.source) {
+            return;
+          }
+
+          quickBarPressStateRef.current = {
+            ...state,
+            source,
+          };
         }
 
-        lastQuickBarPressRef.current = {
-          indicatorValue: indicator.value,
-          timestamp,
-        };
         handleIndicatorPress(indicator);
       },
       [handleIndicatorPress],
     );
 
     const handleQuickBarTap = useCallback(
-      (locationX: number) => {
+      (locationX: number, sequence: number) => {
         const touchContentX = locationX + quickBarScrollXRef.current;
         const indicator = [...mainIndicators, ...subIndicators].find((item) => {
           const layout = quickBarItemLayoutsRef.current.get(item.value);
@@ -311,7 +339,7 @@ export const TradingViewNativeIndicatorQuickBar = memo(
         });
 
         if (indicator) {
-          handleQuickBarIndicatorPress(indicator);
+          handleQuickBarIndicatorPress(indicator, 'fallback', sequence);
         }
       },
       [handleQuickBarIndicatorPress, mainIndicators, subIndicators],
@@ -323,15 +351,24 @@ export const TradingViewNativeIndicatorQuickBar = memo(
           Gesture.Native().shouldActivateOnStart(true),
           Gesture.Tap()
             .maxDistance(QUICK_BAR_TAP_MOVE_THRESHOLD)
+            .onBegin(() => {
+              'worklet';
+
+              quickBarGestureSequence.value += 1;
+              runOnJS(resetQuickBarPressState)(quickBarGestureSequence.value);
+            })
             .onEnd((event, success) => {
               'worklet';
 
               if (success) {
-                runOnJS(handleQuickBarTap)(event.x);
+                runOnJS(handleQuickBarTap)(
+                  event.x,
+                  quickBarGestureSequence.value,
+                );
               }
             }),
         ),
-      [handleQuickBarTap],
+      [handleQuickBarTap, quickBarGestureSequence, resetQuickBarPressState],
     );
 
     if (!hasVisibleIndicators) {
@@ -350,7 +387,8 @@ export const TradingViewNativeIndicatorQuickBar = memo(
             key={indicator.value}
             indicator={indicator}
             isActive={activeIndicatorValues.has(indicator.value)}
-            onPress={() => handleQuickBarIndicatorPress(indicator)}
+            onPress={() => handleQuickBarIndicatorPress(indicator, 'item')}
+            onPressIn={resetQuickBarPressSource}
             onLayout={(event) =>
               handleQuickBarItemLayout(indicator.value, event)
             }
@@ -364,7 +402,8 @@ export const TradingViewNativeIndicatorQuickBar = memo(
             key={indicator.value}
             indicator={indicator}
             isActive={activeIndicatorValues.has(indicator.value)}
-            onPress={() => handleQuickBarIndicatorPress(indicator)}
+            onPress={() => handleQuickBarIndicatorPress(indicator, 'item')}
+            onPressIn={resetQuickBarPressSource}
             onLayout={(event) =>
               handleQuickBarItemLayout(indicator.value, event)
             }

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
@@ -1,6 +1,8 @@
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { runOnJS } from 'react-native-reanimated';
 
 import {
   Button,
@@ -14,6 +16,7 @@ import {
   useDialogInstance,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { HEADER_ICON_BUTTON_STYLE_PROPS } from '../utils/NativeChartControlsShared';
 
@@ -27,6 +30,11 @@ import type {
   ITradingViewIndicatorOption,
   ITradingViewNativeChartControlsConfigData,
 } from '../../types';
+import type {
+  LayoutChangeEvent,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+} from 'react-native';
 
 const INDICATOR_GRID_COLUMN_COUNT = 4;
 const INDICATOR_GRID_ITEM_LAYOUT_PROPS = {
@@ -38,6 +46,18 @@ const INDICATOR_GRID_ITEM_LAYOUT_PROPS = {
   borderWidth: 1,
 } as const;
 export const TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT = 31;
+const QUICK_BAR_TAP_MOVE_THRESHOLD = 8;
+const QUICK_BAR_DUPLICATE_PRESS_THRESHOLD_MS = 120;
+
+type IQuickBarItemLayout = {
+  x: number;
+  width: number;
+};
+
+type IQuickBarLastPress = {
+  indicatorValue: string;
+  timestamp: number;
+};
 
 function buildIndicatorItemTestID(value: string): string {
   return `trading-view-native-indicator-item-${value
@@ -178,11 +198,25 @@ function IndicatorQuickBarItem({
   indicator,
   isActive,
   onPress,
+  onLayout,
 }: {
   indicator: ITradingViewIndicatorOption;
   isActive: boolean;
   onPress: () => void;
+  onLayout?: (event: LayoutChangeEvent) => void;
 }) {
+  const content = (
+    <SizableText
+      size={isActive ? '$bodySmMedium' : '$bodySm'}
+      numberOfLines={1}
+      adjustsFontSizeToFit
+      minimumFontScale={0.82}
+      color={isActive ? '$text' : '$textSubdued'}
+    >
+      {indicator.label}
+    </SizableText>
+  );
+
   return (
     <XStack
       testID={buildIndicatorQuickBarItemTestID(indicator.value)}
@@ -191,17 +225,12 @@ function IndicatorQuickBarItem({
       justifyContent="center"
       cursor="pointer"
       userSelect="none"
+      accessibilityRole="button"
+      accessibilityState={{ selected: isActive }}
+      onLayout={onLayout}
       onPress={onPress}
     >
-      <SizableText
-        size={isActive ? '$bodySmMedium' : '$bodySm'}
-        numberOfLines={1}
-        adjustsFontSizeToFit
-        minimumFontScale={0.82}
-        color={isActive ? '$text' : '$textSubdued'}
-      >
-        {indicator.label}
-      </SizableText>
+      {content}
     </XStack>
   );
 }
@@ -227,10 +256,122 @@ export const TradingViewNativeIndicatorQuickBar = memo(
       nativeIndicatorState,
       onIndicatorSelect,
     });
+    const quickBarScrollXRef = useRef(0);
+    const quickBarItemLayoutsRef = useRef(
+      new Map<string, IQuickBarItemLayout>(),
+    );
+    const lastQuickBarPressRef = useRef<IQuickBarLastPress | null>(null);
+
+    const handleQuickBarScroll = useCallback(
+      (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+        quickBarScrollXRef.current = event.nativeEvent.contentOffset.x;
+      },
+      [],
+    );
+
+    const handleQuickBarItemLayout = useCallback(
+      (indicatorValue: string, event: LayoutChangeEvent) => {
+        const { x, width } = event.nativeEvent.layout;
+        quickBarItemLayoutsRef.current.set(indicatorValue, { x, width });
+      },
+      [],
+    );
+
+    const handleQuickBarIndicatorPress = useCallback(
+      (indicator: ITradingViewIndicatorOption) => {
+        const timestamp = Date.now();
+        const lastPress = lastQuickBarPressRef.current;
+        if (
+          lastPress?.indicatorValue === indicator.value &&
+          timestamp - lastPress.timestamp <
+            QUICK_BAR_DUPLICATE_PRESS_THRESHOLD_MS
+        ) {
+          return;
+        }
+
+        lastQuickBarPressRef.current = {
+          indicatorValue: indicator.value,
+          timestamp,
+        };
+        handleIndicatorPress(indicator);
+      },
+      [handleIndicatorPress],
+    );
+
+    const handleQuickBarTap = useCallback(
+      (locationX: number) => {
+        const touchContentX = locationX + quickBarScrollXRef.current;
+        const indicator = [...mainIndicators, ...subIndicators].find((item) => {
+          const layout = quickBarItemLayoutsRef.current.get(item.value);
+          return (
+            layout &&
+            touchContentX >= layout.x &&
+            touchContentX <= layout.x + layout.width
+          );
+        });
+
+        if (indicator) {
+          handleQuickBarIndicatorPress(indicator);
+        }
+      },
+      [handleQuickBarIndicatorPress, mainIndicators, subIndicators],
+    );
+
+    const quickBarGesture = useMemo(
+      () =>
+        Gesture.Simultaneous(
+          Gesture.Native().shouldActivateOnStart(true),
+          Gesture.Tap()
+            .maxDistance(QUICK_BAR_TAP_MOVE_THRESHOLD)
+            .onEnd((event, success) => {
+              'worklet';
+
+              if (success) {
+                runOnJS(handleQuickBarTap)(event.x);
+              }
+            }),
+        ),
+      [handleQuickBarTap],
+    );
 
     if (!hasVisibleIndicators) {
       return null;
     }
+
+    const quickBarContent = (
+      <XStack
+        h={TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT}
+        px="$5"
+        gap="$4"
+        alignItems="center"
+      >
+        {mainIndicators.map((indicator) => (
+          <IndicatorQuickBarItem
+            key={indicator.value}
+            indicator={indicator}
+            isActive={activeIndicatorValues.has(indicator.value)}
+            onPress={() => handleQuickBarIndicatorPress(indicator)}
+            onLayout={(event) =>
+              handleQuickBarItemLayout(indicator.value, event)
+            }
+          />
+        ))}
+        {subIndicators.length ? (
+          <Stack h="$4" w="$px" bg="$borderSubdued" />
+        ) : null}
+        {subIndicators.map((indicator) => (
+          <IndicatorQuickBarItem
+            key={indicator.value}
+            indicator={indicator}
+            isActive={activeIndicatorValues.has(indicator.value)}
+            onPress={() => handleQuickBarIndicatorPress(indicator)}
+            onLayout={(event) =>
+              handleQuickBarItemLayout(indicator.value, event)
+            }
+          />
+        ))}
+      </XStack>
+    );
 
     return (
       <Stack
@@ -239,34 +380,23 @@ export const TradingViewNativeIndicatorQuickBar = memo(
         bg="$bgApp"
         zIndex={3}
       >
-        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-          <XStack
-            h={TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT}
-            px="$5"
-            gap="$4"
-            alignItems="center"
-          >
-            {mainIndicators.map((indicator) => (
-              <IndicatorQuickBarItem
-                key={indicator.value}
-                indicator={indicator}
-                isActive={activeIndicatorValues.has(indicator.value)}
-                onPress={() => handleIndicatorPress(indicator)}
-              />
-            ))}
-            {subIndicators.length ? (
-              <Stack h="$4" w="$px" bg="$borderSubdued" />
-            ) : null}
-            {subIndicators.map((indicator) => (
-              <IndicatorQuickBarItem
-                key={indicator.value}
-                indicator={indicator}
-                isActive={activeIndicatorValues.has(indicator.value)}
-                onPress={() => handleIndicatorPress(indicator)}
-              />
-            ))}
-          </XStack>
-        </ScrollView>
+        {platformEnv.isNativeAndroid ? (
+          <GestureDetector gesture={quickBarGesture}>
+            <ScrollView
+              horizontal
+              nestedScrollEnabled
+              scrollEventThrottle={16}
+              onScroll={handleQuickBarScroll}
+              showsHorizontalScrollIndicator={false}
+            >
+              {quickBarContent}
+            </ScrollView>
+          </GestureDetector>
+        ) : (
+          <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+            {quickBarContent}
+          </ScrollView>
+        )}
       </Stack>
     );
   },

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { runOnJS, useSharedValue } from 'react-native-reanimated';
+import { runOnJS } from 'react-native-reanimated';
 
 import {
   Button,
@@ -51,13 +51,6 @@ const QUICK_BAR_TAP_MOVE_THRESHOLD = 8;
 type IQuickBarItemLayout = {
   x: number;
   width: number;
-};
-
-type IQuickBarPressSource = 'item' | 'fallback';
-
-type IQuickBarPressState = {
-  sequence: number;
-  source: IQuickBarPressSource | null;
 };
 
 function buildIndicatorItemTestID(value: string): string {
@@ -258,14 +251,10 @@ export const TradingViewNativeIndicatorQuickBar = memo(
       onIndicatorSelect,
     });
     const quickBarScrollXRef = useRef(0);
-    const quickBarGestureSequence = useSharedValue(0);
+    const quickBarPressHandledRef = useRef(false);
     const quickBarItemLayoutsRef = useRef(
       new Map<string, IQuickBarItemLayout>(),
     );
-    const quickBarPressStateRef = useRef<IQuickBarPressState>({
-      sequence: 0,
-      source: null,
-    });
 
     const handleQuickBarScroll = useCallback(
       (event: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -282,34 +271,17 @@ export const TradingViewNativeIndicatorQuickBar = memo(
       [],
     );
 
+    const handleQuickBarTouchStart = useCallback(() => {
+      quickBarPressHandledRef.current = false;
+    }, []);
+
     const handleQuickBarIndicatorPress = useCallback(
-      (
-        indicator: ITradingViewIndicatorOption,
-        source: IQuickBarPressSource,
-        sequence: number,
-      ) => {
+      (indicator: ITradingViewIndicatorOption) => {
         if (platformEnv.isNativeAndroid) {
-          const state = quickBarPressStateRef.current;
-          if (sequence < state.sequence) {
+          if (quickBarPressHandledRef.current) {
             return;
           }
-
-          const nextState =
-            sequence > state.sequence
-              ? {
-                  sequence,
-                  source: null,
-                }
-              : state;
-
-          if (nextState.source) {
-            return;
-          }
-
-          quickBarPressStateRef.current = {
-            sequence,
-            source,
-          };
+          quickBarPressHandledRef.current = true;
         }
 
         handleIndicatorPress(indicator);
@@ -318,7 +290,7 @@ export const TradingViewNativeIndicatorQuickBar = memo(
     );
 
     const handleQuickBarTap = useCallback(
-      (locationX: number, sequence: number) => {
+      (locationX: number) => {
         const touchContentX = locationX + quickBarScrollXRef.current;
         const indicator = [...mainIndicators, ...subIndicators].find((item) => {
           const layout = quickBarItemLayoutsRef.current.get(item.value);
@@ -330,7 +302,7 @@ export const TradingViewNativeIndicatorQuickBar = memo(
         });
 
         if (indicator) {
-          handleQuickBarIndicatorPress(indicator, 'fallback', sequence);
+          handleQuickBarIndicatorPress(indicator);
         }
       },
       [handleQuickBarIndicatorPress, mainIndicators, subIndicators],
@@ -342,23 +314,15 @@ export const TradingViewNativeIndicatorQuickBar = memo(
           Gesture.Native().shouldActivateOnStart(true),
           Gesture.Tap()
             .maxDistance(QUICK_BAR_TAP_MOVE_THRESHOLD)
-            .onBegin(() => {
-              'worklet';
-
-              quickBarGestureSequence.value += 1;
-            })
             .onEnd((event, success) => {
               'worklet';
 
               if (success) {
-                runOnJS(handleQuickBarTap)(
-                  event.x,
-                  quickBarGestureSequence.value,
-                );
+                runOnJS(handleQuickBarTap)(event.x);
               }
             }),
         ),
-      [handleQuickBarTap, quickBarGestureSequence],
+      [handleQuickBarTap],
     );
 
     if (!hasVisibleIndicators) {
@@ -377,13 +341,7 @@ export const TradingViewNativeIndicatorQuickBar = memo(
             key={indicator.value}
             indicator={indicator}
             isActive={activeIndicatorValues.has(indicator.value)}
-            onPress={() =>
-              handleQuickBarIndicatorPress(
-                indicator,
-                'item',
-                quickBarGestureSequence.value,
-              )
-            }
+            onPress={() => handleQuickBarIndicatorPress(indicator)}
             onLayout={(event) =>
               handleQuickBarItemLayout(indicator.value, event)
             }
@@ -397,13 +355,7 @@ export const TradingViewNativeIndicatorQuickBar = memo(
             key={indicator.value}
             indicator={indicator}
             isActive={activeIndicatorValues.has(indicator.value)}
-            onPress={() =>
-              handleQuickBarIndicatorPress(
-                indicator,
-                'item',
-                quickBarGestureSequence.value,
-              )
-            }
+            onPress={() => handleQuickBarIndicatorPress(indicator)}
             onLayout={(event) =>
               handleQuickBarItemLayout(indicator.value, event)
             }
@@ -426,6 +378,7 @@ export const TradingViewNativeIndicatorQuickBar = memo(
               nestedScrollEnabled
               scrollEventThrottle={16}
               onScroll={handleQuickBarScroll}
+              onTouchStart={handleQuickBarTouchStart}
               showsHorizontalScrollIndicator={false}
             >
               {quickBarContent}

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
@@ -1,8 +1,7 @@
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { runOnJS } from 'react-native-reanimated';
+import { ScrollView as GestureHandlerScrollView } from 'react-native-gesture-handler';
 
 import {
   Button,
@@ -30,12 +29,6 @@ import type {
   ITradingViewIndicatorOption,
   ITradingViewNativeChartControlsConfigData,
 } from '../../types';
-import type {
-  GestureResponderEvent,
-  LayoutChangeEvent,
-  NativeScrollEvent,
-  NativeSyntheticEvent,
-} from 'react-native';
 
 const INDICATOR_GRID_COLUMN_COUNT = 4;
 const INDICATOR_GRID_ITEM_LAYOUT_PROPS = {
@@ -47,26 +40,6 @@ const INDICATOR_GRID_ITEM_LAYOUT_PROPS = {
   borderWidth: 1,
 } as const;
 export const TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT = 31;
-const QUICK_BAR_TAP_MOVE_THRESHOLD = 8;
-
-type IQuickBarItemLayout = {
-  x: number;
-  width: number;
-};
-
-function isQuickBarTouchPressEvent(event?: GestureResponderEvent): boolean {
-  const nativeEvent = event?.nativeEvent;
-  if (!nativeEvent) {
-    return false;
-  }
-  const hasTouchIdentifier =
-    nativeEvent.identifier !== null && nativeEvent.identifier !== undefined;
-  return Boolean(
-    hasTouchIdentifier ||
-    nativeEvent.touches?.length ||
-    nativeEvent.changedTouches?.length,
-  );
-}
 
 function buildIndicatorItemTestID(value: string): string {
   return `trading-view-native-indicator-item-${value
@@ -207,12 +180,10 @@ function IndicatorQuickBarItem({
   indicator,
   isActive,
   onPress,
-  onLayout,
 }: {
   indicator: ITradingViewIndicatorOption;
   isActive: boolean;
-  onPress: (event?: GestureResponderEvent) => void;
-  onLayout?: (event: LayoutChangeEvent) => void;
+  onPress: () => void;
 }) {
   const content = (
     <SizableText
@@ -236,7 +207,6 @@ function IndicatorQuickBarItem({
       userSelect="none"
       accessibilityRole="button"
       accessibilityState={{ selected: isActive }}
-      onLayout={onLayout}
       onPress={onPress}
     >
       {content}
@@ -265,83 +235,6 @@ export const TradingViewNativeIndicatorQuickBar = memo(
       nativeIndicatorState,
       onIndicatorSelect,
     });
-    const quickBarScrollXRef = useRef(0);
-    const quickBarPressHandledRef = useRef(false);
-    const quickBarItemLayoutsRef = useRef(
-      new Map<string, IQuickBarItemLayout>(),
-    );
-
-    const handleQuickBarScroll = useCallback(
-      (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-        quickBarScrollXRef.current = event.nativeEvent.contentOffset.x;
-      },
-      [],
-    );
-
-    const handleQuickBarItemLayout = useCallback(
-      (indicatorValue: string, event: LayoutChangeEvent) => {
-        const { x, width } = event.nativeEvent.layout;
-        quickBarItemLayoutsRef.current.set(indicatorValue, { x, width });
-      },
-      [],
-    );
-
-    const handleQuickBarTouchStart = useCallback(() => {
-      quickBarPressHandledRef.current = false;
-    }, []);
-
-    const handleQuickBarIndicatorPress = useCallback(
-      (
-        indicator: ITradingViewIndicatorOption,
-        shouldUseTouchGuard: boolean,
-      ) => {
-        if (platformEnv.isNativeAndroid && shouldUseTouchGuard) {
-          if (quickBarPressHandledRef.current) {
-            return;
-          }
-          quickBarPressHandledRef.current = true;
-        }
-
-        handleIndicatorPress(indicator);
-      },
-      [handleIndicatorPress],
-    );
-
-    const handleQuickBarTap = useCallback(
-      (locationX: number) => {
-        const touchContentX = locationX + quickBarScrollXRef.current;
-        const indicator = [...mainIndicators, ...subIndicators].find((item) => {
-          const layout = quickBarItemLayoutsRef.current.get(item.value);
-          return (
-            layout &&
-            touchContentX >= layout.x &&
-            touchContentX <= layout.x + layout.width
-          );
-        });
-
-        if (indicator) {
-          handleQuickBarIndicatorPress(indicator, true);
-        }
-      },
-      [handleQuickBarIndicatorPress, mainIndicators, subIndicators],
-    );
-
-    const quickBarGesture = useMemo(
-      () =>
-        Gesture.Simultaneous(
-          Gesture.Native().shouldActivateOnStart(true),
-          Gesture.Tap()
-            .maxDistance(QUICK_BAR_TAP_MOVE_THRESHOLD)
-            .onEnd((event, success) => {
-              'worklet';
-
-              if (success) {
-                runOnJS(handleQuickBarTap)(event.x);
-              }
-            }),
-        ),
-      [handleQuickBarTap],
-    );
 
     if (!hasVisibleIndicators) {
       return null;
@@ -359,15 +252,7 @@ export const TradingViewNativeIndicatorQuickBar = memo(
             key={indicator.value}
             indicator={indicator}
             isActive={activeIndicatorValues.has(indicator.value)}
-            onPress={(event) =>
-              handleQuickBarIndicatorPress(
-                indicator,
-                isQuickBarTouchPressEvent(event),
-              )
-            }
-            onLayout={(event) =>
-              handleQuickBarItemLayout(indicator.value, event)
-            }
+            onPress={() => handleIndicatorPress(indicator)}
           />
         ))}
         {subIndicators.length ? (
@@ -378,15 +263,7 @@ export const TradingViewNativeIndicatorQuickBar = memo(
             key={indicator.value}
             indicator={indicator}
             isActive={activeIndicatorValues.has(indicator.value)}
-            onPress={(event) =>
-              handleQuickBarIndicatorPress(
-                indicator,
-                isQuickBarTouchPressEvent(event),
-              )
-            }
-            onLayout={(event) =>
-              handleQuickBarItemLayout(indicator.value, event)
-            }
+            onPress={() => handleIndicatorPress(indicator)}
           />
         ))}
       </XStack>
@@ -400,18 +277,13 @@ export const TradingViewNativeIndicatorQuickBar = memo(
         zIndex={3}
       >
         {platformEnv.isNativeAndroid ? (
-          <GestureDetector gesture={quickBarGesture}>
-            <ScrollView
-              horizontal
-              nestedScrollEnabled
-              scrollEventThrottle={16}
-              onScroll={handleQuickBarScroll}
-              onTouchStart={handleQuickBarTouchStart}
-              showsHorizontalScrollIndicator={false}
-            >
-              {quickBarContent}
-            </ScrollView>
-          </GestureDetector>
+          <GestureHandlerScrollView
+            horizontal
+            nestedScrollEnabled
+            showsHorizontalScrollIndicator={false}
+          >
+            {quickBarContent}
+          </GestureHandlerScrollView>
         ) : (
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
             {quickBarContent}

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/hooks/useNativeIndicatorActiveValues.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/hooks/useNativeIndicatorActiveValues.ts
@@ -147,10 +147,13 @@ export function useNativeIndicatorActiveValues(
     [],
   );
 
-  return {
-    activeIndicatorValues,
-    updateActiveIndicatorValue,
-  };
+  return useMemo(
+    () => ({
+      activeIndicatorValues,
+      updateActiveIndicatorValue,
+    }),
+    [activeIndicatorValues, updateActiveIndicatorValue],
+  );
 }
 
 export function useNativeIndicatorControls({

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { SizableText, Stack, useTheme } from '@onekeyhq/components';
 import type { IStackStyle } from '@onekeyhq/components';
@@ -119,6 +126,7 @@ interface IBaseTradingViewV2Props {
   nativeControlsLayoutMode?: ITradingViewNativeControlsLayoutMode;
   isNativeChartFullscreen?: boolean;
   showNativeIndicatorQuickBar?: boolean;
+  onNativeIndicatorQuickBarChange?: (quickBar: ReactNode | null) => void;
   onNativeChartFullscreenChange?: (isFullscreen: boolean) => void;
   onKLineDataReady?: (data: ITradingViewKLineDataReadyData) => void;
   onKLineLoadError?: (data: ITradingViewKLineLoadErrorData) => void;
@@ -179,6 +187,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     nativeControlsLayoutMode,
     isNativeChartFullscreen,
     showNativeIndicatorQuickBar = true,
+    onNativeIndicatorQuickBarChange,
     onNativeChartFullscreenChange,
     onKLineDataReady,
     onKLineLoadError,
@@ -592,11 +601,50 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     [resetInteractionLocks, webRef],
   );
 
+  const nativeIndicatorQuickBar = useMemo(() => {
+    if (
+      !enableNativeChartControls ||
+      !showNativeIndicatorQuickBar ||
+      !nativeChartControlsConfig ||
+      nativeChartControlsConfig.indicatorsEnabled === false
+    ) {
+      return null;
+    }
+
+    return (
+      <TradingViewNativeIndicatorQuickBar
+        nativeChartControlsConfig={nativeChartControlsConfig}
+        nativeIndicatorState={nativeIndicatorState}
+        onIndicatorSelect={handleNativeIndicatorSelect}
+      />
+    );
+  }, [
+    enableNativeChartControls,
+    handleNativeIndicatorSelect,
+    nativeChartControlsConfig,
+    nativeIndicatorState,
+    showNativeIndicatorQuickBar,
+  ]);
+
+  useEffect(() => {
+    onNativeIndicatorQuickBarChange?.(nativeIndicatorQuickBar);
+  }, [nativeIndicatorQuickBar, onNativeIndicatorQuickBarChange]);
+
   useEffect(() => {
     return () => {
       resetInteractionLocks();
     };
   }, [resetInteractionLocks]);
+
+  useEffect(() => {
+    if (!onNativeIndicatorQuickBarChange) {
+      return undefined;
+    }
+
+    return () => {
+      onNativeIndicatorQuickBarChange(null);
+    };
+  }, [onNativeIndicatorQuickBarChange]);
 
   const handleMockEmptyKLineBadgePress = useCallback(() => {
     setMockEmptyKLineBadgePositionIndex(
@@ -706,13 +754,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
         ) : null}
       </Stack>
 
-      {enableNativeChartControls && showNativeIndicatorQuickBar ? (
-        <TradingViewNativeIndicatorQuickBar
-          nativeChartControlsConfig={nativeChartControlsConfig}
-          nativeIndicatorState={nativeIndicatorState}
-          onIndicatorSelect={handleNativeIndicatorSelect}
-        />
-      ) : null}
+      {onNativeIndicatorQuickBarChange ? null : nativeIndicatorQuickBar}
     </Stack>
   );
 };

--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketTradingView/MarketTradingView.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketTradingView/MarketTradingView.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react';
+import { type ReactNode, memo, useCallback } from 'react';
 
 import {
   TRADING_VIEW_DISABLED_FEATURES,
@@ -91,6 +91,7 @@ interface IMarketTradingViewProps {
   showNativeIndicatorQuickBar?: boolean;
   onTouchScroll?: (deltaY: number) => void;
   onNativeChartFullscreenChange?: (isFullscreen: boolean) => void;
+  onNativeIndicatorQuickBarChange?: (quickBar: ReactNode | null) => void;
   onIndicatorsDialogOpenChange?: (isOpen: boolean) => void;
   onInteractionOverlayOpenChange?: (isOpen: boolean) => void;
 }
@@ -112,6 +113,7 @@ export const MarketTradingView = memo(
     showNativeIndicatorQuickBar,
     onTouchScroll,
     onNativeChartFullscreenChange,
+    onNativeIndicatorQuickBarChange,
     onIndicatorsDialogOpenChange,
     onInteractionOverlayOpenChange,
   }: IMarketTradingViewProps) => {
@@ -173,6 +175,7 @@ export const MarketTradingView = memo(
         isNativeChartFullscreen={isNativeChartFullscreen}
         showNativeIndicatorQuickBar={showNativeIndicatorQuickBar}
         onNativeChartFullscreenChange={onNativeChartFullscreenChange}
+        onNativeIndicatorQuickBarChange={onNativeIndicatorQuickBarChange}
       />
     );
   },

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -333,6 +333,9 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
             excludeBottomEdgeHeight={
               TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT
             }
+            failExcludedBottomEdgeTouchesOnTouchDown={
+              platformEnv.isNativeAndroid
+            }
             scrollScale={1}
             onHorizontalSwipe={chartAreaHorizontalSwipeHandler}
             horizontalSwipeThreshold={24}

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { noop } from 'lodash';
 import { useIntl } from 'react-intl';
@@ -55,6 +62,7 @@ function MobileTradingViewTouchBridge({
   tokenSymbol,
   dataSource,
   pageWidth,
+  onNativeIndicatorQuickBarChange,
   onIndicatorsDialogOpenChange,
   onInteractionOverlayOpenChange,
 }: {
@@ -63,6 +71,7 @@ function MobileTradingViewTouchBridge({
   tokenSymbol: string;
   dataSource: 'websocket' | 'polling';
   pageWidth?: number;
+  onNativeIndicatorQuickBarChange: (quickBar: ReactNode | null) => void;
   onIndicatorsDialogOpenChange: (isOpen: boolean) => void;
   onInteractionOverlayOpenChange: (isOpen: boolean) => void;
 }) {
@@ -113,6 +122,7 @@ function MobileTradingViewTouchBridge({
       dataSource={dataSource}
       pageWidth={pageWidth}
       onTouchScroll={handleTouchScrollWhenEnabled}
+      onNativeIndicatorQuickBarChange={onNativeIndicatorQuickBarChange}
       onIndicatorsDialogOpenChange={handleIndicatorsDialogOpenChange}
       onInteractionOverlayOpenChange={handleInteractionOverlayOpenChange}
     />
@@ -187,6 +197,8 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
     isTradingViewInteractionOverlayOpen,
     setIsTradingViewInteractionOverlayOpen,
   ] = useState(false);
+  const [nativeIndicatorQuickBar, setNativeIndicatorQuickBar] =
+    useState<ReactNode | null>(null);
   const isTradingViewScrollLocked =
     isTradingViewIndicatorsDialogOpen || isTradingViewInteractionOverlayOpen;
   const secondTabTouchStartRef = useRef<{
@@ -245,6 +257,12 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
   const handleInteractionOverlayOpenChange = useCallback((isOpen: boolean) => {
     setIsTradingViewInteractionOverlayOpen(isOpen);
   }, []);
+  const handleNativeIndicatorQuickBarChange = useCallback(
+    (quickBar: ReactNode | null) => {
+      setNativeIndicatorQuickBar(() => quickBar);
+    },
+    [],
+  );
 
   const handleHeaderHorizontalSwipe = useCallback(
     (direction: 'left' | 'right') => {
@@ -271,6 +289,21 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
     }
     return 'calc(100vh - 96px - 74px - 250px)';
   }, [height]);
+
+  const tradingViewChartHeight = useMemo(() => {
+    if (
+      typeof tradingViewHeight === 'number' &&
+      nativeIndicatorQuickBar &&
+      platformEnv.isNative
+    ) {
+      return Math.max(
+        0,
+        tradingViewHeight - TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT,
+      );
+    }
+
+    return tradingViewHeight;
+  }, [nativeIndicatorQuickBar, tradingViewHeight]);
 
   const handleSecondTabTouchStart = useCallback(
     (event: GestureResponderEvent) => {
@@ -330,12 +363,6 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
             panActiveOffsetY={[-4, 4]}
             panFailOffsetX={chartAreaPanFailOffsetX}
             excludeRightEdgeRatio={chartAreaExcludeRightEdgeRatio}
-            excludeBottomEdgeHeight={
-              TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT
-            }
-            failExcludedBottomEdgeTouchesOnTouchDown={
-              platformEnv.isNativeAndroid
-            }
             scrollScale={1}
             onHorizontalSwipe={chartAreaHorizontalSwipeHandler}
             horizontalSwipeThreshold={24}
@@ -343,7 +370,7 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
             simultaneousWithNativeGesture
             cancelChildTouches={false}
           >
-            <Stack h={tradingViewHeight} overflow="hidden">
+            <Stack h={tradingViewChartHeight} overflow="hidden">
               {(() => {
                 if (!networkId || !tokenSymbol) {
                   return null;
@@ -359,6 +386,9 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
                         websocketConfig?.kline ? 'websocket' : 'polling'
                       }
                       pageWidth={effectivePageWidth}
+                      onNativeIndicatorQuickBarChange={
+                        handleNativeIndicatorQuickBarChange
+                      }
                       onIndicatorsDialogOpenChange={
                         handleIndicatorsDialogOpenChange
                       }
@@ -382,6 +412,7 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
               })()}
             </Stack>
           </HeaderScrollGestureWrapper>
+          {nativeIndicatorQuickBar}
           {platformEnv.isNativeIOS ? (
             <View
               style={{
@@ -402,11 +433,13 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
     handleHeaderHorizontalSwipe,
     handleIndicatorsDialogOpenChange,
     handleInteractionOverlayOpenChange,
+    handleNativeIndicatorQuickBarChange,
     isTradingViewScrollLocked,
+    nativeIndicatorQuickBar,
     networkId,
     tokenAddress,
     tokenSymbol,
-    tradingViewHeight,
+    tradingViewChartHeight,
     websocketConfig?.kline,
   ]);
 


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56896](https://onekeyhq.atlassian.net/browse/OK-56896)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Enable horizontal scrolling for the Market TradingView v2 native indicator quickbar on Android.
- Keep the existing iOS quickbar ScrollView implementation unchanged.
- Use a React Native Gesture Handler ScrollView on Android so the quickbar can take ownership of the touch stream inside the chart header gesture wrapper.

## Intent & Context
The Market TradingView v2 quickbar at the bottom of the chart scrolled correctly on iOS, but Android could not scroll it horizontally. The user asked why Android was not scrolling, then requested the fix and confirmed the first nestedScrollEnabled-only attempt did not work. After PR creation, latest x had refactored TradingViewV2 controls, so the fix was rebased onto the new component structure.

## Root Cause
The quickbar lives inside Market detail mobile chart content, which is wrapped by HeaderScrollGestureWrapper for vertical header scrolling and chart-area gesture handling. On Android, the child RN ScrollView did not reliably win gesture competition against that parent gesture wrapper. Adding nestedScrollEnabled to the existing RN ScrollView was not enough because the touch stream was still contested in the same gesture-handler tree.

## Design Decisions
The final fix changes only the Android quickbar scroll container to react-native-gesture-handler ScrollView with shouldActivateOnStart and disallowInterruption. This lets the quickbar actively take ownership of horizontal scroll gestures before the parent HeaderScrollGestureWrapper interrupts it. iOS keeps the original @onekeyhq/components ScrollView because it already worked and should not be affected by the Android-specific fix.

## Changes Detail
- packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx: Extracted shared quickbar content and rendered it with GestureHandlerScrollView only on Android; other platforms continue using the original ScrollView.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile Android primarily; iOS quickbar path is intentionally unchanged.
- **Risk Areas**: Gesture interaction between the TradingView native indicator quickbar and the Market detail chart header scroll wrapper. Indicator item press behavior should also be checked after horizontal dragging.

## Test plan
- [x] yarn lint:staged
- [x] yarn tsc:staged
- [x] yarn test packages/kit/src/components/TradingView/TradingViewV2
- [x] Manually verified with the user that Android quickbar horizontal scrolling works after switching to GestureHandlerScrollView.

[OK-56896]: https://onekeyhq.atlassian.net/browse/OK-56896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ