### PR TITLE
fix: use ble animation for ledger onboarding(OK-57795)

### DIFF
--- a/packages/kit/src/views/Onboardingv2/pages/ConnectionFlowLedger.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ConnectionFlowLedger.tsx
@@ -9,12 +9,15 @@ import {
   Button,
   EVideoResizeMode,
   HeightTransition,
+  LottieView,
   SizableText,
+  Stack,
   Toast,
   Video,
   XStack,
   YStack,
 } from '@onekeyhq/components';
+import BluetoothSignalSpreading from '@onekeyhq/kit/assets/animations/bluetooth_signal_spreading.json';
 import { usePromptWebDeviceAccess } from '@onekeyhq/kit/src/hooks/usePromptWebDeviceAccess';
 import { ThirdPartyDevicePermissionDenied } from '@onekeyhq/shared/src/errors/errors/thirdPartyHardwareErrors';
 import { convertDeviceError } from '@onekeyhq/shared/src/errors/utils/deviceErrorUtils';
@@ -69,6 +72,36 @@ function DeviceVideo({ themeVariant }: { themeVariant: 'light' | 'dark' }) {
   );
 }
 
+function DevicePlaceholder({
+  isBle,
+  themeVariant,
+}: {
+  isBle: boolean;
+  themeVariant: 'light' | 'dark';
+}) {
+  return (
+    <Stack
+      w="100%"
+      h="100%"
+      alignItems="center"
+      justifyContent="center"
+      bg="$bgSubdued"
+    >
+      {isBle ? (
+        <LottieView
+          source={BluetoothSignalSpreading}
+          width={320}
+          height={320}
+          autoPlay
+          loop
+        />
+      ) : (
+        <DeviceVideo themeVariant={themeVariant} />
+      )}
+    </Stack>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Main Ledger connection flow — same structure as USBOrBLEConnectionIndicator
 // ---------------------------------------------------------------------------
@@ -84,7 +117,7 @@ export default function LedgerConnectionFlow() {
   const tabValue = EConnectDeviceChannel.usbOrBle;
   const deviceLabel = 'Ledger';
   // Mobile (iOS/Android) uses BLE; extension and desktop use USB.
-  const isBle = platformEnv.isNative;
+  const isBle = Boolean(platformEnv.isNative);
 
   // --- Device connection state (copied from useDeviceConnection) ---
   const [connectStatus, setConnectStatus] = useState(EConnectionStatus.init);
@@ -273,13 +306,13 @@ export default function LedgerConnectionFlow() {
     [stopScan],
   );
 
-  // --- Render (1:1 copy of USBOrBLEConnectionIndicator USB branch) ---
+  // --- Render ---
   return (
     <>
       <ConnectionIndicator>
         <ConnectionIndicator.Card>
           <ConnectionIndicator.Animation>
-            <DeviceVideo themeVariant={themeVariant} />
+            <DevicePlaceholder isBle={isBle} themeVariant={themeVariant} />
           </ConnectionIndicator.Animation>
           <ConnectionIndicator.Content gap="$2">
             <ConnectionIndicator.Title>


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57795](https://onekeyhq.atlassian.net/browse/OK-57795)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Show the Bluetooth signal Lottie animation in the Ledger onboarding connection card on native mobile platforms.
- Preserve the existing theme-aware Ledger device video for USB-based desktop, extension, and web flows.

## Intent & Context
Ledger onboarding should visually match the connection channel used by each platform. Mobile iOS and Android connect through BLE, while desktop, extension, and web use the USB flow. This change addresses OK-57795 by giving native users BLE-specific connection guidance.

## Root Cause
The connection card always rendered `DeviceVideo`, even though the flow already derived `isBle` from the native platform environment. As a result, native users saw USB-oriented device media while entering the BLE connection flow.

## Design Decisions
- Reuse the existing `bluetooth_signal_spreading.json` animation and the shared `LottieView` component instead of adding a new asset.
- Keep platform selection local to the onboarding animation placeholder so scanning, permissions, and connection state behavior remain unchanged.
- Retain the existing light/dark Ledger video for non-BLE platforms.

## Changes Detail
- `packages/kit/src/views/Onboardingv2/pages/ConnectionFlowLedger.tsx`: add a channel-aware animation placeholder that renders the Bluetooth Lottie animation for native BLE and the existing device video for USB.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile, Desktop, Extension, Web
- **Risk Areas**: Native Lottie sizing and ensuring the existing USB video remains unchanged on non-native platforms.

## Test plan
- [x] Run `yarn agent:check --profile commit`.
- [ ] Verify the Bluetooth signal animation is displayed in Ledger onboarding on iOS and Android.
- [ ] Verify the Ledger device video still renders in desktop, extension, and web USB flows in both light and dark themes.

[OK-57795]: https://onekeyhq.atlassian.net/browse/OK-57795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ