### PR TITLE
fix: unify OneKey ID OAuth copy terminology and mark i18n TODOs

### DIFF
--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -3180,8 +3180,9 @@ class ServiceKeylessWallet extends ServiceBase {
         ownerId: context.ownerId,
       });
       if (!accessToken) {
+        // TODO: i18n
         throw new OneKeyLocalError(
-          'The local Keyless Wallet session has expired. Please continue with your linked social account.',
+          'The local Keyless wallet session has expired. Please continue with your linked social account.',
         );
       }
     }

--- a/packages/kit/src/components/KeylessWallet/AccountMismatchDialog.tsx
+++ b/packages/kit/src/components/KeylessWallet/AccountMismatchDialog.tsx
@@ -122,7 +122,7 @@ export async function showKeylessOneKeyIdSessionConflictDialog(params: {
         id: ETranslations.keyless_wallet_verify_pin_account_mismatch,
       }),
       // TODO: i18n
-      description: `You are signed in to OneKey ID as ${displayEmail}, but this Keyless wallet is linked to a different account. Continuing will log out of OneKey ID (you can log in again later); the Keyless wallet stays untouched.`,
+      description: `You are signed in to OneKey ID as ${displayEmail}, but this Keyless wallet is linked to a different account. Continuing will log you out of OneKey ID (you can log in again later); the Keyless wallet stays untouched.`,
       showCancelButton: true,
       onConfirmText: intl.formatMessage({
         id: ETranslations.global_continue,

--- a/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
+++ b/packages/kit/src/components/KeylessWallet/useKeylessWallet.tsx
@@ -590,6 +590,7 @@ export function useKeylessWallet() {
       });
       const accessToken = result?.session?.accessToken;
       if (!accessToken) {
+        // TODO: i18n
         throw new OneKeyLocalError(
           'Keyless wallet OAuth login failed: access token not found',
         );
@@ -648,8 +649,10 @@ export function useKeylessWallet() {
           displayEmail: prepareResult.displayEmail,
         });
         Dialog.show({
+          // TODO: i18n
           title: 'Continue with current OneKey ID?',
-          description: `You are signed in as ${displayEmail}. Continue with this OneKey ID to create a Keyless wallet, or sign out to use another Google or Apple account.`,
+          // TODO: i18n
+          description: `You are signed in as ${displayEmail}. Continue with this OneKey ID to create a Keyless wallet, or log out to use another Google or Apple account.`,
           showCancelButton: true,
           onConfirmText: intl.formatMessage({
             id: ETranslations.global_continue,

--- a/packages/kit/src/components/OneKeyAuth/oneKeyIdLogoutConsts.ts
+++ b/packages/kit/src/components/OneKeyAuth/oneKeyIdLogoutConsts.ts
@@ -1,5 +1,7 @@
+// TODO: i18n
 export const ONEKEY_ID_ASSOCIATED_KEYLESS_LOGOUT_TITLE =
-  'Log out OneKey ID and associated Keyless wallet';
+  'Log out OneKey ID and linked Keyless wallet';
 
+// TODO: i18n
 export const ONEKEY_ID_ASSOCIATED_KEYLESS_LOGOUT_DESCRIPTION =
-  'This will sign out of OneKey ID and remove the associated Keyless wallet from this device.';
+  'This will log out of OneKey ID and remove the linked Keyless wallet from this device.';

--- a/packages/kit/src/components/OneKeyAuth/supabase/useSupabaseAuth.tsx
+++ b/packages/kit/src/components/OneKeyAuth/supabase/useSupabaseAuth.tsx
@@ -112,6 +112,7 @@ export function useSupabaseAuth() {
       // first (see extOneKeyIdAuthExpandTab); fail loudly if one slips
       // through instead of dying without any feedback.
       if (platformEnv.isExtensionUiPopup) {
+        // TODO: i18n
         throw new OneKeyLocalError(
           'OAuth sign-in cannot run in the extension popup. Please continue in the expanded view.',
         );

--- a/packages/kit/src/views/Prime/components/OneKeyIdLegacyOAuthBind/OneKeyIdLegacyOAuthBind.tsx
+++ b/packages/kit/src/views/Prime/components/OneKeyIdLegacyOAuthBind/OneKeyIdLegacyOAuthBind.tsx
@@ -53,22 +53,26 @@ import { useOneKeyIdLocalKeylessOAuth } from '../useOneKeyIdLocalKeylessOAuth';
 
 import type { IntlShape } from 'react-intl';
 
+// TODO: i18n
 export const ONEKEY_ID_BIND_OAUTH_TITLE = 'Add Google or Apple Sign-In';
+// TODO: i18n
 export const ONEKEY_ID_BIND_OAUTH_DESC =
   'Email sign-in is legacy. Add a social sign-in method to keep access to your OneKey ID.';
 let isLegacyOAuthBindDialogVisible = false;
 
+// TODO: i18n (use a {provider} placeholder)
 function getBindOAuthTitle(provider?: EOAuthSocialLoginProvider) {
   return provider
     ? `Add ${getOAuthSocialLoginProviderName(provider)} Sign-In`
     : ONEKEY_ID_BIND_OAUTH_TITLE;
 }
 
+// TODO: i18n (use a {provider} placeholder)
 function getBindOAuthDescription(provider?: EOAuthSocialLoginProvider) {
   return provider
     ? `Email sign-in is legacy. Add ${getOAuthSocialLoginProviderName(
         provider,
-      )} sign-in method to keep access to your OneKey ID.`
+      )} sign-in to keep access to your OneKey ID.`
     : ONEKEY_ID_BIND_OAUTH_DESC;
 }
 
@@ -120,8 +124,9 @@ async function showOneKeyIdOAuthIdentityAlreadyBoundSwitchDialog({
       icon: 'ErrorOutline',
       // TODO: i18n
       title: 'Already Linked to Another OneKey ID',
-      // TODO: i18n
-      description: `This ${providerName} account is already linked to another OneKey ID, so it can't be added to ${emailText}. Continue to log out of ${emailText} and sign in with the OneKey ID linked to this ${providerName} account instead. You can log back in to ${emailText} with email verification at any time${
+      // TODO: i18n (two full messages — with and without the trailing
+      // Keyless clause; never concatenate translated fragments)
+      description: `This ${providerName} account is already linked to another OneKey ID, so it can't be added to ${emailText}. Continuing will log out of ${emailText} and sign in with the OneKey ID linked to this ${providerName} account. You can log back in with email verification at any time${
         hasLocalKeylessWallet ? '; the Keyless wallet stays untouched' : ''
       }.`,
       showCancelButton: true,
@@ -302,6 +307,7 @@ function OneKeyIdLegacyOAuthBindActions({
           try {
             const result = await getOAuthAccessToken({
               provider,
+              // TODO: i18n (surfaces as a raw toast via withErrorAutoToast)
               missingTokenMessage: 'OAuth bind failed: access token not found',
             });
             didUseOAuthSignIn = result.didUseOAuthSignIn;
@@ -516,6 +522,8 @@ function OneKeyIdOAuthBindStatus({
   const providerNames = providers.map((provider) =>
     getOneKeyIdOAuthProviderName(provider),
   );
+  // TODO: i18n (localize the list conjunction via intl.formatList instead of
+  // hardcoding ' and ')
   const providerText =
     providerNames.length > 1 ? providerNames.join(' and ') : providerNames[0];
 
@@ -533,6 +541,7 @@ function OneKeyIdOAuthBindStatus({
         mx={0}
         borderRadius={0}
         userSelect="none"
+        // TODO: i18n (use a {provider} placeholder)
         title={`${providerText} Sign-In linked`}
         titleProps={{
           size: '$bodyMdMedium',

--- a/packages/kit/src/views/Prime/components/PrimeLoginEmailDialogV2/PrimeLoginEmailDialogV2.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeLoginEmailDialogV2/PrimeLoginEmailDialogV2.tsx
@@ -111,6 +111,7 @@ function PrimeLoginEmailDialogV2(props: {
                 try {
                   const token = await getAccessToken();
                   if (!token) {
+                    // TODO: i18n
                     throw new OneKeyLocalError(
                       'OneKey ID login failed: access token not found',
                     );

--- a/packages/kit/src/views/Prime/components/PrimeLoginOAuthDialog/PrimeLoginOAuthDialog.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeLoginOAuthDialog/PrimeLoginOAuthDialog.tsx
@@ -126,6 +126,7 @@ function PrimeLoginOAuthDialog(props: {
         setLoggingInProvider(provider);
         const result = await getOAuthAccessToken({
           provider,
+          // TODO: i18n
           missingTokenMessage: 'OAuth login failed: access token not found',
         });
         didUseOAuthSignIn = result.didUseOAuthSignIn;
@@ -261,11 +262,13 @@ function PrimeLoginOAuthDialog(props: {
       <Stack>
         <Dialog.Header>
           <Dialog.Icon icon="InfoCircleOutline" />
-          <Dialog.Title>Use Email Sign In?</Dialog.Title>
+          {/* TODO: i18n */}
+          <Dialog.Title>Use Email Sign-In?</Dialog.Title>
+          {/* TODO: i18n */}
           <Dialog.Description>
-            Email sign in is only available for existing OneKey ID accounts that
-            previously used email login. It does not support creating a new
-            OneKey ID with email.
+            Email sign-in is only available for existing OneKey ID accounts
+            that previously used email login. It can't be used to create a new
+            OneKey ID.
           </Dialog.Description>
         </Dialog.Header>
         <Dialog.Footer
@@ -337,7 +340,8 @@ function PrimeLoginOAuthDialog(props: {
         ) : null}
         {isLocalKeylessOAuthMode && localKeylessProvider ? (
           <SizableText size="$bodySm" color="$textSubdued" ta="center">
-            {`Use the ${localKeylessProviderName} account linked to your Keyless Wallet.`}
+            {/* TODO: i18n (use a {provider} placeholder) */}
+            {`Use the ${localKeylessProviderName} account linked to your Keyless wallet.`}
           </SizableText>
         ) : null}
         {showKeylessLogoutAction && isLocalKeylessOAuthMode ? (
@@ -398,7 +402,8 @@ function PrimeLoginOAuthDialog(props: {
                   variant="tertiary"
                   icon="InfoCircleOutline"
                   iconSize="$4"
-                  title="Email sign in"
+                  // TODO: i18n
+                  title="Email sign-in"
                   testID="prime-login-oauth-email-help-btn"
                   ml="$1"
                   onPress={showLegacyEmailLoginConfirm}

--- a/packages/shared/src/errors/errors/appErrors.ts
+++ b/packages/shared/src/errors/errors/appErrors.ts
@@ -356,9 +356,10 @@ export class OneKeyErrorOneKeyIdOAuthIdentityAlreadyBound extends OneKeyAppError
           };
     super(
       normalizeErrorProps(nextProps, {
-        // TODO: Remove this client fallback once the server returns message or translatedMessage for oauth_identity_already_bound.
+        // TODO: i18n — remove this client fallback once the server returns
+        // message or translatedMessage for oauth_identity_already_bound.
         defaultMessage:
-          'This Google or Apple account is already bound to another OneKey ID.',
+          'This Google or Apple account is already linked to another OneKey ID.',
         defaultAutoToast: true,
       }),
     );


### PR DESCRIPTION
## Summary

Copy-only follow-up to #12284: unify terminology across the hardcoded OneKey ID / Keyless OAuth strings introduced there, tighten wording without changing meaning, and mark every remaining hardcoded user-visible string with `// TODO: i18n` so the future translation pass can find them all with a single grep.

No logic changes — only string literals and comments.

## Terminology baseline (derived from existing `en_US.json`)

| Standard | Replaces | Rationale (existing corpus) |
| --- | --- | --- |
| `log out` (verb) | `sign out` | "Log out" 11 occurrences vs "Sign out" 0 (`log_out_wallet`, `keyless_wallet_logout_google_drive`, …) |
| `linked` | `bound`, `associated` | "linked" 14 occurrences vs "bound" 1 (`keyless_wallet_verify_pin_account_mismatch_desc`, …) |
| `Keyless wallet` (mid-sentence) | `Keyless Wallet` | matches `connect_wallet_keyless_singleton_desc`; title case reserved for headings |
| `sign-in` (noun) / `sign in` (verb) / `Sign-In` (heading) | mixed `sign in` / `Sign In` | consistent hyphenation of the noun form |

## Changes

- `oneKeyIdLogoutConsts.ts`: linked-logout dialog — "sign out of" → "log out of", "associated" → "linked".
- `useKeylessWallet.tsx`: continue-with-current-OneKey-ID dialog — "or sign out to use another…" → "or log out to use another…" (the cancel button is `global_logout`).
- `AccountMismatchDialog.tsx`: session-conflict dialog — "Continuing will log out of" → "Continuing will log you out of" (grammar).
- `OneKeyIdLegacyOAuthBind.tsx`:
  - provider-specific bind description — drop dangling "method" ("Add {provider} sign-in method…" → "Add {provider} sign-in…");
  - already-bound switch dialog — "Continue to log out … instead." → "Continuing will log out …" (matches the other confirm dialogs), drop the third repetition of the email.
- `PrimeLoginOAuthDialog.tsx`: "Use Email Sign In?" → "Use Email Sign-In?", tighten the legacy-email description, "Keyless Wallet" → "Keyless wallet", tooltip "Email sign in" → "Email sign-in".
- `appErrors.ts`: `OneKeyErrorOneKeyIdOAuthIdentityAlreadyBound` default message — "already bound to" → "already linked to" (matches the dialog title "Already Linked to Another OneKey ID").
- `ServiceKeylessWallet.ts`: "Keyless Wallet session" → "Keyless wallet session".
- `// TODO: i18n` markers added at every hardcoded user-visible string (dialog titles/descriptions, list-item title, tooltip, error fallbacks that can surface as toasts), including notes where the future key needs a `{provider}` placeholder, where the conditional sentence must become two full messages instead of concatenated fragments, and where the `' and '` list conjunction needs `intl.formatList`.

## Known i18n debt intentionally NOT addressed here

- `id_login_failed` is missing from the generated translations (dropped during an i18n merge); `showOneKeyIdLoginFailedToast` documents the fallback. Restore the key in Lokalise + `yarn i18n:pull`.
- New keys for all `TODO: i18n` sites should be added via `yarn i18n:add` / Lokalise in a dedicated pass; generated locale files are not touched in this PR.

## Test plan

- [x] Bun transpiler syntax check on all 9 edited files
- [ ] `yarn agent:check --profile commit` (dependency install still running in the session; will report/fix in a follow-up if anything trips)
- [x] Copy-only diff review: no logic, prop, or control-flow changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpNyxADTXvHG5W3x3J5fRA)_