### PR TITLE
fix: prevent Android PagerView recycle crash

### DIFF
--- a/patches/react-native-pager-view+3.0.78.patch
+++ b/patches/react-native-pager-view+3.0.78.patch
@@ -1,0 +1,29 @@
+diff --git a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
+index d8cded7..cbcb371 100644
+--- a/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
++++ b/node_modules/react-native-pager-view/android/src/main/java/com/reactnativepagerview/ViewPagerAdapter.kt
+@@ -93,13 +93,21 @@ class ViewPagerAdapter() : Adapter<ViewPagerViewHolder>() {
+       handler.post { removeAll() }
+       return
+     }
++    val removedChildrenCount = childrenViews.size
++    if (removedChildrenCount == 0) {
++      return
++    }
+     for (index in 1..childrenViews.size) {
+       val child = childrenViews[index-1]
+-      if (child.parent?.parent != null) {
+-        (child.parent.parent as ViewGroup).removeView(child.parent as View)
++      // OneKey patch: RecyclerView must own holder container removal during recycle.
++      // if (child.parent?.parent != null) {
++      //   (child.parent.parent as ViewGroup).removeView(child.parent as View)
++      // }
++      val parent = child.parent
++      if (parent is ViewGroup) {
++        parent.removeView(child)
+       }
+     }
+-    val removedChildrenCount = childrenViews.size
+     childrenViews.clear()
+     notifyItemRangeRemoved(0, removedChildrenCount)
+   }


### PR DESCRIPTION
## Summary
- Patch `react-native-pager-view@3.0.78` so `ViewPagerAdapter.removeAll()` no longer removes ViewPager2 RecyclerView holder containers directly.
- Detach only React Native page child views and leave holder container removal/recycling to RecyclerView.

## Intent & Context
Android release `so.onekey.app.wallet@6.4.0+2026061231` has low-frequency Play Console and Sentry crashes grouped under `REACT-NATIVE-1ZK`: `IllegalArgumentException: Scrapped or attached views may not be recycled`. The native stack points through `RecyclerView$Recycler.recycleViewHolderInternal`, `LinearLayoutManager`, `ViewPager2$RecyclerViewImpl`, and `com.reactnativepagerview.ViewPagerAdapter`.

Runtime scope is main React Native runtime plus Android native UI thread. The involved RecyclerView, ViewPager2, PagerView adapter, holder containers, and React Native page views are Android native UI resources. There is no evidence that bg JS participates in this crash.

## Root Cause
`ViewPagerAdapter.removeAll()` removed `child.parent.parent` directly. At runtime, `child.parent` is the ViewPager holder `FrameLayout`, and `child.parent.parent` is the internal ViewPager2 RecyclerView. After directly removing those holder containers, the adapter cleared its child list and sent `notifyItemRangeRemoved`. This bypasses RecyclerView ownership of holder detach/recycle state. During a later ViewPager2/LinearLayoutManager recycle pass, RecyclerView can still see a holder as attached or scrapped and throws `Scrapped or attached views may not be recycled`.

## Design Decisions
The fix avoids swallowing RecyclerView exceptions. Instead, it preserves RecyclerView ownership invariants: `removeAll()` detaches only React Native page children from their immediate holder containers, then lets RecyclerView process holder removal from the adapter notification. JS-only stabilization was not enough because navigation unmounts and third-party Tabs usage can still call native `removeAll()`.

## Changes Detail
- `patches/react-native-pager-view+3.0.78.patch`: changes `ViewPagerAdapter.removeAll()` to return early for zero children, remove only page child views from their immediate parent, and stop directly removing RecyclerView holder containers.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile Android
- **Risk Areas**: PagerView/ViewPager2 unmount and dynamic page removal paths. The change is native-module scoped and should not affect iOS, web, desktop, or extension. Remaining risk is any separate ViewPager2 timing race outside `removeAll()`.

## Test plan
- [x] Wrote root-cause analysis to `node_modules/.cache/bugs/android-pager-view-recycle-crash-react-native-1zk.md`.
- [x] Verified patch-package applies in a temporary pristine alias install: `react-native-pager-view@3.0.78 ✔`.
- [x] Verified the patch has no `android/build` entries.
- [x] Ran `JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.15/libexec/openjdk.jdk/Contents/Home ./gradlew :react-native-pager-view:compileDebugKotlin --no-daemon --console=plain`.
- [x] Ran `yarn agent:check --profile commit`.
