### PR TITLE
fix: match WalletConnect connect results to their attempt (review fixes round 4 for #12424)

### DIFF
--- a/packages/kit-bg/src/services/ServiceWalletConnect/WalletConnectDappSide.ts
+++ b/packages/kit-bg/src/services/ServiceWalletConnect/WalletConnectDappSide.ts
@@ -610,12 +610,14 @@ export class WalletConnectDappSide {
       }
       appEventBus.emit(EAppEventBusNames.WalletConnectConnectSuccess, {
         session: provider.session,
+        attemptId: attempt.attemptId,
       });
       return provider.session;
     } catch (error) {
       console.error('connectToWallet error: ', error);
       appEventBus.emit(EAppEventBusNames.WalletConnectConnectError, {
         error: errorUtils.toPlainErrorObject(error),
+        attemptId: attempt.attemptId,
       });
       throw error;
     } finally {

--- a/packages/kit/src/components/WalletConnect/WalletConnectModal.native.tsx
+++ b/packages/kit/src/components/WalletConnect/WalletConnectModal.native.tsx
@@ -81,6 +81,7 @@ const appKit = createAppKit({
   chains: [],
 });
 let pairingUri = '';
+let pairingAttemptId: number | undefined;
 let updateConnectModalUri: (uri: string) => void = (uri: string) => {
   console.log('updateConnectModalUri-init-fn', uri);
 };
@@ -116,6 +117,7 @@ appKit.walletConnectProvider = {
 
 async function resetAppKit() {
   pairingUri = '';
+  pairingAttemptId = undefined;
   // await appKitModalCtrl.disconnect();
 
   // ClientCtrl.resetSession();
@@ -162,17 +164,29 @@ appKit.setWalletConnectProvider = async () => {
   void setMockedProviderConnectedV2();
 };
 
+// The module-level resolve/reject slots always belong to the pairing this
+// modal flow is currently driving. main and bg heaps are independent and the
+// relay only copies payloads, so a superseded attempt settling late must be
+// matched by attemptId or it would settle the newer attempt's connection.
+function isStaleAttemptEvent(attemptId: number | undefined) {
+  return Boolean(
+    attemptId && pairingAttemptId && attemptId !== pairingAttemptId,
+  );
+}
+
 appEventBus.on(
   EAppEventBusNames.WalletConnectConnectSuccess,
-  (payload: { session: IWalletConnectSession }) => {
-    const { session } = payload;
+  (payload: { session: IWalletConnectSession; attemptId?: number }) => {
+    const { session, attemptId } = payload;
+    if (isStaleAttemptEvent(attemptId)) return;
     resolveConnect(session);
   },
 );
 appEventBus.on(
   EAppEventBusNames.WalletConnectConnectError,
-  (payload: { error: IOneKeyError }) => {
-    const { error } = payload;
+  (payload: { error: IOneKeyError; attemptId?: number }) => {
+    const { error, attemptId } = payload;
+    if (isStaleAttemptEvent(attemptId)) return;
     rejectConnect(error);
   },
 );
@@ -400,6 +414,7 @@ const modal: IWalletConnectModalShared = {
           return;
         }
         pairingUri = uri;
+        pairingAttemptId = attemptId;
         updateConnectModalUri(uri);
 
         // TODO use custom provider from bg make QRCode Modal not open automatically

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -225,9 +225,11 @@ export interface IAppEventBusPayload {
   };
   [EAppEventBusNames.WalletConnectConnectSuccess]: {
     session: IWalletConnectSession;
+    attemptId?: number;
   };
   [EAppEventBusNames.WalletConnectConnectError]: {
     error: IOneKeyError;
+    attemptId?: number;
   };
   [EAppEventBusNames.ShowToast]: IEventBusPayloadShowToast;
   [EAppEventBusNames.ShowLocalSecretEnvelopeErrorDialog]: IEventBusPayloadShowLocalSecretEnvelopeErrorDialog;


### PR DESCRIPTION
## Summary

Stacked on #12424. Addresses the latest review comment from @originalix: `WalletConnectConnectSuccess` / `WalletConnectConnectError` carried no attemptId, so a superseded attempt settling late (e.g. cancelled during `getAllChains()` before `rejectCancellation` was installed) could invoke the module-level `resolveConnect`/`rejectConnect` slots that already belong to the newer attempt, rejecting the new AppKit connection while its pairing keeps running in bg.

## Changes

- `appEventBus.ts`: `WalletConnectConnectSuccess` / `WalletConnectConnectError` payloads gain optional `attemptId`.
- `WalletConnectDappSide.ts` (bg): both emits include `attempt.attemptId`.
- `WalletConnectModal.native.tsx` (main): module-level `pairingAttemptId` is recorded when a pairing enters `openModal` and cleared by `resetAppKit`; the ConnectSuccess/ConnectError listeners drop events whose attemptId does not match it, so only the attempt this modal flow is driving may settle the AppKit connect promise. attemptId-less events keep the legacy behavior.

## Test plan
- [x] `yarn jest packages/kit/src/provider/Container/GlobalWalletConnectModalContainer/GlobalWalletConnectModalContainer.test.tsx packages/kit/src/hooks/useWebDapp/useWalletConnection.test.tsx --runInBand` — 2 suites, 6 tests passed
- [x] `yarn agent:check --profile commit` — lint + tsc passed
- [ ] iOS manual: cancel during loading then immediately retry; the retried AppKit connection must not be rejected by the superseded attempt's error

---
_Generated by [Claude Code](https://claude.ai/code/session_018D7YDVNFd6JV9FBGkWRSpq)_