### PR TITLE
fix: rework pending fixes (OK-57787, OK-56469, OK-56028)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
@@ -30,6 +30,7 @@ import {
 import { useSwapActions } from './actions';
 import {
   ProviderJotaiContextSwap,
+  swapActiveSelectedFromTokenBalanceAtom,
   swapAlertsAtom,
   swapFromTokenAmountAtom,
   swapInitialSelectedTokensSyncedAtom,
@@ -45,9 +46,11 @@ import {
   swapQuoteListAtom,
   swapSelectFromTokenAtom,
   swapSelectToTokenAtom,
+  swapSelectedFromTokenBalanceAtom,
   swapSelectedTokensColdStartContextAtom,
   swapStockExecutionTokenSyncIdAtom,
   swapStockExecutionTokensAtom,
+  swapStockSelectedFromTokenBalanceAtom,
   swapStockSelectedTokenAtom,
   swapToTokenAmountAtom,
   swapTypeSwitchAtom,
@@ -991,6 +994,7 @@ describe('useSwapActions', () => {
       storeInstance.set(swapTypeSwitchAtom(), ESwapTabSwitchType.STOCK);
       storeInstance.set(swapSelectFromTokenAtom(), usdcToken);
       storeInstance.set(swapSelectToTokenAtom(), appleStockToken);
+      storeInstance.set(swapStockSelectedFromTokenBalanceAtom(), '999');
       storeInstance.set(swapFromTokenAmountAtom(), {
         value: '10',
         isInput: true,
@@ -1039,6 +1043,8 @@ describe('useSwapActions', () => {
     expect(store.get(swapSelectedTokensColdStartContextAtom())).toBeUndefined();
     expect(store.get(swapInitialSelectedTokensSyncedAtom())).toBe(false);
     expect(store.get(swapLastNonLimitSelectedTokensAtom())).toBeUndefined();
+    expect(store.get(swapSelectedFromTokenBalanceAtom())).toBe('');
+    expect(store.get(swapStockSelectedFromTokenBalanceAtom())).toBe('');
 
     await act(async () => {
       await result.current.actions.swapTypeSwitchAction(
@@ -1056,11 +1062,12 @@ describe('useSwapActions', () => {
     });
   });
 
-  it('restores the previous Swap pair after visiting Stock', async () => {
+  it('restores the previous Swap pair without exposing the Stock balance', async () => {
     const { store, Wrapper } = createWrapperWithStore((storeInstance) => {
       storeInstance.set(swapTypeSwitchAtom(), ESwapTabSwitchType.SWAP);
       storeInstance.set(swapSelectFromTokenAtom(), bnbToken);
       storeInstance.set(swapSelectToTokenAtom(), usdtToken);
+      storeInstance.set(swapSelectedFromTokenBalanceAtom(), '0.1724');
     });
     const { result } = renderHook(
       () => {
@@ -1082,8 +1089,14 @@ describe('useSwapActions', () => {
       );
     });
 
+    expect(store.get(swapSelectedFromTokenBalanceAtom())).toBe('0.1724');
+    expect(store.get(swapStockSelectedFromTokenBalanceAtom())).toBe('');
+    expect(store.get(swapActiveSelectedFromTokenBalanceAtom())).toBe('');
+
     store.set(swapSelectFromTokenAtom(), usdcToken);
     store.set(swapSelectToTokenAtom(), appleStockToken);
+    store.set(swapStockSelectedFromTokenBalanceAtom(), '999');
+    expect(store.get(swapActiveSelectedFromTokenBalanceAtom())).toBe('999');
 
     await act(async () => {
       await result.current.actions.swapTypeSwitchAction(
@@ -1105,6 +1118,12 @@ describe('useSwapActions', () => {
       value: '',
       isInput: false,
     });
+    expect(store.get(swapSelectedFromTokenBalanceAtom())).toBe('0.1724');
+    expect(store.get(swapStockSelectedFromTokenBalanceAtom())).toBe('');
+    expect(store.get(swapActiveSelectedFromTokenBalanceAtom())).toBe('0.1724');
+
+    store.set(swapStockSelectedFromTokenBalanceAtom(), '999');
+    expect(store.get(swapActiveSelectedFromTokenBalanceAtom())).toBe('0.1724');
   });
 
   it('blocks Stock quote before Stock execution tokens own the selected pair', async () => {

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -135,6 +135,7 @@ import {
   swapSpeedQuoteResultAtom,
   swapStockExecutionTokenSyncIdAtom,
   swapStockExecutionTokensAtom,
+  swapStockSelectedFromTokenBalanceAtom,
   swapStockSelectedTokenAtom,
   swapToTokenAmountAtom,
   swapTokenFetchingAtom,
@@ -2708,6 +2709,18 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
     ) => {
       const oldType = get(swapTypeSwitchAtom());
       const normalizedType = getVisibleSwapTabSwitchType(type) ?? type;
+      const isCrossingStockBoundary =
+        (oldType === ESwapTabSwitchType.STOCK) !==
+        (normalizedType === ESwapTabSwitchType.STOCK);
+      if (isCrossingStockBoundary) {
+        set(swapStockSelectedFromTokenBalanceAtom(), '');
+      }
+      if (
+        oldType === ESwapTabSwitchType.STOCK &&
+        normalizedType === ESwapTabSwitchType.LIMIT
+      ) {
+        set(swapSelectedFromTokenBalanceAtom(), '');
+      }
       let currentFromToken = get(swapSelectFromTokenAtom());
       let currentToToken = get(swapSelectToTokenAtom());
       const oldVisibleType = getVisibleSwapTabSwitchType(oldType) ?? oldType;

--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -273,6 +273,20 @@ export const {
 } = contextAtom('');
 
 export const {
+  atom: swapStockSelectedFromTokenBalanceAtom,
+  use: useSwapStockSelectedFromTokenBalanceAtom,
+} = contextAtom('');
+
+export const {
+  atom: swapActiveSelectedFromTokenBalanceAtom,
+  use: useSwapActiveSelectedFromTokenBalanceAtom,
+} = contextAtomComputed((get) =>
+  get(swapTypeSwitchAtom()) === ESwapTabSwitchType.STOCK
+    ? get(swapStockSelectedFromTokenBalanceAtom())
+    : get(swapSelectedFromTokenBalanceAtom()),
+);
+
+export const {
   atom: swapSelectedToTokenBalanceAtom,
   use: useSwapSelectedToTokenBalanceAtom,
 } = contextAtom('');

--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
@@ -713,7 +713,7 @@ const ManagePositionPart = ({
 const EarnProtocolDetailsPage = ({ route }: { route: IRouteProps }) => {
   const intl = useIntl();
   const appNavigation = useAppNavigation();
-  const { gtMd } = useMedia();
+  const { gtMd, gtSm } = useMedia();
   const { shareText } = useShare();
   const [devSettings] = useDevSettingsPersistAtom();
   const { activeAccount } = useActiveAccount({ num: 0 });
@@ -938,7 +938,7 @@ const EarnProtocolDetailsPage = ({ route }: { route: IRouteProps }) => {
       tabRoute={ETabRoutes.Earn}
       showBackButton
       header={
-        <XStack ml={gtMd ? 'auto' : '0'} pr="$2" pt={gtMd ? undefined : '$4'}>
+        <XStack ml={gtSm ? 'auto' : '0'} pr="$2" pt={gtSm ? undefined : '$4'}>
           <ManagersSection managers={detailInfo?.managers} noPadding />
         </XStack>
       }

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -25,6 +25,7 @@ import {
   Image,
   KEYBOARD_AWARE_SCROLL_BOTTOM_OFFSET,
   Keyboard,
+  NATIVE_HIT_SLOP,
   NumberSizeableText,
   Page,
   ScrollView,
@@ -4074,6 +4075,57 @@ function SendAmountInputContainer() {
             gap="$1"
             flexShrink={1}
             minWidth={0}
+            px={shouldUsePrivateSendQuoteCollapse ? '$1' : undefined}
+            py={shouldUsePrivateSendQuoteCollapse ? '$1' : undefined}
+            mr={shouldUsePrivateSendQuoteCollapse ? '$-1' : undefined}
+            borderRadius={shouldUsePrivateSendQuoteCollapse ? '$2' : undefined}
+            borderCurve={
+              shouldUsePrivateSendQuoteCollapse ? 'continuous' : undefined
+            }
+            userSelect={shouldUsePrivateSendQuoteCollapse ? 'none' : undefined}
+            hitSlop={
+              shouldUsePrivateSendQuoteCollapse ? NATIVE_HIT_SLOP : undefined
+            }
+            role={shouldUsePrivateSendQuoteCollapse ? 'button' : undefined}
+            aria-expanded={
+              shouldUsePrivateSendQuoteCollapse
+                ? isPrivateSendQuoteDetailsExpanded
+                : undefined
+            }
+            focusable={shouldUsePrivateSendQuoteCollapse || undefined}
+            cursor={shouldUsePrivateSendQuoteCollapse ? 'pointer' : undefined}
+            hoverStyle={
+              shouldUsePrivateSendQuoteCollapse ? { bg: '$bgHover' } : undefined
+            }
+            pressStyle={
+              shouldUsePrivateSendQuoteCollapse
+                ? { bg: '$bgActive' }
+                : undefined
+            }
+            focusVisibleStyle={
+              shouldUsePrivateSendQuoteCollapse
+                ? {
+                    outlineColor: '$focusRing',
+                    outlineWidth: 2,
+                    outlineStyle: 'solid',
+                    outlineOffset: 1,
+                  }
+                : undefined
+            }
+            onPress={
+              shouldUsePrivateSendQuoteCollapse
+                ? handleTogglePrivateSendQuoteDetails
+                : undefined
+            }
+            {...(shouldUsePrivateSendQuoteCollapse &&
+              !platformEnv.isNative && {
+                onKeyDown: (event: KeyboardEvent) => {
+                  if (event.key !== 'Enter' && event.key !== ' ') return;
+                  event.preventDefault();
+                  event.stopPropagation();
+                  handleTogglePrivateSendQuoteDetails();
+                },
+              })}
           >
             {showPrivateSendQuoteSkeleton ? (
               <Skeleton h="$4" w="$24" />
@@ -4120,10 +4172,6 @@ function SendAmountInputContainer() {
                 alignItems="center"
                 justifyContent="center"
                 borderRadius="$full"
-                cursor="pointer"
-                hoverStyle={{ bg: '$bgHover' }}
-                pressStyle={{ bg: '$bgActive' }}
-                onPress={handleTogglePrivateSendQuoteDetails}
               >
                 <Stack
                   animation="quick"

--- a/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.test.ts
+++ b/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.test.ts
@@ -5,7 +5,9 @@ import {
   ESwapStockTradeSide,
   buildStockSwapTokenFromMarketListToken,
   filterStockPayTokenCandidates,
+  isStockBalanceInitializing,
   isStockPayTokenReadyForTradeInput,
+  resolveStockBalanceSnapshot,
   resolveStockChannelSwapPair,
   resolveStockKLineToken,
   shouldLoadDefaultStockToken,
@@ -249,6 +251,74 @@ describe('swapStockChannelUtils', () => {
         isBuySide: true,
       }),
     ).toBe(false);
+  });
+
+  it('shows Stock balance loading only before the first scoped balance lands', () => {
+    expect(
+      isStockBalanceInitializing({
+        balance: undefined,
+        requestPending: true,
+      }),
+    ).toBe(true);
+    expect(
+      isStockBalanceInitializing({
+        balance: '12.34',
+        requestPending: true,
+      }),
+    ).toBe(false);
+    expect(
+      isStockBalanceInitializing({
+        balance: '0',
+        requestPending: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps a scoped Stock balance visible from seed through authoritative refresh', () => {
+    const seededSnapshot = resolveStockBalanceSnapshot({
+      ownerScope: 'account-1:usdc',
+      seededBalance: '0.24',
+      seededTokenDetail: usdcToken,
+    });
+    expect(seededSnapshot).toEqual({
+      ownerScope: 'account-1:usdc',
+      balance: '0.24',
+      tokenDetail: usdcToken,
+    });
+
+    expect(
+      resolveStockBalanceSnapshot({
+        ownerScope: 'account-1:usdc',
+        previousSnapshot: seededSnapshot,
+        seededBalance: '0.10',
+      }),
+    ).toBe(seededSnapshot);
+
+    expect(
+      resolveStockBalanceSnapshot({
+        authoritativeBalance: '0.25',
+        authoritativeTokenDetail: usdcToken,
+        ownerScope: 'account-1:usdc',
+        previousSnapshot: seededSnapshot,
+      }),
+    ).toEqual({
+      ownerScope: 'account-1:usdc',
+      balance: '0.25',
+      tokenDetail: usdcToken,
+    });
+  });
+
+  it('does not reuse a Stock balance snapshot across owner scopes', () => {
+    expect(
+      resolveStockBalanceSnapshot({
+        ownerScope: 'account-2:usdc',
+        previousSnapshot: {
+          ownerScope: 'account-1:usdc',
+          balance: '0.24',
+          tokenDetail: usdcToken,
+        },
+      }),
+    ).toBeUndefined();
   });
 
   it('keeps sell-side stock input skeleton tied to full readiness', () => {

--- a/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.ts
+++ b/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.ts
@@ -239,6 +239,57 @@ export function shouldRenderStockTradeInputSkeleton({
   return isBuySide ? !inputTokenVisible : !inputTokenReady;
 }
 
+export function isStockBalanceInitializing({
+  balance,
+  requestPending,
+}: {
+  balance?: string;
+  requestPending: boolean;
+}) {
+  return balance === undefined && requestPending;
+}
+
+export type IStockBalanceSnapshot = {
+  ownerScope: string;
+  balance: string;
+  tokenDetail?: ISwapToken;
+};
+
+export function resolveStockBalanceSnapshot({
+  authoritativeBalance,
+  authoritativeTokenDetail,
+  ownerScope,
+  previousSnapshot,
+  seededBalance,
+  seededTokenDetail,
+}: {
+  authoritativeBalance?: string;
+  authoritativeTokenDetail?: ISwapToken;
+  ownerScope: string;
+  previousSnapshot?: IStockBalanceSnapshot;
+  seededBalance?: string;
+  seededTokenDetail?: ISwapToken;
+}): IStockBalanceSnapshot | undefined {
+  if (authoritativeBalance !== undefined) {
+    return {
+      ownerScope,
+      balance: authoritativeBalance,
+      tokenDetail: authoritativeTokenDetail,
+    };
+  }
+  if (previousSnapshot?.ownerScope === ownerScope) {
+    return previousSnapshot;
+  }
+  if (seededBalance !== undefined) {
+    return {
+      ownerScope,
+      balance: seededBalance,
+      tokenDetail: seededTokenDetail,
+    };
+  }
+  return undefined;
+}
+
 function getStockDefaultPayTokenCandidates(candidates: IToken[]) {
   return filterStockPayTokenCandidates(candidates);
 }

--- a/packages/kit/src/views/Swap/hooks/useSwapState.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapState.ts
@@ -43,6 +43,7 @@ import {
 } from '../../../states/jotai/contexts/accountSelector';
 import {
   useSwapActions,
+  useSwapActiveSelectedFromTokenBalanceAtom,
   useSwapAlertsAtom,
   useSwapBuildTxFetchingAtom,
   useSwapFromTokenAmountAtom,
@@ -59,7 +60,6 @@ import {
   useSwapQuoteListAtom,
   useSwapSelectFromTokenAtom,
   useSwapSelectToTokenAtom,
-  useSwapSelectedFromTokenBalanceAtom,
   useSwapShouldRefreshQuoteAtom,
   useSwapSilenceQuoteLoading,
   useSwapSlippageOverrideAtom,
@@ -95,7 +95,7 @@ function useSwapWarningCheck() {
   const [quoteEventCompleted] = useSwapQuoteEventCompletedAtom();
   const [quoteEventError] = useSwapQuoteEventErrorAtom();
   const [fromTokenAmount] = useSwapFromTokenAmountAtom();
-  const [fromTokenBalance] = useSwapSelectedFromTokenBalanceAtom();
+  const [fromTokenBalance] = useSwapActiveSelectedFromTokenBalanceAtom();
   const { checkSwapWarning } = useSwapActions().current;
   const [swapLimitUseRate] = useSwapLimitPriceUseRateAtom();
   const [accountSelectorStorageInitDone] =
@@ -401,7 +401,8 @@ export function useSwapActionState() {
     useSwapQuoteApproveAllowanceUnLimitAtom();
   useSwapWarningCheck();
   const [alerts] = useSwapAlertsAtom();
-  const [selectedFromTokenBalance] = useSwapSelectedFromTokenBalanceAtom();
+  const [selectedFromTokenBalance] =
+    useSwapActiveSelectedFromTokenBalanceAtom();
   const isCrossChain = fromToken?.networkId !== toToken?.networkId;
   const swapFromAddressInfo = useSwapAddressInfo(ESwapDirectionType.FROM);
   const swapToAddressInfo = useSwapAddressInfo(ESwapDirectionType.TO);

--- a/packages/kit/src/views/Swap/hooks/useSwapStockTradeInputs.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapStockTradeInputs.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import BigNumber from 'bignumber.js';
 
@@ -8,8 +8,7 @@ import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accoun
 import {
   useSwapAlertsAtom,
   useSwapFromTokenAmountAtom,
-  useSwapSelectTokenDetailFetchingAtom,
-  useSwapSelectedFromTokenBalanceAtom,
+  useSwapStockSelectedFromTokenBalanceAtom,
   useSwapToTokenAmountAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import { validateAmountInput } from '@onekeyhq/kit/src/utils/validateAmountInput';
@@ -33,7 +32,10 @@ import {
 import { buildSwapRateDifference } from '../utils/swapRateDifferenceUtils';
 
 import {
+  type IStockBalanceSnapshot,
+  isStockBalanceInitializing,
   isStockPayTokenReadyForTradeInput,
+  resolveStockBalanceSnapshot,
   shouldRenderStockTradeInputSkeleton,
 } from './swapStockChannelUtils';
 import {
@@ -76,6 +78,9 @@ function useStockInputTokenBalance({
 }) {
   const { activeAccount } = useActiveAccount({ num: 0 });
   const [refreshKey, setRefreshKey] = useState(0);
+  const lastValidBalanceStateRef = useRef<IStockBalanceSnapshot | undefined>(
+    undefined,
+  );
   const tokenScope = getStockInputTokenIdentityKey(token);
   const hasActiveAccount = Boolean(
     activeAccount?.indexedAccount?.id || activeAccount?.account?.id,
@@ -84,6 +89,9 @@ function useStockInputTokenBalance({
   const accountNetworkReady = Boolean(
     !hasActiveAccount || activeAccount?.ready,
   );
+  const balanceOwnerScope = `${tokenScope}:${
+    activeAccount?.indexedAccount?.id ?? ''
+  }:${activeAccount?.account?.id ?? ''}`;
   const shouldFetchNetworkAccount = Boolean(
     enabled && tokenNetworkId && hasActiveAccount && accountNetworkReady,
   );
@@ -239,19 +247,37 @@ function useStockInputTokenBalance({
 
   const balanceReady =
     detailState.scope === balanceScope && detailState.balance !== undefined;
+  const balanceState = resolveStockBalanceSnapshot({
+    authoritativeBalance: balanceReady ? detailState.balance : undefined,
+    authoritativeTokenDetail: balanceReady
+      ? detailState.tokenDetail
+      : undefined,
+    ownerScope: balanceOwnerScope,
+    previousSnapshot: lastValidBalanceStateRef.current,
+    seededBalance: enabled ? token?.balanceParsed : undefined,
+    seededTokenDetail: enabled ? token : undefined,
+  });
+  if (balanceState) {
+    lastValidBalanceStateRef.current = balanceState;
+  }
+  const balance = balanceState?.balance;
+  const tokenDetail = balanceState?.tokenDetail;
 
   return {
-    balance: balanceReady ? detailState.balance : undefined,
-    tokenDetail: balanceReady ? detailState.tokenDetail : undefined,
-    loading:
-      enabled &&
-      Boolean(
-        token &&
-        (!balanceReady ||
-          networkAccountLoading ||
-          shouldWaitForNetworkAccount ||
-          detailLoading),
-      ),
+    balance,
+    tokenDetail,
+    loading: isStockBalanceInitializing({
+      balance,
+      requestPending:
+        enabled &&
+        Boolean(
+          token &&
+          (!balanceReady ||
+            networkAccountLoading ||
+            shouldWaitForNetworkAccount ||
+            detailLoading),
+        ),
+    }),
   };
 }
 
@@ -430,8 +456,7 @@ export function useSwapStockAmountInputState({
   const [fromTokenAmount, setFromTokenAmount] = useSwapFromTokenAmountAtom();
   const [, setSwapAlerts] = useSwapAlertsAtom();
   const [fromTokenBalance, setFromTokenBalance] =
-    useSwapSelectedFromTokenBalanceAtom();
-  const [swapTokenDetailLoading] = useSwapSelectTokenDetailFetchingAtom();
+    useSwapStockSelectedFromTokenBalanceAtom();
   const [settingsPersistAtom] = useSettingsPersistAtom();
   const [{ currencyMap }] = useCurrencyPersistAtom();
   const {
@@ -592,8 +617,7 @@ export function useSwapStockAmountInputState({
 
   return {
     amountFiatValue,
-    balanceLoading:
-      swapTokenDetailLoading.from || stockInputTokenBalance.loading,
+    balanceLoading: stockInputTokenBalance.loading,
     currencySymbol,
     disableNativePayToken,
     displayBalance,


### PR DESCRIPTION
## Issues

- [OK-57787](https://onekeyhq.atlassian.net/browse/OK-57787)
- [OK-56469](https://onekeyhq.atlassian.net/browse/OK-56469)
- [OK-56028](https://onekeyhq.atlassian.net/browse/OK-56028)

## Changes

- Clear the transient from-token balance whenever the UI crosses the Stock ownership boundary, preventing either trade mode from rendering the other mode's balance.
- Align the Earn provider header at the existing `gtSm` tablet-header breakpoint used by its breadcrumb row.
- Expand the Private Send amount/chevron interaction target with native hit slop and compact rounded feedback while keeping tooltip and refresh actions independent.

## Verification

- [x] `yarn agent:check --profile commit`
- [x] `yarn agent:check --profile pr`
- [x] `yarn jest packages/kit/src/states/jotai/contexts/swap/actions.test.tsx --runInBand` — 25 tests passed
- [x] `git diff --check origin/x...HEAD`
- [x] Desktop: 5 repeated transitions in each Stock ↔ Swap direction; frame-level balance sampling found 0 cross-mode leaks
- [x] iPhone 17: recorded and inspected both Stock ↔ Swap transitions frame by frame; cached balances never appeared under the wrong token
- [x] iPad mini: verified the local RN screen in portrait and landscape; provider/manager information stays at the right edge without overlapping the breadcrumb
- [x] Private Send on iPhone 17: amount, gap, and chevron toggle details; tooltip and refresh stay independent; held-press feedback is a compact rounded shape

## Runtime boundary

- OK-57787 changes the `main` JS Jotai store only. The `bg` runtime still owns asynchronous token-detail fetching; no shared native resource or background data contract changed.
- OK-56469 is a UI-only breakpoint correction. Earn business logic and footer breakpoints are unchanged.
- OK-56028 changes interaction geometry and accessibility semantics only. Quote state and transaction behavior are unchanged.

## Risk boundary

- No quote-fetching, token-pair restoration, crypto, storage schema, dependency, or generated translation changes.
- Each issue is isolated in its own commit.


[OK-57787]: https://onekeyhq.atlassian.net/browse/OK-57787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-56469]: https://onekeyhq.atlassian.net/browse/OK-56469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-56028]: https://onekeyhq.atlassian.net/browse/OK-56028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ