### PR TITLE
fix: close TradingView settings on native control interactions(OK-57749)

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewV2/components/calendarControls/CalendarPanelPopover.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/calendarControls/CalendarPanelPopover.tsx
@@ -360,9 +360,11 @@ function CalendarGrid({
 export function CalendarPanelPopover({
   chartTimezone,
   onSubmit,
+  onControlInteraction,
 }: {
   chartTimezone: string;
   onSubmit: (payload: ICalendarPanelSubmitPayload) => void;
+  onControlInteraction?: () => void;
 }) {
   const intl = useIntl();
   const today = useMemo(() => startOfDay(new Date()), []);
@@ -440,11 +442,12 @@ export function CalendarPanelPopover({
   const handleOpenChange = useCallback(
     (open: boolean) => {
       if (open) {
+        onControlInteraction?.();
         resetPanelState();
       }
       setIsOpen(open);
     },
-    [resetPanelState],
+    [onControlInteraction, resetPanelState],
   );
 
   const handleDatePress = useCallback(

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/chartControls/TradingViewNativeChartControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/chartControls/TradingViewNativeChartControls.tsx
@@ -76,6 +76,7 @@ interface ITradingViewNativeChartControlsProps {
   onPriceMarketCapModeChange: (mode: ITradingViewPriceMarketCapMode) => void;
   onCalendarPanelSubmit?: (payload: ICalendarPanelSubmitPayload) => void;
   onOpenChartSettings?: () => void;
+  onControlInteraction?: () => void;
   onUndo?: () => void;
   onRedo?: () => void;
   onFullscreenChange?: (isFullscreen: boolean) => void;
@@ -108,6 +109,7 @@ export const TradingViewNativeChartControls = memo(
     onPriceMarketCapModeChange,
     onCalendarPanelSubmit,
     onOpenChartSettings,
+    onControlInteraction,
     onUndo,
     onRedo,
     onFullscreenChange,
@@ -169,6 +171,7 @@ export const TradingViewNativeChartControls = memo(
     );
 
     const showIndicatorsDialog = useCallback(() => {
+      onControlInteraction?.();
       Dialog.show({
         title: indicatorsTitle,
         showFooter: false,
@@ -186,6 +189,7 @@ export const TradingViewNativeChartControls = memo(
       handleNativeIndicatorSelect,
       indicators,
       indicatorsTitle,
+      onControlInteraction,
       onResetLayout,
       resetLayout,
     ]);
@@ -225,13 +229,25 @@ export const TradingViewNativeChartControls = memo(
 
     const handleChartTypeToggle = useCallback(() => {
       if (nextChartType) {
+        onControlInteraction?.();
         onChartTypeChange(nextChartType.value);
       }
-    }, [nextChartType, onChartTypeChange]);
+    }, [nextChartType, onChartTypeChange, onControlInteraction]);
 
     const handleFullscreenToggle = useCallback(() => {
+      onControlInteraction?.();
       onFullscreenChange?.(!isFullscreen);
-    }, [isFullscreen, onFullscreenChange]);
+    }, [isFullscreen, onControlInteraction, onFullscreenChange]);
+
+    const handleUndo = useCallback(() => {
+      onControlInteraction?.();
+      onUndo?.();
+    }, [onControlInteraction, onUndo]);
+
+    const handleRedo = useCallback(() => {
+      onControlInteraction?.();
+      onRedo?.();
+    }, [onControlInteraction, onRedo]);
 
     const handleSettingsPress = useCallback(() => {
       if (isDesktopLayout && onOpenChartSettings) {
@@ -250,6 +266,7 @@ export const TradingViewNativeChartControls = memo(
             chartTypes={chartTypes}
             activeChartType={activeChartType}
             onChartTypeChange={onChartTypeChange}
+            onControlInteraction={onControlInteraction}
           />
         );
       }
@@ -278,6 +295,7 @@ export const TradingViewNativeChartControls = memo(
       handleChartTypeToggle,
       nextChartTypeLabel,
       onChartTypeChange,
+      onControlInteraction,
       showChartTypeSelect,
       showChartTypeToggle,
     ]);
@@ -294,6 +312,7 @@ export const TradingViewNativeChartControls = memo(
             indicators={indicators}
             activeIndicatorValues={activeIndicatorValues}
             onIndicatorPress={handleIndicatorPress}
+            onControlInteraction={onControlInteraction}
           />
         );
       }
@@ -316,6 +335,7 @@ export const TradingViewNativeChartControls = memo(
       hasVisibleIndicators,
       indicators,
       indicatorsTitle,
+      onControlInteraction,
       showIndicatorPopover,
       showIndicatorsDialog,
     ]);
@@ -329,15 +349,22 @@ export const TradingViewNativeChartControls = memo(
         <PriceMarketCapSelect
           priceMarketCap={priceMarketCap}
           onPriceMarketCapModeChange={onPriceMarketCapModeChange}
+          onControlInteraction={onControlInteraction}
         />
       );
-    }, [onPriceMarketCapModeChange, priceMarketCap, showPriceMarketCapSelect]);
+    }, [
+      onControlInteraction,
+      onPriceMarketCapModeChange,
+      priceMarketCap,
+      showPriceMarketCapSelect,
+    ]);
 
     const calendarControl =
       hasCalendarControl && onCalendarPanelSubmit ? (
         <CalendarPanelPopover
           chartTimezone={chartTimezone}
           onSubmit={onCalendarPanelSubmit}
+          onControlInteraction={onControlInteraction}
         />
       ) : null;
 
@@ -385,7 +412,7 @@ export const TradingViewNativeChartControls = memo(
             icon="UndoOutline"
             iconSize="$5"
             title={intl.formatMessage({ id: ETranslations.menu_undo })}
-            onPress={onUndo}
+            onPress={handleUndo}
             {...HEADER_ICON_BUTTON_STYLE_PROPS}
           />
           <IconButton
@@ -395,7 +422,7 @@ export const TradingViewNativeChartControls = memo(
             icon="UndoFlipHorOutline"
             iconSize="$5"
             title={intl.formatMessage({ id: ETranslations.menu_redo })}
-            onPress={onRedo}
+            onPress={handleRedo}
             {...HEADER_ICON_BUTTON_STYLE_PROPS}
           />
         </XStack>
@@ -416,6 +443,7 @@ export const TradingViewNativeChartControls = memo(
         intervalConfig={intervalConfig}
         intervalControlMode={intervalControlMode}
         onIntervalChange={onIntervalChange}
+        onControlInteraction={onControlInteraction}
       />
     ) : null;
     const hasLeftChartTools = Boolean(

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/chartType/ChartTypeSelect.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/chartType/ChartTypeSelect.tsx
@@ -17,11 +17,13 @@ export function ChartTypeSelect({
   chartTypes,
   activeChartType,
   onChartTypeChange,
+  onControlInteraction,
 }: {
   title: string;
   chartTypes: ITradingViewChartTypeOption[];
   activeChartType: number | undefined;
   onChartTypeChange: (chartType: number) => void;
+  onControlInteraction?: () => void;
 }) {
   const intl = useIntl();
   const items = useMemo(
@@ -67,7 +69,10 @@ export function ChartTypeSelect({
           iconSize="$5"
           title={title}
           disabled={disabled}
-          onPress={onPress}
+          onPress={(event) => {
+            onControlInteraction?.();
+            onPress?.(event);
+          }}
           {...HEADER_ICON_BUTTON_STYLE_PROPS}
         />
       )}

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
@@ -217,10 +217,12 @@ export const TradingViewNativeIndicatorQuickBar = memo(
     nativeChartControlsConfig,
     nativeIndicatorState,
     onIndicatorSelect,
+    onControlInteraction,
   }: {
     nativeChartControlsConfig: ITradingViewNativeChartControlsConfigData | null;
     nativeIndicatorState: ITradingViewNativeIndicatorState;
     onIndicatorSelect: (indicatorName: string, desiredActive: boolean) => void;
+    onControlInteraction?: () => void;
   }) => {
     const {
       activeIndicatorValues,
@@ -250,7 +252,10 @@ export const TradingViewNativeIndicatorQuickBar = memo(
             key={indicator.value}
             indicator={indicator}
             isActive={activeIndicatorValues.has(indicator.value)}
-            onPress={() => handleIndicatorPress(indicator)}
+            onPress={() => {
+              onControlInteraction?.();
+              handleIndicatorPress(indicator);
+            }}
           />
         ))}
         {subIndicators.length ? (
@@ -261,7 +266,10 @@ export const TradingViewNativeIndicatorQuickBar = memo(
             key={indicator.value}
             indicator={indicator}
             isActive={activeIndicatorValues.has(indicator.value)}
-            onPress={() => handleIndicatorPress(indicator)}
+            onPress={() => {
+              onControlInteraction?.();
+              handleIndicatorPress(indicator);
+            }}
           />
         ))}
       </XStack>
@@ -447,15 +455,22 @@ export function IndicatorPopover({
   indicators,
   activeIndicatorValues,
   onIndicatorPress,
+  onControlInteraction,
 }: {
   title: string;
   indicators: ITradingViewIndicatorOption[];
   activeIndicatorValues: Set<string>;
   onIndicatorPress: (indicator: ITradingViewIndicatorOption) => void;
+  onControlInteraction?: () => void;
 }) {
   return (
     <Popover
       title={title}
+      onOpenChange={(open) => {
+        if (open) {
+          onControlInteraction?.();
+        }
+      }}
       showHeader={false}
       usingSheet={false}
       placement="bottom-end"

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/intervalSelector/NativeIntervalSelector.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/intervalSelector/NativeIntervalSelector.tsx
@@ -28,6 +28,7 @@ interface ITradingViewNativeIntervalSelectorProps {
   intervalConfig: ITradingViewIntervalConfigData | null;
   intervalControlMode?: ITradingViewNativeIntervalControlMode;
   onIntervalChange: (interval: string) => void;
+  onControlInteraction?: () => void;
 }
 
 function IntervalMoreTrigger({
@@ -80,6 +81,7 @@ export const TradingViewNativeIntervalSelector = memo(
     intervalConfig,
     intervalControlMode = 'dialog',
     onIntervalChange,
+    onControlInteraction,
   }: ITradingViewNativeIntervalSelectorProps) => {
     const intl = useIntl();
     const [intervalsPopoverSessionKey, setIntervalsPopoverSessionKey] =
@@ -110,14 +112,16 @@ export const TradingViewNativeIntervalSelector = memo(
     const handleIntervalsPopoverOpenChange = useCallback(
       (open: boolean) => {
         if (open) {
+          onControlInteraction?.();
           setIntervalsPopoverSessionKey((key) => key + 1);
         }
         setIsIntervalsPopoverOpen(open);
       },
-      [setIsIntervalsPopoverOpen],
+      [onControlInteraction, setIsIntervalsPopoverOpen],
     );
 
     const showIntervalsDialog = useCallback(() => {
+      onControlInteraction?.();
       closeIntervalsDialog();
       const dialogInstance = Dialog.show({
         title: intl.formatMessage({ id: ETranslations.market_intervals }),
@@ -148,6 +152,7 @@ export const TradingViewNativeIntervalSelector = memo(
       handleIntervalsDialogClose,
       handlePreferredValuesChange,
       intl,
+      onControlInteraction,
       onIntervalChange,
       options,
       preferredIntervalValues,
@@ -227,6 +232,7 @@ export const TradingViewNativeIntervalSelector = memo(
             }
             options={segmentOptions}
             onChange={(value) => {
+              onControlInteraction?.();
               const nextOption = options.find(
                 (option) => option.value === value,
               );

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/priceMarketCap/PriceMarketCapSelect.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/priceMarketCap/PriceMarketCapSelect.tsx
@@ -18,11 +18,13 @@ type IPriceMarketCapConfig = NonNullable<
 export function PriceMarketCapSelect({
   priceMarketCap,
   onPriceMarketCapModeChange,
+  onControlInteraction,
 }: {
   priceMarketCap: IPriceMarketCapConfig;
   onPriceMarketCapModeChange: (
     mode: IPriceMarketCapConfig['activeMode'],
   ) => void;
+  onControlInteraction?: () => void;
 }) {
   const intl = useIntl();
   const items = useMemo(
@@ -67,7 +69,10 @@ export function PriceMarketCapSelect({
           pressStyle={{ bg: '$bgActive' }}
           cursor={disabled ? 'not-allowed' : 'pointer'}
           userSelect="none"
-          onPress={onPress}
+          onPress={(event) => {
+            onControlInteraction?.();
+            onPress?.(event);
+          }}
         >
           <SizableText
             size="$bodyMdMedium"

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
@@ -86,6 +86,8 @@ const TRADINGVIEW_PRICE_MARKET_CAP_CHANGE_MESSAGE =
   'TRADINGVIEW_PRICE_MARKET_CAP_CHANGE';
 const TRADINGVIEW_OPEN_CHART_SETTINGS_MESSAGE =
   'TRADINGVIEW_OPEN_CHART_SETTINGS';
+const TRADINGVIEW_CLOSE_POPUPS_AND_DIALOGS_MESSAGE =
+  'TRADINGVIEW_CLOSE_POPUPS_AND_DIALOGS';
 const TRADINGVIEW_CALENDAR_PANEL_SUBMIT_MESSAGE =
   'TRADINGVIEW_CALENDAR_PANEL_SUBMIT';
 const TRADINGVIEW_UNDO_MESSAGE = 'TRADINGVIEW_UNDO';
@@ -337,6 +339,12 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
   const handleNativeOpenChartSettings = useCallback(() => {
     webRef.current?.sendMessageViaInjectedScript({
       type: TRADINGVIEW_OPEN_CHART_SETTINGS_MESSAGE,
+      payload: {},
+    });
+  }, []);
+  const handleNativeControlInteraction = useCallback(() => {
+    webRef.current?.sendMessageViaInjectedScript({
+      type: TRADINGVIEW_CLOSE_POPUPS_AND_DIALOGS_MESSAGE,
       payload: {},
     });
   }, []);
@@ -626,10 +634,12 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
         nativeChartControlsConfig={nativeChartControlsConfig}
         nativeIndicatorState={nativeIndicatorState}
         onIndicatorSelect={handleNativeIndicatorSelect}
+        onControlInteraction={handleNativeControlInteraction}
       />
     );
   }, [
     enableNativeChartControls,
+    handleNativeControlInteraction,
     handleNativeIndicatorSelect,
     nativeChartControlsConfig,
     nativeIndicatorState,
@@ -722,6 +732,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
           onPriceScaleModeChange={handleNativePriceScaleModeChange}
           onPriceMarketCapModeChange={handleNativePriceMarketCapModeChange}
           onOpenChartSettings={handleNativeOpenChartSettings}
+          onControlInteraction={handleNativeControlInteraction}
           onCalendarPanelSubmit={handleNativeCalendarPanelSubmit}
           onUndo={handleNativeUndo}
           onRedo={handleNativeRedo}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57749](https://onekeyhq.atlassian.net/browse/OK-57749)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Dismiss TradingView-owned popups and dialogs before handling a different native chart control interaction.
- Cover interval, chart type, indicator, calendar, Price/Market Cap, undo/redo, fullscreen, and indicator quick-bar interactions.
- Keep the settings trigger excluded so the settings panel is not closed immediately after it opens.

## Intent & Context
Market TradingViewV2 uses OneKey native controls while the chart settings panel is rendered inside the embedded TradingView runtime. After opening chart settings, interacting with another native control (for example the interval selector, calendar, or indicators) left the TradingView settings panel visible behind or alongside the new UI.

OK-57749 makes native control interactions behave as a single active surface: when the user moves from TradingView settings to another chart control, the chart-owned panel closes first.

Companion chart implementation: https://github.com/OneKeyHQ/tradingview-charting-library/pull/196

## Root Cause
The native controls and the TradingView settings panel run in separate UI/JavaScript contexts. Existing native control handlers executed their own actions or opened OneKey popovers/dialogs, but they did not notify the embedded chart to dismiss chart-owned overlays. Because there was no cross-context close request, TradingView retained the settings panel until the user explicitly closed it.

## Design Decisions
- Send one explicit `TRADINGVIEW_CLOSE_POPUPS_AND_DIALOGS` bridge message before non-settings native control interactions instead of mirroring TradingView popup state in React.
- Keep the callback optional and propagate it through reusable control components, preserving existing callers and component behavior.
- Trigger dismissal when a selector/popover/dialog actually opens, or immediately before a direct control action.
- Do not invoke dismissal from the settings button itself; doing so would race with and potentially close the panel that the same press is opening.
- This affects the app `main` UI runtime and the embedded TradingView web runtime only. The background runtime, native resource ownership, persistence, and per-runtime data deserialization are unchanged; the two UI contexts initialize independently and communicate through serialized messages.

## Changes Detail
- `TradingViewV2.tsx`: add the close message and expose a shared native-control interaction handler to the toolbar and indicator quick bar.
- `TradingViewNativeChartControls.tsx`: invoke the interaction handler for chart type, indicators, calendar, Price/Market Cap, undo/redo, fullscreen, and interval controls while leaving settings unchanged.
- `NativeIntervalSelector.tsx`: close chart overlays when interval popovers/dialogs open or a segmented interval is selected.
- `NativeIndicatorControls.tsx`: close chart overlays when indicator popovers or quick-bar actions are used.
- `CalendarPanelPopover.tsx`, `ChartTypeSelect.tsx`, and `PriceMarketCapSelect.tsx`: notify the shared handler when their native control surfaces are opened.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop / Web / Extension in the desktop native-controls layout; Mobile shares the callback path but does not currently use the TradingView-owned settings panel on `x`
- **Risk Areas**: Requires the companion chart deployment to recognize the new message. Interaction ordering must close the old TradingView surface without closing the newly requested OneKey surface or the settings panel itself.

## Test plan
- [x] Run `yarn agent:check --profile commit` after rebasing onto the latest `origin/x`.
- [ ] Open Market TradingViewV2 with native controls, open chart settings, then open the interval selector and verify settings closes.
- [ ] Repeat with chart type, indicators (dialog/popover and quick bar), calendar, Price/Market Cap, undo, redo, and fullscreen.
- [ ] Press the settings button and verify the settings panel remains open until another control is used.
- [ ] Verify mobile native-control dialogs and selectors continue to open and perform their actions normally.

[OK-57749]: https://onekeyhq.atlassian.net/browse/OK-57749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ