### PR TITLE
perf: reduce Market table resize rerenders

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,8 +7,8 @@
     "start:webpack": "cross-env NODE_OPTIONS=\"--max-old-space-size=10240\" webpack serve -c ./webpack.config.kill-switch.js",
     "clean": "yarn clean:build",
     "clean:build": "rimraf ./web-build && rimraf .generated && rimraf .tamagui && rimraf ./node_modules/.cache",
-    "build": "yarn clean && node ./scripts/fetch-market-home-token-seed.js && cross-env NODE_ENV=production rspack build && cp ./web-build/index.html ./web-build/404.html && bash ./postbuild.sh",
-    "build:webpack": "yarn clean && node ./scripts/fetch-market-home-token-seed.js && cross-env NODE_ENV=production webpack build -c ./webpack.config.kill-switch.js && cp ./web-build/index.html ./web-build/404.html && bash ./postbuild.sh",
+    "build": "yarn clean && node ./scripts/fetch-market-home-token-seed.js && cross-env NODE_ENV=production rspack build && node ./scripts/postbuild.js",
+    "build:webpack": "yarn clean && node ./scripts/fetch-market-home-token-seed.js && cross-env NODE_ENV=production webpack build -c ./webpack.config.kill-switch.js && node ./scripts/postbuild.js",
     "stats": "cross-env NODE_ENV=production RSPACK_FULL_STATS=1 rspack build --json=web-build/stats.json",
     "check:startup-graph-budget": "node scripts/check-startup-graph-budget.js"
   },

--- a/apps/web/scripts/postbuild.js
+++ b/apps/web/scripts/postbuild.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+// cspell:ignore postbuild
+
+const webRoot = path.join(__dirname, '..');
+const buildDir = path.join(webRoot, 'web-build');
+const wellKnownDir = path.join(buildDir, '.well-known');
+
+function copyFile(source, destination) {
+  fs.copyFileSync(source, destination);
+  // eslint-disable-next-line no-console
+  console.log(`[web:postbuild] copied ${source} -> ${destination}`);
+}
+
+fs.mkdirSync(wellKnownDir, { recursive: true });
+copyFile(path.join(buildDir, 'index.html'), path.join(buildDir, '404.html'));
+copyFile(
+  path.join(webRoot, 'validation', 'deeplink.android.json'),
+  path.join(wellKnownDir, 'assetlinks.json'),
+);
+copyFile(
+  path.join(webRoot, 'validation', 'deeplink.ios.json'),
+  path.join(wellKnownDir, 'apple-app-site-association'),
+);
+
+// eslint-disable-next-line no-console
+console.log('[web:postbuild] completed');

--- a/apps/web/validation/README.md
+++ b/apps/web/validation/README.md
@@ -1,7 +1,7 @@
 # App link verification files
 
 The files in this directory are copied into the web build by
-`apps/web/postbuild.sh`:
+`apps/web/scripts/postbuild.js`:
 
 - `deeplink.ios.json` -> `web-build/.well-known/apple-app-site-association`
 - `deeplink.android.json` -> `web-build/.well-known/assetlinks.json`

--- a/development/perf-ci/README.md
+++ b/development/perf-ci/README.md
@@ -121,6 +121,39 @@ yarn perf:web:prepare --headed
 # run release perf job (3 runs; median aggregation + thresholds)
 yarn perf:web:release --headed
 
+# warm Market table resize benchmark without changing the desktop/mobile shell.
+# Defaults to an equal-distance control and 1016 <-> 1032 px, where the real
+# Market table changes from 8 to 9 visible columns. The runner verifies the
+# column counts before recording 20 transitions per scenario.
+# The wallet profile is preserved while PWA/network caches are cleared. Loaded
+# entry bundle names must match the current disk build or the run fails as stale.
+yarn perf:web:resize
+
+# optional: measure the 9 <-> 11 column transition around 1280 px
+PERF_WEB_RESIZE_SCENARIOS=market-control-xl,market-cross-xl yarn perf:web:resize
+
+# optional: retain the old Home 768 px shell-switch benchmark as a structural
+# stress regression; it is not the primary Tamagui style/list benchmark.
+PERF_WEB_RESIZE_TARGET=home yarn perf:web:resize
+
+# optional: save Chrome timeline traces next to report.json
+PERF_WEB_RESIZE_TRACE=1 yarn perf:web:resize
+
+# optional: include high-resolution V8 CPU samples in the Chrome trace.
+# Keep this diagnostic-only because sampling changes timing and trace size.
+PERF_WEB_RESIZE_TRACE=1 PERF_WEB_RESIZE_CPU_PROFILE=1 yarn perf:web:resize
+
+# optional: enable OneKey function-hit instrumentation in a diagnostic build.
+# Keep this off for comparison baselines because instrumentation adds CPU cost.
+PERF_WEB_RESIZE_FUNCTION_MONITOR=1 yarn perf:web:resize
+
+# compare a candidate with a previously captured resize report
+PERF_WEB_RESIZE_BASELINE_REPORT=/absolute/path/to/report.json yarn perf:web:resize
+
+# optional: exercise every configured width boundary on an explicitly chosen
+# page. These generic cases do not assert Market column counts.
+PERF_WEB_RESIZE_TARGET=home PERF_WEB_RESIZE_SCENARIOS=all-width-breakpoints yarn perf:web:resize
+
 # first-visit cold load matrix for entry routes.
 # This uses a fresh browser context, disables browser cache, blocks service workers,
 # and keeps budget failures non-fatal so it can be used to establish baselines.
@@ -135,6 +168,10 @@ yarn perf:web:cold
 # optional: narrow the cold matrix while investigating
 PERF_WEB_COLD_SCENARIOS=perps,swap,defi,refer-friends yarn perf:web:cold --headed
 ```
+
+If the ready selector times out, the resize runner writes
+`page-readiness-run-<n>.json` and `.png` beside the job report with page text,
+loaded bundle names, page errors, and console errors.
 
 Budget CI also writes AI-oriented diagnostic artifacts next to the raw reports:
 

--- a/development/perf-ci/lib/chromium.js
+++ b/development/perf-ci/lib/chromium.js
@@ -1,4 +1,7 @@
 const fs = require('fs');
+const path = require('path');
+
+// cspell:ignore LOCALAPPDATA
 
 function fileExists(p) {
   try {
@@ -6,6 +9,106 @@ function fileExists(p) {
   } catch {
     return false;
   }
+}
+
+function getChromiumExecutableCandidates(
+  env = process.env,
+  platform = process.platform,
+) {
+  const windowsCandidates =
+    platform === 'win32'
+      ? [
+          path.win32.join(
+            env['PROGRAMFILES(X86)'] || 'C:\\Program Files (x86)',
+            'Google',
+            'Chrome',
+            'Application',
+            'chrome.exe',
+          ),
+          path.win32.join(
+            env.PROGRAMFILES || 'C:\\Program Files',
+            'Google',
+            'Chrome',
+            'Application',
+            'chrome.exe',
+          ),
+          env.LOCALAPPDATA
+            ? path.win32.join(
+                env.LOCALAPPDATA,
+                'Google',
+                'Chrome',
+                'Application',
+                'chrome.exe',
+              )
+            : null,
+          path.win32.join(
+            env['PROGRAMFILES(X86)'] || 'C:\\Program Files (x86)',
+            'Microsoft',
+            'Edge',
+            'Application',
+            'msedge.exe',
+          ),
+          path.win32.join(
+            env.PROGRAMFILES || 'C:\\Program Files',
+            'Microsoft',
+            'Edge',
+            'Application',
+            'msedge.exe',
+          ),
+          env.LOCALAPPDATA
+            ? path.win32.join(
+                env.LOCALAPPDATA,
+                'Microsoft',
+                'Edge',
+                'Application',
+                'msedge.exe',
+              )
+            : null,
+        ]
+      : [];
+
+  return [
+    ...windowsCandidates,
+    // Microsoft Edge (Chromium)
+    '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+    env.HOME
+      ? `${env.HOME}/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge`
+      : null,
+    '/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta',
+    env.HOME
+      ? `${env.HOME}/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta`
+      : null,
+    '/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev',
+    env.HOME
+      ? `${env.HOME}/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev`
+      : null,
+    '/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary',
+    env.HOME
+      ? `${env.HOME}/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary`
+      : null,
+    // Google Chrome
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    env.HOME
+      ? `${env.HOME}/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`
+      : null,
+    // Chrome Canary
+    '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
+    env.HOME
+      ? `${env.HOME}/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary`
+      : null,
+    // Chromium
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    env.HOME
+      ? `${env.HOME}/Applications/Chromium.app/Contents/MacOS/Chromium`
+      : null,
+    // Linux CI images, including GitHub-hosted Ubuntu runners.
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/opt/google/chrome/chrome',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+    '/snap/bin/chromium',
+  ].filter(Boolean);
 }
 
 function findChromiumExecutable(preferred) {
@@ -17,33 +120,7 @@ function findChromiumExecutable(preferred) {
     null;
   if (fileExists(env)) return env;
 
-  const candidates = [
-    // Microsoft Edge (Chromium)
-    '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
-    `${process.env.HOME}/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge`,
-    '/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta',
-    `${process.env.HOME}/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta`,
-    '/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev',
-    `${process.env.HOME}/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev`,
-    '/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary',
-    `${process.env.HOME}/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary`,
-    // Google Chrome
-    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-    `${process.env.HOME}/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`,
-    // Chrome Canary
-    '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
-    `${process.env.HOME}/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary`,
-    // Chromium
-    '/Applications/Chromium.app/Contents/MacOS/Chromium',
-    `${process.env.HOME}/Applications/Chromium.app/Contents/MacOS/Chromium`,
-    // Linux CI images, including GitHub-hosted Ubuntu runners.
-    '/usr/bin/google-chrome',
-    '/usr/bin/google-chrome-stable',
-    '/opt/google/chrome/chrome',
-    '/usr/bin/chromium',
-    '/usr/bin/chromium-browser',
-    '/snap/bin/chromium',
-  ];
+  const candidates = getChromiumExecutableCandidates();
 
   for (const p of candidates) {
     if (fileExists(p)) return p;
@@ -54,4 +131,5 @@ function findChromiumExecutable(preferred) {
 
 module.exports = {
   findChromiumExecutable,
+  getChromiumExecutableCandidates,
 };

--- a/development/perf-ci/lib/chromium.test.js
+++ b/development/perf-ci/lib/chromium.test.js
@@ -1,0 +1,35 @@
+const { getChromiumExecutableCandidates } = require('./chromium');
+
+// cspell:ignore LOCALAPPDATA
+
+describe('getChromiumExecutableCandidates', () => {
+  test('includes installed-browser locations on Windows', () => {
+    const candidates = getChromiumExecutableCandidates(
+      {
+        'PROGRAMFILES(X86)': 'D:\\Program Files (x86)',
+        PROGRAMFILES: 'D:\\Program Files',
+        LOCALAPPDATA: 'D:\\Users\\tester\\AppData\\Local',
+      },
+      'win32',
+    );
+
+    expect(candidates).toContain(
+      'D:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+    );
+    expect(candidates).toContain(
+      'D:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
+    );
+    expect(candidates).toContain(
+      'D:\\Users\\tester\\AppData\\Local\\Google\\Chrome\\Application\\chrome.exe',
+    );
+  });
+
+  test('does not add Windows locations on other platforms', () => {
+    const candidates = getChromiumExecutableCandidates({}, 'linux');
+
+    expect(candidates).not.toContain(
+      'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+    );
+    expect(candidates).toContain('/usr/bin/google-chrome');
+  });
+});

--- a/development/perf-ci/lib/exec.js
+++ b/development/perf-ci/lib/exec.js
@@ -1,7 +1,52 @@
 const { spawn } = require('child_process');
+const fs = require('fs');
 const path = require('path');
 
 const { stopChild } = require('./processTree');
+
+function findRepoYarnPath(startDir) {
+  let currentDir = path.resolve(startDir || process.cwd());
+  while (true) {
+    const yarnRcPath = path.join(currentDir, '.yarnrc.yml');
+    try {
+      const yarnRc = fs.readFileSync(yarnRcPath, 'utf8');
+      const match = yarnRc.match(
+        /^\s*yarnPath:\s*(?:"([^"]+)"|'([^']+)'|(\S+))\s*$/m,
+      );
+      const configuredPath = match?.[1] || match?.[2] || match?.[3];
+      if (configuredPath) {
+        const yarnPath = path.resolve(currentDir, configuredPath);
+        if (fs.existsSync(yarnPath)) return yarnPath;
+      }
+    } catch {
+      // Continue toward the filesystem root when this directory has no config.
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) return null;
+    currentDir = parentDir;
+  }
+}
+
+function resolveSpawnInvocation(
+  cmd,
+  args,
+  { cwd, platform = process.platform } = {},
+) {
+  if (platform === 'win32' && String(cmd).toLowerCase() === 'yarn') {
+    const yarnPath = findRepoYarnPath(cwd);
+    if (!yarnPath) {
+      throw new Error(
+        `Unable to locate yarnPath from ${path.resolve(cwd || process.cwd())}`,
+      );
+    }
+    return {
+      command: process.execPath,
+      args: [yarnPath, ...args],
+    };
+  }
+  return { command: cmd, args };
+}
 
 function appendTail(buffer, chunk, maxChars) {
   const next = `${buffer}${chunk}`;
@@ -27,7 +72,8 @@ function execCmd(
     let stoppingForSignal = false;
     let t = null;
 
-    const child = spawn(cmd, args, {
+    const invocation = resolveSpawnInvocation(cmd, args, { cwd });
+    const child = spawn(invocation.command, invocation.args, {
       cwd,
       env: env ? { ...process.env, ...env } : process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -168,6 +214,8 @@ function withRepoNodeBin(repoRoot, env = {}) {
 
 module.exports = {
   execCmd,
+  findRepoYarnPath,
   formatExecResultError,
+  resolveSpawnInvocation,
   withRepoNodeBin,
 };

--- a/development/perf-ci/lib/exec.test.js
+++ b/development/perf-ci/lib/exec.test.js
@@ -1,0 +1,33 @@
+const path = require('path');
+
+const { findRepoYarnPath, resolveSpawnInvocation } = require('./exec');
+
+describe('resolveSpawnInvocation', () => {
+  const repoRoot = path.join(__dirname, '..', '..', '..');
+
+  test('runs the repository Yarn release through Node on Windows', () => {
+    const invocation = resolveSpawnInvocation('yarn', ['test'], {
+      cwd: repoRoot,
+      platform: 'win32',
+    });
+
+    expect(invocation.command).toBe(process.execPath);
+    expect(invocation.args[0]).toBe(findRepoYarnPath(repoRoot));
+    expect(invocation.args.slice(1)).toEqual(['test']);
+  });
+
+  test('does not rewrite native or non-Windows commands', () => {
+    expect(
+      resolveSpawnInvocation('git', ['status'], {
+        cwd: repoRoot,
+        platform: 'win32',
+      }),
+    ).toEqual({ command: 'git', args: ['status'] });
+    expect(
+      resolveSpawnInvocation('yarn', ['test'], {
+        cwd: repoRoot,
+        platform: 'linux',
+      }),
+    ).toEqual({ command: 'yarn', args: ['test'] });
+  });
+});

--- a/development/perf-ci/lib/webBuildIdentity.js
+++ b/development/perf-ci/lib/webBuildIdentity.js
@@ -1,0 +1,39 @@
+const path = require('path');
+
+function scriptAssetNamesFromHtml(html) {
+  const assetNames = [];
+  const scriptSourcePattern =
+    /<script\b[^>]*\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s>]+))/gi;
+
+  for (const match of String(html).matchAll(scriptSourcePattern)) {
+    const source = match[1] || match[2] || match[3];
+    if (source) {
+      const pathname = source.split(/[?#]/, 1)[0];
+      const assetName = path.posix.basename(pathname.replace(/\\/g, '/'));
+      if (assetName) assetNames.push(assetName);
+    }
+  }
+
+  return [...new Set(assetNames)];
+}
+
+function assertBuildScriptsLoaded({ expected, loaded }) {
+  const loadedSet = new Set(loaded);
+  const missing = expected.filter((assetName) => !loadedSet.has(assetName));
+
+  if (missing.length) {
+    throw new Error(
+      [
+        'The browser loaded scripts that do not match the current Web build.',
+        `Missing current assets: ${missing.join(', ')}`,
+        `Loaded assets: ${loaded.join(', ') || '(none)'}`,
+        'A stale Service Worker or browser cache may be serving an older build.',
+      ].join(' '),
+    );
+  }
+}
+
+module.exports = {
+  assertBuildScriptsLoaded,
+  scriptAssetNamesFromHtml,
+};

--- a/development/perf-ci/lib/webBuildIdentity.test.js
+++ b/development/perf-ci/lib/webBuildIdentity.test.js
@@ -1,0 +1,34 @@
+const {
+  assertBuildScriptsLoaded,
+  scriptAssetNamesFromHtml,
+} = require('./webBuildIdentity');
+
+describe('web build identity', () => {
+  test('extracts quoted and unquoted script assets without query strings', () => {
+    expect(
+      scriptAssetNamesFromHtml(`
+        <script defer src="/main.abc.bundle.js"></script>
+        <script src='/static/js/chunk.def.js?v=1'></script>
+        <script src=vendor.js#hash></script>
+      `),
+    ).toEqual(['main.abc.bundle.js', 'chunk.def.js', 'vendor.js']);
+  });
+
+  test('accepts the current build when all entry scripts are loaded', () => {
+    expect(() =>
+      assertBuildScriptsLoaded({
+        expected: ['main.abc.bundle.js', 'vendor.js'],
+        loaded: ['main.abc.bundle.js', 'vendor.js', 'lazy.js'],
+      }),
+    ).not.toThrow();
+  });
+
+  test('rejects a stale cached build', () => {
+    expect(() =>
+      assertBuildScriptsLoaded({
+        expected: ['main.current.bundle.js'],
+        loaded: ['main.stale.bundle.js'],
+      }),
+    ).toThrow(/stale Service Worker or browser cache/);
+  });
+});

--- a/development/perf-ci/lib/webResizeMetrics.js
+++ b/development/perf-ci/lib/webResizeMetrics.js
@@ -1,0 +1,153 @@
+const { median } = require('./metrics');
+
+const AGGREGATED_METRICS = [
+  'settleMedianMs',
+  'settleP95Ms',
+  'settleMaxMs',
+  'taskDurationMs',
+  'scriptDurationMs',
+  'recalcStyleDurationMs',
+  'layoutDurationMs',
+  'longTaskCount',
+  'longTaskTotalMs',
+  'longTaskMaxMs',
+  'maxFrameDurationMs',
+  'slowFrameCount',
+  'droppedFrameEstimate',
+  'resizeEventCount',
+  'heapBeforeBytes',
+  'heapAfterBytes',
+  'heapDeltaBytes',
+];
+
+function aggregateResizeRuns(runs) {
+  const byScenario = new Map();
+
+  for (const run of runs) {
+    for (const scenario of run.scenarios || []) {
+      if (!byScenario.has(scenario.name)) {
+        byScenario.set(scenario.name, []);
+      }
+      byScenario.get(scenario.name).push(scenario.metrics);
+    }
+  }
+
+  const scenarios = {};
+  for (const [name, metricsList] of byScenario) {
+    const summary = { runCount: metricsList.length };
+    for (const metricName of AGGREGATED_METRICS) {
+      summary[metricName] = median(
+        metricsList.map((metrics) => metrics[metricName]),
+      );
+    }
+    scenarios[name] = summary;
+  }
+
+  return {
+    runCount: runs.length,
+    scenarios,
+  };
+}
+
+function relativeChange(current, baseline) {
+  if (!Number.isFinite(current) || !Number.isFinite(baseline)) return null;
+  if (baseline === 0) return current === 0 ? 0 : null;
+  return (current - baseline) / baseline;
+}
+
+function compareResizeSummaries({ current, baseline, thresholds }) {
+  const primaryMetric = thresholds.primaryMetric || 'scriptDurationMs';
+  const defaultMinimumImprovementRatio =
+    thresholds.minimumImprovementRatio ?? 0.1;
+  const defaultMaximumRegressionRatio =
+    thresholds.maximumRegressionRatio ?? 0.05;
+  const guardMetrics = thresholds.guardMetrics || [];
+  const scenarioResults = {};
+  const reasons = [];
+
+  for (const [name, currentMetrics] of Object.entries(current.scenarios)) {
+    const baselineMetrics = baseline.scenarios[name];
+    if (!baselineMetrics) {
+      reasons.push(`${name}: missing baseline scenario`);
+      scenarioResults[name] = { pass: false, reason: 'missing baseline' };
+    } else {
+      const scenarioThresholds = thresholds.scenarios?.[name] || {};
+      const mode = scenarioThresholds.mode || 'improve';
+      const minimumImprovementRatio =
+        scenarioThresholds.minimumImprovementRatio ??
+        defaultMinimumImprovementRatio;
+      const maximumRegressionRatio =
+        scenarioThresholds.maximumRegressionRatio ??
+        defaultMaximumRegressionRatio;
+      const primaryChangeRatio = relativeChange(
+        currentMetrics[primaryMetric],
+        baselineMetrics[primaryMetric],
+      );
+      const primaryImprovementRatio =
+        primaryChangeRatio === null ? null : -primaryChangeRatio;
+      const primaryPass =
+        primaryChangeRatio !== null &&
+        (mode === 'guard'
+          ? primaryChangeRatio <= maximumRegressionRatio
+          : primaryImprovementRatio >= minimumImprovementRatio);
+
+      const guards = guardMetrics.map((metricName) => {
+        const changeRatio = relativeChange(
+          currentMetrics[metricName],
+          baselineMetrics[metricName],
+        );
+        const pass =
+          changeRatio !== null && changeRatio <= maximumRegressionRatio;
+        return {
+          metricName,
+          current: currentMetrics[metricName],
+          baseline: baselineMetrics[metricName],
+          changeRatio,
+          pass,
+        };
+      });
+      const pass = primaryPass && guards.every((guard) => guard.pass);
+
+      if (!primaryPass) {
+        const expected =
+          mode === 'guard'
+            ? `regression <= ${maximumRegressionRatio}`
+            : `improvement >= ${minimumImprovementRatio}`;
+        reasons.push(
+          `${name}: ${primaryMetric} did not meet ${expected} ` +
+            `(actual improvement=${primaryImprovementRatio})`,
+        );
+      }
+      for (const guard of guards.filter((item) => !item.pass)) {
+        reasons.push(
+          `${name}: ${guard.metricName} regressed beyond ` +
+            `${maximumRegressionRatio} (change=${guard.changeRatio})`,
+        );
+      }
+
+      scenarioResults[name] = {
+        pass,
+        mode,
+        primaryMetric,
+        primaryChangeRatio,
+        primaryImprovementRatio,
+        minimumImprovementRatio,
+        maximumRegressionRatio,
+        guards,
+      };
+    }
+  }
+
+  return {
+    triggered: reasons.length > 0,
+    reasons,
+    scenarios: scenarioResults,
+  };
+}
+
+module.exports = {
+  AGGREGATED_METRICS,
+  aggregateResizeRuns,
+  compareResizeSummaries,
+  relativeChange,
+};

--- a/development/perf-ci/lib/webResizeMetrics.test.js
+++ b/development/perf-ci/lib/webResizeMetrics.test.js
@@ -1,0 +1,94 @@
+const {
+  aggregateResizeRuns,
+  compareResizeSummaries,
+  relativeChange,
+} = require('./webResizeMetrics');
+
+function scenario(name, scriptDurationMs, taskDurationMs) {
+  return {
+    name,
+    metrics: {
+      scriptDurationMs,
+      taskDurationMs,
+    },
+  };
+}
+
+describe('webResizeMetrics', () => {
+  test('aggregates scenario medians across runs', () => {
+    const summary = aggregateResizeRuns([
+      { scenarios: [scenario('cross-md', 30, 50)] },
+      { scenarios: [scenario('cross-md', 10, 20)] },
+      { scenarios: [scenario('cross-md', 20, 30)] },
+    ]);
+
+    expect(summary.runCount).toBe(3);
+    expect(summary.scenarios['cross-md']).toMatchObject({
+      runCount: 3,
+      scriptDurationMs: 20,
+      taskDurationMs: 30,
+    });
+  });
+
+  test('passes improvement and control guard scenarios', () => {
+    const comparison = compareResizeSummaries({
+      current: {
+        scenarios: {
+          'control-gt-md': { scriptDurationMs: 102, taskDurationMs: 103 },
+          'cross-md': { scriptDurationMs: 80, taskDurationMs: 95 },
+        },
+      },
+      baseline: {
+        scenarios: {
+          'control-gt-md': { scriptDurationMs: 100, taskDurationMs: 100 },
+          'cross-md': { scriptDurationMs: 100, taskDurationMs: 100 },
+        },
+      },
+      thresholds: {
+        primaryMetric: 'scriptDurationMs',
+        minimumImprovementRatio: 0.1,
+        maximumRegressionRatio: 0.05,
+        guardMetrics: ['taskDurationMs'],
+        scenarios: {
+          'control-gt-md': { mode: 'guard' },
+          'cross-md': { mode: 'improve' },
+        },
+      },
+    });
+
+    expect(comparison.triggered).toBe(false);
+    expect(comparison.scenarios['control-gt-md'].pass).toBe(true);
+    expect(
+      comparison.scenarios['cross-md'].primaryImprovementRatio,
+    ).toBeCloseTo(0.2);
+  });
+
+  test('fails a candidate that does not improve the primary scenario', () => {
+    const comparison = compareResizeSummaries({
+      current: {
+        scenarios: {
+          'cross-md': { scriptDurationMs: 95, taskDurationMs: 100 },
+        },
+      },
+      baseline: {
+        scenarios: {
+          'cross-md': { scriptDurationMs: 100, taskDurationMs: 100 },
+        },
+      },
+      thresholds: {
+        primaryMetric: 'scriptDurationMs',
+        minimumImprovementRatio: 0.1,
+        maximumRegressionRatio: 0.05,
+        guardMetrics: ['taskDurationMs'],
+      },
+    });
+
+    expect(comparison.triggered).toBe(true);
+    expect(comparison.scenarios['cross-md'].pass).toBe(false);
+  });
+
+  test('handles a stable zero baseline without division by zero', () => {
+    expect(relativeChange(0, 0)).toBe(0);
+    expect(relativeChange(1, 0)).toBeNull();
+  });
+});

--- a/development/perf-ci/run-web-resize-perf.js
+++ b/development/perf-ci/run-web-resize-perf.js
@@ -1,0 +1,1050 @@
+#!/usr/bin/env node
+
+/**
+ * Warm Web viewport-resize performance guard.
+ *
+ * Builds and serves the production Web app, opens the prepared persistent
+ * profile, then measures repeated viewport transitions around Tamagui media
+ * boundaries. Use PERF_WEB_RESIZE_BASELINE_REPORT to turn a candidate run into
+ * a baseline comparison.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { chromium } = require('playwright-core');
+
+const { withBuildLock } = require('./lib/buildLock');
+const { findChromiumExecutable } = require('./lib/chromium');
+const { readPerfCiLocalConfig } = require('./lib/config');
+const {
+  execCmd,
+  formatExecResultError,
+  withRepoNodeBin,
+} = require('./lib/exec');
+const { ensureDir, fileExists, readJson, writeJson } = require('./lib/fs');
+const { nowId } = require('./lib/id');
+const { median } = require('./lib/metrics');
+const { startStaticServer } = require('./lib/staticServer');
+const {
+  assertBuildScriptsLoaded,
+  scriptAssetNamesFromHtml,
+} = require('./lib/webBuildIdentity');
+const {
+  aggregateResizeRuns,
+  compareResizeSummaries,
+} = require('./lib/webResizeMetrics');
+
+// cspell:ignore recalc
+
+const WIDTH_HEIGHT = 900;
+const DEFAULT_TARGET_NAME = 'market-list';
+const TARGETS = {
+  home: {
+    name: 'home',
+    path: '/',
+    readySelector: '[data-testid="wallet-refresh-manually"]',
+    businessReady: null,
+    defaultScenarioNames: ['control-gt-md', 'cross-md'],
+  },
+  'market-list': {
+    name: 'market-list',
+    path: '/market',
+    readySelector: '[data-testid="market-normal-token-list"]',
+    businessReady: 'marketList',
+    defaultScenarioNames: ['market-control-lg', 'market-cross-lg'],
+  },
+};
+const WIDTH_SCENARIO_NAMES = [
+  'cross-sm',
+  'cross-md',
+  'cross-2md',
+  'cross-lg',
+  'cross-xl',
+  'cross-2xl',
+];
+const SCENARIOS = [
+  {
+    name: 'market-control-lg',
+    sizes: [
+      { width: 984, height: WIDTH_HEIGHT },
+      { width: 1000, height: WIDTH_HEIGHT },
+    ],
+    expectedVisibleMarketColumnCounts: [8, 8],
+  },
+  {
+    name: 'market-cross-lg',
+    sizes: [
+      { width: 1016, height: WIDTH_HEIGHT },
+      { width: 1032, height: WIDTH_HEIGHT },
+    ],
+    expectedVisibleMarketColumnCounts: [8, 9],
+  },
+  {
+    name: 'market-control-xl',
+    sizes: [
+      { width: 1240, height: WIDTH_HEIGHT },
+      { width: 1256, height: WIDTH_HEIGHT },
+    ],
+    expectedVisibleMarketColumnCounts: [9, 9],
+  },
+  {
+    name: 'market-cross-xl',
+    sizes: [
+      { width: 1272, height: WIDTH_HEIGHT },
+      { width: 1288, height: WIDTH_HEIGHT },
+    ],
+    expectedVisibleMarketColumnCounts: [9, 11],
+  },
+  {
+    name: 'control-gt-md',
+    sizes: [
+      { width: 780, height: WIDTH_HEIGHT },
+      { width: 850, height: WIDTH_HEIGHT },
+    ],
+  },
+  {
+    name: 'cross-sm',
+    sizes: [
+      { width: 632, height: WIDTH_HEIGHT },
+      { width: 648, height: WIDTH_HEIGHT },
+    ],
+  },
+  {
+    name: 'cross-md',
+    sizes: [
+      { width: 760, height: WIDTH_HEIGHT },
+      { width: 780, height: WIDTH_HEIGHT },
+    ],
+  },
+  {
+    name: 'cross-2md',
+    sizes: [
+      { width: 888, height: WIDTH_HEIGHT },
+      { width: 904, height: WIDTH_HEIGHT },
+    ],
+  },
+  {
+    name: 'cross-lg',
+    sizes: [
+      { width: 1016, height: WIDTH_HEIGHT },
+      { width: 1032, height: WIDTH_HEIGHT },
+    ],
+  },
+  {
+    name: 'cross-xl',
+    sizes: [
+      { width: 1272, height: WIDTH_HEIGHT },
+      { width: 1288, height: WIDTH_HEIGHT },
+    ],
+  },
+  {
+    name: 'cross-2xl',
+    sizes: [
+      { width: 1528, height: WIDTH_HEIGHT },
+      { width: 1544, height: WIDTH_HEIGHT },
+    ],
+  },
+  {
+    name: 'cross-height',
+    sizes: [
+      { width: 1024, height: 812 },
+      { width: 1024, height: 828 },
+    ],
+  },
+];
+
+function hasFlag(name) {
+  return process.argv.includes(name);
+}
+
+function numberEnv(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function booleanEnv(name) {
+  return process.env[name] === '1' || process.env[name] === 'true';
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function percentile(values, ratio) {
+  const sorted = values
+    .filter((value) => Number.isFinite(value))
+    .slice()
+    .toSorted((a, b) => a - b);
+  if (!sorted.length) return null;
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(sorted.length * ratio) - 1),
+  );
+  return sorted[index];
+}
+
+function sum(values) {
+  return values.reduce(
+    (total, value) => total + (Number.isFinite(value) ? value : 0),
+    0,
+  );
+}
+
+function max(values) {
+  const finite = values.filter((value) => Number.isFinite(value));
+  return finite.length ? Math.max(...finite) : null;
+}
+
+function parseTarget() {
+  const targetName = process.env.PERF_WEB_RESIZE_TARGET || DEFAULT_TARGET_NAME;
+  const target = TARGETS[targetName];
+  if (!target) {
+    throw new Error(
+      `Unknown Web resize target: ${targetName}. Known: ${Object.keys(TARGETS).join(', ')}`,
+    );
+  }
+  return target;
+}
+
+function parseScenarios(
+  defaultScenarioNames = TARGETS.home.defaultScenarioNames,
+) {
+  const raw = process.env.PERF_WEB_RESIZE_SCENARIOS || 'default';
+  const requested = raw
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean);
+  const names = [];
+
+  for (const name of requested) {
+    if (name === 'default') {
+      names.push(...defaultScenarioNames);
+    } else if (name === 'all-width-breakpoints') {
+      names.push(...WIDTH_SCENARIO_NAMES);
+    } else if (name === 'all') {
+      names.push(...SCENARIOS.map((scenario) => scenario.name));
+    } else {
+      names.push(name);
+    }
+  }
+
+  const selected = [...new Set(names)].map((name) => {
+    const scenario = SCENARIOS.find((item) => item.name === name);
+    if (!scenario) {
+      throw new Error(`Unknown Web resize scenario: ${name}`);
+    }
+    return scenario;
+  });
+  if (!selected.length) {
+    throw new Error('At least one Web resize scenario is required');
+  }
+  return selected;
+}
+
+async function waitForBusinessReady({ page, businessReady, timeoutMs }) {
+  if (!businessReady) return null;
+  if (businessReady !== 'marketList') {
+    throw new Error(`Unknown Web resize business readiness: ${businessReady}`);
+  }
+
+  await page.waitForFunction(
+    () => {
+      const perfGlobal = globalThis;
+      const readyAt = Number(perfGlobal.__onekeyMarketListReadyAt);
+      const readyCount = Number(perfGlobal.__onekeyMarketListReadyCount);
+      const list = document.querySelector(
+        '[data-testid="market-normal-token-list"]',
+      );
+      return (
+        (Number.isFinite(readyAt) && readyAt > 0 && readyCount > 0) ||
+        (list?.textContent?.trim()?.length || 0) > 200
+      );
+    },
+    undefined,
+    { timeout: timeoutMs },
+  );
+
+  return page.evaluate(() => {
+    const perfGlobal = globalThis;
+    const readyAt = Number(perfGlobal.__onekeyMarketListReadyAt);
+    const readyCount = Number(perfGlobal.__onekeyMarketListReadyCount);
+    const list = document.querySelector(
+      '[data-testid="market-normal-token-list"]',
+    );
+    return {
+      name: 'marketList',
+      readyAt: Number.isFinite(readyAt) && readyAt > 0 ? readyAt : null,
+      readyCount:
+        Number.isFinite(readyCount) && readyCount > 0 ? readyCount : 0,
+      domTextLength: list?.textContent?.trim()?.length || 0,
+    };
+  });
+}
+
+async function readVisibleMarketColumns(page) {
+  return page.evaluate(() => {
+    const prefix = 'list-column-';
+    const visibleColumnNames = new Set();
+    for (const element of document.querySelectorAll(
+      '[data-testid^="list-column-"]',
+    )) {
+      const testId = element.getAttribute('data-testid');
+      const rect = element.getBoundingClientRect();
+      const style = getComputedStyle(element);
+      if (
+        testId?.startsWith(prefix) &&
+        style.display !== 'none' &&
+        style.visibility !== 'hidden' &&
+        rect.width > 0 &&
+        rect.height > 0
+      ) {
+        visibleColumnNames.add(testId.slice(prefix.length));
+      }
+    }
+    return [...visibleColumnNames].toSorted();
+  });
+}
+
+async function verifyScenarioFixture({ page, scenario }) {
+  const expectedCounts = scenario.expectedVisibleMarketColumnCounts;
+  if (!expectedCounts) return [];
+
+  const fixtureStates = [];
+  for (let index = 0; index < scenario.sizes.length; index += 1) {
+    const size = scenario.sizes[index];
+    // eslint-disable-next-line no-await-in-loop
+    await page.setViewportSize(size);
+    // eslint-disable-next-line no-await-in-loop
+    await waitForAnimationFrames(page);
+    // eslint-disable-next-line no-await-in-loop
+    const visibleColumns = await readVisibleMarketColumns(page);
+    const expectedCount = expectedCounts[index];
+    const state = {
+      size,
+      expectedCount,
+      visibleCount: visibleColumns.length,
+      visibleColumns,
+    };
+    fixtureStates.push(state);
+    if (visibleColumns.length !== expectedCount) {
+      throw new Error(
+        `${scenario.name}: expected ${expectedCount} visible Market columns at ${size.width}x${size.height}, found ${visibleColumns.length}: ${visibleColumns.join(', ')}`,
+      );
+    }
+  }
+  return fixtureStates;
+}
+
+function webExtensionsEnabled() {
+  return process.env.PERF_WEB_DISABLE_EXTENSIONS !== '1';
+}
+
+function installResizeObservers() {
+  if (globalThis.__onekeyResizePerf) return;
+
+  const state = {
+    active: false,
+    generation: 0,
+    frameDeltas: [],
+    longTasks: [],
+    resizeEventCount: 0,
+  };
+  globalThis.__onekeyResizePerf = state;
+
+  globalThis.addEventListener('resize', () => {
+    if (state.active) state.resizeEventCount += 1;
+  });
+
+  if ('PerformanceObserver' in globalThis) {
+    try {
+      const observer = new PerformanceObserver((list) => {
+        if (!state.active) return;
+        state.longTasks.push(
+          ...list.getEntries().map((entry) => ({
+            startTime: entry.startTime,
+            duration: entry.duration,
+            name: entry.name,
+          })),
+        );
+      });
+      observer.observe({ type: 'longtask', buffered: false });
+    } catch {
+      // Long-task entries are not exposed in every browser mode.
+    }
+  }
+}
+
+async function waitForAnimationFrames(page, count = 2) {
+  await page.evaluate(async (frameCount) => {
+    for (let index = 0; index < frameCount; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    }
+  }, count);
+}
+
+async function startPageMeasurement(page) {
+  return page.evaluate(() => {
+    const state = globalThis.__onekeyResizePerf;
+    if (!state) throw new Error('Resize observers are not installed');
+
+    state.active = true;
+    state.generation += 1;
+    state.frameDeltas = [];
+    state.longTasks = [];
+    state.resizeEventCount = 0;
+    const generation = state.generation;
+    let lastFrameTime = null;
+
+    const onFrame = (frameTime) => {
+      if (!state.active || state.generation !== generation) return;
+      if (lastFrameTime !== null) {
+        state.frameDeltas.push(frameTime - lastFrameTime);
+      }
+      lastFrameTime = frameTime;
+      requestAnimationFrame(onFrame);
+    };
+    requestAnimationFrame(onFrame);
+
+    return performance.now();
+  });
+}
+
+async function stopPageMeasurement(page) {
+  return page.evaluate(() => {
+    const state = globalThis.__onekeyResizePerf;
+    state.active = false;
+    state.generation += 1;
+    return {
+      endTime: performance.now(),
+      frameDeltas: state.frameDeltas.slice(),
+      longTasks: state.longTasks.slice(),
+      resizeEventCount: state.resizeEventCount,
+    };
+  });
+}
+
+function cdpMetricsToMap(payload) {
+  return Object.fromEntries(
+    (payload.metrics || []).map((metric) => [metric.name, metric.value]),
+  );
+}
+
+function durationDeltaMs(before, after, metricName) {
+  const beforeValue = before[metricName];
+  const afterValue = after[metricName];
+  if (!Number.isFinite(beforeValue) || !Number.isFinite(afterValue)) {
+    return null;
+  }
+  return Math.max(0, (afterValue - beforeValue) * 1000);
+}
+
+async function getCdpPerformanceMetrics(cdp) {
+  return cdpMetricsToMap(await cdp.send('Performance.getMetrics'));
+}
+
+async function startBrowserTrace(cdp) {
+  const traceEvents = [];
+  let resolveComplete;
+  const complete = new Promise((resolve) => {
+    resolveComplete = resolve;
+  });
+  const onData = (event) => traceEvents.push(...event.value);
+  const onComplete = () => resolveComplete();
+  cdp.on('Tracing.dataCollected', onData);
+  cdp.on('Tracing.tracingComplete', onComplete);
+
+  const categories = [
+    'devtools.timeline',
+    'blink.user_timing',
+    'v8.execute',
+    ...(booleanEnv('PERF_WEB_RESIZE_CPU_PROFILE')
+      ? [
+          'disabled-by-default-v8.cpu_profiler',
+          'disabled-by-default-v8.cpu_profiler.hires',
+        ]
+      : []),
+  ];
+  await cdp.send('Tracing.start', {
+    categories: categories.join(','),
+    transferMode: 'ReportEvents',
+  });
+
+  return async (tracePath) => {
+    await cdp.send('Tracing.end');
+    await Promise.race([
+      complete,
+      delay(30_000).then(() => {
+        throw new Error('Timed out while collecting Chrome trace data');
+      }),
+    ]);
+    cdp.off('Tracing.dataCollected', onData);
+    cdp.off('Tracing.tracingComplete', onComplete);
+    fs.writeFileSync(tracePath, JSON.stringify({ traceEvents }));
+  };
+}
+
+async function runScenario({
+  page,
+  cdp,
+  scenario,
+  transitionCount,
+  warmupTransitionCount,
+  log,
+}) {
+  const [firstSize, secondSize] = scenario.sizes;
+  log(`scenario=${scenario.name}: verify fixture`);
+  const fixtureStates = await verifyScenarioFixture({ page, scenario });
+  log(`scenario=${scenario.name}: warmup`);
+  await page.setViewportSize(firstSize);
+  await waitForAnimationFrames(page);
+  for (let index = 0; index < warmupTransitionCount; index += 1) {
+    const target = index % 2 === 0 ? secondSize : firstSize;
+    // eslint-disable-next-line no-await-in-loop
+    await page.setViewportSize(target);
+    // eslint-disable-next-line no-await-in-loop
+    await waitForAnimationFrames(page);
+  }
+  await page.setViewportSize(firstSize);
+  await waitForAnimationFrames(page);
+  await page.waitForTimeout(250);
+
+  await page.evaluate(
+    (name) => performance.mark(`onekey-resize:${name}:start`),
+    scenario.name,
+  );
+  const measurementStart = await startPageMeasurement(page);
+  const before = await getCdpPerformanceMetrics(cdp);
+  const settleDurations = [];
+
+  log(
+    `scenario=${scenario.name}: measure ${transitionCount} viewport transitions`,
+  );
+  for (let index = 0; index < transitionCount; index += 1) {
+    const target = index % 2 === 0 ? secondSize : firstSize;
+    // eslint-disable-next-line no-await-in-loop
+    const transitionStart = await page.evaluate(() => performance.now());
+    // eslint-disable-next-line no-await-in-loop
+    await page.setViewportSize(target);
+    // eslint-disable-next-line no-await-in-loop
+    const transitionEnd = await page.evaluate(async (expectedSize) => {
+      await new Promise((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve)),
+      );
+      if (
+        globalThis.innerWidth !== expectedSize.width ||
+        globalThis.innerHeight !== expectedSize.height
+      ) {
+        throw new Error(
+          `Viewport mismatch: expected ${expectedSize.width}x${expectedSize.height}, ` +
+            `received ${globalThis.innerWidth}x${globalThis.innerHeight}`,
+        );
+      }
+      return performance.now();
+    }, target);
+    settleDurations.push(transitionEnd - transitionStart);
+  }
+
+  await waitForAnimationFrames(page);
+  const pageMeasurement = await stopPageMeasurement(page);
+  const after = await getCdpPerformanceMetrics(cdp);
+  await page.evaluate(
+    (name) => performance.mark(`onekey-resize:${name}:end`),
+    scenario.name,
+  );
+
+  const frameDeltas = pageMeasurement.frameDeltas.filter(
+    (value) => Number.isFinite(value) && value >= 0,
+  );
+  const longTaskDurations = pageMeasurement.longTasks.map(
+    (entry) => entry.duration,
+  );
+  const frameBudgetMs = 1000 / 60;
+  const heapBeforeBytes = before.JSHeapUsedSize ?? null;
+  const heapAfterBytes = after.JSHeapUsedSize ?? null;
+
+  return {
+    name: scenario.name,
+    sizes: scenario.sizes,
+    fixtureStates,
+    transitionCount,
+    warmupTransitionCount,
+    metrics: {
+      measurementDurationMs: pageMeasurement.endTime - measurementStart,
+      settleMedianMs: median(settleDurations),
+      settleP95Ms: percentile(settleDurations, 0.95),
+      settleMaxMs: max(settleDurations),
+      taskDurationMs: durationDeltaMs(before, after, 'TaskDuration'),
+      scriptDurationMs: durationDeltaMs(before, after, 'ScriptDuration'),
+      recalcStyleDurationMs: durationDeltaMs(
+        before,
+        after,
+        'RecalcStyleDuration',
+      ),
+      layoutDurationMs: durationDeltaMs(before, after, 'LayoutDuration'),
+      longTaskCount: longTaskDurations.length,
+      longTaskTotalMs: sum(longTaskDurations),
+      longTaskMaxMs: max(longTaskDurations) || 0,
+      maxFrameDurationMs: max(frameDeltas),
+      slowFrameCount: frameDeltas.filter((value) => value > 20).length,
+      droppedFrameEstimate: sum(
+        frameDeltas.map((value) =>
+          Math.max(0, Math.round(value / frameBudgetMs) - 1),
+        ),
+      ),
+      resizeEventCount: pageMeasurement.resizeEventCount,
+      heapBeforeBytes,
+      heapAfterBytes,
+      heapDeltaBytes:
+        Number.isFinite(heapBeforeBytes) && Number.isFinite(heapAfterBytes)
+          ? heapAfterBytes - heapBeforeBytes
+          : null,
+    },
+    transitions: settleDurations,
+  };
+}
+
+async function buildWeb({ repoRoot, outputDir, log }) {
+  if (process.env.PERF_SKIP_BUILD === '1') {
+    log('web build skipped (PERF_SKIP_BUILD=1)');
+    return;
+  }
+
+  const result = await withBuildLock(
+    'webpack-build',
+    () =>
+      execCmd('yarn', ['workspace', '@onekeyhq/web', 'build'], {
+        cwd: repoRoot,
+        env: withRepoNodeBin(repoRoot, {
+          PERF_MONITOR_ENABLED: booleanEnv('PERF_WEB_RESIZE_FUNCTION_MONITOR')
+            ? '1'
+            : '0',
+        }),
+        timeoutMs: numberEnv('PERF_WEB_BUILD_TIMEOUT_MS', 30 * 60 * 1000),
+        killProcessGroup: true,
+        stdout: (data) => process.stdout.write(data),
+        stderr: (data) => process.stderr.write(data),
+      }),
+    { log },
+  );
+  if (result.code !== 0) {
+    throw new Error(formatExecResultError('web build', result, { outputDir }));
+  }
+}
+
+async function readGitMeta(repoRoot) {
+  const meta = {};
+  const sha = await execCmd('git', ['rev-parse', 'HEAD'], { cwd: repoRoot });
+  if (sha.code === 0) meta.sha = String(sha.stdout).trim();
+  const branch = await execCmd('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    cwd: repoRoot,
+  });
+  if (branch.code === 0) meta.branch = String(branch.stdout).trim();
+  return meta;
+}
+
+async function runOne({
+  runIndex,
+  scenarios,
+  transitionCount,
+  warmupTransitionCount,
+  webUrl,
+  readySelector,
+  businessReady,
+  readyTimeoutMs,
+  waitAfterReadyMs,
+  profileDir,
+  executablePath,
+  headless,
+  enableExtensions,
+  traceEnabled,
+  expectedBuildScripts,
+  outputDir,
+  log,
+}) {
+  if (headless && enableExtensions) {
+    throw new Error(
+      'Headless resize runs require PERF_WEB_DISABLE_EXTENSIONS=1',
+    );
+  }
+
+  const initialViewport = scenarios[0].sizes[0];
+  const context = await chromium.launchPersistentContext(profileDir, {
+    headless: enableExtensions ? false : headless,
+    executablePath,
+    viewport: initialViewport,
+    ignoreDefaultArgs: enableExtensions ? ['--disable-extensions'] : undefined,
+    args: [
+      '--no-first-run',
+      '--no-default-browser-check',
+      '--enable-precise-memory-info',
+      ...(enableExtensions ? [] : ['--disable-background-networking']),
+      '--disable-background-timer-throttling',
+      '--disable-renderer-backgrounding',
+      ...(process.env.PERF_WEB_EXTENSION_DIR
+        ? [
+            `--disable-extensions-except=${process.env.PERF_WEB_EXTENSION_DIR}`,
+            `--load-extension=${process.env.PERF_WEB_EXTENSION_DIR}`,
+          ]
+        : []),
+    ],
+  });
+  let cdp = null;
+  let stopTrace = null;
+  let tracePath = null;
+
+  try {
+    await context.addInitScript(installResizeObservers);
+    const page = context.pages()[0] || (await context.newPage());
+    const pageErrors = [];
+    const consoleErrors = [];
+    page.on('pageerror', (error) =>
+      pageErrors.push({
+        at: Date.now(),
+        message: error?.message || String(error),
+        stack: error?.stack || null,
+      }),
+    );
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        consoleErrors.push({
+          at: Date.now(),
+          text: message.text(),
+          location: message.location(),
+        });
+      }
+    });
+    // A persistent profile keeps the watch-only wallet state, but it also keeps
+    // PWA caches. Detach a restored page from any old controller and clear only
+    // Service Worker/network caches so a previous instrumented build cannot
+    // contaminate the production baseline. IndexedDB/localStorage stay intact.
+    await page.goto('about:blank');
+    cdp = await context.newCDPSession(page);
+    await cdp.send('Network.enable');
+    await cdp.send('Network.clearBrowserCache');
+    await cdp.send('Storage.clearDataForOrigin', {
+      origin: new URL(webUrl).origin,
+      storageTypes: 'service_workers,cache_storage',
+    });
+    await cdp.send('Network.disable');
+
+    await page.setViewportSize(initialViewport);
+    log(`run#${runIndex}: open ${webUrl}`);
+    await page.goto(webUrl, { waitUntil: 'domcontentloaded' });
+    const loadedBuildScripts = await page.evaluate(() =>
+      [...document.scripts]
+        .map((script) => script.src)
+        .filter(Boolean)
+        .map((source) => new URL(source).pathname.split('/').pop())
+        .filter(Boolean),
+    );
+    assertBuildScriptsLoaded({
+      expected: expectedBuildScripts,
+      loaded: loadedBuildScripts,
+    });
+    log(`run#${runIndex}: build identity verified`);
+    log(`run#${runIndex}: wait for ${readySelector}`);
+    let businessReadyStatus = null;
+    try {
+      await page.locator(readySelector).waitFor({
+        state: 'visible',
+        timeout: readyTimeoutMs,
+      });
+      businessReadyStatus = await waitForBusinessReady({
+        page,
+        businessReady,
+        timeoutMs: readyTimeoutMs,
+      });
+    } catch (error) {
+      const diagnosticPath = path.join(
+        outputDir,
+        `page-readiness-run-${runIndex}.json`,
+      );
+      const screenshotPath = path.join(
+        outputDir,
+        `page-readiness-run-${runIndex}.png`,
+      );
+      writeJson(diagnosticPath, {
+        url: page.url(),
+        title: await page.title().catch(() => null),
+        bodyText: await page
+          .locator('body')
+          .innerText({ timeout: 5000 })
+          .catch(() => null),
+        readySelector,
+        businessReady,
+        loadedBuildScripts,
+        pageErrors,
+        consoleErrors,
+      });
+      await page
+        .screenshot({ path: screenshotPath, fullPage: true })
+        .catch(() => {});
+      throw error;
+    }
+    await page.waitForTimeout(waitAfterReadyMs);
+    await cdp.send('Performance.enable');
+    if (traceEnabled) {
+      tracePath = path.join(outputDir, `chrome-trace-run-${runIndex}.json`);
+      stopTrace = await startBrowserTrace(cdp);
+    }
+
+    const scenarioResults = [];
+    for (const scenario of scenarios) {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await runScenario({
+        page,
+        cdp,
+        scenario,
+        transitionCount,
+        warmupTransitionCount,
+        log: (message) => log(`run#${runIndex}: ${message}`),
+      });
+      scenarioResults.push(result);
+    }
+
+    if (stopTrace) {
+      await stopTrace(tracePath);
+      stopTrace = null;
+    }
+
+    return {
+      runIndex,
+      tracePath,
+      loadedBuildScripts,
+      businessReadyStatus,
+      pageErrorCount: pageErrors.length,
+      consoleErrorCount: consoleErrors.length,
+      pageErrors,
+      consoleErrors,
+      scenarios: scenarioResults,
+    };
+  } finally {
+    if (stopTrace && tracePath) {
+      await stopTrace(tracePath).catch(() => {});
+    }
+    if (cdp) await cdp.detach().catch(() => {});
+    await context.close().catch(() => {});
+  }
+}
+
+async function main() {
+  const repoRoot = path.join(__dirname, '..', '..');
+  const localConfig = readPerfCiLocalConfig(repoRoot) || {};
+  const log = (...args) => {
+    // eslint-disable-next-line no-console
+    console.log('[perf:web:resize]', ...args);
+  };
+  const outputRoot =
+    process.env.PERF_JOB_OUTPUT_ROOT ||
+    path.join(repoRoot, 'development', 'perf-ci', 'output');
+  const jobId = process.env.PERF_JOB_ID || `web-resize-${nowId()}`;
+  const outputDir = path.join(outputRoot, jobId);
+  const buildDir =
+    process.env.PERF_WEB_BUILD_DIR ||
+    path.join(repoRoot, 'apps', 'web', 'web-build');
+  const profileDir =
+    process.env.PERF_WEB_PROFILE_DIR ||
+    localConfig.webProfileDir ||
+    path.join(os.homedir(), 'perf-profiles', 'web');
+  const thresholdsPath =
+    process.env.PERF_WEB_RESIZE_THRESHOLDS_PATH ||
+    path.join(
+      repoRoot,
+      'development',
+      'perf-ci',
+      'thresholds',
+      'web.resize.json',
+    );
+  const baselineReportPath =
+    process.env.PERF_WEB_RESIZE_BASELINE_REPORT || null;
+  const target = parseTarget();
+  const scenarios = parseScenarios(target.defaultScenarioNames);
+  const runCount = numberEnv('PERF_RUN_COUNT', 3);
+  const transitionCount = numberEnv('PERF_WEB_RESIZE_TRANSITIONS', 20);
+  const warmupTransitionCount = numberEnv(
+    'PERF_WEB_RESIZE_WARMUP_TRANSITIONS',
+    4,
+  );
+  const readySelector =
+    process.env.PERF_WEB_RESIZE_READY_SELECTOR || target.readySelector;
+  const readyTimeoutMs = numberEnv('PERF_WEB_RESIZE_READY_TIMEOUT_MS', 120_000);
+  const waitAfterReadyMs = numberEnv(
+    'PERF_WEB_RESIZE_WAIT_AFTER_READY_MS',
+    5000,
+  );
+  const enableExtensions = webExtensionsEnabled();
+  const headless = hasFlag('--headless');
+  const traceEnabled = booleanEnv('PERF_WEB_RESIZE_TRACE');
+  const cpuProfileEnabled = booleanEnv('PERF_WEB_RESIZE_CPU_PROFILE');
+  const functionMonitorEnabled = booleanEnv('PERF_WEB_RESIZE_FUNCTION_MONITOR');
+  const executablePath = findChromiumExecutable(
+    localConfig.chromeExecutablePath || null,
+  );
+
+  ensureDir(outputDir);
+  ensureDir(profileDir);
+
+  const meta = {
+    startedAt: new Date().toISOString(),
+    jobId,
+    targetKey: 'web.resize',
+    mode: 'release',
+    git: await readGitMeta(repoRoot),
+    web: {
+      buildDir,
+      profileDir,
+      executablePath,
+      headless,
+      enableExtensions,
+      target: target.name,
+      path: target.path,
+      readySelector,
+      businessReady: target.businessReady,
+    },
+    runCount,
+    transitionCount,
+    warmupTransitionCount,
+    scenarios: scenarios.map((scenario) => scenario.name),
+    traceEnabled,
+    cpuProfileEnabled,
+    functionMonitorEnabled,
+    baselineReportPath,
+    thresholdsPath,
+  };
+  writeJson(path.join(outputDir, 'job-meta.json'), {
+    status: 'running',
+    meta,
+  });
+
+  let staticServer = null;
+  try {
+    log('start', { jobId, outputDir });
+    if (!executablePath) {
+      throw new Error('Chromium/Chrome/Edge executable not found');
+    }
+    await buildWeb({ repoRoot, outputDir, log });
+    if (!fileExists(path.join(buildDir, 'index.html'))) {
+      throw new Error(`Web build output missing index.html: ${buildDir}`);
+    }
+    const expectedBuildScripts = scriptAssetNamesFromHtml(
+      fs.readFileSync(path.join(buildDir, 'index.html'), 'utf8'),
+    );
+    if (!expectedBuildScripts.length) {
+      throw new Error(
+        `Web build index contains no external scripts: ${buildDir}`,
+      );
+    }
+    meta.web.expectedBuildScripts = expectedBuildScripts;
+
+    staticServer = await startStaticServer({
+      rootDir: buildDir,
+      host: '127.0.0.1',
+      port:
+        Number(process.env.PERF_WEB_PORT) ||
+        Number(localConfig.webPort) ||
+        3123,
+      spaFallback: true,
+    });
+    const webUrl =
+      process.env.PERF_WEB_URL ||
+      new URL(target.path, `${staticServer.baseUrl}/`).toString();
+    meta.web.url = webUrl;
+    const runs = [];
+
+    for (let runIndex = 1; runIndex <= runCount; runIndex += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const run = await runOne({
+        runIndex,
+        scenarios,
+        transitionCount,
+        warmupTransitionCount,
+        webUrl,
+        readySelector,
+        businessReady: target.businessReady,
+        readyTimeoutMs,
+        waitAfterReadyMs,
+        profileDir,
+        executablePath,
+        headless,
+        enableExtensions,
+        traceEnabled,
+        expectedBuildScripts,
+        outputDir,
+        log,
+      });
+      runs.push(run);
+      writeJson(path.join(outputDir, 'runs.json'), { meta, runs });
+    }
+
+    const summary = aggregateResizeRuns(runs);
+    const thresholds = readJson(thresholdsPath);
+    const baselineReport = baselineReportPath
+      ? readJson(path.resolve(baselineReportPath))
+      : null;
+    const comparison = baselineReport
+      ? compareResizeSummaries({
+          current: summary,
+          baseline: baselineReport.summary,
+          thresholds,
+        })
+      : null;
+    const report = {
+      meta,
+      outputDir,
+      runs,
+      summary,
+      thresholds,
+      baselineReportPath,
+      comparison,
+    };
+    writeJson(path.join(outputDir, 'report.json'), report);
+    writeJson(path.join(outputDir, 'job-result.json'), {
+      status: comparison?.triggered ? 'regression' : 'ok',
+      reasons: comparison?.reasons || [],
+    });
+    writeJson(path.join(outputDir, 'job-meta.json'), {
+      status: comparison?.triggered ? 'regression' : 'ok',
+      meta: { ...meta, finishedAt: new Date().toISOString() },
+    });
+
+    log('summary', summary);
+    if (comparison?.triggered) {
+      log('comparison failed', comparison.reasons);
+      return 3;
+    }
+    log('report written', path.join(outputDir, 'report.json'));
+    return 0;
+  } catch (error) {
+    const message = error?.stack || error?.message || String(error);
+    writeJson(path.join(outputDir, 'job-error.json'), { error: message });
+    writeJson(path.join(outputDir, 'job-meta.json'), {
+      status: 'failed',
+      meta: { ...meta, finishedAt: new Date().toISOString() },
+    });
+    // eslint-disable-next-line no-console
+    console.error(message);
+    return 2;
+  } finally {
+    if (staticServer) await staticServer.close().catch(() => {});
+  }
+}
+
+module.exports = {
+  SCENARIOS,
+  TARGETS,
+  installResizeObservers,
+  main,
+  parseScenarios,
+  parseTarget,
+  readVisibleMarketColumns,
+  runScenario,
+  verifyScenarioFixture,
+  waitForBusinessReady,
+};
+
+if (require.main === module) {
+  main().then((code) => process.exit(code));
+}

--- a/development/perf-ci/run-web-resize-perf.test.js
+++ b/development/perf-ci/run-web-resize-perf.test.js
@@ -1,0 +1,60 @@
+const {
+  SCENARIOS,
+  TARGETS,
+  parseScenarios,
+  parseTarget,
+} = require('./run-web-resize-perf');
+
+describe('run-web-resize-perf configuration', () => {
+  const originalTarget = process.env.PERF_WEB_RESIZE_TARGET;
+  const originalScenarios = process.env.PERF_WEB_RESIZE_SCENARIOS;
+
+  afterEach(() => {
+    if (originalTarget === undefined) {
+      delete process.env.PERF_WEB_RESIZE_TARGET;
+    } else {
+      process.env.PERF_WEB_RESIZE_TARGET = originalTarget;
+    }
+    if (originalScenarios === undefined) {
+      delete process.env.PERF_WEB_RESIZE_SCENARIOS;
+    } else {
+      process.env.PERF_WEB_RESIZE_SCENARIOS = originalScenarios;
+    }
+  });
+
+  test('uses the Market list as the default resize target', () => {
+    delete process.env.PERF_WEB_RESIZE_TARGET;
+
+    expect(parseTarget()).toEqual(TARGETS['market-list']);
+    expect(parseScenarios(TARGETS['market-list'].defaultScenarioNames)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'market-control-lg' }),
+        expect.objectContaining({ name: 'market-cross-lg' }),
+      ]),
+    );
+  });
+
+  test('defines column-count assertions for both Market breakpoints', () => {
+    const byName = new Map(
+      SCENARIOS.map((scenario) => [scenario.name, scenario]),
+    );
+
+    expect(
+      byName.get('market-cross-lg').expectedVisibleMarketColumnCounts,
+    ).toEqual([8, 9]);
+    expect(
+      byName.get('market-cross-xl').expectedVisibleMarketColumnCounts,
+    ).toEqual([9, 11]);
+  });
+
+  test('keeps the previous Home target available explicitly', () => {
+    process.env.PERF_WEB_RESIZE_TARGET = 'home';
+    delete process.env.PERF_WEB_RESIZE_SCENARIOS;
+
+    const target = parseTarget();
+    expect(target).toEqual(TARGETS.home);
+    expect(
+      parseScenarios(target.defaultScenarioNames).map(({ name }) => name),
+    ).toEqual(['control-gt-md', 'cross-md']);
+  });
+});

--- a/development/perf-ci/thresholds/web.resize.json
+++ b/development/perf-ci/thresholds/web.resize.json
@@ -1,0 +1,50 @@
+{
+  "primaryMetric": "scriptDurationMs",
+  "minimumImprovementRatio": 0.1,
+  "maximumRegressionRatio": 0.05,
+  "guardMetrics": [
+    "taskDurationMs",
+    "recalcStyleDurationMs",
+    "layoutDurationMs",
+    "longTaskTotalMs",
+    "maxFrameDurationMs"
+  ],
+  "scenarios": {
+    "market-control-lg": {
+      "mode": "guard"
+    },
+    "market-cross-lg": {
+      "mode": "improve"
+    },
+    "market-control-xl": {
+      "mode": "guard"
+    },
+    "market-cross-xl": {
+      "mode": "improve"
+    },
+    "control-gt-md": {
+      "mode": "guard"
+    },
+    "cross-sm": {
+      "mode": "improve"
+    },
+    "cross-md": {
+      "mode": "improve"
+    },
+    "cross-2md": {
+      "mode": "improve"
+    },
+    "cross-lg": {
+      "mode": "improve"
+    },
+    "cross-xl": {
+      "mode": "improve"
+    },
+    "cross-2xl": {
+      "mode": "improve"
+    },
+    "cross-height": {
+      "mode": "improve"
+    }
+  }
+}

--- a/development/scripts/agent-check.js
+++ b/development/scripts/agent-check.js
@@ -122,6 +122,71 @@ function relativeLogPath(logPath) {
   return path.relative(process.cwd(), logPath);
 }
 
+function findRepoYarnPath() {
+  const yarnRc = fs.readFileSync(
+    path.join(process.cwd(), '.yarnrc.yml'),
+    'utf8',
+  );
+  const match = yarnRc.match(
+    /^\s*yarnPath:\s*(?:"([^"]+)"|'([^']+)'|(\S+))\s*$/m,
+  );
+  const configuredPath = match?.[1] || match?.[2] || match?.[3];
+  if (!configuredPath) {
+    throw new Error('Unable to resolve yarnPath from .yarnrc.yml');
+  }
+  const yarnPath = path.resolve(process.cwd(), configuredPath);
+  if (!fs.existsSync(yarnPath)) {
+    throw new Error(`Configured Yarn release does not exist: ${yarnPath}`);
+  }
+  return yarnPath;
+}
+
+function resolveCommandInvocation(command, args) {
+  if (process.platform !== 'win32') return { command, args };
+  if (command === 'yarn') {
+    return {
+      command: process.execPath,
+      args: [findRepoYarnPath(), ...args],
+    };
+  }
+  if ((command === 'npx' || command === 'npx.cmd') && args[0] === 'oxlint') {
+    return {
+      command: process.execPath,
+      args: [
+        path.join(process.cwd(), 'node_modules', 'oxlint', 'bin', 'oxlint'),
+        ...args.slice(1),
+      ],
+    };
+  }
+  return { command, args };
+}
+
+function commandEnvironment() {
+  if (process.platform !== 'win32') return process.env;
+  const candidates = [
+    path.join(
+      process.env.PROGRAMFILES || 'C:\\Program Files',
+      'Git',
+      'usr',
+      'bin',
+    ),
+    path.join(
+      process.env['PROGRAMFILES(X86)'] || 'C:\\Program Files (x86)',
+      'Git',
+      'usr',
+      'bin',
+    ),
+  ];
+  const gitUnixToolsDir = candidates.find((candidate) =>
+    fs.existsSync(path.join(candidate, 'grep.exe')),
+  );
+  if (!gitUnixToolsDir) return process.env;
+  return {
+    ...process.env,
+    PATH: `${gitUnixToolsDir}${path.delimiter}${process.env.PATH || ''}`,
+  };
+}
+
 function writeCommandLog(logDir, name, command, args, result, durationMs) {
   const fileName = `${name.replace(/[^a-zA-Z0-9._-]/g, '_')}.log`;
   const logPath = path.join(logDir, fileName);
@@ -129,6 +194,7 @@ function writeCommandLog(logDir, name, command, args, result, durationMs) {
     `$ ${[command, ...args].join(' ')}`,
     `exitCode: ${String(result.status)}`,
     `signal: ${result.signal || ''}`,
+    result.error ? `spawnError: ${result.error.message}` : '',
     `duration: ${formatDuration(durationMs)}`,
     '',
     '--- stdout ---',
@@ -157,8 +223,10 @@ function compactCommandResult(result) {
 
 function runCommand(logDir, name, command, args) {
   const startedAt = Date.now();
-  const result = spawnSync(command, args, {
+  const invocation = resolveCommandInvocation(command, args);
+  const result = spawnSync(invocation.command, invocation.args, {
     cwd: process.cwd(),
+    env: commandEnvironment(),
     encoding: 'utf8',
     maxBuffer: 1024 * 1024 * 50,
   });
@@ -166,8 +234,8 @@ function runCommand(logDir, name, command, args) {
   const logPath = writeCommandLog(
     logDir,
     name,
-    command,
-    args,
+    invocation.command,
+    invocation.args,
     result,
     durationMs,
   );
@@ -181,8 +249,8 @@ function runCommand(logDir, name, command, args) {
 
   return {
     name,
-    command,
-    args,
+    command: invocation.command,
+    args: invocation.args,
     ok,
     exitCode: result.status,
     signal: result.signal,

--- a/docs/performance/tamagui-web-performance-handoff.md
+++ b/docs/performance/tamagui-web-performance-handoff.md
@@ -1,0 +1,436 @@
+# Tamagui Web Performance Optimization Handoff
+
+## Session
+
+- Status: In progress
+- Started: 2026-07-13 20:01 +08:00
+- Last updated: 2026-07-14 00:32 +08:00
+- Worktree: `D:\Project\app-monorepo-tamagui-analysis`
+- Branch: `feat/tamagui-performance-analysis`
+- Baseline commit: `71432893052f677abbda7d9a1a488397c91a4eee`
+- Tamagui version: `1.108.0`
+- Runtime scope: Web main JavaScript runtime. The same renderer-side risks may apply to Desktop and Extension, but they require separate baselines before rollout.
+- Out of scope for this phase: React Native main/bg runtimes, native resources, wallet data flow, and a Tamagui version upgrade.
+
+## Objective
+
+Reduce Web Market-table viewport-resize jank and Tamagui runtime style-resolution cost, then enable measurable static style extraction in the default Rspack production build. The primary benchmark must keep the desktop shell stable and cross only a real list-column breakpoint; desktop/mobile shell replacement is tracked separately as a structural stress regression.
+
+The work is split into five ordered workstreams:
+
+1. Replace CSS-only `useMedia` decisions with responsive props and consolidate structural media decisions at layout boundaries.
+2. Remove avoidable `useStyle`, `usePropsAndStyle`, and `useProps` resolution passes from hot component paths.
+3. Provide a compiler-safe OneKey component entry that Tamagui can load without application side effects.
+4. Add one shared `tamagui.build.ts` configuration and deterministic generated CSS output.
+5. Integrate extraction into the default Web Rspack production build, then evaluate Desktop and Extension separately.
+
+## Current Evidence
+
+### Media fan-out
+
+- Explicit `useMedia()` calls: 351 across 308 files.
+- Package distribution: 317 in `packages/kit`, 34 in `packages/components`.
+- Key usage: `gtMd` 225, `md` 85, `gtLg` 23, `gtSm` 20, `gtXl` 20, plus less frequent keys.
+- The 768 px boundary flips both `md` and `gtMd` and replaces large parts of the page shell. It is therefore not a fair primary benchmark for list/style optimization and is retained only as a structural stress regression.
+- Tamagui has one `matchMedia` listener per configured query, but subscriber callbacks are broadcast and every styled component internally participates in media handling. Key tracking can avoid some React updates but does not remove callback and resolution overhead.
+
+### Corrected primary scenario: Market column resize
+
+- Route: `/market`, normal trending token list, Web main JavaScript runtime.
+- The page remains in `DesktopLayout` throughout the primary transition.
+- `useColumnsDesktop()` reads only `gtLg` and `gtXl` for responsive column membership.
+- Below 1024 px the normal list has 8 columns: star, name, price, 24h change, market cap, liquidity, turnover, and transactions.
+- Crossing 1024 px adds `uniqueTraders`, producing an 8 -> 9 column transition.
+- Crossing 1280 px adds `holders` and `tokenAge`, producing a 9 -> 11 column transition.
+- `TableRow` is memoized, but each row receives the complete `columns` array. Rebuilding that array at a breakpoint invalidates the memoized prop for every rendered row and reconstructs its cells.
+- Primary pair: control `984 <-> 1000` versus column transition `1016 <-> 1032`; both move 16 px and remain in the same desktop shell.
+- Secondary pair: control `1240 <-> 1256` versus column transition `1272 <-> 1288`.
+- The runner checks the unique visible `list-column-*` test IDs at both endpoints before timing. A count mismatch invalidates the run instead of silently measuring the wrong tab/category.
+
+### Historical Home structural stress baseline
+
+- Stable profile: `C:\Users\workboring\perf-profiles\web`.
+- Web mode: wallet mode, persisted only in the dedicated profile via `$onekey_web_dapp_mode=wallet`.
+- Account: public Ethereum watch-only address `0xF977814e90dA44bFA03b6295A0616a897441aceC`, named `Binance Hot Wallet 20 Perf`; no private key or recovery phrase was used.
+- Job: `web-resize-home-production-baseline-v2-20260713`.
+- Report: `development/perf-ci/output/web-resize-home-production-baseline-v2-20260713/report.json`.
+- Method: uninstrumented production build, Service Worker and Cache Storage cleared without clearing wallet data, current bundle identity verified, extensions disabled during measurement, headless Chrome, three runs, four warmups and 20 measured transitions per scenario.
+
+| Median-of-runs metric  | `control-gt-md` 780 <-> 850 | `cross-md` 760 <-> 780 | Cross/control ratio |
+| ---------------------- | --------------------------: | ---------------------: | ------------------: |
+| Settle median          |                    39.50 ms |              406.95 ms |              10.30x |
+| Scripting              |                   367.36 ms |            6,336.18 ms |              17.25x |
+| Recalculate style      |                    86.63 ms |            1,153.26 ms |              13.31x |
+| Layout                 |                    49.75 ms |              249.04 ms |               5.01x |
+| Long tasks             |                           0 |                     20 |                 n/a |
+| Long-task total        |                        0 ms |               6,483 ms |                 n/a |
+| Maximum frame          |                    17.30 ms |              416.60 ms |              24.08x |
+| Dropped-frame estimate |                           0 |                    416 |                 n/a |
+| Heap delta             |                   12.83 MiB |             153.66 MiB |              11.98x |
+
+The original formal job was invalidated after its CPU trace loaded old instrumented `main~14` chunks while the disk build contained `main~11`. The persistent PWA Service Worker was serving stale cached assets. The runner now clears only `service_workers`, `cache_storage`, and the network cache, preserves localStorage/IndexedDB wallet state, and fails if the scripts in the page do not match the current disk `index.html`.
+
+The v2 direction is consistent in all three runs and proves that the 768 px shell replacement is expensive. It must not be used as the comparison anchor for Market table/style work because the route and ownership are different. A clean three-run Market baseline is now required before retaining any new optimization.
+
+### Style-resolution chain
+
+- Observed hot chain: `createComponent -> useComponentState -> useThemeWithState -> useMedia -> useSplitStyles -> getSplitStyles -> propMapper/getStyleAtomic`.
+- `createComponent` has a deep hook chain and `getSplitStyles` recomputes substantial per-render state.
+- Existing caches are partial; there is no whole-result cache that makes repeated component resolution free.
+- A clean 1,056 ms two-transition CPU window attributes self time to Tamagui helpers including the anonymous `getSplitStyles` body (43.97 ms), `mergeProps` (17.79 ms), `mergeStyle` (16.04 ms), `isValidStyleKey` (13.97 ms), `propMapper` (11.93 ms), `getStyleObject` (10.63 ms), and `useSplitStyles` (9.86 ms). DOM measurement/removal and React reconciliation remain material alongside style resolution.
+- Project usage: `usePropsAndStyle` 19, `useStyle` 33, `useProps` 3.
+- A global cache inside Tamagui is not the first intervention because the returned object also contains current children/viewProps and correctness depends on theme, media, pseudo, group, animation, component state, and prop state. A cache must separate reusable style computation from current render props rather than memoizing the complete result.
+
+### Static extraction
+
+- Web defaults to Rspack and its JavaScript rule currently has no Tamagui loader/plugin.
+- The legacy Webpack configuration has `tamagui-loader`, with extraction disabled in development.
+- Direct imports from `tamagui` extract in a minimal compiler experiment.
+- Imports through `@onekeyhq/components/src/shared/tamagui` do not extract.
+- Registering the full OneKey components package is not compiler-safe because loading the package traverses non-static application dependencies.
+- Runtime atomic classes and CSS variables work today; component flattening, static prop removal, hook elimination, and generated external CSS are not broadly effective.
+- A compiler-safe manifest containing only the public identity aliases `Stack`, `XStack`, `YStack`, `ZStack`, `View`, and `ThemeableStack` successfully loads and a standalone `PortfolioContainer` experiment reports five matches, three optimizations, and two flattened nodes.
+- Broad Rspack extraction is not releasable: it produced 332 CSS files / 2.69 MiB and the app entered its caught unknown-error fallback.
+- A Home Portfolio allowlist was functionally loadable and limited output to six CSS files / 102,958 bytes, but `cross-md` style recalculation rose from 1,153.26 ms to 5,331.49 ms (+362%), long tasks rose from 20 to 60, and total task time regressed 49%. Extraction must therefore include CSS rule deduplication/merging and enough flatten coverage to offset browser media-rule invalidation before it is reconsidered.
+
+## Test Machine
+
+- OS: Windows
+- CPU: Intel Core i5-9400F, 6 cores / 6 logical processors
+- Memory: approximately 16 GB
+- Node: `v24.13.0`
+- Yarn: `4.12.0`
+- Primary browser: installed Google Chrome
+- Secondary browser: installed Microsoft Edge
+
+Because this machine has six logical processors, baseline and candidate runs must be made with unrelated browsers, IDE indexing, sync clients, and build jobs stopped. Power mode, browser version, browser profile, page data, and build mode must remain fixed.
+
+## Reproduction And Pass Conditions
+
+### Reproduction
+
+1. Use a production Web build with the stable perf profile.
+2. Open `/market` and wait for `__onekeyMarketListReadyCount > 0` plus the visible normal-list fixture.
+3. Verify 8 columns at 1016 px and 9 columns at 1032 px.
+4. Run the equal-distance `984 <-> 1000` control, then resize `1016 <-> 1032` 20 times.
+5. Capture a Chrome performance trace and aggregate browser metrics across at least three runs.
+
+### What Does Not Count As Passing
+
+- Dev-mode profiling alone.
+- A single run or a visually smoother result without trace data.
+- Fewer explicit `useMedia` calls without lower resize CPU/long-task cost.
+- Generated CSS existing without proof that a real OneKey component was flattened.
+- Improved resize metrics accompanied by startup, bundle, visual, hydration, focus, or interaction regressions.
+
+### Final Pass Condition
+
+- At least three controlled runs with median aggregation.
+- Primary Market column-resize scripting time improves by at least 10% for a retained change.
+- Important secondary metrics do not regress by more than 5%.
+- Results point in the same direction in at least two of three runs.
+- Functional breakpoint, theme, focus, dialog, and scrolling checks pass.
+- `yarn agent:check --profile commit` passes before commit.
+
+## Baseline Procedure
+
+Run from the analysis worktree:
+
+```powershell
+Set-Location D:\Project\app-monorepo-tamagui-analysis
+yarn install --immutable
+yarn perf:web:prepare --headed
+$env:PERF_JOB_ID = 'tamagui-baseline-release'
+yarn perf:web:release --headed
+yarn perf:web:cold
+```
+
+The release runner performs three runs and median aggregation. Outputs are written below `development/perf-ci/output/<job-id>/`.
+
+Preserve these artifacts for every accepted comparison:
+
+- `report.json`
+- `runs.json`
+- `derived/`
+- resize trace and summary JSON
+- commit SHA, browser version, scenario, and run count
+- initial JavaScript and CSS compressed sizes
+
+## Dedicated Resize Benchmark
+
+Implemented files:
+
+- `development/perf-ci/run-web-resize-perf.js`
+- `development/perf-ci/thresholds/web.resize.json`
+
+Primary Market scenarios:
+
+| Scenario            | Viewport transition | Expected visible columns | Purpose                                              |
+| ------------------- | ------------------- | -----------------------: | ---------------------------------------------------- |
+| `market-control-lg` | 984 <-> 1000        |                  8 <-> 8 | Equal-distance resize below the column breakpoint    |
+| `market-cross-lg`   | 1016 <-> 1032       |                  8 <-> 9 | Primary single-column change                         |
+| `market-control-xl` | 1240 <-> 1256       |                  9 <-> 9 | Equal-distance resize below the XL column breakpoint |
+| `market-cross-xl`   | 1272 <-> 1288       |                 9 <-> 11 | Secondary two-column change                          |
+
+Generic and structural regression scenarios:
+
+| Scenario                | Viewport transition | Purpose                                      |
+| ----------------------- | ------------------- | -------------------------------------------- |
+| `control-gt-md`         | 780 <-> 850         | Historical Home resize without crossing 768  |
+| `cross-md`              | 760 <-> 780         | Structural desktop/mobile shell stress only  |
+| `all-width-breakpoints` | boundary +/- 8 px   | Validate 640, 768, 896, 1024, 1280, and 1536 |
+| `cross-height`          | 812 <-> 828         | Validate the 820 px height media boundary    |
+
+Primary metrics:
+
+- resize settle duration
+- main-thread scripting duration
+- long-task count, total duration, and maximum duration
+- style recalculation, layout, and paint duration
+- maximum frame duration and dropped frames when available
+
+Diagnostic metrics:
+
+- `useMedia` callback activity
+- `getSplitStyles` and related style-resolution samples
+- React render/commit ownership in a profiling build
+
+Regression guards:
+
+- release Home metrics
+- cold entry metrics
+- initial JavaScript and CSS compressed size
+- peak and ending JavaScript heap
+
+## Experiment Rules
+
+1. Make one targeted change per iteration.
+2. Use the same production build path for baseline and candidate.
+3. Run at least three times and compare medians; use five runs for the short resize microbenchmark when practical.
+4. If median absolute deviation exceeds 10%, discard and rerun the experiment.
+5. Retain a change only when the primary metric improves by at least 10% and important secondary metrics remain within 5% of baseline.
+6. Document failed experiments and revert their code.
+7. Do not combine a Tamagui dependency upgrade with extraction integration.
+8. Do not patch `node_modules` or add a global `getSplitStyles` cache without a separate measured experiment and correctness model.
+
+## Workstream Plan
+
+### 1. Media subscriptions
+
+- Produce an AST-backed inventory with file, line, key, component, usage category, and expected mount multiplier.
+- Audit the ten unknown/broad uses first.
+- Prioritize repeated Home/list components using `md` and `gtMd`.
+- Convert style-only branches to Tamagui responsive props.
+- Consolidate structural decisions in a parent layout and pass a stable layout variant to children.
+- Change 10-20 call sites per batch and measure after each batch.
+
+Target for the first retained batch on Market:
+
+- at least 10% lower scripting time in `market-cross-lg`
+- at least 20% lower cumulative long-task duration when the baseline contains long tasks
+- fewer `TableRow`/column-cell renders in the profiling build
+- no more than 5% regression in `market-control-lg`
+
+### 2. Redundant style hooks
+
+- Classify all 55 project calls as required bridge/plain-element resolution, double Tamagui resolution, static token lookup, or dynamic measurement.
+- Start with repeated list/card primitives.
+- Pass original responsive props directly to the final Tamagui component where possible.
+- Hoist truly static definitions and only memoize after profiling demonstrates value.
+
+Target:
+
+- at least 20% lower cumulative `getSplitStyles` CPU in the target screen
+- at least 30% fewer hot-path style-hook calls
+- no more than 5% release/cold regression
+
+### 3. Compiler-safe component entry
+
+- Add a narrow entry that exports styled primitives and static variants only.
+- Do not import routes, stores, wallet services, native modules, animation setup, or broad business barrels.
+- Build the entry while preserving the form and metadata required by Tamagui 1.108.
+- Add a fixture containing tokens and a `$gtMd` prop.
+- Require compiler logs to show at least one optimized/flattened real OneKey component.
+
+### 4. Shared Tamagui build configuration
+
+- Add root `tamagui.build.ts` with config, components, generated CSS path, extraction mode, and diagnostics.
+- Import generated CSS once from the Web entry.
+- Keep extraction disabled in development during the initial rollout.
+- Verify deterministic regeneration and CSS side-effect retention.
+
+### 5. Rspack integration
+
+- Start with the compiler fixture and reproduce the legacy Webpack loader options in an isolated Rspack spike.
+- Verify loader order, source maps, compiler logs, and generated CSS processing.
+- Expand in order: fixture, one Home module, full Web build.
+- Baseline Desktop and Extension separately before applying the same integration.
+- If the 1.108 loader is incompatible, evaluate CLI precompilation or a separately measured Tamagui upgrade.
+
+## Functional Verification Matrix
+
+- Widths: 639/640, 767/768, 895/896, 1023/1024, 1279/1280, 1535/1536.
+- Heights: 819/820/821.
+- Themes: light and dark.
+- Inputs: mouse hover, no-hover, and coarse pointer where emulation is available.
+- Interactions: keyboard focus, scrolling, dialog/popover open and close, and layout transitions.
+- Rendering: screenshots before and after each boundary, hydration warnings, and style flashes.
+
+## Iteration Log
+
+### Iteration 0: Baseline and harness
+
+- Status: Complete; infrastructure and the stable three-run Home baseline passed.
+- Hypothesis: Existing release/cold tooling protects startup and bundle behavior, while a dedicated breakpoint-crossing trace is required to quantify the reported resize jank.
+- Environment setup:
+  - `yarn install --immutable` completed in 8 minutes 47 seconds with exit code 0.
+  - The optional Windows Bluetooth native package `@stoprocent/bluetooth-hci-socket` failed to build. It is outside the Web renderer path and did not fail installation.
+  - No existing `~/perf-profiles/web` or `~/perf-sessions` data was present.
+- Stable profile preparation:
+  - Installed browser control was used only to prepare the isolated perf profile.
+  - Switched the Web build from its default dapp mode to wallet mode in that profile; the application source and ordinary browser profile were not changed.
+  - Imported the public Ethereum address `0xF977814e90dA44bFA03b6295A0616a897441aceC` as a watch-only account named `Binance Hot Wallet 20 Perf`.
+  - Home loaded a large portfolio and activity history, making this a substantially more representative stress fixture than the onboarding smoke.
+- Infrastructure changes:
+  - Added Windows Chrome and Edge discovery to the shared Chromium helper.
+  - Made shared perf command execution invoke the repository Yarn release through Node on Windows, avoiding `.cmd` spawn failures with detached process trees.
+  - Replaced Web production postbuild `cp`/`bash` steps with a cross-platform Node script.
+  - Added `perf:web:resize`, resize metric aggregation, baseline comparison thresholds, tests, and documentation.
+- Failed setup attempts:
+  - `web-resize-smoke-20260713`: `spawn yarn ENOENT`; fixed by adding Windows Yarn resolution.
+  - `web-resize-smoke-20260713-2`: `.cmd` plus detached spawn returned `EINVAL`; fixed by invoking `.yarn/releases/yarn-4.12.0.cjs` through Node.
+  - `web-resize-smoke-20260713-3`: Rspack compiled successfully, then the Web package failed on Unix-only `cp`; fixed with `apps/web/scripts/postbuild.js`.
+- Successful resize smoke:
+  - Job: `web-resize-smoke-20260713-4`.
+  - Mode: production build output, isolated temporary profile, extensions disabled, headless Chrome.
+  - Scope: one run, two warmups, four measured transitions. This validates the harness and does not count as the Home baseline.
+  - `control-gt-md` scripting: 95.119 ms; long tasks: 0; median settle: 80.45 ms.
+  - `cross-md` scripting: 7519.998 ms; long tasks: 17 / 8207 ms total; median settle: 1818.95 ms.
+  - The 768 px boundary reproduced severe fan-out even on the onboarding route, but the temporary route, one-run sample, and 154 console errors prevent using these values as an optimization baseline.
+- Successful cold smoke:
+  - Production build output, root scenario, one run, non-fatal budget mode.
+  - FCP: 744 ms; first text: 731 ms; long tasks: 1651 ms total / 265 ms max / 12 count.
+  - Initial JavaScript raw/gzip/Brotli: 6.11 MiB / 1.60 MiB / 1.30 MiB.
+  - Existing budget misses: resource count 247/240, script count 197/175, decoded JavaScript 22.14/16.80 MiB, and initial raw JavaScript 6.11/6.00 MiB.
+- Successful real Home resize baseline:
+  - Provisional instrumented job: `web-resize-20260713-212600`. CPU sampling showed the function-hit logger itself consumed about 72 ms across two transitions, so this job is retained for diagnostics but is not the comparison anchor.
+  - The first formal job `web-resize-home-production-baseline-20260713` was later invalidated because its persistent Service Worker served stale instrumented chunks.
+  - Clean formal job: `web-resize-home-production-baseline-v2-20260713`.
+  - The formal runner defaults `PERF_MONITOR_ENABLED` to off; diagnostics can opt in with `PERF_WEB_RESIZE_FUNCTION_MONITOR=1`.
+  - Each run clears only PWA/network caches, verifies current disk bundle names, and preserves the watch-only wallet state.
+  - Three runs, four warmups, 20 measured transitions, extensions disabled during measurement.
+  - `control-gt-md`: scripting 367.36 ms; recalculate style 86.63 ms; long tasks 0; median settle 39.50 ms; heap delta 12.83 MiB.
+  - `cross-md`: scripting 6,336.18 ms; recalculate style 1,153.26 ms; long tasks 20 / 6,483 ms total; median settle 406.95 ms; heap delta 153.66 MiB.
+- Verification:
+  - Eleven focused Jest tests pass across Chromium discovery, Windows command resolution, build identity, aggregation, and comparison logic.
+  - Node syntax checks and `git diff --check` pass.
+  - `yarn agent:check --profile commit` passes: worktree JavaScript lint, staged lint command, and staged TypeScript check are all green.
+  - A complete Rspack production rebuild passed with the existing 72 warnings, and the cross-platform Node postbuild copied all expected files successfully.
+- Baseline job: Complete for the Home structural stress case only. It remains the anchor for that historical case; the Market list comparison anchor is pending Iteration 3.
+- Result: Harness validated and the reported breakpoint problem reproduced on a real, data-heavy Home screen. No production component has been optimized yet.
+
+### Iteration 1: Media subscription boundary
+
+- Status: Rejected and reverted.
+- Job: `web-resize-home-media-boundary-candidate-20260713`.
+- Change: Move the Home `md` subscription from `HomePageView` to the TabBar child; merge NavigationBar's two media subscriptions; remove one unused and two redundant Home media reads.
+- Result: `cross-md` scripting improved from 6,336.18 ms to 6,038.21 ms (4.70%), below the 10% retention threshold. Control scripting regressed 3.36% and one control run contained a 33.2 ms maximum-frame outlier.
+- Verdict: The direction supports shrinking media ownership, but this batch is too small to retain as a performance change.
+
+### Iteration 2: Tamagui static extraction
+
+- Status: Rejected and reverted.
+- Broad experiment:
+  - A compiler-safe six-primitive component manifest and a Base64URL Rspack adapter made real first-party flattening compile.
+  - The build emitted 332 CSS files / 2.69 MiB and the application entered its caught unknown-error fallback before Home readiness.
+- Home Portfolio allowlist:
+  - Job: `web-resize-home-targeted-extraction-candidate-20260713`.
+  - The app reached Home and CSS was limited to six files / 102,958 bytes.
+  - `cross-md` scripting improved only 0.75% (6,288.48 ms), while recalculation rose 362% (5,331.49 ms), task duration rose 49% (12,615.13 ms), long-task total rose 75% (11,324 ms), and long-task count rose from 20 to 60.
+- Verdict: Generated CSS alone is not proof of optimization. Per-chunk duplicated atomic/media rules can move work from JavaScript into more expensive browser style invalidation. Do not re-enable extraction until CSS is globally deduplicated/merged and flatten coverage plus functional semantics are measured together.
+
+### Iteration 3: Benchmark correction to Market responsive columns
+
+- Status: Harness and clean production baseline complete.
+- Reason: The prior `760 <-> 780` Home case crosses the desktop/mobile ownership boundary and replaces the navigation, header, and content structure. It is useful as a worst-case regression but is not an accurate primary measure of list/Tamagui style work.
+- Target: `/market`, normal trending token list, stable desktop shell.
+- Primary scenario: `market-control-lg` (`984 <-> 1000`, 8 columns) versus `market-cross-lg` (`1016 <-> 1032`, 8 <-> 9 columns).
+- Secondary scenario: `market-control-xl` (`1240 <-> 1256`, 9 columns) versus `market-cross-xl` (`1272 <-> 1288`, 9 <-> 11 columns).
+- Fixture guard: Before trace collection, the harness enumerates unique visible `list-column-*` cells and fails if the expected endpoint counts do not match.
+- Source evidence: `useColumnsDesktop()` reconstructs the full column array when `gtLg` or `gtXl` changes. The memoized `TableRow` receives that array, so all rendered rows receive a changed prop and rebuild their cell children.
+- Compatibility: `PERF_WEB_RESIZE_TARGET=home` preserves the old Home benchmark explicitly; it is no longer the default.
+- Smoke job: `web-resize-market-smoke-20260713`; the real fixture reported 50 rows and verified `8 -> 8` for the control plus `8 -> 9` for the primary transition.
+- Formal baseline job: `web-resize-market-production-baseline-20260713`.
+- Formal report: `development/perf-ci/output/web-resize-market-production-baseline-20260713/report.json`.
+- Method: clean production build, current bundle identity verified, three runs, four warmups, 20 measured transitions, extensions disabled, headless Chrome.
+
+| Median-of-runs metric  | `market-control-lg` 984 <-> 1000 | `market-cross-lg` 1016 <-> 1032 | Cross/control ratio |
+| ---------------------- | -------------------------------: | ------------------------------: | ------------------: |
+| Settle median          |                         45.40 ms |                       277.90 ms |               6.12x |
+| Scripting              |                        384.52 ms |                     3,926.36 ms |              10.21x |
+| Recalculate style      |                        158.09 ms |                       991.58 ms |               6.27x |
+| Task duration          |                      1,046.22 ms |                     5,839.67 ms |               5.58x |
+| Long tasks             |                                0 |                              23 |                 n/a |
+| Long-task total        |                             0 ms |                        4,203 ms |                 n/a |
+| Maximum frame          |                         33.30 ms |                       300.00 ms |               9.01x |
+| Dropped-frame estimate |                                1 |                             265 |                265x |
+
+- Per-run cross scripting was 3,886.02 / 3,957.68 / 3,926.36 ms, showing low variance and the same direction in all runs.
+- All runs loaded 50 rows and had zero uncaught page errors. Repeated resource cancellation/404 console messages remain in the realistic workload; timings were nevertheless stable.
+- CPU diagnostic job: `web-resize-market-clean-cpu-20260713`, two measured transitions with a 985.41 ms marked window.
+- In that window the Tamagui bundle (`16428`) accounted for 439.65 ms self time (44.6% of the window), versus 118.07 ms in the React bundle. Leading Tamagui samples included the anonymous `getSplitStyles` body, `getStylesAtomic`, `useSplitStyles`, `resolveVariants`, `mergeProps`, `mergeStyle`, `resolveTokensAndVariants`, `normalizeStyle`, `isValidStyleKey`, and `useMedia`.
+- Conclusion: the first candidate should stabilize column descriptor identity and prevent unchanged cells from rerendering. Keeping all responsive columns mounted is only acceptable if measurement proves that its extra DOM and style work is cheaper; it must not be assumed.
+
+### Iteration 4: Stable descriptors and memoized table cells
+
+- Status: Retained in the worktree; production comparison passed.
+- Baseline: `web-resize-market-production-baseline-20260713`.
+- Retained candidate: `web-resize-market-memo-cells-candidate-20260714`.
+- Change:
+  - Build all eligible Market column descriptors independently of `gtLg`/`gtXl`, then filter the returned descriptor list by the active breakpoint. Unchanged columns preserve object identity.
+  - Extract the cell body from `TableRow` into `MemoTableCell`. When the breakpoint adds a column, the existing cells receive the same `column`, `item`, `index`, and skeleton props and skip reconstruction.
+  - Continue mounting only the real 8, 9, or 11 visible columns. No hidden responsive cell trees are added to the DOM.
+
+| Median-of-runs metric  | Baseline `market-cross-lg` | Retained candidate | Change |
+| ---------------------- | -------------------------: | -----------------: | -----: |
+| Settle median          |                  277.90 ms |          124.70 ms | -55.1% |
+| Scripting              |                3,926.36 ms |          894.80 ms | -77.2% |
+| Recalculate style      |                  991.58 ms |          903.81 ms |  -8.9% |
+| Task duration          |                5,839.67 ms |        2,534.49 ms | -56.6% |
+| Long tasks             |                         23 |                 10 | -56.5% |
+| Long-task total        |                   4,203 ms |             644 ms | -84.7% |
+| Maximum frame          |                  300.00 ms |          100.10 ms | -66.6% |
+| Dropped-frame estimate |                        265 |                 79 | -70.2% |
+
+- The equal-distance control also improved: scripting 384.52 -> 325.52 ms (-15.3%), task duration -18.9%, recalculation -10.5%, layout -7.4%, and maximum frame 33.3 -> 17.6 ms. Candidate cross-layout time changed by +0.8%, inside the 5% guard.
+- The comparison runner reported no triggered thresholds. The primary scripting improvement exceeded the 10% retention requirement and all configured guards passed.
+- Secondary XL job: `web-resize-market-memo-cells-xl-20260714`. All three runs verified 9 -> 11 columns. `market-cross-xl` scripting was 1,190.13 ms, with 10 long tasks / 986 ms total and a 116.7 ms maximum frame. There is no clean pre-change XL baseline, so this is functional/stress evidence, not a before/after claim.
+- Cold Market run used the same production candidate build. Median FCP was 904 ms, business/list readiness 3,711 ms, and long-task total 1,662 ms; all configured cold and initial-bundle budgets passed. There is no clean pre-change Market cold baseline, so this only rules out a gross budget regression.
+- Functional production checks verified exact 8 -> 9 column counts, 0 px maximum header/row alignment difference, no horizontal overflow at either endpoint, and token-name navigation to the expected `/market/token/...` route. The destination detail screen then emitted account/network-context errors, so the list click-through chain passed but the detail screen is not claimed as a full end-to-end pass.
+
+Rejected alternatives:
+
+1. `web-resize-market-stable-columns-candidate-20260713` kept all 11 columns mounted and used Tamagui responsive visibility. Cross scripting regressed 24.3%, recalculation 20.2%, long-task total 37.3%, and maximum frame 22.2%. Reverted.
+2. `web-resize-market-native-css-columns-candidate-20260713` kept all 11 columns mounted and used native CSS media classes. Cross scripting regressed 26.7%, recalculation 32.5%, layout 185.9%, long-task total 63.1%, and maximum frame 61.1%. Reverted.
+
+Verdict: Stable object identity plus memoized unchanged cells is substantially cheaper than keeping hidden cell trees mounted. The remaining cross-LG cost is now dominated more by style recalculation for the newly inserted column and surrounding responsive system than by rebuilding all existing cell content.
+
+## Current Next Actions
+
+1. Complete the final focused tests, `agent:check`, and diff review for the retained descriptor/cell change; do not commit until explicitly requested.
+2. Add React Profiler or development-only render counters in a separate diagnostic build to quantify skipped existing-cell renders. Do not ship the instrumentation.
+3. Capture a clean pre-change XL baseline only if the 1280 px transition becomes a release gate; the current XL run proves function and stress behavior but not improvement.
+4. Verify sorting plus keyboard focus on the Market list. The existing production check covers column counts, alignment, horizontal overflow, and click routing.
+5. Treat `cross-md` as a separate structural project for `TabPageHeader` and `NavigationBar`; do not combine it with Market list iterations.
+6. Build an offline extraction prototype that emits one globally deduplicated stylesheet and a manifest of flattened source locations. Do not integrate it until it proves lower style recalculation on the corrected Market benchmark.
+7. If pursuing Tamagui caching, split cacheable style computation from current `viewProps`/children and key it on theme, exact media keys, pseudo/group/animation/component state, and prop values. Add upstream-level correctness tests before benchmarking.
+
+## Handoff Checklist
+
+When another engineer or agent continues this work:
+
+1. Read this document and `CLAUDE.md`.
+2. Confirm the worktree, branch, and clean Git status.
+3. Do not modify application components until Iteration 0 has a recorded baseline.
+4. Continue the iteration log with job IDs, session IDs, median metrics, deltas, verdict, and retained/reverted status.
+5. Run `yarn agent:check --profile commit` before committing retained changes.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "perf:android:release:daemon": "node development/perf-ci/run-android-perf-detox-release-daemon.js",
     "perf:web:release": "node development/perf-ci/run-web-perf-release.js",
     "perf:web:release:daemon": "node development/perf-ci/run-web-perf-release-daemon.js",
+    "perf:web:resize": "node development/perf-ci/run-web-resize-perf.js",
     "perf:web:cold": "node development/perf-ci/run-web-cold.js",
     "perf:web:cold:entries": "cross-env PERF_WEB_COLD_SCENARIOS=entries PERF_WEB_COLD_BUDGET_FAIL=0 node development/perf-ci/run-web-cold.js",
     "perf:web:prepare": "node development/perf-ci/run-web-perf-prepare.js",

--- a/packages/components/src/composite/Table/index.tsx
+++ b/packages/components/src/composite/Table/index.tsx
@@ -33,7 +33,7 @@ import { useTabNameContextSafe } from '../Tabs/TabNameContext';
 
 import { Column, MemoHeaderColumn } from './components';
 
-import type { ITableProps } from './types';
+import type { ITableColumn, ITableProps } from './types';
 import type { IListViewRef } from '../../layouts';
 import type {
   IRenderItemParams,
@@ -99,6 +99,45 @@ const renderContent = (text?: string) => (
     {text ?? '-'}
   </SizableText>
 );
+
+function TableCell<T>({
+  column,
+  index,
+  item,
+  showSkeleton,
+}: {
+  column: ITableColumn<T>;
+  index: number;
+  item: T;
+  showSkeleton: boolean;
+}) {
+  const {
+    dataIndex,
+    align,
+    render = renderContent,
+    renderSkeleton,
+    columnWidth = 40,
+    columnProps,
+  } = column;
+  return (
+    <Column
+      name={dataIndex}
+      align={align}
+      width={columnWidth}
+      {...(columnProps as any)}
+    >
+      {showSkeleton
+        ? renderSkeleton?.()
+        : render(
+            (item as Record<string, string>)[dataIndex] as unknown as string,
+            item,
+            index,
+          )}
+    </Column>
+  );
+}
+
+const MemoTableCell = memo(TableCell) as typeof TableCell;
 
 function TableRow<T>({
   columns,
@@ -251,32 +290,14 @@ function TableRow<T>({
         if (!column) {
           return null;
         }
-        const {
-          dataIndex,
-          align,
-          render = renderContent,
-          renderSkeleton,
-          columnWidth = 40,
-          columnProps,
-        } = column;
         return (
-          <Column
-            key={dataIndex}
-            name={dataIndex}
-            align={align}
-            width={columnWidth}
-            {...(columnProps as any)}
-          >
-            {showSkeleton
-              ? renderSkeleton?.()
-              : render(
-                  (item as Record<string, string>)[
-                    dataIndex
-                  ] as unknown as string,
-                  item,
-                  index,
-                )}
-          </Column>
+          <MemoTableCell
+            key={column.dataIndex}
+            column={column}
+            item={item}
+            index={index}
+            showSkeleton={showSkeleton}
+          />
         );
       })}
     </XStack>

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenColumns/useColumnsDesktop.tsx
@@ -162,9 +162,9 @@ export const useColumnsDesktop = (
 ): ITableColumn<IMarketToken>[] => {
   const { gtLg, gtXl } = useMedia();
   const intl = useIntl();
+  const watchlistNameWidth = isWatchlistMode && gtLg ? 340 : 260;
 
-  return useMemo<ITableColumn<IMarketToken>[]>(() => {
-    const watchlistNameWidth = gtLg ? 340 : 260;
+  const allColumns = useMemo<ITableColumn<IMarketToken>[]>(() => {
     const shouldRenderRichCell = (index?: number) =>
       !shouldUseLightweightCell(index, deferRichRowAfterIndex);
 
@@ -455,7 +455,7 @@ export const useColumnsDesktop = (
               </YStack>
             ),
           },
-      gtLg && !isWatchlistMode
+      !isWatchlistMode
         ? {
             title: intl.formatMessage({ id: ETranslations.dexmarket_traders }),
             dataIndex: 'uniqueTraders',
@@ -471,7 +471,7 @@ export const useColumnsDesktop = (
             renderSkeleton: () => <Skeleton width={60} height={16} />,
           }
         : undefined,
-      gtXl && !isWatchlistMode
+      !isWatchlistMode
         ? {
             title: intl.formatMessage({ id: ETranslations.dexmarket_holders }),
             dataIndex: 'holders',
@@ -487,7 +487,7 @@ export const useColumnsDesktop = (
             renderSkeleton: () => <Skeleton width={60} height={16} />,
           }
         : undefined,
-      gtXl && !isWatchlistMode && !hideTokenAge
+      !isWatchlistMode && !hideTokenAge
         ? {
             title: intl.formatMessage({
               id: ETranslations.dexmarket_token_age,
@@ -528,8 +528,6 @@ export const useColumnsDesktop = (
     change24hColumnTitle,
     copyFrom,
     deferRichRowAfterIndex,
-    gtLg,
-    gtXl,
     hasStock,
     hiddenDesktopColumns,
     hideTokenAge,
@@ -538,6 +536,21 @@ export const useColumnsDesktop = (
     networkId,
     showStockSubtitle,
     useStockMetadataColumns,
+    watchlistNameWidth,
     watchlistFrom,
   ]);
+
+  return useMemo(
+    () =>
+      allColumns.filter((column) => {
+        if (column.dataIndex === 'uniqueTraders') {
+          return gtLg;
+        }
+        if (column.dataIndex === 'holders' || column.dataIndex === 'tokenAge') {
+          return gtXl;
+        }
+        return true;
+      }),
+    [allColumns, gtLg, gtXl],
+  );
 };


### PR DESCRIPTION
## What changed

- Keep Market desktop column descriptors stable across the `gtLg` and `gtXl` breakpoints, then filter only the active 8/9/11-column set.
- Extract table cell rendering into a memoized `MemoTableCell`, allowing unchanged cells to skip React and Tamagui style resolution when a responsive column is added.
- Add a production Market resize benchmark with equal-distance controls, visible-column fixture assertions, stale-build detection, thresholds, and aggregation.
- Add Windows support for browser discovery, repository Yarn process spawning, agent checks, and the Web postbuild step.
- Document the investigation, rejected alternatives, benchmark procedure, and follow-up work in the Tamagui performance handoff.

## Why

The previous `md` resize case replaced the desktop/mobile shell, so it was not a fair measure of Market list performance. The corrected benchmark keeps the desktop shell stable and measures the real 8 -> 9 column transition around 1024 px.

At the breakpoint, `useColumnsDesktop()` previously rebuilt every column descriptor. Each memoized row received a new columns array and reconstructed every existing cell, causing repeated React work and deep Tamagui style resolution.

## Impact

Production build, three-run median, 20 measured transitions per scenario:

| Metric | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| Scripting | 3,926 ms | 895 ms | -77.2% |
| Main-thread task duration | 5,840 ms | 2,534 ms | -56.6% |
| Long-task total | 4,203 ms | 644 ms | -84.7% |
| Maximum frame | 300 ms | 100 ms | -66.6% |
| Dropped-frame estimate | 265 | 79 | -70.2% |
| Style recalculation | 992 ms | 904 ms | -8.9% |

The equal-distance non-breakpoint control scripting time also improved by 15.3%. Visible behavior remains 8 columns below 1024 px, 9 columns at `gtLg`, and 11 columns at `gtXl`. Hidden columns are not kept mounted.

## Validation

- `yarn agent:check --profile commit`
- 8 focused Jest suites, 103 tests
- Production three-run Market control/cross comparison
- XL 9 -> 11 column stress run
- Market cold-start and initial bundle budgets
- Exact visible column counts, header/row alignment, horizontal overflow, and token-route click-through checks
- `git diff --check`

Two alternatives that kept all 11 cells mounted using Tamagui responsive props or native CSS media classes were measured, regressed performance, and were reverted.