### PR TITLE
fix: restore desktop updater install state

### DIFF
--- a/apps/desktop/scripts/electron-updater-runtime-patch.test.js
+++ b/apps/desktop/scripts/electron-updater-runtime-patch.test.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { BaseUpdater } = require('electron-updater/out/BaseUpdater');
+
+describe('electron-updater runtime patch', () => {
+  test('rehydrates the persisted installer metadata after an app restart', async () => {
+    const cacheDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'electron-updater-test-'),
+    );
+    const downloadedFileInfo = {
+      fileName: 'OneKey-Wallet-9906.17.0-win-x64.exe',
+      sha512: 'sha512-value',
+      isAdminRightsRequired: false,
+    };
+    const downloadedUpdateHelper = {
+      cacheDirForPendingUpdate: cacheDir,
+      updateFile: jest.fn(),
+      updateDownloadedFileInfo: jest.fn(),
+    };
+    const updater = {
+      downloadedUpdateHelper,
+      _logger: { info: jest.fn() },
+    };
+
+    try {
+      fs.writeFileSync(
+        path.join(cacheDir, 'update-info.json'),
+        JSON.stringify(downloadedFileInfo),
+      );
+
+      await BaseUpdater.prototype.updateInstallerPath.call(
+        updater,
+        'C:\\Users\\asus\\AppData\\Local\\OneKey\\pending\\installer.exe',
+      );
+
+      expect(downloadedUpdateHelper.updateFile).toHaveBeenCalledWith(
+        'C:\\Users\\asus\\AppData\\Local\\OneKey\\pending\\installer.exe',
+      );
+      expect(
+        downloadedUpdateHelper.updateDownloadedFileInfo,
+      ).toHaveBeenCalledWith(downloadedFileInfo);
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/patches/electron-updater+6.8.9.patch
+++ b/patches/electron-updater+6.8.9.patch
@@ -20,7 +20,7 @@ index 449df36..d592976 100644
  export interface DownloadUpdateOptions {
      readonly updateInfoAndProvider: UpdateInfoAndProvider;
 diff --git a/node_modules/electron-updater/out/AppUpdater.js b/node_modules/electron-updater/out/AppUpdater.js
-index d6d5deb..b0a8a8c 100644
+index d6d5deb..31a3efe 100644
 --- a/node_modules/electron-updater/out/AppUpdater.js
 +++ b/node_modules/electron-updater/out/AppUpdater.js
 @@ -558,6 +558,8 @@ class AppUpdater extends events_1.EventEmitter {
@@ -46,7 +46,7 @@ index 00bbd5f..2359e0e 100644
      install(isSilent?: boolean, isForceRunAfter?: boolean): boolean;
      protected addQuitHandler(): void;
 diff --git a/node_modules/electron-updater/out/BaseUpdater.js b/node_modules/electron-updater/out/BaseUpdater.js
-index f7c2965..7a8beef 100644
+index f7c2965..266fa46 100644
 --- a/node_modules/electron-updater/out/BaseUpdater.js
 +++ b/node_modules/electron-updater/out/BaseUpdater.js
 @@ -2,6 +2,7 @@
@@ -57,7 +57,7 @@ index f7c2965..7a8beef 100644
  const path = require("path");
  const AppUpdater_1 = require("./AppUpdater");
  class BaseUpdater extends AppUpdater_1.AppUpdater {
-@@ -38,6 +39,30 @@ class BaseUpdater extends AppUpdater_1.AppUpdater {
+@@ -38,6 +39,32 @@ class BaseUpdater extends AppUpdater_1.AppUpdater {
      get installerPath() {
          return this.downloadedUpdateHelper == null ? null : this.downloadedUpdateHelper.file;
      }
@@ -77,9 +77,11 @@ index f7c2965..7a8beef 100644
 +            return;
 +        }
 +        try {
-+            const cachedInfo = await (0, fs_extra_1.readJson)(updateInfoFilePath);
++            // OneKey patch: force text decoding because packaged Electron can return a Uint8Array.
++            const cachedInfo = await (0, fs_extra_1.readJson)(updateInfoFilePath, { encoding: "utf8" });
++            const downloadedFileInfo = cachedInfo?.downloadedFileInfo ?? cachedInfo;
 +            this.downloadedUpdateHelper.updateFile(installerPath);
-+            this.downloadedUpdateHelper.updateDownloadedFileInfo(cachedInfo.downloadedFileInfo);
++            this.downloadedUpdateHelper.updateDownloadedFileInfo(downloadedFileInfo);
 +        }
 +        catch (error) {
 +            this._logger.info(error);
@@ -102,7 +104,7 @@ index 26ea883..64ed1bc 100644
      setDownloadedFile(downloadedFile: string, packageFile: string | null, versionInfo: UpdateInfo, fileInfo: ResolvedUpdateFileInfo, updateFileName: string, isSaveCache: boolean): Promise<void>;
      clear(): Promise<void>;
 diff --git a/node_modules/electron-updater/out/DownloadedUpdateHelper.js b/node_modules/electron-updater/out/DownloadedUpdateHelper.js
-index e6c33ea..7fbe978 100644
+index e6c33ea..890debd 100644
 --- a/node_modules/electron-updater/out/DownloadedUpdateHelper.js
 +++ b/node_modules/electron-updater/out/DownloadedUpdateHelper.js
 @@ -30,6 +30,14 @@ class DownloadedUpdateHelper {


### PR DESCRIPTION
## Summary
- Fix Windows desktop auto-update installation after the app restarts with a downloaded installer.
- Add a regression test for restoring the persisted installer path and metadata.

## Intent & Context
The Windows desktop upgrade reported by the user downloaded and verified the update successfully, but the installation action did not launch the installer. The fix ensures the downloaded package can be rehydrated and installed from the persisted updater state.

## Root Cause
The runtime patch read `update-info.json` without forcing text decoding, which could make `jsonfile` fail with `content.replace is not a function` in packaged Electron. It also expected a `downloadedFileInfo` wrapper, while electron-updater persists the metadata object directly. The failed restore made the updater fall back to manual installation.

## Design Decisions
- Keep the existing electron-updater runtime patch and update only its cache rehydration logic.
- Force UTF-8 decoding for compatibility with packaged Electron file reads.
- Accept both the persisted direct metadata format and the wrapped format for compatibility.

## Changes Detail
- Update `patches/electron-updater+6.8.9.patch` to restore installer metadata correctly.
- Add `apps/desktop/scripts/electron-updater-runtime-patch.test.js` covering app-restart rehydration.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop
- **Risk Areas**: Windows installer handoff and electron-updater runtime patch application.

## Test plan
- [x] Targeted Jest regression test
- [x] `yarn agent:check --profile commit`
- [x] `git apply --check` against pristine electron-updater 6.8.9