### PR TITLE
fix: All Networks dead-end fallback and Android history load-more(OK-57945, OK-57069)

### DIFF
--- a/packages/kit-bg/src/services/ServiceAllNetwork/ServiceAllNetwork.ts
+++ b/packages/kit-bg/src/services/ServiceAllNetwork/ServiceAllNetwork.ts
@@ -20,6 +20,7 @@ import perfUtils, {
 import networkUtils, {
   isEnabledNetworksInAllNetworks,
 } from '@onekeyhq/shared/src/utils/networkUtils';
+import type { IServerNetwork } from '@onekeyhq/shared/types';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
 
 import ServiceBase from '../ServiceBase';
@@ -790,6 +791,74 @@ class ServiceAllNetwork extends ServiceBase {
     const allNetworksState =
       await this.backgroundApi.simpleDb.allNetworks.getAllNetworksState();
     return allNetworksState;
+  }
+
+  @backgroundMethod()
+  async getEnabledNetworksCompatibleWithWalletId({
+    walletId,
+  }: {
+    walletId: string;
+  }): Promise<IServerNetwork[]> {
+    // Mirrors useEnabledNetworksCompatibleWithWalletIdInAllNetworks (kit):
+    // the mainnet networks the All Networks view actually aggregates for
+    // this wallet. An empty result means All Networks is a dead end for
+    // the wallet (e.g. QR wallet with only QR-unsupported networks enabled).
+    const [{ enabledNetworks, disabledNetworks }, { networks }] =
+      await Promise.all([
+        this.getAllNetworksState(),
+        this.backgroundApi.serviceNetwork.getAllNetworks({
+          excludeTestNetwork: true,
+          excludeAllNetworkItem: true,
+        }),
+      ]);
+    const enabledNetworkIds = networks
+      .filter((n) =>
+        isEnabledNetworksInAllNetworks({
+          networkId: n.id,
+          disabledNetworks,
+          enabledNetworks,
+          isTestnet: n.isTestnet,
+        }),
+      )
+      .map((n) => n.id);
+    if (enabledNetworkIds.length === 0) {
+      // getChainSelectorNetworksCompatibleWithAccountId treats an empty
+      // networkIds list as "all networks", so return early here.
+      return [];
+    }
+    const { mainnetItems } =
+      await this.backgroundApi.serviceNetwork.getChainSelectorNetworksCompatibleWithAccountId(
+        {
+          walletId,
+          networkIds: enabledNetworkIds,
+        },
+      );
+    return mainnetItems;
+  }
+
+  @backgroundMethod()
+  async getAllNetworksFallbackNetworkId({
+    walletId,
+  }: {
+    walletId: string;
+  }): Promise<string | undefined> {
+    // Returns undefined when the All Networks view is usable for this wallet
+    // (at least one enabled network is compatible); otherwise returns the
+    // first wallet-compatible mainnet as the single-chain fallback.
+    const compatibleEnabledNetworks =
+      await this.getEnabledNetworksCompatibleWithWalletId({
+        walletId,
+      });
+    if (compatibleEnabledNetworks.length > 0) {
+      return undefined;
+    }
+    const { mainnetItems } =
+      await this.backgroundApi.serviceNetwork.getChainSelectorNetworksCompatibleWithAccountId(
+        {
+          walletId,
+        },
+      );
+    return mainnetItems?.[0]?.id;
   }
 
   @backgroundMethod()

--- a/packages/kit/src/components/AccountSelector/AllNetworksManagerTrigger.tsx
+++ b/packages/kit/src/components/AccountSelector/AllNetworksManagerTrigger.tsx
@@ -51,6 +51,7 @@ function AllNetworksManagerTrigger({
   const {
     enabledNetworksCompatibleWithWalletId,
     enabledNetworksWithoutAccount,
+    isReady: isCompatQueryReady,
     run,
   } = useEnabledNetworksCompatibleWithWalletIdInAllNetworks({
     walletId: compatQueryWalletId,
@@ -122,10 +123,45 @@ function AllNetworksManagerTrigger({
 
   if (
     showSkeleton ||
-    !enabledNetworksCompatibleWithWalletId ||
-    enabledNetworksCompatibleWithWalletId.length === 0
+    !isCompatQueryReady ||
+    !enabledNetworksCompatibleWithWalletId
   ) {
     return <Stack h={36} />;
+  }
+
+  if (enabledNetworksCompatibleWithWalletId.length === 0) {
+    // Dead-end escape hatch: none of the enabled All Networks chains is
+    // compatible with this wallet, so there are no network avatars to show.
+    // Keep the trigger pressable so the user can still open the network
+    // selector and switch to a single chain (or enable a compatible one).
+    return (
+      <XStack
+        borderRadius="$2"
+        hoverStyle={{
+          bg: '$bgHover',
+        }}
+        pressStyle={{
+          bg: '$bgActive',
+        }}
+        focusable
+        focusVisibleStyle={{
+          outlineWidth: 2,
+          outlineColor: '$focusRing',
+          outlineStyle: 'solid',
+        }}
+        userSelect="none"
+        onPress={handleOnPress}
+        alignItems="center"
+      >
+        <NetworkAvatarBase
+          logoURI={network?.logoURI ?? ''}
+          size="$6"
+          networkName={network?.name}
+          isAllNetworks={network?.isAllNetworks}
+        />
+        <Icon name="ChevronDownSmallOutline" color="$iconSubdued" size="$5" />
+      </XStack>
+    );
   }
 
   return (

--- a/packages/kit/src/hooks/useAllNetwork.ts
+++ b/packages/kit/src/hooks/useAllNetwork.ts
@@ -1236,6 +1236,10 @@ function useEnabledNetworksCompatibleWithWalletIdInAllNetworks({
     networkInfoMap: result?.networkInfoMap ?? {},
     enabledNetworksCompatibleWithWalletId,
     enabledNetworksWithoutAccount,
+    // usePromiseResult resets result to the memoized initResult reference on
+    // scope (swrKey) change, so identity tells "not resolved for this scope
+    // yet" apart from a resolved-but-empty compatible set.
+    isReady: result !== initResult,
     run,
   };
 }

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
@@ -5,11 +5,16 @@ import type { ReactNode } from 'react';
 import { act, renderHook } from '@testing-library/react';
 import { createStore } from 'jotai';
 
-import type { IDBAccount } from '@onekeyhq/kit-bg/src/dbs/local/types';
+import type {
+  IDBAccount,
+  IDBCreateQRWalletParams,
+} from '@onekeyhq/kit-bg/src/dbs/local/types';
+import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { WALLET_TYPE_IMPORTED } from '@onekeyhq/shared/src/consts/dbConsts';
 import { EAppSyncStorageKeys } from '@onekeyhq/shared/src/storage/syncStorageKeys';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+import type { IServerNetwork } from '@onekeyhq/shared/types';
 import {
   EAccountSelectorAutoSelectTriggerBy,
   EAccountSelectorSceneName,
@@ -194,6 +199,33 @@ const mockAddTonImportedAccountByMnemonic = jest.fn<
     },
   ]
 >();
+const mockCreateQrWalletService = jest.fn<
+  Promise<{
+    wallet: IWallet;
+    indexedAccount: IIndexedAccount | undefined;
+    isOverrideWallet?: boolean;
+  }>,
+  [IDBCreateQRWalletParams]
+>();
+const mockAddDefaultNetworkAccountsService = jest.fn<
+  Promise<{
+    addedAccounts: { networkId: string; deriveType: IAccountDeriveTypes }[];
+    failedAccounts: {
+      networkId: string;
+      deriveType: IAccountDeriveTypes;
+      error: unknown;
+    }[];
+  }>,
+  [unknown]
+>();
+const mockGetEnabledNetworksCompatibleWithWalletId = jest.fn<
+  Promise<IServerNetwork[]>,
+  [{ walletId: string }]
+>();
+const mockGetAllNetworksFallbackNetworkId = jest.fn<
+  Promise<string | undefined>,
+  [{ walletId: string }]
+>();
 
 jest.mock('@onekeyhq/kit-bg/src/states/jotai/utils', () => {
   const actual = jest.requireActual<
@@ -272,6 +304,8 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
       addTonImportedAccountByMnemonic: (
         ...args: Parameters<typeof mockAddTonImportedAccountByMnemonic>
       ) => mockAddTonImportedAccountByMnemonic(...args),
+      createQrWallet: (...args: Parameters<typeof mockCreateQrWalletService>) =>
+        mockCreateQrWalletService(...args),
       clearAccountCache: () => mockClearAccountCache(),
       getAllHdHwQrWallets: () => mockGetAllHdHwQrWallets(),
       getIndexedAccountsOfWallet: ({ walletId }: { walletId: string }) =>
@@ -310,6 +344,19 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
       shouldSyncWithHomeSource: (params: IGetSelectedAccountParams) =>
         mockShouldSyncWithHomeSource(params),
       shouldUseGlobalDeriveType: () => mockShouldUseGlobalDeriveType(),
+    },
+    serviceAllNetwork: {
+      getAllNetworksFallbackNetworkId: (
+        ...args: Parameters<typeof mockGetAllNetworksFallbackNetworkId>
+      ) => mockGetAllNetworksFallbackNetworkId(...args),
+      getEnabledNetworksCompatibleWithWalletId: (
+        ...args: Parameters<typeof mockGetEnabledNetworksCompatibleWithWalletId>
+      ) => mockGetEnabledNetworksCompatibleWithWalletId(...args),
+    },
+    serviceBatchCreateAccount: {
+      addDefaultNetworkAccounts: (
+        ...args: Parameters<typeof mockAddDefaultNetworkAccountsService>
+      ) => mockAddDefaultNetworkAccountsService(...args),
     },
     serviceNetwork: {
       isDeriveTypeAvailableForNetwork: () =>
@@ -536,6 +583,253 @@ describe('useAccountSelectorActions', () => {
       focusedWallet: WALLET_TYPE_IMPORTED,
       indexedAccountId: undefined,
       othersWalletAccountId: accountId,
+    });
+  });
+
+  describe('createQrWallet onboarding network selection', () => {
+    const qrWallet = { id: 'qr-1' } as IWallet;
+    const qrIndexedAccount = {
+      id: 'qr-1--0',
+      walletId: 'qr-1',
+    } as IIndexedAccount;
+    const qrDevice = {
+      deviceId: 'qr-device-1',
+    } as unknown as IDBCreateQRWalletParams['qrDevice'];
+
+    function seedAllNetworksSelection(
+      store: ReturnType<typeof createWrapper>['store'],
+    ) {
+      store.set(selectedAccountsAtom(), {
+        0: {
+          ...defaultSelectedAccount(),
+          walletId: 'hd-1',
+          indexedAccountId: 'hd-1--0',
+          focusedWallet: 'hd-1',
+          networkId: getNetworkIdsMap().onekeyall,
+          deriveType: 'default',
+        },
+      });
+    }
+
+    beforeEach(() => {
+      mockCreateQrWalletService.mockResolvedValue({
+        wallet: qrWallet,
+        indexedAccount: qrIndexedAccount,
+        isOverrideWallet: false,
+      });
+      mockAddDefaultNetworkAccountsService.mockResolvedValue({
+        addedAccounts: [
+          { networkId: 'btc--0', deriveType: 'default' },
+          { networkId: 'evm--1', deriveType: 'default' },
+        ],
+        failedAccounts: [],
+      });
+    });
+
+    it('falls back to the first added network when All Networks has no compatible enabled networks', async () => {
+      mockGetEnabledNetworksCompatibleWithWalletId.mockResolvedValue([]);
+
+      const { store, Wrapper } = createWrapper();
+      seedAllNetworksSelection(store);
+      const { result } = renderHook(() => useAccountSelectorActions().current, {
+        wrapper: Wrapper,
+      });
+
+      await act(async () => {
+        await result.current.createQrWallet({
+          qrDevice,
+          airGapAccounts: [],
+          isOnboarding: true,
+        });
+      });
+
+      expect(mockGetEnabledNetworksCompatibleWithWalletId).toHaveBeenCalledWith(
+        {
+          walletId: 'qr-1',
+        },
+      );
+      expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+        walletId: 'qr-1',
+        indexedAccountId: 'qr-1--0',
+        networkId: 'btc--0',
+        deriveType: 'default',
+      });
+    });
+
+    it('keeps All Networks when compatible enabled networks exist', async () => {
+      mockGetEnabledNetworksCompatibleWithWalletId.mockResolvedValue([
+        { id: 'evm--1' } as IServerNetwork,
+      ]);
+
+      const { store, Wrapper } = createWrapper();
+      seedAllNetworksSelection(store);
+      const { result } = renderHook(() => useAccountSelectorActions().current, {
+        wrapper: Wrapper,
+      });
+
+      await act(async () => {
+        await result.current.createQrWallet({
+          qrDevice,
+          airGapAccounts: [],
+          isOnboarding: true,
+        });
+      });
+
+      expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+        walletId: 'qr-1',
+        indexedAccountId: 'qr-1--0',
+        networkId: getNetworkIdsMap().onekeyall,
+        deriveType: 'default',
+      });
+    });
+
+    it('keeps All Networks when the compatibility check fails', async () => {
+      mockGetEnabledNetworksCompatibleWithWalletId.mockRejectedValue(
+        new Error('bg call failed'),
+      );
+
+      const { store, Wrapper } = createWrapper();
+      seedAllNetworksSelection(store);
+      const { result } = renderHook(() => useAccountSelectorActions().current, {
+        wrapper: Wrapper,
+      });
+
+      await act(async () => {
+        await result.current.createQrWallet({
+          qrDevice,
+          airGapAccounts: [],
+          isOnboarding: true,
+        });
+      });
+
+      expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+        walletId: 'qr-1',
+        networkId: getNetworkIdsMap().onekeyall,
+        deriveType: 'default',
+      });
+    });
+  });
+
+  describe('confirmAccountSelect All Networks fallback', () => {
+    const qrIndexedAccount = {
+      id: 'qr-1--0',
+      walletId: 'qr-1',
+    } as IIndexedAccount;
+
+    function seedSelection(
+      store: ReturnType<typeof createWrapper>['store'],
+      networkId: string,
+    ) {
+      store.set(selectedAccountsAtom(), {
+        0: {
+          ...defaultSelectedAccount(),
+          walletId: 'hd-1',
+          indexedAccountId: 'hd-1--0',
+          focusedWallet: 'hd-1',
+          networkId,
+          deriveType: 'default',
+        },
+      });
+    }
+
+    it('falls back to the first compatible chain when All Networks is a dead end for the target wallet', async () => {
+      mockGetAllNetworksFallbackNetworkId.mockResolvedValue('btc--0');
+
+      const { store, Wrapper } = createWrapper();
+      seedSelection(store, getNetworkIdsMap().onekeyall);
+      const { result } = renderHook(() => useAccountSelectorActions().current, {
+        wrapper: Wrapper,
+      });
+
+      await act(async () => {
+        await result.current.confirmAccountSelect({
+          indexedAccount: qrIndexedAccount,
+          othersWalletAccount: undefined,
+          num: 0,
+        });
+      });
+
+      expect(mockGetAllNetworksFallbackNetworkId).toHaveBeenCalledWith({
+        walletId: 'qr-1',
+      });
+      expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+        walletId: 'qr-1',
+        indexedAccountId: 'qr-1--0',
+        networkId: 'btc--0',
+      });
+    });
+
+    it('keeps All Networks when the target wallet has compatible enabled networks', async () => {
+      mockGetAllNetworksFallbackNetworkId.mockResolvedValue(undefined);
+
+      const { store, Wrapper } = createWrapper();
+      seedSelection(store, getNetworkIdsMap().onekeyall);
+      const { result } = renderHook(() => useAccountSelectorActions().current, {
+        wrapper: Wrapper,
+      });
+
+      await act(async () => {
+        await result.current.confirmAccountSelect({
+          indexedAccount: qrIndexedAccount,
+          othersWalletAccount: undefined,
+          num: 0,
+        });
+      });
+
+      expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+        walletId: 'qr-1',
+        indexedAccountId: 'qr-1--0',
+        networkId: getNetworkIdsMap().onekeyall,
+      });
+    });
+
+    it('keeps All Networks when the fallback check fails', async () => {
+      mockGetAllNetworksFallbackNetworkId.mockRejectedValue(
+        new Error('bg call failed'),
+      );
+
+      const { store, Wrapper } = createWrapper();
+      seedSelection(store, getNetworkIdsMap().onekeyall);
+      const { result } = renderHook(() => useAccountSelectorActions().current, {
+        wrapper: Wrapper,
+      });
+
+      await act(async () => {
+        await result.current.confirmAccountSelect({
+          indexedAccount: qrIndexedAccount,
+          othersWalletAccount: undefined,
+          num: 0,
+        });
+      });
+
+      expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+        walletId: 'qr-1',
+        indexedAccountId: 'qr-1--0',
+        networkId: getNetworkIdsMap().onekeyall,
+      });
+    });
+
+    it('does not run the fallback check for single-chain selections', async () => {
+      const { store, Wrapper } = createWrapper();
+      seedSelection(store, 'tron--0x2b6653dc');
+      const { result } = renderHook(() => useAccountSelectorActions().current, {
+        wrapper: Wrapper,
+      });
+
+      await act(async () => {
+        await result.current.confirmAccountSelect({
+          indexedAccount: qrIndexedAccount,
+          othersWalletAccount: undefined,
+          num: 0,
+        });
+      });
+
+      expect(mockGetAllNetworksFallbackNetworkId).not.toHaveBeenCalled();
+      expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+        walletId: 'qr-1',
+        indexedAccountId: 'qr-1--0',
+        networkId: 'tron--0x2b6653dc',
+      });
     });
   });
 

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -1386,15 +1386,43 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
       const oldSelectedAccount: IAccountSelectorSelectedAccount = cloneDeep(
         this.getSelectedAccount.call(set, { num }) || defaultSelectedAccount(),
       );
+
+      // All Networks is a dead end when none of its enabled networks is
+      // compatible with the target wallet (home renders a blank network
+      // selector); fall back to the first compatible single chain instead.
+      let resolvedNetworkId: string = accountNetworkId;
+      const targetNetworkId = accountNetworkId || oldSelectedAccount.networkId;
+      if (
+        !platformEnv.isWebDappMode &&
+        targetNetworkId &&
+        networkUtils.isAllNetwork({ networkId: targetNetworkId }) &&
+        !accountUtils.isOthersWallet({ walletId })
+      ) {
+        try {
+          const fallbackNetworkId =
+            await backgroundApiProxy.serviceAllNetwork.getAllNetworksFallbackNetworkId(
+              {
+                walletId,
+              },
+            );
+          if (fallbackNetworkId) {
+            resolvedNetworkId = fallbackNetworkId;
+          }
+        } catch {
+          // keep the All Networks selection if the check fails
+        }
+      }
+
       const newSelectedAccount: IAccountSelectorSelectedAccount = {
         ...oldSelectedAccount,
-        networkId: accountNetworkId || oldSelectedAccount.networkId,
+        networkId: resolvedNetworkId || oldSelectedAccount.networkId,
         walletId,
         othersWalletAccountId: othersWalletAccount?.id,
         indexedAccountId: indexedAccount?.id,
       };
       const shouldUseFastConfirm =
-        !accountNetworkId || accountNetworkId === oldSelectedAccount.networkId;
+        !resolvedNetworkId ||
+        resolvedNetworkId === oldSelectedAccount.networkId;
 
       if (shouldUseFastConfirm) {
         if (platformEnv.isWebDappMode) {
@@ -1447,7 +1475,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
           num,
           builder: (v) => ({
             ...v,
-            networkId: accountNetworkId || v.networkId,
+            networkId: resolvedNetworkId || v.networkId,
             walletId,
             othersWalletAccountId: othersWalletAccount?.id,
             indexedAccountId: indexedAccount?.id,
@@ -2249,6 +2277,26 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
               indexedAccount,
               isCreateWallet: true,
             });
+            const firstAccount = result?.addedAccounts?.[0];
+            // All Networks is a dead end when none of its enabled networks
+            // is compatible with the QR wallet (home renders a blank network
+            // selector with no way to escape); fall back to the first created
+            // account's network in that case.
+            let shouldFallbackToFirstAccountNetwork = false;
+            if (firstAccount) {
+              try {
+                const compatibleEnabledNetworks =
+                  await backgroundApiProxy.serviceAllNetwork.getEnabledNetworksCompatibleWithWalletId(
+                    {
+                      walletId: wallet.id,
+                    },
+                  );
+                shouldFallbackToFirstAccountNetwork =
+                  compatibleEnabledNetworks.length === 0;
+              } catch {
+                // keep the All Networks default if the check fails
+              }
+            }
             // update networkId and deriveType matched with first account
             await this.updateSelectedAccount.call(set, {
               num: 0, // update home num selector
@@ -2258,10 +2306,17 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
                     item.networkId === v.networkId &&
                     item.deriveType === v.deriveType,
                 );
-                const firstAccount = result?.addedAccounts?.[0];
 
                 if (currentNetworkSupport || !firstAccount) {
                   return v;
+                }
+
+                if (shouldFallbackToFirstAccountNetwork) {
+                  return {
+                    ...v,
+                    networkId: firstAccount.networkId,
+                    deriveType: firstAccount.deriveType || 'default',
+                  };
                 }
 
                 return {

--- a/patches/@react-native+virtualized-lists+0.81.5.patch
+++ b/patches/@react-native+virtualized-lists+0.81.5.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@react-native/virtualized-lists/Lists/VirtualizedList.js b/node_modules/@react-native/virtualized-lists/Lists/VirtualizedList.js
-index 5b8aaa5..a6e2662 100644
+index 5b8aaa5..6db20ca 100644
 --- a/node_modules/@react-native/virtualized-lists/Lists/VirtualizedList.js
 +++ b/node_modules/@react-native/virtualized-lists/Lists/VirtualizedList.js
 @@ -1210,9 +1210,19 @@ class VirtualizedList extends StateSafePureComponent<
@@ -25,3 +25,33 @@ index 5b8aaa5..a6e2662 100644
    }
  
    _cellRefs: {[string]: null | CellRenderer<any>} = {};
+@@ -1575,12 +1585,28 @@ class VirtualizedList extends StateSafePureComponent<
+     const isWithinStartThreshold = distanceFromStart <= startThreshold;
+     const isWithinEndThreshold = distanceFromEnd <= endThreshold;
+ 
++    // OneKey patch (OK-57069): the stock fire condition requires BOTH the
++    // render window to include the very last item AND the offset to sit
++    // within the end threshold of the laid-out content. With a small
++    // windowSize and heavy rows (Android history list) these two are
++    // anti-correlated: while the user is clamped at the bottom of the
++    // partially-rendered content the window is still expanding, and every
++    // rendered batch grows the content, pushing the user back out of the
++    // threshold — on slow devices onEndReached then never fires. A user
++    // pinned to the absolute bottom of everything currently laid out cannot
++    // scroll any further, so treat that hard clamp as end-reached even when
++    // the render window has not caught up yet. The sentEndForContentLength
++    // dedupe still limits this to one call per content-length plateau.
++    const isRenderWindowAtEnd =
++      this.state.cellsAroundViewport.last === getItemCount(data) - 1;
++    const isPinnedToContentBottom = distanceFromEnd <= DEFAULT_THRESHOLD_PX;
++
+     // First check if the user just scrolled within the end threshold
+     // and call onEndReached only once for a given content length,
+     // and only if onStartReached is not being executed
+     if (
+       onEndReached &&
+-      this.state.cellsAroundViewport.last === getItemCount(data) - 1 &&
++      (isRenderWindowAtEnd || isPinnedToContentBottom) &&
+       isWithinEndThreshold &&
+       this._listMetrics.getContentLength() !== this._sentEndForContentLength
+     ) {


### PR DESCRIPTION
## Summary
- Fall back to the first available single chain when the All Networks view is a dead end for the target wallet (QR wallet creation, wallet switching, and a pressable escape hatch in the home network trigger) (OK-57945)
- Fix Android history list pagination never firing `onEndReached`: fire when the user is pinned to the bottom of the currently laid-out content, even if the render window has not caught up yet (OK-57069)

## Intent & Context
Two QA-reported wallet issues:

1. **OK-57945**: With a software wallet on All Networks whose enabled set contains only QR-unsupported chains (e.g. DOT only), creating a QR wallet lands home on All Networks with zero compatible networks. The home network selector renders a blank placeholder (no press target), and the all-network data pipeline has nothing to aggregate — the page dead-ends with no way for the user to escape. The same dead end existed when switching to an existing QR wallet, and via legacy persisted state on cold start.
2. **OK-57069** (Highest, reopened): On Android, the wallet history tab only shows the first page; scrolling down never shows the footer spinner and never loads more. Always reproducible on QA's device, intermittent on faster devices. A previous fix (#12360, unconditional edge-check in componentDidUpdate) did not resolve it.

## Root Cause
1. **OK-57945**: `createQrWallet` forces the post-create selection to `onekeyall` without checking whether any enabled All Networks chain is compatible with the QR wallet; `confirmAccountSelect` similarly carries `onekeyall` over when switching wallets. `AllNetworksManagerTrigger` renders a non-pressable empty `<Stack h={36}/>` when the compatible enabled set is empty, so the user cannot recover from the UI.
2. **OK-57069**: Confirmed via on-device instrumentation. `VirtualizedList._maybeCallOnEdgeReached` requires BOTH (a) the render window to include the last item AND (b) the offset to be within the end threshold of the laid-out content. The Android history list uses `windowSize={3}` with heavy rows, so the two guards are anti-correlated: while the user is clamped at the bottom of partially-rendered content, the window is still expanding, and every rendered batch grows the content and pushes the user back out of the threshold. Slow devices never win this race (always reproduces); faster devices need multiple bottom-chases (intermittent). iOS is unaffected because it has no `windowSize=3` override, so the window covers all items early. QA's reliable repro (slow network, switch chain, scroll down while history is still loading) simply pre-positions the user at the bottom clamp before the first page lands, entering the losing race immediately.

## Design Decisions
- **OK-57945** is fixed at three layers:
  - `createQrWallet` (onboarding): if no enabled All Networks chain is compatible with the new wallet, select the first created account's network instead of `onekeyall` (this restores previously commented-out fallback code, now gated on the compatibility check).
  - `confirmAccountSelect` (wallet switch): a new BG method `getAllNetworksFallbackNetworkId` returns the first wallet-compatible mainnet only when the All Networks view would be empty; the switch then goes through `updateSelectedAccount` so deriveType is re-fixed for the new network. Skipped in webDappMode (which forces All Networks by design).
  - `AllNetworksManagerTrigger` (escape hatch for any residual path — cold-start legacy state, tray switches): when the compatible set is resolved and empty, render a pressable All Networks trigger that opens the unified network selector instead of a blank placeholder. A new `isReady` flag on the hook distinguishes "not resolved yet" (keeps the loading placeholder, no cold-start visual change) from "resolved but empty".
  - The compatibility computation mirrors the trigger hook exactly (enabled set ∩ wallet-compatible mainnets), so "fallback fires" ⟺ "trigger would have been blank".
- **OK-57069** is fixed by extending the existing `@react-native/virtualized-lists` patch rather than app code: a user pinned to the absolute bottom (`distanceFromEnd <= 2px`) of everything currently laid out is unambiguously at the end, so `onEndReached` now fires on `isRenderWindowAtEnd || isPinnedToContentBottom`. The `sentEndForContentLength` dedupe still limits this to one call per content-length plateau, and the history load-more hook already tolerates early calls via its `pendingLoadMoreRef` replay. This slightly advances `onEndReached` timing for under-filled lists app-wide (closer to FlashList semantics).

## Changes Detail
- `packages/kit-bg/src/services/ServiceAllNetwork/ServiceAllNetwork.ts`: new BG methods `getEnabledNetworksCompatibleWithWalletId` and `getAllNetworksFallbackNetworkId`.
- `packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx`: All Networks dead-end fallback in `createQrWallet` (onboarding) and `confirmAccountSelect` (wallet switch).
- `packages/kit/src/hooks/useAllNetwork.ts`: `useEnabledNetworksCompatibleWithWalletIdInAllNetworks` now returns `isReady` (initResult identity check; no behavior change for existing consumers).
- `packages/kit/src/components/AccountSelector/AllNetworksManagerTrigger.tsx`: pressable escape-hatch trigger when the compatible enabled set is resolved and empty.
- `packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx`: 7 regression tests covering the createQrWallet fallback and confirmAccountSelect fallback paths.
- `patches/@react-native+virtualized-lists+0.81.5.patch`: pinned-to-content-bottom fire condition for `onEndReached` (with root-cause comment), on top of the existing componentDidUpdate edge-check.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile (primary for OK-57069) / Desktop / Web / Extension (account selector changes are cross-platform)
- **Risk Areas**:
  - The virtualized-lists patch changes `onEndReached` semantics for all RN lists: under-filled or slow-rendering lists may fire slightly earlier. Dedupe plus per-list idempotency guards bound the impact, but other paginated lists (NFT, market) are worth a quick regression pass.
  - `confirmAccountSelect` now awaits one extra BG call when the target network is All Networks; failure falls back to current behavior.

## Test plan
- [ ] OK-57945: HD wallet + All Networks with only DOT enabled → create a QR wallet → home lands on the first created chain (BTC), network selector visible and functional
- [ ] OK-57945: same state → switch to an existing QR wallet → selection falls back to a compatible single chain
- [ ] OK-57945: All Networks with compatible chains enabled → create/switch QR wallet → stays on All Networks (behavior unchanged)
- [ ] OK-57945: force the legacy dead-end state (QR wallet + All Networks + DOT-only) → home trigger is pressable and opens the network selector
- [ ] OK-57069: on the originally always-reproducing Android device, scroll history to the bottom once → footer spinner appears and page 2 loads
- [ ] OK-57069: QA's reliable repro — slow network, switch to a single chain, open history while still loading and scroll down immediately → pagination recovers once the first page lands
- [ ] Regression: other paginated lists (NFT, market) show no duplicate/looping page loads
- [ ] `yarn jest packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx` (37 tests) passes
