### PR TITLE
fix: fit and center receive share card in ext side panel (OK-58222)

### DIFF
--- a/packages/kit/src/views/Receive/components/ReceiveShare/ReceiveShareDialog.tsx
+++ b/packages/kit/src/views/Receive/components/ReceiveShare/ReceiveShareDialog.tsx
@@ -3,7 +3,7 @@ import { useCallback, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useWindowDimensions } from 'react-native';
 
-import { Dialog, Stack, Toast, YStack } from '@onekeyhq/components';
+import { Dialog, Toast, YStack } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { appLocale } from '@onekeyhq/shared/src/locale/appLocale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -126,30 +126,19 @@ function ShareContent({
     });
   }, [runWithImage, shareImage, closeDialog]);
 
-  const desktopLayout = (
-    <YStack gap="$5">
-      <Stack
-        width={SHARE_CARD_CONFIG.width}
-        testID={ReceiveTestIDs.ShareDialogPreview}
-      >
-        <ShareView
-          data={data}
-          generatorRef={generatorRef}
-          maxHeight={previewMaxHeight}
-          presetImage={presetImage}
-        />
-      </Stack>
-      <ControlPanel
-        onSaveImage={handleSaveImage}
-        onShareImage={handleShareImage}
-        isLoading={isActionLoading}
-        isMobile={false}
-      />
-    </YStack>
-  );
-
-  const mobileLayout = (
-    <YStack gap="$5" width="100%" testID={ReceiveTestIDs.ShareDialogPreview}>
+  return (
+    // on desktop the fixed width drives the autoWidth floating panel's
+    // shrink-to-fit sizing; below the md breakpoint the dialog becomes a
+    // full-width sheet (ext side panel / popup), where maxWidth lets the
+    // card shrink instead of clipping and alignSelf centers it in wider
+    // panels (OK-58222)
+    <YStack
+      gap="$5"
+      width={isMobile ? '100%' : SHARE_CARD_CONFIG.width}
+      maxWidth="100%"
+      alignSelf="center"
+      testID={ReceiveTestIDs.ShareDialogPreview}
+    >
       <ShareView
         data={data}
         generatorRef={generatorRef}
@@ -160,12 +149,10 @@ function ShareContent({
         onSaveImage={handleSaveImage}
         onShareImage={handleShareImage}
         isLoading={isActionLoading}
-        isMobile
+        isMobile={isMobile}
       />
     </YStack>
   );
-
-  return isMobile ? mobileLayout : desktopLayout;
 }
 
 export function showReceiveShareDialog(


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58222](https://onekeyhq.atlassian.net/browse/OK-58222)

----------

<!-- github-pr-monitor:jira-links:end -->


### Jira

https://onekeyhq.atlassian.net/browse/OK-58222

### Problem

In the extension side panel, the receive share dialog body misbehaves at both width extremes:

1. Narrowest side panel: the share card keeps its fixed 360px width, overflows the sheet's 20px content padding, and the right edge/border gets clipped.
2. Wide side panel: the card sits left-aligned instead of centered, while the action buttons stretch to full sheet width.

### Root cause

Below the `md` breakpoint (767px) `Dialog` always renders as a full-width bottom sheet — the side panel lives entirely in that range. `desktopLayout` hard-coded `width={SHARE_CARD_CONFIG.width}` on the preview `Stack`: wider than the available content box when the panel is narrow, and pinned to flex-start by the sheet's stretched content column when the panel is wide.

### Fix

Move the intrinsic width to the outer `YStack` and let it adapt: `width={SHARE_CARD_CONFIG.width}` + `maxWidth="100%"` + `alignSelf="center"`. The fixed width still drives the desktop floating panel's `autoWidth` shrink-to-fit sizing (unchanged there), while in sheet mode the whole block (card + buttons) clamps to the available width and centers. Since the desktop and mobile layouts now differ only in the width value and the `isMobile` flag, the two near-identical JSX blocks are merged into one (`width={isMobile ? '100%' : SHARE_CARD_CONFIG.width}`); on native the explicit 100% width makes the added `maxWidth`/`alignSelf` no-ops.

### Verification

- CSS replica of the exact dialog wrapper chain, measured: floating panel still hugs 400px (360 + padding); 360px sheet → card clamps to 320px, no overflow (old: clipped 20px); 760px sheet → card centered with equal 200px side gaps (old: left-aligned).
- `yarn agent:check --profile commit` and `--profile pr` pass.
- Ext side panel on-device QA still needed: narrowest width (right border visible) and dragged-wide (card centered), plus a desktop app sanity check that the floating dialog is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OK-58222]: https://onekeyhq.atlassian.net/browse/OK-58222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ