### PR TITLE
feat: confirm Native instant withdraw fee before withdrawing

### DIFF
--- a/packages/kit-bg/src/services/ServiceStaking.ts
+++ b/packages/kit-bg/src/services/ServiceStaking.ts
@@ -468,6 +468,13 @@ class ServiceStaking extends ServiceBase {
 
   @backgroundMethod()
   async buildUnstakeTransaction(params: IWithdrawBaseParams) {
+    if (
+      earnUtils.isNativeProvider({ providerName: params.provider }) &&
+      params.withdrawType === undefined
+    ) {
+      throw new OneKeyLocalError('Native withdrawal type is required');
+    }
+
     const { networkId, accountId, protocolVault, effectiveApy, ...rest } =
       params;
     const client = await this.getClient(EServiceEndpointEnum.Earn);

--- a/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
@@ -48,7 +48,6 @@ import {
 import type {
   ICheckAmountAlert,
   IEarnEstimateFeeResp,
-  IEarnText,
   IEarnTokenInfo,
   IEarnTransactionTip,
   IEarnWithdrawType,
@@ -94,6 +93,13 @@ import {
 } from '../StakingAmountInput';
 import StakingFormWrapper from '../StakingFormWrapper';
 
+import {
+  clampWithdrawPathIndex,
+  resolveSelectedWithdrawPath,
+  shouldConfirmNativeInstantWithdrawFee,
+} from './withdrawPathUtils';
+
+import type { IWithdrawPathBox } from './withdrawPathUtils';
 import type { FontSizeTokens } from 'tamagui';
 
 type IFooterActionOverride = {
@@ -185,16 +191,6 @@ type IUniversalWithdrawProps = {
 };
 
 const WITHDRAW_ACCORDION_KEY = 'withdraw-accordion-content';
-
-type IWithdrawPathBox = {
-  title: IEarnText;
-  description: IEarnText;
-  subtitle?: IEarnText;
-  subtitleDescription?: IEarnText;
-  withdrawType?: IEarnWithdrawType;
-  disabled?: boolean;
-  tip?: IEarnTransactionTip;
-};
 
 type IWithdrawPathDialogContentProps = {
   boxes: IWithdrawPathBox[];
@@ -413,13 +409,14 @@ export function UniversalWithdraw({
     transactionConfirmation?.withdrawPath?.data?.confirmBoxes,
   ]);
 
-  const effectiveSelectedWithdrawPathIndex = useMemo(() => {
-    if (withdrawPathConfirmBoxes.length <= 1) return 0;
-    return Math.min(
-      Math.max(selectedWithdrawPathIndex, 0),
-      withdrawPathConfirmBoxes.length - 1,
-    );
-  }, [selectedWithdrawPathIndex, withdrawPathConfirmBoxes.length]);
+  const effectiveSelectedWithdrawPathIndex = useMemo(
+    () =>
+      clampWithdrawPathIndex({
+        selectedIndex: selectedWithdrawPathIndex,
+        boxesLength: withdrawPathConfirmBoxes.length,
+      }),
+    [selectedWithdrawPathIndex, withdrawPathConfirmBoxes.length],
+  );
 
   useEffect(() => {
     if (selectedWithdrawPathIndex !== effectiveSelectedWithdrawPathIndex) {
@@ -427,13 +424,14 @@ export function UniversalWithdraw({
     }
   }, [effectiveSelectedWithdrawPathIndex, selectedWithdrawPathIndex]);
 
-  const selectedWithdrawPath = useMemo(() => {
-    if (!withdrawPathConfirmBoxes.length) return undefined;
-    return (
-      withdrawPathConfirmBoxes[effectiveSelectedWithdrawPathIndex] ??
-      withdrawPathConfirmBoxes[0]
-    );
-  }, [withdrawPathConfirmBoxes, effectiveSelectedWithdrawPathIndex]);
+  const selectedWithdrawPath = useMemo(
+    () =>
+      resolveSelectedWithdrawPath({
+        boxes: withdrawPathConfirmBoxes,
+        selectedIndex: effectiveSelectedWithdrawPathIndex,
+      }),
+    [withdrawPathConfirmBoxes, effectiveSelectedWithdrawPathIndex],
+  );
 
   const selectedWithdrawType = useMemo<IEarnWithdrawType | undefined>(() => {
     if (isCancelWithdrawal) return 'cancel';
@@ -862,9 +860,11 @@ export function UniversalWithdraw({
       // Native charges a protocol fee on instant withdrawals; require an
       // explicit confirmation whether instant is the default or user-picked.
       if (
-        isNativeProvider &&
-        !isCancelWithdrawal &&
-        selectedWithdrawType === 'instant'
+        shouldConfirmNativeInstantWithdrawFee({
+          providerName: providerName ?? '',
+          isCancelWithdrawal,
+          withdrawType: selectedWithdrawType,
+        })
       ) {
         const feeConfirmed = await showNativeInstantWithdrawFeeDialog(intl);
         if (!feeConfirmed) return;
@@ -935,7 +935,6 @@ export function UniversalWithdraw({
     pendingEthenaCooldownUnstake,
     selectedWithdrawType,
     isCancelWithdrawal,
-    isNativeProvider,
   ]);
 
   const [checkAmountLoading, setCheckAmountLoading] = useState(false);

--- a/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
@@ -97,6 +97,7 @@ import {
   clampWithdrawPathIndex,
   resolveSelectedWithdrawPath,
   shouldConfirmNativeInstantWithdrawFee,
+  shouldWaitForNativeWithdrawPath,
 } from './withdrawPathUtils';
 
 import type { IWithdrawPathBox } from './withdrawPathUtils';
@@ -361,6 +362,9 @@ export function UniversalWithdraw({
     isCancelWithdrawal ? '0' : (initialAmount ?? ''),
   );
   const [selectedWithdrawPathIndex, setSelectedWithdrawPathIndex] = useState(0);
+  const [preferredWithdrawType, setPreferredWithdrawType] = useState<
+    IEarnWithdrawType | undefined
+  >();
   const [withdrawProgressStep, setWithdrawProgressStep] = useState(
     EStakeProgressStep.approve,
   );
@@ -372,6 +376,9 @@ export function UniversalWithdraw({
   const [transactionConfirmation, setTransactionConfirmation] = useState<
     IStakeTransactionConfirmation | undefined
   >();
+  const [transactionConfirmationLoading, setTransactionConfirmationLoading] =
+    useState(false);
+  const transactionConfirmationRequestIdRef = useRef(0);
 
   // Sign message hook and refs for withdraw all signature
   const signPersonalMessage = useEarnSignMessageWithoutVerify();
@@ -392,6 +399,11 @@ export function UniversalWithdraw({
     () => earnUtils.isNativeProvider({ providerName: providerName ?? '' }),
     [providerName],
   );
+  const transactionConfirmationRequestAmount = useMemo(() => {
+    if (!isNativeProvider) return amountValue;
+    const amountBN = new BigNumber(amountValue);
+    return amountBN.isNaN() ? amountValue : amountBN.toFixed();
+  }, [amountValue, isNativeProvider]);
   const shouldSendProtocolVault = useMemo(
     () =>
       earnUtils.shouldSendEarnProtocolVault({
@@ -409,14 +421,29 @@ export function UniversalWithdraw({
     transactionConfirmation?.withdrawPath?.data?.confirmBoxes,
   ]);
 
-  const effectiveSelectedWithdrawPathIndex = useMemo(
+  const selectedWithdrawPath = useMemo(
     () =>
-      clampWithdrawPathIndex({
+      resolveSelectedWithdrawPath({
+        boxes: withdrawPathConfirmBoxes,
         selectedIndex: selectedWithdrawPathIndex,
-        boxesLength: withdrawPathConfirmBoxes.length,
+        preferredWithdrawType,
       }),
-    [selectedWithdrawPathIndex, withdrawPathConfirmBoxes.length],
+    [
+      preferredWithdrawType,
+      selectedWithdrawPathIndex,
+      withdrawPathConfirmBoxes,
+    ],
   );
+
+  const effectiveSelectedWithdrawPathIndex = useMemo(() => {
+    if (!selectedWithdrawPath) return 0;
+    const resolvedIndex =
+      withdrawPathConfirmBoxes.indexOf(selectedWithdrawPath);
+    return clampWithdrawPathIndex({
+      selectedIndex: resolvedIndex,
+      boxesLength: withdrawPathConfirmBoxes.length,
+    });
+  }, [selectedWithdrawPath, withdrawPathConfirmBoxes]);
 
   useEffect(() => {
     if (selectedWithdrawPathIndex !== effectiveSelectedWithdrawPathIndex) {
@@ -424,19 +451,38 @@ export function UniversalWithdraw({
     }
   }, [effectiveSelectedWithdrawPathIndex, selectedWithdrawPathIndex]);
 
-  const selectedWithdrawPath = useMemo(
-    () =>
-      resolveSelectedWithdrawPath({
-        boxes: withdrawPathConfirmBoxes,
-        selectedIndex: effectiveSelectedWithdrawPathIndex,
-      }),
-    [withdrawPathConfirmBoxes, effectiveSelectedWithdrawPathIndex],
-  );
+  useEffect(() => {
+    if (
+      preferredWithdrawType &&
+      withdrawPathConfirmBoxes.length > 0 &&
+      !withdrawPathConfirmBoxes.some(
+        (box) => box.withdrawType === preferredWithdrawType,
+      )
+    ) {
+      setPreferredWithdrawType(undefined);
+    }
+  }, [preferredWithdrawType, withdrawPathConfirmBoxes]);
 
   const selectedWithdrawType = useMemo<IEarnWithdrawType | undefined>(() => {
     if (isCancelWithdrawal) return 'cancel';
     return selectedWithdrawPath?.withdrawType;
   }, [isCancelWithdrawal, selectedWithdrawPath?.withdrawType]);
+
+  const isNativeWithdrawPathPending = useMemo(
+    () =>
+      shouldWaitForNativeWithdrawPath({
+        providerName: providerName ?? '',
+        isCancelWithdrawal,
+        withdrawType: selectedWithdrawType,
+        isLoading: transactionConfirmationLoading,
+      }),
+    [
+      isCancelWithdrawal,
+      providerName,
+      selectedWithdrawType,
+      transactionConfirmationLoading,
+    ],
+  );
 
   const rootTransactionTip = useMemo(
     () =>
@@ -791,13 +837,66 @@ export function UniversalWithdraw({
       setIgnoreAllowanceCheck(false);
       setPendingEthenaCooldownUnstake(false);
       setWithdrawProgressStep(EStakeProgressStep.approve);
+      if (isNativeProvider) {
+        setTransactionConfirmationLoading(true);
+      }
+      setPreferredWithdrawType(targetBox.withdrawType);
       setSelectedWithdrawPathIndex(index);
     },
-    [withdrawPathConfirmBoxes],
+    [isNativeProvider, withdrawPathConfirmBoxes],
   );
+
+  const withdrawSubmissionContext = useMemo(
+    () => ({
+      accountAddress,
+      accountId,
+      amount: transactionConfirmationRequestAmount,
+      networkId,
+      providerName,
+      actionSymbol,
+      protocolVault: shouldSendProtocolVault ? protocolVault : undefined,
+      identity,
+      transactionInputTokenAddress,
+      transactionOutputTokenAddress,
+      pendleSlippage,
+      selectedWithdrawType,
+      isDisabled,
+    }),
+    [
+      accountAddress,
+      accountId,
+      actionSymbol,
+      identity,
+      isDisabled,
+      networkId,
+      pendleSlippage,
+      protocolVault,
+      providerName,
+      selectedWithdrawType,
+      shouldSendProtocolVault,
+      transactionInputTokenAddress,
+      transactionOutputTokenAddress,
+      transactionConfirmationRequestAmount,
+    ],
+  );
+  const withdrawSubmissionContextRef = useRef(withdrawSubmissionContext);
+  withdrawSubmissionContextRef.current = withdrawSubmissionContext;
 
   const onPress = useCallback(async () => {
     try {
+      const submissionContext = withdrawSubmissionContext;
+      const submitAmount = transactionConfirmationRequestAmount;
+      const submitWithdrawAll = withdrawAllRef.current;
+      let nativePreflightRequestId: number | undefined;
+      const isCurrentConfirmationRequest = () =>
+        submissionContext === withdrawSubmissionContextRef.current &&
+        (nativePreflightRequestId === undefined ||
+          nativePreflightRequestId ===
+            transactionConfirmationRequestIdRef.current);
+      const isCurrentSubmission = () =>
+        isCurrentConfirmationRequest() &&
+        submitWithdrawAll === withdrawAllRef.current;
+
       Keyboard.dismiss();
       setLoading(true);
       ethenaCooldownCompletedRef.current = false;
@@ -808,6 +907,80 @@ export function UniversalWithdraw({
         effectiveSelectedWithdrawPathIndex === 0;
       const shouldResumeEthenaCooldownUnstake =
         shouldUseEthenaCooldown && pendingEthenaCooldownUnstake;
+      let confirmedWithdrawType = selectedWithdrawType;
+      let confirmedEffectiveApy = transactionConfirmation?.effectiveApy;
+
+      if (isNativeProvider && !isCancelWithdrawal) {
+        nativePreflightRequestId =
+          transactionConfirmationRequestIdRef.current + 1;
+        transactionConfirmationRequestIdRef.current = nativePreflightRequestId;
+        setTransactionConfirmationLoading(true);
+        let latestTransactionConfirmation:
+          | IStakeTransactionConfirmation
+          | undefined;
+        try {
+          latestTransactionConfirmation =
+            await fetchTransactionConfirmationRef.current?.(submitAmount);
+        } catch {
+          if (
+            nativePreflightRequestId ===
+              transactionConfirmationRequestIdRef.current &&
+            isCurrentConfirmationRequest()
+          ) {
+            setTransactionConfirmation(undefined);
+          }
+          return;
+        } finally {
+          if (
+            nativePreflightRequestId ===
+              transactionConfirmationRequestIdRef.current &&
+            isCurrentConfirmationRequest()
+          ) {
+            setTransactionConfirmationLoading(false);
+          }
+        }
+
+        if (
+          nativePreflightRequestId !==
+            transactionConfirmationRequestIdRef.current ||
+          !isCurrentSubmission()
+        ) {
+          return;
+        }
+
+        setTransactionConfirmation(latestTransactionConfirmation);
+        const latestWithdrawPathConfirmBoxes =
+          latestTransactionConfirmation?.withdrawPath?.data?.confirmBoxes ?? [];
+        const latestSelectedWithdrawPath = resolveSelectedWithdrawPath({
+          boxes: latestWithdrawPathConfirmBoxes,
+          selectedIndex: effectiveSelectedWithdrawPathIndex,
+          preferredWithdrawType: selectedWithdrawType,
+        });
+        confirmedWithdrawType = latestSelectedWithdrawPath?.withdrawType;
+        confirmedEffectiveApy = latestTransactionConfirmation?.effectiveApy;
+
+        if (
+          latestSelectedWithdrawPath?.disabled ||
+          shouldWaitForNativeWithdrawPath({
+            providerName: providerName ?? '',
+            isCancelWithdrawal,
+            withdrawType: confirmedWithdrawType,
+            isLoading: false,
+          })
+        ) {
+          return;
+        }
+
+        const latestSelectedWithdrawPathIndex = latestSelectedWithdrawPath
+          ? latestWithdrawPathConfirmBoxes.indexOf(latestSelectedWithdrawPath)
+          : -1;
+        if (
+          latestSelectedWithdrawPathIndex >= 0 &&
+          latestSelectedWithdrawPathIndex !== effectiveSelectedWithdrawPathIndex
+        ) {
+          setSelectedWithdrawPathIndex(latestSelectedWithdrawPathIndex);
+        }
+      }
 
       // Get signature for withdraw all (Stakefish ETH)
       if (
@@ -863,20 +1036,24 @@ export function UniversalWithdraw({
         shouldConfirmNativeInstantWithdrawFee({
           providerName: providerName ?? '',
           isCancelWithdrawal,
-          withdrawType: selectedWithdrawType,
+          withdrawType: confirmedWithdrawType,
         })
       ) {
         const feeConfirmed = await showNativeInstantWithdrawFeeDialog(intl);
         if (!feeConfirmed) return;
       }
 
+      if (isNativeProvider && !isCancelWithdrawal && !isCurrentSubmission()) {
+        return;
+      }
+
       await onConfirm?.({
-        amount: isCancelWithdrawal ? '0' : amountValue,
-        withdrawAll: withdrawAllRef.current,
+        amount: isCancelWithdrawal ? '0' : submitAmount,
+        withdrawAll: submitWithdrawAll,
         signature: withdrawSignatureRef.current,
         message: withdrawMessageRef.current,
-        effectiveApy: transactionConfirmation?.effectiveApy,
-        withdrawType: selectedWithdrawType,
+        effectiveApy: confirmedEffectiveApy,
+        withdrawType: confirmedWithdrawType,
         useEthenaCooldown: shouldUseEthenaCooldown ? true : undefined,
         resumeEthenaCooldownUnstake: shouldResumeEthenaCooldownUnstake
           ? true
@@ -935,11 +1112,12 @@ export function UniversalWithdraw({
     pendingEthenaCooldownUnstake,
     selectedWithdrawType,
     isCancelWithdrawal,
+    isNativeProvider,
+    transactionConfirmationRequestAmount,
+    withdrawSubmissionContext,
   ]);
 
   const [checkAmountLoading, setCheckAmountLoading] = useState(false);
-  const [transactionConfirmationLoading, setTransactionConfirmationLoading] =
-    useState(false);
 
   const quoteLoading = checkAmountLoading || transactionConfirmationLoading;
 
@@ -1020,31 +1198,63 @@ export function UniversalWithdraw({
   fetchTransactionConfirmationRef.current = fetchTransactionConfirmation;
 
   const debouncedFetchTransactionConfirmation = useDebouncedCallback(
-    async (amount?: string) => {
+    async ({ amount, requestId }: { amount?: string; requestId: number }) => {
+      if (requestId !== transactionConfirmationRequestIdRef.current) {
+        return;
+      }
       setTransactionConfirmationLoading(true);
       try {
         const resp = await fetchTransactionConfirmation(amount || '0');
+        if (requestId !== transactionConfirmationRequestIdRef.current) {
+          return;
+        }
         setTransactionConfirmation(resp);
         if (resp && amount && Number(amount) > 0) {
           onQuoteReset?.();
         }
       } catch {
-        // keep stale state
+        if (
+          requestId === transactionConfirmationRequestIdRef.current &&
+          isNativeProvider
+        ) {
+          setTransactionConfirmation(undefined);
+        }
       } finally {
-        setTransactionConfirmationLoading(false);
+        if (requestId === transactionConfirmationRequestIdRef.current) {
+          setTransactionConfirmationLoading(false);
+        }
       }
     },
     350,
   );
 
   useEffect(() => {
-    void debouncedFetchTransactionConfirmation(amountValue);
+    const requestId = transactionConfirmationRequestIdRef.current + 1;
+    transactionConfirmationRequestIdRef.current = requestId;
+    if (isNativeProvider) {
+      setTransactionConfirmationLoading(true);
+    }
+    void debouncedFetchTransactionConfirmation({
+      amount: transactionConfirmationRequestAmount,
+      requestId,
+    });
   }, [
-    amountValue,
     debouncedFetchTransactionConfirmation,
+    fetchTransactionConfirmation,
+    isNativeProvider,
     selectedWithdrawType,
+    transactionConfirmationRequestAmount,
     transactionOutputTokenAddress,
+    withdrawSubmissionContext,
   ]);
+
+  useEffect(
+    () => () => {
+      transactionConfirmationRequestIdRef.current += 1;
+      debouncedFetchTransactionConfirmation.cancel();
+    },
+    [debouncedFetchTransactionConfirmation],
+  );
 
   const { quoteRefreshing, handleLocalRefreshQuote } = useQuoteRefresh({
     enabled: isPendleProvider,
@@ -1089,13 +1299,27 @@ export function UniversalWithdraw({
         setIgnoreAllowanceCheck(false);
         setPendingEthenaCooldownUnstake(false);
         setWithdrawProgressStep(EStakeProgressStep.approve);
+        const nextTransactionConfirmationAmount = valueBN.toFixed();
+        if (
+          isNativeProvider &&
+          nextTransactionConfirmationAmount !==
+            transactionConfirmationRequestAmount
+        ) {
+          setTransactionConfirmationLoading(true);
+        }
         setAmountValue(value);
       }
       withdrawAllRef.current = !!isMax;
       setIsWithdrawAll(!!isMax);
       void checkAmount(value);
     },
-    [checkAmount, decimals, isCancelWithdrawal],
+    [
+      checkAmount,
+      decimals,
+      isCancelWithdrawal,
+      isNativeProvider,
+      transactionConfirmationRequestAmount,
+    ],
   );
 
   // Re-trigger checkAmount when output token changes
@@ -1165,7 +1389,8 @@ export function UniversalWithdraw({
           BigNumber(amountValue).isLessThanOrEqualTo(0))) ||
       isCheckAmountMessageError ||
       checkAmountAlerts.length > 0 ||
-      checkAmountLoading,
+      checkAmountLoading ||
+      isNativeWithdrawPathPending,
     [
       isDisabled,
       amountValue,
@@ -1173,6 +1398,7 @@ export function UniversalWithdraw({
       checkAmountAlerts.length,
       checkAmountLoading,
       isCancelWithdrawal,
+      isNativeWithdrawPathPending,
       selectedWithdrawPath?.disabled,
     ],
   );
@@ -1208,8 +1434,14 @@ export function UniversalWithdraw({
   const effectiveShowExpiredRefresh = showExpiredRefresh && !isTransacting;
 
   const amountInputDisabled = useMemo(() => {
-    return isDisabled || initialAmount !== undefined || isCancelWithdrawal;
-  }, [isDisabled, initialAmount, isCancelWithdrawal]);
+    return (
+      isDisabled ||
+      initialAmount !== undefined ||
+      isCancelWithdrawal ||
+      loading ||
+      approving
+    );
+  }, [approving, initialAmount, isCancelWithdrawal, isDisabled, loading]);
 
   const accordionContent = useMemo(() => {
     const items: ReactElement[] = [];
@@ -1344,10 +1576,13 @@ export function UniversalWithdraw({
   ]);
 
   const confirmLoading = useMemo(() => {
+    if (isNativeProvider && transactionConfirmationLoading) return true;
     if (shouldApprove) return loadingAllowance || approving;
     if (effectiveShowExpiredRefresh) return quoteRefreshing;
     return loading || checkAmountLoading;
   }, [
+    isNativeProvider,
+    transactionConfirmationLoading,
     shouldApprove,
     effectiveShowExpiredRefresh,
     loadingAllowance,
@@ -1470,6 +1705,7 @@ export function UniversalWithdraw({
           userSelect="none"
           cursor="pointer"
           hoverStyle={{ bg: '$bgHover' }}
+          disabled={loading || approving}
           onPress={showWithdrawPathDialog}
         >
           <YStack flex={1} gap="$1">

--- a/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
@@ -86,6 +86,7 @@ import {
   calcPriceImpactInfo,
   showHighPriceImpactDialog,
 } from '../showHighPriceImpactDialog';
+import { showNativeInstantWithdrawFeeDialog } from '../showNativeInstantWithdrawFeeDialog';
 import { EStakeProgressStep, StakeProgress } from '../StakeProgress';
 import {
   StakingAmountInput,
@@ -858,6 +859,17 @@ export function UniversalWithdraw({
         }
       }
 
+      // Native charges a protocol fee on instant withdrawals; require an
+      // explicit confirmation whether instant is the default or user-picked.
+      if (
+        isNativeProvider &&
+        !isCancelWithdrawal &&
+        selectedWithdrawType === 'instant'
+      ) {
+        const feeConfirmed = await showNativeInstantWithdrawFeeDialog(intl);
+        if (!feeConfirmed) return;
+      }
+
       await onConfirm?.({
         amount: isCancelWithdrawal ? '0' : amountValue,
         withdrawAll: withdrawAllRef.current,
@@ -923,6 +935,7 @@ export function UniversalWithdraw({
     pendingEthenaCooldownUnstake,
     selectedWithdrawType,
     isCancelWithdrawal,
+    isNativeProvider,
   ]);
 
   const [checkAmountLoading, setCheckAmountLoading] = useState(false);

--- a/packages/kit/src/views/Staking/components/UniversalWithdraw/withdrawPathUtils.test.ts
+++ b/packages/kit/src/views/Staking/components/UniversalWithdraw/withdrawPathUtils.test.ts
@@ -1,0 +1,178 @@
+import {
+  clampWithdrawPathIndex,
+  resolveSelectedWithdrawPath,
+  shouldConfirmNativeInstantWithdrawFee,
+} from './withdrawPathUtils';
+
+import type { IWithdrawPathBox } from './withdrawPathUtils';
+
+const instantBox: IWithdrawPathBox = {
+  title: { text: 'Instant withdrawal' },
+  description: { text: '99 USDT' },
+  withdrawType: 'instant',
+};
+
+const queuedBox: IWithdrawPathBox = {
+  title: { text: 'Standard withdrawal' },
+  description: { text: '100 USDT' },
+  withdrawType: 'queued',
+};
+
+function selectedWithdrawTypeFor(
+  boxes: IWithdrawPathBox[],
+  selectedIndex: number,
+) {
+  return resolveSelectedWithdrawPath({ boxes, selectedIndex })?.withdrawType;
+}
+
+describe('withdrawPathUtils', () => {
+  describe('server returns instant first (current ordering)', () => {
+    const boxes = [instantBox, queuedBox];
+
+    it('defaults to instant and requires the fee confirmation', () => {
+      const withdrawType = selectedWithdrawTypeFor(boxes, 0);
+      expect(withdrawType).toBe('instant');
+      expect(
+        shouldConfirmNativeInstantWithdrawFee({
+          providerName: 'native',
+          isCancelWithdrawal: false,
+          withdrawType,
+        }),
+      ).toBe(true);
+    });
+
+    it('skips the fee confirmation after switching to queued', () => {
+      const withdrawType = selectedWithdrawTypeFor(boxes, 1);
+      expect(withdrawType).toBe('queued');
+      expect(
+        shouldConfirmNativeInstantWithdrawFee({
+          providerName: 'native',
+          isCancelWithdrawal: false,
+          withdrawType,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('server returns queued first (future ordering)', () => {
+    const boxes = [queuedBox, instantBox];
+
+    it('defaults to queued and skips the fee confirmation', () => {
+      const withdrawType = selectedWithdrawTypeFor(boxes, 0);
+      expect(withdrawType).toBe('queued');
+      expect(
+        shouldConfirmNativeInstantWithdrawFee({
+          providerName: 'native',
+          isCancelWithdrawal: false,
+          withdrawType,
+        }),
+      ).toBe(false);
+    });
+
+    it('requires the fee confirmation after switching to instant', () => {
+      const withdrawType = selectedWithdrawTypeFor(boxes, 1);
+      expect(withdrawType).toBe('instant');
+      expect(
+        shouldConfirmNativeInstantWithdrawFee({
+          providerName: 'native',
+          isCancelWithdrawal: false,
+          withdrawType,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('boxes change between refetches', () => {
+    it('falls back to the only remaining box when a stale index overflows', () => {
+      // user had instant selected at index 1, refreshed response only has queued
+      const withdrawType = selectedWithdrawTypeFor([queuedBox], 1);
+      expect(withdrawType).toBe('queued');
+      expect(
+        shouldConfirmNativeInstantWithdrawFee({
+          providerName: 'native',
+          isCancelWithdrawal: false,
+          withdrawType,
+        }),
+      ).toBe(false);
+    });
+
+    it('still gates a single-box instant-only response', () => {
+      const withdrawType = selectedWithdrawTypeFor([instantBox], 0);
+      expect(
+        shouldConfirmNativeInstantWithdrawFee({
+          providerName: 'native',
+          isCancelWithdrawal: false,
+          withdrawType,
+        }),
+      ).toBe(true);
+    });
+
+    it('resolves nothing for an empty response and never gates', () => {
+      expect(resolveSelectedWithdrawPath({ boxes: [], selectedIndex: 0 })).toBe(
+        undefined,
+      );
+      expect(
+        shouldConfirmNativeInstantWithdrawFee({
+          providerName: 'native',
+          isCancelWithdrawal: false,
+          withdrawType: undefined,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('clampWithdrawPathIndex', () => {
+    it('pins to 0 when there are no or single boxes', () => {
+      expect(clampWithdrawPathIndex({ selectedIndex: 3, boxesLength: 0 })).toBe(
+        0,
+      );
+      expect(clampWithdrawPathIndex({ selectedIndex: 3, boxesLength: 1 })).toBe(
+        0,
+      );
+    });
+
+    it('clamps out-of-range indexes into the valid range', () => {
+      expect(
+        clampWithdrawPathIndex({ selectedIndex: -1, boxesLength: 2 }),
+      ).toBe(0);
+      expect(clampWithdrawPathIndex({ selectedIndex: 5, boxesLength: 2 })).toBe(
+        1,
+      );
+      expect(clampWithdrawPathIndex({ selectedIndex: 1, boxesLength: 2 })).toBe(
+        1,
+      );
+    });
+  });
+
+  describe('shouldConfirmNativeInstantWithdrawFee', () => {
+    it('never gates other providers even on instant paths', () => {
+      expect(
+        shouldConfirmNativeInstantWithdrawFee({
+          providerName: 'pendle',
+          isCancelWithdrawal: false,
+          withdrawType: 'instant',
+        }),
+      ).toBe(false);
+    });
+
+    it('never gates cancel-withdrawal flows', () => {
+      expect(
+        shouldConfirmNativeInstantWithdrawFee({
+          providerName: 'native',
+          isCancelWithdrawal: true,
+          withdrawType: 'instant',
+        }),
+      ).toBe(false);
+    });
+
+    it('matches the provider name case-insensitively', () => {
+      expect(
+        shouldConfirmNativeInstantWithdrawFee({
+          providerName: 'Native',
+          isCancelWithdrawal: false,
+          withdrawType: 'instant',
+        }),
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/kit/src/views/Staking/components/UniversalWithdraw/withdrawPathUtils.test.ts
+++ b/packages/kit/src/views/Staking/components/UniversalWithdraw/withdrawPathUtils.test.ts
@@ -2,6 +2,7 @@ import {
   clampWithdrawPathIndex,
   resolveSelectedWithdrawPath,
   shouldConfirmNativeInstantWithdrawFee,
+  shouldWaitForNativeWithdrawPath,
 } from './withdrawPathUtils';
 
 import type { IWithdrawPathBox } from './withdrawPathUtils';
@@ -21,8 +22,13 @@ const queuedBox: IWithdrawPathBox = {
 function selectedWithdrawTypeFor(
   boxes: IWithdrawPathBox[],
   selectedIndex: number,
+  preferredWithdrawType?: IWithdrawPathBox['withdrawType'],
 ) {
-  return resolveSelectedWithdrawPath({ boxes, selectedIndex })?.withdrawType;
+  return resolveSelectedWithdrawPath({
+    boxes,
+    selectedIndex,
+    preferredWithdrawType,
+  })?.withdrawType;
 }
 
 describe('withdrawPathUtils', () => {
@@ -107,7 +113,26 @@ describe('withdrawPathUtils', () => {
       ).toBe(true);
     });
 
-    it('resolves nothing for an empty response and never gates', () => {
+    it('preserves the selected path when the server reorders boxes', () => {
+      const withdrawType = selectedWithdrawTypeFor(
+        [queuedBox, instantBox],
+        1,
+        'queued',
+      );
+      expect(withdrawType).toBe('queued');
+    });
+
+    it('does not substitute another path when the selected type disappears', () => {
+      expect(
+        resolveSelectedWithdrawPath({
+          boxes: [instantBox],
+          selectedIndex: 0,
+          preferredWithdrawType: 'queued',
+        }),
+      ).toBeUndefined();
+    });
+
+    it('blocks Native submission when the response has no path', () => {
       expect(resolveSelectedWithdrawPath({ boxes: [], selectedIndex: 0 })).toBe(
         undefined,
       );
@@ -118,6 +143,14 @@ describe('withdrawPathUtils', () => {
           withdrawType: undefined,
         }),
       ).toBe(false);
+      expect(
+        shouldWaitForNativeWithdrawPath({
+          providerName: 'native',
+          isCancelWithdrawal: false,
+          withdrawType: undefined,
+          isLoading: false,
+        }),
+      ).toBe(true);
     });
   });
 
@@ -173,6 +206,52 @@ describe('withdrawPathUtils', () => {
           withdrawType: 'instant',
         }),
       ).toBe(true);
+    });
+  });
+
+  describe('shouldWaitForNativeWithdrawPath', () => {
+    it.each(['instant', 'queued'] as const)(
+      'allows a resolved %s path when no refresh is pending',
+      (withdrawType) => {
+        expect(
+          shouldWaitForNativeWithdrawPath({
+            providerName: 'native',
+            isCancelWithdrawal: false,
+            withdrawType,
+            isLoading: false,
+          }),
+        ).toBe(false);
+      },
+    );
+
+    it('blocks while the current Native path is refreshing', () => {
+      expect(
+        shouldWaitForNativeWithdrawPath({
+          providerName: 'native',
+          isCancelWithdrawal: false,
+          withdrawType: 'instant',
+          isLoading: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('does not block other providers or cancellation', () => {
+      expect(
+        shouldWaitForNativeWithdrawPath({
+          providerName: 'pendle',
+          isCancelWithdrawal: false,
+          withdrawType: undefined,
+          isLoading: true,
+        }),
+      ).toBe(false);
+      expect(
+        shouldWaitForNativeWithdrawPath({
+          providerName: 'native',
+          isCancelWithdrawal: true,
+          withdrawType: 'cancel',
+          isLoading: true,
+        }),
+      ).toBe(false);
     });
   });
 });

--- a/packages/kit/src/views/Staking/components/UniversalWithdraw/withdrawPathUtils.ts
+++ b/packages/kit/src/views/Staking/components/UniversalWithdraw/withdrawPathUtils.ts
@@ -1,0 +1,58 @@
+import earnUtils from '@onekeyhq/shared/src/utils/earnUtils';
+import type {
+  IEarnText,
+  IEarnTransactionTip,
+  IEarnWithdrawType,
+} from '@onekeyhq/shared/types/staking';
+
+export type IWithdrawPathBox = {
+  title: IEarnText;
+  description: IEarnText;
+  subtitle?: IEarnText;
+  subtitleDescription?: IEarnText;
+  withdrawType?: IEarnWithdrawType;
+  disabled?: boolean;
+  tip?: IEarnTransactionTip;
+};
+
+export function clampWithdrawPathIndex({
+  selectedIndex,
+  boxesLength,
+}: {
+  selectedIndex: number;
+  boxesLength: number;
+}): number {
+  if (boxesLength <= 1) return 0;
+  return Math.min(Math.max(selectedIndex, 0), boxesLength - 1);
+}
+
+export function resolveSelectedWithdrawPath({
+  boxes,
+  selectedIndex,
+}: {
+  boxes: IWithdrawPathBox[];
+  selectedIndex: number;
+}): IWithdrawPathBox | undefined {
+  if (!boxes.length) return undefined;
+  const effectiveIndex = clampWithdrawPathIndex({
+    selectedIndex,
+    boxesLength: boxes.length,
+  });
+  return boxes[effectiveIndex] ?? boxes[0];
+}
+
+export function shouldConfirmNativeInstantWithdrawFee({
+  providerName,
+  isCancelWithdrawal,
+  withdrawType,
+}: {
+  providerName: string;
+  isCancelWithdrawal: boolean;
+  withdrawType?: IEarnWithdrawType;
+}): boolean {
+  return (
+    earnUtils.isNativeProvider({ providerName }) &&
+    !isCancelWithdrawal &&
+    withdrawType === 'instant'
+  );
+}

--- a/packages/kit/src/views/Staking/components/UniversalWithdraw/withdrawPathUtils.ts
+++ b/packages/kit/src/views/Staking/components/UniversalWithdraw/withdrawPathUtils.ts
@@ -29,11 +29,16 @@ export function clampWithdrawPathIndex({
 export function resolveSelectedWithdrawPath({
   boxes,
   selectedIndex,
+  preferredWithdrawType,
 }: {
   boxes: IWithdrawPathBox[];
   selectedIndex: number;
+  preferredWithdrawType?: IEarnWithdrawType;
 }): IWithdrawPathBox | undefined {
   if (!boxes.length) return undefined;
+  if (preferredWithdrawType) {
+    return boxes.find((box) => box.withdrawType === preferredWithdrawType);
+  }
   const effectiveIndex = clampWithdrawPathIndex({
     selectedIndex,
     boxesLength: boxes.length,
@@ -54,5 +59,25 @@ export function shouldConfirmNativeInstantWithdrawFee({
     earnUtils.isNativeProvider({ providerName }) &&
     !isCancelWithdrawal &&
     withdrawType === 'instant'
+  );
+}
+
+export function shouldWaitForNativeWithdrawPath({
+  providerName,
+  isCancelWithdrawal,
+  withdrawType,
+  isLoading,
+}: {
+  providerName: string;
+  isCancelWithdrawal: boolean;
+  withdrawType?: IEarnWithdrawType;
+  isLoading: boolean;
+}): boolean {
+  const hasResolvedWithdrawPath =
+    withdrawType === 'instant' || withdrawType === 'queued';
+  return (
+    earnUtils.isNativeProvider({ providerName }) &&
+    !isCancelWithdrawal &&
+    (isLoading || !hasResolvedWithdrawPath)
   );
 }

--- a/packages/kit/src/views/Staking/components/showNativeInstantWithdrawFeeDialog.tsx
+++ b/packages/kit/src/views/Staking/components/showNativeInstantWithdrawFeeDialog.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import type { ICheckedState } from '@onekeyhq/components';
+import { Checkbox, Dialog, SizableText, YStack } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+import type { IntlShape } from 'react-intl';
+
+function NativeInstantWithdrawFeeContent({
+  onConfirm,
+}: {
+  onConfirm: () => void;
+}) {
+  const intl = useIntl();
+  const [acknowledged, setAcknowledged] = useState<ICheckedState>(false);
+
+  return (
+    <YStack gap="$5">
+      <SizableText size="$bodyLg">
+        {intl.formatMessage(
+          { id: ETranslations.defi_native_instant_withdraw_fee__desc },
+          {
+            // eslint-disable-next-line react/no-unstable-nested-components
+            strong: (chunks: ReactNode[]) => (
+              <SizableText size="$bodyLgMedium" color="$textCritical">
+                {chunks}
+              </SizableText>
+            ),
+          },
+        )}
+      </SizableText>
+      <Checkbox
+        testID="native-instant-withdraw-fee-checkbox"
+        value={acknowledged}
+        label={intl.formatMessage({
+          id: ETranslations.wallet_i_understand_risks_and_proceed,
+        })}
+        onChange={setAcknowledged}
+      />
+      <Dialog.Footer
+        onConfirm={onConfirm}
+        onConfirmText={intl.formatMessage({
+          id: ETranslations.global_confirm,
+        })}
+        onCancelText={intl.formatMessage({
+          id: ETranslations.global_cancel,
+        })}
+        confirmButtonProps={{
+          disabled: !acknowledged,
+        }}
+      />
+    </YStack>
+  );
+}
+
+export function showNativeInstantWithdrawFeeDialog(
+  intl: IntlShape,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    let confirmed = false;
+    const dialog = Dialog.show({
+      icon: 'InfoCircleOutline',
+      title: intl.formatMessage({
+        id: ETranslations.defi_native_instant_withdraw_fee__title,
+      }),
+      showFooter: false,
+      onClose: () => resolve(confirmed),
+      renderContent: (
+        <NativeInstantWithdrawFeeContent
+          onConfirm={() => {
+            confirmed = true;
+            void dialog.close();
+          }}
+        />
+      ),
+    });
+  });
+}

--- a/packages/shared/src/locale/enum/translations.ts
+++ b/packages/shared/src/locale/enum/translations.ts
@@ -586,6 +586,8 @@ export enum ETranslations {
   defi_lending_permit_sign__hint = 'defi_lending_permit_sign__hint',
   defi_lending_step_of_total = 'defi_lending_step_of_total',
   defi_lending_waiting_approval = 'defi_lending_waiting_approval',
+  defi_native_instant_withdraw_fee__desc = 'defi_native_instant_withdraw_fee__desc',
+  defi_native_instant_withdraw_fee__title = 'defi_native_instant_withdraw_fee__title',
   derivation_path = 'derivation_path',
   description_403 = 'description_403',
   device_btc_only_coming_soon = 'device.btc_only_coming_soon',

--- a/packages/shared/src/locale/json/bn.json
+++ b/packages/shared/src/locale/json/bn.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "প্রথমে একটি উত্তোলনের অনুমতি স্বাক্ষর করবেন, তারপর লেনদেন নিশ্চিত করবেন",
   "defi_lending_step_of_total": "ধাপ {step} / {total}",
   "defi_lending_waiting_approval": "অনুমোদনের জন্য অপেক্ষা করা হচ্ছে…",
+  "defi_native_instant_withdraw_fee__desc": "অপেক্ষার সময় এড়াতে Native প্রোটোকল আপনার <strong>মূলধনের 1%</strong> ফি নেয় — এর কোনো অংশ OneKey পায় না। সাধারণ প্রত্যাহারে প্রায় 3 দিন লাগে, তবে কোনো ফি নেই।",
+  "defi_native_instant_withdraw_fee__title": "তাৎক্ষণিক প্রত্যাহারে 1% ফি",
   "derivation_path": "উৎপত্তি পথ",
   "description_403": "আমাদের সেবাগুলি আপনার অঞ্চলে পাওয়া যায় না।",
   "device.btc_only_coming_soon": "এই ফিচারটি পরবর্তী BTC-Only ফার্মওয়্যার রিলিজে উপলভ্য হবে।",

--- a/packages/shared/src/locale/json/de.json
+++ b/packages/shared/src/locale/json/de.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "Sie signieren zuerst eine Auszahlungsberechtigung und bestätigen dann die Transaktion",
   "defi_lending_step_of_total": "Schritt {step} von {total}",
   "defi_lending_waiting_approval": "Warten auf Genehmigung…",
+  "defi_native_instant_withdraw_fee__desc": "Das Native-Protokoll erhebt <strong>1 % Ihres Kapitals</strong> für das Überspringen der Wartezeit — nichts davon geht an OneKey. Die Standard-Abhebung dauert etwa 3 Tage, ist aber gebührenfrei.",
+  "defi_native_instant_withdraw_fee__title": "1 % Gebühr für sofortige Abhebung",
   "derivation_path": "Ableitungspfad",
   "description_403": "Unsere Dienstleistungen sind in Ihrer Region nicht verfügbar.",
   "device.btc_only_coming_soon": "Dieses Feature wird in einer späteren BTC-Only-Firmware-Version verfügbar sein.",

--- a/packages/shared/src/locale/json/en_US.json
+++ b/packages/shared/src/locale/json/en_US.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "You'll sign a withdrawal permission first, then confirm the transaction",
   "defi_lending_step_of_total": "Step {step} of {total}",
   "defi_lending_waiting_approval": "Waiting for approval…",
+  "defi_native_instant_withdraw_fee__desc": "The Native protocol charges <strong>1% of your principal</strong> for skipping the waiting period — none of it goes to OneKey. Standard withdrawal takes about 3 days but has no fee.",
+  "defi_native_instant_withdraw_fee__title": "1% Fee for Instant Withdrawal",
   "derivation_path": "Derivation path",
   "description_403": "Our services are not available in your region.",
   "device.btc_only_coming_soon": "This feature will be available in a later BTC-Only firmware release.",

--- a/packages/shared/src/locale/json/es.json
+++ b/packages/shared/src/locale/json/es.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "Primero firmarás un permiso de retiro y luego confirmarás la transacción",
   "defi_lending_step_of_total": "Paso {step} de {total}",
   "defi_lending_waiting_approval": "Esperando aprobación…",
+  "defi_native_instant_withdraw_fee__desc": "El protocolo Native cobra el <strong>1% de tu capital</strong> por omitir el período de espera; OneKey no recibe nada. El retiro estándar tarda unos 3 días, pero no tiene comisión.",
+  "defi_native_instant_withdraw_fee__title": "Comisión del 1% por retiro instantáneo",
   "derivation_path": "Ruta de derivación",
   "description_403": "Nuestros servicios no están disponibles en su región.",
   "device.btc_only_coming_soon": "Esta función estará disponible en una futura versión de firmware Solo-BTC.",

--- a/packages/shared/src/locale/json/fr_FR.json
+++ b/packages/shared/src/locale/json/fr_FR.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "Vous signerez d’abord une autorisation de retrait, puis confirmerez la transaction",
   "defi_lending_step_of_total": "Étape {step} sur {total}",
   "defi_lending_waiting_approval": "En attente d’approbation…",
+  "defi_native_instant_withdraw_fee__desc": "Le protocole Native prélève <strong>1 % de votre capital</strong> pour éviter la période d'attente — OneKey n'en reçoit rien. Le retrait standard prend environ 3 jours mais est sans frais.",
+  "defi_native_instant_withdraw_fee__title": "Frais de 1 % pour le retrait instantané",
   "derivation_path": "Chemin de dérivation",
   "description_403": "Nos services ne sont pas disponibles dans votre région.",
   "device.btc_only_coming_soon": "Cette fonctionnalité sera disponible dans une version ultérieure du micrologiciel BTC-Only.",

--- a/packages/shared/src/locale/json/hi_IN.json
+++ b/packages/shared/src/locale/json/hi_IN.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "आप पहले निकासी अनुमति पर हस्ताक्षर करेंगे, फिर लेनदेन की पुष्टि करेंगे",
   "defi_lending_step_of_total": "कुल {total} में से चरण {step}",
   "defi_lending_waiting_approval": "स्वीकृति की प्रतीक्षा है…",
+  "defi_native_instant_withdraw_fee__desc": "प्रतीक्षा अवधि छोड़ने के लिए Native प्रोटोकॉल आपकी <strong>मूल राशि का 1%</strong> शुल्क लेता है — इसका कोई हिस्सा OneKey को नहीं मिलता। सामान्य निकासी में लगभग 3 दिन लगते हैं, लेकिन कोई शुल्क नहीं है।",
+  "defi_native_instant_withdraw_fee__title": "तत्काल निकासी पर 1% शुल्क",
   "derivation_path": "व्युत्पन्न पथ",
   "description_403": "हमारी सेवाएं आपके क्षेत्र में उपलब्ध नहीं हैं।",
   "device.btc_only_coming_soon": "यह सुविधा बाद में BTC-Only फर्मवेयर रिलीज़ में उपलब्ध होगी।",

--- a/packages/shared/src/locale/json/id.json
+++ b/packages/shared/src/locale/json/id.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "Anda akan menandatangani izin penarikan terlebih dahulu, lalu mengonfirmasi transaksi",
   "defi_lending_step_of_total": "Langkah {step} dari {total}",
   "defi_lending_waiting_approval": "Menunggu persetujuan…",
+  "defi_native_instant_withdraw_fee__desc": "Protokol Native mengenakan <strong>1% dari pokok Anda</strong> untuk melewati masa tunggu — tidak ada yang diterima OneKey. Penarikan standar memakan waktu sekitar 3 hari tetapi tanpa biaya.",
+  "defi_native_instant_withdraw_fee__title": "Biaya 1% untuk Penarikan Instan",
   "derivation_path": "Jalur derivasi",
   "description_403": "Layanan kami tidak tersedia di wilayah Anda.",
   "device.btc_only_coming_soon": "Fitur ini akan tersedia dalam rilis firmware BTC-Only selanjutnya.",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -581,7 +581,7 @@
   "defi_lending_permit_sign__hint": "Prima firmerai un’autorizzazione di prelievo, poi confermerai la transazione",
   "defi_lending_step_of_total": "Passaggio {step} di {total}",
   "defi_lending_waiting_approval": "In attesa dell’approvazione…",
-  "defi_native_instant_withdraw_fee__desc": "Il protocollo Native addebita l'<strong>1% del tuo capitale</strong> per saltare il periodo di attesa — nulla va a OneKey. Il prelievo standard richiede circa 3 giorni ma non prevede commissioni.",
+  "defi_native_instant_withdraw_fee__desc": "Il protocollo Native addebita l’<strong>1% del tuo capitale</strong> per saltare il periodo di attesa — nulla va a OneKey. Il prelievo standard richiede circa 3 giorni ma non prevede commissioni.",
   "defi_native_instant_withdraw_fee__title": "Commissione dell'1% per il prelievo istantaneo",
   "derivation_path": "Percorso di derivazione",
   "description_403": "I nostri servizi non sono disponibili nella tua regione.",

--- a/packages/shared/src/locale/json/it_IT.json
+++ b/packages/shared/src/locale/json/it_IT.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "Prima firmerai un’autorizzazione di prelievo, poi confermerai la transazione",
   "defi_lending_step_of_total": "Passaggio {step} di {total}",
   "defi_lending_waiting_approval": "In attesa dell’approvazione…",
+  "defi_native_instant_withdraw_fee__desc": "Il protocollo Native addebita l'<strong>1% del tuo capitale</strong> per saltare il periodo di attesa — nulla va a OneKey. Il prelievo standard richiede circa 3 giorni ma non prevede commissioni.",
+  "defi_native_instant_withdraw_fee__title": "Commissione dell'1% per il prelievo istantaneo",
   "derivation_path": "Percorso di derivazione",
   "description_403": "I nostri servizi non sono disponibili nella tua regione.",
   "device.btc_only_coming_soon": "Questa funzionalità sarà disponibile in una versione successiva del firmware BTC-Only.",

--- a/packages/shared/src/locale/json/ja_JP.json
+++ b/packages/shared/src/locale/json/ja_JP.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "先に出金許可に署名し、その後トランザクションを確認します",
   "defi_lending_step_of_total": "ステップ {step}/{total}",
   "defi_lending_waiting_approval": "承認を待っています…",
+  "defi_native_instant_withdraw_fee__desc": "待機期間をスキップするため、Native プロトコルが<strong>元本の 1%</strong>を手数料として徴収します。OneKey は一切受け取りません。通常の引き出しには約 3 日かかりますが、手数料はかかりません。",
+  "defi_native_instant_withdraw_fee__title": "即時引き出しには 1% の手数料",
   "derivation_path": "導出パス",
   "description_403": "弊社のサービスはお客様の地域ではご利用いただけません。",
   "device.btc_only_coming_soon": "この機能は、今後のBTC専用ファームウェアリリースで利用可能になります。",

--- a/packages/shared/src/locale/json/ko_KR.json
+++ b/packages/shared/src/locale/json/ko_KR.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "먼저 출금 권한에 서명한 다음 트랜잭션을 확인합니다",
   "defi_lending_step_of_total": "{total}단계 중 {step}단계",
   "defi_lending_waiting_approval": "승인 대기 중…",
+  "defi_native_instant_withdraw_fee__desc": "대기 기간을 건너뛰는 대가로 Native 프로토콜이 <strong>원금의 1%</strong>를 수수료로 부과하며, OneKey는 어떠한 수수료도 받지 않습니다. 일반 인출은 약 3일이 걸리지만 수수료가 없습니다.",
+  "defi_native_instant_withdraw_fee__title": "즉시 인출 시 1% 수수료",
   "derivation_path": "유도 경로",
   "description_403": "귀하의 지역에서는 당사 서비스를 이용할 수 없습니다.",
   "device.btc_only_coming_soon": "이 기능은 이후에 출시될 BTC 전용 펌웨어에서 제공될 예정입니다.",

--- a/packages/shared/src/locale/json/pt.json
+++ b/packages/shared/src/locale/json/pt.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "Primeiro irá assinar uma permissão de levantamento e depois confirmar a transação",
   "defi_lending_step_of_total": "Passo {step} de {total}",
   "defi_lending_waiting_approval": "A aguardar aprovação…",
+  "defi_native_instant_withdraw_fee__desc": "O protocolo Native cobra <strong>1% do seu capital</strong> para saltar o período de espera — nada vai para a OneKey. A retirada padrão demora cerca de 3 dias, mas não tem taxa.",
+  "defi_native_instant_withdraw_fee__title": "Taxa de 1% para retirada instantânea",
   "derivation_path": "Caminho de derivação",
   "description_403": "Nossos serviços não estão disponíveis em sua região.",
   "device.btc_only_coming_soon": "Este recurso estará disponível em uma versão posterior do firmware BTC-Only.",

--- a/packages/shared/src/locale/json/pt_BR.json
+++ b/packages/shared/src/locale/json/pt_BR.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "Você assinará uma permissão de saque primeiro e depois confirmará a transação",
   "defi_lending_step_of_total": "Passo {step} de {total}",
   "defi_lending_waiting_approval": "Aguardando aprovação…",
+  "defi_native_instant_withdraw_fee__desc": "O protocolo Native cobra <strong>1% do seu principal</strong> para pular o período de espera — nada disso vai para a OneKey. O saque padrão leva cerca de 3 dias, mas não tem taxa.",
+  "defi_native_instant_withdraw_fee__title": "Taxa de 1% para saque instantâneo",
   "derivation_path": "Caminho de derivação",
   "description_403": "Nossos serviços não estão disponíveis em sua região.",
   "device.btc_only_coming_soon": "Este recurso estará disponível em uma versão futura do firmware BTC-Only.",

--- a/packages/shared/src/locale/json/ru.json
+++ b/packages/shared/src/locale/json/ru.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "Сначала вы подпишете разрешение на вывод, затем подтвердите транзакцию",
   "defi_lending_step_of_total": "Шаг {step} из {total}",
   "defi_lending_waiting_approval": "Ожидание одобрения…",
+  "defi_native_instant_withdraw_fee__desc": "Протокол Native взимает <strong>1% от основной суммы</strong> за пропуск периода ожидания — OneKey ничего из этого не получает. Стандартный вывод занимает около 3 дней, но без комиссии.",
+  "defi_native_instant_withdraw_fee__title": "Комиссия 1% за мгновенный вывод",
   "derivation_path": "Путь производного",
   "description_403": "Наши услуги недоступны в вашем регионе.",
   "device.btc_only_coming_soon": "Эта функция будет доступна в следующем выпуске прошивки BTC-Only.",

--- a/packages/shared/src/locale/json/th_TH.json
+++ b/packages/shared/src/locale/json/th_TH.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "คุณจะลงนามอนุญาตการถอนก่อน จากนั้นจึงยืนยันธุรกรรม",
   "defi_lending_step_of_total": "ขั้นตอนที่ {step} จาก {total}",
   "defi_lending_waiting_approval": "กำลังรอการอนุมัติ…",
+  "defi_native_instant_withdraw_fee__desc": "โปรโตคอล Native เรียกเก็บ<strong>1% ของเงินต้น</strong>เพื่อข้ามระยะเวลารอ โดย OneKey ไม่ได้รับส่วนแบ่งใด ๆ การถอนแบบปกติใช้เวลาประมาณ 3 วันแต่ไม่มีค่าธรรมเนียม",
+  "defi_native_instant_withdraw_fee__title": "ค่าธรรมเนียม 1% สำหรับการถอนทันที",
   "derivation_path": "เส้นทางการสืบทอด",
   "description_403": "บริการของเราไม่มีให้บริการในภูมิภาคของคุณ",
   "device.btc_only_coming_soon": "ฟีเจอร์นี้จะพร้อมใช้งานในการอัปเดตเฟิร์มแวร์แบบ BTC-Only รุ่นถัดไป",

--- a/packages/shared/src/locale/json/uk_UA.json
+++ b/packages/shared/src/locale/json/uk_UA.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "Спочатку ви підпишете дозвіл на виведення, а потім підтвердите транзакцію",
   "defi_lending_step_of_total": "Крок {step} із {total}",
   "defi_lending_waiting_approval": "Очікування схвалення…",
+  "defi_native_instant_withdraw_fee__desc": "Протокол Native стягує <strong>1% від основної суми</strong> за пропуск періоду очікування — OneKey нічого з цього не отримує. Стандартне виведення триває близько 3 днів, але без комісії.",
+  "defi_native_instant_withdraw_fee__title": "Комісія 1% за миттєве виведення",
   "derivation_path": "Шлях похідного",
   "description_403": "Наші послуги недоступні у вашому регіоні.",
   "device.btc_only_coming_soon": "Ця функція буде доступна в наступному випуску прошивки BTC-Only.",

--- a/packages/shared/src/locale/json/vi.json
+++ b/packages/shared/src/locale/json/vi.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "Trước tiên bạn sẽ ký quyền rút tiền, sau đó xác nhận giao dịch",
   "defi_lending_step_of_total": "Bước {step} trên {total}",
   "defi_lending_waiting_approval": "Đang chờ phê duyệt…",
+  "defi_native_instant_withdraw_fee__desc": "Giao thức Native thu <strong>1% tiền gốc của bạn</strong> để bỏ qua thời gian chờ — OneKey không nhận bất kỳ khoản nào. Rút tiền thông thường mất khoảng 3 ngày nhưng không mất phí.",
+  "defi_native_instant_withdraw_fee__title": "Phí 1% cho rút tiền ngay",
   "derivation_path": "Đường dẫn xuất phát",
   "description_403": "Dịch vụ của chúng tôi không có sẵn ở khu vực của bạn.",
   "device.btc_only_coming_soon": "Tính năng này sẽ có sẵn trong bản phát hành firmware BTC-Only sau này.",

--- a/packages/shared/src/locale/json/zh_CN.json
+++ b/packages/shared/src/locale/json/zh_CN.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "你将先签署提现许可，然后确认交易",
   "defi_lending_step_of_total": "第 {step} 步，共 {total} 步",
   "defi_lending_waiting_approval": "等待授权…",
+  "defi_native_instant_withdraw_fee__desc": "Native 协议将收取<strong>本金 1%</strong>作为免排队费用，OneKey 不收取任何费用。普通赎回需要等待约 3 天，但没有手续费。",
+  "defi_native_instant_withdraw_fee__title": "立即赎回收取 1% 手续费",
   "derivation_path": "派生路径",
   "description_403": "我们的服务在您的地区无法使用",
   "device.btc_only_coming_soon": "此功能将在后续的 BTC-Only 固件上线后提供。",

--- a/packages/shared/src/locale/json/zh_HK.json
+++ b/packages/shared/src/locale/json/zh_HK.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "你將先簽署提款許可，然後確認交易",
   "defi_lending_step_of_total": "第 {step} 步，共 {total} 步",
   "defi_lending_waiting_approval": "等待授權…",
+  "defi_native_instant_withdraw_fee__desc": "Native 協議將收取<strong>本金 1%</strong>作為免排隊費用，OneKey 不收取任何費用。普通贖回需要等待約 3 天，但沒有手續費。",
+  "defi_native_instant_withdraw_fee__title": "立即贖回收取 1% 手續費",
   "derivation_path": "派生路徑",
   "description_403": "我們的服務在您的地區並不提供",
   "device.btc_only_coming_soon": "此功能將在稍後的 BTC-Only 韌體版本中提供。",

--- a/packages/shared/src/locale/json/zh_TW.json
+++ b/packages/shared/src/locale/json/zh_TW.json
@@ -581,6 +581,8 @@
   "defi_lending_permit_sign__hint": "你將先簽署提款許可，然後確認交易",
   "defi_lending_step_of_total": "第 {step} 步，共 {total} 步",
   "defi_lending_waiting_approval": "等待授權…",
+  "defi_native_instant_withdraw_fee__desc": "Native 協議將收取<strong>本金 1%</strong>作為免排隊費用，OneKey 不收取任何費用。普通贖回需要等待約 3 天，但沒有手續費。",
+  "defi_native_instant_withdraw_fee__title": "立即贖回收取 1% 手續費",
   "derivation_path": "導出路徑",
   "description_403": "我們的服務在您的地區無法使用",
   "device.btc_only_coming_soon": "此功能將在稍後的 BTC-Only 韌體版本中提供。",


### PR DESCRIPTION
## Summary

- Require an explicit acknowledgement before a Native instant withdrawal that charges 1% of principal.
- Make Native withdrawal-path resolution fail closed across debounce windows, failed or stale confirmation requests, reordered/removed paths, and account or quote-context changes.
- Add a background-service guard for missing Native withdrawal types and fix the Italian rich-text translation through Lokalise's official pull workflow.

## Intent & Context

Native exposes server-driven `instant` and `queued` withdrawal paths. An instant withdrawal charges a 1% protocol fee, but the existing flow could proceed without a warning when `instant` was the default path. Review also identified that `selectedWithdrawType` came from an asynchronous, debounced confirmation response, so stale state could bypass the new fee gate after the amount or path changed.

## Root Cause

The fee decision and transaction submission trusted the last rendered `transactionConfirmation`. During the 350 ms debounce window, after a request failure, or when responses completed out of order, that state could describe an earlier amount or selected path. Path selection was also index-based, so a server-side box reorder could change its meaning. The Italian translation used an ASCII apostrophe directly before `<strong>`, which ICU parsed as quoting instead of a rich-text tag.

## Design Decisions

- The main runtime treats Native path readiness as authoritative state: unresolved, loading, failed, disabled, or stale paths keep submission blocked.
- A request generation and full submission-context snapshot reject out-of-order responses and abort if the amount, account, network, vault, tokens, slippage, selected type, or `withdrawAll` changes.
- Submission performs a fresh preflight and uses the same response to decide the instant-fee dialog, effective APY, and `withdrawType` passed to `onConfirm`.
- User selection is preserved by semantic type (`instant` / `queued`), not array index; if that exact type disappears, submission aborts instead of substituting another path.
- The background runtime independently rejects Native unstake construction without an explicit withdrawal type. Main and background exchange serialized data and do not assume initialization ordering; no shared native resource was added.

## Changes Detail

- `UniversalWithdraw`: fail-closed readiness, semantic path selection, stale-response protection, fresh preflight, submission snapshot validation, and input/path locking during approval or submission.
- `withdrawPathUtils`: path resolution and Native readiness predicates with focused ordering and failure tests.
- `ServiceStaking`: defense-in-depth validation before calling the unstake endpoint.
- Lokalise / `it_IT.json`: replace the ICU-escaping ASCII apostrophe with a typographic apostrophe and regenerate via the official locale pull.

## Risk Assessment

- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Desktop, Web, Extension
- **Risk Areas**: Native instant/queued withdrawal selection, asynchronous confirmation ordering, and approval-to-submit transitions. Non-Native and cancel-withdrawal paths retain their existing behavior.

## Test plan

- [x] Focused Jest coverage for instant/queued ordering, reordering, disappearing paths, loading, cancellation, and provider gating (18/18).
- [x] `yarn agent:check --profile commit` for the scoped PR files.
- [x] `yarn agent:check --profile pr` after push.
- [x] Oxlint, `lint:staged`, `tsc:staged`, and `git diff --check`.
- [x] ICU rich-text parsing for the new description in all 19 locale files.
- [ ] Runtime verification with an account holding a Native position: instant shows the acknowledgement dialog; cancel builds no transaction; confirm submits `withdrawType=instant`; queued submits without the fee dialog; changing amount/path during refresh cannot submit stale state.
