### PR TITLE
feat: use fast l2 order book subscriptions

### DIFF
--- a/packages/kit-bg/package.json
+++ b/packages/kit-bg/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.tsx",
   "dependencies": {
     "eth-url-parser": "^1.0.4",
+    "fflate": "0.8.2",
     "idb": "^7.1.1",
     "ipaddr.js": "^2.3.0",
     "miscreant": "^0.3.2"

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidCache.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidCache.test.ts
@@ -114,6 +114,21 @@ describe('ServiceHyperliquidCache L2 book helpers', () => {
       mantissa: null,
     });
   });
+
+  it('uses the source precision instead of current UI options', () => {
+    const data = Object.assign(
+      buildBook({ coin: 'ETH', bidLevels: 20, askLevels: 20 }),
+      { nSigFigs: 5, mantissa: 5 },
+    );
+
+    expect(
+      buildL2BookSnapshotCachePayload({
+        data,
+        activeBookCoin: 'ETH',
+        activeOptions: { nSigFigs: 5, mantissa: 2 },
+      }),
+    ).toMatchObject({ nSigFigs: 5, mantissa: 5 });
+  });
 });
 
 describe('ServiceHyperliquidCache account display write throttle', () => {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidCache.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidCache.ts
@@ -139,10 +139,22 @@ export function buildL2BookSnapshotCachePayload({
   }
 
   const isActiveBook = activeBookCoin === coin;
+  const hasSourceOptions =
+    Object.prototype.hasOwnProperty.call(data, 'nSigFigs') ||
+    Object.prototype.hasOwnProperty.call(data, 'mantissa');
+  let nSigFigs = null;
+  let mantissa = null;
+  if (hasSourceOptions) {
+    nSigFigs = data.nSigFigs ?? null;
+    mantissa = data.mantissa ?? null;
+  } else if (isActiveBook) {
+    nSigFigs = activeOptions?.nSigFigs ?? null;
+    mantissa = activeOptions?.mantissa ?? null;
+  }
   return {
     coin,
-    nSigFigs: isActiveBook ? (activeOptions?.nSigFigs ?? null) : null,
-    mantissa: isActiveBook ? (activeOptions?.mantissa ?? null) : null,
+    nSigFigs,
+    mantissa,
     data,
   };
 }
@@ -313,6 +325,8 @@ export default class ServiceHyperliquidCache extends ServiceBase {
     });
     return {
       ...cacheEntry.data,
+      nSigFigs: cacheEntry.nSigFigs ?? null,
+      mantissa: cacheEntry.mantissa ?? null,
       localReceivedAt: cacheEntry.updatedAt,
     } as IBook & { localReceivedAt?: number };
   }

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -215,6 +215,10 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   private _fastL2RecoveryPromise: Promise<void> | null = null;
 
+  private _fastL2DiagnosticSequence = 0;
+
+  private _fastL2ReconcileSequence = 0;
+
   private static readonly FAST_L2_SNAPSHOT_TIMEOUT_MS = 3000;
 
   private static readonly FAST_L2_RECOVERY_DELAYS_MS = [0, 1000, 3000];
@@ -223,6 +227,23 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   private static readonly ORDER_BOOK_STRATEGY: 'fastL2Primary' | 'l2BookOnly' =
     'fastL2Primary';
+
+  private _logFastL2Diagnostic(
+    event: string,
+    params: Omit<
+      Parameters<
+        typeof defaultLogger.perp.hyperliquid.subscriptionFastL2Diagnostic
+      >[0],
+      'event' | 'sequence'
+    > = {},
+  ): void {
+    this._fastL2DiagnosticSequence += 1;
+    defaultLogger.perp.hyperliquid.subscriptionFastL2Diagnostic({
+      event,
+      sequence: this._fastL2DiagnosticSequence,
+      ...params,
+    });
+  }
 
   // Cross-runtime atom sync can lag behind a reopened socket, leaving current
   // market subscriptions absent while the socket still looks healthy.
@@ -248,26 +269,36 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     }
     this._unwatchSubscriptionAtoms();
 
-    const handler = () => {
+    const handler = (source: string) => {
       const client = this._client;
       if (!client || client.transport?.socket?.readyState !== WebSocket.OPEN) {
         return;
       }
+      this._logFastL2Diagnostic('atom-change', { detail: source });
       console.log('updateSubscriptions__by__atomWatcher');
       void this.updateSubscriptions();
     };
 
     this._subscriptionAtomsUnsubs = [
-      perpsActiveAccountAtom.sub(handler),
-      perpsActiveAssetAtom.sub(handler),
-      spotActiveAssetAtom.sub(handler),
-      tradingModeAtom.sub(handler),
-      perpsActiveOrderBookOptionsAtom.sub(handler),
+      perpsActiveAccountAtom.sub(() => handler('active-account')),
+      perpsActiveAssetAtom.sub(() => handler('active-asset')),
+      spotActiveAssetAtom.sub(() => handler('spot-active-asset')),
+      tradingModeAtom.sub(() => handler('trading-mode')),
+      perpsActiveOrderBookOptionsAtom.sub(() => handler('order-book-options')),
     ];
   }
 
   private _resetFastL2Book(subscriptionKey?: string): void {
+    this._logFastL2Diagnostic('decoder-reset', {
+      subscriptionKey: this._fastL2SubscriptionKey,
+      hasSnapshot: this._fastL2Book?.hasSnapshot ?? false,
+      detail: subscriptionKey ? `requested:${subscriptionKey}` : 'unscoped',
+    });
     if (subscriptionKey && this._fastL2SubscriptionKey !== subscriptionKey) {
+      this._logFastL2Diagnostic('decoder-reset-skipped', {
+        subscriptionKey: this._fastL2SubscriptionKey,
+        detail: `requested:${subscriptionKey}`,
+      });
       return;
     }
     if (this._fastL2SnapshotTimer) {
@@ -298,6 +329,13 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     }
     this._fastL2SubscriptionKey = spec.key;
     this._fastL2Book = new FastL2Book(spec.params.c);
+    this._logFastL2Diagnostic('decoder-prepared', {
+      coin: spec.params.c,
+      nSigFigs: spec.params.s ?? null,
+      mantissa: spec.params.m ?? null,
+      subscriptionKey: spec.key,
+      pending: Boolean(this.pendingSubSpecsMap[spec.key]),
+    });
   }
 
   private _startFastL2SnapshotTimer(subscriptionKey: string): void {
@@ -517,6 +555,11 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   private async _updateSubscriptionsCore(
     preparedRequiredSubInfo?: IRequiredSubscriptionInfo,
   ) {
+    this._fastL2ReconcileSequence += 1;
+    const reconcileSequence = this._fastL2ReconcileSequence;
+    this._logFastL2Diagnostic('reconcile-start', {
+      detail: `${reconcileSequence}`,
+    });
     if (this.subscriptionsHandlerDisabled) {
       return;
     }
@@ -557,9 +600,35 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     this._applyStateUpdates(newState, requiredSubInfo.params);
 
     this._currentState = newState;
+    const orderBookSpec = Object.values(
+      requiredSubInfo.requiredSubSpecsMap,
+    ).find(
+      (spec) =>
+        spec.type === ESubscriptionType.L2 ||
+        spec.type === ESubscriptionType.L2_BOOK,
+    );
+    this._logFastL2Diagnostic('reconcile-target', {
+      coin:
+        orderBookSpec?.type === ESubscriptionType.L2
+          ? orderBookSpec.params.c
+          : orderBookSpec?.params.coin,
+      nSigFigs:
+        orderBookSpec?.type === ESubscriptionType.L2
+          ? (orderBookSpec.params.s ?? null)
+          : (orderBookSpec?.params.nSigFigs ?? null),
+      mantissa:
+        orderBookSpec?.type === ESubscriptionType.L2
+          ? (orderBookSpec.params.m ?? null)
+          : (orderBookSpec?.params.mantissa ?? null),
+      subscriptionKey: orderBookSpec?.key,
+      detail: `${reconcileSequence}:${orderBookSpec?.type ?? 'none'}`,
+    });
     this._emitConnectionStatus();
     await this._executeSubscriptionChanges();
     this._scheduleCriticalSubscriptionHealthCheck('update_subscriptions');
+    this._logFastL2Diagnostic('reconcile-end', {
+      detail: `${reconcileSequence}`,
+    });
   }
 
   _updateSubscriptionsDebounced = debounce(
@@ -1799,6 +1868,13 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     try {
       const lifecycleVersion = this._subscriptionLifecycleVersion;
       if (spec.type === ESubscriptionType.L2) {
+        this._logFastL2Diagnostic('subscribe-start', {
+          coin: spec.params.c,
+          nSigFigs: spec.params.s ?? null,
+          mantissa: spec.params.m ?? null,
+          subscriptionKey: spec.key,
+          pending: this._isSubscriptionSpecPending(spec),
+        });
         this._prepareFastL2Book(
           spec as ISubscriptionSpec<ESubscriptionType.L2>,
         );
@@ -1828,6 +1904,12 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         isActive: true,
       });
       if (spec.type === ESubscriptionType.L2) {
+        this._logFastL2Diagnostic('subscribe-complete', {
+          coin: spec.params.c,
+          subscriptionKey: spec.key,
+          pending: this._isSubscriptionSpecPending(spec),
+          hasSnapshot: this._fastL2Book?.hasSnapshot ?? false,
+        });
         this._startFastL2SnapshotTimer(spec.key);
       }
     } catch (error) {
@@ -1869,6 +1951,12 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     try {
       if (spec) {
         if (spec.type === ESubscriptionType.L2) {
+          this._logFastL2Diagnostic('unsubscribe-start', {
+            coin: spec.params.c,
+            nSigFigs: spec.params.s ?? null,
+            mantissa: spec.params.m ?? null,
+            subscriptionKey: spec.key,
+          });
           this._resetFastL2Book(spec.key);
         }
         const shouldRemoveCache = options?.removeCache ?? true;
@@ -1888,6 +1976,12 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
           }
           // await sdkSub.unsubscribe();
           await client.unsubscribe(spec.type, spec.params);
+          if (spec.type === ESubscriptionType.L2) {
+            this._logFastL2Diagnostic('unsubscribe-complete', {
+              coin: spec.params.c,
+              subscriptionKey: spec.key,
+            });
+          }
           removeSubCache();
           return true;
         } catch (error) {
@@ -2194,11 +2288,19 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         const subscriptionKey = this._fastL2SubscriptionKey;
         const fastL2Book = this._fastL2Book;
         if (!subscriptionKey || !fastL2Book) {
+          this._logFastL2Diagnostic('frame-dropped-no-decoder', {
+            subscriptionKey,
+            detail: 's' in (data as IFastL2Frame) ? 'snapshot' : 'update',
+          });
           return;
         }
         // A late frame from a destroyed subscription must never mutate a
         // newly selected market's book.
         if (!this.pendingSubSpecsMap[subscriptionKey]) {
+          this._logFastL2Diagnostic('frame-dropped-not-pending', {
+            subscriptionKey,
+            hasSnapshot: fastL2Book.hasSnapshot,
+          });
           return;
         }
 
@@ -2214,6 +2316,14 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         }
         if (!normalizedBook) {
           return;
+        }
+        if ('s' in (data as IFastL2Frame)) {
+          this._logFastL2Diagnostic('snapshot-applied', {
+            coin: normalizedBook.coin,
+            subscriptionKey,
+            pending: Boolean(this.pendingSubSpecsMap[subscriptionKey]),
+            hasSnapshot: fastL2Book.hasSnapshot,
+          });
         }
         this._markSubscriptionActivity(subscriptionType, messageTimestamp);
         if (this._fastL2SnapshotTimer && fastL2Book.hasSnapshot) {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -83,6 +83,7 @@ import {
 import {
   SUBSCRIPTION_TYPE_INFO,
   calculateRequiredSubscriptionsMap,
+  isOrderBookOptionsTargetReady,
 } from './utils/SubscriptionConfig';
 import { PerKeyMutationQueue } from './utils/SubscriptionMutationQueue';
 import { LatestSubscriptionReconcileQueue } from './utils/SubscriptionReconcileQueue';
@@ -331,7 +332,10 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       this._fastL2ReconnectAttempted = false;
     }
     this._fastL2SubscriptionKey = spec.key;
-    this._fastL2Book = new FastL2Book(spec.params.c);
+    this._fastL2Book = new FastL2Book(spec.params.c, {
+      nSigFigs: spec.params.s ?? null,
+      mantissa: spec.params.m ?? null,
+    });
     this._logFastL2Diagnostic('decoder-prepared', {
       coin: spec.params.c,
       nSigFigs: spec.params.s ?? null,
@@ -470,6 +474,15 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     const currentAssetId =
       currentMode === 'spot' ? spotActiveAsset?.assetId : activeAsset?.assetId;
     const activeOrderBookOptions = await perpsActiveOrderBookOptionsAtom.get();
+    if (
+      !isOrderBookOptionsTargetReady(currentCoin, activeOrderBookOptions?.coin)
+    ) {
+      this._logFastL2Diagnostic('target-options-not-ready', {
+        coin: currentCoin,
+        detail: activeOrderBookOptions?.coin,
+      });
+      return undefined;
+    }
     const isOrderBookOptionsForCurrentCoin =
       Boolean(currentCoin) && activeOrderBookOptions?.coin === currentCoin;
 
@@ -2356,15 +2369,20 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
           normalizedBook,
         );
       } else if (subscriptionType === ESubscriptionType.L2_BOOK) {
+        const normalizedBook = {
+          ...(data as IBook),
+          nSigFigs: this._currentState.l2BookOptions?.nSigFigs ?? null,
+          mantissa: this._currentState.l2BookOptions?.mantissa ?? null,
+        };
         this.backgroundApi.serviceHyperliquidCache.cacheL2BookSnapshot({
-          data: data as IBook,
+          data: normalizedBook,
           activeBookCoin:
             this._currentState.tradingMode === 'spot'
               ? this._currentState.currentSpotSymbol
               : this._currentState.currentSymbol,
           activeOptions: this._currentState.l2BookOptions,
         });
-        this._emitHyperliquidDataUpdate(subscriptionType, data);
+        this._emitHyperliquidDataUpdate(subscriptionType, normalizedBook);
       } else {
         this._emitHyperliquidDataUpdate(subscriptionType, data);
       }

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -76,6 +76,11 @@ import ServiceBase from '../ServiceBase';
 
 import hyperLiquidCache from './hyperLiquidCache';
 import {
+  FastL2Book,
+  type IFastL2Frame,
+  isStaleFastL2TargetError,
+} from './utils/FastL2Book';
+import {
   SUBSCRIPTION_TYPE_INFO,
   calculateRequiredSubscriptionsMap,
 } from './utils/SubscriptionConfig';
@@ -125,6 +130,7 @@ interface ISubscriptionUpdateParams {
   tradingMode?: 'perp' | 'spot';
   isConnected?: boolean;
   l2BookOptions?: IL2BookOptions | null;
+  orderBookTransport?: 'l2' | 'l2Book';
 }
 
 interface IRequiredSubscriptionInfo {
@@ -162,6 +168,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     spotAssetCtxsEnabled: false,
     currentSpotSymbol: undefined,
     tradingMode: 'perp',
+    orderBookTransport: 'l2',
   };
 
   private _networkTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
@@ -191,6 +198,31 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   pendingSubSpecsMap: Record<string, ISubscriptionSpec<ESubscriptionType>> = {};
 
   private _activeSubscriptions = new Map<string, IActiveSubscription>();
+
+  private _fastL2Book: FastL2Book | null = null;
+
+  private _fastL2SubscriptionKey: string | null = null;
+
+  private _fastL2SnapshotTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private _fastL2TargetKey: string | null = null;
+
+  private _fastL2FallbackTargetKey: string | null = null;
+
+  private _fastL2RecoveryAttempts = 0;
+
+  private _fastL2ReconnectAttempted = false;
+
+  private _fastL2RecoveryPromise: Promise<void> | null = null;
+
+  private static readonly FAST_L2_SNAPSHOT_TIMEOUT_MS = 3000;
+
+  private static readonly FAST_L2_RECOVERY_DELAYS_MS = [0, 1000, 3000];
+
+  private static readonly ORDER_BOOK_MUTATION_KEY = 'hyperliquid-order-book';
+
+  private static readonly ORDER_BOOK_STRATEGY: 'fastL2Primary' | 'l2BookOnly' =
+    'fastL2Primary';
 
   // Cross-runtime atom sync can lag behind a reopened socket, leaving current
   // market subscriptions absent while the socket still looks healthy.
@@ -232,6 +264,141 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       tradingModeAtom.sub(handler),
       perpsActiveOrderBookOptionsAtom.sub(handler),
     ];
+  }
+
+  private _resetFastL2Book(subscriptionKey?: string): void {
+    if (subscriptionKey && this._fastL2SubscriptionKey !== subscriptionKey) {
+      return;
+    }
+    if (this._fastL2SnapshotTimer) {
+      clearTimeout(this._fastL2SnapshotTimer);
+      this._fastL2SnapshotTimer = null;
+    }
+    this._fastL2Book = null;
+    this._fastL2SubscriptionKey = null;
+  }
+
+  private _resetFastL2Recovery(): void {
+    this._fastL2TargetKey = null;
+    this._fastL2FallbackTargetKey = null;
+    this._fastL2RecoveryAttempts = 0;
+    this._fastL2ReconnectAttempted = false;
+    this._fastL2RecoveryPromise = null;
+  }
+
+  private _prepareFastL2Book(
+    spec: ISubscriptionSpec<ESubscriptionType.L2>,
+  ): void {
+    this._resetFastL2Book();
+    if (this._fastL2TargetKey !== spec.key) {
+      this._fastL2TargetKey = spec.key;
+      this._fastL2FallbackTargetKey = null;
+      this._fastL2RecoveryAttempts = 0;
+      this._fastL2ReconnectAttempted = false;
+    }
+    this._fastL2SubscriptionKey = spec.key;
+    this._fastL2Book = new FastL2Book(spec.params.c);
+  }
+
+  private _startFastL2SnapshotTimer(subscriptionKey: string): void {
+    if (
+      this._fastL2SubscriptionKey !== subscriptionKey ||
+      this._fastL2Book?.hasSnapshot
+    ) {
+      return;
+    }
+    if (this._fastL2SnapshotTimer) {
+      clearTimeout(this._fastL2SnapshotTimer);
+    }
+    this._fastL2SnapshotTimer = setTimeout(() => {
+      if (
+        this._fastL2SubscriptionKey === subscriptionKey &&
+        !this._fastL2Book?.hasSnapshot
+      ) {
+        void this._recoverFastL2('snapshot_timeout');
+      }
+    }, ServiceHyperliquidSubscription.FAST_L2_SNAPSHOT_TIMEOUT_MS);
+  }
+
+  private async _recoverFastL2(reason: string): Promise<void> {
+    if (this._fastL2RecoveryPromise || !this._fastL2TargetKey) {
+      return;
+    }
+
+    const targetKey = this._fastL2TargetKey;
+    const spec = this.pendingSubSpecsMap[targetKey] as
+      | ISubscriptionSpec<ESubscriptionType.L2>
+      | undefined;
+    if (!spec) {
+      return;
+    }
+
+    const recoveryPromise = (async () => {
+      const delay =
+        ServiceHyperliquidSubscription.FAST_L2_RECOVERY_DELAYS_MS[
+          this._fastL2RecoveryAttempts
+        ];
+      if (delay !== undefined) {
+        this._fastL2RecoveryAttempts += 1;
+        if (delay > 0) {
+          await timerUtils.wait(delay);
+        }
+        if (
+          this._fastL2TargetKey !== targetKey ||
+          !this.pendingSubSpecsMap[targetKey]
+        ) {
+          return;
+        }
+        console.warn(
+          `[HyperLiquid WebSocket] Reset Fast L2 subscription: ${reason}`,
+        );
+        const resetSucceeded = await this._subscriptionMutationQueue.enqueue(
+          ServiceHyperliquidSubscription.ORDER_BOOK_MUTATION_KEY,
+          async () => {
+            const destroyed = await this._destroySubscription(spec);
+            if (!destroyed) {
+              return false;
+            }
+            if (
+              this._fastL2TargetKey === targetKey &&
+              this.pendingSubSpecsMap[targetKey]
+            ) {
+              await this._createSubscription(spec);
+            }
+            return true;
+          },
+        );
+        if (!resetSucceeded && !this._fastL2ReconnectAttempted) {
+          this._fastL2ReconnectAttempted = true;
+          await this._forceReconnectTransport();
+        }
+        return;
+      }
+
+      if (!this._fastL2ReconnectAttempted) {
+        this._fastL2ReconnectAttempted = true;
+        console.warn(
+          `[HyperLiquid WebSocket] Reconnect after Fast L2 recovery exhausted: ${reason}`,
+        );
+        await this._forceReconnectTransport();
+        return;
+      }
+
+      this._fastL2FallbackTargetKey = targetKey;
+      this._resetFastL2Book(targetKey);
+      console.warn(
+        `[HyperLiquid WebSocket] Fast L2 fallback to l2Book for current target: ${reason}`,
+      );
+      await this.updateSubscriptions();
+    })();
+    this._fastL2RecoveryPromise = recoveryPromise;
+    try {
+      await recoveryPromise;
+    } finally {
+      if (this._fastL2RecoveryPromise === recoveryPromise) {
+        this._fastL2RecoveryPromise = null;
+      }
+    }
   }
 
   private _unwatchSubscriptionAtoms(): void {
@@ -307,9 +474,20 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       spotAssetCtxsEnabled: this._currentState.spotAssetCtxsEnabled,
       currentSpotSymbol,
       tradingMode: currentMode,
+      orderBookTransport:
+        ServiceHyperliquidSubscription.ORDER_BOOK_STRATEGY === 'l2BookOnly'
+          ? 'l2Book'
+          : 'l2',
     };
 
-    const requiredSubSpecsMap = calculateRequiredSubscriptionsMap(params);
+    let requiredSubSpecsMap = calculateRequiredSubscriptionsMap(params);
+    const fastL2Spec = Object.values(requiredSubSpecsMap).find(
+      (spec) => spec.type === ESubscriptionType.L2,
+    );
+    if (fastL2Spec?.key === this._fastL2FallbackTargetKey) {
+      params.orderBookTransport = 'l2Book';
+      requiredSubSpecsMap = calculateRequiredSubscriptionsMap(params);
+    }
 
     return { requiredSubSpecsMap, params };
   }
@@ -328,6 +506,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       params.currentSymbol !== this._currentState.currentSymbol ||
       params.currentSpotSymbol !== this._currentState.currentSpotSymbol ||
       params.tradingMode !== this._currentState.tradingMode ||
+      params.orderBookTransport !== this._currentState.orderBookTransport ||
       !isEqual(
         params.l2BookOptions ?? null,
         this._currentState.l2BookOptions ?? null,
@@ -516,6 +695,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     const criticalTypes = new Set<ESubscriptionType>([
       ESubscriptionType.ALL_DEXS_ASSET_CTXS,
       ESubscriptionType.L2_BOOK,
+      ESubscriptionType.L2,
     ]);
     const now = Date.now();
     const staleTypes = new Set<ESubscriptionType>();
@@ -550,6 +730,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     const criticalTypes = new Set<ESubscriptionType>([
       ESubscriptionType.ALL_DEXS_ASSET_CTXS,
       ESubscriptionType.L2_BOOK,
+      ESubscriptionType.L2,
     ]);
     const missingTypes = new Set<ESubscriptionType>();
     for (const spec of Object.values(requiredSubSpecsMap)) {
@@ -927,6 +1108,8 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   async disconnect(): Promise<void> {
     this.backgroundApi.serviceHyperliquidCache.flushPendingL2BookSnapshotCache();
     this._subscriptionLifecycleVersion += 1;
+    this._resetFastL2Book();
+    this._resetFastL2Recovery();
     this._updateSubscriptionsDebounced.cancel();
     this._unwatchSubscriptionAtoms();
     await this._cleanupAllSubscriptions();
@@ -953,6 +1136,8 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   async cleanup(): Promise<void> {
     this.backgroundApi.serviceHyperliquidCache.flushPendingL2BookSnapshotCache();
     this._subscriptionLifecycleVersion += 1;
+    this._resetFastL2Book();
+    this._resetFastL2Recovery();
     this._updateSubscriptionsDebounced.cancel();
     this._unwatchSubscriptionAtoms();
     this._stopPingLoop();
@@ -966,6 +1151,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   private async _forceReconnectTransport(): Promise<void> {
     this.backgroundApi.serviceHyperliquidCache.flushPendingL2BookSnapshotCache();
     this._subscriptionLifecycleVersion += 1;
+    this._resetFastL2Book();
     this._updateSubscriptionsDebounced.cancel();
     this._unwatchSubscriptionAtoms();
     this._clearPostOpenDataCheck();
@@ -1139,6 +1325,9 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     if ('l2BookOptions' in params) {
       state.l2BookOptions = params.l2BookOptions;
     }
+    if ('orderBookTransport' in params) {
+      state.orderBookTransport = params.orderBookTransport;
+    }
   }
 
   // export interface ISubscriptionSpec<T extends ESubscriptionType> {
@@ -1167,6 +1356,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     void perpsWebSocketReadyStateAtom.set({ readyState });
     // WS close event — readyState tracked via perpsWebSocketReadyStateAtom
     this._activeSubscriptions.clear();
+    this._resetFastL2Book();
     this._clearPostOpenDataCheck();
     this._stopPingLoop();
     // OK-53014: WS closed — drop any pending atom-change reconcile.  A new
@@ -1198,7 +1388,9 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       await perpsWebSocketReadyStateAtom.set({
         readyState: readyState ?? WebSocket.OPEN,
       });
-
+      // A new transport retries Fast L2 even if the previous connection had
+      // temporarily degraded this target to l2Book.
+      this._fastL2FallbackTargetKey = null;
       const prevNetworkStatus = await perpsNetworkStatusAtom.get();
       const wasConnected = prevNetworkStatus?.connected;
       const openClient = this._client;
@@ -1355,6 +1547,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         ESubscriptionType.ALL_MIDS,
         ESubscriptionType.BBO,
         ESubscriptionType.L2_BOOK,
+        ESubscriptionType.L2,
         ESubscriptionType.ACTIVE_ASSET_CTX,
         ESubscriptionType.ACTIVE_ASSET_DATA,
         ESubscriptionType.WEB_DATA2,
@@ -1535,12 +1728,38 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       }
     });
 
-    // Different subscription keys must reconcile independently; otherwise an
-    // obsolete L2 subscribe ack can stall the next selected market.
-    await Promise.all([
-      ...toDestroySubscriptions.map((spec) => this._destroySubscription(spec)),
-      ...toCreateSubscriptions.map((spec) => this._createSubscription(spec)),
-    ]);
+    const isOrderBookSpec = (spec: ISubscriptionSpec<ESubscriptionType>) =>
+      spec.type === ESubscriptionType.L2 ||
+      spec.type === ESubscriptionType.L2_BOOK;
+    const orderBookToDestroy = toDestroySubscriptions.filter(isOrderBookSpec);
+    const orderBookToCreate = toCreateSubscriptions.filter(isOrderBookSpec);
+    const otherTasks = [
+      ...toDestroySubscriptions
+        .filter((spec) => !isOrderBookSpec(spec))
+        .map((spec) => this._destroySubscription(spec)),
+      ...toCreateSubscriptions
+        .filter((spec) => !isOrderBookSpec(spec))
+        .map((spec) => this._createSubscription(spec)),
+    ];
+
+    const orderBookTask =
+      orderBookToDestroy.length > 0 || orderBookToCreate.length > 0
+        ? this._subscriptionMutationQueue.enqueue(
+            ServiceHyperliquidSubscription.ORDER_BOOK_MUTATION_KEY,
+            async () => {
+              for (const spec of orderBookToDestroy) {
+                await this._destroySubscription(spec);
+              }
+              for (const spec of orderBookToCreate) {
+                if (this._isSubscriptionSpecPending(spec)) {
+                  await this._createSubscription(spec);
+                }
+              }
+            },
+          )
+        : Promise.resolve();
+
+    await Promise.all([...otherTasks, orderBookTask]);
   }
 
   private async _createSubscription<T extends ESubscriptionType>(
@@ -1579,6 +1798,11 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
     try {
       const lifecycleVersion = this._subscriptionLifecycleVersion;
+      if (spec.type === ESubscriptionType.L2) {
+        this._prepareFastL2Book(
+          spec as ISubscriptionSpec<ESubscriptionType.L2>,
+        );
+      }
       const client = await this._createSubscriptionDirect(spec);
       const isCreateResultStale =
         this.subscriptionsHandlerDisabled ||
@@ -1603,11 +1827,20 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         lastActivity: Date.now(),
         isActive: true,
       });
+      if (spec.type === ESubscriptionType.L2) {
+        this._startFastL2SnapshotTimer(spec.key);
+      }
     } catch (error) {
+      this._resetFastL2Book(spec.key);
       console.error(
         `[ServiceHyperliquidSubscription.createSubscription] Failed to create subscription ${spec.type}:`,
         error,
       );
+      if (spec.type === ESubscriptionType.L2) {
+        setTimeout(() => {
+          void this._recoverFastL2('subscribe_failed');
+        }, 0);
+      }
     } finally {
       if (
         !this.subscriptionsHandlerDisabled &&
@@ -1635,6 +1868,9 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   ): Promise<boolean> {
     try {
       if (spec) {
+        if (spec.type === ESubscriptionType.L2) {
+          this._resetFastL2Book(spec.key);
+        }
         const shouldRemoveCache = options?.removeCache ?? true;
         const removeSubCache = () => {
           if (!shouldRemoveCache) {
@@ -1769,7 +2005,9 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       }
 
       const messageTimestamp = Date.now();
-      this._markSubscriptionActivity(subscriptionType, messageTimestamp);
+      if (subscriptionType !== ESubscriptionType.L2) {
+        this._markSubscriptionActivity(subscriptionType, messageTimestamp);
+      }
       markPerpsColdStartPerfOnce(`service_ws_first_${subscriptionType}`, {
         subscriptionType,
       });
@@ -1951,6 +2189,53 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         this._emitHyperliquidDataUpdate(
           subscriptionType,
           data as IWsAllDexsAssetCtxs,
+        );
+      } else if (subscriptionType === ESubscriptionType.L2) {
+        const subscriptionKey = this._fastL2SubscriptionKey;
+        const fastL2Book = this._fastL2Book;
+        if (!subscriptionKey || !fastL2Book) {
+          return;
+        }
+        // A late frame from a destroyed subscription must never mutate a
+        // newly selected market's book.
+        if (!this.pendingSubSpecsMap[subscriptionKey]) {
+          return;
+        }
+
+        let normalizedBook: IBook | null;
+        try {
+          normalizedBook = fastL2Book.apply(data as IFastL2Frame);
+        } catch (error) {
+          if (isStaleFastL2TargetError(error)) {
+            return;
+          }
+          await this._recoverFastL2('invalid_frame');
+          return;
+        }
+        if (!normalizedBook) {
+          return;
+        }
+        this._markSubscriptionActivity(subscriptionType, messageTimestamp);
+        if (this._fastL2SnapshotTimer && fastL2Book.hasSnapshot) {
+          clearTimeout(this._fastL2SnapshotTimer);
+          this._fastL2SnapshotTimer = null;
+        }
+        if (fastL2Book.hasSnapshot) {
+          this._fastL2RecoveryAttempts = 0;
+          this._fastL2ReconnectAttempted = false;
+          this._fastL2FallbackTargetKey = null;
+        }
+        this.backgroundApi.serviceHyperliquidCache.cacheL2BookSnapshot({
+          data: normalizedBook,
+          activeBookCoin:
+            this._currentState.tradingMode === 'spot'
+              ? this._currentState.currentSpotSymbol
+              : this._currentState.currentSymbol,
+          activeOptions: this._currentState.l2BookOptions,
+        });
+        this._emitHyperliquidDataUpdate(
+          ESubscriptionType.L2_BOOK,
+          normalizedBook,
         );
       } else if (subscriptionType === ESubscriptionType.L2_BOOK) {
         this.backgroundApi.serviceHyperliquidCache.cacheL2BookSnapshot({

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -85,6 +85,7 @@ import {
   calculateRequiredSubscriptionsMap,
 } from './utils/SubscriptionConfig';
 import { PerKeyMutationQueue } from './utils/SubscriptionMutationQueue';
+import { LatestSubscriptionReconcileQueue } from './utils/SubscriptionReconcileQueue';
 
 import type {
   ISubscriptionSpec,
@@ -252,6 +253,8 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   private _subscriptionLifecycleVersion = 0;
 
   private _subscriptionMutationQueue = new PerKeyMutationQueue();
+
+  private _subscriptionReconcileQueue = new LatestSubscriptionReconcileQueue();
 
   private _destroyingSubscriptionKeys = new Set<string>();
 
@@ -600,26 +603,25 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     this._applyStateUpdates(newState, requiredSubInfo.params);
 
     this._currentState = newState;
-    const orderBookSpec = Object.values(
-      requiredSubInfo.requiredSubSpecsMap,
-    ).find(
-      (spec) =>
-        spec.type === ESubscriptionType.L2 ||
-        spec.type === ESubscriptionType.L2_BOOK,
-    );
+    const requiredSpecs = Object.values(requiredSubInfo.requiredSubSpecsMap);
+    const fastL2Spec = requiredSpecs.find(
+      (spec) => spec.type === ESubscriptionType.L2,
+    ) as ISubscriptionSpec<ESubscriptionType.L2> | undefined;
+    const l2BookSpec = requiredSpecs.find(
+      (spec) => spec.type === ESubscriptionType.L2_BOOK,
+    ) as ISubscriptionSpec<ESubscriptionType.L2_BOOK> | undefined;
+    const orderBookSpec = fastL2Spec ?? l2BookSpec;
+    const orderBookCoin = fastL2Spec?.params.c ?? l2BookSpec?.params.coin;
+    const orderBookNSigFigs = fastL2Spec
+      ? (fastL2Spec.params.s ?? null)
+      : (l2BookSpec?.params.nSigFigs ?? null);
+    const orderBookMantissa = fastL2Spec
+      ? (fastL2Spec.params.m ?? null)
+      : (l2BookSpec?.params.mantissa ?? null);
     this._logFastL2Diagnostic('reconcile-target', {
-      coin:
-        orderBookSpec?.type === ESubscriptionType.L2
-          ? orderBookSpec.params.c
-          : orderBookSpec?.params.coin,
-      nSigFigs:
-        orderBookSpec?.type === ESubscriptionType.L2
-          ? (orderBookSpec.params.s ?? null)
-          : (orderBookSpec?.params.nSigFigs ?? null),
-      mantissa:
-        orderBookSpec?.type === ESubscriptionType.L2
-          ? (orderBookSpec.params.m ?? null)
-          : (orderBookSpec?.params.mantissa ?? null),
+      coin: orderBookCoin,
+      nSigFigs: orderBookNSigFigs,
+      mantissa: orderBookMantissa,
       subscriptionKey: orderBookSpec?.key,
       detail: `${reconcileSequence}:${orderBookSpec?.type ?? 'none'}`,
     });
@@ -631,9 +633,17 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     });
   }
 
+  private async _enqueueSubscriptionReconcile(source: string): Promise<void> {
+    this._logFastL2Diagnostic('reconcile-queued', { detail: source });
+    await this._subscriptionReconcileQueue.enqueue(async () => {
+      this._logFastL2Diagnostic('reconcile-dequeued', { detail: source });
+      await this._updateSubscriptionsCore();
+    });
+  }
+
   _updateSubscriptionsDebounced = debounce(
     async () => {
-      await this._updateSubscriptionsCore();
+      await this._enqueueSubscriptionReconcile('debounced');
     },
     300,
     {
@@ -668,12 +678,8 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     // Skip debounce on first subscription to speed up initial load
     if (!this._hasInitialSubscription) {
       this._hasInitialSubscription = true;
-      const requiredSubInfo = await this.buildRequiredSubscriptionsMap();
-      if (!requiredSubInfo) {
-        return;
-      }
       markPerpsColdStartPerf('service_update_subscriptions_core_first_start');
-      await this._updateSubscriptionsCore(requiredSubInfo);
+      await this._enqueueSubscriptionReconcile('initial');
       markPerpsColdStartPerf('service_update_subscriptions_core_first_end');
       return;
     }
@@ -685,7 +691,7 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     if (this._shouldUpdateSubscriptionsImmediately(requiredSubInfo.params)) {
       this._updateSubscriptionsDebounced.cancel();
       this._hasInitialSubscription = true;
-      await this._updateSubscriptionsCore(requiredSubInfo);
+      await this._enqueueSubscriptionReconcile('immediate');
       markPerpsColdStartPerf('service_update_subscriptions_end');
       return;
     }
@@ -1868,16 +1874,15 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     try {
       const lifecycleVersion = this._subscriptionLifecycleVersion;
       if (spec.type === ESubscriptionType.L2) {
+        const fastL2Spec = spec as ISubscriptionSpec<ESubscriptionType.L2>;
         this._logFastL2Diagnostic('subscribe-start', {
-          coin: spec.params.c,
-          nSigFigs: spec.params.s ?? null,
-          mantissa: spec.params.m ?? null,
-          subscriptionKey: spec.key,
-          pending: this._isSubscriptionSpecPending(spec),
+          coin: fastL2Spec.params.c,
+          nSigFigs: fastL2Spec.params.s ?? null,
+          mantissa: fastL2Spec.params.m ?? null,
+          subscriptionKey: fastL2Spec.key,
+          pending: this._isSubscriptionSpecPending(fastL2Spec),
         });
-        this._prepareFastL2Book(
-          spec as ISubscriptionSpec<ESubscriptionType.L2>,
-        );
+        this._prepareFastL2Book(fastL2Spec);
       }
       const client = await this._createSubscriptionDirect(spec);
       const isCreateResultStale =
@@ -1904,10 +1909,11 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
         isActive: true,
       });
       if (spec.type === ESubscriptionType.L2) {
+        const fastL2Spec = spec as ISubscriptionSpec<ESubscriptionType.L2>;
         this._logFastL2Diagnostic('subscribe-complete', {
-          coin: spec.params.c,
-          subscriptionKey: spec.key,
-          pending: this._isSubscriptionSpecPending(spec),
+          coin: fastL2Spec.params.c,
+          subscriptionKey: fastL2Spec.key,
+          pending: this._isSubscriptionSpecPending(fastL2Spec),
           hasSnapshot: this._fastL2Book?.hasSnapshot ?? false,
         });
         this._startFastL2SnapshotTimer(spec.key);
@@ -1951,11 +1957,12 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     try {
       if (spec) {
         if (spec.type === ESubscriptionType.L2) {
+          const fastL2Spec = spec as ISubscriptionSpec<ESubscriptionType.L2>;
           this._logFastL2Diagnostic('unsubscribe-start', {
-            coin: spec.params.c,
-            nSigFigs: spec.params.s ?? null,
-            mantissa: spec.params.m ?? null,
-            subscriptionKey: spec.key,
+            coin: fastL2Spec.params.c,
+            nSigFigs: fastL2Spec.params.s ?? null,
+            mantissa: fastL2Spec.params.m ?? null,
+            subscriptionKey: fastL2Spec.key,
           });
           this._resetFastL2Book(spec.key);
         }
@@ -1977,9 +1984,10 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
           // await sdkSub.unsubscribe();
           await client.unsubscribe(spec.type, spec.params);
           if (spec.type === ESubscriptionType.L2) {
+            const fastL2Spec = spec as ISubscriptionSpec<ESubscriptionType.L2>;
             this._logFastL2Diagnostic('unsubscribe-complete', {
-              coin: spec.params.c,
-              subscriptionKey: spec.key,
+              coin: fastL2Spec.params.c,
+              subscriptionKey: fastL2Spec.key,
             });
           }
           removeSubCache();

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/FastL2Book.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/FastL2Book.test.ts
@@ -1,6 +1,24 @@
 import { FastL2Book } from './FastL2Book';
 
 describe('FastL2Book', () => {
+  it('keeps source precision on snapshots and updates', () => {
+    const book = new FastL2Book('ETH', { nSigFigs: 5, mantissa: 2 });
+    book.apply({
+      s: {
+        coin: 'ETH',
+        time: 1,
+        levels: [
+          [{ px: '100', sz: '1', n: 1 }],
+          [{ px: '101', sz: '1', n: 1 }],
+        ],
+      },
+    });
+
+    expect(
+      book.apply({ u: { c: 'ETH', t: 2, l: [[], []], r: [[], []] } }),
+    ).toMatchObject({ nSigFigs: 5, mantissa: 2 });
+  });
+
   it('merges an l2 delta into a snapshot without changing the book contract', () => {
     const book = new FastL2Book('BTC');
 

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/FastL2Book.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/FastL2Book.test.ts
@@ -1,0 +1,143 @@
+import { FastL2Book } from './FastL2Book';
+
+describe('FastL2Book', () => {
+  it('merges an l2 delta into a snapshot without changing the book contract', () => {
+    const book = new FastL2Book('BTC');
+
+    expect(
+      book.apply({
+        s: {
+          coin: 'BTC',
+          time: 1,
+          levels: [
+            [
+              { px: '100', sz: '1', n: 1 },
+              { px: '99', sz: '2', n: 1 },
+            ],
+            [
+              { px: '101', sz: '3', n: 1 },
+              { px: '102', sz: '4', n: 1 },
+            ],
+          ],
+        },
+      }),
+    ).toEqual({
+      coin: 'BTC',
+      time: 1,
+      levels: [
+        [
+          { px: '100', sz: '1', n: 1 },
+          { px: '99', sz: '2', n: 1 },
+        ],
+        [
+          { px: '101', sz: '3', n: 1 },
+          { px: '102', sz: '4', n: 1 },
+        ],
+      ],
+    });
+
+    expect(
+      book.apply({
+        u: {
+          c: 'BTC',
+          t: 2,
+          l: [
+            [
+              { p: '100', s: '5' },
+              { p: '98', s: '6' },
+            ],
+            [{ p: '101', s: '7' }],
+          ],
+          r: [[1], [1]],
+        },
+      }),
+    ).toEqual({
+      coin: 'BTC',
+      time: 2,
+      levels: [
+        [
+          { px: '100', sz: '5', n: 0 },
+          { px: '98', sz: '6', n: 0 },
+        ],
+        [{ px: '101', sz: '7', n: 0 }],
+      ],
+    });
+  });
+
+  it('drops a delta received before the first snapshot', () => {
+    const book = new FastL2Book('BTC');
+
+    expect(
+      book.apply({
+        u: {
+          c: 'BTC',
+          t: 2,
+          l: [[], []],
+          r: [[], []],
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it('classifies frames from a previous target as stale', () => {
+    const book = new FastL2Book('ETH');
+
+    expect(() =>
+      book.apply({
+        u: {
+          c: 'BTC',
+          t: 2,
+          l: [[], []],
+          r: [[], []],
+        },
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: 'stale_target',
+      }),
+    );
+  });
+
+  it('merges a compressed delta after the first snapshot', () => {
+    const book = new FastL2Book('BTC');
+    book.apply({
+      s: {
+        coin: 'BTC',
+        time: 1,
+        levels: [[{ px: '100', sz: '1', n: 1 }], []],
+      },
+    });
+
+    expect(
+      book.apply({
+        c: 'q1ZKVrJScgpxVtJRKlGyMtJRylGyio6uVipQslIyNDBQ0lEqVrJSMlWqjdWJjo3VUSoCSYPZtQA=',
+      }),
+    ).toEqual({
+      coin: 'BTC',
+      time: 2,
+      levels: [[{ px: '100', sz: '5', n: 0 }], []],
+    });
+  });
+
+  it('rejects removal indexes outside the current book', () => {
+    const book = new FastL2Book('BTC');
+    book.apply({
+      s: {
+        coin: 'BTC',
+        time: 1,
+        levels: [[{ px: '100', sz: '1', n: 1 }], []],
+      },
+    });
+
+    expect(() =>
+      book.apply({
+        u: {
+          c: 'BTC',
+          t: 2,
+          l: [[], []],
+          r: [[1], []],
+        },
+      }),
+    ).toThrow('Fast L2 book: Invalid L2 removal index');
+  });
+});

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/FastL2Book.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/FastL2Book.ts
@@ -315,8 +315,14 @@ export class FastL2Book {
 
   private readonly _coin: string;
 
-  constructor(coin: string) {
+  private readonly _options: Pick<IBook, 'nSigFigs' | 'mantissa'>;
+
+  constructor(
+    coin: string,
+    options: Pick<IBook, 'nSigFigs' | 'mantissa'> = {},
+  ) {
     this._coin = coin;
+    this._options = options;
   }
 
   get hasSnapshot(): boolean {
@@ -325,7 +331,7 @@ export class FastL2Book {
 
   apply(frame: IFastL2Frame): IBook | null {
     if ('s' in frame) {
-      this._book = parseSnapshot(frame.s, this._coin);
+      this._book = { ...parseSnapshot(frame.s, this._coin), ...this._options };
       return this._book;
     }
     const update = parseUpdate(
@@ -344,7 +350,12 @@ export class FastL2Book {
       mergeSide(this._book.levels[1], update.l[1], update.r[1], 1),
     ];
     assertBookInvariant(levels);
-    this._book = { coin: this._coin, time: update.t, levels } as IBook;
+    this._book = {
+      coin: this._coin,
+      time: update.t,
+      levels,
+      ...this._options,
+    } as IBook;
     return this._book;
   }
 }

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/FastL2Book.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/FastL2Book.ts
@@ -1,0 +1,350 @@
+import BigNumber from 'bignumber.js';
+import { Inflate, strFromU8 } from 'fflate';
+
+import type { IBook, IBookLevel } from '@onekeyhq/shared/types/hyperliquid/sdk';
+
+const MAX_LEVELS_PER_SIDE = 200;
+const MAX_COMPRESSED_BYTES = 256 * 1024;
+const MAX_DECOMPRESSED_BYTES = 1024 * 1024;
+const INFLATE_CHUNK_BYTES = 16 * 1024;
+const DECIMAL_PATTERN = /^\d+(?:\.\d+)?$/;
+const BASE64_PATTERN =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+type IFastL2Level = {
+  p: string;
+  s: string;
+};
+
+type IFastL2Update = {
+  c: string;
+  t: number;
+  l: [IFastL2Level[], IFastL2Level[]];
+  r: [number[], number[]];
+};
+
+export type IFastL2Frame = { s: IBook } | { u: IFastL2Update } | { c: string };
+
+export type IFastL2BookError = Error & {
+  code: 'invalid_stream' | 'stale_target';
+};
+
+export function isStaleFastL2TargetError(
+  error: unknown,
+): error is IFastL2BookError {
+  return (
+    error instanceof Error && 'code' in error && error.code === 'stale_target'
+  );
+}
+
+function createFastL2BookError(
+  message: string,
+  code: 'invalid_stream' | 'stale_target' = 'invalid_stream',
+): IFastL2BookError {
+  return Object.assign(new Error(`Fast L2 book: ${message}`), { code });
+}
+
+function assertFiniteTimestamp(value: unknown): asserts value is number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    throw createFastL2BookError('Invalid L2 timestamp');
+  }
+}
+
+function assertDecimal(value: unknown, field: string): asserts value is string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > 64 ||
+    !DECIMAL_PATTERN.test(value)
+  ) {
+    throw createFastL2BookError(`Invalid L2 ${field}`);
+  }
+
+  const decimal = new BigNumber(value);
+  if (!decimal.isFinite() || decimal.lte(0)) {
+    throw createFastL2BookError(`Invalid L2 ${field}`);
+  }
+}
+
+function comparePrices(left: string, right: string): number {
+  return new BigNumber(left).comparedTo(new BigNumber(right));
+}
+
+function decodeBase64(value: string): Uint8Array {
+  if (
+    value.length === 0 ||
+    value.length > Math.ceil((MAX_COMPRESSED_BYTES * 4) / 3) + 4 ||
+    !BASE64_PATTERN.test(value)
+  ) {
+    throw createFastL2BookError('Invalid compressed L2 payload');
+  }
+
+  const global = globalThis as typeof globalThis & {
+    Buffer?: {
+      from: (input: string, encoding: 'base64') => Uint8Array;
+    };
+    atob?: (input: string) => string;
+  };
+  if (global.Buffer) {
+    const decoded = new Uint8Array(global.Buffer.from(value, 'base64'));
+    if (decoded.length > MAX_COMPRESSED_BYTES) {
+      throw createFastL2BookError('Compressed L2 payload exceeds byte limit');
+    }
+    return decoded;
+  }
+  if (!global.atob) {
+    throw createFastL2BookError('Base64 decoder is unavailable');
+  }
+
+  const binary = global.atob(value);
+  if (binary.length > MAX_COMPRESSED_BYTES) {
+    throw createFastL2BookError('Compressed L2 payload exceeds byte limit');
+  }
+  const decoded = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    decoded[index] = binary.charCodeAt(index);
+  }
+  return decoded;
+}
+
+function decodeCompressedUpdate(payload: string): unknown {
+  const compressed = decodeBase64(payload);
+  const chunks: Uint8Array[] = [];
+  let outputLength = 0;
+  const inflate = new Inflate((chunk) => {
+    outputLength += chunk.length;
+    if (outputLength > MAX_DECOMPRESSED_BYTES) {
+      throw createFastL2BookError('Decompressed L2 payload exceeds byte limit');
+    }
+    chunks.push(chunk);
+  });
+
+  for (
+    let offset = 0;
+    offset < compressed.length;
+    offset += INFLATE_CHUNK_BYTES
+  ) {
+    inflate.push(
+      compressed.subarray(offset, offset + INFLATE_CHUNK_BYTES),
+      offset + INFLATE_CHUNK_BYTES >= compressed.length,
+    );
+  }
+
+  const output = new Uint8Array(outputLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.length;
+  }
+  try {
+    return JSON.parse(strFromU8(output));
+  } catch {
+    throw createFastL2BookError('Invalid decompressed L2 payload');
+  }
+}
+
+function assertSortedLevels(levels: IBookLevel[], side: 0 | 1): void {
+  for (let index = 1; index < levels.length; index += 1) {
+    const previous = levels[index - 1];
+    const current = levels[index];
+    if (!previous || !current) {
+      throw createFastL2BookError('Invalid L2 level');
+    }
+    const comparison = comparePrices(previous.px, current.px);
+    if ((side === 0 && comparison <= 0) || (side === 1 && comparison >= 0)) {
+      throw createFastL2BookError('Invalid L2 price order');
+    }
+  }
+}
+
+function assertBookInvariant(levels: [IBookLevel[], IBookLevel[]]): void {
+  const [bids, asks] = levels;
+  assertSortedLevels(bids, 0);
+  assertSortedLevels(asks, 1);
+
+  const bestBid = bids[0];
+  const bestAsk = asks[0];
+  if (bestBid && bestAsk && comparePrices(bestBid.px, bestAsk.px) >= 0) {
+    throw createFastL2BookError('Invalid crossed L2 book');
+  }
+}
+
+function parseSnapshot(snapshot: unknown, expectedCoin: string): IBook {
+  if (!snapshot || typeof snapshot !== 'object') {
+    throw createFastL2BookError('Invalid L2 snapshot');
+  }
+
+  const data = snapshot as Partial<IBook>;
+  if (typeof data.coin === 'string' && data.coin !== expectedCoin) {
+    throw createFastL2BookError('Stale L2 snapshot target', 'stale_target');
+  }
+  if (data.coin !== expectedCoin || !Array.isArray(data.levels)) {
+    throw createFastL2BookError('Invalid L2 snapshot coin or levels');
+  }
+  assertFiniteTimestamp(data.time);
+
+  const [bids, asks] = data.levels;
+  if (!Array.isArray(bids) || !Array.isArray(asks)) {
+    throw createFastL2BookError('Invalid L2 snapshot levels');
+  }
+  if (bids.length > MAX_LEVELS_PER_SIDE || asks.length > MAX_LEVELS_PER_SIDE) {
+    throw createFastL2BookError('L2 snapshot exceeds level limit');
+  }
+
+  const normalized: [IBookLevel[], IBookLevel[]] = [
+    bids.map((level) => {
+      assertDecimal(level?.px, 'price');
+      assertDecimal(level?.sz, 'size');
+      if (
+        typeof level?.n !== 'number' ||
+        !Number.isSafeInteger(level.n) ||
+        level.n < 0
+      ) {
+        throw createFastL2BookError('Invalid L2 order count');
+      }
+      return { px: level.px, sz: level.sz, n: level.n };
+    }),
+    asks.map((level) => {
+      assertDecimal(level?.px, 'price');
+      assertDecimal(level?.sz, 'size');
+      if (
+        typeof level?.n !== 'number' ||
+        !Number.isSafeInteger(level.n) ||
+        level.n < 0
+      ) {
+        throw createFastL2BookError('Invalid L2 order count');
+      }
+      return { px: level.px, sz: level.sz, n: level.n };
+    }),
+  ];
+  assertBookInvariant(normalized);
+
+  return { coin: expectedCoin, time: data.time, levels: normalized } as IBook;
+}
+
+function parseUpdate(update: unknown, expectedCoin: string): IFastL2Update {
+  if (!update || typeof update !== 'object') {
+    throw createFastL2BookError('Invalid L2 update');
+  }
+  const data = update as Partial<IFastL2Update>;
+  if (typeof data.c === 'string' && data.c !== expectedCoin) {
+    throw createFastL2BookError('Stale L2 update target', 'stale_target');
+  }
+  if (
+    data.c !== expectedCoin ||
+    !Array.isArray(data.l) ||
+    !Array.isArray(data.r)
+  ) {
+    throw createFastL2BookError('Invalid L2 update coin or levels');
+  }
+  assertFiniteTimestamp(data.t);
+  const [bidUpdates, askUpdates] = data.l;
+  const [bidRemovals, askRemovals] = data.r;
+  if (
+    !Array.isArray(bidUpdates) ||
+    !Array.isArray(askUpdates) ||
+    !Array.isArray(bidRemovals) ||
+    !Array.isArray(askRemovals) ||
+    bidUpdates.length > MAX_LEVELS_PER_SIDE ||
+    askUpdates.length > MAX_LEVELS_PER_SIDE ||
+    bidRemovals.length > MAX_LEVELS_PER_SIDE ||
+    askRemovals.length > MAX_LEVELS_PER_SIDE
+  ) {
+    throw createFastL2BookError('Invalid L2 update bounds');
+  }
+
+  const normalizeUpdates = (updates: IFastL2Level[]) =>
+    updates.map((level) => {
+      assertDecimal(level?.p, 'price');
+      assertDecimal(level?.s, 'size');
+      return { p: level.p, s: level.s };
+    });
+  const normalizeRemovals = (removals: number[]) =>
+    removals.map((index) => {
+      if (!Number.isSafeInteger(index) || index < 0) {
+        throw createFastL2BookError('Invalid L2 removal index');
+      }
+      return index;
+    });
+
+  return {
+    c: expectedCoin,
+    t: data.t,
+    l: [normalizeUpdates(bidUpdates), normalizeUpdates(askUpdates)],
+    r: [normalizeRemovals(bidRemovals), normalizeRemovals(askRemovals)],
+  };
+}
+
+function mergeSide(
+  currentLevels: IBookLevel[],
+  updates: IFastL2Level[],
+  removals: number[],
+  side: 0 | 1,
+): IBookLevel[] {
+  const removedIndexes = new Set<number>();
+  for (const index of removals) {
+    if (index >= currentLevels.length || removedIndexes.has(index)) {
+      throw createFastL2BookError('Invalid L2 removal index');
+    }
+    removedIndexes.add(index);
+  }
+
+  const levelsByPrice = new Map<string, IBookLevel>();
+  currentLevels.forEach((level, index) => {
+    if (!removedIndexes.has(index)) {
+      levelsByPrice.set(level.px, level);
+    }
+  });
+  updates.forEach((level) => {
+    levelsByPrice.set(level.p, { px: level.p, sz: level.s, n: 0 });
+  });
+
+  const merged = Array.from(levelsByPrice.values());
+  if (merged.length > MAX_LEVELS_PER_SIDE) {
+    throw createFastL2BookError('L2 book exceeds level limit');
+  }
+  merged.sort((left, right) => {
+    const comparison = comparePrices(left.px, right.px);
+    return side === 0 ? -comparison : comparison;
+  });
+  return merged;
+}
+
+export class FastL2Book {
+  private _book: IBook | null = null;
+
+  private readonly _coin: string;
+
+  constructor(coin: string) {
+    this._coin = coin;
+  }
+
+  get hasSnapshot(): boolean {
+    return this._book !== null;
+  }
+
+  apply(frame: IFastL2Frame): IBook | null {
+    if ('s' in frame) {
+      this._book = parseSnapshot(frame.s, this._coin);
+      return this._book;
+    }
+    const update = parseUpdate(
+      'c' in frame ? decodeCompressedUpdate(frame.c) : frame.u,
+      this._coin,
+    );
+    if (!this._book) {
+      return null;
+    }
+    if (update.t < this._book.time) {
+      throw createFastL2BookError('Out-of-order L2 update');
+    }
+
+    const levels: [IBookLevel[], IBookLevel[]] = [
+      mergeSide(this._book.levels[0], update.l[0], update.r[0], 0),
+      mergeSide(this._book.levels[1], update.l[1], update.r[1], 1),
+    ];
+    assertBookInvariant(levels);
+    this._book = { coin: this._coin, time: update.t, levels } as IBook;
+    return this._book;
+  }
+}

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.test.ts
@@ -39,6 +39,90 @@ describe('calculateRequiredSubscriptions', () => {
     ]);
   });
 
+  it('prefers fast L2 for a perp book when explicitly enabled', () => {
+    const specs = calculateRequiredSubscriptions({
+      currentUser: null,
+      currentSymbol: 'BTC',
+      isConnected: true,
+      orderBookTransport: 'l2',
+      l2BookOptions: {
+        nSigFigs: 5,
+        mantissa: null,
+      },
+    });
+
+    expect(
+      specs
+        .filter((spec) => spec.type === ESubscriptionType.L2)
+        .map((spec) => spec.params),
+    ).toEqual([
+      {
+        c: 'BTC',
+        s: 5,
+      },
+    ]);
+    expect(specs.some((spec) => spec.type === ESubscriptionType.L2_BOOK)).toBe(
+      false,
+    );
+  });
+
+  it('prefers fast L2 for a spot book when explicitly enabled', () => {
+    const specs = calculateRequiredSubscriptions({
+      currentUser: null,
+      currentSymbol: '',
+      currentSpotSymbol: '@107',
+      tradingMode: 'spot',
+      isConnected: true,
+      orderBookTransport: 'l2',
+      l2BookOptions: {
+        nSigFigs: 5,
+        mantissa: null,
+      },
+    });
+
+    expect(
+      specs
+        .filter((spec) => spec.type === ESubscriptionType.L2)
+        .map((spec) => spec.params),
+    ).toEqual([
+      {
+        c: '@107',
+        s: 5,
+      },
+    ]);
+    expect(specs.some((spec) => spec.type === ESubscriptionType.L2_BOOK)).toBe(
+      false,
+    );
+  });
+
+  it('uses l2Book when the service selects the fallback transport', () => {
+    const specs = calculateRequiredSubscriptions({
+      currentUser: null,
+      currentSymbol: 'BTC',
+      isConnected: true,
+      orderBookTransport: 'l2Book',
+      l2BookOptions: {
+        nSigFigs: 5,
+        mantissa: null,
+      },
+    });
+
+    expect(specs.some((spec) => spec.type === ESubscriptionType.L2)).toBe(
+      false,
+    );
+    expect(
+      specs
+        .filter((spec) => spec.type === ESubscriptionType.L2_BOOK)
+        .map((spec) => spec.params),
+    ).toEqual([
+      {
+        coin: 'BTC',
+        nSigFigs: 5,
+        mantissa: null,
+      },
+    ]);
+  });
+
   it('subscribes openOrders to all supported perp dex response channels', () => {
     const specs = calculateRequiredSubscriptions({
       currentUser: '0x0000000000000000000000000000000000000001',

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.test.ts
@@ -1,6 +1,17 @@
 import { ESubscriptionType } from '@onekeyhq/shared/types/hyperliquid/types';
 
-import { calculateRequiredSubscriptions } from './SubscriptionConfig';
+import {
+  calculateRequiredSubscriptions,
+  isOrderBookOptionsTargetReady,
+} from './SubscriptionConfig';
+
+describe('isOrderBookOptionsTargetReady', () => {
+  it('waits for order book options to catch up with the active coin', () => {
+    expect(isOrderBookOptionsTargetReady('ETH', 'BTC')).toBe(false);
+    expect(isOrderBookOptionsTargetReady('ETH', 'ETH')).toBe(true);
+    expect(isOrderBookOptionsTargetReady('ETH', undefined)).toBe(true);
+  });
+});
 
 describe('calculateRequiredSubscriptions', () => {
   it('always subscribes to all dex asset contexts for token selector prices', () => {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
@@ -133,6 +133,13 @@ export interface ISubscriptionDiff {
   toSubscribe: ISubscriptionSpec<ESubscriptionType>[];
 }
 
+export function isOrderBookOptionsTargetReady(
+  currentCoin: string | undefined,
+  optionsCoin: string | undefined,
+) {
+  return !currentCoin || !optionsCoin || currentCoin === optionsCoin;
+}
+
 export function generateSubscriptionKey<T extends ESubscriptionType>(
   type: T,
   params: IPerpsSubscriptionParams[T],

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
@@ -3,6 +3,7 @@ import stringUtils from '@onekeyhq/shared/src/utils/stringUtils';
 import { DEX_PREFIXES } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import type {
   IEventAllDexsClearinghouseStateParameters,
+  IEventFastL2Parameters,
   IEventL2BookParameters,
   IEventOpenOrdersParameters,
   IEventTwapStatesParameters,
@@ -86,6 +87,10 @@ export const SUBSCRIPTION_TYPE_INFO: {
     eventType: EPerpsSubscriptionCategory.MARKET,
     priority: 3,
   },
+  [ESubscriptionType.L2]: {
+    eventType: EPerpsSubscriptionCategory.MARKET,
+    priority: 3,
+  },
   [ESubscriptionType.ACTIVE_ASSET_DATA]: {
     eventType: EPerpsSubscriptionCategory.ACCOUNT,
     priority: 3,
@@ -114,6 +119,7 @@ export interface ISubscriptionState {
   currentSymbol: string;
   isConnected: boolean;
   l2BookOptions?: IL2BookOptions | null;
+  orderBookTransport?: 'l2' | 'l2Book';
   enableLedgerUpdates?: boolean;
   spotEnabled?: boolean;
   spotAssetCtxsEnabled?: boolean;
@@ -157,6 +163,20 @@ function buildSubscriptionSpec<T extends ESubscriptionType>({
   };
 }
 
+function buildFastL2Params(
+  coin: string,
+  l2BookParams: IEventL2BookParameters,
+): IEventFastL2Parameters {
+  const fastL2Params: IEventFastL2Parameters = { c: coin };
+  if (l2BookParams.nSigFigs !== null) {
+    fastL2Params.s = l2BookParams.nSigFigs;
+  }
+  if (l2BookParams.mantissa !== null) {
+    fastL2Params.m = l2BookParams.mantissa;
+  }
+  return fastL2Params;
+}
+
 export function calculateRequiredSubscriptions(
   state: ISubscriptionState,
 ): ISubscriptionSpec<ESubscriptionType>[] {
@@ -198,16 +218,26 @@ export function calculateRequiredSubscriptions(
       }),
     );
     if (state.l2BookOptions) {
-      specs.push(
-        buildSubscriptionSpec({
-          type: ESubscriptionType.L2_BOOK,
-          params: {
-            coin: state.currentSpotSymbol,
-            nSigFigs: state.l2BookOptions.nSigFigs ?? null,
-            mantissa: state.l2BookOptions.mantissa ?? null,
-          },
-        }),
-      );
+      const l2BookParams: IEventL2BookParameters = {
+        coin: state.currentSpotSymbol,
+        nSigFigs: state.l2BookOptions.nSigFigs ?? null,
+        mantissa: state.l2BookOptions.mantissa ?? null,
+      };
+      if (state.orderBookTransport === 'l2') {
+        specs.push(
+          buildSubscriptionSpec({
+            type: ESubscriptionType.L2,
+            params: buildFastL2Params(state.currentSpotSymbol, l2BookParams),
+          }),
+        );
+      } else {
+        specs.push(
+          buildSubscriptionSpec({
+            type: ESubscriptionType.L2_BOOK,
+            params: l2BookParams,
+          }),
+        );
+      }
     }
   } else if (state.currentSymbol) {
     specs.push(
@@ -237,12 +267,21 @@ export function calculateRequiredSubscriptions(
         nSigFigs: state.l2BookOptions.nSigFigs ?? null,
         mantissa: state.l2BookOptions.mantissa ?? null,
       };
-      specs.push(
-        buildSubscriptionSpec({
-          type: ESubscriptionType.L2_BOOK,
-          params: l2BookParams,
-        }),
-      );
+      if (state.orderBookTransport === 'l2') {
+        specs.push(
+          buildSubscriptionSpec({
+            type: ESubscriptionType.L2,
+            params: buildFastL2Params(state.currentSymbol, l2BookParams),
+          }),
+        );
+      } else {
+        specs.push(
+          buildSubscriptionSpec({
+            type: ESubscriptionType.L2_BOOK,
+            params: l2BookParams,
+          }),
+        );
+      }
     }
   }
 

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionReconcileQueue.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionReconcileQueue.test.ts
@@ -1,0 +1,32 @@
+import { LatestSubscriptionReconcileQueue } from './SubscriptionReconcileQueue';
+
+describe('LatestSubscriptionReconcileQueue', () => {
+  it('serializes reconciles and runs only the latest pending request', async () => {
+    const queue = new LatestSubscriptionReconcileQueue();
+    const events: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = queue.enqueue(async () => {
+      events.push('first:start');
+      await firstBlocked;
+      events.push('first:end');
+    });
+    const stale = queue.enqueue(async () => {
+      events.push('stale');
+    });
+    const latest = queue.enqueue(async () => {
+      events.push('latest');
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(['first:start']);
+
+    releaseFirst?.();
+    await Promise.all([first, stale, latest]);
+
+    expect(events).toEqual(['first:start', 'first:end', 'latest']);
+  });
+});

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionReconcileQueue.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionReconcileQueue.ts
@@ -1,0 +1,34 @@
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
+export class LatestSubscriptionReconcileQueue {
+  private pendingTask: (() => Promise<void>) | null = null;
+
+  private runningPromise: Promise<void> | null = null;
+
+  enqueue(task: () => Promise<void>): Promise<void> {
+    this.pendingTask = task;
+    if (!this.runningPromise) {
+      this.runningPromise = this.drain().finally(() => {
+        this.runningPromise = null;
+      });
+    }
+    return this.runningPromise;
+  }
+
+  private async drain(): Promise<void> {
+    let firstError: Error | undefined;
+    while (this.pendingTask) {
+      const task = this.pendingTask;
+      this.pendingTask = null;
+      try {
+        await task();
+      } catch (error) {
+        firstError ??=
+          error instanceof Error ? error : new Error(String(error));
+      }
+    }
+    if (firstError) {
+      throw new OneKeyLocalError(firstError.message);
+    }
+  }
+}

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -1387,11 +1387,12 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         });
         const keys = getPerpsL2BookSnapshotCacheKeys({
           coin: data.coin,
-          nSigFigs: storedTickOptions?.nSigFigs ?? null,
+          nSigFigs: nextBook.nSigFigs ?? storedTickOptions?.nSigFigs ?? null,
           mantissa:
+            nextBook.mantissa === undefined &&
             storedTickOptions?.mantissa === undefined
               ? undefined
-              : storedTickOptions.mantissa,
+              : (nextBook.mantissa ?? storedTickOptions?.mantissa),
         });
         const updatedAt = nextBook.localReceivedAt ?? now;
         const nextColdCache = Object.fromEntries(

--- a/packages/kit/src/views/Perp/components/OrderBook/tickSizeUtils.test.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/tickSizeUtils.test.ts
@@ -2,7 +2,32 @@ import BigNumber from 'bignumber.js';
 
 import { getDisplayPriceScaleDecimals } from '@onekeyhq/shared/src/utils/perpsUtils';
 
-import { buildTickOptions } from './tickSizeUtils';
+import {
+  buildTickOptions,
+  shouldPersistOrderBookTickOption,
+} from './tickSizeUtils';
+
+describe('shouldPersistOrderBookTickOption', () => {
+  it('does not replace precision while order book data is transitioning', () => {
+    expect(
+      shouldPersistOrderBookTickOption({
+        hasMarketData: false,
+        persisted: { value: '0.2', nSigFigs: 5, mantissa: 2 },
+        selected: { value: '100', nSigFigs: 2, mantissa: null },
+      }),
+    ).toBe(false);
+  });
+
+  it('persists a changed selection derived from live market data', () => {
+    expect(
+      shouldPersistOrderBookTickOption({
+        hasMarketData: true,
+        persisted: { value: '0.1', nSigFigs: 5, mantissa: null },
+        selected: { value: '0.2', nSigFigs: 5, mantissa: 2 },
+      }),
+    ).toBe(true);
+  });
+});
 
 const fixtures = {
   BTC: {

--- a/packages/kit/src/views/Perp/components/OrderBook/tickSizeUtils.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/tickSizeUtils.ts
@@ -23,6 +23,30 @@ export interface ITickParam {
   value: string;
 }
 
+type IOrderBookTickOptionState = {
+  value: string;
+  nSigFigs?: INSig;
+  mantissa?: IMantissa | null;
+};
+
+export function shouldPersistOrderBookTickOption({
+  hasMarketData,
+  persisted,
+  selected,
+}: {
+  hasMarketData: boolean;
+  persisted: IOrderBookTickOptionState | undefined;
+  selected: IOrderBookTickOptionState;
+}) {
+  return (
+    hasMarketData &&
+    (!persisted ||
+      persisted.value !== selected.value ||
+      persisted.nSigFigs !== selected.nSigFigs ||
+      persisted.mantissa !== selected.mantissa)
+  );
+}
+
 function floorLog10(x: number): number {
   return Math.floor(Math.log10(x));
 }

--- a/packages/kit/src/views/Perp/components/OrderBook/useTickOptions.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/useTickOptions.ts
@@ -18,6 +18,7 @@ import {
   type ITickParam,
   buildTickOptions,
   getDefaultTickOption,
+  shouldPersistOrderBookTickOption,
 } from './tickSizeUtils';
 
 interface ITickOptionsResult {
@@ -165,17 +166,24 @@ export function useTickOptions({
     };
 
     if (
-      !persisted ||
-      persisted.value !== currentPersist.value ||
-      persisted.nSigFigs !== currentPersist.nSigFigs ||
-      persisted.mantissa !== currentPersist.mantissa
+      shouldPersistOrderBookTickOption({
+        hasMarketData: Boolean(tickOptionsData),
+        persisted,
+        selected: currentPersist,
+      })
     ) {
       void actions.current.setOrderBookTickOption({
         symbol,
         option: currentPersist,
       });
     }
-  }, [symbol, persistedTickOptions, selectedTickOption, actions]);
+  }, [
+    symbol,
+    persistedTickOptions,
+    selectedTickOption,
+    tickOptionsData,
+    actions,
+  ]);
 
   const handleSelectTickOption = useCallback(
     (option: ITickParam) => {

--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -41,6 +41,7 @@ import { useTradingPrice } from '../hooks/useTradingPrice';
 import {
   getFreshL2BookSnapshotFromColdCache,
   getPerpsL2BookColdCacheGlobalSnapshot,
+  isL2BookForTarget,
   isPerpsL2BookInteractive,
 } from '../utils/l2BookFreshness';
 import {
@@ -600,8 +601,13 @@ export function PerpOrderBook({
     l2SubscriptionOptions.mantissa,
     l2SubscriptionOptions.nSigFigs,
   ]);
-  const activeRenderL2Book =
-    renderL2Book?.coin === activeTradeInstrument.coin ? renderL2Book : null;
+  const activeRenderL2Book = isL2BookForTarget(
+    renderL2Book,
+    activeTradeInstrument.coin,
+    l2SubscriptionOptions,
+  )
+    ? renderL2Book
+    : null;
   const visibleL2Book = activeRenderL2Book ?? initialCachedL2Book;
   const hasRenderOrderBook = Boolean(visibleL2Book);
 
@@ -623,7 +629,7 @@ export function PerpOrderBook({
   // Do NOT reset renderL2Book/isOrderBookInteractive on coin/options change:
   // the bridge only re-reports isInteractive on a boolean flip, so a reset
   // landing after a `true` report leaves it stuck out of sync. Render-time gates
-  // (activeRenderL2Book coin filter + freshness checks) already cover staleness.
+  // (activeRenderL2Book target filter + freshness checks) already cover staleness.
 
   useEffect(() => {
     const coin = activeTradeInstrument.coin;

--- a/packages/kit/src/views/Perp/hooks/usePerpMarketData.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpMarketData.ts
@@ -22,6 +22,7 @@ import {
   getPerpsL2BookColdCacheGlobalSnapshot,
   getPerpsL2BookInteractiveRefreshDelayMs,
   hasL2BookLevels,
+  isL2BookForTarget,
   isPerpsL2BookInteractive,
 } from '../utils/l2BookFreshness';
 
@@ -75,7 +76,8 @@ export function getFreshL2BookSnapshotFromSwr({
     for (const key of keys) {
       const entry = swrCacheUtils.getWithTimestamp<HL.IBook>(key);
       if (
-        entry?.data?.coin === coin &&
+        entry &&
+        isL2BookForTarget(entry.data, coin, options) &&
         Date.now() - entry.updatedAt <= PERPS_L2_BOOK_SWR_CACHE_MAX_AGE_MS
       ) {
         return withPerpsL2BookLocalReceivedAt(entry.data, entry.updatedAt);
@@ -109,6 +111,8 @@ export function normalizeL2BookData({
     coin: bookData.coin,
     time: bookData.time,
     levels: bookData.levels,
+    nSigFigs: bookData.nSigFigs,
+    mantissa: bookData.mantissa,
     localReceivedAt: getPerpsMarketDataLocalReceivedAt(bookData),
     bids: bids || [],
     asks: asks || [],
@@ -149,7 +153,13 @@ export function useL2Book(options?: IL2BookOptions): {
 
   const l2Book = useMemo((): IL2BookData | null => {
     let bookData: HL.IBook | null | undefined;
-    if (l2BookData?.coin === expectedCoin && hasL2BookLevels(l2BookData)) {
+    if (
+      isL2BookForTarget(l2BookData, expectedCoin, {
+        nSigFigs,
+        mantissa,
+      }) &&
+      hasL2BookLevels(l2BookData)
+    ) {
       bookData = l2BookData;
     } else if (expectedCoin) {
       const cacheOptions = {

--- a/packages/kit/src/views/Perp/utils/l2BookFreshness.test.ts
+++ b/packages/kit/src/views/Perp/utils/l2BookFreshness.test.ts
@@ -6,6 +6,7 @@ import {
   getPerpsL2BookColdCacheGlobalSnapshot,
   getPerpsL2BookInteractiveRefreshDelayMs,
   hasL2BookLevels,
+  isL2BookForTarget,
   isPerpsL2BookInteractive,
 } from './l2BookFreshness';
 
@@ -63,12 +64,39 @@ describe('hasL2BookLevels', () => {
   });
 });
 
+describe('isL2BookForTarget', () => {
+  it('requires both coin and source precision to match', () => {
+    const book = {
+      ...buildBook({}),
+      nSigFigs: 5,
+      mantissa: 5,
+    };
+
+    expect(isL2BookForTarget(book, 'ETH', { nSigFigs: 5, mantissa: 5 })).toBe(
+      true,
+    );
+    expect(isL2BookForTarget(book, 'ETH', { nSigFigs: 5, mantissa: 2 })).toBe(
+      false,
+    );
+    expect(
+      isL2BookForTarget(buildBook({}), 'ETH', {
+        nSigFigs: 5,
+        mantissa: 2,
+      }),
+    ).toBe(false);
+  });
+});
+
 describe('getFreshL2BookSnapshotFromColdCache', () => {
-  it('falls back from option-specific lookup to the latest coin snapshot', () => {
-    const book = buildBook({
-      bidLevels: [{ px: '1', sz: '1', n: 1 }],
-      askLevels: [{ px: '2', sz: '1', n: 1 }],
-    });
+  it('falls back only to a latest coin snapshot with matching precision', () => {
+    const book = {
+      ...buildBook({
+        bidLevels: [{ px: '1', sz: '1', n: 1 }],
+        askLevels: [{ px: '2', sz: '1', n: 1 }],
+      }),
+      nSigFigs: 5,
+      mantissa: null,
+    };
 
     expect(
       getFreshL2BookSnapshotFromColdCache({

--- a/packages/kit/src/views/Perp/utils/l2BookFreshness.ts
+++ b/packages/kit/src/views/Perp/utils/l2BookFreshness.ts
@@ -29,6 +29,20 @@ export function hasL2BookLevels(bookData: HL.IBook | null | undefined) {
   );
 }
 
+export function isL2BookForTarget(
+  book: HL.IBook | null | undefined,
+  coin: string,
+  options?: IL2BookOptions,
+) {
+  return (
+    book?.coin === coin &&
+    book.nSigFigs !== undefined &&
+    book.mantissa !== undefined &&
+    (book.nSigFigs ?? null) === (options?.nSigFigs ?? null) &&
+    (book.mantissa ?? null) === (options?.mantissa ?? null)
+  );
+}
+
 export function getFreshL2BookSnapshotFromColdCache({
   coin,
   options,
@@ -51,7 +65,7 @@ export function getFreshL2BookSnapshotFromColdCache({
   for (const key of keys) {
     const entry = cache[key];
     if (
-      entry?.data?.coin === coin &&
+      isL2BookForTarget(entry?.data, coin, options) &&
       Date.now() - entry.updatedAt <= maxAgeMs
     ) {
       return entry.data;

--- a/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
+++ b/packages/shared/src/logger/scopes/perp/scenes/hyperliquid.ts
@@ -367,6 +367,21 @@ export class HyperLiquidScene extends BaseScene {
     return params;
   }
 
+  @LogToLocal({ level: 'info' })
+  public subscriptionFastL2Diagnostic(params: {
+    event: string;
+    sequence: number;
+    coin?: string;
+    nSigFigs?: number | null;
+    mantissa?: number | null;
+    subscriptionKey?: string | null;
+    pending?: boolean;
+    hasSnapshot?: boolean;
+    detail?: string;
+  }) {
+    return params;
+  }
+
   /**
    * Defensive log for inner SDK SubscriptionClient dispose errors.
    */

--- a/packages/shared/types/hyperliquid/sdk.ts
+++ b/packages/shared/types/hyperliquid/sdk.ts
@@ -148,7 +148,10 @@ export type IWebSocketTransport = HL.WebSocketTransport;
 // Market data types
 export type IAllMids = HL.AllMidsResponse;
 export type ICandle = HL.CandleSnapshotResponse[number];
-export type IBook = HL.L2BookWsEvent;
+export type IBook = HL.L2BookWsEvent & {
+  nSigFigs?: number | null;
+  mantissa?: number | null;
+};
 export type IBookLevel = IBook['levels'][number][number];
 export type IFill = HL.UserFillsResponse[number];
 

--- a/packages/shared/types/hyperliquid/sdk.ts
+++ b/packages/shared/types/hyperliquid/sdk.ts
@@ -177,6 +177,11 @@ export type IWsAllMidsParameters = HL.AllMidsWsParameters;
 export type IEventActiveAssetCtxParameters = HL.ActiveAssetCtxWsParameters;
 export type IEventActiveAssetDataParameters = HL.ActiveAssetDataWsParameters;
 export type IEventL2BookParameters = HL.L2BookWsParameters;
+export type IEventFastL2Parameters = {
+  c: string;
+  s?: IEventL2BookParameters['nSigFigs'];
+  m?: IEventL2BookParameters['mantissa'];
+};
 export type IEventBboParameters = HL.BboWsParameters;
 export type IEventWebData2Parameters = HL.WebData2WsParameters;
 export type IEventUserFillsParameters = HL.UserFillsWsParameters;
@@ -202,6 +207,7 @@ export type ISignature = unknown;
 
 export type IPerpsSubscriptionParams = {
   [ESubscriptionType.L2_BOOK]: IEventL2BookParameters;
+  [ESubscriptionType.L2]: IEventFastL2Parameters;
   [ESubscriptionType.BBO]: IEventBboParameters;
   [ESubscriptionType.USER_FILLS]: IEventUserFillsParameters;
   [ESubscriptionType.USER_NON_FUNDING_LEDGER_UPDATES]: IEventUserNonFundingLedgerUpdatesParameters;

--- a/packages/shared/types/hyperliquid/types.ts
+++ b/packages/shared/types/hyperliquid/types.ts
@@ -8,6 +8,7 @@ export enum EPerpsSubscriptionCategory {
 export enum ESubscriptionType {
   ALL_MIDS = 'allMids',
   L2_BOOK = 'l2Book',
+  L2 = 'l2',
   ACTIVE_ASSET_CTX = 'activeAssetCtx',
   ACTIVE_ASSET_DATA = 'activeAssetData',
   WEB_DATA2 = 'webData2',

--- a/yarn.lock
+++ b/yarn.lock
@@ -10153,6 +10153,7 @@ __metadata:
   resolution: "@onekeyhq/kit-bg@workspace:packages/kit-bg"
   dependencies:
     eth-url-parser: "npm:^1.0.4"
+    fflate: "npm:0.8.2"
     idb: "npm:^7.1.1"
     ipaddr.js: "npm:^2.3.0"
     miscreant: "npm:^0.3.2"
@@ -30858,6 +30859,13 @@ __metadata:
     node-domexception: "npm:^1.0.0"
     web-streams-polyfill: "npm:^3.0.3"
   checksum: 10/5264ecceb5fdc19eb51d1d0359921f12730941e333019e673e71eb73921146dceabcb0b8f534582be4497312d656508a439ad0f5edeec2b29ab2e10c72a1f86b
+  languageName: node
+  linkType: hard
+
+"fflate@npm:0.8.2":
+  version: 0.8.2
+  resolution: "fflate@npm:0.8.2"
+  checksum: 10/2bd26ba6d235d428de793c6a0cd1aaa96a06269ebd4e21b46c8fd1bd136abc631acf27e188d47c3936db090bf3e1ede11d15ce9eae9bffdc4bfe1b9dc66ca9cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Use Hyperliquid's fast `l2` snapshot-and-delta stream for Perp and Spot order books.
- Normalize fast L2 data back into the existing `L2_BOOK` / `IBook` contract so UI and cache consumers remain unchanged.
- Recover through target-scoped resubscription, one WebSocket reconnect, and a final `l2Book` fallback.

## Intent & Context
Hyperliquid reduced the documented `l2Book` stream frequency, making the order book visibly less responsive. The undocumented `l2` stream provides an initial 20-level snapshot followed by higher-frequency deltas. This change adopts that stream without upgrading `@nktkas/hyperliquid` or changing order submission, signing, risk, or UI contracts.

A read-only mainnet comparison sampled BTC Perp and `@107` Spot for 20 seconds. Fast L2 reconstructed prices and sizes matched all aligned `l2Book` samples across the top 20 levels, while delivering approximately 7.4x as many frames in that sample.

## Design Decisions
- Keep `@nktkas/hyperliquid@0.32.2` and model the dynamic `l2` channel locally because current and latest checked SDK versions do not expose it.
- Add `fflate@0.8.2` as a direct pure-JavaScript dependency for bounded raw-DEFLATE decoding. It has no native module or transitive dependency requirement and can ship in app bundles.
- Keep the background runtime as the only owner of WebSocket, decoder, and reconstructed book state. The main runtime continues receiving serialized `IBook` copies.
- Serialize order-book subscription mutations so a late frame or subscribe acknowledgement from the previous coin cannot mutate the newly selected market.
- Prefer Fast L2 recovery over immediate degradation: retry the target subscription, reconnect once, then fall back only for the current target. A new target or connection retries Fast L2.
- Preserve the existing UI-side 50 ms leading/trailing throttle by emitting reconstructed books as `L2_BOOK` events.

## Changes Detail
- Add shared Fast L2 subscription parameter types and channel registration.
- Add a bounded decoder and book reconstructor for snapshot, plain JSON delta, and base64/raw-DEFLATE delta frames.
- Add lifecycle cleanup, snapshot timeout, stale-target rejection, target-scoped recovery, and emergency `l2BookOnly` strategy support.
- Add Perp/Spot subscription planning and decoder regression tests.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: The fast `l2` protocol is not documented by Hyperliquid; compressed input decoding and stateful delta reconstruction run in the background runtime. Repeated recovery failure can reconnect the shared Hyperliquid WebSocket, briefly rebuilding non-order-book subscriptions as well.
- **Bundle Compatibility**: No native files or native packages change. `fflate` is bundled JavaScript. Native main and background runtimes remain version-locked and initialize independently.

## Test plan
- [x] Fast L2 snapshot, plain delta, compressed delta, stale target, and invalid removal tests
- [x] Perp and Spot subscription planning tests
- [x] `yarn agent:check --profile commit`
- [x] Read-only mainnet Fast L2 versus `l2Book` top-20 price/size comparison
- [ ] Build app bundles through GitHub Actions
- [ ] Verify rapid Perp-to-Perp and Spot-to-Spot switching
- [ ] Verify Perp/Spot mode switching
- [ ] Verify foreground/background and offline/reconnect recovery on iOS and Android
- [ ] Smoke test Web, Desktop, and Extension order books
