### PR TITLE
fix: resolve Jira UI issues(OK-57565)

### DIFF
--- a/packages/kit/src/views/Staking/components/ProtocolDetails/PendleSharedComponents.test.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/PendleSharedComponents.test.tsx
@@ -1,0 +1,91 @@
+import { Children } from 'react';
+
+import type { ReactElement, ReactNode } from 'react';
+import { renderHook } from '@testing-library/react-native';
+
+import type {
+  IEarnTooltip,
+  IStakeTransactionConfirmation,
+} from '@onekeyhq/shared/types/staking';
+
+import { EarnTooltip } from './EarnTooltip';
+import { usePendleTransactionDetails } from './PendleSharedComponents';
+
+
+jest.mock('@onekeyhq/components', () => ({
+  Divider: 'Divider',
+  Icon: 'Icon',
+  Popover: 'Popover',
+  SizableText: 'SizableText',
+  Skeleton: 'Skeleton',
+  Stack: 'Stack',
+  XStack: 'XStack',
+  YStack: 'YStack',
+}));
+jest.mock('@onekeyhq/components/src/utils/animationConstants', () => ({
+  ANIMATE_ONLY_TRANSFORM: [],
+}));
+jest.mock('../CalculationList', () => {
+  const CalculationListItem = Object.assign(() => null, {
+    Label: () => null,
+  });
+  return { CalculationListItem };
+});
+jest.mock('./EarnActionIcon', () => ({ ActionPopupContent: () => null }));
+jest.mock('./EarnAmountText', () => ({ EarnAmountText: () => null }));
+jest.mock('./EarnSwapRoute', () => ({ EarnSwapRoute: () => null }));
+jest.mock('./EarnText', () => ({ EarnText: () => null }));
+jest.mock('./EarnTooltip', () => ({ EarnTooltip: () => null }));
+
+function getElementChildren(element: ReactElement): ReactNode[] {
+  return Children.toArray((element.props as { children?: ReactNode }).children);
+}
+
+describe('usePendleTransactionDetails', () => {
+  it('preserves structured text tooltip data for remote typography', () => {
+    const tooltip = {
+      type: 'text',
+      data: {
+        title: { text: 'About fees' },
+        description: {
+          text: 'Fee details',
+          size: '$bodyXs',
+        },
+      },
+    } satisfies IEarnTooltip;
+    const transactionConfirmation: IStakeTransactionConfirmation = {
+      transactionDetails: {
+        type: 'view',
+        data: {
+          transactionDetails: [
+            {
+              title: { text: 'Fee' },
+              description: { text: '0.12%' },
+              tooltip,
+            },
+          ],
+        },
+      },
+    };
+
+    const { result } = renderHook(() =>
+      usePendleTransactionDetails({
+        transactionConfirmation,
+        amountValue: '1',
+        isPendleLikeLayout: true,
+      }),
+    );
+
+    const labelContainer = getElementChildren(
+      result.current[0],
+    )[0] as ReactElement;
+    const tooltipElement = getElementChildren(
+      labelContainer,
+    )[1] as ReactElement<{
+      tooltip?: IEarnTooltip;
+    }>;
+
+    expect(tooltipElement.type).toBe(EarnTooltip);
+    expect(tooltipElement.props.tooltip).toBe(tooltip);
+  });
+});

--- a/packages/kit/src/views/Staking/components/ProtocolDetails/PendleSharedComponents.tsx
+++ b/packages/kit/src/views/Staking/components/ProtocolDetails/PendleSharedComponents.tsx
@@ -238,24 +238,14 @@ export function usePendleTransactionDetails({
         (routeItem) =>
           !!routeItem?.token?.symbol && !!routeItem?.token?.logoURI,
       ) ?? [];
-    const resolveTooltipText = (tooltip?: IEarnTooltip) => {
-      if (tooltip?.type !== 'text') {
-        return undefined;
-      }
-      return tooltip.data?.description?.text;
-    };
-
     detailItems.forEach((detailItem, index) => {
-      const hasRichTooltip =
-        detailItem.tooltip &&
-        (detailItem.tooltip.type !== 'text' ||
-          detailItem.tooltip.data?.items?.length);
+      const hasTooltip = Boolean(detailItem.tooltip);
       const popupButton =
         detailItem.button?.type === 'popup' ? detailItem.button : undefined;
 
       items.push(
         <CalculationListItem key={`tx-detail-${index}`}>
-          {hasRichTooltip ? (
+          {hasTooltip ? (
             <XStack gap="$1" ai="center" flex={1}>
               <SizableText
                 color={detailItem.title.color ?? '$textSubdued'}
@@ -272,7 +262,6 @@ export function usePendleTransactionDetails({
             <CalculationListItem.Label
               size={detailItem.title.size || '$bodyMd'}
               color={detailItem.title.color}
-              tooltip={resolveTooltipText(detailItem.tooltip)}
             >
               {detailItem.title.text}
             </CalculationListItem.Label>


### PR DESCRIPTION
## Summary
- Preserve structured Pendle transaction tooltips instead of flattening text tooltip payloads into strings.
- Keep remote typography fields such as description.size available to the shared Earn tooltip renderer.
- Add focused regression coverage for the structured tooltip handoff.

## Intent & Context
This is a Draft aggregation PR for selected Jira UI fixes. The initial scope fixes OK-57565, where the Pendle fee tooltip text rendered larger than other tooltips and ignored typography supplied by the transaction-confirmation payload.

## Root Cause
Pendle transaction details treated text tooltips without comparison items as plain strings. The App extracted only description.text and passed it to CalculationListItem.Label, which rendered Popover.Tooltip with a hard-coded bodyLg size. The structured IEarnTooltip payload, including description.size, was discarded before rendering.

## Design Decisions
- Route every structured Pendle transaction detail tooltip through EarnTooltip, including simple text tooltips.
- Keep CalculationListItem.Label for rows without tooltip data.
- Avoid changing the shared Popover.Tooltip default because that would affect unrelated product surfaces.
- Remove the temporary background-response mock used during diagnosis.

## Changes Detail
- Update PendleSharedComponents to preserve and render the complete tooltip DTO.
- Add a focused hook test proving the same structured tooltip object reaches EarnTooltip.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile, Desktop, Web, Extension
- **Risk Areas**: Pendle transaction-detail tooltip presentation only; trigger and popover behavior now use the existing Earn tooltip implementation.

## Test plan
- [x] Focused Jest test for structured Pendle tooltip handoff
- [x] yarn agent:check --profile commit
- [ ] Runtime verify the Pendle fee tooltip against a transaction-confirmation response containing description.size
- [ ] Add subsequent selected Jira UI fixes as separate commits while this PR remains Draft
