### PR TITLE
fix Intercom language override OK-57320

### DIFF
--- a/packages/shared/src/modules3rdParty/intercom/index.native.ts
+++ b/packages/shared/src/modules3rdParty/intercom/index.native.ts
@@ -1,6 +1,11 @@
 import openUrlUtils from '../../utils/openUrlUtils';
 
-import { buildIntercomUrl, getCustomerJWT, getInstanceId } from './utils';
+import {
+  buildIntercomUrl,
+  getCustomerJWT,
+  getInstanceId,
+  getIntercomLanguageOverride,
+} from './utils';
 
 export const initIntercom = async () => {
   console.log('initIntercom');
@@ -9,6 +14,7 @@ export const initIntercom = async () => {
 export const showIntercom = async (params?: { requestId?: string }) => {
   const token = await getCustomerJWT();
   const instanceId = await getInstanceId();
+  const languageOverride = await getIntercomLanguageOverride();
 
   const supportUrl = 'https://intercom.onekey.so/';
 
@@ -16,6 +22,7 @@ export const showIntercom = async (params?: { requestId?: string }) => {
     token,
     instanceId,
     requestId: params?.requestId,
+    languageOverride,
   });
 
   openUrlUtils.openUrlInApp(url, 'Support');

--- a/packages/shared/src/modules3rdParty/intercom/index.ts
+++ b/packages/shared/src/modules3rdParty/intercom/index.ts
@@ -1,4 +1,8 @@
-import { getCustomerJWT, getInstanceId } from './utils';
+import {
+  getCustomerJWT,
+  getInstanceId,
+  getIntercomLanguageOverride,
+} from './utils';
 
 import type { InitType } from '@intercom/messenger-js-sdk/dist/types';
 
@@ -43,6 +47,8 @@ export const initIntercom = async (settings?: Partial<InitType>) => {
 
     const APP_ID =
       settings?.app_id || process.env.INTERCOM_APP_ID || 'vbbj4ssb';
+    const languageOverride =
+      settings?.language_override || (await getIntercomLanguageOverride());
 
     // Clear previous session's openOnBoot state to prevent auto-opening messenger on cold start
     clearIntercomOpenOnBoot(APP_ID);
@@ -53,6 +59,7 @@ export const initIntercom = async (settings?: Partial<InitType>) => {
       alignment: 'right',
       horizontal_padding: 10,
       vertical_padding: 55,
+      ...(languageOverride ? { language_override: languageOverride } : {}),
       ...settings,
     });
 
@@ -78,13 +85,20 @@ export const initIntercom = async (settings?: Partial<InitType>) => {
 
 export const showIntercom = async (params?: { requestId?: string }) => {
   await initIntercom();
-  const { show, trackEvent } = await loadIntercomSdk();
+  const { show, trackEvent, update: updateIntercom } = await loadIntercomSdk();
   const instanceIdValue = await getInstanceId();
+  const languageOverride = await getIntercomLanguageOverride();
 
   trackEvent('client info', {
     instanceId: instanceIdValue,
     requestId: params?.requestId,
   });
+
+  if (languageOverride) {
+    updateIntercom({
+      language_override: languageOverride,
+    });
+  }
 
   show();
 };

--- a/packages/shared/src/modules3rdParty/intercom/utils.ts
+++ b/packages/shared/src/modules3rdParty/intercom/utils.ts
@@ -1,5 +1,60 @@
 import appGlobals from '../../appGlobals';
 
+const INTERCOM_LANGUAGE_OVERRIDES: Record<string, string> = {
+  bn: 'bn',
+  de: 'de',
+  en: 'en',
+  'en-us': 'en',
+  es: 'es',
+  fr: 'fr',
+  'fr-fr': 'fr',
+  hi: 'hi',
+  'hi-in': 'hi',
+  id: 'id',
+  it: 'it',
+  'it-it': 'it',
+  ja: 'ja',
+  'ja-jp': 'ja',
+  ko: 'ko',
+  'ko-kr': 'ko',
+  pt: 'pt',
+  'pt-br': 'pt-BR',
+  ru: 'ru',
+  th: 'th',
+  'th-th': 'th',
+  uk: 'uk',
+  'uk-ua': 'uk',
+  vi: 'vi',
+  zh: 'zh-CN',
+  'zh-cn': 'zh-CN',
+  'zh-hans': 'zh-CN',
+  'zh-hk': 'zh-TW',
+  'zh-hant': 'zh-TW',
+  'zh-tw': 'zh-TW',
+};
+
+export const toIntercomLanguageOverride = (
+  locale: string | null | undefined,
+): string => {
+  const normalizedLocale = locale?.trim().replace(/_/g, '-');
+
+  if (
+    !normalizedLocale ||
+    ['null', 'undefined'].includes(normalizedLocale.toLowerCase())
+  ) {
+    return 'en';
+  }
+
+  const localeKey = normalizedLocale.toLowerCase();
+  const languageKey = localeKey.split('-')[0];
+
+  return (
+    INTERCOM_LANGUAGE_OVERRIDES[localeKey] ??
+    INTERCOM_LANGUAGE_OVERRIDES[languageKey] ??
+    'en'
+  );
+};
+
 export const getCustomerJWT = async (): Promise<string | undefined> => {
   try {
     // Use appGlobals to access backgroundApiProxy instead of direct import
@@ -44,12 +99,33 @@ export const getInstanceId = async (): Promise<string | undefined> => {
   return undefined;
 };
 
+export const getCurrentLocale = async (): Promise<string | undefined> => {
+  try {
+    const backgroundApiProxy = appGlobals.$backgroundApiProxy;
+
+    if (!backgroundApiProxy) {
+      console.warn('backgroundApiProxy not available for current locale');
+      return undefined;
+    }
+
+    return await backgroundApiProxy.serviceSetting.getCurrentLocale();
+  } catch (error) {
+    console.warn('Failed to get current locale for Intercom:', error);
+  }
+
+  return undefined;
+};
+
+export const getIntercomLanguageOverride = async (): Promise<string> =>
+  toIntercomLanguageOverride(await getCurrentLocale());
+
 export const buildIntercomUrl = (
   baseUrl: string,
   params?: {
     token?: string;
     instanceId?: string;
     requestId?: string;
+    languageOverride?: string;
   },
 ): string => {
   let url = baseUrl;
@@ -70,6 +146,13 @@ export const buildIntercomUrl = (
   if (params?.requestId) {
     const separator = url.includes('?') ? '&' : '?';
     url += `${separator}requestId=${encodeURIComponent(params.requestId)}`;
+  }
+
+  if (params?.languageOverride) {
+    const separator = url.includes('?') ? '&' : '?';
+    url += `${separator}language_override=${encodeURIComponent(
+      params.languageOverride,
+    )}`;
   }
 
   return url;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57320](https://onekeyhq.atlassian.net/browse/OK-57320)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

Fixes OK-57320 for the app-side Intercom integration.

- Maps the current app locale to Intercom-supported `language_override` values.
- Passes `language_override` into the mobile Intercom webview URL.
- Applies `language_override` during web Intercom boot and updates it before showing Messenger.

## Impact

Support Messenger now follows the app-selected locale instead of relying only on browser or system language detection.

## Validation

- `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/shared/src/modules3rdParty/intercom --deny-warnings`

[OK-57320]: https://onekeyhq.atlassian.net/browse/OK-57320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ