### PR TITLE
fix: remeasure DeFi tab scroll extent(OK-57257)

### DIFF
--- a/packages/kit/src/views/Home/pages/DeFiContainer.tsx
+++ b/packages/kit/src/views/Home/pages/DeFiContainer.tsx
@@ -21,6 +21,8 @@ import {
   useMedia,
   useScrollContentTabBarOffset,
 } from '@onekeyhq/components';
+import { useTabsContext } from '@onekeyhq/components/src/composite/Tabs/context';
+import { useTabNameContextSafe } from '@onekeyhq/components/src/composite/Tabs/TabNameContext';
 import {
   useSettingsPersistAtom,
   useSettingsValuePersistAtom,
@@ -78,6 +80,8 @@ import {
 const DEFI_CONTAINER_CONTENT_MAX_WIDTH = 1140;
 const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
 const PROTOCOL_NAV_PENDING_TARGET_TIMEOUT_MS = 5000;
+const DEFI_TAB_REMEASURE_DELAYS_MS = [100, 350, 800] as const;
+const DEFI_TAB_CONTENT_TEST_ID = 'home-defi-tab-content';
 
 function scrollToAnchor(
   anchor: HTMLElement,
@@ -109,6 +113,8 @@ function DeFiContainer() {
   const media = useMedia();
   const reducedMotion = useReducedMotion();
   const intl = useIntl();
+  const currentTabName = useTabNameContextSafe();
+  const { requestRemeasure, scrollTabElementsRef } = useTabsContext();
 
   const tableLayout = media.gtMd;
 
@@ -160,6 +166,7 @@ function DeFiContainer() {
 
   const triggerPinCheckRef = useRef<() => void>(() => {});
   const scrollContainerRef = useRef<HTMLElement | null>(null);
+  const reportedDeFiTabContentRef = useRef<HTMLElement | null>(null);
   const protocolRefs = useRef<Map<string, IProtocolHandle>>(new Map());
   // Read by pin tracker each scroll frame; ref avoids effect teardown on remeasure.
   const chipStripHeightRef = useRef<number>(0);
@@ -447,6 +454,88 @@ function DeFiContainer() {
   const shouldShowChipStrip =
     tableLayout && !isOverviewLoading && filteredProtocols.length >= 2;
 
+  const reportDeFiContentHeight = useCallback(() => {
+    if (platformEnv.isNative || !isTabFocused || !currentTabName) {
+      return;
+    }
+
+    const element = globalThis.document?.querySelector?.(
+      `[data-testid="${DEFI_TAB_CONTENT_TEST_ID}"]`,
+    );
+    const refStore = scrollTabElementsRef?.current;
+    if (!(element instanceof HTMLElement) || !refStore) {
+      return;
+    }
+
+    const nextHeight = Math.max(
+      element.scrollHeight || 0,
+      element.clientHeight || 0,
+      element.getBoundingClientRect().height || 0,
+    );
+    if (!Number.isFinite(nextHeight) || nextHeight <= 0) {
+      return;
+    }
+
+    if (!refStore[currentTabName]) {
+      refStore[currentTabName] = {} as {
+        element: HTMLElement;
+        height?: number;
+      };
+    }
+    const entry = refStore[currentTabName];
+    const didChange =
+      entry.element !== element ||
+      Math.abs((entry.height ?? 0) - nextHeight) > 1;
+    if (!didChange) {
+      return;
+    }
+
+    entry.element = element;
+    entry.height = nextHeight;
+    reportedDeFiTabContentRef.current = element;
+    requestRemeasure?.();
+  }, [currentTabName, isTabFocused, requestRemeasure, scrollTabElementsRef]);
+
+  useEffect(() => {
+    if (platformEnv.isNative || !isTabFocused) {
+      return undefined;
+    }
+
+    reportDeFiContentHeight();
+    const refStore = scrollTabElementsRef?.current;
+    const frame = requestAnimationFrame(reportDeFiContentHeight);
+    const timers = DEFI_TAB_REMEASURE_DELAYS_MS.map((delay) =>
+      setTimeout(reportDeFiContentHeight, delay),
+    );
+
+    return () => {
+      cancelAnimationFrame(frame);
+      timers.forEach(clearTimeout);
+      const reportedElement = reportedDeFiTabContentRef.current;
+      const entry = currentTabName ? refStore?.[currentTabName] : undefined;
+      if (entry?.element === reportedElement) {
+        delete refStore[currentTabName];
+        reportedDeFiTabContentRef.current = null;
+        requestRemeasure?.();
+      }
+    };
+  }, [
+    addPaddingOnListFooter,
+    currentTabName,
+    filteredProtocols.length,
+    isDeFiEnabled,
+    isOverviewLoading,
+    isTabFocused,
+    portfolioStats.slices.length,
+    protocols?.length,
+    requestRemeasure,
+    reportDeFiContentHeight,
+    scrollTabElementsRef,
+    shouldShowChipStrip,
+    shouldShowOverview,
+    tableLayout,
+  ]);
+
   // When the strip unmounts (data not ready, dropped below threshold),
   // reset the height ref so the next scrollToAnchor / pin tracker pass
   // uses an accurate sticky line again, and force the reveal shared value
@@ -688,6 +777,7 @@ function DeFiContainer() {
     return (
       <>
         <YStack
+          testID={DEFI_TAB_CONTENT_TEST_ID}
           pt="$4"
           pb="$8"
           width="100%"
@@ -776,7 +866,7 @@ function DeFiContainer() {
   }
 
   return (
-    <YStack gap="$6" pb="$5">
+    <YStack testID={DEFI_TAB_CONTENT_TEST_ID} gap="$6" pb="$5">
       <DeFiListBlock />
       <Upgrade />
       <SupportHub />


### PR DESCRIPTION
## Summary
- Report the DeFi tab content height back to the existing Tabs remeasure path after focus and async data settlement.
- Add delayed web-only remeasure passes for the DeFi tab to refresh the outer Home tab scroll extent.
- Keep the fix scoped to DeFi/Home instead of widening generic Tabs behavior.

## Intent & Context
OK-57257 tracks an intermittent Wallet DeFi tab scroll issue. Runtime investigation narrowed the failure to stale outer tab scroll extent registration after entering the DeFi tab or after DeFi content grows from loading state into the full protocol list.

## Root Cause
On desktop/web, the Home tab container can keep an outdated measured height for the DeFi tab when DeFi data settles after activation. When that height is stale, the outer tab scroller can behave as if the page is shorter than the rendered DeFi content, making the protocol section area appear unable to scroll.

## Design Decisions
- Reuse the existing Tabs `scrollTabElementsRef` and `requestRemeasure` mechanism instead of adding a new generic Tabs behavior.
- Gate the logic with `platformEnv.isNative` so it only affects the web/desktop DOM path.
- Trigger a small set of delayed remeasure passes to cover the skeleton-to-content transition without continuous polling.
- Clean up only the entry written by DeFiContainer so other tab registrations are not removed accidentally.

## Changes Detail
- `packages/kit/src/views/Home/pages/DeFiContainer.tsx`: register the rendered DeFi tab content element height with Tabs context when the tab is focused.
- Add a stable `testID` on the desktop/tablet and compact DeFi content roots so the DOM height source is explicit.
- Schedule immediate, next-frame, and delayed remeasure calls when DeFi visibility and data-dependent layout inputs change.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web
- **Runtime Scope**: main UI runtime only. No background runtime change, no shared native resource change, and no native JS heap impact because the path returns early on native.
- **Risk Areas**: Incorrect height reporting could affect DeFi tab scroll extent, but the cleanup only deletes the element this component reported and the change is gated to the active DeFi tab.

## Test plan
- [x] `git diff --check`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [ ] Desktop runtime regression: open Wallet Home, switch to DeFi, wait for protocol content to load, verify the page scrolls through protocol sections after tab switches and refreshes.