### PR TITLE
fix: align perps position metrics

### DIFF
--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -1294,11 +1294,15 @@ function PerpsMetric({
   emphasis?: boolean;
 }) {
   const intl = useIntl();
-  let alignItems: 'center' | 'flex-end' | 'flex-start' = 'flex-start';
-  if (column === 'center') {
-    alignItems = 'center';
-  } else if (align === 'right') {
-    alignItems = 'flex-end';
+  const alignItems = align === 'right' ? 'flex-end' : 'flex-start';
+  let columnFlexGrow = 1;
+  let columnGtMdFlexGrow = 1;
+  if (column === 'left') {
+    columnFlexGrow = 1.35;
+    columnGtMdFlexGrow = 1.45;
+  } else if (column === 'center') {
+    columnFlexGrow = 0.65;
+    columnGtMdFlexGrow = 0.55;
   }
   let valueColor = '$text';
   if (positive) {
@@ -1311,47 +1315,54 @@ function PerpsMetric({
 
   return (
     <YStack
-      width={column === 'left' || column === 'right' ? 120 : undefined}
-      $gtMd={{
-        width: column === 'left' || column === 'right' ? 180 : undefined,
-      }}
-      flex={column === 'center' || !column ? 1 : undefined}
-      gap="$1"
-      alignItems={alignItems}
+      flexGrow={columnFlexGrow}
+      flexBasis={0}
+      minWidth={0}
+      $gtMd={{ flexGrow: columnGtMdFlexGrow }}
     >
-      <XStack alignItems="center" gap="$1">
-        <SizableText
-          size="$bodySm"
-          color="$textSubdued"
-          numberOfLines={1}
-          $gtMd={{ size: '$bodySm' }}
-        >
-          {intl.formatMessage({ id: labelId })}
-          {labelExtra}
-        </SizableText>
+      <XStack width="100%" justifyContent={alignItems}>
+        <YStack gap="$1" alignItems={alignItems}>
+          <XStack alignItems="center" gap="$1">
+            <SizableText
+              size="$bodySm"
+              color="$textSubdued"
+              numberOfLines={1}
+              $gtMd={{ size: '$bodySm' }}
+            >
+              {intl.formatMessage({ id: labelId })}
+              {labelExtra}
+            </SizableText>
+          </XStack>
+          {formatter ? (
+            <NumberSizeableText
+              size={valueSize}
+              color={valueColor}
+              $gtMd={{ size: valueGtMdSize }}
+              formatter={formatter}
+              formatterOptions={formatterOptions}
+              numberOfLines={1}
+              adjustsFontSizeToFit
+              minimumFontScale={0.7}
+              contentStyle={{ color: valueColor }}
+              decimalTextStyle={{ color: valueColor }}
+              subTextStyle={{ color: valueColor }}
+            >
+              {value}
+            </NumberSizeableText>
+          ) : (
+            <SizableText
+              size={valueSize}
+              color={valueColor}
+              $gtMd={{ size: valueGtMdSize }}
+              numberOfLines={1}
+              adjustsFontSizeToFit
+              minimumFontScale={0.7}
+            >
+              {value}
+            </SizableText>
+          )}
+        </YStack>
       </XStack>
-      {formatter ? (
-        <NumberSizeableText
-          size={valueSize}
-          color={valueColor}
-          $gtMd={{ size: valueGtMdSize }}
-          formatter={formatter}
-          formatterOptions={formatterOptions}
-          contentStyle={{ color: valueColor }}
-          decimalTextStyle={{ color: valueColor }}
-          subTextStyle={{ color: valueColor }}
-        >
-          {value}
-        </NumberSizeableText>
-      ) : (
-        <SizableText
-          size={valueSize}
-          color={valueColor}
-          $gtMd={{ size: valueGtMdSize }}
-        >
-          {value}
-        </SizableText>
-      )}
     </YStack>
   );
 }
@@ -1506,7 +1517,7 @@ function PerpsPositionCard({ position }: { position: IPerpsHomePosition }) {
         </XStack>
 
         <YStack gap="$3">
-          <XStack width="100%" justifyContent="space-between">
+          <XStack width="100%">
             <PerpsMetric
               labelId={ETranslations.perp_position_position_size}
               labelExtra={` (${displayCoin})`}
@@ -1528,7 +1539,7 @@ function PerpsPositionCard({ position }: { position: IPerpsHomePosition }) {
             />
           </XStack>
 
-          <XStack width="100%" justifyContent="space-between">
+          <XStack width="100%">
             {/* fundingUsd > 0 = paid -> red '-$' (mirrors PositionsRow) */}
             <PerpsMetric
               labelId={ETranslations.perp_position_funding_2}

--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -1321,7 +1321,7 @@ function PerpsMetric({
       $gtMd={{ flexGrow: columnGtMdFlexGrow }}
     >
       <XStack width="100%" justifyContent={alignItems}>
-        <YStack gap="$1" alignItems={alignItems}>
+        <YStack width="100%" minWidth={0} gap="$1" alignItems={alignItems}>
           <XStack alignItems="center" gap="$1">
             <SizableText
               size="$bodySm"
@@ -1340,7 +1340,9 @@ function PerpsMetric({
               $gtMd={{ size: valueGtMdSize }}
               formatter={formatter}
               formatterOptions={formatterOptions}
-              numberOfLines={1}
+              flexShrink={1}
+              minWidth={0}
+              numberOfLines={platformEnv.isNative ? 1 : 2}
               adjustsFontSizeToFit
               minimumFontScale={0.7}
               contentStyle={{ color: valueColor }}
@@ -1354,7 +1356,9 @@ function PerpsMetric({
               size={valueSize}
               color={valueColor}
               $gtMd={{ size: valueGtMdSize }}
-              numberOfLines={1}
+              flexShrink={1}
+              minWidth={0}
+              numberOfLines={platformEnv.isNative ? 1 : 2}
               adjustsFontSizeToFit
               minimumFontScale={0.7}
             >

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -838,23 +838,45 @@ const PositionRowMobilePnLAndROE = memo(
         alignItems="center"
         position="relative"
       >
-        <YStack gap="$1">
+        <YStack gap="$1" flexGrow={1} flexBasis={0} minWidth={0}>
           <SizableText size="$bodySm" color="$textSubdued">
             {intl.formatMessage({
               id: ETranslations.perp_position_pnl_mobile,
             })}
           </SizableText>
-          <SizableText size="$bodyLgMedium" color={otherInfo.pnlColor}>
+          <SizableText
+            size="$bodyLgMedium"
+            color={otherInfo.pnlColor}
+            flexShrink={1}
+            minWidth={0}
+            numberOfLines={1}
+            adjustsFontSizeToFit
+            minimumFontScale={0.7}
+          >
             {`${otherInfo.pnlPlusOrMinus}${otherInfo.unrealizedPnl}`}
           </SizableText>
         </YStack>
-        <YStack gap="$1" alignItems="flex-end">
+        <YStack
+          gap="$1"
+          flexGrow={1}
+          flexBasis={0}
+          minWidth={0}
+          alignItems="flex-end"
+        >
           <SizableText size="$bodySm" color="$textSubdued">
             {intl.formatMessage({
               id: ETranslations.perp_share_roe,
             })}
           </SizableText>
-          <SizableText size="$bodyLgMedium" color={otherInfo.pnlColor}>
+          <SizableText
+            size="$bodyLgMedium"
+            color={otherInfo.pnlColor}
+            flexShrink={1}
+            minWidth={0}
+            numberOfLines={1}
+            adjustsFontSizeToFit
+            minimumFontScale={0.7}
+          >
             {`${otherInfo.pnlPlusOrMinus}${otherInfo.roiPercent}%`}
           </SizableText>
         </YStack>
@@ -879,7 +901,13 @@ const PositionRowMobilePositionSize = memo(
     const intl = useIntl();
 
     return (
-      <YStack gap="$1" flex={1.35} position="relative">
+      <YStack
+        gap="$1"
+        flexGrow={1.35}
+        flexBasis={0}
+        minWidth={0}
+        position="relative"
+      >
         <XStack
           alignItems="center"
           gap="$1"
@@ -899,7 +927,14 @@ const PositionRowMobilePositionSize = memo(
           <Icon name="RepeatOutline" size="$3" color="$textSubdued" />
         </XStack>
         <XStack alignItems="center" gap="$1">
-          <SizableText size="$bodyMdMedium">
+          <SizableText
+            size="$bodyMdMedium"
+            flexShrink={1}
+            minWidth={0}
+            numberOfLines={1}
+            adjustsFontSizeToFit
+            minimumFontScale={0.7}
+          >
             {isSizeViewChange
               ? `$${sizeInfo.sizeValue}`
               : sizeInfo.sizeAbsFormatted}
@@ -924,14 +959,28 @@ const PositionRowMobileMargin = memo(
     const intl = useIntl();
 
     return (
-      <YStack gap="$1" flex={0.65} alignItems="flex-start" position="relative">
+      <YStack
+        gap="$1"
+        flexGrow={0.65}
+        flexBasis={0}
+        minWidth={0}
+        alignItems="flex-start"
+        position="relative"
+      >
         <SizableText size="$bodySm" color="$textSubdued">
           {intl.formatMessage({
             id: ETranslations.perp_position_margin,
           })}
         </SizableText>
         <XStack alignItems="center" gap="$1">
-          <SizableText size="$bodyMdMedium">
+          <SizableText
+            size="$bodyMdMedium"
+            flexShrink={1}
+            minWidth={0}
+            numberOfLines={1}
+            adjustsFontSizeToFit
+            minimumFontScale={0.7}
+          >
             {`${otherInfo.marginUsedFormatted}`}
           </SizableText>
           {isIsolatedMode ? (
@@ -957,13 +1006,27 @@ const PositionRowMobileEntryPrice = memo(
     const intl = useIntl();
 
     return (
-      <YStack gap="$1" flex={1} alignItems="flex-end" position="relative">
+      <YStack
+        gap="$1"
+        flexGrow={1}
+        flexBasis={0}
+        minWidth={0}
+        alignItems="flex-end"
+        position="relative"
+      >
         <SizableText size="$bodySm" color="$textSubdued">
           {intl.formatMessage({
             id: ETranslations.perp_position_entry_price,
           })}
         </SizableText>
-        <SizableText size="$bodyMdMedium">
+        <SizableText
+          size="$bodyMdMedium"
+          flexShrink={1}
+          minWidth={0}
+          numberOfLines={1}
+          adjustsFontSizeToFit
+          minimumFontScale={0.7}
+        >
           {priceInfo.entryPriceFormatted}
         </SizableText>
       </YStack>
@@ -982,7 +1045,13 @@ const PositionRowMobileFunding = memo(
   }) => {
     const intl = useIntl();
     return (
-      <YStack gap="$1" flex={1.35} position="relative">
+      <YStack
+        gap="$1"
+        flexGrow={1.35}
+        flexBasis={0}
+        minWidth={0}
+        position="relative"
+      >
         <Popover
           title={intl.formatMessage({
             id: ETranslations.perp_position_funding_2,
@@ -1076,6 +1145,11 @@ const PositionRowMobileFunding = memo(
         <SizableText
           size="$bodyMdMedium"
           color={otherInfo.fundingSinceOpenColor}
+          flexShrink={1}
+          minWidth={0}
+          numberOfLines={1}
+          adjustsFontSizeToFit
+          minimumFontScale={0.7}
         >
           {`${otherInfo.fundingSinceOpenPlusOrMinus}$${otherInfo.fundingSinceOpenFormatted}`}
         </SizableText>
@@ -1114,13 +1188,27 @@ const PositionRowMobileTPSL = memo(({ coin }: { coin: string }) => {
   }, [currentAssetOpenOrders]);
 
   return (
-    <YStack gap="$1" flex={0.65} alignItems="flex-start" position="relative">
+    <YStack
+      gap="$1"
+      flexGrow={0.65}
+      flexBasis={0}
+      minWidth={0}
+      alignItems="flex-start"
+      position="relative"
+    >
       <SizableText size="$bodySm" color="$textSubdued">
         {intl.formatMessage({
           id: ETranslations.perp_position_tp_sl,
         })}
       </SizableText>
-      <SizableText size="$bodyMdMedium" numberOfLines={1}>
+      <SizableText
+        size="$bodyMdMedium"
+        flexShrink={1}
+        minWidth={0}
+        numberOfLines={1}
+        adjustsFontSizeToFit
+        minimumFontScale={0.7}
+      >
         {tpslInfo.tpsl}
       </SizableText>
     </YStack>
@@ -1136,13 +1224,27 @@ const PositionRowMobileMarkPrice = memo(({ coin }: { coin: string }) => {
   });
 
   return (
-    <YStack gap="$1" flex={0.65} alignItems="flex-start" position="relative">
+    <YStack
+      gap="$1"
+      flexGrow={0.65}
+      flexBasis={0}
+      minWidth={0}
+      alignItems="flex-start"
+      position="relative"
+    >
       <SizableText size="$bodySm" color="$textSubdued">
         {intl.formatMessage({
           id: ETranslations.perp_position_mark_price,
         })}
       </SizableText>
-      <SizableText size="$bodyMdMedium" numberOfLines={1}>
+      <SizableText
+        size="$bodyMdMedium"
+        flexShrink={1}
+        minWidth={0}
+        numberOfLines={1}
+        adjustsFontSizeToFit
+        minimumFontScale={0.7}
+      >
         {formatLocalizedNumberString(midFormattedByDecimals || '--')}
       </SizableText>
     </YStack>
@@ -1154,13 +1256,27 @@ const PositionRowMobileLiqPrice = memo(
   ({ priceInfo }: { priceInfo: IPriceInfo }) => {
     const intl = useIntl();
     return (
-      <YStack gap="$1" flex={1} alignItems="flex-end" position="relative">
+      <YStack
+        gap="$1"
+        flexGrow={1}
+        flexBasis={0}
+        minWidth={0}
+        alignItems="flex-end"
+        position="relative"
+      >
         <SizableText size="$bodySm" color="$textSubdued">
           {intl.formatMessage({
             id: ETranslations.perp_position_liq_price,
           })}
         </SizableText>
-        <SizableText size="$bodyMdMedium">
+        <SizableText
+          size="$bodyMdMedium"
+          flexShrink={1}
+          minWidth={0}
+          numberOfLines={1}
+          adjustsFontSizeToFit
+          minimumFontScale={0.7}
+        >
           {priceInfo.liquidationPriceFormatted}
         </SizableText>
       </YStack>

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -20,6 +20,7 @@ import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useHyperliquidActions } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { INumberFormatProps } from '@onekeyhq/shared/src/utils/numberUtils';
 import {
   formatLocalizedNumberString,
@@ -849,7 +850,7 @@ const PositionRowMobilePnLAndROE = memo(
             color={otherInfo.pnlColor}
             flexShrink={1}
             minWidth={0}
-            numberOfLines={1}
+            numberOfLines={platformEnv.isNative ? 1 : 2}
             adjustsFontSizeToFit
             minimumFontScale={0.7}
           >
@@ -873,7 +874,7 @@ const PositionRowMobilePnLAndROE = memo(
             color={otherInfo.pnlColor}
             flexShrink={1}
             minWidth={0}
-            numberOfLines={1}
+            numberOfLines={platformEnv.isNative ? 1 : 2}
             adjustsFontSizeToFit
             minimumFontScale={0.7}
           >
@@ -931,7 +932,7 @@ const PositionRowMobilePositionSize = memo(
             size="$bodyMdMedium"
             flexShrink={1}
             minWidth={0}
-            numberOfLines={1}
+            numberOfLines={platformEnv.isNative ? 1 : 2}
             adjustsFontSizeToFit
             minimumFontScale={0.7}
           >
@@ -977,7 +978,7 @@ const PositionRowMobileMargin = memo(
             size="$bodyMdMedium"
             flexShrink={1}
             minWidth={0}
-            numberOfLines={1}
+            numberOfLines={platformEnv.isNative ? 1 : 2}
             adjustsFontSizeToFit
             minimumFontScale={0.7}
           >
@@ -1023,7 +1024,7 @@ const PositionRowMobileEntryPrice = memo(
           size="$bodyMdMedium"
           flexShrink={1}
           minWidth={0}
-          numberOfLines={1}
+          numberOfLines={platformEnv.isNative ? 1 : 2}
           adjustsFontSizeToFit
           minimumFontScale={0.7}
         >
@@ -1147,7 +1148,7 @@ const PositionRowMobileFunding = memo(
           color={otherInfo.fundingSinceOpenColor}
           flexShrink={1}
           minWidth={0}
-          numberOfLines={1}
+          numberOfLines={platformEnv.isNative ? 1 : 2}
           adjustsFontSizeToFit
           minimumFontScale={0.7}
         >
@@ -1205,7 +1206,7 @@ const PositionRowMobileTPSL = memo(({ coin }: { coin: string }) => {
         size="$bodyMdMedium"
         flexShrink={1}
         minWidth={0}
-        numberOfLines={1}
+        numberOfLines={platformEnv.isNative ? 1 : 2}
         adjustsFontSizeToFit
         minimumFontScale={0.7}
       >
@@ -1241,7 +1242,7 @@ const PositionRowMobileMarkPrice = memo(({ coin }: { coin: string }) => {
         size="$bodyMdMedium"
         flexShrink={1}
         minWidth={0}
-        numberOfLines={1}
+        numberOfLines={platformEnv.isNative ? 1 : 2}
         adjustsFontSizeToFit
         minimumFontScale={0.7}
       >
@@ -1273,7 +1274,7 @@ const PositionRowMobileLiqPrice = memo(
           size="$bodyMdMedium"
           flexShrink={1}
           minWidth={0}
-          numberOfLines={1}
+          numberOfLines={platformEnv.isNative ? 1 : 2}
           adjustsFontSizeToFit
           minimumFontScale={0.7}
         >


### PR DESCRIPTION
## Summary
- align Home Perps position metric columns across responsive layouts
- stabilize Perps mobile position columns on small Web viewports
- keep long position values on one line with native font scaling

## Intent & Context
Home and Perps position cards displayed the Margin and Mark Price column inconsistently across desktop, mobile, and small Web layouts. Long position values could also wrap and increase card height.

## Root Cause
The layouts mixed fixed widths, intrinsic Flex sizing, and centered content. On Web, long labels contributed their minimum content width and changed column boundaries between rows. Values also lacked single-line constraints.

## Design Decisions
- preserve the Perps mobile column ratio of 1.35 / 0.65 / 1
- use zero flex basis and zero minimum width so labels cannot reshape columns
- use a desktop-only Home ratio of 1.45 / 0.55 / 1 without changing mobile proportions
- keep complete values visible by combining single-line rendering with native font scaling instead of truncation

## Changes Detail
- update Home Perps metric layout and responsive column proportions
- update Perps mobile position rows to use stable Flex boundaries
- apply single-line auto-scaling to PNL, ROE, position size, margin, entry price, funding, mark price, liquidation price, and TP/SL values

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile, Web, Desktop
- **Risk Areas**: responsive spacing and font scaling for unusually long localized values

## Test plan
- [x] Run `yarn agent:check --profile commit`
- [x] Verify Home Perps cards on desktop and mobile-sized layouts
- [x] Verify Perps position rows on small Web and native-sized layouts
- [x] Verify long values stay on one line