### PR TITLE
fix: prevent duplicate DeFi action toast (OK-56838)

### DIFF
--- a/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
@@ -23,6 +23,7 @@ import { PerpsSlider } from '@onekeyhq/kit/src/views/Perp/components/PerpsSlider
 import { SendAutoSizeAmountInput } from '@onekeyhq/kit/src/views/Send/components/SendAutoSizeAmountInput';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import errorToastUtils from '@onekeyhq/shared/src/errors/utils/errorToastUtils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   buildDeFiActionBps,
@@ -855,10 +856,12 @@ function useProtocolPositionActionSubmit({
           isTxConfirmInitializing = false;
         }
         if (txConfirmInitError) {
+          errorToastUtils.toastIfErrorDisable(txConfirmInitError);
           throw new OneKeyLocalError(getErrorMessage(txConfirmInitError));
         }
       } catch (error) {
         if (!isUserRejectedErrorMessage({ error, intl })) {
+          errorToastUtils.toastIfErrorDisable(error);
           Toast.error({
             title: getErrorMessage(error),
           });


### PR DESCRIPTION
<!-- github-pr-monitor:jira-links:start -->
[OK-56838](https://onekeyhq.atlassian.net/browse/OK-56838)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Use the existing `errorToastUtils.toastIfErrorDisable(error)` pattern before the DeFi action local error toast.
- Suppress the original tx-confirm initialization error before wrapping it, so its queued background auto-toast cannot duplicate the local toast.
- Keep the server-provided error message shown once via the existing local `Toast.error(getErrorMessage(error))` path and preserve user-rejected silence.

## Issues
- Fixes OK-56838

## Test Plan
- npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx --deny-warnings
- yarn lint:staged
- yarn tsc:staged

[OK-56838]: https://onekeyhq.atlassian.net/browse/OK-56838