### PR TITLE
fix: address ten recent issues(OK-57834, OK-57836, OK-57826, OK-57787, OK-57752, OK-57547, OK-57451, OK-56469, OK-56028, OK-54672)

### DIFF
--- a/packages/kit-bg/src/services/ServiceSwap.quoteEventRequest.test.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.quoteEventRequest.test.ts
@@ -1,0 +1,143 @@
+/** @jest-environment node */
+
+import EventSource from '@onekeyhq/shared/src/eventSource';
+import type { IFetchSwapQuoteParams } from '@onekeyhq/shared/types/swap/types';
+import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
+
+import ServiceSwap from './ServiceSwap';
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundClass: () => (constructor: unknown) => constructor,
+  backgroundMethod:
+    () =>
+    (_target: object, _propertyKey: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+  backgroundMethodForDev:
+    () =>
+    (_target: object, _propertyKey: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+  toastIfError:
+    () =>
+    (_target: object, _propertyKey: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+}));
+
+jest.mock('@onekeyhq/shared/src/eventSource', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    addEventListener: jest.fn(),
+    close: jest.fn(),
+    removeAllEventListeners: jest.fn(),
+  })),
+}));
+
+jest.mock('@onekeyhq/shared/src/request/Interceptor', () => ({
+  getRequestHeaders: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('@onekeyhq/shared/src/request/customUA', () => ({
+  withCustomUAHeaders: jest
+    .fn()
+    .mockImplementation(
+      async (_url: string, headers: Record<string, string>) => headers,
+    ),
+}));
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function buildQuoteParams(toTokenAddress: string): IFetchSwapQuoteParams {
+  return {
+    accountId: 'account-1',
+    autoSlippage: true,
+    fromToken: {
+      contractAddress: '',
+      decimals: 18,
+      isNative: true,
+      networkId: 'evm--56',
+      symbol: 'BNB',
+    },
+    fromTokenAmount: '1',
+    protocol: ESwapTabSwitchType.SWAP,
+    slippagePercentage: 0.5,
+    toToken: {
+      contractAddress: toTokenAddress,
+      decimals: 18,
+      isNative: false,
+      networkId: 'evm--56',
+      symbol: 'TOKEN',
+    },
+    userAddress: '0xaccount',
+  };
+}
+
+function createService() {
+  const backgroundApi = {
+    serviceAccount: {
+      getAccountDeviceSafe: jest.fn().mockResolvedValue(undefined),
+    },
+    serviceAccountProfile: {
+      _getRequestWalletType: jest.fn().mockResolvedValue('hd'),
+    },
+  };
+  const service = new ServiceSwap({ backgroundApi });
+  jest.spyOn(service, 'getDenySingleSwapProvider').mockResolvedValue(undefined);
+  jest.spyOn(service as never, 'getClient').mockResolvedValue({
+    getUri: ({ params }: { params: { toTokenAddress: string } }) =>
+      `https://swap.test/${params.toTokenAddress}`,
+  } as never);
+  return service;
+}
+
+describe('ServiceSwap quote event request ownership', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not let an older preflight replace the latest EventSource', async () => {
+    const stalePreflight = createDeferred<string | undefined>();
+    const service = createService();
+    jest
+      .spyOn(service, 'getDenyCrossChainProvider')
+      .mockImplementationOnce(() => stalePreflight.promise)
+      .mockResolvedValue(undefined);
+
+    const staleRequest = service.fetchQuotesEvents(buildQuoteParams('0xstale'));
+    await Promise.resolve();
+    await service.fetchQuotesEvents(buildQuoteParams('0xlatest'));
+
+    expect(EventSource).toHaveBeenCalledTimes(1);
+    expect(EventSource).toHaveBeenLastCalledWith(
+      'https://swap.test/0xlatest',
+      expect.any(Object),
+    );
+
+    stalePreflight.resolve(undefined);
+    await staleRequest;
+
+    expect(EventSource).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not install an EventSource after cancellation', async () => {
+    const stalePreflight = createDeferred<string | undefined>();
+    const service = createService();
+    jest
+      .spyOn(service, 'getDenyCrossChainProvider')
+      .mockImplementationOnce(() => stalePreflight.promise);
+
+    const staleRequest = service.fetchQuotesEvents(
+      buildQuoteParams('0xcancelled'),
+    );
+    await Promise.resolve();
+    await service.cancelFetchQuoteEvents();
+    stalePreflight.resolve(undefined);
+    await staleRequest;
+
+    expect(EventSource).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -489,6 +489,8 @@ export default class ServiceSwap extends ServiceBase {
 
   private _quoteEventSourcePolyfill?: EventSourcePolyfill;
 
+  private _quoteEventRequestId = 0;
+
   private _tokenDetailAbortControllerMap: Record<
     ESwapDirectionType,
     AbortController | undefined
@@ -574,6 +576,7 @@ export default class ServiceSwap extends ServiceBase {
 
   @backgroundMethod()
   async cancelFetchQuoteEvents() {
+    this._quoteEventRequestId += 1;
     if (this._quoteEventSource) {
       this._quoteEventSource.close();
       this._quoteEventSource = undefined;
@@ -979,19 +982,26 @@ export default class ServiceSwap extends ServiceBase {
     toTokenAmount,
     userMarketPriceRate,
   }: IFetchSwapQuoteParams) {
+    const requestId = this._quoteEventRequestId + 1;
+    this._quoteEventRequestId = requestId;
+    const isCurrentRequest = () => this._quoteEventRequestId === requestId;
     await this.removeQuoteEventSourceListeners();
+    if (!isCurrentRequest()) return;
     const denyCrossChainProvider = await this.getDenyCrossChainProvider(
       fromToken.networkId,
       toToken.networkId,
     );
+    if (!isCurrentRequest()) return;
     const denySingleSwapProvider = await this.getDenySingleSwapProvider(
       fromToken.networkId,
       toToken.networkId,
     );
+    if (!isCurrentRequest()) return;
     const walletDevice =
       await this.backgroundApi.serviceAccount.getAccountDeviceSafe({
         accountId: accountId ?? '',
       });
+    if (!isCurrentRequest()) return;
     const params: IFetchQuotesParams = {
       fromTokenAddress: fromToken.contractAddress,
       toTokenAddress: toToken.contractAddress,
@@ -1014,17 +1024,19 @@ export default class ServiceSwap extends ServiceBase {
       walletDeviceType: walletDevice?.deviceType,
       ...(incognito ? { incognito } : {}),
     };
-    const swapEventUrl = (
-      await this.getClient(EServiceEndpointEnum.Swap)
-    ).getUri({
+    const client = await this.getClient(EServiceEndpointEnum.Swap);
+    if (!isCurrentRequest()) return;
+    const swapEventUrl = client.getUri({
       url: '/swap/v1/quote/events',
       params,
     });
     let headers = await getRequestHeaders();
+    if (!isCurrentRequest()) return;
     const walletType =
       await this.backgroundApi.serviceAccountProfile._getRequestWalletType({
         accountId,
       });
+    if (!isCurrentRequest()) return;
     headers = {
       ...headers,
       ...(accountId
@@ -1037,6 +1049,7 @@ export default class ServiceSwap extends ServiceBase {
       swapEventUrl,
       headers as Record<string, string>,
     );
+    if (!isCurrentRequest()) return;
     if (platformEnv.isExtension) {
       if (this._quoteEventSourcePolyfill) {
         this._quoteEventSourcePolyfill.close();
@@ -1046,6 +1059,7 @@ export default class ServiceSwap extends ServiceBase {
         headers: headers as Record<string, string>,
       });
       this._quoteEventSourcePolyfill.onmessage = (event) => {
+        if (!isCurrentRequest()) return;
         appEventBus.emit(EAppEventBusNames.SwapQuoteEvent, {
           type: 'message',
           event: {
@@ -1060,6 +1074,7 @@ export default class ServiceSwap extends ServiceBase {
         });
       };
       this._quoteEventSourcePolyfill.onerror = async (event) => {
+        if (!isCurrentRequest()) return;
         const errorEvent = event as {
           error?: string;
           type: string;
@@ -1090,6 +1105,7 @@ export default class ServiceSwap extends ServiceBase {
         await this.cancelFetchQuoteEvents();
       };
       this._quoteEventSourcePolyfill.onopen = () => {
+        if (!isCurrentRequest()) return;
         appEventBus.emit(EAppEventBusNames.SwapQuoteEvent, {
           type: 'open',
           event: { type: 'open' },
@@ -1110,6 +1126,7 @@ export default class ServiceSwap extends ServiceBase {
         timeout: swapQuoteEventTimeout,
       });
       this._quoteEventSource.addEventListener('open', (event) => {
+        if (!isCurrentRequest()) return;
         appEventBus.emit(EAppEventBusNames.SwapQuoteEvent, {
           type: 'open',
           event,
@@ -1119,6 +1136,7 @@ export default class ServiceSwap extends ServiceBase {
         });
       });
       this._quoteEventSource.addEventListener('message', (event) => {
+        if (!isCurrentRequest()) return;
         appEventBus.emit(EAppEventBusNames.SwapQuoteEvent, {
           type: 'message',
           event,
@@ -1128,6 +1146,7 @@ export default class ServiceSwap extends ServiceBase {
         });
       });
       this._quoteEventSource.addEventListener('done', (event) => {
+        if (!isCurrentRequest()) return;
         appEventBus.emit(EAppEventBusNames.SwapQuoteEvent, {
           type: 'done',
           event,
@@ -1137,6 +1156,7 @@ export default class ServiceSwap extends ServiceBase {
         });
       });
       this._quoteEventSource.addEventListener('close', (event) => {
+        if (!isCurrentRequest()) return;
         appEventBus.emit(EAppEventBusNames.SwapQuoteEvent, {
           type: 'close',
           event,
@@ -1146,6 +1166,7 @@ export default class ServiceSwap extends ServiceBase {
         });
       });
       this._quoteEventSource.addEventListener('error', (event) => {
+        if (!isCurrentRequest()) return;
         appEventBus.emit(EAppEventBusNames.SwapQuoteEvent, {
           type: 'error',
           event,

--- a/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
@@ -67,6 +67,7 @@ import {
   resolveProtocolLendingRepayAmountState,
   resolveProtocolLendingRepayDebtState,
   resolveProtocolLendingWithdrawAmountState,
+  shouldShowProtocolLendingHealthFactorSkeleton,
 } from './protocolLendingActionUtils';
 import {
   type IProtocolPositionActionSuccessParams,
@@ -1290,6 +1291,17 @@ function ProtocolLendingActionBorrowContent({
     }
   };
 
+  const isActionRequestDisabled =
+    !accountId ||
+    !networkId ||
+    !source.provider ||
+    !source.marketAddress ||
+    !reserveAddress ||
+    isBorrowDataLoading ||
+    isRepayWalletBalancePending ||
+    hasBorrowLoadError ||
+    isAmountInsufficient;
+
   const actionResult = useUniversalBorrowAction({
     action: actionType,
     accountId,
@@ -1298,11 +1310,7 @@ function ProtocolLendingActionBorrowContent({
     marketAddress: source.marketAddress,
     reserveAddress,
     amount,
-    isDisabled:
-      isBorrowDataLoading ||
-      isRepayWalletBalancePending ||
-      hasBorrowLoadError ||
-      isAmountInsufficient,
+    isDisabled: isActionRequestDisabled,
     repayAll: actionType === 'repay' ? isFullClose : undefined,
   });
 
@@ -1619,7 +1627,12 @@ function ProtocolLendingActionBorrowContent({
     actionResult.checkAmountResult === false ||
     actionResult.checkAmountLoading;
   const shouldShowHealthFactorSkeleton =
-    !healthFactor && isAmountPositive && !actionResult.transactionConfirmation;
+    shouldShowProtocolLendingHealthFactorSkeleton({
+      hasHealthFactor: Boolean(healthFactor),
+      hasTransactionConfirmation: Boolean(actionResult.transactionConfirmation),
+      isAmountPositive,
+      isActionRequestDisabled,
+    });
   // Belt-and-suspenders: a selectable Aave entry whose asset fetch AND protocol
   // info both come back empty falls back to the empty state instead of crashing.
   const isEmpty =

--- a/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
@@ -98,6 +98,7 @@ const DEFI_ACTION_HERO_MIN_HEIGHT = 128;
 // two heroes read as one, and so a short amount can't grow past the reserved
 // height (SendAutoSizeAmountInput otherwise ramps up to ~84px on desktop).
 const MANUAL_AMOUNT_INPUT_MAX_FONT_SIZE = 40;
+const PERCENT_INPUT_HORIZONTAL_OVERFLOW = 12;
 const resolveActionTxAmount = resolveDeFiActionTxAmount as (params: {
   percentageAction: boolean;
   percent?: number;
@@ -1250,35 +1251,54 @@ function ProtocolPositionActionPercentHero({
       gap="$2"
     >
       <XStack alignItems="center" justifyContent="center" gap="$1">
-        <Input
-          testID="defi-position-action-percent-input"
-          value={percentText}
-          onChangeText={onChangePercentText}
-          keyboardType="number-pad"
-          maxLength={maxLength}
-          onFocus={onFocus}
-          onKeyPress={handleKeyPress}
-          autoCorrect={false}
-          spellCheck={false}
-          autoComplete="off"
-          textContentType="none"
-          unstyled
-          borderWidth={0}
-          bg="transparent"
-          p="$0"
-          h={Math.ceil(MANUAL_AMOUNT_INPUT_MAX_FONT_SIZE * 1.4)}
-          size="large"
-          fontSize={MANUAL_AMOUNT_INPUT_MAX_FONT_SIZE}
-          fontWeight="500"
-          textAlign="right"
-          placeholder="0"
-          placeholderTextColor="$textDisabled"
-          containerProps={{
-            width: 96,
-            borderWidth: 0,
-            bg: 'transparent',
-          }}
-        />
+        <Stack position="relative">
+          <SizableText
+            opacity={0}
+            pointerEvents="none"
+            aria-hidden
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+            fontSize={MANUAL_AMOUNT_INPUT_MAX_FONT_SIZE}
+            lineHeight={Math.ceil(MANUAL_AMOUNT_INPUT_MAX_FONT_SIZE * 1.4)}
+            fontWeight="500"
+            numberOfLines={1}
+          >
+            {percentText || '0'}
+          </SizableText>
+          <Input
+            testID="defi-position-action-percent-input"
+            value={percentText}
+            onChangeText={onChangePercentText}
+            keyboardType="number-pad"
+            maxLength={maxLength}
+            onFocus={onFocus}
+            onKeyPress={handleKeyPress}
+            autoCorrect={false}
+            spellCheck={false}
+            autoComplete="off"
+            textContentType="none"
+            unstyled
+            borderWidth={0}
+            bg="transparent"
+            p="$0"
+            h={Math.ceil(MANUAL_AMOUNT_INPUT_MAX_FONT_SIZE * 1.4)}
+            size="large"
+            fontSize={MANUAL_AMOUNT_INPUT_MAX_FONT_SIZE}
+            fontWeight="500"
+            textAlign="center"
+            placeholder="0"
+            placeholderTextColor="$textDisabled"
+            containerProps={{
+              position: 'absolute',
+              top: 0,
+              right: -PERCENT_INPUT_HORIZONTAL_OVERFLOW,
+              bottom: 0,
+              left: -PERCENT_INPUT_HORIZONTAL_OVERFLOW,
+              borderWidth: 0,
+              bg: 'transparent',
+            }}
+          />
+        </Stack>
         <SizableText
           fontSize={MANUAL_AMOUNT_INPUT_MAX_FONT_SIZE}
           lineHeight={Math.ceil(MANUAL_AMOUNT_INPUT_MAX_FONT_SIZE * 1.4)}

--- a/packages/kit/src/components/DeFi/protocolLendingActionUtils.test.ts
+++ b/packages/kit/src/components/DeFi/protocolLendingActionUtils.test.ts
@@ -6,6 +6,7 @@ import {
   resolveProtocolLendingRepayAmountState,
   resolveProtocolLendingRepayDebtState,
   resolveProtocolLendingWithdrawAmountState,
+  shouldShowProtocolLendingHealthFactorSkeleton,
 } from './protocolLendingActionUtils';
 
 describe('protocolLendingActionUtils', () => {
@@ -233,6 +234,39 @@ describe('protocolLendingActionUtils', () => {
       primaryLabel: 'available',
       secondaryWalletBalance: '2',
     });
+  });
+
+  it('shows a health-factor skeleton while a valid positive amount is pending', () => {
+    expect(
+      shouldShowProtocolLendingHealthFactorSkeleton({
+        hasHealthFactor: false,
+        hasTransactionConfirmation: false,
+        isAmountPositive: true,
+        isActionRequestDisabled: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not show a health-factor skeleton when the action request is disabled', () => {
+    expect(
+      shouldShowProtocolLendingHealthFactorSkeleton({
+        hasHealthFactor: false,
+        hasTransactionConfirmation: false,
+        isAmountPositive: true,
+        isActionRequestDisabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not show a health-factor skeleton after confirmation resolves', () => {
+    expect(
+      shouldShowProtocolLendingHealthFactorSkeleton({
+        hasHealthFactor: false,
+        hasTransactionConfirmation: true,
+        isAmountPositive: true,
+        isActionRequestDisabled: false,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/kit/src/components/DeFi/protocolLendingActionUtils.ts
+++ b/packages/kit/src/components/DeFi/protocolLendingActionUtils.ts
@@ -225,6 +225,25 @@ export function resolveProtocolLendingBalanceContext({
   };
 }
 
+export function shouldShowProtocolLendingHealthFactorSkeleton({
+  hasHealthFactor,
+  hasTransactionConfirmation,
+  isAmountPositive,
+  isActionRequestDisabled,
+}: {
+  hasHealthFactor: boolean;
+  hasTransactionConfirmation: boolean;
+  isAmountPositive: boolean;
+  isActionRequestDisabled: boolean;
+}) {
+  return (
+    !hasHealthFactor &&
+    !hasTransactionConfirmation &&
+    isAmountPositive &&
+    !isActionRequestDisabled
+  );
+}
+
 // The server's /earn/v1/borrow/markets list is the per-environment source of
 // truth for which (provider, network, market) combos the borrow stack
 // supports. Fail-closed by design: no markets (still loading, fetch failed,

--- a/packages/kit/src/components/SlippageSettingDialog/SlippageInput.tsx
+++ b/packages/kit/src/components/SlippageSettingDialog/SlippageInput.tsx
@@ -139,6 +139,7 @@ const BaseSlippageInput = ({
       disabled={swapSlippage.key === ESwapSlippageSegmentKey.AUTO}
       placeholder={displaySlippage}
       onChangeText={handleTextChange}
+      keyboardType="decimal-pad"
       {...props}
     />
   );

--- a/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
@@ -45,6 +45,7 @@ import {
   swapQuoteListAtom,
   swapSelectFromTokenAtom,
   swapSelectToTokenAtom,
+  swapSelectedFromTokenBalanceAtom,
   swapSelectedTokensColdStartContextAtom,
   swapStockExecutionTokenSyncIdAtom,
   swapStockExecutionTokensAtom,
@@ -991,6 +992,7 @@ describe('useSwapActions', () => {
       storeInstance.set(swapTypeSwitchAtom(), ESwapTabSwitchType.STOCK);
       storeInstance.set(swapSelectFromTokenAtom(), usdcToken);
       storeInstance.set(swapSelectToTokenAtom(), appleStockToken);
+      storeInstance.set(swapSelectedFromTokenBalanceAtom(), '999');
       storeInstance.set(swapFromTokenAmountAtom(), {
         value: '10',
         isInput: true,
@@ -1039,6 +1041,7 @@ describe('useSwapActions', () => {
     expect(store.get(swapSelectedTokensColdStartContextAtom())).toBeUndefined();
     expect(store.get(swapInitialSelectedTokensSyncedAtom())).toBe(false);
     expect(store.get(swapLastNonLimitSelectedTokensAtom())).toBeUndefined();
+    expect(store.get(swapSelectedFromTokenBalanceAtom())).toBe('');
 
     await act(async () => {
       await result.current.actions.swapTypeSwitchAction(
@@ -1084,6 +1087,7 @@ describe('useSwapActions', () => {
 
     store.set(swapSelectFromTokenAtom(), usdcToken);
     store.set(swapSelectToTokenAtom(), appleStockToken);
+    store.set(swapSelectedFromTokenBalanceAtom(), '999');
 
     await act(async () => {
       await result.current.actions.swapTypeSwitchAction(
@@ -1105,6 +1109,7 @@ describe('useSwapActions', () => {
       value: '',
       isInput: false,
     });
+    expect(store.get(swapSelectedFromTokenBalanceAtom())).toBe('');
   });
 
   it('blocks Stock quote before Stock execution tokens own the selected pair', async () => {

--- a/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
@@ -6,6 +6,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { createStore } from 'jotai';
 
 import type { IAccountSelectorActiveAccountInfo } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
+import { ESwapDirection } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
 import type { useSwapAddressInfo } from '@onekeyhq/kit/src/views/Swap/hooks/useSwapAccount';
 import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import { settingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -22,7 +23,9 @@ import type {
 import {
   EProtocolOfExchange,
   ESwapDirectionType,
+  ESwapProTradeType,
   ESwapQuoteKind,
+  ESwapRateDifferenceUnit,
   ESwapSlippageSegmentKey,
   ESwapTabSwitchType,
 } from '@onekeyhq/shared/types/swap/types';
@@ -30,11 +33,19 @@ import {
 import { useSwapActions } from './actions';
 import {
   ProviderJotaiContextSwap,
+  rateDifferenceAtom,
   swapAlertsAtom,
+  swapAutoSlippageSuggestedValueAtom,
+  swapBuildTxFetchingAtom,
   swapFromTokenAmountAtom,
   swapInitialSelectedTokensSyncedAtom,
   swapLastNonLimitSelectedTokensAtom,
   swapNetworks,
+  swapProDirectionAtom,
+  swapProInputAmountAtom,
+  swapProSelectTokenAtom,
+  swapProTradeTypeAtom,
+  swapProUseSelectBuyTokenAtom,
   swapQuoteActionLockAtom,
   swapQuoteCurrentEventProviderKeysAtom,
   swapQuoteCurrentEventReceivedCountAtom,
@@ -42,11 +53,18 @@ import {
   swapQuoteEventCompletedAtom,
   swapQuoteEventErrorAtom,
   swapQuoteEventTotalCountAtom,
+  swapQuoteFetchingAtom,
   swapQuoteListAtom,
+  swapQuoteRequestIdAtom,
   swapSelectFromTokenAtom,
   swapSelectToTokenAtom,
   swapSelectedFromTokenBalanceAtom,
+  swapSelectedToTokenBalanceAtom,
   swapSelectedTokensColdStartContextAtom,
+  swapShouldRefreshQuoteAtom,
+  swapSpeedQuoteFetchingAtom,
+  swapSpeedQuoteRequestIdAtom,
+  swapSpeedQuoteResultAtom,
   swapStockExecutionTokenSyncIdAtom,
   swapStockExecutionTokensAtom,
   swapStockSelectedTokenAtom,
@@ -79,6 +97,17 @@ const mockFetchQuotesEvents: jest.MockedFunction<
 const mockCloseApproving: jest.MockedFunction<() => Promise<void>> = jest.fn();
 const mockCancelFetchQuoteEvents: jest.MockedFunction<() => Promise<void>> =
   jest.fn();
+const mockCancelFetchSpeedSwapQuote: jest.MockedFunction<() => Promise<void>> =
+  jest.fn();
+const mockFetchSpeedSwapQuote: jest.MockedFunction<
+  (params: unknown) => Promise<IFetchQuoteResult[]>
+> = jest.fn();
+const mockSetSwapProSelectToken: jest.MockedFunction<
+  (token: ISwapToken) => Promise<void>
+> = jest.fn();
+const mockGetSwapProSelectToken: jest.MockedFunction<
+  () => Promise<ISwapToken | undefined>
+> = jest.fn();
 const mockSetSwapNetworksSortRawData: jest.MockedFunction<
   (params: { data: unknown[] }) => Promise<void>
 > = jest.fn();
@@ -92,11 +121,18 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
       fetchQuotesEvents: (params: unknown) => mockFetchQuotesEvents(params),
       closeApproving: () => mockCloseApproving(),
       cancelFetchQuoteEvents: () => mockCancelFetchQuoteEvents(),
+      cancelFetchSpeedSwapQuote: () => mockCancelFetchSpeedSwapQuote(),
+      fetchSpeedSwapQuote: (params: unknown) => mockFetchSpeedSwapQuote(params),
     },
     simpleDb: {
       swapNetworksSort: {
         setRawData: (params: { data: unknown[] }) =>
           mockSetSwapNetworksSortRawData(params),
+      },
+      swapProSelectToken: {
+        getSwapProSelectToken: () => mockGetSwapProSelectToken(),
+        setSwapProSelectToken: (token: ISwapToken) =>
+          mockSetSwapProSelectToken(token),
       },
     },
   },
@@ -115,6 +151,10 @@ const bnbToken: ISwapToken = {
   symbol: 'BNB',
   decimals: 18,
   isNative: true,
+};
+const proBnbToken = {
+  ...bnbToken,
+  speedSwapDefaultAmount: [0.01, 0.1, 1],
 };
 const usdcToken: ISwapToken = {
   networkId: 'evm--56',
@@ -251,6 +291,16 @@ async function withMutedConsoleError(fn: () => Promise<void>) {
   }
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
 function createWrapper(
   setup?: (store: ReturnType<typeof createStore>) => void,
 ) {
@@ -264,6 +314,10 @@ describe('useSwapActions', () => {
     mockSetSwapNetworksSortRawData.mockResolvedValue(undefined);
     mockCloseApproving.mockResolvedValue(undefined);
     mockCancelFetchQuoteEvents.mockResolvedValue(undefined);
+    mockCancelFetchSpeedSwapQuote.mockResolvedValue(undefined);
+    mockFetchSpeedSwapQuote.mockResolvedValue([]);
+    mockSetSwapProSelectToken.mockResolvedValue(undefined);
+    mockGetSwapProSelectToken.mockResolvedValue(undefined);
     mockFetchQuotesEvents.mockResolvedValue(undefined);
     jest.spyOn(settingsAtom, 'get').mockResolvedValue({
       swapEnableRecipientAddress: false,
@@ -964,7 +1018,7 @@ describe('useSwapActions', () => {
     await act(async () => {
       await result.current.actions.resetSwapTokenData(ESwapDirectionType.FROM);
       await result.current.actions.resetSwapTokenData(ESwapDirectionType.TO);
-      await result.current.actions.swapTypeSwitchAction(
+      result.current.actions.swapTypeSwitchAction(
         ESwapTabSwitchType.LIMIT,
         'evm--56',
       );
@@ -993,6 +1047,7 @@ describe('useSwapActions', () => {
       storeInstance.set(swapSelectFromTokenAtom(), usdcToken);
       storeInstance.set(swapSelectToTokenAtom(), appleStockToken);
       storeInstance.set(swapSelectedFromTokenBalanceAtom(), '999');
+      storeInstance.set(swapSelectedToTokenBalanceAtom(), '888');
       storeInstance.set(swapFromTokenAmountAtom(), {
         value: '10',
         isInput: true,
@@ -1018,8 +1073,8 @@ describe('useSwapActions', () => {
       },
     );
 
-    await act(async () => {
-      await result.current.actions.swapTypeSwitchAction(
+    act(() => {
+      result.current.actions.swapTypeSwitchAction(
         ESwapTabSwitchType.LIMIT,
         'evm--56',
       );
@@ -1042,9 +1097,10 @@ describe('useSwapActions', () => {
     expect(store.get(swapInitialSelectedTokensSyncedAtom())).toBe(false);
     expect(store.get(swapLastNonLimitSelectedTokensAtom())).toBeUndefined();
     expect(store.get(swapSelectedFromTokenBalanceAtom())).toBe('');
+    expect(store.get(swapSelectedToTokenBalanceAtom())).toBe('');
 
-    await act(async () => {
-      await result.current.actions.swapTypeSwitchAction(
+    act(() => {
+      result.current.actions.swapTypeSwitchAction(
         ESwapTabSwitchType.SWAP,
         'evm--56',
       );
@@ -1078,8 +1134,8 @@ describe('useSwapActions', () => {
       },
     );
 
-    await act(async () => {
-      await result.current.actions.swapTypeSwitchAction(
+    act(() => {
+      result.current.actions.swapTypeSwitchAction(
         ESwapTabSwitchType.STOCK,
         'evm--56',
       );
@@ -1089,8 +1145,8 @@ describe('useSwapActions', () => {
     store.set(swapSelectToTokenAtom(), appleStockToken);
     store.set(swapSelectedFromTokenBalanceAtom(), '999');
 
-    await act(async () => {
-      await result.current.actions.swapTypeSwitchAction(
+    act(() => {
+      result.current.actions.swapTypeSwitchAction(
         ESwapTabSwitchType.SWAP,
         'evm--56',
       );
@@ -1110,6 +1166,149 @@ describe('useSwapActions', () => {
       isInput: false,
     });
     expect(store.get(swapSelectedFromTokenBalanceAtom())).toBe('');
+  });
+
+  it('atomically opens a non-Stock position with the restored Swap pair', () => {
+    const { store, Wrapper } = createWrapperWithStore((storeInstance) => {
+      storeInstance.set(swapTypeSwitchAtom(), ESwapTabSwitchType.STOCK);
+      storeInstance.set(swapSelectFromTokenAtom(), usdcToken);
+      storeInstance.set(swapSelectToTokenAtom(), appleStockToken);
+      storeInstance.set(swapSelectedFromTokenBalanceAtom(), '99');
+      storeInstance.set(swapSelectedToTokenBalanceAtom(), '88');
+      storeInstance.set(swapLastNonLimitSelectedTokensAtom(), {
+        sourceSwapType: ESwapTabSwitchType.SWAP,
+        fromToken: bnbToken,
+        toToken: usdtToken,
+      });
+    });
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.switchStockPositionToSwapAction(usdcToken);
+    });
+
+    expect(store.get(swapTypeSwitchAtom())).toBe(ESwapTabSwitchType.SWAP);
+    expect(store.get(swapSelectFromTokenAtom())).toBe(usdcToken);
+    expect(store.get(swapSelectToTokenAtom())).toBe(usdtToken);
+    expect(store.get(swapSelectedFromTokenBalanceAtom())).toBe('');
+    expect(store.get(swapSelectedToTokenBalanceAtom())).toBe('');
+  });
+
+  it('maps a Pro buy back to Swap while preserving the input amount', () => {
+    const { store, Wrapper } = createWrapperWithStore((storeInstance) => {
+      storeInstance.set(swapTypeSwitchAtom(), ESwapTabSwitchType.LIMIT);
+      storeInstance.set(swapLastNonLimitSelectedTokensAtom(), {
+        sourceSwapType: ESwapTabSwitchType.SWAP,
+        fromToken: bnbToken,
+        toToken: usdtToken,
+      });
+    });
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.switchSwapProToSwapAction({
+        direction: ESwapDirection.BUY,
+        inputAmount: '2',
+        inputToken: bnbToken,
+        selectedToken: usdcToken,
+      });
+    });
+
+    expect(store.get(swapTypeSwitchAtom())).toBe(ESwapTabSwitchType.SWAP);
+    expect(store.get(swapSelectFromTokenAtom())).toBe(bnbToken);
+    expect(store.get(swapSelectToTokenAtom())).toBe(usdcToken);
+    expect(store.get(swapFromTokenAmountAtom())).toEqual({
+      value: '2',
+      isInput: true,
+    });
+  });
+
+  it('maps a Pro sell back to a compatible Swap pair', () => {
+    const { store, Wrapper } = createWrapperWithStore((storeInstance) => {
+      storeInstance.set(swapTypeSwitchAtom(), ESwapTabSwitchType.LIMIT);
+      storeInstance.set(swapLastNonLimitSelectedTokensAtom(), {
+        sourceSwapType: ESwapTabSwitchType.SWAP,
+        fromToken: bnbToken,
+        toToken: usdtToken,
+      });
+    });
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.switchSwapProToSwapAction({
+        direction: ESwapDirection.SELL,
+        inputAmount: '3',
+        outputToken: usdcToken,
+        selectedToken: usdtToken,
+      });
+    });
+
+    expect(store.get(swapTypeSwitchAtom())).toBe(ESwapTabSwitchType.SWAP);
+    expect(store.get(swapSelectFromTokenAtom())).toBe(usdtToken);
+    expect(store.get(swapSelectToTokenAtom())).toBe(usdcToken);
+    expect(store.get(swapFromTokenAmountAtom())).toEqual({
+      value: '3',
+      isInput: true,
+    });
+  });
+
+  it('invalidates quote producers when a Stock position action is reused in Swap', () => {
+    const { store, Wrapper } = createWrapperWithStore((storeInstance) => {
+      storeInstance.set(swapTypeSwitchAtom(), ESwapTabSwitchType.SWAP);
+      storeInstance.set(swapSelectFromTokenAtom(), bnbToken);
+      storeInstance.set(swapSelectToTokenAtom(), usdtToken);
+      storeInstance.set(swapQuoteListAtom(), [
+        { quoteId: 'active' } as IFetchQuoteResult,
+      ]);
+      storeInstance.set(swapQuoteRequestIdAtom(), 5);
+      storeInstance.set(swapSpeedQuoteRequestIdAtom(), 7);
+    });
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.switchStockPositionToSwapAction(usdcToken);
+    });
+
+    expect(store.get(swapQuoteListAtom())).toEqual([]);
+    expect(store.get(swapQuoteRequestIdAtom())).toBe(6);
+    expect(store.get(swapSpeedQuoteRequestIdAtom())).toBe(8);
+  });
+
+  it('invalidates quote producers when a Pro mapping is reused after route change', () => {
+    const { store, Wrapper } = createWrapperWithStore((storeInstance) => {
+      storeInstance.set(swapTypeSwitchAtom(), ESwapTabSwitchType.SWAP);
+      storeInstance.set(swapSelectFromTokenAtom(), bnbToken);
+      storeInstance.set(swapSelectToTokenAtom(), usdtToken);
+      storeInstance.set(swapQuoteListAtom(), [
+        { quoteId: 'active' } as IFetchQuoteResult,
+      ]);
+      storeInstance.set(swapQuoteRequestIdAtom(), 11);
+      storeInstance.set(swapSpeedQuoteRequestIdAtom(), 13);
+    });
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.switchSwapProToSwapAction({
+        direction: ESwapDirection.BUY,
+        inputAmount: '4',
+        inputToken: bnbToken,
+        selectedToken: usdcToken,
+      });
+    });
+
+    expect(store.get(swapQuoteListAtom())).toEqual([]);
+    expect(store.get(swapQuoteRequestIdAtom())).toBe(12);
+    expect(store.get(swapSpeedQuoteRequestIdAtom())).toBe(14);
   });
 
   it('blocks Stock quote before Stock execution tokens own the selected pair', async () => {
@@ -1650,6 +1849,327 @@ describe('useSwapActions', () => {
       quoteId: '',
       states: [],
     });
+  });
+
+  it('keeps an active quote when reselecting the current token', async () => {
+    const activeQuote = { quoteId: 'active' } as IFetchQuoteResult;
+    const { store, Wrapper } = createWrapperWithStore((storeInstance) => {
+      storeInstance.set(swapSelectFromTokenAtom(), bnbToken);
+      storeInstance.set(swapSelectToTokenAtom(), usdcToken);
+      storeInstance.set(swapQuoteListAtom(), [activeQuote]);
+      storeInstance.set(swapQuoteActionLockAtom(), { actionLock: true });
+      storeInstance.set(swapQuoteRequestIdAtom(), 5);
+    });
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.selectFromToken(bnbToken);
+      await result.current.selectToToken(usdcToken);
+    });
+
+    expect(store.get(swapQuoteListAtom())).toEqual([activeQuote]);
+    expect(store.get(swapQuoteActionLockAtom())).toEqual({ actionLock: true });
+    expect(store.get(swapQuoteRequestIdAtom())).toBe(5);
+    expect(mockCancelFetchQuoteEvents).not.toHaveBeenCalled();
+  });
+
+  it('ignores an ordinary event whose quote kind no longer owns the lock', async () => {
+    const { store, Wrapper } = createWrapperWithStore((storeInstance) => {
+      storeInstance.set(swapTypeSwitchAtom(), ESwapTabSwitchType.SWAP);
+      storeInstance.set(swapSelectFromTokenAtom(), bnbToken);
+      storeInstance.set(swapSelectToTokenAtom(), usdcToken);
+      storeInstance.set(swapFromTokenAmountAtom(), {
+        value: '1',
+        isInput: false,
+      });
+      storeInstance.set(swapToTokenAmountAtom(), {
+        value: '1',
+        isInput: true,
+      });
+      storeInstance.set(swapQuoteActionLockAtom(), {
+        type: ESwapTabSwitchType.SWAP,
+        actionLock: true,
+        fromToken: bnbToken,
+        toToken: usdcToken,
+        fromTokenAmount: '1',
+        toTokenAmount: '1',
+        kind: ESwapQuoteKind.BUY,
+        accountId: evmAccount.id,
+        address: '0xabc',
+      });
+    });
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.quoteEventHandler({
+        event: { type: 'done' } as ISwapQuoteEvent,
+        type: 'done',
+        params: {
+          accountId: evmAccount.id,
+          fromNetworkId: bnbToken.networkId,
+          fromTokenAddress: bnbToken.contractAddress,
+          fromTokenAmount: '1',
+          kind: ESwapQuoteKind.SELL,
+          protocol: ESwapTabSwitchType.SWAP,
+          slippagePercentage: 0.5,
+          toNetworkId: usdcToken.networkId,
+          toTokenAddress: usdcToken.contractAddress,
+          toTokenAmount: '1',
+          userAddress: '0xabc',
+        },
+        tokenPairs: { fromToken: bnbToken, toToken: usdcToken },
+        accountId: evmAccount.id,
+      });
+    });
+
+    expect(store.get(swapQuoteEventCompletedAtom())).toBe(false);
+    expect(store.get(swapQuoteActionLockAtom()).actionLock).toBe(true);
+  });
+
+  it.each(['token', 'amount'] as const)(
+    'does not dispatch a preflight quote after a direct %s identity change',
+    async (mutation) => {
+      const closeApproving = createDeferred<void>();
+      mockCloseApproving.mockReturnValueOnce(closeApproving.promise);
+      const { store, Wrapper } = createWrapperWithStore((storeInstance) => {
+        storeInstance.set(swapTypeSwitchAtom(), ESwapTabSwitchType.SWAP);
+        storeInstance.set(swapSelectFromTokenAtom(), bnbToken);
+        storeInstance.set(swapSelectToTokenAtom(), usdcToken);
+        storeInstance.set(swapFromTokenAmountAtom(), {
+          value: '1',
+          isInput: true,
+        });
+      });
+      const { result } = renderHook(() => useSwapActions().current, {
+        wrapper: Wrapper,
+      });
+
+      await act(async () => {
+        await result.current.quoteAction(
+          { key: ESwapSlippageSegmentKey.AUTO, value: 0.5 },
+          '0xabc',
+          evmAccount.id,
+          undefined,
+          undefined,
+          ESwapQuoteKind.SELL,
+        );
+      });
+      await waitFor(() => expect(mockCloseApproving).toHaveBeenCalledTimes(1));
+
+      act(() => {
+        if (mutation === 'token') {
+          store.set(swapSelectFromTokenAtom(), ethToken);
+        } else {
+          store.set(swapFromTokenAmountAtom(), {
+            value: '2',
+            isInput: true,
+          });
+        }
+      });
+      closeApproving.resolve();
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockFetchQuotesEvents).not.toHaveBeenCalled();
+      expect(store.get(swapQuoteFetchingAtom())).toBe(false);
+    },
+  );
+
+  it('uses the effective reQuote kind for the request identity', async () => {
+    const { store, Wrapper } = createWrapperWithStore((storeInstance) => {
+      storeInstance.set(swapTypeSwitchAtom(), ESwapTabSwitchType.SWAP);
+      storeInstance.set(swapSelectFromTokenAtom(), bnbToken);
+      storeInstance.set(swapSelectToTokenAtom(), usdcToken);
+      storeInstance.set(swapFromTokenAmountAtom(), {
+        value: '',
+        isInput: false,
+      });
+      storeInstance.set(swapToTokenAmountAtom(), {
+        value: '5',
+        isInput: true,
+      });
+    });
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.quoteAction(
+        { key: ESwapSlippageSegmentKey.AUTO, value: 0.5 },
+        '0xabc',
+        evmAccount.id,
+        undefined,
+        undefined,
+        ESwapQuoteKind.SELL,
+        true,
+      );
+    });
+
+    await waitFor(() => expect(mockFetchQuotesEvents).toHaveBeenCalledTimes(1));
+    expect(store.get(swapQuoteActionLockAtom()).kind).toBe(ESwapQuoteKind.BUY);
+    expect(mockFetchQuotesEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: ESwapQuoteKind.BUY, toTokenAmount: '5' }),
+    );
+  });
+
+  it('keeps the latest speed quote when an older request resolves last', async () => {
+    const firstQuote = createDeferred<IFetchQuoteResult[]>();
+    const staleResult = {
+      quoteId: 'stale-speed-quote',
+      fromAmount: '1',
+    } as IFetchQuoteResult;
+    const currentResult = {
+      quoteId: 'current-speed-quote',
+      fromAmount: '2',
+    } as IFetchQuoteResult;
+    mockFetchSpeedSwapQuote
+      .mockImplementationOnce(() => firstQuote.promise)
+      .mockResolvedValueOnce([currentResult]);
+    const { store, Wrapper } = createWrapperWithStore((storeInstance) => {
+      storeInstance.set(swapTypeSwitchAtom(), ESwapTabSwitchType.LIMIT);
+      storeInstance.set(swapProTradeTypeAtom(), ESwapProTradeType.MARKET);
+      storeInstance.set(swapProDirectionAtom(), ESwapDirection.BUY);
+      storeInstance.set(swapProUseSelectBuyTokenAtom(), proBnbToken);
+      storeInstance.set(swapProSelectTokenAtom(), usdcToken);
+      storeInstance.set(swapProInputAmountAtom(), '1');
+    });
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.quoteSpeedAction({
+        key: ESwapSlippageSegmentKey.AUTO,
+        value: 0.5,
+      });
+    });
+    act(() => store.set(swapProInputAmountAtom(), '2'));
+    await act(async () => {
+      await result.current.quoteSpeedAction({
+        key: ESwapSlippageSegmentKey.AUTO,
+        value: 0.5,
+      });
+    });
+    await waitFor(() =>
+      expect(store.get(swapSpeedQuoteResultAtom())).toBe(currentResult),
+    );
+
+    firstQuote.resolve([staleResult]);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(store.get(swapSpeedQuoteResultAtom())).toBe(currentResult);
+    expect(store.get(swapSpeedQuoteFetchingAtom())).toBe(false);
+  });
+
+  it('does not let an older speed quote error stop the active request', async () => {
+    const staleQuote = createDeferred<IFetchQuoteResult[]>();
+    const activeQuote = createDeferred<IFetchQuoteResult[]>();
+    mockFetchSpeedSwapQuote
+      .mockImplementationOnce(() => staleQuote.promise)
+      .mockImplementationOnce(() => activeQuote.promise);
+    const { store, Wrapper } = createWrapperWithStore((storeInstance) => {
+      storeInstance.set(swapTypeSwitchAtom(), ESwapTabSwitchType.LIMIT);
+      storeInstance.set(swapProDirectionAtom(), ESwapDirection.BUY);
+      storeInstance.set(swapProUseSelectBuyTokenAtom(), proBnbToken);
+      storeInstance.set(swapProSelectTokenAtom(), usdcToken);
+      storeInstance.set(swapProInputAmountAtom(), '1');
+    });
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.quoteSpeedAction({
+        key: ESwapSlippageSegmentKey.AUTO,
+        value: 0.5,
+      });
+    });
+    act(() => store.set(swapProInputAmountAtom(), '2'));
+    await act(async () => {
+      await result.current.quoteSpeedAction({
+        key: ESwapSlippageSegmentKey.AUTO,
+        value: 0.5,
+      });
+    });
+    expect(store.get(swapSpeedQuoteFetchingAtom())).toBe(true);
+
+    staleQuote.reject(new Error('stale quote failed'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(store.get(swapSpeedQuoteFetchingAtom())).toBe(true);
+
+    activeQuote.resolve([]);
+    await waitFor(() =>
+      expect(store.get(swapSpeedQuoteFetchingAtom())).toBe(false),
+    );
+  });
+
+  it('clears the complete quote lifecycle when the type identity changes', async () => {
+    const staleQuote = { quoteId: 'stale' } as IFetchQuoteResult;
+    const { store, Wrapper } = createWrapperWithStore((storeInstance) => {
+      storeInstance.set(swapTypeSwitchAtom(), ESwapTabSwitchType.SWAP);
+      storeInstance.set(swapSelectFromTokenAtom(), bnbToken);
+      storeInstance.set(swapSelectToTokenAtom(), usdcToken);
+      storeInstance.set(swapQuoteListAtom(), [staleQuote]);
+      storeInstance.set(swapQuoteFetchingAtom(), true);
+      storeInstance.set(swapQuoteEventCompletedAtom(), true);
+      storeInstance.set(swapQuoteEventErrorAtom(), {
+        message: 'stale',
+        fromToken: bnbToken,
+        toToken: usdcToken,
+      });
+      storeInstance.set(swapQuoteActionLockAtom(), { actionLock: true });
+      storeInstance.set(rateDifferenceAtom(), {
+        value: '1',
+        unit: ESwapRateDifferenceUnit.POSITIVE,
+      });
+      storeInstance.set(swapBuildTxFetchingAtom(), true);
+      storeInstance.set(swapShouldRefreshQuoteAtom(), true);
+      storeInstance.set(swapAutoSlippageSuggestedValueAtom(), {
+        value: 0.5,
+        from: 'api',
+        to: 'user',
+        eventId: 'stale',
+      });
+      storeInstance.set(swapAlertsAtom(), {
+        quoteId: 'stale',
+        states: [{ message: 'stale' }],
+      });
+      storeInstance.set(swapSpeedQuoteFetchingAtom(), true);
+      storeInstance.set(swapSpeedQuoteResultAtom(), staleQuote);
+      storeInstance.set(swapQuoteRequestIdAtom(), 3);
+      storeInstance.set(swapSpeedQuoteRequestIdAtom(), 4);
+    });
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.swapTypeSwitchAction(ESwapTabSwitchType.LIMIT);
+    });
+
+    expect(store.get(swapQuoteListAtom())).toEqual([]);
+    expect(store.get(swapQuoteFetchingAtom())).toBe(false);
+    expect(store.get(swapQuoteEventCompletedAtom())).toBe(false);
+    expect(store.get(swapQuoteEventErrorAtom())).toBeUndefined();
+    expect(store.get(swapQuoteActionLockAtom())).toEqual({ actionLock: false });
+    expect(store.get(rateDifferenceAtom())).toBeUndefined();
+    expect(store.get(swapBuildTxFetchingAtom())).toBe(false);
+    expect(store.get(swapShouldRefreshQuoteAtom())).toBe(false);
+    expect(store.get(swapAutoSlippageSuggestedValueAtom())).toBeUndefined();
+    expect(store.get(swapAlertsAtom())).toEqual({ quoteId: '', states: [] });
+    expect(store.get(swapSpeedQuoteFetchingAtom())).toBe(false);
+    expect(store.get(swapSpeedQuoteResultAtom())).toBeUndefined();
+    expect(store.get(swapQuoteRequestIdAtom())).toBe(4);
+    expect(store.get(swapSpeedQuoteRequestIdAtom())).toBe(5);
   });
 
   it('does not keep noConnectWallet warning when native wallet readiness is not proven', async () => {

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -21,6 +21,10 @@ import {
   settingsAtom,
   settingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import type {
+  IJotaiGetter,
+  IJotaiSetter,
+} from '@onekeyhq/kit-bg/src/states/jotai/types';
 import { USD_CURRENCY_ID } from '@onekeyhq/shared/src/consts/currencyConsts';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import type { IEventSourceMessageEvent } from '@onekeyhq/shared/src/eventSource';
@@ -123,6 +127,7 @@ import {
   swapQuoteFetchingAtom,
   swapQuoteIntervalCountAtom,
   swapQuoteListAtom,
+  swapQuoteRequestIdAtom,
   swapSelectFromTokenAtom,
   swapSelectToTokenAtom,
   swapSelectTokenDetailFetchingAtom,
@@ -132,6 +137,7 @@ import {
   swapShouldRefreshQuoteAtom,
   swapSilenceQuoteLoading,
   swapSpeedQuoteFetchingAtom,
+  swapSpeedQuoteRequestIdAtom,
   swapSpeedQuoteResultAtom,
   swapStockExecutionTokenSyncIdAtom,
   swapStockExecutionTokensAtom,
@@ -142,6 +148,12 @@ import {
   swapTokenMetadataAtom,
   swapTypeSwitchAtom,
 } from './atoms';
+import {
+  isCurrentQuoteEventParams,
+  isSameQuoteActionIdentity,
+  isSameSwapAmountValue,
+  isStockProtocol,
+} from './quoteIdentity';
 import {
   SWAP_INCOGNITO_QUOTE_PROVIDER_COUNT_CAP,
   buildSwapQuoteProviderKey,
@@ -203,13 +215,6 @@ function isQuoteResultSelectedTokenPair({
   );
 }
 
-function isStockProtocol(protocol?: string) {
-  return (
-    protocol === ESwapTabSwitchType.STOCK ||
-    protocol === EProtocolOfExchange.STOCK
-  );
-}
-
 function isQuoteEventErrorSelectedTokenPair({
   fromTokenAmount,
   quoteEventError,
@@ -241,68 +246,27 @@ function isQuoteEventErrorSelectedTokenPair({
   );
 }
 
-function isSameSwapAmountValue({
-  currentAmount,
-  eventAmount,
-}: {
-  currentAmount?: string;
-  eventAmount?: string;
-}) {
-  if (eventAmount === undefined) {
-    return true;
-  }
-  const normalizedCurrentAmount = currentAmount ?? '';
-  if (!eventAmount && !normalizedCurrentAmount) {
-    return true;
-  }
-  const eventAmountBN = new BigNumber(eventAmount);
-  const currentAmountBN = new BigNumber(normalizedCurrentAmount);
-  if (
-    eventAmountBN.isFinite() &&
-    !eventAmountBN.isNaN() &&
-    currentAmountBN.isFinite() &&
-    !currentAmountBN.isNaN()
-  ) {
-    return eventAmountBN.eq(currentAmountBN);
-  }
-  return eventAmount === normalizedCurrentAmount;
-}
-
-function isCurrentStockQuoteEventParams({
-  currentSwapType,
+function hasStockOwnedTokens({
   fromToken,
-  fromTokenAmount,
-  params,
+  stockSelectedToken,
   toToken,
-  tokenPairs,
 }: {
-  currentSwapType: ESwapTabSwitchType;
   fromToken?: ISwapToken;
-  fromTokenAmount?: string;
-  params: IFetchQuotesParams;
+  stockSelectedToken?: ISwapToken;
   toToken?: ISwapToken;
-  tokenPairs: { fromToken: ISwapToken; toToken: ISwapToken };
 }) {
-  if (!isStockProtocol(params.protocol)) {
-    return true;
-  }
-  const isSameTokenPair =
-    equalTokenNoCaseSensitive({
-      token1: tokenPairs.fromToken,
-      token2: fromToken,
-    }) &&
-    equalTokenNoCaseSensitive({
-      token1: tokenPairs.toToken,
-      token2: toToken,
-    });
-  const isSameFromAmount = isSameSwapAmountValue({
-    currentAmount: fromTokenAmount,
-    eventAmount: params.fromTokenAmount,
-  });
-  return (
-    currentSwapType === ESwapTabSwitchType.STOCK &&
-    isSameTokenPair &&
-    isSameFromAmount
+  return Boolean(
+    fromToken?.isStock ||
+    toToken?.isStock ||
+    (stockSelectedToken &&
+      (equalTokenNoCaseSensitive({
+        token1: stockSelectedToken,
+        token2: fromToken,
+      }) ||
+        equalTokenNoCaseSensitive({
+          token1: stockSelectedToken,
+          token2: toToken,
+        }))),
   );
 }
 
@@ -377,8 +341,29 @@ function getLimitDefaultNetworkId({
   return undefined;
 }
 
+function getSwapProTokenForStorage(token: ISwapToken): ISwapToken {
+  const {
+    balanceParsed,
+    price,
+    fiatValue,
+    reservationValue,
+    accountAddress,
+    ...storedToken
+  } = token;
+  return storedToken;
+}
+
+enum ESwapQuoteLifecycleResetScope {
+  ORDINARY = 'ordinary',
+  ORDINARY_WITH_ALERTS = 'ordinaryWithAlerts',
+  SPEED = 'speed',
+  ALL = 'all',
+}
+
 class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
   private quoteInterval: ReturnType<typeof setTimeout> | undefined;
+
+  private swapProSelectTokenPersistenceQueue = Promise.resolve();
 
   private stockTokenCheckCache = new Map<string, Promise<boolean>>();
 
@@ -396,6 +381,105 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
     | undefined;
 
   private limitOrderMarketPriceRequestId = 0;
+
+  private persistSwapProSelectToken(token: ISwapToken) {
+    const persistence = this.swapProSelectTokenPersistenceQueue
+      .then(() =>
+        backgroundApiProxy.simpleDb.swapProSelectToken.setSwapProSelectToken(
+          getSwapProTokenForStorage(token),
+        ),
+      )
+      .catch((error: unknown) => {
+        defaultLogger.app.error.log(
+          `Swap Pro selected token persistence failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
+    this.swapProSelectTokenPersistenceQueue = persistence;
+    return persistence;
+  }
+
+  private resetSwapQuoteLifecycle = contextAtomMethod(
+    (get, set, scope: ESwapQuoteLifecycleResetScope) => {
+      const resetOrdinary = scope !== ESwapQuoteLifecycleResetScope.SPEED;
+      const resetSpeed =
+        scope === ESwapQuoteLifecycleResetScope.SPEED ||
+        scope === ESwapQuoteLifecycleResetScope.ALL;
+
+      if (resetOrdinary) {
+        this.cleanQuoteInterval();
+        set(swapQuoteRequestIdAtom(), (requestId) => requestId + 1);
+        set(swapQuoteListAtom(), []);
+        set(swapQuoteCurrentEventProviderKeysAtom(), []);
+        set(swapQuoteCurrentEventReceivedCountAtom(), 0);
+        set(swapQuoteEventCompletedAtom(), false);
+        set(swapQuoteEventTotalCountAtom(), { count: 0 });
+        set(swapQuoteEventErrorAtom(), undefined);
+        set(swapQuoteFetchingAtom(), false);
+        set(swapQuoteActionLockAtom(), { actionLock: false });
+        set(swapManualSelectQuoteProvidersAtom(), undefined);
+        set(swapAutoSlippageSuggestedValueAtom(), undefined);
+        set(rateDifferenceAtom(), undefined);
+        set(swapBuildTxFetchingAtom(), false);
+        set(swapShouldRefreshQuoteAtom(), false);
+        set(swapQuoteIntervalCountAtom(), 0);
+      }
+      if (
+        scope === ESwapQuoteLifecycleResetScope.ORDINARY_WITH_ALERTS ||
+        scope === ESwapQuoteLifecycleResetScope.ALL
+      ) {
+        set(swapAlertsAtom(), { quoteId: '', states: [] });
+      }
+      if (resetSpeed) {
+        set(swapSpeedQuoteRequestIdAtom(), (requestId) => requestId + 1);
+        set(swapSpeedQuoteFetchingAtom(), false);
+        set(swapSpeedQuoteResultAtom(), undefined);
+      }
+    },
+  );
+
+  private invalidateQuoteProducers(
+    set: IJotaiSetter,
+    scope: ESwapQuoteLifecycleResetScope,
+  ) {
+    this.resetSwapQuoteLifecycle.call(set, scope);
+    if (scope !== ESwapQuoteLifecycleResetScope.SPEED) {
+      this.closeQuoteEvent();
+    }
+    if (
+      scope === ESwapQuoteLifecycleResetScope.SPEED ||
+      scope === ESwapQuoteLifecycleResetScope.ALL
+    ) {
+      this.cancelSpeedQuote();
+    }
+  }
+
+  private resolveActiveQuotePair(
+    get: IJotaiGetter,
+    swapType = get(swapTypeSwitchAtom()),
+  ) {
+    if (
+      swapType === ESwapTabSwitchType.LIMIT &&
+      get(swapProTradeTypeAtom()) === ESwapProTradeType.LIMIT
+    ) {
+      const direction = get(swapProDirectionAtom());
+      const selectedToken = get(swapProSelectTokenAtom());
+      return direction === ESwapDirection.BUY
+        ? {
+            fromToken: get(swapProUseSelectBuyTokenAtom()),
+            toToken: selectedToken,
+          }
+        : {
+            fromToken: selectedToken,
+            toToken: get(swapProSellToTokenAtom()),
+          };
+    }
+    return {
+      fromToken: get(swapSelectFromTokenAtom()),
+      toToken: get(swapSelectToTokenAtom()),
+    };
+  }
 
   /**
    * Execute promises in batches with concurrency control to prevent overwhelming the system
@@ -426,24 +510,17 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
   // If token is not provided: load from db, if db is empty, use defaultToken
   setSwapProSelectToken = contextAtomMethod(
     async (get, set, token?: ISwapToken, defaultToken?: ISwapToken) => {
-      // Remove realtime properties before saving to db
-      const getTokenForStorage = (t: ISwapToken): ISwapToken => {
-        const {
-          balanceParsed,
-          price,
-          fiatValue,
-          reservationValue,
-          accountAddress,
-          ...rest
-        } = t;
-        return rest;
-      };
-
       if (token) {
+        if (
+          !equalTokenNoCaseSensitive({
+            token1: get(swapProSelectTokenAtom()),
+            token2: token,
+          })
+        ) {
+          this.invalidateQuoteProducers(set, ESwapQuoteLifecycleResetScope.ALL);
+        }
         set(swapProSelectTokenAtom(), token);
-        await backgroundApiProxy.simpleDb.swapProSelectToken.setSwapProSelectToken(
-          getTokenForStorage(token),
-        );
+        await this.persistSwapProSelectToken(token);
       } else {
         const savedToken =
           await backgroundApiProxy.simpleDb.swapProSelectToken.getSwapProSelectToken();
@@ -451,9 +528,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           set(swapProSelectTokenAtom(), savedToken);
         } else if (defaultToken) {
           set(swapProSelectTokenAtom(), defaultToken);
-          await backgroundApiProxy.simpleDb.swapProSelectToken.setSwapProSelectToken(
-            getTokenForStorage(defaultToken),
-          );
+          await this.persistSwapProSelectToken(defaultToken);
         }
       }
     },
@@ -611,6 +686,10 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
   };
 
   resetSwapTokenData = contextAtomMethod(async (get, set, type) => {
+    this.invalidateQuoteProducers(
+      set,
+      ESwapQuoteLifecycleResetScope.ORDINARY_WITH_ALERTS,
+    );
     if (type === ESwapDirectionType.FROM) {
       set(swapSelectFromTokenAtom(), undefined);
       set(swapSelectedFromTokenBalanceAtom(), '');
@@ -619,8 +698,6 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       set(swapSelectedToTokenBalanceAtom(), '');
     }
     set(swapStockExecutionTokensAtom(), undefined);
-    set(swapQuoteListAtom(), []);
-    set(rateDifferenceAtom(), undefined);
   });
 
   selectFromToken = contextAtomMethod(
@@ -629,23 +706,22 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       set,
       token: ISwapToken,
       disableCheckToToken?: boolean,
-      skipCleanManualSelectQuoteProviders?: boolean,
       skipCheckEqualToken?: boolean,
     ) => {
+      const fromToken = get(swapSelectFromTokenAtom());
       const toToken = get(swapSelectToTokenAtom());
       if (
         !skipCheckEqualToken &&
-        equalTokenNoCaseSensitive({
-          token1: toToken,
-          token2: token,
-        })
+        (equalTokenNoCaseSensitive({ token1: fromToken, token2: token }) ||
+          equalTokenNoCaseSensitive({ token1: toToken, token2: token }))
       ) {
         return;
       }
       const swapTypeSwitchValue = get(swapTypeSwitchAtom());
-      if (!skipCleanManualSelectQuoteProviders) {
-        this.cleanManualSelectQuoteProviders.call(set);
-      }
+      this.invalidateQuoteProducers(
+        set,
+        ESwapQuoteLifecycleResetScope.ORDINARY_WITH_ALERTS,
+      );
       await this.syncNetworksSort.call(set, token.networkId);
       const needChangeToToken = this.needChangeToken({
         token,
@@ -662,26 +738,20 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
   );
 
   selectToToken = contextAtomMethod(
-    async (
-      get,
-      set,
-      token: ISwapToken,
-      skipCleanManualSelectQuoteProviders?: boolean,
-      skipCheckEqualToken?: boolean,
-    ) => {
-      if (!skipCleanManualSelectQuoteProviders) {
-        this.cleanManualSelectQuoteProviders.call(set);
-      }
+    async (get, set, token: ISwapToken, skipCheckEqualToken?: boolean) => {
       const fromToken = get(swapSelectFromTokenAtom());
+      const toToken = get(swapSelectToTokenAtom());
       if (
         !skipCheckEqualToken &&
-        equalTokenNoCaseSensitive({
-          token1: fromToken,
-          token2: token,
-        })
+        (equalTokenNoCaseSensitive({ token1: fromToken, token2: token }) ||
+          equalTokenNoCaseSensitive({ token1: toToken, token2: token }))
       ) {
         return;
       }
+      this.invalidateQuoteProducers(
+        set,
+        ESwapQuoteLifecycleResetScope.ORDINARY_WITH_ALERTS,
+      );
       await this.syncNetworksSort.call(set, token.networkId);
       set(swapSelectToTokenAtom(), token);
     },
@@ -701,6 +771,21 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         syncId: number;
       },
     ) => {
+      const executionPairChanged =
+        !equalTokenNoCaseSensitive({
+          token1: get(swapSelectFromTokenAtom()),
+          token2: fromToken,
+        }) ||
+        !equalTokenNoCaseSensitive({
+          token1: get(swapSelectToTokenAtom()),
+          token2: toToken,
+        });
+      if (executionPairChanged) {
+        this.invalidateQuoteProducers(
+          set,
+          ESwapQuoteLifecycleResetScope.ORDINARY_WITH_ALERTS,
+        );
+      }
       set(swapStockExecutionTokenSyncIdAtom(), syncId);
       if (fromToken) {
         set(swapSelectFromTokenAtom(), fromToken);
@@ -749,6 +834,10 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
     if (!fromToken && !toToken) {
       return;
     }
+    this.invalidateQuoteProducers(
+      set,
+      ESwapQuoteLifecycleResetScope.ORDINARY_WITH_ALERTS,
+    );
     set(swapSelectFromTokenAtom(), toToken);
     set(swapSelectToTokenAtom(), fromToken);
     this.cleanManualSelectQuoteProviders.call(set);
@@ -793,13 +882,19 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         accountId?: string;
       },
     ) => {
+      const currentSwapType = get(swapTypeSwitchAtom());
+      const { fromToken: currentFromToken, toToken: currentToToken } =
+        this.resolveActiveQuotePair(get, currentSwapType);
       if (
-        !isCurrentStockQuoteEventParams({
-          currentSwapType: get(swapTypeSwitchAtom()),
-          fromToken: get(swapSelectFromTokenAtom()),
+        !isCurrentQuoteEventParams({
+          actionLock: get(swapQuoteActionLockAtom()),
+          accountId: event.accountId,
+          currentSwapType,
+          fromToken: currentFromToken,
           fromTokenAmount: get(swapFromTokenAmountAtom()).value,
           params: event.params,
-          toToken: get(swapSelectToTokenAtom()),
+          toToken: currentToToken,
+          toTokenAmount: get(swapToTokenAmountAtom()).value,
           tokenPairs: event.tokenPairs,
         })
       ) {
@@ -1108,6 +1203,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       set,
       fromToken: ISwapToken,
       toToken: ISwapToken,
+      requestId: number,
       slippagePercentage: number,
       autoSlippage?: boolean,
       address?: string,
@@ -1119,9 +1215,55 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       receivingAddress?: string,
       incognito?: boolean,
     ) => {
-      const shouldRefreshQuote = get(swapShouldRefreshQuoteAtom());
       const protocol = get(swapTypeSwitchAtom());
+      const isCurrentQuoteRequest = () => {
+        if (
+          get(swapQuoteRequestIdAtom()) !== requestId ||
+          get(swapTypeSwitchAtom()) !== protocol ||
+          get(swapShouldRefreshQuoteAtom())
+        ) {
+          return false;
+        }
+        const { fromToken: currentFromToken, toToken: currentToToken } =
+          this.resolveActiveQuotePair(get, protocol);
+        const actionLock = get(swapQuoteActionLockAtom());
+        const isBuyQuote = kind === ESwapQuoteKind.BUY;
+        const expectedInputAmount = isBuyQuote
+          ? toTokenAmount
+          : fromTokenAmount;
+        const currentInputAmount = isBuyQuote
+          ? get(swapToTokenAmountAtom()).value
+          : get(swapFromTokenAmountAtom()).value;
+        return (
+          equalTokenNoCaseSensitive({
+            token1: currentFromToken,
+            token2: fromToken,
+          }) &&
+          equalTokenNoCaseSensitive({
+            token1: currentToToken,
+            token2: toToken,
+          }) &&
+          isSameQuoteActionIdentity({
+            actionLock,
+            accountId,
+            address,
+            fromToken,
+            inputAmount: expectedInputAmount,
+            kind,
+            receivingAddress,
+            swapType: protocol,
+            toToken,
+          }) &&
+          isSameSwapAmountValue({
+            currentAmount: currentInputAmount,
+            eventAmount: expectedInputAmount,
+          })
+        );
+      };
       const { swapIncognitoMode } = await settingsAtom.get();
+      if (!isCurrentQuoteRequest()) {
+        return;
+      }
       const incognitoEnabled =
         protocol === ESwapTabSwitchType.LIMIT ||
         protocol === ESwapTabSwitchType.STOCK
@@ -1130,12 +1272,10 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       const limitPartiallyFillableObj = get(swapLimitPartiallyFillAtom());
       const limitPartiallyFillable = limitPartiallyFillableObj.value;
       const expirationTime = get(swapLimitExpirationTimeAtom());
-      if (shouldRefreshQuote) {
-        this.cleanQuoteInterval();
-        set(swapQuoteActionLockAtom(), (v) => ({ ...v, actionLock: false }));
+      await backgroundApiProxy.serviceSwap.closeApproving();
+      if (!isCurrentQuoteRequest()) {
         return;
       }
-      await backgroundApiProxy.serviceSwap.closeApproving();
       set(swapQuoteEventErrorAtom(), undefined);
       set(swapQuoteFetchingAtom(), true);
       set(swapQuoteEventCompletedAtom(), false);
@@ -1177,24 +1317,12 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
     const fromTokenAmount = get(swapFromTokenAmountAtom());
     const toTokenAmount = get(swapToTokenAmountAtom());
     const swapTypeSwitch = get(swapTypeSwitchAtom());
-    set(swapQuoteFetchingAtom(), false);
-    set(swapQuoteEventErrorAtom(), undefined);
-    set(swapQuoteCurrentEventProviderKeysAtom(), []);
-    set(swapQuoteCurrentEventReceivedCountAtom(), 0);
-    set(swapQuoteEventCompletedAtom(), false);
-    set(swapQuoteEventTotalCountAtom(), {
-      count: 0,
-    });
-    set(swapQuoteListAtom(), []);
-    set(swapManualSelectQuoteProvidersAtom(), undefined);
-    set(rateDifferenceAtom(), undefined);
-    set(swapQuoteActionLockAtom(), (v) => ({ ...v, actionLock: false }));
-    if (swapTypeSwitch === ESwapTabSwitchType.STOCK) {
-      set(swapAlertsAtom(), {
-        quoteId: '',
-        states: [],
-      });
-    }
+    this.invalidateQuoteProducers(
+      set,
+      swapTypeSwitch === ESwapTabSwitchType.STOCK
+        ? ESwapQuoteLifecycleResetScope.ORDINARY_WITH_ALERTS
+        : ESwapQuoteLifecycleResetScope.ORDINARY,
+    );
     if (!fromToken) {
       set(swapFromTokenAmountAtom(), { value: '', isInput: false });
     }
@@ -1222,13 +1350,16 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       receivingAddress?: string,
       incognito?: boolean,
     ) => {
-      let fromToken = get(swapSelectFromTokenAtom());
-      let toToken = get(swapSelectToTokenAtom());
+      const requestId = get(swapQuoteRequestIdAtom()) + 1;
+      set(swapQuoteRequestIdAtom(), requestId);
       const fromTokenAmount = get(swapFromTokenAmountAtom());
       const swapTabSwitchType = get(swapTypeSwitchAtom());
       const toTokenAmount = get(swapToTokenAmountAtom());
       const swapProTradeType = get(swapProTradeTypeAtom());
-      const swapProDirection = get(swapProDirectionAtom());
+      const { fromToken, toToken } = this.resolveActiveQuotePair(
+        get,
+        swapTabSwitchType,
+      );
       set(swapQuoteEventErrorAtom(), undefined);
       if (
         swapTabSwitchType === ESwapTabSwitchType.LIMIT &&
@@ -1237,18 +1368,6 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       ) {
         void this.resetQuoteAction.call(set);
         return;
-      }
-      if (
-        swapProTradeType === ESwapProTradeType.LIMIT &&
-        swapTabSwitchType === ESwapTabSwitchType.LIMIT
-      ) {
-        if (swapProDirection === ESwapDirection.BUY) {
-          fromToken = get(swapProUseSelectBuyTokenAtom());
-          toToken = get(swapProSelectTokenAtom());
-        } else {
-          fromToken = get(swapProSelectTokenAtom());
-          toToken = get(swapProSellToTokenAtom());
-        }
       }
       const fromTokenAmountNumber = Number(fromTokenAmount.value);
       const toTokenAmountNumber = Number(toTokenAmount.value);
@@ -1318,7 +1437,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         toToken,
         fromTokenAmount: fromTokenAmount.value,
         toTokenAmount: toTokenAmount.value,
-        kind,
+        kind: quoteKind,
         accountId,
         address,
         receivingAddress,
@@ -1327,6 +1446,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         set,
         fromToken,
         toToken,
+        requestId,
         slippageItem.value,
         slippageItem.key === ESwapSlippageSegmentKey.AUTO,
         address,
@@ -1347,6 +1467,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       set,
       fromToken: ISwapToken,
       toToken: ISwapToken,
+      requestId: number,
       slippagePercentage: number,
       autoSlippage?: boolean,
       address?: string,
@@ -1356,7 +1477,40 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       toTokenAmount?: string,
       receivingAddress?: string,
     ) => {
+      const isCurrentSpeedQuoteIdentity = () => {
+        const currentDirection = get(swapProDirectionAtom());
+        const currentSelectedToken = get(swapProSelectTokenAtom());
+        const currentFromToken =
+          currentDirection === ESwapDirection.BUY
+            ? get(swapProUseSelectBuyTokenAtom())
+            : currentSelectedToken;
+        const currentToToken =
+          currentDirection === ESwapDirection.BUY
+            ? currentSelectedToken
+            : get(swapProSellToTokenAtom());
+        return (
+          get(swapTypeSwitchAtom()) === ESwapTabSwitchType.LIMIT &&
+          equalTokenNoCaseSensitive({
+            token1: currentFromToken,
+            token2: fromToken,
+          }) &&
+          equalTokenNoCaseSensitive({
+            token1: currentToToken,
+            token2: toToken,
+          }) &&
+          isSameSwapAmountValue({
+            currentAmount: get(swapProInputAmountAtom()),
+            eventAmount: fromTokenAmount,
+          })
+        );
+      };
       try {
+        if (
+          get(swapSpeedQuoteRequestIdAtom()) !== requestId ||
+          !isCurrentSpeedQuoteIdentity()
+        ) {
+          return;
+        }
         set(swapSpeedQuoteFetchingAtom(), true);
         set(swapSpeedQuoteResultAtom(), undefined);
         const res = await backgroundApiProxy.serviceSwap.fetchSpeedSwapQuote({
@@ -1372,20 +1526,26 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           accountId,
           protocol: ESwapTabSwitchType.SWAP,
         });
+        if (get(swapSpeedQuoteRequestIdAtom()) !== requestId) {
+          return;
+        }
+        if (!isCurrentSpeedQuoteIdentity()) {
+          set(swapSpeedQuoteFetchingAtom(), false);
+          return;
+        }
         if (res && res.length > 0) {
           const quoteResult = res[0];
-          const quoteResultFromAmount = quoteResult.fromAmount;
-          const fromTokenCurrentAmount = get(swapProInputAmountAtom());
-          if (
-            !quoteResult.errorMessage &&
-            quoteResultFromAmount !== fromTokenCurrentAmount
-          ) {
-            return;
-          }
           set(swapSpeedQuoteResultAtom(), quoteResult);
         }
         set(swapSpeedQuoteFetchingAtom(), false);
       } catch (e: any) {
+        if (get(swapSpeedQuoteRequestIdAtom()) !== requestId) {
+          return;
+        }
+        if (!isCurrentSpeedQuoteIdentity()) {
+          set(swapSpeedQuoteFetchingAtom(), false);
+          return;
+        }
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (e?.cause !== ESwapFetchCancelCause.SWAP_SPEED_QUOTE_CANCEL) {
           set(swapSpeedQuoteFetchingAtom(), false);
@@ -1404,6 +1564,8 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       receivingAddress?: string,
     ) => {
       this.cancelSpeedQuote();
+      const requestId = get(swapSpeedQuoteRequestIdAtom()) + 1;
+      set(swapSpeedQuoteRequestIdAtom(), requestId);
       const selectedToken = get(swapProSelectTokenAtom());
       const buySelectToken = get(swapProUseSelectBuyTokenAtom());
       const sellSelectToken = get(swapProSellToTokenAtom());
@@ -1418,12 +1580,15 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           ? selectedToken
           : sellSelectToken;
       if (!fromToken || !toToken || fromToken.networkId !== toToken.networkId) {
+        set(swapSpeedQuoteFetchingAtom(), false);
+        set(swapSpeedQuoteResultAtom(), undefined);
         return;
       }
       void this.runSpeedQuote.call(
         set,
         fromToken,
         toToken,
+        requestId,
         slippageItem.value,
         slippageItem.key === ESwapSlippageSegmentKey.AUTO,
         address,
@@ -1451,9 +1616,8 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
     void backgroundApiProxy.serviceSwap.cancelFetchSpeedSwapQuote();
   };
 
-  cleanSpeedQuote = contextAtomMethod(async (get, set) => {
-    set(swapSpeedQuoteFetchingAtom(), false);
-    set(swapSpeedQuoteResultAtom(), undefined);
+  cleanSpeedQuote = contextAtomMethod((get, set) => {
+    this.invalidateQuoteProducers(set, ESwapQuoteLifecycleResetScope.SPEED);
   });
 
   cleanLimitOrderMarketPriceInterval = () => {
@@ -2575,12 +2739,11 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
             });
           } else {
             // Subsequent fetches: collect results and update atom
-            const allTokensResult = results
-              .filter((r) => r.status === 'fulfilled' && r.value)
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-              .map((r) => (r as PromiseFulfilledResult<any>).value)
-              .filter(Boolean)
-              .flat();
+            const allTokensResult = results.flatMap((result): ISwapToken[] =>
+              result.status === 'fulfilled' && Array.isArray(result.value)
+                ? result.value
+                : [],
+            );
             set(swapAllNetworkTokenListMapAtom(), (v) => ({
               ...v,
               [tokenListCacheKey]: allTokensResult,
@@ -2679,11 +2842,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
 
         // Extract successful results and sort by fiat value
         const sortedResult = results
-          .filter((r) => r.status === 'fulfilled' && r.value)
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-          .map((r) => (r as PromiseFulfilledResult<any>).value)
-          .filter(Boolean)
-          .flat()
+          .flatMap((result): ISwapToken[] =>
+            result.status === 'fulfilled' ? result.value : [],
+          )
           .toSorted((a, b) => {
             return new BigNumber(b.fiatValue ?? '0').comparedTo(
               new BigNumber(a.fiatValue ?? '0'),
@@ -2700,16 +2861,55 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
   );
 
   swapTypeSwitchAction = contextAtomMethod(
-    async (
+    (
       get,
       set,
       type: ESwapTabSwitchType,
       swapAccountNetworkId?: string,
+      options?: {
+        preserveNativeAmount?: boolean;
+        skipLimitPairReconciliation?: boolean;
+      },
     ) => {
       const oldType = get(swapTypeSwitchAtom());
       const normalizedType = getVisibleSwapTabSwitchType(type) ?? type;
+      const oldFromToken = get(swapSelectFromTokenAtom());
+      const oldToToken = get(swapSelectToTokenAtom());
+      const oldFromTokenAmount = get(swapFromTokenAmountAtom());
+      const oldToTokenAmount = get(swapToTokenAmountAtom());
+      const finalizeTransition = () => {
+        const quoteIdentityChanged =
+          oldType !== normalizedType ||
+          !equalTokenNoCaseSensitive({
+            token1: oldFromToken,
+            token2: get(swapSelectFromTokenAtom()),
+          }) ||
+          !equalTokenNoCaseSensitive({
+            token1: oldToToken,
+            token2: get(swapSelectToTokenAtom()),
+          }) ||
+          oldFromTokenAmount.value !== get(swapFromTokenAmountAtom()).value ||
+          oldFromTokenAmount.isInput !==
+            get(swapFromTokenAmountAtom()).isInput ||
+          oldToTokenAmount.value !== get(swapToTokenAmountAtom()).value ||
+          oldToTokenAmount.isInput !== get(swapToTokenAmountAtom()).isInput;
+        if (quoteIdentityChanged) {
+          this.invalidateQuoteProducers(set, ESwapQuoteLifecycleResetScope.ALL);
+        }
+        return { quoteIdentityChanged };
+      };
       let currentFromToken = get(swapSelectFromTokenAtom());
       let currentToToken = get(swapSelectToTokenAtom());
+      const selectedTokensColdStartContext = get(
+        swapSelectedTokensColdStartContextAtom(),
+      );
+      const hasStockOwnedSelection =
+        oldType === ESwapTabSwitchType.STOCK ||
+        hasStockOwnedTokens({
+          fromToken: currentFromToken,
+          stockSelectedToken: get(swapStockSelectedTokenAtom()),
+          toToken: currentToToken,
+        });
       const oldVisibleType = getVisibleSwapTabSwitchType(oldType) ?? oldType;
       if (
         oldType !== ESwapTabSwitchType.STOCK &&
@@ -2728,8 +2928,15 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         );
       }
       const isSwitchingFromStockToNonStock =
-        oldType === ESwapTabSwitchType.STOCK &&
+        hasStockOwnedSelection && normalizedType !== ESwapTabSwitchType.STOCK;
+      const hasStaleStockContext =
+        !hasStockOwnedSelection &&
+        selectedTokensColdStartContext?.swapType === ESwapTabSwitchType.STOCK &&
         normalizedType !== ESwapTabSwitchType.STOCK;
+      if (hasStaleStockContext) {
+        set(swapSelectedTokensColdStartContextAtom(), undefined);
+        set(swapInitialSelectedTokensSyncedAtom(), true);
+      }
       let stockExitDefaultTokens:
         | ReturnType<typeof buildSwapDefaultSelectedTokensForNetwork>
         | undefined;
@@ -2783,6 +2990,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         set(swapFromTokenAmountAtom(), { value: '', isInput: false });
         set(swapToTokenAmountAtom(), { value: '', isInput: false });
         set(swapSelectedFromTokenBalanceAtom(), '');
+        set(swapSelectedToTokenBalanceAtom(), '');
         set(swapSelectedTokensColdStartContextAtom(), undefined);
         set(swapInitialSelectedTokensSyncedAtom(), false);
       }
@@ -2800,21 +3008,20 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       }
       if (
         platformEnv.isNative &&
+        oldType !== normalizedType &&
+        !options?.preserveNativeAmount &&
         (oldType === ESwapTabSwitchType.LIMIT ||
-          type === ESwapTabSwitchType.LIMIT)
+          normalizedType === ESwapTabSwitchType.LIMIT)
       ) {
         set(swapFromTokenAmountAtom(), { value: '', isInput: false });
         set(swapToTokenAmountAtom(), { value: '', isInput: false });
       }
-      // OK-49718: Clear quote list when switching type to prevent showing stale data
-      set(swapQuoteListAtom(), []);
-      set(swapQuoteCurrentEventProviderKeysAtom(), []);
-      set(swapQuoteCurrentEventReceivedCountAtom(), 0);
-      set(swapQuoteEventCompletedAtom(), false);
-      set(swapQuoteEventTotalCountAtom(), { count: 0 });
       set(swapTypeSwitchAtom(), normalizedType);
-      if (platformEnv.isNative && normalizedType === ESwapTabSwitchType.LIMIT) {
-        return;
+      if (
+        normalizedType === ESwapTabSwitchType.LIMIT &&
+        (platformEnv.isNative || options?.skipLimitPairReconciliation)
+      ) {
+        return finalizeTransition();
       }
       if (
         oldType === ESwapTabSwitchType.LIMIT &&
@@ -2847,7 +3054,6 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           isFromTokenSupported &&
           isToTokenSupported
         ) {
-          this.cleanManualSelectQuoteProviders.call(set);
           set(swapSelectFromTokenAtom(), lastNonLimitSelectedTokens.fromToken);
           set(swapSelectToTokenAtom(), lastNonLimitSelectedTokens.toToken);
           const sortNetworkId =
@@ -2856,7 +3062,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           if (sortNetworkId) {
             void this.syncNetworksSort.call(set, sortNetworkId);
           }
-          return;
+          return finalizeTransition();
         }
       }
       const fromTokenAmount = get(swapFromTokenAmountAtom());
@@ -2868,7 +3074,6 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       ) {
         set(swapFromTokenAmountAtom(), (o) => ({ ...o, isInput: true }));
       }
-      this.cleanManualSelectQuoteProviders.call(set);
       const swapSupportNetworks = get(swapNetworksIncludeAllNetworkAtom());
       let fromToken = get(swapSelectFromTokenAtom());
       let toToken = get(swapSelectToTokenAtom());
@@ -2900,7 +3105,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           (net) => net.networkId === fromToken?.networkId,
         )
       ) {
-        void this.resetSwapTokenData.call(set, ESwapDirectionType.FROM);
+        set(swapSelectFromTokenAtom(), undefined);
+        set(swapSelectedFromTokenBalanceAtom(), '');
+        set(swapStockExecutionTokensAtom(), undefined);
         fromToken = undefined;
       }
       if (
@@ -2908,7 +3115,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         !isStockExitDefaultToken(toToken) &&
         !swapSupportNetworks.some((net) => net.networkId === toToken?.networkId)
       ) {
-        void this.resetSwapTokenData.call(set, ESwapDirectionType.TO);
+        set(swapSelectToTokenAtom(), undefined);
+        set(swapSelectedToTokenBalanceAtom(), '');
+        set(swapStockExecutionTokensAtom(), undefined);
         toToken = undefined;
       }
       if (
@@ -3002,7 +3211,10 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
                 }
               }
             } else {
-              void this.resetSwapTokenData.call(set, ESwapDirectionType.TO);
+              set(swapSelectToTokenAtom(), undefined);
+              set(swapSelectedToTokenBalanceAtom(), '');
+              set(swapStockExecutionTokensAtom(), undefined);
+              toToken = undefined;
             }
           }
           const fromLimitTokenDefault = fromNetworkDefault?.limitFromToken;
@@ -3018,6 +3230,219 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
             fromToken = fromLimitTokenDefault;
           }
         }
+      }
+      return finalizeTransition();
+    },
+  );
+
+  switchStockPositionToSwapAction = contextAtomMethod(
+    (get, set, token: ISwapToken) => {
+      const previousFromToken = get(swapSelectFromTokenAtom());
+      const previousToToken = get(swapSelectToTokenAtom());
+      const { quoteIdentityChanged } = this.swapTypeSwitchAction.call(
+        set,
+        ESwapTabSwitchType.SWAP,
+      );
+      const currentFromToken = get(swapSelectFromTokenAtom());
+      const currentToToken = get(swapSelectToTokenAtom());
+      let nextToToken = currentToToken;
+      if (
+        equalTokenNoCaseSensitive({
+          token1: currentToToken,
+          token2: token,
+        })
+      ) {
+        nextToToken = currentFromToken;
+      } else {
+        const compatibleToToken = this.needChangeToken({
+          token,
+          swapTypeSwitchValue: ESwapTabSwitchType.SWAP,
+          toToken: currentToToken,
+        });
+        if (compatibleToToken !== null) {
+          nextToToken = compatibleToToken;
+        }
+      }
+      set(swapSelectFromTokenAtom(), token);
+      set(swapSelectToTokenAtom(), nextToToken);
+      if (
+        !quoteIdentityChanged &&
+        (!equalTokenNoCaseSensitive({
+          token1: previousFromToken,
+          token2: token,
+        }) ||
+          !equalTokenNoCaseSensitive({
+            token1: previousToToken,
+            token2: nextToToken,
+          }))
+      ) {
+        this.invalidateQuoteProducers(set, ESwapQuoteLifecycleResetScope.ALL);
+      }
+      void this.syncNetworksSort.call(set, token.networkId);
+    },
+  );
+
+  prepareSwapProEntryAction = contextAtomMethod(
+    (
+      get,
+      set,
+      {
+        direction,
+        token,
+      }: {
+        direction: ESwapDirection;
+        token: ISwapToken;
+      },
+    ) => {
+      const hasStockOwnedSelection = hasStockOwnedTokens({
+        fromToken: get(swapSelectFromTokenAtom()),
+        stockSelectedToken: get(swapStockSelectedTokenAtom()),
+        toToken: get(swapSelectToTokenAtom()),
+      });
+      const hasStaleStockContext =
+        get(swapSelectedTokensColdStartContextAtom())?.swapType ===
+        ESwapTabSwitchType.STOCK;
+      const isPreparedIdentity =
+        get(swapTypeSwitchAtom()) === ESwapTabSwitchType.LIMIT &&
+        get(swapProDirectionAtom()) === direction &&
+        !hasStockOwnedSelection &&
+        !hasStaleStockContext &&
+        equalTokenNoCaseSensitive({
+          token1: get(swapProSelectTokenAtom()),
+          token2: token,
+        });
+      if (isPreparedIdentity) {
+        return this.persistSwapProSelectToken(token);
+      }
+
+      const proIdentityChanged =
+        get(swapProDirectionAtom()) !== direction ||
+        !equalTokenNoCaseSensitive({
+          token1: get(swapProSelectTokenAtom()),
+          token2: token,
+        });
+      const { quoteIdentityChanged } = this.swapTypeSwitchAction.call(
+        set,
+        ESwapTabSwitchType.LIMIT,
+        token.networkId,
+        {
+          preserveNativeAmount: true,
+          skipLimitPairReconciliation: true,
+        },
+      );
+      set(swapProDirectionAtom(), direction);
+      set(swapProSelectTokenAtom(), token);
+      set(swapSelectedTokensColdStartContextAtom(), undefined);
+      set(swapInitialSelectedTokensSyncedAtom(), true);
+      if (proIdentityChanged && !quoteIdentityChanged) {
+        this.invalidateQuoteProducers(set, ESwapQuoteLifecycleResetScope.ALL);
+      }
+      return this.persistSwapProSelectToken(token);
+    },
+  );
+
+  switchSwapProToSwapAction = contextAtomMethod(
+    (
+      get,
+      set,
+      {
+        direction,
+        inputAmount,
+        inputToken,
+        outputToken,
+        selectedToken,
+      }: {
+        direction: ESwapDirection;
+        inputAmount?: string;
+        inputToken?: ISwapToken;
+        outputToken?: ISwapToken;
+        selectedToken?: ISwapToken;
+      },
+    ) => {
+      const previousFromToken = get(swapSelectFromTokenAtom());
+      const previousToToken = get(swapSelectToTokenAtom());
+      const previousFromTokenAmount = get(swapFromTokenAmountAtom());
+      const { quoteIdentityChanged } = this.swapTypeSwitchAction.call(
+        set,
+        ESwapTabSwitchType.SWAP,
+      );
+      let nextFromToken = get(swapSelectFromTokenAtom());
+      let nextToToken = get(swapSelectToTokenAtom());
+      if (direction === ESwapDirection.BUY) {
+        if (
+          selectedToken &&
+          equalTokenNoCaseSensitive({
+            token1: nextFromToken,
+            token2: selectedToken,
+          })
+        ) {
+          nextFromToken = undefined;
+        }
+        nextFromToken = inputToken ?? nextFromToken;
+        if (
+          selectedToken &&
+          !equalTokenNoCaseSensitive({
+            token1: nextFromToken,
+            token2: selectedToken,
+          })
+        ) {
+          nextToToken = selectedToken;
+        }
+      } else {
+        if (
+          selectedToken &&
+          equalTokenNoCaseSensitive({
+            token1: nextToToken,
+            token2: selectedToken,
+          })
+        ) {
+          nextToToken = undefined;
+        }
+        nextToToken = outputToken ?? nextToToken;
+        if (
+          selectedToken &&
+          !equalTokenNoCaseSensitive({
+            token1: nextToToken,
+            token2: selectedToken,
+          })
+        ) {
+          const compatibleToToken = this.needChangeToken({
+            token: selectedToken,
+            swapTypeSwitchValue: ESwapTabSwitchType.SWAP,
+            toToken: nextToToken,
+          });
+          nextFromToken = selectedToken;
+          if (compatibleToToken !== null) {
+            nextToToken = compatibleToToken;
+          }
+        }
+      }
+      set(swapSelectFromTokenAtom(), nextFromToken);
+      set(swapSelectToTokenAtom(), nextToToken);
+      if (selectedToken?.networkId) {
+        void this.syncNetworksSort.call(set, selectedToken.networkId);
+      }
+      if (inputAmount) {
+        set(swapFromTokenAmountAtom(), {
+          value: inputAmount,
+          isInput: true,
+        });
+      }
+      const finalFromTokenAmount = get(swapFromTokenAmountAtom());
+      if (
+        !quoteIdentityChanged &&
+        (!equalTokenNoCaseSensitive({
+          token1: previousFromToken,
+          token2: nextFromToken,
+        }) ||
+          !equalTokenNoCaseSensitive({
+            token1: previousToToken,
+            token2: nextToToken,
+          }) ||
+          previousFromTokenAmount.value !== finalFromTokenAmount.value ||
+          previousFromTokenAmount.isInput !== finalFromTokenAmount.isInput)
+      ) {
+        this.invalidateQuoteProducers(set, ESwapQuoteLifecycleResetScope.ALL);
       }
     },
   );
@@ -3170,6 +3595,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
 
 const createActions = memoFn(() => new ContentJotaiActionsSwap());
 
+export const prepareSwapProEntryCommand =
+  createActions().prepareSwapProEntryAction;
+
 export const useSwapActions = () => {
   const actions = createActions();
   const selectFromToken = actions.selectFromToken.use();
@@ -3185,6 +3613,10 @@ export const useSwapActions = () => {
   const loadSwapSelectTokenDetail = actions.loadSwapSelectTokenDetail.use();
   const swapLoadAllNetworkTokenList = actions.swapLoadAllNetworkTokenList.use();
   const swapTypeSwitchAction = actions.swapTypeSwitchAction.use();
+  const switchStockPositionToSwapAction =
+    actions.switchStockPositionToSwapAction.use();
+  const prepareSwapProEntryAction = actions.prepareSwapProEntryAction.use();
+  const switchSwapProToSwapAction = actions.switchSwapProToSwapAction.use();
   const limitOrderMarketPriceIntervalAction =
     actions.limitOrderMarketPriceIntervalAction.use();
   const swapProTokenMarketDetailFetchAction =
@@ -3220,6 +3652,9 @@ export const useSwapActions = () => {
     swapLoadAllNetworkTokenList,
     closeQuoteEvent,
     swapTypeSwitchAction,
+    switchStockPositionToSwapAction,
+    prepareSwapProEntryAction,
+    switchSwapProToSwapAction,
     needChangeToken,
     limitOrderMarketPriceIntervalAction,
     cleanLimitOrderMarketPriceInterval,

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -2782,6 +2782,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         set(swapSelectToTokenAtom(), currentToToken);
         set(swapFromTokenAmountAtom(), { value: '', isInput: false });
         set(swapToTokenAmountAtom(), { value: '', isInput: false });
+        set(swapSelectedFromTokenBalanceAtom(), '');
         set(swapSelectedTokensColdStartContextAtom(), undefined);
         set(swapInitialSelectedTokensSyncedAtom(), false);
       }

--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -315,6 +315,8 @@ export const {
   receivingAddress?: string;
 }>({ actionLock: false });
 
+export const { atom: swapQuoteRequestIdAtom } = contextAtom<number>(0);
+
 export const {
   atom: swapQuoteIntervalCountAtom,
   use: useSwapQuoteIntervalCountAtom,
@@ -784,6 +786,8 @@ export const {
   atom: swapSpeedQuoteFetchingAtom,
   use: useSwapSpeedQuoteFetchingAtom,
 } = contextAtom<boolean>(false);
+
+export const { atom: swapSpeedQuoteRequestIdAtom } = contextAtom<number>(0);
 
 export const {
   atom: swapSpeedQuoteResultAtom,

--- a/packages/kit/src/states/jotai/contexts/swap/quoteIdentity.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/quoteIdentity.ts
@@ -1,0 +1,205 @@
+import BigNumber from 'bignumber.js';
+
+import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
+import type {
+  IFetchQuotesParams,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
+import {
+  EProtocolOfExchange,
+  ESwapQuoteKind,
+  ESwapTabSwitchType,
+} from '@onekeyhq/shared/types/swap/types';
+
+type ISwapQuoteActionIdentity = {
+  type?: ESwapTabSwitchType;
+  actionLock: boolean;
+  fromToken?: ISwapToken;
+  toToken?: ISwapToken;
+  fromTokenAmount?: string;
+  toTokenAmount?: string;
+  accountId?: string;
+  kind?: ESwapQuoteKind;
+  address?: string;
+  receivingAddress?: string;
+};
+
+export function isStockProtocol(protocol?: string) {
+  return (
+    protocol === ESwapTabSwitchType.STOCK ||
+    protocol === EProtocolOfExchange.STOCK
+  );
+}
+
+export function isSameSwapAmountValue({
+  currentAmount,
+  eventAmount,
+}: {
+  currentAmount?: string;
+  eventAmount?: string;
+}) {
+  if (eventAmount === undefined) {
+    return true;
+  }
+  const normalizedCurrentAmount = currentAmount ?? '';
+  if (!eventAmount && !normalizedCurrentAmount) {
+    return true;
+  }
+  const eventAmountBN = new BigNumber(eventAmount);
+  const currentAmountBN = new BigNumber(normalizedCurrentAmount);
+  if (
+    eventAmountBN.isFinite() &&
+    !eventAmountBN.isNaN() &&
+    currentAmountBN.isFinite() &&
+    !currentAmountBN.isNaN()
+  ) {
+    return eventAmountBN.eq(currentAmountBN);
+  }
+  return eventAmount === normalizedCurrentAmount;
+}
+
+export function isSameQuoteActionIdentity({
+  actionLock,
+  accountId,
+  address,
+  fromToken,
+  inputAmount,
+  kind,
+  receivingAddress,
+  swapType,
+  toToken,
+}: {
+  actionLock: ISwapQuoteActionIdentity;
+  accountId?: string;
+  address?: string;
+  fromToken?: ISwapToken;
+  inputAmount?: string;
+  kind?: ESwapQuoteKind;
+  receivingAddress?: string;
+  swapType: ESwapTabSwitchType;
+  toToken?: ISwapToken;
+}) {
+  const lockedInputAmount =
+    kind === ESwapQuoteKind.BUY
+      ? actionLock.toTokenAmount
+      : actionLock.fromTokenAmount;
+  return (
+    actionLock.actionLock &&
+    actionLock.type === swapType &&
+    actionLock.kind === kind &&
+    equalTokenNoCaseSensitive({
+      token1: actionLock.fromToken,
+      token2: fromToken,
+    }) &&
+    equalTokenNoCaseSensitive({
+      token1: actionLock.toToken,
+      token2: toToken,
+    }) &&
+    isSameSwapAmountValue({
+      currentAmount: lockedInputAmount,
+      eventAmount: inputAmount,
+    }) &&
+    actionLock.accountId === accountId &&
+    actionLock.address === address &&
+    actionLock.receivingAddress === receivingAddress
+  );
+}
+
+function isQuoteProtocolForSwapType({
+  protocol,
+  swapType,
+}: {
+  protocol: string;
+  swapType: ESwapTabSwitchType;
+}) {
+  if (swapType === ESwapTabSwitchType.STOCK) {
+    return isStockProtocol(protocol);
+  }
+  if (swapType === ESwapTabSwitchType.LIMIT) {
+    return (
+      protocol === ESwapTabSwitchType.LIMIT ||
+      protocol === EProtocolOfExchange.LIMIT
+    );
+  }
+  if (swapType === ESwapTabSwitchType.PRIVATE_SEND) {
+    return (
+      protocol === ESwapTabSwitchType.PRIVATE_SEND ||
+      protocol === EProtocolOfExchange.PRIVATE_SEND
+    );
+  }
+  return (
+    protocol === ESwapTabSwitchType.SWAP ||
+    protocol === ESwapTabSwitchType.BRIDGE ||
+    protocol === EProtocolOfExchange.SWAP
+  );
+}
+
+export function isCurrentQuoteEventParams({
+  actionLock,
+  accountId,
+  currentSwapType,
+  fromToken,
+  fromTokenAmount,
+  params,
+  toToken,
+  toTokenAmount,
+  tokenPairs,
+}: {
+  actionLock: ISwapQuoteActionIdentity;
+  accountId?: string;
+  currentSwapType: ESwapTabSwitchType;
+  fromToken?: ISwapToken;
+  fromTokenAmount?: string;
+  params: IFetchQuotesParams;
+  toToken?: ISwapToken;
+  toTokenAmount?: string;
+  tokenPairs: { fromToken: ISwapToken; toToken: ISwapToken };
+}) {
+  const isSameTokenPair =
+    equalTokenNoCaseSensitive({
+      token1: tokenPairs.fromToken,
+      token2: fromToken,
+    }) &&
+    equalTokenNoCaseSensitive({
+      token1: tokenPairs.toToken,
+      token2: toToken,
+    });
+  const isSameFromAmount = isSameSwapAmountValue({
+    currentAmount: fromTokenAmount,
+    eventAmount: params.fromTokenAmount,
+  });
+  if (isStockProtocol(params.protocol)) {
+    return (
+      currentSwapType === ESwapTabSwitchType.STOCK &&
+      isSameTokenPair &&
+      isSameFromAmount
+    );
+  }
+
+  const isBuyQuote = params.kind === ESwapQuoteKind.BUY;
+  const eventInputAmount = isBuyQuote
+    ? params.toTokenAmount
+    : params.fromTokenAmount;
+  return (
+    isQuoteProtocolForSwapType({
+      protocol: params.protocol,
+      swapType: currentSwapType,
+    }) &&
+    isSameTokenPair &&
+    isSameQuoteActionIdentity({
+      actionLock,
+      accountId,
+      address: params.userAddress,
+      fromToken: tokenPairs.fromToken,
+      inputAmount: eventInputAmount,
+      kind: params.kind,
+      receivingAddress: params.receivingAddress,
+      swapType: currentSwapType,
+      toToken: tokenPairs.toToken,
+    }) &&
+    isSameSwapAmountValue({
+      currentAmount: isBuyQuote ? toTokenAmount : fromTokenAmount,
+      eventAmount: eventInputAmount,
+    })
+  );
+}

--- a/packages/kit/src/views/Borrow/borrowUtils.test.ts
+++ b/packages/kit/src/views/Borrow/borrowUtils.test.ts
@@ -1,0 +1,69 @@
+import {
+  EModalStakingRoutes,
+  ETabEarnRoutes,
+} from '@onekeyhq/shared/src/routes';
+
+import { safePushToEarnRoute } from '../Earn/earnUtils';
+
+import { BorrowNavigation } from './borrowUtils';
+
+jest.mock('../Earn/earnUtils', () => ({
+  safePushToEarnRoute: jest.fn(),
+}));
+
+describe('BorrowNavigation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps token and provider logos distinct in reserve-details params', () => {
+    const navigation = {} as Parameters<
+      typeof BorrowNavigation.pushToBorrowReserveDetails
+    >[0];
+
+    BorrowNavigation.pushToBorrowReserveDetails(navigation, {
+      networkId: 'evm--1',
+      provider: 'aave',
+      marketAddress: 'market-address',
+      reserveAddress: 'reserve-address',
+      symbol: 'USDC',
+      logoURI: 'token-logo',
+      providerLogoURI: 'provider-logo',
+    });
+
+    expect(safePushToEarnRoute).toHaveBeenCalledWith(
+      navigation,
+      ETabEarnRoutes.BorrowReserveDetails,
+      expect.objectContaining({
+        logoURI: 'token-logo',
+        providerLogoURI: 'provider-logo',
+      }),
+    );
+  });
+
+  it('keeps provider identity when reserve details opens in a modal', () => {
+    const push = jest.fn();
+    const navigation = { push } as unknown as Parameters<
+      typeof BorrowNavigation.pushToBorrowReserveDetails
+    >[0];
+
+    BorrowNavigation.pushToBorrowReserveDetails(navigation, {
+      networkId: 'evm--1',
+      provider: 'aave',
+      marketAddress: 'market-address',
+      reserveAddress: 'reserve-address',
+      symbol: 'USDC',
+      logoURI: 'token-logo',
+      providerLogoURI: 'provider-logo',
+      isModal: true,
+    });
+
+    expect(push).toHaveBeenCalledWith(
+      EModalStakingRoutes.BorrowReserveDetails,
+      expect.objectContaining({
+        logoURI: 'token-logo',
+        providerLogoURI: 'provider-logo',
+      }),
+    );
+  });
+});

--- a/packages/kit/src/views/Borrow/borrowUtils.ts
+++ b/packages/kit/src/views/Borrow/borrowUtils.ts
@@ -49,6 +49,7 @@ export const BorrowNavigation = {
       reserveAddress: string;
       symbol: string;
       logoURI?: string;
+      providerLogoURI?: string;
       isModal?: boolean;
       accountId?: string;
       indexedAccountId?: string;
@@ -61,6 +62,7 @@ export const BorrowNavigation = {
       reserveAddress: params.reserveAddress,
       symbol: params.symbol,
       logoURI: params.logoURI,
+      providerLogoURI: params.providerLogoURI,
       accountId: params.accountId,
       indexedAccountId: params.indexedAccountId,
     };

--- a/packages/kit/src/views/Borrow/components/BorrowCard.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowCard.tsx
@@ -69,6 +69,7 @@ export const BorrowCard = () => {
           reserveAddress: item.reserveAddress,
           symbol: item.token.symbol,
           logoURI: item.token.logoURI,
+          providerLogoURI: market.logoURI,
           accountId: accountId || undefined,
           indexedAccountId,
         });

--- a/packages/kit/src/views/Borrow/components/BorrowedCard.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowedCard.tsx
@@ -111,6 +111,7 @@ export const BorrowedCard = () => {
           reserveAddress: item.reserveAddress,
           symbol: item.token.symbol,
           logoURI: item.token.logoURI,
+          providerLogoURI: market.logoURI,
           accountId: accountId || undefined,
           indexedAccountId,
         });

--- a/packages/kit/src/views/Borrow/components/SuppliedCard.tsx
+++ b/packages/kit/src/views/Borrow/components/SuppliedCard.tsx
@@ -111,6 +111,7 @@ export const SuppliedCard = () => {
           reserveAddress: item.reserveAddress,
           symbol: item.token.symbol,
           logoURI: item.token.logoURI,
+          providerLogoURI: market.logoURI,
           accountId: accountId || undefined,
           indexedAccountId,
         });

--- a/packages/kit/src/views/Borrow/components/SupplyCard.tsx
+++ b/packages/kit/src/views/Borrow/components/SupplyCard.tsx
@@ -128,6 +128,7 @@ export const SupplyCard = () => {
           reserveAddress: item.reserveAddress,
           symbol: item.token.symbol,
           logoURI: item.token.logoURI,
+          providerLogoURI: market.logoURI,
           accountId: accountId || undefined,
           indexedAccountId,
         });

--- a/packages/kit/src/views/Borrow/pages/BorrowManagePosition/index.tsx
+++ b/packages/kit/src/views/Borrow/pages/BorrowManagePosition/index.tsx
@@ -67,6 +67,7 @@ const BorrowManagePosition = () => {
       reserveAddress,
       symbol,
       logoURI,
+      providerLogoURI,
       isModal: true,
       accountId: accountId || undefined,
       indexedAccountId,
@@ -79,6 +80,7 @@ const BorrowManagePosition = () => {
     reserveAddress,
     symbol,
     logoURI,
+    providerLogoURI,
     accountId,
     indexedAccountId,
   ]);

--- a/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ManagePositionPart.test.tsx
+++ b/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ManagePositionPart.test.tsx
@@ -1,0 +1,141 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import type { IBorrowReserveDetail } from '@onekeyhq/shared/types/staking';
+
+import { ManagePositionPart } from './ManagePositionPart';
+
+const mockNavigation = {};
+const mockPushToBorrowManagePosition = jest.fn();
+
+jest.mock('@onekeyhq/components', () => ({
+  Button: ({
+    children,
+    disabled,
+    onPress,
+    testID,
+  }: {
+    children?: ReactNode;
+    disabled?: boolean;
+    onPress?: () => void;
+    testID?: string;
+  }) => (
+    <button
+      data-testid={testID}
+      disabled={disabled}
+      onClick={onPress}
+      type="button"
+    >
+      {children}
+    </button>
+  ),
+  Divider: () => <hr />,
+  Icon: () => null,
+  SizableText: ({ children }: { children?: ReactNode }) => (
+    <span>{children}</span>
+  ),
+  XStack: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  YStack: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/useAppNavigation', () => ({
+  __esModule: true,
+  default: () => mockNavigation,
+}));
+
+jest.mock(
+  '@onekeyhq/kit/src/views/Staking/components/ProtocolDetails/EarnText',
+  () => ({ EarnText: () => null }),
+);
+
+jest.mock(
+  '@onekeyhq/kit/src/views/Staking/components/ProtocolDetails/EarnTooltip',
+  () => ({ EarnTooltip: () => null }),
+);
+
+jest.mock(
+  '@onekeyhq/kit/src/views/Staking/pages/ManagePosition/hooks/useManagePage',
+  () => ({
+    EManagePositionType: {
+      Supply: 'supply',
+      Borrow: 'borrow',
+    },
+  }),
+);
+
+jest.mock('../../../borrowUtils', () => ({
+  BorrowNavigation: {
+    pushToBorrowManagePosition: (...args: unknown[]) => {
+      mockPushToBorrowManagePosition(...args);
+    },
+  },
+}));
+
+describe('ManagePositionPart', () => {
+  beforeEach(() => {
+    mockPushToBorrowManagePosition.mockClear();
+  });
+
+  it('keeps token and provider logos distinct for supply and borrow actions', () => {
+    const userInfo = {
+      walletBalance: {
+        button: {
+          disabled: false,
+          text: { text: 'Supply' },
+        },
+      },
+      availableBorrowBalance: {
+        button: {
+          disabled: false,
+          text: { text: 'Borrow' },
+        },
+      },
+    } as IBorrowReserveDetail['userInfo'];
+
+    render(
+      <ManagePositionPart
+        accountId="account-1"
+        userInfo={userInfo}
+        networkId="evm--1"
+        provider="aave"
+        marketAddress="market-address"
+        reserveAddress="reserve-address"
+        symbol="USDC"
+        logoURI="token-logo"
+        providerLogoURI="provider-logo"
+      />,
+    );
+
+    const [supplyButton, borrowButton] = screen.getAllByTestId('borrow-btn');
+    fireEvent.click(supplyButton);
+    fireEvent.click(borrowButton);
+
+    expect(mockPushToBorrowManagePosition).toHaveBeenNthCalledWith(
+      1,
+      mockNavigation,
+      expect.objectContaining({
+        logoURI: 'token-logo',
+        providerLogoURI: 'provider-logo',
+        type: 'supply',
+      }),
+    );
+    expect(mockPushToBorrowManagePosition).toHaveBeenNthCalledWith(
+      2,
+      mockNavigation,
+      expect.objectContaining({
+        logoURI: 'token-logo',
+        providerLogoURI: 'provider-logo',
+        type: 'borrow',
+      }),
+    );
+  });
+});

--- a/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ManagePositionPart.tsx
+++ b/packages/kit/src/views/Borrow/pages/ReserveDetails/components/ManagePositionPart.tsx
@@ -28,6 +28,7 @@ interface IManagePositionPartProps {
   reserveAddress: string;
   symbol: string;
   logoURI?: string;
+  providerLogoURI?: string;
 }
 
 export const ManagePositionPart = ({
@@ -39,6 +40,7 @@ export const ManagePositionPart = ({
   reserveAddress,
   symbol,
   logoURI,
+  providerLogoURI,
 }: IManagePositionPartProps) => {
   const navigation = useAppNavigation();
   const intl = useIntl();
@@ -52,7 +54,7 @@ export const ManagePositionPart = ({
       reserveAddress,
       symbol,
       logoURI,
-      providerLogoURI: logoURI,
+      providerLogoURI,
       type: EManagePositionType.Supply,
     });
   }, [
@@ -64,6 +66,7 @@ export const ManagePositionPart = ({
     reserveAddress,
     symbol,
     logoURI,
+    providerLogoURI,
   ]);
 
   const handleBorrow = useCallback(() => {
@@ -75,7 +78,7 @@ export const ManagePositionPart = ({
       reserveAddress,
       symbol,
       logoURI,
-      providerLogoURI: logoURI,
+      providerLogoURI,
       type: EManagePositionType.Borrow,
     });
   }, [
@@ -87,6 +90,7 @@ export const ManagePositionPart = ({
     reserveAddress,
     symbol,
     logoURI,
+    providerLogoURI,
   ]);
 
   const labels = {

--- a/packages/kit/src/views/Borrow/pages/ReserveDetails/index.tsx
+++ b/packages/kit/src/views/Borrow/pages/ReserveDetails/index.tsx
@@ -17,7 +17,9 @@ import { useAppRoute } from '@onekeyhq/kit/src/hooks/useAppRoute';
 import { EarnText } from '@onekeyhq/kit/src/views/Staking/components/ProtocolDetails/EarnText';
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type {
+  EModalStakingRoutes,
   ETabEarnRoutes,
+  IModalStakingParamList,
   ITabEarnParamList,
 } from '@onekeyhq/shared/src/routes';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
@@ -59,9 +61,10 @@ function ManagersSection({
 
 const ReserveDetailsPage = () => {
   const route = useAppRoute<
-    ITabEarnParamList,
+    ITabEarnParamList & IModalStakingParamList,
     | ETabEarnRoutes.BorrowReserveDetails
     | ETabEarnRoutes.BorrowReserveDetailsShare
+    | EModalStakingRoutes.BorrowReserveDetails
   >();
   const { gtMd } = useMedia();
   const { shareText } = useShare();
@@ -75,6 +78,7 @@ const ReserveDetailsPage = () => {
     reserveAddress: string;
     symbol: string;
     logoURI?: string;
+    providerLogoURI?: string;
     accountId?: string;
     indexedAccountId?: string;
   }>(() => {
@@ -90,6 +94,7 @@ const ReserveDetailsPage = () => {
       reserveAddress: routeParams.reserveAddress,
       symbol: routeParams.symbol,
       logoURI: routeParams.logoURI,
+      providerLogoURI: routeParams.providerLogoURI,
       accountId: routeParams.accountId,
       indexedAccountId: routeParams.indexedAccountId,
     };
@@ -102,6 +107,7 @@ const ReserveDetailsPage = () => {
     reserveAddress,
     symbol,
     logoURI,
+    providerLogoURI,
     accountId: routeAccountId,
     indexedAccountId,
   } = resolvedParams;
@@ -247,6 +253,7 @@ const ReserveDetailsPage = () => {
             reserveAddress={reserveAddress}
             symbol={symbol}
             logoURI={logoURI}
+            providerLogoURI={providerLogoURI}
           />
         </Stack>
       </XStack>

--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
@@ -713,7 +713,7 @@ const ManagePositionPart = ({
 const EarnProtocolDetailsPage = ({ route }: { route: IRouteProps }) => {
   const intl = useIntl();
   const appNavigation = useAppNavigation();
-  const { gtMd } = useMedia();
+  const { gtMd, gtSm } = useMedia();
   const { shareText } = useShare();
   const [devSettings] = useDevSettingsPersistAtom();
   const { activeAccount } = useActiveAccount({ num: 0 });
@@ -938,7 +938,7 @@ const EarnProtocolDetailsPage = ({ route }: { route: IRouteProps }) => {
       tabRoute={ETabRoutes.Earn}
       showBackButton
       header={
-        <XStack ml={gtMd ? 'auto' : '0'} pr="$2" pt={gtMd ? undefined : '$4'}>
+        <XStack ml={gtSm ? 'auto' : '0'} pr="$2" pt={gtSm ? undefined : '$4'}>
           <ManagersSection managers={detailInfo?.managers} noPadding />
         </XStack>
       }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanel.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanel.tsx
@@ -19,6 +19,7 @@ import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/Acco
 import { useAccountSelectorTrigger } from '@onekeyhq/kit/src/components/AccountSelector/hooks/useAccountSelectorTrigger';
 import { Currency } from '@onekeyhq/kit/src/components/Currency';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { prepareSwapProEntryState } from '@onekeyhq/kit/src/views/Swap/utils/swapProEntryState';
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   ESwapProJumpTokenDirection,
@@ -129,15 +130,17 @@ export function SwapPanel({
   const [, setSwapProJumpTokenAtom] = useSwapProJumpTokenAtom();
 
   const handleTrade = useCallback(() => {
+    const direction = ESwapProJumpTokenDirection.BUY;
     setSwapProJumpTokenAtom({
       token: swapToken,
-      direction: ESwapProJumpTokenDirection.BUY,
+      direction,
       marketPresetToken: {
         networkId: swapToken.networkId,
         contractAddress: swapToken.contractAddress,
         isNative: swapToken.isNative,
       },
     });
+    prepareSwapProEntryState({ token: swapToken, direction });
     navigation.pop();
     navigation.switchTab(ETabRoutes.Swap);
   }, [setSwapProJumpTokenAtom, swapToken, navigation]);

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/MarketPresetSelector/MarketPresetSelector.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/MarketPresetSelector/MarketPresetSelector.tsx
@@ -1428,6 +1428,7 @@ function MarketPresetSettingsDialog({
                       size="medium"
                       error={showCurrentPriorityFeeError}
                       value={currentSettings.priorityFee.customValue ?? ''}
+                      keyboardType="decimal-pad"
                       addOns={[
                         {
                           renderContent: (

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenListNetworkSelector/NetworksFilterItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenListNetworkSelector/NetworksFilterItem.tsx
@@ -8,6 +8,7 @@ import {
   useMedia,
 } from '@onekeyhq/components';
 import type { IXStackProps } from '@onekeyhq/components';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 export type INetworksFilterItemProps = {
   networkImageUri?: string;
@@ -59,7 +60,7 @@ export function NetworksFilterItem({
     <XStack
       alignItems="center"
       justifyContent="center"
-      px="$2.5"
+      px={md && platformEnv.isNativeIOS ? '$2' : '$2.5'}
       py="$1.5"
       gap={md ? '$1' : '$2'}
       borderRadius={md ? '$full' : '$2.5'}

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -4074,6 +4074,51 @@ function SendAmountInputContainer() {
             gap="$1"
             flexShrink={1}
             minWidth={0}
+            minHeight={
+              shouldUsePrivateSendQuoteCollapse
+                ? privateSendQuoteSummaryRowMinHeight
+                : undefined
+            }
+            role={shouldUsePrivateSendQuoteCollapse ? 'button' : undefined}
+            aria-expanded={
+              shouldUsePrivateSendQuoteCollapse
+                ? isPrivateSendQuoteDetailsExpanded
+                : undefined
+            }
+            focusable={shouldUsePrivateSendQuoteCollapse || undefined}
+            cursor={shouldUsePrivateSendQuoteCollapse ? 'pointer' : undefined}
+            hoverStyle={
+              shouldUsePrivateSendQuoteCollapse ? { bg: '$bgHover' } : undefined
+            }
+            pressStyle={
+              shouldUsePrivateSendQuoteCollapse
+                ? { bg: '$bgActive' }
+                : undefined
+            }
+            focusVisibleStyle={
+              shouldUsePrivateSendQuoteCollapse
+                ? {
+                    outlineColor: '$focusRing',
+                    outlineWidth: 2,
+                    outlineStyle: 'solid',
+                    outlineOffset: 1,
+                  }
+                : undefined
+            }
+            onPress={
+              shouldUsePrivateSendQuoteCollapse
+                ? handleTogglePrivateSendQuoteDetails
+                : undefined
+            }
+            {...(shouldUsePrivateSendQuoteCollapse &&
+              !platformEnv.isNative && {
+                onKeyDown: (event: KeyboardEvent) => {
+                  if (event.key !== 'Enter' && event.key !== ' ') return;
+                  event.preventDefault();
+                  event.stopPropagation();
+                  handleTogglePrivateSendQuoteDetails();
+                },
+              })}
           >
             {showPrivateSendQuoteSkeleton ? (
               <Skeleton h="$4" w="$24" />
@@ -4120,10 +4165,6 @@ function SendAmountInputContainer() {
                 alignItems="center"
                 justifyContent="center"
                 borderRadius="$full"
-                cursor="pointer"
-                hoverStyle={{ bg: '$bgHover' }}
-                pressStyle={{ bg: '$bgActive' }}
-                onPress={handleTogglePrivateSendQuoteDetails}
               >
                 <Stack
                   animation="quick"

--- a/packages/kit/src/views/Swap/hooks/useSwapPro.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapPro.ts
@@ -99,18 +99,15 @@ const SWAP_PRO_SEARCH_RESULTS_REFRESH_INTERVAL = timerUtils.getTimeDurationMs({
 });
 
 export function useSwapProInit() {
-  const [, setSwapSwitchType] = useSwapTypeSwitchAtom();
-  const [, setSwapProDirection] = useSwapProDirectionAtom();
   const { networkList } = useMarketBasicConfig();
-  const { setSwapProSelectToken } = useSwapActions().current;
+  const { prepareSwapProEntryAction } = useSwapActions().current;
   const [swapProSelectToken] = useSwapProSelectTokenAtom();
   const [swapProJumpToken, setSwapProJumpToken] = useSwapProJumpTokenAtom();
   const swapSwitchProToken = useCallback(
-    (payload: { token: ISwapToken }) => {
-      setSwapSwitchType(ESwapTabSwitchType.LIMIT);
-      void setSwapProSelectToken(payload.token);
+    (payload: { direction: ESwapDirection; token: ISwapToken }) => {
+      void prepareSwapProEntryAction(payload);
     },
-    [setSwapSwitchType, setSwapProSelectToken],
+    [prepareSwapProEntryAction],
   );
   const swapProSelectTokenRef = useRef<ISwapToken | undefined>(
     swapProSelectToken,
@@ -126,24 +123,20 @@ export function useSwapProInit() {
   }
   useEffect(() => {
     if (swapProJumpToken.token) {
-      swapSwitchProToken({ token: swapProJumpToken.token });
-      if (swapProJumpToken.direction === ESwapProJumpTokenDirection.SELL) {
-        setSwapProDirection(ESwapDirection.SELL);
-      } else {
-        setSwapProDirection(ESwapDirection.BUY);
-      }
+      swapSwitchProToken({
+        direction:
+          swapProJumpToken.direction === ESwapProJumpTokenDirection.SELL
+            ? ESwapDirection.SELL
+            : ESwapDirection.BUY,
+        token: swapProJumpToken.token,
+      });
       setSwapProJumpToken({
         token: undefined,
         direction: ESwapProJumpTokenDirection.BUY,
         marketPresetToken: undefined,
       });
     }
-  }, [
-    swapProJumpToken,
-    swapSwitchProToken,
-    setSwapProJumpToken,
-    setSwapProDirection,
-  ]);
+  }, [swapProJumpToken, swapSwitchProToken, setSwapProJumpToken]);
   return {
     networkList,
   };
@@ -1572,8 +1565,7 @@ export function useSwapBuildTxInfo() {
 }
 
 export function useSwapProActionsQuote() {
-  const { quoteSpeedAction, cancelSpeedQuote, cleanSpeedQuote } =
-    useSwapActions().current;
+  const { quoteSpeedAction, cleanSpeedQuote } = useSwapActions().current;
   const [swapTabSwitchType] = useSwapTypeSwitchAtom();
   const [swapTradeType] = useSwapProTradeTypeAtom();
   const [swapProInputAmount, setSwapProInputAmount] =
@@ -1637,10 +1629,9 @@ export function useSwapProActionsQuote() {
   useEffect(() => {
     const debounceInputAmountBN = new BigNumber(debounceInputAmount || '0');
     if (debounceInputAmountBN.isNaN() || debounceInputAmountBN.lte(0)) {
-      cancelSpeedQuote();
       void cleanSpeedQuote();
     }
-  }, [cancelSpeedQuote, cleanSpeedQuote, debounceInputAmount]);
+  }, [cleanSpeedQuote, debounceInputAmount]);
 
   useEffect(() => {
     if (

--- a/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
@@ -708,7 +708,7 @@ export function useSwapQuote() {
         );
       } else if (enableFilled) {
         if (swapTabSwitchTypeRef.current !== swapType) {
-          await swapTypeSwitchAction(swapType);
+          swapTypeSwitchAction(swapType);
         }
         setSwapSelectFromToken(fromTokenInfo);
         setSwapSelectToToken(toTokenInfo);

--- a/packages/kit/src/views/Swap/pages/components/SwapHeaderContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHeaderContainer.tsx
@@ -25,6 +25,7 @@ import {
   useSwapSelectFromTokenAtom,
   useSwapTypeSwitchAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
+import { useSwapProJumpTokenAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/swap';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -42,6 +43,7 @@ import {
 } from '../../utils/swapStockAnalytics';
 import { getVisibleSwapTabSwitchType } from '../../utils/swapTypeUtils';
 
+import { shouldInitializeSwapTypeFromRoute } from './swapHeaderInitialization';
 import SwapHeaderRightActionContainer from './SwapHeaderRightActionContainer';
 
 import type { IMarketPresetSettingsState } from '../../../Market/MarketDetailV2/components/SwapPanel/hooks/useMarketPresetSettings';
@@ -140,6 +142,7 @@ const SwapHeaderContainer = ({
   const { gtLg } = useMedia();
   const navigation = useAppNavigation<IPageNavigationProp<ITabSwapParamList>>();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
+  const [swapProJumpToken] = useSwapProJumpTokenAtom();
   const { swapTypeSwitchAction } = useSwapActions().current;
   const { networkId } = useSwapAddressInfo(ESwapDirectionType.FROM);
   const { updateSelectedAccountNetwork } = useAccountSelectorActions().current;
@@ -151,17 +154,28 @@ const SwapHeaderContainer = ({
   if (networkIdRef.current !== fromToken?.networkId) {
     networkIdRef.current = fromToken?.networkId;
   }
+  const preservePreparedSwapTypeOnMountRef = useRef(
+    Boolean(platformEnv.isNative && swapProJumpToken.token),
+  );
   useEffect(() => {
-    if (defaultSwapType) {
-      // Avoid switching the default toToken before it has been loaded,
-      // resulting in the default network toToken across chains
-      setTimeout(
-        () => {
-          void swapTypeSwitchAction(defaultSwapType, networkIdRef.current);
-        },
-        platformEnv.isExtension ? 100 : 10,
-      );
+    if (
+      !defaultSwapType ||
+      !shouldInitializeSwapTypeFromRoute({
+        defaultSwapType,
+        hasPreparedSwapProEntry: preservePreparedSwapTypeOnMountRef.current,
+      })
+    ) {
+      return;
     }
+    // Avoid switching the default toToken before it has been loaded,
+    // resulting in the default network toToken across chains
+    const timer = setTimeout(
+      () => {
+        void swapTypeSwitchAction(defaultSwapType, networkIdRef.current);
+      },
+      platformEnv.isExtension ? 100 : 10,
+    );
+    return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -202,7 +216,7 @@ const SwapHeaderContainer = ({
 
       if (swapTypeSwitch === ESwapTabSwitchType.STOCK) {
         syncRouteTabParam(newType);
-        await swapTypeSwitchAction(newType, networkId);
+        swapTypeSwitchAction(newType, networkId);
         return;
       }
 

--- a/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHeaderRightActionContainer.tsx
@@ -301,8 +301,7 @@ const SwapSettingsDialogContent = ({
   const [{ swapBatchApproveAndSwap }, setPersistSettings] =
     useSettingsPersistAtom();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
-  const { cleanQuoteInterval, closeQuoteEvent, resetQuoteAction } =
-    useSwapActions().current;
+  const { resetQuoteAction } = useSwapActions().current;
   const keyboardHeight = useKeyboardHeight();
   const { top: safeAreaTop } = useSafeAreaInsets();
   const { height: windowHeight } = useWindowDimensions();
@@ -377,11 +376,9 @@ const SwapSettingsDialogContent = ({
   );
   const dialogRef = useRef<ReturnType<typeof Dialog.show> | null>(null);
   const handleProviderManagerSaved = useCallback(() => {
-    cleanQuoteInterval();
-    closeQuoteEvent();
     void resetQuoteAction();
     void dialogRef.current?.close();
-  }, [cleanQuoteInterval, closeQuoteEvent, resetQuoteAction]);
+  }, [resetQuoteAction]);
   return (
     <ScrollView
       mx="$-5"

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -176,8 +176,13 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   const [{ swapRecentTokenPairs }] = useInAppNotificationAtom();
   const [fromTokenAmount, setFromInputAmount] = useSwapFromTokenAmountAtom();
   const [, setSwapQuoteIntervalCount] = useSwapQuoteIntervalCountAtom();
-  const { selectFromToken, selectToToken, quoteAction, cleanQuoteInterval } =
-    useSwapActions().current;
+  const {
+    selectFromToken,
+    selectToToken,
+    quoteAction,
+    cleanQuoteInterval,
+    switchStockPositionToSwapAction,
+  } = useSwapActions().current;
   const [{ actionLock }] = useSwapQuoteActionLockAtom();
   const [swapFromTokenBalance] = useSwapSelectedFromTokenBalanceAtom();
   const [, setSwapShouldRefreshQuote] = useSwapShouldRefreshQuoteAtom();
@@ -511,8 +516,8 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
         token1: fromTokenPair,
         token2: toTokenPair,
       });
-      void selectFromToken(fromTokenPair, true, undefined, skipCheckEqualToken);
-      void selectToToken(toTokenPair, undefined, skipCheckEqualToken);
+      void selectFromToken(fromTokenPair, true, skipCheckEqualToken);
+      void selectToToken(toTokenPair, skipCheckEqualToken);
       defaultLogger.swap.selectToken.selectToken({
         selectFrom: ESwapSelectTokenSource.RECENT_SELECT,
         tokenListType: getSwapAnalyticsTokenListType({
@@ -1163,6 +1168,16 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
       setSwapSelectToToken,
     ],
   );
+  const onSwitchToSwapTokenPress = useCallback(
+    (token: ISwapToken) => {
+      void switchStockPositionToSwapAction(token);
+      scrollViewRef.current?.scrollTo({
+        y: 0,
+        animated: true,
+      });
+    },
+    [switchStockPositionToSwapAction],
+  );
 
   const { networkList: SwapProSupportNetworksList } = useSwapProInit();
   const [swapNetworks] = useSwapNetworksAtom();
@@ -1216,7 +1231,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
         <SwapStockDesktopContainer
           storeName={storeName}
           onSelectToken={onSelectToken}
-          onTokenPress={onTokenPress}
+          onSwitchToSwapTokenPress={onSwitchToSwapTokenPress}
           supportNetworksList={swapBridgeSupportNetworksFilterAllNet}
           fetchLoading={fetchLoading}
           onSelectPercentageStage={onSelectPercentageStage}
@@ -1246,7 +1261,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
         <SwapStockMobileContainer
           storeName={storeName}
           onSelectToken={onSelectToken}
-          onTokenPress={onTokenPress}
+          onSwitchToSwapTokenPress={onSwitchToSwapTokenPress}
           supportNetworksList={swapBridgeSupportNetworksFilterAllNet}
           fetchLoading={fetchLoading}
           onSelectPercentageStage={onSelectPercentageStage}
@@ -1337,6 +1352,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     quoteLoading,
     quoteEventFetching,
     alerts,
+    onSwitchToSwapTokenPress,
     onTokenPress,
     onSelectRecentTokenPairs,
     onOpenOrdersClick,

--- a/packages/kit/src/views/Swap/pages/components/SwapProActionButton.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProActionButton.tsx
@@ -16,18 +16,11 @@ import {
   useSwapProTokenMarketDetailInfoAtom,
   useSwapProTradeTypeAtom,
   useSwapQuoteCurrentSelectAtom,
-  useSwapSelectFromTokenAtom,
-  useSwapSelectToTokenAtom,
   useSwapSpeedQuoteFetchingAtom,
   useSwapSpeedQuoteResultAtom,
-  useSwapTypeSwitchAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
-import {
-  ESwapProTradeType,
-  ESwapTabSwitchType,
-} from '@onekeyhq/shared/types/swap/types';
+import { ESwapProTradeType } from '@onekeyhq/shared/types/swap/types';
 
 import { ESwapDirection } from '../../../Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
 import {
@@ -273,68 +266,23 @@ const SwapProActionButton = ({
     limitPriceUseRate?.rate,
   ]);
 
-  const [, setSwapTypeSwitch] = useSwapTypeSwitchAtom();
-  const { selectToToken, selectFromToken } = useSwapActions().current;
-  const [swapSelectToken, setSwapSelectFromToken] =
-    useSwapSelectFromTokenAtom();
-  const [swapSelectToToken, setSwapSelectToToken] = useSwapSelectToTokenAtom();
-  const [, setSwapFromInputAmount] = useSwapFromTokenAmountAtom();
+  const { switchSwapProToSwapAction } = useSwapActions().current;
 
   const handleJumpToSwapAction = useCallback(() => {
-    void setSwapTypeSwitch(ESwapTabSwitchType.SWAP);
-    if (swapProDirection === ESwapDirection.BUY) {
-      if (
-        equalTokenNoCaseSensitive({
-          token1: swapSelectToken,
-          token2: swapProSelectToken,
-        }) &&
-        swapProSelectToken
-      ) {
-        void setSwapSelectFromToken(undefined);
-      }
-      if (inputToken) {
-        void setSwapSelectFromToken(inputToken);
-      }
-      if (swapProSelectToken) {
-        void selectToToken(swapProSelectToken);
-      }
-    } else {
-      if (
-        equalTokenNoCaseSensitive({
-          token1: swapSelectToToken,
-          token2: swapProSelectToken,
-        }) &&
-        swapProSelectToken
-      ) {
-        void setSwapSelectToToken(undefined);
-      }
-      if (toToken) {
-        void setSwapSelectToToken(toToken);
-      }
-      if (swapProSelectToken) {
-        void selectFromToken(swapProSelectToken);
-      }
-    }
-    if (swapProInputAmount) {
-      void setSwapFromInputAmount({
-        value: swapProInputAmount,
-        isInput: true,
-      });
-    }
+    void switchSwapProToSwapAction({
+      direction: swapProDirection,
+      inputAmount: swapProInputAmount,
+      inputToken,
+      outputToken: toToken,
+      selectedToken: swapProSelectToken,
+    });
   }, [
+    inputToken,
     swapProDirection,
     swapProInputAmount,
-    setSwapTypeSwitch,
-    swapSelectToken,
     swapProSelectToken,
-    inputToken,
-    setSwapSelectFromToken,
-    selectToToken,
-    swapSelectToToken,
+    switchSwapProToSwapAction,
     toToken,
-    setSwapSelectToToken,
-    selectFromToken,
-    setSwapFromInputAmount,
   ]);
   const onPressActionButton = useCallback(() => {
     if (!supportSpeedSwap) {

--- a/packages/kit/src/views/Swap/pages/components/SwapProInputContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProInputContainer.tsx
@@ -24,7 +24,6 @@ import {
   useSwapProSellToTokenAtom,
   useSwapProTradeTypeAtom,
   useSwapProUseSelectBuyTokenAtom,
-  useSwapTypeSwitchAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import { validateAmountInput } from '@onekeyhq/kit/src/utils/validateAmountInput';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -36,7 +35,6 @@ import {
 import type { ISwapTokenBase } from '@onekeyhq/shared/types/swap/types';
 import {
   ESwapProTradeType,
-  ESwapTabSwitchType,
   SwapAmountInputAccessoryViewID,
 } from '@onekeyhq/shared/types/swap/types';
 
@@ -74,7 +72,6 @@ const SwapProInputContainer = ({
   const [swapProDirection] = useSwapProDirectionAtom();
   const [swapProTradeType] = useSwapProTradeTypeAtom();
   const [swapProSelectToken] = useSwapProSelectTokenAtom();
-  const [, setSwapTypeSwitch] = useSwapTypeSwitchAtom();
   const [fromInputAmount, setFromInputAmount] = useSwapFromTokenAmountAtom();
   const [swapProInputAmount, setSwapProInputAmount] =
     useSwapProInputAmountAtom();
@@ -283,9 +280,6 @@ const SwapProInputContainer = ({
           onOpenChange={setIsPopoverOpen}
           tokens={defaultTokensFromType as IToken[]}
           onTokenPress={handleTokenSelect}
-          onTradePress={() => {
-            setSwapTypeSwitch(ESwapTabSwitchType.SWAP);
-          }}
           disabledOnSwitchToTrade
         />
       </XStack>

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -48,7 +48,6 @@ import {
   useSwapSelectFromTokenAtom,
   useSwapSelectToTokenAtom,
   useSwapToTokenAmountAtom,
-  useSwapTypeSwitchAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import { BaseMarketTokenPrice } from '@onekeyhq/kit/src/views/Market/components/MarketTokenPrice';
 import {
@@ -163,7 +162,7 @@ interface ISwapStockDesktopContainerProps {
   headerContent?: ReactNode;
   storeName: EJotaiContextStoreNames;
   onSelectToken: (type: ESwapDirectionType) => void;
-  onTokenPress?: (token: ISwapToken) => void;
+  onSwitchToSwapTokenPress?: (token: ISwapToken) => void;
   supportNetworksList: (IMarketBasicConfigNetwork | ISwapNetwork)[];
   fetchLoading: boolean;
   onSelectPercentageStage: (stage: number) => void;
@@ -1791,18 +1790,17 @@ function StockPriceChart({
 }
 
 function StockMobilePositionsSection({
-  onTokenPress,
+  onSwitchToSwapTokenPress,
   supportNetworksList,
   storeName,
 }: {
-  onTokenPress?: (token: ISwapToken) => void;
+  onSwitchToSwapTokenPress?: (token: ISwapToken) => void;
   supportNetworksList: (IMarketBasicConfigNetwork | ISwapNetwork)[];
   storeName: EJotaiContextStoreNames;
 }) {
   const intl = useIntl();
   const stockChannel = useSwapStockTradeContext();
   const [swapProEnableCurrentSymbol] = useSwapProEnableCurrentSymbolAtom();
-  const [, setSwapTypeSwitch] = useSwapTypeSwitchAtom();
   const [swapFromToken] = useSwapSelectFromTokenAtom();
   const [swapToToken] = useSwapSelectToTokenAtom();
   const { selectStockSwapToken } = stockChannel;
@@ -1826,10 +1824,9 @@ function StockMobilePositionsSection({
         selectStockSwapToken(token, { resetReceiveAmount: true });
         return;
       }
-      void setSwapTypeSwitch(ESwapTabSwitchType.SWAP);
-      onTokenPress?.(token);
+      onSwitchToSwapTokenPress?.(token);
     },
-    [onTokenPress, selectStockSwapToken, setSwapTypeSwitch],
+    [onSwitchToSwapTokenPress, selectStockSwapToken],
   );
 
   const [activeStockTab, setActiveStockTab] = useState<'position' | 'history'>(
@@ -2307,7 +2304,7 @@ function SwapStockMobileContent(props: ISwapStockDesktopContainerProps) {
         {isDesktopModalPage ? null : (
           <YStack mt="$2">
             <StockMobilePositionsSection
-              onTokenPress={props.onTokenPress}
+              onSwitchToSwapTokenPress={props.onSwitchToSwapTokenPress}
               supportNetworksList={props.supportNetworksList}
               storeName={props.storeName}
             />

--- a/packages/kit/src/views/Swap/pages/components/swapHeaderInitialization.test.ts
+++ b/packages/kit/src/views/Swap/pages/components/swapHeaderInitialization.test.ts
@@ -1,0 +1,23 @@
+import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
+
+import { shouldInitializeSwapTypeFromRoute } from './swapHeaderInitialization';
+
+describe('shouldInitializeSwapTypeFromRoute', () => {
+  it('does not let a stale Swap route override a prepared Pro handoff', () => {
+    expect(
+      shouldInitializeSwapTypeFromRoute({
+        defaultSwapType: ESwapTabSwitchType.SWAP,
+        hasPreparedSwapProEntry: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('still applies an explicit route when there is no Pro handoff', () => {
+    expect(
+      shouldInitializeSwapTypeFromRoute({
+        defaultSwapType: ESwapTabSwitchType.LIMIT,
+        hasPreparedSwapProEntry: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/kit/src/views/Swap/pages/components/swapHeaderInitialization.ts
+++ b/packages/kit/src/views/Swap/pages/components/swapHeaderInitialization.ts
@@ -1,0 +1,11 @@
+import type { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
+
+export function shouldInitializeSwapTypeFromRoute({
+  defaultSwapType,
+  hasPreparedSwapProEntry,
+}: {
+  defaultSwapType?: ESwapTabSwitchType;
+  hasPreparedSwapProEntry: boolean;
+}) {
+  return Boolean(defaultSwapType && !hasPreparedSwapProEntry);
+}

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryListModal.tsx
@@ -49,6 +49,7 @@ import {
   getSwapLimitOpenOrderCount,
   getSwapMarketPendingHistoryList,
   isStockSwapHistoryItem,
+  isSwapLimitHistoryTypeSupported,
 } from '../../utils/swapMarketHistory';
 import { SwapHistoryClearButtonView } from '../components/SwapHistoryClearButton';
 import SwapMarketHistoryList from '../components/SwapMarketHistoryList';
@@ -81,8 +82,9 @@ const SwapHistoryListModal = ({
   ] = useInAppNotificationAtom();
   const { shouldShowSwapLocalData, shouldShowSwapLimitOrders } =
     useSwapLimitOrdersLocalDataVisibility(swapLimitOrdersAccountIdKey);
-  const shouldShowLimitHistoryType =
-    shouldShowSwapLocalData && !platformEnv.isNative;
+  const shouldShowLimitHistoryType = isSwapLimitHistoryTypeSupported({
+    isNative: platformEnv.isNative,
+  });
   const visibleHistoryType =
     historyType === EProtocolOfExchange.LIMIT && !shouldShowLimitHistoryType
       ? EProtocolOfExchange.SWAP

--- a/packages/kit/src/views/Swap/utils/swapMarketHistory.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapMarketHistory.test.ts
@@ -16,6 +16,7 @@ import {
   getSwapMarketPendingHistoryCount,
   getSwapMarketPendingHistoryKey,
   isStockSwapHistoryItem,
+  isSwapLimitHistoryTypeSupported,
   isSwapLimitOpenOrder,
   isSwapMarketHistoryItem,
 } from './swapMarketHistory';
@@ -96,6 +97,12 @@ function createLimitOrder(status: ESwapLimitOrderStatus): IFetchLimitOrderRes {
 }
 
 describe('swapMarketHistory', () => {
+  it('supports the Limit history category only outside native apps', () => {
+    expect(isSwapLimitHistoryTypeSupported({ isNative: false })).toBe(true);
+    expect(isSwapLimitHistoryTypeSupported({})).toBe(true);
+    expect(isSwapLimitHistoryTypeSupported({ isNative: true })).toBe(false);
+  });
+
   it('keeps stock orders in the market history bucket', () => {
     expect(
       isSwapMarketHistoryItem(

--- a/packages/kit/src/views/Swap/utils/swapMarketHistory.ts
+++ b/packages/kit/src/views/Swap/utils/swapMarketHistory.ts
@@ -44,6 +44,14 @@ export const SWAP_LIMIT_OPEN_STATUSES = [
   ESwapLimitOrderStatus.PRESIGNATURE_PENDING,
 ];
 
+export function isSwapLimitHistoryTypeSupported({
+  isNative,
+}: {
+  isNative?: boolean;
+}) {
+  return isNative !== true;
+}
+
 export function isSwapLimitOpenOrder(item: IFetchLimitOrderRes) {
   return SWAP_LIMIT_OPEN_STATUSES.includes(item.status);
 }

--- a/packages/kit/src/views/Swap/utils/swapProEntryState.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapProEntryState.test.ts
@@ -2,12 +2,15 @@
 
 import { createElement } from 'react';
 
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms/jotaiContextStoreMap';
 import { ESwapProJumpTokenDirection } from '@onekeyhq/kit-bg/src/states/jotai/atoms/swap';
 import { CONTEXT_ATOM_COLD_START_CACHE_KEYS } from '@onekeyhq/shared/src/consts/jotaiConsts';
-import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+import type {
+  IFetchQuoteResult,
+  ISwapToken,
+} from '@onekeyhq/shared/types/swap/types';
 import {
   ESwapProTradeType,
   ESwapTabSwitchType,
@@ -16,11 +19,20 @@ import {
 import {
   ProviderJotaiContextSwap,
   swapFromTokenAmountAtom,
+  swapInitialSelectedTokensSyncedAtom,
   swapProDirectionAtom,
   swapProSelectTokenAtom,
   swapProTradeTypeAtom,
+  swapQuoteActionLockAtom,
+  swapQuoteListAtom,
+  swapQuoteRequestIdAtom,
   swapSelectFromTokenAtom,
   swapSelectToTokenAtom,
+  swapSelectedFromTokenBalanceAtom,
+  swapSelectedTokensColdStartContextAtom,
+  swapSpeedQuoteRequestIdAtom,
+  swapStockSelectedTokenAtom,
+  swapToTokenAmountAtom,
   swapTypeSwitchAtom,
   useSwapProDirectionAtom,
   useSwapProSelectTokenAtom,
@@ -30,6 +42,29 @@ import { jotaiContextStore } from '../../../states/jotai/utils/jotaiContextStore
 import { ESwapDirection } from '../../Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
 
 import { prepareSwapProEntryState } from './swapProEntryState';
+
+const mockCancelFetchQuoteEvents = jest.fn<Promise<void>, []>();
+const mockCancelFetchSpeedSwapQuote = jest.fn<Promise<void>, []>();
+const mockSetSwapProSelectToken = jest.fn<Promise<void>, [ISwapToken]>();
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceSwap: {
+      cancelFetchQuoteEvents: () => mockCancelFetchQuoteEvents(),
+      cancelFetchSpeedSwapQuote: () => mockCancelFetchSpeedSwapQuote(),
+    },
+    simpleDb: {
+      swapNetworksSort: {
+        setRawData: jest.fn().mockResolvedValue(undefined),
+      },
+      swapProSelectToken: {
+        setSwapProSelectToken: (token: ISwapToken) =>
+          mockSetSwapProSelectToken(token),
+      },
+    },
+  },
+}));
 
 type IGlobalColdStartSnapshot = typeof globalThis & {
   __ONEKEY_CTX_ATOM_SNAPSHOT__?: Record<string, unknown>;
@@ -67,8 +102,29 @@ const ordinaryToToken: ISwapToken = {
   isNative: false,
 };
 
+const stockToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xstock',
+  symbol: 'STOCK',
+  decimals: 18,
+  isNative: false,
+  isStock: true,
+};
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe('prepareSwapProEntryState', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
+    mockCancelFetchQuoteEvents.mockResolvedValue(undefined);
+    mockCancelFetchSpeedSwapQuote.mockResolvedValue(undefined);
+    mockSetSwapProSelectToken.mockResolvedValue(undefined);
     jotaiContextStore.storeCache.clear();
     jotaiContextStore.storeResetRequests.clear();
     delete (globalThis as IGlobalColdStartSnapshot)
@@ -109,6 +165,278 @@ describe('prepareSwapProEntryState', () => {
       value: '1',
       isInput: true,
     });
+    expect(store.get(swapInitialSelectedTokensSyncedAtom())).toBe(true);
+    expect(store.get(swapSelectedTokensColdStartContextAtom())).toBeUndefined();
+  });
+
+  it('publishes the Market handoff as one Jotai transaction', () => {
+    const store = jotaiContextStore.getOrCreateStore({
+      storeName: EJotaiContextStoreNames.swap,
+    });
+    store.set(swapTypeSwitchAtom(), ESwapTabSwitchType.SWAP);
+    store.set(swapProDirectionAtom(), ESwapDirection.SELL);
+    store.set(swapProSelectTokenAtom(), oldToken);
+    const snapshots: Array<{
+      direction: ESwapDirection;
+      token?: ISwapToken;
+      type: ESwapTabSwitchType;
+    }> = [];
+    const recordSnapshot = () => {
+      snapshots.push({
+        direction: store.get(swapProDirectionAtom()),
+        token: store.get(swapProSelectTokenAtom()),
+        type: store.get(swapTypeSwitchAtom()),
+      });
+    };
+    const subscriptions = [
+      store.sub(swapTypeSwitchAtom(), recordSnapshot),
+      store.sub(swapProDirectionAtom(), recordSnapshot),
+      store.sub(swapProSelectTokenAtom(), recordSnapshot),
+    ];
+
+    prepareSwapProEntryState({
+      token: nextToken,
+      direction: ESwapProJumpTokenDirection.BUY,
+    });
+    subscriptions.forEach((unsubscribe) => unsubscribe());
+
+    expect(snapshots.length).toBeGreaterThan(0);
+    expect(snapshots).toEqual(
+      snapshots.map(() => ({
+        direction: ESwapDirection.BUY,
+        token: nextToken,
+        type: ESwapTabSwitchType.LIMIT,
+      })),
+    );
+  });
+
+  it('clears Stock-only state while preserving an ordinary native amount', () => {
+    const store = jotaiContextStore.getOrCreateStore({
+      storeName: EJotaiContextStoreNames.swap,
+    });
+    store.set(swapTypeSwitchAtom(), ESwapTabSwitchType.SWAP);
+    store.set(swapSelectFromTokenAtom(), ordinaryFromToken);
+    store.set(swapSelectToTokenAtom(), ordinaryToToken);
+    store.set(swapFromTokenAmountAtom(), { value: '1', isInput: true });
+
+    prepareSwapProEntryState({
+      token: nextToken,
+      direction: ESwapProJumpTokenDirection.BUY,
+    });
+    expect(store.get(swapFromTokenAmountAtom())).toEqual({
+      value: '1',
+      isInput: true,
+    });
+
+    store.set(swapTypeSwitchAtom(), ESwapTabSwitchType.STOCK);
+    store.set(swapSelectFromTokenAtom(), ordinaryToToken);
+    store.set(swapSelectToTokenAtom(), stockToken);
+    store.set(swapStockSelectedTokenAtom(), stockToken);
+    store.set(swapSelectedFromTokenBalanceAtom(), '99');
+    store.set(swapFromTokenAmountAtom(), { value: '2', isInput: true });
+    store.set(swapToTokenAmountAtom(), { value: '20', isInput: false });
+    store.set(swapSelectedTokensColdStartContextAtom(), {
+      accountKey: 'stock-account',
+      networkId: stockToken.networkId,
+      swapType: ESwapTabSwitchType.STOCK,
+      updatedAt: 1,
+    });
+    store.set(swapInitialSelectedTokensSyncedAtom(), true);
+
+    prepareSwapProEntryState({
+      token: nextToken,
+      direction: ESwapProJumpTokenDirection.SELL,
+    });
+
+    expect(store.get(swapFromTokenAmountAtom())).toEqual({
+      value: '',
+      isInput: false,
+    });
+    expect(store.get(swapToTokenAmountAtom())).toEqual({
+      value: '',
+      isInput: false,
+    });
+    expect(store.get(swapSelectedFromTokenBalanceAtom())).toBe('');
+    expect(store.get(swapSelectedTokensColdStartContextAtom())).toBeUndefined();
+    expect(store.get(swapInitialSelectedTokensSyncedAtom())).toBe(true);
+  });
+
+  it('repairs legacy Limit state that still owns a Stock selection', () => {
+    const store = jotaiContextStore.getOrCreateStore({
+      storeName: EJotaiContextStoreNames.swap,
+    });
+    store.set(swapTypeSwitchAtom(), ESwapTabSwitchType.LIMIT);
+    store.set(swapProDirectionAtom(), ESwapDirection.BUY);
+    store.set(swapProSelectTokenAtom(), nextToken);
+    store.set(swapSelectFromTokenAtom(), ordinaryToToken);
+    store.set(swapSelectToTokenAtom(), stockToken);
+    store.set(swapStockSelectedTokenAtom(), stockToken);
+    store.set(swapFromTokenAmountAtom(), { value: '2', isInput: true });
+    store.set(swapToTokenAmountAtom(), { value: '20', isInput: false });
+    store.set(swapSelectedTokensColdStartContextAtom(), {
+      accountKey: 'legacy-stock-account',
+      networkId: stockToken.networkId,
+      swapType: ESwapTabSwitchType.STOCK,
+      updatedAt: 1,
+    });
+
+    prepareSwapProEntryState({
+      token: nextToken,
+      direction: ESwapProJumpTokenDirection.BUY,
+    });
+
+    const repairedTokens = [
+      store.get(swapSelectFromTokenAtom()),
+      store.get(swapSelectToTokenAtom()),
+    ].filter(Boolean);
+    expect(repairedTokens).not.toContainEqual(stockToken);
+    expect(repairedTokens.every((token) => !token?.isStock)).toBe(true);
+    expect(store.get(swapFromTokenAmountAtom())).toEqual({
+      value: '',
+      isInput: false,
+    });
+    expect(store.get(swapToTokenAmountAtom())).toEqual({
+      value: '',
+      isInput: false,
+    });
+    expect(store.get(swapSelectedTokensColdStartContextAtom())).toBeUndefined();
+    expect(store.get(swapInitialSelectedTokensSyncedAtom())).toBe(true);
+  });
+
+  it('drops a stale Stock context without replacing a valid ordinary pair', async () => {
+    const store = jotaiContextStore.getOrCreateStore({
+      storeName: EJotaiContextStoreNames.swap,
+    });
+    const activeQuote = { quoteId: 'active' } as IFetchQuoteResult;
+    store.set(swapTypeSwitchAtom(), ESwapTabSwitchType.LIMIT);
+    store.set(swapProDirectionAtom(), ESwapDirection.BUY);
+    store.set(swapProSelectTokenAtom(), nextToken);
+    store.set(swapSelectFromTokenAtom(), ordinaryFromToken);
+    store.set(swapSelectToTokenAtom(), ordinaryToToken);
+    store.set(swapStockSelectedTokenAtom(), stockToken);
+    store.set(swapFromTokenAmountAtom(), { value: '1', isInput: true });
+    store.set(swapToTokenAmountAtom(), { value: '10', isInput: false });
+    store.set(swapQuoteListAtom(), [activeQuote]);
+    store.set(swapQuoteRequestIdAtom(), 7);
+    store.set(swapSpeedQuoteRequestIdAtom(), 9);
+    store.set(swapSelectedTokensColdStartContextAtom(), {
+      accountKey: 'stale-stock-context',
+      networkId: stockToken.networkId,
+      swapType: ESwapTabSwitchType.STOCK,
+      updatedAt: 1,
+    });
+
+    prepareSwapProEntryState({
+      token: nextToken,
+      direction: ESwapProJumpTokenDirection.BUY,
+    });
+    await Promise.resolve();
+
+    expect(store.get(swapSelectFromTokenAtom())).toBe(ordinaryFromToken);
+    expect(store.get(swapSelectToTokenAtom())).toBe(ordinaryToToken);
+    expect(store.get(swapFromTokenAmountAtom())).toEqual({
+      value: '1',
+      isInput: true,
+    });
+    expect(store.get(swapToTokenAmountAtom())).toEqual({
+      value: '10',
+      isInput: false,
+    });
+    expect(store.get(swapSelectedTokensColdStartContextAtom())).toBeUndefined();
+    expect(store.get(swapInitialSelectedTokensSyncedAtom())).toBe(true);
+    expect(store.get(swapQuoteListAtom())).toEqual([activeQuote]);
+    expect(store.get(swapQuoteRequestIdAtom())).toBe(7);
+    expect(store.get(swapSpeedQuoteRequestIdAtom())).toBe(9);
+    expect(mockCancelFetchQuoteEvents).not.toHaveBeenCalled();
+    expect(mockCancelFetchSpeedSwapQuote).not.toHaveBeenCalled();
+  });
+
+  it('keeps an active quote when the mounted child consumes the same handoff', async () => {
+    const store = jotaiContextStore.getOrCreateStore({
+      storeName: EJotaiContextStoreNames.swap,
+    });
+    const activeQuote = { quoteId: 'active' } as IFetchQuoteResult;
+    store.set(swapTypeSwitchAtom(), ESwapTabSwitchType.LIMIT);
+    store.set(swapProDirectionAtom(), ESwapDirection.BUY);
+    store.set(swapProSelectTokenAtom(), nextToken);
+    store.set(swapQuoteListAtom(), [activeQuote]);
+    store.set(swapQuoteActionLockAtom(), { actionLock: true });
+    store.set(swapQuoteRequestIdAtom(), 7);
+    store.set(swapSpeedQuoteRequestIdAtom(), 9);
+
+    prepareSwapProEntryState({
+      token: nextToken,
+      direction: ESwapProJumpTokenDirection.BUY,
+    });
+    await Promise.resolve();
+
+    expect(store.get(swapQuoteListAtom())).toEqual([activeQuote]);
+    expect(store.get(swapQuoteActionLockAtom())).toEqual({ actionLock: true });
+    expect(store.get(swapQuoteRequestIdAtom())).toBe(7);
+    expect(store.get(swapSpeedQuoteRequestIdAtom())).toBe(9);
+    expect(mockCancelFetchQuoteEvents).not.toHaveBeenCalled();
+    expect(mockCancelFetchSpeedSwapQuote).not.toHaveBeenCalled();
+  });
+
+  it('serializes consecutive handoff persistence and stores stable token fields', async () => {
+    const firstWrite = createDeferred<void>();
+    mockSetSwapProSelectToken
+      .mockImplementationOnce(() => firstWrite.promise)
+      .mockResolvedValue(undefined);
+    const oldTokenWithRealtimeFields: ISwapToken = {
+      ...oldToken,
+      accountAddress: '0xaccount',
+      balanceParsed: '1',
+      fiatValue: '2',
+      price: '3',
+      reservationValue: '4',
+    };
+
+    prepareSwapProEntryState({
+      token: oldTokenWithRealtimeFields,
+      direction: ESwapProJumpTokenDirection.BUY,
+    });
+    prepareSwapProEntryState({
+      token: nextToken,
+      direction: ESwapProJumpTokenDirection.SELL,
+    });
+
+    await waitFor(() =>
+      expect(mockSetSwapProSelectToken).toHaveBeenCalledTimes(1),
+    );
+    expect(mockSetSwapProSelectToken).toHaveBeenNthCalledWith(1, oldToken);
+
+    firstWrite.resolve();
+    await waitFor(() =>
+      expect(mockSetSwapProSelectToken).toHaveBeenCalledTimes(2),
+    );
+    expect(mockSetSwapProSelectToken).toHaveBeenNthCalledWith(2, nextToken);
+  });
+
+  it('keeps the handoff usable when a queued persistence write fails', async () => {
+    mockSetSwapProSelectToken
+      .mockRejectedValueOnce(new Error('storage unavailable'))
+      .mockResolvedValue(undefined);
+
+    prepareSwapProEntryState({
+      token: oldToken,
+      direction: ESwapProJumpTokenDirection.BUY,
+    });
+    prepareSwapProEntryState({
+      token: nextToken,
+      direction: ESwapProJumpTokenDirection.SELL,
+    });
+
+    await waitFor(() =>
+      expect(mockSetSwapProSelectToken).toHaveBeenCalledTimes(2),
+    );
+    expect(mockSetSwapProSelectToken).toHaveBeenNthCalledWith(2, nextToken);
+
+    const store = jotaiContextStore.getOrCreateStore({
+      storeName: EJotaiContextStoreNames.swap,
+    });
+    expect(store.get(swapProSelectTokenAtom())).toBe(nextToken);
+    expect(store.get(swapProDirectionAtom())).toBe(ESwapDirection.SELL);
   });
 
   it('creates the root store and maps a Sell handoff immediately', () => {

--- a/packages/kit/src/views/Swap/utils/swapProEntryState.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapProEntryState.test.ts
@@ -1,0 +1,194 @@
+/** @jest-environment jsdom */
+
+import { createElement } from 'react';
+
+import { render } from '@testing-library/react';
+
+import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms/jotaiContextStoreMap';
+import { ESwapProJumpTokenDirection } from '@onekeyhq/kit-bg/src/states/jotai/atoms/swap';
+import { CONTEXT_ATOM_COLD_START_CACHE_KEYS } from '@onekeyhq/shared/src/consts/jotaiConsts';
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+import {
+  ESwapProTradeType,
+  ESwapTabSwitchType,
+} from '@onekeyhq/shared/types/swap/types';
+
+import {
+  ProviderJotaiContextSwap,
+  swapFromTokenAmountAtom,
+  swapProDirectionAtom,
+  swapProSelectTokenAtom,
+  swapProTradeTypeAtom,
+  swapSelectFromTokenAtom,
+  swapSelectToTokenAtom,
+  swapTypeSwitchAtom,
+  useSwapProDirectionAtom,
+  useSwapProSelectTokenAtom,
+  useSwapTypeSwitchAtom,
+} from '../../../states/jotai/contexts/swap/atoms';
+import { jotaiContextStore } from '../../../states/jotai/utils/jotaiContextStore';
+import { ESwapDirection } from '../../Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
+
+import { prepareSwapProEntryState } from './swapProEntryState';
+
+type IGlobalColdStartSnapshot = typeof globalThis & {
+  __ONEKEY_CTX_ATOM_SNAPSHOT__?: Record<string, unknown>;
+};
+
+const oldToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xold',
+  symbol: 'OLD',
+  decimals: 18,
+  isNative: false,
+};
+
+const nextToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xnext',
+  symbol: 'NEXT',
+  decimals: 18,
+  isNative: false,
+};
+
+const ordinaryFromToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '',
+  symbol: 'ETH',
+  decimals: 18,
+  isNative: true,
+};
+
+const ordinaryToToken: ISwapToken = {
+  networkId: 'evm--1',
+  contractAddress: '0xusdc',
+  symbol: 'USDC',
+  decimals: 6,
+  isNative: false,
+};
+
+describe('prepareSwapProEntryState', () => {
+  beforeEach(() => {
+    jotaiContextStore.storeCache.clear();
+    jotaiContextStore.storeResetRequests.clear();
+    delete (globalThis as IGlobalColdStartSnapshot)
+      .__ONEKEY_CTX_ATOM_SNAPSHOT__;
+  });
+
+  afterEach(() => {
+    jotaiContextStore.storeCache.clear();
+    jotaiContextStore.storeResetRequests.clear();
+    delete (globalThis as IGlobalColdStartSnapshot)
+      .__ONEKEY_CTX_ATOM_SNAPSHOT__;
+  });
+
+  it('prepares Pro synchronously without resetting ordinary Swap state', () => {
+    const store = jotaiContextStore.getOrCreateStore({
+      storeName: EJotaiContextStoreNames.swap,
+    });
+    store.set(swapTypeSwitchAtom(), ESwapTabSwitchType.SWAP);
+    store.set(swapProDirectionAtom(), ESwapDirection.SELL);
+    store.set(swapProSelectTokenAtom(), oldToken);
+    store.set(swapProTradeTypeAtom(), ESwapProTradeType.LIMIT);
+    store.set(swapSelectFromTokenAtom(), ordinaryFromToken);
+    store.set(swapSelectToTokenAtom(), ordinaryToToken);
+    store.set(swapFromTokenAmountAtom(), { value: '1', isInput: true });
+
+    prepareSwapProEntryState({
+      token: nextToken,
+      direction: ESwapProJumpTokenDirection.BUY,
+    });
+
+    expect(store.get(swapTypeSwitchAtom())).toBe(ESwapTabSwitchType.LIMIT);
+    expect(store.get(swapProDirectionAtom())).toBe(ESwapDirection.BUY);
+    expect(store.get(swapProSelectTokenAtom())).toBe(nextToken);
+    expect(store.get(swapProTradeTypeAtom())).toBe(ESwapProTradeType.LIMIT);
+    expect(store.get(swapSelectFromTokenAtom())).toBe(ordinaryFromToken);
+    expect(store.get(swapSelectToTokenAtom())).toBe(ordinaryToToken);
+    expect(store.get(swapFromTokenAmountAtom())).toEqual({
+      value: '1',
+      isInput: true,
+    });
+  });
+
+  it('creates the root store and maps a Sell handoff immediately', () => {
+    expect(
+      jotaiContextStore.getStore({
+        storeName: EJotaiContextStoreNames.swap,
+      }),
+    ).toBeUndefined();
+
+    prepareSwapProEntryState({
+      token: nextToken,
+      direction: ESwapProJumpTokenDirection.SELL,
+    });
+
+    const store = jotaiContextStore.getStore({
+      storeName: EJotaiContextStoreNames.swap,
+    });
+    expect(store?.get(swapTypeSwitchAtom())).toBe(ESwapTabSwitchType.LIMIT);
+    expect(store?.get(swapProDirectionAtom())).toBe(ESwapDirection.SELL);
+    expect(store?.get(swapProSelectTokenAtom())).toBe(nextToken);
+  });
+
+  it('keeps the handoff after the first Provider hydration pass', () => {
+    const actualSwapRootScopeKey = `store:${EJotaiContextStoreNames.swap}`;
+    (globalThis as IGlobalColdStartSnapshot).__ONEKEY_CTX_ATOM_SNAPSHOT__ = {
+      [`${actualSwapRootScopeKey}::${CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapTypeSwitchAtom}`]:
+        ESwapTabSwitchType.SWAP,
+    };
+
+    prepareSwapProEntryState({
+      token: nextToken,
+      direction: ESwapProJumpTokenDirection.BUY,
+    });
+
+    const store = jotaiContextStore.getOrCreateStore({
+      storeName: EJotaiContextStoreNames.swap,
+    });
+    const firstPaintStates: Array<{
+      direction: ESwapDirection;
+      token: ISwapToken | undefined;
+      type: ESwapTabSwitchType;
+    }> = [];
+    function FirstPaintProbe() {
+      const [type] = useSwapTypeSwitchAtom();
+      const [direction] = useSwapProDirectionAtom();
+      const [token] = useSwapProSelectTokenAtom();
+      firstPaintStates.push({ type, direction, token });
+      return null;
+    }
+
+    render(
+      createElement(
+        ProviderJotaiContextSwap,
+        { store },
+        createElement(FirstPaintProbe),
+      ),
+    );
+
+    expect(firstPaintStates[0]).toEqual({
+      type: ESwapTabSwitchType.LIMIT,
+      direction: ESwapDirection.BUY,
+      token: nextToken,
+    });
+  });
+
+  it('lets the latest consecutive handoff win', () => {
+    prepareSwapProEntryState({
+      token: oldToken,
+      direction: ESwapProJumpTokenDirection.BUY,
+    });
+    prepareSwapProEntryState({
+      token: nextToken,
+      direction: ESwapProJumpTokenDirection.SELL,
+    });
+
+    const store = jotaiContextStore.getOrCreateStore({
+      storeName: EJotaiContextStoreNames.swap,
+    });
+    expect(store.get(swapProSelectTokenAtom())).toBe(nextToken);
+    expect(store.get(swapProDirectionAtom())).toBe(ESwapDirection.SELL);
+    expect(store.get(swapTypeSwitchAtom())).toBe(ESwapTabSwitchType.LIMIT);
+  });
+});

--- a/packages/kit/src/views/Swap/utils/swapProEntryState.ts
+++ b/packages/kit/src/views/Swap/utils/swapProEntryState.ts
@@ -1,14 +1,9 @@
-import {
-  swapProDirectionAtom,
-  swapProSelectTokenAtom,
-  swapTypeSwitchAtom,
-} from '@onekeyhq/kit/src/states/jotai/contexts/swap/atoms';
+import { prepareSwapProEntryCommand } from '@onekeyhq/kit/src/states/jotai/contexts/swap/actions';
 import { jotaiContextStore } from '@onekeyhq/kit/src/states/jotai/utils/jotaiContextStore';
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms/jotaiContextStoreMap';
 import { ESwapProJumpTokenDirection } from '@onekeyhq/kit-bg/src/states/jotai/atoms/swap';
 import { hydrateContextColdStartCacheForProvider } from '@onekeyhq/kit-bg/src/states/jotai/utils';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
-import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
 
 import { ESwapDirection } from '../../Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
 
@@ -34,12 +29,11 @@ export function prepareSwapProEntryState({
     coldStartScopeKey: SWAP_ROOT_COLD_START_SCOPE_KEY,
   });
 
-  store.set(
-    swapProDirectionAtom(),
-    direction === ESwapProJumpTokenDirection.SELL
-      ? ESwapDirection.SELL
-      : ESwapDirection.BUY,
-  );
-  store.set(swapProSelectTokenAtom(), token);
-  store.set(swapTypeSwitchAtom(), ESwapTabSwitchType.LIMIT);
+  void store.set(prepareSwapProEntryCommand.atom(), {
+    direction:
+      direction === ESwapProJumpTokenDirection.SELL
+        ? ESwapDirection.SELL
+        : ESwapDirection.BUY,
+    token,
+  });
 }

--- a/packages/kit/src/views/Swap/utils/swapProEntryState.ts
+++ b/packages/kit/src/views/Swap/utils/swapProEntryState.ts
@@ -1,0 +1,45 @@
+import {
+  swapProDirectionAtom,
+  swapProSelectTokenAtom,
+  swapTypeSwitchAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/swap/atoms';
+import { jotaiContextStore } from '@onekeyhq/kit/src/states/jotai/utils/jotaiContextStore';
+import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms/jotaiContextStoreMap';
+import { ESwapProJumpTokenDirection } from '@onekeyhq/kit-bg/src/states/jotai/atoms/swap';
+import { hydrateContextColdStartCacheForProvider } from '@onekeyhq/kit-bg/src/states/jotai/utils';
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
+
+import { ESwapDirection } from '../../Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
+
+const SWAP_ROOT_COLD_START_SCOPE_KEY = `store:${EJotaiContextStoreNames.swap}`;
+
+export function prepareSwapProEntryState({
+  token,
+  direction,
+}: {
+  token: ISwapToken;
+  direction: ESwapProJumpTokenDirection;
+}) {
+  const store = jotaiContextStore.getOrCreateStore({
+    storeName: EJotaiContextStoreNames.swap,
+  });
+
+  // Hydrate before the handoff so the first Provider mount cannot restore a
+  // cached Swap tab over the synchronously prepared Pro state.
+  hydrateContextColdStartCacheForProvider({
+    store: store as unknown as Parameters<
+      typeof hydrateContextColdStartCacheForProvider
+    >[0]['store'],
+    coldStartScopeKey: SWAP_ROOT_COLD_START_SCOPE_KEY,
+  });
+
+  store.set(
+    swapProDirectionAtom(),
+    direction === ESwapProJumpTokenDirection.SELL
+      ? ESwapDirection.SELL
+      : ESwapDirection.BUY,
+  );
+  store.set(swapProSelectTokenAtom(), token);
+  store.set(swapTypeSwitchAtom(), ESwapTabSwitchType.LIMIT);
+}

--- a/packages/shared/src/routes/staking.ts
+++ b/packages/shared/src/routes/staking.ts
@@ -103,6 +103,7 @@ export type IModalStakingParamList = {
     reserveAddress: string;
     symbol: string;
     logoURI?: string;
+    providerLogoURI?: string;
     accountId?: string;
     indexedAccountId?: string;
   };

--- a/packages/shared/src/routes/tabEarn.ts
+++ b/packages/shared/src/routes/tabEarn.ts
@@ -39,6 +39,7 @@ export type ITabEarnParamList = {
     reserveAddress: string;
     symbol: string;
     logoURI?: string;
+    providerLogoURI?: string;
     accountId?: string;
     indexedAccountId?: string;
   };
@@ -49,6 +50,7 @@ export type ITabEarnParamList = {
     marketAddress: string;
     reserveAddress: string;
     logoURI?: string;
+    providerLogoURI?: string;
     accountId?: string;
     indexedAccountId?: string;
   };


### PR DESCRIPTION
## Summary

- Resolve ten recent Jira issues across DeFi, Borrow/Earn, Swap/Market, Private Send, and trading inputs.
- Keep every commit issue-scoped and include its Jira key; review/CI hardening follow-ups remain isolated to OK-57752.
- Preserve package boundaries and avoid schema, generated translation, cryptographic, and server-contract changes.

## Intent & Context

This batch was selected from a live scan of 80 unresolved Jira issues created within the last 60 days. The selected issues have current evidence, clear ownership, and bounded root causes suitable for restrained fixes.

The branch targets `x`. Jira and Slack were used read-only; this PR does not transition issues, alter server contracts, or include speculative refactors.

## Root Cause

| Issue | Root cause | Scoped fix |
| --- | --- | --- |
| OK-57834 | A disabled lending confirmation request cannot return data, but the health-factor UI treated the absent result as perpetual loading. | Align the skeleton with the exact request-readiness gate. |
| OK-57836 | A fixed-width right-aligned percentage input and separate `%` suffix shifted the editable value away from the visual center. | Measure the natural value width and use a symmetric interactive layer. |
| OK-57826 | The reserve token logo was reused as the provider-logo fallback, allowing provider identity to change with the asset. | Carry optional `providerLogoURI` independently through Borrow routes and consumers. |
| OK-57787 | Stock wrote the shared selected-from balance atom, while Stock-to-Swap restored the pair but left the stale balance for first paint. | Clear that atom only when leaving Stock for a non-Stock mode. |
| OK-57752 | Market trade intent was applied after navigation, while route/default hydration and stale quote producers could overwrite or outlive the prepared Pro identity. | Prepare the root Swap store synchronously, centralize semantic transitions and quote identity invalidation, and guard main/bg async quote producers independently. |
| OK-57547 | Four network chips plus iOS text metrics and 10pt side padding exceeded the 402pt viewport. | Reduce chip padding to 8pt only on iOS mobile. |
| OK-57451 | Limit category visibility was coupled to connected-account local-data visibility instead of platform capability. | Keep the category available on supported platforms while retaining account-scoped data guards. |
| OK-56469 | The breadcrumb entered the shared header at `gtSm`, but provider alignment waited until `gtMd`. | Align only the provider-header breakpoint with `gtSm`. |
| OK-56028 | Only the 20x20 chevron owned the Private Send disclosure action. | Make the full quote group the accessible toggle, including Web keyboard activation and local event propagation control. |
| OK-54672 | Custom slippage and Market priority-fee inputs omitted decimal keyboard hints on mobile. | Apply `decimal-pad` to the shared slippage and Market preset fee inputs. |

## Design Decisions

- Change the smallest current owner for each defect instead of introducing cross-feature abstractions.
- Keep platform-specific behavior local; the Market chip spacing adjustment is iOS-mobile-only.
- Preserve provider and token identity as separate route values.
- Keep one semantic Jotai owner for Swap/Stock/Pro transitions; UI components do not publish partial type/pair state.
- Keep ordinary and speed quote identities explicit. Main and bg invalidate their own request generations because their JS heaps are isolated.
- Serialize the existing Swap Pro token persistence side effect; persistence failure is logged without token data and cannot roll back the synchronous handoff.
- Keep account/history data guards while separating them from platform capability.
- Keep tooltip and refresh controls independent from the Private Send disclosure control.

## Changes Detail

- DeFi and Borrow/Earn: lending readiness, percentage layout, provider-logo routing, and responsive header alignment.
- Swap and Market: Stock balance cleanup, synchronous Pro entry, stale-request protection, iOS network-chip spacing, and disconnected Limit-history visibility.
- Send: expanded and accessible Private Send quote disclosure target.
- Trading inputs: decimal keyboards for custom slippage and priority fee.
- Tests: focused coverage for lending, percentage layout, Borrow route consumers, Swap transitions/history/Pro hydration, main/bg request generations, slippage, and Market presets.

## Runtime Ownership

- **Runtime scope:** `main` owns Jotai transition state and ordinary/speed request identities. `bg` owns the `ServiceSwap` EventSource generation and the existing SimpleDB write.
- **Native resources:** The EventSource remains bg-owned; existing SimpleDB may use shared underlying native storage, but this PR adds no schema, handle, or ownership change.
- **JS heaps:** main and bg do not share token or request objects. Proxy payloads are serialized into independent JS copies, and each runtime rejects stale work with its own generation.
- **Timing:** main and bg initialize independently. The main handoff is complete before navigation and never assumes bg readiness; bg cancellation is asynchronous and backed by its own generation guard.

## Risk Assessment

- **Risk Level:** Medium overall because this PR contains ten independent UI fixes; each fix is narrow and separately committed.
- **Affected Platforms:** Mobile, Desktop, Web, and Extension where the shared kit screens are consumed.
- **Risk Areas:** Swap first-paint/transition ordering, stale async quote delivery, provider-logo route compatibility, editable DeFi layout, and Private Send keyboard/event propagation.
- **Mitigations:** Ten focused suites, independent strict architecture review at 9.2/10 with no remaining P0-P3 findings, scoped platform behavior, and real iOS/iPad/Web/Desktop runtime checks.

## Test plan

- [x] Confirm ten unique Jira keys and issue-scoped commits; the two follow-up commits are isolated to OK-57752 review/CI hardening.
- [x] Run ten focused Jest suites: 104/104 tests passed after the final `x` rebase.
- [x] Run `git diff --check`.
- [x] Run `yarn agent:check --profile pr`: local lint/type checks passed.
- [x] Complete strict correctness/minimization/architecture review; final architecture score 9.2/10 with no remaining P0-P3 findings.
- [x] Verify OK-57834 over-limit disabled state on iOS; no health-factor skeleton remains.
- [x] Verify OK-57836 at 1%, 25%, and 100% on iOS.
- [x] Verify OK-57826 with distinct SOL/USDC token logos and a stable Kamino provider logo route.
- [x] Verify OK-57787 using a real Stock balance; first possible Swap paint is cleared, then the correct balance loads.
- [x] Verify OK-57752 warm/cold-store entry plus final iOS HYPE Market→Pro BUY→SELL; first stable paint is Pro, token/direction stay consistent, and console error delta is zero.
- [x] Run `yarn app:desktop:rspack` in an isolated profile, create a fresh mnemonic wallet without reading/logging the phrase, and cycle Stock→Limit→Swap with no feature-specific console error.
- [x] Verify OK-57547 on a fresh iPhone 17 / 402pt launch, including selected-chip auto-scroll.
- [x] Verify OK-57451 native reverse gating and disconnected Web Limit history.
- [x] Verify OK-56469 on iPad mini at the 744pt target breakpoint.
- [x] Verify OK-56028 iOS hit target/refresh/tooltip isolation and narrow Electron Enter/Space activation.
- [x] Verify all three OK-54672 iOS decimal-keyboard surfaces with trailing-dot decimal input.
- [x] Confirm remote CI on the final Draft PR head: 16/16 passed, 0 failed, 0 pending.

## Draft Status

This PR is intentionally Draft. Keep it Draft until remote CI and maintainer review pass.
