### PR TITLE
fix: open TradingView chart settings from market desktop

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewV2/components/chartControls/TradingViewNativeChartControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/chartControls/TradingViewNativeChartControls.tsx
@@ -74,6 +74,7 @@ interface ITradingViewNativeChartControlsProps {
   onPriceScaleModeChange: (mode: ITradingViewPriceScaleMode) => void;
   onPriceMarketCapModeChange: (mode: ITradingViewPriceMarketCapMode) => void;
   onCalendarPanelSubmit?: (payload: ICalendarPanelSubmitPayload) => void;
+  onOpenChartSettings?: () => void;
   onUndo?: () => void;
   onRedo?: () => void;
   onFullscreenChange?: (isFullscreen: boolean) => void;
@@ -102,6 +103,7 @@ export const TradingViewNativeChartControls = memo(
     onPriceScaleModeChange,
     onPriceMarketCapModeChange,
     onCalendarPanelSubmit,
+    onOpenChartSettings,
     onUndo,
     onRedo,
     onFullscreenChange,
@@ -227,6 +229,15 @@ export const TradingViewNativeChartControls = memo(
       onFullscreenChange?.(!isFullscreen);
     }, [isFullscreen, onFullscreenChange]);
 
+    const handleSettingsPress = useCallback(() => {
+      if (isDesktopLayout && onOpenChartSettings) {
+        onOpenChartSettings();
+        return;
+      }
+
+      showChartSettingsDialog();
+    }, [isDesktopLayout, onOpenChartSettings, showChartSettingsDialog]);
+
     const chartTypeControl = useMemo(() => {
       if (showChartTypeSelect) {
         return (
@@ -334,7 +345,7 @@ export const TradingViewNativeChartControls = memo(
         icon="SliderHorOutline"
         iconSize="$5"
         title={chartSettingsTitle}
-        onPress={showChartSettingsDialog}
+        onPress={handleSettingsPress}
         {...HEADER_ICON_BUTTON_STYLE_PROPS}
       />
     ) : null;

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
@@ -84,6 +84,8 @@ const TRADINGVIEW_RESET_LAYOUT_MESSAGE = 'TRADINGVIEW_RESET_LAYOUT';
 const TRADINGVIEW_PRICE_SCALE_CHANGE_MESSAGE = 'TRADINGVIEW_PRICE_SCALE_CHANGE';
 const TRADINGVIEW_PRICE_MARKET_CAP_CHANGE_MESSAGE =
   'TRADINGVIEW_PRICE_MARKET_CAP_CHANGE';
+const TRADINGVIEW_OPEN_CHART_SETTINGS_MESSAGE =
+  'TRADINGVIEW_OPEN_CHART_SETTINGS';
 const TRADINGVIEW_CALENDAR_PANEL_SUBMIT_MESSAGE =
   'TRADINGVIEW_CALENDAR_PANEL_SUBMIT';
 const TRADINGVIEW_UNDO_MESSAGE = 'TRADINGVIEW_UNDO';
@@ -330,6 +332,12 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     },
     [],
   );
+  const handleNativeOpenChartSettings = useCallback(() => {
+    webRef.current?.sendMessageViaInjectedScript({
+      type: TRADINGVIEW_OPEN_CHART_SETTINGS_MESSAGE,
+      payload: {},
+    });
+  }, []);
   const handleNativeCalendarPanelSubmit = useCallback(
     (payload: ICalendarPanelSubmitPayload) => {
       webRef.current?.sendMessageViaInjectedScript({
@@ -710,6 +718,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
           onResetLayout={handleNativeResetLayout}
           onPriceScaleModeChange={handleNativePriceScaleModeChange}
           onPriceMarketCapModeChange={handleNativePriceMarketCapModeChange}
+          onOpenChartSettings={handleNativeOpenChartSettings}
           onCalendarPanelSubmit={handleNativeCalendarPanelSubmit}
           onUndo={handleNativeUndo}
           onRedo={handleNativeRedo}


### PR DESCRIPTION
## Summary
- Route the Market desktop chart settings button to TradingView's internal settings panel.
- Keep the existing OneKey chart settings dialog for non-desktop native-control layouts.

## Intent & Context
The page feedback reported that the Market token detail desktop settings button currently opens a OneKey dialog. The requested behavior is for desktop to notify TradingView and open TradingView's own internal settings panel.

## Root Cause
The desktop settings button used the same local Dialog path as mobile-style native chart controls. It did not send an app-to-chart command for TradingView to open its internal chart settings UI.

## Design Decisions
- Desktop layout sends a single TRADINGVIEW_OPEN_CHART_SETTINGS message to the embedded chart.
- Non-desktop layouts keep the existing OneKey dialog behavior.
- The app side does not add platform-specific disabled-feature rules; the chart side is responsible for showing settings when it receives the message.

## Changes Detail
- Added an optional onOpenChartSettings callback to TradingViewNativeChartControls.
- Desktop settings button calls onOpenChartSettings when provided.
- TradingViewV2 sends TRADINGVIEW_OPEN_CHART_SETTINGS via sendMessageViaInjectedScript.

## Related PR
- https://github.com/OneKeyHQ/tradingview-charting-library/pull/193

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop, Web
- **Risk Areas**: App-to-chart message compatibility; requires the chart-side handler from the related PR.

## Test plan
- [x] yarn tsc:only
- [x] yarn lint:staged
- [x] yarn tsc:staged
- [x] git diff --check
