### PR TITLE
fix: prevent browser toolbar scroll jump OK-58319

### DIFF
--- a/packages/kit/src/views/Discovery/hooks/useMobileBottomBarAnimation.ts
+++ b/packages/kit/src/views/Discovery/hooks/useMobileBottomBarAnimation.ts
@@ -95,15 +95,12 @@ function useMobileBottomBarAnimation(activeTabId: string | null) {
         Math.round(contentOffsetY) > Math.round(scrollableHeight);
       const canScroll =
         Math.round(contentSize.height) >
-        Math.round(
-          layoutMeasurement.height + contentInset.top + contentInset.bottom,
-        ) +
-          MIN_TOGGLE_BROWSER_VISIBLE_DISTANCE +
-          fullBarHeight;
+        Math.round(layoutMeasurement.height) +
+          MIN_TOGGLE_BROWSER_VISIBLE_DISTANCE;
 
       runOnUI(processScroll)(contentOffsetY, canScroll, isOutOfBounds);
     },
-    [fullBarHeight, processScroll],
+    [processScroll],
   );
 
   const toolbarAnimatedStyle = useAnimatedStyle(() => ({

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -6,10 +6,8 @@ import { Freeze } from 'react-freeze';
 import {
   BackHandler,
   type LayoutChangeEvent,
-  type StyleProp,
   StyleSheet,
   View,
-  type ViewStyle,
 } from 'react-native';
 import Animated, { useSharedValue } from 'react-native-reanimated';
 
@@ -69,7 +67,6 @@ import { HandleRebuildBrowserData } from '../../components/HandleData/HandleRebu
 import HeaderRightToolBar from '../../components/HeaderRightToolBar';
 import MobileBrowserBottomBar from '../../components/MobileBrowser/MobileBrowserBottomBar';
 import { OuterTabPagerView } from '../../components/OuterTabPagerView';
-import { BROWSER_BOTTOM_BAR_HEIGHT } from '../../config/Animation.constants';
 import { useDAppNotifyChanges } from '../../hooks/useDAppNotifyChanges';
 // import { useEdgeSwipeDetection } from '../../hooks/useEdgeSwipeDetection';
 import useMobileBottomBarAnimation from '../../hooks/useMobileBottomBarAnimation';
@@ -112,6 +109,13 @@ const styles = StyleSheet.create({
   webPageRootLayer: {
     ...StyleSheet.absoluteFillObject,
     zIndex: 3,
+  },
+  webPageRootToolbar: {
+    position: 'absolute',
+    right: 0,
+    bottom: 0,
+    left: 0,
+    zIndex: 4,
   },
 });
 
@@ -404,7 +408,7 @@ function MobileBrowser() {
     [tabs, navigation, activeTabId],
   );
 
-  const { top, bottom } = useSafeAreaInsets();
+  const { top } = useSafeAreaInsets();
   // iOS 26: the Discover search bar opts into the Liquid Glass capsule (so it
   // matches the Wallet header's glass search bar) and is nudged down so its
   // center vertically aligns with the Wallet search bar — which sits centered in
@@ -514,13 +518,6 @@ function MobileBrowser() {
 
   const displayBottomBar = !showDiscoveryPage;
   const shouldShowRootWebPageLayer = useOuterPager && isBrowserWebPageVisible;
-  const rootWebPageLayerStyle: StyleProp<ViewStyle> = [
-    styles.webPageRootLayer,
-    {
-      bottom: BROWSER_BOTTOM_BAR_HEIGHT + bottom,
-      display: shouldShowRootWebPageLayer ? 'flex' : 'none',
-    },
-  ];
 
   return (
     <Page fullPage>
@@ -586,26 +583,12 @@ function MobileBrowser() {
                       <DashboardContent onScroll={handleScroll} />
                     </View>
                   </Stack>
-                  <Freeze freeze={!displayBottomBar}>
-                    <Animated.View
-                      style={[
-                        toolbarAnimatedStyle,
-                        {
-                          bottom: 0,
-                          left: 0,
-                          right: 0,
-                        },
-                      ]}
-                    >
-                      <MobileBrowserBottomBar
-                        id={activeTabId ?? ''}
-                        onGoBackHomePage={handleGoBackHome}
-                      />
-                    </Animated.View>
-                  </Freeze>
                 </Stack>
               }
             />
+            {/* Keep the native WebView full-height while the toolbar reveals or
+                covers its bottom edge. Resizing the WebView during a scroll
+                changes its viewport and causes a visible jump. */}
             <View
               collapsable={false}
               pointerEvents={shouldShowRootWebPageLayer ? 'auto' : 'none'}
@@ -613,10 +596,32 @@ function MobileBrowser() {
               importantForAccessibility={
                 shouldShowRootWebPageLayer ? 'auto' : 'no-hide-descendants'
               }
-              style={rootWebPageLayerStyle}
+              style={[
+                styles.webPageRootLayer,
+                {
+                  display: shouldShowRootWebPageLayer ? 'flex' : 'none',
+                },
+              ]}
             >
               {content}
             </View>
+            <Freeze freeze={!displayBottomBar}>
+              <Animated.View
+                pointerEvents={shouldShowRootWebPageLayer ? 'auto' : 'none'}
+                style={[
+                  styles.webPageRootToolbar,
+                  toolbarAnimatedStyle,
+                  {
+                    display: shouldShowRootWebPageLayer ? 'flex' : 'none',
+                  },
+                ]}
+              >
+                <MobileBrowserBottomBar
+                  id={activeTabId ?? ''}
+                  onGoBackHomePage={handleGoBackHome}
+                />
+              </Animated.View>
+            </Freeze>
           </>
         ) : (
           <>


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58319](https://onekeyhq.atlassian.net/browse/OK-58319)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- keep the native mobile WebView full-height while the browser toolbar overlays its bottom edge
- animate only the overlaid toolbar so scrolling no longer resizes the WebView viewport
- update the scrollability threshold for the new full-height layout

## Root cause

The WebView frame reserved the toolbar height even after the toolbar collapsed, leaving an empty area at the bottom. Resizing that native frame during scrolling changed the page viewport and produced a visible jump.

## Impact

This affects the iOS and Android `main` UI runtime only. It does not change background runtimes, native modules, or third-party patches.

## Validation

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr` local checks
- Android emulator smoke: toolbar collapse/reveal and WebView bottom fill
- iOS layout/toolbar visibility smoke; automated WKWebView drag could not be completed reliably

[OK-58319]: https://onekeyhq.atlassian.net/browse/OK-58319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ