### PR TITLE
fix: remove stock chart x-axis units(OK-57649)

### DIFF
--- a/packages/kit/src/components/LightweightChart/LightweightChart.native.tsx
+++ b/packages/kit/src/components/LightweightChart/LightweightChart.native.tsx
@@ -44,6 +44,7 @@ export function LightweightChart({
   showLastValue,
   showLastPointMarker,
   showTimeScale,
+  useTimeScaleTickMarkWithoutUnit,
   onHover,
 }: ILightweightChartProps) {
   const webViewRef = useRef<WebView>(null);
@@ -71,6 +72,7 @@ export function LightweightChart({
     showLastValue,
     showLastPointMarker,
     showTimeScale,
+    useTimeScaleTickMarkWithoutUnit,
   });
   const nativeConfig = useMemo(
     () => ({ ...chartConfig, showLastValue: !!showLastValue }),

--- a/packages/kit/src/components/LightweightChart/LightweightChart.tsx
+++ b/packages/kit/src/components/LightweightChart/LightweightChart.tsx
@@ -72,6 +72,7 @@ export function LightweightChart({
   showLastValue,
   showLastPointMarker,
   showTimeScale,
+  useTimeScaleTickMarkWithoutUnit,
   pulseLastPoint,
   onHover,
 }: ILightweightChartProps) {
@@ -107,6 +108,7 @@ export function LightweightChart({
     showLastValue,
     showLastPointMarker,
     showTimeScale,
+    useTimeScaleTickMarkWithoutUnit,
   });
 
   useEffect(() => {
@@ -133,6 +135,7 @@ export function LightweightChart({
           chartConfig.priceScaleMargins,
           chartConfig.showTimeScale,
           chartConfig.priceScaleEntireTextOnly,
+          chartConfig.useTimeScaleTickMarkWithoutUnit,
         );
         const gridOptions = {
           vertLines: { visible: false },

--- a/packages/kit/src/components/LightweightChart/hooks/useChartConfig.ts
+++ b/packages/kit/src/components/LightweightChart/hooks/useChartConfig.ts
@@ -35,6 +35,7 @@ interface IUseChartConfigProps {
   showLastValue?: boolean;
   showLastPointMarker?: boolean;
   showTimeScale?: boolean;
+  useTimeScaleTickMarkWithoutUnit?: boolean;
 }
 
 export function useChartConfig({
@@ -59,6 +60,7 @@ export function useChartConfig({
   showLastValue,
   showLastPointMarker,
   showTimeScale = true,
+  useTimeScaleTickMarkWithoutUnit,
 }: IUseChartConfigProps): ILightweightChartConfig {
   const theme = useTheme();
   const resolvedSeriesType = seriesType ?? 'area';
@@ -109,6 +111,7 @@ export function useChartConfig({
       showLastValue,
       showLastPointMarker,
       showTimeScale,
+      useTimeScaleTickMarkWithoutUnit,
     }),
     [
       data,
@@ -135,6 +138,7 @@ export function useChartConfig({
       showLastValue,
       showLastPointMarker,
       showTimeScale,
+      useTimeScaleTickMarkWithoutUnit,
     ],
   );
 }

--- a/packages/kit/src/components/LightweightChart/types/index.ts
+++ b/packages/kit/src/components/LightweightChart/types/index.ts
@@ -43,6 +43,7 @@ export interface ILightweightChartConfig {
   showLastValue?: boolean;
   showLastPointMarker?: boolean;
   showTimeScale?: boolean;
+  useTimeScaleTickMarkWithoutUnit?: boolean;
 }
 
 export interface ILightweightChartProps {
@@ -68,6 +69,7 @@ export interface ILightweightChartProps {
   showLastValue?: boolean;
   showLastPointMarker?: boolean;
   showTimeScale?: boolean;
+  useTimeScaleTickMarkWithoutUnit?: boolean;
   // When true, overlays an animated "breathing" dot on the last data point to
   // signal the chart is live. Web/desktop only; toggling it does not recreate
   // the chart.

--- a/packages/kit/src/components/LightweightChart/utils/chartOptions.ts
+++ b/packages/kit/src/components/LightweightChart/utils/chartOptions.ts
@@ -3,10 +3,91 @@ import type {
   AreaSeriesPartialOptions,
   ChartOptions,
   DeepPartial,
+  TickMarkFormatter,
 } from 'lightweight-charts';
 
 const CHART_FONT_FAMILY =
   'Roobert, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
+
+const CHART_TICK_MARK_TYPE = {
+  Year: 0,
+  Month: 1,
+  DayOfMonth: 2,
+  Time: 3,
+  TimeWithSeconds: 4,
+} as const;
+
+function padTimePart(value: number) {
+  return value.toString().padStart(2, '0');
+}
+
+function getDatePartsFromChartTime(time: Parameters<TickMarkFormatter>[0]) {
+  if (typeof time === 'number') {
+    const date = new Date(time * 1000);
+    return {
+      year: date.getUTCFullYear(),
+      month: date.getUTCMonth() + 1,
+      day: date.getUTCDate(),
+      hours: date.getUTCHours(),
+      minutes: date.getUTCMinutes(),
+      seconds: date.getUTCSeconds(),
+    };
+  }
+
+  if (typeof time === 'string') {
+    const date = new Date(time);
+    return {
+      year: date.getUTCFullYear(),
+      month: date.getUTCMonth() + 1,
+      day: date.getUTCDate(),
+      hours: date.getUTCHours(),
+      minutes: date.getUTCMinutes(),
+      seconds: date.getUTCSeconds(),
+    };
+  }
+
+  return {
+    year: time.year,
+    month: time.month,
+    day: time.day,
+    hours: 0,
+    minutes: 0,
+    seconds: 0,
+  };
+}
+
+const formatChartTickMarkWithoutUnit: TickMarkFormatter = (
+  time,
+  tickMarkType,
+) => {
+  const dateParts = getDatePartsFromChartTime(time);
+  if (
+    !Number.isFinite(dateParts.year) ||
+    !Number.isFinite(dateParts.month) ||
+    !Number.isFinite(dateParts.day)
+  ) {
+    return null;
+  }
+
+  switch (tickMarkType) {
+    case CHART_TICK_MARK_TYPE.Year:
+      return dateParts.year.toString();
+    case CHART_TICK_MARK_TYPE.Month:
+      return padTimePart(dateParts.month);
+    case CHART_TICK_MARK_TYPE.DayOfMonth:
+      return padTimePart(dateParts.day);
+    case CHART_TICK_MARK_TYPE.Time:
+      return `${padTimePart(dateParts.hours)}:${padTimePart(
+        dateParts.minutes,
+      )}`;
+    case CHART_TICK_MARK_TYPE.TimeWithSeconds:
+      return `${padTimePart(dateParts.hours)}:${padTimePart(
+        dateParts.minutes,
+      )}:${padTimePart(dateParts.seconds)}`;
+    default:
+      return `${padTimePart(dateParts.month)}/${padTimePart(dateParts.day)}`;
+  }
+};
 
 export function createChartOptions(
   theme: ILightweightChartTheme,
@@ -15,6 +96,7 @@ export function createChartOptions(
   priceScaleMargins?: { top: number; bottom: number },
   showTimeScale = true,
   priceScaleEntireTextOnly = false,
+  useTimeScaleTickMarkWithoutUnit = false,
 ): DeepPartial<ChartOptions> {
   return {
     layout: {
@@ -47,6 +129,9 @@ export function createChartOptions(
       fixLeftEdge: true,
       fixRightEdge: true,
       lockVisibleTimeRangeOnResize: true,
+      ...(useTimeScaleTickMarkWithoutUnit
+        ? { tickMarkFormatter: formatChartTickMarkWithoutUnit }
+        : {}),
     },
     rightPriceScale: {
       visible: showPriceScale,

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -1741,6 +1741,7 @@ function StockPriceChart({
           priceScaleEntireTextOnly
           priceFormatter={priceFormatter}
           fontSize={11}
+          useTimeScaleTickMarkWithoutUnit
           onHover={handleChartHover}
         />
       </YStack>


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57649](https://onekeyhq.atlassian.net/browse/OK-57649)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Format LightweightChart x-axis ticks with unitless numeric/time labels.
- Keep the x-axis visible while removing locale-specific units such as Chinese day/month suffixes.

## Intent & Context
OK-57649 reports that the Stock K-line x-axis should not display units. The desired behavior matches the TradingView reference: keep the horizontal axis labels, but show unitless values such as day numbers or intraday times.

## Root Cause
Lightweight Charts falls back to locale-aware tick formatting. In Chinese locale, date ticks can render with units such as `日` or `月`, which does not match the requested Stock K-line display.

## Design Decisions
- Do not hard-code `en-US`, because that prevents the chart labels from following the app language correctly.
- Add a locale-independent `tickMarkFormatter` that returns only numeric dates or times, avoiding both Chinese units and English month text.
- Keep the axis visible; only the unit-bearing label format changes.

## Changes Detail
- `packages/kit/src/components/LightweightChart/utils/chartOptions.ts`: adds a shared x-axis tick formatter for LightweightChart options.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Web
- **Risk Areas**: LightweightChart is shared by multiple chart surfaces, so x-axis labels on other non-native charts will also use unitless numeric/time labels.

## Test plan
- [x] `yarn lint:staged`
- [x] `git diff --cached --check`
- [ ] `yarn tsc:staged` - blocked by existing unrelated Sol/Trezor and third-party hardware error type failures in `packages/kit-bg` and `packages/shared`.

[OK-57649]: https://onekeyhq.atlassian.net/browse/OK-57649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ