### PR TITLE
fix: prevent Tamagui static bundle media listeners

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -377,12 +377,6 @@ if (buildTimeEnv.enableNativeBackgroundThread) {
 // ---------------------------------------------------------------
 
 // Ensure cache directories exist
-const fileMapCacheDirectoryPath = path.resolve(
-  projectRoot,
-  'node_modules',
-  '.cache/file-map-cache',
-);
-fs.ensureDirSync(fileMapCacheDirectoryPath);
 const cacheStoreDirectoryPath = path.resolve(
   projectRoot,
   'node_modules',
@@ -390,7 +384,6 @@ const cacheStoreDirectoryPath = path.resolve(
 );
 fs.ensureDirSync(cacheStoreDirectoryPath);
 
-config.fileMapCacheDirectory = fileMapCacheDirectoryPath;
 config.cacheStores = ({ FileStore }) => [
   new FileStore({
     root: cacheStoreDirectoryPath,

--- a/packages/components/tamagui.config.ts
+++ b/packages/components/tamagui.config.ts
@@ -51,6 +51,7 @@ import { webFontFamily } from './src/utils/webFontFamily';
 import type { Variable } from '@tamagui/web';
 
 const isTamaguiNative = process.env.TAMAGUI_TARGET === 'native';
+const isTamaguiStatic = process.env.IS_STATIC === 'is_static';
 
 const basicFontVariants = {
   size: {
@@ -700,7 +701,9 @@ const config = createTamagui({
     hoverNone: { hover: 'none' },
     pointerCoarse: { pointer: 'coarse' },
   }),
-  disableSSR: true,
+  // Tamagui static extraction runs in Node with the native target. Avoid
+  // registering native media listeners while the config is only being parsed.
+  disableSSR: !isTamaguiStatic,
 });
 
 export type IAppConfig = typeof config;


### PR DESCRIPTION
## Summary
- Prevent Tamagui static extraction from registering native media listeners while parsing the native config in the Node bundling process.
- Remove the unsupported Metro `fileMapCacheDirectory` top-level option while keeping the explicit Metro cache store.

## Intent & Context
Android bundling was printing `Error loading tamagui.config.ts` followed by `Cannot read properties of undefined (reading 'apply')`, causing Tamagui to fall back to its default config and warning that no valid components were found. The original request was to fix this packaging-blocking error and then verify the full Android bundle/Hermes path.

## Root Cause
The mobile Babel config sets `TAMAGUI_TARGET=native`, and Tamagui static extraction sets `IS_STATIC=is_static` before loading `packages/components/tamagui.config.ts` in a Node process. The config previously always used `disableSSR: true`, so Tamagui's native `createTamagui()` immediately called `configureMedia()` and registered native media listeners during static extraction. That listener setup expects a real RN/native runtime, not the Node bundling process, which caused the `matchMedia` implementation path to fail with `Cannot read properties of undefined (reading 'apply')`.

The separate Metro validation warning came from `config.fileMapCacheDirectory`, which is not accepted by the current Metro/Expo config validation path even though Metro internals still reference similar cache fields.

## Design Decisions
- Scope the Tamagui behavior change to `process.env.IS_STATIC === 'is_static'` only. Real mobile runtime keeps `disableSSR: true`; only static extraction avoids native media listener setup.
- Keep the existing Metro `cacheStores` configuration and remove only the unsupported top-level `fileMapCacheDirectory` option and now-unused directory setup.
- Do not touch unrelated modified files in the original working tree; this PR branch was created from `origin/x` in a clean worktree and contains only this fix.

## Changes Detail
- `packages/components/tamagui.config.ts`: adds an `isTamaguiStatic` guard and sets `disableSSR` to `false` only for Tamagui static extraction.
- `apps/mobile/metro.config.js`: removes `fileMapCacheDirectory` and the unused `file-map-cache` directory creation.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile Android bundling; Tamagui native static extraction
- **Risk Areas**: Tamagui media-query initialization during static extraction. Runtime main/bg JS behavior is unchanged because `IS_STATIC` is not set in production runtime.

## Test plan
- [x] `DEBUG=tamagui TAMAGUI_TARGET=native node -e "const {loadTamaguiSync}=require('@tamagui/static'); const info=loadTamaguiSync({config:'./packages/components/tamagui.config.ts', components:['tamagui'], platform:'native'}); console.log({components: info.components.length, hasConfig: !!info.tamaguiConfig})"`
- [x] `node -e "const {loadConfig}=require('metro-config'); loadConfig({cwd: require('path').resolve('apps/mobile'), config: require('path').resolve('apps/mobile/metro.config.js')}).then((config)=>{ console.log('loaded'); console.log('hasFileMapCacheDirectory', Object.prototype.hasOwnProperty.call(config, 'fileMapCacheDirectory')); console.log('cacheStores', Array.isArray(config.cacheStores), config.cacheStores.length); })"`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/components/tamagui.config.ts apps/mobile/metro.config.js --deny-warnings`
- [x] `npx tsgo -p packages/components/tsconfig.json --noEmit --pretty false`
- [x] `TAMAGUI_TARGET=native NODE_ENV=production node -e "const path=require('path'); const babel=require('@babel/core'); const filename=path.resolve('packages/components/src/primitives/Button/index.tsx'); babel.transformFileSync(filename,{configFile:path.resolve('apps/mobile/babel.config.js'), babelrc:false, filename}); console.log('babel transform ok')"`
- [x] `env SENTRY_TOKEN= SENTRY_PROJECT= yarn app:build-bundle:android`
