### PR TITLE
fix: filter zero-fiat perps deposit tokens(OK-57824)

### DIFF
--- a/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
@@ -52,6 +52,8 @@ import { logHyperLiquidApiFailure } from '../ServiceHyperLiquid/utils/logHyperLi
 import {
   buildPerpsDepositTokensByNetwork,
   buildPerpsDepositTokensFromWalletTokenResponses,
+  filterPerpsDepositTokensByNetworkWithPositiveFiatValue,
+  filterPerpsDepositTokensWithPositiveFiatValue,
   resolvePerpsDepositSelectedToken,
 } from './utils/depositTokenListUtils';
 
@@ -740,8 +742,10 @@ class ServiceWebviewPerp extends ServiceBase {
     if (coldCache) {
       const data = {
         ownerKey: coldCache.ownerKey ?? ownerKey,
-        tokens: coldCache.tokens,
-        tokensByNetwork: coldCache.tokensByNetwork,
+        tokens: filterPerpsDepositTokensWithPositiveFiatValue(coldCache.tokens),
+        tokensByNetwork: filterPerpsDepositTokensByNetworkWithPositiveFiatValue(
+          coldCache.tokensByNetwork,
+        ),
       };
       const { selectedToken, isStale } =
         await this.updatePerpsDepositTokenListAtom(data, {

--- a/packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.test.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.test.ts
@@ -9,6 +9,7 @@ import type {
 import {
   buildPerpsDepositTokensByNetwork,
   buildPerpsDepositTokensFromWalletTokenResponses,
+  filterPerpsDepositTokensByNetworkWithPositiveFiatValue,
   getDefaultPerpsDepositToken,
   resolvePerpsDepositSelectedToken,
 } from './depositTokenListUtils';
@@ -191,6 +192,82 @@ describe('depositTokenListUtils', () => {
     ]);
   });
 
+  it('filters wallet tokens without a positive fiat value', () => {
+    const positive = makeToken({
+      networkId: 'evm--1',
+      address: '0xpositive',
+      symbol: 'POSITIVE',
+    });
+    const zero = makeToken({
+      networkId: 'evm--1',
+      address: '0xzero',
+      symbol: 'ZERO',
+    });
+    const missing = makeToken({
+      networkId: 'evm--1',
+      address: '0xmissing',
+      symbol: 'MISSING',
+    });
+    const invalid = makeToken({
+      networkId: 'evm--1',
+      address: '0xinvalid',
+      symbol: 'INVALID',
+    });
+    const negative = makeToken({
+      networkId: 'evm--1',
+      address: '0xnegative',
+      symbol: 'NEGATIVE',
+    });
+
+    const result = buildPerpsDepositTokensFromWalletTokenResponses({
+      responses: [
+        makeResponse({
+          tokens: [positive, zero, missing, invalid, negative],
+          tokenMap: {
+            [positive.$key]: makeFiat({ fiatValue: '0.01', price: 1 }),
+            [zero.$key]: makeFiat({ fiatValue: '0', price: 1 }),
+            [invalid.$key]: makeFiat({
+              fiatValue: 'not-a-number',
+              price: 1,
+            }),
+            [negative.$key]: makeFiat({ fiatValue: '-1', price: 1 }),
+          },
+        }),
+      ],
+      networkLogoURIByNetworkId: {},
+    });
+
+    expect(result.map((token) => token.symbol)).toEqual(['POSITIVE']);
+  });
+
+  it('filters cached tokens by network while preserving empty network entries', () => {
+    const positiveToken = {
+      networkId: 'evm--1',
+      contractAddress: '0xpositive',
+      name: 'Positive',
+      symbol: 'POSITIVE',
+      decimals: 18,
+      networkLogoURI: '',
+      fiatValue: '0.01',
+    };
+    const zeroToken = {
+      ...positiveToken,
+      contractAddress: '0xzero',
+      symbol: 'ZERO',
+      fiatValue: '0',
+    };
+
+    expect(
+      filterPerpsDepositTokensByNetworkWithPositiveFiatValue({
+        'evm--1': [positiveToken, zeroToken],
+        'evm--137': [],
+      }),
+    ).toEqual({
+      'evm--1': [positiveToken],
+      'evm--137': [],
+    });
+  });
+
   it('maps fiat data when wallet token map keys do not exactly match token $key', () => {
     const arbUsdc = makeToken({
       networkId: PERPS_NETWORK_ID,
@@ -257,14 +334,7 @@ describe('depositTokenListUtils', () => {
       networkLogoURIByNetworkId: {},
     });
 
-    expect(result[0]).toEqual(
-      expect.objectContaining({
-        symbol: 'TOKEN',
-        balanceParsed: undefined,
-        fiatValue: undefined,
-        price: undefined,
-      }),
-    );
+    expect(result).toEqual([]);
   });
 
   it('uses highest positive fiat value before the legacy Arbitrum USDC fallback', () => {

--- a/packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.ts
@@ -69,6 +69,28 @@ function toOptionalString(value: string | number | undefined) {
   return String(value);
 }
 
+function hasPositiveFiatValue(token: IPerpsDepositToken) {
+  const fiatValue = new BigNumber(token.fiatValue ?? '');
+  return fiatValue.isFinite() && fiatValue.gt(0);
+}
+
+export function filterPerpsDepositTokensWithPositiveFiatValue(
+  tokens: IPerpsDepositToken[],
+) {
+  return tokens.filter(hasPositiveFiatValue);
+}
+
+export function filterPerpsDepositTokensByNetworkWithPositiveFiatValue(
+  tokensByNetwork: Record<string, IPerpsDepositToken[]>,
+) {
+  return Object.fromEntries(
+    Object.entries(tokensByNetwork).map(([networkId, tokens]) => [
+      networkId,
+      filterPerpsDepositTokensWithPositiveFiatValue(tokens),
+    ]),
+  );
+}
+
 function mapWalletTokenToPerpsDepositToken({
   token,
   fiat,
@@ -121,7 +143,9 @@ export function buildPerpsDepositTokensFromWalletTokenResponses({
     }
   }
 
-  return sortPerpsDepositTokensByFiatValue(tokens);
+  return sortPerpsDepositTokensByFiatValue(
+    filterPerpsDepositTokensWithPositiveFiatValue(tokens),
+  );
 }
 
 export function sortPerpsDepositTokensByFiatValue(

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -1677,6 +1677,7 @@ function DepositWithdrawContent({
       >
         <YStack flex={1} minWidth={0}>
           <XStack
+            testID="perp-deposit-token-selector"
             alignItems="center"
             gap="$2.5"
             flexShrink={1}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57824](https://onekeyhq.atlassian.net/browse/OK-57824)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Filter Perps deposit tokens to only include entries with a finite positive fiat value.
- Apply the same filtering to cold-cache data and per-network token maps.
- Add regression coverage for zero, missing, invalid, negative, and cached fiat values.

## Intent & Context
OK-57824 reported that the Perps deposit selector displayed wallet tokens without a fiat amount, including entries rendered as $0.00. The requested behavior is to hide tokens that have no fiat value while keeping funded tokens available for deposit.

## Root Cause
Wallet token responses were mapped into the Perps deposit list before checking fiat metadata. Tokens with missing, zero, invalid, or non-positive fiat values therefore remained visible. The cold-cache path returned previously persisted lists without applying the same validation.

## Design Decisions
- Use BigNumber validation and require a finite value greater than zero, matching the existing fiat-value sorting semantics.
- Filter before sorting so the visible order remains the wallet fiat-value order.
- Reuse the filter for both live responses and cold-cache data to prevent stale $0.00 entries during cache-first rendering.
- Preserve empty network buckets so supported-network UI behavior remains unchanged.

## Changes Detail
- packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.ts: add positive-fiat filtering helpers and apply them to wallet response mapping.
- packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts: sanitize cold-cache token data before writing it to the atom.
- packages/kit-bg/src/services/ServiceWebviewPerp/utils/depositTokenListUtils.test.ts: cover live and cached filtering edge cases.
- packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx: add a stable selector test ID for UI verification.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop
- **Risk Areas**: Perps deposit-token selection and cache-first rendering; no transaction, signing, or balance calculation logic is changed.

## Test plan
- [x] Targeted Jest suites: 3 suites, 23 tests passed.
- [x] Desktop self-test: zero-fiat account shows no deposit token entries.
- [x] iOS self-test: positive-fiat tokens remain visible and DAI with $0.00 is absent.
- [x] Android self-test: empty wallet deposit form shows no $0.00 token entry.
- [x] yarn agent:check --profile commit passed.

[OK-57824]: https://onekeyhq.atlassian.net/browse/OK-57824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ