### PR TITLE
fix: stop logging pairing uri in default connect modal callback (review fix round 6 for #12424)

### DIFF
--- a/packages/kit/src/components/WalletConnect/WalletConnectModal.native.tsx
+++ b/packages/kit/src/components/WalletConnect/WalletConnectModal.native.tsx
@@ -82,8 +82,11 @@ const appKit = createAppKit({
 });
 let pairingUri = '';
 let pairingAttemptId: number | undefined;
-let updateConnectModalUri: (uri: string) => void = (uri: string) => {
-  console.log('updateConnectModalUri-init-fn', uri);
+let updateConnectModalUri: (uri: string) => void = () => {
+  // No-op until the SDK registers its display_uri listener; the uri is
+  // replayed from the pairingUri cache at registration time. Never log the
+  // argument here: the wc: uri query carries the pairing symKey and would
+  // leak into device logs and console breadcrumbs.
 };
 let resolveConnect: (session: IWalletConnectSession) => void = () => {};
 let rejectConnect: (error: IOneKeyError) => void = () => {};


### PR DESCRIPTION
## Summary

Stacked on #12424. Addresses the latest review comment from @originalix: on the first native AppKit open, `updateConnectModalUri` can still be the module's default callback, which logged the full `wc:` uri — the query carries the pairing symKey and could leak into device logs and collected console breadcrumbs.

## Changes

- `WalletConnectModal.native.tsx`: the default `updateConnectModalUri` is now a no-op that never touches its argument. The full uri still reaches the SDK: it is cached in `pairingUri` and replayed when `walletConnectProvider.on('display_uri', ...)` registers the real listener.

## Test plan
- [x] `yarn agent:check --profile commit` — lint + tsc passed (log-only change, no behavior under test)

---
_Generated by [Claude Code](https://claude.ai/code/session_018D7YDVNFd6JV9FBGkWRSpq)_