### PR TITLE
fix: route TON mnemonic import through background

### DIFF
--- a/packages/core/src/chains/ada/sdkAda/sdk/index.native.ts
+++ b/packages/core/src/chains/ada/sdkAda/sdk/index.native.ts
@@ -1,9 +1,9 @@
-import appGlobals from '@onekeyhq/shared/src/appGlobals';
+import { ensureWebembedApiProxyAvailable } from '@onekeyhq/shared/src/utils/assertUtils';
 
 import type { IAdaSdk, IEnsureSDKReady } from './types';
 
 const getCardanoApi = async () =>
-  Promise.resolve(appGlobals.$webembedApiProxy.chainAdaLegacy);
+  Promise.resolve(ensureWebembedApiProxyAvailable().chainAdaLegacy);
 
 const ensureSDKReady: IEnsureSDKReady = async () => Promise.resolve(true);
 

--- a/packages/core/src/chains/kaspa/sdkKaspa/sdk/index.native.ts
+++ b/packages/core/src/chains/kaspa/sdkKaspa/sdk/index.native.ts
@@ -1,30 +1,32 @@
-import appGlobals from '@onekeyhq/shared/src/appGlobals';
+import { ensureWebembedApiProxyAvailable } from '@onekeyhq/shared/src/utils/assertUtils';
 
 import type { IEnsureSDKReady, IGetKaspaApi, IKaspaSdk } from '../types';
 
 const ensureSDKReady: IEnsureSDKReady = async () => Promise.resolve(true);
 
 const buildCommitTxInfo = async (...args: any[]) =>
-  appGlobals.$webembedApiProxy.chainKaspa.buildCommitTxInfo(...args);
+  ensureWebembedApiProxyAvailable().chainKaspa.buildCommitTxInfo(...args);
 
 const createKRC20RevealTxJSON = async (...args: any[]) =>
-  appGlobals.$webembedApiProxy.chainKaspa.createKRC20RevealTxJSON(...args);
+  ensureWebembedApiProxyAvailable().chainKaspa.createKRC20RevealTxJSON(...args);
 
 const signRevealTransactionSoftware = async (...args: any[]) =>
-  appGlobals.$webembedApiProxy.chainKaspa.signRevealTransactionSoftware(
+  ensureWebembedApiProxyAvailable().chainKaspa.signRevealTransactionSoftware(
     ...args,
   );
 
 const signRevealTransactionHardware = async (...args: any[]) =>
-  appGlobals.$webembedApiProxy.chainKaspa.signRevealTransactionHardware(
+  ensureWebembedApiProxyAvailable().chainKaspa.signRevealTransactionHardware(
     ...args,
   );
 
 const buildUnsignedTxForHardware = async (...args: any[]) =>
-  appGlobals.$webembedApiProxy.chainKaspa.buildUnsignedTxForHardware(...args);
+  ensureWebembedApiProxyAvailable().chainKaspa.buildUnsignedTxForHardware(
+    ...args,
+  );
 
 const deserializeFromSafeJSON = async (...args: any[]) =>
-  appGlobals.$webembedApiProxy.chainKaspa.deserializeFromSafeJSON(...args);
+  ensureWebembedApiProxyAvailable().chainKaspa.deserializeFromSafeJSON(...args);
 
 const getKaspaApi: IGetKaspaApi = async () =>
   Promise.resolve({

--- a/packages/core/src/secret/index.ts
+++ b/packages/core/src/secret/index.ts
@@ -3,11 +3,11 @@ import type {
   IPbkdf2DispatchBackend,
   IPbkdf2KdfParams,
 } from '@onekeyhq/shared/src/appCrypto/modules/pbkdf2';
-import appGlobals from '@onekeyhq/shared/src/appGlobals';
 import { DEFAULT_VERIFY_STRING } from '@onekeyhq/shared/src/consts/dbConsts';
 import { InvalidMnemonic, OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { ensureWebembedApiProxyAvailable } from '@onekeyhq/shared/src/utils/assertUtils';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
 import { BaseBip32KeyDeriver, ED25519Bip32KeyDeriver } from './bip32';
@@ -742,7 +742,7 @@ async function clearPbkdf2CacheAsync(): Promise<void> {
     !platformEnv.isJest &&
     !globalThis.$onekeyAppWebembedApiWebviewInitFailed
   ) {
-    await appGlobals.$webembedApiProxy.secret.clearPbkdf2Cache();
+    await ensureWebembedApiProxyAvailable().secret.clearPbkdf2Cache();
   }
 }
 
@@ -765,9 +765,11 @@ async function clearHdCredentialDecryptCache({
     !platformEnv.isJest &&
     !globalThis.$onekeyAppWebembedApiWebviewInitFailed
   ) {
-    await appGlobals.$webembedApiProxy.secret.clearHdCredentialDecryptCache({
-      hdCredentialCacheScopeId,
-    });
+    await ensureWebembedApiProxyAvailable().secret.clearHdCredentialDecryptCache(
+      {
+        hdCredentialCacheScopeId,
+      },
+    );
   }
 }
 
@@ -1403,9 +1405,10 @@ async function batchGetPublicKeys(
     !platformEnv.isJest &&
     !globalThis.$onekeyAppWebembedApiWebviewInitFailed
   ) {
-    const keys = await appGlobals.$webembedApiProxy.secret.batchGetPublicKeys(
-      getBatchGetPublicKeysSerializableParams(params),
-    );
+    const keys =
+      await ensureWebembedApiProxyAvailable().secret.batchGetPublicKeys(
+        getBatchGetPublicKeysSerializableParams(params),
+      );
     return keys.map((key) => ({
       path: key.path,
       parentFingerPrint: Buffer.from(key.parentFingerPrint, 'hex'),
@@ -1601,7 +1604,9 @@ async function mnemonicFromEntropyAsync(
     !platformEnv.isJest &&
     !globalThis.$onekeyAppWebembedApiWebviewInitFailed
   ) {
-    return appGlobals.$webembedApiProxy.secret.mnemonicFromEntropyAsync(params);
+    return ensureWebembedApiProxyAvailable().secret.mnemonicFromEntropyAsync(
+      params,
+    );
   }
   return Promise.resolve(
     mnemonicFromEntropy(params.hdCredential, params.password, {
@@ -1629,7 +1634,7 @@ async function seedFromHdCredentialAsync(
     !globalThis.$onekeyAppWebembedApiWebviewInitFailed
   ) {
     const hex =
-      await appGlobals.$webembedApiProxy.secret.seedFromHdCredentialAsync(
+      await ensureWebembedApiProxyAvailable().secret.seedFromHdCredentialAsync(
         params,
       );
     return Buffer.from(hex, 'hex');
@@ -1662,12 +1667,13 @@ async function mnemonicToSeedAsync(
     !globalThis.$onekeyAppWebembedApiWebviewInitFailed
   ) {
     const { kdfBackend, mnemonic, passphrase } = params;
-    const hex = await appGlobals.$webembedApiProxy.secret.mnemonicToSeedAsync({
-      kdfBackend,
-      mnemonic,
-      passphrase,
-      useWebembedApi,
-    });
+    const hex =
+      await ensureWebembedApiProxyAvailable().secret.mnemonicToSeedAsync({
+        kdfBackend,
+        mnemonic,
+        passphrase,
+        useWebembedApi,
+      });
     return Buffer.from(hex, 'hex');
   }
   const validateStart = perfTrace ? perfTraceNowMs() : 0;
@@ -1713,7 +1719,7 @@ async function generateRootFingerprintHexAsync(
     !platformEnv.isJest &&
     !globalThis.$onekeyAppWebembedApiWebviewInitFailed
   ) {
-    return appGlobals.$webembedApiProxy.secret.generateRootFingerprintHexAsync(
+    return ensureWebembedApiProxyAvailable().secret.generateRootFingerprintHexAsync(
       params,
     );
   }

--- a/packages/core/src/secret/ton-mnemonic.ts
+++ b/packages/core/src/secret/ton-mnemonic.ts
@@ -3,9 +3,9 @@ import {
   validateMnemonic as tonValidateMnemonicFn,
 } from 'tonweb-mnemonic';
 
-import appGlobals from '@onekeyhq/shared/src/appGlobals';
 import { InvalidMnemonic } from '@onekeyhq/shared/src/errors';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { ensureWebembedApiProxyAvailable } from '@onekeyhq/shared/src/utils/assertUtils';
 import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
 import type { IBip39RevealableSeed } from './bip39';
@@ -40,7 +40,7 @@ async function tonValidateMnemonic(mnemonicArray: string[]): Promise<boolean> {
     !platformEnv.isJest &&
     !globalThis.$onekeyAppWebembedApiWebviewInitFailed
   ) {
-    return appGlobals.$webembedApiProxy.secret.tonValidateMnemonic(
+    return ensureWebembedApiProxyAvailable().secret.tonValidateMnemonic(
       mnemonicArray,
     );
   }
@@ -55,7 +55,7 @@ async function tonMnemonicToKeyPair(
     !platformEnv.isJest &&
     !globalThis.$onekeyAppWebembedApiWebviewInitFailed
   ) {
-    return appGlobals.$webembedApiProxy.secret.tonMnemonicToKeyPair(
+    return ensureWebembedApiProxyAvailable().secret.tonMnemonicToKeyPair(
       mnemonicArray,
     );
   }

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -24,6 +24,7 @@ import {
   revealableSeedFromMnemonic,
   revealableSeedFromTonMnemonic,
   tonMnemonicFromEntropy,
+  tonMnemonicToKeyPair,
   tonValidateMnemonic,
   validateMnemonic,
 } from '@onekeyhq/core/src/secret';
@@ -248,6 +249,23 @@ export type IAddHDOrHWAccountsResult = {
   accounts: IBatchCreateAccount[];
   deriveType: IAccountDeriveTypes;
 };
+
+function normalizeTonSecretKey(secretKey: unknown): Uint8Array {
+  if (secretKey instanceof Uint8Array) {
+    return new Uint8Array(secretKey);
+  }
+  if (Array.isArray(secretKey)) {
+    return new Uint8Array(secretKey);
+  }
+  if (secretKey && typeof secretKey === 'object') {
+    return new Uint8Array(
+      Object.values(secretKey as Record<string, number>).map((value) =>
+        Number(value),
+      ),
+    );
+  }
+  throw new InvalidMnemonic();
+}
 
 @backgroundClass()
 class ServiceAccount extends ServiceBase {
@@ -3898,6 +3916,83 @@ class ServiceAccount extends ServiceBase {
       skipAddHDNextIndexedAccount,
       applyRestoreSyncPolicy,
     });
+  }
+
+  @backgroundMethod()
+  async addTonImportedAccountByMnemonic({
+    mnemonic,
+    name,
+    shouldCheckDuplicateName,
+  }: {
+    mnemonic: string;
+    name?: string;
+    shouldCheckDuplicateName?: boolean;
+  }): Promise<{
+    networkId: string;
+    walletId: string;
+    accounts: IDBAccount[];
+    isOverrideAccounts: boolean;
+  }> {
+    ensureSensitiveTextEncoded(mnemonic);
+    const { mnemonic: realMnemonic, mnemonicType } =
+      await this.validateMnemonic(mnemonic);
+
+    if (mnemonicType !== EMnemonicType.TON) {
+      throw new OneKeyLocalError(
+        'addTonImportedAccountByMnemonic ERROR: Not a TON mnemonic',
+      );
+    }
+
+    const { servicePassword } = this.backgroundApi;
+    const { password } = await servicePassword.promptPasswordVerify({
+      reason: EReasonForNeedPassword.CreateOrRemoveWallet,
+    });
+    ensureSensitiveTextEncoded(password);
+
+    const keyPair = await tonMnemonicToKeyPair(realMnemonic.split(' '));
+    const secretKeyBytes = normalizeTonSecretKey(keyPair?.secretKey);
+    if (secretKeyBytes.length < 32) {
+      throw new InvalidMnemonic();
+    }
+    let privateHex = '';
+
+    try {
+      privateHex = bufferUtils.bytesToHex(secretKeyBytes.slice(0, 32));
+      const result = await this.addImportedAccountWithCredentialBase({
+        credentialRaw: privateHex,
+        password,
+        deriveType: 'default',
+        networkId: getNetworkIdsMap().ton,
+        name,
+        shouldCheckDuplicateName,
+      });
+      privateHex = '';
+
+      const accountId = result.accounts?.[0]?.id;
+      if (!accountId) {
+        throw new OneKeyLocalError(
+          'addTonImportedAccountByMnemonic ERROR: Account is required',
+        );
+      }
+
+      let rs: IBip39RevealableSeedEncryptHex | undefined;
+      try {
+        rs = await revealableSeedFromTonMnemonic(realMnemonic, password);
+      } catch {
+        throw new InvalidMnemonic();
+      }
+
+      const tonMnemonicFromRs = await tonMnemonicFromEntropy(rs, password);
+      if (realMnemonic !== tonMnemonicFromRs) {
+        throw new InvalidMnemonic();
+      }
+      await localDb.saveTonImportedAccountMnemonic({ accountId, rs });
+
+      return result;
+    } finally {
+      secretKeyBytes.fill(0);
+      privateHex = '';
+    }
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/webembeds/instance/webembedApiProxy.ts
+++ b/packages/kit-bg/src/webembeds/instance/webembedApiProxy.ts
@@ -31,6 +31,15 @@ class WebembedApiProxy extends RemoteApiProxyBase implements IWebembedApi {
         'WebembedApiProxy should only be used in iOS/Android Native env.',
       );
     }
+    if (
+      !platformEnv.isJest &&
+      platformEnv.enableNativeBackgroundThread &&
+      platformEnv.isNativeMainThread
+    ) {
+      throw new OneKeyLocalError(
+        'WebembedApiProxy must be used from the background JS runtime in native dual-runtime builds. Route this call through backgroundApiProxy instead of calling webembed APIs from the UI/main runtime.',
+      );
+    }
   }
 
   override async waitRemoteApiReady(): Promise<void> {

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
@@ -5,6 +5,10 @@ import type { ReactNode } from 'react';
 import { act, renderHook } from '@testing-library/react';
 import { createStore } from 'jotai';
 
+import type { IDBAccount } from '@onekeyhq/kit-bg/src/dbs/local/types';
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
+import { WALLET_TYPE_IMPORTED } from '@onekeyhq/shared/src/consts/dbConsts';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import {
@@ -69,6 +73,21 @@ const mockFixDeriveTypesForInitAccountSelectorMap: jest.MockedFunction<
 > = jest.fn();
 const mockWriteContextAtomColdStartCacheValues: jest.MockedFunction<IWriteContextAtomColdStartCacheValues> =
   jest.fn();
+const mockAddTonImportedAccountByMnemonic = jest.fn<
+  Promise<{
+    networkId: string;
+    walletId: string;
+    accounts: IDBAccount[];
+    isOverrideAccounts: boolean;
+  }>,
+  [
+    {
+      mnemonic: string;
+      name?: string;
+      shouldCheckDuplicateName?: boolean;
+    },
+  ]
+>();
 
 jest.mock('@onekeyhq/kit-bg/src/states/jotai/utils', () => {
   const actual = jest.requireActual<
@@ -118,7 +137,11 @@ jest.mock(
 jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
   __esModule: true,
   default: {
-    serviceAccount: {},
+    serviceAccount: {
+      addTonImportedAccountByMnemonic: (
+        ...args: Parameters<typeof mockAddTonImportedAccountByMnemonic>
+      ) => mockAddTonImportedAccountByMnemonic(...args),
+    },
     serviceAccountSelector: {
       buildActiveAccountInfoFromSelectedAccount: () =>
         mockBuildActiveAccountInfoFromSelectedAccount(),
@@ -259,6 +282,44 @@ describe('useAccountSelectorActions', () => {
     expect(store.get(accountSelectorActiveAccountInitDoneAtom())?.[0]).toBe(
       true,
     );
+  });
+
+  it('creates TON imported wallets through the background service', async () => {
+    const accountId = 'imported--607--ton';
+    const mnemonic = 'encoded-ton-mnemonic';
+    const waitSpy = jest.spyOn(timerUtils, 'wait').mockResolvedValue(undefined);
+    mockAddTonImportedAccountByMnemonic.mockResolvedValue({
+      networkId: getNetworkIdsMap().ton,
+      walletId: WALLET_TYPE_IMPORTED,
+      accounts: [{ id: accountId } as IDBAccount],
+      isOverrideAccounts: false,
+    });
+
+    const { store, Wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    try {
+      await act(async () => {
+        await result.current.createTonImportedWallet({ mnemonic });
+      });
+    } finally {
+      waitSpy.mockRestore();
+    }
+
+    expect(mockAddTonImportedAccountByMnemonic).toHaveBeenCalledWith({
+      mnemonic,
+      name: '',
+      shouldCheckDuplicateName: true,
+    });
+    expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+      networkId: getNetworkIdsMap().ton,
+      walletId: WALLET_TYPE_IMPORTED,
+      focusedWallet: WALLET_TYPE_IMPORTED,
+      indexedAccountId: undefined,
+      othersWalletAccountId: accountId,
+    });
   });
 
   // OK-57139: the dApp connection record is the single source of truth for

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -73,7 +73,6 @@ import { coldStartCacheStorage } from '@onekeyhq/shared/src/storage/instance/syn
 import { EAppSyncStorageKeys } from '@onekeyhq/shared/src/storage/syncStorageKeys';
 import accountSelectorUtils from '@onekeyhq/shared/src/utils/accountSelectorUtils';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
-import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 import { memoFn } from '@onekeyhq/shared/src/utils/cacheUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
@@ -1865,34 +1864,13 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
 
         await Promise.all([
           (async () => {
-            const { servicePassword } = backgroundApiProxy;
-            const { mnemonic: realMnemonic } =
-              await serviceAccount.validateMnemonic(mnemonic);
-            const { tonMnemonicToKeyPair } =
-              await import('@onekeyhq/core/src/secret/ton-mnemonic');
-            const keyPair = await tonMnemonicToKeyPair(realMnemonic.split(' '));
-            const secretKeyUint8Array = platformEnv.isNative
-              ? new Uint8Array(Object.values(keyPair.secretKey))
-              : keyPair.secretKey;
-            const privateHex = bufferUtils.bytesToHex(
-              secretKeyUint8Array.slice(0, 32),
-            );
-            const input = await servicePassword.encodeSensitiveText({
-              text: privateHex,
-            });
-            const r = await serviceAccount.addImportedAccount({
-              input,
-              deriveType: 'default',
-              networkId: getNetworkIdsMap().ton,
+            const r = await serviceAccount.addTonImportedAccountByMnemonic({
+              mnemonic,
               name: '',
               shouldCheckDuplicateName: true,
             });
             const accountId = r?.accounts?.[0]?.id;
-            await serviceAccount.saveTonImportedAccountMnemonic({
-              accountId,
-              mnemonic,
-            });
-            void this.updateSelectedAccountForSingletonAccount.call(set, {
+            await this.updateSelectedAccountForSingletonAccount.call(set, {
               num: 0,
               networkId: getNetworkIdsMap().ton,
               walletId: WALLET_TYPE_IMPORTED,

--- a/packages/shared/src/utils/assertUtils.test.ts
+++ b/packages/shared/src/utils/assertUtils.test.ts
@@ -1,4 +1,12 @@
-import { check, checkIsDefined, checkIsUndefined } from './assertUtils';
+import appGlobals from '../appGlobals';
+import platformEnv from '../platformEnv';
+
+import {
+  check,
+  checkIsDefined,
+  checkIsUndefined,
+  ensureWebembedApiProxyAvailable,
+} from './assertUtils';
 
 test('Check statement expect correct', () => {
   check(true);
@@ -46,4 +54,36 @@ test('check is undefined', () => {
   expect(() => checkIsUndefined(hold.a)).toThrow(
     'Expect undefined but actually 1',
   );
+});
+
+test('ensure webembed api proxy reports missing registration', () => {
+  const originalWebembedApiProxy = appGlobals.$webembedApiProxy;
+  try {
+    appGlobals.$webembedApiProxy = undefined as never;
+    expect(() => ensureWebembedApiProxyAvailable()).toThrow(
+      'WebembedApiProxy is not registered in this JS runtime',
+    );
+  } finally {
+    appGlobals.$webembedApiProxy = originalWebembedApiProxy;
+  }
+});
+
+test('ensure webembed api proxy rejects native main runtime', () => {
+  const originalIsJest = platformEnv.isJest;
+  const originalEnableNativeBackgroundThread =
+    platformEnv.enableNativeBackgroundThread;
+  const originalIsNativeMainThread = platformEnv.isNativeMainThread;
+  try {
+    platformEnv.isJest = false;
+    platformEnv.enableNativeBackgroundThread = true;
+    platformEnv.isNativeMainThread = true;
+    expect(() => ensureWebembedApiProxyAvailable()).toThrow(
+      'WebembedApiProxy must be used from the background JS runtime',
+    );
+  } finally {
+    platformEnv.isJest = originalIsJest;
+    platformEnv.enableNativeBackgroundThread =
+      originalEnableNativeBackgroundThread;
+    platformEnv.isNativeMainThread = originalIsNativeMainThread;
+  }
 });

--- a/packages/shared/src/utils/assertUtils.ts
+++ b/packages/shared/src/utils/assertUtils.ts
@@ -218,3 +218,24 @@ export function ensureLocalDbNotOnNativeMainThread() {
     );
   }
 }
+
+export function ensureWebembedApiProxyAvailable() {
+  if (
+    !platformEnv.isJest &&
+    platformEnv.enableNativeBackgroundThread &&
+    platformEnv.isNativeMainThread
+  ) {
+    throw new OneKeyLocalError(
+      'WebembedApiProxy must be used from the background JS runtime in native dual-runtime builds. Route this call through backgroundApiProxy instead of calling webembed APIs from the UI/main runtime.',
+    );
+  }
+
+  const webembedApiProxy = appGlobals.$webembedApiProxy;
+  if (!webembedApiProxy) {
+    throw new OneKeyLocalError(
+      'WebembedApiProxy is not registered in this JS runtime. Importing code should route through backgroundApiProxy or initialize webembedApiProxy before use.',
+    );
+  }
+
+  return webembedApiProxy;
+}


### PR DESCRIPTION
## Summary
- Route mobile TON mnemonic import through the background account service instead of deriving the TON key pair directly in the UI/main runtime.
- Add an explicit WebembedApiProxy runtime guard so accidental main-runtime calls fail with a clear background-runtime error.
- Cover the TON import action and WebembedApiProxy guard with focused Jest tests.

## Intent & Context
Mobile TON mnemonic import could crash with `Cannot read property secret of undefined` while desktop import and other mobile import paths worked. The user asked whether this was caused by calling core TON mnemonic derivation from a main-runtime action while native webembed access is registered through the background runtime, then asked for a guard that reports the runtime misuse clearly.

## Root Cause
In native production there are two isolated JS runtimes: `main` for UI and `bg` for background work. They run in the same native process, but each has its own JS heap. Native resources may be shared by the process, but JS globals are not shared between runtimes.

`appGlobals.$webembedApiProxy` is registered by the background webembed proxy setup in the `bg` runtime. The TON mnemonic import action was running in the `main` runtime and imported core TON mnemonic derivation directly. On native, that derivation needs `appGlobals.$webembedApiProxy.secret`, but the main-runtime JS copy of `appGlobals` does not have `$webembedApiProxy`, so the undefined object was `appGlobals.$webembedApiProxy`.

## Design Decisions
- Move TON mnemonic-to-private-key derivation into `ServiceAccount` as a background method, keeping webembed access inside the `bg` runtime.
- Keep the UI/main action as orchestration only, calling `backgroundApiProxy.serviceAccount.addTonImportedAccountByMnemonic`.
- Add `ensureWebembedApiProxyAvailable()` in shared assertions and use it in direct core/native webembed call sites. This makes future misuse fail with an explicit background-runtime message instead of a generic undefined property error.
- Normalize webembed-returned TON secret key shapes before converting the first 32 bytes to the imported-account private key.
- Preserve sensitive-data handling by validating encoded mnemonic/password inputs and clearing derived secret/private key buffers after use.

## Changes Detail
- `packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx`: delegates TON mnemonic import to the background service and awaits selected-account update.
- `packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts`: adds background TON mnemonic import flow, password verification, TON key derivation, imported account creation, and TON mnemonic persistence.
- `packages/shared/src/utils/assertUtils.ts`: adds WebembedApiProxy availability/runtime guard.
- `packages/core/src/secret/*` and native ADA/Kaspa SDK call sites: use the guard before accessing webembed proxy APIs.
- Jest tests: cover the new background-service path from the action and the WebembedApiProxy guard behavior.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile native primarily; native core webembed proxy call sites also get clearer guard errors. Desktop/web behavior should be unchanged.
- **Risk Areas**: TON mnemonic import, background service password flow, webembed proxy call sites, and sensitive key material handling.

## Test plan
- [x] `yarn tsc:staged`
- [x] `yarn lint:staged`
- [x] `yarn jest packages/shared/src/utils/assertUtils.test.ts --runInBand`
- [x] `yarn jest packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx --runInBand`
- [x] `yarn agent:check --profile commit`
- [x] `yarn app:web-embed:build`
- [x] Built and launched iOS simulator with `yarn app:ios`
- [x] Verified real iOS simulator flow: Add existing wallet -> Import phrase/private key -> 24-word TON mnemonic -> Confirm -> set passcode -> Your wallet is ready -> enter wallet home with TON selected
- [x] Filtered recent simulator logs for `Cannot read property`, `secret`, `webembed`, `WebembedApiProxy`, and `TypeError`; no target error appeared