### PR TITLE
fix: route legacy keyless migration slot write through login commit boundary

### DIFF
--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.test.ts
@@ -259,6 +259,14 @@ function createService(params: { wallet?: any; password?: string } = {}) {
       })),
       isLoggedIn: jest.fn(async () => true),
       isOAuthProviderBoundToCurrentOneKeyId: jest.fn(async () => false),
+      // Pass-through commit boundary preserving the serial-execution shape;
+      // lock-order and guard behavior are asserted per test.
+      runExclusiveInKeylessSlotCommitBoundary: jest.fn(
+        async (fn: () => Promise<unknown>) => fn(),
+      ),
+      persistKeylessOAuthSessionInsideCommitBoundary: jest.fn(
+        async () => undefined,
+      ),
     },
     servicePassword: {
       getCachedPassword: jest.fn(async () => params.password ?? PASSWORD),
@@ -2088,6 +2096,8 @@ describe('ServiceKeylessWallet legacy keyless OAuth token exchange serialization
 
   test('interactive migration re-checks blob presence inside the lock and returns null without any exchange when it is gone', async () => {
     const { serviceAny, wallet, backgroundApi } = createService();
+    const persistMock =
+      backgroundApi.servicePrime.persistKeylessOAuthSessionInsideCommitBoundary;
     // Blob exists at the cheap pre-prompt check, but is gone by the time the
     // exchange lock is acquired (the passive path consumed it and removed it
     // after a definitive GoTrue rejection while this call waited).
@@ -2124,11 +2134,13 @@ describe('ServiceKeylessWallet legacy keyless OAuth token exchange serialization
       serviceAny.saveLegacyKeylessOAuthRefreshToken,
     ).not.toHaveBeenCalled();
     expect(serviceAny.removeLegacyKeylessOAuthTokens).not.toHaveBeenCalled();
-    expect(mockSupabaseSetSession).not.toHaveBeenCalled();
+    expect(persistMock).not.toHaveBeenCalled();
   });
 
   test('interactive migration queues behind the exchange lock and then consumes the freshly rotated blob token', async () => {
-    const { serviceAny, wallet } = createService();
+    const { serviceAny, wallet, backgroundApi } = createService();
+    const persistMock =
+      backgroundApi.servicePrime.persistKeylessOAuthSessionInsideCommitBoundary;
     serviceAny.hasLegacyKeylessOAuthRefreshToken = jest.fn(async () => true);
     // Simulates the passive path having already rotated the blob while it
     // held the lock: the in-lock re-read must pick up the rotated token,
@@ -2188,24 +2200,30 @@ describe('ServiceKeylessWallet legacy keyless OAuth token exchange serialization
         }),
       }),
     );
-    // …persisted the newly rotated token before setSession, and removed the
-    // blob after the session was installed.
+    // …persisted the newly rotated token before the slot write, and removed
+    // the blob after the session was installed. The slot write itself must
+    // go through ServicePrime's guarded persist core (never a direct
+    // setSession on the shared keyless slot).
     expect(serviceAny.saveLegacyKeylessOAuthRefreshToken).toHaveBeenCalledWith({
       ownerId: OWNER_ID,
       refreshToken: 'interactively-rotated-refresh-token',
       password: PASSWORD,
     });
-    expect(mockSupabaseSetSession).toHaveBeenCalledWith({
-      access_token: TOKEN,
-      refresh_token: 'interactively-rotated-refresh-token',
+    expect(persistMock).toHaveBeenCalledWith({
+      accessToken: TOKEN,
+      refreshToken: 'interactively-rotated-refresh-token',
+      legacyBindGuard: undefined,
     });
+    expect(mockSupabaseSetSession).not.toHaveBeenCalled();
     expect(serviceAny.removeLegacyKeylessOAuthTokens).toHaveBeenCalledWith({
       ownerId: OWNER_ID,
     });
   });
 
   test('interactive migration persists the rotated token before wallet validation so a mismatch cannot strand the consumed token', async () => {
-    const { serviceAny, wallet } = createService();
+    const { serviceAny, wallet, backgroundApi } = createService();
+    const persistMock =
+      backgroundApi.servicePrime.persistKeylessOAuthSessionInsideCommitBoundary;
     serviceAny.hasLegacyKeylessOAuthRefreshToken = jest.fn(async () => true);
     serviceAny.getLegacyKeylessOAuthRefreshToken = jest.fn(
       async () => 'legacy-refresh-token',
@@ -2247,7 +2265,125 @@ describe('ServiceKeylessWallet legacy keyless OAuth token exchange serialization
     });
     // A mismatched session must never be installed, and the blob must not
     // be removed.
-    expect(mockSupabaseSetSession).not.toHaveBeenCalled();
+    expect(persistMock).not.toHaveBeenCalled();
+    expect(serviceAny.removeLegacyKeylessOAuthTokens).not.toHaveBeenCalled();
+  });
+
+  test('interactive migration nests the exchange lock inside the ServicePrime commit boundary and threads the legacy bind guard', async () => {
+    // Lock order (loginMutex outer -> exchange mutex inner) is what closes
+    // the review scenario: a KeylessOAuth login committing during the
+    // password/network wait now serializes against this whole section, so
+    // the migration can never overwrite the winner's slot session — and the
+    // guarded persist re-asserts the bind preconditions atomically with the
+    // write.
+    const { serviceAny, wallet, backgroundApi } = createService();
+    serviceAny.hasLegacyKeylessOAuthRefreshToken = jest.fn(async () => true);
+    serviceAny.getLegacyKeylessOAuthRefreshToken = jest.fn(
+      async () => 'legacy-refresh-token',
+    );
+    serviceAny.saveLegacyKeylessOAuthRefreshToken = jest.fn(
+      async () => undefined,
+    );
+    serviceAny.removeLegacyKeylessOAuthTokens = jest.fn(async () => undefined);
+    serviceAny.validateKeylessAccessTokenMatchesLocalWallet = jest.fn(
+      async () => undefined,
+    );
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        access_token: TOKEN,
+        refresh_token: 'rotated-refresh-token',
+      }),
+    } as any);
+    const boundaryMock =
+      backgroundApi.servicePrime.runExclusiveInKeylessSlotCommitBoundary;
+    const persistMock =
+      backgroundApi.servicePrime.persistKeylessOAuthSessionInsideCommitBoundary;
+    boundaryMock.mockImplementation(async (fn: () => Promise<unknown>) => {
+      // Boundary entered BEFORE the exchange lock (outer position).
+      expect(serviceAny.legacyKeylessOAuthTokenExchangeMutex.isLocked()).toBe(
+        false,
+      );
+      return fn();
+    });
+    persistMock.mockImplementation(async () => {
+      // Slot write runs with the exchange lock still held (inner position),
+      // i.e. inside boundary -> exchange -> persist.
+      expect(serviceAny.legacyKeylessOAuthTokenExchangeMutex.isLocked()).toBe(
+        true,
+      );
+    });
+
+    await expect(
+      serviceAny.migrateLegacyKeylessOAuthSessionForLocalWallet({
+        keylessWallet: wallet,
+        ownerId: OWNER_ID,
+        legacyBindGuard: { expectedOnekeyUserId: 'user-l' },
+      }),
+    ).resolves.toBe(TOKEN);
+
+    expect(boundaryMock).toHaveBeenCalledTimes(1);
+    expect(persistMock).toHaveBeenCalledWith({
+      accessToken: TOKEN,
+      refreshToken: 'rotated-refresh-token',
+      legacyBindGuard: { expectedOnekeyUserId: 'user-l' },
+    });
+    // The interactive prompt must never run inside the boundary: it fires
+    // before any lock is taken (unchanged behavior).
+    expect(
+      backgroundApi.servicePassword.promptPasswordVerify,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  test('interactive migration propagates a guarded-persist rejection and keeps the blob for retry', async () => {
+    // The guarded persist throws the typed state-changed error when a
+    // concurrent KeylessOAuth login already committed: the migration must
+    // NOT remove the legacy blob (the rotated token was already saved back,
+    // so a later attempt can retry) and must surface the typed error to the
+    // caller, whose UI aborts the bind without tearing the shared slot down.
+    const { serviceAny, wallet, backgroundApi } = createService();
+    serviceAny.hasLegacyKeylessOAuthRefreshToken = jest.fn(async () => true);
+    serviceAny.getLegacyKeylessOAuthRefreshToken = jest.fn(
+      async () => 'legacy-refresh-token',
+    );
+    serviceAny.saveLegacyKeylessOAuthRefreshToken = jest.fn(
+      async () => undefined,
+    );
+    serviceAny.removeLegacyKeylessOAuthTokens = jest.fn(async () => undefined);
+    serviceAny.validateKeylessAccessTokenMatchesLocalWallet = jest.fn(
+      async () => undefined,
+    );
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        access_token: TOKEN,
+        refresh_token: 'rotated-refresh-token',
+      }),
+    } as any);
+    const stateChangedError = new Error(
+      'assertLegacyOneKeyIdOAuthBindPreconditions ERROR: Active login is not a legacy email session',
+    );
+    backgroundApi.servicePrime.persistKeylessOAuthSessionInsideCommitBoundary.mockRejectedValue(
+      stateChangedError,
+    );
+
+    await expect(
+      serviceAny.migrateLegacyKeylessOAuthSessionForLocalWallet({
+        keylessWallet: wallet,
+        ownerId: OWNER_ID,
+        legacyBindGuard: { expectedOnekeyUserId: 'user-l' },
+      }),
+    ).rejects.toBe(stateChangedError);
+
+    // Rotated token was saved back before the write attempt; the blob stays
+    // for a later retry.
+    expect(serviceAny.saveLegacyKeylessOAuthRefreshToken).toHaveBeenCalledWith({
+      ownerId: OWNER_ID,
+      refreshToken: 'rotated-refresh-token',
+      password: PASSWORD,
+    });
     expect(serviceAny.removeLegacyKeylessOAuthTokens).not.toHaveBeenCalled();
   });
 });

--- a/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
+++ b/packages/kit-bg/src/services/ServiceKeylessWallet/ServiceKeylessWallet.ts
@@ -3015,18 +3015,23 @@ class ServiceKeylessWallet extends ServiceBase {
   private async migrateLegacyKeylessOAuthSessionForLocalWallet(params: {
     keylessWallet: IDBWallet;
     ownerId: string;
+    // Threaded through from the legacy->OAuth bind flow: the slot write
+    // below re-asserts the consented legacy login atomically inside the
+    // keyless-slot commit boundary (see ServicePrime.persistKeylessOAuthSession).
+    legacyBindGuard?: { expectedOnekeyUserId: string };
   }): Promise<string | null> {
-    const { keylessWallet, ownerId } = params;
+    const { keylessWallet, ownerId, legacyBindGuard } = params;
     if (!(await this.hasLegacyKeylessOAuthRefreshToken({ ownerId }))) {
       return null;
     }
 
-    // Prompt for the password BEFORE taking the exchange lock — holding a
-    // mutex across an interactive prompt would stall the passive migration
-    // for as long as the dialog stays open. Note the prompt itself is what
-    // arms the race this lock exists for: a successful verify caches the
-    // password, which fires tryMigrateLocalExistingKeylessBackendShareToV2
-    // and thus the passive consumer of the same single-use blob token.
+    // Prompt for the password BEFORE taking any lock — holding a mutex
+    // across an interactive prompt would stall the passive migration (and,
+    // for the commit boundary, every login/bind commit) for as long as the
+    // dialog stays open. Note the prompt itself is what arms the race the
+    // exchange lock exists for: a successful verify caches the password,
+    // which fires tryMigrateLocalExistingKeylessBackendShareToV2 and thus
+    // the passive consumer of the same single-use blob token.
     const { password } =
       await this.backgroundApi.servicePassword.promptPasswordVerify();
 
@@ -3035,126 +3040,142 @@ class ServiceKeylessWallet extends ServiceBase {
     // path (which fast-yields), the interactive path queues: the user is
     // actively waiting, and after the passive path finishes the blob holds
     // its rotated — still valid — token, so this attempt still succeeds.
-    return this.legacyKeylessOAuthTokenExchangeMutex.runExclusive(async () => {
-      // Re-check INSIDE the lock and re-read the blob fresh: while this call
-      // waited, the passive migration may have consumed the stored token and
-      // saved a rotated one back (re-read picks it up), or removed the blob
-      // after a definitive GoTrue rejection (return null so callers fall
-      // back to a fresh OAuth login instead of replaying a dead token).
-      if (!(await this.hasLegacyKeylessOAuthRefreshToken({ ownerId }))) {
-        return null;
-      }
+    //
+    // The exchange section nests INSIDE ServicePrime's keyless-slot commit
+    // boundary (loginMutex) so the setSession write at the end is guarded
+    // and serialized against every login/bind commit — a KeylessOAuth login
+    // committing during the password/network wait can no longer have its
+    // slot session overwritten by this migration. Lock order: loginMutex
+    // (outer) -> legacyKeylessOAuthTokenExchangeMutex (inner) — the SAME
+    // order the login/bind commits establish via their post-commit
+    // cleanupLocalKeylessOAuthTokens; never invert it.
+    return this.backgroundApi.servicePrime.runExclusiveInKeylessSlotCommitBoundary(
+      async () =>
+        this.legacyKeylessOAuthTokenExchangeMutex.runExclusive(async () => {
+          // Re-check INSIDE the lock and re-read the blob fresh: while this call
+          // waited, the passive migration may have consumed the stored token and
+          // saved a rotated one back (re-read picks it up), or removed the blob
+          // after a definitive GoTrue rejection (return null so callers fall
+          // back to a fresh OAuth login instead of replaying a dead token).
+          if (!(await this.hasLegacyKeylessOAuthRefreshToken({ ownerId }))) {
+            return null;
+          }
 
-      let refreshToken: string | null = null;
-      try {
-        refreshToken = await this.getLegacyKeylessOAuthRefreshToken({
-          ownerId,
-          password,
-        });
-      } catch (error) {
-        if (this.isKeylessDataCorruptedError(error)) {
-          // The legacy blob can no longer be decrypted (e.g. it was left stale
-          // by a passcode change on an old build). It is unrecoverable and
-          // would fail again on every retry, so drop it and let callers fall
-          // back to a fresh OAuth login.
+          let refreshToken: string | null = null;
+          try {
+            refreshToken = await this.getLegacyKeylessOAuthRefreshToken({
+              ownerId,
+              password,
+            });
+          } catch (error) {
+            if (this.isKeylessDataCorruptedError(error)) {
+              // The legacy blob can no longer be decrypted (e.g. it was left stale
+              // by a passcode change on an old build). It is unrecoverable and
+              // would fail again on every retry, so drop it and let callers fall
+              // back to a fresh OAuth login.
+              await this.removeLegacyKeylessOAuthTokens({ ownerId });
+              return null;
+            }
+            throw error;
+          }
+          if (!refreshToken) {
+            return null;
+          }
+
+          const refreshUrl = `${KEYLESS_SUPABASE_PROJECT_URL}/auth/v1/token?grant_type=refresh_token`;
+          const response = await fetch(refreshUrl, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              // oxlint-disable-next-line @cspell/spellchecker
+              apikey: KEYLESS_SUPABASE_PUBLIC_API_KEY,
+            },
+            body: JSON.stringify({
+              refresh_token: refreshToken,
+            }),
+          });
+          // Transient HTTP failures (auth server down / timeout / rate limited)
+          // keep the blob so a later attempt can retry the exchange.
+          if (
+            response.status >= 500 ||
+            response.status === 408 ||
+            response.status === 429
+          ) {
+            return null;
+          }
+          if (!response.ok) {
+            if (await this.isDefinitiveGoTrueRefreshTokenRejection(response)) {
+              // GoTrue definitively rejected the refresh token (revoked / expired /
+              // already rotated elsewhere). The blob is dead and would fail on
+              // every retry — drop it so prepareOneKeyIdLoginWithLocalKeyless stops
+              // steering to ContinueWithKeyless (passcode prompt + doomed exchange)
+              // and routes to a fresh OAuth login instead. Mirrors the passive
+              // migration path.
+              await this.removeLegacyKeylessOAuthTokens({ ownerId });
+              return null;
+            }
+            // Any other non-OK response (proxy / CDN challenge page, unparseable
+            // body) is not a GoTrue verdict on the token — keep the blob and treat
+            // it like the transient branch above.
+            return null;
+          }
+
+          const refreshResult = (await response.json()) as {
+            access_token?: string;
+            refresh_token?: string;
+          };
+          const accessToken = refreshResult?.access_token;
+          const nextRefreshToken = refreshResult?.refresh_token;
+
+          // Supabase rotates refresh tokens on use — the exchange above already
+          // consumed the stored single-use token, so persist the rotated one
+          // back IMMEDIATELY, before the wallet validation below (mirroring the
+          // passive refresh helper). The rotated token is an identity-equivalent
+          // replacement of what the blob already held, so this save must never
+          // be gated on a validation verdict: a mismatch result (e.g. a
+          // same-email wallet whose local provider was rewritten, or a transient
+          // hash failure classified as a mismatch) would otherwise strand the
+          // consumed token in the blob, and the next attempt's definitive GoTrue
+          // rejection would delete the credential for good. It also means that
+          // if setSession below throws, the blob still holds a usable token for
+          // the next attempt.
+          if (nextRefreshToken) {
+            await this.saveLegacyKeylessOAuthRefreshToken({
+              ownerId,
+              refreshToken: nextRefreshToken,
+              password,
+            });
+          }
+          if (!accessToken || !nextRefreshToken) {
+            return null;
+          }
+
+          const mismatchReason =
+            await this.validateKeylessAccessTokenMatchesLocalWallet({
+              keylessWallet,
+              token: accessToken,
+            });
+          if (mismatchReason) {
+            return null;
+          }
+
+          // Guarded slot write inside the commit boundary already held above:
+          // runs the legacy-bind precondition assertion (when threaded through)
+          // atomically with the setSession write, with the same error contract
+          // as every other keyless slot writer. Never call setSession on the
+          // shared keyless slot directly.
+          await this.backgroundApi.servicePrime.persistKeylessOAuthSessionInsideCommitBoundary(
+            {
+              accessToken,
+              refreshToken: nextRefreshToken,
+              legacyBindGuard,
+            },
+          );
+
           await this.removeLegacyKeylessOAuthTokens({ ownerId });
-          return null;
-        }
-        throw error;
-      }
-      if (!refreshToken) {
-        return null;
-      }
-
-      const refreshUrl = `${KEYLESS_SUPABASE_PROJECT_URL}/auth/v1/token?grant_type=refresh_token`;
-      const response = await fetch(refreshUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          // oxlint-disable-next-line @cspell/spellchecker
-          apikey: KEYLESS_SUPABASE_PUBLIC_API_KEY,
-        },
-        body: JSON.stringify({
-          refresh_token: refreshToken,
+          return accessToken;
         }),
-      });
-      // Transient HTTP failures (auth server down / timeout / rate limited)
-      // keep the blob so a later attempt can retry the exchange.
-      if (
-        response.status >= 500 ||
-        response.status === 408 ||
-        response.status === 429
-      ) {
-        return null;
-      }
-      if (!response.ok) {
-        if (await this.isDefinitiveGoTrueRefreshTokenRejection(response)) {
-          // GoTrue definitively rejected the refresh token (revoked / expired /
-          // already rotated elsewhere). The blob is dead and would fail on
-          // every retry — drop it so prepareOneKeyIdLoginWithLocalKeyless stops
-          // steering to ContinueWithKeyless (passcode prompt + doomed exchange)
-          // and routes to a fresh OAuth login instead. Mirrors the passive
-          // migration path.
-          await this.removeLegacyKeylessOAuthTokens({ ownerId });
-          return null;
-        }
-        // Any other non-OK response (proxy / CDN challenge page, unparseable
-        // body) is not a GoTrue verdict on the token — keep the blob and treat
-        // it like the transient branch above.
-        return null;
-      }
-
-      const refreshResult = (await response.json()) as {
-        access_token?: string;
-        refresh_token?: string;
-      };
-      const accessToken = refreshResult?.access_token;
-      const nextRefreshToken = refreshResult?.refresh_token;
-
-      // Supabase rotates refresh tokens on use — the exchange above already
-      // consumed the stored single-use token, so persist the rotated one
-      // back IMMEDIATELY, before the wallet validation below (mirroring the
-      // passive refresh helper). The rotated token is an identity-equivalent
-      // replacement of what the blob already held, so this save must never
-      // be gated on a validation verdict: a mismatch result (e.g. a
-      // same-email wallet whose local provider was rewritten, or a transient
-      // hash failure classified as a mismatch) would otherwise strand the
-      // consumed token in the blob, and the next attempt's definitive GoTrue
-      // rejection would delete the credential for good. It also means that
-      // if setSession below throws, the blob still holds a usable token for
-      // the next attempt.
-      if (nextRefreshToken) {
-        await this.saveLegacyKeylessOAuthRefreshToken({
-          ownerId,
-          refreshToken: nextRefreshToken,
-          password,
-        });
-      }
-      if (!accessToken || !nextRefreshToken) {
-        return null;
-      }
-
-      const mismatchReason =
-        await this.validateKeylessAccessTokenMatchesLocalWallet({
-          keylessWallet,
-          token: accessToken,
-        });
-      if (mismatchReason) {
-        return null;
-      }
-
-      const setSessionResult =
-        await getKeylessSupabaseClient().client.auth.setSession({
-          access_token: accessToken,
-          refresh_token: nextRefreshToken,
-        });
-      if (setSessionResult.error) {
-        throw new OneKeyLocalError(setSessionResult.error.message);
-      }
-
-      await this.removeLegacyKeylessOAuthTokens({ ownerId });
-      return accessToken;
-    });
+    );
   }
 
   @backgroundMethod()
@@ -3224,7 +3245,14 @@ class ServiceKeylessWallet extends ServiceBase {
   }
 
   @backgroundMethod()
-  async continueOneKeyIdLoginWithLocalKeyless(): Promise<{
+  async continueOneKeyIdLoginWithLocalKeyless(params?: {
+    // Forwarded by the legacy->OAuth bind flow into the migration's guarded
+    // slot write. The session-reuse path above the migration performs no
+    // slot write, so the guard has nothing to protect there — the bind
+    // method itself re-asserts the preconditions inside its own loginMutex
+    // section.
+    legacyBindGuard?: { expectedOnekeyUserId: string };
+  }): Promise<{
     accessToken: string;
     provider: EOAuthSocialLoginProvider;
   }> {
@@ -3270,6 +3298,7 @@ class ServiceKeylessWallet extends ServiceBase {
       accessToken = await this.migrateLegacyKeylessOAuthSessionForLocalWallet({
         keylessWallet: context.keylessWallet,
         ownerId: context.ownerId,
+        legacyBindGuard: params?.legacyBindGuard,
       });
       if (!accessToken) {
         // TODO: i18n

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
@@ -1789,3 +1789,60 @@ describe('ServicePrime.persistKeylessOAuthSession bg-owned slot write', () => {
     expect(mockKeylessSetSession).not.toHaveBeenCalled();
   });
 });
+
+describe('ServicePrime keyless slot commit boundary composition', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPrimePersistAtom.get.mockImplementation(async () => ({}));
+  });
+
+  it('rejects a boundary-skipping caller before touching the slot (tripwire)', async () => {
+    // bg-internal contract: the core slot write may only run inside
+    // runExclusiveInKeylessSlotCommitBoundary. A caller that skips the
+    // boundary (like the pre-fix legacy keyless migration's direct
+    // setSession) must fail loudly instead of silently racing login commits.
+    const { service } = createService();
+
+    await expect(
+      service.persistKeylessOAuthSessionInsideCommitBoundary({
+        accessToken: 'access-a',
+        refreshToken: 'refresh-a',
+      }),
+    ).rejects.toThrow(
+      'must run inside runExclusiveInKeylessSlotCommitBoundary',
+    );
+
+    expect(mockKeylessSetSession).not.toHaveBeenCalled();
+  });
+
+  it('lets a composed bg writer nest its own section inside the boundary (migration shape)', async () => {
+    // Mirrors ServiceKeylessWallet.migrateLegacyKeylessOAuthSessionForLocalWallet:
+    // boundary (loginMutex, outer) -> caller's inner work -> guarded core
+    // write, all in one section.
+    const { service, simpleDbPrime } = createService();
+    simpleDbPrime.getEffectiveAuthSessionSource.mockResolvedValue(
+      EPrimeAuthSessionSource.LegacyEmailSupabase,
+    );
+    mockPrimePersistAtom.get.mockImplementation(async () => ({
+      isLoggedIn: true,
+      onekeyUserId: 'user-l',
+    }));
+
+    const result = await service.runExclusiveInKeylessSlotCommitBoundary(
+      async () => {
+        await service.persistKeylessOAuthSessionInsideCommitBoundary({
+          accessToken: 'access-a',
+          refreshToken: 'refresh-a',
+          legacyBindGuard: { expectedOnekeyUserId: 'user-l' },
+        });
+        return 'migrated-token';
+      },
+    );
+
+    expect(result).toBe('migrated-token');
+    expect(mockKeylessSetSession).toHaveBeenCalledWith({
+      access_token: 'access-a',
+      refresh_token: 'refresh-a',
+    });
+  });
+});

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -848,9 +848,9 @@ class ServicePrime extends ServiceBase {
     callerName: string;
   }) {
     // Force a fresh local read: the bg storage cache may still hold a
-    // pre-login empty probe (up to 30s). The guarded persist clears it after
-    // writing, but other slot writers (the bg legacy keyless migration)
-    // do not.
+    // pre-login empty probe (up to 30s). Every slot writer now clears it
+    // after writing (they all run the guarded persist core), so this is
+    // defense in depth for any cache fill between that clear and this read.
     clearSupabaseStorageLocalCache();
     const slot = await readPersistedAccessTokenBySessionSourceStrict(
       EPrimeAuthSessionSource.KeylessOAuth,
@@ -1278,12 +1278,15 @@ class ServicePrime extends ServiceBase {
 
   /**
    * Single bg-owned commit path for writing the shared Keyless OAuth session
-   * slot. Every main-runtime slot writer delegates here (see
-   * useSupabaseAuth.persistKeylessOAuthSession), so slot writes serialize on
+   * slot. Every slot writer converges here: main-runtime writers delegate
+   * through useSupabaseAuth.persistKeylessOAuthSession, and the bg legacy
+   * keyless migration nests its blob-exchange section inside
+   * runExclusiveInKeylessSlotCommitBoundary and calls the
+   * ...InsideCommitBoundary core. Slot writes therefore serialize on
    * loginMutex against every login/bind commit instead of racing them from
-   * an unlocked runtime — and the bg-local write also spares the post-persist
-   * bg slot reads their dependence on best-effort cross-runtime cache
-   * invalidation.
+   * an unlocked runtime — and the bg-local write also spares the
+   * post-persist bg slot reads their dependence on best-effort cross-runtime
+   * cache invalidation.
    *
    * legacyBindGuard closes the legacy bind's check->write window: the
    * precondition assertion and the slot write execute inside ONE loginMutex
@@ -1309,69 +1312,118 @@ class ServicePrime extends ServiceBase {
     // legacy login atomically with the slot write (see the method doc).
     legacyBindGuard?: { expectedOnekeyUserId: string };
   }): Promise<void> {
-    await this.loginMutex.runExclusive(async () => {
-      if (!accessToken || !refreshToken) {
-        throw new OneKeyLocalError(
-          'persistKeylessOAuthSession ERROR: Invalid session tokens',
-        );
-      }
-      if (legacyBindGuard) {
-        await this.assertLegacyOneKeyIdOAuthBindPreconditions({
-          expectedOnekeyUserId: legacyBindGuard.expectedOnekeyUserId,
-        });
-      }
-      const { data, error } =
-        await getKeylessSupabaseClient().client.auth.setSession({
-          access_token: accessToken,
-          refresh_token: refreshToken,
-        });
-      // setSession returns AuthErrors instead of throwing them. Swallowing
-      // one leaves the shared keyless session slot EMPTY while the caller
-      // continues as if the login stuck — apiOAuthLogin then commits on the
-      // server but the local commit cannot read the token back, surfacing
-      // only as a generic "unknown error" much later. Fail here with the
-      // underlying reason instead (setSession internally performs
-      // GET /auth/v1/user, so e.g. a gateway/WAF rejection of that endpoint
-      // shows up as its HTTP status).
-      if (error || !data?.session) {
-        // Check the type, not truthiness: AuthRetryableFetchError (produced
-        // when sessionPreservingSupabaseFetch masks an intercepted response)
-        // carries status 0, which a truthiness check would silently drop.
-        const statusPart =
-          typeof error?.status === 'number' ? ` status=${error.status}` : '';
-        const codePart = error?.code ? ` code=${error.code}` : '';
-        const reason = `Failed to persist Keyless OAuth session: ${
-          error?.message || 'no session returned'
-        }${statusPart}${codePart}`;
-        // Mirror into exported logs at the failure source — this covers paths
-        // where the error is later swallowed and never reaches the fallback
-        // toast (e.g. useKeylessWallet's apiOAuthLogin try/catch).
-        defaultLogger.prime.subscription.onekeyIdSessionPersistFailed({
-          reason,
-        });
-        // autoToast so callers WITHOUT their own catch/toast (e.g. the
-        // verify-PIN flow, whose onPress rethrows into a voided promise)
-        // still surface the failure via the global handler instead of dying
-        // silently; httpStatusCode kept for transient-vs-definitive
-        // classification. Both survive bridge serialization (see
-        // toPlainErrorObject); the server-logged dedup marker rides in
-        // `data` because ad-hoc `$$` properties do NOT cross the bridge —
-        // the main-side wrapper re-applies markOneKeyIdFailureServerLogged
-        // from it so the fallback toast skips its duplicate @LogToServer
-        // event.
-        throw new OneKeyLocalError({
-          message: reason,
-          autoToast: true,
-          httpStatusCode:
-            typeof error?.status === 'number' ? error.status : undefined,
-          data: { onekeyIdFailureServerLogged: true },
-        });
-      }
-      // The bg storage read cache may still hold a pre-persist probe; the
-      // clear (with its cross-runtime broadcast) makes both the bg slot
-      // guards and the main-runtime session projection re-read fresh bytes.
-      clearSupabaseStorageCache();
+    await this.runExclusiveInKeylessSlotCommitBoundary(async () => {
+      await this.persistKeylessOAuthSessionInsideCommitBoundary({
+        accessToken,
+        refreshToken,
+        legacyBindGuard,
+      });
     });
+  }
+
+  /**
+   * bg-internal entry to the keyless-slot commit boundary — the loginMutex
+   * section every login/bind commit serializes on. For bg slot writers that
+   * must COMPOSE the guarded slot write with their own inner serialization
+   * (e.g. the legacy keyless migration, whose blob-exchange section must
+   * stay atomic with its slot write). Lock order: loginMutex (this
+   * boundary, outer) -> caller's inner mutex — the same order the login/bind
+   * commits already establish by taking the legacy-blob exchange mutex
+   * (cleanupLocalKeylessOAuthTokens) inside their loginMutex sections.
+   * Never call from code that already holds loginMutex (non-reentrant).
+   */
+  async runExclusiveInKeylessSlotCommitBoundary<T>(
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    return this.loginMutex.runExclusive(fn);
+  }
+
+  /**
+   * Slot-write core of persistKeylessOAuthSession. bg-internal: the caller
+   * MUST already be inside runExclusiveInKeylessSlotCommitBoundary so the
+   * optional legacy-bind precondition assertion and the setSession write
+   * stay atomic against login/bind commits (see persistKeylessOAuthSession's
+   * doc for the interleaving analysis).
+   */
+  async persistKeylessOAuthSessionInsideCommitBoundary({
+    accessToken,
+    refreshToken,
+    legacyBindGuard,
+  }: {
+    accessToken: string;
+    refreshToken: string;
+    legacyBindGuard?: { expectedOnekeyUserId: string };
+  }): Promise<void> {
+    // Tripwire, not a lock: catches a caller that skipped the boundary
+    // (isLocked is also true when another section holds the mutex, but a
+    // boundary-skipping caller racing an active section is exactly the bug
+    // this guards against surfacing silently).
+    if (!this.loginMutex.isLocked()) {
+      throw new OneKeyLocalError(
+        'persistKeylessOAuthSessionInsideCommitBoundary ERROR: must run inside runExclusiveInKeylessSlotCommitBoundary',
+      );
+    }
+    if (!accessToken || !refreshToken) {
+      throw new OneKeyLocalError(
+        'persistKeylessOAuthSession ERROR: Invalid session tokens',
+      );
+    }
+    if (legacyBindGuard) {
+      await this.assertLegacyOneKeyIdOAuthBindPreconditions({
+        expectedOnekeyUserId: legacyBindGuard.expectedOnekeyUserId,
+      });
+    }
+    const { data, error } =
+      await getKeylessSupabaseClient().client.auth.setSession({
+        access_token: accessToken,
+        refresh_token: refreshToken,
+      });
+    // setSession returns AuthErrors instead of throwing them. Swallowing
+    // one leaves the shared keyless session slot EMPTY while the caller
+    // continues as if the login stuck — apiOAuthLogin then commits on the
+    // server but the local commit cannot read the token back, surfacing
+    // only as a generic "unknown error" much later. Fail here with the
+    // underlying reason instead (setSession internally performs
+    // GET /auth/v1/user, so e.g. a gateway/WAF rejection of that endpoint
+    // shows up as its HTTP status).
+    if (error || !data?.session) {
+      // Check the type, not truthiness: AuthRetryableFetchError (produced
+      // when sessionPreservingSupabaseFetch masks an intercepted response)
+      // carries status 0, which a truthiness check would silently drop.
+      const statusPart =
+        typeof error?.status === 'number' ? ` status=${error.status}` : '';
+      const codePart = error?.code ? ` code=${error.code}` : '';
+      const reason = `Failed to persist Keyless OAuth session: ${
+        error?.message || 'no session returned'
+      }${statusPart}${codePart}`;
+      // Mirror into exported logs at the failure source — this covers paths
+      // where the error is later swallowed and never reaches the fallback
+      // toast (e.g. useKeylessWallet's apiOAuthLogin try/catch).
+      defaultLogger.prime.subscription.onekeyIdSessionPersistFailed({
+        reason,
+      });
+      // autoToast so callers WITHOUT their own catch/toast (e.g. the
+      // verify-PIN flow, whose onPress rethrows into a voided promise)
+      // still surface the failure via the global handler instead of dying
+      // silently; httpStatusCode kept for transient-vs-definitive
+      // classification. Both survive bridge serialization (see
+      // toPlainErrorObject); the server-logged dedup marker rides in
+      // `data` because ad-hoc `$$` properties do NOT cross the bridge —
+      // the main-side wrapper re-applies markOneKeyIdFailureServerLogged
+      // from it so the fallback toast skips its duplicate @LogToServer
+      // event.
+      throw new OneKeyLocalError({
+        message: reason,
+        autoToast: true,
+        httpStatusCode:
+          typeof error?.status === 'number' ? error.status : undefined,
+        data: { onekeyIdFailureServerLogged: true },
+      });
+    }
+    // The bg storage read cache may still hold a pre-persist probe; the
+    // clear (with its cross-runtime broadcast) makes both the bg slot
+    // guards and the main-runtime session projection re-read fresh bytes.
+    clearSupabaseStorageCache();
   }
 
   @backgroundMethod()

--- a/packages/kit/src/views/Prime/components/useOneKeyIdLocalKeylessOAuth.ts
+++ b/packages/kit/src/views/Prime/components/useOneKeyIdLocalKeylessOAuth.ts
@@ -7,7 +7,9 @@ import { showKeylessWalletAccountMismatchError } from '@onekeyhq/kit/src/compone
 import { useOneKeyAuth } from '@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth';
 import type { EOAuthSocialLoginProvider } from '@onekeyhq/shared/src/consts/authConsts';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import { EOneKeyErrorClassNames } from '@onekeyhq/shared/src/errors/types/errorTypes';
 import errorToastUtils from '@onekeyhq/shared/src/errors/utils/errorToastUtils';
+import errorUtils from '@onekeyhq/shared/src/errors/utils/errorUtils';
 import {
   EOneKeyIdLoginWithLocalKeylessPrepareStatus,
   type IOneKeyIdLoginWithLocalKeylessPrepareResult,
@@ -132,19 +134,46 @@ export function useOneKeyIdLocalKeylessOAuth({
       if (shouldTryLocalKeylessSession) {
         try {
           const result =
-            await backgroundApiProxy.serviceKeylessWallet.continueOneKeyIdLoginWithLocalKeyless();
+            await backgroundApiProxy.serviceKeylessWallet.continueOneKeyIdLoginWithLocalKeyless(
+              // The migration path inside writes the shared keyless slot;
+              // its guarded persist re-asserts the legacy bind
+              // preconditions atomically with that write, same as the
+              // fresh-OAuth persist below.
+              { legacyBindGuard: persistLegacyBindGuard },
+            );
           accessToken = result.accessToken;
         } catch (error) {
-          // Dead/expired legacy blob -> fall back to a fresh OAuth
-          // round-trip below. But a user-initiated cancel (the legacy-blob
-          // migration's passcode prompt was dismissed) must settle the flow
-          // instead — a "Cancel" click must never escalate into opening the
-          // system browser. Both hosts skip toasts for cancel-style errors
+          // A user-initiated cancel (the legacy-blob migration's passcode
+          // prompt was dismissed) must settle the flow — a "Cancel" click
+          // must never escalate into opening the system browser. Both hosts
+          // skip toasts for cancel-style errors
           // (errorToastUtils.isUserCancelStyleError), so rethrowing is
           // silent there.
           if (errorToastUtils.isUserCancelStyleError(error)) {
             throw error;
           }
+          // The migration's guarded slot write failed the legacy bind
+          // preconditions: they are gone for good, so falling back to the
+          // fresh OAuth round-trip below would only fail the same guard
+          // again AFTER a pointless Google/Apple login. Propagate so the
+          // host aborts now (its cleanup exemption keys off this className
+          // and leaves the shared slot alone).
+          if (
+            errorUtils.isErrorByClassName({
+              error,
+              className:
+                EOneKeyErrorClassNames.OneKeyErrorOneKeyIdLegacyBindStateChanged,
+            })
+          ) {
+            throw error;
+          }
+          // Dead/expired legacy blob (or a slot-persist failure inside the
+          // migration) -> fall back to a fresh OAuth round-trip below. The
+          // bridged error may carry autoToast (the guarded persist's
+          // failure contract); cancel the scheduled toast — this path
+          // recovers, so surfacing the swallowed failure would read as a
+          // spurious error.
+          errorToastUtils.toastIfErrorDisable(error);
           accessToken = '';
         }
       }


### PR DESCRIPTION
Stacked on #12587 (follow-up to #12598). Addresses originalix's review there ([useOneKeyIdLocalKeylessOAuth.ts:184](https://github.com/OneKeyHQ/app-monorepo/pull/12587#discussion_r3628678842)): when `continueOneKeyIdLoginWithLocalKeyless()` has no reusable session, the legacy keyless migration in `ServiceKeylessWallet` exchanged the blob token and wrote the shared keyless slot via a direct `setSession()` — outside `ServicePrime.loginMutex` and without the legacy-bind precondition guard, so a KeylessOAuth login committing during the password/network wait could still have its slot session overwritten by the migration, reproducing the split state (`source`/atom on the winner, slot holding the migrated account's credentials).

## Fix

**`ServicePrime`** — the guarded persist is split so bg writers can compose with it:
- `runExclusiveInKeylessSlotCommitBoundary(fn)`: bg-internal entry to the loginMutex commit boundary, for writers that must keep their own inner serialization atomic with the slot write. Lock order is documented and matches what login/bind commits already establish (`loginMutex` outer → legacy-blob exchange mutex inner, via post-commit `cleanupLocalKeylessOAuthTokens`) — no new lock-order edge, no ABBA risk with the existing `loginMutex`-held cleanup that takes the exchange mutex.
- `persistKeylessOAuthSessionInsideCommitBoundary(...)`: the slot-write core (guard + `setSession` + error contract + cache clear), with a tripwire that rejects boundary-skipping callers. The public bridged `persistKeylessOAuthSession` is now boundary + core, behavior unchanged.

**`ServiceKeylessWallet.migrateLegacyKeylessOAuthSessionForLocalWallet`**:
- The whole blob-exchange section now nests inside the commit boundary (password prompt stays outside all locks, unchanged), and the direct `setSession` is replaced by the guarded core write with an optional `legacyBindGuard` threaded from the bind flow via `continueOneKeyIdLoginWithLocalKeyless({ legacyBindGuard })`. The blob's rotated-token save-before-validation ordering is untouched; a guarded-persist rejection leaves the blob in place for retry.
- `getOrMigrateKeylessOAuthAccessTokenForLocalWallet` (PIN-verify path) gets the same boundary automatically, with no guard (not a bind flow).

**`useOneKeyIdLocalKeylessOAuth`**:
- Forwards `persistLegacyBindGuard` into `continueOneKeyIdLoginWithLocalKeyless`.
- Its fallback catch now rethrows the typed `OneKeyErrorOneKeyIdLegacyBindStateChanged` (falling back would only re-fail the same guard after a pointless OAuth round-trip; the host's cleanup exemption keys off this className) and cancels the scheduled bridged auto-toast before silently recovering from other migration failures, preserving the previous silent-fallback behavior.

## Tests

- `ServiceKeylessWallet.test.ts`: migration suite updated to the guarded core write; new lock-order/nesting test (boundary entered before the exchange lock, slot write runs with the exchange lock held, guard threaded through) and a guarded-persist rejection test (blob kept for retry). 
- `ServicePrime.test.ts`: boundary tripwire + composed-writer (migration shape) tests.
- 128 tests pass across both suites; `yarn agent:check --profile commit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfMAs36NhVUzSFvNL5QVqB

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfMAs36NhVUzSFvNL5QVqB)_