### PR TITLE
fix: localize perp order modification feedback

### DIFF
--- a/packages/kit/src/states/jotai/contexts/hyperliquid/utils/config.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/utils/config.ts
@@ -101,10 +101,8 @@ export const TOAST_CONFIGS: Record<EActionType, IToastConfig> = {
   },
 
   [EActionType.MODIFY_ORDER]: {
-    // TODO(i18n): swap for ETranslations.perp_toast_modifying_order once PM adds the key.
-    loading: 'Modifying order…',
-    // TODO(i18n): swap for ETranslations.perp_toast_order_modified once PM adds the key.
-    successTitle: 'Order modified',
+    loading: t(ETranslations.perp_toast_modifying_order),
+    successTitle: t(ETranslations.perp_toast_order_modified),
   },
 
   [EActionType.WITHDRAW]: {

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -2806,6 +2806,8 @@ export enum ETranslations {
   perp_time_in_force_gtc__desc = 'perp_time_in_force_gtc__desc',
   perp_time_in_force_ioc__desc = 'perp_time_in_force_ioc__desc',
   perp_toast_deposit_success_eta_one_minute__msg = 'perp_toast_deposit_success_eta_one_minute__msg',
+  perp_toast_modifying_order = 'perp_toast_modifying_order',
+  perp_toast_order_modified = 'perp_toast_order_modified',
   perp_token_info_not_found__msg = 'perp_token_info_not_found__msg',
   perp_trade_account_overview_avbl = 'perp_trade_account_overview_avbl',
   perp_trade_deposit_to_trade__action = 'perp_trade_deposit_to_trade__action',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC (বাতিল না হওয়া পর্যন্ত কার্যকর): অর্ডারটি পূরণ বা বাতিল না হওয়া পর্যন্ত বহাল থাকবে。",
   "perp_time_in_force_ioc__desc": "IOC (তাৎক্ষণিকভাবে সম্পন্ন না হলে বাতিল): যে অংশটি সঙ্গে সঙ্গে পূরণ হবে না তা বাতিল করা হবে。",
   "perp_toast_deposit_success_eta_one_minute__msg": "{amount} {token} জমা দেওয়া হয়েছে। জমাগুলো ১ মিনিটের মধ্যে পৌঁছানো উচিত।",
+  "perp_toast_modifying_order": "অর্ডার পরিবর্তন করা হচ্ছে…",
+  "perp_toast_order_modified": "অর্ডার পরিবর্তন করা হয়েছে",
   "perp_token_info_not_found__msg": "টোকেনের তথ্য পাওয়া যায়নি",
   "perp_trade_account_overview_avbl": "উপলভ্য",
   "perp_trade_deposit_to_trade__action": "ট্রেড করতে ডিপোজিট করুন",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC (gültig bis zur Stornierung): Die Order bleibt bestehen, bis sie ausgeführt oder storniert wird.",
   "perp_time_in_force_ioc__desc": "IOC (sofort oder stornieren): Jeder Teil, der nicht sofort ausgeführt wird, wird storniert.",
   "perp_toast_deposit_success_eta_one_minute__msg": "{amount} {token}-Einzahlung wurde eingereicht. Einzahlungen sollten innerhalb von 1 Minute eintreffen.",
+  "perp_toast_modifying_order": "Order wird geändert…",
+  "perp_toast_order_modified": "Order geändert",
   "perp_token_info_not_found__msg": "Tokeninformationen nicht gefunden",
   "perp_trade_account_overview_avbl": "Verfügbar",
   "perp_trade_deposit_to_trade__action": "Einzahlen zum Traden",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC (Good Til Cancel): Order will rest until filled or canceled.",
   "perp_time_in_force_ioc__desc": "IOC (Immediate Or Cancel): Any portion that is not immediately filled will be canceled.",
   "perp_toast_deposit_success_eta_one_minute__msg": "{amount} {token} deposit has been submitted. Deposits should arrive within 1 minute.",
+  "perp_toast_modifying_order": "Modifying order…",
+  "perp_toast_order_modified": "Order modified",
   "perp_token_info_not_found__msg": "Token info not found",
   "perp_trade_account_overview_avbl": "Avbl",
   "perp_trade_deposit_to_trade__action": "Deposit to Trade",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC (vigente hasta cancelar): La orden permanecerá activa hasta ejecutarse o cancelarse.",
   "perp_time_in_force_ioc__desc": "IOC (inmediata o cancelar): Cualquier parte que no se ejecute de inmediato se cancelará.",
   "perp_toast_deposit_success_eta_one_minute__msg": "Se ha enviado el depósito de {amount} {token}. Los depósitos deberían llegar en 1 minuto.",
+  "perp_toast_modifying_order": "Modificando la orden…",
+  "perp_toast_order_modified": "Orden modificada",
   "perp_token_info_not_found__msg": "Información del token no encontrada",
   "perp_trade_account_overview_avbl": "Disp.",
   "perp_trade_deposit_to_trade__action": "Depositar para operar",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC (valable jusqu'à annulation) : l'ordre restera actif jusqu'à son exécution ou son annulation.",
   "perp_time_in_force_ioc__desc": "IOC (immédiat ou annulation) : toute partie non exécutée immédiatement sera annulée.",
   "perp_toast_deposit_success_eta_one_minute__msg": "Le dépôt de {amount} {token} a été soumis. Les dépôts devraient arriver dans 1 minute.",
+  "perp_toast_modifying_order": "Modification de l’ordre…",
+  "perp_toast_order_modified": "Ordre modifié",
   "perp_token_info_not_found__msg": "Informations sur le jeton introuvables",
   "perp_trade_account_overview_avbl": "Disp.",
   "perp_trade_deposit_to_trade__action": "Déposer pour trader",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC (रद्द होने तक मान्य): ऑर्डर तब तक बनी रहेगी जब तक वह पूरी न हो जाए या रद्द न कर दी जाए।",
   "perp_time_in_force_ioc__desc": "IOC (तुरंत निष्पादित या रद्द): जो भी हिस्सा तुरंत पूरा नहीं होगा, उसे रद्द कर दिया जाएगा।",
   "perp_toast_deposit_success_eta_one_minute__msg": "{amount} {token} जमा प्रस्तुत कर दी गई है। जमा 1 मिनट के भीतर पहुँचेगी।",
+  "perp_toast_modifying_order": "ऑर्डर में बदलाव किया जा रहा है…",
+  "perp_toast_order_modified": "ऑर्डर में बदलाव किया गया",
   "perp_token_info_not_found__msg": "टोकन जानकारी नहीं मिली",
   "perp_trade_account_overview_avbl": "उपलब्ध",
   "perp_trade_deposit_to_trade__action": "ट्रेड करने के लिए जमा करें",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC (Good Til Cancel): Order akan tetap aktif hingga terisi atau dibatalkan.",
   "perp_time_in_force_ioc__desc": "IOC (Immediate Or Cancel): Bagian apa pun yang tidak langsung terisi akan dibatalkan.",
   "perp_toast_deposit_success_eta_one_minute__msg": "{amount} {token} deposit telah dikirim. Deposit seharusnya tiba dalam 1 menit.",
+  "perp_toast_modifying_order": "Mengubah order…",
+  "perp_toast_order_modified": "Order diubah",
   "perp_token_info_not_found__msg": "Informasi token tidak ditemukan",
   "perp_trade_account_overview_avbl": "Tersedia",
   "perp_trade_deposit_to_trade__action": "Deposit untuk Trading",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC (valido fino ad annullamento): L'ordine resterà attivo finché non viene eseguito o annullato.",
   "perp_time_in_force_ioc__desc": "IOC (immediato o annulla): Qualsiasi parte non eseguita immediatamente verrà annullata.",
   "perp_toast_deposit_success_eta_one_minute__msg": "Il deposito di {amount} {token} è stato inviato. I depositi dovrebbero arrivare entro 1 minuto.",
+  "perp_toast_modifying_order": "Modifica dell’ordine…",
+  "perp_toast_order_modified": "Ordine modificato",
   "perp_token_info_not_found__msg": "Informazioni sul token non trovate",
   "perp_trade_account_overview_avbl": "Disp.",
   "perp_trade_deposit_to_trade__action": "Deposita per fare trading",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC（キャンセルまで有効）: 注文は約定またはキャンセルされるまで有効です。",
   "perp_time_in_force_ioc__desc": "IOC（即時約定またはキャンセル）: 直ちに約定しなかった部分はキャンセルされます。",
   "perp_toast_deposit_success_eta_one_minute__msg": "{amount} {token} の入金が送信されました。入金は 1 分以内に反映されるはずです。",
+  "perp_toast_modifying_order": "注文を変更中…",
+  "perp_toast_order_modified": "注文を変更しました",
   "perp_token_info_not_found__msg": "トークン情報が見つかりません",
   "perp_trade_account_overview_avbl": "利用可",
   "perp_trade_deposit_to_trade__action": "入金して取引",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC(취소 시까지 유효): 주문은 체결되거나 취소될 때까지 유지됩니다。",
   "perp_time_in_force_ioc__desc": "IOC(즉시 체결 아니면 취소): 즉시 체결되지 않은 수량은 취소됩니다。",
   "perp_toast_deposit_success_eta_one_minute__msg": "{amount} {token} 입금이 제출되었습니다. 입금은 1분 이내에 도착해야 합니다.",
+  "perp_toast_modifying_order": "주문 수정 중…",
+  "perp_toast_order_modified": "주문이 수정되었습니다",
   "perp_token_info_not_found__msg": "토큰 정보를 찾을 수 없음",
   "perp_trade_account_overview_avbl": "사용 가능",
   "perp_trade_deposit_to_trade__action": "거래하려면 입금",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC (válida até cancelar): A ordem permanecerá ativa até ser executada ou cancelada.",
   "perp_time_in_force_ioc__desc": "IOC (imediata ou cancelar): Qualquer parte que não seja executada imediatamente será cancelada.",
   "perp_toast_deposit_success_eta_one_minute__msg": "O depósito de {amount} {token} foi submetido. Os depósitos deverão chegar no prazo de 1 minuto.",
+  "perp_toast_modifying_order": "A modificar ordem…",
+  "perp_toast_order_modified": "Ordem modificada",
   "perp_token_info_not_found__msg": "Informações do token não encontradas",
   "perp_trade_account_overview_avbl": "Disp.",
   "perp_trade_deposit_to_trade__action": "Depositar para negociar",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC (válida até cancelar): A ordem permanecerá ativa até ser executada ou cancelada.",
   "perp_time_in_force_ioc__desc": "IOC (imediata ou cancelar): Qualquer parte que não seja executada imediatamente será cancelada.",
   "perp_toast_deposit_success_eta_one_minute__msg": "O depósito de {amount} {token} foi enviado. Os depósitos devem chegar em até 1 minuto.",
+  "perp_toast_modifying_order": "Modificando ordem…",
+  "perp_toast_order_modified": "Ordem modificada",
   "perp_token_info_not_found__msg": "Informações do token não encontradas",
   "perp_trade_account_overview_avbl": "Disponível",
   "perp_trade_deposit_to_trade__action": "Depositar para negociar",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC (действителен до отмены): Ордер будет оставаться активным, пока не исполнится или не будет отменён.",
   "perp_time_in_force_ioc__desc": "IOC (исполнить немедленно или отменить): Любая часть, которая не будет исполнена сразу, будет отменена.",
   "perp_toast_deposit_success_eta_one_minute__msg": "{amount} {token} депозит был отправлен. Депозиты должны поступить в течение 1 минуты.",
+  "perp_toast_modifying_order": "Изменение ордера…",
+  "perp_toast_order_modified": "Ордер изменён",
   "perp_token_info_not_found__msg": "Информация о токене не найдена",
   "perp_trade_account_overview_avbl": "Доступно",
   "perp_trade_deposit_to_trade__action": "Пополнить для торговли",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC (มีผลจนกว่าจะยกเลิก): คำสั่งจะคงอยู่จนกว่าจะถูกจับคู่หรือยกเลิก",
   "perp_time_in_force_ioc__desc": "IOC (จับคู่ทันทีหรือยกเลิก): ส่วนที่ไม่ถูกจับคู่ทันทีจะถูกยกเลิก",
   "perp_toast_deposit_success_eta_one_minute__msg": "ส่งคำขอฝาก {amount} {token} แล้ว การฝากควรถึงภายใน 1 นาที",
+  "perp_toast_modifying_order": "กำลังแก้ไขคำสั่ง…",
+  "perp_toast_order_modified": "แก้ไขคำสั่งแล้ว",
   "perp_token_info_not_found__msg": "ไม่พบข้อมูลโทเคน",
   "perp_trade_account_overview_avbl": "พร้อมใช้",
   "perp_trade_deposit_to_trade__action": "ฝากเพื่อเทรด",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC (діє до скасування): Ордер залишатиметься активним, доки не буде виконаний або скасований.",
   "perp_time_in_force_ioc__desc": "IOC (виконати негайно або скасувати): Будь-яка частина, яка не буде виконана негайно, буде скасована.",
   "perp_toast_deposit_success_eta_one_minute__msg": "{amount} {token} депозит надіслано. Депозити мають надійти протягом 1 хвилини.",
+  "perp_toast_modifying_order": "Змінення ордера…",
+  "perp_toast_order_modified": "Ордер змінено",
   "perp_token_info_not_found__msg": "Інформація про токен не знайдена",
   "perp_trade_account_overview_avbl": "Доступно",
   "perp_trade_deposit_to_trade__action": "Поповнити для торгівлі",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC (hiệu lực đến khi hủy): Lệnh sẽ duy trì cho đến khi được khớp hoặc bị hủy.",
   "perp_time_in_force_ioc__desc": "IOC (khớp ngay hoặc hủy): Bất kỳ phần nào không được khớp ngay lập tức sẽ bị hủy.",
   "perp_toast_deposit_success_eta_one_minute__msg": "{amount} {token} tiền nạp đã được gửi. Khoản nạp sẽ đến trong vòng 1 phút.",
+  "perp_toast_modifying_order": "Đang sửa lệnh…",
+  "perp_toast_order_modified": "Đã sửa lệnh",
   "perp_token_info_not_found__msg": "Không tìm thấy thông tin token",
   "perp_trade_account_overview_avbl": "Khả dụng",
   "perp_trade_deposit_to_trade__action": "Nạp để giao dịch",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC（取消前有效）：订单会一直保留，直到成交或被取消。",
   "perp_time_in_force_ioc__desc": "IOC（立即成交否则取消）：未立即成交的部分会被取消。",
   "perp_toast_deposit_success_eta_one_minute__msg": "{amount} {token} 存款已提交。预计 1 分钟到账",
+  "perp_toast_modifying_order": "正在修改订单…",
+  "perp_toast_order_modified": "订单已修改",
   "perp_token_info_not_found__msg": "未找到代币信息",
   "perp_trade_account_overview_avbl": "Avbl",
   "perp_trade_deposit_to_trade__action": "充值以交易",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC（取消前有效）：訂單會一直保留，直到成交或被取消。",
   "perp_time_in_force_ioc__desc": "IOC（立即成交否則取消）：未立即成交的部分會被取消。",
   "perp_toast_deposit_success_eta_one_minute__msg": "{amount} {token} 存款已提交。存款應於 1 分鐘內到帳。",
+  "perp_toast_modifying_order": "正在修改訂單…",
+  "perp_toast_order_modified": "訂單已修改",
   "perp_token_info_not_found__msg": "未找到代幣資訊",
   "perp_trade_account_overview_avbl": "可用",
   "perp_trade_deposit_to_trade__action": "充值以交易",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -2801,6 +2801,8 @@
   "perp_time_in_force_gtc__desc": "GTC（取消前有效）：訂單會一直保留，直到成交或被取消。",
   "perp_time_in_force_ioc__desc": "IOC（立即成交否則取消）：未立即成交的部分會被取消。",
   "perp_toast_deposit_success_eta_one_minute__msg": "{amount} {token} 存款已提交。款項應於 1 分鐘內入帳。",
+  "perp_toast_modifying_order": "正在修改訂單…",
+  "perp_toast_order_modified": "訂單已修改",
   "perp_token_info_not_found__msg": "未找到代幣資訊",
   "perp_trade_account_overview_avbl": "可用",
   "perp_trade_deposit_to_trade__action": "充值以交易",


### PR DESCRIPTION
## Summary
- Replace hardcoded Perps order modification feedback with localized strings.
- Add loading and success translations for all 19 supported locales.

## Intent & Context
The Perps order modification flow displayed the English-only messages `Modifying order…` and `Order modified`. This change localizes both states so the feedback follows the user's selected language.

## Root Cause
The `MODIFY_ORDER` toast configuration used hardcoded English strings while other Hyperliquid actions already used `ETranslations` keys.

## Design Decisions
- Keep the success message owned by OneKey's toast configuration because Hyperliquid's modify response does not provide user-facing success copy.
- Add both the loading and success states to avoid showing English while the modification request is pending.
- Use the standard Lokalise pull workflow and include the complete generated locale set.

## Changes Detail
- Wire `EActionType.MODIFY_ORDER` feedback to `ETranslations`.
- Add `perp_toast_modifying_order` and `perp_toast_order_modified` to the generated translation enum.
- Add localized values to all 19 supported locale JSON files.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: User-facing copy for the Perps order modification toast only.

## Test plan
- [x] Run `yarn agent:check --profile commit`.
- [x] Verify the Web app compiles and serves successfully.
- [ ] Modify a Perps order under a non-English locale and verify localized loading and success toasts.
