### PR TITLE
fix: dedupe passkey Webpack chunks

### DIFF
--- a/development/webpack/webpack.ext.config.js
+++ b/development/webpack/webpack.ext.config.js
@@ -26,6 +26,30 @@ const productionConfig = require('./webpack.prod.config');
 
 const IS_DEV = isDev;
 
+const passkeyIconRuntimeDependencyRegex =
+  /[\\/]node_modules[\\/](?:react-native-svg[\\/]|react-native-web[\\/]dist[\\/](?:exports[\\/]Touchable[\\/]|vendor[\\/]react-native[\\/]PooledClass[\\/]))/;
+
+function includePasskeyIconRuntimeDependencies({ config }) {
+  const iconsCacheGroup = config.optimization?.splitChunks?.cacheGroups?.icons;
+  const originalIconsTest = iconsCacheGroup?.test;
+
+  if (typeof originalIconsTest !== 'function') {
+    throw new Error(
+      'Expected the extension icons cache group to be configured',
+    );
+  }
+
+  // Keep the icon modules and their SVG runtime closure in the same async
+  // chunk. Splitting the closure into a second shared chunk makes Webpack 5
+  // emit one equivalent JSONP asset for every generated icon import.
+  iconsCacheGroup.test = (module, ...args) =>
+    originalIconsTest(module, ...args) ||
+    Boolean(
+      module.resource &&
+      passkeyIconRuntimeDependencyRegex.test(module.resource),
+    );
+}
+
 const chromeExtensionV3ViolationPlugin = new ChromeExtensionV3ViolationPlugin([
   // @sentry/react
   {
@@ -150,7 +174,7 @@ module.exports = ({
       },
     },
 
-    // **** passkey standalone entry build without code-split
+    // **** passkey standalone entry build with async icon code-splitting
     {
       config: {
         name: devUtils.consts.configName.passkey,
@@ -171,6 +195,7 @@ module.exports = ({
             config,
           });
         }
+        includePasskeyIconRuntimeDependencies({ config });
         config.plugins = [
           ...config.plugins,
           ...pluginsHtml.passkeyHtml,


### PR DESCRIPTION
## Summary

- keep the extension on Webpack
- scope the change to the `ui-passkey` compiler
- place the icon modules and their `react-native-svg` runtime closure in the same existing async `icons` cache group
- preserve stable background/content-script entries, extension HTML loading, and CSP

## Root cause

After `packages/components` became tree-shakeable, `react-native-svg` stopped being accidentally available in the passkey initial chunk. The enforced async icons cache group extracted only the generated icon modules, leaving the same sub-`minSize` SVG closure in roughly 1,907 dynamic-import chunks.

Webpack emitted every equivalent chunk as a separate physical JSONP asset because each payload had a different chunk ID/header, even though the module body was identical.

A separate SVG cache group still leaves 1,907 header-only assets. Keeping the complete SVG/Touchable/PooledClass closure in the existing icons group removes both the duplicated module body and the redundant chunk boundaries.

## Production cold-build comparison

Both variants were built from the latest `release/v6.5.0` source with the same dependency installation and clean build/Tamagui/node caches.

| Metric | Baseline | Fixed |
| --- | ---: | ---: |
| Inner extension zip | 103.68 MiB | 70.77 MiB |
| Unpacked | 321.33 MiB | 219.06 MiB |
| JS total | 282.59 MiB / 2,767 files | 180.32 MiB / 860 files |
| `ui-passkey*` JS | 113.80 MiB / 1,938 files | 11.53 MiB / 31 files |
| Repeated SVG factory assets | 1,907 | 1 |
| Background bundle | 36,831,011 B | 36,831,011 B |
| Content script bundle | 2,232,452 B | 2,232,452 B |
| Offscreen bundle | 669,046 B | 669,046 B |

The local Windows packaging script does not execute its multi-line Info-ZIP commands, so both comparison zips were produced with the same Windows `Compress-Archive` path. CI should be used for the final GitHub artifact/container number.

Cold wall time was 1,153 s for baseline and 1,779 s for fixed, but the fixed run experienced severe unrelated system memory contention and paging; this timing is not considered a regression signal.

## Validation

- `yarn app:ext:build:all` production build
- `yarn prettier --check development/webpack/webpack.ext.config.js`
- `npx oxlint --fix --deny-warnings development/webpack/webpack.ext.config.js`
- `npx tsgo -p ./tsconfig.json --noEmit ...`
- `node --check development/webpack/webpack.ext.config.js`
- verified all 72 HTML script references exist
- verified manifest background/content-script references exist
- verified passkey HTML keeps the stable entry and does not statically inject the async icons chunk
- verified the passkey runtime maps the unique icons chunk with public path `/`
- verified CSP remains self-hosted and baseline/fixed have identical CSP-sensitive string-scan counts

The repository `agent:check` wrapper cannot spawn its Windows child commands in this environment (`exitCode: null`), and `lint:staged` depends on unavailable `grep/xargs`; the underlying oxlint and TypeScript checks were run directly and passed. Automated access to `chrome://extensions` is blocked by the browser-control security policy, so loading the unpacked extension remains a manual/CI validation step.