### PR TITLE
fix: preserve token list cache during refresh

### DIFF
--- a/development/scripts/home-token-refresh-stress.mjs
+++ b/development/scripts/home-token-refresh-stress.mjs
@@ -1,0 +1,660 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const DEFAULT_UDID = '4837E819-A117-4E08-9936-445785D199E3';
+const DEFAULT_BUNDLE_ID = 'so.onekey.wallet';
+
+const COORDS = {
+  accountButton: [95, 136],
+  account1: [195, 196],
+  account2: [195, 258],
+  addAccount: [190, 310],
+  newAccountMore: [361, 315],
+  passwordClose: [358, 687],
+  removeMenu: [105, 790],
+  removeConfirm: [292, 775],
+
+  networkButton: [340, 136],
+  allNetworksTab: [160, 98],
+  singleNetworkTab: [245, 98],
+  allNetworksDone: [196, 812],
+  singleRows: {
+    solana: [115, 336],
+    bitcoin: [115, 476],
+    polygon: [115, 523],
+  },
+
+  pullToRefreshStart: [200, 360],
+  pullToRefreshEnd: [200, 700],
+};
+
+function parseArgs(argv) {
+  const opts = {
+    iterations: 100,
+    udid: DEFAULT_UDID,
+    bundleId: DEFAULT_BUNDLE_ID,
+    session: 'default',
+    outDir: `.tmp/home-token-stress-${new Date()
+      .toISOString()
+      .replace(/[:.]/g, '-')
+      .replace('T', '-')
+      .slice(0, 19)}`,
+    screenshotEvery: 10,
+    coldStartEvery: 5,
+    accountMutationEvery: 1,
+    newAccountColdStart: true,
+    purgeColdStartCacheEvery: 0,
+    stopOnCrash: true,
+    commandTimeoutMs: 90_000,
+    waitScale: 1,
+  };
+
+  for (const arg of argv) {
+    const [key, rawValue] = arg.split('=');
+    const value = rawValue ?? '';
+    switch (key) {
+      case '--iterations':
+        opts.iterations = Number(value);
+        break;
+      case '--udid':
+        opts.udid = value;
+        break;
+      case '--bundle-id':
+        opts.bundleId = value;
+        break;
+      case '--session':
+        opts.session = value;
+        break;
+      case '--out':
+        opts.outDir = value;
+        break;
+      case '--screenshot-every':
+        opts.screenshotEvery = Number(value);
+        break;
+      case '--cold-start-every':
+        opts.coldStartEvery = Number(value);
+        break;
+      case '--account-mutation-every':
+        opts.accountMutationEvery = Number(value);
+        break;
+      case '--purge-cold-start-cache-every':
+        opts.purgeColdStartCacheEvery = Number(value);
+        break;
+      case '--no-new-account-cold-start':
+        opts.newAccountColdStart = false;
+        break;
+      case '--no-stop-on-crash':
+        opts.stopOnCrash = false;
+        break;
+      case '--wait-scale':
+        opts.waitScale = Number(value);
+        break;
+      default:
+        if (key === '--help' || key === '-h') {
+          printHelpAndExit();
+        }
+        throw new Error(`Unknown arg: ${arg}`);
+    }
+  }
+
+  if (!Number.isFinite(opts.iterations) || opts.iterations <= 0) {
+    throw new Error('--iterations must be a positive number');
+  }
+  if (!Number.isFinite(opts.screenshotEvery) || opts.screenshotEvery < 0) {
+    throw new Error('--screenshot-every must be a non-negative number');
+  }
+  return opts;
+}
+
+function printHelpAndExit() {
+  console.log(`Usage:
+  node development/scripts/home-token-refresh-stress.mjs [options]
+
+Options:
+  --iterations=100
+  --udid=${DEFAULT_UDID}
+  --bundle-id=${DEFAULT_BUNDLE_ID}
+  --session=default
+  --out=.tmp/home-token-stress-...
+  --screenshot-every=10          0 disables routine screenshots
+  --cold-start-every=5
+  --account-mutation-every=1       0 disables add/remove account mutation
+  --no-new-account-cold-start      skip cold start on the newly-added empty account
+  --purge-cold-start-cache-every=0 0 disables MMKV cold-start-cache purge
+  --no-stop-on-crash
+  --wait-scale=1
+
+Scenario per loop:
+  1. optional cold start with existing cache
+  2. All Networks pull-to-refresh
+  3. All <-> Solana <-> All <-> Polygon <-> All <-> Bitcoin <-> All
+  4. Account #1 <-> Account #2
+  5. optional add account, cold start on new no-local-cache account, remove it
+
+Evidence:
+  - screenshots under <out>/screenshots
+  - run log JSONL under <out>/events.jsonl
+  - summary under <out>/summary.md
+  - if a crash appears, crash .ips copy + parsed summary + native log tail
+`);
+  process.exit(0);
+}
+
+const opts = parseArgs(process.argv.slice(2));
+const rootDir = process.cwd();
+const outDir = path.resolve(rootDir, opts.outDir);
+const screenshotDir = path.join(outDir, 'screenshots');
+const crashDir = path.join(outDir, 'crashes');
+fs.mkdirSync(screenshotDir, { recursive: true });
+fs.mkdirSync(crashDir, { recursive: true });
+
+const eventLogPath = path.join(outDir, 'events.jsonl');
+const summaryPath = path.join(outDir, 'summary.md');
+const startMs = Date.now();
+const initialCrashFiles = new Set(listCrashReports().map((f) => f.path));
+let lastFailure;
+let crashDetected;
+let isCheckingCrash = false;
+
+function writeEvent(event) {
+  fs.appendFileSync(
+    eventLogPath,
+    `${JSON.stringify({ ts: new Date().toISOString(), ...event })}\n`,
+  );
+}
+
+function sleep(ms) {
+  const scaled = Math.max(0, Math.round(ms * opts.waitScale));
+  if (scaled === 0) return;
+  spawnSync('sleep', [String(scaled / 1000)], { stdio: 'ignore' });
+}
+
+function runCommand(name, args, options = {}) {
+  const startedAt = Date.now();
+  const result = spawnSync(name, args, {
+    cwd: rootDir,
+    encoding: 'utf8',
+    timeout: options.timeoutMs ?? opts.commandTimeoutMs,
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  const elapsedMs = Date.now() - startedAt;
+  const event = {
+    phase: 'command',
+    cmd: [name, ...args].join(' '),
+    status: result.status,
+    signal: result.signal,
+    elapsedMs,
+    stdout: truncate(result.stdout),
+    stderr: truncate(result.stderr),
+  };
+  writeEvent(event);
+  if (result.error || result.status !== 0) {
+    lastFailure = {
+      ...event,
+      error: result.error ? String(result.error) : undefined,
+    };
+    checkCrash(`command-failed:${name}`);
+    if (options.allowFailure) {
+      return result;
+    }
+    throw new Error(
+      `Command failed (${result.status ?? result.signal}): ${name} ${args.join(
+        ' ',
+      )}`,
+    );
+  }
+  return result;
+}
+
+function truncate(text, max = 4000) {
+  if (!text) return '';
+  return text.length > max ? `${text.slice(0, max)}...<truncated>` : text;
+}
+
+function agent(args, options) {
+  return runCommand(
+    'agent-device',
+    [
+      ...args,
+      '--platform',
+      'ios',
+      '--udid',
+      opts.udid,
+      '--session',
+      opts.session,
+      '--json',
+    ],
+    options,
+  );
+}
+
+function click(x, y, label) {
+  writeEvent({ phase: 'tap', label, x, y });
+  agent(['click', String(x), String(y)]);
+}
+
+function clickSelector(selector, label, fallback) {
+  writeEvent({ phase: 'tap-selector', label, selector });
+  const result = agent(['click', selector], { allowFailure: true });
+  if (result.status !== 0 && fallback) {
+    writeEvent({ phase: 'tap-selector-fallback', label, selector, fallback });
+    click(fallback[0], fallback[1], `${label}:fallback`);
+  }
+}
+
+function swipe(x1, y1, x2, y2, durationMs, label) {
+  writeEvent({ phase: 'swipe', label, x1, y1, x2, y2, durationMs });
+  agent([
+    'swipe',
+    String(x1),
+    String(y1),
+    String(x2),
+    String(y2),
+    String(durationMs),
+  ]);
+}
+
+function screenshot(name, force = false) {
+  if (!force && opts.screenshotEvery <= 0) return;
+  const file = path.join(screenshotDir, `${name}.png`);
+  agent(['screenshot', file], { timeoutMs: 120_000 });
+  writeEvent({ phase: 'screenshot', file });
+}
+
+function shouldTakeIterationScreenshot(iteration) {
+  return opts.screenshotEvery > 0 && iteration % opts.screenshotEvery === 0;
+}
+
+function openApp() {
+  agent(['open', opts.bundleId], { timeoutMs: 120_000 });
+  sleep(2500);
+}
+
+function terminateApp() {
+  runCommand('xcrun', ['simctl', 'terminate', opts.udid, opts.bundleId], {
+    allowFailure: true,
+    timeoutMs: 30_000,
+  });
+  sleep(1000);
+}
+
+function getAppDataDir() {
+  const result = runCommand(
+    'xcrun',
+    ['simctl', 'get_app_container', opts.udid, opts.bundleId, 'data'],
+    { timeoutMs: 30_000 },
+  );
+  return result.stdout.trim();
+}
+
+function purgeColdStartCache() {
+  terminateApp();
+  const appData = getAppDataDir();
+  const mmkvDir = path.join(appData, 'Documents', 'mmkv');
+  for (const filename of [
+    'onekey-cold-start-cache',
+    'onekey-cold-start-cache.crc',
+  ]) {
+    const target = path.join(mmkvDir, filename);
+    if (fs.existsSync(target)) {
+      fs.rmSync(target, { force: true });
+      writeEvent({ phase: 'purge-cold-start-cache', target });
+    }
+  }
+  openApp();
+}
+
+function coldStart(label, purge = false, capture = true) {
+  writeEvent({ phase: 'cold-start', label, purge });
+  if (purge) {
+    purgeColdStartCache();
+  } else {
+    terminateApp();
+    openApp();
+  }
+  if (capture) {
+    screenshot(`${label}-cold-start`, true);
+  }
+  checkCrash(`cold-start:${label}`);
+}
+
+function ensureAllNetworks() {
+  click(...COORDS.networkButton, 'network:open');
+  sleep(900);
+  click(...COORDS.allNetworksTab, 'network:all-tab');
+  sleep(500);
+  click(...COORDS.allNetworksDone, 'network:all-done');
+  sleep(2500);
+  checkCrash('ensure-all-networks');
+}
+
+function selectSingleNetwork(name) {
+  const row = COORDS.singleRows[name];
+  if (!row) throw new Error(`Unknown single network: ${name}`);
+  click(...COORDS.networkButton, `network:${name}:open`);
+  sleep(900);
+  click(...COORDS.singleNetworkTab, `network:${name}:single-tab`);
+  sleep(500);
+  click(...row, `network:${name}:row`);
+  sleep(2500);
+  checkCrash(`select-single:${name}`);
+}
+
+function manualRefreshAllNetworks() {
+  swipe(
+    COORDS.pullToRefreshStart[0],
+    COORDS.pullToRefreshStart[1],
+    COORDS.pullToRefreshEnd[0],
+    COORDS.pullToRefreshEnd[1],
+    650,
+    'home:pull-to-refresh',
+  );
+  sleep(5000);
+  checkCrash('manual-refresh-all-networks');
+}
+
+function selectAccount(accountNumber) {
+  click(...COORDS.accountButton, `account:${accountNumber}:open`);
+  sleep(900);
+  const row = accountNumber === 1 ? COORDS.account1 : COORDS.account2;
+  click(...row, `account:${accountNumber}:row`);
+  sleep(3000);
+  checkCrash(`select-account:${accountNumber}`);
+}
+
+function addAndRemoveAccount(iteration) {
+  const capture = shouldTakeIterationScreenshot(iteration);
+  writeEvent({ phase: 'account-mutation:start', iteration });
+  click(...COORDS.accountButton, 'account:add:open-selector');
+  sleep(900);
+  click(...COORDS.addAccount, 'account:add');
+  sleep(3500);
+  if (capture) {
+    screenshot(`iter-${iteration}-account-added`, true);
+  }
+  // A password sheet may appear after account creation. Tapping the close
+  // coordinate is harmless when it is absent.
+  click(...COORDS.passwordClose, 'account:add:password-close');
+  sleep(1000);
+
+  if (opts.newAccountColdStart) {
+    coldStart(`iter-${iteration}-new-account-no-local-cache`, false, capture);
+  }
+
+  click(...COORDS.accountButton, 'account:remove:open-selector');
+  sleep(900);
+  click(...COORDS.newAccountMore, 'account:remove:more');
+  sleep(900);
+  clickSelector(
+    'id="account-manager-account-remove-button"',
+    'account:remove:menu',
+    COORDS.removeMenu,
+  );
+  sleep(900);
+  click(...COORDS.removeConfirm, 'account:remove:confirm');
+  sleep(2500);
+  if (capture) {
+    screenshot(`iter-${iteration}-account-removed`, true);
+  }
+  checkCrash(`account-mutation:${iteration}`);
+
+  // Return to Account #2 as the steady-state account for the rest of the loop.
+  click(...COORDS.account2, 'account:return-account-2');
+  sleep(2500);
+  writeEvent({ phase: 'account-mutation:done', iteration });
+}
+
+function runIteration(iteration) {
+  writeEvent({ phase: 'iteration:start', iteration });
+  console.log(`[home-token-stress] iteration ${iteration}/${opts.iterations}`);
+  const capture = shouldTakeIterationScreenshot(iteration);
+
+  if (opts.coldStartEvery > 0 && iteration % opts.coldStartEvery === 0) {
+    coldStart(`iter-${iteration}-existing-cache`, false, capture);
+  }
+  if (
+    opts.purgeColdStartCacheEvery > 0 &&
+    iteration % opts.purgeColdStartCacheEvery === 0
+  ) {
+    coldStart(`iter-${iteration}-purged-cold-start-cache`, true, capture);
+  }
+
+  ensureAllNetworks();
+  manualRefreshAllNetworks();
+  if (capture) {
+    screenshot(`iter-${iteration}-all-after-refresh`, true);
+  }
+
+  for (const network of ['solana', 'polygon', 'bitcoin']) {
+    selectSingleNetwork(network);
+    if (capture) {
+      screenshot(`iter-${iteration}-single-${network}`, true);
+    }
+    ensureAllNetworks();
+    if (capture) {
+      screenshot(`iter-${iteration}-back-all-after-${network}`, true);
+    }
+  }
+
+  selectAccount(1);
+  if (capture) {
+    screenshot(`iter-${iteration}-account-1`, true);
+  }
+  selectAccount(2);
+  if (capture) {
+    screenshot(`iter-${iteration}-account-2`, true);
+  }
+
+  if (
+    opts.accountMutationEvery > 0 &&
+    iteration % opts.accountMutationEvery === 0
+  ) {
+    addAndRemoveAccount(iteration);
+  }
+
+  writeEvent({ phase: 'iteration:done', iteration });
+}
+
+function listCrashReports() {
+  const dir = path.join(os.homedir(), 'Library', 'Logs', 'DiagnosticReports');
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((name) => /^OneKeyWallet-.*\.ips$/.test(name))
+    .map((name) => {
+      const file = path.join(dir, name);
+      const stat = fs.statSync(file);
+      return { path: file, mtimeMs: stat.mtimeMs, size: stat.size };
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
+
+function parseCrashReport(file) {
+  const text = fs.readFileSync(file, 'utf8');
+  const lines = text.split(/\r?\n/);
+  const header = JSON.parse(lines[0]);
+  const body = JSON.parse(lines.slice(1).join('\n'));
+  const usedImages = body.usedImages ?? [];
+  const faultingThread = body.threads?.[body.faultingThread];
+  const frames = (faultingThread?.frames ?? []).slice(0, 40).map((frame) => {
+    const image = usedImages[frame.imageIndex] ?? {};
+    return `${image.name ?? '?'} ${frame.symbol ?? ''}`.trim();
+  });
+  const vmLines = String(body.vmSummary ?? '')
+    .split('\n')
+    .filter((line) =>
+      [
+        'JS JIT generated code',
+        'JS VM Gigacage',
+        'MALLOC',
+        'VM_ALLOCATE',
+        'WebKit Malloc',
+        'TOTAL',
+      ].some((needle) => line.includes(needle)),
+    );
+  return {
+    file,
+    header,
+    captureTime: body.captureTime,
+    procLaunch: body.procLaunch,
+    procRole: body.procRole,
+    exception: body.exception,
+    termination: body.termination,
+    faultingThread: body.faultingThread,
+    threadName: faultingThread?.name,
+    frames,
+    vmLines,
+  };
+}
+
+function copyNativeLogTail(label) {
+  try {
+    const appData = getAppDataDir();
+    const log = path.join(appData, 'Library', 'Caches', 'logs', 'app-latest.log');
+    if (!fs.existsSync(log)) return undefined;
+    const out = path.join(crashDir, `${label}-app-latest-tail.log`);
+    const result = runCommand('tail', ['-2000', log], {
+      allowFailure: true,
+      timeoutMs: 30_000,
+    });
+    fs.writeFileSync(out, result.stdout);
+    return out;
+  } catch (e) {
+    writeEvent({ phase: 'native-log-tail-failed', error: String(e) });
+    return undefined;
+  }
+}
+
+function checkCrash(label) {
+  if (crashDetected || isCheckingCrash) return crashDetected;
+  const newCrashes = listCrashReports().filter(
+    (f) => f.mtimeMs >= startMs - 1000 && !initialCrashFiles.has(f.path),
+  );
+  if (!newCrashes.length) return undefined;
+  isCheckingCrash = true;
+  try {
+    const latest = newCrashes[0];
+    const parsed = parseCrashReport(latest.path);
+    const safeLabel = label.replace(/[^a-z0-9_-]+/gi, '_');
+    const copyPath = path.join(crashDir, path.basename(latest.path));
+    fs.copyFileSync(latest.path, copyPath);
+    const parsedPath = path.join(
+      crashDir,
+      `${path.basename(latest.path)}.json`,
+    );
+    fs.writeFileSync(parsedPath, JSON.stringify(parsed, null, 2));
+    const crashScreenshot = path.join(crashDir, `${safeLabel}-screen.png`);
+    agent(['screenshot', crashScreenshot], {
+      allowFailure: true,
+      timeoutMs: 120_000,
+    });
+    const nativeTail = copyNativeLogTail(safeLabel);
+    crashDetected = {
+      label,
+      latest,
+      copyPath,
+      parsedPath,
+      parsed,
+      nativeTail,
+      crashScreenshot: fs.existsSync(crashScreenshot)
+        ? crashScreenshot
+        : undefined,
+    };
+    writeEvent({ phase: 'crash-detected', label, crashDetected });
+    if (opts.stopOnCrash) {
+      throw new Error(`Crash detected after ${label}: ${latest.path}`);
+    }
+    return crashDetected;
+  } finally {
+    isCheckingCrash = false;
+  }
+}
+
+function writeSummary(status) {
+  const lines = [
+    '# Home Token Refresh Stress Report',
+    '',
+    `- Status: ${status}`,
+    `- Started: ${new Date(startMs).toISOString()}`,
+    `- Ended: ${new Date().toISOString()}`,
+    `- Iterations requested: ${opts.iterations}`,
+    `- UDID: ${opts.udid}`,
+    `- Bundle: ${opts.bundleId}`,
+    `- Output: ${outDir}`,
+    `- Events: ${eventLogPath}`,
+    '',
+    '## Runtime Notes',
+    '',
+    '- iOS release native process contains main and background JS runtimes.',
+    '- Native MMKV/native-logger are shared process resources.',
+    '- JS heap objects are per-runtime copies; this stress test is meant to expose heap pressure across main/bg runtime traffic.',
+    '',
+    '## Scenario',
+    '',
+    '- All Networks pull-to-refresh.',
+    '- All Networks <-> Solana/Polygon/Bitcoin round trips.',
+    '- Account #1 <-> Account #2 switches.',
+    '- Add account, optional cold start on the newly-added no-local-token-cache account, then remove account.',
+    '- Optional cold start with existing cache and optional purge of cold-start MMKV.',
+    `- Routine screenshots are sampled every ${opts.screenshotEvery} iteration(s); crash evidence is always captured.`,
+    '',
+  ];
+
+  if (crashDetected) {
+    lines.push('## Crash');
+    lines.push('');
+    lines.push(`- Detected after: ${crashDetected.label}`);
+    lines.push(`- Crash report: ${crashDetected.copyPath}`);
+    lines.push(`- Parsed report: ${crashDetected.parsedPath}`);
+    if (crashDetected.nativeTail) {
+      lines.push(`- Native log tail: ${crashDetected.nativeTail}`);
+    }
+    if (crashDetected.crashScreenshot) {
+      lines.push(`- Screen at detection: ${crashDetected.crashScreenshot}`);
+    }
+    lines.push(`- Exception: ${JSON.stringify(crashDetected.parsed.exception)}`);
+    lines.push(
+      `- Faulting thread: ${crashDetected.parsed.faultingThread} ${crashDetected.parsed.threadName ?? ''}`,
+    );
+    lines.push('');
+    lines.push('Top frames:');
+    lines.push('');
+    for (const frame of crashDetected.parsed.frames.slice(0, 12)) {
+      lines.push(`- ${frame}`);
+    }
+    lines.push('');
+  }
+
+  if (lastFailure) {
+    lines.push('## Last Failure');
+    lines.push('');
+    lines.push('```json');
+    lines.push(JSON.stringify(lastFailure, null, 2));
+    lines.push('```');
+    lines.push('');
+  }
+
+  fs.writeFileSync(summaryPath, `${lines.join('\n')}\n`);
+}
+
+writeEvent({ phase: 'run:start', opts });
+
+try {
+  coldStart('start-existing-cache', false);
+  for (let iteration = 1; iteration <= opts.iterations; iteration += 1) {
+    runIteration(iteration);
+  }
+  checkCrash('run-complete');
+  writeSummary('passed-no-crash-detected');
+  writeEvent({ phase: 'run:done', status: 'passed-no-crash-detected' });
+  console.log(`[home-token-stress] done: ${summaryPath}`);
+} catch (e) {
+  writeEvent({ phase: 'run:error', error: String(e) });
+  writeSummary(crashDetected ? 'failed-crash-detected' : 'failed-command-error');
+  console.error(`[home-token-stress] failed: ${String(e)}`);
+  console.error(`[home-token-stress] summary: ${summaryPath}`);
+  process.exit(1);
+}

--- a/development/scripts/home-token-refresh-stress.mjs
+++ b/development/scripts/home-token-refresh-stress.mjs
@@ -510,13 +510,6 @@ function parseCrashReport(file) {
   };
 }
 
-function formatErrorForLog(e) {
-  if (e instanceof Error) {
-    return { name: e.name };
-  }
-  return { name: typeof e };
-}
-
 function copyNativeLogTail(label) {
   try {
     const appData = getAppDataDir();
@@ -535,10 +528,9 @@ function copyNativeLogTail(label) {
     });
     fs.writeFileSync(out, result.stdout);
     return out;
-  } catch (e) {
+  } catch {
     writeEvent({
       phase: 'native-log-tail-failed',
-      error: formatErrorForLog(e),
     });
     return undefined;
   }
@@ -669,12 +661,12 @@ try {
   writeSummary('passed-no-crash-detected');
   writeEvent({ phase: 'run:done', status: 'passed-no-crash-detected' });
   console.log(`[home-token-stress] done: ${summaryPath}`);
-} catch (e) {
-  writeEvent({ phase: 'run:error', error: formatErrorForLog(e) });
+} catch {
+  writeEvent({ phase: 'run:error' });
   writeSummary(
     crashDetected ? 'failed-crash-detected' : 'failed-command-error',
   );
-  console.error(`[home-token-stress] failed: ${formatErrorForLog(e).name}`);
+  console.error('[home-token-stress] failed');
   console.error(`[home-token-stress] summary: ${summaryPath}`);
   process.exit(1);
 }

--- a/development/scripts/home-token-refresh-stress.mjs
+++ b/development/scripts/home-token-refresh-stress.mjs
@@ -469,7 +469,7 @@ function listCrashReports() {
       const stat = fs.statSync(file);
       return { path: file, mtimeMs: stat.mtimeMs, size: stat.size };
     })
-    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    .toSorted((a, b) => b.mtimeMs - a.mtimeMs);
 }
 
 function parseCrashReport(file) {
@@ -510,10 +510,23 @@ function parseCrashReport(file) {
   };
 }
 
+function formatErrorForLog(e) {
+  if (e instanceof Error) {
+    return { name: e.name };
+  }
+  return { name: typeof e };
+}
+
 function copyNativeLogTail(label) {
   try {
     const appData = getAppDataDir();
-    const log = path.join(appData, 'Library', 'Caches', 'logs', 'app-latest.log');
+    const log = path.join(
+      appData,
+      'Library',
+      'Caches',
+      'logs',
+      'app-latest.log',
+    );
     if (!fs.existsSync(log)) return undefined;
     const out = path.join(crashDir, `${label}-app-latest-tail.log`);
     const result = runCommand('tail', ['-2000', log], {
@@ -523,7 +536,10 @@ function copyNativeLogTail(label) {
     fs.writeFileSync(out, result.stdout);
     return out;
   } catch (e) {
-    writeEvent({ phase: 'native-log-tail-failed', error: String(e) });
+    writeEvent({
+      phase: 'native-log-tail-failed',
+      error: formatErrorForLog(e),
+    });
     return undefined;
   }
 }
@@ -615,7 +631,9 @@ function writeSummary(status) {
     if (crashDetected.crashScreenshot) {
       lines.push(`- Screen at detection: ${crashDetected.crashScreenshot}`);
     }
-    lines.push(`- Exception: ${JSON.stringify(crashDetected.parsed.exception)}`);
+    lines.push(
+      `- Exception: ${JSON.stringify(crashDetected.parsed.exception)}`,
+    );
     lines.push(
       `- Faulting thread: ${crashDetected.parsed.faultingThread} ${crashDetected.parsed.threadName ?? ''}`,
     );
@@ -652,9 +670,11 @@ try {
   writeEvent({ phase: 'run:done', status: 'passed-no-crash-detected' });
   console.log(`[home-token-stress] done: ${summaryPath}`);
 } catch (e) {
-  writeEvent({ phase: 'run:error', error: String(e) });
-  writeSummary(crashDetected ? 'failed-crash-detected' : 'failed-command-error');
-  console.error(`[home-token-stress] failed: ${String(e)}`);
+  writeEvent({ phase: 'run:error', error: formatErrorForLog(e) });
+  writeSummary(
+    crashDetected ? 'failed-crash-detected' : 'failed-command-error',
+  );
+  console.error(`[home-token-stress] failed: ${formatErrorForLog(e).name}`);
   console.error(`[home-token-stress] summary: ${summaryPath}`);
   process.exit(1);
 }

--- a/development/scripts/ios-release-build-deploy.sh
+++ b/development/scripts/ios-release-build-deploy.sh
@@ -171,8 +171,12 @@ cmd_logs() {
   local LAST_START
   LAST_START=$(grep 'hostDidStart fired' "$LOG" | tail -1 | cut -d'|' -f1 | xargs)
 
-  echo "=== Session: $LAST_START ==="
-  grep -A999 "$LAST_START.*hostDidStart fired" "$LOG" | grep -E "$FILTER" | head -30
+  echo "=== Session: ${LAST_START:-latest available log} ==="
+  if [ -n "$LAST_START" ]; then
+    grep -A999 "$LAST_START.*hostDidStart fired" "$LOG" | grep -E "$FILTER" | tail -60 || true
+  else
+    grep -E "$FILTER" "$LOG" | tail -60 || true
+  fi
 }
 
 # --- Main ---

--- a/docs/home-token-list-refresh-cache.md
+++ b/docs/home-token-list-refresh-cache.md
@@ -1,0 +1,166 @@
+# Home Token List Refresh And Cache Verification
+
+Date: 2026-07-04
+Branch: `codex/home-token-cache-refresh`
+
+## Runtime Ownership
+
+Production native uses two JS runtimes in one native process:
+
+- `main`: Home UI, `TokenListBlock`, `TokenListView`, `useAllNetworkRequests`, account overview atoms, token-list cells receive shell.
+- `bg`: `ServiceAllNetwork`, `ServiceToken`, `ServiceTokenViewModel`, SimpleDB/local DB service access, token frame production.
+- Shared native resources: native storage/DB/MMKV/file handles/native-logger are process-level resources. A token cache written by `bg` can be read later by `main`, but the JS objects are deserialized separately.
+- Per-runtime JS heap copies: token arrays, fiat maps, LWW views, and `ServiceTokenViewModel` frames are not shared between `main` and `bg`. If `main` reads a local cache, it must explicitly feed the bg ViewModel with `ingestRound` before `TokenListView` can reuse that cache without owner-mismatch skeleton.
+- Timing/order: `main` and `bg` initialize independently. Do not assume Home UI has already subscribed to bg frames when cache is read; bg `getTokenListFrames` pull must also work.
+
+## Refresh Entrances
+
+| Entrance                                               | Runtime        | Trigger                                                                                                        | Current behavior before this fix                                                                                                                                                                       | Expected behavior                                                                                                                                         |
+| ------------------------------------------------------ | -------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Home token tab mount / account change / network change | `main`         | `initTokenListData` effect dependencies: account, network, wallet, merge-derive state                          | Single-network local cache updated worth only; token cells kept previous all-networks owner until live fetch, causing skeleton. All-networks starts fan-out and may show cache only after cache probe. | If local cache exists, paint cached rows immediately and refresh in background. No token-list skeleton or balance skeleton for cached owner.              |
+| Single-network live refresh                            | `main` -> `bg` | `usePromiseResult(run)`, polling, focus revalidation, manual header refresh, visibility active, refresh events | Live result feeds `ServiceTokenViewModel.ingestRound`; rows update after network fetch.                                                                                                                | Keep cached rows while fetching; changed rows update through token cells only.                                                                            |
+| All-networks initial run                               | `main` -> `bg` | `useAllNetworkRequests` first run when All Networks is selected                                                | Probes per-network local cache. If cache exists, seeds LWW floor and paints merged snapshot. If no cache, progressive live settles paint partial list.                                                 | Same, but logs must show account fan-out counts, cache count, progressive settle count, and authoritative commit count.                                   |
+| All-networks warm auto/manual refresh                  | `main` -> `bg` | Header pull-to-refresh, auto polling/focus revalidation, visibility active                                     | After authoritative commit, LWW view was cleared. Next warm refresh progressive paint started from an empty floor, so the full list shrank to only settled networks and grew row by row.               | Retain last authoritative per-network rounds as SWR floor. Refresh keeps full cached list visible and only overwrites networks whose live result settled. |
+| All-networks enabled-network changes                   | `main`         | `EnabledNetworksChanged` event                                                                                 | Clears account-list base cache and reruns.                                                                                                                                                             | Removed/disabled networks are evicted by enabled-key intersection; still-enabled unsettled networks keep floor.                                           |
+| Hardware/default account batch creation                | `main`         | `AddDBAccountsToWallet` event                                                                                  | Account-list cache can capture a half-formed wallet and show only the first one or two networks if not invalidated.                                                                                    | Invalidate this wallet's account-list cache and rerun with `skipAccountsCache` without clearing visible rows between batches.                             |
+| Account add/delete                                     | `main`         | `AddDBAccountsToWallet`, account selector changes, account data updates                                        | Add may reuse stale all-network account cache; delete may leave removed networks until next authoritative set.                                                                                         | Add bypasses account cache and fetches all new accounts. Delete updates enabled/account set and evicts missing keys without wiping remaining cached rows. |
+| Account switch                                         | `main`         | active account changes, Test Wallet Account #1/#2 switch                                                       | Existing owner guards prevent stale late writes, but single-network disk cache was not fed to cells.                                                                                                   | Cached owner paints via bg VM pull/ingest. Late previous-owner responses are dropped.                                                                     |
+| Transaction history changes                            | `main` -> `bg` | `fetchAccountHistory` polling returns `accountsWithChangedTxs`                                                 | Refreshes only changed all-network account/network pairs.                                                                                                                                              | Only affected network rows and account worth update; full list remains visible.                                                                           |
+| External refresh event                                 | `main`         | `RefreshTokenList`, `AccountDataUpdate`, `NetworkDeriveTypeChanged`                                            | All-networks can refresh all or specific accounts; single network can use explicit target if tab closures are stale.                                                                                   | Provided account/network refresh must not use stale closures and must not clear unrelated rows.                                                           |
+| LP/DeFi-token display switch                           | `main` -> `bg` | `homeShowLpTokensOnly` toggle                                                                                  | LP scoped list owns its loading state and can show its own skeleton.                                                                                                                                   | Wallet-token cache and account worth still hydrate in background; LP mode does not regress wallet-token cache.                                            |
+| Balance amount updates                                 | `main`         | `updateAccountWorth`, `updateAccountOverviewState`, cache/live all-network snapshot                            | `initialized=false/isRefreshing=true` can show balance skeleton during uncached init.                                                                                                                  | Cached worth updates immediately from local cache; live refresh merges precise per-network worth without global skeleton.                                 |
+
+## Logging
+
+Local native logs use:
+
+- `account => allNetworkAccountPerf => homeTokenListRefreshTrace`
+- `account => allNetworkAccountPerf => getAllNetworkAccountsStart`
+- `account => allNetworkAccountPerf => getAllNetworkAccountsEnd`
+
+Important phases:
+
+- `single-network-local-cache-read`
+- `single-network-cache-ingest`
+- `all-network-hook-run-start`
+- `all-network-accounts-resolved`
+- `all-network-cache-probe`
+- `all-network-run-started`
+- `all-network-cache-hydrate`
+- `all-network-fetch-settled`
+- `all-network-progressive-settled`
+- `all-network-authoritative-commit`
+- `all-network-hook-run-finished`
+- `all-network-manual-refresh`
+
+The log payload intentionally avoids addresses, xpubs, walletId, and full accountId. It records runtime, phase, networkId, cache hit, counts, owner presence, and request kind.
+
+## Code Changes Under Test
+
+- Single-network local cache now builds an ingest payload with `buildHomeTokenListCacheIngestRound` and feeds `serviceTokenViewModel.ingestRound` before marking token state initialized.
+- Cached empty single-network owners also emit an empty owner-stamp frame, so the empty state renders instead of previous-owner skeleton.
+- All-networks authoritative commit no longer clears the LWW view. The retained per-network rounds become the next refresh's SWR floor.
+- The native performance monitor uses the new `showPerformanceMonitorV2` dev-setting key and defaults to off. Legacy `showPerformanceMonitor` values are intentionally ignored so old QA/dev settings do not auto-open the overlay.
+- Added focused tests for single-network cache ingest and all-network warm-refresh floor retention.
+
+## Verification Matrix
+
+Use iOS release build/install:
+
+```bash
+development/scripts/ios-release-build-deploy.sh xcode
+development/scripts/ios-release-build-deploy.sh deploy
+```
+
+Use the Test Wallet shown in the screenshot:
+
+1. Test Wallet -> Account #1 -> All Networks.
+2. Wait for the first full token list and total balance.
+3. Pull-to-refresh All Networks.
+4. Confirm the list remains visible; logs show `all-network-manual-refresh`, progressive settles, then `all-network-authoritative-commit`.
+5. Switch All Networks -> one funded single network.
+6. Confirm cached token rows show immediately; logs show `single-network-local-cache-read` with `hasCache:true`, then `single-network-cache-ingest`.
+7. Switch back to All Networks.
+8. Switch Account #1 -> Account #2 and repeat All Networks + single-network cache checks.
+9. Add an account under Test Wallet, stay on All Networks, confirm new network/account fan-out does not shrink the existing list.
+10. Delete/remove the added account, confirm removed account data disappears without clearing unaffected token rows.
+11. Trigger a transaction-history refresh path if possible, then confirm only changed network rows update.
+
+Pass criteria:
+
+- Cached owner never shows token-list skeleton.
+- Cached balance amount never returns to global skeleton during refresh.
+- All-networks refresh keeps the full cached list visible and updates by network/row.
+- Account switch/add/delete does not reuse stale previous-owner data.
+- Native logs contain the phase sequence needed to explain each refresh.
+
+## Simulator Verification On 2026-07-04
+
+Environment:
+
+- Simulator: iPhone 17 Pro, iOS 26.5, UDID `4837E819-A117-4E08-9936-445785D199E3`.
+- Build/deploy: `development/scripts/ios-release-build-deploy.sh all`, with `ENABLE_NATIVE_BACKGROUND_THREAD=true`, `UNION_BUILD=true`, `SPLIT_BUNDLE=1`, and split-bundle integrity check passing for both main and bg bundles. Deploy preserved app data and launched `so.onekey.wallet`.
+
+Completed checks:
+
+- Test Wallet opened on Home with All Networks selected and cached rows visible immediately. The old persisted performance-monitor setting did not show the native overlay with the new `showPerformanceMonitorV2` default-off key. Screenshot: `.tmp/home-token-verify/no-perf-overlay.png`.
+- App relaunch on All Networks kept cached balance and token rows visible during automatic refresh. Screenshots:
+  - `.tmp/home-token-verify/home-after-relaunch.png`
+  - `.tmp/home-token-verify/all-network-after-single.png`
+- Manual All Networks pull-to-refresh kept the token list visible. `USDC`, `BTC`, `USDT`, `JupSOL`, and following cached rows stayed on screen during refresh instead of a full-list skeleton. Screenshots:
+  - `.tmp/home-token-verify/all-network-refresh-immediate.png`
+  - `.tmp/home-token-verify/all-network-refresh-after.png`
+  - `.tmp/home-token-verify/all-network-refresh-point-immediate.png`
+  - `.tmp/home-token-verify/all-network-refresh-point-after.png`
+- All Networks -> Solana single-network switch reused cache immediately. `JupSOL`, `JupUSD`, and `USDC` rows painted without a token-list skeleton. Screenshot: `.tmp/home-token-verify/single-solana-immediate.png`.
+- Account switch Account #2 -> Account #1 kept cached rows visible and then refreshed Account #1 data. Screenshot: `.tmp/home-token-verify/account1-switch-immediate.png`.
+- Added Account #3 under Test Wallet. Because Account #3 had no cached token rows, the new-account path showed an empty/loading state, which is acceptable for a cache miss. Screenshot: `.tmp/home-token-verify/account3-after-add-close.png`.
+- Removed only the newly added Account #3. The account selector returned to Account #1 and Account #2 only, then switching back to Account #2 hit all-network cache hydrate and painted cached rows. Screenshots:
+  - `.tmp/home-token-verify/account3-remove-confirm.png`
+  - `.tmp/home-token-verify/account3-removed.png`
+  - `.tmp/home-token-verify/account2-restored-final.png`
+- Multi-chain/single-chain back-and-forth switching was verified after the QA gap review:
+  - Sequence: All Networks -> Solana -> All Networks -> Polygon -> All Networks -> Bitcoin -> All Networks.
+  - Screenshots:
+    - `.tmp/home-token-verify/switch-loop-1-solana.png`
+    - `.tmp/home-token-verify/switch-loop-1-all.png`
+    - `.tmp/home-token-verify/switch-loop-2-polygon.png`
+    - `.tmp/home-token-verify/switch-loop-2-all.png`
+    - `.tmp/home-token-verify/switch-loop-3-bitcoin.png`
+    - `.tmp/home-token-verify/switch-loop-3-all-final.png`
+  - Logs confirmed `single-network-local-cache-read` with `hasCache:true`, followed by `single-network-cache-ingest`, for `sol--101` (`tokenCount:11`), `evm--137` (`tokenCount:8`, `smallBalanceCount:12`, `riskyCount:30`), and `btc--0` (`tokenCount:1`).
+  - Every return to All Networks kept cached rows visible while per-network `all-network-fetch-settled` and `all-network-progressive-settled` updated changed networks.
+- Cold-start cache coverage was verified after the QA gap review:
+  - All Networks with cache: app was killed and relaunched with existing native storage. Cached rows were visible immediately without a token-list skeleton. Screenshot: `.tmp/home-token-verify/cold-cache-all-network-immediate.png`. This run used visual evidence plus the earlier all-network cache-hydrate logs because the relaunch painted from the warm persisted store before another `all-network-cache-hydrate` line was emitted.
+  - Solana single-network with cache: app was killed while Solana was selected and relaunched. Logs at `19:39:04` showed `single-network-local-cache-read` with `hasCache:true`, `networkId:"sol--101"`, `tokenCount:11`, followed by `single-network-cache-ingest` with `source:"singleCacheSeed"`. Screenshots:
+    - `.tmp/home-token-verify/cold-cache-single-solana-before-kill.png`
+    - `.tmp/home-token-verify/cold-cache-single-solana-immediate.png`
+    - `.tmp/home-token-verify/cold-cache-single-solana-after3s.png`
+  - All Networks without cache: selected `代币 & NFT 数据` in `清除应用缓存`, terminated from the settings screen, and removed `Documents/mmkv/onekey-cold-start-cache*` before launch. Logs at `19:52:12` showed `all-network-cache-probe` with `cacheCount:0` and `hasCache:false`; no `all-network-cache-hydrate` occurred. Screenshots:
+    - `.tmp/home-token-verify/cold-nocache-all-network-3-immediate.png`
+    - `.tmp/home-token-verify/cold-nocache-all-network-3-after3s.png`
+    - `.tmp/home-token-verify/cold-nocache-all-network-3-after11s.png`
+  - Solana single-network without cache: selected `代币 & NFT 数据` in `清除应用缓存`, terminated from the settings screen, and removed `Documents/mmkv/onekey-cold-start-cache*` before launch while Solana was the active network. Logs at `19:57:39` showed `single-network-local-cache-read` with `hasCache:false`, `networkId:"sol--101"`, and `tokenCount:0`; there was no `single-network-cache-ingest`. The token rows were present by the 3-second screenshot because the live Solana request completed quickly, which is acceptable for a cache miss. Screenshots:
+    - `.tmp/home-token-verify/cold-nocache-single-solana-immediate.png`
+    - `.tmp/home-token-verify/cold-nocache-single-solana-after3s.png`
+    - `.tmp/home-token-verify/cold-nocache-single-solana-after11s.png`
+- Native logger file confirmed at simulator data container `Library/Caches/logs/app-latest.log`.
+- `development/scripts/ios-release-build-deploy.sh logs 'homeTokenListRefreshTrace'` and direct `app-latest.log` grep show the expected main-runtime sequences:
+  - `all-network-manual-refresh`
+  - `all-network-hook-run-start`
+  - `all-network-accounts-resolved`
+  - `all-network-cache-probe`
+  - `all-network-cache-hydrate`
+  - `all-network-authoritative-commit`
+  - per-network `all-network-fetch-settled`
+  - per-network `all-network-progressive-settled`
+  - `all-network-hook-run-finished`
+  - `single-network-local-cache-read` with `hasCache:true`
+  - `single-network-cache-ingest` with `source:"singleCacheSeed"` and `tokenCount:11` for `sol--101`
+- `development/scripts/ios-release-build-deploy.sh logs 'getAllNetworkAccounts'` shows bg-runtime `getAllNetworkAccountsStart/End` written through native logger.
+- The `logs` command now falls back to tailing the latest matching log lines when the `hostDidStart fired` anchor is absent, so native logger diagnostics are still readable in this release simulator session.
+
+Residual notes:
+
+- `agent-device snapshot -i` still returns a sparse React Native accessibility tree on this screen, but the performance monitor no longer owns the native window and visual/coordinate verification works.
+- Newly created Account #3 has no cache, so it can show a loading/empty state. The expected invariant is only that cached owners do not show a skeleton and previous-owner rows do not leak into the new owner.

--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -74,6 +74,9 @@ export interface IDevSettings {
   customApiEndpoints?: IApiEndpointConfig[];
   // show performance monitor
   showPerformanceMonitor?: boolean;
+  // show performance monitor, replacing legacy showPerformanceMonitor which
+  // was default-on in older dev builds.
+  showPerformanceMonitorV2?: boolean;
   // use local trading view URL for development
   useLocalTradingViewUrl?: boolean;
   showPerpsRenderStats?: boolean;
@@ -150,7 +153,8 @@ export const {
       enableBotWalletFeature: false,
       showPrimeTest: true,
       usePrimeSandboxPayment: platformEnv.isDev,
-      showPerformanceMonitor: true,
+      showPerformanceMonitor: false,
+      showPerformanceMonitorV2: false,
       autoNavigation: {
         enabled: false,
         selectedTab: ETabRoutes.Home,

--- a/packages/kit/src/components/TokenListView/computeShowTokenListSkeleton.test.ts
+++ b/packages/kit/src/components/TokenListView/computeShowTokenListSkeleton.test.ts
@@ -75,6 +75,18 @@ describe('computeShowTokenListSkeleton — other branches unchanged', () => {
     ).toBe(true);
   });
 
+  it('active-account refresh with cached rows does NOT skeleton', () => {
+    expect(
+      computeShowTokenListSkeleton({
+        ...baseHomeFirstLoad(),
+        showActiveAccountTokenList: true,
+        activeAccountTokenListInitialized: false,
+        activeAccountTokenListIsRefreshing: true,
+        displayCount: 3,
+      }),
+    ).toBe(false);
+  });
+
   it('selector not yet initialized skeletons', () => {
     expect(
       computeShowTokenListSkeleton({
@@ -83,6 +95,17 @@ describe('computeShowTokenListSkeleton — other branches unchanged', () => {
         tokenSelectorInitialized: false,
       }),
     ).toBe(true);
+  });
+
+  it('selector not yet initialized with cached rows does NOT skeleton', () => {
+    expect(
+      computeShowTokenListSkeleton({
+        ...baseHomeFirstLoad(),
+        isTokenSelector: true,
+        tokenSelectorInitialized: false,
+        displayCount: 3,
+      }),
+    ).toBe(false);
   });
 
   it('initialized home that is merely refreshing does NOT skeleton (no flash over existing data)', () => {

--- a/packages/kit/src/components/TokenListView/computeShowTokenListSkeleton.test.ts
+++ b/packages/kit/src/components/TokenListView/computeShowTokenListSkeleton.test.ts
@@ -87,6 +87,19 @@ describe('computeShowTokenListSkeleton — other branches unchanged', () => {
     ).toBe(false);
   });
 
+  it('active-account owner switch skeletons even with cached rows', () => {
+    expect(
+      computeShowTokenListSkeleton({
+        ...baseHomeFirstLoad(),
+        showActiveAccountTokenList: true,
+        activeAccountTokenListInitialized: false,
+        activeAccountTokenListIsRefreshing: true,
+        ownerMismatch: true,
+        displayCount: 3,
+      }),
+    ).toBe(true);
+  });
+
   it('selector not yet initialized skeletons', () => {
     expect(
       computeShowTokenListSkeleton({
@@ -106,6 +119,18 @@ describe('computeShowTokenListSkeleton — other branches unchanged', () => {
         displayCount: 3,
       }),
     ).toBe(false);
+  });
+
+  it('selector owner switch skeletons even with cached rows', () => {
+    expect(
+      computeShowTokenListSkeleton({
+        ...baseHomeFirstLoad(),
+        isTokenSelector: true,
+        tokenSelectorInitialized: false,
+        ownerMismatch: true,
+        displayCount: 3,
+      }),
+    ).toBe(true);
   });
 
   it('initialized home that is merely refreshing does NOT skeleton (no flash over existing data)', () => {

--- a/packages/kit/src/components/TokenListView/computeShowTokenListSkeleton.ts
+++ b/packages/kit/src/components/TokenListView/computeShowTokenListSkeleton.ts
@@ -45,7 +45,8 @@ export function computeShowTokenListSkeleton(
   if (
     p.showActiveAccountTokenList &&
     !p.activeAccountTokenListInitialized &&
-    p.activeAccountTokenListIsRefreshing
+    p.activeAccountTokenListIsRefreshing &&
+    p.displayCount === 0
   ) {
     return true;
   }
@@ -73,11 +74,12 @@ export function computeShowTokenListSkeleton(
   // the home atoms. The home mirror keeps `tokenListInitialized` true, so the
   // final clause never fires for the selector and it would flash EmptyToken for
   // a frame before the self-fetch lands. Skeleton until the selector self-fetch
-  // resolves.
+  // resolves, but only when there is genuinely nothing cached to display.
   if (
     p.isTokenSelector &&
     !p.showActiveAccountTokenList &&
-    !p.tokenSelectorInitialized
+    !p.tokenSelectorInitialized &&
+    p.displayCount === 0
   ) {
     return true;
   }

--- a/packages/kit/src/components/TokenListView/computeShowTokenListSkeleton.ts
+++ b/packages/kit/src/components/TokenListView/computeShowTokenListSkeleton.ts
@@ -42,6 +42,12 @@ export interface IComputeShowTokenListSkeletonParams {
 export function computeShowTokenListSkeleton(
   p: IComputeShowTokenListSkeletonParams,
 ): boolean {
+  // Loaded rows belong to a previous owner. Owner switches must show the
+  // skeleton even when stale cached rows are still present.
+  if (p.ownerMismatch) {
+    return true;
+  }
+
   if (
     p.showActiveAccountTokenList &&
     !p.activeAccountTokenListInitialized &&
@@ -58,15 +64,6 @@ export function computeShowTokenListSkeleton(
     p.tokenSelectorSearchTokenListSearchKey !== p.tokenSelectorSearchKey &&
     p.filteredTokensLength === 0
   ) {
-    return true;
-  }
-
-  // PR-7: loaded atoms belong to a PREVIOUS owner — show skeleton until the
-  // fresh data lands. Without this `tokenListInitialized` is still true from the
-  // prior network so the final clause would not fire. (On home, cold-start
-  // instant paint is the cells slim fan-out and in-session switch is the BG
-  // per-owner VM pull; both paint cells before this gate matters.)
-  if (p.ownerMismatch && !p.showActiveAccountTokenList) {
     return true;
   }
 

--- a/packages/kit/src/components/WebPerformanceMonitor/MonitorContainer.tsx
+++ b/packages/kit/src/components/WebPerformanceMonitor/MonitorContainer.tsx
@@ -98,7 +98,7 @@ export const MonitorContainer = () => {
     e.stopPropagation();
     setVisible(false);
     void backgroundApiProxy.serviceDevSetting.updateDevSetting(
-      'showPerformanceMonitor',
+      'showPerformanceMonitorV2',
       false,
     );
   };

--- a/packages/kit/src/components/WebPerformanceMonitor/index.tsx
+++ b/packages/kit/src/components/WebPerformanceMonitor/index.tsx
@@ -7,7 +7,7 @@ import { MonitorContainer } from './MonitorContainer';
 const BasePerformanceMonitor = () => {
   const [settings] = useDevSettingsPersistAtom();
 
-  if (!settings.enabled || !settings.settings?.showPerformanceMonitor) {
+  if (!settings.enabled || !settings.settings?.showPerformanceMonitorV2) {
     return null;
   }
 

--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -14,6 +14,7 @@ import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { perfMark } from '@onekeyhq/shared/src/performance/mark';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
@@ -520,6 +521,12 @@ function useAllNetworkRequests<T>(params: {
         alwaysSetStateForThisRun ||
         skipAccountsCacheRef.current ||
         ignoreDisabledForThisRun;
+      let requestKind = 'token';
+      if (isNFTRequests) {
+        requestKind = 'nft';
+      } else if (isDeFiRequests) {
+        requestKind = 'defi';
+      }
       if (
         shouldSkipRedundantAllNetworkRun({
           isMustRun,
@@ -539,6 +546,17 @@ function useAllNetworkRequests<T>(params: {
       // so the consumer's LWW materialized view rejects a stale earlier run.
       const runGeneration = runGenerationRef.current;
       isFetching.current = true;
+
+      defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+        runtime: 'main',
+        phase: 'all-network-hook-run-start',
+        networkId: currentNetworkId,
+        isAllNetworks: true,
+        allNetworkDataInit: allNetworkDataInit.current,
+        isMustRun,
+        ownerPresent: !!currentAccountId,
+        reason: requestKind,
+      });
 
       let onStartedError: unknown;
       let onStartedTask: Promise<void> | undefined;
@@ -618,6 +636,18 @@ function useAllNetworkRequests<T>(params: {
           allAccountsInfo,
         } = accountsInfoResult;
         perf.markEnd('getAllNetworkAccountsWithEnabledNetworks');
+        defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+          runtime: 'main',
+          phase: 'all-network-accounts-resolved',
+          networkId: currentNetworkId,
+          isAllNetworks: true,
+          accountsCount: accountsInfo?.length ?? 0,
+          backendIndexedCount: accountsInfoBackendIndexed?.length ?? 0,
+          backendNotIndexedCount: accountsInfoBackendNotIndexed?.length ?? 0,
+          allAccountsCount: allAccountsInfo?.length ?? 0,
+          ownerPresent: !!currentAccountId,
+          reason: requestKind,
+        });
         perfMark('AllNet:getAllNetworkAccounts:done', {
           duration: Date.now() - allNetAccountsStart,
           counts: {
@@ -712,6 +742,18 @@ function useAllNetworkRequests<T>(params: {
             if (cachedData && !isEmpty(cachedData)) {
               cacheHasData = true;
               allNetworkDataInit.current = true;
+              defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace(
+                {
+                  runtime: 'main',
+                  phase: 'all-network-cache-probe',
+                  networkId: currentNetworkId,
+                  isAllNetworks: true,
+                  hasCache: true,
+                  cacheCount: cachedData.length,
+                  ownerPresent: !!currentAccountId,
+                  reason: requestKind,
+                },
+              );
               perf.done();
               perfTokenListView.markEnd(
                 'useAllNetworkRequestsRun',
@@ -727,6 +769,20 @@ function useAllNetworkRequests<T>(params: {
           } catch (e) {
             console.error(e);
           } finally {
+            if (!cacheHasData) {
+              defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace(
+                {
+                  runtime: 'main',
+                  phase: 'all-network-cache-probe',
+                  networkId: currentNetworkId,
+                  isAllNetworks: true,
+                  hasCache: false,
+                  cacheCount: 0,
+                  ownerPresent: !!currentAccountId,
+                  reason: requestKind,
+                },
+              );
+            }
             try {
               await onCacheChecked?.({
                 accountId: currentAccountId,
@@ -837,6 +893,18 @@ function useAllNetworkRequests<T>(params: {
         if (accountsInfo.length && accountsInfo.length > 0) {
           allNetworkDataInit.current = true;
         }
+
+        defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+          runtime: 'main',
+          phase: 'all-network-hook-run-finished',
+          networkId: currentNetworkId,
+          isAllNetworks: true,
+          allNetworkDataInit: allNetworkDataInit.current,
+          resultCount: resp?.length ?? 0,
+          accountsCount: accountsInfo.length,
+          ownerPresent: !!currentAccountId,
+          reason: requestKind,
+        });
 
         return resp;
       } finally {

--- a/packages/kit/src/provider/Bootstrap.tsx
+++ b/packages/kit/src/provider/Bootstrap.tsx
@@ -811,6 +811,9 @@ export function Bootstrap() {
     devSettings,
     !!platformEnv.isNative,
   );
+  const performanceMonitorEnabled =
+    devSettings.enabled &&
+    devSettings.settings?.showPerformanceMonitorV2 === true;
 
   const [, setOnboardingConnectWalletLoading] =
     useOnboardingConnectWalletLoadingAtom();
@@ -899,7 +902,7 @@ export function Bootstrap() {
   }, []);
 
   useEffect(() => {
-    if (devSettings.enabled && devSettings.settings?.showPerformanceMonitor) {
+    if (performanceMonitorEnabled) {
       performance.showOverlay();
     } else {
       performance.hideOverlay();
@@ -907,7 +910,7 @@ export function Bootstrap() {
     return () => {
       performance.hideOverlay();
     };
-  }, [devSettings.enabled, devSettings.settings?.showPerformanceMonitor]);
+  }, [performanceMonitorEnabled]);
 
   // Dev-only: expose a global handle to control the native performance
   // overlay from the JS console or an automation harness. On iOS the overlay
@@ -927,9 +930,7 @@ export function Bootstrap() {
         toggle: () => void;
       };
     };
-    let shown = Boolean(
-      devSettings.enabled && devSettings.settings?.showPerformanceMonitor,
-    );
+    let shown = performanceMonitorEnabled;
     globalRef.$onekeyPerfMonitor = {
       show: () => {
         shown = true;
@@ -951,7 +952,7 @@ export function Bootstrap() {
     return () => {
       delete globalRef.$onekeyPerfMonitor;
     };
-  }, [devSettings.enabled, devSettings.settings?.showPerformanceMonitor]);
+  }, [performanceMonitorEnabled]);
 
   // Bridge native memory-warning notifications to the cross-process
   // appEventBus, so background services and JS-side caches can react.

--- a/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
+++ b/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
@@ -1235,8 +1235,8 @@ function TokenSelector() {
           });
         } else {
           setScopedActiveTokenListState({
-            initialized: false,
-            isRefreshing: true,
+            initialized: true,
+            isRefreshing: false,
           });
           showFetchTokenListErrorToast();
         }

--- a/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
+++ b/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
@@ -1227,11 +1227,19 @@ function TokenSelector() {
 
       const isIncompleteAllNetworksFanOut =
         isSelectorAllNetworks && responses.length < expectedResponseCount;
-      if (isIncompleteAllNetworksFanOut && hasRestoredSnapshot) {
-        setScopedActiveTokenListState({
-          initialized: true,
-          isRefreshing: false,
-        });
+      if (isIncompleteAllNetworksFanOut) {
+        if (hasRestoredSnapshot) {
+          setScopedActiveTokenListState({
+            initialized: true,
+            isRefreshing: false,
+          });
+        } else {
+          setScopedActiveTokenListState({
+            initialized: false,
+            isRefreshing: true,
+          });
+          showFetchTokenListErrorToast();
+        }
         return;
       }
 
@@ -1255,12 +1263,10 @@ function TokenSelector() {
           isRefreshing: false,
         },
       });
-      if (!isIncompleteAllNetworksFanOut) {
-        writeScopedTokenSelectorViewSnapshot({
-          key: filteredTokenSelectorViewSWRKey,
-          snapshot,
-        });
-      }
+      writeScopedTokenSelectorViewSnapshot({
+        key: filteredTokenSelectorViewSWRKey,
+        snapshot,
+      });
     } catch (e) {
       if (isLatestRequest()) {
         setScopedActiveTokenListState({

--- a/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
+++ b/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
@@ -102,6 +102,8 @@ type ITokenSelectorScopedViewSnapshot = {
   tokenListMap: Record<string, ITokenFiat>;
 };
 
+const TOKEN_SELECTOR_VIEW_CACHE_MAX_TOKEN_ROWS = 300;
+
 type ITokenSelectorHeaderRightProps = {
   showDeFiTokenSwitch?: boolean;
   loading?: boolean;
@@ -219,6 +221,101 @@ function hasNormalTokenSelectorSnapshotData(
   );
 }
 
+function getNormalTokenSelectorSnapshotRowCount(
+  snapshot: ITokenSelectorNormalViewSnapshot,
+) {
+  return (
+    snapshot.tokenList.tokens.length +
+    snapshot.tokenList.smallBalanceTokens.length
+  );
+}
+
+function getScopedTokenSelectorSnapshotRowCount(
+  snapshot: ITokenSelectorScopedViewSnapshot,
+) {
+  return snapshot.tokenList.tokens.length;
+}
+
+function isTokenSelectorViewCacheSizeSafe(rowCount: number) {
+  return rowCount <= TOKEN_SELECTOR_VIEW_CACHE_MAX_TOKEN_ROWS;
+}
+
+function readNormalTokenSelectorViewSnapshot(key: string | undefined) {
+  const snapshot =
+    readTokenSelectorViewSnapshot<ITokenSelectorNormalViewSnapshot>(key);
+  if (
+    snapshot &&
+    !isTokenSelectorViewCacheSizeSafe(
+      getNormalTokenSelectorSnapshotRowCount(snapshot),
+    )
+  ) {
+    if (key) {
+      swrCacheUtils.remove(key);
+    }
+    return undefined;
+  }
+  return snapshot;
+}
+
+function readScopedTokenSelectorViewSnapshot(key: string | undefined) {
+  const snapshot =
+    readTokenSelectorViewSnapshot<ITokenSelectorScopedViewSnapshot>(key);
+  if (
+    snapshot &&
+    !isTokenSelectorViewCacheSizeSafe(
+      getScopedTokenSelectorSnapshotRowCount(snapshot),
+    )
+  ) {
+    if (key) {
+      swrCacheUtils.remove(key);
+    }
+    return undefined;
+  }
+  return snapshot;
+}
+
+function writeNormalTokenSelectorViewSnapshot({
+  key,
+  snapshot,
+}: {
+  key: string | undefined;
+  snapshot: ITokenSelectorNormalViewSnapshot;
+}) {
+  if (!key) {
+    return;
+  }
+  if (
+    !isTokenSelectorViewCacheSizeSafe(
+      getNormalTokenSelectorSnapshotRowCount(snapshot),
+    )
+  ) {
+    swrCacheUtils.remove(key);
+    return;
+  }
+  writeTokenSelectorViewSnapshot({ key, snapshot });
+}
+
+function writeScopedTokenSelectorViewSnapshot({
+  key,
+  snapshot,
+}: {
+  key: string | undefined;
+  snapshot: ITokenSelectorScopedViewSnapshot;
+}) {
+  if (!key) {
+    return;
+  }
+  if (
+    !isTokenSelectorViewCacheSizeSafe(
+      getScopedTokenSelectorSnapshotRowCount(snapshot),
+    )
+  ) {
+    swrCacheUtils.remove(key);
+    return;
+  }
+  writeTokenSelectorViewSnapshot({ key, snapshot });
+}
+
 function buildNormalTokenSelectorViewSnapshot({
   tokenList,
   tokenListMap,
@@ -272,7 +369,6 @@ function TokenSelector() {
     activeNetworkId,
     forceShowActiveAccountTokenList,
     aggregateTokenSelectorScreen,
-    tokens: routeTokens,
     allAggregateTokenMap,
     hideZeroBalanceTokens,
     keepDefaultZeroBalanceTokens,
@@ -442,32 +538,28 @@ function TokenSelector() {
     () =>
       buildNormalTokenSelectorViewSnapshot({
         tokenList: {
-          tokens: routeTokens?.data ?? [],
+          tokens: [],
           smallBalanceTokens: [],
         },
-        tokenListMap: routeTokens?.map ?? {},
-        aggregateTokenListMap: allAggregateTokenMap ?? {},
+        tokenListMap: {},
+        aggregateTokenListMap: {},
         aggregateTokenFiatMap: {},
       }),
-    [allAggregateTokenMap, routeTokens],
+    [],
   );
 
   const initialNormalTokenSelectorSnapshot = useMemo(
     () =>
-      readTokenSelectorViewSnapshot<ITokenSelectorNormalViewSnapshot>(
-        normalTokenSelectorViewSWRKey,
-      ) ?? routeTokenSelectorCache,
+      readNormalTokenSelectorViewSnapshot(normalTokenSelectorViewSWRKey) ??
+      routeTokenSelectorCache,
     [normalTokenSelectorViewSWRKey, routeTokenSelectorCache],
   );
 
   const initialScopedTokenSelectorSnapshot = useMemo(
     () =>
-      readTokenSelectorViewSnapshot<ITokenSelectorScopedViewSnapshot>(
+      readScopedTokenSelectorViewSnapshot(
         activeAccountTokenSelectorViewSWRKey,
-      ) ??
-      readTokenSelectorViewSnapshot<ITokenSelectorScopedViewSnapshot>(
-        filteredTokenSelectorViewSWRKey,
-      ),
+      ) ?? readScopedTokenSelectorViewSnapshot(filteredTokenSelectorViewSWRKey),
     [activeAccountTokenSelectorViewSWRKey, filteredTokenSelectorViewSWRKey],
   );
 
@@ -989,9 +1081,8 @@ function TokenSelector() {
 
   const restoreCachedNormalTokenSelectorSnapshot = useCallback(() => {
     const cachedSnapshot =
-      readTokenSelectorViewSnapshot<ITokenSelectorNormalViewSnapshot>(
-        normalTokenSelectorViewSWRKey,
-      ) ?? routeTokenSelectorCache;
+      readNormalTokenSelectorViewSnapshot(normalTokenSelectorViewSWRKey) ??
+      routeTokenSelectorCache;
     if (!hasNormalTokenSelectorSnapshotData(cachedSnapshot)) {
       return false;
     }
@@ -1016,10 +1107,7 @@ function TokenSelector() {
   useEffect(() => {
     const scopedKey =
       activeAccountTokenSelectorViewSWRKey ?? filteredTokenSelectorViewSWRKey;
-    const snapshot =
-      readTokenSelectorViewSnapshot<ITokenSelectorScopedViewSnapshot>(
-        scopedKey,
-      );
+    const snapshot = readScopedTokenSelectorViewSnapshot(scopedKey);
     if (!snapshot) {
       return;
     }
@@ -1097,10 +1185,9 @@ function TokenSelector() {
       return;
     }
 
-    const cachedSnapshot =
-      readTokenSelectorViewSnapshot<ITokenSelectorScopedViewSnapshot>(
-        filteredTokenSelectorViewSWRKey,
-      );
+    const cachedSnapshot = readScopedTokenSelectorViewSnapshot(
+      filteredTokenSelectorViewSWRKey,
+    );
     if (cachedSnapshot) {
       applyScopedTokenSelectorSnapshot({
         snapshot: cachedSnapshot,
@@ -1156,7 +1243,7 @@ function TokenSelector() {
           isRefreshing: false,
         },
       });
-      writeTokenSelectorViewSnapshot({
+      writeScopedTokenSelectorViewSnapshot({
         key: filteredTokenSelectorViewSWRKey,
         snapshot,
       });
@@ -1215,10 +1302,9 @@ function TokenSelector() {
         return;
       }
 
-      const cachedSnapshot =
-        readTokenSelectorViewSnapshot<ITokenSelectorScopedViewSnapshot>(
-          activeAccountTokenSelectorViewSWRKey,
-        );
+      const cachedSnapshot = readScopedTokenSelectorViewSnapshot(
+        activeAccountTokenSelectorViewSWRKey,
+      );
       if (cachedSnapshot) {
         applyScopedTokenSelectorSnapshot({
           snapshot: cachedSnapshot,
@@ -1295,7 +1381,7 @@ function TokenSelector() {
             initialized: true,
           },
         });
-        writeTokenSelectorViewSnapshot({
+        writeScopedTokenSelectorViewSnapshot({
           key: activeAccountTokenSelectorViewSWRKey,
           snapshot,
         });
@@ -1419,7 +1505,7 @@ function TokenSelector() {
           aggregateTokenFiatMap: snapshot.map,
         });
         applyNormalTokenSelectorSnapshot(floorSnapshot);
-        writeTokenSelectorViewSnapshot({
+        writeNormalTokenSelectorViewSnapshot({
           key: normalTokenSelectorViewSWRKey,
           snapshot: floorSnapshot,
         });
@@ -1566,7 +1652,7 @@ function TokenSelector() {
       });
       applyNormalTokenSelectorSnapshot(snapshot);
       if (!isIncompleteAllNetworksFanOut) {
-        writeTokenSelectorViewSnapshot({
+        writeNormalTokenSelectorViewSnapshot({
           key: normalTokenSelectorViewSWRKey,
           snapshot,
         });

--- a/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
+++ b/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
@@ -37,6 +37,10 @@ import type { IAssetSelectorParamList } from '@onekeyhq/shared/src/routes';
 import { EAssetSelectorRoutes } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { isEnabledNetworksInAllNetworks } from '@onekeyhq/shared/src/utils/networkUtils';
+import {
+  swrCacheUtils,
+  swrKeys,
+} from '@onekeyhq/shared/src/utils/swrCacheUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import {
   TOKEN_SELECTOR_LP_TOKEN_FILTER_ENABLED,
@@ -82,6 +86,21 @@ type ITokenSelectorSearchFilterContext =
   | 'all-token'
   | 'wallet-token'
   | 'dapp-token';
+
+type ITokenSelectorNormalViewSnapshot = {
+  tokenList: {
+    tokens: IAccountToken[];
+    smallBalanceTokens: IAccountToken[];
+  };
+  tokenListMap: Record<string, ITokenFiat>;
+  aggregateTokenListMap: Record<string, { tokens: IAccountToken[] }>;
+  aggregateTokenFiatMap: Record<string, ITokenFiat>;
+};
+
+type ITokenSelectorScopedViewSnapshot = {
+  tokenList: IScopedActiveTokenList;
+  tokenListMap: Record<string, ITokenFiat>;
+};
 
 type ITokenSelectorHeaderRightProps = {
   showDeFiTokenSwitch?: boolean;
@@ -174,6 +193,56 @@ function isSameSelectorTokenListRequestContext(
   );
 }
 
+function readTokenSelectorViewSnapshot<T>(key: string | undefined) {
+  return key ? swrCacheUtils.get<T>(key) : undefined;
+}
+
+function writeTokenSelectorViewSnapshot<T>({
+  key,
+  snapshot,
+}: {
+  key: string | undefined;
+  snapshot: T;
+}) {
+  if (key) {
+    swrCacheUtils.set(key, snapshot);
+  }
+}
+
+function hasNormalTokenSelectorSnapshotData(
+  snapshot: ITokenSelectorNormalViewSnapshot | undefined,
+) {
+  return Boolean(
+    snapshot &&
+    (snapshot.tokenList.tokens.length > 0 ||
+      snapshot.tokenList.smallBalanceTokens.length > 0),
+  );
+}
+
+function buildNormalTokenSelectorViewSnapshot({
+  tokenList,
+  tokenListMap,
+  aggregateTokenListMap,
+  aggregateTokenFiatMap,
+}: ITokenSelectorNormalViewSnapshot): ITokenSelectorNormalViewSnapshot {
+  return {
+    tokenList,
+    tokenListMap,
+    aggregateTokenListMap,
+    aggregateTokenFiatMap,
+  };
+}
+
+function buildScopedTokenSelectorViewSnapshot({
+  tokenList,
+  tokenListMap,
+}: ITokenSelectorScopedViewSnapshot): ITokenSelectorScopedViewSnapshot {
+  return {
+    tokenList,
+    tokenListMap,
+  };
+}
+
 function TokenSelector() {
   const intl = useIntl();
   const { updateCreateAccountState, updateProcessingTokenState } =
@@ -203,6 +272,7 @@ function TokenSelector() {
     activeNetworkId,
     forceShowActiveAccountTokenList,
     aggregateTokenSelectorScreen,
+    tokens: routeTokens,
     allAggregateTokenMap,
     hideZeroBalanceTokens,
     keepDefaultZeroBalanceTokens,
@@ -249,18 +319,172 @@ function TokenSelector() {
       ? 'dapp-token'
       : 'wallet-token';
   }
+
+  const tokenSelectorFilterParams = useMemo(
+    () =>
+      showTokenSelectorFilter
+        ? buildTokenSelectorDappTokenFilterParams({
+            lpToken: showLpTokensOnly,
+          })
+        : {},
+    [showLpTokensOnly, showTokenSelectorFilter],
+  );
+
+  const showActiveAccountTokenList = useMemo(() => {
+    if (!activeAccountId || !activeNetworkId) {
+      return false;
+    }
+
+    if (forceShowActiveAccountTokenList) {
+      return true;
+    }
+
+    return activeAccountId !== accountId && activeNetworkId !== networkId;
+  }, [
+    activeAccountId,
+    activeNetworkId,
+    accountId,
+    forceShowActiveAccountTokenList,
+    networkId,
+  ]);
+
+  const mergeDeriveAddressData =
+    !!selectorVaultSettings?.mergeDeriveAssetsEnabled &&
+    !!indexedAccountId &&
+    !accountUtils.isOthersAccount({ accountId });
+  const homeTokenListSnapshot = useHomeTokenListSnapshot();
+  const useSelectorFilteredTokenList =
+    !!showTokenSelectorFilter && showLpTokensOnly;
+  const effectiveShowActiveAccountTokenList =
+    showActiveAccountTokenList || useSelectorFilteredTokenList;
+  const effectiveHideZeroBalanceTokens =
+    showTokenSelectorFilter && showLpTokensOnly ? false : hideZeroBalanceTokens;
+
+  const normalTokenSelectorViewSWRKey = useMemo(
+    () =>
+      !effectiveShowActiveAccountTokenList && accountId && networkId
+        ? swrKeys.tokenSelectorView({
+            ownerMode: 'normal',
+            filterMode: tokenSelectorSearchFilterContext,
+            accountId,
+            networkId,
+            indexedAccountId,
+            isAllNetworks: !!isSelectorAllNetworks,
+            mergeDeriveAddressData,
+          })
+        : undefined,
+    [
+      accountId,
+      effectiveShowActiveAccountTokenList,
+      indexedAccountId,
+      isSelectorAllNetworks,
+      mergeDeriveAddressData,
+      networkId,
+      tokenSelectorSearchFilterContext,
+    ],
+  );
+
+  const filteredTokenSelectorViewSWRKey = useMemo(
+    () =>
+      useSelectorFilteredTokenList &&
+      !showActiveAccountTokenList &&
+      accountId &&
+      networkId
+        ? swrKeys.tokenSelectorView({
+            ownerMode: 'filtered',
+            filterMode: tokenSelectorSearchFilterContext,
+            accountId,
+            networkId,
+            indexedAccountId,
+            isAllNetworks: !!isSelectorAllNetworks,
+            mergeDeriveAddressData,
+          })
+        : undefined,
+    [
+      accountId,
+      indexedAccountId,
+      isSelectorAllNetworks,
+      mergeDeriveAddressData,
+      networkId,
+      showActiveAccountTokenList,
+      tokenSelectorSearchFilterContext,
+      useSelectorFilteredTokenList,
+    ],
+  );
+
+  const activeAccountTokenSelectorViewSWRKey = useMemo(
+    () =>
+      showActiveAccountTokenList && activeAccountId && activeNetworkId
+        ? swrKeys.tokenSelectorView({
+            ownerMode: 'active-account',
+            filterMode: tokenSelectorSearchFilterContext,
+            accountId: activeAccountId,
+            networkId: activeNetworkId,
+            indexedAccountId,
+            activeAccountId,
+            activeNetworkId,
+            isAllNetworks: !!isSelectorAllNetworks,
+            mergeDeriveAddressData,
+          })
+        : undefined,
+    [
+      activeAccountId,
+      activeNetworkId,
+      indexedAccountId,
+      isSelectorAllNetworks,
+      mergeDeriveAddressData,
+      showActiveAccountTokenList,
+      tokenSelectorSearchFilterContext,
+    ],
+  );
+
+  const routeTokenSelectorCache = useMemo<ITokenSelectorNormalViewSnapshot>(
+    () =>
+      buildNormalTokenSelectorViewSnapshot({
+        tokenList: {
+          tokens: routeTokens?.data ?? [],
+          smallBalanceTokens: [],
+        },
+        tokenListMap: routeTokens?.map ?? {},
+        aggregateTokenListMap: allAggregateTokenMap ?? {},
+        aggregateTokenFiatMap: {},
+      }),
+    [allAggregateTokenMap, routeTokens],
+  );
+
+  const initialNormalTokenSelectorSnapshot = useMemo(
+    () =>
+      readTokenSelectorViewSnapshot<ITokenSelectorNormalViewSnapshot>(
+        normalTokenSelectorViewSWRKey,
+      ) ?? routeTokenSelectorCache,
+    [normalTokenSelectorViewSWRKey, routeTokenSelectorCache],
+  );
+
+  const initialScopedTokenSelectorSnapshot = useMemo(
+    () =>
+      readTokenSelectorViewSnapshot<ITokenSelectorScopedViewSnapshot>(
+        activeAccountTokenSelectorViewSWRKey,
+      ) ??
+      readTokenSelectorViewSnapshot<ITokenSelectorScopedViewSnapshot>(
+        filteredTokenSelectorViewSWRKey,
+      ),
+    [activeAccountTokenSelectorViewSWRKey, filteredTokenSelectorViewSWRKey],
+  );
+
   const [scopedActiveTokenList, setScopedActiveTokenList] =
-    useState<IScopedActiveTokenList>({
-      tokens: [],
-      keys: '',
-    });
+    useState<IScopedActiveTokenList>(
+      initialScopedTokenSelectorSnapshot?.tokenList ?? {
+        tokens: [],
+        keys: '',
+      },
+    );
   const [scopedActiveTokenListMap, setScopedActiveTokenListMap] = useState<
     Record<string, ITokenFiat>
-  >({});
+  >(initialScopedTokenSelectorSnapshot?.tokenListMap ?? {});
   const [scopedActiveTokenListState, setScopedActiveTokenListState] =
     useState<IScopedActiveTokenListState>({
       isRefreshing: false,
-      initialized: false,
+      initialized: !!initialScopedTokenSelectorSnapshot,
     });
   const [isLpTokenSwitchLoading, setIsLpTokenSwitchLoading] = useState(false);
   const [searchTokenState, setSearchTokenState] = useState({
@@ -272,6 +496,20 @@ function TokenSelector() {
     filterContext: ITokenSelectorSearchFilterContext;
   }>({ tokens: [], searchKey: '', filterContext: 'all-token' });
   const latestSearchRequestContextRef = useRef('');
+  const lastTokenSelectorErrorToastAtRef = useRef(0);
+
+  const showFetchTokenListErrorToast = useCallback(() => {
+    const now = Date.now();
+    if (now - lastTokenSelectorErrorToastAtRef.current < 2000) {
+      return;
+    }
+    lastTokenSelectorErrorToastAtRef.current = now;
+    Toast.error({
+      title: intl.formatMessage({
+        id: ETranslations.global_network_error,
+      }),
+    });
+  }, [intl]);
 
   // PR-3 (tokenList cells full-delete): the selector self-fetches its displayed
   // list + fiat map + owned-aggregate map and threads them as props into
@@ -282,57 +520,42 @@ function TokenSelector() {
   const [selectorTokenList, setSelectorTokenList] = useState<{
     tokens: IAccountToken[];
     smallBalanceTokens: IAccountToken[];
-  }>({ tokens: [], smallBalanceTokens: [] });
+  }>(initialNormalTokenSelectorSnapshot.tokenList);
   const [selectorTokenListMap, setSelectorTokenListMap] = useState<
     Record<string, ITokenFiat>
-  >({});
+  >(initialNormalTokenSelectorSnapshot.tokenListMap);
   const [selectorAggregateTokenListMap, setSelectorAggregateTokenListMap] =
-    useState<Record<string, { tokens: IAccountToken[] }>>({});
+    useState<Record<string, { tokens: IAccountToken[] }>>(
+      initialNormalTokenSelectorSnapshot.aggregateTokenListMap,
+    );
   // PR-6: the flattened ($key -> summed ITokenFiat) aggregate fiat map for the
-  // selector's aggregate rows. Each self-fetch response's `aggregateTokenMap`
-  // is FLAT and scoped to that response's networkId (one response per network
-  // in all-networks mode); the merge nests them by networkId and re-flattens
+  // selector's all-networks rows. The self-fetch response's `aggregateTokenMap`
+  // is FLAT per single-network request; we nest it by networkId and re-flatten
   // with the SAME sum semantics the home `flattenAggregateTokensMapAtom` uses
-  // so the aggregate selector rows resolve real balance/value/price (the
-  // per-row `tokenSelectorTokenListMap` does NOT carry aggregate `$key` fiat).
-  // Threaded into TokenListView as `tokenSelectorAggregateTokenFiatMap`.
+  // so the aggregate (all-networks) selector rows resolve real balance/value/
+  // price (the per-row `tokenSelectorTokenListMap` does NOT carry aggregate
+  // `$key` fiat). Threaded into TokenListView as `tokenSelectorAggregateTokenFiatMap`.
   const [selectorAggregateTokenFiatMap, setSelectorAggregateTokenFiatMap] =
-    useState<Record<string, ITokenFiat>>({});
+    useState<Record<string, ITokenFiat>>(
+      initialNormalTokenSelectorSnapshot.aggregateTokenFiatMap,
+    );
   // PR-3: `false` until the self-fetch below resolves the first time. Threaded
   // into TokenListView so the selector shows a skeleton (or its per-owner
   // cached list) until the self-fetch lands instead of flashing EmptyToken —
   // the home tokenList mirror keeps `tokenListState.initialized === true`, so
   // TokenListView cannot infer "selector not yet fetched" on its own.
-  const [selectorInitialized, setSelectorInitialized] = useState(false);
-  // SWR floor bookkeeping: `floorSeeded` marks the home-VM snapshot paint (so
-  // the live self-fetch does not flash the skeleton over it), `liveLanded`
-  // marks the live fan-out commit (so a late-resolving floor pull can never
-  // clobber fresh live data).
+  const [selectorInitialized, setSelectorInitialized] = useState(
+    hasNormalTokenSelectorSnapshotData(initialNormalTokenSelectorSnapshot),
+  );
   const selectorFloorSeededRef = useRef(false);
   const selectorLiveLandedRef = useRef(false);
-  // Owner-scope the floor bookkeeping: both refs are one-way latches, so if
-  // the selector owner ever changes while this instance stays MOUNTED the
-  // stale latches would silently skip the skeleton reset (previous owner's
-  // list stays on screen) and permanently disable the floor for the new
-  // owner. Today every known owner switch remounts the selector (fresh refs);
-  // this guards the invariant instead of relying on it.
   const selectorFloorOwnerKeyRef = useRef('');
-  const selectorFloorOwnerKey = `${accountId ?? ''}__${networkId ?? ''}`;
+  const selectorFloorOwnerKey = [accountId ?? '', networkId ?? ''].join('__');
   if (selectorFloorOwnerKeyRef.current !== selectorFloorOwnerKey) {
     selectorFloorOwnerKeyRef.current = selectorFloorOwnerKey;
     selectorFloorSeededRef.current = false;
     selectorLiveLandedRef.current = false;
   }
-
-  const tokenSelectorFilterParams = useMemo(
-    () =>
-      showTokenSelectorFilter
-        ? buildTokenSelectorDappTokenFilterParams({
-            lpToken: showLpTokensOnly,
-          })
-        : {},
-    [showLpTokensOnly, showTokenSelectorFilter],
-  );
 
   const handleLpTokenFilterChange = useCallback(
     (value: boolean) => {
@@ -417,13 +640,11 @@ function TokenSelector() {
 
         const { tokenHasBalance, tokenHasBalanceCount } =
           checkIsOnlyOneTokenHasBalance({
-            // `selectorTokenListMap` carries the per-network sub-token fiat
-            // (`r.tokens.map` ∪ `r.smallBalanceTokens.map`, keyed by sub-token
-            // `$key`) PLUS aggregate `$key` fiat composed in for the zero-balance
-            // filter (live path) / the composed home map (floor path).
-            // `checkIsOnlyOneTokenHasBalance` only looks up the sub-token `$key`s
-            // in `aggregateTokenList`, so the extra aggregate entries are inert
-            // here. Replaces the deleted home `allTokenListMapAtom` read.
+            // The selector self-fetches its per-row fiat map (`r.tokens.map` ∪
+            // `r.smallBalanceTokens.map`), which is keyed by the per-network
+            // sub-token `$key` — exactly what `checkIsOnlyOneTokenHasBalance`
+            // iterates (red-team C-F2: NOT the summed aggregate map). Replaces
+            // the deleted home `allTokenListMapAtom` read.
             tokenMap: selectorTokenListMap,
             aggregateTokenList,
             allAggregateTokenList,
@@ -740,38 +961,81 @@ function TokenSelector() {
     ],
   );
 
-  const showActiveAccountTokenList = useMemo(() => {
-    if (!activeAccountId || !activeNetworkId) {
+  const applyNormalTokenSelectorSnapshot = useCallback(
+    (snapshot: ITokenSelectorNormalViewSnapshot) => {
+      setSelectorTokenList(snapshot.tokenList);
+      setSelectorTokenListMap(snapshot.tokenListMap);
+      setSelectorAggregateTokenListMap(snapshot.aggregateTokenListMap);
+      setSelectorAggregateTokenFiatMap(snapshot.aggregateTokenFiatMap);
+      setSelectorInitialized(true);
+    },
+    [],
+  );
+
+  const applyScopedTokenSelectorSnapshot = useCallback(
+    ({
+      snapshot,
+      state,
+    }: {
+      snapshot: ITokenSelectorScopedViewSnapshot;
+      state: IScopedActiveTokenListState;
+    }) => {
+      setScopedActiveTokenList(snapshot.tokenList);
+      setScopedActiveTokenListMap(snapshot.tokenListMap);
+      setScopedActiveTokenListState(state);
+    },
+    [],
+  );
+
+  const restoreCachedNormalTokenSelectorSnapshot = useCallback(() => {
+    const cachedSnapshot =
+      readTokenSelectorViewSnapshot<ITokenSelectorNormalViewSnapshot>(
+        normalTokenSelectorViewSWRKey,
+      ) ?? routeTokenSelectorCache;
+    if (!hasNormalTokenSelectorSnapshotData(cachedSnapshot)) {
       return false;
     }
-
-    if (forceShowActiveAccountTokenList) {
-      return true;
-    }
-
-    return activeAccountId !== accountId && activeNetworkId !== networkId;
+    applyNormalTokenSelectorSnapshot(cachedSnapshot);
+    return true;
   }, [
-    activeAccountId,
-    activeNetworkId,
-    accountId,
-    forceShowActiveAccountTokenList,
-    networkId,
+    applyNormalTokenSelectorSnapshot,
+    normalTokenSelectorViewSWRKey,
+    routeTokenSelectorCache,
   ]);
 
-  const mergeDeriveAddressData =
-    !!selectorVaultSettings?.mergeDeriveAssetsEnabled &&
-    !!indexedAccountId &&
-    !accountUtils.isOthersAccount({ accountId });
-  // Home-owner list snapshot PULLed from the BG per-owner ViewModel (same
-  // channel WalletActions uses). Feeds the SWR floor below; EMPTY when the
-  // home VM has no entry for the mirrored owner.
-  const homeTokenListSnapshot = useHomeTokenListSnapshot();
-  const useSelectorFilteredTokenList =
-    !!showTokenSelectorFilter && showLpTokensOnly;
-  const effectiveShowActiveAccountTokenList =
-    showActiveAccountTokenList || useSelectorFilteredTokenList;
-  const effectiveHideZeroBalanceTokens =
-    showTokenSelectorFilter && showLpTokensOnly ? false : hideZeroBalanceTokens;
+  useEffect(() => {
+    if (effectiveShowActiveAccountTokenList) {
+      return;
+    }
+    restoreCachedNormalTokenSelectorSnapshot();
+  }, [
+    effectiveShowActiveAccountTokenList,
+    restoreCachedNormalTokenSelectorSnapshot,
+  ]);
+
+  useEffect(() => {
+    const scopedKey =
+      activeAccountTokenSelectorViewSWRKey ?? filteredTokenSelectorViewSWRKey;
+    const snapshot =
+      readTokenSelectorViewSnapshot<ITokenSelectorScopedViewSnapshot>(
+        scopedKey,
+      );
+    if (!snapshot) {
+      return;
+    }
+    applyScopedTokenSelectorSnapshot({
+      snapshot,
+      state: {
+        initialized: true,
+        isRefreshing: false,
+      },
+    });
+  }, [
+    activeAccountTokenSelectorViewSWRKey,
+    applyScopedTokenSelectorSnapshot,
+    filteredTokenSelectorViewSWRKey,
+  ]);
+
   const latestSelectorTokenListRequestContextRef =
     useRef<ISelectorTokenListRequestContext>({
       accountId: accountId ?? '',
@@ -833,15 +1097,29 @@ function TokenSelector() {
       return;
     }
 
-    setScopedActiveTokenListState({
-      initialized: false,
-      isRefreshing: true,
-    });
-    setScopedActiveTokenList({
-      tokens: [],
-      keys: '',
-    });
-    setScopedActiveTokenListMap({});
+    const cachedSnapshot =
+      readTokenSelectorViewSnapshot<ITokenSelectorScopedViewSnapshot>(
+        filteredTokenSelectorViewSWRKey,
+      );
+    if (cachedSnapshot) {
+      applyScopedTokenSelectorSnapshot({
+        snapshot: cachedSnapshot,
+        state: {
+          initialized: true,
+          isRefreshing: true,
+        },
+      });
+    } else {
+      setScopedActiveTokenListState({
+        initialized: false,
+        isRefreshing: true,
+      });
+      setScopedActiveTokenList({
+        tokens: [],
+        keys: '',
+      });
+      setScopedActiveTokenListMap({});
+    }
 
     try {
       const { responses } = await fetchFilteredTokenSelectorTokens({
@@ -867,16 +1145,32 @@ function TokenSelector() {
           keySuffix: tokenFilterKeySuffix,
         });
 
-      setScopedActiveTokenList(tokenList);
-      setScopedActiveTokenListMap(tokenListMap);
+      const snapshot = buildScopedTokenSelectorViewSnapshot({
+        tokenList,
+        tokenListMap,
+      });
+      applyScopedTokenSelectorSnapshot({
+        snapshot,
+        state: {
+          initialized: true,
+          isRefreshing: false,
+        },
+      });
+      writeTokenSelectorViewSnapshot({
+        key: filteredTokenSelectorViewSWRKey,
+        snapshot,
+      });
     } catch (e) {
-      console.error(e);
-    } finally {
       if (isLatestRequest()) {
         setScopedActiveTokenListState({
           initialized: true,
           isRefreshing: false,
         });
+        showFetchTokenListErrorToast();
+      }
+      console.error(e);
+    } finally {
+      if (isLatestRequest()) {
         setIsLpTokenSwitchLoading(false);
       }
     }
@@ -884,12 +1178,15 @@ function TokenSelector() {
     activeAccountId,
     activeNetworkId,
     accountId,
+    applyScopedTokenSelectorSnapshot,
+    filteredTokenSelectorViewSWRKey,
     indexedAccountId,
     isSelectorAllNetworks,
     mergeDeriveAddressData,
     networkId,
     showActiveAccountTokenList,
     showLpTokensOnly,
+    showFetchTokenListErrorToast,
     tokenSelectorFilterParams,
     useSelectorFilteredTokenList,
   ]);
@@ -918,15 +1215,29 @@ function TokenSelector() {
         return;
       }
 
-      setScopedActiveTokenListState({
-        initialized: false,
-        isRefreshing: true,
-      });
-      setScopedActiveTokenList({
-        tokens: [],
-        keys: '',
-      });
-      setScopedActiveTokenListMap({});
+      const cachedSnapshot =
+        readTokenSelectorViewSnapshot<ITokenSelectorScopedViewSnapshot>(
+          activeAccountTokenSelectorViewSWRKey,
+        );
+      if (cachedSnapshot) {
+        applyScopedTokenSelectorSnapshot({
+          snapshot: cachedSnapshot,
+          state: {
+            initialized: true,
+            isRefreshing: true,
+          },
+        });
+      } else {
+        setScopedActiveTokenListState({
+          initialized: false,
+          isRefreshing: true,
+        });
+        setScopedActiveTokenList({
+          tokens: [],
+          keys: '',
+        });
+        setScopedActiveTokenListMap({});
+      }
 
       try {
         if (showLpTokensOnly) {
@@ -967,17 +1278,26 @@ function TokenSelector() {
           return;
         }
 
-        setScopedActiveTokenList({
-          tokens: [...r.tokens.data, ...r.smallBalanceTokens.data],
-          keys: `${r.tokens.keys}_${r.smallBalanceTokens.keys}`,
+        const snapshot = buildScopedTokenSelectorViewSnapshot({
+          tokenList: {
+            tokens: [...r.tokens.data, ...r.smallBalanceTokens.data],
+            keys: `${r.tokens.keys}_${r.smallBalanceTokens.keys}`,
+          },
+          tokenListMap: {
+            ...r.tokens.map,
+            ...r.smallBalanceTokens.map,
+          },
         });
-        setScopedActiveTokenListMap({
-          ...r.tokens.map,
-          ...r.smallBalanceTokens.map,
+        applyScopedTokenSelectorSnapshot({
+          snapshot,
+          state: {
+            isRefreshing: false,
+            initialized: true,
+          },
         });
-        setScopedActiveTokenListState({
-          isRefreshing: false,
-          initialized: true,
+        writeTokenSelectorViewSnapshot({
+          key: activeAccountTokenSelectorViewSWRKey,
+          snapshot,
         });
 
         // Update network value cache so ChainSelector shows fresh values on back
@@ -1007,6 +1327,14 @@ function TokenSelector() {
             },
           );
         }
+      } catch {
+        if (isLatestRequest()) {
+          setScopedActiveTokenListState({
+            isRefreshing: false,
+            initialized: true,
+          });
+          showFetchTokenListErrorToast();
+        }
       } finally {
         if (isLatestRequest()) {
           setIsLpTokenSwitchLoading(false);
@@ -1017,27 +1345,23 @@ function TokenSelector() {
     }
   }, [
     activeAccountId,
+    activeAccountTokenSelectorViewSWRKey,
     activeNetworkId,
     accountId,
+    applyScopedTokenSelectorSnapshot,
     indexedAccountId,
     isSelectorAllNetworks,
     mergeDeriveAddressData,
     networkId,
     showActiveAccountTokenList,
     showLpTokensOnly,
+    showFetchTokenListErrorToast,
     tokenSelectorFilterParams,
     useSelectorFilteredTokenList,
   ]);
 
-  // SWR floor: when the selector owner IS the home owner (Send/Receive opened
-  // from home), the BG per-owner ViewModel already holds the exact list home is
-  // showing — paint it immediately instead of holding the skeleton for the
-  // full live fan-out (which on all-networks costs one request per enabled
-  // network). The snapshot pull is the same channel WalletActions uses
-  // (`useHomeTokenListSnapshot`); owner mismatch or a cold VM falls back to
-  // the skeleton path unchanged. Risky rows ride the VM raw list, so they are
-  // filtered with the risky set before seeding (the selector never offers
-  // risky tokens).
+  // When opened from home for the same owner, seed the selector from the home
+  // ViewModel snapshot instead of waiting for the full selector fetch.
   useEffect(() => {
     if (
       effectiveShowActiveAccountTokenList ||
@@ -1068,9 +1392,6 @@ function TokenSelector() {
             networkId,
           }),
         ]);
-        // Bail if the live data already landed OR a newer owner superseded this
-        // floor pull mid-flight (same staleness idiom the live self-fetch uses):
-        // either way this floor snapshot is stale and must not clobber state.
         if (
           selectorLiveLandedRef.current ||
           latestSelectorTokenListRequestContextRef.current.accountId !==
@@ -1083,44 +1404,25 @@ function TokenSelector() {
         const riskyTokenKeys = new Set(
           frames.riskyTokens.map((token) => token.$key),
         );
-        // Seed the floor in the VM raw-list order VERBATIM (risky rows filtered
-        // out): the raw blob is `orderedTokens ++ smallBalanceTokens` in the
-        // exact per-owner order the SAME ingest feeds home — server order for a
-        // single-network owner, the already-merged fiat order for an
-        // all-networks owner. The live selector replaces this floor with
-        // `buildSelectorTokenListFromResponses`, whose single-network branch
-        // returns that server order VERBATIM (no re-sort) and whose
-        // all-networks branch reproduces the merged fiat order; keeping the
-        // snapshot order therefore matches the live order for BOTH cases. A
-        // fiat re-sort here would only match the all-networks live branch and
-        // would reshuffle a single-network owner whose display order is not
-        // pure fiat (pinned defaults / custom tokens) the moment the live
-        // verbatim list lands.
-        setSelectorTokenList({
-          tokens: snapshot.tokens.filter(
-            (token) => !riskyTokenKeys.has(token.$key),
-          ),
-          smallBalanceTokens: [],
-        });
-        // `snapshot.map` is the composed home map (tokenListMap + riskyMap +
-        // flattened aggregate fiat), so it serves BOTH the per-row map and the
-        // aggregate `$key` fiat lookups.
-        setSelectorTokenListMap(snapshot.map);
-        setSelectorAggregateTokenFiatMap(snapshot.map);
-        // Aggregate membership MUST ride the SAME structure frame the floor
-        // rows come from: `getTokenListFrames` is home's atomic per-owner
-        // snapshot, whereas the simpleDb copy (`getLocalAggregateTokenListMap`)
-        // is home's LAST settled write and can lag the VM by a round. Reading
-        // simpleDb here would pair the fresh structure rows with a stale/empty
-        // member map, so aggregate row clicks and the single-owned-sub-token
-        // auto-select would resolve against outdated membership. Fall back to
-        // simpleDb only when the structure frame itself is absent (cold VM).
-        setSelectorAggregateTokenListMap(
-          frames.structure?.ownedAggregateTokenListMap ??
+        const floorSnapshot = buildNormalTokenSelectorViewSnapshot({
+          tokenList: {
+            tokens: snapshot.tokens.filter(
+              (token) => !riskyTokenKeys.has(token.$key),
+            ),
+            smallBalanceTokens: [],
+          },
+          tokenListMap: snapshot.map,
+          aggregateTokenListMap:
+            frames.structure?.ownedAggregateTokenListMap ??
             localAggregateTokenListMap ??
             {},
-        );
-        setSelectorInitialized(true);
+          aggregateTokenFiatMap: snapshot.map,
+        });
+        applyNormalTokenSelectorSnapshot(floorSnapshot);
+        writeTokenSelectorViewSnapshot({
+          key: normalTokenSelectorViewSWRKey,
+          snapshot: floorSnapshot,
+        });
       } catch (e) {
         console.error(e);
       }
@@ -1130,6 +1432,8 @@ function TokenSelector() {
     accountId,
     networkId,
     effectiveShowActiveAccountTokenList,
+    applyNormalTokenSelectorSnapshot,
+    normalTokenSelectorViewSWRKey,
   ]);
 
   // PR-3 selector self-fetch: on the NORMAL selector path (not the
@@ -1148,11 +1452,13 @@ function TokenSelector() {
       return;
     }
     if (!accountId || !networkId) {
-      setSelectorTokenList({ tokens: [], smallBalanceTokens: [] });
-      setSelectorTokenListMap({});
-      setSelectorAggregateTokenListMap({});
-      setSelectorAggregateTokenFiatMap({});
-      setSelectorInitialized(true);
+      if (!restoreCachedNormalTokenSelectorSnapshot()) {
+        setSelectorTokenList({ tokens: [], smallBalanceTokens: [] });
+        setSelectorTokenListMap({});
+        setSelectorAggregateTokenListMap({});
+        setSelectorAggregateTokenFiatMap({});
+        setSelectorInitialized(true);
+      }
       return;
     }
 
@@ -1174,30 +1480,22 @@ function TokenSelector() {
         requestContext,
       );
 
-    // Reset to `false` while (re)fetching for a new owner so TokenListView
-    // shows a skeleton (or the per-owner cache) instead of the previous owner's
-    // list for a frame — unless the SWR floor already painted the home
-    // snapshot; then keep it on screen until the live data replaces it. Also
-    // drop the previous owner's list/maps here: the `finally` below always
-    // lifts the skeleton (`setSelectorInitialized(true)`) even when this fetch
-    // throws or is canceled, so without the reset a failed live fetch for a new
-    // owner would re-expose the prior owner's rows instead of an empty state.
-    // The floor-seeded branch is excluded on purpose — it deliberately keeps
-    // its painted list until the live data lands.
-    if (!selectorFloorSeededRef.current) {
-      setSelectorInitialized(false);
+    if (!isLatestRequest()) {
+      return;
+    }
+
+    const hasRestoredSnapshot = restoreCachedNormalTokenSelectorSnapshot();
+    if (!hasRestoredSnapshot && !selectorFloorSeededRef.current) {
+      // Reset to `false` while fetching a new owner with no view snapshot so
+      // TokenListView skeletons instead of showing the previous owner's rows.
       setSelectorTokenList({ tokens: [], smallBalanceTokens: [] });
       setSelectorTokenListMap({});
       setSelectorAggregateTokenListMap({});
       setSelectorAggregateTokenFiatMap({});
+      setSelectorInitialized(false);
     }
 
     try {
-      // All-networks owners carry the mock account/network
-      // (AllNetworkMockAddress / onekeyall--*), which `fetchAccountTokens`
-      // forwards to the wallet API verbatim — the server rejects it. Fan out
-      // per real network instead (same enumeration + child requests the
-      // LP/scoped branch uses) and merge the per-network responses.
       const [fanOut, localAggregateTokenListMap, aggregateTokenRawData] =
         await Promise.all([
           isSelectorAllNetworks
@@ -1223,9 +1521,6 @@ function TokenSelector() {
             accountId,
             networkId,
           }),
-          // All-networks child responses carry RAW rows — aggregation is
-          // client-side authority in that mode (same aggregate config walk the
-          // home per-network handler runs).
           isSelectorAllNetworks
             ? backgroundApiProxy.simpleDb.aggregateToken.getRawData()
             : Promise.resolve(undefined),
@@ -1236,104 +1531,81 @@ function TokenSelector() {
       }
 
       const { responses, expectedResponseCount } = fanOut;
-
-      // The all-networks fan-out runs continue-on-error, so a failed child
-      // network is silently DROPPED from `responses` rather than throwing.
-      // `responses.length < expectedResponseCount` therefore means this round is
-      // INCOMPLETE — it is missing one or more networks' tokens (total failure,
-      // where zero networks answered, is just the extreme case). It must NOT be
-      // treated as an authoritative full snapshot. (Single-network / derive
-      // paths report `expectedResponseCount === responses.length`, so they never
-      // trip this.)
       const isIncompleteAllNetworksFanOut =
         isSelectorAllNetworks && responses.length < expectedResponseCount;
 
-      // An incomplete round must not overwrite an already-painted floor: the SWR
-      // home snapshot is COMPLETE, so keep it on screen instead of replacing it
-      // with a gap-ridden live list. Re-ARM the floor latch so a later home
-      // structure frame re-seeds it with fresh, full data; `liveLanded` stays
-      // unset (cleared together with the latch) so the floor effect is not
-      // permanently short-circuited, which would pin the selector on the stale
-      // floor until the owner changes or the page reopens.
-      if (isIncompleteAllNetworksFanOut && selectorFloorSeededRef.current) {
+      if (
+        isIncompleteAllNetworksFanOut &&
+        (selectorFloorSeededRef.current || hasRestoredSnapshot)
+      ) {
         selectorFloorSeededRef.current = false;
         return;
       }
 
-      // Each response's `aggregateTokenMap` is FLAT ($key -> ITokenFiat) and
-      // scoped to that response's networkId; the merge nests them by networkId
-      // then flattens with the home sum semantics so aggregate rows resolve
-      // correct fiat in TokenListView. Aggregate common rows dedupe by $key
-      // across the per-network responses.
       const merged = buildSelectorTokenListFromResponses({
         responses,
         aggregateTokenConfigMapRawData:
           aggregateTokenRawData?.aggregateTokenConfigMap,
       });
-
-      setSelectorTokenList({
-        tokens: merged.tokens,
-        smallBalanceTokens: merged.smallBalanceTokens,
-      });
-      // TokenListView's selector path resolves EVERY per-row fiat lookup —
-      // including the hideZeroBalanceTokens filter — from this map only (its
-      // `aggregateTokenMap` binding is the HOST prop, empty on the selector
-      // path); `tokenSelectorAggregateTokenFiatMap` feeds row display. Compose
-      // the aggregate `$key` fiat in so aggregate rows survive the
-      // zero-balance filter (Send passes hideZeroBalanceTokens).
-      setSelectorTokenListMap({
-        ...merged.tokenListMap,
-        ...merged.aggregateTokenFiatMap,
-      });
-      // All-networks: the freshly folded member map is the authority (the local
-      // simpleDb copy is home's LAST write — absent until home settles once).
-      // Single-network: responses carry server-aggregated rows without member
-      // metadata, so the home-written local map remains the source.
-      setSelectorAggregateTokenListMap(
+      const aggregateTokenListMap =
         isSelectorAllNetworks &&
-          Object.keys(merged.aggregateTokenListMap).length > 0
+        Object.keys(merged.aggregateTokenListMap).length > 0
           ? merged.aggregateTokenListMap
-          : (localAggregateTokenListMap ?? {}),
-      );
-      setSelectorAggregateTokenFiatMap(merged.aggregateTokenFiatMap);
-      // Only LATCH live-landed for a COMPLETE round. An incomplete fan-out with
-      // no floor to fall back on is still shown as a best-effort list (better
-      // than an indefinite skeleton), but leaving the latch unset lets a later
-      // home structure frame seed the missing networks through the floor effect
-      // instead of pinning this partial list. Complete rounds (and every
-      // single-network round) latch as before, so the floor stops re-seeding.
+          : (localAggregateTokenListMap ?? {});
+      const snapshot = buildNormalTokenSelectorViewSnapshot({
+        tokenList: {
+          tokens: merged.tokens,
+          smallBalanceTokens: merged.smallBalanceTokens,
+        },
+        tokenListMap: {
+          ...merged.tokenListMap,
+          ...merged.aggregateTokenFiatMap,
+        },
+        aggregateTokenListMap,
+        aggregateTokenFiatMap: merged.aggregateTokenFiatMap,
+      });
+      applyNormalTokenSelectorSnapshot(snapshot);
       if (!isIncompleteAllNetworksFanOut) {
+        writeTokenSelectorViewSnapshot({
+          key: normalTokenSelectorViewSWRKey,
+          snapshot,
+        });
         selectorLiveLandedRef.current = true;
       }
     } catch (e) {
-      // A superseded/aborted fetch is routine (same distinction the home
-      // TokenListBlock catch makes) — don't log it at error level.
       if (e instanceof CanceledError) {
         console.log('token selector fetchAccountTokens canceled');
       } else {
         console.error(e);
+        if (isLatestRequest()) {
+          showFetchTokenListErrorToast();
+        }
+      }
+      if (isLatestRequest()) {
+        void restoreCachedNormalTokenSelectorSnapshot();
       }
     } finally {
-      // Always leave the skeleton, even when the fetch failed — an unhandled
-      // throw here used to keep `selectorInitialized` false forever, pinning
-      // the selector on the skeleton with no self-recovery.
       if (isLatestRequest()) {
         setSelectorInitialized(true);
       }
     }
   }, [
-    accountId,
-    networkId,
-    indexedAccountId,
     activeAccountId,
     activeNetworkId,
+    accountId,
+    effectiveShowActiveAccountTokenList,
+    indexedAccountId,
     isSelectorAllNetworks,
     mergeDeriveAddressData,
-    showLpTokensOnly,
-    useSelectorFilteredTokenList,
+    networkId,
+    normalTokenSelectorViewSWRKey,
+    applyNormalTokenSelectorSnapshot,
+    restoreCachedNormalTokenSelectorSnapshot,
     showActiveAccountTokenList,
-    effectiveShowActiveAccountTokenList,
+    showFetchTokenListErrorToast,
+    showLpTokensOnly,
     tokenSelectorFilterParams,
+    useSelectorFilteredTokenList,
   ]);
 
   useEffect(() => {

--- a/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
+++ b/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
@@ -1188,6 +1188,7 @@ function TokenSelector() {
     const cachedSnapshot = readScopedTokenSelectorViewSnapshot(
       filteredTokenSelectorViewSWRKey,
     );
+    const hasRestoredSnapshot = Boolean(cachedSnapshot);
     if (cachedSnapshot) {
       applyScopedTokenSelectorSnapshot({
         snapshot: cachedSnapshot,
@@ -1209,17 +1210,28 @@ function TokenSelector() {
     }
 
     try {
-      const { responses } = await fetchFilteredTokenSelectorTokens({
-        accountId,
-        networkId,
-        indexedAccountId,
-        isAllNetworks: !!isSelectorAllNetworks,
-        mergeDeriveAddressData,
-        onlyBackendIndexedNetworks: showLpTokensOnly,
-        tokenSelectorFilterParams,
-      });
+      const { responses, expectedResponseCount } =
+        await fetchFilteredTokenSelectorTokens({
+          accountId,
+          networkId,
+          indexedAccountId,
+          isAllNetworks: !!isSelectorAllNetworks,
+          mergeDeriveAddressData,
+          onlyBackendIndexedNetworks: showLpTokensOnly,
+          tokenSelectorFilterParams,
+        });
 
       if (!isLatestRequest()) {
+        return;
+      }
+
+      const isIncompleteAllNetworksFanOut =
+        isSelectorAllNetworks && responses.length < expectedResponseCount;
+      if (isIncompleteAllNetworksFanOut && hasRestoredSnapshot) {
+        setScopedActiveTokenListState({
+          initialized: true,
+          isRefreshing: false,
+        });
         return;
       }
 
@@ -1243,10 +1255,12 @@ function TokenSelector() {
           isRefreshing: false,
         },
       });
-      writeScopedTokenSelectorViewSnapshot({
-        key: filteredTokenSelectorViewSWRKey,
-        snapshot,
-      });
+      if (!isIncompleteAllNetworksFanOut) {
+        writeScopedTokenSelectorViewSnapshot({
+          key: filteredTokenSelectorViewSWRKey,
+          snapshot,
+        });
+      }
     } catch (e) {
       if (isLatestRequest()) {
         setScopedActiveTokenListState({

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -178,6 +178,23 @@ type IAggregateTokenListMapWithCommonToken = Record<
   }
 >;
 
+function pickTokenListFiatMap({
+  tokens,
+  tokenListMap,
+}: {
+  tokens: IAccountToken[];
+  tokenListMap: Record<string, ITokenFiat>;
+}) {
+  const map: Record<string, ITokenFiat> = {};
+  tokens.forEach((token) => {
+    const fiat = tokenListMap[token.$key];
+    if (fiat) {
+      map[token.$key] = fiat;
+    }
+  });
+  return map;
+}
+
 type IActiveAccountTokenListRequestContext = {
   accountId: string;
   indexedAccountId: string;
@@ -1938,17 +1955,26 @@ function TokenListBlock({
             tokens: {
               data: r.tokenList,
               keys: '',
-              map: r.tokenListMap,
+              map: pickTokenListFiatMap({
+                tokens: r.tokenList,
+                tokenListMap: r.tokenListMap,
+              }),
             },
             smallBalanceTokens: {
               data: r.smallBalanceTokenList,
               keys: '',
-              map: r.tokenListMap,
+              map: pickTokenListFiatMap({
+                tokens: r.smallBalanceTokenList,
+                tokenListMap: r.tokenListMap,
+              }),
             },
             riskTokens: {
               data: r.riskyTokenList,
               keys: '',
-              map: r.tokenListMap,
+              map: pickTokenListFiatMap({
+                tokens: r.riskyTokenList,
+                tokenListMap: r.tokenListMap,
+              }),
             },
           };
         });
@@ -1979,9 +2005,18 @@ function TokenListBlock({
         tokenList = localTokens.tokenList;
         smallBalanceTokenList = localTokens.smallBalanceTokenList;
         riskyTokenList = localTokens.riskyTokenList;
-        tokenListMap = localTokens.tokenListMap;
-        smallBalanceTokenListMap = localTokens.tokenListMap;
-        riskyTokenListMap = localTokens.tokenListMap;
+        tokenListMap = pickTokenListFiatMap({
+          tokens: tokenList,
+          tokenListMap: localTokens.tokenListMap,
+        });
+        smallBalanceTokenListMap = pickTokenListFiatMap({
+          tokens: smallBalanceTokenList,
+          tokenListMap: localTokens.tokenListMap,
+        });
+        riskyTokenListMap = pickTokenListFiatMap({
+          tokens: riskyTokenList,
+          tokenListMap: localTokens.tokenListMap,
+        });
         tokenListValue = localTokens.tokenListValue;
         tokenListWorth = {
           [accountUtils.buildAccountValueKey({

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -140,6 +140,7 @@ import {
   shouldReportWalletAssetStatusChange,
   shouldReportWalletAssetStatusSnapshot,
 } from './assetStatusAnalytics';
+import { buildHomeTokenListCacheIngestRound } from './buildHomeTokenListCacheIngestRound';
 import { useTokenListReactivePipeline } from './useTokenListReactivePipeline';
 
 const networkIdsMap = getNetworkIdsMap();
@@ -1069,6 +1070,20 @@ function TokenListBlock({
       }
       r.allTokens = allTokens;
 
+      defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+        runtime: 'main',
+        phase: 'all-network-fetch-settled',
+        networkId,
+        isAllNetworks: true,
+        allNetworkDataInit,
+        tokenCount: r.tokens.data.length,
+        smallBalanceCount: r.smallBalanceTokens.data.length,
+        riskyCount: r.riskTokens.data.length,
+        aggregateCount: Object.keys(r.aggregateTokenListMap ?? {}).length,
+        ownerPresent: !!account?.id,
+        indexedAccountPresent: !!indexedAccount?.id,
+      });
+
       // The active owner may have changed during the awaits above (detached
       // history-loop refresh, un-aborted fetch from a previous owner). Writing
       // would land this owner's data on atoms already cleared and re-stamped
@@ -1207,9 +1222,11 @@ function TokenListBlock({
     async ({
       accountId,
       networkId,
+      allNetworkDataInit,
     }: {
       accountId?: string;
       networkId?: string;
+      allNetworkDataInit?: boolean;
     }) => {
       perfTokenListView.markStart('allNetworkRequestsStarted_getRawData');
 
@@ -1243,6 +1260,16 @@ function TokenListBlock({
         networkId: networkId ?? '',
       });
 
+      defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+        runtime: 'main',
+        phase: 'all-network-run-started',
+        networkId,
+        isAllNetworks: true,
+        allNetworkDataInit,
+        ownerPresent: !!account?.id,
+        indexedAccountPresent: !!indexedAccount?.id,
+      });
+
       if (syncTokenFilterToOverview) {
         setOverviewTokenCacheState({
           ownerKey: buildOverviewOwnerKey(account?.id, network?.id),
@@ -1252,6 +1279,7 @@ function TokenListBlock({
     },
     [
       account?.id,
+      indexedAccount?.id,
       network?.id,
       setOverviewTokenCacheState,
       syncTokenFilterToOverview,
@@ -1419,6 +1447,29 @@ function TokenListBlock({
       }
 
       if (hasAnyCache) {
+        defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+          runtime: 'main',
+          phase: 'all-network-cache-hydrate',
+          networkId,
+          isAllNetworks: true,
+          hasCache: true,
+          cacheCount: data.length,
+          tokenCount: data.reduce(
+            (total, item) => total + item.tokenList.length,
+            0,
+          ),
+          smallBalanceCount: data.reduce(
+            (total, item) => total + item.smallBalanceTokenList.length,
+            0,
+          ),
+          riskyCount: data.reduce(
+            (total, item) => total + item.riskyTokenList.length,
+            0,
+          ),
+          ownerPresent: !!account?.id,
+          indexedAccountPresent: !!indexedAccount?.id,
+        });
+
         if (syncTokenFilterToOverview) {
           // All items share the storage currency (same multi-network fetch);
           // fall back to USD when the cache is empty.
@@ -1507,6 +1558,17 @@ function TokenListBlock({
   // guard + ingest + throttle all live in the facade now (design §2).
   const handleAllNetworkRequestSettled = useCallback(
     (result: IAllNetworkTokenListResp, generation: number) => {
+      defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+        runtime: 'main',
+        phase: 'all-network-progressive-settled',
+        networkId: result.networkId,
+        isAllNetworks: true,
+        tokenCount: result.tokens.data.length,
+        smallBalanceCount: result.smallBalanceTokens.data.length,
+        riskyCount: result.riskTokens.data.length,
+        aggregateCount: Object.keys(result.aggregateTokenListMap ?? {}).length,
+        source: `generation:${generation}`,
+      });
       ingestLiveRound(result, generation);
     },
     [ingestLiveRound],
@@ -1726,11 +1788,24 @@ function TokenListBlock({
       });
     }
 
-    // Authoritative ingest + reset (facade, design §2): ingest the FULL merged
+    // Authoritative ingest (facade, design §2): ingest the FULL merged
     // snapshot (REPLACE semantics — `vm.lastStructure` compares full-vs-full),
-    // cancel any trailing progressive flush, bump the epoch (P1-g) so a flush
-    // already past its timer aborts after its await instead of overwriting this
-    // authoritative full list, and clear the view for the next run.
+    // cancel any trailing progressive flush, and bump the epoch (P1-g) so a
+    // flush already past its timer aborts after its await instead of overwriting
+    // this authoritative full list. The LWW rounds stay resident as the next
+    // warm refresh's SWR floor so the list never shrinks to settled rows only.
+    defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+      runtime: 'main',
+      phase: 'all-network-authoritative-commit',
+      networkId: network?.id,
+      isAllNetworks: true,
+      tokenCount: snapshot.orderedTokens.length,
+      smallBalanceCount: snapshot.smallBalanceTokens.length,
+      riskyCount: snapshot.riskyTokens.length,
+      aggregateCount: Object.keys(snapshot.aggregateTokenListMap).length,
+      ownerPresent: !!account?.id,
+      indexedAccountPresent: !!indexedAccount?.id,
+    });
     commitAuthoritativeIngest(snapshot);
 
     updateTokenListState({
@@ -1809,6 +1884,9 @@ function TokenListBlock({
       let tokenList: IAccountToken[] = [];
       let smallBalanceTokenList: IAccountToken[] = [];
       let riskyTokenList: IAccountToken[] = [];
+      let tokenListMap: Record<string, ITokenFiat> = {};
+      let smallBalanceTokenListMap: Record<string, ITokenFiat> = {};
+      let riskyTokenListMap: Record<string, ITokenFiat> = {};
       let tokenListValue = '0';
       let tokenListWorth: Record<string, string> = {};
       let hasLocalTokenCache = false;
@@ -1884,6 +1962,9 @@ function TokenListBlock({
         smallBalanceTokenList =
           tokenListData.smallBalanceTokenList.smallBalanceTokens;
         riskyTokenList = tokenListData.riskyTokenList.riskyTokens;
+        tokenListMap = tokenListData.tokenListMap;
+        smallBalanceTokenListMap = tokenListData.smallBalanceTokenListMap;
+        riskyTokenListMap = tokenListData.riskyTokenListMap;
       } else {
         const localTokens =
           await backgroundApiProxy.serviceToken.getAccountLocalTokens({
@@ -1898,6 +1979,9 @@ function TokenListBlock({
         tokenList = localTokens.tokenList;
         smallBalanceTokenList = localTokens.smallBalanceTokenList;
         riskyTokenList = localTokens.riskyTokenList;
+        tokenListMap = localTokens.tokenListMap;
+        smallBalanceTokenListMap = localTokens.tokenListMap;
+        riskyTokenListMap = localTokens.tokenListMap;
         tokenListValue = localTokens.tokenListValue;
         tokenListWorth = {
           [accountUtils.buildAccountValueKey({
@@ -1911,6 +1995,58 @@ function TokenListBlock({
       // token cache — drop the result so we don't overwrite the new owner's
       // freshly hydrated atoms with this stale response.
       if (cancelled) return;
+
+      defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+        runtime: 'main',
+        phase: 'single-network-local-cache-read',
+        networkId,
+        isAllNetworks: false,
+        hasCache: hasLocalTokenCache,
+        tokenCount: tokenList.length,
+        smallBalanceCount: smallBalanceTokenList.length,
+        riskyCount: riskyTokenList.length,
+        ownerPresent: !!account?.id,
+        indexedAccountPresent: !!indexedAccount?.id,
+      });
+
+      const ingestSingleNetworkCache = ({
+        source,
+      }: {
+        source: 'singleCacheSeed' | 'singleEmptyCacheSeed';
+      }) => {
+        void backgroundApiProxy.serviceTokenViewModel.ingestRound(
+          buildHomeTokenListCacheIngestRound({
+            ownerKey: cellsIngestInputsRef.current.ownerKey,
+            accountId: account?.id,
+            networkId,
+            tokenList,
+            smallBalanceTokenList,
+            riskyTokenList,
+            tokenListMap,
+            smallBalanceTokenListMap,
+            riskyTokenListMap,
+            keepDefault: cellsIngestInputsRef.current.nonZeroInputs.keepDefault,
+            homeDefaultTokenMap:
+              cellsIngestInputsRef.current.nonZeroInputs.homeDefaultTokenMap,
+            customTokens:
+              cellsIngestInputsRef.current.nonZeroInputs.customTokens,
+            source,
+          }),
+        );
+        defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+          runtime: 'main',
+          phase: 'single-network-cache-ingest',
+          networkId,
+          isAllNetworks: false,
+          hasCache: true,
+          tokenCount: tokenList.length,
+          smallBalanceCount: smallBalanceTokenList.length,
+          riskyCount: riskyTokenList.length,
+          ownerPresent: !!account?.id,
+          indexedAccountPresent: !!indexedAccount?.id,
+          source,
+        });
+      };
 
       if (
         isEmpty(tokenList) &&
@@ -1932,11 +2068,10 @@ function TokenListBlock({
             merge: false,
             currency: cachedWorthCurrency,
           });
-          // Without these refresh calls the token list atoms keep the
-          // previous owner's data, leaving allTokenList.accountId/networkId
-          // stale and triggering the owner-mismatch skeleton in TokenListView
-          // forever for this empty-cache target.
           handleClearAllNetworkData();
+          // Stamp the empty cached owner into the cell VM so an empty cached
+          // target renders the empty state instead of a previous-owner skeleton.
+          ingestSingleNetworkCache({ source: 'singleEmptyCacheSeed' });
           updateAccountOverviewState({
             isRefreshing: false,
             initialized: true,
@@ -1985,6 +2120,7 @@ function TokenListBlock({
           initialized: true,
         });
 
+        ingestSingleNetworkCache({ source: 'singleCacheSeed' });
         perfTokenListView.markEnd('tokenListRefreshing_initTokenListData');
         updateTokenListState({
           initialized: true,
@@ -2127,11 +2263,19 @@ function TokenListBlock({
 
   const handleRefreshAllNetworkData = useCallback(() => {
     isAllNetworkManualRefresh.current = true;
+    defaultLogger.account.allNetworkAccountPerf.homeTokenListRefreshTrace({
+      runtime: 'main',
+      phase: 'all-network-manual-refresh',
+      networkId: network?.id,
+      isAllNetworks: true,
+      ownerPresent: !!account?.id,
+      indexedAccountPresent: !!indexedAccount?.id,
+    });
     void runAllNetworksRequests({
       alwaysSetState: true,
       skipAccountsCache: true,
     });
-  }, [runAllNetworksRequests]);
+  }, [account?.id, indexedAccount?.id, network?.id, runAllNetworksRequests]);
 
   refreshWalletTokenListRef.current = () => {
     if (network?.isAllNetworks) {

--- a/packages/kit/src/views/Home/components/TokenListBlock/buildHomeTokenListCacheIngestRound.test.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/buildHomeTokenListCacheIngestRound.test.ts
@@ -1,0 +1,96 @@
+import type { IAccountToken, ITokenFiat } from '@onekeyhq/shared/types/token';
+
+import { buildHomeTokenListCacheIngestRound } from './buildHomeTokenListCacheIngestRound';
+
+function makeToken(
+  key: string,
+  overrides: Partial<IAccountToken> = {},
+): IAccountToken {
+  return {
+    $key: key,
+    name: key,
+    symbol: key,
+    decimals: 18,
+    address: `0x${key}`,
+    isNative: false,
+    ...overrides,
+  } as IAccountToken;
+}
+
+function makeFiat(
+  fiatValue: string,
+  overrides: Partial<ITokenFiat> = {},
+): ITokenFiat {
+  return {
+    balance: '1',
+    balanceParsed: '1',
+    fiatValue,
+    price: 1,
+    ...overrides,
+  };
+}
+
+describe('buildHomeTokenListCacheIngestRound', () => {
+  it('builds a single-network cache ingest payload with visible and risky maps split', () => {
+    const token = makeToken('native');
+    const small = makeToken('dust');
+    const risky = makeToken('risk');
+
+    const payload = buildHomeTokenListCacheIngestRound({
+      ownerKey: 'acc__evm--1',
+      accountId: 'acc',
+      networkId: 'evm--1',
+      tokenList: [token],
+      smallBalanceTokenList: [small],
+      riskyTokenList: [risky],
+      tokenListMap: {
+        native: makeFiat('10'),
+      },
+      smallBalanceTokenListMap: {
+        dust: makeFiat('0.25'),
+      },
+      riskyTokenListMap: {
+        risk: makeFiat('999'),
+      },
+      source: 'singleCacheSeed',
+    });
+
+    expect(payload.ownerKey).toBe('acc__evm--1');
+    expect(payload.orderedTokens).toEqual([token]);
+    expect(payload.smallBalanceTokens).toEqual([small]);
+    expect(payload.riskyTokens).toEqual([risky]);
+    expect(payload.tokenListMap).toEqual({
+      native: makeFiat('10'),
+      dust: makeFiat('0.25'),
+    });
+    expect(payload.riskyMap).toEqual({
+      risk: makeFiat('999'),
+    });
+    expect(payload.smallBalanceFiatValue).toBe('0.25');
+    expect(payload.rawKeys).toBe('native_dust_risk');
+    expect(payload.source).toBe('singleCacheSeed');
+  });
+
+  it('builds an empty owner-stamp payload for cached empty lists', () => {
+    const payload = buildHomeTokenListCacheIngestRound({
+      ownerKey: 'acc__btc--0',
+      accountId: 'acc',
+      networkId: 'btc--0',
+      tokenList: [],
+      smallBalanceTokenList: [],
+      riskyTokenList: [],
+      tokenListMap: {},
+      source: 'singleEmptyCacheSeed',
+    });
+
+    expect(payload.ownerKey).toBe('acc__btc--0');
+    expect(payload.orderedTokens).toEqual([]);
+    expect(payload.smallBalanceTokens).toEqual([]);
+    expect(payload.riskyTokens).toEqual([]);
+    expect(payload.tokenListMap).toEqual({});
+    expect(payload.riskyMap).toEqual({});
+    expect(payload.smallBalanceFiatValue).toBe('0');
+    expect(payload.rawKeys).toBe('__');
+    expect(payload.source).toBe('singleEmptyCacheSeed');
+  });
+});

--- a/packages/kit/src/views/Home/components/TokenListBlock/buildHomeTokenListCacheIngestRound.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/buildHomeTokenListCacheIngestRound.ts
@@ -1,0 +1,98 @@
+import BigNumber from 'bignumber.js';
+
+import type { IIngestRoundParams } from '@onekeyhq/kit-bg/src/services/ServiceTokenViewModel';
+import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { isValidNumberValue } from '@onekeyhq/shared/src/utils/tokenValueUtils';
+import type {
+  IAccountToken,
+  ICustomTokenItem,
+  IHomeDefaultToken,
+  ITokenFiat,
+} from '@onekeyhq/shared/types/token';
+
+function buildTokenKeys(tokens: IAccountToken[]): string {
+  return tokens.map((token) => token.$key).join(',');
+}
+
+function sumFiatValueByTokens({
+  tokens,
+  tokenListMap,
+}: {
+  tokens: IAccountToken[];
+  tokenListMap: Record<string, ITokenFiat>;
+}): string {
+  return tokens
+    .reduce((total, token) => {
+      const fiatValue = tokenListMap[token.$key]?.fiatValue;
+      if (!isValidNumberValue(fiatValue)) {
+        return total;
+      }
+      return total.plus(fiatValue);
+    }, new BigNumber(0))
+    .toFixed();
+}
+
+export function buildHomeTokenListCacheIngestRound({
+  ownerKey,
+  accountId,
+  networkId,
+  tokenList,
+  smallBalanceTokenList,
+  riskyTokenList,
+  tokenListMap,
+  smallBalanceTokenListMap = {},
+  riskyTokenListMap = {},
+  keepDefault,
+  homeDefaultTokenMap,
+  customTokens,
+  source,
+}: {
+  ownerKey: string;
+  accountId?: string;
+  networkId?: string;
+  tokenList: IAccountToken[];
+  smallBalanceTokenList: IAccountToken[];
+  riskyTokenList: IAccountToken[];
+  tokenListMap: Record<string, ITokenFiat>;
+  smallBalanceTokenListMap?: Record<string, ITokenFiat>;
+  riskyTokenListMap?: Record<string, ITokenFiat>;
+  keepDefault?: boolean;
+  homeDefaultTokenMap?: Record<string, IHomeDefaultToken>;
+  customTokens?: ICustomTokenItem[];
+  source: IIngestRoundParams['source'];
+}): IIngestRoundParams {
+  const visibleTokenListMap = {
+    ...tokenListMap,
+    ...smallBalanceTokenListMap,
+  };
+  const rawKeys = [
+    buildTokenKeys(tokenList),
+    buildTokenKeys(smallBalanceTokenList),
+    buildTokenKeys(riskyTokenList),
+  ].join('_');
+
+  return {
+    ownerKey,
+    orderedTokens: tokenList,
+    smallBalanceTokens: smallBalanceTokenList,
+    tokenListMap: visibleTokenListMap,
+    aggregateTokensMap: {},
+    ownedAggregateTokenListMap: {},
+    smallBalanceFiatValue: sumFiatValueByTokens({
+      tokens: smallBalanceTokenList,
+      tokenListMap: visibleTokenListMap,
+    }),
+    storeData: { storeName: EJotaiContextStoreNames.homeTokenList },
+    keepDefault,
+    homeDefaultTokenMap,
+    customTokens,
+    riskyTokens: riskyTokenList,
+    riskyMap: {
+      ...riskyTokenListMap,
+    },
+    accountId,
+    networkId,
+    rawKeys,
+    source,
+  };
+}

--- a/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.test.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.test.ts
@@ -374,7 +374,7 @@ describe('useTokenListReactivePipeline', () => {
           1,
         );
       });
-      // authoritative commit lands first (bumps the epoch + clears the view)
+      // authoritative commit lands first (bumps the epoch)
       await act(async () => {
         const snap = await result.current.buildAuthoritativeSnapshot();
         result.current.commitAuthoritativeIngest(snap);
@@ -385,6 +385,89 @@ describe('useTokenListReactivePipeline', () => {
         await jest.advanceTimersByTimeAsync(400);
       });
       expect(mockIngestRound).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps the previous authoritative rounds as the next warm-refresh floor', async () => {
+    jest.useFakeTimers();
+    try {
+      const { result } = render(true);
+      act(() => {
+        result.current.setEnabledKeys([
+          OWNER,
+          { accountId: OWNER.accountId, networkId: 'evm--56' },
+        ]);
+      });
+      await act(async () => {
+        await result.current.seedAndFlushCache({
+          data: [
+            makeCacheItem({
+              tokenList: [
+                {
+                  $key: 'old-a1',
+                  name: 'Old A1',
+                  symbol: 'OA1',
+                  decimals: 18,
+                  address: '0xolda1',
+                  isNative: false,
+                },
+              ] as ICacheSeedItem['tokenList'],
+              tokenListMap: {
+                'old-a1': {
+                  balance: '1',
+                  balanceParsed: '1',
+                  fiatValue: '10',
+                  price: 1,
+                },
+              },
+            }),
+            makeCacheItem({
+              networkId: 'evm--56',
+              tokenList: [
+                {
+                  $key: 'b1',
+                  name: 'B1',
+                  symbol: 'B1',
+                  decimals: 18,
+                  address: '0xb1',
+                  isNative: false,
+                },
+              ] as ICacheSeedItem['tokenList'],
+              tokenListMap: {
+                b1: {
+                  balance: '1',
+                  balanceParsed: '1',
+                  fiatValue: '5',
+                  price: 1,
+                },
+              },
+            }),
+          ],
+          accountId: OWNER.accountId,
+          networkId: OWNER.networkId,
+          generation: 1,
+        });
+        const snap = await result.current.buildAuthoritativeSnapshot();
+        result.current.commitAuthoritativeIngest(snap);
+      });
+      mockIngestRound.mockClear();
+
+      act(() => {
+        result.current.ingestLiveRound(makeLiveRound(), 2);
+      });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(PROGRESSIVE_PAINT_THROTTLE_MS + 1);
+      });
+
+      expect(mockIngestRound).toHaveBeenCalledTimes(1);
+      const arg = mockIngestRound.mock.calls[0][0] as {
+        source: string;
+        orderedTokens: { $key: string }[];
+      };
+      expect(arg.source).toBe('progPaint');
+      expect(arg.orderedTokens.map((t) => t.$key)).toEqual(['live-a1', 'b1']);
     } finally {
       jest.useRealTimers();
     }

--- a/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.ts
@@ -12,7 +12,7 @@
  * which calls these methods from thin wrappers. Specifically:
  *   - P0-b: `buildAuthoritativeSnapshot()` RETURNS the built snapshot so the
  *     component can compute `updateAccountWorth(snapshot.accountsWorth…)` before
- *     `commitAuthoritativeIngest(snapshot)` does the ingest + clear + epoch bump.
+ *     `commitAuthoritativeIngest(snapshot)` does the ingest + epoch bump.
  *   - P0-a: the cache path keeps `updateTokenListState` in the component AFTER
  *     `await seedAndFlushCache(...)` and inside its `hasAnyCache` guard.
  *   - P0-h: every returned callback is memoised with the SAME dep footprint the
@@ -22,7 +22,7 @@
  *   - P1-f: the flush captures the owner once and re-checks a live owner
  *     generation + ownerKey after awaits before writing to the BG VM.
  *   - P1-g: `reset()` clears WITHOUT bumping epoch; `commitAuthoritativeIngest`
- *     clears AND bumps epoch.
+ *     bumps epoch and keeps the latest rounds as the next refresh's SWR floor.
  *
  * The single-network `run()` ingest stays in the component: it touches none of
  * these refs (a direct `ingestRound` reading `cellsIngestInputsRef`), so moving
@@ -123,7 +123,7 @@ export interface ITokenListReactivePipeline {
   ingestLiveRound: (result: ILiveRound, generation: number) => void;
   /** materialize ∩ enabledKeys → resolve merge flags → build the merged snapshot. */
   buildAuthoritativeSnapshot: () => Promise<IMergedAllNetworkSnapshot>;
-  /** ingest the authoritative snapshot + clear timer + bump epoch + clear view. */
+  /** Ingest the authoritative snapshot + clear timer + bump epoch. */
   commitAuthoritativeIngest: (snapshot: IMergedAllNetworkSnapshot) => void;
 }
 
@@ -455,7 +455,6 @@ export function useTokenListReactivePipeline(
         progressiveFlushTimerRef.current = null;
       }
       progressivePaintEpochRef.current += 1;
-      progressiveViewRef.current.clear();
     },
     [enabled, ingestMergedSnapshot],
   );

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -1485,11 +1485,11 @@ const BaseDevSettingsSection = () => {
                             isUncontrolled
                             size={ESwitchSize.small}
                             defaultChecked={
-                              !!devSettings.settings?.showPerformanceMonitor
+                              !!devSettings.settings?.showPerformanceMonitorV2
                             }
                             onChange={(v) => {
                               void backgroundApiProxy.serviceDevSetting.updateDevSetting(
-                                'showPerformanceMonitor',
+                                'showPerformanceMonitorV2',
                                 v,
                               );
                               setTimeout(() => {

--- a/packages/shared/src/logger/scopes/account/scenes/allNetworkAccountPerf.ts
+++ b/packages/shared/src/logger/scopes/account/scenes/allNetworkAccountPerf.ts
@@ -1,15 +1,48 @@
 import { BaseScene } from '../../../base/baseScene';
-import { LogToConsole } from '../../../base/decorators';
+import { LogToConsole, LogToLocal } from '../../../base/decorators';
+
+type IHomeTokenListRefreshTraceParams = {
+  runtime: 'main' | 'bg';
+  phase: string;
+  networkId?: string;
+  isAllNetworks?: boolean;
+  allNetworkDataInit?: boolean;
+  isMustRun?: boolean;
+  hasCache?: boolean;
+  cacheCount?: number;
+  accountsCount?: number;
+  backendIndexedCount?: number;
+  backendNotIndexedCount?: number;
+  allAccountsCount?: number;
+  resultCount?: number;
+  tokenCount?: number;
+  smallBalanceCount?: number;
+  riskyCount?: number;
+  aggregateCount?: number;
+  initialized?: boolean;
+  isRefreshing?: boolean;
+  ownerPresent?: boolean;
+  indexedAccountPresent?: boolean;
+  source?: string;
+  reason?: string;
+};
 
 export class AllNetworkAccountPerf extends BaseScene {
   @LogToConsole()
+  @LogToLocal()
   public getAllNetworkAccountsStart() {
     this.resetTimestamp();
     return ['>>>>>>>>>>>>', true];
   }
 
   @LogToConsole()
+  @LogToLocal()
   public getAllNetworkAccountsEnd() {
     return ['<<<<<<<<<<<<', true];
+  }
+
+  @LogToLocal()
+  public homeTokenListRefreshTrace(params: IHomeTokenListRefreshTraceParams) {
+    return params;
   }
 }

--- a/packages/shared/src/utils/swrCacheUtils.ts
+++ b/packages/shared/src/utils/swrCacheUtils.ts
@@ -174,6 +174,7 @@ const NS = {
   perpsL2BookSnapshot: 'perpsL2Book',
   historyTxDetail: 'historyTxDetail',
   marketHomeTokenList: 'marketHomeTokenList',
+  tokenSelectorView: 'tokenSelectorView',
   swapStockTokenDetail: 'swapStockTokenDetail',
   swapStockSpeedConfig: 'swapStockSpeedConfig',
   swapStockPayTokenDetails: 'swapStockPayTokenDetails',
@@ -408,6 +409,40 @@ export const swrKeys = {
       minLiquidity ?? '',
       type ?? '',
       timeFrame ?? '',
+    ].join(':'),
+  tokenSelectorView: ({
+    ownerMode,
+    filterMode,
+    accountId,
+    networkId,
+    indexedAccountId,
+    activeAccountId,
+    activeNetworkId,
+    isAllNetworks,
+    mergeDeriveAddressData,
+  }: {
+    ownerMode: 'normal' | 'active-account' | 'filtered';
+    filterMode: 'all-token' | 'wallet-token' | 'dapp-token';
+    accountId?: string;
+    networkId?: string;
+    indexedAccountId?: string;
+    activeAccountId?: string;
+    activeNetworkId?: string;
+    isAllNetworks?: boolean;
+    mergeDeriveAddressData?: boolean;
+  }) =>
+    [
+      NS.tokenSelectorView,
+      'v1',
+      ownerMode,
+      filterMode,
+      accountId ?? '',
+      networkId ?? '',
+      indexedAccountId ?? '',
+      activeAccountId ?? '',
+      activeNetworkId ?? '',
+      isAllNetworks ? '1' : '0',
+      mergeDeriveAddressData ? '1' : '0',
     ].join(':'),
   swapStockTokenDetail: ({ tokenScope }: { tokenScope: string }) =>
     [NS.swapStockTokenDetail, 'v1', tokenScope].join(':'),


### PR DESCRIPTION
## Summary
- Preserve Home token rows during all-network and single-network refreshes instead of clearing the whole list before fresh data returns.
- Add TokenSelector view-layer SWR snapshots so Send token selection can paint cached rows immediately and revalidate in the background.
- Add local trace logging, a repeatable home-token stress script, focused tests, and keep the native performance overlay disabled by default unless manually enabled.

## Intent & Context
This fixes regressions observed on the wallet Home and Send token selector flows. The target behavior is stale-while-revalidate at the view layer: once a usable rendered list exists, refreshes should keep readable cached rows on screen and only update changed rows after fresh background data arrives. The request also required repeatable verification across all-network/single-network switching, cold-start with and without cache, account switching, account add/remove, and crash observation.

## Root Cause
Home and TokenSelector refresh paths treated `loading` as a reason to clear visible token state. On all-network refresh this made the Home list shrink or flash skeletons while network rows settled progressively. On Send token selection, the selector did not reuse a ready-to-render view snapshot, so re-opening the page or hitting a revalidation error could show skeletons even when the previous page already had usable token data.

## Design Decisions
- Keep SWR at the view layer for TokenSelector instead of adding a normalized all-network data cache in the main runtime.
- Store ready-to-render selector snapshots keyed by owner/filter/network mode via `swrCacheUtils`.
- Keep Home token reactive pipeline rounds resident after authoritative commits so warm refreshes have a stable floor instead of shrinking to only currently settled rows.
- For single-network cached data, ingest a lightweight cache round into the token list VM so owner/network stamping stays correct even for empty cached lists.
- Use native logger local traces for refresh entry points and cache hydration, while avoiding sensitive wallet data in logs.
- Introduce `showPerformanceMonitorV2` defaulting to false so legacy persisted dev values do not auto-open the overlay.

## Changes Detail
- `TokenSelector.tsx`: reads/writes view-layer SWR snapshots for normal, active-account, and filtered token selector modes; cached rows are rendered before background revalidation.
- `computeShowTokenListSkeleton.ts`: requires `displayCount === 0` for refresh skeletons so cached rows are not hidden.
- `TokenListBlock.tsx` and `useTokenListReactivePipeline.ts`: preserve authoritative rounds as the next refresh floor and ingest single-network cached rounds.
- `buildHomeTokenListCacheIngestRound.ts`: builds cache ingest payloads for single-network cached and empty cached states.
- `allNetworkAccountPerf.ts` and `useAllNetwork.ts`: add local trace points for refresh/cache behavior.
- `home-token-refresh-stress.mjs`: adds repeatable simulator automation for refresh/cache/crash observation.
- `ios-release-build-deploy.sh`: improves local log filtering when no fresh session marker exists.
- `WebPerformanceMonitor` / dev settings / `Bootstrap`: performance overlay no longer starts from legacy default-on state.
- `docs/home-token-list-refresh-cache.md`: records scenarios, expected behavior, current behavior, and validation notes.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile native primarily; shared SWR utility and tests are cross-platform TypeScript.
- **Risk Areas**: Home token list refresh ordering, selector cache key correctness, stale owner/network guards, and cache memory footprint. The selected approach avoids main-thread normalized all-network data parsing and keeps background/main JS heaps isolated.

## Test plan
- [x] `yarn test packages/kit/src/components/TokenListView/computeShowTokenListSkeleton.test.ts packages/kit/src/views/Home/components/TokenListBlock/buildHomeTokenListCacheIngestRound.test.ts packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.test.ts --runInBand`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [x] `yarn tsc:only`
- [x] `development/scripts/ios-release-build-deploy.sh all`
- [x] iOS simulator: Home has cached token rows, tap Send, TokenSelector shows cached token rows within 1s instead of skeleton.
- [x] iOS simulator: close and reopen Send token selector; cached rows render immediately again.
- [x] iOS simulator: revalidation can fail with a network/server error while cached rows remain visible.
