### PR TITLE
feat: add Overview first tab for aggregated token details (OK-57944)

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAggregateToken.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityAggregateToken.ts
@@ -221,43 +221,6 @@ export class SimpleDbEntityAggregateToken extends SimpleDbEntityBase<ISimpleDBAg
   }
 
   @backgroundMethod()
-  async updateLastActiveTabNameInTokenDetails({
-    accountId,
-    aggregateTokenId,
-    lastActiveTabName,
-  }: {
-    accountId: string;
-    aggregateTokenId: string;
-    lastActiveTabName: string;
-  }) {
-    await this.setRawData((rawData) => ({
-      ...rawData,
-      tokenDetails: {
-        ...rawData?.tokenDetails,
-        [accountId]: {
-          ...rawData?.tokenDetails?.[accountId],
-          [aggregateTokenId]: {
-            lastActiveTabName,
-          },
-        },
-      },
-    }));
-  }
-
-  @backgroundMethod()
-  async getLastActiveTabNameInTokenDetails({
-    accountId,
-    aggregateTokenId,
-  }: {
-    accountId: string;
-    aggregateTokenId: string;
-  }) {
-    return (await this.getRawData())?.tokenDetails?.[accountId]?.[
-      aggregateTokenId
-    ]?.lastActiveTabName;
-  }
-
-  @backgroundMethod()
   async clearLastActiveTabNameData() {
     await this.setRawData((rawData) => {
       return {

--- a/packages/kit-bg/src/services/ServiceToken.ts
+++ b/packages/kit-bg/src/services/ServiceToken.ts
@@ -1390,41 +1390,6 @@ class ServiceToken extends ServiceBase {
   }
 
   @backgroundMethod()
-  public async updateLastActiveTabNameInTokenDetails({
-    accountId,
-    aggregateTokenId,
-    lastActiveTabName,
-  }: {
-    accountId: string;
-    aggregateTokenId: string;
-    lastActiveTabName: string;
-  }) {
-    return this.backgroundApi.simpleDb.aggregateToken.updateLastActiveTabNameInTokenDetails(
-      {
-        accountId,
-        aggregateTokenId,
-        lastActiveTabName,
-      },
-    );
-  }
-
-  @backgroundMethod()
-  public async getLastActiveTabNameInTokenDetails({
-    accountId,
-    aggregateTokenId,
-  }: {
-    accountId: string;
-    aggregateTokenId: string;
-  }) {
-    return this.backgroundApi.simpleDb.aggregateToken.getLastActiveTabNameInTokenDetails(
-      {
-        accountId,
-        aggregateTokenId,
-      },
-    );
-  }
-
-  @backgroundMethod()
   public async clearLastActiveTabNameData() {
     return this.backgroundApi.simpleDb.aggregateToken.clearLastActiveTabNameData();
   }

--- a/packages/kit/src/states/jotai/contexts/tokenList/cells/tapTimeHomeMap.ts
+++ b/packages/kit/src/states/jotai/contexts/tokenList/cells/tapTimeHomeMap.ts
@@ -74,10 +74,16 @@ export function buildTapTimeHomeTokenMap(
       // Each owned sub-token's per-network fiat, keyed by the SUB-TOKEN `$key`
       // (the key TokenDetails rebuilds for its sort + seed). One sub-token per
       // network per aggregate, so the network -> sub-cell join is exact.
+      // Only `aggMembership` networks are emitted: the owned sub-token list is
+      // the full server config (it can include disabled networks the home never
+      // fetched), while membership is exactly the set `aggCell` sums — a stale
+      // sub-cell outside it would seed TokenDetails with a balance the home row
+      // does not count.
+      const memberNetworkIds = new Set(structure.aggMembership[id] ?? []);
       const subTokens = structure.ownedAggregateTokenListMap[id]?.tokens ?? [];
       for (const subToken of subTokens) {
         const networkId = subToken.networkId;
-        if (networkId) {
+        if (networkId && memberNetworkIds.has(networkId)) {
           const subFiat = readers.readSubCell(id, networkId);
           if (subFiat) {
             map[subToken.$key] = subFiat;

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/ActionBuy.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/ActionBuy.tsx
@@ -31,6 +31,75 @@ type IActionBuyContentProps = Omit<IActionProps, 'isTabView'> & {
   focusParam: boolean;
 };
 
+// Shared with the aggregate Overview tab, which resolves the concrete network
+// via the aggregate network selector before opening the fiat widget.
+export async function openFiatCryptoWidget({
+  type,
+  networkId,
+  tokenAddress,
+  tokenSymbol,
+  accountId,
+  walletId,
+  walletType,
+  source,
+  isSoftwareWalletOnlyUser,
+}: {
+  type: IFiatCryptoType;
+  networkId: string;
+  tokenAddress: string;
+  tokenSymbol: string;
+  accountId: string;
+  walletId: string;
+  walletType?: string;
+  source: IActionProps['source'];
+  isSoftwareWalletOnlyUser: boolean;
+}) {
+  if (
+    await backgroundApiProxy.serviceAccount.checkIsWalletNotBackedUp({
+      walletId,
+    })
+  ) {
+    return;
+  }
+
+  if (type === 'buy') {
+    defaultLogger.wallet.walletActions.buyStarted({
+      tokenAddress,
+      tokenSymbol,
+      networkID: networkId,
+    });
+    defaultLogger.wallet.walletActions.actionBuy({
+      walletType: walletType ?? '',
+      networkId: networkId ?? '',
+      source,
+      isSoftwareWalletOnlyUser,
+    });
+  } else if (type === 'sell') {
+    defaultLogger.wallet.walletActions.actionSell({
+      walletType: walletType ?? '',
+      networkId: networkId ?? '',
+      source,
+      isSoftwareWalletOnlyUser,
+    });
+  }
+
+  const { url } = await backgroundApiProxy.serviceFiatCrypto.generateWidgetUrl({
+    networkId,
+    tokenAddress,
+    accountId,
+    type,
+  });
+  if (!url) {
+    Toast.error({ title: 'Failed to get widget url' });
+    return;
+  }
+  if (platformEnv.isDesktop || platformEnv.isNative) {
+    openFiatCryptoUrl(url);
+  } else {
+    openUrlExternal(url);
+  }
+}
+
 function ActionBuyContent({
   networkId,
   tokenAddress,
@@ -98,55 +167,21 @@ function ActionBuyContent({
     async (type: IFiatCryptoType) => {
       if (loadingRef.current) return;
 
-      if (
-        await backgroundApiProxy.serviceAccount.checkIsWalletNotBackedUp({
-          walletId,
-        })
-      ) {
-        return;
-      }
-
       loadingRef.current = true;
       setLoading(true);
 
-      if (type === 'buy') {
-        defaultLogger.wallet.walletActions.buyStarted({
+      try {
+        await openFiatCryptoWidget({
+          type,
+          networkId,
           tokenAddress,
           tokenSymbol,
-          networkID: networkId,
-        });
-        defaultLogger.wallet.walletActions.actionBuy({
-          walletType: walletType ?? '',
-          networkId: networkId ?? '',
+          accountId,
+          walletId,
+          walletType,
           source,
           isSoftwareWalletOnlyUser,
         });
-      } else if (type === 'sell') {
-        defaultLogger.wallet.walletActions.actionSell({
-          walletType: walletType ?? '',
-          networkId: networkId ?? '',
-          source,
-          isSoftwareWalletOnlyUser,
-        });
-      }
-
-      try {
-        const { url } =
-          await backgroundApiProxy.serviceFiatCrypto.generateWidgetUrl({
-            networkId,
-            tokenAddress,
-            accountId,
-            type,
-          });
-        if (!url) {
-          Toast.error({ title: 'Failed to get widget url' });
-          return;
-        }
-        if (platformEnv.isDesktop || platformEnv.isNative) {
-          openFiatCryptoUrl(url);
-        } else {
-          openUrlExternal(url);
-        }
       } finally {
         loadingRef.current = false;
         setLoading(false);

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsBalanceHero.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsBalanceHero.tsx
@@ -1,0 +1,64 @@
+import { memo } from 'react';
+
+import { PROPORTIONAL_NUMS, Skeleton, YStack } from '@onekeyhq/components';
+import { Currency } from '@onekeyhq/kit/src/components/Currency';
+import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
+import {
+  displayFiatValueOrUnavailable,
+  displayOrUnavailable,
+} from '@onekeyhq/shared/src/utils/tokenValueUtils';
+
+type IProps = {
+  isLoading: boolean;
+  currency?: string;
+  fiatValue?: string;
+  balanceParsed?: string;
+};
+
+// The large fiat-value + balance block shared by the per-network header and
+// the aggregate Overview tab.
+function TokenDetailsBalanceHero({
+  isLoading,
+  currency,
+  fiatValue,
+  balanceParsed,
+}: IProps) {
+  return (
+    <YStack gap="$2" mb="$5">
+      {isLoading ? (
+        <Skeleton.Group show>
+          <Skeleton.Heading5Xl />
+          <Skeleton.BodyLg />
+        </Skeleton.Group>
+      ) : (
+        <>
+          <Currency
+            hideValue
+            splitDecimal
+            formatter="value"
+            sourceCurrency={currency}
+            fontSize={48}
+            lineHeight={48}
+            fontWeight={500}
+            // Large hero value uses natural proportional figures (matches the
+            // home total-balance hero); tabular is reserved for tables /
+            // ticking data.
+            fontVariant={PROPORTIONAL_NUMS}
+          >
+            {displayFiatValueOrUnavailable(fiatValue, balanceParsed)}
+          </Currency>
+          <NumberSizeableTextWrapper
+            hideValue
+            formatter="balance"
+            color="$textSubdued"
+            size="$bodyLg"
+          >
+            {displayOrUnavailable(balanceParsed)}
+          </NumberSizeableTextWrapper>
+        </>
+      )}
+    </YStack>
+  );
+}
+
+export default memo(TokenDetailsBalanceHero);

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsDeFiBlock.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsDeFiBlock.tsx
@@ -76,7 +76,16 @@ export function TokenDetailsDeFiBlock({
   const requestIdRef = useRef(generateUUID());
   const isUnmountedRef = useRef(false);
 
-  const cacheKey = `${networkId}_${tokenAddress}`;
+  // Aggregate mode resolves against the member set, and different wallets can
+  // aggregate different member networks under the same mock networkId/$key —
+  // fingerprint the members so each set gets its own cache entry.
+  const memberFingerprint = aggregateTokens?.length
+    ? aggregateTokens
+        .map((member) => `${member.networkId}:${member.address}`)
+        .toSorted()
+        .join(',')
+    : '';
+  const cacheKey = `${networkId}_${tokenAddress}_${memberFingerprint}`;
   // Aggregate mode shows protocols across all member networks (no filter).
   const protocolFilterNetworkId = aggregateTokens?.length
     ? undefined

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsDeFiBlock.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsDeFiBlock.tsx
@@ -27,6 +27,11 @@ interface ITokenDetailsDeFiBlockProps {
   tokenAddress: string;
   walletType?: string;
   tokenLogoURI?: string;
+  // Aggregate-token mode: member (networkId, address) pairs. When set, the
+  // symbol lookup walks the members and the protocol list is NOT filtered by
+  // network, so the banner shows the highest APY across all networks and taps
+  // into the cross-network protocol list.
+  aggregateTokens?: { networkId: string; address: string }[];
 }
 
 type ITokenDetailsDeFiBlockResult = {
@@ -63,6 +68,7 @@ export function TokenDetailsDeFiBlock({
   tokenAddress,
   walletType,
   tokenLogoURI,
+  aggregateTokens,
 }: ITokenDetailsDeFiBlockProps) {
   const intl = useIntl();
   const navigation = useAppNavigation();
@@ -71,6 +77,10 @@ export function TokenDetailsDeFiBlock({
   const isUnmountedRef = useRef(false);
 
   const cacheKey = `${networkId}_${tokenAddress}`;
+  // Aggregate mode shows protocols across all member networks (no filter).
+  const protocolFilterNetworkId = aggregateTokens?.length
+    ? undefined
+    : networkId;
   // `undefined` means cache miss; `null` means cached "no DeFi banner".
   // The cache wraps values in `{ result }` so we can distinguish the two cases.
   const cachedEntry = useMemo(() => earnResultCache.get(cacheKey), [cacheKey]);
@@ -83,11 +93,20 @@ export function TokenDetailsDeFiBlock({
         return cachedResult;
       }
 
-      const symbolInfo =
-        await backgroundApiProxy.serviceStaking.findSymbolByTokenAddress({
-          networkId,
-          tokenAddress,
-        });
+      // Aggregate mode resolves the symbol across the member networks; single
+      // mode is just a one-element member list.
+      const lookupTargets = aggregateTokens?.length
+        ? aggregateTokens
+        : [{ networkId, address: tokenAddress }];
+      const symbolInfos = await Promise.all(
+        lookupTargets.map((target) =>
+          backgroundApiProxy.serviceStaking.findSymbolByTokenAddress({
+            networkId: target.networkId,
+            tokenAddress: target.address,
+          }),
+        ),
+      );
+      const symbolInfo = symbolInfos.find(Boolean) ?? null;
       if (isUnmountedRef.current) {
         return undefined;
       }
@@ -99,7 +118,7 @@ export function TokenDetailsDeFiBlock({
       try {
         protocolList = await backgroundApiProxy.serviceStaking.getProtocolList({
           symbol: symbolInfo.symbol,
-          filterNetworkId: networkId,
+          filterNetworkId: protocolFilterNetworkId,
           includeWithdrawOnly: true,
           requestId: requestIdRef.current,
         });
@@ -132,7 +151,15 @@ export function TokenDetailsDeFiBlock({
       earnResultCache.set(cacheKey, { result: data });
       return data;
     },
-    [networkId, tokenAddress, cacheKey, hasCachedResult, cachedResult],
+    [
+      networkId,
+      tokenAddress,
+      cacheKey,
+      hasCachedResult,
+      cachedResult,
+      aggregateTokens,
+      protocolFilterNetworkId,
+    ],
     {
       watchLoading: true,
       ...(hasCachedResult ? { initResult: cachedResult } : {}),
@@ -195,7 +222,10 @@ export function TokenDetailsDeFiBlock({
     if (protocolList.length === 1) {
       const protocol = protocolList[0];
       await EarnNavigation.pushToEarnProtocolDetails(navigation, {
-        networkId,
+        // In aggregate mode `networkId` is the mock aggregate id; the
+        // protocol's own network is the routable one (they are equal in the
+        // single-network mode because the list is network-filtered there).
+        networkId: protocol.network?.networkId ?? networkId,
         symbol,
         provider: protocol.provider.name,
         vault: protocol.provider.vault,
@@ -203,7 +233,7 @@ export function TokenDetailsDeFiBlock({
     } else {
       EarnNavigation.pushToEarnProtocols(navigation, {
         symbol,
-        filterNetworkId: networkId,
+        filterNetworkId: protocolFilterNetworkId,
         logoURI: tokenLogoURI ? encodeURIComponent(tokenLogoURI) : undefined,
       });
     }
@@ -215,6 +245,7 @@ export function TokenDetailsDeFiBlock({
     isSoftwareWalletOnlyUser,
     navigation,
     tokenLogoURI,
+    protocolFilterNetworkId,
   ]);
 
   // Show skeleton only on first load (no cache). Cache also stores null for

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
@@ -9,20 +9,17 @@ import {
   DebugRenderTracker,
   Divider,
   Icon,
-  PROPORTIONAL_NUMS,
   SizableText,
-  Skeleton,
   Stack,
   XStack,
   YStack,
   useTabIsRefreshingFocused,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { Currency } from '@onekeyhq/kit/src/components/Currency';
-import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
 import { ReviewControl } from '@onekeyhq/kit/src/components/ReviewControl';
 import { useAccountData } from '@onekeyhq/kit/src/hooks/useAccountData';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import type { IAppNavigation } from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWalletDeactivatedStatus';
 import { useCopyAccountAddress } from '@onekeyhq/kit/src/hooks/useCopyAccountAddress';
 import { useDisplayAccountAddress } from '@onekeyhq/kit/src/hooks/useDisplayAccountAddress';
@@ -36,6 +33,7 @@ import {
 } from '@onekeyhq/kit/src/utils/botWalletStatusUtils';
 import { RawActions } from '@onekeyhq/kit/src/views/Home/components/WalletActions/RawActions';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 import {
   WALLET_TYPE_HD,
   WALLET_TYPE_WATCHING,
@@ -53,10 +51,6 @@ import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import cacheUtils from '@onekeyhq/shared/src/utils/cacheUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
-import {
-  displayFiatValueOrUnavailable,
-  displayOrUnavailable,
-} from '@onekeyhq/shared/src/utils/tokenValueUtils';
 import { getSwapBridgeDefaultToToken } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import {
   ESwapSource,
@@ -71,6 +65,7 @@ import type {
 import { AssetDetailsTestIDs } from '../../testIDs';
 
 import ActionBuy from './ActionBuy';
+import TokenDetailsBalanceHero from './TokenDetailsBalanceHero';
 import { useTokenDetailsContext } from './TokenDetailsContext';
 import { TokenDetailsDeFiBlock } from './TokenDetailsDeFiBlock';
 
@@ -82,6 +77,75 @@ const tokenDetailsCache = new cacheUtils.LRUCache<
   ttl: timerUtils.getTimeDurationMs({ minute: 10 }),
   ttlAutopurge: true,
 });
+
+// Shared with the aggregate Overview tab, which resolves the concrete member
+// network / derive type before delegating here.
+export async function pushSwapFromTokenDetails({
+  navigation,
+  token,
+  networkId,
+  networkLogoURI,
+  deriveType,
+  walletType,
+  isSoftwareWalletOnlyUser,
+}: {
+  navigation: IAppNavigation;
+  token: {
+    address: string;
+    symbol: string;
+    isNative?: boolean;
+    decimals: number;
+    name?: string;
+    logoURI?: string;
+  };
+  networkId: string;
+  networkLogoURI?: string;
+  deriveType?: IAccountDeriveTypes;
+  walletType?: string;
+  isSoftwareWalletOnlyUser: boolean;
+}) {
+  const importFromToken: ISwapToken = {
+    contractAddress: token.address,
+    symbol: token.symbol,
+    networkId,
+    isNative: token.isNative,
+    decimals: token.decimals,
+    name: token.name,
+    logoURI: token.logoURI,
+    networkLogoURI,
+  };
+  let importToToken: ISwapToken | undefined;
+  try {
+    const { isSupportSwap, isSupportCrossChain } =
+      await backgroundApiProxy.serviceSwap.checkSupportSwap({
+        networkId,
+      });
+    if (!isSupportSwap && isSupportCrossChain) {
+      importToToken = getSwapBridgeDefaultToToken(importFromToken);
+    }
+  } catch {
+    // Keep the existing Swap fallback if capability refresh fails.
+  }
+
+  defaultLogger.wallet.walletActions.actionTrade({
+    walletType: walletType ?? '',
+    networkId,
+    source: 'tokenDetails',
+    tradeType: ESwapTabSwitchType.SWAP,
+    isSoftwareWalletOnlyUser,
+  });
+  navigation.pushModal(EModalRoutes.SwapModal, {
+    screen: EModalSwapRoutes.SwapMainLand,
+    params: {
+      importNetworkId: networkId,
+      importFromToken,
+      importToToken,
+      importDeriveType: deriveType,
+      swapTabSwitchType: ESwapTabSwitchType.SWAP,
+      swapSource: ESwapSource.TOKEN_DETAIL,
+    },
+  });
+}
 
 type ITokenDetailsAddressBlockProps = {
   shouldShow: boolean;
@@ -267,7 +331,7 @@ function TokenDetailsHeaderContent({
         const data = tokensDetails?.[0];
 
         // Chart price-line surface cannot render '--'; coerce to 0. Header
-        // price/balance render '--' via displayOrUnavailable below.
+        // price/balance render '--' via TokenDetailsBalanceHero below.
         updateTokenMetadata({
           price: data?.price ?? 0,
           priceChange24h: data?.price24h ?? 0,
@@ -340,56 +404,26 @@ function TokenDetailsHeaderContent({
 
   const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
 
-  const createSwapActionHandler = useCallback(
-    () => async () => {
-      const importFromToken: ISwapToken = {
-        contractAddress: tokenInfo.address,
-        symbol: tokenInfo.symbol,
-        networkId,
-        isNative: tokenInfo.isNative,
-        decimals: tokenInfo.decimals,
-        name: tokenInfo.name,
-        logoURI: tokenInfo.logoURI,
-        networkLogoURI: network?.logoURI,
-      };
-      let importToToken: ISwapToken | undefined;
-      try {
-        const { isSupportSwap, isSupportCrossChain } =
-          await backgroundApiProxy.serviceSwap.checkSupportSwap({
-            networkId,
-          });
-        if (!isSupportSwap && isSupportCrossChain) {
-          importToToken = getSwapBridgeDefaultToToken(importFromToken);
-        }
-      } catch {
-        // Keep the existing Swap fallback if capability refresh fails.
-      }
-      const swapTabSwitchType = ESwapTabSwitchType.SWAP;
-
-      defaultLogger.wallet.walletActions.actionTrade({
-        walletType: wallet?.type ?? '',
-        networkId: network?.id ?? '',
-        source: 'tokenDetails',
-        tradeType: swapTabSwitchType,
-        isSoftwareWalletOnlyUser,
-      });
-      navigation.pushModal(EModalRoutes.SwapModal, {
-        screen: EModalSwapRoutes.SwapMainLand,
-        params: {
-          importNetworkId: networkId,
-          importFromToken,
-          importToToken,
-          importDeriveType: deriveType,
-          ...(swapTabSwitchType && {
-            swapTabSwitchType,
-          }),
-          swapSource: ESwapSource.TOKEN_DETAIL,
+  const handleOnSwap = useCallback(
+    () =>
+      pushSwapFromTokenDetails({
+        navigation,
+        token: {
+          address: tokenInfo.address,
+          symbol: tokenInfo.symbol,
+          isNative: tokenInfo.isNative,
+          decimals: tokenInfo.decimals,
+          name: tokenInfo.name,
+          logoURI: tokenInfo.logoURI,
         },
-      });
-    },
+        networkId,
+        networkLogoURI: network?.logoURI,
+        deriveType,
+        walletType: wallet?.type,
+        isSoftwareWalletOnlyUser,
+      }),
     [
       wallet?.type,
-      network?.id,
       network?.logoURI,
       navigation,
       networkId,
@@ -403,8 +437,6 @@ function TokenDetailsHeaderContent({
       isSoftwareWalletOnlyUser,
     ],
   );
-
-  const handleOnSwap = createSwapActionHandler();
 
   const disableSwapAction = useMemo(
     () => accountUtils.isUrlAccountFn({ accountId }),
@@ -527,43 +559,12 @@ function TokenDetailsHeaderContent({
         {/* Overview */}
         <Stack px="$5" py="$5">
           {/* Balance */}
-          <YStack gap="$2" mb="$5">
-            {showLoadingState ? (
-              <Skeleton.Group show>
-                <Skeleton.Heading5Xl />
-                <Skeleton.BodyLg />
-              </Skeleton.Group>
-            ) : (
-              <>
-                <Currency
-                  hideValue
-                  splitDecimal
-                  formatter="value"
-                  sourceCurrency={tokenDetails?.currency}
-                  fontSize={48}
-                  lineHeight={48}
-                  fontWeight={500}
-                  // Large hero value uses natural proportional figures (matches
-                  // the home total-balance hero); tabular is reserved for
-                  // tables / ticking data.
-                  fontVariant={PROPORTIONAL_NUMS}
-                >
-                  {displayFiatValueOrUnavailable(
-                    tokenDetails?.fiatValue,
-                    tokenDetails?.balanceParsed,
-                  )}
-                </Currency>
-                <NumberSizeableTextWrapper
-                  hideValue
-                  formatter="balance"
-                  color="$textSubdued"
-                  size="$bodyLg"
-                >
-                  {displayOrUnavailable(tokenDetails?.balanceParsed)}
-                </NumberSizeableTextWrapper>
-              </>
-            )}
-          </YStack>
+          <TokenDetailsBalanceHero
+            isLoading={showLoadingState}
+            currency={tokenDetails?.currency}
+            fiatValue={tokenDetails?.fiatValue}
+            balanceParsed={tokenDetails?.balanceParsed}
+          />
           {/* Actions */}
           <RawActions>
             <RawActions.Send

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsOverview.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsOverview.tsx
@@ -1,0 +1,546 @@
+import { memo, useCallback, useMemo, useRef } from 'react';
+
+import BigNumber from 'bignumber.js';
+import { useIntl } from 'react-intl';
+
+import {
+  Alert,
+  Icon,
+  SizableText,
+  Stack,
+  Tabs,
+  Tooltip,
+  YStack,
+} from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { Currency } from '@onekeyhq/kit/src/components/Currency';
+import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import { NetworkAvatar } from '@onekeyhq/kit/src/components/NetworkAvatar';
+import NumberSizeableTextWrapper from '@onekeyhq/kit/src/components/NumberSizeableTextWrapper';
+import { ReviewControl } from '@onekeyhq/kit/src/components/ReviewControl';
+import { useAccountData } from '@onekeyhq/kit/src/hooks/useAccountData';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { useBotWalletDeactivatedStatus } from '@onekeyhq/kit/src/hooks/useBotWalletDeactivatedStatus';
+import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { useUserWalletProfile } from '@onekeyhq/kit/src/hooks/useUserWalletProfile';
+import { showBotWalletDisabledToast } from '@onekeyhq/kit/src/utils/botWalletDisabledToast';
+import { shouldBlockBotWalletReceive } from '@onekeyhq/kit/src/utils/botWalletStatusUtils';
+import { formatPortfolioPercent } from '@onekeyhq/kit/src/views/Home/components/DeFiListBlock/formatPortfolioPercent';
+import { RawActions } from '@onekeyhq/kit/src/views/Home/components/WalletActions/RawActions';
+import { WALLET_TYPE_WATCHING } from '@onekeyhq/shared/src/consts/dbConsts';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import {
+  EAssetSelectorRoutes,
+  EModalReceiveRoutes,
+  EModalRoutes,
+  EModalSignatureConfirmRoutes,
+} from '@onekeyhq/shared/src/routes';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
+import {
+  displayFiatValueOrUnavailable,
+  displayOrUnavailable,
+  isValidNumberValue,
+} from '@onekeyhq/shared/src/utils/tokenValueUtils';
+import type { IAccountToken, ITokenFiat } from '@onekeyhq/shared/types/token';
+
+import { openFiatCryptoWidget } from './ActionBuy';
+import TokenDetailsBalanceHero from './TokenDetailsBalanceHero';
+import { useTokenDetailsContext } from './TokenDetailsContext';
+import { TokenDetailsDeFiBlock } from './TokenDetailsDeFiBlock';
+import { pushSwapFromTokenDetails } from './TokenDetailsHeader';
+import { useAggregateTokenDetails } from './useAggregateTokenDetails';
+
+type IProps = {
+  accountId: string;
+  networkId: string;
+  walletId: string;
+  indexedAccountId?: string;
+  tokenInfo: IAccountToken;
+  tokens: IAccountToken[];
+  tokenMap?: Record<string, ITokenFiat>;
+  isAllNetworks?: boolean;
+  onSelectToken: (token: IAccountToken) => void;
+};
+
+function TokenDetailsOverview(props: IProps) {
+  const {
+    accountId,
+    walletId,
+    indexedAccountId,
+    tokenInfo,
+    tokens,
+    tokenMap,
+    isAllNetworks,
+    onSelectToken,
+  } = props;
+
+  const intl = useIntl();
+  const navigation = useAppNavigation();
+  const { wallet } = useAccountData({ accountId, walletId });
+  const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
+  const { updateTokenDetails } = useTokenDetailsContext();
+
+  const {
+    rows,
+    totalFiatValueBN,
+    totalFiatValue,
+    totalBalanceParsed,
+    currency,
+    hasBalanceData,
+  } = useAggregateTokenDetails({ tokens, tokenMap });
+
+  const isWatchOnly = wallet?.type === WALLET_TYPE_WATCHING;
+
+  const { isBotWallet, isBotWalletDeactivated } = useBotWalletDeactivatedStatus(
+    {
+      walletId,
+    },
+  );
+  const isBotWalletReceiveBlocked = shouldBlockBotWalletReceive({
+    isBotWallet,
+    isBotWalletDeactivated,
+  });
+
+  // Entry points other than the wallet home (e.g. universal search) do not
+  // carry the full home fiat snapshot, and member tabs only fetch on focus —
+  // which never happens while the user stays on Overview. Backfill the members
+  // that have an address but no data yet; the fetched-keys set keeps re-runs
+  // (rows change on every context update) from refetching.
+  const backfilledKeysRef = useRef(new Set<string>());
+  const { isLoading: isBackfillingDetails } = usePromiseResult(
+    async () => {
+      const missingRows = rows.filter(
+        (row) =>
+          !row.tokenDetail &&
+          row.token.accountId &&
+          row.token.networkId &&
+          !backfilledKeysRef.current.has(row.token.$key),
+      );
+      if (!missingRows.length) {
+        return;
+      }
+      missingRows.forEach((row) =>
+        backfilledKeysRef.current.add(row.token.$key),
+      );
+      await Promise.all(
+        missingRows.map(async ({ token }) => {
+          try {
+            const resp =
+              await backgroundApiProxy.serviceToken.fetchTokensDetails({
+                accountId: token.accountId ?? '',
+                networkId: token.networkId ?? '',
+                contractList: [token.address],
+              });
+            const data = resp?.[0];
+            if (data) {
+              updateTokenDetails({
+                accountId: token.accountId ?? '',
+                networkId: token.networkId ?? '',
+                isInit: true,
+                data,
+              });
+            }
+          } catch {
+            // Tolerated: the row keeps its unavailable placeholder.
+          }
+        }),
+      );
+    },
+    [rows, updateTokenDetails],
+    {
+      watchLoading: true,
+    },
+  );
+
+  const showLoadingState = !hasBalanceData && (isBackfillingDetails ?? true);
+
+  const earnMembers = useMemo(
+    () =>
+      tokens
+        .map((token) => ({
+          networkId: token.networkId ?? '',
+          address: token.address ?? '',
+        }))
+        .filter((member) => member.networkId),
+    [tokens],
+  );
+
+  const handleSendPress = useCallback(() => {
+    navigation.pushModal(EModalRoutes.SignatureConfirmModal, {
+      screen: EModalSignatureConfirmRoutes.TxSelectAggregateToken,
+      params: {
+        accountId,
+        indexedAccountId,
+        aggregateToken: tokenInfo,
+        aggregateSubTokenList: tokens,
+        hideZeroBalanceTokens: true,
+        enableNetworkAfterSelect: true,
+        closeAfterSelect: false,
+        onSelect: async (token: IAccountToken) => {
+          defaultLogger.wallet.walletActions.actionSend({
+            walletType: wallet?.type ?? '',
+            networkId: token.networkId ?? '',
+            source: 'tokenDetails',
+            isSoftwareWalletOnlyUser,
+          });
+
+          const settings =
+            await backgroundApiProxy.serviceNetwork.getVaultSettings({
+              networkId: token.networkId ?? '',
+            });
+
+          let sendAccountId = token.accountId ?? '';
+          if (
+            settings.mergeDeriveAssetsEnabled &&
+            isAllNetworks &&
+            !accountUtils.isOthersWallet({ walletId })
+          ) {
+            const defaultDeriveType =
+              await backgroundApiProxy.serviceNetwork.getGlobalDeriveTypeOfNetwork(
+                {
+                  networkId: token.networkId ?? '',
+                },
+              );
+            const { accounts } =
+              await backgroundApiProxy.serviceAccount.getAccountsByIndexedAccounts(
+                {
+                  indexedAccountIds: [indexedAccountId ?? ''],
+                  networkId: token.networkId ?? '',
+                  deriveType: defaultDeriveType,
+                },
+              );
+            sendAccountId = accounts?.[0]?.id ?? sendAccountId;
+          }
+
+          navigation.push(EModalSignatureConfirmRoutes.TxDataInput, {
+            accountId: sendAccountId,
+            networkId: token.networkId ?? '',
+            isNFT: false,
+            token,
+            isAllNetworks,
+          });
+        },
+      },
+    });
+  }, [
+    navigation,
+    accountId,
+    indexedAccountId,
+    tokenInfo,
+    tokens,
+    wallet?.type,
+    isSoftwareWalletOnlyUser,
+    isAllNetworks,
+    walletId,
+  ]);
+
+  const handleReceivePress = useCallback(async () => {
+    if (isBotWalletReceiveBlocked) {
+      showBotWalletDisabledToast('receive');
+      return;
+    }
+    if (
+      await backgroundApiProxy.serviceAccount.checkIsWalletNotBackedUp({
+        walletId: wallet?.id ?? '',
+      })
+    ) {
+      return;
+    }
+    defaultLogger.wallet.walletActions.actionReceive({
+      walletType: wallet?.type ?? '',
+      networkId: tokenInfo.networkId ?? '',
+      source: 'tokenDetails',
+      isSoftwareWalletOnlyUser,
+    });
+    navigation.pushModal(EModalRoutes.ReceiveModal, {
+      screen: EModalReceiveRoutes.ReceiveSelectAggregateToken,
+      params: {
+        accountId,
+        indexedAccountId,
+        aggregateToken: tokenInfo,
+        aggregateSubTokenList: tokens,
+        enableNetworkAfterSelect: true,
+        closeAfterSelect: false,
+        onSelect: async (token: IAccountToken) => {
+          if (networkUtils.isLightningNetworkByNetworkId(token.networkId)) {
+            navigation.push(EModalReceiveRoutes.CreateInvoice, {
+              networkId: token.networkId ?? '',
+              accountId: token.accountId ?? '',
+            });
+            return;
+          }
+
+          const settings =
+            await backgroundApiProxy.serviceNetwork.getVaultSettings({
+              networkId: token.networkId ?? '',
+            });
+
+          // Merge-derive networks route through the derive-type selector,
+          // which requires an empty accountId.
+          const useDeriveSelector =
+            settings.mergeDeriveAssetsEnabled &&
+            isAllNetworks &&
+            !accountUtils.isOthersWallet({ walletId });
+
+          navigation.push(EModalReceiveRoutes.ReceiveToken, {
+            networkId: token.networkId ?? '',
+            accountId: useDeriveSelector ? '' : (token.accountId ?? ''),
+            walletId,
+            token,
+            indexedAccountId,
+          });
+        },
+      },
+    });
+  }, [
+    isBotWalletReceiveBlocked,
+    wallet?.id,
+    wallet?.type,
+    isSoftwareWalletOnlyUser,
+    navigation,
+    accountId,
+    indexedAccountId,
+    tokenInfo,
+    tokens,
+    isAllNetworks,
+    walletId,
+  ]);
+
+  const handleSwapPress = useCallback(async () => {
+    // Rows are sorted by fiat value, so the first member is the one the user
+    // most plausibly wants to trade; the swap page allows changing it.
+    const member = rows[0]?.token ?? tokens[0];
+    if (!member?.networkId) {
+      return;
+    }
+    const [memberNetwork, memberDeriveType] = await Promise.all([
+      backgroundApiProxy.serviceNetwork.getNetworkSafe({
+        networkId: member.networkId,
+      }),
+      backgroundApiProxy.serviceNetwork.getGlobalDeriveTypeOfNetwork({
+        networkId: member.networkId,
+      }),
+    ]);
+    await pushSwapFromTokenDetails({
+      navigation,
+      token: {
+        address: member.address,
+        symbol: member.symbol,
+        isNative: member.isNative,
+        decimals: member.decimals,
+        name: member.name,
+        logoURI: member.logoURI ?? tokenInfo.logoURI,
+      },
+      networkId: member.networkId,
+      networkLogoURI: memberNetwork?.logoURI,
+      deriveType: memberDeriveType,
+      walletType: wallet?.type,
+      isSoftwareWalletOnlyUser,
+    });
+  }, [
+    rows,
+    tokens,
+    tokenInfo.logoURI,
+    wallet?.type,
+    isSoftwareWalletOnlyUser,
+    navigation,
+  ]);
+
+  const disableSwapAction = useMemo(
+    () => accountUtils.isUrlAccountFn({ accountId }),
+    [accountId],
+  );
+
+  const disableBuyAction = isWatchOnly && !platformEnv.isDev;
+
+  const handleBuyPress = useCallback(() => {
+    navigation.pushModal(EModalRoutes.AssetSelectorModal, {
+      screen: EAssetSelectorRoutes.AggregateTokenSelector,
+      params: {
+        accountId,
+        indexedAccountId,
+        aggregateToken: tokenInfo,
+        aggregateSubTokenList: tokens,
+        enableNetworkAfterSelect: true,
+        closeAfterSelect: false,
+        onSelect: async (token: IAccountToken) => {
+          await openFiatCryptoWidget({
+            type: 'buy',
+            networkId: token.networkId ?? '',
+            tokenAddress: token.address,
+            tokenSymbol: token.symbol,
+            accountId: token.accountId ?? '',
+            walletId,
+            walletType: wallet?.type,
+            source: 'tokenDetails',
+            isSoftwareWalletOnlyUser,
+          });
+        },
+      },
+    });
+  }, [
+    navigation,
+    accountId,
+    indexedAccountId,
+    tokenInfo,
+    tokens,
+    walletId,
+    wallet?.type,
+    isSoftwareWalletOnlyUser,
+  ]);
+
+  const renderPercent = useCallback(
+    (tokenDetail?: { fiatValue?: string }) => {
+      if (
+        !tokenDetail ||
+        !totalFiatValueBN ||
+        totalFiatValueBN.lte(0) ||
+        !isValidNumberValue(tokenDetail.fiatValue)
+      ) {
+        return null;
+      }
+      const percent = new BigNumber(tokenDetail.fiatValue)
+        .div(totalFiatValueBN)
+        .times(100);
+      if (percent.isNaN() || percent.lt(0)) {
+        return null;
+      }
+      return formatPortfolioPercent(
+        percent.decimalPlaces(1).toNumber(),
+        tokenDetail.fiatValue,
+      );
+    },
+    [totalFiatValueBN],
+  );
+
+  return (
+    <Tabs.ScrollView showsVerticalScrollIndicator={false}>
+      {isWatchOnly ? (
+        <Stack pt="$5" px="$5">
+          <Alert
+            type="warning"
+            icon="ErrorOutline"
+            title={intl.formatMessage({
+              id: ETranslations.watch_only_alert_do_not_send,
+            })}
+          />
+        </Stack>
+      ) : null}
+      <Stack px="$5" py="$5">
+        {/* Aggregate balance */}
+        <TokenDetailsBalanceHero
+          isLoading={showLoadingState}
+          currency={currency}
+          fiatValue={totalFiatValue}
+          balanceParsed={totalBalanceParsed}
+        />
+        {/* Actions */}
+        <RawActions>
+          <RawActions.Send
+            onPress={handleSendPress}
+            trackID="wallet-token-details-overview-send"
+          />
+          <RawActions.Receive
+            disabled={isWatchOnly || isBotWalletReceiveBlocked}
+            allowPressWhenDisabled={isBotWalletReceiveBlocked}
+            onPress={handleReceivePress}
+            trackID="wallet-token-details-overview-receive"
+          />
+          <RawActions.Swap
+            onPress={handleSwapPress}
+            disabled={disableSwapAction}
+            trackID="wallet-token-details-overview-swap"
+          />
+          <ReviewControl>
+            <RawActions.Buy
+              label={intl.formatMessage({ id: ETranslations.global_buy })}
+              disabled={disableBuyAction}
+              onPress={handleBuyPress}
+              trackID="wallet-token-details-overview-buy"
+            />
+          </ReviewControl>
+        </RawActions>
+      </Stack>
+      {/* Earn entry across all member networks */}
+      <TokenDetailsDeFiBlock
+        networkId={tokenInfo.networkId ?? ''}
+        tokenAddress={tokenInfo.$key}
+        walletType={wallet?.type}
+        tokenLogoURI={tokenInfo.logoURI}
+        aggregateTokens={earnMembers}
+      />
+      {/* Allocation */}
+      <YStack pb="$5">
+        <SizableText px="$5" pb="$1" size="$headingSm" color="$textSubdued">
+          {intl.formatMessage({ id: ETranslations.defi_allocation })}
+        </SizableText>
+        {rows.map(({ token, tokenDetail }) => {
+          const percentText = renderPercent(tokenDetail);
+          return (
+            <ListItem
+              key={token.$key}
+              userSelect="none"
+              onPress={() => onSelectToken(token)}
+            >
+              <NetworkAvatar networkId={token.networkId} size="$8" />
+              <ListItem.Text
+                flex={1}
+                primary={token.networkName || token.networkId}
+                secondary={percentText ?? undefined}
+              />
+              {tokenDetail ? (
+                <ListItem.Text
+                  align="right"
+                  primary={
+                    <NumberSizeableTextWrapper
+                      hideValue
+                      formatter="balance"
+                      size="$bodyLgMedium"
+                      textAlign="right"
+                    >
+                      {displayOrUnavailable(tokenDetail.balanceParsed)}
+                    </NumberSizeableTextWrapper>
+                  }
+                  secondary={
+                    <Currency
+                      hideValue
+                      size="$bodyMd"
+                      color="$textSubdued"
+                      formatter="value"
+                      sourceCurrency={tokenDetail.currency}
+                      textAlign="right"
+                    >
+                      {displayFiatValueOrUnavailable(
+                        tokenDetail.fiatValue,
+                        tokenDetail.balanceParsed,
+                      )}
+                    </Currency>
+                  }
+                />
+              ) : (
+                <Tooltip
+                  renderTrigger={
+                    <Icon
+                      name="RefreshCcwOutline"
+                      size="$4"
+                      color="$iconSubdued"
+                    />
+                  }
+                  renderContent={intl.formatMessage({
+                    id: ETranslations.network_enable_or_create_address,
+                  })}
+                />
+              )}
+              <Icon name="ChevronRightSmallOutline" color="$iconSubdued" />
+            </ListItem>
+          );
+        })}
+      </YStack>
+    </Tabs.ScrollView>
+  );
+}
+
+export default memo(TokenDetailsOverview);

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsOverview.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsOverview.tsx
@@ -9,6 +9,7 @@ import {
   SizableText,
   Stack,
   Tabs,
+  Toast,
   Tooltip,
   YStack,
 } from '@onekeyhq/components';
@@ -164,9 +165,15 @@ function TokenDetailsOverview(props: IProps) {
                 isInit: true,
                 data,
               });
+            } else {
+              // No data came back — unmark so a later run can retry instead of
+              // leaving the row on its placeholder forever (member tabs only
+              // fetch on focus, which never happens while staying on Overview).
+              backfilledKeysRef.current.delete(token.$key);
             }
           } catch {
-            // Tolerated: the row keeps its unavailable placeholder.
+            // Transient failure — same retry rationale as the empty response.
+            backfilledKeysRef.current.delete(token.$key);
           }
         }),
       );
@@ -389,6 +396,26 @@ function TokenDetailsOverview(props: IProps) {
         enableNetworkAfterSelect: true,
         closeAfterSelect: false,
         onSelect: async (token: IAccountToken) => {
+          // The chain-tab Buy button disables itself via this same check; the
+          // selector cannot know support upfront, so gate after selection
+          // instead of letting the widget request fail with a generic error.
+          const isBuySupported =
+            await backgroundApiProxy.serviceFiatCrypto.isTokenSupported({
+              networkId: token.networkId ?? '',
+              tokenAddress: token.address,
+              type: 'buy',
+            });
+          if (!isBuySupported) {
+            Toast.error({
+              title: intl.formatMessage(
+                {
+                  id: ETranslations.wallet_history_settings_hide_risk_transaction_desc_unsupported,
+                },
+                { networkName: token.networkName || token.symbol },
+              ),
+            });
+            return;
+          }
           await openFiatCryptoWidget({
             type: 'buy',
             networkId: token.networkId ?? '',
@@ -409,6 +436,7 @@ function TokenDetailsOverview(props: IProps) {
     indexedAccountId,
     tokenInfo,
     tokens,
+    intl,
     walletId,
     wallet?.type,
     isSoftwareWalletOnlyUser,

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsOverview.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsOverview.tsx
@@ -38,7 +38,9 @@ import {
   EModalSignatureConfirmRoutes,
 } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
-import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
+import networkUtils, {
+  isEnabledNetworksInAllNetworks,
+} from '@onekeyhq/shared/src/utils/networkUtils';
 import {
   displayFiatValueOrUnavailable,
   displayOrUnavailable,
@@ -122,11 +124,31 @@ function TokenDetailsOverview(props: IProps) {
       if (!missingRows.length) {
         return;
       }
-      missingRows.forEach((row) =>
+      // The home aggregate row only sums members on enabled networks, so
+      // fetching a disabled member here would push the Overview total above
+      // the home figure. Those members keep their "enable network" placeholder
+      // row and stay unmarked so a later enable can still fill them in.
+      let fetchableRows = missingRows;
+      if (isAllNetworks) {
+        const allNetworksState =
+          await backgroundApiProxy.serviceAllNetwork.getAllNetworksState();
+        fetchableRows = missingRows.filter(({ token }) =>
+          isEnabledNetworksInAllNetworks({
+            networkId: token.networkId ?? '',
+            disabledNetworks: allNetworksState.disabledNetworks,
+            enabledNetworks: allNetworksState.enabledNetworks,
+            isTestnet: false,
+          }),
+        );
+      }
+      if (!fetchableRows.length) {
+        return;
+      }
+      fetchableRows.forEach((row) =>
         backfilledKeysRef.current.add(row.token.$key),
       );
       await Promise.all(
-        missingRows.map(async ({ token }) => {
+        fetchableRows.map(async ({ token }) => {
           try {
             const resp =
               await backgroundApiProxy.serviceToken.fetchTokensDetails({
@@ -149,7 +171,7 @@ function TokenDetailsOverview(props: IProps) {
         }),
       );
     },
-    [rows, updateTokenDetails],
+    [rows, isAllNetworks, updateTokenDetails],
     {
       watchLoading: true,
     },

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsTabToolbar.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsTabToolbar.tsx
@@ -1,6 +1,5 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback } from 'react';
 
-import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
 import {
@@ -19,11 +18,10 @@ import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { NetworkAvatar } from '@onekeyhq/kit/src/components/NetworkAvatar';
 import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { sortTokensByOrder } from '@onekeyhq/shared/src/utils/tokenUtils';
 import { displayFiatValueOrUnavailable } from '@onekeyhq/shared/src/utils/tokenValueUtils';
 import type { IAccountToken } from '@onekeyhq/shared/types/token';
 
-import { useTokenDetailsContext } from './TokenDetailsContext';
+import { useAggregateTokenDetails } from './useAggregateTokenDetails';
 
 type IProps = {
   tokens: IAccountToken[];
@@ -35,83 +33,8 @@ function TokenDetailsTabToolbar(props: IProps) {
   const { tokens, onSelected } = props;
   const themeVariant = useThemeVariant();
   const intl = useIntl();
-  const { tokenDetails, tokenAccountMap } = useTokenDetailsContext();
 
-  const sortedTokensByFiatValue = useMemo(() => {
-    let sortedTokens = tokens?.toSorted((a, b) => {
-      const aKey = `${
-        a.accountId ||
-        tokenAccountMap[`${a.networkId || ''}_${a.address}`] ||
-        ''
-      }_${a.networkId || ''}`;
-      const bKey = `${
-        b.accountId ||
-        tokenAccountMap[`${b.networkId || ''}_${b.address}`] ||
-        ''
-      }_${b.networkId || ''}`;
-      const aFiat = new BigNumber(tokenDetails[aKey]?.data?.fiatValue ?? -1);
-      const bFiat = new BigNumber(tokenDetails[bKey]?.data?.fiatValue ?? -1);
-
-      return new BigNumber(bFiat.isNaN() ? -1 : bFiat).comparedTo(
-        new BigNumber(aFiat.isNaN() ? -1 : aFiat),
-      );
-    });
-    const negativeIndex = sortedTokens.findIndex((t) => {
-      const key = `${
-        t.accountId ||
-        tokenAccountMap[`${t.networkId || ''}_${t.address}`] ||
-        ''
-      }_${t.networkId || ''}`;
-      return new BigNumber(
-        tokenDetails[key]?.data?.fiatValue ?? -1,
-      ).isNegative();
-    });
-
-    const zeroIndex = sortedTokens.findIndex((t) => {
-      const key = `${
-        t.accountId ||
-        tokenAccountMap[`${t.networkId || ''}_${t.address}`] ||
-        ''
-      }_${t.networkId || ''}`;
-      return new BigNumber(tokenDetails[key]?.data?.fiatValue ?? -1).isZero();
-    });
-
-    if (negativeIndex > -1 || zeroIndex > -1) {
-      let tokensWithNonZeroBalance: IAccountToken[] = [];
-      let tokensWithZeroBalance: IAccountToken[] = [];
-      let tokensWithoutBalance: IAccountToken[] = [];
-
-      if (negativeIndex > -1) {
-        const tokensWithBalance = sortedTokens.slice(0, negativeIndex);
-        tokensWithoutBalance = sortedTokens.slice(negativeIndex);
-        if (zeroIndex > -1) {
-          tokensWithNonZeroBalance = tokensWithBalance.slice(0, zeroIndex);
-          tokensWithZeroBalance = tokensWithBalance.slice(zeroIndex);
-        } else {
-          tokensWithNonZeroBalance = tokensWithBalance;
-        }
-      } else if (zeroIndex > -1) {
-        tokensWithNonZeroBalance = sortedTokens.slice(0, zeroIndex);
-        tokensWithZeroBalance = sortedTokens.slice(zeroIndex);
-      }
-
-      tokensWithZeroBalance = sortTokensByOrder({
-        tokens: tokensWithZeroBalance,
-      });
-
-      tokensWithoutBalance = sortTokensByOrder({
-        tokens: tokensWithoutBalance,
-      });
-
-      sortedTokens = [
-        ...tokensWithNonZeroBalance,
-        ...tokensWithZeroBalance,
-        ...tokensWithoutBalance,
-      ];
-    }
-
-    return sortedTokens;
-  }, [tokens, tokenAccountMap, tokenDetails]);
+  const { rows } = useAggregateTokenDetails({ tokens });
 
   const renderContent = useCallback(
     ({ closePopover }: { closePopover: () => void }) => {
@@ -123,14 +46,7 @@ function TokenDetailsTabToolbar(props: IProps) {
             py: '$1.5',
           }}
         >
-          {sortedTokensByFiatValue?.map((token) => {
-            const tokenDetailKey = `${
-              token.accountId ||
-              tokenAccountMap[`${token.networkId || ''}_${token.address}`] ||
-              ''
-            }_${token.networkId || ''}`;
-            const tokenDetail = tokenDetails[tokenDetailKey]?.data;
-
+          {rows.map(({ token, tokenDetail }) => {
             return (
               <ListItem
                 key={token.$key}
@@ -203,14 +119,7 @@ function TokenDetailsTabToolbar(props: IProps) {
         </Stack>
       );
     },
-    [
-      sortedTokensByFiatValue,
-      tokenAccountMap,
-      tokenDetails,
-      gtMd,
-      intl,
-      onSelected,
-    ],
+    [rows, gtMd, intl, onSelected],
   );
 
   if (tokens.length <= 1) {

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
@@ -78,6 +78,7 @@ import {
   useTokenDetailsContext,
 } from './TokenDetailsContext';
 import TokenDetailsFooter from './TokenDetailsFooter';
+import TokenDetailsOverview from './TokenDetailsOverview';
 import TokenDetailsTabToolbar from './TokenDetailsTabToolbar';
 import TokenDetailsViews from './TokenDetailsView';
 
@@ -146,7 +147,7 @@ function TokenDetailsView() {
   const { vaultSettings, network } = useAccountData({ networkId });
 
   const {
-    result: { tokens, lastActiveTabName },
+    result: { tokens },
     isLoading: isLoadingTokens,
   } = usePromiseResult(
     async () => {
@@ -156,10 +157,6 @@ function TokenDetailsView() {
 
         const allAggregateTokenMap =
           aggregateTokenRawData?.allAggregateTokenMap ?? {};
-        const _lastActiveTabName =
-          aggregateTokenRawData?.tokenDetails?.[
-            indexedAccountId ?? accountId
-          ]?.[tokenInfo.$key]?.lastActiveTabName;
         const aggregateTokens: IAccountToken[] = [];
 
         const { unavailableItems } =
@@ -245,13 +242,11 @@ function TokenDetailsView() {
             }),
             (token) => token.$key,
           ),
-          lastActiveTabName: _lastActiveTabName,
         };
       }
 
       return {
         tokens: [tokenInfo],
-        lastActiveTabName: undefined,
       };
     },
     [
@@ -267,7 +262,6 @@ function TokenDetailsView() {
       watchLoading: true,
       initResult: {
         tokens: [],
-        lastActiveTabName: undefined,
       },
     },
   );
@@ -509,22 +503,12 @@ function TokenDetailsView() {
     },
   );
 
-  usePromiseResult(async () => {
-    const activeToken = tokens[activeTabIndex] ?? tokens[0];
-    if (!activeToken) return;
-
-    const resp = await backgroundApiProxy.serviceToken.fetchTokenInfoOnly({
-      networkId: activeToken.networkId ?? '',
-      tokenAddress: activeToken.address,
-    });
-    updateTokenMetadata({
-      price: resp?.price ?? 0,
-      priceChange24h: resp?.price24h ?? 0,
-      coingeckoId: resp?.info?.coingeckoId ?? '',
-    });
-  }, [activeTabIndex, tokens, updateTokenMetadata]);
-
   const listViewContentContainerStyle = useMemo(() => ({ pt: '$5' }), []);
+
+  const overviewTabName = intl.formatMessage({
+    id: ETranslations.global_overview,
+  });
+
   // Build unique tab names for aggregate tokens to avoid
   // "Tab names must be unique" crash in collapsible-tab-view.
   // Naming rules:
@@ -532,6 +516,8 @@ function TokenDetailsView() {
   //   2. Fallback to networkId if networkName is empty (e.g. "evm--1")
   //   3. Append networkShortName for duplicates (e.g. "Ethereum(ETH)", "Ethereum(ARB)")
   //   4. Append numeric suffix as final deduplicate guard (e.g. "Ethereum(ETH) 2")
+  // The Overview tab name is reserved up front so no network tab can collide
+  // with it.
   const uniqueTabNames = useMemo(() => {
     const nameCount = new Map<string, number>();
     for (const token of tokens) {
@@ -539,7 +525,7 @@ function TokenDetailsView() {
       nameCount.set(baseName, (nameCount.get(baseName) ?? 0) + 1);
     }
     const nameMap = new Map<string, string>();
-    const usedNames = new Set<string>();
+    const usedNames = new Set<string>([overviewTabName]);
     for (const token of tokens) {
       const baseName = token.networkName || token.networkId || token.$key;
       let name = baseName;
@@ -556,31 +542,89 @@ function TokenDetailsView() {
       nameMap.set(token.$key, name);
     }
     return nameMap;
-  }, [tokens]);
+  }, [tokens, overviewTabName]);
+
+  // One descriptor per rendered tab in the aggregate view: slot 0 is the
+  // Overview (no token), member tabs follow in `tokens` order. Every
+  // tab-index ↔ member mapping derives from this array instead of offset
+  // arithmetic.
+  const aggregateTabs = useMemo(() => {
+    if (tokens.length <= 1) {
+      return undefined;
+    }
+    return [
+      { name: overviewTabName, token: undefined as IAccountToken | undefined },
+      ...tokens.map((token) => ({
+        name: uniqueTabNames.get(token.$key) ?? token.$key,
+        token,
+      })),
+    ];
+  }, [tokens, overviewTabName, uniqueTabNames]);
+
+  const jumpToMemberTab = useCallback(
+    (token: IAccountToken) => {
+      tabsRef.current?.jumpToTab(uniqueTabNames.get(token.$key) ?? token.$key);
+    },
+    [uniqueTabNames],
+  );
+
+  usePromiseResult(async () => {
+    // The Overview descriptor has no token; fall back to the largest member
+    // for its market data (tokens are fiat-sorted, tokens[0] is the largest
+    // holding).
+    const activeToken =
+      (aggregateTabs
+        ? aggregateTabs[activeTabIndex]?.token
+        : tokens[activeTabIndex]) ?? tokens[0];
+    if (!activeToken) return;
+
+    const resp = await backgroundApiProxy.serviceToken.fetchTokenInfoOnly({
+      networkId: activeToken.networkId ?? '',
+      tokenAddress: activeToken.address,
+    });
+    updateTokenMetadata({
+      price: resp?.price ?? 0,
+      priceChange24h: resp?.price24h ?? 0,
+      coingeckoId: resp?.info?.coingeckoId ?? '',
+    });
+  }, [activeTabIndex, tokens, aggregateTabs, updateTokenMetadata]);
 
   const tabs = useMemo(() => {
-    if (tokens.length > 1) {
-      return tokens.map((token) => (
-        <Tabs.Tab
-          key={token.$key}
-          name={uniqueTabNames.get(token.$key) ?? token.$key}
-        >
-          <TokenDetailsViews
-            inTabList
-            isTabView
-            accountId={token.accountId ?? ''}
-            networkId={token.networkId ?? ''}
-            walletId={walletId}
-            tokenInfo={token}
-            tokenMap={tokenMap}
-            isAllNetworks={isAllNetworks}
-            listViewContentContainerStyle={listViewContentContainerStyle}
-            indexedAccountId={indexedAccountId}
-            allNetworksState={allNetworksState}
-            refreshAllNetworkState={refreshAllNetworkState}
-          />
-        </Tabs.Tab>
-      ));
+    if (aggregateTabs) {
+      return aggregateTabs.map(({ name, token }) =>
+        token ? (
+          <Tabs.Tab key={token.$key} name={name}>
+            <TokenDetailsViews
+              inTabList
+              isTabView
+              accountId={token.accountId ?? ''}
+              networkId={token.networkId ?? ''}
+              walletId={walletId}
+              tokenInfo={token}
+              tokenMap={tokenMap}
+              isAllNetworks={isAllNetworks}
+              listViewContentContainerStyle={listViewContentContainerStyle}
+              indexedAccountId={indexedAccountId}
+              allNetworksState={allNetworksState}
+              refreshAllNetworkState={refreshAllNetworkState}
+            />
+          </Tabs.Tab>
+        ) : (
+          <Tabs.Tab key="aggregate-overview" name={name}>
+            <TokenDetailsOverview
+              accountId={accountId}
+              networkId={networkId}
+              walletId={walletId}
+              indexedAccountId={indexedAccountId}
+              tokenInfo={tokenInfo}
+              tokens={tokens}
+              tokenMap={tokenMap}
+              isAllNetworks={isAllNetworks}
+              onSelectToken={jumpToMemberTab}
+            />
+          </Tabs.Tab>
+        ),
+      );
     }
 
     if (networkId && walletId) {
@@ -632,6 +676,7 @@ function TokenDetailsView() {
     return [];
   }, [
     tokens,
+    accountId,
     networkId,
     walletId,
     isAllNetworks,
@@ -644,61 +689,49 @@ function TokenDetailsView() {
     tokenMap,
     result?.networkAccounts,
     intl,
-    uniqueTabNames,
+    aggregateTabs,
+    jumpToMemberTab,
   ]);
 
   const pageWidth = useTabletModalPageWidth();
 
   const handleTabIndexChange = useCallback(
     async (index: number) => {
-      if (isAllNetworks && tokens.length > 1 && tokens[index]) {
-        const activeToken = tokens[index];
-
-        await backgroundApiProxy.serviceToken.updateLastActiveTabNameInTokenDetails(
-          {
-            accountId: indexedAccountId ?? accountId,
-            aggregateTokenId: tokenInfo.$key,
-            lastActiveTabName:
-              uniqueTabNames.get(activeToken.$key) ?? activeToken.$key,
-          },
-        );
-
-        if (
-          activeToken.accountId &&
-          activeToken.networkId &&
-          !isEnabledNetworksInAllNetworks({
-            networkId: activeToken.networkId,
-            disabledNetworks: allNetworksState.disabledNetworks,
-            enabledNetworks: allNetworksState.enabledNetworks,
-            isTestnet: false,
-          })
-        ) {
-          await backgroundApiProxy.serviceAllNetwork.updateAllNetworksState({
-            enabledNetworks: { [activeToken.networkId]: true },
-          });
-          appEventBus.emit(EAppEventBusNames.AccountDataUpdate, undefined);
-          Toast.success({
-            title: intl.formatMessage({
-              id: ETranslations.network_also_enabled,
-            }),
-          });
-          void refreshAllNetworkState();
-        }
+      // The Overview descriptor has no token, so only member tabs can trigger
+      // the auto-enable below.
+      const activeToken = aggregateTabs?.[index]?.token;
+      if (
+        isAllNetworks &&
+        activeToken?.accountId &&
+        activeToken.networkId &&
+        !isEnabledNetworksInAllNetworks({
+          networkId: activeToken.networkId,
+          disabledNetworks: allNetworksState.disabledNetworks,
+          enabledNetworks: allNetworksState.enabledNetworks,
+          isTestnet: false,
+        })
+      ) {
+        await backgroundApiProxy.serviceAllNetwork.updateAllNetworksState({
+          enabledNetworks: { [activeToken.networkId]: true },
+        });
+        appEventBus.emit(EAppEventBusNames.AccountDataUpdate, undefined);
+        Toast.success({
+          title: intl.formatMessage({
+            id: ETranslations.network_also_enabled,
+          }),
+        });
+        void refreshAllNetworkState();
       }
 
       setActiveTabIndex(index);
     },
     [
       isAllNetworks,
-      tokens,
-      indexedAccountId,
-      accountId,
-      tokenInfo.$key,
+      aggregateTabs,
       allNetworksState.disabledNetworks,
       allNetworksState.enabledNetworks,
       intl,
       refreshAllNetworkState,
-      uniqueTabNames,
     ],
   );
 
@@ -725,7 +758,6 @@ function TokenDetailsView() {
             width={pageWidth}
             ref={tabsRef as any}
             onIndexChange={handleTabIndexChange}
-            initialTabName={lastActiveTabName}
             renderTabBar={(props) => (
               <Tabs.TabBar
                 {...props}
@@ -733,11 +765,7 @@ function TokenDetailsView() {
                 renderToolbar={() => (
                   <TokenDetailsTabToolbar
                     tokens={tokens}
-                    onSelected={(token) => {
-                      tabsRef.current?.jumpToTab(
-                        uniqueTabNames.get(token.$key) ?? token.$key,
-                      );
-                    }}
+                    onSelected={jumpToMemberTab}
                   />
                 )}
               />
@@ -778,8 +806,7 @@ function TokenDetailsView() {
     tabs,
     pageWidth,
     handleTabIndexChange,
-    lastActiveTabName,
-    uniqueTabNames,
+    jumpToMemberTab,
   ]);
 
   const headerTitle = useCallback(() => {

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
@@ -568,7 +568,11 @@ function TokenDetailsView() {
     [uniqueTabNames],
   );
 
-  usePromiseResult(async () => {
+  // Updating the context from the hook result (not inside the promise body)
+  // keeps usePromiseResult's stale-run protection: a slow response for a
+  // previously active tab can no longer overwrite the current tab's market
+  // data during fast tab switches.
+  const { result: footerTokenMetadata } = usePromiseResult(async () => {
     // The Overview descriptor has no token; fall back to the largest member
     // for its market data (tokens are fiat-sorted, tokens[0] is the largest
     // holding).
@@ -576,18 +580,25 @@ function TokenDetailsView() {
       (aggregateTabs
         ? aggregateTabs[activeTabIndex]?.token
         : tokens[activeTabIndex]) ?? tokens[0];
-    if (!activeToken) return;
+    if (!activeToken) return undefined;
 
     const resp = await backgroundApiProxy.serviceToken.fetchTokenInfoOnly({
       networkId: activeToken.networkId ?? '',
       tokenAddress: activeToken.address,
     });
-    updateTokenMetadata({
+    return {
       price: resp?.price ?? 0,
       priceChange24h: resp?.price24h ?? 0,
       coingeckoId: resp?.info?.coingeckoId ?? '',
-    });
-  }, [activeTabIndex, tokens, aggregateTabs, updateTokenMetadata]);
+      currency: resp?.currency,
+    };
+  }, [activeTabIndex, tokens, aggregateTabs]);
+
+  useEffect(() => {
+    if (footerTokenMetadata) {
+      updateTokenMetadata(footerTokenMetadata);
+    }
+  }, [footerTokenMetadata, updateTokenMetadata]);
 
   const tabs = useMemo(() => {
     if (aggregateTabs) {

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/useAggregateTokenDetails.ts
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/useAggregateTokenDetails.ts
@@ -1,0 +1,158 @@
+import { useMemo } from 'react';
+
+import BigNumber from 'bignumber.js';
+
+import { sortTokensByOrder } from '@onekeyhq/shared/src/utils/tokenUtils';
+import { isValidNumberValue } from '@onekeyhq/shared/src/utils/tokenValueUtils';
+import type {
+  IAccountToken,
+  IFetchTokenDetailItem,
+  ITokenFiat,
+} from '@onekeyhq/shared/types/token';
+
+import { useTokenDetailsContext } from './TokenDetailsContext';
+
+export type IAggregateTokenDetailsRow = {
+  token: IAccountToken;
+  tokenDetail?: IFetchTokenDetailItem;
+};
+
+type IAggregateTokenDetailsEntry = IAggregateTokenDetailsRow & {
+  fiatValueBN: BigNumber;
+};
+
+// Aggregate-token member rows sorted the same way the tab list and the network
+// dropdown sort them: fiat value descending, then zero-balance members, then
+// members with no data yet (no address / disabled network), the latter two
+// groups falling back to the server-config order. Details are read from the
+// TokenDetails context (live per-tab fetches) and seeded from the route
+// `tokenMap` snapshot so rows render on first paint.
+export function useAggregateTokenDetails({
+  tokens,
+  tokenMap,
+}: {
+  tokens: IAccountToken[];
+  tokenMap?: Record<string, ITokenFiat>;
+}) {
+  const { tokenDetails, tokenAccountMap } = useTokenDetailsContext();
+
+  return useMemo(() => {
+    const getDetail = (
+      token: IAccountToken,
+    ): IFetchTokenDetailItem | undefined => {
+      const detailKey = `${
+        token.accountId ||
+        tokenAccountMap[`${token.networkId || ''}_${token.address}`] ||
+        ''
+      }_${token.networkId || ''}`;
+      const contextDetail = tokenDetails[detailKey]?.data;
+      if (contextDetail) {
+        return contextDetail;
+      }
+      const seed = tokenMap?.[token.$key];
+      if (seed) {
+        return {
+          info: token,
+          ...seed,
+        };
+      }
+      return undefined;
+    };
+
+    // Decorate once — one detail lookup + BigNumber per member — then sort and
+    // partition over the precomputed values.
+    const entries: IAggregateTokenDetailsEntry[] = tokens.map((token) => {
+      const tokenDetail = getDetail(token);
+      const fiatValue = new BigNumber(tokenDetail?.fiatValue ?? -1);
+      return {
+        token,
+        tokenDetail,
+        fiatValueBN: fiatValue.isNaN() ? new BigNumber(-1) : fiatValue,
+      };
+    });
+
+    let sortedEntries = entries.toSorted((a, b) =>
+      b.fiatValueBN.comparedTo(a.fiatValueBN),
+    );
+
+    const negativeIndex = sortedEntries.findIndex((entry) =>
+      entry.fiatValueBN.isNegative(),
+    );
+    const zeroIndex = sortedEntries.findIndex((entry) =>
+      entry.fiatValueBN.isZero(),
+    );
+
+    if (negativeIndex > -1 || zeroIndex > -1) {
+      let entriesWithNonZeroBalance: IAggregateTokenDetailsEntry[] = [];
+      let entriesWithZeroBalance: IAggregateTokenDetailsEntry[] = [];
+      let entriesWithoutBalance: IAggregateTokenDetailsEntry[] = [];
+
+      if (negativeIndex > -1) {
+        const entriesWithBalance = sortedEntries.slice(0, negativeIndex);
+        entriesWithoutBalance = sortedEntries.slice(negativeIndex);
+        if (zeroIndex > -1) {
+          entriesWithNonZeroBalance = entriesWithBalance.slice(0, zeroIndex);
+          entriesWithZeroBalance = entriesWithBalance.slice(zeroIndex);
+        } else {
+          entriesWithNonZeroBalance = entriesWithBalance;
+        }
+      } else if (zeroIndex > -1) {
+        entriesWithNonZeroBalance = sortedEntries.slice(0, zeroIndex);
+        entriesWithZeroBalance = sortedEntries.slice(zeroIndex);
+      }
+
+      const reorderByConfig = (group: IAggregateTokenDetailsEntry[]) => {
+        const entryByKey = new Map(
+          group.map((entry) => [entry.token.$key, entry]),
+        );
+        return sortTokensByOrder({
+          tokens: group.map((entry) => entry.token),
+        }).flatMap((token) => {
+          const entry = entryByKey.get(token.$key);
+          return entry ? [entry] : [];
+        });
+      };
+
+      sortedEntries = [
+        ...entriesWithNonZeroBalance,
+        ...reorderByConfig(entriesWithZeroBalance),
+        ...reorderByConfig(entriesWithoutBalance),
+      ];
+    }
+
+    const rows: IAggregateTokenDetailsRow[] = sortedEntries.map(
+      ({ token, tokenDetail }) => ({ token, tokenDetail }),
+    );
+
+    let totalFiatValue = new BigNumber(0);
+    let totalBalance = new BigNumber(0);
+    let hasFiatValue = false;
+    let hasBalanceData = false;
+    let currency: string | undefined;
+
+    for (const { tokenDetail } of sortedEntries) {
+      if (tokenDetail) {
+        hasBalanceData = true;
+        if (isValidNumberValue(tokenDetail.fiatValue)) {
+          totalFiatValue = totalFiatValue.plus(tokenDetail.fiatValue);
+          hasFiatValue = true;
+        }
+        if (isValidNumberValue(tokenDetail.balanceParsed)) {
+          totalBalance = totalBalance.plus(tokenDetail.balanceParsed);
+        }
+        if (!currency && tokenDetail.currency) {
+          currency = tokenDetail.currency;
+        }
+      }
+    }
+
+    return {
+      rows,
+      totalFiatValueBN: hasFiatValue ? totalFiatValue : undefined,
+      totalFiatValue: hasFiatValue ? totalFiatValue.toFixed() : undefined,
+      totalBalanceParsed: hasBalanceData ? totalBalance.toFixed() : undefined,
+      currency,
+      hasBalanceData,
+    };
+  }, [tokens, tokenMap, tokenDetails, tokenAccountMap]);
+}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57944](https://onekeyhq.atlassian.net/browse/OK-57944)

----------

<!-- github-pr-monitor:jira-links:end -->


## What

Aggregated (multi-chain) tokens now open the Token Details page on a new **Overview** first tab, modeled on the operations team's request. Single-chain (non-aggregated) tokens are unchanged and have no Overview tab.

The Overview tab shows:
- **Total balance hero** — cross-chain fiat total + token amount, equal to what Home shows for that token.
- **Send / Receive / Swap / Buy** actions with per-action network resolution (Send/Buy → network selector, Receive → aggregate receive selector, Swap → largest-balance member chain).
- **Earn banner** with the whole-symbol max APY; tapping opens the protocol list unfiltered by network.
- **Asset allocation** list — one row per chain (network avatar, name, % of total, balance + fiat, trailing chevron). Tapping a row jumps to that chain's tab and auto-enables/creates the network address if needed. Zero-balance chains stay visible, sunk to the bottom.

## Why

Operations asked for a multi-chain aggregate token to land on a summary view first (Bitget-style), instead of dropping straight into the first chain's history. Users get the total and per-chain split at a glance, with actions that resolve the network in one extra step.

## Notes for reviewers

- **No backend / no new i18n.** `tokenMap` already carries the aggregate total + member fiat at first paint; existing `AggregateTokenSelector` screens cover network selection; Earn APIs already accept an optional `filterNetworkId`. All copy reuses existing `ETranslations` keys.
- **Tab memory removed.** The per-token last-active-tab persistence (`lastActiveTabName` in `ServiceToken` + simpleDb) is deleted so the page always defaults to Overview. `clearLastActiveTabNameData` is kept and still wipes stale persisted data on bootstrap.
- **Shared extractions** (used by both the header and chain tabs): `TokenDetailsBalanceHero`, `pushSwapFromTokenDetails`, `openFiatCryptoWidget`, and the `useAggregateTokenDetails` sort/totals hook.
- Product decisions, edge cases, and QA test cases are tracked in **OK-57944**.
- Structural changes worth a closer look: `index.tsx` `aggregateTabs` descriptor array (replaces scattered tab-offset arithmetic) and `TokenDetailsHeader.pushSwapFromTokenDetails`.

## Testing

`yarn agent:check --profile commit` green (lint + staged typecheck). Runtime self-test on a wallet with multi-chain aggregated balances is pending; QA scenarios are in OK-57944.

### Known v1 scope
- Buy entry is buy-only (sell stays on chain tabs).
- Network dropdown has no "Overview" entry.
- No dedicated overview-exposure / allocation-click analytics events yet.

[OK-57944]: https://onekeyhq.atlassian.net/browse/OK-57944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ