### PR TITLE
fix: prevent market tab revert from stale atom echo(OK-57367)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/MarketHomeV2.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/MarketHomeV2.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -33,6 +33,7 @@ import { useMarketRenderCommitProbe } from '../utils/marketReactPerf';
 
 import { useNetworkAnalytics, useTabAnalytics } from './hooks';
 import { DesktopLayout } from './layouts/DesktopLayout';
+import { shouldRestoreSpotCategoryFromAtom } from './layouts/marketTabSelectionGuards';
 import { MobileLayout } from './layouts/MobileLayout';
 import { isMarketStockCategory } from './utils';
 
@@ -109,6 +110,14 @@ const useMarketHomeLayoutProps = () => {
   const [selectedCategory, setSelectedCategory] = useState(
     selectedSpotCategory || 'trending',
   );
+  // The category most recently applied by an explicit intent (user tap or
+  // deep link). The bg-synced atom echoes writes back asynchronously, so this
+  // ref is the freshest truth; the atom may lag behind it.
+  const pendingSpotCategoryRef = useRef<string | undefined>(undefined);
+  const applySelectedCategory = useCallback((categoryId: string) => {
+    pendingSpotCategoryRef.current = categoryId;
+    setSelectedCategory(categoryId);
+  }, []);
 
   const categories: IMarketCategoryItem[] = useMemo(() => {
     if (apiSpotCategories.length > 0) {
@@ -157,12 +166,24 @@ const useMarketHomeLayoutProps = () => {
       return;
     }
 
+    // The atom echoes UI writes back after a bg round-trip; until it carries
+    // the latest locally-applied category, restoring from it would revert the
+    // user's selection and make the pager jump back (OK-57367).
+    if (
+      !shouldRestoreSpotCategoryFromAtom({
+        pendingSpotCategoryId: pendingSpotCategoryRef.current,
+        atomSpotCategoryId: selectedSpotCategory,
+      })
+    ) {
+      return;
+    }
+
     const hasSelectedCategory = categories.some(
       (item) => item.id === selectedSpotCategory,
     );
     if (hasSelectedCategory) {
       if (selectedCategory !== selectedSpotCategory) {
-        setSelectedCategory(selectedSpotCategory);
+        applySelectedCategory(selectedSpotCategory);
       }
       return;
     }
@@ -170,7 +191,7 @@ const useMarketHomeLayoutProps = () => {
     if (isMarketBasicConfigLoading === false) {
       const nextSelectedCategory = categories[0]?.id ?? 'trending';
       if (selectedCategory !== nextSelectedCategory) {
-        setSelectedCategory(nextSelectedCategory);
+        applySelectedCategory(nextSelectedCategory);
       }
       setMarketSelectedTab((prev) => {
         if (prev.selectedSpotCategory !== selectedSpotCategory) {
@@ -183,6 +204,7 @@ const useMarketHomeLayoutProps = () => {
       });
     }
   }, [
+    applySelectedCategory,
     categories,
     isMarketBasicConfigLoading,
     selectedCategory,
@@ -215,7 +237,7 @@ const useMarketHomeLayoutProps = () => {
       return;
     }
 
-    setSelectedCategory(spotCategoryToSelect);
+    applySelectedCategory(spotCategoryToSelect);
     setMarketSelectedTab((prev) => ({
       ...prev,
       tab: 'trending',
@@ -223,6 +245,7 @@ const useMarketHomeLayoutProps = () => {
       spotCategoryToSelect: undefined,
     }));
   }, [
+    applySelectedCategory,
     categories,
     isMarketBasicConfigLoading,
     setMarketSelectedTab,
@@ -248,7 +271,7 @@ const useMarketHomeLayoutProps = () => {
         selectedCategory,
         categories,
         stockCategories,
-        onCategoryChange: setSelectedCategory,
+        onCategoryChange: applySelectedCategory,
       },
       selectedNetworkId: effectiveSelectedNetworkId,
       liquidityFilter,
@@ -263,6 +286,7 @@ const useMarketHomeLayoutProps = () => {
       selectedCategory,
       categories,
       stockCategories,
+      applySelectedCategory,
     ],
   );
 

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
@@ -322,6 +322,7 @@ function MobileLayoutComponent({
     handleTabChange,
     getSpotCategoryIdByTabName,
     selectedTabName,
+    isTabSelectionInFlight,
   } = useMarketTabsLogic(onTabChange, {
     spotCategories: filterBarProps.categories,
     selectedSpotCategory: filterBarProps.selectedCategory,
@@ -455,6 +456,14 @@ function MobileLayoutComponent({
   );
   const shouldDeferPageSync = useCallback(
     ({ targetTabName }: { targetTabName: string; currentTabName: string }) => {
+      // A locally-initiated tab selection is still round-tripping through the
+      // bg-synced atom; `selectedTabName` derived from the stale UI mirror
+      // must not drive a pager jump, or it reverts the user's tap (OK-57367).
+      // Keep deferring until the atom echoes the selection back.
+      if (isTabSelectionInFlight()) {
+        return true;
+      }
+
       const now = Date.now();
       const lastPagerDraggingAt = lastPagerDraggingAtRef.current;
       const pagerDragElapsedMs =
@@ -486,7 +495,7 @@ function MobileLayoutComponent({
       }
       return startedAt > 0 && now - startedAt < MARKET_TAB_SYNC_JUMP_DEFER_MS;
     },
-    [],
+    [isTabSelectionInFlight],
   );
 
   useEffect(

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/hooks/useMarketTabsLogic.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/hooks/useMarketTabsLogic.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -6,7 +6,10 @@ import { usePerpTabConfig } from '@onekeyhq/kit/src/hooks/usePerpTabConfig';
 import { useMarketSelectedTabAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
+import { getIsMarketTabSelectionInFlight } from '../marketTabSelectionGuards';
+
 import type { IMarketCategoryItem, IMarketHomeTabValue } from '../../types';
+import type { IMarketTabWrittenSelection } from '../marketTabSelectionGuards';
 
 export interface IMarketSpotTabItem {
   categoryId: string;
@@ -23,6 +26,12 @@ export interface IMarketTabsLogicReturn {
   getSpotCategoryIdByTabName: (tabName: string) => string | undefined;
   selectedTab: string;
   selectedTabName: string;
+  /**
+   * Whether a locally-initiated tab selection is still round-tripping
+   * through the bg-synced atom. While true, `selectedTab`/`selectedTabName`
+   * may be stale and must not drive programmatic pager jumps.
+   */
+  isTabSelectionInFlight: () => boolean;
 }
 
 interface IUseMarketTabsLogicOptions {
@@ -36,8 +45,30 @@ export function useMarketTabsLogic(
   options?: IUseMarketTabsLogicOptions,
 ): IMarketTabsLogicReturn {
   const intl = useIntl();
-  const [{ tab: selectedTab }, setSelectedTabAtom] = useMarketSelectedTabAtom();
+  const [marketSelectedTab, setSelectedTabAtom] = useMarketSelectedTabAtom();
+  const { tab: selectedTab } = marketSelectedTab;
   const { perpDisabled } = usePerpTabConfig();
+
+  // Latest selection written to the bg-synced atom. On runtimes that proxy
+  // UI atom writes to bg, the UI mirror only updates after the bg round-trip
+  // echoes the value back, so the mirror stays stale until then.
+  const lastWrittenSelectionRef = useRef<
+    IMarketTabWrittenSelection | undefined
+  >(undefined);
+  const marketSelectedTabRef = useRef(marketSelectedTab);
+  marketSelectedTabRef.current = marketSelectedTab;
+
+  const isTabSelectionInFlight = useCallback(() => {
+    const inFlight = getIsMarketTabSelectionInFlight({
+      lastWrittenSelection: lastWrittenSelectionRef.current,
+      atomTab: marketSelectedTabRef.current.tab,
+      atomSpotCategoryId: marketSelectedTabRef.current.selectedSpotCategory,
+    });
+    if (!inFlight) {
+      lastWrittenSelectionRef.current = undefined;
+    }
+    return inFlight;
+  }, []);
   const showPerpsTab = !perpDisabled;
   const { spotCategories, selectedSpotCategory, onSpotCategoryChange } =
     options ?? {};
@@ -112,6 +143,7 @@ export function useMarketTabsLogic(
         onSpotCategoryChange?.(categoryId);
       }
 
+      lastWrittenSelectionRef.current = { tab: tabValue, categoryId };
       setSelectedTabAtom((prev) => ({
         ...prev,
         tab: tabValue,
@@ -154,5 +186,6 @@ export function useMarketTabsLogic(
     getSpotCategoryIdByTabName,
     selectedTab,
     selectedTabName,
+    isTabSelectionInFlight,
   };
 }

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/marketTabSelectionGuards.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/marketTabSelectionGuards.test.ts
@@ -1,0 +1,96 @@
+import {
+  getIsMarketTabSelectionInFlight,
+  shouldRestoreSpotCategoryFromAtom,
+} from './marketTabSelectionGuards';
+
+describe('shouldRestoreSpotCategoryFromAtom', () => {
+  it('allows cold-start restore when no local selection is pending', () => {
+    expect(
+      shouldRestoreSpotCategoryFromAtom({
+        pendingSpotCategoryId: undefined,
+        atomSpotCategoryId: 'stock',
+      }),
+    ).toBe(true);
+  });
+
+  it('blocks restore while the atom echo lags the local selection', () => {
+    expect(
+      shouldRestoreSpotCategoryFromAtom({
+        pendingSpotCategoryId: 'stock',
+        atomSpotCategoryId: 'trending',
+      }),
+    ).toBe(false);
+  });
+
+  it('blocks out-of-order stale echoes of older selections', () => {
+    // User picked "stock" last; an older "ai-tech" write echoes back later.
+    expect(
+      shouldRestoreSpotCategoryFromAtom({
+        pendingSpotCategoryId: 'stock',
+        atomSpotCategoryId: 'ai-tech',
+      }),
+    ).toBe(false);
+  });
+
+  it('allows restore once the atom caught up with the local selection', () => {
+    expect(
+      shouldRestoreSpotCategoryFromAtom({
+        pendingSpotCategoryId: 'stock',
+        atomSpotCategoryId: 'stock',
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('getIsMarketTabSelectionInFlight', () => {
+  it('is not in flight without a recorded write', () => {
+    expect(
+      getIsMarketTabSelectionInFlight({
+        lastWrittenSelection: undefined,
+        atomTab: 'trending',
+        atomSpotCategoryId: 'trending',
+      }),
+    ).toBe(false);
+  });
+
+  it('is in flight while the written tab has not echoed back', () => {
+    expect(
+      getIsMarketTabSelectionInFlight({
+        lastWrittenSelection: { tab: 'watchlist' },
+        atomTab: 'trending',
+        atomSpotCategoryId: 'trending',
+      }),
+    ).toBe(true);
+  });
+
+  it('is in flight while the written category has not echoed back', () => {
+    expect(
+      getIsMarketTabSelectionInFlight({
+        lastWrittenSelection: { tab: 'trending', categoryId: 'stock' },
+        atomTab: 'trending',
+        atomSpotCategoryId: 'trending',
+      }),
+    ).toBe(true);
+  });
+
+  it('settles once tab and category both echoed back', () => {
+    expect(
+      getIsMarketTabSelectionInFlight({
+        lastWrittenSelection: { tab: 'trending', categoryId: 'stock' },
+        atomTab: 'trending',
+        atomSpotCategoryId: 'stock',
+      }),
+    ).toBe(false);
+  });
+
+  it('ignores the category when the write did not include one', () => {
+    // Watchlist/perps taps keep the previous spot category untouched.
+    expect(
+      getIsMarketTabSelectionInFlight({
+        lastWrittenSelection: { tab: 'perps' },
+        atomTab: 'perps',
+        atomSpotCategoryId: 'stock',
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/marketTabSelectionGuards.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/marketTabSelectionGuards.ts
@@ -1,0 +1,66 @@
+// Guards for market tab/category selection state that lives in the bg-synced
+// `marketSelectedTabAtom`. On runtimes where UI atom writes are proxied to the
+// bg runtime (production native, extension UI), the UI mirror only updates
+// after a bg round-trip, so values read from the atom can be stale for tens to
+// hundreds of milliseconds after a local write. Deriving tab targets from the
+// stale mirror is what made the pager revert the user's tab selection
+// (OK-57367).
+
+interface IShouldRestoreSpotCategoryFromAtomParams {
+  pendingSpotCategoryId?: string;
+  atomSpotCategoryId: string;
+}
+
+/**
+ * Whether the atom's `selectedSpotCategory` may be restored into the local
+ * `selectedCategory` state. Restoring is only safe when no local selection is
+ * awaiting its atom echo (cold-start restore) or when the atom has caught up
+ * with the latest local selection; otherwise the stale echo would revert the
+ * user's category choice.
+ */
+export function shouldRestoreSpotCategoryFromAtom({
+  pendingSpotCategoryId,
+  atomSpotCategoryId,
+}: IShouldRestoreSpotCategoryFromAtomParams): boolean {
+  if (!pendingSpotCategoryId) {
+    return true;
+  }
+  return atomSpotCategoryId === pendingSpotCategoryId;
+}
+
+export interface IMarketTabWrittenSelection {
+  tab: string;
+  categoryId?: string;
+}
+
+interface IGetIsMarketTabSelectionInFlightParams {
+  lastWrittenSelection?: IMarketTabWrittenSelection;
+  atomTab: string;
+  atomSpotCategoryId?: string;
+}
+
+/**
+ * A tab selection written to the bg-synced atom stays "in flight" until the
+ * UI mirror echoes back the written tab (and category, when one was written).
+ * While in flight, `selectedTabName` derived from the mirror is stale and
+ * must not drive a programmatic pager jump.
+ */
+export function getIsMarketTabSelectionInFlight({
+  lastWrittenSelection,
+  atomTab,
+  atomSpotCategoryId,
+}: IGetIsMarketTabSelectionInFlightParams): boolean {
+  if (!lastWrittenSelection) {
+    return false;
+  }
+  if (atomTab !== lastWrittenSelection.tab) {
+    return true;
+  }
+  if (
+    lastWrittenSelection.categoryId &&
+    atomSpotCategoryId !== lastWrittenSelection.categoryId
+  ) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- Stop the Market home pager from reverting the user's tab selection right after a tap settles (OK-57367 still reproduced 100% on Android release builds after #12412).
- Guard the two places where state derived from the bg-synced \`marketSelectedTabAtom\` could act on a stale UI mirror: the local category restore effect and the tab resync loop.
- Add \`marketTabSelectionGuards.ts\` pure helpers with focused unit tests.

## Intent & Context
QA recordings on Android release packages showed every Trending → US-stocks tab tap sliding back to Trending ~100ms after the pager settled, occasional revert ping-pong (revert → jump forward → revert again), and a double revert (Perps → US-stocks → Trending) after tapping Perps. The tab indicator did not move during the backward slide, proving the motion was programmatic rather than user input. #12412 (OK-57367) added accept-side guards for pager events but did not cover the resync trigger side, so the revert survived.

## Root Cause
Three layers interact:

1. **Structurally async atom writes (main → bg → main).** \`marketSelectedTabAtom\` is a \`persist: true\` cross-runtime globalAtom. On production native builds (\`ENABLE_NATIVE_BACKGROUND_THREAD=true\`) and extension UI, \`wrapAtomPro\` proxies UI writes to the bg runtime and the UI mirror only updates when bg broadcasts the echo back. The mirror stays stale for tens to hundreds of milliseconds after every write. This is also why dev single-runtime builds do not reproduce the bug.
2. **Stale echo restore (the poison).** \`MarketHomeV2\`'s restore effect unconditionally copied the stale \`selectedSpotCategory\` mirror back into the local \`selectedCategory\` state, deterministically undoing the category the user just picked. \`selectedTabName\` then derived to the previous tab.
3. **Resync loop executes the revert.** \`useSyncedMarketTab\` treats \`selectedTabName\` as authoritative; once the Android pager goes idle it issues \`jumpToTab(staleTarget)\`, and \`onBeforeJumpToTab\` marks that jump as the expected target, so the accept-side guards from #12412 approve and persist the wrong state. The later atom echo then flips the target again, producing the ping-pong.

## Design Decisions
- **Pager is authoritative during user interaction; the store is an async follower.** Store-driven pager jumps are only allowed for genuinely external changes (deep links, \`useNavigateToMarketTab\`), which do not go through \`handleTabChange\` and are therefore never flagged as in-flight.
- \`MarketHomeV2\` tracks the last explicitly applied category (\`pendingSpotCategoryRef\` via \`applySelectedCategory\`) and skips the restore effect until the atom echo catches up, which also ignores out-of-order echoes of older writes. Cold-start restore (no pending intent yet) is unchanged.
- \`useMarketTabsLogic\` records the last selection written to the atom and exposes \`isTabSelectionInFlight()\`; \`MobileLayout.native\`'s \`shouldDeferPageSync\` defers page resync while a write is in flight. After the echo lands the loop either converges (no jump) or performs a legitimate external jump.
- Deliberately did NOT change \`wrapAtomPro\` semantics (optimistic local writes would affect every global atom app-wide) nor the react-native-collapsible-tab-view patch (Android \`onPageSelected\` phantom events; candidate for separate hardening).
- Web/desktop apply atom writes synchronously in-process, so both guards are structural no-ops there.

## Changes Detail
- \`layouts/marketTabSelectionGuards.ts\` (new): pure decision helpers \`shouldRestoreSpotCategoryFromAtom\` and \`getIsMarketTabSelectionInFlight\`.
- \`layouts/marketTabSelectionGuards.test.ts\` (new): 9 unit tests covering cold start, lagging echo, out-of-order echoes, category-less (watchlist/perps) writes.
- \`MarketHomeV2.tsx\`: route all intent-driven category updates through \`applySelectedCategory\`; guard the restore effect with \`shouldRestoreSpotCategoryFromAtom\`.
- \`layouts/hooks/useMarketTabsLogic.ts\`: track \`lastWrittenSelectionRef\` on atom writes; expose \`isTabSelectionInFlight()\`.
- \`layouts/MobileLayout.native.tsx\`: defer page resync while a tab selection is in flight.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile (primary), Extension UI (same proxied-write path); Web/Desktop structurally unaffected
- **Risk Areas**: cold-start restore of the persisted spot category, deep-link \`spotCategoryToSelect\` flow, external tab navigation via \`useNavigateToMarketTab\`, and rapid tap/swipe sequences while a previous write is still in flight

## Test plan
- [x] \`npx jest packages/kit/src/views/Market/MarketHomeV2/layouts/\` — 30/30 passed (9 new)
- [x] \`yarn agent:check --profile commit\` — lint/tsc all green
- [ ] QA on \`ENABLE_NATIVE_BACKGROUND_THREAD=true\` package ([release-app-bundles run](https://github.com/OneKeyHQ/app-monorepo/actions/runs/29107075023)): repeated Trending ↔ US-stocks taps (×10, no revert/ping-pong), Watchlist → US-stocks cross-page tap, Perps round trips, horizontal swipe gestures, deep link into a specific category, kill & relaunch restores last category
- [ ] iOS same matrix; verify web/desktop market category switching unchanged