### PR TITLE
chore: upgrade revenuecat sdk to 10.4.3

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -614,9 +614,7 @@ dependencies {
     // implementation("org.mozilla.geckoview:geckoview:133.0.20241209150345")
     // implementation("com.google.code.gson:gson:2.13.1")
 
-    // add billing sdk, also update AndroidManifest.xml
-    // def billingVersion = 7.1.1
-    // implementation("com.android.billingclient:billing:$billingVersion")
+    // Google Play Billing is provided transitively by react-native-purchases.
 
     // Detox (Android instrumentation tests)
     // Keep this pinned (no '+') to ensure reproducible builds and reduce supply-chain risk.

--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -79,9 +79,6 @@
   android:usesCleartextTraffic="false"
   android:enableOnBackInvokedCallback="false"
    android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme" android:largeHeap="true" android:supportsRtl="true">
-    <meta-data
-        android:name="com.google.android.play.billingclient.version"
-        android:value="7.1.1"/>
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
     <meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="49.0.0"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>

--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -727,8 +727,8 @@ PODS:
     - SocketRocket
     - Yoga
   - PromisesObjC (2.4.0)
-  - PurchasesHybridCommon (14.2.0):
-    - RevenueCat (= 5.32.0)
+  - PurchasesHybridCommon (18.21.0):
+    - RevenueCat (= 5.80.3)
   - QuickCrypto (1.1.5):
     - boost
     - DoubleConversion
@@ -4100,7 +4100,7 @@ PODS:
     - Yoga
   - RealmJS (20.2.0):
     - React
-  - RevenueCat (5.32.0)
+  - RevenueCat (5.80.3)
   - RNDateTimePicker (8.4.4):
     - boost
     - DoubleConversion
@@ -4309,8 +4309,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNPurchases (8.11.9):
-    - PurchasesHybridCommon (= 14.2.0)
+  - RNPurchases (10.4.3):
+    - PurchasesHybridCommon (= 18.21.0)
     - React-Core
   - RNReanimated (4.2.1):
     - boost
@@ -5500,7 +5500,7 @@ SPEC CHECKSUMS:
   PerpDepthBar: ea764fd9ca6dde336b3b6ca292e783e2b9c66c69
   Ping: fa822267f2829fc55b444fe503ce3022463d875e
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  PurchasesHybridCommon: f1650b33e9a1dd04d5e8a40dfe757f39e63f935c
+  PurchasesHybridCommon: 097af88db3cb39b415bef2f3140e6b3324899756
   QuickCrypto: fbb50daf9313753153af0e4f67a9f14ec1a26979
   RCT-Folly: b29feb752b08042c62badaef7d453f3bb5e6ae23
   RCTDeprecation: 5eb1d2eeff5fb91151e8a8eef45b6c7658b6c897
@@ -5599,7 +5599,7 @@ SPEC CHECKSUMS:
   ReactNativeSplashScreen: 0bc82cdce113b2f60366b3d0f2a495ff86e13022
   ReactNativeZipArchive: bb4a2b338281c0166bee97142bf59ef9cd124c62
   RealmJS: 1c37c6bdfe060f4caa0f9175aa0eedb962622ee1
-  RevenueCat: 7e1d0768fb287c9983173c9b28e39ccbeeb828a9
+  RevenueCat: 72d1e14966339bf38c41d9b2841ef64c8fd79646
   RNDateTimePicker: cda4c045beca864cebb3209ef9cc4094f974864c
   RNGestureHandler: e37bdb684df1ac17c7e1d8f71a3311b2793c186b
   RNGoogleSignin: 628d629e8dca39fc4ab70e30cf55bb3fc284f518
@@ -5607,7 +5607,7 @@ SPEC CHECKSUMS:
   RNJuiceboxSdk: a2e85ef9d73eac5547cc89d0a4b7b0f6e798d253
   RNNotifee: 5e3b271e8ea7456a36eec994085543c9adca9168
   RNPermissions: d0f185d461a25bb0f75fdd58c855ba0988fe18ab
-  RNPurchases: 4c820359d90fab9c83ffd3ef5471d59db72e2ed1
+  RNPurchases: 33dbce0054a0833a8c20c8d6244e971dfedaa0c3
   RNReanimated: 464375ff2caa801358547c44eca894ff0bf68e74
   RNScreens: afaf526a9c804c3b4503f950cf3e67ed81e29ada
   RNSentry: a20c5194cc6d7902683276f399a6eb5206fb9f05

--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -4101,6 +4101,34 @@ PODS:
   - RealmJS (20.2.0):
     - React
   - RevenueCat (5.32.0)
+  - RNDateTimePicker (8.4.4):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - RNGestureHandler (2.30.0):
     - boost
     - DoubleConversion
@@ -4971,6 +4999,7 @@ DEPENDENCIES:
   - "ReactNativeSplashScreen (from `../../../node_modules/@onekeyfe/react-native-splash-screen`)"
   - ReactNativeZipArchive (from `../../../node_modules/react-native-zip-archive`)
   - RealmJS (from `../../../node_modules/realm`)
+  - "RNDateTimePicker (from `../../../node_modules/@react-native-community/datetimepicker`)"
   - RNGestureHandler (from `../../../node_modules/react-native-gesture-handler`)
   - "RNGoogleSignin (from `../../../node_modules/@react-native-google-signin/google-signin`)"
   - RNImageCropPicker (from `../../../node_modules/react-native-image-crop-picker`)
@@ -5344,6 +5373,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native-zip-archive"
   RealmJS:
     :path: "../../../node_modules/realm"
+  RNDateTimePicker:
+    :path: "../../../node_modules/@react-native-community/datetimepicker"
   RNGestureHandler:
     :path: "../../../node_modules/react-native-gesture-handler"
   RNGoogleSignin:
@@ -5569,6 +5600,7 @@ SPEC CHECKSUMS:
   ReactNativeZipArchive: bb4a2b338281c0166bee97142bf59ef9cd124c62
   RealmJS: 1c37c6bdfe060f4caa0f9175aa0eedb962622ee1
   RevenueCat: 7e1d0768fb287c9983173c9b28e39ccbeeb828a9
+  RNDateTimePicker: cda4c045beca864cebb3209ef9cc4094f974864c
   RNGestureHandler: e37bdb684df1ac17c7e1d8f71a3311b2793c186b
   RNGoogleSignin: 628d629e8dca39fc4ab70e30cf55bb3fc284f518
   RNImageCropPicker: 5fd4ceaead64d8c53c787e4e559004f97bc76df7

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -165,7 +165,7 @@
     "react-native-passkeys": "0.3.3",
     "react-native-permissions": "5.4.4",
     "react-native-ping": "npm:@onekeyfe/react-native-ping@3.0.78",
-    "react-native-purchases": "8.11.9",
+    "react-native-purchases": "10.4.3",
     "react-native-qrcode-styled": "0.4.0",
     "react-native-quick-base64": "^3.0.0",
     "react-native-quick-crypto": "^1.1.3",

--- a/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.native.ts
+++ b/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.native.ts
@@ -3,8 +3,10 @@ import { useCallback, useEffect, useState } from 'react';
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 import PurchasesReactNative, {
+  type CustomerInfo,
   INTRO_ELIGIBILITY_STATUS,
   LOG_LEVEL,
+  type PurchasesPackage,
 } from 'react-native-purchases';
 
 import { Dialog, Toast } from '@onekeyhq/components';
@@ -37,11 +39,6 @@ import type {
   ISubscriptionPeriod,
   IUsePrimePayment,
 } from './usePrimePaymentTypes';
-import type {
-  CustomerInfo,
-  PurchasesPackage,
-} from '@revenuecat/purchases-typescript-internal';
-
 void (async () => {
   if (process.env.NODE_ENV !== 'production') {
     await PurchasesReactNative.setLogLevel(LOG_LEVEL.VERBOSE);

--- a/packages/kit/src/views/Prime/hooks/usePrimePaymentTypes.ts
+++ b/packages/kit/src/views/Prime/hooks/usePrimePaymentTypes.ts
@@ -7,7 +7,7 @@ import type {
 import type {
   CustomerInfo as CustomerInfoNative,
   MakePurchaseResult,
-} from '@revenuecat/purchases-typescript-internal';
+} from 'react-native-purchases';
 
 export type ISubscriptionPeriod = 'P1Y' | 'P1M';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10410,7 +10410,7 @@ __metadata:
     react-native-passkeys: "npm:0.3.3"
     react-native-permissions: "npm:5.4.4"
     react-native-ping: "npm:@onekeyfe/react-native-ping@3.0.78"
-    react-native-purchases: "npm:8.11.9"
+    react-native-purchases: "npm:10.4.3"
     react-native-qrcode-styled: "npm:0.4.0"
     react-native-quick-base64: "npm:^3.0.0"
     react-native-quick-crypto: "npm:^1.1.3"
@@ -14563,6 +14563,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@revenuecat/purchases-js-hybrid-mappings@npm:18.21.0":
+  version: 18.21.0
+  resolution: "@revenuecat/purchases-js-hybrid-mappings@npm:18.21.0"
+  dependencies:
+    "@revenuecat/purchases-js": "npm:1.47.1"
+  checksum: 10/7205efe31d7b992f86be987ca9200903a74d4b01dbd2bd5d4893991ab3e5e5a1da0f945fb0ad9839b7f83a5d330e46e6f57bb8f44251bc10008825848d3be33f
+  languageName: node
+  linkType: hard
+
 "@revenuecat/purchases-js@npm:0.15.1":
   version: 0.15.1
   resolution: "@revenuecat/purchases-js@npm:0.15.1"
@@ -14570,10 +14579,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@revenuecat/purchases-typescript-internal@npm:14.2.0":
-  version: 14.2.0
-  resolution: "@revenuecat/purchases-typescript-internal@npm:14.2.0"
-  checksum: 10/6ea103adf6956d0c018b242627bfca9fe64b2da94c1d5c5fbb5f8528f936d331b30f3def55499a4d9de9a274843c0fa584c9c6b5b1ad0f1e357e4cc79642759a
+"@revenuecat/purchases-js@npm:1.47.1":
+  version: 1.47.1
+  resolution: "@revenuecat/purchases-js@npm:1.47.1"
+  checksum: 10/88c205cce7a59b67ec3d936559f179f466b9427d6e664c97752856510836ad84dfac761a99e7392ce870a46e269d1246a911fef5dc2baa7e3592f30c19eec3ba
+  languageName: node
+  linkType: hard
+
+"@revenuecat/purchases-typescript-internal@npm:18.21.0":
+  version: 18.21.0
+  resolution: "@revenuecat/purchases-typescript-internal@npm:18.21.0"
+  checksum: 10/8edc1fc98a79c05294bac90f3f3a11e4de2f667624e3ffc3bede7b341a9b47971b73b2537181a3c72c20302129680af30134dfceaf65aa1f82c8e128980d291d
   languageName: node
   linkType: hard
 
@@ -42642,15 +42658,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-purchases@npm:8.11.9":
-  version: 8.11.9
-  resolution: "react-native-purchases@npm:8.11.9"
+"react-native-purchases@npm:10.4.3":
+  version: 10.4.3
+  resolution: "react-native-purchases@npm:10.4.3"
   dependencies:
-    "@revenuecat/purchases-typescript-internal": "npm:14.2.0"
+    "@revenuecat/purchases-js-hybrid-mappings": "npm:18.21.0"
+    "@revenuecat/purchases-typescript-internal": "npm:18.21.0"
   peerDependencies:
     react: ">= 16.6.3"
-    react-native: "*"
-  checksum: 10/9194e08e65f730a50b852de15ef654b3da478d0bfef55137c749b96f3c1e068d7c910d4c3ee89ccabadd8361e45e9d59ecce1da8e999cb3e19a79c2478c71282
+    react-native: ">= 0.73.0"
+    react-native-web: "*"
+  peerDependenciesMeta:
+    react-native-web:
+      optional: true
+  checksum: 10/1bc2e6d057f3495c27ee238e825afc71012757b513a0addc2aa3e52b83d8c82ad63c4e8bdb504e4fb0f03ca5124e44732ae0f4f61eb4c2312e31f1949ba3c795
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- upgrade `react-native-purchases` from 8.11.9 to 10.4.3
- update the resolved RevenueCat native dependency chain:
  - Android: `com.revenuecat.purchases:purchases:10.13.0`
  - iOS: `PurchasesHybridCommon 18.21.0` and `RevenueCat 5.80.3`
- remove the stale hardcoded Android Billing Client metadata override and use the version provided by the resolved Billing library
- import RevenueCat types from the public `react-native-purchases` API
- synchronize the missing `RNDateTimePicker 8.4.4` Pod lock entry introduced by Storybook PR #12465 in a separate commit

## Why

Google Play requires apps to use Google Play Billing Library 8.0.0 or newer by August 31, 2026. RevenueCat React Native SDK 10.4.3 resolves Android Billing Client 8.3.0, satisfying that requirement.

The Storybook dependency is intentionally allowed in the production native dependency graph. Its previously missing Pod lock entry is isolated in `chore: sync ios pod lock for storybook`.

## Runtime impact

On iOS and Android, RevenueCat remains configured by the `main` JS runtime only. The `bg` runtime initialization and JS heap remain unchanged. The native RevenueCat SDK remains process-owned, and the two JS bundles remain version-locked.

## Validation

- `yarn install --immutable`
- targeted Prime purchase tests: 8/8 passed
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- Android Google Release build: `:app:assembleGoogleRelease` passed
- verified merged Android manifest reports `com.google.android.play.billingclient.version=8.3.0`
- iOS generic-device Release build passed with code signing disabled
- verified `RevenueCat`, `PurchasesHybridCommon`, and `RNPurchases` native artifacts
- verified both `main.jsbundle` and `background.bundle` were generated