### PR TITLE
perf: reduce Windows desktop tab switch jank

### DIFF
--- a/development/scripts/win-tab-switch-perf.mjs
+++ b/development/scripts/win-tab-switch-perf.mjs
@@ -1,0 +1,552 @@
+/* eslint-disable no-console */
+/* cspell:words recalc */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { chromium } from 'playwright-core';
+
+const CDP_URL = process.env.CDP_URL || 'http://127.0.0.1:9222';
+const DEFAULT_OUT_DIR = '.tmp/win-tab-switch-perf';
+const POST_READY_MS = 1200;
+const READY_TIMEOUT_MS = 15_000;
+
+const TABS = [
+  { key: 'market', readyTestIds: ['market-page'] },
+  { key: 'swap', readyTestIds: ['swap-content-container'] },
+  {
+    key: 'perp',
+    readyTestIds: [
+      'perp-margin-mode-selector',
+      'perp-long-button',
+      'perp-short-button',
+    ],
+    readySelectors: ['webview[src*="tradingview.onekey.so"]'],
+  },
+  {
+    key: 'earn',
+    readyTestIds: [
+      'earn-page',
+      'earn-portfolio-overview',
+      'earn-market-selector',
+    ],
+  },
+  {
+    key: 'referfriends',
+    readySelectors: ['[data-testid^="refer-friends-"]'],
+  },
+  {
+    key: 'discovery',
+    readyTestIds: [
+      'discovery-dashboard-page',
+      'sidebar-browser-section',
+      'explore-index-search',
+      'discovery-trending-section',
+    ],
+  },
+  { key: 'home', readyTestIds: ['home-page'] },
+];
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token.startsWith('--')) {
+      const key = token.slice(2);
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        args[key] = true;
+      } else {
+        args[key] = value;
+        index += 1;
+      }
+    }
+  }
+  return args;
+}
+
+function ensureDirectory(directory) {
+  fs.mkdirSync(path.resolve(directory), { recursive: true });
+}
+
+function metricMap(metrics) {
+  return Object.fromEntries(
+    metrics.metrics.map(({ name, value }) => [name, value]),
+  );
+}
+
+function metricDelta(before, after, name) {
+  return (after[name] || 0) - (before[name] || 0);
+}
+
+function summarizeCpuProfile(profile) {
+  const nodesById = new Map(profile.nodes.map((node) => [node.id, node]));
+  const selfTimeByFrame = new Map();
+  for (let index = 0; index < (profile.samples?.length || 0); index += 1) {
+    const node = nodesById.get(profile.samples[index]);
+    if (node) {
+      const frame = node.callFrame || {};
+      let source = '(native)';
+      if (frame.url) {
+        try {
+          const parsed = new URL(frame.url);
+          source = parsed.pathname.split('/').slice(-2).join('/');
+        } catch {
+          source = frame.url.split('/').slice(-2).join('/');
+        }
+      }
+      const key = `${frame.functionName || '(anonymous)'} @ ${source}:${frame.lineNumber ?? '?'}`;
+      selfTimeByFrame.set(
+        key,
+        (selfTimeByFrame.get(key) || 0) + (profile.timeDeltas?.[index] || 0),
+      );
+    }
+  }
+  const totalUs = [...selfTimeByFrame.values()].reduce(
+    (total, value) => total + value,
+    0,
+  );
+  return [...selfTimeByFrame.entries()]
+    .toSorted((left, right) => right[1] - left[1])
+    .slice(0, 30)
+    .map(([frame, selfUs]) => ({
+      frame,
+      selfMs: selfUs / 1000,
+      share: totalUs ? selfUs / totalUs : 0,
+    }));
+}
+
+async function readTraceStream(session, stream) {
+  const chunks = [];
+  while (true) {
+    const result = await session.send('IO.read', { handle: stream });
+    chunks.push(result.data);
+    if (result.eof) {
+      break;
+    }
+  }
+  await session.send('IO.close', { handle: stream });
+  return chunks.join('');
+}
+
+async function startTrace(session) {
+  await session.send('Tracing.start', {
+    categories: [
+      'blink.user_timing',
+      'devtools.timeline',
+      'disabled-by-default-devtools.timeline',
+      'disabled-by-default-devtools.timeline.frame',
+      'loading',
+      'toplevel',
+      'v8',
+      'v8.execute',
+    ].join(','),
+    options: 'sampling-frequency=1000',
+    transferMode: 'ReturnAsStream',
+  });
+}
+
+async function stopTrace(session) {
+  const tracingComplete = new Promise((resolve) => {
+    session.once('Tracing.tracingComplete', resolve);
+  });
+  await session.send('Tracing.end');
+  const { stream } = await tracingComplete;
+  return readTraceStream(session, stream);
+}
+
+async function installObservers(page) {
+  await page.evaluate(() => {
+    globalThis.__onekeyTabPerf = {
+      longTasks: [],
+      mutation: null,
+    };
+    try {
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          globalThis.__onekeyTabPerf.longTasks.push({
+            startTime: entry.startTime,
+            duration: entry.duration,
+          });
+        }
+      });
+      observer.observe({ entryTypes: ['longtask'] });
+      globalThis.__onekeyTabPerf.longTaskObserver = observer;
+    } catch {
+      // PerformanceObserver long-task entries are unavailable in some builds.
+    }
+  });
+}
+
+async function prepareSwitch(page) {
+  return page.evaluate(() => {
+    const now = performance.now();
+    const sidebar = document.querySelector(
+      '[data-testid="Desktop-AppSideBar-Container"]',
+    );
+    const root = document.querySelector('#root') || document.body;
+    globalThis.__onekeyTabPerf.mutation?.observer?.disconnect();
+    const mutation = {
+      clickStart: now,
+      firstContentMutation: null,
+      lastContentMutation: null,
+      count: 0,
+    };
+    const observer = new MutationObserver((records) => {
+      const hasContentMutation = records.some((record) => {
+        const target =
+          record.target.nodeType === Node.ELEMENT_NODE
+            ? record.target
+            : record.target.parentElement;
+        return target && !sidebar?.contains(target);
+      });
+      if (!hasContentMutation) {
+        return;
+      }
+      const mutationTime = performance.now();
+      mutation.firstContentMutation ??= mutationTime;
+      mutation.lastContentMutation = mutationTime;
+      mutation.count += 1;
+    });
+    observer.observe(root, {
+      attributes: true,
+      characterData: true,
+      childList: true,
+      subtree: true,
+    });
+    mutation.observer = observer;
+    globalThis.__onekeyTabPerf.mutation = mutation;
+    return now;
+  });
+}
+
+function isElementVisible(element) {
+  if (!element) {
+    return false;
+  }
+  const style = getComputedStyle(element);
+  const rect = element.getBoundingClientRect();
+  const ancestorsVisible = element.checkVisibility
+    ? element.checkVisibility({
+        checkOpacity: true,
+        checkVisibilityCSS: true,
+      })
+    : true;
+  return (
+    ancestorsVisible &&
+    style.display !== 'none' &&
+    style.visibility !== 'hidden' &&
+    Number(style.opacity || 1) > 0 &&
+    rect.width > 0 &&
+    rect.height > 0
+  );
+}
+
+async function waitForTabReady(page, tab) {
+  const activeHandle = await page.waitForFunction(
+    ({ key }) => {
+      const tabElement = document.querySelector(`[data-testid="${key}"]`);
+      return tabElement?.querySelector(
+        '[data-testid^="tab-modal-active-item-"]',
+      )
+        ? performance.now()
+        : null;
+    },
+    tab,
+    { timeout: READY_TIMEOUT_MS },
+  );
+  const activeAt = await activeHandle.jsonValue();
+  const readyHandle = await page.waitForFunction(
+    ({ readySelectors, readyTestIds }) => {
+      const visible = (element) => {
+        if (!element) {
+          return false;
+        }
+        const style = getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        const ancestorsVisible = element.checkVisibility
+          ? element.checkVisibility({
+              checkOpacity: true,
+              checkVisibilityCSS: true,
+            })
+          : true;
+        return (
+          ancestorsVisible &&
+          style.display !== 'none' &&
+          style.visibility !== 'hidden' &&
+          Number(style.opacity || 1) > 0 &&
+          rect.width > 0 &&
+          rect.height > 0 &&
+          rect.right > 72 &&
+          rect.left < window.innerWidth &&
+          rect.bottom > 48 &&
+          rect.top < window.innerHeight
+        );
+      };
+      const selectors = [
+        ...(readyTestIds || []).map((testId) => `[data-testid="${testId}"]`),
+        ...(readySelectors || []),
+      ];
+      const readySelector = selectors.find((selector) =>
+        [...document.querySelectorAll(selector)].some(visible),
+      );
+      if (!readySelector) {
+        return null;
+      }
+      return {
+        readyAt: performance.now(),
+        readySelector,
+      };
+    },
+    tab,
+    { timeout: READY_TIMEOUT_MS },
+  );
+  return { activeAt, ...(await readyHandle.jsonValue()) };
+}
+
+async function collectSwitchResult({ networkEvents, page, session, tab }) {
+  const nav = page.locator(
+    `[data-testid="${tab.key}"] > [data-testid^="tab-modal-"]`,
+  );
+  if ((await nav.count()) !== 1) {
+    throw new Error(`Expected exactly one navigation item for ${tab.key}`);
+  }
+  const navElement = await nav.elementHandle();
+  if (!navElement || !(await navElement.evaluate(isElementVisible))) {
+    throw new Error(`Navigation item ${tab.key} is not visible`);
+  }
+
+  const beforeMetrics = metricMap(await session.send('Performance.getMetrics'));
+  const networkStartIndex = networkEvents.length;
+  const clickStart = await prepareSwitch(page);
+  await nav.click();
+  const ready = await waitForTabReady(page, tab);
+  await page.evaluate(
+    () =>
+      new Promise((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(resolve));
+      }),
+  );
+  const paintedAt = await page.evaluate(() => performance.now());
+  await page.waitForTimeout(POST_READY_MS);
+  const afterMetrics = metricMap(await session.send('Performance.getMetrics'));
+  const details = await page.evaluate((startTime) => {
+    const mutation = globalThis.__onekeyTabPerf.mutation;
+    mutation?.observer?.disconnect();
+    const longTasks = (globalThis.__onekeyTabPerf.longTasks || []).filter(
+      (entry) => entry.startTime >= startTime,
+    );
+    return {
+      firstContentMutationAt: mutation?.firstContentMutation,
+      lastContentMutationAt: mutation?.lastContentMutation,
+      mutationCount: mutation?.count || 0,
+      longTasks,
+    };
+  }, clickStart);
+  const longTaskTotalMs = details.longTasks.reduce(
+    (total, entry) => total + entry.duration,
+    0,
+  );
+  const longTaskMaxMs = details.longTasks.reduce(
+    (maximum, entry) => Math.max(maximum, entry.duration),
+    0,
+  );
+
+  const switchNetworkEvents = networkEvents.slice(networkStartIndex);
+  const requestCount = switchNetworkEvents.filter(
+    (event) => event.kind === 'request',
+  ).length;
+  const failedRequestCount = switchNetworkEvents.filter(
+    (event) => event.kind === 'failed',
+  ).length;
+
+  return {
+    tab: tab.key,
+    activeMs: ready.activeAt - clickStart,
+    readyMs: ready.readyAt - clickStart,
+    paintedMs: paintedAt - clickStart,
+    firstContentMutationMs:
+      details.firstContentMutationAt === null
+        ? null
+        : details.firstContentMutationAt - clickStart,
+    lastContentMutationMs:
+      details.lastContentMutationAt === null
+        ? null
+        : details.lastContentMutationAt - clickStart,
+    mutationCount: details.mutationCount,
+    longTaskCount: details.longTasks.length,
+    longTaskTotalMs,
+    longTaskMaxMs,
+    readySelector: ready.readySelector,
+    requestCount,
+    failedRequestCount,
+    metrics: {
+      taskDurationMs:
+        metricDelta(beforeMetrics, afterMetrics, 'TaskDuration') * 1000,
+      scriptDurationMs:
+        metricDelta(beforeMetrics, afterMetrics, 'ScriptDuration') * 1000,
+      layoutDurationMs:
+        metricDelta(beforeMetrics, afterMetrics, 'LayoutDuration') * 1000,
+      recalcStyleDurationMs:
+        metricDelta(beforeMetrics, afterMetrics, 'RecalcStyleDuration') * 1000,
+      layoutCount: metricDelta(beforeMetrics, afterMetrics, 'LayoutCount'),
+      recalcStyleCount: metricDelta(
+        beforeMetrics,
+        afterMetrics,
+        'RecalcStyleCount',
+      ),
+      jsHeapUsedDeltaMb:
+        metricDelta(beforeMetrics, afterMetrics, 'JSHeapUsedSize') / 1_048_576,
+      nodeDelta: metricDelta(beforeMetrics, afterMetrics, 'Nodes'),
+    },
+  };
+}
+
+async function collectPass({
+  name,
+  networkEvents,
+  outDirectory,
+  page,
+  session,
+}) {
+  console.error(`Starting ${name} pass`);
+  await session.send('Profiler.enable');
+  await session.send('Profiler.setSamplingInterval', { interval: 1000 });
+  await session.send('Profiler.start');
+  await startTrace(session);
+
+  const switches = [];
+  for (const tab of TABS) {
+    const result = await collectSwitchResult({
+      networkEvents,
+      page,
+      session,
+      tab,
+    });
+    switches.push(result);
+    console.error(
+      `${name.padEnd(5)} ${tab.key.padEnd(12)} ready=${result.readyMs.toFixed(1)}ms ` +
+        `paint=${result.paintedMs.toFixed(1)}ms maxLongTask=${result.longTaskMaxMs.toFixed(1)}ms`,
+    );
+  }
+
+  const trace = await stopTrace(session);
+  const { profile } = await session.send('Profiler.stop');
+  const tracePath = path.resolve(outDirectory, `${name}.trace.json`);
+  const profilePath = path.resolve(outDirectory, `${name}.cpuprofile`);
+  fs.writeFileSync(tracePath, trace);
+  fs.writeFileSync(profilePath, JSON.stringify(profile));
+  return {
+    name,
+    switches,
+    tracePath,
+    profilePath,
+    cpuTopSelfTime: summarizeCpuProfile(profile),
+  };
+}
+
+async function fetchTargets() {
+  const response = await fetch(`${CDP_URL}/json`);
+  if (!response.ok) {
+    throw new Error(`GET ${CDP_URL}/json failed: ${response.status}`);
+  }
+  const targets = await response.json();
+  return targets.map((target) => {
+    let origin = '';
+    try {
+      origin = new URL(target.url).origin;
+    } catch {
+      // Keep non-URL targets empty so no page content is written to artifacts.
+    }
+    return {
+      type: target.type,
+      title:
+        target.type === 'page' && target.url === 'file:///' ? 'OneKey' : '',
+      origin,
+    };
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const outDirectory = path.resolve(args.out || DEFAULT_OUT_DIR);
+  const settleSeconds = Number(args.settle || 20);
+  ensureDirectory(outDirectory);
+
+  const browser = await chromium.connectOverCDP(CDP_URL);
+  const pages = browser.contexts().flatMap((context) => context.pages());
+  const page =
+    pages.find((candidate) => candidate.url().startsWith('file:')) || pages[0];
+  if (!page) {
+    throw new Error('No Electron renderer page is exposed over CDP');
+  }
+  await page.locator('[data-testid="home-page"]').waitFor({
+    state: 'visible',
+    timeout: READY_TIMEOUT_MS,
+  });
+  await page.locator('[data-testid="home-total-balance"]').waitFor({
+    state: 'visible',
+    timeout: READY_TIMEOUT_MS,
+  });
+  await page.waitForFunction(
+    () =>
+      document.querySelectorAll(
+        '[data-testid="Desktop-AppSideBar-Container"] [data-testid^="tab-modal-"]',
+      ).length >= 7,
+    undefined,
+    { timeout: READY_TIMEOUT_MS },
+  );
+
+  const session = await page.context().newCDPSession(page);
+  await session.send('Performance.enable');
+  await installObservers(page);
+
+  const networkEvents = [];
+  page.on('request', (request) => {
+    networkEvents.push({
+      kind: 'request',
+      resourceType: request.resourceType(),
+    });
+  });
+  page.on('requestfailed', (request) => {
+    networkEvents.push({
+      kind: 'failed',
+      resourceType: request.resourceType(),
+    });
+  });
+
+  const startedAt = new Date().toISOString();
+  const cold = await collectPass({
+    name: 'cold',
+    networkEvents,
+    outDirectory,
+    page,
+    session,
+  });
+  console.error(`Waiting ${settleSeconds}s before warm pass`);
+  await page.waitForTimeout(settleSeconds * 1000);
+  const warm = await collectPass({
+    name: 'warm',
+    networkEvents,
+    outDirectory,
+    page,
+    session,
+  });
+
+  const result = {
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    cdpUrl: CDP_URL,
+    settleSeconds,
+    targets: await fetchTargets(),
+    passes: { cold, warm },
+  };
+  const resultPath = path.resolve(outDirectory, 'results.json');
+  fs.writeFileSync(resultPath, JSON.stringify(result, null, 2));
+  console.log(JSON.stringify(result, null, 2));
+  console.error(`Results written to ${resultPath}`);
+  await session.detach().catch(() => {});
+  await browser.close();
+}
+
+await main();

--- a/packages/components/src/actions/Popover/index.tsx
+++ b/packages/components/src/actions/Popover/index.tsx
@@ -282,7 +282,13 @@ function RawPopover({
 }: IPopoverProps) {
   const { bottom } = useSafeAreaInsets();
   const triggerRef = useRef<View | null>(null);
-  const placement = getPlacement(placementProp, triggerRef);
+  // Closed Windows popovers are present throughout every tab tree. Measuring
+  // each trigger during a focus render forces repeated synchronous layouts;
+  // the geometry is only needed once the popover is actually opened.
+  const shouldSkipClosedMeasurement = platformEnv.isDesktopWin && !isOpen;
+  const placement = shouldSkipClosedMeasurement
+    ? placementProp || 'bottom-end'
+    : getPlacement(placementProp, triggerRef);
   const transformOrigin = useMemo(() => {
     switch (placement) {
       case 'top':
@@ -398,7 +404,9 @@ function RawPopover({
 
   const isShowNativeKeepChildrenMountedBackdrop =
     platformEnv.isNative && props.keepChildrenMounted;
-  const maxScrollViewHeight = getMaxScrollViewHeight();
+  const maxScrollViewHeight = shouldSkipClosedMeasurement
+    ? undefined
+    : getMaxScrollViewHeight();
   const transformOriginStyle = useMemo(
     () => ({ transformOrigin }),
     [transformOrigin],

--- a/packages/kit/src/hooks/useListenTabFocusState.test.tsx
+++ b/packages/kit/src/hooks/useListenTabFocusState.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook } from '@testing-library/react-native';
+
+import { ERootRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
+
+import useListenTabFocusState from './useListenTabFocusState';
+
+import type { NavigationState } from '@react-navigation/native';
+
+let mockRouterChangeListener:
+  | ((state: NavigationState | undefined) => void)
+  | undefined;
+
+jest.mock('@onekeyhq/components', () => ({
+  useOnRouterChange: (
+    callback: (state: NavigationState | undefined) => void,
+  ) => {
+    mockRouterChangeListener = callback;
+  },
+}));
+
+function buildState(
+  currentTab: ETabRoutes,
+  { withModal = false }: { withModal?: boolean } = {},
+) {
+  const tabRoutes = [
+    { key: 'home', name: ETabRoutes.Home },
+    { key: 'market', name: ETabRoutes.Market },
+    { key: 'swap', name: ETabRoutes.Swap },
+  ];
+  const routes: any[] = [
+    {
+      key: 'main',
+      name: ERootRoutes.Main,
+      state: {
+        index: tabRoutes.findIndex((route) => route.name === currentTab),
+        routeNames: tabRoutes.map((route) => route.name),
+        routes: tabRoutes,
+      },
+    },
+  ];
+  if (withModal) {
+    routes.push({ key: 'modal', name: ERootRoutes.Modal });
+  }
+  return { index: routes.length - 1, routes } as NavigationState;
+}
+
+describe('useListenTabFocusState', () => {
+  beforeEach(() => {
+    mockRouterChangeListener = undefined;
+  });
+
+  it('only notifies when focus or modal visibility changes', () => {
+    const callback = jest.fn();
+    renderHook(() => useListenTabFocusState(ETabRoutes.Home, callback));
+
+    act(() => mockRouterChangeListener?.(buildState(ETabRoutes.Home)));
+    expect(callback).toHaveBeenLastCalledWith(true, false);
+
+    act(() => mockRouterChangeListener?.(buildState(ETabRoutes.Home)));
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    act(() => mockRouterChangeListener?.(buildState(ETabRoutes.Market)));
+    expect(callback).toHaveBeenLastCalledWith(false, false);
+
+    act(() => mockRouterChangeListener?.(buildState(ETabRoutes.Market)));
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    act(() =>
+      mockRouterChangeListener?.(
+        buildState(ETabRoutes.Market, { withModal: true }),
+      ),
+    );
+    expect(callback).toHaveBeenLastCalledWith(false, true);
+
+    act(() => mockRouterChangeListener?.(buildState(ETabRoutes.Market)));
+    expect(callback).toHaveBeenLastCalledWith(false, false);
+    expect(callback).toHaveBeenCalledTimes(4);
+  });
+
+  it('preserves the extension fallback state', () => {
+    const callback = jest.fn();
+    renderHook(() => useListenTabFocusState(ETabRoutes.Home, callback));
+
+    act(() => mockRouterChangeListener?.(undefined));
+    act(() => mockRouterChangeListener?.(undefined));
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(true, false);
+  });
+});

--- a/packages/kit/src/hooks/useListenTabFocusState.ts
+++ b/packages/kit/src/hooks/useListenTabFocusState.ts
@@ -8,10 +8,24 @@ export default function useListenTabFocusState(
   callback: (isFocus: boolean, isHideByModal: boolean) => void, // do NOT useCallback to wrap the callback
 ) {
   const tabNames = Array.isArray(tabName) ? tabName : [tabName];
+  const previousStateRef = useRef<
+    | {
+        isFocus: boolean;
+        isHideByModal: boolean;
+      }
+    | undefined
+  >(undefined);
   useOnRouterChange((state) => {
     // the state may be undefined when initializing the interface on the Ext.
     if (!state) {
-      callback(tabName === ETabRoutes.Home, false);
+      const isFocus = tabName === ETabRoutes.Home;
+      if (
+        previousStateRef.current?.isFocus !== isFocus ||
+        previousStateRef.current?.isHideByModal !== false
+      ) {
+        previousStateRef.current = { isFocus, isHideByModal: false };
+        callback(isFocus, false);
+      }
       return;
     }
     const rootState = state?.routes.find(
@@ -29,10 +43,18 @@ export default function useListenTabFocusState(
     const currentTabName = rootState?.routeNames
       ? (rootState?.routeNames?.[rootState?.index || 0] as ETabRoutes)
       : (rootState?.routes[0].name as ETabRoutes);
-    callback(
-      tabNames.includes(currentTabName),
-      !!(modalRoutes || fullModalRoutes || fullScreenPushRoutes),
-    );
+    const nextState = {
+      isFocus: tabNames.includes(currentTabName),
+      isHideByModal: !!(modalRoutes || fullModalRoutes || fullScreenPushRoutes),
+    };
+    if (
+      previousStateRef.current?.isFocus === nextState.isFocus &&
+      previousStateRef.current?.isHideByModal === nextState.isHideByModal
+    ) {
+      return;
+    }
+    previousStateRef.current = nextState;
+    callback(nextState.isFocus, nextState.isHideByModal);
   });
 }
 

--- a/packages/kit/src/hooks/usePromiseResult.test.tsx
+++ b/packages/kit/src/hooks/usePromiseResult.test.tsx
@@ -41,16 +41,19 @@ jest.mock('@onekeyhq/kit/src/hooks/useRouteIsFocused', () => {
   const ReactModule = require('react') as typeof import('react');
   let currentFocus = true;
   const listeners: Array<(v: boolean) => void> = [];
+  const refListeners: Array<(v: boolean) => void> = [];
 
   const __setFocus = (v: boolean) => {
     if (currentFocus === v) return;
     currentFocus = v;
     listeners.slice().forEach((l) => l(v));
+    refListeners.slice().forEach((l) => l(v));
   };
 
   const __resetFocus = () => {
     currentFocus = true;
     listeners.slice().forEach((l) => l(true));
+    refListeners.slice().forEach((l) => l(true));
   };
 
   const useRouteIsFocused = () => {
@@ -67,8 +70,54 @@ jest.mock('@onekeyhq/kit/src/hooks/useRouteIsFocused', () => {
     return v;
   };
 
+  const useRouteIsFocusedRef = ({
+    onChangeRef,
+    overrideIsFocused,
+  }: {
+    onChangeRef: React.MutableRefObject<
+      ((isFocused: boolean) => void) | undefined
+    >;
+    overrideIsFocused?: (isFocused: boolean) => boolean;
+  }) => {
+    const overrideRef = ReactModule.useRef(overrideIsFocused);
+    overrideRef.current = overrideIsFocused;
+    const applyOverride = (isFocused: boolean) =>
+      overrideRef.current?.(isFocused) ?? isFocused;
+    const renderValue = applyOverride(currentFocus);
+    const focusedRef = ReactModule.useRef(renderValue);
+    focusedRef.current = renderValue;
+    const notifiedRef = ReactModule.useRef<boolean | undefined>(undefined);
+
+    ReactModule.useEffect(() => {
+      const listener = (isFocused: boolean) => {
+        const nextValue = applyOverride(isFocused);
+        focusedRef.current = nextValue;
+        if (notifiedRef.current !== nextValue) {
+          notifiedRef.current = nextValue;
+          onChangeRef.current?.(nextValue);
+        }
+      };
+      refListeners.push(listener);
+      listener(currentFocus);
+      return () => {
+        const idx = refListeners.indexOf(listener);
+        if (idx >= 0) refListeners.splice(idx, 1);
+      };
+    }, [onChangeRef]);
+
+    ReactModule.useEffect(() => {
+      if (notifiedRef.current !== renderValue) {
+        notifiedRef.current = renderValue;
+        onChangeRef.current?.(renderValue);
+      }
+    }, [onChangeRef, renderValue]);
+
+    return focusedRef;
+  };
+
   return {
     useRouteIsFocused,
+    useRouteIsFocusedRef,
     __setFocus,
     __resetFocus,
   };
@@ -707,6 +756,27 @@ describe('usePromiseResult', () => {
         expect(result.current.result).toBe('data');
       });
       expect(method).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not rerender the consumer solely because route focus changes', async () => {
+      const method = jest.fn(() => new Promise<string>(() => {}));
+      const { result } = renderHook(() =>
+        usePromiseResultWithRenderCount(method),
+      );
+
+      await waitFor(() => {
+        expect(method).toHaveBeenCalledTimes(1);
+      });
+      const initialRenderCount = result.current.renderCount;
+
+      act(() => {
+        focusControl.__setFocus(false);
+      });
+      act(() => {
+        focusControl.__setFocus(true);
+      });
+
+      expect(result.current.renderCount).toBe(initialRenderCount);
     });
 
     it('does not start fetch when not focused at mount (default checkIsFocused: true)', async () => {

--- a/packages/kit/src/hooks/usePromiseResult.ts
+++ b/packages/kit/src/hooks/usePromiseResult.ts
@@ -8,7 +8,7 @@ import {
   useDeferredPromise,
   useNetInfo,
 } from '@onekeyhq/components';
-import { useRouteIsFocused as useIsFocused } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
+import { useRouteIsFocusedRef } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { swrCacheUtils } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
@@ -157,13 +157,6 @@ export function usePromiseResult<T>(
   }
   const [isLoading, setIsLoading] = useState<boolean | undefined>();
   const isMountedRef = useIsMounted();
-  const _isFocused = useIsFocused({ testID: options.testID });
-  const isFocusedRef = useRef<boolean>(_isFocused);
-  const pollingNonceRef = useRef<number>(0);
-  isFocusedRef.current = _isFocused;
-  if (options?.overrideIsFocused !== undefined) {
-    isFocusedRef.current = options?.overrideIsFocused?.(_isFocused);
-  }
   const methodRef = useRef<typeof method>(method);
   methodRef.current = method;
   const optionsRef = useRef(options);
@@ -175,6 +168,15 @@ export function usePromiseResult<T>(
     alwaysSetState: false,
     ...options,
   };
+  const focusChangeCallbackRef = useRef<
+    ((isFocused: boolean) => void) | undefined
+  >(undefined);
+  const isFocusedRef = useRouteIsFocusedRef({
+    onChangeRef: focusChangeCallbackRef,
+    overrideIsFocused: options.overrideIsFocused,
+    testID: options.testID,
+  });
+  const pollingNonceRef = useRef<number>(0);
   const isDepsChangedOnBlur = useRef(false);
   const nonceRef = useRef(0);
 
@@ -477,9 +479,9 @@ export function usePromiseResult<T>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, runnerDeps);
 
-  const isFocusedRefValue = isFocusedRef.current;
-  const prevFocusedRef = useRef(isFocusedRefValue);
+  const prevFocusedRef = useRef<boolean | undefined>(undefined);
   const isLoadingRef = useRef(isLoading);
+  isLoadingRef.current = isLoading;
   const runWithPollingNonce = useCallback(() => {
     isDepsChangedOnBlur.current = false;
     void runRef.current({ pollingNonce: pollingNonceRef.current });
@@ -501,58 +503,71 @@ export function usePromiseResult<T>(
     }
   }, [isInternetReachable, runWithPollingNonce]);
 
-  useEffect(() => {
-    if (optionsRef.current.checkIsFocused) {
-      if (isFocusedRefValue) {
-        resolveDefer();
-      } else {
-        resetDefer();
+  const focusIdleHandlesRef = useRef<
+    Set<ReturnType<typeof requestIdleCallback>>
+  >(new Set());
+  const applyFocusedState = useCallback(
+    (isFocused: boolean) => {
+      isFocusedRef.current = isFocused;
+      if (prevFocusedRef.current === isFocused) {
+        return;
       }
-
-      // On native, defer focus-recovery re-execution until the JS thread is
-      // idle so the first render frame after tab switch can paint without
-      // being blocked by data fetching across 40+ hooks.
-      const idleHandles: ReturnType<typeof requestIdleCallback>[] = [];
-      const scheduleRun = () => {
-        if (platformEnv.isNative) {
-          idleHandles.push(requestIdleCallback(runWithPollingNonce));
+      const wasFocused = prevFocusedRef.current;
+      prevFocusedRef.current = isFocused;
+      if (optionsRef.current.checkIsFocused) {
+        if (isFocused) {
+          resolveDefer();
         } else {
-          runWithPollingNonce();
+          resetDefer();
         }
-      };
 
-      // By employing a hack to simulate the recovery from a network disconnection and subsequently make a new network request.
-      if (
-        platformEnv.isNative &&
-        !isLoadingRef.current &&
-        isEmptyResultRef.current &&
-        optionsRef.current.revalidateOnReconnect
-      ) {
-        scheduleRun();
-      }
+        // On native, defer focus-recovery re-execution until the JS thread is
+        // idle so the first render frame after tab switch can paint without
+        // being blocked by data fetching across 40+ hooks.
+        const scheduleRun = () => {
+          if (platformEnv.isNative) {
+            const idleHandle = requestIdleCallback(() => {
+              focusIdleHandlesRef.current.delete(idleHandle);
+              runWithPollingNonce();
+            });
+            focusIdleHandlesRef.current.add(idleHandle);
+          } else {
+            runWithPollingNonce();
+          }
+        };
 
-      if (
-        prevFocusedRef.current === false &&
-        isFocusedRefValue &&
-        optionsRef.current.revalidateOnFocus
-      ) {
-        scheduleRun();
-      } else if (isFocusedRefValue && isDepsChangedOnBlur.current) {
-        scheduleRun();
-      }
-      prevFocusedRef.current = isFocusedRefValue;
-
-      return () => {
-        if (platformEnv.isNative) {
-          idleHandles.forEach(cancelIdleCallback);
+        // By employing a hack to simulate the recovery from a network disconnection and subsequently make a new network request.
+        if (
+          platformEnv.isNative &&
+          !isLoadingRef.current &&
+          isEmptyResultRef.current &&
+          optionsRef.current.revalidateOnReconnect
+        ) {
+          scheduleRun();
         }
-      };
-    }
-  }, [isFocusedRefValue, resetDefer, resolveDefer, runWithPollingNonce]);
+
+        if (
+          wasFocused === false &&
+          isFocused &&
+          optionsRef.current.revalidateOnFocus
+        ) {
+          scheduleRun();
+        } else if (isFocused && isDepsChangedOnBlur.current) {
+          scheduleRun();
+        }
+      }
+    },
+    [isFocusedRef, resetDefer, resolveDefer, runWithPollingNonce],
+  );
+
+  focusChangeCallbackRef.current = applyFocusedState;
 
   useEffect(() => {
+    const focusIdleHandles = focusIdleHandlesRef.current;
     return () => {
       isEffectValid.current = false;
+      focusIdleHandles.forEach(cancelIdleCallback);
+      focusIdleHandles.clear();
     };
   }, []);
 

--- a/packages/kit/src/hooks/useRouteIsFocused.ts
+++ b/packages/kit/src/hooks/useRouteIsFocused.ts
@@ -1,8 +1,9 @@
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import type { MutableRefObject } from 'react';
 
-import { useIsFocused } from '@react-navigation/core';
+import { useIsFocused, useNavigation } from '@react-navigation/core';
 
-import { rootNavigationRef } from '@onekeyhq/components';
+import { rootNavigationRef, useOnRouterChange } from '@onekeyhq/components';
 import { useAppIsLockedAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/passwordLock';
 
 export const getRootRoutersLength = () =>
@@ -27,4 +28,62 @@ export const useRouteIsFocused = ({
     // fix the issue where the current page remains in focus after multiple modals appear on Web.
     rootRoutersLength >= getRootRoutersLength()
   );
+};
+
+export const useRouteIsFocusedRef = ({
+  disableLockScreenCheck = false,
+  onChangeRef,
+  overrideIsFocused,
+  testID: _testID,
+}: {
+  disableLockScreenCheck?: boolean;
+  onChangeRef: MutableRefObject<((isFocused: boolean) => void) | undefined>;
+  overrideIsFocused?: (isFocused: boolean) => boolean;
+  testID?: string;
+}) => {
+  const navigation = useNavigation();
+  const [isLocked] = useAppIsLockedAtom();
+  const isLockedRef = useRef(isLocked);
+  isLockedRef.current = isLocked;
+  const overrideIsFocusedRef = useRef(overrideIsFocused);
+  overrideIsFocusedRef.current = overrideIsFocused;
+  const rootRoutersLength = useMemo(getRootRoutersLength, []);
+
+  const getIsFocused = useCallback(() => {
+    const isFocused =
+      (disableLockScreenCheck || !isLockedRef.current) &&
+      navigation.isFocused() &&
+      rootRoutersLength >= getRootRoutersLength();
+    return overrideIsFocusedRef.current?.(isFocused) ?? isFocused;
+  }, [disableLockScreenCheck, navigation, rootRoutersLength]);
+
+  const renderFocusedValue = getIsFocused();
+  const isFocusedRef = useRef(renderFocusedValue);
+  isFocusedRef.current = renderFocusedValue;
+  const notifiedFocusedRef = useRef<boolean | undefined>(undefined);
+
+  const notifyFocusChange = useCallback(
+    (isFocused: boolean) => {
+      isFocusedRef.current = isFocused;
+      if (notifiedFocusedRef.current === isFocused) {
+        return;
+      }
+      notifiedFocusedRef.current = isFocused;
+      onChangeRef.current?.(isFocused);
+    },
+    [onChangeRef],
+  );
+
+  // Navigation focus is a gate for async work, not rendered output. Updating a
+  // ref from the router event avoids forcing every data hook consumer to
+  // re-render together during a tab switch.
+  useOnRouterChange(() => notifyFocusChange(getIsFocused()));
+
+  // Re-evaluate lock state and caller overrides when their owning component
+  // renders for a reason unrelated to navigation.
+  useEffect(() => {
+    notifyFocusChange(renderFocusedValue);
+  }, [notifyFocusChange, renderFocusedValue]);
+
+  return isFocusedRef;
 };

--- a/packages/kit/src/states/jotai/contexts/earn/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/earn/actions.ts
@@ -1,5 +1,7 @@
 import { useCallback, useRef } from 'react';
 
+import { isEqual } from 'lodash';
+
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ContextJotaiActionsBase } from '@onekeyhq/kit/src/states/jotai/utils/ContextJotaiActionsBase';
 import { memoFn } from '@onekeyhq/shared/src/utils/cacheUtils';
@@ -62,6 +64,9 @@ class ContextJotaiActionsEarn extends ContextJotaiActionsBase {
       availableAssets: IAvailableAsset[],
     ) => {
       const earnData = get(earnAtom());
+      if (isEqual(earnData.availableAssetsByType?.[type], availableAssets)) {
+        return;
+      }
       this.syncToDb.call(set, {
         availableAssetsByType: {
           ...earnData.availableAssetsByType,

--- a/packages/kit/src/states/jotai/contexts/marketV2/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/marketV2/actions.ts
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 
-import { cloneDeep } from 'lodash';
+import { cloneDeep, isEqual } from 'lodash';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ContextJotaiActionsBase } from '@onekeyhq/kit/src/states/jotai/utils/ContextJotaiActionsBase';
@@ -452,9 +452,14 @@ class ContextJotaiActionsMarketV2 extends ContextJotaiActionsBase {
 
   // Existing WatchList Actions
   flushWatchListV2Atom = contextAtomMethod(
-    (_, set, payload: IMarketWatchListItemV2[]) => {
+    (get, set, payload: IMarketWatchListItemV2[]) => {
+      const previous = get(marketWatchListV2Atom());
+      if (isEqual(previous.data, payload)) {
+        return previous;
+      }
       const result = { data: payload };
       set(marketWatchListV2Atom(), result);
+      return result;
     },
   );
 

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -87,8 +87,13 @@ function BasicEarnHome({
     useBlockRegion();
 
   const { faqList, isFaqLoading, refetchFAQ } = useFAQListInfo();
-  const [isEarnTabFocused, setIsEarnTabFocused] = useState(false);
-  const [isEarnDataActive, setIsEarnDataActive] = useState(false);
+  const isEarnTabFocusedRef = useRef(false);
+  // Desktop data hooks already gate work through their non-rendering route
+  // focus ref. Keep their inner-tab active state stable so a top-level tab
+  // switch doesn't re-render the entire Earn tree.
+  const [isEarnDataActive, setIsEarnDataActive] = useState(
+    platformEnv.isDesktop,
+  );
   const [isManualRefreshing, setIsManualRefreshing] = useState(false);
   const wasFocusedRef = useRef(false);
   const wasHiddenByModalRef = useRef(false);
@@ -337,8 +342,8 @@ function BasicEarnHome({
     [navigation, route.params?.tab],
   );
 
-  useEffect(() => {
-    if (!showContent || !isEarnTabFocused) {
+  const logEarnModeSwitch = useCallback(() => {
+    if (!showContent || !isEarnTabFocusedRef.current) {
       return;
     }
 
@@ -357,7 +362,11 @@ function BasicEarnHome({
       switchType,
     });
     earnModeSwitchTypeRef.current = 'default';
-  }, [defaultMode, isEarnTabFocused, showContent]);
+  }, [defaultMode, showContent]);
+
+  useEffect(() => {
+    logEarnModeSwitch();
+  }, [defaultMode, logEarnModeSwitch]);
 
   useEffect(() => {
     const handleSwitchEarnMode = ({
@@ -400,8 +409,10 @@ function BasicEarnHome({
       if (isVisibleFocus && !wasFocused && !wasHiddenByModal) {
         shouldLogEnterEarnRef.current = true;
       }
-      setIsEarnTabFocused(isVisibleFocus);
-      setIsEarnDataActive(isDataActive);
+      isEarnTabFocusedRef.current = isVisibleFocus;
+      if (!platformEnv.isDesktop) {
+        setIsEarnDataActive(isDataActive);
+      }
       if (
         !isVisibleFocus ||
         showContent === false ||
@@ -409,6 +420,8 @@ function BasicEarnHome({
       ) {
         return;
       }
+
+      logEarnModeSwitch();
 
       void refetchFAQ();
 
@@ -435,7 +448,13 @@ function BasicEarnHome({
         actions.current.triggerRefresh();
       }
     },
-    [actions, prefetchEarnAvailableAssets, refetchFAQ, showContent],
+    [
+      actions,
+      logEarnModeSwitch,
+      prefetchEarnAvailableAssets,
+      refetchFAQ,
+      showContent,
+    ],
   );
 
   useListenTabFocusState(earnFocusTabRoutes, handleListenTabFocusState);

--- a/packages/kit/src/views/Earn/components/EarnMainTabs.tsx
+++ b/packages/kit/src/views/Earn/components/EarnMainTabs.tsx
@@ -27,7 +27,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { ListItem } from '../../../components/ListItem';
 import { useIsFirstFocused } from '../../../hooks/useIsFirstFocused';
-import { useRouteIsFocused } from '../../../hooks/useRouteIsFocused';
+import { useRouteIsFocusedRef } from '../../../hooks/useRouteIsFocused';
 import { useTabContainerWidth } from '../../../hooks/useTabContainerWidth';
 import { useEarnHideSmallAssets } from '../hooks/useEarnHideSmallAssets';
 
@@ -234,17 +234,20 @@ const EarnMainTabsComponent = ({
     useDesktopPageScrollTabs,
   ]);
 
-  const isFocused = useRouteIsFocused();
-  const isFocusedRef = useRef(isFocused);
-
-  useEffect(() => {
+  const routeFocusChangeRef = useRef<
+    ((isFocused: boolean) => void) | undefined
+  >(undefined);
+  useRouteIsFocusedRef({ onChangeRef: routeFocusChangeRef });
+  const previousRouteFocusedRef = useRef<boolean | undefined>(undefined);
+  routeFocusChangeRef.current = (isFocused: boolean) => {
+    if (previousRouteFocusedRef.current === undefined) {
+      previousRouteFocusedRef.current = isFocused;
+      return;
+    }
+    previousRouteFocusedRef.current = isFocused;
     if (platformEnv.isNativeIOS) {
       return;
     }
-    if (isFocused === isFocusedRef.current) {
-      return;
-    }
-    isFocusedRef.current = isFocused;
     if (defaultTab) {
       const targetTabName = initialTabName;
       if (!useDesktopPageScrollTabs) {
@@ -256,15 +259,7 @@ const EarnMainTabsComponent = ({
         syncDesktopTabName(targetTabName);
       }
     }
-  }, [
-    defaultTab,
-    desktopTabName,
-    initialTabName,
-    isFocused,
-    syncDesktopTabName,
-    tabsRef,
-    useDesktopPageScrollTabs,
-  ]);
+  };
 
   useEffect(() => {
     const callback = ({ tab }: { tab: 'assets' | 'portfolio' | 'faqs' }) => {
@@ -468,6 +463,6 @@ function ForwardedEarnMainTabs(
 ) {
   const isFocused = useIsFocused();
   const isFirstFocused = useIsFirstFocused(isFocused);
-  return isFirstFocused ? <EarnMainTabsComponent {...props} /> : null;
+  return isFirstFocused ? <MemoizedEarnMainTabs {...props} /> : null;
 }
 export const EarnMainTabs = memo(ForwardedEarnMainTabs);

--- a/packages/kit/src/views/Earn/hooks/useFAQListInfo.ts
+++ b/packages/kit/src/views/Earn/hooks/useFAQListInfo.ts
@@ -1,3 +1,7 @@
+import { useCallback } from 'react';
+
+import { isEqual } from 'lodash';
+
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
@@ -6,7 +10,7 @@ export const useFAQListInfo = () => {
   const {
     result: faqList,
     isLoading: isFaqLoading = true,
-    run: refetchFAQ,
+    setResult: setFaqList,
   } = usePromiseResult(
     async () => {
       const result =
@@ -19,6 +23,14 @@ export const useFAQListInfo = () => {
       watchLoading: true,
     },
   );
+
+  const refetchFAQ = useCallback(async () => {
+    const nextFaqList =
+      await backgroundApiProxy.serviceStaking.getFAQListForHome();
+    setFaqList((previousFaqList) =>
+      isEqual(previousFaqList, nextFaqList) ? previousFaqList : nextFaqList,
+    );
+  }, [setFaqList]);
 
   return { faqList, isFaqLoading, refetchFAQ };
 };


### PR DESCRIPTION
## Scope and outcome

This PR addresses the 1–2 second perceived jank when switching Wallet, Market, Swap, Perps, Earn, Refer Friends, and Discovery in the Windows Electron release build.

The optimization deliberately keeps the existing desktop navigation model and the current user profile:

- the Windows release was built and launched locally, not through a remote environment;
- the existing funded test wallet was preserved throughout the work;
- application data was not cleared between runs;
- pages remain mounted so their warm state is retained;
- refresh, polling, lock-screen, modal, and focus-recovery behavior is preserved;
- the solution does not assume a separate desktop bg/main runtime.

The central design change is to treat route focus as a control signal for asynchronous work, rather than as rendered component state that every data-hook consumer must subscribe to.

## 1. Measurement design, baseline, and root-cause analysis

### Benchmark design

The investigation began with a reproducible release-build baseline rather than development-mode timings.

The renderer, main process, and Windows Electron package were built with:

    yarn workspace @onekeyhq/desktop build:renderer
    yarn workspace @onekeyhq/desktop build:main
    yarn workspace @onekeyhq/desktop build:electron:win --publish never

The packaged application was then launched with CDP enabled, without clearing the existing profile:

    powershell -ExecutionPolicy Bypass -File apps\desktop\scripts\build-launch-perf-win.ps1 -NoBuild -Detach -Port 9222

Each benchmark run used the following sequence:

1. connect to the packaged Electron renderer through CDP;
2. verify that the Wallet home page and existing account balance are visible;
3. switch through Market, Swap, Perps, Earn, Refer Friends, Discovery, and Wallet once as the cold pass;
4. allow all mounted tabs and embedded content to finish loading and settle;
5. switch through the same tabs again as the warm pass;
6. collect Chrome trace, CPU profile, task/script/layout/style metrics, DOM mutation timing, long tasks, requests, and tab-ready/paint timing;
7. run a separate trace-free warm cycle, because DevTools tracing itself adds measurable overhead;
8. after a 20-second settle, observe a 10-second idle window to distinguish tab-switch work from background traffic or polling.

The added development/scripts/win-tab-switch-perf.mjs script makes this procedure repeatable. It records cold and warm traces and CPU profiles, checks page-specific ready selectors, measures the first usable paint after a switch, counts long tasks and requests, and sanitizes CDP target metadata so benchmark artifacts do not capture page content or wallet data.

### Evidence chain

The traces showed that the delay was primarily renderer main-thread work, not a slow route transition or a single blocking network request.

A sidebar click entered React Navigation and then spent a large synchronous block in React scheduling, including processRootScheduleInMicrotask. Focus propagation caused dozens of mounted usePromiseResult consumers to update together. Those component renders fanned out into Tamagui style calculation before Chromium could produce the next frame.

The Market trace exposed a second multiplier: closed Popover trees were still performing placement and geometry reads. Calls such as getPlacement and getBoundingClientRect forced style and layout work even though the popovers were not visible.

The warm-pass and idle evidence also mattered to the choice of fix:

- warm switches still contained the synchronous React/style block after data had loaded;
- the settled idle probe produced no new resources and no long tasks;
- therefore clearing caches, suppressing all refreshes, or treating the issue as a network-only problem would not address the measured bottleneck;
- unmounting every inactive tab would reduce mounted work, but would trade the switch jank for repeated cold initialization and loss of warm page state.

The chosen direction was therefore to reduce synchronous render fan-out and no-op state writes while retaining the current navigation and data lifecycle.

## 2. Non-rendering route focus for usePromiseResult

### Previous behavior

usePromiseResult used the rendered useRouteIsFocused/useIsFocused value. A route-focus change was therefore a React state change for every component using the hook, even when focus only controlled whether an async task was allowed to run.

On a desktop tab switch, many mounted hooks observed the same focus edge at once. Their consumers re-rendered synchronously, and the resulting Tamagui work remained inside the click-to-frame critical path.

### New behavior

This PR adds useRouteIsFocusedRef and moves usePromiseResult focus handling onto that non-rendering path.

The focus ref evaluates the same conditions as the rendered focus hook:

- the current navigation route must be focused;
- the root-router/modal depth must allow the page to be considered visible;
- the lock screen must be respected unless the caller explicitly disables that check;
- overrideIsFocused is still applied when supplied by the caller.

Router events update the ref and invoke a callback only when the effective focus value changes. They do not turn the route focus edge into local rendered state for every usePromiseResult consumer.

usePromiseResult then uses that ref to control its runner. A tab focus change can update async-control state without forcing the component that owns the hook to render solely because focus changed.

### Preserved semantics

This is intentionally not a removal of focus handling. The following behavior remains in place:

- requests with checkIsFocused enabled do not begin while the route is inactive;
- the deferred promise gate is reset on blur and resolved on focus;
- dependency changes that occur while blurred are remembered and recovered after focus;
- revalidateOnFocus still schedules a refresh on a real false-to-true transition;
- native revalidation is deferred through requestIdleCallback so the first frame can paint before recovery work begins;
- revalidateOnReconnect behavior remains available;
- polling still uses its existing nonce and focus checks;
- lock-screen and modal visibility continue to affect the effective focus state;
- in-flight results keep their existing result/state semantics;
- scheduled focus-recovery idle callbacks are cancelled when the hook unmounts.

A focused Jest case verifies the key performance invariant directly: changing route focus from true to false and back does not increase the consumer render count.

The important distinction is that data freshness is retained, but focus is no longer broadcast as a page-wide render trigger.

## 3. Edge-deduplicated tab-focus notifications

useListenTabFocusState is used by mounted page trees for work that genuinely must react to tab visibility. During navigation and modal transitions it could receive repeated notifications carrying the same effective values, especially repeated inactive notifications for already inactive routes.

Those callbacks were individually small, but multiplied across mounted tabs they caused avoidable work in the same switch window.

The listener now tracks the last effective focus/modal state and invokes consumers only when that state crosses an edge:

- inactive to active;
- active to inactive;
- visible to hidden by a modal;
- hidden by a modal to visible.

Repeated notifications with an unchanged focus/modal state are ignored.

This does not debounce or delay real transitions, and it does not remove callbacks that pages rely on. It only removes duplicate delivery of the same state.

## 4. Defer closed Windows Popover geometry work

### Problem

Mounted closed popovers participated in render-time placement calculation on Windows. Even though their content was not visible, the code could still execute placement, max-scroll-height calculation, and bounding-box reads.

A geometry read after style changes can force Chromium to synchronously recalculate style and layout. In the Market baseline this became a large part of the click block because many components were rerendering at once.

### Change

On desktop Windows, closed popovers now skip placement and maximum-height geometry measurement until they are actually opened.

When a popover opens, the normal placement path still runs, so positioning behavior is not replaced with a cached or guessed value. The optimization removes only work that cannot affect a closed popover's visible output.

### Measured and functional result

Market RecalcStyleDuration fell from 427.1 ms to 7.7 ms in the comparable formal warm trace, a reduction of about 98%.

A wallet Popover was also opened and dismissed through CDP after the change to verify that deferring closed-state measurement did not break the real open path.

## 5. Avoid no-op Market watchlist atom updates

The Market refresh path could receive a watchlist payload that was structurally identical to the value already stored in Jotai. It still created a new wrapper and wrote the atom.

That write changed identity and notified subscribers even though no user-visible data had changed. On a mounted Market tree, the resulting subscriber work added to the cost of returning to or leaving the page.

flushWatchListV2Atom now compares the incoming payload with the current watchlist data:

- if the payload is identical, it returns the current value and skips the atom write;
- if the payload changed, it performs the same update as before.

The refresh request itself is not removed. The server remains authoritative and changed watchlist data still propagates normally. This optimization only turns an identical response into a true no-op.

## 6. Earn-specific render and refresh stabilization

Earn had additional page-local fan-out after the shared focus problem was reduced, so it required a second layer of optimization.

### Remove desktop page-wide focus state toggles

BasicEarnHome previously copied top-level focus into React state through isEarnTabFocused and isEarnDataActive. Every desktop focus change could therefore rerender the whole Earn page independently of the shared data-hook renders.

On desktop:

- pure focus and analytics bookkeeping now uses refs;
- the data-active value remains stable because desktop data hooks already gate their work with the new route-focus ref;
- real focus edges still trigger entry analytics, FAQ refresh, asset prefetch, and page refresh behavior where required.

The native/mobile state-driven behavior is left intact.

### Memoize the mounted Earn tab tree

After the first focus mounts the Earn tab content, the mounted inner tree now goes through a memoized component boundary. An unrelated parent update can bail out when its props are unchanged instead of walking the complete Earn tab tree again.

This keeps the existing mounted-tab behavior. It does not unmount Earn on blur or discard the user's warm page state.

### Move inner default-tab synchronization off rendered focus

EarnMainTabs previously subscribed to rendered route focus so it could restore the correct inner default tab. That meant the synchronization mechanism itself caused another render.

It now listens through the non-rendering route-focus ref and performs the same tab synchronization on a real focus edge. The route focus remains an event for the imperative tab controller, not a reason to render the tab tree.

### Keep FAQ refresh fresh without loading-state churn

A focus refresh previously reused the normal promise runner, which could reset existing FAQ content into a loading path even when the page already had valid content.

The explicit FAQ refresh now:

1. requests the latest FAQ list;
2. retains the current rendered content during the request;
3. compares the result with the current list;
4. reuses the current state when the response is identical;
5. updates the state normally when the FAQ data changed.

The page still refreshes on the intended focus edge; it simply avoids blank/loading churn and identical state writes.

### Avoid identical Earn asset atom and DB writes

Earn available-assets refreshes could also produce an array identical to the current value. That previously rewrote the Earn atom and synchronized the same data to the database.

The Earn action now compares by asset type before writing:

- an identical available-assets array skips both the atom update and DB synchronization;
- changed data follows the existing atom and persistence path.

Together, these changes reduce Earn's focus-time render and write amplification without weakening freshness or changing the native lifecycle.

## 7. Results, interpretation, and validation

### Formal warm CDP trace

The table below reports the synchronous click block from comparable warm traced runs. These numbers include tracing overhead, so they are used primarily for before/after attribution rather than as the only user-perceived latency metric.

| Tab | Baseline | After | Change |
| --- | ---: | ---: | ---: |
| Market | 543.6 ms | 159.0 ms | -70.8% |
| Swap | 304.5 ms | 164.0 ms | -46.1% |
| Perp | 232.0 ms | 318.9 ms | +37.5% |
| Earn | 434.9 ms | 386.9 ms | -11.0% |
| Refer Friends | 127.7 ms | 84.3 ms | -34.0% |
| Discovery | 123.4 ms | 90.0 ms | -27.1% |
| Wallet | 166.3 ms | 134.9 ms | -18.9% |

Across all seven tabs:

- mean synchronous click blocking fell from approximately 276 ms to 191 ms, about a 31% reduction;
- the worst measured tab fell from 543.6 ms to 386.9 ms, about a 29% reduction;
- Market style recalculation fell from 427.1 ms to 7.7 ms, about a 98% reduction.

Perp is intentionally shown as a regression in the formal trace: 232.0 ms to 318.9 ms. The result does not support claiming that every individual formal trace improved. Perp includes the mounted TradingView webview and has more run-to-run scheduling variance; the actual TradingView webview was verified to be present, but this PR does not assign the regression to it without stronger evidence. The after value remains below the previous 1–2 second perceived-stall range, and the trace-free measurements below are reported separately rather than hiding this result.

### Trace-free stable warm paint

Repeated warm switching without DevTools tracing produced the following click-to-paint ranges:

| Tab | Stable warm paint |
| --- | ---: |
| Market | 0.52–0.81 s |
| Swap | 0.30–0.57 s |
| Perp | 0.59–0.62 s |
| Earn | 0.47–0.52 s |
| Refer Friends | approximately 0.21 s |
| Discovery | 0.28–0.30 s |
| Wallet | 0.42–0.46 s |

These values measure the packaged application in the preserved wallet profile and are closer to the user-visible result than the instrumented trace alone. Cold-pass timings remain dependent on first-time page initialization, API responses, and embedded content; they were measured separately and were not mixed into the warm-switch claim.

### Settled idle probe

After allowing the application to settle for 20 seconds, a 10-second observation window recorded:

- 0 long tasks;
- 0 new resources.

This supports the conclusion that the remaining warm-tab cost is switch-time renderer work rather than continuous background loading.

### Functional verification

The CDP validation covered:

- Wallet;
- Market;
- Swap;
- Perps, including the real TradingView webview target;
- Earn;
- Refer Friends;
- Discovery;
- the existing funded test wallet and visible balance;
- opening and dismissing a wallet Popover;
- a complete cold pass followed by a settled warm pass;
- repeated trace-free warm switching.

The existing Electron profile was never cleared, so the validation did not fall back to the new-wallet onboarding state.

### Build and automated checks

All three requested release-build steps completed successfully:

    yarn workspace @onekeyhq/desktop build:renderer
    yarn workspace @onekeyhq/desktop build:main
    yarn workspace @onekeyhq/desktop build:electron:win --publish never

Additional checks:

- 34 focused Jest tests passed;
- Prettier passed for the changed files;
- type-aware Oxlint passed for the changed files;
- the benchmark script syntax check passed.

Full tsgo --noEmit still reports seven pre-existing errors outside this diff:

- six missing exports from react-native-collapsible-tab-view;
- HardwareErrorCode.PinMismatch.

Those errors were present outside the changed surface and are recorded here so the validation boundary is explicit.

## Why this approach

The optimization is deliberately centered on the highest-fan-out synchronous work:

1. measure a real packaged Windows build with the user's persistent profile;
2. separate cold initialization, warm switching, tracing overhead, and settled idle behavior;
3. use traces and CPU/style metrics to locate the click-to-frame critical path;
4. remove shared render amplification before adding page-specific workarounds;
5. preserve refresh and navigation semantics, then prove the non-rendering invariant with focused tests;
6. apply page-local equality and memoization only where traces still showed avoidable work;
7. rebuild the release and validate through the same CDP path used for the baseline.

This avoids improving a synthetic empty profile while regressing the real funded-wallet workflow, and it avoids exchanging warm switch jank for repeated cold-page initialization.