### PR TITLE
fix: break onboarding segment dependency cycle

### DIFF
--- a/packages/kit/src/views/Onboardingv2/pages/ConnectQRCode.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ConnectQRCode.tsx
@@ -28,7 +28,7 @@ import { OnboardingPage } from '../components/Layout';
 import { OnboardingTestIDs } from '../testIDs';
 import { trackHardwareWalletConnection } from '../utils';
 
-import { ConnectionIndicator } from './ConnectYourDevice';
+import { ConnectionIndicator } from './ConnectionIndicator';
 
 function ConnectQRCodePage() {
   const { createQrWallet } = useCreateQrWallet();

--- a/packages/kit/src/views/Onboardingv2/pages/ConnectYourDevice.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ConnectYourDevice.tsx
@@ -8,7 +8,7 @@ import natsort from 'natsort';
 import { useIntl } from 'react-intl';
 import { Linking, StyleSheet } from 'react-native';
 
-import type { IPageScreenProps, IYStackProps } from '@onekeyhq/components';
+import type { IPageScreenProps } from '@onekeyhq/components';
 import {
   Button,
   Dialog,
@@ -29,7 +29,6 @@ import {
   usePopoverContext,
   useThemeName,
 } from '@onekeyhq/components';
-import { ANIMATE_ONLY_OPACITY_TRANSFORM } from '@onekeyhq/components/src/utils/animationConstants';
 import { usePromptWebDeviceAccess } from '@onekeyhq/kit/src/hooks/usePromptWebDeviceAccess';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
@@ -92,6 +91,8 @@ import {
   getForceTransportType,
   sortDevicesData,
 } from '../utils';
+
+import { ConnectionIndicator } from './ConnectionIndicator';
 
 import type { IDeviceType, SearchDevice } from '@onekeyfe/hd-core';
 import type { ReactVideoSource } from 'react-native-video';
@@ -394,84 +395,6 @@ function useDeviceConnection({
   );
 }
 
-function ConnectionIndicatorCard({ children }: { children: React.ReactNode }) {
-  return (
-    <YStack
-      borderRadius={10}
-      borderCurve="continuous"
-      $platform-web={{
-        boxShadow: '0 1px 1px 0 rgba(0, 0, 0, 0.20)',
-      }}
-      // $platform-android={{ elevation: 0.1 }}
-      $platform-ios={{
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: 0.5 },
-        shadowOpacity: 0.2,
-        shadowRadius: 0.5,
-      }}
-      bg="$bg"
-    >
-      {children}
-    </YStack>
-  );
-}
-
-function ConnectionIndicatorAnimation({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return (
-    <YStack
-      h={320}
-      alignItems="center"
-      justifyContent="center"
-      overflow="hidden"
-    >
-      {children}
-    </YStack>
-  );
-}
-
-function ConnectionIndicatorContent({
-  children,
-  ...rest
-}: {
-  children: React.ReactNode;
-} & IYStackProps) {
-  return (
-    <YStack
-      px="$5"
-      py="$4"
-      borderWidth={0}
-      borderTopWidth={StyleSheet.hairlineWidth}
-      borderTopColor="$borderSubdued"
-      $platform-web={{
-        borderStyle: 'dashed',
-      }}
-      {...rest}
-    >
-      {children}
-    </YStack>
-  );
-}
-
-function ConnectionIndicatorTitle({ children }: { children: React.ReactNode }) {
-  return <SizableText size="$bodyMdMedium">{children}</SizableText>;
-}
-
-function ConnectionIndicatorFooter({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return (
-    <YStack pt="$5" pb="$2" gap="$2">
-      {children}
-    </YStack>
-  );
-}
-
 function TroubleShootingButton({ type: _type }: { type: 'usb' | 'bluetooth' }) {
   const [showHelper, setShowHelper] = useState(false);
   const intl = useIntl();
@@ -538,46 +461,6 @@ function TroubleShootingButton({ type: _type }: { type: 'usb' | 'bluetooth' }) {
     </>
   );
 }
-
-function ConnectionIndicatorRoot({ children }: { children: React.ReactNode }) {
-  return (
-    <YStack
-      $platform-web={{
-        boxShadow:
-          '0 1px 1px 0 rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 6px 0 rgba(0, 0, 0, 0.04), 0 24px 68px 0 rgba(0, 0, 0, 0.05), 0 2px 3px 0 rgba(0, 0, 0, 0.04)',
-      }}
-      $theme-dark={{
-        borderWidth: StyleSheet.hairlineWidth,
-        borderColor: '$neutral3',
-        bg: '$neutral4',
-      }}
-      $platform-native={{
-        borderWidth: StyleSheet.hairlineWidth,
-        borderColor: '$neutral4',
-      }}
-      overflow="hidden"
-      borderRadius={10}
-      borderCurve="continuous"
-      bg="$bgSubdued"
-      animation="quick"
-      animateOnly={ANIMATE_ONLY_OPACITY_TRANSFORM}
-      enterStyle={{
-        opacity: 0,
-        x: 24,
-      }}
-    >
-      {children}
-    </YStack>
-  );
-}
-
-export const ConnectionIndicator = Object.assign(ConnectionIndicatorRoot, {
-  Animation: ConnectionIndicatorAnimation,
-  Card: ConnectionIndicatorCard,
-  Content: ConnectionIndicatorContent,
-  Title: ConnectionIndicatorTitle,
-  Footer: ConnectionIndicatorFooter,
-});
 
 function BluetoothCard({
   onConnect,

--- a/packages/kit/src/views/Onboardingv2/pages/ConnectionFlowLedger.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ConnectionFlowLedger.tsx
@@ -35,7 +35,7 @@ import { useThemeVariant } from '../../../hooks/useThemeVariant';
 import { OnboardingTestIDs } from '../testIDs';
 import { getForceTransportType, sortDevicesData } from '../utils';
 
-import { ConnectionIndicator } from './ConnectYourDevice';
+import { ConnectionIndicator } from './ConnectionIndicator';
 
 import type { SearchDevice } from '@onekeyfe/hd-core';
 import type { ReactVideoSource } from 'react-native-video';

--- a/packages/kit/src/views/Onboardingv2/pages/ConnectionFlowTrezor.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ConnectionFlowTrezor.tsx
@@ -43,7 +43,7 @@ import {
   shouldRequestTrezorWebUsbPermissionBeforeListing,
   shouldShowTrezorScanTimeout,
 } from './ConnectionFlowTrezorUtils';
-import { ConnectionIndicator } from './ConnectYourDevice';
+import { ConnectionIndicator } from './ConnectionIndicator';
 
 import type { SearchDevice } from '@onekeyfe/hd-core';
 import type { ReactVideoSource } from 'react-native-video';

--- a/packages/kit/src/views/Onboardingv2/pages/ConnectionIndicator.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ConnectionIndicator.tsx
@@ -1,0 +1,117 @@
+import type { ReactNode } from 'react';
+
+import { StyleSheet } from 'react-native';
+
+import type { IYStackProps } from '@onekeyhq/components';
+import { SizableText, YStack } from '@onekeyhq/components';
+import { ANIMATE_ONLY_OPACITY_TRANSFORM } from '@onekeyhq/components/src/utils/animationConstants';
+
+function ConnectionIndicatorCard({ children }: { children: ReactNode }) {
+  return (
+    <YStack
+      borderRadius={10}
+      borderCurve="continuous"
+      $platform-web={{
+        boxShadow: '0 1px 1px 0 rgba(0, 0, 0, 0.20)',
+      }}
+      // $platform-android={{ elevation: 0.1 }}
+      $platform-ios={{
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 0.5 },
+        shadowOpacity: 0.2,
+        shadowRadius: 0.5,
+      }}
+      bg="$bg"
+    >
+      {children}
+    </YStack>
+  );
+}
+
+function ConnectionIndicatorAnimation({ children }: { children: ReactNode }) {
+  return (
+    <YStack
+      h={320}
+      alignItems="center"
+      justifyContent="center"
+      overflow="hidden"
+    >
+      {children}
+    </YStack>
+  );
+}
+
+function ConnectionIndicatorContent({
+  children,
+  ...rest
+}: {
+  children: ReactNode;
+} & IYStackProps) {
+  return (
+    <YStack
+      px="$5"
+      py="$4"
+      borderWidth={0}
+      borderTopWidth={StyleSheet.hairlineWidth}
+      borderTopColor="$borderSubdued"
+      $platform-web={{
+        borderStyle: 'dashed',
+      }}
+      {...rest}
+    >
+      {children}
+    </YStack>
+  );
+}
+
+function ConnectionIndicatorTitle({ children }: { children: ReactNode }) {
+  return <SizableText size="$bodyMdMedium">{children}</SizableText>;
+}
+
+function ConnectionIndicatorFooter({ children }: { children: ReactNode }) {
+  return (
+    <YStack pt="$5" pb="$2" gap="$2">
+      {children}
+    </YStack>
+  );
+}
+
+function ConnectionIndicatorRoot({ children }: { children: ReactNode }) {
+  return (
+    <YStack
+      $platform-web={{
+        boxShadow:
+          '0 1px 1px 0 rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 6px 0 rgba(0, 0, 0, 0.04), 0 24px 68px 0 rgba(0, 0, 0, 0.05), 0 2px 3px 0 rgba(0, 0, 0, 0.04)',
+      }}
+      $theme-dark={{
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: '$neutral3',
+        bg: '$neutral4',
+      }}
+      $platform-native={{
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: '$neutral4',
+      }}
+      overflow="hidden"
+      borderRadius={10}
+      borderCurve="continuous"
+      bg="$bgSubdued"
+      animation="quick"
+      animateOnly={ANIMATE_ONLY_OPACITY_TRANSFORM}
+      enterStyle={{
+        opacity: 0,
+        x: 24,
+      }}
+    >
+      {children}
+    </YStack>
+  );
+}
+
+export const ConnectionIndicator = Object.assign(ConnectionIndicatorRoot, {
+  Animation: ConnectionIndicatorAnimation,
+  Card: ConnectionIndicatorCard,
+  Content: ConnectionIndicatorContent,
+  Title: ConnectionIndicatorTitle,
+  Footer: ConnectionIndicatorFooter,
+});


### PR DESCRIPTION
## Summary
- Extract shared onboarding connection indicator UI into a standalone module.
- Update hardware onboarding flows to import the shared component directly instead of importing it from `ConnectYourDevice`.
- Fix Android EAS `expo export:embed` failure caused by a circular segment dependency.

## Intent & Context
The Android EAS build failed during Metro export with `segmentSerializer` reporting a circular segment dependency. The request was to reproduce the EAS failure locally first, then fix it and open a PR.

## Root Cause
`ConnectYourDevice.tsx` lazy-loads `ConnectionFlowLedger.tsx`, but `ConnectionFlowLedger.tsx` synchronously imported `ConnectionIndicator` from `ConnectYourDevice.tsx`. With split bundle segments enabled, that created a segment cycle:

`Modal.Navigator -> ConnectYourDevice -> ConnectionFlowLedger -> ConnectYourDevice`

This affects the mobile main JS runtime bundle generation. The background JS runtime does not render these onboarding pages, and this change does not alter native shared resources or per-runtime JS heap state.

## Design Decisions
The fix keeps the existing lazy-loading behavior and moves only the shared presentational component to `ConnectionIndicator.tsx`. This breaks the reverse dependency without changing navigation, hardware connection logic, route params, storage, translations, or native configuration.

## Changes Detail
- `ConnectionIndicator.tsx`: new shared UI component module for the onboarding connection indicator shell and subcomponents.
- `ConnectYourDevice.tsx`: imports `ConnectionIndicator` from the new module and no longer exports that UI component.
- `ConnectionFlowLedger.tsx`, `ConnectionFlowTrezor.tsx`, `ConnectQRCode.tsx`: import `ConnectionIndicator` from the standalone module.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile Android/iOS onboarding UI bundle generation; primarily validates the Android EAS export path that failed.
- **Risk Areas**: Visual parity of the extracted connection indicator component. Business logic and hardware flows are unchanged.

## Test plan
- [x] Reproduced the original failure locally with `SPLIT_BUNDLE=1 SPLIT_BUNDLE_SEGMENTS=true UNION_BUILD=true yarn expo export:embed --eager --platform android --dev false`.
- [x] Verified the same Android export command passes after the fix on the final PR branch.
- [x] Ran `yarn lint:staged`.
- [x] Ran `yarn tsc:staged`.