### PR TITLE
feat: immersive liquid-glass headers on Wallet + Trade tabs (iOS) OK-57114

### DIFF
--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -124,7 +124,7 @@ PODS:
     - ReactNativeNativeLogger
     - SocketRocket
     - Yoga
-  - BleUtils (0.1.5):
+  - BleUtils (0.1.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -4101,6 +4101,34 @@ PODS:
   - RealmJS (20.2.0):
     - React
   - RevenueCat (5.32.0)
+  - RNCMaskedView (0.3.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - RNGestureHandler (2.30.0):
     - boost
     - DoubleConversion
@@ -4971,6 +4999,7 @@ DEPENDENCIES:
   - "ReactNativeSplashScreen (from `../../../node_modules/@onekeyfe/react-native-splash-screen`)"
   - ReactNativeZipArchive (from `../../../node_modules/react-native-zip-archive`)
   - RealmJS (from `../../../node_modules/realm`)
+  - "RNCMaskedView (from `../../../node_modules/@react-native-masked-view/masked-view`)"
   - RNGestureHandler (from `../../../node_modules/react-native-gesture-handler`)
   - "RNGoogleSignin (from `../../../node_modules/@react-native-google-signin/google-signin`)"
   - RNImageCropPicker (from `../../../node_modules/react-native-image-crop-picker`)
@@ -5344,6 +5373,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native-zip-archive"
   RealmJS:
     :path: "../../../node_modules/realm"
+  RNCMaskedView:
+    :path: "../../../node_modules/@react-native-masked-view/masked-view"
   RNGestureHandler:
     :path: "../../../node_modules/react-native-gesture-handler"
   RNGoogleSignin:
@@ -5398,7 +5429,7 @@ SPEC CHECKSUMS:
   AsyncStorage: c412e811f40580575ae1349fe3a00ba20abbd7b9
   AutoSizeInput: 058768d2d7b2eba06620d9a3fabe260d08de1218
   BackgroundThread: 2716941fdd405d1e2b782579834ded774968bd62
-  BleUtils: 100aa150e12ea28847766790f44f673628827abb
+  BleUtils: 3ab85e1bcf3c7a5594488ee144a0b9bbf4537d55
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   Burnt: e3a3397e26172fca31a59bb27421475a58068836
   ChartWebview: 91e4e32693e817baee0d449695939d98a66fbb8e
@@ -5569,6 +5600,7 @@ SPEC CHECKSUMS:
   ReactNativeZipArchive: bb4a2b338281c0166bee97142bf59ef9cd124c62
   RealmJS: 1c37c6bdfe060f4caa0f9175aa0eedb962622ee1
   RevenueCat: 7e1d0768fb287c9983173c9b28e39ccbeeb828a9
+  RNCMaskedView: 5ef8c95cbab95334a32763b72896a7b7d07e6299
   RNGestureHandler: e37bdb684df1ac17c7e1d8f71a3311b2793c186b
   RNGoogleSignin: 628d629e8dca39fc4ab70e30cf55bb3fc284f518
   RNImageCropPicker: 5fd4ceaead64d8c53c787e4e559004f97bc76df7

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -89,6 +89,7 @@
     "@react-native-community/slider": "5.0.1",
     "@react-native-documents/picker": "^12.0.1",
     "@react-native-google-signin/google-signin": "16.1.0",
+    "@react-native-masked-view/masked-view": "0.3.2",
     "@reown/appkit-ethers5-react-native": "https://github.com/OneKeyHQ/app-modules#9d96daccc13625e5b3c8b236f9357956b049b884",
     "@sentry/react-native": "6.22.0",
     "@shopify/flash-list": "2.2.0",

--- a/packages/components/src/content/ProgressiveBlur/index.ios.tsx
+++ b/packages/components/src/content/ProgressiveBlur/index.ios.tsx
@@ -1,0 +1,42 @@
+import MaskedView from '@react-native-masked-view/masked-view';
+import { StyleSheet } from 'react-native';
+
+import { BlurView } from '../BlurView';
+import { LinearGradient } from '../LinearGradient';
+
+// Mask alpha: opaque (frost visible) down to 55% of the height, then ramps to
+// transparent (frost hidden) at the bottom edge — a progressive falloff.
+const MASK_COLORS = ['#000000', '#000000', 'transparent'];
+const MASK_LOCATIONS: [number, number, number] = [0, 0.55, 1];
+const MASK_START: [number, number] = [0, 0];
+const MASK_END: [number, number] = [0, 1];
+// Blur strength (0-100). Kept light so the frost reads as translucent.
+const BLUR_INTENSITY = 25;
+
+const MASK_ELEMENT = (
+  <LinearGradient
+    style={StyleSheet.absoluteFill}
+    colors={MASK_COLORS}
+    locations={MASK_LOCATIONS}
+    start={MASK_START}
+    end={MASK_END}
+  />
+);
+
+// iOS-only "progressive blur": a frost whose opacity fades to transparent toward
+// the bottom edge via a vertical alpha gradient mask, mimicking the native
+// nav-bar scroll-edge look so content scrolling underneath dissolves softly
+// instead of meeting a hard, uniformly-blurred rectangle. Fills its parent.
+//
+// Uses BlurView (UIBlurEffect), NOT GlassView: a CALayer alpha mask composites
+// cleanly over a UIVisualEffectView, but breaks the iOS 26 Liquid Glass
+// material (it renders nothing when masked). Liquid Glass stays on the header's
+// pills/capsules; this is the frosted BACKDROP behind them. Masking is native,
+// so it is GPU-cheap — no per-frame JS work.
+export function ProgressiveBlur() {
+  return (
+    <MaskedView style={StyleSheet.absoluteFill} maskElement={MASK_ELEMENT}>
+      <BlurView flex={1} intensity={BLUR_INTENSITY} />
+    </MaskedView>
+  );
+}

--- a/packages/components/src/content/ProgressiveBlur/index.tsx
+++ b/packages/components/src/content/ProgressiveBlur/index.tsx
@@ -1,0 +1,9 @@
+// Non-iOS placeholder. The progressive Liquid Glass / blur header is iOS-only
+// (it relies on the iOS-only masked-view stack). Every caller gates rendering on
+// platformEnv.isNativeIOS, so this is never rendered; it exists only so
+// cross-platform code can import ProgressiveBlur without pulling the native-only
+// modules into other platform bundles. The `.ios.tsx` variant is the only place
+// those modules are referenced.
+export function ProgressiveBlur() {
+  return null;
+}

--- a/packages/components/src/content/index.ts
+++ b/packages/components/src/content/index.ts
@@ -7,6 +7,7 @@ export * from './LinearGradient';
 export * from './BlurView';
 export * from './GlassButtonCapsule';
 export * from './GlassView';
+export * from './ProgressiveBlur';
 export * from './Empty';
 // Markdown removed from barrel — import directly from
 // '@onekeyhq/components/src/content/Markdown' to avoid pulling

--- a/packages/kit/src/components/ImmersiveGlassHeader/index.tsx
+++ b/packages/kit/src/components/ImmersiveGlassHeader/index.tsx
@@ -1,0 +1,103 @@
+import { useMemo } from 'react';
+
+import Animated, {
+  Extrapolation,
+  interpolate,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
+
+import { ProgressiveBlur, useSafeAreaInsets } from '@onekeyhq/components';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+
+import type { SharedValue } from 'react-native-reanimated';
+
+// Single source of truth for the immersive Liquid-Glass header effect (the
+// translucent progressive-blur nav bar that page content scrolls under). Both
+// the Home (Wallet) and Trade (Swap) tab headers gate on this, so restricting
+// the effect later — e.g. to iOS 26+ via a JS hot-update — is a one-line change
+// here (`platformEnv.isNativeIOS` -> `platformEnv.isNativeIOS26Plus`) that flips
+// every page at once instead of drifting per-page.
+export const ENABLE_IMMERSIVE_GLASS_HEADER = platformEnv.isNativeIOS;
+
+// Height of the single fixed header row that stays put while content scrolls
+// under it (Home search row / Swap tab-switch row). Both were deliberately set
+// to 56 so the two tab headers align; the glass frost sizes itself to this.
+export const IMMERSIVE_HEADER_ROW_HEIGHT = 56;
+
+// Distance (px) over which the glass ramps 0 -> 1 as content scrolls under the
+// bar: transparent at rest (blends seamlessly with the page), frosting only once
+// content actually slides beneath it.
+const GLASS_FADE_DISTANCE = 16;
+// Default px the frost layer extends BELOW the header row, into the content
+// area, so the progressive-blur gradient falloff plays out over a taller band
+// (softer, more native transition) instead of ending right at the row. Pages
+// with a pinned row directly under the bar (e.g. Swap Pro's sticky token
+// selector) pass overhang={0} so the frost doesn't blur that pinned row.
+export const IMMERSIVE_GLASS_OVERHANG = 80;
+// Compensation (px) Home passes so the frost still reaches the true top edge:
+// Home's fixed bar sits at top={-IMMERSIVE_GLASS_TOP_OFFSET}. Pages that anchor
+// the overlay at the real top edge use the default topOffset={0}.
+export const IMMERSIVE_GLASS_TOP_OFFSET = 20;
+
+// Tab routes whose immersive glass header owns the top region: MDHeader drops
+// its status-bar spacer for these so the page can scroll content under the bar.
+// Add a route here (rather than another `|| tabRoute === X` inside MDHeader)
+// when giving a non-Home tab the immersive treatment. Home renders on its own
+// header path and does not go through that spacer branch.
+export const IMMERSIVE_GLASS_HEADER_TAB_ROUTES = new Set<ETabRoutes>([
+  ETabRoutes.Swap,
+]);
+
+// The translucent Liquid-Glass frost behind a fixed immersive nav bar. Fades in
+// with `scrollY` (fed by the host page's scroll observer) and progressively
+// blurs via ProgressiveBlur. Rendered only on iOS, so its reanimated /
+// safe-area hooks never run on other platforms.
+//
+// - scrollY:   the focused scroll offset that drives the fade.
+// - rowHeight: the fixed header row height the frost sizes itself to.
+// - topOffset: px to add so the frost still reaches the screen's top edge when
+//              the host bar is shifted upward (Home passes
+//              IMMERSIVE_GLASS_TOP_OFFSET; anchored-at-top pages keep the 0
+//              default).
+// - overhang:  px the frost extends below the row into scrolling content; pass 0
+//              when a pinned row sits directly under the bar.
+export function ImmersiveGlassOverlay({
+  scrollY,
+  rowHeight = IMMERSIVE_HEADER_ROW_HEIGHT,
+  topOffset = 0,
+  overhang = IMMERSIVE_GLASS_OVERHANG,
+}: {
+  scrollY: SharedValue<number>;
+  rowHeight?: number;
+  topOffset?: number;
+  overhang?: number;
+}) {
+  const { top } = useSafeAreaInsets();
+  const glassStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(
+      scrollY.value,
+      [0, GLASS_FADE_DISTANCE],
+      [0, 1],
+      Extrapolation.CLAMP,
+    ),
+  }));
+  // Explicit geometry so the frost spans safe-area-top + the header row + the
+  // overhang band (relying on the overlay's own margin/padding came up short).
+  const layerStyle = useMemo(
+    () => ({
+      position: 'absolute' as const,
+      top: 0,
+      left: 0,
+      right: 0,
+      height: top + rowHeight + topOffset + overhang,
+    }),
+    [top, rowHeight, topOffset, overhang],
+  );
+
+  return (
+    <Animated.View pointerEvents="none" style={[layerStyle, glassStyle]}>
+      <ProgressiveBlur />
+    </Animated.View>
+  );
+}

--- a/packages/kit/src/components/TabPageHeader/MDHeader.tsx
+++ b/packages/kit/src/components/TabPageHeader/MDHeader.tsx
@@ -19,6 +19,10 @@ import {
   useIsAccountSelectorSyncLoading,
 } from '../../states/jotai/contexts/accountSelector';
 import { HomeTokenListProviderMirror } from '../../views/Home/components/HomeTokenListProvider/HomeTokenListProviderMirror';
+import {
+  ENABLE_IMMERSIVE_GLASS_HEADER,
+  IMMERSIVE_GLASS_HEADER_TAB_ROUTES,
+} from '../ImmersiveGlassHeader';
 import { MoreActionButton } from '../MoreActionButton';
 
 import { HeaderNotificationIconButton } from './components/HeaderNotificationIconButton';
@@ -141,6 +145,18 @@ export function MDHeader({
     tabRoute === ETabRoutes.Home &&
     sceneName !== EAccountSelectorSceneName.homeUrlAccount;
 
+  // Immersive-glass tabs (e.g. Swap) own their full top region, so drop the
+  // status-bar spacer and let the page scroll content under the translucent bar
+  // (mirroring Home). Other non-base-header tabs, and iOS builds without the
+  // effect, keep the spacer. The route list lives with the flag in
+  // ImmersiveGlassHeader so a new page doesn't have to edit this condition.
+  const suppressStatusBarSpacer =
+    ENABLE_IMMERSIVE_GLASS_HEADER &&
+    IMMERSIVE_GLASS_HEADER_TAB_ROUTES.has(tabRoute);
+  const baseHeaderFallback = suppressStatusBarSpacer ? null : (
+    <XStack h={top || '$2'} bg="$bgApp" />
+  );
+
   return (
     <>
       <Page.Header headerShown={false} />
@@ -183,7 +199,7 @@ export function MDHeader({
                   (see HomePageView `renderHeader`) so it scrolls away with the
                   page for the Liquid Glass immersive layout — only the search
                   row stays fixed. Other platforms keep it pinned here. */}
-              {platformEnv.isNativeIOS ? null : (
+              {ENABLE_IMMERSIVE_GLASS_HEADER ? null : (
                 <HomeWalletConnectionRow
                   headerPx={headerPx}
                   selectedHeaderTab={selectedHeaderTab}
@@ -226,7 +242,7 @@ export function MDHeader({
           )}
         </>
       ) : (
-        <XStack h={top || '$2'} bg="$bgApp" />
+        baseHeaderFallback
       )}
     </>
   );

--- a/packages/kit/src/components/TabPageHeader/MDHeader.tsx
+++ b/packages/kit/src/components/TabPageHeader/MDHeader.tsx
@@ -31,7 +31,12 @@ import { LegacyUniversalSearchInput } from './LegacyUniversalSearchInput';
 
 import type { SharedValue } from 'react-native-reanimated';
 
-function HomeWalletConnectionRow({
+// Height of the Home search-bar row. Shared source of truth so the iOS glass
+// frost layer (HomeHeaderGlass) can size itself to the same value instead of
+// hardcoding a copy that silently drifts if this row's height changes.
+export const HOME_HEADER_SEARCH_ROW_HEIGHT = 56;
+
+export function HomeWalletConnectionRow({
   headerPx,
   selectedHeaderTab,
   sceneName,
@@ -147,7 +152,7 @@ export function MDHeader({
               <XStack
                 alignItems="center"
                 px={headerPx}
-                h={56}
+                h={HOME_HEADER_SEARCH_ROW_HEIGHT}
                 gap={headerGlassActive ? '$3' : '$6'}
                 {...(top || platformEnv.isNativeAndroid
                   ? { mt: top || '$2' }
@@ -173,14 +178,20 @@ export function MDHeader({
                   <MoreActionButton />
                 </GlassButtonCapsule>
               </XStack>
-              {/* Row 2: Wallet connection (account + network + address) */}
-              <HomeWalletConnectionRow
-                headerPx={headerPx}
-                selectedHeaderTab={selectedHeaderTab}
-                sceneName={sceneName}
-                tabRoute={tabRoute}
-                customHeaderLeftItems={customHeaderLeftItems}
-              />
+              {/* Row 2: Wallet connection (account + network + address).
+                  iOS relocates this row into the collapsible scroll header
+                  (see HomePageView `renderHeader`) so it scrolls away with the
+                  page for the Liquid Glass immersive layout — only the search
+                  row stays fixed. Other platforms keep it pinned here. */}
+              {platformEnv.isNativeIOS ? null : (
+                <HomeWalletConnectionRow
+                  headerPx={headerPx}
+                  selectedHeaderTab={selectedHeaderTab}
+                  sceneName={sceneName}
+                  tabRoute={tabRoute}
+                  customHeaderLeftItems={customHeaderLeftItems}
+                />
+              )}
             </>
           ) : (
             <>

--- a/packages/kit/src/views/Home/components/HomeHeaderGlass/index.tsx
+++ b/packages/kit/src/views/Home/components/HomeHeaderGlass/index.tsx
@@ -1,0 +1,97 @@
+import { useMemo } from 'react';
+
+import Animated, {
+  Extrapolation,
+  interpolate,
+  useAnimatedReaction,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
+
+import {
+  ProgressiveBlur,
+  useCurrentTabScrollY,
+  useSafeAreaInsets,
+} from '@onekeyhq/components';
+import { HOME_HEADER_SEARCH_ROW_HEIGHT } from '@onekeyhq/kit/src/components/TabPageHeader/MDHeader';
+
+import type { SharedValue } from 'react-native-reanimated';
+
+// Distance (px) over which the glass ramps 0 -> 1 as content scrolls under the
+// bar: transparent at rest (blends seamlessly with the page), frosting only once
+// content actually slides beneath it.
+const GLASS_FADE_DISTANCE = 16;
+// Extra px the frost layer extends BELOW the search row, into the content area,
+// so the progressive-blur gradient falloff plays out over a taller band (softer,
+// more native transition) instead of ending right at the search row.
+const GLASS_OVERHANG = 80;
+// Cancels the fixed overlay's own `top={-20}` so the frost still reaches the
+// very top edge of the screen.
+const OVERLAY_TOP_OFFSET = 20;
+
+// Bridges the focused tab's scroll offset out to the fixed glass overlay (which
+// lives OUTSIDE Tabs.Container and so cannot call useCurrentTabScrollY itself).
+// Calls useCurrentTabScrollY, so it MUST only be mounted inside a Tabs.Container
+// subtree (rendered from HomePageView's renderHeader, gated on headerProps).
+// Same constraint/pattern as FrozenTopHistoryScrollObserver.
+export function HomeHeaderGlassScrollObserver({
+  scrollYOut,
+}: {
+  scrollYOut: SharedValue<number>;
+}) {
+  const scrollY = useCurrentTabScrollY();
+  useAnimatedReaction(
+    () => (scrollY as SharedValue<number>).value,
+    (y) => {
+      'worklet';
+
+      scrollYOut.value = y;
+    },
+  );
+  return null;
+}
+
+// The translucent Liquid-Glass frost behind the fixed iOS Home nav bar. Fades in
+// with `scrollY` (fed by HomeHeaderGlassScrollObserver) and progressively blurs
+// via ProgressiveBlur. Rendered only on iOS, so its reanimated / safe-area hooks
+// never run on other platforms.
+export function HomeHeaderGlassOverlay({
+  scrollY,
+}: {
+  scrollY: SharedValue<number>;
+}) {
+  const { top } = useSafeAreaInsets();
+  const glassStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(
+      scrollY.value,
+      [0, GLASS_FADE_DISTANCE],
+      [0, 1],
+      Extrapolation.CLAMP,
+    ),
+  }));
+  // Explicit geometry so the frost spans safe-area-top + the search row + the
+  // overhang band (relying on the overlay's own margin/padding came up short).
+  const layerStyle = useMemo(
+    () => ({
+      position: 'absolute' as const,
+      top: 0,
+      left: 0,
+      right: 0,
+      height:
+        top +
+        HOME_HEADER_SEARCH_ROW_HEIGHT +
+        OVERLAY_TOP_OFFSET +
+        GLASS_OVERHANG,
+    }),
+    [top],
+  );
+  const style = useMemo(
+    () => [layerStyle, glassStyle],
+    [layerStyle, glassStyle],
+  );
+
+  return (
+    <Animated.View pointerEvents="none" style={style}>
+      <ProgressiveBlur />
+    </Animated.View>
+  );
+}

--- a/packages/kit/src/views/Home/components/HomeHeaderGlass/index.tsx
+++ b/packages/kit/src/views/Home/components/HomeHeaderGlass/index.tsx
@@ -1,32 +1,13 @@
-import { useMemo } from 'react';
+import { useAnimatedReaction } from 'react-native-reanimated';
 
-import Animated, {
-  Extrapolation,
-  interpolate,
-  useAnimatedReaction,
-  useAnimatedStyle,
-} from 'react-native-reanimated';
-
+import { useCurrentTabScrollY } from '@onekeyhq/components';
 import {
-  ProgressiveBlur,
-  useCurrentTabScrollY,
-  useSafeAreaInsets,
-} from '@onekeyhq/components';
+  IMMERSIVE_GLASS_TOP_OFFSET,
+  ImmersiveGlassOverlay,
+} from '@onekeyhq/kit/src/components/ImmersiveGlassHeader';
 import { HOME_HEADER_SEARCH_ROW_HEIGHT } from '@onekeyhq/kit/src/components/TabPageHeader/MDHeader';
 
 import type { SharedValue } from 'react-native-reanimated';
-
-// Distance (px) over which the glass ramps 0 -> 1 as content scrolls under the
-// bar: transparent at rest (blends seamlessly with the page), frosting only once
-// content actually slides beneath it.
-const GLASS_FADE_DISTANCE = 16;
-// Extra px the frost layer extends BELOW the search row, into the content area,
-// so the progressive-blur gradient falloff plays out over a taller band (softer,
-// more native transition) instead of ending right at the search row.
-const GLASS_OVERHANG = 80;
-// Cancels the fixed overlay's own `top={-20}` so the frost still reaches the
-// very top edge of the screen.
-const OVERLAY_TOP_OFFSET = 20;
 
 // Bridges the focused tab's scroll offset out to the fixed glass overlay (which
 // lives OUTSIDE Tabs.Container and so cannot call useCurrentTabScrollY itself).
@@ -50,48 +31,20 @@ export function HomeHeaderGlassScrollObserver({
   return null;
 }
 
-// The translucent Liquid-Glass frost behind the fixed iOS Home nav bar. Fades in
-// with `scrollY` (fed by HomeHeaderGlassScrollObserver) and progressively blurs
-// via ProgressiveBlur. Rendered only on iOS, so its reanimated / safe-area hooks
-// never run on other platforms.
+// The Home (Wallet) instance of the shared immersive glass nav bar, sized to the
+// Home search row. Fades in with `scrollY` (fed by HomeHeaderGlassScrollObserver
+// above). The frost itself lives in the shared ImmersiveGlassOverlay so Home and
+// the other immersive tab headers (Trade, ...) stay visually identical.
 export function HomeHeaderGlassOverlay({
   scrollY,
 }: {
   scrollY: SharedValue<number>;
 }) {
-  const { top } = useSafeAreaInsets();
-  const glassStyle = useAnimatedStyle(() => ({
-    opacity: interpolate(
-      scrollY.value,
-      [0, GLASS_FADE_DISTANCE],
-      [0, 1],
-      Extrapolation.CLAMP,
-    ),
-  }));
-  // Explicit geometry so the frost spans safe-area-top + the search row + the
-  // overhang band (relying on the overlay's own margin/padding came up short).
-  const layerStyle = useMemo(
-    () => ({
-      position: 'absolute' as const,
-      top: 0,
-      left: 0,
-      right: 0,
-      height:
-        top +
-        HOME_HEADER_SEARCH_ROW_HEIGHT +
-        OVERLAY_TOP_OFFSET +
-        GLASS_OVERHANG,
-    }),
-    [top],
-  );
-  const style = useMemo(
-    () => [layerStyle, glassStyle],
-    [layerStyle, glassStyle],
-  );
-
   return (
-    <Animated.View pointerEvents="none" style={style}>
-      <ProgressiveBlur />
-    </Animated.View>
+    <ImmersiveGlassOverlay
+      scrollY={scrollY}
+      rowHeight={HOME_HEADER_SEARCH_ROW_HEIGHT}
+      topOffset={IMMERSIVE_GLASS_TOP_OFFSET}
+    />
   );
 }

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useFocusEffect } from '@react-navigation/core';
 import { CanceledError } from 'axios';
 import { useIntl } from 'react-intl';
+import { useSharedValue } from 'react-native-reanimated';
 
 import type { ITabContainerRef } from '@onekeyhq/components';
 import {
@@ -38,7 +39,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
-import type { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
+import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { EHomeWalletTab } from '@onekeyhq/shared/types/wallet';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
@@ -47,6 +48,7 @@ import { NetworkAlert } from '../../../components/NetworkAlert';
 import { NotificationEnableAlert } from '../../../components/NotificationEnableAlert';
 import { RiskApprovalAlert } from '../../../components/RiskApprovalAlert';
 import { TabPageHeader } from '../../../components/TabPageHeader';
+import { HomeWalletConnectionRow } from '../../../components/TabPageHeader/MDHeader';
 import { WatchOnlyAlert } from '../../../components/WatchOnlyAlert';
 import { WebDappEmptyView } from '../../../components/WebDapp/WebDappEmptyView';
 import useAppNavigation from '../../../hooks/useAppNavigation';
@@ -64,6 +66,10 @@ import {
 } from '../../../states/jotai/contexts/accountSelector';
 import { deferHeavyWorkUntilUIIdle } from '../../../utils/deferHeavyWork';
 import { NetworkUnsupportedWarning } from '../../Staking/components/ProtocolDetails/NetworkUnsupportedWarning';
+import {
+  HomeHeaderGlassOverlay,
+  HomeHeaderGlassScrollObserver,
+} from '../components/HomeHeaderGlass';
 import { HomeStickyHeaderContext } from '../components/HomeStickyHeaderContext';
 import { HomeSupportedWallet } from '../components/HomeSupportedWallet';
 import { NotBackedUpEmpty } from '../components/NotBakcedUp';
@@ -86,6 +92,24 @@ import type { LayoutChangeEvent } from 'react-native';
 
 const networksSupportBulkRevokeApproval =
   getNetworksSupportBulkRevokeApproval();
+
+// Initial (first-render) estimate for the collapsible header height on native.
+// iOS folds into the collapsible header: the top pass-through padding
+// (~tabPageHeight 118, so content starts below the fixed glass bar) + the
+// wallet-connection row (~44) + balance/actions/banner (~312) + the non-sticky
+// TabBar (~48). Other native platforms keep the original 312. The library
+// re-measures via onLayout; this only minimizes first-frame content shift, so
+// tune against a real device if a first-frame jump appears.
+let NATIVE_HOME_HEADER_HEIGHT: number | undefined;
+if (platformEnv.isNativeIOS) {
+  NATIVE_HOME_HEADER_HEIGHT = 522;
+} else if (platformEnv.isNative) {
+  NATIVE_HOME_HEADER_HEIGHT = 312;
+}
+
+// Web sticky TabBar is `position: relative` so its absolutely-positioned portal
+// `<div>` (rendered just below it) anchors to the TabBar instead of the page.
+const WEB_TABBAR_CONTAINER_STYLE = { position: 'relative' as const };
 
 interface IAndroidScrollContainerProps {
   children: React.ReactNode;
@@ -132,7 +156,15 @@ function HistoryTabNotificationAlertSlot() {
   return <NotificationEnableAlert scene="txHistory" />;
 }
 
-function NoWalletContent({ tabBarHeight = 0 }: { tabBarHeight?: number }) {
+function NoWalletContent({
+  tabBarHeight = 0,
+  topInset = 0,
+}: {
+  tabBarHeight?: number;
+  // iOS removes the fixed nav-bar spacer for the glass pass-through, so the
+  // empty-wallet state carries its own top inset to clear the fixed bar.
+  topInset?: number;
+}) {
   const isSyncLoading = useIsAccountSelectorSyncLoading(0);
   if (isSyncLoading) {
     return (
@@ -147,6 +179,7 @@ function NoWalletContent({ tabBarHeight = 0 }: { tabBarHeight?: number }) {
       contentContainerStyle={{
         justifyContent: 'center',
         flexGrow: 1,
+        pt: topInset,
         pb: tabBarHeight,
       }}
     >
@@ -160,6 +193,19 @@ function HomeTabContentMaxWidth({ children }: { children: React.ReactNode }) {
     <Stack flex={1} {...homePageContentMaxWidthSx}>
       {children}
     </Stack>
+  );
+}
+
+// The home alerts, in fixed order. iOS renders them inside the collapsible
+// header (so they don't sit behind the glass bar); other platforms pin them
+// below the fixed nav bar. Shared so the two placements can't drift.
+function HomeAlerts() {
+  return (
+    <>
+      <RiskApprovalAlert />
+      <WatchOnlyAlert />
+      <NetworkAlert />
+    </>
   );
 }
 
@@ -432,17 +478,9 @@ export function HomePageView({
     [accountName, deriveInfo?.label, deriveInfo?.labelKey, intl, network?.name],
   );
 
-  // Alerts sit outside Tabs.Container (rendered next to TabPageHeader below).
-  // Keeping them inside renderHeader made them scroll through the sticky
-  // TabBar area — a partially-scrolled alert would leave a visible band
-  // between TabPageHeader and the tabs.
-  const renderHeader = useCallback(() => {
-    return (
-      <Stack {...homePageContentMaxWidthSx}>
-        <HomeHeaderContainer />
-      </Stack>
-    );
-  }, []);
+  // `renderHeader` is defined below (after `buildTabBar`) so that on iOS
+  // it can inline the now non-sticky TabBar and the relocated wallet connection
+  // row into the collapsible header.
 
   // Rendered on web only. On native the equivalent lives inside the history
   // list's ListHeaderComponent so its height stays inside the list's measurer.
@@ -638,35 +676,83 @@ export function HomePageView({
     [],
   );
 
+  // Fixed nav-bar (TabPageHeader overlay) height. iOS previously measured 162
+  // (raw 182 - 20 offset) with the wallet-connection row (Row 2) pinned in the
+  // nav bar. That row now scrolls inside the collapsible header, so the fixed
+  // bar is ~44pt shorter (search row only) → ~118. Declared here (above the
+  // render callbacks) so renderHeader can read it for its iOS glass-pass-through
+  // top padding. Re-measured via handleTabPageLayout; the initial value only
+  // minimizes first-frame shift.
+  const [tabPageHeight, setTabPageHeight] = useState(
+    platformEnv.isNativeIOS ? 118 : 92,
+  );
+  const handleTabPageLayout = useCallback((e: LayoutChangeEvent) => {
+    const height = e.nativeEvent.layout.height - 20;
+    setTabPageHeight(height);
+  }, []);
+
+  // iOS glass fade: shared value written by HomeHeaderGlassScrollObserver
+  // (inside Tabs.Container) and read by HomeHeaderGlassOverlay (the fixed bar).
+  // Both live in ../components/HomeHeaderGlass; only this bridge value is kept
+  // here since it spans the two subtrees. Cheap enough to run on all platforms.
+  const headerGlassScrollY = useSharedValue(0);
+
+  const makeTabPressHandler = useCallback(
+    (tabBarProps: any) => (name: string) => {
+      const nextTab = tabConfigs.find((tab) => tab.name === name);
+      if (perpTabShowWeb && nextTab?.id === EHomeWalletTab.Perps) {
+        switchToPerpsWebTab();
+        return;
+      }
+      setActiveTabName(nextTab?.name ?? name);
+      setActiveTabId(nextTab?.id);
+      lastDisplayableTabNameRef.current = nextTab?.name ?? name;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      tabBarProps.onTabPress?.(name);
+    },
+    [tabConfigs, perpTabShowWeb, switchToPerpsWebTab],
+  );
+
+  // Shared TabBar builder (Spot / Perps / DeFi / NFT / History), used by all
+  // three placements: iOS renders it inside `renderHeader` (scrolls away with
+  // the collapsible header), Android in `renderTabBar` (pinned), and web in the
+  // sticky bar (which passes `position: relative` so its portal can anchor).
+  // Design: plain-text tabs on small screens only; pill elsewhere.
+  const buildTabBar = useCallback(
+    (tabBarProps: any, containerStyle?: any) => (
+      <Tabs.TabBar
+        {...tabBarProps}
+        tabNames={tabBarTabNames}
+        indexDecimal={perpTabShowWeb ? undefined : tabBarProps.indexDecimal}
+        onTabPress={makeTabPressHandler(tabBarProps)}
+        variant={isSmallScreen ? 'text' : 'pill'}
+        renderItem={handleRenderItem}
+        renderToolbar={renderToolbar}
+        containerStyle={containerStyle}
+      />
+    ),
+    [
+      tabBarTabNames,
+      perpTabShowWeb,
+      makeTabPressHandler,
+      isSmallScreen,
+      handleRenderItem,
+      renderToolbar,
+    ],
+  );
+
   const renderTabBar = useCallback(
     (tabBarProps: any) => {
-      // Design: plain-text tabs on small screens only; pill elsewhere.
-      const tabBarVariant = isSmallScreen ? 'text' : 'pill';
-      const handleTabPress = (name: string) => {
-        const nextTab = tabConfigs.find((tab) => tab.name === name);
-        if (perpTabShowWeb && nextTab?.id === EHomeWalletTab.Perps) {
-          switchToPerpsWebTab();
-          return;
-        }
-        setActiveTabName(nextTab?.name ?? name);
-        setActiveTabId(nextTab?.id);
-        lastDisplayableTabNameRef.current = nextTab?.name ?? name;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        tabBarProps.onTabPress?.(name);
-      };
-
       if (platformEnv.isNative) {
-        return (
-          <Tabs.TabBar
-            {...tabBarProps}
-            tabNames={tabBarTabNames}
-            indexDecimal={perpTabShowWeb ? undefined : tabBarProps.indexDecimal}
-            onTabPress={handleTabPress}
-            variant={tabBarVariant}
-            renderItem={handleRenderItem}
-            renderToolbar={renderToolbar}
-          />
-        );
+        // iOS: the TabBar is rendered inside `renderHeader` so it scrolls away
+        // with the collapsible header instead of pinning below the nav bar
+        // (Liquid Glass immersive layout). Returning null keeps the library's
+        // tabBar slot empty (measured height 0); tab switching stays available
+        // via horizontal swipe, or by scrolling the header back into view.
+        if (platformEnv.isNativeIOS) {
+          return null;
+        }
+        return buildTabBar(tabBarProps);
       }
 
       // Outer YStack stays full-width so the sticky bg covers the entire
@@ -682,18 +768,7 @@ export function HomePageView({
           zIndex={10}
         >
           <Stack {...homePageContentMaxWidthSx}>
-            <Tabs.TabBar
-              {...tabBarProps}
-              tabNames={tabBarTabNames}
-              indexDecimal={
-                perpTabShowWeb ? undefined : tabBarProps.indexDecimal
-              }
-              onTabPress={handleTabPress}
-              variant={tabBarVariant}
-              renderItem={handleRenderItem}
-              renderToolbar={renderToolbar}
-              containerStyle={{ position: 'relative' as any }}
-            />
+            {buildTabBar(tabBarProps, WEB_TABBAR_CONTAINER_STYLE)}
             <div
               ref={portalRefCallback}
               style={{
@@ -708,17 +783,56 @@ export function HomePageView({
         </YStack>
       );
     },
-    [
-      portalRefCallback,
-      stickyHostRefCallback,
-      handleRenderItem,
-      renderToolbar,
-      switchToPerpsWebTab,
-      perpTabShowWeb,
-      isSmallScreen,
-      tabConfigs,
-      tabBarTabNames,
-    ],
+    [buildTabBar, portalRefCallback, stickyHostRefCallback],
+  );
+
+  // Alerts sit outside Tabs.Container (rendered next to TabPageHeader below).
+  // Keeping them inside renderHeader made them scroll through the sticky
+  // TabBar area — a partially-scrolled alert would leave a visible band
+  // between TabPageHeader and the tabs.
+  const renderHeader = useCallback(
+    (headerProps?: any) => (
+      <Stack
+        {...homePageContentMaxWidthSx}
+        // iOS pass-through: the fixed nav-bar spacer is removed (see homePage),
+        // so the collapsible header starts at the very top (behind the glass
+        // bar). This top padding pushes its first visible row below the bar;
+        // scrolling then slides the content up UNDER the translucent bar.
+        pt={platformEnv.isNativeIOS ? tabPageHeight : undefined}
+      >
+        {/* iOS: the wallet connection row (account + network) is relocated from
+            the fixed nav bar into the collapsible header so it scrolls away with
+            the page — only the search row stays fixed. Home scene only; the
+            url-account page keeps its own header. */}
+        {platformEnv.isNativeIOS &&
+        sceneName === EAccountSelectorSceneName.home ? (
+          <>
+            <HomeWalletConnectionRow
+              headerPx="$5"
+              sceneName={sceneName}
+              tabRoute={ETabRoutes.Home}
+            />
+            {/* iOS: alerts move into the collapsible header so they don't sit
+                behind the translucent glass bar; they scroll with the page.
+                Non-iOS keeps them pinned below the nav bar (see homePage). */}
+            <HomeAlerts />
+          </>
+        ) : null}
+        <HomeHeaderContainer />
+        {/* iOS: the non-sticky TabBar lives here so it scrolls away with the
+            header. `headerProps` is only present when invoked by Tabs.Container;
+            the not-backed-up path calls renderHeader() with no tabs. */}
+        {platformEnv.isNativeIOS && headerProps ? (
+          <>
+            <Stack bg="$bgApp">{buildTabBar(headerProps)}</Stack>
+            {/* Headless: bridges the focused tab's scroll offset out to the
+                fixed glass bar's fade (must live inside Tabs.Container). */}
+            <HomeHeaderGlassScrollObserver scrollYOut={headerGlassScrollY} />
+          </>
+        ) : null}
+      </Stack>
+    ),
+    [buildTabBar, sceneName, tabPageHeight, headerGlassScrollY],
   );
 
   const handleTabChange = useCallback(
@@ -832,7 +946,19 @@ export function HomePageView({
         ref={tabsRef as any}
         key={key}
         allowHeaderOverscroll
-        headerHeight={platformEnv.isNative ? 312 : undefined}
+        // iOS folds the wallet-connection row + TabBar into the collapsible
+        // header, so the header estimate grows and the separate tabBar slot
+        // collapses to 0 (see NATIVE_HOME_HEADER_HEIGHT).
+        headerHeight={NATIVE_HOME_HEADER_HEIGHT}
+        tabBarHeight={platformEnv.isNativeIOS ? 0 : undefined}
+        // iOS glass pass-through: clear the library's default white
+        // topContainer background so the collapsible header's top-padding strip
+        // (behind the translucent bar) shows the app background, not white.
+        headerContainerStyle={
+          platformEnv.isNativeIOS
+            ? { backgroundColor: 'transparent' }
+            : undefined
+        }
         useNativeHeaderAnimation={platformEnv.isNativeAndroid}
         width={platformEnv.isNative ? (tabContainerWidth as number) : undefined}
         renderHeader={renderHeader}
@@ -1017,16 +1143,9 @@ export function HomePageView({
     tabs,
   ]);
 
-  // Initial heights based on measured header sizes on each platform.
-  // iOS measured: 162 (raw 182 - 20 offset). Must match actual layout
-  // to prevent content shift when onLayout fires.
-  const [tabPageHeight, setTabPageHeight] = useState(
-    platformEnv.isNativeIOS ? 162 : 92,
-  );
-  const handleTabPageLayout = useCallback((e: LayoutChangeEvent) => {
-    const height = e.nativeEvent.layout.height - 20;
-    setTabPageHeight(height);
-  }, []);
+  // (tabPageHeight state + handleTabPageLayout are declared earlier, above the
+  // render callbacks, so renderHeader can read tabPageHeight for its iOS glass
+  // pass-through top padding.)
 
   const hasNoUsableWallet = accountUtils.hasNoUsableWallet({
     wallet,
@@ -1056,38 +1175,61 @@ export function HomePageView({
     let content = <Stack flex={1} />;
 
     if (showNoWalletContent) {
-      content = <NoWalletContent tabBarHeight={tabBarHeight} />;
+      content = (
+        <NoWalletContent
+          tabBarHeight={tabBarHeight}
+          topInset={platformEnv.isNativeIOS ? tabPageHeight : 0}
+        />
+      );
     }
 
     if (!hasNoUsableWallet) {
       content = walletPageContent;
       // This is a temporary hack solution, need to fix the layout of headerLeft and headerRight
     }
+    // Top slot above content: iOS pass-through omits the fixed nav-bar spacer
+    // entirely (renderHeader carries the equal top padding so content scrolls
+    // under the glass bar); other native platforms reserve the bar height; web
+    // renders the header inline.
+    let nativeTopSlot: React.ReactNode = null;
+    if (!platformEnv.isNativeIOS) {
+      nativeTopSlot = platformEnv.isNative ? (
+        <Stack h={tabPageHeight} />
+      ) : (
+        <TabPageHeader sceneName={sceneName} tabRoute={ETabRoutes.Home} />
+      );
+    }
     return (
       <>
         <Page.Body>
           <Page.Container flex={1} padded={false}>
-            {platformEnv.isNative ? (
-              <Stack h={tabPageHeight} />
-            ) : (
-              <TabPageHeader sceneName={sceneName} tabRoute={ETabRoutes.Home} />
+            {nativeTopSlot}
+            {/* Alerts: iOS renders these inside the collapsible header
+                (renderHeader) so they don't sit behind the glass bar; other
+                platforms keep them pinned below the fixed nav bar. */}
+            {platformEnv.isNativeIOS ? null : (
+              <Stack {...homePageContentMaxWidthSx}>
+                <HomeAlerts />
+              </Stack>
             )}
-            <Stack {...homePageContentMaxWidthSx}>
-              <RiskApprovalAlert />
-              <WatchOnlyAlert />
-              <NetworkAlert />
-            </Stack>
             {content}
             {platformEnv.isNative ? (
               <YStack
                 position="absolute"
                 top={-20}
                 left={0}
-                bg="$bgApp"
                 pt="$5"
                 width="100%"
                 onLayout={handleTabPageLayout}
+                // iOS (all supported versions): transparent bar with a
+                // progressive BlurView frost (HomeHeaderGlassOverlay) so home
+                // content scrolls visibly beneath it. Android keeps the solid
+                // background (tab bar still pinned).
+                {...(platformEnv.isNativeIOS ? {} : { bg: '$bgApp' })}
               >
+                {platformEnv.isNativeIOS ? (
+                  <HomeHeaderGlassOverlay scrollY={headerGlassScrollY} />
+                ) : null}
                 <TabPageHeader
                   sceneName={sceneName}
                   tabRoute={ETabRoutes.Home}
@@ -1107,6 +1249,7 @@ export function HomePageView({
     handleTabPageLayout,
     walletPageContent,
     tabBarHeight,
+    headerGlassScrollY,
   ]);
 
   return useMemo(() => {

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -24,6 +24,10 @@ import {
 } from '@onekeyhq/components';
 import type { ITabBarItemProps } from '@onekeyhq/components/src/composite/Tabs/TabBar';
 import { TabBarItem } from '@onekeyhq/components/src/composite/Tabs/TabBar';
+import {
+  ENABLE_IMMERSIVE_GLASS_HEADER,
+  IMMERSIVE_GLASS_TOP_OFFSET,
+} from '@onekeyhq/kit/src/components/ImmersiveGlassHeader';
 import { useTabContainerWidth } from '@onekeyhq/kit/src/hooks/useTabContainerWidth';
 import { getNetworksSupportBulkRevokeApproval } from '@onekeyhq/shared/src/config/presetNetworks';
 import {
@@ -101,7 +105,7 @@ const networksSupportBulkRevokeApproval =
 // re-measures via onLayout; this only minimizes first-frame content shift, so
 // tune against a real device if a first-frame jump appears.
 let NATIVE_HOME_HEADER_HEIGHT: number | undefined;
-if (platformEnv.isNativeIOS) {
+if (ENABLE_IMMERSIVE_GLASS_HEADER) {
   NATIVE_HOME_HEADER_HEIGHT = 522;
 } else if (platformEnv.isNative) {
   NATIVE_HOME_HEADER_HEIGHT = 312;
@@ -684,7 +688,7 @@ export function HomePageView({
   // top padding. Re-measured via handleTabPageLayout; the initial value only
   // minimizes first-frame shift.
   const [tabPageHeight, setTabPageHeight] = useState(
-    platformEnv.isNativeIOS ? 118 : 92,
+    ENABLE_IMMERSIVE_GLASS_HEADER ? 118 : 92,
   );
   const handleTabPageLayout = useCallback((e: LayoutChangeEvent) => {
     const height = e.nativeEvent.layout.height - 20;
@@ -749,7 +753,7 @@ export function HomePageView({
         // (Liquid Glass immersive layout). Returning null keeps the library's
         // tabBar slot empty (measured height 0); tab switching stays available
         // via horizontal swipe, or by scrolling the header back into view.
-        if (platformEnv.isNativeIOS) {
+        if (ENABLE_IMMERSIVE_GLASS_HEADER) {
           return null;
         }
         return buildTabBar(tabBarProps);
@@ -798,13 +802,13 @@ export function HomePageView({
         // so the collapsible header starts at the very top (behind the glass
         // bar). This top padding pushes its first visible row below the bar;
         // scrolling then slides the content up UNDER the translucent bar.
-        pt={platformEnv.isNativeIOS ? tabPageHeight : undefined}
+        pt={ENABLE_IMMERSIVE_GLASS_HEADER ? tabPageHeight : undefined}
       >
         {/* iOS: the wallet connection row (account + network) is relocated from
             the fixed nav bar into the collapsible header so it scrolls away with
             the page — only the search row stays fixed. Home scene only; the
             url-account page keeps its own header. */}
-        {platformEnv.isNativeIOS &&
+        {ENABLE_IMMERSIVE_GLASS_HEADER &&
         sceneName === EAccountSelectorSceneName.home ? (
           <>
             <HomeWalletConnectionRow
@@ -822,7 +826,7 @@ export function HomePageView({
         {/* iOS: the non-sticky TabBar lives here so it scrolls away with the
             header. `headerProps` is only present when invoked by Tabs.Container;
             the not-backed-up path calls renderHeader() with no tabs. */}
-        {platformEnv.isNativeIOS && headerProps ? (
+        {ENABLE_IMMERSIVE_GLASS_HEADER && headerProps ? (
           <>
             <Stack bg="$bgApp">{buildTabBar(headerProps)}</Stack>
             {/* Headless: bridges the focused tab's scroll offset out to the
@@ -950,12 +954,12 @@ export function HomePageView({
         // header, so the header estimate grows and the separate tabBar slot
         // collapses to 0 (see NATIVE_HOME_HEADER_HEIGHT).
         headerHeight={NATIVE_HOME_HEADER_HEIGHT}
-        tabBarHeight={platformEnv.isNativeIOS ? 0 : undefined}
+        tabBarHeight={ENABLE_IMMERSIVE_GLASS_HEADER ? 0 : undefined}
         // iOS glass pass-through: clear the library's default white
         // topContainer background so the collapsible header's top-padding strip
         // (behind the translucent bar) shows the app background, not white.
         headerContainerStyle={
-          platformEnv.isNativeIOS
+          ENABLE_IMMERSIVE_GLASS_HEADER
             ? { backgroundColor: 'transparent' }
             : undefined
         }
@@ -1178,7 +1182,7 @@ export function HomePageView({
       content = (
         <NoWalletContent
           tabBarHeight={tabBarHeight}
-          topInset={platformEnv.isNativeIOS ? tabPageHeight : 0}
+          topInset={ENABLE_IMMERSIVE_GLASS_HEADER ? tabPageHeight : 0}
         />
       );
     }
@@ -1192,7 +1196,7 @@ export function HomePageView({
     // under the glass bar); other native platforms reserve the bar height; web
     // renders the header inline.
     let nativeTopSlot: React.ReactNode = null;
-    if (!platformEnv.isNativeIOS) {
+    if (!ENABLE_IMMERSIVE_GLASS_HEADER) {
       nativeTopSlot = platformEnv.isNative ? (
         <Stack h={tabPageHeight} />
       ) : (
@@ -1207,7 +1211,7 @@ export function HomePageView({
             {/* Alerts: iOS renders these inside the collapsible header
                 (renderHeader) so they don't sit behind the glass bar; other
                 platforms keep them pinned below the fixed nav bar. */}
-            {platformEnv.isNativeIOS ? null : (
+            {ENABLE_IMMERSIVE_GLASS_HEADER ? null : (
               <Stack {...homePageContentMaxWidthSx}>
                 <HomeAlerts />
               </Stack>
@@ -1216,7 +1220,7 @@ export function HomePageView({
             {platformEnv.isNative ? (
               <YStack
                 position="absolute"
-                top={-20}
+                top={-IMMERSIVE_GLASS_TOP_OFFSET}
                 left={0}
                 pt="$5"
                 width="100%"
@@ -1225,9 +1229,9 @@ export function HomePageView({
                 // progressive BlurView frost (HomeHeaderGlassOverlay) so home
                 // content scrolls visibly beneath it. Android keeps the solid
                 // background (tab bar still pinned).
-                {...(platformEnv.isNativeIOS ? {} : { bg: '$bgApp' })}
+                {...(ENABLE_IMMERSIVE_GLASS_HEADER ? {} : { bg: '$bgApp' })}
               >
-                {platformEnv.isNativeIOS ? (
+                {ENABLE_IMMERSIVE_GLASS_HEADER ? (
                   <HomeHeaderGlassOverlay scrollY={headerGlassScrollY} />
                 ) : null}
                 <TabPageHeader

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import BigNumber from 'bignumber.js';
 import { isEqual } from 'lodash';
 import { useIntl } from 'react-intl';
+import { useSharedValue } from 'react-native-reanimated';
 
 import type {
   IDialogInstance,
@@ -12,14 +13,22 @@ import {
   Dialog,
   EPageType,
   Page,
+  Stack,
   Toast,
   YStack,
   useInModalDialog,
   useInTabDialog,
   useMedia,
+  useSafeAreaInsets,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
+import {
+  ENABLE_IMMERSIVE_GLASS_HEADER,
+  IMMERSIVE_GLASS_OVERHANG,
+  IMMERSIVE_HEADER_ROW_HEIGHT,
+  ImmersiveGlassOverlay,
+} from '@onekeyhq/kit/src/components/ImmersiveGlassHeader';
 import { LazyPageContainer } from '@onekeyhq/kit/src/components/LazyPageContainer';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useCustomRpcAvailability } from '@onekeyhq/kit/src/hooks/useCustomRpcAvailability';
@@ -144,7 +153,11 @@ import {
 } from './SwapStockDesktopContainer';
 import SwapSwapMbContainer from './SwapSwapMbContainer';
 
-import type { ScrollView as ScrollViewNative } from 'react-native';
+import type {
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  ScrollView as ScrollViewNative,
+} from 'react-native';
 
 interface ISwapMainLoadProps {
   children?: React.ReactNode;
@@ -156,6 +169,29 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   const { preSwapStepsStart, preSwapBeforeStepActions } = useSwapBuildTx();
   const intl = useIntl();
   const { gtLg } = useMedia();
+  const { top } = useSafeAreaInsets();
+  // iOS immersive header: bridges each swap panel's scroll offset to the fixed
+  // glass nav bar so it fades in as content scrolls under it. All three native
+  // panels (Swap, Stock, Pro) feed this shared value via onScroll.
+  const headerGlassScrollY = useSharedValue(0);
+  const handleContentScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      headerGlassScrollY.value = e.nativeEvent.contentOffset.y;
+    },
+    [headerGlassScrollY],
+  );
+  // Immersive glass header applies to the compact iOS tab surface only (never
+  // the swap modal, never the wide iPad/desktop split). Content then scrolls
+  // under a fixed translucent bar: pad its top by the bar height and route its
+  // scroll offset to the fade.
+  const isSwapImmersiveHeader =
+    ENABLE_IMMERSIVE_GLASS_HEADER && pageType !== EPageType.modal && !gtLg;
+  const swapContentTopInset = isSwapImmersiveHeader
+    ? top + IMMERSIVE_HEADER_ROW_HEIGHT
+    : 0;
+  const onSwapContentScroll = isSwapImmersiveHeader
+    ? handleContentScroll
+    : undefined;
   const { fetchLoading } = useSwapInit(swapInitParams);
   const navigation =
     useAppNavigation<IPageNavigationProp<IModalSwapParamList>>();
@@ -1259,6 +1295,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
           quoteLoading={quoteLoading}
           quoteEventFetching={quoteEventFetching}
           alerts={alerts}
+          onScroll={onSwapContentScroll}
+          contentTopInset={swapContentTopInset}
         />
       );
     }
@@ -1320,6 +1358,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
         fromTokenAmountValue={fromTokenAmount.value}
         swapRecentTokenPairs={swapRecentTokenPairs}
         supportNetworksList={swapBridgeSupportNetworksFilterAllNet}
+        onScroll={onSwapContentScroll}
+        contentTopInset={swapContentTopInset}
       />
     );
   }, [
@@ -1348,6 +1388,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     swapInitParams?.swapTabSwitchType,
     swapInitParams?.swapSource,
     gtLg,
+    onSwapContentScroll,
+    swapContentTopInset,
   ]);
 
   // Desktop: show provider panel on the right side, need wider layout
@@ -1396,68 +1438,113 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     contentTopPadding = '$0';
   }
 
-  return (
-    <>
+  const swapHeaderNode =
+    gtLg && pageType !== EPageType.modal && !platformEnv.isNative ? null : (
+      <SwapHeaderContainer
+        pageType={pageType}
+        defaultSwapType={swapInitParams?.swapTabSwitchType}
+        showSwapPro={platformEnv.isNative}
+        hideRightActions={showDesktopProviderPanel}
+        enterFrom={swapInitParams?.swapSource}
+        marketPresetSettings={
+          focusSwapPro ? swapProMarketPresetSettings : undefined
+        }
+      />
+    );
+
+  // Build the active scroll panel lazily: only the Pro branch allocates the
+  // heavy SwapProContainer element (and its inline config/props), so it isn't
+  // created and discarded on every render when the user is not in Pro mode.
+  let swapBodyNode: React.ReactNode;
+  if (focusSwapPro) {
+    swapBodyNode = (
+      <SwapProContainer
+        pageType={pageType}
+        onProSelectToken={onProSelectToken}
+        onOpenOrdersClick={onOpenOrdersClick}
+        onSwapProActionClick={onPreSwap}
+        onSelectPercentageStage={onSelectPercentageStage}
+        onBalanceMaxPress={onBalanceMaxPress}
+        handleSelectAccountClick={handleSelectAccountClick}
+        onProMarketDetail={onProMarketDetail}
+        onTokenPress={onTokenPress}
+        supportNetworksList={SwapProSupportNetworksList}
+        onScroll={onSwapContentScroll}
+        marketPresetSettings={
+          swapProMarketPresetTokenContext
+            ? swapProMarketPresetSettings
+            : undefined
+        }
+        config={{
+          isLoading,
+          speedConfig,
+          balanceLoading,
+          isMEV,
+          hasEnoughBalance,
+          supportSpeedSwap,
+        }}
+      />
+    );
+    // Pro mode pins a sticky token-selector header. If its scroll view filled
+    // the screen, that sticky row would pin at the top and tuck under the glass
+    // bar. So in immersive mode Pro's scroll view starts BELOW the bar (wrapped
+    // with the top inset), keeping the sticky row visible. Swap / Stock have no
+    // sticky header, so their content scrolls under the bar via contentTopInset.
+    if (isSwapImmersiveHeader) {
+      swapBodyNode = (
+        <Stack flex={1} pt={swapContentTopInset}>
+          {swapBodyNode}
+        </Stack>
+      );
+    }
+  } else {
+    swapBodyNode = renderSwapSwapBridgeContainer();
+  }
+
+  if (isSwapImmersiveHeader) {
+    return (
       <Page.Container flex={1} layout={containerLayout} padded={false}>
-        <YStack
-          testID={SwapTestIDs.pageContainer}
-          flex={1}
-          width="100%"
-          pt={contentTopPadding}
-          gap="$2"
-          $gtMd={{
-            flex: 'unset',
-          }}
-          $gtLg={{
-            pt: '$0',
-          }}
-        >
-          {gtLg &&
-          pageType !== EPageType.modal &&
-          !platformEnv.isNative ? null : (
-            <SwapHeaderContainer
-              pageType={pageType}
-              defaultSwapType={swapInitParams?.swapTabSwitchType}
-              showSwapPro={platformEnv.isNative}
-              hideRightActions={showDesktopProviderPanel}
-              enterFrom={swapInitParams?.swapSource}
-              marketPresetSettings={
-                focusSwapPro ? swapProMarketPresetSettings : undefined
-              }
+        <YStack testID={SwapTestIDs.pageContainer} flex={1} width="100%">
+          {swapBodyNode}
+          {/* Fixed translucent nav bar: the progressive-blur glass frost
+              (fades in on scroll) sits behind the status-bar spacer + the swap
+              tab-switch row; content above scrolls up under it. */}
+          <YStack position="absolute" top={0} left={0} right={0}>
+            {/* Pro mode pins a sticky token selector directly under the bar, so
+                drop the overhang there to keep that row un-frosted; Swap / Stock
+                keep the soft overhang over their scrolling content. */}
+            <ImmersiveGlassOverlay
+              scrollY={headerGlassScrollY}
+              topOffset={0}
+              overhang={focusSwapPro ? 0 : IMMERSIVE_GLASS_OVERHANG}
             />
-          )}
-          {focusSwapPro ? (
-            <SwapProContainer
-              pageType={pageType}
-              onProSelectToken={onProSelectToken}
-              onOpenOrdersClick={onOpenOrdersClick}
-              onSwapProActionClick={onPreSwap}
-              onSelectPercentageStage={onSelectPercentageStage}
-              onBalanceMaxPress={onBalanceMaxPress}
-              handleSelectAccountClick={handleSelectAccountClick}
-              onProMarketDetail={onProMarketDetail}
-              onTokenPress={onTokenPress}
-              supportNetworksList={SwapProSupportNetworksList}
-              marketPresetSettings={
-                swapProMarketPresetTokenContext
-                  ? swapProMarketPresetSettings
-                  : undefined
-              }
-              config={{
-                isLoading,
-                speedConfig,
-                balanceLoading,
-                isMEV,
-                hasEnoughBalance,
-                supportSpeedSwap,
-              }}
-            />
-          ) : (
-            renderSwapSwapBridgeContainer()
-          )}
+            <Stack h={top} />
+            {swapHeaderNode}
+          </YStack>
         </YStack>
       </Page.Container>
-    </>
+    );
+  }
+
+  return (
+    <Page.Container flex={1} layout={containerLayout} padded={false}>
+      <YStack
+        testID={SwapTestIDs.pageContainer}
+        flex={1}
+        width="100%"
+        pt={contentTopPadding}
+        gap="$2"
+        $gtMd={{
+          flex: 'unset',
+        }}
+        $gtLg={{
+          pt: '$0',
+        }}
+      >
+        {swapHeaderNode}
+        {swapBodyNode}
+      </YStack>
+    </Page.Container>
   );
 };
 

--- a/packages/kit/src/views/Swap/pages/components/SwapProContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProContainer.tsx
@@ -64,6 +64,7 @@ import SwapProTradingPanel from './SwapProTradingPanel';
 import SwapTipsContainer from './SwapTipsContainer';
 
 import type { IMarketPresetSettingsState } from '../../../Market/MarketDetailV2/components/SwapPanel/hooks/useMarketPresetSettings';
+import type { ScrollViewProps } from 'react-native';
 
 interface ISwapProContainerProps {
   pageType?: EPageType;
@@ -77,6 +78,8 @@ interface ISwapProContainerProps {
   onTokenPress: (token: ISwapToken) => void;
   supportNetworksList: IMarketBasicConfigNetwork[];
   marketPresetSettings?: IMarketPresetSettingsState;
+  // iOS immersive header: drives the glass nav-bar fade as this panel scrolls.
+  onScroll?: ScrollViewProps['onScroll'];
   config: {
     isLoading: boolean;
     speedConfig: ISwapProSpeedConfig;
@@ -99,6 +102,7 @@ const SwapProContainer = ({
   onTokenPress,
   supportNetworksList,
   marketPresetSettings,
+  onScroll,
   config,
 }: ISwapProContainerProps) => {
   const {
@@ -282,6 +286,8 @@ const SwapProContainer = ({
       stickyHeaderIndices={[1]}
       keyboardShouldPersistTaps="handled"
       keyboardDismissMode="on-drag"
+      onScroll={onScroll}
+      scrollEventThrottle={16}
       refreshControl={
         <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
       }

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -157,6 +157,7 @@ import {
   useSwapStockTradeContext,
 } from './SwapStockTradeProvider';
 
+import type { ScrollViewProps } from 'react-native';
 import type { KeyboardAwareScrollViewRef } from 'react-native-keyboard-controller';
 
 interface ISwapStockDesktopContainerProps {
@@ -179,6 +180,11 @@ interface ISwapStockDesktopContainerProps {
     states: ISwapAlertState[];
     quoteId: string;
   };
+  // iOS immersive header: drives the glass nav-bar fade and adds the top inset so
+  // the mobile Stock scroll view starts below the fixed bar and scrolls up under
+  // it. Unused by the desktop layout.
+  onScroll?: ScrollViewProps['onScroll'];
+  contentTopInset?: number;
 }
 
 type IStockMarketTokenDetail = IMarketTokenDetail | undefined;
@@ -2264,7 +2270,11 @@ function SwapStockMobileContent(props: ISwapStockDesktopContainerProps) {
       keyboardDismissMode="on-drag"
       ref={scrollViewRef}
       showsVerticalScrollIndicator={false}
-      contentContainerStyle={{ paddingBottom: tabBarHeight }}
+      onScroll={props.onScroll}
+      contentContainerStyle={{
+        paddingTop: props.contentTopInset ?? 0,
+        paddingBottom: tabBarHeight,
+      }}
       bottomOffset={bottomOffset}
     >
       <YStack

--- a/packages/kit/src/views/Swap/pages/components/SwapSwapMbContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapSwapMbContainer.tsx
@@ -26,6 +26,7 @@ import SwapQuoteInput from './SwapQuoteInput';
 import SwapQuoteResult from './SwapQuoteResult';
 import SwapTipsContainer from './SwapTipsContainer';
 
+import type { ScrollViewProps } from 'react-native';
 import type { KeyboardAwareScrollViewRef } from 'react-native-keyboard-controller';
 
 interface ISwapSwapMbContainerProps {
@@ -58,6 +59,11 @@ interface ISwapSwapMbContainerProps {
   fromTokenAmountValue: string;
   swapRecentTokenPairs: { fromToken: ISwapToken; toToken: ISwapToken }[];
   supportNetworksList: ISwapNetwork[];
+  // iOS immersive header: drives the glass nav-bar fade as this panel scrolls.
+  onScroll?: ScrollViewProps['onScroll'];
+  // iOS immersive header: top padding so content starts below the fixed glass
+  // bar and scrolls up under it (0 when the effect is off).
+  contentTopInset?: number;
 }
 
 const SwapSwapMbContainer = ({
@@ -81,6 +87,8 @@ const SwapSwapMbContainer = ({
   fromTokenAmountValue,
   swapRecentTokenPairs,
   supportNetworksList,
+  onScroll,
+  contentTopInset = 0,
 }: ISwapSwapMbContainerProps) => {
   const tabBarHeight = useScrollContentTabBarOffset();
   const scrollViewRef = useRef<KeyboardAwareScrollViewRef>(null);
@@ -108,7 +116,11 @@ const SwapSwapMbContainer = ({
       keyboardDismissMode="on-drag"
       ref={scrollViewRef}
       showsVerticalScrollIndicator={false}
-      contentContainerStyle={{ paddingBottom: tabBarHeight }}
+      onScroll={onScroll}
+      contentContainerStyle={{
+        paddingTop: contentTopInset,
+        paddingBottom: tabBarHeight,
+      }}
       bottomOffset={bottomOffset}
     >
       <SwapTipsContainer pageType={swapTipsPageType} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -10231,6 +10231,7 @@ __metadata:
     "@react-native-community/slider": "npm:5.0.1"
     "@react-native-documents/picker": "npm:^12.0.1"
     "@react-native-google-signin/google-signin": "npm:16.1.0"
+    "@react-native-masked-view/masked-view": "npm:0.3.2"
     "@react-native/metro-config": "npm:0.81.5"
     "@reown/appkit-ethers5-react-native": "https://github.com/OneKeyHQ/app-modules#9d96daccc13625e5b3c8b236f9357956b049b884"
     "@rozenite/expo-atlas-plugin": "npm:1.0.0-alpha.16"
@@ -13674,6 +13675,16 @@ __metadata:
   peerDependencies:
     react-native: "*"
   checksum: 10/070442281d7ce0d766bfb8fcccf435db56dd8fe67a1475bcc548c915970bdb29d1569c5b1a87359dc8a74e6dabaea07b486d2868e1340c04d2558cfbb135d6a7
+  languageName: node
+  linkType: hard
+
+"@react-native-masked-view/masked-view@npm:0.3.2":
+  version: 0.3.2
+  resolution: "@react-native-masked-view/masked-view@npm:0.3.2"
+  peerDependencies:
+    react: ">=16"
+    react-native: ">=0.57"
+  checksum: 10/04ffbc01083aa563ca1e2d7ef6759e7b326b8129f5bb1aa5f3142348adab06d5e321a400cf70a5434324dfa906add383f8214640697c48c9e5311b30bfea03d9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57114](https://onekeyhq.atlassian.net/browse/OK-57114)

----------

<!-- github-pr-monitor:jira-links:end -->


## What

Immersive Liquid-Glass tab headers on iOS: a fixed, translucent progressive-blur nav bar that page content scrolls **under**, fading in on scroll (transparent/seamless at rest). Applied to the **Wallet (Home)** and **Trade (Swap)** tabs, on a shared primitive so more tabs can adopt it with a one-line change.

Implements OK-57114 【预期】#1 (whole-header Liquid Glass, referencing iOS native Appstore / Stocks / Safari) for the Wallet + Trade tabs.

## Why

Designers (Patrick & Yishi) asked for the iOS nav bar to stop pinning (吸顶) and instead let content scroll up through a frosted, immersive header — matching iOS-native chrome. This lands that for the two most-used tabs and extracts the mechanism so Perps/Discover can follow.

## Changes

**Shared primitive** — `packages/kit/src/components/ImmersiveGlassHeader/`
- `ENABLE_IMMERSIVE_GLASS_HEADER` — single gate (currently `platformEnv.isNativeIOS`). Restricting to iOS 26+ later is one line here + a JS hot-update, and it flips every page at once.
- `ImmersiveGlassOverlay` — the frost, delegating to the existing `ProgressiveBlur` (masked `BlurView` + gradient; deliberately **not** the iOS-26 native `GlassView`, which renders nothing when masked).
- `IMMERSIVE_GLASS_HEADER_TAB_ROUTES` — data-driven route set; `MDHeader` reads it to drop the status-bar spacer for immersive tabs (no hardcoded route).

**Wallet (Home)** — un-pin the tab bar; only the search row stays fixed. The account/network row + the Spot/Perps/DeFi/NFT/History tab bar scroll away with the page (scroll back up to switch network/wallet). Home's inline `platformEnv.isNativeIOS` glass gates migrated to the shared flag (runtime unchanged — flag === isNativeIOS today).

**Trade (Swap)** — the mode-switch row (Swap/Stock/Limit) becomes the fixed frosted bar; content scrolls under it, fading in on scroll. All three native panels (Swap/Bridge, Stock, Pro/Limit) feed the fade via `onScroll`. Pro's sticky token selector stays visible (its scroll view starts below the bar; the frost overhang is dropped there so the pinned row isn't blurred).

## Scope / platforms

- **iOS only**, phone-portrait tab surface. Android / Web / Desktop / swap-modal / iPad-split are unchanged.
- Not in this PR: Perps & Discover headers, and Popup/Toast Liquid Glass (OK-57114 【预期】#2).

## Reviewer notes

- `git diff` on `SwapMainLand.tsx` is large but the non-immersive (Android/web/desktop/modal) render path is behavior-preserving — only the `platformEnv.isNativeIOS && !modal && !gtLg` branch is new.
- The scroll→fade uses a plain JS `onScroll` writing a reanimated shared value (no `useAnimatedScrollHandler` precedent in the repo; the fade window is 16px so JS-thread updates are fine).
- Went through `/simplify` (reuse/simplification/efficiency/altitude); `yarn agent:check --profile commit` passes (lint + tsc).

## Testing

Needs on-device iOS verification (QA cases in OK-57114). Key checks: content visibly scrolls under a seamless-at-rest frosted bar on Wallet + all 3 Trade modes; Pro's sticky token selector stays clear; Android/Web/Desktop unaffected.

[OK-57114]: https://onekeyhq.atlassian.net/browse/OK-57114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ