### PR TITLE
fix: decouple iOS refresh indicator offset

### DIFF
--- a/packages/kit/src/views/Home/components/PullToRefresh/index.tsx
+++ b/packages/kit/src/views/Home/components/PullToRefresh/index.tsx
@@ -3,7 +3,6 @@ import {
   memo,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -55,33 +54,11 @@ function BasePullToRefresh({ onRefresh, ...props }: IPullToRefreshProps) {
   const progressViewOffsetFromContext = useContext(
     HomePullToRefreshOffsetContext,
   );
-  const shouldUseContextProgressViewOffset =
+  const shouldUseContextProgressViewVisualOffset =
     platformEnv.isNativeIOS &&
     (props.progressViewOffset === undefined ||
       props.progressViewOffset === 0) &&
     progressViewOffsetFromContext !== undefined;
-  const [
-    deferredContextProgressViewOffset,
-    setDeferredContextProgressViewOffset,
-  ] = useState<number | undefined>();
-
-  useEffect(() => {
-    if (!shouldUseContextProgressViewOffset) {
-      setDeferredContextProgressViewOffset(undefined);
-      return;
-    }
-
-    // Fabric iOS ignores the initial progressViewOffset because the deferred
-    // initial props are compared against themselves. Apply Home's offset after
-    // mount so native sees a real 0 -> offset update before refresh starts.
-    setDeferredContextProgressViewOffset(undefined);
-    const frameId = requestAnimationFrame(() => {
-      setDeferredContextProgressViewOffset(progressViewOffsetFromContext);
-    });
-    return () => {
-      cancelAnimationFrame(frameId);
-    };
-  }, [progressViewOffsetFromContext, shouldUseContextProgressViewOffset]);
 
   const handleRefresh = useCallback(() => {
     onRefresh?.();
@@ -92,21 +69,21 @@ function BasePullToRefresh({ onRefresh, ...props }: IPullToRefreshProps) {
     defaultLogger.account.wallet.walletPullToRefresh();
   }, [onRefresh]);
 
-  const progressViewOffset =
-    shouldUseContextProgressViewOffset &&
-    deferredContextProgressViewOffset !== undefined
-      ? deferredContextProgressViewOffset
-      : props.progressViewOffset;
+  const progressViewVisualOffset = shouldUseContextProgressViewVisualOffset
+    ? progressViewOffsetFromContext
+    : undefined;
   const iosRefreshControlProps: Partial<IRefreshControlType> =
     platformEnv.isNativeIOS
-      ? { tintColor: props.tintColor ?? theme.iconSubdued.val }
+      ? {
+          progressViewVisualOffset,
+          tintColor: props.tintColor ?? theme.iconSubdued.val,
+        }
       : {};
 
   return (
     <RefreshControl
       {...props}
       {...iosRefreshControlProps}
-      progressViewOffset={progressViewOffset}
       refreshing={refreshing}
       onRefresh={handleRefresh}
     />

--- a/patches/react-native+0.81.5.patch
+++ b/patches/react-native+0.81.5.patch
@@ -1,3 +1,37 @@
+diff --git a/node_modules/react-native/Libraries/Components/RefreshControl/RefreshControl.d.ts b/node_modules/react-native/Libraries/Components/RefreshControl/RefreshControl.d.ts
+index 81eba74..41d940b 100644
+--- a/node_modules/react-native/Libraries/Components/RefreshControl/RefreshControl.d.ts
++++ b/node_modules/react-native/Libraries/Components/RefreshControl/RefreshControl.d.ts
+@@ -69,6 +69,12 @@ export interface RefreshControlProps
+    * Progress view top offset
+    */
+   progressViewOffset?: number | undefined;
++
++  /**
++   * OneKey patch: visual-only progress view offset that does not affect the
++   * native pull distance required to trigger refresh.
++   */
++  progressViewVisualOffset?: number | undefined;
+ }
+
+ /**
+diff --git a/node_modules/react-native/Libraries/Components/RefreshControl/RefreshControl.js b/node_modules/react-native/Libraries/Components/RefreshControl/RefreshControl.js
+index 4c6947a..879c0bc 100644
+--- a/node_modules/react-native/Libraries/Components/RefreshControl/RefreshControl.js
++++ b/node_modules/react-native/Libraries/Components/RefreshControl/RefreshControl.js
+@@ -70,6 +70,12 @@ type RefreshControlBaseProps = $ReadOnly<{
+    * Progress view top offset
+    */
+   progressViewOffset?: ?number,
++
++  /**
++   * OneKey patch: visual-only progress view offset that does not affect the
++   * native pull distance required to trigger refresh.
++   */
++  progressViewVisualOffset?: ?number,
+ }>;
+
+ export type RefreshControlProps = $ReadOnly<{
 diff --git a/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js b/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
 index 05bddcb..5211253 100644
 --- a/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -19,7 +53,7 @@ index 6e9c384..e68e675 100644
 @@ -13,6 +13,10 @@
  #import <React/RCTBackedTextInputDelegateAdapter.h>
  #import <React/RCTTextAttributes.h>
- 
+
 +#import <MobileCoreServices/MobileCoreServices.h>
 +#import <MobileCoreServices/UTType.h>
 +#import <UIKit/UIKit.h>
@@ -33,10 +67,10 @@ index 6e9c384..e68e675 100644
    NSArray<NSString *> *_acceptDragAndDropTypes;
 +  BOOL _isProcessingImagePaste;
  }
- 
+
  static UIFont *defaultPlaceholderFont(void)
 @@ -208,10 +213,98 @@ - (void)scrollRangeToVisible:(NSRange)range
- 
+
  - (void)paste:(id)sender
  {
 +  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
@@ -53,7 +87,7 @@ index 6e9c384..e68e675 100644
 +  }
    [super paste:sender];
  }
- 
+
 +- (void)_superPaste:(id)sender
 +{
 +  [super paste:sender];
@@ -137,47 +171,47 @@ index 6e9c384..e68e675 100644
 @@ -301,6 +394,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
      return NO;
    }
- 
+
 +  if (action == @selector(paste:) && [UIPasteboard generalPasteboard].hasImages) {
 +    return YES;
 +  }
 +
    return [super canPerformAction:action withSender:sender];
  }
- 
+
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
 index 7187177..da00893 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
 +++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
 @@ -37,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
- 
+
  - (void)textInputDidChangeSelection;
- 
+
 +- (void)textInputDidPaste:(NSString *)type withData:(NSString *)data;
 +
  @optional
- 
+
  - (void)scrollViewDidScroll:(UIScrollView *)scrollView;
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.h b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.h
 index f1c32e6..7ec9bb0 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.h
 +++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.h
 @@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
- 
+
  - (void)skipNextTextInputDidChangeSelectionEventWithTextRange:(UITextRange *)textRange;
  - (void)selectedTextRangeWasSet;
 +- (void)didPaste:(NSString *)type withData:(NSString *)data;
- 
+
  @end
- 
+
 @@ -31,6 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
- 
+
  - (void)skipNextTextInputDidChangeSelectionEventWithTextRange:(UITextRange *)textRange;
- 
+
 +- (void)didPaste:(NSString *)type withData:(NSString *)data;
 +
  @end
- 
+
  NS_ASSUME_NONNULL_END
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm
 index 82d9a79..8cc48ec 100644
@@ -186,26 +220,26 @@ index 82d9a79..8cc48ec 100644
 @@ -148,6 +148,11 @@ - (void)selectedTextRangeWasSet
    [self textFieldProbablyDidChangeSelection];
  }
- 
+
 +- (void)didPaste:(NSString *)type withData:(NSString *)data
 +{
 +  [_backedTextInputView.textInputDelegate textInputDidPaste:type withData:data];
 +}
 +
  #pragma mark - Generalization
- 
+
  - (void)textFieldProbablyDidChangeSelection
 @@ -330,6 +335,11 @@ - (void)skipNextTextInputDidChangeSelectionEventWithTextRange:(UITextRange *)tex
    _previousSelectedTextRange = textRange;
  }
- 
+
 +- (void)didPaste:(NSString *)type withData:(NSString *)data
 +{
 +  [_backedTextInputView.textInputDelegate textInputDidPaste:type withData:data];
 +}
 +
  #pragma mark - Generalization
- 
+
  - (void)textViewProbablyDidChangeSelection
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.h b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.h
 index 4804624..90b7081 100644
@@ -216,7 +250,7 @@ index 4804624..90b7081 100644
  @property (nonatomic, copy, nullable) RCTDirectEventBlock onChangeSync;
  @property (nonatomic, copy, nullable) RCTDirectEventBlock onScroll;
 +@property (nonatomic, copy, nullable) RCTDirectEventBlock onPaste;
- 
+
  @property (nonatomic, assign) NSInteger mostRecentEventCount;
  @property (nonatomic, assign, readonly) NSInteger nativeEventCount;
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -226,7 +260,7 @@ index 6a2d4f8..caae2d0 100644
 @@ -599,6 +599,52 @@ - (void)textInputDidChangeSelection
    });
  }
- 
+
 +BOOL isBlankString(NSString *string) {
 +  if (!string) {
 +    return YES;
@@ -254,7 +288,7 @@ index 6a2d4f8..caae2d0 100644
 +  if (!_onPaste) {
 +    return;
 +  }
-+  
++
 +  if (isBlankString(type) || isBlankString(data)) {
 +    return;
 +  }
@@ -285,7 +319,7 @@ index 47adc53..1865e0a 100644
  RCT_EXPORT_VIEW_PROPERTY(onSelectionChange, RCTDirectEventBlock)
  RCT_EXPORT_VIEW_PROPERTY(onScroll, RCTDirectEventBlock)
 +RCT_EXPORT_VIEW_PROPERTY(onPaste, RCTDirectEventBlock)
- 
+
  RCT_EXPORT_SHADOW_PROPERTY(text, NSString)
  RCT_EXPORT_SHADOW_PROPERTY(placeholder, NSString)
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -295,7 +329,7 @@ index 377f41e..2bab943 100644
 @@ -12,12 +12,17 @@
  #import <React/RCTUtils.h>
  #import <React/UIView+React.h>
- 
+
 +#import <MobileCoreServices/MobileCoreServices.h>
 +#import <MobileCoreServices/UTType.h>
 +#import <UIKit/UIKit.h>
@@ -308,23 +342,23 @@ index 377f41e..2bab943 100644
    NSArray<NSString *> *_acceptDragAndDropTypes;
 +  BOOL _isProcessingImagePaste;
  }
- 
+
  // This should not be needed but internal build were failing without it.
 @@ -180,6 +185,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
      return NO;
    }
- 
+
 +  if (action == @selector(paste:) && [UIPasteboard generalPasteboard].hasImages) {
 +    return YES;
 +  }
 +
    return [super canPerformAction:action withSender:sender];
  }
- 
+
 @@ -260,12 +269,100 @@ - (void)scrollRangeToVisible:(NSRange)range
    // Singleline TextInput does not require scrolling after calling setSelectedTextRange (PR 38679).
  }
- 
+
 +- (void)_superPaste:(id)sender
 +{
 +  [super paste:sender];
@@ -346,7 +380,7 @@ index 377f41e..2bab943 100644
 +  }
    [super paste:sender];
  }
- 
+
 +- (BOOL)processImagePaste:(UIPasteboard *)clipboard
 +{
 +  // Prevent concurrent image paste operations from rapid taps
@@ -420,14 +454,34 @@ index 377f41e..2bab943 100644
 +}
 +
  #pragma mark - Layout
- 
+
  - (CGSize)contentSize
+diff --git a/node_modules/react-native/React/FBReactNativeSpec/react/renderer/components/FBReactNativeSpec/Props.cpp b/node_modules/react-native/React/FBReactNativeSpec/react/renderer/components/FBReactNativeSpec/Props.cpp
+index b1d811e..d3ef37f 100644
+--- a/node_modules/react-native/React/FBReactNativeSpec/react/renderer/components/FBReactNativeSpec/Props.cpp
++++ b/node_modules/react-native/React/FBReactNativeSpec/react/renderer/components/FBReactNativeSpec/Props.cpp
+@@ -394,2 +394,3 @@ PullToRefreshViewProps::PullToRefreshViewProps(
+     progressViewOffset(convertRawProp(context, rawProps, "progressViewOffset", sourceProps.progressViewOffset, {0.0})),
++    progressViewVisualOffset(convertRawProp(context, rawProps, "progressViewVisualOffset", sourceProps.progressViewVisualOffset, {0.0})),
+     refreshing(convertRawProp(context, rawProps, "refreshing", sourceProps.refreshing, {false})) {}
+diff --git a/node_modules/react-native/React/FBReactNativeSpec/react/renderer/components/FBReactNativeSpec/Props.h b/node_modules/react-native/React/FBReactNativeSpec/react/renderer/components/FBReactNativeSpec/Props.h
+index 2c047bf..9c36e5e 100644
+--- a/node_modules/react-native/React/FBReactNativeSpec/react/renderer/components/FBReactNativeSpec/Props.h
++++ b/node_modules/react-native/React/FBReactNativeSpec/react/renderer/components/FBReactNativeSpec/Props.h
+@@ -294,6 +294,7 @@ class PullToRefreshViewProps final : public ViewProps {
+   SharedColor titleColor{};
+   std::string title{};
+   Float progressViewOffset{0.0};
++  Float progressViewVisualOffset{0.0};
+   bool refreshing{false};
+
+   #ifdef RN_SERIALIZABLE_STATE
 diff --git a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
 index bec2ac5..4cab4b5 100644
 --- a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
 +++ b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
 @@ -103,46 +103,51 @@ - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
- 
+
  + (BOOL)isSupported:(NSString *)componentName
  {
 -  // Step 1: check if ViewManager with specified name is supported.
@@ -446,7 +500,7 @@ index bec2ac5..4cab4b5 100644
 +    if (isComponentNameSupported) {
 +      return YES;
 +    }
- 
+
 -  // Step 2: check if component has supported prefix.
 -  for (NSString *item in [RCTLegacyViewManagerInteropComponentView supportedViewManagersPrefixes]) {
 -    if ([componentName hasPrefix:item]) {
@@ -466,7 +520,7 @@ index bec2ac5..4cab4b5 100644
        return YES;
      }
 -  }
- 
+
 -  // Step 3: check if the module has been registered
 -  // TODO(T174674274): Implement lazy loading of legacy view managers in the new architecture.
 -  NSArray<Class> *registeredModules = RCTGetModuleClasses();
@@ -480,7 +534,7 @@ index bec2ac5..4cab4b5 100644
 +      NSString *moduleName = [[bridgeModule moduleName] isEqualToString:@""]
 +          ? [NSStringFromClass(moduleClass) stringByReplacingOccurrencesOfString:@"Manager" withString:@""]
 +          : [bridgeModule moduleName];
- 
+
 -  for (Class moduleClass in registeredModules) {
 -    id<RCTBridgeModule> bridgeModule = (id<RCTBridgeModule>)moduleClass;
 -    NSString *moduleName = [[bridgeModule moduleName] isEqualToString:@""]
@@ -489,7 +543,7 @@ index bec2ac5..4cab4b5 100644
 +      if (supportedLegacyViewComponents[moduleName] == NULL) {
 +        supportedLegacyViewComponents[moduleName] = moduleClass;
 +      }
- 
+
 -    if (supportedLegacyViewComponents[moduleName] == NULL) {
 -      supportedLegacyViewComponents[moduleName] = moduleClass;
 +      if ([moduleName isEqualToString:componentName] ||
@@ -497,7 +551,7 @@ index bec2ac5..4cab4b5 100644
 +        return YES;
 +      }
      }
- 
+
 -    if ([moduleName isEqualToString:componentName] ||
 -        [moduleName isEqualToString:[@"RCT" stringByAppendingString:componentName]]) {
 -      return YES;
@@ -507,8 +561,47 @@ index bec2ac5..4cab4b5 100644
 -
 -  return NO;
  }
- 
+
  + (void)supportLegacyViewManagersWithPrefix:(NSString *)prefix
+diff --git a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+index 0d231bc..3adb26b 100644
+--- a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
++++ b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+@@ -78,6 +78,8 @@ - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &
+
+   const auto &oldConcreteProps = static_cast<const PullToRefreshViewProps &>(*_props);
+   const auto &newConcreteProps = static_cast<const PullToRefreshViewProps &>(*props);
++  const auto &oldConcretePropsForVisualOffset =
++      oldProps ? static_cast<const PullToRefreshViewProps &>(*oldProps) : oldConcreteProps;
+
+   if (newConcreteProps.tintColor != oldConcreteProps.tintColor) {
+     _refreshControl.tintColor = RCTUIColorFromSharedColor(newConcreteProps.tintColor);
+@@ -87,6 +89,10 @@ - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &
+     [self _updateProgressViewOffset:newConcreteProps.progressViewOffset];
+   }
+
++  if (newConcreteProps.progressViewVisualOffset != oldConcretePropsForVisualOffset.progressViewVisualOffset) {
++    [self _updateProgressViewVisualOffset:newConcreteProps.progressViewVisualOffset];
++  }
++
+   BOOL needsUpdateTitle = NO;
+
+   if (newConcreteProps.title != oldConcreteProps.title) {
+@@ -129,6 +135,14 @@ - (void)_updateProgressViewOffset:(Float)progressViewOffset
+       _refreshControl.bounds.size.height);
+ }
+
++- (void)_updateProgressViewVisualOffset:(Float)progressViewVisualOffset
++{
++  // OneKey patch: move only the rendered indicator. Unlike bounds-based
++  // progressViewOffset, this transform does not increase the native pull
++  // distance required to trigger UIRefreshControl.
++  _refreshControl.transform = CGAffineTransformMakeTranslation(0, progressViewVisualOffset);
++}
++
+ - (void)_updateTitle
+ {
+   const auto &concreteProps = static_cast<const PullToRefreshViewProps &>(*_props);
 diff --git a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
 index 577bebe..ad0f253 100644
 --- a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -516,7 +609,7 @@ index 577bebe..ad0f253 100644
 @@ -381,6 +381,38 @@ - (void)prepareForRecycle
    [_backedTextInputView resignFirstResponder];
  }
- 
+
 +BOOL checkIsBlankString(NSString *string) {
 +  if (!string) {
 +    return YES;
@@ -550,7 +643,7 @@ index 577bebe..ad0f253 100644
 +}
 +
  #pragma mark - RCTBackedTextInputDelegate
- 
+
  - (BOOL)textInputShouldBeginEditing
 diff --git a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
 index a99f103..27865c2 100644
@@ -558,7 +651,7 @@ index a99f103..27865c2 100644
 +++ b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
 @@ -828,6 +828,19 @@ - (UIView *)currentContainerView
  }
- 
+
  - (void)invalidateLayer
 +{
 +  // During modal transition, prevent backgroundColor and layer changes from being animated.
@@ -575,7 +668,7 @@ index a99f103..27865c2 100644
 +- (void)_invalidateLayerImpl
  {
    CALayer *layer = self.layer;
- 
+
 diff --git a/node_modules/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm b/node_modules/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
 index 9f50554..23eaaa8 100644
 --- a/node_modules/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
@@ -606,7 +699,7 @@ index 9f50554..23eaaa8 100644
 +      }
      }
    }
- 
+
 diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.kt b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.kt
 index f8dd833..db25f53 100644
 --- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.kt
@@ -620,7 +713,7 @@ index f8dd833..db25f53 100644
 +      // return a stale, out-of-bounds index (Sentry REACT-NATIVE-48W / 4AM).
 +      currentDrawingOrderIndices = null
      }
- 
+
      if (currentDrawingOrderIndices == null) {
 diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
 index 89b666d..246c9cf 100644
@@ -639,14 +732,14 @@ index 89b666d..246c9cf 100644
 +      // Tracking: https://github.com/software-mansion/react-native-reanimated/issues/8422
 +    }
    }
- 
+
    override fun drawChild(canvas: Canvas, child: View, drawingTime: Long): Boolean {
 diff --git a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
 index 2a67797..5e5aeff 100644
 --- a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
 +++ b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
 @@ -57,6 +57,9 @@ static int32_t getUniqueId()
- 
+
  static jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *value)
  {
 +  if (value == nil) {
@@ -654,9 +747,9 @@ index 2a67797..5e5aeff 100644
 +  }
    return jsi::String::createFromUtf8(runtime, [value UTF8String] ? [value UTF8String] : "");
  }
- 
+
 @@ -89,6 +92,9 @@ static int32_t getUniqueId()
- 
+
  jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value)
  {
 +  if (value == nil) {
@@ -732,7 +825,7 @@ index a9bc219..0fc50bf 100644
 @@ -131,6 +131,19 @@ static jsi::Value keyPressMetricsPayload(
    return payload;
  };
- 
+
 +void TextInputEventEmitter::onPaste(const std::string& type, const std::string& data) const {
 +  dispatchEvent("paste", [type, data](jsi::Runtime& runtime) {
 +    auto payload = jsi::Object(runtime);
@@ -758,9 +851,26 @@ index dbce575..5b03581 100644
    void onKeyPress(const KeyPressMetrics& keyPressMetrics) const;
    void onScroll(const Metrics& textInputMetrics) const;
 +  void onPaste(const std::string& type, const std::string& data) const;
- 
+
   private:
    void dispatchTextInputEvent(
+diff --git a/node_modules/react-native/src/private/specs_DEPRECATED/components/PullToRefreshViewNativeComponent.js b/node_modules/react-native/src/private/specs_DEPRECATED/components/PullToRefreshViewNativeComponent.js
+index 64b0110..02a57fa 100644
+--- a/node_modules/react-native/src/private/specs_DEPRECATED/components/PullToRefreshViewNativeComponent.js
++++ b/node_modules/react-native/src/private/specs_DEPRECATED/components/PullToRefreshViewNativeComponent.js
+@@ -41,6 +41,12 @@ type PullToRefreshNativeProps = $ReadOnly<{
+    */
+   progressViewOffset?: WithDefault<Float, 0>,
+
++  /**
++   * OneKey patch: visual-only progress view offset that does not affect the
++   * native pull distance required to trigger refresh.
++   */
++  progressViewVisualOffset?: WithDefault<Float, 0>,
++
+   /**
+    * Called when the view starts refreshing.
+    */
 diff --git a/node_modules/react-native/third-party-podspecs/RCT-Folly.podspec b/node_modules/react-native/third-party-podspecs/RCT-Folly.podspec
 index 8852179..040c4f0 100644
 --- a/node_modules/react-native/third-party-podspecs/RCT-Folly.podspec
@@ -779,7 +889,7 @@ index 2f38990..a40c575 100644
 --- a/node_modules/react-native/third-party-podspecs/fmt.podspec
 +++ b/node_modules/react-native/third-party-podspecs/fmt.podspec
 @@ -8,14 +8,14 @@ fmt_git_url = fmt_config[:git]
- 
+
  Pod::Spec.new do |spec|
    spec.name = "fmt"
 -  spec.version = "11.0.2"


### PR DESCRIPTION
## Summary
- Add a React Native iOS Fabric patch for `progressViewVisualOffset`, a visual-only refresh indicator offset.
- Keep native `progressViewOffset` semantics unchanged so pull distance is not increased by Home's glass header offset.
- Update Home `PullToRefresh` to use the visual-only offset and remove the JS deferred `progressViewOffset` workaround.

## Intent & Context
This is a follow-up to the Home immersive glass header pull-to-refresh investigation. The previous Home fix made the spinner visible below the glass/search header by setting `progressViewOffset`, but iOS counts that offset toward the native pull distance. The result was a spinner that could appear in the right place only after a very long pull. A later JS-only attempt to apply the offset after `refreshing=true` shortened the threshold, but left the pre-trigger pull indicator invisible and could introduce a visible jump, so that PR was closed.

## Root Cause
In React Native iOS Fabric, `progressViewOffset` is applied by changing `UIRefreshControl.bounds.origin.y`. That moves the spinner visually, but it also changes how far the user must pull before `UIRefreshControl` reaches the refresh threshold. Home needs a visual offset for the glass header while keeping the native trigger distance close to default.

## Design Decisions
- Add a new Fabric prop, `progressViewVisualOffset`, instead of changing existing `progressViewOffset` semantics globally.
- Implement the visual offset with `CGAffineTransformMakeTranslation` on the `UIRefreshControl`, which moves rendering without changing bounds-based pull distance.
- Keep the prop iOS-only in Home usage through the existing `platformEnv.isNativeIOS` guard.
- Fix the Fabric deferred initial props comparison to use the actual `oldProps`, so the visual offset applies on initial layout without a JS `requestAnimationFrame` workaround.

## Changes Detail
- `patches/react-native+0.81.5.patch`: adds `progressViewVisualOffset` to RN RefreshControl Flow/TS/codegen props and iOS Fabric native handling.
- `PullToRefresh`: passes Home's header offset as `progressViewVisualOffset`, removes deferred `progressViewOffset` state, and leaves `progressViewOffset` untouched for native pull distance.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile iOS Fabric
- **Risk Areas**: React Native patch-package maintenance, iOS refresh indicator transform behavior, and interaction with existing RN patches.

## Test plan
- [x] Verified `patches/react-native+0.81.5.patch` applies cleanly to pristine `react-native@0.81.5`
- [x] Verified patch contains no build artifacts
- [x] Ran `git diff --check`
- [x] Ran targeted `oxlint` for `PullToRefresh/index.tsx`
- [ ] Rebuild iOS app and verify Home pull-to-refresh shows the indicator during pull without requiring the longer `progressViewOffset` distance
