### PR TITLE
fix: default network throttle in dev mode

### DIFF
--- a/apps/desktop/app/libs/store.ts
+++ b/apps/desktop/app/libs/store.ts
@@ -46,7 +46,7 @@ export const setDevTools = (devTools: boolean) => {
 };
 
 const defaultNetworkThrottle: IDesktopStoreNetworkThrottle = {
-  enabled: false,
+  enabled: true,
   profile: 'slow4g',
 };
 

--- a/packages/kit-bg/src/services/ServiceBootstrap.ts
+++ b/packages/kit-bg/src/services/ServiceBootstrap.ts
@@ -142,6 +142,11 @@ class ServiceBootstrap extends ServiceBase {
       timedDeferred('serviceDevSetting.saveDevModeToSyncStorage', () =>
         this.backgroundApi.serviceDevSetting.saveDevModeToSyncStorage(),
       ),
+      timedDeferred(
+        'serviceDevSetting.syncDesktopNetworkThrottleSettings',
+        () =>
+          this.backgroundApi.serviceDevSetting.syncDesktopNetworkThrottleSettings(),
+      ),
       timedDeferred('serviceDevSetting.syncCryptoSettings', () =>
         this.backgroundApi.serviceDevSetting.syncCryptoSettings(),
       ),

--- a/packages/kit-bg/src/services/ServiceBootstrap.ts
+++ b/packages/kit-bg/src/services/ServiceBootstrap.ts
@@ -142,10 +142,8 @@ class ServiceBootstrap extends ServiceBase {
       timedDeferred('serviceDevSetting.saveDevModeToSyncStorage', () =>
         this.backgroundApi.serviceDevSetting.saveDevModeToSyncStorage(),
       ),
-      timedDeferred(
-        'serviceDevSetting.syncDesktopNetworkThrottleSettings',
-        () =>
-          this.backgroundApi.serviceDevSetting.syncDesktopNetworkThrottleSettings(),
+      timedDeferred('serviceDevSetting.syncNetworkThrottleSettings', () =>
+        this.backgroundApi.serviceDevSetting.syncNetworkThrottleSettings(),
       ),
       timedDeferred('serviceDevSetting.syncCryptoSettings', () =>
         this.backgroundApi.serviceDevSetting.syncCryptoSettings(),

--- a/packages/kit-bg/src/services/ServiceDevSetting.ts
+++ b/packages/kit-bg/src/services/ServiceDevSetting.ts
@@ -23,6 +23,7 @@ import { EServiceEndpointEnum } from '@onekeyhq/shared/types/endpoint';
 import {
   devSettingsPersistAtom,
   firmwareUpdateDevSettingsPersistAtom,
+  getDevSettingsNetworkThrottleEnabled,
 } from '../states/jotai/atoms/devSettings';
 
 import ServiceBase from './ServiceBase';
@@ -41,8 +42,17 @@ class ServiceDevSetting extends ServiceBase {
     super({ backgroundApi });
   }
 
+  private getExpectedNetworkThrottleEnabled(
+    devSettings: IDevSettingsPersistAtom,
+  ) {
+    return getDevSettingsNetworkThrottleEnabled(devSettings, true);
+  }
+
   async saveDevModeToSyncStorage() {
     const devSettings = await devSettingsPersistAtom.get();
+    const networkThrottleEnabledForNativeSync = platformEnv.isNative
+      ? this.getExpectedNetworkThrottleEnabled(devSettings)
+      : false;
     appStorage.syncStorage.set(
       EAppSyncStorageKeys.onekey_developer_mode_enabled,
       !!devSettings.enabled,
@@ -54,8 +64,7 @@ class ServiceDevSetting extends ServiceBase {
     );
     devSettingSyncStorage.set(
       EDevSettingSyncStorageKeys.onekey_native_network_throttle_enabled,
-      !!devSettings.enabled &&
-        !!devSettings.settings?.nativeNetworkThrottleEnabled,
+      networkThrottleEnabledForNativeSync,
     );
   }
 
@@ -100,44 +109,69 @@ class ServiceDevSetting extends ServiceBase {
     }
   }
 
-  private async applyDesktopNetworkThrottleAfterEnableDevMode() {
-    if (!platformEnv.isDesktop) {
+  private async applyNetworkThrottleAfterEnableDevMode() {
+    const devSettings = await devSettingsPersistAtom.get();
+
+    if (platformEnv.isDesktop) {
+      const expectedEnabled =
+        this.getExpectedNetworkThrottleEnabled(devSettings);
+      const config =
+        await globalThis.desktopApiProxy?.dev?.setNetworkThrottle?.({
+          enabled: expectedEnabled,
+          profile: 'slow4g',
+        });
+      if (!config) {
+        throw new OneKeyLocalError('Failed to update desktop network throttle');
+      }
+
+      const actualEnabled = Boolean(config.enabled);
+      setNetworkThrottleRuntimeConfig({
+        enabled: actualEnabled,
+        profile: 'slow4g',
+        latencyMs: NATIVE_SLOW_4G_LATENCY_MS,
+      });
+      if (actualEnabled !== devSettings.settings?.networkThrottleEnabled) {
+        await devSettingsPersistAtom.set((prev) => ({
+          ...prev,
+          settings: {
+            ...prev.settings,
+            networkThrottleEnabled: actualEnabled,
+          },
+        }));
+        await this.saveDevModeToSyncStorage();
+        await this.syncCryptoSettings();
+      }
       return;
     }
 
-    const devSettings = await devSettingsPersistAtom.get();
-    const expectedEnabled =
-      devSettings.enabled &&
-      (devSettings.settings?.desktopNetworkThrottleEnabled ?? true);
-    const config = await globalThis.desktopApiProxy?.dev?.setNetworkThrottle?.({
-      enabled: expectedEnabled,
-      profile: 'slow4g',
-    });
-    if (!config) {
-      throw new OneKeyLocalError('Failed to update desktop network throttle');
-    }
+    if (platformEnv.isNative) {
+      const expectedEnabled =
+        this.getExpectedNetworkThrottleEnabled(devSettings);
+      const config = await nativeNetworkThrottle.setNetworkThrottle({
+        enabled: expectedEnabled,
+        profile: 'slow4g',
+      });
+      const actualEnabled = Boolean(config.enabled);
+      if (actualEnabled !== expectedEnabled) {
+        throw new OneKeyLocalError('Failed to update native network throttle');
+      }
 
-    const actualEnabled = Boolean(config.enabled);
-    setNetworkThrottleRuntimeConfig({
-      enabled: actualEnabled,
-      profile: 'slow4g',
-      latencyMs: NATIVE_SLOW_4G_LATENCY_MS,
-    });
-    if (actualEnabled !== devSettings.settings?.desktopNetworkThrottleEnabled) {
-      await devSettingsPersistAtom.set((prev) => ({
-        ...prev,
-        settings: {
-          ...prev.settings,
-          desktopNetworkThrottleEnabled: actualEnabled,
-        },
-      }));
-      await this.saveDevModeToSyncStorage();
-      await this.syncCryptoSettings();
+      if (actualEnabled !== devSettings.settings?.networkThrottleEnabled) {
+        await devSettingsPersistAtom.set((prev) => ({
+          ...prev,
+          settings: {
+            ...prev.settings,
+            networkThrottleEnabled: actualEnabled,
+          },
+        }));
+        await this.saveDevModeToSyncStorage();
+        await this.syncCryptoSettings();
+      }
     }
   }
 
-  async syncDesktopNetworkThrottleSettings() {
-    if (!platformEnv.isDesktop) {
+  async syncNetworkThrottleSettings() {
+    if (!platformEnv.isDesktop && !platformEnv.isNative) {
       return;
     }
 
@@ -149,7 +183,11 @@ class ServiceDevSetting extends ServiceBase {
       return;
     }
 
-    await this.applyDesktopNetworkThrottleAfterEnableDevMode();
+    await this.applyNetworkThrottleAfterEnableDevMode();
+  }
+
+  async syncDesktopNetworkThrottleSettings() {
+    await this.syncNetworkThrottleSettings();
   }
 
   @backgroundMethod()
@@ -160,15 +198,15 @@ class ServiceDevSetting extends ServiceBase {
         enabled: true,
         settings: {
           ...prev.settings,
-          ...(platformEnv.isDesktop
-            ? { desktopNetworkThrottleEnabled: true }
+          ...(platformEnv.isDesktop || platformEnv.isNative
+            ? { networkThrottleEnabled: true }
             : undefined),
         },
       }));
       await this.saveDevModeToSyncStorage();
       await this.syncCryptoSettings();
       try {
-        await this.applyDesktopNetworkThrottleAfterEnableDevMode();
+        await this.applyNetworkThrottleAfterEnableDevMode();
       } catch (error) {
         await devSettingsPersistAtom.set(() => previousDevSettings);
         await this.saveDevModeToSyncStorage();
@@ -215,70 +253,42 @@ class ServiceDevSetting extends ServiceBase {
       await this.syncCryptoSettings();
     };
 
-    if (platformEnv.isDesktop && name === 'desktopNetworkThrottleEnabled') {
+    if (
+      (platformEnv.isDesktop || platformEnv.isNative) &&
+      name === 'networkThrottleEnabled'
+    ) {
       if (!previousDevSettings.enabled) {
         return false;
       }
       try {
         await updatePersistedDevSetting(Boolean(value));
-        const config =
-          await globalThis.desktopApiProxy?.dev?.setNetworkThrottle?.({
-            enabled: Boolean(value),
-            profile: 'slow4g',
-          });
-        if (!config) {
-          throw new OneKeyLocalError(
-            'Failed to update desktop network throttle',
-          );
-        }
-        const actualEnabled = Boolean(config.enabled);
-        if (actualEnabled !== Boolean(value)) {
-          await updatePersistedDevSetting(actualEnabled);
-        }
-        setNetworkThrottleRuntimeConfig({
-          enabled: actualEnabled,
-          profile: 'slow4g',
-          latencyMs: NATIVE_SLOW_4G_LATENCY_MS,
-        });
-        return actualEnabled;
+        await this.applyNetworkThrottleAfterEnableDevMode();
+        const devSettings = await devSettingsPersistAtom.get();
+        return this.getExpectedNetworkThrottleEnabled(devSettings);
       } catch (error) {
         await devSettingsPersistAtom.set(() => previousDevSettings);
         await this.saveDevModeToSyncStorage();
         await this.syncCryptoSettings();
-        await globalThis.desktopApiProxy?.dev
-          ?.setNetworkThrottle?.({
-            enabled:
-              previousDevSettings.enabled &&
-              !!previousDevSettings.settings?.desktopNetworkThrottleEnabled,
-            profile: 'slow4g',
-          })
-          .catch(() => undefined);
+        if (platformEnv.isDesktop) {
+          await globalThis.desktopApiProxy?.dev
+            ?.setNetworkThrottle?.({
+              enabled:
+                this.getExpectedNetworkThrottleEnabled(previousDevSettings),
+              profile: 'slow4g',
+            })
+            .catch(() => undefined);
+        }
+        if (platformEnv.isNative) {
+          await nativeNetworkThrottle
+            .setNetworkThrottle({
+              enabled:
+                this.getExpectedNetworkThrottleEnabled(previousDevSettings),
+              profile: 'slow4g',
+            })
+            .catch(() => undefined);
+        }
         throw error;
       }
-    }
-
-    try {
-      if (platformEnv.isNative && name === 'nativeNetworkThrottleEnabled') {
-        if (!previousDevSettings.enabled) {
-          return false;
-        }
-        await updatePersistedDevSetting(Boolean(value));
-        const config = await nativeNetworkThrottle.setNetworkThrottle({
-          enabled: Boolean(value),
-          profile: 'slow4g',
-        });
-        if (config.enabled !== Boolean(value)) {
-          throw new OneKeyLocalError(
-            'Failed to update native network throttle',
-          );
-        }
-        return config.enabled;
-      }
-    } catch (error) {
-      await devSettingsPersistAtom.set(() => previousDevSettings);
-      await this.saveDevModeToSyncStorage();
-      await this.syncCryptoSettings();
-      throw error;
     }
 
     await updatePersistedDevSetting(value);

--- a/packages/kit-bg/src/services/ServiceDevSetting.ts
+++ b/packages/kit-bg/src/services/ServiceDevSetting.ts
@@ -100,19 +100,84 @@ class ServiceDevSetting extends ServiceBase {
     }
   }
 
-  @backgroundMethod()
-  public async switchDevMode(isOpen: boolean) {
-    if (isOpen) {
-      await devSettingsPersistAtom.set((prev) => ({
-        enabled: true,
-        settings: prev.settings,
-      }));
-      await this.saveDevModeToSyncStorage();
-      await this.syncCryptoSettings();
+  private async applyDesktopNetworkThrottleAfterEnableDevMode() {
+    if (!platformEnv.isDesktop) {
       return;
     }
 
+    const devSettings = await devSettingsPersistAtom.get();
+    const expectedEnabled =
+      devSettings.enabled &&
+      (devSettings.settings?.desktopNetworkThrottleEnabled ?? true);
+    const config = await globalThis.desktopApiProxy?.dev?.setNetworkThrottle?.({
+      enabled: expectedEnabled,
+      profile: 'slow4g',
+    });
+    if (!config) {
+      throw new OneKeyLocalError('Failed to update desktop network throttle');
+    }
+
+    const actualEnabled = Boolean(config.enabled);
+    setNetworkThrottleRuntimeConfig({
+      enabled: actualEnabled,
+      profile: 'slow4g',
+      latencyMs: NATIVE_SLOW_4G_LATENCY_MS,
+    });
+    if (actualEnabled !== devSettings.settings?.desktopNetworkThrottleEnabled) {
+      await devSettingsPersistAtom.set((prev) => ({
+        ...prev,
+        settings: {
+          ...prev.settings,
+          desktopNetworkThrottleEnabled: actualEnabled,
+        },
+      }));
+      await this.saveDevModeToSyncStorage();
+      await this.syncCryptoSettings();
+    }
+  }
+
+  async syncDesktopNetworkThrottleSettings() {
+    if (!platformEnv.isDesktop) {
+      return;
+    }
+
+    await this.saveDevModeToSyncStorage();
+
+    const devSettings = await devSettingsPersistAtom.get();
+    if (!devSettings.enabled) {
+      await this.clearNetworkThrottleAfterDisableDevMode();
+      return;
+    }
+
+    await this.applyDesktopNetworkThrottleAfterEnableDevMode();
+  }
+
+  @backgroundMethod()
+  public async switchDevMode(isOpen: boolean) {
     const previousDevSettings = await devSettingsPersistAtom.get();
+    if (isOpen) {
+      await devSettingsPersistAtom.set((prev) => ({
+        enabled: true,
+        settings: {
+          ...prev.settings,
+          ...(platformEnv.isDesktop
+            ? { desktopNetworkThrottleEnabled: true }
+            : undefined),
+        },
+      }));
+      await this.saveDevModeToSyncStorage();
+      await this.syncCryptoSettings();
+      try {
+        await this.applyDesktopNetworkThrottleAfterEnableDevMode();
+      } catch (error) {
+        await devSettingsPersistAtom.set(() => previousDevSettings);
+        await this.saveDevModeToSyncStorage();
+        await this.syncCryptoSettings();
+        throw error;
+      }
+      return;
+    }
+
     await devSettingsPersistAtom.set(() => ({
       enabled: false,
       settings: {},
@@ -151,6 +216,9 @@ class ServiceDevSetting extends ServiceBase {
     };
 
     if (platformEnv.isDesktop && name === 'desktopNetworkThrottleEnabled') {
+      if (!previousDevSettings.enabled) {
+        return false;
+      }
       try {
         await updatePersistedDevSetting(Boolean(value));
         const config =
@@ -191,6 +259,9 @@ class ServiceDevSetting extends ServiceBase {
 
     try {
       if (platformEnv.isNative && name === 'nativeNetworkThrottleEnabled') {
+        if (!previousDevSettings.enabled) {
+          return false;
+        }
         await updatePersistedDevSetting(Boolean(value));
         const config = await nativeNetworkThrottle.setNetworkThrottle({
           enabled: Boolean(value),

--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -109,10 +109,8 @@ export interface IDevSettings {
   // Force react-native-fast-pbkdf2 instead of the default quick-crypto backend
   // for native PBKDF2 calls (debug only).
   useFastPbkdf2NativeBackend?: boolean;
-  // Enable Electron session-level Slow 4G throttling on desktop.
-  desktopNetworkThrottleEnabled?: boolean;
-  // Enable native Slow 4G latency throttling on iOS and Android.
-  nativeNetworkThrottleEnabled?: boolean;
+  // Enable Slow 4G throttling on platforms with a supported backend.
+  networkThrottleEnabled?: boolean;
 }
 
 export type IDevSettingsKeys = keyof IDevSettings;
@@ -121,6 +119,16 @@ export type IDevSettingsPersistAtom = {
   enabled: boolean;
   settings?: IDevSettings;
 };
+
+export function getDevSettingsNetworkThrottleEnabled(
+  devSettings: IDevSettingsPersistAtom,
+  defaultEnabled: boolean,
+) {
+  if (!devSettings.enabled) {
+    return false;
+  }
+  return devSettings.settings?.networkThrottleEnabled ?? defaultEnabled;
+}
 export const {
   target: devSettingsPersistAtom,
   use: useDevSettingsPersistAtom,
@@ -151,8 +159,7 @@ export const {
       mockTradingViewKLineEmptyEnabled: false,
       mockTradingViewKLineEmptyIntervals: ['1m'],
       showMarketHomeWsDebug: false,
-      desktopNetworkThrottleEnabled: !!platformEnv.isDesktop,
-      nativeNetworkThrottleEnabled: false,
+      networkThrottleEnabled: !!platformEnv.isDesktop || !!platformEnv.isNative,
       allowLocalhostUrlInDAppBrowser: false,
       // Linux Desktop use Bridge，avoiding WebUSB permission problem
       usbCommunicationMode: platformEnv.isDesktopLinux ? 'bridge' : 'webusb',

--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -151,7 +151,7 @@ export const {
       mockTradingViewKLineEmptyEnabled: false,
       mockTradingViewKLineEmptyIntervals: ['1m'],
       showMarketHomeWsDebug: false,
-      desktopNetworkThrottleEnabled: false,
+      desktopNetworkThrottleEnabled: !!platformEnv.isDesktop,
       nativeNetworkThrottleEnabled: false,
       allowLocalhostUrlInDAppBrowser: false,
       // Linux Desktop use Bridge，avoiding WebUSB permission problem

--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -20,6 +20,7 @@ import {
 } from '@onekeyhq/components';
 import { ipcMessageKeys } from '@onekeyhq/desktop/app/config';
 import {
+  getDevSettingsNetworkThrottleEnabled,
   useAppIsLockedAtom,
   useDevSettingsPersistAtom,
   useOnboardingConnectWalletLoadingAtom,
@@ -775,9 +776,10 @@ export function Bootstrap() {
   const navigation = useAppNavigation();
   const [devSettings] = useDevSettingsPersistAtom();
   const autoNavigation = devSettings.settings?.autoNavigation;
-  const nativeNetworkThrottleEnabled =
-    devSettings.enabled &&
-    (devSettings.settings?.nativeNetworkThrottleEnabled ?? false);
+  const networkThrottleEnabled = getDevSettingsNetworkThrottleEnabled(
+    devSettings,
+    !!platformEnv.isNative,
+  );
 
   const [, setOnboardingConnectWalletLoading] =
     useOnboardingConnectWalletLoadingAtom();
@@ -796,15 +798,15 @@ export function Bootstrap() {
     );
     devSettingSyncStorage.set(
       EDevSettingSyncStorageKeys.onekey_native_network_throttle_enabled,
-      nativeNetworkThrottleEnabled,
+      networkThrottleEnabled,
     );
     void nativeNetworkThrottle
       .setNetworkThrottle({
-        enabled: nativeNetworkThrottleEnabled,
+        enabled: networkThrottleEnabled,
         profile: 'slow4g',
       })
       .catch(() => undefined);
-  }, [devSettings.enabled, nativeNetworkThrottleEnabled]);
+  }, [devSettings.enabled, networkThrottleEnabled]);
 
   useEffect(() => {
     if (

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -49,7 +49,10 @@ import { navigateToReferralLanding } from '@onekeyhq/kit/src/routes/config/deepl
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { WebEmbedDevConfig } from '@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/WebEmbed';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
+import {
+  getDevSettingsNetworkThrottleEnabled,
+  useDevSettingsPersistAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import type { ITradingViewKLineMockEmptyInterval } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import appDeviceInfo from '@onekeyhq/shared/src/appDeviceInfo/appDeviceInfo';
 import type { IBackgroundMethodWithDevOnlyPassword } from '@onekeyhq/shared/src/background/backgroundDecorators';
@@ -459,12 +462,10 @@ const BaseDevSettingsSection = () => {
   const mockTradingViewKLineEmptySubtitle = mockTradingViewKLineEmptyEnabled
     ? mockTradingViewKLineEmptyIntervalsText
     : '已关闭';
-  const desktopNetworkThrottleEnabled =
-    devSettings.enabled &&
-    (devSettings.settings?.desktopNetworkThrottleEnabled ?? false);
-  const nativeNetworkThrottleEnabled =
-    devSettings.enabled &&
-    (devSettings.settings?.nativeNetworkThrottleEnabled ?? false);
+  const networkThrottleEnabled = getDevSettingsNetworkThrottleEnabled(
+    devSettings,
+    Boolean(platformEnv.isDesktop || platformEnv.isNative),
+  );
 
   useEffect(() => {
     if (!platformEnv.isDesktop) {
@@ -475,14 +476,14 @@ const BaseDevSettingsSection = () => {
       .then((config) => {
         const enabled = !!config.enabled;
         setDevSettings((prev) => {
-          if (prev.settings?.desktopNetworkThrottleEnabled === enabled) {
+          if (prev.settings?.networkThrottleEnabled === enabled) {
             return prev;
           }
           return {
             ...prev,
             settings: {
               ...prev.settings,
-              desktopNetworkThrottleEnabled: enabled,
+              networkThrottleEnabled: enabled,
             },
           };
         });
@@ -490,7 +491,7 @@ const BaseDevSettingsSection = () => {
       .catch(() => undefined);
   }, [setDevSettings]);
 
-  const handleDesktopNetworkThrottleChange = useCallback(
+  const handleNetworkThrottleChange = useCallback(
     async (enabled: boolean) => {
       if (!devSettings.enabled) {
         Toast.error({
@@ -501,47 +502,18 @@ const BaseDevSettingsSection = () => {
       try {
         const actualEnabled = Boolean(
           await backgroundApiProxy.serviceDevSetting.updateDevSetting(
-            'desktopNetworkThrottleEnabled',
+            'networkThrottleEnabled',
             enabled,
           ),
         );
         Toast.success({
           title: actualEnabled
-            ? 'Desktop Slow 4G enabled'
-            : 'Desktop network throttle disabled',
+            ? 'Slow 4G enabled'
+            : 'Network throttle disabled',
         });
       } catch {
         Toast.error({
-          title: 'Failed to update desktop network throttle',
-        });
-      }
-    },
-    [devSettings.enabled],
-  );
-
-  const handleNativeNetworkThrottleChange = useCallback(
-    async (enabled: boolean) => {
-      if (!devSettings.enabled) {
-        Toast.error({
-          title: 'Enable developer mode first',
-        });
-        return;
-      }
-      try {
-        const actualEnabled = Boolean(
-          await backgroundApiProxy.serviceDevSetting.updateDevSetting(
-            'nativeNetworkThrottleEnabled',
-            enabled,
-          ),
-        );
-        Toast.success({
-          title: actualEnabled
-            ? 'Native Slow 4G latency enabled'
-            : 'Native network throttle disabled',
-        });
-      } catch {
-        Toast.error({
-          title: 'Failed to update native network throttle',
+          title: 'Failed to update network throttle',
         });
       }
     },
@@ -1144,7 +1116,7 @@ const BaseDevSettingsSection = () => {
                           icon="SpeedLowOutline"
                           title="Desktop Slow 4G Network Throttle"
                           subtitle={
-                            desktopNetworkThrottleEnabled
+                            networkThrottleEnabled
                               ? 'Slow 4G latency enabled: 562.5ms'
                               : 'Disabled'
                           }
@@ -1153,8 +1125,8 @@ const BaseDevSettingsSection = () => {
                         >
                           <Switch
                             size={ESwitchSize.small}
-                            value={desktopNetworkThrottleEnabled}
-                            onChange={handleDesktopNetworkThrottleChange}
+                            value={networkThrottleEnabled}
+                            onChange={handleNetworkThrottleChange}
                           />
                         </SectionPressItem>
                       ) : null}
@@ -1164,7 +1136,7 @@ const BaseDevSettingsSection = () => {
                           icon="SpeedLowOutline"
                           title="Native Slow 4G Network Throttle"
                           subtitle={
-                            nativeNetworkThrottleEnabled
+                            networkThrottleEnabled
                               ? `Slow 4G latency enabled: ${NATIVE_SLOW_4G_LATENCY_MS}ms`
                               : 'Disabled'
                           }
@@ -1173,8 +1145,8 @@ const BaseDevSettingsSection = () => {
                         >
                           <Switch
                             size={ESwitchSize.small}
-                            value={nativeNetworkThrottleEnabled}
-                            onChange={handleNativeNetworkThrottleChange}
+                            value={networkThrottleEnabled}
+                            onChange={handleNetworkThrottleChange}
                           />
                         </SectionPressItem>
                       ) : null}

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -460,9 +460,11 @@ const BaseDevSettingsSection = () => {
     ? mockTradingViewKLineEmptyIntervalsText
     : '已关闭';
   const desktopNetworkThrottleEnabled =
-    devSettings.settings?.desktopNetworkThrottleEnabled ?? false;
+    devSettings.enabled &&
+    (devSettings.settings?.desktopNetworkThrottleEnabled ?? false);
   const nativeNetworkThrottleEnabled =
-    devSettings.settings?.nativeNetworkThrottleEnabled ?? false;
+    devSettings.enabled &&
+    (devSettings.settings?.nativeNetworkThrottleEnabled ?? false);
 
   useEffect(() => {
     if (!platformEnv.isDesktop) {
@@ -490,6 +492,12 @@ const BaseDevSettingsSection = () => {
 
   const handleDesktopNetworkThrottleChange = useCallback(
     async (enabled: boolean) => {
+      if (!devSettings.enabled) {
+        Toast.error({
+          title: 'Enable developer mode first',
+        });
+        return;
+      }
       try {
         const actualEnabled = Boolean(
           await backgroundApiProxy.serviceDevSetting.updateDevSetting(
@@ -508,11 +516,17 @@ const BaseDevSettingsSection = () => {
         });
       }
     },
-    [],
+    [devSettings.enabled],
   );
 
   const handleNativeNetworkThrottleChange = useCallback(
     async (enabled: boolean) => {
+      if (!devSettings.enabled) {
+        Toast.error({
+          title: 'Enable developer mode first',
+        });
+        return;
+      }
       try {
         const actualEnabled = Boolean(
           await backgroundApiProxy.serviceDevSetting.updateDevSetting(
@@ -531,7 +545,7 @@ const BaseDevSettingsSection = () => {
         });
       }
     },
-    [],
+    [devSettings.enabled],
   );
 
   const handleDevModeOnChange = useCallback(() => {


### PR DESCRIPTION
## Summary
- Default the Slow 4G network throttle setting to enabled when developer mode is enabled on supported platforms.
- Use one dev-setting flag, `networkThrottleEnabled`, for desktop and native instead of separate platform-specific setting keys.
- Keep desktop and native throttle gates tied to developer mode so throttle cannot remain effective when developer mode is disabled.
- Sync throttle state during bootstrap across Electron desktop and native iOS/Android paths to avoid stale persisted state.

## Intent & Context
The requested behavior is that the Slow 4G switch should be usable only when developer mode is enabled, and that the default network throttle should be open by default once developer mode is enabled. The implementation applies this to supported throttle backends: Electron desktop and native iOS/Android. Web and extension still have no throttle backend, so the setting remains inert there.

## Design Decisions
- This is a new dev-setting feature, so no migration from previous temporary key names is included.
- Developer mode is the hard gate. When developer mode is disabled, desktop and native throttle are cleared and sync storage writes false.
- `networkThrottleEnabled` is the only persisted dev setting for the Slow 4G switch. Platform-specific logic stays in the apply layer.
- Desktop applies through Electron dev APIs. Native applies through the shared native NetworkThrottle module.
- Native production has separate main/background JS runtimes. The native throttle module is a shared native resource, while JS runtime state is per runtime, so both background service sync and main Bootstrap sync use the same default semantics.
- Web/extension are not forced on because there is no Electron/native throttle backend to apply.

## Changes Detail
- `apps/desktop/app/libs/store.ts`: defaults desktop network throttle storage to Slow 4G enabled.
- `packages/kit-bg/src/states/jotai/atoms/devSettings.ts`: adds the single `networkThrottleEnabled` dev setting defaulted on for desktop/native platforms.
- `packages/kit-bg/src/services/ServiceDevSetting.ts`: uses one expected-state helper and one update entry for desktop/native throttle, applies platform-specific backends internally, writes native sync storage with default-on semantics, and rolls back platform throttle state on update failures.
- `packages/kit-bg/src/services/ServiceBootstrap.ts`: calls the generic network throttle sync task during background bootstrap.
- `packages/kit/src/provider/Bootstrap.tsx`: applies native throttle from the main runtime using `networkThrottleEnabled`.
- `packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx`: uses one switch value/handler for the desktop/native Slow 4G UI entries, still rendered by platform.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop, iOS, Android
- **Risk Areas**: Developer-mode state synchronization between background/main JS runtimes and Electron/native throttle backends; ensuring stale persisted throttle state is cleared when developer mode is disabled.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] Targeted `oxlint --type-aware --deny-warnings` on changed files from the earlier desktop validation pass
- [x] Started Desktop dev app and validated via Electron CDP that `desktopApiProxy.dev.getNetworkThrottle()` returns `{ enabled: true, profile: "slow4g" }` when the switch is enabled under developer mode
- [x] Confirmed Electron main-process logs include `applied state=slow4g ... latencyMs=562.5 downloadBps=180000 uploadBps=84375`
- [x] Ran `yarn lint --fix`; TypeScript, Oxlint, language, font, and Electron checks passed, then it failed on pre-existing `.yalc` package version consistency issues unrelated to this change