### PR TITLE
fix: prevent empty iOS header action(OK-57635)

### DIFF
--- a/packages/kit/src/components/TxAction/TxActionUnknown.tsx
+++ b/packages/kit/src/components/TxAction/TxActionUnknown.tsx
@@ -95,6 +95,9 @@ function TxActionUnknownDetailView(props: ITxActionProps) {
   const { decodedTx } = props;
   const { unknownFrom, unknownTo, unknownIcon } = getTxActionUnknownInfo(props);
 
+  // TODO(6.7.0): Stop reading the legacy SendConfirm route after the
+  // SendModal confirmation page is removed. Active confirmation lives in
+  // SignatureConfirmModal -> TxConfirm.
   const route =
     useRoute<RouteProp<IModalSendParamList, EModalSendRoutes.SendConfirm>>();
   const sourceInfo = route.params?.sourceInfo;

--- a/packages/kit/src/views/Send/index.ts
+++ b/packages/kit/src/views/Send/index.ts
@@ -1,4 +1,7 @@
 export * from './pages/SendDataInput/SendDataInputContainer';
+
+// TODO(6.7.0): Remove this legacy SendModal confirmation export.
+// Active confirmation flows use SignatureConfirmModal -> TxConfirm.
 export {
   SendConfirmContainer as SendConfirm,
   SendConfirmContainerWithProvider as SendConfirmWithProvider,

--- a/packages/kit/src/views/Send/pages/SendConfirm/SendConfirmContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendConfirm/SendConfirmContainer.tsx
@@ -38,6 +38,9 @@ import { TxSpecialInfoContainer } from './TxSpecialInfoContainer';
 
 import type { RouteProp } from '@react-navigation/core';
 
+// TODO(6.7.0): Remove this legacy SendModal confirmation page.
+// Current send confirmations go through SignatureConfirmModal -> TxConfirm;
+// debug confirmation issues in the TxConfirm page instead.
 function SendConfirmContainer() {
   const intl = useIntl();
   const route =

--- a/packages/kit/src/views/Send/pages/SendConfirmFromDApp/SendConfirmFromDApp.tsx
+++ b/packages/kit/src/views/Send/pages/SendConfirmFromDApp/SendConfirmFromDApp.tsx
@@ -156,7 +156,7 @@ function SendConfirmFromDApp() {
             _disabledAnimationOfNavigate: true,
             _$t,
           };
-        // replace router to SendConfirm
+        // Replace the DApp entry screen with the shared TxConfirm page.
         action = StackActions.replace(signatureConfirmRoute, params);
       }
 

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -814,6 +814,8 @@ function SendDataInputContainer() {
         import(
           /* webpackPrefetch: true */ '@onekeyhq/kit/src/views/ScanQrCode/pages/ScanQrCodeModal'
         ),
+        // TODO(6.7.0): Remove this legacy SendModal confirmation prefetch.
+        // Active confirmation flows use SignatureConfirmModal -> TxConfirm.
         import(
           /* webpackPrefetch: true */ '@onekeyhq/kit/src/views/Send/pages/SendConfirm/SendConfirmContainer'
         ),

--- a/packages/kit/src/views/Send/router/index.ts
+++ b/packages/kit/src/views/Send/router/index.ts
@@ -4,6 +4,8 @@ import { EModalSendRoutes } from '@onekeyhq/shared/src/routes';
 
 import { LazyLoadPage } from '../../../components/LazyLoadPage';
 
+// TODO(6.7.0): Remove this legacy SendModal confirmation page registration.
+// Active confirmation flows use SignatureConfirmModal -> TxConfirm.
 const SendConfirmWithProvider = LazyLoadPage(() =>
   import('@onekeyhq/kit/src/views/Send').then((m) => ({
     default: m.SendConfirmWithProvider,
@@ -63,6 +65,8 @@ export const ModalSendStack: IModalFlowNavigatorConfig<
     modalContentMaxWidth: 544,
   },
   {
+    // TODO(6.7.0): Remove this unused legacy route. Debug confirmation issues
+    // in SignatureConfirmModal -> TxConfirm instead of this SendModal page.
     name: EModalSendRoutes.SendConfirm,
     component: SendConfirmWithProvider,
   },

--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmHeader/TxConfirmHeaderRight.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmHeader/TxConfirmHeaderRight.tsx
@@ -35,88 +35,103 @@ function isPrivateSendSwapInfo(swapInfo: IUnsignedTxPro['swapInfo']) {
   );
 }
 
-function TxConfirmHeaderRight(props: {
+export type ITxConfirmHeaderRightProps = {
   decodedTxs: IDecodedTx[] | undefined;
   unsignedTxs: IUnsignedTxPro[] | undefined;
   effectiveFeePayer?: IGasPayer;
   txFeeInfoInit?: boolean;
-}) {
+};
+
+export function getTxConfirmMevProtectionProvider({
+  decodedTxs,
+  unsignedTxs,
+  effectiveFeePayer,
+  txFeeInfoInit,
+}: ITxConfirmHeaderRightProps) {
+  const decodedTx = decodedTxs?.[0];
+
+  if (!unsignedTxs) return null;
+
+  // Wait until fee info is initialized before deciding on the badge.
+  // `effectiveFeePayer` defaults to `'user'` and is only updated once the
+  // async fee estimation completes, so rendering the badge earlier would
+  // briefly show MEV for sponsored txs (and could leak the previous tx's
+  // payer in queue mode). Hiding it until init avoids that flicker.
+  if (!txFeeInfoInit) {
+    return null;
+  }
+
+  // Hide the MEV badge whenever the fee is sponsored (gas account or BNB
+  // gas-free / megafuel). Sponsored transactions are relayed through a
+  // sponsor-bound RPC rather than the MEV-protected RPC, so the badge would
+  // be misleading. Only user-paid transactions go through the MEV-protected
+  // RPC and keep the badge.
+  if (effectiveFeePayer === 'gasAccount' || effectiveFeePayer === 'megafuel') {
+    return null;
+  }
+
+  const unsignedTx = unsignedTxs[0];
+  if (!unsignedTx) {
+    return null;
+  }
+
+  const swapTx = find(unsignedTxs, 'swapInfo');
+
+  if (
+    decodedTx?.payload?.privateSend ||
+    isPrivateSendSwapInfo(swapTx?.swapInfo)
+  ) {
+    return null;
+  }
+
+  if (unsignedTx.disableMev) {
+    return null;
+  }
+
+  if (decodedTx?.txDisplay?.mevProtectionProvider) {
+    return decodedTx.txDisplay.mevProtectionProvider;
+  }
+
+  if (swapTx && swapTx.swapInfo) {
+    let isBridge = false;
+
+    try {
+      isBridge =
+        swapTx.swapInfo.sender.accountInfo.networkId !==
+        swapTx.swapInfo.receiver.accountInfo.networkId;
+    } catch (_e) {
+      isBridge = false;
+    }
+
+    if (
+      !isBridge &&
+      mevProtectionProviders[swapTx.swapInfo.receiver.accountInfo.networkId]
+    ) {
+      return mevProtectionProviders[
+        swapTx.swapInfo.receiver.accountInfo.networkId
+      ];
+    }
+  }
+
+  return null;
+}
+
+function TxConfirmHeaderRight(props: ITxConfirmHeaderRightProps) {
   const { decodedTxs, unsignedTxs, effectiveFeePayer, txFeeInfoInit } = props;
   const intl = useIntl();
   const { gtMd } = useMedia();
   const theme = useThemeName();
 
-  const decodedTx = decodedTxs?.[0];
-
-  const mevProtectionProvider = useMemo(() => {
-    if (!unsignedTxs) return null;
-
-    // Wait until fee info is initialized before deciding on the badge.
-    // `effectiveFeePayer` defaults to `'user'` and is only updated once the
-    // async fee estimation completes, so rendering the badge earlier would
-    // briefly show MEV for sponsored txs (and could leak the previous tx's
-    // payer in queue mode). Hiding it until init avoids that flicker.
-    if (!txFeeInfoInit) {
-      return null;
-    }
-
-    // Hide the MEV badge whenever the fee is sponsored (gas account or BNB
-    // gas-free / megafuel). Sponsored transactions are relayed through a
-    // sponsor-bound RPC rather than the MEV-protected RPC, so the badge would
-    // be misleading. Only user-paid transactions go through the MEV-protected
-    // RPC and keep the badge.
-    if (
-      effectiveFeePayer === 'gasAccount' ||
-      effectiveFeePayer === 'megafuel'
-    ) {
-      return null;
-    }
-
-    const unsignedTx = unsignedTxs[0];
-    const swapTx = find(unsignedTxs, 'swapInfo');
-
-    if (
-      decodedTx?.payload?.privateSend ||
-      isPrivateSendSwapInfo(swapTx?.swapInfo)
-    ) {
-      return null;
-    }
-
-    if (unsignedTx.disableMev) {
-      return null;
-    }
-
-    if (decodedTx?.txDisplay?.mevProtectionProvider) {
-      return decodedTx.txDisplay.mevProtectionProvider;
-    }
-
-    if (swapTx && swapTx.swapInfo) {
-      let isBridge = false;
-
-      try {
-        isBridge =
-          swapTx.swapInfo.sender.accountInfo.networkId !==
-          swapTx.swapInfo.receiver.accountInfo.networkId;
-      } catch (_e) {
-        isBridge = false;
-      }
-
-      if (
-        !isBridge &&
-        mevProtectionProviders[swapTx.swapInfo.receiver.accountInfo.networkId]
-      ) {
-        return mevProtectionProviders[
-          swapTx.swapInfo.receiver.accountInfo.networkId
-        ];
-      }
-    }
-  }, [
-    unsignedTxs,
-    decodedTx?.payload?.privateSend,
-    decodedTx?.txDisplay?.mevProtectionProvider,
-    effectiveFeePayer,
-    txFeeInfoInit,
-  ]);
+  const mevProtectionProvider = useMemo(
+    () =>
+      getTxConfirmMevProtectionProvider({
+        decodedTxs,
+        unsignedTxs,
+        effectiveFeePayer,
+        txFeeInfoInit,
+      }),
+    [decodedTxs, unsignedTxs, effectiveFeePayer, txFeeInfoInit],
+  );
 
   const imageUri = useMemo(() => {
     if (!mevProtectionProvider) {

--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmHeader/index.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmHeader/index.tsx
@@ -1,1 +1,4 @@
-export { default as TxConfirmHeaderRight } from './TxConfirmHeaderRight';
+export {
+  default as TxConfirmHeaderRight,
+  getTxConfirmMevProtectionProvider,
+} from './TxConfirmHeaderRight';

--- a/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
+++ b/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
@@ -45,7 +45,10 @@ import { TxAdvancedSettings } from '../../components/SignatureConfirmAdvanced';
 import { TxConfirmAlert } from '../../components/SignatureConfirmAlert';
 import { TxConfirmDetails } from '../../components/SignatureConfirmDetails';
 import { TxConfirmExtraInfo } from '../../components/SignatureConfirmExtraInfo';
-import { TxConfirmHeaderRight } from '../../components/SignatureConfirmHeader';
+import {
+  TxConfirmHeaderRight,
+  getTxConfirmMevProtectionProvider,
+} from '../../components/SignatureConfirmHeader';
 import { SignatureConfirmLoading } from '../../components/SignatureConfirmLoading';
 import { SignatureConfirmProviderMirror } from '../../components/SignatureConfirmProvider/SignatureConfirmProviderMirror';
 import StakingInfo from '../../components/StakingInfo';
@@ -456,17 +459,39 @@ function TxConfirm() {
     return <TaskQueueController taskQueue={unsignedTxQueue} />;
   }, [isQueueMode, unsignedTxQueue]);
 
-  const renderHeaderRight = useCallback(
-    () => (
+  const shouldRenderHeaderRight = useMemo(
+    () =>
+      Boolean(
+        getTxConfirmMevProtectionProvider({
+          decodedTxs,
+          unsignedTxs,
+          effectiveFeePayer,
+          txFeeInfoInit,
+        }),
+      ),
+    [decodedTxs, unsignedTxs, effectiveFeePayer, txFeeInfoInit],
+  );
+
+  const renderHeaderRight = useCallback(() => {
+    if (!shouldRenderHeaderRight) {
+      return null;
+    }
+
+    return (
       <TxConfirmHeaderRight
         decodedTxs={decodedTxs}
         unsignedTxs={unsignedTxs}
         effectiveFeePayer={effectiveFeePayer}
         txFeeInfoInit={txFeeInfoInit}
       />
-    ),
-    [decodedTxs, unsignedTxs, effectiveFeePayer, txFeeInfoInit],
-  );
+    );
+  }, [
+    decodedTxs,
+    unsignedTxs,
+    effectiveFeePayer,
+    txFeeInfoInit,
+    shouldRenderHeaderRight,
+  ]);
 
   return (
     <Page
@@ -475,7 +500,11 @@ function TxConfirm() {
       safeAreaEnabled
       testID={SignatureConfirmTestIDs.TxConfirmPage}
     >
-      <Page.Header title={txConfirmTitle} headerRight={renderHeaderRight} />
+      <Page.Header
+        title={txConfirmTitle}
+        headerRight={shouldRenderHeaderRight ? renderHeaderRight : undefined}
+        unstable_headerRightItems={undefined}
+      />
       <Page.Body testID={SignatureConfirmTestIDs.TxConfirmBody} px="$5">
         {renderTxQueueController()}
         {renderTxConfirmContent()}

--- a/packages/kit/src/views/SignatureConfirm/router/index.tsx
+++ b/packages/kit/src/views/SignatureConfirm/router/index.tsx
@@ -4,6 +4,10 @@ import { EModalSignatureConfirmRoutes } from '@onekeyhq/shared/src/routes';
 
 import { LazyLoadPage } from '../../../components/LazyLoadPage';
 
+// The current send flow is hosted by SignatureConfirmModal. TxConfirm is the
+// shared send/transaction confirmation screen used by wallet, DApp, and swap
+// entries. Legacy SendModal confirmation routes are expected to be removed in
+// 6.7.0; debug confirmation issues in TxConfirm instead.
 const TxConfirmFromDApp = LazyLoadPage(
   () =>
     import('@onekeyhq/kit/src/views/Send/pages/SendConfirmFromDApp/SendConfirmFromDApp'),

--- a/packages/shared/src/routes/send.ts
+++ b/packages/shared/src/routes/send.ts
@@ -19,6 +19,8 @@ export enum EModalSendRoutes {
   SendAmountInput = 'SendAmountInput',
   SendConfirmFromDApp = 'SendConfirmFromDApp',
   SendConfirmFromSwap = 'SendConfirmFromSwap',
+  // TODO(6.7.0): Remove this legacy SendModal confirmation route.
+  // Active confirmation flows use SignatureConfirmModal -> TxConfirm.
   SendConfirm = 'SendConfirm',
   SendFeedback = 'SendFeedback',
   SendReplaceTx = 'SendReplaceTx',
@@ -60,6 +62,8 @@ export type IModalSendParamList = {
     onFail?: (error: Error) => void;
     onCancel?: () => void;
   };
+  // TODO(6.7.0): Remove this legacy param entry with SendModal.SendConfirm.
+  // Debug confirmation issues in SignatureConfirmModal -> TxConfirm instead.
   [EModalSendRoutes.SendConfirm]: {
     networkId: string;
     accountId: string;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57635](https://onekeyhq.atlassian.net/browse/OK-57635)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Prevent `TxConfirm` from registering a native header-right item when the MEV badge has no content.
- Extract the MEV provider visibility decision so the page can decide whether to pass `headerRight` before native-stack creates an iOS header item.
- Mark legacy `SendModal.SendConfirm` references as expected to be removed in 6.7.0 and point future debugging to `SignatureConfirmModal -> TxConfirm`.

## Intent & Context
The send confirmation page showed an empty circular Liquid Glass control in the top-right corner on iOS 26.5. The repro was initially misleading because the visible page says send confirmation, but the active route is `SignatureConfirmModal -> TxConfirm`, not the legacy `SendModal.SendConfirm` page.

A key constraint was to keep the native header and avoid self-drawing a replacement header, because iOS Liquid Glass styling would differ significantly from the system header.

## Root Cause
`TxConfirm` always passed a `headerRight` render function to `Page.Header`. That function returned a `TxConfirmHeaderRight` element, and the nested component later returned `null` when no MEV provider should be shown.

React Navigation/native-stack had already created a native right header slot by that point. On iOS 26, the empty `UIBarButtonItem` custom view still receives a Liquid Glass circular background, producing the blank circle.

## Design Decisions
- Keep using the existing `Page.Header` and native-stack header instead of drawing a custom header.
- Move the MEV badge visibility check ahead of the `headerRight` prop so no native right item is registered when there is no real content.
- Preserve the existing MEV badge behavior when a provider is available.
- Leave legacy `SendModal.SendConfirm` code in place for now, but annotate the removal target and direct future debugging to `SignatureConfirmModal -> TxConfirm`.

## Changes Detail
- `TxConfirmHeaderRight.tsx`: extracts `getTxConfirmMevProtectionProvider()` and keeps the visual MEV badge component behavior unchanged.
- `TxConfirm.tsx`: only passes `headerRight` when the helper confirms that a MEV badge should render.
- `SignatureConfirmHeader/index.tsx`: exports the new helper.
- Send route files: add 6.7.0 removal notes for the unused legacy confirmation route and related references.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, primarily iOS 26 native header rendering
- **Risk Areas**: MEV badge visibility in transaction confirmation headers, route cleanup notes for legacy send confirmation paths

## Test plan
- [x] Verified on iOS 26.5 simulator that the empty top-right Liquid Glass circle disappears while the native left back button remains.
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware <changed files> --deny-warnings`
- [x] `yarn agent:check --profile commit`

[OK-57635]: https://onekeyhq.atlassian.net/browse/OK-57635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ