### PR TITLE
docs: add Cursor Cloud specific setup instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,3 +120,36 @@ yarn agent:review-thread --pr <number> --list
 - `apps/cli/` has its own guidance. External OneKey wallet CLI skill packs live
   in `https://github.com/OneKeyHQ/onekey-wallet-skills`; do not re-add them to
   this monorepo.
+
+## Cursor Cloud specific instructions
+
+Environment: Linux cloud VM, Node 22, Yarn 4 (pinned via `.yarn/releases`, run
+`yarn` — do not use npm/corepack). Dependencies are refreshed automatically by
+the startup update script (`yarn install`); `postinstall` runs automatically via
+the yarn `afterInstall` hook.
+
+- Runnable surface here: only the **web app** (`yarn app:web`, serves
+  `http://localhost:3000`). It exercises the same `kit`/`kit-bg`/`components`/
+  `core` logic as every platform, so it is the target for end-to-end dev testing.
+  Desktop (Electron, needs a display), the browser extension (needs a headed
+  Chrome with the unpacked build loaded), and mobile iOS/Android (need
+  simulators/devices) cannot be fully run in this headless Linux VM.
+- `rsync` is a required system dependency: the `postinstall` → `copy:inject` →
+  `web-embed` build runs `apps/web-embed/postbuild.sh`, which uses `rsync` to sync
+  web-embed assets into the mobile app folders. Without `rsync`, `yarn install`
+  fails at the root workspace build step (`YN0009 ... couldn't be built`). It is
+  preinstalled in the VM snapshot; if a future run reports `rsync: command not
+  found`, install it with `sudo apt-get install -y rsync` and re-run `yarn`.
+- The web app starts in **dapp mode by default** (Market/Trade/Perps header with
+  a "Connect" button and no create-wallet onboarding). To use the full
+  standalone wallet (create/import HD wallet), switch it to wallet mode: open the
+  site, run `localStorage.setItem('$onekey_web_dapp_mode','wallet')` in the
+  browser console, and reload. The app then auto-redirects to
+  `/onboarding/get-started` where you can create a seed-phrase wallet. This flag
+  is controlled by `isWebInDappMode()` in
+  `packages/shared/src/utils/devModeUtils.ts`.
+- Lint/test/build (details already in "Git And Commands" above and root
+  `package.json` scripts): lint via `yarn lint` (whole-monorepo, slow — prefer
+  `npx oxlint --tsconfig ./tsconfig.json <path>` for a targeted check); tests via
+  `yarn jest <path>` (jest preset is `jest-expo/web`); web dev build via
+  `yarn app:web`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and validates the development environment for OneKey in a Linux cloud VM, and documents durable, non-obvious startup caveats for future cloud agents.

This PR adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` (symlinked to `CLAUDE.md`). No application code is modified.

## What was set up & verified

- **Dependencies:** `yarn install` (Node 22, Yarn 4). `postinstall` runs automatically via the yarn `afterInstall` hook.
- **System dependency:** `rsync` — required by `postinstall` → `copy:inject` → web-embed `postbuild.sh` (syncs web-embed assets into mobile folders). Missing `rsync` makes `yarn install` fail at the root workspace build step. Installed into the VM snapshot.
- **Lint:** `npx oxlint --tsconfig ./tsconfig.json packages/shared/src/referralCode` → 0 warnings, 0 errors.
- **Tests:** `yarn jest` on targeted suites → 88 passed / 3 suites.
- **Run:** `yarn app:web` → serves `http://localhost:3000` (HTTP 200, title "OneKey").
- **Hello-world:** Switched the web app from default dapp mode to wallet mode (`localStorage['$onekey_web_dapp_mode']='wallet'`), completed onboarding, and created a new seed-phrase HD wallet reaching the wallet Home screen (Account #1, $0.00).

## Key learnings captured in AGENTS.md

- Only the **web app** is fully runnable in a headless Linux VM (desktop/extension/mobile need display/simulators).
- `rsync` is a required system dependency for `yarn install`.
- The web app defaults to **dapp mode**; switch to **wallet mode** via a localStorage flag to access create/import wallet onboarding.

## Walkthrough

[OneKey Get Started onboarding](https://cursor.com/agents/bc-dcfd0746-8c18-4663-8d35-b8d3e25909e4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonekey_get_started.webp)
[OneKey passcode setup](https://cursor.com/agents/bc-dcfd0746-8c18-4663-8d35-b8d3e25909e4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonekey_passcode_setup.webp)
[OneKey wallet home after creating Account #1](https://cursor.com/agents/bc-dcfd0746-8c18-4663-8d35-b8d3e25909e4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonekey_wallet_home.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcfd0746-8c18-4663-8d35-b8d3e25909e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcfd0746-8c18-4663-8d35-b8d3e25909e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

