### PR TITLE
feat: improve gas sponsorship and perps ui

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -23,7 +23,6 @@ import {
   useTheme,
   useThemeName,
 } from '@onekeyhq/components';
-import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import { useActiveTradeInstrumentAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { useSpotActiveAssetCtxAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -48,7 +47,6 @@ import {
   isPerpsMobileLayoutTraceRectChanged,
   tracePerpsMobileLayout,
 } from '../../utils/mobileLayoutTrace';
-import { PERP_TRADE_BUTTON_COLORS } from '../../utils/styleUtils';
 
 import {
   DepthBar,
@@ -536,21 +534,14 @@ const useTextColor = () => {
 };
 
 const useSideRatioColors = () => {
-  const themeName = useThemeName();
-  const themeVariant = useThemeVariant();
+  const theme = useTheme();
 
   return useMemo(() => {
     return {
-      long:
-        themeVariant === 'light'
-          ? PERP_TRADE_BUTTON_COLORS.light.long
-          : colorTokens[themeName].green.green8,
-      short:
-        themeVariant === 'light'
-          ? colorTokens[themeName].red.red11
-          : colorTokens[themeName].red.red8,
+      long: theme.bgAccent.val,
+      short: theme.bgCriticalStrong.val,
     };
-  }, [themeName, themeVariant]);
+  }, [theme.bgAccent.val, theme.bgCriticalStrong.val]);
 };
 
 const useSpreadColor = () => {

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
@@ -369,12 +369,8 @@ function SpotBalanceList({
       return ListHeaderComponent ?? null;
     }
 
-    const accountValue = computedValue.isLoading
-      ? '--'
-      : (computedValue.accountValue ?? '0');
-    const availableValue = computedValue.isLoading
-      ? '--'
-      : (computedValue.withdrawable ?? '0');
+    const accountValue = computedValue.accountValue ?? '0';
+    const availableValue = computedValue.withdrawable ?? '0';
 
     return (
       <>
@@ -505,7 +501,6 @@ function SpotBalanceList({
   }, [
     ListHeaderComponent,
     computedValue.accountValue,
-    computedValue.isLoading,
     computedValue.withdrawable,
     currentUser?.accountAddress,
     intl,

--- a/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
+++ b/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
@@ -65,6 +65,8 @@ const WIN_RATE_TOOLTIP_MAP: Record<IPortfolioTimePeriod, ETranslations> = {
   allTime: ETranslations.perp_portfolio_win_rate_tooltip_all_time__desc,
 };
 
+const MOBILE_TIME_PERIOD_ITEM_MIN_WIDTH = 36;
+
 // Time period and chart type options are built inside the component using intl
 
 function formatPercent(value: number | null | undefined): string {
@@ -378,7 +380,12 @@ function PerpPortfolioContentComponent({
       timePeriodOptions.map((option) => ({
         ...option,
         label: (
-          <XStack height={20} alignItems="center" justifyContent="center">
+          <XStack
+            height={20}
+            minWidth={MOBILE_TIME_PERIOD_ITEM_MIN_WIDTH}
+            alignItems="center"
+            justifyContent="center"
+          >
             <SizableText
               size="$bodySmMedium"
               color={timePeriod === option.value ? '$textInverse' : '$text'}
@@ -703,8 +710,10 @@ function PerpPortfolioContentComponent({
               value={timePeriod}
               onChange={handleTimePeriodChange}
               options={mobileTimePeriodOptions}
+              flexShrink={0}
               segmentControlItemStyleProps={{
-                px: '$2.5',
+                minWidth: MOBILE_TIME_PERIOD_ITEM_MIN_WIDTH,
+                px: '$2',
                 py: '$1',
               }}
             />
@@ -1161,13 +1170,13 @@ function PerpPortfolioContentComponent({
               <>
                 <XStack
                   flex={winRateProgress}
-                  bg="$green9"
+                  bg="$bgAccent"
                   borderTopLeftRadius="$full"
                   borderBottomLeftRadius="$full"
                 />
                 <XStack
                   flex={100 - winRateProgress}
-                  bg="$red9"
+                  bg="$bgCriticalStrong"
                   borderTopRightRadius="$full"
                   borderBottomRightRadius="$full"
                 />

--- a/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
+++ b/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
@@ -144,13 +144,15 @@ function TradingGuardWrapperInternal({
   if (perpsAccountStatus.accountNotSupport) {
     return (
       <Button
-        variant="primary"
+        variant="secondary"
         size={buttonSize}
         disabled
+        disabledStyle={{ opacity: 1 }}
+        bg="$bgDisabled"
         childrenAsText={false}
         testID="perp-is-disabled-btn"
       >
-        <SizableText size="$bodyMdMedium" color="$textOnColor">
+        <SizableText size="$bodyMdMedium" color="$textDisabled">
           {intl.formatMessage({
             id: ETranslations.perp_trade_button_account_unsupported,
           })}

--- a/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingButton.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingButton.tsx
@@ -8,7 +8,6 @@ import type { IButtonProps } from '@onekeyhq/components';
 import { Button, SizableText, Toast, resetToRoute } from '@onekeyhq/components';
 import { AccountSelectorCreateAddressButton } from '@onekeyhq/kit/src/components/AccountSelector/AccountSelectorCreateAddressButton';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
-import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import { useSelectedAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import type { ITradingFormData } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
@@ -34,7 +33,7 @@ import { useShowDepositWithdrawModal } from '../../hooks/useShowDepositWithdrawM
 import { useTradingPrice } from '../../hooks/useTradingPrice';
 import { PerpTestIDs } from '../../testIDs';
 import { shouldBlockPerpsTradingForMarketData } from '../../utils/perpsMarketDataFreshness';
-import { PERP_TRADE_BUTTON_COLORS } from '../../utils/styleUtils';
+import { getTradingButtonStyleValues } from '../../utils/styleUtils';
 
 const sharedButtonProps = {
   size: 'medium',
@@ -83,7 +82,6 @@ export function PerpTradingButton({
   const marketDataFreshness = usePerpsMarketDataFreshness();
   const shouldBlockForMarketData =
     shouldBlockPerpsTradingForMarketData(marketDataFreshness);
-  const themeVariant = useThemeVariant();
   const isSpot = tradingMode === 'spot';
 
   const handleConnectWallet = useCallback(async () => {
@@ -179,36 +177,15 @@ export function PerpTradingButton({
 
   const isLong = useMemo(() => formData.side === 'long', [formData.side]);
   const buttonStyles = useMemo(() => {
-    const colors = PERP_TRADE_BUTTON_COLORS;
-    const getBgColor = () => {
-      if (isAccountLoading) return undefined;
-
-      return themeVariant === 'light'
-        ? colors.light[isLong ? 'long' : 'short']
-        : colors.dark[isLong ? 'long' : 'short'];
-    };
-
-    const getHoverBgColor = () => {
-      if (isAccountLoading) return undefined;
-      return themeVariant === 'light'
-        ? colors.light[isLong ? 'longHover' : 'shortHover']
-        : colors.dark[isLong ? 'longHover' : 'shortHover'];
-    };
-
-    const getPressBgColor = () => {
-      if (isAccountLoading) return undefined;
-      return themeVariant === 'light'
-        ? colors.light[isLong ? 'longPress' : 'shortPress']
-        : colors.dark[isLong ? 'longPress' : 'shortPress'];
-    };
+    const styles = getTradingButtonStyleValues(isLong ? 'long' : 'short');
 
     return {
-      bg: getBgColor(),
-      hoverBg: getHoverBgColor(),
-      pressBg: getPressBgColor(),
+      bg: isAccountLoading ? undefined : styles.bg,
+      hoverBg: isAccountLoading ? undefined : styles.hoverBg,
+      pressBg: isAccountLoading ? undefined : styles.pressBg,
       textColor: '$textOnColor',
     };
-  }, [isAccountLoading, isLong, themeVariant]);
+  }, [isAccountLoading, isLong]);
 
   const createAddressButtonRender = useCallback(
     (props: IButtonProps) => (

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/AccountModeModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/AccountModeModal.tsx
@@ -37,6 +37,7 @@ const ACCOUNT_MODE_OPTIONS: {
   learnMore?: boolean;
   modeIcon: 'single' | 'portfolio';
   recommended?: boolean;
+  requirement?: ETranslations;
   value: IPerpsAccountModeOption;
 }[] = [
   {
@@ -51,6 +52,7 @@ const ACCOUNT_MODE_OPTIONS: {
     label: ETranslations.perp_portfolio_margin__title,
     learnMore: true,
     modeIcon: 'portfolio',
+    requirement: ETranslations.perp_portfolio_margin_requirement__msg,
     value: EHyperLiquidAbstractionMode.PORTFOLIO_MARGIN,
   },
 ];
@@ -131,6 +133,7 @@ function AccountModeOption({
   modeIcon,
   onPress,
   recommended,
+  requirement,
 }: {
   desc: ETranslations;
   isSelected: boolean;
@@ -139,11 +142,22 @@ function AccountModeOption({
   modeIcon: 'single' | 'portfolio';
   onPress: () => void;
   recommended?: boolean;
+  requirement?: ETranslations;
 }) {
   const intl = useIntl();
   const handleLearnMorePress = useCallback(() => {
     openUrlExternal(PORTFOLIO_MARGIN_LEARN_MORE_URL);
   }, []);
+  const learnMoreText = learnMore ? (
+    <SizableText
+      size="$bodySm"
+      color="$textInfo"
+      textDecorationLine="underline"
+      onPress={handleLearnMorePress}
+    >
+      {intl.formatMessage({ id: ETranslations.global_learn_more })}
+    </SizableText>
+  ) : null;
 
   return (
     <YStack
@@ -177,20 +191,15 @@ function AccountModeOption({
           </XStack>
           <SizableText size="$bodySm" color="$textSubdued">
             {intl.formatMessage({ id: desc })}
-            {learnMore ? (
-              <>
-                {' '}
-                <SizableText
-                  size="$bodySm"
-                  color="$textSubdued"
-                  textDecorationLine="underline"
-                  onPress={handleLearnMorePress}
-                >
-                  {intl.formatMessage({ id: ETranslations.global_learn_more })}
-                </SizableText>
-              </>
-            ) : null}
           </SizableText>
+          {requirement ? (
+            <SizableText size="$bodySm" color="$textSubdued">
+              {intl.formatMessage({ id: requirement })}
+              {learnMore ? <> {learnMoreText}</> : null}
+            </SizableText>
+          ) : (
+            learnMoreText
+          )}
         </YStack>
       </XStack>
     </YStack>
@@ -267,36 +276,9 @@ function AccountModeContent({
           modeIcon={option.modeIcon}
           onPress={() => setSelectedMode(option.value)}
           recommended={option.recommended}
+          requirement={option.requirement}
         />
       ))}
-      {selectedMode === EHyperLiquidAbstractionMode.PORTFOLIO_MARGIN ? (
-        <XStack
-          p="$3"
-          borderRadius="$3"
-          bg="$bgStrong"
-          gap="$2"
-          alignItems="flex-start"
-        >
-          <XStack
-            w={14}
-            h={14}
-            borderRadius="$full"
-            bg="$iconDisabled"
-            alignItems="center"
-            justifyContent="center"
-            mt="$0.5"
-          >
-            <SizableText size="$bodySmMedium" color="$bg" lineHeight={14}>
-              i
-            </SizableText>
-          </XStack>
-          <SizableText size="$bodySm" color="$textSubdued" flex={1}>
-            {intl.formatMessage({
-              id: ETranslations.perp_portfolio_margin_requirement__msg,
-            })}
-          </SizableText>
-        </XStack>
-      ) : null}
       <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
         <Button
           testID="perp-account-mode-confirm-button"

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
@@ -20,7 +20,6 @@ import type { IButtonProps } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { AccountSelectorCreateAddressButton } from '@onekeyhq/kit/src/components/AccountSelector/AccountSelectorCreateAddressButton';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
-import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import { useSelectedAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import {
   type IBBOPriceMode,
@@ -84,7 +83,7 @@ import { shouldApplyMinimumOrderGuard } from '../../../utils/minimumOrderGuard';
 import { shouldBlockPerpsTradingForMarketData } from '../../../utils/perpsMarketDataFreshness';
 import { resolveTpSlTriggerPx } from '../../../utils/resolveTpSlTriggerPx';
 import {
-  PERP_TRADE_BUTTON_COLORS,
+  getTradingButtonStyleValues,
   getTradingSideTextColor,
 } from '../../../utils/styleUtils';
 import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../../PerpDialogLayout';
@@ -147,7 +146,6 @@ export function LimitOrderForm({
   const intl = useIntl();
   const navigation = useAppNavigation();
   const { selectedAccount } = useSelectedAccount({ num: 0 });
-  const themeVariant = useThemeVariant();
 
   const [perpsAccount] = usePerpsActiveAccountAtom();
   const [activeAsset] = usePerpsActiveAssetAtom();
@@ -901,11 +899,6 @@ export function LimitOrderForm({
     ],
   );
 
-  const longColors =
-    themeVariant === 'light'
-      ? PERP_TRADE_BUTTON_COLORS.light
-      : PERP_TRADE_BUTTON_COLORS.dark;
-
   const createActionButtonRender = useCallback(
     (props: IButtonProps) => (
       <Button
@@ -997,6 +990,14 @@ export function LimitOrderForm({
     isTradingActionLoading,
     shouldDisableAccountActionButtons,
   ]);
+  const reduceOnlyLabel = intl.formatMessage({
+    id: ETranslations.perps_reduce_only,
+  });
+  const reduceOnlyTooltip = intl.formatMessage({
+    id: ETranslations.perp_reduce_only__desc,
+  });
+  const longButtonStyles = getTradingButtonStyleValues('long');
+  const shortButtonStyles = getTradingButtonStyleValues('short');
 
   return (
     <YStack gap="$2.5">
@@ -1112,24 +1113,26 @@ export function LimitOrderForm({
       {!isSpot ? (
         <>
           {/* Reduce-only (perps only), mirroring the standard order panel. */}
-          <XStack alignItems="center" mb="$2">
+          <XStack alignItems="center" gap="$2" mb="$2">
             <Checkbox
               testID="chart-limit-reduce-only-checkbox"
               value={reduceOnly}
               onChange={(checked) => setReduceOnly(!!checked)}
-              label={intl.formatMessage({
-                id: ETranslations.perps_reduce_only,
-              })}
               containerProps={{
                 p: 0,
                 alignItems: 'center',
                 cursor: 'pointer',
               }}
-              labelProps={{
-                size: '$bodyMd',
-                color: '$text',
-              }}
             />
+            <DashText
+              size="$bodyMd"
+              dashColor="$textDisabled"
+              dashThickness={0.5}
+              tooltip={reduceOnlyTooltip}
+              tooltipTitle={reduceOnlyLabel}
+            >
+              {reduceOnlyLabel}
+            </DashText>
           </XStack>
 
           {/* TP/SL */}
@@ -1223,9 +1226,9 @@ export function LimitOrderForm({
           <YStack flex={1} gap="$2">
             {renderActionButton({
               sideKey: 'long',
-              bg: longColors.long,
-              hoverBg: longColors.longHover,
-              pressBg: longColors.longPress,
+              bg: longButtonStyles.bg,
+              hoverBg: longButtonStyles.hoverBg,
+              pressBg: longButtonStyles.pressBg,
               defaultText: intl.formatMessage({
                 id: isSpot
                   ? ETranslations.dexmarket_details_transactions_buy
@@ -1291,9 +1294,9 @@ export function LimitOrderForm({
           <YStack flex={1} gap="$2">
             {renderActionButton({
               sideKey: 'short',
-              bg: longColors.short,
-              hoverBg: longColors.shortHover,
-              pressBg: longColors.shortPress,
+              bg: shortButtonStyles.bg,
+              hoverBg: shortButtonStyles.hoverBg,
+              pressBg: shortButtonStyles.pressBg,
               defaultText: intl.formatMessage({
                 id: isSpot
                   ? ETranslations.dexmarket_details_transactions_sell

--- a/packages/kit/src/views/Perp/components/TradingPanel/selectors/TradeSideToggle.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/selectors/TradeSideToggle.tsx
@@ -4,13 +4,12 @@ import { memo, useCallback } from 'react';
 import { useIntl } from 'react-intl';
 
 import { SegmentControl, SizableText, XStack } from '@onekeyhq/components';
-import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { PerpTestIDs } from '../../../testIDs';
 import {
   type ITradeSide,
-  PERP_TRADE_BUTTON_COLORS,
+  getTradingButtonStyleValues,
 } from '../../../utils/styleUtils';
 
 export type ISide = ITradeSide;
@@ -47,43 +46,32 @@ export const TradeSideToggle = memo<ITradeSideToggleProps>(
     const intl = useIntl();
     const isLongActive = value === 'long';
     const isShortActive = value === 'short';
-    const themeVariant = useThemeVariant();
+    const longStyles = getTradingButtonStyleValues('long');
+    const shortStyles = getTradingButtonStyleValues('short');
     const getLongBgColor = () => {
       if (!isLongActive) return '$transparent';
-      return themeVariant === 'light'
-        ? PERP_TRADE_BUTTON_COLORS.light.long
-        : PERP_TRADE_BUTTON_COLORS.dark.long;
+      return longStyles.bg;
     };
 
     const getShortBgColor = () => {
       if (!isShortActive) return '$transparent';
-      return themeVariant === 'light'
-        ? PERP_TRADE_BUTTON_COLORS.light.short
-        : PERP_TRADE_BUTTON_COLORS.dark.short;
+      return shortStyles.bg;
     };
     const getLongHoverBgColor = () => {
       if (!isLongActive) return undefined;
-      return themeVariant === 'light'
-        ? PERP_TRADE_BUTTON_COLORS.light.longHover
-        : PERP_TRADE_BUTTON_COLORS.dark.longHover;
+      return longStyles.hoverBg;
     };
     const getLongPressBgColor = () => {
       if (!isLongActive) return undefined;
-      return themeVariant === 'light'
-        ? PERP_TRADE_BUTTON_COLORS.light.longPress
-        : PERP_TRADE_BUTTON_COLORS.dark.longPress;
+      return longStyles.pressBg;
     };
     const getShortHoverBgColor = () => {
       if (!isShortActive) return undefined;
-      return themeVariant === 'light'
-        ? PERP_TRADE_BUTTON_COLORS.light.shortHover
-        : PERP_TRADE_BUTTON_COLORS.dark.shortHover;
+      return shortStyles.hoverBg;
     };
     const getShortPressBgColor = () => {
       if (!isShortActive) return undefined;
-      return themeVariant === 'light'
-        ? PERP_TRADE_BUTTON_COLORS.light.shortPress
-        : PERP_TRADE_BUTTON_COLORS.dark.shortPress;
+      return shortStyles.pressBg;
     };
     const longHoverBgColor = getLongHoverBgColor();
     const longPressBgColor = getLongPressBgColor();

--- a/packages/kit/src/views/Perp/utils/styleUtils.ts
+++ b/packages/kit/src/views/Perp/utils/styleUtils.ts
@@ -2,25 +2,6 @@ import type { ColorTokens } from 'tamagui';
 
 export type ITradeSide = 'long' | 'short';
 
-export const PERP_TRADE_BUTTON_COLORS = {
-  light: {
-    long: '#008236',
-    longHover: '#016630',
-    longPress: '#0D542B',
-    short: '$red11',
-    shortHover: '#9C2125',
-    shortPress: '#72181B',
-  },
-  dark: {
-    long: '$green8',
-    longHover: '$green7',
-    longPress: '$green6',
-    short: '$red8',
-    shortHover: '$red7',
-    shortPress: '$red6',
-  },
-};
-
 interface ITradingButtonStyleProps {
   bg: ColorTokens;
   hoverStyle: { bg: ColorTokens };
@@ -59,6 +40,23 @@ export function getTradingButtonStyleProps(
 ): ITradingButtonStyleProps {
   const styles = TRADING_BUTTON_STYLE_PROPS[side];
   return disabled ? { ...styles, textColor: '$textDisabled' } : styles;
+}
+
+export function getTradingButtonStyleValues(
+  side: ITradeSide,
+  disabled = false,
+) {
+  const styles = getTradingButtonStyleProps(side, disabled);
+  return {
+    bg: styles.bg,
+    hoverBg: styles.hoverStyle.bg,
+    pressBg: styles.pressStyle.bg,
+    textColor: styles.textColor,
+  };
+}
+
+export function GetTradingButtonStyleProps(side: ITradeSide, disabled = false) {
+  return getTradingButtonStyleProps(side, disabled);
 }
 
 export function getTradingSideTextColor(

--- a/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
@@ -2159,7 +2159,7 @@ function TxFeeInfo(props: IProps) {
           >
             {sponsoredSummaryTitle}
           </DashText>
-          <SizableText size="$bodyMd" color="$text">
+          <SizableText size="$headingSm" color="$textInteractive">
             {sponsoredSummaryDescription}
           </SizableText>
         </Stack>

--- a/packages/kit/src/views/Swap/components/PreSwapInfoGroup.tsx
+++ b/packages/kit/src/views/Swap/components/PreSwapInfoGroup.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import BigNumber from 'bignumber.js';
 import { isNil } from 'lodash';
@@ -6,6 +6,8 @@ import { useIntl } from 'react-intl';
 
 import {
   Badge,
+  Button,
+  Dialog,
   Icon,
   Image,
   NumberSizeableText,
@@ -18,6 +20,7 @@ import {
 } from '@onekeyhq/components';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import {
   ESwapNetworkFeeLevel,
   type ISwapPreSwapData,
@@ -28,6 +31,13 @@ import { useSwapStepNetFeeLevelAtom } from '../../../states/jotai/contexts/swap'
 import PreSwapInfoItem from './PreSwapInfoItem';
 
 export const SWAP_REVIEW_CUSTOM_NETWORK_FEE_VALUE = 'CUSTOM' as const;
+
+const SPONSORED_COUPON_INFO_WIDTH = 56;
+const SPONSORED_COUPON_SEPARATOR_STROKE = 2;
+const SPONSORED_COUPON_CUTOUT_SIZE = 18;
+const SPONSORED_COUPON_CUTOUT_OFFSET = SPONSORED_COUPON_CUTOUT_SIZE / 2;
+const SPONSORED_FEES_HELP_CENTER_URL =
+  'https://help.onekey.so/articles/14994693';
 
 export type ISwapReviewNetworkFeeSelectValue =
   | ESwapNetworkFeeLevel
@@ -134,23 +144,184 @@ const PreSwapInfoGroup = ({
     return '-';
   }, [activeNetworkFeeSelectValue, customNetworkFeeOptionLabel, intl]);
 
-  // Show the sponsorship badge only when estimate-fee actually confirmed Gas
-  // Account eligibility (carried on the estimated gasInfo). The quote/build-tx
-  // `gasAccountEnabled` flag alone is just a pre-check and is not sufficient.
+  // Show the sponsorship badge only when estimate-fee actually confirmed
+  // sponsorship. The quote/build-tx `gasAccountEnabled` flag alone is just a
+  // pre-check and is not sufficient.
   const isGasSponsored = useMemo(
     () =>
       !!preSwapData.netWorkFee?.gasInfos?.some(
-        (item) => item.gasInfo.gasAccountEligible,
+        (item) =>
+          item.gasInfo.gasAccountEligible ||
+          item.gasInfo.megafuelEligible?.sponsorable ||
+          item.gasInfo.payer === 'megafuel',
       ),
     [preSwapData.netWorkFee?.gasInfos],
   );
+
+  const handleOpenSponsoredFeesHelpCenter = useCallback(() => {
+    openUrlExternal(SPONSORED_FEES_HELP_CENTER_URL);
+  }, []);
+
+  const renderSponsoredCoupon = useCallback(
+    () => (
+      <Stack position="relative" alignSelf="stretch">
+        <XStack overflow="hidden" borderRadius="$5" bg="$brand3">
+          <XStack
+            flex={1}
+            px="$3.5"
+            py="$3"
+            gap="$3"
+            alignItems="center"
+            minWidth={0}
+          >
+            <Stack
+              width={42}
+              height={42}
+              borderRadius="$full"
+              bg="$brand9"
+              alignItems="center"
+              justifyContent="center"
+              flexShrink={0}
+            >
+              <Icon name="GiftSolid" size="$4.5" color="$iconOnColor" />
+            </Stack>
+            <Stack flex={1} minWidth={0} gap="$1">
+              <SizableText size="$headingMd" color="$text" numberOfLines={1}>
+                {intl.formatMessage({
+                  id: ETranslations.wallet_zero_network_fee__title,
+                })}
+              </SizableText>
+              <SizableText
+                size="$bodySmMedium"
+                color="$textSubdued"
+                numberOfLines={1}
+              >
+                {intl.formatMessage({
+                  id: ETranslations.wallet_sponsored_by_onekey__title,
+                })}
+              </SizableText>
+            </Stack>
+          </XStack>
+          <Stack
+            width={SPONSORED_COUPON_INFO_WIDTH}
+            position="relative"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <Stack
+              position="absolute"
+              left={-(SPONSORED_COUPON_SEPARATOR_STROKE / 2)}
+              top="$3"
+              bottom="$3"
+              borderLeftWidth={SPONSORED_COUPON_SEPARATOR_STROKE}
+              borderStyle="dashed"
+              borderColor="$borderSubdued"
+              opacity={0.52}
+            />
+            <Stack
+              width={28}
+              height={28}
+              borderRadius="$full"
+              alignItems="center"
+              justifyContent="center"
+              cursor="pointer"
+              onPress={handleOpenSponsoredFeesHelpCenter}
+              hoverStyle={{ opacity: 0.72 }}
+              pressStyle={{ opacity: 0.56 }}
+            >
+              <Icon name="InfoCircleOutline" size="$4.5" color="$iconSubdued" />
+            </Stack>
+          </Stack>
+        </XStack>
+        <Stack
+          position="absolute"
+          right={SPONSORED_COUPON_INFO_WIDTH - SPONSORED_COUPON_CUTOUT_OFFSET}
+          top={-SPONSORED_COUPON_CUTOUT_OFFSET}
+          width={SPONSORED_COUPON_CUTOUT_SIZE}
+          height={SPONSORED_COUPON_CUTOUT_SIZE}
+          borderRadius="$full"
+          bg="$bg"
+          pointerEvents="none"
+        />
+        <Stack
+          position="absolute"
+          right={SPONSORED_COUPON_INFO_WIDTH - SPONSORED_COUPON_CUTOUT_OFFSET}
+          bottom={-SPONSORED_COUPON_CUTOUT_OFFSET}
+          width={SPONSORED_COUPON_CUTOUT_SIZE}
+          height={SPONSORED_COUPON_CUTOUT_SIZE}
+          borderRadius="$full"
+          bg="$bg"
+          pointerEvents="none"
+        />
+      </Stack>
+    ),
+    [handleOpenSponsoredFeesHelpCenter, intl],
+  );
+
+  const handleShowSponsoredInfo = useCallback(() => {
+    const dialogInstance = Dialog.show({
+      title: intl.formatMessage({
+        id: ETranslations.wallet_fee_sponsorship__title,
+      }),
+      showFooter: false,
+      showCancelButton: false,
+      renderContent: (
+        <Stack gap="$4">
+          {renderSponsoredCoupon()}
+          <Stack px="$1" gap="$3">
+            <SizableText size="$bodySm" color="$textSubdued">
+              {intl.formatMessage({
+                id: ETranslations.wallet_sponsorship_availability_rules__desc,
+              })}
+            </SizableText>
+            <SizableText size="$bodySm" color="$textSubdued">
+              {intl.formatMessage({
+                id: ETranslations.wallet_sponsored_tx_confirmation_may_take_longer__desc,
+              })}
+            </SizableText>
+            <SizableText
+              size="$bodySmMedium"
+              color="$text"
+              textDecorationLine="underline"
+              cursor="pointer"
+              alignSelf="flex-start"
+              hoverStyle={{ opacity: 0.8 }}
+              pressStyle={{ opacity: 0.7 }}
+              onPress={handleOpenSponsoredFeesHelpCenter}
+            >
+              {intl.formatMessage({
+                id: ETranslations.wallet_learn_about_sponsored_fees__action,
+              })}
+            </SizableText>
+          </Stack>
+          <Button
+            testID="swap-sponsored-fee-got-it-btn"
+            size="medium"
+            onPress={() => {
+              void dialogInstance?.close?.();
+            }}
+          >
+            {intl.formatMessage({ id: ETranslations.global_got_it })}
+          </Button>
+        </Stack>
+      ),
+    });
+    return dialogInstance;
+  }, [handleOpenSponsoredFeesHelpCenter, intl, renderSponsoredCoupon]);
 
   const networkFeeSelect = useMemo(() => {
     // OneKey sponsors the network fee: the estimated amount and the fee-level
     // selector are meaningless to the user, so show only the sponsored badge.
     if (isGasSponsored) {
       return (
-        <XStack alignItems="center" gap="$2">
+        <XStack
+          alignItems="center"
+          gap="$2"
+          cursor="pointer"
+          onPress={handleShowSponsoredInfo}
+          hoverStyle={{ opacity: 0.9 }}
+          pressStyle={{ opacity: 0.82 }}
+        >
           <Badge badgeType="success" badgeSize="sm">
             <Badge.Text>
               {intl.formatMessage({
@@ -199,6 +370,7 @@ const PreSwapInfoGroup = ({
   }, [
     intl,
     isGasSponsored,
+    handleShowSponsoredInfo,
     activeNetworkFeeSelectValue,
     networkFeeLevelArray,
     networkFeeLevelLabel,

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -60,6 +60,7 @@ import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
 import type {
   IEstimateFeeParams,
+  IEstimateGasResp,
   IFeeAlgo,
   IFeeCkb,
   IFeeDot,
@@ -1336,6 +1337,7 @@ export function useSwapBuildTx() {
         feeAlgo?: IFeeAlgo[];
         feeDot?: IFeeDot[];
         feeBudget?: IFeeSui[];
+        megafuelEligible?: IEstimateGasResp['megafuelEligible'];
         payer?: IGasPayer;
         gasAccountEligible?: boolean;
         gasAccountQuote?: IGasAccountQuote;
@@ -1407,10 +1409,11 @@ export function useSwapBuildTx() {
         customPriorityFee: swapNetWorkFeeLevel?.customPriorityFee,
         estimateFeeParams,
       });
-      // Carry Gas Account sponsorship result from estimate-fee so it flows into
-      // both the preview (sponsored badge) and the send path (broadcast quoteId).
+      // Carry sponsorship result from estimate-fee so it flows into the preview
+      // badge and, for Gas Account, the send path broadcast quoteId.
       return {
         ...gasInfo,
+        megafuelEligible: gasRes.megafuelEligible,
         payer: gasRes.payer,
         gasAccountEligible: gasRes.gasAccountEligible,
         gasAccountQuote: gasRes.gasAccountQuote,

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -197,6 +197,24 @@ describe('getSwapRequiredNativeBalanceAmount', () => {
     ).toBeUndefined();
   });
 
+  it('excludes sponsored (megafuelEligible) gas from the requirement', () => {
+    expect(
+      getSwapRequiredNativeBalanceAmount({
+        gasInfos: [
+          {
+            gasInfo: {
+              ...evmGasInfo,
+              megafuelEligible: { sponsorable: true, sponsorName: 'OneKey' },
+            },
+          },
+        ],
+        networkId: 'evm--56',
+        fromToken: usdcToken,
+        fromAmount: '12',
+      }),
+    ).toBeUndefined();
+  });
+
   it('still requires the native sending amount even when gas is sponsored', () => {
     // Gas is sponsored, but the native token being swapped is still required.
     expect(

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -295,13 +295,15 @@ export function getSwapRequiredNativeBalanceAmount({
         fromToken,
       });
 
-    // Gas Account sponsored tx: OneKey pays this tx's network fee, so it must
-    // not count toward the user's required native balance. estimate-fee only
-    // sets gasAccountEligible=true when sponsorship is actually available (and
-    // the global "use Gas Account" switch is on), so the original
-    // insufficient-gas block still applies whenever sponsorship is off or the
-    // backend rejects it.
-    if (item.gasInfo.gasAccountEligible) {
+    // Sponsored tx: OneKey pays this tx's network fee, so it must not count
+    // toward the user's required native balance. estimate-fee only sets these
+    // flags when sponsorship is actually available, so the original
+    // insufficient-gas block still applies whenever sponsorship is off.
+    if (
+      item.gasInfo.gasAccountEligible ||
+      item.gasInfo.megafuelEligible?.sponsorable ||
+      item.gasInfo.payer === 'megafuel'
+    ) {
       return acc;
     }
 

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -19,6 +19,7 @@ import type {
 } from '@onekeyhq/shared/src/eventSource';
 
 import type {
+  IEstimateGasResp,
   IFeeAlgo,
   IFeeCkb,
   IFeeDot,
@@ -515,6 +516,7 @@ export interface ISwapGasInfo {
   // Gas Account sponsorship result carried over from the estimate-fee response,
   // so the preview UI (sponsored badge) and the send path (broadcast quoteId)
   // can read it from the same gasInfo snapshot.
+  megafuelEligible?: IEstimateGasResp['megafuelEligible'];
   payer?: IGasPayer;
   gasAccountEligible?: boolean;
   gasAccountQuote?: IGasAccountQuote;


### PR DESCRIPTION
## Summary
- Add Swap gas sponsorship UI interactions and support Megafuel/BSC sponsored gas eligibility in balance checks.
- Align Perps order dialog, account mode, portfolio, and trade button UI with the main trading panel styles.
- Polish sponsored transaction fee display on the transaction confirmation page.

## Intent & Context
This PR covers several UI issues found while working on Swap gas sponsorship and Perps screens. The goal is to make sponsored gas states clearer, keep Perps controls visually consistent, and fix small mobile display issues.

Related issues:
- https://onekeyhq.atlassian.net/browse/OK-57072
- https://onekeyhq.atlassian.net/browse/OK-57079
- https://onekeyhq.atlassian.net/browse/OK-57136
- https://onekeyhq.atlassian.net/browse/OK-57250
- https://onekeyhq.atlassian.net/browse/OK-57254

## Changes Detail
- Swap preview now shows an interactive OneKey gas sponsorship badge and dialog when Gas Account or Megafuel sponsorship is available.
- Swap balance validation now treats Gas Account and Megafuel sponsored native gas as covered.
- Transaction confirmation sponsored fee copy now uses the green interactive style and larger heading text.
- Perps limit order modal aligns reduce-only with TP/SL and adds the existing reduce-only tooltip.
- Perps buy/sell button colors now reuse the trading panel token colors across popups and related UI.
- Perps account mode modal keeps the portfolio margin requirement inside the option card and adjusts the Learn More link placement/color.
- Perps mobile portfolio and holdings UI now avoids truncating month labels and displays empty holdings value as $0.00.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Web, Mobile, Desktop
- **Risk Areas**: Swap sponsored gas balance validation and Perps trading UI consistency.

## Test plan
- [x] yarn lint:staged
- [x] yarn jest packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts --runInBand
- [x] yarn jest packages/kit-bg/src/states/jotai/atoms/perps.test.ts --runInBand
- [x] Targeted oxlint checks for changed Perps/Swap files
- [ ] yarn _lint currently fails on existing unrelated hardware Trezor type errors in packages/kit-bg/src/vaults/impls/*/KeyringHardwareTrezor.ts