### PR TITLE
feat: add color picker component

### DIFF
--- a/packages/components/src/forms/ColorPicker/index.tsx
+++ b/packages/components/src/forms/ColorPicker/index.tsx
@@ -30,6 +30,7 @@ export interface IColorPickerPaletteProps extends Omit<
   colors?: readonly IColorPickerColor[];
   columns?: number;
   swatchSize?: number;
+  fullWidth?: boolean;
   disabled?: boolean;
   testID?: string;
 }
@@ -56,8 +57,10 @@ export interface IColorPickerProps extends Omit<
 }
 
 export const DEFAULT_COLOR_PICKER_COLUMNS = 11;
-const DEFAULT_MOBILE_COLOR_PICKER_COLUMNS = 6;
+const DEFAULT_COLOR_PICKER_SWATCH_SIZE = 28;
+const DEFAULT_COLOR_PICKER_GAP = '$0.5';
 const DEFAULT_COLOR_PICKER_TRIGGER_COLOR = '#FFFFFF';
+const DIALOG_CLOSE_DELAY_MS = 300;
 
 export const DEFAULT_COLOR_PICKER_COLORS: readonly string[] = [
   '#FFFFFF',
@@ -152,6 +155,9 @@ const defaultFloatingPanelProps = {
   width: 'auto',
   minWidth: 0,
 } as const;
+const defaultDialogContentContainerProps = {
+  pt: '$2',
+} as const;
 const allowTriggerPress = () => undefined;
 const preventTriggerPress = () => false;
 const swatchAccessibilityStateSelectedEnabled = {
@@ -229,6 +235,7 @@ const ColorSwatch = memo(
     option,
     selected,
     size,
+    fullWidth,
     disabled,
     onSelect,
     testID,
@@ -236,6 +243,7 @@ const ColorSwatch = memo(
     option: IColorPickerOption;
     selected: boolean;
     size: number;
+    fullWidth?: boolean;
     disabled?: boolean;
     onSelect: (value: string) => void;
     testID?: string;
@@ -256,8 +264,11 @@ const ColorSwatch = memo(
 
     return (
       <YStack
-        width={size}
-        height={size}
+        width={fullWidth ? undefined : size}
+        height={fullWidth ? undefined : size}
+        flex={fullWidth ? 1 : undefined}
+        aspectRatio={fullWidth ? 1 : undefined}
+        minWidth={fullWidth ? 0 : undefined}
         padding={2}
         alignItems="center"
         justifyContent="center"
@@ -304,17 +315,22 @@ const DefaultColorPickerTrigger = memo(
   ({
     color,
     disabled,
+    onPress,
     size,
     testID,
   }: {
     color: string;
     disabled?: boolean;
+    onPress?: IYStackProps['onPress'];
     size: number;
     testID?: string;
   }) => {
     const accessibilityState = disabled
       ? triggerAccessibilityStateDisabled
       : triggerAccessibilityStateEnabled;
+    const handlePress = disabled
+      ? preventTriggerPress
+      : (onPress ?? allowTriggerPress);
     return (
       <YStack
         width={size}
@@ -334,7 +350,7 @@ const DefaultColorPickerTrigger = memo(
         focusVisibleStyle={swatchFocusVisibleStyle}
         hoverStyle={disabled ? undefined : triggerHoverStyle}
         pressStyle={disabled ? undefined : triggerPressStyle}
-        onPress={disabled ? preventTriggerPress : allowTriggerPress}
+        onPress={handlePress}
         role={!platformEnv.isNative ? 'button' : undefined}
         aria-disabled={!platformEnv.isNative ? disabled : undefined}
         aria-label={
@@ -377,6 +393,7 @@ type IColorPickerContentProps = Omit<
 function ColorPickerContent({
   closeOverlay,
   closeOnSelect,
+  fullWidth,
   onValueChange,
   ...paletteProps
 }: IColorPickerContentProps) {
@@ -391,8 +408,16 @@ function ColorPickerContent({
   );
 
   return (
-    <YStack padding="$2">
-      <ColorPickerPalette {...paletteProps} onChange={handlePaletteChange} />
+    <YStack
+      width={fullWidth ? '100%' : undefined}
+      padding="$2"
+      alignItems={fullWidth ? 'stretch' : 'center'}
+    >
+      <ColorPickerPalette
+        {...paletteProps}
+        fullWidth={fullWidth}
+        onChange={handlePaletteChange}
+      />
     </YStack>
   );
 }
@@ -403,8 +428,9 @@ export function ColorPickerPalette({
   onChange,
   colors = DEFAULT_COLOR_PICKER_COLORS,
   columns = DEFAULT_COLOR_PICKER_COLUMNS,
-  swatchSize = 28,
-  gap = '$0.5',
+  swatchSize = DEFAULT_COLOR_PICKER_SWATCH_SIZE,
+  gap = DEFAULT_COLOR_PICKER_GAP,
+  fullWidth,
   disabled,
   testID,
   ...rest
@@ -435,6 +461,7 @@ export function ColorPickerPalette({
 
   return (
     <YStack
+      width={fullWidth ? '100%' : undefined}
       gap={gap}
       testID={testID}
       role={!platformEnv.isNative ? 'radiogroup' : undefined}
@@ -442,7 +469,7 @@ export function ColorPickerPalette({
       {...rest}
     >
       {colorRows.map((row, rowIndex) => (
-        <XStack key={rowIndex} gap={gap}>
+        <XStack key={rowIndex} width={fullWidth ? '100%' : undefined} gap={gap}>
           {row.map((option, optionIndex) => {
             const optionNormalizedValue = normalizeColorValue(option.value);
             return (
@@ -451,12 +478,25 @@ export function ColorPickerPalette({
                 option={option}
                 selected={selectedNormalizedValue === optionNormalizedValue}
                 size={swatchSize}
+                fullWidth={fullWidth}
                 disabled={disabled}
                 onSelect={handleSelect}
                 testID={testID ? `${testID}-${option.value}` : undefined}
               />
             );
           })}
+          {fullWidth && row.length < normalizedColumns
+            ? Array.from({ length: normalizedColumns - row.length }).map(
+                (_, placeholderIndex) => (
+                  <Stack
+                    key={`placeholder-${rowIndex}-${placeholderIndex}`}
+                    flex={1}
+                    aspectRatio={1}
+                    minWidth={0}
+                  />
+                ),
+              )
+            : null}
         </XStack>
       ))}
     </YStack>
@@ -469,8 +509,9 @@ export function ColorPicker({
   onChange,
   colors = DEFAULT_COLOR_PICKER_COLORS,
   columns,
-  swatchSize = 28,
-  gap = '$0.5',
+  swatchSize,
+  gap = DEFAULT_COLOR_PICKER_GAP,
+  fullWidth,
   disabled,
   testID,
   open,
@@ -486,6 +527,8 @@ export function ColorPicker({
   const { md } = useMedia();
   const [innerValue, setInnerValue] = useState(defaultValue);
   const [innerOpen, setInnerOpen] = useState(false);
+  const [shouldRenderMobileDialog, setShouldRenderMobileDialog] =
+    useState(false);
   const selectedValue = value ?? innerValue;
   const isOpenControlled = open !== undefined;
   const usedOpen = isOpenControlled ? !!open : innerOpen;
@@ -504,15 +547,31 @@ export function ColorPicker({
   }, [disabled, isOpenControlled, onOpenChange, open]);
 
   const resolvedColumns = useMemo(
-    () =>
-      normalizeColumns(
-        columns ??
-          (md
-            ? DEFAULT_MOBILE_COLOR_PICKER_COLUMNS
-            : DEFAULT_COLOR_PICKER_COLUMNS),
-      ),
-    [columns, md],
+    () => normalizeColumns(columns ?? DEFAULT_COLOR_PICKER_COLUMNS),
+    [columns],
   );
+
+  const resolvedSwatchSize = useMemo(
+    () => swatchSize ?? DEFAULT_COLOR_PICKER_SWATCH_SIZE,
+    [swatchSize],
+  );
+
+  const resolvedFullWidth = fullWidth ?? (md && swatchSize === undefined);
+
+  useEffect(() => {
+    if (!md) {
+      setShouldRenderMobileDialog(false);
+      return undefined;
+    }
+    if (effectiveOpen) {
+      setShouldRenderMobileDialog(true);
+      return undefined;
+    }
+    const timer = setTimeout(() => {
+      setShouldRenderMobileDialog(false);
+    }, DIALOG_CLOSE_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [effectiveOpen, md]);
 
   const fallbackColor = useMemo(() => getColorOptionValue(colors[0]), [colors]);
   const triggerColor = selectedValue ?? fallbackColor;
@@ -587,8 +646,9 @@ export function ColorPicker({
         onValueChange={handleChange}
         colors={colors}
         columns={resolvedColumns}
-        swatchSize={swatchSize}
+        swatchSize={resolvedSwatchSize}
         gap={gap}
+        fullWidth={resolvedFullWidth}
         disabled={disabled}
         testID={testID ? `${testID}-palette` : undefined}
       />
@@ -601,8 +661,9 @@ export function ColorPicker({
       handleChange,
       paletteProps,
       resolvedColumns,
+      resolvedFullWidth,
+      resolvedSwatchSize,
       selectedValue,
-      swatchSize,
       testID,
     ],
   );
@@ -627,6 +688,7 @@ export function ColorPicker({
           open={effectiveOpen}
           onClose={handleDialogClose}
           renderContent={dialogContent}
+          contentContainerProps={defaultDialogContentContainerProps}
           sheetProps={sheetProps}
           floatingPanelProps={mergedFloatingPanelProps}
           testID={testID ? `${testID}-dialog` : undefined}
@@ -653,7 +715,7 @@ export function ColorPicker({
         >
           {trigger}
         </Trigger>
-        {mobileDialog}
+        {shouldRenderMobileDialog ? mobileDialog : null}
       </>
     );
   }

--- a/packages/components/src/forms/ColorPicker/index.tsx
+++ b/packages/components/src/forms/ColorPicker/index.tsx
@@ -1,0 +1,674 @@
+import type { ReactElement } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import { Popover, Trigger } from '../../actions';
+import { DialogContainer } from '../../composite/Dialog';
+import { Portal } from '../../hocs';
+import { useMedia } from '../../hooks';
+import { Stack, XStack, YStack } from '../../primitives';
+
+import type { IPopoverContent, IPopoverProps } from '../../actions';
+import type { IYStackProps } from '../../primitives';
+
+export interface IColorPickerOption {
+  value: string;
+  label?: string;
+  disabled?: boolean;
+}
+
+export type IColorPickerColor = string | IColorPickerOption;
+
+export interface IColorPickerPaletteProps extends Omit<
+  IYStackProps,
+  'children' | 'onChange'
+> {
+  value?: string;
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  colors?: readonly IColorPickerColor[];
+  columns?: number;
+  swatchSize?: number;
+  disabled?: boolean;
+  testID?: string;
+}
+
+export interface IColorPickerRenderTriggerProps {
+  value?: string;
+  color: string;
+  disabled?: boolean;
+}
+
+export interface IColorPickerProps extends Omit<
+  IColorPickerPaletteProps,
+  'testID'
+> {
+  open?: IPopoverProps['open'];
+  onOpenChange?: IPopoverProps['onOpenChange'];
+  placement?: IPopoverProps['placement'];
+  floatingPanelProps?: IPopoverProps['floatingPanelProps'];
+  sheetProps?: IPopoverProps['sheetProps'];
+  renderTrigger?: (props: IColorPickerRenderTriggerProps) => ReactElement;
+  closeOnSelect?: boolean;
+  triggerSize?: number;
+  testID?: string;
+}
+
+export const DEFAULT_COLOR_PICKER_COLUMNS = 11;
+const DEFAULT_MOBILE_COLOR_PICKER_COLUMNS = 6;
+const DEFAULT_COLOR_PICKER_TRIGGER_COLOR = '#FFFFFF';
+
+export const DEFAULT_COLOR_PICKER_COLORS: readonly string[] = [
+  '#FFFFFF',
+  '#E5484D',
+  '#FBA43A',
+  '#FDEB5B',
+  '#6AAF63',
+  '#4E9F8A',
+  '#5CB8D1',
+  '#3D63DD',
+  '#6747C7',
+  '#953EA8',
+  '#D64073',
+  '#D4D8E1',
+  '#F4C7C7',
+  '#F8DDB4',
+  '#FBF4C4',
+  '#CDE7CE',
+  '#B9E1D9',
+  '#B8E7EF',
+  '#BDD2F0',
+  '#CFC4E8',
+  '#D9BBE1',
+  '#E7B7C8',
+  '#B2B5BF',
+  '#E99AA2',
+  '#F4C37D',
+  '#FBEEA6',
+  '#A8D2AA',
+  '#86C9BA',
+  '#8ED4E0',
+  '#90B6E8',
+  '#B19AD8',
+  '#C28FD0',
+  '#DE8AAA',
+  '#83858F',
+  '#E08188',
+  '#F2BE63',
+  '#F9EA86',
+  '#8FBE8F',
+  '#70B9A7',
+  '#75CBD9',
+  '#6D9BE5',
+  '#967CCF',
+  '#AD6BC1',
+  '#D96A96',
+  '#555966',
+  '#E05261',
+  '#F8AA3E',
+  '#FBE764',
+  '#75B56F',
+  '#56AA93',
+  '#5DBFD1',
+  '#4575E6',
+  '#7B5BC6',
+  '#9642B6',
+  '#D8427A',
+  '#2B2E38',
+  '#A33A43',
+  '#E7862B',
+  '#F1C54A',
+  '#4D8A48',
+  '#306957',
+  '#3D96A6',
+  '#3149B9',
+  '#5733A5',
+  '#72289C',
+  '#B12C65',
+  '#0F1013',
+  '#7C202A',
+  '#DB5524',
+  '#EC7F32',
+  '#2D652C',
+  '#123F37',
+  '#276774',
+  '#1F2F91',
+  '#36208A',
+  '#471B80',
+  '#8C1E59',
+];
+
+const swatchHoverStyle = { bg: '$bgHover' } as const;
+const swatchPressStyle = { bg: '$bgActive' } as const;
+const triggerHoverStyle = { backgroundColor: '$bgHover' } as const;
+const triggerPressStyle = { backgroundColor: '$bgActive' } as const;
+const swatchFocusVisibleStyle = {
+  outlineWidth: 2,
+  outlineColor: '$focusRing',
+  outlineStyle: 'solid',
+} as const;
+const defaultFloatingPanelProps = {
+  width: 'auto',
+  minWidth: 0,
+} as const;
+const allowTriggerPress = () => undefined;
+const preventTriggerPress = () => false;
+const swatchAccessibilityStateSelectedEnabled = {
+  checked: true,
+  disabled: false,
+} as const;
+const swatchAccessibilityStateSelectedDisabled = {
+  checked: true,
+  disabled: true,
+} as const;
+const swatchAccessibilityStateUnselectedEnabled = {
+  checked: false,
+  disabled: false,
+} as const;
+const swatchAccessibilityStateUnselectedDisabled = {
+  checked: false,
+  disabled: true,
+} as const;
+const triggerAccessibilityStateEnabled = { disabled: false } as const;
+const triggerAccessibilityStateDisabled = { disabled: true } as const;
+
+function normalizeColorValue(value: string | undefined) {
+  return value?.toLowerCase();
+}
+
+function normalizeColorOption(color: IColorPickerColor): IColorPickerOption {
+  return typeof color === 'string' ? { value: color } : color;
+}
+
+function getColorOptionValue(color: IColorPickerColor | undefined) {
+  if (!color) {
+    return DEFAULT_COLOR_PICKER_TRIGGER_COLOR;
+  }
+  return normalizeColorOption(color).value;
+}
+
+function normalizeColumns(columns: number) {
+  const nextColumns = Math.floor(columns);
+  if (!Number.isFinite(nextColumns) || nextColumns < 1) {
+    return DEFAULT_COLOR_PICKER_COLUMNS;
+  }
+  return nextColumns;
+}
+
+function getSwatchAccessibilityState({
+  selected,
+  disabled,
+}: {
+  selected: boolean;
+  disabled: boolean;
+}) {
+  if (selected) {
+    return disabled
+      ? swatchAccessibilityStateSelectedDisabled
+      : swatchAccessibilityStateSelectedEnabled;
+  }
+  return disabled
+    ? swatchAccessibilityStateUnselectedDisabled
+    : swatchAccessibilityStateUnselectedEnabled;
+}
+
+function chunkColorOptions(
+  colors: readonly IColorPickerOption[],
+  columns: number,
+) {
+  const rows: IColorPickerOption[][] = [];
+  for (let index = 0; index < colors.length; index += columns) {
+    rows.push(colors.slice(index, index + columns));
+  }
+  return rows;
+}
+
+const ColorSwatch = memo(
+  ({
+    option,
+    selected,
+    size,
+    disabled,
+    onSelect,
+    testID,
+  }: {
+    option: IColorPickerOption;
+    selected: boolean;
+    size: number;
+    disabled?: boolean;
+    onSelect: (value: string) => void;
+    testID?: string;
+  }) => {
+    const isDisabled = !!(disabled || option.disabled);
+    const label = option.label ?? option.value;
+    const accessibilityState = getSwatchAccessibilityState({
+      selected,
+      disabled: isDisabled,
+    });
+
+    const handlePress = useCallback(() => {
+      if (isDisabled) {
+        return;
+      }
+      onSelect(option.value);
+    }, [isDisabled, onSelect, option.value]);
+
+    return (
+      <YStack
+        width={size}
+        height={size}
+        padding={2}
+        alignItems="center"
+        justifyContent="center"
+        borderRadius="$2"
+        borderCurve="continuous"
+        borderWidth={2}
+        borderColor={selected ? '$borderActive' : '$transparent'}
+        opacity={isDisabled ? 0.5 : 1}
+        userSelect="none"
+        cursor={isDisabled ? 'not-allowed' : 'pointer'}
+        focusable={!isDisabled}
+        focusVisibleStyle={swatchFocusVisibleStyle}
+        hoverStyle={isDisabled ? undefined : swatchHoverStyle}
+        pressStyle={isDisabled ? undefined : swatchPressStyle}
+        onPress={handlePress}
+        role={!platformEnv.isNative ? 'radio' : undefined}
+        aria-checked={!platformEnv.isNative ? selected : undefined}
+        aria-disabled={!platformEnv.isNative ? isDisabled : undefined}
+        aria-label={!platformEnv.isNative ? label : undefined}
+        accessibilityRole={platformEnv.isNative ? 'radio' : undefined}
+        accessibilityLabel={platformEnv.isNative ? label : undefined}
+        accessibilityState={
+          platformEnv.isNative ? accessibilityState : undefined
+        }
+        testID={testID}
+      >
+        <Stack
+          width="100%"
+          height="100%"
+          borderRadius="$1"
+          borderCurve="continuous"
+          borderWidth="$px"
+          borderColor="$borderSubdued"
+          backgroundColor={option.value}
+        />
+      </YStack>
+    );
+  },
+);
+
+ColorSwatch.displayName = 'ColorSwatch';
+
+const DefaultColorPickerTrigger = memo(
+  ({
+    color,
+    disabled,
+    size,
+    testID,
+  }: {
+    color: string;
+    disabled?: boolean;
+    size: number;
+    testID?: string;
+  }) => {
+    const accessibilityState = disabled
+      ? triggerAccessibilityStateDisabled
+      : triggerAccessibilityStateEnabled;
+    return (
+      <YStack
+        width={size}
+        height={size}
+        padding="$1"
+        alignItems="center"
+        justifyContent="center"
+        borderRadius="$2"
+        borderCurve="continuous"
+        borderWidth="$px"
+        borderColor="$borderSubdued"
+        backgroundColor="$bgStrong"
+        opacity={disabled ? 0.5 : 1}
+        userSelect="none"
+        cursor={disabled ? 'not-allowed' : 'pointer'}
+        focusable={!disabled}
+        focusVisibleStyle={swatchFocusVisibleStyle}
+        hoverStyle={disabled ? undefined : triggerHoverStyle}
+        pressStyle={disabled ? undefined : triggerPressStyle}
+        onPress={disabled ? preventTriggerPress : allowTriggerPress}
+        role={!platformEnv.isNative ? 'button' : undefined}
+        aria-disabled={!platformEnv.isNative ? disabled : undefined}
+        aria-label={
+          !platformEnv.isNative ? `Color picker, ${color}` : undefined
+        }
+        accessibilityRole={platformEnv.isNative ? 'button' : undefined}
+        accessibilityLabel={
+          platformEnv.isNative ? `Color picker, ${color}` : undefined
+        }
+        accessibilityState={
+          platformEnv.isNative ? accessibilityState : undefined
+        }
+        testID={testID}
+      >
+        <Stack
+          width="100%"
+          height="100%"
+          borderRadius="$1"
+          borderCurve="continuous"
+          borderWidth="$px"
+          borderColor="$borderSubdued"
+          backgroundColor={color}
+        />
+      </YStack>
+    );
+  },
+);
+
+DefaultColorPickerTrigger.displayName = 'DefaultColorPickerTrigger';
+
+type IColorPickerContentProps = Omit<
+  IColorPickerPaletteProps,
+  'defaultValue' | 'onChange'
+> & {
+  closeOverlay: () => void;
+  closeOnSelect?: boolean;
+  onValueChange: (value: string) => void;
+};
+
+function ColorPickerContent({
+  closeOverlay,
+  closeOnSelect,
+  onValueChange,
+  ...paletteProps
+}: IColorPickerContentProps) {
+  const handlePaletteChange = useCallback(
+    (nextValue: string) => {
+      onValueChange(nextValue);
+      if (closeOnSelect) {
+        closeOverlay();
+      }
+    },
+    [closeOnSelect, closeOverlay, onValueChange],
+  );
+
+  return (
+    <YStack padding="$2">
+      <ColorPickerPalette {...paletteProps} onChange={handlePaletteChange} />
+    </YStack>
+  );
+}
+
+export function ColorPickerPalette({
+  value,
+  defaultValue,
+  onChange,
+  colors = DEFAULT_COLOR_PICKER_COLORS,
+  columns = DEFAULT_COLOR_PICKER_COLUMNS,
+  swatchSize = 28,
+  gap = '$0.5',
+  disabled,
+  testID,
+  ...rest
+}: IColorPickerPaletteProps) {
+  const [innerValue, setInnerValue] = useState(defaultValue);
+  const selectedValue = value ?? innerValue;
+  const selectedNormalizedValue = normalizeColorValue(selectedValue);
+
+  const normalizedColumns = useMemo(() => normalizeColumns(columns), [columns]);
+
+  const normalizedColors = useMemo(
+    () => colors.map(normalizeColorOption),
+    [colors],
+  );
+
+  const colorRows = useMemo(
+    () => chunkColorOptions(normalizedColors, normalizedColumns),
+    [normalizedColors, normalizedColumns],
+  );
+
+  const handleSelect = useCallback(
+    (nextValue: string) => {
+      setInnerValue(nextValue);
+      onChange?.(nextValue);
+    },
+    [onChange],
+  );
+
+  return (
+    <YStack
+      gap={gap}
+      testID={testID}
+      role={!platformEnv.isNative ? 'radiogroup' : undefined}
+      accessibilityRole={platformEnv.isNative ? 'radiogroup' : undefined}
+      {...rest}
+    >
+      {colorRows.map((row, rowIndex) => (
+        <XStack key={rowIndex} gap={gap}>
+          {row.map((option, optionIndex) => {
+            const optionNormalizedValue = normalizeColorValue(option.value);
+            return (
+              <ColorSwatch
+                key={`${option.value}-${optionIndex}`}
+                option={option}
+                selected={selectedNormalizedValue === optionNormalizedValue}
+                size={swatchSize}
+                disabled={disabled}
+                onSelect={handleSelect}
+                testID={testID ? `${testID}-${option.value}` : undefined}
+              />
+            );
+          })}
+        </XStack>
+      ))}
+    </YStack>
+  );
+}
+
+export function ColorPicker({
+  value,
+  defaultValue,
+  onChange,
+  colors = DEFAULT_COLOR_PICKER_COLORS,
+  columns,
+  swatchSize = 28,
+  gap = '$0.5',
+  disabled,
+  testID,
+  open,
+  onOpenChange,
+  placement = 'bottom-start',
+  floatingPanelProps,
+  sheetProps,
+  renderTrigger,
+  closeOnSelect = true,
+  triggerSize = 36,
+  ...paletteProps
+}: IColorPickerProps) {
+  const { md } = useMedia();
+  const [innerValue, setInnerValue] = useState(defaultValue);
+  const [innerOpen, setInnerOpen] = useState(false);
+  const selectedValue = value ?? innerValue;
+  const isOpenControlled = open !== undefined;
+  const usedOpen = isOpenControlled ? !!open : innerOpen;
+  const effectiveOpen = disabled ? false : usedOpen;
+
+  useEffect(() => {
+    if (!disabled) {
+      return;
+    }
+    if (!isOpenControlled) {
+      setInnerOpen(false);
+    }
+    if (isOpenControlled && open) {
+      onOpenChange?.(false);
+    }
+  }, [disabled, isOpenControlled, onOpenChange, open]);
+
+  const resolvedColumns = useMemo(
+    () =>
+      normalizeColumns(
+        columns ??
+          (md
+            ? DEFAULT_MOBILE_COLOR_PICKER_COLUMNS
+            : DEFAULT_COLOR_PICKER_COLUMNS),
+      ),
+    [columns, md],
+  );
+
+  const fallbackColor = useMemo(() => getColorOptionValue(colors[0]), [colors]);
+  const triggerColor = selectedValue ?? fallbackColor;
+
+  const handleChange = useCallback(
+    (nextValue: string) => {
+      setInnerValue(nextValue);
+      onChange?.(nextValue);
+    },
+    [onChange],
+  );
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      const nextEffectiveOpen = disabled ? false : nextOpen;
+      if (!isOpenControlled) {
+        setInnerOpen(nextEffectiveOpen);
+      }
+      if (disabled && nextOpen) {
+        if (open) {
+          onOpenChange?.(false);
+        }
+        return;
+      }
+      onOpenChange?.(nextEffectiveOpen);
+    },
+    [disabled, isOpenControlled, onOpenChange, open],
+  );
+
+  const handleOpenPicker = useCallback(() => {
+    handleOpenChange(true);
+  }, [handleOpenChange]);
+
+  const handleClosePicker = useCallback(() => {
+    handleOpenChange(false);
+  }, [handleOpenChange]);
+
+  const handleDialogClose = useCallback(async () => {
+    handleClosePicker();
+  }, [handleClosePicker]);
+
+  const trigger = useMemo(
+    () =>
+      renderTrigger ? (
+        renderTrigger({ value: selectedValue, color: triggerColor, disabled })
+      ) : (
+        <DefaultColorPickerTrigger
+          color={triggerColor}
+          disabled={disabled}
+          size={triggerSize}
+          testID={testID ? `${testID}-trigger` : undefined}
+        />
+      ),
+    [disabled, renderTrigger, selectedValue, testID, triggerColor, triggerSize],
+  );
+
+  const mergedFloatingPanelProps = useMemo(
+    () => ({
+      ...defaultFloatingPanelProps,
+      ...floatingPanelProps,
+    }),
+    [floatingPanelProps],
+  );
+
+  const renderPaletteContent = useCallback(
+    (closeOverlay: () => void) => (
+      <ColorPickerContent
+        {...paletteProps}
+        value={selectedValue}
+        closeOverlay={closeOverlay}
+        closeOnSelect={closeOnSelect}
+        onValueChange={handleChange}
+        colors={colors}
+        columns={resolvedColumns}
+        swatchSize={swatchSize}
+        gap={gap}
+        disabled={disabled}
+        testID={testID ? `${testID}-palette` : undefined}
+      />
+    ),
+    [
+      closeOnSelect,
+      colors,
+      disabled,
+      gap,
+      handleChange,
+      paletteProps,
+      resolvedColumns,
+      selectedValue,
+      swatchSize,
+      testID,
+    ],
+  );
+
+  const renderContent = useCallback(
+    ({ closePopover }: IPopoverContent) => renderPaletteContent(closePopover),
+    [renderPaletteContent],
+  );
+
+  const dialogContent = useMemo(
+    () => renderPaletteContent(handleClosePicker),
+    [handleClosePicker, renderPaletteContent],
+  );
+
+  const mobileDialog = useMemo(
+    () => (
+      <Portal.Body container={Portal.Constant.FULL_WINDOW_OVERLAY_PORTAL}>
+        <DialogContainer
+          title="Color"
+          showHeader={false}
+          showFooter={false}
+          open={effectiveOpen}
+          onClose={handleDialogClose}
+          renderContent={dialogContent}
+          sheetProps={sheetProps}
+          floatingPanelProps={mergedFloatingPanelProps}
+          testID={testID ? `${testID}-dialog` : undefined}
+        />
+      </Portal.Body>
+    ),
+    [
+      dialogContent,
+      effectiveOpen,
+      handleDialogClose,
+      mergedFloatingPanelProps,
+      sheetProps,
+      testID,
+    ],
+  );
+
+  if (md) {
+    return (
+      <>
+        <Trigger
+          testID={testID ? `${testID}-trigger-wrapper` : undefined}
+          disabled={disabled}
+          onPress={handleOpenPicker}
+        >
+          {trigger}
+        </Trigger>
+        {mobileDialog}
+      </>
+    );
+  }
+
+  return (
+    <Popover
+      title="Color"
+      showHeader={false}
+      open={effectiveOpen}
+      onOpenChange={handleOpenChange}
+      placement={placement}
+      renderTrigger={trigger}
+      renderContent={renderContent}
+      floatingPanelProps={mergedFloatingPanelProps}
+      sheetProps={sheetProps}
+    />
+  );
+}

--- a/packages/components/src/forms/index.ts
+++ b/packages/components/src/forms/index.ts
@@ -1,4 +1,5 @@
 export * from './Checkbox';
+export * from './ColorPicker';
 export * from './Form';
 export * from './Form/formInstances';
 export * from './Input';

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/ColorPicker.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/ColorPicker.tsx
@@ -1,0 +1,262 @@
+import { useCallback, useState } from 'react';
+
+import {
+  Button,
+  ColorPicker,
+  ColorPickerPalette,
+  SizableText,
+  Stack,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
+import type { IColorPickerRenderTriggerProps } from '@onekeyhq/components';
+
+import { Layout } from './utils/Layout';
+
+const customColors = [
+  '#111827',
+  '#2563EB',
+  '#0891B2',
+  '#059669',
+  '#65A30D',
+  '#EAB308',
+  '#EA580C',
+  '#DC2626',
+  '#DB2777',
+  '#7C3AED',
+];
+
+const customColorOptions = customColors.map((color, index) => ({
+  value: color,
+  label: `Custom color ${index + 1}`,
+  disabled: index === 2 || index === 6,
+}));
+
+function ColorValue({ value }: { value: string }) {
+  return (
+    <XStack gap="$2" alignItems="center">
+      <Stack
+        width="$5"
+        height="$5"
+        borderRadius="$1"
+        borderCurve="continuous"
+        borderWidth="$px"
+        borderColor="$borderSubdued"
+        backgroundColor={value}
+      />
+      <SizableText size="$bodySm" color="$textSubdued">
+        Selected: {value}
+      </SizableText>
+    </XStack>
+  );
+}
+
+function DefaultColorPickerDemo() {
+  const [value, setValue] = useState('#D64073');
+
+  return (
+    <YStack gap="$3">
+      <ColorPicker value={value} onChange={setValue} />
+      <ColorValue value={value} />
+    </YStack>
+  );
+}
+
+function CustomPaletteColorPickerDemo() {
+  const [value, setValue] = useState(customColors[1]);
+
+  return (
+    <YStack gap="$3">
+      <ColorPicker
+        value={value}
+        onChange={setValue}
+        colors={customColors}
+        columns={5}
+      />
+      <ColorValue value={value} />
+    </YStack>
+  );
+}
+
+function CustomTriggerColorPickerDemo() {
+  const [value, setValue] = useState('#059669');
+  const renderTrigger = useCallback(
+    ({ color, disabled }: IColorPickerRenderTriggerProps) => (
+      <XStack
+        gap="$2"
+        alignItems="center"
+        paddingHorizontal="$3"
+        paddingVertical="$2"
+        borderRadius="$2"
+        borderCurve="continuous"
+        borderWidth="$px"
+        borderColor="$borderSubdued"
+        opacity={disabled ? 0.5 : 1}
+      >
+        <Stack
+          width="$5"
+          height="$5"
+          borderRadius="$1"
+          borderCurve="continuous"
+          backgroundColor={color}
+        />
+        <SizableText size="$bodyMdMedium">Pick color</SizableText>
+      </XStack>
+    ),
+    [],
+  );
+
+  return (
+    <YStack gap="$3">
+      <ColorPicker
+        value={value}
+        onChange={setValue}
+        colors={customColors}
+        columns={5}
+        renderTrigger={renderTrigger}
+      />
+      <ColorValue value={value} />
+    </YStack>
+  );
+}
+
+function ControlledOpenColorPickerDemo() {
+  const [value, setValue] = useState(customColors[3]);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <YStack gap="$3">
+      <XStack gap="$2" alignItems="center">
+        <ColorPicker
+          value={value}
+          onChange={setValue}
+          open={open}
+          onOpenChange={setOpen}
+          closeOnSelect={false}
+          colors={customColors}
+          columns={5}
+        />
+        <Button size="small" onPress={() => setOpen((prev) => !prev)}>
+          {open ? 'Close' : 'Open'}
+        </Button>
+      </XStack>
+      <ColorValue value={value} />
+      <SizableText size="$bodySm" color="$textSubdued">
+        Open: {open ? 'Yes' : 'No'} | closeOnSelect: false
+      </SizableText>
+    </YStack>
+  );
+}
+
+function DisabledOptionColorPickerDemo() {
+  const [value, setValue] = useState(customColorOptions[1].value);
+
+  return (
+    <YStack gap="$3">
+      <ColorPickerPalette
+        value={value}
+        onChange={setValue}
+        colors={customColorOptions}
+        columns={5}
+      />
+      <ColorValue value={value} />
+    </YStack>
+  );
+}
+
+function ColorPickerPaletteDemo() {
+  const [value, setValue] = useState('#3D63DD');
+
+  return (
+    <YStack gap="$3">
+      <ColorPickerPalette value={value} onChange={setValue} columns={6} />
+      <ColorValue value={value} />
+    </YStack>
+  );
+}
+
+function DisabledColorPickerDemo() {
+  return <ColorPicker value="#83858F" disabled />;
+}
+
+function DisabledCustomTriggerColorPickerDemo() {
+  const renderTrigger = useCallback(
+    ({ color, disabled }: IColorPickerRenderTriggerProps) => (
+      <XStack
+        gap="$2"
+        alignItems="center"
+        paddingHorizontal="$3"
+        paddingVertical="$2"
+        borderRadius="$2"
+        borderCurve="continuous"
+        borderWidth="$px"
+        borderColor="$borderSubdued"
+        opacity={disabled ? 0.5 : 1}
+      >
+        <Stack
+          width="$5"
+          height="$5"
+          borderRadius="$1"
+          borderCurve="continuous"
+          backgroundColor={color}
+        />
+        <SizableText size="$bodyMdMedium">Disabled trigger</SizableText>
+      </XStack>
+    ),
+    [],
+  );
+
+  return (
+    <ColorPicker
+      value="#7C3AED"
+      disabled
+      colors={customColors}
+      renderTrigger={renderTrigger}
+    />
+  );
+}
+
+function ColorPickerGallery() {
+  return (
+    <Layout
+      getFilePath={() => __CURRENT_FILE_PATH__}
+      componentName="ColorPicker"
+      elements={[
+        {
+          title: 'Default',
+          element: <DefaultColorPickerDemo />,
+        },
+        {
+          title: 'Custom palette',
+          element: <CustomPaletteColorPickerDemo />,
+        },
+        {
+          title: 'Custom trigger',
+          element: <CustomTriggerColorPickerDemo />,
+        },
+        {
+          title: 'Controlled open',
+          element: <ControlledOpenColorPickerDemo />,
+        },
+        {
+          title: 'Disabled options',
+          element: <DisabledOptionColorPickerDemo />,
+        },
+        {
+          title: 'Palette only',
+          element: <ColorPickerPaletteDemo />,
+        },
+        {
+          title: 'Disabled',
+          element: <DisabledColorPickerDemo />,
+        },
+        {
+          title: 'Disabled custom trigger',
+          element: <DisabledCustomTriggerColorPickerDemo />,
+        },
+      ]}
+    />
+  );
+}
+
+export default ColorPickerGallery;

--- a/packages/kit/src/views/Developer/pages/Gallery/index.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/index.tsx
@@ -42,6 +42,10 @@ const CheckboxGallery = LazyLoadPage(
   () =>
     import('@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/Checkbox'),
 );
+const ColorPickerGallery = LazyLoadPage(
+  () =>
+    import('@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/ColorPicker'),
+);
 const DatePickerGallery = LazyLoadPage(
   () =>
     import('@onekeyhq/kit/src/views/Developer/pages/Gallery/Components/stories/DatePicker'),
@@ -596,6 +600,7 @@ export const galleryScreenList: {
   { name: EGalleryRoutes.ComponentListItem, component: ListItemGallery },
   { name: EGalleryRoutes.ComponentSkeleton, component: SkeletonGallery },
   { name: EGalleryRoutes.ComponentCheckbox, component: CheckboxGallery },
+  { name: EGalleryRoutes.ComponentColorPicker, component: ColorPickerGallery },
   { name: EGalleryRoutes.ComponentActionList, component: ActionListGallery },
   { name: EGalleryRoutes.ComponentPopover, component: PopoverGallery },
   { name: EGalleryRoutes.ComponentProgress, component: ProgressGallery },

--- a/packages/shared/src/routes/gallery.ts
+++ b/packages/shared/src/routes/gallery.ts
@@ -14,6 +14,7 @@ export enum EGalleryRoutes {
   ComponentButton = 'component-Button',
   ComponentChainSelector = 'component-ChainSelector',
   ComponentCheckbox = 'component-Checkbox',
+  ComponentColorPicker = 'component-ColorPicker',
   ComponentCurrency = 'component-Currency',
   ComponentCryptoGallery = 'component-CryptoGallery',
   ComponentCarousel = 'component-Carousel',


### PR DESCRIPTION
## Summary
- Add a reusable ColorPicker component with a default swatch trigger and palette grid.
- Add ColorPickerPalette for inline palette-only usage and export the new form component.
- Register a Developer Gallery page covering default, custom palette, custom trigger, controlled open, disabled options, palette-only, and disabled states.

## Intent & Context
The user asked to build a basic color picker component based on the provided visual reference and explicitly requested a Gallery entry. After a delegated 3-agent review, the follow-up fixes addressed disabled/open state behavior, accessibility semantics, and missing Gallery edge cases. The panel was then reduced in density, with default swatches set smaller and the palette gap changed to $0.5.

## Design Decisions
- Keep the component in packages/components so it can be reused across app surfaces without depending on kit.
- Provide both ColorPicker and ColorPickerPalette so callers can use either a Popover-backed picker or an inline palette.
- Support controlled and uncontrolled value/open states to match existing form component patterns.
- Close disabled pickers deterministically and report onOpenChange(false) for controlled callers when needed.
- Use cross-platform accessibility props, with radio/radiogroup semantics on the palette and button semantics on the default trigger.

## Changes Detail
- packages/components/src/forms/ColorPicker/index.tsx: adds the ColorPicker implementation, default palette colors, Popover integration, accessibility states, and compact panel defaults.
- packages/components/src/forms/index.ts: exports the new component.
- packages/shared/src/routes/gallery.ts: adds the ColorPicker Gallery route enum.
- packages/kit/src/views/Developer/pages/Gallery/index.tsx: lazy-loads and registers the new Gallery page.
- packages/kit/src/views/Developer/pages/Gallery/Components/stories/ColorPicker.tsx: adds examples for common and edge-case usage.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Mobile / Web / Extension UI surfaces that consume components; Developer Gallery for examples
- **Risk Areas**: Popover open-state control, cross-platform accessibility prop compatibility, and palette layout density on small screens

## Test plan
- [x] npx oxlint --tsconfig ./tsconfig.json --type-aware packages/components/src/forms/ColorPicker/index.tsx packages/components/src/forms/index.ts packages/shared/src/routes/gallery.ts packages/kit/src/views/Developer/pages/Gallery/index.tsx packages/kit/src/views/Developer/pages/Gallery/Components/stories/ColorPicker.tsx --deny-warnings
- [x] git diff --check
- [x] yarn lint:staged
- [x] yarn tsc:staged