### PR TITLE
fix: reset market chart price scale range(OK-56765)

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
@@ -239,6 +239,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
         type: TRADINGVIEW_INTERVAL_CHANGE_MESSAGE,
         payload: {
           interval,
+          resetPriceScaleRange: true,
         },
       });
     },
@@ -352,7 +353,10 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     (payload: ICalendarPanelSubmitPayload) => {
       webRef.current?.sendMessageViaInjectedScript({
         type: TRADINGVIEW_CALENDAR_PANEL_SUBMIT_MESSAGE,
-        payload,
+        payload: {
+          ...payload,
+          resetPriceScaleRange: true,
+        },
       });
     },
     [],


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-56765](https://onekeyhq.atlassian.net/browse/OK-56765)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- request a main price-axis range reset when Market Detail native controls change the interval
- request the same reset for go-to-date and custom time-range navigation
- keep the bridge change backward-compatible with older chart builds

## Intent & Context
Market Detail users who manually adjust the Y-axis should see the chart fit the newly visible candles after changing the time granularity or jumping to another time through the native controls.

Related issue: OK-56765  
TradingView companion: https://github.com/OneKeyHQ/tradingview-charting-library/pull/198

## Root Cause
The App sent only the interval or calendar navigation payload. The chart therefore preserved a previously manual Y-axis range while changing the visible X-axis data.

## Design Decisions
- Add `resetPriceScaleRange: true` to the existing interval and calendar payloads instead of sending a second message, which keeps the reset ordered with the asynchronous chart action.
- Keep the flag optional so older chart builds safely ignore it.
- Leave price-scale mode handling to the chart companion PR, which resets only the range and preserves Log/% settings.

## Changes Detail
- extend native interval-change messages with the reset request
- extend native calendar submissions for both go-to-date and time-range flows with the reset request

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile, Desktop, Web, Extension
- **Risk Areas**: Compatibility between independently deployed App and TradingView builds

## Test plan
- [x] `yarn agent:check --profile commit`
- [x] verified the paired TradingView bridge tests, full test suite, lint, and production build
- [ ] manually drag the Market Detail Y-axis, switch interval, and confirm visible candles are autoscaled
- [ ] manually drag the Y-axis, use go-to-date/custom range, and confirm Log/% mode remains unchanged

[OK-56765]: https://onekeyhq.atlassian.net/browse/OK-56765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ