### PR TITLE
fix: address revenuecat sdk upgrade regressions

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -151,6 +151,13 @@ const devRouterStub = path.resolve(
   monorepoRoot,
   'packages/kit/src/views/Developer/router.empty.ts',
 );
+// react-native-purchases statically imports its browser implementation, which
+// otherwise pulls the full purchases-js runtime into native bundles even
+// though the linked RNPurchases module is always selected on iOS and Android.
+const revenueCatBrowserMappingsStub = path.resolve(
+  projectRoot,
+  'shims/revenueCatBrowserMappings.js',
+);
 
 // Ledger DMK packages only declare `exports` (no `main`). With
 // unstable_enablePackageExports=false above, Metro can't find the entry
@@ -174,6 +181,15 @@ const ledgerCjsByPackage = new Map(
 );
 
 config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (
+    (platform === 'ios' || platform === 'android') &&
+    moduleName === '@revenuecat/purchases-js-hybrid-mappings'
+  ) {
+    return {
+      type: 'sourceFile',
+      filePath: revenueCatBrowserMappingsStub,
+    };
+  }
   if (moduleName === '@nktkas/hyperliquid/signing') {
     return {
       type: 'sourceFile',

--- a/apps/mobile/scripts/check-startup-graph-budget.js
+++ b/apps/mobile/scripts/check-startup-graph-budget.js
@@ -63,6 +63,7 @@ const FORBIDDEN_NPM_IN_MAIN = [
   '@keystonehq/', // Hardware wallet QR SDK — lazy via qr-wallet-sdk
   '@reown/', //       WalletConnect UI — event-driven lazy mount
   '@bufbuild/protobuf', // Protobuf — transitive dep of @keystonehq
+  '@revenuecat/purchases-js-hybrid-mappings', // Browser-only RevenueCat runtime
 ];
 
 // npm packages that must NEVER appear in the common startup graph.

--- a/apps/mobile/shims/revenueCatBrowserMappings.js
+++ b/apps/mobile/shims/revenueCatBrowserMappings.js
@@ -1,0 +1,5 @@
+'use strict';
+
+// Native builds use the linked RNPurchases module. RevenueCat only reads these
+// browser exports when browser mode is selected.
+module.exports = {};

--- a/packages/kit/src/views/Prime/hooks/primePaymentUtils.test.ts
+++ b/packages/kit/src/views/Prime/hooks/primePaymentUtils.test.ts
@@ -6,8 +6,16 @@ yarn test packages/kit/src/views/Prime/hooks/primePaymentUtils.test.ts
 
 describe('primePaymentUtils', () => {
   describe('normalizeNativePrice', () => {
-    it('keeps RevenueCat prices in major currency units', () => {
-      expect(primePaymentUtils.normalizeNativePrice(29.99)).toBe(29.99);
+    it('keeps current RevenueCat prices in major currency units', () => {
+      expect(primePaymentUtils.normalizeNativePrice(29.99, 'major')).toBe(
+        29.99,
+      );
+    });
+
+    it('converts legacy Android RevenueCat prices from micros', () => {
+      expect(primePaymentUtils.normalizeNativePrice(29_990_000, 'micros')).toBe(
+        29.99,
+      );
     });
   });
 

--- a/packages/kit/src/views/Prime/hooks/primePaymentUtils.test.ts
+++ b/packages/kit/src/views/Prime/hooks/primePaymentUtils.test.ts
@@ -5,6 +5,12 @@ yarn test packages/kit/src/views/Prime/hooks/primePaymentUtils.test.ts
 */
 
 describe('primePaymentUtils', () => {
+  describe('normalizeNativePrice', () => {
+    it('keeps RevenueCat prices in major currency units', () => {
+      expect(primePaymentUtils.normalizeNativePrice(29.99)).toBe(29.99);
+    });
+  });
+
   describe('extractCurrencySymbol', () => {
     it('should extract $ from $183.77', () => {
       expect(primePaymentUtils.extractCurrencySymbol('$183.77')).toBe('$');

--- a/packages/kit/src/views/Prime/hooks/primePaymentUtils.ts
+++ b/packages/kit/src/views/Prime/hooks/primePaymentUtils.ts
@@ -180,10 +180,13 @@ function trackPrimeSubscriptionSuccess({
   });
 }
 
-// PurchasesHybridCommon 18.x exposes subscription prices in major currency
-// units on both iOS and Android.
-function normalizeNativePrice(rawPrice: number): number {
-  return rawPrice;
+function normalizeNativePrice(
+  rawPrice: number,
+  priceUnit: 'major' | 'micros',
+): number {
+  return priceUnit === 'micros'
+    ? new BigNumber(rawPrice || 0).div(1_000_000).toNumber()
+    : rawPrice;
 }
 
 function extractWebPaywallPrice(paywallPackage: {

--- a/packages/kit/src/views/Prime/hooks/primePaymentUtils.ts
+++ b/packages/kit/src/views/Prime/hooks/primePaymentUtils.ts
@@ -180,11 +180,10 @@ function trackPrimeSubscriptionSuccess({
   });
 }
 
-// RevenueCat React Native SDK returns prices in micros on Android, in major
-// units on iOS — normalize to major units here.
+// PurchasesHybridCommon 18.x exposes subscription prices in major currency
+// units on both iOS and Android.
 function normalizeNativePrice(rawPrice: number): number {
-  if (!platformEnv.isNativeAndroid) return rawPrice;
-  return new BigNumber(rawPrice || 0).div(1_000_000).toNumber();
+  return rawPrice;
 }
 
 function extractWebPaywallPrice(paywallPackage: {

--- a/packages/kit/src/views/Prime/hooks/revenueCatNativeCompatibility.native.test.ts
+++ b/packages/kit/src/views/Prime/hooks/revenueCatNativeCompatibility.native.test.ts
@@ -1,0 +1,95 @@
+import { NativeModules } from 'react-native';
+
+import {
+  configureRevenueCat,
+  getRevenueCatRecurringPriceUnit,
+} from './revenueCatNativeCompatibility.native';
+
+const mockConfigure = jest.fn<void, [unknown]>();
+const mockSetupPurchases = jest.fn();
+let mockIsNative = true;
+let mockIsNativeAndroid = true;
+
+jest.mock('react-native', () => ({
+  NativeModules: {
+    RNPurchases: {
+      setupPurchases: (...args: unknown[]) => {
+        mockSetupPurchases(...args);
+      },
+    },
+  },
+}));
+
+jest.mock('react-native-purchases', () => ({
+  __esModule: true,
+  default: {
+    configure: (params: unknown) => mockConfigure(params),
+    PURCHASES_ARE_COMPLETED_BY_TYPE: { REVENUECAT: 'REVENUECAT' },
+    // cspell:disable-next-line
+    STOREKIT_VERSION: { DEFAULT: 'DEFAULT' },
+    ENTITLEMENT_VERIFICATION_MODE: { DISABLED: 'DISABLED' },
+  },
+}));
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: {
+    get isNative() {
+      return mockIsNative;
+    },
+    get isNativeAndroid() {
+      return mockIsNativeAndroid;
+    },
+  },
+}));
+
+type IMockRevenueCatNativeModule = {
+  getVirtualCurrencies?: jest.Mock;
+};
+
+const mockNativeModule =
+  NativeModules.RNPurchases as IMockRevenueCatNativeModule;
+
+describe('revenueCatNativeCompatibility', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsNative = true;
+    mockIsNativeAndroid = true;
+    delete mockNativeModule.getVirtualCurrencies;
+  });
+
+  it('uses the current bridge and major units when the native capability exists', () => {
+    mockNativeModule.getVirtualCurrencies = jest.fn();
+
+    configureRevenueCat({ apiKey: 'rc-key' });
+
+    expect(mockConfigure).toHaveBeenCalledWith({ apiKey: 'rc-key' });
+    expect(mockSetupPurchases).not.toHaveBeenCalled();
+    expect(getRevenueCatRecurringPriceUnit()).toBe('major');
+  });
+
+  it('uses the legacy bridge signature and micros on an older Android shell', () => {
+    configureRevenueCat({ apiKey: 'rc-key' });
+
+    expect(mockConfigure).not.toHaveBeenCalled();
+    expect(mockSetupPurchases).toHaveBeenCalledWith(
+      'rc-key',
+      null,
+      'REVENUECAT',
+      null,
+      'DEFAULT',
+      false,
+      true,
+      'DISABLED',
+      false,
+      false,
+    );
+    expect(getRevenueCatRecurringPriceUnit()).toBe('micros');
+  });
+
+  it('keeps legacy iOS recurring prices in major units', () => {
+    mockIsNativeAndroid = false;
+
+    expect(getRevenueCatRecurringPriceUnit()).toBe('major');
+  });
+});

--- a/packages/kit/src/views/Prime/hooks/revenueCatNativeCompatibility.native.ts
+++ b/packages/kit/src/views/Prime/hooks/revenueCatNativeCompatibility.native.ts
@@ -1,0 +1,55 @@
+import { NativeModules } from 'react-native';
+import PurchasesReactNative from 'react-native-purchases';
+
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+type IRevenueCatNativeModule = {
+  getVirtualCurrencies?: (...args: unknown[]) => unknown;
+  setupPurchases?: (...args: unknown[]) => void;
+};
+
+function getRevenueCatNativeModule(): IRevenueCatNativeModule | undefined {
+  return NativeModules.RNPurchases as IRevenueCatNativeModule | undefined;
+}
+
+function isLegacyRevenueCatNativeBridge(): boolean {
+  const nativeModule = getRevenueCatNativeModule();
+  // Virtual currencies exist in the 10.4.3 bridge but not in the 8.11.9
+  // bridge that can host a newer JS bundle after an OTA update.
+  return (
+    platformEnv.isNative === true &&
+    typeof nativeModule?.setupPurchases === 'function' &&
+    typeof nativeModule.getVirtualCurrencies !== 'function'
+  );
+}
+
+function configureRevenueCat({ apiKey }: { apiKey: string }): void {
+  const nativeModule = getRevenueCatNativeModule();
+  if (isLegacyRevenueCatNativeBridge() && nativeModule?.setupPurchases) {
+    // React Native Purchases 8.11.9 used a 10-argument native bridge. OTA
+    // bundles must preserve that signature when running on an older app shell.
+    nativeModule.setupPurchases(
+      apiKey,
+      null,
+      PurchasesReactNative.PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT,
+      null,
+      PurchasesReactNative.STOREKIT_VERSION.DEFAULT,
+      false,
+      true,
+      PurchasesReactNative.ENTITLEMENT_VERIFICATION_MODE.DISABLED,
+      false,
+      false,
+    );
+    return;
+  }
+
+  PurchasesReactNative.configure({ apiKey });
+}
+
+function getRevenueCatRecurringPriceUnit(): 'major' | 'micros' {
+  return platformEnv.isNativeAndroid && isLegacyRevenueCatNativeBridge()
+    ? 'micros'
+    : 'major';
+}
+
+export { configureRevenueCat, getRevenueCatRecurringPriceUnit };

--- a/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.native.test.tsx
+++ b/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.native.test.tsx
@@ -7,6 +7,7 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 
+import primePaymentUtils from './primePaymentUtils';
 import { usePrimePaymentMethods } from './usePrimePaymentMethods.native';
 
 const mockConfigure = jest.fn<void, [unknown]>();
@@ -32,6 +33,10 @@ const mockEmitToSelf = jest.spyOn(appEventBus, 'emitToSelf');
 const mockIsGooglePlayAvailable = jest.fn(async () => true);
 let mockIsNativeAndroid = false;
 let mockIsNativeIOS = true;
+let mockRecurringPriceUnit: 'major' | 'micros' = 'major';
+const mockTrackPrimeSubscriptionSuccessSpy = jest
+  .spyOn(primePaymentUtils, 'trackPrimeSubscriptionSuccess')
+  .mockImplementation((params) => mockTrackPrimeSubscriptionSuccess(params));
 
 jest.mock('react-intl', () => ({
   useIntl: () => ({ formatMessage: ({ id }: { id: string }) => id }),
@@ -136,15 +141,9 @@ jest.mock('./getPrimePaymentApiKey', () => ({
   getPrimePaymentApiKey: jest.fn(async () => ({ apiKey: 'rc-native-key' })),
 }));
 
-jest.mock('./primePaymentUtils', () => ({
-  __esModule: true,
-  default: {
-    extractNativeFreeTrial: jest.fn(),
-    formatPriceString: jest.fn((value: number) => String(value)),
-    normalizeNativePrice: jest.fn((value: number) => value),
-    trackPrimeSubscriptionSuccess: (params: unknown) =>
-      mockTrackPrimeSubscriptionSuccess(params),
-  },
+jest.mock('./revenueCatNativeCompatibility.native', () => ({
+  configureRevenueCat: (params: unknown) => mockConfigure(params),
+  getRevenueCatRecurringPriceUnit: () => mockRecurringPriceUnit,
 }));
 
 type ISuccessDialogOptions = {
@@ -179,6 +178,7 @@ describe('usePrimePaymentMethods native purchase', () => {
     jest.clearAllMocks();
     mockIsNativeAndroid = false;
     mockIsNativeIOS = true;
+    mockRecurringPriceUnit = 'major';
     setRequestIdleCallback();
     mockGetAppUserID.mockResolvedValue('user-a');
     mockGetOfferings.mockResolvedValue({
@@ -208,16 +208,54 @@ describe('usePrimePaymentMethods native purchase', () => {
 
   afterAll(() => {
     mockEmitToSelf.mockRestore();
+    mockTrackPrimeSubscriptionSuccessSpy.mockRestore();
   });
 
   it.each([
-    ['iOS', false, true],
-    ['Google Play', true, false],
+    {
+      platform: 'iOS',
+      isNativeAndroid: false,
+      isNativeIOS: true,
+      recurringPriceUnit: 'major' as const,
+      rawPricePerYear: 99,
+    },
+    {
+      platform: 'Google Play',
+      isNativeAndroid: true,
+      isNativeIOS: false,
+      recurringPriceUnit: 'major' as const,
+      rawPricePerYear: 99,
+    },
+    {
+      platform: 'legacy Google Play OTA',
+      isNativeAndroid: true,
+      isNativeIOS: false,
+      recurringPriceUnit: 'micros' as const,
+      rawPricePerYear: 99_000_000,
+    },
   ])(
-    'emits after the success dialog closes for an active %s entitlement',
-    async (_platform, isNativeAndroid, isNativeIOS) => {
+    'emits after the success dialog closes for an active $platform entitlement',
+    async ({
+      isNativeAndroid,
+      isNativeIOS,
+      recurringPriceUnit,
+      rawPricePerYear,
+    }) => {
       mockIsNativeAndroid = isNativeAndroid;
       mockIsNativeIOS = isNativeIOS;
+      mockRecurringPriceUnit = recurringPriceUnit;
+      mockGetOfferings.mockResolvedValue({
+        current: {
+          availablePackages: [
+            {
+              product: {
+                ...mockOffering.product,
+                pricePerYear: rawPricePerYear,
+              },
+            },
+          ],
+        },
+      });
       const purchaseResult = {
         customerInfo: {
           entitlements: {
@@ -297,10 +335,49 @@ describe('usePrimePaymentMethods native purchase', () => {
     expect(packages).toEqual([
       expect.objectContaining({
         pricePerMonth: 9,
-        pricePerMonthString: '9',
+        pricePerMonthString: '9 USD',
         pricePerYear: 99,
-        pricePerYearString: '99',
-        priceTotalPerYearString: '99',
+        pricePerYearString: '99 USD',
+        priceTotalPerYearString: '99 USD',
+      }),
+    ]);
+  });
+
+  it('converts legacy Android offering prices from micros', async () => {
+    mockIsNativeAndroid = true;
+    mockIsNativeIOS = false;
+    mockRecurringPriceUnit = 'micros';
+    mockGetOfferings.mockResolvedValue({
+      current: {
+        availablePackages: [
+          {
+            product: {
+              ...mockOffering.product,
+              pricePerMonth: 9_000_000,
+              pricePerYear: 99_000_000,
+            },
+          },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() => usePrimePaymentMethods());
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    let packages: Awaited<
+      ReturnType<NonNullable<typeof result.current.getPackagesNative>>
+    > = [];
+    await act(async () => {
+      packages = (await result.current.getPackagesNative?.()) || [];
+    });
+
+    expect(packages).toEqual([
+      expect.objectContaining({
+        pricePerMonth: 9,
+        pricePerMonthString: '9 USD',
+        pricePerYear: 99,
+        pricePerYearString: '99 USD',
+        priceTotalPerYearString: '99 USD',
       }),
     ]);
   });

--- a/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.native.test.tsx
+++ b/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.native.test.tsx
@@ -269,6 +269,12 @@ describe('usePrimePaymentMethods native purchase', () => {
       );
       // The hook is the single refresh owner: exactly one refresh per purchase.
       expect(mockFetchPrimeUserInfo).toHaveBeenCalledTimes(1);
+      expect(mockTrackPrimeSubscriptionSuccess).toHaveBeenCalledWith({
+        amount: 99,
+        currency: 'USD',
+        subscriptionPeriod: 'P1Y',
+        featureName: undefined,
+      });
       if (isNativeAndroid) {
         expect(mockIsGooglePlayAvailable).toHaveBeenCalledTimes(1);
       } else {
@@ -276,6 +282,28 @@ describe('usePrimePaymentMethods native purchase', () => {
       }
     },
   );
+
+  it('keeps native offering prices in major currency units', async () => {
+    const { result } = renderHook(() => usePrimePaymentMethods());
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    let packages: Awaited<
+      ReturnType<NonNullable<typeof result.current.getPackagesNative>>
+    > = [];
+    await act(async () => {
+      packages = (await result.current.getPackagesNative?.()) || [];
+    });
+
+    expect(packages).toEqual([
+      expect.objectContaining({
+        pricePerMonth: 9,
+        pricePerMonthString: '9',
+        pricePerYear: 99,
+        pricePerYearString: '99',
+        priceTotalPerYearString: '99',
+      }),
+    ]);
+  });
 
   it('does not show success or emit without an active Prime entitlement', async () => {
     mockPurchasePackage.mockResolvedValue({

--- a/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.native.ts
+++ b/packages/kit/src/views/Prime/hooks/usePrimePaymentMethods.native.ts
@@ -33,6 +33,10 @@ import {
 
 import { getPrimePaymentApiKey } from './getPrimePaymentApiKey';
 import primePaymentUtils from './primePaymentUtils';
+import {
+  configureRevenueCat,
+  getRevenueCatRecurringPriceUnit,
+} from './revenueCatNativeCompatibility.native';
 
 import type {
   IPackage,
@@ -105,10 +109,7 @@ export function usePrimePaymentMethods(): IUsePrimePayment {
       // The native setupPurchases runs synchronously on main thread via TurboModule,
       // and performs heavy JSON decoding of cached CustomerInfo causing 5s+ AppHang.
       requestIdleCallback(() => {
-        PurchasesReactNative.configure({
-          apiKey,
-          // useAmazon: true
-        });
+        configureRevenueCat({ apiKey });
         setIsPaymentReady(true);
       });
     })();
@@ -213,14 +214,17 @@ export function usePrimePaymentMethods(): IUsePrimePayment {
     const availablePackages = offerings.current?.availablePackages || [];
     const iosIntroEligibleProductIds =
       await getIOSIntroEligibleProductIds(availablePackages);
+    const recurringPriceUnit = getRevenueCatRecurringPriceUnit();
 
     availablePackages.forEach((p) => {
       const { subscriptionPeriod } = p.product;
       const pricePerYear = primePaymentUtils.normalizeNativePrice(
         p.product.pricePerYear || 0,
+        recurringPriceUnit,
       );
       const pricePerMonth = primePaymentUtils.normalizeNativePrice(
         p.product.pricePerMonth || 0,
+        recurringPriceUnit,
       );
 
       const currencyCode = p.product.currencyCode || '';
@@ -331,7 +335,10 @@ export function usePrimePaymentMethods(): IUsePrimePayment {
             subscriptionPeriod === 'P1Y'
               ? offering.product.pricePerYear
               : offering.product.pricePerMonth;
-          const amount = primePaymentUtils.normalizeNativePrice(rawPrice || 0);
+          const amount = primePaymentUtils.normalizeNativePrice(
+            rawPrice || 0,
+            getRevenueCatRecurringPriceUnit(),
+          );
 
           primePaymentUtils.trackPrimeSubscriptionSuccess({
             amount,


### PR DESCRIPTION
## Summary

- keep RevenueCat native subscription prices in major currency units on Android, fixing Prime price display and purchase-success analytics after the PurchasesHybridCommon 18.x upgrade
- redirect `@revenuecat/purchases-js-hybrid-mappings` to a native-only Metro stub on iOS and Android
- add regression tests for native price display and analytics amounts
- fail the native startup graph check if the browser-only RevenueCat mapping package re-enters the main startup graph

## Root cause

The RevenueCat upgrade in #12593 changed Android `pricePerMonth` and `pricePerYear` from micros to major currency units, while the app still divided those values by `1_000_000`.

The React Native SDK also statically imports its browser implementation. Metro therefore included the approximately 740 KB purchases-js hybrid mapping bundle in native startup code even though iOS and Android use the linked `RNPurchases` module.

## Scope

This PR addresses the two unresolved actionable review threads from #12593. It intentionally does not change or pin the `react-native-purchases` version.

## Runtime impact

On iOS and Android, the changes affect the `main` JS runtime only. The process-owned native RevenueCat instance and the independently initialized `bg` runtime are unchanged. Web RevenueCat browser behavior is unchanged because the Metro redirect is limited to `ios` and `android`.

## Validation

- `yarn install --immutable`
- Prime targeted Jest suites: 2 passed, 19 tests passed
- CI-equivalent native three-bundle union build passed
- native main startup graph: 2,601 modules / 13.08 MB (budget: 3,000 / 13.5 MB)
- native background startup graph: 2,447 modules / 19.28 MB (budget: 2,600 / 19.5 MB)
- bundle architecture check passed
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr` local checks passed before PR creation