### PR TITLE
fix: ignore stale bulk send validation results(OK-57475)

### DIFF
--- a/packages/kit/src/views/BulkSend/hooks/useDebouncedValidation.test.ts
+++ b/packages/kit/src/views/BulkSend/hooks/useDebouncedValidation.test.ts
@@ -62,6 +62,70 @@ describe('useDebouncedValidation', () => {
     expect(nextValidateFn).toHaveBeenCalledWith('0xabc');
   });
 
+  it('re-runs in-flight validation when validateFn changes after the debounce fires', async () => {
+    let resolveStaleValidation: ((value: string | boolean) => void) | undefined;
+    let resolveLatestValidation:
+      | ((value: string | boolean) => void)
+      | undefined;
+    const validateFn = jest.fn<Promise<string | boolean>, [string]>(
+      () =>
+        new Promise((resolve) => {
+          resolveStaleValidation = resolve;
+        }),
+    );
+    const nextValidateFn = jest.fn<Promise<string | boolean>, [string]>(
+      () =>
+        new Promise((resolve) => {
+          resolveLatestValidation = resolve;
+        }),
+    );
+    const { result, rerender } = renderHook(
+      ({ fn }) => useDebouncedValidation(fn, 300),
+      {
+        initialProps: {
+          fn: validateFn,
+        },
+      },
+    );
+
+    let resolvedValue: string | boolean | undefined;
+    let validationPromise: Promise<string | boolean> | undefined;
+
+    act(() => {
+      validationPromise = result.current.validate('0xabc').then((value) => {
+        resolvedValue = value;
+        return value;
+      });
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+    expect(validateFn).toHaveBeenCalledWith('0xabc');
+
+    rerender({ fn: nextValidateFn });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(nextValidateFn).toHaveBeenCalledWith('0xabc');
+
+    await act(async () => {
+      resolveStaleValidation?.('stale invalid');
+      await Promise.resolve();
+    });
+    expect(resolvedValue).toBeUndefined();
+
+    await act(async () => {
+      resolveLatestValidation?.(true);
+      await Promise.resolve();
+    });
+
+    await expect(validationPromise).resolves.toBe(true);
+    expect(resolvedValue).toBe(true);
+  });
+
   it('resolves with the validator result once the debounce fires', async () => {
     const validateFn = jest.fn<Promise<string | boolean>, [string]>(
       async (value) => (value === '0xgood' ? true : 'bad address'),

--- a/packages/kit/src/views/BulkSend/hooks/useDebouncedValidation.ts
+++ b/packages/kit/src/views/BulkSend/hooks/useDebouncedValidation.ts
@@ -9,17 +9,12 @@ export function useDebouncedValidation<T extends string>(
   validateFn: (value: T) => Promise<string | boolean>,
   delay = 300,
 ): IDebouncedValidation<T> {
-  // Keep the latest validateFn in a ref so identity churn (e.g. `network` /
-  // `vaultSettings` resolving asynchronously while the user is entering
-  // addresses) never cancels an in-flight validation. Previously, a changed
-  // validateFn force-resolved the pending validation to `false`, which left the
-  // field invalid with an empty error message: react-hook-form renders no error
-  // text for a boolean-`false` result, so the Next button stayed disabled and
-  // invalid addresses produced no visible error. When the debounce fires we
-  // always run the current validator, so the value is re-checked with the
-  // freshest network/token context and resolves with the real result.
   const validateFnRef = useRef(validateFn);
-  validateFnRef.current = validateFn;
+  const validateFnVersionRef = useRef(0);
+  if (validateFnRef.current !== validateFn) {
+    validateFnRef.current = validateFn;
+    validateFnVersionRef.current += 1;
+  }
 
   const currentValueRef = useRef<T>('' as T);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -27,10 +22,59 @@ export function useDebouncedValidation<T extends string>(
     null,
   );
   const validationVersionRef = useRef(0);
+  const activeValidationRunRef = useRef(0);
   // Track the last validation result so cancelled promises preserve error state
   const lastResultRef = useRef<string | boolean>(true);
 
+  const startValidation = useCallback(
+    (
+      value: T,
+      resolve: (value: string | boolean) => void,
+      validationVersion: number,
+    ) => {
+      activeValidationRunRef.current += 1;
+      const validationRun = activeValidationRunRef.current;
+
+      void (async () => {
+        let shouldValidate = true;
+        while (shouldValidate) {
+          shouldValidate = false;
+          const validateFnVersion = validateFnVersionRef.current;
+          let result: string | boolean;
+
+          try {
+            result = await validateFnRef.current(value);
+          } catch {
+            result = false;
+          }
+
+          if (
+            validationVersionRef.current !== validationVersion ||
+            currentValueRef.current !== value ||
+            pendingResolveRef.current !== resolve ||
+            activeValidationRunRef.current !== validationRun
+          ) {
+            return;
+          }
+
+          // Validator context changed while this async call was awaiting, so
+          // resolve the pending form validation with a fresh result instead.
+          if (validateFnVersionRef.current !== validateFnVersion) {
+            shouldValidate = true;
+          } else {
+            lastResultRef.current = result;
+            resolve(result);
+            pendingResolveRef.current = null;
+            return;
+          }
+        }
+      })();
+    },
+    [],
+  );
+
   const cancel = useCallback((result = lastResultRef.current) => {
+    activeValidationRunRef.current += 1;
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current);
       debounceTimerRef.current = null;
@@ -40,6 +84,19 @@ export function useDebouncedValidation<T extends string>(
       pendingResolveRef.current = null;
     }
   }, []);
+
+  useEffect(() => {
+    const pendingResolve = pendingResolveRef.current;
+    if (!pendingResolve || debounceTimerRef.current) {
+      return;
+    }
+
+    startValidation(
+      currentValueRef.current,
+      pendingResolve,
+      validationVersionRef.current,
+    );
+  }, [startValidation, validateFn]);
 
   // Clean up pending validation on unmount.
   useEffect(
@@ -62,34 +119,12 @@ export function useDebouncedValidation<T extends string>(
         cancel();
         pendingResolveRef.current = resolve;
 
-        debounceTimerRef.current = setTimeout(async () => {
+        debounceTimerRef.current = setTimeout(() => {
           debounceTimerRef.current = null;
-          try {
-            const result = await validateFnRef.current(value);
-            if (
-              validationVersionRef.current === validationVersion &&
-              currentValueRef.current === value &&
-              pendingResolveRef.current === resolve
-            ) {
-              lastResultRef.current = result;
-              resolve(result);
-              pendingResolveRef.current = null;
-            }
-          } catch {
-            // Resolve with false on error to prevent hanging validation
-            if (
-              validationVersionRef.current === validationVersion &&
-              currentValueRef.current === value &&
-              pendingResolveRef.current === resolve
-            ) {
-              lastResultRef.current = false;
-              resolve(false);
-              pendingResolveRef.current = null;
-            }
-          }
+          startValidation(value, resolve, validationVersion);
         }, delay);
       }),
-    [cancel, delay],
+    [cancel, delay, startValidation],
   );
 
   return useMemo(() => ({ validate, cancel }), [validate, cancel]);


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57475](https://onekeyhq.atlassian.net/browse/OK-57475)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Ignore stale Bulk Send validation results when the validator changes after the debounce timer has already fired.
- Re-run the current field value with the latest validator context instead of resolving the form with an old async result.
- Add regression coverage for validator churn during in-flight validation.

## Intent & Context
PR #12320 fixed the pre-debounce validator identity churn case, but one unresolved review comment pointed out a second race: after the 300ms debounce fires, the old validator can already be awaiting background checks while network, token, vault settings, or allowlist context changes. In that case, the old async result could still resolve the React Hook Form validation promise and leave stale errors or stale success state until the user edits the field again.

This change addresses that unresolved review comment without restoring the old behavior that force-resolved pending validation to false.

## Root Cause
useDebouncedValidation stored the latest validateFn in a ref and read it when the timer fired, but it no longer invalidated validator changes after validation had started. The existing guards only checked the validation version, current value, and resolver identity. None of those changed when only validateFn context changed during an awaited async call, so stale results could be accepted.

## Design Decisions
- Keep the validateFn ref so pre-debounce validator churn still uses the latest context.
- Track a validateFn version separately so post-debounce async results can detect that their validator context became stale while awaiting.
- Re-run the same current value with the latest validator before resolving the pending form validation promise, avoiding both stale results and hanging React Hook Form validation.
- Keep cancellation behavior based on the last known result so Android controlled TextInput behavior remains unchanged.

## Changes Detail
- packages/kit/src/views/BulkSend/hooks/useDebouncedValidation.ts: adds validator version tracking and an active validation run guard, and reruns stale in-flight validations with the latest validator.
- packages/kit/src/views/BulkSend/hooks/useDebouncedValidation.test.ts: adds a regression test for debounce fired -> validateFn changes -> old async resolves, proving the stale result is ignored and the latest result resolves the form.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Runtime Impact**: Main JS form validation only. Background JS services may still be called by the validator, but this change does not alter bg runtime state, shared native resources, or per-runtime JS heap residency.
- **Risk Areas**: Debounced validation timing and React Hook Form promise settlement. The main risk is repeated validation if validator identity changes frequently while async validation is in flight.

## Test plan
- [x] npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/BulkSend/hooks/useDebouncedValidation.ts packages/kit/src/views/BulkSend/hooks/useDebouncedValidation.test.ts
- [x] yarn jest packages/kit/src/views/BulkSend/hooks/useDebouncedValidation.test.ts --runInBand
- [x] yarn lint:staged
- [x] yarn tsc:staged

[OK-57475]: https://onekeyhq.atlassian.net/browse/OK-57475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ