### PR TITLE
fix: align app update indicators with accent update button color

### DIFF
--- a/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopTabItem.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/DesktopTabItem.tsx
@@ -277,7 +277,7 @@ export function DesktopTabItem(
               <Stack
                 width="$2.5"
                 height="$2.5"
-                bg="$iconInfo"
+                bg="$bgAccent"
                 borderRadius="$full"
                 position="absolute"
                 right={-3}

--- a/packages/kit/src/components/MoreActionButton/index.tsx
+++ b/packages/kit/src/components/MoreActionButton/index.tsx
@@ -1569,7 +1569,8 @@ function MoreButtonWithDot({
     if (isShowUpgradeDot) {
       return (
         <Dot
-          color="$blue8"
+          // Accent (brand green) to match the header "Update now" button.
+          color="$bgAccent"
           top={isDesktopMode ? 0 : '$-2'}
           right={isDesktopMode ? undefined : '$-2.5'}
         />
@@ -1585,7 +1586,9 @@ function MoreButtonWithDot({
       <Stack
         width="$3"
         height="$3"
-        bg={isShowUpgradeDot ? '$iconInfo' : '$bgCriticalStrong'}
+        // Update dot uses accent (brand green) to match the header "Update
+        // now" button; the notification (non-update) dot stays critical red.
+        bg={isShowUpgradeDot ? '$bgAccent' : '$bgCriticalStrong'}
         borderRadius="$full"
         position="absolute"
         right={-4}

--- a/packages/kit/src/components/UpdateReminder/index.tsx
+++ b/packages/kit/src/components/UpdateReminder/index.tsx
@@ -41,7 +41,7 @@ function UpdateStatusText({ updateInfo }: { updateInfo: IAppUpdateInfo }) {
       ({
         [EAppUpdateStatus.notify]: {
           iconName: 'DownloadOutline',
-          iconColor: '$iconInfo',
+          iconColor: '$iconSuccess',
           renderText({
             updateInfo: appUpdateInfo,
           }: {
@@ -57,12 +57,12 @@ function UpdateStatusText({ updateInfo }: { updateInfo: IAppUpdateInfo }) {
         },
         [EAppUpdateStatus.downloadPackage]: {
           iconName: 'RefreshCcwSolid',
-          iconColor: '$iconInfo',
+          iconColor: '$iconSuccess',
           renderText: DownloadProgress,
         },
         [EAppUpdateStatus.downloadASC]: {
           iconName: 'RefreshCcwSolid',
-          iconColor: '$iconInfo',
+          iconColor: '$iconSuccess',
           renderText() {
             return intl.formatMessage({
               id: ETranslations.update_download_asc_label,
@@ -71,7 +71,7 @@ function UpdateStatusText({ updateInfo }: { updateInfo: IAppUpdateInfo }) {
         },
         [EAppUpdateStatus.verifyASC]: {
           iconName: 'RefreshCcwSolid',
-          iconColor: '$iconInfo',
+          iconColor: '$iconSuccess',
           renderText() {
             return intl.formatMessage({
               id: ETranslations.update_verify_asc_label,
@@ -80,7 +80,7 @@ function UpdateStatusText({ updateInfo }: { updateInfo: IAppUpdateInfo }) {
         },
         [EAppUpdateStatus.verifyPackage]: {
           iconName: 'RefreshCcwSolid',
-          iconColor: '$iconInfo',
+          iconColor: '$iconSuccess',
           renderText() {
             return intl.formatMessage({
               id: ETranslations.update_verify_file_signature,
@@ -248,24 +248,24 @@ const UPDATE_REMINDER_BAR_STYLE: Record<
   IStackProps | undefined
 > = {
   [EAppUpdateStatus.notify]: {
-    bg: '$bgInfoSubdued',
-    borderColor: '$borderInfoSubdued',
+    bg: '$bgSuccessSubdued',
+    borderColor: '$borderSuccessSubdued',
   },
   [EAppUpdateStatus.downloadPackage]: {
-    bg: '$bgInfoSubdued',
-    borderColor: '$borderInfoSubdued',
+    bg: '$bgSuccessSubdued',
+    borderColor: '$borderSuccessSubdued',
   },
   [EAppUpdateStatus.downloadASC]: {
-    bg: '$bgInfoSubdued',
-    borderColor: '$borderInfoSubdued',
+    bg: '$bgSuccessSubdued',
+    borderColor: '$borderSuccessSubdued',
   },
   [EAppUpdateStatus.verifyASC]: {
-    bg: '$bgInfoSubdued',
-    borderColor: '$borderInfoSubdued',
+    bg: '$bgSuccessSubdued',
+    borderColor: '$borderSuccessSubdued',
   },
   [EAppUpdateStatus.verifyPackage]: {
-    bg: '$bgInfoSubdued',
-    borderColor: '$borderInfoSubdued',
+    bg: '$bgSuccessSubdued',
+    borderColor: '$borderSuccessSubdued',
   },
   [EAppUpdateStatus.ready]: {
     bg: '$bgSuccessSubdued',

--- a/packages/kit/src/views/Setting/pages/Tab/CustomElement.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/CustomElement.tsx
@@ -442,13 +442,13 @@ export function ListVersionItem(props: ICustomElementProps) {
     <TabSettingsListItem
       {...props}
       onPress={handleToUpdatePreviewPage}
-      iconProps={{ ...iconProps, color: '$textInfo' }}
-      titleProps={{ ...titleProps, color: '$textInfo' }}
+      iconProps={{ ...iconProps, color: '$textSuccess' }}
+      titleProps={{ ...titleProps, color: '$textSuccess' }}
       drillIn
     >
       <ListItem.Text
         primary={
-          <Badge badgeType="info" badgeSize="lg">
+          <Badge badgeType="success" badgeSize="lg">
             {displayAppUpdateVersion(appUpdateInfo.data)}
           </Badge>
         }

--- a/packages/kit/src/views/Setting/pages/Tab/ListItem.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/ListItem.tsx
@@ -43,7 +43,7 @@ export function TabSettingsListItem({
     <BaseListItem py="$3" px="$5" mx={0} borderRadius={0} {...props}>
       {children}
       {showDot ? (
-        <Stack width="$2" height="$2" bg="$iconInfo" borderRadius="$full" />
+        <Stack width="$2" height="$2" bg="$bgAccent" borderRadius="$full" />
       ) : null}
     </BaseListItem>
   );


### PR DESCRIPTION
## What

Aligns the app-update–related indicators with the accent (brand green) "Update now" button introduced in #12394, so all update affordances read as one consistent color instead of the previous blue/info tone.

## Changes

- **Grid / toolbox update dot** (`MoreActionButton`): the upgrade dot now uses `$bgAccent` to match the header button; the unrelated notification dot stays critical red.
- **Update reminder bar** (`UpdateReminder`): the notify / downloading / verifying / ready states move from the `info` (blue) family to the `success` (green) family — `$bgSuccessSubdued` background, `$borderSuccessSubdued` border, `$iconSuccess` icon. Failure states stay critical; incomplete stays caution.
- **Settings "App update available" row** (`CustomElement`): icon + title recolored to `$textSuccess`, badge switched to `success`.
- **Settings update dots** (`ListItem`, `DesktopTabItem`): the app-update `showDot` indicator now uses `$bgAccent`.

Two-tier by design: the small dots use `$bgAccent` (the exact button green); the larger banner / row surfaces use the subdued `success` family, since there is no accent-subdued token.

## Scope

Cross-platform (desktop / mobile / web / ext); pure design-token swaps, no logic changes. `yarn agent:check --profile pr` passes (lint + tsc).