### PR TITLE
fix: P0 review fixes for OneKey ID / Keyless OAuth unification (#12284)

### DIFF
--- a/packages/kit/src/components/OneKeyAuth/OneKeyIdLogoutDialog.tsx
+++ b/packages/kit/src/components/OneKeyAuth/OneKeyIdLogoutDialog.tsx
@@ -268,13 +268,18 @@ export function useShowOneKeyIdLogoutDialog() {
           // the non-destructive (wallet-preserving) classification.
         }
       }
+      // A not-logged-in OneKey ID logout must never remove the keyless
+      // wallet: without a confirmed server-side session there is no proof
+      // the wallet is OAuth-bound (e.g. the bg invalid-token cleanup may
+      // have just flipped the login state), so default to the
+      // wallet-preserving classification, same as unknown identity data.
       const shouldSkipLinkedLogout =
         Boolean(keylessWallet) &&
-        isOneKeyIdLoggedIn &&
-        isLegacyOneKeyIdAccountMissingOAuthIdentityWithFallback({
-          onekeyAccount: userOneKeyAccount,
-          authSessionSource,
-        });
+        (!isOneKeyIdLoggedIn ||
+          isLegacyOneKeyIdAccountMissingOAuthIdentityWithFallback({
+            onekeyAccount: userOneKeyAccount,
+            authSessionSource,
+          }));
       const shouldLogoutKeylessWallet =
         Boolean(keylessWallet) &&
         !(

--- a/packages/kit/src/views/Prime/components/PrimeLoginEmailDialogV2/PrimeLoginEmailDialogV2.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeLoginEmailDialogV2/PrimeLoginEmailDialogV2.tsx
@@ -89,7 +89,16 @@ function PrimeLoginEmailDialogV2(props: {
         await timerUtils.wait(550);
         const dialog = Dialog.show({
           onCancel,
-          onClose: onCancel,
+          onClose: async (extra) => {
+            // dialog.close({ flag: 'loginSuccess' }) means the dialog was
+            // closed programmatically after a successful login; skip the
+            // cancel handler so the outer login promise is not rejected
+            // with PrimeLoginDialogCancelError before onLoginSuccess runs.
+            if (extra?.flag === 'loginSuccess') {
+              return;
+            }
+            await onCancel?.();
+          },
           renderContent: (
             <PrimeLoginEmailCodeDialogV2
               sendCode={sendCode}
@@ -111,7 +120,7 @@ function PrimeLoginEmailDialogV2(props: {
                   });
                   isOneKeyIdLoginCommitted = true;
                   showOneKeyIdLoginSuccessToast(intl);
-                  await dialog.close();
+                  await dialog.close({ flag: 'loginSuccess' });
                   isDialogClosed = true;
                   await onLoginSuccess?.();
                   await showOneKeyIdLegacyOAuthBindDialogAfterLegacyEmailOtpLogin();


### PR DESCRIPTION
## Summary

Fixes the two P0 findings from the code review of #12284. Targets the PR branch `prague13/merge-onekeyid-keyless-accounts` so it can be merged into that PR.

## Changes

### 1. `fix: settle legacy email OTP login promise as success instead of cancel`

`PrimeLoginEmailDialogV2.tsx`: the success path calls `await dialog.close()` before `await onLoginSuccess?.()`, and the code dialog was wired with `onClose: onCancel`. `Dialog.close()` invokes `onClose` before resolving, so the outer `showOneKeyIdLoginDialog` promise was rejected with `PrimeLoginDialogCancelError` on **every successful legacy email OTP login** — all `await loginOneKeyId()` callers (refer friends, redemption center, cloud sync, more-action button, prime requirements) aborted their flow as "user cancelled" and `toOneKeyIdPageOnLoginSuccess` navigation was skipped, despite the login succeeding.

Fix: close with `dialog.close({ flag: 'loginSuccess' })` and make the `onClose` wrapper skip the cancel handler for that flag (idiomatic — same pattern as `OneKeyIdLegacyOAuthBind`'s `close({ flag: 'confirm' })`). Real user dismissal (backdrop / ESC / header close / footer cancel) still rejects with `PrimeLoginDialogCancelError`; the error path (`finally` with plain `close()`) is unchanged. The close-before-bind-dialog ordering is preserved, so the post-OTP bind prompt UX is not regressed.

### 2. `fix: never remove keyless wallet from logout dialog when OneKey ID is not logged in`

`OneKeyIdLogoutDialog.tsx`: in `useShowOneKeyIdLogoutDialog`, when `source === OneKeyId`, a local keyless wallet exists, and `isOneKeyIdLoggedIn === false`, both the skip predicate and the `authSessionSource` fallback were gated on `isOneKeyIdLoggedIn`, forcing `shouldSkipLinkedLogout = false` — the dialog landed in the destructive linked branch and confirming removed the keyless wallet. Reachable in practice: the bg invalid-token cleanup (`PrimeLoginInvalidToken`) flips `isLoggedInOnServer` while the OneKey ID page is open; tapping "Log out" then offered (and completed) removal of a keyless wallet that a legacy-email OneKey ID never backed — violating the file's own invariant that unknown identity data must never trigger wallet removal.

Fix: `!isOneKeyIdLoggedIn` now short-circuits into the wallet-preserving skip-linked classification (non-destructive dialog, `preserveLocalKeylessAuth: true`), the same default as unknown identity data. Explicit keyless-wallet removal (`source === KeylessWallet`) and all logged-in paths are unchanged.

## Test plan

- [x] Project type check (`tsc:only` via tsgo) passes with no diagnostics
- [x] ESLint clean on edited files
- [ ] Legacy email OTP login through a gated flow (e.g. Refer Friends) completes the flow and navigates on success
- [ ] Dismissing the OTP dialog without logging in still cancels the flow
- [ ] With a local keyless wallet and OneKey ID session invalidated server-side, "Log out" shows the non-destructive dialog and does not remove the wallet
- [ ] Explicit keyless wallet removal flow unchanged (checkbox + password verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014WCAcFqzCkJySaUtPdb71z

---
_Generated by [Claude Code](https://claude.ai/code/session_014WCAcFqzCkJySaUtPdb71z)_