### PR TITLE
fix: dedupe all-network worth summing and trust PancakeSwap Permit2

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -640,6 +640,7 @@ Outout
 p2pkh
 p2wpkh
 pageview
+pancakeswap
 passcode
 passpharse
 passphrase

--- a/packages/kit-bg/src/vaults/impls/evm/approveTransactionUtils.test.ts
+++ b/packages/kit-bg/src/vaults/impls/evm/approveTransactionUtils.test.ts
@@ -82,6 +82,39 @@ describe('approval transaction utils', () => {
     ).toBeUndefined();
   });
 
+  test('resolves the PancakeSwap Permit2 deployment on trusted networks', () => {
+    // The server-side approvals whitelist returns Uniswap AND PancakeSwap
+    // Permit2 contracts; only trusting Uniswap blocked PancakeSwap Permit2
+    // revocations at _assertPermit2ApproveInfo.
+    const pancakePermit2Address = '0x31c2f6fcff4f8759b3bd5bf0e1084a055615c768';
+    const networkIdsMap = getNetworkIdsMap();
+    const supportedNetworkIds = [
+      networkIdsMap.eth,
+      networkIdsMap.bsc,
+      networkIdsMap.polygon,
+      networkIdsMap.arbitrum,
+      networkIdsMap.avalanche,
+      networkIdsMap.optimism,
+      networkIdsMap.base,
+    ];
+
+    for (const networkId of supportedNetworkIds) {
+      expect(
+        resolveTrustedPermit2Address({
+          networkId,
+          permit2Address: pancakePermit2Address,
+        }),
+      ).toBe('0x31c2F6fcFf4F8759b3Bd5Bf0e1084A055615c768');
+    }
+
+    expect(
+      resolveTrustedPermit2Address({
+        networkId: networkIdsMap.zksyncera,
+        permit2Address: pancakePermit2Address,
+      }),
+    ).toBeUndefined();
+  });
+
   test('encodes the on-chain Permit2 revoke example', () => {
     expect(buildPermit2Tx()).toEqual({
       from: owner,

--- a/packages/kit-bg/src/vaults/impls/evm/approveTransactionUtils.ts
+++ b/packages/kit-bg/src/vaults/impls/evm/approveTransactionUtils.ts
@@ -14,18 +14,27 @@ import type { BigNumber as EthersBigNumber } from '@ethersproject/bignumber';
 
 export const PERMIT2_APPROVE_SELECTOR = '0x87517c45';
 
-const PERMIT2_ADDRESS = '0x000000000022D473030F116dDEE9F6B43aC78BA3';
+const UNISWAP_PERMIT2_ADDRESS = '0x000000000022D473030F116dDEE9F6B43aC78BA3';
+const PANCAKESWAP_PERMIT2_ADDRESS =
+  '0x31c2F6fcFf4F8759b3Bd5Bf0e1084A055615c768';
 const PERMIT2_APPROVE_DATA_LENGTH = 2 + 8 + 64 * 4;
 const UINT48_MAX = new BigNumber(2).pow(48).minus(1);
 const networkIdsMap = getNetworkIdsMap();
-const TRUSTED_PERMIT2_ADDRESSES: Readonly<Record<string, string>> = {
-  [networkIdsMap.eth]: PERMIT2_ADDRESS,
-  [networkIdsMap.bsc]: PERMIT2_ADDRESS,
-  [networkIdsMap.polygon]: PERMIT2_ADDRESS,
-  [networkIdsMap.arbitrum]: PERMIT2_ADDRESS,
-  [networkIdsMap.avalanche]: PERMIT2_ADDRESS,
-  [networkIdsMap.optimism]: PERMIT2_ADDRESS,
-  [networkIdsMap.base]: PERMIT2_ADDRESS,
+// The server-side approvals whitelist only returns these two Permit2
+// deployments (>99.9% of Permit2 approval records); both are deterministic
+// CREATE2 deployments sharing one address across chains.
+const TRUSTED_PERMIT2_ADDRESS_LIST: readonly string[] = [
+  UNISWAP_PERMIT2_ADDRESS,
+  PANCAKESWAP_PERMIT2_ADDRESS,
+];
+const TRUSTED_PERMIT2_ADDRESSES: Readonly<Record<string, readonly string[]>> = {
+  [networkIdsMap.eth]: TRUSTED_PERMIT2_ADDRESS_LIST,
+  [networkIdsMap.bsc]: TRUSTED_PERMIT2_ADDRESS_LIST,
+  [networkIdsMap.polygon]: TRUSTED_PERMIT2_ADDRESS_LIST,
+  [networkIdsMap.arbitrum]: TRUSTED_PERMIT2_ADDRESS_LIST,
+  [networkIdsMap.avalanche]: TRUSTED_PERMIT2_ADDRESS_LIST,
+  [networkIdsMap.optimism]: TRUSTED_PERMIT2_ADDRESS_LIST,
+  [networkIdsMap.base]: TRUSTED_PERMIT2_ADDRESS_LIST,
 };
 
 function isSameEvmAddress(left?: string, right?: string) {
@@ -46,10 +55,10 @@ export function resolveTrustedPermit2Address({
   networkId: string;
   permit2Address?: string;
 }) {
-  const trustedPermit2Address = TRUSTED_PERMIT2_ADDRESSES[networkId];
-  return isSameEvmAddress(permit2Address, trustedPermit2Address)
-    ? trustedPermit2Address
-    : undefined;
+  const trustedPermit2Addresses = TRUSTED_PERMIT2_ADDRESSES[networkId] ?? [];
+  return trustedPermit2Addresses.find((trustedPermit2Address) =>
+    isSameEvmAddress(permit2Address, trustedPermit2Address),
+  );
 }
 
 export function buildErc20ApproveEncodedTx({

--- a/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.test.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.test.ts
@@ -140,6 +140,47 @@ describe('buildMergedAllNetworkSnapshot', () => {
     expect(snap.orderedTokens.map((t) => t.$key)).toEqual(['dup']);
   });
 
+  it('does not double a cache-floor round worth whose groups share one map', () => {
+    // seedAndFlushCache builds cache-floor rounds with the ONE cached full
+    // tokenListMap as tokens.map, smallBalanceTokens.map AND riskTokens.map
+    // (the cache stores a single merged map). The per-round worth must count
+    // each $key once — summing tokens.map + smallBalanceTokens.map verbatim
+    // doubled every cache-floor network on the Home total (desktop "assets
+    // doubled" report, ticket 906970).
+    const fullCachedMap = {
+      usdt: makeFiat('5000'),
+      trx: makeFiat('150'),
+    };
+    const rounds: IAllNetworkSnapshotRound[] = [
+      makeRound({
+        networkId: 'tron--0.9',
+        accountId: 'acc1',
+        tokens: {
+          data: [makeToken('usdt'), makeToken('trx')],
+          keys: 'k',
+          map: fullCachedMap,
+        },
+        smallBalanceTokens: { data: [], keys: '', map: fullCachedMap },
+        riskTokens: { data: [], keys: '', map: fullCachedMap },
+      }),
+    ];
+
+    const snap = buildMergedAllNetworkSnapshot({
+      rounds,
+      mergeDeriveAssetsByNetworkId: {},
+      accountId: 'acc1',
+    });
+
+    expect(
+      snap.accountsWorth[
+        accountUtils.buildAccountValueKey({
+          accountId: 'acc1',
+          networkId: 'tron--0.9',
+        })
+      ],
+    ).toBe('5150');
+  });
+
   it('carries and sorts the risky slice', () => {
     const rounds: IAllNetworkSnapshotRound[] = [
       makeRound({

--- a/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.test.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.test.ts
@@ -181,6 +181,55 @@ describe('buildMergedAllNetworkSnapshot', () => {
     ).toBe('5150');
   });
 
+  it('prefers the explicit round accountWorth so risk-only keys stay out of the worth', () => {
+    // Cache-floor rounds share the ONE cached full tokenListMap — which also
+    // holds risk-only entries — across all three group maps. Per-$key dedup
+    // fixes the doubling, but a map-derived sum would still count risk-only
+    // keys, while the cached tokenListValue counts tokens + smallBalanceTokens
+    // only. The explicit accountWorth must win so the authoritative snapshot
+    // matches the cache-hydrate overview write.
+    const fullCachedMap = {
+      usdt: makeFiat('5000'),
+      trx: makeFiat('150'),
+      scam: makeFiat('999'),
+    };
+    const rounds: IAllNetworkSnapshotRound[] = [
+      makeRound({
+        networkId: 'tron--0.9',
+        accountId: 'acc1',
+        accountWorth: '5150',
+        tokens: {
+          data: [makeToken('usdt'), makeToken('trx')],
+          keys: 'k',
+          map: fullCachedMap,
+        },
+        smallBalanceTokens: { data: [], keys: '', map: fullCachedMap },
+        riskTokens: {
+          data: [makeToken('scam')],
+          keys: 'kr',
+          map: fullCachedMap,
+        },
+      }),
+    ];
+
+    const snap = buildMergedAllNetworkSnapshot({
+      rounds,
+      mergeDeriveAssetsByNetworkId: {},
+      accountId: 'acc1',
+    });
+
+    expect(
+      snap.accountsWorth[
+        accountUtils.buildAccountValueKey({
+          accountId: 'acc1',
+          networkId: 'tron--0.9',
+        })
+      ],
+    ).toBe('5150');
+    // the explicit worth also feeds the createAtNetworkWorth accumulation
+    expect(new BigNumber(snap.createAtNetworkWorth).toNumber()).toBe(5150);
+  });
+
   it('carries and sorts the risky slice', () => {
     const rounds: IAllNetworkSnapshotRound[] = [
       makeRound({

--- a/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.ts
@@ -15,6 +15,7 @@ import {
 } from '@onekeyhq/shared/src/utils/tokenUtils';
 import {
   isUnavailableOrZeroFiatValue,
+  isValidNumberValue,
   sumFiatValuesFromTokens,
   sumTokenGroupsFiatValueIgnoringUnavailable,
 } from '@onekeyhq/shared/src/utils/tokenValueUtils';
@@ -54,6 +55,15 @@ export interface IAllNetworkSnapshotRound {
    * round, not be looked up per-networkId.
    */
   mergeDeriveAssets?: boolean;
+  /**
+   * Explicit precomputed worth for THIS round, taking precedence over the
+   * map-derived sum. Cache-floor rounds
+   * (useTokenListReactivePipeline.seedAndFlushCache) MUST carry the cached
+   * `tokenListValue` (tokens + smallBalanceTokens only): their three group
+   * maps share the ONE cached full tokenListMap, so a map-derived sum would
+   * leak risk-only keys into the account worth even after per-$key dedup.
+   */
+  accountWorth?: string;
 }
 
 /**
@@ -197,7 +207,13 @@ export function buildMergedAllNetworkSnapshot({
       mergeDeriveAssets: mergeDeriveAssetsEnabled,
     });
 
-    const accountWorth = sumTokenGroupsFiatValueIgnoringUnavailable(r);
+    // Prefer the round's explicit precomputed worth (see the
+    // `IAllNetworkSnapshotRound.accountWorth` contract): summing a cache-floor
+    // round's maps would count risk-only keys the cached tokenListValue
+    // deliberately excludes.
+    const accountWorth = isValidNumberValue(r.accountWorth)
+      ? r.accountWorth
+      : sumTokenGroupsFiatValueIgnoringUnavailable(r);
 
     accountsWorth[
       accountUtils.buildAccountValueKey({

--- a/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.test.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.test.ts
@@ -18,6 +18,8 @@ import type { MutableRefObject } from 'react';
 
 import { act, renderHook } from '@testing-library/react';
 
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+
 const mockIngestRound = jest.fn();
 const mockGetVaultSettings = jest.fn(async () => ({
   mergeDeriveAssetsEnabled: false,
@@ -350,6 +352,64 @@ describe('useTokenListReactivePipeline', () => {
     expect(
       (mockIngestRound.mock.calls[0][0] as { source: string }).source,
     ).toBe('authoritative');
+  });
+
+  it('cache seed: explicit tokenListValue keeps risk-only map keys out of the worth', async () => {
+    // The cache stores ONE full tokenListMap (normal + small + risk entries)
+    // that seedAndFlushCache reuses for all three group maps. The cached
+    // tokenListValue counts tokens + smallBalanceTokens only, so it must be
+    // carried as the round's explicit accountWorth — a map-derived sum would
+    // add risk-only keys and write the authoritative worth too high.
+    const { result } = render(true);
+    act(() => {
+      result.current.setEnabledKeys([OWNER]);
+    });
+    let worth: string | undefined;
+    await act(async () => {
+      await result.current.seedAndFlushCache({
+        data: [
+          makeCacheItem({
+            riskyTokenList: [
+              {
+                $key: 'scam',
+                name: 'Scam',
+                symbol: 'SCAM',
+                decimals: 18,
+                address: '0xscam',
+                isNative: false,
+              },
+            ] as ICacheSeedItem['riskyTokenList'],
+            tokenListMap: {
+              a1: {
+                balance: '1',
+                balanceParsed: '1',
+                fiatValue: '10',
+                price: 1,
+              },
+              scam: {
+                balance: '1',
+                balanceParsed: '1',
+                fiatValue: '999',
+                price: 1,
+              },
+            },
+            tokenListValue: '10',
+          }),
+        ],
+        accountId: OWNER.accountId,
+        networkId: OWNER.networkId,
+        generation: 1,
+      });
+      const snap = await result.current.buildAuthoritativeSnapshot();
+      worth =
+        snap.accountsWorth[
+          accountUtils.buildAccountValueKey({
+            accountId: OWNER.accountId,
+            networkId: OWNER.networkId,
+          })
+        ];
+    });
+    expect(worth).toBe('10');
   });
 
   it('P1-g: a throttled live flush is SUPERSEDED by an authoritative commit (epoch bump)', async () => {

--- a/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.ts
@@ -81,6 +81,14 @@ export interface ICacheSeedItem {
   smallBalanceTokenList: IAccountToken[];
   riskyTokenList: IAccountToken[];
   tokenListMap: Record<string, ITokenFiat>;
+  /**
+   * Cached per-network worth counting tokens + smallBalanceTokens ONLY (risk
+   * excluded — ServiceToken computes it from the two group fiat subtotals).
+   * Seeded onto the floor round as its explicit `accountWorth` because the
+   * shared full `tokenListMap` below also contains risk-only entries a
+   * map-derived sum would wrongly include. Optional: legacy caches predate it.
+   */
+  tokenListValue?: string;
   aggregateTokenListMap?: { [key: string]: { tokens: IAccountToken[] } };
   aggregateTokenMap?: Record<string, ITokenFiat>;
   accountId: string;
@@ -368,6 +376,7 @@ export function useTokenListReactivePipeline(
               keys: item.riskyTokenList.map((t) => t.$key).join(','),
               map: item.tokenListMap,
             },
+            accountWorth: item.tokenListValue,
             aggregateTokenListMap: item.aggregateTokenListMap,
             aggregateTokenMap: item.aggregateTokenMap,
             ownerAccountId,

--- a/packages/shared/src/utils/tokenValueUtils.test.ts
+++ b/packages/shared/src/utils/tokenValueUtils.test.ts
@@ -193,4 +193,32 @@ describe('sumTokenGroupsFiatValueIgnoringUnavailable', () => {
   test('handles missing token group shapes', () => {
     expect(sumTokenGroupsFiatValueIgnoringUnavailable({})).toBe('0');
   });
+
+  test('counts a $key present in both maps only once', () => {
+    // Cache-floor rounds (useTokenListReactivePipeline.seedAndFlushCache) carry
+    // the ONE cached full tokenListMap as BOTH tokens.map and
+    // smallBalanceTokens.map — summing both verbatim doubled every
+    // cache-floor network's account worth on the Home overview.
+    const fullCachedMap = {
+      usdt: { fiatValue: '5000' },
+      trx: { fiatValue: '150' },
+    };
+    expect(
+      sumTokenGroupsFiatValueIgnoringUnavailable({
+        tokens: { map: fullCachedMap },
+        smallBalanceTokens: { map: fullCachedMap },
+      }),
+    ).toBe('5150');
+  });
+
+  test('overlapping keys are counted once while distinct keys still sum', () => {
+    expect(
+      sumTokenGroupsFiatValueIgnoringUnavailable({
+        tokens: { map: { a: { fiatValue: '10' }, b: { fiatValue: '2' } } },
+        smallBalanceTokens: {
+          map: { b: { fiatValue: '2' }, c: { fiatValue: '0.5' } },
+        },
+      }),
+    ).toBe('12.5');
+  });
 });

--- a/packages/shared/src/utils/tokenValueUtils.ts
+++ b/packages/shared/src/utils/tokenValueUtils.ts
@@ -83,6 +83,12 @@ export function sumFiatValuesIgnoringUnavailable(
 // collapses the duplicated `tokens.map + smallBalanceTokens.map` sum at every
 // accountWorth write site. Single pass over both maps to avoid the
 // toFixed → reparse round trip.
+//
+// Each $key is counted ONCE across both maps: cache-floor rounds
+// (useTokenListReactivePipeline.seedAndFlushCache) reuse the ONE cached full
+// tokenListMap as both tokens.map and smallBalanceTokens.map — summing them
+// verbatim doubled every cache-floor network's worth on the Home overview.
+// Live rounds carry disjoint maps, so the dedup is a no-op for them.
 export function sumTokenGroupsFiatValueIgnoringUnavailable(r: {
   tokens?: { map?: Record<string, ITokenFiatValueShape | undefined> };
   smallBalanceTokens?: {
@@ -90,13 +96,17 @@ export function sumTokenGroupsFiatValueIgnoringUnavailable(r: {
   };
 }): string {
   let acc = new BigNumber(0);
+  const seenKeys = new Set<string>();
   const addAll = (
     map: Record<string, ITokenFiatValueShape | undefined> | undefined,
   ) => {
     if (!map) return;
-    for (const entry of Object.values(map)) {
-      if (entry && isValidNumberValue(entry.fiatValue)) {
-        acc = acc.plus(entry.fiatValue);
+    for (const [key, entry] of Object.entries(map)) {
+      if (!seenKeys.has(key)) {
+        seenKeys.add(key);
+        if (entry && isValidNumberValue(entry.fiatValue)) {
+          acc = acc.plus(entry.fiatValue);
+        }
       }
     }
   };


### PR DESCRIPTION
## Summary
- Fix Home total assets showing exactly double on desktop: dedupe token `$key`s when summing per-network account worth, so cache-floor rounds (which reuse one cached tokenListMap for both token groups) are no longer counted twice.
- Fix PancakeSwap Permit2 revocation being blocked: allow multiple trusted Permit2 addresses per network and add the PancakeSwap deployment to the client whitelist.

## Intent & Context
Two hot-update-targeted production issues on v6.5.0:

1. A user reported (support ticket 906970) that ALL assets were double-counted on desktop (¥78,857 shown vs ¥39,388 real, ratio ≈ 2.0), while the same account on mobile was correct. Clearing app cache did not help. Individual token rows and amounts displayed correctly — only the header totals doubled.
2. After the latest hot update, users reported that revoking a PancakeSwap Permit2 approval was rejected by the client. The server-side approvals whitelist returns both Uniswap Permit2 (`0x000000000022d473030f116ddee9f6b43ac78ba3`) and PancakeSwap Permit2 (`0x31c2f6fcff4f8759b3bd5bf0e1084a055615c768`) (together >99.9% of Permit2 approval records), but the client trusted-address list from #12473 only contained Uniswap.

## Root Cause
**Worth doubling** (diagnosed from the user's desktop logs + code trace):
- `useTokenListReactivePipeline.seedAndFlushCache` (introduced in #12068) builds all-network cache-floor rounds passing the ONE cached full `tokenListMap` as BOTH `tokens.map` and `smallBalanceTokens.map` (the local cache stores a single merged map).
- `buildMergedAllNetworkSnapshot` computes each round's worth via `sumTokenGroupsFiatValueIgnoringUnavailable` = sum(tokens.map) + sum(smallBalanceTokens.map), so every cache-floor network's worth is exactly doubled. List rows stay correct because display maps merge by `$key`.
- The user's logs showed why floors never got replaced by live data: the desktop all-network fan-out issues full-concurrency token-list requests, while the desktop SNI direct-IP channel caps 16 active requests per destination and fails closed (`SNI_RESOURCE_LIMIT`, durationMs=0). ~83 of 98 network requests died every refresh round, so high-value networks (tron/evm/sol) stayed on the doubled cache floor permanently. Mobile uses a capped fan-out and does not hit this, which is why only desktop doubled. Clearing cache cannot help because any successful fetch immediately rebuilds the cache and the doubling is in the floor-round construction, not the cached data.
- Numeric cross-check against the user's screenshots: live-settled low-value networks (~¥1,020) single + floored networks (~¥38,412) doubled ≈ ¥77,844, matching the reported "代币: ¥77,849.43" header within rate-refresh noise.

**Permit2 blocking**: `_assertPermit2ApproveInfo` → `resolveTrustedPermit2Address` returned `undefined` for the PancakeSwap contract, flipping `isPermit2InfoValid` to false and throwing before the revoke tx could be built.

## Design Decisions
- **Worth fix at the summing helper, not the floor-round construction**: making `seedAndFlushCache` pick per-group maps would silently drop aggregate-member token values (aggregate members are not in `tokenList` data) and risky-row display depends on the full map — both display regressions. Deduping by `$key` in `sumTokenGroupsFiatValueIgnoringUnavailable` is a strict no-op for live rounds (their maps are disjoint) and exactly corrects shared-map floor rounds. Minimal, release-safe diff.
- **Keep the client Permit2 whitelist instead of trusting the server**: the `permit2Address` becomes the `to` address of the transaction the user signs; dropping the client check would let a compromised server direct users to sign calls to arbitrary contracts presented as a benign "revoke". Both deployments are deterministic CREATE2 addresses shared across chains, and new mainstream Permit2 deployments are rare (two in four years), so a static two-entry whitelist per network is the right cost/risk trade-off. Structure changed from single address to address list per network to make future additions one-line.
- The desktop SNI 16-per-destination fail-closed limit vs full fan-out (which keeps floors alive and data stale) is a separate issue and intentionally NOT addressed here; it should be tracked independently.

## Changes Detail
- `packages/shared/src/utils/tokenValueUtils.ts`: `sumTokenGroupsFiatValueIgnoringUnavailable` now tracks seen `$key`s across both maps and counts each once.
- `packages/shared/src/utils/tokenValueUtils.test.ts`: unit tests — shared-map shape must not double (5150, not 10300); overlapping keys counted once while distinct keys still sum.
- `packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.test.ts`: integration test — a cache-floor-shaped round (one map reused for all three groups) yields single-counted per-network worth.
- `packages/kit-bg/src/vaults/impls/evm/approveTransactionUtils.ts`: `TRUSTED_PERMIT2_ADDRESSES` is now per-network address lists containing Uniswap + PancakeSwap Permit2; `resolveTrustedPermit2Address` matches against the list. PancakeSwap address EIP-55 checksum verified with ethers `getAddress`.
- `packages/kit-bg/src/vaults/impls/evm/approveTransactionUtils.test.ts`: PancakeSwap Permit2 resolves on all whitelisted networks, still undefined on non-whitelisted networks.
- `development/spellCheckerSkipWords.txt`: add `pancakeswap`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop / Mobile / Web / Extension
- **Risk Areas**: The worth-summing helper is shared by the Home overview, single-network path, and WebAccountPanel — all live callers pass disjoint maps, so behavior only changes for shared-map (cache-floor) inputs, covered by tests. Permit2 change only widens the trusted set; validation logic (amount=0, value=0, selector/decode checks) is untouched.

## Test plan
- [x] Unit + integration tests added (red → green): 8/8 approveTransactionUtils, 34/34 tokenValueUtils + buildMergedAllNetworkSnapshot
- [x] Regression: TokenListBlock suite + tokenList cells + tokenUtils — 16 suites / 209 tests pass
- [x] `yarn agent:check --profile commit` passes (lint, lint-staged, tsc)
- [ ] Manual: offline cold start (cache floor only) — Home total must equal the real portfolio value, not double
- [ ] Manual: revoke a PancakeSwap Permit2 approval on BSC/ETH — transaction builds and reaches the confirmation screen
- [ ] Manual: revoke a Uniswap Permit2 approval — unchanged behavior
