### PR TITLE
fix: preserve market tab selection during navigation(OK-57886)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
@@ -40,6 +40,7 @@ import {
   getMarketStockCategoryRequestParam,
 } from './marketStockCategoryUtils';
 import { shouldIgnoreProgrammaticSettlingTab } from './marketTabChangeGuards';
+import { shouldIgnoreStalePagerTabChange } from './marketTabSelectionGuards';
 import {
   MARKET_MOBILE_COLUMN_HEADER_HEIGHT,
   getMarketMobileSecondaryHeaderHeight,
@@ -605,6 +606,18 @@ function MobileLayoutComponent({
       const wasDraggedAfterExpectedTab =
         expectedTabNameStartedAt > 0 &&
         lastPagerDraggingAt > expectedTabNameStartedAt;
+
+      if (
+        shouldIgnoreStalePagerTabChange({
+          expectedTabName,
+          incomingTabName: tabName,
+          selectedTabName: latestTabState.selectedTabName,
+          isRecentPagerDrag,
+        })
+      ) {
+        requestPageSync();
+        return;
+      }
 
       const lastProgrammaticAcceptedTab =
         lastProgrammaticAcceptedTabRef.current;

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/marketTabSelectionGuards.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/marketTabSelectionGuards.test.ts
@@ -1,5 +1,6 @@
 import {
   getIsMarketTabSelectionInFlight,
+  shouldIgnoreStalePagerTabChange,
   shouldRestoreSpotCategoryFromAtom,
 } from './marketTabSelectionGuards';
 
@@ -90,6 +91,39 @@ describe('getIsMarketTabSelectionInFlight', () => {
         lastWrittenSelection: { tab: 'perps' },
         atomTab: 'perps',
         atomSpotCategoryId: 'stock',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('shouldIgnoreStalePagerTabChange', () => {
+  it('ignores an old pager callback after an external atom selection', () => {
+    expect(
+      shouldIgnoreStalePagerTabChange({
+        incomingTabName: 'Favorites',
+        selectedTabName: 'Stocks',
+        isRecentPagerDrag: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('accepts a tab change backed by a user drag', () => {
+    expect(
+      shouldIgnoreStalePagerTabChange({
+        incomingTabName: 'Favorites',
+        selectedTabName: 'Stocks',
+        isRecentPagerDrag: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('accepts the expected programmatic target', () => {
+    expect(
+      shouldIgnoreStalePagerTabChange({
+        expectedTabName: 'Favorites',
+        incomingTabName: 'Favorites',
+        selectedTabName: 'Stocks',
+        isRecentPagerDrag: false,
       }),
     ).toBe(false);
   });

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/marketTabSelectionGuards.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/marketTabSelectionGuards.ts
@@ -64,3 +64,23 @@ export function getIsMarketTabSelectionInFlight({
   }
   return false;
 }
+
+interface IShouldIgnoreStalePagerTabChangeParams {
+  expectedTabName?: string;
+  incomingTabName: string;
+  selectedTabName: string;
+  isRecentPagerDrag: boolean;
+}
+
+export function shouldIgnoreStalePagerTabChange({
+  expectedTabName,
+  incomingTabName,
+  selectedTabName,
+  isRecentPagerDrag,
+}: IShouldIgnoreStalePagerTabChangeParams): boolean {
+  return Boolean(
+    !expectedTabName &&
+    incomingTabName !== selectedTabName &&
+    !isRecentPagerDrag,
+  );
+}

--- a/packages/kit/src/views/Market/hooks/marketNavigationTarget.ts
+++ b/packages/kit/src/views/Market/hooks/marketNavigationTarget.ts
@@ -1,0 +1,23 @@
+import type {
+  IMarketSelectedTab,
+  IMarketSelectedTabAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+
+export interface IMarketNavigationTarget {
+  tab?: IMarketSelectedTab;
+  spotCategory?: string;
+  perpsCategory?: string;
+}
+
+export function isMarketNavigationTargetApplied(
+  selection: IMarketSelectedTabAtom,
+  target: IMarketNavigationTarget,
+) {
+  return Boolean(
+    (!target.tab || selection.tab === target.tab) &&
+    (!target.spotCategory ||
+      selection.selectedSpotCategory === target.spotCategory) &&
+    (!target.perpsCategory ||
+      selection.selectedPerpsCategory === target.perpsCategory),
+  );
+}

--- a/packages/kit/src/views/Market/hooks/useNavigateToMarketTab.test.ts
+++ b/packages/kit/src/views/Market/hooks/useNavigateToMarketTab.test.ts
@@ -1,0 +1,62 @@
+import { isMarketNavigationTargetApplied } from './marketNavigationTarget';
+
+describe('isMarketNavigationTargetApplied', () => {
+  it('does not accept a stale selected spot category from another tab', () => {
+    expect(
+      isMarketNavigationTargetApplied(
+        {
+          tab: 'watchlist',
+          selectedSpotCategory: 'stock',
+        },
+        {
+          tab: 'trending',
+          spotCategory: 'stock',
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it('accepts the requested spot category after it is fully applied', () => {
+    expect(
+      isMarketNavigationTargetApplied(
+        {
+          tab: 'trending',
+          selectedSpotCategory: 'stock',
+        },
+        {
+          tab: 'trending',
+          spotCategory: 'stock',
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it('accepts the requested perps category after it is fully applied', () => {
+    expect(
+      isMarketNavigationTargetApplied(
+        {
+          tab: 'perps',
+          selectedPerpsCategory: 'all',
+        },
+        {
+          tab: 'perps',
+          perpsCategory: 'all',
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it('accepts a tab-only target after the tab is applied', () => {
+    expect(
+      isMarketNavigationTargetApplied(
+        {
+          tab: 'watchlist',
+          selectedSpotCategory: 'stock',
+        },
+        {
+          tab: 'watchlist',
+        },
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/kit/src/views/Market/hooks/useNavigateToMarketTab.ts
+++ b/packages/kit/src/views/Market/hooks/useNavigateToMarketTab.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { rootNavigationRef } from '@onekeyhq/components';
 import {
@@ -20,6 +20,10 @@ import {
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 
+import { isMarketNavigationTargetApplied } from './marketNavigationTarget';
+
+import type { IMarketNavigationTarget } from './marketNavigationTarget';
+
 interface INavigateToMarketTabOptions {
   tabToSelect?: IMarketSelectedTab;
   spotCategoryToSelect?: string;
@@ -27,38 +31,34 @@ interface INavigateToMarketTabOptions {
 }
 
 export function useNavigateToMarketTab() {
-  const [, setMarketSelectedTab] = useMarketSelectedTabAtom();
+  const [marketSelectedTab, setMarketSelectedTab] = useMarketSelectedTabAtom();
+  const marketSelectedTabRef = useRef(marketSelectedTab);
+  marketSelectedTabRef.current = marketSelectedTab;
+  const pendingNavigationTargetRef = useRef<
+    IMarketNavigationTarget | undefined
+  >(undefined);
 
-  const navigateToMarketTab = useCallback(
-    (options?: INavigateToMarketTabOptions) => {
-      const { tabToSelect, spotCategoryToSelect, perpsCategoryToSelect } =
-        options ?? {};
-      let targetTab = tabToSelect;
-      if (spotCategoryToSelect) {
-        targetTab = 'trending';
-      }
-      if (perpsCategoryToSelect) {
-        targetTab = 'perps';
-      }
+  const applyNavigationTarget = useCallback(
+    (target: IMarketNavigationTarget) => {
+      setMarketSelectedTab((prev) => ({
+        ...prev,
+        tab: target.tab ?? prev.tab,
+        selectedSpotCategory: target.spotCategory ?? prev.selectedSpotCategory,
+        spotCategoryToSelect:
+          target.tab === 'perps' ? undefined : target.spotCategory,
+        selectedPerpsCategory:
+          target.perpsCategory ?? prev.selectedPerpsCategory,
+        perpsCategoryToSelect:
+          target.tab === 'trending' || target.tab === 'watchlist'
+            ? undefined
+            : target.perpsCategory,
+      }));
+    },
+    [setMarketSelectedTab],
+  );
 
-      // Switch to specific tab inside Market (watchlist or trending)
-      if (targetTab || spotCategoryToSelect || perpsCategoryToSelect) {
-        setMarketSelectedTab((prev) => ({
-          ...prev,
-          tab: targetTab ?? prev.tab,
-          selectedSpotCategory:
-            spotCategoryToSelect ?? prev.selectedSpotCategory,
-          spotCategoryToSelect:
-            targetTab === 'perps' ? undefined : spotCategoryToSelect,
-          selectedPerpsCategory:
-            perpsCategoryToSelect ?? prev.selectedPerpsCategory,
-          perpsCategoryToSelect:
-            targetTab === 'trending' || targetTab === 'watchlist'
-              ? undefined
-              : perpsCategoryToSelect,
-        }));
-      }
-
+  const performNavigation = useCallback(
+    (target?: IMarketNavigationTarget) => {
       if (
         platformEnv.isExtensionUiPopup ||
         platformEnv.isExtensionUiSidePanel
@@ -95,10 +95,73 @@ export function useNavigateToMarketTab() {
           appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
             tab: ETranslations.global_market,
           });
+          if (target) {
+            applyNavigationTarget(target);
+          }
         }, 150);
+      } else if (target) {
+        requestAnimationFrame(() => applyNavigationTarget(target));
       }
     },
-    [setMarketSelectedTab],
+    [applyNavigationTarget],
+  );
+
+  useEffect(() => {
+    const target = pendingNavigationTargetRef.current;
+    if (
+      !target ||
+      !isMarketNavigationTargetApplied(marketSelectedTab, target)
+    ) {
+      return;
+    }
+
+    pendingNavigationTargetRef.current = undefined;
+    performNavigation(target);
+  }, [marketSelectedTab, performNavigation]);
+
+  const navigateToMarketTab = useCallback(
+    (options?: INavigateToMarketTabOptions) => {
+      const { tabToSelect, spotCategoryToSelect, perpsCategoryToSelect } =
+        options ?? {};
+      let targetTab = tabToSelect;
+      if (spotCategoryToSelect) {
+        targetTab = 'trending';
+      }
+      if (perpsCategoryToSelect) {
+        targetTab = 'perps';
+      }
+
+      const navigationTarget: IMarketNavigationTarget = {
+        tab: targetTab,
+        spotCategory: spotCategoryToSelect,
+        perpsCategory: perpsCategoryToSelect,
+      };
+      const shouldWaitForSelection = Boolean(
+        navigationTarget.tab ||
+        navigationTarget.spotCategory ||
+        navigationTarget.perpsCategory,
+      );
+
+      // Switch to specific tab inside Market (watchlist or trending)
+      if (shouldWaitForSelection) {
+        pendingNavigationTargetRef.current = navigationTarget;
+        applyNavigationTarget(navigationTarget);
+
+        if (
+          isMarketNavigationTargetApplied(
+            marketSelectedTabRef.current,
+            navigationTarget,
+          )
+        ) {
+          pendingNavigationTargetRef.current = undefined;
+          performNavigation(navigationTarget);
+        }
+        return;
+      }
+
+      performNavigation();
+    },
+    [applyNavigationTarget, performNavigation],
   );
 
   return navigateToMarketTab;


### PR DESCRIPTION
## Summary
- Synchronize the requested Market tab/category before switching routes and replay the target after the destination becomes active.
- Prevent stale native pager callbacks from overwriting an externally requested Market tab while preserving real user swipes.
- Add focused tests for navigation-target synchronization and stale-pager guarding.

## Intent & Context
OK-57886 reports that tapping **View more** from the Wallet Home Market section on Android does not reliably open the requested Market tab. For example, selecting Stocks on Home could navigate to Market with the Stocks indicator active while still rendering Favorites content.

The requested behavior is for Home Market handoffs to open the matching Market tab and content consistently across route transitions.

## Root Cause
On production native builds, the main and background JavaScript runtimes have isolated heaps. `marketSelectedTabAtom` is synchronized through the background runtime, so a main-runtime write is reflected back to the UI asynchronously.

The previous flow wrote the requested tab and immediately navigated. During destination activation, the native Market pager could still hold the previous Favorites page and emit a stale tab callback before the atom mirror caught up. That callback then wrote Favorites back over the requested Stocks/Perps selection, producing mismatched tab and content state.

## Design Decisions
- Wait for the background-synchronized atom mirror to contain the requested target before performing navigation instead of relying on a fixed delay.
- Replay the same target after route activation so the destination observes the intended state even when its local pager mounts during the transition.
- Ignore a pager tab callback only when it conflicts with the atom-derived selection, has no expected programmatic target, and is not backed by a recent user drag. This keeps normal swipe navigation intact.
- Keep the fix inside the existing shared Market handoff and native pager synchronization paths without changing persisted schema or weakening cache-first behavior.

## Changes Detail
- `useNavigateToMarketTab.ts`: tracks pending navigation targets, waits for the synchronized atom echo, and reapplies the target after navigation.
- `marketNavigationTarget.ts`: provides a pure target-applied predicate shared by the hook and its tests.
- `MobileLayout.native.tsx`: rejects stale native pager callbacks and requests the pager to resynchronize with the selected tab.
- `marketTabSelectionGuards.ts`: adds the pure stale-pager guard.
- Tests cover tab/category target matching, stale callbacks, expected programmatic changes, and recent user drags.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Desktop, Web, Extension
- **Risk Areas**: Market route handoff timing and native pager synchronization. The native guard is intentionally limited to callbacks that conflict with the synchronized selection and are not associated with user interaction.

## Test plan
- [x] Reproduce the original Android flow: Wallet Home Stocks -> View more -> Market Stocks content.
- [x] Verify Android renders the Stocks list without Favorites content after navigation.
- [x] Verify iOS Market stock navigation and rendered stock content on an iPhone 17 Pro simulator.
- [x] Verify Desktop Market/Stocks selection and rendered content through Electron CDP.
- [x] Run `yarn jest packages/kit/src/views/Market/hooks/useNavigateToMarketTab.test.ts packages/kit/src/views/Market/MarketHomeV2/layouts/marketTabSelectionGuards.test.ts --runInBand` (16 tests passed).
- [x] Run `yarn agent:check --profile commit`.
