### PR TITLE
feat: add one-click SegmentLoadError repro action

### DIFF
--- a/packages/kit/src/views/Setting/pages/DevBundleSwitcher/BundleList.tsx
+++ b/packages/kit/src/views/Setting/pages/DevBundleSwitcher/BundleList.tsx
@@ -31,6 +31,8 @@ import type {
   IModalSettingParamList,
 } from '@onekeyhq/shared/src/routes';
 
+import { loadTargetSegmentForRepro } from './segmentLoadRepro';
+
 import type { RouteProp } from '@react-navigation/core';
 
 const PLACEHOLDER_SIGNATURE = 'dev-no-signature';
@@ -84,10 +86,17 @@ export function BundleItem({
 }) {
   const downloadPercent = useDownloadProgress();
   const [status, setStatus] = useState<
-    'idle' | 'downloading' | 'downloaded' | 'installing' | 'error'
+    | 'idle'
+    | 'downloading'
+    | 'downloaded'
+    | 'installing'
+    | 'reproducing'
+    | 'error'
   >(alreadyDownloaded ? 'downloaded' : 'idle');
   const [errorMessage, setErrorMessage] = useState('');
   const downloadedEventRef = useRef<Record<string, unknown> | null>(null);
+  const segmentLoadReproEnabled =
+    platformEnv.isNative && version === String(platformEnv.version);
 
   useEffect(() => {
     if (alreadyDownloaded && status === 'idle') {
@@ -167,91 +176,108 @@ export function BundleItem({
     skipGpgVerificationAllowed,
   ]);
 
-  const handleInstall = useCallback(async () => {
-    const skipGPGVerification = skipGpgVerificationAllowed && gpgSkipped;
-    setStatus('installing');
-    // Enable ignore toggle so auto-rollback doesn't undo the dev switch
-    await backgroundApiProxy.serviceDevSetting.updateDevSetting(
-      'ignoreServerBundleUpdate',
-      true,
-    );
-    // await backgroundApiProxy.serviceAppUpdate.reset();
-    await backgroundApiProxy.servicePendingInstallTask.clearPendingInstallTask();
-    defaultLogger.app.jsBundleDev.installBundle({
-      version,
-      bundleVersion: bundle.ciBundleVersion,
-    });
-    try {
-      if (alreadyDownloaded && !downloadedEventRef.current) {
-        await BundleUpdate.verifyExtractedBundle(
-          version,
-          bundle.ciBundleVersion,
-        );
-        defaultLogger.app.jsBundleDev.installBundleResult({
-          version,
-          bundleVersion: bundle.ciBundleVersion,
-          success: true,
-        });
-        await BundleUpdate.installBundle({
-          latestVersion: version,
-          bundleVersion: bundle.ciBundleVersion,
-          signature: bundle.signature || PLACEHOLDER_SIGNATURE,
-          skipGPGVerification,
-        });
-      } else {
-        if (!downloadedEventRef.current) {
-          throw new OneKeyLocalError(
-            'Downloaded bundle info missing, please download again.',
-          );
-        }
-        await BundleUpdate.verifyBundleASC({
-          ...downloadedEventRef.current,
-          latestVersion: version,
-          bundleVersion: bundle.ciBundleVersion,
-          sha256: bundle.sha256,
-          signature: bundle.signature || PLACEHOLDER_SIGNATURE,
-          skipGPGVerification,
-        });
-
-        await BundleUpdate.verifyBundle({
-          ...downloadedEventRef.current,
-          latestVersion: version,
-          bundleVersion: bundle.ciBundleVersion,
-          sha256: bundle.sha256,
-          skipGPGVerification,
-        });
-
-        defaultLogger.app.jsBundleDev.installBundleResult({
-          version,
-          bundleVersion: bundle.ciBundleVersion,
-          success: true,
-        });
-        await BundleUpdate.installBundle({
-          ...downloadedEventRef.current,
-          latestVersion: version,
-          bundleVersion: bundle.ciBundleVersion,
-          signature: bundle.signature || PLACEHOLDER_SIGNATURE,
-          skipGPGVerification,
-        });
-      }
-    } catch (e) {
-      const errMsg = (e as Error)?.message || 'Install failed';
-      setStatus('error');
-      setErrorMessage(errMsg);
-      defaultLogger.app.jsBundleDev.installBundleResult({
+  const handleInstall = useCallback(
+    async (loadTargetSegment: boolean) => {
+      const skipGPGVerification = skipGpgVerificationAllowed && gpgSkipped;
+      let isLoadingTargetSegment = false;
+      setStatus(loadTargetSegment ? 'reproducing' : 'installing');
+      setErrorMessage('');
+      // Enable ignore toggle so auto-rollback doesn't undo the dev switch
+      await backgroundApiProxy.serviceDevSetting.updateDevSetting(
+        'ignoreServerBundleUpdate',
+        true,
+      );
+      // await backgroundApiProxy.serviceAppUpdate.reset();
+      await backgroundApiProxy.servicePendingInstallTask.clearPendingInstallTask();
+      defaultLogger.app.jsBundleDev.installBundle({
         version,
         bundleVersion: bundle.ciBundleVersion,
-        success: false,
-        error: errMsg,
       });
-    }
-  }, [
-    alreadyDownloaded,
-    bundle,
-    version,
-    gpgSkipped,
-    skipGpgVerificationAllowed,
-  ]);
+      try {
+        if (alreadyDownloaded && !downloadedEventRef.current) {
+          await BundleUpdate.verifyExtractedBundle(
+            version,
+            bundle.ciBundleVersion,
+          );
+          defaultLogger.app.jsBundleDev.installBundleResult({
+            version,
+            bundleVersion: bundle.ciBundleVersion,
+            success: true,
+          });
+          await BundleUpdate.installBundle({
+            latestVersion: version,
+            bundleVersion: bundle.ciBundleVersion,
+            signature: bundle.signature || PLACEHOLDER_SIGNATURE,
+            skipGPGVerification,
+          });
+        } else {
+          if (!downloadedEventRef.current) {
+            throw new OneKeyLocalError(
+              'Downloaded bundle info missing, please download again.',
+            );
+          }
+          await BundleUpdate.verifyBundleASC({
+            ...downloadedEventRef.current,
+            latestVersion: version,
+            bundleVersion: bundle.ciBundleVersion,
+            sha256: bundle.sha256,
+            signature: bundle.signature || PLACEHOLDER_SIGNATURE,
+            skipGPGVerification,
+          });
+
+          await BundleUpdate.verifyBundle({
+            ...downloadedEventRef.current,
+            latestVersion: version,
+            bundleVersion: bundle.ciBundleVersion,
+            sha256: bundle.sha256,
+            skipGPGVerification,
+          });
+
+          defaultLogger.app.jsBundleDev.installBundleResult({
+            version,
+            bundleVersion: bundle.ciBundleVersion,
+            success: true,
+          });
+          await BundleUpdate.installBundle({
+            ...downloadedEventRef.current,
+            latestVersion: version,
+            bundleVersion: bundle.ciBundleVersion,
+            signature: bundle.signature || PLACEHOLDER_SIGNATURE,
+            skipGPGVerification,
+          });
+        }
+
+        if (loadTargetSegment) {
+          isLoadingTargetSegment = true;
+          await loadTargetSegmentForRepro();
+        }
+      } catch (e) {
+        const error = e as Error;
+        const errMsg = error?.message || 'Install failed';
+        setStatus('error');
+        setErrorMessage(
+          loadTargetSegment && error?.name
+            ? `${error.name}: ${errMsg}`
+            : errMsg,
+        );
+        if (!isLoadingTargetSegment) {
+          defaultLogger.app.jsBundleDev.installBundleResult({
+            version,
+            bundleVersion: bundle.ciBundleVersion,
+            success: false,
+            error: errMsg,
+          });
+        }
+      }
+    },
+    [
+      alreadyDownloaded,
+      bundle,
+      version,
+      gpgSkipped,
+      skipGpgVerificationAllowed,
+    ],
+  );
 
   const downloadDisabled = isDownloading && status !== 'downloading';
 
@@ -340,25 +366,39 @@ export function BundleItem({
       ) : null}
 
       {/* Status: installing */}
-      {status === 'installing' ? (
+      {status === 'installing' || status === 'reproducing' ? (
         <XStack alignItems="center" gap="$2">
           <Spinner size="small" />
           <SizableText size="$bodyXs" color="$textSubdued">
-            Installing & restarting...
+            {status === 'reproducing'
+              ? 'Installing & loading target segment...'
+              : 'Installing & restarting...'}
           </SizableText>
         </XStack>
       ) : null}
 
       {/* Action: install */}
       {!isCurrentBundle && status === 'downloaded' ? (
-        <XStack justifyContent="flex-end">
+        <XStack justifyContent="flex-end" gap="$2" flexWrap="wrap">
+          {segmentLoadReproEnabled ? (
+            <Button
+              testID="setting-load-target-segment-btn"
+              variant="secondary"
+              size="small"
+              alignSelf="flex-end"
+              px="$3"
+              onPress={() => handleInstall(true)}
+            >
+              Load Target Segment
+            </Button>
+          ) : null}
           <Button
             testID="setting-btn"
             variant="primary"
             size="small"
             alignSelf="flex-end"
             px="$3"
-            onPress={handleInstall}
+            onPress={() => handleInstall(false)}
           >
             Switch
           </Button>

--- a/packages/kit/src/views/Setting/pages/DevBundleSwitcher/segmentLoadRepro.test.ts
+++ b/packages/kit/src/views/Setting/pages/DevBundleSwitcher/segmentLoadRepro.test.ts
@@ -1,0 +1,23 @@
+import {
+  SEGMENT_LOAD_REPRO_TARGET,
+  loadTargetSegmentForRepro,
+} from './segmentLoadRepro';
+
+describe('segmentLoadRepro', () => {
+  it('loads the target segment through the production split bundle loader', async () => {
+    const loadBundleAsync = jest.fn(async () => undefined);
+
+    await loadTargetSegmentForRepro({
+      __loadBundleAsync: loadBundleAsync,
+    });
+
+    expect(loadBundleAsync).toHaveBeenCalledTimes(1);
+    expect(loadBundleAsync).toHaveBeenCalledWith(SEGMENT_LOAD_REPRO_TARGET);
+  });
+
+  it('rejects when the split bundle loader is unavailable', async () => {
+    await expect(loadTargetSegmentForRepro({})).rejects.toThrow(
+      'Split bundle loader is unavailable in this runtime.',
+    );
+  });
+});

--- a/packages/kit/src/views/Setting/pages/DevBundleSwitcher/segmentLoadRepro.ts
+++ b/packages/kit/src/views/Setting/pages/DevBundleSwitcher/segmentLoadRepro.ts
@@ -1,0 +1,22 @@
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
+export const SEGMENT_LOAD_REPRO_TARGET =
+  // Bundle Manager does not render this lazy icon before the repro action.
+  'seg:components.primitives.Icon.react.brand.ArtifactNews';
+
+type ISegmentLoadReproGlobal = {
+  __loadBundleAsync?: (bundlePath: string) => Promise<void>;
+};
+
+export async function loadTargetSegmentForRepro(
+  globalRef: ISegmentLoadReproGlobal = globalThis as ISegmentLoadReproGlobal,
+): Promise<void> {
+  const loadBundleAsync = globalRef.__loadBundleAsync;
+  if (!loadBundleAsync) {
+    throw new OneKeyLocalError(
+      'Split bundle loader is unavailable in this runtime.',
+    );
+  }
+
+  await loadBundleAsync(SEGMENT_LOAD_REPRO_TARGET);
+}


### PR DESCRIPTION
## Summary

- add a Native-only `Load Target Segment` action to JS Bundle Manager for downloaded bundles matching the running app version
- reuse the existing verified install flow, then load a deliberately untouched lazy segment before the scheduled 2.5-second all-runtime restart
- surface the exact loader error in the bundle row and keep ordinary `Switch` behavior unchanged
- add focused tests for the target segment loader helper

## Why

This provides a deterministic harness for the `SegmentLoadError` activation race:

1. the running main JS runtime keeps manifest A in its isolated JS heap
2. installing bundle B changes the shared native current-bundle pointer
3. the restart of main and background runtimes is scheduled 2.5 seconds later
4. the harness immediately requests `seg:components.primitives.Icon.react.brand.ArtifactNews`
5. the old runtime validates B's bytes with A's expected SHA and reports `SegmentLoadError`

The selected icon is lazy and is not rendered by Bundle Manager before the action, so an already-loaded segment should not short-circuit the repro.

This PR is a QA reproduction tool, not the production fix.

## Runtime and resource scope

- the action runs in the **main** UI JS runtime
- the manifest is a per-runtime JS heap copy; main and background deserialize independently
- the current bundle pointer and extracted files are shared native resources
- main and background initialize and restart independently; reproducing this in main does not by itself prove a background-runtime occurrence

## Test plan

- open Dev Settings > JS Bundle Manager on iOS or Android
- select the running app version and download a non-current bundle
- tap `Load Target Segment`
- expect the row to show a `SegmentLoadError` SHA mismatch before restart
- verify ordinary `Switch` still installs and restarts without requesting the target segment

Automated checks:

- `yarn jest packages/kit/src/views/Setting/pages/DevBundleSwitcher/segmentLoadRepro.test.ts --runInBand`
- `yarn agent:check --profile commit`
