### PR TITLE
fix: register desktop webview load listeners after deferred preload(OK-57862)

### DIFF
--- a/packages/kit/src/components/WebView/DesktopWebView.tsx
+++ b/packages/kit/src/components/WebView/DesktopWebView.tsx
@@ -444,7 +444,9 @@ const DesktopWebView = forwardRef(
       ref as Ref<unknown>,
       (): IWebViewWrapperRef => {
         const wrapper = {
-          innerRef: webviewRef.current,
+          // deferred preload mounts the node after the first create; the
+          // isWebviewReady dep re-snapshots innerRef once it exists.
+          innerRef: isWebviewReady ? webviewRef.current : null,
           jsBridge: jsBridgeHost,
           reload: () => {
             webviewRef.current?.reload();
@@ -483,7 +485,7 @@ const DesktopWebView = forwardRef(
       },
       // dom-ready is read via isDomReadyRef so a parent holding an old
       // wrapper still delivers.
-      [jsBridgeHost],
+      [isWebviewReady, jsBridgeHost],
     );
 
     const initWebviewByRef = useCallback(

--- a/packages/kit/src/components/WebView/DesktopWebView.tsx
+++ b/packages/kit/src/components/WebView/DesktopWebView.tsx
@@ -129,6 +129,13 @@ const DesktopWebView = forwardRef(
   ) => {
     const [isWebviewReady, setIsWebviewReady] = useState(false);
     const [isDomReady, setIsDomReady] = useState(false);
+    // Parents hold wrapper closures across renders, so dom-ready must be read
+    // from a ref, not a render snapshot.
+    const isDomReadyRef = useRef(false);
+    const updateIsDomReady = useCallback((value: boolean) => {
+      isDomReadyRef.current = value;
+      setIsDomReady(value);
+    }, []);
     const webviewRef = useRef<IElectronWebView | null>(null);
     const pendingScriptsRef = useRef<string[]>([]);
     const [devToolsAtLeft, setDevToolsAtLeft] = useState(false);
@@ -293,7 +300,7 @@ const DesktopWebView = forwardRef(
             lastMainFrameLoadErrorRef.current = undefined;
             setDesktopLoadError(false);
             setDesktopLoadErrorCode(undefined);
-            setIsDomReady(false);
+            updateIsDomReady(false);
             startLoadTimeout();
           }
           checkGoogleOauth(url);
@@ -351,7 +358,7 @@ const DesktopWebView = forwardRef(
         webview.addEventListener('page-favicon-updated', onPageFaviconUpdated);
         webview.addEventListener('new-window', onNewWindow);
         const handleDomReady = (event: Event) => {
-          setIsDomReady(true);
+          updateIsDomReady(true);
           onDomReady?.(event);
         };
 
@@ -386,8 +393,12 @@ const DesktopWebView = forwardRef(
         console.error(error);
       }
     }, [
+      // the first run can precede <webview> mount when the preload URL
+      // resolves async, leaving every load listener unregistered.
+      isWebviewReady,
       clearLoadTimeout,
       startLoadTimeout,
+      updateIsDomReady,
       onDidFailLoad,
       onDidFinishLoad,
       onDidStartLoading,
@@ -445,7 +456,7 @@ const DesktopWebView = forwardRef(
           },
           sendMessageViaInjectedScript: (message: unknown) => {
             const script = createMessageInjectedScript(message);
-            if (!isDomReady || !webviewRef.current) {
+            if (!isDomReadyRef.current || !webviewRef.current) {
               pendingScriptsRef.current.push(script);
               if (pendingScriptsRef.current.length > 50) {
                 console.warn(
@@ -470,14 +481,19 @@ const DesktopWebView = forwardRef(
         jsBridgeHost.webviewWrapper = wrapper;
         return wrapper as IWebViewRef;
       },
-      [isDomReady, jsBridgeHost],
+      // dom-ready is read via isDomReadyRef so a parent holding an old
+      // wrapper still delivers.
+      [jsBridgeHost],
     );
 
-    const initWebviewByRef = useCallback(($ref: any) => {
-      webviewRef.current = $ref;
-      setIsDomReady(false);
-      setIsWebviewReady(Boolean($ref));
-    }, []);
+    const initWebviewByRef = useCallback(
+      ($ref: any) => {
+        webviewRef.current = $ref;
+        updateIsDomReady(false);
+        setIsWebviewReady(Boolean($ref));
+      },
+      [updateIsDomReady],
+    );
 
     useEffect(() => {
       const webview = webviewRef.current;

--- a/packages/kit/src/components/WebView/desktopWebViewMessageDelivery.test.tsx
+++ b/packages/kit/src/components/WebView/desktopWebViewMessageDelivery.test.tsx
@@ -1,0 +1,234 @@
+/** @jest-environment jsdom */
+
+import { act, render, waitFor } from '@testing-library/react';
+
+// jest.mock calls below are hoisted above this import by babel-jest.
+import InpageProviderWebView from './InpageProviderWebView.desktop';
+
+import type { IWebViewRef } from './types';
+
+jest.mock('@onekeyfe/cross-inpage-provider-core', () => ({
+  consts: {
+    JS_BRIDGE_MESSAGE_IPC_CHANNEL: 'onekey-js-bridge',
+  },
+}));
+
+jest.mock('@onekeyfe/onekey-cross-webview', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  return {
+    JsBridgeDesktopHost: class MockJsBridgeDesktopHost {
+      globalOnMessageEnabled = false;
+
+      webviewWrapper: unknown;
+    },
+    // Mirrors the real dist/useWebViewBridge.js so parent re-render
+    // behavior matches production.
+    useWebViewBridge: () => {
+      const webviewRef = React.useRef<unknown>(null);
+      const [jsBridge, setJsBridge] = React.useState<unknown>(null);
+      const setWebViewRef = (ref: { jsBridge?: unknown } | null) => {
+        webviewRef.current = ref;
+        const newJsBridge = ref?.jsBridge;
+        if (newJsBridge) {
+          setJsBridge(newJsBridge);
+        }
+      };
+      return { jsBridge, webviewRef, setWebViewRef };
+    },
+  };
+});
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    connectBridge: jest.fn(),
+  },
+}));
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
+  useDevSettingsPersistAtom: () => [
+    {
+      enabled: false,
+      settings: {},
+    },
+  ],
+}));
+
+jest.mock('@onekeyhq/components', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  return {
+    Stack: ({
+      children,
+      ...props
+    }: {
+      children?: React.ReactNode;
+      [key: string]: unknown;
+    }) => React.createElement('div', props, children),
+    Progress: (props: Record<string, unknown>) =>
+      React.createElement('div', { 'data-testid': 'progress', ...props }),
+    Spinner: (props: Record<string, unknown>) =>
+      React.createElement('div', { 'data-testid': 'spinner', ...props }),
+  };
+});
+
+jest.mock('@onekeyhq/shared/src/background/backgroundUtils', () => ({
+  waitForDataLoaded: jest.fn(),
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/stringUtils', () => ({
+  __esModule: true,
+  default: {
+    generateUUID: () => 'test-uuid',
+  },
+}));
+
+jest.mock('./ErrorView', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  return {
+    __esModule: true,
+    default: () => React.createElement('div', null, 'error'),
+  };
+});
+
+const SRC = 'https://tradingview.example.com/?symbol=BTC&type=perps';
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function dispatch(
+  node: Element,
+  type: string,
+  props: Record<string, unknown> = {},
+) {
+  const event = new Event(type);
+  Object.assign(event, props);
+  act(() => {
+    node.dispatchEvent(event);
+  });
+}
+
+function mount(getPreloadJsContent: jest.Mock) {
+  Object.defineProperty(globalThis, 'desktopApiProxy', {
+    configurable: true,
+    value: {
+      webview: {
+        getPreloadJsContent,
+      },
+    },
+  });
+
+  const captured: { current: IWebViewRef | null } = { current: null };
+  const { container } = render(
+    <InpageProviderWebView
+      ref={(ref: IWebViewRef | null) => {
+        captured.current = ref;
+      }}
+      src={SRC}
+      receiveHandler={jest.fn()}
+      allowpopups={false}
+      displayProgressBar={false}
+    />,
+  );
+  return { container, captured };
+}
+
+async function getWebviewNode(container: HTMLElement) {
+  await waitFor(() => {
+    expect(container.querySelector('webview')).not.toBeNull();
+  });
+  const node = container.querySelector('webview') as Element & {
+    executeJavaScript: jest.Mock;
+  };
+  node.executeJavaScript = jest.fn();
+  return node;
+}
+
+function sendSymbolChange(
+  captured: { current: IWebViewRef | null },
+  symbol: string,
+) {
+  act(() => {
+    captured.current?.sendMessageViaInjectedScript({
+      type: 'SYMBOL_CHANGE',
+      payload: { symbol },
+    });
+  });
+}
+
+function deliveredSymbols(node: { executeJavaScript: jest.Mock }): string[] {
+  return node.executeJavaScript.mock.calls
+    .map((call) => /MARKER_(\w+)/.exec(String(call[0]))?.[1])
+    .filter((marker): marker is string => Boolean(marker));
+}
+
+// Regression coverage: (1) deferred preload left load listeners unregistered
+// so sends queued forever; (2) wrappers captured a stale isDomReady snapshot.
+describe('desktop webview injected message delivery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('delivers messages when preload resolves after first render', async () => {
+    const preload = createDeferred<string>();
+    const { container, captured } = mount(
+      jest.fn().mockReturnValue(preload.promise),
+    );
+
+    // regression precondition: webview must mount after the first render
+    expect(container.querySelector('webview')).toBeNull();
+
+    await act(async () => {
+      preload.resolve('file:///preload.js');
+      await preload.promise;
+    });
+    const node = await getWebviewNode(container);
+
+    dispatch(node, 'did-start-loading');
+    dispatch(node, 'dom-ready');
+    dispatch(node, 'did-finish-load');
+    dispatch(node, 'did-stop-loading');
+
+    sendSymbolChange(captured, 'MARKER_deferred');
+    expect(deliveredSymbols(node)).toContain('deferred');
+  });
+
+  it('flushes messages queued before dom-ready', async () => {
+    const { container, captured } = mount(
+      jest.fn().mockResolvedValue('file:///preload.js'),
+    );
+    const node = await getWebviewNode(container);
+
+    dispatch(node, 'did-start-loading');
+    sendSymbolChange(captured, 'MARKER_early');
+    expect(deliveredSymbols(node)).not.toContain('early');
+
+    dispatch(node, 'dom-ready');
+    expect(deliveredSymbols(node)).toContain('early');
+  });
+
+  it('delivers messages when dom-ready arrives after the last parent render', async () => {
+    const { container, captured } = mount(
+      jest.fn().mockResolvedValue('file:///preload.js'),
+    );
+    const node = await getWebviewNode(container);
+
+    dispatch(node, 'did-start-loading');
+    dispatch(node, 'did-finish-load');
+    dispatch(node, 'did-stop-loading');
+    // let the progress-bar timers settle so no parent render follows dom-ready
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 150);
+      });
+    });
+    dispatch(node, 'dom-ready');
+
+    sendSymbolChange(captured, 'MARKER_late');
+    expect(deliveredSymbols(node)).toContain('late');
+  });
+});

--- a/packages/kit/src/components/WebView/desktopWebViewMessageDelivery.test.tsx
+++ b/packages/kit/src/components/WebView/desktopWebViewMessageDelivery.test.tsx
@@ -195,6 +195,9 @@ describe('desktop webview injected message delivery', () => {
 
     sendSymbolChange(captured, 'MARKER_deferred');
     expect(deliveredSymbols(node)).toContain('deferred');
+    // consumers gate registration on innerRef (WebContent.desktop), so the
+    // wrapper snapshot must refresh after the deferred mount
+    expect(captured.current?.innerRef).toBe(node);
   });
 
   it('flushes messages queued before dom-ready', async () => {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57862](https://onekeyhq.atlassian.net/browse/OK-57862)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Register desktop webview load-event listeners once the `<webview>` node actually mounts, restoring app→webview injected-message delivery (Perps chart `SYMBOL_CHANGE`, chart lines sync, `FORCE_RECOVER_WS`, navigation guard).
- Read dom-ready state through a ref in the imperative-handle wrapper so a parent holding an older wrapper still delivers instead of queueing on a stale snapshot.
- Add jest regression tests covering both failure modes.

## Intent & Context
QA reported on the desktop 6.5.0 test build (OK-57862): on the Perps page, switching to a spot pair did not switch the TradingView chart, and right-click → trade inside the chart opened no order dialog. The production app was unaffected.

Log analysis showed the app-side state switched correctly, but the chart never resolved any new symbol after an in-page switch — perp→perp switches were equally dead, spot just made it visible. Every fresh webview load resolved its URL symbol fine, which is why the page looked normal until the first switch.

## Root Cause
`d7b9d95a6d` (OK-57292, #12342) deferred the preload URL fetch from module-load time to a mount effect. The first `DesktopWebView` of a renderer session now renders `null` first and only re-renders with the `<webview>` once the preload URL resolves. The load-event listener effect ran on the first commit (webview node absent, early return) and never re-ran because its dependency array contained only stable callbacks.

As a result `dom-ready` was never handled, `isDomReady` stayed `false` forever, and every `sendMessageViaInjectedScript` call was pushed into `pendingScriptsRef` and never flushed. The chart→webview receive direction (`ipc-message` effect, which does depend on `isWebviewReady`) kept working, masking the failure: request/response flows like price-scale and marks worked, only app-initiated pushes were dead.

The right-click trade symptom is downstream: the chart was stuck on the old symbol, so the order-intent message carried a stale symbol and failed the `payload.symbol === latestSymbolRef.current` check in `TradingViewPerpsV2` silently.

Also broken for the first webview of each session: the `onShouldStartLoadWithRequest` navigation guard (wired via `did-start-navigation` / `did-redirect-navigation`), load-failure error views and timeouts, and `onLoadEnd`/`onDomReady` callbacks. The dapp browser is equally affected when it is the first webview opened after launch.

The chart repo was ruled out by injecting `SYMBOL_CHANGE` messages directly into the deployed chart bundle (both perp and spot symbols switch correctly).

## Design Decisions
- Minimal-surface fix: add `isWebviewReady` to the listener effect deps instead of restructuring the effect; the effect already early-returns while the node is absent and its cleanup correctly re-registers.
- Introduced `isDomReadyRef` and switched the wrapper's send path to read it, then reduced the imperative-handle deps to `[jsBridgeHost]`. This keeps the wrapper stable across renders and eliminates the whole class of stale-closure delivery bugs (parents such as `InpageProviderWebView.desktop` cache the wrapper and only refresh it on their own re-renders).
- `flushPendingScripts` still keys off `isDomReady` state so queued messages flush on the dom-ready flip.

## Changes Detail
- `DesktopWebView.tsx`: listener effect re-runs on `isWebviewReady`; `updateIsDomReady` keeps a ref in sync with state; wrapper send reads the ref; wrapper handle stable per `jsBridgeHost`.
- `desktopWebViewMessageDelivery.test.tsx`: full-chain tests through `InpageProviderWebView.desktop` with production-equivalent `useWebViewBridge` semantics. Cases: deferred preload (regression), pre-dom-ready queue flush, dom-ready arriving after the last parent render (stale wrapper). Cases 1 and 3 fail without the fix.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop
- **Risk Areas**: listener effect now re-registers when `isWebviewReady` flips (cleanup path exercised more often); imperative-handle wrapper identity no longer changes on dom-ready, so consumers relying on wrapper recreation timing would be affected (none found).

## Test plan
- [x] `yarn jest packages/kit/src/components/WebView/desktopWebViewMessageDelivery.test.tsx` — passes with fix, cases 1 & 3 fail without it
- [x] `yarn jest packages/kit/src/components/WebView/DesktopWebView.test.tsx` — existing preload-retry test still passes
- [x] Manual desktop verify: launch app → Perps → switch perp↔spot repeatedly, chart follows; right-click → trade opens the limit-order dialog
- [ ] Dapp browser smoke: first webview after app launch loads normally and blocked URLs are still stopped

[OK-57862]: https://onekeyhq.atlassian.net/browse/OK-57862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ