### PR TITLE
fix: align perps deposit button style

### DIFF
--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -32,6 +32,7 @@ import {
 import { useNavigateToMarketTab } from '@onekeyhq/kit/src/views/Market/hooks';
 import { useMarketPerpsTokenList } from '@onekeyhq/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/useMarketPerpsTokenList';
 import { useShowDepositWithdrawModal } from '@onekeyhq/kit/src/views/Perp/hooks/useShowDepositWithdrawModal';
+import { getTradingButtonStyleValues } from '@onekeyhq/kit/src/views/Perp/utils/styleUtils';
 import {
   perpsPendingInfoPanelTabAtom,
   spotActiveAssetAtom,
@@ -922,6 +923,7 @@ function PerpsDepositButton({
   const intl = useIntl();
   const { showDepositWithdrawModal } = useShowDepositWithdrawModal();
   const ensureHomePerpsAccount = useEnsureHomePerpsAccount();
+  const buttonStyles = getTradingButtonStyleValues('long', isDepositDisabled);
 
   const handleDeposit = useCallback(async () => {
     if (!canDeposit || isDepositDisabled) {
@@ -948,19 +950,23 @@ function PerpsDepositButton({
       testID={testID}
       size="small"
       variant="primary"
-      bg="$brand8"
+      bg="$bgAccent"
       minHeight={32}
-      color="$textOnColor"
+      color={buttonStyles.textColor}
       cursor={isDepositDisabled ? 'default' : 'pointer'}
       disabled={isDepositDisabled}
-      hoverStyle={{ bg: '$brand9' }}
-      pressStyle={{ bg: '$brand10' }}
+      hoverStyle={{ bg: '$bgAccentHover' }}
+      pressStyle={{ bg: '$bgAccentActive' }}
       onPress={() => void handleDeposit()}
       childrenAsText={false}
     >
       <XStack alignItems="center" gap="$2">
-        <Icon name="AlignBottomOutline" size="$4" color="$iconOnColor" />
-        <SizableText size="$bodyMdMedium" color="$textOnColor">
+        <Icon
+          name="AlignBottomOutline"
+          size="$4"
+          color={buttonStyles.textColor}
+        />
+        <SizableText size="$bodyMdMedium" color={buttonStyles.textColor}>
           {intl.formatMessage({ id: ETranslations.perp_trade_deposit })}
         </SizableText>
       </XStack>

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -1852,37 +1852,45 @@ function DepositWithdrawContent({
         justifyContent="space-between"
         gap="$3"
         minHeight={50}
-        cursor={checkAccountSupport ? 'pointer' : 'default'}
-        onPress={openTokenSelectorPage}
       >
-        <XStack alignItems="center" gap="$2.5" flex={1} minWidth={0}>
-          <Token
-            size="md"
-            tokenImageUri={displayDepositToken?.logoURI}
-            networkImageUri={displayDepositToken?.networkLogoURI}
-            showNetworkIcon
-          />
-          <YStack flex={1} minWidth={0}>
-            <YStack gap="$0.5">
-              <XStack alignItems="center" gap="$1" flexWrap="wrap">
-                <SizableText size="$bodyMdMedium" color="$text">
-                  {displayDepositToken?.symbol ?? '-'}
+        <YStack flex={1} minWidth={0}>
+          <XStack
+            alignItems="center"
+            gap="$2.5"
+            flexShrink={1}
+            minWidth={0}
+            alignSelf="flex-start"
+            cursor={checkAccountSupport ? 'pointer' : 'default'}
+            onPress={openTokenSelectorPage}
+          >
+            <Token
+              size="md"
+              tokenImageUri={displayDepositToken?.logoURI}
+              networkImageUri={displayDepositToken?.networkLogoURI}
+              showNetworkIcon
+            />
+            <YStack flex={1} minWidth={0}>
+              <YStack gap="$0.5">
+                <XStack alignItems="center" gap="$1" flexWrap="wrap">
+                  <SizableText size="$bodyMdMedium" color="$text">
+                    {displayDepositToken?.symbol ?? '-'}
+                  </SizableText>
+                  <SizableText size="$bodyMd" color="$textSubdued">
+                    {currentNetworkInfo?.name ?? ''}
+                  </SizableText>
+                  <Icon
+                    name="ChevronDownSmallOutline"
+                    color="$iconSubdued"
+                    size="$3.5"
+                  />
+                </XStack>
+                <SizableText size="$bodySm" color="$textSubdued">
+                  {hasSourceBalance ? sourceBalanceText : ' '}
                 </SizableText>
-                <SizableText size="$bodyMd" color="$textSubdued">
-                  {currentNetworkInfo?.name ?? ''}
-                </SizableText>
-                <Icon
-                  name="ChevronDownSmallOutline"
-                  color="$iconSubdued"
-                  size="$3.5"
-                />
-              </XStack>
-              <SizableText size="$bodySm" color="$textSubdued">
-                {hasSourceBalance ? sourceBalanceText : ' '}
-              </SizableText>
+              </YStack>
             </YStack>
-          </YStack>
-        </XStack>
+          </XStack>
+        </YStack>
         {checkAccountSupport ? (
           <Button
             testID="perp-deposit-token-max"


### PR DESCRIPTION
## Summary
- align the Home Perps deposit button background and text/icon color with the Perps trading buy button theme tokens
- narrow the deposit token selector tap target so blank space near the right side no longer opens token selection
- keep the button sizing unchanged while making the style theme-aware

## Intent & Context
The change came from UI polish feedback on the Home Perps experience. The request was to make the green deposit button match the main green used in the trading panel, including the text color behavior under theme changes, and to fix an overly large tap area in the deposit modal that was triggering token selection when tapping near the right side.

## Root Cause
The Home Perps deposit button used hard-coded brand color tokens instead of the same semantic trading-button tokens used by the Perps buy button. In the deposit modal, the token selector handler was bound to the full row container, so taps on trailing blank space could still trigger token selection.

## Design Decisions
- Reused the existing `getTradingButtonStyleValues('long')` helper instead of introducing another button color mapping.
- Kept the existing button size, min height, icon size, and text size unchanged to avoid unintended layout regressions.
- Moved the token-selector press handler to the left token info block only, which is the smallest fix that removes the false-positive hit area without changing the rest of the layout.

## Changes Detail
- `packages/kit/src/views/Home/pages/PerpsContainer.tsx`: switched the deposit button to Perps long-side semantic background tokens and reused the trading button text color token for both icon and label.
- `packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx`: limited the token selector press target to the token info content instead of the full row.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile, Web, Desktop
- **Risk Areas**: Perps Home deposit CTA styling and deposit modal token selector interaction

## Test plan
- [x] Run `yarn agent:check --profile commit` and confirm lint passes for the touched files
- [x] Verify the Home Perps deposit button now uses the same green/theme text treatment as the Perps buy button
- [x] Verify tapping blank space near the right side of the deposit token row no longer opens token selection, while tapping the token info area still does
- [ ] Repo note: `tsc-staged` is currently blocked by existing unrelated Trezor/SNI type errors in the workspace
