### PR TITLE
fix: polish home perps tab behavior (OK-57384, OK-57386, OK-57387, OK-57388, OK-57389, OK-57390, OK-57392, OK-57393, OK-57394, OK-57395, OK-57397, OK-57398, OK-57399)

### DIFF
--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -16,8 +16,11 @@ import {
   useCurrencyPersistAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { USD_CURRENCY_ID } from '@onekeyhq/shared/src/consts/currencyConsts';
 import { WALLET_TYPE_HD } from '@onekeyhq/shared/src/consts/dbConsts';
+import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
+import { PERPS_HL_PORTFOLIO_ACTIVE_MAX_AGE_MS } from '@onekeyhq/shared/src/consts/perpCache';
 import { SHOW_WALLET_FUNCTION_BLOCK_VALUE_THRESHOLD_USD } from '@onekeyhq/shared/src/consts/walletConsts';
 import {
   EAppEventBusNames,
@@ -28,6 +31,7 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { perfMark } from '@onekeyhq/shared/src/performance/mark';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   calculateAccountTokensValue,
@@ -127,6 +131,55 @@ function HomeOverviewContainer() {
   } = useAccountOverviewActions().current;
 
   const [settings] = useSettingsPersistAtom();
+  const isPerpsEnabled = useMemo(() => {
+    if (network?.isAllNetworks) return true;
+    return networkUtils.isEvmNetwork({ networkId: network?.id });
+  }, [network?.id, network?.isAllNetworks]);
+
+  const { result: perpsNetWorthUsd } = usePromiseResult<string | undefined>(
+    async () => {
+      if (!isPerpsEnabled) return undefined;
+      const accountId = account?.id;
+      const indexedAccountId = account?.indexedAccountId;
+      if (!accountId && !indexedAccountId) return undefined;
+
+      const deriveType =
+        await backgroundApiProxy.serviceNetwork.getGlobalDeriveTypeOfNetwork({
+          networkId: PERPS_NETWORK_ID,
+        });
+      if (!deriveType) return undefined;
+
+      let address = '';
+      try {
+        const acc = await backgroundApiProxy.serviceAccount.getNetworkAccount({
+          accountId: indexedAccountId ? undefined : accountId,
+          indexedAccountId,
+          deriveType,
+          networkId: PERPS_NETWORK_ID,
+        });
+        address = acc?.addressDetail?.normalizedAddress || acc?.address || '';
+      } catch {
+        return undefined;
+      }
+
+      if (!address) return undefined;
+
+      const snapshot =
+        await backgroundApiProxy.serviceHyperliquid.getHyperliquidPortfolioSnapshot(
+          { address },
+        );
+
+      return snapshot?.netWorthUsd;
+    },
+    [account?.id, account?.indexedAccountId, isPerpsEnabled],
+    {
+      swrKey:
+        account?.id || account?.indexedAccountId
+          ? `home-overview-perps-worth:${account?.indexedAccountId ?? account?.id}`
+          : undefined,
+      pollingInterval: PERPS_HL_PORTFOLIO_ACTIVE_MAX_AGE_MS,
+    },
+  );
 
   const isWalletNotBackedUp = useMemo(() => {
     if (wallet && wallet.type === WALLET_TYPE_HD && !wallet.backuped) {
@@ -630,10 +683,11 @@ function HomeOverviewContainer() {
       targetCurrency: USD_CURRENCY_ID,
       currencyMap,
     });
+    const perpsWorthUsd = perpsNetWorthUsd ?? '0';
 
     return calculateAccountTotalValue({
       tokensValue: tokenWorthUsd,
-      deFiNetWorth: deFiWorthUsd,
+      deFiNetWorth: new BigNumber(deFiWorthUsd).plus(perpsWorthUsd).toFixed(),
     });
   }, [
     account?.id,
@@ -645,6 +699,7 @@ function HomeOverviewContainer() {
     isCurrentAccountDeFiReady,
     isCurrentAccountWorthReady,
     network?.isAllNetworks,
+    perpsNetWorthUsd,
     settings.currencyInfo.id,
     vaultSettings?.mergeDeriveAssetsEnabled,
   ]);

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -11,12 +11,12 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import type { IDialogInstance } from '@onekeyhq/components';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import {
   settingsValuePersistAtom,
   useCurrencyPersistAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { USD_CURRENCY_ID } from '@onekeyhq/shared/src/consts/currencyConsts';
 import { WALLET_TYPE_HD } from '@onekeyhq/shared/src/consts/dbConsts';
 import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -850,6 +850,7 @@ export function HomePageView({
           <Tabs.Tab key={tab.name} name={tab.name}>
             <FreezeInactiveHomeTab tabName={tab.name}>
               {platformEnv.isNative ||
+              tab.id === EHomeWalletTab.Perps ||
               activeTabId === tab.id ||
               mountedHomeTabIds.has(tab.id) ? (
                 tab.component

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -319,6 +319,12 @@ export function HomePageView({
   );
   const { perpDisabled, perpTabShowWeb } = usePerpTabConfig();
 
+  const isPerpsEnabled = useMemo(() => {
+    if (perpDisabled) return false;
+    if (network?.isAllNetworks) return true;
+    return networkUtils.isEvmNetwork({ networkId: network?.id });
+  }, [network?.id, network?.isAllNetworks, perpDisabled]);
+
   const isWalletNotBackedUp = useMemo(() => {
     if (wallet && wallet.type === WALLET_TYPE_HD && !wallet.backuped) {
       return true;
@@ -474,7 +480,7 @@ export function HomePageView({
         testID: HomeTestIDs.tabPortfolio,
         component: <PortfolioContainerWithProvider />,
       },
-      !perpDisabled
+      isPerpsEnabled
         ? {
             id: EHomeWalletTab.Perps,
             name: intl.formatMessage({
@@ -525,7 +531,7 @@ export function HomePageView({
         ),
       },
     ].filter(Boolean);
-  }, [intl, isDeFiEnabled, isNFTEnabled, perpDisabled]);
+  }, [intl, isDeFiEnabled, isNFTEnabled, isPerpsEnabled]);
 
   const pagerTabConfigs = useMemo(
     () =>

--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -610,6 +610,7 @@ function PerpsDepositButton({
       px="$3"
       h={28}
       bg="$brand8"
+      cursor="pointer"
     >
       <Icon name="AlignBottomOutline" size="$4" color="$iconOnColor" />
       <SizableText size="$bodySmMedium" color="$textOnColor">
@@ -620,9 +621,6 @@ function PerpsDepositButton({
 }
 
 function PerpsHeaderActions({ canDeposit }: { canDeposit: boolean }) {
-  const intl = useIntl();
-  const openPerp = useOpenPerpAsset();
-
   if (!canDeposit) {
     return null;
   }
@@ -633,19 +631,6 @@ function PerpsHeaderActions({ canDeposit }: { canDeposit: boolean }) {
         testID={HomeTestIDs.perpsDesktopDepositButton}
         canDeposit={canDeposit}
       />
-      <Button
-        size="medium"
-        variant="secondary"
-        childrenAsText={false}
-        testID={HomeTestIDs.perpsManageButton}
-        onPress={() => openPerp()}
-      >
-        <SizableText size="$bodySmMedium">
-          {intl.formatMessage({
-            id: ETranslations.global_manage,
-          })}
-        </SizableText>
-      </Button>
     </XStack>
   );
 }
@@ -920,6 +905,9 @@ function PerpsPositionCard({ position }: { position: IPerpsHomePosition }) {
   const openPerp = useOpenPerpAsset();
   const isLong = position.side === 'long';
   const sideColor = isLong ? '$green11' : '$red11';
+  const handleOpenPerp = useCallback(() => {
+    openPerp(position.coin, 'perp', false);
+  }, [openPerp, position.coin]);
   const leverageTypeText = intl.formatMessage({
     id:
       position.leverageType === 'cross'
@@ -937,6 +925,17 @@ function PerpsPositionCard({ position }: { position: IPerpsHomePosition }) {
   return (
     <YStack
       py="$3"
+      cursor="pointer"
+      focusable
+      role="button"
+      hoverStyle={{ bg: '$bgHover' }}
+      pressStyle={{ bg: '$bgActive' }}
+      focusVisibleStyle={{
+        outlineColor: '$focusRing',
+        outlineStyle: 'solid',
+        outlineWidth: 2,
+      }}
+      onPress={handleOpenPerp}
       $gtMd={{
         bg: '$bgSubdued',
         borderRadius: '$3',
@@ -985,6 +984,15 @@ function PerpsPositionCard({ position }: { position: IPerpsHomePosition }) {
             {leverageTypeText} {position.leverageValue}x
           </SizableText>
         </XStack>
+        <SizableText
+          testID={HomeTestIDs.perpsManageButton}
+          display="none"
+          size="$bodyXs"
+          color="$textSubdued"
+          $gtMd={{ display: 'flex', size: '$bodySm' }}
+        >
+          {intl.formatMessage({ id: ETranslations.global_manage })}
+        </SizableText>
       </XStack>
 
       <YStack gap="$3">
@@ -1071,7 +1079,7 @@ function PerpsPositionCard({ position }: { position: IPerpsHomePosition }) {
         size="small"
         display="flex"
         $gtMd={{ display: 'none' }}
-        onPress={() => openPerp(position.coin, 'perp', false)}
+        onPress={handleOpenPerp}
       >
         {intl.formatMessage({ id: ETranslations.global_manage })}
       </Button>
@@ -1096,7 +1104,13 @@ export function PerpsContainer() {
           ) : undefined
         }
       >
-        <YStack px="$5" py="$3" gap="$2" $gtMd={{ px: '$pagePadding' }}>
+        <YStack
+          px="$5"
+          py="$3"
+          pb="$4"
+          gap="$2"
+          $gtMd={{ px: '$pagePadding', pb: '$8' }}
+        >
           {viewState === 'loading' ? <PerpsLoadingState /> : null}
           {viewState === 'empty' ? (
             <PerpsEmptyState canDeposit={canDeposit} />

--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -54,6 +54,7 @@ import {
   parseDexCoin,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 
+import { convertFiat } from '../../../utils/fiatConvert';
 import {
   OVERVIEW_TILE_SHADOW,
   buildOverviewGridStyle,
@@ -62,7 +63,6 @@ import { resolveOverviewCols } from '../components/DeFiListBlock/overviewColsRes
 import { PullToRefresh, onHomePageRefresh } from '../components/PullToRefresh';
 import { RichBlock } from '../components/RichBlock';
 import { HomeTestIDs } from '../testIDs';
-import { convertFiat } from '../../../utils/fiatConvert';
 
 import { usePerpsHomePortfolio } from './usePerpsHomePortfolio';
 

--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -66,7 +66,7 @@ const HYPER_EVM_LOGO_URI =
   'https://uni.onekey-asset.com/static/chain/hyper-evm.png';
 const SPAN_1: React.CSSProperties = { gridColumnEnd: 'span 1' };
 const noop = () => undefined;
-type TPerpsTradeMode = 'perp' | 'spot';
+type IPerpsTradeMode = 'perp' | 'spot';
 
 function isTradableSpotHolding(holding: IPerpsHomeHolding) {
   return Boolean(
@@ -101,7 +101,7 @@ function useOpenPerpAsset() {
   const navigation = useAppNavigation();
   const ensureHomePerpsAccount = useEnsureHomePerpsAccount();
   return useCallback(
-    (coin?: string, mode: TPerpsTradeMode = 'perp', openMarket = true) => {
+    (coin?: string, mode: IPerpsTradeMode = 'perp', openMarket = true) => {
       void (async () => {
         const activePerpsAccount = await ensureHomePerpsAccount();
         if (!activePerpsAccount) {
@@ -1096,7 +1096,7 @@ export function PerpsContainer() {
           ) : undefined
         }
       >
-        <YStack px="$5" py="$3" gap="$2" $gtMd={{ px: '$4' }}>
+        <YStack px="$5" py="$3" gap="$2" $gtMd={{ px: '$pagePadding' }}>
           {viewState === 'loading' ? <PerpsLoadingState /> : null}
           {viewState === 'empty' ? (
             <PerpsEmptyState canDeposit={canDeposit} />

--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -46,13 +46,17 @@ import type {
   IPerpsHomeHolding,
   IPerpsHomePosition,
 } from '@onekeyhq/shared/src/utils/perpsHomeViewUtils';
-import { getHyperliquidTokenImageUrl } from '@onekeyhq/shared/src/utils/perpsUtils';
+import {
+  getHyperliquidTokenImageUrl,
+  parseDexCoin,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import {
   OVERVIEW_TILE_SHADOW,
   buildOverviewGridStyle,
 } from '../components/DeFiListBlock/DeFiOverviewLayout';
 import { resolveOverviewCols } from '../components/DeFiListBlock/overviewColsResolver';
+import { PullToRefresh, onHomePageRefresh } from '../components/PullToRefresh';
 import { RichBlock } from '../components/RichBlock';
 import { HomeTestIDs } from '../testIDs';
 
@@ -97,7 +101,7 @@ function useOpenPerpAsset() {
   const navigation = useAppNavigation();
   const ensureHomePerpsAccount = useEnsureHomePerpsAccount();
   return useCallback(
-    (coin?: string, mode: TPerpsTradeMode = 'perp') => {
+    (coin?: string, mode: TPerpsTradeMode = 'perp', openMarket = true) => {
       void (async () => {
         const activePerpsAccount = await ensureHomePerpsAccount();
         if (!activePerpsAccount) {
@@ -135,7 +139,7 @@ function useOpenPerpAsset() {
         } catch {
           return;
         }
-        if (platformEnv.isNative) {
+        if (platformEnv.isNative && openMarket) {
           // The Home navigator can't push into the Perp tab's stack, so go via the root.
           setTimeout(() => {
             rootNavigationRef.current?.navigate(ERootRoutes.Main, {
@@ -839,7 +843,6 @@ function PerpsMetric({
   negative,
   labelExtra,
   column,
-  showRepeat,
   emphasis,
 }: {
   labelId: ETranslations;
@@ -851,7 +854,6 @@ function PerpsMetric({
   negative?: boolean;
   labelExtra?: string;
   column?: 'left' | 'center' | 'right';
-  showRepeat?: boolean;
   emphasis?: boolean;
 }) {
   const intl = useIntl();
@@ -886,9 +888,6 @@ function PerpsMetric({
           {intl.formatMessage({ id: labelId })}
           {labelExtra}
         </SizableText>
-        {showRepeat ? (
-          <Icon name="RepeatOutline" size="$3" color="$textSubdued" />
-        ) : null}
       </XStack>
       {formatter ? (
         <NumberSizeableText
@@ -897,6 +896,9 @@ function PerpsMetric({
           $gtMd={{ size: valueGtMdSize }}
           formatter={formatter}
           formatterOptions={formatterOptions}
+          contentStyle={{ color: valueColor }}
+          decimalTextStyle={{ color: valueColor }}
+          subTextStyle={{ color: valueColor }}
         >
           {value}
         </NumberSizeableText>
@@ -926,28 +928,22 @@ function PerpsPositionCard({ position }: { position: IPerpsHomePosition }) {
   });
   // priceChange formatter is fixed at 2 decimals; PositionsRow shows ROE at 1.
   const roiPercent = new BigNumber(position.roi).times(100).abs().toFixed(1);
+  const displayCoin = parseDexCoin(position.coin).displayName;
+  const positionSizeUsd = new BigNumber(position.sizeCoin)
+    .times(position.markPx)
+    .abs()
+    .toFixed();
 
   return (
     <YStack
-      py="$4"
+      py="$3"
       $gtMd={{
         bg: '$bgSubdued',
         borderRadius: '$3',
         px: '$4',
         py: '$4',
       }}
-      gap="$4"
-      cursor="pointer"
-      focusable
-      focusVisibleStyle={{
-        outlineColor: '$focusRing',
-        outlineStyle: 'solid',
-        outlineWidth: 2,
-      }}
-      hoverStyle={{ bg: '$bgHover' }}
-      pressStyle={{ bg: '$bgActive' }}
-      onPress={() => openPerp(position.coin)}
-      role="button"
+      gap="$3"
     >
       <XStack justifyContent="space-between" flex={1} position="relative">
         <XStack flex={1} gap="$2" alignItems="center">
@@ -972,11 +968,11 @@ function PerpsPositionCard({ position }: { position: IPerpsHomePosition }) {
             </SizableText>
           </XStack>
           <SizableText
-            size="$bodyMdMedium"
+            size="$headingSm"
             color="$text"
             $gtMd={{ size: '$headingMd' }}
           >
-            {position.coin}
+            {displayCoin}
           </SizableText>
           <SizableText
             bg="$bgSubdued"
@@ -989,15 +985,9 @@ function PerpsPositionCard({ position }: { position: IPerpsHomePosition }) {
             {leverageTypeText} {position.leverageValue}x
           </SizableText>
         </XStack>
-        <Icon
-          name="ShareOutline"
-          size="$3.5"
-          color="$iconSubdued"
-          $gtMd={{ size: '$4.5' }}
-        />
       </XStack>
 
-      <YStack gap="$4">
+      <YStack gap="$3">
         <XStack width="100%" justifyContent="space-between" alignItems="center">
           <PerpsMetric
             labelId={ETranslations.perp_position_pnl_mobile}
@@ -1018,15 +1008,15 @@ function PerpsPositionCard({ position }: { position: IPerpsHomePosition }) {
           />
         </XStack>
 
-        <YStack gap="$4">
+        <YStack gap="$3">
           <XStack width="100%" justifyContent="space-between">
             <PerpsMetric
               labelId={ETranslations.perp_position_position_size}
-              labelExtra={` (${position.coin})`}
-              value={position.sizeCoin}
-              formatter="balance"
+              labelExtra=" (USDC)"
+              value={positionSizeUsd}
+              formatter="value"
+              formatterOptions={{ currency: '$' }}
               column="left"
-              showRepeat
             />
             <PerpsMetric
               labelId={ETranslations.perp_position_margin}
@@ -1076,19 +1066,14 @@ function PerpsPositionCard({ position }: { position: IPerpsHomePosition }) {
           </XStack>
         </YStack>
       </YStack>
-
       <Button
+        testID={HomeTestIDs.perpsManageButton}
+        size="small"
         display="flex"
         $gtMd={{ display: 'none' }}
-        size="medium"
-        variant="secondary"
-        childrenAsText={false}
-        testID={`${HomeTestIDs.perpsManageButton}-${position.side}`}
-        onPress={() => openPerp(position.coin)}
+        onPress={() => openPerp(position.coin, 'perp', false)}
       >
-        <SizableText size="$bodyMdMedium">
-          {intl.formatMessage({ id: ETranslations.global_manage })}
-        </SizableText>
+        {intl.formatMessage({ id: ETranslations.global_manage })}
       </Button>
     </YStack>
   );
@@ -1100,59 +1085,70 @@ export function PerpsContainer() {
   const { viewState, view, canDeposit } = usePerpsHomePortfolio();
 
   return (
-    <Tabs.ScrollView contentContainerStyle={{ paddingBottom: tabBarHeight }}>
-      <YStack px="$4" py="$3" gap="$2">
-        {viewState === 'loading' ? <PerpsLoadingState /> : null}
-        {viewState === 'empty' ? (
-          <PerpsEmptyState canDeposit={canDeposit} />
-        ) : null}
-        {viewState === 'ready' && view ? (
-          <>
-            <PerpsMobileHoldingsSummary
-              totalUsd={view.accountValueUsd}
-              holdings={view.holdings}
-              isDegraded={view.isDegraded}
-              canDeposit={canDeposit}
-            />
-            <YStack display="none" $gtMd={{ display: 'flex' }}>
-              <RichBlock
-                withTitleSeparator
-                title={intl.formatMessage({
-                  id: ETranslations.perp_account_panel_account_value,
-                })}
-                subTitle={
-                  <PerpsTotalUsd
-                    value={view.accountValueUsd}
-                    isDegraded={view.isDegraded}
-                    size="$headingXl"
-                    color="$textSubdued"
-                  />
-                }
-                headerContainerProps={{ px: 0, pb: 0 }}
-                headerActions={<PerpsHeaderActions canDeposit={canDeposit} />}
-                content={null}
-                plainContentContainer
-              />
-              <PerpsHoldingsBlock
+    <Stack flex={1}>
+      <Tabs.ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: tabBarHeight }}
+        nestedScrollEnabled={platformEnv.isNativeAndroid}
+        refreshControl={
+          !platformEnv.isNativeAndroid ? (
+            <PullToRefresh onRefresh={onHomePageRefresh} />
+          ) : undefined
+        }
+      >
+        <YStack px="$5" py="$3" gap="$2" $gtMd={{ px: '$4' }}>
+          {viewState === 'loading' ? <PerpsLoadingState /> : null}
+          {viewState === 'empty' ? (
+            <PerpsEmptyState canDeposit={canDeposit} />
+          ) : null}
+          {viewState === 'ready' && view ? (
+            <>
+              <PerpsMobileHoldingsSummary
+                totalUsd={view.accountValueUsd}
                 holdings={view.holdings}
-                hyperEvmLogoUri={HYPER_EVM_LOGO_URI}
+                isDegraded={view.isDegraded}
+                canDeposit={canDeposit}
               />
-            </YStack>
-            <YStack gap="$3">
-              {view.positions.length > 0 ? (
-                view.positions.map((position) => (
-                  <PerpsPositionCard
-                    key={`${position.coin}-${position.side}`}
-                    position={position}
-                  />
-                ))
-              ) : (
-                <PerpsPositionsEmptyContent />
-              )}
-            </YStack>
-          </>
-        ) : null}
-      </YStack>
-    </Tabs.ScrollView>
+              <YStack display="none" $gtMd={{ display: 'flex' }}>
+                <RichBlock
+                  withTitleSeparator
+                  title={intl.formatMessage({
+                    id: ETranslations.perp_account_panel_account_value,
+                  })}
+                  subTitle={
+                    <PerpsTotalUsd
+                      value={view.accountValueUsd}
+                      isDegraded={view.isDegraded}
+                      size="$headingXl"
+                      color="$textSubdued"
+                    />
+                  }
+                  headerContainerProps={{ px: 0, pb: 0 }}
+                  headerActions={<PerpsHeaderActions canDeposit={canDeposit} />}
+                  content={null}
+                  plainContentContainer
+                />
+                <PerpsHoldingsBlock
+                  holdings={view.holdings}
+                  hyperEvmLogoUri={HYPER_EVM_LOGO_URI}
+                />
+              </YStack>
+              <YStack gap="$2">
+                {view.positions.length > 0 ? (
+                  view.positions.map((position) => (
+                    <PerpsPositionCard
+                      key={`${position.coin}-${position.side}`}
+                      position={position}
+                    />
+                  ))
+                ) : (
+                  <PerpsPositionsEmptyContent />
+                )}
+              </YStack>
+            </>
+          ) : null}
+        </YStack>
+      </Tabs.ScrollView>
+    </Stack>
   );
 }

--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -677,10 +677,14 @@ function PerpsMobileHoldingRow({
   return (
     <XStack
       py="$2"
+      px="$3"
+      mx="$-3"
+      borderRadius="$3"
       alignItems="center"
       justifyContent="space-between"
       gap="$3"
       cursor={isPressable ? 'pointer' : 'default'}
+      hoverStyle={isPressable ? { bg: '$bgHover' } : undefined}
       pressStyle={isPressable ? { bg: '$bgActive' } : undefined}
       onPress={onPress ?? noop}
       role={isPressable ? 'button' : undefined}
@@ -931,8 +935,10 @@ function PerpsMetric({
 
 function PerpsPositionCard({ position }: { position: IPerpsHomePosition }) {
   const intl = useIntl();
+  const media = useMedia();
   const openPerp = useOpenPerpAsset();
   const isLong = position.side === 'long';
+  const isCardPressable = media.gtMd;
   const sideColor = isLong ? '$green11' : '$red11';
   const handleOpenPerp = useCallback(() => {
     openPerp(position.coin, 'perp', false);
@@ -954,17 +960,21 @@ function PerpsPositionCard({ position }: { position: IPerpsHomePosition }) {
   return (
     <YStack
       py="$3"
-      cursor="pointer"
-      focusable
-      role="button"
-      hoverStyle={{ bg: '$bgHover' }}
-      pressStyle={{ bg: '$bgActive' }}
-      focusVisibleStyle={{
-        outlineColor: '$focusRing',
-        outlineStyle: 'solid',
-        outlineWidth: 2,
-      }}
-      onPress={handleOpenPerp}
+      cursor={isCardPressable ? 'pointer' : 'default'}
+      focusable={isCardPressable}
+      role={isCardPressable ? 'button' : undefined}
+      hoverStyle={isCardPressable ? { bg: '$bgHover' } : undefined}
+      pressStyle={isCardPressable ? { bg: '$bgActive' } : undefined}
+      focusVisibleStyle={
+        isCardPressable
+          ? {
+              outlineColor: '$focusRing',
+              outlineStyle: 'solid',
+              outlineWidth: 2,
+            }
+          : undefined
+      }
+      onPress={isCardPressable ? handleOpenPerp : undefined}
       $gtMd={{
         bg: '$bgSubdued',
         borderRadius: '$3',

--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -31,7 +31,10 @@ import { useShowDepositWithdrawModal } from '@onekeyhq/kit/src/views/Perp/hooks/
 import {
   spotActiveAssetAtom,
   tradingModeAtom,
+  useCurrencyPersistAtom,
+  useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { USD_CURRENCY_ID } from '@onekeyhq/shared/src/consts/currencyConsts';
 import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
 import {
   EAppEventBusNames,
@@ -59,6 +62,7 @@ import { resolveOverviewCols } from '../components/DeFiListBlock/overviewColsRes
 import { PullToRefresh, onHomePageRefresh } from '../components/PullToRefresh';
 import { RichBlock } from '../components/RichBlock';
 import { HomeTestIDs } from '../testIDs';
+import { convertFiat } from '../../../utils/fiatConvert';
 
 import { usePerpsHomePortfolio } from './usePerpsHomePortfolio';
 
@@ -180,15 +184,40 @@ function PerpsTotalUsd({
   value: number | undefined;
   isDegraded?: boolean;
 } & Omit<ISizableTextProps, 'children'>) {
+  const [settings] = useSettingsPersistAtom();
+  const [{ currencyMap }] = useCurrencyPersistAtom();
+  const displayValue =
+    value === undefined
+      ? undefined
+      : convertFiat({
+          value,
+          sourceCurrency: USD_CURRENCY_ID,
+          targetCurrency: settings.currencyInfo.id,
+          currencyMap,
+        });
   if (!isDegraded) {
-    return <PerpsUsd value={value} {...rest} />;
+    return (
+      <NumberSizeableText
+        formatter="value"
+        formatterOptions={{ currency: settings.currencyInfo.symbol }}
+        {...rest}
+      >
+        {displayValue}
+      </NumberSizeableText>
+    );
   }
   return (
     <XStack minWidth={0} alignItems="baseline" gap="$0.5">
       <SizableText size={rest.size} color={rest.color ?? '$textSubdued'}>
         ≈
       </SizableText>
-      <PerpsUsd value={value} {...rest} />
+      <NumberSizeableText
+        formatter="value"
+        formatterOptions={{ currency: settings.currencyInfo.symbol }}
+        {...rest}
+      >
+        {displayValue}
+      </NumberSizeableText>
     </XStack>
   );
 }

--- a/packages/shared/src/utils/perpsHomeViewUtils.test.ts
+++ b/packages/shared/src/utils/perpsHomeViewUtils.test.ts
@@ -90,6 +90,7 @@ describe('mapSnapshotToPerpsHomeView', () => {
     const v = mapSnapshotToPerpsHomeView(snap);
     expect(v.isEmpty).toBe(false);
     expect(v.accountValueUsd).toBeCloseTo(257.26);
+    expect(v.positions.map((p) => p.coin)).toEqual(['BTC', 'ETH']);
     const eth = v.positions.find((p) => p.coin === 'ETH');
     expect(eth?.side).toBe('long');
     expect(eth?.sizeCoin).toBe('1.2');
@@ -103,6 +104,12 @@ describe('mapSnapshotToPerpsHomeView', () => {
   });
   it('maps holdings with spot pnl = value - entryNtl, undefined when price missing', () => {
     const v = mapSnapshotToPerpsHomeView(snap);
+    expect(v.holdings.map((h) => h.symbol)).toEqual([
+      'USDC',
+      'HYPE',
+      'UETH',
+      'WEIRD',
+    ]);
     const hype = v.holdings.find((h) => h.symbol === 'HYPE');
     expect(hype?.displaySymbol).toBe('HYPE');
     expect(hype?.spotUniverseName).toBe('HYPE/USDC');

--- a/packages/shared/src/utils/perpsHomeViewUtils.ts
+++ b/packages/shared/src/utils/perpsHomeViewUtils.ts
@@ -40,8 +40,7 @@ export function mapSnapshotToPerpsHomeView(
 ): IPerpsHomeView {
   const positions: IPerpsHomePosition[] = snapshot.perpPositions
     .toSorted(
-      (a, b) =>
-        Number(b.positionValue || 0) - Number(a.positionValue || 0),
+      (a, b) => Number(b.positionValue || 0) - Number(a.positionValue || 0),
     )
     .map((p) => {
       const sziBN = new BigNumber(p.szi);

--- a/packages/shared/src/utils/perpsHomeViewUtils.ts
+++ b/packages/shared/src/utils/perpsHomeViewUtils.ts
@@ -38,30 +38,40 @@ export interface IPerpsHomeView {
 export function mapSnapshotToPerpsHomeView(
   snapshot: IHyperliquidPortfolioSnapshot,
 ): IPerpsHomeView {
-  const positions: IPerpsHomePosition[] = snapshot.perpPositions.map((p) => {
-    const sziBN = new BigNumber(p.szi);
-    const absSz = sziBN.abs();
-    const markPx = absSz.gt(0)
-      ? new BigNumber(p.positionValue).div(absSz).toFixed()
-      : p.entryPx;
-    return {
-      coin: p.coin,
-      side: sziBN.isNegative() ? 'short' : 'long',
-      leverageType: p.leverageType,
-      leverageValue: p.leverageValue,
-      pnlUsd: Number(p.unrealizedPnl) || 0,
-      roi: Number(p.returnOnEquity) || 0,
-      sizeCoin: absSz.toFixed(),
-      marginUsd: Number(p.marginUsed) || 0,
-      entryPx: p.entryPx,
-      fundingUsd: Number(p.cumFundingSinceOpen) || 0,
-      markPx,
-      liqPx: p.liquidationPx,
-    };
-  });
+  const positions: IPerpsHomePosition[] = snapshot.perpPositions
+    .toSorted(
+      (a, b) =>
+        Number(b.positionValue || 0) - Number(a.positionValue || 0),
+    )
+    .map((p) => {
+      const sziBN = new BigNumber(p.szi);
+      const absSz = sziBN.abs();
+      const markPx = absSz.gt(0)
+        ? new BigNumber(p.positionValue).div(absSz).toFixed()
+        : p.entryPx;
+      return {
+        coin: p.coin,
+        side: sziBN.isNegative() ? 'short' : 'long',
+        leverageType: p.leverageType,
+        leverageValue: p.leverageValue,
+        pnlUsd: Number(p.unrealizedPnl) || 0,
+        roi: Number(p.returnOnEquity) || 0,
+        sizeCoin: absSz.toFixed(),
+        marginUsd: Number(p.marginUsed) || 0,
+        entryPx: p.entryPx,
+        fundingUsd: Number(p.cumFundingSinceOpen) || 0,
+        markPx,
+        liqPx: p.liquidationPx,
+      };
+    });
 
   const holdings: IPerpsHomeHolding[] = snapshot.spotBalances
     .filter((b) => Number(b.total) > 0)
+    .toSorted((a, b) => {
+      if (a.coin === 'USDC' && b.coin !== 'USDC') return -1;
+      if (a.coin !== 'USDC' && b.coin === 'USDC') return 1;
+      return Number(b.valueUsd || 0) - Number(a.valueUsd || 0);
+    })
     .map((b) => {
       const priced = b.valueUsd !== undefined && b.priceUsd !== undefined;
       const valueUsd = priced ? Number(b.valueUsd) : undefined;


### PR DESCRIPTION
## Summary
- refine the Home Perps tab layout, interactions, and state handling across desktop, web, and mobile
- sort Perps holdings/positions correctly, align visibility with supported networks, and remove invalid share/switch-position affordances
- include Perps assets in Home total balance and make the Perps header total follow the selected fiat currency

## Intent & Context
This PR bundles the Home Perps tab fixes we iterated on for the wallet homepage experience. The goal was to make the Home Perps tab behave consistently with the Perps product and the neighboring Home tabs, while removing broken or misleading affordances.

## Root Cause
Several issues came from the Home Perps tab being implemented as a parallel presentation layer rather than fully mirroring the existing Perps and Spot behaviors:
- sorting used raw snapshot order instead of fiat-value order
- card interactions and visual feedback diverged between mobile and desktop
- tab visibility and totals were not aligned with network support and account summary logic
- the scroll container could enter a bad state when switching tabs/accounts during the initial render path

## Design Decisions
- reused existing Hyperliquid snapshot and Home overview calculation paths instead of introducing a new aggregation layer
- kept only the header total on the Perps tab synced to the selected fiat, while preserving USD display for lower-level position metrics
- removed or reduced interactions where the UI should be display-only, and kept explicit action entry points such as the manage button
- aligned network gating with the same EVM/all-network expectation used by related Home sections

## Changes Detail
- sort Home Perps positions by fiat value and normalize spot holdings ordering
- gate the Home Perps tab by supported network and fix the tab-switch scroll/render edge case
- remove the invalid share and switch-position affordances from Home Perps positions
- align position card styling, token naming, spacing, cursor/press behavior, and manage navigation with the Perps and Spot experiences
- add Perps assets into the Home total asset calculation and convert the Perps header total with the active fiat currency

## Related Issues
- [OK-57384](https://onekeyhq.atlassian.net/browse/OK-57384)
- [OK-57386](https://onekeyhq.atlassian.net/browse/OK-57386)
- [OK-57387](https://onekeyhq.atlassian.net/browse/OK-57387)
- [OK-57388](https://onekeyhq.atlassian.net/browse/OK-57388)
- [OK-57389](https://onekeyhq.atlassian.net/browse/OK-57389)
- [OK-57390](https://onekeyhq.atlassian.net/browse/OK-57390)
- [OK-57392](https://onekeyhq.atlassian.net/browse/OK-57392)
- [OK-57393](https://onekeyhq.atlassian.net/browse/OK-57393)
- [OK-57394](https://onekeyhq.atlassian.net/browse/OK-57394)
- [OK-57395](https://onekeyhq.atlassian.net/browse/OK-57395)
- [OK-57397](https://onekeyhq.atlassian.net/browse/OK-57397)
- [OK-57398](https://onekeyhq.atlassian.net/browse/OK-57398)
- [OK-57399](https://onekeyhq.atlassian.net/browse/OK-57399)

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Web / Desktop
- **Risk Areas**: Home overview totals, Perps tab rendering, mobile/desktop interaction differences, tab scroll behavior

## Test plan
- [ ] Verify the Home Perps tab only appears on supported networks / all networks
- [ ] Verify Perps holdings and positions are sorted by fiat value as expected
- [ ] Verify mobile position cards have no card-level press feedback and only the manage button navigates
- [ ] Verify spot holdings rows still show the expected clickable feedback and route correctly
- [ ] Verify Home total assets include Perps assets and the Perps header total follows the selected fiat currency
- [ ] Verify switching accounts/tabs does not break Perps tab scrolling


[OK-57384]: https://onekeyhq.atlassian.net/browse/OK-57384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ