### PR TITLE
feat: tabular numerals and localized thousands separators across trading UI

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -1492,3 +1492,6 @@ retryably
 
 # @mysten/sui 2.x package name
 mysten
+
+# OpenType tabular-figures feature tag
+tnum

--- a/packages/components/src/composite/SegmentSlider/index.tsx
+++ b/packages/components/src/composite/SegmentSlider/index.tsx
@@ -586,6 +586,7 @@ function SegmentSliderComponent({
       fontSize: 12,
       lineHeight: '16px',
       fontWeight: 600,
+      fontVariantNumeric: 'tabular-nums',
       opacity: 0,
       transition: 'opacity 150ms ease',
       pointerEvents: 'none',

--- a/packages/components/src/content/NetworkStatusBadge/index.tsx
+++ b/packages/components/src/content/NetworkStatusBadge/index.tsx
@@ -4,11 +4,13 @@ import type { ComponentProps, ReactElement } from 'react';
 import { useIntl } from 'react-intl';
 
 import { Stack } from '@onekeyhq/components/src/primitives';
+import {
+  TABULAR_NUMS,
+  getFontVariantStyle,
+} from '@onekeyhq/components/src/utils/tabularNums';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { Badge } from '../Badge';
-
-const fontVariant: ['tabular-nums'] = ['tabular-nums'];
 
 export type INetworkStatusBadgeProps = {
   connected: boolean;
@@ -89,8 +91,7 @@ export function NetworkStatusBadge({
         <Badge.Text
           flex={1}
           size="$bodySmMedium"
-          fontFamily="$monoRegular"
-          fontVariant={fontVariant}
+          style={getFontVariantStyle(TABULAR_NUMS)}
           minWidth={40}
           textAlign="right"
         >

--- a/packages/components/src/content/NumberSizeableText/index.tsx
+++ b/packages/components/src/content/NumberSizeableText/index.tsx
@@ -9,6 +9,7 @@ import { numberFormatAsRenderText } from '@onekeyhq/shared/src/utils/numberUtils
 
 import { SizableText } from '../../primitives/SizeableText';
 import { getFontSize, getFontToken } from '../../utils/getFontSize';
+import { TABULAR_NUMS } from '../../utils/tabularNums';
 
 import type { ISizableTextProps } from '../../primitives';
 
@@ -47,6 +48,10 @@ export function NumberSizeableText({
   minWidth,
   maxWidth,
   width,
+  // This component only ever renders formatter-produced numerals, so equal-width
+  // digits are the right default — ticking values stop jittering and column
+  // digits align. Callers can still override per-site.
+  fontVariant = TABULAR_NUMS,
   ...props
 }: INumberSizeableTextProps) {
   const layoutProps = {
@@ -124,24 +129,34 @@ export function NumberSizeableText({
   if (hideValue) {
     if (formatter === 'balance' && formatterOptions?.tokenSymbol) {
       return (
-        <SizableText {...props} {...layoutProps}>
+        <SizableText fontVariant={fontVariant} {...props} {...layoutProps}>
           **** {formatterOptions.tokenSymbol}
         </SizableText>
       );
     }
     return (
-      <SizableText {...props} {...layoutProps}>
+      <SizableText fontVariant={fontVariant} {...props} {...layoutProps}>
         ****
       </SizableText>
     );
   }
 
   return typeof result === 'string' ? (
-    <SizableText {...props} {...layoutProps} {...contentStyle}>
+    <SizableText
+      fontVariant={fontVariant}
+      {...props}
+      {...layoutProps}
+      {...contentStyle}
+    >
       {result}
     </SizableText>
   ) : (
-    <SizableText {...props} {...layoutProps} {...contentStyle}>
+    <SizableText
+      fontVariant={fontVariant}
+      {...props}
+      {...layoutProps}
+      {...contentStyle}
+    >
       {/* eslint-disable no-nested-ternary */}
       {result.map((r, index) =>
         typeof r === 'string' ? (
@@ -155,7 +170,12 @@ export function NumberSizeableText({
             {r}
           </SizableText>
         ) : 'type' in r && r.type === 'decimal' ? (
-          <SizableText key={index} {...props} {...mergedDecimalTextStyle}>
+          <SizableText
+            key={index}
+            fontVariant={fontVariant}
+            {...props}
+            {...mergedDecimalTextStyle}
+          >
             {r.value}
           </SizableText>
         ) : (

--- a/packages/components/src/primitives/SizeableText/index.tsx
+++ b/packages/components/src/primitives/SizeableText/index.tsx
@@ -2,14 +2,35 @@ import { SizableText as TamaguiSizableText } from '@tamagui/text';
 
 import { type SizableTextProps } from '@onekeyhq/components/src/shared/tamagui';
 
+import { getFontVariantStyle } from '../../utils/tabularNums';
+
 export const StyledSizableText = TamaguiSizableText;
 
-export function SizableText({ size = '$bodyMd', ...props }: SizableTextProps) {
+export function SizableText({
+  size = '$bodyMd',
+  fontVariant,
+  style,
+  ...props
+}: SizableTextProps) {
+  // Tamagui silently drops the RN `fontVariant` prop, so numeric variants
+  // (tabular-nums etc.) never reach the renderer — re-route it through the
+  // `style` prop: RN style `fontVariant` on native, CSS `font-variant-numeric`
+  // on web. Caller-provided `style` still wins on conflicts.
+  let mergedStyle = style;
+  const variantStyle = getFontVariantStyle(fontVariant);
+  if (variantStyle) {
+    if (Array.isArray(style)) {
+      mergedStyle = [variantStyle, ...style];
+    } else {
+      mergedStyle = style ? [variantStyle, style] : variantStyle;
+    }
+  }
   return (
     <StyledSizableText
       allowFontScaling={false}
       maxFontSizeMultiplier={1}
       size={size}
+      style={mergedStyle}
       {...props}
     />
   );

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -2,4 +2,5 @@ export * from './DebugRenderTracker';
 export * from './getFontSize';
 export * from './scale';
 export * from './sidebar';
+export * from './tabularNums';
 export * from './webFontFamily';

--- a/packages/components/src/utils/tabularNums.ts
+++ b/packages/components/src/utils/tabularNums.ts
@@ -1,0 +1,77 @@
+import type { CSSProperties } from 'react';
+
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import type { TextStyle } from 'react-native';
+
+/**
+ * Tabular (equal-width) figures for numeric text.
+ *
+ * Apply as `fontVariant={TABULAR_NUMS}` on `SizableText` / `NumberSizeableText`
+ * (and any Tamagui text) so every digit shares one advance width — columns of
+ * numbers stay aligned and a value doesn't reflow left/right as it ticks.
+ *
+ * Prefer this over switching to a monospace font family (`$monoRegular` /
+ * `$monoMedium`): a mono font also mono-widths letters (typewriter look),
+ * whereas tabular-nums keeps the app font's natural proportional letters and
+ * only equalizes digits. The app font (Roobert) ships the `tnum` OpenType
+ * feature, so this renders correctly on iOS, Android and web.
+ *
+ * Monospace is still the right choice for addresses / hashes / mnemonics /
+ * codes, where character (not just digit) alignment matters — do NOT replace
+ * those with tabular-nums.
+ */
+export const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
+
+type IFontVariantStyle = CSSProperties | TextStyle;
+
+function buildFontVariantStyle(
+  fontVariant: NonNullable<TextStyle['fontVariant']>,
+): IFontVariantStyle {
+  if (platformEnv.isNative) {
+    return Object.freeze({ fontVariant });
+  }
+  const style: CSSProperties = {};
+  const numericVariants = fontVariant.filter((v) => v.endsWith('-nums'));
+  if (numericVariants.length > 0) {
+    style.fontVariantNumeric = numericVariants.join(' ');
+  }
+  if (fontVariant.includes('small-caps')) {
+    style.fontVariantCaps = 'small-caps';
+  }
+  return Object.freeze(style);
+}
+
+const TABULAR_NUMS_STYLE = buildFontVariantStyle(TABULAR_NUMS);
+
+const fontVariantStyleCache = new WeakMap<
+  NonNullable<TextStyle['fontVariant']>,
+  IFontVariantStyle
+>();
+
+/**
+ * Translate the RN `fontVariant` array into a platform-appropriate style
+ * object (RN style `fontVariant` on native, CSS `font-variant-numeric` /
+ * `font-variant-caps` on web), since Tamagui silently drops the raw
+ * `fontVariant` prop.
+ *
+ * Results are cached per array reference (with a hoisted fast path for
+ * `TABULAR_NUMS`), so the returned object is reference-stable across renders.
+ */
+export function getFontVariantStyle(
+  // Tamagui widens the prop with an extra 'unset' string literal.
+  fontVariant: TextStyle['fontVariant'] | 'unset',
+): IFontVariantStyle | undefined {
+  if (fontVariant === TABULAR_NUMS) {
+    return TABULAR_NUMS_STYLE;
+  }
+  if (!Array.isArray(fontVariant) || fontVariant.length === 0) {
+    return undefined;
+  }
+  let cached = fontVariantStyleCache.get(fontVariant);
+  if (!cached) {
+    cached = buildFontVariantStyle(fontVariant);
+    fontVariantStyleCache.set(fontVariant, cached);
+  }
+  return cached;
+}

--- a/packages/kit/src/components/CountDownCalendarAlert/index.tsx
+++ b/packages/kit/src/components/CountDownCalendarAlert/index.tsx
@@ -3,7 +3,14 @@ import { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import type { ISizableTextProps } from '@onekeyhq/components';
-import { Alert, Badge, SizableText, XStack } from '@onekeyhq/components';
+import {
+  Alert,
+  Badge,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  getFontVariantStyle,
+} from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 
 export interface ICountDownCalendarAlertProps {
@@ -44,7 +51,11 @@ function TimeItem({
   return (
     <>
       <Badge badgeType="info">
-        <Badge.Text size="$bodyMdMedium" color="$textInfo">
+        <Badge.Text
+          size="$bodyMdMedium"
+          color="$textInfo"
+          style={getFontVariantStyle(TABULAR_NUMS)}
+        >
           {formattedTimeLeft}
         </Badge.Text>
       </Badge>

--- a/packages/kit/src/components/Resource/TronResource.tsx
+++ b/packages/kit/src/components/Resource/TronResource.tsx
@@ -13,6 +13,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useDialogInstance,
@@ -247,7 +248,7 @@ function DonutArc({
         strokeWidth={DONUT_STROKE}
         progressColor={DONUT_COLOR}
       >
-        <SizableText size="$bodyXs" fontWeight="600">
+        <SizableText size="$bodyXs" fontWeight="600" fontVariant={TABULAR_NUMS}>
           {`${Math.round(percentage)}%`}
         </SizableText>
       </CircleProgress>

--- a/packages/kit/src/views/Borrow/components/BorrowAssetSelectPopover/index.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowAssetSelectPopover/index.tsx
@@ -6,6 +6,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -64,8 +65,14 @@ function AssetRow({
 
       {/* Amount column */}
       <YStack alignItems="flex-end" flexShrink={0}>
-        <SizableText size="$bodyMd">{balance?.title?.text ?? '-'}</SizableText>
-        <SizableText size="$bodySm" color="$textSubdued">
+        <SizableText size="$bodyMd" fontVariant={TABULAR_NUMS}>
+          {balance?.title?.text ?? '-'}
+        </SizableText>
+        <SizableText
+          size="$bodySm"
+          color="$textSubdued"
+          fontVariant={TABULAR_NUMS}
+        >
           {balance?.description?.text ?? '-'}
         </SizableText>
       </YStack>

--- a/packages/kit/src/views/Borrow/components/BorrowBonusTooltip.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowBonusTooltip.tsx
@@ -11,6 +11,7 @@ import {
   Popover,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -131,6 +132,7 @@ export const BorrowBonusTooltip = ({
                     text={data.totalReceived.description}
                     size="$headingXl"
                     color="$text"
+                    fontVariant={TABULAR_NUMS}
                   />
                   {data.totalReceived.button ? (
                     <XStack
@@ -298,6 +300,7 @@ export const BorrowBonusTooltip = ({
                         { number: endsInDays },
                       ),
                     }}
+                    fontVariant={TABULAR_NUMS}
                   />
                 </XStack>
                 {!isEmpty(data.data.rewards) ? (

--- a/packages/kit/src/views/Borrow/components/BorrowHealthFactorTooltip.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowHealthFactorTooltip.tsx
@@ -7,6 +7,7 @@ import {
   Icon,
   Popover,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -107,7 +108,11 @@ export const BorrowHealthFactorTooltip = ({
           <XStack jc="space-between" ai="center">
             <XStack ai="center" gap="$2">
               <SizableText size="$headingMd">{healthFactorLabel}</SizableText>
-              <SizableText size="$headingMd" color={valueColor}>
+              <SizableText
+                size="$headingMd"
+                color={valueColor}
+                fontVariant={TABULAR_NUMS}
+              >
                 {detail.value}
               </SizableText>
             </XStack>

--- a/packages/kit/src/views/Borrow/components/BorrowRepayPosition.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowRepayPosition.tsx
@@ -18,6 +18,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -232,7 +233,9 @@ function RemainingCollateralInfo({
   return (
     <BorrowInfoItem title={data.title.text}>
       <YStack alignItems="flex-end">
-        <SizableText size="$bodyMdMedium">{data.description.text}</SizableText>
+        <SizableText size="$bodyMdMedium" fontVariant={TABULAR_NUMS}>
+          {data.description.text}
+        </SizableText>
       </YStack>
     </BorrowInfoItem>
   );
@@ -936,7 +939,7 @@ function RepayWithCollateralForm({
                 </XStack>
                 <XStack alignItems="center" justifyContent="space-between">
                   <Stack flex={1} px="$3.5" pt="$3" pb="$2.5">
-                    <SizableText size="$heading3xl">
+                    <SizableText size="$heading3xl" fontVariant={TABULAR_NUMS}>
                       {usingAmountText}
                     </SizableText>
                   </Stack>
@@ -949,7 +952,11 @@ function RepayWithCollateralForm({
                   alignItems="center"
                 >
                   {priceImpactInfo?.fiatValue ? (
-                    <SizableText size="$bodySm" color="$textSubdued">
+                    <SizableText
+                      size="$bodySm"
+                      color="$textSubdued"
+                      fontVariant={TABULAR_NUMS}
+                    >
                       <NumberSizeableText
                         size="$bodySm"
                         color="$textSubdued"
@@ -963,7 +970,11 @@ function RepayWithCollateralForm({
                       {` (${priceImpactInfo.pctFormatted})`}
                     </SizableText>
                   ) : (
-                    <SizableText size="$bodySm" color="$textSubdued">
+                    <SizableText
+                      size="$bodySm"
+                      color="$textSubdued"
+                      fontVariant={TABULAR_NUMS}
+                    >
                       {priceImpactInfo?.pctFormatted ?? '-'}
                     </SizableText>
                   )}
@@ -1105,6 +1116,7 @@ function RepayWithCollateralForm({
                       text={{ text: quoteSummary }}
                       color="$text"
                       size="$bodyMdMedium"
+                      fontVariant={TABULAR_NUMS}
                     />
                   }
                 />
@@ -1155,7 +1167,7 @@ function RepayWithCollateralForm({
                 userSelect="none"
                 onPress={handleOpenSlippage}
               >
-                <SizableText size="$bodyMdMedium">
+                <SizableText size="$bodyMdMedium" fontVariant={TABULAR_NUMS}>
                   {displaySlippageText}
                 </SizableText>
                 <Icon
@@ -1175,7 +1187,7 @@ function RepayWithCollateralForm({
                   />
                 }
               >
-                <SizableText size="$bodyMdMedium">
+                <SizableText size="$bodyMdMedium" fontVariant={TABULAR_NUMS}>
                   {transactionConfirmation.fee.description.text}
                 </SizableText>
               </BorrowInfoItem>

--- a/packages/kit/src/views/Borrow/components/BorrowTableList/AmountField.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowTableList/AmountField.tsx
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js';
 
+import { TABULAR_NUMS } from '@onekeyhq/components';
 import type { IEarnText } from '@onekeyhq/shared/types/staking';
 
 import { EarnText } from '../../../Staking/components/ProtocolDetails/EarnText';
@@ -16,9 +17,19 @@ export const AmountField = ({ title, description }: IAmountFieldProps) => {
 
   return (
     <FieldWrapper ai="flex-end">
-      <EarnText text={title} size="$bodyMdMedium" color="$text" />
+      <EarnText
+        text={title}
+        size="$bodyMdMedium"
+        color="$text"
+        fontVariant={TABULAR_NUMS}
+      />
       {!isZero ? (
-        <EarnText text={description} size="$bodySm" color="$textSubdued" />
+        <EarnText
+          text={description}
+          size="$bodySm"
+          color="$textSubdued"
+          fontVariant={TABULAR_NUMS}
+        />
       ) : null}
     </FieldWrapper>
   );

--- a/packages/kit/src/views/Borrow/components/BorrowTableList/ApyTextV2.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowTableList/ApyTextV2.tsx
@@ -12,6 +12,7 @@ import {
   ScrollView,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
   YStack,
@@ -338,6 +339,7 @@ function TextWithDottedUnderline({
         textAlign="right"
         dashColor={textColor}
         dashThickness={1}
+        fontVariant={TABULAR_NUMS}
       >
         {text}
       </DashText>
@@ -361,7 +363,12 @@ function TextWithTrigger({
   if (triggerMode === 'icon') {
     return (
       <XStack alignItems="center" gap="$1">
-        <SizableText size={size} textAlign="right" color={color || '$text'}>
+        <SizableText
+          size={size}
+          textAlign="right"
+          color={color || '$text'}
+          fontVariant={TABULAR_NUMS}
+        >
           {text}
         </SizableText>
         {showChevron ? (
@@ -481,6 +488,7 @@ export const ApyTextV2 = ({
         textAlign="right"
         color={deprecated.color || '$textSubdued'}
         textDecorationLine="line-through"
+        fontVariant={TABULAR_NUMS}
       >
         {deprecated.text}
       </SizableText>
@@ -535,7 +543,12 @@ export const ApyTextV2 = ({
 
   return (
     <YStack ai="flex-end">
-      <SizableText size="$bodyMdMedium" textAlign="right" color={displayColor}>
+      <SizableText
+        size="$bodyMdMedium"
+        textAlign="right"
+        color={displayColor}
+        fontVariant={TABULAR_NUMS}
+      >
         {displayText}
       </SizableText>
     </YStack>

--- a/packages/kit/src/views/Borrow/components/BorrowTableList/AssetField.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowTableList/AssetField.tsx
@@ -1,4 +1,11 @@
-import { Icon, Image, SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  Icon,
+  Image,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import { EarnText } from '@onekeyhq/kit/src/views/Staking/components/ProtocolDetails/EarnText';
 import type { IBorrowToken, IEarnText } from '@onekeyhq/shared/types/staking';
@@ -51,6 +58,7 @@ export const AssetField = ({
                 size="$bodySmMedium"
                 color="$textSuccess"
                 whiteSpace="nowrap"
+                fontVariant={TABULAR_NUMS}
               />
               <Image
                 src={platformBonusApy.logoURI}

--- a/packages/kit/src/views/Borrow/components/BorrowTableList/AssetWithAmountField.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowTableList/AssetWithAmountField.tsx
@@ -1,4 +1,11 @@
-import { Icon, Image, SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  Icon,
+  Image,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import { EarnText } from '@onekeyhq/kit/src/views/Staking/components/ProtocolDetails/EarnText';
 import type { IBorrowToken, IEarnText } from '@onekeyhq/shared/types/staking';
@@ -58,6 +65,7 @@ export const AssetWithAmountField = ({
                 size="$bodySmMedium"
                 color="$textSuccess"
                 whiteSpace="nowrap"
+                fontVariant={TABULAR_NUMS}
               />
               <Image
                 src={platformBonusApy.logoURI}
@@ -71,12 +79,18 @@ export const AssetWithAmountField = ({
               <Icon name="WalletOutline" size="$3.5" color="$iconSubdued" />
             ) : null}
             <EarnText text={amountLabel} size="$bodySm" color="$textSubdued" />
-            <EarnText text={amount} size="$bodySm" color="$textSubdued" />
+            <EarnText
+              text={amount}
+              size="$bodySm"
+              color="$textSubdued"
+              fontVariant={TABULAR_NUMS}
+            />
             {amountDescription ? (
               <EarnText
                 text={{ text: `(${amountDescription.text})` }}
                 size="$bodySm"
                 color="$textSubdued"
+                fontVariant={TABULAR_NUMS}
               />
             ) : null}
           </XStack>

--- a/packages/kit/src/views/Borrow/components/BorrowedCard.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowedCard.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { XStack, useMedia } from '@onekeyhq/components';
+import { TABULAR_NUMS, XStack, useMedia } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IBorrowReserveItem } from '@onekeyhq/shared/types/staking';
@@ -50,7 +50,10 @@ const BorrowedHeader = ({
               color: '$textSubdued',
             }}
           />
-          <EarnText text={data?.borrowedBalance?.title} />
+          <EarnText
+            text={data?.borrowedBalance?.title}
+            fontVariant={TABULAR_NUMS}
+          />
         </XStack>
       ) : null}
       {data?.borrowedApy?.title ? (
@@ -62,7 +65,10 @@ const BorrowedHeader = ({
               color: '$textSubdued',
             }}
           />
-          <EarnText text={data?.borrowedApy?.title} />
+          <EarnText
+            text={data?.borrowedApy?.title}
+            fontVariant={TABULAR_NUMS}
+          />
           <EarnTooltip tooltip={data?.borrowedApy?.tooltip} />
         </XStack>
       ) : null}

--- a/packages/kit/src/views/Borrow/components/CircleProgress.tsx
+++ b/packages/kit/src/views/Borrow/components/CircleProgress.tsx
@@ -2,7 +2,13 @@ import { type ReactNode, useMemo } from 'react';
 
 import Svg, { Circle } from 'react-native-svg';
 
-import { SizableText, XStack, YStack, useTheme } from '@onekeyhq/components';
+import {
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+  useTheme,
+} from '@onekeyhq/components';
 
 interface ICircleProgressProps {
   percentage: number;
@@ -87,7 +93,11 @@ export function CircleProgress({
         justifyContent="center"
       >
         {children ?? (
-          <SizableText size="$bodyMdMedium" color="$text">
+          <SizableText
+            size="$bodyMdMedium"
+            color="$text"
+            fontVariant={TABULAR_NUMS}
+          >
             {percentageText}%
           </SizableText>
         )}

--- a/packages/kit/src/views/Borrow/components/HealthFactor.tsx
+++ b/packages/kit/src/views/Borrow/components/HealthFactor.tsx
@@ -5,6 +5,7 @@ import {
   LinearGradient,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   YStack,
   useTheme,
 } from '@onekeyhq/components';
@@ -245,6 +246,7 @@ export const HealthFactor = ({
               size="$bodySmMedium"
               whiteSpace="nowrap"
               color={valueColor ?? '$text'}
+              fontVariant={TABULAR_NUMS}
             >
               {displayText}
             </SizableText>

--- a/packages/kit/src/views/Borrow/components/Overview.tsx
+++ b/packages/kit/src/views/Borrow/components/Overview.tsx
@@ -15,10 +15,12 @@ import {
   IconButton,
   SizableText,
   Skeleton,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useMedia,
 } from '@onekeyhq/components';
+import type { ISizableTextProps } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -57,6 +59,7 @@ const OverviewItem = ({
   tooltip,
   needDivider,
   isLoading,
+  fontVariant,
 }: {
   title: IEarnText;
   text?: IEarnText;
@@ -64,6 +67,9 @@ const OverviewItem = ({
   tooltip?: IEarnTooltip | React.ReactNode;
   needDivider?: boolean;
   isLoading?: boolean;
+  /** Set by call sites whose `text` binding is an explicit amount — the
+   *  generic prop itself must not assume numeric content. */
+  fontVariant?: ISizableTextProps['fontVariant'];
 }) => {
   return (
     <>
@@ -75,7 +81,12 @@ const OverviewItem = ({
           ) : (
             <>
               {text ? (
-                <EarnText text={text} size="$headingLg" color="$textText" />
+                <EarnText
+                  text={text}
+                  size="$headingLg"
+                  color="$textText"
+                  fontVariant={fontVariant}
+                />
               ) : null}
               {isValidElement(tooltip) ? (
                 tooltip
@@ -352,6 +363,7 @@ export const Overview = ({
                 }
                 size="$heading3xl"
                 color="$textText"
+                fontVariant={TABULAR_NUMS}
               />
               <IconButton
                 testID={BorrowTestIDs.overviewRefreshBtn}
@@ -369,6 +381,7 @@ export const Overview = ({
                   text={reserves.data.overview.netApy}
                   size="$bodyMdMedium"
                   color="$textText"
+                  fontVariant={TABULAR_NUMS}
                 />
                 <SizableText size="$bodyMd" color="$textSubdued">
                   {labels.netApy}
@@ -429,6 +442,7 @@ export const Overview = ({
                       }
                       size="$headingLg"
                       color="$textText"
+                      fontVariant={TABULAR_NUMS}
                     />
                     {healthFactorData?.healthFactor ? (
                       <XStack mt="$1">
@@ -459,6 +473,7 @@ export const Overview = ({
                   }
                   size="$headingLg"
                   color="$textText"
+                  fontVariant={TABULAR_NUMS}
                 />
                 <XStack mt="$1">
                   <BorrowBonusTooltip
@@ -529,6 +544,7 @@ export const Overview = ({
     <XStack mt="$2" mb={showBottomSpacing ? '$10' : undefined} ai="center">
       <OverviewItem
         needDivider
+        fontVariant={TABULAR_NUMS}
         title={{ text: labels.netWorth }}
         text={
           reserves.data?.overview?.netWorth ?? {
@@ -550,6 +566,7 @@ export const Overview = ({
 
       <OverviewItem
         needDivider
+        fontVariant={TABULAR_NUMS}
         title={{ text: labels.netApy }}
         text={
           reserves.data?.overview?.netApy ?? {
@@ -560,6 +577,7 @@ export const Overview = ({
       />
       <OverviewItem
         needDivider
+        fontVariant={TABULAR_NUMS}
         title={{ text: labels.healthFactor }}
         text={
           isHealthFactorLoading && !healthFactorData
@@ -582,6 +600,7 @@ export const Overview = ({
       />
       <OverviewItem
         needDivider
+        fontVariant={TABULAR_NUMS}
         title={
           reserves.data?.overview?.platformBonus?.data?.title ?? {
             text: labels.platformBonus,

--- a/packages/kit/src/views/Borrow/components/SuppliedCard.tsx
+++ b/packages/kit/src/views/Borrow/components/SuppliedCard.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { XStack, useMedia } from '@onekeyhq/components';
+import { TABULAR_NUMS, XStack, useMedia } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { IBorrowReserveItem } from '@onekeyhq/shared/types/staking';
@@ -50,7 +50,11 @@ const SuppliedHeader = ({
               color: '$textSubdued',
             }}
           />
-          <EarnText text={data?.suppliedBalance?.title} size="$bodyMdMedium" />
+          <EarnText
+            text={data?.suppliedBalance?.title}
+            size="$bodyMdMedium"
+            fontVariant={TABULAR_NUMS}
+          />
         </XStack>
       ) : null}
       {data?.suppliedApy?.title ? (
@@ -62,7 +66,11 @@ const SuppliedHeader = ({
               color: '$textSubdued',
             }}
           />
-          <EarnText text={data?.suppliedApy?.title} size="$bodyMdMedium" />
+          <EarnText
+            text={data?.suppliedApy?.title}
+            size="$bodyMdMedium"
+            fontVariant={TABULAR_NUMS}
+          />
           <EarnTooltip tooltip={data?.suppliedApy?.tooltip} />
         </XStack>
       ) : null}

--- a/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ApyChartSection.tsx
+++ b/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ApyChartSection.tsx
@@ -2,7 +2,13 @@ import { memo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { SizableText, XStack, YStack, useMedia } from '@onekeyhq/components';
+import {
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+  useMedia,
+} from '@onekeyhq/components';
 import { ApyChartBase } from '@onekeyhq/kit/src/views/Staking/components/ApyChartBase';
 import { GridItem } from '@onekeyhq/kit/src/views/Staking/components/ProtocolDetails/GridItemV2';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -90,7 +96,7 @@ function ApyChartSectionComponent({
       {/* APY Chart */}
       <YStack gap="$3">
         <XStack jc="space-between" ai="center">
-          <SizableText size="$headingXl">
+          <SizableText size="$headingXl" fontVariant={TABULAR_NUMS}>
             {Number(apyValue).toFixed(2)}% {apyLabel}
           </SizableText>
           {media.gtSm ? (

--- a/packages/kit/src/views/Borrow/pages/ReserveDetails/components/InterestRateModelChartShared.tsx
+++ b/packages/kit/src/views/Borrow/pages/ReserveDetails/components/InterestRateModelChartShared.tsx
@@ -2,7 +2,13 @@ import { useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { Icon, SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  Icon,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import type { ColorTokens } from '@tamagui/core';
@@ -152,7 +158,7 @@ export function InterestRateModelHeader({
   utilizationRatioLabel,
 }: IInterestRateModelHeaderProps) {
   return (
-    <SizableText size="$headingXl">
+    <SizableText size="$headingXl" fontVariant={TABULAR_NUMS}>
       {utilizationPercentage} {utilizationRatioLabel}
     </SizableText>
   );
@@ -245,7 +251,12 @@ export function InterestRateModelTooltip({
           <SizableText size="$bodySm" color="$textSubdued" whiteSpace="nowrap">
             {utilizationRatioLabel}
           </SizableText>
-          <SizableText size="$bodySmMedium" color="$text" whiteSpace="nowrap">
+          <SizableText
+            size="$bodySmMedium"
+            color="$text"
+            whiteSpace="nowrap"
+            fontVariant={TABULAR_NUMS}
+          >
             {(hoverData.utilizationRatio * 100).toFixed(2)}%
           </SizableText>
         </XStack>
@@ -253,7 +264,12 @@ export function InterestRateModelTooltip({
           <SizableText size="$bodySm" color="$textSubdued" whiteSpace="nowrap">
             {borrowApyLabel}
           </SizableText>
-          <SizableText size="$bodySmMedium" color="$text" whiteSpace="nowrap">
+          <SizableText
+            size="$bodySmMedium"
+            color="$text"
+            whiteSpace="nowrap"
+            fontVariant={TABULAR_NUMS}
+          >
             {hoverData.borrowApy.toFixed(2)}%
           </SizableText>
         </XStack>
@@ -261,7 +277,12 @@ export function InterestRateModelTooltip({
           <SizableText size="$bodySm" color="$textSubdued" whiteSpace="nowrap">
             {supplyApyLabel}
           </SizableText>
-          <SizableText size="$bodySmMedium" color="$text" whiteSpace="nowrap">
+          <SizableText
+            size="$bodySmMedium"
+            color="$text"
+            whiteSpace="nowrap"
+            fontVariant={TABULAR_NUMS}
+          >
             {hoverData.supplyApy.toFixed(2)}%
           </SizableText>
         </XStack>

--- a/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ManagePositionPart.tsx
+++ b/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ManagePositionPart.tsx
@@ -7,6 +7,7 @@ import {
   Divider,
   Icon,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -126,11 +127,13 @@ export const ManagePositionPart = ({
               text={userInfo?.walletBalance?.title}
               size="$headingXl"
               color="$text"
+              fontVariant={TABULAR_NUMS}
             />
             <EarnText
               text={userInfo?.walletBalance?.description}
               size="$bodyMd"
               color="$textSubdued"
+              fontVariant={TABULAR_NUMS}
             />
           </YStack>
           {userInfo?.walletBalance?.button ? (
@@ -167,11 +170,13 @@ export const ManagePositionPart = ({
               text={userInfo?.availableBorrowBalance?.title}
               size="$headingXl"
               color="$text"
+              fontVariant={TABULAR_NUMS}
             />
             <EarnText
               text={userInfo?.availableBorrowBalance?.description}
               size="$bodyMd"
               color="$textSubdued"
+              fontVariant={TABULAR_NUMS}
             />
           </YStack>
           {userInfo?.availableBorrowBalance?.button ? (
@@ -201,9 +206,14 @@ export const ManagePositionPart = ({
             text={userInfo?.suppliedBalance?.title}
             size="$bodyMdMedium"
             color="$text"
+            fontVariant={TABULAR_NUMS}
           />
           {userInfo?.suppliedBalance?.description?.text ? (
-            <SizableText size="$bodyMd" color="$textSubdued">
+            <SizableText
+              size="$bodyMd"
+              color="$textSubdued"
+              fontVariant={TABULAR_NUMS}
+            >
               ({userInfo.suppliedBalance.description.text})
             </SizableText>
           ) : null}
@@ -218,9 +228,14 @@ export const ManagePositionPart = ({
             text={userInfo?.borrowedBalance?.title}
             size="$bodyMdMedium"
             color="$text"
+            fontVariant={TABULAR_NUMS}
           />
           {userInfo?.borrowedBalance?.description?.text ? (
-            <SizableText size="$bodyMd" color="$textSubdued">
+            <SizableText
+              size="$bodyMd"
+              color="$textSubdued"
+              fontVariant={TABULAR_NUMS}
+            >
               ({userInfo.borrowedBalance.description.text})
             </SizableText>
           ) : null}

--- a/packages/kit/src/views/Borrow/pages/ReserveDetails/components/PlatformBonusSection.tsx
+++ b/packages/kit/src/views/Borrow/pages/ReserveDetails/components/PlatformBonusSection.tsx
@@ -7,6 +7,7 @@ import {
   Divider,
   Icon,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useMedia,
@@ -57,7 +58,11 @@ export function PlatformBonusSection({
                   id: ETranslations.earn_event_ends_in,
                 })}
               </SizableText>
-              <SizableText size="$bodySmMedium" color="$textSuccess">
+              <SizableText
+                size="$bodySmMedium"
+                color="$textSuccess"
+                fontVariant={TABULAR_NUMS}
+              >
                 {intl.formatMessage(
                   { id: ETranslations.earn_number_days },
                   { number: endsInDays },

--- a/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ReserveProtocolHeader.native.tsx
+++ b/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ReserveProtocolHeader.native.tsx
@@ -2,7 +2,13 @@ import { Fragment } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { Image, SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  Image,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import { EarnText } from '@onekeyhq/kit/src/views/Staking/components/ProtocolDetails/EarnText';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -33,7 +39,9 @@ const HeaderField = ({
       <SizableText size="$bodyMd" color="$textSubdued">
         {title}
       </SizableText>
-      <SizableText size="$bodyLgMedium">{description}</SizableText>
+      <SizableText size="$bodyLgMedium" fontVariant={TABULAR_NUMS}>
+        {description}
+      </SizableText>
     </YStack>
   );
 };

--- a/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ReserveProtocolHeader.tsx
+++ b/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ReserveProtocolHeader.tsx
@@ -6,6 +6,7 @@ import {
   IconButton,
   Image,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useMedia,
@@ -41,7 +42,9 @@ const HeaderField = ({
       <SizableText size="$bodyMd" color="$textSubdued">
         {title}
       </SizableText>
-      <SizableText size="$bodyLgMedium">{description}</SizableText>
+      <SizableText size="$bodyLgMedium" fontVariant={TABULAR_NUMS}>
+        {description}
+      </SizableText>
     </YStack>
   );
 };
@@ -182,7 +185,9 @@ export const ReserveProtocolHeader = ({
               <SizableText size="$bodySm" color="$textSubdued">
                 {`${labels.oraclePrice}:`}
               </SizableText>
-              <SizableText size="$bodySmMedium">{oraclePrice}</SizableText>
+              <SizableText size="$bodySmMedium" fontVariant={TABULAR_NUMS}>
+                {oraclePrice}
+              </SizableText>
             </XStack>
           ) : null}
         </XStack>

--- a/packages/kit/src/views/Borrow/pages/ReserveDetails/components/UserInfoSection.tsx
+++ b/packages/kit/src/views/Borrow/pages/ReserveDetails/components/UserInfoSection.tsx
@@ -1,6 +1,6 @@
 import { useIntl } from 'react-intl';
 
-import { Divider, XStack, YStack } from '@onekeyhq/components';
+import { Divider, TABULAR_NUMS, XStack, YStack } from '@onekeyhq/components';
 import { EarnText } from '@onekeyhq/kit/src/views/Staking/components/ProtocolDetails/EarnText';
 import { GridItem } from '@onekeyhq/kit/src/views/Staking/components/ProtocolDetails/GridItemV2';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -48,6 +48,7 @@ export const UserInfoSection = ({ userInfo }: IUserInfoSectionProps) => {
                 text={walletBalance.description}
                 size="$bodySm"
                 color="$textSubdued"
+                fontVariant={TABULAR_NUMS}
               />
             ) : null
           }
@@ -62,6 +63,7 @@ export const UserInfoSection = ({ userInfo }: IUserInfoSectionProps) => {
                 text={suppliedBalance.description}
                 size="$bodySm"
                 color="$textSubdued"
+                fontVariant={TABULAR_NUMS}
               />
             ) : null
           }
@@ -76,6 +78,7 @@ export const UserInfoSection = ({ userInfo }: IUserInfoSectionProps) => {
                 text={borrowedBalance.description}
                 size="$bodySm"
                 color="$textSubdued"
+                fontVariant={TABULAR_NUMS}
               />
             ) : null
           }
@@ -90,6 +93,7 @@ export const UserInfoSection = ({ userInfo }: IUserInfoSectionProps) => {
                 text={availableBorrowBalance.description}
                 size="$bodySm"
                 color="$textSubdued"
+                fontVariant={TABULAR_NUMS}
               />
             ) : null
           }

--- a/packages/kit/src/views/Earn/components/AprText.tsx
+++ b/packages/kit/src/views/Earn/components/AprText.tsx
@@ -1,6 +1,12 @@
 import type { ComponentProps } from 'react';
 
-import { Icon, SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  Icon,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
 
 import {
@@ -43,6 +49,7 @@ export function AprText({
       <SizableText
         size={size}
         textAlign="right"
+        fontVariant={TABULAR_NUMS}
         color={
           minAprInfo?.normal?.color ||
           maxAprInfo?.normal?.color ||
@@ -75,6 +82,7 @@ export function AprText({
           <SizableText
             size={size}
             textAlign="right"
+            fontVariant={TABULAR_NUMS}
             color={highlight.color || '$textSuccess'}
           >
             {formatRewardText({
@@ -87,6 +95,7 @@ export function AprText({
         <SizableText
           size="$bodyMd"
           textAlign="right"
+          fontVariant={TABULAR_NUMS}
           color={deprecated.color || '$textSubdued'}
           textDecorationLine="line-through"
         >
@@ -115,6 +124,7 @@ export function AprText({
         <SizableText
           size={size}
           textAlign="right"
+          fontVariant={TABULAR_NUMS}
           color={highlight.color || '$textSuccess'}
         >
           {formatRewardText({
@@ -134,6 +144,7 @@ export function AprText({
       <SizableText
         size={size}
         textAlign="right"
+        fontVariant={TABULAR_NUMS}
         color={normal.color || '$text'}
       >
         {formatRewardText({
@@ -152,6 +163,7 @@ export function AprText({
       <SizableText
         size={size}
         textAlign="right"
+        fontVariant={TABULAR_NUMS}
         color={deprecated.color || '$textSubdued'}
         textDecorationLine="line-through"
       >
@@ -166,7 +178,7 @@ export function AprText({
 
   // Priority 4: fallback to current logic
   return (
-    <SizableText size={size} textAlign="right">
+    <SizableText size={size} textAlign="right" fontVariant={TABULAR_NUMS}>
       {hideSuffix ? aprWithoutFee : buildAprText(aprWithoutFee, rewardUnit)}
     </SizableText>
   );

--- a/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
+++ b/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
@@ -14,6 +14,7 @@ import {
   Skeleton,
   Stack,
   Switch,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -273,7 +274,12 @@ function BalanceDetailsContent({
           {isLoading ? (
             <Skeleton.BodyLg />
           ) : (
-            <SizableText textAlign="right" size="$bodyLgMedium" minWidth={125}>
+            <SizableText
+              textAlign="right"
+              size="$bodyLgMedium"
+              minWidth={125}
+              fontVariant={TABULAR_NUMS}
+            >
               {`${overview?.frozenBalanceParsed ?? '-'} ${
                 network?.symbol ?? ''
               }`}
@@ -300,6 +306,7 @@ function BalanceDetailsContent({
                         textAlign="right"
                         size="$bodyMd"
                         color="$textSubdued"
+                        fontVariant={TABULAR_NUMS}
                       >
                         {`${
                           overview?.deriveItems?.[index]?.frozenBalanceParsed ??
@@ -391,7 +398,7 @@ function BalanceDetailsContent({
           {isLoading ? (
             <Skeleton.Heading3Xl />
           ) : (
-            <SizableText size="$heading3xl">
+            <SizableText size="$heading3xl" fontVariant={TABULAR_NUMS}>
               {`${overview?.balanceParsed ?? '-'} ${network?.symbol ?? ''}`}
             </SizableText>
           )}
@@ -413,7 +420,11 @@ function BalanceDetailsContent({
             {isLoading ? (
               <Skeleton.BodyLg />
             ) : (
-              <SizableText textAlign="right" size="$bodyLgMedium">
+              <SizableText
+                textAlign="right"
+                size="$bodyLgMedium"
+                fontVariant={TABULAR_NUMS}
+              >
                 {`${overview?.totalBalanceParsed ?? '-'} ${
                   network?.symbol ?? ''
                 }`}
@@ -438,6 +449,7 @@ function BalanceDetailsContent({
                       textAlign="right"
                       size="$bodyMd"
                       color="$textSubdued"
+                      fontVariant={TABULAR_NUMS}
                     >
                       {`${
                         overview?.deriveItems?.[index]?.totalBalanceParsed ??

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -9,6 +9,7 @@ import {
   Divider,
   SizableText,
   Skeleton,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useMedia,
@@ -69,8 +70,6 @@ import { buildDeFiOverviewCells } from './hooks/useDeFiOverviewTopN';
 import { resolveOverviewCols } from './overviewColsResolver';
 import { type IProtocolHandle, Protocol } from './Protocol';
 import { useIsDeFiEnabled } from './useIsDeFiEnabled';
-
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
 
 const MAX_PROTOCOLS_ON_SMALL_SCREEN = 6;
 const PROTOCOL_LIST_TOGGLE_PRESS_LOCK_MS = 600;

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiOverviewTile.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiOverviewTile.tsx
@@ -1,7 +1,13 @@
 import { useIntl } from 'react-intl';
 import { StyleSheet } from 'react-native';
 
-import { SizableText, Stack, XStack, YStack } from '@onekeyhq/components';
+import {
+  SizableText,
+  Stack,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import {
   useSettingsPersistAtom,
@@ -15,8 +21,6 @@ import type {
 
 import { OVERVIEW_TILE_SHADOW } from './DeFiOverviewLayout';
 import { formatPortfolioTotal } from './formatPortfolioTotal';
-
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
 
 export type IDeFiOverviewTileProps = {
   protocol: IDeFiProtocol;

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiPortfolioStackedBar.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiPortfolioStackedBar.tsx
@@ -7,6 +7,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
   YStack,
@@ -64,8 +65,6 @@ const STACKED_BAR_CHROME = {
     borderColor: '$borderSubdued',
   },
 } as const;
-
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
 
 const SEGMENT_OPACITY = 0.86;
 

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolAssetBalanceText.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolAssetBalanceText.tsx
@@ -4,8 +4,6 @@ import { isProtocolAssetValueUnavailable } from '@onekeyhq/kit/src/components/De
 import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
 import type { IDeFiAsset } from '@onekeyhq/shared/types/defi';
 
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
-
 type IProtocolAssetBalanceTextProps = {
   asset: IDeFiAsset;
   currencySymbol: string;
@@ -27,7 +25,6 @@ function ProtocolAssetBalanceText({
         formatter="balance"
         formatterOptions={{ tokenSymbol: asset.symbol }}
         numberOfLines={1}
-        fontVariant={TABULAR_NUMS}
       >
         {asset.amount}
       </NumberSizeableTextWrapper>
@@ -43,7 +40,6 @@ function ProtocolAssetBalanceText({
             isUnavailable={isProtocolAssetValueUnavailable(asset)}
             size="$bodyMd"
             color="$textSubdued"
-            fontVariant={TABULAR_NUMS}
             numberOfLines={1}
             justifyContent="flex-start"
           />

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolHeaderRow.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolHeaderRow.tsx
@@ -2,6 +2,7 @@ import {
   Icon,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   View,
   XStack,
   YStack,
@@ -10,8 +11,6 @@ import { Token } from '@onekeyhq/kit/src/components/Token';
 import { useSettingsValuePersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
 import { formatPortfolioTotal } from './formatPortfolioTotal';
-
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
 
 export type IProtocolHeaderRowProps = {
   name: string;

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolSectionedPositionTable.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolSectionedPositionTable.tsx
@@ -2,7 +2,13 @@ import { Fragment, memo, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { SizableText, Stack, XStack, YStack } from '@onekeyhq/components';
+import {
+  SizableText,
+  Stack,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { ProtocolValueCell } from '@onekeyhq/kit/src/components/DeFi/ProtocolValueCell';
 import { isProtocolAssetValueUnavailable } from '@onekeyhq/kit/src/components/DeFi/protocolValueUtils';
 import { Token } from '@onekeyhq/kit/src/components/Token';
@@ -23,8 +29,6 @@ import {
 //
 // The Supplied segment uses "Positions" in the first header cell to align with
 // the unified table; Borrowed and Rewards keep their semantic labels.
-
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
 
 type IProtocolSectionedPositionTableProps = {
   position: ILocalizedProtocolPositionItem;

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolUnifiedTable.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolUnifiedTable.tsx
@@ -2,7 +2,14 @@ import { memo, useCallback, useMemo, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { Icon, SizableText, Stack, XStack, YStack } from '@onekeyhq/components';
+import {
+  Icon,
+  SizableText,
+  Stack,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { ProtocolValueCell } from '@onekeyhq/kit/src/components/DeFi/ProtocolValueCell';
 import type { IProtocolUnifiedRow } from '@onekeyhq/kit/src/utils/defiPositionUtils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -55,8 +62,6 @@ export const USD_FLEX_WITHOUT_REWARDS = 1;
 // the top-by-USD rows + a "+N more" chip, so an 8-token yield position
 // settles at four lines of content instead of eight.
 const MAX_BALANCE_LINES = 3;
-
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
 
 type IProtocolUnifiedTableProps = {
   rows: IProtocolUnifiedRow[];

--- a/packages/kit/src/views/Home/components/NFTListView/NFTListItem.tsx
+++ b/packages/kit/src/views/Home/components/NFTListView/NFTListItem.tsx
@@ -8,6 +8,7 @@ import {
   Image,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   Video,
   XStack,
 } from '@onekeyhq/components';
@@ -105,7 +106,11 @@ function BasicNFTListItem(props: IProps) {
               borderWidth={2}
               borderColor="$bgApp"
             >
-              <SizableText size="$bodyMdMedium" color="$textInverse">
+              <SizableText
+                size="$bodyMdMedium"
+                color="$textInverse"
+                fontVariant={TABULAR_NUMS}
+              >
                 x
                 {new BigNumber(nft.amount).gt(SHOW_NFT_AMOUNT_MAX)
                   ? `${SHOW_NFT_AMOUNT_MAX}+`

--- a/packages/kit/src/views/Home/pages/DeFiContainer.tsx
+++ b/packages/kit/src/views/Home/pages/DeFiContainer.tsx
@@ -16,6 +16,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   Tabs,
   YStack,
   useMedia,
@@ -76,7 +77,6 @@ import {
 // Page.Container is now layout="full" so the scroll container fills the
 // viewport, and visual max-width is enforced one level down per content block.
 const DEFI_CONTAINER_CONTENT_MAX_WIDTH = 1140;
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
 const PROTOCOL_NAV_PENDING_TARGET_TIMEOUT_MS = 5000;
 
 function scrollToAnchor(

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
@@ -3,6 +3,7 @@ import { useIntl } from 'react-intl';
 import {
   NumberSizeableText,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -42,7 +43,9 @@ function StatRow({ label, value }: { label: string; value: string }) {
       <SizableText size="$bodySm" color="$textSubdued">
         {label}
       </SizableText>
-      <SizableText size="$bodySmMedium">{value}</SizableText>
+      <SizableText size="$bodySmMedium" fontVariant={TABULAR_NUMS}>
+        {value}
+      </SizableText>
     </XStack>
   );
 }
@@ -213,7 +216,12 @@ export function InformationPanel() {
               {priceConverted}
             </NumberSizeableText>
           ) : null}
-          <SizableText pt="$1" size="$bodyLgMedium" color={priceChangeColor}>
+          <SizableText
+            pt="$1"
+            size="$bodyLgMedium"
+            color={priceChangeColor}
+            fontVariant={TABULAR_NUMS}
+          >
             {priceChangeDisplay}
           </SizableText>
         </YStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/layout/HolderItemNormal/HolderItemNormal.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/layout/HolderItemNormal/HolderItemNormal.tsx
@@ -1,6 +1,11 @@
 import { memo } from 'react';
 
-import { NumberSizeableText, SizableText, XStack } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+} from '@onekeyhq/components';
 import type { IMarketTokenHolder } from '@onekeyhq/shared/types/marketV2';
 
 import { AddressDisplay } from '../../../AddressDisplay';
@@ -34,7 +39,12 @@ function HolderItemNormalBase({
       hoverStyle={{ backgroundColor: '$bgHover' }}
     >
       {/* Rank */}
-      <SizableText size="$bodyMd" color="$textSubdued" {...styles.rank}>
+      <SizableText
+        size="$bodyMd"
+        color="$textSubdued"
+        fontVariant={TABULAR_NUMS}
+        {...styles.rank}
+      >
         #{rank}
       </SizableText>
 
@@ -48,7 +58,12 @@ function HolderItemNormalBase({
       />
 
       {/* Market Cap Percentage */}
-      <SizableText size="$bodyMd" color="$text" {...styles.percentage}>
+      <SizableText
+        size="$bodyMd"
+        color="$text"
+        fontVariant={TABULAR_NUMS}
+        {...styles.percentage}
+      >
         {displayPercentage}
       </SizableText>
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/layout/HolderItemSmall/HolderItemSmall.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/layout/HolderItemSmall/HolderItemSmall.tsx
@@ -1,6 +1,11 @@
 import { memo } from 'react';
 
-import { NumberSizeableText, SizableText, XStack } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+} from '@onekeyhq/components';
 import type { IMarketTokenHolder } from '@onekeyhq/shared/types/marketV2';
 
 import { AddressDisplay } from '../../../AddressDisplay';
@@ -27,7 +32,11 @@ function HolderItemSmallBase({
     <XStack h={52} px="$5" alignItems="center" gap="$3">
       <XStack gap="$4" alignItems="center" flex={1}>
         {/* Rank */}
-        <SizableText size="$bodyMd" color="$textSubdued">
+        <SizableText
+          size="$bodyMd"
+          color="$textSubdued"
+          fontVariant={TABULAR_NUMS}
+        >
           {rank}
         </SizableText>
 
@@ -46,7 +55,12 @@ function HolderItemSmallBase({
       </XStack>
 
       {/* Percentage */}
-      <SizableText size="$bodyMd" color="$text" {...styles.percentage}>
+      <SizableText
+        size="$bodyMd"
+        color="$text"
+        fontVariant={TABULAR_NUMS}
+        {...styles.percentage}
+      >
         {displayPercentage}
       </SizableText>
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/components/PnlCell.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/components/PnlCell.tsx
@@ -2,7 +2,12 @@ import { memo } from 'react';
 
 import BigNumber from 'bignumber.js';
 
-import { NumberSizeableText, SizableText, YStack } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  TABULAR_NUMS,
+  YStack,
+} from '@onekeyhq/components';
 
 function PnlCellBase({
   usdValue,
@@ -49,7 +54,11 @@ function PnlCellBase({
           --
         </SizableText>
       )}
-      <SizableText size="$bodySm" color={displayColor}>
+      <SizableText
+        size="$bodySm"
+        color={displayColor}
+        fontVariant={TABULAR_NUMS}
+      >
         {isValid ? `${percent}%` : '--'}
       </SizableText>
     </YStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/components/TransactionRelativeTime.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/components/TransactionRelativeTime.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import type { PropsWithChildren } from 'react';
 
-import { SizableText } from '@onekeyhq/components';
+import { SizableText, TABULAR_NUMS } from '@onekeyhq/components';
 import type { ISizableTextProps } from '@onekeyhq/components';
 import { useInterval } from '@onekeyhq/kit/src/hooks/useInterval';
 
@@ -62,7 +62,12 @@ function TransactionRelativeTimeBase({
   );
 
   return (
-    <SizableText size={size} color={color} {...textProps}>
+    <SizableText
+      size={size}
+      color={color}
+      fontVariant={TABULAR_NUMS}
+      {...textProps}
+    >
       {formattedTime}
     </SizableText>
   );

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/components/TimeRangeSelector.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/components/TimeRangeSelector.tsx
@@ -1,4 +1,10 @@
-import { ButtonFrame, SizableText, Stack, YStack } from '@onekeyhq/components';
+import {
+  ButtonFrame,
+  SizableText,
+  Stack,
+  TABULAR_NUMS,
+  YStack,
+} from '@onekeyhq/components';
 
 import { MarketTestIDs } from '../../../testIDs';
 
@@ -54,6 +60,7 @@ export function TimeRangeSelector({
             <SizableText
               size="$bodySm"
               color={isLoading ? '$textSubdued' : getPercentageColor(opt)}
+              fontVariant={TABULAR_NUMS}
             >
               {isLoading ? '--' : opt.percentageChange}
             </SizableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderRight.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderRight.tsx
@@ -3,6 +3,7 @@ import { useIntl } from 'react-intl';
 import {
   NumberSizeableText,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -128,7 +129,11 @@ export function TokenDetailHeaderRight({
             id: ETranslations.dexmarket_stock_pe_ttm,
           })}
           value={
-            <SizableText size="$headingXs" color="$text">
+            <SizableText
+              size="$headingXs"
+              color="$text"
+              fontVariant={TABULAR_NUMS}
+            >
               {formatRatioValue(tokenDetail?.stock?.tradingActivity?.peRatio)}
             </SizableText>
           }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx
@@ -15,6 +15,7 @@ import {
   ScrollView,
   SizableText,
   Skeleton,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
   YStack,
@@ -1003,13 +1004,23 @@ function TokenLiquidityPoolsDesktop({ pools }: { pools: IDisplayPool[] }) {
             <YStack {...styles.pool}>
               <PoolIdentity item={item} textSize="$bodyMd" />
             </YStack>
-            <SizableText size="$bodyMd" color="$text" {...styles.liquidity}>
+            <SizableText
+              size="$bodyMd"
+              color="$text"
+              fontVariant={TABULAR_NUMS}
+              {...styles.liquidity}
+            >
               {item.liquidity}
             </SizableText>
             <YStack {...styles.tokenAmount}>
               <TokenAmountLines tokens={item.tokenAmounts} />
             </YStack>
-            <SizableText size="$bodyMd" color="$text" {...styles.feeRate}>
+            <SizableText
+              size="$bodyMd"
+              color="$text"
+              fontVariant={TABULAR_NUMS}
+              {...styles.feeRate}
+            >
               {item.feeRate}
             </SizableText>
             <YStack {...styles.poolAddress}>
@@ -1100,6 +1111,7 @@ function DetailInfoRow({
           color="$text"
           textAlign="right"
           numberOfLines={1}
+          fontVariant={TABULAR_NUMS}
         >
           {value ?? FALLBACK_VALUE}
         </SizableText>
@@ -1131,6 +1143,7 @@ function PoolDetailsContent({ item }: { item: IDisplayPool }) {
           color="$text"
           numberOfLines={1}
           flexShrink={0}
+          fontVariant={TABULAR_NUMS}
         >
           {item.liquidity}
         </SizableText>
@@ -1213,6 +1226,7 @@ function MobilePoolRow({ item }: { item: IDisplayPool }) {
         color="$text"
         textAlign="right"
         numberOfLines={1}
+        fontVariant={TABULAR_NUMS}
         {...MOBILE_COLUMN_STYLE.liquidity}
       >
         {item.liquidity}
@@ -1228,6 +1242,7 @@ function MobilePoolRow({ item }: { item: IDisplayPool }) {
           color="$text"
           textAlign="right"
           numberOfLines={1}
+          fontVariant={TABULAR_NUMS}
         >
           {item.feeRate}
         </SizableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenOverview/components/StatCard.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenOverview/components/StatCard.tsx
@@ -3,6 +3,7 @@ import {
   Popover,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
 } from '@onekeyhq/components';
 import type { ColorTokens, IIconProps } from '@onekeyhq/components';
@@ -62,7 +63,11 @@ export function StatCard({
         {icon ? (
           <Icon name={icon} size="$4" color={iconColor || '$iconSuccess'} />
         ) : null}
-        <SizableText size="$bodyLgMedium" color="$text">
+        <SizableText
+          size="$bodyLgMedium"
+          color="$text"
+          fontVariant={TABULAR_NUMS}
+        >
           {value}
         </SizableText>
       </XStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenSecurityAlert/TokenSecurityAlert.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenSecurityAlert/TokenSecurityAlert.tsx
@@ -1,6 +1,12 @@
 import { useIntl } from 'react-intl';
 
-import { Dialog, Icon, SizableText, XStack } from '@onekeyhq/components';
+import {
+  Dialog,
+  Icon,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+} from '@onekeyhq/components';
 import { NATIVE_HIT_SLOP } from '@onekeyhq/components/src/utils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -63,7 +69,11 @@ function TokenSecurityAlert() {
       hitSlop={NATIVE_HIT_SLOP}
     >
       <Icon name="BugOutline" size="$4" color={color} />
-      <SizableText size="$bodySmMedium" color={color}>
+      <SizableText
+        size="$bodySmMedium"
+        color={color}
+        fontVariant={TABULAR_NUMS}
+      >
         {count}
       </SizableText>
     </XStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenSecurityAlert/components/TokenSecurityAlertDialogContentOverview.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenSecurityAlert/components/TokenSecurityAlertDialogContentOverview.tsx
@@ -3,7 +3,13 @@ import { memo } from 'react';
 import { useIntl } from 'react-intl';
 
 import type { IKeyOfIcons } from '@onekeyhq/components';
-import { Icon, SizableText, Stack, XStack } from '@onekeyhq/components';
+import {
+  Icon,
+  SizableText,
+  Stack,
+  TABULAR_NUMS,
+  XStack,
+} from '@onekeyhq/components';
 import type { ColorTokens } from '@onekeyhq/components/src/primitives';
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
 
@@ -40,7 +46,7 @@ function SecurityStatusItem({
       </Stack>
 
       <Stack>
-        <SizableText size="$headingXl" color="$text">
+        <SizableText size="$headingXl" color="$text" fontVariant={TABULAR_NUMS}>
           {count}
         </SizableText>
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenSupplementaryInfo/TokenSupplementaryInfo.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenSupplementaryInfo/TokenSupplementaryInfo.tsx
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl';
 import {
   DashText,
   SizableText,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
   YStack,
@@ -159,6 +160,7 @@ export function TokenSupplementaryInfo() {
           <SizableText
             size="$bodySmMedium"
             color={item.onPress ? '$textInfo' : '$text'}
+            fontVariant={TABULAR_NUMS}
             cursor={item.onPress ? 'pointer' : undefined}
             hoverStyle={
               item.onPress ? { textDecorationLine: 'underline' } : undefined

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerItem.tsx
@@ -7,6 +7,7 @@ import {
   Image,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -158,7 +159,11 @@ function MarketBannerItemComponent({
           ) : null}
         </XStack>
         {description ? (
-          <SizableText size="$bodyMdMedium" color={descriptionColor}>
+          <SizableText
+            size="$bodyMdMedium"
+            color={descriptionColor}
+            fontVariant={TABULAR_NUMS}
+          >
             {description.text}
           </SizableText>
         ) : null}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/usePerpsColumns.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/usePerpsColumns.tsx
@@ -7,6 +7,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useMedia,
@@ -223,6 +224,7 @@ export function usePerpsColumnsDesktop(): ITableColumn<IMarketPerpsToken>[] {
                   <SizableText
                     size="$bodyMd"
                     color={rate >= 0 ? '$textSuccess' : '$textCritical'}
+                    fontVariant={TABULAR_NUMS}
                   >
                     {`${rate >= 0 ? '+' : ''}${rate.toFixed(4)}%`}
                   </SizableText>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
@@ -7,6 +7,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useMedia,
@@ -356,7 +357,11 @@ export const useColumnsDesktop = (
               { amount: ageInfo.amount },
             );
 
-            return <SizableText size="$bodyMd">{ageLabel}</SizableText>;
+            return (
+              <SizableText size="$bodyMd" fontVariant={TABULAR_NUMS}>
+                {ageLabel}
+              </SizableText>
+            );
           },
           renderSkeleton: () => <Skeleton width={60} height={16} />,
         }

--- a/packages/kit/src/views/Market/components/Chart/PriceLabel.tsx
+++ b/packages/kit/src/views/Market/components/Chart/PriceLabel.tsx
@@ -2,6 +2,7 @@ import {
   NumberSizeableText,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
 } from '@onekeyhq/components';
 import type { IStackProps } from '@onekeyhq/components';
@@ -120,6 +121,7 @@ export function PriceLabel({
           size="$bodyMd"
           color="$textSubdued"
           $md={{ color: '$text' }}
+          fontVariant={TABULAR_NUMS}
         >
           {time}
         </SizableText>

--- a/packages/kit/src/views/Market/components/Chart/value-chart/ExtremeLabels.tsx
+++ b/packages/kit/src/views/Market/components/Chart/value-chart/ExtremeLabels.tsx
@@ -2,12 +2,20 @@ import type { ReactNode } from 'react';
 import { memo, useCallback, useMemo, useState } from 'react';
 
 import { useChartData } from '@onekeyfe/react-native-animated-charts';
-import { Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
-import { NumberSizeableText } from '@onekeyhq/components';
+import { NumberSizeableText, TABULAR_NUMS } from '@onekeyhq/components';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
 import type { LayoutChangeEvent } from 'react-native';
+
+const styles = StyleSheet.create({
+  label: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    fontVariant: TABULAR_NUMS,
+  },
+});
 
 function trim(val: number) {
   return Math.min(Math.max(val, 0.05), 0.95);
@@ -79,15 +87,7 @@ const CenteredLabel = ({
         position: 'absolute',
       }}
     >
-      <Text
-        style={{
-          color,
-          fontSize: 14,
-          fontWeight: 'bold',
-        }}
-      >
-        {children}
-      </Text>
+      <Text style={[styles.label, { color }]}>{children}</Text>
     </View>
   );
 };

--- a/packages/kit/src/views/Market/components/MarketDetailOverview.tsx
+++ b/packages/kit/src/views/Market/components/MarketDetailOverview.tsx
@@ -9,6 +9,7 @@ import {
   Popover,
   Progress,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useIsOverlayPage,
@@ -169,6 +170,7 @@ function OverviewMarketVOLItem({
             color="$textSubdued"
             borderRadius="$1"
             px="$1"
+            fontVariant={TABULAR_NUMS}
           >
             {`#${rank}`}
           </SizableText>

--- a/packages/kit/src/views/Market/components/MarketHomeList.tsx
+++ b/packages/kit/src/views/Market/components/MarketHomeList.tsx
@@ -20,6 +20,7 @@ import {
   Skeleton,
   Spinner,
   Stack,
+  TABULAR_NUMS,
   Table,
   View,
   XStack,
@@ -662,6 +663,7 @@ function BasicMarketHomeList({
                   size="$bodyMd"
                   color="$textSubdued"
                   userSelect="none"
+                  fontVariant={TABULAR_NUMS}
                 >
                   {serialNumber ?? '-'}
                 </SizableText>

--- a/packages/kit/src/views/Market/components/PerpsBadges.tsx
+++ b/packages/kit/src/views/Market/components/PerpsBadges.tsx
@@ -6,6 +6,7 @@ import {
   Image,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
 } from '@onekeyhq/components';
@@ -23,7 +24,12 @@ const LeverageBadge = memo(({ leverage }: { leverage: number }) => (
     alignItems="center"
     px="$1.5"
   >
-    <SizableText fontSize={10} color="$textInfo" lineHeight={16}>
+    <SizableText
+      fontSize={10}
+      color="$textInfo"
+      lineHeight={16}
+      fontVariant={TABULAR_NUMS}
+    >
       {leverage}x
     </SizableText>
   </XStack>

--- a/packages/kit/src/views/Market/components/PoolDetailDialog.tsx
+++ b/packages/kit/src/views/Market/components/PoolDetailDialog.tsx
@@ -8,6 +8,7 @@ import type { INumberSizeableTextProps } from '@onekeyhq/components';
 import {
   NumberSizeableText,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -50,7 +51,9 @@ export function PoolDetailsItem({
       );
     }
     return typeof children === 'string' ? (
-      <SizableText size="$bodyMdMedium">{children}</SizableText>
+      <SizableText size="$bodyMdMedium" fontVariant={TABULAR_NUMS}>
+        {children}
+      </SizableText>
     ) : (
       children
     );

--- a/packages/kit/src/views/Market/components/PriceChangePercentage.tsx
+++ b/packages/kit/src/views/Market/components/PriceChangePercentage.tsx
@@ -2,6 +2,7 @@ import {
   type INumberSizeableTextProps,
   NumberSizeableText,
   SizableText,
+  TABULAR_NUMS,
 } from '@onekeyhq/components';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
@@ -16,7 +17,11 @@ export function PriceChangePercentage({
     children === null ||
     (typeof children === 'string' && children.length === 0)
   ) {
-    return <SizableText size="$bodyMd">-</SizableText>;
+    return (
+      <SizableText size="$bodyMd" fontVariant={TABULAR_NUMS}>
+        -
+      </SizableText>
+    );
   }
 
   const { color } = formatPriceChangeDisplay(children);

--- a/packages/kit/src/views/Perp/components/OrderBook/DefaultLoadingNode.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/DefaultLoadingNode.tsx
@@ -4,6 +4,7 @@ import {
   SizableText,
   Spinner,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -35,8 +36,7 @@ function MobileVerticalEmptyRow({
       <SizableText
         fontSize={11}
         lineHeight={14}
-        fontFamily="$monoRegular"
-        fontVariant={['tabular-nums']}
+        fontVariant={TABULAR_NUMS}
         color={priceColor}
       >
         --
@@ -44,8 +44,7 @@ function MobileVerticalEmptyRow({
       <SizableText
         fontSize={11}
         lineHeight={14}
-        fontFamily="$monoRegular"
-        fontVariant={['tabular-nums']}
+        fontVariant={TABULAR_NUMS}
         color="$textSubdued"
       >
         --
@@ -61,8 +60,7 @@ function MobileHorizontalEmptyRow() {
         <SizableText
           fontSize={12}
           lineHeight={16}
-          fontFamily="$monoRegular"
-          fontVariant={['tabular-nums']}
+          fontVariant={TABULAR_NUMS}
           color="$textSubdued"
         >
           --
@@ -70,8 +68,7 @@ function MobileHorizontalEmptyRow() {
         <SizableText
           fontSize={12}
           lineHeight={16}
-          fontFamily="$monoRegular"
-          fontVariant={['tabular-nums']}
+          fontVariant={TABULAR_NUMS}
           color="$green11"
         >
           --
@@ -81,8 +78,7 @@ function MobileHorizontalEmptyRow() {
         <SizableText
           fontSize={12}
           lineHeight={16}
-          fontFamily="$monoRegular"
-          fontVariant={['tabular-nums']}
+          fontVariant={TABULAR_NUMS}
           color="$red11"
         >
           --
@@ -90,8 +86,7 @@ function MobileHorizontalEmptyRow() {
         <SizableText
           fontSize={12}
           lineHeight={16}
-          fontFamily="$monoRegular"
-          fontVariant={['tabular-nums']}
+          fontVariant={TABULAR_NUMS}
           color="$textSubdued"
         >
           --
@@ -200,8 +195,7 @@ export function DefaultLoadingNode({
               fontSize={20}
               lineHeight={24}
               fontWeight="600"
-              fontFamily="$monoRegular"
-              fontVariant={['tabular-nums']}
+              fontVariant={TABULAR_NUMS}
               color="$text"
             >
               {midPriceDisplay}
@@ -209,8 +203,7 @@ export function DefaultLoadingNode({
             <SizableText
               fontSize={10}
               lineHeight={14}
-              fontFamily="$monoRegular"
-              fontVariant={['tabular-nums']}
+              fontVariant={TABULAR_NUMS}
               color="$textSubdued"
             >
               --

--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -19,6 +19,7 @@ import {
   Popover,
   Select,
   SizableText,
+  TABULAR_NUMS,
   YStack,
   useTheme,
   useThemeName,
@@ -256,13 +257,19 @@ const styles = StyleSheet.create({
     letterSpacing: 0.8,
     width: '100%',
   },
-  monospaceText: {
-    fontFamily: platformEnv.isNative ? 'GeistMono-Regular' : 'monospace',
+  tabularText: {
+    // Not a mono face: the app font (Roobert) ships tabular figures via the
+    // `tnum` OpenType feature, so digits stay column-aligned while letters keep
+    // their natural proportional widths. Native raw <Text> can't pick a weight
+    // from a custom family via fontWeight, so name the medium face explicitly.
+    fontFamily: platformEnv.isNative ? 'Roobert-Medium' : undefined,
+    fontVariant: TABULAR_NUMS,
     fontSize: 12,
     lineHeight: 16,
     fontWeight: '500',
   },
-  monospaceTextBold: {
+  tabularTextBold: {
+    fontFamily: platformEnv.isNative ? 'Roobert-SemiBold' : undefined,
     fontWeight: '600',
   },
   interactiveRow: {
@@ -424,7 +431,7 @@ const styles = StyleSheet.create({
     borderBottomRightRadius: 999,
   },
   sideRatioLabel: {
-    fontFamily: platformEnv.isNative ? 'GeistMono-Regular' : 'monospace',
+    fontFamily: platformEnv.isNative ? 'Roobert-Medium' : undefined,
     fontSize: 12,
     lineHeight: 16,
     fontWeight: '500',
@@ -464,27 +471,27 @@ const OrderBookVerticalRow = memo(
     sizeColor: string;
     isHovered?: boolean;
   }) => {
-    const fontWeightStyle = isHovered ? styles.monospaceTextBold : null;
+    const fontWeightStyle = isHovered ? styles.tabularTextBold : null;
     return (
       <DebugRenderTracker name="OrderBookVerticalRow" position="right-center">
         <View style={styles.verticalRowContainer}>
           <View style={styles.verticalRowCellPrice}>
             <PerpBookText
               style={[
-                styles.monospaceText,
+                styles.tabularText,
                 { color: priceColor },
                 fontWeightStyle,
               ]}
               numberOfLines={1}
             >
-              {item.price}
+              {item.displayPrice}
             </PerpBookText>
           </View>
           <View style={styles.verticalRowCellSize}>
             <PerpBookText
               numberOfLines={1}
               style={[
-                styles.monospaceText,
+                styles.tabularText,
                 { color: sizeColor },
                 fontWeightStyle,
               ]}
@@ -496,7 +503,7 @@ const OrderBookVerticalRow = memo(
             <PerpBookText
               numberOfLines={1}
               style={[
-                styles.monospaceText,
+                styles.tabularText,
                 { color: sizeColor },
                 fontWeightStyle,
               ]}
@@ -1020,21 +1027,21 @@ export function OrderBook({
                             <View style={styles.interactiveRowContent}>
                               <PerpBookText
                                 style={[
-                                  styles.monospaceText,
+                                  styles.tabularText,
                                   { color: textColor.textSubdued },
-                                  isHovered ? styles.monospaceTextBold : null,
+                                  isHovered ? styles.tabularTextBold : null,
                                 ]}
                               >
                                 {item.displaySize}
                               </PerpBookText>
                               <PerpBookText
                                 style={[
-                                  styles.monospaceText,
+                                  styles.tabularText,
                                   { color: textColor.green },
-                                  isHovered ? styles.monospaceTextBold : null,
+                                  isHovered ? styles.tabularTextBold : null,
                                 ]}
                               >
-                                {item.price}
+                                {item.displayPrice}
                               </PerpBookText>
                             </View>
                           );
@@ -1061,18 +1068,18 @@ export function OrderBook({
                             <View style={styles.interactiveRowContent}>
                               <PerpBookText
                                 style={[
-                                  styles.monospaceText,
+                                  styles.tabularText,
                                   { color: textColor.red },
-                                  isHovered ? styles.monospaceTextBold : null,
+                                  isHovered ? styles.tabularTextBold : null,
                                 ]}
                               >
-                                {item.price}
+                                {item.displayPrice}
                               </PerpBookText>
                               <PerpBookText
                                 style={[
-                                  styles.monospaceText,
+                                  styles.tabularText,
                                   { color: textColor.textSubdued },
-                                  isHovered ? styles.monospaceTextBold : null,
+                                  isHovered ? styles.tabularTextBold : null,
                                 ]}
                               >
                                 {item.displaySize}
@@ -1302,7 +1309,7 @@ const OrderBookPairRow = memo(
     sizeColor: string;
     isHovered?: boolean;
   }) => {
-    const fontWeightStyle = isHovered ? styles.monospaceTextBold : null;
+    const fontWeightStyle = isHovered ? styles.tabularTextBold : null;
     return (
       <DebugRenderTracker name="OrderBookPairRow" position="right-center">
         <View
@@ -1315,20 +1322,12 @@ const OrderBookPairRow = memo(
           }}
         >
           <PerpBookText
-            style={[
-              styles.monospaceText,
-              { color: priceColor },
-              fontWeightStyle,
-            ]}
+            style={[styles.tabularText, { color: priceColor }, fontWeightStyle]}
           >
-            {item.price}
+            {item.displayPrice}
           </PerpBookText>
           <PerpBookText
-            style={[
-              styles.monospaceText,
-              { color: sizeColor },
-              fontWeightStyle,
-            ]}
+            style={[styles.tabularText, { color: sizeColor }, fontWeightStyle]}
           >
             {item.displaySize}
           </PerpBookText>
@@ -1619,7 +1618,7 @@ function MobileSpreadInfoContent({
         renderTrigger={
           <PerpBookText
             style={[
-              styles.monospaceText,
+              styles.tabularText,
               {
                 color: textColor.text,
                 fontSize: 20,
@@ -1651,7 +1650,7 @@ function MobileSpreadInfoContent({
           isSpot ? (
             <PerpBookText
               style={[
-                styles.monospaceText,
+                styles.tabularText,
                 {
                   color: textColor.textSubdued,
                   fontSize: 11,
@@ -1665,7 +1664,7 @@ function MobileSpreadInfoContent({
           ) : (
             <DashText
               style={[
-                styles.monospaceText,
+                styles.tabularText,
                 {
                   color: textColor.textSubdued,
                   fontSize: 10,

--- a/packages/kit/src/views/Perp/components/OrderBook/types.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/types.ts
@@ -17,6 +17,9 @@ export interface IOBLevel {
 }
 
 export interface IFormattedOBLevel extends IOBLevel {
+  /** Human readable representation of price for rendering (thousands-separated).
+   * `price` stays the raw numeric string for selection/order-form logic. */
+  displayPrice: string;
   /** Human readable representation of size for rendering */
   displaySize: string;
   /** Human readable representation of cumulative size for rendering */

--- a/packages/kit/src/views/Perp/components/OrderBook/useAggregatedBook.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/useAggregatedBook.tsx
@@ -2,7 +2,10 @@ import { useMemo } from 'react';
 
 import BigNumber from 'bignumber.js';
 
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  formatLocalizedNumberString,
+  numberFormat,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 import type { IBookLevel } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 import { type ITickParam } from './tickSizeUtils';
@@ -52,6 +55,7 @@ const withDisplayFields = (
 ): IFormattedOBLevel[] =>
   levels.map((level) => ({
     ...level,
+    displayPrice: formatLocalizedNumberString(level.price),
     displaySize: formatOrderBookValue(level.size, variant),
     displayCumSize: formatOrderBookValue(level.cumSize, variant),
   }));

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/AccountRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/AccountRow.tsx
@@ -3,7 +3,13 @@ import { memo, useMemo } from 'react';
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
-import { Icon, SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  Icon,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { usePerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale/enum/translations';
@@ -375,7 +381,11 @@ const AccountRow = memo(
           <YStack flex={1} gap="$1">
             <XStack justifyContent="space-between" alignItems="center">
               <SizableText size="$bodyMdMedium">{typeConfig.text}</SizableText>
-              <SizableText size="$bodyMdMedium" color={textColor}>
+              <SizableText
+                size="$bodyMdMedium"
+                color={textColor}
+                fontVariant={TABULAR_NUMS}
+              >
                 {signPrefix}
                 {numberFormat(totalAmount, balanceFormatter)}
               </SizableText>
@@ -384,7 +394,11 @@ const AccountRow = memo(
               <SizableText size="$bodySm" color={statusInfo.color}>
                 {statusInfo.text}
               </SizableText>
-              <SizableText size="$bodySm" color="$textSubdued">
+              <SizableText
+                size="$bodySm"
+                color="$textSubdued"
+                fontVariant={TABULAR_NUMS}
+              >
                 {dateInfo.date} {dateInfo.time}
               </SizableText>
             </XStack>
@@ -412,7 +426,12 @@ const AccountRow = memo(
           justifyContent="center"
           alignItems={calcCellAlign(columnConfigs[0].align)}
         >
-          <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+          <SizableText
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            size="$bodySm"
+            fontVariant={TABULAR_NUMS}
+          >
             {dateInfo.date}
           </SizableText>
           <SizableText
@@ -420,6 +439,7 @@ const AccountRow = memo(
             ellipsizeMode="tail"
             size="$bodySm"
             color="$textSubdued"
+            fontVariant={TABULAR_NUMS}
           >
             {dateInfo.time}
           </SizableText>
@@ -463,6 +483,7 @@ const AccountRow = memo(
             ellipsizeMode="tail"
             size="$bodySm"
             color={textColor}
+            fontVariant={TABULAR_NUMS}
           >
             {signPrefix}
             {numberFormat(amount, balanceFormatter)}
@@ -480,6 +501,7 @@ const AccountRow = memo(
             ellipsizeMode="tail"
             size="$bodySm"
             color={fee && Number(fee) !== 0 ? '$red11' : undefined}
+            fontVariant={TABULAR_NUMS}
           >
             {fee && Number(fee) !== 0
               ? numberFormat(fee, balanceFormatter)

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/BalanceRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/BalanceRow.tsx
@@ -8,6 +8,7 @@ import {
   IconButton,
   NumberSizeableText,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useClipboard,
@@ -209,7 +210,12 @@ function BalanceRowMobile({ item, onChangeAsset }: IBalanceRowProps) {
                 />
               ) : null}
             </XStack>
-            <SizableText size="$bodySm" color="$textSubdued" numberOfLines={1}>
+            <SizableText
+              size="$bodySm"
+              color="$textSubdued"
+              numberOfLines={1}
+              fontVariant={TABULAR_NUMS}
+            >
               {balanceText}
             </SizableText>
           </YStack>
@@ -231,6 +237,7 @@ function BalanceRowMobile({ item, onChangeAsset }: IBalanceRowProps) {
                 color={pnlColor}
                 numberOfLines={1}
                 textAlign="right"
+                fontVariant={TABULAR_NUMS}
               >
                 {pnlText}
               </SizableText>
@@ -322,7 +329,12 @@ function BalanceRowDesktop({
     if (cell.key === 'pnl') {
       return (
         <XStack minWidth={0} alignItems="center" gap="$1">
-          <SizableText size="$bodySmMedium" color={pnlColor} numberOfLines={1}>
+          <SizableText
+            size="$bodySmMedium"
+            color={pnlColor}
+            numberOfLines={1}
+            fontVariant={TABULAR_NUMS}
+          >
             {cell.cellValue}
           </SizableText>
           {canShare ? (
@@ -348,6 +360,7 @@ function BalanceRowDesktop({
       <SizableText
         size="$bodySmMedium"
         color={cell.key === 'pnl' ? pnlColor : undefined}
+        fontVariant={TABULAR_NUMS}
       >
         {cell.cellValue}
       </SizableText>

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/MobileTwapOpenOrdersRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/MobileTwapOpenOrdersRow.tsx
@@ -3,7 +3,13 @@ import { memo, useEffect, useMemo, useState } from 'react';
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
-import { Button, SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  Button,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import type { IPerpsActiveTwapOrder } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
@@ -72,6 +78,7 @@ function MobileTwapInfoRow({ label, value }: { label: string; value: string }) {
         ellipsizeMode="tail"
         textAlign="right"
         maxWidth="60%"
+        fontVariant={TABULAR_NUMS}
       >
         {value}
       </SizableText>
@@ -206,6 +213,7 @@ const MobileTwapOpenOrdersRow = memo(
                 color="$textSubdued"
                 numberOfLines={1}
                 ellipsizeMode="tail"
+                fontVariant={TABULAR_NUMS}
               >
                 {dateInfo.date} {dateInfo.time}
               </SizableText>

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
@@ -3,7 +3,13 @@ import { memo, useCallback, useMemo } from 'react';
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
-import { Button, SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  Button,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
@@ -13,7 +19,10 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatTime } from '@onekeyhq/shared/src/utils/dateUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  formatLocalizedNumberString,
+  numberFormat,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   getValidPriceDecimals,
   isSpotInstrument,
@@ -186,9 +195,9 @@ const OpenOrdersRow = memo(
       const executePriceFormatted = new BigNumber(executePrice).toFixed(
         decimals,
       );
-      const executePriceLimitFormatted = new BigNumber(
-        executePriceLimit,
-      ).toFixed(decimals);
+      const executePriceLimitFormatted = formatLocalizedNumberString(
+        new BigNumber(executePriceLimit).toFixed(decimals),
+      );
       const priceFormatted = new BigNumber(price).toFixed(decimals);
       const sizeFormatted = numberFormat(size, balanceFormatter);
       const value = priceBN.times(origSizeBN).toFixed();
@@ -273,6 +282,7 @@ const OpenOrdersRow = memo(
                   ellipsizeMode="tail"
                   size="$bodySm"
                   color="$textSubdued"
+                  fontVariant={TABULAR_NUMS}
                 >
                   {`${dateInfo.date} ${dateInfo.time}`}
                 </SizableText>
@@ -302,7 +312,7 @@ const OpenOrdersRow = memo(
                 id: ETranslations.perp_position_mobile_fill,
               })}
             </SizableText>
-            <SizableText size="$bodySm">
+            <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
               {`${orderBaseInfo.sizeFormatted} / ${orderBaseInfo.origSizeFormatted}`}
             </SizableText>
           </XStack>
@@ -316,7 +326,12 @@ const OpenOrdersRow = memo(
                 id: ETranslations.perp_orderbook_price,
               })}
             </SizableText>
-            <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+            <SizableText
+              numberOfLines={1}
+              ellipsizeMode="tail"
+              size="$bodySm"
+              fontVariant={TABULAR_NUMS}
+            >
               {order.orderType.includes('Market')
                 ? intl.formatMessage({
                     id: ETranslations.perp_position_market,
@@ -348,7 +363,12 @@ const OpenOrdersRow = memo(
                 id: ETranslations.perp_open_orders_trigger_condition,
               })}
             </SizableText>
-            <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+            <SizableText
+              numberOfLines={1}
+              ellipsizeMode="tail"
+              size="$bodySm"
+              fontVariant={TABULAR_NUMS}
+            >
               {orderBaseInfo.triggerCondition}
             </SizableText>
           </XStack>
@@ -362,7 +382,12 @@ const OpenOrdersRow = memo(
                 id: ETranslations.perp_position_tp_sl,
               })}
             </SizableText>
-            <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+            <SizableText
+              numberOfLines={1}
+              ellipsizeMode="tail"
+              size="$bodySm"
+              fontVariant={TABULAR_NUMS}
+            >
               {tpslInfo.tpsl}
             </SizableText>
           </XStack>
@@ -394,6 +419,7 @@ const OpenOrdersRow = memo(
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
+                fontVariant={TABULAR_NUMS}
               >
                 {dateInfo.date}
               </SizableText>
@@ -402,6 +428,7 @@ const OpenOrdersRow = memo(
                 ellipsizeMode="tail"
                 size="$bodySm"
                 color="$textSubdued"
+                fontVariant={TABULAR_NUMS}
               >
                 {dateInfo.time}
               </SizableText>
@@ -458,6 +485,7 @@ const OpenOrdersRow = memo(
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
+                fontVariant={TABULAR_NUMS}
               >
                 {orderBaseInfo.sizeFormatted}
               </SizableText>
@@ -473,6 +501,7 @@ const OpenOrdersRow = memo(
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
+                fontVariant={TABULAR_NUMS}
               >
                 {orderBaseInfo.origSizeFormatted}
               </SizableText>
@@ -488,6 +517,7 @@ const OpenOrdersRow = memo(
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
+                fontVariant={TABULAR_NUMS}
               >
                 {orderBaseInfo.valueFormatted}
               </SizableText>
@@ -503,6 +533,7 @@ const OpenOrdersRow = memo(
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
+                fontVariant={TABULAR_NUMS}
               >
                 {order.orderType.includes('Market')
                   ? intl.formatMessage({
@@ -535,6 +566,7 @@ const OpenOrdersRow = memo(
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
+                fontVariant={TABULAR_NUMS}
               >
                 {orderBaseInfo.triggerCondition}
               </SizableText>
@@ -549,6 +581,7 @@ const OpenOrdersRow = memo(
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
+                fontVariant={TABULAR_NUMS}
               >
                 {tpslInfo.tpsl}
               </SizableText>

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -12,6 +12,7 @@ import {
   IconButton,
   Popover,
   SizableText,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
   YStack,
@@ -24,7 +25,10 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  formatLocalizedNumberString,
+  numberFormat,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   getValidPriceDecimals,
   parseDexCoin,
@@ -99,8 +103,15 @@ function MarkPrice({ coin }: { coin: string }) {
   return useMemo(
     () => (
       <DebugRenderTracker position="bottom-right" name="MarkPrice" offsetY={10}>
-        <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
-          {midFormattedByDecimals}
+        <SizableText
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          size="$bodySm"
+          fontVariant={TABULAR_NUMS}
+        >
+          {midFormattedByDecimals
+            ? formatLocalizedNumberString(midFormattedByDecimals)
+            : midFormattedByDecimals}
         </SizableText>
       </DebugRenderTracker>
     ),
@@ -157,6 +168,7 @@ const PositionRowDesktopSymbolAndLeverage = memo(
                 lineHeight={20}
                 color="$textSubdued"
                 fontSize={12}
+                fontVariant={TABULAR_NUMS}
               >
                 {assetInfo.leverageType} {assetInfo.leverage}x
               </SizableText>
@@ -188,7 +200,12 @@ const PositionRowDesktopPositionSize = memo(
           justifyContent="center"
           alignItems={calcCellAlign(columnConfig.align)}
         >
-          <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+          <SizableText
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            size="$bodySm"
+            fontVariant={TABULAR_NUMS}
+          >
             {`${sizeInfo.sizeAbsFormatted}`}
           </SizableText>
           <SizableText
@@ -196,6 +213,7 @@ const PositionRowDesktopPositionSize = memo(
             ellipsizeMode="tail"
             size="$bodySm"
             color="$textSubdued"
+            fontVariant={TABULAR_NUMS}
           >
             {`${sizeInfo.sizeValue}`}
           </SizableText>
@@ -224,7 +242,12 @@ const PositionRowDesktopEntryPrice = memo(
           justifyContent={calcCellAlign(columnConfig.align)}
           alignItems="center"
         >
-          <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+          <SizableText
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            size="$bodySm"
+            fontVariant={TABULAR_NUMS}
+          >
             {priceInfo.entryPriceFormatted}
           </SizableText>
         </XStack>
@@ -248,8 +271,15 @@ const PositionRowDesktopMarkPrice = memo(
           name="MarkPrice"
           offsetY={10}
         >
-          <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
-            {midFormattedByDecimals}
+          <SizableText
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            size="$bodySm"
+            fontVariant={TABULAR_NUMS}
+          >
+            {midFormattedByDecimals
+              ? formatLocalizedNumberString(midFormattedByDecimals)
+              : midFormattedByDecimals}
           </SizableText>
         </DebugRenderTracker>
       </XStack>
@@ -276,7 +306,12 @@ const PositionRowDesktopLiqPrice = memo(
           justifyContent={calcCellAlign(columnConfig.align)}
           alignItems="center"
         >
-          <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+          <SizableText
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            size="$bodySm"
+            fontVariant={TABULAR_NUMS}
+          >
             {priceInfo.liquidationPriceFormatted}
           </SizableText>
         </XStack>
@@ -309,6 +344,7 @@ const PositionRowDesktopPnL = memo(
             color={otherInfo.pnlColor}
             numberOfLines={1}
             ellipsizeMode="tail"
+            fontVariant={TABULAR_NUMS}
           >
             {`${otherInfo.pnlPlusOrMinus}${otherInfo.unrealizedPnl}(${otherInfo.pnlPlusOrMinus}${otherInfo.roiPercent}%)`}
           </SizableText>
@@ -355,6 +391,7 @@ const PositionRowDesktopMargin = memo(
               numberOfLines={1}
               ellipsizeMode="tail"
               size="$bodySm"
+              fontVariant={TABULAR_NUMS}
             >{`${otherInfo.marginUsedFormatted}`}</SizableText>
             {isIsolatedMode ? (
               <IconButton
@@ -403,6 +440,7 @@ const PositionRowDesktopFunding = memo(
                 ellipsizeMode="tail"
                 size="$bodySm"
                 color={otherInfo.fundingSinceOpenColor}
+                fontVariant={TABULAR_NUMS}
               >{`${otherInfo.fundingSinceOpenPlusOrMinus}$${otherInfo.fundingSinceOpenFormatted}`}</SizableText>
             }
             renderContent={
@@ -420,6 +458,7 @@ const PositionRowDesktopFunding = memo(
                   <SizableText
                     size="$bodySm"
                     color={otherInfo.fundingAllTimeColor}
+                    fontVariant={TABULAR_NUMS}
                   >
                     {`${otherInfo.fundingSinceOpenPlusOrMinus}$${otherInfo.fundingSinceOpenFormatted}`}{' '}
                   </SizableText>
@@ -437,6 +476,7 @@ const PositionRowDesktopFunding = memo(
                   <SizableText
                     size="$bodySm"
                     color={otherInfo.fundingAllTimeColor}
+                    fontVariant={TABULAR_NUMS}
                   >
                     {`${otherInfo.fundingAllPlusOrMinus}$${otherInfo.fundingAllTimeFormatted}`}{' '}
                   </SizableText>
@@ -451,6 +491,7 @@ const PositionRowDesktopFunding = memo(
                   <SizableText
                     size="$bodySm"
                     color={otherInfo.fundingSinceChangeColor}
+                    fontVariant={TABULAR_NUMS}
                   >
                     {`${otherInfo.fundingSinceChangePlusOrMinus}$${otherInfo.fundingSinceChangeFormatted}`}
                   </SizableText>
@@ -507,7 +548,12 @@ const PositionRowDesktopTPSL = memo(
         showOrder = true;
       }
 
-      return { tpsl: `${tpPrice}/${slPrice}`, showOrder };
+      return {
+        tpsl: `${formatLocalizedNumberString(
+          tpPrice,
+        )}/${formatLocalizedNumberString(slPrice)}`,
+        showOrder,
+      };
     }, [currentAssetOpenOrders]);
 
     return (
@@ -554,6 +600,7 @@ const PositionRowDesktopTPSL = memo(
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
+                fontVariant={TABULAR_NUMS}
               >
                 {tpslInfo.tpsl}
               </SizableText>
@@ -795,6 +842,7 @@ const PositionRowMobileHeader = memo(
             px="$1"
             color="$textSubdued"
             fontSize={10}
+            fontVariant={TABULAR_NUMS}
           >
             {assetInfo.leverageType} {assetInfo.leverage}x
           </SizableText>
@@ -830,7 +878,11 @@ const PositionRowMobilePnLAndROE = memo(
               id: ETranslations.perp_position_pnl_mobile,
             })}
           </SizableText>
-          <SizableText size="$bodyMdMedium" color={otherInfo.pnlColor}>
+          <SizableText
+            size="$bodyMdMedium"
+            color={otherInfo.pnlColor}
+            fontVariant={TABULAR_NUMS}
+          >
             {`${otherInfo.pnlPlusOrMinus}${otherInfo.unrealizedPnl}`}
           </SizableText>
         </YStack>
@@ -838,7 +890,11 @@ const PositionRowMobilePnLAndROE = memo(
           <SizableText size="$bodySm" color="$textSubdued">
             ROE
           </SizableText>
-          <SizableText size="$bodyMdMedium" color={otherInfo.pnlColor}>
+          <SizableText
+            size="$bodyMdMedium"
+            color={otherInfo.pnlColor}
+            fontVariant={TABULAR_NUMS}
+          >
             {`${otherInfo.pnlPlusOrMinus}${otherInfo.roiPercent}%`}
           </SizableText>
         </YStack>
@@ -883,7 +939,7 @@ const PositionRowMobilePositionSize = memo(
           <Icon name="RepeatOutline" size="$3" color="$textSubdued" />
         </XStack>
         <XStack alignItems="center" gap="$1">
-          <SizableText size="$bodySmMedium">
+          <SizableText size="$bodySmMedium" fontVariant={TABULAR_NUMS}>
             {isSizeViewChange
               ? `$${sizeInfo.sizeValue}`
               : sizeInfo.sizeAbsFormatted}
@@ -915,7 +971,7 @@ const PositionRowMobileMargin = memo(
           })}
         </SizableText>
         <XStack alignItems="center" gap="$1">
-          <SizableText size="$bodySmMedium">
+          <SizableText size="$bodySmMedium" fontVariant={TABULAR_NUMS}>
             {`${otherInfo.marginUsedFormatted}`}
           </SizableText>
           {isIsolatedMode ? (
@@ -947,7 +1003,7 @@ const PositionRowMobileEntryPrice = memo(
             id: ETranslations.perp_position_entry_price,
           })}
         </SizableText>
-        <SizableText size="$bodySmMedium">
+        <SizableText size="$bodySmMedium" fontVariant={TABULAR_NUMS}>
           {priceInfo.entryPriceFormatted}
         </SizableText>
       </YStack>
@@ -998,6 +1054,7 @@ const PositionRowMobileFunding = memo(
                   <SizableText
                     size="$bodyMdMedium"
                     color={otherInfo.fundingSinceOpenColor}
+                    fontVariant={TABULAR_NUMS}
                   >
                     {`${otherInfo.fundingSinceOpenPlusOrMinus}$${otherInfo.fundingSinceOpenFormatted}`}
                   </SizableText>
@@ -1012,6 +1069,7 @@ const PositionRowMobileFunding = memo(
                   <SizableText
                     size="$bodyMdMedium"
                     color={otherInfo.fundingSinceChangeColor}
+                    fontVariant={TABULAR_NUMS}
                   >
                     {`${otherInfo.fundingSinceChangePlusOrMinus}$${otherInfo.fundingSinceChangeFormatted}`}
                   </SizableText>
@@ -1030,6 +1088,7 @@ const PositionRowMobileFunding = memo(
                   <SizableText
                     size="$bodyMdMedium"
                     color={otherInfo.fundingAllTimeColor}
+                    fontVariant={TABULAR_NUMS}
                   >
                     {`${otherInfo.fundingAllPlusOrMinus}$${otherInfo.fundingAllTimeFormatted}`}
                   </SizableText>
@@ -1060,6 +1119,7 @@ const PositionRowMobileFunding = memo(
         <SizableText
           size="$bodySmMedium"
           color={otherInfo.fundingSinceOpenColor}
+          fontVariant={TABULAR_NUMS}
         >
           {`${otherInfo.fundingSinceOpenPlusOrMinus}$${otherInfo.fundingSinceOpenFormatted}`}
         </SizableText>
@@ -1088,7 +1148,11 @@ const PositionRowMobileTPSL = memo(({ coin }: { coin: string }) => {
       }
     });
 
-    return { tpsl: `${tpPrice}/${slPrice}` };
+    return {
+      tpsl: `${formatLocalizedNumberString(
+        tpPrice,
+      )}/${formatLocalizedNumberString(slPrice)}`,
+    };
   }, [currentAssetOpenOrders]);
 
   return (
@@ -1098,7 +1162,11 @@ const PositionRowMobileTPSL = memo(({ coin }: { coin: string }) => {
           id: ETranslations.perp_position_tp_sl,
         })}
       </SizableText>
-      <SizableText size="$bodySmMedium" numberOfLines={1}>
+      <SizableText
+        size="$bodySmMedium"
+        numberOfLines={1}
+        fontVariant={TABULAR_NUMS}
+      >
         {tpslInfo.tpsl}
       </SizableText>
     </YStack>
@@ -1120,8 +1188,12 @@ const PositionRowMobileMarkPrice = memo(({ coin }: { coin: string }) => {
           id: ETranslations.perp_position_mark_price,
         })}
       </SizableText>
-      <SizableText size="$bodySmMedium" numberOfLines={1}>
-        {midFormattedByDecimals || '--'}
+      <SizableText
+        size="$bodySmMedium"
+        numberOfLines={1}
+        fontVariant={TABULAR_NUMS}
+      >
+        {formatLocalizedNumberString(midFormattedByDecimals || '--')}
       </SizableText>
     </YStack>
   );
@@ -1138,7 +1210,7 @@ const PositionRowMobileLiqPrice = memo(
             id: ETranslations.perp_position_liq_price,
           })}
         </SizableText>
-        <SizableText size="$bodySmMedium">
+        <SizableText size="$bodySmMedium" fontVariant={TABULAR_NUMS}>
           {priceInfo.liquidationPriceFormatted}
         </SizableText>
       </YStack>
@@ -1364,10 +1436,10 @@ const PositionRow = memo(
       const entryPrice = new BigNumber(pos.entryPx || '0').toFixed(decimals);
 
       const liquidationPrice = new BigNumber(pos.liquidationPx || '0');
-      const entryPriceFormatted = entryPrice;
-      const liquidationPriceFormatted = liquidationPrice.isZero()
-        ? 'N/A'
-        : liquidationPrice.toFixed(decimals);
+      const entryPriceFormatted = formatLocalizedNumberString(entryPrice);
+      const liquidationPriceFormatted = formatLocalizedNumberString(
+        liquidationPrice.isZero() ? 'N/A' : liquidationPrice.toFixed(decimals),
+      );
 
       return {
         entryPriceFormatted,

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -9,6 +9,7 @@ import {
   IconButton,
   Popover,
   SizableText,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
   YStack,
@@ -19,7 +20,10 @@ import { useSpotPairDisplayMapAtom } from '@onekeyhq/kit-bg/src/states/jotai/ato
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatTime } from '@onekeyhq/shared/src/utils/dateUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  formatLocalizedNumberString,
+  numberFormat,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   getSpotTokenDisplayName,
   getValidPriceDecimals,
@@ -136,7 +140,9 @@ const TradesHistoryRow = memo(
       const decimals = getValidPriceDecimals(price);
       const priceBN = new BigNumber(price);
       const sizeBN = new BigNumber(size);
-      const priceFormatted = priceBN.toFixed(decimals);
+      const priceFormatted = formatLocalizedNumberString(
+        priceBN.toFixed(decimals),
+      );
       const feeFormatted = numberFormat(fee, formatter);
 
       const tradeValue = priceBN.times(sizeBN).toFixed();
@@ -171,11 +177,17 @@ const TradesHistoryRow = memo(
       return (
         <YStack gap="$3">
           <YStack gap="$1.5">
-            <SizableText size={isMobile ? '$bodyMd' : '$bodySm'}>
+            <SizableText
+              size={isMobile ? '$bodyMd' : '$bodySm'}
+              fontVariant={TABULAR_NUMS}
+            >
               {intl.formatMessage({ id: ETranslations.perps_fee_title })}
               {feeRatePercentage}
             </SizableText>
-            <SizableText size={isMobile ? '$bodyMd' : '$bodySm'}>
+            <SizableText
+              size={isMobile ? '$bodyMd' : '$bodySm'}
+              fontVariant={TABULAR_NUMS}
+            >
               {intl.formatMessage({ id: ETranslations.perps_fee_total })}
               {tradeBaseInfo.feeFormatted}
             </SizableText>
@@ -230,7 +242,11 @@ const TradesHistoryRow = memo(
                   {directionInfo.directionStr}
                 </SizableText>
               </XStack>
-              <SizableText size="$bodySm" color="$textSubdued">
+              <SizableText
+                size="$bodySm"
+                color="$textSubdued"
+                fontVariant={TABULAR_NUMS}
+              >
                 {dateInfo.date} {dateInfo.time}
               </SizableText>
             </YStack>
@@ -245,6 +261,7 @@ const TradesHistoryRow = memo(
                   <SizableText
                     size="$bodySm"
                     color={closePnlInfo.closePnlColor}
+                    fontVariant={TABULAR_NUMS}
                   >
                     {`${closePnlInfo.closePnlPlusOrMinus}${closePnlInfo.closePnlFormatted}`}
                   </SizableText>
@@ -280,7 +297,7 @@ const TradesHistoryRow = memo(
                   id: ETranslations.perp_trades_history_price,
                 })}
               </SizableText>
-              <SizableText size="$bodySm">
+              <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
                 {tradeBaseInfo.priceFormatted}
               </SizableText>
             </YStack>
@@ -290,7 +307,9 @@ const TradesHistoryRow = memo(
                   id: ETranslations.perp_position_position_size,
                 })}
               </SizableText>
-              <SizableText size="$bodySm">{tradeBaseInfo.size}</SizableText>
+              <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
+                {tradeBaseInfo.size}
+              </SizableText>
             </YStack>
             <YStack gap="$1" flex={1} alignItems="flex-start">
               <SizableText size="$bodySm" color="$textSubdued">
@@ -298,7 +317,7 @@ const TradesHistoryRow = memo(
                   id: ETranslations.perp_trades_history_trade_value,
                 })}
               </SizableText>
-              <SizableText size="$bodySm">
+              <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
                 {tradeBaseInfo.tradeValueFormatted}
               </SizableText>
             </YStack>
@@ -318,6 +337,7 @@ const TradesHistoryRow = memo(
                     size="$bodySm"
                     color="$textSubdued"
                     dashThickness={0.3}
+                    fontVariant={TABULAR_NUMS}
                   >
                     {tradeBaseInfo.feeFormatted}
                   </DashText>
@@ -358,6 +378,7 @@ const TradesHistoryRow = memo(
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
+                fontVariant={TABULAR_NUMS}
               >
                 {dateInfo.date}
               </SizableText>
@@ -366,6 +387,7 @@ const TradesHistoryRow = memo(
                 ellipsizeMode="tail"
                 size="$bodySm"
                 color="$textSubdued"
+                fontVariant={TABULAR_NUMS}
               >
                 {dateInfo.time}
               </SizableText>
@@ -415,6 +437,7 @@ const TradesHistoryRow = memo(
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
+                fontVariant={TABULAR_NUMS}
               >
                 {tradeBaseInfo.priceFormatted}
               </SizableText>
@@ -430,6 +453,7 @@ const TradesHistoryRow = memo(
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
+                fontVariant={TABULAR_NUMS}
               >{`${tradeBaseInfo.size} ${assetSymbol}`}</SizableText>
             </XStack>
 
@@ -443,6 +467,7 @@ const TradesHistoryRow = memo(
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
+                fontVariant={TABULAR_NUMS}
               >
                 {tradeBaseInfo.tradeValueFormatted}
               </SizableText>
@@ -461,6 +486,7 @@ const TradesHistoryRow = memo(
                     size="$bodySm"
                     color="$textSubdued"
                     dashThickness={0.3}
+                    fontVariant={TABULAR_NUMS}
                   >
                     {tradeBaseInfo.feeFormatted}
                   </DashText>
@@ -485,6 +511,7 @@ const TradesHistoryRow = memo(
               ellipsizeMode="tail"
               size="$bodySm"
               color={closePnlInfo.closePnlColor}
+              fontVariant={TABULAR_NUMS}
             >
               {`${closePnlInfo.closePnlPlusOrMinus}${closePnlInfo.closePnlFormatted}`}
             </SizableText>

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -12,6 +12,7 @@ import {
   Illustration,
   Popover,
   SizableText,
+  TABULAR_NUMS,
   Toast,
   Tooltip,
   XStack,
@@ -285,6 +286,7 @@ function MobileTwapHistoryInfoRow({
         ellipsizeMode="tail"
         textAlign="right"
         maxWidth="60%"
+        fontVariant={TABULAR_NUMS}
       >
         {value}
       </SizableText>
@@ -507,7 +509,11 @@ function TwapActiveRow({
             justifyContent={calcCellAlign(columnConfigs[1].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm" color={sideInfo.color}>
+            <SizableText
+              size="$bodySm"
+              color={sideInfo.color}
+              fontVariant={TABULAR_NUMS}
+            >
               {baseInfo.sizeWithSymbol}
             </SizableText>
           </XStack>
@@ -516,7 +522,11 @@ function TwapActiveRow({
             justifyContent={calcCellAlign(columnConfigs[2].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm" color={sideInfo.color}>
+            <SizableText
+              size="$bodySm"
+              color={sideInfo.color}
+              fontVariant={TABULAR_NUMS}
+            >
               {baseInfo.executedSizeWithSymbol}
             </SizableText>
           </XStack>
@@ -525,7 +535,7 @@ function TwapActiveRow({
             justifyContent={calcCellAlign(columnConfigs[3].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm">
+            <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
               {baseInfo.avgPriceFormatted}
             </SizableText>
           </XStack>
@@ -534,7 +544,9 @@ function TwapActiveRow({
             justifyContent="center"
             alignItems={calcCellAlign(columnConfigs[4].align)}
           >
-            <SizableText size="$bodySm">{baseInfo.runningTimeText}</SizableText>
+            <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
+              {baseInfo.runningTimeText}
+            </SizableText>
           </YStack>
           <XStack
             {...getColumnStyle(columnConfigs[5])}
@@ -555,7 +567,9 @@ function TwapActiveRow({
             justifyContent="center"
             alignItems={calcCellAlign(columnConfigs[7].align)}
           >
-            <SizableText size="$bodySm">{creationTime.inline}</SizableText>
+            <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
+              {creationTime.inline}
+            </SizableText>
           </YStack>
         </>
       ) : null}
@@ -700,7 +714,11 @@ function TwapHistoryRow({
                 {sideInfo.text}
               </SizableText>
             </XStack>
-            <SizableText size="$bodySm" color="$textSubdued">
+            <SizableText
+              size="$bodySm"
+              color="$textSubdued"
+              fontVariant={TABULAR_NUMS}
+            >
               {historyTime.inline}
             </SizableText>
           </YStack>
@@ -793,8 +811,14 @@ function TwapHistoryRow({
             justifyContent="center"
             alignItems={calcCellAlign(columnConfigs[0].align)}
           >
-            <SizableText size="$bodySm">{historyTime.date}</SizableText>
-            <SizableText size="$bodySm" color="$textSubdued">
+            <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
+              {historyTime.date}
+            </SizableText>
+            <SizableText
+              size="$bodySm"
+              color="$textSubdued"
+              fontVariant={TABULAR_NUMS}
+            >
               {historyTime.time}
             </SizableText>
           </YStack>
@@ -812,7 +836,11 @@ function TwapHistoryRow({
             justifyContent={calcCellAlign(columnConfigs[2].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm" color={sideInfo.color}>
+            <SizableText
+              size="$bodySm"
+              color={sideInfo.color}
+              fontVariant={TABULAR_NUMS}
+            >
               {baseInfo.sizeWithSymbol}
             </SizableText>
           </XStack>
@@ -824,6 +852,7 @@ function TwapHistoryRow({
             <SizableText
               size="$bodySm"
               color={isActivated ? undefined : sideInfo.color}
+              fontVariant={TABULAR_NUMS}
             >
               {historyDisplayInfo.executedSize}
             </SizableText>
@@ -833,7 +862,7 @@ function TwapHistoryRow({
             justifyContent={calcCellAlign(columnConfigs[4].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm">
+            <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
               {historyDisplayInfo.averagePrice}
             </SizableText>
           </XStack>
@@ -842,7 +871,7 @@ function TwapHistoryRow({
             justifyContent="center"
             alignItems={calcCellAlign(columnConfigs[5].align)}
           >
-            <SizableText size="$bodySm">
+            <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
               {historyDisplayInfo.totalRuntime}
             </SizableText>
           </YStack>
@@ -960,11 +989,11 @@ function TwapFillRow({
     return (
       <YStack gap="$3">
         <YStack gap="$1.5">
-          <SizableText size="$bodySm">
+          <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
             {intl.formatMessage({ id: ETranslations.perps_fee_title })}
             {feeRatePercentage}
           </SizableText>
-          <SizableText size="$bodySm">
+          <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
             {intl.formatMessage({ id: ETranslations.perps_fee_total })}
             {fillInfo.feeFormatted}
           </SizableText>
@@ -1004,7 +1033,11 @@ function TwapFillRow({
                 {directionInfo.text}
               </SizableText>
             </XStack>
-            <SizableText size="$bodySm" color="$textSubdued">
+            <SizableText
+              size="$bodySm"
+              color="$textSubdued"
+              fontVariant={TABULAR_NUMS}
+            >
               {dateInfo.date} {dateInfo.time}
             </SizableText>
           </YStack>
@@ -1014,7 +1047,11 @@ function TwapFillRow({
                 id: ETranslations.perp_trades_close_pnl,
               })}
             </SizableText>
-            <SizableText size="$bodySm" color={fillInfo.closePnlColor}>
+            <SizableText
+              size="$bodySm"
+              color={fillInfo.closePnlColor}
+              fontVariant={TABULAR_NUMS}
+            >
               {`${fillInfo.closePnlPlusOrMinus}${fillInfo.closePnlFormatted}`}
             </SizableText>
           </YStack>
@@ -1034,7 +1071,9 @@ function TwapFillRow({
                 id: ETranslations.perp_trades_history_price,
               })}
             </SizableText>
-            <SizableText size="$bodySm">{fillInfo.priceFormatted}</SizableText>
+            <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
+              {fillInfo.priceFormatted}
+            </SizableText>
           </YStack>
           <YStack gap="$1" flex={1} alignItems="flex-start">
             <SizableText size="$bodySm" color="$textSubdued">
@@ -1042,7 +1081,9 @@ function TwapFillRow({
                 id: ETranslations.perp_position_position_size,
               })}
             </SizableText>
-            <SizableText size="$bodySm">{fillInfo.sizeFormatted}</SizableText>
+            <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
+              {fillInfo.sizeFormatted}
+            </SizableText>
           </YStack>
           <YStack gap="$1" flex={1} alignItems="flex-start">
             <SizableText size="$bodySm" color="$textSubdued">
@@ -1050,7 +1091,9 @@ function TwapFillRow({
                 id: ETranslations.perp_trades_history_trade_value,
               })}
             </SizableText>
-            <SizableText size="$bodySm">{fillInfo.valueFormatted}</SizableText>
+            <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
+              {fillInfo.valueFormatted}
+            </SizableText>
           </YStack>
           <YStack gap="$1" flex={1} alignItems="flex-end">
             <SizableText size="$bodySm" color="$textSubdued">
@@ -1068,6 +1111,7 @@ function TwapFillRow({
                   size="$bodySm"
                   color="$textSubdued"
                   dashThickness={0.3}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {fillInfo.feeFormatted}
                 </DashText>
@@ -1104,8 +1148,14 @@ function TwapFillRow({
             justifyContent="center"
             alignItems={calcCellAlign(columnConfigs[0].align)}
           >
-            <SizableText size="$bodySm">{dateInfo.date}</SizableText>
-            <SizableText size="$bodySm" color="$textSubdued">
+            <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
+              {dateInfo.date}
+            </SizableText>
+            <SizableText
+              size="$bodySm"
+              color="$textSubdued"
+              fontVariant={TABULAR_NUMS}
+            >
               {dateInfo.time}
             </SizableText>
           </YStack>
@@ -1130,21 +1180,27 @@ function TwapFillRow({
             justifyContent={calcCellAlign(columnConfigs[3].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm">{fillInfo.priceFormatted}</SizableText>
+            <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
+              {fillInfo.priceFormatted}
+            </SizableText>
           </XStack>
           <XStack
             {...getColumnStyle(columnConfigs[4])}
             justifyContent={calcCellAlign(columnConfigs[4].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm">{fillInfo.sizeFormatted}</SizableText>
+            <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
+              {fillInfo.sizeFormatted}
+            </SizableText>
           </XStack>
           <XStack
             {...getColumnStyle(columnConfigs[5])}
             justifyContent={calcCellAlign(columnConfigs[5].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm">{fillInfo.valueFormatted}</SizableText>
+            <SizableText size="$bodySm" fontVariant={TABULAR_NUMS}>
+              {fillInfo.valueFormatted}
+            </SizableText>
           </XStack>
           <XStack
             {...getColumnStyle(columnConfigs[6])}
@@ -1158,6 +1214,7 @@ function TwapFillRow({
                   size="$bodySm"
                   color="$textSubdued"
                   dashThickness={0.3}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {fillInfo.feeFormatted}
                 </DashText>
@@ -1178,6 +1235,7 @@ function TwapFillRow({
             ellipsizeMode="tail"
             size="$bodySm"
             color={fillInfo.closePnlColor}
+            fontVariant={TABULAR_NUMS}
           >
             {`${fillInfo.closePnlPlusOrMinus}${fillInfo.closePnlFormatted}`}
           </SizableText>

--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -8,6 +8,7 @@ import {
   Divider,
   Popover,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useMedia,
@@ -221,19 +222,14 @@ function MobileHeader({
             <YStack gap="$3">
               <XStack justifyContent="space-between" alignItems="center">
                 <XStack gap="$1" alignItems="center">
-                  <SizableText
-                    size="$headingXs"
-                    fontFamily="$monoRegular"
-                    fontVariant={['tabular-nums']}
-                  >
+                  <SizableText size="$headingXs">
                     {intl.formatMessage({
                       id: ETranslations.perps_hourly,
                     })}
                   </SizableText>
                   <SizableText
                     size="$headingXs"
-                    fontFamily="$monoRegular"
-                    fontVariant={['tabular-nums']}
+                    fontVariant={TABULAR_NUMS}
                     color="$textSubdued"
                   >
                     ({countdown})
@@ -241,84 +237,63 @@ function MobileHeader({
                 </XStack>
                 <SizableText
                   size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
+                  fontVariant={TABULAR_NUMS}
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
                 >
                   {hourlyFundingRate}%
                 </SizableText>
               </XStack>
               <XStack justifyContent="space-between" alignItems="center">
-                <SizableText
-                  size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
-                >
+                <SizableText size="$headingXs">
                   {intl.formatMessage({
                     id: ETranslations.earn_daily,
                   })}
                 </SizableText>
                 <SizableText
                   size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
+                  fontVariant={TABULAR_NUMS}
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
                 >
                   {dailyFundingRate}%
                 </SizableText>
               </XStack>
               <XStack justifyContent="space-between" alignItems="center">
-                <SizableText
-                  size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
-                >
+                <SizableText size="$headingXs">
                   {intl.formatMessage({
                     id: ETranslations.earn_weekly,
                   })}
                 </SizableText>
                 <SizableText
                   size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
+                  fontVariant={TABULAR_NUMS}
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
                 >
                   {weeklyFundingRate}%
                 </SizableText>
               </XStack>
               <XStack justifyContent="space-between" alignItems="center">
-                <SizableText
-                  size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
-                >
+                <SizableText size="$headingXs">
                   {intl.formatMessage({
                     id: ETranslations.earn_monthly,
                   })}
                 </SizableText>
                 <SizableText
                   size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
+                  fontVariant={TABULAR_NUMS}
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
                 >
                   {monthlyFundingRate}%
                 </SizableText>
               </XStack>
               <XStack justifyContent="space-between" alignItems="center">
-                <SizableText
-                  size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
-                >
+                <SizableText size="$headingXs">
                   {intl.formatMessage({
                     id: ETranslations.earn_annually,
                   })}
                 </SizableText>
                 <SizableText
                   size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
+                  fontVariant={TABULAR_NUMS}
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
                 >
                   {annualizedFundingRate}%

--- a/packages/kit/src/views/Perp/components/TickerBar/MobilePerpMarketHeader.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/MobilePerpMarketHeader.tsx
@@ -10,6 +10,7 @@ import {
   Popover,
   SizableText,
   Skeleton,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -270,6 +271,7 @@ function MobilePerpMarketHeader() {
               lineHeight={14}
               color="$textSubdued"
               dashThickness={0.5}
+              fontVariant={TABULAR_NUMS}
             >
               {markPriceDisplay}
             </DashText>
@@ -419,7 +421,9 @@ function MobilePerpMarketHeader() {
                 </YStack>
               }
             />
-            <SizableText size="$heading2xl">{midPrice}</SizableText>
+            <SizableText size="$heading2xl" fontVariant={TABULAR_NUMS}>
+              {midPrice}
+            </SizableText>
           </>
 
           {priceMetaContent}
@@ -431,7 +435,12 @@ function MobilePerpMarketHeader() {
               id: ETranslations.perp_token_bar_24h_Volume,
             })}
           >
-            <SizableText size="$bodySmMedium" color="$text" textAlign="right">
+            <SizableText
+              size="$bodySmMedium"
+              color="$text"
+              textAlign="right"
+              fontVariant={TABULAR_NUMS}
+            >
               {volumeDisplay}
             </SizableText>
           </StatRow>
@@ -443,7 +452,12 @@ function MobilePerpMarketHeader() {
                 : ETranslations.perp_token_bar_open_Interest,
             })}
           >
-            <SizableText size="$bodySmMedium" color="$text" textAlign="right">
+            <SizableText
+              size="$bodySmMedium"
+              color="$text"
+              textAlign="right"
+              fontVariant={TABULAR_NUMS}
+            >
               {openInterestDisplay}
             </SizableText>
           </StatRow>
@@ -458,6 +472,7 @@ function MobilePerpMarketHeader() {
                 size="$bodySmMedium"
                 textAlign="right"
                 color={fundingColor}
+                fontVariant={TABULAR_NUMS}
               >
                 {fundingDisplay}
               </SizableText>
@@ -495,6 +510,7 @@ function MobilePerpMarketHeader() {
                 size="$bodySmMedium"
                 textAlign="right"
                 color="$green11"
+                fontVariant={TABULAR_NUMS}
               >
                 0%
               </SizableText>

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
@@ -12,6 +12,7 @@ import {
   ScrollView,
   SizableText,
   SkeletonContainer,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
   YStack,
@@ -53,11 +54,12 @@ import { useSpotMetaMaps } from '../../hooks/useSpotMetaMaps';
 import { PerpTokenSelector } from '../TokenSelector/PerpTokenSelector';
 import { FavoriteButton } from '../TokenSelector/PerpTokenSelectorRow';
 
+// Medium-weight (500) data values — the heading tokens' 600 reads too heavy
+// for a dense stat strip of tabular digits, while plain 400 gets lost against
+// the subdued labels at this size.
 const TICKER_BAR_STAT_VALUE_TEXT_PROPS = {
-  size: '$headingXs',
-  fontFamily: '$monoRegular',
-  textTransform: 'none',
-  letterSpacing: 0,
+  size: '$bodySmMedium',
+  fontVariant: TABULAR_NUMS,
 } as const;
 
 const TICKER_BAR_STAT_LABEL_VALUE_GAP = 5;
@@ -175,7 +177,12 @@ const TickerBarMarkPriceView = memo(
           <Tooltip
             placement="top"
             renderTrigger={
-              <SizableText size="$headingXl" cursor="help">
+              <SizableText
+                size="$headingXl"
+                fontWeight="500"
+                cursor="help"
+                fontVariant={TABULAR_NUMS}
+              >
                 {formattedMarkPrice}
               </SizableText>
             }
@@ -201,7 +208,7 @@ function TickerBarMarkPrice() {
   const isSpot = tradingMode === 'spot';
   const formattedMarkPrice = isSpot
     ? formatLocalizedNumberString(spotAssetCtx?.ctx?.markPrice || '')
-    : assetCtx?.ctx?.markPrice || '';
+    : formatLocalizedNumberString(assetCtx?.ctx?.markPrice || '');
   const isLoading = useTickerBarIsLoading();
   useEffect(() => {
     if (!isLoading && formattedMarkPrice) {
@@ -241,7 +248,7 @@ const TickerBarChange24hPercentView = memo(
     >
       <SkeletonContainer isLoading={isLoading} width={50} height={16}>
         <NumberSizeableText
-          size={gtMd ? '$headingXs' : '$bodySmMedium'}
+          size="$bodySmMedium"
           fontSize={gtMd ? undefined : 10}
           mt={gtMd ? undefined : '$-2'}
           color={change24hPercent >= 0 ? '$green11' : '$red11'}
@@ -314,10 +321,7 @@ const TickerBarOraclePriceView = memo(
             placement="top"
           />
           <SkeletonContainer isLoading={isLoading} width={80} height={16}>
-            <SizableText
-              {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-              fontVariant={['tabular-nums']}
-            >
+            <SizableText {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}>
               {formattedOraclePrice}
             </SizableText>
           </SkeletonContainer>
@@ -330,7 +334,9 @@ TickerBarOraclePriceView.displayName = 'TickerBarOraclePriceView';
 
 function TickerBarOraclePrice() {
   const assetCtx = useTickerBarPerpAssetCtx();
-  const formattedOraclePrice = assetCtx?.ctx?.oraclePrice || '';
+  const formattedOraclePrice = formatLocalizedNumberString(
+    assetCtx?.ctx?.oraclePrice || '',
+  );
   const isLoading = useTickerBarIsLoading();
 
   return (
@@ -359,10 +365,7 @@ const TickerBar24hVolumeView = memo(
             })}
           </SizableText>
           <SkeletonContainer isLoading={isLoading} width={80} height={16}>
-            <SizableText
-              {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-              fontVariant={['tabular-nums']}
-            >
+            <SizableText {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}>
               ${formattedVolume24h}
             </SizableText>
           </SkeletonContainer>
@@ -432,10 +435,7 @@ const TickerBarOpenInterestView = memo(
             placement="top"
           />
           <SkeletonContainer isLoading={isLoading} width={80} height={16}>
-            <SizableText
-              {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-              fontVariant={['tabular-nums']}
-            >
+            <SizableText {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}>
               ${formattedOpenInterest}
             </SizableText>
           </SkeletonContainer>
@@ -484,10 +484,7 @@ const TickerBarMarketCapView = memo(
             })}
           </SizableText>
           <SkeletonContainer isLoading={isLoading} width={80} height={16}>
-            <SizableText
-              {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-              fontVariant={['tabular-nums']}
-            >
+            <SizableText {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}>
               {formattedMarketCap === '--'
                 ? formattedMarketCap
                 : `$${formattedMarketCap}`}
@@ -543,6 +540,7 @@ const TickerBarSpotContractView = memo(
             <XStack gap="$1" alignItems="center">
               <SizableText
                 {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
+                fontFamily="$monoRegular"
                 color="$text"
                 numberOfLines={1}
               >
@@ -604,11 +602,7 @@ function TickerBarFundingRateCountdown() {
       position="bottom-right"
       offsetX={10}
     >
-      <SizableText
-        {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-        color="$text"
-        fontVariant={['tabular-nums']}
-      >
+      <SizableText {...TICKER_BAR_STAT_VALUE_TEXT_PROPS} color="$text">
         {countdown}
       </SizableText>
     </DebugRenderTracker>
@@ -654,7 +648,6 @@ const TickerBarFundingRateView = memo(
                   <XStack alignItems="center" gap="$2">
                     <DashText
                       {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-                      fontVariant={['tabular-nums']}
                       color={fundingRate >= 0 ? '$green11' : '$red11'}
                       dashThickness={0.5}
                       dashSpacing={0}
@@ -672,22 +665,12 @@ const TickerBarFundingRateView = memo(
                         justifyContent="space-between"
                         alignItems="center"
                       >
-                        <SizableText
-                          size="$headingXs"
-                          fontFamily="$monoRegular"
-                          fontVariant={['tabular-nums']}
-                          color="$textSubdued"
-                        >
+                        <SizableText size="$bodySm" color="$textSubdued">
                           {intl.formatMessage({
                             id: ETranslations.perps_fee_rate_projection,
                           })}
                         </SizableText>
-                        <SizableText
-                          size="$headingXs"
-                          fontFamily="$monoRegular"
-                          fontVariant={['tabular-nums']}
-                          color="$textSubdued"
-                        >
+                        <SizableText size="$bodySm" color="$textSubdued">
                           {intl.formatMessage({
                             id: ETranslations.perp_position_funding,
                           })}
@@ -699,28 +682,22 @@ const TickerBarFundingRateView = memo(
                           alignItems="center"
                         >
                           <XStack gap="$1" alignItems="center">
-                            <SizableText
-                              size="$headingXs"
-                              fontFamily="$monoRegular"
-                              fontVariant={['tabular-nums']}
-                            >
+                            <SizableText size="$bodySm">
                               {intl.formatMessage({
                                 id: ETranslations.perps_hourly,
                               })}
                             </SizableText>
                             <SizableText
-                              size="$headingXs"
-                              fontFamily="$monoRegular"
-                              fontVariant={['tabular-nums']}
+                              size="$bodySm"
+                              fontVariant={TABULAR_NUMS}
                               color="$textSubdued"
                             >
                               ({countdown})
                             </SizableText>
                           </XStack>
                           <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
+                            size="$bodySm"
+                            fontVariant={TABULAR_NUMS}
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
                           >
                             {hourlyFundingRate}%
@@ -730,19 +707,14 @@ const TickerBarFundingRateView = memo(
                           justifyContent="space-between"
                           alignItems="center"
                         >
-                          <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
-                          >
+                          <SizableText size="$bodySm">
                             {intl.formatMessage({
                               id: ETranslations.earn_daily,
                             })}
                           </SizableText>
                           <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
+                            size="$bodySm"
+                            fontVariant={TABULAR_NUMS}
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
                           >
                             {dailyFundingRate}%
@@ -752,19 +724,14 @@ const TickerBarFundingRateView = memo(
                           justifyContent="space-between"
                           alignItems="center"
                         >
-                          <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
-                          >
+                          <SizableText size="$bodySm">
                             {intl.formatMessage({
                               id: ETranslations.earn_weekly,
                             })}
                           </SizableText>
                           <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
+                            size="$bodySm"
+                            fontVariant={TABULAR_NUMS}
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
                           >
                             {weeklyFundingRate}%
@@ -774,19 +741,14 @@ const TickerBarFundingRateView = memo(
                           justifyContent="space-between"
                           alignItems="center"
                         >
-                          <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
-                          >
+                          <SizableText size="$bodySm">
                             {intl.formatMessage({
                               id: ETranslations.earn_monthly,
                             })}
                           </SizableText>
                           <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
+                            size="$bodySm"
+                            fontVariant={TABULAR_NUMS}
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
                           >
                             {monthlyFundingRate}%
@@ -796,19 +758,14 @@ const TickerBarFundingRateView = memo(
                           justifyContent="space-between"
                           alignItems="center"
                         >
-                          <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
-                          >
+                          <SizableText size="$bodySm">
                             {intl.formatMessage({
                               id: ETranslations.earn_annually,
                             })}
                           </SizableText>
                           <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
+                            size="$bodySm"
+                            fontVariant={TABULAR_NUMS}
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
                           >
                             {annualizedFundingRate}%
@@ -818,11 +775,7 @@ const TickerBarFundingRateView = memo(
                     </YStack>
                     <Divider />
                     <YStack gap="$2" justifyContent="space-between">
-                      <SizableText
-                        size="$headingXs"
-                        fontVariant={['tabular-nums']}
-                        color="$textSubdued"
-                      >
+                      <SizableText size="$bodySm" color="$textSubdued">
                         {intl.formatMessage({
                           id: ETranslations.perp_trades_history_direction,
                         })}
@@ -863,7 +816,7 @@ const TickerBarFundingRateView = memo(
                     </YStack>
                     <Divider />
                     <YStack gap="$2">
-                      <SizableText size="$headingXs" color="$textSubdued">
+                      <SizableText size="$bodySm" color="$textSubdued">
                         {intl.formatMessage({
                           id: ETranslations.perp_funding_rate_tip0,
                         })}

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -24,6 +24,7 @@ import {
   SearchBar,
   SizableText,
   Spinner,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
   YStack,
@@ -1462,7 +1463,7 @@ const PerpTickerChangeLeaf = memo(
       return (
         <SizableText
           fontSize={10}
-          fontFamily="$monoRegular"
+          fontVariant={TABULAR_NUMS}
           color="$textSubdued"
           alignSelf="center"
         >
@@ -1473,8 +1474,6 @@ const PerpTickerChangeLeaf = memo(
     return (
       <NumberSizeableText
         style={{ fontSize: 10 }}
-        fontFamily="$monoRegular"
-        fontVariant={['tabular-nums']}
         alignSelf="center"
         color={change24hPercent < 0 ? '$red11' : '$green11'}
         formatter="priceChange"

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -22,7 +22,10 @@ import {
   usePerpsCustomSettingsAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  formatLocalizedNumberString,
+  numberFormat,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   formatPriceToSignificantDigits,
   formatSpotPriceToValid,
@@ -65,7 +68,7 @@ function formatOrderPriceDisplay({
   const formattedPrice = isSpot
     ? formatSpotPriceToValid(price, szDecimals)
     : formatPriceToSignificantDigits(price, szDecimals);
-  return `$${formattedPrice}`;
+  return `$${formatLocalizedNumberString(formattedPrice)}`;
 }
 
 interface IOrderConfirmContentProps {

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/EarnAmountText.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/EarnAmountText.tsx
@@ -1,6 +1,10 @@
 import { useMemo } from 'react';
 
-import { NumberSizeableText, SizableText } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  TABULAR_NUMS,
+} from '@onekeyhq/components';
 import type { ISizableTextProps } from '@onekeyhq/components';
 import { FormatHyperlinkText } from '@onekeyhq/kit/src/components/HyperlinkText';
 
@@ -67,7 +71,11 @@ export function EarnAmountText({
 
   // Percentages and unrecognized text: render as-is
   if (parsed.type === 'passthrough') {
-    return <SizableText {...textProps}>{text}</SizableText>;
+    return (
+      <SizableText fontVariant={TABULAR_NUMS} {...textProps}>
+        {text}
+      </SizableText>
+    );
   }
 
   // Pure number without suffix

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/PortfolioSection.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/PortfolioSection.tsx
@@ -16,8 +16,10 @@ import {
   Popover,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
+  getFontVariantStyle,
 } from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -120,7 +122,9 @@ function PortfolioItem({
         ) : null}
         {badgeText ? (
           <Badge badgeType={badgeType}>
-            <Badge.Text>{badgeText}</Badge.Text>
+            <Badge.Text style={getFontVariantStyle(TABULAR_NUMS)}>
+              {badgeText}
+            </Badge.Text>
           </Badge>
         ) : null}
       </XStack>

--- a/packages/kit/src/views/Swap/components/SwapProBuySellInfo.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProBuySellInfo.tsx
@@ -6,6 +6,7 @@ import {
   NumberSizeableText,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -45,7 +46,6 @@ const SwapProBuySellInfo = ({
       <NumberSizeableText
         size="$bodySm"
         color="$textSuccess"
-        fontFamily="$monoRegular"
         formatter={isAboveThreshold ? 'marketCap' : 'value'}
         formatterOptions={{ currency: '$' }}
       >
@@ -69,7 +69,6 @@ const SwapProBuySellInfo = ({
       <NumberSizeableText
         size="$bodySm"
         color="$textCritical"
-        fontFamily="$monoRegular"
         formatter={isAboveThreshold ? 'marketCap' : 'value'}
         formatterOptions={{ currency: '$' }}
       >
@@ -149,7 +148,7 @@ const SwapProBuySellInfo = ({
             size="$bodyXs"
             color="$textSuccess"
             ml="$0.5"
-            fontFamily="$monoRegular"
+            fontVariant={TABULAR_NUMS}
           >
             {!supportSpeedSwap ? '--' : buyPercentage.toFixed(2)}%
           </SizableText>
@@ -165,7 +164,7 @@ const SwapProBuySellInfo = ({
             size="$bodyXs"
             color="$textCritical"
             mr="$0.5"
-            fontFamily="$monoRegular"
+            fontVariant={TABULAR_NUMS}
           >
             {!supportSpeedSwap ? '--' : sellPercentage.toFixed(2)}%
           </SizableText>

--- a/packages/kit/src/views/Swap/components/SwapProPositionItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProPositionItem.tsx
@@ -8,6 +8,7 @@ import {
   NumberSizeableText,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -128,6 +129,7 @@ const SwapProPositionItem = ({
             size="$bodyMd"
             color={pnlDisplay.color}
             numberOfLines={1}
+            fontVariant={TABULAR_NUMS}
           >
             {pnlDisplay.text}
           </SizableText>

--- a/packages/kit/src/views/Swap/components/SwapProTokenTransactionItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProTokenTransactionItem.tsx
@@ -2,7 +2,12 @@ import { useMemo } from 'react';
 
 import BigNumber from 'bignumber.js';
 
-import { NumberSizeableText, SizableText, XStack } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+} from '@onekeyhq/components';
 import type { IMarketTokenTransaction } from '@onekeyhq/shared/types/marketV2';
 
 interface ISwapProTokenTransactionItemProps {
@@ -35,7 +40,7 @@ const SwapProTokenTransactionItem = ({
       <SizableText
         size="$bodySm"
         color={textColorValue}
-        fontFamily="$monoRegular"
+        fontVariant={TABULAR_NUMS}
       >
         {FALLBACK_DISPLAY};
       </SizableText>
@@ -46,7 +51,6 @@ const SwapProTokenTransactionItem = ({
         <NumberSizeableText
           size="$bodySm"
           color={textColorValue}
-          fontFamily="$monoRegular"
           formatter={isAboveThreshold ? 'marketCap' : 'price'}
           formatterOptions={{
             currency: '$',
@@ -61,7 +65,7 @@ const SwapProTokenTransactionItem = ({
       <SizableText
         size="$bodySm"
         color={textColorValue}
-        fontFamily="$monoRegular"
+        fontVariant={TABULAR_NUMS}
       >
         {FALLBACK_DISPLAY};
       </SizableText>
@@ -75,7 +79,6 @@ const SwapProTokenTransactionItem = ({
         <NumberSizeableText
           size="$bodySm"
           color={textColorValue}
-          fontFamily="$monoRegular"
           formatter={isAboveThreshold ? 'marketCap' : 'value'}
           formatterOptions={{
             currency: '$',

--- a/packages/kit/src/views/Swap/components/SwapRateInfoItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapRateInfoItem.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 
 import BigNumber from 'bignumber.js';
 
-import { SizableText, XStack } from '@onekeyhq/components';
+import { SizableText, TABULAR_NUMS, XStack } from '@onekeyhq/components';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
@@ -49,7 +49,11 @@ const SwapRateInfoItem = ({
       cursor="pointer"
       onPress={handleExchangeRate}
     >
-      <SizableText color="$textSubdued" size="$bodyMd">
+      <SizableText
+        color="$textSubdued"
+        size="$bodyMd"
+        fontVariant={TABULAR_NUMS}
+      >
         {rateContent}
       </SizableText>
     </XStack>

--- a/packages/kit/src/views/Swap/pages/components/SwapProPriceInfo.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProPriceInfo.tsx
@@ -1,6 +1,11 @@
 import { useMemo } from 'react';
 
-import { NumberSizeableText, SizableText, YStack } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  TABULAR_NUMS,
+  YStack,
+} from '@onekeyhq/components';
 import { useCurrency } from '@onekeyhq/kit/src/components/Currency';
 import {
   useSwapProSelectTokenAtom,
@@ -83,7 +88,7 @@ const SwapProPriceInfo = ({ onPricePress }: ISwapProPriceInfoProps) => {
       <NumberSizeableText
         size="$headingLg"
         color={textColor}
-        fontFamily="$monoMedium"
+        fontWeight="500"
         formatter="price"
         formatterOptions={{
           currency: '$',
@@ -104,7 +109,7 @@ const SwapProPriceInfo = ({ onPricePress }: ISwapProPriceInfoProps) => {
       <SizableText
         size="$bodySmMedium"
         color={textColor}
-        fontFamily="$monoMedium"
+        fontVariant={TABULAR_NUMS}
       >
         {formattedPriceChange}
       </SizableText>

--- a/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
@@ -18,6 +18,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useMedia,
@@ -951,7 +952,6 @@ function SwapKLineTokenPriceInfo({
       {price ? (
         <NumberSizeableText
           size={compact ? '$bodyMdMedium' : '$bodyLgMedium'}
-          fontFamily="$monoMedium"
           formatter="price"
           formatterOptions={{ currency: '$' }}
           numberOfLines={1}
@@ -963,7 +963,7 @@ function SwapKLineTokenPriceInfo({
         <SizableText
           size={compact ? '$bodyMdMedium' : '$bodyLgMedium'}
           color="$textSubdued"
-          fontFamily="$monoMedium"
+          fontVariant={TABULAR_NUMS}
           numberOfLines={1}
         >
           --
@@ -972,7 +972,6 @@ function SwapKLineTokenPriceInfo({
       {priceChange ? (
         <PriceChangePercentage
           size={compact ? '$bodyXsMedium' : '$bodySmMedium'}
-          fontFamily="$monoMedium"
           numberOfLines={1}
         >
           {priceChange}
@@ -981,7 +980,7 @@ function SwapKLineTokenPriceInfo({
         <SizableText
           size="$bodySmMedium"
           color="$textSubdued"
-          fontFamily="$monoMedium"
+          fontVariant={TABULAR_NUMS}
           numberOfLines={1}
         >
           --


### PR DESCRIPTION
## Summary

Unify numeric typography across the trading UI: numbers now align in columns via the OpenType `tabular-nums` feature (tnum) instead of mono fonts, and quoted prices gain locale-aware thousands separators. Also softens the perps ticker-bar font weights (600 → 500) which read too heavy at small sizes.

**Hot-update scope**: JS-only — no native changes, no dependency changes. Branched from `release/v6.4.0` per the bundle release flow.

## What changed

### Core (`@onekeyhq/components`) — commit 1
- **`SizeableText`**: the RN `fontVariant` prop was silently dropped by Tamagui app-wide; it is now translated into real styles (web `font-variant-numeric` / native `style.fontVariant`) via a cached, allocation-free helper (`getFontVariantStyle`, also maps `small-caps`).
- **`NumberSizeableText`**: defaults `fontVariant` to `TABULAR_NUMS` — every formatted number in the app (balances, prices, price changes) gets tabular digits automatically; callers can override.
- New shared `TABULAR_NUMS` constant (`packages/components/src/utils/tabularNums.ts`); five duplicated local copies in DeFi/NetworkStatusBadge were consolidated onto it.
- `Badge.Text` sites (NetworkStatusBadge countdown etc.) apply the feature via `style` since Badge.Text bypasses the SizeableText wrapper.

### Trading UI (`@onekeyhq/kit`) — commit 2
- **Perp**: order book (incl. thousands-separated `displayPrice`, split from the raw `price` used by order-form selection), ticker bars (desktop + mobile), positions / open orders / trades history / TWAP / account / balance rows, token selector, order confirm modal.
- **Perps ticker bar (desktop)**: stat values `$headingXs` (600, uppercase label token) → `$bodySmMedium` (500); headline mark price 600 → 500; oracle price now thousands-separated.
- **Market**: V1 chart extreme labels.
- **Earn / Borrow / Staking**: APY texts (`AprText`, `ApyTextV2`), overview stat values, reserve details, claim dialogs — applied only where the server-driven text binding is explicitly a numeric amount (`*Balance`, `*Apy`, `amount`, `netWorth`, …); generic `title`/`description` bindings are deliberately left alone.
- **Swap Pro**: price info, buy/sell info, transaction items, K-line content (mono → tnum).
- **DeFi home blocks**: mono → tnum, local consts consolidated.

### Localized thousands separators
All separator work goes through the existing locale-aware `formatLocalizedNumberString` (grouping/decimal symbols from `appLocale` + `LOCALE_SEPARATORS`), so European formats (`78.056,1`) and Indian grouping work out of the box. Formatting happens at the producer memos, not in JSX, so each value is formatted once.

## Verification
- `tsgo --noEmit`: 0 errors; `oxlint --type-aware --deny-warnings` on all 86 changed files: clean; `numberUtils.locale.test.ts`: 72/72 passed.
- Live web verification (playwright probes on the running app): perps ticker/order book, Market home (1118 numeric elements tabular), /defi Earn+Borrow — computed `font-variant-numeric: tabular-nums` confirmed on the DOM, separators rendered.

<details>
<summary>All 86 modified files</summary>

```
development/spellCheckerSkipWords.txt
packages/components/src/composite/SegmentSlider/index.tsx
packages/components/src/content/NetworkStatusBadge/index.tsx
packages/components/src/content/NumberSizeableText/index.tsx
packages/components/src/primitives/SizeableText/index.tsx
packages/components/src/utils/index.ts
packages/components/src/utils/tabularNums.ts
packages/kit/src/components/CountDownCalendarAlert/index.tsx
packages/kit/src/components/Resource/TronResource.tsx
packages/kit/src/views/Borrow/components/BorrowAssetSelectPopover/index.tsx
packages/kit/src/views/Borrow/components/BorrowBonusTooltip.tsx
packages/kit/src/views/Borrow/components/BorrowHealthFactorTooltip.tsx
packages/kit/src/views/Borrow/components/BorrowRepayPosition.tsx
packages/kit/src/views/Borrow/components/BorrowTableList/AmountField.tsx
packages/kit/src/views/Borrow/components/BorrowTableList/ApyTextV2.tsx
packages/kit/src/views/Borrow/components/BorrowTableList/AssetField.tsx
packages/kit/src/views/Borrow/components/BorrowTableList/AssetWithAmountField.tsx
packages/kit/src/views/Borrow/components/BorrowedCard.tsx
packages/kit/src/views/Borrow/components/CircleProgress.tsx
packages/kit/src/views/Borrow/components/HealthFactor.tsx
packages/kit/src/views/Borrow/components/Overview.tsx
packages/kit/src/views/Borrow/components/SuppliedCard.tsx
packages/kit/src/views/Borrow/pages/ReserveDetails/components/ApyChartSection.tsx
packages/kit/src/views/Borrow/pages/ReserveDetails/components/InterestRateModelChartShared.tsx
packages/kit/src/views/Borrow/pages/ReserveDetails/components/ManagePositionPart.tsx
packages/kit/src/views/Borrow/pages/ReserveDetails/components/PlatformBonusSection.tsx
packages/kit/src/views/Borrow/pages/ReserveDetails/components/ReserveProtocolHeader.native.tsx
packages/kit/src/views/Borrow/pages/ReserveDetails/components/ReserveProtocolHeader.tsx
packages/kit/src/views/Borrow/pages/ReserveDetails/components/UserInfoSection.tsx
packages/kit/src/views/Earn/components/AprText.tsx
packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
packages/kit/src/views/Home/components/DeFiListBlock/DeFiOverviewTile.tsx
packages/kit/src/views/Home/components/DeFiListBlock/DeFiPortfolioStackedBar.tsx
packages/kit/src/views/Home/components/DeFiListBlock/ProtocolAssetBalanceText.tsx
packages/kit/src/views/Home/components/DeFiListBlock/ProtocolHeaderRow.tsx
packages/kit/src/views/Home/components/DeFiListBlock/ProtocolSectionedPositionTable.tsx
packages/kit/src/views/Home/components/DeFiListBlock/ProtocolUnifiedTable.tsx
packages/kit/src/views/Home/components/NFTListView/NFTListItem.tsx
packages/kit/src/views/Home/pages/DeFiContainer.tsx
packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/layout/HolderItemNormal/HolderItemNormal.tsx
packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/layout/HolderItemSmall/HolderItemSmall.tsx
packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/components/PnlCell.tsx
packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/components/TransactionRelativeTime.tsx
packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/components/TimeRangeSelector.tsx
packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderRight.tsx
packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx
packages/kit/src/views/Market/MarketDetailV2/components/TokenOverview/components/StatCard.tsx
packages/kit/src/views/Market/MarketDetailV2/components/TokenSecurityAlert/TokenSecurityAlert.tsx
packages/kit/src/views/Market/MarketDetailV2/components/TokenSecurityAlert/components/TokenSecurityAlertDialogContentOverview.tsx
packages/kit/src/views/Market/MarketDetailV2/components/TokenSupplementaryInfo/TokenSupplementaryInfo.tsx
packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerItem.tsx
packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/usePerpsColumns.tsx
packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
packages/kit/src/views/Market/components/Chart/PriceLabel.tsx
packages/kit/src/views/Market/components/Chart/value-chart/ExtremeLabels.tsx
packages/kit/src/views/Market/components/MarketDetailOverview.tsx
packages/kit/src/views/Market/components/MarketHomeList.tsx
packages/kit/src/views/Market/components/PerpsBadges.tsx
packages/kit/src/views/Market/components/PoolDetailDialog.tsx
packages/kit/src/views/Market/components/PriceChangePercentage.tsx
packages/kit/src/views/Perp/components/OrderBook/DefaultLoadingNode.tsx
packages/kit/src/views/Perp/components/OrderBook/index.tsx
packages/kit/src/views/Perp/components/OrderBook/types.ts
packages/kit/src/views/Perp/components/OrderBook/useAggregatedBook.tsx
packages/kit/src/views/Perp/components/OrderInfoPanel/Components/AccountRow.tsx
packages/kit/src/views/Perp/components/OrderInfoPanel/Components/BalanceRow.tsx
packages/kit/src/views/Perp/components/OrderInfoPanel/Components/MobileTwapOpenOrdersRow.tsx
packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
packages/kit/src/views/Perp/components/PerpOrderBook.tsx
packages/kit/src/views/Perp/components/TickerBar/MobilePerpMarketHeader.tsx
packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
packages/kit/src/views/Staking/components/ProtocolDetails/EarnAmountText.tsx
packages/kit/src/views/Staking/components/ProtocolDetails/PortfolioSection.tsx
packages/kit/src/views/Swap/components/SwapProBuySellInfo.tsx
packages/kit/src/views/Swap/components/SwapProPositionItem.tsx
packages/kit/src/views/Swap/components/SwapProTokenTransactionItem.tsx
packages/kit/src/views/Swap/components/SwapRateInfoItem.tsx
packages/kit/src/views/Swap/pages/components/SwapProPriceInfo.tsx
packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
```
</details>
