### PR TITLE
fix: keep perp mid price at full precision

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -69,7 +69,7 @@ import { DefaultLoadingNode } from './DefaultLoadingNode';
 import { type ITickParam } from './tickSizeUtils';
 import { useAggregatedBook } from './useAggregatedBook';
 import { useRafCoalesced } from './useRafCoalesced';
-import { getOrderBookMidPrice } from './utils';
+import { getOrderBookLiveMidPrice, getOrderBookMidPrice } from './utils';
 
 import type { IFormattedOBLevel, IOrderBookVariant } from './types';
 import type {
@@ -1569,11 +1569,13 @@ function MobileSpreadInfoContent({
     referencePriceDisplay = isSpot ? `≈$${localizedMarkPrice}` : markPrice;
   }
   const fallbackMidPrice = isEmpty ? markPrice : undefined;
+  const liveMidPrice = getOrderBookLiveMidPrice({
+    isSpot,
+    spotMidPrice: spotAssetCtx?.ctx?.midPrice,
+    tradingMidPrice: hasTradingMidPrice ? tradingMidPrice : undefined,
+  });
   const resolvedMidPrice = getOrderBookMidPrice({
-    liveMidPrice:
-      hasTradingMidPrice && tradingMidPrice
-        ? tradingMidPrice
-        : fallbackMidPrice,
+    liveMidPrice: liveMidPrice || fallbackMidPrice,
     bestBid: bestBidPx,
     bestAsk: bestAskPx,
   });

--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -1339,6 +1339,7 @@ export function OrderPairBook({
   symbol: _symbol,
   bids,
   asks,
+  liveMidPrice,
   maxLevelsPerSide = 30,
   selectedTickOption,
   onSelectLevel,
@@ -1348,11 +1349,11 @@ export function OrderPairBook({
   maxLevelsPerSide?: number;
   bids: IBookLevel[];
   asks: IBookLevel[];
+  liveMidPrice?: string;
   selectedTickOption?: ITickParam;
   onSelectLevel?: (payload: IOrderBookSelection) => void;
 }) {
   const intl = useIntl();
-  const { midPrice: liveMidPrice } = useTradingPrice();
   const aggregatedData = useAggregatedBook(
     variant,
     bids,

--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -69,7 +69,7 @@ import { DefaultLoadingNode } from './DefaultLoadingNode';
 import { type ITickParam } from './tickSizeUtils';
 import { useAggregatedBook } from './useAggregatedBook';
 import { useRafCoalesced } from './useRafCoalesced';
-import { getMidPrice } from './utils';
+import { getOrderBookMidPrice } from './utils';
 
 import type { IFormattedOBLevel, IOrderBookVariant } from './types';
 import type {
@@ -1352,6 +1352,7 @@ export function OrderPairBook({
   onSelectLevel?: (payload: IOrderBookSelection) => void;
 }) {
   const intl = useIntl();
+  const { midPrice: liveMidPrice } = useTradingPrice();
   const aggregatedData = useAggregatedBook(
     variant,
     bids,
@@ -1367,10 +1368,11 @@ export function OrderPairBook({
   const askDepth = useMemo(() => {
     return new BigNumber(aggregatedData.asks.at(-1)?.cumSize ?? '0');
   }, [aggregatedData.asks]);
-  const midPrice = getMidPrice(
-    parseFloat(bids[0]?.px ?? '0'),
-    parseFloat(asks[0]?.px ?? '0'),
-  );
+  const midPrice = getOrderBookMidPrice({
+    liveMidPrice,
+    bestBid: bids[0]?.px,
+    bestAsk: asks[0]?.px,
+  });
   const textColor = useTextColor();
   const blockColors = useBlockColors();
   const isInteractive = Boolean(onSelectLevel);
@@ -1565,13 +1567,20 @@ function MobileSpreadInfoContent({
   if (hasMarkPrice) {
     referencePriceDisplay = isSpot ? `≈$${localizedMarkPrice}` : markPrice;
   }
-  const emptyMidPrice =
-    hasTradingMidPrice && tradingMidPrice
-      ? formatLocalizedNumberString(tradingMidPrice)
-      : localizedMarkPrice;
-  const midPrice = isEmpty
-    ? emptyMidPrice
-    : getMidPrice(parseFloat(bestBidPx ?? '0'), parseFloat(bestAskPx ?? '0'));
+  const fallbackMidPrice = isEmpty ? markPrice : undefined;
+  const resolvedMidPrice = getOrderBookMidPrice({
+    liveMidPrice:
+      hasTradingMidPrice && tradingMidPrice
+        ? tradingMidPrice
+        : fallbackMidPrice,
+    bestBid: bestBidPx,
+    bestAsk: bestAskPx,
+  });
+  const resolvedMidPriceBN = new BigNumber(resolvedMidPrice);
+  const midPrice =
+    resolvedMidPriceBN.isFinite() && resolvedMidPriceBN.gt(0)
+      ? formatLocalizedNumberString(resolvedMidPrice)
+      : '--';
 
   useEffect(() => {
     tracePerpsMobileLayout('orderBook.mobileReferencePrice.state', {
@@ -1690,28 +1699,6 @@ function MobileSpreadInfoContent({
 }
 const MobileSpreadInfoContentMemo = memo(MobileSpreadInfoContent);
 
-const MobileEmptySpreadInfoRow = memo(
-  ({
-    isEmpty,
-    textColor,
-  }: {
-    isEmpty: boolean;
-    textColor: ReturnType<typeof useTextColor>;
-  }) => {
-    const { midPrice: tradingMidPrice, isValid: hasTradingMidPrice } =
-      useTradingPrice();
-    return (
-      <MobileSpreadInfoContentMemo
-        hasTradingMidPrice={hasTradingMidPrice}
-        isEmpty={isEmpty}
-        textColor={textColor}
-        tradingMidPrice={tradingMidPrice}
-      />
-    );
-  },
-);
-MobileEmptySpreadInfoRow.displayName = 'MobileEmptySpreadInfoRow';
-
 const MobileSpreadInfoRow = memo(
   ({
     bestAskPx,
@@ -1724,18 +1711,17 @@ const MobileSpreadInfoRow = memo(
     isEmpty: boolean;
     textColor: ReturnType<typeof useTextColor>;
   }) => {
-    if (isEmpty) {
-      return (
-        <MobileEmptySpreadInfoRow isEmpty={isEmpty} textColor={textColor} />
-      );
-    }
+    const { midPrice: tradingMidPrice, isValid: hasTradingMidPrice } =
+      useTradingPrice();
 
     return (
       <MobileSpreadInfoContentMemo
         bestAskPx={bestAskPx}
         bestBidPx={bestBidPx}
+        hasTradingMidPrice={hasTradingMidPrice}
         isEmpty={isEmpty}
         textColor={textColor}
+        tradingMidPrice={tradingMidPrice}
       />
     );
   },

--- a/packages/kit/src/views/Perp/components/OrderBook/utils.test.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/utils.test.ts
@@ -1,0 +1,22 @@
+import { getOrderBookMidPrice } from './utils';
+
+describe('getOrderBookMidPrice', () => {
+  it('keeps the live mid price independent from aggregated order book ticks', () => {
+    expect(
+      getOrderBookMidPrice({
+        liveMidPrice: '64145.5',
+        bestBid: '64000',
+        bestAsk: '65000',
+      }),
+    ).toBe('64145.5');
+  });
+
+  it('falls back to the best bid and ask midpoint when live mid is unavailable', () => {
+    expect(
+      getOrderBookMidPrice({
+        bestBid: '64000',
+        bestAsk: '65000',
+      }),
+    ).toBe('64500');
+  });
+});

--- a/packages/kit/src/views/Perp/components/OrderBook/utils.test.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/utils.test.ts
@@ -1,4 +1,4 @@
-import { getOrderBookMidPrice } from './utils';
+import { getOrderBookLiveMidPrice, getOrderBookMidPrice } from './utils';
 
 describe('getOrderBookMidPrice', () => {
   it('keeps the live mid price independent from aggregated order book ticks', () => {
@@ -18,5 +18,15 @@ describe('getOrderBookMidPrice', () => {
         bestAsk: '65000',
       }),
     ).toBe('64500');
+  });
+
+  it('only uses the real spot mid price for spot books', () => {
+    expect(
+      getOrderBookLiveMidPrice({
+        isSpot: true,
+        spotMidPrice: undefined,
+        tradingMidPrice: '99',
+      }),
+    ).toBeUndefined();
   });
 });

--- a/packages/kit/src/views/Perp/components/OrderBook/utils.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/utils.ts
@@ -90,3 +90,15 @@ export function getOrderBookMidPrice({
 
   return getMidPrice(bestBid ?? '0', bestAsk ?? '0');
 }
+
+export function getOrderBookLiveMidPrice({
+  isSpot,
+  spotMidPrice,
+  tradingMidPrice,
+}: {
+  isSpot: boolean;
+  spotMidPrice?: string;
+  tradingMidPrice?: string;
+}): string | undefined {
+  return isSpot ? spotMidPrice : tradingMidPrice;
+}

--- a/packages/kit/src/views/Perp/components/OrderBook/utils.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/utils.ts
@@ -73,3 +73,20 @@ export function getMidPrice(
 
   return bestBidBN.plus(bestAskBN).dividedBy(2).toFixed();
 }
+
+export function getOrderBookMidPrice({
+  liveMidPrice,
+  bestBid,
+  bestAsk,
+}: {
+  liveMidPrice?: string;
+  bestBid?: string;
+  bestAsk?: string;
+}): string {
+  const liveMidPriceBN = new BigNumber(liveMidPrice ?? '');
+  if (liveMidPriceBN.isFinite() && liveMidPriceBN.isGreaterThan(0)) {
+    return liveMidPriceBN.toFixed();
+  }
+
+  return getMidPrice(bestBid ?? '0', bestAsk ?? '0');
+}


### PR DESCRIPTION
## Summary
- Keep the displayed Perps order book mid price at full market precision.
- Keep the selected depth precision scoped to order book level aggregation only.
- Add coverage for coarse depth ticks with a precise live mid price.

## Intent & Context
Selecting a coarse order book depth such as 1000 should only change the spacing between displayed levels. The mid price must continue to reflect the live market mid at its original precision.

## Root Cause
The mid price display was calculated from the best bid and ask returned by the L2 subscription. Those levels are already aggregated according to the selected `nSigFigs` and `mantissa`, so a 1000 depth setting could turn the displayed mid into a fixed value such as 64500.

## Design Decisions
- Prefer the independent live mid price used by the trading flow, which is not affected by order book depth aggregation.
- Preserve the best bid/ask midpoint as a fallback when the live mid is temporarily unavailable.

## Changes Detail
- Update pair and mobile order book mid price displays to consume the live trading mid.
- Add a shared resolver for live-mid preference and bid/ask fallback behavior.
- Add unit tests covering precise live mids with coarsely aggregated book levels.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile, Desktop, Web
- **Risk Areas**: Temporary live-mid unavailability continues to use the existing bid/ask midpoint fallback.

## Test plan
- [x] Run targeted order book utility Jest tests.
- [x] Run `yarn agent:check --profile commit`.
- [ ] Verify changing depth to 1000 changes book spacing without rounding the displayed mid price.
