### PR TITLE
chore: pin revenuecat sdk to 10.4.2

### DIFF
--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -727,8 +727,8 @@ PODS:
     - SocketRocket
     - Yoga
   - PromisesObjC (2.4.0)
-  - PurchasesHybridCommon (18.21.0):
-    - RevenueCat (= 5.80.3)
+  - PurchasesHybridCommon (18.19.0):
+    - RevenueCat (= 5.80.2)
   - QuickCrypto (1.1.5):
     - boost
     - DoubleConversion
@@ -4100,7 +4100,7 @@ PODS:
     - Yoga
   - RealmJS (20.2.0):
     - React
-  - RevenueCat (5.80.3)
+  - RevenueCat (5.80.2)
   - RNDateTimePicker (8.4.4):
     - boost
     - DoubleConversion
@@ -4309,8 +4309,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNPurchases (10.4.3):
-    - PurchasesHybridCommon (= 18.21.0)
+  - RNPurchases (10.4.2):
+    - PurchasesHybridCommon (= 18.19.0)
     - React-Core
   - RNReanimated (4.2.1):
     - boost
@@ -5500,7 +5500,7 @@ SPEC CHECKSUMS:
   PerpDepthBar: ea764fd9ca6dde336b3b6ca292e783e2b9c66c69
   Ping: fa822267f2829fc55b444fe503ce3022463d875e
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  PurchasesHybridCommon: 097af88db3cb39b415bef2f3140e6b3324899756
+  PurchasesHybridCommon: 1eb67a6c8997233b35ed9b4eee8205dd8dd92890
   QuickCrypto: fbb50daf9313753153af0e4f67a9f14ec1a26979
   RCT-Folly: b29feb752b08042c62badaef7d453f3bb5e6ae23
   RCTDeprecation: 5eb1d2eeff5fb91151e8a8eef45b6c7658b6c897
@@ -5599,7 +5599,7 @@ SPEC CHECKSUMS:
   ReactNativeSplashScreen: 0bc82cdce113b2f60366b3d0f2a495ff86e13022
   ReactNativeZipArchive: bb4a2b338281c0166bee97142bf59ef9cd124c62
   RealmJS: 1c37c6bdfe060f4caa0f9175aa0eedb962622ee1
-  RevenueCat: 72d1e14966339bf38c41d9b2841ef64c8fd79646
+  RevenueCat: b772273e51fa103a2ecc644439dd54a5dec199f3
   RNDateTimePicker: cda4c045beca864cebb3209ef9cc4094f974864c
   RNGestureHandler: e37bdb684df1ac17c7e1d8f71a3311b2793c186b
   RNGoogleSignin: 628d629e8dca39fc4ab70e30cf55bb3fc284f518
@@ -5607,7 +5607,7 @@ SPEC CHECKSUMS:
   RNJuiceboxSdk: a2e85ef9d73eac5547cc89d0a4b7b0f6e798d253
   RNNotifee: 5e3b271e8ea7456a36eec994085543c9adca9168
   RNPermissions: d0f185d461a25bb0f75fdd58c855ba0988fe18ab
-  RNPurchases: 33dbce0054a0833a8c20c8d6244e971dfedaa0c3
+  RNPurchases: 64e5e656f042c2f20ccdb3fe3ed683664229de73
   RNReanimated: 464375ff2caa801358547c44eca894ff0bf68e74
   RNScreens: afaf526a9c804c3b4503f950cf3e67ed81e29ada
   RNSentry: a20c5194cc6d7902683276f399a6eb5206fb9f05

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -165,7 +165,7 @@
     "react-native-passkeys": "0.3.3",
     "react-native-permissions": "5.4.4",
     "react-native-ping": "npm:@onekeyfe/react-native-ping@3.0.78",
-    "react-native-purchases": "10.4.3",
+    "react-native-purchases": "10.4.2",
     "react-native-qrcode-styled": "0.4.0",
     "react-native-quick-base64": "^3.0.0",
     "react-native-quick-crypto": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10410,7 +10410,7 @@ __metadata:
     react-native-passkeys: "npm:0.3.3"
     react-native-permissions: "npm:5.4.4"
     react-native-ping: "npm:@onekeyfe/react-native-ping@3.0.78"
-    react-native-purchases: "npm:10.4.3"
+    react-native-purchases: "npm:10.4.2"
     react-native-qrcode-styled: "npm:0.4.0"
     react-native-quick-base64: "npm:^3.0.0"
     react-native-quick-crypto: "npm:^1.1.3"
@@ -14563,12 +14563,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@revenuecat/purchases-js-hybrid-mappings@npm:18.21.0":
-  version: 18.21.0
-  resolution: "@revenuecat/purchases-js-hybrid-mappings@npm:18.21.0"
+"@revenuecat/purchases-js-hybrid-mappings@npm:18.19.0":
+  version: 18.19.0
+  resolution: "@revenuecat/purchases-js-hybrid-mappings@npm:18.19.0"
   dependencies:
-    "@revenuecat/purchases-js": "npm:1.47.1"
-  checksum: 10/7205efe31d7b992f86be987ca9200903a74d4b01dbd2bd5d4893991ab3e5e5a1da0f945fb0ad9839b7f83a5d330e46e6f57bb8f44251bc10008825848d3be33f
+    "@revenuecat/purchases-js": "npm:1.47.0"
+  checksum: 10/3b3d51935d5094c6ba1026c1a78d804f219a89d5ff89907b9d9d183f3d9de9dd8b55608fad7c9624e0a354ad82fcaacf2453a63c8c55ef34a16dddc022757a56
   languageName: node
   linkType: hard
 
@@ -14579,17 +14579,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@revenuecat/purchases-js@npm:1.47.1":
-  version: 1.47.1
-  resolution: "@revenuecat/purchases-js@npm:1.47.1"
-  checksum: 10/88c205cce7a59b67ec3d936559f179f466b9427d6e664c97752856510836ad84dfac761a99e7392ce870a46e269d1246a911fef5dc2baa7e3592f30c19eec3ba
+"@revenuecat/purchases-js@npm:1.47.0":
+  version: 1.47.0
+  resolution: "@revenuecat/purchases-js@npm:1.47.0"
+  checksum: 10/c9bf30e7cf748a25b85c5f1ecb9b81aa4a999ae137875dd3773a031eb7a2bc43c7f08c7cea3a189c43f9f39ce388140fdd640296e65ae0bc45b2fd436ed023c8
   languageName: node
   linkType: hard
 
-"@revenuecat/purchases-typescript-internal@npm:18.21.0":
-  version: 18.21.0
-  resolution: "@revenuecat/purchases-typescript-internal@npm:18.21.0"
-  checksum: 10/8edc1fc98a79c05294bac90f3f3a11e4de2f667624e3ffc3bede7b341a9b47971b73b2537181a3c72c20302129680af30134dfceaf65aa1f82c8e128980d291d
+"@revenuecat/purchases-typescript-internal@npm:18.19.0":
+  version: 18.19.0
+  resolution: "@revenuecat/purchases-typescript-internal@npm:18.19.0"
+  checksum: 10/204726a8a9fbb7d90fee0ee30290b2335614f3225cf01a1718b3ea7d13abbdd383ee0757d41ebdfe61580619c19a6a0195ec38c74c70e6d0cc824ef47f46765e
   languageName: node
   linkType: hard
 
@@ -42658,12 +42658,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-purchases@npm:10.4.3":
-  version: 10.4.3
-  resolution: "react-native-purchases@npm:10.4.3"
+"react-native-purchases@npm:10.4.2":
+  version: 10.4.2
+  resolution: "react-native-purchases@npm:10.4.2"
   dependencies:
-    "@revenuecat/purchases-js-hybrid-mappings": "npm:18.21.0"
-    "@revenuecat/purchases-typescript-internal": "npm:18.21.0"
+    "@revenuecat/purchases-js-hybrid-mappings": "npm:18.19.0"
+    "@revenuecat/purchases-typescript-internal": "npm:18.19.0"
   peerDependencies:
     react: ">= 16.6.3"
     react-native: ">= 0.73.0"
@@ -42671,7 +42671,7 @@ __metadata:
   peerDependenciesMeta:
     react-native-web:
       optional: true
-  checksum: 10/1bc2e6d057f3495c27ee238e825afc71012757b513a0addc2aa3e52b83d8c82ad63c4e8bdb504e4fb0f03ca5124e44732ae0f4f61eb4c2312e31f1949ba3c795
+  checksum: 10/eca7cda3c704a3103a91536d2f2cb7e71bf6b93061e531bd0a62a68f2fdc84d4a3841de6d2e0f0068677be9a18dd836689bdb384fbf100eb5d0e821ee2fe3bd7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- follow up on #12593 by pinning `react-native-purchases` from `10.4.3` to `10.4.2`
- satisfy the repository's 7-day minimum release-age gate (`10.4.2` was published on 2026-07-08 UTC)
- keep Google Play Billing compliant: the resolved Android dependency remains Billing `8.3.0`
- sync Yarn and CocoaPods lockfiles (`PurchasesHybridCommon` `18.19.0`, iOS RevenueCat `5.80.2`)

## Validation

- `yarn install --immutable`
- `yarn check:release-age origin/x` — 4 ok, 0 too young
- targeted Prime payment-method Jest test — 4/4 passed
- Android `assembleGoogleRelease` — passed; packaged manifest reports `com.google.android.play.billingclient.version=8.3.0`
- iOS generic-device Release build with code signing disabled — passed
- `yarn agent:check --profile commit` — passed

## Runtime scope

Mobile `main` and `bg` bundles remain version-locked and both Release bundles were built. RevenueCat is configured from the main runtime; no runtime behavior or purchase flow code changes are included.