### PR TITLE
fix: restore Perps actions and empty-wallet deposits(OK-57890)

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/DesktopActionIconButton.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/DesktopActionIconButton.tsx
@@ -30,10 +30,9 @@ export const DesktopActionIconButton = memo(
         iconSize={iconSize}
         iconProps={{
           color: '$iconSubdued',
-          '$group-hover': { color: '$icon' },
-          '$group-press': { color: '$iconActive' },
+          hoverStyle: { color: '$icon' },
+          pressStyle: { color: '$iconActive' },
         }}
-        group
         hoverStyle={{ bg: 'transparent' }}
         pressStyle={{ bg: 'transparent' }}
         onPress={onPress}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.test.ts
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.test.ts
@@ -6,6 +6,7 @@ import {
   getPerpsDepositTokenDisplayList,
   getPerpsDepositTokensWithDefaultFallback,
   mergePerpsDepositTokensPreservingOrder,
+  shouldPreservePerpsDepositSelectedToken,
   shouldShowPerpsDepositTokenSkeleton,
 } from './depositTokenDisplayUtils';
 
@@ -136,6 +137,30 @@ describe('getPerpsDepositTokensWithDefaultFallback', () => {
         defaultTokens: [defaultToken],
       }),
     ).toEqual([defaultToken]);
+  });
+});
+
+describe('shouldPreservePerpsDepositSelectedToken', () => {
+  it('does not preserve an empty-wallet fallback after live wallet tokens arrive', () => {
+    const fallbackUsdc = makeDepositToken({
+      networkId: 'evm--42161',
+      contractAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+      symbol: 'USDC',
+    });
+    const liveEth = makeDepositToken({
+      networkId: 'evm--1',
+      contractAddress: '',
+      symbol: 'ETH',
+      fiatValue: '100',
+    });
+
+    expect(
+      shouldPreservePerpsDepositSelectedToken({
+        depositTokenListSource: 'walletBalance',
+        currentToken: fallbackUsdc,
+        tokens: [liveEth],
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.test.ts
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.test.ts
@@ -4,6 +4,7 @@ import {
   arePerpsDepositSelectedTokenRefreshFieldsEqual,
   getPerpsDepositMinimumCheck,
   getPerpsDepositTokenDisplayList,
+  getPerpsDepositTokensWithDefaultFallback,
   mergePerpsDepositTokensPreservingOrder,
   shouldShowPerpsDepositTokenSkeleton,
 } from './depositTokenDisplayUtils';
@@ -118,6 +119,23 @@ describe('getPerpsDepositTokenDisplayList', () => {
     });
 
     expect(result.map((token) => token.symbol)).toEqual(['POL', 'USDC', 'ETH']);
+  });
+});
+
+describe('getPerpsDepositTokensWithDefaultFallback', () => {
+  it('keeps a server default token selectable for an empty wallet', () => {
+    const defaultToken = makeDepositToken({
+      networkId: 'evm--42161',
+      contractAddress: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+      symbol: 'USDC',
+    });
+
+    expect(
+      getPerpsDepositTokensWithDefaultFallback({
+        walletTokens: [],
+        defaultTokens: [defaultToken],
+      }),
+    ).toEqual([defaultToken]);
   });
 });
 

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -95,6 +95,7 @@ import {
   getPerpsDepositTokenDisplayList,
   getPerpsDepositTokensWithDefaultFallback,
   mergePerpsDepositTokensPreservingOrder,
+  shouldPreservePerpsDepositSelectedToken,
   shouldShowPerpsDepositTokenSkeleton,
 } from './depositTokenDisplayUtils';
 import { DepositTokenSelectionContent } from './DepositTokenSelectionContent';
@@ -496,7 +497,7 @@ function DepositWithdrawContent({
     [],
   );
 
-  const { result, isLoading: balanceLoading } = usePromiseResult(
+  const { isLoading: balanceLoading } = usePromiseResult(
     async () => {
       const requestKey = depositTokenRequestKey;
       if (
@@ -703,57 +704,61 @@ function DepositWithdrawContent({
   }, [currentDepositTokenIdentity, selectedAction]);
 
   useEffect(() => {
-    if (result) {
-      const previousToken = currentPerpsDepositSelectedTokenRef.current;
-      const selectedToken = resolvePerpsDepositSelectedToken({
-        tokens: result,
+    if (depositTokensWithPrice.length === 0) return;
+
+    const previousToken = currentPerpsDepositSelectedTokenRef.current;
+    const selectedToken = resolvePerpsDepositSelectedToken({
+      tokens: depositTokensWithPrice,
+      currentToken: previousToken,
+      defaultTokens,
+      preserveCurrentToken: shouldPreservePerpsDepositSelectedToken({
+        depositTokenListSource,
         currentToken: previousToken,
-        defaultTokens,
-        preserveCurrentToken: depositTokenListSource === 'walletBalance',
-      });
-      if (selectedToken) {
-        setPerpsDepositTokensAtom((prev) => {
-          const currentToken = prev.currentPerpsDepositSelectedToken;
-          if (
-            arePerpsDepositSelectedTokenRefreshFieldsEqual({
-              currentToken,
-              nextToken: selectedToken,
-            })
-          ) {
-            return prev;
-          }
-          return equalTokenNoCaseSensitive({
-            token1: currentToken,
-            token2: selectedToken,
+        tokens: depositTokensWithPrice,
+      }),
+    });
+    if (selectedToken) {
+      setPerpsDepositTokensAtom((prev) => {
+        const currentToken = prev.currentPerpsDepositSelectedToken;
+        if (
+          arePerpsDepositSelectedTokenRefreshFieldsEqual({
+            currentToken,
+            nextToken: selectedToken,
           })
-            ? {
-                ...prev,
-                currentPerpsDepositSelectedToken: {
-                  ...currentToken,
-                  networkId: selectedToken.networkId,
-                  contractAddress: selectedToken.contractAddress,
-                  name: selectedToken.name,
-                  symbol: selectedToken.symbol,
-                  decimals: selectedToken.decimals,
-                  networkLogoURI: selectedToken.networkLogoURI,
-                  logoURI: selectedToken.logoURI,
-                  isNative: selectedToken.isNative,
-                  balanceParsed: selectedToken.balanceParsed,
-                  fiatValue: selectedToken.fiatValue,
-                  price: selectedToken.price,
-                },
-              }
-            : {
-                ...prev,
-                currentPerpsDepositSelectedToken: selectedToken,
-              };
-        });
-      }
+        ) {
+          return prev;
+        }
+        return equalTokenNoCaseSensitive({
+          token1: currentToken,
+          token2: selectedToken,
+        })
+          ? {
+              ...prev,
+              currentPerpsDepositSelectedToken: {
+                ...currentToken,
+                networkId: selectedToken.networkId,
+                contractAddress: selectedToken.contractAddress,
+                name: selectedToken.name,
+                symbol: selectedToken.symbol,
+                decimals: selectedToken.decimals,
+                networkLogoURI: selectedToken.networkLogoURI,
+                logoURI: selectedToken.logoURI,
+                isNative: selectedToken.isNative,
+                balanceParsed: selectedToken.balanceParsed,
+                fiatValue: selectedToken.fiatValue,
+                price: selectedToken.price,
+              },
+            }
+          : {
+              ...prev,
+              currentPerpsDepositSelectedToken: selectedToken,
+            };
+      });
     }
   }, [
     defaultTokens,
+    depositTokensWithPrice,
     depositTokenListSource,
-    result,
     setPerpsDepositTokensAtom,
   ]);
 

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -93,6 +93,7 @@ import {
   arePerpsDepositSelectedTokenRefreshFieldsEqual,
   getPerpsDepositMinimumCheck,
   getPerpsDepositTokenDisplayList,
+  getPerpsDepositTokensWithDefaultFallback,
   mergePerpsDepositTokensPreservingOrder,
   shouldShowPerpsDepositTokenSkeleton,
 } from './depositTokenDisplayUtils';
@@ -522,15 +523,19 @@ function DepositWithdrawContent({
           return [];
         }
         depositTokenListOwnerKeyRef.current = ownerKey;
+        const displayDepositTokens = getPerpsDepositTokensWithDefaultFallback({
+          walletTokens: depositTokens,
+          defaultTokens,
+        });
         const didSync = await syncDepositTokenBalances({
-          depositTokens,
+          depositTokens: displayDepositTokens,
           requestKey,
           preserveCurrentOrder: depositTokensWithPriceRef.current.length > 0,
         });
         if (!didSync) {
           return [];
         }
-        return depositTokens;
+        return displayDepositTokens;
       } catch (error) {
         if (depositTokenRequestKeyRef.current !== requestKey) {
           return [];
@@ -554,6 +559,7 @@ function DepositWithdrawContent({
       selectedAccount.indexedAccountId,
       depositTokenRequestKey,
       checkAccountSupport,
+      defaultTokens,
       setPerpsDepositTokensAtom,
       syncDepositTokenBalances,
     ],
@@ -591,7 +597,10 @@ function DepositWithdrawContent({
       }
       depositTokenListOwnerKeyRef.current = ownerKey;
       await syncDepositTokenBalances({
-        depositTokens,
+        depositTokens: getPerpsDepositTokensWithDefaultFallback({
+          walletTokens: depositTokens,
+          defaultTokens,
+        }),
         requestKey,
         preserveCurrentOrder: true,
       });
@@ -610,6 +619,7 @@ function DepositWithdrawContent({
     selectedAccount.indexedAccountId,
     depositTokenRequestKey,
     checkAccountSupport,
+    defaultTokens,
     syncDepositTokenBalances,
   ]);
 
@@ -626,13 +636,17 @@ function DepositWithdrawContent({
 
     lastSyncedDepositTokenListRevisionRef.current = depositTokenListRevision;
     void syncDepositTokenBalances({
-      depositTokens: cachedDepositTokens,
+      depositTokens: getPerpsDepositTokensWithDefaultFallback({
+        walletTokens: cachedDepositTokens,
+        defaultTokens,
+      }),
       requestKey: depositTokenRequestKeyRef.current,
       preserveCurrentOrder: depositTokensWithPriceRef.current.length > 0,
     });
   }, [
     cachedDepositTokens,
     checkAccountSupport,
+    defaultTokens,
     depositTokenListOwnerKey,
     depositTokenListRevision,
     syncDepositTokenBalances,

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/depositTokenDisplayUtils.ts
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/depositTokenDisplayUtils.ts
@@ -56,6 +56,16 @@ export function getPerpsDepositTokenDisplayList(
   );
 }
 
+export function getPerpsDepositTokensWithDefaultFallback({
+  walletTokens,
+  defaultTokens,
+}: {
+  walletTokens: IPerpsDepositToken[];
+  defaultTokens?: IPerpsDepositToken[];
+}) {
+  return walletTokens.length > 0 ? walletTokens : (defaultTokens ?? []);
+}
+
 export function shouldUsePerpsDepositLiveWalletTokens({
   atomOwnerKey,
   routeOwnerKey,

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/depositTokenDisplayUtils.ts
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/depositTokenDisplayUtils.ts
@@ -66,6 +66,26 @@ export function getPerpsDepositTokensWithDefaultFallback({
   return walletTokens.length > 0 ? walletTokens : (defaultTokens ?? []);
 }
 
+export function shouldPreservePerpsDepositSelectedToken({
+  depositTokenListSource,
+  currentToken,
+  tokens,
+}: {
+  depositTokenListSource?: 'serverConfig' | 'walletBalance';
+  currentToken?: IPerpsDepositToken;
+  tokens: IPerpsDepositToken[];
+}) {
+  return (
+    depositTokenListSource === 'walletBalance' &&
+    tokens.some((token) =>
+      equalTokenNoCaseSensitive({
+        token1: token,
+        token2: currentToken,
+      }),
+    )
+  );
+}
+
 export function shouldUsePerpsDepositLiveWalletTokens({
   atomOwnerKey,
   routeOwnerKey,


### PR DESCRIPTION
## Summary
- Restore visible Perps order-list actions with the intended icon interaction states.
- Keep server-configured Perps deposit defaults selectable when a new wallet has no qualifying assets.

## Intent & Context
Users reported that isolated-margin editing disappeared from the Perps position panel, following the same class of regression as a previously missing position-share action. A second report showed an empty token selector when a new account opened the Perps deposit modal.

## Root Cause
- The desktop action icon relied on group hover/press styles that did not apply in the rendered list context, leaving the action visually unavailable.
- A successful empty wallet-token response replaced the configured deposit-token list; the selector therefore lost its server default token after zero-balance filtering.

## Design Decisions
- Use direct icon hover and press properties, preserving the requested Kahn-style visual behavior with a one-file action fix.
- Apply the default-token fallback only when the wallet token list is empty, across initial load and refresh paths. Funded wallets retain the existing positive-fiat filtering and order.

## Changes Detail
- Update the shared desktop Perps action icon to use direct icon interaction styles.
- Add a small deposit-token fallback helper, wire it into deposit token synchronization, and cover an empty-wallet default-token case.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Perps order-list icon interactions and deposit-token refresh behavior.

## Test plan
- [x] Verify isolated-margin edit and related Perps actions are visible and usable.
- [x] Run targeted Jest tests for the deposit modal and deposit token list utilities.
- [x] Run ESLint for the three deposit-fix files.
- [ ] Verify a new account can select the configured default token in the Perps deposit modal.