### PR TITLE
fix: stabilize market loading fallback (OK-58323)

### DIFF
--- a/packages/kit/src/routes/Tab/Marktet/router.ts
+++ b/packages/kit/src/routes/Tab/Marktet/router.ts
@@ -9,13 +9,17 @@ import {
   LazyLoadRootTabPage,
 } from '../../../components/LazyLoadPage';
 import { createMarketDetailV2Route } from '../../../views/Market/MarketDetailV2/MarketDetailV2Route';
+import { MarketHomeLoadingFallback } from '../../../views/Market/MarketHomeV2/components/MarketHomeLoadingFallback';
 import { RootTabLoadingFallback } from '../RootTabLoadingFallback';
 
 import { MarketDetailV2LoadingFallback } from './MarketDetailV2LoadingFallback';
 
 const MarketHome = LazyLoadRootTabPage(
   () => import(/* webpackPrefetch: true */ '../../../views/Market/MarketHome'),
-  createElement(RootTabLoadingFallback, { tabRoute: ETabRoutes.Market }),
+  createElement(RootTabLoadingFallback, {
+    tabRoute: ETabRoutes.Market,
+    mobileContentFallback: createElement(MarketHomeLoadingFallback),
+  }),
 );
 
 const MarketDetail = LazyLoadPage(

--- a/packages/kit/src/routes/Tab/RootTabLoadingFallback.test.tsx
+++ b/packages/kit/src/routes/Tab/RootTabLoadingFallback.test.tsx
@@ -1,0 +1,108 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
+
+import { RootTabLoadingFallback } from './RootTabLoadingFallback';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __rootTabLoadingFallbackMedia: { md: boolean };
+  // eslint-disable-next-line no-var
+  var __rootTabLoadingFallbackPlatformEnv: { isNative: boolean };
+}
+
+jest.mock('@onekeyhq/components', () => ({
+  Page: {
+    Header: () => <div data-testid="page-header" />,
+  },
+  Spinner: () => <div data-testid="loading-spinner" />,
+  Stack: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  useMedia: () => globalThis.__rootTabLoadingFallbackMedia,
+}));
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => {
+  const platformEnv = { isNative: false };
+  globalThis.__rootTabLoadingFallbackPlatformEnv = platformEnv;
+  return {
+    __esModule: true,
+    default: platformEnv,
+  };
+});
+
+jest.mock('../../components/AccountSelector', () => ({
+  AccountSelectorProviderMirror: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+jest.mock('../../components/TabPageHeader', () => ({
+  TabPageHeader: () => <div data-testid="tab-page-header" />,
+}));
+
+const marketTabRoute = 'Market' as ETabRoutes;
+
+beforeEach(() => {
+  globalThis.__rootTabLoadingFallbackMedia = { md: false };
+  globalThis.__rootTabLoadingFallbackPlatformEnv.isNative = false;
+});
+
+describe('RootTabLoadingFallback', () => {
+  it('keeps the web header and route-specific chrome mounted on small screens', () => {
+    globalThis.__rootTabLoadingFallbackMedia = { md: true };
+
+    render(
+      <RootTabLoadingFallback
+        tabRoute={marketTabRoute}
+        mobileContentFallback={<div data-testid="mobile-content-fallback" />}
+      />,
+    );
+
+    expect(screen.getByTestId('mobile-content-fallback')).toBeTruthy();
+    expect(screen.getByTestId('tab-page-header')).toBeTruthy();
+    expect(screen.queryByTestId('loading-spinner')).toBeNull();
+    expect(screen.queryByTestId('page-header')).toBeNull();
+  });
+
+  it('uses the neutral spinner on native', () => {
+    globalThis.__rootTabLoadingFallbackMedia = { md: true };
+    globalThis.__rootTabLoadingFallbackPlatformEnv.isNative = true;
+
+    render(
+      <RootTabLoadingFallback
+        tabRoute={marketTabRoute}
+        mobileContentFallback={<div data-testid="mobile-content-fallback" />}
+      />,
+    );
+
+    expect(screen.getByTestId('loading-spinner')).toBeTruthy();
+    expect(screen.queryByTestId('mobile-content-fallback')).toBeNull();
+    expect(screen.queryByTestId('tab-page-header')).toBeNull();
+  });
+
+  it('preserves the neutral fallback for small web routes without custom chrome', () => {
+    globalThis.__rootTabLoadingFallbackMedia = { md: true };
+
+    render(<RootTabLoadingFallback tabRoute={marketTabRoute} />);
+
+    expect(screen.getByTestId('page-header')).toBeTruthy();
+    expect(screen.getByTestId('loading-spinner')).toBeTruthy();
+    expect(screen.queryByTestId('tab-page-header')).toBeNull();
+  });
+
+  it('preserves the desktop tab page header on wide web screens', () => {
+    render(
+      <RootTabLoadingFallback
+        tabRoute={marketTabRoute}
+        mobileContentFallback={<div data-testid="mobile-content-fallback" />}
+      />,
+    );
+
+    expect(screen.getByTestId('tab-page-header')).toBeTruthy();
+    expect(screen.getByTestId('loading-spinner')).toBeTruthy();
+    expect(screen.queryByTestId('mobile-content-fallback')).toBeNull();
+  });
+});

--- a/packages/kit/src/routes/Tab/RootTabLoadingFallback.tsx
+++ b/packages/kit/src/routes/Tab/RootTabLoadingFallback.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 import { Page, Spinner, Stack, useMedia } from '@onekeyhq/components';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
@@ -20,16 +22,18 @@ type IRootTabLoadingFallbackProps = {
   tabRoute: ETabRoutes;
   sceneName?: EAccountSelectorSceneName;
   enabledNum?: number[];
+  mobileContentFallback?: ReactNode;
 };
 
 export function RootTabLoadingFallback({
   tabRoute,
   sceneName = EAccountSelectorSceneName.home,
   enabledNum = DEFAULT_ENABLED_NUM,
+  mobileContentFallback,
 }: IRootTabLoadingFallbackProps) {
   const media = useMedia();
 
-  if (platformEnv.isNative || media.md) {
+  if (platformEnv.isNative || (media.md && !mobileContentFallback)) {
     return (
       <>
         <Page.Header headerShown={false} />
@@ -47,7 +51,11 @@ export function RootTabLoadingFallback({
       enabledNum={enabledNum}
     >
       <TabPageHeader sceneName={sceneName} tabRoute={tabRoute} />
-      <LoadingSpinner />
+      {media.md && mobileContentFallback ? (
+        mobileContentFallback
+      ) : (
+        <LoadingSpinner />
+      )}
     </AccountSelectorProviderMirror>
   );
 }

--- a/packages/kit/src/views/Market/MarketHomeV2/MarketHomeV2.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/MarketHomeV2.tsx
@@ -31,6 +31,7 @@ import { preloadMarketHomeTokenListSeed } from '../utils/marketHomeTokenListSeed
 import { markMarketPerf } from '../utils/marketPerf';
 import { useMarketRenderCommitProbe } from '../utils/marketReactPerf';
 
+import { MarketHomeLoadingFallback } from './components/MarketHomeLoadingFallback';
 import { useNetworkAnalytics, useTabAnalytics } from './hooks';
 import { DesktopLayout } from './layouts/DesktopLayout';
 import { shouldRestoreSpotCategoryFromAtom } from './layouts/marketTabSelectionGuards';
@@ -310,7 +311,9 @@ function BaseMarketHomeLayout() {
 
   if (shouldWaitForSpotCategoryReady) {
     return (
-      <LazyPageContainer eager={platformEnv.isWeb}>{null}</LazyPageContainer>
+      <LazyPageContainer eager={platformEnv.isWeb}>
+        {md && !platformEnv.isNative ? <MarketHomeLoadingFallback /> : null}
+      </LazyPageContainer>
     );
   }
 

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketHomeLoadingFallback.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketHomeLoadingFallback.tsx
@@ -1,0 +1,58 @@
+import {
+  Divider,
+  Skeleton,
+  Spinner,
+  Stack,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
+
+const MARKET_HOME_TAB_BAR_HEIGHT = 44;
+const MARKET_HOME_BANNER_HEIGHT = 134;
+const MARKET_HOME_BANNER_ITEM_HEIGHT = 118;
+const MARKET_HOME_BANNER_ITEM_WIDTH = 128;
+const BANNER_SKELETON_COUNT = 3;
+const TAB_LABEL_SKELETON_WIDTHS = [32, 32, 32, 32] as const;
+
+export function MarketHomeLoadingFallback() {
+  return (
+    <YStack flex={1} bg="$bgApp" testID="market-home-loading-fallback">
+      <XStack
+        h={MARKET_HOME_BANNER_HEIGHT}
+        flexShrink={0}
+        alignItems="center"
+        px="$4"
+        py="$2"
+        gap="$3"
+        overflow="hidden"
+        testID="market-home-banner-skeleton"
+      >
+        {Array.from({ length: BANNER_SKELETON_COUNT }, (_, index) => (
+          <Skeleton
+            key={index}
+            h={MARKET_HOME_BANNER_ITEM_HEIGHT}
+            w={MARKET_HOME_BANNER_ITEM_WIDTH}
+            flexShrink={0}
+            radius={12}
+          />
+        ))}
+      </XStack>
+      <YStack flexShrink={0} testID="market-home-tab-bar-skeleton">
+        <XStack
+          h={MARKET_HOME_TAB_BAR_HEIGHT}
+          alignItems="center"
+          px="$5"
+          gap="$5"
+        >
+          {TAB_LABEL_SKELETON_WIDTHS.map((width, index) => (
+            <Skeleton key={index} h="$4" w={width} radius="round" />
+          ))}
+        </XStack>
+        <Divider />
+      </YStack>
+      <Stack flex={1} alignItems="center" justifyContent="center">
+        <Spinner size="large" />
+      </Stack>
+    </YStack>
+  );
+}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58323](https://onekeyhq.atlassian.net/browse/OK-58323)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- keep the small-screen web `TabPageHeader` mounted while the Market root chunk loads
- add a Market-specific banner and tab bar skeleton that matches the loaded layout
- reuse the same fallback while waiting for the Market category configuration
- preserve the existing native and non-Market root-tab loading behavior

## Root cause

The lazy root-tab fallback hid the page header at widths up to 767px, while the loaded Market page rendered a 101px header/search area. The fallback content therefore started at the top of the viewport and shifted down when Market finished loading. The Market banner and internal tab bar also had no reserved loading geometry during the lazy chunk and category-configuration stages.

## Impact

Small-screen web users should no longer see the Market tab content jump during cold loading. The change only touches TypeScript/TSX and is suitable for a hot update based on `release/v6.5.0`.

Jira: https://onekeyhq.atlassian.net/browse/OK-58323

## Validation

- Jest: `RootTabLoadingFallback.test.tsx` (4 tests)
- type-aware Oxlint on the 5 changed files
- `yarn tsc:staged`
- `yarn tsc:only`
- local web server at 390x844; cold-load sampling used to isolate the 101px header offset

[OK-58323]: https://onekeyhq.atlassian.net/browse/OK-58323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ