### PR TITLE
fix: adjust market chart fullscreen bottom(OK-57363)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
@@ -46,7 +46,7 @@ const MARKET_CHART_FULLSCREEN_STYLE = {
   left: 0,
   top: 0,
   right: 0,
-  bottom: 0,
+  bottom: platformEnv.isWeb ? 40 : 0,
 } as const;
 const IFRAME_WHEEL_EVENT_TYPE = 'wheelEvent' as const;
 


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57363](https://onekeyhq.atlassian.net/browse/OK-57363)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Adds a 40px bottom inset to the Market Detail TradingView fullscreen overlay on web.
- Keeps non-web fullscreen chart layout unchanged with bottom 0.

## Intent & Context
The Market Detail TradingView fullscreen implementation uses an app-level fixed overlay rather than the browser fullscreen API. The requested fix was to leave 40px at the bottom for the web fullscreen chart path.

## Root Cause
The shared fullscreen overlay style used bottom 0 for every platform, so the web chart extended all the way to the viewport bottom instead of preserving the required 40px inset.

## Design Decisions
Use the existing platformEnv.isWeb branch inside the existing fullscreen style so the fix stays scoped to the web surface. Desktop Electron, native mobile, and other non-web paths keep the previous bottom 0 behavior.

## Changes Detail
- packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx: sets the TradingView fullscreen overlay bottom to 40 on web and 0 elsewhere.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web
- **Risk Areas**: Visual spacing of the Market Detail TradingView fullscreen overlay on wide web layouts.

## Test plan
- [x] yarn lint:staged
- [x] yarn tsc:staged
- [ ] Open Market Detail on web, enter TradingView fullscreen, and verify the chart leaves a 40px bottom inset.
- [ ] Exit fullscreen and verify the normal chart layout is unchanged.

[OK-57363]: https://onekeyhq.atlassian.net/browse/OK-57363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ