### PR TITLE
fix: prevent all-network BTC asset hiding(OK-57370)

### DIFF
--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -1211,12 +1211,13 @@ function TokenListBlock({
       accountId?: string;
       networkId?: string;
     }) => {
-      if (accountId && networkId) {
-        void backgroundApiProxy.serviceToken.updateCurrentAccount({
-          accountId,
-          networkId,
-        });
-      }
+      const updateCurrentAccountTask =
+        accountId && networkId
+          ? backgroundApiProxy.serviceToken.updateCurrentAccount({
+              accountId,
+              networkId,
+            })
+          : Promise.resolve();
 
       perfTokenListView.markStart('allNetworkRequestsStarted_getRawData');
 
@@ -1226,6 +1227,7 @@ function TokenListBlock({
         backgroundApiProxy.simpleDb.riskTokenManagement.getRawData(),
         backgroundApiProxy.simpleDb.localTokens.getRawData(),
         backgroundApiProxy.simpleDb.aggregateToken.getRawData(),
+        updateCurrentAccountTask,
       ]);
 
       perfTokenListView.markEnd('allNetworkRequestsStarted_getRawData');

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -1211,6 +1211,13 @@ function TokenListBlock({
       accountId?: string;
       networkId?: string;
     }) => {
+      if (accountId && networkId) {
+        await backgroundApiProxy.serviceToken.updateCurrentAccount({
+          accountId,
+          networkId,
+        });
+      }
+
       perfTokenListView.markStart('allNetworkRequestsStarted_getRawData');
 
       // eslint-disable-next-line prefer-const

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -1212,7 +1212,7 @@ function TokenListBlock({
       networkId?: string;
     }) => {
       if (accountId && networkId) {
-        await backgroundApiProxy.serviceToken.updateCurrentAccount({
+        void backgroundApiProxy.serviceToken.updateCurrentAccount({
           accountId,
           networkId,
         });

--- a/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.test.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.test.ts
@@ -8,6 +8,7 @@
  */
 import BigNumber from 'bignumber.js';
 
+import { TOKEN_LIST_HIGH_VALUE_MAX } from '@onekeyhq/shared/src/consts/walletConsts';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import type { IAccountToken, ITokenFiat } from '@onekeyhq/shared/types/token';
 
@@ -227,5 +228,92 @@ describe('buildMergedAllNetworkSnapshot', () => {
     expect(snap.orderedTokens.map((t) => t.$key)).toEqual([
       'btc--0_xpubabc_native',
     ]);
+  });
+
+  it('uses aggregate fiat when partitioning the zero-value tail', () => {
+    const aggregateBtc = makeToken('aggregate_BTC_', {
+      symbol: 'BTC',
+      isAggregateToken: true,
+      order: 2,
+    });
+    const zeroToken = makeToken('zero', { order: 1 });
+
+    const snap = buildMergedAllNetworkSnapshot({
+      rounds: [
+        makeRound({
+          networkId: 'btc--0',
+          tokens: {
+            data: [aggregateBtc, zeroToken],
+            keys: 'kbtc',
+            map: { zero: makeFiat('0') },
+          },
+          aggregateTokenMap: {
+            aggregate_BTC_: makeFiat('100', {
+              balance: '1',
+              balanceParsed: '1',
+            }),
+          },
+          aggregateTokenListMap: {
+            aggregate_BTC_: {
+              tokens: [makeToken('btc-sub', { networkId: 'btc--0' })],
+            },
+          },
+        }),
+      ],
+      mergeDeriveAssetsByNetworkId: {},
+      accountId: 'acc1',
+    });
+
+    expect(snap.orderedTokens.map((t) => t.$key)).toEqual([
+      'aggregate_BTC_',
+      'zero',
+    ]);
+  });
+
+  it('includes aggregate fiat in the small-balance scalar', () => {
+    const highValueTokens = Array.from(
+      { length: TOKEN_LIST_HIGH_VALUE_MAX },
+      (_, index) => makeToken(`token-${index}`),
+    );
+    const aggregateBtc = makeToken('aggregate_BTC_', {
+      symbol: 'BTC',
+      isAggregateToken: true,
+    });
+
+    const snap = buildMergedAllNetworkSnapshot({
+      rounds: [
+        makeRound({
+          networkId: 'btc--0',
+          tokens: {
+            data: [...highValueTokens, aggregateBtc],
+            keys: 'kbtc',
+            map: Object.fromEntries(
+              highValueTokens.map((token, index) => [
+                token.$key,
+                makeFiat(`${TOKEN_LIST_HIGH_VALUE_MAX - index + 1}`),
+              ]),
+            ),
+          },
+          aggregateTokenMap: {
+            aggregate_BTC_: makeFiat('1', {
+              balance: '0.01',
+              balanceParsed: '0.01',
+            }),
+          },
+          aggregateTokenListMap: {
+            aggregate_BTC_: {
+              tokens: [makeToken('btc-sub', { networkId: 'btc--0' })],
+            },
+          },
+        }),
+      ],
+      mergeDeriveAssetsByNetworkId: {},
+      accountId: 'acc1',
+    });
+
+    expect(snap.smallBalanceTokens.map((t) => t.$key)).toEqual([
+      'aggregate_BTC_',
+    ]);
+    expect(snap.smallBalanceFiatValue).toBe('1');
   });
 });

--- a/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.ts
@@ -233,17 +233,18 @@ export function buildMergedAllNetworkSnapshot({
   };
 
   const flattenAggregateTokenMap = flattenAggregateTokensMap(aggregateTokenMap);
+  const displayTokenFiatMap = {
+    ...mergeTokenListMap,
+    ...flattenAggregateTokenMap,
+  };
 
   let mergedTokens = sortTokensByFiatValue({
     tokens: [...tokenList.tokens, ...smallBalanceTokenList.smallBalanceTokens],
-    map: {
-      ...mergeTokenListMap,
-      ...flattenAggregateTokenMap,
-    },
+    map: displayTokenFiatMap,
   });
 
   const index = mergedTokens.findIndex((token) =>
-    isUnavailableOrZeroFiatValue(mergeTokenListMap[token.$key]?.fiatValue),
+    isUnavailableOrZeroFiatValue(displayTokenFiatMap[token.$key]?.fiatValue),
   );
 
   if (index > -1) {
@@ -265,7 +266,7 @@ export function buildMergedAllNetworkSnapshot({
 
   smallBalanceTokensFiatValue = sumFiatValuesFromTokens(
     smallBalanceTokenList.smallBalanceTokens,
-    mergeTokenListMap,
+    displayTokenFiatMap,
   );
 
   riskyTokenList.riskyTokens = sortTokensByFiatValue({


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57370](https://onekeyhq.atlassian.net/browse/OK-57370)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Await Token service current-account synchronization before all-network token fan-out starts.
- Use aggregate-aware fiat values when partitioning all-network token rows and calculating the small-balance scalar.
- Add regression coverage for aggregate BTC rows in all-network snapshot merging.

## Intent & Context
The reported issue was that on iOS, after switching accounts in All Networks, an account with BTC could briefly show the correct BTC asset and then hide it after a delay. The issue was hard to reproduce and appeared probabilistic, so this PR applies defensive hardening to the all-network Home token pipeline rather than relying on a narrow reproduction.

## Root Cause
Two risk paths were identified during investigation:

1. The Token all-network fan-out could start before the background Token service current account/network was explicitly awaited. ServiceToken uses its bg runtime current network guard for all-network requests, while the previous Token path only fired updateCurrentAccount from init as a fire-and-forget RPC.
2. buildMergedAllNetworkSnapshot sorted rows with aggregate fiat included, but its zero/unavailable tail partition and small-balance scalar used only the normal token fiat map. Aggregate rows such as BTC can store fiat in the flattened aggregate map, so they could be treated as zero/unavailable during the final authoritative snapshot.

## Design Decisions
- Followed the existing DeFi all-network pattern by awaiting current-account synchronization in onStarted before fan-out work continues.
- Kept the snapshot merge shape unchanged and introduced a local displayTokenFiatMap that combines normal token fiat with flattened aggregate fiat for display-only partitioning and scalar calculation.
- Added pure-function tests instead of UI-level tests because the issue is intermittent and the deterministic risk is in snapshot projection logic.

## Changes Detail
- packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx: await serviceToken.updateCurrentAccount in all-network request startup.
- packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.ts: use aggregate-aware fiat when sorting partition boundaries and calculating small-balance fiat.
- packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.test.ts: cover aggregate BTC row partitioning and small-balance fiat scalar behavior.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile, Desktop, Web, Extension
- **Risk Areas**: Home Token list in All Networks, especially aggregate assets and account-switch refresh timing. The most visible target is iOS because its token fan-out concurrency is higher, but the merge correction is shared by all platforms.

## Test plan
- [x] yarn jest packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.test.ts --runInBand
- [x] yarn tsc:staged
- [x] npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.ts packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.test.ts

[OK-57370]: https://onekeyhq.atlassian.net/browse/OK-57370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ