### PR TITLE
fix: cap Android image decode size

### DIFF
--- a/packages/components/src/primitives/Image/ImageV2.native.tsx
+++ b/packages/components/src/primitives/Image/ImageV2.native.tsx
@@ -10,6 +10,7 @@ import { Skeleton } from '../Skeleton';
 import { Stack } from '../Stack';
 
 import { AnimatedExpoImage } from './AnimatedImage';
+import { getAndroidSafeImageLoadOptions } from './safeLoadOptions';
 import { useImage } from './useImage';
 import { isEmptyResolvedSource, useResetError } from './utils';
 
@@ -70,23 +71,36 @@ export function ImageV2({
     autoplay,
     ...imageProps
   } = restProps;
+  const imageLoadOptions = useMemo(
+    () =>
+      getAndroidSafeImageLoadOptions(undefined, {
+        width: style.width,
+        height: style.height,
+      }),
+    [style.height, style.width],
+  );
   const retryTimesLimit = useRef<number>(defaultRetryTimes || 1);
   const retryTimes = useRef<number>(0);
 
   const [hasError, setHasError] = useState(false);
-  const { image, reFetchImage } = useImage((source as ImageSource) || src, {
-    onError(error, retry) {
-      console.error('Loading failed:', error.message);
-      if (canRetry && retryTimes.current < retryTimesLimit.current) {
-        retryTimes.current += 1;
-        setTimeout(() => {
-          retry();
-        }, getRandomRetryTimes());
-      } else {
-        setHasError(true);
-      }
+  const { image, reFetchImage } = useImage(
+    (source as ImageSource) || src,
+    {
+      ...imageLoadOptions,
+      onError(error, retry) {
+        console.error('Loading failed:', error.message);
+        if (canRetry && retryTimes.current < retryTimesLimit.current) {
+          retryTimes.current += 1;
+          setTimeout(() => {
+            retry();
+          }, getRandomRetryTimes());
+        } else {
+          setHasError(true);
+        }
+      },
     },
-  });
+    [imageLoadOptions.maxWidth, imageLoadOptions.maxHeight],
+  );
 
   const onResetError = useCallback((error: boolean) => {
     setHasError(error);

--- a/packages/components/src/primitives/Image/preload.ts
+++ b/packages/components/src/primitives/Image/preload.ts
@@ -6,6 +6,7 @@ import {
   refreshCachedImagePaths,
 } from './cache';
 import { DEFAULT_CACHE_POLICY } from './cachePolicy';
+import { getAndroidSafeImageLoadOptions } from './safeLoadOptions';
 
 import type { IPreloadImageFunc, IPreloadImagesFunc } from './type';
 
@@ -37,8 +38,10 @@ export const loadImage = (source: { uri?: string }) => {
   if (!source.uri) {
     return Promise.resolve(null);
   }
-  return Image.loadAsync(source.uri).then(async (imageRef) => {
-    await refreshCachedImagePath(source.uri);
-    return imageRef;
-  });
+  return Image.loadAsync(source.uri, getAndroidSafeImageLoadOptions()).then(
+    async (imageRef) => {
+      await refreshCachedImagePath(source.uri);
+      return imageRef;
+    },
+  );
 };

--- a/packages/components/src/primitives/Image/safeLoadOptions.ts
+++ b/packages/components/src/primitives/Image/safeLoadOptions.ts
@@ -1,0 +1,61 @@
+import { PixelRatio } from 'react-native';
+
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import type { ImageLoadOptions } from 'expo-image';
+
+type IImageDecodeTarget = {
+  width?: unknown;
+  height?: unknown;
+};
+
+const ANDROID_MAX_DECODE_SIDE_PX = 2048;
+const ANDROID_MIN_DECODE_SIDE_PX = 1;
+
+function clampDecodeSidePx(value?: number) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.min(
+    ANDROID_MAX_DECODE_SIDE_PX,
+    Math.max(ANDROID_MIN_DECODE_SIDE_PX, Math.ceil(value)),
+  );
+}
+
+function getDevicePixelRatio() {
+  const ratio = PixelRatio.get();
+  return Number.isFinite(ratio) && ratio > 0 ? ratio : 1;
+}
+
+function resolveTargetSidePx(value: unknown) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return clampDecodeSidePx(value * getDevicePixelRatio());
+}
+
+export function getAndroidSafeImageLoadOptions(
+  options: ImageLoadOptions = {},
+  target?: IImageDecodeTarget,
+): ImageLoadOptions {
+  if (!platformEnv.isNativeAndroid) {
+    return options;
+  }
+
+  // Image.loadAsync() defaults to original size on Android. Keep decoded ImageRefs
+  // below Canvas draw limits before they are handed to ExpoImageView.
+  const maxWidth =
+    clampDecodeSidePx(options.maxWidth) ??
+    resolveTargetSidePx(target?.width) ??
+    ANDROID_MAX_DECODE_SIDE_PX;
+  const maxHeight =
+    clampDecodeSidePx(options.maxHeight) ??
+    resolveTargetSidePx(target?.height) ??
+    ANDROID_MAX_DECODE_SIDE_PX;
+
+  return {
+    ...options,
+    maxWidth,
+    maxHeight,
+  };
+}


### PR DESCRIPTION
## Summary
- Add Android-safe max decode bounds for shared Image.loadAsync usage.
- Apply component-size-aware decode caps in native ImageV2 and the direct loadImage helper.
- Prevent oversized decoded ImageRefs from reaching ExpoImageView.draw.

## Intent & Context
Android release so.onekey.app.wallet@6.4.0+2026061231 reported low-frequency Play Console and Sentry crashes in expo.modules.image.ExpoImageView.draw. Sentry issue REACT-NATIVE-1YW showed RuntimeException: Canvas: trying to draw too large(...) bitmap, with observed decoded bitmap sizes including 157954624, 277822224, and 696643236 bytes. One sample breadcrumb pointed near UniversalSearch, where DApp logos and token/perp/market icons are rendered as small UI images.

## Root Cause
On Android, OneKey ImageV2 preloads sources through Image.loadAsync before rendering ExpoImage. Expo image loadAsync defaults maxWidth/maxHeight to Target.SIZE_ORIGINAL, so an unexpectedly large remote logo can be decoded at original size. The resulting ImageRef is then passed back into ExpoImage as an already-decoded SharedRef/DecodedSource, bypassing the normal view-target downsample path. ExpoImageView.draw eventually attempts to draw that oversized BitmapDrawable and Android RecordingCanvas rejects it.

## Design Decisions
The fix caps decoded ImageRefs before draw time instead of catching ExpoImageView.draw exceptions. Draw-time suppression was rejected because native view state would already contain a bad drawable and could blank or repeatedly redraw. Patching expo-image native ImageLoadTask was also possible, but the risky path is controlled by OneKey shared Image wrappers, so a component-layer guard is narrower and avoids a new patch-package change.

## Changes Detail
- packages/components/src/primitives/Image/safeLoadOptions.ts: adds an Android-only helper that clamps loadAsync maxWidth/maxHeight to component size * PixelRatio when available, or 2048px fallback per side.
- packages/components/src/primitives/Image/ImageV2.native.tsx: passes safe Android load options into useImage and reloads if resolved decode bounds change.
- packages/components/src/primitives/Image/preload.ts: applies the same safe options to the direct Image.loadImage helper.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile Android
- **Risk Areas**: Very large images rendered through ImageRef are now downsampled to a maximum 2048px side. This should be safe for icon/logo usage and most mobile UI images, but extremely high-resolution image inspection flows could render less detail if they use this shared ImageRef path. Non-Android platforms return existing options unchanged.

## Test plan
- [x] npx oxlint --tsconfig ./tsconfig.json --type-aware packages/components/src/primitives/Image/ImageV2.native.tsx packages/components/src/primitives/Image/preload.ts packages/components/src/primitives/Image/safeLoadOptions.ts --deny-warnings
- [x] yarn tsc:only
- [x] yarn agent:check --profile commit
- [ ] Verify Android UniversalSearch with DApp/token/perp/market image results, including an abnormally large remote logo, does not crash with Canvas: trying to draw too large bitmap.
