### PR TITLE
perf: speed up market token detail preview rendering ｜ OK-57270

### DIFF
--- a/packages/kit/src/routes/Tab/Discovery/router.ts
+++ b/packages/kit/src/routes/Tab/Discovery/router.ts
@@ -26,7 +26,8 @@ const EarnProtocolDetails = LazyLoadRootTabPage(
 
 // Market pages for native platforms (Market is embedded in Discovery on mobile)
 const MarketDetailV2 = LazyLoadPage(
-  () => import('../../../views/Market/MarketDetailV2'),
+  () =>
+    import(/* webpackPrefetch: true */ '../../../views/Market/MarketDetailV2'),
 );
 
 const MarketBannerDetail = LazyLoadPage(

--- a/packages/kit/src/routes/Tab/Marktet/router.ts
+++ b/packages/kit/src/routes/Tab/Marktet/router.ts
@@ -26,7 +26,8 @@ const MarketDetail = LazyLoadPage(
 );
 
 const MarketDetailV2 = LazyLoadPage(
-  () => import('../../../views/Market/MarketDetailV2'),
+  () =>
+    import(/* webpackPrefetch: true */ '../../../views/Market/MarketDetailV2'),
   undefined,
   undefined,
   createElement(MarketDetailV2LoadingFallback),

--- a/packages/kit/src/states/jotai/contexts/marketV2/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/marketV2/actions.ts
@@ -18,6 +18,7 @@ import type { IMarketWatchListItemV2 } from '@onekeyhq/shared/types/market';
 import type {
   IMarketPerpsInfo,
   IMarketTokenDetail,
+  IMarketTokenDetailPreview,
   IMarketTokenDetailResponse,
   IMarketTokenDetailWebsocket,
 } from '@onekeyhq/shared/types/marketV2';
@@ -33,6 +34,7 @@ import {
   tokenAddressAtom,
   tokenDetailAtom,
   tokenDetailLoadingAtom,
+  tokenDetailPreviewAtom,
   tokenDetailWebsocketAtom,
 } from './atoms';
 
@@ -62,6 +64,43 @@ class ContextJotaiActionsMarketV2 extends ContextJotaiActionsBase {
     set(tokenDetailLoadingAtom(), payload);
   });
 
+  setTokenDetailPreview = contextAtomMethod(
+    (_, set, payload: IMarketTokenDetailPreview | undefined) => {
+      set(tokenDetailPreviewAtom(), payload);
+      if (!payload) {
+        return;
+      }
+      set(tokenAddressAtom(), payload.address);
+      set(networkIdAtom(), payload.networkId);
+      set(isNativeAtom(), Boolean(payload.isNative));
+    },
+  );
+
+  prepareTokenDetailPreview = contextAtomMethod(
+    (_, set, payload: IMarketTokenDetailPreview | undefined) => {
+      set(tokenDetailAtom(), undefined);
+      set(tokenDetailPreviewAtom(), payload);
+      set(tokenDetailLoadingAtom(), false);
+      set(tokenDetailWebsocketAtom(), undefined);
+      set(perpsInfoAtom(), undefined);
+
+      if (!payload) {
+        set(tokenAddressAtom(), '');
+        set(networkIdAtom(), '');
+        set(isNativeAtom(), false);
+        return;
+      }
+
+      set(tokenAddressAtom(), payload.address);
+      set(networkIdAtom(), payload.networkId);
+      set(isNativeAtom(), Boolean(payload.isNative));
+    },
+  );
+
+  clearTokenDetailPreview = contextAtomMethod((_, set) => {
+    set(tokenDetailPreviewAtom(), undefined);
+  });
+
   setTokenAddress = contextAtomMethod((_, set, payload: string) => {
     set(tokenAddressAtom(), payload);
   });
@@ -88,6 +127,7 @@ class ContextJotaiActionsMarketV2 extends ContextJotaiActionsBase {
 
   clearTokenDetail = contextAtomMethod((_, set) => {
     set(tokenDetailAtom(), undefined);
+    set(tokenDetailPreviewAtom(), undefined);
     set(tokenDetailLoadingAtom(), false);
     set(tokenAddressAtom(), '');
     set(networkIdAtom(), '');
@@ -172,12 +212,23 @@ class ContextJotaiActionsMarketV2 extends ContextJotaiActionsBase {
     async (
       get,
       set,
-      payload: { tokenAddress: string; networkId: string; isNative: boolean },
+      payload: {
+        tokenAddress: string;
+        networkId: string;
+        isNative: boolean;
+        tokenDetailPreview?: IMarketTokenDetailPreview;
+      },
     ) => {
-      const { tokenAddress, networkId, isNative } = payload;
+      const { tokenAddress, networkId, isNative, tokenDetailPreview } = payload;
+      const nextPreview =
+        tokenDetailPreview?.address === tokenAddress &&
+        tokenDetailPreview.networkId === networkId
+          ? tokenDetailPreview
+          : undefined;
       // Set atom values directly — `this.xxx.call(set)` doesn't work
       // because `this` is not the class instance inside contextAtomMethod.
       set(tokenDetailAtom(), undefined);
+      set(tokenDetailPreviewAtom(), nextPreview);
       set(tokenDetailWebsocketAtom(), undefined);
       set(perpsInfoAtom(), undefined);
       set(tokenAddressAtom(), tokenAddress);
@@ -209,6 +260,7 @@ class ContextJotaiActionsMarketV2 extends ContextJotaiActionsBase {
           return;
         }
         set(tokenDetailAtom(), responseData.data.token);
+        set(tokenDetailPreviewAtom(), undefined);
         set(tokenDetailWebsocketAtom(), responseData.data.websocket);
         set(perpsInfoAtom(), responseData.data.perpsInfo);
       } catch (error) {
@@ -219,6 +271,7 @@ class ContextJotaiActionsMarketV2 extends ContextJotaiActionsBase {
           isStale = true;
         } else {
           set(tokenDetailAtom(), undefined);
+          set(tokenDetailPreviewAtom(), undefined);
           set(tokenDetailWebsocketAtom(), undefined);
           set(perpsInfoAtom(), undefined);
         }
@@ -325,6 +378,7 @@ class ContextJotaiActionsMarketV2 extends ContextJotaiActionsBase {
           : tokenData;
 
         set(tokenDetailAtom(), finalTokenData);
+        set(tokenDetailPreviewAtom(), undefined);
         set(tokenDetailWebsocketAtom(), websocketConfig);
         set(perpsInfoAtom(), perpsInfo);
 
@@ -339,6 +393,7 @@ class ContextJotaiActionsMarketV2 extends ContextJotaiActionsBase {
           (currentNetworkId === networkId || currentNetworkId === '')
         ) {
           set(tokenDetailAtom(), undefined);
+          set(tokenDetailPreviewAtom(), undefined);
           set(tokenDetailWebsocketAtom(), undefined);
           set(perpsInfoAtom(), undefined);
         } else {
@@ -670,6 +725,9 @@ export function useTokenDetailActions() {
   const actions = createActions();
   const setTokenDetail = actions.setTokenDetail.use();
   const setTokenDetailLoading = actions.setTokenDetailLoading.use();
+  const setTokenDetailPreview = actions.setTokenDetailPreview.use();
+  const prepareTokenDetailPreview = actions.prepareTokenDetailPreview.use();
+  const clearTokenDetailPreview = actions.clearTokenDetailPreview.use();
   const setTokenAddress = actions.setTokenAddress.use();
   const setNetworkId = actions.setNetworkId.use();
   const setIsNative = actions.setIsNative.use();
@@ -683,6 +741,9 @@ export function useTokenDetailActions() {
   return useRef({
     setTokenDetail,
     setTokenDetailLoading,
+    setTokenDetailPreview,
+    prepareTokenDetailPreview,
+    clearTokenDetailPreview,
     setTokenAddress,
     setNetworkId,
     setIsNative,

--- a/packages/kit/src/states/jotai/contexts/marketV2/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/marketV2/atoms.ts
@@ -15,6 +15,7 @@ import type { IMarketWatchListDataV2 } from '@onekeyhq/shared/types/market';
 import type {
   IMarketPerpsInfo,
   IMarketTokenDetail,
+  IMarketTokenDetailPreview,
   IMarketTokenDetailWebsocket,
 } from '@onekeyhq/shared/types/marketV2';
 
@@ -37,6 +38,9 @@ export const {
 export const { atom: tokenDetailAtom, use: useTokenDetailAtom } = contextAtom<
   IMarketTokenDetail | undefined
 >(undefined);
+
+export const { atom: tokenDetailPreviewAtom, use: useTokenDetailPreviewAtom } =
+  contextAtom<IMarketTokenDetailPreview | undefined>(undefined);
 
 export const { atom: tokenDetailLoadingAtom, use: useTokenDetailLoadingAtom } =
   contextAtom<boolean>(false);

--- a/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
+++ b/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
@@ -101,6 +101,7 @@ function MarketBannerDetailContent({ title }: { title: string }) {
   const handleItemPress = useCallback(
     (item: IMarketToken) => {
       void toDetailPage({
+        ...item,
         tokenAddress: item.address,
         networkId: item.networkId,
         symbol: item.symbol,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
@@ -7,13 +7,16 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import { useCurrency } from '@onekeyhq/kit/src/components/Currency';
-import { MarketTokenPrice } from '@onekeyhq/kit/src/views/Market/components/MarketTokenPrice';
+import {
+  BaseMarketTokenPrice,
+  MarketTokenPrice,
+} from '@onekeyhq/kit/src/views/Market/components/MarketTokenPrice';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IMarketTokenDetail } from '@onekeyhq/shared/types/marketV2';
 
 import { TokenTagsPopover } from '../../../components/TokenTagsPopover';
 import { useBtcMetadataContext } from '../../hooks/BtcMetadataContext';
-import { useTokenDetail } from '../../hooks/useTokenDetail';
+import { useMarketDetailDisplayData } from '../../hooks/useMarketDetailDisplayData';
 import {
   MARKET_CAP_FORMATTER,
   USD_CURRENCY_FORMATTER,
@@ -143,13 +146,14 @@ function HeaderStatRows({
 export function InformationPanel() {
   const intl = useIntl();
   const currencyInfo = useCurrency();
-  const { tokenDetail, networkId, tokenAddress, isStockToken } =
-    useTokenDetail();
+  const { tokenDetail, networkId, isPreviewTokenDetail, isStockToken } =
+    useMarketDetailDisplayData();
   const btcMetadata = useBtcMetadataContext();
+  const tokenAddress = tokenDetail?.address;
 
   const { securityData } = useTokenSecurity({
-    tokenAddress,
-    networkId,
+    tokenAddress: tokenAddress ?? '',
+    networkId: networkId ?? '',
   });
 
   if (!tokenDetail) return <InformationPanelSkeleton />;
@@ -197,12 +201,22 @@ export function InformationPanel() {
     >
       <YStack>
         <YStack pointerEvents="none">
-          <MarketTokenPrice
-            size={getPriceSizeByValue(currentPrice)}
-            price={currentPrice}
-            tokenName={name}
-            tokenSymbol={symbol}
-          />
+          {isPreviewTokenDetail ? (
+            <BaseMarketTokenPrice
+              size={getPriceSizeByValue(currentPrice)}
+              price={currentPrice}
+              tokenName={name}
+              tokenSymbol={symbol}
+            />
+          ) : (
+            <MarketTokenPrice
+              size={getPriceSizeByValue(currentPrice)}
+              price={currentPrice}
+              tokenName={name}
+              tokenSymbol={symbol}
+              lastUpdated={tokenDetail.lastUpdated?.toString()}
+            />
+          )}
           {priceConverted ? (
             <NumberSizeableText
               size="$bodySm"

--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketDetailHeader/MarketDetailHeader.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketDetailHeader/MarketDetailHeader.tsx
@@ -39,7 +39,7 @@ import { TokenTagsPopover } from '../../../components/TokenTagsPopover';
 import { buildMarketFullUrlV2 } from '../../../marketUtils';
 import { EModalMarketRoutes } from '../../../router';
 import { useMarketDetailBackNavigation } from '../../hooks/useMarketDetailBackNavigation';
-import { useTokenDetail } from '../../hooks/useTokenDetail';
+import { useMarketDetailHeaderDisplayData } from '../../hooks/useMarketDetailDisplayData';
 import { ShareButton } from '../TokenDetailHeader/ShareButton';
 
 import { TabPageHeaderContainer } from './TabPageHeaderContainer';
@@ -52,7 +52,8 @@ export function MarketDetailHeader({
   const media = useMedia();
   const { handleBackPress } = useMarketDetailBackNavigation();
   const navigation = useAppNavigation();
-  const { tokenDetail, networkId, isNative } = useTokenDetail();
+  const { tokenDetail, networkId, isNative } =
+    useMarketDetailHeaderDisplayData();
   const { copyText } = useClipboard();
   const isOverlayPage = useIsOverlayPage();
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeader.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeader.tsx
@@ -11,7 +11,7 @@ import {
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 
-import { useTokenDetail } from '../../hooks/useTokenDetail';
+import { useMarketDetailHeaderDisplayData } from '../../hooks/useMarketDetailDisplayData';
 
 import { ShareButton } from './ShareButton';
 import { TokenDetailHeaderLeft } from './TokenDetailHeaderLeft';
@@ -37,7 +37,13 @@ export function TokenDetailHeader({
   containerProps?: ComponentProps<typeof XStack>;
 }) {
   const { lg, md } = useMedia();
-  const { tokenDetail, networkId, isNative, isStockToken } = useTokenDetail();
+  const {
+    tokenDetail,
+    networkId,
+    isNative,
+    isPreviewTokenDetail,
+    isStockToken,
+  } = useMarketDetailHeaderDisplayData();
   const [scrollX, setScrollX] = useState(0);
   const [scrollViewWidth, setScrollViewWidth] = useState(0);
   const [contentWidth, setContentWidth] = useState(0);
@@ -95,6 +101,7 @@ export function TokenDetailHeader({
           networkId={networkId}
           isNative={isNative}
           showStats={showStats}
+          isPreviewTokenDetail={isPreviewTokenDetail}
           isStockToken={isStockToken}
         />
       )}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderRight.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderRight.tsx
@@ -7,7 +7,10 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import { useCurrency } from '@onekeyhq/kit/src/components/Currency';
-import { MarketTokenPrice } from '@onekeyhq/kit/src/views/Market/components/MarketTokenPrice';
+import {
+  BaseMarketTokenPrice,
+  MarketTokenPrice,
+} from '@onekeyhq/kit/src/views/Market/components/MarketTokenPrice';
 import { PriceChangePercentage } from '@onekeyhq/kit/src/views/Market/components/PriceChangePercentage';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -43,6 +46,7 @@ interface ITokenDetailHeaderRightProps {
   networkId?: string;
   isNative?: boolean;
   showStats: boolean;
+  isPreviewTokenDetail?: boolean;
   isStockToken?: boolean;
 }
 
@@ -51,6 +55,7 @@ export function TokenDetailHeaderRight({
   networkId,
   isNative,
   showStats,
+  isPreviewTokenDetail,
   isStockToken,
 }: ITokenDetailHeaderRightProps) {
   const intl = useIntl();
@@ -255,13 +260,22 @@ export function TokenDetailHeaderRight({
       <XStack ai="center" gap="$1.5">
         <XStack ai="center" jc="center" gap="$3">
           <YStack ai="flex-end">
-            <MarketTokenPrice
-              size="$bodyLgMedium"
-              price={currentPrice}
-              tokenName={name}
-              tokenSymbol={symbol}
-              lastUpdated={tokenDetail?.lastUpdated?.toString()}
-            />
+            {isPreviewTokenDetail ? (
+              <BaseMarketTokenPrice
+                size="$bodyLgMedium"
+                price={currentPrice}
+                tokenName={name}
+                tokenSymbol={symbol}
+              />
+            ) : (
+              <MarketTokenPrice
+                size="$bodyLgMedium"
+                price={currentPrice}
+                tokenName={name}
+                tokenSymbol={symbol}
+                lastUpdated={tokenDetail?.lastUpdated?.toString()}
+              />
+            )}
             {priceConverted ? (
               <NumberSizeableText
                 size="$bodySm"

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenSecurityAlert/hooks/useTokenSecurity.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenSecurityAlert/hooks/useTokenSecurity.ts
@@ -34,6 +34,7 @@ export const useTokenSecurity = ({
     [tokenAddress, networkId],
     {
       initResult: null,
+      undefinedResultIfReRun: true,
     },
   );
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/MarketTokenSelector.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/MarketTokenSelector.tsx
@@ -18,16 +18,23 @@ import { useNetworkLogoUri } from '@onekeyhq/kit/src/hooks/useNetworkLogoUri';
 import { useTokenDetailActions } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import { useMarketBasicConfig } from '@onekeyhq/kit/src/views/Market/hooks';
 import { usePerpsNavigation } from '@onekeyhq/kit/src/views/Market/hooks/usePerpsNavigation';
-import { useTokenDetail } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/hooks/useTokenDetail';
 import type { IMarketToken } from '@onekeyhq/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenData';
 import type { IMarketCategoryItem } from '@onekeyhq/kit/src/views/Market/MarketHomeV2/types';
 import { useSwapProTokenSearch } from '@onekeyhq/kit/src/views/Swap/hooks/useSwapPro';
 import { useMarketTokenSelectorConfigAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type { IMarketTokenDetailPreview } from '@onekeyhq/shared/types/marketV2';
+
+import { useMarketDetailHeaderDisplayData } from '../../hooks/useMarketDetailDisplayData';
+import { buildMarketTokenDetailPreview } from '../../utils/marketDetailPreview';
 
 import { ALL_NETWORK_ID, TOKEN_SELECTOR_POLLING_INTERVAL } from './constants';
 import { MarketTokenSelectorList } from './MarketTokenSelectorList';
 import { navigateToMarketTokenDetail } from './navigateToMarketTokenDetail';
+
+type IMarketTokenSelectorItem = IMarketToken & {
+  tokenDetailPreview?: IMarketTokenDetailPreview;
+};
 
 function normalizeRouteBooleanParam(value: boolean | string | undefined) {
   if (typeof value === 'string') {
@@ -144,6 +151,7 @@ function BaseMarketTokenSelectorContent() {
       networkId: string;
       isNative?: boolean;
       perpsCoin?: string;
+      tokenDetailPreview?: IMarketTokenDetailPreview;
     }) => {
       if (token.perpsCoin) {
         void closePopover?.();
@@ -155,14 +163,19 @@ function BaseMarketTokenSelectorContent() {
         tokenDetailActions,
         beforeNavigate: () => void closePopover?.(),
         showFavoriteButton,
+        tokenDetailPreview: token.tokenDetailPreview,
       });
     },
     [tokenDetailActions, closePopover, navigateToPerps, showFavoriteButton],
   );
 
   const handleSelectToken = useCallback(
-    (item: IMarketToken) => {
-      navigateToTokenDetail(item);
+    (item: IMarketTokenSelectorItem) => {
+      navigateToTokenDetail({
+        ...item,
+        tokenDetailPreview:
+          item.tokenDetailPreview ?? buildMarketTokenDetailPreview(item),
+      });
     },
     [navigateToTokenDetail],
   );
@@ -244,7 +257,7 @@ const MarketTokenSelectorContentMemo = memo(MarketTokenSelectorContent);
 function BaseMarketTokenSelector() {
   const intl = useIntl();
   const [isOpen, setIsOpen] = useState(false);
-  const { tokenDetail, networkId } = useTokenDetail();
+  const { tokenDetail, networkId } = useMarketDetailHeaderDisplayData();
 
   const effectiveNetworkLogoUri = useNetworkLogoUri({
     logoUri: undefined,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/MarketTokenSelectorList.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/MarketTokenSelectorList.tsx
@@ -13,9 +13,11 @@ import {
 import { useMarketWatchListV2Atom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IMarketSearchV2Token } from '@onekeyhq/shared/types/market';
+import type { IMarketTokenDetailPreview } from '@onekeyhq/shared/types/marketV2';
 
 import { useMarketTokenList } from '../../../MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList';
 import { useMarketWatchlistTokenList } from '../../../MarketHomeV2/components/MarketTokenList/hooks/useMarketWatchlistTokenList';
+import { buildMarketSearchTokenDetailPreview } from '../../utils/marketDetailPreview';
 
 import {
   COLUMN_WIDTH_CHANGE,
@@ -32,11 +34,15 @@ import { MarketTokenSelectorRow } from './MarketTokenSelectorRow';
 import type { IMarketToken } from '../../../MarketHomeV2/components/MarketTokenList/MarketTokenData';
 import type { IMarketTimeRangeValue } from '../../../MarketHomeV2/types';
 
+type IMarketTokenSelectorItem = IMarketToken & {
+  tokenDetailPreview?: IMarketTokenDetailPreview;
+};
+
 interface IMarketTokenSelectorListProps {
   networkId: string;
   selectedCategory?: string;
   timeRange?: IMarketTimeRangeValue;
-  onItemPress: (item: IMarketToken) => void;
+  onItemPress: (item: IMarketTokenSelectorItem) => void;
   pollingInterval?: number;
   isWatchlistMode?: boolean;
   searchQuery?: string;
@@ -52,10 +58,10 @@ function TokenSelectorListView({
   onItemPress,
   emptyMessage,
 }: {
-  data: IMarketToken[];
+  data: IMarketTokenSelectorItem[];
   isLoading?: boolean;
   networkId: string;
-  onItemPress: (item: IMarketToken) => void;
+  onItemPress: (item: IMarketTokenSelectorItem) => void;
   emptyMessage?: string;
 }) {
   if (isLoading && data.length === 0) {
@@ -99,7 +105,7 @@ const WatchlistTokenSelectorList = memo(
     pollingInterval,
   }: {
     networkId: string;
-    onItemPress: (item: IMarketToken) => void;
+    onItemPress: (item: IMarketTokenSelectorItem) => void;
     pollingInterval?: number;
   }) => {
     const intl = useIntl();
@@ -142,7 +148,7 @@ const CategoryTokenSelectorList = memo(
     networkId: string;
     selectedCategory?: string;
     timeRange?: IMarketTimeRangeValue;
-    onItemPress: (item: IMarketToken) => void;
+    onItemPress: (item: IMarketTokenSelectorItem) => void;
     pollingInterval?: number;
   }) => {
     const { data, isLoading } = useMarketTokenList({
@@ -174,12 +180,16 @@ const SearchTokenSelectorList = memo(
   }: {
     searchResults: (IMarketSearchV2Token & { networkLogoURI: string })[];
     searchLoading?: boolean;
-    onItemPress: (item: IMarketToken) => void;
+    onItemPress: (item: IMarketTokenSelectorItem) => void;
     networkId: string;
   }) => {
     const intl = useIntl();
     const data = useMemo(
-      () => searchResults.map(convertSearchTokenToMarketToken),
+      () =>
+        searchResults.map((item) => ({
+          ...convertSearchTokenToMarketToken(item),
+          tokenDetailPreview: buildMarketSearchTokenDetailPreview(item),
+        })),
       [searchResults],
     );
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/MarketTokenSelectorRow.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/MarketTokenSelectorRow.tsx
@@ -25,6 +25,7 @@ import {
   useStarV2Checked,
 } from '../../../components/MarketStarV2';
 import { StockSourceLogo, SubtitleText } from '../../../components/PerpsBadges';
+import { prewarmMarketTokenImages } from '../../utils/marketDetailImagePreload';
 
 import {
   COLUMN_WIDTH_CHANGE,
@@ -50,9 +51,15 @@ const PRICE_LARGE_THRESHOLD = 1_000_000;
 const MarketTokenSelectorRow = memo(
   ({ item, networkId, onPress, showAddress }: IMarketTokenSelectorRowProps) => {
     const { copyText } = useClipboard();
+
+    const prewarmTokenImages = useCallback(() => {
+      prewarmMarketTokenImages(item);
+    }, [item]);
+
     const handlePress = useCallback(() => {
+      prewarmTokenImages();
       onPress(item);
-    }, [onPress, item]);
+    }, [onPress, item, prewarmTokenImages]);
 
     const priceFormatter = useMemo(() => {
       if (new BigNumber(item.price).gte(PRICE_LARGE_THRESHOLD)) {
@@ -109,6 +116,8 @@ const MarketTokenSelectorRow = memo(
     return (
       <XStack
         onPress={handlePress}
+        onPressIn={prewarmTokenImages}
+        onHoverIn={prewarmTokenImages}
         hoverStyle={{ bg: '$bgHover' }}
         px="$4"
         py="$3"

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/MobileTokenSelector.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/MobileTokenSelector.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { useRoute } from '@react-navigation/native';
 import { useIntl } from 'react-intl';
@@ -23,6 +23,13 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IMarketSearchV2Token } from '@onekeyhq/shared/types/market';
+import type { IMarketTokenDetailPreview } from '@onekeyhq/shared/types/marketV2';
+
+import { prewarmMarketTokenImages } from '../../utils/marketDetailImagePreload';
+import {
+  buildMarketSearchTokenDetailPreview,
+  buildMarketTokenDetailPreview,
+} from '../../utils/marketDetailPreview';
 
 import { TOKEN_SELECTOR_POLLING_INTERVAL } from './constants';
 import { navigateToMarketTokenDetail } from './navigateToMarketTokenDetail';
@@ -65,6 +72,18 @@ function MobileTokenSelectorContent() {
   );
   const liveTokenOverride = useLiveTokenOverride();
 
+  useEffect(() => {
+    if (!searchValueDebounce) {
+      return;
+    }
+    searchTokenList.slice(0, 20).forEach((token) => {
+      prewarmMarketTokenImages({
+        tokenImageUri: token.logoUrl,
+        tokenImageUris: token.logoUrls,
+      });
+    });
+  }, [searchTokenList, searchValueDebounce]);
+
   const handleNetworkIdChange = useCallback(
     (networkId: string) => {
       setStartListSelect(false);
@@ -90,6 +109,7 @@ function MobileTokenSelectorContent() {
       networkId: string;
       isNative?: boolean;
       perpsCoin?: string;
+      tokenDetailPreview?: IMarketTokenDetailPreview;
     }) => {
       if (token.perpsCoin) {
         navigation.popStack();
@@ -101,6 +121,7 @@ function MobileTokenSelectorContent() {
         tokenDetailActions,
         beforeNavigate: () => navigation.popStack(),
         showFavoriteButton,
+        tokenDetailPreview: token.tokenDetailPreview,
       });
     },
     [tokenDetailActions, navigation, navigateToPerps, showFavoriteButton],
@@ -108,17 +129,26 @@ function MobileTokenSelectorContent() {
 
   const handleTokenSelect = useCallback(
     (item: IMarketToken) => {
-      navigateToTokenDetail(item);
+      navigateToTokenDetail({
+        ...item,
+        tokenDetailPreview: buildMarketTokenDetailPreview(item),
+      });
     },
     [navigateToTokenDetail],
   );
 
   const handleSearchTokenSelect = useCallback(
     (token: IMarketSearchV2Token & { networkLogoURI: string }) => {
+      prewarmMarketTokenImages({
+        tokenImageUri: token.logoUrl,
+        tokenImageUris: token.logoUrls,
+      });
+      const tokenDetailPreview = buildMarketSearchTokenDetailPreview(token);
       navigateToTokenDetail({
         address: token.address,
         networkId: token.network,
         isNative: token.isNative,
+        tokenDetailPreview,
       });
     },
     [navigateToTokenDetail],

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/navigateToMarketTokenDetail.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/navigateToMarketTokenDetail.ts
@@ -7,6 +7,9 @@ import {
   ETabRoutes,
 } from '@onekeyhq/shared/src/routes';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
+import type { IMarketTokenDetailPreview } from '@onekeyhq/shared/types/marketV2';
+
+import { prewarmMarketTokenDetailPreviewImages } from '../../utils/marketDetailImagePreload';
 
 export function navigateToMarketTokenDetail(
   token: { address: string; networkId: string; isNative?: boolean },
@@ -14,8 +17,11 @@ export function navigateToMarketTokenDetail(
     tokenDetailActions: ReturnType<typeof useTokenDetailActions>;
     beforeNavigate?: () => void;
     showFavoriteButton?: boolean;
+    tokenDetailPreview?: IMarketTokenDetailPreview;
   },
 ) {
+  prewarmMarketTokenDetailPreviewImages(opts.tokenDetailPreview);
+
   const shortCode = networkUtils.getNetworkShortCode({
     networkId: token.networkId,
   });
@@ -24,6 +30,7 @@ export function navigateToMarketTokenDetail(
     tokenAddress: token.address,
     networkId: token.networkId,
     isNative: token.isNative ?? false,
+    tokenDetailPreview: opts.tokenDetailPreview,
   });
 
   opts.beforeNavigate?.();

--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/index.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useTokenDetail';
+export * from './useMarketDetailDisplayData';
 export * from './useMarketHolders';
 export * from './useAutoRefreshTokenDetail';
 export * from './useBtcMetadata';

--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/useMarketDetailDisplayData.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/useMarketDetailDisplayData.ts
@@ -1,0 +1,64 @@
+import { useMemo } from 'react';
+
+import type {
+  IMarketTokenDetail,
+  IMarketTokenDetailPreview,
+} from '@onekeyhq/shared/types/marketV2';
+
+import { useTokenDetail } from './useTokenDetail';
+
+function toDisplayNumber(value: number | undefined) {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? String(value)
+    : undefined;
+}
+
+function buildPreviewTokenDetail(
+  tokenDetailPreview?: IMarketTokenDetailPreview,
+): IMarketTokenDetail | undefined {
+  if (!tokenDetailPreview) return undefined;
+
+  return {
+    address: tokenDetailPreview.address,
+    networkId: tokenDetailPreview.networkId,
+    isNative: tokenDetailPreview.isNative,
+    logoUrl: tokenDetailPreview.tokenImageUri ?? '',
+    logoUrls: tokenDetailPreview.tokenImageUris,
+    name: tokenDetailPreview.name,
+    symbol: tokenDetailPreview.symbol,
+    decimals: tokenDetailPreview.decimals,
+    price: toDisplayNumber(tokenDetailPreview.price),
+    priceChange24hPercent: toDisplayNumber(tokenDetailPreview.change24h),
+    marketCap: toDisplayNumber(tokenDetailPreview.marketCap),
+    liquidity: toDisplayNumber(tokenDetailPreview.liquidity),
+    holders: tokenDetailPreview.holders,
+    volume24h: toDisplayNumber(tokenDetailPreview.turnover),
+    communityRecognized: tokenDetailPreview.communityRecognized,
+    stock: tokenDetailPreview.stock,
+  };
+}
+
+export function useMarketDetailDisplayData() {
+  const tokenDetailData = useTokenDetail();
+  const { tokenDetail, tokenDetailPreview } = tokenDetailData;
+
+  const previewTokenDetail = useMemo(
+    () => buildPreviewTokenDetail(tokenDetailPreview),
+    [tokenDetailPreview],
+  );
+
+  const displayTokenDetail = tokenDetail ?? previewTokenDetail;
+
+  return useMemo(
+    () => ({
+      ...tokenDetailData,
+      tokenDetail: displayTokenDetail,
+      fullTokenDetail: tokenDetail,
+      isPreviewTokenDetail: Boolean(displayTokenDetail && !tokenDetail),
+      isStockToken: Boolean(displayTokenDetail?.stock?.underlyingAssetTicker),
+    }),
+    [displayTokenDetail, tokenDetail, tokenDetailData],
+  );
+}
+
+export const useMarketDetailHeaderDisplayData = useMarketDetailDisplayData;

--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/useTokenDetail.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/useTokenDetail.ts
@@ -7,11 +7,32 @@ import {
   useTokenAddressAtom,
   useTokenDetailAtom,
   useTokenDetailLoadingAtom,
+  useTokenDetailPreviewAtom,
   useTokenDetailWebsocketAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
+import type {
+  IMarketPerpsInfo,
+  IMarketTokenDetail,
+  IMarketTokenDetailPreview,
+  IMarketTokenDetailWebsocket,
+} from '@onekeyhq/shared/types/marketV2';
 
-export function useTokenDetail() {
+interface IUseTokenDetailResult {
+  tokenDetail?: IMarketTokenDetail;
+  tokenDetailPreview?: IMarketTokenDetailPreview;
+  isLoading: boolean;
+  tokenAddress: string;
+  networkId: string;
+  isNative: boolean;
+  websocketConfig?: IMarketTokenDetailWebsocket;
+  perpsInfo?: IMarketPerpsInfo;
+  isReady: boolean;
+  isStockToken: boolean;
+}
+
+export function useTokenDetail(): IUseTokenDetailResult {
   const [tokenDetail] = useTokenDetailAtom();
+  const [tokenDetailPreview] = useTokenDetailPreviewAtom();
   const [isLoading] = useTokenDetailLoadingAtom();
   const [tokenAddress] = useTokenAddressAtom();
   const [networkId] = useNetworkIdAtom();
@@ -31,6 +52,7 @@ export function useTokenDetail() {
 
   return {
     tokenDetail,
+    tokenDetailPreview,
     isLoading,
     tokenAddress,
     networkId,
@@ -40,4 +62,43 @@ export function useTokenDetail() {
     isReady,
     isStockToken,
   };
+}
+
+type IUseMarketTradingViewParamsOptions = {
+  tokenAddress: string;
+  networkId: string;
+  tokenDetail?: IMarketTokenDetail;
+  isNative: boolean;
+  websocketConfig?: IMarketTokenDetailWebsocket;
+};
+
+export function useMarketTradingViewParams({
+  tokenAddress,
+  networkId,
+  tokenDetail,
+  isNative,
+  websocketConfig,
+}: IUseMarketTradingViewParamsOptions) {
+  return useMemo(() => {
+    if (!tokenDetail?.symbol || !networkId) {
+      return undefined;
+    }
+
+    return {
+      tokenAddress: tokenDetail.address || tokenAddress,
+      networkId,
+      tokenSymbol: tokenDetail.symbol,
+      isNative,
+      dataSource: websocketConfig?.kline
+        ? ('websocket' as const)
+        : ('polling' as const),
+    };
+  }, [
+    isNative,
+    networkId,
+    tokenAddress,
+    tokenDetail?.address,
+    tokenDetail?.symbol,
+    websocketConfig?.kline,
+  ]);
 }

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
@@ -28,7 +28,10 @@ import {
 import { usePortfolioData } from '../components/InformationTabs/components/Portfolio/hooks/usePortfolioData';
 import { useNetworkAccount } from '../components/InformationTabs/hooks/useNetworkAccount';
 import { DesktopInformationTabs } from '../components/InformationTabs/layout/DesktopInformationTabs';
-import { useTokenDetail } from '../hooks/useTokenDetail';
+import {
+  useMarketTradingViewParams,
+  useTokenDetail,
+} from '../hooks/useTokenDetail';
 
 const MARKET_DETAIL_LAYOUT = {
   chartHeight: 550,
@@ -160,18 +163,26 @@ export function DesktopLayout({
     [isChartFullscreen],
   );
 
+  const marketTradingViewParams = useMarketTradingViewParams({
+    tokenAddress,
+    networkId,
+    tokenDetail,
+    isNative,
+    websocketConfig,
+  });
+
   const marketTradingView = useMemo(() => {
-    if (!networkId || !tokenDetail?.symbol) {
+    if (!marketTradingViewParams) {
       return null;
     }
 
     return (
       <MarketTradingView
-        tokenAddress={tokenAddress}
-        networkId={networkId}
-        tokenSymbol={tokenDetail.symbol}
-        isNative={isNative}
-        dataSource={websocketConfig?.kline ? 'websocket' : 'polling'}
+        tokenAddress={marketTradingViewParams.tokenAddress}
+        networkId={marketTradingViewParams.networkId}
+        tokenSymbol={marketTradingViewParams.tokenSymbol}
+        isNative={marketTradingViewParams.isNative}
+        dataSource={marketTradingViewParams.dataSource}
         onTouchScroll={handleTradingViewTouchScroll}
         nativeChartTypeControlMode="select"
         nativeIndicatorControlMode="popover"
@@ -187,11 +198,7 @@ export function DesktopLayout({
     handleChartFullscreenChange,
     handleTradingViewTouchScroll,
     isChartFullscreen,
-    isNative,
-    networkId,
-    tokenAddress,
-    tokenDetail?.symbol,
-    websocketConfig?.kline,
+    marketTradingViewParams,
   ]);
 
   return (

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -54,7 +54,10 @@ import { useNetworkAccount } from '../components/InformationTabs/hooks/useNetwor
 import { MobileInformationTabs } from '../components/InformationTabs/layout/MobileInformationTabs';
 import { SwapPanelWrap } from '../components/SwapPanel/SwapPanelWrap';
 import { StockTokenOverview } from '../components/TokenOverview/StockTokenOverview';
-import { useTokenDetail } from '../hooks/useTokenDetail';
+import {
+  useMarketTradingViewParams,
+  useTokenDetail,
+} from '../hooks/useTokenDetail';
 
 function MobileTradingViewTouchBridge({
   tokenAddress,
@@ -134,10 +137,18 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
     tokenAddress,
     networkId,
     tokenDetail,
+    isNative,
     websocketConfig,
     isStockToken,
   } = useTokenDetail();
   const tokenSymbol = tokenDetail?.symbol;
+  const marketTradingViewParams = useMarketTradingViewParams({
+    tokenAddress,
+    networkId,
+    tokenDetail,
+    isNative,
+    websocketConfig,
+  });
   const intl = useIntl();
   const isBTCMainnet = networkUtils.isBTCMainnet(networkId);
 
@@ -363,6 +374,9 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
             panActiveOffsetY={[-4, 4]}
             panFailOffsetX={chartAreaPanFailOffsetX}
             excludeRightEdgeRatio={chartAreaExcludeRightEdgeRatio}
+            excludeBottomEdgeHeight={
+              TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT
+            }
             scrollScale={1}
             onHorizontalSwipe={chartAreaHorizontalSwipeHandler}
             horizontalSwipeThreshold={24}
@@ -372,19 +386,24 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
           >
             <Stack h={tradingViewChartHeight} overflow="hidden">
               {(() => {
-                if (!networkId || !tokenSymbol) {
+                if (!marketTradingViewParams) {
                   return null;
                 }
+
                 if (platformEnv.isNativeAndroid || platformEnv.isNativeIOS) {
+                  const tradingViewKey = [
+                    marketTradingViewParams.networkId,
+                    marketTradingViewParams.tokenAddress,
+                    marketTradingViewParams.tokenSymbol,
+                  ].join(':');
+
                   return (
                     <MobileTradingViewTouchBridge
-                      key={`${networkId}:${tokenAddress}:${tokenSymbol}`}
-                      tokenAddress={tokenAddress}
-                      networkId={networkId}
-                      tokenSymbol={tokenSymbol}
-                      dataSource={
-                        websocketConfig?.kline ? 'websocket' : 'polling'
-                      }
+                      key={tradingViewKey}
+                      tokenAddress={marketTradingViewParams.tokenAddress}
+                      networkId={marketTradingViewParams.networkId}
+                      tokenSymbol={marketTradingViewParams.tokenSymbol}
+                      dataSource={marketTradingViewParams.dataSource}
                       pageWidth={effectivePageWidth}
                       onNativeIndicatorQuickBarChange={
                         handleNativeIndicatorQuickBarChange
@@ -400,12 +419,10 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
                 }
                 return (
                   <MarketTradingView
-                    tokenAddress={tokenAddress}
-                    networkId={networkId}
-                    tokenSymbol={tokenSymbol}
-                    dataSource={
-                      websocketConfig?.kline ? 'websocket' : 'polling'
-                    }
+                    tokenAddress={marketTradingViewParams.tokenAddress}
+                    networkId={marketTradingViewParams.networkId}
+                    tokenSymbol={marketTradingViewParams.tokenSymbol}
+                    dataSource={marketTradingViewParams.dataSource}
                     pageWidth={effectivePageWidth}
                   />
                 );
@@ -435,12 +452,9 @@ export function MobileLayout({ disableTrade }: { disableTrade?: boolean }) {
     handleInteractionOverlayOpenChange,
     handleNativeIndicatorQuickBarChange,
     isTradingViewScrollLocked,
+    marketTradingViewParams,
     nativeIndicatorQuickBar,
-    networkId,
-    tokenAddress,
-    tokenSymbol,
     tradingViewChartHeight,
-    websocketConfig?.kline,
   ]);
 
   const renderInformationHeader = useCallback(

--- a/packages/kit/src/views/Market/MarketDetailV2/utils/marketDetailImagePreload.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/utils/marketDetailImagePreload.ts
@@ -1,0 +1,74 @@
+import { primeCachedImageRefs } from '@onekeyhq/components/src/primitives/Image/cache';
+import { preloadImages } from '@onekeyhq/components/src/primitives/Image/preload';
+import type { IMarketTokenDetailPreview } from '@onekeyhq/shared/types/marketV2';
+
+type IMarketTokenImageSource = {
+  tokenImageUri?: string;
+  tokenImageUris?: string[];
+};
+
+const MARKET_TOKEN_IMAGE_PREWARM_LIMIT = 4;
+const MARKET_TOKEN_IMAGE_DECODE_TIMEOUT_MS = 350;
+const MAX_TRACKED_MARKET_TOKEN_IMAGE_URIS = 600;
+
+const prewarmedMarketTokenImageUris = new Set<string>();
+const prewarmingMarketTokenImageUris = new Set<string>();
+
+function uniqueImageUris(uris: Array<string | undefined>) {
+  return [...new Set(uris.filter((uri): uri is string => Boolean(uri)))];
+}
+
+function rememberPrewarmedUris(uris: string[]) {
+  if (
+    prewarmedMarketTokenImageUris.size > MAX_TRACKED_MARKET_TOKEN_IMAGE_URIS
+  ) {
+    prewarmedMarketTokenImageUris.clear();
+  }
+  uris.forEach((uri) => prewarmedMarketTokenImageUris.add(uri));
+}
+
+export function prewarmMarketTokenImages(
+  source?: IMarketTokenImageSource,
+  options?: {
+    limit?: number;
+  },
+) {
+  if (!source) return;
+
+  const uris = uniqueImageUris([
+    source.tokenImageUri,
+    ...(source.tokenImageUris ?? []),
+  ])
+    .filter(
+      (uri) =>
+        !prewarmedMarketTokenImageUris.has(uri) &&
+        !prewarmingMarketTokenImageUris.has(uri),
+    )
+    .slice(0, options?.limit ?? MARKET_TOKEN_IMAGE_PREWARM_LIMIT);
+
+  if (uris.length === 0) return;
+
+  uris.forEach((uri) => prewarmingMarketTokenImageUris.add(uri));
+
+  void Promise.allSettled([
+    preloadImages(uris.map((uri) => ({ uri }))),
+    primeCachedImageRefs({
+      uris,
+      timeoutMs: MARKET_TOKEN_IMAGE_DECODE_TIMEOUT_MS,
+    }),
+  ])
+    .then(([preloadResult]) => {
+      if (preloadResult.status === 'fulfilled' && preloadResult.value) {
+        rememberPrewarmedUris(uris);
+      }
+    })
+    .finally(() => {
+      uris.forEach((uri) => prewarmingMarketTokenImageUris.delete(uri));
+    });
+}
+
+export function prewarmMarketTokenDetailPreviewImages(
+  tokenDetailPreview?: IMarketTokenDetailPreview,
+) {
+  prewarmMarketTokenImages(tokenDetailPreview);
+}

--- a/packages/kit/src/views/Market/MarketDetailV2/utils/marketDetailPreview.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/utils/marketDetailPreview.ts
@@ -1,0 +1,93 @@
+import type { IMarketSearchV2Token } from '@onekeyhq/shared/types/market';
+import type { IMarketTokenDetailPreview } from '@onekeyhq/shared/types/marketV2';
+
+import type { IMarketToken } from '../../MarketHomeV2/components/MarketTokenList/MarketTokenData';
+
+type IBuildMarketTokenDetailPreviewInput = Pick<
+  IMarketToken,
+  | 'address'
+  | 'networkId'
+  | 'name'
+  | 'symbol'
+  | 'decimals'
+  | 'isNative'
+  | 'price'
+  | 'change24h'
+  | 'marketCap'
+  | 'liquidity'
+  | 'holders'
+  | 'turnover'
+  | 'tokenImageUri'
+  | 'tokenImageUris'
+  | 'communityRecognized'
+  | 'stock'
+>;
+
+type IBuildMarketSearchTokenDetailPreviewInput = IMarketSearchV2Token & {
+  networkLogoURI?: string;
+};
+
+function toOptionalNumber(value: unknown) {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : undefined;
+}
+
+function toFirstOptionalNumber(...values: unknown[]) {
+  for (const value of values) {
+    const numberValue = toOptionalNumber(value);
+    if (numberValue !== undefined) {
+      return numberValue;
+    }
+  }
+  return undefined;
+}
+
+export function buildMarketTokenDetailPreview(
+  token: IBuildMarketTokenDetailPreviewInput,
+): IMarketTokenDetailPreview {
+  return {
+    address: token.address,
+    networkId: token.networkId,
+    isNative: token.isNative,
+    name: token.name,
+    symbol: token.symbol,
+    decimals: token.decimals,
+    price: token.price,
+    change24h: token.change24h,
+    marketCap: token.marketCap,
+    liquidity: token.liquidity,
+    holders: token.holders,
+    turnover: token.turnover,
+    tokenImageUri: token.tokenImageUri,
+    tokenImageUris: token.tokenImageUris,
+    communityRecognized: token.communityRecognized,
+    stock: token.stock,
+    selectedAt: Date.now(),
+  };
+}
+
+export function buildMarketSearchTokenDetailPreview(
+  token: IBuildMarketSearchTokenDetailPreviewInput,
+): IMarketTokenDetailPreview {
+  return {
+    address: token.address,
+    networkId: token.network,
+    isNative: token.isNative,
+    name: token.name,
+    symbol: token.symbol,
+    decimals: token.decimals,
+    price: toOptionalNumber(token.price),
+    change24h: toOptionalNumber(token.priceChange24hPercent),
+    marketCap: toOptionalNumber(token.marketCap),
+    liquidity: toOptionalNumber(token.liquidity),
+    turnover: toFirstOptionalNumber(token.volume_24h, token.volume24h),
+    tokenImageUri: token.logoUrl,
+    tokenImageUris: token.logoUrls,
+    communityRecognized: token.communityRecognized,
+    stock: token.stock,
+    selectedAt: Date.now(),
+  };
+}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
@@ -635,6 +635,7 @@ function MarketTokenListBase({
                 return;
               }
               void toMarketDetailPage({
+                ...item,
                 symbol: item.symbol,
                 tokenAddress: item.address,
                 networkId: item.networkId,

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketTokenFlatList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketTokenFlatList.tsx
@@ -86,6 +86,7 @@ function MobileMarketTokenFlatListBase({
             return;
           }
           void toMarketDetailPage({
+            ...item,
             symbol: item.symbol,
             tokenAddress: item.address,
             networkId: item.networkId,

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketWatchlistFlatList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketWatchlistFlatList.tsx
@@ -270,6 +270,7 @@ function MobileMarketWatchlistFlatListImpl({
               return;
             }
             void toMarketDetailPage({
+              ...item,
               symbol: item.symbol,
               tokenAddress: item.address,
               networkId: item.networkId,

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenListItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenListItem.tsx
@@ -1,7 +1,8 @@
 import type { FC } from 'react';
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 
 import { NumberSizeableText, XStack, useThemeName } from '@onekeyhq/components';
+import { prewarmMarketTokenImages } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/utils/marketDetailImagePreload';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { MarketTestIDs } from '../../../testIDs';
@@ -65,13 +66,26 @@ const BasicTokenListItem: FC<ITokenListItemProps> = ({
   const priceChange =
     item.priceChangeRaw === '-' ? item.priceChangeRaw : item.change24h;
 
+  const prewarmTokenImages = useCallback(() => {
+    prewarmMarketTokenImages(item);
+  }, [item]);
+
+  const handlePressIn = useCallback(
+    (event: GestureResponderEvent) => {
+      prewarmTokenImages();
+      onPressIn?.(event);
+    },
+    [onPressIn, prewarmTokenImages],
+  );
+
   return (
     <XStack
       testID={MarketTestIDs.tokenListItem(item.symbol)}
       pressStyle={{ opacity: 0.8 }}
       onPress={onPress}
       onLongPress={onLongPress}
-      onPressIn={onPressIn}
+      onPressIn={handlePressIn}
+      onHoverIn={prewarmTokenImages}
       onTouchMove={onTouchMove}
       onTouchEnd={onTouchEnd}
       onPressOut={onPressOut}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useToMarketDetailPage.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useToMarketDetailPage.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import type { IPageNavigationProp } from '@onekeyhq/components';
 import {
@@ -8,6 +8,8 @@ import {
 } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useTokenDetailActions } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
+import { prewarmMarketTokenDetailPreviewImages } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/utils/marketDetailImagePreload';
+import { buildMarketTokenDetailPreview } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/utils/marketDetailPreview';
 import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
 import { EEnterWay } from '@onekeyhq/shared/src/logger/scopes/dex';
@@ -20,7 +22,9 @@ import {
 } from '@onekeyhq/shared/src/routes';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 
-interface IMarketToken {
+import type { IMarketToken as IMarketHomeToken } from '../MarketTokenData';
+
+interface IMarketToken extends Partial<IMarketHomeToken> {
   tokenAddress: string;
   networkId: string;
   symbol: string;
@@ -46,11 +50,48 @@ interface IUseToDetailPageOptions {
 
 const EXTENSION_POPUP_CLOSE_DELAY_MS = 100;
 
+function preloadMarketDetailV2Page() {
+  void import(/* webpackPrefetch: true */ '../../../../MarketDetailV2').catch(
+    () => undefined,
+  );
+}
+
 export function useToDetailPage(options?: IUseToDetailPageOptions) {
   const navigation =
     useAppNavigation<IPageNavigationProp<ITabMarketParamList>>();
   const tokenDetailActions = useTokenDetailActions();
   const splitViewType = useSplitViewType();
+
+  useEffect(() => {
+    preloadMarketDetailV2Page();
+  }, []);
+
+  const preparePreviewTokenDetail = useCallback(
+    (item: IMarketToken) => {
+      const previewAddress = item.address ?? item.tokenAddress;
+
+      if (
+        (!previewAddress && !item.isNative) ||
+        !item.name ||
+        typeof item.decimals !== 'number'
+      ) {
+        tokenDetailActions.current.clearTokenDetail();
+        return;
+      }
+
+      const tokenDetailPreview = buildMarketTokenDetailPreview({
+        ...(item as IMarketHomeToken),
+        address: previewAddress,
+        networkId: item.networkId,
+        symbol: item.symbol,
+        isNative: item.isNative,
+      });
+
+      prewarmMarketTokenDetailPreviewImages(tokenDetailPreview);
+      tokenDetailActions.current.prepareTokenDetailPreview(tokenDetailPreview);
+    },
+    [tokenDetailActions],
+  );
 
   const toMarketDetailPage = useCallback(
     async (item: IMarketToken) => {
@@ -92,8 +133,7 @@ export function useToDetailPage(options?: IUseToDetailPageOptions) {
           }, EXTENSION_POPUP_CLOSE_DELAY_MS);
         }
       } else if (options?.switchToMarketTabFirst) {
-        // Clear token detail before navigation
-        tokenDetailActions.current.clearTokenDetail();
+        preparePreviewTokenDetail(item);
 
         const targetTab = platformEnv.isNative
           ? ETabRoutes.Discovery
@@ -126,8 +166,7 @@ export function useToDetailPage(options?: IUseToDetailPageOptions) {
           }, 500);
         }
       } else {
-        // Clear token detail before navigation
-        tokenDetailActions.current.clearTokenDetail();
+        preparePreviewTokenDetail(item);
 
         // Clean existing token detail pages in tablet split view mode before pushing new one
         if (splitViewType !== ESplitViewType.UNKNOWN) {
@@ -143,7 +182,7 @@ export function useToDetailPage(options?: IUseToDetailPageOptions) {
     },
     [
       navigation,
-      tokenDetailActions,
+      preparePreviewTokenDetail,
       options?.switchToMarketTabFirst,
       options?.from,
       options?.showFavoriteButton,

--- a/packages/kit/src/views/Market/router/index.tsx
+++ b/packages/kit/src/views/Market/router/index.tsx
@@ -4,7 +4,9 @@ import type { EMarketBannerType } from '@onekeyhq/shared/types/marketV2';
 
 import { LazyLoadPage } from '../../../components/LazyLoadPage';
 
-const MarketDetailV2Modal = LazyLoadPage(() => import('../MarketDetailV2'));
+const MarketDetailV2Modal = LazyLoadPage(
+  () => import(/* webpackPrefetch: true */ '../MarketDetailV2'),
+);
 const MarketBannerDetailModal = LazyLoadPage(
   () => import('../MarketBannerDetail'),
 );

--- a/packages/shared/types/marketV2.ts
+++ b/packages/shared/types/marketV2.ts
@@ -127,6 +127,26 @@ export interface IMarketTokenDetail {
   [key: string]: unknown;
 }
 
+export interface IMarketTokenDetailPreview {
+  address: string;
+  networkId: string;
+  isNative?: boolean;
+  name: string;
+  symbol: string;
+  decimals: number;
+  price?: number;
+  change24h?: number;
+  marketCap?: number;
+  liquidity?: number;
+  holders?: number;
+  turnover?: number;
+  tokenImageUri?: string;
+  tokenImageUris?: string[];
+  communityRecognized?: boolean;
+  stock?: IMarketStockInfo;
+  selectedAt: number;
+}
+
 export interface IMarketChain {
   networkId: string;
   name: string;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57270](https://onekeyhq.atlassian.net/browse/OK-57270)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

This PR improves the perceived loading speed of the Market token detail page by introducing a lightweight token detail preview path.

Before this change, switching from the Market token list to a token detail page, or switching tokens inside the detail page, cleared the current token detail state and waited for the full token detail API response before rendering the main detail header. This made the header, token logo/name, and key first-screen information feel slow.

After this change, the clicked token's lightweight data is written into a preview detail state immediately. The detail page can render the header and lightweight first-screen information from preview data first, then replace it with the full token detail once the API response returns.

TradingView remains conservative: it still waits for full token detail data before rendering, because chart parameters should not rely on potentially incomplete preview data.

## Changes

- Added `IMarketTokenDetailPreview` for lightweight token detail preview data.
- Added `tokenDetailPreviewAtom` and related actions for preview detail state.
- Added `prepareTokenDetailPreview` so Market list clicks can write preview data before navigation.
- Updated token detail switching to accept preview data when switching from the detail-page token selector.
- Added stale-response protection when writing full detail data after fast token switches.
- Added `useMarketDetailDisplayData` / `useMarketDetailHeaderDisplayData` to centralize fallback between:
  - full `tokenDetail`
  - lightweight `tokenDetailPreview`
- Updated Market detail header and first-screen information components to render from preview data when full detail is not ready yet.
- Added token image prewarming to reduce the chance of briefly showing the built-in image placeholder.
- Added active preload for the Market detail page chunk from the Market list path.
- Kept TradingView gated by full detail data, so chart rendering behavior stays safe and predictable.

## Performance Result

Performance data was collected manually on Desktop with the same measurement method before and after the optimization.

Runtime note: the measurement targets the Desktop Market detail renderer, which is the UI main JS runtime. The background JS runtime is not involved in this page rendering path.

### Key Metric

The main metric is `detailHeaderMs`: time from user click to the main Market detail header becoming renderable.

| Scenario | Before avg / P50 | After avg / P50 | Avg improvement | Avg reduction |
| --- | ---: | ---: | ---: | ---: |
| Market list → detail page | 3167ms / 2703ms | 785ms / 594ms | -2382ms | 75.2% |
| Detail-page token selector switch | 1540ms / 1456ms | 58ms / 60ms | -1482ms | 96.2% |

### Market List To Detail Page

For the Market list entry path, the detail header no longer waits for the full detail API response.

| Token | Before detail header avg | After detail header avg | Improvement | Reduction |
| --- | ---: | ---: | ---: | ---: |
| BTC | 3221ms | 781ms | -2440ms | 75.8% |
| 领头羊 | 2606ms | 618ms | -1988ms | 76.3% |
| ANSEM | 3624ms | 439ms | -3185ms | 87.9% |
| 哈基米 | 3496ms | 479ms | -3017ms | 86.3% |
| dog | 2512ms | 1352ms | -1160ms | 46.2% |
| world | 2785ms | 683ms | -2102ms | 75.5% |
| sLGNS | 2940ms | 817ms | -2123ms | 72.2% |
| skew | 4128ms | 1032ms | -3096ms | 75.0% |

### Detail Page Token Selector Switch

This is the strongest improvement. Since the page is already mounted, preview data can update the header almost immediately.

| Token | Before detail header avg | After detail header avg | Improvement | Reduction |
| --- | ---: | ---: | ---: | ---: |
| BTC | 1316ms | 51ms | -1265ms | 96.1% |
| 领头羊 | 1443ms | 44ms | -1399ms | 97.0% |
| ANSEM | 2072ms | 60ms | -2012ms | 97.1% |
| 哈基米 | 1595ms | 84ms | -1511ms | 94.7% |
| dog | 1580ms | 61ms | -1519ms | 96.1% |
| world | 1580ms | 79ms | -1501ms | 95.0% |
| sLGNS | 1540ms | 51ms | -1489ms | 96.7% |
| skew | 1192ms | 30ms | -1162ms | 97.5% |

### Non-Core Metrics

| Scenario | Metric | Before avg / P50 | After avg / P50 | Notes |
| --- | --- | ---: | ---: | --- |
| Market list → detail page | `pageMountedMs` | 1008ms / 739ms | 755ms / 566ms | Improved, but not the direct target of preview data |
| Market list → detail page | `detailReadyMs` | 3170ms / 2705ms | 2425ms / 2285ms | Affected by API/network variance |
| Market list → detail page | `tradingViewMs` | 3168ms / 2704ms | 2423ms / 2283ms | Still close to full detail readiness |
| Detail selector switch | `detailReadyMs` | 1474ms / 1443ms | 1438ms / 1355ms | Mostly unchanged |
| Detail selector switch | `tradingViewMs` | 1541ms / 1457ms | 1436ms / 1353ms | Slightly lower, but not the main preview target |

## Notes

- The optimization primarily targets first-screen perceived responsiveness, especially the detail header.
- TradingView is intentionally not initialized from preview data.
- `infoPanelMs` was not stable in the local samples, so it is not used as a conclusion metric.
- The before/after comparison uses the shared token set available in both measurements: `BTC`, `领头羊`, `ANSEM`, `哈基米`, `dog`, `world`, `sLGNS`, and `skew`.
- The original local performance Markdown files were used as reference data but are not included in this PR.

[OK-57270]: https://onekeyhq.atlassian.net/browse/OK-57270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ