### PR TITLE
fix: use -exec rm instead of -delete for sourcemap cleanup

### DIFF
--- a/.github/workflows/build-desktop-renderer.yml
+++ b/.github/workflows/build-desktop-renderer.yml
@@ -191,15 +191,35 @@ jobs:
             exit 0
           fi
 
-          find ./apps/desktop/web-build -name '*.LICENSE.txt' -type f -delete
+          find ./apps/desktop/web-build -name '*.LICENSE.txt' -type f -exec rm -f {} +
           find ./apps/desktop/web-build \
-            \( -name '*.js.map' -o -name '*.css.map' \) \
-            -type f -delete
+            -type f \( -name '*.js.map' -o -name '*.css.map' \) \
+            -exec rm -f {} +
 
       - name: Finalize Renderer Assets
         run: |
           cd apps/desktop
           node scripts/finalize-renderer-assets.js
+
+      - name: Cleanup Desktop Sourcemaps from Artifact
+        if: always()
+        continue-on-error: true
+        run: |
+          if [ ! -d ./apps/desktop/app/build ]; then
+            echo "Desktop app/build directory does not exist - skipping sourcemap cleanup."
+            exit 0
+          fi
+
+          artifact_maps="$(find ./apps/desktop/app/build \
+            -type f \( -name '*.js.map' -o -name '*.css.map' \) \
+            -print)"
+          if [ -n "$artifact_maps" ]; then
+            echo "::warning::Desktop renderer artifact still contains sourcemaps after finalize; removing before upload:"
+            echo "$artifact_maps"
+            find ./apps/desktop/app/build \
+              -type f \( -name '*.js.map' -o -name '*.css.map' \) \
+              -exec rm -f {} +
+          fi
 
       - name: Assert Desktop Sourcemaps Are Stripped
         run: |
@@ -209,8 +229,8 @@ jobs:
           fi
 
           remaining_maps="$(find ./apps/desktop/app/build \
-            \( -name '*.js.map' -o -name '*.css.map' \) \
-            -type f -print)"
+            -type f \( -name '*.js.map' -o -name '*.css.map' \) \
+            -print)"
           if [ -n "$remaining_maps" ]; then
             echo "::error::Desktop renderer artifact still contains sourcemaps:"
             echo "$remaining_maps"

--- a/.github/workflows/release-desktop-snap.yml
+++ b/.github/workflows/release-desktop-snap.yml
@@ -161,10 +161,10 @@ jobs:
             exit 0
           fi
 
-          find ./apps/desktop/web-build -name '*.LICENSE.txt' -type f -delete
+          find ./apps/desktop/web-build -name '*.LICENSE.txt' -type f -exec rm -f {} +
           find ./apps/desktop/web-build \
-            \( -name '*.js.map' -o -name '*.css.map' \) \
-            -type f -delete
+            -type f \( -name '*.js.map' -o -name '*.css.map' \) \
+            -exec rm -f {} +
 
       - name: Build and Sign Snap Linux
         env:
@@ -179,9 +179,19 @@ jobs:
         run: |
           cd apps/desktop
           node scripts/finalize-renderer-assets.js
+          artifact_maps="$(find ./app/build \
+            -type f \( -name '*.js.map' -o -name '*.css.map' \) \
+            -print)"
+          if [ -n "$artifact_maps" ]; then
+            echo "::warning::Desktop snap package still contains sourcemaps after finalize; removing before packaging:"
+            echo "$artifact_maps"
+            find ./app/build \
+              -type f \( -name '*.js.map' -o -name '*.css.map' \) \
+              -exec rm -f {} +
+          fi
           remaining_maps="$(find ./app/build \
-            \( -name '*.js.map' -o -name '*.css.map' \) \
-            -type f -print)"
+            -type f \( -name '*.js.map' -o -name '*.css.map' \) \
+            -print)"
           if [ -n "$remaining_maps" ]; then
             echo "::error::Desktop snap package still contains sourcemaps:"
             echo "$remaining_maps"


### PR DESCRIPTION
修复 CI 构建中 \`Assert Desktop Sourcemaps Are Stripped\` 失败的问题。

### 改动
1. 将 \`find -delete\` 替换为更可靠的 \`-exec rm -f {} +\`
2. 在 \`Finalize\` 之后增加保险清理步骤，防止 sourcemap 残留
3. 统一 \`find\` 条件顺序，提高兼容性

### 验证
- CI Run: https://github.com/OneKeyHQ/app-monorepo/actions/runs/28443106092
- \`renderer / build-renderer\` 的 \`Assert Desktop Sourcemaps Are Stripped\` 步骤已确认通过
