### PR TITLE
fix: align remaining trade/deposit buttons to design-system variants (OK-57256)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelFooterButtons.android.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelFooterButtons.android.tsx
@@ -63,8 +63,7 @@ function SwapPanelFooterButtons({ onTrade, onInstant }: IProps) {
           <Button
             testID={MarketTestIDs.detailBuyButton}
             size="large"
-            variant="primary"
-            bg="$buttonSuccess"
+            variant="accent"
             icon="FlashSolid"
           >
             {intl.formatMessage({ id: ETranslations.dexmarket_quick_buy })}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelFooterButtons.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelFooterButtons.tsx
@@ -26,9 +26,8 @@ function SwapPanelFooterButtons({ onTrade, onInstant }: IProps) {
       <Button
         testID={MarketTestIDs.detailBuyButton}
         size="large"
-        variant="primary"
+        variant="accent"
         flex={1}
-        bg="$buttonSuccess"
         onPress={onInstant}
         icon="FlashSolid"
       >

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/MarketPresetSelector/MarketPresetSelector.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/MarketPresetSelector/MarketPresetSelector.tsx
@@ -443,8 +443,14 @@ function parseDirectionKey(directionKey: string) {
 
 function getTradeSideActiveBackgroundColor(tradeSide: EMarketPresetTradeSide) {
   return tradeSide === EMarketPresetTradeSide.BUY
-    ? '$bgSuccessStrong'
+    ? '$bgAccent'
     : '$bgCriticalStrong';
+}
+
+function getTradeSideActiveTextColor(tradeSide: EMarketPresetTradeSide) {
+  return tradeSide === EMarketPresetTradeSide.BUY
+    ? '$textInverse'
+    : '$textOnColor';
 }
 
 function MarketPresetDialogHeader({ networkId }: { networkId?: string }) {
@@ -1215,7 +1221,7 @@ function MarketPresetSettingsDialog({
             activeBackgroundColor={getTradeSideActiveBackgroundColor(
               activeTradeSide,
             )}
-            activeTextColor="$textOnColor"
+            activeTextColor={getTradeSideActiveTextColor(activeTradeSide)}
             inactiveTextColor="$textSubdued"
             segmentControlItemStyleProps={{
               borderRadius: '$2',

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
@@ -431,15 +431,15 @@ function SpotBalanceList({
             gap="$2"
             px="$3"
             h={28}
-            bg="$brand8"
+            bg="$bgAccent"
             onPress={
               currentUser?.accountAddress
                 ? () => void showDepositWithdrawModal('deposit')
                 : undefined
             }
           >
-            <Icon name="AlignBottomOutline" size="$4" color="$iconOnColor" />
-            <SizableText size="$bodySmMedium" color="$textOnColor">
+            <Icon name="AlignBottomOutline" size="$4" color="$iconInverse" />
+            <SizableText size="$bodySmMedium" color="$textInverse">
               {intl.formatMessage({ id: ETranslations.perp_trade_deposit })}
             </SizableText>
           </Badge>

--- a/packages/kit/src/views/Perp/components/PerpMarketFooter.android.tsx
+++ b/packages/kit/src/views/Perp/components/PerpMarketFooter.android.tsx
@@ -11,7 +11,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import useAppNavigation from '../../../hooks/useAppNavigation';
 import { useHyperliquidActions } from '../../../states/jotai/contexts/hyperliquid';
 import { useActiveTradeDisplay } from '../hooks/useActiveTradeDisplay';
-import { GetTradingButtonStyleProps } from '../utils/styleUtils';
+import { getTradingButtonStyleProps } from '../utils/styleUtils';
 
 const MARKET_FOOTER_BUTTON_WIDTH = '47%';
 const MARKET_FOOTER_BUTTON_HEIGHT = 36;
@@ -34,8 +34,8 @@ function PerpMarketFooter() {
   const intl = useIntl();
   const actionsRef = useHyperliquidActions();
   const { mode } = useActiveTradeDisplay();
-  const longButtonStyle = GetTradingButtonStyleProps('long');
-  const shortButtonStyle = GetTradingButtonStyleProps('short');
+  const longButtonStyle = getTradingButtonStyleProps('long');
+  const shortButtonStyle = getTradingButtonStyleProps('short');
   const navigation = useAppNavigation();
 
   const buyText = intl.formatMessage({

--- a/packages/kit/src/views/Perp/components/PerpMarketFooter.tsx
+++ b/packages/kit/src/views/Perp/components/PerpMarketFooter.tsx
@@ -7,7 +7,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { useHyperliquidActions } from '../../../states/jotai/contexts/hyperliquid';
 import { useActiveTradeDisplay } from '../hooks/useActiveTradeDisplay';
-import { GetTradingButtonStyleProps } from '../utils/styleUtils';
+import { getTradingButtonStyleProps } from '../utils/styleUtils';
 
 const MARKET_FOOTER_BUTTON_HEIGHT = 36;
 const MARKET_FOOTER_BUTTON_TEXT_LINE_HEIGHT = 20;
@@ -16,8 +16,8 @@ function PerpMarketFooter() {
   const intl = useIntl();
   const actionsRef = useHyperliquidActions();
   const { mode } = useActiveTradeDisplay();
-  const longButtonStyle = GetTradingButtonStyleProps('long');
-  const shortButtonStyle = GetTradingButtonStyleProps('short');
+  const longButtonStyle = getTradingButtonStyleProps('long');
+  const shortButtonStyle = getTradingButtonStyleProps('short');
 
   const buyText = intl.formatMessage({
     id:

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
@@ -277,7 +277,7 @@ function DepositButton() {
   // neutral material. Off iOS 26 (every other platform) this stays the original
   // solid Badge.
   const glassActive = isLiquidGlassAvailable();
-  const nonGlassBg = isEmptyAccount ? '$brand8' : '$bgStrong';
+  const nonGlassBg = isEmptyAccount ? '$bgAccent' : '$bgStrong';
   const badge = (
     <Badge
       borderRadius="$full"
@@ -312,8 +312,8 @@ function DepositButton() {
         if (isEmptyAccount) {
           return (
             <>
-              <Icon name="AlignBottomOutline" size="$4" color="$iconOnColor" />
-              <SizableText size="$bodySmMedium" color="$textOnColor">
+              <Icon name="AlignBottomOutline" size="$4" color="$iconInverse" />
+              <SizableText size="$bodySmMedium" color="$textInverse">
                 {intl.formatMessage({ id: ETranslations.perp_trade_deposit })}
               </SizableText>
             </>
@@ -341,7 +341,7 @@ function DepositButton() {
       isInteractive
       glassEffectStyle="regular"
       // Deposit CTA → green-tinted glass; balance/unknown → neutral glass.
-      {...(isEmptyAccount && { tintColor: theme.brand8?.val })}
+      {...(isEmptyAccount && { tintColor: theme.bgAccent?.val })}
       style={depositGlassStyle}
     >
       {badge}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -40,7 +40,7 @@ import { useTradingPrice } from '../../../hooks/useTradingPrice';
 import { PerpsAccountSelectorProviderMirror } from '../../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
 import {
-  GetTradingButtonStyleProps,
+  getTradingButtonStyleProps,
   getTradingSideTextColor,
 } from '../../../utils/styleUtils';
 import { getTifLabel } from '../../../utils/timeInForce';
@@ -216,7 +216,7 @@ function OrderConfirmContent({
         setOnekeyFee(fee ?? 0);
       });
   }, []);
-  const buttonStyleProps = GetTradingButtonStyleProps(effectiveSide, false);
+  const buttonStyleProps = getTradingButtonStyleProps(effectiveSide, false);
   const intl = useIntl();
 
   const isTriggerMode = formData.orderMode === 'trigger';

--- a/packages/kit/src/views/Perp/utils/styleUtils.ts
+++ b/packages/kit/src/views/Perp/utils/styleUtils.ts
@@ -1,12 +1,7 @@
-import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
-
 import type { ColorTokens } from 'tamagui';
 
 export type ITradeSide = 'long' | 'short';
 
-/**
- * Get trading button style props based on side and disabled state
- */
 export const PERP_TRADE_BUTTON_COLORS = {
   light: {
     long: '#008236',
@@ -26,17 +21,44 @@ export const PERP_TRADE_BUTTON_COLORS = {
   },
 };
 
-export function GetTradingButtonStyleProps(side: ITradeSide, disabled = false) {
-  const themeVariant = useThemeVariant();
-  const isLong = side === 'long';
-  const colors = PERP_TRADE_BUTTON_COLORS[themeVariant];
+interface ITradingButtonStyleProps {
+  bg: ColorTokens;
+  hoverStyle: { bg: ColorTokens };
+  pressStyle: { bg: ColorTokens };
+  textColor: ColorTokens;
+}
 
-  return {
-    bg: colors[isLong ? 'long' : 'short'],
-    hoverStyle: { bg: colors[isLong ? 'longHover' : 'shortHover'] },
-    pressStyle: { bg: colors[isLong ? 'longPress' : 'shortPress'] },
-    textColor: (disabled ? '$textDisabled' : '$textOnColor') as ColorTokens,
+// Long = design-system "accent", short = "destructive". These semantic tokens
+// are theme-aware (same rationale as TradingButtonGroup's
+// PERP_SIDE_BUTTON_STYLES), so no light/dark branching is needed. Frozen
+// module-level constants keep the returned reference stable across renders, so
+// consumers that memoize on it (e.g. PerpMarketFooter.android) don't rebuild
+// their button subtrees on every render.
+const TRADING_BUTTON_STYLE_PROPS: Record<ITradeSide, ITradingButtonStyleProps> =
+  {
+    long: {
+      bg: '$bgAccent',
+      hoverStyle: { bg: '$bgAccentHover' },
+      pressStyle: { bg: '$bgAccentActive' },
+      textColor: '$textInverse',
+    },
+    short: {
+      bg: '$bgCriticalStrong',
+      hoverStyle: { bg: '$bgCriticalStrongHover' },
+      pressStyle: { bg: '$bgCriticalStrongActive' },
+      textColor: '$textOnColor',
+    },
   };
+
+/**
+ * Get trading button style props based on side and disabled state.
+ */
+export function getTradingButtonStyleProps(
+  side: ITradeSide,
+  disabled = false,
+): ITradingButtonStyleProps {
+  const styles = TRADING_BUTTON_STYLE_PROPS[side];
+  return disabled ? { ...styles, textColor: '$textDisabled' } : styles;
 }
 
 export function getTradingSideTextColor(

--- a/packages/kit/src/views/Swap/pages/components/SwapProActionButton.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProActionButton.tsx
@@ -483,34 +483,30 @@ const SwapProActionButton = ({
     inputAmount,
   ]);
 
+  const isBuy = swapProDirection === ESwapDirection.BUY;
+  // Match the design-system accent (buy) / destructive (sell) buttons. The
+  // accent variant labels use $textInverse, destructive uses $textOnColor;
+  // childrenAsText is false, so the label color must be set explicitly.
+  const labelColor = isBuy ? '$textInverse' : '$textOnColor';
+
   return (
     <Button
       testID="swap-sub-value-btn"
       disabled={actionButtonDisabled}
       onPress={debouncedOnSwapProActionClick}
-      variant="primary"
+      variant={isBuy ? 'accent' : 'destructive'}
       size="small"
       childrenAsText={false}
-      color="$textOnColor"
       py={5}
-      backgroundColor={
-        swapProDirection === ESwapDirection.BUY
-          ? '$bgSuccessStrong'
-          : '$bgCriticalStrong'
-      }
     >
       <YStack alignItems="center">
-        <SizableText
-          size="$bodyMdMedium"
-          color="$textOnColor"
-          textAlign="center"
-        >
+        <SizableText size="$bodyMdMedium" color={labelColor} textAlign="center">
           {actionButtonText.resValue}
         </SizableText>
         {actionButtonText.subValue ? (
           <SizableText
             size="$bodyMdMedium"
-            color="$textOnColor"
+            color={labelColor}
             textAlign="center"
           >
             {actionButtonText.subValue}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57256](https://onekeyhq.atlassian.net/browse/OK-57256)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

Follow-up to #12238. That PR aligned several buy/trade/deposit buttons to the design-system `accent` (buy/long) / `destructive` (sell/short) Button variants and semantic color tokens; this PR covers the surfaces it missed, as reported in [OK-57256](https://onekeyhq.atlassian.net/browse/OK-57256).

## Changes

- **Perps mobile chart footer** (`PerpMarketFooter`, iOS/web + Android) — Buy/Long & Sell/Short now use `$bgAccent` / `$bgCriticalStrong` semantic tokens via `getTradingButtonStyleProps`. Because that helper is shared, the **Perps Order Confirm dialog** confirm button is unified in the same pass.
- **Perps Deposit buttons** — the Holdings list badge (`SpotBalanceList`) and the empty-account CTA + iOS-26 Liquid Glass tint (`PerpsHeaderRight`) now use `$bgAccent`, matching the accent Buy/Long button (previously the muted `$brand8`).
- **Market mobile chart "Quick buy" footer** (`SwapPanelFooterButtons`, iOS/web + Android) — `variant="accent"`, dropping the hand-rolled `$buttonSuccess` background.
- **Swap Pro-mode order button** (`SwapProActionButton`) — `accent` (buy) / `destructive` (sell) variant with matching label colors, replacing the hand-rolled `$bgSuccessStrong` / `$bgCriticalStrong` override.
- **Swap "Edit preset" Buy/Sell segment** (`MarketPresetSelector`) — accent active background + `$textInverse` active label, matching `TradeTypeSelector`.

## Refactor / cleanup

- `getTradingButtonStyleProps` no longer branches on `useThemeVariant`; it returns theme-aware semantic tokens from stable module-level constants (mirrors `TradingButtonGroup`'s pattern), which also fixes a defeated `useMemo` in the Android footer.
- Renamed from the former hook-style `GetTradingButtonStyleProps` (it is no longer a hook) and dropped a dead `color` prop on the Pro-mode Button.

## Testing

- `yarn tsc:staged` — passing
- `yarn lint:staged` — 0 warnings / 0 errors

Visual verification on device recommended (dark + light mode) for the Perps chart footer, Deposit buttons, Market quick-buy, Swap Pro-mode order button, and the Edit-preset segment.


[OK-57256]: https://onekeyhq.atlassian.net/browse/OK-57256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ