### PR TITLE
fix: support legacy bundle checkouts

### DIFF
--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -252,8 +252,12 @@ jobs:
           # shellcheck disable=SC2088
           URL_PREFIX='~/web-embed'
           npx sentry-cli releases new "$RELEASE" || true
-          if ! npx sentry-cli sourcemaps inject ./apps/web-embed/web-build; then
-            echo "::warning::Web-embed Sentry debug-id injection failed; continuing with release-based upload."
+          if [ -f ./apps/web-embed/scripts/check-browser-compat.js ]; then
+            if ! npx sentry-cli sourcemaps inject ./apps/web-embed/web-build; then
+              echo "::warning::Web-embed Sentry debug-id injection failed; continuing with release-based upload."
+            fi
+          else
+            echo "::notice::Skipping Sentry debug-id injection for a legacy checkout without the post-injection browser compatibility check."
           fi
           if npx sentry-cli sourcemaps upload --release "$RELEASE" --url-prefix "$URL_PREFIX" ./apps/web-embed/web-build; then
             npx sentry-cli releases finalize "$RELEASE" || true
@@ -264,7 +268,12 @@ jobs:
           fi
 
       - name: Verify injected Web-embed Chromium 67 compatibility
-        run: node ./apps/web-embed/scripts/check-browser-compat.js
+        run: |
+          if [ -f ./apps/web-embed/scripts/check-browser-compat.js ]; then
+            node ./apps/web-embed/scripts/check-browser-compat.js
+          else
+            echo "::notice::Skipping the Chromium 67 compatibility check for a legacy checkout."
+          fi
 
       - name: Upload Web-embed Sourcemap Diagnostic Artifact
         if: always() && steps.upload_web_embed_sourcemaps.outputs.uploaded != 'true'
@@ -280,7 +289,25 @@ jobs:
 
       - name: Finalize Web-embed Production Assets
         if: always()
-        run: node ./apps/web-embed/scripts/finalize-production-assets.js --strip-only
+        run: |
+          if [ -f ./apps/web-embed/scripts/finalize-production-assets.js ]; then
+            node ./apps/web-embed/scripts/finalize-production-assets.js --strip-only
+          else
+            echo "::notice::Using legacy web-embed production asset cleanup."
+            find ./apps/web-embed/web-build -type f \( \
+              -name '*.css.map' -o \
+              -name '*.js.map' -o \
+              -name '*.LICENSE.txt' \
+            \) -print -delete
+            if find ./apps/web-embed/web-build -type f \( \
+              -name '*.css.map' -o \
+              -name '*.js.map' -o \
+              -name '*.LICENSE.txt' \
+            \) -print -quit | grep -q .; then
+              echo "::error::Legacy web-embed production asset cleanup left sourcemap or license files behind."
+              exit 1
+            fi
+          fi
 
       - name: Upload web-embed artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-desktop-bundle.yml
+++ b/.github/workflows/release-desktop-bundle.yml
@@ -260,7 +260,25 @@ jobs:
 
       - name: Finalize Desktop Bundle Production Assets
         if: always()
-        run: node ./apps/desktop/scripts/finalize-production-assets.js --strip-only
+        run: |
+          if [ -f ./apps/desktop/scripts/finalize-production-assets.js ]; then
+            node ./apps/desktop/scripts/finalize-production-assets.js --strip-only
+          else
+            echo "::notice::Using legacy desktop bundle production asset cleanup."
+            find ./apps/desktop/web-build -type f \( \
+              -name '*.css.map' -o \
+              -name '*.js.map' -o \
+              -name '*.LICENSE.txt' \
+            \) -print -delete
+            if find ./apps/desktop/web-build -type f \( \
+              -name '*.css.map' -o \
+              -name '*.js.map' -o \
+              -name '*.LICENSE.txt' \
+            \) -print -quit | grep -q .; then
+              echo "::error::Legacy desktop bundle production asset cleanup left sourcemap or license files behind."
+              exit 1
+            fi
+          fi
 
       - name: bundle folder
         run: |


### PR DESCRIPTION
## Summary

- keep the release bundle workflows compatible with legacy PR checkouts that predate the Rspack production-asset helper scripts
- skip web-embed Sentry debug-ID injection when the post-injection Chromium 67 checker is unavailable
- fall back to inline sourcemap and license-file cleanup for legacy web-embed and desktop bundles

## Root cause

`release-app-bundles` runs the workflow definition from `x` but checks out the selected PR head before building. Release-branch PRs created before the Rspack migration do not contain `check-browser-compat.js` or `finalize-production-assets.js`, so the newer workflow failed with `MODULE_NOT_FOUND` after successful bundle compilation.

## Impact

Legacy release PRs can be built by the current `x` workflow without shipping sourcemaps or license artifacts. Current checkouts retain the existing Sentry injection, Chromium 67 verification, and finalizer behavior.

## Validation

- `yarn lint:agent-context`
- `yarn lint:staged`
- `yarn tsc:staged`
- YAML parse and Bash syntax checks for the modified workflow steps
- synthetic legacy production-asset cleanup check
- [release-app-bundles run 29568580576](https://github.com/OneKeyHQ/app-monorepo/actions/runs/29568580576): all web-embed, desktop, web, iOS, Android, and QA upload jobs passed