### PR TITLE
fix: preserve browser webviews across tab switches

### DIFF
--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -105,6 +105,8 @@ function getExploreTabName(tab: ETranslations): IExploreTabName {
 }
 
 const styles = StyleSheet.create({
+  // iOS WKWebViews must stay in the native layout tree. In nested layouts,
+  // display:none can reload the page even though React keeps it mounted.
   webPageLayer: {
     ...StyleSheet.absoluteFillObject,
     zIndex: 3,
@@ -112,6 +114,14 @@ const styles = StyleSheet.create({
   webPageRootLayer: {
     ...StyleSheet.absoluteFillObject,
     zIndex: 3,
+  },
+  iosWebPageRootLayerVisible: {
+    opacity: 1,
+    zIndex: 3,
+  },
+  iosWebPageRootLayerHidden: {
+    opacity: 0,
+    zIndex: 0,
   },
 });
 
@@ -518,9 +528,40 @@ function MobileBrowser() {
     styles.webPageRootLayer,
     {
       bottom: BROWSER_BOTTOM_BAR_HEIGHT + bottom,
-      display: shouldShowRootWebPageLayer ? 'flex' : 'none',
     },
+    shouldShowRootWebPageLayer
+      ? styles.iosWebPageRootLayerVisible
+      : styles.iosWebPageRootLayerHidden,
   ];
+  const browserDashboardContent = (
+    <View
+      style={{
+        display: showDiscoveryPage ? 'flex' : 'none',
+        flex: showDiscoveryPage ? 1 : undefined,
+      }}
+    >
+      <DashboardContent onScroll={handleScroll} />
+    </View>
+  );
+  const browserBottomBarContent = (
+    <Freeze freeze={!displayBottomBar}>
+      <Animated.View
+        style={[
+          toolbarAnimatedStyle,
+          {
+            bottom: 0,
+            left: 0,
+            right: 0,
+          },
+        ]}
+      >
+        <MobileBrowserBottomBar
+          id={activeTabId ?? ''}
+          onGoBackHomePage={handleGoBackHome}
+        />
+      </Animated.View>
+    </Freeze>
+  );
 
   return (
     <Page fullPage>
@@ -577,46 +618,28 @@ function MobileBrowser() {
               browserContent={
                 <Stack flex={1} zIndex={3}>
                   <Stack flex={1}>
-                    <View
-                      style={{
-                        display: showDiscoveryPage ? 'flex' : 'none',
-                        flex: showDiscoveryPage ? 1 : undefined,
-                      }}
-                    >
-                      <DashboardContent onScroll={handleScroll} />
-                    </View>
+                    {browserDashboardContent}
+                    {platformEnv.isNativeAndroid ? (
+                      <Freeze freeze={showDiscoveryPage}>{content}</Freeze>
+                    ) : null}
                   </Stack>
-                  <Freeze freeze={!displayBottomBar}>
-                    <Animated.View
-                      style={[
-                        toolbarAnimatedStyle,
-                        {
-                          bottom: 0,
-                          left: 0,
-                          right: 0,
-                        },
-                      ]}
-                    >
-                      <MobileBrowserBottomBar
-                        id={activeTabId ?? ''}
-                        onGoBackHomePage={handleGoBackHome}
-                      />
-                    </Animated.View>
-                  </Freeze>
+                  {browserBottomBarContent}
                 </Stack>
               }
             />
-            <View
-              collapsable={false}
-              pointerEvents={shouldShowRootWebPageLayer ? 'auto' : 'none'}
-              accessibilityElementsHidden={!shouldShowRootWebPageLayer}
-              importantForAccessibility={
-                shouldShowRootWebPageLayer ? 'auto' : 'no-hide-descendants'
-              }
-              style={rootWebPageLayerStyle}
-            >
-              {content}
-            </View>
+            {platformEnv.isNativeIOS ? (
+              <View
+                collapsable={false}
+                pointerEvents={shouldShowRootWebPageLayer ? 'auto' : 'none'}
+                accessibilityElementsHidden={!shouldShowRootWebPageLayer}
+                importantForAccessibility={
+                  shouldShowRootWebPageLayer ? 'auto' : 'no-hide-descendants'
+                }
+                style={rootWebPageLayerStyle}
+              >
+                {content}
+              </View>
+            ) : null}
           </>
         ) : (
           <>

--- a/packages/kit/src/views/Discovery/pages/Browser/MobileBrowserContent.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/MobileBrowserContent.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { Freeze } from 'react-freeze';
 import { StyleSheet, View } from 'react-native';
 import ViewShot from 'react-native-view-shot';
 
@@ -17,8 +18,17 @@ import {
 import { captureViewRefs } from '../../utils/explorerUtils';
 
 const styles = StyleSheet.create({
+  // Opacity preserves the iOS WKWebView instance when switching tabs.
   webPageLayer: {
     ...StyleSheet.absoluteFillObject,
+  },
+  iosWebPageLayerVisible: {
+    opacity: 1,
+    zIndex: 1,
+  },
+  iosWebPageLayerHidden: {
+    opacity: 0,
+    zIndex: 0,
   },
 });
 
@@ -103,6 +113,37 @@ function MobileBrowserContent({
     if (!keepAlive || !shouldMountWebView) {
       return null;
     }
+    const webView = (
+      <ViewShot ref={initCaptureViewRef} style={{ flex: 1 }}>
+        <Stack
+          flex={1}
+          mt="$3"
+          // https://github.com/gre/react-native-view-shot/issues/7
+          collapsable={platformEnv.isNativeAndroid ? false : undefined}
+          bg={platformEnv.isNativeAndroid ? '$bgApp' : undefined}
+        >
+          <WebContent
+            id={tab.id}
+            url={webViewInitialUrl}
+            siteMode={tab.siteMode}
+            isCurrent={isCurrent}
+            setBackEnabled={setBackEnabled}
+            setForwardEnabled={setForwardEnabled}
+            onScroll={onScroll}
+            customReceiveHandler={customReceiveHandler}
+          />
+        </Stack>
+      </ViewShot>
+    );
+
+    if (platformEnv.isNativeAndroid) {
+      return (
+        <Freeze key={tab.id} freeze={!isActive}>
+          {webView}
+        </Freeze>
+      );
+    }
+
     return (
       <View
         key={tab.id}
@@ -110,28 +151,14 @@ function MobileBrowserContent({
         pointerEvents={isActive ? 'auto' : 'none'}
         accessibilityElementsHidden={!isActive}
         importantForAccessibility={isActive ? 'auto' : 'no-hide-descendants'}
-        style={[styles.webPageLayer, { display: isActive ? 'flex' : 'none' }]}
+        style={[
+          styles.webPageLayer,
+          isActive
+            ? styles.iosWebPageLayerVisible
+            : styles.iosWebPageLayerHidden,
+        ]}
       >
-        <ViewShot ref={initCaptureViewRef} style={{ flex: 1 }}>
-          <Stack
-            flex={1}
-            mt="$3"
-            // https://github.com/gre/react-native-view-shot/issues/7
-            collapsable={platformEnv.isNativeAndroid ? false : undefined}
-            bg={platformEnv.isNativeAndroid ? '$bgApp' : undefined}
-          >
-            <WebContent
-              id={tab.id}
-              url={webViewInitialUrl}
-              siteMode={tab.siteMode}
-              isCurrent={isCurrent}
-              setBackEnabled={setBackEnabled}
-              setForwardEnabled={setForwardEnabled}
-              onScroll={onScroll}
-              customReceiveHandler={customReceiveHandler}
-            />
-          </Stack>
-        </ViewShot>
+        {webView}
       </View>
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary

- keep iOS phone WKWebViews mounted outside the nested pager and switch visibility with opacity
- restore the original `react-freeze` lifecycle on Android for outer browser visibility and inactive browser tabs
- keep tablet/split-view behavior unchanged
- target `release/v6.5.0`

## Root cause

The previous keep-alive path still placed iOS WKWebViews behind nested `react-freeze` or `display: none` visibility boundaries. In complex Browser navigation paths, those boundaries could remove the native WKWebView from the rendered native tree and reload the page when it became visible again.

Android does not reproduce this WKWebView lifecycle issue, so it continues using Freeze to suspend hidden browser content.

## Impact

- iOS phone browser tabs retain their native WKWebView session and page state while hidden
- Android keeps the lower-cost Freeze behavior
- native `main` UI runtime only; no background-runtime changes
- iPad split view is intentionally out of scope

## Validation

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr` on `release/v6.5.0` (local lint and TypeScript passed)
- Android phone: verified outer/home/inner Freeze modes and complex round-trip page state
- iOS phone: verified opacity visibility modes and complex round-trip page state