### PR TITLE
fix: harden WalletConnect connect attempt lifecycle (review fixes for #12424)

### DIFF
--- a/packages/kit-bg/src/services/ServiceWalletConnect/ServiceWalletConnect.ts
+++ b/packages/kit-bg/src/services/ServiceWalletConnect/ServiceWalletConnect.ts
@@ -53,13 +53,12 @@ class ServiceWalletConnect extends ServiceBase {
 
   @backgroundMethod()
   async abortConnectPairing({ uri }: { uri: string }) {
-    const providers = this.dappSide.providers;
     const cancelled = await this.dappSide.abortConnectPairing({ uri });
+    // the pairing uri query carries the symKey, never log it
     console.log(
       'abortConnectPairing current attempt: ',
-      uri,
+      uri.split('?')[0],
       cancelled,
-      providers,
     );
   }
 

--- a/packages/kit-bg/src/services/ServiceWalletConnect/WalletConnectDappSide.ts
+++ b/packages/kit-bg/src/services/ServiceWalletConnect/WalletConnectDappSide.ts
@@ -407,12 +407,29 @@ export class WalletConnectDappSide {
     }
 
     this.closeModal();
-    await attempt.provider?.abortConnectPairing();
+    try {
+      // best-effort SDK-side cleanup; the attempt is already rejected above,
+      // so a provider failure here must not reject the abort call itself
+      await attempt.provider?.abortConnectPairing();
+    } catch (error) {
+      console.error('abortConnectPairing provider error: ', error);
+    }
     return true;
   }
 
   async connectToWallet({ impl }: IWalletConnectConnectToWalletParams) {
     console.log('WalletConnectDappSide connectToWallet111');
+
+    // Cancel any superseded attempt before replacing it, so its pending
+    // connect() cannot re-emit display_uri or tear down this newer
+    // attempt's modal when it finally settles.
+    if (this.activeConnectAttempt) {
+      try {
+        await this.abortConnectPairing({ uri: '' });
+      } catch (error) {
+        console.error('abort superseded connect attempt error: ', error);
+      }
+    }
 
     const attempt: IWalletConnectConnectAttempt = {};
     this.activeConnectAttempt = attempt;
@@ -484,7 +501,8 @@ export class WalletConnectDappSide {
 
       attempt.provider = provider;
       displayUriHandler = async (uri: string) => {
-        console.log('uri', uri);
+        // the pairing uri query carries the symKey, never log it
+        console.log('uri', uri.split('?')[0]);
         if (attempt.cancelError) return;
         attempt.uri = uri;
         this.openModal({ uri });
@@ -546,10 +564,26 @@ export class WalletConnectDappSide {
       });
       throwIfCancelled();
       // call connect() to create new session
-      await Promise.race([
-        provider.connect(connectParams),
-        cancellationPromise,
-      ]);
+      const connectPromise = provider.connect(connectParams);
+      try {
+        await Promise.race([connectPromise, cancellationPromise]);
+      } catch (error) {
+        if (attempt.cancelError && error === attempt.cancelError) {
+          // connect() keeps running inside the SDK after cancellation; if the
+          // wallet approves later, disconnect the session nobody consumes
+          // instead of leaving it alive until the next cold start cleanup.
+          const orphanProvider = provider;
+          void connectPromise
+            .then(async () => {
+              const topic = orphanProvider?.session?.topic;
+              if (topic) {
+                await this.disconnectProvider({ topic });
+              }
+            })
+            .catch(() => undefined);
+        }
+        throw error;
+      }
       attempt.rejectCancellation = undefined;
       throwIfCancelled();
       if (!provider.session || !provider.isWalletConnect) {
@@ -569,7 +603,8 @@ export class WalletConnectDappSide {
       throw error;
     } finally {
       attempt.rejectCancellation = undefined;
-      if (this.activeConnectAttempt === attempt) {
+      const isCurrentAttempt = this.activeConnectAttempt === attempt;
+      if (isCurrentAttempt) {
         this.activeConnectAttempt = undefined;
       }
       if (this.lastConnectToWalletProvider === provider) {
@@ -587,7 +622,12 @@ export class WalletConnectDappSide {
           sessionDeleteHandler,
         );
       }
-      this.closeModal();
+      // Only the attempt that still owns the modal may close it; a superseded
+      // attempt settling late (e.g. proposal expiry minutes later) must not
+      // tear down the newer attempt's modal and main-runtime payload store.
+      if (isCurrentAttempt) {
+        this.closeModal();
+      }
     }
   }
 

--- a/packages/kit/src/components/WalletConnect/WalletConnectModal.native.tsx
+++ b/packages/kit/src/components/WalletConnect/WalletConnectModal.native.tsx
@@ -332,6 +332,7 @@ const modal: IWalletConnectModalShared = {
     const openRequestIdRef = useRef(0);
     const isClosingProgrammaticallyRef = useRef(false);
     const isAwaitingMobileWalletApprovalRef = useRef(false);
+    const activePairingUriRef = useRef('');
 
     useEffect(
       () => () => {
@@ -359,15 +360,19 @@ const modal: IWalletConnectModalShared = {
             event.data.properties.connected;
 
           // AppKit may close after launching a mobile wallet but before the
-          // WalletConnect session is approved. The OneKey status dialog remains
-          // the explicit cancellation surface while that pairing is pending.
+          // WalletConnect session is approved; skip aborting so that pending
+          // pairing can still complete. It then terminates in bg via wallet
+          // approval/rejection or proposal expiry.
           if (
             !isClosingProgrammaticallyRef.current &&
             !isConnected &&
             !isAwaitingMobileWalletApprovalRef.current
           ) {
+            // Use the uri captured at open time: the module-level pairingUri
+            // is cleared while a newer attempt resets AppKit, and an empty
+            // uri would wildcard-cancel that newer attempt in bg.
             void backgroundApiProxy.serviceWalletConnect.abortConnectPairing({
-              uri: pairingUri,
+              uri: activePairingUriRef.current,
             });
           }
         },
@@ -393,6 +398,7 @@ const modal: IWalletConnectModalShared = {
         return;
       }
       pairingUri = uri;
+      activePairingUriRef.current = uri;
       updateConnectModalUri(uri);
 
       // TODO use custom provider from bg make QRCode Modal not open automatically

--- a/packages/kit/src/hooks/useWebDapp/useWalletConnection.test.tsx
+++ b/packages/kit/src/hooks/useWebDapp/useWalletConnection.test.tsx
@@ -32,6 +32,7 @@ jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
   __esModule: true,
   default: {
     isNative: true,
+    isNativeIOS: true,
   },
 }));
 

--- a/packages/kit/src/hooks/useWebDapp/useWalletConnection.tsx
+++ b/packages/kit/src/hooks/useWebDapp/useWalletConnection.tsx
@@ -124,8 +124,11 @@ export function useWalletConnection({
         ),
         showFooter: false,
         dismissOnOverlayPress: false,
+        // The zero-inset first frame only happens inside the iOS
+        // FullWindowOverlay portal; Android must not pad with the startup
+        // snapshot (stale under edge-to-edge gesture navigation).
         useInitialSafeAreaBottomInsetFallback:
-          platformEnv.isNative && isWalletConnect,
+          platformEnv.isNativeIOS && isWalletConnect,
         onClose() {
           if (
             platformEnv.isNative &&

--- a/packages/kit/src/provider/Container/GlobalWalletConnectModalContainer/GlobalWalletConnectModalContainer.test.tsx
+++ b/packages/kit/src/provider/Container/GlobalWalletConnectModalContainer/GlobalWalletConnectModalContainer.test.tsx
@@ -141,6 +141,56 @@ describe('GlobalWalletConnectModalContainer', () => {
     view.unmount();
   });
 
+  it('clears the payload when a second pairing arrives while the modal stays open', async () => {
+    const view = render(<GlobalWalletConnectModalContainer />);
+
+    act(() => {
+      appEventBus.emit(EAppEventBusNames.WalletConnectOpenModal, {
+        uri: 'wc:first-session',
+      });
+      appEventBus.emit(EAppEventBusNames.WalletConnectModalState, {
+        open: true,
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockWalletConnectModalContainer).toHaveBeenCalledTimes(1);
+    });
+
+    // A second pairing lands while AppKit stays open, so no fresh open:true
+    // transition will ever follow for it.
+    act(() => {
+      appEventBus.emit(EAppEventBusNames.WalletConnectOpenModal, {
+        uri: 'wc:second-session',
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockWalletConnectModalContainer).toHaveBeenCalledTimes(2);
+    });
+
+    act(() => {
+      appEventBus.emit(EAppEventBusNames.WalletConnectModalState, {
+        open: false,
+      });
+    });
+
+    mockShouldRenderPageEveryChildren = false;
+    view.rerender(<GlobalWalletConnectModalContainer />);
+
+    mockShouldRenderPageEveryChildren = true;
+    view.rerender(<GlobalWalletConnectModalContainer />);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // The stale second uri must not be replayed after the user closed the modal.
+    expect(mockWalletConnectModalContainer).toHaveBeenCalledTimes(2);
+
+    view.unmount();
+  });
+
   it('renders the modal only in the detail tree for split view', async () => {
     mockSplitViewType = 'main';
     const view = render(<GlobalWalletConnectModalContainer />);

--- a/packages/kit/src/provider/Container/GlobalWalletConnectModalContainer/GlobalWalletConnectModalContainer.tsx
+++ b/packages/kit/src/provider/Container/GlobalWalletConnectModalContainer/GlobalWalletConnectModalContainer.tsx
@@ -21,6 +21,7 @@ type IWalletConnectOpenModalPayload =
 
 let pendingPayload: IWalletConnectOpenModalPayload | null = null;
 let wasModalOpened = false;
+let isModalOpen = false;
 const pendingPayloadListeners = new Set<() => void>();
 
 function getPendingPayload() {
@@ -37,7 +38,10 @@ function subscribePendingPayload(listener: () => void) {
 function updatePendingPayload(payload: IWalletConnectOpenModalPayload) {
   if (pendingPayload?.uri === payload.uri) return;
   pendingPayload = payload;
-  wasModalOpened = false;
+  // A new pairing can arrive while AppKit is still open (interleaved
+  // sessions). No fresh open:true transition follows in that case, so inherit
+  // the current open state to keep the eventual close clearing this store.
+  wasModalOpened = isModalOpen;
   pendingPayloadListeners.forEach((listener) => listener());
 }
 
@@ -51,6 +55,7 @@ function clearPendingPayload() {
 function handleModalState({
   open,
 }: IAppEventBusPayload[EAppEventBusNames.WalletConnectModalState]) {
+  isModalOpen = open;
   if (open) {
     wasModalOpened = true;
   } else if (wasModalOpened) {


### PR DESCRIPTION
## Summary

Stacked on #12424. Addresses the unresolved review comment from @originalix (`useWalletConnection.tsx` — stale empty-uri `abortConnectPairing` can cancel a newer attempt) plus the remaining confirmed findings from the review of that PR.

## Changes

**bg runtime — `WalletConnectDappSide.ts` / `ServiceWalletConnect.ts`**
- `connectToWallet` now cancels a superseded attempt before replacing it, so its pending `connect()` cannot re-emit `display_uri` or interfere later.
- The `finally` block only emits the final `CloseModal` when the attempt still owns the modal; a stale attempt settling minutes later (proposal expiry) no longer tears down the newer attempt's modal and main-runtime payload store.
- When a cancelled `connect()` is approved by the wallet afterwards, the orphan session is disconnected immediately instead of surviving until the next cold-start cleanup.
- `abortConnectPairing` swallows provider cleanup errors (all main-runtime call sites are `void`ed, so a rejection became an unhandled rejection).
- Pairing uris are no longer logged with their query string (it carries the pairing symKey); dev-only since prod strips console, but zero-cost to fix.

**main runtime — `WalletConnectModal.native.tsx`**
- The `MODAL_CLOSE` handler aborts with the uri captured at open time instead of the module-level `pairingUri`, which is cleared while a newer attempt resets AppKit and would wildcard-cancel that newer attempt in bg.
- Corrected a misleading comment: after selecting a mobile wallet the OneKey status dialog is already closed and is not a cancellation surface; the pairing terminates via wallet approval/rejection or proposal expiry.

**main runtime — `GlobalWalletConnectModalContainer.tsx`**
- When a second pairing arrives while AppKit stays open (interleaved sessions), no fresh `open:true` transition follows, so `wasModalOpened` now inherits the live modal-open state. Previously the eventual close never cleared the store and navigation remounts would replay the stale uri.

**`useWalletConnection.tsx`**
- `useInitialSafeAreaBottomInsetFallback` is scoped back to `isNativeIOS`: the zero-inset first frame only occurs inside the iOS `FullWindowOverlay` portal, while on Android the startup snapshot can be stale (edge-to-edge gesture navigation) and would add bogus bottom padding.

## Tests
- New regression test: interleaved second pairing → modal close → remount must not replay the stale uri.
- Updated the `useWalletConnection` platformEnv mock for the iOS scoping.

## Test plan
- [x] `yarn jest packages/kit/src/provider/Container/GlobalWalletConnectModalContainer/GlobalWalletConnectModalContainer.test.tsx packages/kit/src/hooks/useWebDapp/useWalletConnection.test.tsx --runInBand` — 2 suites, 6 tests passed
- [x] `yarn agent:check --profile commit` — lint + tsc passed
- [x] `eslint` on all changed files — no findings
- [ ] iOS manual: close loading → immediately retry; select mobile wallet without approving → retry → wait ~5min, newer modal must stay open
- [ ] Android manual: WalletConnect dialog bottom inset unchanged