### PR TITLE
fix: defi portfolio refresh (OK-56841)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHistory.ts
+++ b/packages/kit-bg/src/services/ServiceHistory.ts
@@ -1346,6 +1346,8 @@ class ServiceHistory extends ServiceBase {
       }
     }
 
+    const localPendingTxConfirmedEventKeys = new Set<string>();
+
     // Notify subscribers (e.g. DeFi scheduler) that locally-pending txs
     // submitted by this app have just transitioned to confirmed/failed.
     // Resolve indexedAccountId so UI subscribers in All Networks mode (where
@@ -1357,6 +1359,9 @@ class ServiceHistory extends ServiceBase {
         await this.backgroundApi.serviceAccount.getDBAccountSafe({
           accountId: txAccountId,
         });
+      localPendingTxConfirmedEventKeys.add(
+        `${txAccountId}_${tx.decodedTx.networkId}_${tx.decodedTx.txid}`,
+      );
       appEventBus.emit(EAppEventBusNames.LocalPendingTxConfirmed, {
         accountId: txAccountId,
         indexedAccountId: txDBAccount?.indexedAccountId,
@@ -1580,6 +1585,22 @@ class ServiceHistory extends ServiceBase {
     });
 
     if (changedPendingTxInfos.length > 0) {
+      for (const tx of changedPendingTxInfos) {
+        const eventKey = `${tx.accountId}_${tx.networkId}_${tx.txId}`;
+        if (!localPendingTxConfirmedEventKeys.has(eventKey)) {
+          const txDBAccount =
+            await this.backgroundApi.serviceAccount.getDBAccountSafe({
+              accountId: tx.accountId,
+            });
+          appEventBus.emit(EAppEventBusNames.LocalPendingTxConfirmed, {
+            accountId: tx.accountId,
+            indexedAccountId: txDBAccount?.indexedAccountId,
+            networkId: tx.networkId,
+            txid: tx.txId,
+            status: tx.status,
+          });
+        }
+      }
       // Check if staking transaction status has changed, if so request backend to update order status
       await this.backgroundApi.serviceStaking.updateEarnOrder({
         txs: changedPendingTxInfos,

--- a/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
@@ -30,7 +30,6 @@ import {
   resolveDeFiActionTxAmount,
 } from '@onekeyhq/shared/src/utils/defiActionUtils';
 import defiPermitUtils from '@onekeyhq/shared/src/utils/defiPermitUtils';
-import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
 import { stableStringify } from '@onekeyhq/shared/src/utils/stringUtils';
 import {
   EDeFiPositionAction,
@@ -42,7 +41,6 @@ import {
 } from '@onekeyhq/shared/types/defi';
 import { EOnChainHistoryTxStatus } from '@onekeyhq/shared/types/history';
 import { EMessageTypesEth } from '@onekeyhq/shared/types/message';
-import { EEarnLabels } from '@onekeyhq/shared/types/staking';
 import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
 
 import { showDeFiActionTxConfirmDialog } from './DeFiActionTxConfirmResult';
@@ -549,53 +547,6 @@ function attachDeFiActionTxConfirmInfo({
   };
 }
 
-function getDeFiActionEarnLabel(action: EDeFiPositionAction) {
-  if (
-    action === EDeFiPositionAction.Claim ||
-    action === EDeFiPositionAction.ClaimWithdrawal
-  ) {
-    return EEarnLabels.Claim;
-  }
-  if (
-    action === EDeFiPositionAction.Withdraw ||
-    action === EDeFiPositionAction.Repay ||
-    action === EDeFiPositionAction.RemoveLiquidity
-  ) {
-    return action === EDeFiPositionAction.Repay
-      ? EEarnLabels.Repay
-      : EEarnLabels.Withdraw;
-  }
-  return EEarnLabels.Unknown;
-}
-
-async function addDeFiActionEarnOrders({
-  action,
-  networkId,
-  data,
-}: {
-  action: IResolvedDeFiPositionAction;
-  networkId: string;
-  data: ISendTxOnSuccessData[];
-}) {
-  for (const orderTx of data) {
-    if (orderTx?.signedTx?.txid) {
-      await backgroundApiProxy.serviceStaking.addEarnOrder({
-        orderId: generateUUID(),
-        networkId,
-        txId: orderTx.signedTx.txid,
-        status: orderTx.decodedTx.status,
-        stakingLabel: getDeFiActionEarnLabel(action.action),
-        stakingProtocol: action.protocolId,
-        stakingTags: [
-          'defi-portfolio-action',
-          action.protocolId,
-          action.action,
-        ],
-      });
-    }
-  }
-}
-
 type IProtocolPositionActionSuccessParams = {
   accountId: string;
   networkId: string;
@@ -827,13 +778,6 @@ function useProtocolPositionActionSubmit({
             // not request Gas Account sponsorship.
             gasAccountScenario: 'defi',
             onSuccess: async (data: ISendTxOnSuccessData[]) => {
-              // Tag the tx for pending tracking, but don't block the confirming
-              // sheet on it: showing the sheet in the same tick the confirm
-              // modal pops keeps the handoff smooth instead of flashing the page
-              // underneath while the earn-order call resolves.
-              void addDeFiActionEarnOrders({ action, networkId, data }).catch(
-                () => undefined,
-              );
               // Block on the confirming sheet until the tx settles, then run
               // the caller's refresh so the position reflects the result.
               const finalStatus = await showDeFiActionTxConfirmDialog({


### PR DESCRIPTION
## Issues
- Fixes OK-56841

## Summary
- Stop registering DeFi Portfolio actions as Earn orders with a client-generated orderId.
- Emit the existing LocalPendingTxConfirmed event from history-list pending transitions so DeFi positions refresh by account and network after pending txs settle.

## Test Plan
- git diff --check
- npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit-bg/src/services/ServiceHistory.ts packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
- yarn tsc:only
- yarn lint:staged
- yarn tsc:staged

## Notes
- Draft PR for DeFi Portfolio follow-up fixes.