### PR TITLE
fix: polish perp ticker and tif popover

### DIFF
--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
@@ -61,6 +61,12 @@ const TICKER_BAR_STAT_VALUE_TEXT_PROPS = {
 
 const TICKER_BAR_STAT_LABEL_VALUE_GAP = 5;
 const TICKER_BAR_STAT_DASH_LABEL_VALUE_GAP = 4;
+const TICKER_BAR_PRICE_SECTION_WIDTH = 90;
+const TICKER_BAR_WIDE_PRICE_SECTION_WIDTH = 120;
+const TICKER_BAR_SPOT_PRICE_SECTION_WIDTH = 168;
+const TICKER_BAR_WIDE_MARK_PRICE_LENGTH = 8;
+const TICKER_BAR_WIDE_CHANGE_DISPLAY_LENGTH = 15;
+
 function isValidPerpFormattedCtx(
   ctx: ReturnType<typeof formatAssetCtx> | undefined,
 ) {
@@ -129,6 +135,27 @@ function useTickerBarPerpAssetCtx() {
   return resolved.assetCtx;
 }
 
+function formatTickerBarChange24hDisplay({
+  change24h,
+  change24hPercent,
+}: {
+  change24h?: string;
+  change24hPercent?: string | number;
+}) {
+  const changeValue = change24h || '0';
+  const signedChangeValue =
+    changeValue.startsWith('-') || changeValue === '0'
+      ? changeValue
+      : `+${changeValue}`;
+  const percentText = numberFormat(String(change24hPercent || 0), {
+    formatter: 'priceChange',
+    formatterOptions: {
+      showPlusMinusSigns: true,
+    },
+  });
+  return `${signedChangeValue} (${percentText})`;
+}
+
 function useTickerBarIsLoading() {
   const { currentToken } = usePerpSession();
   const [tradingMode] = useTradingModeAtom();
@@ -179,6 +206,7 @@ const TickerBarMarkPriceView = memo(
                 fontWeight="500"
                 cursor="help"
                 lineHeight={20}
+                numberOfLines={1}
               >
                 {formattedMarkPrice}
               </SizableText>
@@ -245,10 +273,11 @@ const TickerBarChange24hView = memo(
         <SizableText
           size="$bodyXs"
           textTransform="none"
-          fontWeight="500"
+          fontWeight="600"
           letterSpacing={0.2}
           lineHeight={12}
           color={changeDisplay.trim().startsWith('-') ? '$red11' : '$green11'}
+          numberOfLines={1}
         >
           {changeDisplay}
         </SizableText>
@@ -264,21 +293,10 @@ export function TickerBarChange24h() {
   const [spotAssetCtx] = useSpotActiveAssetCtxAtom();
   const displayCtx = tradingMode === 'spot' ? spotAssetCtx?.ctx : assetCtx?.ctx;
   const changeDisplay = useMemo(() => {
-    const changeValue = displayCtx?.change24h || '0';
-    const signedChangeValue =
-      changeValue.startsWith('-') || changeValue === '0'
-        ? changeValue
-        : `+${changeValue}`;
-    const percentText = numberFormat(
-      String(displayCtx?.change24hPercent || 0),
-      {
-        formatter: 'priceChange',
-        formatterOptions: {
-          showPlusMinusSigns: true,
-        },
-      },
-    );
-    return `${signedChangeValue} (${percentText})`;
+    return formatTickerBarChange24hDisplay({
+      change24h: displayCtx?.change24h,
+      change24hPercent: displayCtx?.change24hPercent,
+    });
   }, [displayCtx?.change24h, displayCtx?.change24hPercent]);
   const isLoading = useTickerBarIsLoading();
 
@@ -871,9 +889,34 @@ function TickerBarFundingRate() {
 function PerpTickerBarDesktop() {
   const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [tradingMode] = useTradingModeAtom();
+  const assetCtx = useTickerBarPerpAssetCtx();
   const isSpot = tradingMode === 'spot';
   const marketDataGap = useMemo(() => (isSpot ? '$6' : '$6'), [isSpot]);
-  const priceSectionWidth = useMemo(() => (isSpot ? 168 : 96), [isSpot]);
+  const priceSectionWidth = useMemo(() => {
+    if (isSpot) {
+      return TICKER_BAR_SPOT_PRICE_SECTION_WIDTH;
+    }
+
+    const formattedMarkPrice = formatLocalizedNumberString(
+      assetCtx?.ctx?.markPrice || '',
+    );
+    const changeDisplay = formatTickerBarChange24hDisplay({
+      change24h: assetCtx?.ctx?.change24h,
+      change24hPercent: assetCtx?.ctx?.change24hPercent,
+    });
+    const needsWidePriceSection =
+      formattedMarkPrice.length > TICKER_BAR_WIDE_MARK_PRICE_LENGTH ||
+      changeDisplay.length > TICKER_BAR_WIDE_CHANGE_DISPLAY_LENGTH;
+
+    return needsWidePriceSection
+      ? TICKER_BAR_WIDE_PRICE_SECTION_WIDTH
+      : TICKER_BAR_PRICE_SECTION_WIDTH;
+  }, [
+    assetCtx?.ctx?.change24h,
+    assetCtx?.ctx?.change24hPercent,
+    assetCtx?.ctx?.markPrice,
+    isSpot,
+  ]);
   const content = (
     <XStack
       bg="$bgApp"

--- a/packages/kit/src/views/Perp/components/TradingPanel/selectors/TimeInForceSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/selectors/TimeInForceSelector.tsx
@@ -145,9 +145,12 @@ const TimeInForceSelector = memo<ITimeInForceSelectorProps>(
                   variant="tertiary"
                   childrenAsText={false}
                   justifyContent="flex-start"
+                  alignItems="stretch"
                   px="$3"
                   py="$2"
                   m="$0"
+                  h="auto"
+                  minHeight={isMobile ? 64 : 72}
                   borderRadius="$2"
                   onPress={() => {
                     if (disabled) {
@@ -159,9 +162,14 @@ const TimeInForceSelector = memo<ITimeInForceSelectorProps>(
                   pressStyle={{ opacity: 0.7 }}
                   hoverStyle={{ bg: '$bgHover' }}
                 >
-                  <XStack alignItems="center">
-                    <YStack flex={1} pr="$3">
-                      <Heading size="$headingSm" lineHeight={20} color="$text">
+                  <XStack width="100%" alignItems="center" gap="$3">
+                    <YStack flex={1} minWidth={0} alignItems="flex-start">
+                      <Heading
+                        size="$headingSm"
+                        lineHeight={20}
+                        color="$text"
+                        textAlign="left"
+                      >
                         {item.label}
                       </Heading>
                       <SizableText
@@ -170,6 +178,8 @@ const TimeInForceSelector = memo<ITimeInForceSelectorProps>(
                         fontSize={isMobile ? 12 : undefined}
                         lineHeight={isMobile ? 18 : undefined}
                         color="$textSubdued"
+                        flexShrink={1}
+                        textAlign="left"
                       >
                         {item.description}
                       </SizableText>


### PR DESCRIPTION
## Summary
- Prevent long Perps ticker prices and 24h changes from wrapping in the desktop ticker bar.
- Keep normal ticker rows compact while widening only when displayed price/change text is long.
- Fix Time in Force popover option layout so descriptions wrap cleanly and remain left-aligned.

## Intent & Context
The Perps desktop ticker bar wrapped small-decimal price/change text into multiple lines when assets had long decimal values. During visual review, the normal BTC-style ticker needed to stay compact, while long decimal assets needed extra width only when necessary. A second UI issue was found in the limit order TIF popover: option content was visually centered/misaligned, and long descriptions could crowd the selected check icon.

## Root Cause
The ticker price section used a fixed narrow width and allowed text to wrap naturally. The TIF popover option rows did not force the row content to occupy full width, and the text column did not explicitly allow left-aligned wrapping within the fixed popover panel.

## Design Decisions
- Use a lightweight display-length heuristic for ticker width instead of runtime text measurement to avoid layout reflow and measurement state.
- Keep the compact Perps price section at 90px and widen to 120px only when formatted price or 24h change text crosses the long-text threshold.
- Keep the TIF popover placement unchanged and fix the internal option row layout directly.

## Changes Detail
- `PerpTickerBarDesktop.tsx`: extracted 24h change formatting, added single-line text constraints, adjusted change font weight, and added dynamic compact/wide price-section widths.
- `TimeInForceSelector.tsx`: made option rows auto-height/full-width, allowed description text to shrink and wrap, and left-aligned option labels/descriptions.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Web, Desktop
- **Risk Areas**: Visual layout around Perps ticker and limit-order TIF popover.

## Test plan
- [x] Run `yarn agent:check --profile commit`
- [x] Run targeted `oxlint` for touched Perps files
- [x] Confirm web dev server recompiles after changes
- [ ] Manually verify Perps desktop ticker with normal and long-decimal assets
- [ ] Manually verify the limit order TIF popover option layout
