### PR TITLE
[OK-38010] feat: add configurable haptic feedback

### DIFF
--- a/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.native.tsx
+++ b/packages/components/src/composite/Tabs/HeaderScrollGestureWrapper.native.tsx
@@ -11,6 +11,8 @@ import Animated, {
   withDecay,
 } from 'react-native-reanimated';
 
+import { Haptics, ImpactFeedbackStyle } from '../../primitives/Haptics';
+
 import { CollapsibleTabContext } from './CollapsibleTabContext';
 
 import type { IHeaderScrollGestureWrapperProps } from './HeaderScrollGestureWrapper';
@@ -48,7 +50,12 @@ export function HeaderScrollGestureWrapper({
   const containerHeight = useSharedValue(0);
   const isGestureEnabled = useSharedValue(true);
   const hasNotifiedGestureActive = useSharedValue(false);
+  const hasTriggeredRefreshHaptic = useSharedValue(false);
   const [measuredWidth, setMeasuredWidth] = useState(0);
+
+  const triggerRefreshHaptic = useCallback(() => {
+    Haptics.impact(ImpactFeedbackStyle.Medium);
+  }, []);
 
   const handleLayout = useCallback(
     (event: LayoutChangeEvent) => {
@@ -132,6 +139,7 @@ export function HeaderScrollGestureWrapper({
       .onStart((e) => {
         'worklet';
 
+        hasTriggeredRefreshHaptic.value = false;
         isGestureEnabled.value = !shouldIgnoreByStartPoint(e.x, e.y);
         if (!isGestureEnabled.value) {
           hasNotifiedGestureActive.value = false;
@@ -151,6 +159,17 @@ export function HeaderScrollGestureWrapper({
           return;
         }
         targetScrollY.value = startScrollY.value - e.translationY * scrollScale;
+        const isRefreshThresholdReached =
+          startScrollY.value <= contentInset &&
+          e.translationY > REFRESH_THRESHOLD;
+        if (
+          onRefresh &&
+          isRefreshThresholdReached &&
+          !hasTriggeredRefreshHaptic.value
+        ) {
+          hasTriggeredRefreshHaptic.value = true;
+          runOnJS(triggerRefreshHaptic)();
+        }
       })
       .onEnd((e) => {
         'worklet';
@@ -257,6 +276,8 @@ export function HeaderScrollGestureWrapper({
     measuredWidth,
     isGestureEnabled,
     hasNotifiedGestureActive,
+    hasTriggeredRefreshHaptic,
+    triggerRefreshHaptic,
   ]);
 
   return (

--- a/packages/components/src/hocs/Provider/hooks/useProviderValue.ts
+++ b/packages/components/src/hocs/Provider/hooks/useProviderValue.ts
@@ -10,6 +10,7 @@ export type ISettingConfigContextValue = {
   // hosts that don't have a persisted settings store.
   themeSetting?: 'light' | 'dark' | 'system';
   locale: ILocaleSymbol;
+  hapticFeedbackEnabled: boolean;
   HyperlinkText: typeof HyperlinkText;
 };
 

--- a/packages/components/src/hocs/Provider/index.tsx
+++ b/packages/components/src/hocs/Provider/index.tsx
@@ -9,6 +9,7 @@ import { AppIntlProvider } from '@onekeyhq/shared/src/locale/AppIntlProvider';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { setGlassHeaderUIStyle } from '../../primitives/Button/GlassHeaderContext';
+import { Haptics } from '../../primitives/Haptics';
 
 import { useAppearanceTheme } from './hooks/useAppearanceTheme';
 import useLoadCustomFonts from './hooks/useLoadCustomFonts';
@@ -38,6 +39,8 @@ export type IUIProviderProps = PropsWithChildren<{
 
   onLocaleChange?: (locale: ILocaleSymbol) => void;
 
+  hapticFeedbackEnabled?: boolean;
+
   HyperlinkText: typeof HyperlinkText;
 }>;
 export type IFontProviderProps = PropsWithChildren;
@@ -66,6 +69,7 @@ export function ConfigProvider({
   locale,
   HyperlinkText,
   onLocaleChange,
+  hapticFeedbackEnabled = true,
 }: IUIProviderProps) {
   // On iOS 26 the Liquid Glass nav bar's light/dark variant is driven by
   // react-navigation's theme, which resolves a frame late on each navigation
@@ -77,15 +81,17 @@ export function ConfigProvider({
   if (platformEnv.isNativeIOS26Plus) {
     setGlassHeaderUIStyle(theme);
   }
+  Haptics.setEnabled(hapticFeedbackEnabled);
 
   const providerValue = useMemo(
     () => ({
       theme,
       themeSetting,
       locale,
+      hapticFeedbackEnabled,
       HyperlinkText,
     }),
-    [theme, themeSetting, locale, HyperlinkText],
+    [theme, themeSetting, locale, hapticFeedbackEnabled, HyperlinkText],
   );
 
   const config = useMemo(

--- a/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
@@ -12,6 +12,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
 import { ESwapSource } from '@onekeyhq/shared/types/swap/types';
 
+import { useSettingConfig } from '../../../hocs/Provider/hooks/useProviderValue';
 import {
   ESplitViewType,
   useIsSplitView,
@@ -100,6 +101,7 @@ export function TabStackNavigator<RouteName extends string>({
 }: ITabNavigatorProps<RouteName>) {
   const intl = useIntl();
   const theme = useTheme();
+  const { hapticFeedbackEnabled } = useSettingConfig();
   // Subscribe to theme name so OS dark/light switch triggers re-render —
   // `theme.*.val` reads are non-reactive on native.
   useThemeName();
@@ -225,7 +227,7 @@ export function TabStackNavigator<RouteName extends string>({
   return (
     <NativeTab.Navigator
       labeled
-      hapticFeedbackEnabled
+      hapticFeedbackEnabled={hapticFeedbackEnabled !== false}
       disablePageAnimations
       ignoreBottomInsets
       sidebarAdaptable={false}

--- a/packages/components/src/layouts/RefreshControl/index.tsx
+++ b/packages/components/src/layouts/RefreshControl/index.tsx
@@ -1,6 +1,9 @@
+import { useCallback } from 'react';
+
 import { RefreshControl as NativeRefreshControl } from 'react-native';
 
 import { useTheme } from '../../hooks';
+import { Haptics, ImpactFeedbackStyle } from '../../primitives/Haptics';
 
 import type { IRefreshControlType } from './type';
 
@@ -9,5 +12,16 @@ export * from './type';
 export function RefreshControl(props: IRefreshControlType) {
   const theme = useTheme();
   const color = theme.bgPrimaryActive.val;
-  return <NativeRefreshControl tintColor={color} {...props} />;
+  const { onRefresh, ...rest } = props;
+  const handleRefresh = useCallback(() => {
+    Haptics.impact(ImpactFeedbackStyle.Medium);
+    onRefresh?.();
+  }, [onRefresh]);
+  return (
+    <NativeRefreshControl
+      tintColor={color}
+      {...rest}
+      onRefresh={onRefresh ? handleRefresh : undefined}
+    />
+  );
 }

--- a/packages/components/src/primitives/Haptics/index.native.test.ts
+++ b/packages/components/src/primitives/Haptics/index.native.test.ts
@@ -1,0 +1,59 @@
+import { impactAsync, notificationAsync, selectionAsync } from 'expo-haptics';
+
+import {
+  Haptics,
+  ImpactFeedbackStyle,
+  NotificationFeedbackType,
+} from './index.native';
+
+jest.mock('expo-haptics', () => ({
+  ImpactFeedbackStyle: {
+    Medium: 'medium',
+  },
+  NotificationFeedbackType: {
+    Error: 'error',
+    Success: 'success',
+    Warning: 'warning',
+  },
+  impactAsync: jest.fn(),
+  notificationAsync: jest.fn(),
+  selectionAsync: jest.fn(),
+}));
+
+const impactAsyncMock = jest.mocked(impactAsync);
+const notificationAsyncMock = jest.mocked(notificationAsync);
+const selectionAsyncMock = jest.mocked(selectionAsync);
+
+describe('Haptics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Haptics.setEnabled(true);
+  });
+
+  it('forwards feedback to the native haptics module when enabled', () => {
+    Haptics.impact(ImpactFeedbackStyle.Medium);
+    Haptics.selection();
+    Haptics.notification(NotificationFeedbackType.Warning);
+
+    expect(impactAsyncMock).toHaveBeenCalledWith(ImpactFeedbackStyle.Medium);
+    expect(selectionAsyncMock).toHaveBeenCalledTimes(1);
+    expect(notificationAsyncMock).toHaveBeenCalledWith(
+      NotificationFeedbackType.Warning,
+    );
+  });
+
+  it('suppresses all custom feedback when disabled', () => {
+    Haptics.setEnabled(false);
+
+    Haptics.impact(ImpactFeedbackStyle.Medium);
+    Haptics.selection();
+    Haptics.notification(NotificationFeedbackType.Warning);
+    Haptics.success();
+    Haptics.warning();
+    Haptics.error();
+
+    expect(impactAsyncMock).not.toHaveBeenCalled();
+    expect(selectionAsyncMock).not.toHaveBeenCalled();
+    expect(notificationAsyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/components/src/primitives/Haptics/index.native.ts
+++ b/packages/components/src/primitives/Haptics/index.native.ts
@@ -8,27 +8,51 @@ import {
 import type { IHaptics } from './type';
 import type { ImpactFeedbackStyle } from 'expo-haptics';
 
+let enabled = true;
+
 export const Haptics: IHaptics = {
+  setEnabled(value: boolean) {
+    enabled = value;
+  },
+
   impact(style: ImpactFeedbackStyle) {
+    if (!enabled) {
+      return;
+    }
     void impactAsync(style);
   },
 
   selection() {
+    if (!enabled) {
+      return;
+    }
     void selectionAsync();
   },
 
   notification(type: NotificationFeedbackType) {
+    if (!enabled) {
+      return;
+    }
     void notificationAsync(type);
   },
   success() {
+    if (!enabled) {
+      return;
+    }
     void notificationAsync(NotificationFeedbackType.Success);
   },
 
   warning() {
+    if (!enabled) {
+      return;
+    }
     void notificationAsync(NotificationFeedbackType.Warning);
   },
 
   error() {
+    if (!enabled) {
+      return;
+    }
     void notificationAsync(NotificationFeedbackType.Error);
   },
 };

--- a/packages/components/src/primitives/Haptics/index.ts
+++ b/packages/components/src/primitives/Haptics/index.ts
@@ -1,6 +1,7 @@
 import type { IHaptics } from './type';
 
 export const Haptics: IHaptics = {
+  setEnabled() {},
   impact() {},
   selection() {},
   notification() {},

--- a/packages/components/src/primitives/Haptics/type.ts
+++ b/packages/components/src/primitives/Haptics/type.ts
@@ -4,6 +4,7 @@ import type {
 } from 'expo-haptics';
 
 export type IHaptics = {
+  setEnabled: (enabled: boolean) => void;
   impact: (style: ImpactFeedbackStyle) => void;
   selection: () => void;
   notification: (type: NotificationFeedbackType) => void;

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -756,6 +756,14 @@ class ServiceSetting extends ServiceBase {
   }
 
   @backgroundMethod()
+  public async setHapticFeedbackEnabled(value: boolean) {
+    await settingsPersistAtom.set((prev) => ({
+      ...prev,
+      hapticFeedbackEnabled: value,
+    }));
+  }
+
+  @backgroundMethod()
   public async setEnableSplitView(value: boolean) {
     await settingsPersistAtom.set((prev) => ({
       ...prev,

--- a/packages/kit-bg/src/states/jotai/atoms/settings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/settings.ts
@@ -68,6 +68,7 @@ export type ISettingsPersistAtom = {
   enableDesktopBluetooth?: boolean;
   enableBTCFreshAddress?: boolean;
   enableMenuBarTray?: boolean;
+  hapticFeedbackEnabled?: boolean;
   // Split-view layout for tablets / Android foldable devices. Undefined === enabled
   // (default-on for back-compat). Toggling triggers app restart.
   enableSplitView?: boolean;
@@ -118,6 +119,7 @@ export const settingsAtomInitialValue: ISettingsPersistAtom = {
   enableDesktopBluetooth: true,
   enableBTCFreshAddress: true,
   enableMenuBarTray: true,
+  hapticFeedbackEnabled: true,
   newBrowserTabPosition: 'bottom',
   useGasAccountByDefault: true,
 };

--- a/packages/kit/src/components/AccountSelector/hooks/useAccountSelectorTrigger.tsx
+++ b/packages/kit/src/components/AccountSelector/hooks/useAccountSelectorTrigger.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { Haptics } from '@onekeyhq/components';
 import type { IAccountSelectorRouteParamsExtraConfig } from '@onekeyhq/shared/src/routes';
 
 import useAppNavigation from '../../../hooks/useAppNavigation';
@@ -24,6 +25,7 @@ export function useAccountSelectorTrigger({
   const callAccountSelectorAction = useAccountSelectorLazyAction();
 
   const showAccountSelector = useCallback(() => {
+    Haptics.selection();
     void callAccountSelectorAction('showAccountSelector', {
       activeWallet: activeAccount.wallet,
       num,

--- a/packages/kit/src/provider/ThemeProvider.tsx
+++ b/packages/kit/src/provider/ThemeProvider.tsx
@@ -21,7 +21,8 @@ function logThemeProvider(message: string) {
 }
 
 function BasicThemeProvider({ children }: PropsWithChildren<unknown>) {
-  const [{ theme: themeSetting }] = useSettingsPersistAtom();
+  const [{ hapticFeedbackEnabled, theme: themeSetting }] =
+    useSettingsPersistAtom();
   const themeVariant = useThemeVariant();
   const localeVariant = useLocaleVariant();
   logThemeProvider(
@@ -44,13 +45,21 @@ function BasicThemeProvider({ children }: PropsWithChildren<unknown>) {
         theme={themeVariant as any}
         themeSetting={themeSetting}
         locale={localeVariant}
+        hapticFeedbackEnabled={hapticFeedbackEnabled ?? true}
         HyperlinkText={HyperlinkText}
         onLocaleChange={handleLocalChange}
       >
         {children}
       </ConfigProvider>
     );
-  }, [themeSetting, themeVariant, localeVariant, handleLocalChange, children]);
+  }, [
+    themeSetting,
+    themeVariant,
+    localeVariant,
+    hapticFeedbackEnabled,
+    handleLocalChange,
+    children,
+  ]);
 }
 
 export const ThemeProvider = memo(BasicThemeProvider);

--- a/packages/kit/src/views/Perp/layouts/PerpMobileLayout.tsx
+++ b/packages/kit/src/views/Perp/layouts/PerpMobileLayout.tsx
@@ -2,16 +2,13 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
-import {
-  type LayoutChangeEvent,
-  RefreshControl,
-  ScrollView,
-} from 'react-native';
+import { type LayoutChangeEvent, ScrollView } from 'react-native';
 
 import type { IModalNavigationProp } from '@onekeyhq/components';
 import {
   DebugRenderTracker,
   IconButton,
+  RefreshControl,
   SizableText,
   XStack,
   YStack,

--- a/packages/kit/src/views/Setting/pages/Tab/CustomElement.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/CustomElement.tsx
@@ -801,6 +801,25 @@ export function MenuBarTrayListItem(props: ICustomElementProps) {
   );
 }
 
+export function HapticFeedbackListItem(props: ICustomElementProps) {
+  const [{ hapticFeedbackEnabled }] = useSettingsPersistAtom();
+  const toggleHapticFeedback = useCallback((value: boolean) => {
+    startViewTransition(() => {
+      void backgroundApiProxy.serviceSetting.setHapticFeedbackEnabled(value);
+    });
+  }, []);
+  return (
+    <TabSettingsListItem {...props} userSelect="none">
+      <Switch
+        testID={SettingTestIDs.tabHapticFeedbackSwitch}
+        size={ESwitchSize.small}
+        value={hapticFeedbackEnabled ?? true}
+        onChange={toggleHapticFeedback}
+      />
+    </TabSettingsListItem>
+  );
+}
+
 export function BTCFreshAddressListItem(props: ICustomElementProps) {
   const [{ enableBTCFreshAddress }] = useSettingsPersistAtom();
   const toggleBTCFreshAddress = useCallback(async (value: boolean) => {

--- a/packages/kit/src/views/Setting/pages/Tab/config.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/config.tsx
@@ -67,6 +67,7 @@ import {
   ClearPendingTransactionsListItem,
   CurrencyListItem,
   DesktopBluetoothListItem,
+  HapticFeedbackListItem,
   HardwareTransportTypeListItem,
   LanguageListItem,
   ListVersionItem,
@@ -379,6 +380,17 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
                     id: ETranslations.settings_split_view_desc,
                   }),
                   renderElement: <SplitViewListItem />,
+                }
+              : undefined,
+          ],
+          [
+            platformEnv.isNative
+              ? {
+                  icon: 'HandPointerOutline',
+                  title: intl.formatMessage({
+                    id: ETranslations.global_vibration_haptic,
+                  }),
+                  renderElement: <HapticFeedbackListItem />,
                 }
               : undefined,
           ],

--- a/packages/kit/src/views/Setting/testIDs.ts
+++ b/packages/kit/src/views/Setting/testIDs.ts
@@ -60,6 +60,7 @@ export const SettingTestIDs = {
   tabUseGasAccountByDefaultSwitch:
     'setting-tab-use-gas-account-by-default-switch',
   tabSplitViewSwitch: 'setting-tab-split-view-switch',
+  tabHapticFeedbackSwitch: 'setting-tab-haptic-feedback-switch',
 
   // Dev split bundle test page
   devSplitBundleRefreshBtn: 'setting-dev-split-bundle-refresh-btn',

--- a/packages/kit/src/views/Swap/pages/components/SwapProContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProContainer.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { RefreshControl, ScrollView } from 'react-native';
+import { ScrollView } from 'react-native';
 
 import {
   IconButton,
+  RefreshControl,
   Skeleton,
   XStack,
   YStack,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-38010](https://onekeyhq.atlassian.net/browse/OK-38010)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- add a native Haptic Feedback preference that is enabled by default and persisted
- route app-managed haptics through a shared enable/disable gate
- make native tab feedback, account selection, and pull-to-refresh feedback respect the preference
- add unit coverage for enabled and disabled haptic behavior

## Why

Implements [OK-38010](https://onekeyhq.atlassian.net/browse/OK-38010) so native interactions provide consistent tactile feedback while still allowing users to turn it off globally.

## Impact

- Native platforms only
- New and existing users default to haptic feedback enabled
- Disabling the preference suppresses custom app haptics and native tab feedback

## Validation

- `yarn agent:check`
- `yarn tsc:only`
- `npx oxlint --type-aware <changed files>`
- `npx oxfmt --check <changed files>`
- `yarn jest packages/components/src/primitives/Haptics/index.native.test.ts --runInBand --coverage=false`
- `git diff --check`

[OK-38010]: https://onekeyhq.atlassian.net/browse/OK-38010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ