### PR TITLE
fix: ignore network filter for Market Stocks(OK-57973)

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/marketTokenListQueryUtils.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/marketTokenListQueryUtils.ts
@@ -1,0 +1,11 @@
+export function getMarketTokenListApiNetworkId({
+  networkId,
+  isAllNetworks,
+  type,
+}: {
+  networkId: string;
+  isAllNetworks: boolean;
+  type?: string;
+}) {
+  return isAllNetworks || type === 'stocks' ? '' : networkId;
+}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.test.ts
@@ -1,0 +1,31 @@
+import { getMarketTokenListApiNetworkId } from './marketTokenListQueryUtils';
+
+describe('getMarketTokenListApiNetworkId', () => {
+  it('keeps the selected network for ordinary Market categories', () => {
+    expect(
+      getMarketTokenListApiNetworkId({
+        networkId: 'evm--8453',
+        isAllNetworks: false,
+      }),
+    ).toBe('evm--8453');
+  });
+
+  it('removes the network filter for All Networks', () => {
+    expect(
+      getMarketTokenListApiNetworkId({
+        networkId: 'onekeyall--0',
+        isAllNetworks: true,
+      }),
+    ).toBe('');
+  });
+
+  it('removes the network filter for Stocks on a selected network', () => {
+    expect(
+      getMarketTokenListApiNetworkId({
+        networkId: 'sol--101',
+        isAllNetworks: false,
+        type: 'stocks',
+      }),
+    ).toBe('');
+  });
+});

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
@@ -23,6 +23,7 @@ import {
 } from '../utils/tokenListHelpers';
 
 import { fetchMarketTokenListForPlatform } from './marketTokenListPlatformApi';
+import { getMarketTokenListApiNetworkId } from './marketTokenListQueryUtils';
 
 import type { IMarketTokenListResponseWithSource } from './marketTokenListPlatformApiTypes';
 import type { IMarketTimeRangeValue } from '../../../types';
@@ -217,8 +218,12 @@ export function useMarketTokenList({
     [networkId],
   );
 
-  // For API calls, use empty string when "All Networks" is selected
-  const apiNetworkId = isAllNetworks ? '' : networkId;
+  // Stocks and All Networks both request the unfiltered asset universe.
+  const apiNetworkId = getMarketTokenListApiNetworkId({
+    networkId,
+    isAllNetworks,
+    type,
+  });
   const currentQueryKey = useMemo(
     () =>
       JSON.stringify({


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57973](https://onekeyhq.atlassian.net/browse/OK-57973)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Clear the Market token-list network filter for Stocks requests.
- Add focused regression coverage for the request-network decision.

## Intent & Context

Market Home should show Stocks after a user selects a network in Trending and switches tabs. The reported failure occurred on non-BSC networks, where the Stocks list became empty.

## Root Cause

The Market token-list request reused the currently selected network for every category. Stocks requests therefore sent a network ID such as sol--101 or evm--8453 and received an empty result, while the unfiltered Stocks request returned data.

## Design Decisions

- Resolve the exception in the request-parameter layer when type is stocks, rather than propagate a Stocks flag through desktop, web, and native layouts.
- Keep ordinary Market categories network-filtered and preserve the existing All Networks behavior.

## Changes Detail

- Add a small pure helper that resolves the API network ID.
- Use an empty network ID for Stocks and All Networks requests.
- Add unit coverage for ordinary categories, All Networks, and Stocks on a selected network.

## Risk Assessment

- **Risk Level**: Low
- **Affected Platforms**: Web, Desktop, Mobile, Extension
- **Risk Areas**: Market token-list request and cache identity; the Stocks type remains distinct from ordinary category queries.

## Test plan

- [x] yarn jest packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.test.ts --runInBand
- [x] yarn agent:check --profile commit
- [ ] In Market Home, select a non-BSC network in Trending, switch to Stocks, and confirm Stocks data renders.

[OK-57973]: https://onekeyhq.atlassian.net/browse/OK-57973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ