### PR TITLE
fix: reset OTA retry gate on cold restart

### DIFF
--- a/packages/kit-bg/src/services/ServiceAppUpdate.test.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.test.ts
@@ -2470,18 +2470,19 @@ describe('ServiceAppUpdate state transitions', () => {
       },
     );
 
-    // OCDS §5.11 end-to-end: a download that GAVE UP (persisted attempt budget
-    // exhausted → DownloadGaveUpError → downloadPackageFailed) must NOT suppress
-    // a future update. When a newer version arrives, the failed status recovers
-    // to notify (the user is re-prompted) AND the new target starts a fresh
-    // budget. This pins the guarantee that the give-up reuses the recoverable
-    // downloadPackageFailed status, not a special terminal state, and that a
-    // stale per-target give-up never blocks a newer version's download.
+    // OCDS §5.11 end-to-end: a download that GAVE UP (service-instance attempt
+    // budget exhausted → DownloadGaveUpError → downloadPackageFailed) must NOT
+    // suppress a future update. When a newer version arrives, the failed status
+    // recovers to notify (the user is re-prompted) AND the new target starts a
+    // fresh budget. This pins the guarantee that the give-up reuses the
+    // recoverable downloadPackageFailed status, not a special terminal state,
+    // and that a stale per-target give-up never blocks a newer version's
+    // download.
     test('a prior give-up does not suppress a NEWER version: failed→notify + fresh budget for the new target', async () => {
       const OLD_KEY = `${ATTEMPTED_VERSION}:appShell`;
       const NEW_KEY = `${NEWER_VERSION}:appShell`;
 
-      // (a) Reproduce the give-up's persisted effects for the OLD target:
+      // (a) Reproduce the give-up state for the OLD target:
       //     exhaust the per-target attempt budget (8 recorded attempts)…
       for (let i = 1; i <= 8; i += 1) {
         // eslint-disable-next-line no-await-in-loop

--- a/packages/kit-bg/src/services/ServiceAppUpdate.test.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.test.ts
@@ -39,11 +39,8 @@ const INITIAL_APP_UPDATE_VALUE: IAppUpdateInfo = {
 let atomValue: IAppUpdateInfo = { ...INITIAL_APP_UPDATE_VALUE };
 let pendingInstallTaskValue: any;
 
-// The OCDS §5.11 download-attempt budget persists under this MMKV key (see
-// ServiceAppUpdate). It must round-trip through a DURABLE, key-addressed store
-// so the cross-relaunch budget test below actually exercises persistence rather
-// than the single-slot pending-install fallback. Backed by a module-level Map
-// so values survive across createService() calls (= simulated relaunches).
+// Legacy MMKV key retained by ServiceAppUpdate only for stale-data cleanup.
+// The Map lets tests prove that stored values no longer drive the gate.
 const DOWNLOAD_ATTEMPT_BUDGET_KEY = 'onekey_app_update_download_attempt_budget';
 const syncStorageBackingMap = new Map<string, any>();
 function resetSyncStorageBackingMap() {
@@ -1203,12 +1200,19 @@ describe('ServiceAppUpdate state transitions', () => {
         status: EAppUpdateStatus.ready,
         downloadedEvent: { downloadedFile: '/tmp/old.zip' },
       });
+      for (let i = 1; i <= 8; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await service.recordDownloadAttempt({ targetKey: '1.0.0:10' });
+      }
 
       await service.clearCache();
 
       expect(AppUpdate.clearPackage).toHaveBeenCalled();
       expect(BundleUpdate.clearDownload).toHaveBeenCalled();
       expect(atomValue.status).toBe(EAppUpdateStatus.done);
+      await expect(
+        service.getDownloadAttemptBudget({ targetKey: '1.0.0:10' }),
+      ).resolves.toMatchObject({ attemptCount: 0, givenUp: false });
     });
 
     test('also rewrites lastUpdateDialogShownAt to 0 (re-arms the 24h dialog)', async () => {
@@ -3917,17 +3921,13 @@ describe('computeUpdateTargetKey consistency', () => {
   });
 
   // =========================================================================
-  // OCDS v1.1 §5.11 — persisted cross-restart download attempt budget.
-  // Proves the budget (a) persists to the durable key-addressed store across
-  // simulated relaunches (= fresh createService() while the backing Map
-  // survives), (b) goes terminal after N failures, and (c) resets to a fresh
-  // budget when a NEW bundle/app target version supersedes the old one.
+  // Service-instance download attempt budget.
   // =========================================================================
-  describe('download attempt budget (§5.11 persistence)', () => {
+  describe('in-memory download attempt budget', () => {
     const TARGET_A = '1.0.0:10';
     const TARGET_B = '1.1.0:11'; // a new bundle version
 
-    test('persists attempts across relaunches and goes terminal after the budget is spent', async () => {
+    test('allows eight real attempts, then resets on service restart', async () => {
       // Fresh: no record yet → not given up.
       const entry0 = await service.getDownloadAttemptBudget({
         targetKey: TARGET_A,
@@ -3935,47 +3935,39 @@ describe('computeUpdateTargetKey consistency', () => {
       expect(entry0.attemptCount).toBe(0);
       expect(entry0.givenUp).toBe(false);
 
-      // Simulate N relaunches, each recording exactly one attempt against the
-      // SAME target. Each relaunch is a brand-new service instance; only the
-      // durable backing Map carries state between them.
       let lastResult: any;
-      let relaunchService = service;
-      // DOWNLOAD_PERSISTED_MAX_ATTEMPTS is 8: attempts 1..7 keep going, attempt
-      // 8 trips the budget → terminal give-up.
       for (let i = 1; i <= 8; i += 1) {
         // eslint-disable-next-line no-await-in-loop
-        lastResult = await relaunchService.recordDownloadAttempt({
+        lastResult = await service.recordDownloadAttempt({
           targetKey: TARGET_A,
         });
         expect(lastResult.attemptCount).toBe(i);
-        if (i < 8) {
-          expect(lastResult.givenUp).toBe(false);
-        }
-        // New process: budget must survive even with a fresh service instance.
-        relaunchService = createService();
+        expect(lastResult.givenUp).toBe(false);
       }
 
-      // The 8th recorded attempt exhausts the persisted budget → terminal.
-      expect(lastResult.givenUp).toBe(true);
-      expect(lastResult.reason).toBe('maxAttempts');
-
-      // A subsequent entry check on yet another relaunch is ALSO terminal
-      // (scenario #9: no re-spending the in-memory budget on every launch).
-      const afterService = createService();
-      const entryAfter = await afterService.getDownloadAttemptBudget({
+      // recordDownloadAttempt runs immediately before the native operation, so
+      // attempt 8 remains allowed. The next entry check blocks attempt 9.
+      const entryAfter = await service.getDownloadAttemptBudget({
         targetKey: TARGET_A,
       });
       expect(entryAfter.givenUp).toBe(true);
       expect(entryAfter.reason).toBe('maxAttempts');
+
+      syncStorageBackingMap.set(DOWNLOAD_ATTEMPT_BUDGET_KEY, entryAfter);
+      const restartedService = createService();
+      const restartedEntry = await restartedService.getDownloadAttemptBudget({
+        targetKey: TARGET_A,
+      });
+      expect(restartedEntry.attemptCount).toBe(0);
+      expect(restartedEntry.givenUp).toBe(false);
     });
 
     test('a NEW bundle/app target version resets the counter to a fresh budget', async () => {
       // Spend the whole budget on target A → terminal.
-      let svc = service;
+      const svc = service;
       for (let i = 1; i <= 8; i += 1) {
         // eslint-disable-next-line no-await-in-loop
         await svc.recordDownloadAttempt({ targetKey: TARGET_A });
-        svc = createService();
       }
       const aTerminal = await svc.getDownloadAttemptBudget({
         targetKey: TARGET_A,
@@ -4102,7 +4094,7 @@ describe('computeUpdateTargetKey consistency', () => {
     test('a long idle gap does NOT give up — only the attempt count matters (resume-friendly)', async () => {
       const now = 1_000_000_000_000;
       jest.setSystemTime(now);
-      // A couple of failed attempts, then the user closes the app.
+      // A couple of failed attempts, then the app remains idle.
       await service.recordDownloadAttempt({ targetKey: TARGET_A });
       const second = await service.recordDownloadAttempt({
         targetKey: TARGET_A,
@@ -4110,35 +4102,30 @@ describe('computeUpdateTargetKey consistency', () => {
       expect(second.attemptCount).toBe(2);
       expect(second.givenUp).toBe(false);
 
-      // Reopen 30 days later — far past the old 24h wall-clock deadline. Idle
-      // (app-closed) time must NOT abandon a still-resumable partial: with the
-      // attempt count under the cap the budget is NOT given up, so the download
-      // can resume. (There is intentionally no wall-clock deadline.)
+      // Idle time must not abandon a still-resumable partial; only actual
+      // attempts spend the service instance's budget.
       jest.setSystemTime(now + 30 * 24 * 60 * 60 * 1000);
-      const relaunch = createService();
-      const entry = await relaunch.getDownloadAttemptBudget({
+      const entry = await service.getDownloadAttemptBudget({
         targetKey: TARGET_A,
       });
       expect(entry.givenUp).toBe(false);
       expect(entry.attemptCount).toBe(2);
     });
 
-    test('resetDownloadAttemptBudget clears the persisted give-up (success path)', async () => {
+    test('resetDownloadAttemptBudget clears the in-memory give-up', async () => {
       // Exhaust the budget.
-      let svc = service;
+      const svc = service;
       for (let i = 1; i <= 8; i += 1) {
         // eslint-disable-next-line no-await-in-loop
         await svc.recordDownloadAttempt({ targetKey: TARGET_A });
-        svc = createService();
       }
       expect(
         (await svc.getDownloadAttemptBudget({ targetKey: TARGET_A })).givenUp,
       ).toBe(true);
 
-      // A successful download resets the budget; the next relaunch is fresh.
+      // A successful download resets the current service instance's budget.
       await svc.resetDownloadAttemptBudget({ targetKey: TARGET_A });
-      const fresh = createService();
-      const entry = await fresh.getDownloadAttemptBudget({
+      const entry = await svc.getDownloadAttemptBudget({
         targetKey: TARGET_A,
       });
       expect(entry.attemptCount).toBe(0);

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -78,22 +78,13 @@ const FAILED_RECOVERY_FREEZE_MS = 24 * 60 * 60 * 1000; // 24 h
 const FAILED_RECOVERY_IGNORE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 d
 
 // ---------------------------------------------------------------------------
-// OCDS v1.1 §5.11 — cross-restart download attempt budget
+// Download attempt budget
 // ---------------------------------------------------------------------------
 // The in-memory retry loop (updateRetry.ts) bounds attempts WITHIN a single
-// invocation. §5.11 additionally requires a bound that PERSISTS across process
-// restarts, so a permanently-failing object cannot re-spend the full budget on
-// every launch and loop forever (conformance scenario #9). We persist a small
-// counter keyed by the target version to durable MMKV (syncStorage). When the
-// attempt count is exhausted, the download reaches a definitive terminal "gave
-// up" outcome.
-//
-// Persistence is keyed by the target version so a NEW bundle/app release starts
-// with a fresh budget — we never carry a stale give-up into a fresh release.
-//
-// Stored in the onekey-app-setting MMKV instance (syncStorage). The key string
-// is local to this service; the enum cast keeps the typed wrapper happy without
-// editing the shared key enum.
+// invocation. This service-instance counter adds a bound across invocations,
+// while a cold restart creates a new service instance and a fresh budget.
+// Keep the former storage key only so reset can remove stale MMKV data written
+// by an earlier bundle; it is never read or written by the gate.
 const DOWNLOAD_ATTEMPT_BUDGET_STORAGE_KEY =
   'onekey_app_update_download_attempt_budget';
 // Persisted give-up threshold. Distinct from updateRetry's in-memory
@@ -156,6 +147,8 @@ class ServiceAppUpdate extends ServiceBase {
   updateAt = 0;
 
   cachedUpdateInfo: IResponseAppUpdateInfo | undefined;
+
+  private downloadAttemptBudget: IDownloadAttemptBudgetRecord | undefined;
 
   private get pendingInstallTaskService() {
     const service = this.backgroundApi.servicePendingInstallTask;
@@ -840,12 +833,11 @@ class ServiceAppUpdate extends ServiceBase {
   }
 
   // -------------------------------------------------------------------------
-  // OCDS v1.1 §5.11 — persisted cross-restart attempt budget. See the
-  // constants block at the top of this file.
+  // Service-instance attempt budget. See the constants block above.
   // -------------------------------------------------------------------------
 
-  // The typed syncStorage wrapper keys on EAppSyncStorageKeys; the budget uses
-  // a service-local key string, so cast at the single read/write boundary.
+  // The typed syncStorage wrapper keys on EAppSyncStorageKeys; cast the legacy
+  // service-local key at the cleanup boundary.
   private get downloadAttemptBudgetStorageKey(): EAppSyncStorageKeys {
     return DOWNLOAD_ATTEMPT_BUDGET_STORAGE_KEY as EAppSyncStorageKeys;
   }
@@ -853,30 +845,29 @@ class ServiceAppUpdate extends ServiceBase {
   private readDownloadAttemptBudget():
     | IDownloadAttemptBudgetRecord
     | undefined {
-    return appStorage.syncStorage.getObject<IDownloadAttemptBudgetRecord>(
-      this.downloadAttemptBudgetStorageKey,
-    );
+    return this.downloadAttemptBudget;
   }
 
   private writeDownloadAttemptBudget(record: IDownloadAttemptBudgetRecord) {
-    appStorage.syncStorage.setObject(
-      this.downloadAttemptBudgetStorageKey,
-      record,
-    );
+    this.downloadAttemptBudget = record;
   }
 
   private evaluateDownloadBudget(
     record: IDownloadAttemptBudgetRecord,
+    options?: { allowRecordedAttempt?: boolean },
   ): IDownloadAttemptBudgetResult {
-    // Give up purely on the persisted attempt count. We deliberately do NOT
+    // Give up purely on the in-memory attempt count. We deliberately do NOT
     // impose a wall-clock deadline: it would be calendar time measured from the
     // first attempt, so a user who downloaded part of an update and reopened the
     // app days later would be denied the (still valid) resume — idle time must
     // not count against a resumable download. Attempts only ever accrue on real
     // failures, so the count alone bounds a permanently-failing target without
     // punishing legitimate idle gaps. `firstAttemptAt` is retained for telemetry.
-    const attemptsExceeded =
-      record.attemptCount >= DOWNLOAD_PERSISTED_MAX_ATTEMPTS;
+    // recordDownloadAttempt runs before the native operation. Let attempt 8
+    // run; entry checks (and attempt 9) then see an exhausted budget.
+    const attemptsExceeded = options?.allowRecordedAttempt
+      ? record.attemptCount > DOWNLOAD_PERSISTED_MAX_ATTEMPTS
+      : record.attemptCount >= DOWNLOAD_PERSISTED_MAX_ATTEMPTS;
     return {
       targetKey: record.targetKey,
       attemptCount: record.attemptCount,
@@ -908,7 +899,7 @@ class ServiceAppUpdate extends ServiceBase {
     const version = nativeAppVersion || platformEnv.version || 'unknown';
     const buildNumber =
       nativeBuildNumber || platformEnv.buildNumber || 'unknown';
-    // Desktop must always write a stable key. Returning undefined here makes a
+    // Desktop must always record a stable key. Returning undefined here makes a
     // transient native-info failure ambiguous: a later successful read can
     // either erase the same runtime's budget or inherit an older runtime's
     // exhausted budget. Build-time values are stable per installed shell and
@@ -917,10 +908,8 @@ class ServiceAppUpdate extends ServiceBase {
   }
 
   /**
-   * Read the persisted budget for `targetKey` WITHOUT mutating it. The caller
-   * checks `givenUp` on entry (before starting a download) so a target that
-   * already exhausted its budget on a prior launch is terminal immediately and
-   * never re-spends the in-memory retry budget (OCDS §5.11, scenario #9).
+   * Read the current service instance's budget for `targetKey` without
+   * mutating it. The caller checks `givenUp` before starting a download.
    *
    * A record belonging to a DIFFERENT target version is treated as absent: a
    * new release starts fresh, never inheriting a stale give-up.
@@ -949,7 +938,7 @@ class ServiceAppUpdate extends ServiceBase {
   }
 
   /**
-   * Increment and persist the attempt counter for `targetKey`, then return the
+   * Increment the in-memory attempt counter for `targetKey`, then return the
    * post-increment budget state. Called once per download attempt. The first
    * attempt for a target stamps `firstAttemptAt` (retained for telemetry only;
    * there is no wall-clock deadline). A record for a different target version is
@@ -977,7 +966,9 @@ class ServiceAppUpdate extends ServiceBase {
       nativeRuntimeKey: nativeRuntimeKey ?? base.nativeRuntimeKey,
     };
     this.writeDownloadAttemptBudget(next);
-    const result = this.evaluateDownloadBudget(next);
+    const result = this.evaluateDownloadBudget(next, {
+      allowRecordedAttempt: true,
+    });
     if (result.givenUp) {
       defaultLogger.app.appUpdate.log(
         `recordDownloadAttempt: budget exhausted target=${targetKey} attempts=${next.attemptCount} reason=${
@@ -989,7 +980,7 @@ class ServiceAppUpdate extends ServiceBase {
   }
 
   /**
-   * Clear the persisted attempt budget. Called on a successful download or
+   * Clear the in-memory attempt budget. Called on a successful download or
    * when a new target version supersedes the prior one, so the give-up state
    * never outlives the target it was recorded for.
    */
@@ -1000,12 +991,15 @@ class ServiceAppUpdate extends ServiceBase {
     const targetKey = params?.targetKey;
     if (targetKey) {
       const existing = this.readDownloadAttemptBudget();
-      // Only clear when the persisted record matches the target being reset,
+      // Only clear when the in-memory record matches the target being reset,
       // so an unrelated in-flight target's budget is left intact.
       if (existing && existing.targetKey !== targetKey) {
         return;
       }
     }
+    this.downloadAttemptBudget = undefined;
+    // Remove a stale record written by an earlier bundle. The gate never reads
+    // or writes this MMKV key.
     appStorage.syncStorage.delete(this.downloadAttemptBudgetStorageKey);
   }
 
@@ -1458,6 +1452,7 @@ class ServiceAppUpdate extends ServiceBase {
   @backgroundMethod()
   public async clearCache() {
     clearTimeout(downloadTimeoutId);
+    await this.resetDownloadAttemptBudget();
     await AppUpdate.clearPackage();
     await BundleUpdate.clearDownload();
     await this.backgroundApi.servicePendingInstallTask.clearPendingInstallTask();

--- a/packages/kit-bg/src/services/ServiceAppUpdate.ts
+++ b/packages/kit-bg/src/services/ServiceAppUpdate.ts
@@ -87,11 +87,11 @@ const FAILED_RECOVERY_IGNORE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 d
 // by an earlier bundle; it is never read or written by the gate.
 const DOWNLOAD_ATTEMPT_BUDGET_STORAGE_KEY =
   'onekey_app_update_download_attempt_budget';
-// Persisted give-up threshold. Distinct from updateRetry's in-memory
-// per-invocation cap: this counts total attempts across relaunches. There is
-// intentionally NO wall-clock deadline — idle time (app closed) must not
-// abandon a still-resumable partial; see evaluateDownloadBudget.
-const DOWNLOAD_PERSISTED_MAX_ATTEMPTS = 8;
+// Service-instance give-up threshold. Distinct from updateRetry's
+// per-invocation cap: this counts attempts across retry-loop invocations within
+// one bg service instance. A cold restart creates a fresh budget. There is no
+// wall-clock deadline because idle time must not abandon a resumable partial.
+const DOWNLOAD_INSTANCE_MAX_ATTEMPTS = 8;
 
 interface IDownloadAttemptBudgetRecord {
   targetKey: string;
@@ -104,8 +104,8 @@ export interface IDownloadAttemptBudgetResult {
   targetKey: string;
   attemptCount: number;
   firstAttemptAt: number;
-  // True once the persisted attempt count is exhausted: the caller must stop
-  // retrying and surface a terminal outcome.
+  // True once the service-instance attempt count is exhausted: the caller must
+  // stop retrying and surface a terminal outcome.
   givenUp: boolean;
   // Populated when givenUp, for the terminal reason.
   reason?: 'maxAttempts';
@@ -866,8 +866,8 @@ class ServiceAppUpdate extends ServiceBase {
     // recordDownloadAttempt runs before the native operation. Let attempt 8
     // run; entry checks (and attempt 9) then see an exhausted budget.
     const attemptsExceeded = options?.allowRecordedAttempt
-      ? record.attemptCount > DOWNLOAD_PERSISTED_MAX_ATTEMPTS
-      : record.attemptCount >= DOWNLOAD_PERSISTED_MAX_ATTEMPTS;
+      ? record.attemptCount > DOWNLOAD_INSTANCE_MAX_ATTEMPTS
+      : record.attemptCount >= DOWNLOAD_INSTANCE_MAX_ATTEMPTS;
     return {
       targetKey: record.targetKey,
       attemptCount: record.attemptCount,

--- a/packages/kit/src/components/AppUpdate/updateRetry.test.ts
+++ b/packages/kit/src/components/AppUpdate/updateRetry.test.ts
@@ -1,10 +1,8 @@
-// OCDS v1.1 §5.11 — focused unit tests for the cross-restart download retry /
-// give-up loop (`runDownloadWithRetry`). The persistence half (the durable
-// per-target budget) is tested in kit-bg's ServiceAppUpdate.test.ts; this file
-// pins the LOOP contract: it honours the injected budget hooks, accumulates the
-// persisted counter across simulated relaunches (= separate runDownloadWithRetry
-// calls sharing one store), goes terminal with a DownloadGaveUpError, and resets
-// on success.
+// OCDS v1.1 §5.11 — focused unit tests for the download retry / give-up loop
+// (`runDownloadWithRetry`). The service-instance budget is tested in kit-bg's
+// ServiceAppUpdate.test.ts; this file pins the loop contract: it honors the
+// injected budget hooks, shares the counter across retry-loop invocations,
+// goes terminal with a DownloadGaveUpError, and resets on success.
 //
 // The one heavy dependency (`@onekeyhq/components/.../useNetInfo`) and the
 // backoff timer are mocked so this runs in milliseconds and never resolves the
@@ -32,9 +30,8 @@ jest.mock('@onekeyhq/shared/src/logger/logger', () => ({
 // retries it up to DOWNLOAD_RETRY_MAX_ATTEMPTS.
 const transientError = () => new Error('network blip');
 
-// Persisted budget hooks backed by a shared in-memory store. The store survives
-// across separate runDownloadWithRetry() calls — that IS the cross-restart
-// semantics (a relaunch is a fresh call against the same durable store).
+// Budget hooks backed by a shared in-memory store, modeling multiple
+// runDownloadWithRetry() calls within one bg service instance.
 function budgetHooks(
   store: { count: number },
   maxAttempts: number,
@@ -53,7 +50,7 @@ function budgetHooks(
   };
 }
 
-describe('runDownloadWithRetry — OCDS §5.11 cross-restart budget', () => {
+describe('runDownloadWithRetry — OCDS §5.11 service-instance budget', () => {
   test('entry guard: an already-exhausted budget is terminal without running the operation', async () => {
     const store = { count: 8 }; // already at the cap on entry
     const op = jest.fn(async () => 'ok');
@@ -63,23 +60,22 @@ describe('runDownloadWithRetry — OCDS §5.11 cross-restart budget', () => {
     expect(op).not.toHaveBeenCalled();
   });
 
-  test('accumulates the persisted counter across relaunches and goes terminal at the cap', async () => {
+  test('accumulates the counter across retry-loop invocations and goes terminal at the cap', async () => {
     const store = { count: 0 };
     const op = jest.fn(async () => {
       throw transientError();
     });
 
-    // Relaunch #1: the in-memory loop spends 6 attempts (0..MAX), each recording
-    // one persisted attempt. The cap (8) is not yet hit, so it ends by throwing
-    // the RAW transport error — NOT a give-up.
+    // Invocation #1 spends 6 attempts (0..MAX), each recorded in the shared
+    // service-instance budget. The cap (8) is not yet hit, so it ends by
+    // throwing the raw transport error rather than a give-up.
     await expect(
       runDownloadWithRetry(op, 'ctx', budgetHooks(store, 8)),
     ).rejects.not.toBeInstanceOf(DownloadGaveUpError);
     expect(store.count).toBe(6);
 
-    // Relaunch #2: the persisted counter resumes at 6; the 8th recorded attempt
-    // trips the cap → a definitive DownloadGaveUpError('maxAttempts'). No
-    // infinite loop across launches (scenario #9).
+    // Invocation #2 resumes at 6; the 8th recorded attempt trips the cap and
+    // produces a definitive DownloadGaveUpError('maxAttempts').
     let caught: unknown;
     try {
       await runDownloadWithRetry(op, 'ctx', budgetHooks(store, 8));
@@ -91,7 +87,7 @@ describe('runDownloadWithRetry — OCDS §5.11 cross-restart budget', () => {
     expect(store.count).toBe(8);
   });
 
-  test('success clears the persisted budget so the next target starts fresh', async () => {
+  test('success clears the service-instance budget so the next target starts fresh', async () => {
     const store = { count: 0 };
     let calls = 0;
     const op = jest.fn(async () => {

--- a/packages/kit/src/components/AppUpdate/updateRetry.ts
+++ b/packages/kit/src/components/AppUpdate/updateRetry.ts
@@ -98,11 +98,10 @@ async function waitBeforeRetry(
 
 /**
  * OCDS v1.1 §5.11 — definitive terminal "gave up" outcome. Thrown when the
- * persisted cross-restart attempt budget or the overall wall-clock deadline is
- * exhausted, OR when a single-stream fallback failure is treated as the
- * download's terminal failure. Distinct from the underlying transport error so
- * the caller can surface "we have stopped retrying" rather than a transient
- * network blip.
+ * configured attempt budget or deadline is exhausted, OR when a single-stream
+ * fallback failure is treated as the download's terminal failure. Distinct from
+ * the underlying transport error so the caller can surface "we have stopped
+ * retrying" rather than a transient network blip.
  */
 export type IDownloadGaveUpReason =
   | 'maxAttempts'
@@ -131,21 +130,20 @@ export class DownloadGaveUpError extends OneKeyLocalError {
 }
 
 /**
- * Per-target persisted-budget hooks (OCDS §5.11). Owned by ServiceAppUpdate
+ * Per-target attempt-budget hooks (OCDS §5.11). Owned by ServiceAppUpdate
  * (kit-bg) and injected here so this module stays pure / unit-testable. When a
- * caller does not supply them, the loop runs with the legacy in-memory bound
- * only (no cross-restart persistence) — used by existing tests.
+ * caller does not supply them, the loop uses only its per-invocation retry cap.
  */
 export interface IDownloadRetryBudgetResult {
   givenUp: boolean;
   reason?: 'maxAttempts' | 'deadline';
 }
 export interface IDownloadRetryOptions {
-  // Read the persisted budget WITHOUT mutating it (checked on entry).
+  // Read the current budget without mutating it (checked on entry).
   getBudget?: () => Promise<IDownloadRetryBudgetResult>;
-  // Increment + persist the attempt counter; returns the post-increment state.
+  // Increment the attempt counter; returns the post-increment state.
   recordAttempt?: () => Promise<IDownloadRetryBudgetResult>;
-  // Clear the persisted budget (on success).
+  // Clear the attempt budget on success.
   resetBudget?: () => Promise<void>;
   // OCDS §4 — obtain a fresh signed URL after a 401/403 (permanent-this-URL).
   // Returns true if a fresh URL is now available to retry against, false if
@@ -197,34 +195,34 @@ export function isSingleStreamFallbackFailure(error: unknown): boolean {
  * 401/403/404/410/501/505, config errors) so we don't waste backoff windows on
  * deterministic dead states.
  *
- * OCDS v1.1 §5.11 termination contract (active only when `options` carries the
- * persisted-budget hooks — kit-bg's ServiceAppUpdate provides them):
- *   - On entry, if the persisted cross-restart budget is already exhausted the
- *     download is terminal immediately (no in-memory retry budget re-spend).
- *   - Each attempt increments the persisted counter; when the counter or the
- *     wall-clock deadline trips, the loop ends with a DownloadGaveUpError.
+ * OCDS v1.1 §5.11 termination contract (active only when `options` carries
+ * attempt-budget hooks — kit-bg's ServiceAppUpdate provides them):
+ *   - On entry, if the service-instance budget is already exhausted, the
+ *     download is terminal immediately.
+ *   - Each attempt increments the budget; when the counter or a caller-supplied
+ *     deadline trips, the loop ends with a DownloadGaveUpError.
  *   - A 401/403 (permanent-this-URL) triggers a single bounded URL refresh and
  *     one more attempt against the freshly-signed URL before going terminal.
- *   - On success the persisted budget is reset.
+ *   - On success the attempt budget is reset.
  */
 export async function runDownloadWithRetry<T>(
   operation: () => Promise<T>,
   context: string,
   options?: IDownloadRetryOptions,
 ): Promise<T> {
-  // §5.11 entry guard: a target that already exhausted its budget on a prior
-  // launch is terminal before we spend a single in-memory attempt.
+  // §5.11 entry guard: a target that already exhausted the current service
+  // instance's budget is terminal before we run another download attempt.
   if (options?.getBudget) {
     const entry = await options.getBudget();
     if (entry.givenUp) {
       defaultLogger.app.appUpdate.log(
-        `${context}: persisted budget already exhausted on entry reason=${
+        `${context}: attempt budget already exhausted on entry reason=${
           entry.reason ?? ''
         } — terminal`,
       );
       throw new DownloadGaveUpError({
         reason: entry.reason ?? 'maxAttempts',
-        message: `${context}: download gave up (persisted ${
+        message: `${context}: download gave up (budget ${
           entry.reason ?? 'maxAttempts'
         })`,
       });
@@ -235,20 +233,20 @@ export async function runDownloadWithRetry<T>(
   let urlRefreshed = false;
 
   for (let attempt = 0; attempt <= DOWNLOAD_RETRY_MAX_ATTEMPTS; attempt += 1) {
-    // §5.11 — record this attempt in durable storage BEFORE running it so a
-    // crash mid-attempt still counts toward the budget on the next launch.
+    // §5.11 — record before running so every native operation counts against
+    // the current service instance's attempt budget.
     if (options?.recordAttempt) {
       // eslint-disable-next-line no-await-in-loop
       const budget = await options.recordAttempt();
       if (budget.givenUp) {
         defaultLogger.app.appUpdate.log(
-          `${context}: persisted budget exhausted reason=${
+          `${context}: attempt budget exhausted reason=${
             budget.reason ?? ''
           } — terminal`,
         );
         throw new DownloadGaveUpError({
           reason: budget.reason ?? 'maxAttempts',
-          message: `${context}: download gave up (persisted ${
+          message: `${context}: download gave up (budget ${
             budget.reason ?? 'maxAttempts'
           })`,
         });
@@ -257,8 +255,8 @@ export async function runDownloadWithRetry<T>(
     try {
       // eslint-disable-next-line no-await-in-loop
       const result = await operation();
-      // §5.11 — success clears the persisted budget so the next target starts
-      // fresh and a stale give-up never lingers.
+      // §5.11 — success clears the attempt budget so the next target starts
+      // fresh and a stale give-up does not linger in this service instance.
       if (options?.resetBudget) {
         // eslint-disable-next-line no-await-in-loop
         await options.resetBudget().catch(() => undefined);

--- a/packages/kit/src/components/AppUpdate/useAppUpdate.test.ts
+++ b/packages/kit/src/components/AppUpdate/useAppUpdate.test.ts
@@ -44,7 +44,7 @@ jest.mock('../../background/instance/backgroundApiProxy', () => {
     updateLastDialogShownAt: jest.fn(),
     setCurrentUpdateAttemptId: jest.fn(),
     pruneStaleArtifacts: jest.fn().mockResolvedValue(undefined),
-    // OCDS §5.11 persisted-budget hooks (now wired into downloadPackage).
+    // OCDS §5.11 attempt-budget hooks wired into downloadPackage.
     getDownloadAttemptBudget: jest.fn().mockResolvedValue({ givenUp: false }),
     recordDownloadAttempt: jest.fn().mockResolvedValue({ givenUp: false }),
     resetDownloadAttemptBudget: jest.fn().mockResolvedValue(undefined),
@@ -386,8 +386,8 @@ function resetAllMocks() {
   svc.verifyPackageFailed.mockResolvedValue(undefined);
   svc.readyToInstall.mockResolvedValue(undefined);
   svc.updateDownloadedEvent.mockResolvedValue(undefined);
-  // OCDS §5.11 persisted-budget hooks: default to a fresh (non-exhausted)
-  // budget so download tests proceed; give-up cases override per-test.
+  // OCDS §5.11 attempt-budget hooks default to a fresh budget so download
+  // tests proceed; give-up cases override per test.
   svc.getDownloadAttemptBudget.mockResolvedValue({ givenUp: false });
   svc.recordDownloadAttempt.mockResolvedValue({ givenUp: false });
   svc.resetDownloadAttemptBudget.mockResolvedValue(undefined);
@@ -653,10 +653,10 @@ describe('runDownloadWithRetry', () => {
   });
 
   // -----------------------------------------------------------------------
-  // OCDS v1.1 §5.11 — persisted cross-restart budget + terminal outcomes.
-  // The budget hooks model ServiceAppUpdate's persisted MMKV counter.
+  // OCDS v1.1 §5.11 — service-instance budget and terminal outcomes.
+  // The hooks model ServiceAppUpdate's in-memory counter.
   // -----------------------------------------------------------------------
-  test('entry guard: already-exhausted persisted budget is terminal without any attempt', async () => {
+  test('entry guard: an exhausted service-instance budget is terminal without any attempt', async () => {
     const op = jest.fn().mockResolvedValue('ok');
     const options: IDownloadRetryOptions = {
       getBudget: jest
@@ -674,14 +674,14 @@ describe('runDownloadWithRetry', () => {
     expect(options.recordAttempt).not.toHaveBeenCalled();
   });
 
-  test('records each attempt and goes terminal when the persisted counter trips', async () => {
+  test('records each attempt and goes terminal when the service-instance counter trips', async () => {
     const op = jest.fn().mockRejectedValue(new Error('NSURLErrorDomain -1009'));
     let calls = 0;
     const options: IDownloadRetryOptions = {
       getBudget: jest.fn().mockResolvedValue({ givenUp: false }),
       recordAttempt: jest.fn().mockImplementation(() => {
         calls += 1;
-        // Trip the persisted budget on the 3rd recorded attempt.
+        // Trip the service-instance budget on the 3rd recorded attempt.
         return Promise.resolve(
           calls >= 3
             ? { givenUp: true, reason: 'deadline' }
@@ -703,7 +703,7 @@ describe('runDownloadWithRetry', () => {
     expect(options.recordAttempt).toHaveBeenCalledTimes(3);
   });
 
-  test('success resets the persisted budget', async () => {
+  test('success resets the service-instance budget', async () => {
     const op = jest.fn().mockResolvedValue('ok');
     const resetBudget = jest.fn().mockResolvedValue(undefined);
     const options: IDownloadRetryOptions = {
@@ -1210,13 +1210,13 @@ describe('useDownloadPackage', () => {
       expect(svc.downloadASC).toHaveBeenCalled();
     });
 
-    test('OCDS §5.11: an exhausted persisted budget gives up without re-downloading (wired)', async () => {
+    test('OCDS §5.11: an exhausted service-instance budget gives up without re-downloading', async () => {
       svc.getUpdateInfo.mockResolvedValue({
         latestVersion: '2.0.0',
         downloadUrl: 'https://example.com/app.zip',
         updateStrategy: EUpdateStrategy.manual,
       });
-      // The persisted cross-restart budget for this target is already spent.
+      // The current bg service instance has spent this target's budget.
       svc.getDownloadAttemptBudget.mockResolvedValue({
         givenUp: true,
         reason: 'maxAttempts',
@@ -1227,13 +1227,13 @@ describe('useDownloadPackage', () => {
         await result.current.downloadPackage();
       });
 
-      // Wired: the entry-guard consulted ServiceAppUpdate's persisted budget for
-      // this target (key = `${appVersion}:${bundleVersion ?? fileType}`).
+      // The entry guard consults ServiceAppUpdate's budget for this target
+      // (key = `${appVersion}:${bundleVersion ?? fileType}`).
       expect(svc.getDownloadAttemptBudget).toHaveBeenCalledWith({
         targetKey: expect.stringMatching(/^2\.0\.0:/),
       });
-      // Terminal give-up: the native download is NEVER invoked (no re-download
-      // on this relaunch), and the failure surfaces as a DownloadGaveUpError.
+      // Terminal give-up for this service instance: the native download is not
+      // invoked, and the failure surfaces as a DownloadGaveUpError.
       expect(appUpd.downloadPackage).not.toHaveBeenCalled();
       const failArg = (svc.downloadPackageFailed as jest.Mock).mock
         .calls[0]?.[0];

--- a/packages/kit/src/components/AppUpdate/useDownloadPackage.tsx
+++ b/packages/kit/src/components/AppUpdate/useDownloadPackage.tsx
@@ -304,11 +304,10 @@ export const useDownloadPackage = () => {
         // reuses the on-disk resume artifact (iOS .resume / Android & Desktop
         // .partial), so attempts after the first are real range-resumes.
         // Bails immediately on SHA256_MISMATCH / HTTP 4xx-permanent.
-        // OCDS §5.11 — persisted cross-restart attempt budget + wall-clock
-        // deadline. ServiceAppUpdate is the durable owner of the attempt
-        // counter, so a permanently-failing target eventually gives up
-        // (DownloadGaveUpError) instead of re-downloading from scratch on every
-        // relaunch; success resets it and a new target version starts fresh.
+        // OCDS §5.11 — ServiceAppUpdate owns the bg service instance's attempt
+        // budget, so a permanently failing target eventually gives up within
+        // that instance. A cold restart creates a fresh budget; success resets
+        // it, and a new target version also starts fresh.
         // `activeDownloadParams` is mutable so a 401/403 URL refresh can swap in
         // a freshly-signed URL for the next attempt (OCDS §4).
         const targetKey = `${asOptionalString(latestVersion) ?? ''}:${
@@ -368,10 +367,9 @@ export const useDownloadPackage = () => {
           errorCode: extractUpdateErrorCode(e),
         });
         if (e instanceof DownloadGaveUpError) {
-          // §5.11 definitive give-up: the persisted budget/deadline is spent (or
-          // the single-stream fallback itself failed). Surfaced as a terminal
-          // failure; the persisted record keeps the next relaunch from
-          // re-downloading until a new target version supersedes it.
+          // §5.11 definitive give-up: the service-instance budget is spent (or
+          // the single-stream fallback itself failed). Surface a terminal
+          // failure for this bg service instance; a cold restart starts fresh.
           defaultLogger.app.appUpdate.log(
             `downloadPackage: OCDS §5.11 terminal give-up reason=${e.reason}`,
           );


### PR DESCRIPTION
## Summary

- Move the OTA download-attempt gate from persisted MMKV state to the `ServiceAppUpdate` background-service instance.
- A cold background-service/process restart now starts with a fresh budget, so an exhausted value from an earlier launch cannot permanently block OTA recovery.
- Keep the active-process bound: eight real download attempts are allowed; the next entry check blocks attempt nine.
- Reset the in-memory budget when update cache is cleared. Reset also deletes the legacy MMKV key for cleanup, but the gate never reads or writes that value.

## Scope

The fix is intentionally limited to one production TypeScript file and one existing test file.

- No native source or `patch-package` changes.
- No front-end recovery state-machine changes.
- No dependency or build-configuration changes.
- The shared background-service path gives iOS, Android, and Desktop the same gate lifecycle.

## Preserved safeguards

- Per-invocation bounded retry and network-aware backoff.
- Download mutex.
- One-shot 401/403 signed-URL refresh.
- SHA256/signature and unrecoverable-error checks.
- Existing native range/resume behavior.

## Validation

- 3 targeted Jest suites passed (394 tests).
- Post-rebase core service/retry suites passed again (239 tests).
- Full repository TypeScript check passed.
- Type-aware oxlint passed with 0 warnings and 0 errors on both changed files.
- Prettier and diff whitespace checks passed.

## Runtime ownership

The counter lives only in the bg JS `ServiceAppUpdate` instance. Main calls it through `backgroundApiProxy`; native download resources remain unchanged. A new bg service instance has no counter, and “Clear update cache” explicitly clears the current instance’s counter.