### PR TITLE
fix: restore Perps selector scrolling(OK-57864)

### DIFF
--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -429,22 +429,23 @@ function MobileTokenSelectorModal({
   const cachedInitialListRef = useRef<ITokenSelectorListItem[]>(
     getCachedPerpsTokenSelectorInitialList(),
   );
-  const initialListRenderedRef = useRef(!platformEnv.isNativeIOS);
-  const initialListRenderedIndexesRef = useRef<Set<number>>(new Set());
   // iOS only (OK-57864): search interaction permanently ends the cold-start
   // snapshot phase so recycled rows cannot leave a static overlay behind.
-  const initialRowsSnapshotDismissedRef = useRef(!platformEnv.isNativeIOS);
+  const [initialRowsSnapshotDismissed, setInitialRowsSnapshotDismissed] =
+    useState(!platformEnv.isNativeIOS);
+  const initialListRenderedRef = useRef(!platformEnv.isNativeIOS);
+  const initialListRenderedIndexesRef = useRef<Set<number>>(new Set());
   const [hasInitialListRendered, setHasInitialListRendered] = useState(
     !platformEnv.isNativeIOS,
   );
   const dismissInitialRowsSnapshot = useCallback(() => {
-    if (!platformEnv.isNativeIOS || initialRowsSnapshotDismissedRef.current) {
+    if (!platformEnv.isNativeIOS) {
       return;
     }
-    initialRowsSnapshotDismissedRef.current = true;
     initialListRenderedRef.current = true;
     initialListRenderedIndexesRef.current.clear();
     setHasInitialListRendered(true);
+    setInitialRowsSnapshotDismissed(true);
   }, []);
   const fixedTabNames = useMemo(
     () => ({
@@ -1099,7 +1100,7 @@ function MobileTokenSelectorModal({
       DEFAULT_PERP_TOKEN_SORT_DIRECTION;
   const shouldUseCachedInitialList =
     platformEnv.isNativeIOS &&
-    !initialRowsSnapshotDismissedRef.current &&
+    !initialRowsSnapshotDismissed &&
     !searchQuery &&
     isDefaultPerpsSelectorView &&
     mockedListData.length === 0 &&
@@ -1109,13 +1110,13 @@ function MobileTokenSelectorModal({
     : mockedListData;
 
   useEffect(() => {
-    if (!platformEnv.isNativeIOS || initialRowsSnapshotDismissedRef.current) {
+    if (!platformEnv.isNativeIOS || initialRowsSnapshotDismissed) {
       return;
     }
     initialListRenderedRef.current = false;
     initialListRenderedIndexesRef.current.clear();
     setHasInitialListRendered(false);
-  }, [activeTab, shouldUseCachedInitialList]);
+  }, [activeTab, initialRowsSnapshotDismissed, shouldUseCachedInitialList]);
 
   usePerpActiveTabValidation({
     activeTab,
@@ -1227,7 +1228,7 @@ function MobileTokenSelectorModal({
     perpSortedList.length === 0;
   const shouldShowInitialRowsSnapshot =
     platformEnv.isNativeIOS &&
-    !initialRowsSnapshotDismissedRef.current &&
+    !initialRowsSnapshotDismissed &&
     !hasInitialListRendered &&
     !searchQuery &&
     isPerpTokenSelectorPerpsTab(displayPrimaryTab) &&

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -134,10 +134,11 @@ function hasSpotVolumeData(
   );
 }
 
-// Disable anchor preservation only for this selector. Filtering and sorting
-// replace the dataset and should reveal the start of the updated results.
+// Disable visible-content anchoring only for this selector:
+// - Android (OK-54946): sorting must restore the list to the first row.
+// - iOS (OK-57864): clearing search must restore a fully scrollable live list.
 const tokenSelectorScrollBehaviorProps: Record<string, unknown> =
-  platformEnv.isNative
+  platformEnv.isNativeAndroid || platformEnv.isNativeIOS
     ? {
         maintainVisibleContentPosition: {
           disabled: true,
@@ -430,6 +431,8 @@ function MobileTokenSelectorModal({
   );
   const initialListRenderedRef = useRef(!platformEnv.isNativeIOS);
   const initialListRenderedIndexesRef = useRef<Set<number>>(new Set());
+  // iOS only (OK-57864): search interaction permanently ends the cold-start
+  // snapshot phase so recycled rows cannot leave a static overlay behind.
   const initialRowsSnapshotDismissedRef = useRef(!platformEnv.isNativeIOS);
   const [hasInitialListRendered, setHasInitialListRendered] = useState(
     !platformEnv.isNativeIOS,

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -134,10 +134,10 @@ function hasSpotVolumeData(
   );
 }
 
-// Android FlashList can preserve the pre-sort anchor, which defeats the
-// selector's explicit scroll-to-top contract.
-const androidSortScrollBehaviorProps: Record<string, unknown> =
-  platformEnv.isNativeAndroid
+// Disable anchor preservation only for this selector. Filtering and sorting
+// replace the dataset and should reveal the start of the updated results.
+const tokenSelectorScrollBehaviorProps: Record<string, unknown> =
+  platformEnv.isNative
     ? {
         maintainVisibleContentPosition: {
           disabled: true,
@@ -430,9 +430,19 @@ function MobileTokenSelectorModal({
   );
   const initialListRenderedRef = useRef(!platformEnv.isNativeIOS);
   const initialListRenderedIndexesRef = useRef<Set<number>>(new Set());
+  const initialRowsSnapshotDismissedRef = useRef(!platformEnv.isNativeIOS);
   const [hasInitialListRendered, setHasInitialListRendered] = useState(
     !platformEnv.isNativeIOS,
   );
+  const dismissInitialRowsSnapshot = useCallback(() => {
+    if (!platformEnv.isNativeIOS || initialRowsSnapshotDismissedRef.current) {
+      return;
+    }
+    initialRowsSnapshotDismissedRef.current = true;
+    initialListRenderedRef.current = true;
+    initialListRenderedIndexesRef.current.clear();
+    setHasInitialListRendered(true);
+  }, []);
   const fixedTabNames = useMemo(
     () => ({
       favorites: intl.formatMessage({ id: ETranslations.perp_tab_favs }),
@@ -1086,6 +1096,7 @@ function MobileTokenSelectorModal({
       DEFAULT_PERP_TOKEN_SORT_DIRECTION;
   const shouldUseCachedInitialList =
     platformEnv.isNativeIOS &&
+    !initialRowsSnapshotDismissedRef.current &&
     !searchQuery &&
     isDefaultPerpsSelectorView &&
     mockedListData.length === 0 &&
@@ -1095,13 +1106,13 @@ function MobileTokenSelectorModal({
     : mockedListData;
 
   useEffect(() => {
-    if (!platformEnv.isNativeIOS) {
+    if (!platformEnv.isNativeIOS || initialRowsSnapshotDismissedRef.current) {
       return;
     }
     initialListRenderedRef.current = false;
     initialListRenderedIndexesRef.current.clear();
     setHasInitialListRendered(false);
-  }, [activeTab, searchQuery, shouldUseCachedInitialList]);
+  }, [activeTab, shouldUseCachedInitialList]);
 
   usePerpActiveTabValidation({
     activeTab,
@@ -1213,6 +1224,7 @@ function MobileTokenSelectorModal({
     perpSortedList.length === 0;
   const shouldShowInitialRowsSnapshot =
     platformEnv.isNativeIOS &&
+    !initialRowsSnapshotDismissedRef.current &&
     !hasInitialListRendered &&
     !searchQuery &&
     isPerpTokenSelectorPerpsTab(displayPrimaryTab) &&
@@ -1279,6 +1291,7 @@ function MobileTokenSelectorModal({
             id: ETranslations.global_search,
           }),
           onChangeText: ({ nativeEvent }) => {
+            dismissInitialRowsSnapshot();
             const afterTrim = nativeEvent.text.trim();
             setSearchQuery(afterTrim);
           },
@@ -1407,7 +1420,7 @@ function MobileTokenSelectorModal({
               decelerationRate="normal"
               showsVerticalScrollIndicator
               nestedScrollEnabled={platformEnv.isNativeAndroid}
-              {...androidSortScrollBehaviorProps}
+              {...tokenSelectorScrollBehaviorProps}
               contentContainerStyle={{
                 paddingBottom: 10,
               }}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57864](https://onekeyhq.atlassian.net/browse/OK-57864)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Disable visible-content anchoring only for the native Perps mobile token selector.
- End the iOS initial-row snapshot phase when search interaction begins so clearing the query cannot restore a stale overlay or cold-start cache.

## Intent & Context
OK-57864 reports an iOS-only regression in the Perps asset selector: start from the full list, filter to a token such as SKHX, then delete all search text. The full dataset returns, but the upper rows appear frozen while only content at the bottom visibly scrolls.

## Root Cause
Two list behaviors overlap:

1. FlashList v2 preserves the currently visible item by default. When the filtered one-row dataset expands, the previous token can remain anchored near the bottom instead of exposing the beginning of the restored results.
2. The iOS cold-start snapshot was reset whenever `searchQuery` changed. Clearing the query made the absolute snapshot overlay visible again, but recycled FlashList cells did not necessarily fire all first-row `onLayout` callbacks again. The overlay could therefore remain fixed while gestures scrolled the live list underneath it.

## Design Decisions
- Keep the anchor override local to `MobileTokenSelector`; shared `ListView` behavior and unrelated lists remain unchanged.
- Treat the iOS initial-row snapshot as a one-shot cold-start optimization. The first search interaction dismisses it for the remainder of the modal lifecycle.
- Gate both the cached initial list and snapshot overlay after search interaction so an empty filtered result cannot re-enter the cold-start path when the query is cleared.
- Do not add `extraData` or remount the list on every query change because neither addresses the stale overlay and remounting adds avoidable render churn.

## Changes Detail
- `MoblieTokenSelector.tsx`: scope native anchor disabling to the Perps selector and add an iOS snapshot-dismissal latch tied to search interaction.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (iOS behavior fixed; existing Android anchor override preserved)
- **Risk Areas**: iOS selector cold-start transition and search-result restoration

## Test plan
- [x] Run `yarn agent:check --profile commit`.
- [ ] On iOS, open the Perps selector and verify the initial full list renders normally.
- [ ] Search for `SKHX`, clear all text, and verify the full list returns at the top and the entire list scrolls.
- [ ] Repeat search and clear with a query that has no results.
- [ ] Verify Perps tab/category switching and Android sort/search scrolling remain functional.

[OK-57864]: https://onekeyhq.atlassian.net/browse/OK-57864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ