### PR TITLE
fix: lazy load DeFi lending action dialog (OK-57637)

### DIFF
--- a/packages/kit/src/components/DeFi/ProtocolLendingActionDialog.ts
+++ b/packages/kit/src/components/DeFi/ProtocolLendingActionDialog.ts
@@ -1,0 +1,31 @@
+import type {
+  IProtocolLendingActionSource,
+  IProtocolLendingActionType,
+  IShowProtocolLendingActionDialogParams,
+} from './ProtocolLendingActionDialogContent';
+
+let protocolLendingActionDialogModulePromise:
+  | Promise<typeof import('./ProtocolLendingActionDialogContent')>
+  | undefined;
+
+function loadProtocolLendingActionDialogModule() {
+  protocolLendingActionDialogModulePromise ??=
+    import('./ProtocolLendingActionDialogContent');
+  return protocolLendingActionDialogModulePromise;
+}
+
+function showProtocolLendingActionDialog(
+  params: IShowProtocolLendingActionDialogParams,
+) {
+  void loadProtocolLendingActionDialogModule()
+    .then(({ showProtocolLendingActionDialog: showDialog }) => {
+      showDialog(params);
+    })
+    .catch((error: Error) => {
+      protocolLendingActionDialogModulePromise = undefined;
+      console.error('Failed to load ProtocolLendingActionDialog:', error);
+    });
+}
+
+export { showProtocolLendingActionDialog };
+export type { IProtocolLendingActionSource, IProtocolLendingActionType };

--- a/packages/kit/src/components/DeFi/ProtocolLendingActionDialog.ts
+++ b/packages/kit/src/components/DeFi/ProtocolLendingActionDialog.ts
@@ -1,12 +1,27 @@
+import { Toast } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+
 import type {
   IProtocolLendingActionSource,
   IProtocolLendingActionType,
   IShowProtocolLendingActionDialogParams,
 } from './ProtocolLendingActionDialogContent';
+import type { IntlShape } from 'react-intl';
+
+type IProtocolLendingActionDialogModule =
+  typeof import('./ProtocolLendingActionDialogContent');
+
+type IShowProtocolLendingActionDialogWrapperParams =
+  IShowProtocolLendingActionDialogParams & {
+    intl: IntlShape;
+  };
 
 let protocolLendingActionDialogModulePromise:
-  | Promise<typeof import('./ProtocolLendingActionDialogContent')>
+  | Promise<IProtocolLendingActionDialogModule>
   | undefined;
+let hasRequestedProtocolLendingActionDialogPreload = false;
+let protocolLendingActionDialogOpenRequestId = 0;
 
 function loadProtocolLendingActionDialogModule() {
   protocolLendingActionDialogModulePromise ??=
@@ -14,18 +29,90 @@ function loadProtocolLendingActionDialogModule() {
   return protocolLendingActionDialogModulePromise;
 }
 
-function showProtocolLendingActionDialog(
-  params: IShowProtocolLendingActionDialogParams,
-) {
-  void loadProtocolLendingActionDialogModule()
-    .then(({ showProtocolLendingActionDialog: showDialog }) => {
-      showDialog(params);
-    })
-    .catch((error: Error) => {
-      protocolLendingActionDialogModulePromise = undefined;
-      console.error('Failed to load ProtocolLendingActionDialog:', error);
-    });
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message) return error.message;
+  return String(error);
 }
 
-export { showProtocolLendingActionDialog };
+function showProtocolLendingActionDialogLoadErrorToast(intl: IntlShape) {
+  Toast.error({
+    title: intl.formatMessage({
+      id: ETranslations.global_network_error,
+    }),
+    message: intl.formatMessage({
+      id: ETranslations.global_network_error_help_text,
+    }),
+  });
+}
+
+function preloadProtocolLendingActionDialog() {
+  if (
+    hasRequestedProtocolLendingActionDialogPreload ||
+    protocolLendingActionDialogModulePromise
+  ) {
+    return;
+  }
+  hasRequestedProtocolLendingActionDialogPreload = true;
+  void loadProtocolLendingActionDialogModule().catch((error) => {
+    hasRequestedProtocolLendingActionDialogPreload = false;
+    protocolLendingActionDialogModulePromise = undefined;
+    defaultLogger.app.error.log(
+      `Failed to preload ProtocolLendingActionDialog: ${getErrorMessage(
+        error,
+      )}`,
+    );
+  });
+}
+
+function showProtocolLendingActionDialog({
+  intl,
+  ...params
+}: IShowProtocolLendingActionDialogWrapperParams) {
+  const openRequestId = (protocolLendingActionDialogOpenRequestId += 1);
+  let isOpenRequestActive = true;
+  void (async () => {
+    let protocolLendingActionDialogModule: IProtocolLendingActionDialogModule;
+    try {
+      protocolLendingActionDialogModule =
+        await loadProtocolLendingActionDialogModule();
+    } catch (error) {
+      protocolLendingActionDialogModulePromise = undefined;
+      defaultLogger.app.error.log(
+        `Failed to load ProtocolLendingActionDialog: ${getErrorMessage(error)}`,
+      );
+      if (
+        !isOpenRequestActive ||
+        openRequestId !== protocolLendingActionDialogOpenRequestId
+      ) {
+        return;
+      }
+      showProtocolLendingActionDialogLoadErrorToast(intl);
+      return;
+    }
+
+    if (
+      !isOpenRequestActive ||
+      openRequestId !== protocolLendingActionDialogOpenRequestId
+    ) {
+      return;
+    }
+
+    try {
+      protocolLendingActionDialogModule.showProtocolLendingActionDialog(params);
+    } catch (error) {
+      defaultLogger.app.error.log(
+        `Failed to show ProtocolLendingActionDialog: ${getErrorMessage(error)}`,
+      );
+    }
+  })();
+
+  return () => {
+    isOpenRequestActive = false;
+    if (openRequestId === protocolLendingActionDialogOpenRequestId) {
+      protocolLendingActionDialogOpenRequestId += 1;
+    }
+  };
+}
+
+export { preloadProtocolLendingActionDialog, showProtocolLendingActionDialog };
 export type { IProtocolLendingActionSource, IProtocolLendingActionType };

--- a/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
@@ -111,6 +111,17 @@ type IBorrowAssetsListLoadState = {
   errorMessage?: string;
 };
 
+type IShowProtocolLendingActionDialogParams = {
+  accountId: string;
+  networkId: string;
+  actionType: IProtocolLendingActionType;
+  source: IProtocolLendingActionSource;
+  hasDebts?: boolean;
+  onSuccess?: (
+    params: IProtocolPositionActionSuccessParams,
+  ) => void | Promise<void>;
+};
+
 const LENDING_PERCENT_PRESETS = [25, 50, 75, 100] as const;
 const EMPTY_BORROW_ASSETS_LIST: IBorrowAssetsList = {
   assets: [] as IBorrowAsset[],
@@ -1633,16 +1644,7 @@ function showProtocolLendingActionDialog({
   source,
   hasDebts,
   onSuccess,
-}: {
-  accountId: string;
-  networkId: string;
-  actionType: IProtocolLendingActionType;
-  source: IProtocolLendingActionSource;
-  hasDebts?: boolean;
-  onSuccess?: (
-    params: IProtocolPositionActionSuccessParams,
-  ) => void | Promise<void>;
-}) {
+}: IShowProtocolLendingActionDialogParams) {
   Dialog.show({
     showFooter: false,
     renderContent:
@@ -1669,4 +1671,8 @@ function showProtocolLendingActionDialog({
 }
 
 export { showProtocolLendingActionDialog };
-export type { IProtocolLendingActionSource, IProtocolLendingActionType };
+export type {
+  IProtocolLendingActionSource,
+  IProtocolLendingActionType,
+  IShowProtocolLendingActionDialogParams,
+};

--- a/packages/kit/src/components/DeFi/ProtocolPositionActionButton.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionButton.tsx
@@ -2,6 +2,7 @@ import {
   type ComponentProps,
   memo,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -29,6 +30,7 @@ import type { IBorrowMarketItem } from '@onekeyhq/shared/types/staking';
 
 import {
   type IProtocolLendingActionType,
+  preloadProtocolLendingActionDialog,
   showProtocolLendingActionDialog,
 } from './ProtocolLendingActionDialog';
 import { findSupportedBorrowMarket } from './protocolLendingActionUtils';
@@ -531,6 +533,9 @@ const ProtocolPositionActionButton = memo(
     const [submittingActionKey, setSubmittingActionKey] = useState<
       string | undefined
     >(undefined);
+    const cancelPendingLendingDialogOpenRef = useRef<(() => void) | undefined>(
+      undefined,
+    );
     const shouldResolveActionButtons = !!accountId;
     const actions = useMemo(
       () =>
@@ -697,6 +702,27 @@ const ProtocolPositionActionButton = memo(
           action.action !== EDeFiPositionAction.Repay,
       );
     }
+    const shouldPreloadProtocolLendingActionDialog =
+      shouldShowManage ||
+      (preferLendingDialog &&
+        renderedActions.some(
+          (action) =>
+            (action.action === EDeFiPositionAction.Withdraw ||
+              action.action === EDeFiPositionAction.Repay) &&
+            !action.buildAction,
+        ));
+    useEffect(() => {
+      if (shouldPreloadProtocolLendingActionDialog) {
+        preloadProtocolLendingActionDialog();
+      }
+    }, [shouldPreloadProtocolLendingActionDialog]);
+    useEffect(
+      () => () => {
+        cancelPendingLendingDialogOpenRef.current?.();
+        cancelPendingLendingDialogOpenRef.current = undefined;
+      },
+      [],
+    );
     const handleActionPress = useCallback(
       async (action: IResolvedDeFiPositionAction) => {
         if (!accountId) {
@@ -740,17 +766,19 @@ const ProtocolPositionActionButton = memo(
             action.action === EDeFiPositionAction.Repay) &&
           !action.buildAction
         ) {
-          showProtocolLendingActionDialog({
-            accountId,
-            networkId: protocol.networkId,
-            actionType:
-              action.action === EDeFiPositionAction.Repay
-                ? 'repay'
-                : 'withdraw',
-            source: { type: 'defi', action },
-            hasDebts: positionHasDebts,
-            onSuccess,
-          });
+          cancelPendingLendingDialogOpenRef.current =
+            showProtocolLendingActionDialog({
+              accountId,
+              networkId: protocol.networkId,
+              actionType:
+                action.action === EDeFiPositionAction.Repay
+                  ? 'repay'
+                  : 'withdraw',
+              source: { type: 'defi', action },
+              hasDebts: positionHasDebts,
+              intl,
+              onSuccess,
+            });
           return;
         }
 
@@ -769,6 +797,7 @@ const ProtocolPositionActionButton = memo(
       [
         accountId,
         hasRewards,
+        intl,
         onSuccess,
         position,
         positionHasDebts,
@@ -787,31 +816,34 @@ const ProtocolPositionActionButton = memo(
             ? repayManageParams
             : withdrawManageParams;
         if (!params) return;
-        showProtocolLendingActionDialog({
-          accountId,
-          networkId: protocol.networkId,
-          actionType,
-          source: {
-            type: 'borrow',
-            provider: params.provider,
-            marketAddress: params.marketAddress,
-            reserveAddress: params.reserveAddress,
-            symbol: params.symbol,
-            logoURI: params.logoURI,
-            providerDisplayName: params.providerDisplayName,
-            providerLogoURI: params.providerLogoURI,
-            indexedAccountId: protocol.indexedAccountId ?? indexedAccountId,
-            // A row-scoped button already names the asset (fixed); the
-            // position-level block button lets the dialog's dropdown choose it.
-            selectable: !manageAsset,
-          },
-          hasDebts: positionHasDebts,
-          onSuccess,
-        });
+        cancelPendingLendingDialogOpenRef.current =
+          showProtocolLendingActionDialog({
+            accountId,
+            networkId: protocol.networkId,
+            actionType,
+            source: {
+              type: 'borrow',
+              provider: params.provider,
+              marketAddress: params.marketAddress,
+              reserveAddress: params.reserveAddress,
+              symbol: params.symbol,
+              logoURI: params.logoURI,
+              providerDisplayName: params.providerDisplayName,
+              providerLogoURI: params.providerLogoURI,
+              indexedAccountId: protocol.indexedAccountId ?? indexedAccountId,
+              // A row-scoped button already names the asset (fixed); the
+              // position-level block button lets the dialog's dropdown choose it.
+              selectable: !manageAsset,
+            },
+            hasDebts: positionHasDebts,
+            intl,
+            onSuccess,
+          });
       },
       [
         accountId,
         indexedAccountId,
+        intl,
         manageAsset,
         onSuccess,
         positionHasDebts,

--- a/packages/kit/src/components/DeFi/ProtocolPositionActionButton.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionButton.tsx
@@ -30,7 +30,6 @@ import type { IBorrowMarketItem } from '@onekeyhq/shared/types/staking';
 
 import {
   type IProtocolLendingActionType,
-  preloadProtocolLendingActionDialog,
   showProtocolLendingActionDialog,
 } from './ProtocolLendingActionDialog';
 import { findSupportedBorrowMarket } from './protocolLendingActionUtils';
@@ -702,20 +701,6 @@ const ProtocolPositionActionButton = memo(
           action.action !== EDeFiPositionAction.Repay,
       );
     }
-    const shouldPreloadProtocolLendingActionDialog =
-      shouldShowManage ||
-      (preferLendingDialog &&
-        renderedActions.some(
-          (action) =>
-            (action.action === EDeFiPositionAction.Withdraw ||
-              action.action === EDeFiPositionAction.Repay) &&
-            !action.buildAction,
-        ));
-    useEffect(() => {
-      if (shouldPreloadProtocolLendingActionDialog) {
-        preloadProtocolLendingActionDialog();
-      }
-    }, [shouldPreloadProtocolLendingActionDialog]);
     useEffect(
       () => () => {
         cancelPendingLendingDialogOpenRef.current?.();

--- a/packages/kit/src/views/AssetDetails/pages/DeFiProtocolDetails.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/DeFiProtocolDetails.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import { type RouteProp, useRoute } from '@react-navigation/core';
 import { useIntl } from 'react-intl';
@@ -16,6 +16,7 @@ import {
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { DEFI_PORTFOLIO_DETAIL_POSITION_NAME_COLOR } from '@onekeyhq/kit/src/components/DeFi/defiPortfolioDetailStyleUtils';
 import { DeFiPositionHealthFactorRow } from '@onekeyhq/kit/src/components/DeFi/DeFiPositionHealthFactorRow';
+import { preloadProtocolLendingActionDialog } from '@onekeyhq/kit/src/components/DeFi/ProtocolLendingActionDialog';
 import {
   type IProtocolPositionProviderDisplayInfo,
   ProtocolPositionActionButton,
@@ -157,6 +158,14 @@ function DeFiProtocolDetails() {
       }),
     [intl, protocol],
   );
+  const shouldPreloadProtocolLendingActionDialog =
+    positions.some(isSectionedPosition);
+  useEffect(() => {
+    if (shouldPreloadProtocolLendingActionDialog) {
+      preloadProtocolLendingActionDialog();
+    }
+  }, [shouldPreloadProtocolLendingActionDialog]);
+
   const protocolDisplayInfo = useMemo(
     () =>
       buildProtocolDisplayInfo({

--- a/packages/kit/src/views/Home/components/DeFiListBlock/Protocol.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/Protocol.tsx
@@ -2,6 +2,7 @@ import {
   forwardRef,
   memo,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -12,6 +13,7 @@ import { useIntl } from 'react-intl';
 import { StyleSheet } from 'react-native';
 
 import { Accordion, Stack, YStack } from '@onekeyhq/components';
+import { preloadProtocolLendingActionDialog } from '@onekeyhq/kit/src/components/DeFi/ProtocolLendingActionDialog';
 import type { IProtocolPositionProviderDisplayInfo } from '@onekeyhq/kit/src/components/DeFi/ProtocolPositionActionButton';
 import type { IProtocolPositionActionSuccessParams } from '@onekeyhq/kit/src/components/DeFi/ProtocolPositionActionDialog';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
@@ -127,6 +129,15 @@ const ProtocolDesktopLayout = memo(
       const anchorRef = useRef<HTMLElement | null>(null);
       const [accordionValue, setAccordionValue] =
         useState<string>(ACCORDION_OPEN_VALUE);
+      const shouldPreloadProtocolLendingActionDialog = categoryGroups.some(
+        (group) => group.kind === 'sectioned',
+      );
+
+      useEffect(() => {
+        if (shouldPreloadProtocolLendingActionDialog) {
+          preloadProtocolLendingActionDialog();
+        }
+      }, [shouldPreloadProtocolLendingActionDialog]);
 
       useImperativeHandle(
         forwardedRef,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57637](https://onekeyhq.atlassian.net/browse/OK-57637)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Lazy-load the DeFi protocol lending action dialog through an async wrapper so the heavy lending UI is split out of the startup bundle.
- Keep the existing `showProtocolLendingActionDialog` public import path and type exports.

## Context
The web startup graph CI failed after PR #12280 because `allScriptRawBytes` exceeded the 90 MiB budget by about 25.6 KiB. Splitting the dialog into an async chunk brings the web build back under budget.

## Runtime impact
- main/UI runtime: dialog code loads on demand when a lending action opens the modal.
- bg runtime: no change.
- Native resources / JS heap: no shared native resources changed; dialog JS objects are only materialized in the UI runtime after dynamic import.

## Test Plan
- `git diff --check`
- `npx oxlint --tsconfig ./tsconfig.json --type-aware packages/kit/src/components/DeFi/ProtocolLendingActionDialog.ts packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx --deny-warnings`
- `yarn tsc:only`
- `PATH="$PWD/node_modules/.bin:$PATH" yarn workspace @onekeyhq/web build`
- `node apps/web/scripts/check-startup-graph-budget.js apps/web/web-build`
  - PASS `allScriptRawBytes: 89.94 MiB / 90.00 MiB`

[OK-57637]: https://onekeyhq.atlassian.net/browse/OK-57637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ