### PR TITLE
feat: support Spark Savings in Earn (OK-57595)

### DIFF
--- a/packages/kit-bg/src/services/ServiceStaking.ts
+++ b/packages/kit-bg/src/services/ServiceStaking.ts
@@ -1099,6 +1099,7 @@ class ServiceStaking extends ServiceBase {
     accountId: string;
     symbol: string;
     provider: string;
+    vault?: string;
   }) {
     const { networkId, accountId, symbol, ...rest } = params;
     const vault = await vaultFactory.getVault({ networkId, accountId });

--- a/packages/kit-bg/src/vaults/impls/evm/settings.test.ts
+++ b/packages/kit-bg/src/vaults/impls/evm/settings.test.ts
@@ -1,0 +1,35 @@
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
+import {
+  EthereumUSDC,
+  EthereumUSDT,
+} from '@onekeyhq/shared/src/consts/addresses';
+import { EEarnProviderEnum } from '@onekeyhq/shared/types/earn';
+
+import settings from './settings';
+
+describe('EVM Spark Earn settings', () => {
+  it('enables Spark Savings for Ethereum USDC and USDT', () => {
+    const sparkConfig =
+      settings.stakingConfig?.[getNetworkIdsMap().eth]?.providers[
+        EEarnProviderEnum.Spark
+      ];
+
+    expect(sparkConfig).toEqual({
+      supportedSymbols: ['USDC', 'USDT'],
+      configs: {
+        USDC: {
+          enabled: true,
+          tokenAddress: EthereumUSDC,
+          displayProfit: true,
+          stakingWithApprove: true,
+        },
+        USDT: {
+          enabled: true,
+          tokenAddress: EthereumUSDT,
+          displayProfit: true,
+          stakingWithApprove: true,
+        },
+      },
+    });
+  });
+});

--- a/packages/kit-bg/src/vaults/impls/evm/settings.ts
+++ b/packages/kit-bg/src/vaults/impls/evm/settings.ts
@@ -156,6 +156,23 @@ const stakingConfig: IStakingConfig = {
           },
         },
       },
+      [EEarnProviderEnum.Spark]: {
+        supportedSymbols: ['USDC', 'USDT'],
+        configs: {
+          USDC: {
+            enabled: true,
+            tokenAddress: EthereumUSDC,
+            displayProfit: true,
+            stakingWithApprove: true,
+          },
+          USDT: {
+            enabled: true,
+            tokenAddress: EthereumUSDT,
+            displayProfit: true,
+            stakingWithApprove: true,
+          },
+        },
+      },
       [EEarnProviderEnum.Pendle]: {
         supportedSymbols: [],
         configs: {},

--- a/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
@@ -391,10 +391,6 @@ export function UniversalWithdraw({
     () => earnUtils.isPendleProvider({ providerName: providerName ?? '' }),
     [providerName],
   );
-  const isNativeProvider = useMemo(
-    () => earnUtils.isNativeProvider({ providerName: providerName ?? '' }),
-    [providerName],
-  );
   const shouldSendProtocolVault = useMemo(
     () =>
       earnUtils.shouldSendEarnProtocolVault({
@@ -404,13 +400,8 @@ export function UniversalWithdraw({
   );
 
   const withdrawPathConfirmBoxes = useMemo(() => {
-    if (!(isPendleProvider || isNativeProvider)) return [];
     return transactionConfirmation?.withdrawPath?.data?.confirmBoxes ?? [];
-  }, [
-    isPendleProvider,
-    isNativeProvider,
-    transactionConfirmation?.withdrawPath?.data?.confirmBoxes,
-  ]);
+  }, [transactionConfirmation?.withdrawPath?.data?.confirmBoxes]);
 
   const effectiveSelectedWithdrawPathIndex = useMemo(() => {
     if (withdrawPathConfirmBoxes.length <= 1) return 0;
@@ -453,8 +444,7 @@ export function UniversalWithdraw({
     [rootTransactionTip, selectedWithdrawPath?.tip],
   );
 
-  const isNativeQueuedWithdraw =
-    isNativeProvider && selectedWithdrawType === 'queued';
+  const isQueuedWithdraw = selectedWithdrawType === 'queued';
 
   const handleTipAction = useCallback(
     async (tip?: IEarnTransactionTip) => {
@@ -479,7 +469,7 @@ export function UniversalWithdraw({
   );
 
   const approveAmountValue = useMemo(() => {
-    if (!isNativeQueuedWithdraw || !receiptTokenRate) {
+    if (!isQueuedWithdraw || !receiptTokenRate) {
       return amountValue;
     }
 
@@ -512,15 +502,14 @@ export function UniversalWithdraw({
     amountValue,
     approveTarget?.token?.decimals,
     decimals,
-    isNativeQueuedWithdraw,
+    isQueuedWithdraw,
     isWithdrawAll,
     receiptTokenRate,
   ]);
 
-  // --- Approve logic (Pendle sell and Native queued withdraw) ---
+  // --- Approve logic (Pendle sell and server-declared queued withdraw) ---
   const useApprove =
-    (isPendleProvider || isNativeQueuedWithdraw) &&
-    !!approveTarget?.spenderAddress;
+    (isPendleProvider || isQueuedWithdraw) && !!approveTarget?.spenderAddress;
   const [approving, setApproving] = useState(false);
   const allowanceAbortRef = useRef<AbortController | undefined>(undefined);
 

--- a/packages/kit/src/views/Staking/pages/ManagePosition/components/WithdrawSection.tsx
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/components/WithdrawSection.tsx
@@ -113,9 +113,9 @@ export const WithdrawSection = ({
     [protocolInfo?.provider],
   );
   const isPendleProvider = useIsPendleProvider(providerName);
-  const isNativeProvider = useMemo(
-    () => earnUtils.isNativeProvider({ providerName }),
-    [providerName],
+  const hasWithdrawApprove = Boolean(
+    protocolInfo?.withdrawApprove?.approveTarget &&
+    protocolInfo.withdrawApprove.tokenAddress,
   );
   const borrowProviderDisplayName = useMemo(() => {
     if (
@@ -130,7 +130,7 @@ export const WithdrawSection = ({
   }, [protocolInfo?.providerDetail.name, providerName]);
 
   const approveSpenderAddress = useMemo(() => {
-    if (isNativeProvider) {
+    if (hasWithdrawApprove) {
       return protocolInfo?.withdrawApprove?.approveTarget ?? '';
     }
     return isPendleProvider
@@ -142,7 +142,7 @@ export const WithdrawSection = ({
       : '';
   }, [
     isPendleProvider,
-    isNativeProvider,
+    hasWithdrawApprove,
     providerName,
     protocolInfo?.vault,
     protocolInfo?.approve?.approveTarget,
@@ -154,11 +154,7 @@ export const WithdrawSection = ({
     [tokenInfo],
   );
   const withdrawApproveToken = useMemo(() => {
-    if (
-      !isNativeProvider ||
-      !protocolInfo?.withdrawApprove?.tokenAddress ||
-      !token
-    ) {
+    if (!protocolInfo?.withdrawApprove?.tokenAddress || !token) {
       return token;
     }
     return {
@@ -166,12 +162,12 @@ export const WithdrawSection = ({
       address: protocolInfo.withdrawApprove.tokenAddress,
       isNative: false,
     };
-  }, [isNativeProvider, protocolInfo?.withdrawApprove?.tokenAddress, token]);
+  }, [protocolInfo?.withdrawApprove?.tokenAddress, token]);
 
   const { result: initialAllowanceResult } = usePromiseResult(
     async () => {
       if (
-        !(isPendleProvider || isNativeProvider) ||
+        !(isPendleProvider || hasWithdrawApprove) ||
         !approveSpenderAddress ||
         !accountId ||
         !networkId ||
@@ -193,7 +189,7 @@ export const WithdrawSection = ({
     },
     [
       isPendleProvider,
-      isNativeProvider,
+      hasWithdrawApprove,
       approveSpenderAddress,
       accountId,
       networkId,
@@ -205,7 +201,7 @@ export const WithdrawSection = ({
 
   const approveTarget = useMemo(() => {
     if (
-      !(isPendleProvider || isNativeProvider) ||
+      !(isPendleProvider || hasWithdrawApprove) ||
       !approveSpenderAddress ||
       !withdrawApproveToken
     ) {
@@ -219,7 +215,7 @@ export const WithdrawSection = ({
     };
   }, [
     isPendleProvider,
-    isNativeProvider,
+    hasWithdrawApprove,
     approveSpenderAddress,
     accountId,
     networkId,
@@ -1146,7 +1142,9 @@ export const WithdrawSection = ({
           approveTarget={approveTarget}
           currentAllowance={initialAllowanceResult?.allowanceParsed}
           receiptTokenRate={
-            protocolInfo?.receiptTokenRate ?? protocolInfo?.morphoTokenRate
+            protocolInfo?.withdrawApprove?.receiptTokenRate ??
+            protocolInfo?.receiptTokenRate ??
+            protocolInfo?.morphoTokenRate
           }
           pendleSlippage={pendleSlippage}
         />

--- a/packages/kit/src/views/Staking/pages/ManagePosition/hooks/useManagePage.ts
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/hooks/useManagePage.ts
@@ -289,6 +289,7 @@ export const useManagePage = ({
       // supply max balance for supply max button
       maxSupplyBalance: managePageData.supply?.data?.maxBalance,
       receiptTokenRate:
+        managePageData.withdrawApprove?.receiptTokenRate ??
         matchingProtocol?.provider.receiptTokenRate ??
         matchingProtocol?.provider.morphoTokenRate,
       morphoTokenRate: matchingProtocol?.provider.morphoTokenRate,

--- a/packages/kit/src/views/Staking/pages/ProtocolDetailsV2/index.tsx
+++ b/packages/kit/src/views/Staking/pages/ProtocolDetailsV2/index.tsx
@@ -629,6 +629,7 @@ const ProtocolDetailsPage = () => {
       protocolInputDecimals: detailInfo.protocolInputDecimals,
       withdrawApprove: detailInfo.withdrawApprove,
       receiptTokenRate:
+        detailInfo.withdrawApprove?.receiptTokenRate ??
         detailInfo.protocol.receiptTokenRate ??
         detailInfo.protocol.morphoTokenRate,
       morphoTokenRate: detailInfo.protocol.morphoTokenRate,

--- a/packages/kit/src/views/Staking/pages/Withdraw/index.tsx
+++ b/packages/kit/src/views/Staking/pages/Withdraw/index.tsx
@@ -54,16 +54,8 @@ const WithdrawPage = () => {
   const appNavigation = useAppNavigation();
   const handleWithdraw = useUniversalWithdraw({ accountId, networkId });
   const withdrawAbortRef = useRef<AbortController | null>(null);
-  const isNativeProvider = useMemo(
-    () => earnUtils.isNativeProvider({ providerName }),
-    [providerName],
-  );
-  const nativeWithdrawApproveToken = useMemo(() => {
-    if (
-      !isNativeProvider ||
-      !protocolInfo?.withdrawApprove?.tokenAddress ||
-      !token
-    ) {
+  const withdrawApproveToken = useMemo(() => {
+    if (!protocolInfo?.withdrawApprove?.tokenAddress || !token) {
       return undefined;
     }
     return {
@@ -71,31 +63,25 @@ const WithdrawPage = () => {
       address: protocolInfo.withdrawApprove.tokenAddress,
       isNative: false,
     };
-  }, [isNativeProvider, protocolInfo?.withdrawApprove?.tokenAddress, token]);
-  const nativeWithdrawApproveSpender =
-    protocolInfo?.withdrawApprove?.approveTarget;
-  const { result: nativeWithdrawAllowance } = usePromiseResult(
+  }, [protocolInfo?.withdrawApprove?.tokenAddress, token]);
+  const withdrawApproveSpender = protocolInfo?.withdrawApprove?.approveTarget;
+  const { result: withdrawAllowance } = usePromiseResult(
     async () => {
-      if (
-        !isNativeProvider ||
-        !nativeWithdrawApproveToken?.address ||
-        !nativeWithdrawApproveSpender
-      ) {
+      if (!withdrawApproveToken?.address || !withdrawApproveSpender) {
         return undefined;
       }
       return backgroundApiProxy.serviceStaking.fetchTokenAllowance({
         accountId,
         networkId,
-        spenderAddress: nativeWithdrawApproveSpender,
-        tokenAddress: nativeWithdrawApproveToken.address,
+        spenderAddress: withdrawApproveSpender,
+        tokenAddress: withdrawApproveToken.address,
       });
     },
     [
       accountId,
       networkId,
-      isNativeProvider,
-      nativeWithdrawApproveSpender,
-      nativeWithdrawApproveToken?.address,
+      withdrawApproveSpender,
+      withdrawApproveToken?.address,
     ],
     { watchLoading: true },
   );
@@ -251,18 +237,20 @@ const WithdrawPage = () => {
           }
           protocolVault={vault}
           approveTarget={
-            nativeWithdrawApproveSpender && nativeWithdrawApproveToken
+            withdrawApproveSpender && withdrawApproveToken
               ? {
                   accountId,
                   networkId,
-                  spenderAddress: nativeWithdrawApproveSpender,
-                  token: nativeWithdrawApproveToken,
+                  spenderAddress: withdrawApproveSpender,
+                  token: withdrawApproveToken,
                 }
               : undefined
           }
-          currentAllowance={nativeWithdrawAllowance?.allowanceParsed}
+          currentAllowance={withdrawAllowance?.allowanceParsed}
           receiptTokenRate={
-            protocolInfo?.receiptTokenRate ?? protocolInfo?.morphoTokenRate
+            protocolInfo?.withdrawApprove?.receiptTokenRate ??
+            protocolInfo?.receiptTokenRate ??
+            protocolInfo?.morphoTokenRate
           }
         />
       </Page.Body>

--- a/packages/kit/src/views/Staking/pages/WithdrawOptions/index.tsx
+++ b/packages/kit/src/views/Staking/pages/WithdrawOptions/index.tsx
@@ -51,8 +51,9 @@ const WithdrawOptions = () => {
         accountId,
         symbol,
         provider,
+        vault: protocolInfo?.vault,
       }),
-    [accountId, networkId, symbol, provider],
+    [accountId, networkId, symbol, provider, protocolInfo?.vault],
     { watchLoading: true },
   );
 

--- a/packages/shared/src/utils/earnUtils.test.ts
+++ b/packages/shared/src/utils/earnUtils.test.ts
@@ -1,4 +1,33 @@
+import { EEarnProviderEnum } from '../../types/earn';
+import { normalizeToEarnProvider } from '../../types/earn/earnProvider.constants';
+
 import earnUtils from './earnUtils';
+
+describe('earnUtils Spark provider integration', () => {
+  it('normalizes Spark provider identity for Earn routes and config lookup', () => {
+    expect(normalizeToEarnProvider('spark')).toBe(EEarnProviderEnum.Spark);
+    expect(earnUtils.getEarnProviderEnumKey('spark')).toBe(
+      EEarnProviderEnum.Spark,
+    );
+    expect(earnUtils.getEarnProviderName({ providerName: 'spark' })).toBe(
+      EEarnProviderEnum.Spark,
+    );
+  });
+
+  it('uses the protocol vault for Spark requests and ERC20 approval', () => {
+    const protocolVault = '0x28B3a8fb53B741A8Fd78c0fb9A6B2393d896a43d';
+
+    expect(
+      earnUtils.shouldSendEarnProtocolVault({ providerName: 'spark' }),
+    ).toBe(true);
+    expect(
+      earnUtils.resolveEarnApproveSpenderAddress({
+        providerName: 'spark',
+        protocolVault,
+      }),
+    ).toBe(protocolVault);
+  });
+});
 
 describe('earnUtils borrow address normalization', () => {
   describe('normalizeBorrowAddress', () => {

--- a/packages/shared/src/utils/earnUtils.ts
+++ b/packages/shared/src/utils/earnUtils.ts
@@ -41,6 +41,8 @@ const isEverstakeProvider = createProviderCheck(EEarnProviderEnum.Everstake);
 
 const isMorphoProvider = createProviderCheck(EEarnProviderEnum.Morpho);
 
+const isSparkProvider = createProviderCheck(EEarnProviderEnum.Spark);
+
 const isPendleProvider = createProviderCheck(EEarnProviderEnum.Pendle);
 
 const isNativeProvider = createProviderCheck(EEarnProviderEnum.Native);
@@ -58,6 +60,7 @@ const isMomentumProvider = createProviderCheck(EEarnProviderEnum.Momentum);
 const isVaultBasedProvider = ({ providerName }: { providerName: string }) => {
   return (
     isMorphoProvider({ providerName }) ||
+    isSparkProvider({ providerName }) ||
     isPendleProvider({ providerName }) ||
     isListaProvider({ providerName }) ||
     isMomentumProvider({ providerName })
@@ -271,6 +274,7 @@ export default {
   buildEarnAccountKey,
   getEarnProviderEnumKey,
   isMorphoProvider,
+  isSparkProvider,
   isPendleProvider,
   isNativeProvider,
   isListaProvider,

--- a/packages/shared/types/earn.ts
+++ b/packages/shared/types/earn.ts
@@ -15,6 +15,7 @@ export enum EEarnProviderEnum {
   Stakefish = 'Stakefish',
   Kamino = 'Kamino',
   Native = 'Native',
+  Spark = 'Spark',
 }
 
 export type ISupportedSymbol =

--- a/packages/shared/types/earn/earnProvider.constants.ts
+++ b/packages/shared/types/earn/earnProvider.constants.ts
@@ -193,6 +193,7 @@ export function normalizeToEarnProvider(
     'ethena': EEarnProviderEnum.Ethena,
     'momentum': EEarnProviderEnum.Momentum,
     'native': EEarnProviderEnum.Native,
+    'spark': EEarnProviderEnum.Spark,
     'staked': EEarnProviderEnum.Lista,
   };
   return providerMap[provider.toLowerCase()];

--- a/packages/shared/types/staking.ts
+++ b/packages/shared/types/staking.ts
@@ -118,6 +118,7 @@ export type IEarnWithdrawApproveInfo = {
   approveTarget?: string;
   tokenAddress?: string;
   allowance?: string;
+  receiptTokenRate?: string;
 };
 
 export type IStakeProviderInfo = {


### PR DESCRIPTION
## Summary

- recognize Spark Savings as an Earn provider across main and background runtimes
- enable Spark Ethereum USDC and USDT vault flows
- support server-declared instant/queued withdrawal paths, share-token approval, pending requests, and cancellation
- preserve the server-returned protocol vault across stake, withdraw, confirmation, history, and pending-list requests

## Issues

- OK-57595

## Intent & Context

Spark integration follows the implemented `server-service-earn` capability range. The App must not restrict Spark to instant withdrawal when the server exposes queued Savings Liquidity Intents.

Server contract references checked for this integration:

- `server-service-earn` `origin/dev@4b473362`
- `server-service-earn` `origin/feat/spark-savings@eaabe173`

## Design Decisions

- Reuse the existing vault-based ERC20 flow used by Morpho.
- Treat structured server fields as the source of truth; do not infer queued behavior from translated alert text.
- Render `withdrawPath` for any provider that returns it instead of hard-coding Pendle/Native.
- Enable queued approval whenever the server returns `withdrawApprove` and the selected path is `queued`.
- Keep the exact `provider/network/symbol/vault/account/withdrawType` identity across the main-to-background proxy boundary.

## Changes Detail

- add Spark provider identity and normalization
- classify Spark as vault-based for route, request, and approval handling
- add Ethereum USDC/USDT staking settings with approval enabled
- make queued withdraw selection and approval provider-agnostic and server-driven
- carry the Spark vault into pending withdrawal list requests
- accept receipt-token conversion rate with the server withdrawal approval contract
- add focused provider, approval-spender, and settings coverage

## Risk Assessment

- **Risk level:** High until the server exposure gate below is satisfied
- **Affected platforms:** Mobile, Desktop, Web, Extension
- **Runtime scope:** main and bg JS runtimes; route, confirmation, approval, and pending data cross the proxy boundary as serialized copies
- **Native resources:** no new native resource or persistence owner
- **Deployment dependency:** server provider/protocol/Mongo configuration must be enabled after a compatible client is available
- **Server exposure gate:** the Spark service implements queued request/cancel, pending lookup, and share approval internally, but its public detail/manage/transaction-confirmation responses must expose structured `withdrawPath` and `withdrawApprove` data. `withdrawApprove` must include the share token address, Intents spender, and receipt-token conversion rate. The App intentionally does not hard-code these server-owned values.

## Test Plan

- [x] Spark provider/settings Jest suites: 2 suites, 10 tests
- [x] `yarn agent:check --profile commit`
- [x] `yarn agent:check --profile pr`
- [x] Static App/server DTO and handler alignment review
- [ ] Verify Spark is aggregated under USDC/USDT in the test Earn UI after API deployment
- [ ] Verify instant withdrawal below available liquidity
- [ ] Verify queued partial/full withdrawal above available liquidity
- [ ] Verify spToken approval targets the server-returned Intents contract with the server-returned conversion rate
- [ ] Verify pending request display and cancellation
- [ ] Verify desktop/web and at least one native Discovery entry
