### PR TITLE
fix: reset reward center account on open

### DIFF
--- a/packages/kit/src/views/RewardCenter/pages/RewardCenter.tsx
+++ b/packages/kit/src/views/RewardCenter/pages/RewardCenter.tsx
@@ -291,10 +291,10 @@ function RewardCenterDetails() {
             body: {
               method: 'get',
               url: '/api/account',
-              data: {},
-              params: {
+              data: {
                 fromAddress: account.address,
               },
+              params: {},
             },
             returnRawData: true,
           });

--- a/packages/kit/src/views/RewardCenter/pages/RewardCenter.tsx
+++ b/packages/kit/src/views/RewardCenter/pages/RewardCenter.tsx
@@ -1,5 +1,11 @@
 // cspell:ignore Actived
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import { useRoute } from '@react-navigation/core';
 import BigNumber from 'bignumber.js';
@@ -61,7 +67,11 @@ import type { RouteProp } from '@react-navigation/core';
 
 const networkIdsMap = getNetworkIdsMap();
 
-function RewardCenterDetails() {
+function RewardCenterDetails({
+  selectorSceneUrl,
+}: {
+  selectorSceneUrl: string;
+}) {
   const route =
     useRoute<
       RouteProp<
@@ -73,7 +83,6 @@ function RewardCenterDetails() {
   const {
     accountId,
     networkId,
-    walletId,
     onClose,
     showAccountSelector = true,
   } = route?.params ?? {};
@@ -88,7 +97,6 @@ function RewardCenterDetails() {
   });
 
   const { activeAccount } = useActiveAccount({ num: 0 });
-  const { confirmAccountSelect } = useAccountSelectorActions().current;
 
   const navigation = useAppNavigation();
 
@@ -494,58 +502,6 @@ function RewardCenterDetails() {
     }
   }, [account, claimSource, form, intl, network]);
 
-  useEffect(() => {
-    const initActiveAccount = async () => {
-      const [initAccount, initWallet] = await Promise.all([
-        accountId && networkId
-          ? backgroundApiProxy.serviceAccount.getAccount({
-              accountId,
-              networkId,
-            })
-          : undefined,
-        walletId
-          ? backgroundApiProxy.serviceAccount.getWallet({
-              walletId,
-            })
-          : undefined,
-      ]);
-
-      const isOthersAccount = accountUtils.isOthersAccount({
-        accountId,
-      });
-      if (isOthersAccount) {
-        let autoChangeToAccountMatchedNetworkId = networkId;
-        if (
-          networkId &&
-          networkUtils.isAllNetwork({
-            networkId,
-          })
-        ) {
-          autoChangeToAccountMatchedNetworkId = networkId;
-        }
-        await confirmAccountSelect({
-          num: 0,
-          indexedAccount: undefined,
-          othersWalletAccount: initAccount,
-          autoChangeToAccountMatchedNetworkId,
-        });
-      } else if (initWallet) {
-        const indexedAccount =
-          await backgroundApiProxy.serviceAccount.getIndexedAccountByAccount({
-            account: initAccount,
-          });
-        await confirmAccountSelect({
-          num: 0,
-          indexedAccount,
-          othersWalletAccount: undefined,
-          autoChangeToAccountMatchedNetworkId: undefined,
-        });
-      }
-    };
-
-    void initActiveAccount();
-  }, [accountId, confirmAccountSelect, networkId, walletId]);
-
   useEffect(
     () => () => void onClose?.({ isResourceClaimed, isResourceRedeemed }),
     [onClose, isResourceClaimed, isResourceRedeemed],
@@ -913,13 +869,14 @@ function RewardCenterDetails() {
       <AccountSelectorProviderMirror
         config={{
           sceneName: EAccountSelectorSceneName.rewardCenter,
+          sceneUrl: selectorSceneUrl,
         }}
         enabledNum={[0]}
       >
         <AccountSelectorTriggerRewardCenter num={0} />
       </AccountSelectorProviderMirror>
     );
-  }, [showAccountSelector]);
+  }, [selectorSceneUrl, showAccountSelector]);
 
   const renderHeaderLeft = useCallback(() => {
     if (showAccountSelector) {
@@ -974,15 +931,156 @@ function RewardCenterDetails() {
   );
 }
 
+function RewardCenterAccountSelectorSync({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const route =
+    useRoute<
+      RouteProp<
+        IModalRewardCenterParamList,
+        EModalRewardCenterRoutes.RewardCenter
+      >
+    >();
+
+  const {
+    accountId,
+    networkId,
+    walletId,
+    showAccountSelector = true,
+  } = route?.params ?? {};
+
+  const actions = useAccountSelectorActions();
+  const [isReady, setIsReady] = useState(!showAccountSelector);
+  const targetWalletId =
+    walletId ||
+    (accountId
+      ? accountUtils.getWalletIdFromAccountId({
+          accountId,
+        })
+      : undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const syncAccountSelector = async () => {
+      if (!showAccountSelector || !accountId || !networkId) {
+        setIsReady(true);
+        return;
+      }
+
+      setIsReady(false);
+      try {
+        const [initAccount, initWallet] = await Promise.all([
+          backgroundApiProxy.serviceAccount.getAccount({
+            accountId,
+            networkId,
+          }),
+          targetWalletId
+            ? backgroundApiProxy.serviceAccount.getWallet({
+                walletId: targetWalletId,
+              })
+            : undefined,
+        ]);
+
+        if (cancelled) {
+          return;
+        }
+
+        await actions.current.waitForAutoSelectUnlock();
+        if (cancelled) {
+          return;
+        }
+
+        if (
+          accountUtils.isOthersAccount({
+            accountId,
+          })
+        ) {
+          await actions.current.confirmAccountSelect({
+            num: 0,
+            indexedAccount: undefined,
+            othersWalletAccount: initAccount,
+            forceSelectToNetworkId: networkId,
+          });
+        } else if (initWallet) {
+          const indexedAccount =
+            await backgroundApiProxy.serviceAccount.getIndexedAccountByAccount({
+              account: initAccount,
+            });
+          if (cancelled) {
+            return;
+          }
+          await actions.current.confirmAccountSelect({
+            num: 0,
+            indexedAccount,
+            othersWalletAccount: undefined,
+            forceSelectToNetworkId: networkId,
+          });
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        if (targetWalletId) {
+          await actions.current.updateSelectedAccountFocusedWallet({
+            num: 0,
+            focusedWallet: targetWalletId,
+          });
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        const selectedAccount = actions.current.getSelectedAccount({
+          num: 0,
+        });
+        await actions.current.reloadActiveAccountInfo({
+          num: 0,
+          selectedAccount,
+        });
+      } catch (_error) {
+        // ignore account selector sync errors and let the page render fallback states
+      } finally {
+        if (!cancelled) {
+          setIsReady(true);
+        }
+      }
+    };
+
+    void syncAccountSelector();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [accountId, actions, networkId, showAccountSelector, targetWalletId]);
+
+  if (!isReady) {
+    return null;
+  }
+
+  return children;
+}
+
 function RewardCenter() {
+  const selectorSceneUrlRef = useRef<string | undefined>(undefined);
+  selectorSceneUrlRef.current ??= `reward-center-${Date.now()}-${Math.random()}`;
+  const selectorSceneUrl = selectorSceneUrlRef.current;
+
   return (
     <AccountSelectorProviderMirror
       config={{
         sceneName: EAccountSelectorSceneName.rewardCenter,
+        sceneUrl: selectorSceneUrl,
       }}
       enabledNum={[0]}
     >
-      <RewardCenterDetails />
+      <RewardCenterAccountSelectorSync>
+        <RewardCenterDetails selectorSceneUrl={selectorSceneUrl} />
+      </RewardCenterAccountSelectorSync>
     </AccountSelectorProviderMirror>
   );
 }

--- a/packages/shared/src/utils/accountSelectorUtils.ts
+++ b/packages/shared/src/utils/accountSelectorUtils.ts
@@ -49,6 +49,10 @@ function buildAccountSelectorSceneId({
     return `${sceneName}--${origin}`;
   }
 
+  if (sceneName === EAccountSelectorSceneName.rewardCenter && sceneUrl) {
+    return `${sceneName}--${sceneUrl}`;
+  }
+
   if (!sceneName) {
     throw new OneKeyLocalError('buildSceneId ERROR: sceneName is required');
   }
@@ -126,6 +130,7 @@ function isSceneCanPersist({
     [
       EAccountSelectorSceneName.discover,
       EAccountSelectorSceneName.addressInput,
+      EAccountSelectorSceneName.rewardCenter,
     ].includes(sceneName)
   ) {
     return false;


### PR DESCRIPTION
## Summary
- Reset the RewardCenter account selector from the launching home account each time the modal opens.
- Make RewardCenter account selector state non-persistent and scoped per modal instance.
- Send the TRON reward `/api/account` request address in the request body instead of query params.

## Intent & Context
The RewardCenter modal was expected to open with the wallet account currently selected on Home. The reported reproduction was: Home shows account 1, open the free energy modal, switch the modal selector to account 666, close the modal, Home still shows account 1, then reopen the free energy modal and it still shows account 666. The modal account switch should only affect the current RewardCenter session, not the next open from Home.

## Root Cause
RewardCenter used its own stable `rewardCenter` account selector scene. When the user selected account 666 inside the modal, that scene persisted the selection and reused the same in-memory/store state on the next open. Because Home and RewardCenter use separate selector scenes, closing the modal did not update Home, but reopening restored RewardCenter's previous account instead of the Home account that launched it.

The TRON account activation check also sent `fromAddress` as query params for `/api/account`; the endpoint expects it in the request body.

## Design Decisions
RewardCenter now creates a per-open selector scene key and initializes that temporary selector from the route account before rendering the modal content. The `rewardCenter` scene is also marked non-persistent, so account switches inside the modal remain local to that modal instance.

This was chosen over only forcing the account after mount because the old persistent scene could still render or restore stale state before the override. A transient per-open context matches the product behavior: RewardCenter opens from Home, while modal-local account changes are temporary.

## Changes Detail
- `packages/kit/src/views/RewardCenter/pages/RewardCenter.tsx`
  - Adds a RewardCenter selector sync wrapper that initializes from `accountId/networkId/walletId`.
  - Uses `forceSelectToNetworkId` so the modal opens on the launching TRON network.
  - Uses a per-open `sceneUrl` for the RewardCenter selector provider and header trigger.
  - Moves `fromAddress` into the `/api/account` request body.
- `packages/shared/src/utils/accountSelectorUtils.ts`
  - Allows RewardCenter selector stores to be keyed by `sceneUrl`.
  - Prevents RewardCenter selector selections from being persisted to account selector storage.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Account selector scene lifecycle and RewardCenter modal initialization. The change is scoped to RewardCenter, but account selector utility behavior now treats `rewardCenter` as non-persistent.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [ ] On Home with account 1 selected, open the free energy modal and confirm account 1 is selected.
- [ ] Switch the modal account to account 666, close it, and confirm Home still shows account 1.
- [ ] Reopen the free energy modal and confirm it selects account 1 again.
- [ ] Verify claiming/redeeming still uses the currently selected modal account.
