### PR TITLE
fix: run OneKey ID OAuth login in expand tab from extension popup

### DIFF
--- a/packages/kit-bg/src/services/ServiceApp.ts
+++ b/packages/kit-bg/src/services/ServiceApp.ts
@@ -363,6 +363,26 @@ class ServiceApp extends ServiceBase {
     return extUtils.openExpandTab(routeInfo);
   }
 
+  // One-shot, in-memory only (never persisted). Set by an ephemeral extension
+  // UI surface (action popup / side panel / standalone window) that cannot host
+  // the OneKey ID OAuth flow, and consumed once by the persistent expand tab so
+  // it can resume the login there. Lives on the single shared bg service
+  // worker, so it is visible across every extension UI runtime.
+  private pendingOneKeyIdLoginExpandTabRedirect = false;
+
+  @backgroundMethod()
+  async openExtensionExpandTabForOneKeyIdLogin() {
+    this.pendingOneKeyIdLoginExpandTabRedirect = true;
+    return extUtils.openExpandTab({ routes: '' });
+  }
+
+  @backgroundMethod()
+  async consumePendingOneKeyIdLoginExpandTabRedirect(): Promise<boolean> {
+    const pending = this.pendingOneKeyIdLoginExpandTabRedirect;
+    this.pendingOneKeyIdLoginExpandTabRedirect = false;
+    return pending;
+  }
+
   @backgroundMethod()
   async openExtensionMarketTokenDetail(params: {
     tokenAddress: string;

--- a/packages/kit/src/components/OneKeyAuth/useOneKeyAuth.tsx
+++ b/packages/kit/src/components/OneKeyAuth/useOneKeyAuth.tsx
@@ -16,6 +16,7 @@ import {
 } from '@onekeyhq/shared/src/keylessWallet/keylessWalletTypes';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 import supabaseStorageInstance from '@onekeyhq/shared/src/storage/instance/supabaseStorageInstance';
@@ -322,6 +323,21 @@ export function useOneKeyAuth() {
     }: {
       toOneKeyIdPageOnLoginSuccess?: boolean;
     } = {}) => {
+      // OneKey ID login now goes through OAuth (PrimeLoginOAuthDialog), whose
+      // Google/Apple buttons run chrome.identity.launchWebAuthFlow in the
+      // current UI runtime. The browser-action popup is the only extension
+      // surface Chrome tears down on focus loss: the moment the auth window
+      // steals focus the popup document is destroyed, silently killing the
+      // pending PKCE/session/apiOAuthLogin continuation. Hand the flow off to
+      // the persistent expand tab (the popup auto-closes once the tab takes
+      // focus); the expand tab's PrimeGlobalEffect resumes loginOneKeyId there
+      // via a shared bg flag. The side panel and standalone window are
+      // persistent contexts that survive the auth window, so they complete
+      // OAuth in place and are intentionally left alone.
+      if (platformEnv.isExtensionUiPopup) {
+        await backgroundApiProxy.serviceApp.openExtensionExpandTabForOneKeyIdLogin();
+        return;
+      }
       const localKeylessLoginPrepareResult: IOneKeyIdLoginWithLocalKeylessPrepareResult =
         await backgroundApiProxy.serviceKeylessWallet.prepareOneKeyIdLoginWithLocalKeyless();
       const preserveLocalKeylessAuth =

--- a/packages/kit/src/views/Prime/hooks/PrimeGlobalEffect.tsx
+++ b/packages/kit/src/views/Prime/hooks/PrimeGlobalEffect.tsx
@@ -278,8 +278,40 @@ function PrimeGlobalEffectAfterAuthReady() {
 }
 
 function PrimeGlobalEffectView() {
-  const { isReady, legacySupabaseSignOut, keylessSupabaseSignOut } =
-    useOneKeyAuth();
+  const {
+    isReady,
+    legacySupabaseSignOut,
+    keylessSupabaseSignOut,
+    loginOneKeyId,
+  } = useOneKeyAuth();
+
+  // Resume a OneKey ID OAuth login that was handed off from an ephemeral
+  // extension surface (popup / side panel / standalone window). Those surfaces
+  // cannot host chrome.identity.launchWebAuthFlow, so loginOneKeyId there only
+  // opens this expand tab and sets a one-shot bg flag; consume it once on mount
+  // and re-open the login dialog in this persistent runtime. Gated to the
+  // expand tab so the surface that SET the flag never consumes its own flag.
+  useEffect(() => {
+    if (!platformEnv.isExtensionUiExpandTab) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const pending =
+        await backgroundApiProxy.serviceApp.consumePendingOneKeyIdLoginExpandTabRedirect();
+      if (cancelled || !pending) {
+        return;
+      }
+      const isLoggedIn = await backgroundApiProxy.servicePrime.isLoggedIn();
+      if (cancelled || isLoggedIn) {
+        return;
+      }
+      void loginOneKeyId();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loginOneKeyId]);
 
   useEffect(() => {
     const fn = async (


### PR DESCRIPTION
Follow-up fix for a high-priority finding on #12284 (extension MV3 popup OAuth login).

## Problem

The unified OneKey ID login now shows `PrimeLoginOAuthDialog`, whose Google/Apple buttons call `chrome.identity.launchWebAuthFlow` in the **current UI runtime**:

```
loginOneKeyId (useOneKeyAuth)
  → Dialog.show(PrimeLoginOAuthDialog)
     → handleSocialLogin → getOAuthAccessToken → signInWithSocialLogin
        → performOAuthSignIn → OAuthPopup.open (ext) → chrome.identity.launchWebAuthFlow
```

The **browser-action popup** (the default extension entry, `chrome_v3.js: default_popup: 'ui-popup.html'`) is the one surface Chrome tears down on focus loss: the moment the auth window steals focus the popup document is destroyed, so the pending PKCE exchange / session persistence / `apiOAuthLogin` continuation dies with it. The user completes Google/Apple sign-in and **nothing happens, with no error**.

Every entry point that opens login from the popup is affected: user center (`MoreActionButton`), `OneKeyIdTabItem`, `OneKeyIdSettingsPage`, refer-a-friend, `PrimeDashboard`, `usePrimeRequirements`. The pre-existing keyless OAuth path avoided this because onboarding forced an expand tab via `useToOnBoardingPage`; the old `loginOneKeyId` used the popup-safe **email OTP** dialog. Switching to OAuth-in-popup is the regression.

**Scope — action popup only.** The side panel (docked, persistent) and the standalone window (a real browser window) are persistent contexts that are *not* destroyed when the auth window steals focus, so `launchWebAuthFlow` completes in place on those surfaces. The expand tab and native/web/desktop runtimes likewise survive. Only the action popup needs the redirect.

## Fix

Redirect OneKey ID login **from the action popup** to the persistent expand tab:

- `ServiceApp` gets a one-shot **in-memory** flag (never persisted) plus `openExtensionExpandTabForOneKeyIdLogin()` / `consumePendingOneKeyIdLoginExpandTabRedirect()`. The flag lives on the single shared MV3 bg service worker, so it is visible across every extension UI runtime — immune to URL/hash rewrite timing.
- `loginOneKeyId` (`useOneKeyAuth`) guards at the top: on `isExtensionUiPopup` it sets the flag + opens the expand tab, then returns. The popup auto-closes once the tab takes focus (no explicit `window.close()`). Because the guard is in `loginOneKeyId`, every entry point is covered centrally. The side panel and standalone window are deliberately left alone — they finish OAuth in place.
- `PrimeGlobalEffect` (mounted app-wide, including the expand tab) consumes the flag once on mount and re-invokes `loginOneKeyId` in the expand-tab runtime, where `launchWebAuthFlow` survives. Consumption is gated to `isExtensionUiExpandTab`, so the popup that set the flag never consumes its own flag; the read-then-clear in bg is atomic, so a double-mount can't double-trigger.

The email OTP fallback stays popup-safe and is untouched.

## Notes

- No DB schema / persisted fields touched (the flag is a plain in-memory service field), so no `LOCAL_DB_VERSION` bump or persistence audit impact.
- The same `launchWebAuthFlow`-in-popup limitation also applies to the legacy OAuth **bind** flow (`OneKeyIdLegacyOAuthBind`); that path is tracked as a separate finding and is not addressed here.

## Test plan

- [ ] Ext **action popup** → OneKey ID sign in → expand tab opens and the OAuth dialog resumes; Google/Apple login completes and updates logged-in state.
- [ ] **Side panel** → OneKey ID sign in → OAuth completes in place, no redirect (panel stays open).
- [ ] **Standalone window** → OneKey ID sign in → OAuth completes in place, no redirect.
- [ ] Expand tab directly → login shows in place, no redirect loop.
- [ ] Email OTP fallback still works from the popup.
- [ ] Native / web / desktop login unchanged.
- [ ] `yarn tsc:staged`, `yarn lint:staged`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)