### PR TITLE
fix: align send amount font

### DIFF
--- a/packages/kit/src/views/Send/components/SendAutoSizeAmountInput/AutoSizeInput.native.tsx
+++ b/packages/kit/src/views/Send/components/SendAutoSizeAmountInput/AutoSizeInput.native.tsx
@@ -45,6 +45,7 @@ export const AutoSizeInput = forwardRef<IAutoSizeInputRef, IAutoSizeInputProps>(
       inlineTokenSymbol,
       inlinePrefixGapPx,
       inlineSuffixGapPx,
+      fontFamily,
       onChangeText,
       placeholder,
       editable,
@@ -99,6 +100,7 @@ export const AutoSizeInput = forwardRef<IAutoSizeInputRef, IAutoSizeInputProps>(
           fontSize={maxFontSize}
           minFontSize={minFontSize}
           textAlign={autoSizeTextAlign}
+          fontFamily={fontFamily}
           fontWeight="500"
           editable={editable ?? true}
           keyboardType={mapAutoSizeKeyboardType(keyboardType ?? 'decimal-pad')}

--- a/packages/kit/src/views/Send/components/SendAutoSizeAmountInput/AutoSizeInput.tsx
+++ b/packages/kit/src/views/Send/components/SendAutoSizeAmountInput/AutoSizeInput.tsx
@@ -182,6 +182,7 @@ export const AutoSizeInput = forwardRef<IAutoSizeInputRef, IAutoSizeInputProps>(
       inlineTokenSymbol,
       inlinePrefixGapPx,
       inlineSuffixGapPx,
+      fontFamily,
       selectionColor,
       onChangeText,
       placeholder,
@@ -350,6 +351,7 @@ export const AutoSizeInput = forwardRef<IAutoSizeInputRef, IAutoSizeInputProps>(
             fontWeight="500"
             lineHeight={Math.ceil(effectiveFontSize * 1.4)}
             style={{
+              fontFamily,
               fontSize: effectiveFontSize,
               marginRight: inlinePrefixGapPx,
             }}
@@ -365,6 +367,7 @@ export const AutoSizeInput = forwardRef<IAutoSizeInputRef, IAutoSizeInputProps>(
           editable={editable}
           fontSize={effectiveFontSize}
           fontWeight="500"
+          fontFamily={fontFamily}
           color="$text"
           unstyled
           borderWidth={0}
@@ -428,6 +431,7 @@ export const AutoSizeInput = forwardRef<IAutoSizeInputRef, IAutoSizeInputProps>(
             fontWeight="500"
             lineHeight={Math.ceil(effectiveFontSize * 1.4)}
             style={{
+              fontFamily,
               fontSize: effectiveFontSize,
               marginLeft: inlineSuffixGapPx,
             }}

--- a/packages/kit/src/views/Send/components/SendAutoSizeAmountInput/AutoSizeInput.types.ts
+++ b/packages/kit/src/views/Send/components/SendAutoSizeAmountInput/AutoSizeInput.types.ts
@@ -18,6 +18,7 @@ export type IAutoSizeInputProps = {
   inlineTokenSymbol?: string;
   inlinePrefixGapPx: number;
   inlineSuffixGapPx: number;
+  fontFamily: string;
   // Shared selection color for web/native text cursor and selection.
   selectionColor: string;
   onChangeText: (text: string) => void;

--- a/packages/kit/src/views/Send/components/SendAutoSizeAmountInput/index.tsx
+++ b/packages/kit/src/views/Send/components/SendAutoSizeAmountInput/index.tsx
@@ -21,6 +21,7 @@ import {
   useTheme,
 } from '@onekeyhq/components';
 import type { IInputProps, IStackProps } from '@onekeyhq/components';
+import { webFontFamily } from '@onekeyhq/components/src/utils/webFontFamily';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { NUMBER_FORMATTER } from '@onekeyhq/shared/src/utils/numberUtils';
 
@@ -34,6 +35,9 @@ const WRAPPED_SYMBOL_MIN_FONT_SIZE = 14;
 const WRAPPED_SYMBOL_MAX_FONT_SIZE = 24;
 const WRAPPED_SYMBOL_HORIZONTAL_PADDING_PX = 16;
 const WRAPPED_SYMBOL_BREAK_CHARS = new Set([' ', '-', '_', '/', '.']);
+const AMOUNT_FONT_FAMILY = platformEnv.isNative
+  ? 'Roobert-Medium'
+  : webFontFamily;
 // iOS-only hidden marker used to force a native prop delta without visible UI change.
 const IOS_FORCE_WRITE_BACK_MARKER = '\u200B';
 
@@ -446,6 +450,7 @@ function SendAutoSizeAmountInputComponent(
       inlineTokenSymbol={inlineTokenSymbol}
       inlinePrefixGapPx={inlinePrefixGapPx}
       inlineSuffixGapPx={inlineSuffixGapPx}
+      fontFamily={AMOUNT_FONT_FAMILY}
       selectionColor={selectionColor}
       onChangeText={handleChangeText}
       placeholder={placeholder}
@@ -477,7 +482,10 @@ function SendAutoSizeAmountInputComponent(
           maxWidth={wrappedTokenSymbolMaxWidthPx || (md ? '92%' : '96%')}
           mt="$1"
           lineHeight={Math.ceil(wrappedSymbolFontSize * 1.2)}
-          style={{ fontSize: wrappedSymbolFontSize }}
+          style={{
+            fontFamily: AMOUNT_FONT_FAMILY,
+            fontSize: wrappedSymbolFontSize,
+          }}
         >
           {wrappedTokenSymbol}
         </SizableText>


### PR DESCRIPTION
## Summary
- Align the Send amount auto-size input font with the Home total balance font.
- Pass a shared amount font family through the web and native auto-size input implementations.
- Apply the same font family to inline currency/token labels and wrapped token symbols.

## Intent & Context
The user reported that the large Send amount text, shown as `1111 ETH` in the screenshot, should use the same font as the Home page balance amount. The Home balance renders through `NumberSizeableTextWrapper` / `NumberSizeableText` with the app's Roobert font mapping, while the Send amount field uses a custom auto-size input implementation.

## Root Cause
`SendAutoSizeAmountInput` renders the large amount through custom web/native auto-size input components instead of the Home balance number component. Those components set `fontWeight="500"` but did not explicitly pass the Roobert font family, so they could render with a different platform/default font from the Home balance amount.

## Design Decisions
- Keep the existing auto-size input behavior and layout unchanged.
- Add a typed `fontFamily` prop to the shared auto-size input contract.
- Use `webFontFamily` on web and `Roobert-Medium` on native, matching Tamagui's native `fontWeight 500` face mapping.
- Use the native library's existing `fontFamily` prop instead of patching `node_modules`; the native component supports this prop on iOS and Android and falls back safely if a font is unavailable.

## Changes Detail
- `SendAutoSizeAmountInput/index.tsx`: defines the amount font family and passes it to the auto-size input and wrapped token symbol text.
- `AutoSizeInput.types.ts`: adds a typed `fontFamily` field to the shared props.
- `AutoSizeInput.tsx`: applies the font family to the web input, currency prefix, and token suffix.
- `AutoSizeInput.native.tsx`: passes the font family to `AutoSizeInputView` for native rendering.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Visual font rendering in the Send amount field; native font name availability falls back safely in the native library.

## Test plan
- [x] `yarn agent:check --profile commit`
- [x] `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings packages/kit/src/views/Send/components/SendAutoSizeAmountInput/AutoSizeInput.types.ts packages/kit/src/views/Send/components/SendAutoSizeAmountInput/index.tsx packages/kit/src/views/Send/components/SendAutoSizeAmountInput/AutoSizeInput.tsx packages/kit/src/views/Send/components/SendAutoSizeAmountInput/AutoSizeInput.native.tsx`
- [x] `git diff --check`
- [ ] Visual check the Send amount entry on native and web surfaces to confirm the large amount matches the Home balance font.
