### PR TITLE
fix: reserve TON native max-send fee after coin symbol rename

### DIFF
--- a/packages/kit-bg/src/vaults/impls/ton/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/ton/Vault.ts
@@ -240,7 +240,14 @@ export default class Vault extends VaultBase {
                 symbol: token?.symbol ?? '',
                 name: token?.name ?? '',
                 tokenIdOnNetwork: token?.address ?? '',
-                isNative: token?.symbol === network.symbol,
+                // Determine native by transfer structure, not by symbol equality.
+                // The native-coin symbol can be renamed server-side (e.g. TON ->
+                // GRAM) while network.symbol stays "TON"; a `token.symbol ===
+                // network.symbol` check would then flip isNative to false and
+                // silently disable the max-send fee reservation, making a
+                // full-balance send get dropped on-chain by the IGNORE_ERRORS
+                // send mode. A native TON transfer never carries a jetton.
+                isNative: !message.jetton && !decodedPayload.jetton,
               },
             ],
           });


### PR DESCRIPTION
## Summary
- Fix TON native "Max" send silently dropping the entire balance on-chain after the native coin was renamed (TON → GRAM).
- Detect native TON transfers by transfer structure (no jetton) instead of `token.symbol === network.symbol`.

## Intent & Context
QA reported that sending the **max amount** of the TON native coin fails, that it still worked last week, and asked whether it was related to the recent native-coin rename. They provided a "failed" tonviewer transaction and the account balance (`0.349309536 GRAM`).

## Root Cause
- tonviewer rendered the tx as **Failed**, but the tonapi raw JSON showed `success: true` with **`out_msgs: []`** — a *silent drop*: the wallet consumed the seqno and paid the fee but transferred nothing.
- The message value equaled **100% of the balance** (`end_balance + total_fees == message value`), i.e. the max-send fee reservation had been skipped and the full balance was sent.
- `ton/Vault.ts#buildDecodedTx` derived `isNative` from `token.symbol === network.symbol`. After the native coin symbol was renamed server-side (**TON → GRAM**) while the preset `network.symbol` stayed `"TON"`, the equality broke → `isNative = false` → `isSendNativeTokenAction()` returns false → `isSendNativeTokenOnly = false` in `SendConfirm/TxActionsContainer.tsx` → the fee-reservation branch is skipped → the full balance is used.
- On TON send **mode 3** (`PAY_GAS_SEPARATELY + IGNORE_ERRORS`), a full-balance value cannot also cover fees, so the outgoing action is silently dropped instead of erroring.
- The fragile check is latent code from the original 2024 TON integration; it only broke now because of the rename — which explains "it worked last week".

## Design Decisions
- Native TON transfers never carry a jetton, so `isNative: !message.jetton && !decodedPayload.jetton` is deterministic and rename-proof.
- Preferred this structural check over `token?.isNative`, because the latter is `undefined` when the token lookup fails and would re-introduce the same false-negative.
- The token's own `tokenInfo.isNative` (server-provided, used in `buildEncodedTx`) was already correct; only the decode-side symbol override was wrong — which is why the on-chain message was a proper native transfer and only max-send broke, while normal fixed-amount sends were unaffected.
- Scope limited to TON as requested. `impls/cosmos/Vault.ts` (~L360) has the same fragile pattern (`amountDenom === network.symbol`) and should be audited on the next Cosmos coin rename, but is out of scope here.

## Changes Detail
- `packages/kit-bg/src/vaults/impls/ton/Vault.ts` — `buildDecodedTx` now derives `isNative` from transfer structure instead of symbol equality, with an explanatory comment.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web (background vault logic)
- **Risk Areas**: `isNative` feeds native-token detection used by the max-send fee reservation and pre-check balance. The new check is deterministic and preserves jetton behavior (jettons remain non-native). Single-line logic change, no schema/state changes.

## Test plan
- [ ] TON account with the renamed native coin (GRAM): tap **Max** on a native send → tx broadcasts and transfers `balance − fee`; on-chain `out_msgs` is non-empty (funds actually moved).
- [ ] TON normal fixed-amount native send still works.
- [ ] TON jetton send (with and without comment) still works and is treated as non-native.
- [ ] Confirm max-send reserves the fee (sent amount is strictly less than balance).
