### PR TITLE
fix: resolve five release 6.5.0 issues(OK-54831, OK-56215, OK-51901, OK-56908, OK-52908)

### DIFF
--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -133,7 +133,10 @@ import {
 import { vaultFactory } from '../vaults/factory';
 
 import ServiceBase from './ServiceBase';
-import { normalizeSwapTokenListCurrency } from './ServiceSwap.utils';
+import {
+  buildSwapRequestErrorToastPayload,
+  normalizeSwapTokenListCurrency,
+} from './ServiceSwap.utils';
 import { buildSpeedSwapTxParams } from './utils/buildSpeedSwapTxParams';
 import { getSwapHistoryStateTxIdParam } from './utils/swapHistoryStateUtils';
 import {
@@ -3329,11 +3332,9 @@ export default class ServiceSwap extends ServiceBase {
           data?: unknown;
         };
       };
-      void this.backgroundApi.serviceApp.showToast({
-        method: 'error',
-        title: error?.message ?? 'Request failed',
-        message: error?.requestId,
-      });
+      void this.backgroundApi.serviceApp.showToast(
+        buildSwapRequestErrorToastPayload(error),
+      );
       return undefined;
     }
   }

--- a/packages/kit-bg/src/services/ServiceSwap.utils.test.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.utils.test.ts
@@ -1,0 +1,27 @@
+import { buildSwapRequestErrorToastPayload } from './ServiceSwap.utils';
+
+describe('buildSwapRequestErrorToastPayload', () => {
+  it('keeps the request ID out of visible text while preserving diagnostics', () => {
+    const payload = buildSwapRequestErrorToastPayload({
+      message: 'Minimum value is 10 USDT',
+      requestId: 'req-123',
+    });
+
+    expect(payload).toEqual({
+      diagnosticText: 'RequestId: req-123',
+      method: 'error',
+      requestId: 'req-123',
+      title: 'Minimum value is 10 USDT',
+    });
+    expect(payload).not.toHaveProperty('message');
+  });
+
+  it('omits request diagnostics when the error has no request ID', () => {
+    expect(buildSwapRequestErrorToastPayload()).toEqual({
+      diagnosticText: undefined,
+      method: 'error',
+      requestId: undefined,
+      title: 'Request failed',
+    });
+  });
+});

--- a/packages/kit-bg/src/services/ServiceSwap.utils.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.utils.ts
@@ -1,5 +1,19 @@
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
+export function buildSwapRequestErrorToastPayload(error?: {
+  message?: string;
+  requestId?: string;
+}) {
+  return {
+    diagnosticText: error?.requestId
+      ? `RequestId: ${error.requestId}`
+      : undefined,
+    method: 'error' as const,
+    requestId: error?.requestId,
+    title: error?.message ?? 'Request failed',
+  };
+}
+
 export function normalizeSwapTokenListCurrency({
   tokens,
   currency,

--- a/packages/kit/src/components/TokenListView/TokenActionsView.tsx
+++ b/packages/kit/src/components/TokenListView/TokenActionsView.tsx
@@ -4,16 +4,13 @@ import { useIntl } from 'react-intl';
 
 import { Button, XStack } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
-import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EModalRoutes, EModalSwapRoutes } from '@onekeyhq/shared/src/routes';
 import { sortTokensCommon } from '@onekeyhq/shared/src/utils/tokenUtils';
-import { getSwapBridgeDefaultToToken } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import {
   ESwapSource,
   ESwapTabSwitchType,
-  type ISwapToken,
 } from '@onekeyhq/shared/types/swap/types';
 import type { IAccountToken, ITokenFiat } from '@onekeyhq/shared/types/token';
 
@@ -22,6 +19,12 @@ import { useAccountData } from '../../hooks/useAccountData';
 import { useUserWalletProfile } from '../../hooks/useUserWalletProfile';
 import { useActiveAccount } from '../../states/jotai/contexts/accountSelector';
 
+import {
+  buildTokenActionSwapFromToken,
+  getResolvedTokenActionToken,
+  getTokenActionSwapToToken,
+  isResolvedTokenActionReady,
+} from './TokenActionsView.utils';
 import { useTokenListViewContext } from './TokenListViewContext';
 
 import type { XStackProps } from 'tamagui';
@@ -44,12 +47,25 @@ function TokenActionsView(props: IProps) {
   // deleted; the wrapper threads the visible map + the owned aggregate sub-token
   // list-map through context instead.
   const tokenListMap = contextTokenListMap ?? EMPTY_FIAT_MAP;
+  const aggregateTokens = ownedAggregateTokenListMap?.[token.$key]?.tokens;
 
   const [activeToken, setActiveToken] = useState<IAccountToken>(token);
+  const resolvedActiveToken = getResolvedTokenActionToken({
+    token,
+    activeToken,
+    aggregateTokens,
+  });
+  const accountDataToken = resolvedActiveToken ?? token;
 
-  const { network, deriveType } = useAccountData({
-    accountId: activeToken.accountId,
-    networkId: activeToken.networkId,
+  const { account, network, deriveType } = useAccountData({
+    accountId: accountDataToken.accountId,
+    networkId: accountDataToken.networkId,
+  });
+  const isTokenActionReady = isResolvedTokenActionReady({
+    token,
+    resolvedToken: resolvedActiveToken,
+    resolvedAccountId: account?.id,
+    resolvedNetworkId: network?.id,
   });
 
   useEffect(() => {
@@ -62,7 +78,6 @@ function TokenActionsView(props: IProps) {
         return;
       }
 
-      const aggregateTokens = ownedAggregateTokenListMap?.[token.$key]?.tokens;
       if (!aggregateTokens?.length) {
         if (!isStale) {
           setActiveToken(token);
@@ -113,42 +128,37 @@ function TokenActionsView(props: IProps) {
     return () => {
       isStale = true;
     };
-  }, [token, ownedAggregateTokenListMap, tokenListMap]);
+  }, [aggregateTokens, token, tokenListMap]);
 
   const { isSoftwareWalletOnlyUser } = useUserWalletProfile();
   const navigation = useAppNavigation();
 
   const handleTokenOnSwap = useCallback(() => {
     void (async () => {
+      if (!resolvedActiveToken || !isTokenActionReady) {
+        return;
+      }
+
       const networkId =
-        activeToken.networkId ?? activeAccount?.network?.id ?? '';
-      const isBtcNativeToken =
-        networkId === getNetworkIdsMap().btc &&
-        activeToken.isNative &&
-        activeToken.symbol?.toUpperCase() === 'BTC' &&
-        !activeToken.address;
-      const importFromToken: ISwapToken | undefined = !isBtcNativeToken
-        ? {
-            contractAddress: activeToken.address,
-            symbol: activeToken.symbol,
-            networkId,
-            isNative: activeToken.isNative,
-            decimals: activeToken.decimals,
-            name: activeToken.name,
-            logoURI: activeToken.logoURI,
-            networkLogoURI: network?.logoURI ?? activeAccount?.network?.logoURI,
-          }
-        : undefined;
-      let importToToken: ISwapToken | undefined;
-      if (networkId && importFromToken) {
+        resolvedActiveToken.networkId ?? activeAccount?.network?.id ?? '';
+      const importFromToken = buildTokenActionSwapFromToken({
+        token: resolvedActiveToken,
+        networkId,
+        networkLogoURI: network?.logoURI ?? activeAccount?.network?.logoURI,
+      });
+      let importToToken = getTokenActionSwapToToken({
+        fromToken: importFromToken,
+      });
+      if (networkId && !importToToken) {
         try {
-          const { isSupportSwap, isSupportCrossChain } =
+          const swapSupport =
             await backgroundApiProxy.serviceSwap.checkSupportSwap({
               networkId,
             });
-          if (!isSupportSwap && isSupportCrossChain) {
-            importToToken = getSwapBridgeDefaultToToken(importFromToken);
-          }
+          importToToken = getTokenActionSwapToToken({
+            fromToken: importFromToken,
+            swapSupport,
+          });
         } catch {
           // Keep the existing Swap fallback if capability refresh fails.
         }
@@ -175,11 +185,12 @@ function TokenActionsView(props: IProps) {
     })();
   }, [
     activeAccount,
-    activeToken,
     isSoftwareWalletOnlyUser,
     navigation,
     network,
     deriveType,
+    isTokenActionReady,
+    resolvedActiveToken,
   ]);
 
   if (!token) {
@@ -194,6 +205,7 @@ function TokenActionsView(props: IProps) {
         variant="secondary"
         cursor="pointer"
         onPress={handleTokenOnSwap}
+        disabled={!isTokenActionReady}
       >
         {intl.formatMessage({ id: ETranslations.global_swap })}
       </Button>

--- a/packages/kit/src/components/TokenListView/TokenActionsView.utils.test.ts
+++ b/packages/kit/src/components/TokenListView/TokenActionsView.utils.test.ts
@@ -1,0 +1,239 @@
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+import type { IAccountToken } from '@onekeyhq/shared/types/token';
+
+import {
+  buildTokenActionSwapFromToken,
+  getResolvedTokenActionToken,
+  getTokenActionSwapToToken,
+  isResolvedTokenActionReady,
+} from './TokenActionsView.utils';
+
+function buildAccountToken(
+  overrides: Partial<IAccountToken> = {},
+): IAccountToken {
+  return {
+    $key: 'btc-token',
+    address: '',
+    decimals: 8,
+    isNative: true,
+    name: 'Bitcoin',
+    networkId: 'btc--0',
+    symbol: 'BTC',
+    ...overrides,
+  };
+}
+
+function buildSwapToken(overrides: Partial<ISwapToken> = {}): ISwapToken {
+  return {
+    contractAddress: '',
+    decimals: 8,
+    isNative: true,
+    name: 'Bitcoin',
+    networkId: 'btc--0',
+    symbol: 'BTC',
+    ...overrides,
+  };
+}
+
+describe('getResolvedTokenActionToken', () => {
+  it('keeps an aggregate action disabled until a concrete member is resolved', () => {
+    const aggregateToken = buildAccountToken({
+      $key: 'aggregate_BTC_',
+      address: 'aggregate_BTC_',
+      isAggregateToken: true,
+      networkId: 'aggregate--0',
+    });
+
+    expect(
+      getResolvedTokenActionToken({
+        token: aggregateToken,
+        activeToken: aggregateToken,
+        aggregateTokens: [buildAccountToken()],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns the concrete member selected for the current aggregate row', () => {
+    const aggregateToken = buildAccountToken({
+      $key: 'aggregate_BTC_',
+      address: 'aggregate_BTC_',
+      isAggregateToken: true,
+      networkId: 'aggregate--0',
+    });
+    const resolvedToken = buildAccountToken();
+
+    expect(
+      getResolvedTokenActionToken({
+        token: aggregateToken,
+        activeToken: resolvedToken,
+        aggregateTokens: [resolvedToken],
+      }),
+    ).toBe(resolvedToken);
+  });
+
+  it('rejects a stale member from another aggregate row', () => {
+    const aggregateToken = buildAccountToken({
+      $key: 'aggregate_BTC_',
+      address: 'aggregate_BTC_',
+      isAggregateToken: true,
+      networkId: 'aggregate--0',
+    });
+
+    expect(
+      getResolvedTokenActionToken({
+        token: aggregateToken,
+        activeToken: buildAccountToken({ $key: 'stale-token' }),
+        aggregateTokens: [buildAccountToken()],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns fresh metadata when the current aggregate member keeps the same key', () => {
+    const aggregateToken = buildAccountToken({
+      $key: 'aggregate_BTC_',
+      address: 'aggregate_BTC_',
+      isAggregateToken: true,
+      networkId: 'aggregate--0',
+    });
+    const staleToken = buildAccountToken({
+      accountId: 'stale-account',
+    });
+    const currentToken = buildAccountToken({
+      accountId: 'current-account',
+    });
+
+    expect(
+      getResolvedTokenActionToken({
+        token: aggregateToken,
+        activeToken: staleToken,
+        aggregateTokens: [currentToken],
+      }),
+    ).toBe(currentToken);
+  });
+});
+
+describe('isResolvedTokenActionReady', () => {
+  const aggregateToken = buildAccountToken({
+    $key: 'aggregate_BTC_',
+    address: 'aggregate_BTC_',
+    isAggregateToken: true,
+    networkId: 'aggregate--0',
+  });
+  const resolvedToken = buildAccountToken({
+    accountId: 'btc-account',
+  });
+
+  it('waits for account metadata from the resolved aggregate member', () => {
+    expect(
+      isResolvedTokenActionReady({
+        token: aggregateToken,
+        resolvedToken,
+        resolvedAccountId: 'stale-account',
+        resolvedNetworkId: resolvedToken.networkId,
+      }),
+    ).toBe(false);
+  });
+
+  it('waits for network metadata from the resolved aggregate member', () => {
+    expect(
+      isResolvedTokenActionReady({
+        token: aggregateToken,
+        resolvedToken,
+        resolvedAccountId: resolvedToken.accountId,
+        resolvedNetworkId: 'evm--1',
+      }),
+    ).toBe(false);
+  });
+
+  it('enables an aggregate action after token and account metadata match', () => {
+    expect(
+      isResolvedTokenActionReady({
+        token: aggregateToken,
+        resolvedToken,
+        resolvedAccountId: resolvedToken.accountId,
+        resolvedNetworkId: resolvedToken.networkId,
+      }),
+    ).toBe(true);
+  });
+
+  it('preserves the existing readiness behavior for a concrete token', () => {
+    expect(
+      isResolvedTokenActionReady({
+        token: resolvedToken,
+        resolvedToken,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('getTokenActionSwapToToken', () => {
+  it('normalizes the native address used by Home before resolving BTC to ETH', () => {
+    const fromToken = buildTokenActionSwapFromToken({
+      token: buildAccountToken({ address: 'native' }),
+      networkId: 'btc--0',
+    });
+
+    expect(fromToken.contractAddress).toBe('');
+    expect(
+      getTokenActionSwapToToken({
+        fromToken,
+        swapSupport: {
+          isSupportCrossChain: true,
+          isSupportSwap: true,
+        },
+      }),
+    ).toEqual(expect.objectContaining({ networkId: 'evm--1', symbol: 'ETH' }));
+  });
+
+  it.each([
+    undefined,
+    { isSupportCrossChain: true, isSupportSwap: false },
+    { isSupportCrossChain: true, isSupportSwap: true },
+  ])(
+    'keeps the BTC to ETH handoff deterministic for support %p',
+    (swapSupport) => {
+      expect(
+        getTokenActionSwapToToken({
+          fromToken: buildSwapToken(),
+          swapSupport,
+        }),
+      ).toEqual(
+        expect.objectContaining({ networkId: 'evm--1', symbol: 'ETH' }),
+      );
+    },
+  );
+
+  it('does not force an ordinary supported token into a bridge pair', () => {
+    expect(
+      getTokenActionSwapToToken({
+        fromToken: buildSwapToken({
+          decimals: 18,
+          name: 'Ethereum',
+          networkId: 'evm--1',
+          symbol: 'ETH',
+        }),
+        swapSupport: {
+          isSupportCrossChain: true,
+          isSupportSwap: true,
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('uses the bridge default for a cross-chain-only ordinary token', () => {
+    expect(
+      getTokenActionSwapToToken({
+        fromToken: buildSwapToken({
+          decimals: 9,
+          name: 'Solana',
+          networkId: 'sol--101',
+          symbol: 'SOL',
+        }),
+        swapSupport: {
+          isSupportCrossChain: true,
+          isSupportSwap: false,
+        },
+      }),
+    ).toEqual(expect.objectContaining({ networkId: 'evm--1', symbol: 'ETH' }));
+  });
+});

--- a/packages/kit/src/components/TokenListView/TokenActionsView.utils.ts
+++ b/packages/kit/src/components/TokenListView/TokenActionsView.utils.ts
@@ -1,0 +1,105 @@
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
+import { getSwapBridgeDefaultToToken } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
+import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
+import type { IAccountToken } from '@onekeyhq/shared/types/token';
+
+type ITokenActionSwapSupport = {
+  isSupportCrossChain?: boolean;
+  isSupportSwap?: boolean;
+};
+
+export function buildTokenActionSwapFromToken({
+  token,
+  networkId,
+  networkLogoURI,
+}: {
+  token: IAccountToken;
+  networkId: string;
+  networkLogoURI?: string;
+}): ISwapToken {
+  return {
+    contractAddress: token.isNative ? '' : token.address,
+    symbol: token.symbol,
+    networkId,
+    isNative: token.isNative,
+    decimals: token.decimals,
+    name: token.name,
+    logoURI: token.logoURI,
+    networkLogoURI,
+  };
+}
+
+export function getResolvedTokenActionToken({
+  token,
+  activeToken,
+  aggregateTokens,
+}: {
+  token: IAccountToken;
+  activeToken: IAccountToken;
+  aggregateTokens?: IAccountToken[];
+}) {
+  if (!token.isAggregateToken) {
+    return token;
+  }
+
+  if (activeToken.isAggregateToken) {
+    return undefined;
+  }
+
+  return aggregateTokens?.find(
+    (aggregateToken) => aggregateToken.$key === activeToken.$key,
+  );
+}
+
+export function isResolvedTokenActionReady({
+  token,
+  resolvedToken,
+  resolvedAccountId,
+  resolvedNetworkId,
+}: {
+  token: IAccountToken;
+  resolvedToken?: IAccountToken;
+  resolvedAccountId?: string;
+  resolvedNetworkId?: string;
+}) {
+  if (!resolvedToken) {
+    return false;
+  }
+
+  if (!token.isAggregateToken) {
+    return true;
+  }
+
+  if (
+    !resolvedToken.networkId ||
+    resolvedToken.networkId !== resolvedNetworkId
+  ) {
+    return false;
+  }
+
+  return (
+    !resolvedToken.accountId || resolvedToken.accountId === resolvedAccountId
+  );
+}
+
+export function getTokenActionSwapToToken({
+  fromToken,
+  swapSupport,
+}: {
+  fromToken: ISwapToken;
+  swapSupport?: ITokenActionSwapSupport;
+}) {
+  const isBtcNativeToken =
+    fromToken.networkId === getNetworkIdsMap().btc &&
+    fromToken.isNative &&
+    fromToken.symbol.toUpperCase() === 'BTC';
+
+  if (
+    isBtcNativeToken ||
+    (!swapSupport?.isSupportSwap && swapSupport?.isSupportCrossChain)
+  ) {
+    return getSwapBridgeDefaultToToken(fromToken);
+  }
+
+  return undefined;
+}

--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/components/ProtocolIntroSection.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/components/ProtocolIntroSection.tsx
@@ -23,6 +23,7 @@ import {
   Stack,
   XStack,
   YStack,
+  useMedia,
 } from '@onekeyhq/components';
 import {
   ANIMATE_ONLY_OPACITY,
@@ -32,6 +33,7 @@ import { EarnTestIDs } from '@onekeyhq/kit/src/views/Earn/testIDs';
 import { EarnIcon } from '@onekeyhq/kit/src/views/Staking/components/ProtocolDetails/EarnIcon';
 import { EarnText } from '@onekeyhq/kit/src/views/Staking/components/ProtocolDetails/EarnText';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 import type {
   IEarnProtocolIntroAudit,
@@ -345,10 +347,18 @@ function hasProtocolIntroItemContent(item: IEarnProtocolIntroItem) {
 }
 
 const DIALOG_CONTENT_MAX_HEIGHT = 512;
+const COMPACT_DIALOG_CONTENT_HEIGHT = 260;
 
 function DialogContent({ children }: { children: React.ReactNode }) {
+  const { md } = useMedia();
+  const isCompact = Boolean(platformEnv.isRuntimeBrowser && md);
+
   return (
-    <ScrollView maxHeight={DIALOG_CONTENT_MAX_HEIGHT} nestedScrollEnabled>
+    <ScrollView
+      height={isCompact ? COMPACT_DIALOG_CONTENT_HEIGHT : undefined}
+      maxHeight={isCompact ? undefined : DIALOG_CONTENT_MAX_HEIGHT}
+      nestedScrollEnabled
+    >
       <YStack px="$5" pb="$5">
         {children}
       </YStack>
@@ -1561,6 +1571,7 @@ function ProtocolIntroSectionComponent({
           variant: 'secondary',
         },
         showCancelButton: false,
+        disableDrag: platformEnv.isRuntimeBrowser,
       });
     },
     [intl],

--- a/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
+++ b/packages/kit/src/views/Home/components/TokenListBlock/TokenListBlock.tsx
@@ -2701,6 +2701,7 @@ function TokenListBlock({
             variant="tertiary"
             icon="SliderHorOutline"
             onPress={handleOnManageToken}
+            disabled={showLpTokensOnly}
             size="medium"
           />
         </XStack>
@@ -2750,7 +2751,7 @@ function TokenListBlock({
           showLpTokensOnly ? false : !!network?.isAllNetworks
         }
         deferTokenManagement={!!network?.isAllNetworks}
-        manageTokenEnabled={manageTokenEnabled}
+        manageTokenEnabled={manageTokenEnabled && !showLpTokensOnly}
         onManageToken={handleOnManageToken}
         onPressToken={handleOnPressToken}
         isAllNetworks={network?.isAllNetworks}

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.test.ts
@@ -6,9 +6,12 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 
 import type { IAddressQueryResult } from '@onekeyhq/kit/src/components/AddressInput';
 import type { IQueryCheckAddressArgs } from '@onekeyhq/shared/types/address';
+import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
 
 import {
   shouldBlockSwapActionForIncognitoRecipientInput,
+  shouldEnableSwapIncognitoRecipientValidation,
+  shouldShowSwapIncognitoRecipientInput,
   useSwapIncognitoRecipientInput,
 } from './useSwapIncognitoRecipientInput';
 
@@ -28,6 +31,7 @@ type IHookProps = {
   clearRecipientAddressOnHide?: boolean;
   networkId?: string;
   swapToAnotherAccountSwitchOn: boolean;
+  validationEnabled: boolean;
   visible: boolean;
 };
 
@@ -150,6 +154,7 @@ describe('useSwapIncognitoRecipientInput', () => {
       accountId: 'account-1',
       address: undefined,
       swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
     });
 
     act(() => {
@@ -173,6 +178,7 @@ describe('useSwapIncognitoRecipientInput', () => {
       accountId: 'account-1',
       address: undefined,
       swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
     });
 
     await act(async () => {
@@ -205,6 +211,7 @@ describe('useSwapIncognitoRecipientInput', () => {
       accountId: 'account-1',
       address: undefined,
       swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
     });
 
     act(() => {
@@ -225,11 +232,297 @@ describe('useSwapIncognitoRecipientInput', () => {
       accountId: 'account-1',
       address: undefined,
       swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
     });
 
     expect(result.current.inputText).toBe('');
     expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(false);
     expect(mockSwapToAddressState.address).toBeUndefined();
+
+    await flushDebounce();
+    expect(mockQueryAddressWithFallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves typed text until the recipient validation context is ready', async () => {
+    mockQueryAddressWithFallback.mockResolvedValueOnce({
+      input: '0xrecipient',
+      resolveAddress: '0xresolved-recipient',
+      validStatus: 'valid',
+    });
+
+    const { result, rerender } = renderUseSwapIncognitoRecipientInput({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: undefined,
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+      validationEnabled: false,
+    });
+
+    act(() => {
+      result.current.onInputChange('0xrecipient');
+    });
+
+    await flushDebounce();
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.inputText).toBe('0xrecipient');
+    expect(mockQueryAddressWithFallback).not.toHaveBeenCalled();
+    expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(false);
+    expect(mockSwapToAddressState.address).toBeUndefined();
+
+    rerender({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'evm--1',
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
+    });
+
+    expect(result.current.inputText).toBe('0xrecipient');
+
+    await flushDebounce();
+
+    await waitFor(() => {
+      expect(mockQueryAddressWithFallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId: 'account-1',
+          address: '0xrecipient',
+          networkId: 'evm--1',
+        }),
+      );
+      expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(true);
+      expect(mockSwapToAddressState.address).toBe('0xresolved-recipient');
+    });
+  });
+
+  it('preserves raw text typed while validation is paused after another network was enabled', async () => {
+    mockQueryAddressWithFallback.mockResolvedValueOnce({
+      input: 'sol-recipient',
+      resolveAddress: 'sol-resolved-recipient',
+      validStatus: 'valid',
+    });
+
+    const { result, rerender } = renderUseSwapIncognitoRecipientInput({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'evm--1',
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
+    });
+
+    rerender({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'evm--1',
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+      validationEnabled: false,
+    });
+
+    act(() => {
+      result.current.onInputChange('sol-recipient');
+    });
+
+    rerender({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'sol--101',
+      accountId: 'account-sol',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
+    });
+
+    expect(result.current.inputText).toBe('sol-recipient');
+
+    await flushDebounce();
+
+    await waitFor(() => {
+      expect(mockQueryAddressWithFallback).toHaveBeenCalledTimes(1);
+      expect(mockQueryAddressWithFallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId: 'account-sol',
+          address: 'sol-recipient',
+          networkId: 'sol--101',
+        }),
+      );
+      expect(mockSwapToAddressState.address).toBe('sol-resolved-recipient');
+    });
+  });
+
+  it('waits for the resolved target account before validating preserved text', async () => {
+    mockQueryAddressWithFallback.mockResolvedValueOnce({
+      input: '0xrecipient',
+      resolveAddress: '0xresolved-recipient',
+      validStatus: 'valid',
+    });
+
+    const { result, rerender } = renderUseSwapIncognitoRecipientInput({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'evm--10',
+      accountId: 'stale-account',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+      validationEnabled: false,
+    });
+
+    act(() => {
+      result.current.onInputChange('0xrecipient');
+    });
+
+    await flushDebounce();
+
+    expect(result.current.inputText).toBe('0xrecipient');
+    expect(mockQueryAddressWithFallback).not.toHaveBeenCalled();
+
+    rerender({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'evm--10',
+      accountId: 'resolved-account',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
+    });
+
+    await flushDebounce();
+
+    await waitFor(() => {
+      expect(mockQueryAddressWithFallback).toHaveBeenCalledTimes(1);
+      expect(mockQueryAddressWithFallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId: 'resolved-account',
+          address: '0xrecipient',
+          networkId: 'evm--10',
+        }),
+      );
+    });
+  });
+
+  it('preserves edited text when switching networks before it is revalidated', async () => {
+    mockQueryAddressWithFallback
+      .mockResolvedValueOnce({
+        input: '0xrecipient',
+        resolveAddress: '0xresolved-recipient',
+        validStatus: 'valid',
+      })
+      .mockResolvedValueOnce({
+        input: 'sol-recipient',
+        resolveAddress: 'sol-resolved-recipient',
+        validStatus: 'valid',
+      });
+
+    const { result, rerender } = renderUseSwapIncognitoRecipientInput({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'evm--1',
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
+    });
+
+    act(() => {
+      result.current.onInputChange('0xrecipient');
+    });
+
+    await flushDebounce();
+
+    await waitFor(() => {
+      expect(mockSwapToAddressState.address).toBe('0xresolved-recipient');
+    });
+
+    act(() => {
+      result.current.onInputChange('sol-recipient');
+    });
+
+    rerender({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'sol--101',
+      accountId: 'account-sol',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
+    });
+
+    expect(result.current.inputText).toBe('sol-recipient');
+
+    await flushDebounce();
+
+    await waitFor(() => {
+      expect(mockQueryAddressWithFallback).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          accountId: 'account-sol',
+          address: 'sol-recipient',
+          networkId: 'sol--101',
+        }),
+      );
+      expect(mockSwapToAddressState.address).toBe('sol-resolved-recipient');
+    });
+  });
+
+  it('clears input after a validated network changes while validation is paused', async () => {
+    mockQueryAddressWithFallback.mockResolvedValueOnce({
+      input: '0xrecipient',
+      resolveAddress: '0xresolved-recipient',
+      validStatus: 'valid',
+    });
+
+    const { result, rerender } = renderUseSwapIncognitoRecipientInput({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'evm--1',
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
+    });
+
+    act(() => {
+      result.current.onInputChange('0xrecipient');
+    });
+
+    await flushDebounce();
+
+    await waitFor(() => {
+      expect(mockSwapToAddressState.address).toBe('0xresolved-recipient');
+    });
+
+    rerender({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'sol--101',
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+      validationEnabled: false,
+    });
+
+    expect(result.current.inputText).toBe('0xrecipient');
+    expect(mockSwapToAddressState.address).toBeUndefined();
+
+    rerender({
+      visible: true,
+      clearRecipientAddressOnHide: false,
+      networkId: 'sol--101',
+      accountId: 'account-1',
+      address: undefined,
+      swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
+    });
+
+    expect(result.current.inputText).toBe('');
+    expect(mockSettingsState.swapToAnotherAccountSwitchOn).toBe(false);
 
     await flushDebounce();
     expect(mockQueryAddressWithFallback).toHaveBeenCalledTimes(1);
@@ -255,6 +548,7 @@ describe('useSwapIncognitoRecipientInput', () => {
       accountId: 'account-1',
       address: undefined,
       swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
     });
 
     act(() => {
@@ -275,6 +569,7 @@ describe('useSwapIncognitoRecipientInput', () => {
       accountId: 'account-2',
       address: undefined,
       swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
     });
 
     expect(result.current.inputText).toBe('0xrecipient');
@@ -311,6 +606,7 @@ describe('useSwapIncognitoRecipientInput', () => {
       accountId: 'account-1',
       address: undefined,
       swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
     });
 
     act(() => {
@@ -331,6 +627,7 @@ describe('useSwapIncognitoRecipientInput', () => {
       accountId: 'account-1',
       address: mockSwapToAddressState.address,
       swapToAnotherAccountSwitchOn: true,
+      validationEnabled: true,
     });
 
     await flushAsync();
@@ -354,6 +651,7 @@ describe('useSwapIncognitoRecipientInput', () => {
       accountId: 'account-1',
       address: undefined,
       swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
     });
 
     act(() => {
@@ -374,6 +672,7 @@ describe('useSwapIncognitoRecipientInput', () => {
       accountId: 'account-1',
       address: mockSwapToAddressState.address,
       swapToAnotherAccountSwitchOn: true,
+      validationEnabled: true,
     });
 
     await flushAsync();
@@ -397,6 +696,7 @@ describe('useSwapIncognitoRecipientInput', () => {
       accountId: 'account-1',
       address: '0xresolved-recipient',
       swapToAnotherAccountSwitchOn: true,
+      validationEnabled: true,
     });
 
     await flushDebounce();
@@ -414,6 +714,7 @@ describe('useSwapIncognitoRecipientInput', () => {
       accountId: 'account-1',
       address: undefined,
       swapToAnotherAccountSwitchOn: false,
+      validationEnabled: true,
     });
 
     await waitFor(() => {
@@ -426,10 +727,12 @@ describe('shouldBlockSwapActionForIncognitoRecipientInput', () => {
   it('blocks review while the recipient input is still unresolved', () => {
     expect(
       shouldBlockSwapActionForIncognitoRecipientInput({
-        enabled: true,
         inputText: '0xrecipient',
+        isConnectWalletAction: false,
         loading: false,
         queryResult: {},
+        validationEnabled: true,
+        visible: true,
       }),
     ).toBe(true);
   });
@@ -437,12 +740,131 @@ describe('shouldBlockSwapActionForIncognitoRecipientInput', () => {
   it('allows review after the recipient input is validated', () => {
     expect(
       shouldBlockSwapActionForIncognitoRecipientInput({
-        enabled: true,
         inputText: '0xrecipient',
+        isConnectWalletAction: false,
         loading: false,
         queryResult: {
           validStatus: 'valid',
         },
+        validationEnabled: true,
+        visible: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('blocks review while a visible recipient is waiting for validation readiness', () => {
+    expect(
+      shouldBlockSwapActionForIncognitoRecipientInput({
+        inputText: '0xrecipient',
+        isConnectWalletAction: false,
+        loading: false,
+        queryResult: {
+          validStatus: 'valid',
+        },
+        validationEnabled: false,
+        visible: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('blocks review while a validated recipient is being rechecked', () => {
+    expect(
+      shouldBlockSwapActionForIncognitoRecipientInput({
+        inputText: '0xrecipient',
+        isConnectWalletAction: false,
+        loading: true,
+        queryResult: {
+          validStatus: 'valid',
+        },
+        validationEnabled: true,
+        visible: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not block review after the recipient input is hidden', () => {
+    expect(
+      shouldBlockSwapActionForIncognitoRecipientInput({
+        inputText: '0xrecipient',
+        isConnectWalletAction: false,
+        loading: false,
+        queryResult: {},
+        validationEnabled: false,
+        visible: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not block review for an empty recipient input', () => {
+    expect(
+      shouldBlockSwapActionForIncognitoRecipientInput({
+        inputText: '   ',
+        isConnectWalletAction: false,
+        loading: false,
+        queryResult: {},
+        validationEnabled: false,
+        visible: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps Connect Wallet available while recipient validation is pending', () => {
+    expect(
+      shouldBlockSwapActionForIncognitoRecipientInput({
+        inputText: '0xrecipient',
+        isConnectWalletAction: true,
+        loading: false,
+        queryResult: {},
+        validationEnabled: false,
+        visible: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('shouldEnableSwapIncognitoRecipientValidation', () => {
+  const readyParams = {
+    hasFromToken: true,
+    hasToToken: true,
+    isAddressInfoReady: true,
+    networkId: 'evm--1',
+    providerSupportsRecipient: true,
+    visible: true,
+  };
+
+  it('waits for the target address context to resolve', () => {
+    expect(
+      shouldEnableSwapIncognitoRecipientValidation({
+        ...readyParams,
+        isAddressInfoReady: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('enables validation after every recipient dependency is ready', () => {
+    expect(shouldEnableSwapIncognitoRecipientValidation(readyParams)).toBe(
+      true,
+    );
+  });
+});
+
+describe('shouldShowSwapIncognitoRecipientInput', () => {
+  it('keeps the input visible before token selection while support is available', () => {
+    expect(
+      shouldShowSwapIncognitoRecipientInput({
+        incognitoMode: true,
+        providerSupportsRecipient: true,
+        swapType: ESwapTabSwitchType.SWAP,
+      }),
+    ).toBe(true);
+  });
+
+  it('hides the input when the selected provider cannot use the address', () => {
+    expect(
+      shouldShowSwapIncognitoRecipientInput({
+        incognitoMode: true,
+        providerSupportsRecipient: false,
+        swapType: ESwapTabSwitchType.SWAP,
       }),
     ).toBe(false);
   });

--- a/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapIncognitoRecipientInput.ts
@@ -13,9 +13,11 @@ import { useSwapToAnotherAccountAddressAtom } from '@onekeyhq/kit/src/states/jot
 import { useSettingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import stringUtils from '@onekeyhq/shared/src/utils/stringUtils';
+import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
 
 type IUseSwapIncognitoRecipientInputParams = {
   visible: boolean;
+  validationEnabled: boolean;
   clearRecipientAddressOnHide?: boolean;
   networkId?: string;
   accountId?: string;
@@ -25,10 +27,27 @@ type IUseSwapIncognitoRecipientInputParams = {
 };
 
 type IShouldBlockSwapActionForIncognitoRecipientInputParams = {
-  enabled: boolean;
   inputText: string;
+  isConnectWalletAction: boolean;
   loading: boolean;
   queryResult: Pick<IAddressQueryResult, 'validStatus'>;
+  validationEnabled: boolean;
+  visible: boolean;
+};
+
+type IShouldEnableSwapIncognitoRecipientValidationParams = {
+  hasFromToken: boolean;
+  hasToToken: boolean;
+  isAddressInfoReady: boolean;
+  networkId?: string;
+  providerSupportsRecipient: boolean;
+  visible: boolean;
+};
+
+type IShouldShowSwapIncognitoRecipientInputParams = {
+  incognitoMode: boolean;
+  providerSupportsRecipient: boolean;
+  swapType: ESwapTabSwitchType;
 };
 
 type IAddressValidationContext = {
@@ -53,24 +72,62 @@ function isSameAddressValidationContext(
 }
 
 export function shouldBlockSwapActionForIncognitoRecipientInput({
-  enabled,
   inputText,
+  isConnectWalletAction,
   loading,
   queryResult,
+  validationEnabled,
+  visible,
 }: IShouldBlockSwapActionForIncognitoRecipientInputParams) {
-  if (!enabled || !inputText.trim()) {
+  if (isConnectWalletAction) {
     return false;
   }
 
-  if (loading) {
+  if (!visible || !inputText.trim()) {
+    return false;
+  }
+
+  if (!validationEnabled || loading) {
     return true;
   }
 
   return queryResult.validStatus !== 'valid';
 }
 
+export function shouldEnableSwapIncognitoRecipientValidation({
+  hasFromToken,
+  hasToToken,
+  isAddressInfoReady,
+  networkId,
+  providerSupportsRecipient,
+  visible,
+}: IShouldEnableSwapIncognitoRecipientValidationParams) {
+  return Boolean(
+    visible &&
+    providerSupportsRecipient &&
+    hasFromToken &&
+    hasToToken &&
+    networkId &&
+    isAddressInfoReady,
+  );
+}
+
+export function shouldShowSwapIncognitoRecipientInput({
+  incognitoMode,
+  providerSupportsRecipient,
+  swapType,
+}: IShouldShowSwapIncognitoRecipientInputParams) {
+  return Boolean(
+    incognitoMode &&
+    providerSupportsRecipient &&
+    swapType !== ESwapTabSwitchType.LIMIT &&
+    swapType !== ESwapTabSwitchType.STOCK,
+  );
+}
+
 export function useSwapIncognitoRecipientInput({
   visible,
+  validationEnabled,
   clearRecipientAddressOnHide,
   networkId,
   accountId,
@@ -101,7 +158,14 @@ export function useSwapIncognitoRecipientInput({
     networkId,
   });
 
-  const enabled = visible && !!networkId;
+  const enabled = visible && validationEnabled && !!networkId;
+  const validatedInputRef = useRef<
+    | {
+        networkId: string;
+        queryText: string;
+      }
+    | undefined
+  >(undefined);
 
   validationContextRef.current = {
     accountId,
@@ -164,6 +228,7 @@ export function useSwapIncognitoRecipientInput({
           validationContextRef.current,
         )
       ) {
+        validatedInputRef.current = undefined;
         setLoading(false);
         setQueryResult({});
       }
@@ -198,11 +263,16 @@ export function useSwapIncognitoRecipientInput({
         const resolvedAddress = getAddressQueryResolvedAddress(result);
 
         if (resolvedAddress) {
+          validatedInputRef.current = {
+            networkId: requestContext.networkId,
+            queryText: requestContext.queryText,
+          };
           syncRecipientAddress(resolvedAddress);
+          return;
         }
-        return;
       }
 
+      validatedInputRef.current = undefined;
       syncRecipientAddress(undefined);
     } finally {
       if (
@@ -230,6 +300,7 @@ export function useSwapIncognitoRecipientInput({
       setQueryResult({});
 
       if (clearInput) {
+        validatedInputRef.current = undefined;
         textRef.current = '';
         setInputText('');
       }
@@ -242,7 +313,7 @@ export function useSwapIncognitoRecipientInput({
   );
 
   useEffect(() => {
-    if (!enabled) {
+    if (!visible) {
       validationScopeRef.current = {
         accountId,
         networkId,
@@ -254,25 +325,39 @@ export function useSwapIncognitoRecipientInput({
       return;
     }
 
+    if (!enabled) {
+      validationScopeRef.current = {
+        accountId,
+        networkId,
+      };
+      resetValidationState({
+        clearRecipientAddress: true,
+      });
+      return;
+    }
+
     const prevScope = validationScopeRef.current;
     const nextScope = {
       accountId,
       networkId,
     };
+    const validatedInput = validatedInputRef.current;
+    const isValidatedNetworkChanged =
+      validatedInput?.queryText === textRef.current.trim() &&
+      validatedInput.networkId !== nextScope.networkId;
 
     validationScopeRef.current = nextScope;
 
     if (
       prevScope.accountId === nextScope.accountId &&
-      prevScope.networkId === nextScope.networkId
+      prevScope.networkId === nextScope.networkId &&
+      !isValidatedNetworkChanged
     ) {
       return;
     }
 
-    const isNetworkChanged = prevScope.networkId !== nextScope.networkId;
-
     resetValidationState({
-      clearInput: isNetworkChanged,
+      clearInput: isValidatedNetworkChanged,
       clearRecipientAddress: true,
     });
   }, [
@@ -281,6 +366,7 @@ export function useSwapIncognitoRecipientInput({
     enabled,
     networkId,
     resetValidationState,
+    visible,
   ]);
 
   useEffect(() => {
@@ -303,6 +389,7 @@ export function useSwapIncognitoRecipientInput({
     }
 
     textRef.current = nextText;
+    validatedInputRef.current = undefined;
     setInputText(nextText);
     setQueryResult({});
   }, [address, enabled, swapToAnotherAccountSwitchOn]);
@@ -323,6 +410,10 @@ export function useSwapIncognitoRecipientInput({
       const trimmedNextText = nextText.trim();
 
       if (textRef.current === nextText) {
+        if (!enabled) {
+          return;
+        }
+
         const shouldKeepCurrentValidation =
           !trimmedNextText ||
           (queryResult.validStatus === 'valid' &&
@@ -342,6 +433,7 @@ export function useSwapIncognitoRecipientInput({
         return;
       }
 
+      validatedInputRef.current = undefined;
       textRef.current = nextText;
       setInputText(nextText);
       setQueryResult({});
@@ -349,6 +441,7 @@ export function useSwapIncognitoRecipientInput({
     },
     [
       address,
+      enabled,
       queryAddress,
       queryResult.validStatus,
       swapToAnotherAccountSwitchOn,

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -65,6 +65,8 @@ import {
 } from '../../hooks/useSwapAccount';
 import {
   shouldBlockSwapActionForIncognitoRecipientInput,
+  shouldEnableSwapIncognitoRecipientValidation,
+  shouldShowSwapIncognitoRecipientInput,
   useSwapIncognitoRecipientInput,
 } from '../../hooks/useSwapIncognitoRecipientInput';
 import {
@@ -201,19 +203,32 @@ const SwapActionsState = ({
 
   const shouldShowIncognitoRecipientInput = useMemo(
     () =>
-      !!(
-        swapIncognitoMode &&
-        swapProviderSupportReceiveAddress &&
-        fromToken &&
-        toToken &&
-        swapTypeSwitch !== ESwapTabSwitchType.LIMIT &&
-        swapTypeSwitch !== ESwapTabSwitchType.STOCK
-      ),
+      shouldShowSwapIncognitoRecipientInput({
+        incognitoMode: swapIncognitoMode,
+        providerSupportsRecipient: swapProviderSupportReceiveAddress,
+        swapType: swapTypeSwitch,
+      }),
+    [swapIncognitoMode, swapProviderSupportReceiveAddress, swapTypeSwitch],
+  );
+
+  const incognitoRecipientNetworkId =
+    toToken?.networkId ?? swapToAddressInfo.networkId;
+  const shouldValidateIncognitoRecipientInput = useMemo(
+    () =>
+      shouldEnableSwapIncognitoRecipientValidation({
+        hasFromToken: Boolean(fromToken),
+        hasToToken: Boolean(toToken),
+        isAddressInfoReady: swapToAddressInfo.isAddressInfoReady,
+        networkId: incognitoRecipientNetworkId,
+        providerSupportsRecipient: swapProviderSupportReceiveAddress,
+        visible: shouldShowIncognitoRecipientInput,
+      }),
     [
       fromToken,
-      swapIncognitoMode,
+      incognitoRecipientNetworkId,
+      shouldShowIncognitoRecipientInput,
       swapProviderSupportReceiveAddress,
-      swapTypeSwitch,
+      swapToAddressInfo.isAddressInfoReady,
       toToken,
     ],
   );
@@ -225,8 +240,9 @@ const SwapActionsState = ({
 
   const incognitoRecipientInput = useSwapIncognitoRecipientInput({
     visible: shouldShowIncognitoRecipientInput,
+    validationEnabled: shouldValidateIncognitoRecipientInput,
     clearRecipientAddressOnHide,
-    networkId: toToken?.networkId ?? swapToAddressInfo.networkId,
+    networkId: incognitoRecipientNetworkId,
     accountId:
       swapToAddressInfo.accountInfo?.account?.id ??
       swapToAddressInfo.activeAccount?.account?.id,
@@ -273,10 +289,12 @@ const SwapActionsState = ({
 
   const shouldBlockIncognitoRecipientAction =
     shouldBlockSwapActionForIncognitoRecipientInput({
-      enabled: incognitoRecipientInput.enabled,
       inputText: incognitoRecipientInput.inputText,
+      isConnectWalletAction: Boolean(swapActionState.noConnectWallet),
       loading: incognitoRecipientInput.loading,
       queryResult: incognitoRecipientInput.queryResult,
+      validationEnabled: incognitoRecipientInput.enabled,
+      visible: shouldShowIncognitoRecipientInput,
     });
 
   const isActionDisabled =
@@ -285,10 +303,6 @@ const SwapActionsState = ({
     shouldBlockIncognitoRecipientAction;
 
   const onActionHandlerBefore = useCallback(async () => {
-    if (shouldBlockIncognitoRecipientAction) {
-      return;
-    }
-
     if (swapActionState.noConnectWallet) {
       if (platformEnv.isWebDappMode) {
         navigation.pushModal(EModalRoutes.OnboardingModal, {
@@ -302,6 +316,9 @@ const SwapActionsState = ({
           },
         });
       }
+      return;
+    }
+    if (shouldBlockIncognitoRecipientAction) {
       return;
     }
     if (swapActionState.isRefreshQuote) {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-54831](https://onekeyhq.atlassian.net/browse/OK-54831) [OK-56215](https://onekeyhq.atlassian.net/browse/OK-56215) [OK-51901](https://onekeyhq.atlassian.net/browse/OK-51901) [OK-56908](https://onekeyhq.atlassian.net/browse/OK-56908) [OK-52908](https://onekeyhq.atlassian.net/browse/OK-52908)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Fix five QA-reported wallet, DeFi, Swap, and extension issues for `release/v6.5.0`.
- Rebuild the batch on the latest release head as exactly one issue-scoped commit per issue, without rollback noise.
- Add focused regression coverage for deterministic BTC handoff and incognito recipient lifecycle behavior.
- Keep OK-57834, OK-54961, and OK-57826 out of scope; their earlier changes are absent from this branch.

## Issues

- [OK-54831](https://onekeyhq.atlassian.net/browse/OK-54831)
- [OK-56215](https://onekeyhq.atlassian.net/browse/OK-56215)
- [OK-51901](https://onekeyhq.atlassian.net/browse/OK-51901)
- [OK-56908](https://onekeyhq.atlassian.net/browse/OK-56908)
- [OK-52908](https://onekeyhq.atlassian.net/browse/OK-52908)

## Commit Structure

| Issue | Commit |
| --- | --- |
| OK-54831 | `50b417d9e9` |
| OK-51901 | `0cf2c52044` |
| OK-56215 | `8eea4b98f8` |
| OK-56908 | `e4adc4e764` |
| OK-52908 | `7b9bf7db8d` |

Each included issue has exactly one commit.

## Intent & Context

This batch addresses OK-54831, OK-56215, OK-51901, OK-56908, and OK-52908 on top of the latest `release/v6.5.0`. The goal is to preserve the already verified user-visible fixes while closing capability failures, responsive resize, aggregate-token timing, and recipient-validation edge cases found during strict review.

## Root Cause

| Issue | Root cause |
| --- | --- |
| OK-54831 | The token-management action did not inherit the DeFi-only filter's disabled state. |
| OK-56215 | Protocol dialog sizing was derived outside the portal and could retain a stale desktop/mobile breakpoint while the dialog host changed responsively. |
| OK-51901 | The structured request ID was passed through the user-visible toast `message` field. |
| OK-56908 | Native BTC was excluded from the imported source token, and the initial BTC to ETH pair still depended on a fallible capability request; aggregate rows could also act before a concrete member and its account/network metadata resolved. |
| OK-52908 | Incognito recipient visibility was coupled to token readiness, while validation provenance and target-account readiness were incomplete; an unsupported provider could leave visible input that was not used, and the same guard could run before the disconnected-wallet action and disable the Connect Wallet CTA. |

## Design Decisions

- Keep responsive media evaluation inside the dialog portal content so an open dialog follows viewport changes; disable drag only for browser-hosted sheets.
- Keep request IDs in the structured `requestId` and `diagnosticText` fields so Contact/Copy actions remain available without rendering the UUID as body text.
- Normalize native Home token addresses before Swap handoff and resolve native BTC to ETH locally, independent of capability response success or flags.
- Disable aggregate-row Swap actions until a fresh concrete member and its matching account/network metadata resolve.
- Preserve unvalidated incognito input while token/account context is unavailable, clear only text proven against another network, hide the field when the selected provider explicitly cannot use it, and let Connect Wallet run before recipient validation while disconnected; after connection the same guard still blocks Review until valid.

## Changes Detail

| Issue | Change |
| --- | --- |
| OK-54831 | Disable token management while the DeFi token view is active. |
| OK-56215 | Make protocol dialog height respond inside the portal and keep compact browser sheets scrollable. |
| OK-51901 | Move the Swap build error request ID out of toast message text while retaining structured request and diagnostic fields for support actions. |
| OK-56908 | Normalize native BTC, seed a deterministic BTC to ETH pair, and gate aggregate actions until the fresh member and matching account/network metadata resolve. |
| OK-52908 | Show the incognito recipient before token selection, wait for target-account readiness, preserve unvalidated text, block Review while visible validation is pending, keep Connect Wallet available while disconnected, and hide unsupported recipient input. |

## Risk Assessment

- **Risk Level**: Medium
- **Affected Platforms**: Extension, Mobile, Desktop, Web
- **Risk Areas**: Home to Swap handoff, recipient/token selection state, toast diagnostics, and responsive dialog sizing.
- **Runtime boundary**: UI and input state remain in the main JS runtime. On native and extension targets, main and background initialize independently with separate JS heaps; no new shared native resource or persistence schema was introduced. Swap service calls remain behind the existing background API. Desktop and web remain single-runtime.
- **Transaction safety**: No quote execution, build, signing, confirmation, send, or broadcast gate was relaxed. Existing disabled, validation, account/network, and transaction gates remain authoritative.

## Test plan

- [x] Run `yarn agent:check --profile commit` before delivery and again after consolidating the history to one commit per issue.
- [x] Run `yarn agent:check --profile pr`; local lint and TypeScript checks pass, while the existing review-required/release-ready gates remain visible.
- [x] Run 58 focused Jest tests for BTC native/aggregate handoff and metadata readiness, incognito recipient readiness, account selection/settings, and request-ID diagnostics.
- [x] Run 48 focused Jest tests for the recipient/no-wallet review follow-up, including pending validation and Connect Wallet priority.
- [x] Run `git diff --check` against the latest `release/v6.5.0`.
- [x] Confirm OK-57834, OK-54961, and OK-57826 are absent from the effective diff.
- [x] Complete independent strict re-review of the final Swap/Home, recipient/toast, and DeFi/dialog changes with no remaining findings.
- [x] Preserve the existing Desktop, iOS Simulator, and extension issue-flow self-test evidence from the original batch.
- [ ] Recheck open-dialog resize, native BTC Home entry, and provider-unsupported recipient behavior in the updated release bundle.

[OK-54831]: https://onekeyhq.atlassian.net/browse/OK-54831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-56215]: https://onekeyhq.atlassian.net/browse/OK-56215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-51901]: https://onekeyhq.atlassian.net/browse/OK-51901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-56908]: https://onekeyhq.atlassian.net/browse/OK-56908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-52908]: https://onekeyhq.atlassian.net/browse/OK-52908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ