### PR TITLE
feat: optimize Perps deposit token list(OK-56758)

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
@@ -893,7 +893,6 @@ export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
   }
 
   @backgroundMethod()
-<<<<<<< HEAD
   async getHyperliquidPortfolioSnapshot(
     address: string,
   ): Promise<IHyperliquidPortfolioSnapshot | undefined> {
@@ -904,31 +903,12 @@ export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
     const config = await this.getPerpData();
     const entry = config.hyperliquidPortfolioSnapshotByAddress?.[key];
     if (!entry || this._normalizePerpsAccountKey(entry.address) !== key) {
-=======
-  async getPerpsDepositTokenListCache({
-    cacheKey,
-    maxAgeMs,
-  }: {
-    cacheKey: string;
-    maxAgeMs: number;
-  }): Promise<IPerpsDepositTokenListCacheEntry | undefined> {
-    if (!cacheKey) {
-      return undefined;
-    }
-    const config = await this.getPerpData();
-    const entry = config.perpsDepositTokenListCache?.[cacheKey];
-    if (!entry || entry.cacheKey !== cacheKey) {
-      return undefined;
-    }
-    if (!this._isCacheEntryFresh(entry.updatedAt, maxAgeMs)) {
->>>>>>> f584ecbabd (feat: optimize Perps deposit token list)
       return undefined;
     }
     return entry;
   }
 
   @backgroundMethod()
-<<<<<<< HEAD
   async setHyperliquidPortfolioSnapshot(
     snapshot: IHyperliquidPortfolioSnapshot,
   ): Promise<void> {
@@ -950,7 +930,56 @@ export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
           Object.entries(map)
             .toSorted((a, b) => b[1].fetchedAt - a[1].fetchedAt)
             .slice(0, PERPS_HL_PORTFOLIO_SNAPSHOT_MAX_ENTRIES),
-=======
+        ),
+      };
+    });
+  }
+
+  @backgroundMethod()
+  async clearHyperliquidPortfolioSnapshot(address?: string): Promise<void> {
+    await this.setPerpData((prev): ISimpleDbPerpData => {
+      if (!address) {
+        return {
+          ...prev,
+          hyperliquidPortfolioSnapshotByAddress: {},
+        };
+      }
+      const key = this._normalizePerpsAccountKey(address);
+      if (!key) {
+        return prev ?? ({} as ISimpleDbPerpData);
+      }
+      const map = { ...prev?.hyperliquidPortfolioSnapshotByAddress };
+      delete map[key];
+      return {
+        ...prev,
+        hyperliquidPortfolioSnapshotByAddress: map,
+      };
+    });
+  }
+
+  @backgroundMethod()
+  async getPerpsDepositTokenListCache({
+    cacheKey,
+    maxAgeMs,
+  }: {
+    cacheKey: string;
+    maxAgeMs: number;
+  }): Promise<IPerpsDepositTokenListCacheEntry | undefined> {
+    if (!cacheKey) {
+      return undefined;
+    }
+    const config = await this.getPerpData();
+    const entry = config.perpsDepositTokenListCache?.[cacheKey];
+    if (!entry || entry.cacheKey !== cacheKey) {
+      return undefined;
+    }
+    if (!this._isCacheEntryFresh(entry.updatedAt, maxAgeMs)) {
+      return undefined;
+    }
+    return entry;
+  }
+
+  @backgroundMethod()
   async setPerpsDepositTokenListCache({
     cacheKey,
     ownerKey,
@@ -979,34 +1008,8 @@ export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
         perpsDepositTokenListCache: this._limitSnapshotCacheEntries(
           map,
           PERPS_ACCOUNT_DISPLAY_CACHE_MAX_ENTRIES,
->>>>>>> f584ecbabd (feat: optimize Perps deposit token list)
         ),
       };
     });
   }
-<<<<<<< HEAD
-
-  @backgroundMethod()
-  async clearHyperliquidPortfolioSnapshot(address?: string): Promise<void> {
-    await this.setPerpData((prev): ISimpleDbPerpData => {
-      if (!address) {
-        return {
-          ...prev,
-          hyperliquidPortfolioSnapshotByAddress: {},
-        };
-      }
-      const key = this._normalizePerpsAccountKey(address);
-      if (!key) {
-        return prev ?? ({} as ISimpleDbPerpData);
-      }
-      const map = { ...prev?.hyperliquidPortfolioSnapshotByAddress };
-      delete map[key];
-      return {
-        ...prev,
-        hyperliquidPortfolioSnapshotByAddress: map,
-      };
-    });
-  }
-=======
->>>>>>> f584ecbabd (feat: optimize Perps deposit token list)
 }

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
@@ -117,6 +117,7 @@ export interface IPerpsDepositTokenListCacheToken {
 
 export interface IPerpsDepositTokenListCacheEntry {
   cacheKey: string;
+  ownerKey?: string;
   updatedAt: number;
   tokens: IPerpsDepositTokenListCacheToken[];
   tokensByNetwork: Record<string, IPerpsDepositTokenListCacheToken[]>;
@@ -952,10 +953,12 @@ export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
 =======
   async setPerpsDepositTokenListCache({
     cacheKey,
+    ownerKey,
     tokens,
     tokensByNetwork,
   }: {
     cacheKey: string;
+    ownerKey: string;
     tokens: IPerpsDepositTokenListCacheToken[];
     tokensByNetwork: Record<string, IPerpsDepositTokenListCacheToken[]>;
   }) {
@@ -966,6 +969,7 @@ export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
       const map = { ...prev?.perpsDepositTokenListCache };
       map[cacheKey] = {
         cacheKey,
+        ownerKey,
         updatedAt: Date.now(),
         tokens,
         tokensByNetwork,

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
@@ -101,6 +101,27 @@ export interface IPerpsAccountDisplayCacheEntry {
   };
 }
 
+export interface IPerpsDepositTokenListCacheToken {
+  networkId: string;
+  contractAddress: string;
+  name: string;
+  symbol: string;
+  decimals: number;
+  networkLogoURI: string;
+  price?: string;
+  balanceParsed?: string;
+  fiatValue?: string;
+  isNative?: boolean;
+  logoURI?: string;
+}
+
+export interface IPerpsDepositTokenListCacheEntry {
+  cacheKey: string;
+  updatedAt: number;
+  tokens: IPerpsDepositTokenListCacheToken[];
+  tokensByNetwork: Record<string, IPerpsDepositTokenListCacheToken[]>;
+}
+
 export interface ISimpleDbPerpData {
   hyperliquidBuilderAddress?: string;
   hyperliquidMaxBuilderFee?: number;
@@ -164,6 +185,7 @@ export interface ISimpleDbPerpData {
     string,
     IHyperliquidPortfolioSnapshot
   >;
+  perpsDepositTokenListCache?: Record<string, IPerpsDepositTokenListCacheEntry>;
 }
 
 export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
@@ -870,6 +892,7 @@ export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
   }
 
   @backgroundMethod()
+<<<<<<< HEAD
   async getHyperliquidPortfolioSnapshot(
     address: string,
   ): Promise<IHyperliquidPortfolioSnapshot | undefined> {
@@ -880,12 +903,31 @@ export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
     const config = await this.getPerpData();
     const entry = config.hyperliquidPortfolioSnapshotByAddress?.[key];
     if (!entry || this._normalizePerpsAccountKey(entry.address) !== key) {
+=======
+  async getPerpsDepositTokenListCache({
+    cacheKey,
+    maxAgeMs,
+  }: {
+    cacheKey: string;
+    maxAgeMs: number;
+  }): Promise<IPerpsDepositTokenListCacheEntry | undefined> {
+    if (!cacheKey) {
+      return undefined;
+    }
+    const config = await this.getPerpData();
+    const entry = config.perpsDepositTokenListCache?.[cacheKey];
+    if (!entry || entry.cacheKey !== cacheKey) {
+      return undefined;
+    }
+    if (!this._isCacheEntryFresh(entry.updatedAt, maxAgeMs)) {
+>>>>>>> f584ecbabd (feat: optimize Perps deposit token list)
       return undefined;
     }
     return entry;
   }
 
   @backgroundMethod()
+<<<<<<< HEAD
   async setHyperliquidPortfolioSnapshot(
     snapshot: IHyperliquidPortfolioSnapshot,
   ): Promise<void> {
@@ -907,10 +949,38 @@ export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
           Object.entries(map)
             .toSorted((a, b) => b[1].fetchedAt - a[1].fetchedAt)
             .slice(0, PERPS_HL_PORTFOLIO_SNAPSHOT_MAX_ENTRIES),
+=======
+  async setPerpsDepositTokenListCache({
+    cacheKey,
+    tokens,
+    tokensByNetwork,
+  }: {
+    cacheKey: string;
+    tokens: IPerpsDepositTokenListCacheToken[];
+    tokensByNetwork: Record<string, IPerpsDepositTokenListCacheToken[]>;
+  }) {
+    if (!cacheKey) {
+      return;
+    }
+    await this.setPerpData((prev): ISimpleDbPerpData => {
+      const map = { ...prev?.perpsDepositTokenListCache };
+      map[cacheKey] = {
+        cacheKey,
+        updatedAt: Date.now(),
+        tokens,
+        tokensByNetwork,
+      };
+      return {
+        ...prev,
+        perpsDepositTokenListCache: this._limitSnapshotCacheEntries(
+          map,
+          PERPS_ACCOUNT_DISPLAY_CACHE_MAX_ENTRIES,
+>>>>>>> f584ecbabd (feat: optimize Perps deposit token list)
         ),
       };
     });
   }
+<<<<<<< HEAD
 
   @backgroundMethod()
   async clearHyperliquidPortfolioSnapshot(address?: string): Promise<void> {
@@ -933,4 +1003,6 @@ export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
       };
     });
   }
+=======
+>>>>>>> f584ecbabd (feat: optimize Perps deposit token list)
 }

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1462,22 +1462,34 @@ export default class ServiceSwap extends ServiceBase {
 
   @backgroundMethod()
   async fetchSwapNativeTokenConfig({ networkId }: { networkId: string }) {
-    try {
-      const client = await this.getClient(EServiceEndpointEnum.Swap);
-      const resp = await client.get<{
-        data: ISwapNativeTokenConfig;
-      }>(`/swap/v1/native-token-config`, {
-        params: { networkId },
-      });
-      return resp.data.data;
-    } catch (e) {
-      console.error(e);
-      return {
-        networkId,
-        reserveGas: 0,
-      };
-    }
+    return this.fetchSwapNativeTokenConfigMemo({ networkId });
   }
+
+  fetchSwapNativeTokenConfigMemo = memoizee(
+    async ({ networkId }: { networkId: string }) => {
+      try {
+        const client = await this.getClient(EServiceEndpointEnum.Swap);
+        const resp = await client.get<{
+          data: ISwapNativeTokenConfig;
+        }>(`/swap/v1/native-token-config`, {
+          params: { networkId },
+        });
+        return resp.data.data;
+      } catch (e) {
+        console.error(e);
+        return {
+          networkId,
+          reserveGas: 0,
+        };
+      }
+    },
+    {
+      max: 50,
+      maxAge: timerUtils.getTimeDurationMs({ minute: 3 }),
+      promise: true,
+      primitive: true,
+    },
+  );
 
   // swap approving transaction
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1348,11 +1348,11 @@ export default class ServiceSwap extends ServiceBase {
 
   @backgroundMethod()
   async checkSupportSwap({ networkId }: { networkId: string }) {
-    return this.checkSupportSwapMemo({ networkId });
+    return this.checkSupportSwapMemo(networkId);
   }
 
   checkSupportSwapMemo = memoizee(
-    async ({ networkId }: { networkId: string }) => {
+    async (networkId: string) => {
       const client = await this.getClient(EServiceEndpointEnum.Swap);
       const resp = await client.get<{
         data: ISwapCheckSupportResponse[];
@@ -1462,26 +1462,26 @@ export default class ServiceSwap extends ServiceBase {
 
   @backgroundMethod()
   async fetchSwapNativeTokenConfig({ networkId }: { networkId: string }) {
-    return this.fetchSwapNativeTokenConfigMemo({ networkId });
+    try {
+      return await this.fetchSwapNativeTokenConfigMemo(networkId);
+    } catch (e) {
+      console.error(e);
+      return {
+        networkId,
+        reserveGas: 0,
+      };
+    }
   }
 
   fetchSwapNativeTokenConfigMemo = memoizee(
-    async ({ networkId }: { networkId: string }) => {
-      try {
-        const client = await this.getClient(EServiceEndpointEnum.Swap);
-        const resp = await client.get<{
-          data: ISwapNativeTokenConfig;
-        }>(`/swap/v1/native-token-config`, {
-          params: { networkId },
-        });
-        return resp.data.data;
-      } catch (e) {
-        console.error(e);
-        return {
-          networkId,
-          reserveGas: 0,
-        };
-      }
+    async (networkId: string) => {
+      const client = await this.getClient(EServiceEndpointEnum.Swap);
+      const resp = await client.get<{
+        data: ISwapNativeTokenConfig;
+      }>(`/swap/v1/native-token-config`, {
+        params: { networkId },
+      });
+      return resp.data.data;
     },
     {
       max: 50,

--- a/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
@@ -17,14 +17,17 @@ import type { IOneKeyError } from '@onekeyhq/shared/src/errors/types/errorTypes'
 import thirdpartyLocaleConverter from '@onekeyhq/shared/src/locale/thirdpartyLocaleConverter';
 import type { ILocaleSymbol } from '@onekeyhq/shared/src/locale/type';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import cacheUtils from '@onekeyhq/shared/src/utils/cacheUtils';
 import { extractHyperLiquidErrorMessage } from '@onekeyhq/shared/src/utils/hyperLiquidErrorResolver';
 import type {
   ITokenSearchAliasItem,
   ITokenSearchAliases,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
+import { promiseAllSettledEnhanced } from '@onekeyhq/shared/src/utils/promiseUtils';
 import stringUtils from '@onekeyhq/shared/src/utils/stringUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+import { buildTokenSelectorDappTokenFilterParams } from '@onekeyhq/shared/src/utils/tokenSelectorFilterUtils';
 import type {
   IHyperLiquidSignatureRSV,
   IHyperLiquidTypedDataApproveBuilderFee,
@@ -35,16 +38,24 @@ import type {
   IPerpServerBannerConfig,
   IPerpsAssetMetaMap,
 } from '@onekeyhq/shared/types/hyperliquid/types';
+import type { IFetchAccountTokensResp } from '@onekeyhq/shared/types/token';
 
-import { settingsPersistAtom } from '../../states/jotai/atoms';
+import {
+  type IPerpsDepositNetwork,
+  type IPerpsDepositToken,
+  perpsDepositTokensAtom,
+  settingsPersistAtom,
+} from '../../states/jotai/atoms';
 import ServiceBase from '../ServiceBase';
 import { logHyperLiquidApiFailure } from '../ServiceHyperLiquid/utils/logHyperLiquidApiFailure';
 
+import {
+  buildPerpsDepositTokensByNetwork,
+  buildPerpsDepositTokensFromWalletTokenResponses,
+  resolvePerpsDepositSelectedToken,
+} from './utils/depositTokenListUtils';
+
 import type { IHyperliquidCustomSettings } from '../../dbs/simple/entity/SimpleDbEntityPerp';
-import type {
-  IPerpsDepositNetwork,
-  IPerpsDepositToken,
-} from '../../states/jotai/atoms';
 import type {
   IJsBridgeMessagePayload,
   IJsonRpcRequest,
@@ -267,8 +278,49 @@ export interface IPerpServerConfigResponse {
   perpsAssetMetaMap?: IPerpsAssetMetaMap;
   activityCards?: IPerpServerActivityCard[];
 }
+
+export interface IFetchPerpsDepositTokensFromWalletTokenListParams {
+  accountId: string;
+  indexedAccountId?: string;
+}
+
+export interface IFetchPerpsDepositTokensFromWalletTokenListResult {
+  tokens: IPerpsDepositToken[];
+  tokensByNetwork: Record<string, IPerpsDepositToken[]>;
+  selectedToken?: IPerpsDepositToken;
+}
+
+interface IPerpsDepositTokenListData {
+  tokens: IPerpsDepositToken[];
+  tokensByNetwork: Record<string, IPerpsDepositToken[]>;
+}
+
+interface IPerpsDepositTokenListCacheParams {
+  allNetworksAccountId: string;
+  ownerIndexId?: string;
+  supportedNetworkIds: string[];
+}
+
+interface IPerpsDepositTokenListCacheEntry {
+  createdAt: number;
+  promise: Promise<IPerpsDepositTokenListData>;
+}
+
+const PERPS_DEPOSIT_TOKEN_LIST_CACHE_TTL_MS = timerUtils.getTimeDurationMs({
+  seconds: 60,
+});
+const PERPS_DEPOSIT_TOKEN_LIST_COLD_CACHE_MAX_AGE_MS =
+  timerUtils.getTimeDurationMs({
+    day: 1,
+  });
+
 @backgroundClass()
 class ServiceWebviewPerp extends ServiceBase {
+  private perpsDepositTokenListCache = new Map<
+    string,
+    IPerpsDepositTokenListCacheEntry
+  >();
+
   constructor({ backgroundApi }: { backgroundApi: any }) {
     super({ backgroundApi });
   }
@@ -276,6 +328,299 @@ class ServiceWebviewPerp extends ServiceBase {
   @backgroundMethod()
   async initializePerpConfig() {
     // TODO init by server api
+  }
+
+  private isValidIndexedAccountId(indexedAccountId: string | undefined) {
+    if (!indexedAccountId) {
+      return false;
+    }
+    const { walletId, index } = accountUtils.parseIndexedAccountId({
+      indexedAccountId,
+    });
+    return Boolean(walletId) && Number.isFinite(index);
+  }
+
+  private getIndexedAccountIdForAllNetworks({
+    accountId,
+    indexedAccountId,
+  }: {
+    accountId: string;
+    indexedAccountId: string | undefined;
+  }) {
+    if (this.isValidIndexedAccountId(indexedAccountId)) {
+      return indexedAccountId;
+    }
+
+    if (this.isValidIndexedAccountId(accountId)) {
+      return accountId;
+    }
+
+    const resolvedIndexedAccountId =
+      accountUtils.buildAllNetworkIndexedAccountIdFromAccountId({
+        accountId,
+      });
+    return this.isValidIndexedAccountId(resolvedIndexedAccountId)
+      ? resolvedIndexedAccountId
+      : indexedAccountId;
+  }
+
+  private async normalizePerpsDepositAllNetworksOwner({
+    accountId,
+    indexedAccountId,
+  }: IFetchPerpsDepositTokensFromWalletTokenListParams) {
+    if (accountUtils.isOthersAccount({ accountId })) {
+      return { accountId, indexedAccountId };
+    }
+
+    const allNetworksIndexedAccountId = this.getIndexedAccountIdForAllNetworks({
+      accountId,
+      indexedAccountId,
+    });
+    if (!allNetworksIndexedAccountId) {
+      return { accountId, indexedAccountId };
+    }
+
+    const allNetworksAccount =
+      await this.backgroundApi.serviceAccount.getMockedAllNetworkAccount({
+        indexedAccountId: allNetworksIndexedAccountId,
+      });
+
+    return {
+      accountId: allNetworksAccount.id,
+      indexedAccountId: allNetworksIndexedAccountId,
+    };
+  }
+
+  private buildPerpsDepositTokenListCacheKey({
+    allNetworksAccountId,
+    ownerIndexId,
+    supportedNetworkIds,
+  }: IPerpsDepositTokenListCacheParams) {
+    return `${allNetworksAccountId}::${ownerIndexId ?? ''}::${supportedNetworkIds.join(
+      ',',
+    )}`;
+  }
+
+  private getPerpsDepositTokenListDataMemoryCache(
+    params: IPerpsDepositTokenListCacheParams,
+  ): Promise<IPerpsDepositTokenListData> | undefined {
+    const cacheKey = this.buildPerpsDepositTokenListCacheKey(params);
+    const cached = this.perpsDepositTokenListCache.get(cacheKey);
+    if (
+      cached &&
+      Date.now() - cached.createdAt < PERPS_DEPOSIT_TOKEN_LIST_CACHE_TTL_MS
+    ) {
+      return cached.promise;
+    }
+    return undefined;
+  }
+
+  private async fetchPerpsDepositTokenListDataUncached({
+    allNetworksAccountId,
+    ownerIndexId,
+    supportedNetworkIds,
+  }: IPerpsDepositTokenListCacheParams): Promise<IPerpsDepositTokenListData> {
+    if (!supportedNetworkIds.length) {
+      return {
+        tokens: [],
+        tokensByNetwork: {},
+      };
+    }
+
+    const walletTokenFilterParams = buildTokenSelectorDappTokenFilterParams({
+      lpToken: false,
+    });
+    const requestFactories = supportedNetworkIds.map(
+      (networkId) => async () => {
+        const defaultDeriveType =
+          await this.backgroundApi.serviceNetwork.getGlobalDeriveTypeOfNetwork({
+            networkId,
+          });
+        const networkAccount =
+          await this.backgroundApi.serviceAccount.getNetworkAccount({
+            accountId: ownerIndexId ? undefined : allNetworksAccountId,
+            indexedAccountId: ownerIndexId,
+            networkId,
+            deriveType: defaultDeriveType ?? 'default',
+          });
+
+        return this.backgroundApi.serviceToken.fetchAccountTokens({
+          accountId: networkAccount.id,
+          networkId,
+          indexedAccountId: ownerIndexId,
+          flag: 'perps-deposit-token-list',
+          mergeTokens: true,
+          saveToLocal: false,
+          hideSmallBalanceTokens: true,
+          hideRiskTokens: true,
+          ...walletTokenFilterParams,
+        });
+      },
+    );
+
+    const responses = (
+      await promiseAllSettledEnhanced(requestFactories, {
+        continueOnError: true,
+        concurrency: 3,
+      })
+    ).filter((response): response is IFetchAccountTokensResp =>
+      Boolean(response),
+    );
+    const { networks } =
+      await this.backgroundApi.serviceNetwork.getNetworksByIds({
+        networkIds: supportedNetworkIds,
+      });
+    const networkLogoURIByNetworkId = Object.fromEntries(
+      networks.map((network: { id: string; logoURI?: string }) => [
+        network.id,
+        network.logoURI,
+      ]),
+    );
+    const tokens = buildPerpsDepositTokensFromWalletTokenResponses({
+      responses,
+      networkLogoURIByNetworkId,
+    });
+    const walletTokensByNetwork = buildPerpsDepositTokensByNetwork(tokens);
+    const tokensByNetwork = supportedNetworkIds.reduce<
+      Record<string, IPerpsDepositToken[]>
+    >((memo, networkId) => {
+      memo[networkId] = walletTokensByNetwork[networkId] ?? [];
+      return memo;
+    }, {});
+    return {
+      tokens,
+      tokensByNetwork,
+    };
+  }
+
+  private fetchPerpsDepositTokenListDataCached(
+    params: IPerpsDepositTokenListCacheParams,
+  ): Promise<IPerpsDepositTokenListData> {
+    const cacheKey = this.buildPerpsDepositTokenListCacheKey(params);
+    const now = Date.now();
+    const cached = this.getPerpsDepositTokenListDataMemoryCache(params);
+
+    if (cached) {
+      return cached;
+    }
+
+    const promise = this.fetchPerpsDepositTokenListDataUncached(params)
+      .then((data) => {
+        if (data.tokens.length > 0) {
+          void this.backgroundApi.simpleDb.perp.setPerpsDepositTokenListCache({
+            cacheKey,
+            tokens: data.tokens,
+            tokensByNetwork: data.tokensByNetwork,
+          });
+        }
+        return data;
+      })
+      .catch((error: unknown) => {
+        const current = this.perpsDepositTokenListCache.get(cacheKey);
+        if (current?.promise === promise) {
+          this.perpsDepositTokenListCache.delete(cacheKey);
+        }
+        throw error;
+      });
+    this.perpsDepositTokenListCache.set(cacheKey, {
+      createdAt: now,
+      promise,
+    });
+    return promise;
+  }
+
+  private async updatePerpsDepositTokenListAtom({
+    tokens,
+    tokensByNetwork,
+  }: IPerpsDepositTokenListData) {
+    let selectedToken: IPerpsDepositToken | undefined;
+
+    await perpsDepositTokensAtom.set((prev) => {
+      selectedToken = resolvePerpsDepositSelectedToken({
+        tokens,
+        currentToken: prev.currentPerpsDepositSelectedToken,
+      });
+      return {
+        ...prev,
+        tokens: tokensByNetwork,
+        currentPerpsDepositSelectedToken: selectedToken,
+      };
+    });
+
+    return selectedToken;
+  }
+
+  private refreshPerpsDepositTokenListDataInBackground(
+    params: IPerpsDepositTokenListCacheParams,
+  ) {
+    void this.fetchPerpsDepositTokenListDataCached(params)
+      .then((data) => this.updatePerpsDepositTokenListAtom(data))
+      .catch((error: unknown) => {
+        console.error(
+          '[ServiceWebviewPerp] Failed to refresh perps deposit tokens:',
+          error,
+        );
+      });
+  }
+
+  @backgroundMethod()
+  async fetchPerpsDepositTokensFromWalletTokenList({
+    accountId,
+    indexedAccountId,
+  }: IFetchPerpsDepositTokensFromWalletTokenListParams): Promise<IFetchPerpsDepositTokensFromWalletTokenListResult> {
+    const { accountId: allNetworksAccountId, indexedAccountId: ownerIndexId } =
+      await this.normalizePerpsDepositAllNetworksOwner({
+        accountId,
+        indexedAccountId,
+      });
+    const currentDepositTokens = await perpsDepositTokensAtom.get();
+    const supportedNetworkIds = Object.keys(
+      currentDepositTokens.tokens,
+    ).toSorted();
+    const cacheParams = {
+      allNetworksAccountId,
+      ownerIndexId,
+      supportedNetworkIds,
+    };
+
+    const memoryCache =
+      this.getPerpsDepositTokenListDataMemoryCache(cacheParams);
+    if (memoryCache) {
+      const data = await memoryCache;
+      const selectedToken = await this.updatePerpsDepositTokenListAtom(data);
+      return {
+        ...data,
+        selectedToken,
+      };
+    }
+
+    const cacheKey = this.buildPerpsDepositTokenListCacheKey(cacheParams);
+    const coldCache =
+      await this.backgroundApi.simpleDb.perp.getPerpsDepositTokenListCache({
+        cacheKey,
+        maxAgeMs: PERPS_DEPOSIT_TOKEN_LIST_COLD_CACHE_MAX_AGE_MS,
+      });
+
+    if (coldCache) {
+      const data = {
+        tokens: coldCache.tokens,
+        tokensByNetwork: coldCache.tokensByNetwork,
+      };
+      const selectedToken = await this.updatePerpsDepositTokenListAtom(data);
+      this.refreshPerpsDepositTokenListDataInBackground(cacheParams);
+      return {
+        ...data,
+        selectedToken,
+      };
+    }
+
+    const data = await this.fetchPerpsDepositTokenListDataCached(cacheParams);
+    const selectedToken = await this.updatePerpsDepositTokenListAtom(data);
+
+    return {
+      ...data,
+      selectedToken,
+    };
   }
 
   private resolveHyperliquidRequestAction(

--- a/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
@@ -577,6 +577,7 @@ class ServiceWebviewPerp extends ServiceBase {
         tokens: tokensByNetwork,
         currentPerpsDepositSelectedToken: selectedToken,
         depositTokenListOwnerKey: ownerKey,
+        depositTokenListRevision: (prev.depositTokenListRevision ?? 0) + 1,
       };
     });
 

--- a/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
@@ -417,10 +417,15 @@ class ServiceWebviewPerp extends ServiceBase {
       if (prev.depositTokenListOwnerKey === ownerKey) {
         return prev;
       }
+      const emptyTokensByNetwork = Object.fromEntries(
+        Object.keys(prev.tokens).map((networkId) => [networkId, []]),
+      );
       return {
         ...prev,
+        tokens: emptyTokensByNetwork,
         depositTokenListOwnerKey: ownerKey,
         currentPerpsDepositSelectedToken: undefined,
+        depositTokenListRevision: (prev.depositTokenListRevision ?? 0) + 1,
       };
     });
   }
@@ -484,14 +489,18 @@ class ServiceWebviewPerp extends ServiceBase {
       },
     );
 
-    const responses = (
-      await promiseAllSettledEnhanced(requestFactories, {
-        continueOnError: true,
-        concurrency: 3,
-      })
-    ).filter((response): response is IFetchAccountTokensResp =>
-      Boolean(response),
+    const settledResponses = await promiseAllSettledEnhanced(requestFactories, {
+      continueOnError: true,
+      concurrency: 3,
+    });
+    const responses = settledResponses.filter(
+      (response): response is IFetchAccountTokensResp => Boolean(response),
     );
+    if (responses.length !== supportedNetworkIds.length) {
+      throw new OneKeyError(
+        '[ServiceWebviewPerp] Failed to fetch all perps deposit token networks',
+      );
+    }
     const { networks } =
       await this.backgroundApi.serviceNetwork.getNetworksByIds({
         networkIds: supportedNetworkIds,

--- a/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
@@ -285,17 +285,21 @@ export interface IFetchPerpsDepositTokensFromWalletTokenListParams {
 }
 
 export interface IFetchPerpsDepositTokensFromWalletTokenListResult {
+  ownerKey: string;
   tokens: IPerpsDepositToken[];
   tokensByNetwork: Record<string, IPerpsDepositToken[]>;
   selectedToken?: IPerpsDepositToken;
+  isStale?: boolean;
 }
 
 interface IPerpsDepositTokenListData {
+  ownerKey: string;
   tokens: IPerpsDepositToken[];
   tokensByNetwork: Record<string, IPerpsDepositToken[]>;
 }
 
 interface IPerpsDepositTokenListCacheParams {
+  ownerKey: string;
   allNetworksAccountId: string;
   ownerIndexId?: string;
   supportedNetworkIds: string[];
@@ -392,13 +396,33 @@ class ServiceWebviewPerp extends ServiceBase {
   }
 
   private buildPerpsDepositTokenListCacheKey({
-    allNetworksAccountId,
-    ownerIndexId,
+    ownerKey,
     supportedNetworkIds,
   }: IPerpsDepositTokenListCacheParams) {
-    return `${allNetworksAccountId}::${ownerIndexId ?? ''}::${supportedNetworkIds.join(
-      ',',
-    )}`;
+    return `${ownerKey}::${supportedNetworkIds.join(',')}`;
+  }
+
+  private buildPerpsDepositTokenListOwnerKey({
+    allNetworksAccountId,
+    ownerIndexId,
+  }: Pick<
+    IPerpsDepositTokenListCacheParams,
+    'allNetworksAccountId' | 'ownerIndexId'
+  >) {
+    return `${allNetworksAccountId}::${ownerIndexId ?? ''}`;
+  }
+
+  private async setPerpsDepositTokenListActiveOwner(ownerKey: string) {
+    await perpsDepositTokensAtom.set((prev) => {
+      if (prev.depositTokenListOwnerKey === ownerKey) {
+        return prev;
+      }
+      return {
+        ...prev,
+        depositTokenListOwnerKey: ownerKey,
+        currentPerpsDepositSelectedToken: undefined,
+      };
+    });
   }
 
   private getPerpsDepositTokenListDataMemoryCache(
@@ -416,12 +440,14 @@ class ServiceWebviewPerp extends ServiceBase {
   }
 
   private async fetchPerpsDepositTokenListDataUncached({
+    ownerKey,
     allNetworksAccountId,
     ownerIndexId,
     supportedNetworkIds,
   }: IPerpsDepositTokenListCacheParams): Promise<IPerpsDepositTokenListData> {
     if (!supportedNetworkIds.length) {
       return {
+        ownerKey,
         tokens: [],
         tokensByNetwork: {},
       };
@@ -488,6 +514,7 @@ class ServiceWebviewPerp extends ServiceBase {
       return memo;
     }, {});
     return {
+      ownerKey,
       tokens,
       tokensByNetwork,
     };
@@ -506,13 +533,12 @@ class ServiceWebviewPerp extends ServiceBase {
 
     const promise = this.fetchPerpsDepositTokenListDataUncached(params)
       .then((data) => {
-        if (data.tokens.length > 0) {
-          void this.backgroundApi.simpleDb.perp.setPerpsDepositTokenListCache({
-            cacheKey,
-            tokens: data.tokens,
-            tokensByNetwork: data.tokensByNetwork,
-          });
-        }
+        void this.backgroundApi.simpleDb.perp.setPerpsDepositTokenListCache({
+          cacheKey,
+          ownerKey: data.ownerKey,
+          tokens: data.tokens,
+          tokensByNetwork: data.tokensByNetwork,
+        });
         return data;
       })
       .catch((error: unknown) => {
@@ -530,12 +556,18 @@ class ServiceWebviewPerp extends ServiceBase {
   }
 
   private async updatePerpsDepositTokenListAtom({
+    ownerKey,
     tokens,
     tokensByNetwork,
   }: IPerpsDepositTokenListData) {
     let selectedToken: IPerpsDepositToken | undefined;
+    let isStale = false;
 
     await perpsDepositTokensAtom.set((prev) => {
+      if (prev.depositTokenListOwnerKey !== ownerKey) {
+        isStale = true;
+        return prev;
+      }
       selectedToken = resolvePerpsDepositSelectedToken({
         tokens,
         currentToken: prev.currentPerpsDepositSelectedToken,
@@ -544,10 +576,11 @@ class ServiceWebviewPerp extends ServiceBase {
         ...prev,
         tokens: tokensByNetwork,
         currentPerpsDepositSelectedToken: selectedToken,
+        depositTokenListOwnerKey: ownerKey,
       };
     });
 
-    return selectedToken;
+    return { selectedToken, isStale };
   }
 
   private refreshPerpsDepositTokenListDataInBackground(
@@ -573,24 +606,32 @@ class ServiceWebviewPerp extends ServiceBase {
         accountId,
         indexedAccountId,
       });
+    const ownerKey = this.buildPerpsDepositTokenListOwnerKey({
+      allNetworksAccountId,
+      ownerIndexId,
+    });
     const currentDepositTokens = await perpsDepositTokensAtom.get();
     const supportedNetworkIds = Object.keys(
       currentDepositTokens.tokens,
     ).toSorted();
     const cacheParams = {
+      ownerKey,
       allNetworksAccountId,
       ownerIndexId,
       supportedNetworkIds,
     };
+    await this.setPerpsDepositTokenListActiveOwner(ownerKey);
 
     const memoryCache =
       this.getPerpsDepositTokenListDataMemoryCache(cacheParams);
     if (memoryCache) {
       const data = await memoryCache;
-      const selectedToken = await this.updatePerpsDepositTokenListAtom(data);
+      const { selectedToken, isStale } =
+        await this.updatePerpsDepositTokenListAtom(data);
       return {
         ...data,
         selectedToken,
+        isStale,
       };
     }
 
@@ -603,23 +644,28 @@ class ServiceWebviewPerp extends ServiceBase {
 
     if (coldCache) {
       const data = {
+        ownerKey: coldCache.ownerKey ?? ownerKey,
         tokens: coldCache.tokens,
         tokensByNetwork: coldCache.tokensByNetwork,
       };
-      const selectedToken = await this.updatePerpsDepositTokenListAtom(data);
+      const { selectedToken, isStale } =
+        await this.updatePerpsDepositTokenListAtom(data);
       this.refreshPerpsDepositTokenListDataInBackground(cacheParams);
       return {
         ...data,
         selectedToken,
+        isStale,
       };
     }
 
     const data = await this.fetchPerpsDepositTokenListDataCached(cacheParams);
-    const selectedToken = await this.updatePerpsDepositTokenListAtom(data);
+    const { selectedToken, isStale } =
+      await this.updatePerpsDepositTokenListAtom(data);
 
     return {
       ...data,
       selectedToken,
+      isStale,
     };
   }
 

--- a/packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.test.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.test.ts
@@ -228,6 +228,45 @@ describe('depositTokenListUtils', () => {
     );
   });
 
+  it('does not fuzzy match another network when token map keys share network prefixes', () => {
+    const ethToken = makeToken({
+      networkId: 'evm--1',
+      address: '0xabc',
+      symbol: 'TOKEN',
+      $key: 'missing-token-key',
+    });
+
+    const result = buildPerpsDepositTokensFromWalletTokenResponses({
+      responses: [
+        makeResponse({
+          tokens: [ethToken],
+          tokenMap: {
+            'wallet:evm--10:0xabc': makeFiat({
+              balanceParsed: '10',
+              fiatValue: '10',
+              price: 1,
+            }),
+            'wallet:evm--137:0xabc': makeFiat({
+              balanceParsed: '137',
+              fiatValue: '137',
+              price: 1,
+            }),
+          },
+        }),
+      ],
+      networkLogoURIByNetworkId: {},
+    });
+
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        symbol: 'TOKEN',
+        balanceParsed: undefined,
+        fiatValue: undefined,
+        price: undefined,
+      }),
+    );
+  });
+
   it('groups tokens by network and picks Arbitrum USDC as the default token', () => {
     const eth = makeToken({
       networkId: 'evm--1',

--- a/packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.test.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.test.ts
@@ -1,0 +1,326 @@
+import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
+import { USDC_TOKEN_INFO } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type {
+  IAccountToken,
+  IFetchAccountTokensResp,
+  ITokenFiat,
+} from '@onekeyhq/shared/types/token';
+
+import {
+  buildPerpsDepositTokensByNetwork,
+  buildPerpsDepositTokensFromWalletTokenResponses,
+  getDefaultPerpsDepositToken,
+  resolvePerpsDepositSelectedToken,
+} from './depositTokenListUtils';
+
+const makeToken = (
+  overrides: Partial<IAccountToken> & {
+    networkId: string;
+    address: string;
+    symbol: string;
+  },
+): IAccountToken => {
+  const { networkId, address, symbol, ...rest } = overrides;
+  return {
+    $key: `${networkId}_${address}`,
+    decimals: 18,
+    name: symbol,
+    symbol,
+    address,
+    networkId,
+    isNative: false,
+    logoURI: `${symbol}.png`,
+    ...rest,
+  };
+};
+
+const makeFiat = (overrides: Partial<ITokenFiat> = {}): ITokenFiat => ({
+  balance: '0',
+  balanceParsed: '0',
+  fiatValue: '0',
+  price: 0,
+  ...overrides,
+});
+
+const makeResponse = ({
+  tokens,
+  tokenMap,
+  smallBalanceTokens = [],
+  riskTokens = [],
+}: {
+  tokens: IAccountToken[];
+  tokenMap: Record<string, ITokenFiat>;
+  smallBalanceTokens?: IAccountToken[];
+  riskTokens?: IAccountToken[];
+}): IFetchAccountTokensResp => ({
+  tokens: {
+    data: tokens,
+    keys: tokens.map((token) => token.$key).join(','),
+    map: tokenMap,
+  },
+  smallBalanceTokens: {
+    data: smallBalanceTokens,
+    keys: smallBalanceTokens.map((token) => token.$key).join(','),
+    map: Object.fromEntries(
+      smallBalanceTokens.map((token) => [token.$key, makeFiat()]),
+    ),
+  },
+  riskTokens: {
+    data: riskTokens,
+    keys: riskTokens.map((token) => token.$key).join(','),
+    map: Object.fromEntries(
+      riskTokens.map((token) => [token.$key, makeFiat()]),
+    ),
+  },
+});
+
+describe('depositTokenListUtils', () => {
+  it('maps only wallet home visible tokens and excludes small balance and risky tokens', () => {
+    const eth = makeToken({
+      networkId: 'evm--1',
+      address: '',
+      symbol: 'ETH',
+      isNative: true,
+      decimals: 18,
+      name: 'Ethereum',
+    });
+    const arbUsdc = makeToken({
+      networkId: PERPS_NETWORK_ID,
+      address: USDC_TOKEN_INFO.address,
+      symbol: 'USDC',
+      decimals: USDC_TOKEN_INFO.decimals,
+      name: USDC_TOKEN_INFO.name,
+    });
+    const smallSol = makeToken({
+      networkId: 'sol--101',
+      address: 'So11111111111111111111111111111111111111112',
+      symbol: 'SOL',
+    });
+    const risky = makeToken({
+      networkId: 'evm--137',
+      address: '0xrisky',
+      symbol: 'RISK',
+    });
+
+    const result = buildPerpsDepositTokensFromWalletTokenResponses({
+      responses: [
+        makeResponse({
+          tokens: [eth, arbUsdc],
+          smallBalanceTokens: [smallSol],
+          riskTokens: [risky],
+          tokenMap: {
+            [eth.$key]: makeFiat({
+              balanceParsed: '0.1623',
+              fiatValue: '257.04',
+              price: 1583,
+            }),
+            [arbUsdc.$key]: makeFiat({
+              balanceParsed: '24.9523',
+              fiatValue: '24.94',
+              price: 1,
+            }),
+          },
+        }),
+      ],
+      networkLogoURIByNetworkId: {
+        'evm--1': 'eth-network.png',
+        [PERPS_NETWORK_ID]: 'arbitrum-network.png',
+      },
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        networkId: 'evm--1',
+        contractAddress: '',
+        symbol: 'ETH',
+        balanceParsed: '0.1623',
+        fiatValue: '257.04',
+        price: '1583',
+        networkLogoURI: 'eth-network.png',
+        isNative: true,
+      }),
+      expect.objectContaining({
+        networkId: PERPS_NETWORK_ID,
+        contractAddress: USDC_TOKEN_INFO.address,
+        symbol: 'USDC',
+        balanceParsed: '24.9523',
+        fiatValue: '24.94',
+        price: '1',
+        networkLogoURI: 'arbitrum-network.png',
+      }),
+    ]);
+    expect(result.map((token) => token.symbol)).not.toContain('SOL');
+    expect(result.map((token) => token.symbol)).not.toContain('RISK');
+  });
+
+  it('sorts wallet tokens by fiat value descending and keeps stable order for equal values', () => {
+    const first = makeToken({
+      networkId: 'evm--1',
+      address: '0xfirst',
+      symbol: 'FIRST',
+    });
+    const second = makeToken({
+      networkId: 'evm--137',
+      address: '0xsecond',
+      symbol: 'SECOND',
+    });
+    const third = makeToken({
+      networkId: 'sol--101',
+      address: 'third',
+      symbol: 'THIRD',
+    });
+
+    const result = buildPerpsDepositTokensFromWalletTokenResponses({
+      responses: [
+        makeResponse({
+          tokens: [first, second, third],
+          tokenMap: {
+            [first.$key]: makeFiat({ fiatValue: '10', price: 1 }),
+            [second.$key]: makeFiat({ fiatValue: '20', price: 1 }),
+            [third.$key]: makeFiat({ fiatValue: '10', price: 1 }),
+          },
+        }),
+      ],
+      networkLogoURIByNetworkId: {},
+    });
+
+    expect(result.map((token) => token.symbol)).toEqual([
+      'SECOND',
+      'FIRST',
+      'THIRD',
+    ]);
+  });
+
+  it('maps fiat data when wallet token map keys do not exactly match token $key', () => {
+    const arbUsdc = makeToken({
+      networkId: PERPS_NETWORK_ID,
+      address: USDC_TOKEN_INFO.address,
+      symbol: 'USDC',
+      decimals: USDC_TOKEN_INFO.decimals,
+      name: USDC_TOKEN_INFO.name,
+      $key: 'wallet-usdc-key',
+    });
+
+    const result = buildPerpsDepositTokensFromWalletTokenResponses({
+      responses: [
+        makeResponse({
+          tokens: [arbUsdc],
+          tokenMap: {
+            [`wallet:${PERPS_NETWORK_ID}:${USDC_TOKEN_INFO.address.toLowerCase()}`]:
+              makeFiat({
+                balanceParsed: '24.9523',
+                fiatValue: '24.94',
+                price: 1,
+              }),
+          },
+        }),
+      ],
+      networkLogoURIByNetworkId: {},
+    });
+
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        symbol: 'USDC',
+        balanceParsed: '24.9523',
+        fiatValue: '24.94',
+        price: '1',
+      }),
+    );
+  });
+
+  it('groups tokens by network and picks Arbitrum USDC as the default token', () => {
+    const eth = makeToken({
+      networkId: 'evm--1',
+      address: '',
+      symbol: 'ETH',
+      isNative: true,
+    });
+    const arbUsdc = makeToken({
+      networkId: PERPS_NETWORK_ID,
+      address: USDC_TOKEN_INFO.address.toLowerCase(),
+      symbol: 'USDC',
+      decimals: USDC_TOKEN_INFO.decimals,
+      name: USDC_TOKEN_INFO.name,
+    });
+    const depositTokens = buildPerpsDepositTokensFromWalletTokenResponses({
+      responses: [
+        makeResponse({
+          tokens: [eth, arbUsdc],
+          tokenMap: {
+            [eth.$key]: makeFiat({ fiatValue: '100', price: 1000 }),
+            [arbUsdc.$key]: makeFiat({ fiatValue: '50', price: 1 }),
+          },
+        }),
+      ],
+      networkLogoURIByNetworkId: {},
+    });
+
+    expect(buildPerpsDepositTokensByNetwork(depositTokens)).toEqual({
+      'evm--1': [expect.objectContaining({ symbol: 'ETH' })],
+      [PERPS_NETWORK_ID]: [expect.objectContaining({ symbol: 'USDC' })],
+    });
+    expect(getDefaultPerpsDepositToken(depositTokens)).toEqual(
+      expect.objectContaining({
+        networkId: PERPS_NETWORK_ID,
+        contractAddress: USDC_TOKEN_INFO.address.toLowerCase(),
+      }),
+    );
+  });
+
+  it('keeps the current selected token when it still exists in the refreshed wallet list', () => {
+    const eth = makeToken({
+      networkId: 'evm--1',
+      address: '',
+      symbol: 'ETH',
+      isNative: true,
+    });
+    const arbUsdc = makeToken({
+      networkId: PERPS_NETWORK_ID,
+      address: USDC_TOKEN_INFO.address,
+      symbol: 'USDC',
+      decimals: USDC_TOKEN_INFO.decimals,
+      name: USDC_TOKEN_INFO.name,
+    });
+    const depositTokens = buildPerpsDepositTokensFromWalletTokenResponses({
+      responses: [
+        makeResponse({
+          tokens: [eth, arbUsdc],
+          tokenMap: {
+            [eth.$key]: makeFiat({
+              balanceParsed: '0.2',
+              fiatValue: '300',
+              price: 1500,
+            }),
+            [arbUsdc.$key]: makeFiat({
+              balanceParsed: '24.9523',
+              fiatValue: '24.94',
+              price: 1,
+            }),
+          },
+        }),
+      ],
+      networkLogoURIByNetworkId: {},
+    });
+
+    expect(
+      resolvePerpsDepositSelectedToken({
+        tokens: depositTokens,
+        currentToken: {
+          networkId: 'evm--1',
+          contractAddress: '',
+          name: 'Ethereum',
+          symbol: 'ETH',
+          decimals: 18,
+          networkLogoURI: '',
+          isNative: true,
+        },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        symbol: 'ETH',
+        balanceParsed: '0.2',
+        fiatValue: '300',
+      }),
+    );
+  });
+});

--- a/packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.ts
@@ -19,6 +19,10 @@ function normalizeTokenAddress(address?: string) {
   return (address ?? '').toLowerCase();
 }
 
+function splitTokenFiatKey(key: string) {
+  return key.toLowerCase().split(/[:_]/).filter(Boolean);
+}
+
 function getTokenFiat({
   token,
   tokenMap,
@@ -44,10 +48,10 @@ function getTokenFiat({
   if (token.networkId && normalizedAddress) {
     const normalizedNetworkId = token.networkId.toLowerCase();
     const matchedEntry = Object.entries(tokenMap).find(([key]) => {
-      const normalizedKey = key.toLowerCase();
+      const keyParts = splitTokenFiatKey(key);
       return (
-        normalizedKey.includes(normalizedNetworkId) &&
-        normalizedKey.includes(normalizedAddress)
+        keyParts.includes(normalizedNetworkId) &&
+        keyParts.includes(normalizedAddress)
       );
     });
     if (matchedEntry) {

--- a/packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.ts
@@ -1,0 +1,174 @@
+import BigNumber from 'bignumber.js';
+
+import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
+import { USDC_TOKEN_INFO } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
+import type {
+  IAccountToken,
+  IFetchAccountTokensResp,
+  ITokenFiat,
+} from '@onekeyhq/shared/types/token';
+
+import type { IPerpsDepositToken } from '../../../states/jotai/atoms';
+
+type IBuildPerpsDepositTokensFromWalletTokenResponsesParams = {
+  responses: IFetchAccountTokensResp[];
+  networkLogoURIByNetworkId: Record<string, string | undefined>;
+};
+
+function normalizeTokenAddress(address?: string) {
+  return (address ?? '').toLowerCase();
+}
+
+function getTokenFiat({
+  token,
+  tokenMap,
+}: {
+  token: IAccountToken;
+  tokenMap: Record<string, ITokenFiat>;
+}) {
+  const normalizedAddress = normalizeTokenAddress(token.address);
+  const candidates = [
+    token.$key,
+    token.$key && token.$key.toLowerCase(),
+    token.networkId && `${token.networkId}_${token.address}`,
+    token.networkId && `${token.networkId}_${normalizedAddress}`,
+  ].filter(Boolean);
+
+  for (const key of candidates) {
+    const fiat = tokenMap[key];
+    if (fiat) {
+      return fiat;
+    }
+  }
+
+  if (token.networkId && normalizedAddress) {
+    const normalizedNetworkId = token.networkId.toLowerCase();
+    const matchedEntry = Object.entries(tokenMap).find(([key]) => {
+      const normalizedKey = key.toLowerCase();
+      return (
+        normalizedKey.includes(normalizedNetworkId) &&
+        normalizedKey.includes(normalizedAddress)
+      );
+    });
+    if (matchedEntry) {
+      return matchedEntry[1];
+    }
+  }
+
+  return undefined;
+}
+
+function toOptionalString(value: string | number | undefined) {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  return String(value);
+}
+
+function mapWalletTokenToPerpsDepositToken({
+  token,
+  fiat,
+  networkLogoURI,
+}: {
+  token: IAccountToken;
+  fiat?: ITokenFiat;
+  networkLogoURI?: string;
+}): IPerpsDepositToken | undefined {
+  if (!token.networkId) {
+    return undefined;
+  }
+
+  return {
+    networkId: token.networkId,
+    contractAddress: token.address ?? '',
+    name: token.name,
+    symbol: token.symbol,
+    decimals: token.decimals,
+    networkLogoURI: networkLogoURI ?? '',
+    price: toOptionalString(fiat?.price),
+    balanceParsed: fiat?.balanceParsed,
+    fiatValue: fiat?.fiatValue,
+    isNative: token.isNative,
+    logoURI: token.logoURI,
+  };
+}
+
+export function buildPerpsDepositTokensFromWalletTokenResponses({
+  responses,
+  networkLogoURIByNetworkId,
+}: IBuildPerpsDepositTokensFromWalletTokenResponsesParams): IPerpsDepositToken[] {
+  const indexedTokens: Array<{ index: number; token: IPerpsDepositToken }> = [];
+  let index = 0;
+
+  for (const response of responses) {
+    for (const walletToken of response.tokens.data) {
+      const token = mapWalletTokenToPerpsDepositToken({
+        token: walletToken,
+        fiat: getTokenFiat({
+          token: walletToken,
+          tokenMap: response.tokens.map,
+        }),
+        networkLogoURI: walletToken.networkId
+          ? networkLogoURIByNetworkId[walletToken.networkId]
+          : undefined,
+      });
+      if (token) {
+        indexedTokens.push({ index, token });
+      }
+      index += 1;
+    }
+  }
+
+  return indexedTokens
+    .toSorted((a, b) => {
+      const valueCompare = new BigNumber(b.token.fiatValue ?? '0').comparedTo(
+        new BigNumber(a.token.fiatValue ?? '0'),
+      );
+      if (valueCompare !== 0) {
+        return valueCompare;
+      }
+      return a.index - b.index;
+    })
+    .map((item) => item.token);
+}
+
+export function buildPerpsDepositTokensByNetwork(tokens: IPerpsDepositToken[]) {
+  return tokens.reduce<Record<string, IPerpsDepositToken[]>>((memo, token) => {
+    memo[token.networkId] = memo[token.networkId] ?? [];
+    memo[token.networkId].push(token);
+    return memo;
+  }, {});
+}
+
+export function getDefaultPerpsDepositToken(tokens: IPerpsDepositToken[]) {
+  return (
+    tokens.find(
+      (token) =>
+        token.networkId === PERPS_NETWORK_ID &&
+        normalizeTokenAddress(token.contractAddress) ===
+          normalizeTokenAddress(USDC_TOKEN_INFO.address),
+    ) ?? tokens[0]
+  );
+}
+
+export function resolvePerpsDepositSelectedToken({
+  tokens,
+  currentToken,
+}: {
+  tokens: IPerpsDepositToken[];
+  currentToken?: IPerpsDepositToken;
+}) {
+  if (currentToken) {
+    const matchedToken = tokens.find(
+      (token) =>
+        token.networkId === currentToken.networkId &&
+        normalizeTokenAddress(token.contractAddress) ===
+          normalizeTokenAddress(currentToken.contractAddress),
+    );
+    if (matchedToken) {
+      return matchedToken;
+    }
+  }
+
+  return getDefaultPerpsDepositToken(tokens);
+}

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -894,6 +894,7 @@ export interface IPerpsDepositToken {
 export interface IPerpsDepositTokensAtom {
   tokens: Record<string, IPerpsDepositToken[]>;
   currentPerpsDepositSelectedToken?: IPerpsDepositToken;
+  depositTokenListOwnerKey?: string;
 }
 export const {
   target: perpsDepositTokensAtom,

--- a/packages/kit-bg/src/states/jotai/atoms/perps.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/perps.ts
@@ -895,6 +895,7 @@ export interface IPerpsDepositTokensAtom {
   tokens: Record<string, IPerpsDepositToken[]>;
   currentPerpsDepositSelectedToken?: IPerpsDepositToken;
   depositTokenListOwnerKey?: string;
+  depositTokenListRevision?: number;
 }
 export const {
   target: perpsDepositTokensAtom,

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -458,6 +458,21 @@ function DepositWithdrawContent({
     IPerpsDepositToken | undefined
   >(currentPerpsDepositSelectedToken);
   const previousDepositTokenIdentityRef = useRef<string | undefined>(undefined);
+  const depositTokenRequestKey = useMemo(
+    () =>
+      [
+        selectedAccount.accountId ?? '',
+        selectedAccount.indexedAccountId ?? '',
+        selectedAccount.accountAddress ?? '',
+      ].join('::'),
+    [
+      selectedAccount.accountAddress,
+      selectedAccount.accountId,
+      selectedAccount.indexedAccountId,
+    ],
+  );
+  const depositTokenRequestKeyRef = useRef(depositTokenRequestKey);
+  depositTokenRequestKeyRef.current = depositTokenRequestKey;
 
   const [depositTokensWithPrice, setDepositTokensWithPrice] = useState<
     IPerpsDepositToken[]
@@ -546,6 +561,7 @@ function DepositWithdrawContent({
 
   const { result, isLoading: balanceLoading } = usePromiseResult(
     async () => {
+      const requestKey = depositTokenRequestKey;
       if (
         !selectedAccount.accountId ||
         !selectedAccount.accountAddress ||
@@ -555,13 +571,16 @@ function DepositWithdrawContent({
         return [];
       }
       try {
-        const { tokens: depositTokens } =
+        const { isStale, tokens: depositTokens } =
           await backgroundApiProxy.serviceWebviewPerp.fetchPerpsDepositTokensFromWalletTokenList(
             {
               accountId: selectedAccount.accountId ?? '',
               indexedAccountId: selectedAccount.indexedAccountId ?? undefined,
             },
           );
+        if (isStale || depositTokenRequestKeyRef.current !== requestKey) {
+          return [];
+        }
         const nativeTokenNetworkIds = Array.from(
           new Set(
             depositTokens
@@ -583,6 +602,9 @@ function DepositWithdrawContent({
         setHasLoadedDepositTokenBalances(true);
         return depositTokens;
       } catch (error) {
+        if (depositTokenRequestKeyRef.current !== requestKey) {
+          return [];
+        }
         console.error(
           '[DepositWithdrawModal] Failed to fetch tokens balance:',
           error,
@@ -600,6 +622,7 @@ function DepositWithdrawContent({
       selectedAccount.accountId,
       selectedAccount.accountAddress,
       selectedAccount.indexedAccountId,
+      depositTokenRequestKey,
       checkAccountSupport,
       setPerpsDepositTokensAtom,
     ],

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -697,6 +697,10 @@ function DepositWithdrawContent({
   ]);
 
   useEffect(() => {
+    depositTokenListOwnerKeyRef.current = undefined;
+    lastSyncedDepositTokenListRevisionRef.current = undefined;
+    setDepositTokensWithPrice([]);
+    setNativeTokenConfigs([]);
     setHasLoadedDepositTokenBalances(false);
   }, [
     selectedAccount.accountId,

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -100,6 +100,7 @@ const DEPOSIT_WITHDRAW_INPUT_ACCESSORY_VIEW_ID =
 const PERP_DESKTOP_DEPOSIT_WITHDRAW_DIALOG_HEIGHT = 560;
 const PERP_DESKTOP_DEPOSIT_AMOUNT_INPUT_BLOCK_HEIGHT = 220;
 const PERP_DESKTOP_DEPOSIT_SELECT_TOKEN_LIST_HEIGHT = 430;
+const PERP_NATIVE_DEPOSIT_WITHDRAW_ESTIMATED_CONTENT_HEIGHT = 300;
 const LIFI_FALLBACK_LOGO = require('@onekeyhq/kit/assets/perps/lifi-logo.png');
 
 interface IDepositWithdrawParams {
@@ -1597,11 +1598,9 @@ function DepositWithdrawContent({
                   size="$3.5"
                 />
               </XStack>
-              {hasSourceBalance ? (
-                <SizableText size="$bodySm" color="$textSubdued">
-                  {sourceBalanceText}
-                </SizableText>
-              ) : null}
+              <SizableText size="$bodySm" color="$textSubdued">
+                {hasSourceBalance ? sourceBalanceText : ' '}
+              </SizableText>
             </YStack>
           </YStack>
         </XStack>
@@ -2468,6 +2467,9 @@ export async function showDepositWithdrawDialog(
           flex: 1,
           pb: '$0',
         },
+    estimatedContentHeight: platformEnv.isNative
+      ? PERP_NATIVE_DEPOSIT_WITHDRAW_ESTIMATED_CONTENT_HEIGHT
+      : undefined,
     floatingPanelProps: platformEnv.isNative
       ? undefined
       : {

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -436,7 +436,12 @@ function DepositWithdrawContent({
   >('form');
   const amountInputRef = useRef<ISendAmountAutoSizeInputRef>(null);
   const [
-    { tokens, currentPerpsDepositSelectedToken },
+    {
+      tokens,
+      currentPerpsDepositSelectedToken,
+      depositTokenListOwnerKey,
+      depositTokenListRevision,
+    },
     setPerpsDepositTokensAtom,
   ] = usePerpsDepositTokensAtom();
 
@@ -474,6 +479,10 @@ function DepositWithdrawContent({
   );
   const depositTokenRequestKeyRef = useRef(depositTokenRequestKey);
   depositTokenRequestKeyRef.current = depositTokenRequestKey;
+  const depositTokenListOwnerKeyRef = useRef<string | undefined>(undefined);
+  const lastSyncedDepositTokenListRevisionRef = useRef<number | undefined>(
+    undefined,
+  );
 
   const [depositTokensWithPrice, setDepositTokensWithPrice] = useState<
     IPerpsDepositToken[]
@@ -560,6 +569,41 @@ function DepositWithdrawContent({
     return !isWatchingAccount;
   }, [selectedAccount.accountId]);
 
+  const syncDepositTokenBalances = useCallback(
+    async ({
+      depositTokens,
+      requestKey,
+    }: {
+      depositTokens: IPerpsDepositToken[];
+      requestKey: string;
+    }) => {
+      const nativeTokenNetworkIds = Array.from(
+        new Set(
+          depositTokens
+            .filter((token) => token.isNative)
+            .map((token) => token.networkId),
+        ),
+      );
+      const nativeTokenConfigsRes = (
+        await Promise.all(
+          nativeTokenNetworkIds.map((networkId) =>
+            backgroundApiProxy.serviceSwap.fetchSwapNativeTokenConfig({
+              networkId,
+            }),
+          ),
+        )
+      ).filter((item): item is ISwapNativeTokenConfig => Boolean(item));
+      if (depositTokenRequestKeyRef.current !== requestKey) {
+        return false;
+      }
+      setNativeTokenConfigs(nativeTokenConfigsRes);
+      setDepositTokensWithPrice(depositTokens);
+      setHasLoadedDepositTokenBalances(true);
+      return true;
+    },
+    [],
+  );
+
   const { result, isLoading: balanceLoading } = usePromiseResult(
     async () => {
       const requestKey = depositTokenRequestKey;
@@ -568,39 +612,32 @@ function DepositWithdrawContent({
         !selectedAccount.accountAddress ||
         !checkAccountSupport
       ) {
+        depositTokenListOwnerKeyRef.current = undefined;
         setHasLoadedDepositTokenBalances(true);
         return [];
       }
       try {
-        const { isStale, tokens: depositTokens } =
-          await backgroundApiProxy.serviceWebviewPerp.fetchPerpsDepositTokensFromWalletTokenList(
-            {
-              accountId: selectedAccount.accountId ?? '',
-              indexedAccountId: selectedAccount.indexedAccountId ?? undefined,
-            },
-          );
+        const {
+          isStale,
+          ownerKey,
+          tokens: depositTokens,
+        } = await backgroundApiProxy.serviceWebviewPerp.fetchPerpsDepositTokensFromWalletTokenList(
+          {
+            accountId: selectedAccount.accountId ?? '',
+            indexedAccountId: selectedAccount.indexedAccountId ?? undefined,
+          },
+        );
         if (isStale || depositTokenRequestKeyRef.current !== requestKey) {
           return [];
         }
-        const nativeTokenNetworkIds = Array.from(
-          new Set(
-            depositTokens
-              .filter((token) => token.isNative)
-              .map((token) => token.networkId),
-          ),
-        );
-        const nativeTokenConfigsRes = (
-          await Promise.all(
-            nativeTokenNetworkIds.map((networkId) =>
-              backgroundApiProxy.serviceSwap.fetchSwapNativeTokenConfig({
-                networkId,
-              }),
-            ),
-          )
-        ).filter((item): item is ISwapNativeTokenConfig => Boolean(item));
-        setNativeTokenConfigs(nativeTokenConfigsRes);
-        setDepositTokensWithPrice(depositTokens);
-        setHasLoadedDepositTokenBalances(true);
+        depositTokenListOwnerKeyRef.current = ownerKey;
+        const didSync = await syncDepositTokenBalances({
+          depositTokens,
+          requestKey,
+        });
+        if (!didSync) {
+          return [];
+        }
         return depositTokens;
       } catch (error) {
         if (depositTokenRequestKeyRef.current !== requestKey) {
@@ -626,6 +663,7 @@ function DepositWithdrawContent({
       depositTokenRequestKey,
       checkAccountSupport,
       setPerpsDepositTokensAtom,
+      syncDepositTokenBalances,
     ],
     {
       watchLoading: true,
@@ -633,6 +671,30 @@ function DepositWithdrawContent({
       revalidateOnFocus: true,
     },
   );
+
+  useEffect(() => {
+    if (
+      !checkAccountSupport ||
+      !depositTokenListOwnerKey ||
+      depositTokenListOwnerKey !== depositTokenListOwnerKeyRef.current ||
+      depositTokenListRevision === undefined ||
+      depositTokenListRevision === lastSyncedDepositTokenListRevisionRef.current
+    ) {
+      return;
+    }
+
+    lastSyncedDepositTokenListRevisionRef.current = depositTokenListRevision;
+    void syncDepositTokenBalances({
+      depositTokens: cachedDepositTokens,
+      requestKey: depositTokenRequestKeyRef.current,
+    });
+  }, [
+    cachedDepositTokens,
+    checkAccountSupport,
+    depositTokenListOwnerKey,
+    depositTokenListRevision,
+    syncDepositTokenBalances,
+  ]);
 
   useEffect(() => {
     setHasLoadedDepositTokenBalances(false);

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -78,10 +78,7 @@ import {
   WITHDRAW_FEE,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import { swapDefaultSetTokens } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
-import type {
-  ISwapNativeTokenConfig,
-  ISwapToken,
-} from '@onekeyhq/shared/types/swap/types';
+import type { ISwapNativeTokenConfig } from '@onekeyhq/shared/types/swap/types';
 import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
 
 import usePerpDeposit from '../../../hooks/usePerpDeposit';
@@ -442,10 +439,6 @@ function DepositWithdrawContent({
     setPerpsDepositTokensAtom,
   ] = usePerpsDepositTokensAtom();
 
-  const tokensRef = useRef<Record<string, IPerpsDepositToken[]>>(tokens);
-  if (tokensRef.current !== tokens) {
-    tokensRef.current = tokens;
-  }
   const cachedDepositTokens = useMemo(
     () => Object.values(tokens).flat(),
     [tokens],
@@ -562,98 +555,33 @@ function DepositWithdrawContent({
         return [];
       }
       try {
-        const tokensList = Object.values(tokensRef.current).flat() || [];
-        const networkIds = Object.keys(tokensRef.current) || [];
-        const tokenDetailsAndNativeTokenConfigs = await Promise.all(
-          networkIds.map(async (networkId) => {
-            const defaultDeriveType =
-              await backgroundApiProxy.serviceNetwork.getGlobalDeriveTypeOfNetwork(
-                {
-                  networkId,
-                },
-              );
-            let tokenDetails: ISwapToken[] | undefined;
-            let nativeTokenConfig: ISwapNativeTokenConfig | undefined;
-            try {
-              const accountAddressInfo =
-                await backgroundApiProxy.serviceAccount.getNetworkAccount({
-                  indexedAccountId: selectedAccount.indexedAccountId ?? '',
-                  networkId,
-                  deriveType: defaultDeriveType ?? 'default',
-                  accountId: selectedAccount.indexedAccountId
-                    ? undefined
-                    : (selectedAccount.accountId ?? ''),
-                });
-              const [tokenDetailsRes, nativeTokenConfigRes] = await Promise.all(
-                [
-                  backgroundApiProxy.serviceSwap.fetchSwapTokenDetails({
-                    networkId,
-                    contractAddress:
-                      tokensRef.current?.[networkId]
-                        ?.map((token) => token.contractAddress)
-                        .join(',') || '',
-                    accountAddress: accountAddressInfo.addressDetail.address,
-                    accountId: accountAddressInfo.id ?? '',
-                    currency: 'usd',
-                  }),
-                  backgroundApiProxy.serviceSwap.fetchSwapNativeTokenConfig({
-                    networkId,
-                  }),
-                ],
-              );
-              tokenDetails = tokenDetailsRes;
-              nativeTokenConfig = nativeTokenConfigRes;
-            } catch (e) {
-              console.error(
-                '[DepositWithdrawModal] Failed to fetch tokens balance:',
-                e,
-              );
-            }
-            return {
-              tokenDetails,
-              nativeTokenConfig,
-            };
-          }),
+        const { tokens: depositTokens } =
+          await backgroundApiProxy.serviceWebviewPerp.fetchPerpsDepositTokensFromWalletTokenList(
+            {
+              accountId: selectedAccount.accountId ?? '',
+              indexedAccountId: selectedAccount.indexedAccountId ?? undefined,
+            },
+          );
+        const nativeTokenNetworkIds = Array.from(
+          new Set(
+            depositTokens
+              .filter((token) => token.isNative)
+              .map((token) => token.networkId),
+          ),
         );
-        const tokenDetails =
-          tokenDetailsAndNativeTokenConfigs
-            ?.flatMap((t) => t.tokenDetails)
-            .filter(Boolean) ?? [];
-        const nativeTokenConfigsRes =
-          tokenDetailsAndNativeTokenConfigs
-            ?.flatMap((t) => t.nativeTokenConfig)
-            .filter(Boolean) ?? [];
+        const nativeTokenConfigsRes = (
+          await Promise.all(
+            nativeTokenNetworkIds.map((networkId) =>
+              backgroundApiProxy.serviceSwap.fetchSwapNativeTokenConfig({
+                networkId,
+              }),
+            ),
+          )
+        ).filter((item): item is ISwapNativeTokenConfig => Boolean(item));
         setNativeTokenConfigs(nativeTokenConfigsRes);
-        if (tokenDetails) {
-          const depositTokensWithPriceRes = tokensList
-            .filter((originToken) =>
-              tokenDetails.find((t) =>
-                equalTokenNoCaseSensitive({ token1: t, token2: originToken }),
-              ),
-            )
-            .map((token) => ({
-              ...token,
-              balanceParsed: tokenDetails.find((t) =>
-                equalTokenNoCaseSensitive({ token1: t, token2: token }),
-              )?.balanceParsed,
-              price: tokenDetails.find((t) =>
-                equalTokenNoCaseSensitive({ token1: t, token2: token }),
-              )?.price,
-              fiatValue: tokenDetails.find((t) =>
-                equalTokenNoCaseSensitive({ token1: t, token2: token }),
-              )?.fiatValue,
-            }))
-            .toSorted((a, b) =>
-              new BigNumber(b.fiatValue ?? 0).comparedTo(
-                new BigNumber(a.fiatValue ?? 0),
-              ),
-            );
-          setDepositTokensWithPrice(depositTokensWithPriceRes);
-          setHasLoadedDepositTokenBalances(true);
-          return depositTokensWithPriceRes;
-        }
+        setDepositTokensWithPrice(depositTokens);
         setHasLoadedDepositTokenBalances(true);
-        return [];
+        return depositTokens;
       } catch (error) {
         console.error(
           '[DepositWithdrawModal] Failed to fetch tokens balance:',
@@ -679,7 +607,6 @@ function DepositWithdrawContent({
       watchLoading: true,
       checkIsMounted: true,
       revalidateOnFocus: true,
-      debounced: 1000,
     },
   );
 
@@ -1610,7 +1537,7 @@ function DepositWithdrawContent({
       ? numberFormat(displayDepositToken?.balanceParsed ?? '0', {
           formatter: 'balance',
         })
-      : '--';
+      : '';
     const sourceBalanceText = `${sourceBalanceFormatted} ${
       displayDepositToken?.symbol ?? ''
     }`;
@@ -1647,9 +1574,11 @@ function DepositWithdrawContent({
                   size="$3.5"
                 />
               </XStack>
-              <SizableText size="$bodySm" color="$textSubdued">
-                {sourceBalanceText}
-              </SizableText>
+              {hasSourceBalance ? (
+                <SizableText size="$bodySm" color="$textSubdued">
+                  {sourceBalanceText}
+                </SizableText>
+              ) : null}
             </YStack>
           </YStack>
         </XStack>

--- a/packages/kit/src/views/Perp/hooks/useShowDepositWithdrawModal.ts
+++ b/packages/kit/src/views/Perp/hooks/useShowDepositWithdrawModal.ts
@@ -28,6 +28,7 @@ export function useShowDepositWithdrawModal() {
           intl,
         );
       } else {
+        await import('../components/TradingPanel/modals/DepositWithdrawModal');
         navigation.pushModal(EModalRoutes.PerpModal, {
           screen: EModalPerpRoutes.MobileDepositWithdrawModal,
           params: { actionType },

--- a/packages/kit/src/views/Perp/router/index.ts
+++ b/packages/kit/src/views/Perp/router/index.ts
@@ -12,7 +12,6 @@ import {
   LazyLoadPage,
   LazyLoadRootTabPage,
 } from '../../../components/LazyLoadPage';
-import MobileDepositWithdrawModal from '../components/TradingPanel/modals/DepositWithdrawModal';
 import {
   getLoadedPerpsMobileTokenSelectorPage,
   loadPerpsMobileTokenSelectorPage,
@@ -41,6 +40,10 @@ function MobileTokenSelectorPage() {
 
 const MobileSetTpslModal = LazyLoadPage(
   () => import('../components/OrderInfoPanel/SetTpslModal'),
+);
+
+const MobileDepositWithdrawModal = LazyLoadPage(
+  () => import('../components/TradingPanel/modals/DepositWithdrawModal'),
 );
 
 const MobileDepositSelectTokenModal = LazyLoadPage(

--- a/packages/kit/src/views/Perp/router/index.ts
+++ b/packages/kit/src/views/Perp/router/index.ts
@@ -12,6 +12,7 @@ import {
   LazyLoadPage,
   LazyLoadRootTabPage,
 } from '../../../components/LazyLoadPage';
+import MobileDepositWithdrawModal from '../components/TradingPanel/modals/DepositWithdrawModal';
 import {
   getLoadedPerpsMobileTokenSelectorPage,
   loadPerpsMobileTokenSelectorPage,
@@ -40,10 +41,6 @@ function MobileTokenSelectorPage() {
 
 const MobileSetTpslModal = LazyLoadPage(
   () => import('../components/OrderInfoPanel/SetTpslModal'),
-);
-
-const MobileDepositWithdrawModal = LazyLoadPage(
-  () => import('../components/TradingPanel/modals/DepositWithdrawModal'),
 );
 
 const MobileDepositSelectTokenModal = LazyLoadPage(


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56758](https://onekeyhq.atlassian.net/browse/OK-56758)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Source the Perps deposit token list from the wallet token-list flow, scoped only by networks supported in `depositTokensByNetwork`.
- Add background memory cache, simpleDb cold-start cache, request de-duplication, and lower concurrency for deposit token loading.
- Keep wallet visibility filters for hidden, blocked, risky, and small-balance tokens; remove min-value filtering and server-token intersection from the client list.

## Intent & Context
OK-56758 optimizes the Perps deposit token selector so it follows the same visible tokens as the wallet home list while avoiding repeated balance reads on every modal/list open. The final product decision was that `depositTokensByNetwork` only defines supported networkIds, while the actual selectable tokens should come from `/wallet/v1/account/token/list` behavior with the wallet's existing hidden/blocked/small-balance filtering.

The user also reported desktop flicker in the Perps header and `--` balances in the Deposit modal during cold start. The implementation keeps token aggregation in the background service and gives the UI cached hydrated token data where possible.

## Root Cause
The previous deposit modal path depended on per-token swap/native-token detail data and modal-local loading state. That caused repeated requests when reopening the deposit token list and left the selected token balance unavailable during cold start. Separately, native token config was refetched on each modal open, adding avoidable request churn.

## Design Decisions
- Use the wallet token-list API path via `serviceToken.fetchAccountTokens`, because it already applies wallet visibility rules and returns token balances in the shape used by wallet home.
- Use `depositTokensByNetwork` only to choose supported networkIds to query, not as an intersection filter for displayed tokens.
- Store aggregation and cache in bg JS (`ServiceWebviewPerp`) and keep main JS UI focused on rendering hydrated tokens. Native/simpleDb storage is the shared persistent cache resource; hydrated JS objects are still per-runtime copies and are passed back to main as service results.
- Use a 60-second in-memory TTL plus a 1-day cold-start cache with background refresh, so desktop and native can render stable cached balances immediately.
- Memoize `fetchSwapNativeTokenConfig` for 3 minutes to avoid repeated native config requests when opening the modal.
- Limit token-list network concurrency to 3 to reduce startup pressure on mobile.

## Changes Detail
- `packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts`: adds wallet-token-list based deposit token fetching, cache reads/writes, background refresh, network account resolution, and supported-network scoping.
- `packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.ts`: adds mapping, sorting, grouping, default selection, and selected-token preservation helpers.
- `packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.test.ts`: covers filtering behavior, sorting, fiat lookup fallback, grouping/default token selection, and selected-token preservation.
- `packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts`: persists the Perps deposit token-list cold cache.
- `packages/kit-bg/src/services/ServiceSwap.ts`: memoizes swap native token config reads.
- `packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx`: consumes the bg-provided cached deposit token list and selected token balance instead of rendering `--` while the wallet list is loading.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Mobile / Web Perps surfaces
- **Risk Areas**: Account resolution across supported networks, stale cold-start cache behavior, background refresh timing, token selector default selection, and native startup performance.

## Performance Baseline
Use this baseline for any follow-up review fixes on this PR.

Desktop baseline after reload, measured with CDP over 10 Deposit modal open/list cycles:
- Wallet token-list requests: 6 total, only on the first cycle inside the cache window.
- Native token config requests: 6 total, only on the first cycle inside the cache window.
- Max Deposit modal open time: 195 ms.
- Max token selector open time: 54 ms.
- Header portfolio text remains stable at `$10.26` with no disappear/flicker frame.
- Header/trading panel must not regress into `Enable Trading` for an already enabled account.
- Deposit modal selected token balance must not render `--`; verified text: `USDC`, `Arbitrum`, `0.04904 USDC`.
- Pixel diff assertions from the 10-cycle run: `maxPortfolioDiff = 0`, `maxModalDiff = 0`.

Native cold-start baseline:
- iPhone 17 Pro simulator: cold start into Perps, Deposit modal renders `USDC Arbitrum 0.04904 USDC`; token selector shows wallet-visible tokens.
- Pixel 9 Pro Android emulator: cold start into Perps, Deposit modal renders `USDC Arbitrum 0.04904 USDC`; token selector shows wallet-visible tokens.

Mandatory re-test for review fixes:
- Re-run the focused Jest test and `yarn lint:staged`.
- Re-run the desktop 10-cycle Deposit modal/token-list check and compare against the request-count, timing, flicker, and `--` balance baseline above.
- Re-run iOS and Android cold-start smoke checks before marking review feedback resolved.

## Test plan
- [x] `yarn jest packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.test.ts --runInBand`
- [x] `yarn lint:staged`
- [x] `git diff --cached --check`
- [x] Desktop CDP 10-cycle open/list verification: no `Enable Trading` regression, no `--` token balance, stable `$10.26` header, wallet token requests only on first cached cycle, native config requests only on first cached cycle.
- [x] iPhone 17 Pro simulator cold-start verification: Deposit modal renders `USDC Arbitrum 0.04904 USDC`; token selector shows wallet-visible tokens.
- [x] Pixel 9 Pro Android emulator cold-start verification: Deposit modal renders `USDC Arbitrum 0.04904 USDC`; token selector shows wallet-visible tokens.
- [ ] `yarn lint --fix` / staged TypeScript check are blocked by existing repository baseline errors unrelated to this change: missing `@aaroon/workbox-rspack-plugin`, changed `@onekeyfe/hwk-trezor-adapter` exports, and missing `HardwareErrorCode` members.

[OK-56758]: https://onekeyhq.atlassian.net/browse/OK-56758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ