### PR TITLE
fix: restore hidden wallet fallback selection(OK-57468)

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccountSelector.ts
+++ b/packages/kit-bg/src/services/ServiceAccountSelector.ts
@@ -420,6 +420,30 @@ class ServiceAccountSelector extends ServiceBase {
       isNetworkNotMatched,
     };
 
+    defaultLogger.accountSelector.listData.buildActiveAccountInfoResult({
+      selectedWalletId: walletId,
+      selectedIndexedAccountId: indexedAccountId,
+      selectedNetworkId: networkId,
+      selectedDeriveType: deriveType,
+      walletId: wallet?.id,
+      indexedAccountId: indexedAccount?.id,
+      networkId: network?.id,
+      deriveType,
+      hasWallet: Boolean(wallet),
+      isWalletUnusable,
+      hasIndexedAccount: Boolean(indexedAccount),
+      hasAccount: Boolean(account),
+      hasDbAccount: Boolean(dbAccount),
+      hasDevice: Boolean(device),
+      hasNetwork: Boolean(network),
+      isAllNetwork,
+      isOthersWallet,
+      canCreateAddress,
+      isNetworkNotMatched,
+      deriveInfoItemsLength: deriveInfoItems.length,
+      ready: activeAccount.ready,
+    });
+
     // const activeAccount0: IAccountSelectorActiveAccountInfo = {
     //   account: undefined,
     //   indexedAccount: undefined,

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
@@ -903,6 +903,59 @@ describe('useAccountSelectorActions', () => {
     });
   });
 
+  it('clears a restored mocked hardware wallet selection during storage init', async () => {
+    const staleSelection = {
+      ...defaultSelectedAccount(),
+      walletId: 'hw-standard',
+      indexedAccountId: 'hw-standard--0',
+      networkId: 'onekeyall',
+      deriveType: 'default' as const,
+      focusedWallet: 'hw-standard',
+    };
+    const mockedStandardWallet = {
+      id: 'hw-standard',
+      name: 'Standard wallet',
+      isMocked: true,
+    } as IWallet;
+
+    mockGetSelectedAccountsMap.mockResolvedValue({
+      0: staleSelection,
+    });
+    mockGetWalletSafe.mockResolvedValue(mockedStandardWallet);
+
+    const { store, Wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.initFromStorage({
+        sceneName: EAccountSelectorSceneName.home,
+      });
+    });
+
+    expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+      walletId: undefined,
+      focusedWallet: undefined,
+      indexedAccountId: undefined,
+      othersWalletAccountId: undefined,
+      networkId: 'onekeyall',
+    });
+    expect(mockSaveSelectedAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sceneName: EAccountSelectorSceneName.home,
+        num: 0,
+        selectedAccount: expect.objectContaining({
+          walletId: undefined,
+          focusedWallet: undefined,
+          indexedAccountId: undefined,
+          othersWalletAccountId: undefined,
+          networkId: 'onekeyall',
+        }),
+      }),
+    );
+  });
+
   it('preserves concurrent fields while resolving an others wallet network switch', async () => {
     const currentEvmAccount = {
       id: 'imported--evm-account',

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
@@ -7,6 +7,7 @@ import { createStore } from 'jotai';
 
 import type { IDBAccount } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import { EAppSyncStorageKeys } from '@onekeyhq/shared/src/storage/syncStorageKeys';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import { useAccountSelectorActions } from './actions';
@@ -86,6 +87,13 @@ const mockIsDeriveTypeAvailableForNetwork: jest.MockedFunction<
 > = jest.fn();
 const mockShouldSyncHomeAndSwapSelectedAccount: jest.MockedFunction<
   () => Promise<boolean>
+> = jest.fn();
+const mockClearAccountCache: jest.MockedFunction<() => Promise<void>> =
+  jest.fn();
+const mockGetAllHdHwQrWallets: jest.MockedFunction<
+  () => Promise<{
+    wallets: IWallet[];
+  }>
 > = jest.fn();
 const mockIsWalletHasIndexedAccounts: jest.MockedFunction<
   ({ walletId }: { walletId: string }) => Promise<boolean>
@@ -183,6 +191,8 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
   __esModule: true,
   default: {
     serviceAccount: {
+      clearAccountCache: () => mockClearAccountCache(),
+      getAllHdHwQrWallets: () => mockGetAllHdHwQrWallets(),
       getIndexedAccountsOfWallet: ({ walletId }: { walletId: string }) =>
         mockGetIndexedAccountsOfWallet({ walletId }),
       getSingletonAccountsOfWallet: ({
@@ -290,6 +300,7 @@ function getRecentSelectionCache() {
 describe('useAccountSelectorActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(timerUtils, 'wait').mockResolvedValue(undefined);
     mockColdStartCacheStorageData.clear();
     mockBuildActiveAccountInfoFromSelectedAccount.mockResolvedValue({
       activeAccount: {
@@ -308,6 +319,8 @@ describe('useAccountSelectorActions', () => {
     mockIsDeriveTypeAvailableForNetwork.mockResolvedValue(true);
     mockShouldSyncHomeAndSwapSelectedAccount.mockResolvedValue(false);
     mockShouldSyncWithHomeSource.mockResolvedValue(false);
+    mockClearAccountCache.mockResolvedValue(undefined);
+    mockGetAllHdHwQrWallets.mockResolvedValue({ wallets: [] });
     mockIsWalletHasIndexedAccounts.mockResolvedValue(true);
     mockGetDBAccount.mockResolvedValue(undefined);
     mockGetIndexedAccountsOfWallet.mockResolvedValue({
@@ -318,6 +331,10 @@ describe('useAccountSelectorActions', () => {
     });
     mockGetSingletonAccountsOfWallet.mockResolvedValue({ accounts: [] });
     mockGetWalletSafe.mockResolvedValue({ id: 'hd-1' } as IWallet);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('marks active account init done when reload finishes before storage init', async () => {
@@ -1103,6 +1120,61 @@ describe('useAccountSelectorActions', () => {
       walletId: 'hd-1',
       indexedAccountId: 'hd-1--0',
       focusedWallet: 'hd-1',
+    });
+  });
+
+  it('selects an empty hardware wallet after a hidden wallet becomes unavailable', async () => {
+    const hiddenWalletSelection = {
+      ...defaultSelectedAccount(),
+      walletId: 'hw-standard--hidden',
+      indexedAccountId: 'hw-standard--hidden-indexed-1',
+      networkId: 'onekeyall',
+      deriveType: 'default' as const,
+      focusedWallet: 'hw-standard--hidden',
+    };
+    const standardWallet = {
+      id: 'hw-standard',
+      name: 'Standard wallet',
+    } as IWallet;
+
+    mockGetAllHdHwQrWallets.mockResolvedValue({
+      wallets: [standardWallet],
+    });
+    mockIsWalletHasIndexedAccounts.mockResolvedValue(false);
+    mockGetIndexedAccountsOfWallet.mockResolvedValue({ accounts: [] });
+    mockGetWalletSafe.mockResolvedValue(standardWallet);
+
+    const { store, Wrapper } = createWrapper();
+    store.set(selectedAccountsAtom(), {
+      0: hiddenWalletSelection,
+    });
+    store.set(accountSelectorStorageInitDoneAtom(), true);
+    store.set(activeAccountsAtom(), {
+      0: {
+        ...defaultActiveAccountInfo(),
+        ready: true,
+        network: {
+          id: 'onekeyall',
+        } as ReturnType<typeof defaultActiveAccountInfo>['network'],
+      },
+    });
+
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.autoSelectNextAccount({
+        num: 0,
+        sceneName: EAccountSelectorSceneName.home,
+      });
+    });
+
+    expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+      walletId: 'hw-standard',
+      focusedWallet: 'hw-standard',
+      indexedAccountId: undefined,
+      othersWalletAccountId: undefined,
     });
   });
 });

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
@@ -36,6 +36,13 @@ type IBuildActiveAccountInfoResult = {
 type IFixDeriveTypesForInitAccountSelectorMapParams = {
   selectedAccountsMapInDB: ISelectedAccountsMap | undefined;
 };
+type ISaveSelectedAccountParams = {
+  selectedAccount: ISelectedAccount;
+  sceneName: EAccountSelectorSceneName;
+  sceneUrl?: string;
+  num: number;
+  selectedAccountUpdatedAt?: number;
+};
 type IIndexedAccount = NonNullable<
   ReturnType<typeof defaultActiveAccountInfo>['indexedAccount']
 >;
@@ -70,8 +77,9 @@ const mockFixDeriveTypesForInitAccountSelectorMap: jest.MockedFunction<
 const mockGetSelectedAccount: jest.MockedFunction<
   () => Promise<ISelectedAccount | undefined>
 > = jest.fn();
-const mockSaveSelectedAccount: jest.MockedFunction<() => Promise<void>> =
-  jest.fn();
+const mockSaveSelectedAccount: jest.MockedFunction<
+  (params: ISaveSelectedAccountParams) => Promise<void>
+> = jest.fn();
 const mockSaveGlobalDeriveType: jest.MockedFunction<() => Promise<void>> =
   jest.fn();
 const mockShouldSyncWithHomeSource: jest.MockedFunction<
@@ -235,7 +243,8 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
       accountSelector: {
         getSelectedAccount: () => mockGetSelectedAccount(),
         getSelectedAccountsMap: () => mockGetSelectedAccountsMap(),
-        saveSelectedAccount: () => mockSaveSelectedAccount(),
+        saveSelectedAccount: (params: ISaveSelectedAccountParams) =>
+          mockSaveSelectedAccount(params),
       },
       dappConnection: {
         getAccountSelectorMap: jest.fn(async () => undefined),
@@ -1334,5 +1343,94 @@ describe('useAccountSelectorActions', () => {
       indexedAccountId: undefined,
       othersWalletAccountId: undefined,
     });
+  });
+
+  it('persists a cleared selection after a temp hidden wallet is removed without a usable fallback', async () => {
+    const hiddenWalletSelection = {
+      ...defaultSelectedAccount(),
+      walletId: 'hw-standard--hidden',
+      indexedAccountId: 'hw-standard--hidden-indexed-1',
+      networkId: 'onekeyall',
+      deriveType: 'default' as const,
+      focusedWallet: 'hw-standard--hidden',
+    };
+    const hiddenWallet = {
+      id: 'hw-standard--hidden',
+      name: 'Hidden wallet',
+      isTemp: true,
+    } as IWallet;
+    const mockedStandardWallet = {
+      id: 'hw-standard',
+      name: 'Standard wallet',
+      isMocked: true,
+    } as IWallet;
+
+    mockGetAllHdHwQrWallets.mockResolvedValue({
+      wallets: [mockedStandardWallet],
+    });
+    mockGetWalletSafe.mockImplementation(async ({ walletId }) => {
+      if (walletId === hiddenWallet.id) {
+        return hiddenWallet;
+      }
+      if (walletId === mockedStandardWallet.id) {
+        return mockedStandardWallet;
+      }
+      return undefined;
+    });
+    mockIsTempWalletRemoved.mockImplementation(
+      async ({ wallet }) => wallet.id === hiddenWallet.id,
+    );
+
+    const { store, Wrapper } = createWrapper();
+    store.set(selectedAccountsAtom(), {
+      0: hiddenWalletSelection,
+    });
+    store.set(accountSelectorStorageInitDoneAtom(), true);
+    store.set(activeAccountsAtom(), {
+      0: {
+        ...defaultActiveAccountInfo(),
+        ready: true,
+        network: {
+          id: 'onekeyall',
+        } as ReturnType<typeof defaultActiveAccountInfo>['network'],
+        account: {
+          id: 'mocked-all-network-account',
+        } as ReturnType<typeof defaultActiveAccountInfo>['account'],
+      },
+    });
+
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.autoSelectNextAccount({
+        num: 0,
+        sceneName: EAccountSelectorSceneName.home,
+      });
+    });
+
+    const selectedAccountInState = store.get(selectedAccountsAtom())[0];
+    expect(selectedAccountInState).toMatchObject({
+      walletId: undefined,
+      focusedWallet: undefined,
+      indexedAccountId: undefined,
+      othersWalletAccountId: undefined,
+      networkId: 'onekeyall',
+    });
+
+    expect(mockSaveSelectedAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sceneName: EAccountSelectorSceneName.home,
+        num: 0,
+        selectedAccount: expect.objectContaining({
+          walletId: undefined,
+          focusedWallet: undefined,
+          indexedAccountId: undefined,
+          othersWalletAccountId: undefined,
+          networkId: 'onekeyall',
+        }),
+      }),
+    );
   });
 });

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
@@ -8,7 +8,10 @@ import { createStore } from 'jotai';
 import type { IDBAccount } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import { EAppSyncStorageKeys } from '@onekeyhq/shared/src/storage/syncStorageKeys';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
-import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
+import {
+  EAccountSelectorAutoSelectTriggerBy,
+  EAccountSelectorSceneName,
+} from '@onekeyhq/shared/types';
 
 import { useAccountSelectorActions } from './actions';
 import {
@@ -1412,6 +1415,84 @@ describe('useAccountSelectorActions', () => {
 
     const selectedAccountInState = store.get(selectedAccountsAtom())[0];
     expect(selectedAccountInState).toMatchObject({
+      walletId: undefined,
+      focusedWallet: undefined,
+      indexedAccountId: undefined,
+      othersWalletAccountId: undefined,
+      networkId: 'onekeyall',
+    });
+
+    expect(mockSaveSelectedAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sceneName: EAccountSelectorSceneName.home,
+        num: 0,
+        selectedAccount: expect.objectContaining({
+          walletId: undefined,
+          focusedWallet: undefined,
+          indexedAccountId: undefined,
+          othersWalletAccountId: undefined,
+          networkId: 'onekeyall',
+        }),
+      }),
+    );
+  });
+
+  it('clears an empty standard wallet selection after the standard wallet is removed', async () => {
+    const standardWalletSelection = {
+      ...defaultSelectedAccount(),
+      walletId: 'hw-standard',
+      indexedAccountId: undefined,
+      othersWalletAccountId: undefined,
+      networkId: 'onekeyall',
+      deriveType: 'default' as const,
+      focusedWallet: 'hw-standard',
+    };
+    const staleActiveStandardWallet = {
+      id: 'hw-standard',
+      name: 'Standard wallet',
+    } as IWallet;
+    const mockedStandardWallet = {
+      id: 'hw-standard',
+      name: 'Standard wallet',
+      isMocked: true,
+    } as IWallet;
+
+    mockGetAllHdHwQrWallets.mockResolvedValue({
+      wallets: [mockedStandardWallet],
+    });
+    mockIsWalletHasIndexedAccounts.mockResolvedValue(false);
+    mockGetIndexedAccountsOfWallet.mockResolvedValue({ accounts: [] });
+    mockGetWalletSafe.mockResolvedValue(mockedStandardWallet);
+
+    const { store, Wrapper } = createWrapper();
+    store.set(selectedAccountsAtom(), {
+      0: standardWalletSelection,
+    });
+    store.set(accountSelectorStorageInitDoneAtom(), true);
+    store.set(activeAccountsAtom(), {
+      0: {
+        ...defaultActiveAccountInfo(),
+        ready: true,
+        wallet: staleActiveStandardWallet,
+        network: {
+          id: 'onekeyall',
+        } as ReturnType<typeof defaultActiveAccountInfo>['network'],
+      },
+    });
+
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.autoSelectNextAccount({
+        num: 0,
+        sceneName: EAccountSelectorSceneName.home,
+        triggerBy: EAccountSelectorAutoSelectTriggerBy.removeWallet,
+      });
+    });
+
+    expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
       walletId: undefined,
       focusedWallet: undefined,
       indexedAccountId: undefined,

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
@@ -120,6 +120,9 @@ const mockGetDBAccount: jest.MockedFunction<
 const mockGetWalletSafe: jest.MockedFunction<
   ({ walletId }: { walletId: string }) => Promise<IWallet | undefined>
 > = jest.fn();
+const mockIsTempWalletRemoved: jest.MockedFunction<
+  ({ wallet }: { wallet: IWallet }) => Promise<boolean>
+> = jest.fn();
 const mockColdStartCacheStorageData = new Map<string, unknown>();
 const mockColdStartCacheStorage = {
   delete: jest.fn((key: string) => {
@@ -208,6 +211,8 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
         mockGetWalletSafe({ walletId }),
       isWalletHasIndexedAccounts: ({ walletId }: { walletId: string }) =>
         mockIsWalletHasIndexedAccounts({ walletId }),
+      isTempWalletRemoved: ({ wallet }: { wallet: IWallet }) =>
+        mockIsTempWalletRemoved({ wallet }),
     },
     serviceAccountSelector: {
       buildActiveAccountInfoFromSelectedAccount: () =>
@@ -331,6 +336,7 @@ describe('useAccountSelectorActions', () => {
     });
     mockGetSingletonAccountsOfWallet.mockResolvedValue({ accounts: [] });
     mockGetWalletSafe.mockResolvedValue({ id: 'hd-1' } as IWallet);
+    mockIsTempWalletRemoved.mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -1155,6 +1161,74 @@ describe('useAccountSelectorActions', () => {
         ready: true,
         network: {
           id: 'onekeyall',
+        } as ReturnType<typeof defaultActiveAccountInfo>['network'],
+      },
+    });
+
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.autoSelectNextAccount({
+        num: 0,
+        sceneName: EAccountSelectorSceneName.home,
+      });
+    });
+
+    expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+      walletId: 'hw-standard',
+      focusedWallet: 'hw-standard',
+      indexedAccountId: undefined,
+      othersWalletAccountId: undefined,
+    });
+  });
+
+  it('selects an empty hardware wallet after a temp hidden wallet is removed', async () => {
+    const hiddenWalletSelection = {
+      ...defaultSelectedAccount(),
+      walletId: 'hw-standard--hidden',
+      indexedAccountId: 'hw-standard--hidden-indexed-1',
+      networkId: 'evm--1',
+      deriveType: 'default' as const,
+      focusedWallet: 'hw-standard--hidden',
+    };
+    const hiddenWallet = {
+      id: 'hw-standard--hidden',
+      name: 'Hidden wallet',
+      isTemp: true,
+    } as IWallet;
+    const standardWallet = {
+      id: 'hw-standard',
+      name: 'Standard wallet',
+    } as IWallet;
+
+    mockGetAllHdHwQrWallets.mockResolvedValue({
+      wallets: [standardWallet],
+    });
+    mockIsWalletHasIndexedAccounts.mockResolvedValue(true);
+    mockGetIndexedAccountsOfWallet.mockResolvedValue({ accounts: [] });
+    mockGetWalletSafe.mockImplementation(async ({ walletId }) => {
+      if (walletId === hiddenWallet.id) {
+        return hiddenWallet;
+      }
+      return standardWallet;
+    });
+    mockIsTempWalletRemoved.mockImplementation(
+      async ({ wallet }) => wallet.id === hiddenWallet.id,
+    );
+
+    const { store, Wrapper } = createWrapper();
+    store.set(selectedAccountsAtom(), {
+      0: hiddenWalletSelection,
+    });
+    store.set(accountSelectorStorageInitDoneAtom(), true);
+    store.set(activeAccountsAtom(), {
+      0: {
+        ...defaultActiveAccountInfo(),
+        ready: true,
+        network: {
+          id: 'evm--1',
         } as ReturnType<typeof defaultActiveAccountInfo>['network'],
       },
     });

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
@@ -1184,6 +1184,90 @@ describe('useAccountSelectorActions', () => {
     });
   });
 
+  it('keeps a wallet with indexed accounts when replacing a mocked wallet', async () => {
+    const hiddenWalletSelection = {
+      ...defaultSelectedAccount(),
+      walletId: 'hw-standard--hidden',
+      indexedAccountId: 'hw-standard--hidden-indexed-1',
+      networkId: 'evm--1',
+      deriveType: 'default' as const,
+      focusedWallet: 'hw-standard--hidden',
+    };
+    const mockedHiddenWallet = {
+      id: 'hw-standard--hidden',
+      name: 'Hidden wallet',
+      isMocked: true,
+    } as IWallet;
+    const emptyWallet = {
+      id: 'hw-empty',
+      name: 'Empty wallet',
+    } as IWallet;
+    const walletWithAccounts = {
+      id: 'hw-with-accounts',
+      name: 'Wallet with accounts',
+    } as IWallet;
+    const indexedAccount = {
+      id: 'hw-with-accounts-indexed-1',
+      walletId: walletWithAccounts.id,
+    } as IIndexedAccount;
+
+    mockGetAllHdHwQrWallets.mockResolvedValue({
+      wallets: [emptyWallet, walletWithAccounts],
+    });
+    mockIsWalletHasIndexedAccounts.mockImplementation(
+      async ({ walletId }) => walletId === walletWithAccounts.id,
+    );
+    mockGetIndexedAccountsOfWallet.mockImplementation(async ({ walletId }) => ({
+      accounts: walletId === walletWithAccounts.id ? [indexedAccount] : [],
+    }));
+    mockGetWalletSafe.mockImplementation(async ({ walletId }) => {
+      if (walletId === mockedHiddenWallet.id) {
+        return mockedHiddenWallet;
+      }
+      if (walletId === emptyWallet.id) {
+        return emptyWallet;
+      }
+      if (walletId === walletWithAccounts.id) {
+        return walletWithAccounts;
+      }
+      return undefined;
+    });
+
+    const { store, Wrapper } = createWrapper();
+    store.set(selectedAccountsAtom(), {
+      0: hiddenWalletSelection,
+    });
+    store.set(accountSelectorStorageInitDoneAtom(), true);
+    store.set(activeAccountsAtom(), {
+      0: {
+        ...defaultActiveAccountInfo(),
+        ready: true,
+        wallet: mockedHiddenWallet,
+        network: {
+          id: 'evm--1',
+        } as ReturnType<typeof defaultActiveAccountInfo>['network'],
+      },
+    });
+
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.autoSelectNextAccount({
+        num: 0,
+        sceneName: EAccountSelectorSceneName.home,
+      });
+    });
+
+    expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+      walletId: walletWithAccounts.id,
+      focusedWallet: walletWithAccounts.id,
+      indexedAccountId: indexedAccount.id,
+      othersWalletAccountId: undefined,
+    });
+  });
+
   it('selects an empty hardware wallet after a temp hidden wallet is removed', async () => {
     const hiddenWalletSelection = {
       ...defaultSelectedAccount(),

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -131,6 +131,13 @@ type IAccountSelectorRecentSelectionCache = Record<
   IAccountSelectorRecentSelectionCacheItem
 >;
 
+type IUnavailableSelectedAccountWallet = {
+  walletId: string;
+  isMissingWallet: boolean;
+  isDeprecatedOrMocked: boolean;
+  isTempWalletRemoved: boolean;
+};
+
 const isSelectedAccountIdentityIncomplete = (
   selectedAccount: IAccountSelectorSelectedAccount | undefined,
 ) =>
@@ -857,6 +864,158 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
       account,
       networkId,
     });
+  };
+
+  buildSelectedAccountWithoutWallet = ({
+    selectedAccount,
+  }: {
+    selectedAccount: IAccountSelectorSelectedAccount | undefined;
+  }): IAccountSelectorSelectedAccount => ({
+    ...defaultSelectedAccount(),
+    networkId: selectedAccount?.networkId,
+    deriveType: selectedAccount?.deriveType,
+  });
+
+  getSelectedAccountWalletIdForAvailabilityCheck = ({
+    selectedAccount,
+  }: {
+    selectedAccount: IAccountSelectorSelectedAccount | undefined;
+  }) => {
+    if (selectedAccount?.walletId) {
+      return selectedAccount.walletId;
+    }
+    if (
+      selectedAccount?.focusedWallet &&
+      selectedAccount.focusedWallet !== '$$others'
+    ) {
+      return selectedAccount.focusedWallet;
+    }
+    return undefined;
+  };
+
+  isSelectedAccountWalletUnavailable = async ({
+    selectedAccount,
+  }: {
+    selectedAccount: IAccountSelectorSelectedAccount | undefined;
+  }): Promise<IUnavailableSelectedAccountWallet | undefined> => {
+    const walletId = this.getSelectedAccountWalletIdForAvailabilityCheck({
+      selectedAccount,
+    });
+    if (!walletId) {
+      return undefined;
+    }
+    if (
+      !accountUtils.isHdWallet({ walletId }) &&
+      !accountUtils.isHwOrQrWallet({ walletId })
+    ) {
+      return undefined;
+    }
+
+    const wallet = await serviceAccount.getWalletSafe({ walletId });
+    const isMissingWallet = !wallet;
+    const isDeprecatedOrMocked = Boolean(
+      wallet && accountUtils.isWalletDeprecatedOrMocked(wallet),
+    );
+    const isTempWalletRemoved = wallet
+      ? await serviceAccount.isTempWalletRemoved({
+          wallet,
+        })
+      : false;
+    if (!isMissingWallet && !isDeprecatedOrMocked && !isTempWalletRemoved) {
+      return undefined;
+    }
+    return {
+      walletId,
+      isMissingWallet,
+      isDeprecatedOrMocked,
+      isTempWalletRemoved,
+    };
+  };
+
+  clearUnavailableWalletSelectionsInStorage = async ({
+    selectedAccountsMapInDB,
+    sceneName,
+    sceneUrl,
+  }: {
+    selectedAccountsMapInDB: IAccountSelectorSelectedAccountsMap | undefined;
+    sceneName: EAccountSelectorSceneName;
+    sceneUrl?: string;
+  }) => {
+    if (!selectedAccountsMapInDB) {
+      return selectedAccountsMapInDB;
+    }
+
+    const selectedAccountsMap = cloneDeep(selectedAccountsMapInDB);
+    const clearedEntries: {
+      num: number;
+      selectedAccount: IAccountSelectorSelectedAccount | undefined;
+      clearedSelectedAccount: IAccountSelectorSelectedAccount;
+      unavailableWallet: IUnavailableSelectedAccountWallet;
+    }[] = [];
+
+    await Promise.all(
+      Object.entries(selectedAccountsMap).map(
+        async ([numText, selectedAccount]) => {
+          const unavailableWallet =
+            await this.isSelectedAccountWalletUnavailable({
+              selectedAccount,
+            });
+          if (!unavailableWallet) {
+            return;
+          }
+          const num = Number(numText);
+          const clearedSelectedAccount = this.buildSelectedAccountWithoutWallet(
+            {
+              selectedAccount,
+            },
+          );
+          selectedAccountsMap[num] = clearedSelectedAccount;
+          clearedEntries.push({
+            num,
+            selectedAccount,
+            clearedSelectedAccount,
+            unavailableWallet,
+          });
+        },
+      ),
+    );
+
+    if (!clearedEntries.length) {
+      return selectedAccountsMapInDB;
+    }
+
+    await Promise.all(
+      clearedEntries.map(
+        async ({
+          num,
+          selectedAccount,
+          clearedSelectedAccount,
+          unavailableWallet,
+        }) => {
+          defaultLogger.accountSelector.listData.clearUnavailableWalletSelection(
+            {
+              num,
+              selectedAccount,
+              clearedSelectedAccount,
+              walletId: unavailableWallet.walletId,
+              isMissingWallet: unavailableWallet.isMissingWallet,
+              isDeprecatedOrMocked: unavailableWallet.isDeprecatedOrMocked,
+              isTempWalletRemoved: unavailableWallet.isTempWalletRemoved,
+            },
+          );
+          await backgroundApiProxy.simpleDb.accountSelector.saveSelectedAccount(
+            {
+              sceneName,
+              sceneUrl,
+              num,
+              selectedAccount: clearedSelectedAccount,
+            },
+          );
+        },
+      ),
+    );
+
+    return selectedAccountsMap;
   };
 
   updateSelectedAccountNetwork = contextAtomMethod(
@@ -2589,6 +2748,12 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
             await this.repairOthersWalletNetworkPairsInSelectedAccountsMap({
               selectedAccountsMap: selectedAccountsMapInDB,
             });
+          selectedAccountsMapInDB =
+            await this.clearUnavailableWalletSelectionsInStorage({
+              selectedAccountsMapInDB,
+              sceneName,
+              sceneUrl,
+            });
         }
 
         const recentSelectionCache =
@@ -2597,8 +2762,13 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
             sceneUrl,
           });
         const recentSelectionCacheSelectedAccountsMap = recentSelectionCache
-          ? await this.repairOthersWalletNetworkPairsInSelectedAccountsMap({
-              selectedAccountsMap: recentSelectionCache.selectedAccountsMap,
+          ? await this.clearUnavailableWalletSelectionsInStorage({
+              selectedAccountsMapInDB:
+                await this.repairOthersWalletNetworkPairsInSelectedAccountsMap({
+                  selectedAccountsMap: recentSelectionCache.selectedAccountsMap,
+                }),
+              sceneName,
+              sceneUrl,
             })
           : undefined;
         if (
@@ -2643,9 +2813,15 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
           return;
         }
 
-        const selectedAccountsMap =
-          (await this.repairOthersWalletNetworkPairsInSelectedAccountsMap({
+        const repairedSelectedAccountsMap =
+          await this.repairOthersWalletNetworkPairsInSelectedAccountsMap({
             selectedAccountsMap: get(selectedAccountsAtom()),
+          });
+        const selectedAccountsMap =
+          (await this.clearUnavailableWalletSelectionsInStorage({
+            selectedAccountsMapInDB: repairedSelectedAccountsMap,
+            sceneName,
+            sceneUrl,
           })) || {};
         const updateMeta = get(accountSelectorUpdateMetaAtom());
         if (

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -3264,18 +3264,32 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
               await timerUtils.wait(600);
               await serviceAccount.clearAccountCache();
               const { wallets } = await serviceAccount.getAllHdHwQrWallets();
+              let firstAvailableWallet: IDBWallet | undefined;
               for (const wallet0 of wallets) {
-                if (
-                  !accountUtils.isWalletDeprecatedOrMocked(wallet0) &&
-                  (await serviceAccount.isWalletHasIndexedAccounts({
-                    walletId: wallet0.id,
-                  }))
-                ) {
-                  selectedWallet = wallet0;
-                  selectedWalletId = selectedWallet?.id;
-                  selectedAccountNew.walletId = selectedWalletId;
-                  break;
+                if (!accountUtils.isWalletDeprecatedOrMocked(wallet0)) {
+                  firstAvailableWallet = firstAvailableWallet || wallet0;
+                  if (
+                    await serviceAccount.isWalletHasIndexedAccounts({
+                      walletId: wallet0.id,
+                    })
+                  ) {
+                    selectedWallet = wallet0;
+                    selectedWalletId = selectedWallet?.id;
+                    selectedAccountNew.walletId = selectedWalletId;
+                    break;
+                  }
                 }
+              }
+              if (
+                (!selectedWallet || !hasIndexedAccounts) &&
+                firstAvailableWallet
+              ) {
+                selectedWallet = firstAvailableWallet;
+                selectedWalletId = selectedWallet.id;
+                selectedAccountNew.walletId = selectedWalletId;
+                selectedAccountNew.indexedAccountId = undefined;
+                selectedAccountNew.othersWalletAccountId = undefined;
+                selectedAccountNew.focusedWallet = selectedWalletId;
               }
               // maybe no hd hw wallet found, reset walletId and indexedAccountId
               if (

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -3214,8 +3214,14 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
             selectedWallet = await serviceAccount.getWalletSafe({
               walletId: selectedWalletId,
             });
-            if (!selectedWallet) {
+            if (
+              !selectedWallet ||
+              (await serviceAccount.isTempWalletRemoved({
+                wallet: selectedWallet,
+              }))
+            ) {
               selectedWalletId = undefined;
+              selectedWallet = undefined;
             }
           }
           let selectedIndexedAccountId =
@@ -3266,7 +3272,12 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
               const { wallets } = await serviceAccount.getAllHdHwQrWallets();
               let firstAvailableWallet: IDBWallet | undefined;
               for (const wallet0 of wallets) {
-                if (!accountUtils.isWalletDeprecatedOrMocked(wallet0)) {
+                const isWalletUnavailable =
+                  accountUtils.isWalletDeprecatedOrMocked(wallet0) ||
+                  (await serviceAccount.isTempWalletRemoved({
+                    wallet: wallet0,
+                  }));
+                if (!isWalletUnavailable) {
                   firstAvailableWallet = firstAvailableWallet || wallet0;
                   if (
                     await serviceAccount.isWalletHasIndexedAccounts({
@@ -3414,7 +3425,12 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
             const finalWallet = await serviceAccount.getWalletSafe({
               walletId: selectedAccountNew.walletId,
             });
-            if (!finalWallet) {
+            if (
+              !finalWallet ||
+              (await serviceAccount.isTempWalletRemoved({
+                wallet: finalWallet,
+              }))
+            ) {
               selectedAccountNew.walletId = undefined;
               selectedAccountNew.indexedAccountId = undefined;
               selectedAccountNew.othersWalletAccountId = undefined;

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -3271,6 +3271,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
               await serviceAccount.clearAccountCache();
               const { wallets } = await serviceAccount.getAllHdHwQrWallets();
               let firstAvailableWallet: IDBWallet | undefined;
+              let foundWalletWithIndexedAccounts = false;
               for (const wallet0 of wallets) {
                 const isWalletUnavailable =
                   accountUtils.isWalletDeprecatedOrMocked(wallet0) ||
@@ -3287,12 +3288,13 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
                     selectedWallet = wallet0;
                     selectedWalletId = selectedWallet?.id;
                     selectedAccountNew.walletId = selectedWalletId;
+                    foundWalletWithIndexedAccounts = true;
                     break;
                   }
                 }
               }
               if (
-                (!selectedWallet || !hasIndexedAccounts) &&
+                (!selectedWallet || !foundWalletWithIndexedAccounts) &&
                 firstAvailableWallet
               ) {
                 selectedWallet = firstAvailableWallet;

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -2848,6 +2848,85 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
     },
   );
 
+  saveClearedSelectedAccountToStorage = contextAtomMethod(
+    async (
+      get,
+      set,
+      payload: {
+        previousSelectedAccount: IAccountSelectorSelectedAccount | undefined;
+        selectedAccount: IAccountSelectorSelectedAccount;
+        sceneName: EAccountSelectorSceneName | undefined;
+        sceneUrl?: string;
+        num: number;
+      },
+    ) => {
+      const {
+        previousSelectedAccount,
+        selectedAccount,
+        sceneName,
+        sceneUrl,
+        num,
+      } = payload;
+      if (
+        !sceneName ||
+        !accountSelectorUtils.isSceneCanPersist({ sceneName })
+      ) {
+        return;
+      }
+      if (!get(accountSelectorStorageReadyAtom())) {
+        return;
+      }
+
+      const previousSelectedAccountHasIdentity = Boolean(
+        previousSelectedAccount?.walletId &&
+        (previousSelectedAccount.indexedAccountId ||
+          previousSelectedAccount.othersWalletAccountId),
+      );
+      const selectedAccountHasIdentity = Boolean(
+        selectedAccount.walletId &&
+        (selectedAccount.indexedAccountId ||
+          selectedAccount.othersWalletAccountId),
+      );
+      if (!previousSelectedAccountHasIdentity || selectedAccountHasIdentity) {
+        return;
+      }
+
+      const currentSelectedAccount = this.getSelectedAccount.call(set, {
+        num,
+      });
+      if (
+        !isEqual(
+          omitBy(currentSelectedAccount, isUndefined),
+          omitBy(selectedAccount, isUndefined),
+        )
+      ) {
+        return;
+      }
+
+      const { simpleDb } = backgroundApiProxy;
+      const currentSaved = await simpleDb.accountSelector.getSelectedAccount({
+        sceneName,
+        sceneUrl,
+        num,
+      });
+      if (
+        isEqual(
+          omitBy(currentSaved, isUndefined),
+          omitBy(selectedAccount, isUndefined),
+        )
+      ) {
+        return;
+      }
+
+      await simpleDb.accountSelector.saveSelectedAccount({
+        sceneName,
+        sceneUrl,
+        num,
+        selectedAccount,
+      });
+    },
+  );
+
   getSelectedAccount = contextAtomMethod(
     (
       get,
@@ -3468,6 +3547,13 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
                 }
               : undefined,
             builder: () => selectedAccountNew,
+          });
+          await this.saveClearedSelectedAccountToStorage.call(set, {
+            previousSelectedAccount: selectedAccount,
+            selectedAccount: selectedAccountNew,
+            sceneName,
+            sceneUrl,
+            num,
           });
 
           if (

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -2877,17 +2877,21 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
         return;
       }
 
-      const previousSelectedAccountHasIdentity = Boolean(
-        previousSelectedAccount?.walletId &&
-        (previousSelectedAccount.indexedAccountId ||
-          previousSelectedAccount.othersWalletAccountId),
+      const previousSelectedAccountHasWalletSelection = Boolean(
+        previousSelectedAccount?.walletId ||
+        previousSelectedAccount?.focusedWallet ||
+        previousSelectedAccount?.indexedAccountId ||
+        previousSelectedAccount?.othersWalletAccountId,
       );
       const selectedAccountHasIdentity = Boolean(
         selectedAccount.walletId &&
         (selectedAccount.indexedAccountId ||
           selectedAccount.othersWalletAccountId),
       );
-      if (!previousSelectedAccountHasIdentity || selectedAccountHasIdentity) {
+      if (
+        !previousSelectedAccountHasWalletSelection ||
+        selectedAccountHasIdentity
+      ) {
         return;
       }
 
@@ -3508,6 +3512,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
             });
             if (
               !finalWallet ||
+              accountUtils.isWalletDeprecatedOrMocked(finalWallet) ||
               (await serviceAccount.isTempWalletRemoved({
                 wallet: finalWallet,
               }))

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -73,7 +73,10 @@ import { HomeTestIDs } from '../testIDs';
 import { DeFiContainerWithProvider } from './DeFiContainer';
 import { HomeHeaderContainer } from './HomeHeaderContainer';
 import { homePageContentMaxWidthSx } from './homePageContentMaxWidth';
-import { shouldShowNoWalletContent } from './homePageNoWalletContent';
+import {
+  isWalletListResolvedNoWallet,
+  shouldShowNoWalletContent,
+} from './homePageNoWalletContent';
 import { NFTListContainerWithProvider } from './NFTListContainer';
 import { PortfolioContainerWithProvider } from './PortfolioContainer';
 import { TabHeaderSettings } from './TabHeaderSettings';
@@ -925,7 +928,9 @@ export function HomePageView({
     account,
   });
   const walletListCount = walletListResult?.wallets.length;
-  const walletListResolvedNoWallet = walletListCount === 0;
+  const walletListResolvedNoWallet = isWalletListResolvedNoWallet({
+    wallets: walletListResult?.wallets,
+  });
   const walletPageContent = useMemo(
     () =>
       platformEnv.isNative ? (

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -33,6 +33,7 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
@@ -199,9 +200,11 @@ export function HomePageView({
       accountName,
       network,
       deriveInfo,
+      deriveType,
       wallet,
       ready,
       device,
+      dbAccount,
       indexedAccount,
       vaultSettings: cachedVaultSettings,
     },
@@ -811,7 +814,7 @@ export function HomePageView({
 
   const { result: accountNetworkNotSupported } = usePromiseResult(
     async () => {
-      if (!network?.id) return undefined;
+      if (!network?.id || (!wallet?.id && !account?.id)) return undefined;
       const checkResult =
         await backgroundApiProxy.serviceAccount.checkAccountNetworkNotSupported(
           {
@@ -921,6 +924,8 @@ export function HomePageView({
     wallet,
     account,
   });
+  const walletListCount = walletListResult?.wallets.length;
+  const walletListResolvedNoWallet = walletListCount === 0;
   const walletPageContent = useMemo(
     () =>
       platformEnv.isNative ? (
@@ -934,8 +939,64 @@ export function HomePageView({
     hasNoUsableWallet,
     accountSelectorStorageInitDone,
     accountSelectorActiveAccountInitDone,
-    walletListResolvedNoWallet: walletListResult?.wallets.length === 0,
+    walletListResolvedNoWallet,
   });
+  const activeWalletId = wallet?.id;
+  const activeIndexedAccountId = indexedAccount?.id;
+  const activeNetworkId = network?.id;
+  const hasAccount = Boolean(account);
+  const hasDbAccount = Boolean(dbAccount);
+  const hasWallet = Boolean(wallet);
+  const hasIndexedAccount = Boolean(indexedAccount);
+  const hasNetwork = Boolean(network);
+  const homePageContentState = (() => {
+    if (!ready) return 'loading';
+    if (showNoWalletContent) return 'noWallet';
+    if (!hasNoUsableWallet) return 'wallet';
+    return 'blankNoUsableWallet';
+  })();
+
+  useEffect(() => {
+    defaultLogger.accountSelector.render.homePageState({
+      ready,
+      walletId: activeWalletId,
+      indexedAccountId: activeIndexedAccountId,
+      networkId: activeNetworkId,
+      deriveType,
+      hasAccount,
+      hasDbAccount,
+      hasWallet,
+      hasIndexedAccount,
+      hasNetwork,
+      hasNoUsableWallet,
+      showNoWalletContent,
+      accountSelectorStorageInitDone,
+      accountSelectorActiveAccountInitDone,
+      walletListResolvedNoWallet,
+      walletListCount,
+      accountNetworkNotSupported,
+      contentState: homePageContentState,
+    });
+  }, [
+    activeIndexedAccountId,
+    activeNetworkId,
+    activeWalletId,
+    accountNetworkNotSupported,
+    accountSelectorActiveAccountInitDone,
+    accountSelectorStorageInitDone,
+    deriveType,
+    hasAccount,
+    hasDbAccount,
+    hasIndexedAccount,
+    hasNetwork,
+    hasNoUsableWallet,
+    hasWallet,
+    homePageContentState,
+    ready,
+    showNoWalletContent,
+    walletListCount,
+    walletListResolvedNoWallet,
+  ]);
 
   const homePage = useMemo(() => {
     if (!ready) {

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -928,6 +928,7 @@ export function HomePageView({
     account,
   });
   const walletListCount = walletListResult?.wallets.length;
+  const walletListWalletIds = walletListResult?.wallets.map((item) => item.id);
   const walletListResolvedNoWallet = isWalletListResolvedNoWallet({
     wallets: walletListResult?.wallets,
   });
@@ -940,13 +941,15 @@ export function HomePageView({
       ),
     [homePageContent],
   );
+  const activeWalletId = wallet?.id;
   const showNoWalletContent = shouldShowNoWalletContent({
     hasNoUsableWallet,
     accountSelectorStorageInitDone,
     accountSelectorActiveAccountInitDone,
     walletListResolvedNoWallet,
+    activeWalletId,
+    walletListWalletIds,
   });
-  const activeWalletId = wallet?.id;
   const activeIndexedAccountId = indexedAccount?.id;
   const activeNetworkId = network?.id;
   const hasAccount = Boolean(account);

--- a/packages/kit/src/views/Home/pages/homePageNoWalletContent.test.ts
+++ b/packages/kit/src/views/Home/pages/homePageNoWalletContent.test.ts
@@ -48,6 +48,32 @@ describe('shouldShowNoWalletContent', () => {
     ).toBe(true);
   });
 
+  it('allows the no-wallet empty state when the active wallet is already unusable but the wallet list cache is stale', () => {
+    expect(
+      shouldShowNoWalletContent({
+        hasNoUsableWallet: true,
+        accountSelectorStorageInitDone: true,
+        accountSelectorActiveAccountInitDone: true,
+        walletListResolvedNoWallet: false,
+        activeWalletId: 'hw-removed',
+        walletListWalletIds: ['hw-removed'],
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps blocking the no-wallet empty state when another wallet remains in the list', () => {
+    expect(
+      shouldShowNoWalletContent({
+        hasNoUsableWallet: true,
+        accountSelectorStorageInitDone: true,
+        accountSelectorActiveAccountInitDone: true,
+        walletListResolvedNoWallet: false,
+        activeWalletId: 'hw-removed',
+        walletListWalletIds: ['hw-removed', 'hw-usable'],
+      }),
+    ).toBe(false);
+  });
+
   it('does not block cached usable wallet content while storage init is still running', () => {
     expect(
       shouldShowNoWalletContent({

--- a/packages/kit/src/views/Home/pages/homePageNoWalletContent.test.ts
+++ b/packages/kit/src/views/Home/pages/homePageNoWalletContent.test.ts
@@ -1,4 +1,7 @@
-import { shouldShowNoWalletContent } from './homePageNoWalletContent';
+import {
+  isWalletListResolvedNoWallet,
+  shouldShowNoWalletContent,
+} from './homePageNoWalletContent';
 
 describe('shouldShowNoWalletContent', () => {
   it('blocks the no-wallet empty state before account selector storage init completes', () => {
@@ -52,6 +55,44 @@ describe('shouldShowNoWalletContent', () => {
         accountSelectorStorageInitDone: false,
         accountSelectorActiveAccountInitDone: false,
         walletListResolvedNoWallet: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isWalletListResolvedNoWallet', () => {
+  it('waits for the wallet list to resolve', () => {
+    expect(isWalletListResolvedNoWallet({ wallets: undefined })).toBe(false);
+  });
+
+  it('treats an empty wallet list as no wallet', () => {
+    expect(isWalletListResolvedNoWallet({ wallets: [] })).toBe(true);
+  });
+
+  it('treats mocked and deprecated wallet records as no usable wallet', () => {
+    expect(
+      isWalletListResolvedNoWallet({
+        wallets: [
+          {
+            isMocked: true,
+          },
+          {
+            deprecated: true,
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps the wallet list non-empty when a real wallet remains', () => {
+    expect(
+      isWalletListResolvedNoWallet({
+        wallets: [
+          {
+            isMocked: true,
+          },
+          {},
+        ],
       }),
     ).toBe(false);
   });

--- a/packages/kit/src/views/Home/pages/homePageNoWalletContent.ts
+++ b/packages/kit/src/views/Home/pages/homePageNoWalletContent.ts
@@ -1,3 +1,21 @@
+type IWalletListItemForNoWalletCheck =
+  | {
+      isMocked?: boolean;
+      deprecated?: boolean;
+    }
+  | undefined;
+
+export function isWalletListResolvedNoWallet({
+  wallets,
+}: {
+  wallets: IWalletListItemForNoWalletCheck[] | undefined;
+}) {
+  if (!wallets) {
+    return false;
+  }
+  return wallets.every((wallet) => !!(wallet?.isMocked || wallet?.deprecated));
+}
+
 export function shouldShowNoWalletContent({
   hasNoUsableWallet,
   accountSelectorStorageInitDone,

--- a/packages/kit/src/views/Home/pages/homePageNoWalletContent.ts
+++ b/packages/kit/src/views/Home/pages/homePageNoWalletContent.ts
@@ -21,16 +21,26 @@ export function shouldShowNoWalletContent({
   accountSelectorStorageInitDone,
   accountSelectorActiveAccountInitDone,
   walletListResolvedNoWallet,
+  activeWalletId,
+  walletListWalletIds,
 }: {
   hasNoUsableWallet: boolean;
   accountSelectorStorageInitDone: boolean;
   accountSelectorActiveAccountInitDone: boolean;
   walletListResolvedNoWallet: boolean;
+  activeWalletId?: string;
+  walletListWalletIds?: string[];
 }) {
+  const walletListResolvedCurrentUnusableWalletOnly =
+    !!activeWalletId &&
+    !!walletListWalletIds &&
+    walletListWalletIds.length === 1 &&
+    walletListWalletIds[0] === activeWalletId;
+
   return (
     hasNoUsableWallet &&
     accountSelectorStorageInitDone &&
     accountSelectorActiveAccountInitDone &&
-    walletListResolvedNoWallet
+    (walletListResolvedNoWallet || walletListResolvedCurrentUnusableWalletOnly)
   );
 }

--- a/packages/shared/src/logger/scopes/accountSelector/scenes/listData.ts
+++ b/packages/shared/src/logger/scopes/accountSelector/scenes/listData.ts
@@ -135,4 +135,31 @@ export class AccountSelectorListDataScene extends BaseScene {
   }) {
     return params;
   }
+
+  @LogToLocal()
+  public buildActiveAccountInfoResult(params: {
+    selectedWalletId: string | undefined;
+    selectedIndexedAccountId: string | undefined;
+    selectedNetworkId: string | undefined;
+    selectedDeriveType: IAccountDeriveTypes | undefined;
+    walletId: string | undefined;
+    indexedAccountId: string | undefined;
+    networkId: string | undefined;
+    deriveType: IAccountDeriveTypes | undefined;
+    hasWallet: boolean;
+    isWalletUnusable: boolean;
+    hasIndexedAccount: boolean;
+    hasAccount: boolean;
+    hasDbAccount: boolean;
+    hasDevice: boolean;
+    hasNetwork: boolean;
+    isAllNetwork: boolean;
+    isOthersWallet: boolean;
+    canCreateAddress: boolean;
+    isNetworkNotMatched: boolean;
+    deriveInfoItemsLength: number;
+    ready: boolean;
+  }) {
+    return params;
+  }
 }

--- a/packages/shared/src/logger/scopes/accountSelector/scenes/listData.ts
+++ b/packages/shared/src/logger/scopes/accountSelector/scenes/listData.ts
@@ -130,6 +130,19 @@ export class AccountSelectorListDataScene extends BaseScene {
   }
 
   @LogToLocal()
+  public clearUnavailableWalletSelection(params: {
+    num: number;
+    selectedAccount: IAccountSelectorSelectedAccount | undefined;
+    clearedSelectedAccount: IAccountSelectorSelectedAccount;
+    walletId: string | undefined;
+    isMissingWallet: boolean;
+    isDeprecatedOrMocked: boolean;
+    isTempWalletRemoved: boolean;
+  }) {
+    return params;
+  }
+
+  @LogToLocal()
   public initFromStorageSelectedAccountsMapResult(params: {
     selectedAccountsMap: IAccountSelectorSelectedAccountsMap | undefined;
   }) {

--- a/packages/shared/src/logger/scopes/accountSelector/scenes/render.ts
+++ b/packages/shared/src/logger/scopes/accountSelector/scenes/render.ts
@@ -1,5 +1,5 @@
 import { BaseScene } from '../../../base/baseScene';
-import { LogToConsole } from '../../../base/decorators';
+import { LogToConsole, LogToLocal } from '../../../base/decorators';
 
 export class AccountSelectorRenderScene extends BaseScene {
   @LogToConsole()
@@ -15,5 +15,29 @@ export class AccountSelectorRenderScene extends BaseScene {
   public showAccountSelector(p: any) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return ['showAccountSelector', p];
+  }
+
+  @LogToLocal()
+  public homePageState(params: {
+    ready: boolean;
+    walletId: string | undefined;
+    indexedAccountId: string | undefined;
+    networkId: string | undefined;
+    deriveType: string | undefined;
+    hasAccount: boolean;
+    hasDbAccount: boolean;
+    hasWallet: boolean;
+    hasIndexedAccount: boolean;
+    hasNetwork: boolean;
+    hasNoUsableWallet: boolean;
+    showNoWalletContent: boolean;
+    accountSelectorStorageInitDone: boolean;
+    accountSelectorActiveAccountInitDone: boolean;
+    walletListResolvedNoWallet: boolean;
+    walletListCount: number | undefined;
+    accountNetworkNotSupported: boolean | undefined;
+    contentState: 'loading' | 'noWallet' | 'wallet' | 'blankNoUsableWallet';
+  }) {
+    return params;
   }
 }


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57468](https://onekeyhq.atlassian.net/browse/OK-57468)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Keep an available standard HD/HW/QR wallet selected when the previously selected hidden wallet is no longer accessible.
- Add regression coverage for the single hardware wallet + hidden wallet case where the standard wallet has no indexed account yet.

## Intent & Context
A Slack thread reported that after adding a hidden passphrase wallet in OneKey App, disabling "Keep accessible", restarting the app, and returning to the wallet page, the page becomes blank. QA reproduced the issue when the user only has one hardware wallet plus a passphrase wallet. The related Jira is OK-57468.

The expected behavior is to select the standard wallet if possible, or show an empty/create state instead of leaving the wallet page blank.

## Root Cause
When a hidden wallet is not kept accessible, it becomes a temporary wallet. After app restart, the background runtime's process-local `tempWallets` state is empty, so the hidden wallet is treated as removed and filtered out of visible wallet lists.

`autoSelectNextAccount` previously only selected HD/HW/QR wallets that already had indexed accounts. In the single hardware wallet scenario, the standard hardware wallet can still exist but have no indexed account, so the fallback loop skipped it and cleared `walletId` / `focusedWallet`. Home then had no active wallet/account state to render, while the wallet list was not necessarily a true no-wallet list, producing the blank wallet page.

## Design Decisions
The fix stays in account selector fallback logic instead of adding a Home-only visual workaround. When no HD/HW/QR wallet with indexed accounts is found, the selector now keeps the first non-deprecated/non-mocked HD/HW/QR wallet selected as an empty account wallet. This lets existing Home empty-account/create-address UI handle the state naturally.

This preserves the existing priority: wallets with indexed accounts are still preferred. The new fallback only runs after no indexed-account wallet is available.

## Changes Detail
- `packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx`: track the first available HD/HW/QR wallet during auto-select and keep it selected when no wallet with indexed accounts exists.
- `packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx`: add a regression test for an unavailable hidden wallet falling back to an empty standard hardware wallet.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Desktop, Extension, Web surfaces that use account selector; the reported reproduction is Android/iOS.
- **Risk Areas**: Account selector fallback behavior after wallet/account removal or hidden wallet temp-state filtering. The change is scoped to the no-indexed-account fallback path and preserves existing selection priority for wallets with accounts.

## Test plan
- [x] `PATH=/Users/leon/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH yarn jest packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx --runInBand`
- [x] `PATH=/Users/leon/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx --deny-warnings`
- [x] `PATH=/Users/leon/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH yarn tsc:staged`
- [x] `PATH=/Users/leon/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH yarn lint:staged`

[OK-57468]: https://onekeyhq.atlassian.net/browse/OK-57468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ