### PR TITLE
fix: use perps asset logos in account mode modal

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/AccountModeModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/AccountModeModal.tsx
@@ -17,6 +17,7 @@ import { usePerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/ato
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
+import { getHyperliquidTokenImageUrl } from '@onekeyhq/shared/src/utils/perpsUtils';
 import { EHyperLiquidAbstractionMode } from '@onekeyhq/shared/types/hyperliquid';
 
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
@@ -57,23 +58,16 @@ const ACCOUNT_MODE_OPTIONS: {
 const PORTFOLIO_MARGIN_LEARN_MORE_URL =
   'https://hyperliquid.gitbook.io/hyperliquid-docs/support/faq/portfolio-margin#margin-sharing';
 
-const TOKEN_LOGO_URIS = {
-  BTC: 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/bitcoin/info/logo.png',
-  BNB: 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/smartchain/info/logo.png',
-  ETH: 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/logo.png',
-  USDC: 'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png',
-} as const;
-
 function TokenLogo({
   token,
   size = 28,
 }: {
-  token: keyof typeof TOKEN_LOGO_URIS;
+  token: 'BTC' | 'BNB' | 'ETH' | 'USDC';
   size?: number;
 }) {
   return (
     <Image
-      source={{ uri: TOKEN_LOGO_URIS[token] }}
+      source={{ uri: getHyperliquidTokenImageUrl(token) }}
       width={size}
       height={size}
       borderWidth="$px"


### PR DESCRIPTION
## Summary
- Replace hardcoded TrustWallet logo URLs in the Perps account mode modal with the existing Hyperliquid asset logo helper.
- Keep account mode token badges on the same OneKey asset CDN used by other Perps surfaces.

## Intent & Context
The web Perps account mode modal showed blank token logo placeholders for the unified account and portfolio margin options. The issue was reported from the web trading screen screenshot.

## Root Cause
The modal used hardcoded `raw.githubusercontent.com/trustwallet/assets` URLs for BTC, ETH, BNB, and USDC, while nearby Perps surfaces already use `getHyperliquidTokenImageUrl()` and the OneKey asset CDN. The hardcoded external source is more likely to fail in the web runtime due to resource loading policy or network availability.

## Design Decisions
Reused the existing Perps logo helper instead of adding local assets, a new fetch layer, or separate preloading just for this modal. This keeps the fix small and makes the modal follow the same token image source as token selector, market detail, portfolio, and favorites views.

## Changes Detail
- `packages/kit/src/views/Perp/components/TradingPanel/modals/AccountModeModal.tsx`: removed the local token URL map and resolved badge image URLs through `getHyperliquidTokenImageUrl()`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web, Desktop, Mobile
- **Risk Areas**: The visible logo source changes for the account mode modal only; no trading behavior, account state, or background runtime logic is touched.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] Confirmed the replacement CDN URLs for BTC, ETH, BNB, and USDC return HTTP 200 locally.