### PR TITLE
refactor: tabular figures only on dense numeric data; proportional by default (OK-57876)

### DIFF
--- a/packages/components/src/content/Badge/index.tsx
+++ b/packages/components/src/content/Badge/index.tsx
@@ -11,7 +11,7 @@ import type { GetProps } from '@onekeyhq/components/src/shared/tamagui';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { XStack } from '../../primitives/Stack';
-import { TABULAR_NUMS, getFontVariantStyle } from '../../utils/tabularNums';
+import { getFontVariantStyle } from '../../utils/tabularNums';
 
 import type { IXStackProps } from '../../primitives';
 
@@ -98,19 +98,21 @@ const BadgeTextStyled = styled(SizableText, {
   } as const,
 });
 
-// Badge.Text is styled from raw tamagui text, so it bypasses the SizableText
-// wrapper's app-wide tabular default. Re-apply it here (computed once) so badge
-// digits (countdowns, rates, counts) stay equal-width on native. On web the
-// web-fonts.css body rule already covers it, so getFontVariantStyle returns
-// undefined and this is a passthrough.
-const BADGE_TABULAR_STYLE = getFontVariantStyle(TABULAR_NUMS);
-
-function BadgeText({ style, ...props }: GetProps<typeof BadgeTextStyled>) {
+// Badge.Text is styled from raw tamagui text, which silently drops the RN
+// `fontVariant` prop. Translate it into a real style so a badge holding dense
+// numeric data (a ticking countdown, a rate) can opt in with
+// `fontVariant={TABULAR_NUMS}`. Badges are proportional by default like all
+// other text — most of them hold names or labels.
+function BadgeText({
+  style,
+  fontVariant,
+  ...props
+}: GetProps<typeof BadgeTextStyled>) {
   // Merge (not overwrite) so a caller-provided `style` still wins.
-  const mergedStyle = useMemo(
-    () => (BADGE_TABULAR_STYLE ? [BADGE_TABULAR_STYLE, style] : style),
-    [style],
-  );
+  const mergedStyle = useMemo(() => {
+    const variantStyle = getFontVariantStyle(fontVariant);
+    return variantStyle ? [variantStyle, style] : style;
+  }, [fontVariant, style]);
   return <BadgeTextStyled {...props} style={mergedStyle} />;
 }
 

--- a/packages/components/src/content/NumberSizeableText/index.tsx
+++ b/packages/components/src/content/NumberSizeableText/index.tsx
@@ -146,9 +146,9 @@ export function NumberSizeableText({
       {result.map((r, index) =>
         typeof r === 'string' ? (
           // These slices build fresh SizableTexts (not spreading `props`), so
-          // they'd otherwise fall back to the app-wide tabular default and
-          // ignore a caller override (e.g. PROPORTIONAL_NUMS on a hero
-          // balance) — forward `fontVariant` explicitly to every slice.
+          // a caller's `fontVariant={TABULAR_NUMS}` would not reach them —
+          // forward it explicitly, or a split number in a table column would
+          // have only its decimal part tabular.
           <SizableText
             key={index}
             color={props.color}

--- a/packages/components/src/hocs/Provider/web-fonts.css
+++ b/packages/components/src/hocs/Provider/web-fonts.css
@@ -45,9 +45,3 @@
   font-style: normal;
   font-display: swap;
 }
-
-/* App-wide tabular (equal-width) figures — see utils/tabularNums.ts. Inherited
-   by every text node, covering text that bypasses the SizableText wrapper. */
-body {
-  font-variant-numeric: tabular-nums;
-}

--- a/packages/components/src/primitives/SizeableText/index.tsx
+++ b/packages/components/src/primitives/SizeableText/index.tsx
@@ -2,17 +2,16 @@ import { SizableText as TamaguiSizableText } from '@tamagui/text';
 
 import { type SizableTextProps } from '@onekeyhq/components/src/shared/tamagui';
 
-import { TABULAR_NUMS, getFontVariantStyle } from '../../utils/tabularNums';
+import { getFontVariantStyle } from '../../utils/tabularNums';
 
 export const StyledSizableText = TamaguiSizableText;
 
 export function SizableText({
   size = '$bodyMd',
-  // App-wide default: tabular (equal-width) figures on ALL text, matching the
-  // reference exchanges whose brand fonts ship tabular digits by default.
-  // Only digit glyph widths change — letters are unaffected — so prose is
-  // safe. Opt out per text with `fontVariant={PROPORTIONAL_NUMS}`.
-  fontVariant = TABULAR_NUMS,
+  // No default: text is proportional (the font's natural figures), which is
+  // right for names, addresses, prose and hero numbers. Dense numeric data
+  // opts IN with `fontVariant={TABULAR_NUMS}` — see utils/tabularNums.ts.
+  fontVariant,
   style,
   ...props
 }: SizableTextProps) {

--- a/packages/components/src/utils/tabularNums.ts
+++ b/packages/components/src/utils/tabularNums.ts
@@ -5,32 +5,25 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { TextStyle } from 'react-native';
 
 /**
- * Tabular (equal-width) figures for numeric text.
+ * Tabular (equal-width) figures — OPT-IN, for dense numeric data only.
  *
- * `SizableText` applies this by DEFAULT app-wide, and web mirrors it with an
- * injected `body { font-variant-numeric: tabular-nums }` rule, so most text
- * needs nothing. Reach for the constant directly only for text that bypasses
- * the `SizableText` wrapper — raw React Native `<Text>` / `StyleSheet.create`,
- * or `Badge.Text` — via `getFontVariantStyle(TABULAR_NUMS)`.
+ * Apply as `fontVariant={TABULAR_NUMS}` (or a `fontVariant` StyleSheet entry on
+ * raw React Native `<Text>`) to numbers that are **small, sit in a column, and
+ * tick**: market/perps list columns, order books, trading tables, ticker strips.
+ * Every digit then shares one advance width, so columns stay aligned and a value
+ * doesn't reflow as it updates.
  *
- * Every digit shares one advance width, so number columns stay aligned and a
- * value doesn't reflow as it ticks. Unlike a monospace family (`$monoRegular`),
- * only digits are equalized — letters keep Roobert's natural proportional
- * widths. Roobert ships the `tnum` OpenType feature, so this works on iOS,
- * Android and web.
- *
- * Monospace is still the right choice for addresses / hashes / mnemonics /
- * codes, where character (not just digit) alignment matters — do NOT replace
- * those with tabular-nums.
+ * Do NOT apply it to anything a human reads as words. Text is proportional by
+ * default and that is almost always right:
+ *  - names & identifiers (account "A1787", wallet "OneKey Pro2-1-6")
+ *  - addresses / hashes (mixed hex — tabular equalizes only the digits, leaving
+ *    the letters proportional, which reads worse than either)
+ *  - prose and marketing copy
+ *  - large hero numbers (a single big number has no column to align with, and
+ *    Roobert's tabular `1` is nearly 2x wider and grows a foot serif)
+ *  - amount input fields
  */
 export const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
-
-/**
- * Escape hatch from the app-wide tabular default (`SizableText` defaults
- * `fontVariant` to TABULAR_NUMS): pass `fontVariant={PROPORTIONAL_NUMS}` to
- * restore the font's natural proportional figures for a specific text.
- */
-export const PROPORTIONAL_NUMS: ['proportional-nums'] = ['proportional-nums'];
 
 type IFontVariantStyle = CSSProperties | TextStyle;
 
@@ -51,13 +44,10 @@ function buildFontVariantStyle(
   return Object.freeze(style);
 }
 
-// Web applies tabular figures globally via the `body` rule in web-fonts.css,
-// so the DEFAULT variant needs no inline style — leaving it undefined avoids a
-// redundant style attr on every text node and keeps `style` reference-stable.
-// Native has no CSS inheritance, so it must carry the variant inline.
-const TABULAR_NUMS_STYLE: IFontVariantStyle | undefined = platformEnv.isNative
-  ? buildFontVariantStyle(TABULAR_NUMS)
-  : undefined;
+// Hoisted so the common opt-in path allocates nothing and stays
+// reference-stable. Both platforms carry it inline: there is no global rule to
+// inherit from any more.
+const TABULAR_NUMS_STYLE = buildFontVariantStyle(TABULAR_NUMS);
 
 const fontVariantStyleCache = new WeakMap<
   NonNullable<TextStyle['fontVariant']>,

--- a/packages/kit/src/components/DeFi/DeFiPositionHealthFactorRow.tsx
+++ b/packages/kit/src/components/DeFi/DeFiPositionHealthFactorRow.tsx
@@ -1,10 +1,14 @@
 import { useIntl } from 'react-intl';
 
-import { Popover, SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  Popover,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import type { ColorTokens } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
 
 type IHealthFactorRisk = 'critical' | 'warning' | 'success';
 

--- a/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionActionDialog.tsx
@@ -14,6 +14,7 @@ import {
   ScrollView,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useIsKeyboardShown,
@@ -1302,7 +1303,7 @@ function ProtocolPositionActionPercentHero({
           color="$textSubdued"
           textAlign="center"
           numberOfLines={1}
-          fontVariant={['tabular-nums']}
+          fontVariant={TABULAR_NUMS}
         />
       </XStack>
     </YStack>

--- a/packages/kit/src/components/DeFi/ProtocolPositionSection.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolPositionSection.tsx
@@ -2,7 +2,12 @@ import { memo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import type { ITokenProps } from '@onekeyhq/kit/src/components/Token';
@@ -73,6 +78,7 @@ const ProtocolPositionSection = memo(
               color="$textSubdued"
               formatter="balance"
               textAlign="right"
+              fontVariant={TABULAR_NUMS}
             >
               {asset.amount}
             </NumberSizeableTextWrapper>

--- a/packages/kit/src/components/DeFi/ProtocolValueCell.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolValueCell.tsx
@@ -6,6 +6,7 @@ import {
   DashText,
   type INumberSizeableTextProps,
   SizableText,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
 } from '@onekeyhq/components';
@@ -44,7 +45,9 @@ const ProtocolValueCell = memo(
     color,
     textAlign,
     numberOfLines,
-    fontVariant,
+    // A value cell is by definition dense column data, so it opts into tabular
+    // figures by default; callers can still override.
+    fontVariant = TABULAR_NUMS,
   }: IProtocolValueCellProps) => {
     const [{ hideValue }] = useSettingsValuePersistAtom();
     const valueBN = new BigNumber(value);

--- a/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelMain.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelMain.tsx
@@ -11,6 +11,7 @@ import {
   NumberSizeableText,
   SizableText,
   Spinner,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useClipboard,
@@ -189,6 +190,7 @@ function PerpsSection({
       <NumberSizeableText
         size="$bodyMdMedium"
         color="$text"
+        fontVariant={TABULAR_NUMS}
         formatter="value"
         formatterOptions={{ currency: '$' }}
       >

--- a/packages/kit/src/components/TokenListItem/index.tsx
+++ b/packages/kit/src/components/TokenListItem/index.tsx
@@ -4,6 +4,7 @@ import {
   PulseContainer,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -140,6 +141,7 @@ export function TokenListItem({
               color="$text"
               formatter="balance"
               size="$bodyLgMedium"
+              fontVariant={TABULAR_NUMS}
             >
               {balance}
             </NumberSizeableText>
@@ -154,6 +156,7 @@ export function TokenListItem({
                 formatter="value"
                 color="$textSubdued"
                 formatterOptions={{ currency: valueProps?.currency ?? '$' }}
+                fontVariant={TABULAR_NUMS}
               >
                 {valueProps.value}
               </NumberSizeableText>

--- a/packages/kit/src/components/TokenListView/TokenBalanceView.tsx
+++ b/packages/kit/src/components/TokenListView/TokenBalanceView.tsx
@@ -1,6 +1,10 @@
 import { memo } from 'react';
 
-import { type ISizableTextProps, SizableText } from '@onekeyhq/components';
+import {
+  type ISizableTextProps,
+  SizableText,
+  TABULAR_NUMS,
+} from '@onekeyhq/components';
 import { displayOrUnavailable } from '@onekeyhq/shared/src/utils/tokenValueUtils';
 
 import NumberSizeableTextWrapper from '../NumberSizeableTextWrapper';
@@ -23,13 +27,18 @@ function TokenBalanceView(props: IProps) {
   const balanceParsed = useTokenBalanceParsed($key || '');
 
   if (balanceParsed === undefined) {
-    return <SizableText {...rest}>-</SizableText>;
+    return (
+      <SizableText fontVariant={TABULAR_NUMS} {...rest}>
+        -
+      </SizableText>
+    );
   }
 
   return (
     <NumberSizeableTextWrapper
       formatter="balance"
       formatterOptions={{ tokenSymbol: symbol }}
+      fontVariant={TABULAR_NUMS}
       {...rest}
     >
       {displayOrUnavailable(balanceParsed)}

--- a/packages/kit/src/components/TokenListView/TokenPriceChangeView.tsx
+++ b/packages/kit/src/components/TokenListView/TokenPriceChangeView.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 
 import type { ISizableTextProps } from '@onekeyhq/components';
-import { NumberSizeableText } from '@onekeyhq/components';
+import { NumberSizeableText, TABULAR_NUMS } from '@onekeyhq/components';
 import { getTokenPriceChangeStyle } from '@onekeyhq/shared/src/utils/tokenUtils';
 import {
   UNAVAILABLE_DISPLAY,
@@ -24,6 +24,7 @@ function TokenPriceChangeView(props: IProps) {
       <NumberSizeableText
         formatter="priceChange"
         color="$textSubdued"
+        fontVariant={TABULAR_NUMS}
         {...rest}
       >
         {UNAVAILABLE_DISPLAY}
@@ -40,6 +41,7 @@ function TokenPriceChangeView(props: IProps) {
       formatter="priceChange"
       formatterOptions={{ showPlusMinusSigns }}
       color={changeColor}
+      fontVariant={TABULAR_NUMS}
       {...rest}
     >
       {price24h}

--- a/packages/kit/src/components/TokenListView/TokenPriceView.tsx
+++ b/packages/kit/src/components/TokenListView/TokenPriceView.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 
 import type { ISizableTextProps } from '@onekeyhq/components';
+import { TABULAR_NUMS } from '@onekeyhq/components';
 import { displayOrUnavailable } from '@onekeyhq/shared/src/utils/tokenValueUtils';
 
 import { Currency } from '../Currency';
@@ -20,6 +21,7 @@ function TokenPriceView(props: IProps) {
     <Currency
       formatter="price"
       sourceCurrency={currency}
+      fontVariant={TABULAR_NUMS}
       {...(rest as React.ComponentProps<typeof Currency>)}
     >
       {displayOrUnavailable(price)}

--- a/packages/kit/src/components/TokenListView/TokenValueView.tsx
+++ b/packages/kit/src/components/TokenListView/TokenValueView.tsx
@@ -1,6 +1,10 @@
 import { memo } from 'react';
 
-import { type ISizableTextProps, SizableText } from '@onekeyhq/components';
+import {
+  type ISizableTextProps,
+  SizableText,
+  TABULAR_NUMS,
+} from '@onekeyhq/components';
 import { displayFiatValueOrUnavailable } from '@onekeyhq/shared/src/utils/tokenValueUtils';
 
 import { Currency } from '../Currency';
@@ -20,13 +24,18 @@ function TokenValueView(props: IProps) {
   const { has, fiatValue, balanceParsed, currency } = useTokenValueSlice($key);
 
   if (!has) {
-    return <SizableText {...rest}>-</SizableText>;
+    return (
+      <SizableText fontVariant={TABULAR_NUMS} {...rest}>
+        -
+      </SizableText>
+    );
   }
 
   return (
     <Currency
       formatter="value"
       sourceCurrency={currency}
+      fontVariant={TABULAR_NUMS}
       {...(rest as React.ComponentProps<typeof Currency>)}
     >
       {displayFiatValueOrUnavailable(fiatValue, balanceParsed)}

--- a/packages/kit/src/components/TxAction/TxActionCommon.tsx
+++ b/packages/kit/src/components/TxAction/TxActionCommon.tsx
@@ -10,6 +10,7 @@ import {
   NumberSizeableText,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
 } from '@onekeyhq/components';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
@@ -335,6 +336,7 @@ function TxActionCommonChange({
       minWidth={0}
       numberOfLines={1}
       size="$bodyLgMedium"
+      fontVariant={TABULAR_NUMS}
       {...(!tableLayout && {
         textAlign: 'right',
       })}
@@ -360,6 +362,7 @@ function TxActionCommonChangeDescription({
       color="$textSubdued"
       numberOfLines={1}
       minWidth={0}
+      fontVariant={TABULAR_NUMS}
       {...(!tableLayout && {
         textAlign: 'right',
       })}
@@ -403,6 +406,7 @@ function TxActionCommonFee({
           numberOfLines={1}
           flexShrink={1}
           minWidth={0}
+          fontVariant={TABULAR_NUMS}
         >
           {fee}
         </NumberSizeableText>
@@ -414,6 +418,7 @@ function TxActionCommonFee({
           numberOfLines={1}
           flexShrink={1}
           minWidth={0}
+          fontVariant={TABULAR_NUMS}
         >
           {feeFiatValue}
         </NumberSizeableText>

--- a/packages/kit/src/components/TxAction/TxActionTokenApprove.tsx
+++ b/packages/kit/src/components/TxAction/TxActionTokenApprove.tsx
@@ -3,7 +3,12 @@ import { useEffect, useMemo, useRef } from 'react';
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
-import { Button, SizableText, XStack } from '@onekeyhq/components';
+import {
+  Button,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+} from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { EApproveType } from '@onekeyhq/shared/types/tx';
@@ -169,6 +174,7 @@ function TxActionTokenApproveListView(props: ITxActionProps) {
             }}
             size="$bodyMd"
             numberOfLines={1}
+            fontVariant={TABULAR_NUMS}
           >
             {approveAmount}
           </NumberSizeableTextWrapper>
@@ -211,6 +217,7 @@ function TxActionTokenApproveListView(props: ITxActionProps) {
             size="$bodyMd"
             color="$textSubdued"
             numberOfLines={1}
+            fontVariant={TABULAR_NUMS}
           >
             {approveAmount}
           </NumberSizeableTextWrapper>
@@ -227,6 +234,7 @@ function TxActionTokenApproveListView(props: ITxActionProps) {
           size="$bodyMd"
           color="$textSubdued"
           numberOfLines={1}
+          fontVariant={TABULAR_NUMS}
         >
           {approveAmount}
         </NumberSizeableTextWrapper>

--- a/packages/kit/src/components/TxAction/TxActionTransfer.tsx
+++ b/packages/kit/src/components/TxAction/TxActionTransfer.tsx
@@ -10,6 +10,7 @@ import {
   Icon,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -456,6 +457,7 @@ function buildExpandedTransferView({
           numberOfLines={1}
           size="$bodyMd"
           color={color}
+          fontVariant={TABULAR_NUMS}
         >
           {`${prefix === 'r' ? '+' : '-'}${transfer.amount}`}
         </NumberSizeableTextWrapper>
@@ -467,6 +469,7 @@ function buildExpandedTransferView({
             size="$bodyMd"
             color="$textSubdued"
             numberOfLines={1}
+            fontVariant={TABULAR_NUMS}
           >
             {fiatValue}
           </NumberSizeableTextWrapper>
@@ -795,6 +798,7 @@ function TxActionTransferListView(props: ITxActionProps) {
         }}
         numberOfLines={1}
         size="$bodyLgMedium"
+        fontVariant={TABULAR_NUMS}
         {...(isStackedLayout && {
           minWidth: 0,
           maxWidth: '100%',
@@ -829,6 +833,7 @@ function TxActionTransferListView(props: ITxActionProps) {
         color="$textSubdued"
         numberOfLines={1}
         maxWidth={isStackedLayout ? '100%' : '$40'}
+        fontVariant={TABULAR_NUMS}
         {...(isStackedLayout && {
           minWidth: 0,
           textAlign: 'right',

--- a/packages/kit/src/views/ApprovalManagement/components/ApprovedTokenItem.tsx
+++ b/packages/kit/src/views/ApprovalManagement/components/ApprovedTokenItem.tsx
@@ -8,6 +8,7 @@ import {
   Icon,
   NumberSizeableText,
   Stack,
+  TABULAR_NUMS,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import approvalUtils from '@onekeyhq/shared/src/utils/approvalUtils';
@@ -132,6 +133,7 @@ function ApprovedTokenItem(props: IProps) {
               numberOfLines={1}
               textAlign="right"
               size="$bodyLgMedium"
+              fontVariant={TABULAR_NUMS}
               autoFormatter="balance-marketCap"
             >
               {approval.allowanceParsed}

--- a/packages/kit/src/views/ApprovalManagement/components/BulkRevokeItem.tsx
+++ b/packages/kit/src/views/ApprovalManagement/components/BulkRevokeItem.tsx
@@ -13,6 +13,7 @@ import {
   SizableText,
   Spinner,
   Stack,
+  TABULAR_NUMS,
   View,
   XStack,
   YStack,
@@ -176,6 +177,7 @@ function BulkRevokeItem(props: IProps) {
               formatterOptions={{
                 tokenSymbol: status.feeSymbol,
               }}
+              fontVariant={TABULAR_NUMS}
               numberOfLines={1}
             >
               {status.feeBalance ?? '-'}
@@ -188,6 +190,7 @@ function BulkRevokeItem(props: IProps) {
                 formatterOptions={{
                   currency: settings.currencyInfo.symbol,
                 }}
+                fontVariant={TABULAR_NUMS}
                 numberOfLines={1}
               >
                 {status.feeFiat ?? '-'}

--- a/packages/kit/src/views/ApprovalManagement/pages/BulkRevoke.tsx
+++ b/packages/kit/src/views/ApprovalManagement/pages/BulkRevoke.tsx
@@ -15,6 +15,7 @@ import {
   Page,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   getCurrentVisibilityState,
@@ -757,6 +758,7 @@ function BulkRevoke() {
                   formatterOptions={{
                     currency: settings.currencyInfo.symbol,
                   }}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {totalFeeFiat ?? '-'}
                 </NumberSizeableText>

--- a/packages/kit/src/views/AssetDetails/pages/HistoryDetails/HistoryDetails.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/HistoryDetails/HistoryDetails.tsx
@@ -14,6 +14,7 @@ import {
   SizableText,
   Spinner,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -227,6 +228,7 @@ export function AssetItem({
           textAlign="right"
           size="$bodyLgMedium"
           color="$textSuccess"
+          fontVariant={TABULAR_NUMS}
           formatter="value"
         >
           {isApproveUnlimited
@@ -264,6 +266,7 @@ export function AssetItem({
         textAlign="right"
         size="$bodyLgMedium"
         color={direction === EDecodedTxDirection.IN ? '$textSuccess' : '$text'}
+        fontVariant={TABULAR_NUMS}
         formatter="balance"
         formatterOptions={{
           tokenSymbol: asset.isNFT ? '' : asset.symbol,
@@ -279,6 +282,7 @@ export function AssetItem({
         textAlign="right"
         size="$bodyMd"
         color="$textSubdued"
+        fontVariant={TABULAR_NUMS}
         formatter="value"
         formatterOptions={{ currency: currencySymbol }}
       >
@@ -1290,6 +1294,7 @@ function HistoryDetails() {
           formatter="balance"
           size="$bodyMd"
           color="$textSubdued"
+          fontVariant={TABULAR_NUMS}
           formatterOptions={{
             tokenSymbol: nativeToken?.symbol,
           }}
@@ -1304,6 +1309,7 @@ function HistoryDetails() {
               formatterOptions={{ currency: settings.currencyInfo.symbol }}
               size="$bodyMd"
               color="$textSubdued"
+              fontVariant={TABULAR_NUMS}
             >
               {txInfo?.gasFeeFiatValue ?? '0'}
             </NumberSizeableTextWrapper>

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
@@ -9,7 +9,6 @@ import {
   DebugRenderTracker,
   Divider,
   Icon,
-  PROPORTIONAL_NUMS,
   SizableText,
   Skeleton,
   Stack,
@@ -543,10 +542,6 @@ function TokenDetailsHeaderContent({
                   fontSize={48}
                   lineHeight={48}
                   fontWeight={500}
-                  // Large hero value uses natural proportional figures (matches
-                  // the home total-balance hero); tabular is reserved for
-                  // tables / ticking data.
-                  fontVariant={PROPORTIONAL_NUMS}
                 >
                   {displayFiatValueOrUnavailable(
                     tokenDetails?.fiatValue,

--- a/packages/kit/src/views/AssetDetails/pages/UTXODetails.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/UTXODetails.tsx
@@ -11,6 +11,7 @@ import {
   SizableText,
   Spinner,
   Stack,
+  TABULAR_NUMS,
   YStack,
 } from '@onekeyhq/components';
 import type { IDBUtxoAccount } from '@onekeyhq/kit-bg/src/dbs/local/types';
@@ -164,6 +165,7 @@ function UTXODetails() {
                 size: '$bodySm',
               }}
               mt="$1.5"
+              fontVariant={TABULAR_NUMS}
             >
               {`${utxo.balance} ${network?.symbol ?? ''}`}
             </SizableText>

--- a/packages/kit/src/views/Borrow/components/BorrowTableList/AmountField.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowTableList/AmountField.tsx
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js';
 
+import { TABULAR_NUMS } from '@onekeyhq/components';
 import type { IEarnText } from '@onekeyhq/shared/types/staking';
 
 import { EarnText } from '../../../Staking/components/ProtocolDetails/EarnText';
@@ -16,9 +17,19 @@ export const AmountField = ({ title, description }: IAmountFieldProps) => {
 
   return (
     <FieldWrapper ai="flex-end">
-      <EarnText text={title} size="$bodyMdMedium" color="$text" />
+      <EarnText
+        text={title}
+        size="$bodyMdMedium"
+        color="$text"
+        fontVariant={TABULAR_NUMS}
+      />
       {!isZero ? (
-        <EarnText text={description} size="$bodySm" color="$textSubdued" />
+        <EarnText
+          text={description}
+          size="$bodySm"
+          color="$textSubdued"
+          fontVariant={TABULAR_NUMS}
+        />
       ) : null}
     </FieldWrapper>
   );

--- a/packages/kit/src/views/Borrow/components/BorrowTableList/ApyTextV2.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowTableList/ApyTextV2.tsx
@@ -12,6 +12,7 @@ import {
   ScrollView,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
   YStack,
@@ -338,6 +339,7 @@ function TextWithDottedUnderline({
         textAlign="right"
         dashColor={textColor}
         dashThickness={1}
+        fontVariant={TABULAR_NUMS}
       >
         {text}
       </DashText>
@@ -361,7 +363,12 @@ function TextWithTrigger({
   if (triggerMode === 'icon') {
     return (
       <XStack alignItems="center" gap="$1">
-        <SizableText size={size} textAlign="right" color={color || '$text'}>
+        <SizableText
+          size={size}
+          textAlign="right"
+          color={color || '$text'}
+          fontVariant={TABULAR_NUMS}
+        >
           {text}
         </SizableText>
         {showChevron ? (
@@ -481,6 +488,7 @@ export const ApyTextV2 = ({
         textAlign="right"
         color={deprecated.color || '$textSubdued'}
         textDecorationLine="line-through"
+        fontVariant={TABULAR_NUMS}
       >
         {deprecated.text}
       </SizableText>
@@ -535,7 +543,12 @@ export const ApyTextV2 = ({
 
   return (
     <YStack ai="flex-end">
-      <SizableText size="$bodyMdMedium" textAlign="right" color={displayColor}>
+      <SizableText
+        size="$bodyMdMedium"
+        textAlign="right"
+        color={displayColor}
+        fontVariant={TABULAR_NUMS}
+      >
         {displayText}
       </SizableText>
     </YStack>

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/TableLayout.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/components/TableLayout.tsx
@@ -14,6 +14,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -1058,6 +1059,7 @@ function TransferInfoListSection() {
                             ? '$textCritical'
                             : '$textSubdued'
                         }
+                        fontVariant={TABULAR_NUMS}
                         formatter="balance"
                         formatterOptions={{
                           tokenSymbol: tokenInfo?.symbol,
@@ -1147,6 +1149,7 @@ function TransferInfoListSection() {
                     textAlign="right"
                     numberOfLines={1}
                     ellipsizeMode="tail"
+                    fontVariant={TABULAR_NUMS}
                     formatter="balance"
                   >
                     {displayAmount || '-'}

--- a/packages/kit/src/views/BulkSend/pages/BulkSendProcess/BulkSendProcessItem.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendProcess/BulkSendProcessItem.tsx
@@ -13,6 +13,7 @@ import {
   SizableText,
   Spinner,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useClipboard,
@@ -271,6 +272,7 @@ function BulkSendProcessItem(props: IProps) {
             size="$bodyMdMedium"
             formatter="balance"
             formatterOptions={{ tokenSymbol: tokenInfo.symbol }}
+            fontVariant={TABULAR_NUMS}
             numberOfLines={1}
           >
             {transferInfo.amount || '0'}
@@ -284,6 +286,7 @@ function BulkSendProcessItem(props: IProps) {
                 formatterOptions={{
                   currency: settings.currencyInfo.symbol,
                 }}
+                fontVariant={TABULAR_NUMS}
                 numberOfLines={1}
               >
                 {fiatAmount}

--- a/packages/kit/src/views/BulkSend/pages/BulkSendReview/components/BulkSendReviewCostCard.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendReview/components/BulkSendReviewCostCard.tsx
@@ -8,6 +8,7 @@ import {
   NumberSizeableText,
   SizableText,
   Skeleton,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -116,6 +117,7 @@ function BulkSendReviewCostCard({
                             formatterOptions={{
                               tokenSymbol: nativeSymbol,
                             }}
+                            fontVariant={TABULAR_NUMS}
                           >
                             {singleTxFeeNative ?? '0'}
                           </NumberSizeableText>
@@ -131,6 +133,7 @@ function BulkSendReviewCostCard({
                           size="$bodyMdMedium"
                           formatter="balance"
                           formatterOptions={{ tokenSymbol: nativeSymbol }}
+                          fontVariant={TABULAR_NUMS}
                         >
                           {networkFee}
                         </NumberSizeableText>
@@ -144,6 +147,7 @@ function BulkSendReviewCostCard({
                             currency: settings.currencyInfo.symbol,
                             showPlusMinusSigns: false,
                           }}
+                          fontVariant={TABULAR_NUMS}
                         >
                           {networkFeeFiat}
                         </NumberSizeableText>
@@ -238,6 +242,7 @@ function BulkSendReviewCostCard({
                   size="$bodyMdMedium"
                   formatter="balance"
                   formatterOptions={{ tokenSymbol: nativeSymbol }}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {ataRentFeeNative}
                 </NumberSizeableText>

--- a/packages/kit/src/views/Earn/components/AprText.tsx
+++ b/packages/kit/src/views/Earn/components/AprText.tsx
@@ -1,6 +1,12 @@
 import type { ComponentProps } from 'react';
 
-import { Icon, SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  Icon,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
 
 import {
@@ -49,6 +55,7 @@ export function AprText({
           aprInfo?.normal?.color ||
           '$text'
         }
+        fontVariant={TABULAR_NUMS}
       >
         {formatRewardText({
           text: aprRangeText,
@@ -76,6 +83,7 @@ export function AprText({
             size={size}
             textAlign="right"
             color={highlight.color || '$textSuccess'}
+            fontVariant={TABULAR_NUMS}
           >
             {formatRewardText({
               text: highlight.text,
@@ -89,6 +97,7 @@ export function AprText({
           textAlign="right"
           color={deprecated.color || '$textSubdued'}
           textDecorationLine="line-through"
+          fontVariant={TABULAR_NUMS}
         >
           {formatRewardText({
             text: deprecated.text,
@@ -116,6 +125,7 @@ export function AprText({
           size={size}
           textAlign="right"
           color={highlight.color || '$textSuccess'}
+          fontVariant={TABULAR_NUMS}
         >
           {formatRewardText({
             text: highlight.text,
@@ -135,6 +145,7 @@ export function AprText({
         size={size}
         textAlign="right"
         color={normal.color || '$text'}
+        fontVariant={TABULAR_NUMS}
       >
         {formatRewardText({
           text: normal.text,
@@ -154,6 +165,7 @@ export function AprText({
         textAlign="right"
         color={deprecated.color || '$textSubdued'}
         textDecorationLine="line-through"
+        fontVariant={TABULAR_NUMS}
       >
         {formatRewardText({
           text: deprecated.text,
@@ -166,7 +178,7 @@ export function AprText({
 
   // Priority 4: fallback to current logic
   return (
-    <SizableText size={size} textAlign="right">
+    <SizableText size={size} textAlign="right" fontVariant={TABULAR_NUMS}>
       {hideSuffix ? aprWithoutFee : buildAprText(aprWithoutFee, rewardUnit)}
     </SizableText>
   );

--- a/packages/kit/src/views/Earn/components/AvailableAssetsTabViewList.tsx
+++ b/packages/kit/src/views/Earn/components/AvailableAssetsTabViewList.tsx
@@ -10,6 +10,7 @@ import {
   IconButton,
   SearchBar,
   SizableText,
+  TABULAR_NUMS,
   Tabs,
   XStack,
   YStack,
@@ -324,7 +325,7 @@ export function AvailableAssetsTabViewList({
           parseFormattedLiquidityValue(a.liquidity) -
           parseFormattedLiquidityValue(b.liquidity),
         render: (asset) => (
-          <SizableText size="$bodyLgMedium">
+          <SizableText size="$bodyLgMedium" fontVariant={TABULAR_NUMS}>
             {asset.liquidity || '-'}
           </SizableText>
         ),

--- a/packages/kit/src/views/Earn/components/PortfolioTabContent.tsx
+++ b/packages/kit/src/views/Earn/components/PortfolioTabContent.tsx
@@ -18,6 +18,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useMedia,
@@ -338,11 +339,16 @@ const DepositField = ({
       />
       <FieldWrapper ml="$3" mr="$2" flex={1} asset={asset}>
         <XStack gap="$1" maxWidth={200} flexWrap="wrap">
-          <EarnText size="$bodyMdMedium" text={asset.deposit?.title} />
+          <EarnText
+            size="$bodyMdMedium"
+            text={asset.deposit?.title}
+            fontVariant={TABULAR_NUMS}
+          />
           <EarnText
             size="$bodySm"
             color="$textSubdued"
             text={asset.deposit?.description}
+            fontVariant={TABULAR_NUMS}
           />
         </XStack>
         {asset.metadata.protocol.vaultName ? (
@@ -373,11 +379,13 @@ const EarningsField = ({
             size="$bodySm"
             color="$textSubdued"
             text={asset.totalReward.title}
+            fontVariant={TABULAR_NUMS}
           />
           <EarnText
             size="$bodySm"
             color="$textSubdued"
             text={asset.totalReward.description}
+            fontVariant={TABULAR_NUMS}
           />
         </XStack>
       );
@@ -389,8 +397,12 @@ const EarningsField = ({
     return (
       <FieldWrapper asset={asset}>
         <YStack jc="center" flex={1} gap="$1">
-          <EarnText size="$bodyMdMedium" text={netPnlFiatValue} />
-          <EarnText size="$bodySm" text={netPnl} />
+          <EarnText
+            size="$bodyMdMedium"
+            text={netPnlFiatValue}
+            fontVariant={TABULAR_NUMS}
+          />
+          <EarnText size="$bodySm" text={netPnl} fontVariant={TABULAR_NUMS} />
         </YStack>
       </FieldWrapper>
     );
@@ -399,7 +411,11 @@ const EarningsField = ({
   return (
     <FieldWrapper asset={asset}>
       <YStack jc="center" flex={1} gap="$1">
-        <EarnText size="$bodyMdMedium" text={asset.earnings24h?.title} />
+        <EarnText
+          size="$bodyMdMedium"
+          text={asset.earnings24h?.title}
+          fontVariant={TABULAR_NUMS}
+        />
         {secondLine}
       </YStack>
     </FieldWrapper>
@@ -414,8 +430,12 @@ const MobilePnlSection = memo(
     if (netPnl) {
       return (
         <XStack ai="center" gap="$1">
-          <EarnText size="$bodySm" text={netPnlFiatValue} />
-          <EarnText size="$bodySm" text={netPnl} />
+          <EarnText
+            size="$bodySm"
+            text={netPnlFiatValue}
+            fontVariant={TABULAR_NUMS}
+          />
+          <EarnText size="$bodySm" text={netPnl} fontVariant={TABULAR_NUMS} />
         </XStack>
       );
     }
@@ -426,7 +446,9 @@ const MobilePnlSection = memo(
             size="$bodySm"
             color="$textSubdued"
             text={asset.totalReward.description}
+            fontVariant={TABULAR_NUMS}
           />
+          {/* Localized "Total earned" label — prose, stays proportional. */}
           <EarnText
             size="$bodySm"
             color="$textSubdued"
@@ -546,6 +568,7 @@ const PositionValueField = ({ totalFiatValue }: { totalFiatValue: string }) => {
       size="$bodyMdMedium"
       formatter="value"
       formatterOptions={{ currency: currencyInfo.symbol }}
+      fontVariant={TABULAR_NUMS}
     >
       {totalFiatValue}
     </NumberSizeableText>

--- a/packages/kit/src/views/Earn/components/PortfolioTabContent.tsx
+++ b/packages/kit/src/views/Earn/components/PortfolioTabContent.tsx
@@ -542,12 +542,14 @@ const ActionField = ({
             mr="$1"
             size="$bodyMdMedium"
             text={reward.title ?? { text: '-' }}
+            fontVariant={TABULAR_NUMS}
           />
           <EarnText
             mr="$2"
             size="$bodyMd"
             color="$textSubdued"
             text={reward.description}
+            fontVariant={TABULAR_NUMS}
           />
           {reward?.tooltip ? (
             <XStack mr="$2">
@@ -992,16 +994,19 @@ const PortfolioItemComponent = ({
                               <EarnText
                                 size="$bodyLgMedium"
                                 text={asset.metadata.netPnlFiatValue}
+                                fontVariant={TABULAR_NUMS}
                               />
                               <EarnText
                                 size="$bodyMd"
                                 text={asset.metadata.netPnl}
+                                fontVariant={TABULAR_NUMS}
                               />
                             </>
                           ) : (
                             <EarnText
                               size="$bodyLgMedium"
                               text={asset.earnings24h?.title}
+                              fontVariant={TABULAR_NUMS}
                             />
                           )}
                           <SizableText size="$bodyMd" color="$textSubdued">
@@ -1048,11 +1053,13 @@ const PortfolioItemComponent = ({
                               <EarnText
                                 size="$bodyMdMedium"
                                 text={reward.title}
+                                fontVariant={TABULAR_NUMS}
                               />
                               <EarnText
                                 size="$bodyMd"
                                 color="$textSubdued"
                                 text={reward.description}
+                                fontVariant={TABULAR_NUMS}
                               />
                               <EarnTooltip tooltip={reward.tooltip} />
                             </XStack>

--- a/packages/kit/src/views/Earn/pages/EarnProtocols/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocols/index.tsx
@@ -8,6 +8,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useMedia,
@@ -417,7 +418,11 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
         },
         render: (item) => (
           <SizableText size="$bodyLgMedium">
-            <EarnText size="$bodyLg" text={item?.tvl} />
+            <EarnText
+              size="$bodyLg"
+              text={item?.tvl}
+              fontVariant={TABULAR_NUMS}
+            />
           </SizableText>
         ),
       },
@@ -439,7 +444,7 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
                 parseFormattedLiquidityValue(a.provider.liquidity) -
                 parseFormattedLiquidityValue(b.provider.liquidity),
               render: (item: IStakeProtocolListItem) => (
-                <SizableText size="$bodyLgMedium">
+                <SizableText size="$bodyLgMedium" fontVariant={TABULAR_NUMS}>
                   {item.provider.liquidity || '-'}
                 </SizableText>
               ),

--- a/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
+++ b/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
@@ -10,7 +10,6 @@ import {
   Dialog,
   Divider,
   ESwitchSize,
-  PROPORTIONAL_NUMS,
   SizableText,
   Skeleton,
   Stack,
@@ -392,7 +391,7 @@ function BalanceDetailsContent({
           {isLoading ? (
             <Skeleton.Heading3Xl />
           ) : (
-            <SizableText size="$heading3xl" fontVariant={PROPORTIONAL_NUMS}>
+            <SizableText size="$heading3xl">
               {`${overview?.balanceParsed ?? '-'} ${network?.symbol ?? ''}`}
             </SizableText>
           )}

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolAssetBalanceText.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolAssetBalanceText.tsx
@@ -1,4 +1,4 @@
-import { SizableText, XStack } from '@onekeyhq/components';
+import { SizableText, TABULAR_NUMS, XStack } from '@onekeyhq/components';
 import { ProtocolValueCell } from '@onekeyhq/kit/src/components/DeFi/ProtocolValueCell';
 import { isProtocolAssetValueUnavailable } from '@onekeyhq/kit/src/components/DeFi/protocolValueUtils';
 import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
@@ -25,6 +25,7 @@ function ProtocolAssetBalanceText({
         formatter="balance"
         formatterOptions={{ tokenSymbol: asset.symbol }}
         numberOfLines={1}
+        fontVariant={TABULAR_NUMS}
       >
         {asset.amount}
       </NumberSizeableTextWrapper>

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolHeaderRow.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolHeaderRow.tsx
@@ -4,6 +4,7 @@ import {
   Icon,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   View,
   XStack,
   YStack,
@@ -18,8 +19,6 @@ import {
 } from '@onekeyhq/shared/src/utils/openUrlUtils';
 
 import { formatPortfolioTotal } from './formatPortfolioTotal';
-
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
 
 // Mirrors the DeFi detail page: open the protocol's site in the in-app
 // discovery browser on desktop/native, or a new tab on web.

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolRewardsCell.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolRewardsCell.tsx
@@ -1,6 +1,11 @@
 import { memo } from 'react';
 
-import { SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { ProtocolValueCell } from '@onekeyhq/kit/src/components/DeFi/ProtocolValueCell';
 import { isProtocolAssetValueUnavailable } from '@onekeyhq/kit/src/components/DeFi/protocolValueUtils';
 import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
@@ -37,6 +42,7 @@ const ProtocolRewardsCell = memo(
               size="$bodyMd"
               formatter="balance"
               formatterOptions={{ tokenSymbol: asset.symbol }}
+              fontVariant={TABULAR_NUMS}
             >
               {asset.amount}
             </NumberSizeableTextWrapper>

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolSectionedPositionTable.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolSectionedPositionTable.tsx
@@ -34,8 +34,6 @@ import {
 // The Supplied segment uses "Positions" in the first header cell to align with
 // the unified table; Borrowed and Rewards keep their semantic labels.
 
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
-
 function getTableSectionActionPlacement(
   assetType: ILocalizedProtocolPositionItem['sections'][number]['assetType'],
 ): 'balance' | 'rewards' | 'debt' | undefined {
@@ -205,7 +203,6 @@ const ProtocolSectionedPositionTable = memo(
                       size="$bodyMdMedium"
                       textAlign="right"
                       numberOfLines={1}
-                      fontVariant={TABULAR_NUMS}
                     />
                   </Stack>
                 </XStack>

--- a/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolUnifiedTable.tsx
+++ b/packages/kit/src/views/Home/components/DeFiListBlock/ProtocolUnifiedTable.tsx
@@ -67,8 +67,6 @@ export const USD_FLEX_WITHOUT_REWARDS = 1;
 // settles at four lines of content instead of eight.
 const MAX_BALANCE_LINES = 3;
 
-const TABULAR_NUMS: ['tabular-nums'] = ['tabular-nums'];
-
 // Stable identity for the inline action-button container styling so the
 // memo()'d ProtocolPositionActionButton isn't re-created on every parent
 // render (the tables now mount one per asset row). Shared with the sectioned
@@ -400,7 +398,6 @@ const ProtocolUnifiedTable = memo(
                     size="$bodyMdMedium"
                     textAlign="right"
                     numberOfLines={1}
-                    fontVariant={TABULAR_NUMS}
                   />
                 </Stack>
               </XStack>

--- a/packages/kit/src/views/Home/components/PopularTrading/metricColumns.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/metricColumns.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps, ReactNode } from 'react';
 import {
   NumberSizeableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -85,6 +86,7 @@ function renderPopularTradingChangeText(
       formatter="priceChange"
       color={changeColor}
       formatterOptions={{ showPlusMinusSigns }}
+      fontVariant={TABULAR_NUMS}
     >
       {record.priceChange24h ?? '-'}
     </NumberSizeableText>
@@ -99,6 +101,7 @@ function renderPopularTradingPriceWithChange(record: IFavoriteTokenDisplay) {
         size="$bodyLgMedium"
         formatter="price"
         formatterOptions={{ currency: '$' }}
+        fontVariant={TABULAR_NUMS}
       >
         {record.price ?? '-'}
       </NumberSizeableText>
@@ -121,6 +124,7 @@ function getPopularTradingDesktopMetricColumns(
           size="$bodyLgMedium"
           formatter="price"
           formatterOptions={{ currency: '$' }}
+          fontVariant={TABULAR_NUMS}
         >
           {record.price ?? '-'}
         </NumberSizeableText>
@@ -140,6 +144,7 @@ function getPopularTradingDesktopMetricColumns(
           size="$bodyLgMedium"
           formatter="marketCap"
           formatterOptions={{ currency: '$' }}
+          fontVariant={TABULAR_NUMS}
         >
           {record.volume24h ? record.volume24h : EMPTY_MARKET_VALUE}
         </NumberSizeableText>

--- a/packages/kit/src/views/Home/components/WalletOverview/index.tsx
+++ b/packages/kit/src/views/Home/components/WalletOverview/index.tsx
@@ -1,9 +1,4 @@
-import {
-  PROPORTIONAL_NUMS,
-  SizableText,
-  Skeleton,
-  YStack,
-} from '@onekeyhq/components';
+import { SizableText, Skeleton, YStack } from '@onekeyhq/components';
 
 import { HomeTestIDs } from '../../testIDs';
 
@@ -32,9 +27,7 @@ function WalletOverview(props: IProps) {
         {address}
       </SizableText>
       <Skeleton show={isFetchingValue}>
-        <SizableText size="$heading4xl" fontVariant={PROPORTIONAL_NUMS}>
-          {value}
-        </SizableText>
+        <SizableText size="$heading4xl">{value}</SizableText>
       </Skeleton>
     </YStack>
   );

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -6,7 +6,6 @@ import { useIntl } from 'react-intl';
 import {
   Button,
   IconButton,
-  PROPORTIONAL_NUMS,
   Skeleton,
   XStack,
   YStack,
@@ -1010,9 +1009,6 @@ function HomeOverviewContainer() {
                 fontSize={48}
                 lineHeight={48}
                 fontWeight={500}
-                // Large hero balance reads better with the font's natural
-                // proportional figures than equal-width tabular ones.
-                fontVariant={PROPORTIONAL_NUMS}
                 {...numberFormatter}
               >
                 {renderedBalanceStringDisplay ?? '0'}

--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -13,6 +13,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   Tabs,
   XStack,
   YStack,
@@ -202,17 +203,26 @@ function useOpenPerpAsset() {
   );
 }
 
+// These wrappers exist to render live USD values that tick off the websocket and
+// sit in columns, so they opt into tabular figures by default; callers can still
+// override with an explicit `fontVariant`.
 function PerpsUsd({
   value,
+  fontVariant = TABULAR_NUMS,
   ...rest
 }: { value: number | undefined } & Omit<ISizableTextProps, 'children'>) {
   if (value === undefined) {
-    return <SizableText {...rest}>--</SizableText>;
+    return (
+      <SizableText fontVariant={fontVariant} {...rest}>
+        --
+      </SizableText>
+    );
   }
   return (
     <NumberSizeableText
       formatter="value"
       formatterOptions={{ currency: '$' }}
+      fontVariant={fontVariant}
       {...rest}
     >
       {value}
@@ -223,6 +233,7 @@ function PerpsUsd({
 function PerpsTotalUsd({
   value,
   isDegraded,
+  fontVariant = TABULAR_NUMS,
   ...rest
 }: {
   value: number | undefined;
@@ -244,6 +255,7 @@ function PerpsTotalUsd({
       <NumberSizeableText
         formatter="value"
         formatterOptions={{ currency: settings.currencyInfo.symbol }}
+        fontVariant={fontVariant}
         {...rest}
       >
         {displayValue}
@@ -258,6 +270,7 @@ function PerpsTotalUsd({
       <NumberSizeableText
         formatter="value"
         formatterOptions={{ currency: settings.currencyInfo.symbol }}
+        fontVariant={fontVariant}
         {...rest}
       >
         {displayValue}
@@ -270,6 +283,7 @@ function PerpsTotalUsd({
 // carry the sign via a currency prefix + color (mirrors PositionsRow's pnl).
 function PerpsSignedUsd({
   value,
+  fontVariant = TABULAR_NUMS,
   ...rest
 }: { value: number | undefined } & Omit<
   ISizableTextProps,
@@ -277,7 +291,7 @@ function PerpsSignedUsd({
 >) {
   if (value === undefined) {
     return (
-      <SizableText color="$textSubdued" {...rest}>
+      <SizableText color="$textSubdued" fontVariant={fontVariant} {...rest}>
         --
       </SizableText>
     );
@@ -288,6 +302,7 @@ function PerpsSignedUsd({
       formatter="value"
       formatterOptions={{ currency: negative ? '-$' : '+$' }}
       color={negative ? '$red11' : '$green11'}
+      fontVariant={fontVariant}
       {...rest}
     >
       {new BigNumber(value).abs().toFixed()}
@@ -728,6 +743,7 @@ function PerpsEmptyRecommendSection() {
                   textAlign="right"
                   formatter="price"
                   formatterOptions={{ currency: '$' }}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {token.markPrice}
                 </NumberSizeableText>
@@ -760,6 +776,7 @@ function PerpsEmptyRecommendSection() {
                   }
                   formatter="priceChange"
                   formatterOptions={{ showPlusMinusSigns: true }}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {token.change24hPercent}
                 </NumberSizeableText>
@@ -771,6 +788,7 @@ function PerpsEmptyRecommendSection() {
                   textAlign="right"
                   formatter="marketCap"
                   formatterOptions={{ currency: '$' }}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {token.volume24h}
                 </NumberSizeableText>
@@ -849,6 +867,7 @@ function PerpsEmptyRecommendSection() {
                         formatter="marketCap"
                         formatterOptions={{ currency: '$' }}
                         userSelect="none"
+                        fontVariant={TABULAR_NUMS}
                       >
                         {token.volume24h ?? '0'}
                       </NumberSizeableText>
@@ -864,6 +883,7 @@ function PerpsEmptyRecommendSection() {
                     size="$bodyLgMedium"
                     formatter="price"
                     formatterOptions={{ currency: '$' }}
+                    fontVariant={TABULAR_NUMS}
                   >
                     {token.markPrice ?? '-'}
                   </NumberSizeableText>
@@ -872,6 +892,7 @@ function PerpsEmptyRecommendSection() {
                     color={change24hPercentColor}
                     formatter="priceChange"
                     formatterOptions={{ showPlusMinusSigns: true }}
+                    fontVariant={TABULAR_NUMS}
                   >
                     {token.change24hPercent ?? '-'}
                   </NumberSizeableText>
@@ -1135,6 +1156,7 @@ function PerpsMobileHoldingRow({
             size="$bodyMd"
             color="$textSubdued"
             numberOfLines={1}
+            fontVariant={TABULAR_NUMS}
           >
             {holding.balance}
           </NumberSizeableText>
@@ -1333,6 +1355,8 @@ function PerpsMetric({
               {labelExtra}
             </SizableText>
           </XStack>
+          {/* The metric value is dense column data — the same grid repeats on
+              every position card, so the columns have to line up card to card. */}
           {formatter ? (
             <NumberSizeableText
               size={valueSize}
@@ -1348,6 +1372,7 @@ function PerpsMetric({
               contentStyle={{ color: valueColor }}
               decimalTextStyle={{ color: valueColor }}
               subTextStyle={{ color: valueColor }}
+              fontVariant={TABULAR_NUMS}
             >
               {value}
             </NumberSizeableText>
@@ -1361,6 +1386,7 @@ function PerpsMetric({
               numberOfLines={platformEnv.isNative ? 1 : 2}
               adjustsFontSizeToFit
               minimumFontScale={0.7}
+              fontVariant={TABULAR_NUMS}
             >
               {value}
             </SizableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
@@ -226,11 +226,17 @@ export function InformationPanel() {
               color="$textSubdued"
               formatter="price"
               formatterOptions={{ currency: currencyInfo.symbol }}
+              fontVariant={TABULAR_NUMS}
             >
               {priceConverted}
             </NumberSizeableText>
           ) : null}
-          <SizableText pt="$1" size="$bodyLgMedium" color={priceChangeColor}>
+          <SizableText
+            pt="$1"
+            size="$bodyLgMedium"
+            color={priceChangeColor}
+            fontVariant={TABULAR_NUMS}
+          >
             {priceChangeDisplay}
           </SizableText>
         </YStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationPanel/InformationPanel.tsx
@@ -3,6 +3,7 @@ import { useIntl } from 'react-intl';
 import {
   NumberSizeableText,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -45,7 +46,9 @@ function StatRow({ label, value }: { label: string; value: string }) {
       <SizableText size="$bodySm" color="$textSubdued">
         {label}
       </SizableText>
-      <SizableText size="$bodySmMedium">{value}</SizableText>
+      <SizableText size="$bodySmMedium" fontVariant={TABULAR_NUMS}>
+        {value}
+      </SizableText>
     </XStack>
   );
 }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/layout/HolderItemNormal/HolderItemNormal.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/layout/HolderItemNormal/HolderItemNormal.tsx
@@ -1,6 +1,11 @@
 import { memo } from 'react';
 
-import { NumberSizeableText, SizableText, XStack } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+} from '@onekeyhq/components';
 import type { IMarketTokenHolder } from '@onekeyhq/shared/types/marketV2';
 
 import { AddressDisplay } from '../../../AddressDisplay';
@@ -34,7 +39,12 @@ function HolderItemNormalBase({
       hoverStyle={{ backgroundColor: '$bgHover' }}
     >
       {/* Rank */}
-      <SizableText size="$bodyMd" color="$textSubdued" {...styles.rank}>
+      <SizableText
+        size="$bodyMd"
+        color="$textSubdued"
+        {...styles.rank}
+        fontVariant={TABULAR_NUMS}
+      >
         #{rank}
       </SizableText>
 
@@ -48,7 +58,12 @@ function HolderItemNormalBase({
       />
 
       {/* Market Cap Percentage */}
-      <SizableText size="$bodyMd" color="$text" {...styles.percentage}>
+      <SizableText
+        size="$bodyMd"
+        color="$text"
+        {...styles.percentage}
+        fontVariant={TABULAR_NUMS}
+      >
         {displayPercentage}
       </SizableText>
 
@@ -58,6 +73,7 @@ function HolderItemNormalBase({
         color="$text"
         {...styles.amount}
         formatter="marketCap"
+        fontVariant={TABULAR_NUMS}
       >
         {amount}
       </NumberSizeableText>
@@ -71,6 +87,7 @@ function HolderItemNormalBase({
         formatterOptions={{
           currency: '$',
         }}
+        fontVariant={TABULAR_NUMS}
       >
         {fiatValue}
       </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/layout/HolderItemSmall/HolderItemSmall.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Holders/layout/HolderItemSmall/HolderItemSmall.tsx
@@ -1,6 +1,11 @@
 import { memo } from 'react';
 
-import { NumberSizeableText, SizableText, XStack } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+} from '@onekeyhq/components';
 import type { IMarketTokenHolder } from '@onekeyhq/shared/types/marketV2';
 
 import { AddressDisplay } from '../../../AddressDisplay';
@@ -27,7 +32,11 @@ function HolderItemSmallBase({
     <XStack h={52} px="$5" alignItems="center" gap="$3">
       <XStack gap="$4" alignItems="center" flex={1}>
         {/* Rank */}
-        <SizableText size="$bodyMd" color="$textSubdued">
+        <SizableText
+          size="$bodyMd"
+          color="$textSubdued"
+          fontVariant={TABULAR_NUMS}
+        >
           {rank}
         </SizableText>
 
@@ -46,7 +55,12 @@ function HolderItemSmallBase({
       </XStack>
 
       {/* Percentage */}
-      <SizableText size="$bodyMd" color="$text" {...styles.percentage}>
+      <SizableText
+        size="$bodyMd"
+        color="$text"
+        {...styles.percentage}
+        fontVariant={TABULAR_NUMS}
+      >
         {displayPercentage}
       </SizableText>
 
@@ -59,6 +73,7 @@ function HolderItemSmallBase({
         formatterOptions={{
           currency: '$',
         }}
+        fontVariant={TABULAR_NUMS}
       >
         {fiatValue}
       </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/components/PnlCell.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/components/PnlCell.tsx
@@ -2,7 +2,12 @@ import { memo } from 'react';
 
 import BigNumber from 'bignumber.js';
 
-import { SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { Currency } from '@onekeyhq/kit/src/components/Currency';
 import { USD_CURRENCY_ID } from '@onekeyhq/shared/src/consts/currencyConsts';
 
@@ -47,6 +52,7 @@ function PnlCellBase({
             autoFormatter="price-marketCap"
             autoFormatterThreshold={1000}
             sourceCurrency={USD_CURRENCY_ID}
+            fontVariant={TABULAR_NUMS}
           >
             {valueBN.abs().toFixed()}
           </Currency>
@@ -56,7 +62,11 @@ function PnlCellBase({
           --
         </SizableText>
       )}
-      <SizableText size="$bodySm" color={displayColor}>
+      <SizableText
+        size="$bodySm"
+        color={displayColor}
+        fontVariant={TABULAR_NUMS}
+      >
         {isValid ? `${percent}%` : '--'}
       </SizableText>
     </YStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/layout/PortfolioItemNormal.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/layout/PortfolioItemNormal.tsx
@@ -3,6 +3,7 @@ import { memo } from 'react';
 import {
   NumberSizeableText,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -53,6 +54,7 @@ function PortfolioItemNormalBase({
           autoFormatter="price-marketCap"
           autoFormatterThreshold={1000}
           sourceCurrency={USD_CURRENCY_ID}
+          fontVariant={TABULAR_NUMS}
         >
           {item.totalPrice}
         </Currency>
@@ -61,6 +63,7 @@ function PortfolioItemNormalBase({
           color="$textSubdued"
           autoFormatter="price-marketCap"
           autoFormatterThreshold={1000}
+          fontVariant={TABULAR_NUMS}
         >
           {item.amount}
         </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/layout/PortfolioItemSmall.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/Portfolio/layout/PortfolioItemSmall.tsx
@@ -1,6 +1,11 @@
 import { memo } from 'react';
 
-import { NumberSizeableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { Currency } from '@onekeyhq/kit/src/components/Currency';
 import { USD_CURRENCY_ID } from '@onekeyhq/shared/src/consts/currencyConsts';
 import type { IMarketAccountPortfolioItem } from '@onekeyhq/shared/types/marketV2';
@@ -24,6 +29,7 @@ function PortfolioItemSmallBase({ item }: IPortfolioItemSmallProps) {
           autoFormatter="price-marketCap"
           autoFormatterThreshold={1000}
           sourceCurrency={USD_CURRENCY_ID}
+          fontVariant={TABULAR_NUMS}
         >
           {item.totalPrice}
         </Currency>
@@ -32,6 +38,7 @@ function PortfolioItemSmallBase({ item }: IPortfolioItemSmallProps) {
           color="$textSubdued"
           autoFormatter="price-marketCap"
           autoFormatterThreshold={1000}
+          fontVariant={TABULAR_NUMS}
         >
           {item.amount}
         </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/components/TransactionAmount.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/components/TransactionAmount.tsx
@@ -3,6 +3,7 @@ import { type ComponentProps, memo } from 'react';
 import {
   NumberSizeableText,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -42,6 +43,7 @@ function TransactionAmountBase({
             size="$bodyMd"
             autoFormatter="value-marketCap"
             color={typeColor}
+            fontVariant={TABULAR_NUMS}
           >
             {baseToken.amount}
           </NumberSizeableText>
@@ -52,7 +54,11 @@ function TransactionAmountBase({
             {quoteSign}
           </SizableText>
 
-          <NumberSizeableText autoFormatter="value-marketCap" size="$bodyMd">
+          <NumberSizeableText
+            autoFormatter="value-marketCap"
+            size="$bodyMd"
+            fontVariant={TABULAR_NUMS}
+          >
             {quoteToken.amount}
           </NumberSizeableText>
         </XStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/components/TransactionRelativeTime.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/components/TransactionRelativeTime.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import type { PropsWithChildren } from 'react';
 
-import { SizableText } from '@onekeyhq/components';
+import { SizableText, TABULAR_NUMS } from '@onekeyhq/components';
 import type { ISizableTextProps } from '@onekeyhq/components';
 import { useInterval } from '@onekeyhq/kit/src/hooks/useInterval';
 
@@ -62,7 +62,12 @@ function TransactionRelativeTimeBase({
   );
 
   return (
-    <SizableText size={size} color={color} {...textProps}>
+    <SizableText
+      size={size}
+      color={color}
+      {...textProps}
+      fontVariant={TABULAR_NUMS}
+    >
       {formattedTime}
     </SizableText>
   );

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/layout/TransactionItemNormal/TransactionItemNormal.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/layout/TransactionItemNormal/TransactionItemNormal.tsx
@@ -4,6 +4,7 @@ import {
   Image,
   NumberSizeableText,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -89,6 +90,7 @@ function TransactionItemNormalBase({
               capAtMaxT: true,
               currency: '$',
             }}
+            fontVariant={TABULAR_NUMS}
           >
             {value}
           </NumberSizeableText>
@@ -100,6 +102,7 @@ function TransactionItemNormalBase({
               capAtMaxT: true,
               currency: '$',
             }}
+            fontVariant={TABULAR_NUMS}
           >
             {price}
           </NumberSizeableText>
@@ -115,6 +118,7 @@ function TransactionItemNormalBase({
               currency: '$',
             }}
             {...styles.price}
+            fontVariant={TABULAR_NUMS}
           >
             {price}
           </NumberSizeableText>
@@ -128,6 +132,7 @@ function TransactionItemNormalBase({
               currency: '$',
             }}
             {...styles.value}
+            fontVariant={TABULAR_NUMS}
           >
             {value}
           </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/layout/TransactionItemSmall/TransactionItemSmall.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/layout/TransactionItemSmall/TransactionItemSmall.tsx
@@ -4,6 +4,7 @@ import {
   Image,
   NumberSizeableText,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -75,6 +76,7 @@ function TransactionItemSmallBase({ item }: ITransactionItemSmallProps) {
             capAtMaxT: true,
             currency: '$',
           }}
+          fontVariant={TABULAR_NUMS}
         >
           {value}
         </NumberSizeableText>
@@ -88,6 +90,7 @@ function TransactionItemSmallBase({ item }: ITransactionItemSmallProps) {
             capAtMaxT: true,
             currency: '$',
           }}
+          fontVariant={TABULAR_NUMS}
         >
           {price}
         </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/StockDescriptionRows.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/StockDescriptionRows.tsx
@@ -1,4 +1,10 @@
-import { DashText, SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  DashText,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 
 import type { IDescriptionRow } from '../hooks/useStockSecurityStats';
 
@@ -22,7 +28,11 @@ export function StockDescriptionRows({ rows }: { rows: IDescriptionRow[] }) {
               {item.label}
             </SizableText>
           )}
-          <SizableText size="$bodySmMedium" color="$text">
+          <SizableText
+            size="$bodySmMedium"
+            color="$text"
+            fontVariant={TABULAR_NUMS}
+          >
             {item.value}
           </SizableText>
         </XStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/components/TimeRangeSelector.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/components/TimeRangeSelector.tsx
@@ -1,4 +1,10 @@
-import { ButtonFrame, SizableText, Stack, YStack } from '@onekeyhq/components';
+import {
+  ButtonFrame,
+  SizableText,
+  Stack,
+  TABULAR_NUMS,
+  YStack,
+} from '@onekeyhq/components';
 
 import { MarketTestIDs } from '../../../testIDs';
 
@@ -54,6 +60,7 @@ export function TimeRangeSelector({
             <SizableText
               size="$bodySm"
               color={isLoading ? '$textSubdued' : getPercentageColor(opt)}
+              fontVariant={TABULAR_NUMS}
             >
               {isLoading ? '--' : opt.percentageChange}
             </SizableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/components/TransactionRow.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/components/TransactionRow.tsx
@@ -1,6 +1,11 @@
 import { useIntl } from 'react-intl';
 
-import { NumberSizeableText, SizableText, Stack } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  Stack,
+  TABULAR_NUMS,
+} from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { BuySellRatioBar } from './BuySellRatioBar';
@@ -34,7 +39,11 @@ export function TransactionRow({
           {showTotalPlaceholder ? (
             '--'
           ) : (
-            <NumberSizeableText size="$bodyMdMedium" formatter="marketCap">
+            <NumberSizeableText
+              size="$bodyMdMedium"
+              formatter="marketCap"
+              fontVariant={TABULAR_NUMS}
+            >
               {totalCount}
             </NumberSizeableText>
           )}
@@ -61,6 +70,7 @@ export function TransactionRow({
                 size="$bodyMd"
                 color="$textSubdued"
                 formatter="marketCap"
+                fontVariant={TABULAR_NUMS}
               >
                 {buyCount}
               </NumberSizeableText>
@@ -84,6 +94,7 @@ export function TransactionRow({
                 size="$bodyMd"
                 color="$textSubdued"
                 formatter="marketCap"
+                fontVariant={TABULAR_NUMS}
               >
                 {sellCount}
               </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/components/VolumeRow.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenActivityOverview/components/VolumeRow.tsx
@@ -1,6 +1,11 @@
 import { useIntl } from 'react-intl';
 
-import { NumberSizeableText, SizableText, Stack } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  Stack,
+  TABULAR_NUMS,
+} from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import { BuySellRatioBar } from './BuySellRatioBar';
@@ -40,6 +45,7 @@ export function VolumeRow({
               formatterOptions={{
                 currency: '$',
               }}
+              fontVariant={TABULAR_NUMS}
             >
               {totalVolume}
             </NumberSizeableText>
@@ -64,6 +70,7 @@ export function VolumeRow({
               formatterOptions={{
                 currency: '$',
               }}
+              fontVariant={TABULAR_NUMS}
             >
               {buyVolume}
             </NumberSizeableText>
@@ -82,6 +89,7 @@ export function VolumeRow({
               formatterOptions={{
                 currency: '$',
               }}
+              fontVariant={TABULAR_NUMS}
             >
               {sellVolume}
             </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderRight.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderRight.tsx
@@ -99,6 +99,7 @@ export function TokenDetailHeaderRight({
             <NumberSizeableText
               size="$headingXs"
               color="$text"
+              fontVariant={TABULAR_NUMS}
               formatter="marketCap"
               formatterOptions={{
                 capAtMaxT: true,
@@ -118,6 +119,7 @@ export function TokenDetailHeaderRight({
             <NumberSizeableText
               size="$headingXs"
               color="$text"
+              fontVariant={TABULAR_NUMS}
               formatter="marketCap"
               formatterOptions={{
                 currency: '$',
@@ -134,7 +136,11 @@ export function TokenDetailHeaderRight({
             id: ETranslations.dexmarket_stock_pe_ttm,
           })}
           value={
-            <SizableText size="$headingXs" color="$text">
+            <SizableText
+              size="$headingXs"
+              color="$text"
+              fontVariant={TABULAR_NUMS}
+            >
               {formatRatioValue(tokenDetail?.stock?.tradingActivity?.peRatio)}
             </SizableText>
           }
@@ -152,6 +158,7 @@ export function TokenDetailHeaderRight({
             <NumberSizeableText
               size="$headingXs"
               color="$text"
+              fontVariant={TABULAR_NUMS}
               formatter="marketCap"
               formatterOptions={{
                 capAtMaxT: true,
@@ -170,6 +177,7 @@ export function TokenDetailHeaderRight({
             <NumberSizeableText
               size="$headingXs"
               color="$text"
+              fontVariant={TABULAR_NUMS}
               formatter="marketCap"
               formatterOptions={{
                 currency: '$',
@@ -187,6 +195,7 @@ export function TokenDetailHeaderRight({
             <NumberSizeableText
               size="$headingXs"
               color="$text"
+              fontVariant={TABULAR_NUMS}
               formatter="marketCap"
             >
               {btcMetadata.circulatingSupply}
@@ -206,6 +215,7 @@ export function TokenDetailHeaderRight({
             <NumberSizeableText
               size="$headingXs"
               color="$text"
+              fontVariant={TABULAR_NUMS}
               formatter="marketCap"
               formatterOptions={{
                 capAtMaxT: true,
@@ -224,6 +234,7 @@ export function TokenDetailHeaderRight({
             <NumberSizeableText
               size="$headingXs"
               color="$text"
+              fontVariant={TABULAR_NUMS}
               formatter="marketCap"
               formatterOptions={{
                 currency: '$',
@@ -241,6 +252,7 @@ export function TokenDetailHeaderRight({
             <NumberSizeableText
               size="$headingXs"
               color="$text"
+              fontVariant={TABULAR_NUMS}
               formatter="marketCap"
             >
               {holdersValue}
@@ -285,6 +297,7 @@ export function TokenDetailHeaderRight({
                 color="$textSubdued"
                 formatter="price"
                 formatterOptions={{ currency: currencyInfo.symbol }}
+                fontVariant={TABULAR_NUMS}
               >
                 {priceConverted}
               </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderRight.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenDetailHeader/TokenDetailHeaderRight.tsx
@@ -3,6 +3,7 @@ import { useIntl } from 'react-intl';
 import {
   NumberSizeableText,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -266,6 +267,7 @@ export function TokenDetailHeaderRight({
                 price={currentPrice}
                 tokenName={name}
                 tokenSymbol={symbol}
+                fontVariant={TABULAR_NUMS}
               />
             ) : (
               <MarketTokenPrice
@@ -274,6 +276,7 @@ export function TokenDetailHeaderRight({
                 tokenName={name}
                 tokenSymbol={symbol}
                 lastUpdated={tokenDetail?.lastUpdated?.toString()}
+                fontVariant={TABULAR_NUMS}
               />
             )}
             {priceConverted ? (

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenLiquidityPools/TokenLiquidityPools.tsx
@@ -15,6 +15,7 @@ import {
   ScrollView,
   SizableText,
   Skeleton,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
   YStack,
@@ -843,6 +844,7 @@ function TokenAmountLines({ tokens }: { tokens: IDisplayPoolToken[] }) {
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 flexShrink={1}
+                fontVariant={TABULAR_NUMS}
               >
                 {token.amount}
               </NumberSizeableText>
@@ -1003,13 +1005,23 @@ function TokenLiquidityPoolsDesktop({ pools }: { pools: IDisplayPool[] }) {
             <YStack {...styles.pool}>
               <PoolIdentity item={item} textSize="$bodyMd" />
             </YStack>
-            <SizableText size="$bodyMd" color="$text" {...styles.liquidity}>
+            <SizableText
+              size="$bodyMd"
+              color="$text"
+              fontVariant={TABULAR_NUMS}
+              {...styles.liquidity}
+            >
               {item.liquidity}
             </SizableText>
             <YStack {...styles.tokenAmount}>
               <TokenAmountLines tokens={item.tokenAmounts} />
             </YStack>
-            <SizableText size="$bodyMd" color="$text" {...styles.feeRate}>
+            <SizableText
+              size="$bodyMd"
+              color="$text"
+              fontVariant={TABULAR_NUMS}
+              {...styles.feeRate}
+            >
               {item.feeRate}
             </SizableText>
             <YStack {...styles.poolAddress}>
@@ -1062,6 +1074,7 @@ function DetailTokenRows({ tokens }: { tokens: IDisplayPoolToken[] }) {
               autoFormatterThreshold={TOKEN_AMOUNT_COMPACT_THRESHOLD}
               numberOfLines={1}
               ellipsizeMode="tail"
+              fontVariant={TABULAR_NUMS}
             >
               {token.amount}
             </NumberSizeableText>
@@ -1213,6 +1226,7 @@ function MobilePoolRow({ item }: { item: IDisplayPool }) {
         color="$text"
         textAlign="right"
         numberOfLines={1}
+        fontVariant={TABULAR_NUMS}
         {...MOBILE_COLUMN_STYLE.liquidity}
       >
         {item.liquidity}
@@ -1228,6 +1242,7 @@ function MobilePoolRow({ item }: { item: IDisplayPool }) {
           color="$text"
           textAlign="right"
           numberOfLines={1}
+          fontVariant={TABULAR_NUMS}
         >
           {item.feeRate}
         </SizableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenOverview/components/StatCard.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenOverview/components/StatCard.tsx
@@ -3,6 +3,7 @@ import {
   Popover,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
 } from '@onekeyhq/components';
 import type { ColorTokens, IIconProps } from '@onekeyhq/components';
@@ -62,7 +63,11 @@ export function StatCard({
         {icon ? (
           <Icon name={icon} size="$4" color={iconColor || '$iconSuccess'} />
         ) : null}
-        <SizableText size="$bodyLgMedium" color="$text">
+        <SizableText
+          size="$bodyLgMedium"
+          color="$text"
+          fontVariant={TABULAR_NUMS}
+        >
           {value}
         </SizableText>
       </XStack>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/MarketTokenSelectorRow.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenSelector/MarketTokenSelectorRow.tsx
@@ -9,6 +9,7 @@ import {
   NumberSizeableText,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useClipboard,
@@ -205,6 +206,7 @@ const MarketTokenSelectorRow = memo(
             size="$bodySmMedium"
             formatter={priceFormatter}
             formatterOptions={{ currency: '$', capAtMaxT: true }}
+            fontVariant={TABULAR_NUMS}
           >
             {String(item.price)}
           </NumberSizeableText>
@@ -217,6 +219,7 @@ const MarketTokenSelectorRow = memo(
             formatter="priceChange"
             formatterOptions={{ showPlusMinusSigns }}
             color={changeColor}
+            fontVariant={TABULAR_NUMS}
           >
             {String(item.change24h)}
           </NumberSizeableText>
@@ -229,6 +232,7 @@ const MarketTokenSelectorRow = memo(
               size="$bodySm"
               formatter="marketCap"
               formatterOptions={{ currency: '$', capAtMaxT: true }}
+              fontVariant={TABULAR_NUMS}
             >
               {String(item.marketCap)}
             </NumberSizeableText>
@@ -246,6 +250,7 @@ const MarketTokenSelectorRow = memo(
               size="$bodySm"
               formatter="marketCap"
               formatterOptions={{ currency: '$' }}
+              fontVariant={TABULAR_NUMS}
             >
               {String(item.liquidity)}
             </NumberSizeableText>
@@ -263,6 +268,7 @@ const MarketTokenSelectorRow = memo(
               size="$bodySm"
               formatter="marketCap"
               formatterOptions={{ currency: '$' }}
+              fontVariant={TABULAR_NUMS}
             >
               {String(item.turnover)}
             </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketDetailV2/components/TokenSupplementaryInfo/TokenSupplementaryInfo.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/TokenSupplementaryInfo/TokenSupplementaryInfo.tsx
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl';
 import {
   DashText,
   SizableText,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
   YStack,
@@ -164,6 +165,7 @@ export function TokenSupplementaryInfo() {
               item.onPress ? { textDecorationLine: 'underline' } : undefined
             }
             onPress={item.onPress}
+            fontVariant={TABULAR_NUMS}
           >
             {item.value}
           </SizableText>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketBanner/MarketBannerItem.tsx
@@ -7,6 +7,7 @@ import {
   Image,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -158,7 +159,11 @@ function MarketBannerItemComponent({
           ) : null}
         </XStack>
         {description ? (
-          <SizableText size="$bodyMdMedium" color={descriptionColor}>
+          <SizableText
+            size="$bodyMdMedium"
+            color={descriptionColor}
+            fontVariant={TABULAR_NUMS}
+          >
             {description.text}
           </SizableText>
         ) : null}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsTokenListItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsTokenListItem.tsx
@@ -5,6 +5,7 @@ import {
   NumberSizeableText,
   SizableText,
   SkeletonContainer,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -65,6 +66,7 @@ const BasicMarketPerpsTokenListItem: FC<IMarketPerpsTokenListItemProps> = ({
                 formatter="marketCap"
                 formatterOptions={{ currency: '$' }}
                 userSelect="none"
+                fontVariant={TABULAR_NUMS}
               >
                 {item.volume24h ?? '0'}
               </NumberSizeableText>
@@ -83,6 +85,7 @@ const BasicMarketPerpsTokenListItem: FC<IMarketPerpsTokenListItemProps> = ({
             size="$bodyLgMedium"
             formatter="price"
             formatterOptions={{ currency: '$' }}
+            fontVariant={TABULAR_NUMS}
           >
             {item.markPrice ?? '0'}
           </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/usePerpsColumns.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/usePerpsColumns.tsx
@@ -7,6 +7,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useMedia,
@@ -106,6 +107,7 @@ export function usePerpsColumnsDesktop(): ITableColumn<IMarketPerpsToken>[] {
               size="$bodyMd"
               formatter="price"
               formatterOptions={{ currency: '$' }}
+              fontVariant={TABULAR_NUMS}
             >
               {record.markPrice ?? '--'}
             </NumberSizeableText>
@@ -146,6 +148,7 @@ export function usePerpsColumnsDesktop(): ITableColumn<IMarketPerpsToken>[] {
                     showPlusMinusSigns: true,
                     currency: '',
                   }}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {absChange}
                 </NumberSizeableText>
@@ -157,6 +160,7 @@ export function usePerpsColumnsDesktop(): ITableColumn<IMarketPerpsToken>[] {
                   color={color}
                   formatter="priceChange"
                   formatterOptions={{ showPlusMinusSigns: true }}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {record.change24hPercent}
                 </NumberSizeableText>
@@ -178,6 +182,7 @@ export function usePerpsColumnsDesktop(): ITableColumn<IMarketPerpsToken>[] {
               size="$bodyMd"
               formatter="marketCap"
               formatterOptions={{ currency: '$' }}
+              fontVariant={TABULAR_NUMS}
             >
               {record.volume24h ?? '--'}
             </NumberSizeableText>
@@ -197,6 +202,7 @@ export function usePerpsColumnsDesktop(): ITableColumn<IMarketPerpsToken>[] {
               size="$bodyMd"
               formatter="marketCap"
               formatterOptions={{ currency: '$' }}
+              fontVariant={TABULAR_NUMS}
             >
               {record.openInterest ?? '--'}
             </NumberSizeableText>
@@ -225,6 +231,7 @@ export function usePerpsColumnsDesktop(): ITableColumn<IMarketPerpsToken>[] {
                   <SizableText
                     size="$bodyMd"
                     color={rate >= 0 ? '$textSuccess' : '$textCritical'}
+                    fontVariant={TABULAR_NUMS}
                   >
                     {`${rate >= 0 ? '+' : ''}${rate.toFixed(4)}%`}
                   </SizableText>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/usePerpsColumnsMobile.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/usePerpsColumnsMobile.tsx
@@ -6,6 +6,7 @@ import {
   NumberSizeableText,
   SizableText,
   Skeleton,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -67,6 +68,7 @@ export function usePerpsColumnsMobile(): ITableColumn<IMarketPerpsToken>[] {
                   numberOfLines={1}
                   formatter="marketCap"
                   userSelect="none"
+                  fontVariant={TABULAR_NUMS}
                 >
                   {record.volume24h ?? '0'}
                 </NumberSizeableText>
@@ -107,6 +109,7 @@ export function usePerpsColumnsMobile(): ITableColumn<IMarketPerpsToken>[] {
                   size="$bodyLgMedium"
                   formatter="price"
                   formatterOptions={{ currency: '$' }}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {record.markPrice ?? '0'}
                 </NumberSizeableText>
@@ -115,6 +118,7 @@ export function usePerpsColumnsMobile(): ITableColumn<IMarketPerpsToken>[] {
                   color={changeColor}
                   formatter="priceChange"
                   formatterOptions={{ showPlusMinusSigns: true }}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {record.change24hPercent ?? 0}
                 </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
@@ -7,6 +7,7 @@ import {
   NumberSizeableText,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   useClipboard,
   useMedia,
@@ -242,6 +243,7 @@ const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
                 numberOfLines={1}
                 formatter="marketCap"
                 formatterOptions={{ currency: '$' }}
+                fontVariant={TABULAR_NUMS}
               >
                 {volume}
               </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenListItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenListItem.tsx
@@ -3,6 +3,7 @@ import { memo, useCallback } from 'react';
 
 import {
   NumberSizeableText,
+  TABULAR_NUMS,
   XStack,
   useMedia,
   useThemeName,
@@ -136,6 +137,7 @@ const BasicTokenListItem: FC<ITokenListItemProps> = ({
           size="$bodyLgMedium"
           formatter="price"
           formatterOptions={{ currency: '$' }}
+          fontVariant={TABULAR_NUMS}
         >
           {item.price}
         </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/Txns.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/Txns.tsx
@@ -1,6 +1,7 @@
 import {
   NumberSizeableText,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -35,7 +36,11 @@ export function Txns({ transactions, walletInfo }: ITxnsProps) {
   return (
     <YStack gap="$0.5">
       {/* Total transactions */}
-      <NumberSizeableText size="$bodyMd" formatter="marketCap">
+      <NumberSizeableText
+        size="$bodyMd"
+        formatter="marketCap"
+        fontVariant={TABULAR_NUMS}
+      >
         {transactions === 0 ? '--' : transactions}
       </NumberSizeableText>
 
@@ -46,6 +51,7 @@ export function Txns({ transactions, walletInfo }: ITxnsProps) {
             size="$bodySm"
             color="$textSuccess"
             formatter="marketCap"
+            fontVariant={TABULAR_NUMS}
           >
             {walletInfo.buy}
           </NumberSizeableText>
@@ -56,6 +62,7 @@ export function Txns({ transactions, walletInfo }: ITxnsProps) {
             size="$bodySm"
             color="$textCritical"
             formatter="marketCap"
+            fontVariant={TABULAR_NUMS}
           >
             {walletInfo.sell}
           </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
@@ -8,6 +8,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useMedia,
@@ -100,7 +101,12 @@ function formatLightweightMarketValue(value: unknown) {
 
 function renderLightweightText(value: unknown) {
   return (
-    <SizableText size="$bodyMd" numberOfLines={1} ellipsizeMode="tail">
+    <SizableText
+      size="$bodyMd"
+      numberOfLines={1}
+      ellipsizeMode="tail"
+      fontVariant={TABULAR_NUMS}
+    >
       {formatLightweightMarketValue(value)}
     </SizableText>
   );
@@ -298,6 +304,7 @@ export const useColumnsDesktop = (
               size="$bodyMd"
               formatter={Number(text) > 1_000_000 ? 'marketCap' : 'price'}
               formatterOptions={{ currency: '$', capAtMaxT: true }}
+              fontVariant={TABULAR_NUMS}
             >
               {text}
             </NumberSizeableText>
@@ -339,6 +346,7 @@ export const useColumnsDesktop = (
               formatterOptions={{
                 showPlusMinusSigns,
               }}
+              fontVariant={TABULAR_NUMS}
             >
               {text}
             </NumberSizeableText>
@@ -366,6 +374,7 @@ export const useColumnsDesktop = (
                   size="$bodyMd"
                   formatter="marketCap"
                   formatterOptions={{ currency: '$', capAtMaxT: true }}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {value}
                 </NumberSizeableText>
@@ -397,6 +406,7 @@ export const useColumnsDesktop = (
                   size="$bodyMd"
                   formatter="marketCap"
                   formatterOptions={{ currency: '$' }}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {value}
                 </NumberSizeableText>
@@ -426,6 +436,7 @@ export const useColumnsDesktop = (
               formatterOptions={
                 useStockMetadataColumns ? undefined : { currency: '$' }
               }
+              fontVariant={TABULAR_NUMS}
             >
               {value}
             </NumberSizeableText>
@@ -462,7 +473,11 @@ export const useColumnsDesktop = (
             columnProps: { flex: 1 },
             render: (text: number, _record: IMarketToken, index?: number) =>
               shouldRenderRichCell(index) ? (
-                <NumberSizeableText size="$bodyMd" formatter="marketCap">
+                <NumberSizeableText
+                  size="$bodyMd"
+                  formatter="marketCap"
+                  fontVariant={TABULAR_NUMS}
+                >
                   {text === 0 ? '--' : text}
                 </NumberSizeableText>
               ) : (
@@ -478,7 +493,11 @@ export const useColumnsDesktop = (
             columnProps: { flex: 1 },
             render: (text: number, _record: IMarketToken, index?: number) =>
               shouldRenderRichCell(index) ? (
-                <NumberSizeableText size="$bodyMd" formatter="marketCap">
+                <NumberSizeableText
+                  size="$bodyMd"
+                  formatter="marketCap"
+                  fontVariant={TABULAR_NUMS}
+                >
                   {text === 0 ? '--' : text}
                 </NumberSizeableText>
               ) : (
@@ -510,7 +529,11 @@ export const useColumnsDesktop = (
                 { amount: ageInfo.amount },
               );
 
-              return <SizableText size="$bodyMd">{ageLabel}</SizableText>;
+              return (
+                <SizableText size="$bodyMd" fontVariant={TABULAR_NUMS}>
+                  {ageLabel}
+                </SizableText>
+              );
             },
             renderSkeleton: () => <Skeleton width={60} height={16} />,
           }

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsMobile.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsMobile.tsx
@@ -8,6 +8,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -97,6 +98,7 @@ export const useColumnsMobile = (
                           numberOfLines={1}
                           formatter="marketCap"
                           formatterOptions={{ currency: '$' }}
+                          fontVariant={TABULAR_NUMS}
                         >
                           {record.turnover}
                         </NumberSizeableText>
@@ -193,6 +195,7 @@ export const useColumnsMobile = (
                 formatterOptions={{
                   currency: '$',
                 }}
+                fontVariant={TABULAR_NUMS}
               >
                 {record.price}
               </NumberSizeableText>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/PriceChangeBadge.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/PriceChangeBadge.tsx
@@ -1,7 +1,12 @@
 import type { FC } from 'react';
 import { useMemo } from 'react';
 
-import { NumberSizeableText, SizableText, XStack } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+} from '@onekeyhq/components';
 
 interface IPriceChangeBadgeProps {
   change: number | string;
@@ -41,6 +46,7 @@ export const PriceChangeBadge: FC<IPriceChangeBadgeProps> = ({ change }) => {
           formatterOptions={{
             showPlusMinusSigns: true,
           }}
+          fontVariant={TABULAR_NUMS}
         >
           {change}
         </NumberSizeableText>

--- a/packages/kit/src/views/Market/components/Chart/PriceLabel.tsx
+++ b/packages/kit/src/views/Market/components/Chart/PriceLabel.tsx
@@ -2,6 +2,7 @@ import {
   NumberSizeableText,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
 } from '@onekeyhq/components';
 import type { IStackProps } from '@onekeyhq/components';
@@ -120,6 +121,7 @@ export function PriceLabel({
           size="$bodyMd"
           color="$textSubdued"
           $md={{ color: '$text' }}
+          fontVariant={TABULAR_NUMS}
         >
           {time}
         </SizableText>
@@ -153,6 +155,7 @@ export function PriceLabel({
           size="$bodyMd"
           formatter="price"
           formatterOptions={{ currency }}
+          fontVariant={TABULAR_NUMS}
         >
           {String(price)}
         </NumberSizeableText>

--- a/packages/kit/src/views/Market/components/MarketDetailPools.tsx
+++ b/packages/kit/src/views/Market/components/MarketDetailPools.tsx
@@ -8,6 +8,7 @@ import {
   NumberSizeableText,
   SizableText,
   Skeleton,
+  TABULAR_NUMS,
   Table,
   View,
   XStack,
@@ -386,6 +387,7 @@ export function MarketDetailPools({
                 formatter="price"
                 formatterOptions={{ currency }}
                 textAlign="right"
+                fontVariant={TABULAR_NUMS}
               >
                 {price}
               </NumberSizeableText>
@@ -414,6 +416,7 @@ export function MarketDetailPools({
                 formatterOptions={{ currency }}
                 formatter="marketCap"
                 textAlign="right"
+                fontVariant={TABULAR_NUMS}
               >
                 {txTotal}
               </NumberSizeableText>
@@ -441,6 +444,7 @@ export function MarketDetailPools({
             formatterOptions={{ currency }}
             formatter="marketCap"
             textAlign="right"
+            fontVariant={TABULAR_NUMS}
           >
             {volumeUsdH24}
           </NumberSizeableText>
@@ -467,6 +471,7 @@ export function MarketDetailPools({
             formatterOptions={{ currency }}
             formatter="marketCap"
             textAlign="right"
+            fontVariant={TABULAR_NUMS}
           >
             {reserveInUsd}
           </NumberSizeableText>
@@ -499,6 +504,7 @@ export function MarketDetailPools({
             formatter="price"
             formatterOptions={{ currency }}
             textAlign="right"
+            fontVariant={TABULAR_NUMS}
           >
             {price}
           </NumberSizeableText>
@@ -527,6 +533,7 @@ export function MarketDetailPools({
                   formatter="price"
                   formatterOptions={{ currency }}
                   textAlign="right"
+                  fontVariant={TABULAR_NUMS}
                 >
                   {price}
                 </NumberSizeableText>
@@ -558,6 +565,7 @@ export function MarketDetailPools({
                   formatter="price"
                   formatterOptions={{ currency }}
                   textAlign="right"
+                  fontVariant={TABULAR_NUMS}
                 >
                   {price}
                 </NumberSizeableText>
@@ -587,6 +595,7 @@ export function MarketDetailPools({
             formatter="marketCap"
             formatterOptions={{ currency }}
             textAlign="right"
+            fontVariant={TABULAR_NUMS}
           >
             {volumeUsdH24}
           </NumberSizeableText>

--- a/packages/kit/src/views/Market/components/MarketHomeList.tsx
+++ b/packages/kit/src/views/Market/components/MarketHomeList.tsx
@@ -19,6 +19,7 @@ import {
   Skeleton,
   Spinner,
   Stack,
+  TABULAR_NUMS,
   Table,
   View,
   XStack,
@@ -342,6 +343,7 @@ function MarketMdColumn({
             tokenName={item.name}
             tokenSymbol={item.symbol}
             lastUpdated={item.lastUpdated}
+            fontVariant={TABULAR_NUMS}
           />
         ) : (
           <NumberSizeableText
@@ -733,6 +735,7 @@ function BasicMarketHomeList({
                   tokenName={record.name}
                   tokenSymbol={record.symbol}
                   lastUpdated={record.lastUpdated}
+                  fontVariant={TABULAR_NUMS}
                 />
               ),
               renderSkeleton: () => <Skeleton w="$20" h="$3" />,

--- a/packages/kit/src/views/Market/components/MarketHomeList.tsx
+++ b/packages/kit/src/views/Market/components/MarketHomeList.tsx
@@ -327,6 +327,7 @@ function MarketMdColumn({
               formatter="marketCap"
               color="$textSubdued"
               formatterOptions={{ currency }}
+              fontVariant={TABULAR_NUMS}
             >
               {item.totalVolume}
             </NumberSizeableText>
@@ -353,6 +354,7 @@ function MarketMdColumn({
             size="$bodyLgMedium"
             formatter="marketCap"
             formatterOptions={{ currency }}
+            fontVariant={TABULAR_NUMS}
           >
             {item[mdColumnKeys[0]] as string}
           </NumberSizeableText>
@@ -378,6 +380,7 @@ function MarketMdColumn({
               formatterOptions={{
                 showPlusMinusSigns: true,
               }}
+              fontVariant={TABULAR_NUMS}
             >
               {item[mdColumnKeys[1]] as string}
             </NumberSizeableText>
@@ -664,6 +667,7 @@ function BasicMarketHomeList({
                   size="$bodyMd"
                   color="$textSubdued"
                   userSelect="none"
+                  fontVariant={TABULAR_NUMS}
                 >
                   {serialNumber ?? '-'}
                 </SizableText>
@@ -814,6 +818,7 @@ function BasicMarketHomeList({
                       size="$bodyMd"
                       formatter="marketCap"
                       formatterOptions={{ currency }}
+                      fontVariant={TABULAR_NUMS}
                     >
                       {totalVolume || '-'}
                     </NumberSizeableText>
@@ -838,6 +843,7 @@ function BasicMarketHomeList({
                       size="$bodyMd"
                       formatter="marketCap"
                       formatterOptions={{ currency }}
+                      fontVariant={TABULAR_NUMS}
                     >
                       {marketCap || '-'}
                     </NumberSizeableText>

--- a/packages/kit/src/views/Market/components/PriceChangePercentage.tsx
+++ b/packages/kit/src/views/Market/components/PriceChangePercentage.tsx
@@ -2,6 +2,7 @@ import {
   type INumberSizeableTextProps,
   NumberSizeableText,
   SizableText,
+  TABULAR_NUMS,
 } from '@onekeyhq/components';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
@@ -30,6 +31,7 @@ export function PriceChangePercentage({
       formatter="priceChange"
       color={color}
       formatterOptions={{ showPlusMinusSigns: true }}
+      fontVariant={TABULAR_NUMS}
       {...props}
     >
       {children}

--- a/packages/kit/src/views/Perp/components/FavoritesBar/FavoriteTokenItem.tsx
+++ b/packages/kit/src/views/Perp/components/FavoritesBar/FavoriteTokenItem.tsx
@@ -4,6 +4,7 @@ import {
   NumberSizeableText,
   SizableText,
   Skeleton,
+  TABULAR_NUMS,
   XStack,
 } from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
@@ -27,14 +28,11 @@ import {
   MAX_SIGNIFICANT_FIGURES,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 
-export const TABULAR_NUMS_STYLE = {
-  fontVariantNumeric: 'tabular-nums',
-} as const;
-
 /**
  * Calculate stable minWidth (in ch units) for formatted price strings to
  * prevent layout jitter caused by trailing-zero stripping in
  * formatPriceToSignificantDigits. With tabular-nums, 1ch equals one digit width.
+ * Callers must opt the text into `fontVariant={TABULAR_NUMS}` for this to hold.
  */
 export function getStablePriceMinWidth(priceStr: string): string | undefined {
   // ch units are CSS-only, not supported on React Native
@@ -118,7 +116,7 @@ const CtxPriceDisplay = memo(
         <NumberSizeableText
           size="$bodySmMedium"
           color={color}
-          style={TABULAR_NUMS_STYLE}
+          fontVariant={TABULAR_NUMS}
           formatter="priceChange"
           formatterOptions={{ showPlusMinusSigns: true }}
         >
@@ -132,7 +130,7 @@ const CtxPriceDisplay = memo(
       <SizableText
         size="$bodySmMedium"
         color={color}
-        style={TABULAR_NUMS_STYLE}
+        fontVariant={TABULAR_NUMS}
         minWidth={priceMinWidth}
         textAlign="right"
       >
@@ -189,7 +187,7 @@ const ActiveAssetPriceDisplay = memo(
         <NumberSizeableText
           size="$bodySmMedium"
           color={color}
-          style={TABULAR_NUMS_STYLE}
+          fontVariant={TABULAR_NUMS}
           formatter="priceChange"
           formatterOptions={{ showPlusMinusSigns: true }}
         >
@@ -203,7 +201,7 @@ const ActiveAssetPriceDisplay = memo(
       <SizableText
         size="$bodySmMedium"
         color={color}
-        style={TABULAR_NUMS_STYLE}
+        fontVariant={TABULAR_NUMS}
         minWidth={priceMinWidth}
         textAlign="right"
       >
@@ -226,14 +224,14 @@ export const PriceChangeDisplay = memo(
         <SizableText
           size="$bodySmMedium"
           color={color}
-          style={TABULAR_NUMS_STYLE}
+          fontVariant={TABULAR_NUMS}
         >
           {`${sign}${change.toFixed(2)}%`}
         </SizableText>
         <SizableText
           size="$bodySmMedium"
           color="$textSubdued"
-          style={TABULAR_NUMS_STYLE}
+          fontVariant={TABULAR_NUMS}
           minWidth={priceMinWidth}
           textAlign="right"
         >

--- a/packages/kit/src/views/Perp/components/MarketDetail/PerpMarketDetailContent.tsx
+++ b/packages/kit/src/views/Perp/components/MarketDetail/PerpMarketDetailContent.tsx
@@ -15,6 +15,7 @@ import {
   SizableText,
   Spinner,
   Stack,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
   YStack,
@@ -225,7 +226,9 @@ function DetailStatItem({ label, value }: { label: string; value: string }) {
       <SizableText size="$bodySm" color="$textSubdued">
         {label}
       </SizableText>
-      <SizableText size="$bodyMdMedium">{value}</SizableText>
+      <SizableText size="$bodyMdMedium" fontVariant={TABULAR_NUMS}>
+        {value}
+      </SizableText>
     </YStack>
   );
 }
@@ -316,6 +319,7 @@ function DetailInfoTable({
               size="$bodyMdMedium"
               textAlign="right"
               numberOfLines={1}
+              fontVariant={TABULAR_NUMS}
             >
               {item.value}
             </SizableText>
@@ -326,6 +330,7 @@ function DetailInfoTable({
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 textAlign="right"
+                fontVariant={TABULAR_NUMS}
               >
                 {item.secondaryValue}
               </SizableText>

--- a/packages/kit/src/views/Perp/components/OrderBook/AnimatedDepthBlock.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/AnimatedDepthBlock.tsx
@@ -3,6 +3,8 @@ import { useMemo } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useReducedMotion } from 'react-native-reanimated';
 
+import { TABULAR_NUMS } from '@onekeyhq/components';
+
 import {
   ORDER_BOOK_DEPTH_WIDTH_TRANSITION_MS,
   ORDER_BOOK_SIDE_RATIO_TRANSITION_MS,
@@ -181,6 +183,7 @@ export function DepthBarColumn({
                     fontSize: priceFontSize,
                     flexShrink: 1,
                     paddingRight: 4,
+                    fontVariant: TABULAR_NUMS,
                   }}
                 >
                   {priceText}
@@ -192,6 +195,7 @@ export function DepthBarColumn({
                     fontSize: sizeFontSize,
                     flexShrink: 1,
                     textAlign: 'right',
+                    fontVariant: TABULAR_NUMS,
                   }}
                 >
                   {sizeText}

--- a/packages/kit/src/views/Perp/components/OrderBook/DefaultLoadingNode.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/DefaultLoadingNode.tsx
@@ -4,6 +4,7 @@ import {
   SizableText,
   Spinner,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -36,7 +37,7 @@ function MobileVerticalEmptyRow({
         fontSize={11}
         lineHeight={14}
         fontFamily="$monoRegular"
-        fontVariant={['tabular-nums']}
+        fontVariant={TABULAR_NUMS}
         color={priceColor}
       >
         --
@@ -45,7 +46,7 @@ function MobileVerticalEmptyRow({
         fontSize={11}
         lineHeight={14}
         fontFamily="$monoRegular"
-        fontVariant={['tabular-nums']}
+        fontVariant={TABULAR_NUMS}
         color="$textSubdued"
       >
         --
@@ -62,7 +63,7 @@ function MobileHorizontalEmptyRow() {
           fontSize={12}
           lineHeight={16}
           fontFamily="$monoRegular"
-          fontVariant={['tabular-nums']}
+          fontVariant={TABULAR_NUMS}
           color="$textSubdued"
         >
           --
@@ -71,7 +72,7 @@ function MobileHorizontalEmptyRow() {
           fontSize={12}
           lineHeight={16}
           fontFamily="$monoRegular"
-          fontVariant={['tabular-nums']}
+          fontVariant={TABULAR_NUMS}
           color="$bgAccent"
         >
           --
@@ -82,7 +83,7 @@ function MobileHorizontalEmptyRow() {
           fontSize={12}
           lineHeight={16}
           fontFamily="$monoRegular"
-          fontVariant={['tabular-nums']}
+          fontVariant={TABULAR_NUMS}
           color="$bgCriticalStrong"
         >
           --
@@ -91,7 +92,7 @@ function MobileHorizontalEmptyRow() {
           fontSize={12}
           lineHeight={16}
           fontFamily="$monoRegular"
-          fontVariant={['tabular-nums']}
+          fontVariant={TABULAR_NUMS}
           color="$textSubdued"
         >
           --
@@ -204,7 +205,7 @@ export function DefaultLoadingNode({
               lineHeight={24}
               fontWeight="600"
               fontFamily="$monoRegular"
-              fontVariant={['tabular-nums']}
+              fontVariant={TABULAR_NUMS}
               color="$text"
             >
               {midPriceDisplay}
@@ -213,7 +214,7 @@ export function DefaultLoadingNode({
               fontSize={10}
               lineHeight={14}
               fontFamily="$monoRegular"
-              fontVariant={['tabular-nums']}
+              fontVariant={TABULAR_NUMS}
               color="$textSubdued"
             >
               --

--- a/packages/kit/src/views/Perp/components/OrderBook/defaultAggregationBtn.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/defaultAggregationBtn.tsx
@@ -1,5 +1,7 @@
 import { StyleSheet, Text, TouchableOpacity } from 'react-native';
 
+import { TABULAR_NUMS } from '@onekeyhq/components';
+
 import type { IAggregationBtn } from './types';
 
 const styles = StyleSheet.create({
@@ -21,6 +23,7 @@ const styles = StyleSheet.create({
     color: 'rgba(255,255,255,0.4)',
     fontSize: 11,
     fontWeight: '600',
+    fontVariant: TABULAR_NUMS,
   },
   btnLabelSelected: {
     color: 'rgba(255,255,255,0.7)',

--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -330,6 +330,13 @@ const styles = StyleSheet.create({
     fontSize: 12,
     lineHeight: 16,
   },
+  // `bodySm` also carries plain labels (the "Spread" caption), which stay
+  // proportional; numeric spread / tick-size values opt in via this variant.
+  bodySmTabular: {
+    fontSize: 12,
+    lineHeight: 16,
+    fontVariant: TABULAR_NUMS,
+  },
   bodySmMedium: {
     fontSize: 12,
     lineHeight: 16,
@@ -944,7 +951,10 @@ export function OrderBook({
                       <PerpBookText
                         numberOfLines={1}
                         ellipsizeMode="tail"
-                        style={[styles.bodySm, { color: textColor.text }]}
+                        style={[
+                          styles.bodySmTabular,
+                          { color: textColor.text },
+                        ]}
                       >
                         {selectedTickOption?.label
                           ? new BigNumber(selectedTickOption.label).toFixed(
@@ -1242,7 +1252,10 @@ export function OrderBook({
                       <PerpBookText
                         numberOfLines={1}
                         ellipsizeMode="tail"
-                        style={[styles.bodySm, { color: textColor.text }]}
+                        style={[
+                          styles.bodySmTabular,
+                          { color: textColor.text },
+                        ]}
                       >
                         {selectedTickOption?.label
                           ? new BigNumber(selectedTickOption.label).toFixed(
@@ -1259,7 +1272,9 @@ export function OrderBook({
                   )}
                 />
               ) : null}
-              <PerpBookText style={[styles.bodySm, { color: textColor.text }]}>
+              <PerpBookText
+                style={[styles.bodySmTabular, { color: textColor.text }]}
+              >
                 {spreadPercentage}
               </PerpBookText>
             </View>
@@ -1480,12 +1495,12 @@ export function OrderPairBook({
                 })}
               </PerpBookText>
               <PerpBookText
-                style={[styles.bodySm, { color: textColor.textSubdued }]}
+                style={[styles.bodySmTabular, { color: textColor.textSubdued }]}
               >
                 {midPrice}
               </PerpBookText>
               <PerpBookText
-                style={[styles.bodySm, { color: textColor.textSubdued }]}
+                style={[styles.bodySmTabular, { color: textColor.textSubdued }]}
               >
                 {spreadPercentage}
               </PerpBookText>
@@ -2118,7 +2133,7 @@ export function OrderBookMobile({
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 style={[
-                  styles.bodySm,
+                  styles.bodySmTabular,
                   {
                     color: textColor.text,
                     fontSize: 11,

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/AccountRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/AccountRow.tsx
@@ -14,6 +14,8 @@ import type { IUserNonFundingLedgerUpdate } from '@onekeyhq/shared/types/hyperli
 
 import { calcCellAlign, getColumnStyle } from '../utils';
 
+import { PerpTableCellText } from './PerpTableCellText';
+
 import type { IColumnConfig } from '../List/CommonTableListView';
 import type { IntlShape } from 'react-intl';
 
@@ -375,18 +377,18 @@ const AccountRow = memo(
           <YStack flex={1} gap="$1">
             <XStack justifyContent="space-between" alignItems="center">
               <SizableText size="$bodyMdMedium">{typeConfig.text}</SizableText>
-              <SizableText size="$bodyMdMedium" color={textColor}>
+              <PerpTableCellText size="$bodyMdMedium" color={textColor}>
                 {signPrefix}
                 {numberFormat(totalAmount, balanceFormatter)}
-              </SizableText>
+              </PerpTableCellText>
             </XStack>
             <XStack justifyContent="space-between" alignItems="center">
               <SizableText size="$bodySm" color={statusInfo.color}>
                 {statusInfo.text}
               </SizableText>
-              <SizableText size="$bodySm" color="$textSubdued">
+              <PerpTableCellText size="$bodySm" color="$textSubdued">
                 {dateInfo.date} {dateInfo.time}
-              </SizableText>
+              </PerpTableCellText>
             </XStack>
           </YStack>
         </ListItem>
@@ -412,17 +414,21 @@ const AccountRow = memo(
           justifyContent="center"
           alignItems={calcCellAlign(columnConfigs[0].align)}
         >
-          <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+          <PerpTableCellText
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            size="$bodySm"
+          >
             {dateInfo.date}
-          </SizableText>
-          <SizableText
+          </PerpTableCellText>
+          <PerpTableCellText
             numberOfLines={1}
             ellipsizeMode="tail"
             size="$bodySm"
             color="$textSubdued"
           >
             {dateInfo.time}
-          </SizableText>
+          </PerpTableCellText>
         </YStack>
 
         {/* Status */}
@@ -458,7 +464,7 @@ const AccountRow = memo(
           justifyContent={calcCellAlign(columnConfigs[3].align)}
           alignItems="center"
         >
-          <SizableText
+          <PerpTableCellText
             numberOfLines={1}
             ellipsizeMode="tail"
             size="$bodySm"
@@ -466,7 +472,7 @@ const AccountRow = memo(
           >
             {signPrefix}
             {numberFormat(amount, balanceFormatter)}
-          </SizableText>
+          </PerpTableCellText>
         </XStack>
 
         {/* Fee */}
@@ -475,7 +481,7 @@ const AccountRow = memo(
           justifyContent={calcCellAlign(columnConfigs[4].align)}
           alignItems="center"
         >
-          <SizableText
+          <PerpTableCellText
             numberOfLines={1}
             ellipsizeMode="tail"
             size="$bodySm"
@@ -484,7 +490,7 @@ const AccountRow = memo(
             {fee && Number(fee) !== 0
               ? numberFormat(fee, balanceFormatter)
               : '-'}
-          </SizableText>
+          </PerpTableCellText>
         </XStack>
       </XStack>
     );

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/BalanceRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/BalanceRow.tsx
@@ -27,6 +27,8 @@ import {
   getColumnStyle,
 } from '../utils';
 
+import { PerpTableCellText } from './PerpTableCellText';
+
 import type { IColumnConfig } from '../List/CommonTableListView';
 import type { IBalanceDisplayItem } from '../List/SpotBalanceList';
 
@@ -209,9 +211,13 @@ function BalanceRowMobile({ item, onChangeAsset }: IBalanceRowProps) {
                 />
               ) : null}
             </XStack>
-            <SizableText size="$bodySm" color="$textSubdued" numberOfLines={1}>
+            <PerpTableCellText
+              size="$bodySm"
+              color="$textSubdued"
+              numberOfLines={1}
+            >
               {balanceText}
-            </SizableText>
+            </PerpTableCellText>
           </YStack>
         </XStack>
         <YStack flexShrink={0} alignItems="flex-end" gap="$0.5">
@@ -226,14 +232,14 @@ function BalanceRowMobile({ item, onChangeAsset }: IBalanceRowProps) {
           </NumberSizeableText>
           {pnlText ? (
             <XStack gap="$1" alignItems="center" justifyContent="flex-end">
-              <SizableText
+              <PerpTableCellText
                 size="$bodySm"
                 color={pnlColor}
                 numberOfLines={1}
                 textAlign="right"
               >
                 {pnlText}
-              </SizableText>
+              </PerpTableCellText>
               {canShare ? (
                 <IconButton
                   testID={PerpTestIDs.BalanceRowShareButton}
@@ -322,9 +328,13 @@ function BalanceRowDesktop({
     if (cell.key === 'pnl') {
       return (
         <XStack minWidth={0} alignItems="center" gap="$1">
-          <SizableText size="$bodySmMedium" color={pnlColor} numberOfLines={1}>
+          <PerpTableCellText
+            size="$bodySmMedium"
+            color={pnlColor}
+            numberOfLines={1}
+          >
             {cell.cellValue}
-          </SizableText>
+          </PerpTableCellText>
           {canShare ? (
             <IconButton
               testID={PerpTestIDs.BalanceRowShareButton}
@@ -345,12 +355,12 @@ function BalanceRowDesktop({
     }
 
     return (
-      <SizableText
+      <PerpTableCellText
         size="$bodySmMedium"
         color={cell.key === 'pnl' ? pnlColor : undefined}
       >
         {cell.cellValue}
-      </SizableText>
+      </PerpTableCellText>
     );
   };
 

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/MobileTwapOpenOrdersRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/MobileTwapOpenOrdersRow.tsx
@@ -22,6 +22,8 @@ import { getValidPriceDecimals } from '@onekeyhq/shared/src/utils/perpsUtils';
 import { PerpTestIDs } from '../../../testIDs';
 import { getOrderAssetDisplayName } from '../utils';
 
+import { PerpTableCellText } from './PerpTableCellText';
+
 const balanceFormatter: INumberFormatProps = {
   formatter: 'balance',
 };
@@ -66,7 +68,7 @@ function MobileTwapInfoRow({ label, value }: { label: string; value: string }) {
   return (
     <XStack width="100%" alignItems="center" justifyContent="space-between">
       <SizableText size="$bodySm">{label}</SizableText>
-      <SizableText
+      <PerpTableCellText
         size="$bodySm"
         numberOfLines={1}
         ellipsizeMode="tail"
@@ -74,7 +76,7 @@ function MobileTwapInfoRow({ label, value }: { label: string; value: string }) {
         maxWidth="60%"
       >
         {value}
-      </SizableText>
+      </PerpTableCellText>
     </XStack>
   );
 }
@@ -201,14 +203,14 @@ const MobileTwapOpenOrdersRow = memo(
                   id: ETranslations.perp_twap_order__title,
                 })} / ${sideText}`}
               </SizableText>
-              <SizableText
+              <PerpTableCellText
                 size="$bodySm"
                 color="$textSubdued"
                 numberOfLines={1}
                 ellipsizeMode="tail"
               >
                 {dateInfo.date} {dateInfo.time}
-              </SizableText>
+              </PerpTableCellText>
             </XStack>
           </YStack>
           <Button

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/OpenOrdersRow.tsx
@@ -30,6 +30,8 @@ import {
   getOrderAssetDisplayName,
 } from '../utils';
 
+import { PerpTableCellText } from './PerpTableCellText';
+
 import type { IColumnConfig, IRenderMode } from '../List/CommonTableListView';
 
 const balanceFormatter: INumberFormatProps = {
@@ -273,14 +275,14 @@ const OpenOrdersRow = memo(
                 >
                   {`${assetInfo.orderType} / ${assetInfo.type}`}
                 </SizableText>
-                <SizableText
+                <PerpTableCellText
                   numberOfLines={1}
                   ellipsizeMode="tail"
                   size="$bodySm"
                   color="$textSubdued"
                 >
                   {`${dateInfo.date} ${dateInfo.time}`}
-                </SizableText>
+                </PerpTableCellText>
               </XStack>
             </YStack>
             <Button
@@ -307,9 +309,9 @@ const OpenOrdersRow = memo(
                 id: ETranslations.perp_position_mobile_fill,
               })}
             </SizableText>
-            <SizableText size="$bodySm">
+            <PerpTableCellText size="$bodySm">
               {`${orderBaseInfo.sizeFormatted} / ${orderBaseInfo.origSizeFormatted}`}
-            </SizableText>
+            </PerpTableCellText>
           </XStack>
           <XStack
             width="100%"
@@ -321,13 +323,17 @@ const OpenOrdersRow = memo(
                 id: ETranslations.perp_orderbook_price,
               })}
             </SizableText>
-            <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+            <PerpTableCellText
+              numberOfLines={1}
+              ellipsizeMode="tail"
+              size="$bodySm"
+            >
               {order.orderType.includes('Market')
                 ? intl.formatMessage({
                     id: ETranslations.perp_position_market,
                   })
                 : orderBaseInfo.executePriceLimitFormatted}
-            </SizableText>
+            </PerpTableCellText>
           </XStack>
           <XStack
             width="100%"
@@ -353,9 +359,13 @@ const OpenOrdersRow = memo(
                 id: ETranslations.perp_open_orders_trigger_condition,
               })}
             </SizableText>
-            <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+            <PerpTableCellText
+              numberOfLines={1}
+              ellipsizeMode="tail"
+              size="$bodySm"
+            >
               {orderBaseInfo.triggerCondition}
-            </SizableText>
+            </PerpTableCellText>
           </XStack>
           <XStack
             width="100%"
@@ -367,9 +377,13 @@ const OpenOrdersRow = memo(
                 id: ETranslations.perp_position_tp_sl,
               })}
             </SizableText>
-            <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+            <PerpTableCellText
+              numberOfLines={1}
+              ellipsizeMode="tail"
+              size="$bodySm"
+            >
               {tpslInfo.tpsl}
-            </SizableText>
+            </PerpTableCellText>
           </XStack>
         </ListItem>
       );
@@ -395,21 +409,21 @@ const OpenOrdersRow = memo(
               justifyContent="center"
               alignItems={calcCellAlign(columnConfigs[0].align)}
             >
-              <SizableText
+              <PerpTableCellText
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
               >
                 {dateInfo.date}
-              </SizableText>
-              <SizableText
+              </PerpTableCellText>
+              <PerpTableCellText
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
                 color="$textSubdued"
               >
                 {dateInfo.time}
-              </SizableText>
+              </PerpTableCellText>
             </YStack>
             {/* Asset symbol */}
             <YStack
@@ -459,13 +473,13 @@ const OpenOrdersRow = memo(
               justifyContent={calcCellAlign(columnConfigs[3].align)}
               alignItems="center"
             >
-              <SizableText
+              <PerpTableCellText
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
               >
                 {orderBaseInfo.sizeFormatted}
-              </SizableText>
+              </PerpTableCellText>
             </XStack>
 
             {/* Original size */}
@@ -474,13 +488,13 @@ const OpenOrdersRow = memo(
               justifyContent={calcCellAlign(columnConfigs[4].align)}
               alignItems="center"
             >
-              <SizableText
+              <PerpTableCellText
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
               >
                 {orderBaseInfo.origSizeFormatted}
-              </SizableText>
+              </PerpTableCellText>
             </XStack>
 
             {/* value */}
@@ -489,13 +503,13 @@ const OpenOrdersRow = memo(
               justifyContent={calcCellAlign(columnConfigs[5].align)}
               alignItems="center"
             >
-              <SizableText
+              <PerpTableCellText
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
               >
                 {orderBaseInfo.valueFormatted}
-              </SizableText>
+              </PerpTableCellText>
             </XStack>
 
             {/* Execute price */}
@@ -504,7 +518,7 @@ const OpenOrdersRow = memo(
               justifyContent={calcCellAlign(columnConfigs[6].align)}
               alignItems="center"
             >
-              <SizableText
+              <PerpTableCellText
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
@@ -514,7 +528,7 @@ const OpenOrdersRow = memo(
                       id: ETranslations.perp_position_market,
                     })
                   : orderBaseInfo.executePriceLimitFormatted}
-              </SizableText>
+              </PerpTableCellText>
             </XStack>
             {/* Reduce Only */}
             <XStack
@@ -536,13 +550,13 @@ const OpenOrdersRow = memo(
               justifyContent={calcCellAlign(columnConfigs[8].align)}
               alignItems="center"
             >
-              <SizableText
+              <PerpTableCellText
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
               >
                 {orderBaseInfo.triggerCondition}
-              </SizableText>
+              </PerpTableCellText>
             </XStack>
             {/* TPSL */}
             <XStack
@@ -550,13 +564,13 @@ const OpenOrdersRow = memo(
               justifyContent={calcCellAlign(columnConfigs[9].align)}
               alignItems="center"
             >
-              <SizableText
+              <PerpTableCellText
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
               >
                 {tpslInfo.tpsl}
-              </SizableText>
+              </PerpTableCellText>
             </XStack>
           </>
         ) : null}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpTableCellText.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpTableCellText.tsx
@@ -1,5 +1,4 @@
 import { SizableText, TABULAR_NUMS } from '@onekeyhq/components';
-
 import type { ISizableTextProps } from '@onekeyhq/components';
 
 /**

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpTableCellText.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpTableCellText.tsx
@@ -1,0 +1,18 @@
+import { SizableText, TABULAR_NUMS } from '@onekeyhq/components';
+
+import type { ISizableTextProps } from '@onekeyhq/components';
+
+/**
+ * A NUMERIC data cell in the perps tables (positions / open orders / trades /
+ * TWAP / account history / balances).
+ *
+ * Text is proportional by default app-wide. These cells are the opposite case:
+ * small numbers stacked in a column that tick, so they need tabular (equal-width)
+ * figures — otherwise a digit change reflows the cell and the column jitters.
+ *
+ * Use this for VALUES only. Column headers, coin symbols and other labels are
+ * words, and stay proportional (plain `SizableText`).
+ */
+export function PerpTableCellText(props: ISizableTextProps) {
+  return <SizableText fontVariant={TABULAR_NUMS} {...props} />;
+}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -42,6 +42,7 @@ import { showSetTpslDialog } from '../SetTpslModal';
 import { calcCellAlign, getColumnStyle } from '../utils';
 
 import { DesktopActionIconButton } from './DesktopActionIconButton';
+import { PerpTableCellText } from './PerpTableCellText';
 
 import type { IColumnConfig, IRenderMode } from '../List/CommonTableListView';
 
@@ -107,11 +108,15 @@ function MarkPrice({ coin }: { coin: string }) {
   return useMemo(
     () => (
       <DebugRenderTracker position="bottom-right" name="MarkPrice" offsetY={10}>
-        <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+        <PerpTableCellText
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          size="$bodySm"
+        >
           {midFormattedByDecimals
             ? formatLocalizedNumberString(midFormattedByDecimals)
             : midFormattedByDecimals}
-        </SizableText>
+        </PerpTableCellText>
       </DebugRenderTracker>
     ),
     [midFormattedByDecimals],
@@ -198,17 +203,21 @@ const PositionRowDesktopPositionSize = memo(
           justifyContent="center"
           alignItems={calcCellAlign(columnConfig.align)}
         >
-          <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+          <PerpTableCellText
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            size="$bodySm"
+          >
             {`${sizeInfo.sizeAbsFormatted}`}
-          </SizableText>
-          <SizableText
+          </PerpTableCellText>
+          <PerpTableCellText
             numberOfLines={1}
             ellipsizeMode="tail"
             size="$bodySm"
             color="$textSubdued"
           >
             {`${sizeInfo.sizeValue}`}
-          </SizableText>
+          </PerpTableCellText>
         </YStack>
       </DebugRenderTracker>
     );
@@ -234,9 +243,13 @@ const PositionRowDesktopEntryPrice = memo(
           justifyContent={calcCellAlign(columnConfig.align)}
           alignItems="center"
         >
-          <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+          <PerpTableCellText
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            size="$bodySm"
+          >
             {priceInfo.entryPriceFormatted}
-          </SizableText>
+          </PerpTableCellText>
         </XStack>
       </DebugRenderTracker>
     );
@@ -258,11 +271,15 @@ const PositionRowDesktopMarkPrice = memo(
           name="MarkPrice"
           offsetY={10}
         >
-          <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+          <PerpTableCellText
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            size="$bodySm"
+          >
             {midFormattedByDecimals
               ? formatLocalizedNumberString(midFormattedByDecimals)
               : midFormattedByDecimals}
-          </SizableText>
+          </PerpTableCellText>
         </DebugRenderTracker>
       </XStack>
     );
@@ -288,9 +305,13 @@ const PositionRowDesktopLiqPrice = memo(
           justifyContent={calcCellAlign(columnConfig.align)}
           alignItems="center"
         >
-          <SizableText numberOfLines={1} ellipsizeMode="tail" size="$bodySm">
+          <PerpTableCellText
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            size="$bodySm"
+          >
             {priceInfo.liquidationPriceFormatted}
-          </SizableText>
+          </PerpTableCellText>
         </XStack>
       </DebugRenderTracker>
     );
@@ -316,14 +337,14 @@ const PositionRowDesktopPnL = memo(
           alignItems="center"
           gap="$1"
         >
-          <SizableText
+          <PerpTableCellText
             size="$bodySm"
             color={otherInfo.pnlColor}
             numberOfLines={1}
             ellipsizeMode="tail"
           >
             {`${otherInfo.pnlPlusOrMinus}${otherInfo.unrealizedPnl}(${otherInfo.pnlPlusOrMinus}${otherInfo.roiPercent}%)`}
-          </SizableText>
+          </PerpTableCellText>
           <DesktopActionIconButton
             testID="perp-position-row-desktop-pn-l-icon-btn"
             icon="ShareOutline"
@@ -361,11 +382,11 @@ const PositionRowDesktopMargin = memo(
           alignItems="center"
         >
           <XStack alignItems="center" gap="$1">
-            <SizableText
+            <PerpTableCellText
               numberOfLines={1}
               ellipsizeMode="tail"
               size="$bodySm"
-            >{`${otherInfo.marginUsedFormatted}`}</SizableText>
+            >{`${otherInfo.marginUsedFormatted}`}</PerpTableCellText>
             {isIsolatedMode ? (
               <DesktopActionIconButton
                 testID="perp-position-row-desktop-margin-icon-btn"
@@ -405,12 +426,12 @@ const PositionRowDesktopFunding = memo(
         >
           <Tooltip
             renderTrigger={
-              <SizableText
+              <PerpTableCellText
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
                 color={otherInfo.fundingSinceOpenColor}
-              >{`${otherInfo.fundingSinceOpenPlusOrMinus}$${otherInfo.fundingSinceOpenFormatted}`}</SizableText>
+              >{`${otherInfo.fundingSinceOpenPlusOrMinus}$${otherInfo.fundingSinceOpenFormatted}`}</PerpTableCellText>
             }
             renderContent={
               <YStack gap="$2">
@@ -424,12 +445,12 @@ const PositionRowDesktopFunding = memo(
                     )}
                     {': '}
                   </SizableText>
-                  <SizableText
+                  <PerpTableCellText
                     size="$bodySm"
                     color={otherInfo.fundingAllTimeColor}
                   >
                     {`${otherInfo.fundingSinceOpenPlusOrMinus}$${otherInfo.fundingSinceOpenFormatted}`}{' '}
-                  </SizableText>
+                  </PerpTableCellText>
                 </XStack>
                 <XStack>
                   <SizableText size="$bodySm">
@@ -441,12 +462,12 @@ const PositionRowDesktopFunding = memo(
                     )}
                     {': '}
                   </SizableText>
-                  <SizableText
+                  <PerpTableCellText
                     size="$bodySm"
                     color={otherInfo.fundingAllTimeColor}
                   >
                     {`${otherInfo.fundingAllPlusOrMinus}$${otherInfo.fundingAllTimeFormatted}`}{' '}
-                  </SizableText>
+                  </PerpTableCellText>
                 </XStack>
                 <XStack>
                   <SizableText size="$bodySm">
@@ -455,12 +476,12 @@ const PositionRowDesktopFunding = memo(
                     })}
                     {': '}
                   </SizableText>
-                  <SizableText
+                  <PerpTableCellText
                     size="$bodySm"
                     color={otherInfo.fundingSinceChangeColor}
                   >
                     {`${otherInfo.fundingSinceChangePlusOrMinus}$${otherInfo.fundingSinceChangeFormatted}`}
-                  </SizableText>
+                  </PerpTableCellText>
                 </XStack>
               </YStack>
             }
@@ -559,13 +580,13 @@ const PositionRowDesktopTPSL = memo(
               cursor="default"
               onPress={onSetTpsl}
             >
-              <SizableText
+              <PerpTableCellText
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySmMedium"
               >
                 {tpslInfo.tpsl}
-              </SizableText>
+              </PerpTableCellText>
               <DesktopActionIconButton
                 testID="perp-icon-btn"
                 icon="HighlightOutline"
@@ -845,7 +866,7 @@ const PositionRowMobilePnLAndROE = memo(
               id: ETranslations.perp_position_pnl_mobile,
             })}
           </SizableText>
-          <SizableText
+          <PerpTableCellText
             size="$bodyLgMedium"
             color={otherInfo.pnlColor}
             flexShrink={1}
@@ -855,7 +876,7 @@ const PositionRowMobilePnLAndROE = memo(
             minimumFontScale={0.7}
           >
             {`${otherInfo.pnlPlusOrMinus}${otherInfo.unrealizedPnl}`}
-          </SizableText>
+          </PerpTableCellText>
         </YStack>
         <YStack
           gap="$1"
@@ -869,7 +890,7 @@ const PositionRowMobilePnLAndROE = memo(
               id: ETranslations.perp_share_roe,
             })}
           </SizableText>
-          <SizableText
+          <PerpTableCellText
             size="$bodyLgMedium"
             color={otherInfo.pnlColor}
             flexShrink={1}
@@ -879,7 +900,7 @@ const PositionRowMobilePnLAndROE = memo(
             minimumFontScale={0.7}
           >
             {`${otherInfo.pnlPlusOrMinus}${otherInfo.roiPercent}%`}
-          </SizableText>
+          </PerpTableCellText>
         </YStack>
       </XStack>
     );
@@ -928,7 +949,7 @@ const PositionRowMobilePositionSize = memo(
           <Icon name="RepeatOutline" size="$3" color="$textSubdued" />
         </XStack>
         <XStack alignItems="center" gap="$1">
-          <SizableText
+          <PerpTableCellText
             size="$bodyMdMedium"
             flexShrink={1}
             minWidth={0}
@@ -939,7 +960,7 @@ const PositionRowMobilePositionSize = memo(
             {isSizeViewChange
               ? `$${sizeInfo.sizeValue}`
               : sizeInfo.sizeAbsFormatted}
-          </SizableText>
+          </PerpTableCellText>
         </XStack>
       </YStack>
     );
@@ -974,7 +995,7 @@ const PositionRowMobileMargin = memo(
           })}
         </SizableText>
         <XStack alignItems="center" gap="$1">
-          <SizableText
+          <PerpTableCellText
             size="$bodyMdMedium"
             flexShrink={1}
             minWidth={0}
@@ -983,7 +1004,7 @@ const PositionRowMobileMargin = memo(
             minimumFontScale={0.7}
           >
             {`${otherInfo.marginUsedFormatted}`}
-          </SizableText>
+          </PerpTableCellText>
           {isIsolatedMode ? (
             <IconButton
               testID="perp-intl-icon-btn"
@@ -1020,7 +1041,7 @@ const PositionRowMobileEntryPrice = memo(
             id: ETranslations.perp_position_entry_price,
           })}
         </SizableText>
-        <SizableText
+        <PerpTableCellText
           size="$bodyMdMedium"
           flexShrink={1}
           minWidth={0}
@@ -1029,7 +1050,7 @@ const PositionRowMobileEntryPrice = memo(
           minimumFontScale={0.7}
         >
           {priceInfo.entryPriceFormatted}
-        </SizableText>
+        </PerpTableCellText>
       </YStack>
     );
   },
@@ -1081,12 +1102,12 @@ const PositionRowMobileFunding = memo(
                       id: ETranslations.perp_position_funding_since_open,
                     })}
                   </SizableText>
-                  <SizableText
+                  <PerpTableCellText
                     size="$bodyMdMedium"
                     color={otherInfo.fundingSinceOpenColor}
                   >
                     {`${otherInfo.fundingSinceOpenPlusOrMinus}$${otherInfo.fundingSinceOpenFormatted}`}
-                  </SizableText>
+                  </PerpTableCellText>
                 </YStack>
 
                 <YStack w="50%">
@@ -1095,12 +1116,12 @@ const PositionRowMobileFunding = memo(
                       id: ETranslations.perp_position_funding_since_change,
                     })}
                   </SizableText>
-                  <SizableText
+                  <PerpTableCellText
                     size="$bodyMdMedium"
                     color={otherInfo.fundingSinceChangeColor}
                   >
                     {`${otherInfo.fundingSinceChangePlusOrMinus}$${otherInfo.fundingSinceChangeFormatted}`}
-                  </SizableText>
+                  </PerpTableCellText>
                 </YStack>
               </XStack>
               <XStack alignItems="center" justifyContent="space-between">
@@ -1113,12 +1134,12 @@ const PositionRowMobileFunding = memo(
                       { token: assetInfo.assetSymbol },
                     )}
                   </SizableText>
-                  <SizableText
+                  <PerpTableCellText
                     size="$bodyMdMedium"
                     color={otherInfo.fundingAllTimeColor}
                   >
                     {`${otherInfo.fundingAllPlusOrMinus}$${otherInfo.fundingAllTimeFormatted}`}
-                  </SizableText>
+                  </PerpTableCellText>
                 </YStack>
               </XStack>
               <Divider />
@@ -1143,7 +1164,7 @@ const PositionRowMobileFunding = memo(
           }
         />
 
-        <SizableText
+        <PerpTableCellText
           size="$bodyMdMedium"
           color={otherInfo.fundingSinceOpenColor}
           flexShrink={1}
@@ -1153,7 +1174,7 @@ const PositionRowMobileFunding = memo(
           minimumFontScale={0.7}
         >
           {`${otherInfo.fundingSinceOpenPlusOrMinus}$${otherInfo.fundingSinceOpenFormatted}`}
-        </SizableText>
+        </PerpTableCellText>
       </YStack>
     );
   },
@@ -1202,7 +1223,7 @@ const PositionRowMobileTPSL = memo(({ coin }: { coin: string }) => {
           id: ETranslations.perp_position_tp_sl,
         })}
       </SizableText>
-      <SizableText
+      <PerpTableCellText
         size="$bodyMdMedium"
         flexShrink={1}
         minWidth={0}
@@ -1211,7 +1232,7 @@ const PositionRowMobileTPSL = memo(({ coin }: { coin: string }) => {
         minimumFontScale={0.7}
       >
         {tpslInfo.tpsl}
-      </SizableText>
+      </PerpTableCellText>
     </YStack>
   );
 });
@@ -1238,7 +1259,7 @@ const PositionRowMobileMarkPrice = memo(({ coin }: { coin: string }) => {
           id: ETranslations.perp_position_mark_price,
         })}
       </SizableText>
-      <SizableText
+      <PerpTableCellText
         size="$bodyMdMedium"
         flexShrink={1}
         minWidth={0}
@@ -1247,7 +1268,7 @@ const PositionRowMobileMarkPrice = memo(({ coin }: { coin: string }) => {
         minimumFontScale={0.7}
       >
         {formatLocalizedNumberString(midFormattedByDecimals || '--')}
-      </SizableText>
+      </PerpTableCellText>
     </YStack>
   );
 });
@@ -1270,7 +1291,7 @@ const PositionRowMobileLiqPrice = memo(
             id: ETranslations.perp_position_liq_price,
           })}
         </SizableText>
-        <SizableText
+        <PerpTableCellText
           size="$bodyMdMedium"
           flexShrink={1}
           minWidth={0}
@@ -1279,7 +1300,7 @@ const PositionRowMobileLiqPrice = memo(
           minimumFontScale={0.7}
         >
           {priceInfo.liquidationPriceFormatted}
-        </SizableText>
+        </PerpTableCellText>
       </YStack>
     );
   },

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/TradesHistoryRow.tsx
@@ -37,6 +37,7 @@ import {
   getFillDirectionDisplayInfo,
 } from '../utils';
 
+import { PerpTableCellText } from './PerpTableCellText';
 import { TradesHistoryShareAction } from './TradesHistoryShareAction';
 
 import type { IColumnConfig, IRenderMode } from '../List/CommonTableListView';
@@ -178,14 +179,14 @@ const TradesHistoryRow = memo(
       return (
         <YStack gap="$3">
           <YStack gap="$1.5">
-            <SizableText size={isMobile ? '$bodyMd' : '$bodySm'}>
+            <PerpTableCellText size={isMobile ? '$bodyMd' : '$bodySm'}>
               {intl.formatMessage({ id: ETranslations.perps_fee_title })}
               {feeRatePercentage}
-            </SizableText>
-            <SizableText size={isMobile ? '$bodyMd' : '$bodySm'}>
+            </PerpTableCellText>
+            <PerpTableCellText size={isMobile ? '$bodyMd' : '$bodySm'}>
               {intl.formatMessage({ id: ETranslations.perps_fee_total })}
               {tradeBaseInfo.feeFormatted}
-            </SizableText>
+            </PerpTableCellText>
           </YStack>
           <SizableText
             size={isMobile ? '$bodyMd' : '$bodySm'}
@@ -237,9 +238,9 @@ const TradesHistoryRow = memo(
                   {directionInfo.directionStr}
                 </SizableText>
               </XStack>
-              <SizableText size="$bodySm" color="$textSubdued">
+              <PerpTableCellText size="$bodySm" color="$textSubdued">
                 {dateInfo.date} {dateInfo.time}
-              </SizableText>
+              </PerpTableCellText>
             </YStack>
             <XStack gap="$2" alignItems="center">
               <YStack gap="$1" alignItems="flex-end">
@@ -249,12 +250,12 @@ const TradesHistoryRow = memo(
                   })}
                 </SizableText>
                 <XStack gap="$1" alignItems="center">
-                  <SizableText
+                  <PerpTableCellText
                     size="$bodySm"
                     color={closePnlInfo.closePnlColor}
                   >
                     {`${closePnlInfo.closePnlPlusOrMinus}${closePnlInfo.closePnlFormatted}`}
-                  </SizableText>
+                  </PerpTableCellText>
                   {canShare ? (
                     <IconButton
                       testID="perp-icon-btn"
@@ -287,9 +288,9 @@ const TradesHistoryRow = memo(
                   id: ETranslations.perp_trades_history_price,
                 })}
               </SizableText>
-              <SizableText size="$bodySm">
+              <PerpTableCellText size="$bodySm">
                 {tradeBaseInfo.priceFormatted}
-              </SizableText>
+              </PerpTableCellText>
             </YStack>
             <YStack gap="$1" flex={1} alignItems="flex-start">
               <SizableText size="$bodySm" color="$textSubdued">
@@ -297,7 +298,9 @@ const TradesHistoryRow = memo(
                   id: ETranslations.perp_position_position_size,
                 })}
               </SizableText>
-              <SizableText size="$bodySm">{tradeBaseInfo.size}</SizableText>
+              <PerpTableCellText size="$bodySm">
+                {tradeBaseInfo.size}
+              </PerpTableCellText>
             </YStack>
             <YStack gap="$1" flex={1} alignItems="flex-start">
               <SizableText size="$bodySm" color="$textSubdued">
@@ -305,9 +308,9 @@ const TradesHistoryRow = memo(
                   id: ETranslations.perp_trades_history_trade_value,
                 })}
               </SizableText>
-              <SizableText size="$bodySm">
+              <PerpTableCellText size="$bodySm">
                 {tradeBaseInfo.tradeValueFormatted}
-              </SizableText>
+              </PerpTableCellText>
             </YStack>
             <YStack gap="$1" flex={1} alignItems="flex-end">
               <SizableText size="$bodySm" color="$textSubdued">
@@ -361,21 +364,21 @@ const TradesHistoryRow = memo(
               justifyContent="center"
               alignItems={calcCellAlign(columnConfigs[0].align)}
             >
-              <SizableText
+              <PerpTableCellText
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
               >
                 {dateInfo.date}
-              </SizableText>
-              <SizableText
+              </PerpTableCellText>
+              <PerpTableCellText
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
                 color="$textSubdued"
               >
                 {dateInfo.time}
-              </SizableText>
+              </PerpTableCellText>
             </YStack>
             {/* Asset symbol */}
             <XStack
@@ -420,13 +423,13 @@ const TradesHistoryRow = memo(
               justifyContent={calcCellAlign(columnConfigs[3].align)}
               alignItems="center"
             >
-              <SizableText
+              <PerpTableCellText
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
               >
                 {tradeBaseInfo.priceFormatted}
-              </SizableText>
+              </PerpTableCellText>
             </XStack>
 
             {/* Position size */}
@@ -435,11 +438,11 @@ const TradesHistoryRow = memo(
               justifyContent={calcCellAlign(columnConfigs[4].align)}
               alignItems="center"
             >
-              <SizableText
+              <PerpTableCellText
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
-              >{`${tradeBaseInfo.size} ${assetSymbol}`}</SizableText>
+              >{`${tradeBaseInfo.size} ${assetSymbol}`}</PerpTableCellText>
             </XStack>
 
             {/* Trade value */}
@@ -448,13 +451,13 @@ const TradesHistoryRow = memo(
               justifyContent={calcCellAlign(columnConfigs[5].align)}
               alignItems="center"
             >
-              <SizableText
+              <PerpTableCellText
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 size="$bodySm"
               >
                 {tradeBaseInfo.tradeValueFormatted}
-              </SizableText>
+              </PerpTableCellText>
             </XStack>
 
             {/* Fee */}
@@ -488,7 +491,7 @@ const TradesHistoryRow = memo(
             alignItems="center"
             cursor="default"
           >
-            <SizableText
+            <PerpTableCellText
               flexShrink={1}
               numberOfLines={1}
               ellipsizeMode="tail"
@@ -496,7 +499,7 @@ const TradesHistoryRow = memo(
               color={closePnlInfo.closePnlColor}
             >
               {`${closePnlInfo.closePnlPlusOrMinus}${closePnlInfo.closePnlFormatted}`}
-            </SizableText>
+            </PerpTableCellText>
             <TradesHistoryShareAction
               visible={canShare}
               onPress={() => onShare?.(fill)}

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/PerpTwapList.tsx
@@ -51,6 +51,7 @@ import { usePerpTwapHistoryViewAllUrl } from '../../../hooks/usePerpOrderInfoPan
 import { PerpTestIDs } from '../../../testIDs';
 import { buildHelpUrl, openGuideUrl } from '../../Guide/perpGuideData';
 import { OrderInfoSubTabs } from '../Components/OrderInfoSubTabs';
+import { PerpTableCellText } from '../Components/PerpTableCellText';
 import {
   calcCellAlign,
   getColumnStyle,
@@ -278,7 +279,7 @@ function MobileTwapHistoryInfoRow({
       <SizableText size="$bodySm" color="$textSubdued">
         {label}
       </SizableText>
-      <SizableText
+      <PerpTableCellText
         size="$bodySm"
         color={valueColor}
         numberOfLines={1}
@@ -287,7 +288,7 @@ function MobileTwapHistoryInfoRow({
         maxWidth="60%"
       >
         {value}
-      </SizableText>
+      </PerpTableCellText>
     </XStack>
   );
 }
@@ -507,34 +508,36 @@ function TwapActiveRow({
             justifyContent={calcCellAlign(columnConfigs[1].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm" color={sideInfo.color}>
+            <PerpTableCellText size="$bodySm" color={sideInfo.color}>
               {baseInfo.sizeWithSymbol}
-            </SizableText>
+            </PerpTableCellText>
           </XStack>
           <XStack
             {...getColumnStyle(columnConfigs[2])}
             justifyContent={calcCellAlign(columnConfigs[2].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm" color={sideInfo.color}>
+            <PerpTableCellText size="$bodySm" color={sideInfo.color}>
               {baseInfo.executedSizeWithSymbol}
-            </SizableText>
+            </PerpTableCellText>
           </XStack>
           <XStack
             {...getColumnStyle(columnConfigs[3])}
             justifyContent={calcCellAlign(columnConfigs[3].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm">
+            <PerpTableCellText size="$bodySm">
               {baseInfo.avgPriceFormatted}
-            </SizableText>
+            </PerpTableCellText>
           </XStack>
           <YStack
             {...getColumnStyle(columnConfigs[4])}
             justifyContent="center"
             alignItems={calcCellAlign(columnConfigs[4].align)}
           >
-            <SizableText size="$bodySm">{baseInfo.runningTimeText}</SizableText>
+            <PerpTableCellText size="$bodySm">
+              {baseInfo.runningTimeText}
+            </PerpTableCellText>
           </YStack>
           <XStack
             {...getColumnStyle(columnConfigs[5])}
@@ -555,7 +558,9 @@ function TwapActiveRow({
             justifyContent="center"
             alignItems={calcCellAlign(columnConfigs[7].align)}
           >
-            <SizableText size="$bodySm">{creationTime.inline}</SizableText>
+            <PerpTableCellText size="$bodySm">
+              {creationTime.inline}
+            </PerpTableCellText>
           </YStack>
         </>
       ) : null}
@@ -700,9 +705,9 @@ function TwapHistoryRow({
                 {sideInfo.text}
               </SizableText>
             </XStack>
-            <SizableText size="$bodySm" color="$textSubdued">
+            <PerpTableCellText size="$bodySm" color="$textSubdued">
               {historyTime.inline}
-            </SizableText>
+            </PerpTableCellText>
           </YStack>
           <YStack
             alignItems="flex-end"
@@ -793,10 +798,12 @@ function TwapHistoryRow({
             justifyContent="center"
             alignItems={calcCellAlign(columnConfigs[0].align)}
           >
-            <SizableText size="$bodySm">{historyTime.date}</SizableText>
-            <SizableText size="$bodySm" color="$textSubdued">
+            <PerpTableCellText size="$bodySm">
+              {historyTime.date}
+            </PerpTableCellText>
+            <PerpTableCellText size="$bodySm" color="$textSubdued">
               {historyTime.time}
-            </SizableText>
+            </PerpTableCellText>
           </YStack>
           <YStack
             {...getColumnStyle(columnConfigs[1])}
@@ -812,39 +819,39 @@ function TwapHistoryRow({
             justifyContent={calcCellAlign(columnConfigs[2].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm" color={sideInfo.color}>
+            <PerpTableCellText size="$bodySm" color={sideInfo.color}>
               {baseInfo.sizeWithSymbol}
-            </SizableText>
+            </PerpTableCellText>
           </XStack>
           <XStack
             {...getColumnStyle(columnConfigs[3])}
             justifyContent={calcCellAlign(columnConfigs[3].align)}
             alignItems="center"
           >
-            <SizableText
+            <PerpTableCellText
               size="$bodySm"
               color={isActivated ? undefined : sideInfo.color}
             >
               {historyDisplayInfo.executedSize}
-            </SizableText>
+            </PerpTableCellText>
           </XStack>
           <XStack
             {...getColumnStyle(columnConfigs[4])}
             justifyContent={calcCellAlign(columnConfigs[4].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm">
+            <PerpTableCellText size="$bodySm">
               {historyDisplayInfo.averagePrice}
-            </SizableText>
+            </PerpTableCellText>
           </XStack>
           <YStack
             {...getColumnStyle(columnConfigs[5])}
             justifyContent="center"
             alignItems={calcCellAlign(columnConfigs[5].align)}
           >
-            <SizableText size="$bodySm">
+            <PerpTableCellText size="$bodySm">
               {historyDisplayInfo.totalRuntime}
-            </SizableText>
+            </PerpTableCellText>
           </YStack>
           <XStack
             {...getColumnStyle(columnConfigs[6])}
@@ -960,14 +967,14 @@ function TwapFillRow({
     return (
       <YStack gap="$3">
         <YStack gap="$1.5">
-          <SizableText size="$bodySm">
+          <PerpTableCellText size="$bodySm">
             {intl.formatMessage({ id: ETranslations.perps_fee_title })}
             {feeRatePercentage}
-          </SizableText>
-          <SizableText size="$bodySm">
+          </PerpTableCellText>
+          <PerpTableCellText size="$bodySm">
             {intl.formatMessage({ id: ETranslations.perps_fee_total })}
             {fillInfo.feeFormatted}
-          </SizableText>
+          </PerpTableCellText>
         </YStack>
         <SizableText size="$bodySm" color="$textSubdued">
           {intl.formatMessage({ id: ETranslations.perps_fee_desc })}
@@ -1004,9 +1011,9 @@ function TwapFillRow({
                 {directionInfo.text}
               </SizableText>
             </XStack>
-            <SizableText size="$bodySm" color="$textSubdued">
+            <PerpTableCellText size="$bodySm" color="$textSubdued">
               {dateInfo.date} {dateInfo.time}
-            </SizableText>
+            </PerpTableCellText>
           </YStack>
           <YStack gap="$1" alignItems="flex-end">
             <SizableText size="$bodySm" color="$textSubdued">
@@ -1014,9 +1021,9 @@ function TwapFillRow({
                 id: ETranslations.perp_trades_close_pnl,
               })}
             </SizableText>
-            <SizableText size="$bodySm" color={fillInfo.closePnlColor}>
+            <PerpTableCellText size="$bodySm" color={fillInfo.closePnlColor}>
               {`${fillInfo.closePnlPlusOrMinus}${fillInfo.closePnlFormatted}`}
-            </SizableText>
+            </PerpTableCellText>
           </YStack>
         </XStack>
         <Divider width="100%" borderColor="$borderSubdued" />
@@ -1034,7 +1041,9 @@ function TwapFillRow({
                 id: ETranslations.perp_trades_history_price,
               })}
             </SizableText>
-            <SizableText size="$bodySm">{fillInfo.priceFormatted}</SizableText>
+            <PerpTableCellText size="$bodySm">
+              {fillInfo.priceFormatted}
+            </PerpTableCellText>
           </YStack>
           <YStack gap="$1" flex={1} alignItems="flex-start">
             <SizableText size="$bodySm" color="$textSubdued">
@@ -1042,7 +1051,9 @@ function TwapFillRow({
                 id: ETranslations.perp_position_position_size,
               })}
             </SizableText>
-            <SizableText size="$bodySm">{fillInfo.sizeFormatted}</SizableText>
+            <PerpTableCellText size="$bodySm">
+              {fillInfo.sizeFormatted}
+            </PerpTableCellText>
           </YStack>
           <YStack gap="$1" flex={1} alignItems="flex-start">
             <SizableText size="$bodySm" color="$textSubdued">
@@ -1050,7 +1061,9 @@ function TwapFillRow({
                 id: ETranslations.perp_trades_history_trade_value,
               })}
             </SizableText>
-            <SizableText size="$bodySm">{fillInfo.valueFormatted}</SizableText>
+            <PerpTableCellText size="$bodySm">
+              {fillInfo.valueFormatted}
+            </PerpTableCellText>
           </YStack>
           <YStack gap="$1" flex={1} alignItems="flex-end">
             <SizableText size="$bodySm" color="$textSubdued">
@@ -1104,10 +1117,12 @@ function TwapFillRow({
             justifyContent="center"
             alignItems={calcCellAlign(columnConfigs[0].align)}
           >
-            <SizableText size="$bodySm">{dateInfo.date}</SizableText>
-            <SizableText size="$bodySm" color="$textSubdued">
+            <PerpTableCellText size="$bodySm">
+              {dateInfo.date}
+            </PerpTableCellText>
+            <PerpTableCellText size="$bodySm" color="$textSubdued">
               {dateInfo.time}
-            </SizableText>
+            </PerpTableCellText>
           </YStack>
           <XStack
             {...getColumnStyle(columnConfigs[1])}
@@ -1130,21 +1145,27 @@ function TwapFillRow({
             justifyContent={calcCellAlign(columnConfigs[3].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm">{fillInfo.priceFormatted}</SizableText>
+            <PerpTableCellText size="$bodySm">
+              {fillInfo.priceFormatted}
+            </PerpTableCellText>
           </XStack>
           <XStack
             {...getColumnStyle(columnConfigs[4])}
             justifyContent={calcCellAlign(columnConfigs[4].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm">{fillInfo.sizeFormatted}</SizableText>
+            <PerpTableCellText size="$bodySm">
+              {fillInfo.sizeFormatted}
+            </PerpTableCellText>
           </XStack>
           <XStack
             {...getColumnStyle(columnConfigs[5])}
             justifyContent={calcCellAlign(columnConfigs[5].align)}
             alignItems="center"
           >
-            <SizableText size="$bodySm">{fillInfo.valueFormatted}</SizableText>
+            <PerpTableCellText size="$bodySm">
+              {fillInfo.valueFormatted}
+            </PerpTableCellText>
           </XStack>
           <XStack
             {...getColumnStyle(columnConfigs[6])}
@@ -1173,14 +1194,14 @@ function TwapFillRow({
           justifyContent={calcCellAlign(columnConfigs[7].align)}
           alignItems="center"
         >
-          <SizableText
+          <PerpTableCellText
             numberOfLines={1}
             ellipsizeMode="tail"
             size="$bodySm"
             color={fillInfo.closePnlColor}
           >
             {`${fillInfo.closePnlPlusOrMinus}${fillInfo.closePnlFormatted}`}
-          </SizableText>
+          </PerpTableCellText>
         </XStack>
       ) : null}
     </XStack>

--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -8,6 +8,7 @@ import {
   Divider,
   Popover,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useMedia,
@@ -185,10 +186,18 @@ function MobileHeader({
             </SizableText>
           ) : (
             <XStack alignItems="center" gap={6}>
-              <SizableText size="$bodySmMedium" color={fundingColor}>
+              <SizableText
+                size="$bodySmMedium"
+                color={fundingColor}
+                fontVariant={TABULAR_NUMS}
+              >
                 {fundingDisplay}
               </SizableText>
-              <SizableText size="$bodySmMedium" color="$text">
+              <SizableText
+                size="$bodySmMedium"
+                color="$text"
+                fontVariant={TABULAR_NUMS}
+              >
                 {countdown}
               </SizableText>
             </XStack>
@@ -226,13 +235,18 @@ function MobileHeader({
                       id: ETranslations.perps_hourly,
                     })}
                   </SizableText>
-                  <SizableText size="$headingXs" color="$textSubdued">
+                  <SizableText
+                    size="$headingXs"
+                    color="$textSubdued"
+                    fontVariant={TABULAR_NUMS}
+                  >
                     ({countdown})
                   </SizableText>
                 </XStack>
                 <SizableText
                   size="$headingXs"
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {hourlyFundingRate}%
                 </SizableText>
@@ -246,6 +260,7 @@ function MobileHeader({
                 <SizableText
                   size="$headingXs"
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {dailyFundingRate}%
                 </SizableText>
@@ -259,6 +274,7 @@ function MobileHeader({
                 <SizableText
                   size="$headingXs"
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {weeklyFundingRate}%
                 </SizableText>
@@ -272,6 +288,7 @@ function MobileHeader({
                 <SizableText
                   size="$headingXs"
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {monthlyFundingRate}%
                 </SizableText>
@@ -285,6 +302,7 @@ function MobileHeader({
                 <SizableText
                   size="$headingXs"
                   color={fundingRateNumber >= 0 ? '$green11' : '$red11'}
+                  fontVariant={TABULAR_NUMS}
                 >
                   {annualizedFundingRate}%
                 </SizableText>

--- a/packages/kit/src/views/Perp/components/TickerBar/MobilePerpMarketHeader.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/MobilePerpMarketHeader.tsx
@@ -10,6 +10,7 @@ import {
   Popover,
   SizableText,
   Skeleton,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -270,6 +271,7 @@ function MobilePerpMarketHeader() {
               lineHeight={14}
               color="$textSubdued"
               dashThickness={0.5}
+              fontVariant={TABULAR_NUMS}
             >
               {markPriceDisplay}
             </DashText>
@@ -303,6 +305,7 @@ function MobilePerpMarketHeader() {
             formatterOptions={{
               showPlusMinusSigns: true,
             }}
+            fontVariant={TABULAR_NUMS}
           >
             {change24hPercent}
           </NumberSizeableText>
@@ -431,7 +434,12 @@ function MobilePerpMarketHeader() {
               id: ETranslations.perp_token_bar_24h_Volume,
             })}
           >
-            <SizableText size="$bodySmMedium" color="$text" textAlign="right">
+            <SizableText
+              size="$bodySmMedium"
+              color="$text"
+              textAlign="right"
+              fontVariant={TABULAR_NUMS}
+            >
               {volumeDisplay}
             </SizableText>
           </StatRow>
@@ -443,7 +451,12 @@ function MobilePerpMarketHeader() {
                 : ETranslations.perp_token_bar_open_Interest,
             })}
           >
-            <SizableText size="$bodySmMedium" color="$text" textAlign="right">
+            <SizableText
+              size="$bodySmMedium"
+              color="$text"
+              textAlign="right"
+              fontVariant={TABULAR_NUMS}
+            >
               {openInterestDisplay}
             </SizableText>
           </StatRow>
@@ -458,6 +471,7 @@ function MobilePerpMarketHeader() {
                 size="$bodySmMedium"
                 textAlign="right"
                 color={fundingColor}
+                fontVariant={TABULAR_NUMS}
               >
                 {fundingDisplay}
               </SizableText>
@@ -495,6 +509,7 @@ function MobilePerpMarketHeader() {
                 size="$bodySmMedium"
                 textAlign="right"
                 color="$green11"
+                fontVariant={TABULAR_NUMS}
               >
                 0%
               </SizableText>

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarDesktop.tsx
@@ -11,6 +11,7 @@ import {
   ScrollView,
   SizableText,
   SkeletonContainer,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
   YStack,
@@ -57,6 +58,7 @@ import { FavoriteButton } from '../TokenSelector/PerpTokenSelectorRow';
 // the subdued labels at this size.
 const TICKER_BAR_STAT_VALUE_TEXT_PROPS = {
   size: '$bodySmMedium',
+  fontVariant: TABULAR_NUMS,
 } as const;
 
 const TICKER_BAR_STAT_LABEL_VALUE_GAP = 5;
@@ -207,6 +209,7 @@ const TickerBarMarkPriceView = memo(
                 cursor="help"
                 lineHeight={20}
                 numberOfLines={1}
+                fontVariant={TABULAR_NUMS}
               >
                 {formattedMarkPrice}
               </SizableText>
@@ -278,6 +281,7 @@ const TickerBarChange24hView = memo(
           lineHeight={12}
           color={changeDisplay.trim().startsWith('-') ? '$red11' : '$green11'}
           numberOfLines={1}
+          fontVariant={TABULAR_NUMS}
         >
           {changeDisplay}
         </SizableText>
@@ -710,13 +714,18 @@ const TickerBarFundingRateView = memo(
                                 id: ETranslations.perps_hourly,
                               })}
                             </SizableText>
-                            <SizableText size="$bodySm" color="$textSubdued">
+                            <SizableText
+                              size="$bodySm"
+                              color="$textSubdued"
+                              fontVariant={TABULAR_NUMS}
+                            >
                               ({countdown})
                             </SizableText>
                           </XStack>
                           <SizableText
                             size="$bodySm"
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
+                            fontVariant={TABULAR_NUMS}
                           >
                             {hourlyFundingRate}%
                           </SizableText>
@@ -733,6 +742,7 @@ const TickerBarFundingRateView = memo(
                           <SizableText
                             size="$bodySm"
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
+                            fontVariant={TABULAR_NUMS}
                           >
                             {dailyFundingRate}%
                           </SizableText>
@@ -749,6 +759,7 @@ const TickerBarFundingRateView = memo(
                           <SizableText
                             size="$bodySm"
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
+                            fontVariant={TABULAR_NUMS}
                           >
                             {weeklyFundingRate}%
                           </SizableText>
@@ -765,6 +776,7 @@ const TickerBarFundingRateView = memo(
                           <SizableText
                             size="$bodySm"
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
+                            fontVariant={TABULAR_NUMS}
                           >
                             {monthlyFundingRate}%
                           </SizableText>
@@ -781,6 +793,7 @@ const TickerBarFundingRateView = memo(
                           <SizableText
                             size="$bodySm"
                             color={fundingRate >= 0 ? '$green11' : '$red11'}
+                            fontVariant={TABULAR_NUMS}
                           >
                             {annualizedFundingRate}%
                           </SizableText>

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -21,6 +21,7 @@ import {
   SizableText,
   Spinner,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   usePageMounted,
@@ -298,7 +299,11 @@ const InitialRowsSnapshotRow = memo(
               <SubtitleText subtitle={subtitle} maxWidth={80} />
             ) : null}
             {hasDisplayAssetCtx ? (
-              <SizableText size="$bodySm" color="$textSubdued">
+              <SizableText
+                size="$bodySm"
+                color="$textSubdued"
+                fontVariant={TABULAR_NUMS}
+              >
                 ${volumeDisplay}
               </SizableText>
             ) : (
@@ -319,6 +324,7 @@ const InitialRowsSnapshotRow = memo(
                 size="$bodyMdMedium"
                 color="$text"
                 alignSelf="flex-end"
+                fontVariant={TABULAR_NUMS}
               >
                 {assetCtx?.markPrice}
               </NumberSizeableText>
@@ -330,6 +336,7 @@ const InitialRowsSnapshotRow = memo(
                 }
                 formatter="priceChange"
                 formatterOptions={{ showPlusMinusSigns: true }}
+                fontVariant={TABULAR_NUMS}
               >
                 {assetCtx?.change24hPercent.toString()}
               </NumberSizeableText>

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelectorRow.tsx
@@ -19,6 +19,7 @@ import {
   SizableText,
   SkeletonContainer,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -466,6 +467,7 @@ const TokenPriceCellDesktop = memo(() => {
                 size="$bodySmMedium"
                 color="$text"
                 lineHeight={DESKTOP_METRIC_TEXT_LINE_HEIGHT}
+                fontVariant={TABULAR_NUMS}
               >
                 {assetCtx.markPrice}
               </SizableText>
@@ -475,6 +477,7 @@ const TokenPriceCellDesktop = memo(() => {
                 size="$bodySmMedium"
                 color="$text"
                 lineHeight={DESKTOP_METRIC_TEXT_LINE_HEIGHT}
+                fontVariant={TABULAR_NUMS}
               >
                 {assetCtx.markPrice}
               </NumberSizeableText>
@@ -523,11 +526,13 @@ const Token24hChangeCellDesktop = memo(() => {
               size="$bodySm"
               color={assetCtx.change24hPercent > 0 ? '$green11' : '$red11'}
               lineHeight={DESKTOP_METRIC_TEXT_LINE_HEIGHT}
+              fontVariant={TABULAR_NUMS}
             >
               <SizableText
                 size="$bodySm"
                 color={assetCtx.change24hPercent > 0 ? '$green11' : '$red11'}
                 lineHeight={DESKTOP_METRIC_TEXT_LINE_HEIGHT}
+                fontVariant={TABULAR_NUMS}
               >
                 {assetCtx.change24h}
               </SizableText>{' '}
@@ -538,6 +543,7 @@ const Token24hChangeCellDesktop = memo(() => {
                 formatter="priceChange"
                 formatterOptions={{ showPlusMinusSigns: true }}
                 lineHeight={DESKTOP_METRIC_TEXT_LINE_HEIGHT}
+                fontVariant={TABULAR_NUMS}
               >
                 {assetCtx.change24hPercent.toString()}
               </NumberSizeableText>
@@ -596,6 +602,7 @@ const TokenFundingCellDesktop = memo(() => {
               size="$bodySm"
               color="$text"
               lineHeight={DESKTOP_METRIC_TEXT_LINE_HEIGHT}
+              fontVariant={TABULAR_NUMS}
             >
               {isSpot
                 ? '-'
@@ -645,6 +652,7 @@ const TokenVolumeCellDesktop = memo(() => {
               size="$bodySm"
               color="$text"
               lineHeight={DESKTOP_METRIC_TEXT_LINE_HEIGHT}
+              fontVariant={TABULAR_NUMS}
             >
               $
               {formatDisplayNumber(
@@ -693,6 +701,7 @@ const TokenMarketCapCellDesktop = memo(() => {
             size="$bodySm"
             color="$text"
             lineHeight={DESKTOP_METRIC_TEXT_LINE_HEIGHT}
+            fontVariant={TABULAR_NUMS}
           >
             {assetCtx.marketCap ?? '-'}
           </SizableText>
@@ -758,6 +767,7 @@ const TokenOpenInterestCellDesktop = memo(() => {
               size="$bodySm"
               color="$text"
               lineHeight={DESKTOP_METRIC_TEXT_LINE_HEIGHT}
+              fontVariant={TABULAR_NUMS}
             >
               {isSpot ? '-' : openInterestDisplay}
             </SizableText>
@@ -933,7 +943,11 @@ const TokenVolumeMobile = memo(() => {
             <SubtitleText subtitle={token.subtitle} maxWidth={120} />
           ) : null}
           <SkeletonContainer isLoading={isLoading} width={80} height={16}>
-            <SizableText size="$bodySm" color="$textSubdued">
+            <SizableText
+              size="$bodySm"
+              color="$textSubdued"
+              fontVariant={TABULAR_NUMS}
+            >
               $
               {formatDisplayNumber(
                 NUMBER_FORMATTER.marketCap(assetCtx.volume24h),
@@ -971,6 +985,7 @@ const TokenPriceMobile = memo(() => {
               size="$bodyMdMedium"
               color="$text"
               alignSelf="flex-end"
+              fontVariant={TABULAR_NUMS}
             >
               {assetCtx.markPrice}
             </SizableText>
@@ -980,6 +995,7 @@ const TokenPriceMobile = memo(() => {
               size="$bodyMdMedium"
               color="$text"
               alignSelf="flex-end"
+              fontVariant={TABULAR_NUMS}
             >
               {assetCtx.markPrice}
             </NumberSizeableText>
@@ -1016,6 +1032,7 @@ const Token24hChangeMobile = memo(() => {
             color={assetCtx.change24hPercent > 0 ? '$green11' : '$red11'}
             formatter="priceChange"
             formatterOptions={{ showPlusMinusSigns: true }}
+            fontVariant={TABULAR_NUMS}
           >
             {assetCtx.change24hPercent.toString()}
           </NumberSizeableText>

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/LiquidationPriceDisplay.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/LiquidationPriceDisplay.tsx
@@ -1,6 +1,10 @@
 import { memo } from 'react';
 
-import { NumberSizeableText, SizableText } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  TABULAR_NUMS,
+} from '@onekeyhq/components';
 
 import { useLiquidationPrice } from '../../../hooks/useLiquidationPrice';
 
@@ -30,6 +34,7 @@ const LiquidationPriceDisplay = memo(
         }}
         formatter="price"
         formatterOptions={{ currency: '$' }}
+        fontVariant={TABULAR_NUMS}
       >
         {liquidationPrice.toNumber()}
       </NumberSizeableText>

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsAccountNumberValue.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsAccountNumberValue.tsx
@@ -4,6 +4,7 @@ import {
   NumberSizeableText,
   SizableText,
   Skeleton,
+  TABULAR_NUMS,
 } from '@onekeyhq/components';
 import {
   usePerpsAccountLoadingInfoAtom,
@@ -62,6 +63,7 @@ export function PerpsAccountNumberValue({
       size={textSize}
       formatter="value"
       formatterOptions={{ currency: '$' }}
+      fontVariant={TABULAR_NUMS}
     >
       {value}
     </NumberSizeableText>

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
@@ -9,6 +9,7 @@ import {
   DebugRenderTracker,
   IconButton,
   SizableText,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
   YStack,
@@ -88,7 +89,11 @@ function PerpAccountMMRView() {
           renderContent={mmrTooltipContent}
           renderTrigger={mmrTooltipTrigger}
         />
-        <SizableText size="$bodySmMedium" color={mmrColor}>
+        <SizableText
+          size="$bodySmMedium"
+          color={mmrColor}
+          fontVariant={TABULAR_NUMS}
+        >
           {mmrPercent}%
         </SizableText>
       </XStack>
@@ -195,7 +200,11 @@ function PerpAccountPanel() {
               id: ETranslations.perp_account_unrealized_pnl,
             })}
           </SizableText>
-          <SizableText size="$bodySmMedium" color={unrealizedPnlInfo.pnlColor}>
+          <SizableText
+            size="$bodySmMedium"
+            color={unrealizedPnlInfo.pnlColor}
+            fontVariant={TABULAR_NUMS}
+          >
             {`${unrealizedPnlInfo.pnlPlusOrMinus}${unrealizedPnlInfo.pnlFormatted}`}
           </SizableText>
         </XStack>

--- a/packages/kit/src/views/ReferFriends/pages/EarnReward/components/ReferFriendsAccordionItem.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/EarnReward/components/ReferFriendsAccordionItem.tsx
@@ -1,6 +1,12 @@
 import type { ComponentProps, ReactNode } from 'react';
 
-import { Accordion, Icon, SizableText, XStack } from '@onekeyhq/components';
+import {
+  Accordion,
+  Icon,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+} from '@onekeyhq/components';
 import { ANIMATE_ONLY_OPACITY } from '@onekeyhq/components/src/utils/animationConstants';
 import { Currency } from '@onekeyhq/kit/src/components/Currency';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
@@ -63,6 +69,7 @@ export function ReferFriendsAccordionItem({
                 color="$textSuccess"
                 formatter="value"
                 size="$bodyLgMedium"
+                fontVariant={TABULAR_NUMS}
                 formatterOptions={{
                   showPlusMinusSigns: true,
                 }}

--- a/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/components/HardwareRecordCard.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/components/HardwareRecordCard.tsx
@@ -87,11 +87,7 @@ export function HardwareRecordCard({ item }: IHardwareRecordCardProps) {
         </XStack>
 
         {/* Order Number */}
-        <SizableText
-          size="$bodyLgMedium"
-          color="$text"
-          fontVariant={TABULAR_NUMS}
-        >
+        <SizableText size="$bodyLgMedium" color="$text">
           {item.orderNumber}
         </SizableText>
 

--- a/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/components/HardwareRecordCard.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/components/HardwareRecordCard.tsx
@@ -8,6 +8,7 @@ import {
   Icon,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -76,6 +77,7 @@ export function HardwareRecordCard({ item }: IHardwareRecordCardProps) {
             color={rewardColor}
             formatter="value"
             size="$bodyMdMedium"
+            fontVariant={TABULAR_NUMS}
             formatterOptions={{
               showPlusMinusSigns: true,
             }}
@@ -85,7 +87,11 @@ export function HardwareRecordCard({ item }: IHardwareRecordCardProps) {
         </XStack>
 
         {/* Order Number */}
-        <SizableText size="$bodyLgMedium" color="$text">
+        <SizableText
+          size="$bodyLgMedium"
+          color="$text"
+          fontVariant={TABULAR_NUMS}
+        >
           {item.orderNumber}
         </SizableText>
 
@@ -94,7 +100,11 @@ export function HardwareRecordCard({ item }: IHardwareRecordCardProps) {
           <XStack gap="$3" ai="center" flex={1}>
             {/* Date */}
             {formattedDate ? (
-              <SizableText size="$bodyMd" color="$textSubdued">
+              <SizableText
+                size="$bodyMd"
+                color="$textSubdued"
+                fontVariant={TABULAR_NUMS}
+              >
                 {formattedDate}
               </SizableText>
             ) : null}

--- a/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/components/HardwareRecordTable.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/components/HardwareRecordTable.tsx
@@ -103,11 +103,7 @@ function TableRow({ item }: ITableRowProps) {
 
         {/* Order ID Column */}
         <XStack w={COLUMN_WIDTHS.orderId} ai="center" py="$1">
-          <SizableText
-            size="$bodyMdMedium"
-            color="$text"
-            fontVariant={TABULAR_NUMS}
-          >
+          <SizableText size="$bodyMdMedium" color="$text">
             {item.orderNumber}
           </SizableText>
         </XStack>

--- a/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/components/HardwareRecordTable.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/HardwareSalesReward/components/HardwareRecordTable.tsx
@@ -9,6 +9,7 @@ import {
   Icon,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -91,14 +92,22 @@ function TableRow({ item }: ITableRowProps) {
               color="$iconSubdued"
             />
           </Stack>
-          <SizableText size="$bodyMdMedium" color="$text">
+          <SizableText
+            size="$bodyMdMedium"
+            color="$text"
+            fontVariant={TABULAR_NUMS}
+          >
             {formattedDate}
           </SizableText>
         </XStack>
 
         {/* Order ID Column */}
         <XStack w={COLUMN_WIDTHS.orderId} ai="center" py="$1">
-          <SizableText size="$bodyMdMedium" color="$text">
+          <SizableText
+            size="$bodyMdMedium"
+            color="$text"
+            fontVariant={TABULAR_NUMS}
+          >
             {item.orderNumber}
           </SizableText>
         </XStack>
@@ -124,6 +133,7 @@ function TableRow({ item }: ITableRowProps) {
             color={rewardColor}
             formatter="value"
             size="$bodyMdMedium"
+            fontVariant={TABULAR_NUMS}
             formatterOptions={{
               showPlusMinusSigns: true,
             }}

--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/components/InvitationDetailsSection/components/InviteCodeListTable/hooks/useTableColumns.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/components/InvitationDetailsSection/components/InviteCodeListTable/hooks/useTableColumns.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react';
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
-import { SizableText } from '@onekeyhq/components';
+import { SizableText, TABULAR_NUMS } from '@onekeyhq/components';
 import type { ITableColumn } from '@onekeyhq/components';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -134,7 +134,11 @@ export function useTableColumns(
           ? { columnProps: { flex: 1 } }
           : { columnWidth: columnWidths.salesWidth }),
         render: (value: number) => (
-          <SizableText size="$bodyMdMedium" color="$text">
+          <SizableText
+            size="$bodyMdMedium"
+            color="$text"
+            fontVariant={TABULAR_NUMS}
+          >
             {value}
           </SizableText>
         ),
@@ -148,7 +152,11 @@ export function useTableColumns(
           ? { columnProps: { flex: 1 } }
           : { columnWidth: columnWidths.walletsWidth }),
         render: (value: number) => (
-          <SizableText size="$bodyMdMedium" color="$text">
+          <SizableText
+            size="$bodyMdMedium"
+            color="$text"
+            fontVariant={TABULAR_NUMS}
+          >
             {value}
           </SizableText>
         ),
@@ -165,7 +173,11 @@ export function useTableColumns(
         render: (value: string) => {
           const formattedValue = new BigNumber(value).toFixed(2);
           return (
-            <SizableText size="$bodyMdMedium" color="$text">
+            <SizableText
+              size="$bodyMdMedium"
+              color="$text"
+              fontVariant={TABULAR_NUMS}
+            >
               {currencySymbol
                 ? `${currencySymbol}${formattedValue}`
                 : formattedValue}
@@ -180,7 +192,11 @@ export function useTableColumns(
           ? { columnProps: { flex: 1 } }
           : { columnWidth: columnWidths.createdAtWidth }),
         render: (date: string) => (
-          <SizableText size="$bodyMdMedium" color="$text">
+          <SizableText
+            size="$bodyMdMedium"
+            color="$text"
+            fontVariant={TABULAR_NUMS}
+          >
             {formatDate(date, { hideSeconds: true })}
           </SizableText>
         ),

--- a/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsRecordCard.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsRecordCard.tsx
@@ -9,6 +9,7 @@ import {
   Popover,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -60,7 +61,11 @@ function DetailItem({
           />
         ) : null}
       </XStack>
-      <SizableText size="$bodyMdMedium" color={valueColor ?? '$text'}>
+      <SizableText
+        size="$bodyMdMedium"
+        color={valueColor ?? '$text'}
+        fontVariant={TABULAR_NUMS}
+      >
         {value}
       </SizableText>
     </YStack>
@@ -111,6 +116,7 @@ export function PerpsRecordCard({ item }: IPerpsRecordCardProps) {
               color="$textSuccess"
               formatter="value"
               size="$bodyLgMedium"
+              fontVariant={TABULAR_NUMS}
               formatterOptions={{
                 showPlusMinusSigns: true,
               }}
@@ -133,7 +139,12 @@ export function PerpsRecordCard({ item }: IPerpsRecordCardProps) {
                   --
                 </SizableText>
               ) : (
-                <Currency formatter="value" size="$bodyMdMedium" color="$text">
+                <Currency
+                  formatter="value"
+                  size="$bodyMdMedium"
+                  color="$text"
+                  fontVariant={TABULAR_NUMS}
+                >
                   {item.volumeFiatValue}
                 </Currency>
               )}

--- a/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsRecordTable.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/PerpsReward/components/PerpsRecordTable.tsx
@@ -7,6 +7,7 @@ import {
   ScrollView,
   SizableText,
   Spinner,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useMedia,
@@ -171,7 +172,7 @@ function ScrollableCellsContent({ item, columnWidths }: ICellContentProps) {
   return (
     <>
       <XStack w={columnWidths.invitedAt} ai="center" py="$1">
-        <SizableText size="$bodyMd" color="$text">
+        <SizableText size="$bodyMd" color="$text" fontVariant={TABULAR_NUMS}>
           {formatDateTime(item.invitationTime)}
         </SizableText>
       </XStack>
@@ -186,6 +187,7 @@ function ScrollableCellsContent({ item, columnWidths }: ICellContentProps) {
         <SizableText
           size="$bodyMd"
           color={isZeroData && !item.firstTradeTime ? '$textSubdued' : '$text'}
+          fontVariant={TABULAR_NUMS}
         >
           {isZeroData && !item.firstTradeTime
             ? '--'
@@ -199,7 +201,12 @@ function ScrollableCellsContent({ item, columnWidths }: ICellContentProps) {
             --
           </SizableText>
         ) : (
-          <Currency formatter="value" size="$bodyMd" color="$text">
+          <Currency
+            formatter="value"
+            size="$bodyMd"
+            color="$text"
+            fontVariant={TABULAR_NUMS}
+          >
             {item.volumeFiatValue}
           </Currency>
         )}
@@ -211,7 +218,12 @@ function ScrollableCellsContent({ item, columnWidths }: ICellContentProps) {
             --
           </SizableText>
         ) : (
-          <Currency formatter="value" size="$bodyMd" color="$text">
+          <Currency
+            formatter="value"
+            size="$bodyMd"
+            color="$text"
+            fontVariant={TABULAR_NUMS}
+          >
             {item.feeFiatValue}
           </Currency>
         )}
@@ -227,6 +239,7 @@ function ScrollableCellsContent({ item, columnWidths }: ICellContentProps) {
             color="$textSuccess"
             formatter="value"
             size="$bodyMd"
+            fontVariant={TABULAR_NUMS}
             formatterOptions={REWARD_FORMATTER_OPTIONS}
           >
             {item.rewardFiatValue}

--- a/packages/kit/src/views/ReferFriends/pages/RewardDistributionHistory/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/RewardDistributionHistory/index.tsx
@@ -11,6 +11,7 @@ import {
   SectionList,
   SizableText,
   Spinner,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -170,6 +171,7 @@ function RewardDistributionHistoryPageWrapper() {
               <NumberSizeableText
                 numberOfLines={1}
                 formatter="balance"
+                fontVariant={TABULAR_NUMS}
                 formatterOptions={{
                   showPlusMinusSigns: true,
                   tokenSymbol: item.token.symbol,

--- a/packages/kit/src/views/Send/components/SendFee/FeeEditor.tsx
+++ b/packages/kit/src/views/Send/components/SendFee/FeeEditor.tsx
@@ -15,6 +15,7 @@ import {
   SegmentControl,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useDialogInstance,
@@ -136,6 +137,7 @@ function FeeInfoItem({
               tokenSymbol: nativeSymbol,
             }}
             size="$bodyMdMedium"
+            fontVariant={TABULAR_NUMS}
           >
             {nativeValue}
           </NumberSizeableText>
@@ -145,6 +147,7 @@ function FeeInfoItem({
             formatter="balance"
             formatterOptions={{ tokenSymbol: customSymbol }}
             size="$bodyMdMedium"
+            fontVariant={TABULAR_NUMS}
           >
             {customValue}
           </NumberSizeableText>
@@ -157,6 +160,7 @@ function FeeInfoItem({
             }}
             size="$bodyMd"
             color="$textSubdued"
+            fontVariant={TABULAR_NUMS}
           >
             {fiatValue}
           </NumberSizeableText>

--- a/packages/kit/src/views/Send/pages/SendConfirm/TxFeeContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendConfirm/TxFeeContainer.tsx
@@ -10,6 +10,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
 } from '@onekeyhq/components';
 import type { IEncodedTxAptos } from '@onekeyhq/core/src/chains/aptos/types';
@@ -1045,6 +1046,7 @@ function TxFeeContainer(props: IProps) {
       <NumberSizeableText
         size="$bodyMd"
         color="$textSubdued"
+        fontVariant={TABULAR_NUMS}
         formatter="balance"
         formatterOptions={{
           tokenSymbol: txFee?.common.nativeSymbol,
@@ -1063,6 +1065,7 @@ function TxFeeContainer(props: IProps) {
         <NumberSizeableText
           size="$bodyMd"
           color="$textSubdued"
+          fontVariant={TABULAR_NUMS}
           formatter="value"
           formatterOptions={{
             currency: settings.currencyInfo.symbol,

--- a/packages/kit/src/views/Send/pages/SendReplaceTx/SendReplaceTxContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendReplaceTx/SendReplaceTxContainer.tsx
@@ -16,6 +16,7 @@ import {
   SizableText,
   Spinner,
   Stack,
+  TABULAR_NUMS,
   Toast,
   XStack,
 } from '@onekeyhq/components';
@@ -396,6 +397,7 @@ function SendReplaceTxContainer() {
             tokenSymbol: network?.symbol,
           }}
           size="$bodyLg"
+          fontVariant={TABULAR_NUMS}
         >
           {historyTx.decodedTx.totalFeeInNative}
         </NumberSizeableText>
@@ -406,6 +408,7 @@ function SendReplaceTxContainer() {
           }}
           size="$bodyLg"
           color="$textSubdued"
+          fontVariant={TABULAR_NUMS}
         >
           {historyTx.decodedTx.totalFeeFiatValue}
         </NumberSizeableText>
@@ -428,6 +431,7 @@ function SendReplaceTxContainer() {
             tokenSymbol: network?.symbol,
           }}
           size="$bodyLg"
+          fontVariant={TABULAR_NUMS}
         >
           {newFeeInfo?.totalNative}
         </NumberSizeableText>
@@ -438,6 +442,7 @@ function SendReplaceTxContainer() {
           }}
           size="$bodyLg"
           color="$textSubdued"
+          fontVariant={TABULAR_NUMS}
         >
           {newFeeInfo?.totalFiat}
         </NumberSizeableText>

--- a/packages/kit/src/views/Setting/pages/SignatureRecord/Transactions.tsx
+++ b/packages/kit/src/views/Setting/pages/SignatureRecord/Transactions.tsx
@@ -11,6 +11,7 @@ import {
   SectionList,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   Tabs,
   XStack,
   YStack,
@@ -53,6 +54,7 @@ const SendTransactionItem = ({ data }: { data: ISendTransactionData }) => {
           size="$bodyLgMedium"
           formatter="balance"
           numberOfLines={1}
+          fontVariant={TABULAR_NUMS}
           formatterOptions={{
             tokenSymbol: data.token.symbol.toUpperCase(),
             showPlusMinusSigns: true,
@@ -91,6 +93,7 @@ const ApproveTransactionItem = ({
           formatter="balance"
           numberOfLines={1}
           flexShrink={1}
+          fontVariant={TABULAR_NUMS}
           formatterOptions={{
             tokenSymbol: data.token.symbol.toUpperCase(),
             showPlusMinusSigns: true,

--- a/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeEditor.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeEditor.tsx
@@ -17,6 +17,7 @@ import {
   SegmentControl,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useDialogInstance,
@@ -142,6 +143,7 @@ function FeeInfoItem({
               tokenSymbol: nativeSymbol,
             }}
             size="$bodyMdMedium"
+            fontVariant={TABULAR_NUMS}
           >
             {nativeValue}
           </NumberSizeableText>
@@ -151,6 +153,7 @@ function FeeInfoItem({
             formatter="balance"
             formatterOptions={{ tokenSymbol: customSymbol }}
             size="$bodyMdMedium"
+            fontVariant={TABULAR_NUMS}
           >
             {customValue}
           </NumberSizeableText>
@@ -163,6 +166,7 @@ function FeeInfoItem({
             }}
             size="$bodyMd"
             color="$textSubdued"
+            fontVariant={TABULAR_NUMS}
           >
             {fiatValue}
           </NumberSizeableText>

--- a/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
@@ -21,6 +21,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   Toast,
   XStack,
   useTheme,
@@ -1895,6 +1896,7 @@ function TxFeeInfo(props: IProps) {
           size="$bodyMd"
           color="$text"
           formatter="balance"
+          fontVariant={TABULAR_NUMS}
           formatterOptions={{
             tokenSymbol: txFeeCommon?.nativeSymbol,
             keepLeadingZero: true,
@@ -1909,6 +1911,7 @@ function TxFeeInfo(props: IProps) {
               size="$bodyMd"
               color="$textSubdued"
               formatter="value"
+              fontVariant={TABULAR_NUMS}
               formatterOptions={{
                 currency: settings.currencyInfo.symbol,
               }}
@@ -2287,6 +2290,7 @@ function TxFeeInfo(props: IProps) {
           size="$bodyMd"
           color="$text"
           formatter="balance"
+          fontVariant={TABULAR_NUMS}
           formatterOptions={{
             tokenSymbol: payTokenInfo.symbol,
             keepLeadingZero: true,
@@ -2302,6 +2306,7 @@ function TxFeeInfo(props: IProps) {
         size="$bodyMd"
         color="$text"
         formatter="balance"
+        fontVariant={TABULAR_NUMS}
         formatterOptions={{
           tokenSymbol: txFeeCommon?.nativeSymbol,
           keepLeadingZero: true,
@@ -2344,6 +2349,7 @@ function TxFeeInfo(props: IProps) {
             size="$bodyMd"
             color="$text"
             formatter="value"
+            fontVariant={TABULAR_NUMS}
             formatterOptions={{
               currency: settings.currencyInfo.symbol,
             }}
@@ -2362,6 +2368,7 @@ function TxFeeInfo(props: IProps) {
           size="$bodyMd"
           color="$text"
           formatter="value"
+          fontVariant={TABULAR_NUMS}
           formatterOptions={{
             currency: settings.currencyInfo.symbol,
           }}
@@ -2427,6 +2434,7 @@ function TxFeeInfo(props: IProps) {
             size="$bodyMd"
             color={textColor}
             formatter="balance"
+            fontVariant={TABULAR_NUMS}
             formatterOptions={{
               tokenSymbol: txFeeCommon?.nativeSymbol,
               keepLeadingZero: true,
@@ -2439,6 +2447,7 @@ function TxFeeInfo(props: IProps) {
             size="$bodyMd"
             color={textColor}
             formatter="value"
+            fontVariant={TABULAR_NUMS}
             formatterOptions={{
               currency: settings.currencyInfo.symbol,
             }}

--- a/packages/kit/src/views/Staking/components/OptionList/index.tsx
+++ b/packages/kit/src/views/Staking/components/OptionList/index.tsx
@@ -19,6 +19,7 @@ import {
   Page,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -128,6 +129,7 @@ const OptionItem = ({
               <NumberSizeableText
                 size="$bodyLgMedium"
                 formatter="balance"
+                fontVariant={TABULAR_NUMS}
                 formatterOptions={{
                   tokenSymbol: token?.symbol,
                 }}
@@ -138,6 +140,7 @@ const OptionItem = ({
                 size="$bodyMd"
                 color="$textSubdued"
                 formatter="value"
+                fontVariant={TABULAR_NUMS}
                 formatterOptions={{ currency: symbol }}
               >
                 {item.fiatValue}

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/EarnAmountText.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/EarnAmountText.tsx
@@ -1,6 +1,10 @@
 import { useMemo } from 'react';
 
-import { NumberSizeableText, SizableText } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  TABULAR_NUMS,
+} from '@onekeyhq/components';
 import type { ISizableTextProps } from '@onekeyhq/components';
 import { FormatHyperlinkText } from '@onekeyhq/kit/src/components/HyperlinkText';
 
@@ -30,9 +34,13 @@ const LEADING_NUMBER_PATTERN = /^(\d[\d,]*(?:\.\d+)?)([\s\S]*)/;
  *      while any trailing text (token symbol) is rendered as-is.
  *
  * Falls back to plain SizableText when the string does not start with a number.
+ *
+ * Every branch renders numeric data, so this component opts into tabular
+ * figures by default; callers can still override `fontVariant`.
  */
 export function EarnAmountText({
   children: text,
+  fontVariant = TABULAR_NUMS,
   ...textProps
 }: IEarnAmountTextProps) {
   const parsed = useMemo(() => {
@@ -62,18 +70,30 @@ export function EarnAmountText({
   // Delegate <subscripts> text to FormatHyperlinkText which already
   // renders them with 0.6x font size via its subscripts handler.
   if (parsed.type === 'subscripts') {
-    return <FormatHyperlinkText {...textProps}>{text}</FormatHyperlinkText>;
+    return (
+      <FormatHyperlinkText {...textProps} fontVariant={fontVariant}>
+        {text}
+      </FormatHyperlinkText>
+    );
   }
 
   // Percentages and unrecognized text: render as-is
   if (parsed.type === 'passthrough') {
-    return <SizableText {...textProps}>{text}</SizableText>;
+    return (
+      <SizableText {...textProps} fontVariant={fontVariant}>
+        {text}
+      </SizableText>
+    );
   }
 
   // Pure number without suffix
   if (!parsed.suffix) {
     return (
-      <NumberSizeableText {...textProps} formatter="balance">
+      <NumberSizeableText
+        {...textProps}
+        fontVariant={fontVariant}
+        formatter="balance"
+      >
         {parsed.number}
       </NumberSizeableText>
     );
@@ -82,10 +102,11 @@ export function EarnAmountText({
   // Mixed content (number + suffix like "0.000002948 SY-uniBTC"):
   // render inline — NumberSizeableText for number, plain text for suffix.
   return (
-    <SizableText {...textProps}>
+    <SizableText {...textProps} fontVariant={fontVariant}>
       <NumberSizeableText
         size={textProps.size}
         color={textProps.color}
+        fontVariant={fontVariant}
         formatter="balance"
       >
         {parsed.number}

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/GridItemV2.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/GridItemV2.tsx
@@ -1,4 +1,10 @@
-import { Alert, Icon, XStack, YStack } from '@onekeyhq/components';
+import {
+  Alert,
+  Icon,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import type {
   IEarnActionIcon,
@@ -75,13 +81,21 @@ export function GridItem({
             cursor="pointer"
             onPress={() => openUrlExternal(actionIcon?.data?.link)}
           >
-            <EarnText text={description} size="$bodyLgMedium" />
+            <EarnText
+              text={description}
+              size="$bodyLgMedium"
+              fontVariant={TABULAR_NUMS}
+            />
             {descriptionComponent ?? null}
             <Icon name="OpenOutline" size="$4.5" color="$iconSubdued" />
           </XStack>
         ) : (
           <>
-            <EarnText text={description} size="$bodyLgMedium" />
+            <EarnText
+              text={description}
+              size="$bodyLgMedium"
+              fontVariant={TABULAR_NUMS}
+            />
             {descriptionComponent ?? null}
             <EarnActionIcon title={title.text} actionIcon={actionIcon} />
           </>

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/PortfolioSection.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/PortfolioSection.tsx
@@ -16,6 +16,7 @@ import {
   Popover,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -87,6 +88,7 @@ function PortfolioItem({
         <NumberSizeableText
           size="$bodyLgMedium"
           formatter="balance"
+          fontVariant={TABULAR_NUMS}
           formatterOptions={{ tokenSymbol }}
         >
           {amount}
@@ -249,6 +251,7 @@ function PendingInactiveItem({
       <NumberSizeableText
         size="$bodyLgMedium"
         formatter="balance"
+        fontVariant={TABULAR_NUMS}
         formatterOptions={{ tokenSymbol }}
       >
         {pendingInactive}

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/ProtocolApyRewards.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/ProtocolApyRewards.tsx
@@ -8,6 +8,7 @@ import {
   Anchor,
   Icon,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -71,7 +72,7 @@ function ApyLineItem({
           {label}
         </SizableText>
       </XStack>
-      <SizableText size="$bodyMdMedium">
+      <SizableText size="$bodyMdMedium" fontVariant={TABULAR_NUMS}>
         {valuePrefix}
         {formatApy(value)}%
       </SizableText>
@@ -146,7 +147,11 @@ function VaultBasedApyInternal({
               id: ETranslations.earn_last_day,
             })}
           </SizableText>
-          <SizableText color="$text" size="$bodyMdMedium">
+          <SizableText
+            color="$text"
+            size="$bodyMdMedium"
+            fontVariant={TABULAR_NUMS}
+          >
             {isPositiveNumber(apys?.dailyNetApy)
               ? `${formatApy(apys?.dailyNetApy)}%`
               : '-'}
@@ -158,7 +163,11 @@ function VaultBasedApyInternal({
               id: ETranslations.earn_last_week,
             })}
           </SizableText>
-          <SizableText color="$text" size="$bodyMdMedium">
+          <SizableText
+            color="$text"
+            size="$bodyMdMedium"
+            fontVariant={TABULAR_NUMS}
+          >
             {isPositiveNumber(apys?.weeklyNetApy)
               ? `${formatApy(apys?.weeklyNetApy)}%`
               : '-'}
@@ -170,7 +179,11 @@ function VaultBasedApyInternal({
               id: ETranslations.earn_last_month,
             })}
           </SizableText>
-          <SizableText color="$text" size="$bodyMdMedium">
+          <SizableText
+            color="$text"
+            size="$bodyMdMedium"
+            fontVariant={TABULAR_NUMS}
+          >
             {isPositiveNumber(apys?.monthlyNetApy)
               ? `${formatApy(apys?.monthlyNetApy)}%`
               : '-'}

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/ProtocolRewards.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/ProtocolRewards.tsx
@@ -10,6 +10,7 @@ import {
   Popover,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -91,6 +92,7 @@ function RewardItem({
               <NumberSizeableText
                 size="$bodyLgMedium"
                 formatter="balance"
+                fontVariant={TABULAR_NUMS}
                 formatterOptions={{ tokenSymbol: rewardToken.info?.symbol }}
               >
                 {validClaimableNow.toFixed()}
@@ -101,6 +103,7 @@ function RewardItem({
                   <NumberSizeableText
                     size="$bodyLgMedium"
                     formatter="value"
+                    fontVariant={TABULAR_NUMS}
                     formatterOptions={{ currency: symbol }}
                   >
                     {fiatClaimableNowValue.lt(0.01)

--- a/packages/kit/src/views/Staking/components/StakeAssetSelectPopover.tsx
+++ b/packages/kit/src/views/Staking/components/StakeAssetSelectPopover.tsx
@@ -8,6 +8,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -61,10 +62,18 @@ function AssetRow({
       </XStack>
 
       <YStack alignItems="flex-end" flexShrink={0}>
-        <NumberSizeableText size="$bodyMd" formatter="balance">
+        <NumberSizeableText
+          size="$bodyMd"
+          formatter="balance"
+          fontVariant={TABULAR_NUMS}
+        >
           {item.balanceParsed || '0'}
         </NumberSizeableText>
-        <SizableText size="$bodySm" color="$textSubdued">
+        <SizableText
+          size="$bodySm"
+          color="$textSubdued"
+          fontVariant={TABULAR_NUMS}
+        >
           {formatFiatValue(item.fiatValue)}
         </SizableText>
       </YStack>

--- a/packages/kit/src/views/Staking/components/ValuePriceListItem/index.tsx
+++ b/packages/kit/src/views/Staking/components/ValuePriceListItem/index.tsx
@@ -1,4 +1,9 @@
-import { NumberSizeableText, SizableText, Stack } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  Stack,
+  TABULAR_NUMS,
+} from '@onekeyhq/components';
 
 export const ValuePriceListItem = ({
   amount,
@@ -28,6 +33,7 @@ export const ValuePriceListItem = ({
       <NumberSizeableText
         size="$bodyLgMedium"
         textAlign="right"
+        fontVariant={TABULAR_NUMS}
         formatter="balance"
         formatterOptions={{ tokenSymbol }}
       >
@@ -46,6 +52,7 @@ export const ValuePriceListItem = ({
           <NumberSizeableText
             textAlign="right"
             size="$bodyLgMedium"
+            fontVariant={TABULAR_NUMS}
             formatter="value"
             color="$textSubdued"
             formatterOptions={{ currency: fiatSymbol }}

--- a/packages/kit/src/views/Staking/pages/AssetProtocolList/index.tsx
+++ b/packages/kit/src/views/Staking/pages/AssetProtocolList/index.tsx
@@ -13,6 +13,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -211,6 +212,7 @@ function AssetProtocolListContent({
                 userSelect="none"
                 color="$textSubdued"
                 size="$bodyMd"
+                fontVariant={TABULAR_NUMS}
                 formatterOptions={{ currency: currencySymbol }}
                 formatter="marketCap"
               >
@@ -228,6 +230,9 @@ function AssetProtocolListContent({
                   }`
                 : null
             }
+            primaryTextProps={{
+              fontVariant: TABULAR_NUMS,
+            }}
             secondary={
               item.provider.isStaking
                 ? intl.formatMessage({

--- a/packages/kit/src/views/Staking/pages/EarnTokenSelect/index.tsx
+++ b/packages/kit/src/views/Staking/pages/EarnTokenSelect/index.tsx
@@ -10,6 +10,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   useSafeAreaInsets,
@@ -76,10 +77,18 @@ function TokenRow({
       </XStack>
 
       <YStack alignItems="flex-end" flexShrink={0}>
-        <NumberSizeableText size="$bodyMd" formatter="balance">
+        <NumberSizeableText
+          size="$bodyMd"
+          formatter="balance"
+          fontVariant={TABULAR_NUMS}
+        >
           {item.balanceParsed || '0'}
         </NumberSizeableText>
-        <SizableText size="$bodySm" color="$textSubdued">
+        <SizableText
+          size="$bodySm"
+          color="$textSubdued"
+          fontVariant={TABULAR_NUMS}
+        >
           {formatFiatValue(item.fiatValue)}
         </SizableText>
       </YStack>

--- a/packages/kit/src/views/Staking/pages/HistoryList/index.tsx
+++ b/packages/kit/src/views/Staking/pages/HistoryList/index.tsx
@@ -12,6 +12,7 @@ import {
   SectionList,
   Select,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -163,6 +164,7 @@ const HistoryItem = ({
           <NumberSizeableText
             size="$bodyLgMedium"
             formatter="balance"
+            fontVariant={TABULAR_NUMS}
             color={item.direction === 'receive' ? '$textSuccess' : undefined}
             formatterOptions={{
               tokenSymbol: token?.symbol,

--- a/packages/kit/src/views/Staking/pages/InvestmentDetails/index.tsx
+++ b/packages/kit/src/views/Staking/pages/InvestmentDetails/index.tsx
@@ -15,6 +15,7 @@ import {
   SectionList,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -312,6 +313,7 @@ function BasicInvestmentDetails() {
               <NumberSizeableText
                 size="$bodyLgMedium"
                 formatter="balance"
+                fontVariant={TABULAR_NUMS}
                 formatterOptions={{ tokenSymbol: tokenInfo.symbol }}
               >
                 {staked}
@@ -320,6 +322,7 @@ function BasicInvestmentDetails() {
                 size="$bodyMd"
                 color="$textSubdued"
                 formatter="balance"
+                fontVariant={TABULAR_NUMS}
                 formatterOptions={{
                   currency: settings.currencyInfo.symbol,
                 }}

--- a/packages/kit/src/views/Swap/components/PreSwapInfoGroup.tsx
+++ b/packages/kit/src/views/Swap/components/PreSwapInfoGroup.tsx
@@ -15,6 +15,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -359,6 +360,7 @@ const PreSwapInfoGroup = ({
           <NumberSizeableText
             size="$bodyMd"
             color="$text"
+            fontVariant={TABULAR_NUMS}
             formatter="value"
             formatterOptions={{ currency: settings.currencyInfo.symbol }}
           >
@@ -420,7 +422,11 @@ const PreSwapInfoGroup = ({
           title={intl.formatMessage({
             id: ETranslations.swap_page_provider_slippage_tolerance,
           })}
-          value={`${slippage}%`}
+          value={
+            <SizableText size="$bodyMd" fontVariant={TABULAR_NUMS}>
+              {`${slippage}%`}
+            </SizableText>
+          }
           popoverContent={intl.formatMessage({
             id: ETranslations.slippage_tolerance_warning_message_1,
           })}
@@ -438,6 +444,7 @@ const PreSwapInfoGroup = ({
           value={
             <NumberSizeableText
               size="$bodyMd"
+              fontVariant={TABULAR_NUMS}
               formatter="balance"
               formatterOptions={{
                 tokenSymbol: preSwapData?.toToken?.symbol ?? '-',

--- a/packages/kit/src/views/Swap/components/ProtocolFeeComparisonList.tsx
+++ b/packages/kit/src/views/Swap/components/ProtocolFeeComparisonList.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useMemo } from 'react';
 
-import { Image, SizableText, Stack, XStack } from '@onekeyhq/components';
+import {
+  Image,
+  SizableText,
+  Stack,
+  TABULAR_NUMS,
+  XStack,
+} from '@onekeyhq/components';
 import type { IImageProps } from '@onekeyhq/components';
 import { otherWalletFeeData } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 
@@ -36,6 +42,7 @@ export function ProtocolFeeComparisonList({
         <SizableText
           size="$bodySm"
           color={item.name === 'oneKey' ? '$textSuccess' : '$text'}
+          fontVariant={TABULAR_NUMS}
           textAlign="right"
         >
           {item.fee}%

--- a/packages/kit/src/views/Swap/components/SwapProBuySellInfo.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProBuySellInfo.tsx
@@ -6,6 +6,7 @@ import {
   NumberSizeableText,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -45,6 +46,7 @@ const SwapProBuySellInfo = ({
       <NumberSizeableText
         size="$bodySm"
         color="$textSuccess"
+        fontVariant={TABULAR_NUMS}
         formatter={isAboveThreshold ? 'marketCap' : 'value'}
         formatterOptions={{ currency: '$' }}
       >
@@ -68,6 +70,7 @@ const SwapProBuySellInfo = ({
       <NumberSizeableText
         size="$bodySm"
         color="$textCritical"
+        fontVariant={TABULAR_NUMS}
         formatter={isAboveThreshold ? 'marketCap' : 'value'}
         formatterOptions={{ currency: '$' }}
       >
@@ -143,7 +146,12 @@ const SwapProBuySellInfo = ({
               B
             </SizableText>
           </Stack>
-          <SizableText size="$bodyXs" color="$textSuccess" ml="$0.5">
+          <SizableText
+            size="$bodyXs"
+            color="$textSuccess"
+            fontVariant={TABULAR_NUMS}
+            ml="$0.5"
+          >
             {!supportSpeedSwap ? '--' : buyPercentage.toFixed(2)}%
           </SizableText>
         </XStack>
@@ -154,7 +162,12 @@ const SwapProBuySellInfo = ({
           position="relative"
           zIndex={1}
         >
-          <SizableText size="$bodyXs" color="$textCritical" mr="$0.5">
+          <SizableText
+            size="$bodyXs"
+            color="$textCritical"
+            fontVariant={TABULAR_NUMS}
+            mr="$0.5"
+          >
             {!supportSpeedSwap ? '--' : sellPercentage.toFixed(2)}%
           </SizableText>
           <Stack

--- a/packages/kit/src/views/Swap/components/SwapProPositionItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProPositionItem.tsx
@@ -109,6 +109,7 @@ const SwapProPositionItem = ({
           <NumberSizeableText
             size="$bodyMd"
             color="$textSubdued"
+            fontVariant={TABULAR_NUMS}
             formatter="balance"
             numberOfLines={1}
           >

--- a/packages/kit/src/views/Swap/components/SwapProPositionItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProPositionItem.tsx
@@ -8,6 +8,7 @@ import {
   NumberSizeableText,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -119,6 +120,7 @@ const SwapProPositionItem = ({
       <YStack alignItems="flex-end" flexShrink={0}>
         <NumberSizeableText
           size="$bodyLgMedium"
+          fontVariant={TABULAR_NUMS}
           formatter="value"
           formatterOptions={{ currency: currencyInfo.symbol }}
           numberOfLines={1}
@@ -140,6 +142,7 @@ const SwapProPositionItem = ({
               <Currency
                 size="$bodyMd"
                 color={pnlDisplay.color}
+                fontVariant={TABULAR_NUMS}
                 formatter="value"
                 sourceCurrency="usd"
                 numberOfLines={1}
@@ -150,6 +153,7 @@ const SwapProPositionItem = ({
             <SizableText
               size="$bodyMd"
               color={pnlDisplay.color}
+              fontVariant={TABULAR_NUMS}
               numberOfLines={1}
             >
               {`(${pnlDisplay.percent}%)`}

--- a/packages/kit/src/views/Swap/components/SwapProTokenTransactionItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProTokenTransactionItem.tsx
@@ -2,7 +2,12 @@ import { useMemo } from 'react';
 
 import BigNumber from 'bignumber.js';
 
-import { NumberSizeableText, SizableText, XStack } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+} from '@onekeyhq/components';
 import type { IMarketTokenTransaction } from '@onekeyhq/shared/types/marketV2';
 
 interface ISwapProTokenTransactionItemProps {
@@ -42,6 +47,7 @@ const SwapProTokenTransactionItem = ({
         <NumberSizeableText
           size="$bodySm"
           color={textColorValue}
+          fontVariant={TABULAR_NUMS}
           formatter={isAboveThreshold ? 'marketCap' : 'price'}
           formatterOptions={{
             currency: '$',
@@ -66,6 +72,7 @@ const SwapProTokenTransactionItem = ({
         <NumberSizeableText
           size="$bodySm"
           color={textColorValue}
+          fontVariant={TABULAR_NUMS}
           formatter={isAboveThreshold ? 'marketCap' : 'value'}
           formatterOptions={{
             currency: '$',

--- a/packages/kit/src/views/Swap/components/SwapProviderListItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProviderListItem.tsx
@@ -13,6 +13,7 @@ import {
   NumberSizeableText,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   Tooltip,
   XStack,
 } from '@onekeyhq/components';
@@ -82,6 +83,7 @@ const SwapProviderListItem = ({
           <NumberSizeableText
             size="$bodyMd"
             color="$textSubdued"
+            fontVariant={TABULAR_NUMS}
             formatter="value"
             formatterOptions={{
               currency: currencySymbol,
@@ -117,7 +119,11 @@ const SwapProviderListItem = ({
             }
             placement="bottom-start"
           />
-          <SizableText size="$bodyMd" color="$textSubdued">
+          <SizableText
+            size="$bodyMd"
+            color="$textSubdued"
+            fontVariant={TABULAR_NUMS}
+          >
             {displayTime}
           </SizableText>
         </XStack>
@@ -146,6 +152,7 @@ const SwapProviderListItem = ({
         <NumberSizeableText
           size="$bodyMd"
           color="$textSubdued"
+          fontVariant={TABULAR_NUMS}
           formatter="value"
           formatterOptions={{
             currency: currencySymbol,

--- a/packages/kit/src/views/Swap/components/SwapTxHistoryListCell.tsx
+++ b/packages/kit/src/views/Swap/components/SwapTxHistoryListCell.tsx
@@ -7,6 +7,7 @@ import {
   Badge,
   NumberSizeableText,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   YStack,
 } from '@onekeyhq/components';
@@ -275,6 +276,7 @@ const SwapTxHistoryListCell = ({
             <NumberSizeableText
               size="$bodyMdMedium"
               color="$textSuccess"
+              fontVariant={TABULAR_NUMS}
               formatter="balance"
               pointerEvents="none"
             >
@@ -298,6 +300,7 @@ const SwapTxHistoryListCell = ({
             <NumberSizeableText
               size="$bodySm"
               color="$textSubdued"
+              fontVariant={TABULAR_NUMS}
               formatter="balance"
               pointerEvents="none"
             >

--- a/packages/kit/src/views/Swap/pages/components/SwapProSearchTokenListItem.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProSearchTokenListItem.tsx
@@ -1,6 +1,11 @@
 import { memo } from 'react';
 
-import { SizableText, XStack, YStack } from '@onekeyhq/components';
+import {
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { EWatchlistFrom } from '@onekeyhq/shared/src/logger/scopes/dex';
 import type { IMarketSearchV2Token } from '@onekeyhq/shared/types/market';
@@ -66,6 +71,7 @@ const SwapProSearchTokenListItem = ({
           <BaseMarketTokenPrice
             price={price}
             size="$bodyLgMedium"
+            fontVariant={TABULAR_NUMS}
             tokenName={name}
             tokenSymbol={symbol}
           />

--- a/packages/kit/src/views/Swap/pages/components/SwapProTokenDetailGroup/valueRenderers.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProTokenDetailGroup/valueRenderers.tsx
@@ -1,6 +1,11 @@
 import BigNumber from 'bignumber.js';
 
-import { NumberSizeableText, SizableText, XStack } from '@onekeyhq/components';
+import {
+  NumberSizeableText,
+  SizableText,
+  TABULAR_NUMS,
+  XStack,
+} from '@onekeyhq/components';
 
 import { ITEM_VALUE_PROPS } from './constants';
 
@@ -24,6 +29,7 @@ export function renderCurrencyValue(
   return (
     <NumberSizeableText
       size={ITEM_VALUE_PROPS.size}
+      fontVariant={TABULAR_NUMS}
       formatter={
         options?.forceMarketCapFormatter || isAboveThreshold
           ? 'marketCap'
@@ -42,6 +48,7 @@ export function renderAmountValue(value?: string | number) {
   return (
     <NumberSizeableText
       size={ITEM_VALUE_PROPS.size}
+      fontVariant={TABULAR_NUMS}
       formatter={isAboveThreshold ? 'marketCap' : 'value'}
     >
       {normalizedValue}
@@ -60,7 +67,11 @@ export function renderRatioValue(value?: string | number | null) {
   }
 
   return (
-    <NumberSizeableText size={ITEM_VALUE_PROPS.size} formatter="value">
+    <NumberSizeableText
+      size={ITEM_VALUE_PROPS.size}
+      fontVariant={TABULAR_NUMS}
+      formatter="value"
+    >
       {normalizedValue}
     </NumberSizeableText>
   );
@@ -78,7 +89,11 @@ export function renderPercentValue(value?: string | number | null) {
 
   return (
     <XStack alignItems="center">
-      <NumberSizeableText size={ITEM_VALUE_PROPS.size} formatter="marketCap">
+      <NumberSizeableText
+        size={ITEM_VALUE_PROPS.size}
+        fontVariant={TABULAR_NUMS}
+        formatter="marketCap"
+      >
         {normalizedValue}
       </NumberSizeableText>
       <SizableText size={ITEM_VALUE_PROPS.size}>%</SizableText>
@@ -98,6 +113,7 @@ export function renderHoldersValue({
   return (
     <NumberSizeableText
       size={ITEM_VALUE_PROPS.size}
+      fontVariant={TABULAR_NUMS}
       formatter={isAboveThreshold ? 'marketCap' : 'value'}
     >
       {isNative ? '-' : holderValue}

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -20,6 +20,7 @@ import {
   SizableText,
   Skeleton,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   resetToRoute,
@@ -1430,6 +1431,7 @@ function StockMarketTokenHeader({
         <BaseMarketTokenPrice
           size="$bodyLg"
           color="$text"
+          fontVariant={TABULAR_NUMS}
           numberOfLines={1}
           textAlign="right"
           price={tokenDetail.price ?? tokenDetail.priceConverted ?? ''}

--- a/packages/kit/src/views/Tray/components/PendingTransactions.tsx
+++ b/packages/kit/src/views/Tray/components/PendingTransactions.tsx
@@ -3,7 +3,7 @@ import type { ComponentProps } from 'react';
 import BigNumber from 'bignumber.js';
 import { type IntlShape, useIntl } from 'react-intl';
 
-import { SizableText, Stack } from '@onekeyhq/components';
+import { SizableText, Stack, TABULAR_NUMS } from '@onekeyhq/components';
 import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
 import useFormatDate from '@onekeyhq/kit/src/hooks/useFormatDate';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -315,6 +315,7 @@ function TxRow({
       <NumberSizeableTextWrapper
         size={size}
         color={color}
+        fontVariant={TABULAR_NUMS}
         formatter="balance"
         formatterOptions={{ tokenSymbol: value.symbol }}
         subTextStyle={TRAY_AMOUNT_SUB_TEXT_STYLE}

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchAccountAssetItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchAccountAssetItem.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 
 import BigNumber from 'bignumber.js';
 
-import { NumberSizeableText, Stack } from '@onekeyhq/components';
+import { NumberSizeableText, Stack, TABULAR_NUMS } from '@onekeyhq/components';
 import { Currency } from '@onekeyhq/kit/src/components/Currency';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
@@ -153,6 +153,7 @@ export function UniversalSearchAccountAssetItem({
           formatterOptions={{ tokenSymbol: token?.symbol }}
           size="$bodyMd"
           color="$textSubdued"
+          fontVariant={TABULAR_NUMS}
           hideValue={hideValue}
         >
           {tokenFiat?.balanceParsed ?? '0'}
@@ -163,6 +164,7 @@ export function UniversalSearchAccountAssetItem({
           formatter="value"
           sourceCurrency={tokenFiat?.currency}
           size="$bodyLgMedium"
+          fontVariant={TABULAR_NUMS}
           hideValue={hideValue}
         >
           {fiatValue.isNaN() ? 0 : fiatValue.toFixed()}
@@ -172,6 +174,7 @@ export function UniversalSearchAccountAssetItem({
           formatterOptions={{ showPlusMinusSigns }}
           color={changeColor}
           size="$bodyMd"
+          fontVariant={TABULAR_NUMS}
         >
           {priceChange}
         </NumberSizeableText>

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchPerpItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchPerpItem.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from 'react';
 import {
   NumberSizeableText,
   SizableText,
+  TABULAR_NUMS,
   XStack,
   rootNavigationRef,
 } from '@onekeyhq/components';
@@ -186,6 +187,7 @@ export function UniversalSearchPerpItem({
         formatterOptions={{ currency: '$' }}
         size="$bodyLgMedium"
         color="$text"
+        fontVariant={TABULAR_NUMS}
       >
         {midPx}
       </NumberSizeableText>

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -8,6 +8,7 @@ import {
   NumberSizeableText,
   SizableText,
   Stack,
+  TABULAR_NUMS,
   XStack,
   YStack,
   rootNavigationRef,
@@ -370,6 +371,7 @@ export function UniversalSearchV2MarketTokenItem({
             size="$bodyMd"
             tokenName={name}
             tokenSymbol={symbol}
+            fontVariant={TABULAR_NUMS}
           />
           {priceChange24hPercent ? (
             <NumberSizeableText
@@ -379,6 +381,7 @@ export function UniversalSearchV2MarketTokenItem({
               formatterOptions={{
                 showPlusMinusSigns: priceChangeStyle.showPlusMinusSigns,
               }}
+              fontVariant={TABULAR_NUMS}
             >
               {priceChange24hPercent}
             </NumberSizeableText>
@@ -392,6 +395,7 @@ export function UniversalSearchV2MarketTokenItem({
               size="$bodyMd"
               formatter="marketCap"
               formatterOptions={{ capAtMaxT: true }}
+              fontVariant={TABULAR_NUMS}
             >
               {BigNumber(liquidity).gt(0) ? liquidity : '--'}
             </NumberSizeableText>
@@ -405,6 +409,7 @@ export function UniversalSearchV2MarketTokenItem({
               size="$bodyMd"
               formatter="marketCap"
               formatterOptions={{ capAtMaxT: true }}
+              fontVariant={TABULAR_NUMS}
             >
               {BigNumber(volume24h).gt(0) ? volume24h : '--'}
             </NumberSizeableText>


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57876](https://onekeyhq.atlassian.net/browse/OK-57876)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

Inverts the tabular-numerals policy shipped in #12391.

**Before:** `SizableText` defaulted `fontVariant = TABULAR_NUMS` and `web-fonts.css` carried a `body { font-variant-numeric: tabular-nums }` rule — so *every* string in the app rendered with equal-width digits.

**After:** text is **proportional by default**. Tabular figures are an explicit **opt-in**, applied only to numbers that are **small, sit in a column, and tick** — market/perps list columns, order books, trading tables, tickers, fee rows.

Supersedes #12443 (which was patching the symptoms) and fixes [OK-57876](https://onekeyhq.atlassian.net/browse/OK-57876).

## Why invert

Tabular digits exist to keep a *column* aligned. A global default applies them to everything a human reads as words, where they are actively wrong:

- **Names** — `A1787`, `OneKey Pro2-1-6`. Roobert's tabular `1` is ~2× wider and grows a foot serif; a name reads like a typo. (This is OK-57876.)
- **Addresses** — `0x7a84...4444`. Hex mixes digits and letters, so tabular equalizes only *half* the characters and the string comes out ragged — worse than either pure option.
- **Prose / marketing copy**, **amount input fields**, and **large hero balances** (a single big number has no column to align with).

Under the old default each of these needed its own opt-out, and the list only ever grew. The set of surfaces that genuinely *want* tabular, by contrast, is bounded and enumerable: tables and tickers. So the default was on the wrong side.

Net effect: names, addresses, prose, inputs and hero numbers are now correct **with zero annotations** — the escape hatches for them are all deleted.

## The rule

| | |
|---|---|
| **Tabular (opt-in)** | Small numbers in a column that tick — list/table cells, order book, tickers, fee rows |
| **Proportional (default)** | Everything else — names, addresses, labels, headers, prose, inputs, hero numbers |

Documented on `TABULAR_NUMS` in `packages/components/src/utils/tabularNums.ts`.

## Changes

**Core (`@onekeyhq/components`)**
- `SizableText` — dropped the app-wide `fontVariant` default (it still *translates* an explicit `fontVariant` into a real style, since Tamagui drops the raw prop).
- `web-fonts.css` — dropped the global `body` rule.
- `tabularNums.ts` — `TABULAR_NUMS_STYLE` now always builds a real style. It previously resolved to `undefined` on web because the body rule covered it; without that rule, an explicit opt-in would have been a **no-op on web**. `PROPORTIONAL_NUMS` is gone — it has nothing left to escape from.
- `Badge.Text` — no longer hard-codes tabular; it now honors a `fontVariant` prop (it is styled from raw tamagui text, which silently drops the prop).

**Opt-ins** — market/perps list columns, order book (incl. the raw-RN `<Text>` depth rows), ticker bars, perps trading tables, token/home lists, DeFi & Earn/Borrow/Staking tables, transaction history, Swap Pro, provider/quote lists, referral tables, gas-fee editors.

New shared choke-point `PerpTableCellText` collapses ~89 perps table cells into one component, so a new column can't silently forget.

## Verification

- `tsgo --noEmit`: no new errors. `oxlint --type-aware --deny-warnings` on all 120 files: clean.
- Roobert's glyphs were confirmed by rendering the shipped font directly: the tabular `1` nearly doubles in width and gains a foot serif; the proportional `1` does not.
- Live web probes assert the split **in both directions** per screen:
  - Market — 446 numeric cells tabular; category names, badges and **all 35 addresses** proportional.
  - Perps — 113 tabular (mark price, order book, funding, countdown); labels and controls proportional.
  - DeFi — APY columns tabular; the `$0.00` hero proportional.

## Review notes

A cross-review (local + Codex) caught real gaps in the first pass, all fixed here:
- **`TxActionCommon`'s opt-in was dead.** Real transfers pass the amount as a `ReactNode`, which bypassed the `typeof change === 'string'` branch the prop was added to — the wallet's whole transaction-history amount column was silently untouched. Fixed at the `TxActionTransfer` / `TxActionTokenApprove` sources.
- **`MarketHomeList` was half-converted**, which is worse than untouched — its volume / market-cap / rank columns jittered against already-tabular price cells in the same table.
- **Whole modules had been missed**: Staking, Referral, the two gas-fee editors, Home's perps tab, PopularTrading.


[OK-57876]: https://onekeyhq.atlassian.net/browse/OK-57876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ