### PR TITLE
fix: avoid migration dialog for transient cloud-backup LSE error

### DIFF
--- a/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
+++ b/packages/kit-bg/src/services/ServicePrimeTransfer/ServicePrimeTransfer.ts
@@ -98,7 +98,6 @@ import {
   EPrimeTransferStatus,
   primeTransferAtom,
 } from '../../states/jotai/atoms/prime';
-import { markCredentialLocalSecretEnvelopeUnavailableError } from '../../utils/localSecretEnvelopeErrorUtils';
 import {
   EAppCryptoSharedEncryptScene,
   encryptAsyncWithFormat,
@@ -1681,13 +1680,17 @@ class ServicePrimeTransfer extends ServiceBase {
     // recoverable copy of the skipped wallet. Fail fast with a clear, retryable
     // message (the @toastIfError-wrapped caller surfaces it). Interactive
     // transfer instead keeps unavailableCredentials and lets the user confirm.
+    // Do NOT mark this with the credential migration marker: this is a
+    // transient, retryable secure-storage hiccup, not a permanent
+    // device-migration key loss. Tagging it would trigger the
+    // "wallet key unavailable / re-migrate from the original device" Dialog
+    // and mislead the user. The @toastIfError-wrapped caller still surfaces
+    // the retryable message as a normal toast.
     if (isForCloudBackup && unavailableCredentials.length > 0) {
-      const error = new LocalSecretEnvelopeUnavailable({
+      throw new LocalSecretEnvelopeUnavailable({
         message:
           "Secure storage is temporarily unavailable, so some wallets can't be backed up right now. Please try again.",
       });
-      markCredentialLocalSecretEnvelopeUnavailableError(error);
-      throw error;
     }
 
     // fill publicData summary by aggregating from privateBackupData


### PR DESCRIPTION
## Summary

Addresses the **P2** review finding on #12224.

The cloud-backup fast-fail path in `ServicePrimeTransfer.buildTransferData` threw a **transient, retryable** `LocalSecretEnvelopeUnavailable` (`"Secure storage is temporarily unavailable ... Please try again."`) but tagged it with `markCredentialLocalSecretEnvelopeUnavailableError`. That marker sets the `credential` data type, which is exactly the condition that triggers the **permanent device-migration** Dialog (`WALLET_KEY_UNAVAILABLE_DESCRIPTION`: "This device no longer has the local security key ... migrate again from the original device").

So a momentary keychain/secure-storage hiccup (retry would succeed) told the user their wallet key was **permanently lost** — a misleading prompt that could push them toward unnecessary recovery actions.

## Change

- Remove the `markCredentialLocalSecretEnvelopeUnavailableError(error)` call from the cloud-backup fast-fail branch and throw the plain `LocalSecretEnvelopeUnavailable` again.
- Remove the now-unused import.
- Add a comment explaining why this path must not use the credential migration marker.

The error still surfaces as a normal retryable toast: the caller `ServiceCloudBackupV2.buildBackupData` is `@toastIfError()`-wrapped, and `toastIfError` sets `autoToast = true` automatically. Only the migration Dialog (gated on the `credential` marker) is suppressed.

## Notes

- The genuine credential LSE-unavailable paths in `LocalDbBase` still use the marker, so real device-migration key loss continues to surface the Dialog.
- The related P1 "Dialog + Toast double notification" thread was resolved as intended behavior (Dialog + Toast double safety), per the PR author.

## Test plan

- [ ] Trigger a transient cloud-backup LSE failure → expect only the retryable toast, no migration Dialog.
- [ ] Trigger a real credential LSE-unavailable error in `LocalDbBase` → migration Dialog still shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQisXSVdcWd7BnNaF8nNUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQisXSVdcWd7BnNaF8nNUQ)_