### PR TITLE
fix: improve keyless cloud backup flows

### DIFF
--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
@@ -20,6 +20,10 @@ const mockMigrationAtom = {
   get: jest.fn(),
   set: jest.fn(),
 };
+const mockDevSettingsAtom = {
+  get: jest.fn(),
+  set: jest.fn(),
+};
 
 jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
   backgroundClass: () => (target: unknown) => target,
@@ -79,10 +83,7 @@ jest.mock('../../states/jotai/atoms', () => ({
 }));
 
 jest.mock('../../states/jotai/atoms/devSettings', () => ({
-  devSettingsPersistAtom: {
-    get: jest.fn(async () => ({ enabled: false, settings: {} })),
-    set: jest.fn(),
-  },
+  devSettingsPersistAtom: mockDevSettingsAtom,
 }));
 
 jest.mock('../../endpoints', () => ({
@@ -326,6 +327,55 @@ function mockResetPinHappyPath(
 
   return resetBackendShareData;
 }
+
+beforeEach(() => {
+  mockDevSettingsAtom.get.mockResolvedValue({
+    enabled: false,
+    settings: {},
+  });
+});
+
+describe('ServiceKeylessWallet.apiResetKeylessBackendShare', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  test('requires the destructive Keyless reset developer setting', async () => {
+    const { service } = createService();
+
+    mockDevSettingsAtom.get.mockResolvedValue({
+      enabled: true,
+      settings: { allowDeleteKeylessKey: false },
+    });
+
+    await expect(
+      service.apiResetKeylessBackendShare({ token: TOKEN }),
+    ).rejects.toThrow('Keyless wallet reset is not allowed');
+  });
+
+  test('resets with the temporary OAuth token when explicitly allowed', async () => {
+    const { service, serviceAny } = createService();
+    const post = jest.fn(async () => ({
+      data: { code: 0, message: 'success' },
+    }));
+
+    mockDevSettingsAtom.get.mockResolvedValue({
+      enabled: true,
+      settings: { allowDeleteKeylessKey: true },
+    });
+    serviceAny.getClient = jest.fn(async () => ({ post }));
+    serviceAny.apiGetPinConfirmStatus = jest.fn(async () => undefined);
+
+    await expect(
+      service.apiResetKeylessBackendShare({ token: TOKEN }),
+    ).resolves.toEqual({ ok: true });
+    expect(post).toHaveBeenCalledWith(
+      '/prime/v1/keyless-wallet/resetKeylessBackendShare',
+      { token: TOKEN },
+    );
+  });
+});
 
 describe('ServiceKeylessWallet passive backend share v2 migration', () => {
   beforeEach(() => {

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -928,6 +928,9 @@ class ServiceKeylessWallet extends ServiceBase {
     if (!devSettings.enabled) {
       throw new OneKeyLocalError('Dev settings is not enabled');
     }
+    if (!devSettings.settings?.allowDeleteKeylessKey) {
+      throw new OneKeyLocalError('Keyless wallet reset is not allowed');
+    }
     const { token } = params;
     const client = await this.getClient(EServiceEndpointEnum.Prime);
     // /prime/v1/keyless-wallet/resetKeylessBackendShare

--- a/packages/kit/src/views/Onboardingv2/components/KeylessWalletBackupInfo.test.tsx
+++ b/packages/kit/src/views/Onboardingv2/components/KeylessWalletBackupInfo.test.tsx
@@ -1,0 +1,127 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+
+import { useKeylessWalletExistsLocal } from '@onekeyhq/kit/src/components/KeylessWallet/useKeylessWallet';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import { OnboardingTestIDs } from '../testIDs';
+
+import { KeylessWalletBackupInfo } from './KeylessWalletBackupInfo';
+
+const mockDialogShow = jest.fn();
+const mockFormatMessage = jest.fn();
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: (...args: unknown[]) => {
+      mockFormatMessage(...args);
+      return 'translated message';
+    },
+  }),
+}));
+
+jest.mock('@onekeyhq/components', () => ({
+  Dialog: {
+    show: (options: unknown) => {
+      mockDialogShow(options);
+    },
+  },
+  Icon: () => null,
+  SizableText: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  XStack: ({
+    children,
+    onPress,
+    testID,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    testID?: string;
+  }) => (
+    <button data-testid={testID} onClick={onPress} type="button">
+      {children}
+    </button>
+  ),
+  YStack: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock(
+  '@onekeyhq/kit/src/components/KeylessWallet/useKeylessWallet',
+  () => ({
+    useKeylessWalletExistsLocal: jest.fn(),
+  }),
+);
+
+describe('KeylessWalletBackupInfo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    platformEnv.isNativeIOS = false;
+    platformEnv.isNativeAndroid = false;
+    platformEnv.isDesktopMac = false;
+    jest.mocked(useKeylessWalletExistsLocal).mockReturnValue(true);
+  });
+
+  it('does not render without a local Keyless wallet', () => {
+    platformEnv.isNativeIOS = true;
+    jest.mocked(useKeylessWalletExistsLocal).mockReturnValue(false);
+
+    const { queryByTestId } = render(<KeylessWalletBackupInfo />);
+
+    expect(
+      queryByTestId(OnboardingTestIDs.iCloudBackupKeylessWalletHint),
+    ).toBeNull();
+  });
+
+  it('does not render on platforms without cloud backup support', () => {
+    const { queryByTestId } = render(<KeylessWalletBackupInfo />);
+
+    expect(
+      queryByTestId(OnboardingTestIDs.iCloudBackupKeylessWalletHint),
+    ).toBeNull();
+  });
+
+  it.each([
+    {
+      platform: 'Android',
+      isAndroid: true,
+      isIOS: false,
+      isMac: false,
+      provider: 'Google Drive',
+    },
+    {
+      platform: 'iOS',
+      isAndroid: false,
+      isIOS: true,
+      isMac: false,
+      provider: 'iCloud',
+    },
+    {
+      platform: 'macOS',
+      isAndroid: false,
+      isIOS: false,
+      isMac: true,
+      provider: 'iCloud',
+    },
+  ])(
+    'uses the complete cloud provider name on $platform',
+    ({ isAndroid, isIOS, isMac, provider }) => {
+      platformEnv.isNativeAndroid = isAndroid;
+      platformEnv.isNativeIOS = isIOS;
+      platformEnv.isDesktopMac = isMac;
+      const { getByTestId } = render(<KeylessWalletBackupInfo />);
+
+      fireEvent.click(
+        getByTestId(OnboardingTestIDs.iCloudBackupKeylessWalletHint),
+      );
+
+      expect(mockDialogShow).toHaveBeenCalledTimes(1);
+      expect(mockFormatMessage).toHaveBeenCalledWith(
+        { id: ETranslations.backup_keyless_no_cloud_google_desc },
+        { provider },
+      );
+    },
+  );
+});

--- a/packages/kit/src/views/Onboardingv2/components/KeylessWalletBackupInfo.tsx
+++ b/packages/kit/src/views/Onboardingv2/components/KeylessWalletBackupInfo.tsx
@@ -1,0 +1,92 @@
+import { useCallback } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import {
+  Dialog,
+  Icon,
+  SizableText,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
+import { useKeylessWalletExistsLocal } from '@onekeyhq/kit/src/components/KeylessWallet/useKeylessWallet';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import { OnboardingTestIDs } from '../testIDs';
+
+export function KeylessWalletBackupInfo() {
+  const intl = useIntl();
+  const isKeylessWalletExistsLocal = useKeylessWalletExistsLocal();
+  const isCloudBackupSupportedPlatform =
+    platformEnv.isNativeIOS ||
+    platformEnv.isNativeAndroid ||
+    platformEnv.isDesktopMac;
+
+  const handleShowDetails = useCallback(() => {
+    const provider = platformEnv.isNativeAndroid ? 'Google Drive' : 'iCloud';
+
+    Dialog.show({
+      testID: OnboardingTestIDs.iCloudBackupKeylessWalletDialog,
+      showHeader: false,
+      showFooter: false,
+      renderContent: (
+        <YStack alignItems="center" px="$3" pt="$8" pb="$8">
+          <Icon name="CloudOutline" size="$16" color="$iconSubdued" />
+          <SizableText
+            maxWidth="$80"
+            mt="$8"
+            size="$headingXl"
+            textAlign="center"
+          >
+            {intl.formatMessage({
+              id: ETranslations.backup_keyless_no_cloud_title,
+            })}
+          </SizableText>
+          <SizableText
+            maxWidth="$80"
+            mt="$4"
+            size="$bodyLg"
+            color="$textSubdued"
+            textAlign="center"
+          >
+            {intl.formatMessage(
+              { id: ETranslations.backup_keyless_no_cloud_google_desc },
+              { provider },
+            )}
+          </SizableText>
+        </YStack>
+      ),
+    });
+  }, [intl]);
+
+  if (!isCloudBackupSupportedPlatform || !isKeylessWalletExistsLocal) {
+    return null;
+  }
+
+  return (
+    <XStack
+      testID={OnboardingTestIDs.iCloudBackupKeylessWalletHint}
+      accessibilityRole="button"
+      cursor="pointer"
+      userSelect="none"
+      gap="$3"
+      alignItems="flex-start"
+      bg="$bgSubdued"
+      borderRadius="$4"
+      px="$4"
+      py="$3"
+      hoverStyle={{ bg: '$bgHover' }}
+      pressStyle={{ bg: '$bgActive' }}
+      onPress={handleShowDetails}
+    >
+      <Icon name="LockOutline" size="$5" color="$iconSubdued" mt="$0.5" />
+      <SizableText size="$bodyMd" color="$textSubdued" flex={1}>
+        {intl.formatMessage({
+          id: ETranslations.backup_keyless_not_in_cloud_hint,
+        })}
+      </SizableText>
+      <Icon name="InfoCircleOutline" size="$5" color="$iconSubdued" mt="$0.5" />
+    </XStack>
+  );
+}

--- a/packages/kit/src/views/Onboardingv2/hooks/useKeylessLocalExistenceLogin.test.tsx
+++ b/packages/kit/src/views/Onboardingv2/hooks/useKeylessLocalExistenceLogin.test.tsx
@@ -1,0 +1,144 @@
+/** @jest-environment jsdom */
+
+import { act, renderHook } from '@testing-library/react';
+
+import { EOAuthSocialLoginProvider } from '@onekeyhq/shared/src/consts/authConsts';
+
+import { useKeylessWallet } from '../../../components/KeylessWallet/useKeylessWallet';
+import { useOneKeyAuth } from '../../../components/OneKeyAuth/useOneKeyAuth';
+
+import { useKeylessLocalExistenceLogin } from './useKeylessLocalExistenceLogin';
+
+const mockCheckKeylessWalletLocalExistence = jest.fn();
+const mockLogout = jest.fn();
+const mockOnResetModeChange = jest.fn();
+const mockPersistKeylessOAuthSession = jest.fn();
+const mockSignInWithSocialLogin = jest.fn();
+const mockApiResetKeylessBackendShare = jest.fn();
+const mockGetIncomingKeylessOAuthSessionConflictInfo = jest.fn();
+const mockValidateTokenMatchesKeylessWallet = jest.fn();
+const mockToastSuccess = jest.fn();
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: () => 'translated message',
+  }),
+}));
+
+jest.mock('@onekeyhq/components', () => ({
+  Dialog: {
+    loading: jest.fn(),
+  },
+  Toast: {
+    success: (params: { title: string }) => {
+      mockToastSuccess(params);
+    },
+  },
+}));
+
+jest.mock('@onekeyhq/shared/src/logger/logger', () => ({
+  defaultLogger: {
+    account: {
+      wallet: {
+        onboard: jest.fn(),
+      },
+    },
+  },
+}));
+
+jest.mock('../../../background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceKeylessWallet: {
+      apiResetKeylessBackendShare: async (params: { token: string }) => {
+        mockApiResetKeylessBackendShare(params);
+        return { ok: true };
+      },
+      getIncomingKeylessOAuthSessionConflictInfo: async () => {
+        mockGetIncomingKeylessOAuthSessionConflictInfo();
+        return { hasConflict: false };
+      },
+      validateTokenMatchesKeylessWallet: async () => {
+        mockValidateTokenMatchesKeylessWallet();
+        return { isValid: true };
+      },
+    },
+  },
+}));
+
+jest.mock('../../../components/KeylessWallet/useKeylessWallet', () => ({
+  useKeylessWallet: jest.fn(),
+}));
+
+jest.mock('../../../components/OneKeyAuth/useOneKeyAuth', () => ({
+  useOneKeyAuth: jest.fn(),
+}));
+
+describe('useKeylessLocalExistenceLogin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useKeylessWallet).mockReturnValue({
+      checkKeylessWalletLocalExistence: mockCheckKeylessWalletLocalExistence,
+      enableKeylessWalletLoading: false,
+    } as unknown as ReturnType<typeof useKeylessWallet>);
+    jest.mocked(useOneKeyAuth).mockReturnValue({
+      logout: mockLogout,
+      persistKeylessOAuthSession: mockPersistKeylessOAuthSession,
+      signInWithSocialLogin: mockSignInWithSocialLogin,
+    } as unknown as ReturnType<typeof useOneKeyAuth>);
+    mockSignInWithSocialLogin.mockResolvedValue({
+      success: true,
+      session: {
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      },
+    });
+  });
+
+  it('resets the cloud keyless wallet without requiring a local keyless session', async () => {
+    const { result } = renderHook(() =>
+      useKeylessLocalExistenceLogin({
+        isResetMode: true,
+        onResetModeChange: mockOnResetModeChange,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleGoogleLogin();
+    });
+
+    expect(mockSignInWithSocialLogin).toHaveBeenCalledWith(
+      EOAuthSocialLoginProvider.Google,
+    );
+    expect(mockValidateTokenMatchesKeylessWallet).not.toHaveBeenCalled();
+    expect(
+      mockGetIncomingKeylessOAuthSessionConflictInfo,
+    ).not.toHaveBeenCalled();
+    expect(mockPersistKeylessOAuthSession).not.toHaveBeenCalled();
+    expect(mockLogout).not.toHaveBeenCalled();
+    expect(mockApiResetKeylessBackendShare).toHaveBeenCalledWith({
+      token: 'access-token',
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith({ title: 'Reset Success' });
+    expect(mockOnResetModeChange).toHaveBeenCalledWith(false);
+  });
+
+  it('keeps the regular create-or-restore flow unchanged', async () => {
+    const { result } = renderHook(() =>
+      useKeylessLocalExistenceLogin({ isResetMode: false }),
+    );
+
+    await act(async () => {
+      await result.current.handleAppleLogin();
+    });
+
+    expect(mockCheckKeylessWalletLocalExistence).toHaveBeenCalledWith({
+      signInProvider: EOAuthSocialLoginProvider.Apple,
+    });
+    expect(mockApiResetKeylessBackendShare).not.toHaveBeenCalled();
+    expect(mockSignInWithSocialLogin).not.toHaveBeenCalled();
+    expect(mockValidateTokenMatchesKeylessWallet).not.toHaveBeenCalled();
+    expect(mockPersistKeylessOAuthSession).not.toHaveBeenCalled();
+    expect(mockLogout).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kit/src/views/Onboardingv2/hooks/useKeylessLocalExistenceLogin.test.tsx
+++ b/packages/kit/src/views/Onboardingv2/hooks/useKeylessLocalExistenceLogin.test.tsx
@@ -109,6 +109,7 @@ describe('useKeylessLocalExistenceLogin', () => {
 
     expect(mockSignInWithSocialLogin).toHaveBeenCalledWith(
       EOAuthSocialLoginProvider.Google,
+      { persistSession: false },
     );
     expect(mockValidateTokenMatchesKeylessWallet).not.toHaveBeenCalled();
     expect(

--- a/packages/kit/src/views/Onboardingv2/hooks/useKeylessLocalExistenceLogin.ts
+++ b/packages/kit/src/views/Onboardingv2/hooks/useKeylessLocalExistenceLogin.ts
@@ -80,7 +80,9 @@ export function useKeylessLocalExistenceLogin({
           // session because the target cloud wallet may intentionally have no
           // corresponding local wallet. Keeping the token ephemeral also
           // avoids touching an active OneKey ID or Keyless session.
-          const result = await signInWithSocialLogin(provider);
+          const result = await signInWithSocialLogin(provider, {
+            persistSession: false,
+          });
           if (result?.session?.accessToken) {
             await backgroundApiProxy.serviceKeylessWallet.apiResetKeylessBackendShare(
               {

--- a/packages/kit/src/views/Onboardingv2/hooks/useKeylessLocalExistenceLogin.ts
+++ b/packages/kit/src/views/Onboardingv2/hooks/useKeylessLocalExistenceLogin.ts
@@ -5,16 +5,11 @@ import { useIntl } from 'react-intl';
 import type { IDialogInstance } from '@onekeyhq/components';
 import { Dialog, Toast } from '@onekeyhq/components';
 import { EOAuthSocialLoginProvider } from '@onekeyhq/shared/src/consts/authConsts';
-import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { getOAuthSocialLoginProviderName } from '@onekeyhq/shared/src/utils/oauthProviderUtils';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
-import {
-  showKeylessOneKeyIdSessionConflictDialog,
-  showKeylessWalletAccountMismatchError,
-} from '../../../components/KeylessWallet/AccountMismatchDialog';
 import { useKeylessWallet } from '../../../components/KeylessWallet/useKeylessWallet';
 import { useOneKeyAuth } from '../../../components/OneKeyAuth/useOneKeyAuth';
 
@@ -34,8 +29,7 @@ export function useKeylessLocalExistenceLogin({
   const intl = useIntl();
   const { enableKeylessWalletLoading, checkKeylessWalletLocalExistence } =
     useKeylessWallet();
-  const { logout, persistKeylessOAuthSession, signInWithSocialLogin } =
-    useOneKeyAuth();
+  const { signInWithSocialLogin } = useOneKeyAuth();
 
   const [loadingProvider, setLoadingProvider] =
     useState<EOAuthSocialLoginProvider | null>(null);
@@ -81,69 +75,13 @@ export function useKeylessLocalExistenceLogin({
           });
         }
         if (isResetMode) {
-          // Sign in WITHOUT persisting the OAuth session: there is a single
-          // shared keyless session slot, and persisting before validation
-          // would let a wrong-account session overwrite the active one
-          // (which may back the live OneKey ID login).
+          // This dev-only cloud reset authenticates with the fresh OAuth token
+          // itself. It must not require, validate, or persist a local Keyless
+          // session because the target cloud wallet may intentionally have no
+          // corresponding local wallet. Keeping the token ephemeral also
+          // avoids touching an active OneKey ID or Keyless session.
           const result = await signInWithSocialLogin(provider);
           if (result?.session?.accessToken) {
-            const { isValid } =
-              await backgroundApiProxy.serviceKeylessWallet.validateTokenMatchesKeylessWallet(
-                { token: result.session.accessToken },
-              );
-            if (!isValid) {
-              // The wrong-account session was never persisted, so the
-              // previously persisted keyless session stays intact and no
-              // cleanup is needed here.
-              const keylessWallet =
-                await backgroundApiProxy.serviceAccount.getKeylessWallet();
-              showKeylessWalletAccountMismatchError({
-                intl,
-                keylessProvider:
-                  keylessWallet?.keylessDetailsInfo?.keylessProvider,
-              });
-              throw new OneKeyLocalError(
-                intl.formatMessage({
-                  id: ETranslations.keyless_wallet_verify_pin_account_mismatch_desc,
-                }),
-              );
-            }
-            // The session matches the local keyless wallet, but it may still
-            // belong to a DIFFERENT account than the one backing the live
-            // OneKey ID login (single shared keyless session slot). Detect
-            // that BEFORE persisting; on conflict the user must explicitly
-            // confirm logging OneKey ID out (recoverable by re-login) — the
-            // keyless wallet itself is never logged out here.
-            const { hasConflict, currentOneKeyIdEmail } =
-              await backgroundApiProxy.serviceKeylessWallet.getIncomingKeylessOAuthSessionConflictInfo(
-                {
-                  incomingAccessToken: result.session.accessToken,
-                },
-              );
-            if (hasConflict) {
-              const confirmed = await showKeylessOneKeyIdSessionConflictDialog({
-                intl,
-                currentOneKeyIdEmail,
-              });
-              if (!confirmed) {
-                // Abort without persisting: the active OneKey ID session and
-                // its keyless slot stay fully intact.
-                throw new OneKeyLocalError({
-                  message: 'OneKey ID account switch cancelled by user',
-                  autoToast: false,
-                });
-              }
-              // Log out OneKey ID while preserving the keyless wallet and
-              // its local auth artifacts (bg resets the Prime persist atom +
-              // auth session source; the atom change syncs to main runtime).
-              await logout({ preserveLocalKeylessAuth: true });
-            }
-            // Persist the session only after validation passed, keeping the
-            // previous success-path behavior for downstream keyless flows.
-            await persistKeylessOAuthSession({
-              accessToken: result.session.accessToken,
-              refreshToken: result.session.refreshToken,
-            });
             await backgroundApiProxy.serviceKeylessWallet.apiResetKeylessBackendShare(
               {
                 token: result.session.accessToken,
@@ -168,9 +106,7 @@ export function useKeylessLocalExistenceLogin({
       checkKeylessWalletLocalExistence,
       intl,
       isResetMode,
-      logout,
       onResetModeChange,
-      persistKeylessOAuthSession,
       signInWithSocialLogin,
     ],
   );

--- a/packages/kit/src/views/Onboardingv2/pages/ICloudBackup.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ICloudBackup.tsx
@@ -42,6 +42,7 @@ import { CloudAccountBar } from '../components/CloudAccountBar';
 import { showCloudBackupPasswordDialog } from '../components/CloudBackupDialogs';
 import { CloudBackupListEmptyView } from '../components/CloudBackupEmptyView';
 import { CloudBackupLoadingSkeleton } from '../components/CloudBackupLoadingSkeleton';
+import { KeylessWalletBackupInfo } from '../components/KeylessWalletBackupInfo';
 import { OnboardingPage } from '../components/Layout';
 import { useCloudBackup } from '../hooks/useCloudBackup';
 import { OnboardingTestIDs } from '../testIDs';
@@ -103,7 +104,11 @@ export default function ICloudBackup() {
     }
 
     if (!allBackups?.items?.length) {
-      return <CloudBackupListEmptyView />;
+      return (
+        <YStack flex={1} justifyContent="center">
+          <CloudBackupListEmptyView />
+        </YStack>
+      );
     }
 
     return (
@@ -191,16 +196,19 @@ export default function ICloudBackup() {
       contentContainerProps={{ maxWidth: 480, gap: '$3', paddingVertical: 20 }}
     >
       <CloudAccountBar />
-      {renderContent()}
-      {showLegacyBackupsButton ? (
-        <Button
-          testID={OnboardingTestIDs.iCloudBackupViewOlderBackupsBtn}
-          size="large"
-          onPress={handleOpenLegacyBackups}
-        >
-          {intl.formatMessage({ id: ETranslations.view_older_backups })}
-        </Button>
-      ) : null}
+      <YStack flex={1} gap="$3">
+        {renderContent()}
+        {showLegacyBackupsButton ? (
+          <Button
+            testID={OnboardingTestIDs.iCloudBackupViewOlderBackupsBtn}
+            size="large"
+            onPress={handleOpenLegacyBackups}
+          >
+            {intl.formatMessage({ id: ETranslations.view_older_backups })}
+          </Button>
+        ) : null}
+        <KeylessWalletBackupInfo />
+      </YStack>
 
       <MultipleClickStack
         h="$10"

--- a/packages/kit/src/views/Onboardingv2/pages/ICloudBackupDetails.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ICloudBackupDetails.tsx
@@ -37,6 +37,7 @@ import { CloudAccountBar } from '../components/CloudAccountBar';
 import { showCloudBackupPasswordDialog } from '../components/CloudBackupDialogs';
 import { CloudBackupDetailsEmptyView } from '../components/CloudBackupEmptyView';
 import { CloudBackupLoadingSkeleton } from '../components/CloudBackupLoadingSkeleton';
+import { KeylessWalletBackupInfo } from '../components/KeylessWalletBackupInfo';
 import { OnboardingPage } from '../components/Layout';
 import { useCloudBackup } from '../hooks/useCloudBackup';
 import { OnboardingTestIDs } from '../testIDs';
@@ -334,7 +335,10 @@ export default function ICloudBackupDetails({
           </YStack>
         }
       />
-      <YStack {...(!gtMd && { mt: 'auto' })}>{actionButtons}</YStack>
+      <YStack {...(!gtMd && { mt: 'auto' })} gap="$3">
+        <KeylessWalletBackupInfo />
+        {actionButtons}
+      </YStack>
     </OnboardingPage>
   );
 }

--- a/packages/kit/src/views/Onboardingv2/testIDs.ts
+++ b/packages/kit/src/views/Onboardingv2/testIDs.ts
@@ -47,6 +47,9 @@ export const OnboardingTestIDs = {
   iCloudBackupPage: 'onboarding-icloud-backup-page',
   iCloudBackupViewOlderBackupsBtn:
     'onboarding-icloud-backup-view-older-backups-btn',
+  iCloudBackupKeylessWalletHint: 'onboarding-icloud-backup-keyless-wallet-hint',
+  iCloudBackupKeylessWalletDialog:
+    'onboarding-icloud-backup-keyless-wallet-dialog',
   iCloudBackupDevMockEmptyBtn: 'onboarding-icloud-backup-dev-mock-empty-btn',
   iCloudBackupDevClearPasswordBtn:
     'onboarding-icloud-backup-dev-clear-password-btn',


### PR DESCRIPTION
## Summary

- show a clickable Keyless wallet cloud-backup notice on both backup list and backup detail screens, including empty and populated states
- render the notice only when a local Keyless wallet exists and the platform supports cloud backup (iOS/macOS iCloud, Android Google Drive)
- add a details dialog explaining that Keyless wallet keys are not uploaded to the active cloud provider
- narrow the developer-only cloud Keyless reset path to use its fresh OAuth token without requiring or mutating a local Keyless/OneKey ID session
- explicitly disable OAuth session persistence for the reset flow
- enforce the destructive `allowDeleteKeylessKey` permission again in the background reset API

## Review fixes

- added background defense-in-depth so a main-runtime flag cannot bypass the deletion-specific developer setting
- made the ephemeral OAuth-session contract explicit instead of relying on the default option
- added UI coverage for local-Keyless gating, unsupported-platform gating, and Android/iOS/macOS provider names
- added background reset coverage for denied and explicitly allowed operations
- verified the real cloud backup payload filters out `wallet.isKeyless`

## i18n dependency before merge

Update `backup_keyless_no_cloud_google_desc` in Lokalise from `{provider} Drive` to `{provider}`. The code passes the complete provider name: `iCloud` on iOS/macOS and `Google Drive` on Android.

## Validation

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- `yarn jest packages/kit/src/views/Onboardingv2/components/KeylessWalletBackupInfo.test.tsx --runInBand` — 5 passed
- `yarn jest packages/kit/src/views/Onboardingv2/hooks/useKeylessLocalExistenceLogin.test.tsx --runInBand` — 2 passed
- `yarn jest packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts --runInBand` — 69 passed
- iOS physical-device runtime verification: iCloud backup details page and Keyless notice were mounted when a local Keyless wallet existed
