### PR TITLE
fix: resolve Android market recommendation clipping(OK-57820)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketWatchlistFlatList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketWatchlistFlatList.tsx
@@ -410,7 +410,7 @@ function MobileMarketWatchlistFlatListImpl({
         <Stack
           {...(platformEnv.isNative ? null : { justifyContent: 'center' })}
           alignItems="center"
-          y={-25}
+          paddingTop="$8"
         >
           <MarketRecommendList
             maxSize={8}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketWatchlistFlatList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MobileMarketWatchlistFlatList.tsx
@@ -33,6 +33,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IMarketWatchListItemV2 } from '@onekeyhq/shared/types/market';
 
 import { usePerpsNavigation } from '../../../hooks/usePerpsNavigation';
+import { getMarketEmptyWatchlistContainerProps } from '../../layouts/mobileLayoutUtils';
 import { MarketRecommendList } from '../MarketRecommendList';
 
 import { InlineActionBar } from './components/InlineActionBar';
@@ -409,8 +410,10 @@ function MobileMarketWatchlistFlatListImpl({
       <Tabs.ScrollView>
         <Stack
           {...(platformEnv.isNative ? null : { justifyContent: 'center' })}
+          {...getMarketEmptyWatchlistContainerProps({
+            isNativeAndroid: Boolean(platformEnv.isNativeAndroid),
+          })}
           alignItems="center"
-          paddingTop="$8"
         >
           <MarketRecommendList
             maxSize={8}

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
@@ -39,6 +39,7 @@ import {
   getDefaultMarketStockCategoryId,
   getMarketStockCategoryRequestParam,
 } from './marketStockCategoryUtils';
+import { getMarketMobileSecondaryHeaderHeight } from './mobileLayoutUtils';
 
 import type {
   ILiquidityFilter,
@@ -90,7 +91,6 @@ interface IMarketHomeTabBarProps extends TabBarProps<string> {
   perpsTabName: string;
 }
 
-const MARKET_MOBILE_SECONDARY_HEADER_HEIGHT = 74;
 const MARKET_TAB_CHANGE_TARGET_GUARD_MS = platformEnv.isNativeIOS ? 1000 : 350;
 const MARKET_TAB_SYNC_JUMP_DEFER_MS = platformEnv.isNativeIOS ? 180 : 0;
 const MARKET_TAB_USER_DRAG_ACCEPT_MS = platformEnv.isNativeIOS ? 700 : 350;
@@ -237,7 +237,11 @@ function MarketHomeTabBar({
         />
       </YStack>
       <YStack
-        height={MARKET_MOBILE_SECONDARY_HEADER_HEIGHT}
+        height={getMarketMobileSecondaryHeaderHeight({
+          isNativeAndroid: Boolean(platformEnv.isNativeAndroid),
+          isWatchlistEmpty: ctx.isWatchlistEmpty,
+          showWatchlistSubHeader,
+        })}
         overflow={platformEnv.isNativeAndroid ? 'hidden' : undefined}
         position="relative"
       >

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.test.ts
@@ -1,4 +1,21 @@
-import { getMarketMobileSecondaryHeaderHeight } from './mobileLayoutUtils';
+import {
+  getMarketEmptyWatchlistContainerProps,
+  getMarketMobileSecondaryHeaderHeight,
+} from './mobileLayoutUtils';
+
+describe('getMarketEmptyWatchlistContainerProps', () => {
+  it('uses normal-flow padding on Android', () => {
+    expect(
+      getMarketEmptyWatchlistContainerProps({ isNativeAndroid: true }),
+    ).toEqual({ paddingTop: '$8' });
+  });
+
+  it('preserves the negative offset outside Android', () => {
+    expect(
+      getMarketEmptyWatchlistContainerProps({ isNativeAndroid: false }),
+    ).toEqual({ y: -25 });
+  });
+});
 
 describe('getMarketMobileSecondaryHeaderHeight', () => {
   it('collapses the Android secondary header for an empty watchlist', () => {

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.test.ts
@@ -1,0 +1,33 @@
+import { getMarketMobileSecondaryHeaderHeight } from './mobileLayoutUtils';
+
+describe('getMarketMobileSecondaryHeaderHeight', () => {
+  it('collapses the Android secondary header for an empty watchlist', () => {
+    expect(
+      getMarketMobileSecondaryHeaderHeight({
+        isNativeAndroid: true,
+        isWatchlistEmpty: true,
+        showWatchlistSubHeader: true,
+      }),
+    ).toBe(0);
+  });
+
+  it('keeps the secondary header for a populated Android watchlist', () => {
+    expect(
+      getMarketMobileSecondaryHeaderHeight({
+        isNativeAndroid: true,
+        isWatchlistEmpty: false,
+        showWatchlistSubHeader: true,
+      }),
+    ).toBe(74);
+  });
+
+  it('keeps the secondary header outside Android', () => {
+    expect(
+      getMarketMobileSecondaryHeaderHeight({
+        isNativeAndroid: false,
+        isWatchlistEmpty: true,
+        showWatchlistSubHeader: true,
+      }),
+    ).toBe(74);
+  });
+});

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.ts
@@ -1,0 +1,18 @@
+export const MARKET_MOBILE_SECONDARY_HEADER_HEIGHT = 74;
+
+interface IGetMarketMobileSecondaryHeaderHeightParams {
+  isNativeAndroid: boolean;
+  isWatchlistEmpty: boolean;
+  showWatchlistSubHeader: boolean;
+}
+
+export function getMarketMobileSecondaryHeaderHeight({
+  isNativeAndroid,
+  isWatchlistEmpty,
+  showWatchlistSubHeader,
+}: IGetMarketMobileSecondaryHeaderHeightParams) {
+  if (isNativeAndroid && showWatchlistSubHeader && isWatchlistEmpty) {
+    return 0;
+  }
+  return MARKET_MOBILE_SECONDARY_HEADER_HEIGHT;
+}

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.ts
@@ -1,5 +1,17 @@
 export const MARKET_MOBILE_SECONDARY_HEADER_HEIGHT = 74;
 
+interface IGetMarketEmptyWatchlistContainerPropsParams {
+  isNativeAndroid: boolean;
+}
+
+export function getMarketEmptyWatchlistContainerProps({
+  isNativeAndroid,
+}: IGetMarketEmptyWatchlistContainerPropsParams) {
+  return isNativeAndroid
+    ? ({ paddingTop: '$8' } as const)
+    : ({ y: -25 } as const);
+}
+
 interface IGetMarketMobileSecondaryHeaderHeightParams {
   isNativeAndroid: boolean;
   isWatchlistEmpty: boolean;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57820](https://onekeyhq.atlassian.net/browse/OK-57820)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Collapse the native Market secondary header when Android Favorites is empty.
- Use normal-flow `$8` top padding only for the Android empty recommendation grid.
- Preserve the existing `y={-25}` positioning on iOS and mobile Web.
- Add focused coverage for the platform and empty-state layout contracts.

## Intent & Context
OK-57820 reports that the recommended Favorites list is clipped on Android, reproduced on a Samsung Galaxy S23 Ultra-class viewport. The first token row was only partially visible, preventing the empty-state recommendation grid from rendering as intended.

## Root Cause
The regression combined two layout changes: the hidden empty-Favorites secondary header continued reserving 74 pixels, while the recommendation container was shifted upward with `y={-25}`. On Android devices with a shorter logical viewport, the negative translation moved the first row into the `Tabs.ScrollView` clipping boundary.

## Design Decisions
- Collapse the secondary header only for an empty Android Favorites tab, preserving the current 74-pixel behavior for populated Android lists and other platforms.
- Apply `paddingTop="$8"` only inside the existing empty-watchlist branch on Android.
- Retain `y={-25}` for iOS and mobile Web to avoid changing the layout introduced for those platforms.
- Keep both decisions in small pure utilities so the platform and empty-state contracts are explicit and regression-testable.
- Leave Market recommendation data, watchlist persistence, Stock/Perps filters, and background-runtime ownership unchanged.

## Changes Detail
- `MobileLayout.native.tsx`: resolves native secondary-header height from the Android empty-watchlist state.
- `MobileMarketWatchlistFlatList.tsx`: selects the empty-state container layout by platform.
- `mobileLayoutUtils.ts`: owns the Android header-height and platform-specific empty-container decisions.
- `mobileLayoutUtils.test.ts`: covers Android/non-Android container props and Android empty/populated/non-Android header heights.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Android behavior changes; iOS and mobile Web behavior is explicitly preserved.
- **Risk Areas**: Native Market Favorites secondary-header spacing and empty-state recommendation positioning.

## Test plan
- [x] Run the three focused Market suites (14 tests passed).
- [x] Verify Android and non-Android empty-container props (`$8` vs `y={-25}`).
- [x] Run `yarn agent:check --profile commit` (lint and TypeScript passed).
- [x] Build and run Android 15 at 1080x2340, 480 dpi after merging the latest `x`; confirm the first recommendation row is fully visible.
- [x] Toggle a recommendation and verify the selected count changes from 8 to 7 and back to 8.
- [x] Scroll the recommendation area and verify the add button remains reachable.

[OK-57820]: https://onekeyhq.atlassian.net/browse/OK-57820