### PR TITLE
fix: keep DeFi action dialog height stable on amount input (OK-57119)

### DIFF
--- a/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
@@ -52,6 +52,17 @@ import {
 
 const DEFAULT_ACTION_PERCENT = 100;
 const PERCENTAGE_PRESET_VALUES = [25, 50, 75, 100] as const;
+
+// Both action heroes (typed-amount and percentage) reserve this height and
+// center their content, so the Dialog stays the same size in either mode and
+// never resizes as the typed amount changes length. 128px matches the
+// percentage hero's natural height ($heading5xl value + fiat row + $6 breathing).
+const DEFI_ACTION_HERO_MIN_HEIGHT = 128;
+
+// Cap the typed-amount font to the percentage hero's $heading5xl (40px) so the
+// two heroes read as one, and so a short amount can't grow past the reserved
+// height (SendAutoSizeAmountInput otherwise ramps up to ~84px on desktop).
+const MANUAL_AMOUNT_INPUT_MAX_FONT_SIZE = 40;
 const resolveActionTxAmount = resolveDeFiActionTxAmount as (params: {
   percentageAction: boolean;
   percent?: number;
@@ -978,10 +989,15 @@ function ProtocolPositionActionPercentHero({
   const normalizedPercent = normalizeActionPercent(percent);
   // Mirror the typed-amount hero (SendAutoSizeAmountInput): no top label — the
   // Dialog.Title already carries the verb — a large centered value with the
-  // fiat at $headingLg beneath, and the same py="$6" breathing room, so the
+  // fiat at $headingLg beneath, sharing DEFI_ACTION_HERO_MIN_HEIGHT so the
   // percentage and typed-amount flows read as one hero, not two screens.
   return (
-    <YStack gap="$2" alignItems="center" py="$6">
+    <YStack
+      gap="$2"
+      alignItems="center"
+      justifyContent="center"
+      minHeight={DEFI_ACTION_HERO_MIN_HEIGHT}
+    >
       <SizableText
         size="$heading5xl"
         color="$text"
@@ -1157,7 +1173,9 @@ function ProtocolPositionActionAmountInput({
   return (
     <YStack gap="$5">
       <SendAutoSizeAmountInput
-        py="$6"
+        minHeight={DEFI_ACTION_HERO_MIN_HEIGHT}
+        justifyContent="center"
+        maxFontSize={MANUAL_AMOUNT_INPUT_MAX_FONT_SIZE}
         value={amount}
         onChange={onChangeAmount}
         tokenSymbol={symbol}
@@ -1276,12 +1294,11 @@ function ProtocolPositionActionDialogContent({
     action.action === EDeFiPositionAction.Repay;
   const manualAmountAsset = selectedAssets[0];
   // Manual entry only applies to a single fungible token; a multi-asset
-  // selection or Lido's permit withdraw keep the percentage slider.
+  // selection keeps the percentage slider. Lido's permit withdraw still uses
+  // manual amount input — the permit signature is handled at submit time and
+  // does not affect the input UI.
   const useManualAmountInput =
-    isManualAmountAction &&
-    !selectable &&
-    !isLidoProtocol(action.protocolId) &&
-    Boolean(manualAmountAsset);
+    isManualAmountAction && !selectable && Boolean(manualAmountAsset);
   const availableAmount = manualAmountAsset?.amount ?? '0';
   const amountDecimals = manualAmountAsset?.asset.meta?.decimals;
   const amountBN = new BigNumber(amount || '0');

--- a/packages/kit/src/views/Send/components/SendAutoSizeAmountInput/index.tsx
+++ b/packages/kit/src/views/Send/components/SendAutoSizeAmountInput/index.tsx
@@ -202,6 +202,9 @@ type ISendAmountAutoSizeInputProps = {
   reversible?: boolean;
   tokenSymbol?: string;
   inlineTextAlignMode?: 'auto' | 'center';
+  // Cap the display font (in px). Defaults to the full 56*scale ramp; pass a
+  // smaller value to line the amount up with a sibling hero.
+  maxFontSize?: number;
   inputProps?: Omit<IInputProps, 'value' | 'onChangeText' | 'onChange'> & {
     loading?: boolean;
   };
@@ -228,6 +231,7 @@ function SendAutoSizeAmountInputComponent(
     valueProps,
     tokenSymbol,
     inlineTextAlignMode,
+    maxFontSize: maxFontSizeProp,
     extraContent,
     onLayout,
     ...rest
@@ -349,9 +353,11 @@ function SendAutoSizeAmountInputComponent(
   const returnKeyType = inputProps?.returnKeyType;
   const onFocus = inputProps?.onFocus;
   const onBlur = inputProps?.onBlur;
-  const fontSize = getAmountFontSize(
-    effectiveValue?.length || 0,
-    fontSizeScale,
+  // Default keeps the original full-size ramp; callers can cap it (maxFontSizeProp).
+  const maxFontSize = maxFontSizeProp ?? Math.round(56 * fontSizeScale);
+  const fontSize = Math.min(
+    getAmountFontSize(effectiveValue?.length || 0, fontSizeScale),
+    maxFontSize,
   );
   const availableInlineWidth = Math.max(
     Math.floor(layoutWidth || windowWidth || 0),
@@ -359,9 +365,9 @@ function SendAutoSizeAmountInputComponent(
   );
   const isCompactInlineWidth =
     md && availableInlineWidth > 0 && availableInlineWidth < 360;
-  const maxFontSize = Math.round(56 * fontSizeScale);
-  const minFontSize = Math.round(
-    (isCompactInlineWidth ? 12 : 14) * fontSizeScale,
+  const minFontSize = Math.min(
+    Math.round((isCompactInlineWidth ? 12 : 14) * fontSizeScale),
+    maxFontSize,
   );
   const wrappedSymbolFontSize = Math.max(
     WRAPPED_SYMBOL_MIN_FONT_SIZE,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57119](https://onekeyhq.atlassian.net/browse/OK-57119)

----------

<!-- github-pr-monitor:jira-links:end -->


## What

- Fix the DeFi action dialog resizing while typing. The typed-amount hero auto-sized its font to the input length and its height tracked the font, so the whole dialog grew/shrank as the number's length changed. Cap the amount hero font to the percentage hero's size (`$heading5xl`) and share one fixed height between both heroes, so the dialog stays the same size in either mode and no longer resizes while typing.
- Switch Lido withdraw to the manual amount input (matching Morpho/Ethena) instead of the percentage slider. The permit signature is handled at submit time and does not affect the input UI.

## Changes

- `packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx`
  - Lido withdraw no longer forced onto the percentage slider.
  - Both action heroes share `DEFI_ACTION_HERO_MIN_HEIGHT` and center their content; the amount hero font is capped to `MANUAL_AMOUNT_INPUT_MAX_FONT_SIZE` (40 = `$heading5xl`).
- `packages/kit/src/views/Send/components/SendAutoSizeAmountInput/index.tsx`
  - Add optional `maxFontSize` prop (backward compatible; Send / Perp / Gallery unaffected).

## Test

- `tsc:staged` and `eslint` clean on the changed files.
- Manual (web): open a Lido / Morpho / Ethena withdraw → amount input shown; type long and short amounts and tap Max → dialog height stays constant.

## Jira

- Fixes OK-57119
- Parent OK-57014

[OK-57119]: https://onekeyhq.atlassian.net/browse/OK-57119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ