### PR TITLE
fix: close borrow approve dialog before confirm

### DIFF
--- a/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
@@ -1322,6 +1322,11 @@ function ProtocolLendingActionBorrowContent({
       currentAllowance: protocolInfo?.approve?.allowance,
       amountValue: amount,
       onSubmit: submitBorrowTx,
+      onBeforeNavigateConfirm: () => {
+        if (isBorrowDialogClosedRef.current) return;
+        isBorrowDialogClosedRef.current = true;
+        void closeRef.current?.();
+      },
     });
 
   const handleFooterConfirm = async ({
@@ -1333,9 +1338,8 @@ function ProtocolLendingActionBorrowContent({
   }) => {
     closeRef.current = close;
     isBorrowDialogClosedRef.current = false;
-    // We own the close timing: onBeforeNavigate closes right before the
-    // tx-confirm page opens, and the approve hop keeps the dialog open until
-    // it auto-submits.
+    // We own the close timing: approval and business confirms both close this
+    // dialog right before tx-confirm opens, so the old dialog never overlays it.
     preventClose();
     if (submitting) return;
     setSubmitting(true);

--- a/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.test.tsx
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.test.tsx
@@ -1,0 +1,247 @@
+/* eslint-disable import/first */
+
+jest.mock('react-intl', () => {
+  const actualReactIntl =
+    jest.requireActual<typeof import('react-intl')>('react-intl');
+
+  return {
+    __esModule: true,
+    ...actualReactIntl,
+    useIntl: () => ({
+      formatMessage: ({ id }: { id: string }) => id,
+    }),
+  };
+});
+
+jest.mock('@onekeyhq/components', () => ({
+  __esModule: true,
+  Toast: {
+    error: jest.fn(),
+    warning: jest.fn(),
+  },
+}));
+
+jest.mock('react-native', () => {
+  const actualReactNative =
+    jest.requireActual<typeof import('react-native')>('react-native');
+
+  const mockReactNative: typeof actualReactNative = {
+    ...actualReactNative,
+    Keyboard: {
+      ...actualReactNative.Keyboard,
+      dismiss: jest.fn(),
+      emit: jest.fn(),
+      listenerCount: jest.fn(() => 0),
+      removeAllListeners: jest.fn(),
+    } as typeof actualReactNative.Keyboard,
+  };
+
+  return mockReactNative;
+});
+
+jest.mock('@onekeyhq/kit/src/hooks/useRouteIsFocused', () => ({
+  __esModule: true,
+  useRouteIsFocused: () => true,
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/useSignatureConfirm', () => {
+  const mockBag = ((
+    globalThis as typeof globalThis & {
+      __borrowApproveHookMock?: {
+        navigationToTxConfirm?: jest.Mock;
+      };
+    }
+  ).__borrowApproveHookMock ??= {});
+  mockBag.navigationToTxConfirm = jest.fn();
+
+  return {
+    __esModule: true,
+    useSignatureConfirm: () => ({
+      navigationToTxConfirm: mockBag.navigationToTxConfirm,
+    }),
+  };
+});
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => {
+  const mockBag = ((
+    globalThis as typeof globalThis & {
+      __borrowApproveHookMock?: {
+        getAccount?: jest.Mock;
+      };
+    }
+  ).__borrowApproveHookMock ??= {});
+  mockBag.getAccount = jest.fn();
+
+  return {
+    __esModule: true,
+    default: {
+      serviceAccount: {
+        getAccount: mockBag.getAccount,
+      },
+    },
+  };
+});
+
+jest.mock('@onekeyhq/kit/src/views/Staking/hooks/useUtilsHooks', () => {
+  const mockBag = ((
+    globalThis as typeof globalThis & {
+      __borrowApproveHookMock?: {
+        allowance?: string;
+        loadingAllowance?: boolean;
+        fetchAllowanceResponse?: jest.Mock;
+        trackAllowance?: jest.Mock;
+      };
+    }
+  ).__borrowApproveHookMock ??= {});
+  mockBag.fetchAllowanceResponse = jest.fn();
+  mockBag.trackAllowance = jest.fn();
+
+  return {
+    __esModule: true,
+    useTrackTokenAllowance: () => ({
+      allowance: mockBag.allowance ?? '0',
+      loading: mockBag.loadingAllowance ?? false,
+      trackAllowance: mockBag.trackAllowance,
+      fetchAllowanceResponse: mockBag.fetchAllowanceResponse,
+    }),
+  };
+});
+
+jest.mock('@onekeyhq/shared/src/logger/logger', () => ({
+  __esModule: true,
+  defaultLogger: {
+    staking: {
+      page: {
+        permitSignError: jest.fn(),
+      },
+    },
+  },
+}));
+
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useBorrowApproveAndSubmit } from './useBorrowApproveAndSubmit';
+
+import type { IManagePositionApproveTarget } from '../types';
+
+type IBorrowApproveHookMock = {
+  allowance?: string;
+  loadingAllowance?: boolean;
+  fetchAllowanceResponse: jest.Mock;
+  getAccount: jest.Mock;
+  navigationToTxConfirm: jest.Mock;
+  trackAllowance: jest.Mock;
+};
+
+const mockBag = (
+  globalThis as typeof globalThis & {
+    __borrowApproveHookMock: IBorrowApproveHookMock;
+  }
+).__borrowApproveHookMock;
+
+const approveTarget: IManagePositionApproveTarget = {
+  accountId: 'account-1',
+  networkId: 'evm--1',
+  spenderAddress: '0xspender',
+  token: {
+    address: '0xtoken',
+    decimals: 18,
+    isNative: false,
+    name: 'USDe',
+    networkId: 'evm--1',
+    symbol: 'USDe',
+  } as IManagePositionApproveTarget['token'],
+};
+
+describe('useBorrowApproveAndSubmit', () => {
+  beforeEach(() => {
+    mockBag.allowance = '0';
+    mockBag.loadingAllowance = false;
+    mockBag.fetchAllowanceResponse.mockReset();
+    mockBag.getAccount.mockReset();
+    mockBag.navigationToTxConfirm.mockReset();
+    mockBag.trackAllowance.mockReset();
+    mockBag.fetchAllowanceResponse.mockResolvedValue({ allowanceParsed: '0' });
+    mockBag.getAccount.mockResolvedValue({ address: '0xowner' });
+    mockBag.navigationToTxConfirm.mockResolvedValue(undefined);
+  });
+
+  it('runs the before-confirm hook before opening the approve confirm', async () => {
+    const callOrder: string[] = [];
+    const onBeforeNavigateConfirm = jest.fn(() => {
+      callOrder.push('beforeConfirm');
+    });
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+    mockBag.fetchAllowanceResponse.mockImplementation(async () => {
+      callOrder.push('fetchAllowance');
+      return { allowanceParsed: '0' };
+    });
+    mockBag.getAccount.mockImplementation(async () => {
+      callOrder.push('getAccount');
+      return { address: '0xowner' };
+    });
+    mockBag.navigationToTxConfirm.mockImplementation(async () => {
+      callOrder.push('txConfirm');
+    });
+
+    const { result } = renderHook(() =>
+      useBorrowApproveAndSubmit({
+        approveTarget,
+        currentAllowance: '0',
+        amountValue: '10',
+        onSubmit,
+        onBeforeNavigateConfirm,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.onApprove();
+    });
+
+    expect(onBeforeNavigateConfirm).toHaveBeenCalledTimes(1);
+    expect(mockBag.navigationToTxConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        approvesInfo: [
+          expect.objectContaining({
+            amount: '10',
+            owner: '0xowner',
+            spender: '0xspender',
+          }),
+        ],
+      }),
+    );
+    expect(callOrder).toEqual([
+      'fetchAllowance',
+      'getAccount',
+      'beforeConfirm',
+      'txConfirm',
+    ]);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does not run the before-confirm hook when allowance is already enough', async () => {
+    const onBeforeNavigateConfirm = jest.fn();
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    mockBag.allowance = '10';
+    mockBag.fetchAllowanceResponse.mockResolvedValue({ allowanceParsed: '10' });
+
+    const { result } = renderHook(() =>
+      useBorrowApproveAndSubmit({
+        approveTarget,
+        currentAllowance: '10',
+        amountValue: '10',
+        onSubmit,
+        onBeforeNavigateConfirm,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.onApprove();
+    });
+
+    expect(onBeforeNavigateConfirm).not.toHaveBeenCalled();
+    expect(mockBag.navigationToTxConfirm).not.toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.ts
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.ts
@@ -20,11 +20,13 @@ export function useBorrowApproveAndSubmit({
   currentAllowance,
   amountValue,
   onSubmit,
+  onBeforeNavigateConfirm,
 }: {
   approveTarget?: IManagePositionProps['approveTarget'];
   currentAllowance?: string;
   amountValue: string;
   onSubmit: () => Promise<void>;
+  onBeforeNavigateConfirm?: () => void | Promise<void>;
 }): {
   needsApproval: boolean;
   approveLoading: boolean;
@@ -228,6 +230,7 @@ export function useBorrowApproveAndSubmit({
         networkId: approveTarget.networkId,
       });
 
+      await onBeforeNavigateConfirm?.();
       await navigationToTxConfirm({
         approvesInfo: [
           {
@@ -314,6 +317,7 @@ export function useBorrowApproveAndSubmit({
     intl,
     isCurrentApproveRequest,
     navigationToTxConfirm,
+    onBeforeNavigateConfirm,
     onSubmit,
     trackAllowance,
     waitForAllowanceAfterApprove,


### PR DESCRIPTION
## Summary
- Close the Borrow/Lending action dialog before opening the token approval tx confirm.
- Keep normal borrow action submit timing unchanged by reusing the existing dialog-close guard.
- Add hook-level coverage for the approval confirm ordering and the already-approved path.

## Intent & Context
A screenshot showed an Aave repay flow where the approval tx confirm opened while the previous repay dialog stayed visible above it. The issue is not token-specific: it affects Borrow/Lending approval flows hosted inside the DeFi lending action dialog.

## Root Cause
Borrow business transactions already close the action dialog through the existing before-navigate hook before tx confirm opens. The approval path in useBorrowApproveAndSubmit opened navigationToTxConfirm directly and had no equivalent pre-confirm callback, so the old dialog could remain stacked above the approval confirm.

## Design Decisions
- Added an optional onBeforeNavigateConfirm callback to the borrow approval hook instead of changing global tx confirm behavior.
- Passed the existing dialog close guard only from the lending dialog host, so full-page borrow manage flows keep their current behavior.
- Kept approval allowance polling and auto-submit semantics unchanged after the approval succeeds.

## Changes Detail
- packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.ts: invoke an optional pre-confirm hook before opening approve tx confirm.
- packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx: close the lending action dialog before approval or business tx confirm opens.
- packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.test.tsx: verify close-before-confirm ordering and the already-approved fast path.

## Risk Assessment
- Risk Level: Low
- Affected Platforms: Desktop, Web, Mobile
- Risk Areas: Borrow/Lending approval modal sequencing. Real Aave desktop repay runtime still needs manual confirmation because no live funded Aave account was available in this session.

## Test plan
- [x] git diff --check
- [x] npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.ts packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.test.tsx
- [x] yarn jest packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.test.tsx --runInBand
- [ ] yarn agent:check --profile commit (blocked by pre-existing unrelated hardware type errors in KeyringHardwareTrezor.ts and thirdPartyHardwareErrors.ts)
- [ ] Manual desktop runtime: Aave repay/withdraw with approval required

## Issues
- No Jira issue ID was provided or inferable with confidence; draft created from the attached screenshot reproduction.