### PR TITLE
fix: prevent stale dapp account selection restore (OK-57139)

### DIFF
--- a/packages/kit-bg/src/states/jotai/utils/index.ts
+++ b/packages/kit-bg/src/states/jotai/utils/index.ts
@@ -18,6 +18,7 @@ import {
   prepareColdStartSnapshotForWrite,
 } from '@onekeyhq/shared/src/utils/coldStartCacheSnapshotUtils';
 import { swrCacheUtils } from '@onekeyhq/shared/src/utils/swrCacheUtils';
+import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import {
   MMKV_MIGRATION_COMPLETE_KEY,
@@ -438,6 +439,21 @@ const ACCOUNT_SELECTOR_COLD_START_SCOPE_PREFIX = 'store:accountSelector@';
 const RECENT_ACCOUNT_SWITCH_COLD_START_MS = 5 * 60 * 1000;
 const ACCOUNT_SELECTOR_RECENT_SELECTION_CACHE_VERSION = 1;
 
+function isDappConnectionBackedAccountSelectorColdStartScope(
+  coldStartScopeKey: string,
+) {
+  if (!coldStartScopeKey.startsWith(ACCOUNT_SELECTOR_COLD_START_SCOPE_PREFIX)) {
+    return false;
+  }
+  const sceneId = coldStartScopeKey.slice(
+    ACCOUNT_SELECTOR_COLD_START_SCOPE_PREFIX.length,
+  );
+  return (
+    sceneId === EAccountSelectorSceneName.discover ||
+    sceneId.startsWith(`${EAccountSelectorSceneName.discover}--`)
+  );
+}
+
 type IAccountSelectorRecentSelectionCacheItem = {
   version: typeof ACCOUNT_SELECTOR_RECENT_SELECTION_CACHE_VERSION;
   updatedAt: number;
@@ -464,6 +480,14 @@ function getRecentAccountSelectorColdStartValue({
     ACCOUNT_SELECTOR_COLD_START_SCOPE_PREFIX.length,
   );
   if (!sceneId) {
+    return undefined;
+  }
+  // OK-57139: discover (dApp) scenes are backed by the dApp connection
+  // record, not by the recent-selection cache. Hydrating them from this
+  // cache resurrects a stale browser-side selection which then overwrites
+  // the re-aligned connection session. New builds no longer write discover
+  // entries; this guard also ignores entries written by older builds.
+  if (isDappConnectionBackedAccountSelectorColdStartScope(coldStartScopeKey)) {
     return undefined;
   }
 
@@ -858,9 +882,11 @@ export function hydrateContextColdStartCacheForProvider({
           coldStartScopeKey: scope,
           coldStartCacheKey: typedCacheKey,
         });
+      const shouldSkipScopedSnapshot =
+        isDappConnectionBackedAccountSelectorColdStartScope(scope);
       const cached =
         recentAccountSelectorCached ??
-        (snapshot
+        (!shouldSkipScopedSnapshot && snapshot
           ? getScopedColdStartSnapshotValue({
               snapshot,
               coldStartScopeKey: scope,

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
@@ -7,16 +7,22 @@ import { createStore } from 'jotai';
 
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
-import { useAccountSelectorActions } from './actions';
+import {
+  getAccountSelectorActions,
+  useAccountSelectorActions,
+} from './actions';
 import {
   AccountSelectorJotaiProvider,
   accountSelectorActiveAccountInitDoneAtom,
   accountSelectorStorageInitDoneAtom,
   accountSelectorStorageReadyAtom,
+  accountSelectorUpdateMetaAtom,
   defaultActiveAccountInfo,
   defaultSelectedAccount,
   selectedAccountsAtom,
 } from './atoms';
+
+import type { IAccountSelectorContextData } from './atoms';
 
 type IDeferred<T> = {
   promise: Promise<T>;
@@ -31,6 +37,8 @@ type IBuildActiveAccountInfoResult = {
 type IFixDeriveTypesForInitAccountSelectorMapParams = {
   selectedAccountsMapInDB: ISelectedAccountsMap | undefined;
 };
+type IWriteContextAtomColdStartCacheValues =
+  typeof import('@onekeyhq/kit-bg/src/states/jotai/utils').writeContextAtomColdStartCacheValues;
 
 function createDeferred<T>(): IDeferred<T> {
   let resolve: ((value: T) => void) | undefined;
@@ -48,6 +56,9 @@ function createDeferred<T>(): IDeferred<T> {
 const mockGetSelectedAccountsMap: jest.MockedFunction<
   () => Promise<ISelectedAccountsMap | undefined>
 > = jest.fn();
+const mockGetDappAccountSelectorMap: jest.MockedFunction<
+  () => Promise<Record<number, Record<string, unknown>> | undefined>
+> = jest.fn();
 const mockBuildActiveAccountInfoFromSelectedAccount: jest.MockedFunction<
   () => Promise<IBuildActiveAccountInfoResult>
 > = jest.fn();
@@ -56,6 +67,23 @@ const mockFixDeriveTypesForInitAccountSelectorMap: jest.MockedFunction<
     params: IFixDeriveTypesForInitAccountSelectorMapParams,
   ) => Promise<ISelectedAccountsMap | undefined>
 > = jest.fn();
+const mockWriteContextAtomColdStartCacheValues: jest.MockedFunction<IWriteContextAtomColdStartCacheValues> =
+  jest.fn();
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/utils', () => {
+  const actual = jest.requireActual<
+    typeof import('@onekeyhq/kit-bg/src/states/jotai/utils')
+  >('@onekeyhq/kit-bg/src/states/jotai/utils');
+
+  return {
+    ...actual,
+    writeContextAtomColdStartCacheValues: async (
+      ...args: Parameters<IWriteContextAtomColdStartCacheValues>
+    ): Promise<void> => {
+      await mockWriteContextAtomColdStartCacheValues(...args);
+    },
+  };
+});
 
 jest.mock('@onekeyhq/kit/src/components/Hardware/Hardware', () => ({
   CommonDeviceLoading: jest.fn(() => null),
@@ -103,7 +131,7 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
         getSelectedAccountsMap: () => mockGetSelectedAccountsMap(),
       },
       dappConnection: {
-        getAccountSelectorMap: jest.fn(async () => undefined),
+        getAccountSelectorMap: () => mockGetDappAccountSelectorMap(),
       },
     },
   },
@@ -120,7 +148,7 @@ jest.mock('@onekeyhq/shared/src/logger/logger', () => {
   };
 });
 
-function createWrapper() {
+function createWrapper(config?: IAccountSelectorContextData) {
   const store = createStore();
   store.set(accountSelectorStorageReadyAtom(), true);
   store.set(accountSelectorStorageInitDoneAtom(), false);
@@ -133,7 +161,7 @@ function createWrapper() {
     return (
       <AccountSelectorJotaiProvider
         store={store}
-        config={{ sceneName: EAccountSelectorSceneName.home }}
+        config={config ?? { sceneName: EAccountSelectorSceneName.home }}
       >
         {children}
       </AccountSelectorJotaiProvider>
@@ -149,6 +177,8 @@ function createWrapper() {
 describe('useAccountSelectorActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetDappAccountSelectorMap.mockResolvedValue(undefined);
+    mockWriteContextAtomColdStartCacheValues.mockResolvedValue(undefined);
     mockBuildActiveAccountInfoFromSelectedAccount.mockResolvedValue({
       activeAccount: {
         ...defaultActiveAccountInfo(),
@@ -229,5 +259,161 @@ describe('useAccountSelectorActions', () => {
     expect(store.get(accountSelectorActiveAccountInitDoneAtom())?.[0]).toBe(
       true,
     );
+  });
+
+  // OK-57139: the dApp connection record is the single source of truth for
+  // discover scenes. The cold-start keep/restore logic must never resurrect
+  // a stale browser-side selection over a connection record that background
+  // has since re-aligned to the wallet account.
+  describe('discover scene init must follow the dApp connection record', () => {
+    const dappOrigin = 'https://1inch.com';
+    const staleSelectedAccount = {
+      ...defaultSelectedAccount(),
+      walletId: 'hd-1',
+      indexedAccountId: 'hd-1--0',
+      focusedWallet: 'hd-1',
+      networkId: 'evm--1',
+      deriveType: 'default' as const,
+    };
+    const alignedConnectionAccount = {
+      walletId: 'hd-2',
+      indexedAccountId: 'hd-2--1',
+      focusedWallet: 'hd-2',
+      networkId: 'evm--1',
+      deriveType: 'default' as const,
+    };
+
+    it('applies the connection record even when a recent stale selection exists in memory', async () => {
+      mockGetSelectedAccountsMap.mockResolvedValue(undefined);
+      mockGetDappAccountSelectorMap.mockResolvedValue({
+        0: { ...alignedConnectionAccount },
+      });
+
+      const { store, Wrapper } = createWrapper({
+        sceneName: EAccountSelectorSceneName.discover,
+        sceneUrl: dappOrigin,
+      });
+      // Simulate a browser-side account switch made moments ago: the stale
+      // account sits in memory with a fresh updateMeta timestamp, exactly
+      // the state that used to win over the re-aligned connection record.
+      store.set(selectedAccountsAtom(), {
+        0: { ...staleSelectedAccount },
+      });
+      store.set(accountSelectorUpdateMetaAtom(), {
+        0: {
+          eventEmitDisabled: false,
+          updatedAt: Date.now(),
+        },
+      });
+
+      const { result } = renderHook(() => useAccountSelectorActions().current, {
+        wrapper: Wrapper,
+      });
+
+      await act(async () => {
+        await result.current.initFromStorage({
+          sceneName: EAccountSelectorSceneName.discover,
+          sceneUrl: dappOrigin,
+        });
+      });
+
+      expect(store.get(selectedAccountsAtom())[0]).toEqual(
+        alignedConnectionAccount,
+      );
+      expect(store.get(accountSelectorStorageInitDoneAtom())).toBe(true);
+    });
+
+    it('never reads or writes the recent-selection cache for discover scenes', () => {
+      const actions = getAccountSelectorActions();
+
+      expect(
+        actions.buildAccountSelectorRecentSelectionCacheSceneId({
+          sceneName: EAccountSelectorSceneName.discover,
+          sceneUrl: dappOrigin,
+        }),
+      ).toBeUndefined();
+      expect(
+        actions.buildAccountSelectorRecentSelectionCacheSceneId({
+          sceneName: EAccountSelectorSceneName.home,
+        }),
+      ).toBe(EAccountSelectorSceneName.home);
+    });
+
+    it('does not write generic cold-start snapshots for discover scenes', async () => {
+      const actions = getAccountSelectorActions();
+
+      await actions.flushAccountSelectorColdStartSnapshot({
+        sceneName: EAccountSelectorSceneName.discover,
+        sceneUrl: dappOrigin,
+        selectedAccounts: {
+          0: { ...staleSelectedAccount },
+        },
+        updateMeta: {
+          0: {
+            eventEmitDisabled: false,
+            updatedAt: Date.now(),
+          },
+        },
+      });
+
+      expect(mockWriteContextAtomColdStartCacheValues).not.toHaveBeenCalled();
+    });
+
+    it('still keeps a recent in-memory selection for the home scene (cold-start protection intact)', async () => {
+      const homeRecentSelectedAccount = {
+        ...defaultSelectedAccount(),
+        walletId: 'hd-3',
+        indexedAccountId: 'hd-3--2',
+        focusedWallet: 'hd-3',
+        networkId: 'evm--1',
+        deriveType: 'default' as const,
+      };
+      const homeSelectedAccountInDB = {
+        ...defaultSelectedAccount(),
+        walletId: 'hd-1',
+        indexedAccountId: 'hd-1--0',
+        focusedWallet: 'hd-1',
+        networkId: 'evm--1',
+        deriveType: 'default' as const,
+      };
+      mockGetSelectedAccountsMap.mockResolvedValue({
+        0: homeSelectedAccountInDB,
+      });
+
+      const { store, Wrapper } = createWrapper();
+      store.set(selectedAccountsAtom(), {
+        0: { ...homeRecentSelectedAccount },
+      });
+      store.set(accountSelectorUpdateMetaAtom(), {
+        0: {
+          eventEmitDisabled: false,
+          updatedAt: Date.now(),
+        },
+      });
+
+      const { result } = renderHook(() => useAccountSelectorActions().current, {
+        wrapper: Wrapper,
+      });
+      const recentCacheSpy = jest
+        .spyOn(
+          getAccountSelectorActions(),
+          'getRecentAccountSelectorSelectionCache',
+        )
+        .mockReturnValue(undefined);
+
+      try {
+        await act(async () => {
+          await result.current.initFromStorage({
+            sceneName: EAccountSelectorSceneName.home,
+          });
+        });
+      } finally {
+        recentCacheSpy.mockRestore();
+      }
+
+      expect(store.get(selectedAccountsAtom())[0]).toEqual(
+        homeRecentSelectedAccount,
+      );
+    });
   });
 });

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -208,6 +208,14 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
     if (!sceneName) {
       return undefined;
     }
+    // OK-57139: discover scenes are backed by the dApp connection record
+    // (simpleDb.dappConnection), which background keeps re-aligning to the
+    // wallet account. Caching a "recent selection" for them lets a stale
+    // browser-side account survive re-init and overwrite the aligned
+    // session (and, via dApp->Home sync, the wallet home account).
+    if (sceneName === EAccountSelectorSceneName.discover) {
+      return undefined;
+    }
     return accountSelectorUtils.buildAccountSelectorSceneId({
       sceneName,
       sceneUrl,
@@ -393,6 +401,9 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
         sceneUrl,
       });
       if (!coldStartScopeKey) {
+        return;
+      }
+      if (sceneName === EAccountSelectorSceneName.discover) {
         return;
       }
 
@@ -2248,6 +2259,16 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
           );
         }
 
+        // OK-57139: the dApp connection record loaded above is the single
+        // source of truth for discover scenes; background keeps re-aligning
+        // it to the wallet account. Cold-start keep/restore must not
+        // resurrect a stale browser-side selection over it, or the stale
+        // account gets written back into the connection session and then
+        // into the wallet home account. (getRecentAccountSelectorSelectionCache
+        // already returns undefined for discover scenes.)
+        const isDappConnectionBackedScene =
+          sceneName === EAccountSelectorSceneName.discover;
+
         const recentSelectionCache =
           this.getRecentAccountSelectorSelectionCache({
             sceneName,
@@ -2297,6 +2318,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
         const selectedAccountsMap = get(selectedAccountsAtom());
         const updateMeta = get(accountSelectorUpdateMetaAtom());
         if (
+          !isDappConnectionBackedScene &&
           this.shouldKeepColdStartSelectedAccounts({
             selectedAccountsMap,
             selectedAccountsMapInDB,

--- a/packages/kit/src/states/jotai/utils/jotaiContextStore.test.ts
+++ b/packages/kit/src/states/jotai/utils/jotaiContextStore.test.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { Component, createElement } from 'react';
 
 import { render, waitFor } from '@testing-library/react';
+import { type Atom, type WritableAtom, createStore } from 'jotai';
 
 import {
   EJotaiContextStoreNames,
@@ -11,7 +12,11 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IJotaiContextStoreData } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IJotaiSetAtom } from '@onekeyhq/kit-bg/src/states/jotai/types';
-import { contextAtomBase } from '@onekeyhq/kit-bg/src/states/jotai/utils';
+import {
+  contextAtomBase,
+  contextAtomSnapshotRegistry,
+  hydrateContextColdStartCacheForProvider,
+} from '@onekeyhq/kit-bg/src/states/jotai/utils';
 import { CONTEXT_ATOM_COLD_START_CACHE_KEYS } from '@onekeyhq/shared/src/consts/jotaiConsts';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -385,5 +390,70 @@ describe('jotaiContextStore reset flow', () => {
     expect(
       globalCache.__ONEKEY_CTX_ATOM_SNAPSHOT__?.[scopedKey],
     ).toBeUndefined();
+  });
+
+  it('does not hydrate discover account selector state from generic scoped snapshots', () => {
+    const coldStartCacheKey =
+      CONTEXT_ATOM_COLD_START_CACHE_KEYS.selectedAccountsAtom;
+    const originalRegistryEntry =
+      contextAtomSnapshotRegistry.get(coldStartCacheKey);
+    const coldStartScopeKey = `store:accountSelector@${EAccountSelectorSceneName.discover}--https://1inch.com`;
+    const scopedKey = `${coldStartScopeKey}::${coldStartCacheKey}`;
+    const initialValue = {
+      0: {
+        walletId: 'hd-current',
+      },
+    };
+    const staleSnapshotValue = {
+      0: {
+        walletId: 'hd-stale',
+      },
+    };
+    const globalCache = globalThis as IGlobalColdStartSnapshot;
+    globalCache.__ONEKEY_CTX_ATOM_SNAPSHOT__ = {
+      [scopedKey]: staleSnapshotValue,
+    };
+    const coldStartAtom = contextAtomBase<typeof initialValue>({
+      initialValue,
+      coldStartCache: true,
+      coldStartCacheKey,
+      useColdStartScopeKey: () => coldStartScopeKey,
+      useContextAtom: <Value2, Args extends unknown[], Result>(
+        _atomInstance: WritableAtom<Value2, Args, Result>,
+      ) =>
+        [
+          initialValue as Awaited<Value2>,
+          jest.fn() as unknown as IJotaiSetAtom<Args, Result>,
+        ] as [Awaited<Value2>, IJotaiSetAtom<Args, Result>],
+    });
+    const store = createStore();
+    const hydrationStore = {
+      get: (atomInstance: unknown) => store.get(atomInstance as Atom<unknown>),
+      set: (atomInstance: unknown, value: unknown) => {
+        store.set(
+          atomInstance as WritableAtom<unknown, [unknown], unknown>,
+          value,
+        );
+      },
+    };
+    const atomInstance = coldStartAtom.atom();
+
+    try {
+      hydrateContextColdStartCacheForProvider({
+        store: hydrationStore,
+        coldStartScopeKey,
+      });
+
+      expect(store.get(atomInstance)).toEqual(initialValue);
+    } finally {
+      if (originalRegistryEntry) {
+        contextAtomSnapshotRegistry.set(
+          coldStartCacheKey,
+          originalRegistryEntry,
+        );
+      } else {
+        contextAtomSnapshotRegistry.delete(coldStartCacheKey);
+      }
+    }
   });
 });


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57139](https://onekeyhq.atlassian.net/browse/OK-57139)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Prevent Discover/dApp account selector initialization from restoring stale recent-selection state over the active dApp connection record.
- Ignore legacy Discover cold-start cache entries so old Browser-side selections cannot overwrite a re-aligned connection session.
- Add focused account-selector tests and document the OK-57139 reproduction/self-test matrix.

## Intent & Context
OK-57139 covers the account sync path between Wallet Home and Browser/dApp when the dApp alignment mode is "use wallet account". The expected behavior is that the last user-selected account remains stable and Home, Browser toolbar selector, and the dApp connected account converge to the same account.

The failing cases observed during reproduction were:
- Home switches to Wallet2, then entering Browser without any operation can switch Home back to the old dApp account.
- Home switches to Wallet1 Account2, but Browser still displays Wallet2 and can reverse-sync Home back to Wallet2.
- After manually switching the Browser toolbar account, later Home account changes no longer reliably sync back to Browser.

## Root Cause
Discover scenes were using both the dApp connection record and account-selector recent/cold-start selection restore paths. After the Browser toolbar selector had held a previous dApp account, `initFromStorage` could keep or resurrect that stale in-memory/cold-start selection instead of the dApp connection record that background had already re-aligned to the wallet account. That stale selection could then be written back into the dApp session and reverse-sync into Wallet Home.

## Design Decisions
- Treat the dApp connection record as the single source of truth for Discover scenes.
- Disable recent-selection cache scene IDs for Discover so new builds no longer write this stale-prone cache.
- Skip cold-start "keep selected account" restore for Discover scenes while preserving the behavior for Home and other scenes.
- Ignore legacy Discover cold-start cache entries in background to avoid resurrecting data written by older builds.

## Changes Detail
- `AccountSelectorActions.buildAccountSelectorRecentSelectionCacheSceneId` now returns `undefined` for Discover scenes.
- `AccountSelectorActions.initFromStorage` skips `shouldKeepColdStartSelectedAccounts` for Discover scenes so the loaded dApp connection record wins.
- Background cold-start cache hydration ignores scene IDs prefixed with the Discover scene name.
- Account selector tests cover stale in-memory Discover state, Discover cache suppression, and Home cold-start protection remaining intact.
- Added `docs/OK-57139-dapp-account-sync-repro-and-test-cases.md` with Desktop, iOS, Android, and Extension manual self-test cases.

## Risk Assessment
- Scope is limited to Discover/dApp account selector scenes.
- Home scene recent in-memory cold-start protection is explicitly covered by the new test and remains enabled.
- Existing stale Discover cache entries will be ignored after this change, which is intentional for OK-57139.
- Manual platform verification is still required for full Browser/provider behavior because this PR only adds focused unit coverage.

## Test Plan
- PASS: `yarn jest --runTestsByPath packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx`
- PASS: `git diff --cached --check`
- PARTIAL: `yarn lint --fix` was run, but it fails on existing unrelated TypeScript errors outside this change:
  - `packages/kit-bg/src/vaults/impls/sol/KeyringHardwareTrezor.ts` Solana `encodedToken` string vs ArrayBuffer mismatch.
  - `packages/shared/src/errors/errors/thirdPartyHardwareErrors.ts` and `packages/shared/src/errors/utils/thirdPartyDeviceErrorUtils.ts` reference `HardwareErrorCode.DeviceBusyInternal`, which is missing from the current type.

[OK-57139]: https://onekeyhq.atlassian.net/browse/OK-57139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ