### PR TITLE
feat: add attempt-level firmware update tracking(OK-57543)

### DIFF
--- a/packages/kit-bg/src/services/ServiceFirmwareUpdate/ServiceFirmwareUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceFirmwareUpdate/ServiceFirmwareUpdate.ts
@@ -32,6 +32,8 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { CoreSDKLoader } from '@onekeyhq/shared/src/hardware/instance';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import { parseFirmwareVersions } from '@onekeyhq/shared/src/logger/scopes/update/scenes/firmware';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import deviceUtils from '@onekeyhq/shared/src/utils/deviceUtils';
 import { equalsIgnoreCase } from '@onekeyhq/shared/src/utils/stringUtils';
@@ -1356,6 +1358,79 @@ class ServiceFirmwareUpdate extends ServiceBase {
 
   updateTasks: Record<number | string, IUpdateFirmwareTaskFn> = {};
 
+  // Per-workflow analytics context (OK-57543): only one update workflow runs
+  // at a time, reset on each workflow start
+  updateWorkflowTracking:
+    | {
+        updateFlow: 'v1' | 'v2';
+        releaseResult: ICheckAllFirmwareReleaseResult;
+        startedAt: number;
+        failedAttemptCount: number;
+      }
+    | undefined;
+
+  resetUpdateWorkflowTracking({
+    updateFlow,
+    releaseResult,
+  }: {
+    updateFlow: 'v1' | 'v2';
+    releaseResult: ICheckAllFirmwareReleaseResult;
+  }) {
+    this.updateWorkflowTracking = {
+      updateFlow,
+      releaseResult,
+      startedAt: Date.now(),
+      failedAttemptCount: 0,
+    };
+  }
+
+  @backgroundMethod()
+  async getUpdateWorkflowTrackingInfo(): Promise<{
+    retryCount: number | undefined;
+    durationMs: number | undefined;
+  }> {
+    const tracking = this.updateWorkflowTracking;
+    return {
+      retryCount: tracking?.failedAttemptCount,
+      durationMs: tracking ? Date.now() - tracking.startedAt : undefined,
+    };
+  }
+
+  async trackUpdateTaskFailedAttempt(error: unknown) {
+    // Never let analytics break the update/retry flow
+    try {
+      const tracking = this.updateWorkflowTracking;
+      if (!tracking) {
+        return;
+      }
+      // User exit is not a real update failure
+      if (
+        error instanceof FirmwareUpdateExit ||
+        error instanceof FirmwareUpdateTasksClear
+      ) {
+        return;
+      }
+      tracking.failedAttemptCount += 1;
+      const err = toPlainErrorObject(error as any);
+      const hardwareTransportType =
+        await this.backgroundApi.serviceSetting.getHardwareTransportType();
+      defaultLogger.update.firmware.firmwareUpdateFailedAttempt({
+        deviceType: tracking.releaseResult.deviceType,
+        transportType: hardwareTransportType,
+        updateFlow: tracking.updateFlow,
+        firmwareVersions: parseFirmwareVersions(tracking.releaseResult),
+        attempt: tracking.failedAttemptCount,
+        errorCode: err?.code,
+        errorMessage: err?.message,
+      });
+    } catch (loggingError) {
+      serviceHardwareUtils.hardwareLog(
+        'trackUpdateTaskFailedAttempt logging ERROR',
+        loggingError,
+      );
+    }
+  }
+
   updateTasksAdd({
     fn,
     reject,
@@ -1464,6 +1539,10 @@ class ServiceFirmwareUpdate extends ServiceBase {
   @backgroundMethod()
   @toastIfError()
   async startUpdateWorkflow(params: IUpdateFirmwareWorkflowParams) {
+    this.resetUpdateWorkflowTracking({
+      updateFlow: 'v1',
+      releaseResult: params.releaseResult,
+    });
     const dbDevice = await localDb.getDeviceByQuery({
       connectId: params.releaseResult.originalConnectId, // TODO remove connectId check
     });
@@ -1637,6 +1716,10 @@ class ServiceFirmwareUpdate extends ServiceBase {
   @backgroundMethod()
   @toastIfError()
   async startUpdateWorkflowV2(params: IUpdateFirmwareWorkflowParams) {
+    this.resetUpdateWorkflowTracking({
+      updateFlow: 'v2',
+      releaseResult: params.releaseResult,
+    });
     await this.backgroundApi.serviceHardwareUI.withHardwareProcessing(
       async () => {
         appEventBus.emit(EAppEventBusNames.BeginFirmwareUpdate, undefined);
@@ -1812,6 +1895,10 @@ class ServiceFirmwareUpdate extends ServiceBase {
     } catch (error) {
       //
       serviceHardwareUtils.hardwareLog('startUpdateWorkflow ERROR', error);
+
+      // OK-57543: track each real failed attempt (retry may succeed later)
+      await this.trackUpdateTaskFailedAttempt(error);
+
       // never reject here, we should use retry
       // await servicePromise.rejectCallback({ id, error });
       await firmwareUpdateRetryAtom.set({

--- a/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
+++ b/packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx
@@ -171,6 +171,8 @@ export function FirmwareUpdateCheckList({
                     );
                   }
 
+                  const trackingInfo =
+                    await backgroundApiProxy.serviceFirmwareUpdate.getUpdateWorkflowTrackingInfo();
                   defaultLogger.update.firmware.firmwareUpdateResult({
                     deviceType: result?.deviceType,
                     transportType: hardwareTransportType,
@@ -179,6 +181,8 @@ export function FirmwareUpdateCheckList({
                     fromFirmwareType: updateFirmwareInfo?.fromFirmwareType,
                     toFirmwareType: updateFirmwareInfo?.toFirmwareType,
                     status: 'success',
+                    retryCount: trackingInfo.retryCount,
+                    durationMs: trackingInfo.durationMs,
                   });
 
                   const { fromFirmwareType, toFirmwareType } =
@@ -206,6 +210,8 @@ export function FirmwareUpdateCheckList({
                       error: err,
                     },
                   });
+                  const trackingInfo =
+                    await backgroundApiProxy.serviceFirmwareUpdate.getUpdateWorkflowTrackingInfo();
                   defaultLogger.update.firmware.firmwareUpdateResult({
                     deviceType: result?.deviceType,
                     transportType: hardwareTransportType,
@@ -216,6 +222,8 @@ export function FirmwareUpdateCheckList({
                     status: 'failed',
                     errorCode: err?.code,
                     errorMessage: err?.message,
+                    retryCount: trackingInfo.retryCount,
+                    durationMs: trackingInfo.durationMs,
                   });
                 } finally {
                   setWorkflowIsRunning(false);

--- a/packages/shared/src/logger/scopes/update/scenes/firmware.ts
+++ b/packages/shared/src/logger/scopes/update/scenes/firmware.ts
@@ -83,6 +83,24 @@ export class FirmwareScene extends BaseScene {
     return params;
   }
 
+  /**
+   * Track each real update-task failure (before user retry), so attempt-level
+   * failure rate can be measured even when a later retry succeeds
+   */
+  @LogToServer()
+  @LogToLocal()
+  public firmwareUpdateFailedAttempt(params: {
+    deviceType: IDeviceType | undefined;
+    transportType: EHardwareTransportType | undefined;
+    updateFlow: 'v1' | 'v2';
+    firmwareVersions: IFirmwareVersions;
+    attempt: number;
+    errorCode?: string;
+    errorMessage?: string;
+  }) {
+    return params;
+  }
+
   @LogToServer()
   @LogToLocal()
   public firmwareUpdateResult(params: {
@@ -95,6 +113,8 @@ export class FirmwareScene extends BaseScene {
     status: 'success' | 'failed';
     errorCode?: string;
     errorMessage?: string;
+    retryCount?: number;
+    durationMs?: number;
   }) {
     return params;
   }


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57543](https://onekeyhq.atlassian.net/browse/OK-57543)

----------

<!-- github-pr-monitor:jira-links:end -->


> Bundle release PR targeting `release/v6.4.0` — this change ships via hot update (JS-only, no native changes). Counterpart PR for `x`: #12343.

## Summary
- Add new analytics event `firmwareUpdateFailedAttempt` that reports every real firmware-update task failure (fired at the retry funnel, before the user retries)
- Add `retryCount` and `durationMs` optional properties to the existing `firmwareUpdateResult` event
- All properties are sliceable by `deviceType`, `transportType` (USB / BLE / bridge), update flow (v1/v2) and firmware versions

## Intent & Context
We need to measure, per released firmware, how many devices upgraded through the app and what the real failure rate is, split by transport (USB vs Bluetooth) and device type.

The existing `firmwareUpdateStarted` / `firmwareUpdateResult` events only capture the final outcome of a whole update workflow. Because `runUpdateTask` never rejects on task failure (it parks the workflow in a retry-wait state via `firmwareUpdateRetryAtom`), a device that fails 3 times and then succeeds on retry reports a single `success` event and zero failures — attempt-level failure rate was invisible, and retry recovery could not be measured.

## Design Decisions
- **Report failures at the single retry funnel** (`runUpdateTask` catch): all update tasks flow through `createRunTaskWithRetry` → `runUpdateTask`, so one hook covers v1 and v2 flows.
- **Per-workflow tracking context on the service** (`updateWorkflowTracking`): only one update workflow runs at a time; the context (flow type, releaseResult, start time, failed-attempt counter) is reset at both workflow entry points (`startUpdateWorkflow` / `startUpdateWorkflowV2`).
- **User exit is not a failure**: `FirmwareUpdateExit` / `FirmwareUpdateTasksClear` are excluded from failed-attempt reporting.
- **Analytics can never break the update flow**: the reporting helper is fully wrapped in try/catch.
- New fields on `firmwareUpdateResult` are optional and additive — existing Mixpanel dashboards and older app versions are unaffected.
- This branch's adaptation differs from the `x` counterpart (#12343): on `release/v6.4.0` both v1 and v2 results are reported from `FirmwareUpdateCheckList` (there is no `completeUpdateWorkflow`/`failUpdateWorkflow` service path here), so the UI fetches `retryCount`/`durationMs` via the new `getUpdateWorkflowTrackingInfo()` background method.

## Changes Detail
- `packages/shared/src/logger/scopes/update/scenes/firmware.ts`: new `firmwareUpdateFailedAttempt` event; `firmwareUpdateResult` gains optional `retryCount` / `durationMs`
- `packages/kit-bg/src/services/ServiceFirmwareUpdate/ServiceFirmwareUpdate.ts`: workflow tracking context + `getUpdateWorkflowTrackingInfo()` background method + failed-attempt reporting in the `runUpdateTask` catch
- `packages/kit/src/views/FirmwareUpdate/components/FirmwareUpdateCheckList.tsx`: result events (success/failure) now include the new fields

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: analytics-only, additive change; no control-flow change to the update workflow. The only new code on the failure path is wrapped in try/catch. Hot-update safe: pure JS/TS, no native module changes.

## Test plan
- [ ] `yarn tsc:only` — no new errors vs release/v6.4.0 base (same 6 pre-existing unrelated errors)
- [ ] `oxlint` on the 3 touched files — 0 warnings / 0 errors
- [ ] `jest packages/kit-bg/src/services/ServiceFirmwareUpdate packages/shared/src/logger` — all pass
- [ ] Manual: update firmware over USB and BLE with dev analytics enabled (`enableAnalyticsInDev`), verify `firmwareUpdateFailedAttempt` fires on each induced failure and `firmwareUpdateResult` carries `retryCount` / `durationMs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OK-57543]: https://onekeyhq.atlassian.net/browse/OK-57543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ