### PR TITLE
fix: prevent mobile market tabs from reverting(OK-57367)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
@@ -39,6 +39,7 @@ import {
   getDefaultMarketStockCategoryId,
   getMarketStockCategoryRequestParam,
 } from './marketStockCategoryUtils';
+import { shouldIgnoreProgrammaticSettlingTab } from './marketTabChangeGuards';
 
 import type {
   ILiquidityFilter,
@@ -97,9 +98,7 @@ const MARKET_TAB_USER_DRAG_ACCEPT_MS = platformEnv.isNativeIOS ? 700 : 350;
 const MARKET_TAB_SYNC_USER_DRAG_DEFER_MS = platformEnv.isNativeIOS ? 1200 : 500;
 const MARKET_TAB_ITEM_PRESS_GUARD_MS = MARKET_TAB_USER_DRAG_ACCEPT_MS;
 const MARKET_TAB_ITEM_PRESS_IDLE_GUARD_MS = platformEnv.isNativeIOS ? 180 : 120;
-const MARKET_TAB_PROGRAMMATIC_SETTLE_GUARD_MS = platformEnv.isNativeAndroid
-  ? 500
-  : 0;
+const MARKET_TAB_PROGRAMMATIC_SETTLE_GUARD_MS = 500;
 type IMarketPagerProps = Omit<PagerViewProps, 'onPageScroll' | 'initialPage'>;
 
 function MarketHomeTabBar({
@@ -374,6 +373,7 @@ function MobileLayoutComponent({
   const lastPagerDraggingAtRef = useRef(0);
   const isPagerUserDraggingRef = useRef(false);
   const lastPagerUserDragEndedAtRef = useRef(0);
+  const pagerScrollStateRef = useRef('idle');
   const lastAcceptedTabChangeNameRef = useRef<string | undefined>(undefined);
   const lastProgrammaticAcceptedTabRef = useRef<
     | {
@@ -399,13 +399,28 @@ function MobileLayoutComponent({
   const scheduleExpectedTabChangeTargetClear = useCallback(
     (tabName: string, delayMs: number) => {
       clearExpectedTabChangeTargetTimer();
-      expectedTabChangeTargetTimerRef.current = setTimeout(() => {
-        if (expectedTabChangeTargetRef.current === tabName) {
-          expectedTabChangeTargetRef.current = undefined;
-          expectedTabChangeTargetStartedAtRef.current = 0;
+      const tryClearExpectedTabChangeTarget = () => {
+        if (expectedTabChangeTargetRef.current !== tabName) {
+          expectedTabChangeTargetTimerRef.current = undefined;
+          return;
         }
+
+        if (pagerScrollStateRef.current !== 'idle') {
+          expectedTabChangeTargetTimerRef.current = setTimeout(
+            tryClearExpectedTabChangeTarget,
+            100,
+          );
+          return;
+        }
+
+        expectedTabChangeTargetRef.current = undefined;
+        expectedTabChangeTargetStartedAtRef.current = 0;
         expectedTabChangeTargetTimerRef.current = undefined;
-      }, delayMs);
+      };
+      expectedTabChangeTargetTimerRef.current = setTimeout(
+        tryClearExpectedTabChangeTarget,
+        delayMs,
+      );
     },
     [clearExpectedTabChangeTargetTimer],
   );
@@ -423,7 +438,7 @@ function MobileLayoutComponent({
     },
     [clearExpectedTabChangeTarget, scheduleExpectedTabChangeTargetClear],
   );
-  const shouldDeferJumpToTab = useCallback(
+  const shouldDeferPageSync = useCallback(
     ({ targetTabName }: { targetTabName: string; currentTabName: string }) => {
       const now = Date.now();
       const lastPagerDraggingAt = lastPagerDraggingAtRef.current;
@@ -439,14 +454,22 @@ function MobileLayoutComponent({
         return true;
       }
 
+      if (
+        platformEnv.isNativeAndroid &&
+        pagerScrollStateRef.current !== 'idle'
+      ) {
+        return true;
+      }
+
       if (expectedTabChangeTargetRef.current !== targetTabName) {
         return false;
       }
 
       const startedAt = expectedTabChangeTargetStartedAtRef.current;
-      return (
-        startedAt > 0 && Date.now() - startedAt < MARKET_TAB_SYNC_JUMP_DEFER_MS
-      );
+      if (platformEnv.isNativeAndroid && startedAt > 0) {
+        return true;
+      }
+      return startedAt > 0 && now - startedAt < MARKET_TAB_SYNC_JUMP_DEFER_MS;
     },
     [],
   );
@@ -460,11 +483,13 @@ function MobileLayoutComponent({
 
   const {
     activeTabName,
+    cancelPageSync,
+    requestPageSync,
     setActiveTabName,
     tabsRef: currentTabsRef,
   } = useSyncedMarketTab(selectedTabName, tabsRef, isFocused, {
     onBeforeJumpToTab: markExpectedTabChangeTarget,
-    shouldDeferJumpToTab,
+    shouldDeferPageSync,
   });
   const setActiveTabNameRef = useRef(setActiveTabName);
   setActiveTabNameRef.current = setActiveTabName;
@@ -472,9 +497,11 @@ function MobileLayoutComponent({
   handleTabChangeRef.current = handleTabChange;
   const latestTabStateRef = useRef({
     activeTabName,
+    selectedTabName,
   });
   latestTabStateRef.current = {
     activeTabName,
+    selectedTabName,
   };
   const useNativeHeaderAnimation = platformEnv.isNativeAndroid
     ? !nestedPager
@@ -536,6 +563,7 @@ function MobileLayoutComponent({
 
   const onTabChangeHandler = useCallback(
     ({ tabName }: { tabName: string }) => {
+      const now = Date.now();
       const latestTabState = latestTabStateRef.current;
       const focusedTab = currentTabsRef.current?.getFocusedTab();
       const expectedTabName = expectedTabChangeTargetRef.current;
@@ -543,7 +571,7 @@ function MobileLayoutComponent({
         expectedTabChangeTargetStartedAtRef.current;
       const lastPagerDraggingAt = lastPagerDraggingAtRef.current;
       const pagerDragElapsedMs =
-        lastPagerDraggingAt > 0 ? Date.now() - lastPagerDraggingAt : undefined;
+        lastPagerDraggingAt > 0 ? now - lastPagerDraggingAt : undefined;
       const isRecentPagerDrag =
         pagerDragElapsedMs !== undefined &&
         pagerDragElapsedMs < MARKET_TAB_USER_DRAG_ACCEPT_MS;
@@ -554,25 +582,25 @@ function MobileLayoutComponent({
       const lastProgrammaticAcceptedTab =
         lastProgrammaticAcceptedTabRef.current;
       const programmaticAcceptedElapsedMs = lastProgrammaticAcceptedTab
-        ? Date.now() - lastProgrammaticAcceptedTab.acceptedAt
+        ? now - lastProgrammaticAcceptedTab.acceptedAt
         : undefined;
-      const shouldIgnoreProgrammaticSettlingTab = Boolean(
-        !expectedTabName &&
-        MARKET_TAB_PROGRAMMATIC_SETTLE_GUARD_MS > 0 &&
-        lastProgrammaticAcceptedTab &&
-        tabName !== lastProgrammaticAcceptedTab.tabName &&
-        programmaticAcceptedElapsedMs !== undefined &&
-        programmaticAcceptedElapsedMs <
-          MARKET_TAB_PROGRAMMATIC_SETTLE_GUARD_MS &&
-        !isRecentPagerDrag &&
-        !wasDraggedAfterExpectedTab,
-      );
+      const shouldIgnoreSettlingTab = shouldIgnoreProgrammaticSettlingTab({
+        expectedTabName,
+        incomingTabName: tabName,
+        lastProgrammaticAcceptedTabName: lastProgrammaticAcceptedTab?.tabName,
+        programmaticAcceptedElapsedMs,
+        programmaticSettleGuardMs: MARKET_TAB_PROGRAMMATIC_SETTLE_GUARD_MS,
+        isRecentPagerDrag,
+        wasDraggedAfterExpectedTab,
+      });
 
-      if (shouldIgnoreProgrammaticSettlingTab && lastProgrammaticAcceptedTab) {
+      if (shouldIgnoreSettlingTab && lastProgrammaticAcceptedTab) {
         const acceptedTabName = lastProgrammaticAcceptedTab.tabName;
-        if (focusedTab !== acceptedTabName) {
-          markExpectedTabChangeTarget(acceptedTabName);
-          currentTabsRef.current?.jumpToTab(acceptedTabName);
+        const shouldRequestPageSync =
+          acceptedTabName === latestTabState.selectedTabName &&
+          focusedTab !== acceptedTabName;
+        if (shouldRequestPageSync) {
+          requestPageSync();
         }
         return;
       }
@@ -605,7 +633,7 @@ function MobileLayoutComponent({
       if (expectedTabName && tabName === expectedTabName) {
         lastProgrammaticAcceptedTabRef.current = {
           tabName,
-          acceptedAt: Date.now(),
+          acceptedAt: now,
         };
         clearExpectedTabChangeTarget();
       }
@@ -613,25 +641,28 @@ function MobileLayoutComponent({
       setActiveTabNameRef.current(tabName);
       handleTabChangeRef.current(tabName);
     },
-    [clearExpectedTabChangeTarget, currentTabsRef, markExpectedTabChangeTarget],
+    [clearExpectedTabChangeTarget, currentTabsRef, requestPageSync],
   );
 
   const handlePagerScrollStateChanged = useCallback(
     (event: PageScrollStateChangedNativeEvent) => {
       const { pageScrollState } = event.nativeEvent;
-      if (pageScrollState !== 'dragging') {
-        if (pageScrollState === 'idle' && isPagerUserDraggingRef.current) {
-          isPagerUserDraggingRef.current = false;
-          lastPagerUserDragEndedAtRef.current = Date.now();
-        }
-        return;
-      }
+      const wasPagerUserDragging = isPagerUserDraggingRef.current;
+      const now = Date.now();
+      pagerScrollStateRef.current = pageScrollState;
 
-      isPagerUserDraggingRef.current = true;
-      lastProgrammaticAcceptedTabRef.current = undefined;
-      lastPagerDraggingAtRef.current = Date.now();
+      if (pageScrollState === 'dragging') {
+        isPagerUserDraggingRef.current = true;
+        lastProgrammaticAcceptedTabRef.current = undefined;
+        lastPagerDraggingAtRef.current = now;
+        clearExpectedTabChangeTarget();
+        cancelPageSync();
+      } else if (pageScrollState === 'idle' && wasPagerUserDragging) {
+        isPagerUserDraggingRef.current = false;
+        lastPagerUserDragEndedAtRef.current = now;
+      }
     },
-    [],
+    [cancelPageSync, clearExpectedTabChangeTarget],
   );
   const tabNames = useMemo(
     () => [

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/hooks/useSyncedMarketTab.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/hooks/useSyncedMarketTab.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook } from '@testing-library/react-native';
+
+import type { ITabContainerRef } from '@onekeyhq/components';
+
+import { useSyncedMarketTab } from './useSyncedMarketTab';
+
+describe('useSyncedMarketTab', () => {
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+  let nextFrameId = 1;
+  let frameCallbacks = new Map<number, FrameRequestCallback>();
+
+  const flushNextFrame = () => {
+    const nextFrame = frameCallbacks.entries().next().value;
+    expect(nextFrame).toBeDefined();
+    if (!nextFrame) {
+      return;
+    }
+    const [frameId, callback] = nextFrame;
+    frameCallbacks.delete(frameId);
+    act(() => callback(0));
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    nextFrameId = 1;
+    frameCallbacks = new Map();
+    globalThis.requestAnimationFrame = jest.fn((callback) => {
+      const frameId = nextFrameId;
+      nextFrameId += 1;
+      frameCallbacks.set(frameId, callback);
+      return frameId;
+    });
+    globalThis.cancelAnimationFrame = jest.fn((frameId) => {
+      frameCallbacks.delete(frameId);
+    });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+  });
+
+  it('uses one corrective jump after a deferred stale-page sync request', () => {
+    let focusedTab = 'Stocks';
+    let shouldDefer = false;
+    const jumpToTab = jest.fn();
+    const syncCurrentPage = jest.fn();
+    const onBeforeJumpToTab = jest.fn(() => {
+      shouldDefer = true;
+    });
+    const tabContainerRef: ITabContainerRef = {
+      getCurrentIndex: jest.fn(() => 2),
+      getFocusedTab: jest.fn(() => focusedTab),
+      jumpToTab,
+      setIndex: jest.fn(),
+      syncCurrentPage,
+    };
+    const tabsRef = { current: tabContainerRef };
+
+    const { result, unmount } = renderHook(() =>
+      useSyncedMarketTab('Stocks', tabsRef, true, {
+        onBeforeJumpToTab,
+        shouldDeferPageSync: () => shouldDefer,
+      }),
+    );
+
+    focusedTab = 'Favorites';
+    shouldDefer = true;
+    act(() => result.current.requestPageSync());
+    flushNextFrame();
+    expect(jumpToTab).not.toHaveBeenCalled();
+    expect(syncCurrentPage).not.toHaveBeenCalled();
+
+    shouldDefer = false;
+    act(() => jest.advanceTimersByTime(32));
+    flushNextFrame();
+    expect(jumpToTab).toHaveBeenCalledTimes(1);
+    expect(jumpToTab).toHaveBeenCalledWith('Stocks');
+    expect(onBeforeJumpToTab).toHaveBeenCalledTimes(1);
+
+    act(() => jest.advanceTimersByTime(32));
+    flushNextFrame();
+    expect(jumpToTab).toHaveBeenCalledTimes(1);
+    expect(syncCurrentPage).not.toHaveBeenCalled();
+
+    focusedTab = 'Stocks';
+    shouldDefer = false;
+    act(() => jest.advanceTimersByTime(32));
+    flushNextFrame();
+    expect(jumpToTab).toHaveBeenCalledTimes(1);
+    expect(syncCurrentPage).toHaveBeenCalledTimes(1);
+
+    unmount();
+  });
+
+  it('does not revive a cancelled sync request after user drag starts', () => {
+    let focusedTab = 'Stocks';
+    const jumpToTab = jest.fn();
+    const syncCurrentPage = jest.fn();
+    const tabContainerRef: ITabContainerRef = {
+      getCurrentIndex: jest.fn(() => 2),
+      getFocusedTab: jest.fn(() => focusedTab),
+      jumpToTab,
+      setIndex: jest.fn(),
+      syncCurrentPage,
+    };
+    const tabsRef = { current: tabContainerRef };
+
+    const { result, unmount } = renderHook(() =>
+      useSyncedMarketTab('Stocks', tabsRef, true),
+    );
+
+    focusedTab = 'Favorites';
+    act(() => result.current.requestPageSync());
+    expect(frameCallbacks.size).toBe(1);
+
+    act(() => result.current.cancelPageSync());
+    act(() => jest.advanceTimersByTime(1000));
+    expect(frameCallbacks.size).toBe(0);
+    expect(jumpToTab).not.toHaveBeenCalled();
+    expect(syncCurrentPage).not.toHaveBeenCalled();
+
+    unmount();
+  });
+});

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/hooks/useSyncedMarketTab.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/hooks/useSyncedMarketTab.ts
@@ -1,11 +1,11 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { RefObject } from 'react';
 
 import type { ITabContainerRef } from '@onekeyhq/components';
 
 interface IUseSyncedMarketTabOptions {
   onBeforeJumpToTab?: (targetTabName: string) => void;
-  shouldDeferJumpToTab?: (params: {
+  shouldDeferPageSync?: (params: {
     targetTabName: string;
     currentTabName: string;
   }) => boolean;
@@ -17,18 +17,39 @@ export function useSyncedMarketTab(
   shouldResync = false,
   options?: IUseSyncedMarketTabOptions,
 ) {
-  const { onBeforeJumpToTab, shouldDeferJumpToTab } = options ?? {};
+  const { onBeforeJumpToTab, shouldDeferPageSync } = options ?? {};
   const internalTabsRef = useRef<ITabContainerRef | null>(null);
   const resolvedTabsRef = tabsRef ?? internalTabsRef;
   const [activeTabName, setActiveTabName] = useState(targetTabName);
   const pendingPageSyncRef = useRef(false);
   const wasResyncEnabledRef = useRef(shouldResync);
+  const targetTabNameRef = useRef(targetTabName);
+  targetTabNameRef.current = targetTabName;
+  const cancelledTargetTabNameRef = useRef<string | undefined>(undefined);
+  const [syncRequestVersion, setSyncRequestVersion] = useState(0);
+
+  const requestPageSync = useCallback(() => {
+    const wasPending = pendingPageSyncRef.current;
+    cancelledTargetTabNameRef.current = undefined;
+    pendingPageSyncRef.current = true;
+    if (!wasPending) {
+      setSyncRequestVersion((version) => version + 1);
+    }
+  }, []);
+
+  const cancelPageSync = useCallback(() => {
+    cancelledTargetTabNameRef.current = targetTabNameRef.current;
+    pendingPageSyncRef.current = false;
+    setSyncRequestVersion((version) => version + 1);
+  }, []);
 
   useEffect(() => {
     if (shouldResync && !wasResyncEnabledRef.current) {
+      cancelledTargetTabNameRef.current = undefined;
       pendingPageSyncRef.current = true;
     }
     if (!shouldResync) {
+      cancelledTargetTabNameRef.current = undefined;
       pendingPageSyncRef.current = false;
     }
   }, [shouldResync, targetTabName]);
@@ -42,30 +63,24 @@ export function useSyncedMarketTab(
     }
     if (currentTabName !== targetTabName) {
       if (shouldResync) {
+        if (cancelledTargetTabNameRef.current === targetTabName) {
+          return;
+        }
         pendingPageSyncRef.current = true;
-      }
-      if (
-        shouldResync &&
-        shouldDeferJumpToTab?.({
-          targetTabName,
-          currentTabName,
-        })
-      ) {
         return;
       }
       onBeforeJumpToTab?.(targetTabName);
       currentTabsRef?.jumpToTab(targetTabName);
-      if (!shouldResync) {
-        setActiveTabName(targetTabName);
-      }
+      setActiveTabName(targetTabName);
       return;
     }
+    cancelledTargetTabNameRef.current = undefined;
     setActiveTabName(targetTabName);
   }, [
     onBeforeJumpToTab,
     resolvedTabsRef,
-    shouldDeferJumpToTab,
     shouldResync,
+    syncRequestVersion,
     targetTabName,
   ]);
 
@@ -79,7 +94,13 @@ export function useSyncedMarketTab(
     let cancelled = false;
     let retryCount = 0;
 
-    const runResync = () => {
+    const scheduleNextSync = (runPageSync: () => void) => {
+      timeoutId = setTimeout(() => {
+        rafId = requestAnimationFrame(runPageSync);
+      }, 32);
+    };
+
+    const runPageSync = () => {
       if (cancelled) {
         return;
       }
@@ -90,24 +111,22 @@ export function useSyncedMarketTab(
       }
 
       const currentTabName = currentTabsRef.getFocusedTab();
+      pendingPageSyncRef.current = true;
+
+      if (
+        shouldDeferPageSync?.({
+          targetTabName,
+          currentTabName,
+        })
+      ) {
+        scheduleNextSync(runPageSync);
+        return;
+      }
 
       if (currentTabName === targetTabName) {
         currentTabsRef.syncCurrentPage();
         pendingPageSyncRef.current = false;
         setActiveTabName(targetTabName);
-        return;
-      }
-
-      pendingPageSyncRef.current = true;
-      if (
-        shouldDeferJumpToTab?.({
-          targetTabName,
-          currentTabName,
-        })
-      ) {
-        timeoutId = setTimeout(() => {
-          rafId = requestAnimationFrame(runResync);
-        }, 32);
         return;
       }
 
@@ -122,12 +141,10 @@ export function useSyncedMarketTab(
         return;
       }
 
-      timeoutId = setTimeout(() => {
-        rafId = requestAnimationFrame(runResync);
-      }, 32);
+      scheduleNextSync(runPageSync);
     };
 
-    rafId = requestAnimationFrame(runResync);
+    rafId = requestAnimationFrame(runPageSync);
 
     return () => {
       cancelled = true;
@@ -141,8 +158,9 @@ export function useSyncedMarketTab(
   }, [
     onBeforeJumpToTab,
     resolvedTabsRef,
-    shouldDeferJumpToTab,
+    shouldDeferPageSync,
     shouldResync,
+    syncRequestVersion,
     targetTabName,
   ]);
 
@@ -152,6 +170,8 @@ export function useSyncedMarketTab(
 
   return {
     activeTabName,
+    cancelPageSync,
+    requestPageSync,
     setActiveTabName,
     tabsRef: resolvedTabsRef,
   };

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/marketTabChangeGuards.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/marketTabChangeGuards.test.ts
@@ -1,0 +1,36 @@
+import { shouldIgnoreProgrammaticSettlingTab } from './marketTabChangeGuards';
+
+describe('shouldIgnoreProgrammaticSettlingTab', () => {
+  const createParams = () => ({
+    expectedTabName: undefined,
+    incomingTabName: 'Favorites',
+    lastProgrammaticAcceptedTabName: 'Perps',
+    programmaticAcceptedElapsedMs: 80,
+    programmaticSettleGuardMs: 500,
+    isRecentPagerDrag: false,
+    wasDraggedAfterExpectedTab: false,
+  });
+
+  it('ignores a delayed stale callback after a programmatic tab settles', () => {
+    expect(shouldIgnoreProgrammaticSettlingTab(createParams())).toBe(true);
+  });
+
+  it.each([
+    ['a recent user drag', { isRecentPagerDrag: true }],
+    ['a drag after the expected target', { wasDraggedAfterExpectedTab: true }],
+    [
+      'the programmatic marker was cleared by drag start',
+      { lastProgrammaticAcceptedTabName: undefined },
+    ],
+    ['a new expected target exists', { expectedTabName: 'Favorites' }],
+    ['the incoming tab is the accepted tab', { incomingTabName: 'Perps' }],
+    ['the settle guard elapsed', { programmaticAcceptedElapsedMs: 500 }],
+  ])('allows the callback when %s', (_reason, overrides) => {
+    expect(
+      shouldIgnoreProgrammaticSettlingTab({
+        ...createParams(),
+        ...overrides,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/marketTabChangeGuards.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/marketTabChangeGuards.ts
@@ -1,0 +1,30 @@
+interface IShouldIgnoreProgrammaticSettlingTabParams {
+  expectedTabName?: string;
+  incomingTabName: string;
+  lastProgrammaticAcceptedTabName?: string;
+  programmaticAcceptedElapsedMs?: number;
+  programmaticSettleGuardMs: number;
+  isRecentPagerDrag: boolean;
+  wasDraggedAfterExpectedTab: boolean;
+}
+
+export function shouldIgnoreProgrammaticSettlingTab({
+  expectedTabName,
+  incomingTabName,
+  lastProgrammaticAcceptedTabName,
+  programmaticAcceptedElapsedMs,
+  programmaticSettleGuardMs,
+  isRecentPagerDrag,
+  wasDraggedAfterExpectedTab,
+}: IShouldIgnoreProgrammaticSettlingTabParams): boolean {
+  return Boolean(
+    !expectedTabName &&
+    programmaticSettleGuardMs > 0 &&
+    lastProgrammaticAcceptedTabName &&
+    incomingTabName !== lastProgrammaticAcceptedTabName &&
+    programmaticAcceptedElapsedMs !== undefined &&
+    programmaticAcceptedElapsedMs < programmaticSettleGuardMs &&
+    !isRecentPagerDrag &&
+    !wasDraggedAfterExpectedTab,
+  );
+}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57367](https://onekeyhq.atlassian.net/browse/OK-57367)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Coordinate native Market Home tab corrections through a single synchronization path.
- Ignore delayed PagerView callbacks after programmatic tab switches while preserving user swipes.
- Add regression coverage for deferred and cancelled synchronization and stale callback guards.

## Intent & Context
Discovery Market Home tabs could jump back to the previously selected tab after switching tabs and opening a list item. This fix is scoped to tab synchronization; list behavior is unchanged.

## Root Cause
PagerView could emit a delayed callback for the previous page after the programmatic target had already been accepted. Multiple imperative correction paths could then compete and write the stale tab back to the selected-tab atom. iOS was especially exposed because its programmatic settle guard was disabled even when PagerView reported `idle`.

## Design Decisions
- Keep corrective `jumpToTab` and `syncCurrentPage` operations in `useSyncedMarketTab` so requests are coalesced and ordered.
- Defer synchronization while PagerView is settling and cancel pending corrections when a user drag starts.
- Apply a 500 ms post-programmatic settle guard on both native platforms; recent user gestures explicitly bypass the stale-event guard.
- Keep the change isolated from Market list item behavior.

## Changes Detail
- Track expected targets, PagerView state, and user-drag ownership in the native Market Home layout.
- Add request and cancel semantics plus deferred retry coordination to the synchronized-tab hook.
- Extract and test the stale programmatic callback predicate.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile (iOS and Android)
- **Risk Areas**: Programmatic tab changes, manual tab swipes, nested Discovery pager transitions, and returning from Market detail pages.
- **Runtime Scope**: Main UI runtime only. The native PagerView is involved, but no shared native resource ownership or persistence changes. The bg runtime and its JS heap are unaffected.

## Test plan
- [x] Run targeted Jest tests for `useSyncedMarketTab` and `marketTabChangeGuards`.
- [x] Run `yarn agent:check --profile commit`.
- [x] Verify repeated tab switches and route returns on Android.
- [ ] Recheck tap, swipe, open-item/back, and Discovery re-entry flows on iOS with the final settle guard.
- [ ] Recheck the same interaction flows in the PR build on Android.

[OK-57367]: https://onekeyhq.atlassian.net/browse/OK-57367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ