### PR TITLE
fix: keep DeFi action dialog during tx confirm(OK-57640 OK-57652)

### DIFF
--- a/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
@@ -61,6 +61,7 @@ import {
   resolveProtocolLendingDefiFillableAmountState,
   resolveProtocolLendingRemainingDebtState,
   resolveProtocolLendingRepayAmountState,
+  resolveProtocolLendingWithdrawAmountState,
 } from './protocolLendingActionUtils';
 import {
   type IProtocolPositionActionSuccessParams,
@@ -1169,6 +1170,10 @@ function ProtocolLendingActionBorrowContent({
     repayWalletBalance,
     repayAllTargetAmount,
   });
+  const withdrawAmountState = resolveProtocolLendingWithdrawAmountState({
+    amount,
+    referenceBalance,
+  });
   // Max fillable amount: withdraw → the full supplied balance; repay → the
   // server-provided maxRepayBalance first (debt capped by wallet), then direct
   // wallet balance if the server max is unavailable.
@@ -1186,7 +1191,8 @@ function ProtocolLendingActionBorrowContent({
       })
     : repayAmountState.isFullClose;
   const isAmountInsufficient =
-    !isWithdraw && repayAmountState.isAmountInsufficient;
+    (isWithdraw && withdrawAmountState.isAmountInsufficient) ||
+    (!isWithdraw && repayAmountState.isAmountInsufficient);
   const selectedAmountPercent = resolveSelectedAmountPercent({
     isMaxAmount,
     isAmountPositive,
@@ -1257,7 +1263,10 @@ function ProtocolLendingActionBorrowContent({
     reserveAddress,
     amount,
     isDisabled:
-      isBorrowDataLoading || isRepayWalletBalancePending || hasBorrowLoadError,
+      isBorrowDataLoading ||
+      isRepayWalletBalancePending ||
+      hasBorrowLoadError ||
+      isAmountInsufficient,
     repayAll: actionType === 'repay' ? isFullClose : undefined,
   });
 

--- a/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
@@ -70,6 +70,7 @@ import {
   isUserRejectedErrorMessage,
   useProtocolPositionActionSubmit,
 } from './ProtocolPositionActionDialog';
+import { shouldShowProtocolPositionActionInlineSubmitError } from './protocolPositionActionErrorUtils';
 import { getProtocolProviderDisplayName } from './protocolProviderDisplayUtils';
 
 // Withdraw/Repay only — the portfolio dialog is exit-side (Supply/Borrow stay on
@@ -755,7 +756,8 @@ function ProtocolLendingActionDefiContent({
     const releaseSubmitGuardOnceWithError = (error: unknown) => {
       if (
         !submitGuardReleased &&
-        !isUserRejectedErrorMessage({ error, intl })
+        !isUserRejectedErrorMessage({ error, intl }) &&
+        shouldShowProtocolPositionActionInlineSubmitError(error)
       ) {
         setSubmitError(getErrorMessage(error));
       }
@@ -767,7 +769,8 @@ function ProtocolLendingActionDefiContent({
         selectedAssets: [selectedAsset],
         amount,
         isMaxAmount,
-        isErrorToastSuppressed: () => true,
+        isErrorToastSuppressed:
+          shouldShowProtocolPositionActionInlineSubmitError,
         onSettleResult: ({ status }) => {
           releaseSubmitGuardOnce();
           void closeRef.current?.();
@@ -779,7 +782,10 @@ function ProtocolLendingActionDefiContent({
         onConfirmCancel: releaseSubmitGuardOnce,
       });
     } catch (error) {
-      if (!isUserRejectedErrorMessage({ error, intl })) {
+      if (
+        !isUserRejectedErrorMessage({ error, intl }) &&
+        shouldShowProtocolPositionActionInlineSubmitError(error)
+      ) {
         setSubmitError(getErrorMessage(error));
       }
       releaseSubmitGuardOnce();
@@ -1286,7 +1292,8 @@ function ProtocolLendingActionBorrowContent({
     const releaseSubmitGuardOnceWithError = (error: unknown) => {
       if (
         !submitGuardReleased &&
-        !isUserRejectedErrorMessage({ error, intl })
+        !isUserRejectedErrorMessage({ error, intl }) &&
+        shouldShowProtocolPositionActionInlineSubmitError(error)
       ) {
         setSubmitError(getErrorMessage(error));
       }
@@ -1424,7 +1431,10 @@ function ProtocolLendingActionBorrowContent({
       }
       await submitBorrowTx();
     } catch (error) {
-      if (!isUserRejectedErrorMessage({ error, intl })) {
+      if (
+        !isUserRejectedErrorMessage({ error, intl }) &&
+        shouldShowProtocolPositionActionInlineSubmitError(error)
+      ) {
         setSubmitError(getErrorMessage(error));
       }
       releaseSubmitGuard();

--- a/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
@@ -9,11 +9,13 @@ import {
   Dialog,
   Icon,
   Popover,
+  ScrollView,
   SizableText,
   Skeleton,
   Stack,
   XStack,
   YStack,
+  useMedia,
 } from '@onekeyhq/components';
 import type { useInPageDialog } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
@@ -71,6 +73,7 @@ import {
   useProtocolPositionActionSubmit,
 } from './ProtocolPositionActionDialog';
 import { shouldShowProtocolPositionActionInlineSubmitError } from './protocolPositionActionErrorUtils';
+import { resolveProtocolPositionActionDialogLayout } from './protocolPositionActionLayoutUtils';
 import { getProtocolProviderDisplayName } from './protocolProviderDisplayUtils';
 
 // Withdraw/Repay only — the portfolio dialog is exit-side (Supply/Borrow stay on
@@ -474,8 +477,17 @@ function LendingActionAlerts({
       (text) => text?.trim() === liquidationWarningText.trim(),
     );
   });
+  const hasVisibleAlert =
+    showLiquidationWarning ||
+    Boolean(errorMessage) ||
+    visibleCheckAmountAlerts.length > 0;
+
+  if (!hasVisibleAlert) {
+    return null;
+  }
+
   return (
-    <>
+    <YStack gap="$3">
       {showLiquidationWarning ? (
         <Alert
           type="warning"
@@ -518,7 +530,7 @@ function LendingActionAlerts({
           }
         />
       ))}
-    </>
+    </YStack>
   );
 }
 
@@ -540,6 +552,9 @@ function ProtocolLendingActionDefiContent({
   ) => void | Promise<void>;
 }) {
   const intl = useIntl();
+  const { gtMd } = useMedia();
+  const { bodyMaxHeight, feedbackMaxHeight } =
+    resolveProtocolPositionActionDialogLayout({ gtMd });
   const submitProtocolPositionAction = useProtocolPositionActionSubmit({
     accountId,
     networkId,
@@ -827,6 +842,9 @@ function ProtocolLendingActionDefiContent({
     !isRepayWalletBalanceReady ||
     isRepayWalletBalancePending ||
     Boolean(repayWalletBalanceError);
+  const inlineErrorMessage = submitError ?? repayWalletBalanceError;
+  const showFeedbackRegion =
+    (Boolean(hasDebts) && isWithdraw) || Boolean(inlineErrorMessage);
 
   return (
     <YStack gap="$5">
@@ -834,44 +852,64 @@ function ProtocolLendingActionDefiContent({
         <Dialog.Title>{actionLabel}</Dialog.Title>
       </Dialog.Header>
 
-      {selectedAsset && selectedItem ? (
-        <>
-          <LendingAssetSelectorRow
-            item={selectedItem}
-            items={selectorItems}
-            selectable={selectable}
-            onSelect={handleSelectAsset}
-            columnHeaderLabel={columnHeaderLabel}
-          />
-          <ProtocolPositionActionAmountInput
-            amount={amount}
-            onChangeAmount={handleAmountChange}
-            onSelectPercent={handleSelectPercent}
-            selectedPercent={selectedAmountPercent}
-            symbol={selectedAsset.symbol}
-            tokenLogoUrl={selectedAsset.asset.meta?.logoUrl}
-            availableAmount={availableAmount}
-            fiatValue={amountFiatValue}
-            currencySymbol={currencySymbol}
-            isInsufficient={isAmountInsufficient}
-            availableLabel={availableLabel}
-            maxLabel={maxLabel}
-            insufficientLabel={insufficientLabel}
-            onFocus={handleAmountInputFocus}
-          />
-        </>
-      ) : (
-        <YStack py="$6" alignItems="center">
-          <SizableText size="$bodyMd" color="$textSubdued">
-            {intl.formatMessage({ id: ETranslations.global_select_crypto })}
-          </SizableText>
+      <ScrollView
+        maxHeight={bodyMaxHeight}
+        mx="$-5"
+        px="$5"
+        nestedScrollEnabled
+      >
+        <YStack gap="$5">
+          {selectedAsset && selectedItem ? (
+            <>
+              <LendingAssetSelectorRow
+                item={selectedItem}
+                items={selectorItems}
+                selectable={selectable}
+                onSelect={handleSelectAsset}
+                columnHeaderLabel={columnHeaderLabel}
+              />
+              <ProtocolPositionActionAmountInput
+                amount={amount}
+                onChangeAmount={handleAmountChange}
+                onSelectPercent={handleSelectPercent}
+                selectedPercent={selectedAmountPercent}
+                symbol={selectedAsset.symbol}
+                tokenLogoUrl={selectedAsset.asset.meta?.logoUrl}
+                availableAmount={availableAmount}
+                fiatValue={amountFiatValue}
+                currencySymbol={currencySymbol}
+                isInsufficient={isAmountInsufficient}
+                availableLabel={availableLabel}
+                maxLabel={maxLabel}
+                insufficientLabel={insufficientLabel}
+                onFocus={handleAmountInputFocus}
+              />
+            </>
+          ) : (
+            <YStack py="$6" alignItems="center">
+              <SizableText size="$bodyMd" color="$textSubdued">
+                {intl.formatMessage({
+                  id: ETranslations.global_select_crypto,
+                })}
+              </SizableText>
+            </YStack>
+          )}
         </YStack>
-      )}
+      </ScrollView>
 
-      <LendingActionAlerts
-        showLiquidationWarning={Boolean(hasDebts) && isWithdraw}
-        errorMessage={submitError ?? repayWalletBalanceError}
-      />
+      {showFeedbackRegion ? (
+        <ScrollView
+          maxHeight={feedbackMaxHeight}
+          mx="$-5"
+          px="$5"
+          nestedScrollEnabled
+        >
+          <LendingActionAlerts
+            showLiquidationWarning={Boolean(hasDebts) && isWithdraw}
+            errorMessage={inlineErrorMessage}
+          />
+        </ScrollView>
+      ) : null}
 
       <Dialog.Footer
         showCancelButton={false}
@@ -905,6 +943,9 @@ function ProtocolLendingActionBorrowContent({
   ) => void | Promise<void>;
 }) {
   const intl = useIntl();
+  const { gtMd } = useMedia();
+  const { bodyMaxHeight, feedbackMaxHeight } =
+    resolveProtocolPositionActionDialogLayout({ gtMd });
   const [
     {
       currencyInfo: { symbol: currencySymbol },
@@ -1534,6 +1575,19 @@ function ProtocolLendingActionBorrowContent({
     hasLoadedOnceRef.current = true;
   }
   const isInitialLoading = !hasLoadedOnceRef.current;
+  const checkAmountAlerts = actionResult.checkAmountAlerts ?? [];
+  const inlineErrorMessage =
+    assetsError ??
+    repayWalletBalanceError ??
+    submitError ??
+    (actionResult.isCheckAmountMessageError
+      ? actionResult.checkAmountMessage
+      : undefined);
+  const showFeedbackRegion =
+    !isInitialLoading &&
+    ((Boolean(hasDebts) && isWithdraw) ||
+      Boolean(inlineErrorMessage) ||
+      checkAmountAlerts.length > 0);
 
   return (
     <YStack gap="$5">
@@ -1541,159 +1595,173 @@ function ProtocolLendingActionBorrowContent({
         <Dialog.Title>{actionLabel}</Dialog.Title>
       </Dialog.Header>
 
-      {isInitialLoading ? (
+      <ScrollView
+        maxHeight={bodyMaxHeight}
+        mx="$-5"
+        px="$5"
+        nestedScrollEnabled
+      >
         <YStack gap="$5">
-          {source.selectable ? (
-            <Skeleton height="$11" width="100%" borderRadius="$3" />
-          ) : null}
-          <Skeleton
-            height={BORROW_HERO_SKELETON_HEIGHT}
-            width="100%"
-            borderRadius="$3"
-          />
-          <Skeleton height="$11" width="100%" borderRadius="$3" />
-          <XStack gap="$2">
-            {LENDING_PERCENT_PRESETS.map((preset) => (
-              <Skeleton key={preset} flex={1} height="$9" borderRadius="$2" />
-            ))}
-          </XStack>
-        </YStack>
-      ) : null}
-      {!isInitialLoading && isEmpty ? (
-        <YStack py="$6" alignItems="center">
-          <SizableText size="$bodyMd" color="$textSubdued">
-            {intl.formatMessage({ id: ETranslations.global_select_crypto })}
-          </SizableText>
-        </YStack>
-      ) : null}
-      {!isInitialLoading && !isEmpty ? (
-        <>
-          {selectable ? (
-            <LendingAssetSelectorRow
-              item={selectedItem}
-              items={selectorItems}
-              selectable={selectable}
-              onSelect={handleSelectAsset}
-              columnHeaderLabel={columnHeaderLabel}
-            />
-          ) : null}
-          <ProtocolPositionActionAmountInput
-            amount={amount}
-            onChangeAmount={handleAmountChange}
-            onSelectPercent={handleSelectPercent}
-            selectedPercent={selectedAmountPercent}
-            symbol={effectiveSymbol}
-            tokenLogoUrl={effectiveLogo}
-            availableAmount={referenceBalance}
-            fiatValue={amountFiatValue}
-            currencySymbol={currencySymbol}
-            isInsufficient={isAmountInsufficient}
-            availableLabel={availableLabel}
-            maxLabel={maxLabel}
-            insufficientLabel={insufficientLabel}
-            onFocus={handleAmountInputFocus}
-            secondaryLabel={walletBalanceLabel}
-            secondaryAmount={walletBalanceText}
-          />
-          {healthFactor ? (
-            <YStack gap="$1">
-              <ProtocolPositionActionAnchor
-                label={intl.formatMessage({
-                  id: ETranslations.defi_health_factor,
-                })}
-                iconNode={null}
-                valueNode={
-                  <XStack alignItems="center" gap="$2" flexShrink={0}>
-                    <Stack opacity={healthFactor.latest ? 0.5 : 1}>
-                      <EarnText
-                        text={healthFactor.current?.title}
-                        size="$bodyMdMedium"
-                      />
-                    </Stack>
-                    {healthFactor.latest ? (
-                      <>
-                        <Icon
-                          name="ArrowRightSolid"
-                          size="$4"
-                          color="$iconDisabled"
-                        />
-                        <EarnText
-                          text={healthFactor.latest?.title}
-                          size="$bodyMdMedium"
-                        />
-                      </>
-                    ) : null}
-                  </XStack>
-                }
-              />
-              {remainingDebtChange ? (
-                <RemainingDebtChangeRow
-                  label={availableLabel}
-                  currentDebt={remainingDebtChange.currentDebt}
-                  remainingDebt={remainingDebtChange.remainingDebt}
-                  symbol={effectiveSymbol}
-                />
+          {isInitialLoading ? (
+            <YStack gap="$5">
+              {source.selectable ? (
+                <Skeleton height="$11" width="100%" borderRadius="$3" />
               ) : null}
-              <XStack justifyContent="flex-end">
-                <EarnText
-                  text={
-                    actionResult.transactionConfirmation?.liquidationAt
-                      ?.description ?? {
-                      text: intl.formatMessage({
-                        id: ETranslations.defi_liquidation_at_less_than_1_00,
-                      }),
-                    }
-                  }
-                  size="$bodySm"
-                  color="$textSubdued"
-                />
+              <Skeleton
+                height={BORROW_HERO_SKELETON_HEIGHT}
+                width="100%"
+                borderRadius="$3"
+              />
+              <Skeleton height="$11" width="100%" borderRadius="$3" />
+              <XStack gap="$2">
+                {LENDING_PERCENT_PRESETS.map((preset) => (
+                  <Skeleton
+                    key={preset}
+                    flex={1}
+                    height="$9"
+                    borderRadius="$2"
+                  />
+                ))}
               </XStack>
             </YStack>
           ) : null}
-          {/* Health factor arrives on the (separate) simulate stream after the
+          {!isInitialLoading && isEmpty ? (
+            <YStack py="$6" alignItems="center">
+              <SizableText size="$bodyMd" color="$textSubdued">
+                {intl.formatMessage({ id: ETranslations.global_select_crypto })}
+              </SizableText>
+            </YStack>
+          ) : null}
+          {!isInitialLoading && !isEmpty ? (
+            <>
+              {selectable ? (
+                <LendingAssetSelectorRow
+                  item={selectedItem}
+                  items={selectorItems}
+                  selectable={selectable}
+                  onSelect={handleSelectAsset}
+                  columnHeaderLabel={columnHeaderLabel}
+                />
+              ) : null}
+              <ProtocolPositionActionAmountInput
+                amount={amount}
+                onChangeAmount={handleAmountChange}
+                onSelectPercent={handleSelectPercent}
+                selectedPercent={selectedAmountPercent}
+                symbol={effectiveSymbol}
+                tokenLogoUrl={effectiveLogo}
+                availableAmount={referenceBalance}
+                fiatValue={amountFiatValue}
+                currencySymbol={currencySymbol}
+                isInsufficient={isAmountInsufficient}
+                availableLabel={availableLabel}
+                maxLabel={maxLabel}
+                insufficientLabel={insufficientLabel}
+                onFocus={handleAmountInputFocus}
+                secondaryLabel={walletBalanceLabel}
+                secondaryAmount={walletBalanceText}
+              />
+              {healthFactor ? (
+                <YStack gap="$1">
+                  <ProtocolPositionActionAnchor
+                    label={intl.formatMessage({
+                      id: ETranslations.defi_health_factor,
+                    })}
+                    iconNode={null}
+                    valueNode={
+                      <XStack alignItems="center" gap="$2" flexShrink={0}>
+                        <Stack opacity={healthFactor.latest ? 0.5 : 1}>
+                          <EarnText
+                            text={healthFactor.current?.title}
+                            size="$bodyMdMedium"
+                          />
+                        </Stack>
+                        {healthFactor.latest ? (
+                          <>
+                            <Icon
+                              name="ArrowRightSolid"
+                              size="$4"
+                              color="$iconDisabled"
+                            />
+                            <EarnText
+                              text={healthFactor.latest?.title}
+                              size="$bodyMdMedium"
+                            />
+                          </>
+                        ) : null}
+                      </XStack>
+                    }
+                  />
+                  {remainingDebtChange ? (
+                    <RemainingDebtChangeRow
+                      label={availableLabel}
+                      currentDebt={remainingDebtChange.currentDebt}
+                      remainingDebt={remainingDebtChange.remainingDebt}
+                      symbol={effectiveSymbol}
+                    />
+                  ) : null}
+                  <XStack justifyContent="flex-end">
+                    <EarnText
+                      text={
+                        actionResult.transactionConfirmation?.liquidationAt
+                          ?.description ?? {
+                          text: intl.formatMessage({
+                            id: ETranslations.defi_liquidation_at_less_than_1_00,
+                          }),
+                        }
+                      }
+                      size="$bodySm"
+                      color="$textSubdued"
+                    />
+                  </XStack>
+                </YStack>
+              ) : null}
+              {/* Health factor arrives on the (separate) simulate stream after the
               amount is set — reserve its exact height with a skeleton so the
               dialog doesn't grow when it lands. Reuses the same anchor + label
               so the row height matches the loaded state byte-for-byte. */}
-          {shouldShowHealthFactorSkeleton ? (
-            <YStack gap="$1">
-              <ProtocolPositionActionAnchor
-                label={intl.formatMessage({
-                  id: ETranslations.defi_health_factor,
-                })}
-                iconNode={null}
-                valueNode={
-                  <Skeleton height="$4" width="$16" borderRadius="$1" />
-                }
-              />
-              {remainingDebtChange ? (
-                <RemainingDebtChangeRow
-                  label={availableLabel}
-                  currentDebt={remainingDebtChange.currentDebt}
-                  remainingDebt={remainingDebtChange.remainingDebt}
-                  symbol={effectiveSymbol}
-                />
+              {shouldShowHealthFactorSkeleton ? (
+                <YStack gap="$1">
+                  <ProtocolPositionActionAnchor
+                    label={intl.formatMessage({
+                      id: ETranslations.defi_health_factor,
+                    })}
+                    iconNode={null}
+                    valueNode={
+                      <Skeleton height="$4" width="$16" borderRadius="$1" />
+                    }
+                  />
+                  {remainingDebtChange ? (
+                    <RemainingDebtChangeRow
+                      label={availableLabel}
+                      currentDebt={remainingDebtChange.currentDebt}
+                      remainingDebt={remainingDebtChange.remainingDebt}
+                      symbol={effectiveSymbol}
+                    />
+                  ) : null}
+                  <XStack justifyContent="flex-end">
+                    <Skeleton height="$4" width="$24" borderRadius="$1" />
+                  </XStack>
+                </YStack>
               ) : null}
-              <XStack justifyContent="flex-end">
-                <Skeleton height="$4" width="$24" borderRadius="$1" />
-              </XStack>
-            </YStack>
+            </>
           ) : null}
-        </>
-      ) : null}
+        </YStack>
+      </ScrollView>
 
-      {!isInitialLoading ? (
-        <LendingActionAlerts
-          showLiquidationWarning={Boolean(hasDebts) && isWithdraw}
-          errorMessage={
-            assetsError ??
-            repayWalletBalanceError ??
-            submitError ??
-            (actionResult.isCheckAmountMessageError
-              ? actionResult.checkAmountMessage
-              : undefined)
-          }
-          checkAmountAlerts={actionResult.checkAmountAlerts}
-        />
+      {showFeedbackRegion ? (
+        <ScrollView
+          maxHeight={feedbackMaxHeight}
+          mx="$-5"
+          px="$5"
+          nestedScrollEnabled
+        >
+          <LendingActionAlerts
+            showLiquidationWarning={Boolean(hasDebts) && isWithdraw}
+            errorMessage={inlineErrorMessage}
+            checkAmountAlerts={checkAmountAlerts}
+          />
+        </ScrollView>
       ) : null}
       <Dialog.Footer
         showCancelButton={false}

--- a/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
@@ -12,10 +12,10 @@ import {
   SizableText,
   Skeleton,
   Stack,
-  Toast,
   XStack,
   YStack,
 } from '@onekeyhq/components';
+import type { useInPageDialog } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
 import { Token } from '@onekeyhq/kit/src/components/Token';
@@ -44,6 +44,7 @@ import {
   type IResolvedDeFiPositionActionAsset,
 } from '@onekeyhq/shared/types/defi';
 import type { ISupportedSymbol } from '@onekeyhq/shared/types/earn';
+import { EOnChainHistoryTxStatus } from '@onekeyhq/shared/types/history';
 import {
   EBorrowActionsEnum,
   EEarnLabels,
@@ -118,6 +119,7 @@ type IShowProtocolLendingActionDialogParams = {
   actionType: IProtocolLendingActionType;
   source: IProtocolLendingActionSource;
   hasDebts?: boolean;
+  dialog?: ReturnType<typeof useInPageDialog>;
   onSuccess?: (
     params: IProtocolPositionActionSuccessParams,
   ) => void | Promise<void>;
@@ -307,10 +309,12 @@ function LendingSelectorRowContent({ item }: { item: ILendingSelectorItem }) {
   );
 }
 
-// The asset row at the top of the dialog. In `selectable` mode it is the trigger
-// for a popover that lists every asset (supplied for withdraw, borrowed for
-// repay) — the semantics of Borrow's asset-select popover. Fixed mode renders
-// the plain row with no affordance.
+// The asset selector at the top of the dialog. In `selectable` mode it is a
+// compact pill (token + symbol + chevron) that triggers a popover listing every
+// asset (supplied for withdraw, borrowed for repay) — the semantics of Borrow's
+// asset-select popover. Fixed mode renders the same pill with no chevron and no
+// affordance. The per-asset balance is not repeated on the pill; it lives on the
+// "Available" row under the amount field.
 function LendingAssetSelectorRow({
   item,
   items,
@@ -326,11 +330,17 @@ function LendingAssetSelectorRow({
 }) {
   const intl = useIntl();
 
-  const rowInner = (
+  // Pill content: logo + symbol, plus a chevron when it opens the asset list.
+  // The chevron stays a size below the token so it reads as a quiet affordance
+  // rather than competing with the asset identity.
+  const pillInner = (
     <>
-      <LendingSelectorRowContent item={item} />
+      <Token size="sm" tokenImageUri={item.logoURI} bg="$bg" />
+      <SizableText size="$bodyMdMedium" numberOfLines={1} flexShrink={1}>
+        {item.symbol}
+      </SizableText>
       {selectable ? (
-        <Icon name="ChevronDownSmallOutline" color="$iconSubdued" size="$5" />
+        <Icon name="ChevronDownSmallOutline" color="$iconSubdued" size="$4.5" />
       ) : null}
     </>
   );
@@ -338,95 +348,104 @@ function LendingAssetSelectorRow({
   if (!selectable) {
     return (
       <XStack
+        alignSelf="center"
         alignItems="center"
         gap="$2"
-        px="$3"
+        px="$4"
         py="$2.5"
-        borderRadius="$3"
+        borderRadius="$full"
+        borderCurve="continuous"
         bg="$bgSubdued"
       >
-        {rowInner}
+        {pillInner}
       </XStack>
     );
   }
 
   return (
-    <Popover
-      title={intl.formatMessage({ id: ETranslations.token_selector_title })}
-      renderTrigger={
-        // ButtonFrame renders as a native <button> on web, so the asset picker
-        // is keyboard-focusable and Enter/Space opens it — a plain onPress
-        // XStack was mouse-only.
-        <ButtonFrame
-          alignItems="center"
-          justifyContent="flex-start"
-          gap="$2"
-          px="$3"
-          py="$2.5"
-          borderWidth={0}
-          borderRadius="$3"
-          bg="$bgSubdued"
-          hoverStyle={{ bg: '$bgHover' }}
-          pressStyle={{ bg: '$bgActive' }}
-          focusable
-          focusVisibleStyle={LENDING_SELECTOR_FOCUS_STYLE}
-        >
-          {rowInner}
-        </ButtonFrame>
-      }
-      renderContent={({ closePopover }) => (
-        <YStack p="$2">
-          <XStack px="$3" pb="$1">
-            <SizableText size="$bodySmMedium" color="$textSubdued">
-              {columnHeaderLabel}
-            </SizableText>
-          </XStack>
-          {items.map((selectorItem) => {
-            const isSelected = selectorItem.key === item.key;
-            // The current asset is a non-actionable state row (plain XStack);
-            // every other asset is a keyboard-focusable option button.
-            if (isSelected) {
+    // Wrap the popover so its trigger hugs the pill and centers on the dialog's
+    // vertical axis (aligning with the amount hero below). The Popover's internal
+    // Trigger frame is a full-width Stack carrying both the tap target and the
+    // popover anchor, so only a content-sized row parent keeps them on the pill.
+    <XStack alignSelf="center">
+      <Popover
+        title={intl.formatMessage({ id: ETranslations.token_selector_title })}
+        renderTrigger={
+          // ButtonFrame renders as a native <button> on web, so the asset
+          // picker is keyboard-focusable and Enter/Space opens it — a plain
+          // onPress XStack was mouse-only.
+          <ButtonFrame
+            alignItems="center"
+            justifyContent="flex-start"
+            gap="$2"
+            px="$4"
+            py="$2.5"
+            borderWidth={0}
+            borderRadius="$full"
+            borderCurve="continuous"
+            bg="$bgSubdued"
+            hoverStyle={{ bg: '$bgHover' }}
+            pressStyle={{ bg: '$bgActive' }}
+            focusable
+            focusVisibleStyle={LENDING_SELECTOR_FOCUS_STYLE}
+          >
+            {pillInner}
+          </ButtonFrame>
+        }
+        renderContent={({ closePopover }) => (
+          <YStack p="$2">
+            <XStack px="$3" pb="$1">
+              <SizableText size="$bodySmMedium" color="$textSubdued">
+                {columnHeaderLabel}
+              </SizableText>
+            </XStack>
+            {items.map((selectorItem) => {
+              const isSelected = selectorItem.key === item.key;
+              // The current asset is a non-actionable state row (plain XStack);
+              // every other asset is a keyboard-focusable option button.
+              if (isSelected) {
+                return (
+                  <XStack
+                    key={selectorItem.key}
+                    alignItems="center"
+                    gap="$2"
+                    px="$3"
+                    py="$2"
+                    borderRadius="$2"
+                    bg="$bgHover"
+                  >
+                    <LendingSelectorRowContent item={selectorItem} />
+                  </XStack>
+                );
+              }
               return (
-                <XStack
+                <ButtonFrame
                   key={selectorItem.key}
                   alignItems="center"
+                  justifyContent="flex-start"
                   gap="$2"
                   px="$3"
                   py="$2"
+                  borderWidth={0}
                   borderRadius="$2"
-                  bg="$bgHover"
+                  bg="$transparent"
+                  hoverStyle={{ bg: '$bgHover' }}
+                  pressStyle={{ bg: '$bgActive' }}
+                  focusable
+                  focusVisibleStyle={LENDING_SELECTOR_FOCUS_STYLE}
+                  onPress={() => {
+                    onSelect(selectorItem.key);
+                    closePopover();
+                  }}
                 >
                   <LendingSelectorRowContent item={selectorItem} />
-                </XStack>
+                </ButtonFrame>
               );
-            }
-            return (
-              <ButtonFrame
-                key={selectorItem.key}
-                alignItems="center"
-                justifyContent="flex-start"
-                gap="$2"
-                px="$3"
-                py="$2"
-                borderWidth={0}
-                borderRadius="$2"
-                bg="$transparent"
-                hoverStyle={{ bg: '$bgHover' }}
-                pressStyle={{ bg: '$bgActive' }}
-                focusable
-                focusVisibleStyle={LENDING_SELECTOR_FOCUS_STYLE}
-                onPress={() => {
-                  onSelect(selectorItem.key);
-                  closePopover();
-                }}
-              >
-                <LendingSelectorRowContent item={selectorItem} />
-              </ButtonFrame>
-            );
-          })}
-        </YStack>
-      )}
-    />
+            })}
+          </YStack>
+        )}
+      />
+    </XStack>
   );
 }
 
@@ -551,6 +570,14 @@ function ProtocolLendingActionDefiContent({
   );
   const [isMaxAmount, setIsMaxAmount] = useState(isWithdraw);
   const [submitError, setSubmitError] = useState<string | undefined>(undefined);
+  const closeRef = useRef<(() => void | Promise<void>) | undefined>(undefined);
+  const [submitting, setSubmitting] = useState(false);
+  const submittingRef = useRef(false);
+
+  const releaseSubmitGuard = useCallback(() => {
+    submittingRef.current = false;
+    setSubmitting(false);
+  }, []);
 
   // Editing the amount or switching the asset is a fresh intent — drop any
   // stale build/submit error so it doesn't linger over new input.
@@ -713,38 +740,49 @@ function ProtocolLendingActionDefiContent({
     close?: () => void | Promise<void>;
     preventClose: () => void;
   }) => {
-    if (!selectedAsset) {
-      preventClose();
-      return;
-    }
+    preventClose();
+    if (!selectedAsset || submittingRef.current) return;
+    closeRef.current = close;
+    submittingRef.current = true;
+    setSubmitting(true);
     setSubmitError(undefined);
-    // Keep the dialog open while the server builds the tx (button shows
-    // loading); close it right before any signing/tx-confirm modal opens so the
-    // old dialog doesn't stack above the confirm page.
-    let isActionDialogClosed = false;
+    let submitGuardReleased = false;
+    const releaseSubmitGuardOnce = () => {
+      if (submitGuardReleased) return;
+      submitGuardReleased = true;
+      releaseSubmitGuard();
+    };
+    const releaseSubmitGuardOnceWithError = (error: unknown) => {
+      if (
+        !submitGuardReleased &&
+        !isUserRejectedErrorMessage({ error, intl })
+      ) {
+        setSubmitError(getErrorMessage(error));
+      }
+      releaseSubmitGuardOnce();
+    };
     try {
       await submitProtocolPositionAction({
         action: source.action,
         selectedAssets: [selectedAsset],
         amount,
         isMaxAmount,
-        isErrorToastSuppressed: () => !isActionDialogClosed,
-        onBeforeNavigateConfirm: () => {
-          if (isActionDialogClosed) return;
-          isActionDialogClosed = true;
-          // Fire the close without awaiting it — Dialog.close resolves on a
-          // fixed 300ms teardown timer that would delay tx-confirm opening.
-          void close?.();
+        isErrorToastSuppressed: () => true,
+        onSettleResult: ({ status }) => {
+          releaseSubmitGuardOnce();
+          void closeRef.current?.();
+          if (status !== EOnChainHistoryTxStatus.Success) {
+            return false;
+          }
         },
+        onConfirmFail: releaseSubmitGuardOnceWithError,
+        onConfirmCancel: releaseSubmitGuardOnce,
       });
     } catch (error) {
-      if (
-        !isActionDialogClosed &&
-        !isUserRejectedErrorMessage({ error, intl })
-      ) {
+      if (!isUserRejectedErrorMessage({ error, intl })) {
         setSubmitError(getErrorMessage(error));
       }
-      preventClose();
+      releaseSubmitGuardOnce();
     }
   };
 
@@ -835,8 +873,8 @@ function ProtocolLendingActionDefiContent({
         onConfirmText={actionLabel}
         onConfirm={handleConfirm}
         confirmButtonProps={{
-          disabled: isConfirmDisabled,
-          loading: isRepayWalletBalancePending,
+          disabled: isConfirmDisabled || submitting,
+          loading: submitting || isRepayWalletBalancePending,
         }}
       />
     </YStack>
@@ -985,6 +1023,7 @@ function ProtocolLendingActionBorrowContent({
   // Footer confirm loading is overridden by confirmButtonProps and released
   // early by preventClose(), so the dialog owns the build spinner and guard.
   const [submitting, setSubmitting] = useState(false);
+  const submittingRef = useRef(false);
   const hasUserTouchedRef = useRef(false);
   const prefilledReserveRef = useRef<string | undefined>(undefined);
   // Show the body only after the first load settles; later reserve-switch
@@ -1223,83 +1262,110 @@ function ProtocolLendingActionBorrowContent({
   });
   const handleBorrowRepay = useUniversalBorrowRepay({ accountId, networkId });
   const closeRef = useRef<(() => void | Promise<void>) | undefined>(undefined);
-  const isBorrowDialogClosedRef = useRef(false);
+  const businessSubmitCounterRef = useRef(0);
+  const startSubmitGuard = useCallback(() => {
+    submittingRef.current = true;
+    setSubmitting(true);
+    setSubmitError(undefined);
+  }, []);
 
-  // The dialog stays open (confirm button spinning) while the server builds
-  // the tx; onBeforeNavigate closes it right as tx-confirm opens, so a build
-  // failure lands as an inline alert with the user's input intact.
+  const releaseSubmitGuard = useCallback(() => {
+    submittingRef.current = false;
+    setSubmitting(false);
+  }, []);
+
   const submitBorrowTx = useCallback(async () => {
-    const { provider, marketAddress } = source;
-    const tags: string[] = [
-      EEarnLabels.Borrow,
-      buildBorrowTag({ provider, action: actionType }),
-    ];
-    if (protocolInfo?.stakeTag) {
-      tags.push(protocolInfo.stakeTag);
-    }
-    const protocolLogoURI =
-      source.providerLogoURI ?? protocolInfo?.providerDetail.logoURI;
-    const protocolLabel = getProtocolProviderDisplayName({
-      provider,
-      providerDisplayName: source.providerDisplayName,
-      providerDetailName: protocolInfo?.providerDetail.name,
-    });
-    if (actionType === 'repay') {
-      await handleBorrowRepay({
+    businessSubmitCounterRef.current += 1;
+    startSubmitGuard();
+    let submitGuardReleased = false;
+    const releaseSubmitGuardOnce = () => {
+      if (submitGuardReleased) return;
+      submitGuardReleased = true;
+      releaseSubmitGuard();
+    };
+    const releaseSubmitGuardOnceWithError = (error: unknown) => {
+      if (
+        !submitGuardReleased &&
+        !isUserRejectedErrorMessage({ error, intl })
+      ) {
+        setSubmitError(getErrorMessage(error));
+      }
+      releaseSubmitGuardOnce();
+    };
+    try {
+      const { provider, marketAddress } = source;
+      const tags: string[] = [
+        EEarnLabels.Borrow,
+        buildBorrowTag({ provider, action: actionType }),
+      ];
+      if (protocolInfo?.stakeTag) {
+        tags.push(protocolInfo.stakeTag);
+      }
+      const protocolLogoURI =
+        source.providerLogoURI ?? protocolInfo?.providerDetail.logoURI;
+      const protocolLabel = getProtocolProviderDisplayName({
+        provider,
+        providerDisplayName: source.providerDisplayName,
+        providerDetailName: protocolInfo?.providerDetail.name,
+      });
+      if (actionType === 'repay') {
+        await handleBorrowRepay({
+          amount,
+          provider,
+          marketAddress,
+          reserveAddress,
+          repayAll: isFullClose,
+          stakingInfo: effectiveToken
+            ? {
+                label: EEarnLabels.Repay,
+                protocol: protocolLabel,
+                protocolLogoURI,
+                send: { token: effectiveToken, amount },
+                tags,
+              }
+            : undefined,
+          onSuccess: (data) => {
+            releaseSubmitGuardOnce();
+            void onSuccess?.({ accountId, networkId, data });
+          },
+          onSettleResult: () => {
+            releaseSubmitGuardOnce();
+            void closeRef.current?.();
+          },
+          onFail: releaseSubmitGuardOnceWithError,
+          onCancel: releaseSubmitGuardOnce,
+        });
+        return;
+      }
+      await handleBorrowWithdraw({
         amount,
         provider,
         marketAddress,
         reserveAddress,
-        repayAll: isFullClose,
+        withdrawAll: isFullClose,
         stakingInfo: effectiveToken
           ? {
-              label: EEarnLabels.Repay,
+              label: EEarnLabels.Withdraw,
               protocol: protocolLabel,
               protocolLogoURI,
-              send: { token: effectiveToken, amount },
+              receive: { token: effectiveToken, amount },
               tags,
             }
           : undefined,
         onSuccess: (data) => {
+          releaseSubmitGuardOnce();
           void onSuccess?.({ accountId, networkId, data });
         },
-        onBeforeNavigate: () => {
-          if (isBorrowDialogClosedRef.current) return;
-          isBorrowDialogClosedRef.current = true;
-          // Fire the close without awaiting it: Dialog.close resolves on a
-          // fixed 300ms teardown timer, which would sit serially between the
-          // build response and tx-confirm opening.
+        onSettleResult: () => {
+          releaseSubmitGuardOnce();
           void closeRef.current?.();
         },
+        onFail: releaseSubmitGuardOnceWithError,
+        onCancel: releaseSubmitGuardOnce,
       });
-      return;
+    } catch (error) {
+      releaseSubmitGuardOnceWithError(error);
     }
-    await handleBorrowWithdraw({
-      amount,
-      provider,
-      marketAddress,
-      reserveAddress,
-      withdrawAll: isFullClose,
-      stakingInfo: effectiveToken
-        ? {
-            label: EEarnLabels.Withdraw,
-            protocol: protocolLabel,
-            protocolLogoURI,
-            receive: { token: effectiveToken, amount },
-            tags,
-          }
-        : undefined,
-      onSuccess: (data) => {
-        void onSuccess?.({ accountId, networkId, data });
-      },
-      onBeforeNavigate: () => {
-        if (isBorrowDialogClosedRef.current) return;
-        isBorrowDialogClosedRef.current = true;
-        // Same as the repay call: don't serially pay Dialog.close's 300ms
-        // teardown timer before tx-confirm opens.
-        void closeRef.current?.();
-      },
-    });
   }, [
     accountId,
     actionType,
@@ -1308,13 +1374,16 @@ function ProtocolLendingActionBorrowContent({
     handleBorrowRepay,
     handleBorrowWithdraw,
     isFullClose,
+    intl,
     networkId,
     onSuccess,
     protocolInfo?.providerDetail.logoURI,
     protocolInfo?.providerDetail.name,
     protocolInfo?.stakeTag,
     reserveAddress,
+    releaseSubmitGuard,
     source,
+    startSubmitGuard,
   ]);
 
   const { needsApproval, approveLoading, onApprove } =
@@ -1326,11 +1395,6 @@ function ProtocolLendingActionBorrowContent({
       currentAllowance: protocolInfo?.approve?.allowance,
       amountValue: amount,
       onSubmit: submitBorrowTx,
-      onBeforeNavigateConfirm: () => {
-        if (isBorrowDialogClosedRef.current) return;
-        isBorrowDialogClosedRef.current = true;
-        void closeRef.current?.();
-      },
     });
 
   const handleFooterConfirm = async ({
@@ -1341,30 +1405,29 @@ function ProtocolLendingActionBorrowContent({
     preventClose: () => void;
   }) => {
     closeRef.current = close;
-    isBorrowDialogClosedRef.current = false;
-    // We own the close timing: approval and business confirms both close this
-    // dialog right before tx-confirm opens, so the old dialog never overlays it.
     preventClose();
-    if (submitting) return;
-    setSubmitting(true);
+    if (submittingRef.current) return;
+    startSubmitGuard();
     setSubmitError(undefined);
     try {
       if (needsApproval) {
+        const businessSubmitCounterBeforeApprove =
+          businessSubmitCounterRef.current;
         await onApprove();
+        if (
+          businessSubmitCounterRef.current ===
+          businessSubmitCounterBeforeApprove
+        ) {
+          releaseSubmitGuard();
+        }
         return;
       }
       await submitBorrowTx();
     } catch (error) {
       if (!isUserRejectedErrorMessage({ error, intl })) {
-        const errorMessage = getErrorMessage(error);
-        if (isBorrowDialogClosedRef.current) {
-          Toast.error({ title: errorMessage });
-        } else {
-          setSubmitError(errorMessage);
-        }
+        setSubmitError(getErrorMessage(error));
       }
-    } finally {
-      setSubmitting(false);
+      releaseSubmitGuard();
     }
   };
 
@@ -1651,9 +1714,11 @@ function showProtocolLendingActionDialog({
   actionType,
   source,
   hasDebts,
+  dialog,
   onSuccess,
 }: IShowProtocolLendingActionDialogParams) {
-  Dialog.show({
+  const DialogInstance = dialog ?? Dialog;
+  DialogInstance.show({
     showFooter: false,
     renderContent:
       source.type === 'borrow' ? (

--- a/packages/kit/src/components/DeFi/ProtocolPositionActionButton.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionButton.tsx
@@ -11,7 +11,12 @@ import {
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
-import { Button, SizableText, XStack } from '@onekeyhq/components';
+import {
+  Button,
+  SizableText,
+  XStack,
+  useInPageDialog,
+} from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { EManagePositionType } from '@onekeyhq/kit/src/views/Staking/pages/ManagePosition/hooks/useManagePage';
@@ -523,6 +528,7 @@ const ProtocolPositionActionButton = memo(
     onSuccess,
   }: IProtocolPositionActionButtonProps) => {
     const intl = useIntl();
+    const inPageDialog = useInPageDialog();
     const submitProtocolPositionAction = useProtocolPositionActionSubmit({
       accountId: accountId ?? '',
       networkId: protocol.networkId,
@@ -763,6 +769,7 @@ const ProtocolPositionActionButton = memo(
               hasDebts: positionHasDebts,
               intl,
               onSuccess,
+              dialog: inPageDialog,
             });
           return;
         }
@@ -777,11 +784,13 @@ const ProtocolPositionActionButton = memo(
           hasDebts: positionHasDebts,
           rewardAssets: defiActionUtils.getPositionRewardAssets(position),
           onSuccess,
+          dialog: inPageDialog,
         });
       },
       [
         accountId,
         hasRewards,
+        inPageDialog,
         intl,
         onSuccess,
         position,
@@ -823,11 +832,13 @@ const ProtocolPositionActionButton = memo(
             hasDebts: positionHasDebts,
             intl,
             onSuccess,
+            dialog: inPageDialog,
           });
       },
       [
         accountId,
         indexedAccountId,
+        inPageDialog,
         intl,
         manageAsset,
         onSuccess,

--- a/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
@@ -54,6 +54,7 @@ import {
   showDeFiActionTxConfirmDialog,
 } from './DeFiActionTxConfirmResult';
 import { resolveProtocolLendingDefiFillableAmountState } from './protocolLendingActionUtils';
+import { shouldShowProtocolPositionActionInlineSubmitError } from './protocolPositionActionErrorUtils';
 import {
   ProtocolValueCell,
   isProtocolAssetValueUnavailable,
@@ -752,11 +753,9 @@ type IProtocolPositionActionSubmitParams = {
   isMaxAmount?: boolean;
   // Position holds rewards — drives the "Remove & Claim rewards" tx label.
   hasRewards?: boolean;
-  // When provided and returning true at failure time, the hook skips its
-  // error Toast — the caller renders the error inline instead. A callback
-  // (not a boolean) so the dialog can fall back to the Toast for errors
-  // thrown after it has already closed (e.g. tx-confirm init failures).
-  isErrorToastSuppressed?: () => boolean;
+  // When provided and returning true for a specific failure, the hook skips
+  // its error Toast because the caller renders that error inline instead.
+  isErrorToastSuppressed?: (error: unknown) => boolean;
   onBeforeNavigateConfirm?: () => void | Promise<void>;
   onSettleResult?: (result: {
     status: IDeFiActionTxConfirmDialogResult;
@@ -1045,7 +1044,7 @@ function useProtocolPositionActionSubmit({
         }
       } catch (error) {
         if (!isUserRejectedErrorMessage({ error, intl })) {
-          if (isErrorToastSuppressed?.()) {
+          if (isErrorToastSuppressed?.(error)) {
             errorToastUtils.toastIfErrorDisable(error);
           } else {
             showProtocolPositionActionErrorToast(error);
@@ -1873,7 +1872,8 @@ function ProtocolPositionActionDialogContent({
     const releaseSubmitGuardOnceWithError = (error: Error) => {
       if (
         !submitGuardReleased &&
-        !isUserRejectedErrorMessage({ error, intl })
+        !isUserRejectedErrorMessage({ error, intl }) &&
+        shouldShowProtocolPositionActionInlineSubmitError(error)
       ) {
         setSubmitError(getErrorMessage(error));
       }
@@ -1887,7 +1887,8 @@ function ProtocolPositionActionDialogContent({
         percent: isPercentAction ? actionPercent : undefined,
         amount: useManualAmountInput ? amount : undefined,
         isMaxAmount: useManualAmountInput ? isMaxAmount : undefined,
-        isErrorToastSuppressed: () => true,
+        isErrorToastSuppressed:
+          shouldShowProtocolPositionActionInlineSubmitError,
         onSettleResult: ({ status }) => {
           releaseSubmitGuardOnce();
           void closeRef.current?.();
@@ -1899,7 +1900,10 @@ function ProtocolPositionActionDialogContent({
         onConfirmCancel: releaseSubmitGuardOnce,
       });
     } catch (error) {
-      if (!isUserRejectedErrorMessage({ error, intl })) {
+      if (
+        !isUserRejectedErrorMessage({ error, intl }) &&
+        shouldShowProtocolPositionActionInlineSubmitError(error)
+      ) {
         setSubmitError(getErrorMessage(error));
       }
       releaseSubmitGuardOnce();

--- a/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
@@ -8,10 +8,12 @@ import {
   Button,
   Checkbox,
   Dialog,
+  ScrollView,
   SizableText,
   Stack,
   XStack,
   YStack,
+  useMedia,
 } from '@onekeyhq/components';
 import type { useInPageDialog } from '@onekeyhq/components';
 import type { IEncodedTx, IUnsignedTxPro } from '@onekeyhq/core/src/types';
@@ -55,6 +57,7 @@ import {
 } from './DeFiActionTxConfirmResult';
 import { resolveProtocolLendingDefiFillableAmountState } from './protocolLendingActionUtils';
 import { shouldShowProtocolPositionActionInlineSubmitError } from './protocolPositionActionErrorUtils';
+import { resolveProtocolPositionActionDialogLayout } from './protocolPositionActionLayoutUtils';
 import {
   ProtocolValueCell,
   isProtocolAssetValueUnavailable,
@@ -1509,6 +1512,9 @@ function ProtocolPositionActionDialogContent({
   ) => void | Promise<void>;
 }) {
   const intl = useIntl();
+  const { gtMd } = useMedia();
+  const { bodyMaxHeight, feedbackMaxHeight } =
+    resolveProtocolPositionActionDialogLayout({ gtMd });
   const submitProtocolPositionAction = useProtocolPositionActionSubmit({
     accountId,
     networkId,
@@ -2054,46 +2060,79 @@ function ProtocolPositionActionDialogContent({
     );
   }
 
+  const showLiquidationWarning =
+    Boolean(hasDebts) && action.action === EDeFiPositionAction.Withdraw;
+  const inlineErrorMessage = submitError ?? repayWalletBalanceError;
+  const showTransactionCountNotice = selectedAssets.length > 1;
+  const showFeedbackRegion =
+    showLiquidationWarning ||
+    Boolean(inlineErrorMessage) ||
+    showTransactionCountNotice;
+
   return (
     <YStack gap="$5">
       <Dialog.Header>
         <Dialog.Title>{actionLabel}</Dialog.Title>
       </Dialog.Header>
 
-      {selectable ? assetSelector : null}
-      {actionBody}
+      <ScrollView
+        maxHeight={bodyMaxHeight}
+        mx="$-5"
+        px="$5"
+        nestedScrollEnabled
+      >
+        <YStack gap="$5">
+          {selectable ? assetSelector : null}
+          {actionBody}
+        </YStack>
+      </ScrollView>
 
-      {hasDebts && action.action === EDeFiPositionAction.Withdraw ? (
-        <Alert
-          type="warning"
-          icon="InfoCircleOutline"
-          description={intl.formatMessage({
-            id: ETranslations.defi_liquidation_withdraw_desc,
-          })}
-        />
-      ) : null}
+      {showFeedbackRegion ? (
+        <ScrollView
+          maxHeight={feedbackMaxHeight}
+          mx="$-5"
+          px="$5"
+          nestedScrollEnabled
+        >
+          <YStack gap="$3">
+            {showLiquidationWarning ? (
+              <Alert
+                type="warning"
+                icon="InfoCircleOutline"
+                description={intl.formatMessage({
+                  id: ETranslations.defi_liquidation_withdraw_desc,
+                })}
+              />
+            ) : null}
 
-      {submitError || repayWalletBalanceError ? (
-        <Alert
-          type="critical"
-          icon="ErrorOutline"
-          title={intl.formatMessage({
-            id: ETranslations.global_an_error_occurred,
-          })}
-          description={submitError ?? repayWalletBalanceError}
-        />
-      ) : null}
+            {inlineErrorMessage ? (
+              <Alert
+                type="critical"
+                icon="ErrorOutline"
+                title={intl.formatMessage({
+                  id: ETranslations.global_an_error_occurred,
+                })}
+                description={inlineErrorMessage}
+              />
+            ) : null}
 
-      {selectedAssets.length > 1 ? (
-        // Each selected asset builds its own transaction (approvals discovered
-        // at build time may add more), so hardware-wallet users know how many
-        // confirmations to expect. Count shown is the business-tx floor.
-        <SizableText size="$bodySm" color="$textSubdued" textAlign="center">
-          {intl.formatMessage(
-            { id: ETranslations.address_risk_check_txs__msg },
-            { count: selectedAssets.length },
-          )}
-        </SizableText>
+            {showTransactionCountNotice ? (
+              // Each selected asset builds its own transaction (approvals discovered
+              // at build time may add more), so hardware-wallet users know how many
+              // confirmations to expect. Count shown is the business-tx floor.
+              <SizableText
+                size="$bodySm"
+                color="$textSubdued"
+                textAlign="center"
+              >
+                {intl.formatMessage(
+                  { id: ETranslations.address_risk_check_txs__msg },
+                  { count: selectedAssets.length },
+                )}
+              </SizableText>
+            ) : null}
+          </YStack>
+        </ScrollView>
       ) : null}
 
       <Dialog.Footer

--- a/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
@@ -13,6 +13,7 @@ import {
   XStack,
   YStack,
 } from '@onekeyhq/components';
+import type { useInPageDialog } from '@onekeyhq/components';
 import type { IEncodedTx, IUnsignedTxPro } from '@onekeyhq/core/src/types';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
@@ -48,7 +49,10 @@ import { EMessageTypesEth } from '@onekeyhq/shared/types/message';
 import { EEarnLabels } from '@onekeyhq/shared/types/staking';
 import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
 
-import { showDeFiActionTxConfirmDialog } from './DeFiActionTxConfirmResult';
+import {
+  type IDeFiActionTxConfirmDialogResult,
+  showDeFiActionTxConfirmDialog,
+} from './DeFiActionTxConfirmResult';
 import { resolveProtocolLendingDefiFillableAmountState } from './protocolLendingActionUtils';
 import {
   ProtocolValueCell,
@@ -754,6 +758,12 @@ type IProtocolPositionActionSubmitParams = {
   // thrown after it has already closed (e.g. tx-confirm init failures).
   isErrorToastSuppressed?: () => boolean;
   onBeforeNavigateConfirm?: () => void | Promise<void>;
+  onSettleResult?: (result: {
+    status: IDeFiActionTxConfirmDialogResult;
+    data: ISendTxOnSuccessData[];
+  }) => boolean | void | Promise<boolean | void>;
+  onConfirmFail?: (error: Error) => void;
+  onConfirmCancel?: () => void;
 };
 
 function buildDeFiActionExtraParams({
@@ -818,6 +828,9 @@ function useProtocolPositionActionSubmit({
       hasRewards,
       isErrorToastSuppressed,
       onBeforeNavigateConfirm,
+      onSettleResult,
+      onConfirmFail,
+      onConfirmCancel,
     }: IProtocolPositionActionSubmitParams) => {
       if (selectedAssets.length === 0) {
         throw new OneKeyLocalError('DeFi action asset is missing');
@@ -1004,16 +1017,25 @@ function useProtocolPositionActionSubmit({
                 networkId,
                 data,
               });
+              const shouldContinueSuccess = await onSettleResult?.({
+                status: finalStatus,
+                data,
+              });
+              if (shouldContinueSuccess === false) {
+                return;
+              }
               if (finalStatus !== EOnChainHistoryTxStatus.Success) {
                 return;
               }
               await onSuccess?.({ accountId, networkId, data });
             },
             onFail: (error: Error) => {
+              onConfirmFail?.(error);
               if (isTxConfirmInitializing) {
                 txConfirmInitError = error;
               }
             },
+            onCancel: onConfirmCancel,
           });
         } finally {
           isTxConfirmInitializing = false;
@@ -1498,6 +1520,9 @@ function ProtocolPositionActionDialogContent({
       currencyInfo: { symbol: currencySymbol },
     },
   ] = useSettingsPersistAtom();
+  const closeRef = useRef<(() => void | Promise<void>) | undefined>(undefined);
+  const [submitting, setSubmitting] = useState(false);
+  const submittingRef = useRef(false);
   // Percent as typed text so the hero is directly editable. Invalid or empty
   // text zeroes the preview and disables confirm (buildDeFiActionBps returns
   // undefined outside integer 1..100) while keeping the field editable.
@@ -1529,6 +1554,11 @@ function ProtocolPositionActionDialogContent({
     () => (action.assets[0] ? [0] : []),
   );
   const [submitError, setSubmitError] = useState<string | undefined>(undefined);
+
+  const releaseSubmitGuard = useCallback(() => {
+    submittingRef.current = false;
+    setSubmitting(false);
+  }, []);
 
   const selectedAssets = useMemo(
     () =>
@@ -1828,17 +1858,27 @@ function ProtocolPositionActionDialogContent({
     close?: () => void | Promise<void>;
     preventClose: () => void;
   }) => {
-    if (selectedAssets.length === 0) {
-      preventClose();
-      return;
-    }
-
+    preventClose();
+    if (selectedAssets.length === 0 || submittingRef.current) return;
+    closeRef.current = close;
+    submittingRef.current = true;
+    setSubmitting(true);
     setSubmitError(undefined);
-    // Keep the action dialog open while the server builds the transaction so
-    // the button can show loading. Close it immediately before opening any
-    // signing/tx-confirm modal, otherwise the old dialog stays stacked above
-    // the confirm page until the async submit finishes.
-    let isActionDialogClosed = false;
+    let submitGuardReleased = false;
+    const releaseSubmitGuardOnce = () => {
+      if (submitGuardReleased) return;
+      submitGuardReleased = true;
+      releaseSubmitGuard();
+    };
+    const releaseSubmitGuardOnceWithError = (error: Error) => {
+      if (
+        !submitGuardReleased &&
+        !isUserRejectedErrorMessage({ error, intl })
+      ) {
+        setSubmitError(getErrorMessage(error));
+      }
+      releaseSubmitGuardOnce();
+    };
     try {
       await submitProtocolPositionAction({
         action,
@@ -1847,24 +1887,22 @@ function ProtocolPositionActionDialogContent({
         percent: isPercentAction ? actionPercent : undefined,
         amount: useManualAmountInput ? amount : undefined,
         isMaxAmount: useManualAmountInput ? isMaxAmount : undefined,
-        // Errors raised while the dialog is still open render inline below;
-        // once it has closed, the hook's Toast is the only visible surface.
-        isErrorToastSuppressed: () => !isActionDialogClosed,
-        onBeforeNavigateConfirm: async () => {
-          if (isActionDialogClosed) return;
-          isActionDialogClosed = true;
-          await close?.();
+        isErrorToastSuppressed: () => true,
+        onSettleResult: ({ status }) => {
+          releaseSubmitGuardOnce();
+          void closeRef.current?.();
+          if (status !== EOnChainHistoryTxStatus.Success) {
+            return false;
+          }
         },
+        onConfirmFail: releaseSubmitGuardOnceWithError,
+        onConfirmCancel: releaseSubmitGuardOnce,
       });
     } catch (error) {
-      if (
-        !isActionDialogClosed &&
-        !isUserRejectedErrorMessage({ error, intl })
-      ) {
+      if (!isUserRejectedErrorMessage({ error, intl })) {
         setSubmitError(getErrorMessage(error));
       }
-      // Keep the dialog open so the user can retry instead of auto-closing.
-      preventClose();
+      releaseSubmitGuardOnce();
     }
   };
 
@@ -2060,8 +2098,8 @@ function ProtocolPositionActionDialogContent({
         onConfirmText={actionLabel}
         onConfirm={handleConfirm}
         confirmButtonProps={{
-          disabled: isConfirmDisabled,
-          loading: isRepayWalletBalancePending,
+          disabled: isConfirmDisabled || submitting,
+          loading: submitting || isRepayWalletBalancePending,
         }}
       />
     </YStack>
@@ -2076,6 +2114,7 @@ function showProtocolPositionActionDialog({
   hasDebts,
   rewardAssets,
   onSuccess,
+  dialog,
 }: {
   accountId: string;
   networkId: string;
@@ -2086,8 +2125,10 @@ function showProtocolPositionActionDialog({
   onSuccess?: (
     params: IProtocolPositionActionSuccessParams,
   ) => void | Promise<void>;
+  dialog?: ReturnType<typeof useInPageDialog>;
 }) {
-  Dialog.show({
+  const DialogInstance = dialog ?? Dialog;
+  DialogInstance.show({
     showFooter: false,
     renderContent: (
       <ProtocolPositionActionDialogContent

--- a/packages/kit/src/components/DeFi/defiPortfolioDetailStyleUtils.ts
+++ b/packages/kit/src/components/DeFi/defiPortfolioDetailStyleUtils.ts
@@ -1,3 +1,5 @@
+// Badge + position name form a quiet block header on both platforms; the
+// values below carry the emphasis, so both header labels stay subdued.
 const DEFI_PORTFOLIO_DETAIL_POSITION_NAME_COLOR = '$textSubdued';
 const DEFI_PORTFOLIO_DETAIL_COLUMN_NAME_COLOR = '$textSubdued';
 

--- a/packages/kit/src/components/DeFi/protocolLendingActionUtils.test.ts
+++ b/packages/kit/src/components/DeFi/protocolLendingActionUtils.test.ts
@@ -3,9 +3,28 @@ import {
   resolveProtocolLendingDefiFillableAmountState,
   resolveProtocolLendingRemainingDebtState,
   resolveProtocolLendingRepayAmountState,
+  resolveProtocolLendingWithdrawAmountState,
 } from './protocolLendingActionUtils';
 
 describe('protocolLendingActionUtils', () => {
+  it('marks withdraw amount above the supplied balance as insufficient', () => {
+    const state = resolveProtocolLendingWithdrawAmountState({
+      amount: '10.0001',
+      referenceBalance: '10',
+    });
+
+    expect(state.isAmountInsufficient).toBe(true);
+  });
+
+  it('does not mark exact withdraw max as insufficient', () => {
+    const state = resolveProtocolLendingWithdrawAmountState({
+      amount: '10',
+      referenceBalance: '10',
+    });
+
+    expect(state.isAmountInsufficient).toBe(false);
+  });
+
   it('uses server maxRepayBalance for repay max before wallet balance resolves', () => {
     const state = resolveProtocolLendingRepayAmountState({
       amount: '2',

--- a/packages/kit/src/components/DeFi/protocolLendingActionUtils.ts
+++ b/packages/kit/src/components/DeFi/protocolLendingActionUtils.ts
@@ -54,6 +54,26 @@ function resolveRepayValueForMax({
   return referenceBalance;
 }
 
+export function resolveProtocolLendingWithdrawAmountState({
+  amount,
+  referenceBalance,
+}: {
+  amount: string;
+  referenceBalance: string;
+}) {
+  const amountBN = toNonNegativeAmountBN(amount);
+  const referenceBalanceBN = toNonNegativeAmountBN(referenceBalance);
+  const isAmountInsufficient = Boolean(
+    amountBN?.gt(0) &&
+    referenceBalanceBN !== undefined &&
+    amountBN.gt(referenceBalanceBN),
+  );
+
+  return {
+    isAmountInsufficient,
+  };
+}
+
 export function resolveProtocolLendingDefiFillableAmountState({
   isRepay,
   availableAmount,

--- a/packages/kit/src/components/DeFi/protocolPositionActionErrorUtils.test.ts
+++ b/packages/kit/src/components/DeFi/protocolPositionActionErrorUtils.test.ts
@@ -1,0 +1,57 @@
+import {
+  OneKeyLocalError,
+  OneKeyServerApiError,
+} from '@onekeyhq/shared/src/errors';
+
+import { shouldShowProtocolPositionActionInlineSubmitError } from './protocolPositionActionErrorUtils';
+
+describe('protocolPositionActionErrorUtils', () => {
+  it('keeps local submit validation errors inline', () => {
+    expect(
+      shouldShowProtocolPositionActionInlineSubmitError(
+        new OneKeyLocalError('Invalid DeFi action amount'),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not inline auto-toast errors', () => {
+    const error = new OneKeyLocalError({
+      message: 'Failed to submit',
+      autoToast: true,
+    });
+
+    expect(shouldShowProtocolPositionActionInlineSubmitError(error)).toBe(
+      false,
+    );
+  });
+
+  it('does not inline server API errors even after toast suppression mutated autoToast', () => {
+    const error = new OneKeyServerApiError({
+      message: 'build transaction failed',
+      autoToast: false,
+    });
+
+    expect(shouldShowProtocolPositionActionInlineSubmitError(error)).toBe(
+      false,
+    );
+  });
+
+  it('does not inline network or HTTP response errors', () => {
+    const error = Object.assign(new Error('Network Error'), {
+      response: { status: 502 },
+    });
+
+    expect(shouldShowProtocolPositionActionInlineSubmitError(error)).toBe(
+      false,
+    );
+  });
+
+  it('does not inline wrapped tx-confirm errors', () => {
+    const error = new OneKeyLocalError('simulation failed');
+    error.cause = new Error('inner simulation failed');
+
+    expect(shouldShowProtocolPositionActionInlineSubmitError(error)).toBe(
+      false,
+    );
+  });
+});

--- a/packages/kit/src/components/DeFi/protocolPositionActionErrorUtils.ts
+++ b/packages/kit/src/components/DeFi/protocolPositionActionErrorUtils.ts
@@ -1,0 +1,62 @@
+import {
+  EOneKeyErrorClassNames,
+  type IOneKeyError,
+} from '@onekeyhq/shared/src/errors/types/errorTypes';
+
+type IProtocolPositionActionErrorObject = IOneKeyError & {
+  $$autoToastErrorTriggered?: boolean;
+  cause?: unknown;
+  response?: {
+    status?: unknown;
+  };
+};
+
+function isObjectLike(value: unknown): value is Record<string, unknown> {
+  return (
+    (typeof value === 'object' && value !== null) || typeof value === 'function'
+  );
+}
+
+function hasHttpResponseStatus(error: IProtocolPositionActionErrorObject) {
+  return typeof error.response?.status === 'number';
+}
+
+function hasRequestMetadata(error: IProtocolPositionActionErrorObject) {
+  return Boolean(error.requestId || typeof error.httpStatusCode === 'number');
+}
+
+function isOneKeyServerApiError(error: IProtocolPositionActionErrorObject) {
+  return (
+    error.className === EOneKeyErrorClassNames.OneKeyServerApiError ||
+    error.name === EOneKeyErrorClassNames.OneKeyServerApiError
+  );
+}
+
+function isLocalInlineError(error: IProtocolPositionActionErrorObject) {
+  return (
+    error.className === EOneKeyErrorClassNames.OneKeyLocalError ||
+    error.name === EOneKeyErrorClassNames.OneKeyLocalError
+  );
+}
+
+export function shouldShowProtocolPositionActionInlineSubmitError(
+  error: unknown,
+) {
+  if (!isObjectLike(error)) {
+    return false;
+  }
+
+  const oneKeyError = error as IProtocolPositionActionErrorObject;
+  if (oneKeyError.autoToast || oneKeyError.$$autoToastErrorTriggered) {
+    return false;
+  }
+  if (
+    isOneKeyServerApiError(oneKeyError) ||
+    hasRequestMetadata(oneKeyError) ||
+    hasHttpResponseStatus(oneKeyError)
+  ) {
+    return false;
+  }
+
+  return isLocalInlineError(oneKeyError) && !oneKeyError.cause;
+}

--- a/packages/kit/src/components/DeFi/protocolPositionActionLayoutUtils.test.ts
+++ b/packages/kit/src/components/DeFi/protocolPositionActionLayoutUtils.test.ts
@@ -1,0 +1,36 @@
+import { resolveProtocolPositionActionDialogLayout } from './protocolPositionActionLayoutUtils';
+
+describe('protocolPositionActionLayoutUtils', () => {
+  it('uses taller bounded scroll regions on regular-width dialogs', () => {
+    const compactLayout = resolveProtocolPositionActionDialogLayout({
+      gtMd: false,
+    });
+    const regularLayout = resolveProtocolPositionActionDialogLayout({
+      gtMd: true,
+    });
+
+    expect(regularLayout.bodyMaxHeight).toBeGreaterThan(
+      compactLayout.bodyMaxHeight,
+    );
+    expect(regularLayout.feedbackMaxHeight).toBeGreaterThan(
+      compactLayout.feedbackMaxHeight,
+    );
+  });
+
+  it('keeps feedback bounded below the editable action body', () => {
+    const compactLayout = resolveProtocolPositionActionDialogLayout({
+      gtMd: false,
+    });
+    const regularLayout = resolveProtocolPositionActionDialogLayout({
+      gtMd: true,
+    });
+
+    expect(compactLayout.feedbackMaxHeight).toBeLessThan(
+      compactLayout.bodyMaxHeight,
+    );
+    expect(regularLayout.feedbackMaxHeight).toBeLessThan(
+      regularLayout.bodyMaxHeight,
+    );
+    expect(compactLayout.feedbackMaxHeight).toBeGreaterThanOrEqual(128);
+  });
+});

--- a/packages/kit/src/components/DeFi/protocolPositionActionLayoutUtils.ts
+++ b/packages/kit/src/components/DeFi/protocolPositionActionLayoutUtils.ts
@@ -1,0 +1,10 @@
+export function resolveProtocolPositionActionDialogLayout({
+  gtMd,
+}: {
+  gtMd: boolean;
+}) {
+  return {
+    bodyMaxHeight: gtMd ? 420 : 360,
+    feedbackMaxHeight: gtMd ? 160 : 128,
+  };
+}

--- a/packages/kit/src/views/Borrow/hooks/useUniversalBorrowWithdrawRepayHooks.ts
+++ b/packages/kit/src/views/Borrow/hooks/useUniversalBorrowWithdrawRepayHooks.ts
@@ -2,12 +2,20 @@ import { useCallback } from 'react';
 
 import type { IEncodedTx } from '@onekeyhq/core/src/types';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { showDeFiActionTxConfirmDialog } from '@onekeyhq/kit/src/components/DeFi/DeFiActionTxConfirmResult';
+import {
+  type IDeFiActionTxConfirmDialogResult,
+  showDeFiActionTxConfirmDialog,
+} from '@onekeyhq/kit/src/components/DeFi/DeFiActionTxConfirmResult';
 import { useSignatureConfirm } from '@onekeyhq/kit/src/hooks/useSignatureConfirm';
 import type { IModalSendParamList } from '@onekeyhq/shared/src/routes';
 import { EOnChainHistoryTxStatus } from '@onekeyhq/shared/types/history';
 import { EEarnLabels, type IStakingInfo } from '@onekeyhq/shared/types/staking';
 import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
+
+export type IBorrowSettleResult = {
+  status: IDeFiActionTxConfirmDialogResult;
+  data: ISendTxOnSuccessData[];
+};
 
 export type IBorrowBuildTxParams = {
   amount: string;
@@ -23,8 +31,12 @@ export type IBorrowBuildTxParams = {
   stakingInfo?: IStakingInfo;
   onSetupLutReadyForRepay?: () => void;
   onBeforeNavigate?: () => void | Promise<void>;
+  onSettleResult?: (
+    result: IBorrowSettleResult,
+  ) => boolean | void | Promise<boolean | void>;
   onSuccess?: IModalSendParamList['SendConfirm']['onSuccess'];
   onFail?: IModalSendParamList['SendConfirm']['onFail'];
+  onCancel?: IModalSendParamList['SendConfirm']['onCancel'];
 };
 
 export function parseBorrowEncodedTx(tx: string): IEncodedTx {
@@ -72,6 +84,7 @@ export const handleBorrowSuccess = async ({
   networkId,
   accountId,
   stakingInfo,
+  onSettleResult,
   onSuccess,
 }: {
   data: ISendTxOnSuccessData[];
@@ -79,6 +92,9 @@ export const handleBorrowSuccess = async ({
   networkId: string;
   accountId?: string;
   stakingInfo?: IStakingInfo;
+  onSettleResult?: (
+    result: IBorrowSettleResult,
+  ) => boolean | void | Promise<boolean | void>;
   onSuccess?: IModalSendParamList['SendConfirm']['onSuccess'];
 }) => {
   const latestTxId =
@@ -110,6 +126,15 @@ export const handleBorrowSuccess = async ({
       networkId,
       data,
     });
+    if (onSettleResult) {
+      const shouldContinueSuccess = await onSettleResult({
+        status: finalStatus,
+        data,
+      });
+      if (shouldContinueSuccess === false) {
+        return;
+      }
+    }
     if (finalStatus === EOnChainHistoryTxStatus.Failed) {
       return;
     }
@@ -138,8 +163,10 @@ export function useUniversalBorrowWithdraw({
       withdrawAll,
       stakingInfo,
       onBeforeNavigate,
+      onSettleResult,
       onSuccess,
       onFail,
+      onCancel,
     }: IBorrowBuildTxParams) => {
       const resp =
         await backgroundApiProxy.serviceStaking.borrowBuildWithdrawTransaction({
@@ -169,10 +196,12 @@ export function useUniversalBorrowWithdraw({
             networkId,
             accountId,
             stakingInfo: stakingInfoWithOrderId,
+            onSettleResult,
             onSuccess,
           });
         },
         onFail,
+        onCancel,
       });
     },
     [accountId, networkId, navigationToTxConfirm],
@@ -200,8 +229,10 @@ export function useUniversalBorrowRepay({
       repayAll,
       stakingInfo,
       onBeforeNavigate,
+      onSettleResult,
       onSuccess,
       onFail,
+      onCancel,
     }: IBorrowBuildTxParams) => {
       const resp =
         await backgroundApiProxy.serviceStaking.borrowBuildRepayTransaction({
@@ -231,10 +262,12 @@ export function useUniversalBorrowRepay({
             networkId,
             accountId,
             stakingInfo: stakingInfoWithOrderId,
+            onSettleResult,
             onSuccess,
           });
         },
         onFail,
+        onCancel,
       });
     },
     [accountId, networkId, navigationToTxConfirm],

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListSkeleton.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListSkeleton.tsx
@@ -38,8 +38,9 @@ function DesktopProtocolSkeleton({ rows }: { rows: number }) {
         <Skeleton height={20} width={108} radius={4} />
       </XStack>
       <YStack pt="$3" pb="$3" gap="$3">
-        {/* Category badge — Badge "lg" sits at ~22 × 72 px in this layout. */}
-        <Skeleton height={22} width={72} radius={11} ml="$5" />
+        {/* Category badge — Badge "sm" sits at ~20 px tall with $1 (4px)
+            corner radius in this layout. */}
+        <Skeleton height={20} width={56} radius={4} ml="$5" />
         {Array.from({ length: rows }).map((_, i) => (
           <XStack
             // eslint-disable-next-line react/no-array-index-key

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolCategoryGroup.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolCategoryGroup.tsx
@@ -1,6 +1,7 @@
 import { memo, useMemo } from 'react';
 
 import { Badge, SizableText, XStack, YStack } from '@onekeyhq/components';
+import { DEFI_PORTFOLIO_DETAIL_POSITION_NAME_COLOR } from '@onekeyhq/kit/src/components/DeFi/defiPortfolioDetailStyleUtils';
 import { DeFiPositionHealthFactorRow } from '@onekeyhq/kit/src/components/DeFi/DeFiPositionHealthFactorRow';
 import type { IProtocolPositionProviderDisplayInfo } from '@onekeyhq/kit/src/components/DeFi/ProtocolPositionActionButton';
 import type { IProtocolPositionActionSuccessParams } from '@onekeyhq/kit/src/components/DeFi/ProtocolPositionActionDialog';
@@ -102,18 +103,15 @@ const ProtocolCategoryGroup = memo(
                   gap="$2"
                   minWidth={0}
                 >
-                  <Badge
-                    badgeType="success"
-                    badgeSize="lg"
-                    alignSelf="flex-start"
-                    flexShrink={0}
-                  >
+                  {/* Badge + name form a quiet block header (same as the mobile
+                      detail page); the values below carry the emphasis. */}
+                  <Badge badgeType="success" badgeSize="sm" flexShrink={0}>
                     {group.categoryLabel}
                   </Badge>
                   {positionDisplayName ? (
                     <SizableText
                       size="$bodyMdMedium"
-                      color="$text"
+                      color={DEFI_PORTFOLIO_DETAIL_POSITION_NAME_COLOR}
                       numberOfLines={1}
                       flex={1}
                       minWidth={0}
@@ -151,7 +149,7 @@ const ProtocolCategoryGroup = memo(
     return (
       <YStack gap="$2">
         <YStack px="$5" pt="$3">
-          <Badge badgeType="success" badgeSize="lg" alignSelf="flex-start">
+          <Badge badgeType="success" badgeSize="sm" alignSelf="flex-start">
             {group.categoryLabel}
           </Badge>
         </YStack>


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57640](https://onekeyhq.atlassian.net/browse/OK-57640) [OK-57652](https://onekeyhq.atlassian.net/browse/OK-57652)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Keep DeFi portfolio action dialogs mounted underneath approve/signature and transaction confirmation dialogs instead of closing them before the first confirm.
- Close the action dialog only after the final DeFi transaction pending/result sheet finishes.
- Preserve minimal UI/UX cherry-picks for DeFi portfolio action styling without bringing in the larger step-by-step flow.

## Intent & Context
This fixes the UX gap in two-step DeFi flows such as approve then repay. Previously, the DeFi portfolio action modal closed before the approve confirm opened. After the approve confirm finished, allowance polling and transaction building happened with no visible action surface before the repay confirm appeared.

Related issues: OK-57640 OK-57652

## Root Cause
The action dialog used close-before-confirm callbacks so tx confirm would not be visually blocked by the action modal. In approve plus repay flows, that made the action modal disappear before the allowance polling and repay transaction build completed, causing a blank waiting window between the approve confirm and repay confirm.

## Design Decisions
- Use the existing in-page dialog pattern so the action dialog stays in the page/modal portal and normal confirm dialogs stack above it.
- Keep the previous approve flow semantics: approve confirm still waits for allowance readiness before submitting the repay transaction.
- Avoid importing the large step-by-step UX from the earlier PR because QA requested a smaller release-safe change.
- Use button loading as the async handoff surface during approve, allowance polling, transaction building, confirm, and pending result transitions.

## Changes Detail
- ProtocolPositionActionButton passes an in-page dialog instance into DeFi action dialogs.
- ProtocolLendingActionDialogContent keeps withdraw/repay action dialogs open through approve/signature and business tx confirm, releasing loading on cancel/fail and closing only after the final pending/result sheet settles.
- ProtocolPositionActionDialog adds settle/fail/cancel hooks so generic DeFi and permit paths follow the same close timing.
- useUniversalBorrowWithdrawRepayHooks exposes settle/cancel callbacks while retaining the existing failed-transaction refresh guard.
- DeFi portfolio action UI styling tweaks from the smaller cherry-pick remain scoped to the action and list presentation files.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Modal stacking order, approve allowance polling handoff, cancel/fail loading release, and transaction pending result close timing.

## Test plan
- [x] yarn agent:check --profile commit
- [x] git diff --check
- [x] prettier --check on changed files
- [x] npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings on changed files
- [x] yarn jest packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.test.tsx packages/kit/src/views/Borrow/hooks/useUniversalBorrowHooks.test.tsx packages/kit/src/components/DeFi/defiPortfolioDetailStyleUtils.test.ts --runInBand
- [ ] QA verify approve then repay flow: action modal remains below approve confirm, loading bridges the allowance wait, repay confirm appears above it, and the action modal closes after the final pending/result sheet.
- [ ] QA verify permit/signature DeFi action flow follows the same modal stacking and close timing.

[OK-57640]: https://onekeyhq.atlassian.net/browse/OK-57640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-57652]: https://onekeyhq.atlassian.net/browse/OK-57652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ