### PR TITLE
fix: update market chart control icons(OK-57165 OK-57365)

### DIFF
--- a/packages/components/src/primitives/Icon/Icons.tsx
+++ b/packages/components/src/primitives/Icon/Icons.tsx
@@ -46,6 +46,10 @@ const icons = {
   RestartToUpdateCustom: () => import("./react/custom/RestartToUpdate"),
   ShortcutsCustom: () => import("./react/custom/Shortcuts"),
   SidebarLeftArrowCustom: () => import("./react/custom/SidebarLeftArrow"),
+  TradingViewExitFullscreenCustom: () =>
+    import("./react/custom/TradingViewExitFullscreen"),
+  TradingViewFullscreenCustom: () =>
+    import("./react/custom/TradingViewFullscreen"),
   AkashIllus: () => import("./react/illus/Akash"),
   AlgorandIllus: () => import("./react/illus/Algorand"),
   AllNetworksIllus: () => import("./react/illus/AllNetworks"),

--- a/packages/components/src/primitives/Icon/react/custom/TradingViewExitFullscreen.tsx
+++ b/packages/components/src/primitives/Icon/react/custom/TradingViewExitFullscreen.tsx
@@ -1,0 +1,14 @@
+import Svg, { Path } from 'react-native-svg';
+import type { SvgProps } from 'react-native-svg';
+const SvgTradingViewExitFullscreen = (props: SvgProps) => (
+  <Svg fill="none" viewBox="0 0 24 24" accessibilityRole="image" {...props}>
+    <Path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M4 14h6v6M20 10h-6V4M14 10l7-7M3 21l7-7"
+    />
+  </Svg>
+);
+export default SvgTradingViewExitFullscreen;

--- a/packages/components/src/primitives/Icon/react/custom/TradingViewFullscreen.tsx
+++ b/packages/components/src/primitives/Icon/react/custom/TradingViewFullscreen.tsx
@@ -1,0 +1,14 @@
+import Svg, { Path } from 'react-native-svg';
+import type { SvgProps } from 'react-native-svg';
+const SvgTradingViewFullscreen = (props: SvgProps) => (
+  <Svg fill="none" viewBox="0 0 24 24" accessibilityRole="image" {...props}>
+    <Path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7"
+    />
+  </Svg>
+);
+export default SvgTradingViewFullscreen;

--- a/packages/components/src/primitives/Icon/react/custom/index.ts
+++ b/packages/components/src/primitives/Icon/react/custom/index.ts
@@ -7,3 +7,5 @@ export { default as OnekeyDevice } from './OnekeyDevice';
 export { default as RestartToUpdate } from './RestartToUpdate';
 export { default as Shortcuts } from './Shortcuts';
 export { default as SidebarLeftArrow } from './SidebarLeftArrow';
+export { default as TradingViewExitFullscreen } from './TradingViewExitFullscreen';
+export { default as TradingViewFullscreen } from './TradingViewFullscreen';

--- a/packages/components/svg/custom/trading-view-exit-fullscreen.svg
+++ b/packages/components/svg/custom/trading-view-exit-fullscreen.svg
@@ -1,0 +1,6 @@
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <polyline points="4 14 10 14 10 20" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="20 10 14 10 14 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="14" y1="10" x2="21" y2="3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="3" y1="21" x2="10" y2="14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/components/svg/custom/trading-view-fullscreen.svg
+++ b/packages/components/svg/custom/trading-view-fullscreen.svg
@@ -1,0 +1,6 @@
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <polyline points="15 3 21 3 21 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="9 21 3 21 3 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="21" y1="3" x2="14" y2="10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="3" y1="21" x2="10" y2="14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/chartControls/TradingViewNativeChartControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/chartControls/TradingViewNativeChartControls.tsx
@@ -344,7 +344,11 @@ export const TradingViewNativeChartControls = memo(
         testID="trading-view-native-fullscreen-toggle"
         size="small"
         variant="tertiary"
-        icon={isFullscreen ? 'MinimizeOutline' : 'ExpandOutline'}
+        icon={
+          isFullscreen
+            ? 'TradingViewExitFullscreenCustom'
+            : 'TradingViewFullscreenCustom'
+        }
         iconSize="$5"
         title={intl.formatMessage({
           id: isFullscreen
@@ -373,7 +377,7 @@ export const TradingViewNativeChartControls = memo(
             testID="trading-view-native-redo"
             size="small"
             variant="tertiary"
-            icon="RedoOutline"
+            icon="UndoFlipHorOutline"
             iconSize="$5"
             title={intl.formatMessage({ id: ETranslations.menu_redo })}
             onPress={onRedo}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57165](https://onekeyhq.atlassian.net/browse/OK-57165) [OK-57365](https://onekeyhq.atlassian.net/browse/OK-57365)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Added TradingView fullscreen and exit-fullscreen icons to the shared component icon set.
- Updated the Market chart fullscreen toggle to use the TradingView-style icons.
- Updated the chart redo/forward control to use Erik's recent `UndoFlipHorOutline` icon.

## Intent & Context
Page feedback on the Market token detail chart toolbar requested the fullscreen/minimize control to use the same icon style as the TradingView/Perps chart control, and clarified that the forward control should use the recently added icon already in this codebase.

Related issues: OK-57165, OK-57365.

## Root Cause
The native Market chart controls were still using generic component icons: `ExpandOutline`, `MinimizeOutline`, and `RedoOutline`. Those did not match the TradingView-style fullscreen glyphs or the newer forward icon added by Erik.

## Design Decisions
- Kept the fullscreen glyphs in the existing components icon pipeline by adding SVG sources under `packages/components/svg/custom` and generated React icon components.
- Reused the existing `UndoFlipHorOutline` icon for the redo/forward button instead of adding another duplicate icon.
- Left the chart bridge and button behavior unchanged; only icon rendering changed.

## Changes Detail
- `packages/components/svg/custom/trading-view-fullscreen.svg` and `trading-view-exit-fullscreen.svg`: source SVGs copied from the TradingView chart implementation.
- `packages/components/src/primitives/Icon/react/custom/*` and `Icons.tsx`: generated/registered shared icon components.
- `TradingViewNativeChartControls.tsx`: swapped fullscreen/minimize icon names and changed redo to `UndoFlipHorOutline`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Market chart toolbar surfaces using native chart controls, including desktop/web and native hosts.
- **Risk Areas**: Visual regression only; click handlers and message flow are unchanged.

## Test plan
- [x] yarn icon:build
- [x] yarn lint:staged
- [x] yarn tsc:staged

[OK-57165]: https://onekeyhq.atlassian.net/browse/OK-57165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-57365]: https://onekeyhq.atlassian.net/browse/OK-57365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ