### PR TITLE
fix: polish perps market layout and interactions(OK-57734)

### DIFF
--- a/packages/components/src/content/NetworkStatusBadge/index.tsx
+++ b/packages/components/src/content/NetworkStatusBadge/index.tsx
@@ -80,18 +80,17 @@ export function NetworkStatusBadge({
       borderRadius="$full"
       pl="$2"
       px="$3"
-      gap="$1.5"
+      gap={monoLabel ? '$0.5' : '$1.5'}
       cursor="default"
     >
       {indicatorElement}
       <Badge.Text size="$bodySmMedium">{badgeLabel}</Badge.Text>
       {monoLabel ? (
         <Badge.Text
-          flex={1}
           size="$bodySmMedium"
           fontFamily="$monoRegular"
           fontVariant={fontVariant}
-          minWidth={40}
+          width={40}
           textAlign="right"
         >
           {monoLabel}

--- a/packages/kit/src/components/NetworkStatus/index.tsx
+++ b/packages/kit/src/components/NetworkStatus/index.tsx
@@ -41,25 +41,35 @@ export function NetworkStatus() {
     return isInternetReachable !== false;
   }, [isInPerpRoute, perpsNetworkStatus?.connected, isInternetReachable]);
 
-  // Show ping latency in badge label when on Perp tab
   const label = useMemo(() => {
+    if (isInPerpRoute && perpsNetworkStatus?.connected === true) {
+      return intl.formatMessage({ id: ETranslations.perp_online });
+    }
+    return undefined;
+  }, [isInPerpRoute, perpsNetworkStatus?.connected, intl]);
+
+  const monoLabel = useMemo(() => {
     if (
       isInPerpRoute &&
       perpsNetworkStatus?.connected === true &&
       perpsNetworkStatus?.pingMs !== null &&
       perpsNetworkStatus?.pingMs !== undefined
     ) {
-      return `${intl.formatMessage({ id: ETranslations.perp_online })} ${perpsNetworkStatus.pingMs}ms`;
+      return `${perpsNetworkStatus.pingMs}ms`;
     }
     return undefined;
   }, [
     isInPerpRoute,
     perpsNetworkStatus?.connected,
     perpsNetworkStatus?.pingMs,
-    intl,
   ]);
 
   return (
-    <NetworkStatusBadge connected={isConnected} badgeSize="sm" label={label} />
+    <NetworkStatusBadge
+      connected={isConnected}
+      badgeSize="sm"
+      label={label}
+      monoLabel={monoLabel}
+    />
   );
 }

--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -974,10 +974,10 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
             <Button
               testID="home-show-view-more-button-btn"
               variant="secondary"
-              iconAfter="ChevronRightSmallOutline"
               onPress={handleViewMore}
               flexGrow={1}
               flexBasis={0}
+              childrenAsText={false}
               $md={
                 {
                   borderRadius: '$full',
@@ -986,7 +986,12 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
                 } as any
               }
             >
-              {intl.formatMessage({ id: ETranslations.global_view_more })}
+              <XStack alignItems="center" gap="$2">
+                <SizableText size="$bodyMdMedium">
+                  {intl.formatMessage({ id: ETranslations.global_view_more })}
+                </SizableText>
+                <Icon name="ChevronRightSmallOutline" size="$5.5" />
+              </XStack>
             </Button>
           </XStack>
         ) : null}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
@@ -253,7 +253,7 @@ const OpenOrdersRow = memo(
             width="100%"
             alignItems="center"
           >
-            <YStack onPress={handleSwitchInstrument} cursor="default">
+            <YStack onPress={handleSwitchInstrument} cursor="pointer">
               <SizableText
                 numberOfLines={1}
                 ellipsizeMode="tail"
@@ -414,7 +414,7 @@ const OpenOrdersRow = memo(
               justifyContent="center"
               alignItems={calcCellAlign(columnConfigs[1].align)}
               onPress={handleSwitchInstrument}
-              cursor="default"
+              cursor="pointer"
             >
               <SizableText
                 size="$bodySm"

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -133,7 +133,7 @@ const PositionRowDesktopSymbolAndLeverage = memo(
           justifyContent={calcCellAlign(columnConfig.align)}
           gap="$2"
           onPress={onChangeAsset}
-          cursor="default"
+          cursor="pointer"
         >
           <XStack alignItems="center" gap="$2">
             <Divider

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -222,7 +222,7 @@ const TradesHistoryRow = memo(
                 gap="$2"
                 alignItems="center"
                 onPress={handleSwitchInstrument}
-                cursor="default"
+                cursor="pointer"
               >
                 <SizableText size="$bodyMdMedium">{assetSymbol}</SizableText>
                 <SizableText
@@ -378,7 +378,7 @@ const TradesHistoryRow = memo(
               justifyContent={calcCellAlign(columnConfigs[1].align)}
               alignItems="center"
               onPress={handleSwitchInstrument}
-              cursor="default"
+              cursor="pointer"
             >
               <SizableText
                 numberOfLines={1}

--- a/packages/kit/src/views/Perp/components/PerpContentFooter.tsx
+++ b/packages/kit/src/views/Perp/components/PerpContentFooter.tsx
@@ -26,13 +26,7 @@ function PerpNetworkStatus() {
     return undefined;
   }, [networkStatus?.connected, pingMs]);
 
-  return (
-    <NetworkStatusBadge
-      connected={connected}
-      monoLabel={monoLabel}
-      minWidth={135}
-    />
-  );
+  return <NetworkStatusBadge connected={connected} monoLabel={monoLabel} />;
 }
 
 export function PerpContentFooter() {

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
@@ -8,7 +8,6 @@ import {
   DebugRenderTracker,
   Divider,
   IconButton,
-  NumberSizeableText,
   ScrollView,
   SizableText,
   SkeletonContainer,
@@ -16,7 +15,6 @@ import {
   XStack,
   YStack,
   useClipboard,
-  useMedia,
 } from '@onekeyhq/components';
 import { useActiveTradeInstrumentAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { usePerpsAllAssetCtxsAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
@@ -38,6 +36,7 @@ import {
   NUMBER_FORMATTER,
   formatDisplayNumber,
   formatLocalizedNumberString,
+  numberFormat,
 } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   formatAssetCtx,
@@ -175,7 +174,12 @@ const TickerBarMarkPriceView = memo(
           <Tooltip
             placement="top"
             renderTrigger={
-              <SizableText size="$headingXl" cursor="help">
+              <SizableText
+                size="$headingMd"
+                cursor="help"
+                fontVariant={['tabular-nums']}
+                lineHeight={20}
+              >
                 {formattedMarkPrice}
               </SizableText>
             }
@@ -224,56 +228,64 @@ function TickerBarMarkPrice() {
   );
 }
 
-const TickerBarChange24hPercentView = memo(
+const TickerBarChange24hView = memo(
   ({
-    change24hPercent,
+    changeDisplay,
     isLoading,
-    gtMd,
   }: {
-    change24hPercent: number;
+    changeDisplay: string;
     isLoading: boolean;
-    gtMd: boolean;
   }) => (
     <DebugRenderTracker
-      name="TickerBarChange24hPercent"
+      name="TickerBarChange24h"
       position="bottom-right"
       offsetY={10}
     >
-      <SkeletonContainer isLoading={isLoading} width={50} height={16}>
-        <NumberSizeableText
-          size={gtMd ? '$headingXs' : '$bodySmMedium'}
-          fontSize={gtMd ? undefined : 10}
-          mt={gtMd ? undefined : '$-2'}
-          color={change24hPercent >= 0 ? '$green11' : '$red11'}
-          formatter="priceChange"
-          formatterOptions={{
-            showPlusMinusSigns: true,
-          }}
+      <SkeletonContainer isLoading={isLoading} width={120} height={16}>
+        <SizableText
+          size="$bodyXs"
+          textTransform="none"
+          fontWeight="500"
+          letterSpacing={0.2}
+          lineHeight={12}
+          color={changeDisplay.trim().startsWith('-') ? '$red11' : '$green11'}
         >
-          {change24hPercent}
-        </NumberSizeableText>
+          {changeDisplay}
+        </SizableText>
       </SkeletonContainer>
     </DebugRenderTracker>
   ),
 );
-TickerBarChange24hPercentView.displayName = 'TickerBarChange24hPercentView';
+TickerBarChange24hView.displayName = 'TickerBarChange24hView';
 
-export function TickerBarChange24hPercent() {
-  const { gtMd } = useMedia();
+export function TickerBarChange24h() {
   const [tradingMode] = useTradingModeAtom();
   const assetCtx = useTickerBarPerpAssetCtx();
   const [spotAssetCtx] = useSpotActiveAssetCtxAtom();
-  const change24hPercent =
-    tradingMode === 'spot'
-      ? spotAssetCtx?.ctx?.change24hPercent || 0
-      : assetCtx?.ctx?.change24hPercent || 0;
+  const displayCtx = tradingMode === 'spot' ? spotAssetCtx?.ctx : assetCtx?.ctx;
+  const changeDisplay = useMemo(() => {
+    const changeValue = displayCtx?.change24h || '0';
+    const signedChangeValue =
+      changeValue.startsWith('-') || changeValue === '0'
+        ? changeValue
+        : `+${changeValue}`;
+    const percentText = numberFormat(
+      String(displayCtx?.change24hPercent || 0),
+      {
+        formatter: 'priceChange',
+        formatterOptions: {
+          showPlusMinusSigns: true,
+        },
+      },
+    );
+    return `${signedChangeValue} (${percentText})`;
+  }, [displayCtx?.change24h, displayCtx?.change24hPercent]);
   const isLoading = useTickerBarIsLoading();
 
   return (
-    <TickerBarChange24hPercentView
-      change24hPercent={change24hPercent}
+    <TickerBarChange24hView
+      changeDisplay={changeDisplay}
       isLoading={isLoading}
-      gtMd={gtMd}
     />
   );
 }
@@ -647,11 +659,11 @@ const TickerBarFundingRateView = memo(
             })}
           </SizableText>
           <SkeletonContainer isLoading={isLoading} width={120} height={16}>
-            <XStack alignItems="center" gap="$2">
+            <XStack alignItems="baseline" gap="$2">
               <Tooltip
                 hovering
                 renderTrigger={
-                  <XStack alignItems="center" gap="$2">
+                  <XStack alignItems="baseline" gap="$2">
                     <DashText
                       {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
                       fontVariant={['tabular-nums']}
@@ -923,8 +935,8 @@ function PerpTickerBarDesktop() {
   const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [tradingMode] = useTradingModeAtom();
   const isSpot = tradingMode === 'spot';
-  const marketDataGap = useMemo(() => (isSpot ? '$6' : '$8'), [isSpot]);
-  const priceSectionWidth = useMemo(() => (isSpot ? 168 : 140), [isSpot]);
+  const marketDataGap = useMemo(() => (isSpot ? '$6' : '$6'), [isSpot]);
+  const priceSectionWidth = useMemo(() => (isSpot ? 168 : 96), [isSpot]);
   const content = (
     <XStack
       bg="$bgApp"
@@ -935,10 +947,10 @@ function PerpTickerBarDesktop() {
       pr="$3"
       alignItems="center"
       justifyContent="flex-start"
-      gap="$6"
+      gap="$5"
       h={PERP_LAYOUT_CONFIG.desktop.tickerBarHeight}
     >
-      <XStack gap="$4" alignItems="center" minWidth={0} flexShrink={1}>
+      <XStack gap="$3" alignItems="center" minWidth={0} flexShrink={1}>
         <XStack gap="$2" alignItems="center" minWidth={0} flexShrink={1}>
           <FavoriteButton
             coin={activeTradeInstrument.coin}
@@ -948,17 +960,15 @@ function PerpTickerBarDesktop() {
           <PerpTokenSelector />
         </XStack>
 
-        <XStack
-          alignItems="center"
-          minWidth={priceSectionWidth}
+        <YStack
+          alignItems="flex-start"
           width={priceSectionWidth}
-          gap="$1.5"
           flexShrink={0}
           cursor="default"
         >
           <TickerBarMarkPrice />
-          <TickerBarChange24hPercent />
-        </XStack>
+          <TickerBarChange24h />
+        </YStack>
       </XStack>
 
       {/* Right: Market Data */}
@@ -974,10 +984,10 @@ function PerpTickerBarDesktop() {
         }}
       >
         {isSpot ? null : <TickerBarOraclePrice />}
+        {isSpot ? null : <TickerBarFundingRate />}
         <TickerBar24hVolume />
         {isSpot ? <TickerBarMarketCap /> : <TickerBarOpenInterest />}
         {isSpot ? <TickerBarSpotContract /> : null}
-        {isSpot ? null : <TickerBarFundingRate />}
       </ScrollView>
     </XStack>
   );

--- a/packages/shared/types/hyperliquid/perp.constants.ts
+++ b/packages/shared/types/hyperliquid/perp.constants.ts
@@ -65,7 +65,7 @@ export const PERP_LAYOUT_CONFIG = {
   // than total content height, page scrolls vertically; individual modules can
   // still scroll internally.
   desktop: {
-    tickerBarHeight: 54,
+    tickerBarHeight: 60,
     panelHeaderHeight: 38,
     bottomPanelHeaderHeight: 46,
     // Use a height that aligns cleanly with order book row steps to avoid a


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57734](https://onekeyhq.atlassian.net/browse/OK-57734)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Refined the Perps desktop ticker bar layout and status badge alignment for more stable spacing and number rendering.
- Adjusted mobile/home contract "View more" button content rendering so the text size and chevron layout stay consistent.
- Improved clickable affordances in Perps order/position/history rows by using pointer cursors on instrument-switch targets.

## Intent & Context
This PR packages the current branch changes while intentionally excluding the unrelated `apps/mobile/ios/Podfile.lock` modification.
The user asked to commit the branch changes and open a PR without bringing in unrelated edits. The visible issue reference provided was OK-57734.

## Root Cause
Several Perps UI elements relied on default inline button/icon and badge layout behavior, which produced inconsistent typography and spacing across desktop and mobile surfaces.
Some interactive desktop cells also still used a default cursor, which made the affordance weaker than intended.

## Design Decisions
- Kept the fix local to existing UI components instead of introducing new shared abstractions.
- Reused the existing `monoLabel` support in `NetworkStatusBadge` to separate the online label from ping latency.
- Left `Podfile.lock` out of the commit so the PR only contains feature-related UI changes.

## Changes Detail
- Updated `PopularTrading` to render the "View more" button with explicit text and icon layout.
- Adjusted `NetworkStatusBadge`, `NetworkStatus`, and `PerpContentFooter` to improve badge spacing and ping display.
- Refined `PerpTickerBarDesktop` layout, price/change formatting, and funding-rate alignment.
- Updated Perps order table rows to show pointer cursors on instrument-switch click targets.
- Increased desktop ticker bar height in Perps layout constants to match the updated composition.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Desktop
- **Risk Areas**: Perps market header layout, network status badge rendering, home trading entry button typography

## Test plan
- [ ] Verify the mobile contract "View more" button text size and chevron alignment match design expectations.
- [ ] Verify the desktop Perps ticker bar renders mark price, 24h change, funding rate, and status badge without overlap.
- [ ] Verify clicking instrument cells in open orders, positions, and trades history still switches the active instrument.

## Related Issue
- [OK-57734](https://onekeyhq.atlassian.net/browse/OK-57734)


[OK-57734]: https://onekeyhq.atlassian.net/browse/OK-57734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ