### PR TITLE
fix: stabilize Stock mobile web token sync(OK-57559 OK-57561 OK-57562)

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
@@ -107,6 +107,14 @@ function getSelectedTokensColdStartSwapType({
   toToken?: ISwapToken;
 }) {
   if (
+    currentSwapType === ESwapTabSwitchType.STOCK ||
+    fromToken?.isStock ||
+    toToken?.isStock
+  ) {
+    return ESwapTabSwitchType.STOCK;
+  }
+
+  if (
     fromToken?.networkId &&
     toToken?.networkId &&
     fromToken.networkId !== toToken.networkId
@@ -890,6 +898,9 @@ export function useSwapInit(params?: ISwapInitParams) {
     const isStockDefaultTokenFlow =
       swapTypeSwitchRef.current === ESwapTabSwitchType.STOCK ||
       params?.swapTabSwitchType === ESwapTabSwitchType.STOCK;
+    const hasStockExecutionSelectedTokens =
+      fromTokenRef.current?.isStock === true ||
+      toTokenRef.current?.isStock === true;
     const hasInitFromAmount = Boolean(
       hasUnconsumedSwapInitParams && params?.fromAmount,
     );
@@ -905,8 +916,9 @@ export function useSwapInit(params?: ISwapInitParams) {
     }
     if (isStockDefaultTokenFlow) {
       if (
+        !hasStockExecutionSelectedTokens &&
         selectedTokensColdStartContextRef.current?.swapType !==
-        ESwapTabSwitchType.STOCK
+          ESwapTabSwitchType.STOCK
       ) {
         if (fromTokenRef.current) {
           setSwapFromToken(undefined);


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57559](https://onekeyhq.atlassian.net/browse/OK-57559) [OK-57561](https://onekeyhq.atlassian.net/browse/OK-57561) [OK-57562](https://onekeyhq.atlassian.net/browse/OK-57562)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Treat Stock-selected tokens as Stock cold-start state before bridge detection.
- Preserve already-synced Stock execution tokens during Stock default token initialization.
- Prevent the mobile web Stock route from entering a React update loop before opening the K-line detail page.

## Intent & Context
QA reported OK-57559: mobile web users visiting `/swap?tab=stock` could freeze the page by tapping the Stock K-line button. During local runtime validation, the same underlying state loop also explained the adjacent Stock mobile web issues OK-57561 and OK-57562, which were confirmed fixed after this change.

## Root Cause
The Stock trading channel writes its execution pair into the shared Swap `fromToken` / `toToken` atoms. The global Swap cold-start/default-token logic also manages the same atoms. Because Stock token pairs can look like cross-network Swap/Bridge pairs, `getSelectedTokensColdStartSwapType` could classify the state before recognizing the Stock context. Stock default-token initialization then cleared `fromToken` / `toToken`, while the Stock channel immediately wrote them back, producing a repeated React state update loop (`Maximum update depth exceeded`). The K-line button was the visible trigger, but the failure came from the shared token-state synchronization loop.

## Design Decisions
- Keep the fix inside `useSwapGlobal` where cold-start type detection and default-token cleanup already live.
- Prefer Stock classification whenever the active tab or either selected token is Stock, so Stock execution pairs are not misclassified before bridge detection.
- Avoid clearing selected tokens during Stock default-token flow once a Stock execution token is already present, allowing the existing Stock channel sync to remain authoritative.
- Do not change the K-line navigation path; runtime proof showed the button and MarketDetail route work once the state loop is removed.

## Changes Detail
- `packages/kit/src/views/Swap/hooks/useSwapGlobal.ts`: prioritize Stock cold-start detection and guard Stock default-token cleanup when Stock execution tokens are already selected.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Web, Mobile Web
- **Risk Areas**: Swap/Stock shared token initialization and cold-start cache behavior. Normal Swap/Bridge behavior should be preserved because the new priority only applies when the current tab or selected token is explicitly Stock.

## Test plan
- [x] `git diff --check -- packages/kit/src/views/Swap/hooks/useSwapGlobal.ts`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/views/Swap/hooks/useSwapGlobal.ts --deny-warnings`
- [x] `yarn lint:staged`
- [x] Mobile web runtime: hard-load `http://localhost:3000/swap?tab=stock`, verify Stock page remains responsive, tap K-line, and verify `/market` opens with `market-detail-page`, `market-detail-chart`, and TradingView iframe.
- [x] Confirm no new `Maximum update depth exceeded` logs after hard-loading Stock and tapping K-line.
- [ ] `yarn tsc:staged` currently fails on unrelated existing errors in SOL Trezor / `ThirdPartyHwErrorCode.DeviceBusyInternal`, not this change.

[OK-57559]: https://onekeyhq.atlassian.net/browse/OK-57559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-57561]: https://onekeyhq.atlassian.net/browse/OK-57561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-57562]: https://onekeyhq.atlassian.net/browse/OK-57562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ