### PR TITLE
fix: guard Android RN drawing order

### DIFF
--- a/patches/react-native+0.81.5.patch
+++ b/patches/react-native+0.81.5.patch
@@ -608,10 +608,47 @@ index 9f50554..23eaaa8 100644
    }
  
 diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.kt b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.kt
-index f8dd833..db25f53 100644
+index f8dd833..3dd085c 100644
 --- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.kt
 +++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.kt
-@@ -67,6 +67,10 @@ public class ViewGroupDrawingOrderHelper(private val viewGroup: ViewGroup) {
+@@ -55,11 +55,34 @@ public class ViewGroupDrawingOrderHelper(private val viewGroup: ViewGroup) {
+    * The index of the child view that should be drawn. This should be used in
+    * [ViewGroup.getChildDrawingOrder].
+    */
++  private fun isInvalidDrawingOrderIndex(childIndex: Int, childCount: Int): Boolean =
++      childIndex < 0 || childIndex >= childCount
++
++  private fun defaultDrawingOrderIndex(childCount: Int, index: Int): Int =
++      if (childCount > 0) index.coerceIn(0, childCount - 1) else 0
++
++  private fun resetAndGetDefaultDrawingOrder(
++      childCount: Int,
++      index: Int,
++      childIndex: Int?,
++  ): Int {
++    FLog.w(
++        ReactConstants.TAG,
++        "getChildDrawingOrder returned invalid index after rebuild. " +
++            "childCount = %d, index = %d, childIndex = %d",
++        childCount,
++        index,
++        childIndex ?: -1)
++    update()
++    return defaultDrawingOrderIndex(childCount, index)
++  }
++
+   public fun getChildDrawingOrder(childCount: Int, index: Int): Int {
+     var currentDrawingOrderIndices = this.drawingOrderIndices
+     if (currentDrawingOrderIndices != null &&
+-        (index >= currentDrawingOrderIndices.size ||
+-            currentDrawingOrderIndices[index] >= childCount)) {
++        (index < 0 ||
++            index >= currentDrawingOrderIndices.size ||
++            isInvalidDrawingOrderIndex(currentDrawingOrderIndices[index], childCount))) {
+       FLog.w(
+           ReactConstants.TAG,
+           "getChildDrawingOrder index out of bounds! Please check any custom view manipulations you" +
+@@ -67,6 +90,10 @@ public class ViewGroupDrawingOrderHelper(private val viewGroup: ViewGroup) {
            childCount,
            index)
        update()
@@ -622,6 +659,39 @@ index f8dd833..db25f53 100644
      }
  
      if (currentDrawingOrderIndices == null) {
+@@ -83,15 +110,30 @@ public class ViewGroupDrawingOrderHelper(private val viewGroup: ViewGroup) {
+       }
+ 
+       currentDrawingOrderIndices = IntArray(childCount)
++      var hasInvalidDrawingOrderIndex = false
+       for (i in 0 until childCount) {
+         val child = viewsToSort[i]
+-        currentDrawingOrderIndices[i] = viewGroup.indexOfChild(child)
++        val childIndex = viewGroup.indexOfChild(child)
++        currentDrawingOrderIndices[i] = childIndex
++        if (isInvalidDrawingOrderIndex(childIndex, childCount)) {
++          hasInvalidDrawingOrderIndex = true
++        }
++      }
++
++      if (hasInvalidDrawingOrderIndex) {
++        return resetAndGetDefaultDrawingOrder(
++            childCount, index, currentDrawingOrderIndices.getOrNull(index))
+       }
+ 
+       this.drawingOrderIndices = currentDrawingOrderIndices
+     }
+ 
+-    return currentDrawingOrderIndices[index]
++    val childIndex = currentDrawingOrderIndices.getOrNull(index)
++    if (childIndex == null || isInvalidDrawingOrderIndex(childIndex, childCount)) {
++      return resetAndGetDefaultDrawingOrder(childCount, index, childIndex)
++    }
++
++    return childIndex
+   }
+ 
+   /** Recheck all children for z-index changes. */
 diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
 index 89b666d..246c9cf 100644
 --- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt


### PR DESCRIPTION
## Summary
- Harden React Native Android `ViewGroupDrawingOrderHelper` against stale or invalid child drawing-order indices.
- Persist the native RN source change through `patches/react-native+0.81.5.patch`.
- Keep the fallback narrow: reset inconsistent helper state and draw one frame in default child order instead of catching broad draw exceptions.

## Intent & Context
Android release `so.onekey.app.wallet@6.4.0+2026061231` has Sentry and Play Console crashes where `getChildDrawingOrder()` returns indices such as `6` or `5` while the current Android child count is `2` or `3`. The reported stack is on the Android UI thread under `ViewGroup.getAndVerifyPreorderedIndex`, `ReactViewGroup.dispatchDraw`, and `ReactViewGroup.drawChild`.

This is not a background JS crash. Runtime scope is the main runtime plus the Android native UI thread. The native resource is the per-`ReactViewGroup` Android View state and helper cache. JS heap state is a main-runtime copy; the bg runtime is not assumed to participate.

## Root Cause
Browser/WebView to Buy navigation can rapidly hide, remove, or remount native child views under `ReactViewGroup` parents that use Android custom child drawing order because of zIndex. Existing local RN patching already handled one stale-cache path by forcing a rebuild after detecting an out-of-bounds cached array.

The remaining unsafe edge was after rebuild: `ViewGroupDrawingOrderHelper` still returned rebuilt indices without validating the requested slot or returned child index. If the native child set changed during the same draw/mount frame, Android could receive an invalid child index and crash in `getAndVerifyPreorderedIndex`.

ExpoImage prop errors were seen in breadcrumbs near one sample, but current evidence points to those as correlated UI churn rather than the direct drawing-order crash root cause.

## Design Decisions
- Chose a narrow RN helper guard instead of removing zIndex/Freeze/animation usage around Browser or Buy, because the crash mechanism is generic to RN Android custom drawing order.
- Avoided catching `IndexOutOfBoundsException` around `ReactViewGroup.dispatchDraw`, because that would hide broader rendering failures and may skip drawing.
- On invalid rebuilt state, reset the helper and return a valid default current-frame child order. This prevents the process crash while preserving normal zIndex ordering on subsequent frames.

## Changes Detail
- `patches/react-native+0.81.5.patch`: extends `ViewGroupDrawingOrderHelper.kt` validation for cached and rebuilt drawing-order indices, logs the invalid rebuilt state, resets helper state, and falls back to a bounded default drawing index for the current frame.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile Android
- **Risk Areas**: One frame may draw in default child order if native child membership is inconsistent during draw traversal. The release pipeline must consume the patched ReactAndroid source or a locally published/patched `react-android` artifact.

## Test plan
- [x] `yarn agent:check --profile commit`
- [x] Regenerated `patches/react-native+0.81.5.patch` with patch-package workflow.
- [x] Verified the patch excludes `android/build` and `.DS_Store` artifacts.
- [x] Applied the patch cleanly to pristine `react-native@0.81.5` from Yarn cache.
- [x] `ANDROID_HOME=/Users/huhuanming/Library/Android/sdk ANDROID_SDK_ROOT=/Users/huhuanming/Library/Android/sdk JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.15/libexec/openjdk.jdk/Contents/Home ./apps/mobile/android/gradlew -p node_modules/react-native --include-build /Users/huhuanming/Project/app-monorepo/node_modules/@react-native/gradle-plugin :packages:react-native:ReactAndroid:compileDebugKotlin --no-daemon`
