### PR TITLE
feat: support Bitway Earn integration(OK-56813)

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -20,6 +20,7 @@ skillshare
 bitrefill
 Bitrefill
 BITREFILL
+Bitway
 worktree
 googleusercontent
 0xf7ad23226db5c1c00ca0ca1468fd49c8f8bbc1489bc1c382de5adc557a69c229

--- a/packages/kit-bg/src/services/ServiceStaking.ts
+++ b/packages/kit-bg/src/services/ServiceStaking.ts
@@ -1074,10 +1074,11 @@ class ServiceStaking extends ServiceBase {
     accountId: string;
     symbol: string;
     provider: string;
+    vault?: string;
   }) {
     const { networkId, accountId, symbol, ...rest } = params;
-    const vault = await vaultFactory.getVault({ networkId, accountId });
-    const acc = await vault.getAccount();
+    const accountVault = await vaultFactory.getVault({ networkId, accountId });
+    const acc = await accountVault.getAccount();
     const client = await this.getClient(EServiceEndpointEnum.Earn);
     const resp = await client.get<{
       data: IClaimableListResponse;

--- a/packages/kit-bg/src/vaults/impls/evm/settings.ts
+++ b/packages/kit-bg/src/vaults/impls/evm/settings.ts
@@ -2,7 +2,10 @@ import { ECoreApiExportedSecretKeyType } from '@onekeyhq/core/src/types';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import {
   BaseUSDC,
+  BinanceSmartChainBTW,
   BinanceSmartChainLISTA,
+  BinanceSmartChainU,
+  BinanceSmartChainUSD1,
   BinanceSmartChainUSDT,
   EMPTY_NATIVE_TOKEN_ADDRESS,
   EthereumCbBTC,
@@ -283,6 +286,43 @@ const stakingConfig: IStakingConfig = {
       [EEarnProviderEnum.Pendle]: {
         supportedSymbols: [],
         configs: {},
+      },
+      [EEarnProviderEnum.Bitway]: {
+        supportedSymbols: ['USDT', 'U', 'BTW', 'USD1'],
+        configs: {
+          USDT: {
+            enabled: true,
+            tokenAddress: BinanceSmartChainUSDT,
+            displayProfit: true,
+            stakingWithApprove: true,
+            claimWithTx: true,
+            allowPartialWithdraw: true,
+          },
+          U: {
+            enabled: true,
+            tokenAddress: BinanceSmartChainU,
+            displayProfit: true,
+            stakingWithApprove: true,
+            claimWithTx: true,
+            allowPartialWithdraw: true,
+          },
+          BTW: {
+            enabled: true,
+            tokenAddress: BinanceSmartChainBTW,
+            displayProfit: true,
+            stakingWithApprove: true,
+            claimWithTx: true,
+            allowPartialWithdraw: true,
+          },
+          USD1: {
+            enabled: true,
+            tokenAddress: BinanceSmartChainUSD1,
+            displayProfit: true,
+            stakingWithApprove: true,
+            claimWithTx: true,
+            allowPartialWithdraw: true,
+          },
+        },
       },
     },
   },

--- a/packages/kit-bg/src/vaults/impls/evm/settings.ts
+++ b/packages/kit-bg/src/vaults/impls/evm/settings.ts
@@ -5,7 +5,6 @@ import {
   BinanceSmartChainBTW,
   BinanceSmartChainLISTA,
   BinanceSmartChainU,
-  BinanceSmartChainUSD1,
   BinanceSmartChainUSDT,
   EMPTY_NATIVE_TOKEN_ADDRESS,
   EthereumCbBTC,
@@ -288,7 +287,7 @@ const stakingConfig: IStakingConfig = {
         configs: {},
       },
       [EEarnProviderEnum.Bitway]: {
-        supportedSymbols: ['USDT', 'U', 'BTW', 'USD1'],
+        supportedSymbols: ['USDT', 'U', 'BTW'],
         configs: {
           USDT: {
             enabled: true,
@@ -309,14 +308,6 @@ const stakingConfig: IStakingConfig = {
           BTW: {
             enabled: true,
             tokenAddress: BinanceSmartChainBTW,
-            displayProfit: true,
-            stakingWithApprove: true,
-            claimWithTx: true,
-            allowPartialWithdraw: true,
-          },
-          USD1: {
-            enabled: true,
-            tokenAddress: BinanceSmartChainUSD1,
             displayProfit: true,
             stakingWithApprove: true,
             claimWithTx: true,

--- a/packages/kit/src/views/Earn/components/PortfolioTabContent.tsx
+++ b/packages/kit/src/views/Earn/components/PortfolioTabContent.tsx
@@ -183,6 +183,7 @@ const WrappedActionButtonCmp = ({
   const stakeTag = buildLocalTxStatusSyncId({
     providerName: asset.metadata.protocol.providerDetail.code,
     tokenSymbol: symbolForConfig,
+    protocolVault: vaultForConfig,
   });
 
   const pendingTxsFilter = useCallback(

--- a/packages/kit/src/views/Earn/hooks/useStakingPendingTxs.ts
+++ b/packages/kit/src/views/Earn/hooks/useStakingPendingTxs.ts
@@ -232,13 +232,14 @@ export const useStakingPendingTxsByInfo = ({
     const targets: { networkId: string; stakeTag: IStakeTag }[] = [];
 
     availableAssets.forEach((asset) => {
-      asset.protocols?.forEach(({ networkId, provider }) => {
+      asset.protocols?.forEach(({ networkId, provider, vault }) => {
         if (!networkId || !provider) {
           return;
         }
         const stakeTag = buildLocalTxStatusSyncId({
           providerName: provider,
           tokenSymbol: asset.symbol,
+          protocolVault: vault,
         });
         const key = `${networkId}-${stakeTag}`;
         if (seen.has(key)) {

--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/hooks/useProtocolDetailData.ts
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/hooks/useProtocolDetailData.ts
@@ -93,6 +93,7 @@ export function useProtocolDetailData({
       stakeTag: buildLocalTxStatusSyncId({
         providerName: provider,
         tokenSymbol: symbol,
+        protocolVault: detailInfo.protocol.vault ?? vault,
       }),
       overflowBalance: detailInfo.nums?.overflow,
       maxUnstakeAmount: detailInfo.nums?.maxUnstakeAmount,
@@ -106,7 +107,7 @@ export function useProtocolDetailData({
         detailInfo.protocol.morphoTokenRate,
       morphoTokenRate: detailInfo.protocol.morphoTokenRate,
     };
-  }, [detailInfo, earnAccount, provider, symbol]);
+  }, [detailInfo, earnAccount, provider, symbol, vault]);
 
   return {
     earnAccount,

--- a/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
@@ -395,6 +395,17 @@ export function UniversalWithdraw({
     () => earnUtils.isNativeProvider({ providerName: providerName ?? '' }),
     [providerName],
   );
+  const isBitwayProvider = useMemo(
+    () => earnUtils.isBitwayProvider({ providerName: providerName ?? '' }),
+    [providerName],
+  );
+  const supportsWithdrawPath = useMemo(
+    () =>
+      earnUtils.supportsEarnWithdrawPath({
+        providerName: providerName ?? '',
+      }),
+    [providerName],
+  );
   const shouldSendProtocolVault = useMemo(
     () =>
       earnUtils.shouldSendEarnProtocolVault({
@@ -404,11 +415,10 @@ export function UniversalWithdraw({
   );
 
   const withdrawPathConfirmBoxes = useMemo(() => {
-    if (!(isPendleProvider || isNativeProvider)) return [];
+    if (!supportsWithdrawPath) return [];
     return transactionConfirmation?.withdrawPath?.data?.confirmBoxes ?? [];
   }, [
-    isPendleProvider,
-    isNativeProvider,
+    supportsWithdrawPath,
     transactionConfirmation?.withdrawPath?.data?.confirmBoxes,
   ]);
 
@@ -929,6 +939,12 @@ export function UniversalWithdraw({
   const [transactionConfirmationLoading, setTransactionConfirmationLoading] =
     useState(false);
 
+  const isWithdrawPathReady = earnUtils.isEarnWithdrawPathReady({
+    providerName: providerName ?? '',
+    isLoading: transactionConfirmationLoading,
+    withdrawType: selectedWithdrawType,
+  });
+
   const quoteLoading = checkAmountLoading || transactionConfirmationLoading;
 
   const checkAmount = useDebouncedCallback(async (amount: string) => {
@@ -1153,7 +1169,8 @@ export function UniversalWithdraw({
           BigNumber(amountValue).isLessThanOrEqualTo(0))) ||
       isCheckAmountMessageError ||
       checkAmountAlerts.length > 0 ||
-      checkAmountLoading,
+      checkAmountLoading ||
+      !isWithdrawPathReady,
     [
       isDisabled,
       amountValue,
@@ -1161,6 +1178,7 @@ export function UniversalWithdraw({
       checkAmountAlerts.length,
       checkAmountLoading,
       isCancelWithdrawal,
+      isWithdrawPathReady,
       selectedWithdrawPath?.disabled,
     ],
   );
@@ -1334,7 +1352,11 @@ export function UniversalWithdraw({
   const confirmLoading = useMemo(() => {
     if (shouldApprove) return loadingAllowance || approving;
     if (effectiveShowExpiredRefresh) return quoteRefreshing;
-    return loading || checkAmountLoading;
+    return (
+      loading ||
+      checkAmountLoading ||
+      (isBitwayProvider && transactionConfirmationLoading)
+    );
   }, [
     shouldApprove,
     effectiveShowExpiredRefresh,
@@ -1343,6 +1365,8 @@ export function UniversalWithdraw({
     quoteRefreshing,
     loading,
     checkAmountLoading,
+    isBitwayProvider,
+    transactionConfirmationLoading,
   ]);
 
   const confirmDisabled = useMemo(() => {

--- a/packages/kit/src/views/Staking/pages/ClaimOptions/index.tsx
+++ b/packages/kit/src/views/Staking/pages/ClaimOptions/index.tsx
@@ -52,8 +52,9 @@ const ClaimOptions = () => {
         accountId,
         symbol: finalSymbol,
         provider: finalProvider,
+        vault: protocolInfo?.vault,
       }),
-    [accountId, networkId, finalSymbol, finalProvider],
+    [accountId, networkId, finalSymbol, finalProvider, protocolInfo?.vault],
     { watchLoading: true },
   );
 

--- a/packages/kit/src/views/Staking/pages/ManagePosition/hooks/useManagePage.ts
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/hooks/useManagePage.ts
@@ -264,6 +264,7 @@ export const useManagePage = ({
       stakeTag: buildLocalTxStatusSyncId({
         providerName: provider,
         tokenSymbol: symbol,
+        protocolVault: resolvedProtocolVault,
       }),
       providerDetail: {
         name: matchingProtocol?.provider.name || provider,

--- a/packages/kit/src/views/Staking/pages/ProtocolDetails/index.tsx
+++ b/packages/kit/src/views/Staking/pages/ProtocolDetails/index.tsx
@@ -232,6 +232,7 @@ const ProtocolDetailsPage = () => {
         stakeTag: buildLocalTxStatusSyncId({
           providerName: result.provider.name,
           tokenSymbol: result.token.info.symbol,
+          protocolVault: vault,
         }),
         protocolVault: vault,
         filterType,
@@ -491,6 +492,7 @@ const ProtocolDetailsPage = () => {
                   stakeTag={buildLocalTxStatusSyncId({
                     providerName: result.provider.name,
                     tokenSymbol: result.token.info.symbol,
+                    protocolVault: vault,
                   })}
                   onRefresh={run}
                   onPress={onHistory}

--- a/packages/kit/src/views/Staking/pages/ProtocolDetailsV2/index.tsx
+++ b/packages/kit/src/views/Staking/pages/ProtocolDetailsV2/index.tsx
@@ -619,6 +619,7 @@ const ProtocolDetailsPage = () => {
       stakeTag: buildLocalTxStatusSyncId({
         providerName: provider,
         tokenSymbol: symbol,
+        protocolVault: detailInfo.protocol.vault ?? vault,
       }),
       overflowBalance: detailInfo.nums?.overflow,
       maxUnstakeAmount: detailInfo.nums?.maxUnstakeAmount,
@@ -633,7 +634,7 @@ const ProtocolDetailsPage = () => {
         detailInfo.protocol.morphoTokenRate,
       morphoTokenRate: detailInfo.protocol.morphoTokenRate,
     };
-  }, [detailInfo, earnAccount, provider, symbol]);
+  }, [detailInfo, earnAccount, provider, symbol, vault]);
 
   // Handle unsupported protocol
   useUnsupportedProtocol({

--- a/packages/kit/src/views/Staking/utils/utils.test.ts
+++ b/packages/kit/src/views/Staking/utils/utils.test.ts
@@ -1,0 +1,23 @@
+import { buildLocalTxStatusSyncId } from './utils';
+
+describe('buildLocalTxStatusSyncId', () => {
+  it('keeps existing provider tags backward compatible', () => {
+    expect(
+      buildLocalTxStatusSyncId({
+        providerName: 'Native',
+        tokenSymbol: 'USDT',
+        protocolVault: '0xNativeVault',
+      }),
+    ).toBe('native-usdt');
+  });
+
+  it('scopes Bitway tags by vault to isolate duplicate symbols', () => {
+    expect(
+      buildLocalTxStatusSyncId({
+        providerName: 'Bitway',
+        tokenSymbol: 'USDT',
+        protocolVault: '0xAbCd',
+      }),
+    ).toBe('bitway-usdt-0xabcd');
+  });
+});

--- a/packages/kit/src/views/Staking/utils/utils.ts
+++ b/packages/kit/src/views/Staking/utils/utils.ts
@@ -11,10 +11,18 @@ function isNativeEarnEthSymbol(symbol?: string) {
 export const buildLocalTxStatusSyncId = ({
   providerName = '',
   tokenSymbol = '',
+  protocolVault,
 }: {
   providerName?: string;
   tokenSymbol?: string;
-}) => `${providerName?.toLowerCase()}-${tokenSymbol?.toLowerCase()}`;
+  protocolVault?: string;
+}) => {
+  const baseTag = `${providerName.toLowerCase()}-${tokenSymbol.toLowerCase()}`;
+  if (providerName.toLowerCase() === 'bitway' && protocolVault) {
+    return `${baseTag}-${protocolVault.toLowerCase()}`;
+  }
+  return baseTag;
+};
 
 // Borrow tag format: borrow:{provider}:{action}[:claimIds]
 export type IBorrowAction =

--- a/packages/shared/src/consts/addresses.ts
+++ b/packages/shared/src/consts/addresses.ts
@@ -26,8 +26,6 @@ export const BinanceSmartChainUSDT =
 export const BinanceSmartChainU = '0xce24439f2d9c6a2289f741120fe202248b666666';
 export const BinanceSmartChainBTW =
   '0x444045b0ee1ee319a660a5e3d604ca0ffa35acaa';
-export const BinanceSmartChainUSD1 =
-  '0x8d0d000ee44948fc98c9b98a4fa4921476f08b0d';
 export const BinanceSmartChainLISTA =
   '0xFceB31A79F71AC9CBDCF853519c1b12D379EdC46';
 export const BinanceSmartChainSlisBNBx =

--- a/packages/shared/src/consts/addresses.ts
+++ b/packages/shared/src/consts/addresses.ts
@@ -23,6 +23,11 @@ export const ArbitrumSUSDai = '0x0B2b2B2076d95dda7817e785989fE353fe955ef9';
 export const ArbitrumWeETH = '0x35751007a407ca6FEFfE80b3cB397736D2cf4dbe';
 export const BinanceSmartChainUSDT =
   '0x55d398326f99059fF775485246999027B3197955';
+export const BinanceSmartChainU = '0xce24439f2d9c6a2289f741120fe202248b666666';
+export const BinanceSmartChainBTW =
+  '0x444045b0ee1ee319a660a5e3d604ca0ffa35acaa';
+export const BinanceSmartChainUSD1 =
+  '0x8d0d000ee44948fc98c9b98a4fa4921476f08b0d';
 export const BinanceSmartChainLISTA =
   '0xFceB31A79F71AC9CBDCF853519c1b12D379EdC46';
 export const BinanceSmartChainSlisBNBx =

--- a/packages/shared/src/utils/earnUtils.test.ts
+++ b/packages/shared/src/utils/earnUtils.test.ts
@@ -1,5 +1,46 @@
 import earnUtils from './earnUtils';
 
+describe('earnUtils Bitway provider behavior', () => {
+  it('normalizes Bitway and forwards its vault-scoped contract identity', () => {
+    expect(earnUtils.getEarnProviderEnumKey('bitway')).toBe('Bitway');
+    expect(earnUtils.isBitwayProvider({ providerName: 'BITWAY' })).toBe(true);
+    expect(earnUtils.supportsEarnWithdrawPath({ providerName: 'bitway' })).toBe(
+      true,
+    );
+    expect(
+      earnUtils.shouldSendEarnProtocolVault({ providerName: 'Bitway' }),
+    ).toBe(true);
+    expect(
+      earnUtils.isEarnWithdrawPathReady({
+        providerName: 'Bitway',
+        isLoading: true,
+      }),
+    ).toBe(false);
+    expect(
+      earnUtils.isEarnWithdrawPathReady({
+        providerName: 'Bitway',
+        isLoading: false,
+      }),
+    ).toBe(false);
+    expect(
+      earnUtils.isEarnWithdrawPathReady({
+        providerName: 'Bitway',
+        isLoading: false,
+        withdrawType: 'queued',
+      }),
+    ).toBe(true);
+    expect(
+      earnUtils.isEarnWithdrawPathReady({
+        providerName: 'Native',
+        isLoading: false,
+      }),
+    ).toBe(true);
+    expect(earnUtils.getEarnProviderName({ providerName: 'bitway' })).toBe(
+      'Bitway',
+    );
+  });
+});
+
 describe('earnUtils borrow address normalization', () => {
   describe('normalizeBorrowAddress', () => {
     it('lowercases checksum addresses on EVM networks', () => {

--- a/packages/shared/src/utils/earnUtils.ts
+++ b/packages/shared/src/utils/earnUtils.ts
@@ -8,7 +8,11 @@ import {
 import networkUtils from './networkUtils';
 
 import type { IEarnPermitCacheKey } from '../../types/earn';
-import type { IEarnText, IEarnToken } from '../../types/staking';
+import type {
+  IEarnText,
+  IEarnToken,
+  IEarnWithdrawType,
+} from '../../types/staking';
 import type { IToken } from '../../types/token';
 
 function getEarnProviderEnumKey(
@@ -45,6 +49,8 @@ const isPendleProvider = createProviderCheck(EEarnProviderEnum.Pendle);
 
 const isNativeProvider = createProviderCheck(EEarnProviderEnum.Native);
 
+const isBitwayProvider = createProviderCheck(EEarnProviderEnum.Bitway);
+
 const isListaProvider = createProviderCheck(EEarnProviderEnum.Lista);
 
 const isStakefishProvider = createProviderCheck(EEarnProviderEnum.Stakefish);
@@ -60,9 +66,26 @@ const isVaultBasedProvider = ({ providerName }: { providerName: string }) => {
     isMorphoProvider({ providerName }) ||
     isPendleProvider({ providerName }) ||
     isListaProvider({ providerName }) ||
-    isMomentumProvider({ providerName })
+    isMomentumProvider({ providerName }) ||
+    isBitwayProvider({ providerName })
   );
 };
+
+const supportsEarnWithdrawPath = ({ providerName }: { providerName: string }) =>
+  isPendleProvider({ providerName }) ||
+  isNativeProvider({ providerName }) ||
+  isBitwayProvider({ providerName });
+
+const isEarnWithdrawPathReady = ({
+  providerName,
+  isLoading,
+  withdrawType,
+}: {
+  providerName: string;
+  isLoading: boolean;
+  withdrawType?: IEarnWithdrawType;
+}) =>
+  !isBitwayProvider({ providerName }) || (!isLoading && Boolean(withdrawType));
 
 const shouldSendEarnProtocolVault = ({
   providerName,
@@ -273,6 +296,7 @@ export default {
   isMorphoProvider,
   isPendleProvider,
   isNativeProvider,
+  isBitwayProvider,
   isListaProvider,
   isLidoProvider,
   isBabylonProvider,
@@ -285,6 +309,8 @@ export default {
   getEarnPermitCacheKey,
   isUSDTonETHNetwork,
   isVaultBasedProvider,
+  supportsEarnWithdrawPath,
+  isEarnWithdrawPathReady,
   shouldSendEarnProtocolVault,
   isValidatorProvider,
   resolveEarnApproveSpenderAddress,

--- a/packages/shared/types/earn.ts
+++ b/packages/shared/types/earn.ts
@@ -15,6 +15,7 @@ export enum EEarnProviderEnum {
   Stakefish = 'Stakefish',
   Kamino = 'Kamino',
   Native = 'Native',
+  Bitway = 'Bitway',
 }
 
 export type ISupportedSymbol =
@@ -51,7 +52,10 @@ export type ISupportedSymbol =
   | 'weETH'
   | 'aUSDT0'
   | 'stcUSD'
-  | 'kHYPE';
+  | 'kHYPE'
+  | 'U'
+  | 'BTW'
+  | 'USD1';
 
 export interface IStakingFlowConfig {
   enabled: boolean;

--- a/packages/shared/types/earn.ts
+++ b/packages/shared/types/earn.ts
@@ -54,8 +54,7 @@ export type ISupportedSymbol =
   | 'stcUSD'
   | 'kHYPE'
   | 'U'
-  | 'BTW'
-  | 'USD1';
+  | 'BTW';
 
 export interface IStakingFlowConfig {
   enabled: boolean;

--- a/packages/shared/types/earn/earnProvider.constants.test.ts
+++ b/packages/shared/types/earn/earnProvider.constants.test.ts
@@ -13,12 +13,11 @@ describe('Bitway Earn provider constants', () => {
   it.each([
     ['u', 'U'],
     ['btw', 'BTW'],
-    ['usd1', 'USD1'],
   ])('normalizes the Bitway symbol %s to %s', (input, expected) => {
     expect(normalizeToEarnSymbol(input)).toBe(expected);
   });
 
-  it.each(['U', 'BTW', 'USD1'])(
+  it.each(['U', 'BTW'])(
     'exposes the %s Market token as Earn-capable',
     (symbol) => {
       expect(isSupportStaking(symbol)).toBe(true);

--- a/packages/shared/types/earn/earnProvider.constants.test.ts
+++ b/packages/shared/types/earn/earnProvider.constants.test.ts
@@ -1,0 +1,27 @@
+import {
+  isSupportStaking,
+  normalizeToEarnProvider,
+  normalizeToEarnSymbol,
+} from './earnProvider.constants';
+
+describe('Bitway Earn provider constants', () => {
+  it('normalizes the provider name used by Earn routes', () => {
+    expect(normalizeToEarnProvider('bitway')).toBe('Bitway');
+    expect(normalizeToEarnProvider('BITWAY')).toBe('Bitway');
+  });
+
+  it.each([
+    ['u', 'U'],
+    ['btw', 'BTW'],
+    ['usd1', 'USD1'],
+  ])('normalizes the Bitway symbol %s to %s', (input, expected) => {
+    expect(normalizeToEarnSymbol(input)).toBe(expected);
+  });
+
+  it.each(['U', 'BTW', 'USD1'])(
+    'exposes the %s Market token as Earn-capable',
+    (symbol) => {
+      expect(isSupportStaking(symbol)).toBe(true);
+    },
+  );
+});

--- a/packages/shared/types/earn/earnProvider.constants.ts
+++ b/packages/shared/types/earn/earnProvider.constants.ts
@@ -107,6 +107,9 @@ export const isSupportStaking = (symbol: string) =>
     'WETH',
     'CBBTC',
     'WBTC',
+    'U',
+    'BTW',
+    'USD1',
   ].includes(symbol.toUpperCase());
 
 export const earnMainnetNetworkIds: string[] = [
@@ -173,6 +176,9 @@ export function normalizeToEarnSymbol(symbol: string): string {
     'stcusd': 'stcUSD',
     'khype': 'kHYPE',
     'lista': 'LISTA',
+    'u': 'U',
+    'btw': 'BTW',
+    'usd1': 'USD1',
   };
   // Known symbols get case-normalized; unknown symbols (e.g. Pendle tokens) pass through
   return symbolMap[symbol.toLowerCase()] ?? symbol;
@@ -193,6 +199,7 @@ export function normalizeToEarnProvider(
     'ethena': EEarnProviderEnum.Ethena,
     'momentum': EEarnProviderEnum.Momentum,
     'native': EEarnProviderEnum.Native,
+    'bitway': EEarnProviderEnum.Bitway,
     'staked': EEarnProviderEnum.Lista,
   };
   return providerMap[provider.toLowerCase()];
@@ -305,5 +312,8 @@ export function getSymbolSupportedNetworks(): Record<
     'kHYPE': [networkIdsMap.hyperevm],
     'MORPHO': [networkIdsMap.eth],
     'LISTA': [networkIdsMap.bsc],
+    'U': [networkIdsMap.bsc],
+    'BTW': [networkIdsMap.bsc],
+    'USD1': [networkIdsMap.bsc],
   };
 }

--- a/packages/shared/types/earn/earnProvider.constants.ts
+++ b/packages/shared/types/earn/earnProvider.constants.ts
@@ -109,7 +109,6 @@ export const isSupportStaking = (symbol: string) =>
     'WBTC',
     'U',
     'BTW',
-    'USD1',
   ].includes(symbol.toUpperCase());
 
 export const earnMainnetNetworkIds: string[] = [
@@ -178,7 +177,6 @@ export function normalizeToEarnSymbol(symbol: string): string {
     'lista': 'LISTA',
     'u': 'U',
     'btw': 'BTW',
-    'usd1': 'USD1',
   };
   // Known symbols get case-normalized; unknown symbols (e.g. Pendle tokens) pass through
   return symbolMap[symbol.toLowerCase()] ?? symbol;
@@ -314,6 +312,5 @@ export function getSymbolSupportedNetworks(): Record<
     'LISTA': [networkIdsMap.bsc],
     'U': [networkIdsMap.bsc],
     'BTW': [networkIdsMap.bsc],
-    'USD1': [networkIdsMap.bsc],
   };
 }


### PR DESCRIPTION
## Summary

- Register Bitway as a BSC Earn provider for the server-published Absolute Return assets: USDT, U, and BTW.
- Reuse the server-driven universal stake/withdraw/claim flows, including Bitway instant-with-penalty and queued withdrawal paths.
- Scope Bitway pending transaction tags and claim requests by protocol vault so vaults sharing a symbol cannot collide.

## Intent & Context

This implements [OK-56813](https://onekeyhq.atlassian.net/browse/OK-56813) based on the Bitway integration thread in Slack and the server implementation in [server-service-earn#804](https://github.com/OneKeyHQ/server-service-earn/pull/804). The product requirement is to follow the existing Native Earn interaction model: users can redeem immediately with a penalty or join the normal withdrawal queue.

The server feature branch `feat/bitway` was merged separately into server `dev`. The client remains server-driven for protocol display data, APY details, logo, transaction calldata, and withdrawal option copy.

## Design Decisions

- Bitway is a vault-based provider, but it is not classified as Native. Native-only wrapping and queued receipt approval behavior remain unchanged.
- The universal withdraw UI consumes Bitway `withdrawPath.confirmBoxes`; submission is disabled until the server returns a valid Bitway `withdrawType`.
- `withdrawWithTx` is intentionally not enabled because that flag routes the legacy details page to `/withdraw/list`; Bitway builds transactions through the universal withdraw endpoint instead.
- Existing provider transaction tags keep their current format. Only Bitway tags append the lowercased vault address to avoid collisions between vaults using the same asset symbol.
- Client asset support is limited to protocols enabled by the current server migration. Dormant Core Alpha/USD1 code is not exposed by the App.

## Changes Detail

- Add the Bitway provider, server-published supported symbols, BSC token addresses, market normalization, and BSC staking configuration.
- Forward protocol vault identity through approval resolution, pending transaction tracking, history indicators, portfolio refresh, and claimable-list requests.
- Add provider capability and readiness guards for server-driven Bitway withdrawal paths.
- Add focused tests for provider/symbol normalization, Earn market support, withdrawal readiness, and backward-compatible vault-scoped transaction tags.

## Runtime Boundaries

- **main runtime:** Earn routes, forms, withdrawal option selector, claim UI, and pending indicators.
- **background runtime:** staking configuration, account lookup, Earn HTTP requests, transaction building, and existing order persistence.
- No new native shared resource is introduced. Main and background keep separate JS heap copies and initialize independently; the Bitway submit path fails closed until background data returns a valid withdrawal option.

## Known Server Dependency

- The server implements `cancelClaim`, but its current panel/portfolio and claimable-list payloads do not expose the identity of an unexpired queue item. The App cannot safely build a cancel transaction until the server returns that queue identity; no client-derived fallback is used.

## Risk Assessment

- **Risk Level**: Medium
- **Affected Platforms**: Extension, Mobile, Desktop, Web
- **Risk Areas**: server/client vault identity alignment, withdrawal option readiness, and pending-state isolation across Bitway vaults

## Test plan

- [x] Focused Jest suites: 15 tests passed
- [x] `yarn agent:check --profile commit`
- [ ] Validate Bitway Absolute deposit, instant withdrawal, queued withdrawal, and claim against the test Earn endpoint
- [ ] Validate cancel withdrawal after the server exposes unexpired queue identity

[OK-56813]: https://onekeyhq.atlassian.net/browse/OK-56813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
