### PR TITLE
fix: repair Windows notification badge initialization

### DIFF
--- a/packages/kit-bg/src/desktopApis/DesktopApiNotification.ts
+++ b/packages/kit-bg/src/desktopApis/DesktopApiNotification.ts
@@ -1,6 +1,5 @@
-import { Notification, app, ipcMain, systemPreferences } from 'electron';
+import { Notification, app, systemPreferences } from 'electron';
 import logger from 'electron-log/main';
-import TaskBarBadgeWindows from 'electron-taskbar-badge';
 import { isNil } from 'lodash';
 
 import { ipcMessageKeys } from '@onekeyhq/desktop/app/config';
@@ -12,6 +11,16 @@ import type {
 import { ENotificationPermission } from '@onekeyhq/shared/types/notification';
 
 import type { IDesktopApi } from './instance/IDesktopApi';
+
+// The package's ESM entry incorrectly resolves BadgeGenerator under Rspack.
+// Use the CommonJS entry, whose export shape is compatible with Electron's main process.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const TaskBarBadgeWindows = require('electron-taskbar-badge') as new (
+  win: object,
+  options: object,
+) => {
+  update(badgeNumber: number): void;
+};
 
 const isWin = process.platform === 'win32';
 const isMac = process.platform === 'darwin';
@@ -298,6 +307,10 @@ class DesktopApiNotification {
 
   desktopApi: IDesktopApi;
 
+  private win32TaskBarBadge?: {
+    update(badgeNumber: number): void;
+  };
+
   private initWin32TaskBarBadge(APP_NAME: string) {
     if (process.platform === 'win32') {
       app.setAppUserModelId(APP_NAME);
@@ -307,7 +320,7 @@ class DesktopApiNotification {
       if (safelyMainWindow) {
         // TODO not working on Windows 11 (UTM)
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        const badge = new TaskBarBadgeWindows(safelyMainWindow, {
+        this.win32TaskBarBadge = new TaskBarBadgeWindows(safelyMainWindow, {
           fontColor: '#000000',
           font: '62px Microsoft Yahei',
           color: '#000000',
@@ -322,7 +335,7 @@ class DesktopApiNotification {
             console.log(`Received ${count} new notifications!`);
           },
         });
-        console.log('TaskBarBadgeWindows init', badge);
+        console.log('TaskBarBadgeWindows init');
       }
     }
   }
@@ -364,22 +377,11 @@ class DesktopApiNotification {
       const win = globalThis.$desktopMainAppFunctions?.getSafelyMainWindow?.();
       if (win) {
         if (!isNil(count) && count > 0) {
-          // TaskBarBadgeWindows will handle badge count render
+          this.win32TaskBarBadge?.update(count);
         } else {
           win.setOverlayIcon(null, '');
         }
       }
-
-      /* 
-      // If invokeType is set to "handle"
-      // Replace 8 with whatever number you want the badge to display
-      ipcRenderer.invoke('notificationCount', 8); 
-      */
-      // handle -> ipcRenderer.invoke
-      void ipcMain.emit(
-        ipcMessageKeys.NOTIFICATION_SET_BADGE_WINDOWS,
-        params.count ?? 0,
-      );
     }
   }
 


### PR DESCRIPTION
## Summary
- Load `electron-taskbar-badge` through its compatible CommonJS entry.
- Update the Windows taskbar badge directly from the desktop API.

## Intent & Context
Windows users saw `TypeError: BadgeGenerator2 is not a constructor` when enabling notifications or updating the notification badge.

## Root Cause
`electron-taskbar-badge@1.1.2` has an incompatible ESM export path for the desktop main-process bundle. The package's internal `BadgeGenerator` was resolved as a non-constructor at runtime.

## Design Decisions
Use the package's CommonJS export and retain the badge instance so the main process can call `update()` directly. This avoids relying on an IPC event emission path that does not invoke the package's registered handler.

## Changes Detail
- `packages/kit-bg/src/desktopApis/DesktopApiNotification.ts`: use the CommonJS-compatible loader, store the Windows badge instance, and update it directly.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop (Windows)
- **Risk Areas**: Windows taskbar badge rendering.

## Test plan
- [x] File-level ESLint
- [x] TypeScript check for the changed file
- [x] Electron main-process development build
- [ ] Verify enabling notifications and unread badge updates on a Windows package
