### PR TITLE
fix: gate keyless teardown and invalid-token events on auth-state generation

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.test.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.test.ts
@@ -74,6 +74,54 @@ describe('SimpleDbEntityPrime.getEffectiveAuthSessionSource', () => {
   });
 });
 
+describe('SimpleDbEntityPrime.authStateGeneration', () => {
+  test('defaults to 0 for pre-upgrade data', async () => {
+    const entity = new SimpleDbEntityPrime();
+    jest.spyOn(entity, 'getRawData').mockResolvedValue({});
+
+    await expect(entity.getAuthStateGeneration()).resolves.toBe(0);
+  });
+
+  test('setAuthSessionSource bumps the generation on every commit', async () => {
+    const entity = new SimpleDbEntityPrime();
+    let persisted: Record<string, unknown> = { authStateGeneration: 2 };
+    jest.spyOn(entity, 'setRawData').mockImplementation((async (
+      updater: (rawData: Record<string, unknown>) => Record<string, unknown>,
+    ) => {
+      persisted = updater(persisted);
+      return persisted;
+    }) as never);
+
+    await entity.setAuthSessionSource(EPrimeAuthSessionSource.KeylessOAuth);
+    expect(persisted.authSessionSource).toBe(
+      EPrimeAuthSessionSource.KeylessOAuth,
+    );
+    expect(persisted.authStateGeneration).toBe(3);
+
+    // A bind switch (KeylessOAuth while already logged in) is also a commit
+    // and must advance the epoch again.
+    await entity.setAuthSessionSource(
+      EPrimeAuthSessionSource.LegacyEmailSupabase,
+    );
+    expect(persisted.authStateGeneration).toBe(4);
+  });
+
+  test('clearAuthTokens does not bump the generation (clears are not commits)', async () => {
+    const entity = new SimpleDbEntityPrime();
+    let persisted: Record<string, unknown> = { authStateGeneration: 5 };
+    jest.spyOn(entity, 'setRawData').mockImplementation((async (
+      updater: (rawData: Record<string, unknown>) => Record<string, unknown>,
+    ) => {
+      persisted = updater(persisted);
+      return persisted;
+    }) as never);
+
+    await entity.clearAuthTokens();
+    expect(persisted.authSessionSource).toBeUndefined();
+    expect(persisted.authStateGeneration).toBe(5);
+  });
+});
+
 describe('SimpleDbEntityPrime.hasShownLocalKeylessUpgradeBindPrompt', () => {
   test('treats a recent shownAt as throttled', async () => {
     const entity = new SimpleDbEntityPrime();

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.ts
@@ -15,6 +15,15 @@ export interface ISimpleDBPrime {
   // Deprecated token copy. Supabase/OAuth session storage is the source of truth.
   authToken?: string;
   authSessionSource?: EPrimeAuthSessionSource;
+  // Monotonic auth-state commit epoch, bumped on every setAuthSessionSource
+  // write (login commits, bind switches, legacy self-heal). Destructive
+  // cleanups that decide on a pre-await snapshot (keyless session teardown,
+  // bg->main invalid-token events) compare it before acting: a source-only
+  // recheck cannot distinguish "the same KeylessOAuth login I decided to
+  // clear" from "a FRESH KeylessOAuth login committed while I awaited", but
+  // the generation can. Clears intentionally do NOT bump: gating only needs
+  // to detect commits, and a redundant clear is idempotent.
+  authStateGeneration?: number;
   // Per-user throttle timestamp for the local-keyless upgrade bind prompt.
   // Written by ServicePrime.checkAndMarkShouldShowLocalKeylessUpgradeBindPrompt
   // for every completed check outcome (dialog about to show, bind not
@@ -100,11 +109,24 @@ export class SimpleDbEntityPrime extends SimpleDbEntityBase<ISimpleDBPrime> {
     return undefined;
   }
 
+  /**
+   * Current auth-state commit generation (see the ISimpleDBPrime field doc).
+   * Defaults to 0 for pre-upgrade data.
+   */
+  @backgroundMethod()
+  async getAuthStateGeneration(): Promise<number> {
+    const rawData = await this.getRawData();
+    return rawData?.authStateGeneration ?? 0;
+  }
+
   @backgroundMethod()
   async setAuthSessionSource(authSessionSource: EPrimeAuthSessionSource) {
     await this.setRawData((rawData) => ({
       ...rawData,
       authSessionSource,
+      // Every source commit advances the generation so pre-await snapshots
+      // held by in-flight destructive cleanups become detectably stale.
+      authStateGeneration: (rawData?.authStateGeneration ?? 0) + 1,
     }));
     clearSupabaseStorageCache();
   }

--- a/packages/kit-bg/src/services/ServiceBase.ts
+++ b/packages/kit-bg/src/services/ServiceBase.ts
@@ -155,6 +155,7 @@ export default class ServiceBase {
                 appEventBus.emit(EAppEventBusNames.PrimeLoginInvalidToken, {
                   authSessionSource: clearResult.authSessionSource,
                   clearedByBackground: true,
+                  authStateGeneration: clearResult.authStateGeneration,
                 });
               }
             } catch (handlerError) {

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -3634,16 +3634,37 @@ class ServiceKeylessWallet extends ServiceBase {
    */
   @backgroundMethod()
   async clearKeylessAuthSessionAndLoginState(): Promise<void> {
+    // Snapshot the auth-state commit generation BEFORE the slow session
+    // clear below: the in-lock source re-read alone cannot distinguish the
+    // KeylessOAuth login this teardown targets from a FRESH KeylessOAuth
+    // login that commits while clearKeylessAuthSession() awaits (its
+    // signOut can hang on the network for many seconds) — both read as
+    // KeylessOAuth. A fresh commit bumps the generation, which the guarded
+    // clear compares in-lock.
+    const expectedAuthStateGeneration =
+      await this.backgroundApi.simpleDb.prime.getAuthStateGeneration();
     await this.backgroundApi.simpleDb.prime.clearKeylessAuthSession();
-    // Guarded clear (authStateWriteMutex + in-lock source re-read): deciding
-    // on a source snapshot taken before the session clear above could race a
-    // login commit that lands in between (e.g. while a wallet-removal
-    // signOut waits on the network) and wipe the freshly committed login.
-    await this.backgroundApi.servicePrime.clearOneKeyIdAuthStateIfSourceStillKeylessOAuth(
-      {
-        callerName: 'clearKeylessAuthSessionAndLoginState',
-      },
-    );
+    // Guarded clear (authStateWriteMutex + in-lock generation/source
+    // re-read): deciding on a pre-clear snapshot alone could race a login
+    // commit that lands in between (e.g. while a wallet-removal signOut
+    // waits on the network) and wipe the freshly committed login.
+    const { generationChanged } =
+      await this.backgroundApi.servicePrime.clearOneKeyIdAuthStateIfSourceStillKeylessOAuth(
+        {
+          callerName: 'clearKeylessAuthSessionAndLoginState',
+          expectedAuthStateGeneration,
+        },
+      );
+    if (generationChanged) {
+      // A fresh KeylessOAuth login committed while the session clear was in
+      // flight; its session now occupies the shared keyless slot (written
+      // after the sweep above). The KeylessAuthSessionCleared broadcast
+      // below must NOT fire: main-runtime handlers respond by signing out
+      // their keyless client copy, whose storage adapter is the SHARED
+      // session storage — a stale broadcast would delete the fresh login's
+      // persisted session.
+      return;
+    }
     // Runtime note (bg -> main): the clear above only affects the shared
     // native session storage plus THIS (bg) runtime's JS client copy. The
     // main runtime's keyless Supabase client keeps its own isolated

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
@@ -384,6 +384,34 @@ describe('ServicePrime invalid-token handling', () => {
       ).toHaveBeenCalled();
     });
 
+    it('skips the post-lock per-source session sweep when a login commits after the in-lock clear', async () => {
+      const { service, simpleDbPrime } = createService();
+      simpleDbPrime.getAuthSessionSource.mockResolvedValue(
+        EPrimeAuthSessionSource.KeylessOAuth,
+      );
+      simpleDbPrime.getActiveAuthToken.mockResolvedValue(REQUEST_TOKEN);
+      // In-lock snapshot reads 0; a same-source OAuth login fully commits
+      // right after the lock releases, bumping the generation to 1 — the
+      // sweep would otherwise delete the fresh login's session while its
+      // atom/source stay logged-in (the commit fail-safe already passed).
+      simpleDbPrime.getAuthStateGeneration
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(1);
+
+      const result = await service.handlePrimeLoginInvalidToken({
+        requestAuthToken: REQUEST_TOKEN,
+        errorCode: 90_002,
+        errorMessage: 'invalid',
+      });
+
+      // The guarded simpleDb+atom clear already committed in-lock…
+      expect(result.cleared).toBe(true);
+      expect(simpleDbPrime.clearAuthTokens).toHaveBeenCalled();
+      // …but the stale per-source session sweep must be skipped.
+      expect(simpleDbPrime.clearKeylessAuthSession).not.toHaveBeenCalled();
+      expect(simpleDbPrime.clearLegacyAuthSession).not.toHaveBeenCalled();
+    });
+
     it('skips clearing when the active token changed while waiting for the lock (concurrent re-login committed)', async () => {
       const { service, simpleDbPrime } = createService();
       simpleDbPrime.getAuthSessionSource.mockResolvedValue(

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
@@ -148,6 +148,7 @@ const REQUEST_TOKEN = 'request-token';
 function createService() {
   const simpleDbPrime = {
     getAuthSessionSource: jest.fn(async () => undefined as unknown),
+    getAuthStateGeneration: jest.fn(async () => 0),
     getActiveAuthToken: jest.fn(async () => ''),
     getSupabaseAuthToken: jest.fn(async () => ''),
     getKeylessSupabaseAuthToken: jest.fn(async () => ''),
@@ -268,6 +269,9 @@ describe('ServicePrime invalid-token handling', () => {
         {
           authSessionSource: EPrimeAuthSessionSource.KeylessOAuth,
           clearedByBackground: true,
+          // In-lock generation snapshot: lets main-runtime handlers detect
+          // a login that commits during bg->main event propagation.
+          authStateGeneration: 0,
         },
       );
     });
@@ -311,6 +315,7 @@ describe('ServicePrime invalid-token handling', () => {
       handlerImpl.mockImplementation(async () => ({
         cleared: true,
         authSessionSource: EPrimeAuthSessionSource.KeylessOAuth,
+        authStateGeneration: 7,
       }));
       const { thrown } = await invokeInterceptorWith90002();
 
@@ -327,6 +332,9 @@ describe('ServicePrime invalid-token handling', () => {
         {
           authSessionSource: EPrimeAuthSessionSource.KeylessOAuth,
           clearedByBackground: true,
+          // Forwarded from the handler result so main-runtime handlers can
+          // gate on staleness.
+          authStateGeneration: 7,
         },
       );
     });
@@ -366,6 +374,7 @@ describe('ServicePrime invalid-token handling', () => {
       expect(result).toEqual({
         cleared: true,
         authSessionSource: EPrimeAuthSessionSource.KeylessOAuth,
+        authStateGeneration: 0,
       });
       expect(simpleDbPrime.clearAuthTokens).toHaveBeenCalled();
       expect(simpleDbPrime.clearKeylessAuthSession).toHaveBeenCalled();
@@ -575,6 +584,75 @@ describe('ServicePrime.clearOneKeyIdAuthStateIfNoActiveToken', () => {
     });
 
     expect(result.cleared).toBe(false);
+    expect(simpleDbPrime.clearAuthTokens).not.toHaveBeenCalled();
+    expect(atomResetSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('ServicePrime.clearOneKeyIdAuthStateIfSourceStillKeylessOAuth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('clears when the source is still KeylessOAuth and the generation is unchanged', async () => {
+    const { service, simpleDbPrime } = createService();
+    simpleDbPrime.getAuthSessionSource.mockResolvedValue(
+      EPrimeAuthSessionSource.KeylessOAuth,
+    );
+    simpleDbPrime.getAuthStateGeneration.mockResolvedValue(3);
+    const atomResetSpy = jest
+      .spyOn(service, 'setPrimePersistAtomNotLoggedIn')
+      .mockResolvedValue(undefined);
+
+    const result =
+      await service.clearOneKeyIdAuthStateIfSourceStillKeylessOAuth({
+        callerName: 'test',
+        expectedAuthStateGeneration: 3,
+      });
+
+    expect(result).toEqual({ cleared: true });
+    expect(simpleDbPrime.clearAuthTokens).toHaveBeenCalled();
+    expect(atomResetSpy).toHaveBeenCalled();
+  });
+
+  it('skips with generationChanged when a login committed after the caller snapshot', async () => {
+    const { service, simpleDbPrime } = createService();
+    // The fresh login re-committed KeylessOAuth, so a source-only recheck
+    // would still match and wipe it — only the generation exposes the race.
+    simpleDbPrime.getAuthSessionSource.mockResolvedValue(
+      EPrimeAuthSessionSource.KeylessOAuth,
+    );
+    simpleDbPrime.getAuthStateGeneration.mockResolvedValue(4);
+    const atomResetSpy = jest
+      .spyOn(service, 'setPrimePersistAtomNotLoggedIn')
+      .mockResolvedValue(undefined);
+
+    const result =
+      await service.clearOneKeyIdAuthStateIfSourceStillKeylessOAuth({
+        callerName: 'test',
+        expectedAuthStateGeneration: 3,
+      });
+
+    expect(result).toEqual({ cleared: false, generationChanged: true });
+    expect(simpleDbPrime.clearAuthTokens).not.toHaveBeenCalled();
+    expect(atomResetSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps the source-only guard when no generation snapshot is provided', async () => {
+    const { service, simpleDbPrime } = createService();
+    simpleDbPrime.getAuthSessionSource.mockResolvedValue(
+      EPrimeAuthSessionSource.LegacyEmailSupabase,
+    );
+    const atomResetSpy = jest
+      .spyOn(service, 'setPrimePersistAtomNotLoggedIn')
+      .mockResolvedValue(undefined);
+
+    const result =
+      await service.clearOneKeyIdAuthStateIfSourceStillKeylessOAuth({
+        callerName: 'test',
+      });
+
+    expect(result).toEqual({ cleared: false });
     expect(simpleDbPrime.clearAuthTokens).not.toHaveBeenCalled();
     expect(atomResetSpy).not.toHaveBeenCalled();
   });

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -240,6 +240,7 @@ class ServicePrime extends ServiceBase {
         appEventBus.emit(EAppEventBusNames.PrimeLoginInvalidToken, {
           authSessionSource: clearResult.authSessionSource,
           clearedByBackground: true,
+          authStateGeneration: clearResult.authStateGeneration,
         });
       }
       throw error;
@@ -484,6 +485,11 @@ class ServicePrime extends ServiceBase {
   }): Promise<{
     cleared: boolean;
     authSessionSource?: EPrimeAuthSessionSource;
+    // Auth-state commit generation observed in-lock at clear time; carried
+    // into the PrimeLoginInvalidToken event so main-runtime handlers can
+    // detect that a login committed after this clear and skip their stale
+    // sign-outs (see the event payload doc in appEventBus).
+    authStateGeneration?: number;
   }> {
     // Entry-time guard pass OUTSIDE authStateWriteMutex: skips cheaply
     // without contending on the lock, and performs the possibly-slow
@@ -512,6 +518,7 @@ class ServicePrime extends ServiceBase {
       async (): Promise<{
         cleared: boolean;
         authSessionSource?: EPrimeAuthSessionSource;
+        authStateGeneration?: number;
       }> => {
         const guards = await this.evaluateInvalidTokenClearGuards({
           requestAuthToken,
@@ -546,6 +553,11 @@ class ServicePrime extends ServiceBase {
         const sourceToClear =
           guards.authSessionSource ??
           EPrimeAuthSessionSource.LegacyEmailSupabase;
+        // Read the commit generation in-lock so the emitted event carries
+        // the exact auth-state epoch this clear belongs to (clears never
+        // bump the generation — only login commits do).
+        const authStateGeneration =
+          await this.backgroundApi.simpleDb.prime.getAuthStateGeneration();
         // Write section: simpleDb + atom only — no network I/O while the
         // lock is held (clearAuthTokens is a simpleDb write plus a local
         // storage-cache clear; setPrimePersistAtomNotLoggedIn is atom +
@@ -555,6 +567,7 @@ class ServicePrime extends ServiceBase {
         return {
           cleared: true,
           authSessionSource: sourceToClear,
+          authStateGeneration,
         };
       },
     );
@@ -1122,14 +1135,35 @@ class ServicePrime extends ServiceBase {
    * deciding on a pre-clear source snapshot could race a login commit that
    * lands in between and wipe the fresh login; the in-lock re-read under
    * authStateWriteMutex closes that window.
+   *
+   * The source-only re-read cannot distinguish "the same KeylessOAuth login
+   * the caller decided to tear down" from "a FRESH KeylessOAuth login that
+   * committed while the caller's session clear awaited" — both read as
+   * KeylessOAuth. Callers therefore pass `expectedAuthStateGeneration`
+   * (snapshotted BEFORE their session clear): a fresh commit bumps the
+   * generation, and the in-lock comparison skips the wipe with
+   * `generationChanged: true` so the caller can also suppress its stale
+   * follow-up broadcasts (e.g. KeylessAuthSessionCleared).
    */
   @backgroundMethod()
   async clearOneKeyIdAuthStateIfSourceStillKeylessOAuth({
     callerName,
+    expectedAuthStateGeneration,
   }: {
     callerName: string;
-  }): Promise<{ cleared: boolean }> {
+    expectedAuthStateGeneration?: number;
+  }): Promise<{ cleared: boolean; generationChanged?: boolean }> {
     return this.authStateWriteMutex.runExclusive(async () => {
+      if (expectedAuthStateGeneration !== undefined) {
+        const currentGeneration =
+          await this.backgroundApi.simpleDb.prime.getAuthStateGeneration();
+        if (currentGeneration !== expectedAuthStateGeneration) {
+          defaultLogger.prime.subscription.onekeyIdAtomNotLoggedIn({
+            reason: `${callerName}: skip keyless-source clear, a login committed while the caller's session clear was in flight (generation ${expectedAuthStateGeneration} -> ${currentGeneration})`,
+          });
+          return { cleared: false, generationChanged: true };
+        }
+      }
       const source =
         await this.backgroundApi.simpleDb.prime.getAuthSessionSource();
       if (source !== EPrimeAuthSessionSource.KeylessOAuth) {

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -578,11 +578,32 @@ class ServicePrime extends ServiceBase {
 
     // Per-source Supabase session clear (auth.signOut can perform network
     // I/O) deliberately runs OUTSIDE the lock, after the guarded
-    // simpleDb+atom write above committed the clear decision. A login
-    // racing this signOut is not made worse by the move: its own Supabase
-    // sign-in happens outside any mutex either way, and
-    // commitAuthSessionSourceBeforeAtomUpdate fails safe (clears + throws)
-    // when the session storage was swept underneath it.
+    // simpleDb+atom write above committed the clear decision.
+    //
+    // Stale-sweep gate: a same-source OAuth login can FULLY commit (session
+    // + source + atom) between the lock release above and this sweep. Once
+    // committed, commitAuthSessionSourceBeforeAtomUpdate's fail-safe can no
+    // longer catch anything — sweeping here would delete the FRESH login's
+    // session while its atom/source stay logged-in. Re-check the commit
+    // generation right before sweeping and skip when a commit landed in
+    // between: the fresh login owns the slot now, and the invalid session
+    // this sweep targeted was already overwritten by the fresh setItem (or,
+    // for a cross-source login, left inert with its source no longer
+    // selected). A commit landing DURING the sweep below remains possible —
+    // fully closing that would require routing every session write through
+    // the bg mutex (forbidden: network I/O under authStateWriteMutex).
+    const generationBeforeSessionClear =
+      await this.backgroundApi.simpleDb.prime.getAuthStateGeneration();
+    if (generationBeforeSessionClear !== lockResult.authStateGeneration) {
+      defaultLogger.prime.subscription.onekeyIdInvalidToken({
+        url: requestUrl || '',
+        errorCode: errorCode || -1,
+        errorMessage: `skip stale per-source session clear, a login committed after the in-lock clear (generation ${String(
+          lockResult.authStateGeneration,
+        )} -> ${generationBeforeSessionClear})`,
+      });
+      return lockResult;
+    }
     if (lockResult.authSessionSource === EPrimeAuthSessionSource.KeylessOAuth) {
       await this.backgroundApi.simpleDb.prime.clearKeylessAuthSession();
     } else {

--- a/packages/kit/src/views/Prime/hooks/PrimeGlobalEffect.tsx
+++ b/packages/kit/src/views/Prime/hooks/PrimeGlobalEffect.tsx
@@ -295,12 +295,36 @@ function PrimeGlobalEffectView() {
         | {
             authSessionSource?: EPrimeAuthSessionSource;
             clearedByBackground?: boolean;
+            authStateGeneration?: number;
           }
         | undefined,
     ) => {
       defaultLogger.prime.subscription.onekeyIdLogout({
         reason: 'appEventBus: EAppEventBusNames.PrimeLoginInvalidToken',
       });
+      if (
+        payload?.clearedByBackground &&
+        payload.authStateGeneration !== undefined
+      ) {
+        // Staleness gate: the payload carries the auth-state commit
+        // generation observed when bg decided to clear. A user can complete
+        // a fresh login while this event propagates bg -> main (event-bus
+        // hop + the signOut awaits below); that commit bumps the
+        // generation. Signing out then would be destructive: this runtime's
+        // clients persist through the SHARED session storage, so the stale
+        // sign-out would delete the fresh login's persisted session — and
+        // the guarded atom reset at the end cannot restore deleted
+        // credentials. Skip the whole stale event; the fresh login owns the
+        // session slot now.
+        const currentAuthStateGeneration =
+          await backgroundApiProxy.simpleDb.prime.getAuthStateGeneration();
+        if (currentAuthStateGeneration !== payload.authStateGeneration) {
+          defaultLogger.prime.subscription.onekeyIdLogout({
+            reason: `PrimeGlobalEffectView.PrimeLoginInvalidToken: skip stale event, a login committed during propagation (generation ${payload.authStateGeneration} -> ${currentAuthStateGeneration})`,
+          });
+          return;
+        }
+      }
       if (
         payload?.clearedByBackground &&
         payload.authSessionSource === EPrimeAuthSessionSource.KeylessOAuth

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -454,6 +454,13 @@ export interface IAppEventBusPayload {
     | {
         authSessionSource?: EPrimeAuthSessionSource;
         clearedByBackground?: boolean;
+        // Auth-state commit generation (simpleDb.prime.getAuthStateGeneration)
+        // observed by the bg cleanup when it decided to clear. Handlers must
+        // treat the event as STALE and skip their sign-outs when the current
+        // generation differs: a login commit that landed after the clear
+        // decision owns the shared session slot, and a stale sign-out would
+        // destroy the fresh login's persisted session.
+        authStateGeneration?: number;
       }
     | undefined;
   // Emitted from the bg runtime after it clears the shared keyless Supabase

--- a/packages/shared/src/storage/SupabaseStorage/SupabaseStorage.test.ts
+++ b/packages/shared/src/storage/SupabaseStorage/SupabaseStorage.test.ts
@@ -330,6 +330,49 @@ describe('SupabaseStorage', () => {
       );
     });
 
+    it('falls back to plaintext on a transient seal failure and reseals immediately after recovery', async () => {
+      const backing = useInMemoryAppStorage();
+      const realFactory = new IDBFactory();
+      // Device key store fails exactly once (the setItem-time seal attempt),
+      // then recovers — the write must not be rejected (a rejected write
+      // would lose a just-rotated refresh token), and the immediate
+      // opportunistic reseal must shrink the plaintext window without
+      // waiting for the next read.
+      let remainingFailures = 1;
+      const failOnceFactory = {
+        open: (...args: Parameters<IDBFactory['open']>) => {
+          if (remainingFailures > 0) {
+            remainingFailures -= 1;
+            throw new OneKeyLocalError('transient IndexedDB open failure');
+          }
+          return realFactory.open(...args);
+        },
+      } as unknown as IDBFactory;
+      const storage = new SupabaseStorage({
+        sealedValueCodec: buildSupabaseSealedValueCodec({
+          dbName: `test-supabase-sealed-${(testDbNameSeq += 1)}`,
+          indexedDBInstance: failOnceFactory,
+        }),
+      });
+
+      await storage.setItem('session', sessionValue);
+
+      // The reseal is fire-and-forget; wait until it lands sealed.
+      await waitFor(() =>
+        Boolean(
+          backing
+            .get(PREFIXED_SESSION_KEY)
+            ?.startsWith(SUPABASE_SEALED_VALUE_PREFIX),
+        ),
+      );
+      expect(backing.get(PREFIXED_SESSION_KEY)).not.toContain(
+        'secret-access-token',
+      );
+      // The resealed value still decrypts to the same session.
+      storage.clearCache({ syncRemote: false });
+      await expect(storage.getItem('session')).resolves.toBe(sessionValue);
+    });
+
     it('returns null for a recognized but corrupt envelope instead of leaking it as plaintext', async () => {
       const backing = useInMemoryAppStorage();
       backing.set(

--- a/packages/shared/src/storage/SupabaseStorage/SupabaseStorage.ts
+++ b/packages/shared/src/storage/SupabaseStorage/SupabaseStorage.ts
@@ -169,10 +169,23 @@ export class SupabaseStorage {
     }
     // Seal with the device key when available; sealValue returns null when
     // WebCrypto/IndexedDB is unavailable (older webviews, jest), in which
-    // case we keep the pre-sealing plaintext behavior.
+    // case we keep the pre-sealing plaintext behavior. The plaintext
+    // fallback is deliberate even when the PREVIOUS stored value was sealed
+    // and this failure is transient: rejecting the write instead would lose
+    // a just-rotated refresh token that auth-js persists through this
+    // setItem (the old token is already consumed server-side), trading a
+    // short plaintext-at-rest window for a guaranteed forced re-login.
     const sealedValue = await this.sealedValueCodec.sealValue({ key, value });
     const result = await appStorage.setItem(key, sealedValue ?? value);
     this.clearCache();
+    if (sealedValue === null) {
+      // Shrink the plaintext window: retry sealing right away instead of
+      // waiting for the next read's opportunistic rewrite (the device-key
+      // resolution failure is not pinned, so a retry can succeed). The
+      // method self-guards: it no-ops in Main UI runtimes and re-reads
+      // before writing so it can never clobber a newer rotated session.
+      this.resealLegacyPlainValue(key, value);
+    }
     return result;
   }
 


### PR DESCRIPTION
Follow-up to #12511, targeting #12507's head branch. Addresses the two remaining race findings plus the write-path half of the sealed-codec comment.

## Auth-state commit generation

Both remaining findings share one root cause — a destructive cleanup decides on state snapshotted before an `await`, and a **fresh KeylessOAuth login that commits during that await is indistinguishable from the state being torn down** (the source re-reads as `KeylessOAuth` either way):

- **Codex P2 (`ServiceKeylessWallet.ts:3642`)**: `clearKeylessAuthSessionAndLoginState` awaits `clearKeylessAuthSession()` (signOut can hang on the network); a login committing in that window is then wiped by the source-only in-lock recheck, and the unversioned `KeylessAuthSessionCleared` broadcast makes main sign out the fresh client copy — main's clients persist through the SHARED session storage, so the fresh login's persisted session is deleted too.
- **originalix (`PrimeGlobalEffect.tsx:308`)**: a stale `PrimeLoginInvalidToken` event still propagating bg → main after a fresh login unconditionally signs out the current keyless client, deleting the just-persisted session; the trailing guarded atom reset cannot restore deleted credentials.

Mechanism (as suggested in the review):
- `simpleDb.prime.authStateGeneration` — monotonic counter bumped by every `setAuthSessionSource` commit (login, bind switch, legacy self-heal). Clears intentionally do NOT bump: gating only needs to detect commits, and a redundant clear is idempotent.
- `clearOneKeyIdAuthStateIfSourceStillKeylessOAuth` accepts `expectedAuthStateGeneration` (snapshotted before the session clear) and skips in-lock with `generationChanged: true` when a commit landed in between; `clearKeylessAuthSessionAndLoginState` then also suppresses the `KeylessAuthSessionCleared` broadcast.
- `handlePrimeLoginInvalidToken` returns the in-lock generation; both emit sites (ServiceBase interceptor, `throwIfAllPrimeUserInfoRequestsFailedByInvalidTokenError`) carry it in the `PrimeLoginInvalidToken` payload; the `PrimeGlobalEffect` handler compares it against the current generation and skips the whole stale event on mismatch. Payload change is safe on split-runtime targets: `main`/`bg` bundles ship version-locked.
- Generation reads/writes stay inside `authStateWriteMutex` sections that only touch simpleDb/atom — no network I/O added under the lock, per the documented lock policy (the Codex-suggested alternative, serializing the signOut under the mutex, would violate it).

## Write-path sealed-value downgrade (originalix, `sealedValueCodec.ts` comment)

Kept the plaintext fallback on transient seal failure **deliberately**, now documented in code: rejecting the write would lose a just-rotated refresh token that auth-js persists through this exact `setItem` (the old token is already consumed server-side; past GoTrue's ~10s reuse window the family is revoked → guaranteed forced re-login). Mitigation added instead: after a plaintext fallback, `setItem` immediately triggers the opportunistic reseal (same self-guarded `resealLegacyPlainValue` used by the read path — no-op in Main runtimes, re-reads before writing so it can never clobber a newer rotated session), shrinking the plaintext window from "next read" to roughly one retry round-trip.

## Test plan
- [x] `yarn agent:check --profile commit` — lint-worktree-ts / lint-staged / tsc-staged all PASS
- [x] `jest ServicePrime.test.ts SimpleDbEntityPrime.test.ts SupabaseStorage.test.ts` — 40/40, new coverage:
  - generation bumps on every `setAuthSessionSource`, not on `clearAuthTokens`; defaults to 0 for pre-upgrade data
  - keyless-source clear skips with `generationChanged` when a login committed after the caller snapshot; source-only behavior unchanged without a snapshot
  - `PrimeLoginInvalidToken` emit payloads carry the in-lock generation (interceptor + HTTP-200 body-code paths)
  - transient seal failure on write falls back to plaintext (write never rejected) and reseals immediately after device-key recovery

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJTPZLp5xj28qEQqbzJQeB)_