### PR TITLE
fix: serialize keyless OAuth slot writes with login commits in bg

### DIFF
--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
@@ -137,6 +137,25 @@ const mockReadPersistedAccessTokenBySessionSourceStrict = jest.fn(
 const mockRevokeAuthSessionTokenOnServerBestEffort = jest.fn(
   async (_params: unknown) => undefined,
 );
+const mockClearSupabaseStorageCache = jest.fn();
+
+// bg-side keyless Supabase client used by the guarded slot persist
+// (persistKeylessOAuthSession). Default: setSession succeeds.
+const mockKeylessSetSession = jest.fn(
+  async (_tokens: unknown): Promise<unknown> => ({
+    data: { session: { access_token: 'persisted' } },
+    error: null,
+  }),
+);
+jest.mock('@onekeyhq/shared/src/utils/supabaseClientUtils', () => ({
+  getKeylessSupabaseClient: () => ({
+    client: {
+      auth: {
+        setSession: (tokens: unknown) => mockKeylessSetSession(tokens),
+      },
+    },
+  }),
+}));
 
 // Real retryable-error semantics, driven by a `$$retryable` marker on the
 // rejection so tests can simulate a failed local session refresh.
@@ -174,6 +193,7 @@ jest.mock('./primeAuthSessionAccess', () => ({
   revokeAuthSessionTokenOnServerBestEffort: (params: unknown) =>
     mockRevokeAuthSessionTokenOnServerBestEffort(params),
   clearSupabaseStorageLocalCache: jest.fn(),
+  clearSupabaseStorageCache: () => mockClearSupabaseStorageCache(),
 }));
 
 const {
@@ -1539,7 +1559,7 @@ describe('ServicePrime.apiBindLegacyOneKeyIdOAuth legacy identity guard', () => 
     );
   });
 
-  describe('assertLegacyOneKeyIdOAuthBindPreconditions (UI pre-persist guard)', () => {
+  describe('assertLegacyOneKeyIdOAuthBindPreconditions (persist/bind precondition guard)', () => {
     it('passes when the consented legacy login is live', async () => {
       const { service, simpleDbPrime } = createService();
       simpleDbPrime.getEffectiveAuthSessionSource.mockResolvedValue(
@@ -1600,5 +1620,172 @@ describe('ServicePrime.apiBindLegacyOneKeyIdOAuth legacy identity guard', () => 
         EOneKeyErrorClassNames.OneKeyErrorOneKeyIdLegacyBindStateChanged,
       );
     });
+  });
+});
+
+describe('ServicePrime.persistKeylessOAuthSession bg-owned slot write', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPrimePersistAtom.get.mockImplementation(async () => ({}));
+  });
+
+  it('persists the session and clears the shared storage read cache', async () => {
+    const { service } = createService();
+
+    await service.persistKeylessOAuthSession({
+      accessToken: 'access-a',
+      refreshToken: 'refresh-a',
+    });
+
+    expect(mockKeylessSetSession).toHaveBeenCalledWith({
+      access_token: 'access-a',
+      refresh_token: 'refresh-a',
+    });
+    expect(mockClearSupabaseStorageCache).toHaveBeenCalled();
+  });
+
+  it('preserves the persist failure contract across the bridge (message, httpStatusCode, autoToast, server-logged marker)', async () => {
+    const { service } = createService();
+    mockKeylessSetSession.mockResolvedValueOnce({
+      data: { session: null },
+      error: { message: 'bad gateway', status: 502, code: 'gateway_error' },
+    });
+
+    const error: any = await service
+      .persistKeylessOAuthSession({
+        accessToken: 'access-a',
+        refreshToken: 'refresh-a',
+      })
+      .then(
+        () => undefined,
+        (e: unknown) => e,
+      );
+
+    expect(String(error?.message)).toContain(
+      'Failed to persist Keyless OAuth session: bad gateway status=502 code=gateway_error',
+    );
+    // Every field the main-side wrapper and cleanup guards consume must be
+    // on the serialization allowlist (toPlainErrorObject): httpStatusCode
+    // for transient-vs-definitive classification, autoToast for the global
+    // handler, and the dedup marker in `data` (ad-hoc $$ properties do NOT
+    // survive the bridge).
+    expect(error?.httpStatusCode).toBe(502);
+    expect(error?.autoToast).toBe(true);
+    expect(error?.data).toEqual({ onekeyIdFailureServerLogged: true });
+    expect(mockClearSupabaseStorageCache).not.toHaveBeenCalled();
+  });
+
+  it('keeps status 0 visible in the failure reason (masked transient responses)', async () => {
+    const { service } = createService();
+    mockKeylessSetSession.mockResolvedValueOnce({
+      data: { session: null },
+      error: { message: 'fetch failed', status: 0 },
+    });
+
+    await expect(
+      service.persistKeylessOAuthSession({
+        accessToken: 'access-a',
+        refreshToken: 'refresh-a',
+      }),
+    ).rejects.toThrow('status=0');
+  });
+
+  it('runs the legacy bind guard atomically with the write and aborts with the slot untouched', async () => {
+    const { service, simpleDbPrime } = createService();
+    simpleDbPrime.getEffectiveAuthSessionSource.mockResolvedValue(
+      EPrimeAuthSessionSource.KeylessOAuth,
+    );
+
+    const error: unknown = await service
+      .persistKeylessOAuthSession({
+        accessToken: 'access-a',
+        refreshToken: 'refresh-a',
+        legacyBindGuard: { expectedOnekeyUserId: 'user-l' },
+      })
+      .then(
+        () => undefined,
+        (e: unknown) => e,
+      );
+
+    expect((error as { className?: string }).className).toBe(
+      EOneKeyErrorClassNames.OneKeyErrorOneKeyIdLegacyBindStateChanged,
+    );
+    expect(mockKeylessSetSession).not.toHaveBeenCalled();
+  });
+
+  it('writes the slot when the guarded preconditions hold', async () => {
+    const { service, simpleDbPrime } = createService();
+    simpleDbPrime.getEffectiveAuthSessionSource.mockResolvedValue(
+      EPrimeAuthSessionSource.LegacyEmailSupabase,
+    );
+    mockPrimePersistAtom.get.mockImplementation(async () => ({
+      isLoggedIn: true,
+      onekeyUserId: 'user-l',
+    }));
+
+    await service.persistKeylessOAuthSession({
+      accessToken: 'access-a',
+      refreshToken: 'refresh-a',
+      legacyBindGuard: { expectedOnekeyUserId: 'user-l' },
+    });
+
+    expect(mockKeylessSetSession).toHaveBeenCalled();
+  });
+
+  it('cannot interleave with a login commit: the guard observes a commit that finished first (check->write window closed)', async () => {
+    // The review scenario this method exists for: previously the
+    // precondition check passed OUTSIDE any shared lock, a concurrent
+    // KeylessOAuth login then fully committed, and the flow still overwrote
+    // the winner's slot session — atom/source pointing at the winner while
+    // the slot held the bind flow's OAuth credentials. Now the guard+write
+    // section queues behind the in-flight commit on loginMutex and, once it
+    // runs, observes the committed source and aborts with the slot
+    // untouched.
+    const { service, simpleDbPrime } = createService();
+    const sourceRef: { current: unknown } = {
+      current: EPrimeAuthSessionSource.LegacyEmailSupabase,
+    };
+    simpleDbPrime.getEffectiveAuthSessionSource.mockImplementation(
+      async () => sourceRef.current,
+    );
+    mockPrimePersistAtom.get.mockImplementation(async () => ({
+      isLoggedIn: true,
+      onekeyUserId: 'user-l',
+    }));
+
+    // Hold loginMutex, simulating a concurrent KeylessOAuth login commit in
+    // flight (all login/bind commits serialize on this mutex).
+    const lockAcquired = createDeferred();
+    const releaseLock = createDeferred();
+    const lockHolder = service.loginMutex.runExclusive(async () => {
+      lockAcquired.resolve();
+      await releaseLock.promise;
+    });
+    await lockAcquired.promise;
+
+    const persistPromise = service.persistKeylessOAuthSession({
+      accessToken: 'access-a',
+      refreshToken: 'refresh-a',
+      legacyBindGuard: { expectedOnekeyUserId: 'user-l' },
+    });
+    await flushAsync();
+    // The guarded write must be queued behind the in-flight commit — no
+    // check has run and no bytes have been written yet.
+    expect(mockKeylessSetSession).not.toHaveBeenCalled();
+
+    // The login commits KeylessOAuth before releasing the mutex.
+    sourceRef.current = EPrimeAuthSessionSource.KeylessOAuth;
+    releaseLock.resolve();
+    await lockHolder;
+
+    const error: unknown = await persistPromise.then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    expect((error as { className?: string }).className).toBe(
+      EOneKeyErrorClassNames.OneKeyErrorOneKeyIdLegacyBindStateChanged,
+    );
+    // The winner's slot session was never overwritten.
+    expect(mockKeylessSetSession).not.toHaveBeenCalled();
   });
 });

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -38,6 +38,7 @@ import {
 } from '@onekeyhq/shared/src/utils/oauthProviderUtils';
 import { isLegacyOneKeyIdAccountMissingOAuthIdentity } from '@onekeyhq/shared/src/utils/oneKeyIdAccountUtils';
 import stringUtils from '@onekeyhq/shared/src/utils/stringUtils';
+import { getKeylessSupabaseClient } from '@onekeyhq/shared/src/utils/supabaseClientUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { ETranslateEngine } from '@onekeyhq/shared/types/discovery';
 import type { IApiClientResponse } from '@onekeyhq/shared/types/endpoint';
@@ -64,6 +65,7 @@ import {
 import ServiceBase from '../ServiceBase';
 
 import {
+  clearSupabaseStorageCache,
   clearSupabaseStorageLocalCache,
   readAuthTokenAllowingRetryableAuthError,
   readPersistedAccessTokenBySessionSource,
@@ -845,9 +847,10 @@ class ServicePrime extends ServiceBase {
     accessToken: string;
     callerName: string;
   }) {
-    // Force a fresh local read: on split-runtime targets the bg storage cache
-    // may still hold a pre-login empty probe (up to 30s), whose cross-runtime
-    // invalidation after the UI-side persist is best-effort.
+    // Force a fresh local read: the bg storage cache may still hold a
+    // pre-login empty probe (up to 30s). The guarded persist clears it after
+    // writing, but other slot writers (the bg legacy keyless migration)
+    // do not.
     clearSupabaseStorageLocalCache();
     const slot = await readPersistedAccessTokenBySessionSourceStrict(
       EPrimeAuthSessionSource.KeylessOAuth,
@@ -866,10 +869,11 @@ class ServicePrime extends ServiceBase {
           : `${callerName} ERROR: Keyless OAuth session is not persisted locally`,
       );
     }
-    // Identity check, not just occupancy: persistKeylessOAuthSession runs in
-    // the main runtime OUTSIDE loginMutex, so between the caller's persist
-    // and this bg-side guard a concurrent flow (e.g. ext popup vs expand
-    // tab) can overwrite the shared slot with ANOTHER account's session.
+    // Identity check, not just occupancy: the caller's guarded persist
+    // (persistKeylessOAuthSession) and this login/bind method run in
+    // SEPARATE loginMutex sections, so between the caller's persist and this
+    // bg-side guard a concurrent flow (e.g. ext popup vs expand tab) can
+    // still overwrite the shared slot with ANOTHER account's session.
     // Occupancy alone would then let the POST proceed with account A's
     // token while the committed local state serves account B's slot.
     // Compare the JWT `sub` claims (payload decode only, no signature or
@@ -1230,12 +1234,12 @@ class ServicePrime extends ServiceBase {
    * keyless-slot teardown (the slot may hold or back a concurrent flow's
    * valid login).
    *
-   * Called from the bind UI right BEFORE persisting the keyless OAuth
-   * session into the shared slot (fail-fast that keeps a concurrent login's
-   * slot session untouched), and re-run inside apiBindLegacyOneKeyIdOAuth's
-   * loginMutex section to cover the persist->POST window.
+   * Run inside persistKeylessOAuthSession's loginMutex section when the bind
+   * flow persists the fresh OAuth session (atomic with the slot write, so a
+   * failed assertion always means an untouched slot), and re-run inside
+   * apiBindLegacyOneKeyIdOAuth's loginMutex section to cover the
+   * persist->POST window.
    */
-  @backgroundMethod()
   async assertLegacyOneKeyIdOAuthBindPreconditions({
     expectedOnekeyUserId,
   }: {
@@ -1272,6 +1276,104 @@ class ServicePrime extends ServiceBase {
     }
   }
 
+  /**
+   * Single bg-owned commit path for writing the shared Keyless OAuth session
+   * slot. Every main-runtime slot writer delegates here (see
+   * useSupabaseAuth.persistKeylessOAuthSession), so slot writes serialize on
+   * loginMutex against every login/bind commit instead of racing them from
+   * an unlocked runtime — and the bg-local write also spares the post-persist
+   * bg slot reads their dependence on best-effort cross-runtime cache
+   * invalidation.
+   *
+   * legacyBindGuard closes the legacy bind's check->write window: the
+   * precondition assertion and the slot write execute inside ONE loginMutex
+   * section, so a concurrent KeylessOAuth login can only commit BEFORE it
+   * (the assertion observes the committed source and aborts with the slot
+   * untouched) or AFTER it (that login's own slot identity guard —
+   * assertKeylessSessionPersistedBeforeLogin plus the in-commit-lock re-check
+   * — fails cleanly with the typed slot-replaced error), never between the
+   * check and the write. Without this atomicity the bind flow could overwrite
+   * the slot right after a concurrent login committed, leaving that login's
+   * source/atom pointing at one account while the slot held another
+   * account's credentials.
+   */
+  @backgroundMethod()
+  async persistKeylessOAuthSession({
+    accessToken,
+    refreshToken,
+    legacyBindGuard,
+  }: {
+    accessToken: string;
+    refreshToken: string;
+    // Present only for the legacy->OAuth bind flow: re-assert the consented
+    // legacy login atomically with the slot write (see the method doc).
+    legacyBindGuard?: { expectedOnekeyUserId: string };
+  }): Promise<void> {
+    await this.loginMutex.runExclusive(async () => {
+      if (!accessToken || !refreshToken) {
+        throw new OneKeyLocalError(
+          'persistKeylessOAuthSession ERROR: Invalid session tokens',
+        );
+      }
+      if (legacyBindGuard) {
+        await this.assertLegacyOneKeyIdOAuthBindPreconditions({
+          expectedOnekeyUserId: legacyBindGuard.expectedOnekeyUserId,
+        });
+      }
+      const { data, error } =
+        await getKeylessSupabaseClient().client.auth.setSession({
+          access_token: accessToken,
+          refresh_token: refreshToken,
+        });
+      // setSession returns AuthErrors instead of throwing them. Swallowing
+      // one leaves the shared keyless session slot EMPTY while the caller
+      // continues as if the login stuck — apiOAuthLogin then commits on the
+      // server but the local commit cannot read the token back, surfacing
+      // only as a generic "unknown error" much later. Fail here with the
+      // underlying reason instead (setSession internally performs
+      // GET /auth/v1/user, so e.g. a gateway/WAF rejection of that endpoint
+      // shows up as its HTTP status).
+      if (error || !data?.session) {
+        // Check the type, not truthiness: AuthRetryableFetchError (produced
+        // when sessionPreservingSupabaseFetch masks an intercepted response)
+        // carries status 0, which a truthiness check would silently drop.
+        const statusPart =
+          typeof error?.status === 'number' ? ` status=${error.status}` : '';
+        const codePart = error?.code ? ` code=${error.code}` : '';
+        const reason = `Failed to persist Keyless OAuth session: ${
+          error?.message || 'no session returned'
+        }${statusPart}${codePart}`;
+        // Mirror into exported logs at the failure source — this covers paths
+        // where the error is later swallowed and never reaches the fallback
+        // toast (e.g. useKeylessWallet's apiOAuthLogin try/catch).
+        defaultLogger.prime.subscription.onekeyIdSessionPersistFailed({
+          reason,
+        });
+        // autoToast so callers WITHOUT their own catch/toast (e.g. the
+        // verify-PIN flow, whose onPress rethrows into a voided promise)
+        // still surface the failure via the global handler instead of dying
+        // silently; httpStatusCode kept for transient-vs-definitive
+        // classification. Both survive bridge serialization (see
+        // toPlainErrorObject); the server-logged dedup marker rides in
+        // `data` because ad-hoc `$$` properties do NOT cross the bridge —
+        // the main-side wrapper re-applies markOneKeyIdFailureServerLogged
+        // from it so the fallback toast skips its duplicate @LogToServer
+        // event.
+        throw new OneKeyLocalError({
+          message: reason,
+          autoToast: true,
+          httpStatusCode:
+            typeof error?.status === 'number' ? error.status : undefined,
+          data: { onekeyIdFailureServerLogged: true },
+        });
+      }
+      // The bg storage read cache may still hold a pre-persist probe; the
+      // clear (with its cross-runtime broadcast) makes both the bg slot
+      // guards and the main-runtime session projection re-read fresh bytes.
+      clearSupabaseStorageCache();
+    });
+  }
+
   @backgroundMethod()
   @toastIfError()
   async apiBindLegacyOneKeyIdOAuth({
@@ -1300,9 +1402,10 @@ class ServicePrime extends ServiceBase {
       // KeylessOAuth. Binding is irreversible and one-time per identity, so
       // a wrong-target bind can never be undone or repeated; abort unless
       // the live login is still the legacy-email account the UI showed.
-      // (The same guard already ran UI-side BEFORE the keyless session
-      // persist; this re-run inside loginMutex covers the persist->POST
-      // window.)
+      // (The same guard already ran atomically with the keyless session
+      // persist — inside persistKeylessOAuthSession's loginMutex section;
+      // this re-run covers the persist->POST window between the two mutex
+      // sections.)
       await this.assertLegacyOneKeyIdOAuthBindPreconditions({
         expectedOnekeyUserId,
       });

--- a/packages/kit/src/components/OneKeyAuth/supabase/SupabaseAuthProvider.tsx
+++ b/packages/kit/src/components/OneKeyAuth/supabase/SupabaseAuthProvider.tsx
@@ -207,13 +207,17 @@ export default function SupabaseAuthProvider({ children }: PropsWithChildren) {
         setLegacySession(nextLegacySession);
         setKeylessSession(nextKeylessSession);
         // Auth state events only fire from THIS runtime's client (interactive
-        // flows: verifyOtp / setSession / signOut). In pure-UI runtimes the bg
-        // runtime's token refreshes do NOT emit TOKEN_REFRESHED here — that is
-        // fine because this context only tracks identity (user / isLoggedIn),
+        // flows: verifyOtp / signOut). In pure-UI runtimes the bg runtime's
+        // token refreshes do NOT emit TOKEN_REFRESHED here — that is fine
+        // because this context only tracks identity (user / isLoggedIn),
         // which a token refresh never changes; nothing may read a steady-state
         // access token from this context. Subscribe to BOTH realms' clients:
-        // interactive OAuth flows (persistKeylessOAuthSession / keylessSignOut
-        // in useSupabaseAuth) run against the keyless client in this runtime.
+        // keylessSignOut (useSupabaseAuth) still runs against the keyless
+        // client in this runtime, and on single-runtime targets the bg-owned
+        // keyless persist (ServicePrime.persistKeylessOAuthSession) uses the
+        // same client instance, so its setSession emits here too; on
+        // split-runtime targets that persist is covered by the
+        // PrimeAuthSessionSourceCommitted projection refresh below.
         const legacySubscription = legacyClient.auth.onAuthStateChange(
           (_event, nextSession) => {
             setLegacySession(nextSession);
@@ -247,14 +251,15 @@ export default function SupabaseAuthProvider({ children }: PropsWithChildren) {
   // while staying logged in, so the [isPrimeLoggedIn] effect above never
   // re-resolves the source in that flow and this context would keep
   // selecting the (just signed-out) legacy slot — session=null while the
-  // app is logged in — until restart. bg-side setSession writes (legacy
-  // keyless migration) additionally never emit auth events in this runtime,
-  // leaving the keyless SLOT stale even when the source is re-resolved.
-  // Handle both by re-resolving the source AND re-reading both slots on
-  // every commit. Ordering vs the in-flight bind flow is safe: the slots
-  // converge through the onAuthStateChange subscriptions above regardless
-  // of whether this handler runs before or after the main-side legacy
-  // sign-out / keyless persist.
+  // app is logged in — until restart. bg-side setSession writes (the legacy
+  // keyless migration and, on split-runtime targets, the bg-owned keyless
+  // persist) additionally never emit auth events in this runtime, leaving
+  // the keyless SLOT stale even when the source is re-resolved. Handle both
+  // by re-resolving the source AND re-reading both slots on every commit.
+  // Ordering vs the in-flight bind flow is safe: the slots converge through
+  // the storage re-reads here and the onAuthStateChange subscriptions above
+  // regardless of whether this handler runs before or after the main-side
+  // legacy sign-out.
   useEffect(() => {
     let isActive = true;
     // Pure PROJECTION refresh: re-resolve the source and re-read both

--- a/packages/kit/src/components/OneKeyAuth/supabase/useSupabaseAuth.tsx
+++ b/packages/kit/src/components/OneKeyAuth/supabase/useSupabaseAuth.tsx
@@ -10,7 +10,6 @@ import type { EOAuthSocialLoginProvider } from '@onekeyhq/shared/src/consts/auth
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import errorToastUtils from '@onekeyhq/shared/src/errors/utils/errorToastUtils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { OAuthPopup } from '../OAuthPopup';
@@ -81,62 +80,47 @@ export function useSupabaseAuth() {
   // ============ OAuth Sign In Methods ============
 
   // Persist a Keyless OAuth session into the shared Supabase session storage.
-  // There is a single keyless session slot (one shared native store; the bg
-  // runtime re-reads it from storage), so persisting overwrites any currently
-  // active keyless session. Flows that verify an existing keyless wallet MUST
-  // validate the OAuth account first and only persist after validation passes.
+  // There is a single keyless session slot (one shared native store), so
+  // persisting overwrites any currently active keyless session. Flows that
+  // verify an existing keyless wallet MUST validate the OAuth account first
+  // and only persist after validation passes.
+  //
+  // The write itself is delegated to the bg-owned commit path
+  // (ServicePrime.persistKeylessOAuthSession, serialized on the bg
+  // loginMutex), so no slot write can interleave with a concurrent
+  // login/bind commit. legacyBindGuard makes the bg method re-assert the
+  // legacy bind preconditions atomically with the slot write; its typed
+  // state-changed failure always means the slot was left untouched.
   const persistKeylessOAuthSession = useCallback(
     async ({
       accessToken,
       refreshToken,
+      legacyBindGuard,
     }: {
       accessToken: string;
       refreshToken: string;
+      legacyBindGuard?: { expectedOnekeyUserId: string };
     }): Promise<void> => {
-      const { data, error } = await (
-        await getKeylessSupabaseClient()
-      ).client.auth.setSession({
-        access_token: accessToken,
-        refresh_token: refreshToken,
-      });
-      // setSession returns AuthErrors instead of throwing them. Swallowing
-      // one leaves the shared keyless session slot EMPTY while the caller
-      // continues as if the login stuck — apiOAuthLogin then commits on the
-      // server but the local commit cannot read the token back, surfacing
-      // only as a generic "unknown error" much later. Fail here with the
-      // underlying reason instead (setSession internally performs
-      // GET /auth/v1/user, so e.g. a gateway/WAF rejection of that endpoint
-      // shows up as its HTTP status).
-      if (error || !data?.session) {
-        // Check the type, not truthiness: AuthRetryableFetchError (produced
-        // when sessionPreservingSupabaseFetch masks an intercepted response)
-        // carries status 0, which a truthiness check would silently drop.
-        const statusPart =
-          typeof error?.status === 'number' ? ` status=${error.status}` : '';
-        const codePart = error?.code ? ` code=${error.code}` : '';
-        const reason = `Failed to persist Keyless OAuth session: ${
-          error?.message || 'no session returned'
-        }${statusPart}${codePart}`;
-        // Mirror into exported logs at the failure source — this covers paths
-        // where the error is later swallowed and never reaches the fallback
-        // toast (e.g. useKeylessWallet's apiOAuthLogin try/catch).
-        defaultLogger.prime.subscription.onekeyIdSessionPersistFailed({
-          reason,
+      try {
+        await backgroundApiProxy.servicePrime.persistKeylessOAuthSession({
+          accessToken,
+          refreshToken,
+          legacyBindGuard,
         });
-        // autoToast so callers WITHOUT their own catch/toast (e.g. the
-        // verify-PIN flow, whose onPress rethrows into a voided promise) still
-        // surface the failure via the global handler instead of dying
-        // silently; httpStatusCode kept for transient-vs-definitive
-        // classification. Mark it server-logged so the fallback toast does not
-        // emit a duplicate @LogToServer event for the same failure.
-        const persistError = new OneKeyLocalError({
-          message: reason,
-          autoToast: true,
-          httpStatusCode:
-            typeof error?.status === 'number' ? error.status : undefined,
-        });
-        markOneKeyIdFailureServerLogged(persistError);
-        throw persistError;
+      } catch (error) {
+        // The bg method already mirrored persist failures into exported
+        // logs; its server-logged dedup marker travels in the serialized
+        // `data` payload (`$$` properties do not survive the bridge), so
+        // re-apply the marker here before the error reaches the fallback
+        // toast — otherwise a single failure would emit two @LogToServer
+        // events.
+        if (
+          (error as { data?: { onekeyIdFailureServerLogged?: boolean } })?.data
+            ?.onekeyIdFailureServerLogged
+        ) {
+          markOneKeyIdFailureServerLogged(error);
+        }
+        throw error;
       }
     },
     [],

--- a/packages/kit/src/views/Prime/components/OneKeyIdLegacyOAuthBind/OneKeyIdLegacyOAuthBind.tsx
+++ b/packages/kit/src/views/Prime/components/OneKeyIdLegacyOAuthBind/OneKeyIdLegacyOAuthBind.tsx
@@ -364,17 +364,16 @@ function OneKeyIdLegacyOAuthBindActions({
               provider,
               // TODO: i18n (surfaces as a raw toast via withErrorAutoToast)
               missingTokenMessage: 'OAuth bind failed: access token not found',
-              // Re-assert the consented legacy login right before the fresh
-              // OAuth session would be persisted into the SINGLE shared
-              // keyless slot: if a concurrent surface switched or committed
-              // a KeylessOAuth login during the user-paced OAuth
-              // round-trip, abort while the slot is still untouched — the
-              // typed state-changed error also skips the teardown below.
-              beforePersistSession: async () => {
-                await backgroundApiProxy.servicePrime.assertLegacyOneKeyIdOAuthBindPreconditions(
-                  { expectedOnekeyUserId },
-                );
-              },
+              // Re-assert the consented legacy login atomically with
+              // persisting the fresh OAuth session into the SINGLE shared
+              // keyless slot: the bg-owned persist runs this guard and the
+              // slot write inside one loginMutex section, so a concurrent
+              // KeylessOAuth login committed during the user-paced OAuth
+              // round-trip aborts the bind while the slot is still
+              // untouched — no commit can interleave between the check and
+              // the write. The typed state-changed error also skips the
+              // teardown below.
+              persistLegacyBindGuard: { expectedOnekeyUserId },
             });
             didUseOAuthSignIn = result.didUseOAuthSignIn;
             oauthAccessToken = result.accessToken;
@@ -422,10 +421,11 @@ function OneKeyIdLegacyOAuthBindActions({
                   EOneKeyErrorClassNames.OneKeyErrorOneKeyIdKeylessSessionSlotReplaced,
               }) &&
               // Legacy-bind-state-changed is likewise definitive for THIS
-              // flow only: either nothing was persisted yet (pre-persist
-              // guard threw, slot untouched) or the slot may back the
-              // concurrent login that invalidated the bind — tearing it
-              // down would break that login too.
+              // flow only: either nothing was persisted yet (the guard
+              // inside the bg persist threw atomically with the write, slot
+              // untouched) or the slot may back the concurrent login that
+              // invalidated the bind — tearing it down would break that
+              // login too.
               !errorUtils.isErrorByClassName({
                 error,
                 className:

--- a/packages/kit/src/views/Prime/components/useOneKeyIdLocalKeylessOAuth.ts
+++ b/packages/kit/src/views/Prime/components/useOneKeyIdLocalKeylessOAuth.ts
@@ -109,17 +109,20 @@ export function useOneKeyIdLocalKeylessOAuth({
     async ({
       provider,
       missingTokenMessage,
-      beforePersistSession,
+      persistLegacyBindGuard,
     }: {
       provider: EOAuthSocialLoginProvider;
       missingTokenMessage: string;
-      // Host-supplied guard run right before the fresh OAuth session is
-      // persisted into the SINGLE shared keyless slot. A throw here must
-      // leave the slot untouched (nothing has been persisted yet), so hosts
-      // whose flow depends on state that can change during the user-paced
-      // OAuth round-trip (e.g. the legacy bind's login preconditions) can
-      // abort without clobbering a session a concurrent flow committed.
-      beforePersistSession?: () => Promise<void>;
+      // Host-supplied guard for persisting the fresh OAuth session into the
+      // SINGLE shared keyless slot: forwarded to the bg-owned persist
+      // (ServicePrime.persistKeylessOAuthSession), which re-asserts the
+      // legacy bind preconditions INSIDE the same loginMutex section that
+      // writes the slot. Hosts whose flow depends on state that can change
+      // during the user-paced OAuth round-trip (the legacy bind's login
+      // preconditions) thus abort atomically with the write — a guard
+      // failure always means the slot was left untouched, and no concurrent
+      // login commit can land between the check and the write.
+      persistLegacyBindGuard?: { expectedOnekeyUserId: string };
     }) => {
       let accessToken = '';
       let didUseOAuthSignIn = false;
@@ -173,10 +176,13 @@ export function useOneKeyIdLocalKeylessOAuth({
         // starting state can however be invalidated DURING the user-paced
         // OAuth round-trip by a concurrent surface (e.g. a KeylessOAuth
         // login committing into this shared slot); hosts with such a
-        // dependency re-assert it via beforePersistSession, whose throw
-        // keeps the slot untouched.
-        await beforePersistSession?.();
-        await persistKeylessOAuthSession({ accessToken, refreshToken });
+        // dependency pass persistLegacyBindGuard, which the bg-owned
+        // persist re-asserts atomically with the slot write.
+        await persistKeylessOAuthSession({
+          accessToken,
+          refreshToken,
+          legacyBindGuard: persistLegacyBindGuard,
+        });
       }
 
       return {


### PR DESCRIPTION
Stacked on #12587. Addresses originalix's remaining review thread there ([useOneKeyIdLocalKeylessOAuth.ts:178](https://github.com/OneKeyHQ/app-monorepo/pull/12587#discussion_r3627348363)): the `beforePersistSession` check and the keyless slot write were two independent `await`s with no shared lock or generation CAS between them, so a concurrent KeylessOAuth login could commit in that window and still have its slot session overwritten — leaving the Prime source/atom pointing at the winning account while the shared slot held the bind flow's OAuth credentials.

## Fix: bg-owned serialized commit path for keyless slot writes

**bg (`ServicePrime`)** — new `persistKeylessOAuthSession` background method:
- Performs the keyless `setSession` **in the bg runtime** (precedent: the legacy keyless migration in `ServiceKeylessWallet` already writes via `getKeylessSupabaseClient()` bg-side; the shared native session storage makes the write visible to both runtimes) — inside a `loginMutex.runExclusive` section, the same mutex every login/bind commit serializes on.
- Optional `legacyBindGuard: { expectedOnekeyUserId }` runs `assertLegacyOneKeyIdOAuthBindPreconditions` **inside the same critical section as the slot write**. A concurrent KeylessOAuth login can now only commit BEFORE the section (the guard observes the committed source and aborts with the slot untouched, typed `OneKeyErrorOneKeyIdLegacyBindStateChanged`) or AFTER it (that login's own slot identity guard — pre-POST `sub` check + in-commit-lock re-check — fails cleanly with the typed slot-replaced error). No interleaving reaches the split state.
- The persist error contract is migrated intact: status/code in the message (including the `status=0` masked-transient case), `httpStatusCode` for transient-vs-definitive classification, `autoToast`, and source-side `onekeyIdSessionPersistFailed` logging. The server-logged dedup marker now rides in the serialized `data` payload because ad-hoc `$$` properties do not survive the bg→main bridge.
- Side benefit: the bg-local write frees the pre-login slot guards from depending on best-effort cross-runtime storage-cache invalidation, and on split-runtime targets the session is now written by the runtime that owns token refresh.

**main (kit)** — every keyless slot writer now uses the same boundary:
- `useSupabaseAuth.persistKeylessOAuthSession` becomes a thin bridge delegate (so `useKeylessWallet`'s two persist sites and `performOAuthSignIn`'s `persistSession` path converge on the bg path with no per-call-site changes), re-applying `markOneKeyIdFailureServerLogged` from the serialized marker.
- `getOAuthAccessToken`'s `beforePersistSession` callback (not bridge-serializable) is replaced by the declarative `persistLegacyBindGuard: { expectedOnekeyUserId }`, forwarded into the bg critical section; the bind flow passes the consent captured at button-press time.
- `assertLegacyOneKeyIdOAuthBindPreconditions` is no longer called over the bridge, so its `@backgroundMethod` decorator is dropped.

Known residual (pre-existing, unchanged): the bg legacy keyless migration writes the slot outside `loginMutex` but is guarded by its own anti-clobber checks (active-token + live-source probes documented in `ServiceKeylessWallet`).

## Tests

6 new cases in `ServicePrime.test.ts` (50 total pass), including a direct repro of the review scenario: a login commit holds `loginMutex` while the guarded persist queues behind it; after the commit lands, the guard observes the new source, throws the typed error, and `setSession` is never called. Plus bridge-contract coverage for the persist failure fields. `yarn agent:check --profile commit` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfMAs36NhVUzSFvNL5QVqB)_