### PR TITLE
fix: show selected browser tab on iPad split view(OK-57268)

### DIFF
--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -329,6 +329,7 @@ function MobileBrowser() {
     const listener = async (event: {
       tab: ETranslations;
       openUrl?: boolean;
+      showWebPage?: boolean;
       switchType?: IExploreTabSwitchType;
     }) => {
       exploreTabSwitchTypeRef.current = event.switchType ?? 'default';
@@ -339,6 +340,9 @@ function MobileBrowser() {
       // If the target is Browser itself, do NOT collapse the WebView.
       if (!displayHomePage && event.tab !== ETranslations.global_browser) {
         setDisplayHomePage(true);
+      }
+      if (event.tab === ETranslations.global_browser && event.showWebPage) {
+        setDisplayHomePage(false);
       }
 
       await backgroundApiProxy.serviceSetting.setSelectedBrowserTab(event.tab);

--- a/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
@@ -12,23 +12,33 @@ import {
   Stack,
   Toast,
   XStack,
+  switchTabAsync,
   useClipboard,
+  useIsSplitView,
   useSafeAreaInsets,
 } from '@onekeyhq/components';
 import type { IActionListItemProps } from '@onekeyhq/components';
 import type { IPageNavigationProp } from '@onekeyhq/components/src/layouts/Navigation';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useShouldUseSplitView } from '@onekeyhq/kit/src/hooks/useShouldUseSplitView';
 import {
   useBrowserBookmarkAction,
   useBrowserTabActions,
 } from '@onekeyhq/kit/src/states/jotai/contexts/discovery';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IDiscoveryModalParamList } from '@onekeyhq/shared/src/routes';
 import {
   EDiscoveryModalRoutes,
   EModalRoutes,
+  ETabRoutes,
 } from '@onekeyhq/shared/src/routes';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 import MobileTabListItem from '../../components/MobileTabListItem';
 import MobileTabListPinnedItem from '../../components/MobileTabListItem/MobileTabListPinnedItem';
@@ -130,6 +140,21 @@ function MobileTabListModal() {
     setPinnedTab,
     setDisplayHomePage,
   } = useBrowserTabActions().current;
+  const shouldUseSplitView = useShouldUseSplitView();
+  const isLandscape = useIsSplitView();
+  const shouldRevealTabletBrowser =
+    platformEnv.isNativeIOSPad && shouldUseSplitView && isLandscape;
+
+  const revealTabletBrowser = useCallback(async () => {
+    await timerUtils.wait(100);
+    await switchTabAsync(ETabRoutes.Discovery);
+    appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
+      tab: ETranslations.global_browser,
+      openUrl: true,
+      shouldConsumePendingUrl: false,
+      showWebPage: true,
+    });
+  }, []);
 
   const initialScrollIndex = useMemo(() => {
     const index = data.findIndex((t) => t.id === activeTabId);
@@ -361,7 +386,11 @@ function MobileTabListModal() {
         activeTabId={activeTabId}
         onSelectedItem={(id) => {
           void setCurrentWebTab(id);
+          setDisplayHomePage(false);
           navigation.pop();
+          if (shouldRevealTabletBrowser) {
+            void revealTabletBrowser();
+          }
         }}
         onCloseItem={handleCloseTab}
         onLongPress={(id) => {
@@ -369,7 +398,16 @@ function MobileTabListModal() {
         }}
       />
     ),
-    [activeTabId, handleCloseTab, navigation, setCurrentWebTab, showTabOptions],
+    [
+      activeTabId,
+      handleCloseTab,
+      navigation,
+      revealTabletBrowser,
+      setDisplayHomePage,
+      setCurrentWebTab,
+      shouldRevealTabletBrowser,
+      showTabOptions,
+    ],
   );
 
   const renderPinnedItem = useCallback(
@@ -379,7 +417,11 @@ function MobileTabListModal() {
         activeTabId={activeTabId}
         onSelectedItem={(id) => {
           setCurrentWebTab(id);
+          setDisplayHomePage(false);
           navigation.pop();
+          if (shouldRevealTabletBrowser) {
+            void revealTabletBrowser();
+          }
         }}
         onCloseItem={handleCloseTab}
         onLongPress={(id) => {
@@ -387,7 +429,16 @@ function MobileTabListModal() {
         }}
       />
     ),
-    [navigation, setCurrentWebTab, activeTabId, handleCloseTab, showTabOptions],
+    [
+      navigation,
+      revealTabletBrowser,
+      setDisplayHomePage,
+      setCurrentWebTab,
+      activeTabId,
+      handleCloseTab,
+      shouldRevealTabletBrowser,
+      showTabOptions,
+    ],
   );
 
   const renderPinnedList = useMemo(() => {

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -583,6 +583,7 @@ export interface IAppEventBusPayload {
       | ETranslations.global_earn;
     openUrl?: boolean;
     shouldConsumePendingUrl?: boolean;
+    showWebPage?: boolean;
     switchType?: 'default' | 'tap' | 'swipe';
   };
   [EAppEventBusNames.SwitchEarnMode]: {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57268](https://onekeyhq.atlassian.net/browse/OK-57268)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Reveal the actual browser WebView when selecting a tab from the mobile tab list on iPad split-view landscape.
- Keep normal single-pane and portrait behavior unchanged while sharing the selected-tab path.
- Extend the native discovery tab switch event with an explicit WebView reveal flag.

## Intent & Context
The reported issue was that on iPad, in landscape split-view mode, selecting/opening a browser tab could leave the detail pane on the placeholder/browser home state. Rotating to portrait and back could recover the WebView. The requested verification covered split and non-split layouts in both landscape and portrait.

## Root Cause
In iPad split-view landscape, selecting a web tab inside the tab-list modal updated the active web tab in the detail pane, but the Discovery tab/root state could remain on the browser home/display state. The existing native discovery switch event could select the Browser tab, but it had no way to explicitly reveal the WebView for an already-selected browser tab.

## Design Decisions
- The fix is scoped to native iPad split-view landscape by checking iPad, split sub-view, and landscape state before emitting the extra reveal event.
- The normal tab selection path now sets displayHomePage to false, which also matches the user intent in portrait and non-split layouts.
- A new optional showWebPage event payload flag keeps the existing SwitchDiscoveryTabInNative behavior compatible for all other callers.

## Changes Detail
- packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx: after selecting a regular or pinned tab, hide the browser homepage and, only for iPad split-view landscape detail panes, switch to Discovery and emit the native browser reveal event.
- packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx: consume showWebPage on the native discovery tab switch event and force the WebView state for the Browser tab.
- packages/shared/src/eventBus/appEventBus.ts: add the optional showWebPage flag to the SwitchDiscoveryTabInNative payload type.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile iOS iPad primarily; native Discovery browser path.
- **Risk Areas**: Browser tab selection and split-view navigation timing. The reveal event is gated to iPad split-view landscape, and the showWebPage flag is optional to avoid changing unrelated event callers.

## Test plan
- [x] yarn agent:check --profile commit
- [x] iPad simulator split landscape: Browser home -> TabList -> select Uniswap tab -> app.uniswap.org WebView rendered in detail pane.
- [x] iPad simulator split portrait: Browser home -> TabList -> select Uniswap tab -> app.uniswap.org WebView rendered.
- [x] iPad simulator non-split landscape: Browser home -> TabList -> select Uniswap tab -> app.uniswap.org WebView rendered in single-pane layout.
- [x] iPad simulator non-split portrait: Browser home -> TabList -> select Uniswap tab -> app.uniswap.org WebView rendered.

[OK-57268]: https://onekeyhq.atlassian.net/browse/OK-57268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ