### PR TITLE
fix: warm up Lit metadata before SES lockdown

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -25,6 +25,7 @@ googleusercontent
 0xf7ad23226db5c1c00ca0ca1468fd49c8f8bbc1489bc1c382de5adc557a69c229
 0xffffffffffffffffn
 reown
+Reown
 cloudfs
 morelink
 worktrees
@@ -56,6 +57,14 @@ wui
 deeplinks
 minmov
 appkit
+AppKit
+alephium
+jsbi
+JSBI
+lockdown
+Lockdown
+LOCKDOWN
+unpermitted
 wcm
 perp
 hyperliquid

--- a/packages/shared/src/security/sesHarden/runtime.ts
+++ b/packages/shared/src/security/sesHarden/runtime.ts
@@ -1,5 +1,3 @@
-// cspell:ignore lockdown Lockdown jsbi Reown unpermitted
-
 import { OneKeyLocalError } from '../../errors';
 
 import { getConfiguredSesHardenLevel } from './config';

--- a/packages/shared/src/security/sesHarden/runtime.ts
+++ b/packages/shared/src/security/sesHarden/runtime.ts
@@ -365,33 +365,6 @@ function defaultLoadSes(): void {
   require('ses');
 }
 
-// Dependencies that perform the SES "override mistake" at module-init time:
-// they assign `.constructor` (or another frozen-intrinsic property) onto an
-// object whose prototype chain reaches Object.prototype, which throws (in
-// strict mode) once `lockdown()` freezes Object.prototype — unless override for
-// that property is enabled.
-//
-// The PRIMARY fix is `overrideTaming: 'severe'` (see options.ts): it enables
-// override for all of Object.prototype, so these libraries work even when loaded
-// after lockdown. Keep startup warm-up limited to dependencies that are already
-// otherwise needed by the initial graph; pulling optional offenders in here
-// regresses Web cold start.
-//
-// Confirmed offenders (surfaced by the patch-warning monitor):
-//  - axios (lazily pulled in by @ton/ton's HttpApi, so it initializes AFTER
-//    lockdown) runs a "reserved names hotfix" at module init: reduceDescriptors
-//    assigns `constructor` onto a fresh `{}` whose prototype is the frozen
-//    Object.prototype.
-// bn.js / elliptic are NOT offenders (their inherits() chains keep a writable
-// own constructor). Behavior is locked down by sesHardenLibCompat.test.ts. Add
-// new offenders here as the patch-warning monitor surfaces their `culprit`.
-//
-// NOTE: a library that mutates a STANDARD intrinsic (adds non-standard own
-// properties to BigInt/Number/etc.) usually cannot be fixed by warm-up:
-// lockdown() REMOVES unpermitted intrinsics, so the additions are stripped
-// regardless of load order. js-conflux-sdk's jsbi shim hit exactly this; it is
-// fixed by making the shim self-contained instead
-// (patches/js-conflux-sdk+2.3.0.patch).
 function warmUpLitSymbolMetadata(): void {
   try {
     // Lit's @lit/reactive-element does this at module init because TypeScript
@@ -407,15 +380,25 @@ function warmUpLitSymbolMetadata(): void {
   }
 }
 
-function defaultWarmUpBeforeLockdown(): void {
-  warmUpLitSymbolMetadata();
-
+function warmUpAxiosReservedNamesHotfix(): void {
   try {
+    // Axios runs a reserved-names hotfix at module init. Loading it before
+    // lockdown lets that write happen while Object.prototype is still mutable.
+    // The primary compatibility fix for override mistakes remains
+    // `overrideTaming: 'severe'`; this warm-up is defense in depth for the
+    // lazy @ton/ton HttpApi path.
     // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
     require('axios');
   } catch {
     // Best-effort: a failed/missing warm-up must never block startup.
   }
+}
+
+function defaultWarmUpBeforeLockdown(): void {
+  // Keep this registry narrow. Package-specific SES behavior is documented next
+  // to each warm-up helper and pinned by sesHardenLibCompat.test.ts.
+  warmUpLitSymbolMetadata();
+  warmUpAxiosReservedNamesHotfix();
 }
 
 function getLockdownAfterLoad(

--- a/packages/shared/src/security/sesHarden/runtime.ts
+++ b/packages/shared/src/security/sesHarden/runtime.ts
@@ -1,4 +1,4 @@
-// cspell:ignore lockdown Lockdown jsbi unpermitted
+// cspell:ignore lockdown Lockdown jsbi Reown unpermitted
 
 import { OneKeyLocalError } from '../../errors';
 
@@ -389,11 +389,29 @@ function defaultLoadSes(): void {
 // new offenders here as the patch-warning monitor surfaces their `culprit`.
 //
 // NOTE: a library that mutates a STANDARD intrinsic (adds non-standard own
-// properties to BigInt/Number/etc.) cannot be fixed by warm-up: lockdown()
-// REMOVES unpermitted intrinsics, so the additions are stripped regardless of
-// load order. js-conflux-sdk's jsbi shim hit exactly this; it is fixed by
-// making the shim self-contained instead (patches/js-conflux-sdk+2.3.0.patch).
+// properties to BigInt/Number/etc.) usually cannot be fixed by warm-up:
+// lockdown() REMOVES unpermitted intrinsics, so the additions are stripped
+// regardless of load order. js-conflux-sdk's jsbi shim hit exactly this; it is
+// fixed by making the shim self-contained instead
+// (patches/js-conflux-sdk+2.3.0.patch).
+function warmUpLitSymbolMetadata(): void {
+  try {
+    // Lit's @lit/reactive-element does this at module init because TypeScript
+    // does not polyfill decorator metadata. Reown AppKit can lazy-load Lit
+    // after lockdown, where adding a property to the frozen Symbol constructor
+    // throws "Cannot add property metadata, object is not extensible".
+    const symbolConstructor = Symbol as unknown as {
+      metadata?: symbol;
+    };
+    symbolConstructor.metadata ??= Symbol('metadata');
+  } catch {
+    // Best-effort: a failed warm-up must never block startup.
+  }
+}
+
 function defaultWarmUpBeforeLockdown(): void {
+  warmUpLitSymbolMetadata();
+
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
     require('axios');

--- a/packages/shared/src/security/sesHarden/sesHarden.test.ts
+++ b/packages/shared/src/security/sesHarden/sesHarden.test.ts
@@ -106,6 +106,39 @@ test('warms up override-mistake libraries before calling lockdown', () => {
   expect(calls).toEqual(['warmUp', 'lockdown']);
 });
 
+test('default warm-up seeds Lit Symbol.metadata before calling lockdown', () => {
+  const symbolConstructor = Symbol as unknown as {
+    metadata?: symbol;
+  };
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    Symbol,
+    'metadata',
+  );
+  let metadataDuringLockdown: symbol | undefined;
+
+  try {
+    if (originalDescriptor?.configurable !== false) {
+      Reflect.deleteProperty(Symbol, 'metadata');
+    }
+
+    maybeLockdownOneKeyRuntime({
+      runtime: 'web',
+      level: 'L2',
+      lockdown: jest.fn(() => {
+        metadataDuringLockdown = symbolConstructor.metadata;
+      }),
+    });
+
+    expect(typeof metadataDuringLockdown).toBe('symbol');
+  } finally {
+    if (originalDescriptor) {
+      Object.defineProperty(Symbol, 'metadata', originalDescriptor);
+    } else {
+      Reflect.deleteProperty(Symbol, 'metadata');
+    }
+  }
+});
+
 test('does not warm up when lockdown is skipped (L0)', () => {
   const warmUp = jest.fn();
 

--- a/packages/shared/src/security/sesHarden/sesHardenLibCompat.test.ts
+++ b/packages/shared/src/security/sesHarden/sesHardenLibCompat.test.ts
@@ -203,6 +203,9 @@ try {
 test('@reown/appkit-ui throws when lazy-loaded AFTER lockdown without Symbol.metadata warm-up', () => {
   const out = runUnderLockdown(`
 (async () => {
+  // Keep this test focused on SES metadata. If package export conditions pick
+  // Lit's browser build, importing Lit also needs the web-component base class.
+  globalThis.HTMLElement ??= class HTMLElement {};
   require('ses');
   lockdown(opts);
   try {
@@ -221,6 +224,9 @@ test('@reown/appkit-ui throws when lazy-loaded AFTER lockdown without Symbol.met
 test('@reown/appkit-ui works AFTER lockdown when Symbol.metadata is warmed up', () => {
   const out = runUnderLockdown(`
 (async () => {
+  // Keep this test focused on SES metadata. If package export conditions pick
+  // Lit's browser build, importing Lit also needs the web-component base class.
+  globalThis.HTMLElement ??= class HTMLElement {};
   require('ses');
   Symbol.metadata ??= Symbol('metadata');
   lockdown(opts);
@@ -239,6 +245,9 @@ test('@reown/appkit-ui works AFTER lockdown when Symbol.metadata is warmed up', 
 test('@lit/reactive-element throws when lazy-loaded AFTER lockdown without Symbol.metadata warm-up', () => {
   const out = runUnderLockdown(`
 (async () => {
+  // Keep this test focused on SES metadata. If package export conditions pick
+  // Lit's browser build, importing Lit also needs the web-component base class.
+  globalThis.HTMLElement ??= class HTMLElement {};
   require('ses');
   lockdown(opts);
   try {
@@ -257,6 +266,9 @@ test('@lit/reactive-element throws when lazy-loaded AFTER lockdown without Symbo
 test('@lit/reactive-element works AFTER lockdown when Symbol.metadata is warmed up', () => {
   const out = runUnderLockdown(`
 (async () => {
+  // Keep this test focused on SES metadata. If package export conditions pick
+  // Lit's browser build, importing Lit also needs the web-component base class.
+  globalThis.HTMLElement ??= class HTMLElement {};
   require('ses');
   Symbol.metadata ??= Symbol('metadata');
   lockdown(opts);

--- a/packages/shared/src/security/sesHarden/sesHardenLibCompat.test.ts
+++ b/packages/shared/src/security/sesHarden/sesHardenLibCompat.test.ts
@@ -1,4 +1,4 @@
-// cspell:ignore alephium lockdown jsbi JSBI unpermitted
+// cspell:ignore alephium appkit lockdown jsbi JSBI reown unpermitted
 // Verifies how specific third-party libraries behave under a real SES
 // `lockdown()`. `lockdown()` irreversibly freezes the realm's intrinsics, so
 // every scenario runs in its own child node process.
@@ -192,6 +192,84 @@ try {
     MODERATE_OPTIONS,
   );
   expect(out).toBe('OK:bar');
+});
+
+// --- Reown AppKit UI / Lit: Symbol.metadata must be warmed up --------------
+// @reown/appkit-ui imports Lit at module init. Lit seeds Symbol.metadata for
+// decorator metadata support, but the Symbol constructor is already frozen
+// after lockdown. The runtime warm-up seeds Symbol.metadata before lockdown so
+// AppKit UI can still be lazy-loaded by the WalletConnect flow.
+
+test('@reown/appkit-ui throws when lazy-loaded AFTER lockdown without Symbol.metadata warm-up', () => {
+  const out = runUnderLockdown(`
+(async () => {
+  require('ses');
+  lockdown(opts);
+  try {
+    await import('@reown/appkit-ui');
+    process.stdout.write('OK');
+  } catch (e) {
+    process.stdout.write('ERR:' + e.message);
+  }
+})();
+`);
+  expect(out).toContain(
+    'ERR:Cannot add property metadata, object is not extensible',
+  );
+});
+
+test('@reown/appkit-ui works AFTER lockdown when Symbol.metadata is warmed up', () => {
+  const out = runUnderLockdown(`
+(async () => {
+  require('ses');
+  Symbol.metadata ??= Symbol('metadata');
+  lockdown(opts);
+  try {
+    await import('@reown/appkit-ui');
+    process.stdout.write('OK:' + Boolean(Symbol.metadata));
+  } catch (e) {
+    process.stdout.write('ERR:' + e.message);
+  }
+})();
+`);
+  expect(out).toContain('OK:true');
+  expect(out).not.toContain('ERR:');
+});
+
+test('@lit/reactive-element throws when lazy-loaded AFTER lockdown without Symbol.metadata warm-up', () => {
+  const out = runUnderLockdown(`
+(async () => {
+  require('ses');
+  lockdown(opts);
+  try {
+    await import('@lit/reactive-element');
+    process.stdout.write('OK');
+  } catch (e) {
+    process.stdout.write('ERR:' + e.message);
+  }
+})();
+`);
+  expect(out).toContain(
+    'ERR:Cannot add property metadata, object is not extensible',
+  );
+});
+
+test('@lit/reactive-element works AFTER lockdown when Symbol.metadata is warmed up', () => {
+  const out = runUnderLockdown(`
+(async () => {
+  require('ses');
+  Symbol.metadata ??= Symbol('metadata');
+  lockdown(opts);
+  try {
+    await import('@lit/reactive-element');
+    process.stdout.write('OK:' + Boolean(Symbol.metadata));
+  } catch (e) {
+    process.stdout.write('ERR:' + e.message);
+  }
+})();
+`);
+  expect(out).toContain('OK:true');
+  expect(out).not.toContain('ERR:');
 });
 
 // --- js-conflux-sdk: the jsbi shim must be self-contained (patch-package) ----

--- a/packages/shared/src/security/sesHarden/sesHardenLibCompat.test.ts
+++ b/packages/shared/src/security/sesHarden/sesHardenLibCompat.test.ts
@@ -1,4 +1,3 @@
-// cspell:ignore alephium appkit lockdown jsbi JSBI reown unpermitted
 // Verifies how specific third-party libraries behave under a real SES
 // `lockdown()`. `lockdown()` irreversibly freezes the realm's intrinsics, so
 // every scenario runs in its own child node process.


### PR DESCRIPTION
## Summary
- Seed `Symbol.metadata` during the shared SES warm-up before `lockdown()` freezes intrinsics.
- Add SES compatibility coverage for `@reown/appkit-ui` and `@lit/reactive-element` lazy-loading after lockdown.
- Add a unit test proving the default warm-up runs before lockdown and seeds Lit metadata.

## Intent & Context
WalletConnect could white-screen in the desktop renderer when Reown AppKit UI was loaded lazily. The observed stack was `@reown/appkit-ui -> lit -> @lit/reactive-element`, ending with `TypeError: Cannot add property metadata, object is not extensible`.

## Root Cause
The crash happens in the main UI runtime after SES lockdown. `@lit/reactive-element` initializes by running `Symbol.metadata ??= Symbol("metadata")`, but after lockdown the `Symbol` constructor is frozen and cannot accept new properties. The background runtime can start the WalletConnect flow, but the exception is in the renderer UI runtime when AppKit UI loads.

## Design Decisions
- Use the existing shared SES warm-up path instead of changing WalletConnect or Reown code.
- Seed only `Symbol.metadata`, rather than importing all of Lit or AppKit during startup, to avoid pulling optional UI code into the cold-start graph.
- Keep the existing axios warm-up behavior unchanged.

## Changes Detail
- `packages/shared/src/security/sesHarden/runtime.ts`: adds Lit metadata warm-up before lockdown.
- `packages/shared/src/security/sesHarden/sesHarden.test.ts`: verifies the default warm-up seeds `Symbol.metadata` before lockdown.
- `packages/shared/src/security/sesHarden/sesHardenLibCompat.test.ts`: verifies both `@reown/appkit-ui` and `@lit/reactive-element` fail without the warm-up and work with it.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop, Web
- **Risk Areas**: SES hardening startup path. The change is intentionally narrow and does not preload Reown AppKit or Lit.

## Test plan
- [x] `yarn test packages/shared/src/security/sesHarden/sesHarden.test.ts packages/shared/src/security/sesHarden/sesHardenLibCompat.test.ts --runInBand`
- [x] `yarn tsc:staged`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/shared/src/security/sesHarden/runtime.ts packages/shared/src/security/sesHarden/sesHarden.test.ts packages/shared/src/security/sesHarden/sesHardenLibCompat.test.ts --deny-warnings`
