### PR TITLE
fix: route QR wallet scan toast to onboarding v2(OK-57483)

### DIFF
--- a/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
+++ b/packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx
@@ -35,12 +35,12 @@ import {
   EModalRoutes,
   EModalSettingRoutes,
   EModalSignatureConfirmRoutes,
-  EOnboardingPages,
+  EOnboardingPagesV2,
   ERootRoutes,
 } from '@onekeyhq/shared/src/routes';
+import { EOnboardingV2Routes } from '@onekeyhq/shared/src/routes/onboardingv2';
 import { EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
-import { EConnectDeviceChannel } from '@onekeyhq/shared/types/connectDevice';
 import { EQRCodeHandlerType } from '@onekeyhq/shared/types/qrCode';
 import type { IToken } from '@onekeyhq/shared/types/token';
 
@@ -346,13 +346,10 @@ export async function parseQRCodeWithDeps(
                       // target route in a single dispatch. This avoids
                       // the stale navigation reference after
                       // resetAboveMainRoute() (OK-51748).
-                      resetToRoute(ERootRoutes.Modal, {
-                        screen: EModalRoutes.OnboardingModal,
+                      resetToRoute(ERootRoutes.Onboarding, {
+                        screen: EOnboardingV2Routes.OnboardingV2,
                         params: {
-                          screen: EOnboardingPages.ConnectYourDevice,
-                          params: {
-                            channel: EConnectDeviceChannel.qr,
-                          },
+                          screen: EOnboardingPagesV2.ConnectQRCode,
                         },
                       });
                     }}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57483](https://onekeyhq.atlassian.net/browse/OK-57483)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Route the QR wallet animated-code toast connect action to Onboarding V2's QR connection page.
- Remove the legacy V1 onboarding modal/device-channel handoff for this QR wallet entry point.

## Intent & Context
This fixes OK-57483, where iOS universal scanning could enter the legacy QR wallet connection flow after detecting a QR wallet animated-code payload. The user-reported behavior was that after QR wallet scan completion, the connection popup/modal was not closed correctly.

## Root Cause
The `ANIMATION_CODE` toast action in the universal scanner still reset navigation to the V1 onboarding modal (`OnboardingModal -> ConnectYourDevice` with QR channel). QR wallet creation and modal cleanup behavior has moved to the V2 onboarding QR flow, where the scan modal is atomically replaced by the V2 finalize route after scan completion.

## Design Decisions
- Reuse the existing V2 QR connection route (`Onboarding -> OnboardingV2 -> ConnectQRCode`) instead of adding another close/pop path to the V1 modal.
- Keep the existing `resetToRoute` pattern so scanner overlays are replaced atomically and do not leave stale modal navigation state on iOS.
- Leave QR parsing, toast display, and wallet creation logic unchanged.

## Changes Detail
- `packages/kit/src/views/ScanQrCode/hooks/useParseQRCode.tsx`
  - Replaces the QR wallet toast connect target from V1 `OnboardingModal/ConnectYourDevice` to V2 `OnboardingV2/ConnectQRCode`.
  - Updates imports to remove the legacy QR device channel dependency.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile, primarily iOS QR wallet onboarding; shared scan route code also applies where the native universal scanner is used.
- **Risk Areas**: Navigation handoff from universal scanner toast to onboarding. QR parsing and wallet creation data handling are unchanged.

## Test plan
- [x] `yarn agent:check --profile commit`
- [x] iOS simulator: universal scanner detects QR wallet animated-code payload and shows the QR wallet connect toast.
- [x] iOS simulator: tapping connect opens `onboarding-connect-qr-code-page`, confirming the V2 path.
- [x] iOS simulator: V2 QR wallet scan completion replaces the scan modal with `onboarding-finalize-setup-page`.
- [x] iOS simulator: confirmed the app remains foregrounded; a dev LogBox error seen when using a minimal synthetic QR payload was caused by missing air-gap account paths in test data, not by the navigation change.

[OK-57483]: https://onekeyhq.atlassian.net/browse/OK-57483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ