### PR TITLE
refactor: share market loading skeleton dimensions

### DIFF
--- a/packages/components/src/composite/Tabs/TabBar.tsx
+++ b/packages/components/src/composite/Tabs/TabBar.tsx
@@ -47,6 +47,8 @@ import type { SharedValue } from 'react-native-reanimated';
 type IItemLayout = { x: number; width: number };
 type IReadonlySharedValue<T> = { readonly value: T };
 
+export const TAB_BAR_ITEM_HEIGHT = 44;
+
 const TAB_HOVER_STYLE = { bg: '$bgHover' } as const;
 const TAB_PRESS_STYLE = { bg: '$bgActive' } as const;
 const TAB_LIST_VIEW_STYLE = { flexShrink: 1 } as const;
@@ -284,7 +286,7 @@ export function TabBarItem({
   return (
     <YStack
       testID={testID}
-      h={44}
+      h={TAB_BAR_ITEM_HEIGHT}
       // minWidth={52}
       ai="center"
       jc="center"
@@ -367,7 +369,7 @@ function AnimatedTabBarItem({
 
   return (
     <YStack
-      h={44}
+      h={TAB_BAR_ITEM_HEIGHT}
       ai="center"
       jc="center"
       ml="$pagePadding"

--- a/packages/components/src/composite/Tabs/index.native.tsx
+++ b/packages/components/src/composite/Tabs/index.native.tsx
@@ -72,6 +72,7 @@ export const Tabs = {
   DraggableFlatList: TabsDraggableFlatList,
 };
 
+export { TAB_BAR_ITEM_HEIGHT } from './TabBar';
 export * from './hooks';
 export { startViewTransition } from './utils';
 export { CollapsibleTabContext } from './CollapsibleTabContext';

--- a/packages/components/src/composite/Tabs/index.tsx
+++ b/packages/components/src/composite/Tabs/index.tsx
@@ -26,6 +26,7 @@ export const Tabs = {
 
 export type { ITabContainerRef, ITabContainerProps } from './Container';
 export type { ITabBarVariant, ITabBarItemProps } from './TabBar';
+export { TAB_BAR_ITEM_HEIGHT } from './TabBar';
 export type { IGetWebRowHeight, IWebRowHeightInfo } from './List';
 export * from './hooks';
 

--- a/packages/kit/src/routes/Tab/Marktet/router.ts
+++ b/packages/kit/src/routes/Tab/Marktet/router.ts
@@ -9,13 +9,17 @@ import {
   LazyLoadRootTabPage,
 } from '../../../components/LazyLoadPage';
 import { createMarketDetailV2Route } from '../../../views/Market/MarketDetailV2/MarketDetailV2Route';
+import { MarketHomeLoadingFallback } from '../../../views/Market/MarketHomeV2/components/MarketHomeLoadingFallback';
 import { RootTabLoadingFallback } from '../RootTabLoadingFallback';
 
 import { MarketDetailV2LoadingFallback } from './MarketDetailV2LoadingFallback';
 
 const MarketHome = LazyLoadRootTabPage(
   () => import(/* webpackPrefetch: true */ '../../../views/Market/MarketHome'),
-  createElement(RootTabLoadingFallback, { tabRoute: ETabRoutes.Market }),
+  createElement(RootTabLoadingFallback, {
+    tabRoute: ETabRoutes.Market,
+    mobileContentFallback: createElement(MarketHomeLoadingFallback),
+  }),
 );
 
 const MarketDetail = LazyLoadPage(

--- a/packages/kit/src/routes/Tab/RootTabLoadingFallback.test.tsx
+++ b/packages/kit/src/routes/Tab/RootTabLoadingFallback.test.tsx
@@ -1,0 +1,108 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
+
+import { RootTabLoadingFallback } from './RootTabLoadingFallback';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __rootTabLoadingFallbackMedia: { md: boolean };
+  // eslint-disable-next-line no-var
+  var __rootTabLoadingFallbackPlatformEnv: { isNative: boolean };
+}
+
+jest.mock('@onekeyhq/components', () => ({
+  Page: {
+    Header: () => <div data-testid="page-header" />,
+  },
+  Spinner: () => <div data-testid="loading-spinner" />,
+  Stack: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  useMedia: () => globalThis.__rootTabLoadingFallbackMedia,
+}));
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => {
+  const platformEnv = { isNative: false };
+  globalThis.__rootTabLoadingFallbackPlatformEnv = platformEnv;
+  return {
+    __esModule: true,
+    default: platformEnv,
+  };
+});
+
+jest.mock('../../components/AccountSelector', () => ({
+  AccountSelectorProviderMirror: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+jest.mock('../../components/TabPageHeader', () => ({
+  TabPageHeader: () => <div data-testid="tab-page-header" />,
+}));
+
+const marketTabRoute = 'Market' as ETabRoutes;
+
+beforeEach(() => {
+  globalThis.__rootTabLoadingFallbackMedia = { md: false };
+  globalThis.__rootTabLoadingFallbackPlatformEnv.isNative = false;
+});
+
+describe('RootTabLoadingFallback', () => {
+  it('keeps the web header and route-specific chrome mounted on small screens', () => {
+    globalThis.__rootTabLoadingFallbackMedia = { md: true };
+
+    render(
+      <RootTabLoadingFallback
+        tabRoute={marketTabRoute}
+        mobileContentFallback={<div data-testid="mobile-content-fallback" />}
+      />,
+    );
+
+    expect(screen.getByTestId('mobile-content-fallback')).toBeTruthy();
+    expect(screen.getByTestId('tab-page-header')).toBeTruthy();
+    expect(screen.queryByTestId('loading-spinner')).toBeNull();
+    expect(screen.queryByTestId('page-header')).toBeNull();
+  });
+
+  it('uses the neutral spinner on native', () => {
+    globalThis.__rootTabLoadingFallbackMedia = { md: true };
+    globalThis.__rootTabLoadingFallbackPlatformEnv.isNative = true;
+
+    render(
+      <RootTabLoadingFallback
+        tabRoute={marketTabRoute}
+        mobileContentFallback={<div data-testid="mobile-content-fallback" />}
+      />,
+    );
+
+    expect(screen.getByTestId('loading-spinner')).toBeTruthy();
+    expect(screen.queryByTestId('mobile-content-fallback')).toBeNull();
+    expect(screen.queryByTestId('tab-page-header')).toBeNull();
+  });
+
+  it('preserves the neutral fallback for small web routes without custom chrome', () => {
+    globalThis.__rootTabLoadingFallbackMedia = { md: true };
+
+    render(<RootTabLoadingFallback tabRoute={marketTabRoute} />);
+
+    expect(screen.getByTestId('page-header')).toBeTruthy();
+    expect(screen.getByTestId('loading-spinner')).toBeTruthy();
+    expect(screen.queryByTestId('tab-page-header')).toBeNull();
+  });
+
+  it('preserves the desktop tab page header on wide web screens', () => {
+    render(
+      <RootTabLoadingFallback
+        tabRoute={marketTabRoute}
+        mobileContentFallback={<div data-testid="mobile-content-fallback" />}
+      />,
+    );
+
+    expect(screen.getByTestId('tab-page-header')).toBeTruthy();
+    expect(screen.getByTestId('loading-spinner')).toBeTruthy();
+    expect(screen.queryByTestId('mobile-content-fallback')).toBeNull();
+  });
+});

--- a/packages/kit/src/routes/Tab/RootTabLoadingFallback.tsx
+++ b/packages/kit/src/routes/Tab/RootTabLoadingFallback.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 import { Page, Spinner, Stack, useMedia } from '@onekeyhq/components';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
@@ -20,16 +22,18 @@ type IRootTabLoadingFallbackProps = {
   tabRoute: ETabRoutes;
   sceneName?: EAccountSelectorSceneName;
   enabledNum?: number[];
+  mobileContentFallback?: ReactNode;
 };
 
 export function RootTabLoadingFallback({
   tabRoute,
   sceneName = EAccountSelectorSceneName.home,
   enabledNum = DEFAULT_ENABLED_NUM,
+  mobileContentFallback,
 }: IRootTabLoadingFallbackProps) {
   const media = useMedia();
 
-  if (platformEnv.isNative || media.md) {
+  if (platformEnv.isNative || (media.md && !mobileContentFallback)) {
     return (
       <>
         <Page.Header headerShown={false} />
@@ -47,7 +51,11 @@ export function RootTabLoadingFallback({
       enabledNum={enabledNum}
     >
       <TabPageHeader sceneName={sceneName} tabRoute={tabRoute} />
-      <LoadingSpinner />
+      {media.md && mobileContentFallback ? (
+        mobileContentFallback
+      ) : (
+        <LoadingSpinner />
+      )}
     </AccountSelectorProviderMirror>
   );
 }

--- a/packages/kit/src/views/Market/MarketHomeV2/MarketHomeV2.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/MarketHomeV2.tsx
@@ -31,6 +31,7 @@ import { preloadMarketHomeTokenListSeed } from '../utils/marketHomeTokenListSeed
 import { markMarketPerf } from '../utils/marketPerf';
 import { useMarketRenderCommitProbe } from '../utils/marketReactPerf';
 
+import { MarketHomeLoadingFallback } from './components/MarketHomeLoadingFallback';
 import { useNetworkAnalytics, useTabAnalytics } from './hooks';
 import { DesktopLayout } from './layouts/DesktopLayout';
 import { shouldRestoreSpotCategoryFromAtom } from './layouts/marketTabSelectionGuards';
@@ -310,7 +311,9 @@ function BaseMarketHomeLayout() {
 
   if (shouldWaitForSpotCategoryReady) {
     return (
-      <LazyPageContainer eager={platformEnv.isWeb}>{null}</LazyPageContainer>
+      <LazyPageContainer eager={platformEnv.isWeb}>
+        {md && !platformEnv.isNative ? <MarketHomeLoadingFallback /> : null}
+      </LazyPageContainer>
     );
   }
 

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketHomeLoadingFallback.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketHomeLoadingFallback.tsx
@@ -1,0 +1,58 @@
+import {
+  Divider,
+  Skeleton,
+  Spinner,
+  Stack,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
+
+const MARKET_HOME_TAB_BAR_HEIGHT = 44;
+const MARKET_HOME_BANNER_HEIGHT = 134;
+const MARKET_HOME_BANNER_ITEM_HEIGHT = 118;
+const MARKET_HOME_BANNER_ITEM_WIDTH = 128;
+const BANNER_SKELETON_COUNT = 3;
+const TAB_LABEL_SKELETON_WIDTHS = [32, 32, 32, 32] as const;
+
+export function MarketHomeLoadingFallback() {
+  return (
+    <YStack flex={1} bg="$bgApp" testID="market-home-loading-fallback">
+      <XStack
+        h={MARKET_HOME_BANNER_HEIGHT}
+        flexShrink={0}
+        alignItems="center"
+        px="$4"
+        py="$2"
+        gap="$3"
+        overflow="hidden"
+        testID="market-home-banner-skeleton"
+      >
+        {Array.from({ length: BANNER_SKELETON_COUNT }, (_, index) => (
+          <Skeleton
+            key={index}
+            h={MARKET_HOME_BANNER_ITEM_HEIGHT}
+            w={MARKET_HOME_BANNER_ITEM_WIDTH}
+            flexShrink={0}
+            radius={12}
+          />
+        ))}
+      </XStack>
+      <YStack flexShrink={0} testID="market-home-tab-bar-skeleton">
+        <XStack
+          h={MARKET_HOME_TAB_BAR_HEIGHT}
+          alignItems="center"
+          px="$5"
+          gap="$5"
+        >
+          {TAB_LABEL_SKELETON_WIDTHS.map((width, index) => (
+            <Skeleton key={index} h="$4" w={width} radius="round" />
+          ))}
+        </XStack>
+        <Divider />
+      </YStack>
+      <Stack flex={1} alignItems="center" justifyContent="center">
+        <Spinner size="large" />
+      </Stack>
+    </YStack>
+  );
+}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketHomeLoadingFallback.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketHomeLoadingFallback.tsx
@@ -3,14 +3,13 @@ import {
   Skeleton,
   Spinner,
   Stack,
+  TAB_BAR_ITEM_HEIGHT,
   XStack,
   YStack,
 } from '@onekeyhq/components';
 
-const MARKET_HOME_TAB_BAR_HEIGHT = 44;
-const MARKET_HOME_BANNER_HEIGHT = 134;
-const MARKET_HOME_BANNER_ITEM_HEIGHT = 118;
-const MARKET_HOME_BANNER_ITEM_WIDTH = 128;
+import { MarketBannerItemSkeleton } from './MarketBanner/MarketBannerItemSkeleton';
+
 const BANNER_SKELETON_COUNT = 3;
 const TAB_LABEL_SKELETON_WIDTHS = [32, 32, 32, 32] as const;
 
@@ -18,7 +17,6 @@ export function MarketHomeLoadingFallback() {
   return (
     <YStack flex={1} bg="$bgApp" testID="market-home-loading-fallback">
       <XStack
-        h={MARKET_HOME_BANNER_HEIGHT}
         flexShrink={0}
         alignItems="center"
         px="$4"
@@ -28,22 +26,11 @@ export function MarketHomeLoadingFallback() {
         testID="market-home-banner-skeleton"
       >
         {Array.from({ length: BANNER_SKELETON_COUNT }, (_, index) => (
-          <Skeleton
-            key={index}
-            h={MARKET_HOME_BANNER_ITEM_HEIGHT}
-            w={MARKET_HOME_BANNER_ITEM_WIDTH}
-            flexShrink={0}
-            radius={12}
-          />
+          <MarketBannerItemSkeleton key={index} />
         ))}
       </XStack>
       <YStack flexShrink={0} testID="market-home-tab-bar-skeleton">
-        <XStack
-          h={MARKET_HOME_TAB_BAR_HEIGHT}
-          alignItems="center"
-          px="$5"
-          gap="$5"
-        >
+        <XStack h={TAB_BAR_ITEM_HEIGHT} alignItems="center" px="$5" gap="$5">
           {TAB_LABEL_SKELETON_WIDTHS.map((width, index) => (
             <Skeleton key={index} h="$4" w={width} radius="round" />
           ))}


### PR DESCRIPTION
## Summary

- reuse `MarketBannerItemSkeleton` in the market loading fallback
- export and share `TAB_BAR_ITEM_HEIGHT` between the tab bar implementations and fallback
- remove duplicated banner dimensions and radius values

## Branch structure

The branch is now rebuilt directly on the latest `x`; no unrelated `release/v6.5.0` commits are included.

It contains only:

1. `46ab5124da` - the isolated #12603 patch, required because `MarketHomeLoadingFallback.tsx` does not exist on `x` yet
2. `2dcd61139d` - this review follow-up

After `x` absorbs #12603, rebase this branch onto the latest `x` and drop the first commit before merging. The PR will then contain only the four-file review change.

## Context

Follow-up to #12603 and the review feedback in [this thread](https://github.com/OneKeyHQ/app-monorepo/pull/12603#discussion_r3635160309).

## Validation

- `RootTabLoadingFallback.test.tsx`: 4/4 passed
- `git diff --check`: passed

The worktree dependencies still match the release baseline, so the latest `x` tooling (`oxlint-plugin-cspell` and `@typescript/native`) is not installed locally; Oxlint and the full TypeScript check could not start after the rebase.