### PR TITLE
fix: keep perps spot holdings on trade page

### DIFF
--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -377,7 +377,7 @@ function PerpsHoldingsBlock({
             hyperEvmLogoUri={hyperEvmLogoUri}
             onPress={
               isTradableSpotHolding(holding)
-                ? () => openPerp(holding.spotUniverseName, 'spot')
+                ? () => openPerp(holding.spotUniverseName, 'spot', false)
                 : undefined
             }
           />
@@ -840,7 +840,7 @@ function PerpsMobileHoldingsSummary({
               hyperEvmLogoUri={HYPER_EVM_LOGO_URI}
               onPress={
                 isTradableSpotHolding(holding)
-                  ? () => openPerp(holding.spotUniverseName, 'spot')
+                  ? () => openPerp(holding.spotUniverseName, 'spot', false)
                   : undefined
               }
             />


### PR DESCRIPTION
## Summary
- Keep Home Perps spot holding clicks on the Perps trade page instead of opening the native market detail page.

## Intent & Context
Users should be taken to the corresponding Perps coin in the Perps page, not the market detail page, when tapping spot holdings from the Home Perps tab.

## Root Cause
`openPerp` defaults `openMarket` to `true` on native. The spot holding entries reused that default, so native taps opened `MobilePerpMarket`.

## Changes Detail
- Pass `openMarket = false` from desktop and mobile Home Perps spot holding click handlers.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile, Desktop, Web
- **Risk Areas**: Home Perps tab spot holding navigation only.

## Test plan
- [ ] Open Home > Perps tab on mobile.
- [ ] Tap a non-USDC spot holding.
- [ ] Confirm it switches to the Perps trade page with the selected spot coin and does not open the market detail page.