### PR TITLE
fix: adjust iOS header spacing(OK-57793)

### DIFF
--- a/packages/kit/src/views/Developer/pages/Gallery/Components/index.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { useHeaderHeight } from '@react-navigation/elements';
 import { useNavigation } from '@react-navigation/native';
 import natsort from 'natsort';
 
@@ -35,7 +36,13 @@ const Index = () => {
   }
 
   const tabBarHeight = useScrollContentTabBarOffset();
-  const topPadding = platformEnv.isNativeIOS ? '$10' : undefined;
+  const headerHeight = useHeaderHeight();
+  let topPadding: number | '$10' | undefined;
+  if (platformEnv.isNativeIOS26Plus) {
+    topPadding = headerHeight;
+  } else if (platformEnv.isNativeIOS) {
+    topPadding = '$10';
+  }
   return (
     <Page>
       <Page.Body pt={topPadding}>

--- a/packages/kit/src/views/Developer/pages/Gallery/Components/stories/utils/Layout.tsx
+++ b/packages/kit/src/views/Developer/pages/Gallery/Components/stories/utils/Layout.tsx
@@ -1,6 +1,7 @@
 import type { ComponentType, ReactElement } from 'react';
 import { useState } from 'react';
 
+import { useHeaderHeight } from '@react-navigation/elements';
 import { StackActions } from '@react-navigation/native';
 
 import {
@@ -91,6 +92,10 @@ export function Layout({
   const contentWidth = wideScreen ? 1440 : 576;
   const [settings] = useSettingsPersistAtom();
   const isDarkTheme = settings.theme === 'dark';
+  const headerHeight = useHeaderHeight();
+  const scrollViewPaddingTop = platformEnv.isNativeIOS26Plus
+    ? headerHeight + 20
+    : 20;
 
   const toggleTheme = async (isDark: boolean) => {
     await backgroundApiProxy.serviceSetting.setTheme(isDark ? 'dark' : 'light');
@@ -105,7 +110,7 @@ export function Layout({
         marginBottom={keyboardHeight}
         paddingHorizontal="$5"
         contentContainerStyle={{
-          paddingTop: 20,
+          paddingTop: scrollViewPaddingTop,
           paddingBottom: 280,
         }}
         keyboardDismissMode="on-drag"

--- a/packages/kit/src/views/Developer/pages/SignatureRecord.tsx
+++ b/packages/kit/src/views/Developer/pages/SignatureRecord.tsx
@@ -1,8 +1,11 @@
 import { useCallback, useRef, useState } from 'react';
 
+import { useHeaderHeight } from '@react-navigation/elements';
+
 import { Button, Dialog, Input, Page, YStack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { EMessageTypesEth } from '@onekeyhq/shared/types/message';
 import { ETransactionType } from '@onekeyhq/shared/types/signatureRecord';
@@ -149,9 +152,11 @@ const CustomSignMessage = ({ num }: { num: number }) => {
 
 const DevHomeStack2 = () => {
   const num = 0;
+  const headerHeight = useHeaderHeight();
+  const topPadding = platformEnv.isNativeIOS26Plus ? headerHeight : undefined;
   return (
     <Page>
-      <YStack px="$4" gap="$4">
+      <YStack px="$4" pt={topPadding} gap="$4">
         <SignMessageButton />
         <SignTransactionButton />
         <ConnectSiteButton />

--- a/packages/kit/src/views/Developer/pages/TabDeveloper.tsx
+++ b/packages/kit/src/views/Developer/pages/TabDeveloper.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { memo, useCallback, useState } from 'react';
 
+import { useHeaderHeight } from '@react-navigation/elements';
 import { StyleSheet } from 'react-native';
 
 import {
@@ -168,6 +169,8 @@ const TestRefresh = memo(TestRefreshCmp);
 
 const TabDeveloper = () => {
   const tabBarHeight = useScrollContentTabBarOffset();
+  const headerHeight = useHeaderHeight();
+  const bodyPaddingTop = platformEnv.isNativeIOS26Plus ? headerHeight : 0;
   const navigation =
     useAppNavigation<IPageNavigationProp<ITabDeveloperParamList>>();
 
@@ -179,7 +182,7 @@ const TabDeveloper = () => {
       enabledNum={[0]}
     >
       <Page>
-        <Page.Body>
+        <Page.Body pt={bodyPaddingTop}>
           <ScrollView
             flex={1}
             width="100%"

--- a/packages/kit/src/views/Home/components/PullToRefresh/index.tsx
+++ b/packages/kit/src/views/Home/components/PullToRefresh/index.tsx
@@ -1,6 +1,16 @@
-import { memo, useCallback, useState } from 'react';
+import {
+  createContext,
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import type { PropsWithChildren } from 'react';
 
-import { RefreshControl } from '@onekeyhq/components';
+import { RefreshControl, useTheme } from '@onekeyhq/components';
+import type { IRefreshControlType } from '@onekeyhq/components';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -15,12 +25,63 @@ export const onHomePageRefresh = () => {
   });
 };
 
-export interface IPullToRefreshProps {
+const HomePullToRefreshOffsetContext = createContext<number | undefined>(
+  undefined,
+);
+
+export function HomePullToRefreshProvider({
+  children,
+  progressViewOffset,
+}: PropsWithChildren<{ progressViewOffset?: number }>) {
+  const value = useMemo(() => progressViewOffset, [progressViewOffset]);
+
+  return (
+    <HomePullToRefreshOffsetContext.Provider value={value}>
+      {children}
+    </HomePullToRefreshOffsetContext.Provider>
+  );
+}
+
+export interface IPullToRefreshProps extends Omit<
+  IRefreshControlType,
+  'onRefresh' | 'refreshing'
+> {
   onRefresh: () => void;
 }
 
 function BasePullToRefresh({ onRefresh, ...props }: IPullToRefreshProps) {
   const [refreshing, setRefreshing] = useState(false);
+  const theme = useTheme();
+  const progressViewOffsetFromContext = useContext(
+    HomePullToRefreshOffsetContext,
+  );
+  const shouldUseContextProgressViewOffset =
+    platformEnv.isNativeIOS &&
+    (props.progressViewOffset === undefined ||
+      props.progressViewOffset === 0) &&
+    progressViewOffsetFromContext !== undefined;
+  const [
+    deferredContextProgressViewOffset,
+    setDeferredContextProgressViewOffset,
+  ] = useState<number | undefined>();
+
+  useEffect(() => {
+    if (!shouldUseContextProgressViewOffset) {
+      setDeferredContextProgressViewOffset(undefined);
+      return;
+    }
+
+    // Fabric iOS ignores the initial progressViewOffset because the deferred
+    // initial props are compared against themselves. Apply Home's offset after
+    // mount so native sees a real 0 -> offset update before refresh starts.
+    setDeferredContextProgressViewOffset(undefined);
+    const frameId = requestAnimationFrame(() => {
+      setDeferredContextProgressViewOffset(progressViewOffsetFromContext);
+    });
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
+  }, [progressViewOffsetFromContext, shouldUseContextProgressViewOffset]);
 
   const handleRefresh = useCallback(() => {
     onRefresh?.();
@@ -31,9 +92,21 @@ function BasePullToRefresh({ onRefresh, ...props }: IPullToRefreshProps) {
     defaultLogger.account.wallet.walletPullToRefresh();
   }, [onRefresh]);
 
+  const progressViewOffset =
+    shouldUseContextProgressViewOffset &&
+    deferredContextProgressViewOffset !== undefined
+      ? deferredContextProgressViewOffset
+      : props.progressViewOffset;
+  const iosRefreshControlProps: Partial<IRefreshControlType> =
+    platformEnv.isNativeIOS
+      ? { tintColor: props.tintColor ?? theme.iconSubdued.val }
+      : {};
+
   return (
     <RefreshControl
       {...props}
+      {...iosRefreshControlProps}
+      progressViewOffset={progressViewOffset}
       refreshing={refreshing}
       onRefresh={handleRefresh}
     />

--- a/packages/kit/src/views/Home/pages/HomeHeaderContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeHeaderContainer.tsx
@@ -5,6 +5,7 @@ import {
   Stack,
   YStack,
 } from '@onekeyhq/components';
+import { ENABLE_IMMERSIVE_GLASS_HEADER } from '@onekeyhq/kit/src/components/ImmersiveGlassHeader';
 import { WALLET_TYPE_HD } from '@onekeyhq/shared/src/consts/dbConsts';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import type { IHomePageViewedState } from '@onekeyhq/shared/src/logger/scopes/account/scenes/wallet';
@@ -62,6 +63,7 @@ function BaseHomeHeaderContainer() {
   if (platformEnv.isNative && !isWalletNotBackedUp) {
     nativeMinHeight = shouldShowBanner ? 312 : 182;
   }
+  const headerBg = ENABLE_IMMERSIVE_GLASS_HEADER ? '$transparent' : '$bgApp';
 
   // Funnel denominator for backup / receive completion rates: log once per
   // (walletId, state) tuple seen this session. Skip `unknown` so we don't
@@ -93,7 +95,7 @@ function BaseHomeHeaderContainer() {
       gap="$5"
       minHeight={nativeMinHeight}
       $gtMd={{ gap: '$8' }}
-      bg="$bgApp"
+      bg={headerBg}
       pointerEvents="box-none"
     >
       <Stack
@@ -104,7 +106,7 @@ function BaseHomeHeaderContainer() {
           pt: '$8',
         }}
         px="$pagePadding"
-        bg="$bgApp"
+        bg={headerBg}
         pointerEvents="box-none"
       >
         <HeaderScrollGestureWrapper onRefresh={onHomePageRefresh}>

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -77,7 +77,11 @@ import {
 import { HomeStickyHeaderContext } from '../components/HomeStickyHeaderContext';
 import { HomeSupportedWallet } from '../components/HomeSupportedWallet';
 import { NotBackedUpEmpty } from '../components/NotBakcedUp';
-import { PullToRefresh, onHomePageRefresh } from '../components/PullToRefresh';
+import {
+  HomePullToRefreshProvider,
+  PullToRefresh,
+  onHomePageRefresh,
+} from '../components/PullToRefresh';
 import { useHomeWalletTabSupport } from '../hooks/useHomeWalletTabSupport';
 import { HomeTestIDs } from '../testIDs';
 
@@ -1271,11 +1275,17 @@ export function HomePageView({
 
   return useMemo(() => {
     return (
-      <HomeStickyHeaderContext.Provider value={stickyHeaderCtx}>
-        <Page fullPage testID={HomeTestIDs.page}>
-          {homePage}
-        </Page>
-      </HomeStickyHeaderContext.Provider>
+      <HomePullToRefreshProvider
+        progressViewOffset={
+          ENABLE_IMMERSIVE_GLASS_HEADER ? tabPageHeight : undefined
+        }
+      >
+        <HomeStickyHeaderContext.Provider value={stickyHeaderCtx}>
+          <Page fullPage testID={HomeTestIDs.page}>
+            {homePage}
+          </Page>
+        </HomeStickyHeaderContext.Provider>
+      </HomePullToRefreshProvider>
     );
-  }, [homePage, stickyHeaderCtx]);
+  }, [homePage, stickyHeaderCtx, tabPageHeight]);
 }


### PR DESCRIPTION
## Summary
- Fix the Home pull-to-refresh spinner position under the iOS immersive glass header.
- Restore transparent Home header backgrounds for the immersive glass layout.
- Include Developer page iOS 26+ header spacing adjustments using measured navigation header height.

## Intent & Context
The Home page pull-to-refresh indicator was not visible after the immersive glass header changes. The investigation needed to confirm whether the issue came from the transparent header, React Native `RefreshControl` attachment, styling, or native layout. The final requirement was to keep the fix iOS-only and include the pending Developer page spacing changes in the same PR.

## Root Cause
On iOS Fabric, the initial `progressViewOffset` prop can be ignored because deferred initial props are compared against themselves, so native does not observe a real offset change. With the immersive glass header, that leaves the refresh indicator around the top safe-area/Dynamic Island region where it is effectively invisible. Forcing `refreshing={true}` on the first render has the same timing limitation. A later real `0 -> offset` update moves the native `UIScrollView.refreshControl` into the visible header area.

## Design Decisions
- Scope the offset workaround to `platformEnv.isNativeIOS` so Android, web, desktop, and extension behavior remain unchanged.
- Apply the Home offset after mount with `requestAnimationFrame`, which makes iOS native receive a real prop transition without patching React Native.
- Use `tabPageHeight` only, instead of `tabPageHeight + 96`, because the extra padding pushed the spinner too far down into the account area.
- Keep the Home provider local to the Home page so other refresh controls are not affected.
- For Developer screens, use `useHeaderHeight()` only on iOS 26+ paths that need to clear the new native header geometry.

## Changes Detail
- `PullToRefresh`: adds a Home offset context, iOS-only deferred `progressViewOffset` application, and iOS-only spinner tint fallback.
- `HomePageView`: provides the measured Home header height to Home refresh controls when the immersive glass header is enabled.
- `HomeHeaderContainer`: keeps the Home header background transparent under the immersive glass header.
- `Developer` pages: adds iOS 26+ top spacing based on measured header height for component gallery, story layout, signature record, and developer tab screens.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile iOS
- **Risk Areas**: Native pull-to-refresh positioning, Home immersive header layout, and Developer-only iOS 26+ spacing. Non-iOS platforms are gated out of the refresh workaround.

## Test plan
- [x] Ran `yarn agent:check --profile commit`
- [x] Ran targeted `oxlint` on the touched Home refresh/header files
- [x] Ran `git diff --check`
- [x] Reloaded the iOS simulator through Metro after the Home refresh changes
