### PR TITLE
chore: sync release/v6.4.0 to x

### DIFF
--- a/packages/components/src/actions/Toast/index.tsx
+++ b/packages/components/src/actions/Toast/index.tsx
@@ -424,6 +424,7 @@ export { default as Toaster } from './Toaster';
 export type IToastShowResult = {
   close: (extra?: { flag?: string }) => void | Promise<void>;
 };
+
 export const Toast = {
   success: (props: IToastProps) => {
     return toastMessage({ haptic: 'success', ...props });

--- a/packages/kit-bg/src/services/ServiceNotification/PushProvider/PushProviderJPush.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/PushProvider/PushProviderJPush.ts
@@ -19,7 +19,13 @@ import type { IPushProviderBaseProps } from './PushProviderBase';
 // expo-notifications
 // jpush
 
+const JPUSH_REGISTER_ID_RETRY_DELAYS_MS = [1000, 3000, 10_000, 30_000];
+
 export class PushProviderJPush extends PushProviderBase {
+  private loggedRegisterID = '';
+
+  private connectedRegisterID = '';
+
   constructor(props: IPushProviderBaseProps) {
     super(props);
     this.initJPush();
@@ -40,6 +46,9 @@ export class PushProviderJPush extends PushProviderBase {
       options,
     );
     this.addListeners();
+    void this.resolveRegisterID({
+      source: 'startup',
+    });
   }
 
   private addListeners() {
@@ -79,22 +88,77 @@ export class PushProviderJPush extends PushProviderBase {
     JPush.removeListener(this.handleLocalNotification);
   }
 
-  private handleConnect = (result: { connectEnable: boolean }) => {
-    defaultLogger.notification.jpush.consoleLog('JPush 连接状态:', result);
-    if (result.connectEnable) {
-      JPush.getRegistrationID(async ({ registerID }) => {
-        if (!registerID) {
-          return;
-        }
-        defaultLogger.notification.jpush.consoleLog(
-          'JPush registerID:',
-          result,
-          registerID,
+  private getRegistrationID() {
+    return new Promise<string>((resolve) => {
+      try {
+        JPush.getRegistrationID(({ registerID }) => {
+          resolve(registerID || '');
+        });
+      } catch (error) {
+        defaultLogger.notification.jpush.consoleError(
+          'JPush getRegistrationID Error >>>>> ',
+          error,
         );
-        defaultLogger.notification.jpush.registerRid(registerID);
+        resolve('');
+      }
+    });
+  }
+
+  private logRegisterIDToLocal(registerID: string) {
+    defaultLogger.notification.jpush.logRegisterRidToLocal(registerID);
+  }
+
+  private async resolveRegisterID({
+    source,
+    shouldEmitConnected = true,
+    attempt = 0,
+  }: {
+    source: string;
+    shouldEmitConnected?: boolean;
+    attempt?: number;
+  }) {
+    const registerID = await this.getRegistrationID();
+    if (registerID) {
+      defaultLogger.notification.jpush.consoleLog(
+        'JPush registerID:',
+        {
+          source,
+          attempt,
+        },
+        registerID,
+      );
+
+      if (this.loggedRegisterID !== registerID) {
+        this.loggedRegisterID = registerID;
+        this.logRegisterIDToLocal(registerID);
+      }
+
+      if (shouldEmitConnected && this.connectedRegisterID !== registerID) {
+        this.connectedRegisterID = registerID;
         this.eventEmitter.emit(EPushProviderEventNames.jpush_connected, {
           jpushId: registerID,
         });
+      }
+      return;
+    }
+
+    const retryDelay = JPUSH_REGISTER_ID_RETRY_DELAYS_MS[attempt];
+    if (retryDelay) {
+      setTimeout(() => {
+        void this.resolveRegisterID({
+          source,
+          shouldEmitConnected,
+          attempt: attempt + 1,
+        });
+      }, retryDelay);
+    }
+  }
+
+  private handleConnect = (result: { connectEnable: boolean }) => {
+    defaultLogger.notification.jpush.consoleLog('JPush 连接状态:', result);
+    if (result.connectEnable) {
+      void this.resolveRegisterID({
+        source: 'connect',
       });
     }
   };

--- a/packages/kit/src/provider/Container/ErrorToastContainer/ErrorToastContainer.test.tsx
+++ b/packages/kit/src/provider/Container/ErrorToastContainer/ErrorToastContainer.test.tsx
@@ -1,0 +1,151 @@
+/** @jest-environment jsdom */
+
+import { act, render } from '@testing-library/react';
+
+import { Toast, globalNetInfo } from '@onekeyhq/components';
+import { EOneKeyErrorClassNames } from '@onekeyhq/shared/src/errors/types/errorTypes';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
+
+import { ErrorToastContainer } from './ErrorToastContainer';
+
+jest.mock('@onekeyhq/components', () => ({
+  Toast: {
+    error: jest.fn(),
+    message: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+  },
+  globalNetInfo: {
+    currentState: jest.fn(() => ({
+      isInternetReachable: true,
+    })),
+  },
+}));
+
+jest.mock('./ErrorToasts', () => ({
+  getErrorAction: jest.fn(() => undefined),
+}));
+
+const mockedToast = Toast as unknown as {
+  error: jest.Mock;
+};
+const mockedGlobalNetInfo = globalNetInfo as unknown as {
+  currentState: jest.Mock;
+};
+
+describe('ErrorToastContainer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGlobalNetInfo.currentState.mockReturnValue({
+      isInternetReachable: true,
+    });
+  });
+
+  it('does not show axios network error toast when offline is already confirmed', () => {
+    mockedGlobalNetInfo.currentState.mockReturnValue({
+      isInternetReachable: false,
+    });
+    const { unmount } = render(<ErrorToastContainer />);
+
+    act(() => {
+      appEventBus.emit(EAppEventBusNames.ShowToast, {
+        method: 'error',
+        title: 'Network error',
+        errorClassName: EOneKeyErrorClassNames.AxiosNetworkError,
+      });
+    });
+
+    expect(mockedToast.error).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('does not show axios network error toast before offline status is confirmed', () => {
+    const { unmount } = render(<ErrorToastContainer />);
+
+    act(() => {
+      appEventBus.emit(EAppEventBusNames.ShowToast, {
+        method: 'error',
+        title: '网络错误',
+        errorClassName: EOneKeyErrorClassNames.AxiosNetworkError,
+      });
+    });
+
+    expect(mockedToast.error).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('does not show timeout toast even when network status is online', () => {
+    const { unmount } = render(<ErrorToastContainer />);
+
+    act(() => {
+      appEventBus.emit(EAppEventBusNames.ShowToast, {
+        method: 'error',
+        title: 'timeout of 30000ms exceeded',
+        errorCode: 'ECONNABORTED',
+        errorName: 'AxiosError',
+      });
+    });
+
+    expect(mockedToast.error).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('shows numeric errorCode HTTP responses even when offline', () => {
+    mockedGlobalNetInfo.currentState.mockReturnValue({
+      isInternetReachable: false,
+    });
+    const { unmount } = render(<ErrorToastContainer />);
+
+    act(() => {
+      appEventBus.emit(EAppEventBusNames.ShowToast, {
+        method: 'error',
+        title: 'Network error',
+        errorCode: 503,
+      });
+    });
+
+    expect(mockedToast.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Network error',
+      }),
+    );
+    unmount();
+  });
+
+  it('does not use default OneKey error code as an effective HTTP status', () => {
+    const { unmount } = render(<ErrorToastContainer />);
+
+    act(() => {
+      appEventBus.emit(EAppEventBusNames.ShowToast, {
+        method: 'error',
+        title: '网络错误',
+        errorClassName: EOneKeyErrorClassNames.AxiosNetworkError,
+        errorCode: -99_999,
+      });
+    });
+
+    expect(mockedToast.error).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('shows generic timeout text when it is not a transport timeout', () => {
+    const { unmount } = render(<ErrorToastContainer />);
+
+    act(() => {
+      appEventBus.emit(EAppEventBusNames.ShowToast, {
+        method: 'error',
+        title: 'Device method call timeout',
+      });
+    });
+
+    expect(mockedToast.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Device method call timeout',
+      }),
+    );
+    unmount();
+  });
+});

--- a/packages/kit/src/provider/Container/ErrorToastContainer/ErrorToastContainer.tsx
+++ b/packages/kit/src/provider/Container/ErrorToastContainer/ErrorToastContainer.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { Toast } from '@onekeyhq/components';
+import { Toast, globalNetInfo } from '@onekeyhq/components';
 import type { IAppEventBusPayload } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import {
   EAppEventBusNames,
@@ -8,6 +8,10 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 
 import { getErrorAction } from './ErrorToasts';
+import {
+  getEffectiveHttpStatusCode,
+  getNetworkErrorToastSuppressReason,
+} from './offlineNetworkToastGuard';
 
 // Get deduplication ID for HTTP status codes to prevent toast spam
 // @param httpStatusCode - HTTP status code (e.g., 403, 429, 503)
@@ -38,9 +42,18 @@ export function ErrorToastContainer() {
       if (!p.title) {
         return;
       }
-      const statusCodeForDeduplicate =
-        p.httpStatusCode ??
-        (typeof p.errorCode === 'number' ? p.errorCode : undefined);
+      const isInternetReachable =
+        globalNetInfo.currentState().isInternetReachable;
+      const suppressReason = getNetworkErrorToastSuppressReason({
+        isInternetReachable,
+        payload: p,
+      });
+      const shouldSuppress = suppressReason !== null;
+      const statusCodeForDeduplicate = getEffectiveHttpStatusCode(p);
+      if (shouldSuppress) {
+        return;
+      }
+
       const deduplication = getDeduplicationId(statusCodeForDeduplicate);
       // For critical errors (403, 429, 5xx), force deduplication to prevent toast spam
       // Otherwise, respect custom toastId from caller

--- a/packages/kit/src/provider/Container/ErrorToastContainer/ErrorToasts.tsx
+++ b/packages/kit/src/provider/Container/ErrorToastContainer/ErrorToasts.tsx
@@ -27,7 +27,7 @@ import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 interface IErrorActionParams {
-  errorCode?: number;
+  errorCode?: number | string;
   requestId?: string;
   diagnosticText?: string;
   i18nKey?: ETranslations;

--- a/packages/kit/src/provider/Container/ErrorToastContainer/offlineNetworkToastGuard.test.ts
+++ b/packages/kit/src/provider/Container/ErrorToastContainer/offlineNetworkToastGuard.test.ts
@@ -1,0 +1,279 @@
+import { EOneKeyErrorClassNames } from '@onekeyhq/shared/src/errors/types/errorTypes';
+import type {
+  EAppEventBusNames,
+  IAppEventBusPayload,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
+
+import { shouldSuppressNetworkErrorToast } from './offlineNetworkToastGuard';
+
+type IShowToastPayload = IAppEventBusPayload[EAppEventBusNames.ShowToast];
+
+const createErrorToastPayload = (
+  payload: Partial<IShowToastPayload>,
+): IShowToastPayload => ({
+  method: 'error',
+  title: 'Error',
+  ...payload,
+});
+
+describe('offlineNetworkToastGuard', () => {
+  it('suppresses axios network error toast when offline is already confirmed', () => {
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: false,
+        payload: createErrorToastPayload({
+          errorClassName: EOneKeyErrorClassNames.AxiosNetworkError,
+          title: 'Network error',
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it('suppresses axios network error toast before offline status is confirmed', () => {
+    const payload = createErrorToastPayload({
+      errorClassName: EOneKeyErrorClassNames.AxiosNetworkError,
+      title: '网络错误',
+    });
+
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: true,
+        payload,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: null,
+        payload,
+      }),
+    ).toBe(true);
+  });
+
+  it('suppresses exact network error text before offline status is confirmed', () => {
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: true,
+        payload: createErrorToastPayload({
+          title: '网络错误',
+        }),
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: true,
+        payload: createErrorToastPayload({
+          title: 'Network Error',
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it('suppresses ERR_NETWORK before offline status is confirmed', () => {
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: true,
+        payload: createErrorToastPayload({
+          errorCode: 'ERR_NETWORK',
+          title: 'Request failed',
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps broader network failure text tied to the offline state', () => {
+    const payload = createErrorToastPayload({
+      title: 'Network request failed',
+    });
+
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: true,
+        payload,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: false,
+        payload,
+      }),
+    ).toBe(true);
+  });
+
+  it('suppresses transport timeout code only after offline is confirmed', () => {
+    const payload = createErrorToastPayload({
+      errorCode: 'ECONNABORTED',
+      errorName: 'AxiosError',
+      title: 'Request timeout',
+    });
+
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: false,
+        payload,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: true,
+        payload,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: null,
+        payload,
+      }),
+    ).toBe(false);
+  });
+
+  it('suppresses axios timeout text without an HTTP status code', () => {
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: true,
+        payload: createErrorToastPayload({
+          errorName: 'AxiosError',
+          title: 'timeout of 30000ms exceeded',
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it('suppresses exact 30000ms timeout text without transport metadata', () => {
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: false,
+        payload: createErrorToastPayload({
+          title: 'timeout of 30000ms exceeded',
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps generic timeout errors visible', () => {
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: true,
+        payload: createErrorToastPayload({
+          title: 'Device method call timeout',
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps other timeout durations visible without transport metadata', () => {
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: false,
+        payload: createErrorToastPayload({
+          title: 'timeout of 5000ms exceeded',
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps server timeout responses visible without a transport timeout code', () => {
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: true,
+        payload: createErrorToastPayload({
+          errorName: 'AxiosError',
+          httpStatusCode: 504,
+          title: 'Gateway Timeout',
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps server timeout responses visible even with a transport timeout code', () => {
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: true,
+        payload: createErrorToastPayload({
+          errorCode: 'ETIMEDOUT',
+          errorName: 'AxiosError',
+          httpStatusCode: 408,
+          title: 'Request timeout',
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps server and business errors visible while offline', () => {
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: false,
+        payload: createErrorToastPayload({
+          errorClassName: EOneKeyErrorClassNames.OneKeyServerApiError,
+          httpStatusCode: 400,
+          title: 'Invalid request',
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps HTTP status responses visible even with network error metadata', () => {
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: true,
+        payload: createErrorToastPayload({
+          errorClassName: EOneKeyErrorClassNames.AxiosNetworkError,
+          httpStatusCode: 503,
+          title: '网络错误',
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps numeric errorCode HTTP responses visible even with network error text', () => {
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: false,
+        payload: createErrorToastPayload({
+          errorCode: 503,
+          title: 'Network error',
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it('does not treat default OneKey error codes as HTTP status responses', () => {
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: true,
+        payload: createErrorToastPayload({
+          errorClassName: EOneKeyErrorClassNames.AxiosNetworkError,
+          errorCode: -99_999,
+          title: '网络错误',
+        }),
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: false,
+        payload: createErrorToastPayload({
+          errorClassName: EOneKeyErrorClassNames.AxiosNetworkError,
+          httpStatusCode: -99_999,
+          title: 'Network error',
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps non-error toast methods visible while offline', () => {
+    expect(
+      shouldSuppressNetworkErrorToast({
+        isInternetReachable: false,
+        payload: {
+          method: 'warning',
+          title: 'Warning',
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/kit/src/provider/Container/ErrorToastContainer/offlineNetworkToastGuard.ts
+++ b/packages/kit/src/provider/Container/ErrorToastContainer/offlineNetworkToastGuard.ts
@@ -1,0 +1,161 @@
+import { EOneKeyErrorClassNames } from '@onekeyhq/shared/src/errors/types/errorTypes';
+import type {
+  EAppEventBusNames,
+  IAppEventBusPayload,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
+
+type IShowToastPayload = IAppEventBusPayload[EAppEventBusNames.ShowToast];
+
+const OFFLINE_NETWORK_ERROR_TEXT_REGEXP =
+  /network\s+(error|request\s+failed)|failed\s+to\s+fetch|网络错误/i;
+
+const EXACT_NETWORK_ERROR_TEXTS = new Set(['network error', '网络错误']);
+
+const EXACT_30000MS_TIMEOUT_TEXT = 'timeout of 30000ms exceeded';
+
+const OFFLINE_NETWORK_ERROR_CODES = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'ERR_NETWORK',
+]);
+
+const TRANSPORT_NETWORK_ERROR_CODES = new Set(['ERR_NETWORK']);
+
+const TIMEOUT_ERROR_CODES = new Set(['ECONNABORTED', 'ETIMEDOUT']);
+
+function hasOfflineNetworkErrorText(payload: IShowToastPayload) {
+  const text = [payload.title, payload.message, payload.errorCode]
+    .filter(Boolean)
+    .map(String)
+    .join('\n');
+
+  return OFFLINE_NETWORK_ERROR_TEXT_REGEXP.test(text);
+}
+
+function hasExactNetworkErrorText(payload: IShowToastPayload) {
+  return [payload.title, payload.message, payload.errorCode]
+    .filter(Boolean)
+    .some((value) =>
+      EXACT_NETWORK_ERROR_TEXTS.has(String(value).trim().toLowerCase()),
+    );
+}
+
+function hasExact30000MsTimeoutText(payload: IShowToastPayload) {
+  return [payload.title, payload.message, payload.errorCode]
+    .filter(Boolean)
+    .some(
+      (value) =>
+        String(value).trim().toLowerCase() === EXACT_30000MS_TIMEOUT_TEXT,
+    );
+}
+
+function hasTimeoutCode(payload: IShowToastPayload) {
+  return (
+    typeof payload.errorCode === 'string' &&
+    TIMEOUT_ERROR_CODES.has(payload.errorCode.toUpperCase())
+  );
+}
+
+function hasOfflineNetworkErrorCode(payload: IShowToastPayload) {
+  return (
+    typeof payload.errorCode === 'string' &&
+    OFFLINE_NETWORK_ERROR_CODES.has(payload.errorCode.toUpperCase())
+  );
+}
+
+function hasTransportNetworkErrorCode(payload: IShowToastPayload) {
+  return (
+    typeof payload.errorCode === 'string' &&
+    TRANSPORT_NETWORK_ERROR_CODES.has(payload.errorCode.toUpperCase())
+  );
+}
+
+function isTransportNetworkError(payload: IShowToastPayload) {
+  return (
+    payload.errorClassName === EOneKeyErrorClassNames.AxiosNetworkError ||
+    hasTransportNetworkErrorCode(payload) ||
+    hasExactNetworkErrorText(payload)
+  );
+}
+
+function isValidHttpStatusCode(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 100 &&
+    value <= 599
+  );
+}
+
+export function getEffectiveHttpStatusCode(payload: IShowToastPayload) {
+  if (isValidHttpStatusCode(payload.httpStatusCode)) {
+    return payload.httpStatusCode;
+  }
+
+  if (isValidHttpStatusCode(payload.errorCode)) {
+    return payload.errorCode;
+  }
+
+  return undefined;
+}
+
+export type INetworkErrorToastSuppressReason =
+  | 'transport-timeout-code'
+  | 'exact-30000ms-timeout'
+  | 'transport-network-error'
+  | 'offline-network-error';
+
+export function getNetworkErrorToastSuppressReason({
+  isInternetReachable,
+  payload,
+}: {
+  isInternetReachable: boolean | null | undefined;
+  payload: IShowToastPayload;
+}): INetworkErrorToastSuppressReason | null {
+  if (payload.method !== 'error') {
+    return null;
+  }
+
+  if (typeof getEffectiveHttpStatusCode(payload) === 'number') {
+    return null;
+  }
+
+  const hasNetworkErrorCode = hasOfflineNetworkErrorCode(payload);
+  if (isInternetReachable === false) {
+    if (hasTimeoutCode(payload)) {
+      return 'transport-timeout-code';
+    }
+
+    if (
+      payload.errorClassName === EOneKeyErrorClassNames.AxiosNetworkError ||
+      hasNetworkErrorCode ||
+      hasOfflineNetworkErrorText(payload)
+    ) {
+      return 'offline-network-error';
+    }
+  }
+
+  if (hasExact30000MsTimeoutText(payload)) {
+    return 'exact-30000ms-timeout';
+  }
+
+  if (isTransportNetworkError(payload)) {
+    return 'transport-network-error';
+  }
+
+  return null;
+}
+
+export function shouldSuppressNetworkErrorToast({
+  isInternetReachable,
+  payload,
+}: {
+  isInternetReachable: boolean | null | undefined;
+  payload: IShowToastPayload;
+}) {
+  return (
+    getNetworkErrorToastSuppressReason({ isInternetReachable, payload }) !==
+    null
+  );
+}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenData.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenData.ts
@@ -6,6 +6,7 @@ export interface IMarketToken {
   decimals: number;
   price: number;
   change24h: number;
+  priceChangeRaw?: string;
   marketCap: number;
   liquidity: number;
   transactions: number;

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenListItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenListItem.tsx
@@ -62,6 +62,9 @@ const BasicTokenListItem: FC<ITokenListItemProps> = ({
   const themeName = useThemeName();
   const isDarkMode = themeName?.includes('dark');
   const isHighlighted = Boolean(isPrimed || (isDragging && isDarkMode));
+  const priceChange =
+    item.priceChangeRaw === '-' ? item.priceChangeRaw : item.change24h;
+
   return (
     <XStack
       testID={MarketTestIDs.tokenListItem(item.symbol)}
@@ -108,7 +111,7 @@ const BasicTokenListItem: FC<ITokenListItemProps> = ({
         >
           {item.price}
         </NumberSizeableText>
-        <PriceChangeBadge change={item.change24h} />
+        <PriceChangeBadge change={priceChange} />
       </XStack>
     </XStack>
   );

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
@@ -192,7 +192,15 @@ export const useColumnsDesktop = (
         })}(%)`,
       dataIndex: 'change24h',
       columnProps: { flex: 1 },
-      render: (text: number) => {
+      render: (text: number, record: IMarketToken) => {
+        if (record.priceChangeRaw === '-') {
+          return (
+            <SizableText size="$bodyMd" color="$textSubdued">
+              --
+            </SizableText>
+          );
+        }
+
         const { changeColor, showPlusMinusSigns } = getTokenPriceChangeStyle({
           priceChange: text,
         });

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsMobile.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsMobile.tsx
@@ -168,23 +168,35 @@ export const useColumnsMobile = (
       dataIndex: 'change24h',
       columnWidth: '50%',
       align: 'right',
-      render: (_, record: IMarketToken) => (
-        <XStack justifyContent="flex-end" alignItems="center" gap="$2" mr="$5">
-          <NumberSizeableText
-            userSelect="none"
-            flexShrink={1}
-            numberOfLines={1}
-            size="$bodyLgMedium"
-            formatter="price"
-            formatterOptions={{
-              currency: '$',
-            }}
+      render: (_, record: IMarketToken) => {
+        const priceChange =
+          record.priceChangeRaw === '-'
+            ? record.priceChangeRaw
+            : record.change24h;
+
+        return (
+          <XStack
+            justifyContent="flex-end"
+            alignItems="center"
+            gap="$2"
+            mr="$5"
           >
-            {record.price}
-          </NumberSizeableText>
-          <PriceChangeBadge change={record.change24h} />
-        </XStack>
-      ),
+            <NumberSizeableText
+              userSelect="none"
+              flexShrink={1}
+              numberOfLines={1}
+              size="$bodyLgMedium"
+              formatter="price"
+              formatterOptions={{
+                currency: '$',
+              }}
+            >
+              {record.price}
+            </NumberSizeableText>
+            <PriceChangeBadge change={priceChange} />
+          </XStack>
+        );
+      },
       renderSkeleton: () => (
         <XStack
           justifyContent="flex-end"

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts
@@ -108,6 +108,63 @@ describe('stock metadata values', () => {
 
     expect(token.change24h).toBe(-0.62);
     expect(token.priceChangeBasePrice).toBe(100);
+    expect(token.priceChangeRaw).toBe('-0.62');
+  });
+
+  test('keeps raw dash price change without treating zero as missing', () => {
+    const baseToken = {
+      address: '0x390a684ef9cade28a7ad0dfa61ab1eb3842618c4',
+      name: 'Token',
+      symbol: 'TOKEN',
+      decimals: 18,
+    };
+
+    const missingChangeToken = transformApiItemToToken(
+      {
+        ...baseToken,
+        priceChange24hPercent: '-',
+      },
+      {
+        chainId: 'evm--1',
+        networkLogoUri: '',
+      },
+    );
+    const zeroChangeToken = transformApiItemToToken(
+      {
+        ...baseToken,
+        priceChange24hPercent: '0',
+      },
+      {
+        chainId: 'evm--1',
+        networkLogoUri: '',
+      },
+    );
+
+    expect(missingChangeToken.change24h).toBe(0);
+    expect(missingChangeToken.priceChangeRaw).toBe('-');
+    expect(zeroChangeToken.change24h).toBe(0);
+    expect(zeroChangeToken.priceChangeRaw).toBe('0');
+  });
+
+  test('keeps raw dash price change in selected time range', () => {
+    const token = transformApiItemToToken(
+      {
+        address: '0x390a684ef9cade28a7ad0dfa61ab1eb3842618c4',
+        name: 'Token',
+        symbol: 'TOKEN',
+        decimals: 18,
+        priceChange1hPercent: '-',
+        priceChange24hPercent: '1',
+      },
+      {
+        chainId: 'evm--1',
+        networkLogoUri: '',
+        timeRange: '1h',
+      },
+    );
+
+    expect(token.change24h).toBe(0);
+    expect(token.priceChangeRaw).toBe('-');
   });
 });
 

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
@@ -277,6 +277,7 @@ export function transformApiItemToToken(
     address: item.address,
     price: safeNumber(item.price),
     change24h: priceChange,
+    priceChangeRaw: priceChangeValue,
     marketCap: safeNumber(getStockMarketCapValue(item) ?? item.marketCap),
     liquidity: safeNumber(item.liquidity),
     transactions,

--- a/packages/kit/src/views/Market/MarketHomeV2/components/PriceChangeBadge.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/PriceChangeBadge.tsx
@@ -1,14 +1,15 @@
 import type { FC } from 'react';
 import { useMemo } from 'react';
 
-import { NumberSizeableText, XStack } from '@onekeyhq/components';
+import { NumberSizeableText, SizableText, XStack } from '@onekeyhq/components';
 
 interface IPriceChangeBadgeProps {
   change: number | string;
 }
 
 export const PriceChangeBadge: FC<IPriceChangeBadgeProps> = ({ change }) => {
-  const changeNum = Number(change);
+  const isPlaceholder = change === '-';
+  const changeNum = isPlaceholder ? 0 : Number(change);
 
   const backgroundColor = useMemo(() => {
     if (changeNum > 0) return '$bgSuccessStrong';
@@ -25,19 +26,25 @@ export const PriceChangeBadge: FC<IPriceChangeBadgeProps> = ({ change }) => {
       backgroundColor={backgroundColor}
       borderRadius="$2"
     >
-      <NumberSizeableText
-        userSelect="none"
-        numberOfLines={1}
-        size="$bodyMdMedium"
-        fontSize={Math.abs(changeNum) >= 10_000 ? 13 : undefined}
-        color="white"
-        formatter="priceChangeCapped"
-        formatterOptions={{
-          showPlusMinusSigns: true,
-        }}
-      >
-        {change}
-      </NumberSizeableText>
+      {isPlaceholder ? (
+        <SizableText userSelect="none" size="$bodyMdMedium" color="white">
+          --
+        </SizableText>
+      ) : (
+        <NumberSizeableText
+          userSelect="none"
+          numberOfLines={1}
+          size="$bodyMdMedium"
+          fontSize={Math.abs(changeNum) >= 10_000 ? 13 : undefined}
+          color="white"
+          formatter="priceChangeCapped"
+          formatterOptions={{
+            showPlusMinusSigns: true,
+          }}
+        >
+          {change}
+        </NumberSizeableText>
+      )}
     </XStack>
   );
 };

--- a/packages/shared/src/errors/utils/errorToastUtils.ts
+++ b/packages/shared/src/errors/utils/errorToastUtils.ts
@@ -183,15 +183,19 @@ function showToastOfError(error: IOneKeyError | unknown | undefined) {
         }
       }
 
-      appEventBus.emit(EAppEventBusNames.ShowToast, {
+      const toastPayload = {
         errorCode: err?.code,
+        errorClassName: err?.className,
+        errorName: err?.name,
         httpStatusCode,
         method: 'error' as const,
         title: err?.message ?? 'Error',
         requestId: err?.requestId,
         diagnosticText,
         i18nKey: err?.key as ETranslations | undefined,
-      });
+      };
+
+      appEventBus.emit(EAppEventBusNames.ShowToast, toastPayload);
     })();
   }
 }

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -97,7 +97,9 @@ export type IEventBusPayloadShowToast = {
   message?: string;
   icon?: string;
   duration?: number;
-  errorCode?: number;
+  errorCode?: number | string;
+  errorClassName?: string;
+  errorName?: string;
   httpStatusCode?: number;
   toastId?: string;
   i18nKey?: ETranslations;

--- a/packages/shared/src/logger/base/baseScene.ts
+++ b/packages/shared/src/logger/base/baseScene.ts
@@ -1,6 +1,6 @@
 import { formatTime } from '../../utils/dateUtils';
 
-import { LogToConsole, LogToServer } from './decorators';
+import { LogToConsole } from './decorators';
 import { logFn } from './logFn';
 
 import type { IMethodDecoratorMetadata } from '../types';
@@ -76,13 +76,6 @@ export abstract class BaseScene {
   ignoreDurationBegin() {
     this.lastTimestamp = Date.now();
     return [];
-  }
-
-  @LogToServer()
-  registerRid(rid: string) {
-    return {
-      jpush_rid: rid,
-    };
   }
 
   @LogToConsole()

--- a/packages/shared/src/logger/scopes/notification/scenes/jpush.ts
+++ b/packages/shared/src/logger/scopes/notification/scenes/jpush.ts
@@ -8,4 +8,22 @@ export class JPushScene extends BaseScene {
   logSensitiveMessage(a: number, b: number) {
     return [a, b, devOnlyData('this is a sensitive message')];
   }
+
+  logRegisterRidToLocal(rid: string): void {
+    this.registerRidToLocal(rid);
+  }
+
+  // Intentionally NOT wrapped in devOnlyData: we need the raw registerID in the
+  // exportable local log on production/release builds to debug push delivery.
+  //
+  // The native logger (@onekeyfe/react-native-native-logger) redacts anything
+  // matching its sensitive-data regexes before writing to file — a 64-hex push
+  // token hits the "private key" pattern and a 20+ char run hits the token
+  // pattern, both becoming [REDACTED]. Chunking the id into 8-char groups breaks
+  // those contiguous runs so it survives; readers just strip the spaces.
+  @LogToLocal({ level: 'info' })
+  registerRidToLocal(rid: string): string[] {
+    const chunked = rid.replace(/(.{8})/g, '$1 ').trimEnd();
+    return [`JPush registerID (strip spaces): ${chunked}`];
+  }
 }


### PR DESCRIPTION
Sync bundle release changes from `release/v6.4.0` to `x` (seq #5 → seq #6 delta, i.e. the 3 commits merged into the release branch since sync PR #12210).

## Synced commits (3)
- fix(notification): write JPush registerID to exportable local log (#12123)
- fix: suppress offline timeout toasts (#12218)
- fix: show empty market price change as placeholder (#12199)

## Not resynced
- seq #1–#5 (everything through #12210) were already synced to `x` by prior sync PRs (#12101, #12107, #12116, #12156, #12210). `git cherry x release/v6.4.0` still lists them as unsynced because conflict resolution during those PRs changed the patch-id — this PR only carries the genuinely-new work since then.
- `chore: release #5` / `chore: release #6` / RELEASES.json-only commits excluded per policy (release-branch bookkeeping, not shippable content).

## Conflicts resolved
- **#12199** — `tokenListHelpers.test.ts`: structural conflict, not a logic conflict. `x` had independently added a `describe('market home live price change', ...)` block (`priceChangeBasePrice` / `calculateMarketTokenLivePriceChange`, live websocket recalculation); this release commit added `priceChangeRaw` / placeholder-dash tests to the existing `describe('stock metadata values', ...)` block. The already-merged source file (`tokenListHelpers.ts`) cleanly carries both fields independently, so the fix was a straight test union: kept x's new describe block intact and inserted the release's two new tests into their original describe block, merging the one shared test's assertions (`change24h`, `priceChangeBasePrice`, `priceChangeRaw` all asserted together). All other files in this commit (`MarketTokenData.ts`, `useColumnsDesktop.tsx`, `useColumnsMobile.tsx`, `tokenListHelpers.ts`, `TokenListItem.tsx`, `PriceChangeBadge.tsx`) auto-merged cleanly.
- **#12218**, **#12123** — auto-merged cleanly, no conflicts.

## Validation
- ESLint clean on all 17 touched files.
- Tests: `tokenListHelpers.test.ts` 20/20 passing (11 pre-existing + 2 from this sync + the `x`-side live-price-change suite unaffected); `ErrorToastContainer`/`offlineNetworkToastGuard` 23/23 passing. 43/43 total.
- Type check (`tsgo`, full project): 0 errors.