### PR TITLE
fix: adjust iOS firmware update header(OK-57379)

### DIFF
--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdatePageLayout.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdatePageLayout.tsx
@@ -1,9 +1,14 @@
 import { EDeviceType } from '@onekeyfe/hd-shared';
 import { useIntl } from 'react-intl';
+import { useWindowDimensions } from 'react-native';
 
-import type { IStackProps } from '@onekeyhq/components';
+import type {
+  IStackNavigationOptions,
+  IStackProps,
+} from '@onekeyhq/components';
 import { Page, SizableText, Stack, XStack } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { ICheckAllFirmwareReleaseResult } from '@onekeyhq/shared/types/device';
 
 import { DeviceAvatarWithColor } from '../../../components/DeviceAvatar';
@@ -14,6 +19,7 @@ export function FirmwareUpdatePageHeaderTitle(props: {
   result: ICheckAllFirmwareReleaseResult | undefined;
 }) {
   const intl = useIntl();
+  const { width: windowWidth } = useWindowDimensions();
   const { result } = props;
   if (!result) {
     return null;
@@ -40,6 +46,27 @@ export function FirmwareUpdatePageHeaderTitle(props: {
   } else {
     title = result.deviceName;
   }
+  if (platformEnv.isNativeIOS) {
+    const titleWidth = Math.max(0, windowWidth - 220);
+
+    return (
+      <XStack ai="center" gap={6} flex={1} minWidth={0}>
+        <Stack flexShrink={0}>
+          <DeviceAvatarWithColor
+            size="$6"
+            deviceType={result.deviceType || EDeviceType.Unknown}
+            features={result.features}
+          />
+        </Stack>
+        <Stack width={titleWidth} minWidth={0}>
+          <SizableText size="$headingMd" numberOfLines={2}>
+            {title}
+          </SizableText>
+        </Stack>
+      </XStack>
+    );
+  }
+
   return (
     <XStack ai="center" gap={6} flex={1} minWidth={0}>
       <Stack flexShrink={0}>
@@ -71,10 +98,13 @@ export function FirmwareUpdatePageHeaderTitle(props: {
 
 export function FirmwareUpdatePageHeader({
   headerTitle,
+  headerRight,
 }: {
   headerTitle?: React.ReactNode;
+  headerRight?: IStackNavigationOptions['headerRight'];
 }) {
   const intl = useIntl();
+
   return (
     <Page.Header
       dismissOnOverlayPress={false}
@@ -86,6 +116,8 @@ export function FirmwareUpdatePageHeader({
             })
       }
       headerTitle={headerTitle ? () => headerTitle : undefined}
+      headerRight={headerRight}
+      headerRightNoGlass={platformEnv.isNativeIOS && Boolean(headerRight)}
     />
   );
 }
@@ -95,10 +127,12 @@ export const FirmwareUpdatePageFooter = Page.Footer;
 export function FirmwareUpdatePageLayout({
   children,
   headerTitle,
+  headerRight,
   containerStyle,
 }: {
   children: React.ReactNode;
   headerTitle?: React.ReactNode;
+  headerRight?: IStackNavigationOptions['headerRight'];
   containerStyle?: IStackProps;
 }) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -107,7 +141,10 @@ export function FirmwareUpdatePageLayout({
 
   return (
     <Stack>
-      <FirmwareUpdatePageHeader headerTitle={headerTitle} />
+      <FirmwareUpdatePageHeader
+        headerTitle={headerTitle}
+        headerRight={headerRight}
+      />
       <Page.Body>
         <Stack p="$5" {...containerStyle}>
           {children}

--- a/packages/kit/src/views/FirmwareUpdate/pages/PageFirmwareUpdateChangeLog.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/pages/PageFirmwareUpdateChangeLog.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useRef } from 'react';
 
-import { Page } from '@onekeyhq/components';
+import { HeaderButtonGroup, Page, SizableText } from '@onekeyhq/components';
 import {
   EFirmwareUpdateSteps,
   useFirmwareUpdateStepInfoAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { toPlainErrorObject } from '@onekeyhq/shared/src/errors/utils/errorUtils';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type {
   EModalFirmwareUpdateRoutes,
   IModalFirmwareUpdateParamList,
@@ -166,6 +167,21 @@ function PageFirmwareUpdateChangeLog() {
           shouldShowChangeLog ? (
             <FirmwareUpdatePageHeaderTitle result={result} />
           ) : undefined
+        }
+        headerRight={
+          platformEnv.isNativeIOS && shouldShowChangeLog
+            ? () => (
+                <HeaderButtonGroup>
+                  <SizableText
+                    size="$bodyMd"
+                    color="$textSubdued"
+                    numberOfLines={1}
+                  >
+                    {result?.deviceBleName}
+                  </SizableText>
+                </HeaderButtonGroup>
+              )
+            : undefined
         }
         containerStyle={{
           p:


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57379](https://onekeyhq.atlassian.net/browse/OK-57379)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Render the firmware update change-log title differently on iOS so long firmware-switch titles can wrap inside the native header.
- Move the BLE device name into the iOS header right slot so it stays aligned to the right edge.
- Keep the existing one-line header title layout unchanged on non-iOS platforms.

## Intent & Context
OK-57379 reports that on iOS, switching from Bitcoin-only firmware to universal firmware can overflow the modal header. The requested behavior was to change only this firmware update page: iOS should self-render the header title and allow multiple lines, while other platforms should keep the existing layout.

During verification, the first page-body inline-header approach was rejected because it was not actually rendered in the navigation header. The final implementation keeps using Page.Header and only customizes this page's iOS headerTitle/headerRight behavior.

## Root Cause
The original headerTitle rendered avatar, long title, and BLE device name in a single horizontal row. On iOS native-stack headers, the custom title view has constrained measurement, so the long firmware-switch title and the right-side BLE name competed for the same space and could overflow or be clipped.

## Design Decisions
- Keep Page.Header as the real navigation header instead of drawing an inline header in the page body.
- On iOS only, render avatar + multi-line title in headerTitle and render the BLE name via this page's headerRight slot.
- Use a window-width based cap for the iOS title area so the title does not overlap the headerRight BLE name.
- Preserve the existing non-iOS horizontal headerTitle implementation to avoid changing other platforms.

## Changes Detail
- packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdatePageLayout.tsx
  - Adds an iOS-only header title branch with a two-line title width cap.
  - Allows this layout wrapper to receive a typed headerRight function.
- packages/kit/src/views/FirmwareUpdate/pages/PageFirmwareUpdateChangeLog.tsx
  - Passes the BLE device name as iOS-only headerRight when the changelog is visible.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: iOS only for the changed behavior; non-iOS keeps the previous headerTitle layout.
- **Risk Areas**: Native iOS header spacing can vary by device width, so the title width cap was verified on the iPhone simulator used for repro.

## Test plan
- [x] Run targeted oxlint on the changed firmware update files.
- [x] Run project tsgo type check successfully.
- [x] Refresh iOS simulator, mock the firmware changelog data through the main/UI runtime, and open FirmwareUpdateModal -> ChangeLog.
- [x] Verify screenshot: iOS title stays in the native header, wraps to two lines, and Pro A8B4 is shown in the right header slot.
- [ ] Note: yarn tsc:staged currently reports unrelated existing errors in SOL/Trezor and third-party hardware error files outside this PR diff.

[OK-57379]: https://onekeyhq.atlassian.net/browse/OK-57379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ