### PR TITLE
fix: restore all-network token balances(OK-57487)

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityDeFi.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityDeFi.ts
@@ -5,6 +5,11 @@ import { SimpleDbEntityBase } from '../base/SimpleDbEntityBase';
 
 export interface IDeFiDBStruct {
   enabledNetworksMap?: Record<string, boolean>; // <networkId, enabled>
+  manualForceRefreshQuota?: {
+    dayKey: string;
+    count: number;
+    lastForcedAt: number;
+  };
   overview?: Record<
     string,
     Record<
@@ -49,6 +54,105 @@ export class SimpleDbEntityDeFi extends SimpleDbEntityBase<IDeFiDBStruct> {
   async getEnabledNetworksMap(): Promise<Record<string, boolean>> {
     const rawData = await this.getRawData();
     return rawData?.enabledNetworksMap ?? {};
+  }
+
+  @backgroundMethod()
+  async consumeManualForceRefreshQuota({
+    dayKey,
+    now,
+    dailyLimit,
+    minIntervalMs,
+  }: {
+    dayKey: string;
+    now: number;
+    dailyLimit: number;
+    minIntervalMs: number;
+  }): Promise<{
+    allowed: boolean;
+    reason?: 'daily-limit' | 'interval';
+    count: number;
+    lastForcedAt: number;
+    dailyLimit: number;
+    minIntervalMs: number;
+  }> {
+    let result: {
+      allowed: boolean;
+      reason?: 'daily-limit' | 'interval';
+      count: number;
+      lastForcedAt: number;
+      dailyLimit: number;
+      minIntervalMs: number;
+    } = {
+      allowed: false,
+      count: 0,
+      lastForcedAt: 0,
+      dailyLimit,
+      minIntervalMs,
+    };
+
+    await this.setRawData((rawData) => {
+      const current = rawData?.manualForceRefreshQuota;
+      const normalized =
+        current?.dayKey === dayKey
+          ? current
+          : {
+              dayKey,
+              count: 0,
+              lastForcedAt: 0,
+            };
+
+      if (
+        normalized.lastForcedAt > 0 &&
+        now - normalized.lastForcedAt < minIntervalMs
+      ) {
+        result = {
+          allowed: false,
+          reason: 'interval',
+          count: normalized.count,
+          lastForcedAt: normalized.lastForcedAt,
+          dailyLimit,
+          minIntervalMs,
+        };
+        return {
+          ...rawData,
+          manualForceRefreshQuota: normalized,
+        };
+      }
+
+      if (normalized.count >= dailyLimit) {
+        result = {
+          allowed: false,
+          reason: 'daily-limit',
+          count: normalized.count,
+          lastForcedAt: normalized.lastForcedAt,
+          dailyLimit,
+          minIntervalMs,
+        };
+        return {
+          ...rawData,
+          manualForceRefreshQuota: normalized,
+        };
+      }
+
+      const nextQuota = {
+        dayKey,
+        count: normalized.count + 1,
+        lastForcedAt: now,
+      };
+      result = {
+        allowed: true,
+        count: nextQuota.count,
+        lastForcedAt: nextQuota.lastForcedAt,
+        dailyLimit,
+        minIntervalMs,
+      };
+      return {
+        ...rawData,
+        manualForceRefreshQuota: nextQuota,
+      };
+    });
+
+    return result;
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceDeFi.ts
+++ b/packages/kit-bg/src/services/ServiceDeFi.ts
@@ -52,6 +52,11 @@ type IDeFiBuildTransactionApiResp = {
   permit?: IDeFiPermitData | string;
 };
 
+type IManualDeFiForceRefreshConfig = {
+  dailyLimit: number;
+  minIntervalMs: number;
+};
+
 function parseDeFiJsonField<T extends object>({
   fieldName,
   value,
@@ -116,6 +121,10 @@ class ServiceDeFi extends ServiceBase {
   }
 
   _fetchAccountDeFiPositionsControllers: AbortController[] = [];
+
+  private readonly _manualDeFiForceRefreshDefaultDailyLimit = 50;
+
+  private readonly _manualDeFiForceRefreshDefaultMinIntervalMs = 15_000;
 
   // Offsets (ms) from a local tx being confirmed at which we force-refresh
   // the DeFi portfolio for that chain. Covers indexer lag after the tx lands.
@@ -187,6 +196,34 @@ class ServiceDeFi extends ServiceBase {
       controller.abort();
     });
     this._fetchAccountDeFiPositionsControllers = [];
+  }
+
+  private _buildManualDeFiForceRefreshDayKey(now: number) {
+    const date = new Date(now);
+    const year = date.getFullYear();
+    const month = `${date.getMonth() + 1}`.padStart(2, '0');
+    const day = `${date.getDate()}`.padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  @backgroundMethod()
+  public async getManualDeFiForceRefreshConfig(): Promise<IManualDeFiForceRefreshConfig> {
+    return {
+      dailyLimit: this._manualDeFiForceRefreshDefaultDailyLimit,
+      minIntervalMs: this._manualDeFiForceRefreshDefaultMinIntervalMs,
+    };
+  }
+
+  @backgroundMethod()
+  public async consumeManualDeFiForceRefreshQuota() {
+    const config = await this.getManualDeFiForceRefreshConfig();
+    const now = Date.now();
+    return this.backgroundApi.simpleDb.deFi.consumeManualForceRefreshQuota({
+      dayKey: this._buildManualDeFiForceRefreshDayKey(now),
+      now,
+      dailyLimit: config.dailyLimit,
+      minIntervalMs: config.minIntervalMs,
+    });
   }
 
   @backgroundMethod()
@@ -458,6 +495,11 @@ class ServiceDeFi extends ServiceBase {
 
     const key = this._buildDeFiForceRefreshKey(accountId, networkId);
     this._scheduleDeFiForceRefresh(key, {
+      accountId,
+      indexedAccountId,
+      networkId,
+    });
+    return this._runDeFiForceRefresh({
       accountId,
       indexedAccountId,
       networkId,

--- a/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
@@ -969,7 +969,7 @@ function useProtocolPositionActionSubmit({
                 networkId,
                 data,
               });
-              if (finalStatus === EOnChainHistoryTxStatus.Failed) {
+              if (finalStatus !== EOnChainHistoryTxStatus.Success) {
                 return;
               }
               await onSuccess?.({ accountId, networkId, data });

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -2416,12 +2416,13 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       currency?: string,
     ) => {
       const protocol = get(swapTypeSwitchAtom());
+      const shouldFetchOnlyAccountTokens = !isStockProtocol(protocol);
       const result = await backgroundApiProxy.serviceSwap.fetchSwapTokens({
         networkId: accountNetworkId,
         accountNetworkId,
         accountAddress,
         accountId,
-        onlyAccountTokens: true,
+        onlyAccountTokens: shouldFetchOnlyAccountTokens,
         isAllNetworkFetchAccountTokens: true,
         protocol,
         lpToken,

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -253,7 +253,8 @@ function DeFiListBlock({
   const { updateAccountDeFiOverview, updateOverviewDeFiDataState } =
     useAccountOverviewActions().current;
 
-  const { isFocused, isHeaderRefreshing } = useTabIsRefreshingFocused();
+  const { isFocused, isHeaderRefreshing, setIsHeaderRefreshing } =
+    useTabIsRefreshingFocused();
 
   const [overview] = useAccountDeFiOverviewAtom();
   const [{ isRefreshing, initialized, loadedOwnerKey }] =
@@ -272,7 +273,12 @@ function DeFiListBlock({
   const protocolMapRef = useRef(protocolMap);
   protocolsRef.current = protocols;
   protocolMapRef.current = protocolMap;
-  const pendingRefreshRef = useRef(false);
+  const pendingRefreshRef = useRef<
+    | {
+        payload: IAppEventBusPayload[EAppEventBusNames.AccountDataUpdate];
+      }
+    | undefined
+  >(undefined);
   const singleNetworkLocalCacheRef = useRef<{
     cacheKey?: string;
     hasCache: boolean;
@@ -312,7 +318,45 @@ function DeFiListBlock({
     [account?.id, network?.id],
   );
 
-  const isForceRefreshRef = useRef(false);
+  const pendingManualForceRefreshIntentRef = useRef<
+    | {
+        ownerKey: string;
+      }
+    | undefined
+  >(undefined);
+  const allNetworkManualForceRefreshRef = useRef(false);
+  const prepareManualDeFiForceRefresh = useCallback(
+    (payload?: IAppEventBusPayload[EAppEventBusNames.AccountDataUpdate]) => {
+      if (!payload?.isManualRefresh || refreshCacheOnly || !currentOwnerKey) {
+        return;
+      }
+
+      pendingManualForceRefreshIntentRef.current = {
+        ownerKey: currentOwnerKey,
+      };
+    },
+    [currentOwnerKey, refreshCacheOnly],
+  );
+  const consumePendingManualForceRefreshIntent = useCallback(async () => {
+    const intent = pendingManualForceRefreshIntentRef.current;
+    if (!intent) {
+      return false;
+    }
+
+    pendingManualForceRefreshIntentRef.current = undefined;
+    if (!currentOwnerKey || intent.ownerKey !== currentOwnerKey) {
+      return false;
+    }
+
+    try {
+      const { allowed } =
+        await backgroundApiProxy.serviceDeFi.consumeManualDeFiForceRefreshQuota();
+      return allowed;
+    } catch (error) {
+      console.error(error);
+      return false;
+    }
+  }, [currentOwnerKey]);
 
   const computedIsDeFiEnabled = useIsDeFiEnabled(
     network?.id,
@@ -418,6 +462,7 @@ function DeFiListBlock({
           isRefreshing: false,
           loadedOwnerKey: currentOwnerKey,
         });
+        setIsHeaderRefreshing(false);
         return;
       }
 
@@ -443,6 +488,8 @@ function DeFiListBlock({
         const shouldForceInitialRefresh =
           singleNetworkLocalCacheRef.current.cacheKey !== cacheKey ||
           !singleNetworkLocalCacheRef.current.hasCache;
+        const shouldForceManualRefresh =
+          await consumePendingManualForceRefreshIntent();
         const resp =
           await backgroundApiProxy.serviceDeFi.fetchAccountDeFiPositions({
             accountId: account.id,
@@ -454,7 +501,7 @@ function DeFiListBlock({
             targetCurrencyInfo,
             saveToLocal: true,
             isForceRefresh:
-              isForceRefreshRef.current || shouldForceInitialRefresh,
+              shouldForceManualRefresh || shouldForceInitialRefresh,
           });
         if (singleNetworkLocalCacheRef.current.cacheKey === cacheKey) {
           singleNetworkLocalCacheRef.current.hasCache = true;
@@ -485,7 +532,7 @@ function DeFiListBlock({
       } catch (e) {
         console.error(e);
       } finally {
-        isForceRefreshRef.current = false;
+        setIsHeaderRefreshing(false);
         updateDeFiListState(
           deFiListLoadingReducer({
             type: 'settled',
@@ -512,6 +559,8 @@ function DeFiListBlock({
       currentOwnerKey,
       sourceCurrencyInfo,
       targetCurrencyInfo,
+      setIsHeaderRefreshing,
+      consumePendingManualForceRefreshIntent,
     ],
     {
       overrideIsFocused: (isPageFocused) => isPageFocused && isFocused,
@@ -581,7 +630,8 @@ function DeFiListBlock({
         excludeLowValueProtocols: true,
         sourceCurrencyInfo,
         targetCurrencyInfo,
-        isForceRefresh: isForceRefreshRef.current || shouldForceInitialRefresh,
+        isForceRefresh:
+          allNetworkManualForceRefreshRef.current || shouldForceInitialRefresh,
       });
 
       if (!allNetworkDataInit && r.isSameAllNetworksAccountData) {
@@ -692,6 +742,9 @@ function DeFiListBlock({
         return;
       }
 
+      allNetworkManualForceRefreshRef.current =
+        await consumePendingManualForceRefreshIntent();
+
       appEventBus.emit(EAppEventBusNames.TabListStateUpdate, {
         isRefreshing: true,
         type: EHomeTab.DEFI,
@@ -712,6 +765,7 @@ function DeFiListBlock({
       account?.id,
       network?.id,
       refreshCacheOnly,
+      consumePendingManualForceRefreshIntent,
       updateDeFiListState,
       updateOverviewDeFiDataState,
     ],
@@ -826,7 +880,8 @@ function DeFiListBlock({
       accountId?: string;
       networkId?: string;
     }) => {
-      isForceRefreshRef.current = false;
+      allNetworkManualForceRefreshRef.current = false;
+      setIsHeaderRefreshing(false);
 
       if (refreshCacheOnly) {
         return;
@@ -851,7 +906,12 @@ function DeFiListBlock({
         }),
       );
     },
-    [refreshCacheOnly, updateAllNetworkData, updateDeFiListState],
+    [
+      refreshCacheOnly,
+      setIsHeaderRefreshing,
+      updateAllNetworkData,
+      updateDeFiListState,
+    ],
   );
 
   const handleAllNetworkCacheChecked = useCallback(
@@ -1194,7 +1254,14 @@ function DeFiListBlock({
   }, [refreshCacheOnly, refreshSingleNetworkDeFiOverviewByTarget]);
 
   useEffect(() => {
-    const refresh = () => {
+    if (refreshCacheOnly) {
+      return;
+    }
+
+    const refresh = (
+      payload?: IAppEventBusPayload[EAppEventBusNames.AccountDataUpdate],
+    ) => {
+      prepareManualDeFiForceRefresh(payload);
       if (network?.isAllNetworks) {
         void handleRefreshAllNetworkData();
       } else {
@@ -1202,18 +1269,23 @@ function DeFiListBlock({
       }
     };
 
-    const onRefresh = () => {
+    const onRefresh = (
+      payload?: IAppEventBusPayload[EAppEventBusNames.AccountDataUpdate],
+    ) => {
       if (isFocused) {
-        pendingRefreshRef.current = false;
-        refresh();
+        pendingRefreshRef.current = undefined;
+        void refresh(payload);
       } else {
-        pendingRefreshRef.current = true;
+        pendingRefreshRef.current = {
+          payload: payload?.isManualRefresh ? undefined : payload,
+        };
       }
     };
 
     if (isFocused && pendingRefreshRef.current) {
-      pendingRefreshRef.current = false;
-      refresh();
+      const { payload } = pendingRefreshRef.current;
+      pendingRefreshRef.current = undefined;
+      void refresh(payload);
     }
 
     appEventBus.on(EAppEventBusNames.NetworkDeriveTypeChanged, onRefresh);
@@ -1224,7 +1296,14 @@ function DeFiListBlock({
       appEventBus.off(EAppEventBusNames.GlobalDeriveTypeUpdate, onRefresh);
       appEventBus.off(EAppEventBusNames.NetworkDeriveTypeChanged, onRefresh);
     };
-  }, [isFocused, network?.isAllNetworks, handleRefreshAllNetworkData, run]);
+  }, [
+    isFocused,
+    network?.isAllNetworks,
+    handleRefreshAllNetworkData,
+    prepareManualDeFiForceRefresh,
+    refreshCacheOnly,
+    run,
+  ]);
 
   useEffect(() => {
     const onDeFiPositionRefreshed = (
@@ -1423,8 +1502,7 @@ function DeFiListBlock({
   ]);
 
   useEffect(() => {
-    if (isHeaderRefreshing) {
-      isForceRefreshRef.current = true;
+    if (isHeaderRefreshing && !refreshCacheOnly) {
       if (network?.isAllNetworks) {
         handleRefreshAllNetworkData();
       } else {
@@ -1433,6 +1511,7 @@ function DeFiListBlock({
     }
   }, [
     isHeaderRefreshing,
+    refreshCacheOnly,
     run,
     handleRefreshAllNetworkData,
     network?.isAllNetworks,

--- a/packages/kit/src/views/Home/components/PullToRefresh/index.tsx
+++ b/packages/kit/src/views/Home/components/PullToRefresh/index.tsx
@@ -9,7 +9,10 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 export const onHomePageRefresh = () => {
-  appEventBus.emit(EAppEventBusNames.AccountDataUpdate, undefined);
+  appEventBus.emit(EAppEventBusNames.AccountDataUpdate, {
+    isManualRefresh: true,
+    refreshSource: 'pull-to-refresh',
+  });
 };
 
 export interface IPullToRefreshProps {

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -521,7 +521,10 @@ function HomeOverviewContainer() {
   const handleRefreshWorth = useCallback(() => {
     if (isRefreshingWorth) return;
     setIsRefreshingWorth(true);
-    appEventBus.emit(EAppEventBusNames.AccountDataUpdate, undefined);
+    appEventBus.emit(EAppEventBusNames.AccountDataUpdate, {
+      isManualRefresh: true,
+      refreshSource: 'home-header',
+    });
     defaultLogger.account.wallet.walletManualRefresh();
   }, [isRefreshingWorth]);
 

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -126,6 +126,13 @@ export type IEventBusPayloadShowLocalSecretEnvelopeErrorDialog = {
   technicalMessage: string;
 };
 
+export type IEventBusPayloadAccountDataUpdate =
+  | undefined
+  | {
+      isManualRefresh?: boolean;
+      refreshSource?: 'home-header' | 'pull-to-refresh';
+    };
+
 export interface IAppEventBusPayload {
   [EAppEventBusNames.ConfirmAccountSelected]: {
     num: number;
@@ -366,7 +373,7 @@ export interface IAppEventBusPayload {
     accountId: string;
     networkId: string;
   };
-  [EAppEventBusNames.AccountDataUpdate]: undefined;
+  [EAppEventBusNames.AccountDataUpdate]: IEventBusPayloadAccountDataUpdate;
   [EAppEventBusNames.AccountValueUpdate]: undefined;
   [EAppEventBusNames.onDragBeginInListView]: undefined;
   [EAppEventBusNames.onDragEndInListView]: undefined;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57487](https://onekeyhq.atlassian.net/browse/OK-57487)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Restore balance-aware token results for Stock all-network token lists.
- Keep non-Stock all-network account-token prefetch behavior unchanged.

## Intent & Context
The all-network token selector can show Stock recommended tokens without wallet balances even though the same child network shows balances correctly. The intended behavior is for all-network Stock to aggregate child-network token data with the same account-aware semantics as the single-network selector.

## Root Cause
The all-network child-network prefetch path always sent `onlyAccountTokens: true`. For Stock, that skips the normal supported-token-list path that merges account token details, so the all-network UI may fall back to recommended tokens without `balanceParsed` or fiat values.

## Design Decisions
- Scope the behavior change to Stock by deriving `onlyAccountTokens` from the active protocol.
- Preserve existing account-only prefetch behavior for regular Swap protocols to avoid changing wallet-token ordering or payload size outside the Stock selector path.
- Keep the fix in the Jotai all-network prefetch action because the server already supports account-aware child-network token detail requests.

## Changes Detail
- `packages/kit/src/states/jotai/contexts/swap/actions.ts`: use normal token-list fetching for Stock all-network child-network prefetches, while keeping `onlyAccountTokens: true` for other protocols.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Web / Mobile / Extension
- **Risk Areas**: Stock all-network selector ordering and balance merge behavior.

## Runtime Notes
This change affects the main-runtime Jotai action that calls background service APIs through `backgroundApiProxy`. It does not change native shared resources such as MMKV, DB handles, file handles, or native singletons.

## Test plan
- [x] `git diff --check`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/states/jotai/contexts/swap/actions.ts --deny-warnings`
- [x] `yarn jest packages/kit/src/views/Swap/hooks/swapTokenFetchParamsUtils.test.ts --runInBand`
- [x] `yarn lint:staged`
- [ ] `yarn tsc:staged` fails on existing unrelated baseline errors in Sol Trezor `encodedToken` types and missing `HardwareErrorCode.DeviceBusyInternal`.

[OK-57487]: https://onekeyhq.atlassian.net/browse/OK-57487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ