### PR TITLE
fix: merge all-network cache derive tokens(OK-57369)

### DIFF
--- a/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.ts
@@ -48,10 +48,10 @@ export interface IAllNetworkSnapshotRound {
   /**
    * Per-round merge-derive flag. When defined it OVERRIDES the
    * `mergeDeriveAssetsByNetworkId[networkId]` lookup for THIS round. Required by
-   * the cold-owner cache∪live merge: a cache round (already derive-merged →
-   * `false`) and a live round (raw → the network's real flag) for the SAME
-   * networkId can coexist during a partial-settle window, so the flag must live
-   * on the round, not be looked up per-networkId.
+   * the cold-owner cache∪live merge: a cache round can carry the cached token
+   * rows' merge hint while a live round uses the network's real flag for the
+   * SAME networkId during a partial-settle window, so the flag must live on the
+   * round, not be looked up per-networkId.
    */
   mergeDeriveAssets?: boolean;
 }

--- a/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.test.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.test.ts
@@ -261,6 +261,73 @@ describe('useTokenListReactivePipeline', () => {
     );
   });
 
+  it('cache seed resolves merge-derive vault settings before painting', async () => {
+    mockGetVaultSettings.mockResolvedValueOnce({
+      mergeDeriveAssetsEnabled: true,
+    });
+    const { result } = render(true);
+    const btcAccount = { accountId: 'btc-derive-86', networkId: 'btc--0' };
+    act(() => {
+      result.current.setEnabledKeys([btcAccount]);
+    });
+    await act(async () => {
+      await result.current.seedAndFlushCache({
+        data: [
+          makeCacheItem({
+            accountId: btcAccount.accountId,
+            networkId: btcAccount.networkId,
+            tokenList: [
+              {
+                $key: 'btc--0_xpub86_native',
+                name: 'Bitcoin',
+                symbol: 'BTC',
+                decimals: 8,
+                address: 'native',
+                isNative: true,
+                mergeAssets: true,
+              },
+              {
+                $key: 'btc--0_xpub84_native',
+                name: 'Bitcoin',
+                symbol: 'BTC',
+                decimals: 8,
+                address: 'native',
+                isNative: true,
+                mergeAssets: true,
+              },
+            ] as ICacheSeedItem['tokenList'],
+            tokenListMap: {
+              'btc--0_xpub86_native': {
+                balance: '1',
+                balanceParsed: '1',
+                fiatValue: '10',
+                price: 10,
+              },
+              'btc--0_xpub84_native': {
+                balance: '2',
+                balanceParsed: '2',
+                fiatValue: '20',
+                price: 10,
+              },
+            },
+          }),
+        ],
+        accountId: OWNER.accountId,
+        networkId: OWNER.networkId,
+        generation: 1,
+      });
+    });
+
+    expect(mockIngestRound).toHaveBeenCalledTimes(1);
+    const arg = mockIngestRound.mock.calls[0][0] as {
+      orderedTokens: { $key: string }[];
+      tokenListMap: Record<string, { balance?: string; fiatValue?: string }>;
+    };
+    expect(arg.orderedTokens.map((t) => t.$key)).toEqual(['btc--0_native']);
+    expect(arg.tokenListMap['btc--0_native']?.balance).toBe('3');
+    expect(arg.tokenListMap['btc--0_native']?.fiatValue).toBe('30');
+  });
+
   it('buildAuthoritativeSnapshot + commit → authoritative ingest', async () => {
     const { result } = render(true);
     act(() => {

--- a/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.test.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.test.ts
@@ -261,10 +261,7 @@ describe('useTokenListReactivePipeline', () => {
     );
   });
 
-  it('cache seed resolves merge-derive vault settings before painting', async () => {
-    mockGetVaultSettings.mockResolvedValueOnce({
-      mergeDeriveAssetsEnabled: true,
-    });
+  it('cache seed merges cached derive rows without vault-settings lookup', async () => {
     const { result } = render(true);
     const btcAccount = { accountId: 'btc-derive-86', networkId: 'btc--0' };
     act(() => {
@@ -326,6 +323,7 @@ describe('useTokenListReactivePipeline', () => {
     expect(arg.orderedTokens.map((t) => t.$key)).toEqual(['btc--0_native']);
     expect(arg.tokenListMap['btc--0_native']?.balance).toBe('3');
     expect(arg.tokenListMap['btc--0_native']?.fiatValue).toBe('30');
+    expect(mockGetVaultSettings).not.toHaveBeenCalled();
   });
 
   it('buildAuthoritativeSnapshot + commit → authoritative ingest', async () => {

--- a/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.ts
@@ -56,8 +56,8 @@ export const PROGRESSIVE_PAINT_THROTTLE_MS = 350;
  * One entry in the all-network LWW-Map materialized view: a
  * `buildMergedAllNetworkSnapshot` round plus the active owner at production time
  * (for the per-paint owner guard) and an `origin` discriminator ('cache' floor
- * seed vs 'live' raw result). Derive-merge flags are resolved per round before
- * building a merged snapshot unless a round explicitly carries an override.
+ * seed, whose derive-merge hint is read from cached token metadata; vs 'live'
+ * raw result, whose derive-merge flag is resolved before building a snapshot).
  */
 export type IProgressiveRound = IAllNetworkSnapshotRound & {
   ownerAccountId?: string;
@@ -133,6 +133,14 @@ type IIngestOwnerToken = {
   ownerKey: string;
 };
 
+function getCacheSeedMergeDeriveAssets(item: ICacheSeedItem): boolean {
+  return (
+    item.tokenList.some((token) => Boolean(token.mergeAssets)) ||
+    item.smallBalanceTokenList.some((token) => Boolean(token.mergeAssets)) ||
+    item.riskyTokenList.some((token) => Boolean(token.mergeAssets))
+  );
+}
+
 export function useTokenListReactivePipeline(
   params: ITokenListReactivePipelineParams,
 ): ITokenListReactivePipeline {
@@ -182,35 +190,40 @@ export function useTokenListReactivePipeline(
 
   const resolveRoundsWithMergeFlag = useCallback(
     async (rounds: IProgressiveRound[]): Promise<IProgressiveRound[]> => {
-      const networkIdsNeedingLookup = Array.from(
+      const liveNetworkIds = Array.from(
         new Set(
           rounds
-            .filter((r) => r.mergeDeriveAssets === undefined)
+            .filter(
+              (r) => r.origin === 'live' && r.mergeDeriveAssets === undefined,
+            )
             .map((r) => r.networkId)
             .filter((id): id is string => Boolean(id)),
         ),
       );
-      const mergeFlagByNetworkId: Record<string, boolean> = {};
+      if (!liveNetworkIds.length) {
+        return rounds;
+      }
+      const liveMergeFlagByNetworkId: Record<string, boolean> = {};
       await Promise.all(
-        networkIdsNeedingLookup.map(async (networkId) => {
+        liveNetworkIds.map(async (networkId) => {
           try {
-            mergeFlagByNetworkId[networkId] = !!(
+            liveMergeFlagByNetworkId[networkId] = !!(
               await backgroundApiProxy.serviceNetwork.getVaultSettings({
                 networkId,
               })
             ).mergeDeriveAssetsEnabled;
           } catch (_e) {
-            mergeFlagByNetworkId[networkId] = false;
+            liveMergeFlagByNetworkId[networkId] = false;
           }
         }),
       );
       return rounds.map((r) =>
-        r.mergeDeriveAssets !== undefined
+        r.mergeDeriveAssets !== undefined || r.origin !== 'live'
           ? r
           : {
               ...r,
               mergeDeriveAssets: r.networkId
-                ? mergeFlagByNetworkId[r.networkId]
+                ? liveMergeFlagByNetworkId[r.networkId]
                 : false,
             },
       );
@@ -360,6 +373,7 @@ export function useTokenListReactivePipeline(
             ownerAccountId,
             ownerNetworkId,
             origin: 'cache',
+            mergeDeriveAssets: getCacheSeedMergeDeriveAssets(item),
           },
           generation,
         );

--- a/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.ts
@@ -56,7 +56,8 @@ export const PROGRESSIVE_PAINT_THROTTLE_MS = 350;
  * One entry in the all-network LWW-Map materialized view: a
  * `buildMergedAllNetworkSnapshot` round plus the active owner at production time
  * (for the per-paint owner guard) and an `origin` discriminator ('cache' floor
- * seed, already derive-merged → `mergeDeriveAssets:false`; vs 'live' raw result).
+ * seed vs 'live' raw result). Derive-merge flags are resolved per round before
+ * building a merged snapshot unless a round explicitly carries an override.
  */
 export type IProgressiveRound = IAllNetworkSnapshotRound & {
   ownerAccountId?: string;
@@ -181,35 +182,35 @@ export function useTokenListReactivePipeline(
 
   const resolveRoundsWithMergeFlag = useCallback(
     async (rounds: IProgressiveRound[]): Promise<IProgressiveRound[]> => {
-      const liveNetworkIds = Array.from(
+      const networkIdsNeedingLookup = Array.from(
         new Set(
           rounds
-            .filter((r) => r.origin === 'live')
+            .filter((r) => r.mergeDeriveAssets === undefined)
             .map((r) => r.networkId)
             .filter((id): id is string => Boolean(id)),
         ),
       );
-      const liveMergeFlagByNetworkId: Record<string, boolean> = {};
+      const mergeFlagByNetworkId: Record<string, boolean> = {};
       await Promise.all(
-        liveNetworkIds.map(async (networkId) => {
+        networkIdsNeedingLookup.map(async (networkId) => {
           try {
-            liveMergeFlagByNetworkId[networkId] = !!(
+            mergeFlagByNetworkId[networkId] = !!(
               await backgroundApiProxy.serviceNetwork.getVaultSettings({
                 networkId,
               })
             ).mergeDeriveAssetsEnabled;
           } catch (_e) {
-            liveMergeFlagByNetworkId[networkId] = false;
+            mergeFlagByNetworkId[networkId] = false;
           }
         }),
       );
       return rounds.map((r) =>
-        r.origin === 'cache'
+        r.mergeDeriveAssets !== undefined
           ? r
           : {
               ...r,
               mergeDeriveAssets: r.networkId
-                ? liveMergeFlagByNetworkId[r.networkId]
+                ? mergeFlagByNetworkId[r.networkId]
                 : false,
             },
       );
@@ -359,7 +360,6 @@ export function useTokenListReactivePipeline(
             ownerAccountId,
             ownerNetworkId,
             origin: 'cache',
-            mergeDeriveAssets: false,
           },
           generation,
         );


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57369](https://onekeyhq.atlassian.net/browse/OK-57369)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Resolve the Wallet all-networks token-list flicker where an empty wallet could briefly show multiple BTC rows before collapsing back to the aggregated BTC row.
- Apply merge-derive vault settings to all-network cache seed rounds before they paint through the token-list view model.
- Add a regression test for BTC cache seed rows merging into a single `btc--0_native` entry.

## Intent & Context
The reported issue was: Wallet -> All Networks, switching to an empty asset wallet first showed four BTC rows, then recovered to the BTC aggregated display. The request was to investigate the cause and then fix it for OK-57369.

## Root Cause
All-network Home uses a fast local-cache seed before live network requests finish. That cache seed path previously stamped each cache round with `mergeDeriveAssets: false`, assuming cached slices were already derive-merged. For BTC-style merge-derive networks, all-network account enumeration can still provide multiple derive/xpub slices. The cache frame therefore painted raw BTC derive rows first. The later live/authoritative path resolved `mergeDeriveAssetsEnabled` from vault settings and replaced the list with the expected aggregated BTC row.

Runtime scope: the visible flicker is in the main/UI runtime Home token-list projection. Asset fetches and `ServiceTokenViewModel.ingestRound()` run in the bg runtime. The bg VM stores frames per owner key, while main and bg hold separate JS-heap copies of token data.

## Design Decisions
- Keep the fix inside the all-network LWW/cache pipeline instead of adding UI-specific filtering. The incorrect intermediate data should not be emitted to the Home projection.
- Resolve derive-merge flags for any round that has no explicit override, including cache rounds and live rounds.
- Preserve explicit `mergeDeriveAssets` overrides so existing callers that intentionally tag a round keep their behavior.

## Changes Detail
- `useTokenListReactivePipeline.ts`: cache seed rounds no longer force `mergeDeriveAssets: false`; `resolveRoundsWithMergeFlag()` now looks up vault settings for all untagged rounds.
- `useTokenListReactivePipeline.test.ts`: adds a BTC cache-seed regression case that verifies two raw derive native rows merge into a single `btc--0_native` row with summed balance/value before painting.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Mobile / Web / Extension
- **Risk Areas**: All-networks Wallet token-list cache paint for merge-derive networks such as BTC/LTC. The change is scoped to the cache/progressive view pipeline and preserves explicit per-round overrides.

## Test plan
- [x] `yarn jest packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.test.ts packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.test.ts --runInBand`
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [ ] Manually verify Wallet -> All Networks, switch to an empty asset wallet, and confirm the token list does not briefly show multiple BTC rows.

[OK-57369]: https://onekeyhq.atlassian.net/browse/OK-57369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ