### PR TITLE
fix: restore iOS 26 market token header details

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketDetailHeader/MarketDetailHeader.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketDetailHeader/MarketDetailHeader.tsx
@@ -68,18 +68,6 @@ export function MarketDetailHeader({
     });
   }, [navigation, showFavoriteButton]);
 
-  const handleCopyAddress = useCallback(() => {
-    const address = tokenDetail?.address;
-    if (!address) {
-      return;
-    }
-    copyText(address);
-    defaultLogger.dex.actions.dexCopyCA({
-      copyFrom: ECopyFrom.Detail,
-      copiedContent: address,
-    });
-  }, [copyText, tokenDetail?.address]);
-
   // Stabilize logoUrls to prevent re-renders from polling returning fresh array references
   const logoUrls = tokenDetail?.logoUrls;
   const logoUrlsCacheKey = useMemo(() => logoUrls?.join('|') ?? '', [logoUrls]);
@@ -104,6 +92,18 @@ export function MarketDetailHeader({
   );
 
   const customHeaderRight = useMemo(() => null, []);
+
+  const handleCopyAddressNativeIOS26 = useCallback(() => {
+    const address = tokenDetail?.address;
+    if (!address) {
+      return;
+    }
+    copyText(address);
+    defaultLogger.dex.actions.dexCopyCA({
+      copyFrom: ECopyFrom.Detail,
+      copiedContent: address,
+    });
+  }, [copyText, tokenDetail?.address]);
 
   // iOS 26+ mobile: render via the native UINavigationBar so the header
   // gets the system Liquid Glass material and the back chevron sits in
@@ -169,7 +169,7 @@ export function MarketDetailHeader({
                     cursor="pointer"
                     hoverStyle={{ opacity: 0.8 }}
                     pressStyle={{ opacity: 0.6 }}
-                    onPress={handleCopyAddress}
+                    onPress={handleCopyAddressNativeIOS26}
                   >
                     {accountUtils.shortenAddress({
                       address: tokenDetail.address,
@@ -181,7 +181,7 @@ export function MarketDetailHeader({
                     testID="market-icon"
                     icon="Copy3Outline"
                     size="$4"
-                    onPress={handleCopyAddress}
+                    onPress={handleCopyAddressNativeIOS26}
                   />
                 </XStack>
               ) : null}
@@ -200,7 +200,7 @@ export function MarketDetailHeader({
       networkLogoUri,
       isOverlayPage,
       onPressTokenSelector,
-      handleCopyAddress,
+      handleCopyAddressNativeIOS26,
     ],
   );
 
@@ -341,7 +341,13 @@ export function MarketDetailHeader({
                       cursor="pointer"
                       hoverStyle={{ opacity: 0.8 }}
                       pressStyle={{ opacity: 0.6 }}
-                      onPress={handleCopyAddress}
+                      onPress={() => {
+                        copyText(tokenDetail.address);
+                        defaultLogger.dex.actions.dexCopyCA({
+                          copyFrom: ECopyFrom.Detail,
+                          copiedContent: tokenDetail.address,
+                        });
+                      }}
                     >
                       {accountUtils.shortenAddress({
                         address: tokenDetail.address,
@@ -353,7 +359,13 @@ export function MarketDetailHeader({
                       testID="market-icon"
                       icon="Copy3Outline"
                       size="$4"
-                      onPress={handleCopyAddress}
+                      onPress={() => {
+                        copyText(tokenDetail.address);
+                        defaultLogger.dex.actions.dexCopyCA({
+                          copyFrom: ECopyFrom.Detail,
+                          copiedContent: tokenDetail.address,
+                        });
+                      }}
                     />
                   </XStack>
                 ) : null}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketDetailHeader/MarketDetailHeader.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketDetailHeader/MarketDetailHeader.tsx
@@ -68,6 +68,18 @@ export function MarketDetailHeader({
     });
   }, [navigation, showFavoriteButton]);
 
+  const handleCopyAddress = useCallback(() => {
+    const address = tokenDetail?.address;
+    if (!address) {
+      return;
+    }
+    copyText(address);
+    defaultLogger.dex.actions.dexCopyCA({
+      copyFrom: ECopyFrom.Detail,
+      copiedContent: address,
+    });
+  }, [copyText, tokenDetail?.address]);
+
   // Stabilize logoUrls to prevent re-renders from polling returning fresh array references
   const logoUrls = tokenDetail?.logoUrls;
   const logoUrlsCacheKey = useMemo(() => logoUrls?.join('|') ?? '', [logoUrls]);
@@ -96,14 +108,11 @@ export function MarketDetailHeader({
   // iOS 26+ mobile: render via the native UINavigationBar so the header
   // gets the system Liquid Glass material and the back chevron sits in
   // its proper iOS 26 circular glass container. The token symbol +
-  // dropdown chevron live in headerTitle; Star + Share live in
-  // headerRight. The address-copy secondary label that the custom pill
-  // used to render below the symbol is dropped here — single-row
-  // navigation bars can't host it cleanly. Pages that need the address
-  // can surface it in the body content.
+  // dropdown chevron and token identity live in headerTitle; Star + Share
+  // live in headerRight.
   const renderNativeHeaderTitle = useCallback(
     () => (
-      <XStack ai="center" gap="$2" flex={1}>
+      <XStack ai="center" gap="$2" flex={1} minWidth={0}>
         <Token
           size="sm"
           tokenImageUri={tokenDetail?.logoUrl}
@@ -111,37 +120,87 @@ export function MarketDetailHeader({
           networkImageUri={networkLogoUri}
           fallbackIcon="CryptoCoinOutline"
         />
-        <XStack
-          ai="center"
-          gap="$1"
-          flexShrink={1}
-          {...(!isOverlayPage && {
-            onPress: onPressTokenSelector,
-            hoverStyle: { opacity: 0.8 },
-            pressStyle: { opacity: 0.6 },
-            cursor: 'pointer',
-          })}
-        >
-          <SizableText size="$headingLg" numberOfLines={1}>
-            {tokenDetail?.symbol || ''}
-          </SizableText>
-          {!isOverlayPage ? (
-            <Icon
-              name="ChevronDownSmallOutline"
-              size="$4"
-              color="$iconSubdued"
-            />
+        <YStack flexShrink={1} minWidth={0}>
+          <XStack
+            ai="center"
+            gap="$1"
+            flexShrink={1}
+            {...(!isOverlayPage && {
+              onPress: onPressTokenSelector,
+              hoverStyle: { opacity: 0.8 },
+              pressStyle: { opacity: 0.6 },
+              cursor: 'pointer',
+            })}
+          >
+            <SizableText size="$headingLg" numberOfLines={1} flexShrink={1}>
+              {tokenDetail?.symbol || ''}
+            </SizableText>
+            {!isOverlayPage ? (
+              <Icon
+                name="ChevronDownSmallOutline"
+                size="$4"
+                color="$iconSubdued"
+              />
+            ) : null}
+          </XStack>
+
+          {tokenDetail?.communityRecognized || tokenDetail?.address ? (
+            <XStack ai="center" gap="$1" minWidth={0}>
+              {tokenDetail?.communityRecognized ? (
+                <TokenTagsPopover
+                  communityRecognized={tokenDetail.communityRecognized}
+                  stock={tokenDetail.stock}
+                  customTrigger={
+                    <Icon
+                      name="BadgeRecognizedSolid"
+                      size="$4"
+                      color="$iconSuccess"
+                    />
+                  }
+                />
+              ) : null}
+              {tokenDetail?.address ? (
+                <XStack ai="center" gap="$1" minWidth={0}>
+                  <SizableText
+                    size="$bodySm"
+                    color="$textSubdued"
+                    numberOfLines={1}
+                    flexShrink={1}
+                    cursor="pointer"
+                    hoverStyle={{ opacity: 0.8 }}
+                    pressStyle={{ opacity: 0.6 }}
+                    onPress={handleCopyAddress}
+                  >
+                    {accountUtils.shortenAddress({
+                      address: tokenDetail.address,
+                      leadingLength: 6,
+                      trailingLength: 4,
+                    })}
+                  </SizableText>
+                  <InteractiveIcon
+                    testID="market-icon"
+                    icon="Copy3Outline"
+                    size="$4"
+                    onPress={handleCopyAddress}
+                  />
+                </XStack>
+              ) : null}
+            </XStack>
           ) : null}
-        </XStack>
+        </YStack>
       </XStack>
     ),
     [
       tokenDetail?.logoUrl,
       tokenDetail?.symbol,
+      tokenDetail?.communityRecognized,
+      tokenDetail?.stock,
+      tokenDetail?.address,
       stableLogoUrls,
       networkLogoUri,
       isOverlayPage,
       onPressTokenSelector,
+      handleCopyAddress,
     ],
   );
 
@@ -282,13 +341,7 @@ export function MarketDetailHeader({
                       cursor="pointer"
                       hoverStyle={{ opacity: 0.8 }}
                       pressStyle={{ opacity: 0.6 }}
-                      onPress={() => {
-                        copyText(tokenDetail.address);
-                        defaultLogger.dex.actions.dexCopyCA({
-                          copyFrom: ECopyFrom.Detail,
-                          copiedContent: tokenDetail.address,
-                        });
-                      }}
+                      onPress={handleCopyAddress}
                     >
                       {accountUtils.shortenAddress({
                         address: tokenDetail.address,
@@ -300,13 +353,7 @@ export function MarketDetailHeader({
                       testID="market-icon"
                       icon="Copy3Outline"
                       size="$4"
-                      onPress={() => {
-                        copyText(tokenDetail.address);
-                        defaultLogger.dex.actions.dexCopyCA({
-                          copyFrom: ECopyFrom.Detail,
-                          copiedContent: tokenDetail.address,
-                        });
-                      }}
+                      onPress={handleCopyAddress}
                     />
                   </XStack>
                 ) : null}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketDetailHeader/MarketDetailHeader.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketDetailHeader/MarketDetailHeader.tsx
@@ -68,6 +68,18 @@ export function MarketDetailHeader({
     });
   }, [navigation, showFavoriteButton]);
 
+  const handleCopyAddress = useCallback(() => {
+    const address = tokenDetail?.address;
+    if (!address) {
+      return;
+    }
+    copyText(address);
+    defaultLogger.dex.actions.dexCopyCA({
+      copyFrom: ECopyFrom.Detail,
+      copiedContent: address,
+    });
+  }, [copyText, tokenDetail?.address]);
+
   // Stabilize logoUrls to prevent re-renders from polling returning fresh array references
   const logoUrls = tokenDetail?.logoUrls;
   const logoUrlsCacheKey = useMemo(() => logoUrls?.join('|') ?? '', [logoUrls]);
@@ -92,18 +104,6 @@ export function MarketDetailHeader({
   );
 
   const customHeaderRight = useMemo(() => null, []);
-
-  const handleCopyAddressNativeIOS26 = useCallback(() => {
-    const address = tokenDetail?.address;
-    if (!address) {
-      return;
-    }
-    copyText(address);
-    defaultLogger.dex.actions.dexCopyCA({
-      copyFrom: ECopyFrom.Detail,
-      copiedContent: address,
-    });
-  }, [copyText, tokenDetail?.address]);
 
   // iOS 26+ mobile: render via the native UINavigationBar so the header
   // gets the system Liquid Glass material and the back chevron sits in
@@ -169,7 +169,7 @@ export function MarketDetailHeader({
                     cursor="pointer"
                     hoverStyle={{ opacity: 0.8 }}
                     pressStyle={{ opacity: 0.6 }}
-                    onPress={handleCopyAddressNativeIOS26}
+                    onPress={handleCopyAddress}
                   >
                     {accountUtils.shortenAddress({
                       address: tokenDetail.address,
@@ -181,7 +181,7 @@ export function MarketDetailHeader({
                     testID="market-icon"
                     icon="Copy3Outline"
                     size="$4"
-                    onPress={handleCopyAddressNativeIOS26}
+                    onPress={handleCopyAddress}
                   />
                 </XStack>
               ) : null}
@@ -200,7 +200,7 @@ export function MarketDetailHeader({
       networkLogoUri,
       isOverlayPage,
       onPressTokenSelector,
-      handleCopyAddressNativeIOS26,
+      handleCopyAddress,
     ],
   );
 
@@ -341,13 +341,7 @@ export function MarketDetailHeader({
                       cursor="pointer"
                       hoverStyle={{ opacity: 0.8 }}
                       pressStyle={{ opacity: 0.6 }}
-                      onPress={() => {
-                        copyText(tokenDetail.address);
-                        defaultLogger.dex.actions.dexCopyCA({
-                          copyFrom: ECopyFrom.Detail,
-                          copiedContent: tokenDetail.address,
-                        });
-                      }}
+                      onPress={handleCopyAddress}
                     >
                       {accountUtils.shortenAddress({
                         address: tokenDetail.address,
@@ -359,13 +353,7 @@ export function MarketDetailHeader({
                       testID="market-icon"
                       icon="Copy3Outline"
                       size="$4"
-                      onPress={() => {
-                        copyText(tokenDetail.address);
-                        defaultLogger.dex.actions.dexCopyCA({
-                          copyFrom: ECopyFrom.Detail,
-                          copiedContent: tokenDetail.address,
-                        });
-                      }}
+                      onPress={handleCopyAddress}
                     />
                   </XStack>
                 ) : null}


### PR DESCRIPTION
## Summary

- Restore the community-recognized token badge below the symbol in the iOS 26 Market detail header.
- Restore the shortened contract address and copy action in the native Liquid Glass navigation title.
- Reuse one stable copy handler across native and legacy header paths while preserving Dex copy analytics.

<img width="604" height="1311" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-12 at 11 17 11" src="https://github.com/user-attachments/assets/1a078f80-efbb-434d-b77a-a60f83d50881" />

## Intent & Context

The iOS 26 Liquid Glass adaptation retained the token icon, symbol, selector, favorite action, and share action, but removed the secondary token identity row available in the original Market detail header. Users could no longer see the token recognition badge or contract address, and could not copy the address from the header.

This change aligns the iOS 26 header capability with the original mobile header without changing the native navigation-bar integration.

## Root Cause

The iOS 26-specific `headerTitle` renderer was implemented as a single-row layout and explicitly omitted the original secondary row. Token security recognition, the shortened address, and the copy action therefore never entered the native navigation title render tree.

## Design Decisions

- Keep the system `UINavigationBar` and Liquid Glass back/favorite/share controls intact.
- Use a compact two-row title next to the token icon so the missing identity information remains inside the native header.
- Reuse the existing `TokenTagsPopover`, address shortening rules, clipboard behavior, and `dexCopyCA` analytics instead of introducing a parallel implementation.
- Add shrink constraints to protect long token symbols and addresses from colliding with right-side native bar items.

## Changes Detail

- `MarketDetailHeader.tsx`: renders the recognized badge, shortened address, and copy icon only in the iOS 26 native header title; both header paths reuse the same address-copy callback while all layout and style changes stay in the iOS 26 renderer.

## Risk Assessment

- **Risk Level**: Medium
- **Affected Platforms**: Mobile (iOS 26+ native header only for the visual change)
- **Risk Areas**: Native navigation-title sizing for unusually long token symbols; iOS versions below 26 and other platforms retain the existing layout path.

## Test plan

- [x] Run `yarn agent:check --profile commit` in an isolated worktree.
- [x] Open ANSEM Market detail on an iOS 26.5 simulator and verify the recognized badge, shortened address, and copy icon are visible without clipping.
- [x] Confirm the copy icon is hittable in the native header and shows the copied-success toast.
- [x] Confirm the Liquid Glass back, favorite, and share controls remain laid out correctly.
