### PR TITLE
fix: remove borrow tab new badge

### DIFF
--- a/packages/kit/src/views/Earn/components/MarketSelector.tsx
+++ b/packages/kit/src/views/Earn/components/MarketSelector.tsx
@@ -12,7 +12,6 @@ import {
   SegmentControl,
   SizableText,
   Stack,
-  XStack,
   YStack,
   fs,
   useMedia,
@@ -258,15 +257,13 @@ const MarketSelectorMobile = ({
           pb="$2"
           position="relative"
         >
-          <XStack alignItems="center" justifyContent="center" gap="$2">
-            <SizableText
-              size="$headingMd"
-              textAlign="center"
-              color={isActive ? '$text' : '$textSubdued'}
-            >
-              {intl.formatMessage({ id: messageId })}
-            </SizableText>
-          </XStack>
+          <SizableText
+            size="$headingMd"
+            textAlign="center"
+            color={isActive ? '$text' : '$textSubdued'}
+          >
+            {intl.formatMessage({ id: messageId })}
+          </SizableText>
           {isActive ? (
             <YStack
               position="absolute"

--- a/packages/kit/src/views/Earn/components/MarketSelector.tsx
+++ b/packages/kit/src/views/Earn/components/MarketSelector.tsx
@@ -9,7 +9,6 @@ import Animated, {
 } from 'react-native-reanimated';
 
 import {
-  Badge,
   SegmentControl,
   SizableText,
   Stack,
@@ -20,7 +19,6 @@ import {
   useTheme,
 } from '@onekeyhq/components';
 import type { ISegmentControlProps } from '@onekeyhq/components';
-import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { EarnTestIDs } from '../testIDs';
@@ -29,15 +27,6 @@ import type { LayoutChangeEvent } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
 
 export type IEarnHomeMode = 'earn' | 'borrow';
-
-const getBadgeTheme = ({
-  themeVariant,
-  isActive,
-}: {
-  themeVariant: 'light' | 'dark';
-  isActive: boolean;
-  // eslint-disable-next-line no-nested-ternary
-}) => (isActive ? (themeVariant === 'light' ? 'dark' : 'light') : themeVariant);
 
 const MarketSelectorDesktop = ({
   mode,
@@ -51,16 +40,11 @@ const MarketSelectorDesktop = ({
   activeBackgroundColor?: ISegmentControlProps['activeBackgroundColor'];
 }) => {
   const intl = useIntl();
-  const themeVariant = useThemeVariant();
 
   const options = useMemo(() => {
-    const renderLabel = (
-      value: IEarnHomeMode,
-      messageId: ETranslations,
-      withBadge = false,
-    ) => {
+    const renderLabel = (value: IEarnHomeMode, messageId: ETranslations) => {
       const isActive = mode === value;
-      const labelText = (
+      return (
         <SizableText
           size="$bodyMdMedium"
           textAlign="center"
@@ -69,25 +53,6 @@ const MarketSelectorDesktop = ({
           {intl.formatMessage({ id: messageId })}
         </SizableText>
       );
-      if (!withBadge) {
-        return labelText;
-      }
-      const badgeTheme = getBadgeTheme({ themeVariant, isActive });
-      return (
-        <XStack alignItems="center" justifyContent="center" gap="$2">
-          {labelText}
-          <Badge
-            badgeSize="sm"
-            badgeType="success"
-            pointerEvents="none"
-            theme={badgeTheme}
-          >
-            <Badge.Text>
-              {intl.formatMessage({ id: ETranslations.explore_badge_new })}
-            </Badge.Text>
-          </Badge>
-        </XStack>
-      );
     };
     return [
       {
@@ -95,11 +60,11 @@ const MarketSelectorDesktop = ({
         value: 'earn' as const,
       },
       {
-        label: renderLabel('borrow', ETranslations.global_borrow, true),
+        label: renderLabel('borrow', ETranslations.global_borrow),
         value: 'borrow' as const,
       },
     ];
-  }, [intl, mode, themeVariant]);
+  }, [intl, mode]);
 
   const itemStyleProps = useMemo(() => {
     const baseProps = {
@@ -258,11 +223,6 @@ const AnimatedTabBar = ({
         <Animated.Text style={[animatedStyles.tabText, borrowTextStyle]}>
           {intl.formatMessage({ id: ETranslations.global_borrow })}
         </Animated.Text>
-        <Badge badgeSize="sm" badgeType="success" pointerEvents="none">
-          <Badge.Text>
-            {intl.formatMessage({ id: ETranslations.explore_badge_new })}
-          </Badge.Text>
-        </Badge>
       </Pressable>
       {containerWidth > 0 ? (
         <AnimatedUnderline
@@ -287,11 +247,7 @@ const MarketSelectorMobile = ({
   const intl = useIntl();
 
   const options = useMemo(() => {
-    const renderLabel = (
-      value: IEarnHomeMode,
-      messageId: ETranslations,
-      withBadge = false,
-    ) => {
+    const renderLabel = (value: IEarnHomeMode, messageId: ETranslations) => {
       const isActive = mode === value;
       return (
         <YStack
@@ -310,13 +266,6 @@ const MarketSelectorMobile = ({
             >
               {intl.formatMessage({ id: messageId })}
             </SizableText>
-            {withBadge ? (
-              <Badge badgeSize="sm" badgeType="success" pointerEvents="none">
-                <Badge.Text>
-                  {intl.formatMessage({ id: ETranslations.explore_badge_new })}
-                </Badge.Text>
-              </Badge>
-            ) : null}
           </XStack>
           {isActive ? (
             <YStack
@@ -338,7 +287,7 @@ const MarketSelectorMobile = ({
         value: 'earn' as const,
       },
       {
-        label: renderLabel('borrow', ETranslations.global_borrow, true),
+        label: renderLabel('borrow', ETranslations.global_borrow),
         value: 'borrow' as const,
       },
     ];


### PR DESCRIPTION
## Summary
- Removed the `New` badge from the DeFi Borrow tab.
- Cleaned up now-unused badge rendering helpers and imports in the Earn/Borrow market selector.

## Intent & Context
The Borrow tab in the DeFi/Earn home selector still showed a `New` badge next to the tab label. The requested behavior is to remove that badge while leaving the Borrow tab itself and its mode switching unchanged.

## Root Cause
`MarketSelector` rendered the `explore_badge_new` badge in all Borrow tab label paths: desktop segmented control, mobile fallback segmented control, and the animated mobile tab bar.

## Design Decisions
Removed the badge rendering directly from `MarketSelector` instead of hiding it with styles, so there is no unused UI work or invisible translated text. The change stays local to the Earn/Borrow home selector and does not touch Borrow data, routing, transactions, or portfolio state.

## Changes Detail
- `packages/kit/src/views/Earn/components/MarketSelector.tsx`: removed Borrow tab badge JSX from desktop, mobile fallback, and animated mobile tab render paths; removed unused badge/theme helper code.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web
- **Risk Areas**: Visual regression around the Earn/Borrow tab selector only.

## Test plan
- [x] `yarn agent:check --profile commit`
- [x] `npx eslint packages/kit/src/views/Earn/components/MarketSelector.tsx --ext .ts,.tsx`
- [x] Confirmed `MarketSelector.tsx` no longer references `explore_badge_new`, `Badge`, `useThemeVariant`, `getBadgeTheme`, or `withBadge`.