### PR TITLE
feat: default tabular numerals app-wide + localized thousands separators

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -1556,3 +1556,6 @@ mysten
 # web service worker / workbox (rspack migration) comments + cache names
 precaches
 navigations
+
+# OpenType tabular-figures feature tag
+tnum

--- a/packages/components/src/content/Badge/index.tsx
+++ b/packages/components/src/content/Badge/index.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { SizableText } from '@tamagui/text';
 
 import {
@@ -5,9 +7,11 @@ import {
   styled,
   withStaticProperties,
 } from '@onekeyhq/components/src/shared/tamagui';
+import type { GetProps } from '@onekeyhq/components/src/shared/tamagui';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { XStack } from '../../primitives/Stack';
+import { TABULAR_NUMS, getFontVariantStyle } from '../../utils/tabularNums';
 
 import type { IXStackProps } from '../../primitives';
 
@@ -60,7 +64,7 @@ const BadgeFrame = styled(XStack, {
   } as const,
 });
 
-const BadgeText = styled(SizableText, {
+const BadgeTextStyled = styled(SizableText, {
   name: 'BadgeText',
   allowFontScaling: false,
   numberOfLines: 1,
@@ -93,6 +97,22 @@ const BadgeText = styled(SizableText, {
     },
   } as const,
 });
+
+// Badge.Text is styled from raw tamagui text, so it bypasses the SizableText
+// wrapper's app-wide tabular default. Re-apply it here (computed once) so badge
+// digits (countdowns, rates, counts) stay equal-width on native. On web the
+// web-fonts.css body rule already covers it, so getFontVariantStyle returns
+// undefined and this is a passthrough.
+const BADGE_TABULAR_STYLE = getFontVariantStyle(TABULAR_NUMS);
+
+function BadgeText({ style, ...props }: GetProps<typeof BadgeTextStyled>) {
+  // Merge (not overwrite) so a caller-provided `style` still wins.
+  const mergedStyle = useMemo(
+    () => (BADGE_TABULAR_STYLE ? [BADGE_TABULAR_STYLE, style] : style),
+    [style],
+  );
+  return <BadgeTextStyled {...props} style={mergedStyle} />;
+}
 
 export type IBadgeProps = IXStackProps & {
   badgeType?: IBadgeType;

--- a/packages/components/src/content/NumberSizeableText/index.tsx
+++ b/packages/components/src/content/NumberSizeableText/index.tsx
@@ -145,9 +145,14 @@ export function NumberSizeableText({
       {/* eslint-disable no-nested-ternary */}
       {result.map((r, index) =>
         typeof r === 'string' ? (
+          // These slices build fresh SizableTexts (not spreading `props`), so
+          // they'd otherwise fall back to the app-wide tabular default and
+          // ignore a caller override (e.g. PROPORTIONAL_NUMS on a hero
+          // balance) — forward `fontVariant` explicitly to every slice.
           <SizableText
             key={index}
             color={props.color}
+            fontVariant={props.fontVariant}
             fontWeight={parentFontWeight}
             fontSize={parentFontSize}
             lineHeight={props.lineHeight ?? parentFontSize}
@@ -162,6 +167,7 @@ export function NumberSizeableText({
           <SizableText
             key={index}
             color={props.color}
+            fontVariant={props.fontVariant}
             fontWeight={parentFontWeight}
             fontSize={scriptFontSize}
             lineHeight={parentFontSize}

--- a/packages/components/src/hocs/Provider/web-fonts.css
+++ b/packages/components/src/hocs/Provider/web-fonts.css
@@ -45,3 +45,9 @@
   font-style: normal;
   font-display: swap;
 }
+
+/* App-wide tabular (equal-width) figures — see utils/tabularNums.ts. Inherited
+   by every text node, covering text that bypasses the SizableText wrapper. */
+body {
+  font-variant-numeric: tabular-nums;
+}

--- a/packages/components/src/primitives/SizeableText/index.tsx
+++ b/packages/components/src/primitives/SizeableText/index.tsx
@@ -2,14 +2,39 @@ import { SizableText as TamaguiSizableText } from '@tamagui/text';
 
 import { type SizableTextProps } from '@onekeyhq/components/src/shared/tamagui';
 
+import { TABULAR_NUMS, getFontVariantStyle } from '../../utils/tabularNums';
+
 export const StyledSizableText = TamaguiSizableText;
 
-export function SizableText({ size = '$bodyMd', ...props }: SizableTextProps) {
+export function SizableText({
+  size = '$bodyMd',
+  // App-wide default: tabular (equal-width) figures on ALL text, matching the
+  // reference exchanges whose brand fonts ship tabular digits by default.
+  // Only digit glyph widths change — letters are unaffected — so prose is
+  // safe. Opt out per text with `fontVariant={PROPORTIONAL_NUMS}`.
+  fontVariant = TABULAR_NUMS,
+  style,
+  ...props
+}: SizableTextProps) {
+  // Tamagui silently drops the RN `fontVariant` prop, so numeric variants
+  // (tabular-nums etc.) never reach the renderer — re-route it through the
+  // `style` prop: RN style `fontVariant` on native, CSS `font-variant-numeric`
+  // on web. Caller-provided `style` still wins on conflicts.
+  let mergedStyle = style;
+  const variantStyle = getFontVariantStyle(fontVariant);
+  if (variantStyle) {
+    if (Array.isArray(style)) {
+      mergedStyle = [variantStyle, ...style];
+    } else {
+      mergedStyle = style ? [variantStyle, style] : variantStyle;
+    }
+  }
   return (
     <StyledSizableText
       allowFontScaling={false}
       maxFontSizeMultiplier={1}
       size={size}
+      style={mergedStyle}
       {...props}
     />
   );

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -2,4 +2,5 @@ export * from './DebugRenderTracker';
 export * from './getFontSize';
 export * from './scale';
 export * from './sidebar';
+export * from './tabularNums';
 export * from './webFontFamily';

--- a/packages/components/src/utils/tabularNums.ts
+++ b/packages/components/src/utils/tabularNums.ts
@@ -1,0 +1,92 @@
+import type { CSSProperties } from 'react';
+
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import type { TextStyle } from 'react-native';
+
+/**
+ * Tabular (equal-width) figures for numeric text.
+ *
+ * `SizableText` applies this by DEFAULT app-wide, and web mirrors it with an
+ * injected `body { font-variant-numeric: tabular-nums }` rule, so most text
+ * needs nothing. Reach for the constant directly only for text that bypasses
+ * the `SizableText` wrapper — raw React Native `<Text>` / `StyleSheet.create`,
+ * or `Badge.Text` — via `getFontVariantStyle(TABULAR_NUMS)`.
+ *
+ * Every digit shares one advance width, so number columns stay aligned and a
+ * value doesn't reflow as it ticks. Unlike a monospace family (`$monoRegular`),
+ * only digits are equalized — letters keep Roobert's natural proportional
+ * widths. Roobert ships the `tnum` OpenType feature, so this works on iOS,
+ * Android and web.
+ *
+ * Monospace is still the right choice for addresses / hashes / mnemonics /
+ * codes, where character (not just digit) alignment matters — do NOT replace
+ * those with tabular-nums.
+ */
+export const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
+
+/**
+ * Escape hatch from the app-wide tabular default (`SizableText` defaults
+ * `fontVariant` to TABULAR_NUMS): pass `fontVariant={PROPORTIONAL_NUMS}` to
+ * restore the font's natural proportional figures for a specific text.
+ */
+export const PROPORTIONAL_NUMS: ['proportional-nums'] = ['proportional-nums'];
+
+type IFontVariantStyle = CSSProperties | TextStyle;
+
+function buildFontVariantStyle(
+  fontVariant: NonNullable<TextStyle['fontVariant']>,
+): IFontVariantStyle {
+  if (platformEnv.isNative) {
+    return Object.freeze({ fontVariant });
+  }
+  const style: CSSProperties = {};
+  const numericVariants = fontVariant.filter((v) => v.endsWith('-nums'));
+  if (numericVariants.length > 0) {
+    style.fontVariantNumeric = numericVariants.join(' ');
+  }
+  if (fontVariant.includes('small-caps')) {
+    style.fontVariantCaps = 'small-caps';
+  }
+  return Object.freeze(style);
+}
+
+// Web applies tabular figures globally via the `body` rule in web-fonts.css,
+// so the DEFAULT variant needs no inline style — leaving it undefined avoids a
+// redundant style attr on every text node and keeps `style` reference-stable.
+// Native has no CSS inheritance, so it must carry the variant inline.
+const TABULAR_NUMS_STYLE: IFontVariantStyle | undefined = platformEnv.isNative
+  ? buildFontVariantStyle(TABULAR_NUMS)
+  : undefined;
+
+const fontVariantStyleCache = new WeakMap<
+  NonNullable<TextStyle['fontVariant']>,
+  IFontVariantStyle
+>();
+
+/**
+ * Translate the RN `fontVariant` array into a platform-appropriate style
+ * object (RN style `fontVariant` on native, CSS `font-variant-numeric` /
+ * `font-variant-caps` on web), since Tamagui silently drops the raw
+ * `fontVariant` prop.
+ *
+ * Results are cached per array reference (with a hoisted fast path for
+ * `TABULAR_NUMS`), so the returned object is reference-stable across renders.
+ */
+export function getFontVariantStyle(
+  // Tamagui widens the prop with an extra 'unset' string literal.
+  fontVariant: TextStyle['fontVariant'] | 'unset',
+): IFontVariantStyle | undefined {
+  if (fontVariant === TABULAR_NUMS) {
+    return TABULAR_NUMS_STYLE;
+  }
+  if (!Array.isArray(fontVariant) || fontVariant.length === 0) {
+    return undefined;
+  }
+  let cached = fontVariantStyleCache.get(fontVariant);
+  if (!cached) {
+    cached = buildFontVariantStyle(fontVariant);
+    fontVariantStyleCache.set(fontVariant, cached);
+  }
+  return cached;
+}

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
@@ -9,6 +9,7 @@ import {
   DebugRenderTracker,
   Divider,
   Icon,
+  PROPORTIONAL_NUMS,
   SizableText,
   Skeleton,
   Stack,
@@ -542,6 +543,10 @@ function TokenDetailsHeaderContent({
                   fontSize={48}
                   lineHeight={48}
                   fontWeight={500}
+                  // Large hero value uses natural proportional figures (matches
+                  // the home total-balance hero); tabular is reserved for
+                  // tables / ticking data.
+                  fontVariant={PROPORTIONAL_NUMS}
                 >
                   {displayFiatValueOrUnavailable(
                     tokenDetails?.fiatValue,

--- a/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
+++ b/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
@@ -10,6 +10,7 @@ import {
   Dialog,
   Divider,
   ESwitchSize,
+  PROPORTIONAL_NUMS,
   SizableText,
   Skeleton,
   Stack,
@@ -391,7 +392,7 @@ function BalanceDetailsContent({
           {isLoading ? (
             <Skeleton.Heading3Xl />
           ) : (
-            <SizableText size="$heading3xl">
+            <SizableText size="$heading3xl" fontVariant={PROPORTIONAL_NUMS}>
               {`${overview?.balanceParsed ?? '-'} ${network?.symbol ?? ''}`}
             </SizableText>
           )}

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiListBlock.tsx
@@ -71,8 +71,6 @@ import { resolveOverviewCols } from './overviewColsResolver';
 import { type IProtocolHandle, Protocol } from './Protocol';
 import { useIsDeFiEnabled } from './useIsDeFiEnabled';
 
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
-
 const MAX_PROTOCOLS_ON_SMALL_SCREEN = 6;
 const PROTOCOL_LIST_TOGGLE_PRESS_LOCK_MS = 600;
 
@@ -1616,7 +1614,6 @@ function DeFiListBlock({
       <SizableText
         size="$headingXl"
         color={tableLayout ? '$textSubdued' : '$text'}
-        fontVariant={TABULAR_NUMS}
       >
         {formatPortfolioTotal(
           Number(overview.netWorth) || 0,

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiOverviewTile.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiOverviewTile.tsx
@@ -16,8 +16,6 @@ import type {
 import { OVERVIEW_TILE_SHADOW } from './DeFiOverviewLayout';
 import { formatPortfolioTotal } from './formatPortfolioTotal';
 
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
-
 export type IDeFiOverviewTileProps = {
   protocol: IDeFiProtocol;
   protocolInfo: IProtocolSummary | undefined;
@@ -105,11 +103,7 @@ function DeFiOverviewTile({
         >
           {name}
         </SizableText>
-        <SizableText
-          size="$bodyLgMedium"
-          numberOfLines={1}
-          fontVariant={TABULAR_NUMS}
-        >
+        <SizableText size="$bodyLgMedium" numberOfLines={1}>
           {formattedNetWorth}
         </SizableText>
       </YStack>

--- a/packages/kit/src/views/Home/components/DeFiListBlock/DeFiPortfolioStackedBar.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/DeFiPortfolioStackedBar.tsx
@@ -65,8 +65,6 @@ const STACKED_BAR_CHROME = {
   },
 } as const;
 
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
-
 const SEGMENT_OPACITY = 0.86;
 
 function buildA11yLabel(
@@ -249,7 +247,6 @@ function DeFiPortfolioStackedBar({
                   color="$text"
                   selectable={false}
                   numberOfLines={1}
-                  fontVariant={TABULAR_NUMS}
                   flexShrink={0}
                 >
                   {seg.label}

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolAssetBalanceText.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolAssetBalanceText.tsx
@@ -4,8 +4,6 @@ import { isProtocolAssetValueUnavailable } from '@onekeyhq/kit/src/components/De
 import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
 import type { IDeFiAsset } from '@onekeyhq/shared/types/defi';
 
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
-
 type IProtocolAssetBalanceTextProps = {
   asset: IDeFiAsset;
   currencySymbol: string;
@@ -27,7 +25,6 @@ function ProtocolAssetBalanceText({
         formatter="balance"
         formatterOptions={{ tokenSymbol: asset.symbol }}
         numberOfLines={1}
-        fontVariant={TABULAR_NUMS}
       >
         {asset.amount}
       </NumberSizeableTextWrapper>
@@ -43,7 +40,6 @@ function ProtocolAssetBalanceText({
             isUnavailable={isProtocolAssetValueUnavailable(asset)}
             size="$bodyMd"
             color="$textSubdued"
-            fontVariant={TABULAR_NUMS}
             numberOfLines={1}
             justifyContent="flex-start"
           />

--- a/packages/kit/src/views/Home/components/WalletOverview/index.tsx
+++ b/packages/kit/src/views/Home/components/WalletOverview/index.tsx
@@ -1,4 +1,9 @@
-import { SizableText, Skeleton, YStack } from '@onekeyhq/components';
+import {
+  PROPORTIONAL_NUMS,
+  SizableText,
+  Skeleton,
+  YStack,
+} from '@onekeyhq/components';
 
 import { HomeTestIDs } from '../../testIDs';
 
@@ -27,7 +32,9 @@ function WalletOverview(props: IProps) {
         {address}
       </SizableText>
       <Skeleton show={isFetchingValue}>
-        <SizableText size="$heading4xl">{value}</SizableText>
+        <SizableText size="$heading4xl" fontVariant={PROPORTIONAL_NUMS}>
+          {value}
+        </SizableText>
       </Skeleton>
     </YStack>
   );

--- a/packages/kit/src/views/Home/pages/DeFiContainer.tsx
+++ b/packages/kit/src/views/Home/pages/DeFiContainer.tsx
@@ -78,7 +78,6 @@ import {
 // Page.Container is now layout="full" so the scroll container fills the
 // viewport, and visual max-width is enforced one level down per content block.
 const DEFI_CONTAINER_CONTENT_MAX_WIDTH = 1140;
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
 const PROTOCOL_NAV_PENDING_TARGET_TIMEOUT_MS = 5000;
 const DEFI_TAB_REMEASURE_DELAYS_MS = [100, 350, 800] as const;
 const DEFI_TAB_CONTENT_TEST_ID = 'home-defi-tab-content';
@@ -800,11 +799,7 @@ function DeFiContainer() {
                 // approximate a typical "$XX,XXX.XX" measurement.
                 <Skeleton.HeadingXl w={120} />
               ) : (
-                <SizableText
-                  size="$headingXl"
-                  color="$textSubdued"
-                  fontVariant={TABULAR_NUMS}
-                >
+                <SizableText size="$headingXl" color="$textSubdued">
                   {formatPortfolioTotal(
                     portfolioStats.total,
                     currencySymbol,

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -6,6 +6,7 @@ import { useIntl } from 'react-intl';
 import {
   Button,
   IconButton,
+  PROPORTIONAL_NUMS,
   Skeleton,
   XStack,
   YStack,
@@ -1009,6 +1010,9 @@ function HomeOverviewContainer() {
                 fontSize={48}
                 lineHeight={48}
                 fontWeight={500}
+                // Large hero balance reads better with the font's natural
+                // proportional figures than equal-width tabular ones.
+                fontVariant={PROPORTIONAL_NUMS}
                 {...numberFormatter}
               >
                 {renderedBalanceStringDisplay ?? '0'}

--- a/packages/kit/src/views/Market/components/Chart/value-chart/ExtremeLabels.tsx
+++ b/packages/kit/src/views/Market/components/Chart/value-chart/ExtremeLabels.tsx
@@ -2,12 +2,19 @@ import type { ReactNode } from 'react';
 import { memo, useCallback, useMemo, useState } from 'react';
 
 import { useChartData } from '@onekeyfe/react-native-animated-charts';
-import { Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 import { NumberSizeableText } from '@onekeyhq/components';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
 import type { LayoutChangeEvent } from 'react-native';
+
+const styles = StyleSheet.create({
+  label: {
+    fontSize: 14,
+    fontWeight: 'bold',
+  },
+});
 
 function trim(val: number) {
   return Math.min(Math.max(val, 0.05), 0.95);
@@ -79,15 +86,7 @@ const CenteredLabel = ({
         position: 'absolute',
       }}
     >
-      <Text
-        style={{
-          color,
-          fontSize: 14,
-          fontWeight: 'bold',
-        }}
-      >
-        {children}
-      </Text>
+      <Text style={[styles.label, { color }]}>{children}</Text>
     </View>
   );
 };

--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -19,6 +19,7 @@ import {
   Popover,
   Select,
   SizableText,
+  TABULAR_NUMS,
   YStack,
   useTheme,
   useThemeName,
@@ -254,13 +255,19 @@ const styles = StyleSheet.create({
     letterSpacing: 0.8,
     width: '100%',
   },
-  monospaceText: {
-    fontFamily: platformEnv.isNative ? 'GeistMono-Regular' : 'monospace',
+  tabularText: {
+    // Not a mono face: the app font (Roobert) ships tabular figures via the
+    // `tnum` OpenType feature, so digits stay column-aligned while letters keep
+    // their natural proportional widths. Native raw <Text> can't pick a weight
+    // from a custom family via fontWeight, so name the medium face explicitly.
+    fontFamily: platformEnv.isNative ? 'Roobert-Medium' : undefined,
+    fontVariant: TABULAR_NUMS,
     fontSize: 12,
     lineHeight: 16,
     fontWeight: '500',
   },
-  monospaceTextBold: {
+  tabularTextBold: {
+    fontFamily: platformEnv.isNative ? 'Roobert-SemiBold' : undefined,
     fontWeight: '600',
   },
   interactiveRow: {
@@ -422,11 +429,11 @@ const styles = StyleSheet.create({
     borderBottomRightRadius: 999,
   },
   sideRatioLabel: {
-    fontFamily: platformEnv.isNative ? 'GeistMono-Regular' : 'monospace',
+    fontFamily: platformEnv.isNative ? 'Roobert-Medium' : undefined,
     fontSize: 12,
     lineHeight: 16,
     fontWeight: '500',
-    fontVariant: ['tabular-nums'],
+    fontVariant: TABULAR_NUMS,
   },
   sideRatioLabelCompact: {
     fontSize: 11,
@@ -462,27 +469,27 @@ const OrderBookVerticalRow = memo(
     sizeColor: string;
     isHovered?: boolean;
   }) => {
-    const fontWeightStyle = isHovered ? styles.monospaceTextBold : null;
+    const fontWeightStyle = isHovered ? styles.tabularTextBold : null;
     return (
       <DebugRenderTracker name="OrderBookVerticalRow" position="right-center">
         <View style={styles.verticalRowContainer}>
           <View style={styles.verticalRowCellPrice}>
             <PerpBookText
               style={[
-                styles.monospaceText,
+                styles.tabularText,
                 { color: priceColor },
                 fontWeightStyle,
               ]}
               numberOfLines={1}
             >
-              {item.price}
+              {item.displayPrice}
             </PerpBookText>
           </View>
           <View style={styles.verticalRowCellSize}>
             <PerpBookText
               numberOfLines={1}
               style={[
-                styles.monospaceText,
+                styles.tabularText,
                 { color: sizeColor },
                 fontWeightStyle,
               ]}
@@ -494,7 +501,7 @@ const OrderBookVerticalRow = memo(
             <PerpBookText
               numberOfLines={1}
               style={[
-                styles.monospaceText,
+                styles.tabularText,
                 { color: sizeColor },
                 fontWeightStyle,
               ]}
@@ -1015,21 +1022,21 @@ export function OrderBook({
                             <View style={styles.interactiveRowContent}>
                               <PerpBookText
                                 style={[
-                                  styles.monospaceText,
+                                  styles.tabularText,
                                   { color: textColor.textSubdued },
-                                  isHovered ? styles.monospaceTextBold : null,
+                                  isHovered ? styles.tabularTextBold : null,
                                 ]}
                               >
                                 {item.displaySize}
                               </PerpBookText>
                               <PerpBookText
                                 style={[
-                                  styles.monospaceText,
+                                  styles.tabularText,
                                   { color: textColor.green },
-                                  isHovered ? styles.monospaceTextBold : null,
+                                  isHovered ? styles.tabularTextBold : null,
                                 ]}
                               >
-                                {item.price}
+                                {item.displayPrice}
                               </PerpBookText>
                             </View>
                           );
@@ -1056,18 +1063,18 @@ export function OrderBook({
                             <View style={styles.interactiveRowContent}>
                               <PerpBookText
                                 style={[
-                                  styles.monospaceText,
+                                  styles.tabularText,
                                   { color: textColor.red },
-                                  isHovered ? styles.monospaceTextBold : null,
+                                  isHovered ? styles.tabularTextBold : null,
                                 ]}
                               >
-                                {item.price}
+                                {item.displayPrice}
                               </PerpBookText>
                               <PerpBookText
                                 style={[
-                                  styles.monospaceText,
+                                  styles.tabularText,
                                   { color: textColor.textSubdued },
-                                  isHovered ? styles.monospaceTextBold : null,
+                                  isHovered ? styles.tabularTextBold : null,
                                 ]}
                               >
                                 {item.displaySize}
@@ -1297,7 +1304,7 @@ const OrderBookPairRow = memo(
     sizeColor: string;
     isHovered?: boolean;
   }) => {
-    const fontWeightStyle = isHovered ? styles.monospaceTextBold : null;
+    const fontWeightStyle = isHovered ? styles.tabularTextBold : null;
     return (
       <DebugRenderTracker name="OrderBookPairRow" position="right-center">
         <View
@@ -1310,20 +1317,12 @@ const OrderBookPairRow = memo(
           }}
         >
           <PerpBookText
-            style={[
-              styles.monospaceText,
-              { color: priceColor },
-              fontWeightStyle,
-            ]}
+            style={[styles.tabularText, { color: priceColor }, fontWeightStyle]}
           >
-            {item.price}
+            {item.displayPrice}
           </PerpBookText>
           <PerpBookText
-            style={[
-              styles.monospaceText,
-              { color: sizeColor },
-              fontWeightStyle,
-            ]}
+            style={[styles.tabularText, { color: sizeColor }, fontWeightStyle]}
           >
             {item.displaySize}
           </PerpBookText>
@@ -1614,7 +1613,7 @@ function MobileSpreadInfoContent({
         renderTrigger={
           <PerpBookText
             style={[
-              styles.monospaceText,
+              styles.tabularText,
               {
                 color: textColor.text,
                 fontSize: 20,
@@ -1646,7 +1645,7 @@ function MobileSpreadInfoContent({
           isSpot ? (
             <PerpBookText
               style={[
-                styles.monospaceText,
+                styles.tabularText,
                 {
                   color: textColor.textSubdued,
                   fontSize: 11,
@@ -1660,7 +1659,7 @@ function MobileSpreadInfoContent({
           ) : (
             <DashText
               style={[
-                styles.monospaceText,
+                styles.tabularText,
                 {
                   color: textColor.textSubdued,
                   fontSize: 10,

--- a/packages/kit/src/views/Perp/components/OrderBook/types.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/types.ts
@@ -17,6 +17,9 @@ export interface IOBLevel {
 }
 
 export interface IFormattedOBLevel extends IOBLevel {
+  /** Human readable representation of price for rendering (thousands-separated).
+   * `price` stays the raw numeric string for selection/order-form logic. */
+  displayPrice: string;
   /** Human readable representation of size for rendering */
   displaySize: string;
   /** Human readable representation of cumulative size for rendering */

--- a/packages/kit/src/views/Perp/components/OrderBook/useAggregatedBook.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/useAggregatedBook.tsx
@@ -2,7 +2,10 @@ import { useMemo } from 'react';
 
 import BigNumber from 'bignumber.js';
 
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  formatLocalizedNumberString,
+  numberFormat,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 import type { IBookLevel } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 import { type ITickParam } from './tickSizeUtils';
@@ -52,6 +55,7 @@ const withDisplayFields = (
 ): IFormattedOBLevel[] =>
   levels.map((level) => ({
     ...level,
+    displayPrice: formatLocalizedNumberString(level.price),
     displaySize: formatOrderBookValue(level.size, variant),
     displayCumSize: formatOrderBookValue(level.cumSize, variant),
   }));

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
@@ -13,7 +13,10 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatTime } from '@onekeyhq/shared/src/utils/dateUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  formatLocalizedNumberString,
+  numberFormat,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   getValidPriceDecimals,
   isSpotInstrument,
@@ -186,9 +189,9 @@ const OpenOrdersRow = memo(
       const executePriceFormatted = new BigNumber(executePrice).toFixed(
         decimals,
       );
-      const executePriceLimitFormatted = new BigNumber(
-        executePriceLimit,
-      ).toFixed(decimals);
+      const executePriceLimitFormatted = formatLocalizedNumberString(
+        new BigNumber(executePriceLimit).toFixed(decimals),
+      );
       const priceFormatted = new BigNumber(price).toFixed(decimals);
       const sizeFormatted = numberFormat(size, balanceFormatter);
       const value = priceBN.times(origSizeBN).toFixed();

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -21,7 +21,10 @@ import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  formatLocalizedNumberString,
+  numberFormat,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 import { getTpSlKind } from '@onekeyhq/shared/src/utils/perpsTpSlUtils';
 import {
   getValidPriceDecimals,
@@ -104,7 +107,9 @@ function MarkPrice({ coin }: { coin: string }) {
     () => (
       <DebugRenderTracker position="bottom-right" name="MarkPrice" offsetY={10}>
         <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
-          {midFormattedByDecimals}
+          {midFormattedByDecimals
+            ? formatLocalizedNumberString(midFormattedByDecimals)
+            : midFormattedByDecimals}
         </SizableText>
       </DebugRenderTracker>
     ),
@@ -253,7 +258,9 @@ const PositionRowDesktopMarkPrice = memo(
           offsetY={10}
         >
           <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
-            {midFormattedByDecimals}
+            {midFormattedByDecimals
+              ? formatLocalizedNumberString(midFormattedByDecimals)
+              : midFormattedByDecimals}
           </SizableText>
         </DebugRenderTracker>
       </XStack>
@@ -509,7 +516,12 @@ const PositionRowDesktopTPSL = memo(
         showOrder = true;
       }
 
-      return { tpsl: `${tpPrice}/${slPrice}`, showOrder };
+      return {
+        tpsl: `${formatLocalizedNumberString(
+          tpPrice,
+        )}/${formatLocalizedNumberString(slPrice)}`,
+        showOrder,
+      };
     }, [currentAssetOpenOrders]);
 
     return (
@@ -1094,7 +1106,11 @@ const PositionRowMobileTPSL = memo(({ coin }: { coin: string }) => {
       }
     });
 
-    return { tpsl: `${tpPrice}/${slPrice}` };
+    return {
+      tpsl: `${formatLocalizedNumberString(
+        tpPrice,
+      )}/${formatLocalizedNumberString(slPrice)}`,
+    };
   }, [currentAssetOpenOrders]);
 
   return (
@@ -1127,7 +1143,7 @@ const PositionRowMobileMarkPrice = memo(({ coin }: { coin: string }) => {
         })}
       </SizableText>
       <SizableText size="$bodyMdMedium" numberOfLines={1}>
-        {midFormattedByDecimals || '--'}
+        {formatLocalizedNumberString(midFormattedByDecimals || '--')}
       </SizableText>
     </YStack>
   );
@@ -1373,10 +1389,10 @@ const PositionRow = memo(
       const entryPrice = new BigNumber(pos.entryPx || '0').toFixed(decimals);
 
       const liquidationPrice = new BigNumber(pos.liquidationPx || '0');
-      const entryPriceFormatted = entryPrice;
-      const liquidationPriceFormatted = liquidationPrice.isZero()
-        ? 'N/A'
-        : liquidationPrice.toFixed(decimals);
+      const entryPriceFormatted = formatLocalizedNumberString(entryPrice);
+      const liquidationPriceFormatted = formatLocalizedNumberString(
+        liquidationPrice.isZero() ? 'N/A' : liquidationPrice.toFixed(decimals),
+      );
 
       return {
         entryPriceFormatted,

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -19,7 +19,10 @@ import { useSpotPairDisplayMapAtom } from '@onekeyhq/kit-bg/src/states/jotai/ato
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatTime } from '@onekeyhq/shared/src/utils/dateUtils';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  formatLocalizedNumberString,
+  numberFormat,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   getSpotTokenDisplayName,
   getValidPriceDecimals,
@@ -138,7 +141,9 @@ const TradesHistoryRow = memo(
       const decimals = getValidPriceDecimals(price);
       const priceBN = new BigNumber(price);
       const sizeBN = new BigNumber(size);
-      const priceFormatted = priceBN.toFixed(decimals);
+      const priceFormatted = formatLocalizedNumberString(
+        priceBN.toFixed(decimals),
+      );
       const feeFormatted = numberFormat(fee, formatter);
 
       const tradeValue = priceBN.times(sizeBN).toFixed();

--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -221,104 +221,69 @@ function MobileHeader({
             <YStack gap="$3">
               <XStack justifyContent="space-between" alignItems="center">
                 <XStack gap="$1" alignItems="center">
-                  <SizableText
-                    size="$headingXs"
-                    fontFamily="$monoRegular"
-                    fontVariant={['tabular-nums']}
-                  >
+                  <SizableText size="$headingXs">
                     {intl.formatMessage({
                       id: ETranslations.perps_hourly,
                     })}
                   </SizableText>
-                  <SizableText
-                    size="$headingXs"
-                    fontFamily="$monoRegular"
-                    fontVariant={['tabular-nums']}
-                    color="$textSubdued"
-                  >
+                  <SizableText size="$headingXs" color="$textSubdued">
                     ({countdown})
                   </SizableText>
                 </XStack>
                 <SizableText
                   size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
                 >
                   {hourlyFundingRate}%
                 </SizableText>
               </XStack>
               <XStack justifyContent="space-between" alignItems="center">
-                <SizableText
-                  size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
-                >
+                <SizableText size="$headingXs">
                   {intl.formatMessage({
                     id: ETranslations.earn_daily,
                   })}
                 </SizableText>
                 <SizableText
                   size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
                 >
                   {dailyFundingRate}%
                 </SizableText>
               </XStack>
               <XStack justifyContent="space-between" alignItems="center">
-                <SizableText
-                  size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
-                >
+                <SizableText size="$headingXs">
                   {intl.formatMessage({
                     id: ETranslations.earn_weekly,
                   })}
                 </SizableText>
                 <SizableText
                   size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
                 >
                   {weeklyFundingRate}%
                 </SizableText>
               </XStack>
               <XStack justifyContent="space-between" alignItems="center">
-                <SizableText
-                  size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
-                >
+                <SizableText size="$headingXs">
                   {intl.formatMessage({
                     id: ETranslations.earn_monthly,
                   })}
                 </SizableText>
                 <SizableText
                   size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
                 >
                   {monthlyFundingRate}%
                 </SizableText>
               </XStack>
               <XStack justifyContent="space-between" alignItems="center">
-                <SizableText
-                  size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
-                >
+                <SizableText size="$headingXs">
                   {intl.formatMessage({
                     id: ETranslations.earn_annually,
                   })}
                 </SizableText>
                 <SizableText
                   size="$headingXs"
-                  fontFamily="$monoRegular"
-                  fontVariant={['tabular-nums']}
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
                 >
                   {annualizedFundingRate}%

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
@@ -52,11 +52,11 @@ import { useSpotMetaMaps } from '../../hooks/useSpotMetaMaps';
 import { PerpTokenSelector } from '../TokenSelector/PerpTokenSelector';
 import { FavoriteButton } from '../TokenSelector/PerpTokenSelectorRow';
 
+// Medium-weight (500) data values — the heading tokens' 600 reads too heavy
+// for a dense stat strip of tabular digits, while plain 400 gets lost against
+// the subdued labels at this size.
 const TICKER_BAR_STAT_VALUE_TEXT_PROPS = {
-  size: '$headingXs',
-  fontFamily: '$monoRegular',
-  textTransform: 'none',
-  letterSpacing: 0,
+  size: '$bodySmMedium',
 } as const;
 
 const TICKER_BAR_STAT_LABEL_VALUE_GAP = 5;
@@ -176,8 +176,8 @@ const TickerBarMarkPriceView = memo(
             renderTrigger={
               <SizableText
                 size="$headingMd"
+                fontWeight="500"
                 cursor="help"
-                fontVariant={['tabular-nums']}
                 lineHeight={20}
               >
                 {formattedMarkPrice}
@@ -203,9 +203,9 @@ function TickerBarMarkPrice() {
   const assetCtx = useTickerBarPerpAssetCtx();
   const [spotAssetCtx] = useSpotActiveAssetCtxAtom();
   const isSpot = tradingMode === 'spot';
-  const formattedMarkPrice = isSpot
-    ? formatLocalizedNumberString(spotAssetCtx?.ctx?.markPrice || '')
-    : assetCtx?.ctx?.markPrice || '';
+  const formattedMarkPrice = formatLocalizedNumberString(
+    (isSpot ? spotAssetCtx?.ctx?.markPrice : assetCtx?.ctx?.markPrice) || '',
+  );
   const isLoading = useTickerBarIsLoading();
   useEffect(() => {
     if (!isLoading && formattedMarkPrice) {
@@ -326,10 +326,7 @@ const TickerBarOraclePriceView = memo(
             placement="top"
           />
           <SkeletonContainer isLoading={isLoading} width={80} height={16}>
-            <SizableText
-              {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-              fontVariant={['tabular-nums']}
-            >
+            <SizableText {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}>
               {formattedOraclePrice}
             </SizableText>
           </SkeletonContainer>
@@ -342,7 +339,9 @@ TickerBarOraclePriceView.displayName = 'TickerBarOraclePriceView';
 
 function TickerBarOraclePrice() {
   const assetCtx = useTickerBarPerpAssetCtx();
-  const formattedOraclePrice = assetCtx?.ctx?.oraclePrice || '';
+  const formattedOraclePrice = formatLocalizedNumberString(
+    assetCtx?.ctx?.oraclePrice || '',
+  );
   const isLoading = useTickerBarIsLoading();
 
   return (
@@ -371,10 +370,7 @@ const TickerBar24hVolumeView = memo(
             })}
           </SizableText>
           <SkeletonContainer isLoading={isLoading} width={80} height={16}>
-            <SizableText
-              {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-              fontVariant={['tabular-nums']}
-            >
+            <SizableText {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}>
               ${formattedVolume24h}
             </SizableText>
           </SkeletonContainer>
@@ -444,10 +440,7 @@ const TickerBarOpenInterestView = memo(
             placement="top"
           />
           <SkeletonContainer isLoading={isLoading} width={80} height={16}>
-            <SizableText
-              {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-              fontVariant={['tabular-nums']}
-            >
+            <SizableText {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}>
               ${formattedOpenInterest}
             </SizableText>
           </SkeletonContainer>
@@ -496,10 +489,7 @@ const TickerBarMarketCapView = memo(
             })}
           </SizableText>
           <SkeletonContainer isLoading={isLoading} width={80} height={16}>
-            <SizableText
-              {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-              fontVariant={['tabular-nums']}
-            >
+            <SizableText {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}>
               {formattedMarketCap === '--'
                 ? formattedMarketCap
                 : `$${formattedMarketCap}`}
@@ -555,6 +545,7 @@ const TickerBarSpotContractView = memo(
             <XStack gap="$1" alignItems="center">
               <SizableText
                 {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
+                fontFamily="$monoRegular"
                 color="$text"
                 numberOfLines={1}
               >
@@ -616,11 +607,7 @@ function TickerBarFundingRateCountdown() {
       position="bottom-right"
       offsetX={10}
     >
-      <SizableText
-        {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-        color="$text"
-        fontVariant={['tabular-nums']}
-      >
+      <SizableText {...TICKER_BAR_STAT_VALUE_TEXT_PROPS} color="$text">
         {countdown}
       </SizableText>
     </DebugRenderTracker>
@@ -666,7 +653,6 @@ const TickerBarFundingRateView = memo(
                   <XStack alignItems="baseline" gap="$2">
                     <DashText
                       {...TICKER_BAR_STAT_VALUE_TEXT_PROPS}
-                      fontVariant={['tabular-nums']}
                       color={fundingRate >= 0 ? '$green11' : '$red11'}
                       dashThickness={0.5}
                       dashSpacing={0}
@@ -684,22 +670,12 @@ const TickerBarFundingRateView = memo(
                         justifyContent="space-between"
                         alignItems="center"
                       >
-                        <SizableText
-                          size="$headingXs"
-                          fontFamily="$monoRegular"
-                          fontVariant={['tabular-nums']}
-                          color="$textSubdued"
-                        >
+                        <SizableText size="$bodySm" color="$textSubdued">
                           {intl.formatMessage({
                             id: ETranslations.perps_fee_rate_projection,
                           })}
                         </SizableText>
-                        <SizableText
-                          size="$headingXs"
-                          fontFamily="$monoRegular"
-                          fontVariant={['tabular-nums']}
-                          color="$textSubdued"
-                        >
+                        <SizableText size="$bodySm" color="$textSubdued">
                           {intl.formatMessage({
                             id: ETranslations.perp_position_funding,
                           })}
@@ -711,28 +687,17 @@ const TickerBarFundingRateView = memo(
                           alignItems="center"
                         >
                           <XStack gap="$1" alignItems="center">
-                            <SizableText
-                              size="$headingXs"
-                              fontFamily="$monoRegular"
-                              fontVariant={['tabular-nums']}
-                            >
+                            <SizableText size="$bodySm">
                               {intl.formatMessage({
                                 id: ETranslations.perps_hourly,
                               })}
                             </SizableText>
-                            <SizableText
-                              size="$headingXs"
-                              fontFamily="$monoRegular"
-                              fontVariant={['tabular-nums']}
-                              color="$textSubdued"
-                            >
+                            <SizableText size="$bodySm" color="$textSubdued">
                               ({countdown})
                             </SizableText>
                           </XStack>
                           <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
+                            size="$bodySm"
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
                           >
                             {hourlyFundingRate}%
@@ -742,19 +707,13 @@ const TickerBarFundingRateView = memo(
                           justifyContent="space-between"
                           alignItems="center"
                         >
-                          <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
-                          >
+                          <SizableText size="$bodySm">
                             {intl.formatMessage({
                               id: ETranslations.earn_daily,
                             })}
                           </SizableText>
                           <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
+                            size="$bodySm"
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
                           >
                             {dailyFundingRate}%
@@ -764,19 +723,13 @@ const TickerBarFundingRateView = memo(
                           justifyContent="space-between"
                           alignItems="center"
                         >
-                          <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
-                          >
+                          <SizableText size="$bodySm">
                             {intl.formatMessage({
                               id: ETranslations.earn_weekly,
                             })}
                           </SizableText>
                           <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
+                            size="$bodySm"
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
                           >
                             {weeklyFundingRate}%
@@ -786,19 +739,13 @@ const TickerBarFundingRateView = memo(
                           justifyContent="space-between"
                           alignItems="center"
                         >
-                          <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
-                          >
+                          <SizableText size="$bodySm">
                             {intl.formatMessage({
                               id: ETranslations.earn_monthly,
                             })}
                           </SizableText>
                           <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
+                            size="$bodySm"
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
                           >
                             {monthlyFundingRate}%
@@ -808,19 +755,13 @@ const TickerBarFundingRateView = memo(
                           justifyContent="space-between"
                           alignItems="center"
                         >
-                          <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
-                          >
+                          <SizableText size="$bodySm">
                             {intl.formatMessage({
                               id: ETranslations.earn_annually,
                             })}
                           </SizableText>
                           <SizableText
-                            size="$headingXs"
-                            fontFamily="$monoRegular"
-                            fontVariant={['tabular-nums']}
+                            size="$bodySm"
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
                           >
                             {annualizedFundingRate}%
@@ -830,11 +771,7 @@ const TickerBarFundingRateView = memo(
                     </YStack>
                     <Divider />
                     <YStack gap="$2" justifyContent="space-between">
-                      <SizableText
-                        size="$headingXs"
-                        fontVariant={['tabular-nums']}
-                        color="$textSubdued"
-                      >
+                      <SizableText size="$bodySm" color="$textSubdued">
                         {intl.formatMessage({
                           id: ETranslations.perp_trades_history_direction,
                         })}
@@ -875,7 +812,7 @@ const TickerBarFundingRateView = memo(
                     </YStack>
                     <Divider />
                     <YStack gap="$2">
-                      <SizableText size="$headingXs" color="$textSubdued">
+                      <SizableText size="$bodySm" color="$textSubdued">
                         {intl.formatMessage({
                           id: ETranslations.perp_funding_rate_tip0,
                         })}

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -1524,12 +1524,7 @@ const PerpTickerChangeLeaf = memo(
 
     if (!hasChange24hPercent) {
       return (
-        <SizableText
-          fontSize={10}
-          fontFamily="$monoRegular"
-          color="$textSubdued"
-          alignSelf="center"
-        >
+        <SizableText fontSize={10} color="$textSubdued" alignSelf="center">
           --
         </SizableText>
       );
@@ -1537,8 +1532,6 @@ const PerpTickerChangeLeaf = memo(
     return (
       <NumberSizeableText
         style={{ fontSize: 10 }}
-        fontFamily="$monoRegular"
-        fontVariant={['tabular-nums']}
         alignSelf="center"
         color={change24hPercent < 0 ? '$red11' : '$green11'}
         formatter="priceChange"

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -25,7 +25,10 @@ import {
   usePerpsCustomSettingsAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+import {
+  formatLocalizedNumberString,
+  numberFormat,
+} from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   formatPriceToSignificantDigits,
   formatSpotPriceToValid,
@@ -68,7 +71,7 @@ function formatOrderPriceDisplay({
   const formattedPrice = isSpot
     ? formatSpotPriceToValid(price, szDecimals)
     : formatPriceToSignificantDigits(price, szDecimals);
-  return `$${formattedPrice}`;
+  return `$${formatLocalizedNumberString(formattedPrice)}`;
 }
 
 interface IOrderConfirmContentProps {

--- a/packages/kit/src/views/Swap/components/SwapProBuySellInfo.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProBuySellInfo.tsx
@@ -45,7 +45,6 @@ const SwapProBuySellInfo = ({
       <NumberSizeableText
         size="$bodySm"
         color="$textSuccess"
-        fontFamily="$monoRegular"
         formatter={isAboveThreshold ? 'marketCap' : 'value'}
         formatterOptions={{ currency: '$' }}
       >
@@ -69,7 +68,6 @@ const SwapProBuySellInfo = ({
       <NumberSizeableText
         size="$bodySm"
         color="$textCritical"
-        fontFamily="$monoRegular"
         formatter={isAboveThreshold ? 'marketCap' : 'value'}
         formatterOptions={{ currency: '$' }}
       >
@@ -145,12 +143,7 @@ const SwapProBuySellInfo = ({
               B
             </SizableText>
           </Stack>
-          <SizableText
-            size="$bodyXs"
-            color="$textSuccess"
-            ml="$0.5"
-            fontFamily="$monoRegular"
-          >
+          <SizableText size="$bodyXs" color="$textSuccess" ml="$0.5">
             {!supportSpeedSwap ? '--' : buyPercentage.toFixed(2)}%
           </SizableText>
         </XStack>
@@ -161,12 +154,7 @@ const SwapProBuySellInfo = ({
           position="relative"
           zIndex={1}
         >
-          <SizableText
-            size="$bodyXs"
-            color="$textCritical"
-            mr="$0.5"
-            fontFamily="$monoRegular"
-          >
+          <SizableText size="$bodyXs" color="$textCritical" mr="$0.5">
             {!supportSpeedSwap ? '--' : sellPercentage.toFixed(2)}%
           </SizableText>
           <Stack

--- a/packages/kit/src/views/Swap/components/SwapProTokenTransactionItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProTokenTransactionItem.tsx
@@ -32,11 +32,7 @@ const SwapProTokenTransactionItem = ({
     const textColorValue =
       item.type === 'buy' ? '$textSuccess' : '$textCritical';
     let formatPriceValue = (
-      <SizableText
-        size="$bodySm"
-        color={textColorValue}
-        fontFamily="$monoRegular"
-      >
+      <SizableText size="$bodySm" color={textColorValue}>
         {FALLBACK_DISPLAY};
       </SizableText>
     );
@@ -46,7 +42,6 @@ const SwapProTokenTransactionItem = ({
         <NumberSizeableText
           size="$bodySm"
           color={textColorValue}
-          fontFamily="$monoRegular"
           formatter={isAboveThreshold ? 'marketCap' : 'price'}
           formatterOptions={{
             currency: '$',
@@ -58,11 +53,7 @@ const SwapProTokenTransactionItem = ({
     }
 
     let formatTokenValueValue = (
-      <SizableText
-        size="$bodySm"
-        color={textColorValue}
-        fontFamily="$monoRegular"
-      >
+      <SizableText size="$bodySm" color={textColorValue}>
         {FALLBACK_DISPLAY};
       </SizableText>
     );
@@ -75,7 +66,6 @@ const SwapProTokenTransactionItem = ({
         <NumberSizeableText
           size="$bodySm"
           color={textColorValue}
-          fontFamily="$monoRegular"
           formatter={isAboveThreshold ? 'marketCap' : 'value'}
           formatterOptions={{
             currency: '$',

--- a/packages/kit/src/views/Swap/pages/components/SwapProPriceInfo.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProPriceInfo.tsx
@@ -83,7 +83,7 @@ const SwapProPriceInfo = ({ onPricePress }: ISwapProPriceInfoProps) => {
       <NumberSizeableText
         size="$headingLg"
         color={textColor}
-        fontFamily="$monoMedium"
+        fontWeight="500"
         formatter="price"
         formatterOptions={{
           currency: '$',
@@ -101,11 +101,7 @@ const SwapProPriceInfo = ({ onPricePress }: ISwapProPriceInfoProps) => {
           {tokenMarketDetailInfo.priceConverted}
         </NumberSizeableText>
       ) : null}
-      <SizableText
-        size="$bodySmMedium"
-        color={textColor}
-        fontFamily="$monoMedium"
-      >
+      <SizableText size="$bodySmMedium" color={textColor}>
         {formattedPriceChange}
       </SizableText>
     </YStack>

--- a/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
@@ -987,7 +987,6 @@ function SwapKLineTokenPriceInfo({
       {price ? (
         <NumberSizeableText
           size={compact ? '$bodyMdMedium' : '$bodyLgMedium'}
-          fontFamily="$monoMedium"
           formatter="price"
           formatterOptions={{ currency: '$' }}
           numberOfLines={1}
@@ -999,7 +998,6 @@ function SwapKLineTokenPriceInfo({
         <SizableText
           size={compact ? '$bodyMdMedium' : '$bodyLgMedium'}
           color="$textSubdued"
-          fontFamily="$monoMedium"
           numberOfLines={1}
         >
           --
@@ -1008,7 +1006,6 @@ function SwapKLineTokenPriceInfo({
       {priceChange ? (
         <PriceChangePercentage
           size={compact ? '$bodyXsMedium' : '$bodySmMedium'}
-          fontFamily="$monoMedium"
           numberOfLines={1}
         >
           {priceChange}
@@ -1017,7 +1014,6 @@ function SwapKLineTokenPriceInfo({
         <SizableText
           size="$bodySmMedium"
           color="$textSubdued"
-          fontFamily="$monoMedium"
           numberOfLines={1}
         >
           --


### PR DESCRIPTION
## Summary

Make **tabular (equal-width) figures the app-wide default** for all UI text, and give quoted prices locale-aware thousands separators. Tabular digits keep numbers from reflowing as they tick and keep columns aligned — the standard treatment for trading interfaces. We get it from the OpenType `tnum` feature our font (Roobert) already ships, applied globally.

## How it works (two mechanisms, one per platform)

- **Native**: `SizableText` (the wrapper every text primitive routes through) defaults `fontVariant` to `TABULAR_NUMS`, translated into a real RN `style.fontVariant` (Tamagui silently drops the raw prop). Reference-stable and allocation-free on the hot path.
- **Web**: a single `body { font-variant-numeric: tabular-nums }` rule in `web-fonts.css` (already imported by every web-stack app). CSS inheritance covers every text node — including ones that bypass the wrapper (raw `<Text>`, `Badge.Text`, portals) — so the wrapper emits **no** inline style for the default on web.

Both are opt-out: `fontVariant={PROPORTIONAL_NUMS}` restores proportional figures for a specific text.

Text that bypasses the wrapper on **native** applies the feature at the source: `Badge.Text` is centralized in the `Badge` component (all badge digits go tabular in one place), and raw RN `<Text>` in the order book / chart labels carries it via a `StyleSheet` entry.

**Large hero balances stay proportional** (the escape hatch): the home total balance, account-overview balance, token-detail fiat value, and balance-details dialog use `PROPORTIONAL_NUMS`. A single large display number has no column to align with, and the font's natural proportional figures read better at hero sizes — tabular is reserved for tables and ticking data.

## Also in this change

- **Localized thousands separators** on quoted prices (order book `displayPrice`, ticker/oracle price, TP-SL, order confirm, positions/history rows) via the existing locale-aware `formatLocalizedNumberString` — European `78.056,1` and Indian grouping work out of the box. Formatting happens at the producing memo, not in JSX.
- **Perps ticker bar (desktop)**: headline mark price weight → 500 (the heading token's 600 reads too heavy for a dense tabular stat strip).

## Verification
- `tsgo --noEmit`: 0 errors in changed files; `oxlint --type-aware --deny-warnings`: clean; `numberUtils.locale.test.ts`: 72/72.
- Live web probes: computed `font-variant-numeric: tabular-nums` confirmed via inheritance (Market home 1208 numeric nodes / 0 non-tabular, /defi, perps ticker/order book); `PROPORTIONAL_NUMS` verified to override the body rule (computed style flips to `proportional-nums`); separators rendered.
