### PR TITLE
feat: default tabular numerals app-wide + localized thousands separators

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -1492,3 +1492,6 @@ retryably
 
 # @mysten/sui 2.x package name
 mysten
+
+# OpenType tabular-figures feature tag
+tnum

--- a/packages/components/src/composite/SegmentSlider/index.tsx
+++ b/packages/components/src/composite/SegmentSlider/index.tsx
@@ -586,6 +586,7 @@ function SegmentSliderComponent({
       fontSize: 12,
       lineHeight: '16px',
       fontWeight: 600,
+      fontVariantNumeric: 'tabular-nums',
       opacity: 0,
       transition: 'opacity 150ms ease',
       pointerEvents: 'none',

--- a/packages/components/src/content/Badge/index.tsx
+++ b/packages/components/src/content/Badge/index.tsx
@@ -8,8 +8,10 @@ import {
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { XStack } from '../../primitives/Stack';
+import { TABULAR_NUMS, getFontVariantStyle } from '../../utils/tabularNums';
 
 import type { IXStackProps } from '../../primitives';
+import type { GetProps } from '@onekeyhq/components/src/shared/tamagui';
 
 export type IBadgeType =
   | 'success'
@@ -60,7 +62,7 @@ const BadgeFrame = styled(XStack, {
   } as const,
 });
 
-const BadgeText = styled(SizableText, {
+const BadgeTextStyled = styled(SizableText, {
   name: 'BadgeText',
   allowFontScaling: false,
   numberOfLines: 1,
@@ -93,6 +95,20 @@ const BadgeText = styled(SizableText, {
     },
   } as const,
 });
+
+// Badge.Text is styled from raw tamagui text, so it bypasses the SizableText
+// wrapper's app-wide tabular default. Re-apply it here so badge digits
+// (countdowns, rates, counts) stay equal-width on native. On web the injected
+// body rule already covers it, so getFontVariantStyle returns undefined there.
+function BadgeText({ style, ...props }: GetProps<typeof BadgeTextStyled>) {
+  const variantStyle = getFontVariantStyle(TABULAR_NUMS);
+  return (
+    <BadgeTextStyled
+      {...props}
+      style={variantStyle ? [variantStyle, style] : style}
+    />
+  );
+}
 
 export type IBadgeProps = IXStackProps & {
   badgeType?: IBadgeType;

--- a/packages/components/src/content/NetworkStatusBadge/index.tsx
+++ b/packages/components/src/content/NetworkStatusBadge/index.tsx
@@ -4,11 +4,10 @@ import type { ComponentProps, ReactElement } from 'react';
 import { useIntl } from 'react-intl';
 
 import { Stack } from '@onekeyhq/components/src/primitives';
+import {} from '@onekeyhq/components/src/utils/tabularNums';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { Badge } from '../Badge';
-
-const fontVariant: ['tabular-nums'] = ['tabular-nums'];
 
 export type INetworkStatusBadgeProps = {
   connected: boolean;
@@ -89,8 +88,6 @@ export function NetworkStatusBadge({
         <Badge.Text
           flex={1}
           size="$bodySmMedium"
-          fontFamily="$monoRegular"
-          fontVariant={fontVariant}
           minWidth={40}
           textAlign="right"
         >

--- a/packages/components/src/hocs/Provider/hooks/useLoadCustomFonts.web.ts
+++ b/packages/components/src/hocs/Provider/hooks/useLoadCustomFonts.web.ts
@@ -16,6 +16,18 @@ const monoFonts = {
 
 let loadPromise: Promise<void> | null = null;
 
+// App-wide tabular figures (see utils/tabularNums.ts). SizableText already
+// defaults this, but text rendered outside the wrapper (raw tamagui Text,
+// Badge.Text, portals) inherits it from body via this rule on web.
+let numericStyleInjected = false;
+function injectGlobalNumericStyle() {
+  if (numericStyleInjected) return;
+  numericStyleInjected = true;
+  const style = document.createElement('style');
+  style.textContent = 'body{font-variant-numeric:tabular-nums}';
+  document.head.appendChild(style);
+}
+
 function loadRoobertFonts() {
   if (!loadPromise) {
     loadPromise = (async () => {
@@ -35,6 +47,7 @@ export default function useLoadCustomFonts(): [boolean, Error | null] {
   const [rError, setRError] = useState<Error | null>(null);
 
   useEffect(() => {
+    injectGlobalNumericStyle();
     loadRoobertFonts()
       .then(() => setRLoaded(true))
       .catch((err) =>

--- a/packages/components/src/primitives/SizeableText/index.tsx
+++ b/packages/components/src/primitives/SizeableText/index.tsx
@@ -2,14 +2,39 @@ import { SizableText as TamaguiSizableText } from '@tamagui/text';
 
 import { type SizableTextProps } from '@onekeyhq/components/src/shared/tamagui';
 
+import { TABULAR_NUMS, getFontVariantStyle } from '../../utils/tabularNums';
+
 export const StyledSizableText = TamaguiSizableText;
 
-export function SizableText({ size = '$bodyMd', ...props }: SizableTextProps) {
+export function SizableText({
+  size = '$bodyMd',
+  // App-wide default: tabular (equal-width) figures on ALL text, matching the
+  // reference exchanges whose brand fonts ship tabular digits by default.
+  // Only digit glyph widths change — letters are unaffected — so prose is
+  // safe. Opt out per text with `fontVariant={PROPORTIONAL_NUMS}`.
+  fontVariant = TABULAR_NUMS,
+  style,
+  ...props
+}: SizableTextProps) {
+  // Tamagui silently drops the RN `fontVariant` prop, so numeric variants
+  // (tabular-nums etc.) never reach the renderer — re-route it through the
+  // `style` prop: RN style `fontVariant` on native, CSS `font-variant-numeric`
+  // on web. Caller-provided `style` still wins on conflicts.
+  let mergedStyle = style;
+  const variantStyle = getFontVariantStyle(fontVariant);
+  if (variantStyle) {
+    if (Array.isArray(style)) {
+      mergedStyle = [variantStyle, ...style];
+    } else {
+      mergedStyle = style ? [variantStyle, style] : variantStyle;
+    }
+  }
   return (
     <StyledSizableText
       allowFontScaling={false}
       maxFontSizeMultiplier={1}
       size={size}
+      style={mergedStyle}
       {...props}
     />
   );

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -2,4 +2,5 @@ export * from './DebugRenderTracker';
 export * from './getFontSize';
 export * from './scale';
 export * from './sidebar';
+export * from './tabularNums';
 export * from './webFontFamily';

--- a/packages/components/src/utils/tabularNums.ts
+++ b/packages/components/src/utils/tabularNums.ts
@@ -1,0 +1,93 @@
+import type { CSSProperties } from 'react';
+
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import type { TextStyle } from 'react-native';
+
+/**
+ * Tabular (equal-width) figures for numeric text.
+ *
+ * `SizableText` applies this by DEFAULT app-wide, and web mirrors it with an
+ * injected `body { font-variant-numeric: tabular-nums }` rule, so most text
+ * needs nothing. Reach for the constant directly only for text that bypasses
+ * the `SizableText` wrapper — raw React Native `<Text>` / `StyleSheet.create`,
+ * or `Badge.Text` — via `getFontVariantStyle(TABULAR_NUMS)`.
+ *
+ * Every digit shares one advance width, so number columns stay aligned and a
+ * value doesn't reflow as it ticks. Unlike a monospace family (`$monoRegular`),
+ * only digits are equalized — letters keep Roobert's natural proportional
+ * widths. Roobert ships the `tnum` OpenType feature, so this works on iOS,
+ * Android and web.
+ *
+ * Monospace is still the right choice for addresses / hashes / mnemonics /
+ * codes, where character (not just digit) alignment matters — do NOT replace
+ * those with tabular-nums.
+ */
+export const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
+
+/**
+ * Escape hatch from the app-wide tabular default (`SizableText` defaults
+ * `fontVariant` to TABULAR_NUMS): pass `fontVariant={PROPORTIONAL_NUMS}` to
+ * restore the font's natural proportional figures for a specific text.
+ */
+export const PROPORTIONAL_NUMS: ['proportional-nums'] = ['proportional-nums'];
+
+type IFontVariantStyle = CSSProperties | TextStyle;
+
+function buildFontVariantStyle(
+  fontVariant: NonNullable<TextStyle['fontVariant']>,
+): IFontVariantStyle {
+  if (platformEnv.isNative) {
+    return Object.freeze({ fontVariant });
+  }
+  const style: CSSProperties = {};
+  const numericVariants = fontVariant.filter((v) => v.endsWith('-nums'));
+  if (numericVariants.length > 0) {
+    style.fontVariantNumeric = numericVariants.join(' ');
+  }
+  if (fontVariant.includes('small-caps')) {
+    style.fontVariantCaps = 'small-caps';
+  }
+  return Object.freeze(style);
+}
+
+// Web applies tabular figures globally via the injected `body` rule
+// (useLoadCustomFonts.web.ts), so the DEFAULT variant needs no inline style —
+// leaving it undefined avoids a redundant style attr on every text node and
+// keeps `style` reference-stable. Native has no CSS inheritance, so it must
+// carry the variant inline.
+const TABULAR_NUMS_STYLE: IFontVariantStyle | undefined = platformEnv.isNative
+  ? buildFontVariantStyle(TABULAR_NUMS)
+  : undefined;
+
+const fontVariantStyleCache = new WeakMap<
+  NonNullable<TextStyle['fontVariant']>,
+  IFontVariantStyle
+>();
+
+/**
+ * Translate the RN `fontVariant` array into a platform-appropriate style
+ * object (RN style `fontVariant` on native, CSS `font-variant-numeric` /
+ * `font-variant-caps` on web), since Tamagui silently drops the raw
+ * `fontVariant` prop.
+ *
+ * Results are cached per array reference (with a hoisted fast path for
+ * `TABULAR_NUMS`), so the returned object is reference-stable across renders.
+ */
+export function getFontVariantStyle(
+  // Tamagui widens the prop with an extra 'unset' string literal.
+  fontVariant: TextStyle['fontVariant'] | 'unset',
+): IFontVariantStyle | undefined {
+  if (fontVariant === TABULAR_NUMS) {
+    return TABULAR_NUMS_STYLE;
+  }
+  if (!Array.isArray(fontVariant) || fontVariant.length === 0) {
+    return undefined;
+  }
+  let cached = fontVariantStyleCache.get(fontVariant);
+  if (!cached) {
+    cached = buildFontVariantStyle(fontVariant);
+    fontVariantStyleCache.set(fontVariant, cached);
+  }
+  return cached;
+}

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
@@ -9,6 +9,7 @@ import {
   DebugRenderTracker,
   Divider,
   Icon,
+  PROPORTIONAL_NUMS,
   SizableText,
   Skeleton,
   Stack,
@@ -524,6 +525,10 @@ function TokenDetailsHeaderContent({
                   fontSize={48}
                   lineHeight={48}
                   fontWeight={500}
+                  // Large hero value uses natural proportional figures (matches
+                  // the home total-balance hero); tabular is reserved for
+                  // tables / ticking data.
+                  fontVariant={PROPORTIONAL_NUMS}
                 >
                   {displayFiatValueOrUnavailable(
                     tokenDetails?.fiatValue,

--- a/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
+++ b/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
@@ -10,6 +10,7 @@ import {
   Dialog,
   Divider,
   ESwitchSize,
+  PROPORTIONAL_NUMS,
   SizableText,
   Skeleton,
   Stack,
@@ -391,7 +392,7 @@ function BalanceDetailsContent({
           {isLoading ? (
             <Skeleton.Heading3Xl />
           ) : (
-            <SizableText size="$heading3xl">
+            <SizableText size="$heading3xl" fontVariant={PROPORTIONAL_NUMS}>
               {`${overview?.balanceParsed ?? '-'} ${network?.symbol ?? ''}`}
             </SizableText>
           )}

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -70,8 +70,6 @@ import { resolveOverviewCols } from './overviewColsResolver';
 import { type IProtocolHandle, Protocol } from './Protocol';
 import { useIsDeFiEnabled } from './useIsDeFiEnabled';
 
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
-
 const MAX_PROTOCOLS_ON_SMALL_SCREEN = 6;
 const PROTOCOL_LIST_TOGGLE_PRESS_LOCK_MS = 600;
 
@@ -1454,7 +1452,6 @@ function DeFiListBlock({
       <SizableText
         size="$headingXl"
         color={tableLayout ? '$textSubdued' : '$text'}
-        fontVariant={TABULAR_NUMS}
       >
         {formatPortfolioTotal(
           Number(overview.netWorth) || 0,

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiOverviewTile.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiOverviewTile.tsx
@@ -16,8 +16,6 @@ import type {
 import { OVERVIEW_TILE_SHADOW } from './DeFiOverviewLayout';
 import { formatPortfolioTotal } from './formatPortfolioTotal';
 
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
-
 export type IDeFiOverviewTileProps = {
   protocol: IDeFiProtocol;
   protocolInfo: IProtocolSummary | undefined;
@@ -105,11 +103,7 @@ function DeFiOverviewTile({
         >
           {name}
         </SizableText>
-        <SizableText
-          size="$bodyLgMedium"
-          numberOfLines={1}
-          fontVariant={TABULAR_NUMS}
-        >
+        <SizableText size="$bodyLgMedium" numberOfLines={1}>
           {formattedNetWorth}
         </SizableText>
       </YStack>

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiPortfolioStackedBar.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiPortfolioStackedBar.tsx
@@ -65,8 +65,6 @@ const STACKED_BAR_CHROME = {
   },
 } as const;
 
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
-
 const SEGMENT_OPACITY = 0.86;
 
 function buildA11yLabel(
@@ -249,7 +247,6 @@ function DeFiPortfolioStackedBar({
                   color="$text"
                   selectable={false}
                   numberOfLines={1}
-                  fontVariant={TABULAR_NUMS}
                   flexShrink={0}
                 >
                   {seg.label}

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolAssetBalanceText.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolAssetBalanceText.tsx
@@ -4,8 +4,6 @@ import { isProtocolAssetValueUnavailable } from '@onekeyhq/kit/src/components/De
 import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
 import type { IDeFiAsset } from '@onekeyhq/shared/types/defi';
 
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
-
 type IProtocolAssetBalanceTextProps = {
   asset: IDeFiAsset;
   currencySymbol: string;
@@ -27,7 +25,6 @@ function ProtocolAssetBalanceText({
         formatter="balance"
         formatterOptions={{ tokenSymbol: asset.symbol }}
         numberOfLines={1}
-        fontVariant={TABULAR_NUMS}
       >
         {asset.amount}
       </NumberSizeableTextWrapper>
@@ -43,7 +40,6 @@ function ProtocolAssetBalanceText({
             isUnavailable={isProtocolAssetValueUnavailable(asset)}
             size="$bodyMd"
             color="$textSubdued"
-            fontVariant={TABULAR_NUMS}
             numberOfLines={1}
             justifyContent="flex-start"
           />

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolHeaderRow.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolHeaderRow.tsx
@@ -11,8 +11,6 @@ import { useSettingsValuePersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/a
 
 import { formatPortfolioTotal } from './formatPortfolioTotal';
 
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
-
 export type IProtocolHeaderRowProps = {
   name: string;
   logo?: string;
@@ -84,7 +82,6 @@ function ProtocolHeaderRow({
         minWidth={120}
         maxWidth={168}
         color="$text"
-        fontVariant={TABULAR_NUMS}
       >
         {formattedNetWorth}
       </SizableText>

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolSectionedPositionTable.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolSectionedPositionTable.tsx
@@ -24,8 +24,6 @@ import {
 // The Supplied segment uses "Positions" in the first header cell to align with
 // the unified table; Borrowed and Rewards keep their semantic labels.
 
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
-
 type IProtocolSectionedPositionTableProps = {
   position: ILocalizedProtocolPositionItem;
   currencySymbol: string;
@@ -146,7 +144,6 @@ const ProtocolSectionedPositionTable = memo(
                     size="$bodyMdMedium"
                     textAlign="right"
                     numberOfLines={1}
-                    fontVariant={TABULAR_NUMS}
                   />
                 </Stack>
               </XStack>

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolUnifiedTable.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolUnifiedTable.tsx
@@ -56,8 +56,6 @@ export const USD_FLEX_WITHOUT_REWARDS = 1;
 // settles at four lines of content instead of eight.
 const MAX_BALANCE_LINES = 3;
 
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
-
 type IProtocolUnifiedTableProps = {
   rows: IProtocolUnifiedRow[];
   currencySymbol: string;
@@ -294,7 +292,6 @@ const ProtocolUnifiedTable = memo(
                   size="$bodyMdMedium"
                   textAlign="right"
                   numberOfLines={1}
-                  fontVariant={TABULAR_NUMS}
                 />
               </Stack>
             </XStack>

--- a/packages/kit/src/views/Home/components/WalletOverview/index.tsx
+++ b/packages/kit/src/views/Home/components/WalletOverview/index.tsx
@@ -1,4 +1,9 @@
-import { SizableText, Skeleton, YStack } from '@onekeyhq/components';
+import {
+  PROPORTIONAL_NUMS,
+  SizableText,
+  Skeleton,
+  YStack,
+} from '@onekeyhq/components';
 
 import { HomeTestIDs } from '../../testIDs';
 
@@ -27,7 +32,9 @@ function WalletOverview(props: IProps) {
         {address}
       </SizableText>
       <Skeleton show={isFetchingValue}>
-        <SizableText size="$heading4xl">{value}</SizableText>
+        <SizableText size="$heading4xl" fontVariant={PROPORTIONAL_NUMS}>
+          {value}
+        </SizableText>
       </Skeleton>
     </YStack>
   );

--- a/packages/kit/src/views/Home/pages/DeFiContainer.tsx
+++ b/packages/kit/src/views/Home/pages/DeFiContainer.tsx
@@ -76,7 +76,6 @@ import {
 // Page.Container is now layout="full" so the scroll container fills the
 // viewport, and visual max-width is enforced one level down per content block.
 const DEFI_CONTAINER_CONTENT_MAX_WIDTH = 1140;
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
 const PROTOCOL_NAV_PENDING_TARGET_TIMEOUT_MS = 5000;
 
 function scrollToAnchor(
@@ -710,11 +709,7 @@ function DeFiContainer() {
                 // approximate a typical "$XX,XXX.XX" measurement.
                 <Skeleton.HeadingXl w={120} />
               ) : (
-                <SizableText
-                  size="$headingXl"
-                  color="$textSubdued"
-                  fontVariant={TABULAR_NUMS}
-                >
+                <SizableText size="$headingXl" color="$textSubdued">
                   {formatPortfolioTotal(
                     portfolioStats.total,
                     currencySymbol,

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -6,6 +6,7 @@ import { useIntl } from 'react-intl';
 import {
   Button,
   IconButton,
+  PROPORTIONAL_NUMS,
   Skeleton,
   XStack,
   YStack,
@@ -951,6 +952,9 @@ function HomeOverviewContainer() {
                 fontSize={48}
                 lineHeight={48}
                 fontWeight={500}
+                // Large hero balance reads better with the font's natural
+                // proportional figures than equal-width tabular ones.
+                fontVariant={PROPORTIONAL_NUMS}
                 {...numberFormatter}
               >
                 {renderedBalanceStringDisplay ?? '0'}

--- a/packages/kit/src/views/Market/components/Chart/value-chart/ExtremeLabels.tsx
+++ b/packages/kit/src/views/Market/components/Chart/value-chart/ExtremeLabels.tsx
@@ -2,12 +2,20 @@ import type { ReactNode } from 'react';
 import { memo, useCallback, useMemo, useState } from 'react';
 
 import { useChartData } from '@onekeyfe/react-native-animated-charts';
-import { Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
-import { NumberSizeableText } from '@onekeyhq/components';
+import { NumberSizeableText, TABULAR_NUMS } from '@onekeyhq/components';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
 import type { LayoutChangeEvent } from 'react-native';
+
+const styles = StyleSheet.create({
+  label: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    fontVariant: TABULAR_NUMS,
+  },
+});
 
 function trim(val: number) {
   return Math.min(Math.max(val, 0.05), 0.95);
@@ -79,15 +87,7 @@ const CenteredLabel = ({
         position: 'absolute',
       }}
     >
-      <Text
-        style={{
-          color,
-          fontSize: 14,
-          fontWeight: 'bold',
-        }}
-      >
-        {children}
-      </Text>
+      <Text style={[styles.label, { color }]}>{children}</Text>
     </View>
   );
 };

--- a/packages/kit/src/views/Perp/components/OrderBook/DefaultLoadingNode.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/DefaultLoadingNode.tsx
@@ -32,22 +32,10 @@ function MobileVerticalEmptyRow({
       alignItems="center"
       justifyContent="space-between"
     >
-      <SizableText
-        fontSize={11}
-        lineHeight={14}
-        fontFamily="$monoRegular"
-        fontVariant={['tabular-nums']}
-        color={priceColor}
-      >
+      <SizableText fontSize={11} lineHeight={14} color={priceColor}>
         --
       </SizableText>
-      <SizableText
-        fontSize={11}
-        lineHeight={14}
-        fontFamily="$monoRegular"
-        fontVariant={['tabular-nums']}
-        color="$textSubdued"
-      >
+      <SizableText fontSize={11} lineHeight={14} color="$textSubdued">
         --
       </SizableText>
     </XStack>
@@ -58,42 +46,18 @@ function MobileHorizontalEmptyRow() {
   return (
     <XStack h={MOBILE_HORIZONTAL_ROW_HEIGHT} gap="$1" alignItems="center">
       <XStack flex={1} px="$1" justifyContent="space-between">
-        <SizableText
-          fontSize={12}
-          lineHeight={16}
-          fontFamily="$monoRegular"
-          fontVariant={['tabular-nums']}
-          color="$textSubdued"
-        >
+        <SizableText fontSize={12} lineHeight={16} color="$textSubdued">
           --
         </SizableText>
-        <SizableText
-          fontSize={12}
-          lineHeight={16}
-          fontFamily="$monoRegular"
-          fontVariant={['tabular-nums']}
-          color="$green11"
-        >
+        <SizableText fontSize={12} lineHeight={16} color="$green11">
           --
         </SizableText>
       </XStack>
       <XStack flex={1} px="$1" justifyContent="space-between">
-        <SizableText
-          fontSize={12}
-          lineHeight={16}
-          fontFamily="$monoRegular"
-          fontVariant={['tabular-nums']}
-          color="$red11"
-        >
+        <SizableText fontSize={12} lineHeight={16} color="$red11">
           --
         </SizableText>
-        <SizableText
-          fontSize={12}
-          lineHeight={16}
-          fontFamily="$monoRegular"
-          fontVariant={['tabular-nums']}
-          color="$textSubdued"
-        >
+        <SizableText fontSize={12} lineHeight={16} color="$textSubdued">
           --
         </SizableText>
       </XStack>
@@ -200,19 +164,11 @@ export function DefaultLoadingNode({
               fontSize={20}
               lineHeight={24}
               fontWeight="600"
-              fontFamily="$monoRegular"
-              fontVariant={['tabular-nums']}
               color="$text"
             >
               {midPriceDisplay}
             </SizableText>
-            <SizableText
-              fontSize={10}
-              lineHeight={14}
-              fontFamily="$monoRegular"
-              fontVariant={['tabular-nums']}
-              color="$textSubdued"
-            >
+            <SizableText fontSize={10} lineHeight={14} color="$textSubdued">
               --
             </SizableText>
           </YStack>

--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -19,6 +19,7 @@ import {
   Popover,
   Select,
   SizableText,
+  TABULAR_NUMS,
   YStack,
   useTheme,
   useThemeName,
@@ -256,13 +257,19 @@ const styles = StyleSheet.create({
     letterSpacing: 0.8,
     width: '100%',
   },
-  monospaceText: {
-    fontFamily: platformEnv.isNative ? 'GeistMono-Regular' : 'monospace',
+  tabularText: {
+    // Not a mono face: the app font (Roobert) ships tabular figures via the
+    // `tnum` OpenType feature, so digits stay column-aligned while letters keep
+    // their natural proportional widths. Native raw <Text> can't pick a weight
+    // from a custom family via fontWeight, so name the medium face explicitly.
+    fontFamily: platformEnv.isNative ? 'Roobert-Medium' : undefined,
+    fontVariant: TABULAR_NUMS,
     fontSize: 12,
     lineHeight: 16,
     fontWeight: '500',
   },
-  monospaceTextBold: {
+  tabularTextBold: {
+    fontFamily: platformEnv.isNative ? 'Roobert-SemiBold' : undefined,
     fontWeight: '600',
   },
   interactiveRow: {
@@ -424,11 +431,11 @@ const styles = StyleSheet.create({
     borderBottomRightRadius: 999,
   },
   sideRatioLabel: {
-    fontFamily: platformEnv.isNative ? 'GeistMono-Regular' : 'monospace',
+    fontFamily: platformEnv.isNative ? 'Roobert-Medium' : undefined,
     fontSize: 12,
     lineHeight: 16,
     fontWeight: '500',
-    fontVariant: ['tabular-nums'],
+    fontVariant: TABULAR_NUMS,
   },
   sideRatioLabelCompact: {
     fontSize: 11,
@@ -464,27 +471,27 @@ const OrderBookVerticalRow = memo(
     sizeColor: string;
     isHovered?: boolean;
   }) => {
-    const fontWeightStyle = isHovered ? styles.monospaceTextBold : null;
+    const fontWeightStyle = isHovered ? styles.tabularTextBold : null;
     return (
       <DebugRenderTracker name="OrderBookVerticalRow" position="right-center">
         <View style={styles.verticalRowContainer}>
           <View style={styles.verticalRowCellPrice}>
             <PerpBookText
               style={[
-                styles.monospaceText,
+                styles.tabularText,
                 { color: priceColor },
                 fontWeightStyle,
               ]}
               numberOfLines={1}
             >
-              {item.price}
+              {item.displayPrice}
             </PerpBookText>
           </View>
           <View style={styles.verticalRowCellSize}>
             <PerpBookText
               numberOfLines={1}
               style={[
-                styles.monospaceText,
+                styles.tabularText,
                 { color: sizeColor },
                 fontWeightStyle,
               ]}
@@ -496,7 +503,7 @@ const OrderBookVerticalRow = memo(
             <PerpBookText
               numberOfLines={1}
               style={[
-                styles.monospaceText,
+                styles.tabularText,
                 { color: sizeColor },
                 fontWeightStyle,
               ]}
@@ -1020,21 +1027,21 @@ export function OrderBook({
                             <View style={styles.interactiveRowContent}>
                               <PerpBookText
                                 style={[
-                                  styles.monospaceText,
+                                  styles.tabularText,
                                   { color: textColor.textSubdued },
-                                  isHovered ? styles.monospaceTextBold : null,
+                                  isHovered ? styles.tabularTextBold : null,
                                 ]}
                               >
                                 {item.displaySize}
                               </PerpBookText>
                               <PerpBookText
                                 style={[
-                                  styles.monospaceText,
+                                  styles.tabularText,
                                   { color: textColor.green },
-                                  isHovered ? styles.monospaceTextBold : null,
+                                  isHovered ? styles.tabularTextBold : null,
                                 ]}
                               >
-                                {item.price}
+                                {item.displayPrice}
                               </PerpBookText>
                             </View>
                           );
@@ -1061,18 +1068,18 @@ export function OrderBook({
                             <View style={styles.interactiveRowContent}>
                               <PerpBookText
                                 style={[
-                                  styles.monospaceText,
+                                  styles.tabularText,
                                   { color: textColor.red },
-                                  isHovered ? styles.monospaceTextBold : null,
+                                  isHovered ? styles.tabularTextBold : null,
                                 ]}
                               >
-                                {item.price}
+                                {item.displayPrice}
                               </PerpBookText>
                               <PerpBookText
                                 style={[
-                                  styles.monospaceText,
+                                  styles.tabularText,
                                   { color: textColor.textSubdued },
-                                  isHovered ? styles.monospaceTextBold : null,
+                                  isHovered ? styles.tabularTextBold : null,
                                 ]}
                               >
                                 {item.displaySize}
@@ -1302,7 +1309,7 @@ const OrderBookPairRow = memo(
     sizeColor: string;
     isHovered?: boolean;
   }) => {
-    const fontWeightStyle = isHovered ? styles.monospaceTextBold : null;
+    const fontWeightStyle = isHovered ? styles.tabularTextBold : null;
     return (
       <DebugRenderTracker name="OrderBookPairRow" position="right-center">
         <View
@@ -1315,20 +1322,12 @@ const OrderBookPairRow = memo(
           }}
         >
           <PerpBookText
-            style={[
-              styles.monospaceText,
-              { color: priceColor },
-              fontWeightStyle,
-            ]}
+            style={[styles.tabularText, { color: priceColor }, fontWeightStyle]}
           >
-            {item.price}
+            {item.displayPrice}
           </PerpBookText>
           <PerpBookText
-            style={[
-              styles.monospaceText,
-              { color: sizeColor },
-              fontWeightStyle,
-            ]}
+            style={[styles.tabularText, { color: sizeColor }, fontWeightStyle]}
           >
             {item.displaySize}
           </PerpBookText>
@@ -1619,7 +1618,7 @@ function MobileSpreadInfoContent({
         renderTrigger={
           <PerpBookText
             style={[
-              styles.monospaceText,
+              styles.tabularText,
               {
                 color: textColor.text,
                 fontSize: 20,
@@ -1651,7 +1650,7 @@ function MobileSpreadInfoContent({
           isSpot ? (
             <PerpBookText
               style={[
-                styles.monospaceText,
+                styles.tabularText,
                 {
                   color: textColor.textSubdued,
                   fontSize: 11,
@@ -1665,7 +1664,7 @@ function MobileSpreadInfoContent({
           ) : (
             <DashText
               style={[
-                styles.monospaceText,
+                styles.tabularText,
                 {
                   color: textColor.textSubdued,
                   fontSize: 10,

--- a/packages/kit/src/views/Perp/components/OrderBook/types.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/types.ts
@@ -17,6 +17,9 @@ export interface IOBLevel {
 }
 
 export interface IFormattedOBLevel extends IOBLevel {
+  /** Human readable representation of price for rendering (thousands-separated).
+   * `price` stays the raw numeric string for selection/order-form logic. */
+  displayPrice: string;
   /** Human readable representation of size for rendering */
   displaySize: string;
   /** Human readable representation of cumulative size for rendering */

--- a/packages/kit/src/views/Perp/components/OrderBook/useAggregatedBook.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/useAggregatedBook.tsx
@@ -2,7 +2,10 @@ import { useMemo } from 'react';
 
 import BigNumber from 'bignumber.js';
 
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  formatLocalizedNumberString,
+  numberFormat,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 import type { IBookLevel } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 import { type ITickParam } from './tickSizeUtils';
@@ -52,6 +55,7 @@ const withDisplayFields = (
 ): IFormattedOBLevel[] =>
   levels.map((level) => ({
     ...level,
+    displayPrice: formatLocalizedNumberString(level.price),
     displaySize: formatOrderBookValue(level.size, variant),
     displayCumSize: formatOrderBookValue(level.cumSize, variant),
   }));

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
@@ -13,7 +13,10 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatTime } from '@onekeyhq/shared/src/utils/dateUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  formatLocalizedNumberString,
+  numberFormat,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   getValidPriceDecimals,
   isSpotInstrument,
@@ -186,9 +189,9 @@ const OpenOrdersRow = memo(
       const executePriceFormatted = new BigNumber(executePrice).toFixed(
         decimals,
       );
-      const executePriceLimitFormatted = new BigNumber(
-        executePriceLimit,
-      ).toFixed(decimals);
+      const executePriceLimitFormatted = formatLocalizedNumberString(
+        new BigNumber(executePriceLimit).toFixed(decimals),
+      );
       const priceFormatted = new BigNumber(price).toFixed(decimals);
       const sizeFormatted = numberFormat(size, balanceFormatter);
       const value = priceBN.times(origSizeBN).toFixed();

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -24,7 +24,10 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  formatLocalizedNumberString,
+  numberFormat,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   getValidPriceDecimals,
   parseDexCoin,
@@ -100,7 +103,9 @@ function MarkPrice({ coin }: { coin: string }) {
     () => (
       <DebugRenderTracker position="bottom-right" name="MarkPrice" offsetY={10}>
         <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
-          {midFormattedByDecimals}
+          {midFormattedByDecimals
+            ? formatLocalizedNumberString(midFormattedByDecimals)
+            : midFormattedByDecimals}
         </SizableText>
       </DebugRenderTracker>
     ),
@@ -249,7 +254,9 @@ const PositionRowDesktopMarkPrice = memo(
           offsetY={10}
         >
           <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
-            {midFormattedByDecimals}
+            {midFormattedByDecimals
+              ? formatLocalizedNumberString(midFormattedByDecimals)
+              : midFormattedByDecimals}
           </SizableText>
         </DebugRenderTracker>
       </XStack>
@@ -507,7 +514,12 @@ const PositionRowDesktopTPSL = memo(
         showOrder = true;
       }
 
-      return { tpsl: `${tpPrice}/${slPrice}`, showOrder };
+      return {
+        tpsl: `${formatLocalizedNumberString(
+          tpPrice,
+        )}/${formatLocalizedNumberString(slPrice)}`,
+        showOrder,
+      };
     }, [currentAssetOpenOrders]);
 
     return (
@@ -1088,7 +1100,11 @@ const PositionRowMobileTPSL = memo(({ coin }: { coin: string }) => {
       }
     });
 
-    return { tpsl: `${tpPrice}/${slPrice}` };
+    return {
+      tpsl: `${formatLocalizedNumberString(
+        tpPrice,
+      )}/${formatLocalizedNumberString(slPrice)}`,
+    };
   }, [currentAssetOpenOrders]);
 
   return (
@@ -1121,7 +1137,7 @@ const PositionRowMobileMarkPrice = memo(({ coin }: { coin: string }) => {
         })}
       </SizableText>
       <SizableText size="$bodySmMedium" numberOfLines={1}>
-        {midFormattedByDecimals || '--'}
+        {formatLocalizedNumberString(midFormattedByDecimals || '--')}
       </SizableText>
     </YStack>
   );
@@ -1364,10 +1380,10 @@ const PositionRow = memo(
       const entryPrice = new BigNumber(pos.entryPx || '0').toFixed(decimals);
 
       const liquidationPrice = new BigNumber(pos.liquidationPx || '0');
-      const entryPriceFormatted = entryPrice;
-      const liquidationPriceFormatted = liquidationPrice.isZero()
-        ? 'N/A'
-        : liquidationPrice.toFixed(decimals);
+      const entryPriceFormatted = formatLocalizedNumberString(entryPrice);
+      const liquidationPriceFormatted = formatLocalizedNumberString(
+        liquidationPrice.isZero() ? 'N/A' : liquidationPrice.toFixed(decimals),
+      );
 
       return {
         entryPriceFormatted,

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -19,7 +19,10 @@ import { useSpotPairDisplayMapAtom } from '@onekeyhq/kit-bg/src/states/jotai/ato
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatTime } from '@onekeyhq/shared/src/utils/dateUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  formatLocalizedNumberString,
+  numberFormat,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   getSpotTokenDisplayName,
   getValidPriceDecimals,
@@ -136,7 +139,9 @@ const TradesHistoryRow = memo(
       const decimals = getValidPriceDecimals(price);
       const priceBN = new BigNumber(price);
       const sizeBN = new BigNumber(size);
-      const priceFormatted = priceBN.toFixed(decimals);
+      const priceFormatted = formatLocalizedNumberString(
+        priceBN.toFixed(decimals),
+      );
       const feeFormatted = numberFormat(fee, formatter);
 
       const tradeValue = priceBN.times(sizeBN).toFixed();

--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -221,104 +221,69 @@ function MobileHeader({
             <YStack gap="$3">
               <XStack justifyContent="space-between" alignItems="center">
                 <XStack gap="$1" alignItems="center">
-                  <SizableText
-                    size="$headingXs"
-                    fontFamily="$monoRegular"
-                    fontVariant={['tabular-nums']}
-                  >
+                  <SizableText size="$headingXs">
                     {intl.formatMessage({
                       id: ETranslations.perps_hourly,
                     })}
                   </SizableText>
-                  <SizableText
-                    size="$headingXs"
-                    fontFamily="$monoRegular"
-                    fontVariant={['tabular-nums']}
-                    color="$textSubdued"
-                  >
+                  <SizableText size="$headingXs" color="$textSubdued">
                     ({countdown})
                   </SizableText>
                 </XStack>
                 <SizableText
                   size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
                 >
                   {hourlyFundingRate}%
                 </SizableText>
               </XStack>
               <XStack justifyContent="space-between" alignItems="center">
-                <SizableText
-                  size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
-                >
+                <SizableText size="$headingXs">
                   {intl.formatMessage({
                     id: ETranslations.earn_daily,
                   })}
                 </SizableText>
                 <SizableText
                   size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
                 >
                   {dailyFundingRate}%
                 </SizableText>
               </XStack>
               <XStack justifyContent="space-between" alignItems="center">
-                <SizableText
-                  size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
-                >
+                <SizableText size="$headingXs">
                   {intl.formatMessage({
                     id: ETranslations.earn_weekly,
                   })}
                 </SizableText>
                 <SizableText
                   size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
                 >
                   {weeklyFundingRate}%
                 </SizableText>
               </XStack>
               <XStack justifyContent="space-between" alignItems="center">
-                <SizableText
-                  size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
-                >
+                <SizableText size="$headingXs">
                   {intl.formatMessage({
                     id: ETranslations.earn_monthly,
                   })}
                 </SizableText>
                 <SizableText
                   size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
                 >
                   {monthlyFundingRate}%
                 </SizableText>
               </XStack>
               <XStack justifyContent="space-between" alignItems="center">
-                <SizableText
-                  size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
-                >
+                <SizableText size="$headingXs">
                   {intl.formatMessage({
                     id: ETranslations.earn_annually,
                   })}
                 </SizableText>
                 <SizableText
                   size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
                 >
                   {annualizedFundingRate}%

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
@@ -53,11 +53,11 @@ import { useSpotMetaMaps } from '../../hooks/useSpotMetaMaps';
 import { PerpTokenSelector } from '../TokenSelector/PerpTokenSelector';
 import { FavoriteButton } from '../TokenSelector/PerpTokenSelectorRow';
 
+// Medium-weight (500) data values — the heading tokens' 600 reads too heavy
+// for a dense stat strip of tabular digits, while plain 400 gets lost against
+// the subdued labels at this size.
 const TICKER_BAR_STAT_VALUE_TEXT_PROPS = {
-  size: '$headingXs',
-  fontFamily: '$monoRegular',
-  textTransform: 'none',
-  letterSpacing: 0,
+  size: '$bodySmMedium',
 } as const;
 
 const TICKER_BAR_STAT_LABEL_VALUE_GAP = 5;
@@ -175,7 +175,7 @@ const TickerBarMarkPriceView = memo(
           <Tooltip
             placement="top"
             renderTrigger={
-              <SizableText size="$headingXl" cursor="help">
+              <SizableText size="$headingXl" fontWeight="500" cursor="help">
                 {formattedMarkPrice}
               </SizableText>
             }
@@ -199,9 +199,9 @@ function TickerBarMarkPrice() {
   const assetCtx = useTickerBarPerpAssetCtx();
   const [spotAssetCtx] = useSpotActiveAssetCtxAtom();
   const isSpot = tradingMode === 'spot';
-  const formattedMarkPrice = isSpot
-    ? formatLocalizedNumberString(spotAssetCtx?.ctx?.markPrice || '')
-    : assetCtx?.ctx?.markPrice || '';
+  const formattedMarkPrice = formatLocalizedNumberString(
+    (isSpot ? spotAssetCtx?.ctx?.markPrice : assetCtx?.ctx?.markPrice) || '',
+  );
   const isLoading = useTickerBarIsLoading();
   useEffect(() => {
     if (!isLoading && formattedMarkPrice) {
@@ -241,7 +241,7 @@ const TickerBarChange24hPercentView = memo(
     >
       <SkeletonContainer isLoading={isLoading} width={50} height={16}>
         <NumberSizeableText
-          size={gtMd ? '$headingXs' : '$bodySmMedium'}
+          size="$bodySmMedium"
           fontSize={gtMd ? undefined : 10}
           mt={gtMd ? undefined : '$-2'}
           color={change24hPercent >= 0 ? '$green11' : '$red11'}
@@ -314,10 +314,7 @@ const TickerBarOraclePriceView = memo(
             placement="top"
           />
           <SkeletonContainer isLoading={isLoading} width={80} height={16}>
-            <SizableText
-              {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-              fontVariant={['tabular-nums']}
-            >
+            <SizableText {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}>
               {formattedOraclePrice}
             </SizableText>
           </SkeletonContainer>
@@ -330,7 +327,9 @@ TickerBarOraclePriceView.displayName = 'TickerBarOraclePriceView';
 
 function TickerBarOraclePrice() {
   const assetCtx = useTickerBarPerpAssetCtx();
-  const formattedOraclePrice = assetCtx?.ctx?.oraclePrice || '';
+  const formattedOraclePrice = formatLocalizedNumberString(
+    assetCtx?.ctx?.oraclePrice || '',
+  );
   const isLoading = useTickerBarIsLoading();
 
   return (
@@ -359,10 +358,7 @@ const TickerBar24hVolumeView = memo(
             })}
           </SizableText>
           <SkeletonContainer isLoading={isLoading} width={80} height={16}>
-            <SizableText
-              {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-              fontVariant={['tabular-nums']}
-            >
+            <SizableText {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}>
               ${formattedVolume24h}
             </SizableText>
           </SkeletonContainer>
@@ -432,10 +428,7 @@ const TickerBarOpenInterestView = memo(
             placement="top"
           />
           <SkeletonContainer isLoading={isLoading} width={80} height={16}>
-            <SizableText
-              {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-              fontVariant={['tabular-nums']}
-            >
+            <SizableText {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}>
               ${formattedOpenInterest}
             </SizableText>
           </SkeletonContainer>
@@ -484,10 +477,7 @@ const TickerBarMarketCapView = memo(
             })}
           </SizableText>
           <SkeletonContainer isLoading={isLoading} width={80} height={16}>
-            <SizableText
-              {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-              fontVariant={['tabular-nums']}
-            >
+            <SizableText {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}>
               {formattedMarketCap === '--'
                 ? formattedMarketCap
                 : `$${formattedMarketCap}`}
@@ -543,6 +533,7 @@ const TickerBarSpotContractView = memo(
             <XStack gap="$1" alignItems="center">
               <SizableText
                 {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
+                fontFamily="$monoRegular"
                 color="$text"
                 numberOfLines={1}
               >
@@ -604,11 +595,7 @@ function TickerBarFundingRateCountdown() {
       position="bottom-right"
       offsetX={10}
     >
-      <SizableText
-        {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-        color="$text"
-        fontVariant={['tabular-nums']}
-      >
+      <SizableText {...TICKER_BAR_STAT_VALUE_TEXT_PROPS} color="$text">
         {countdown}
       </SizableText>
     </DebugRenderTracker>
@@ -654,7 +641,6 @@ const TickerBarFundingRateView = memo(
                   <XStack alignItems="center" gap="$2">
                     <DashText
                       {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-                      fontVariant={['tabular-nums']}
                       color={fundingRate >= 0 ? '$green11' : '$red11'}
                       dashThickness={0.5}
                       dashSpacing={0}
@@ -672,22 +658,12 @@ const TickerBarFundingRateView = memo(
                         justifyContent="space-between"
                         alignItems="center"
                       >
-                        <SizableText
-                          size="$headingXs"
-                          fontFamily="$monoRegular"
-                          fontVariant={['tabular-nums']}
-                          color="$textSubdued"
-                        >
+                        <SizableText size="$bodySm" color="$textSubdued">
                           {intl.formatMessage({
                             id: ETranslations.perps_fee_rate_projection,
                           })}
                         </SizableText>
-                        <SizableText
-                          size="$headingXs"
-                          fontFamily="$monoRegular"
-                          fontVariant={['tabular-nums']}
-                          color="$textSubdued"
-                        >
+                        <SizableText size="$bodySm" color="$textSubdued">
                           {intl.formatMessage({
                             id: ETranslations.perp_position_funding,
                           })}
@@ -699,28 +675,17 @@ const TickerBarFundingRateView = memo(
                           alignItems="center"
                         >
                           <XStack gap="$1" alignItems="center">
-                            <SizableText
-                              size="$headingXs"
-                              fontFamily="$monoRegular"
-                              fontVariant={['tabular-nums']}
-                            >
+                            <SizableText size="$bodySm">
                               {intl.formatMessage({
                                 id: ETranslations.perps_hourly,
                               })}
                             </SizableText>
-                            <SizableText
-                              size="$headingXs"
-                              fontFamily="$monoRegular"
-                              fontVariant={['tabular-nums']}
-                              color="$textSubdued"
-                            >
+                            <SizableText size="$bodySm" color="$textSubdued">
                               ({countdown})
                             </SizableText>
                           </XStack>
                           <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
+                            size="$bodySm"
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
                           >
                             {hourlyFundingRate}%
@@ -730,19 +695,13 @@ const TickerBarFundingRateView = memo(
                           justifyContent="space-between"
                           alignItems="center"
                         >
-                          <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
-                          >
+                          <SizableText size="$bodySm">
                             {intl.formatMessage({
                               id: ETranslations.earn_daily,
                             })}
                           </SizableText>
                           <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
+                            size="$bodySm"
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
                           >
                             {dailyFundingRate}%
@@ -752,19 +711,13 @@ const TickerBarFundingRateView = memo(
                           justifyContent="space-between"
                           alignItems="center"
                         >
-                          <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
-                          >
+                          <SizableText size="$bodySm">
                             {intl.formatMessage({
                               id: ETranslations.earn_weekly,
                             })}
                           </SizableText>
                           <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
+                            size="$bodySm"
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
                           >
                             {weeklyFundingRate}%
@@ -774,19 +727,13 @@ const TickerBarFundingRateView = memo(
                           justifyContent="space-between"
                           alignItems="center"
                         >
-                          <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
-                          >
+                          <SizableText size="$bodySm">
                             {intl.formatMessage({
                               id: ETranslations.earn_monthly,
                             })}
                           </SizableText>
                           <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
+                            size="$bodySm"
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
                           >
                             {monthlyFundingRate}%
@@ -796,19 +743,13 @@ const TickerBarFundingRateView = memo(
                           justifyContent="space-between"
                           alignItems="center"
                         >
-                          <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
-                          >
+                          <SizableText size="$bodySm">
                             {intl.formatMessage({
                               id: ETranslations.earn_annually,
                             })}
                           </SizableText>
                           <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
+                            size="$bodySm"
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
                           >
                             {annualizedFundingRate}%
@@ -818,11 +759,7 @@ const TickerBarFundingRateView = memo(
                     </YStack>
                     <Divider />
                     <YStack gap="$2" justifyContent="space-between">
-                      <SizableText
-                        size="$headingXs"
-                        fontVariant={['tabular-nums']}
-                        color="$textSubdued"
-                      >
+                      <SizableText size="$bodySm" color="$textSubdued">
                         {intl.formatMessage({
                           id: ETranslations.perp_trades_history_direction,
                         })}
@@ -863,7 +800,7 @@ const TickerBarFundingRateView = memo(
                     </YStack>
                     <Divider />
                     <YStack gap="$2">
-                      <SizableText size="$headingXs" color="$textSubdued">
+                      <SizableText size="$bodySm" color="$textSubdued">
                         {intl.formatMessage({
                           id: ETranslations.perp_funding_rate_tip0,
                         })}

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -1460,12 +1460,7 @@ const PerpTickerChangeLeaf = memo(
 
     if (!hasChange24hPercent) {
       return (
-        <SizableText
-          fontSize={10}
-          fontFamily="$monoRegular"
-          color="$textSubdued"
-          alignSelf="center"
-        >
+        <SizableText fontSize={10} color="$textSubdued" alignSelf="center">
           --
         </SizableText>
       );
@@ -1473,8 +1468,6 @@ const PerpTickerChangeLeaf = memo(
     return (
       <NumberSizeableText
         style={{ fontSize: 10 }}
-        fontFamily="$monoRegular"
-        fontVariant={['tabular-nums']}
         alignSelf="center"
         color={change24hPercent < 0 ? '$red11' : '$green11'}
         formatter="priceChange"

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -22,7 +22,10 @@ import {
   usePerpsCustomSettingsAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  formatLocalizedNumberString,
+  numberFormat,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   formatPriceToSignificantDigits,
   formatSpotPriceToValid,
@@ -65,7 +68,7 @@ function formatOrderPriceDisplay({
   const formattedPrice = isSpot
     ? formatSpotPriceToValid(price, szDecimals)
     : formatPriceToSignificantDigits(price, szDecimals);
-  return `$${formattedPrice}`;
+  return `$${formatLocalizedNumberString(formattedPrice)}`;
 }
 
 interface IOrderConfirmContentProps {

--- a/packages/kit/src/views/Swap/components/SwapProBuySellInfo.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProBuySellInfo.tsx
@@ -45,7 +45,6 @@ const SwapProBuySellInfo = ({
       <NumberSizeableText
         size="$bodySm"
         color="$textSuccess"
-        fontFamily="$monoRegular"
         formatter={isAboveThreshold ? 'marketCap' : 'value'}
         formatterOptions={{ currency: '$' }}
       >
@@ -69,7 +68,6 @@ const SwapProBuySellInfo = ({
       <NumberSizeableText
         size="$bodySm"
         color="$textCritical"
-        fontFamily="$monoRegular"
         formatter={isAboveThreshold ? 'marketCap' : 'value'}
         formatterOptions={{ currency: '$' }}
       >
@@ -145,12 +143,7 @@ const SwapProBuySellInfo = ({
               B
             </SizableText>
           </Stack>
-          <SizableText
-            size="$bodyXs"
-            color="$textSuccess"
-            ml="$0.5"
-            fontFamily="$monoRegular"
-          >
+          <SizableText size="$bodyXs" color="$textSuccess" ml="$0.5">
             {!supportSpeedSwap ? '--' : buyPercentage.toFixed(2)}%
           </SizableText>
         </XStack>
@@ -161,12 +154,7 @@ const SwapProBuySellInfo = ({
           position="relative"
           zIndex={1}
         >
-          <SizableText
-            size="$bodyXs"
-            color="$textCritical"
-            mr="$0.5"
-            fontFamily="$monoRegular"
-          >
+          <SizableText size="$bodyXs" color="$textCritical" mr="$0.5">
             {!supportSpeedSwap ? '--' : sellPercentage.toFixed(2)}%
           </SizableText>
           <Stack

--- a/packages/kit/src/views/Swap/components/SwapProTokenTransactionItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProTokenTransactionItem.tsx
@@ -32,11 +32,7 @@ const SwapProTokenTransactionItem = ({
     const textColorValue =
       item.type === 'buy' ? '$textSuccess' : '$textCritical';
     let formatPriceValue = (
-      <SizableText
-        size="$bodySm"
-        color={textColorValue}
-        fontFamily="$monoRegular"
-      >
+      <SizableText size="$bodySm" color={textColorValue}>
         {FALLBACK_DISPLAY};
       </SizableText>
     );
@@ -46,7 +42,6 @@ const SwapProTokenTransactionItem = ({
         <NumberSizeableText
           size="$bodySm"
           color={textColorValue}
-          fontFamily="$monoRegular"
           formatter={isAboveThreshold ? 'marketCap' : 'price'}
           formatterOptions={{
             currency: '$',
@@ -58,11 +53,7 @@ const SwapProTokenTransactionItem = ({
     }
 
     let formatTokenValueValue = (
-      <SizableText
-        size="$bodySm"
-        color={textColorValue}
-        fontFamily="$monoRegular"
-      >
+      <SizableText size="$bodySm" color={textColorValue}>
         {FALLBACK_DISPLAY};
       </SizableText>
     );
@@ -75,7 +66,6 @@ const SwapProTokenTransactionItem = ({
         <NumberSizeableText
           size="$bodySm"
           color={textColorValue}
-          fontFamily="$monoRegular"
           formatter={isAboveThreshold ? 'marketCap' : 'value'}
           formatterOptions={{
             currency: '$',

--- a/packages/kit/src/views/Swap/pages/components/SwapProPriceInfo.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProPriceInfo.tsx
@@ -83,7 +83,7 @@ const SwapProPriceInfo = ({ onPricePress }: ISwapProPriceInfoProps) => {
       <NumberSizeableText
         size="$headingLg"
         color={textColor}
-        fontFamily="$monoMedium"
+        fontWeight="500"
         formatter="price"
         formatterOptions={{
           currency: '$',
@@ -101,11 +101,7 @@ const SwapProPriceInfo = ({ onPricePress }: ISwapProPriceInfoProps) => {
           {tokenMarketDetailInfo.priceConverted}
         </NumberSizeableText>
       ) : null}
-      <SizableText
-        size="$bodySmMedium"
-        color={textColor}
-        fontFamily="$monoMedium"
-      >
+      <SizableText size="$bodySmMedium" color={textColor}>
         {formattedPriceChange}
       </SizableText>
     </YStack>

--- a/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
@@ -951,7 +951,6 @@ function SwapKLineTokenPriceInfo({
       {price ? (
         <NumberSizeableText
           size={compact ? '$bodyMdMedium' : '$bodyLgMedium'}
-          fontFamily="$monoMedium"
           formatter="price"
           formatterOptions={{ currency: '$' }}
           numberOfLines={1}
@@ -963,7 +962,6 @@ function SwapKLineTokenPriceInfo({
         <SizableText
           size={compact ? '$bodyMdMedium' : '$bodyLgMedium'}
           color="$textSubdued"
-          fontFamily="$monoMedium"
           numberOfLines={1}
         >
           --
@@ -972,7 +970,6 @@ function SwapKLineTokenPriceInfo({
       {priceChange ? (
         <PriceChangePercentage
           size={compact ? '$bodyXsMedium' : '$bodySmMedium'}
-          fontFamily="$monoMedium"
           numberOfLines={1}
         >
           {priceChange}
@@ -981,7 +978,6 @@ function SwapKLineTokenPriceInfo({
         <SizableText
           size="$bodySmMedium"
           color="$textSubdued"
-          fontFamily="$monoMedium"
           numberOfLines={1}
         >
           --


### PR DESCRIPTION
## Summary

Make **tabular (equal-width) figures the app-wide default** for all UI text, and give quoted prices locale-aware thousands separators. This is the standard treatment for trading interfaces — where a common approach is a brand font whose digits are tabular by default, so numbers never reflow as they tick and columns always align. We reach the same result with the OpenType `tnum` feature that our font (Roobert) already carries, applied globally rather than font-frozen (Roobert is a licensed font).

**Hot-update scope**: JS-only — no native code, no dependency, no font-file changes. Branched from `release/v6.4.0` per the bundle release flow.

## How it works (two mechanisms, one per platform)

- **Native**: `SizableText` (the wrapper every text primitive routes through) defaults `fontVariant` to `TABULAR_NUMS`, translated into a real RN `style.fontVariant` (Tamagui silently drops the raw prop). Reference-stable, allocation-free on the hot path.
- **Web**: a single injected `body { font-variant-numeric: tabular-nums }` rule; CSS inheritance covers every text node — including ones that bypass the wrapper (raw `<Text>`, `Badge.Text`, portals). The wrapper therefore emits **no** inline style for the default on web, avoiding a redundant attribute on every node.

Both are opt-out: `fontVariant={PROPORTIONAL_NUMS}` restores proportional figures for a specific text.

Text that bypasses the wrapper on **native** (raw RN `<Text>` in the order book / chart labels, and `Badge.Text` for ticking countdowns) applies the feature explicitly via `getFontVariantStyle(TABULAR_NUMS)` / a `StyleSheet` entry.

## Also in this change

- **Localized thousands separators** on quoted prices (order book, ticker/oracle price, TP-SL, order confirm, positions/orders/history rows) via the existing locale-aware `formatLocalizedNumberString` — European `78.056,1` and Indian grouping work out of the box. Formatting happens at the producing memo, not in JSX.
- **Perps ticker bar (desktop)**: stat values `$headingXs` (600, uppercase label token) → `$bodySmMedium` (500); headline mark price 600 → 500 — the heading weights read too heavy for a dense tabular stat strip.
- The ~150 per-site `fontVariant={TABULAR_NUMS}` props from the earlier draft are **removed** — the global default makes them redundant. Net deletion.

## Verification
- `tsgo --noEmit`: 0 errors; `oxlint --type-aware --deny-warnings`: clean; `numberUtils.locale.test.ts`: 72/72.
- Live web probes on the running app: computed `font-variant-numeric: tabular-nums` confirmed via inheritance across Market home (1208 numeric nodes, 0 non-tabular), /defi (Earn+Borrow), perps ticker/order book; separators rendered.

## Follow-ups (not in this PR)
- Optional: base `Badge.Text` on the wrapped `SizableText` so all badge digits go tabular on native in one place (currently only the ticking-countdown badges are patched).
