### PR TITLE
fix: reset stock list offset with secondary tabs

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.test.ts
@@ -42,8 +42,10 @@ describe('getMarketNativeCompactListStyle', () => {
     });
   });
 
-  it('does not transform tabs that render secondary controls', () => {
-    expect(getMarketNativeCompactListStyle(false)).toEqual({});
+  it('resets the compact offset when secondary controls are rendered', () => {
+    expect(getMarketNativeCompactListStyle(false)).toEqual({
+      transform: [{ translateY: 0 }],
+    });
   });
 });
 

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/mobileLayoutUtils.ts
@@ -25,11 +25,13 @@ export function getMarketMobileSecondaryHeaderHeight() {
 }
 
 export function getMarketNativeCompactListStyle(isCompact: boolean) {
-  return isCompact
-    ? ({
-        transform: [{ translateY: MARKET_MOBILE_COMPACT_HEADER_OFFSET }],
-      } as const)
-    : ({} as const);
+  return {
+    transform: [
+      {
+        translateY: isCompact ? MARKET_MOBILE_COMPACT_HEADER_OFFSET : 0,
+      },
+    ],
+  } as const;
 }
 
 interface IGetMarketRecommendContainerPaddingTopParams {


### PR DESCRIPTION
## Summary
- Explicitly reset the native market token list transform when stock secondary tabs are rendered.
- Add a regression test for the compact-to-secondary-header state transition.

## Intent & Context
The stock-token list could render its first token underneath the secondary category tabs when stock categories were configured. This follows the previous mobile market spacing stabilization and preserves its compact spacing behavior for stock-like tabs that do not render secondary controls.

The fix was validated across Web, Mobile Web, iOS, Android, and Desktop while cycling the primary market tabs, every configured stock secondary tab, and list scrolling states.

## Root Cause
Native Market UI initially renders before the asynchronous market basic configuration has supplied `stockCategories`. During that initial state, the stock list uses the compact header transform (`translateY(-42)`). When the categories arrive, the list switches to the full secondary-header state, but returning an empty style object did not reliably clear the previously applied native transform. The stale offset moved the first token underneath the new secondary tab row.

This affects the main UI runtime. The background runtime only supplies the serialized market configuration asynchronously; no shared native resource ownership, storage, or background JS behavior is changed.

## Design Decisions
- Keep the existing compact `-42px` transform so tabs without secondary controls retain the intended spacing from the previous fix.
- Return an explicit `translateY: 0` for the non-compact state so React Native always resets the previous transform when asynchronous configuration changes the header mode.
- Avoid changing header heights, list padding, data fetching, or tab interaction behavior.

## Changes Detail
- `mobileLayoutUtils.ts`: make both compact and non-compact native list transforms explicit.
- `mobileLayoutUtils.test.ts`: verify that rendering secondary controls resets the compact offset to zero.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile (iOS and Android); Web, Mobile Web, and Desktop were regression-tested
- **Risk Areas**: Native list positioning during the asynchronous transition from an empty stock category configuration to configured secondary tabs

## Test plan
- [x] Run `mobileLayoutUtils.test.ts` (12/12 tests passed).
- [x] Run `yarn agent:check --profile commit`.
- [x] Verify Web and Mobile Web by switching Favorites, Trending, Stocks, and Perps; switch Hot, New List, Crypto, Stocks, and Metals; scroll down and back to the top.
- [x] Verify iOS and Android through the same primary/secondary tab and scrolling matrix with the configured-category state.
- [x] Verify Desktop through the same tab matrix and confirm the first token remains below the column header.
