### PR TITLE
perf: split DeFi borrow action hooks(OK-57637)

### DIFF
--- a/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
@@ -28,7 +28,7 @@ import { useUniversalBorrowAction } from '@onekeyhq/kit/src/views/Borrow/compone
 import {
   useUniversalBorrowRepay,
   useUniversalBorrowWithdraw,
-} from '@onekeyhq/kit/src/views/Borrow/hooks/useUniversalBorrowHooks';
+} from '@onekeyhq/kit/src/views/Borrow/hooks/useUniversalBorrowWithdrawRepayHooks';
 import { EarnText } from '@onekeyhq/kit/src/views/Staking/components/ProtocolDetails/EarnText';
 import { useManagePage } from '@onekeyhq/kit/src/views/Staking/pages/ManagePosition/hooks/useManagePage';
 import { buildBorrowTag } from '@onekeyhq/kit/src/views/Staking/utils/utils';

--- a/packages/kit/src/views/Borrow/hooks/useUniversalBorrowHooks.ts
+++ b/packages/kit/src/views/Borrow/hooks/useUniversalBorrowHooks.ts
@@ -5,15 +5,12 @@ import { useIntl } from 'react-intl';
 import { Toast } from '@onekeyhq/components';
 import type { IEncodedTx } from '@onekeyhq/core/src/types';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { showDeFiActionTxConfirmDialog } from '@onekeyhq/kit/src/components/DeFi/DeFiActionTxConfirmResult';
 import { useSignatureConfirm } from '@onekeyhq/kit/src/hooks/useSignatureConfirm';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IModalSendParamList } from '@onekeyhq/shared/src/routes';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
-import { EOnChainHistoryTxStatus } from '@onekeyhq/shared/types/history';
 import {
-  EEarnLabels,
   type IRepayWithCollateralQuote,
   type IStakingInfo,
 } from '@onekeyhq/shared/types/staking';
@@ -24,27 +21,16 @@ import {
   getBorrowLutFinalizationErrorTranslation,
   mapBorrowLutFinalizationToTxStatus,
 } from './borrowLutFinalization';
+import {
+  type IBorrowBuildTxParams,
+  attachBorrowOrderId,
+  handleBorrowSuccess,
+  parseBorrowEncodedTx,
+  useUniversalBorrowRepay,
+  useUniversalBorrowWithdraw,
+} from './useUniversalBorrowWithdrawRepayHooks';
 
-function parseBorrowEncodedTx(tx: string): IEncodedTx {
-  try {
-    const parsed = JSON.parse(tx) as unknown;
-    if (parsed && typeof parsed === 'object') {
-      return parsed as IEncodedTx;
-    }
-  } catch {
-    // Ignore parsing errors and fallback to raw string
-  }
-  return tx;
-}
-
-const attachBorrowOrderId = ({
-  stakingInfo,
-  orderId,
-}: {
-  stakingInfo?: IStakingInfo;
-  orderId?: string;
-}): IStakingInfo | undefined =>
-  stakingInfo ? { ...stakingInfo, orderId } : undefined;
+export { useUniversalBorrowRepay, useUniversalBorrowWithdraw };
 
 const attachRepayWithCollateralAmount = ({
   stakingInfo,
@@ -145,84 +131,8 @@ const syncBorrowOrder = async ({
   });
 };
 
-const handleBorrowSuccess = async ({
-  data,
-  orderId,
-  networkId,
-  accountId,
-  stakingInfo,
-  onSuccess,
-}: {
-  data: ISendTxOnSuccessData[];
-  orderId?: string;
-  networkId: string;
-  accountId?: string;
-  stakingInfo?: IStakingInfo;
-  onSuccess?: IModalSendParamList['SendConfirm']['onSuccess'];
-}) => {
-  const latestTxId =
-    Array.isArray(data) && data.length > 0 ? getLatestTxId(data) : undefined;
-
-  // Aave withdraw / repay get the shared confirming sheet before the caller's
-  // refresh; supply / borrow keep the existing pending-badge flow.
-  const label = stakingInfo?.label;
-  const shouldShowConfirmSheet =
-    !!accountId &&
-    (label === EEarnLabels.Withdraw || label === EEarnLabels.Repay);
-
-  if (orderId && latestTxId) {
-    const addEarnOrderPromise = backgroundApiProxy.serviceStaking.addEarnOrder({
-      orderId,
-      networkId,
-      txId: latestTxId,
-      status: data[data.length - 1]?.decodedTx.status,
-      ...getEarnOrderTrackingInfo(stakingInfo),
-    });
-    // Don't block the confirming sheet on order tagging: showing the sheet in
-    // the same tick the confirm modal pops is what keeps the handoff smooth.
-    // Non-sheet flows keep awaiting so their pending badge is ready on return.
-    if (shouldShowConfirmSheet) {
-      void addEarnOrderPromise.catch(() => undefined);
-    } else {
-      await addEarnOrderPromise;
-    }
-  }
-
-  if (shouldShowConfirmSheet && accountId) {
-    const finalStatus = await showDeFiActionTxConfirmDialog({
-      accountId,
-      networkId,
-      data,
-    });
-    if (finalStatus === EOnChainHistoryTxStatus.Failed) {
-      return;
-    }
-  }
-  onSuccess?.(data);
-};
-
 // Buffer after RPC finalization to allow all RPC nodes to sync the LUT state
 const LUT_PROPAGATION_BUFFER_MS = 5000;
-
-type IBorrowBuildTxParams = {
-  amount: string;
-  provider: string;
-  marketAddress: string;
-  reserveAddress: string;
-  collateralReserveAddress?: string;
-  withdrawAll?: boolean;
-  repayAll?: boolean;
-  needsSetupLut?: boolean;
-  slippageBps?: number;
-  routeKey?: string;
-  stakingInfo?: IStakingInfo;
-  onSetupLutReadyForRepay?: () => void;
-  // Awaited right before navigationToTxConfirm so dialog callers can close
-  // themselves at navigation time instead of before the build request.
-  onBeforeNavigate?: () => void | Promise<void>;
-  onSuccess?: IModalSendParamList['SendConfirm']['onSuccess'];
-  onFail?: IModalSendParamList['SendConfirm']['onFail'];
-};
 
 export function useUniversalBorrowSupply({
   networkId,
@@ -281,68 +191,6 @@ export function useUniversalBorrowSupply({
   );
 }
 
-export function useUniversalBorrowWithdraw({
-  networkId,
-  accountId,
-}: {
-  networkId: string;
-  accountId: string;
-}) {
-  const { navigationToTxConfirm } = useSignatureConfirm({
-    accountId,
-    networkId,
-  });
-
-  return useCallback(
-    async ({
-      amount,
-      provider,
-      marketAddress,
-      reserveAddress,
-      withdrawAll,
-      stakingInfo,
-      onBeforeNavigate,
-      onSuccess,
-      onFail,
-    }: IBorrowBuildTxParams) => {
-      const resp =
-        await backgroundApiProxy.serviceStaking.borrowBuildWithdrawTransaction({
-          networkId,
-          accountId,
-          provider,
-          marketAddress,
-          reserveAddress,
-          amount,
-          withdrawAll,
-        });
-
-      const stakingInfoWithOrderId = attachBorrowOrderId({
-        stakingInfo,
-        orderId: resp.orderId,
-      });
-
-      await onBeforeNavigate?.();
-
-      await navigationToTxConfirm({
-        encodedTx: parseBorrowEncodedTx(resp.tx),
-        stakingInfo: stakingInfoWithOrderId,
-        onSuccess: async (data) => {
-          await handleBorrowSuccess({
-            data,
-            orderId: resp.orderId,
-            networkId,
-            accountId,
-            stakingInfo: stakingInfoWithOrderId,
-            onSuccess,
-          });
-        },
-        onFail,
-      });
-    },
-    [accountId, networkId, navigationToTxConfirm],
-  );
-}
-
 export function useUniversalBorrowBorrow({
   networkId,
   accountId,
@@ -379,68 +227,6 @@ export function useUniversalBorrowBorrow({
         stakingInfo,
         orderId: resp.orderId,
       });
-
-      await navigationToTxConfirm({
-        encodedTx: parseBorrowEncodedTx(resp.tx),
-        stakingInfo: stakingInfoWithOrderId,
-        onSuccess: async (data) => {
-          await handleBorrowSuccess({
-            data,
-            orderId: resp.orderId,
-            networkId,
-            accountId,
-            stakingInfo: stakingInfoWithOrderId,
-            onSuccess,
-          });
-        },
-        onFail,
-      });
-    },
-    [accountId, networkId, navigationToTxConfirm],
-  );
-}
-
-export function useUniversalBorrowRepay({
-  networkId,
-  accountId,
-}: {
-  networkId: string;
-  accountId: string;
-}) {
-  const { navigationToTxConfirm } = useSignatureConfirm({
-    accountId,
-    networkId,
-  });
-
-  return useCallback(
-    async ({
-      amount,
-      provider,
-      marketAddress,
-      reserveAddress,
-      repayAll,
-      stakingInfo,
-      onBeforeNavigate,
-      onSuccess,
-      onFail,
-    }: IBorrowBuildTxParams) => {
-      const resp =
-        await backgroundApiProxy.serviceStaking.borrowBuildRepayTransaction({
-          networkId,
-          accountId,
-          provider,
-          marketAddress,
-          reserveAddress,
-          amount,
-          repayAll,
-        });
-
-      const stakingInfoWithOrderId = attachBorrowOrderId({
-        stakingInfo,
-        orderId: resp.orderId,
-      });
-
-      await onBeforeNavigate?.();
 
       await navigationToTxConfirm({
         encodedTx: parseBorrowEncodedTx(resp.tx),

--- a/packages/kit/src/views/Borrow/hooks/useUniversalBorrowWithdrawRepayHooks.ts
+++ b/packages/kit/src/views/Borrow/hooks/useUniversalBorrowWithdrawRepayHooks.ts
@@ -1,0 +1,242 @@
+import { useCallback } from 'react';
+
+import type { IEncodedTx } from '@onekeyhq/core/src/types';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { showDeFiActionTxConfirmDialog } from '@onekeyhq/kit/src/components/DeFi/DeFiActionTxConfirmResult';
+import { useSignatureConfirm } from '@onekeyhq/kit/src/hooks/useSignatureConfirm';
+import type { IModalSendParamList } from '@onekeyhq/shared/src/routes';
+import { EOnChainHistoryTxStatus } from '@onekeyhq/shared/types/history';
+import { EEarnLabels, type IStakingInfo } from '@onekeyhq/shared/types/staking';
+import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
+
+export type IBorrowBuildTxParams = {
+  amount: string;
+  provider: string;
+  marketAddress: string;
+  reserveAddress: string;
+  collateralReserveAddress?: string;
+  withdrawAll?: boolean;
+  repayAll?: boolean;
+  needsSetupLut?: boolean;
+  slippageBps?: number;
+  routeKey?: string;
+  stakingInfo?: IStakingInfo;
+  onSetupLutReadyForRepay?: () => void;
+  onBeforeNavigate?: () => void | Promise<void>;
+  onSuccess?: IModalSendParamList['SendConfirm']['onSuccess'];
+  onFail?: IModalSendParamList['SendConfirm']['onFail'];
+};
+
+export function parseBorrowEncodedTx(tx: string): IEncodedTx {
+  try {
+    const parsed = JSON.parse(tx) as unknown;
+    if (parsed && typeof parsed === 'object') {
+      return parsed as IEncodedTx;
+    }
+  } catch {
+    // Ignore parsing errors and fallback to raw string.
+  }
+  return tx;
+}
+
+export const attachBorrowOrderId = ({
+  stakingInfo,
+  orderId,
+}: {
+  stakingInfo?: IStakingInfo;
+  orderId?: string;
+}): IStakingInfo | undefined =>
+  stakingInfo ? { ...stakingInfo, orderId } : undefined;
+
+const getLatestTxId = (data: ISendTxOnSuccessData[]) => {
+  for (let index = data.length - 1; index >= 0; index -= 1) {
+    const item = data[index];
+    const txId = item?.signedTx?.txid || item?.decodedTx?.txid;
+    if (txId) {
+      return txId;
+    }
+  }
+
+  return undefined;
+};
+
+const getEarnOrderTrackingInfo = (stakingInfo?: IStakingInfo) => ({
+  stakingLabel: stakingInfo?.label,
+  stakingProtocol: stakingInfo?.protocol,
+  stakingTags: stakingInfo?.tags,
+});
+
+export const handleBorrowSuccess = async ({
+  data,
+  orderId,
+  networkId,
+  accountId,
+  stakingInfo,
+  onSuccess,
+}: {
+  data: ISendTxOnSuccessData[];
+  orderId?: string;
+  networkId: string;
+  accountId?: string;
+  stakingInfo?: IStakingInfo;
+  onSuccess?: IModalSendParamList['SendConfirm']['onSuccess'];
+}) => {
+  const latestTxId =
+    Array.isArray(data) && data.length > 0 ? getLatestTxId(data) : undefined;
+
+  const label = stakingInfo?.label;
+  const shouldShowConfirmSheet =
+    !!accountId &&
+    (label === EEarnLabels.Withdraw || label === EEarnLabels.Repay);
+
+  if (orderId && latestTxId) {
+    const addEarnOrderPromise = backgroundApiProxy.serviceStaking.addEarnOrder({
+      orderId,
+      networkId,
+      txId: latestTxId,
+      status: data[data.length - 1]?.decodedTx.status,
+      ...getEarnOrderTrackingInfo(stakingInfo),
+    });
+    if (shouldShowConfirmSheet) {
+      void addEarnOrderPromise.catch(() => undefined);
+    } else {
+      await addEarnOrderPromise;
+    }
+  }
+
+  if (shouldShowConfirmSheet && accountId) {
+    const finalStatus = await showDeFiActionTxConfirmDialog({
+      accountId,
+      networkId,
+      data,
+    });
+    if (finalStatus === EOnChainHistoryTxStatus.Failed) {
+      return;
+    }
+  }
+  onSuccess?.(data);
+};
+
+export function useUniversalBorrowWithdraw({
+  networkId,
+  accountId,
+}: {
+  networkId: string;
+  accountId: string;
+}) {
+  const { navigationToTxConfirm } = useSignatureConfirm({
+    accountId,
+    networkId,
+  });
+
+  return useCallback(
+    async ({
+      amount,
+      provider,
+      marketAddress,
+      reserveAddress,
+      withdrawAll,
+      stakingInfo,
+      onBeforeNavigate,
+      onSuccess,
+      onFail,
+    }: IBorrowBuildTxParams) => {
+      const resp =
+        await backgroundApiProxy.serviceStaking.borrowBuildWithdrawTransaction({
+          networkId,
+          accountId,
+          provider,
+          marketAddress,
+          reserveAddress,
+          amount,
+          withdrawAll,
+        });
+
+      const stakingInfoWithOrderId = attachBorrowOrderId({
+        stakingInfo,
+        orderId: resp.orderId,
+      });
+
+      await onBeforeNavigate?.();
+
+      await navigationToTxConfirm({
+        encodedTx: parseBorrowEncodedTx(resp.tx),
+        stakingInfo: stakingInfoWithOrderId,
+        onSuccess: async (data) => {
+          await handleBorrowSuccess({
+            data,
+            orderId: resp.orderId,
+            networkId,
+            accountId,
+            stakingInfo: stakingInfoWithOrderId,
+            onSuccess,
+          });
+        },
+        onFail,
+      });
+    },
+    [accountId, networkId, navigationToTxConfirm],
+  );
+}
+
+export function useUniversalBorrowRepay({
+  networkId,
+  accountId,
+}: {
+  networkId: string;
+  accountId: string;
+}) {
+  const { navigationToTxConfirm } = useSignatureConfirm({
+    accountId,
+    networkId,
+  });
+
+  return useCallback(
+    async ({
+      amount,
+      provider,
+      marketAddress,
+      reserveAddress,
+      repayAll,
+      stakingInfo,
+      onBeforeNavigate,
+      onSuccess,
+      onFail,
+    }: IBorrowBuildTxParams) => {
+      const resp =
+        await backgroundApiProxy.serviceStaking.borrowBuildRepayTransaction({
+          networkId,
+          accountId,
+          provider,
+          marketAddress,
+          reserveAddress,
+          amount,
+          repayAll,
+        });
+
+      const stakingInfoWithOrderId = attachBorrowOrderId({
+        stakingInfo,
+        orderId: resp.orderId,
+      });
+
+      await onBeforeNavigate?.();
+
+      await navigationToTxConfirm({
+        encodedTx: parseBorrowEncodedTx(resp.tx),
+        stakingInfo: stakingInfoWithOrderId,
+        onSuccess: async (data) => {
+          await handleBorrowSuccess({
+            data,
+            orderId: resp.orderId,
+            networkId,
+            accountId,
+            stakingInfo: stakingInfoWithOrderId,
+            onSuccess,
+          });
+        },
+        onFail,
+      });
+    },
+    [accountId, networkId, navigationToTxConfirm],
+  );
+}


### PR DESCRIPTION
## Summary
- Split the withdraw/repay borrow action hooks used by the DeFi lending action dialog into a smaller module.
- Keep the existing `useUniversalBorrowHooks` entrypoint compatible by re-exporting the moved hooks.
- Point `ProtocolLendingActionDialogContent` at the smaller withdraw/repay hook module so the dialog chunk no longer pulls the full Borrow hook entrypoint.

## Intent & Context
PR #12280 introduced the DeFi lending action dialog path and added Borrow action behavior to the DeFi portfolio action flow. PR #12353 lazy-loaded the dialog and brought `x` back under the web startup graph budget, but the remaining `allScriptRawBytes` margin was very small. PR #12350 then exposed that lack of headroom with a small unrelated swap default-pair addition.

This PR fixes the DeFi-side bundle pressure instead of optimizing unrelated Swap constants or relaxing the budget.

## Root Cause
`ProtocolLendingActionDialogContent` only needs the Borrow withdraw/repay submit hooks, but it imported them through `useUniversalBorrowHooks.ts`, which also contains supply, borrow, claim, and repay-with-collateral flows. That larger entrypoint is already used by Borrow/Staking chunks, so the DeFi dialog path caused unnecessary duplicated JS in async chunks counted by `allScriptRawBytes`.

## Design Decisions
- Move only the withdraw/repay hooks and the shared submit-success helper they need.
- Preserve the old `useUniversalBorrowHooks.ts` public imports by re-exporting the moved hooks.
- Avoid changing transaction flow, approval behavior, dialog UX, or budget thresholds.

## Changes Detail
- `ProtocolLendingActionDialogContent.tsx`: import withdraw/repay hooks from the smaller module.
- `useUniversalBorrowWithdrawRepayHooks.ts`: new smaller hook module for withdraw/repay transaction submission and success handling.
- `useUniversalBorrowHooks.ts`: remove the moved definitions and re-export them for existing Borrow/Staking callers.

## Risk Assessment
- **Risk Level**: Medium, because the submit hooks are transaction-flow code even though the change is mostly module splitting.
- **Affected Platforms**: Web bundle output directly; shared DeFi/Borrow JS code is used by desktop/mobile/extension as well.
- **Risk Areas**: Import wiring and re-export compatibility. Runtime behavior should remain equivalent because the hook bodies were moved without changing the transaction logic.

## Test plan
- [x] `npx oxlint packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx packages/kit/src/views/Borrow/hooks/useUniversalBorrowHooks.ts packages/kit/src/views/Borrow/hooks/useUniversalBorrowWithdrawRepayHooks.ts`
- [x] `yarn jest packages/kit/src/views/Borrow/hooks/useUniversalBorrowHooks.test.tsx --runInBand`
- [x] `git diff --cached --check`
- [x] `yarn lint:staged`
- [x] Local web production build + startup graph check against a same-machine `origin/x` baseline: `allScriptRawBytes -62,858`
- [ ] `yarn tsc:staged` is currently blocked by unrelated existing errors in `packages/kit-bg/src/vaults/impls/sol/KeyringHardwareTrezor.ts`, `packages/shared/src/errors/errors/thirdPartyHardwareErrors.ts`, and `packages/shared/src/errors/utils/thirdPartyDeviceErrorUtils.ts`.
- [ ] GitHub Web startup graph budget check
