### PR TITLE
fix: keep Tabs scroll extent in sync after tab switches and async refreshes (OK-57257 OK-57977)

### DIFF
--- a/development/codeql/rust_sentinel.rs
+++ b/development/codeql/rust_sentinel.rs
@@ -1,0 +1,6 @@
+// This maintenance branch predates the repository's production Rust sources,
+// while the repository-wide CodeQL default setup still scans Rust. Keep one
+// analyzable source file so CodeQL can initialize its Rust database without
+// affecting any product build.
+#[allow(dead_code)]
+fn codeql_rust_sentinel() {}

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -142,6 +142,12 @@ export interface ITabContainerProps {
   initialTabName?: string;
   allowHeaderOverscroll?: boolean;
   disableScroll?: boolean;
+  /**
+   * Rebuilds the web tab content box when its measured extent changes so
+   * Chromium cannot retain a stale async-scroll range. Keep disabled unless
+   * the consumer is known to use the affected shared-scroller layout.
+   */
+  enableWebScrollExtentRecovery?: boolean;
   /** Only used on native Android, ignored on web */
   useNativeHeaderAnimation?: boolean;
 }
@@ -161,11 +167,15 @@ export function Container({
   ref: containerRef,
   initialTabName,
   disableScroll,
+  enableWebScrollExtentRecovery,
 }: PropsWithChildren<CollapsibleProps> &
   ITabContainerRefProps &
   Pick<
     ITabContainerProps,
-    'disableScroll' | 'useNativeHeaderAnimation' | 'renderSubHeader'
+    | 'disableScroll'
+    | 'enableWebScrollExtentRecovery'
+    | 'useNativeHeaderAnimation'
+    | 'renderSubHeader'
   >) {
   const getTabContentHeight = useCallback((element: Element | null) => {
     const htmlElement = element as HTMLElement | null;
@@ -280,18 +290,18 @@ export function Container({
   // this is "the previous tab's height" — comparing the next tab against it
   // tells us whether we just switched to a TALLER tab.
   const lastListContainerHeightRef = useRef(0);
-  // Armed during a settle window after each tab switch (see the reaction
-  // below). While armed, any growth of the focused tab's content (re)arms a
-  // debounced refresh; the window auto-expires so post-settle load-more
-  // growth never toggles display mid-scroll.
-  const extentRefreshArmedRef = useRef(false);
-  // Hard cap that disarms the settle window.
-  const extentRefreshWindowTimerRef = useRef<ReturnType<
-    typeof setTimeout
-  > | null>(null);
-  // Debounce so progressive restoration and any row-measure jitter collapse
-  // into a single refresh at the final settled height — no magnitude
-  // threshold and no per-grow toggling needed.
+  // Keep a single compositor rebuild in flight while content growth settles.
+  const pendingExtentRefreshRef = useRef<{
+    animationFrameId: number;
+    focusedTabName: string;
+    listContainer: HTMLElement;
+    previousDisplay: string;
+    previousScrollTop: number;
+    previousSwitching: boolean;
+    scroller: HTMLElement | null;
+  } | null>(null);
+  // Debounce progressive restoration and row-measure jitter into one refresh
+  // without relying on a post-switch deadline.
   const extentRefreshDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -310,33 +320,57 @@ export function Container({
   // window resize refreshes the cached extent; only tearing down and
   // rebuilding the list container's layout box does. The rebuild reads the
   // CURRENT layout, so it is correct regardless of which tab we came from, and
-  // is a cheap no-op where the extent was already correct. Toggle display
-  // synchronously so no frame is painted in between (no visible flash), and
-  // restore scrollTop because display:none collapses it to 0.
+  // is a cheap no-op where the extent was already correct. Chromium can merge
+  // a same-frame display toggle before the compositor observes the teardown,
+  // so keep the box detached for one painted frame. Restore scrollTop because
+  // display:none collapses it to 0.
   const refreshScrollExtent = useCallback(() => {
+    if (!enableWebScrollExtentRecovery) return;
     const lc = listContainerRef.current as HTMLElement | null;
     const scroller = scrollElement as HTMLElement | null;
-    if (!lc) return;
+    if (!lc || pendingExtentRefreshRef.current) return;
     const prevScrollTop = scroller?.scrollTop ?? 0;
     const prevDisplay = lc.style.display;
+    const prevSwitching = isSwitchingTabRef.current;
+    const pendingRefresh = {
+      animationFrameId: 0,
+      focusedTabName: focusedTab.value,
+      listContainer: lc,
+      previousDisplay: prevDisplay,
+      previousScrollTop: prevScrollTop,
+      previousSwitching: prevSwitching,
+      scroller,
+    };
+    pendingExtentRefreshRef.current = pendingRefresh;
     // Collapsing the list box momentarily clamps the scroller to 0, which the
     // WindowScroller scroll handler would persist into scrollTopRef. Borrow
     // the same flag tab-switch uses to suppress that bookkeeping while we tear
     // the box down and restore it.
-    const prevSwitching = isSwitchingTabRef.current;
     isSwitchingTabRef.current = true;
     lc.style.display = 'none';
-    // Force a synchronous reflow so the box is actually torn down before it is
-    // restored on the next line.
-    void lc.offsetHeight;
-    lc.style.display = prevDisplay;
-    // Restoring scrollTop reads layout, which flushes the rebuilt box, so the
-    // assignment clamps against the fresh (full) extent rather than 0.
-    if (scroller && scroller.scrollTop !== prevScrollTop) {
-      scroller.scrollTop = prevScrollTop;
-    }
-    isSwitchingTabRef.current = prevSwitching;
-  }, [scrollElement]);
+    pendingRefresh.animationFrameId = globalThis.requestAnimationFrame(() => {
+      pendingRefresh.animationFrameId = globalThis.requestAnimationFrame(() => {
+        if (pendingExtentRefreshRef.current !== pendingRefresh) {
+          return;
+        }
+        pendingExtentRefreshRef.current = null;
+        pendingRefresh.listContainer.style.display =
+          pendingRefresh.previousDisplay;
+        const isSameFocusedTab =
+          focusedTab.value === pendingRefresh.focusedTabName;
+        if (
+          isSameFocusedTab &&
+          pendingRefresh.scroller &&
+          pendingRefresh.scroller.scrollTop !== pendingRefresh.previousScrollTop
+        ) {
+          pendingRefresh.scroller.scrollTop = pendingRefresh.previousScrollTop;
+        }
+        if (isSameFocusedTab) {
+          isSwitchingTabRef.current = pendingRefresh.previousSwitching;
+        }
+      });
+    });
+  }, [enableWebScrollExtentRecovery, focusedTab, scrollElement]);
   const handlerStickyHeaderLayout = useCallback(
     (event: LayoutChangeEvent) => {
       const nextHeight = event.nativeEvent.layout.height;
@@ -436,9 +470,9 @@ export function Container({
         // pair, not only the tallest tab). Debounce so progressive react-freeze
         // / content-visibility restoration and row-measure jitter collapse into
         // a single refresh once the height stops changing, at the final height.
-        // The window auto-expires (see the tab-switch reaction) so later
-        // load-more growth on the settled tab never toggles display mid-scroll.
-        if (grew && extentRefreshArmedRef.current) {
+        // Slow data can settle at any time, so this is not tied to a fixed
+        // post-switch deadline.
+        if (grew && enableWebScrollExtentRecovery) {
           if (extentRefreshDebounceRef.current) {
             clearTimeout(extentRefreshDebounceRef.current);
           }
@@ -522,7 +556,13 @@ export function Container({
       mo.observe(registeredElement, { childList: true, subtree: true });
       mutationObserverRef.current = mo;
     }
-  }, [focusedTab, getTabContentHeight, tabNames, refreshScrollExtent]);
+  }, [
+    enableWebScrollExtentRecovery,
+    focusedTab,
+    getTabContentHeight,
+    tabNames,
+    refreshScrollExtent,
+  ]);
 
   // Keep the requestRemeasure context callback pointing at the latest
   // attach function. We use an indirection ref so contextValue identity
@@ -555,13 +595,16 @@ export function Container({
   useEffect(
     () => () => {
       isEffectValid.current = false;
-      if (extentRefreshWindowTimerRef.current) {
-        clearTimeout(extentRefreshWindowTimerRef.current);
-        extentRefreshWindowTimerRef.current = null;
-      }
       if (extentRefreshDebounceRef.current) {
         clearTimeout(extentRefreshDebounceRef.current);
         extentRefreshDebounceRef.current = null;
+      }
+      const pendingRefresh = pendingExtentRefreshRef.current;
+      if (pendingRefresh) {
+        globalThis.cancelAnimationFrame(pendingRefresh.animationFrameId);
+        pendingRefresh.listContainer.style.display =
+          pendingRefresh.previousDisplay;
+        pendingExtentRefreshRef.current = null;
       }
     },
     [],
@@ -615,23 +658,11 @@ export function Container({
     (tabName, prevTabName) => {
       if (isEffectValid.current && prevTabName && tabName !== prevTabName) {
         isSwitchingTabRef.current = true;
-        // Arm the stale-scroll-extent refresh for a settle window: while armed,
-        // `apply` debounces a refresh as the newly-focused tab's content grows
-        // back to its full height. A fresh switch drops any debounce queued for
-        // the previous tab. The window auto-expires so later (load-more) growth
-        // on the settled tab does not toggle display mid-scroll.
-        extentRefreshArmedRef.current = true;
+        // A fresh switch drops any debounce queued for the previous tab.
         if (extentRefreshDebounceRef.current) {
           clearTimeout(extentRefreshDebounceRef.current);
           extentRefreshDebounceRef.current = null;
         }
-        if (extentRefreshWindowTimerRef.current) {
-          clearTimeout(extentRefreshWindowTimerRef.current);
-        }
-        extentRefreshWindowTimerRef.current = setTimeout(() => {
-          extentRefreshArmedRef.current = false;
-          extentRefreshWindowTimerRef.current = null;
-        }, 1000);
         const index = tabNamesRef.current.findIndex((name) => name === tabName);
         let scrollTop = scrollTopRef.current[tabName] || 0;
 

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -66,10 +66,12 @@ export function ContainerChild({
       }
       listContainerRef.current.childNodes.forEach((element, index) => {
         if (!element) return;
-        const style = (element as HTMLElement).style;
+        const htmlElement = element as HTMLElement;
+        const style = htmlElement.style;
+        const isFocused = focusedIndex === index;
         let next = '';
         if (!disableWebTabContentVisibility) {
-          next = focusedIndex === index ? 'visible' : 'hidden';
+          next = isFocused ? 'visible' : 'hidden';
         }
         // Avoid redundant style writes during rapid focus changes.
         if (style.getPropertyValue('content-visibility') !== next) {
@@ -78,6 +80,20 @@ export function ContainerChild({
           } else {
             style.removeProperty('content-visibility');
           }
+        }
+        // content-visibility:hidden used to keep inactive tab controls out of
+        // keyboard and accessibility navigation. Preserve that behavior when
+        // Home disables the rendering optimization.
+        if (disableWebTabContentVisibility) {
+          htmlElement.inert = !isFocused;
+          if (isFocused) {
+            htmlElement.removeAttribute('aria-hidden');
+          } else {
+            htmlElement.setAttribute('aria-hidden', 'true');
+          }
+        } else {
+          htmlElement.inert = false;
+          htmlElement.removeAttribute('aria-hidden');
         }
       });
     },

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -358,6 +358,8 @@ export function Container({
       tabIndex >= 0 ? listContainerRef.current.children.item(tabIndex) : null;
     const element = (registeredElement ??
       fallbackElement) as HTMLElement | null;
+    const isRegisteredScrollView =
+      registeredElement?.classList.contains('onekey-tabs-scroll-view') ?? false;
     // Fallback-measured tabs (no registered Tabs.List/ScrollView element)
     // observe the page div, but that div is a flex item stretched to the
     // pinned container height — its border box never resizes when inner
@@ -379,7 +381,7 @@ export function Container({
       element
         ? [
             observedElement,
-            ...(registeredElement?.classList.contains('onekey-tabs-scroll-view')
+            ...(isRegisteredScrollView && registeredElement
               ? Array.from(registeredElement.children).filter(
                   (child): child is HTMLElement => child instanceof HTMLElement,
                 )
@@ -437,8 +439,13 @@ export function Container({
       observedElements.every(
         (candidate, index) => candidate === observedElementsRef.current[index],
       );
-    // Same measurement source and signal elements -> nothing to re-attach.
-    if (element && isObservingSameElements) {
+    const canReuseObservers =
+      resizeObserverRef.current !== null &&
+      isObservingSameElements &&
+      (!isRegisteredScrollView || mutationObserverRef.current !== null);
+    // Same measurement source, signal elements, and required observers ->
+    // nothing to re-attach.
+    if (element && canReuseObservers) {
       apply(element);
       return;
     }
@@ -468,10 +475,7 @@ export function Container({
     // set follows the live children and remeasure the registered root. This is
     // intentionally generic to Tabs.ScrollView; business tabs do not need to
     // report their loading phases or schedule delayed retries.
-    if (
-      registeredElement?.classList.contains('onekey-tabs-scroll-view') &&
-      typeof MutationObserver !== 'undefined'
-    ) {
+    if (isRegisteredScrollView && typeof MutationObserver !== 'undefined') {
       const mo = new MutationObserver(() => {
         if (
           !isEffectValid.current ||

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -475,7 +475,11 @@ export function Container({
     // set follows the live children and remeasure the registered root. This is
     // intentionally generic to Tabs.ScrollView; business tabs do not need to
     // report their loading phases or schedule delayed retries.
-    if (isRegisteredScrollView && typeof MutationObserver !== 'undefined') {
+    if (
+      isRegisteredScrollView &&
+      registeredElement &&
+      typeof MutationObserver !== 'undefined'
+    ) {
       const mo = new MutationObserver(() => {
         if (
           !isEffectValid.current ||

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -44,30 +44,44 @@ export function ContainerChild({
   containerWidth,
   focusedTab,
   tabNames,
+  disableWebTabContentVisibility,
   ...props
 }: PropsWithChildren<WindowScrollerChildProps> & {
   listContainerRef: RefObject<Element>;
   containerWidth: number | string | undefined;
   focusedTab: SharedValue<string>;
   tabNames: (string | null)[];
+  disableWebTabContentVisibility: boolean;
 }) {
   const focusedTabValue = useConvertAnimatedToValue(focusedTab, '');
 
   const syncFocusedTabVisibility = useCallback(
     (tabName: string) => {
       const focusedIndex = tabNames.findIndex((name) => name === tabName);
-      if (focusedIndex < 0 || !listContainerRef.current) return;
+      if (
+        (!disableWebTabContentVisibility && focusedIndex < 0) ||
+        !listContainerRef.current
+      ) {
+        return;
+      }
       listContainerRef.current.childNodes.forEach((element, index) => {
         if (!element) return;
         const style = (element as HTMLElement).style;
-        const next = focusedIndex === index ? 'visible' : 'hidden';
+        let next = '';
+        if (!disableWebTabContentVisibility) {
+          next = focusedIndex === index ? 'visible' : 'hidden';
+        }
         // Avoid redundant style writes during rapid focus changes.
         if (style.getPropertyValue('content-visibility') !== next) {
-          style.setProperty('content-visibility', next);
+          if (next) {
+            style.setProperty('content-visibility', next);
+          } else {
+            style.removeProperty('content-visibility');
+          }
         }
       });
     },
-    [listContainerRef, tabNames],
+    [disableWebTabContentVisibility, listContainerRef, tabNames],
   );
 
   useAnimatedReaction(
@@ -143,11 +157,10 @@ export interface ITabContainerProps {
   allowHeaderOverscroll?: boolean;
   disableScroll?: boolean;
   /**
-   * Rebuilds the web tab content box when its measured extent changes so
-   * Chromium cannot retain a stale async-scroll range. Keep disabled unless
-   * the consumer is known to use the affected shared-scroller layout.
+   * Disables content-visibility on web tab wrappers. Use this for shared scroll
+   * containers with dynamic content or header heights.
    */
-  enableWebScrollExtentRecovery?: boolean;
+  disableWebTabContentVisibility?: boolean;
   /** Only used on native Android, ignored on web */
   useNativeHeaderAnimation?: boolean;
 }
@@ -167,13 +180,13 @@ export function Container({
   ref: containerRef,
   initialTabName,
   disableScroll,
-  enableWebScrollExtentRecovery,
+  disableWebTabContentVisibility = false,
 }: PropsWithChildren<CollapsibleProps> &
   ITabContainerRefProps &
   Pick<
     ITabContainerProps,
     | 'disableScroll'
-    | 'enableWebScrollExtentRecovery'
+    | 'disableWebTabContentVisibility'
     | 'useNativeHeaderAnimation'
     | 'renderSubHeader'
   >) {
@@ -277,7 +290,9 @@ export function Container({
   const listContainerRef = useRef<Element>(null);
 
   const stickyHeaderHeight = useRef(0);
-  const hasMeasuredStickyHeaderRef = useRef(false);
+  const handlerStickyHeaderLayout = useCallback((event: LayoutChangeEvent) => {
+    stickyHeaderHeight.current = event.nativeEvent.layout.height;
+  }, []);
 
   const [scrollElement, setScrollElement] = useState<Element | null>(null);
   const isSwitchingTabRef = useRef(false);
@@ -285,111 +300,6 @@ export function Container({
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const mutationObserverRef = useRef<MutationObserver | null>(null);
   const observedElementsRef = useRef<HTMLElement[]>([]);
-  // Last height written to listContainerRef. Because listContainerRef is the
-  // single shared scroll content whose height always tracks the focused tab,
-  // this is "the previous tab's height" — comparing the next tab against it
-  // tells us whether we just switched to a TALLER tab.
-  const lastListContainerHeightRef = useRef(0);
-  // Keep a single compositor rebuild in flight while content growth settles.
-  const pendingExtentRefreshRef = useRef<{
-    animationFrameId: number;
-    focusedTabName: string;
-    listContainer: HTMLElement;
-    previousDisplay: string;
-    previousScrollTop: number;
-    previousSwitching: boolean;
-    scroller: HTMLElement | null;
-  } | null>(null);
-  // Debounce progressive restoration and row-measure jitter into one refresh
-  // without relying on a post-switch deadline.
-  const extentRefreshDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-
-  // A scroll container whose content first shrinks (the previously-focused
-  // taller tab is hidden by react-freeze, so listContainerRef height drops to
-  // the shorter tab) and then grows back (switching to the taller tab again)
-  // can keep a STALE, too-small scroll extent: scrollHeight and programmatic
-  // `scrollTop = n` are correct, but compositor/async-driven wheel scrolling
-  // clamps to the previous, shorter tab's extent — so the user cannot scroll
-  // to the bottom. We reproduced this on Chromium (the Electron desktop
-  // surface), whose threaded scrolling makes it easy to hit; this is NOT
-  // assumed to be Chromium-only — engines with async scrolling (WebKit/Gecko)
-  // can behave the same, so the refresh is intentionally not gated by browser.
-  // Neither a reflow, an overflow toggle, a content-height change, nor a
-  // window resize refreshes the cached extent; only tearing down and
-  // rebuilding the list container's layout box does. The rebuild reads the
-  // CURRENT layout, so it is correct regardless of which tab we came from, and
-  // is a cheap no-op where the extent was already correct. Chromium can merge
-  // a same-frame display toggle before the compositor observes the teardown,
-  // so keep the box detached for one painted frame. Restore scrollTop because
-  // display:none collapses it to 0.
-  const refreshScrollExtent = useCallback(() => {
-    if (!enableWebScrollExtentRecovery) return;
-    const lc = listContainerRef.current as HTMLElement | null;
-    const scroller = scrollElement as HTMLElement | null;
-    if (!lc || pendingExtentRefreshRef.current) return;
-    const prevScrollTop = scroller?.scrollTop ?? 0;
-    const prevDisplay = lc.style.display;
-    const prevSwitching = isSwitchingTabRef.current;
-    const pendingRefresh = {
-      animationFrameId: 0,
-      focusedTabName: focusedTab.value,
-      listContainer: lc,
-      previousDisplay: prevDisplay,
-      previousScrollTop: prevScrollTop,
-      previousSwitching: prevSwitching,
-      scroller,
-    };
-    pendingExtentRefreshRef.current = pendingRefresh;
-    // Collapsing the list box momentarily clamps the scroller to 0, which the
-    // WindowScroller scroll handler would persist into scrollTopRef. Borrow
-    // the same flag tab-switch uses to suppress that bookkeeping while we tear
-    // the box down and restore it.
-    isSwitchingTabRef.current = true;
-    lc.style.display = 'none';
-    pendingRefresh.animationFrameId = globalThis.requestAnimationFrame(() => {
-      pendingRefresh.animationFrameId = globalThis.requestAnimationFrame(() => {
-        if (pendingExtentRefreshRef.current !== pendingRefresh) {
-          return;
-        }
-        pendingExtentRefreshRef.current = null;
-        pendingRefresh.listContainer.style.display =
-          pendingRefresh.previousDisplay;
-        const isSameFocusedTab =
-          focusedTab.value === pendingRefresh.focusedTabName;
-        if (
-          isSameFocusedTab &&
-          pendingRefresh.scroller &&
-          pendingRefresh.scroller.scrollTop !== pendingRefresh.previousScrollTop
-        ) {
-          pendingRefresh.scroller.scrollTop = pendingRefresh.previousScrollTop;
-        }
-        if (isSameFocusedTab) {
-          isSwitchingTabRef.current = pendingRefresh.previousSwitching;
-        }
-      });
-    });
-  }, [enableWebScrollExtentRecovery, focusedTab, scrollElement]);
-  const handlerStickyHeaderLayout = useCallback(
-    (event: LayoutChangeEvent) => {
-      const nextHeight = event.nativeEvent.layout.height;
-      const previousHeight = stickyHeaderHeight.current;
-      stickyHeaderHeight.current = nextHeight;
-      if (!hasMeasuredStickyHeaderRef.current) {
-        hasMeasuredStickyHeaderRef.current = true;
-        return;
-      }
-      // renderHeader can change height independently from the focused tab
-      // (for example, dismissing the wallet banner). Chromium can retain the
-      // old async-scroll extent until the list layout box is rebuilt, leaving
-      // the current tab unable to reach its real bottom until a tab switch.
-      if (Math.abs(nextHeight - previousHeight) > 0.5) {
-        refreshScrollExtent();
-      }
-    },
-    [refreshScrollExtent],
-  );
   // Attach (or re-attach) a ResizeObserver to the focused tab's scroll
   // element so listContainerRef height follows it. Replaces the previous
   // 250ms-polling retry loop entirely:
@@ -462,25 +372,7 @@ export function Container({
           ? registeredHeight
           : getTabContentHeight(targetElement);
       if (h > 0) {
-        const grew = h > lastListContainerHeightRef.current;
         containerElement.style.height = `${h}px`;
-        lastListContainerHeightRef.current = h;
-        // Any growth that follows a tab switch can strand the stale compositor
-        // extent (arriving at a tab taller than the one just left — for any
-        // pair, not only the tallest tab). Debounce so progressive react-freeze
-        // / content-visibility restoration and row-measure jitter collapse into
-        // a single refresh once the height stops changing, at the final height.
-        // Slow data can settle at any time, so this is not tied to a fixed
-        // post-switch deadline.
-        if (grew && enableWebScrollExtentRecovery) {
-          if (extentRefreshDebounceRef.current) {
-            clearTimeout(extentRefreshDebounceRef.current);
-          }
-          extentRefreshDebounceRef.current = setTimeout(() => {
-            extentRefreshDebounceRef.current = null;
-            refreshScrollExtent();
-          }, 150);
-        }
       } else {
         containerElement.style.height = '';
       }
@@ -556,13 +448,7 @@ export function Container({
       mo.observe(registeredElement, { childList: true, subtree: true });
       mutationObserverRef.current = mo;
     }
-  }, [
-    enableWebScrollExtentRecovery,
-    focusedTab,
-    getTabContentHeight,
-    tabNames,
-    refreshScrollExtent,
-  ]);
+  }, [focusedTab, getTabContentHeight, tabNames]);
 
   // Keep the requestRemeasure context callback pointing at the latest
   // attach function. We use an indirection ref so contextValue identity
@@ -595,17 +481,6 @@ export function Container({
   useEffect(
     () => () => {
       isEffectValid.current = false;
-      if (extentRefreshDebounceRef.current) {
-        clearTimeout(extentRefreshDebounceRef.current);
-        extentRefreshDebounceRef.current = null;
-      }
-      const pendingRefresh = pendingExtentRefreshRef.current;
-      if (pendingRefresh) {
-        globalThis.cancelAnimationFrame(pendingRefresh.animationFrameId);
-        pendingRefresh.listContainer.style.display =
-          pendingRefresh.previousDisplay;
-        pendingExtentRefreshRef.current = null;
-      }
     },
     [],
   );
@@ -658,11 +533,6 @@ export function Container({
     (tabName, prevTabName) => {
       if (isEffectValid.current && prevTabName && tabName !== prevTabName) {
         isSwitchingTabRef.current = true;
-        // A fresh switch drops any debounce queued for the previous tab.
-        if (extentRefreshDebounceRef.current) {
-          clearTimeout(extentRefreshDebounceRef.current);
-          extentRefreshDebounceRef.current = null;
-        }
         const index = tabNamesRef.current.findIndex((name) => name === tabName);
         let scrollTop = scrollTopRef.current[tabName] || 0;
 
@@ -838,6 +708,9 @@ export function Container({
                   listContainerRef={listContainerRef as any}
                   focusedTab={focusedTab}
                   tabNames={tabNames}
+                  disableWebTabContentVisibility={
+                    disableWebTabContentVisibility
+                  }
                 >
                   {children}
                 </ContainerChild>

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -267,9 +267,7 @@ export function Container({
   const listContainerRef = useRef<Element>(null);
 
   const stickyHeaderHeight = useRef(0);
-  const handlerStickyHeaderLayout = useCallback((event: LayoutChangeEvent) => {
-    stickyHeaderHeight.current = event.nativeEvent.layout.height;
-  }, []);
+  const hasMeasuredStickyHeaderRef = useRef(false);
 
   const [scrollElement, setScrollElement] = useState<Element | null>(null);
   const isSwitchingTabRef = useRef(false);
@@ -339,6 +337,25 @@ export function Container({
     }
     isSwitchingTabRef.current = prevSwitching;
   }, [scrollElement]);
+  const handlerStickyHeaderLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const nextHeight = event.nativeEvent.layout.height;
+      const previousHeight = stickyHeaderHeight.current;
+      stickyHeaderHeight.current = nextHeight;
+      if (!hasMeasuredStickyHeaderRef.current) {
+        hasMeasuredStickyHeaderRef.current = true;
+        return;
+      }
+      // renderHeader can change height independently from the focused tab
+      // (for example, dismissing the wallet banner). Chromium can retain the
+      // old async-scroll extent until the list layout box is rebuilt, leaving
+      // the current tab unable to reach its real bottom until a tab switch.
+      if (Math.abs(nextHeight - previousHeight) > 0.5) {
+        refreshScrollExtent();
+      }
+    },
+    [refreshScrollExtent],
+  );
   // Attach (or re-attach) a ResizeObserver to the focused tab's scroll
   // element so listContainerRef height follows it. Replaces the previous
   // 250ms-polling retry loop entirely:

--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -275,7 +275,8 @@ export function Container({
   const isSwitchingTabRef = useRef(false);
 
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
-  const observedElementRef = useRef<HTMLElement | null>(null);
+  const mutationObserverRef = useRef<MutationObserver | null>(null);
+  const observedElementsRef = useRef<HTMLElement[]>([]);
   // Last height written to listContainerRef. Because listContainerRef is the
   // single shared scroll content whose height always tracks the focused tab,
   // this is "the previous tab's height" — comparing the next tab against it
@@ -369,6 +370,27 @@ export function Container({
       !registeredElement && element
         ? ((element.firstElementChild as HTMLElement | null) ?? element)
         : element;
+    // A registered ScrollView can temporarily keep the same border-box while
+    // its thawed/async content makes scrollHeight grow. Observing only the
+    // root misses that transition, which leaves the shared list container at
+    // the shorter tab's height. Keep the root as the measurement source, but
+    // also observe its direct content nodes as generic change signals.
+    const getObservedElements = () =>
+      element
+        ? [
+            observedElement,
+            ...(registeredElement?.classList.contains('onekey-tabs-scroll-view')
+              ? Array.from(registeredElement.children).filter(
+                  (child): child is HTMLElement => child instanceof HTMLElement,
+                )
+              : []),
+          ].filter(
+            (candidate, index, elements): candidate is HTMLElement =>
+              candidate instanceof HTMLElement &&
+              elements.indexOf(candidate) === index,
+          )
+        : [];
+    const observedElements = getObservedElements();
     const apply = (targetElement: HTMLElement) => {
       const containerElement = listContainerRef.current as HTMLElement | null;
       if (!containerElement) return;
@@ -410,8 +432,13 @@ export function Container({
         containerElement.style.height = '';
       }
     };
-    // Same element + already observing -> nothing to do.
-    if (element && observedElementRef.current === observedElement) {
+    const isObservingSameElements =
+      observedElements.length === observedElementsRef.current.length &&
+      observedElements.every(
+        (candidate, index) => candidate === observedElementsRef.current[index],
+      );
+    // Same measurement source and signal elements -> nothing to re-attach.
+    if (element && isObservingSameElements) {
       apply(element);
       return;
     }
@@ -419,16 +446,57 @@ export function Container({
       resizeObserverRef.current.disconnect();
       resizeObserverRef.current = null;
     }
-    observedElementRef.current = observedElement;
-    if (!element || !observedElement) {
+    if (mutationObserverRef.current) {
+      mutationObserverRef.current.disconnect();
+      mutationObserverRef.current = null;
+    }
+    observedElementsRef.current = observedElements;
+    if (!element || observedElements.length === 0) {
       return;
     }
     // Synchronous initial measurement so the container doesn't flicker
     // between 0-height and the first observer callback.
     apply(element);
     const ro = new ResizeObserver(() => apply(element));
-    ro.observe(observedElement);
+    observedElements.forEach((candidate) => ro.observe(candidate));
     resizeObserverRef.current = ro;
+
+    // React can replace the focused ScrollView's direct content node after
+    // the initial skeleton/data render. The old node remains the RO target,
+    // while the ScrollView's pinned border box can stay unchanged even though
+    // its scrollHeight has grown. Observe structural changes so the RO target
+    // set follows the live children and remeasure the registered root. This is
+    // intentionally generic to Tabs.ScrollView; business tabs do not need to
+    // report their loading phases or schedule delayed retries.
+    if (
+      registeredElement?.classList.contains('onekey-tabs-scroll-view') &&
+      typeof MutationObserver !== 'undefined'
+    ) {
+      const mo = new MutationObserver(() => {
+        if (
+          !isEffectValid.current ||
+          scrollTabElementsRef.current?.[focusedTab.value]?.element !==
+            registeredElement
+        ) {
+          return;
+        }
+        const nextObservedElements = getObservedElements();
+        const targetsChanged =
+          nextObservedElements.length !== observedElementsRef.current.length ||
+          nextObservedElements.some(
+            (candidate, index) =>
+              candidate !== observedElementsRef.current[index],
+          );
+        if (targetsChanged) {
+          ro.disconnect();
+          nextObservedElements.forEach((candidate) => ro.observe(candidate));
+          observedElementsRef.current = nextObservedElements;
+        }
+        apply(element);
+      });
+      mo.observe(registeredElement, { childList: true, subtree: true });
+      mutationObserverRef.current = mo;
+    }
   }, [focusedTab, getTabContentHeight, tabNames, refreshScrollExtent]);
 
   // Keep the requestRemeasure context callback pointing at the latest
@@ -448,7 +516,11 @@ export function Container({
         resizeObserverRef.current.disconnect();
         resizeObserverRef.current = null;
       }
-      observedElementRef.current = null;
+      if (mutationObserverRef.current) {
+        mutationObserverRef.current.disconnect();
+        mutationObserverRef.current = null;
+      }
+      observedElementsRef.current = [];
     };
   }, [attachObserverForFocusedTab]);
 

--- a/packages/components/src/composite/Tabs/ScrollView.tsx
+++ b/packages/components/src/composite/Tabs/ScrollView.tsx
@@ -46,7 +46,13 @@ export function ScrollView({
   ]);
 
   return (
-    <YStack flex={1} style={style} ref={ref as any} width={width}>
+    <YStack
+      flex={1}
+      style={style}
+      ref={ref as any}
+      width={width}
+      className="onekey-tabs-scroll-view"
+    >
       {children}
     </YStack>
   );

--- a/packages/components/src/composite/Tabs/index.native.tsx
+++ b/packages/components/src/composite/Tabs/index.native.tsx
@@ -9,8 +9,8 @@ import type { CollapsibleProps } from 'react-native-collapsible-tab-view';
 
 interface IExtendedContainerProps extends CollapsibleProps {
   useNativeHeaderAnimation?: boolean;
-  /** Web-only scroll extent recovery; accepted for API parity and ignored. */
-  enableWebScrollExtentRecovery?: boolean;
+  /** Web-only content-visibility optimization; accepted for API parity. */
+  disableWebTabContentVisibility?: boolean;
   /**
    * Web-only: slot between the sticky TabBar and tab content. On native, the
    * equivalent should live inside each tab list's ListHeaderComponent, so the
@@ -28,7 +28,7 @@ const Container = forwardRef<any, PropsWithChildren<IExtendedContainerProps>>(
       pagerProps,
       headerContainerStyle,
       renderSubHeader: _renderSubHeader,
-      enableWebScrollExtentRecovery: _enableWebScrollExtentRecovery,
+      disableWebTabContentVisibility: _disableWebTabContentVisibility,
       ...props
     },
     ref,

--- a/packages/components/src/composite/Tabs/index.native.tsx
+++ b/packages/components/src/composite/Tabs/index.native.tsx
@@ -9,6 +9,8 @@ import type { CollapsibleProps } from 'react-native-collapsible-tab-view';
 
 interface IExtendedContainerProps extends CollapsibleProps {
   useNativeHeaderAnimation?: boolean;
+  /** Web-only scroll extent recovery; accepted for API parity and ignored. */
+  enableWebScrollExtentRecovery?: boolean;
   /**
    * Web-only: slot between the sticky TabBar and tab content. On native, the
    * equivalent should live inside each tab list's ListHeaderComponent, so the
@@ -26,6 +28,7 @@ const Container = forwardRef<any, PropsWithChildren<IExtendedContainerProps>>(
       pagerProps,
       headerContainerStyle,
       renderSubHeader: _renderSubHeader,
+      enableWebScrollExtentRecovery: _enableWebScrollExtentRecovery,
       ...props
     },
     ref,

--- a/packages/kit/src/views/Home/pages/DeFiContainer.tsx
+++ b/packages/kit/src/views/Home/pages/DeFiContainer.tsx
@@ -21,8 +21,6 @@ import {
   useMedia,
   useScrollContentTabBarOffset,
 } from '@onekeyhq/components';
-import { useTabsContext } from '@onekeyhq/components/src/composite/Tabs/context';
-import { useTabNameContextSafe } from '@onekeyhq/components/src/composite/Tabs/TabNameContext';
 import {
   useSettingsPersistAtom,
   useSettingsValuePersistAtom,
@@ -79,7 +77,6 @@ import {
 // viewport, and visual max-width is enforced one level down per content block.
 const DEFI_CONTAINER_CONTENT_MAX_WIDTH = 1140;
 const PROTOCOL_NAV_PENDING_TARGET_TIMEOUT_MS = 5000;
-const DEFI_TAB_REMEASURE_DELAYS_MS = [100, 350, 800] as const;
 const DEFI_TAB_CONTENT_TEST_ID = 'home-defi-tab-content';
 
 function scrollToAnchor(
@@ -112,8 +109,6 @@ function DeFiContainer() {
   const media = useMedia();
   const reducedMotion = useReducedMotion();
   const intl = useIntl();
-  const currentTabName = useTabNameContextSafe();
-  const { requestRemeasure, scrollTabElementsRef } = useTabsContext();
 
   const tableLayout = media.gtMd;
 
@@ -165,7 +160,6 @@ function DeFiContainer() {
 
   const triggerPinCheckRef = useRef<() => void>(() => {});
   const scrollContainerRef = useRef<HTMLElement | null>(null);
-  const reportedDeFiTabContentRef = useRef<HTMLElement | null>(null);
   const protocolRefs = useRef<Map<string, IProtocolHandle>>(new Map());
   // Read by pin tracker each scroll frame; ref avoids effect teardown on remeasure.
   const chipStripHeightRef = useRef<number>(0);
@@ -452,88 +446,6 @@ function DeFiContainer() {
   // chips would just create flicker on cold start.
   const shouldShowChipStrip =
     tableLayout && !isOverviewLoading && filteredProtocols.length >= 2;
-
-  const reportDeFiContentHeight = useCallback(() => {
-    if (platformEnv.isNative || !isTabFocused || !currentTabName) {
-      return;
-    }
-
-    const element = globalThis.document?.querySelector?.(
-      `[data-testid="${DEFI_TAB_CONTENT_TEST_ID}"]`,
-    );
-    const refStore = scrollTabElementsRef?.current;
-    if (!(element instanceof HTMLElement) || !refStore) {
-      return;
-    }
-
-    const nextHeight = Math.max(
-      element.scrollHeight || 0,
-      element.clientHeight || 0,
-      element.getBoundingClientRect().height || 0,
-    );
-    if (!Number.isFinite(nextHeight) || nextHeight <= 0) {
-      return;
-    }
-
-    if (!refStore[currentTabName]) {
-      refStore[currentTabName] = {} as {
-        element: HTMLElement;
-        height?: number;
-      };
-    }
-    const entry = refStore[currentTabName];
-    const didChange =
-      entry.element !== element ||
-      Math.abs((entry.height ?? 0) - nextHeight) > 1;
-    if (!didChange) {
-      return;
-    }
-
-    entry.element = element;
-    entry.height = nextHeight;
-    reportedDeFiTabContentRef.current = element;
-    requestRemeasure?.();
-  }, [currentTabName, isTabFocused, requestRemeasure, scrollTabElementsRef]);
-
-  useEffect(() => {
-    if (platformEnv.isNative || !isTabFocused) {
-      return undefined;
-    }
-
-    reportDeFiContentHeight();
-    const refStore = scrollTabElementsRef?.current;
-    const frame = requestAnimationFrame(reportDeFiContentHeight);
-    const timers = DEFI_TAB_REMEASURE_DELAYS_MS.map((delay) =>
-      setTimeout(reportDeFiContentHeight, delay),
-    );
-
-    return () => {
-      cancelAnimationFrame(frame);
-      timers.forEach(clearTimeout);
-      const reportedElement = reportedDeFiTabContentRef.current;
-      const entry = currentTabName ? refStore?.[currentTabName] : undefined;
-      if (entry?.element === reportedElement) {
-        delete refStore[currentTabName];
-        reportedDeFiTabContentRef.current = null;
-        requestRemeasure?.();
-      }
-    };
-  }, [
-    addPaddingOnListFooter,
-    currentTabName,
-    filteredProtocols.length,
-    isDeFiEnabled,
-    isOverviewLoading,
-    isTabFocused,
-    portfolioStats.slices.length,
-    protocols?.length,
-    requestRemeasure,
-    reportDeFiContentHeight,
-    scrollTabElementsRef,
-    shouldShowChipStrip,
-    shouldShowOverview,
-    tableLayout,
-  ]);
 
   // When the strip unmounts (data not ready, dropped below threshold),
   // reset the height ref so the next scrollToAnchor / pin tracker pass

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -840,7 +840,7 @@ export function HomePageView({
         ref={tabsRef as any}
         key={key}
         allowHeaderOverscroll
-        enableWebScrollExtentRecovery
+        disableWebTabContentVisibility
         headerHeight={platformEnv.isNative ? 312 : undefined}
         useNativeHeaderAnimation={platformEnv.isNativeAndroid}
         width={platformEnv.isNative ? (tabContainerWidth as number) : undefined}

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -840,6 +840,7 @@ export function HomePageView({
         ref={tabsRef as any}
         key={key}
         allowHeaderOverscroll
+        enableWebScrollExtentRecovery
         headerHeight={platformEnv.isNative ? 312 : undefined}
         useNativeHeaderAnimation={platformEnv.isNativeAndroid}
         width={platformEnv.isNative ? (tabContainerWidth as number) : undefined}

--- a/scenarios/regression.mjs
+++ b/scenarios/regression.mjs
@@ -615,6 +615,7 @@ async function runDappColdStartDesktop(cdpUrl, flags) {
 async function runTabsScrollExtentDesktop(cdpUrl) {
   const { page } = await connectCdpMainWindow(cdpUrl);
   const growthProbeTestId = 'tabs-scroll-extent-late-growth-probe';
+  const headerProbeTestId = 'tabs-scroll-extent-header-probe';
   const tabSwitchRounds = Number(process.env.TAB_SWITCH_ROUNDS || 8);
   const visiblePasswordInput = page.locator(
     '[data-testid="password-input"]:visible',
@@ -739,6 +740,141 @@ async function runTabsScrollExtentDesktop(cdpUrl) {
       previousScrollTop = metrics.scrollTop;
     }
   };
+
+  // Closing a wallet banner shrinks renderHeader without changing the focused
+  // tab's own content height. Reproduce that structural change with a
+  // deterministic header child, then verify the current tab accepts real wheel
+  // input immediately; switching tabs must not be required to recover it.
+  const cleanupHeaderProbe = () =>
+    defiContent.evaluate((tabContent, testId) => {
+      if (!(tabContent instanceof HTMLElement)) return;
+      const scroller = tabContent
+        .closest('.onekey-tabs-scroll-view')
+        ?.closest('.onekey-tabs-container');
+      if (scroller instanceof HTMLElement) {
+        scroller.querySelector(`[data-testid="${testId}"]`)?.remove();
+      }
+    }, headerProbeTestId);
+  const cleanupHeaderRefreshObserver = () =>
+    defiContent.evaluate((tabContent) => {
+      if (!(tabContent instanceof HTMLElement)) return;
+      const scroller = tabContent
+        .closest('.onekey-tabs-scroll-view')
+        ?.closest('.onekey-tabs-container');
+      if (!(scroller instanceof HTMLElement)) return;
+      scroller.__tabsHeaderRefreshObserver?.disconnect();
+      delete scroller.__tabsHeaderRefreshObserver;
+      delete scroller.dataset.tabsHeaderRefreshObserved;
+    });
+
+  await cleanupHeaderProbe();
+  await cleanupHeaderRefreshObserver();
+  let headerShrinkFailure = false;
+  try {
+    const insertedHeaderProbe = await defiContent.evaluate(
+      (tabContent, testId) => {
+        if (!(tabContent instanceof HTMLElement)) return false;
+        const scroller = tabContent
+          .closest('.onekey-tabs-scroll-view')
+          ?.closest('.onekey-tabs-container');
+        const header = scroller?.firstElementChild;
+        if (
+          !(scroller instanceof HTMLElement) ||
+          !(header instanceof HTMLElement)
+        ) {
+          return false;
+        }
+        const scrollViewRoot = tabContent.closest('.onekey-tabs-scroll-view');
+        let listContainer = scrollViewRoot?.parentElement;
+        while (
+          listContainer &&
+          listContainer !== scroller &&
+          !listContainer.style.height
+        ) {
+          listContainer = listContainer.parentElement;
+        }
+        if (
+          !(listContainer instanceof HTMLElement) ||
+          listContainer === scroller
+        ) {
+          return false;
+        }
+        scroller.dataset.tabsHeaderRefreshObserved = 'false';
+        const refreshObserver = new MutationObserver((records) => {
+          if (
+            records.some((record) => record.oldValue?.includes('display: none'))
+          ) {
+            scroller.dataset.tabsHeaderRefreshObserved = 'true';
+          }
+        });
+        refreshObserver.observe(listContainer, {
+          attributeFilter: ['style'],
+          attributeOldValue: true,
+          attributes: true,
+        });
+        scroller.__tabsHeaderRefreshObserver = refreshObserver;
+        scroller.scrollTop = 0;
+        const probe = document.createElement('div');
+        probe.setAttribute('data-testid', testId);
+        probe.style.cssText =
+          'display:block;flex:none;width:100%;height:96px;min-height:96px;';
+        header.append(probe);
+        return true;
+      },
+      headerProbeTestId,
+    );
+    if (!insertedHeaderProbe) {
+      throw new Error('Could not insert the Tabs header probe');
+    }
+    await sleep(300);
+    await cleanupHeaderProbe();
+    await sleep(300);
+
+    await wheelToBottom();
+    await sleep(300);
+
+    const headerShrinkMetrics = await getMetrics();
+    if (!headerShrinkMetrics) {
+      throw new Error(
+        'Tabs scroll metrics are unavailable after header shrink',
+      );
+    }
+    const headerRefreshObserved = await defiContent.evaluate((tabContent) => {
+      if (!(tabContent instanceof HTMLElement)) return false;
+      const scroller = tabContent
+        .closest('.onekey-tabs-scroll-view')
+        ?.closest('.onekey-tabs-container');
+      return (
+        scroller instanceof HTMLElement &&
+        scroller.dataset.tabsHeaderRefreshObserved === 'true'
+      );
+    });
+    headerShrinkFailure =
+      !headerRefreshObserved ||
+      !headerShrinkMetrics.atBottom ||
+      headerShrinkMetrics.hiddenBelowScroller > 2 ||
+      headerShrinkMetrics.unmeasuredScrollViewOverflow > 2;
+    log(
+      `Header shrink wheel: ${
+        headerShrinkFailure ? 'stuck' : 'clean'
+      } refresh=${headerRefreshObserved} scrollTop=${headerShrinkMetrics.scrollTop.toFixed(
+        1,
+      )}/${headerShrinkMetrics.maxScrollTop.toFixed(1)}`,
+    );
+  } finally {
+    await cleanupHeaderProbe();
+    await cleanupHeaderRefreshObserver();
+  }
+
+  if (headerShrinkFailure) {
+    const screenshotPath = path.resolve(
+      '.tmp/ui/tabs-scroll-extent-header-shrink-desktop.png',
+    );
+    fs.mkdirSync(path.dirname(screenshotPath), { recursive: true });
+    await page.screenshot({ path: screenshotPath });
+    log(`evidence -> ${screenshotPath}`);
+    return report('tabs-scroll-extent-desktop', 1, 1, 0, 0, '');
+  }
 
   // Reproduce OK-57257's recorded sequence first: a fully rendered, tall DeFi
   // tab is scrolled away from the top, switched to the short NFT tab, restored,
@@ -888,6 +1024,7 @@ async function runTabsScrollExtentDesktop(cdpUrl) {
     const listContainerGrowth =
       metrics.listContainerHeight - beforeGrowthMetrics.listContainerHeight;
     const reproduced =
+      headerShrinkFailure ||
       coldStartClipped ||
       tabRoundTripFailures > 0 ||
       extentGrowth < 90 ||
@@ -896,7 +1033,7 @@ async function runTabsScrollExtentDesktop(cdpUrl) {
       metrics.hiddenBelowScroller > 2 ||
       metrics.unmeasuredScrollViewOverflow > 2;
     log(
-      `Tabs extent coldStartClipped=${coldStartClipped} roundTripFailures=${tabRoundTripFailures}/${tabSwitchRounds} oldMax=${beforeGrowthMetrics.maxScrollTop.toFixed(
+      `Tabs extent headerShrinkFailure=${headerShrinkFailure} coldStartClipped=${coldStartClipped} roundTripFailures=${tabRoundTripFailures}/${tabSwitchRounds} oldMax=${beforeGrowthMetrics.maxScrollTop.toFixed(
         1,
       )} scrollTop=${metrics.scrollTop.toFixed(1)}/${metrics.maxScrollTop.toFixed(
         1,

--- a/scenarios/regression.mjs
+++ b/scenarios/regression.mjs
@@ -636,27 +636,22 @@ async function runTabsScrollExtentDesktop(cdpUrl) {
   // cold-start failure this first phase is meant to catch.
   await defiTab.click({ force: true });
 
-  const content = page
-    .locator(
-      '.onekey-tabs-scroll-view:visible, [data-testid="home-defi-tab-content"]:visible',
-    )
+  const defiContent = page
+    .locator('[data-testid="home-defi-tab-content"]:visible')
     .first();
-  await content.waitFor({ state: 'visible', timeout: 30_000 });
+  await defiContent.waitFor({ state: 'visible', timeout: 30_000 });
   await waitForCondition(
     'scrollable Tabs.ScrollView content',
     () =>
-      page.evaluate(() => {
-        const element = [
-          ...document.querySelectorAll(
-            '.onekey-tabs-scroll-view, [data-testid="home-defi-tab-content"]',
-          ),
-        ].find(
-          (candidate) =>
-            candidate instanceof HTMLElement &&
-            candidate.getBoundingClientRect().height > 0,
+      defiContent.evaluate((tabContent) => {
+        if (!(tabContent instanceof HTMLElement)) return false;
+        const scrollViewRoot = tabContent.closest('.onekey-tabs-scroll-view');
+        const scroller = scrollViewRoot?.closest('.onekey-tabs-container');
+        return (
+          scrollViewRoot instanceof HTMLElement &&
+          scroller instanceof HTMLElement &&
+          scrollViewRoot.scrollHeight > window.innerHeight
         );
-        if (!(element instanceof HTMLElement)) return false;
-        return element.scrollHeight > window.innerHeight;
       }),
     45_000,
   );
@@ -668,21 +663,14 @@ async function runTabsScrollExtentDesktop(cdpUrl) {
   // requiring the business tab to report its own height.
   await sleep(1200);
   const getMetrics = () =>
-    page.evaluate(() => {
-      const scroller = document.querySelector('.onekey-tabs-container');
-      const visibleElement = (selector) =>
-        [...document.querySelectorAll(selector)].find(
-          (candidate) =>
-            candidate instanceof HTMLElement &&
-            candidate.getBoundingClientRect().height > 0,
-        );
-      const scrollViewRoot = visibleElement('.onekey-tabs-scroll-view');
-      const tabContent =
-        visibleElement('[data-testid="home-defi-tab-content"]') ??
-        scrollViewRoot;
+    defiContent.evaluate((tabContent) => {
+      if (!(tabContent instanceof HTMLElement)) return null;
+      const scrollViewRoot = tabContent.closest('.onekey-tabs-scroll-view');
+      const scroller = scrollViewRoot?.closest('.onekey-tabs-container');
       if (
+        !(scrollViewRoot instanceof HTMLElement) ||
         !(scroller instanceof HTMLElement) ||
-        !(tabContent instanceof HTMLElement)
+        !scroller.contains(tabContent)
       ) {
         return null;
       }
@@ -690,10 +678,7 @@ async function runTabsScrollExtentDesktop(cdpUrl) {
       // and the shared horizontal list container. The latter is the nearest
       // ancestor with an imperative inline height; asserting that height
       // changes prevents overflow from masking a stale Tabs measurement.
-      let listContainer =
-        scrollViewRoot instanceof HTMLElement
-          ? scrollViewRoot.parentElement
-          : null;
+      let listContainer = scrollViewRoot.parentElement;
       while (
         listContainer &&
         listContainer !== scroller &&
@@ -721,16 +706,9 @@ async function runTabsScrollExtentDesktop(cdpUrl) {
             ? listContainer.getBoundingClientRect().height
             : 0,
         maxScrollTop,
-        scrollViewHeight:
-          scrollViewRoot instanceof HTMLElement
-            ? scrollViewRoot.getBoundingClientRect().height
-            : 0,
-        scrollViewScrollHeight:
-          scrollViewRoot instanceof HTMLElement
-            ? scrollViewRoot.scrollHeight
-            : 0,
+        scrollViewHeight: scrollViewRoot.getBoundingClientRect().height,
+        scrollViewScrollHeight: scrollViewRoot.scrollHeight,
         unmeasuredScrollViewOverflow:
-          scrollViewRoot instanceof HTMLElement &&
           listContainer instanceof HTMLElement
             ? Math.max(
                 0,
@@ -836,41 +814,46 @@ async function runTabsScrollExtentDesktop(cdpUrl) {
     throw new Error('Could not establish the Tabs pre-growth scroll bottom');
   }
 
-  const insertedGrowthProbe = await page.evaluate((testId) => {
-    document.querySelector(`[data-testid="${testId}"]`)?.remove();
-    const element = [
-      ...document.querySelectorAll('[data-testid="home-defi-tab-content"]'),
-    ].find(
-      (candidate) =>
-        candidate instanceof HTMLElement &&
-        candidate.getBoundingClientRect().height > 0,
-    );
-    if (!(element instanceof HTMLElement)) return false;
-    const scrollViewRoot = element.closest('.onekey-tabs-scroll-view');
-    if (!(scrollViewRoot instanceof HTMLElement)) return false;
-    const properties = ['height', 'min-height', 'max-height', 'flex'];
-    scrollViewRoot.dataset.tabsScrollExtentOriginalStyle = JSON.stringify(
-      properties.map((property) => [
-        property,
-        scrollViewRoot.style.getPropertyValue(property),
-        scrollViewRoot.style.getPropertyPriority(property),
-      ]),
-    );
-    const lockedHeight = scrollViewRoot.getBoundingClientRect().height;
-    scrollViewRoot.style.setProperty('height', `${lockedHeight}px`);
-    scrollViewRoot.style.setProperty('min-height', `${lockedHeight}px`);
-    scrollViewRoot.style.setProperty('max-height', `${lockedHeight}px`);
-    scrollViewRoot.style.setProperty('flex', 'none');
-    const probe = document.createElement('div');
-    probe.setAttribute('data-testid', testId);
-    probe.style.cssText =
-      'display:block;flex:none;width:100%;height:96px;min-height:96px;';
-    // Add a new direct content node. The previous implementation observed a
-    // one-time child snapshot, so a cold-start skeleton/data replacement left
-    // the new node unobserved while the root border box stayed pinned.
-    scrollViewRoot.append(probe);
-    return true;
-  }, growthProbeTestId);
+  const insertedGrowthProbe = await defiContent.evaluate(
+    (tabContent, testId) => {
+      if (!(tabContent instanceof HTMLElement)) return false;
+      const scrollViewRoot = tabContent.closest('.onekey-tabs-scroll-view');
+      const scroller = scrollViewRoot?.closest('.onekey-tabs-container');
+      if (
+        !(scrollViewRoot instanceof HTMLElement) ||
+        !(scroller instanceof HTMLElement)
+      ) {
+        return false;
+      }
+      const existingProbe = scrollViewRoot.querySelector(
+        `[data-testid="${testId}"]`,
+      );
+      existingProbe?.remove();
+      const properties = ['height', 'min-height', 'max-height', 'flex'];
+      scrollViewRoot.dataset.tabsScrollExtentOriginalStyle = JSON.stringify(
+        properties.map((property) => [
+          property,
+          scrollViewRoot.style.getPropertyValue(property),
+          scrollViewRoot.style.getPropertyPriority(property),
+        ]),
+      );
+      const lockedHeight = scrollViewRoot.getBoundingClientRect().height;
+      scrollViewRoot.style.setProperty('height', `${lockedHeight}px`);
+      scrollViewRoot.style.setProperty('min-height', `${lockedHeight}px`);
+      scrollViewRoot.style.setProperty('max-height', `${lockedHeight}px`);
+      scrollViewRoot.style.setProperty('flex', 'none');
+      const probe = document.createElement('div');
+      probe.setAttribute('data-testid', testId);
+      probe.style.cssText =
+        'display:block;flex:none;width:100%;height:96px;min-height:96px;';
+      // Add a new direct content node. The previous implementation observed a
+      // one-time child snapshot, so a cold-start skeleton/data replacement left
+      // the new node unobserved while the root border box stayed pinned.
+      scrollViewRoot.append(probe);
+      return true;
+    },
+    growthProbeTestId,
+  );
   if (!insertedGrowthProbe) {
     throw new Error('Could not insert the Tabs.ScrollView growth probe');
   }
@@ -919,16 +902,12 @@ async function runTabsScrollExtentDesktop(cdpUrl) {
     log(`evidence -> ${screenshotPath}`);
   }
 
-  await page.evaluate((testId) => {
-    document.querySelector(`[data-testid="${testId}"]`)?.remove();
-    const scrollViewRoot = [
-      ...document.querySelectorAll('.onekey-tabs-scroll-view'),
-    ].find(
-      (candidate) =>
-        candidate instanceof HTMLElement &&
-        candidate.dataset.tabsScrollExtentOriginalStyle,
-    );
+  await defiContent.evaluate((tabContent, testId) => {
+    if (!(tabContent instanceof HTMLElement)) return;
+    const scrollViewRoot = tabContent.closest('.onekey-tabs-scroll-view');
     if (scrollViewRoot instanceof HTMLElement) {
+      const probe = scrollViewRoot.querySelector(`[data-testid="${testId}"]`);
+      probe?.remove();
       const snapshot = JSON.parse(
         scrollViewRoot.dataset.tabsScrollExtentOriginalStyle ?? '[]',
       );

--- a/scenarios/regression.mjs
+++ b/scenarios/regression.mjs
@@ -814,115 +814,125 @@ async function runTabsScrollExtentDesktop(cdpUrl) {
     throw new Error('Could not establish the Tabs pre-growth scroll bottom');
   }
 
-  const insertedGrowthProbe = await defiContent.evaluate(
-    (tabContent, testId) => {
-      if (!(tabContent instanceof HTMLElement)) return false;
+  const cleanupGrowthProbe = () =>
+    defiContent.evaluate((tabContent, testId) => {
+      if (!(tabContent instanceof HTMLElement)) return;
       const scrollViewRoot = tabContent.closest('.onekey-tabs-scroll-view');
-      const scroller = scrollViewRoot?.closest('.onekey-tabs-container');
-      if (
-        !(scrollViewRoot instanceof HTMLElement) ||
-        !(scroller instanceof HTMLElement)
-      ) {
-        return false;
-      }
-      const existingProbe = scrollViewRoot.querySelector(
-        `[data-testid="${testId}"]`,
-      );
-      existingProbe?.remove();
-      const properties = ['height', 'min-height', 'max-height', 'flex'];
-      scrollViewRoot.dataset.tabsScrollExtentOriginalStyle = JSON.stringify(
-        properties.map((property) => [
-          property,
-          scrollViewRoot.style.getPropertyValue(property),
-          scrollViewRoot.style.getPropertyPriority(property),
-        ]),
-      );
-      const lockedHeight = scrollViewRoot.getBoundingClientRect().height;
-      scrollViewRoot.style.setProperty('height', `${lockedHeight}px`);
-      scrollViewRoot.style.setProperty('min-height', `${lockedHeight}px`);
-      scrollViewRoot.style.setProperty('max-height', `${lockedHeight}px`);
-      scrollViewRoot.style.setProperty('flex', 'none');
-      const probe = document.createElement('div');
-      probe.setAttribute('data-testid', testId);
-      probe.style.cssText =
-        'display:block;flex:none;width:100%;height:96px;min-height:96px;';
-      // Add a new direct content node. The previous implementation observed a
-      // one-time child snapshot, so a cold-start skeleton/data replacement left
-      // the new node unobserved while the root border box stayed pinned.
-      scrollViewRoot.append(probe);
-      return true;
-    },
-    growthProbeTestId,
-  );
-  if (!insertedGrowthProbe) {
-    throw new Error('Could not insert the Tabs.ScrollView growth probe');
-  }
-  await sleep(300);
-
-  await wheelToBottom();
-  await sleep(300);
-
-  const metrics = await getMetrics();
-  if (!metrics) throw new Error('Tabs scroll metrics are unavailable');
-  const extentGrowth = metrics.maxScrollTop - beforeGrowthMetrics.maxScrollTop;
-  const listContainerGrowth =
-    metrics.listContainerHeight - beforeGrowthMetrics.listContainerHeight;
-  const reproduced =
-    coldStartClipped ||
-    tabRoundTripFailures > 0 ||
-    extentGrowth < 90 ||
-    listContainerGrowth < 90 ||
-    !metrics.atBottom ||
-    metrics.hiddenBelowScroller > 2 ||
-    metrics.unmeasuredScrollViewOverflow > 2;
-  log(
-    `Tabs extent coldStartClipped=${coldStartClipped} roundTripFailures=${tabRoundTripFailures}/${tabSwitchRounds} oldMax=${beforeGrowthMetrics.maxScrollTop.toFixed(
-      1,
-    )} scrollTop=${metrics.scrollTop.toFixed(1)}/${metrics.maxScrollTop.toFixed(
-      1,
-    )} container=${beforeGrowthMetrics.listContainerHeight.toFixed(
-      1,
-    )}->${metrics.listContainerHeight.toFixed(
-      1,
-    )} scrollView=${metrics.scrollViewHeight.toFixed(
-      1,
-    )}/${metrics.scrollViewScrollHeight}px content=${metrics.contentScrollHeight}px hidden=${metrics.hiddenBelowScroller.toFixed(
-      1,
-    )}px unmeasured=${metrics.unmeasuredScrollViewOverflow.toFixed(
-      1,
-    )}px viewport=${metrics.viewportWidth}x${metrics.viewportHeight}`,
-  );
-
-  if (reproduced) {
-    const screenshotPath = path.resolve(
-      '.tmp/ui/tabs-scroll-extent-desktop.png',
-    );
-    fs.mkdirSync(path.dirname(screenshotPath), { recursive: true });
-    await page.screenshot({ path: screenshotPath });
-    log(`evidence -> ${screenshotPath}`);
-  }
-
-  await defiContent.evaluate((tabContent, testId) => {
-    if (!(tabContent instanceof HTMLElement)) return;
-    const scrollViewRoot = tabContent.closest('.onekey-tabs-scroll-view');
-    if (scrollViewRoot instanceof HTMLElement) {
-      const probe = scrollViewRoot.querySelector(`[data-testid="${testId}"]`);
-      probe?.remove();
-      const snapshot = JSON.parse(
-        scrollViewRoot.dataset.tabsScrollExtentOriginalStyle ?? '[]',
-      );
-      for (const [property, value, priority] of snapshot) {
-        if (value) {
-          scrollViewRoot.style.setProperty(property, value, priority);
-        } else {
-          scrollViewRoot.style.removeProperty(property);
+      if (scrollViewRoot instanceof HTMLElement) {
+        const probe = scrollViewRoot.querySelector(`[data-testid="${testId}"]`);
+        probe?.remove();
+        const snapshot = JSON.parse(
+          scrollViewRoot.dataset.tabsScrollExtentOriginalStyle ?? '[]',
+        );
+        for (const [property, value, priority] of snapshot) {
+          if (value) {
+            scrollViewRoot.style.setProperty(property, value, priority);
+          } else {
+            scrollViewRoot.style.removeProperty(property);
+          }
         }
+        delete scrollViewRoot.dataset.tabsScrollExtentOriginalStyle;
       }
-      delete scrollViewRoot.dataset.tabsScrollExtentOriginalStyle;
-    }
-  }, growthProbeTestId);
+    }, growthProbeTestId);
 
-  return report('tabs-scroll-extent-desktop', reproduced ? 1 : 0, 1, 0, 0, '');
+  await cleanupGrowthProbe();
+  try {
+    const insertedGrowthProbe = await defiContent.evaluate(
+      (tabContent, testId) => {
+        if (!(tabContent instanceof HTMLElement)) return false;
+        const scrollViewRoot = tabContent.closest('.onekey-tabs-scroll-view');
+        const scroller = scrollViewRoot?.closest('.onekey-tabs-container');
+        if (
+          !(scrollViewRoot instanceof HTMLElement) ||
+          !(scroller instanceof HTMLElement)
+        ) {
+          return false;
+        }
+        const properties = ['height', 'min-height', 'max-height', 'flex'];
+        scrollViewRoot.dataset.tabsScrollExtentOriginalStyle = JSON.stringify(
+          properties.map((property) => [
+            property,
+            scrollViewRoot.style.getPropertyValue(property),
+            scrollViewRoot.style.getPropertyPriority(property),
+          ]),
+        );
+        const lockedHeight = scrollViewRoot.getBoundingClientRect().height;
+        scrollViewRoot.style.setProperty('height', `${lockedHeight}px`);
+        scrollViewRoot.style.setProperty('min-height', `${lockedHeight}px`);
+        scrollViewRoot.style.setProperty('max-height', `${lockedHeight}px`);
+        scrollViewRoot.style.setProperty('flex', 'none');
+        const probe = document.createElement('div');
+        probe.setAttribute('data-testid', testId);
+        probe.style.cssText =
+          'display:block;flex:none;width:100%;height:96px;min-height:96px;';
+        // Add a new direct content node. The previous implementation observed a
+        // one-time child snapshot, so a cold-start skeleton/data replacement left
+        // the new node unobserved while the root border box stayed pinned.
+        scrollViewRoot.append(probe);
+        return true;
+      },
+      growthProbeTestId,
+    );
+    if (!insertedGrowthProbe) {
+      throw new Error('Could not insert the Tabs.ScrollView growth probe');
+    }
+    await sleep(300);
+
+    await wheelToBottom();
+    await sleep(300);
+
+    const metrics = await getMetrics();
+    if (!metrics) throw new Error('Tabs scroll metrics are unavailable');
+    const extentGrowth =
+      metrics.maxScrollTop - beforeGrowthMetrics.maxScrollTop;
+    const listContainerGrowth =
+      metrics.listContainerHeight - beforeGrowthMetrics.listContainerHeight;
+    const reproduced =
+      coldStartClipped ||
+      tabRoundTripFailures > 0 ||
+      extentGrowth < 90 ||
+      listContainerGrowth < 90 ||
+      !metrics.atBottom ||
+      metrics.hiddenBelowScroller > 2 ||
+      metrics.unmeasuredScrollViewOverflow > 2;
+    log(
+      `Tabs extent coldStartClipped=${coldStartClipped} roundTripFailures=${tabRoundTripFailures}/${tabSwitchRounds} oldMax=${beforeGrowthMetrics.maxScrollTop.toFixed(
+        1,
+      )} scrollTop=${metrics.scrollTop.toFixed(1)}/${metrics.maxScrollTop.toFixed(
+        1,
+      )} container=${beforeGrowthMetrics.listContainerHeight.toFixed(
+        1,
+      )}->${metrics.listContainerHeight.toFixed(
+        1,
+      )} scrollView=${metrics.scrollViewHeight.toFixed(
+        1,
+      )}/${metrics.scrollViewScrollHeight}px content=${metrics.contentScrollHeight}px hidden=${metrics.hiddenBelowScroller.toFixed(
+        1,
+      )}px unmeasured=${metrics.unmeasuredScrollViewOverflow.toFixed(
+        1,
+      )}px viewport=${metrics.viewportWidth}x${metrics.viewportHeight}`,
+    );
+
+    if (reproduced) {
+      const screenshotPath = path.resolve(
+        '.tmp/ui/tabs-scroll-extent-desktop.png',
+      );
+      fs.mkdirSync(path.dirname(screenshotPath), { recursive: true });
+      await page.screenshot({ path: screenshotPath });
+      log(`evidence -> ${screenshotPath}`);
+    }
+
+    return report(
+      'tabs-scroll-extent-desktop',
+      reproduced ? 1 : 0,
+      1,
+      0,
+      0,
+      '',
+    );
+  } finally {
+    await cleanupGrowthProbe();
+  }
 }
 
 // Ported from the former cdp-repro-gift-storm.mjs. The detection

--- a/scenarios/regression.mjs
+++ b/scenarios/regression.mjs
@@ -773,20 +773,8 @@ async function runTabsScrollExtentDesktop(cdpUrl) {
         scroller.querySelector(`[data-testid="${testId}"]`)?.remove();
       }
     }, headerProbeTestId);
-  const cleanupHeaderRefreshObserver = () =>
-    defiContent.evaluate((tabContent) => {
-      if (!(tabContent instanceof HTMLElement)) return;
-      const scroller = tabContent
-        .closest('.onekey-tabs-scroll-view')
-        ?.closest('.onekey-tabs-container');
-      if (!(scroller instanceof HTMLElement)) return;
-      scroller.__tabsHeaderRefreshObserver?.disconnect();
-      delete scroller.__tabsHeaderRefreshObserver;
-      delete scroller.dataset.tabsHeaderRefreshObserved;
-    });
 
   await cleanupHeaderProbe();
-  await cleanupHeaderRefreshObserver();
   let headerShrinkFailure = false;
   try {
     const insertedHeaderProbe = await defiContent.evaluate(
@@ -802,35 +790,6 @@ async function runTabsScrollExtentDesktop(cdpUrl) {
         ) {
           return false;
         }
-        const scrollViewRoot = tabContent.closest('.onekey-tabs-scroll-view');
-        let listContainer = scrollViewRoot?.parentElement;
-        while (
-          listContainer &&
-          listContainer !== scroller &&
-          !listContainer.style.height
-        ) {
-          listContainer = listContainer.parentElement;
-        }
-        if (
-          !(listContainer instanceof HTMLElement) ||
-          listContainer === scroller
-        ) {
-          return false;
-        }
-        scroller.dataset.tabsHeaderRefreshObserved = 'false';
-        const refreshObserver = new MutationObserver((records) => {
-          if (
-            records.some((record) => record.oldValue?.includes('display: none'))
-          ) {
-            scroller.dataset.tabsHeaderRefreshObserved = 'true';
-          }
-        });
-        refreshObserver.observe(listContainer, {
-          attributeFilter: ['style'],
-          attributeOldValue: true,
-          attributes: true,
-        });
-        scroller.__tabsHeaderRefreshObserver = refreshObserver;
         scroller.scrollTop = 0;
         const probe = document.createElement('div');
         probe.setAttribute('data-testid', testId);
@@ -857,31 +816,19 @@ async function runTabsScrollExtentDesktop(cdpUrl) {
         'Tabs scroll metrics are unavailable after header shrink',
       );
     }
-    const headerRefreshObserved = await defiContent.evaluate((tabContent) => {
-      if (!(tabContent instanceof HTMLElement)) return false;
-      const scroller = tabContent
-        .closest('.onekey-tabs-scroll-view')
-        ?.closest('.onekey-tabs-container');
-      return (
-        scroller instanceof HTMLElement &&
-        scroller.dataset.tabsHeaderRefreshObserved === 'true'
-      );
-    });
     headerShrinkFailure =
-      !headerRefreshObserved ||
       !headerShrinkMetrics.atBottom ||
       headerShrinkMetrics.hiddenBelowScroller > 2 ||
       headerShrinkMetrics.unmeasuredScrollViewOverflow > 2;
     log(
       `Header shrink wheel: ${
         headerShrinkFailure ? 'stuck' : 'clean'
-      } refresh=${headerRefreshObserved} scrollTop=${headerShrinkMetrics.scrollTop.toFixed(
+      } scrollTop=${headerShrinkMetrics.scrollTop.toFixed(
         1,
       )}/${headerShrinkMetrics.maxScrollTop.toFixed(1)}`,
     );
   } finally {
     await cleanupHeaderProbe();
-    await cleanupHeaderRefreshObserver();
   }
 
   if (headerShrinkFailure) {

--- a/scenarios/regression.mjs
+++ b/scenarios/regression.mjs
@@ -725,6 +725,24 @@ async function runTabsScrollExtentDesktop(cdpUrl) {
     });
 
   const wheelToBottom = async () => {
+    const scrollTarget = await defiContent.evaluate((tabContent) => {
+      if (!(tabContent instanceof HTMLElement)) return null;
+      const scroller = tabContent
+        .closest('.onekey-tabs-scroll-view')
+        ?.closest('.onekey-tabs-container');
+      if (!(scroller instanceof HTMLElement)) return null;
+      const rect = scroller.getBoundingClientRect();
+      return {
+        x: rect.left + rect.width / 2,
+        y: Math.max(rect.top + 1, rect.bottom - 100),
+      };
+    });
+    if (!scrollTarget) {
+      throw new Error('Tabs wheel target is unavailable');
+    }
+    // Keep the pointer over real tab content. Leaving it on the sticky tab
+    // button bypasses Chromium's stale hit-test extent and masks this bug.
+    await page.mouse.move(scrollTarget.x, scrollTarget.y);
     let previousScrollTop = -1;
     let settledRounds = 0;
     for (let round = 0; round < 30 && settledRounds < 3; round += 1) {

--- a/scenarios/regression.mjs
+++ b/scenarios/regression.mjs
@@ -17,12 +17,14 @@
  * Usage:
  *   node scenarios/regression.mjs list
  *   node scenarios/regression.mjs dapp-cold-start-desktop --url https://onekey.so
+ *   node scenarios/regression.mjs tabs-scroll-extent-desktop # CDP 9222 (yarn app:desktop)
  *   node scenarios/regression.mjs gift-storm-desktop          # CDP 9222 (yarn app:desktop)
  *   node scenarios/regression.mjs gift-storm-web              # CDP 9223 (Chrome --remote-debugging-port=9223 on the web build)
  *   node scenarios/regression.mjs gift-storm-rn --platform ios
  *   node scenarios/regression.mjs gift-storm-rn --platform android
  *
  * Env (shared): ROUNDS, REGRESSION=1 (exit 1 if reproduced, 0 if clean).
+ * Env (Tabs): TAB_SWITCH_ROUNDS (default 8).
  * Env (cdp targets): CDP_URL_DESKTOP (falls back to CDP_URL, default 9222),
  *   CDP_URL_WEB (default 9223). Separate names so a desktop CDP_URL override
  *   can't silently redirect the web scenario.
@@ -102,19 +104,25 @@ async function connectCdpMainWindow(cdpUrl) {
     );
   }
   let page = null;
-  for (const c of browser.contexts()) {
-    for (const p of c.pages()) {
-      try {
-        if ((await p.locator('[data-testid^="tab-modal"]').count()) > 0) {
-          page = p;
-          break;
+  await waitForCondition(
+    'OneKey main window on CDP',
+    async () => {
+      for (const c of browser.contexts()) {
+        for (const p of c.pages()) {
+          try {
+            if ((await p.locator('[data-testid^="tab-modal"]').count()) > 0) {
+              page = p;
+              return true;
+            }
+          } catch {
+            /* page may be navigating */
+          }
         }
-      } catch {
-        /* page may be navigating */
       }
-    }
-    if (page) break;
-  }
+      return false;
+    },
+    30_000,
+  );
   if (!page) {
     // Detach only — never browser.close(), it would kill the user's running app
     // (see references/rules/electron-cdp.md). connectOverCDP leaks no process.
@@ -604,6 +612,340 @@ async function runDappColdStartDesktop(cdpUrl, flags) {
   return reportVerification('dapp-cold-start-desktop', checks);
 }
 
+async function runTabsScrollExtentDesktop(cdpUrl) {
+  const { page } = await connectCdpMainWindow(cdpUrl);
+  const growthProbeTestId = 'tabs-scroll-extent-late-growth-probe';
+  const tabSwitchRounds = Number(process.env.TAB_SWITCH_ROUNDS || 8);
+  const visiblePasswordInput = page.locator(
+    '[data-testid="password-input"]:visible',
+  );
+  if ((await visiblePasswordInput.count()) > 0) {
+    throw new Error(
+      'Desktop app is locked. Unlock it before running the Tabs scroll extent scenario.',
+    );
+  }
+
+  const defiTab = page.locator('[data-testid="home-tab-defi"]');
+  const nftTab = page.locator('[data-testid="home-tab-nft"]');
+  await defiTab.waitFor({ state: 'visible', timeout: 15_000 });
+  await nftTab.waitFor({ state: 'visible', timeout: 15_000 });
+
+  // The dev shell starts on Portfolio, whereas QA can reopen with DeFi still
+  // selected. Enter DeFi at most once and do not leave/re-enter while its slow
+  // data resolves: a round trip would re-attach the old observer and mask the
+  // cold-start failure this first phase is meant to catch.
+  await defiTab.click({ force: true });
+
+  const content = page
+    .locator(
+      '.onekey-tabs-scroll-view:visible, [data-testid="home-defi-tab-content"]:visible',
+    )
+    .first();
+  await content.waitFor({ state: 'visible', timeout: 30_000 });
+  await waitForCondition(
+    'scrollable Tabs.ScrollView content',
+    () =>
+      page.evaluate(() => {
+        const element = [
+          ...document.querySelectorAll(
+            '.onekey-tabs-scroll-view, [data-testid="home-defi-tab-content"]',
+          ),
+        ].find(
+          (candidate) =>
+            candidate instanceof HTMLElement &&
+            candidate.getBoundingClientRect().height > 0,
+        );
+        if (!(element instanceof HTMLElement)) return false;
+        return element.scrollHeight > window.innerHeight;
+      }),
+    45_000,
+  );
+
+  // Use DeFi as a real, long Tabs.ScrollView fixture, then inject a
+  // deterministic late-growing block after the tab has settled. This models
+  // any tab child (image, list section, banner) resolving asynchronously.
+  // A correct Tabs implementation expands the shared scroll extent without
+  // requiring the business tab to report its own height.
+  await sleep(1200);
+  const getMetrics = () =>
+    page.evaluate(() => {
+      const scroller = document.querySelector('.onekey-tabs-container');
+      const visibleElement = (selector) =>
+        [...document.querySelectorAll(selector)].find(
+          (candidate) =>
+            candidate instanceof HTMLElement &&
+            candidate.getBoundingClientRect().height > 0,
+        );
+      const scrollViewRoot = visibleElement('.onekey-tabs-scroll-view');
+      const tabContent =
+        visibleElement('[data-testid="home-defi-tab-content"]') ??
+        scrollViewRoot;
+      if (
+        !(scroller instanceof HTMLElement) ||
+        !(tabContent instanceof HTMLElement)
+      ) {
+        return null;
+      }
+      // WindowScroller adds wrapper nodes between the registered ScrollView
+      // and the shared horizontal list container. The latter is the nearest
+      // ancestor with an imperative inline height; asserting that height
+      // changes prevents overflow from masking a stale Tabs measurement.
+      let listContainer =
+        scrollViewRoot instanceof HTMLElement
+          ? scrollViewRoot.parentElement
+          : null;
+      while (
+        listContainer &&
+        listContainer !== scroller &&
+        !listContainer.style.height
+      ) {
+        listContainer = listContainer.parentElement;
+      }
+      if (listContainer === scroller) {
+        listContainer = null;
+      }
+      const scrollerRect = scroller.getBoundingClientRect();
+      const contentRect = tabContent.getBoundingClientRect();
+      const maxScrollTop = scroller.scrollHeight - scroller.clientHeight;
+      return {
+        atBottom: Math.abs(scroller.scrollTop - maxScrollTop) <= 2,
+        clientHeight: scroller.clientHeight,
+        contentHeight: contentRect.height,
+        contentScrollHeight: tabContent.scrollHeight,
+        hiddenBelowScroller: Math.max(
+          0,
+          contentRect.bottom - scrollerRect.bottom,
+        ),
+        listContainerHeight:
+          listContainer instanceof HTMLElement
+            ? listContainer.getBoundingClientRect().height
+            : 0,
+        maxScrollTop,
+        scrollViewHeight:
+          scrollViewRoot instanceof HTMLElement
+            ? scrollViewRoot.getBoundingClientRect().height
+            : 0,
+        scrollViewScrollHeight:
+          scrollViewRoot instanceof HTMLElement
+            ? scrollViewRoot.scrollHeight
+            : 0,
+        unmeasuredScrollViewOverflow:
+          scrollViewRoot instanceof HTMLElement &&
+          listContainer instanceof HTMLElement
+            ? Math.max(
+                0,
+                scrollViewRoot.scrollHeight -
+                  listContainer.getBoundingClientRect().height,
+              )
+            : 0,
+        scrollHeight: scroller.scrollHeight,
+        scrollTop: scroller.scrollTop,
+        viewportHeight: window.innerHeight,
+        viewportWidth: window.innerWidth,
+      };
+    });
+
+  const wheelToBottom = async () => {
+    let previousScrollTop = -1;
+    let settledRounds = 0;
+    for (let round = 0; round < 30 && settledRounds < 3; round += 1) {
+      await page.mouse.wheel(0, 1200);
+      await sleep(80);
+      const metrics = await getMetrics();
+      if (!metrics) throw new Error('Tabs scroll metrics are unavailable');
+      if (Math.abs(metrics.scrollTop - previousScrollTop) <= 0.5) {
+        settledRounds += 1;
+      } else {
+        settledRounds = 0;
+      }
+      previousScrollTop = metrics.scrollTop;
+    }
+  };
+
+  // Reproduce OK-57257's recorded sequence first: a fully rendered, tall DeFi
+  // tab is scrolled away from the top, switched to the short NFT tab, restored,
+  // and then driven to the bottom with real wheel events. Repeat it because the
+  // original bug was timing-sensitive.
+  await wheelToBottom();
+  const initialDefiMetrics = await getMetrics();
+  if (!initialDefiMetrics?.atBottom) {
+    throw new Error('Could not establish the initial DeFi scroll bottom');
+  }
+  const coldStartClipped =
+    initialDefiMetrics.hiddenBelowScroller > 2 ||
+    initialDefiMetrics.unmeasuredScrollViewOverflow > 2;
+  log(
+    `DeFi initial load before tab round trip: ${
+      coldStartClipped ? 'clipped' : 'clean'
+    } scrollTop=${initialDefiMetrics.scrollTop.toFixed(
+      1,
+    )}/${initialDefiMetrics.maxScrollTop.toFixed(
+      1,
+    )} container=${initialDefiMetrics.listContainerHeight.toFixed(
+      1,
+    )} scrollView=${initialDefiMetrics.scrollViewHeight.toFixed(
+      1,
+    )}/${initialDefiMetrics.scrollViewScrollHeight}px hidden=${initialDefiMetrics.hiddenBelowScroller.toFixed(
+      1,
+    )}px unmeasured=${initialDefiMetrics.unmeasuredScrollViewOverflow.toFixed(
+      1,
+    )}px`,
+  );
+
+  let tabRoundTripFailures = 0;
+  for (let round = 1; round <= tabSwitchRounds; round += 1) {
+    // The issue video switches tabs while DeFi is part-way down the page and
+    // the sticky tab selector is visible, rather than from the page top.
+    await page.mouse.wheel(0, -2400);
+    await sleep(120);
+    await nftTab.click({ force: true });
+    await sleep(300);
+    await defiTab.click({ force: true });
+    await sleep(500);
+    await wheelToBottom();
+
+    const roundMetrics = await getMetrics();
+    if (!roundMetrics) throw new Error('Tabs scroll metrics are unavailable');
+    const clipped =
+      !roundMetrics.atBottom ||
+      roundMetrics.hiddenBelowScroller > 2 ||
+      roundMetrics.listContainerHeight <
+        initialDefiMetrics.listContainerHeight - 2;
+    if (clipped) tabRoundTripFailures += 1;
+    log(
+      `DeFi->NFT->DeFi round ${round}/${tabSwitchRounds}: ${
+        clipped ? 'clipped' : 'clean'
+      } scrollTop=${roundMetrics.scrollTop.toFixed(
+        1,
+      )}/${roundMetrics.maxScrollTop.toFixed(
+        1,
+      )} container=${roundMetrics.listContainerHeight.toFixed(
+        1,
+      )} content=${roundMetrics.contentScrollHeight}px hidden=${roundMetrics.hiddenBelowScroller.toFixed(
+        1,
+      )}px`,
+    );
+  }
+
+  // Then establish the old compositor extent at the current bottom and grow
+  // the content, matching the related failure where slow data expands a tab
+  // after the user has already reached its initially shorter bottom.
+  await wheelToBottom();
+  const beforeGrowthMetrics = await getMetrics();
+  if (!beforeGrowthMetrics?.atBottom) {
+    throw new Error('Could not establish the Tabs pre-growth scroll bottom');
+  }
+
+  const insertedGrowthProbe = await page.evaluate((testId) => {
+    document.querySelector(`[data-testid="${testId}"]`)?.remove();
+    const element = [
+      ...document.querySelectorAll('[data-testid="home-defi-tab-content"]'),
+    ].find(
+      (candidate) =>
+        candidate instanceof HTMLElement &&
+        candidate.getBoundingClientRect().height > 0,
+    );
+    if (!(element instanceof HTMLElement)) return false;
+    const scrollViewRoot = element.closest('.onekey-tabs-scroll-view');
+    if (!(scrollViewRoot instanceof HTMLElement)) return false;
+    const properties = ['height', 'min-height', 'max-height', 'flex'];
+    scrollViewRoot.dataset.tabsScrollExtentOriginalStyle = JSON.stringify(
+      properties.map((property) => [
+        property,
+        scrollViewRoot.style.getPropertyValue(property),
+        scrollViewRoot.style.getPropertyPriority(property),
+      ]),
+    );
+    const lockedHeight = scrollViewRoot.getBoundingClientRect().height;
+    scrollViewRoot.style.setProperty('height', `${lockedHeight}px`);
+    scrollViewRoot.style.setProperty('min-height', `${lockedHeight}px`);
+    scrollViewRoot.style.setProperty('max-height', `${lockedHeight}px`);
+    scrollViewRoot.style.setProperty('flex', 'none');
+    const probe = document.createElement('div');
+    probe.setAttribute('data-testid', testId);
+    probe.style.cssText =
+      'display:block;flex:none;width:100%;height:96px;min-height:96px;';
+    // Add a new direct content node. The previous implementation observed a
+    // one-time child snapshot, so a cold-start skeleton/data replacement left
+    // the new node unobserved while the root border box stayed pinned.
+    scrollViewRoot.append(probe);
+    return true;
+  }, growthProbeTestId);
+  if (!insertedGrowthProbe) {
+    throw new Error('Could not insert the Tabs.ScrollView growth probe');
+  }
+  await sleep(300);
+
+  await wheelToBottom();
+  await sleep(300);
+
+  const metrics = await getMetrics();
+  if (!metrics) throw new Error('Tabs scroll metrics are unavailable');
+  const extentGrowth = metrics.maxScrollTop - beforeGrowthMetrics.maxScrollTop;
+  const listContainerGrowth =
+    metrics.listContainerHeight - beforeGrowthMetrics.listContainerHeight;
+  const reproduced =
+    coldStartClipped ||
+    tabRoundTripFailures > 0 ||
+    extentGrowth < 90 ||
+    listContainerGrowth < 90 ||
+    !metrics.atBottom ||
+    metrics.hiddenBelowScroller > 2 ||
+    metrics.unmeasuredScrollViewOverflow > 2;
+  log(
+    `Tabs extent coldStartClipped=${coldStartClipped} roundTripFailures=${tabRoundTripFailures}/${tabSwitchRounds} oldMax=${beforeGrowthMetrics.maxScrollTop.toFixed(
+      1,
+    )} scrollTop=${metrics.scrollTop.toFixed(1)}/${metrics.maxScrollTop.toFixed(
+      1,
+    )} container=${beforeGrowthMetrics.listContainerHeight.toFixed(
+      1,
+    )}->${metrics.listContainerHeight.toFixed(
+      1,
+    )} scrollView=${metrics.scrollViewHeight.toFixed(
+      1,
+    )}/${metrics.scrollViewScrollHeight}px content=${metrics.contentScrollHeight}px hidden=${metrics.hiddenBelowScroller.toFixed(
+      1,
+    )}px unmeasured=${metrics.unmeasuredScrollViewOverflow.toFixed(
+      1,
+    )}px viewport=${metrics.viewportWidth}x${metrics.viewportHeight}`,
+  );
+
+  if (reproduced) {
+    const screenshotPath = path.resolve(
+      '.tmp/ui/tabs-scroll-extent-desktop.png',
+    );
+    fs.mkdirSync(path.dirname(screenshotPath), { recursive: true });
+    await page.screenshot({ path: screenshotPath });
+    log(`evidence -> ${screenshotPath}`);
+  }
+
+  await page.evaluate((testId) => {
+    document.querySelector(`[data-testid="${testId}"]`)?.remove();
+    const scrollViewRoot = [
+      ...document.querySelectorAll('.onekey-tabs-scroll-view'),
+    ].find(
+      (candidate) =>
+        candidate instanceof HTMLElement &&
+        candidate.dataset.tabsScrollExtentOriginalStyle,
+    );
+    if (scrollViewRoot instanceof HTMLElement) {
+      const snapshot = JSON.parse(
+        scrollViewRoot.dataset.tabsScrollExtentOriginalStyle ?? '[]',
+      );
+      for (const [property, value, priority] of snapshot) {
+        if (value) {
+          scrollViewRoot.style.setProperty(property, value, priority);
+        } else {
+          scrollViewRoot.style.removeProperty(property);
+        }
+      }
+      delete scrollViewRoot.dataset.tabsScrollExtentOriginalStyle;
+    }
+  }, growthProbeTestId);
+
+  return report('tabs-scroll-extent-desktop', reproduced ? 1 : 0, 1, 0, 0, '');
+}
+
 // Ported from the former cdp-repro-gift-storm.mjs. The detection
 // signal — console "Maximum update depth", JS heap, evaluate RTT — is CDP-only,
 // which is exactly why this scenario stays on CDP.
@@ -923,6 +1265,17 @@ const scenarios = {
           process.env.CDP_URL ||
           'http://127.0.0.1:9222',
         flags,
+      ),
+  },
+  'tabs-scroll-extent-desktop': {
+    backend: 'cdp',
+    describe:
+      'Detect Tabs.ScrollView clipping after DeFi/NFT round trips or async growth. CDP 9222.',
+    run: () =>
+      runTabsScrollExtentDesktop(
+        process.env.CDP_URL_DESKTOP ||
+          process.env.CDP_URL ||
+          'http://127.0.0.1:9222',
       ),
   },
   'gift-storm-desktop': {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57257](https://onekeyhq.atlassian.net/browse/OK-57257) [OK-57977](https://onekeyhq.atlassian.net/browse/OK-57977)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- fix stale scroll extents in the shared web/desktop `Tabs.Container`
- cover tab round trips, account/network-driven content changes, and DeFi data restoration after an app relaunch
- replace the one-time direct-child observer snapshot with live structural tracking for every `Tabs.ScrollView`
- remove the DeFi-only height selectors, cached values, and delayed retries
- keep virtualized `Tabs.List` pages on their existing explicit-height contract

## Reported problems

### OK-57257 — DeFi cannot reach the bottom after switching tabs

The issue video starts on a tall DeFi page, switches to the shorter NFT tab, and then returns to DeFi. Wheel scrolling stops at an older, shorter extent, leaving the lower protocol sections and Support Hub cards unreachable.

The layout transition is tall -> short -> tall. Restoring the DeFi scene can increase its live `scrollHeight` without rebuilding the shared horizontal Tabs list at the same height.

### OK-57977 — the active DeFi page cannot reach the bottom after an account/network change

The Jira video shows the same symptom without requiring a tab change:

1. Stay on DeFi.
2. Change the account or network context (the video includes Arbitrum -> Ethereum).
3. A different, often taller, set of positions replaces the current content.
4. Wheel scrolling stops before the final Support Hub cards.
5. A later tab/network change can temporarily restore the correct bottom.

This is a different trigger from OK-57257, but the same shared layout failure: the focused tab receives taller async content while the outer Tabs list retains an earlier height.

### QA retest — relaunch while DeFi is active

QA reported an additional stable path after testing the first version of this PR:

1. Immediately after updating, DeFi/NFT tab switching and scrolling work.
2. Leave the app on DeFi.
3. Exit and relaunch the desktop app.
4. DeFi data restores asynchronously without a subsequent tab focus cycle.
5. The DeFi list once again stops before the real bottom.

The attached logs show the Home UI initializing first, followed several seconds later by the supported-protocol and position responses under the configured slow-4G profile. This makes the first DeFi measurement an initial/skeleton measurement; later data changes the DOM while DeFi remains focused.

## Why the first shared fix was still incomplete

The first revision correctly moved the workaround out of `DeFiContainer` and made the registered `Tabs.ScrollView` root the live measurement source. It also attached `ResizeObserver` to the root and its direct content nodes.

However, those direct nodes were captured only once when the observer was attached. On relaunch or another async refresh, React can add or replace content after that snapshot:

- the old node remains observed even after it is detached
- the new node is not a `ResizeObserver` target
- the `Tabs.ScrollView` border box can remain pinned by its parent layout
- only the root's `scrollHeight` changes, which is not itself a `ResizeObserver` notification
- no tab focus change occurs to re-run observer attachment

This explains QA's sequence precisely: switching tabs after an update re-attached the observer and temporarily fixed the page; relaunching into a fresh async DeFi load recreated the stale snapshot.

## Root cause and relationship between the issues

| Path | Layout event | Why the old extent survives |
| --- | --- | --- |
| OK-57257 | tall DeFi -> short NFT -> restored DeFi | focused content grows after the shared list was sized for a shorter scene |
| OK-57977 | account/network changes while DeFi stays focused | focused content is replaced/grows without a focus cycle |
| QA relaunch | initial/skeleton DeFi -> restored positions | observer targets are snapshotted before async structure settles |

All three paths increase a focused tab's live content extent while the shared horizontal list still owns an older numeric height. The failure belongs to `Tabs.Container`, not DeFi margin/padding and not a background-service scroll state.

## Fix

For registered `Tabs.ScrollView` pages, `Tabs.Container` now combines two observers with separate responsibilities:

1. `ResizeObserver` watches the root and its current direct content nodes for intrinsic size changes such as image, font, and layout resolution.
2. `MutationObserver` watches structural `childList` changes in the focused ScrollView subtree.
3. After a structural change, the container recomputes the live direct-child set, disconnects stale targets, and observes newly inserted/replaced nodes.
4. It then re-reads the registered root's current `scrollHeight` and writes that live value to the shared horizontal list.
5. Both observers are disconnected when the focused measurement source changes or the container unmounts.

The mutation observer intentionally excludes attribute/style observation, so updating the list height cannot feed back into the observer. The fix is generic to every flow-content tab using `Tabs.ScrollView`; business pages do not need selectors, focus-specific timers, or height reports.

The previous DeFi-specific registration is removed. In particular, it no longer caches a sampled DeFi height that can override later live DOM measurements.

## Stable reproduction script

Run against the desktop client on CDP port 9222:

```bash
REGRESSION=1 node scenarios/regression.mjs tabs-scroll-extent-desktop
```

The scenario now validates three phases:

1. Enter DeFi at most once and scroll to the bottom before any DeFi -> NFT -> DeFi round trip. This catches the relaunch/initial-load failure instead of masking it by re-attaching the observer.
2. Repeat DeFi -> NFT -> DeFi with real wheel input for the original OK-57257 transition.
3. Pin the ScrollView border box and insert a new direct content node. This deterministically models a skeleton/data node replacement and asserts that both the shared list height and wheel extent grow.

The CDP connection also waits for the OneKey renderer to finish booting, so the scenario can be started together with the app instead of racing the initial page load.

## Before/after evidence

### Before this revision

On the first shared-fix implementation, adding a `160 px` direct child produced:

- ScrollView border height: `5178 px`
- ScrollView live `scrollHeight`: `5338 px`
- shared Tabs list height: `5178 px`
- unmeasured/unreachable content: exactly `160 px`

The new node was absent from the one-time `ResizeObserver` target snapshot.

### After this revision

With the deterministic `96 px` probe:

- shared Tabs list: `5178 -> 5274 px`
- wheel max extent: `5043 -> 5139 px`
- final wheel position: `5139 / 5139`
- unmeasured content: `0 px`

The structural observer detects the insertion, refreshes the target set, and measures the live root extent.

## App relaunch validation

Validation used the real release-based Electron client with desktop network throttling enabled (`slow4g`, `562.5 ms` latency).

After a full process exit and restart (`isSoftRestart: false`), the scenario waited for DeFi's async content, then checked the bottom before any tab round trip:

- initial load: `scrollTop = maxScrollTop = 5043`
- shared list / ScrollView: `5178 / 5178 px`
- hidden content: `0 px`
- unmeasured content: `0 px`
- result: `coldStartClipped=false`

The subsequent DeFi -> NFT -> DeFi check and direct-node growth probe also passed. A separate full run repeated the tab round trip 8 times; all 8 were clean.

## QA acceptance

Please recheck all three routes with wheel input:

1. DeFi -> NFT -> DeFi on a page taller than the viewport.
2. Stay on DeFi and switch between accounts/networks with substantially different position heights.
3. Leave DeFi active, exit/relaunch the app, wait for positions to restore, and scroll to the final Support Hub card without first switching tabs.

Repeat long -> short -> long data transitions where possible. None of the routes should require a recovery tab switch.

## Checks

- based directly on current `release/v6.5.0` at `2ebdd41fdd`
- exactly 1 PR commit (`c4772776fe`) and 4 changed files
- `node --check scenarios/regression.mjs`
- JS `oxlint --deny-warnings`: 0 warnings, 0 errors
- type-aware TS `oxlint --deny-warnings`: 0 warnings, 0 errors
- full `tsgo -p ./tsconfig.json --noEmit`: passed
- `git diff --check`: passed
- Electron/CDP regression, full process restart + slow4g: `REGRESSION PASS`
- Electron/CDP DeFi -> NFT -> DeFi, 8 rounds: 8/8 clean

`yarn agent:check --profile commit` cannot spawn its child commands correctly on this Windows checkout (`exitCode: null` in 0-3 ms). `yarn lint:staged` also relies on Unix-only `grep`/`xargs`. The corresponding oxlint, syntax, diff, and tsgo checks above were run directly and passed.


[OK-57257]: https://onekeyhq.atlassian.net/browse/OK-57257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-57977]: https://onekeyhq.atlassian.net/browse/OK-57977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ