### PR TITLE
fix: serialize WalletConnect connect attempts and scope terminal events (review fixes round 2 for #12424)

### DIFF
--- a/packages/kit-bg/src/services/ServiceWalletConnect/WalletConnectDappSide.ts
+++ b/packages/kit-bg/src/services/ServiceWalletConnect/WalletConnectDappSide.ts
@@ -46,6 +46,7 @@ import type { IBackgroundApi } from '../../apis/IBackgroundApi';
 import type { IDBExternalAccount } from '../../dbs/local/types';
 
 type IWalletConnectConnectAttempt = {
+  attemptId: number;
   cancelError?: OneKeyWalletConnectModalCloseError;
   provider?: WalletConnectDappSideProvider;
   rejectCancellation?: (error: OneKeyWalletConnectModalCloseError) => void;
@@ -371,16 +372,17 @@ export class WalletConnectDappSide {
     }, delay);
   }
 
-  openModal({ uri }: { uri: string }) {
+  openModal({ uri, attemptId }: { uri: string; attemptId?: number }) {
     // emit event
     appEventBus.emit(EAppEventBusNames.WalletConnectOpenModal, {
       uri,
+      attemptId,
     });
   }
 
-  closeModal() {
-    // emit event
-    appEventBus.emit(EAppEventBusNames.WalletConnectCloseModal, undefined);
+  closeModal(params?: { attemptId?: number }) {
+    // emit event; omitting attemptId means a wildcard close
+    appEventBus.emit(EAppEventBusNames.WalletConnectCloseModal, params);
   }
 
   async activateSession({ topic }: { topic: string }) {
@@ -406,7 +408,7 @@ export class WalletConnectDappSide {
       attempt.rejectCancellation?.(attempt.cancelError);
     }
 
-    this.closeModal();
+    this.closeModal({ attemptId: attempt.attemptId });
     try {
       // best-effort SDK-side cleanup; the attempt is already rejected above,
       // so a provider failure here must not reject the abort call itself
@@ -417,8 +419,16 @@ export class WalletConnectDappSide {
     return true;
   }
 
+  connectToWalletGeneration = 0;
+
   async connectToWallet({ impl }: IWalletConnectConnectToWalletParams) {
     console.log('WalletConnectDappSide connectToWallet111');
+
+    // Serialize the supersede transition: every call claims a generation
+    // synchronously; after any await, only the latest generation may install
+    // its attempt, so concurrent retries cannot leave two attempts running.
+    this.connectToWalletGeneration += 1;
+    const generation = this.connectToWalletGeneration;
 
     // Cancel any superseded attempt before replacing it, so its pending
     // connect() cannot re-emit display_uri or tear down this newer
@@ -430,8 +440,15 @@ export class WalletConnectDappSide {
         console.error('abort superseded connect attempt error: ', error);
       }
     }
+    if (generation !== this.connectToWalletGeneration) {
+      // A newer connectToWallet call arrived while awaiting the abort;
+      // yield to it instead of racing two live attempts.
+      throw new OneKeyWalletConnectModalCloseError({ autoToast: false });
+    }
 
-    const attempt: IWalletConnectConnectAttempt = {};
+    const attempt: IWalletConnectConnectAttempt = {
+      attemptId: generation,
+    };
     this.activeConnectAttempt = attempt;
     this.closeModal();
 
@@ -505,7 +522,7 @@ export class WalletConnectDappSide {
         console.log('uri', uri.split('?')[0]);
         if (attempt.cancelError) return;
         attempt.uri = uri;
-        this.openModal({ uri });
+        this.openModal({ uri, attemptId: attempt.attemptId });
       };
 
       sessionDeleteHandler = async (
@@ -626,7 +643,7 @@ export class WalletConnectDappSide {
       // attempt settling late (e.g. proposal expiry minutes later) must not
       // tear down the newer attempt's modal and main-runtime payload store.
       if (isCurrentAttempt) {
-        this.closeModal();
+        this.closeModal({ attemptId: attempt.attemptId });
       }
     }
   }

--- a/packages/kit/src/components/WalletConnect/WalletConnectModal.native.tsx
+++ b/packages/kit/src/components/WalletConnect/WalletConnectModal.native.tsx
@@ -333,6 +333,7 @@ const modal: IWalletConnectModalShared = {
     const isClosingProgrammaticallyRef = useRef(false);
     const isAwaitingMobileWalletApprovalRef = useRef(false);
     const activePairingUriRef = useRef('');
+    const activeAttemptIdRef = useRef<number | undefined>(undefined);
 
     useEffect(
       () => () => {
@@ -389,58 +390,68 @@ const modal: IWalletConnectModalShared = {
     const [shouldRenderNativeModal, setShouldRenderNativeModal] =
       useState(false);
 
-    const openModal = useCallback(async ({ uri }: { uri: string }) => {
-      isAwaitingMobileWalletApprovalRef.current = false;
-      const requestId = openRequestIdRef.current + 1;
-      openRequestIdRef.current = requestId;
-      await resetAppKit();
-      if (!isMountedRef.current || requestId !== openRequestIdRef.current) {
-        return;
-      }
-      pairingUri = uri;
-      activePairingUriRef.current = uri;
-      updateConnectModalUri(uri);
-
-      // TODO use custom provider from bg make QRCode Modal not open automatically
-      // ClientCtrl.setProvider({} as any);
-      // // resetApp(); // onSessionDelete
-      // ClientCtrl.setInitialized(true);
-
-      if (!isMountedRef.current) return;
-      setShouldRenderNativeModal(true);
-
-      // try {
-      //   await nativeProviderRef.current?.disconnect();
-      // } catch (error) {
-      //   console.error(error);
-      // }
-
-      await timerUtils.wait(600); // wait modal render done
-
-      if (!isMountedRef.current || requestId !== openRequestIdRef.current) {
-        return;
-      }
-
-      console.log(
-        'WalletConnectModalContainer openNativeModalRef: ------------------------ ',
-      );
-      await openNativeModalRef.current({
-        view: 'Connect',
-      }); // show modal
-
-      if (isMountedRef.current && requestId !== openRequestIdRef.current) {
-        isClosingProgrammaticallyRef.current = true;
-        try {
-          await closeNativeModalRef.current();
-        } finally {
-          isClosingProgrammaticallyRef.current = false;
+    const openModal = useCallback(
+      async ({ uri, attemptId }: { uri: string; attemptId?: number }) => {
+        isAwaitingMobileWalletApprovalRef.current = false;
+        const requestId = openRequestIdRef.current + 1;
+        openRequestIdRef.current = requestId;
+        await resetAppKit();
+        if (!isMountedRef.current || requestId !== openRequestIdRef.current) {
+          return;
         }
-      }
+        pairingUri = uri;
+        updateConnectModalUri(uri);
 
-      // await openNativeModal({
-      //   route: 'ConnectWallet',
-      // });
-    }, []);
+        // TODO use custom provider from bg make QRCode Modal not open automatically
+        // ClientCtrl.setProvider({} as any);
+        // // resetApp(); // onSessionDelete
+        // ClientCtrl.setInitialized(true);
+
+        if (!isMountedRef.current) return;
+        setShouldRenderNativeModal(true);
+
+        // try {
+        //   await nativeProviderRef.current?.disconnect();
+        // } catch (error) {
+        //   console.error(error);
+        // }
+
+        await timerUtils.wait(600); // wait modal render done
+
+        if (!isMountedRef.current || requestId !== openRequestIdRef.current) {
+          return;
+        }
+
+        console.log(
+          'WalletConnectModalContainer openNativeModalRef: ------------------------ ',
+        );
+        await openNativeModalRef.current({
+          view: 'Connect',
+        }); // show modal
+
+        if (isMountedRef.current && requestId !== openRequestIdRef.current) {
+          isClosingProgrammaticallyRef.current = true;
+          try {
+            await closeNativeModalRef.current();
+          } finally {
+            isClosingProgrammaticallyRef.current = false;
+          }
+          return;
+        }
+
+        // The modal now shows this pairing. Attribute user closes and
+        // modal-state transitions to it only from this point, so a stale
+        // close from the previous modal keeps blaming the previous attempt
+        // and cannot cancel or clear the one still opening.
+        activePairingUriRef.current = uri;
+        activeAttemptIdRef.current = attemptId;
+
+        // await openNativeModal({
+        //   route: 'ConnectWallet',
+        // });
+      },
+      [],
+    );
 
     const closeModal = useCallback(async () => {
       openRequestIdRef.current += 1;
@@ -467,6 +478,7 @@ const modal: IWalletConnectModalShared = {
           if (!isMountedRef.current) return;
           appEventBus.emit(EAppEventBusNames.WalletConnectModalState, {
             open: isNativeModalOpen,
+            attemptId: activeAttemptIdRef.current,
           });
         }
       })();

--- a/packages/kit/src/components/WalletConnect/WalletConnectModal.tsx
+++ b/packages/kit/src/components/WalletConnect/WalletConnectModal.tsx
@@ -91,56 +91,68 @@ const modal: IWalletConnectModalShared = {
     // const modalRef0 = useRef<WalletConnectModal | null>(null);
     const modalRef = useRef<AppKit | null>(null);
     const uriRef = useRef<string | undefined>(undefined);
-    const openModal = useCallback(async ({ uri }: { uri: string }) => {
-      uriRef.current = uri;
-      const tamaguiWebFontFamily = webFontFamily;
-      if (!modalRef.current) {
-        // modalRef.current = new WalletConnectModal({
-        //   projectId: WALLET_CONNECT_V2_PROJECT_ID,
+    const attemptIdRef = useRef<number | undefined>(undefined);
+    const openModal = useCallback(
+      async ({ uri, attemptId }: { uri: string; attemptId?: number }) => {
+        uriRef.current = uri;
+        attemptIdRef.current = attemptId;
+        const tamaguiWebFontFamily = webFontFamily;
+        if (!modalRef.current) {
+          // modalRef.current = new WalletConnectModal({
+          //   projectId: WALLET_CONNECT_V2_PROJECT_ID,
+          // });
+          // modalRef.current.subscribeModal((state: { open: boolean }) => {
+          //   appEventBus.emit(EAppEventBusNames.WalletConnectModalState, state);
+          //   if (state.open) {
+          //     updateModalSizeOnExt();
+          //   }
+          // });
+          modalRef.current = createOneKeyAppKit({
+            projectId: WALLET_CONNECT_V2_PROJECT_ID,
+            networks: [mainnet, solana], // show all network matched wallets
+            // networks: [] as any,
+            universalProvider: {} as any,
+            // manualWCControl: true,
+            themeMode: 'dark',
+            themeVariables: {
+              // https://docs.reown.com/appkit/react/core/theming
+              '--w3m-font-family': tamaguiWebFontFamily,
+            },
+            // debug: true,
+            enableInjected: true,
+            enableEIP6963: true,
+            enableCoinbase: true,
+            enableWallets: true,
+          });
+          modalRef.current.subscribeState(
+            (state: PublicStateControllerState) => {
+              // hide connect Dialog loading by eventBus
+              appEventBus.emit(EAppEventBusNames.WalletConnectModalState, {
+                open: state.open,
+                attemptId: attemptIdRef.current,
+              });
+              if (state.open) {
+                updateModalSizeOnExt();
+              } else {
+                console.log('WalletConnectModal closed.');
+                void backgroundApiProxy.serviceWalletConnect.abortConnectPairing(
+                  {
+                    uri: uriRef.current || '',
+                  },
+                );
+              }
+            },
+          );
+        }
+        // await modalRef.current.openModal({
+        //   uri,
         // });
-        // modalRef.current.subscribeModal((state: { open: boolean }) => {
-        //   appEventBus.emit(EAppEventBusNames.WalletConnectModalState, state);
-        //   if (state.open) {
-        //     updateModalSizeOnExt();
-        //   }
-        // });
-        modalRef.current = createOneKeyAppKit({
-          projectId: WALLET_CONNECT_V2_PROJECT_ID,
-          networks: [mainnet, solana], // show all network matched wallets
-          // networks: [] as any,
-          universalProvider: {} as any,
-          // manualWCControl: true,
-          themeMode: 'dark',
-          themeVariables: {
-            // https://docs.reown.com/appkit/react/core/theming
-            '--w3m-font-family': tamaguiWebFontFamily,
-          },
-          // debug: true,
-          enableInjected: true,
-          enableEIP6963: true,
-          enableCoinbase: true,
-          enableWallets: true,
+        await modalRef.current.open({
+          uri,
         });
-        modalRef.current.subscribeState((state: PublicStateControllerState) => {
-          // hide connect Dialog loading by eventBus
-          appEventBus.emit(EAppEventBusNames.WalletConnectModalState, state);
-          if (state.open) {
-            updateModalSizeOnExt();
-          } else {
-            console.log('WalletConnectModal closed.');
-            void backgroundApiProxy.serviceWalletConnect.abortConnectPairing({
-              uri: uriRef.current || '',
-            });
-          }
-        });
-      }
-      // await modalRef.current.openModal({
-      //   uri,
-      // });
-      await modalRef.current.open({
-        uri,
-      });
-    }, []);
+      },
+      [],
+    );
 
     const closeModal = useCallback(async () => {
       if (modalRef.current) {

--- a/packages/kit/src/components/WalletConnect/WalletConnectModalContainer.tsx
+++ b/packages/kit/src/components/WalletConnect/WalletConnectModalContainer.tsx
@@ -17,15 +17,16 @@ export function WalletConnectModalContainer() {
     const open = async (
       p: IAppEventBusPayload[EAppEventBusNames.WalletConnectOpenModal],
     ) => {
-      const { uri } = p;
+      const { uri, attemptId } = p;
 
       console.log(
         'WalletConnectModalContainer show qrcode uri: ------------------------ ',
       );
-      console.log(uri);
+      // the pairing uri query carries the symKey, never log it
+      console.log(uri.split('?')[0]);
       console.log('------------------------');
 
-      await openModal({ uri });
+      await openModal({ uri, attemptId });
     };
 
     const close = async () => {

--- a/packages/kit/src/components/WalletConnect/types.tsx
+++ b/packages/kit/src/components/WalletConnect/types.tsx
@@ -1,7 +1,13 @@
 export type IWalletConnectModalShared = {
   useModal: () => {
     modal: JSX.Element | null;
-    openModal: ({ uri }: { uri: string }) => Promise<void>;
+    openModal: ({
+      uri,
+      attemptId,
+    }: {
+      uri: string;
+      attemptId?: number;
+    }) => Promise<void>;
     closeModal: () => void;
   };
 };

--- a/packages/kit/src/provider/Container/GlobalWalletConnectModalContainer/GlobalWalletConnectModalContainer.test.tsx
+++ b/packages/kit/src/provider/Container/GlobalWalletConnectModalContainer/GlobalWalletConnectModalContainer.test.tsx
@@ -60,6 +60,7 @@ describe('GlobalWalletConnectModalContainer', () => {
     act(() => {
       appEventBus.emit(EAppEventBusNames.WalletConnectOpenModal, {
         uri: 'wc:test-pairing-uri',
+        attemptId: 11,
       });
     });
 
@@ -67,6 +68,7 @@ describe('GlobalWalletConnectModalContainer', () => {
       expect(mockWalletConnectModalContainer).toHaveBeenCalledTimes(1);
     });
 
+    // the native modal's initial open:false emit carries no attemptId
     act(() => {
       appEventBus.emit(EAppEventBusNames.WalletConnectModalState, {
         open: false,
@@ -88,9 +90,11 @@ describe('GlobalWalletConnectModalContainer', () => {
     act(() => {
       appEventBus.emit(EAppEventBusNames.WalletConnectModalState, {
         open: true,
+        attemptId: 11,
       });
       appEventBus.emit(EAppEventBusNames.WalletConnectModalState, {
         open: false,
+        attemptId: 11,
       });
     });
 
@@ -141,15 +145,17 @@ describe('GlobalWalletConnectModalContainer', () => {
     view.unmount();
   });
 
-  it('clears the payload when a second pairing arrives while the modal stays open', async () => {
+  it('ignores stale terminal events from a superseded attempt and clears on its own', async () => {
     const view = render(<GlobalWalletConnectModalContainer />);
 
     act(() => {
       appEventBus.emit(EAppEventBusNames.WalletConnectOpenModal, {
         uri: 'wc:first-session',
+        attemptId: 1,
       });
       appEventBus.emit(EAppEventBusNames.WalletConnectModalState, {
         open: true,
+        attemptId: 1,
       });
     });
 
@@ -157,11 +163,11 @@ describe('GlobalWalletConnectModalContainer', () => {
       expect(mockWalletConnectModalContainer).toHaveBeenCalledTimes(1);
     });
 
-    // A second pairing lands while AppKit stays open, so no fresh open:true
-    // transition will ever follow for it.
+    // A second pairing lands while the first modal is still open.
     act(() => {
       appEventBus.emit(EAppEventBusNames.WalletConnectOpenModal, {
         uri: 'wc:second-session',
+        attemptId: 2,
       });
     });
 
@@ -169,9 +175,34 @@ describe('GlobalWalletConnectModalContainer', () => {
       expect(mockWalletConnectModalContainer).toHaveBeenCalledTimes(2);
     });
 
+    // Stale terminal events of the superseded attempt arrive late; they must
+    // not clear the newer payload.
     act(() => {
       appEventBus.emit(EAppEventBusNames.WalletConnectModalState, {
         open: false,
+        attemptId: 1,
+      });
+      appEventBus.emit(EAppEventBusNames.WalletConnectCloseModal, {
+        attemptId: 1,
+      });
+    });
+
+    mockShouldRenderPageEveryChildren = false;
+    view.rerender(<GlobalWalletConnectModalContainer />);
+
+    mockShouldRenderPageEveryChildren = true;
+    view.rerender(<GlobalWalletConnectModalContainer />);
+
+    // The newer payload survived and is replayed on remount.
+    await waitFor(() => {
+      expect(mockWalletConnectModalContainer).toHaveBeenCalledTimes(3);
+    });
+
+    // The matching terminal event clears it even without a fresh open:true.
+    act(() => {
+      appEventBus.emit(EAppEventBusNames.WalletConnectModalState, {
+        open: false,
+        attemptId: 2,
       });
     });
 
@@ -185,8 +216,7 @@ describe('GlobalWalletConnectModalContainer', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    // The stale second uri must not be replayed after the user closed the modal.
-    expect(mockWalletConnectModalContainer).toHaveBeenCalledTimes(2);
+    expect(mockWalletConnectModalContainer).toHaveBeenCalledTimes(3);
 
     view.unmount();
   });

--- a/packages/kit/src/provider/Container/GlobalWalletConnectModalContainer/GlobalWalletConnectModalContainer.tsx
+++ b/packages/kit/src/provider/Container/GlobalWalletConnectModalContainer/GlobalWalletConnectModalContainer.tsx
@@ -20,8 +20,6 @@ type IWalletConnectOpenModalPayload =
   IAppEventBusPayload[EAppEventBusNames.WalletConnectOpenModal];
 
 let pendingPayload: IWalletConnectOpenModalPayload | null = null;
-let wasModalOpened = false;
-let isModalOpen = false;
 const pendingPayloadListeners = new Set<() => void>();
 
 function getPendingPayload() {
@@ -38,29 +36,43 @@ function subscribePendingPayload(listener: () => void) {
 function updatePendingPayload(payload: IWalletConnectOpenModalPayload) {
   if (pendingPayload?.uri === payload.uri) return;
   pendingPayload = payload;
-  // A new pairing can arrive while AppKit is still open (interleaved
-  // sessions). No fresh open:true transition follows in that case, so inherit
-  // the current open state to keep the eventual close clearing this store.
-  wasModalOpened = isModalOpen;
   pendingPayloadListeners.forEach((listener) => listener());
 }
 
 function clearPendingPayload() {
   if (!pendingPayload) return;
   pendingPayload = null;
-  wasModalOpened = false;
   pendingPayloadListeners.forEach((listener) => listener());
+}
+
+function handleCloseModal(
+  payload: IAppEventBusPayload[EAppEventBusNames.WalletConnectCloseModal],
+) {
+  if (!pendingPayload) return;
+  // An attempt-scoped close only clears its own payload, so a stale close
+  // from a superseded attempt cannot tear down the newer pairing. Closes
+  // without attemptId are wildcard clears (dialog close, session delete).
+  if (
+    payload?.attemptId &&
+    pendingPayload.attemptId &&
+    payload.attemptId !== pendingPayload.attemptId
+  ) {
+    return;
+  }
+  clearPendingPayload();
 }
 
 function handleModalState({
   open,
+  attemptId,
 }: IAppEventBusPayload[EAppEventBusNames.WalletConnectModalState]) {
-  isModalOpen = open;
-  if (open) {
-    wasModalOpened = true;
-  } else if (wasModalOpened) {
-    clearPendingPayload();
-  }
+  if (open || !pendingPayload) return;
+  // Only the modal session belonging to the current payload may clear it:
+  // main and bg schedule independently, so close(A) can be delivered after
+  // open(B) and must not drop B back to loading. The native modal's initial
+  // open:false emit carries no attemptId and is ignored the same way.
+  if (!attemptId || attemptId !== pendingPayload.attemptId) return;
+  clearPendingPayload();
 }
 
 function ReplayWalletConnectEvent({
@@ -105,10 +117,7 @@ export function GlobalWalletConnectModalContainer() {
       EAppEventBusNames.WalletConnectOpenModal,
       updatePendingPayload,
     );
-    appEventBus.on(
-      EAppEventBusNames.WalletConnectCloseModal,
-      clearPendingPayload,
-    );
+    appEventBus.on(EAppEventBusNames.WalletConnectCloseModal, handleCloseModal);
     appEventBus.on(EAppEventBusNames.WalletConnectModalState, handleModalState);
     return () => {
       appEventBus.off(
@@ -117,7 +126,7 @@ export function GlobalWalletConnectModalContainer() {
       );
       appEventBus.off(
         EAppEventBusNames.WalletConnectCloseModal,
-        clearPendingPayload,
+        handleCloseModal,
       );
       appEventBus.off(
         EAppEventBusNames.WalletConnectModalState,

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -209,10 +209,19 @@ export interface IAppEventBusPayload {
   };
   [EAppEventBusNames.WalletConnectOpenModal]: {
     uri: string;
+    // bg connect attempt generation; lets main-runtime consumers match
+    // terminal close/modal-state events to the pairing they belong to
+    attemptId?: number;
   };
-  [EAppEventBusNames.WalletConnectCloseModal]: undefined;
+  [EAppEventBusNames.WalletConnectCloseModal]:
+    | {
+        // scope the close to one attempt; omitted means wildcard close
+        attemptId?: number;
+      }
+    | undefined;
   [EAppEventBusNames.WalletConnectModalState]: {
     open: boolean;
+    attemptId?: number;
   };
   [EAppEventBusNames.WalletConnectConnectSuccess]: {
     session: IWalletConnectSession;


### PR DESCRIPTION
## Summary

Stacked on #12424. Addresses the two review comments from @originalix on the round-1 fixes (#12472):

1. `WalletConnectDappSide.ts` — two concurrent retries can both read attempt A, both await the abort, then each install a new attempt; the later one only overwrites `activeConnectAttempt` without cancelling the earlier one, leaving two live `provider.connect()` calls.
2. `GlobalWalletConnectModalContainer.tsx` — inheriting `isModalOpen` lets a delayed `open:false` of pairing A clear pairing B's payload, since close(A) and open(B) cross the native relay with no ordering guarantee.

## Changes

**bg runtime — `WalletConnectDappSide.ts`**
- `connectToWalletGeneration` counter serializes the supersede transition: every call claims a generation synchronously; after awaiting the abort, only the latest generation may install its attempt — stale calls throw the modal-close cancel error (`autoToast: false`) instead of racing a second live attempt.
- Each attempt carries `attemptId` (its generation). `WalletConnectOpenModal` and attempt-scoped `WalletConnectCloseModal` now include it; wildcard closes (session delete, pre-connect reset) still omit it.

**main runtime — event/attempt matching**
- `WalletConnectOpenModal` / `WalletConnectCloseModal` / `WalletConnectModalState` payloads gain optional `attemptId` (`appEventBus.ts`).
- `GlobalWalletConnectModalContainer.tsx`: the `wasModalOpened`/`isModalOpen` heuristic is replaced by attemptId matching. `ModalState open:false` clears only when its attemptId matches the current payload; attempt-scoped closes clear only their own payload; attemptId-less closes remain wildcard clears. This also covers the interleaved-session case without inheriting foreign open state.
- `WalletConnectModal.native.tsx`: tracks the attemptId of the modal it is showing and attaches it to `ModalState` emits. The pairing-uri/attemptId attribution refs are now set only after the native modal actually opens for that pairing, so a stale close keeps blaming the superseded attempt.
- `WalletConnectModal.tsx` (web) attaches the attemptId to its `subscribeState` emits; `WalletConnectModalContainer.tsx` forwards attemptId and stops logging the uri query (symKey).

## Tests
- Reworked the store suite to the attemptId contract, including a regression for the exact scenario in the review: stale `close(A)`/`CloseModal(A)` delivered after `open(B)` must not clear B, while B's own terminal event clears it even without a fresh `open:true` transition.

## Test plan
- [x] `yarn jest packages/kit/src/provider/Container/GlobalWalletConnectModalContainer/GlobalWalletConnectModalContainer.test.tsx packages/kit/src/hooks/useWebDapp/useWalletConnection.test.tsx --runInBand` — 2 suites, 6 tests passed
- [x] `yarn agent:check --profile commit` — lint + tsc passed
- [ ] iOS manual: double-tap retry storm while a pairing is active; interleaved pairing close ordering

---
_Generated by [Claude Code](https://claude.ai/code/session_018D7YDVNFd6JV9FBGkWRSpq)_