### PR TITLE
fix: restore DApp market header after chart fullscreen(OK-57381)

### DIFF
--- a/packages/kit/src/components/TabPageHeader/DappHeader.tsx
+++ b/packages/kit/src/components/TabPageHeader/DappHeader.tsx
@@ -553,6 +553,7 @@ export function DappHeader({
     return (
       <>
         <Page.Header
+          headerShown
           headerTitleAlign="center"
           headerShadowVisible={false}
           headerStyle={{
@@ -571,6 +572,7 @@ export function DappHeader({
   return (
     <>
       <Page.Header
+        headerShown
         headerShadowVisible={false}
         headerStyle={{
           backgroundColor: 'transparent',


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57381](https://onekeyhq.atlassian.net/browse/OK-57381)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Restore the DApp web header after exiting Market token chart fullscreen.
- Make DappHeader explicitly set headerShown in both desktop and responsive DApp layouts.

## Intent & Context
The Market token detail chart fullscreen button hides the platform header while expanded. In web DApp mode, exiting fullscreen left the HeaderView hidden, while webapp mode restored correctly.

## Root Cause
Entering fullscreen renders Page.Header with headerShown=false, which writes React Navigation screen options. On exit, DappHeader rendered Page.Header without an explicit headerShown value, and React Navigation merges options, so the stale headerShown=false value was preserved.

## Design Decisions
Use the existing Page.Header contract and explicitly restore headerShown in DappHeader. This matches the webapp header path, which already passes headerShown, and avoids adding Market-specific imperative navigation resets.

## Changes Detail
- packages/kit/src/components/TabPageHeader/DappHeader.tsx: add headerShown to the desktop and mobile DApp Page.Header branches.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web
- **Risk Areas**: DApp mode page header visibility after route-level code temporarily hides the header.

## Test plan
- [x] yarn lint:staged
- [x] yarn tsc:staged
- [x] npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/components/TabPageHeader/DappHeader.tsx --deny-warnings
- [x] yarn tsc:only
- [ ] In web DApp mode, open a Market token detail page, enter chart fullscreen, exit fullscreen, and confirm the platform header returns.
- [ ] In webapp mode, repeat the fullscreen enter/exit flow and confirm the platform header still returns.

[OK-57381]: https://onekeyhq.atlassian.net/browse/OK-57381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ