### PR TITLE
fix: run ext OneKey ID OAuth flows in expand tab

### DIFF
--- a/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
+++ b/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
@@ -46,6 +46,7 @@ import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
 import useAppNavigation from '../../hooks/useAppNavigation';
 import { usePromiseResult } from '../../hooks/usePromiseResult';
 import { showOneKeyIdLegacyOAuthBindDialog } from '../../views/Prime/components/OneKeyIdLegacyOAuthBind/OneKeyIdLegacyOAuthBind';
+import { shouldRunOneKeyIdAuthInExtExpandTab } from '../OneKeyAuth/extOneKeyIdAuthExpandTab';
 import { getDisplayEmailOrUnknown } from '../OneKeyAuth/oneKeyIdDisplayEmailUtils';
 import { useOneKeyAuth } from '../OneKeyAuth/useOneKeyAuth';
 
@@ -820,6 +821,22 @@ export function useKeylessWallet() {
             return;
           }
         }
+      }
+
+      // The OneKey ID login onboarding page runs launchWebAuthFlow, which
+      // can never complete in the ext action popup (Chrome destroys it on
+      // focus loss). Open the page in the expand tab instead of navigating
+      // inside the popup.
+      if (shouldRunOneKeyIdAuthInExtExpandTab()) {
+        const expandTabParams: Record<string, string> = { mode };
+        if (keylessProvider) {
+          expandTabParams.provider = keylessProvider;
+        }
+        await backgroundApiProxy.serviceApp.openExtensionExpandTab({
+          path: `/onboarding/${EOnboardingPagesV2.OneKeyIDLogin}`,
+          params: expandTabParams,
+        });
+        return;
       }
 
       navigation.navigate(ERootRoutes.Onboarding, {

--- a/packages/kit/src/components/OneKeyAuth/ExtOneKeyIdAuthOnMount.tsx
+++ b/packages/kit/src/components/OneKeyAuth/ExtOneKeyIdAuthOnMount.tsx
@@ -1,0 +1,57 @@
+import { memo, useEffect } from 'react';
+
+import { EExtOneKeyIdAuthFlow } from '@onekeyhq/shared/src/consts/authConsts';
+import { PrimeLoginDialogCancelError } from '@onekeyhq/shared/src/errors';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+
+import { consumeExtOneKeyIdAuthFlowFromUrl } from './extOneKeyIdAuthExpandTab';
+import { useOneKeyAuth } from './useOneKeyAuth';
+
+// Module-level flag: the flow must run at most once per expand-tab document,
+// even if the host page remounts.
+let isFlowConsumed = false;
+
+// Auto-resumes a OneKey ID auth flow handed off from the extension action
+// popup (see extOneKeyIdAuthExpandTab.ts). Only the expand tab runs the
+// flow; everywhere else this component is a no-op.
+function ExtOneKeyIdAuthOnMountCmp() {
+  const { loginOneKeyId } = useOneKeyAuth();
+
+  useEffect(() => {
+    if (!platformEnv.isExtensionUiExpandTab || isFlowConsumed) {
+      return;
+    }
+    isFlowConsumed = true;
+    const flowInfo = consumeExtOneKeyIdAuthFlowFromUrl();
+    if (!flowInfo) {
+      return;
+    }
+    void (async () => {
+      // Let the app finish mounting so the dialog overlay renders reliably.
+      await timerUtils.wait(600);
+      try {
+        if (flowInfo.flow === EExtOneKeyIdAuthFlow.Login) {
+          await loginOneKeyId({
+            toOneKeyIdPageOnLoginSuccess: flowInfo.toOneKeyIdPageOnLoginSuccess,
+          });
+        } else if (flowInfo.flow === EExtOneKeyIdAuthFlow.LegacyOAuthBind) {
+          // Lazy import keeps the Prime bind dialog out of the home bundle
+          // on platforms that never run this flow.
+          const { showOneKeyIdLegacyOAuthBindDialog } =
+            await import('../../views/Prime/components/OneKeyIdLegacyOAuthBind/OneKeyIdLegacyOAuthBind');
+          await showOneKeyIdLegacyOAuthBindDialog();
+        }
+      } catch (error) {
+        if (error instanceof PrimeLoginDialogCancelError) {
+          return;
+        }
+        console.error('ExtOneKeyIdAuthOnMount: auth flow failed:', error);
+      }
+    })();
+  }, [loginOneKeyId]);
+
+  return null;
+}
+
+export const ExtOneKeyIdAuthOnMount = memo(ExtOneKeyIdAuthOnMountCmp);

--- a/packages/kit/src/components/OneKeyAuth/extOneKeyIdAuthExpandTab.ts
+++ b/packages/kit/src/components/OneKeyAuth/extOneKeyIdAuthExpandTab.ts
@@ -1,0 +1,85 @@
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import {
+  EExtOneKeyIdAuthFlow,
+  EXT_ONEKEY_ID_AUTH_FLOW_PARAM,
+  EXT_ONEKEY_ID_AUTH_TO_PAGE_PARAM,
+} from '@onekeyhq/shared/src/consts/authConsts';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+export interface IExtOneKeyIdAuthFlowInfo {
+  flow: EExtOneKeyIdAuthFlow;
+  toOneKeyIdPageOnLoginSuccess?: boolean;
+}
+
+// Only the extension action popup needs the expand-tab handoff: Chrome
+// destroys it when it loses focus, so the launchWebAuthFlow-based OAuth flow
+// can never complete there (see EXT_ONEKEY_ID_AUTH_FLOW_PARAM in authConsts).
+// Side panel and standalone window survive focus loss and run the flow in
+// place.
+export function shouldRunOneKeyIdAuthInExtExpandTab(): boolean {
+  return Boolean(platformEnv.isExtensionUiPopup);
+}
+
+export async function redirectOneKeyIdAuthToExtExpandTab({
+  flow,
+  toOneKeyIdPageOnLoginSuccess,
+}: IExtOneKeyIdAuthFlowInfo): Promise<void> {
+  const params: Record<string, string> = {
+    [EXT_ONEKEY_ID_AUTH_FLOW_PARAM]: flow,
+  };
+  if (toOneKeyIdPageOnLoginSuccess) {
+    params[EXT_ONEKEY_ID_AUTH_TO_PAGE_PARAM] = 'true';
+  }
+  // The popup does not need an explicit close: Chrome dismisses it as soon
+  // as the newly opened expand tab takes focus.
+  await backgroundApiProxy.serviceApp.openExtensionExpandTab({
+    path: '/',
+    params,
+  });
+}
+
+// Parse the auth-flow params from the expand-tab URL hash
+// (ui-expand-tab.html#/?oneKeyIdAuthFlow=login), then strip them via
+// history.replaceState so a manual refresh does not re-trigger the flow.
+export function consumeExtOneKeyIdAuthFlowFromUrl():
+  | IExtOneKeyIdAuthFlowInfo
+  | undefined {
+  if (!platformEnv.isExtensionUiExpandTab) {
+    return undefined;
+  }
+  const hash = globalThis.location?.hash ?? '';
+  const queryIndex = hash.indexOf('?');
+  if (queryIndex < 0) {
+    return undefined;
+  }
+  const searchParams = new URLSearchParams(hash.slice(queryIndex + 1));
+  const flow = searchParams.get(EXT_ONEKEY_ID_AUTH_FLOW_PARAM);
+  if (
+    flow !== EExtOneKeyIdAuthFlow.Login &&
+    flow !== EExtOneKeyIdAuthFlow.LegacyOAuthBind
+  ) {
+    return undefined;
+  }
+  const toOneKeyIdPageOnLoginSuccess =
+    searchParams.get(EXT_ONEKEY_ID_AUTH_TO_PAGE_PARAM) === 'true';
+
+  try {
+    searchParams.delete(EXT_ONEKEY_ID_AUTH_FLOW_PARAM);
+    searchParams.delete(EXT_ONEKEY_ID_AUTH_TO_PAGE_PARAM);
+    const restQuery = searchParams.toString();
+    const newHash = `${hash.slice(0, queryIndex)}${
+      restQuery ? `?${restQuery}` : ''
+    }`;
+    globalThis.history?.replaceState?.(
+      globalThis.history?.state ?? null,
+      '',
+      `${globalThis.location.pathname}${globalThis.location.search}${
+        newHash || '#/'
+      }`,
+    );
+  } catch {
+    // URL cleanup is best-effort only; the flow info is already extracted.
+  }
+
+  return { flow, toOneKeyIdPageOnLoginSuccess };
+}

--- a/packages/kit/src/components/OneKeyAuth/supabase/useSupabaseAuth.tsx
+++ b/packages/kit/src/components/OneKeyAuth/supabase/useSupabaseAuth.tsx
@@ -9,6 +9,7 @@ import type { EOAuthSocialLoginProvider } from '@onekeyhq/shared/src/consts/auth
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import errorToastUtils from '@onekeyhq/shared/src/errors/utils/errorToastUtils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { OAuthPopup } from '../OAuthPopup';
 import { ensureOneKeyOAuthState } from '../oauthUtils';
@@ -105,6 +106,16 @@ export function useSupabaseAuth() {
       provider: EOAuthSocialLoginProvider,
       options?: IOAuthSignInOptions,
     ): Promise<IOAuthSignInResult> => {
+      // Last-resort guard: Chrome destroys the action popup on focus loss,
+      // so the launchWebAuthFlow window opened below would silently kill
+      // this whole pending flow. Callers must redirect to the expand tab
+      // first (see extOneKeyIdAuthExpandTab); fail loudly if one slips
+      // through instead of dying without any feedback.
+      if (platformEnv.isExtensionUiPopup) {
+        throw new OneKeyLocalError(
+          'OAuth sign-in cannot run in the extension popup. Please continue in the expanded view.',
+        );
+      }
       const { persistSession } = options ?? {};
       const clientTemp: SupabaseClient = await createTemporarySupabaseClient();
 

--- a/packages/kit/src/components/OneKeyAuth/useOneKeyAuth.tsx
+++ b/packages/kit/src/components/OneKeyAuth/useOneKeyAuth.tsx
@@ -8,6 +8,7 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { LazyLoadPage } from '@onekeyhq/kit/src/components/LazyLoadPage';
 import { useSupabaseAuth } from '@onekeyhq/kit/src/components/OneKeyAuth/supabase/useSupabaseAuth';
 import { usePrimePersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/prime';
+import { EExtOneKeyIdAuthFlow } from '@onekeyhq/shared/src/consts/authConsts';
 import type { EPrimeEmailOTPScene } from '@onekeyhq/shared/src/consts/primeConsts';
 import { PrimeLoginDialogCancelError } from '@onekeyhq/shared/src/errors';
 import {
@@ -25,6 +26,10 @@ import type { IPrimeUserInfo } from '@onekeyhq/shared/types/prime/primeTypes';
 import useAppNavigation from '../../hooks/useAppNavigation';
 import { logoutPurchasesSdk } from '../../views/Prime/hooks/purchasesSdkLogout';
 
+import {
+  redirectOneKeyIdAuthToExtExpandTab,
+  shouldRunOneKeyIdAuthInExtExpandTab,
+} from './extOneKeyIdAuthExpandTab';
 import { getDisplayEmailOrUnknown } from './oneKeyIdDisplayEmailUtils';
 
 // import PrimeLoginEmailDialogV2 from '../../views/Prime/components/PrimeLoginEmailDialogV2/PrimeLoginEmailDialogV2';
@@ -254,6 +259,18 @@ export function useOneKeyAuth() {
         return;
       }
 
+      // The extension action popup dies on focus loss, which destroys the
+      // pending launchWebAuthFlow OAuth flow (see extOneKeyIdAuthExpandTab).
+      // Hand the whole login flow off to the expand tab before touching any
+      // local auth state, and settle this call as a user cancel.
+      if (shouldRunOneKeyIdAuthInExtExpandTab()) {
+        await redirectOneKeyIdAuthToExtExpandTab({
+          flow: EExtOneKeyIdAuthFlow.Login,
+          toOneKeyIdPageOnLoginSuccess,
+        });
+        throw new PrimeLoginDialogCancelError();
+      }
+
       if (preserveLocalKeylessAuth) {
         defaultLogger.prime.subscription.onekeyIdLogout({
           reason:
@@ -336,6 +353,7 @@ export function useOneKeyAuth() {
             onLoginSuccess={onLoginSuccess}
             onCancel={onCancel}
             localKeylessLoginPrepareResult={localKeylessLoginPrepareResult}
+            toOneKeyIdPageOnLoginSuccess={toOneKeyIdPageOnLoginSuccess}
           />
         ),
       });

--- a/packages/kit/src/views/Home/pages/HomePageContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageContainer.tsx
@@ -7,6 +7,7 @@ import { useDebugComponentRemountLog } from '@onekeyhq/shared/src/utils/debug/de
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import { AccountSelectorProviderMirror } from '../../../components/AccountSelector';
+import { ExtOneKeyIdAuthOnMount } from '../../../components/OneKeyAuth/ExtOneKeyIdAuthOnMount';
 import { TabletHomeContainer } from '../../../components/TabletHomeContainer';
 import { ProviderJotaiContextAccountOverview } from '../../../states/jotai/contexts/accountOverview';
 import {
@@ -85,6 +86,7 @@ function HomePageContainer() {
           />
           <DAppConnectExtensionFloatingTrigger />
           <OnboardingOnMount />
+          <ExtOneKeyIdAuthOnMount />
           <NotificationRegisterDaily />
           <KYTIntroOnMount />
           <BTCFreshAddressProvider />

--- a/packages/kit/src/views/Prime/components/OneKeyIdLegacyOAuthBind/OneKeyIdLegacyOAuthBind.tsx
+++ b/packages/kit/src/views/Prime/components/OneKeyIdLegacyOAuthBind/OneKeyIdLegacyOAuthBind.tsx
@@ -15,11 +15,18 @@ import {
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import {
+  redirectOneKeyIdAuthToExtExpandTab,
+  shouldRunOneKeyIdAuthInExtExpandTab,
+} from '@onekeyhq/kit/src/components/OneKeyAuth/extOneKeyIdAuthExpandTab';
+import {
   EOneKeyIdLogoutDialogSource,
   useShowOneKeyIdLogoutDialog,
 } from '@onekeyhq/kit/src/components/OneKeyAuth/OneKeyIdLogoutDialog';
 import { useOneKeyAuth } from '@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth';
-import { EOAuthSocialLoginProvider } from '@onekeyhq/shared/src/consts/authConsts';
+import {
+  EExtOneKeyIdAuthFlow,
+  EOAuthSocialLoginProvider,
+} from '@onekeyhq/shared/src/consts/authConsts';
 import errorToastUtils from '@onekeyhq/shared/src/errors/utils/errorToastUtils';
 import {
   EOneKeyIdLoginWithLocalKeylessPrepareStatus,
@@ -155,6 +162,18 @@ function OneKeyIdLegacyOAuthBindActions({
   const handleBindOAuth = useCallback(
     async (provider: EOAuthSocialLoginProvider) => {
       if (bindingProviderRef.current) {
+        return;
+      }
+      // launchWebAuthFlow can never complete in the ext action popup (Chrome
+      // destroys it on focus loss), so hand the bind flow off to the expand
+      // tab. Guarding the button press (not the mount) keeps the passive
+      // upgrade prompt (PrimeGlobalEffect) from opening tabs without an
+      // explicit user gesture, and also covers the inline bind prompt on the
+      // OneKey ID page.
+      if (shouldRunOneKeyIdAuthInExtExpandTab()) {
+        await redirectOneKeyIdAuthToExtExpandTab({
+          flow: EExtOneKeyIdAuthFlow.LegacyOAuthBind,
+        });
         return;
       }
       bindingProviderRef.current = provider;

--- a/packages/kit/src/views/Prime/components/PrimeLoginOAuthDialog/PrimeLoginOAuthDialog.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeLoginOAuthDialog/PrimeLoginOAuthDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -13,11 +13,18 @@ import {
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import {
+  redirectOneKeyIdAuthToExtExpandTab,
+  shouldRunOneKeyIdAuthInExtExpandTab,
+} from '@onekeyhq/kit/src/components/OneKeyAuth/extOneKeyIdAuthExpandTab';
+import {
   EOneKeyIdLogoutDialogSource,
   useShowOneKeyIdLogoutDialog,
 } from '@onekeyhq/kit/src/components/OneKeyAuth/OneKeyIdLogoutDialog';
 import { useOneKeyAuth } from '@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth';
-import { EOAuthSocialLoginProvider } from '@onekeyhq/shared/src/consts/authConsts';
+import {
+  EExtOneKeyIdAuthFlow,
+  EOAuthSocialLoginProvider,
+} from '@onekeyhq/shared/src/consts/authConsts';
 import { PrimeLoginDialogCancelError } from '@onekeyhq/shared/src/errors';
 import type { IOneKeyIdLoginWithLocalKeylessPrepareResult } from '@onekeyhq/shared/src/keylessWallet/keylessWalletTypes';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -34,12 +41,14 @@ function PrimeLoginOAuthDialog(props: {
   onLoginSuccess?: () => void | Promise<void>;
   onCancel?: () => void | Promise<void>;
   localKeylessLoginPrepareResult?: IOneKeyIdLoginWithLocalKeylessPrepareResult;
+  toOneKeyIdPageOnLoginSuccess?: boolean;
 }) {
   const {
     onComplete,
     onLoginSuccess,
     onCancel,
     localKeylessLoginPrepareResult,
+    toOneKeyIdPageOnLoginSuccess,
   } = props;
   const intl = useIntl();
   const { loginOneKeyIdWithLegacyEmail, supabaseSignOut } = useOneKeyAuth();
@@ -73,6 +82,36 @@ function PrimeLoginOAuthDialog(props: {
   const shouldShowAppleButton = shouldShowProvider(
     EOAuthSocialLoginProvider.Apple,
   );
+
+  // Fallback guard: the showOneKeyIdLoginDialog funnel already redirects the
+  // ext action popup to the expand tab, but this dialog can also be rendered
+  // directly. launchWebAuthFlow can never complete in the action popup
+  // (Chrome destroys it on focus loss), so hand the flow off to the expand
+  // tab on mount instead of showing the buttons.
+  const shouldRedirectToExtExpandTab = shouldRunOneKeyIdAuthInExtExpandTab();
+  const hasRedirectedToExtExpandTabRef = useRef(false);
+  useEffect(() => {
+    if (
+      !shouldRedirectToExtExpandTab ||
+      hasRedirectedToExtExpandTabRef.current
+    ) {
+      return;
+    }
+    hasRedirectedToExtExpandTabRef.current = true;
+    void (async () => {
+      await redirectOneKeyIdAuthToExtExpandTab({
+        flow: EExtOneKeyIdAuthFlow.Login,
+        toOneKeyIdPageOnLoginSuccess,
+      });
+      onComplete?.();
+      void onCancel?.();
+    })();
+  }, [
+    onCancel,
+    onComplete,
+    shouldRedirectToExtExpandTab,
+    toOneKeyIdPageOnLoginSuccess,
+  ]);
 
   const handleSocialLogin = useCallback(
     async (provider: EOAuthSocialLoginProvider) => {
@@ -211,6 +250,11 @@ function PrimeLoginOAuthDialog(props: {
   const hideLegacyEmailLoginConfirm = useCallback(() => {
     setIsLegacyEmailConfirmMode(false);
   }, []);
+
+  if (shouldRedirectToExtExpandTab) {
+    // Render nothing while the expand-tab handoff closes this dialog.
+    return null;
+  }
 
   if (isLegacyEmailConfirmMode) {
     return (

--- a/packages/shared/src/consts/authConsts.ts
+++ b/packages/shared/src/consts/authConsts.ts
@@ -117,6 +117,23 @@ export const GOOGLE_OAUTH_DEFAULT_SCOPES = [
 
 export const EXTENSION_OAUTH_USE_PKCE_FLOW = true;
 
+// Extension OneKey ID auth expand-tab handoff.
+// chrome.identity.launchWebAuthFlow opens a separate auth window that steals
+// focus, and the extension action popup is destroyed by Chrome as soon as it
+// loses focus — killing the pending OAuth flow (temporary Supabase client,
+// PKCE code exchange, session persistence, api login) with it. OneKey ID
+// OAuth flows started from the action popup must therefore be redirected to
+// the expand tab first (side panel and standalone window survive focus loss
+// and run the flow in place). These URL params tell the expand tab which
+// flow to auto-resume on mount.
+export const EXT_ONEKEY_ID_AUTH_FLOW_PARAM = 'oneKeyIdAuthFlow';
+export const EXT_ONEKEY_ID_AUTH_TO_PAGE_PARAM = 'oneKeyIdAuthToPageOnSuccess';
+
+export enum EExtOneKeyIdAuthFlow {
+  Login = 'login',
+  LegacyOAuthBind = 'legacyOAuthBind',
+}
+
 // Apple Sign-In nonce support
 // When enabled, a nonce will be generated and passed to Apple Sign-In for replay attack protection
 // Reference: https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest/nonce


### PR DESCRIPTION
## Summary
- Fix the ext MV3 issue where OneKey ID OAuth login started from the browser action popup always fails silently: `chrome.identity.launchWebAuthFlow` opens an auth window that steals focus, Chrome destroys the popup on focus loss, and the pending flow (temporary Supabase client, PKCE `exchangeCodeForSession`, `persistKeylessOAuthSession`, `apiOAuthLogin`) dies with the popup document.
- Mirror the existing `useToOnBoardingPage` handoff: redirect the action popup to the expand tab first, then auto-resume the flow there. Side panel and standalone window survive focus loss, so they keep running the flow in place.

## Root Cause
`loginOneKeyId()` switched from the email OTP dialog to `PrimeLoginOAuthDialog`, whose Google/Apple buttons run the whole OAuth flow in the calling UI runtime. The extension default entry is the action popup (`default_popup: 'ui-popup.html'`), which Chrome destroys as soon as it loses focus — and `OAuthPopup.ext` even actively focuses the auth window. Reachable unguarded entries included MoreActionButton, OneKeyIdButton, OneKeyIdTabItem, OneKeyIdSettingsPage, ReferFriends, RedemptionCenter, PrimeDashboard, and more. Legacy keyless OAuth was mostly protected by `useToOnBoardingPage` forcing `openExtensionExpandTab`, but `goToOneKeyIDLoginPageForKeylessWallet` navigated directly and carried the same latent bug.

## Design Decisions
- **Popup-only scope**: only `platformEnv.isExtensionUiPopup` triggers the handoff. Side panel and standalone window are not destroyed on focus loss, so OAuth works there and they are left untouched.
- **Funnel guard (primary fix)**: `showOneKeyIdLoginDialog` redirects the action popup to the expand tab (with flow + `toOneKeyIdPageOnLoginSuccess` URL params) before touching any local auth state, and settles the caller's promise as a user cancel — one guard covers every `loginOneKeyId` / `loginOneKeyIdWithLegacyEmail` entry point.
- **Dialog mount fallback**: `PrimeLoginOAuthDialog` detects on mount that it is rendered in the action popup, hands off to the expand tab, and closes itself — protecting any cold path that renders the dialog directly.
- **Bind flow guard on button press**: `OneKeyIdLegacyOAuthBindActions.handleBindOAuth` redirects on the explicit provider-button gesture instead of on mount, so the passive upgrade prompt (`PrimeGlobalEffect`) never opens tabs without user intent, and the inline bind prompt on the OneKey ID page is covered too.
- **Legacy path covered**: `goToOneKeyIDLoginPageForKeylessWallet` now opens `/onboarding/OneKeyIDLogin` in the expand tab (mirroring `useNavigateToPickYourDevicePage`) instead of navigating inside the popup.
- **Expand-tab auto-resume**: new `ExtOneKeyIdAuthOnMount` (mounted next to `OnboardingOnMount`) consumes the URL params, auto-opens the login or bind dialog, and strips the params via `history.replaceState` so refresh does not re-trigger.
- **Last-resort safety net**: `performOAuthSignIn` throws a clear error when running in `isExtensionUiPopup`, converting any missed path from a silent death into a visible toast.

## Changes Detail
- `packages/shared/src/consts/authConsts.ts`: expand-tab handoff URL param consts and `EExtOneKeyIdAuthFlow` enum.
- `packages/kit/src/components/OneKeyAuth/extOneKeyIdAuthExpandTab.ts` (new): popup-only guard predicate, expand-tab redirect helper, URL param consume/cleanup.
- `packages/kit/src/components/OneKeyAuth/ExtOneKeyIdAuthOnMount.tsx` (new): expand-tab auto-resume component.
- `packages/kit/src/components/OneKeyAuth/useOneKeyAuth.tsx`: funnel guard in `showOneKeyIdLoginDialog`; pass `toOneKeyIdPageOnLoginSuccess` to the OAuth dialog.
- `packages/kit/src/views/Prime/components/PrimeLoginOAuthDialog/PrimeLoginOAuthDialog.tsx`: mount fallback guard.
- `packages/kit/src/views/Prime/components/OneKeyIdLegacyOAuthBind/OneKeyIdLegacyOAuthBind.tsx`: button-press guard for the bind flow.
- `packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx`: expand-tab redirect for `goToOneKeyIDLoginPageForKeylessWallet`.
- `packages/kit/src/components/OneKeyAuth/supabase/useSupabaseAuth.tsx`: popup throw in `performOAuthSignIn`.
- `packages/kit/src/views/Home/pages/HomePageContainer.tsx`: mount `ExtOneKeyIdAuthOnMount`.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension only (all guards are behind `platformEnv.isExtensionUiPopup` / `isExtensionUiExpandTab` checks; web/desktop/native and ext side panel / standalone window behavior unchanged)
- **Risk Areas**: ext popup login entries, expand-tab auto-resume timing, legacy keyless PIN reset/verify navigation.

## Test plan
- [x] `yarn lint:staged`
- [x] `yarn tsc:staged`
- [ ] Ext action popup: every OneKey ID login entry (MoreActionButton, header OneKeyIdButton, Settings tab item, OneKey ID settings page, ReferFriends, Redemption) opens the expand tab and auto-shows the OAuth login dialog; Google/Apple login completes there.
- [ ] Ext side panel / standalone window: login dialog opens in place and Google/Apple OAuth completes without redirecting to the expand tab.
- [ ] Expand tab / web / desktop / native: login dialog opens in place, unchanged.
- [ ] Legacy bind prompts (OneKey ID page inline prompt, upgrade dialog) in the popup: pressing Google/Apple opens the expand tab and auto-shows the bind dialog.
- [ ] Keyless PIN reset / verify from WalletEdit or Settings in the popup: OneKey ID login onboarding page opens in the expand tab with mode/provider preserved.
- [ ] Refreshing the expand tab after the handoff does not re-open the dialog.