### PR TITLE
Add hot update performance journeys

### DIFF
--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -988,6 +988,7 @@ export default class ServiceSwap extends ServiceBase {
     kind,
     toTokenAmount,
     userMarketPriceRate,
+    performanceRunId,
   }: IFetchSwapQuoteParams) {
     await this.removeQuoteEventSourceListeners();
     const denyCrossChainProvider = await this.getDenyCrossChainProvider(
@@ -1065,6 +1066,7 @@ export default class ServiceSwap extends ServiceBase {
             url: swapEventUrl,
           },
           params,
+          performanceRunId,
           tokenPairs: { fromToken, toToken },
           accountId,
         });
@@ -1081,6 +1083,7 @@ export default class ServiceSwap extends ServiceBase {
             event: { type: 'done' },
             params,
             accountId,
+            performanceRunId,
             tokenPairs: { fromToken, toToken },
           });
         } else {
@@ -1094,6 +1097,7 @@ export default class ServiceSwap extends ServiceBase {
             },
             params,
             accountId,
+            performanceRunId,
             tokenPairs: { fromToken, toToken },
           });
         }
@@ -1105,6 +1109,7 @@ export default class ServiceSwap extends ServiceBase {
           event: { type: 'open' },
           params,
           accountId,
+          performanceRunId,
           tokenPairs: { fromToken, toToken },
         });
       };
@@ -1125,6 +1130,7 @@ export default class ServiceSwap extends ServiceBase {
           event,
           params,
           accountId,
+          performanceRunId,
           tokenPairs: { fromToken, toToken },
         });
       });
@@ -1134,6 +1140,7 @@ export default class ServiceSwap extends ServiceBase {
           event,
           params,
           accountId,
+          performanceRunId,
           tokenPairs: { fromToken, toToken },
         });
       });
@@ -1143,6 +1150,7 @@ export default class ServiceSwap extends ServiceBase {
           event,
           params,
           accountId,
+          performanceRunId,
           tokenPairs: { fromToken, toToken },
         });
       });
@@ -1152,6 +1160,7 @@ export default class ServiceSwap extends ServiceBase {
           event,
           params,
           accountId,
+          performanceRunId,
           tokenPairs: { fromToken, toToken },
         });
       });
@@ -1161,6 +1170,7 @@ export default class ServiceSwap extends ServiceBase {
           event,
           params,
           accountId,
+          performanceRunId,
           tokenPairs: { fromToken, toToken },
         });
       });

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
@@ -60,6 +60,7 @@ import type {
   ICustomReceiveHandlerData,
   ITradingViewIntervalConfigData,
   ITradingViewKLineDataReadyData,
+  ITradingViewKLineDataRequestData,
   ITradingViewKLineLoadErrorData,
   ITradingViewKLinePeriodChangeData,
   ITradingViewNativeChartControlsConfigData,
@@ -138,8 +139,12 @@ interface IBaseTradingViewV2Props {
   onNativeIndicatorQuickBarChange?: (quickBar: ReactNode | null) => void;
   onNativeChartFullscreenChange?: (isFullscreen: boolean) => void;
   onKLineDataReady?: (data: ITradingViewKLineDataReadyData) => void;
+  onKLineDataRequest?: (data: ITradingViewKLineDataRequestData) => void;
   onKLineLoadError?: (data: ITradingViewKLineLoadErrorData) => void;
   onKLinePeriodChange?: (data: ITradingViewKLinePeriodChangeData) => void;
+  onKLineSourceChange?: (sourceClass: 'market_api' | 'hyperliquid') => void;
+  onPriceScaleStart?: () => void;
+  onPriceScaleDone?: () => void;
 }
 
 export type ITradingViewV2Props = IBaseTradingViewV2Props & IStackStyle;
@@ -201,9 +206,15 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     onNativeIndicatorQuickBarChange,
     onNativeChartFullscreenChange,
     onKLineDataReady,
+    onKLineDataRequest,
     onKLineLoadError,
     onKLinePeriodChange,
+    onKLineSourceChange,
+    onPriceScaleStart,
+    onPriceScaleDone,
     onLoadStart,
+    onLoad,
+    onError,
     ...stackStyle
   } = props;
   const enableNativeChartControls = Boolean(enableNativeChartControlsProp);
@@ -447,16 +458,27 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
       ? handleNativeChartControlsConfigChange
       : undefined,
     onKLineDataReady,
+    onKLineDataRequest,
     onKLineLoadError,
     onKLinePeriodChange,
+    onPriceScaleStart,
+    onPriceScaleDone,
   });
 
-  const { isHyperLiquidSource, symbol: hyperLiquidSymbol } =
-    useHyperLiquidKlineSource(networkId, tokenAddress);
+  const {
+    isHyperLiquidSource,
+    symbol: hyperLiquidSymbol,
+    isLoading: isKLineSourceLoading,
+  } = useHyperLiquidKlineSource(networkId, tokenAddress);
   const useHyperLiquid = Boolean(isHyperLiquidSource && hyperLiquidSymbol);
   const chartSymbol = useHyperLiquid ? (hyperLiquidSymbol ?? symbol) : symbol;
   const effectiveDataSource =
     dataSource === 'websocket' && !tokenAddress ? 'polling' : dataSource;
+  useEffect(() => {
+    if (!isKLineSourceLoading) {
+      onKLineSourceChange?.(isHyperLiquidSource ? 'hyperliquid' : 'market_api');
+    }
+  }, [isHyperLiquidSource, isKLineSourceLoading, onKLineSourceChange]);
   const mockEmptyKLineEnabled =
     devSettings.enabled &&
     devSettings.settings?.mockTradingViewKLineEmptyEnabled;
@@ -740,6 +762,8 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
         onWebViewRef={handleWebViewRef}
         allowsBackForwardNavigationGestures={false}
         onLoadStart={handleLoadStart}
+        onLoad={onLoad}
+        onError={onError}
         onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
         displayProgressBar={false}
         pullToRefreshEnabled={false}
@@ -756,6 +780,8 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
       customReceiveHandler,
       handleLoadStart,
       handleWebViewRef,
+      onError,
+      onLoad,
       onShouldStartLoadWithRequest,
       theme,
       tradingViewUrlWithParams,

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/klineDataHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/klineDataHandler.ts
@@ -286,6 +286,11 @@ export async function handleKLineDataRequest({
     const to = safeData.to as number;
     const isFirstDataRequest = safeData.firstDataRequest === true;
 
+    context.onKLineDataRequest?.({
+      period: normalizeTradingViewKLineInterval(resolution),
+      firstDataRequest: isFirstDataRequest,
+    });
+
     if (context.onCurrentKLineResolutionChange) {
       context.onCurrentKLineResolutionChange(resolution);
     } else if (context.currentKLineResolution) {

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/types.ts
@@ -3,6 +3,7 @@ import type { IWebViewRef } from '@onekeyhq/kit/src/components/WebView/types';
 import type {
   ICustomReceiveHandlerData,
   ITradingViewKLineDataReadyData,
+  ITradingViewKLineDataRequestData,
   ITradingViewKLineLoadErrorData,
   ITradingViewKLinePeriodChangeData,
 } from '../../../types';
@@ -41,6 +42,7 @@ export interface IMessageHandlerContext {
   primaryKLineDataUnavailable?: boolean;
   onPrimaryKLineDataUnavailable?: () => void;
   onKLineDataReady?: (data: ITradingViewKLineDataReadyData) => void;
+  onKLineDataRequest?: (data: ITradingViewKLineDataRequestData) => void;
   onKLineLoadError?: (data: ITradingViewKLineLoadErrorData) => void;
   onKLinePeriodChange?: (data: ITradingViewKLinePeriodChangeData) => void;
 }

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
@@ -22,6 +22,7 @@ import type {
   ITradingViewIntervalConfigData,
   ITradingViewIntervalOption,
   ITradingViewKLineDataReadyData,
+  ITradingViewKLineDataRequestData,
   ITradingViewKLineLoadErrorData,
   ITradingViewKLinePeriodChangeData,
   ITradingViewNativeChartControlsConfigData,
@@ -60,8 +61,11 @@ interface IUseTradingViewMessageHandlerParams {
     data: ITradingViewNativeChartControlsConfigData,
   ) => void;
   onKLineDataReady?: (data: ITradingViewKLineDataReadyData) => void;
+  onKLineDataRequest?: (data: ITradingViewKLineDataRequestData) => void;
   onKLineLoadError?: (data: ITradingViewKLineLoadErrorData) => void;
   onKLinePeriodChange?: (data: ITradingViewKLinePeriodChangeData) => void;
+  onPriceScaleStart?: () => void;
+  onPriceScaleDone?: () => void;
 }
 
 async function handleGetHyperliquidPriceScale({
@@ -625,8 +629,11 @@ export function useTradingViewMessageHandler({
   onIntervalConfigChange,
   onNativeChartControlsConfigChange,
   onKLineDataReady,
+  onKLineDataRequest,
   onKLineLoadError,
   onKLinePeriodChange,
+  onPriceScaleStart,
+  onPriceScaleDone,
 }: IUseTradingViewMessageHandlerParams) {
   const customReceiveHandler = useCallback(
     async (payload: ICustomReceiveHandlerData) => {
@@ -648,6 +655,7 @@ export function useTradingViewMessageHandler({
         primaryKLineDataUnavailable,
         onPrimaryKLineDataUnavailable,
         onKLineDataReady,
+        onKLineDataRequest,
         onKLineLoadError,
         onKLinePeriodChange,
       };
@@ -680,10 +688,15 @@ export function useTradingViewMessageHandler({
         data.scope === '$private' &&
         data.method === 'tradingview_getHyperliquidPriceScale'
       ) {
-        await handleGetHyperliquidPriceScale({
-          request: data.data as { symbol?: string; requestId?: string },
-          webRef,
-        });
+        onPriceScaleStart?.();
+        try {
+          await handleGetHyperliquidPriceScale({
+            request: data.data as { symbol?: string; requestId?: string },
+            webRef,
+          });
+        } finally {
+          onPriceScaleDone?.();
+        }
       }
 
       if (
@@ -802,8 +815,11 @@ export function useTradingViewMessageHandler({
       onIntervalConfigChange,
       onNativeChartControlsConfigChange,
       onKLineDataReady,
+      onKLineDataRequest,
       onKLineLoadError,
       onKLinePeriodChange,
+      onPriceScaleStart,
+      onPriceScaleDone,
     ],
   );
 

--- a/packages/kit/src/components/TradingView/TradingViewV2/performance/marketChartPerformance.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/performance/marketChartPerformance.test.ts
@@ -1,0 +1,82 @@
+import { MarketChartPerformanceMonitor } from './marketChartPerformance';
+
+const MARKET_ALLOWED_PAYLOAD_KEYS = new Set([
+  'durationMs',
+  'errorCode',
+  'fallbackUsed',
+  'firstBarMs',
+  'hostLoadedMs',
+  'hostRequestedMs',
+  'page',
+  'paramsReadyMs',
+  'priceScaleMs',
+  'reloadCount',
+  'renderer',
+  'result',
+  'sampleRate',
+  'scenario',
+  'sourceClass',
+]);
+
+function expectAllowedPayloadKeys(payload: Record<string, unknown>) {
+  expect(Object.keys(payload).sort()).toEqual(
+    Object.keys(payload)
+      .filter((key) => MARKET_ALLOWED_PAYLOAD_KEYS.has(key))
+      .sort(),
+  );
+}
+
+describe('MarketChartPerformanceMonitor', () => {
+  it('does not finish a symbol switch until first-bar data acknowledges it', () => {
+    const reporter = jest.fn();
+    const monitor = new MarketChartPerformanceMonitor({
+      page: 'market_detail',
+      reporter,
+    });
+
+    const initial = monitor.paramsReady('scope-a');
+    monitor.firstBarReady(initial, '1m');
+    expect(reporter).toHaveBeenCalledTimes(1);
+
+    const switched = monitor.paramsReady('scope-b');
+    expect(monitor.hasActiveJourney()).toBe(true);
+    expect(reporter).toHaveBeenCalledTimes(1);
+
+    monitor.firstBarReady(switched, '1m');
+    expect(reporter).toHaveBeenCalledTimes(2);
+    expect(reporter.mock.calls[1][0]).toBe('marketChartPerfSymbolSwitch');
+  });
+
+  it('ignores a first-bar callback from an old generation', () => {
+    const reporter = jest.fn();
+    const monitor = new MarketChartPerformanceMonitor({
+      page: 'market_detail',
+      reporter,
+    });
+    const oldToken = monitor.paramsReady('scope-a');
+    const newToken = monitor.paramsReady('scope-b');
+    reporter.mockClear();
+
+    expect(monitor.firstBarReady(oldToken, '1m')).toBe(false);
+    expect(reporter).not.toHaveBeenCalled();
+    monitor.firstBarReady(newToken, '1m');
+    expect(reporter).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports only allowed market terminal payload keys', () => {
+    const reporter = jest.fn();
+    const monitor = new MarketChartPerformanceMonitor({
+      page: 'market_detail',
+      reporter,
+    });
+    const token = monitor.paramsReady('scope-a');
+
+    monitor.hostRequested(token);
+    monitor.hostLoaded(token);
+    monitor.sourceChanged(token, 'market_api');
+    monitor.firstBarReady(token, '1m');
+
+    expect(reporter).toHaveBeenCalledTimes(1);
+    expectAllowedPayloadKeys(reporter.mock.calls[0][1]);
+  });
+});

--- a/packages/kit/src/components/TradingView/TradingViewV2/performance/marketChartPerformance.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/performance/marketChartPerformance.ts
@@ -1,0 +1,297 @@
+import {
+  PERFORMANCE_JOURNEY_TIMEOUTS,
+  PerformanceJourneyManager,
+  getPerformanceNow,
+} from '@onekeyhq/shared/src/performance/journey';
+import type { IPerformanceJourneyTerminalInfo } from '@onekeyhq/shared/src/performance/journey';
+import {
+  type IPerformanceTerminalEventName,
+  logPerformanceJourneyTerminalLocal,
+  reportPerformanceTerminal,
+} from '@onekeyhq/shared/src/performance/terminalReporter';
+
+type IMarketChartScenario =
+  | 'first_entry'
+  | 'warm_reentry'
+  | 'symbol_switch'
+  | 'period_switch';
+type IMarketChartSourceClass =
+  | 'market_api'
+  | 'hyperliquid'
+  | 'fallback'
+  | 'unknown';
+type IMarketChartPage = 'market_detail' | 'swap_kline';
+
+type IMarketChartContext = {
+  errorCode?: string;
+  expectedPeriod?: string;
+  fallbackUsed: boolean;
+  page: IMarketChartPage;
+  priceScaleDoneAt?: number;
+  priceScaleMs?: number;
+  priceScaleStartedAt?: number;
+  reloadCount: number;
+  scenario: IMarketChartScenario;
+  scopeKey: string;
+  sourceClass: IMarketChartSourceClass;
+};
+
+export type IMarketChartJourneyToken = {
+  generation: number;
+  scopeKey: string;
+};
+
+type IMarketChartReporter = (
+  eventName: IPerformanceTerminalEventName,
+  payload: Record<string, unknown>,
+) => void;
+
+export class MarketChartPerformanceMonitor {
+  private readonly manager = new PerformanceJourneyManager();
+
+  private readonly page: IMarketChartPage;
+
+  private readonly reporter: IMarketChartReporter;
+
+  private didEnter = false;
+
+  private activeScopeKey?: string;
+
+  private context?: IMarketChartContext;
+
+  constructor({
+    page,
+    reporter = reportPerformanceTerminal,
+  }: {
+    page: IMarketChartPage;
+    reporter?: IMarketChartReporter;
+  }) {
+    this.page = page;
+    this.reporter = reporter;
+  }
+
+  routeStart(scopeKey: string) {
+    if (!scopeKey) return undefined;
+    const current = this.manager.getCurrent();
+    if (current && this.activeScopeKey === scopeKey) {
+      return this.getToken();
+    }
+    let scenario: IMarketChartScenario = 'warm_reentry';
+    if (!this.didEnter) {
+      scenario = 'first_entry';
+    } else if (this.activeScopeKey && this.activeScopeKey !== scopeKey) {
+      scenario = 'symbol_switch';
+    }
+    this.didEnter = true;
+    this.activeScopeKey = scopeKey;
+    return this.startJourney(scopeKey, scenario);
+  }
+
+  paramsReady(scopeKey: string) {
+    const token =
+      this.activeScopeKey === scopeKey && this.manager.getCurrent()
+        ? this.getToken()
+        : this.routeStart(scopeKey);
+    const journey = this.getJourney(token);
+    journey?.mark('chart_params_ready');
+    return token;
+  }
+
+  hostRequested(token: IMarketChartJourneyToken | undefined) {
+    const journey = this.getJourney(token);
+    if (!journey || !this.context) return;
+    if (journey.getStageDuration('host_requested') !== undefined) {
+      this.context.reloadCount += 1;
+    }
+    journey.mark('host_requested');
+  }
+
+  hostLoaded(token: IMarketChartJourneyToken | undefined) {
+    this.getJourney(token)?.mark('host_loaded');
+  }
+
+  hostError(token: IMarketChartJourneyToken | undefined) {
+    this.fail(token, 'host_load_failed');
+  }
+
+  dataRequestStart(token: IMarketChartJourneyToken | undefined) {
+    this.getJourney(token)?.mark('data_request_start');
+  }
+
+  firstBarReady(token: IMarketChartJourneyToken | undefined, period: string) {
+    const journey = this.getJourney(token);
+    if (!journey || !this.context) return false;
+    if (
+      this.context.scenario === 'period_switch' &&
+      this.context.expectedPeriod !== period
+    ) {
+      return false;
+    }
+    journey.mark('first_bar_ready');
+    if (this.context.scenario === 'symbol_switch') {
+      // The callback is emitted only after non-empty data for the new scope.
+      journey.mark('symbol_change_done');
+    }
+    return journey.succeed();
+  }
+
+  periodChange(token: IMarketChartJourneyToken | undefined, toPeriod: string) {
+    const current = this.manager.getCurrent();
+    if (current && token?.generation !== current.generation) {
+      return token;
+    }
+    const scopeKey = token?.scopeKey ?? this.activeScopeKey;
+    if (!scopeKey || scopeKey !== this.activeScopeKey) return token;
+    return this.startJourney(scopeKey, 'period_switch', toPeriod);
+  }
+
+  kLineError(
+    token: IMarketChartJourneyToken | undefined,
+    status: 'empty' | 'failed',
+  ) {
+    this.fail(token, status === 'empty' ? 'kline_empty' : 'kline_failed');
+  }
+
+  sourceChanged(
+    token: IMarketChartJourneyToken | undefined,
+    sourceClass: Exclude<IMarketChartSourceClass, 'fallback' | 'unknown'>,
+  ) {
+    if (this.getJourney(token) && this.context) {
+      this.context.sourceClass = sourceClass;
+    }
+  }
+
+  fallbackUsed(token: IMarketChartJourneyToken | undefined) {
+    if (this.getJourney(token) && this.context) {
+      this.context.fallbackUsed = true;
+      this.context.sourceClass = 'fallback';
+    }
+  }
+
+  priceScaleStart(token: IMarketChartJourneyToken | undefined) {
+    const journey = this.getJourney(token);
+    if (!journey || !this.context) return;
+    this.context.priceScaleStartedAt = getPerformanceNow();
+    this.context.priceScaleDoneAt = undefined;
+    journey.mark('price_scale_start');
+  }
+
+  priceScaleDone(token: IMarketChartJourneyToken | undefined) {
+    const journey = this.getJourney(token);
+    if (!journey || this.context?.priceScaleStartedAt === undefined) {
+      return;
+    }
+    this.context.priceScaleDoneAt = getPerformanceNow();
+    this.context.priceScaleMs = Math.max(
+      0,
+      Math.round(
+        this.context.priceScaleDoneAt - this.context.priceScaleStartedAt,
+      ),
+    );
+    journey.mark('price_scale_done');
+  }
+
+  leave() {
+    this.manager.cancelCurrent();
+  }
+
+  hasActiveJourney() {
+    return Boolean(this.manager.getCurrent());
+  }
+
+  private startJourney(
+    scopeKey: string,
+    scenario: IMarketChartScenario,
+    expectedPeriod?: string,
+  ) {
+    const context: IMarketChartContext = {
+      expectedPeriod,
+      fallbackUsed: false,
+      page: this.page,
+      reloadCount: 0,
+      scenario,
+      scopeKey,
+      sourceClass: 'unknown',
+    };
+    this.context = context;
+    const journey = this.manager.start({
+      markPrefix: 'MarketPerf',
+      timeoutMs: PERFORMANCE_JOURNEY_TIMEOUTS.market,
+      onTerminal: (info) => this.reportTerminal(info, context),
+    });
+    journey.mark('route_start');
+    if (scenario === 'symbol_switch') journey.mark('symbol_change_start');
+    return { generation: journey.generation, scopeKey };
+  }
+
+  private getToken(): IMarketChartJourneyToken | undefined {
+    const journey = this.manager.getCurrent();
+    return journey && this.activeScopeKey
+      ? { generation: journey.generation, scopeKey: this.activeScopeKey }
+      : undefined;
+  }
+
+  private getJourney(token: IMarketChartJourneyToken | undefined) {
+    const journey = this.manager.getCurrent();
+    return journey &&
+      token?.generation === journey.generation &&
+      token.scopeKey === this.activeScopeKey
+      ? journey
+      : undefined;
+  }
+
+  private fail(token: IMarketChartJourneyToken | undefined, errorCode: string) {
+    const journey = this.getJourney(token);
+    if (!journey || !this.context) return false;
+    this.context.errorCode = errorCode;
+    return journey.error();
+  }
+
+  private reportTerminal(
+    info: IPerformanceJourneyTerminalInfo,
+    context: IMarketChartContext,
+  ) {
+    const isFailure = info.state === 'error' || info.state === 'timeout';
+    let eventName: IPerformanceTerminalEventName = 'marketChartPerfReady';
+    if (isFailure) {
+      eventName = 'marketChartPerfError';
+    } else if (context.scenario === 'symbol_switch') {
+      eventName = 'marketChartPerfSymbolSwitch';
+    }
+    logPerformanceJourneyTerminalLocal(eventName, info);
+    if (!info.sampled) return;
+
+    const priceScalePending =
+      context.priceScaleStartedAt !== undefined &&
+      context.priceScaleDoneAt === undefined;
+    let errorCode = context.errorCode;
+    if (!errorCode && info.state === 'timeout') {
+      errorCode = priceScalePending ? 'price_scale_timeout' : 'timeout';
+    }
+    this.reporter(eventName, {
+      page: context.page,
+      scenario: context.scenario,
+      renderer: 'full_tv',
+      sourceClass: context.sourceClass,
+      durationMs: info.durationMs,
+      paramsReadyMs: info.stageDurations.chart_params_ready,
+      hostRequestedMs: info.stageDurations.host_requested,
+      hostLoadedMs: info.stageDurations.host_loaded,
+      priceScaleMs: context.priceScaleMs,
+      firstBarMs: info.stageDurations.first_bar_ready,
+      reloadCount: context.reloadCount,
+      fallbackUsed: context.fallbackUsed,
+      result: info.state,
+      errorCode,
+      sampleRate: info.sampleRate,
+    });
+  }
+}
+
+export const marketDetailChartPerformance = new MarketChartPerformanceMonitor({
+  page: 'market_detail',
+});
+
+export const swapKLineChartPerformance = new MarketChartPerformanceMonitor({
+  page: 'swap_kline',
+});

--- a/packages/kit/src/components/TradingView/TradingViewV2/types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/types.ts
@@ -106,6 +106,11 @@ export interface ITradingViewKLineDataReadyData {
   period: string;
 }
 
+export interface ITradingViewKLineDataRequestData {
+  period: string;
+  firstDataRequest: boolean;
+}
+
 export interface ITradingViewKLinePeriodChangeData {
   fromPeriod: string;
   toPeriod: string;

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -5,6 +5,11 @@ import BigNumber from 'bignumber.js';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ESwapDirection } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
 import type { useSwapAddressInfo } from '@onekeyhq/kit/src/views/Swap/hooks/useSwapAccount';
+import {
+  getSwapPerformanceQuoteMode,
+  runSwapPerformanceSafely,
+  swapPerformance,
+} from '@onekeyhq/kit/src/views/Swap/performance/swapPerformance';
 import { buildSwapDefaultSelectedTokensForNetwork } from '@onekeyhq/kit/src/views/Swap/utils/swapColdStartTokenCacheUtils';
 import {
   removeSwapNoConnectWalletAlerts,
@@ -149,6 +154,7 @@ import {
   getSwapQuoteEventProgressTotalCount,
   getSwapQuoteProgressState,
   hasSwapZeroProviderQuoteEvent,
+  isSwapQuoteActionable,
   isSwapQuoteEventFetching,
 } from './quoteProgress';
 
@@ -209,6 +215,21 @@ function isStockProtocol(protocol?: string) {
     protocol === ESwapTabSwitchType.STOCK ||
     protocol === EProtocolOfExchange.STOCK
   );
+}
+
+function buildSwapPerformanceIntentFromEvent(params: IFetchQuotesParams) {
+  return {
+    amountKey:
+      params.kind === ESwapQuoteKind.BUY
+        ? (params.toTokenAmount ?? '')
+        : (params.fromTokenAmount ?? ''),
+    fromNetworkKey: params.fromNetworkId,
+    fromTokenKey: params.fromTokenAddress,
+    quoteKind: params.kind ?? ESwapQuoteKind.SELL,
+    quoteMode: getSwapPerformanceQuoteMode(params.protocol),
+    toNetworkKey: params.toNetworkId,
+    toTokenKey: params.toTokenAddress,
+  };
 }
 
 function isQuoteEventErrorSelectedTokenPair({
@@ -792,8 +813,12 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         params: IFetchQuotesParams;
         tokenPairs: { fromToken: ISwapToken; toToken: ISwapToken };
         accountId?: string;
+        performanceRunId?: string;
       },
     ) => {
+      const performanceIntent = buildSwapPerformanceIntentFromEvent(
+        event.params,
+      );
       if (
         !isCurrentStockQuoteEventParams({
           currentSwapType: get(swapTypeSwitchAtom()),
@@ -816,6 +841,13 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
             const dataJson = JSON.parse(data) as ISwapQuoteEventData;
             const errorData = dataJson as ISwapQuoteEventError;
             if (errorData?.errorMessage) {
+              runSwapPerformanceSafely(() =>
+                swapPerformance.error({
+                  eventId: errorData.eventId,
+                  intent: performanceIntent,
+                  runId: event.performanceRunId,
+                }),
+              );
               const isStockQuoteEventError =
                 Boolean(errorData.isStock) ||
                 isStockProtocol(event.params.protocol);
@@ -903,6 +935,14 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
             ) {
               const { totalQuoteCount, eventId } =
                 dataJson as ISwapQuoteEventInfo;
+              runSwapPerformanceSafely(() =>
+                swapPerformance.expectedProviders({
+                  count: totalQuoteCount,
+                  eventId,
+                  intent: performanceIntent,
+                  runId: event.performanceRunId,
+                }),
+              );
               const quoteEventError = get(swapQuoteEventErrorAtom());
               const quoteEventTotalCount = get(swapQuoteEventTotalCountAtom());
               const shouldResetCurrentEventProgress =
@@ -956,6 +996,19 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
                       totalQuoteCountReceived: false,
                     }
                   : quoteEventTotalCount;
+              runSwapPerformanceSafely(() =>
+                swapPerformance.quotesReceived({
+                  eventId: quoteResultEventId,
+                  expectedProviderCount: activeQuoteEventTotalCount.count,
+                  intent: performanceIntent,
+                  runId: event.performanceRunId,
+                  quotes: (quoteResultData.data ?? []).map((quote) => ({
+                    actionable: isSwapQuoteActionable(quote),
+                    // Provider identity is retained in memory only for de-dupe.
+                    providerKey: buildSwapQuoteProviderKey(quote),
+                  })),
+                }),
+              );
               if (shouldSeedStockQuoteEventFromResult && quoteResultEventId) {
                 set(swapQuoteEventTotalCountAtom(), activeQuoteEventTotalCount);
               }
@@ -1119,6 +1172,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       toTokenAmount?: string,
       receivingAddress?: string,
       incognito?: boolean,
+      performanceRunId?: string,
     ) => {
       const shouldRefreshQuote = get(swapShouldRefreshQuoteAtom());
       const protocol = get(swapTypeSwitchAtom());
@@ -1161,6 +1215,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         protocol,
         receivingAddress,
         incognito: incognitoEnabled,
+        performanceRunId,
         userMarketPriceRate,
         ...(protocol === ESwapTabSwitchType.LIMIT
           ? {
@@ -1294,6 +1349,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       set(swapShouldRefreshQuoteAtom(), false);
 
       if (!hasValidQuoteInput || !fromToken || !toToken) {
+        runSwapPerformanceSafely(() => swapPerformance.cancelIntent());
         void this.resetQuoteAction.call(set);
         return;
       }
@@ -1309,6 +1365,23 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         void this.resetQuoteAction.call(set);
         return;
       }
+
+      let performanceRunId: string | undefined;
+      runSwapPerformanceSafely(() => {
+        performanceRunId = swapPerformance.beginIntent({
+          amountKey:
+            quoteKind === ESwapQuoteKind.BUY
+              ? toTokenAmount.value
+              : fromTokenAmount.value,
+          fromNetworkKey: fromToken.networkId,
+          fromTokenKey: fromToken.contractAddress ?? '',
+          manualRefresh: Boolean(reQuote),
+          quoteKind: quoteKind ?? ESwapQuoteKind.SELL,
+          quoteMode: getSwapPerformanceQuoteMode(swapTabSwitchType),
+          toNetworkKey: toToken.networkId,
+          toTokenKey: toToken.contractAddress ?? '',
+        });
+      });
 
       // check limit zero
       set(swapQuoteActionLockAtom(), (v) => ({
@@ -1338,6 +1411,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         toTokenAmount.value,
         receivingAddress,
         incognito,
+        performanceRunId,
       );
     },
   );

--- a/packages/kit/src/views/Home/components/PullToRefresh/index.tsx
+++ b/packages/kit/src/views/Home/components/PullToRefresh/index.tsx
@@ -9,7 +9,10 @@ import {
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
+import { homePerformance } from '../../performance/homePerformance';
+
 export const onHomePageRefresh = () => {
+  homePerformance.startRefresh();
   appEventBus.emit(EAppEventBusNames.AccountDataUpdate, {
     isManualRefresh: true,
     refreshSource: 'pull-to-refresh',

--- a/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
+++ b/packages/kit/src/views/Home/pages/HomeOverviewContainer.tsx
@@ -58,6 +58,10 @@ import { useActiveAccount } from '../../../states/jotai/contexts/accountSelector
 import { convertFiat } from '../../../utils/fiatConvert';
 import { showBalanceDetailsDialog } from '../components/BalanceDetailsDialog';
 import { useHomeWalletTabSupport } from '../hooks/useHomeWalletTabSupport';
+import {
+  type IHomePerfCacheState,
+  homePerformance,
+} from '../performance/homePerformance';
 import { HomeTestIDs } from '../testIDs';
 
 // Grace period (ms) after an account switch during which the previous
@@ -381,6 +385,11 @@ function HomeOverviewContainer() {
       }
 
       syncWorthRefreshingState();
+      homePerformance.refreshActivity(
+        HOME_OVERVIEW_REFRESH_TABS.some((refreshType) =>
+          Boolean(listRefreshKeys.current[refreshType]),
+        ),
+      );
       if (isRefreshing) {
         perfMark(`Home:refresh:start:${type}`, {
           refreshType: type,
@@ -521,12 +530,15 @@ function HomeOverviewContainer() {
   const handleRefreshWorth = useCallback(() => {
     if (isRefreshingWorth) return;
     setIsRefreshingWorth(true);
+    homePerformance.startRefresh({
+      networkScope: network?.isAllNetworks ? 'all_networks' : 'single_network',
+    });
     appEventBus.emit(EAppEventBusNames.AccountDataUpdate, {
       isManualRefresh: true,
       refreshSource: 'home-header',
     });
     defaultLogger.account.wallet.walletManualRefresh();
-  }, [isRefreshingWorth]);
+  }, [isRefreshingWorth, network?.isAllNetworks]);
 
   const isLoading =
     isRefreshingWorth ||
@@ -915,6 +927,50 @@ function HomeOverviewContainer() {
     !showSkeleton &&
     renderedBalanceString !== null &&
     renderedBalanceString !== undefined;
+  useEffect(() => {
+    const authoritativeZero =
+      shouldDisplayZeroBalancePlaceholder && overviewState.initialized;
+    if (!balanceReady && !authoritativeZero) return;
+
+    if (account?.id && network?.id && wallet?.id) {
+      homePerformance.scopeReady({
+        // Scope identifiers stay in memory and are never sent to the logger.
+        scopeKey: `${wallet.id}:${account.id}:${network.id}`,
+        networkScope: network.isAllNetworks ? 'all_networks' : 'single_network',
+      });
+    }
+
+    const hasCurrentOwnerCache =
+      !!currentConfirmedBalance ||
+      (isCurrentTokenCacheStateMatched &&
+        overviewTokenCacheState.hasCache === true);
+    let cacheState: IHomePerfCacheState = 'unknown';
+    if (canReuseLatestDisplayedBalance) {
+      cacheState = 'stale';
+    } else if (hasCurrentOwnerCache) {
+      cacheState = 'hit';
+    } else if (resolvedBalanceString !== undefined || authoritativeZero) {
+      cacheState = 'miss';
+    }
+    homePerformance.dataCandidate({
+      cacheState,
+      contentClass: authoritativeZero ? 'authoritative_empty' : 'normal',
+      snapshotApplied: hasCurrentOwnerCache,
+    });
+  }, [
+    account?.id,
+    balanceReady,
+    canReuseLatestDisplayedBalance,
+    currentConfirmedBalance,
+    isCurrentTokenCacheStateMatched,
+    network?.id,
+    network?.isAllNetworks,
+    overviewState.initialized,
+    overviewTokenCacheState.hasCache,
+    resolvedBalanceString,
+    shouldDisplayZeroBalancePlaceholder,
+    wallet?.id,
+  ]);
   useEffect(() => {
     if (balanceReady && !(globalThis as any).__onekeyBalanceDisplayed) {
       (globalThis as any).__onekeyBalanceDisplayed = true;

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -69,6 +69,7 @@ import { HomeSupportedWallet } from '../components/HomeSupportedWallet';
 import { NotBackedUpEmpty } from '../components/NotBakcedUp';
 import { PullToRefresh, onHomePageRefresh } from '../components/PullToRefresh';
 import { useHomeWalletTabSupport } from '../hooks/useHomeWalletTabSupport';
+import { homePerformance } from '../performance/homePerformance';
 import { HomeTestIDs } from '../testIDs';
 
 import { DeFiContainerWithProvider } from './DeFiContainer';
@@ -238,6 +239,7 @@ export function HomePageView({
   const wasBlurredRef = useRef(false);
   useFocusEffect(
     useCallback(() => {
+      homePerformance.enter();
       let idleHandle: ReturnType<typeof requestIdleCallback> | undefined;
       if (wasBlurredRef.current && tabsRef.current) {
         // Force PagerView to display the correct page after freeze/unfreeze.
@@ -248,6 +250,7 @@ export function HomePageView({
         });
       }
       return () => {
+        homePerformance.leave();
         if (idleHandle !== undefined) {
           cancelIdleCallback(idleHandle);
         }
@@ -1090,6 +1093,51 @@ export function HomePageView({
     activeWalletId,
     walletListWalletIds,
   });
+
+  useEffect(() => {
+    if (!ready) {
+      homePerformance.setShellInteractive(false);
+      return;
+    }
+    if (showNoWalletContent) {
+      homePerformance.scopeReady({
+        scopeKey: 'authoritative-no-wallet',
+        networkScope: 'single_network',
+      });
+      homePerformance.dataCandidate({
+        cacheState: 'unknown',
+        contentClass: 'no_wallet',
+      });
+      homePerformance.setShellInteractive(true);
+      return;
+    }
+    if (!hasNoUsableWallet && account?.id && network?.id && wallet?.id) {
+      homePerformance.scopeReady({
+        // Scope identifiers stay in memory and are never sent to the logger.
+        scopeKey: `${wallet.id}:${account.id}:${network.id}`,
+        networkScope: network.isAllNetworks ? 'all_networks' : 'single_network',
+      });
+      if (isWalletNotBackedUp) {
+        homePerformance.dataCandidate({
+          cacheState: 'unknown',
+          contentClass: 'unbacked',
+        });
+      }
+      homePerformance.setShellInteractive(true);
+      return;
+    }
+    // The account selector's transient empty state is intentionally not Ready.
+    homePerformance.setShellInteractive(false);
+  }, [
+    account?.id,
+    hasNoUsableWallet,
+    isWalletNotBackedUp,
+    network?.id,
+    network?.isAllNetworks,
+    ready,
+    showNoWalletContent,
+    wallet?.id,
+  ]);
 
   const homePage = useMemo(() => {
     if (!ready) {

--- a/packages/kit/src/views/Home/performance/homePerformance.test.ts
+++ b/packages/kit/src/views/Home/performance/homePerformance.test.ts
@@ -1,0 +1,80 @@
+import {
+  HomePerformanceMonitor,
+  isHomeAuthoritativeReady,
+} from './homePerformance';
+
+const HOME_ALLOWED_PAYLOAD_KEYS = new Set([
+  'cacheState',
+  'contentClass',
+  'dataCandidateMs',
+  'durationMs',
+  'errorCode',
+  'networkScope',
+  'renderer',
+  'result',
+  'sampleRate',
+  'scenario',
+  'scopeReadyMs',
+  'snapshotAppliedMs',
+]);
+
+function expectAllowedPayloadKeys(payload: Record<string, unknown>) {
+  expect(Object.keys(payload).sort()).toEqual(
+    Object.keys(payload).filter((key) => HOME_ALLOWED_PAYLOAD_KEYS.has(key)).sort(),
+  );
+}
+
+describe('home performance readiness', () => {
+  it('does not treat a temporary initialization empty state as ready', () => {
+    expect(
+      isHomeAuthoritativeReady({
+        dataCandidateReady: false,
+        scopeReady: false,
+        shellInteractive: true,
+        temporaryEmpty: true,
+      }),
+    ).toBe(false);
+  });
+
+  it.each(['authoritative empty', 'unbacked wallet', 'no wallet'])(
+    'allows %s after the state is authoritative',
+    () => {
+      expect(
+        isHomeAuthoritativeReady({
+          dataCandidateReady: true,
+          scopeReady: true,
+          shellInteractive: true,
+          temporaryEmpty: false,
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it('reports only allowed home terminal payload keys', () => {
+    jest.useFakeTimers();
+    const reporter = jest.fn();
+    const monitor = new HomePerformanceMonitor(reporter);
+
+    monitor.enter();
+    monitor.scopeReady({
+      networkScope: 'single_network',
+      scopeKey: 'wallet:account:network',
+    });
+    monitor.dataCandidate({
+      cacheState: 'hit',
+      contentClass: 'normal',
+      snapshotApplied: true,
+    });
+    monitor.setShellInteractive(true);
+
+    jest.runOnlyPendingTimers();
+    jest.runOnlyPendingTimers();
+    jest.advanceTimersByTime(300);
+
+    expect(reporter).toHaveBeenCalledTimes(1);
+    expect(reporter.mock.calls[0][0]).toBe('homePerfReady');
+    expectAllowedPayloadKeys(reporter.mock.calls[0][1]);
+    monitor.leave();
+    jest.useRealTimers();
+  });
+});

--- a/packages/kit/src/views/Home/performance/homePerformance.ts
+++ b/packages/kit/src/views/Home/performance/homePerformance.ts
@@ -1,0 +1,298 @@
+import {
+  PERFORMANCE_JOURNEY_TIMEOUTS,
+  PerformanceJourneyManager,
+} from '@onekeyhq/shared/src/performance/journey';
+import type { IPerformanceJourneyTerminalInfo } from '@onekeyhq/shared/src/performance/journey';
+import {
+  logPerformanceJourneyTerminalLocal,
+  reportPerformanceTerminal,
+} from '@onekeyhq/shared/src/performance/terminalReporter';
+
+export type IHomePerfCacheState = 'hit' | 'miss' | 'stale' | 'unknown';
+export type IHomePerfContentClass =
+  | 'normal'
+  | 'heavy'
+  | 'authoritative_empty'
+  | 'unbacked'
+  | 'no_wallet';
+type IHomePerfScenario = 'cold' | 'warm_reentry' | 'scope_switch' | 'refresh';
+type IHomePerfNetworkScope = 'all_networks' | 'single_network';
+
+type IHomePerfContext = {
+  cacheState: IHomePerfCacheState;
+  contentClass: IHomePerfContentClass;
+  networkScope: IHomePerfNetworkScope;
+  scenario: IHomePerfScenario;
+};
+
+type IHomePerfReporter = (
+  eventName: 'homePerfReady' | 'homePerfRefreshSettled',
+  payload: Record<string, unknown>,
+) => void;
+
+export function isHomeAuthoritativeReady({
+  dataCandidateReady,
+  scopeReady,
+  shellInteractive,
+  temporaryEmpty,
+}: {
+  dataCandidateReady: boolean;
+  scopeReady: boolean;
+  shellInteractive: boolean;
+  temporaryEmpty: boolean;
+}) {
+  return (
+    scopeReady && shellInteractive && dataCandidateReady && !temporaryEmpty
+  );
+}
+
+function scheduleAfterStableFrames(callback: () => void) {
+  let secondFrame: number | undefined;
+  let stableTimer: ReturnType<typeof setTimeout> | undefined;
+  let cancelled = false;
+
+  const requestFrame = (frameCallback: () => void) => {
+    if (typeof requestAnimationFrame === 'function') {
+      return requestAnimationFrame(frameCallback);
+    }
+    return setTimeout(frameCallback, 0) as unknown as number;
+  };
+  const cancelFrame = (frame: number | undefined) => {
+    if (frame === undefined) return;
+    if (typeof cancelAnimationFrame === 'function') {
+      cancelAnimationFrame(frame);
+    } else {
+      clearTimeout(frame);
+    }
+  };
+
+  const firstFrame = requestFrame(() => {
+    secondFrame = requestFrame(() => {
+      stableTimer = setTimeout(() => {
+        if (!cancelled) callback();
+      }, 300);
+    });
+  });
+
+  return () => {
+    cancelled = true;
+    cancelFrame(firstFrame);
+    cancelFrame(secondFrame);
+    if (stableTimer !== undefined) clearTimeout(stableTimer);
+  };
+}
+
+export class HomePerformanceMonitor {
+  private readonly readyManager = new PerformanceJourneyManager();
+
+  private readonly refreshManager = new PerformanceJourneyManager();
+
+  private readonly reporter: IHomePerfReporter;
+
+  private didEnter = false;
+
+  private activeScopeKey?: string;
+
+  private readyContext?: IHomePerfContext;
+
+  private hasScope = false;
+
+  private hasDataCandidate = false;
+
+  private shellInteractive = false;
+
+  private stableCleanup?: () => void;
+
+  private refreshSettleCleanup?: () => void;
+
+  constructor(reporter: IHomePerfReporter = reportPerformanceTerminal) {
+    this.reporter = reporter;
+  }
+
+  enter() {
+    const scenario: IHomePerfScenario = this.didEnter ? 'warm_reentry' : 'cold';
+    this.didEnter = true;
+    this.startReadyJourney(scenario);
+  }
+
+  leave() {
+    this.stableCleanup?.();
+    this.stableCleanup = undefined;
+    this.readyManager.cancelCurrent();
+  }
+
+  scopeReady({
+    networkScope,
+    scopeKey,
+  }: {
+    networkScope: IHomePerfNetworkScope;
+    scopeKey: string;
+  }) {
+    if (!scopeKey) return;
+    if (!this.readyManager.getCurrent()) {
+      this.startReadyJourney(this.didEnter ? 'warm_reentry' : 'cold');
+      this.didEnter = true;
+    }
+    if (this.activeScopeKey && this.activeScopeKey !== scopeKey) {
+      this.startReadyJourney('scope_switch');
+    }
+    this.activeScopeKey = scopeKey;
+    this.hasScope = true;
+    if (this.readyContext) this.readyContext.networkScope = networkScope;
+    this.readyManager.getCurrent()?.mark('scope_ready');
+    this.maybeScheduleReady();
+  }
+
+  dataCandidate({
+    cacheState,
+    contentClass,
+    snapshotApplied = false,
+  }: {
+    cacheState: IHomePerfCacheState;
+    contentClass: IHomePerfContentClass;
+    snapshotApplied?: boolean;
+  }) {
+    const journey = this.readyManager.getCurrent();
+    if (!journey || journey.isTerminal) return;
+    this.hasDataCandidate = true;
+    if (this.readyContext) {
+      this.readyContext.cacheState = cacheState;
+      this.readyContext.contentClass = contentClass;
+    }
+    journey.mark('data_candidate');
+    if (snapshotApplied) journey.mark('snapshot_applied');
+    this.maybeScheduleReady();
+  }
+
+  setShellInteractive(interactive: boolean) {
+    this.shellInteractive = interactive;
+    if (!interactive) {
+      this.stableCleanup?.();
+      this.stableCleanup = undefined;
+      return;
+    }
+    this.maybeScheduleReady();
+  }
+
+  startRefresh(context?: Partial<IHomePerfContext>) {
+    this.refreshSettleCleanup?.();
+    this.refreshSettleCleanup = undefined;
+    const refreshContext: IHomePerfContext = {
+      cacheState:
+        context?.cacheState ?? this.readyContext?.cacheState ?? 'unknown',
+      contentClass:
+        context?.contentClass ?? this.readyContext?.contentClass ?? 'normal',
+      networkScope:
+        context?.networkScope ??
+        this.readyContext?.networkScope ??
+        'single_network',
+      scenario: 'refresh',
+    };
+    const journey = this.refreshManager.start({
+      markPrefix: 'HomePerf',
+      timeoutMs: PERFORMANCE_JOURNEY_TIMEOUTS.home,
+      onTerminal: (info) =>
+        this.reportTerminal('homePerfRefreshSettled', info, refreshContext),
+    });
+    journey.mark('enter');
+  }
+
+  refreshActivity(isRefreshing: boolean) {
+    const journey = this.refreshManager.getCurrent();
+    if (!journey || journey.isTerminal || isRefreshing) {
+      this.refreshSettleCleanup?.();
+      this.refreshSettleCleanup = undefined;
+      return;
+    }
+    const generation = journey.generation;
+    const timer = setTimeout(() => {
+      if (
+        this.refreshManager.isCurrent(journey) &&
+        journey.generation === generation
+      ) {
+        journey.mark('refresh_settled');
+        journey.succeed();
+      }
+    }, 300);
+    this.refreshSettleCleanup = () => clearTimeout(timer);
+    journey.addCleanup(this.refreshSettleCleanup);
+  }
+
+  private startReadyJourney(scenario: IHomePerfScenario) {
+    this.stableCleanup?.();
+    this.stableCleanup = undefined;
+    this.hasScope = false;
+    this.hasDataCandidate = false;
+    this.shellInteractive = false;
+    const context: IHomePerfContext = {
+      cacheState: 'unknown',
+      contentClass: 'normal',
+      networkScope: 'single_network',
+      scenario,
+    };
+    this.readyContext = context;
+    const journey = this.readyManager.start({
+      markPrefix: 'HomePerf',
+      timeoutMs: PERFORMANCE_JOURNEY_TIMEOUTS.home,
+      onTerminal: (info) => this.reportTerminal('homePerfReady', info, context),
+    });
+    journey.mark('enter');
+  }
+
+  private maybeScheduleReady() {
+    const journey = this.readyManager.getCurrent();
+    if (
+      !journey ||
+      this.stableCleanup ||
+      !isHomeAuthoritativeReady({
+        dataCandidateReady: this.hasDataCandidate,
+        scopeReady: this.hasScope,
+        shellInteractive: this.shellInteractive,
+        temporaryEmpty: false,
+      })
+    ) {
+      return;
+    }
+    const generation = journey.generation;
+    this.stableCleanup = scheduleAfterStableFrames(() => {
+      this.stableCleanup = undefined;
+      if (
+        this.readyManager.isCurrent(journey) &&
+        journey.generation === generation &&
+        this.hasScope &&
+        this.hasDataCandidate &&
+        this.shellInteractive
+      ) {
+        journey.mark('first_stable_interactive');
+        journey.succeed();
+      }
+    });
+    journey.addCleanup(() => {
+      this.stableCleanup?.();
+      this.stableCleanup = undefined;
+    });
+  }
+
+  private reportTerminal(
+    eventName: 'homePerfReady' | 'homePerfRefreshSettled',
+    info: IPerformanceJourneyTerminalInfo,
+    context: IHomePerfContext,
+  ) {
+    logPerformanceJourneyTerminalLocal(eventName, info);
+    if (!info.sampled) return;
+    const payload = {
+      ...context,
+      durationMs: info.durationMs,
+      result: info.state,
+      sampleRate: info.sampleRate,
+      scopeReadyMs: info.stageDurations.scope_ready,
+      dataCandidateMs: info.stageDurations.data_candidate,
+      snapshotAppliedMs: info.stageDurations.snapshot_applied,
+      renderer: 'legacy',
+      errorCode: info.state === 'timeout' ? 'timeout' : undefined,
+    };
+    this.reporter(eventName, payload);
+  }
+}
+
+export const homePerformance = new HomePerformanceMonitor();

--- a/packages/kit/src/views/Market/MarketDetailV2/MarketDetailV2.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/MarketDetailV2.tsx
@@ -19,6 +19,7 @@ import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import { AccountSelectorProviderMirror } from '../../../components/AccountSelector';
+import { marketDetailChartPerformance } from '../../../components/TradingView/TradingViewV2/performance/marketChartPerformance';
 import { useMarketEnterAnalytics } from '../hooks';
 import { MarketWatchListProviderMirrorV2 } from '../MarketWatchListProviderMirrorV2';
 import { MarketTestIDs } from '../testIDs';
@@ -68,6 +69,14 @@ function MarketDetail({
   const networkId =
     networkUtils.getNetworkIdFromShortCode({ shortCode: network }) || network;
   const isNativeBoolean = normalizeRouteBooleanParam(isNative, false);
+
+  useFocusEffect(
+    useCallback(() => {
+      // Route identifiers are used only as an in-memory generation scope.
+      marketDetailChartPerformance.routeStart(`${networkId}:${tokenAddress}`);
+      return () => marketDetailChartPerformance.leave();
+    }, [networkId, tokenAddress]),
+  );
 
   // Track market entry analytics
   useMarketEnterAnalytics();

--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketTradingView/MarketTradingView.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketTradingView/MarketTradingView.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, memo, useCallback } from 'react';
+import { type ReactNode, memo, useCallback, useEffect, useState } from 'react';
 
 import {
   TRADING_VIEW_DISABLED_FEATURES,
@@ -8,6 +8,10 @@ import type {
   ITradingViewDisabledFeature,
   ITradingViewPriceUpdateData,
 } from '@onekeyhq/kit/src/components/TradingView/TradingViewV2';
+import {
+  type IMarketChartJourneyToken,
+  marketDetailChartPerformance,
+} from '@onekeyhq/kit/src/components/TradingView/TradingViewV2/performance/marketChartPerformance';
 import { useTokenDetailActions } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 
 import { MarketTestIDs } from '../../../testIDs';
@@ -123,6 +127,47 @@ export const MarketTradingView = memo(
   }: IMarketTradingViewProps) => {
     const { accountAddress } = useNetworkAccountAddress(networkId);
     const tokenDetailActions = useTokenDetailActions();
+    const [performanceToken, setPerformanceToken] =
+      useState<IMarketChartJourneyToken>();
+
+    useEffect(() => {
+      // Token/network identifiers never leave this in-memory generation key.
+      setPerformanceToken(
+        marketDetailChartPerformance.paramsReady(
+          `${networkId}:${tokenAddress}`,
+        ),
+      );
+    }, [networkId, tokenAddress]);
+
+    const handleKLineDataReady = useCallback(
+      (data: { period: string }) => {
+        marketDetailChartPerformance.firstBarReady(
+          performanceToken,
+          data.period,
+        );
+      },
+      [performanceToken],
+    );
+    const handleKLineDataRequest = useCallback(() => {
+      marketDetailChartPerformance.dataRequestStart(performanceToken);
+    }, [performanceToken]);
+    const handleKLineLoadError = useCallback(
+      (data: { status: 'empty' | 'failed' }) => {
+        marketDetailChartPerformance.kLineError(performanceToken, data.status);
+      },
+      [performanceToken],
+    );
+    const handleKLinePeriodChange = useCallback(
+      (data: { toPeriod: string }) => {
+        setPerformanceToken(
+          marketDetailChartPerformance.periodChange(
+            performanceToken,
+            data.toPeriod,
+          ),
+        );
+      },
+      [performanceToken],
+    );
 
     const handlePriceUpdate = useCallback(
       (data: ITradingViewPriceUpdateData) => {
@@ -171,6 +216,30 @@ export const MarketTradingView = memo(
         onNativeSubIndicatorCountChange={onNativeSubIndicatorCountChange}
         maxNativeSubIndicatorCount={maxNativeSubIndicatorCount}
         onPriceUpdate={handlePriceUpdate}
+        onLoadStart={() =>
+          marketDetailChartPerformance.hostRequested(performanceToken)
+        }
+        onLoad={() => marketDetailChartPerformance.hostLoaded(performanceToken)}
+        onError={() => marketDetailChartPerformance.hostError(performanceToken)}
+        onKLineDataRequest={handleKLineDataRequest}
+        onKLineDataReady={handleKLineDataReady}
+        onKLineLoadError={handleKLineLoadError}
+        onKLinePeriodChange={handleKLinePeriodChange}
+        onKLineSourceChange={(sourceClass) =>
+          marketDetailChartPerformance.sourceChanged(
+            performanceToken,
+            sourceClass,
+          )
+        }
+        onPrimaryKLineDataUnavailable={() =>
+          marketDetailChartPerformance.fallbackUsed(performanceToken)
+        }
+        onPriceScaleStart={() =>
+          marketDetailChartPerformance.priceScaleStart(performanceToken)
+        }
+        onPriceScaleDone={() =>
+          marketDetailChartPerformance.priceScaleDone(performanceToken)
+        }
         disabledFeatures={MARKET_NATIVE_CHART_CONTROL_DISABLED_FEATURES}
         enableNativeChartControls
         nativeChartTypeControlMode={nativeChartTypeControlMode}

--- a/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapQuote.ts
@@ -52,6 +52,11 @@ import {
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
 import { buildSwapManualProviderSelectionIntent } from '../../../states/jotai/contexts/swap/quoteProgress';
+import {
+  getSwapPerformanceQuoteMode,
+  runSwapPerformanceSafely,
+  swapPerformance,
+} from '../performance/swapPerformance';
 import { shouldPreserveSwapUserInputAmountOnAccountSwitch } from '../utils/swapColdStartTokenCacheUtils';
 import {
   getStockTradeAnalyticsPayload,
@@ -207,6 +212,28 @@ export function useSwapQuote() {
   if (isFocusRef.current !== isFocused) {
     isFocusRef.current = isFocused;
   }
+  const initialPerformanceQuoteModeRef = useRef(
+    getSwapPerformanceQuoteMode(swapTabSwitchType),
+  );
+  useEffect(() => {
+    runSwapPerformanceSafely(() =>
+      swapPerformance.pageEnter(initialPerformanceQuoteModeRef.current),
+    );
+    return () => {
+      runSwapPerformanceSafely(() => {
+        swapPerformance.pageLeave();
+        swapPerformance.cancelIntent();
+      });
+    };
+  }, []);
+  useEffect(() => {
+    runSwapPerformanceSafely(() => swapPerformance.setPageVisible(isFocused));
+  }, [isFocused]);
+  useEffect(() => {
+    if (isFocused && !shouldPauseQuote && fromToken && toToken) {
+      runSwapPerformanceSafely(() => swapPerformance.pageReady());
+    }
+  }, [fromToken, isFocused, shouldPauseQuote, toToken]);
   const activeAccountRef = useRef<
     ReturnType<typeof useSwapAddressInfo> | undefined
   >(undefined);
@@ -853,6 +880,9 @@ export function useSwapQuote() {
   useListenTabFocusState(
     ETabRoutes.Swap,
     (isFocus: boolean, isHiddenModel: boolean) => {
+      runSwapPerformanceSafely(() =>
+        swapPerformance.setPageVisible(isFocus && !isHiddenModel),
+      );
       if (!isModalPage) {
         if (isFocus) {
           appEventBus.off(EAppEventBusNames.SwapQuoteEvent, quoteEventHandler);

--- a/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapKLineContent.tsx
@@ -34,6 +34,10 @@ import {
   TRADING_VIEW_DISABLED_FEATURES,
   TradingViewV2,
 } from '@onekeyhq/kit/src/components/TradingView/TradingViewV2';
+import {
+  type IMarketChartJourneyToken,
+  swapKLineChartPerformance,
+} from '@onekeyhq/kit/src/components/TradingView/TradingViewV2/performance/marketChartPerformance';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { ProviderJotaiContextMarketV2 } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2';
 import {
@@ -1233,6 +1237,16 @@ function SwapKLineContentBody({
   const selectedToken = state.selectedToken;
   const chartNetworkId = selectedToken?.networkId ?? '';
   const chartTokenAddress = selectedToken?.contractAddress ?? '';
+  const [performanceToken, setPerformanceToken] =
+    useState<IMarketChartJourneyToken>();
+  useEffect(() => {
+    if (!chartNetworkId) return;
+    // Token identity is an in-memory generation scope only.
+    const scopeKey = `${chartNetworkId}:${chartTokenAddress}`;
+    swapKLineChartPerformance.routeStart(scopeKey);
+    setPerformanceToken(swapKLineChartPerformance.paramsReady(scopeKey));
+    return () => swapKLineChartPerformance.leave();
+  }, [chartNetworkId, chartTokenAddress]);
   const disabledTradingViewFeatures = gtMd
     ? SWAP_KLINE_DESKTOP_DISABLED_TRADING_VIEW_FEATURES
     : SWAP_KLINE_MOBILE_DISABLED_TRADING_VIEW_FEATURES;
@@ -1298,11 +1312,48 @@ function SwapKLineContentBody({
         emptyKLineDataOnError
         kLineDataFallback={state.coinGeckoKLineDataSource}
         primaryKLineDataUnavailable={state.primaryKLineDataUnavailable}
-        onPrimaryKLineDataUnavailable={state.handlePrimaryKLineDataUnavailable}
+        onPrimaryKLineDataUnavailable={() => {
+          state.handlePrimaryKLineDataUnavailable();
+          swapKLineChartPerformance.fallbackUsed(performanceToken);
+        }}
         onPriceUpdate={state.handleChartPriceUpdate}
-        onKLineDataReady={state.handleKLineDataReady}
-        onKLineLoadError={state.handleKLineLoadError}
-        onKLinePeriodChange={state.handleKLinePeriodChange}
+        onLoadStart={() =>
+          swapKLineChartPerformance.hostRequested(performanceToken)
+        }
+        onLoad={() => swapKLineChartPerformance.hostLoaded(performanceToken)}
+        onError={() => swapKLineChartPerformance.hostError(performanceToken)}
+        onKLineDataRequest={() =>
+          swapKLineChartPerformance.dataRequestStart(performanceToken)
+        }
+        onKLineDataReady={(data) => {
+          state.handleKLineDataReady(data);
+          swapKLineChartPerformance.firstBarReady(
+            performanceToken,
+            data.period,
+          );
+        }}
+        onKLineLoadError={(data) => {
+          state.handleKLineLoadError(data);
+          swapKLineChartPerformance.kLineError(performanceToken, data.status);
+        }}
+        onKLinePeriodChange={(data) => {
+          state.handleKLinePeriodChange(data);
+          setPerformanceToken(
+            swapKLineChartPerformance.periodChange(
+              performanceToken,
+              data.toPeriod,
+            ),
+          );
+        }}
+        onKLineSourceChange={(sourceClass) =>
+          swapKLineChartPerformance.sourceChanged(performanceToken, sourceClass)
+        }
+        onPriceScaleStart={() =>
+          swapKLineChartPerformance.priceScaleStart(performanceToken)
+        }
+        onPriceScaleDone={() =>
+          swapKLineChartPerformance.priceScaleDone(performanceToken)
+        }
         w="100%"
         h="100%"
       />

--- a/packages/kit/src/views/Swap/performance/swapPerformance.test.ts
+++ b/packages/kit/src/views/Swap/performance/swapPerformance.test.ts
@@ -1,0 +1,147 @@
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
+import {
+  SwapPerformanceMonitor,
+  runSwapPerformanceSafely,
+} from './swapPerformance';
+
+const SWAP_ALLOWED_PAYLOAD_KEYS = new Set([
+  'durationMs',
+  'errorCode',
+  'expectedProviderCount',
+  'firstQuoteMs',
+  'pageVisible',
+  'quoteMode',
+  'receivedProviderCount',
+  'result',
+  'sampleRate',
+  'scenario',
+  'settledMs',
+  'staleDiscardCount',
+  'successProviderCount',
+]);
+
+function expectAllowedPayloadKeys(payload: Record<string, unknown>) {
+  expect(Object.keys(payload).sort()).toEqual(
+    Object.keys(payload).filter((key) => SWAP_ALLOWED_PAYLOAD_KEYS.has(key)).sort(),
+  );
+}
+
+const intent = {
+  amountKey: '1',
+  fromNetworkKey: 'network-a',
+  fromTokenKey: 'token-a',
+  quoteKind: 'sell',
+  quoteMode: 'market' as const,
+  toNetworkKey: 'network-b',
+  toTokenKey: 'token-b',
+};
+
+describe('SwapPerformanceMonitor', () => {
+  it('does not let an old eventId finish the new intent', () => {
+    const reporter = jest.fn();
+    const monitor = new SwapPerformanceMonitor(reporter);
+    const oldRunId = monitor.beginIntent(intent);
+    monitor.expectedProviders({ count: 1, eventId: 'old', intent, runId: oldRunId });
+    monitor.beginIntent({ ...intent, amountKey: '2' });
+    reporter.mockClear();
+
+    const accepted = monitor.settled({
+      eventId: 'old',
+      intent: { ...intent, amountKey: '2' },
+    });
+
+    expect(accepted).toBe(false);
+    expect(reporter).not.toHaveBeenCalled();
+    monitor.cancelIntent();
+  });
+
+  it('separates first actionable quote from provider settlement', () => {
+    const reporter = jest.fn();
+    const monitor = new SwapPerformanceMonitor(reporter);
+    const runId = monitor.beginIntent(intent);
+    monitor.expectedProviders({ count: 2, eventId: 'current', intent, runId });
+    monitor.quotesReceived({
+      eventId: 'current',
+      intent,
+      runId,
+      quotes: [{ actionable: true, providerKey: 'provider-a' }],
+    });
+
+    expect(reporter).toHaveBeenCalledTimes(1);
+    expect(reporter.mock.calls[0][0]).toBe('swapPerfFirstQuote');
+    monitor.quotesReceived({
+      eventId: 'current',
+      intent,
+      runId,
+      quotes: [{ actionable: false, providerKey: 'provider-b' }],
+    });
+    expect(reporter).toHaveBeenCalledTimes(2);
+    expect(reporter.mock.calls[1][0]).toBe('swapPerfQuoteSettled');
+    expect(reporter.mock.calls[1][1].result).toBe('partial');
+    monitor.cancelIntent();
+  });
+
+  it('does not let an old run bind the same intent after manual refresh', () => {
+    const reporter = jest.fn();
+    const monitor = new SwapPerformanceMonitor(reporter);
+    const oldRunId = monitor.beginIntent(intent);
+    const newRunId = monitor.beginIntent({ ...intent, manualRefresh: true });
+    reporter.mockClear();
+
+    expect(
+      monitor.expectedProviders({
+        count: 1,
+        eventId: 'old-first-arrival',
+        intent,
+        runId: oldRunId,
+      }),
+    ).toBe(false);
+    expect(reporter).not.toHaveBeenCalled();
+
+    expect(
+      monitor.expectedProviders({
+        count: 1,
+        eventId: 'current',
+        intent: { ...intent, manualRefresh: true },
+        runId: newRunId,
+      }),
+    ).toBe(true);
+    monitor.quotesReceived({
+      eventId: 'current',
+      intent: { ...intent, manualRefresh: true },
+      runId: newRunId,
+      quotes: [{ actionable: true, providerKey: 'provider-a' }],
+    });
+    expect(reporter).toHaveBeenCalledTimes(2);
+    monitor.cancelIntent();
+  });
+
+  it('reports only allowed swap terminal payload keys', () => {
+    const reporter = jest.fn();
+    const monitor = new SwapPerformanceMonitor(reporter);
+    const runId = monitor.beginIntent(intent);
+
+    monitor.expectedProviders({ count: 1, eventId: 'current', intent, runId });
+    monitor.quotesReceived({
+      eventId: 'current',
+      intent,
+      runId,
+      quotes: [{ actionable: true, providerKey: 'provider-a' }],
+    });
+
+    expect(reporter).toHaveBeenCalledTimes(2);
+    expectAllowedPayloadKeys(reporter.mock.calls[0][1]);
+    expectAllowedPayloadKeys(reporter.mock.calls[1][1]);
+    monitor.cancelIntent();
+  });
+
+  it('isolates instrumentation failures from the caller', () => {
+    const businessAction = jest.fn();
+    runSwapPerformanceSafely(() => {
+      throw new OneKeyLocalError('instrumentation failed');
+    });
+    businessAction();
+    expect(businessAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kit/src/views/Swap/performance/swapPerformance.ts
+++ b/packages/kit/src/views/Swap/performance/swapPerformance.ts
@@ -1,0 +1,446 @@
+import {
+  PERFORMANCE_JOURNEY_TIMEOUTS,
+  PerformanceJourneyManager,
+} from '@onekeyhq/shared/src/performance/journey';
+import type { IPerformanceJourneyTerminalInfo } from '@onekeyhq/shared/src/performance/journey';
+import {
+  type IPerformanceTerminalEventName,
+  logPerformanceJourneyTerminalLocal,
+  reportPerformanceTerminal,
+} from '@onekeyhq/shared/src/performance/terminalReporter';
+
+export type ISwapPerformanceQuoteMode = 'market' | 'limit' | 'stock';
+type ISwapPerformanceScenario =
+  | 'first_open'
+  | 'amount_change'
+  | 'token_change'
+  | 'network_change'
+  | 'manual_refresh';
+type ISwapPerformanceResult =
+  | 'success'
+  | 'partial'
+  | 'empty'
+  | 'timeout'
+  | 'error'
+  | 'cancelled';
+
+export type ISwapPerformanceIntent = {
+  amountKey: string;
+  fromNetworkKey: string;
+  fromTokenKey: string;
+  manualRefresh?: boolean;
+  quoteKind: string;
+  quoteMode: ISwapPerformanceQuoteMode;
+  toNetworkKey: string;
+  toTokenKey: string;
+};
+
+export type ISwapPerformanceRunId = string;
+
+type ISwapPerformanceQuote = {
+  actionable: boolean;
+  providerKey: string;
+};
+
+type ISwapPerformanceContext = {
+  errorCode?: string;
+  eventId?: string;
+  expectedProviderCount: number;
+  firstResult?: ISwapPerformanceResult;
+  intent: ISwapPerformanceIntent;
+  intentKey: string;
+  pageVisible: boolean;
+  receivedProviderCount: number;
+  receivedProviders: Set<string>;
+  result?: ISwapPerformanceResult;
+  runId: ISwapPerformanceRunId;
+  scenario: ISwapPerformanceScenario;
+  staleDiscardCount: number;
+  successProviders: Set<string>;
+};
+
+type ISwapPerformanceReporter = (
+  eventName: IPerformanceTerminalEventName,
+  payload: Record<string, unknown>,
+) => void;
+
+function getNetworkKey(intent: ISwapPerformanceIntent) {
+  return `${intent.fromNetworkKey}:${intent.toNetworkKey}`;
+}
+
+function getTokenKey(intent: ISwapPerformanceIntent) {
+  return `${getNetworkKey(intent)}:${intent.fromTokenKey}:${intent.toTokenKey}`;
+}
+
+function createSwapPerformanceRunId() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function getSwapPerformanceIntentKey(intent: ISwapPerformanceIntent) {
+  return `${getTokenKey(intent)}:${intent.amountKey}:${intent.quoteKind}:${intent.quoteMode}`;
+}
+
+export function getSwapPerformanceQuoteMode(
+  protocol: string | undefined,
+): ISwapPerformanceQuoteMode {
+  const normalized = protocol?.toLowerCase();
+  if (normalized === 'limit') return 'limit';
+  if (normalized === 'stock') return 'stock';
+  return 'market';
+}
+
+export function runSwapPerformanceSafely(callback: () => void) {
+  try {
+    callback();
+  } catch {
+    // Measurement must never change quote behavior.
+  }
+}
+
+export class SwapPerformanceMonitor {
+  private readonly pageManager = new PerformanceJourneyManager();
+
+  private readonly firstQuoteManager = new PerformanceJourneyManager();
+
+  private readonly settledManager = new PerformanceJourneyManager();
+
+  private readonly reporter: ISwapPerformanceReporter;
+
+  private pageVisible = true;
+
+  private previousIntent?: ISwapPerformanceIntent;
+
+  private context?: ISwapPerformanceContext;
+
+  private readonly retiredEventIds = new Set<string>();
+
+  constructor(reporter: ISwapPerformanceReporter = reportPerformanceTerminal) {
+    this.reporter = reporter;
+  }
+
+  pageEnter(quoteMode: ISwapPerformanceQuoteMode) {
+    if (this.pageManager.getCurrent()) return;
+    const journey = this.pageManager.start({
+      markPrefix: 'SwapPerf',
+      timeoutMs: PERFORMANCE_JOURNEY_TIMEOUTS.swapQuote,
+      onTerminal: (info) => {
+        const eventName = 'swapPerfPageReady';
+        logPerformanceJourneyTerminalLocal(eventName, info);
+        if (!info.sampled) return;
+        this.reporter(eventName, {
+          scenario: 'first_open',
+          quoteMode,
+          durationMs: info.durationMs,
+          pageVisible: this.pageVisible,
+          result: info.state,
+          errorCode: info.state === 'timeout' ? 'page_not_ready' : undefined,
+          sampleRate: info.sampleRate,
+        });
+      },
+    });
+    journey.mark('page_enter');
+  }
+
+  pageReady() {
+    const journey = this.pageManager.getCurrent();
+    if (!journey) return false;
+    journey.mark('page_ready');
+    return journey.succeed();
+  }
+
+  pageLeave() {
+    this.pageManager.cancelCurrent();
+  }
+
+  setPageVisible(pageVisible: boolean) {
+    this.pageVisible = pageVisible;
+  }
+
+  beginIntent(intent: ISwapPerformanceIntent) {
+    if (this.context?.eventId) {
+      this.retiredEventIds.add(this.context.eventId);
+      while (this.retiredEventIds.size > 20) {
+        const first = this.retiredEventIds.values().next().value;
+        if (!first) break;
+        this.retiredEventIds.delete(first);
+      }
+    }
+    const scenario = this.getScenario(intent);
+    const context: ISwapPerformanceContext = {
+      expectedProviderCount: 0,
+      intent,
+      intentKey: getSwapPerformanceIntentKey(intent),
+      pageVisible: this.pageVisible,
+      receivedProviderCount: 0,
+      receivedProviders: new Set(),
+      runId: createSwapPerformanceRunId(),
+      scenario,
+      staleDiscardCount: 0,
+      successProviders: new Set(),
+    };
+    this.context = context;
+    this.previousIntent = intent;
+
+    const firstQuoteJourney = this.firstQuoteManager.start({
+      markPrefix: 'SwapPerf',
+      timeoutMs: PERFORMANCE_JOURNEY_TIMEOUTS.swapQuote,
+      onTerminal: (info) =>
+        this.reportQuoteTerminal('swapPerfFirstQuote', info, context),
+    });
+    const settledJourney = this.settledManager.start({
+      markPrefix: 'SwapPerf',
+      timeoutMs: PERFORMANCE_JOURNEY_TIMEOUTS.swapQuote,
+      onTerminal: (info) =>
+        this.reportQuoteTerminal('swapPerfQuoteSettled', info, context),
+    });
+    firstQuoteJourney.mark('quote_intent');
+    settledJourney.mark('quote_intent');
+    if (!context.pageVisible) {
+      firstQuoteJourney.mark('hidden_refresh');
+      settledJourney.mark('hidden_refresh');
+    }
+    return context.runId;
+  }
+
+  expectedProviders({
+    eventId,
+    intent,
+    count,
+    runId,
+  }: {
+    eventId: string;
+    intent: ISwapPerformanceIntent;
+    count: number;
+    runId?: ISwapPerformanceRunId;
+  }) {
+    if (!eventId) {
+      this.recordStaleDiscard();
+      return false;
+    }
+    const context = this.acceptEvent(intent, eventId, runId);
+    if (!context) return false;
+    context.expectedProviderCount = Math.max(0, count);
+    if (count === 0) {
+      context.firstResult = 'empty';
+      context.result = 'empty';
+      this.firstQuoteManager.getCurrent()?.mark('quote_settled');
+      this.settledManager.getCurrent()?.mark('quote_settled');
+      this.firstQuoteManager.getCurrent()?.succeed();
+      this.settledManager.getCurrent()?.succeed();
+    } else if (context.receivedProviderCount >= count) {
+      context.receivedProviderCount = count;
+      this.finishSettled(context);
+    }
+    return true;
+  }
+
+  quotesReceived({
+    eventId,
+    expectedProviderCount,
+    intent,
+    quotes,
+    runId,
+  }: {
+    eventId: string | undefined;
+    expectedProviderCount?: number;
+    intent: ISwapPerformanceIntent;
+    quotes: ISwapPerformanceQuote[];
+    runId?: ISwapPerformanceRunId;
+  }) {
+    if (!eventId) {
+      this.recordStaleDiscard();
+      return false;
+    }
+    const context = this.acceptEvent(intent, eventId, runId);
+    if (!context) return false;
+    if (expectedProviderCount !== undefined) {
+      context.expectedProviderCount = Math.max(0, expectedProviderCount);
+    }
+    context.receivedProviderCount += quotes.length;
+    if (context.expectedProviderCount > 0) {
+      context.receivedProviderCount = Math.min(
+        context.expectedProviderCount,
+        context.receivedProviderCount,
+      );
+    }
+    for (const quote of quotes) {
+      if (quote.providerKey) {
+        context.receivedProviders.add(quote.providerKey);
+        if (quote.actionable) {
+          context.successProviders.add(quote.providerKey);
+        }
+      }
+    }
+    if (
+      context.successProviders.size > 0 &&
+      this.firstQuoteManager.getCurrent()
+    ) {
+      context.firstResult = 'success';
+      const journey = this.firstQuoteManager.getCurrent();
+      journey?.mark('first_actionable_quote');
+      journey?.succeed();
+    }
+    if (
+      context.expectedProviderCount > 0 &&
+      context.receivedProviderCount >= context.expectedProviderCount
+    ) {
+      this.finishSettled(context);
+    }
+    return true;
+  }
+
+  settled({
+    eventId,
+    intent,
+    runId,
+  }: {
+    eventId?: string;
+    intent: ISwapPerformanceIntent;
+    runId?: ISwapPerformanceRunId;
+  }) {
+    const context = this.acceptEvent(intent, eventId, runId);
+    if (!context) return false;
+    if (
+      context.expectedProviderCount <= 0 ||
+      context.receivedProviderCount < context.expectedProviderCount
+    ) {
+      return false;
+    }
+    this.finishSettled(context);
+    return true;
+  }
+
+  private finishSettled(context: ISwapPerformanceContext) {
+    const successCount = context.successProviders.size;
+    const receivedCount = context.receivedProviderCount;
+    context.result = 'success';
+    if (successCount === 0) {
+      context.result = 'empty';
+    } else if (
+      successCount < receivedCount ||
+      (context.expectedProviderCount > 0 &&
+        successCount < context.expectedProviderCount)
+    ) {
+      context.result = 'partial';
+    }
+    if (this.firstQuoteManager.getCurrent()) {
+      context.firstResult = context.result === 'success' ? 'success' : 'empty';
+      this.firstQuoteManager.getCurrent()?.mark('quote_settled');
+      this.firstQuoteManager.getCurrent()?.succeed();
+    }
+    const journey = this.settledManager.getCurrent();
+    journey?.mark('quote_settled');
+    journey?.succeed();
+  }
+
+  error({
+    eventId,
+    intent,
+    runId,
+  }: {
+    eventId?: string;
+    intent: ISwapPerformanceIntent;
+    runId?: ISwapPerformanceRunId;
+  }) {
+    if (!eventId) {
+      this.recordStaleDiscard();
+      return false;
+    }
+    const context = this.acceptEvent(intent, eventId, runId);
+    if (!context) return false;
+    context.errorCode = 'quote_event_error';
+    this.firstQuoteManager.getCurrent()?.error();
+    this.settledManager.getCurrent()?.error();
+    return true;
+  }
+
+  cancelIntent() {
+    this.firstQuoteManager.cancelCurrent();
+    this.settledManager.cancelCurrent();
+  }
+
+  private acceptEvent(
+    intent: ISwapPerformanceIntent,
+    eventId: string | undefined,
+    runId: ISwapPerformanceRunId | undefined,
+  ) {
+    const context = this.context;
+    if (
+      !context ||
+      context.intentKey !== getSwapPerformanceIntentKey(intent) ||
+      context.runId !== runId ||
+      (eventId && this.retiredEventIds.has(eventId)) ||
+      (context.eventId && context.eventId !== eventId)
+    ) {
+      this.recordStaleDiscard();
+      return undefined;
+    }
+    if (!context.eventId && eventId) context.eventId = eventId;
+    return context;
+  }
+
+  private recordStaleDiscard() {
+    if (!this.context) return;
+    this.context.staleDiscardCount += 1;
+    this.firstQuoteManager.getCurrent()?.mark('stale_discarded');
+    this.settledManager.getCurrent()?.mark('stale_discarded');
+  }
+
+  private getScenario(
+    intent: ISwapPerformanceIntent,
+  ): ISwapPerformanceScenario {
+    const previous = this.previousIntent;
+    if (!previous) return 'first_open';
+    if (
+      intent.manualRefresh ||
+      getSwapPerformanceIntentKey(previous) ===
+        getSwapPerformanceIntentKey(intent)
+    ) {
+      return 'manual_refresh';
+    }
+    if (getNetworkKey(previous) !== getNetworkKey(intent)) {
+      return 'network_change';
+    }
+    if (
+      getTokenKey(previous) !== getTokenKey(intent) ||
+      previous.quoteMode !== intent.quoteMode
+    ) {
+      return 'token_change';
+    }
+    return 'amount_change';
+  }
+
+  private reportQuoteTerminal(
+    eventName: 'swapPerfFirstQuote' | 'swapPerfQuoteSettled',
+    info: IPerformanceJourneyTerminalInfo,
+    context: ISwapPerformanceContext,
+  ) {
+    logPerformanceJourneyTerminalLocal(eventName, info);
+    if (!info.sampled) return;
+    let result: ISwapPerformanceResult = info.state;
+    if (info.state === 'success') {
+      result =
+        eventName === 'swapPerfFirstQuote'
+          ? (context.firstResult ?? 'empty')
+          : (context.result ?? 'empty');
+    }
+    this.reporter(eventName, {
+      scenario: context.scenario,
+      quoteMode: context.intent.quoteMode,
+      durationMs: info.durationMs,
+      firstQuoteMs: info.stageDurations.first_actionable_quote,
+      settledMs: info.stageDurations.quote_settled,
+      expectedProviderCount: context.expectedProviderCount,
+      receivedProviderCount: context.receivedProviderCount,
+      successProviderCount: context.successProviders.size,
+      staleDiscardCount: context.staleDiscardCount,
+      pageVisible: context.pageVisible,
+      result,
+      errorCode:
+        context.errorCode ?? (info.state === 'timeout' ? 'timeout' : undefined),
+      sampleRate: info.sampleRate,
+    });
+  }
+}
+
+export const swapPerformance = new SwapPerformanceMonitor();

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -402,6 +402,7 @@ export interface IAppEventBusPayload {
     event: ISwapQuoteEvent;
     params: IFetchQuotesParams;
     accountId?: string;
+    performanceRunId?: string;
     tokenPairs: { fromToken: ISwapToken; toToken: ISwapToken };
   };
   [EAppEventBusNames.ShowSystemDiskFullWarning]: undefined;

--- a/packages/shared/src/logger/scopes/app/index.ts
+++ b/packages/shared/src/logger/scopes/app/index.ts
@@ -14,6 +14,7 @@ import { JsBundleDevScene } from './scenes/jsBundleDev';
 import { NetworkScene } from './scenes/network';
 import { PageScene } from './scenes/page';
 import { AppPerfScene } from './scenes/perf';
+import { PerformanceJourneyScene } from './scenes/performanceJourney';
 import { RouterScene } from './scenes/router';
 import { WebAuthScene } from './scenes/webAuth';
 import { WebembedScene } from './scenes/webembed';
@@ -36,6 +37,11 @@ export class AppScope extends BaseScope {
   eventBus = this.createScene('eventBus', EventBusScene);
 
   perf = this.createScene('perf', AppPerfScene);
+
+  performanceJourney = this.createScene(
+    'performanceJourney',
+    PerformanceJourneyScene,
+  );
 
   error = this.createScene('error', ErrorScene);
 

--- a/packages/shared/src/logger/scopes/app/scenes/performanceJourney.ts
+++ b/packages/shared/src/logger/scopes/app/scenes/performanceJourney.ts
@@ -1,0 +1,66 @@
+import { BaseScene } from '../../../base/baseScene';
+import { LogToLocal, LogToServer } from '../../../base/decorators';
+
+type IPerformanceTerminalPayload = Record<string, unknown>;
+
+export class PerformanceJourneyScene extends BaseScene {
+  @LogToServer()
+  @LogToLocal()
+  homePerfReady(payload: IPerformanceTerminalPayload) {
+    return payload;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  homePerfRefreshSettled(payload: IPerformanceTerminalPayload) {
+    return payload;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  marketChartPerfReady(payload: IPerformanceTerminalPayload) {
+    return payload;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  marketChartPerfSymbolSwitch(payload: IPerformanceTerminalPayload) {
+    return payload;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  marketChartPerfError(payload: IPerformanceTerminalPayload) {
+    return payload;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  swapPerfPageReady(payload: IPerformanceTerminalPayload) {
+    return payload;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  swapPerfFirstQuote(payload: IPerformanceTerminalPayload) {
+    return payload;
+  }
+
+  @LogToServer()
+  @LogToLocal()
+  swapPerfQuoteSettled(payload: IPerformanceTerminalPayload) {
+    return payload;
+  }
+
+  @LogToLocal()
+  terminalLocal(payload: {
+    eventName: string;
+    journeyId: string;
+    generation: number;
+    state: string;
+    durationMs: number;
+    sampled: boolean;
+  }) {
+    return payload;
+  }
+}

--- a/packages/shared/src/performance/journey.test.ts
+++ b/packages/shared/src/performance/journey.test.ts
@@ -1,0 +1,216 @@
+import { OneKeyLocalError } from '../errors';
+
+import {
+  type IPerformanceJourneyTerminalInfo,
+  PERFORMANCE_JOURNEY_TIMEOUTS,
+  PerformanceJourneyManager,
+} from './journey';
+
+const perfMarkMock = jest.fn();
+
+jest.mock('./mark', () => ({
+  perfMark: (...args: unknown[]) => {
+    perfMarkMock(...args);
+  },
+}));
+
+describe('PerformanceJourney', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalPerfMonitor = process.env.PERF_MONITOR;
+  const originalPerfMonitorEnabled = process.env.PERF_MONITOR_ENABLED;
+  let now = 0;
+  let performanceNowSpy: jest.SpyInstance<number, []>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    now = 0;
+    performanceNowSpy = jest
+      .spyOn(globalThis.performance, 'now')
+      .mockImplementation(() => now);
+    perfMarkMock.mockReset();
+    process.env.NODE_ENV = 'production';
+    delete process.env.PERF_MONITOR;
+    delete process.env.PERF_MONITOR_ENABLED;
+  });
+
+  afterEach(() => {
+    performanceNowSpy.mockRestore();
+    jest.useRealTimers();
+    process.env.NODE_ENV = originalNodeEnv;
+    process.env.PERF_MONITOR = originalPerfMonitor;
+    process.env.PERF_MONITOR_ENABLED = originalPerfMonitorEnabled;
+  });
+
+  it('emits success terminal exactly once', () => {
+    const onTerminal: jest.MockedFunction<
+      (info: IPerformanceJourneyTerminalInfo) => void
+    > = jest.fn();
+    const journey = new PerformanceJourneyManager().start({
+      markPrefix: 'TestPerf',
+      onTerminal,
+      random: () => 0,
+      timeoutMs: 1000,
+    });
+
+    now = 120;
+    expect(journey.succeed()).toBe(true);
+    expect(journey.succeed()).toBe(false);
+    expect(onTerminal).toHaveBeenCalledTimes(1);
+    expect(onTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'success', durationMs: 120 }),
+    );
+  });
+
+  it.each(['timeout', 'error', 'cancelled'] as const)(
+    'keeps %s mutually exclusive with success',
+    (terminal) => {
+      const onTerminal = jest.fn();
+      const journey = new PerformanceJourneyManager().start({
+        markPrefix: 'TestPerf',
+        onTerminal,
+        timeoutMs: 1000,
+      });
+
+      now = 50;
+      journey.finish(terminal);
+      expect(journey.succeed()).toBe(false);
+      expect(onTerminal).toHaveBeenCalledTimes(1);
+      expect(onTerminal).toHaveBeenCalledWith(
+        expect.objectContaining({ state: terminal }),
+      );
+    },
+  );
+
+  it('invalidates callbacks from the previous generation', () => {
+    const onTerminal: jest.MockedFunction<
+      (info: IPerformanceJourneyTerminalInfo) => void
+    > = jest.fn();
+    const manager = new PerformanceJourneyManager();
+    const first = manager.start({
+      markPrefix: 'TestPerf',
+      onTerminal,
+      timeoutMs: 1000,
+    });
+    const second = manager.start({
+      markPrefix: 'TestPerf',
+      onTerminal,
+      timeoutMs: 1000,
+    });
+
+    expect(first.state).toBe('cancelled');
+    expect(first.succeed()).toBe(false);
+    expect(manager.isCurrent(second)).toBe(true);
+    expect(second.succeed()).toBe(true);
+    expect(onTerminal.mock.calls.map(([info]) => info.state)).toEqual([
+      'cancelled',
+      'success',
+    ]);
+  });
+
+  it('clears timers and registered listeners on terminal', () => {
+    const cleanup = jest.fn();
+    const onTerminal = jest.fn();
+    const journey = new PerformanceJourneyManager().start({
+      markPrefix: 'TestPerf',
+      onTerminal,
+      timeoutMs: 1000,
+    });
+    journey.addCleanup(cleanup);
+
+    journey.succeed();
+    now = 2000;
+    jest.advanceTimersByTime(2000);
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(onTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  it('samples success at 10 percent and error/timeout at 100 percent', () => {
+    const terminalInfo: Array<{ sampled: boolean; sampleRate: number }> = [];
+    const manager = new PerformanceJourneyManager();
+    manager
+      .start({
+        markPrefix: 'TestPerf',
+        onTerminal: (info) => terminalInfo.push(info),
+        random: () => 0.11,
+        timeoutMs: 1000,
+      })
+      .succeed();
+    manager
+      .start({
+        markPrefix: 'TestPerf',
+        onTerminal: (info) => terminalInfo.push(info),
+        random: () => 0.99,
+        timeoutMs: 1000,
+      })
+      .error();
+    const timeoutJourney = manager.start({
+      markPrefix: 'TestPerf',
+      onTerminal: (info) => terminalInfo.push(info),
+      random: () => 0.99,
+      timeoutMs: 1000,
+    });
+    now = 1000;
+    jest.advanceTimersByTime(1000);
+
+    expect(timeoutJourney.state).toBe('timeout');
+    expect(terminalInfo).toEqual([
+      expect.objectContaining({ sampled: false, sampleRate: 0.1 }),
+      expect.objectContaining({ sampled: true, sampleRate: 1 }),
+      expect.objectContaining({ sampled: true, sampleRate: 1 }),
+    ]);
+  });
+
+  it.each([
+    ['test environment', 'test', undefined, undefined],
+    ['PERF_MONITOR', 'production', '1', undefined],
+    ['PERF_MONITOR_ENABLED', 'production', undefined, '1'],
+  ])('forces sampling in %s', (_label, nodeEnv, monitor, monitorEnabled) => {
+    process.env.NODE_ENV = nodeEnv;
+    process.env.PERF_MONITOR = monitor;
+    process.env.PERF_MONITOR_ENABLED = monitorEnabled;
+    const onTerminal = jest.fn();
+
+    new PerformanceJourneyManager()
+      .start({
+        markPrefix: 'TestPerf',
+        onTerminal,
+        random: () => 0.99,
+        timeoutMs: 1000,
+      })
+      .succeed();
+
+    expect(onTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({ sampled: true, sampleRate: 1 }),
+    );
+  });
+
+  it('isolates mark, cleanup, and terminal callback failures', () => {
+    perfMarkMock.mockImplementation(() => {
+      throw new OneKeyLocalError('mark failed');
+    });
+    const journey = new PerformanceJourneyManager().start({
+      markPrefix: 'TestPerf',
+      onTerminal: () => {
+        throw new OneKeyLocalError('report failed');
+      },
+      timeoutMs: 1000,
+    });
+    journey.addCleanup(() => {
+      throw new OneKeyLocalError('cleanup failed');
+    });
+
+    expect(() => {
+      journey.mark('stage');
+      journey.succeed();
+    }).not.toThrow();
+  });
+
+  it('keeps timeout constants centralized', () => {
+    expect(PERFORMANCE_JOURNEY_TIMEOUTS).toEqual({
+      home: 15_000,
+      market: 20_000,
+      swapQuote: 30_000,
+    });
+  });
+});

--- a/packages/shared/src/performance/journey.ts
+++ b/packages/shared/src/performance/journey.ts
@@ -1,0 +1,276 @@
+/* eslint-disable max-classes-per-file */
+import { isPerfMonitorEnabled } from './enabled';
+import { perfMark } from './mark';
+
+export const PERFORMANCE_JOURNEY_TIMEOUTS = {
+  home: 15_000,
+  market: 20_000,
+  swapQuote: 30_000,
+} as const;
+
+export const PERFORMANCE_SUCCESS_SAMPLE_RATE = 0.1;
+
+export type IPerformanceJourneyTerminalState =
+  | 'success'
+  | 'timeout'
+  | 'error'
+  | 'cancelled';
+
+export type IPerformanceJourneyTerminalInfo = {
+  durationMs: number;
+  generation: number;
+  journeyId: string;
+  sampleRate: number;
+  sampled: boolean;
+  stageDurations: Readonly<Record<string, number>>;
+  state: IPerformanceJourneyTerminalState;
+};
+
+type IPerformanceJourneyOptions = {
+  generation: number;
+  markPrefix: string;
+  onTerminal?: (info: IPerformanceJourneyTerminalInfo) => void;
+  random?: () => number;
+  startedAt?: number;
+  successSampleRate?: number;
+  timeoutMs: number;
+};
+
+type IPerformanceJourneyGlobal = typeof globalThis & {
+  __performanceJourneySequence__?: number;
+};
+
+function safeInvoke(callback: () => void) {
+  try {
+    callback();
+  } catch {
+    // Performance instrumentation must never affect the measured flow.
+  }
+}
+
+export function getPerformanceNow(): number {
+  if (
+    typeof performance !== 'undefined' &&
+    typeof performance.now === 'function'
+  ) {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+export function isPerformanceSamplingForced(): boolean {
+  try {
+    return (
+      (typeof process !== 'undefined' &&
+        (process.env.NODE_ENV === 'test' ||
+          process.env.PERF_MONITOR === '1')) ||
+      isPerfMonitorEnabled()
+    );
+  } catch {
+    return false;
+  }
+}
+
+function createJourneyId(generation: number) {
+  const state = globalThis as IPerformanceJourneyGlobal;
+  state.__performanceJourneySequence__ =
+    (state.__performanceJourneySequence__ ?? 0) + 1;
+  return `${generation}-${state.__performanceJourneySequence__}`;
+}
+
+function normalizeSampleRate(sampleRate: number) {
+  if (!Number.isFinite(sampleRate)) {
+    return PERFORMANCE_SUCCESS_SAMPLE_RATE;
+  }
+  return Math.min(1, Math.max(0, sampleRate));
+}
+
+export class PerformanceJourney {
+  readonly generation: number;
+
+  readonly journeyId: string;
+
+  private readonly markPrefix: string;
+
+  private readonly onTerminal?: (info: IPerformanceJourneyTerminalInfo) => void;
+
+  private readonly random: () => number;
+
+  private readonly startedAt: number;
+
+  private readonly successSampleRate: number;
+
+  private readonly stageTimes = new Map<string, number>();
+
+  private readonly cleanupCallbacks = new Set<() => void>();
+
+  private terminalState?: IPerformanceJourneyTerminalState;
+
+  private timeoutHandle?: ReturnType<typeof setTimeout>;
+
+  constructor(options: IPerformanceJourneyOptions) {
+    this.generation = options.generation;
+    this.journeyId = createJourneyId(options.generation);
+    this.markPrefix = options.markPrefix;
+    this.onTerminal = options.onTerminal;
+    this.random = options.random ?? Math.random;
+    this.startedAt = options.startedAt ?? getPerformanceNow();
+    this.successSampleRate = normalizeSampleRate(
+      options.successSampleRate ?? PERFORMANCE_SUCCESS_SAMPLE_RATE,
+    );
+
+    const elapsedBeforeStart = Math.max(
+      0,
+      getPerformanceNow() - this.startedAt,
+    );
+    const remainingTimeout = Math.max(
+      0,
+      options.timeoutMs - elapsedBeforeStart,
+    );
+    this.timeoutHandle = setTimeout(() => {
+      this.finish('timeout');
+    }, remainingTimeout);
+  }
+
+  get isTerminal() {
+    return this.terminalState !== undefined;
+  }
+
+  get state() {
+    return this.terminalState;
+  }
+
+  addCleanup(callback: () => void) {
+    if (this.isTerminal) {
+      safeInvoke(callback);
+      return () => undefined;
+    }
+    this.cleanupCallbacks.add(callback);
+    return () => {
+      this.cleanupCallbacks.delete(callback);
+    };
+  }
+
+  mark(stage: string, detail?: unknown) {
+    if (this.isTerminal || !stage) {
+      return false;
+    }
+    const now = getPerformanceNow();
+    if (!this.stageTimes.has(stage)) {
+      this.stageTimes.set(stage, now);
+    }
+    safeInvoke(() => {
+      perfMark(`${this.markPrefix}:${stage}`, detail);
+    });
+    return true;
+  }
+
+  getStageDuration(stage: string): number | undefined {
+    const stageTime = this.stageTimes.get(stage);
+    return stageTime === undefined
+      ? undefined
+      : Math.max(0, Math.round(stageTime - this.startedAt));
+  }
+
+  getStageDurations(): Readonly<Record<string, number>> {
+    return Object.fromEntries(
+      [...this.stageTimes.entries()].map(([stage, timestamp]) => [
+        stage,
+        Math.max(0, Math.round(timestamp - this.startedAt)),
+      ]),
+    );
+  }
+
+  succeed() {
+    return this.finish('success');
+  }
+
+  error() {
+    return this.finish('error');
+  }
+
+  cancel() {
+    return this.finish('cancelled');
+  }
+
+  finish(state: IPerformanceJourneyTerminalState) {
+    if (this.isTerminal) {
+      return false;
+    }
+
+    this.terminalState = state;
+    const finishedAt = getPerformanceNow();
+    if (this.timeoutHandle !== undefined) {
+      clearTimeout(this.timeoutHandle);
+      this.timeoutHandle = undefined;
+    }
+    for (const cleanup of this.cleanupCallbacks) {
+      safeInvoke(cleanup);
+    }
+    this.cleanupCallbacks.clear();
+
+    if (state !== 'success') {
+      safeInvoke(() => {
+        perfMark(`${this.markPrefix}:${state}`);
+      });
+    }
+
+    const forcedSampling = isPerformanceSamplingForced();
+    let sampleRate = this.successSampleRate;
+    if (forcedSampling || state === 'error' || state === 'timeout') {
+      sampleRate = 1;
+    }
+    const sampled = sampleRate >= 1 || this.random() < sampleRate;
+    const terminalInfo: IPerformanceJourneyTerminalInfo = {
+      durationMs: Math.max(0, Math.round(finishedAt - this.startedAt)),
+      generation: this.generation,
+      journeyId: this.journeyId,
+      sampleRate,
+      sampled,
+      stageDurations: this.getStageDurations(),
+      state,
+    };
+    if (this.onTerminal) {
+      safeInvoke(() => this.onTerminal?.(terminalInfo));
+    }
+    return true;
+  }
+}
+
+export class PerformanceJourneyManager {
+  private generation = 0;
+
+  private current?: PerformanceJourney;
+
+  start(options: Omit<IPerformanceJourneyOptions, 'generation'>) {
+    this.current?.cancel();
+    this.generation += 1;
+    const journey = new PerformanceJourney({
+      ...options,
+      generation: this.generation,
+    });
+    this.current = journey;
+    journey.addCleanup(() => {
+      if (this.current === journey) {
+        this.current = undefined;
+      }
+    });
+    return journey;
+  }
+
+  getCurrent() {
+    return this.current;
+  }
+
+  isCurrent(journey: PerformanceJourney) {
+    return this.current === journey && !journey.isTerminal;
+  }
+
+  cancelCurrent() {
+    return this.current?.cancel() ?? false;
+  }
+
+  dispose() {
+    this.cancelCurrent();
+  }
+}

--- a/packages/shared/src/performance/terminalReporter.test.ts
+++ b/packages/shared/src/performance/terminalReporter.test.ts
@@ -1,0 +1,51 @@
+import { OneKeyLocalError } from '../errors';
+
+import { reportPerformanceTerminal } from './terminalReporter';
+
+const homePerfReadyMock = jest.fn();
+
+jest.mock('../logger/logger', () => ({
+  defaultLogger: {
+    app: {
+      performanceJourney: {
+        homePerfReady: (...args: unknown[]) => {
+          homePerfReadyMock(...args);
+        },
+      },
+    },
+  },
+}));
+
+describe('reportPerformanceTerminal', () => {
+  beforeEach(() => {
+    homePerfReadyMock.mockReset();
+  });
+
+  it('forwards the payload unchanged', () => {
+    const input = {
+      scenario: 'cold',
+      renderer: 'legacy',
+      result: 'success',
+      durationMs: 400,
+      sampleRate: 0.1,
+    };
+    const payload = reportPerformanceTerminal('homePerfReady', input);
+
+    expect(payload).toBe(input);
+    expect(homePerfReadyMock).toHaveBeenCalledWith(input);
+  });
+
+  it('isolates logger failures from the caller', () => {
+    homePerfReadyMock.mockImplementationOnce(() => {
+      throw new OneKeyLocalError('logger failed');
+    });
+
+    expect(() =>
+      reportPerformanceTerminal('homePerfReady', {
+        result: 'error',
+        durationMs: 1,
+        sampleRate: 1,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/shared/src/performance/terminalReporter.ts
+++ b/packages/shared/src/performance/terminalReporter.ts
@@ -1,0 +1,73 @@
+import { defaultLogger } from '../logger/logger';
+
+import type { IPerformanceJourneyTerminalInfo } from './journey';
+
+export type IPerformanceTerminalEventName =
+  | 'homePerfReady'
+  | 'homePerfRefreshSettled'
+  | 'marketChartPerfReady'
+  | 'marketChartPerfSymbolSwitch'
+  | 'marketChartPerfError'
+  | 'swapPerfPageReady'
+  | 'swapPerfFirstQuote'
+  | 'swapPerfQuoteSettled';
+
+type IPerformanceTerminalPayload = Record<string, unknown>;
+
+export function reportPerformanceTerminal(
+  eventName: IPerformanceTerminalEventName,
+  payload: Record<string, unknown>,
+): IPerformanceTerminalPayload {
+  try {
+    const scene = defaultLogger.app.performanceJourney;
+    switch (eventName) {
+      case 'homePerfReady':
+        scene.homePerfReady(payload);
+        break;
+      case 'homePerfRefreshSettled':
+        scene.homePerfRefreshSettled(payload);
+        break;
+      case 'marketChartPerfReady':
+        scene.marketChartPerfReady(payload);
+        break;
+      case 'marketChartPerfSymbolSwitch':
+        scene.marketChartPerfSymbolSwitch(payload);
+        break;
+      case 'marketChartPerfError':
+        scene.marketChartPerfError(payload);
+        break;
+      case 'swapPerfPageReady':
+        scene.swapPerfPageReady(payload);
+        break;
+      case 'swapPerfFirstQuote':
+        scene.swapPerfFirstQuote(payload);
+        break;
+      case 'swapPerfQuoteSettled':
+        scene.swapPerfQuoteSettled(payload);
+        break;
+      default:
+        break;
+    }
+  } catch {
+    // Logger failures are isolated from application behavior.
+  }
+  return payload;
+}
+
+export function logPerformanceJourneyTerminalLocal(
+  eventName: IPerformanceTerminalEventName,
+  info: IPerformanceJourneyTerminalInfo,
+) {
+  try {
+    defaultLogger.app.performanceJourney.terminalLocal({
+      eventName,
+      journeyId: info.journeyId,
+      generation: info.generation,
+      state: info.state,
+      durationMs: info.durationMs,
+      sampled: info.sampled,
+    });
+  } catch {
+    // Logger failures are isolated from application behavior.
+  }
+}

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -604,6 +604,7 @@ export interface IFetchSwapQuoteParams {
   kind?: ESwapQuoteKind;
   toTokenAmount?: string;
   userMarketPriceRate?: string;
+  performanceRunId?: string;
 }
 
 export interface IFetchQuoteResult {


### PR DESCRIPTION
## Summary

Add JS/TS hot-update performance journeys for Home, Market K-line, and Swap quote flows on top of `release/v6.5.0`.

- Adds a shared performance journey helper with monotonic durations, generation invalidation, single terminal state, timeout cleanup, sampling, perf marks, and isolated reporter failures.
- Adds a dedicated default Logger app scene for low-frequency terminal performance events.
- Instruments legacy Home ready/refresh, Market Detail and Swap K-line chart readiness/switching, and Swap page/quote journeys.
- Keeps performance payloads caller-owned: no runtime payload filtering, no analytics/index changes, no explicit bundleVersion injection.
- Adds local-only Swap quote `performanceRunId` correlation so stale same-intent events cannot finish a newer journey.

## Hot Update Boundary

This PR only changes JS/TS code. It does not change business results, request strategy, cache strategy, UI, renderer switches, native modules, Swift/Kotlin, Podfile, Gradle, or yarn.lock.

Native/chart runtime gaps remain for true UIKit/RecyclerView first-frame commit and true chart painted/interactive ACKs.

## Validation

- `yarn jest packages/shared/src/performance/terminalReporter.test.ts packages/shared/src/performance/journey.test.ts packages/kit/src/views/Home/performance/homePerformance.test.ts packages/kit/src/components/TradingView/TradingViewV2/performance/marketChartPerformance.test.ts packages/kit/src/views/Swap/performance/swapPerformance.test.ts --runInBand`
- `yarn jest packages/kit/src/states/jotai/contexts/swap/actions.test.tsx --runInBand`
- `yarn tsc:only`
- `git diff --check`
- `npx oxlint --tsconfig ./tsconfig.json --type-aware --deny-warnings --threads=1 <changed files>`