### PR TITLE
fix: guard pairing ownership reset and serialize web modal transitions (review fixes round 5 for #12424)

### DIFF
--- a/packages/kit/src/components/WalletConnect/WalletConnectModal.native.tsx
+++ b/packages/kit/src/components/WalletConnect/WalletConnectModal.native.tsx
@@ -115,9 +115,12 @@ appKit.walletConnectProvider = {
   },
 };
 
-async function resetAppKit() {
+function clearPairingOwnership() {
   pairingUri = '';
   pairingAttemptId = undefined;
+}
+
+async function resetAppKitState() {
   // await appKitModalCtrl.disconnect();
 
   // ClientCtrl.resetSession();
@@ -135,6 +138,11 @@ async function resetAppKit() {
   // @ts-ignore
   appKit.setClientId(null);
   appKit.setAddress(undefined);
+}
+
+async function resetAppKit() {
+  clearPairingOwnership();
+  await resetAppKitState();
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -348,6 +356,7 @@ const modal: IWalletConnectModalShared = {
     const isAwaitingMobileWalletApprovalRef = useRef(false);
     const activePairingUriRef = useRef('');
     const activeAttemptIdRef = useRef<number | undefined>(undefined);
+    const attributedRequestIdRef = useRef(0);
 
     useEffect(
       () => () => {
@@ -460,6 +469,7 @@ const modal: IWalletConnectModalShared = {
         // and cannot cancel or clear the one still opening.
         activePairingUriRef.current = uri;
         activeAttemptIdRef.current = attemptId;
+        attributedRequestIdRef.current = requestId;
 
         // await openNativeModal({
         //   route: 'ConnectWallet',
@@ -486,7 +496,16 @@ const modal: IWalletConnectModalShared = {
       void (async () => {
         if (platformEnv.isNative) {
           if (!isNativeModalOpen) {
-            await resetAppKit();
+            await resetAppKitState();
+            // Only the request that opened the modal producing this close
+            // state may clear the pairing ownership. A newer openModal has
+            // already claimed (or is about to rewrite) the module slots, and
+            // wiping them here would let the superseded attempt's late
+            // success/error bypass the staleness check and settle the newer
+            // attempt's connection.
+            if (attributedRequestIdRef.current === openRequestIdRef.current) {
+              clearPairingOwnership();
+            }
             console.log('setShouldRenderNativeModal false');
             // setShouldRenderNativeModal(false);
           }

--- a/packages/kit/src/components/WalletConnect/WalletConnectModal.tsx
+++ b/packages/kit/src/components/WalletConnect/WalletConnectModal.tsx
@@ -90,78 +90,116 @@ const modal: IWalletConnectModalShared = {
   useModal() {
     // const modalRef0 = useRef<WalletConnectModal | null>(null);
     const modalRef = useRef<AppKit | null>(null);
+    // The pairing being opened (pending) vs the pairing the open modal is
+    // actually showing (attributed). Close events are blamed on the
+    // attributed one, so a stale close from attempt A cannot abort or clear
+    // a newer attempt B whose refs were written while A was still closing.
+    const pendingUriRef = useRef<string | undefined>(undefined);
+    const pendingAttemptIdRef = useRef<number | undefined>(undefined);
     const uriRef = useRef<string | undefined>(undefined);
     const attemptIdRef = useRef<number | undefined>(undefined);
+    // Generation-bound queue: each open/close transition runs only after the
+    // previous one fully settled, and a queued open superseded by a newer
+    // transition is skipped instead of replacing the attempt refs early.
+    const transitionGenerationRef = useRef(0);
+    const transitionQueueRef = useRef<Promise<void>>(Promise.resolve());
+
+    const enqueueTransition = useCallback((task: () => Promise<void>) => {
+      const run = transitionQueueRef.current.then(task);
+      transitionQueueRef.current = run.catch(() => undefined);
+      return run;
+    }, []);
+
     const openModal = useCallback(
       async ({ uri, attemptId }: { uri: string; attemptId?: number }) => {
-        uriRef.current = uri;
-        attemptIdRef.current = attemptId;
+        transitionGenerationRef.current += 1;
+        const generation = transitionGenerationRef.current;
         const tamaguiWebFontFamily = webFontFamily;
-        if (!modalRef.current) {
-          // modalRef.current = new WalletConnectModal({
-          //   projectId: WALLET_CONNECT_V2_PROJECT_ID,
+        await enqueueTransition(async () => {
+          // a newer open/close claimed the flow while this one was queued
+          if (generation !== transitionGenerationRef.current) return;
+          pendingUriRef.current = uri;
+          pendingAttemptIdRef.current = attemptId;
+          if (!modalRef.current) {
+            // modalRef.current = new WalletConnectModal({
+            //   projectId: WALLET_CONNECT_V2_PROJECT_ID,
+            // });
+            // modalRef.current.subscribeModal((state: { open: boolean }) => {
+            //   appEventBus.emit(EAppEventBusNames.WalletConnectModalState, state);
+            //   if (state.open) {
+            //     updateModalSizeOnExt();
+            //   }
+            // });
+            modalRef.current = createOneKeyAppKit({
+              projectId: WALLET_CONNECT_V2_PROJECT_ID,
+              networks: [mainnet, solana], // show all network matched wallets
+              // networks: [] as any,
+              universalProvider: {} as any,
+              // manualWCControl: true,
+              themeMode: 'dark',
+              themeVariables: {
+                // https://docs.reown.com/appkit/react/core/theming
+                '--w3m-font-family': tamaguiWebFontFamily,
+              },
+              // debug: true,
+              enableInjected: true,
+              enableEIP6963: true,
+              enableCoinbase: true,
+              enableWallets: true,
+            });
+            modalRef.current.subscribeState(
+              (state: PublicStateControllerState) => {
+                if (state.open) {
+                  // the modal now shows the pending pairing; attribute
+                  // subsequent events to it from this point only
+                  uriRef.current = pendingUriRef.current;
+                  attemptIdRef.current = pendingAttemptIdRef.current;
+                }
+                // hide connect Dialog loading by eventBus
+                appEventBus.emit(EAppEventBusNames.WalletConnectModalState, {
+                  open: state.open,
+                  attemptId: attemptIdRef.current,
+                });
+                if (state.open) {
+                  updateModalSizeOnExt();
+                } else {
+                  console.log('WalletConnectModal closed.');
+                  const closedUri = uriRef.current;
+                  // without an attributed pairing there is nothing to cancel;
+                  // an empty uri would wildcard-cancel the active attempt
+                  if (closedUri) {
+                    void backgroundApiProxy.serviceWalletConnect.abortConnectPairing(
+                      {
+                        uri: closedUri,
+                      },
+                    );
+                  }
+                }
+              },
+            );
+          }
+          // await modalRef.current.openModal({
+          //   uri,
           // });
-          // modalRef.current.subscribeModal((state: { open: boolean }) => {
-          //   appEventBus.emit(EAppEventBusNames.WalletConnectModalState, state);
-          //   if (state.open) {
-          //     updateModalSizeOnExt();
-          //   }
-          // });
-          modalRef.current = createOneKeyAppKit({
-            projectId: WALLET_CONNECT_V2_PROJECT_ID,
-            networks: [mainnet, solana], // show all network matched wallets
-            // networks: [] as any,
-            universalProvider: {} as any,
-            // manualWCControl: true,
-            themeMode: 'dark',
-            themeVariables: {
-              // https://docs.reown.com/appkit/react/core/theming
-              '--w3m-font-family': tamaguiWebFontFamily,
-            },
-            // debug: true,
-            enableInjected: true,
-            enableEIP6963: true,
-            enableCoinbase: true,
-            enableWallets: true,
+          await modalRef.current.open({
+            uri,
           });
-          modalRef.current.subscribeState(
-            (state: PublicStateControllerState) => {
-              // hide connect Dialog loading by eventBus
-              appEventBus.emit(EAppEventBusNames.WalletConnectModalState, {
-                open: state.open,
-                attemptId: attemptIdRef.current,
-              });
-              if (state.open) {
-                updateModalSizeOnExt();
-              } else {
-                console.log('WalletConnectModal closed.');
-                void backgroundApiProxy.serviceWalletConnect.abortConnectPairing(
-                  {
-                    uri: uriRef.current || '',
-                  },
-                );
-              }
-            },
-          );
-        }
-        // await modalRef.current.openModal({
-        //   uri,
-        // });
-        await modalRef.current.open({
-          uri,
         });
       },
-      [],
+      [enqueueTransition],
     );
 
     const closeModal = useCallback(async () => {
-      if (modalRef.current) {
-        // modalRef.current.closeModal();
-        await modalRef.current.close();
-      }
-      // do not set null, subscribeModal will trigger many times, there is no unsubscribe method
-      // modalRef.current = null;
-    }, []);
+      transitionGenerationRef.current += 1;
+      await enqueueTransition(async () => {
+        if (modalRef.current) {
+          // modalRef.current.closeModal();
+          await modalRef.current.close();
+        }
+        // do not set null, subscribeModal will trigger many times, there is no unsubscribe method
+        // modalRef.current = null;
+      });
+    }, [enqueueTransition]);
 
     return {
       modal: null,


### PR DESCRIPTION
## Summary

Stacked on #12424. Addresses the two latest review comments from @originalix:

1. `WalletConnectModal.native.tsx` — on a rapid A→B retry, attempt A's `isNativeModalOpen=false` passive effect could run after B wrote the module-level `pairingAttemptId` and wipe it via `resetAppKit()`; A's late success/error would then bypass `isStaleAttemptEvent()` (empty ownership acts as wildcard) and settle B's connection.
2. `WalletConnectModal.tsx` (web) — A's `modal.close()` can still be completing while B already updated `uriRef`/`attemptIdRef`; A's `state.open=false` was then attributed to B and aborted with B's uri, cancelling the new pairing and clearing the new payload.

## Changes

**native**
- `resetAppKit` is split into `clearPairingOwnership` + `resetAppKitState`; the open flow keeps the combined behavior.
- The close passive effect now resets only the AppKit state unconditionally, and clears pairing ownership only when the request that opened the closing modal (`attributedRequestIdRef`, recorded at the same point the modal is attributed) is still the latest `openRequestId` generation. A newer openModal's ownership survives a stale close.

**web**
- open/close transitions run through a generation-bound queue: each transition starts only after the previous one fully settled, and a queued open superseded by a newer transition is skipped instead of replacing the attempt refs early.
- Attribution is split into pending vs attributed refs: `uriRef`/`attemptIdRef` are written only when the modal actually reports `open=true` for the pending pairing, so a stale `open=false` from attempt A is emitted and aborted with A's identity, never B's. Without an attributed pairing the close aborts nothing (an empty uri would wildcard-cancel the active attempt).

## Test plan
- [x] `yarn jest packages/kit/src/provider/Container/GlobalWalletConnectModalContainer/GlobalWalletConnectModalContainer.test.tsx packages/kit/src/hooks/useWebDapp/useWalletConnection.test.tsx --runInBand` — 2 suites, 6 tests passed
- [x] `yarn agent:check --profile commit` — lint + tsc passed
- [ ] iOS/web manual: rapid cancel→retry storms; the new pairing's modal must stay open and its bg connection must not be cancelled by the superseded attempt

---
_Generated by [Claude Code](https://claude.ai/code/session_018D7YDVNFd6JV9FBGkWRSpq)_