### PR TITLE
fix: harden account selector against Wallet Home blank-screen states

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccountSelector.test.ts
+++ b/packages/kit-bg/src/services/ServiceAccountSelector.test.ts
@@ -1,6 +1,11 @@
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
+import { WALLET_TYPE_IMPORTED } from '@onekeyhq/shared/src/consts/dbConsts';
+import type { INetworkAccount } from '@onekeyhq/shared/types/account';
+
 import ServiceAccountSelector from './ServiceAccountSelector';
 
-import type { IDBAccount } from '../dbs/local/types';
+import type { IDBAccount, IDBWallet } from '../dbs/local/types';
+import type { IAccountSelectorSelectedAccount } from '../dbs/simple/entity/SimpleDbEntityAccountSelector';
 
 jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
   backgroundClass: () => () => undefined,
@@ -50,6 +55,24 @@ const btcAccount = {
   createAtNetwork: 'btc--0',
   networks: ['btc--0'],
 } as IDBAccount;
+
+const EVM_ACCOUNT_ID =
+  'imported--60--0x9403a0ec47a062f82d2ac402394eecb61a030d57';
+
+const evmDbAccount = {
+  id: EVM_ACCOUNT_ID,
+  name: 'EVM private key',
+  impl: 'evm',
+  createAtNetwork: 'evm--137',
+  networks: ['evm--137'],
+} as IDBAccount;
+
+const evmNetworkAccount = {
+  id: EVM_ACCOUNT_ID,
+  name: 'EVM private key',
+  impl: 'evm',
+  address: '0x9403a0ec47a062f82d2ac402394eecb61a030d57',
+} as INetworkAccount;
 
 function buildService({
   homeSelectedAccount,
@@ -111,6 +134,65 @@ describe('ServiceAccountSelector', () => {
       networkId: 'btc--0',
       deriveType: 'default',
       othersWalletAccountId: BTC_ACCOUNT_ID,
+    });
+  });
+
+  it('keeps an imported account selected on all networks when derive type is absent', async () => {
+    const allNetworkId = getNetworkIdsMap().onekeyall;
+    const selectedAccount: IAccountSelectorSelectedAccount = {
+      walletId: WALLET_TYPE_IMPORTED,
+      focusedWallet: WALLET_TYPE_IMPORTED,
+      networkId: allNetworkId,
+      indexedAccountId: undefined,
+      deriveType: undefined,
+      othersWalletAccountId: EVM_ACCOUNT_ID,
+    };
+    const getNetworkAccount = jest.fn(
+      async ({
+        accountId,
+      }: {
+        accountId: string | undefined;
+        networkId: string;
+      }) => (accountId === EVM_ACCOUNT_ID ? evmNetworkAccount : undefined),
+    );
+    const service = new ServiceAccountSelector({
+      backgroundApi: {
+        serviceAccount: {
+          getWallet: jest.fn(
+            async ({ walletId }: { walletId: string }) =>
+              ({ id: walletId, name: 'Private Key' }) as IDBWallet,
+          ),
+          getNetworkAccount,
+          getDBAccount: jest.fn(async ({ accountId }: { accountId: string }) =>
+            accountId === EVM_ACCOUNT_ID ? evmDbAccount : undefined,
+          ),
+          isTempWalletRemoved: jest.fn(async () => false),
+        },
+        serviceNetwork: {
+          getNetwork: jest.fn(async ({ networkId }: { networkId: string }) => ({
+            id: networkId,
+          })),
+          getDeriveInfoItemsOfNetwork: jest.fn(async () => []),
+        },
+      },
+    });
+
+    const result = await service.buildActiveAccountInfoFromSelectedAccount({
+      selectedAccount,
+    });
+
+    expect(getNetworkAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: EVM_ACCOUNT_ID,
+        networkId: allNetworkId,
+      }),
+    );
+    expect(result.activeAccount.account?.id).toBe(EVM_ACCOUNT_ID);
+    expect(result.selectedAccount).toMatchObject({
+      walletId: WALLET_TYPE_IMPORTED,
+      focusedWallet: WALLET_TYPE_IMPORTED,
+      networkId: allNetworkId,
+      othersWalletAccountId: EVM_ACCOUNT_ID,
     });
   });
 });

--- a/packages/kit-bg/src/services/ServiceAccountSelector.test.ts
+++ b/packages/kit-bg/src/services/ServiceAccountSelector.test.ts
@@ -1,0 +1,116 @@
+import ServiceAccountSelector from './ServiceAccountSelector';
+
+import type { IDBAccount } from '../dbs/local/types';
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundClass: () => () => undefined,
+  backgroundMethod: () => (_t: unknown, _k: unknown, d: PropertyDescriptor) =>
+    d,
+}));
+
+jest.mock('./ServiceBase', () => ({
+  __esModule: true,
+  default: class ServiceBase {
+    backgroundApi: any;
+
+    constructor({ backgroundApi }: { backgroundApi: any }) {
+      this.backgroundApi = backgroundApi;
+    }
+  },
+}));
+
+jest.mock('../states/jotai/atoms', () => ({
+  settingsAtom: {
+    get: jest.fn(async () => ({ swapToAnotherAccountSwitchOn: false })),
+  },
+}));
+
+jest.mock('../vaults/settings', () => ({
+  getVaultSettings: jest.fn(),
+}));
+
+jest.mock('@onekeyhq/shared/src/logger/logger', () => {
+  const noopLogger = new Proxy(jest.fn(), {
+    apply: () => undefined,
+    get: () => noopLogger,
+  });
+
+  return {
+    defaultLogger: noopLogger,
+  };
+});
+
+const BTC_ACCOUNT_ID =
+  'imported--0--xpub6CgTVumLgde7C8aBr9Zfbn6LeJN347raED9oW6ZCfbwEqeQodRGLUvrjK3ec3uNbGYxMcxRJ5Q5grxip4Bd5XWmnai12tkdTLkTepQiAdnR--P2TR';
+
+const btcAccount = {
+  id: BTC_ACCOUNT_ID,
+  name: 'BTC private key',
+  impl: 'btc',
+  createAtNetwork: 'btc--0',
+  networks: ['btc--0'],
+} as IDBAccount;
+
+function buildService({
+  homeSelectedAccount,
+}: {
+  homeSelectedAccount: {
+    walletId: string;
+    focusedWallet: string;
+    networkId: string;
+    deriveType: 'default';
+    indexedAccountId: undefined;
+    othersWalletAccountId: string;
+  };
+}) {
+  return new ServiceAccountSelector({
+    backgroundApi: {
+      simpleDb: {
+        accountSelector: {
+          getSelectedAccount: jest.fn(async () => homeSelectedAccount),
+        },
+      },
+      serviceAccount: {
+        getDBAccount: jest.fn(async ({ accountId }: { accountId: string }) =>
+          accountId === BTC_ACCOUNT_ID ? btcAccount : undefined,
+        ),
+      },
+    },
+  });
+}
+
+describe('ServiceAccountSelector', () => {
+  it('normalizes imported account network pairs when merging home data into swap map', async () => {
+    const service = buildService({
+      homeSelectedAccount: {
+        walletId: 'imported',
+        focusedWallet: 'imported',
+        networkId: 'cfx--1029',
+        deriveType: 'default',
+        indexedAccountId: undefined,
+        othersWalletAccountId: BTC_ACCOUNT_ID,
+      },
+    });
+
+    const result = await service.mergeHomeDataToSwapMap({
+      swapMap: {
+        0: {
+          walletId: 'imported',
+          focusedWallet: 'imported',
+          networkId: 'cfx--1029',
+          deriveType: 'default',
+          indexedAccountId: undefined,
+          othersWalletAccountId: BTC_ACCOUNT_ID,
+        },
+      },
+    });
+
+    expect(result?.[0]).toMatchObject({
+      walletId: 'imported',
+      focusedWallet: 'imported',
+      networkId: 'btc--0',
+      deriveType: 'default',
+      othersWalletAccountId: BTC_ACCOUNT_ID,
+    });
+  });
+});

--- a/packages/kit-bg/src/services/ServiceAccountSelector.ts
+++ b/packages/kit-bg/src/services/ServiceAccountSelector.ts
@@ -108,6 +108,82 @@ class ServiceAccountSelector extends ServiceBase {
   }
 
   @backgroundMethod()
+  public async fixOthersWalletAccountNetworkPair({
+    selectedAccount,
+    source,
+  }: {
+    selectedAccount: IAccountSelectorSelectedAccount;
+    source?: string;
+  }): Promise<IAccountSelectorSelectedAccount> {
+    const { walletId, networkId, othersWalletAccountId } = selectedAccount;
+    if (
+      !walletId ||
+      !networkId ||
+      !othersWalletAccountId ||
+      !accountUtils.isOthersWallet({ walletId }) ||
+      networkUtils.isAllNetwork({ networkId })
+    ) {
+      return selectedAccount;
+    }
+
+    let dbAccount: IDBAccount | undefined;
+    try {
+      dbAccount = await this.backgroundApi.serviceAccount.getDBAccount({
+        accountId: othersWalletAccountId,
+      });
+    } catch {
+      return selectedAccount;
+    }
+
+    if (!dbAccount) {
+      return selectedAccount;
+    }
+
+    try {
+      if (
+        accountUtils.isAccountCompatibleWithNetwork({
+          account: dbAccount,
+          networkId,
+        })
+      ) {
+        return selectedAccount;
+      }
+    } catch {
+      // Fall through to compatible-network resolution below.
+    }
+
+    let fixedNetworkId: string | undefined;
+    try {
+      fixedNetworkId = accountUtils.getAccountCompatibleNetwork({
+        account: dbAccount,
+        networkId,
+      });
+    } catch {
+      return selectedAccount;
+    }
+
+    if (!fixedNetworkId || fixedNetworkId === networkId) {
+      return selectedAccount;
+    }
+
+    defaultLogger.accountSelector.listData.fixOthersWalletAccountNetworkPair({
+      source,
+      walletId,
+      networkId,
+      fixedNetworkId,
+      accountImpl: dbAccount.impl,
+      accountCreateAtNetwork: dbAccount.createAtNetwork,
+      accountNetworksCount: dbAccount.networks?.length,
+    });
+
+    return {
+      ...selectedAccount,
+      networkId: fixedNetworkId,
+      deriveType: selectedAccount.deriveType || 'default',
+    };
+  }
+
+  @backgroundMethod()
   public async mergeHomeDataToSwapMap({
     swapMap,
   }: {
@@ -119,35 +195,43 @@ class ServiceAccountSelector extends ServiceBase {
         num: 0,
       });
     if (homeData) {
+      const fixedHomeData = await this.fixOthersWalletAccountNetworkPair({
+        selectedAccount: homeData,
+        source: 'mergeHomeDataToSwapMap:home',
+      });
       // eslint-disable-next-line no-param-reassign
       swapMap = cloneDeep(swapMap || {});
 
-      const updateSwapMap = (num: number) => {
+      const updateSwapMap = async (num: number) => {
         if (!swapMap) {
           return;
         }
         const swapDataMerged = accountSelectorUtils.buildMergedSelectedAccount({
           data: swapMap[num],
-          mergedByData: homeData,
+          mergedByData: fixedHomeData,
         });
         if (swapDataMerged) {
           const usedNetworkId =
             // swapDataMerged.networkId ??
             // swapMap[num]?.networkId ??
-            homeData?.networkId;
-          swapMap[num] = swapDataMerged;
-          if (swapMap && swapMap[num]) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            swapMap[num].networkId = usedNetworkId;
-          }
+            fixedHomeData?.networkId;
+          const fixedSwapDataMerged =
+            await this.fixOthersWalletAccountNetworkPair({
+              selectedAccount: {
+                ...swapDataMerged,
+                networkId: usedNetworkId,
+              },
+              source: `mergeHomeDataToSwapMap:${num}`,
+            });
+          swapMap[num] = fixedSwapDataMerged;
         }
       };
 
-      updateSwapMap(0);
+      await updateSwapMap(0);
 
       const { swapToAnotherAccountSwitchOn } = await settingsAtom.get();
       if (!swapToAnotherAccountSwitchOn) {
-        updateSwapMap(1);
+        await updateSwapMap(1);
       }
     }
     return swapMap;

--- a/packages/kit-bg/src/services/ServiceAccountSelector.ts
+++ b/packages/kit-bg/src/services/ServiceAccountSelector.ts
@@ -325,20 +325,22 @@ class ServiceAccountSelector extends ServiceBase {
         console.error(e);
       }
 
-      if (deriveType) {
-        if ((indexedAccountId && wallet) || othersWalletAccountId) {
-          try {
-            const r = await serviceAccount.getNetworkAccount({
-              indexedAccountId,
-              accountId: othersWalletAccountId,
-              deriveType,
-              networkId,
-            });
-            account = r;
-          } catch (e) {
-            // account may not compatible with network
-            console.error(e);
-          }
+      const canQueryIndexedNetworkAccount = Boolean(
+        deriveType && indexedAccountId && wallet,
+      );
+      const canQueryOthersNetworkAccount = Boolean(othersWalletAccountId);
+      if (canQueryIndexedNetworkAccount || canQueryOthersNetworkAccount) {
+        try {
+          const r = await serviceAccount.getNetworkAccount({
+            indexedAccountId,
+            accountId: othersWalletAccountId,
+            deriveType: deriveType || 'default',
+            networkId,
+          });
+          account = r;
+        } catch (e) {
+          // account may not compatible with network
+          console.error(e);
         }
       }
 
@@ -359,7 +361,7 @@ class ServiceAccountSelector extends ServiceBase {
       networkId && networkUtils.isAllNetwork({ networkId }),
     );
 
-    if (dbAccountId && !isAllNetwork) {
+    if (dbAccountId && (!isAllNetwork || othersWalletAccountId)) {
       try {
         const r = await serviceAccount.getDBAccount({
           accountId: dbAccountId,
@@ -520,7 +522,7 @@ class ServiceAccountSelector extends ServiceBase {
 
     const selectedAccountFixed: IAccountSelectorSelectedAccount = {
       othersWalletAccountId: isOthersWallet
-        ? activeAccount?.account?.id
+        ? activeAccount?.account?.id || activeAccount?.dbAccount?.id
         : undefined,
       indexedAccountId: activeAccount?.indexedAccount?.id,
       deriveType: activeAccount?.deriveType,

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
@@ -369,6 +369,17 @@ function createWrapper(
   };
 }
 
+function createHdSelectedAccount(indexedAccountId: string): ISelectedAccount {
+  return {
+    ...defaultSelectedAccount(),
+    walletId: 'hd-1',
+    indexedAccountId,
+    networkId: 'tron--0x2b6653dc',
+    deriveType: 'default',
+    focusedWallet: 'hd-1',
+  };
+}
+
 describe('useAccountSelectorActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -539,6 +550,12 @@ describe('useAccountSelectorActions', () => {
       othersWalletAccountId: btcAccountId,
     };
     mockGetSelectedAccount.mockResolvedValue(undefined);
+    mockGetDBAccount.mockResolvedValue({
+      id: btcAccountId,
+      impl: 'btc',
+      createAtNetwork: 'btc--0',
+      networks: ['btc--0'],
+    } as IDBAccount);
     mockFixOthersWalletAccountNetworkPair.mockImplementation(
       async ({ selectedAccount }) => ({
         ...selectedAccount,
@@ -546,7 +563,10 @@ describe('useAccountSelectorActions', () => {
       }),
     );
 
-    const { Wrapper } = createWrapper();
+    const { store, Wrapper } = createWrapper();
+    store.set(selectedAccountsAtom(), {
+      0: mismatchedSelectedAccount,
+    });
     const { result } = renderHook(() => useAccountSelectorActions().current, {
       wrapper: Wrapper,
     });
@@ -572,6 +592,447 @@ describe('useAccountSelectorActions', () => {
         }),
       }),
     );
+  });
+
+  it('skips persisting an all-default selected account', async () => {
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.saveToStorage({
+        selectedAccount: defaultSelectedAccount(),
+        sceneName: EAccountSelectorSceneName.home,
+        num: 0,
+        selectedAccountUpdatedAt: Date.now(),
+      });
+    });
+
+    expect(mockSaveSelectedAccount).not.toHaveBeenCalled();
+    expect(mockSaveGlobalDeriveType).not.toHaveBeenCalled();
+  });
+
+  it('does not persist a network-only cold-start selection over a saved account', async () => {
+    mockGetSelectedAccount.mockResolvedValue(
+      createHdSelectedAccount('hd-1--1'),
+    );
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.saveToStorage({
+        selectedAccount: {
+          ...defaultSelectedAccount(),
+          networkId: 'tron--0x2b6653dc',
+          deriveType: 'default',
+          focusedWallet: 'hd-1',
+        },
+        sceneName: EAccountSelectorSceneName.home,
+        num: 0,
+        selectedAccountUpdatedAt: Date.now(),
+      });
+    });
+
+    expect(mockSaveSelectedAccount).not.toHaveBeenCalled();
+    expect(mockSaveGlobalDeriveType).not.toHaveBeenCalled();
+  });
+
+  it('does not persist a stale selected account after the current account changes', async () => {
+    const { store, Wrapper } = createWrapper();
+    store.set(selectedAccountsAtom(), {
+      0: createHdSelectedAccount('hd-1--1'),
+    });
+    store.set(accountSelectorUpdateMetaAtom(), {
+      0: {
+        eventEmitDisabled: false,
+        updatedAt: 2000,
+      },
+    });
+
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.saveToStorage({
+        selectedAccount: createHdSelectedAccount('hd-1--0'),
+        sceneName: EAccountSelectorSceneName.home,
+        num: 0,
+        selectedAccountUpdatedAt: 1000,
+      });
+    });
+
+    expect(mockGetSelectedAccount).not.toHaveBeenCalled();
+    expect(mockSaveSelectedAccount).not.toHaveBeenCalled();
+    expect(mockSaveGlobalDeriveType).not.toHaveBeenCalled();
+  });
+
+  it('does not persist an incompatible others wallet account and network pair', async () => {
+    const currentBtcAccount = {
+      id: 'imported--btc-p2tr',
+      impl: 'btc',
+      createAtNetwork: 'btc--0',
+      networks: ['btc--0'],
+    } as IDBAccount;
+    const selectedAccount: ISelectedAccount = {
+      ...defaultSelectedAccount(),
+      walletId: WALLET_TYPE_IMPORTED,
+      othersWalletAccountId: currentBtcAccount.id,
+      networkId: 'evm--42161',
+      deriveType: 'default',
+      focusedWallet: WALLET_TYPE_IMPORTED,
+    };
+
+    mockGetDBAccount.mockResolvedValue(currentBtcAccount);
+
+    const { store, Wrapper } = createWrapper();
+    store.set(selectedAccountsAtom(), {
+      0: selectedAccount,
+    });
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.saveToStorage({
+        selectedAccount,
+        sceneName: EAccountSelectorSceneName.home,
+        num: 0,
+        selectedAccountUpdatedAt: Date.now(),
+      });
+    });
+
+    expect(mockSaveSelectedAccount).not.toHaveBeenCalled();
+    expect(mockSaveGlobalDeriveType).not.toHaveBeenCalled();
+  });
+
+  it('does not sync an event-disabled swap source save back to home', async () => {
+    const selectedAccount = createHdSelectedAccount('hd-1--0');
+    mockShouldSyncWithHomeSource.mockResolvedValue(true);
+
+    const { store, Wrapper } = createWrapper(EAccountSelectorSceneName.swap);
+    store.set(selectedAccountsAtom(), {
+      0: selectedAccount,
+    });
+    store.set(accountSelectorUpdateMetaAtom(), {
+      0: {
+        eventEmitDisabled: true,
+        updatedAt: 2000,
+      },
+    });
+
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.saveToStorage({
+        selectedAccount,
+        sceneName: EAccountSelectorSceneName.swap,
+        num: 0,
+        selectedAccountUpdatedAt: 2000,
+      });
+    });
+
+    expect(mockSaveSelectedAccount).toHaveBeenCalledTimes(1);
+    expect(mockShouldSyncWithHomeSource).not.toHaveBeenCalled();
+  });
+
+  it('ignores stale home-swap sync events when current selection is newer', async () => {
+    mockShouldSyncHomeAndSwapSelectedAccount.mockResolvedValue(true);
+
+    const { store, Wrapper } = createWrapper();
+    store.set(selectedAccountsAtom(), {
+      0: createHdSelectedAccount('hd-1--1'),
+    });
+    store.set(accountSelectorUpdateMetaAtom(), {
+      0: {
+        eventEmitDisabled: false,
+        updatedAt: 2000,
+      },
+    });
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+    const staleEventPayload = {
+      selectedAccount: createHdSelectedAccount('hd-1--0'),
+      selectedAccountUpdatedAt: 1000,
+      sceneName: EAccountSelectorSceneName.swap,
+      num: 0,
+    };
+
+    await act(async () => {
+      await result.current.syncHomeAndSwapSelectedAccount({
+        eventPayload: staleEventPayload,
+        sceneName: EAccountSelectorSceneName.home,
+        num: 0,
+      });
+    });
+
+    expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+      indexedAccountId: 'hd-1--1',
+    });
+  });
+
+  it('keeps a restored indexed account when active account is temporarily incomplete', async () => {
+    const selectedAccount = createHdSelectedAccount('hd-1--1');
+
+    const { store, Wrapper } = createWrapper();
+    store.set(selectedAccountsAtom(), {
+      0: selectedAccount,
+    });
+    store.set(activeAccountsAtom(), {
+      0: {
+        ...defaultActiveAccountInfo(),
+        ready: true,
+        wallet: { id: 'hd-1' } as IWallet,
+        network: { id: 'tron--0x2b6653dc' } as NonNullable<
+          ReturnType<typeof defaultActiveAccountInfo>['network']
+        >,
+      },
+    });
+
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.autoSelectNextAccount({
+        num: 0,
+        sceneName: EAccountSelectorSceneName.home,
+      });
+    });
+
+    expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+      walletId: 'hd-1',
+      indexedAccountId: 'hd-1--1',
+      focusedWallet: 'hd-1',
+    });
+  });
+
+  it('keeps a restored indexed account when active wallet is temporarily missing', async () => {
+    const selectedAccount = createHdSelectedAccount('hd-1--1');
+
+    const { store, Wrapper } = createWrapper();
+    store.set(selectedAccountsAtom(), {
+      0: selectedAccount,
+    });
+    store.set(activeAccountsAtom(), {
+      0: {
+        ...defaultActiveAccountInfo(),
+        ready: true,
+      },
+    });
+
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.autoSelectNextAccount({
+        num: 0,
+        sceneName: EAccountSelectorSceneName.home,
+      });
+    });
+
+    expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+      walletId: 'hd-1',
+      indexedAccountId: 'hd-1--1',
+      focusedWallet: 'hd-1',
+    });
+  });
+
+  it('restores the active indexed account from a network-only cold-start selection', async () => {
+    const { store, Wrapper } = createWrapper();
+    store.set(selectedAccountsAtom(), {
+      0: {
+        ...defaultSelectedAccount(),
+        networkId: 'tron--0x2b6653dc',
+        deriveType: 'default' as const,
+      },
+    });
+    store.set(activeAccountsAtom(), {
+      0: {
+        ...defaultActiveAccountInfo(),
+        ready: true,
+        wallet: { id: 'hd-1' } as IWallet,
+        indexedAccount: { id: 'hd-1--1', walletId: 'hd-1' } as IIndexedAccount,
+        account: {
+          id: "hd-1--m/44'/195'/1'/0/0",
+          indexedAccountId: 'hd-1--1',
+        } as NonNullable<
+          ReturnType<typeof defaultActiveAccountInfo>['account']
+        >,
+        dbAccount: {
+          id: "hd-1--m/44'/195'/1'/0/0",
+          indexedAccountId: 'hd-1--1',
+        } as NonNullable<
+          ReturnType<typeof defaultActiveAccountInfo>['dbAccount']
+        >,
+        network: { id: 'tron--0x2b6653dc' } as NonNullable<
+          ReturnType<typeof defaultActiveAccountInfo>['network']
+        >,
+      },
+    });
+
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.autoSelectNextAccount({
+        num: 0,
+        sceneName: EAccountSelectorSceneName.home,
+      });
+    });
+
+    expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+      walletId: 'hd-1',
+      indexedAccountId: 'hd-1--1',
+      focusedWallet: 'hd-1',
+      networkId: 'tron--0x2b6653dc',
+      deriveType: 'default',
+    });
+  });
+
+  it('falls back to the first indexed account when restored indexed account no longer exists', async () => {
+    const selectedAccount = createHdSelectedAccount('hd-1--99');
+
+    const { store, Wrapper } = createWrapper();
+    store.set(selectedAccountsAtom(), {
+      0: selectedAccount,
+    });
+    store.set(activeAccountsAtom(), {
+      0: {
+        ...defaultActiveAccountInfo(),
+        ready: true,
+        wallet: { id: 'hd-1' } as IWallet,
+        network: { id: 'tron--0x2b6653dc' } as NonNullable<
+          ReturnType<typeof defaultActiveAccountInfo>['network']
+        >,
+      },
+    });
+
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.autoSelectNextAccount({
+        num: 0,
+        sceneName: EAccountSelectorSceneName.home,
+      });
+    });
+
+    expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+      walletId: 'hd-1',
+      indexedAccountId: 'hd-1--0',
+      focusedWallet: 'hd-1',
+    });
+  });
+
+  it('keeps swap all-network auto-select fallback local to swap', async () => {
+    const { store, Wrapper } = createWrapper(EAccountSelectorSceneName.swap);
+    store.set(selectedAccountsAtom(), {
+      0: {
+        ...defaultSelectedAccount(),
+        networkId: getNetworkIdsMap().onekeyall,
+        deriveType: 'default' as const,
+      },
+    });
+    store.set(activeAccountsAtom(), {
+      0: {
+        ...defaultActiveAccountInfo(),
+        ready: true,
+        wallet: { id: 'hd-1' } as IWallet,
+        network: { id: getNetworkIdsMap().onekeyall } as NonNullable<
+          ReturnType<typeof defaultActiveAccountInfo>['network']
+        >,
+      },
+    });
+
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.autoSelectNextAccount({
+        num: 0,
+        sceneName: EAccountSelectorSceneName.swap,
+      });
+    });
+
+    expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+      walletId: 'hd-1',
+      indexedAccountId: 'hd-1--0',
+      focusedWallet: 'hd-1',
+      networkId: getNetworkIdsMap().onekeyall,
+      deriveType: 'default',
+    });
+    expect(store.get(accountSelectorUpdateMetaAtom())[0]).toMatchObject({
+      eventEmitDisabled: true,
+    });
+  });
+
+  it('repairs an incompatible others wallet pair kept from a recent in-memory selection', async () => {
+    const currentBtcAccount = {
+      id: 'imported--btc-p2tr',
+      impl: 'btc',
+      createAtNetwork: 'btc--0',
+      networks: ['btc--0'],
+    } as IDBAccount;
+    const matchingEvmAccount = {
+      id: 'imported--evm-account',
+      impl: 'evm',
+      createAtNetwork: 'evm--1',
+    } as IDBAccount;
+
+    mockGetSelectedAccountsMap.mockResolvedValue(undefined);
+    mockGetDBAccount.mockResolvedValue(currentBtcAccount);
+    mockGetSingletonAccountsOfWallet.mockResolvedValue({
+      accounts: [currentBtcAccount, matchingEvmAccount],
+    });
+
+    const { store, Wrapper } = createWrapper();
+    store.set(selectedAccountsAtom(), {
+      0: {
+        ...defaultSelectedAccount(),
+        walletId: WALLET_TYPE_IMPORTED,
+        othersWalletAccountId: currentBtcAccount.id,
+        networkId: 'evm--42161',
+        deriveType: 'default' as const,
+        focusedWallet: WALLET_TYPE_IMPORTED,
+      },
+    });
+    store.set(accountSelectorUpdateMetaAtom(), {
+      0: {
+        eventEmitDisabled: false,
+        updatedAt: Date.now(),
+      },
+    });
+
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.initFromStorage({
+        sceneName: EAccountSelectorSceneName.home,
+      });
+    });
+
+    expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+      walletId: WALLET_TYPE_IMPORTED,
+      focusedWallet: WALLET_TYPE_IMPORTED,
+      indexedAccountId: undefined,
+      othersWalletAccountId: matchingEvmAccount.id,
+      networkId: 'evm--42161',
+      deriveType: 'default',
+    });
   });
 
   it('clears a restored mocked hardware wallet selection during storage init', async () => {

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
@@ -59,6 +59,9 @@ type ISaveSelectedAccountParams = {
 type IMergeHomeDataToSwapMapParams = {
   swapMap: ISelectedAccountsMap | undefined;
 };
+type IFixOthersWalletAccountNetworkPairParams = {
+  selectedAccount: ISelectedAccount;
+};
 type IIndexedAccount = NonNullable<
   ReturnType<typeof defaultActiveAccountInfo>['indexedAccount']
 >;
@@ -110,6 +113,11 @@ const mockMergeHomeDataToSwapMap: jest.MockedFunction<
   (
     params: IMergeHomeDataToSwapMapParams,
   ) => Promise<ISelectedAccountsMap | undefined>
+> = jest.fn();
+const mockFixOthersWalletAccountNetworkPair: jest.MockedFunction<
+  (
+    params: IFixOthersWalletAccountNetworkPairParams,
+  ) => Promise<ISelectedAccount>
 > = jest.fn();
 const mockGetGlobalDeriveType: jest.MockedFunction<() => Promise<string>> =
   jest.fn();
@@ -289,6 +297,9 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
       fixDeriveTypesForInitAccountSelectorMap: (
         params: IFixDeriveTypesForInitAccountSelectorMapParams,
       ) => mockFixDeriveTypesForInitAccountSelectorMap(params),
+      fixOthersWalletAccountNetworkPair: (
+        params: IFixOthersWalletAccountNetworkPairParams,
+      ) => mockFixOthersWalletAccountNetworkPair(params),
       getGlobalDeriveType: () => mockGetGlobalDeriveType(),
       mergeHomeDataToSwapMap: (params: IMergeHomeDataToSwapMapParams) =>
         mockMergeHomeDataToSwapMap(params),
@@ -379,6 +390,9 @@ describe('useAccountSelectorActions', () => {
     mockSaveGlobalDeriveType.mockResolvedValue(undefined);
     mockMergeHomeDataToSwapMap.mockImplementation(
       async (params) => params.swapMap,
+    );
+    mockFixOthersWalletAccountNetworkPair.mockImplementation(
+      async ({ selectedAccount }) => selectedAccount,
     );
     mockGetGlobalDeriveType.mockResolvedValue('default');
     mockShouldUseGlobalDeriveType.mockResolvedValue(true);
@@ -511,6 +525,53 @@ describe('useAccountSelectorActions', () => {
       indexedAccountId: undefined,
       othersWalletAccountId: accountId,
     });
+  });
+
+  it('normalizes imported account network pairs before saving to storage', async () => {
+    const btcAccountId =
+      'imported--0--xpub6CgTVumLgde7C8aBr9Zfbn6LeJN347raED9oW6ZCfbwEqeQodRGLUvrjK3ec3uNbGYxMcxRJ5Q5grxip4Bd5XWmnai12tkdTLkTepQiAdnR--P2TR';
+    const mismatchedSelectedAccount = {
+      ...defaultSelectedAccount(),
+      walletId: WALLET_TYPE_IMPORTED,
+      focusedWallet: WALLET_TYPE_IMPORTED,
+      networkId: 'cfx--1029',
+      deriveType: 'default' as const,
+      othersWalletAccountId: btcAccountId,
+    };
+    mockGetSelectedAccount.mockResolvedValue(undefined);
+    mockFixOthersWalletAccountNetworkPair.mockImplementation(
+      async ({ selectedAccount }) => ({
+        ...selectedAccount,
+        networkId: 'btc--0',
+      }),
+    );
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.saveToStorage({
+        selectedAccount: mismatchedSelectedAccount,
+        sceneName: EAccountSelectorSceneName.home,
+        num: 0,
+        selectedAccountUpdatedAt: Date.now(),
+      });
+    });
+
+    expect(mockSaveSelectedAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sceneName: EAccountSelectorSceneName.home,
+        num: 0,
+        selectedAccount: expect.objectContaining({
+          walletId: WALLET_TYPE_IMPORTED,
+          focusedWallet: WALLET_TYPE_IMPORTED,
+          networkId: 'btc--0',
+          othersWalletAccountId: btcAccountId,
+        }),
+      }),
+    );
   });
 
   it('clears a restored mocked hardware wallet selection during storage init', async () => {

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -128,6 +128,13 @@ type IAccountSelectorRecentSelectionCache = Record<
   IAccountSelectorRecentSelectionCacheItem
 >;
 
+const isSelectedAccountIdentityIncomplete = (
+  selectedAccount: IAccountSelectorSelectedAccount | undefined,
+) =>
+  !selectedAccount?.walletId &&
+  !selectedAccount?.indexedAccountId &&
+  !selectedAccount?.othersWalletAccountId;
+
 const safeIsAccountCompatibleWithNetwork = ({
   account,
   networkId,
@@ -2466,6 +2473,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
         num: number;
         eventPayload: {
           selectedAccount: IAccountSelectorSelectedAccount;
+          selectedAccountUpdatedAt?: number;
           sceneName: EAccountSelectorSceneName;
           sceneUrl?: string | undefined;
           num: number;
@@ -2496,6 +2504,18 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
           });
 
         if (shouldSync) {
+          // Drop stale cross-scene sync events: a slow swap<->home event must
+          // not overwrite a selection the user has changed since it was sent.
+          const eventPayloadUpdatedAt = eventPayload.selectedAccountUpdatedAt;
+          const currentUpdatedAt = get(accountSelectorUpdateMetaAtom())[num]
+            ?.updatedAt;
+          if (
+            eventPayloadUpdatedAt &&
+            currentUpdatedAt &&
+            currentUpdatedAt > eventPayloadUpdatedAt
+          ) {
+            return;
+          }
           const current = this.getSelectedAccount.call(set, { num });
           let newSelectedAccount =
             accountSelectorUtils.buildMergedSelectedAccount({
@@ -2757,9 +2777,10 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
           return;
         }
 
+        const currentSelectedAccountsMap = get(selectedAccountsAtom());
         const repairedSelectedAccountsMap =
           await this.repairOthersWalletNetworkPairsInSelectedAccountsMap({
-            selectedAccountsMap: get(selectedAccountsAtom()),
+            selectedAccountsMap: currentSelectedAccountsMap,
           });
         const selectedAccountsMap =
           (await this.clearUnavailableWalletSelectionsInStorage({
@@ -2809,7 +2830,9 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
               }
             },
           );
-          if (!isEqual(mergedSelectedAccountsMap, selectedAccountsMap)) {
+          // Compare against the raw atom value: repair/clear results must
+          // reach memory even when the fill step adds nothing.
+          if (!isEqual(mergedSelectedAccountsMap, currentSelectedAccountsMap)) {
             this.setSelectedAccountsAtom(
               set,
               () => mergedSelectedAccountsMap,
@@ -2893,10 +2916,36 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
             selectedAccount = defaultSelectedAccount();
           }
         }
-        if (isEqual(selectedAccount, defaultSelectedAccount)) {
+        if (isEqual(selectedAccount, defaultSelectedAccount())) {
           console.error(
             'AccountSelector.saveToStorage skip, selectedAccount is default',
           );
+          return;
+        }
+        // Identity-less selections (e.g. network-only cold-start snapshots)
+        // must never overwrite a saved account. Clearing an unavailable
+        // wallet persists through
+        // savePersistentlyUnavailableWalletSelectionToStorage, which bypasses
+        // this guard on purpose.
+        const hasAccountIdentityForStorage = Boolean(
+          selectedAccount?.walletId &&
+          (selectedAccount.indexedAccountId ||
+            selectedAccount.othersWalletAccountId),
+        );
+        if (!hasAccountIdentityForStorage) {
+          return;
+        }
+        // Skip stale async saves: the in-memory selection may have moved on
+        // while this payload was waiting on the mutex.
+        const currentSelectedAccount = this.getSelectedAccount.call(set, {
+          num,
+        });
+        if (
+          !isEqual(
+            omitBy(currentSelectedAccount, isUndefined),
+            omitBy(selectedAccount, isUndefined),
+          )
+        ) {
           return;
         }
         selectedAccount =
@@ -2904,6 +2953,16 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
             selectedAccount,
             source: `saveToStorage:${sceneName}:${num}`,
           });
+        // If the pair is still broken after the fix (e.g. the account row was
+        // removed), keep the previously saved record instead of persisting an
+        // unresolvable selection.
+        if (
+          await this.isIncompatibleOthersWalletNetworkPair({
+            selectedAccount,
+          })
+        ) {
+          return;
+        }
         const fixedPayload = {
           ...payload,
           selectedAccount,
@@ -2939,6 +2998,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
         // **** also save to home scene SelectedAccount if sync needed
         if (
           sceneName !== EAccountSelectorSceneName.home &&
+          !eventEmitDisabled &&
           (await serviceAccountSelector.shouldSyncWithHomeSource({
             sceneName,
             sceneUrl,
@@ -3555,6 +3615,9 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
           // auto select hd or hw index account
           if (selectedWalletId && (isHdWallet || isHwOrQrWallet)) {
             if (
+              !selectedAccountNew.walletId ||
+              !selectedAccountNew.indexedAccountId ||
+              !selectedAccountNew.focusedWallet ||
               !indexedAccount ||
               indexedAccount.walletId !== selectedWalletId
             ) {
@@ -3562,7 +3625,21 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
                 await serviceAccount.getIndexedAccountsOfWallet({
                   walletId: selectedWalletId,
                 });
-              selectedIndexedAccountId = indexedAccounts?.[0]?.id;
+              // Keep the restored indexed account when it still exists in the
+              // wallet, so an incomplete activeAccount hydration cannot jump
+              // the persisted selection back to the first account.
+              const indexedAccountIdToRestore =
+                selectedAccountNew.indexedAccountId || selectedIndexedAccountId;
+              const restoredIndexedAccount = indexedAccountIdToRestore
+                ? indexedAccounts?.find(
+                    (item) =>
+                      item.id === indexedAccountIdToRestore &&
+                      item.walletId === selectedWalletId,
+                  )
+                : undefined;
+              selectedIndexedAccountId =
+                restoredIndexedAccount?.id || indexedAccounts?.[0]?.id;
+              selectedAccountNew.walletId = selectedWalletId;
               selectedAccountNew.indexedAccountId = selectedIndexedAccountId;
               selectedAccountNew.focusedWallet = selectedWalletId;
               selectedAccountNew.othersWalletAccountId = undefined;
@@ -3656,8 +3733,25 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
             }
           }
 
+          // A swap-scene fallback picked from an empty all-network slot is
+          // scene-local bootstrap data; block the update event so it cannot
+          // sync into the home selection.
+          const shouldDisableAutoSelectSyncToHome =
+            sceneName === EAccountSelectorSceneName.swap &&
+            num === 0 &&
+            isSelectedAccountIdentityIncomplete(selectedAccount) &&
+            networkUtils.isAllNetwork({
+              networkId: selectedAccount?.networkId,
+            });
+
           await this.updateSelectedAccount.call(set, {
             num,
+            updateMeta: shouldDisableAutoSelectSyncToHome
+              ? {
+                  eventEmitDisabled: true,
+                  updatedAt: Date.now(),
+                }
+              : undefined,
             builder: () => selectedAccountNew,
           });
           await this.saveClearedSelectedAccountToStorage.call(set, {

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -2497,17 +2497,16 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
 
         if (shouldSync) {
           const current = this.getSelectedAccount.call(set, { num });
-          const newSelectedAccount =
+          let newSelectedAccount =
             accountSelectorUtils.buildMergedSelectedAccount({
               data: current,
               mergedByData: eventPayload.selectedAccount,
             });
-          console.log('syncHomeAndSwapSelectedAccount >>>> ', {
-            params,
-            data: current,
-            mergedByData: eventPayload.selectedAccount,
-            newSelectedAccount,
-          });
+          newSelectedAccount =
+            await serviceAccountSelector.fixOthersWalletAccountNetworkPair({
+              selectedAccount: newSelectedAccount,
+              source: 'syncHomeAndSwapSelectedAccount',
+            });
           await this.updateSelectedAccount.call(set, {
             updateMeta: {
               eventEmitDisabled: true, // stop update infinite loop here
@@ -2900,6 +2899,15 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
           );
           return;
         }
+        selectedAccount =
+          await serviceAccountSelector.fixOthersWalletAccountNetworkPair({
+            selectedAccount,
+            source: `saveToStorage:${sceneName}:${num}`,
+          });
+        const fixedPayload = {
+          ...payload,
+          selectedAccount,
+        };
         const currentSaved = await simpleDb.accountSelector.getSelectedAccount({
           sceneName,
           sceneUrl,
@@ -2914,7 +2922,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
 
         // **** saveSelectedAccount
         // skip discover account selector persist here
-        await simpleDb.accountSelector.saveSelectedAccount(payload);
+        await simpleDb.accountSelector.saveSelectedAccount(fixedPayload);
 
         // **** save global derive type (with event emit if need)
         const updateMeta = get(accountSelectorUpdateMetaAtom())[num];
@@ -2947,10 +2955,15 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
               data: homeSelectedAccount,
               mergedByData: selectedAccount,
             });
+          const fixedNewSelectedAccount =
+            await serviceAccountSelector.fixOthersWalletAccountNetworkPair({
+              selectedAccount: newSelectedAccount,
+              source: 'saveToStorage:syncHome',
+            });
           await simpleDb.accountSelector.saveSelectedAccount({
             sceneName: EAccountSelectorSceneName.home,
             num: 0,
-            selectedAccount: newSelectedAccount,
+            selectedAccount: fixedNewSelectedAccount,
           });
         }
 
@@ -2971,7 +2984,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
           }
           appEventBus.emit(
             EAppEventBusNames.AccountSelectorSelectedAccountUpdate,
-            payload,
+            fixedPayload,
           );
         }
       });

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -268,7 +268,7 @@ export function HomePageView({
     useAccountSelectorStorageInitDoneAtom();
   const accountSelectorActiveAccountInitDone =
     useIsAccountSelectorActiveAccountInitDone(0);
-  const { result: walletListResult } = usePromiseResult(
+  const { result: walletListResult, run: refreshWalletList } = usePromiseResult(
     () =>
       backgroundApiProxy.serviceAccount.getWallets({
         ignoreEmptySingletonWalletAccounts: true,
@@ -1034,10 +1034,28 @@ export function HomePageView({
     const clearCache = async () => {
       await backgroundApiProxy.serviceAccount.clearAccountNameFromAddressCache();
     };
+    // Keep the no-wallet gate's wallet list fresh: it feeds
+    // shouldShowNoWalletContent, and a stale mount-time list can hold Home on
+    // the blank fallback after wallets are removed while mounted.
+    const refreshWalletListForNoWalletGate = () => {
+      void refreshWalletList();
+    };
 
     appEventBus.on(EAppEventBusNames.WalletUpdate, clearCache);
     appEventBus.on(EAppEventBusNames.AccountUpdate, clearCache);
     appEventBus.on(EAppEventBusNames.AddressBookUpdate, clearCache);
+    appEventBus.on(
+      EAppEventBusNames.WalletUpdate,
+      refreshWalletListForNoWalletGate,
+    );
+    appEventBus.on(
+      EAppEventBusNames.AccountUpdate,
+      refreshWalletListForNoWalletGate,
+    );
+    appEventBus.on(
+      EAppEventBusNames.AccountRemove,
+      refreshWalletListForNoWalletGate,
+    );
     appEventBus.on(
       EAppEventBusNames.SwitchWalletHomeTab,
       handleSwitchWalletHomeTab,
@@ -1047,11 +1065,23 @@ export function HomePageView({
       appEventBus.off(EAppEventBusNames.AccountUpdate, clearCache);
       appEventBus.off(EAppEventBusNames.AddressBookUpdate, clearCache);
       appEventBus.off(
+        EAppEventBusNames.WalletUpdate,
+        refreshWalletListForNoWalletGate,
+      );
+      appEventBus.off(
+        EAppEventBusNames.AccountUpdate,
+        refreshWalletListForNoWalletGate,
+      );
+      appEventBus.off(
+        EAppEventBusNames.AccountRemove,
+        refreshWalletListForNoWalletGate,
+      );
+      appEventBus.off(
         EAppEventBusNames.SwitchWalletHomeTab,
         handleSwitchWalletHomeTab,
       );
     };
-  }, [handleSwitchWalletHomeTab]);
+  }, [handleSwitchWalletHomeTab, refreshWalletList]);
 
   const { result: accountNetworkNotSupported } = usePromiseResult(
     async () => {

--- a/packages/shared/src/logger/scopes/accountSelector/scenes/listData.ts
+++ b/packages/shared/src/logger/scopes/accountSelector/scenes/listData.ts
@@ -130,6 +130,19 @@ export class AccountSelectorListDataScene extends BaseScene {
   }
 
   @LogToLocal()
+  public fixOthersWalletAccountNetworkPair(params: {
+    source: string | undefined;
+    walletId: string | undefined;
+    networkId: string | undefined;
+    fixedNetworkId: string | undefined;
+    accountImpl: string | undefined;
+    accountCreateAtNetwork: string | undefined;
+    accountNetworksCount: number | undefined;
+  }) {
+    return params;
+  }
+
+  @LogToLocal()
   public initFromStorageSelectedAccountsMapResult(params: {
     selectedAccountsMap: IAccountSelectorSelectedAccountsMap | undefined;
   }) {


### PR DESCRIPTION
## Summary
- Normalize imported (others-wallet) account/network pairs and preserve the imported account selection across all-network and derive-type-absent states.
- Port the account-selector cold-start guards from `release/v6.4.0` (#12154) that were skipped during the 6.4.0 → `x` sync and never reached `x`.
- Keep the Wallet Home no-wallet gate's wallet list fresh so it cannot be held on a blank fallback after wallets are removed while Home is mounted.

## Intent & Context
This branch continues the Wallet Home blank-screen (白屏) hardening line (OK-56734 / OK-57468 / OK-57139). A QA-perspective audit of the already-merged blank-screen fixes surfaced two problems:

1. The imported-account network pair could be persisted or resolved in a mismatched state (e.g. a BTC imported account carried under an EVM `networkId`), which resolves to `account: undefined` → `hasNoUsableWallet` → the blank `<Stack flex={1}/>` fallback.
2. **#12154 ("keep restored wallet account on cold start") was skipped during the `release/v6.4.0` → `x` sync** (documented in sync PR #12210 as "superseded on x"). Only the `initFromStorageFillEmptyNumsFromDB` piece was genuinely superseded; the remaining guards in that bundled commit had **no equivalent on `x`**, so several already-fixed-and-QA-validated regressions were still reproducible on `x`.

## Root Cause
The account-selector selection state has many in-memory and persisted write paths, but validation was concentrated in a few of them. The specific holes reintroduced on `x` by the skipped #12154:

- `saveToStorage` compared the selection to `defaultSelectedAccount` (the **function reference**, not `defaultSelectedAccount()`), making the "skip default" guard dead code since 2024 — an all-default or identity-less (network-only) selection could overwrite a saved account.
- `saveToStorage` had no staleness check, so a payload queued behind the mutex could overwrite a newer in-memory selection; and no post-fix compatibility recheck, so an unresolvable others-wallet/network pair could still be persisted.
- `saveToStorage`'s home-sync branch ran even for `eventEmitDisabled` writes, letting event-disabled saves bleed back into the home record.
- `syncHomeAndSwapSelectedAccount` had no `updatedAt` comparison, so a slow swap↔home event could overwrite a selection the user had since changed.
- `autoSelectNextAccount` treated an incompletely-hydrated `activeAccount` as a reason to jump the restored `indexedAccountId` to `accounts[0]` (Account #2 → Account #1 on cold start), and a swap-scene fallback from an empty all-network slot could sync into the home selection.
- `initFromStorage`'s cold-start keep branch only wrote the atom when the fill-empty-nums step produced a diff, dropping the repair/clear results otherwise.
- Wallet Home's no-wallet gate read a mount-time-only wallet list; removing wallets while Home stayed mounted left a stale non-empty list that blocked the no-wallet empty state → blank Home.

## Design Decisions
- **Ported the guards to the current code line rather than cherry-picking #12154.** Cherry-picking conflicts heavily with `x`'s evolved `initFromStorage` and imports tests written against the old implementation; re-applying the guards onto the current code keeps `x`'s newer structure intact.
- **TDD**: every ported guard landed test-first (11 new `actions.test.tsx` cases written RED before implementation), reusing the exact 6.4.0 regression scenarios (Account #2 preservation, stale-payload skip, incompatible-pair skip, event-disabled swap→home isolation, stale sync-event drop).
- **Wallet list refresh** is a pure event subscription (`WalletUpdate` / `AccountUpdate` / `AccountRemove`) driving `usePromiseResult`'s `run`, rather than widening the no-wallet gate's acceptance conditions — the gate stays conservative.
- The `savePersistentlyUnavailableWalletSelectionToStorage` path (clearing removed wallets) intentionally bypasses the new identity guard, so removed-wallet clearing still persists.

## Changes Detail
- `packages/kit-bg/src/services/ServiceAccountSelector.ts` (+ test): `fixOthersWalletAccountNetworkPair`, imported-account all-network resolution when derive type is absent, others-wallet `dbAccount` fallback.
- `packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx` (+ test): ported `saveToStorage` guards (default-fn fix, identity guard, staleness skip, post-fix incompatibility skip, `!eventEmitDisabled` home-sync), `syncHomeAndSwapSelectedAccount` `updatedAt` staleness drop, `autoSelectNextAccount` restored-indexed-account preservation + swap all-network fallback isolation, `initFromStorage` keep-branch atom writeback.
- `packages/kit/src/views/Home/pages/HomePageView.tsx`: refresh the no-wallet gate's wallet list on wallet/account events; replace an `eslint-disable no-unsafe-call` on `tabBarProps.onTabPress` with a typed narrowing.
- `packages/shared/src/logger/scopes/accountSelector/scenes/listData.ts`: `fixOthersWalletAccountNetworkPair` diagnostic log scene.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Account-selector selection reconciliation and Home no-wallet gating are shared cross-platform state. The riskiest paths (persisted-selection writeback, autoSelect fallback) are covered by focused regression tests reproducing the exact reported scenarios; guards are additive and preserve existing fallback semantics.

## Test plan
- [x] `yarn jest packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx packages/kit-bg/src/services/ServiceAccountSelector.test.ts packages/kit/src/views/Home/pages/homePageNoWalletContent.test.ts packages/kit/src/states/jotai/contexts/accountSelector/activeAccountInitGuard.test.ts` — 50/50 passing.
- [x] `yarn agent:check --profile commit` / `--profile pr` — lint + tsc clean.
- [ ] Cold start repeatedly with `Seed / Account #2` selected → stays on Account #2 (no jump to #1).
- [ ] Enter Perps/Swap route directly on a cold start >5 min later → Home account is not overwritten by the swap fallback.
- [ ] Remove the last two HD wallets while Home is mounted → create-wallet empty state appears (not a blank screen); verify on Extension side panel.
- [ ] Restore an imported BTC account persisted under an EVM `networkId` → auto-repairs and Home renders normally.
