### PR TITLE
feat: add attempt-level firmware update tracking(OK-57543)

### DIFF
--- a/packages/kit-bg/src/services/ServiceFirmwareUpdate/ServiceFirmwareUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceFirmwareUpdate/ServiceFirmwareUpdate.ts
@@ -1371,6 +1371,79 @@ class ServiceFirmwareUpdate extends ServiceBase {
 
   updateTasks: Record<number | string, IUpdateFirmwareTaskFn> = {};
 
+  // Per-workflow analytics context (OK-57543): only one update workflow runs
+  // at a time, reset on each workflow start
+  updateWorkflowTracking:
+    | {
+        updateFlow: 'v1' | 'v2';
+        releaseResult: ICheckAllFirmwareReleaseResult;
+        startedAt: number;
+        failedAttemptCount: number;
+      }
+    | undefined;
+
+  resetUpdateWorkflowTracking({
+    updateFlow,
+    releaseResult,
+  }: {
+    updateFlow: 'v1' | 'v2';
+    releaseResult: ICheckAllFirmwareReleaseResult;
+  }) {
+    this.updateWorkflowTracking = {
+      updateFlow,
+      releaseResult,
+      startedAt: Date.now(),
+      failedAttemptCount: 0,
+    };
+  }
+
+  @backgroundMethod()
+  async getUpdateWorkflowTrackingInfo(): Promise<{
+    retryCount: number | undefined;
+    durationMs: number | undefined;
+  }> {
+    const tracking = this.updateWorkflowTracking;
+    return {
+      retryCount: tracking?.failedAttemptCount,
+      durationMs: tracking ? Date.now() - tracking.startedAt : undefined,
+    };
+  }
+
+  async trackUpdateTaskFailedAttempt(error: unknown) {
+    // Never let analytics break the update/retry flow
+    try {
+      const tracking = this.updateWorkflowTracking;
+      if (!tracking) {
+        return;
+      }
+      // User exit is not a real update failure
+      if (
+        error instanceof FirmwareUpdateExit ||
+        error instanceof FirmwareUpdateTasksClear
+      ) {
+        return;
+      }
+      tracking.failedAttemptCount += 1;
+      const err = toPlainErrorObject(error as any);
+      const hardwareTransportType =
+        await this.backgroundApi.serviceSetting.getHardwareTransportType();
+      defaultLogger.update.firmware.firmwareUpdateFailedAttempt({
+        deviceType: tracking.releaseResult.deviceType,
+        transportType: hardwareTransportType,
+        updateFlow: tracking.updateFlow,
+        firmwareVersions: parseFirmwareVersions(tracking.releaseResult),
+        attempt: tracking.failedAttemptCount,
+        errorCode: err?.code,
+        errorMessage: err?.message,
+      });
+    } catch (loggingError) {
+      serviceHardwareUtils.hardwareLog(
+        'trackUpdateTaskFailedAttempt logging ERROR',
+        loggingError,
+      );
+    }
+  }
+
   updateTasksAdd({
     fn,
     reject,
@@ -1479,6 +1552,10 @@ class ServiceFirmwareUpdate extends ServiceBase {
   @backgroundMethod()
   @toastIfError()
   async startUpdateWorkflow(params: IUpdateFirmwareWorkflowParams) {
+    this.resetUpdateWorkflowTracking({
+      updateFlow: 'v1',
+      releaseResult: params.releaseResult,
+    });
     const dbDevice = await localDb.getDeviceByQuery({
       connectId: params.releaseResult.originalConnectId, // TODO remove connectId check
     });
@@ -1672,6 +1749,7 @@ class ServiceFirmwareUpdate extends ServiceBase {
     try {
       const hardwareTransportType =
         await this.backgroundApi.serviceSetting.getHardwareTransportType();
+      const trackingInfo = await this.getUpdateWorkflowTrackingInfo();
 
       defaultLogger.update.firmware.firmwareUpdateResult({
         deviceType: params.releaseResult.deviceType,
@@ -1681,6 +1759,8 @@ class ServiceFirmwareUpdate extends ServiceBase {
         fromFirmwareType,
         toFirmwareType,
         status: 'success',
+        retryCount: trackingInfo.retryCount,
+        durationMs: trackingInfo.durationMs,
       });
     } catch (loggingError) {
       serviceHardwareUtils.hardwareLog(
@@ -1721,6 +1801,7 @@ class ServiceFirmwareUpdate extends ServiceBase {
     try {
       const hardwareTransportType =
         await this.backgroundApi.serviceSetting.getHardwareTransportType();
+      const trackingInfo = await this.getUpdateWorkflowTrackingInfo();
 
       defaultLogger.update.firmware.firmwareUpdateResult({
         deviceType: params.releaseResult.deviceType,
@@ -1732,6 +1813,8 @@ class ServiceFirmwareUpdate extends ServiceBase {
         status: 'failed',
         errorCode: err?.code,
         errorMessage: err?.message,
+        retryCount: trackingInfo.retryCount,
+        durationMs: trackingInfo.durationMs,
       });
     } catch (loggingError) {
       serviceHardwareUtils.hardwareLog(
@@ -1847,6 +1930,10 @@ class ServiceFirmwareUpdate extends ServiceBase {
   async startUpdateWorkflowV2(
     params: IUpdateFirmwareWorkflowParams,
   ): Promise<IStartUpdateWorkflowV2Result> {
+    this.resetUpdateWorkflowTracking({
+      updateFlow: 'v2',
+      releaseResult: params.releaseResult,
+    });
     await firmwareUpdateWorkflowRunningAtom.set(true);
 
     void (async () => {
@@ -1959,6 +2046,10 @@ class ServiceFirmwareUpdate extends ServiceBase {
     } catch (error) {
       //
       serviceHardwareUtils.hardwareLog('startUpdateWorkflow ERROR', error);
+
+      // OK-57543: track each real failed attempt (retry may succeed later)
+      await this.trackUpdateTaskFailedAttempt(error);
+
       // never reject here, we should use retry
       // await servicePromise.rejectCallback({ id, error });
       await firmwareUpdateRetryAtom.set({

--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
@@ -180,8 +180,14 @@ export function FirmwareUpdateCheckList({
                     },
                   );
 
+                  // Never let analytics context reading break the update flow
                   const trackingInfo =
-                    await backgroundApiProxy.serviceFirmwareUpdate.getUpdateWorkflowTrackingInfo();
+                    await backgroundApiProxy.serviceFirmwareUpdate
+                      .getUpdateWorkflowTrackingInfo()
+                      .catch(() => ({
+                        retryCount: undefined,
+                        durationMs: undefined,
+                      }));
                   defaultLogger.update.firmware.firmwareUpdateResult({
                     deviceType: result?.deviceType,
                     transportType: hardwareTransportType,
@@ -219,8 +225,14 @@ export function FirmwareUpdateCheckList({
                       error: err,
                     },
                   });
+                  // Never let analytics context reading break the update flow
                   const trackingInfo =
-                    await backgroundApiProxy.serviceFirmwareUpdate.getUpdateWorkflowTrackingInfo();
+                    await backgroundApiProxy.serviceFirmwareUpdate
+                      .getUpdateWorkflowTrackingInfo()
+                      .catch(() => ({
+                        retryCount: undefined,
+                        durationMs: undefined,
+                      }));
                   defaultLogger.update.firmware.firmwareUpdateResult({
                     deviceType: result?.deviceType,
                     transportType: hardwareTransportType,

--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
@@ -180,6 +180,8 @@ export function FirmwareUpdateCheckList({
                     },
                   );
 
+                  const trackingInfo =
+                    await backgroundApiProxy.serviceFirmwareUpdate.getUpdateWorkflowTrackingInfo();
                   defaultLogger.update.firmware.firmwareUpdateResult({
                     deviceType: result?.deviceType,
                     transportType: hardwareTransportType,
@@ -188,6 +190,8 @@ export function FirmwareUpdateCheckList({
                     fromFirmwareType: updateFirmwareInfo?.fromFirmwareType,
                     toFirmwareType: updateFirmwareInfo?.toFirmwareType,
                     status: 'success',
+                    retryCount: trackingInfo.retryCount,
+                    durationMs: trackingInfo.durationMs,
                   });
 
                   const { fromFirmwareType, toFirmwareType } =
@@ -215,6 +219,8 @@ export function FirmwareUpdateCheckList({
                       error: err,
                     },
                   });
+                  const trackingInfo =
+                    await backgroundApiProxy.serviceFirmwareUpdate.getUpdateWorkflowTrackingInfo();
                   defaultLogger.update.firmware.firmwareUpdateResult({
                     deviceType: result?.deviceType,
                     transportType: hardwareTransportType,
@@ -225,6 +231,8 @@ export function FirmwareUpdateCheckList({
                     status: 'failed',
                     errorCode: err?.code,
                     errorMessage: err?.message,
+                    retryCount: trackingInfo.retryCount,
+                    durationMs: trackingInfo.durationMs,
                   });
                 } finally {
                   if (shouldResetWorkflowRunningInUi) {

--- a/packages/shared/src/logger/scopes/update/scenes/firmware.ts
+++ b/packages/shared/src/logger/scopes/update/scenes/firmware.ts
@@ -39,6 +39,24 @@ export class FirmwareScene extends BaseScene {
     return params;
   }
 
+  /**
+   * Track each real update-task failure (before user retry), so attempt-level
+   * failure rate can be measured even when a later retry succeeds
+   */
+  @LogToServer()
+  @LogToLocal()
+  public firmwareUpdateFailedAttempt(params: {
+    deviceType: IDeviceType | undefined;
+    transportType: EHardwareTransportType | undefined;
+    updateFlow: 'v1' | 'v2';
+    firmwareVersions: IFirmwareVersions;
+    attempt: number;
+    errorCode?: string;
+    errorMessage?: string;
+  }) {
+    return params;
+  }
+
   @LogToServer()
   @LogToLocal()
   public firmwareUpdateResult(params: {
@@ -51,6 +69,8 @@ export class FirmwareScene extends BaseScene {
     status: 'success' | 'failed';
     errorCode?: string;
     errorMessage?: string;
+    retryCount?: number;
+    durationMs?: number;
   }) {
     return params;
   }


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57543](https://onekeyhq.atlassian.net/browse/OK-57543)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Add new analytics event `firmwareUpdateFailedAttempt` that reports every real firmware-update task failure (fired at the retry funnel, before the user retries)
- Add `retryCount` and `durationMs` optional properties to the existing `firmwareUpdateResult` event (both v1 UI flow and v2 background service flow)
- All properties are sliceable by `deviceType`, `transportType` (USB / BLE / bridge), update flow (v1/v2) and firmware versions

## Intent & Context
We need to measure, per released firmware, how many devices upgraded through the app and what the real failure rate is, split by transport (USB vs Bluetooth) and device type.

The existing `firmwareUpdateStarted` / `firmwareUpdateResult` events only capture the final outcome of a whole update workflow. Because `runUpdateTask` never rejects on task failure (it parks the workflow in a retry-wait state via `firmwareUpdateRetryAtom`), a device that fails 3 times and then succeeds on retry reports a single `success` event and zero failures — attempt-level failure rate was invisible, and retry recovery could not be measured.

## Design Decisions
- **Report failures at the single retry funnel** (`runUpdateTask` catch): v1, v2 and v3 update tasks all flow through `createRunTaskWithRetry` → `runUpdateTask`, so one hook covers all flows without touching each updating function.
- **Per-workflow tracking context on the service** (`updateWorkflowTracking`): only one update workflow runs at a time; the context (flow type, releaseResult, start time, failed-attempt counter) is reset at both workflow entry points (`startUpdateWorkflow` / `startUpdateWorkflowV2`).
- **User exit is not a failure**: `FirmwareUpdateExit` / `FirmwareUpdateTasksClear` are excluded from failed-attempt reporting to avoid polluting the failure rate with user cancellations.
- **Analytics can never break the update flow**: the reporting helper is fully wrapped in try/catch, mirroring the existing `completeUpdateWorkflow` / `failUpdateWorkflow` logging pattern.
- New fields on `firmwareUpdateResult` are optional and additive — existing Mixpanel dashboards and older app versions are unaffected (older clients simply won't send the new properties).

## Changes Detail
- `packages/shared/src/logger/scopes/update/scenes/firmware.ts`: new `firmwareUpdateFailedAttempt` event; `firmwareUpdateResult` gains optional `retryCount` / `durationMs`
- `packages/kit-bg/src/services/ServiceFirmwareUpdate/ServiceFirmwareUpdate.ts`: workflow tracking context + `getUpdateWorkflowTrackingInfo()` background method + failed-attempt reporting in the `runUpdateTask` catch; v2 result events now include the new fields
- `packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx`: v1 result events (success/failure) now include the new fields

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: analytics-only, additive change; no control-flow change to the update workflow. The only new code on the failure path is wrapped in try/catch.

## Test plan
- [ ] `yarn tsc:only` — no new errors vs base (verified: same 6 pre-existing unrelated errors on x)
- [ ] `oxlint` on the 3 touched files — 0 warnings / 0 errors
- [ ] `jest packages/kit-bg/src/services/ServiceFirmwareUpdate` and `jest packages/shared/src/logger` — all pass
- [ ] Manual: update firmware over USB and BLE with dev analytics enabled (`enableAnalyticsInDev`), verify `firmwareUpdateFailedAttempt` fires on each induced failure and `firmwareUpdateResult` carries `retryCount` / `durationMs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OK-57543]: https://onekeyhq.atlassian.net/browse/OK-57543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ