### PR TITLE
fix: address #12507 review findings (transient sealed-session read, pinned request token)

### DIFF
--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -1295,14 +1295,26 @@ class ServicePrime extends ServiceBase {
   @backgroundMethod()
   async callApiFetchPrimeUserInfo(): Promise<IPrimeServerUserInfoWithProfile> {
     const client = await this.getPrimeClient();
-    // Capture the token the request interceptor will attach, so invalid-token
-    // cleanup can detect stale in-flight responses after a re-login.
+    // Snapshot the token AND pin it as the explicit request header (the
+    // ServiceBase interceptor respects a pre-set header). Without pinning,
+    // the interceptor would re-read the active token at send time, so a
+    // refresh/re-login between this snapshot and the send would make the
+    // requests carry a token different from `requestAuthToken` — and the
+    // HTTP-200 body-code 90002/90003 cleanup below would compare its
+    // stale-token guard against the wrong snapshot. Pinning keeps the
+    // recorded, sent, and judged token identical. An empty snapshot is
+    // falsy, so the interceptor falls back to the live token exactly as
+    // before — matching the `!requestAuthToken` guard in
+    // evaluateInvalidTokenClearGuards.
     const requestAuthToken =
       await this.backgroundApi.simpleDb.prime.getActiveAuthToken();
     const requestConfig: Parameters<typeof client.get>[1] & {
       autoHandleError?: boolean;
     } = {
       autoHandleError: false,
+      headers: {
+        'X-Onekey-Request-Token': requestAuthToken,
+      },
     };
     const profileRequest = client
       .get<

--- a/packages/shared/src/storage/SupabaseStorage/SupabaseStorage.test.ts
+++ b/packages/shared/src/storage/SupabaseStorage/SupabaseStorage.test.ts
@@ -2,6 +2,7 @@ import { IDBFactory } from 'fake-indexeddb';
 
 import { OneKeyLocalError } from '../../errors';
 import { EAppEventBusNames, appEventBus } from '../../eventBus/appEventBus';
+import { isRetryableSupabaseAuthError } from '../../utils/supabaseAuthErrorUtils';
 import appStorage from '../appStorage';
 import secureStorageInstance from '../instance/secureStorageInstance';
 
@@ -265,6 +266,68 @@ describe('SupabaseStorage', () => {
       const codecB = buildTestCodec();
       const storageB = new SupabaseStorage({ sealedValueCodec: codecB });
       await expect(storageB.getItem('session')).resolves.toBeNull();
+    });
+
+    it('rejects retryable on a transient device-key failure and recovers without caching it', async () => {
+      const backing = useInMemoryAppStorage();
+      const sharedDbName = `test-supabase-sealed-${(testDbNameSeq += 1)}`;
+      const realFactory = new IDBFactory();
+
+      // Seal with a healthy codec so a sealed value AND a persisted device
+      // key exist.
+      const writerStorage = new SupabaseStorage({
+        sealedValueCodec: buildSupabaseSealedValueCodec({
+          dbName: sharedDbName,
+          indexedDBInstance: realFactory,
+        }),
+      });
+      await writerStorage.setItem('session', sessionValue);
+      expect(
+        backing
+          .get(PREFIXED_SESSION_KEY)
+          ?.startsWith(SUPABASE_SEALED_VALUE_PREFIX),
+      ).toBe(true);
+
+      // Reader whose IndexedDB open fails transiently, then recovers to the
+      // SAME underlying database (same persisted device key) — modeling a
+      // cold-start open failure, not a lost key.
+      let failOpen = true;
+      const flakyFactory = {
+        open: (...args: Parameters<IDBFactory['open']>) => {
+          if (failOpen) {
+            throw new OneKeyLocalError('transient IndexedDB open failure');
+          }
+          return realFactory.open(...args);
+        },
+      } as unknown as IDBFactory;
+      const readerStorage = new SupabaseStorage({
+        sealedValueCodec: buildSupabaseSealedValueCodec({
+          dbName: sharedDbName,
+          indexedDBInstance: flakyFactory,
+        }),
+      });
+
+      // Transient unavailability REJECTS retryable instead of resolving
+      // null: resolving null would be indistinguishable from a genuinely
+      // lost session and lets destructive cleanups orphan a valid one.
+      const readError: unknown = await readerStorage.getItem('session').then(
+        () => null,
+        (error: unknown) => error,
+      );
+      expect(readError).toBeTruthy();
+      expect(isRetryableSupabaseAuthError(readError)).toBe(true);
+
+      // The rejection is not kept for maxAge: memoizee evicts rejected
+      // promises on the next event-loop tick, so once the device key store
+      // recovers, the SAME storage instance unseals the same persisted
+      // session instead of serving the stale failure for 30s.
+      failOpen = false;
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      await expect(readerStorage.getItem('session')).resolves.toBe(
+        sessionValue,
+      );
     });
 
     it('returns null for a recognized but corrupt envelope instead of leaking it as plaintext', async () => {

--- a/packages/shared/src/storage/SupabaseStorage/SupabaseStorage.ts
+++ b/packages/shared/src/storage/SupabaseStorage/SupabaseStorage.ts
@@ -85,7 +85,12 @@ export class SupabaseStorage {
       }
       // Recognized sealed envelope: a genuine decrypt failure (device key
       // lost, e.g. browser cleared IndexedDB) returns null — the session is
-      // unrecoverable and the user re-OAuths.
+      // unrecoverable and the user re-OAuths. A TRANSIENT device-key
+      // failure instead rejects with SupabaseStorageTransientError so
+      // callers cannot mistake a recoverable session for "no session";
+      // memoizee evicts rejected promises on the next tick (same-tick
+      // concurrent readers share the retryable rejection), so later reads
+      // retry immediately instead of serving a stale failure for maxAge.
       return this.sealedValueCodec.unsealValue({ key, sealedValue: rawValue });
     },
     {

--- a/packages/shared/src/storage/SupabaseStorage/sealedValueCodec.ts
+++ b/packages/shared/src/storage/SupabaseStorage/sealedValueCodec.ts
@@ -1,4 +1,5 @@
 import bufferUtils from '../../utils/bufferUtils';
+import { SupabaseStorageTransientError } from '../../utils/supabaseAuthErrorUtils';
 import {
   INDEXED_DB_CRYPTO_KEY_AES_GCM_NONCE_BYTES,
   getCryptoGlobal,
@@ -63,9 +64,14 @@ export type ISupabaseSealedValueCodec = {
    */
   sealValue: (params: { key: string; value: string }) => Promise<string | null>;
   /**
-   * Unseal a recognized envelope. Returns null when decryption genuinely
-   * fails (device key lost/cleared, corrupt envelope) — the session is
-   * unrecoverable and the user must re-OAuth.
+   * Unseal a recognized envelope. Returns null only when the session is
+   * PROVEN unrecoverable (unparseable envelope, or AES-GCM decryption fails
+   * because the device key was lost/cleared) — the user must re-OAuth.
+   * Throws a retryable-classified `SupabaseStorageTransientError` when the
+   * device key is merely unavailable right now (transient IndexedDB open
+   * failure): the sealed session may still be perfectly valid, and callers
+   * must not collapse that state into "no session" (destructive cleanups
+   * treat an empty read as authoritative).
    */
   unsealValue: (params: {
     key: string;
@@ -207,10 +213,24 @@ export function buildSupabaseSealedValueCodec({
       }
       const deviceKey = await getDeviceKey();
       if (!deviceKey) {
+        // A present sealed envelope with an unavailable device key is NOT
+        // proof the session is lost: getDeviceKey() fails transiently
+        // (IndexedDB open errors under storage pressure / AV lock at cold
+        // start — the same rationale that keeps failed resolutions unpinned
+        // above). Returning null here would be indistinguishable from a
+        // genuine loss, and destructive callers (startup no-token clear,
+        // invalid-token cleanup) would wipe authSessionSource over a blip —
+        // a wiped KeylessOAuth source is never re-inferred, permanently
+        // orphaning a still-valid session. Throw retryable instead; only
+        // the genuine decrypt failure below returns null. The read cache
+        // evicts rejections on the next tick, so recovery is immediate on
+        // the next read once the device key resolves again.
         console.error(
-          'SupabaseStorage sealed value present but device key unavailable, treating session as lost',
+          'SupabaseStorage sealed value present but device key unavailable, treating as transient read failure',
         );
-        return null;
+        throw new SupabaseStorageTransientError(
+          'SupabaseStorage sealed-value device key transiently unavailable',
+        );
       }
       try {
         const cryptoInstance = getCryptoGlobal(cryptoGlobal);

--- a/packages/shared/src/utils/supabaseAuthErrorUtils.test.ts
+++ b/packages/shared/src/utils/supabaseAuthErrorUtils.test.ts
@@ -1,7 +1,28 @@
-import { isRetryableSupabaseAuthError } from './supabaseAuthErrorUtils';
+import {
+  SupabaseStorageTransientError,
+  isRetryableSupabaseAuthError,
+} from './supabaseAuthErrorUtils';
 
 describe('isRetryableSupabaseAuthError', () => {
   describe('name-based classification', () => {
+    test('SupabaseStorageTransientError (sealed session transiently unreadable) is retryable', () => {
+      expect(
+        isRetryableSupabaseAuthError(
+          new SupabaseStorageTransientError('device key unavailable'),
+        ),
+      ).toBe(true);
+    });
+
+    test('SupabaseStorageTransientError matches structurally by name across realms', () => {
+      // The bg/main runtime split can hand the error across a bridge that
+      // loses the prototype chain; name-based matching must still work.
+      expect(
+        isRetryableSupabaseAuthError({
+          name: 'SupabaseStorageTransientError',
+        }),
+      ).toBe(true);
+    });
+
     test('AuthRetryableFetchError is retryable even without a status', () => {
       expect(
         isRetryableSupabaseAuthError({ name: 'AuthRetryableFetchError' }),

--- a/packages/shared/src/utils/supabaseAuthErrorUtils.ts
+++ b/packages/shared/src/utils/supabaseAuthErrorUtils.ts
@@ -1,3 +1,23 @@
+export const SUPABASE_STORAGE_TRANSIENT_ERROR_NAME =
+  'SupabaseStorageTransientError';
+
+/**
+ * Thrown by the Supabase session storage layer when persisted session
+ * material EXISTS but cannot be read right now for a transient reason (e.g.
+ * the sealed-value device key store failed to open at cold start — see
+ * SupabaseStorage/sealedValueCodec.ts). Classified retryable below so
+ * callers never collapse it into "no session" and run destructive cleanup
+ * against a still-recoverable session. Matched by `name` (set from a string
+ * literal, minification-safe), consistent with the structural typing used
+ * for auth-js errors here.
+ */
+export class SupabaseStorageTransientError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = SUPABASE_STORAGE_TRANSIENT_ERROR_NAME;
+  }
+}
+
 // Structural typing on purpose: `@onekeyhq/shared` must not depend on
 // @supabase/auth-js. Supabase AuthError instances carry a `name` and a
 // numeric HTTP `status` (undefined for non-HTTP failures).
@@ -12,6 +32,12 @@ export function isRetryableSupabaseAuthError(error: unknown): boolean {
   // Thrown by @supabase/auth-js only for fetch-level failures and
   // HTTP 502/503/504.
   if (authError.name === 'AuthRetryableFetchError') {
+    return true;
+  }
+  // Thrown by our own SupabaseStorage sealed-value layer when persisted
+  // session material exists but is transiently unreadable (device key
+  // store failed to open). The session may be perfectly valid.
+  if (authError.name === SUPABASE_STORAGE_TRANSIENT_ERROR_NAME) {
     return true;
   }
   // Thrown by @supabase/auth-js when a non-2xx response has an unparseable


### PR DESCRIPTION
Targets the head branch of #12507 so these review fixes can be merged into that PR directly.

## Addressed review comments

### 1. P1 — transient device-key failure orphans a KeylessOAuth session
([sidmorizon's comment](https://github.com/OneKeyHQ/app-monorepo/pull/12507#discussion_r3586865136), also raised by originalix on `sealedValueCodec.ts:209`)

`unsealValue` previously returned `null` when `getDeviceKey()` was transiently unavailable — indistinguishable from a genuinely lost session. Combined with the 30s read cache, a cold-start IndexedDB blip made `clearOneKeyIdAuthStateIfNoActiveToken` read "no token" both at entry and in-lock, wiping `authSessionSource`; a wiped `KeylessOAuth` source is never re-inferred (HARD SAFETY RULE), permanently orphaning a valid session.

- `unsealValue` now throws `SupabaseStorageTransientError` when the device key is transiently unavailable; only an unparseable envelope or a real AES-GCM decrypt failure still returns `null` (session proven lost).
- `isRetryableSupabaseAuthError` classifies the new error retryable (name-based, matching the module's structural-typing convention), so `readAuthTokenAllowingRetryableAuthError` callers skip every destructive clear.
- Negative caching: memoizee evicts rejected promises on the next tick, so the failure is never served for `maxAge` (test asserts recovery on the same storage instance).

Propagation verified against installed `@supabase/auth-js@2.86.2`:
- `__loadSession` has no catch → `getSession()` rejects and the error reaches our guards (never `_removeSession`);
- `_recoverAndRefresh` catches and logs without touching the stored session;
- main-runtime `SupabaseAuthProvider.readStoredSession` already try/catches (display-only).

**Not included (needs a design decision):** the write-path half of originalix's comment — refusing to downgrade an existing sealed value to plaintext on transient seal failure. Throwing there can lose a just-rotated refresh token (auth-js persists rotation via `setItem`), while the current plaintext fallback self-heals via `resealLegacyPlainValue` on the next bg read. Left for the author to arbitrate.

### 2. Stale `requestAuthToken` snapshot in `callApiFetchPrimeUserInfo`
([originalix's comment on `ServicePrime.tsx:1304`](https://github.com/OneKeyHQ/app-monorepo/pull/12507#files))

The snapshot was taken but the header wasn't pinned, so the ServiceBase interceptor could send a newer token while the HTTP-200 body-code 90002/90003 cleanup compared guards against the old snapshot. The snapshot is now pinned into `requestConfig.headers['X-Onekey-Request-Token']` (the interceptor already respects a pre-set header; an empty snapshot stays falsy and falls back to the live token exactly as before).

## Not addressed here (architecturally significant, awaiting decision)
- Codex P2 (`ServiceKeylessWallet.ts:3642`): source-only in-lock recheck can't distinguish a fresh KeylessOAuth login from the old one during `clearKeylessAuthSessionAndLoginState`.
- originalix on `PrimeGlobalEffect.tsx:308`: `PrimeLoginInvalidToken` event racing a fresh login in the main runtime.

Both point at the same fix shape — a monotonic auth-state commit generation compared before destructive action. That changes the `authStateWriteMutex` commit protocol and the event payload, so it's deliberately not bundled into this small PR.

## Test plan
- [x] `yarn agent:check --profile commit` (lint-worktree-ts, lint-staged, tsc-staged all PASS)
- [x] `jest SupabaseStorage.test.ts supabaseAuthErrorUtils.test.ts` — 35/35, incl. new tests: transient device-key failure rejects retryable + recovers without caching; transient error classified retryable (instance + structural)
- [x] `jest ServicePrime.test.ts SimpleDbEntityPrime.test.ts` — 23/23

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJTPZLp5xj28qEQqbzJQeB)_