### PR TITLE
fix: reduce Home refresh trigger distance

### DIFF
--- a/packages/kit/src/views/Home/components/PullToRefresh/index.tsx
+++ b/packages/kit/src/views/Home/components/PullToRefresh/index.tsx
@@ -3,7 +3,6 @@ import {
   memo,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -60,28 +59,6 @@ function BasePullToRefresh({ onRefresh, ...props }: IPullToRefreshProps) {
     (props.progressViewOffset === undefined ||
       props.progressViewOffset === 0) &&
     progressViewOffsetFromContext !== undefined;
-  const [
-    deferredContextProgressViewOffset,
-    setDeferredContextProgressViewOffset,
-  ] = useState<number | undefined>();
-
-  useEffect(() => {
-    if (!shouldUseContextProgressViewOffset) {
-      setDeferredContextProgressViewOffset(undefined);
-      return;
-    }
-
-    // Fabric iOS ignores the initial progressViewOffset because the deferred
-    // initial props are compared against themselves. Apply Home's offset after
-    // mount so native sees a real 0 -> offset update before refresh starts.
-    setDeferredContextProgressViewOffset(undefined);
-    const frameId = requestAnimationFrame(() => {
-      setDeferredContextProgressViewOffset(progressViewOffsetFromContext);
-    });
-    return () => {
-      cancelAnimationFrame(frameId);
-    };
-  }, [progressViewOffsetFromContext, shouldUseContextProgressViewOffset]);
 
   const handleRefresh = useCallback(() => {
     onRefresh?.();
@@ -92,10 +69,11 @@ function BasePullToRefresh({ onRefresh, ...props }: IPullToRefreshProps) {
     defaultLogger.account.wallet.walletPullToRefresh();
   }, [onRefresh]);
 
+  // Keep the idle offset at zero because iOS also counts progressViewOffset
+  // toward the native pull distance required to trigger UIRefreshControl.
   const progressViewOffset =
-    shouldUseContextProgressViewOffset &&
-    deferredContextProgressViewOffset !== undefined
-      ? deferredContextProgressViewOffset
+    shouldUseContextProgressViewOffset && refreshing
+      ? progressViewOffsetFromContext
       : props.progressViewOffset;
   const iosRefreshControlProps: Partial<IRefreshControlType> =
     platformEnv.isNativeIOS


### PR DESCRIPTION
## Summary
- Reduce the pull distance required to trigger Home pull-to-refresh on iOS.
- Keep the spinner positioned below the immersive glass header after refresh starts.
- Simplify the Home refresh offset workaround by removing the deferred idle offset state.

## Intent & Context
This is a follow-up to #12399. The spinner became visible below the iOS immersive glass header, but the user still had to pull too far before the spinner started refreshing. The goal is to keep the iOS-only visual placement fix without making the native pull threshold feel heavy.

## Root Cause
On iOS Fabric, `progressViewOffset` is applied by changing the `UIRefreshControl` bounds origin. That moves the spinner down visually, but iOS also effectively counts that offset as part of the pull distance needed to trigger refresh. Keeping Home's header offset active while idle made the user pull roughly the header height more than before.

## Design Decisions
- Keep `progressViewOffset` at the default value while idle so the native trigger distance remains short.
- Apply the Home header offset only while `refreshing` is true, so the active spinner still appears below the glass/search header.
- Keep the behavior gated to iOS through the existing `platformEnv.isNativeIOS` check.
- Avoid a native patch or custom refresh overlay for this follow-up; those would be heavier and riskier than changing when the offset is applied.

## Changes Detail
- `PullToRefresh`: removes the deferred after-mount offset state and applies the Home context offset only during the refreshing state.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile iOS
- **Risk Areas**: The pre-trigger spinner may remain less visible under the glass header, but the active refreshing spinner is still positioned below the header and the pull threshold is restored.

## Test plan
- [x] Ran targeted `oxlint` for the touched Home refresh file
- [x] Ran `git diff --check`
- [ ] Verify on iOS simulator/device that Home refresh triggers with a shorter pull and the active spinner appears below the search header
