### PR TITLE
fix: anchor rspack vendor transpile rules to node_modules

### DIFF
--- a/development/rspack/rspack.base.config.ts
+++ b/development/rspack/rspack.base.config.ts
@@ -516,7 +516,7 @@ export function createBaseConfig({
         // Reanimated files need babel-loader with worklets plugin
         {
           test: /\.(js|mjs|jsx|ts|tsx)$/,
-          include: [/react-native-reanimated/],
+          include: [/node_modules[\\/]react-native-reanimated[\\/]/],
           use: [
             {
               loader: 'builtin:swc-loader',
@@ -642,8 +642,13 @@ export function createBaseConfig({
           ],
           resolve: { fullySpecified: false },
         },
+        // Vendor-transpile rules below are anchored to node_modules on purpose:
+        // an unanchored regex matches the absolute path, and on EAS build
+        // machines the checkout lives under /Users/expo/, so a bare
+        // /(@?expo-*)/ matched EVERY first-party file and chained an swc
+        // pass without decorator support ("Unexpected token `@`").
         {
-          test: /(@?react-(navigation|native)).*\.(ts|js)x?$/,
+          test: /node_modules[\\/]@?react-(navigation|native)[\\/-].*\.(ts|js)x?$/,
 
           use: [
             {
@@ -710,9 +715,9 @@ export function createBaseConfig({
           : []),
         {
           test: [
-            /(@?expo-*).*\.(c|m)?(ts|js)x?$/,
-            /(@?set-interval-async).*\.(c|m)?(ts|js)x?$/,
-            /(@?react-aria).*\.(c|m)?(ts|js)x?$/,
+            /node_modules[\\/]@?expo[\\/-].*\.(c|m)?(ts|js)x?$/,
+            /node_modules[\\/]set-interval-async[\\/].*\.(c|m)?(ts|js)x?$/,
+            /node_modules[\\/]@?react-aria[\\/-].*\.(c|m)?(ts|js)x?$/,
           ],
 
           use: [
@@ -750,7 +755,7 @@ export function createBaseConfig({
           resolve: { fullySpecified: false },
         },
         {
-          test: /lru-cache.*\.(ts|js)x?$/,
+          test: /node_modules[\\/]lru-cache[\\/].*\.(ts|js)x?$/,
           use: [
             {
               loader: 'builtin:swc-loader',

--- a/development/rspack/rspack.base.config.ts
+++ b/development/rspack/rspack.base.config.ts
@@ -333,6 +333,13 @@ const buildBaseCache: (
   configName?: string,
 ) => RspackOptions['cache'] = (basePath, configName) => ({
   type: 'persistent',
+  // The CLI only auto-tracks the app-level rspack.config.ts as a build
+  // dependency, so edits to these imported config modules would otherwise
+  // never invalidate warm persistent caches.
+  buildDependencies: fs
+    .readdirSync(__dirname)
+    .filter((file) => file.endsWith('.ts'))
+    .map((file) => path.join(__dirname, file)),
   storage: {
     type: 'filesystem',
     // Use separate cache directories for each config to avoid conflicts
@@ -754,7 +761,7 @@ export function createBaseConfig({
           resolve: { fullySpecified: false },
         },
         {
-          test: /@onekeyfe[\\/]bitcoinforksjs-lib.*\.(ts|js)x?$/,
+          test: /node_modules[\\/].*@onekeyfe[\\/]bitcoinforksjs-lib.*\.(ts|js)x?$/,
           resolve: { fullySpecified: false },
         },
         {
@@ -788,7 +795,7 @@ export function createBaseConfig({
         ...(enableImportMetaCompat
           ? [
               {
-                test: /@polkadot/,
+                test: /node_modules[\\/].*@polkadot/,
                 loader: require.resolve('@open-wc/webpack-import-meta-loader'),
               },
             ]

--- a/development/rspack/rspack.base.config.ts
+++ b/development/rspack/rspack.base.config.ts
@@ -516,7 +516,7 @@ export function createBaseConfig({
         // Reanimated files need babel-loader with worklets plugin
         {
           test: /\.(js|mjs|jsx|ts|tsx)$/,
-          include: [/node_modules[\\/]react-native-reanimated[\\/]/],
+          include: [/node_modules[\\/].*react-native-reanimated/],
           use: [
             {
               loader: 'builtin:swc-loader',
@@ -642,13 +642,16 @@ export function createBaseConfig({
           ],
           resolve: { fullySpecified: false },
         },
-        // Vendor-transpile rules below are anchored to node_modules on purpose:
-        // an unanchored regex matches the absolute path, and on EAS build
-        // machines the checkout lives under /Users/expo/, so a bare
-        // /(@?expo-*)/ matched EVERY first-party file and chained an swc
-        // pass without decorator support ("Unexpected token `@`").
+        // Vendor-transpile rules below require a node_modules segment BEFORE the
+        // package-name substring on purpose: a fully unanchored regex matches
+        // the absolute path, and on EAS build machines the checkout lives under
+        // /Users/expo/, so a bare /(@?expo-*)/ matched EVERY first-party file
+        // and chained an swc pass without decorator support ("Unexpected token
+        // `@`"). Keep the substring semantics after node_modules — packages
+        // like @onekeyfe/react-native-text-input (scoped, raw .ts sources)
+        // rely on it to get transpiled at all.
         {
-          test: /node_modules[\\/]@?react-(navigation|native)[\\/-].*\.(ts|js)x?$/,
+          test: /node_modules[\\/].*(@?react-(navigation|native)).*\.(ts|js)x?$/,
 
           use: [
             {
@@ -715,9 +718,9 @@ export function createBaseConfig({
           : []),
         {
           test: [
-            /node_modules[\\/]@?expo[\\/-].*\.(c|m)?(ts|js)x?$/,
-            /node_modules[\\/]set-interval-async[\\/].*\.(c|m)?(ts|js)x?$/,
-            /node_modules[\\/]@?react-aria[\\/-].*\.(c|m)?(ts|js)x?$/,
+            /node_modules[\\/].*(@?expo-*).*\.(c|m)?(ts|js)x?$/,
+            /node_modules[\\/].*(@?set-interval-async).*\.(c|m)?(ts|js)x?$/,
+            /node_modules[\\/].*(@?react-aria).*\.(c|m)?(ts|js)x?$/,
           ],
 
           use: [
@@ -755,7 +758,7 @@ export function createBaseConfig({
           resolve: { fullySpecified: false },
         },
         {
-          test: /node_modules[\\/]lru-cache[\\/].*\.(ts|js)x?$/,
+          test: /node_modules[\\/].*lru-cache.*\.(ts|js)x?$/,
           use: [
             {
               loader: 'builtin:swc-loader',


### PR DESCRIPTION
## Problem

`yarn app:web-embed:build` fails on EAS build machines with 218 errors like:

```
ERROR in ../../packages/shared/src/logger/scopes/wallet/scenes/walletBanner.ts
Module build failed (from builtin:swc-loader):
x Unexpected token `@`. Expected identifier ...
  5 |   @LogToServer()
```

The build does run rspack (`builtin:swc-loader` is rspack-only); the failure is a config bug, not a webpack/rspack routing issue.

## Root cause

The vendor transpile rules in `development/rspack/rspack.base.config.ts` matched **unanchored substrings of the absolute file path**:

```
/(@?expo-*).*\.(c|m)?(ts|js)x?$/
```

EAS macOS builders check out the repo under `/Users/expo/workingdir/build/…` — the `expo` username makes this regex match **every first-party `.ts`/`.js` file** in the repo. Those files then get an extra `builtin:swc-loader` pass whose parser has no `decorators: true`, so the first decorator (`@LogToServer()`) throws `Unexpected token @`. Local builds pass because local paths don't contain `expo`.

The same regexes exist in `webpack.base.config.js`, but the webpack chain is immune: its rules live in a `oneOf` block where the first-party babel rule (with `@babel/plugin-proposal-decorators`) wins first. The rspack migration (#12427) exposed the latent bug.

## Fix

Require a `node_modules` path segment **before** the original substring patterns, keeping the substring semantics after it, e.g.:

```
/node_modules[\\/].*(@?react-(navigation|native)).*\.(ts|js)x?$/
```

Semantics: the old behavior evaluated on the path suffix after the first `node_modules` segment — root-independent, byte-identical vendor matching, first-party files excluded. A strict per-package anchor was tried first (5166967d) and reverted (05aeb6b9) because scoped packages shipping raw TS (`node_modules/@onekeyfe/react-native-text-input/src/enum.ts`) rely on the substring match — that broke the "Web startup graph budget" CI job.

Also included (hardening, same file):
- `cache.buildDependencies` now lists all `development/rspack/*.ts` config modules — the CLI only auto-tracks the app-level `rspack.config.ts`, so warm persistent caches never invalidated on edits to the imported configs.
- The two remaining unanchored vendor regexes (`@onekeyfe/bitcoinforksjs-lib`, `@polkadot`) got the same `node_modules[\\/].*` prefix for consistency (both verified equivalent on the real tree; the former has no loader, the latter is web-embed-only).

## Verification

- **Set equivalence**: node script over all 243k+ real `node_modules` JS/TS files, 6 checkout roots (Linux/macOS EAS `/Users/expo/…`/Windows backslash): new regexes match the exact same vendor file set as pre-PR (0 diffs, all 8 rules), and zero first-party files match under any root.
- **Engine-level repro** (independent adversarial review agent, rspack 2.1.2 fixture under a `/Users/expo/workingdir/build` root): original fails with `Unexpected token @`, v1 fails with `Expected '{', got 'enum'`, this version builds and the output bundle runs (decorator executes, enum resolves).
- **All four rspack consumers actually built locally** with the final config, all 0 errors:
  - `yarn app:web-embed:build` — plus its Chromium 67 syntax-compat gate passed (proves vendor transpilation still applies)
  - `yarn app:web:build` (the path the "Web startup graph budget" job builds)
  - `yarn workspace @onekeyhq/desktop build:renderer`
  - ext `build:v3:rspack` (rspack invoked with the same env vars)
- `yarn agent:check --profile commit` passes.

`webpack.base.config.js` is intentionally unchanged: its `oneOf` structure + babel decorators make the over-match harmless (pre-migration EAS builds ran this way), and no webpack CI job runs on an EAS-style path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192dD4vRtBuTmFVqRGU65ET