### PR TITLE
feat: add perps conversion funnel analytics(OK-58335)

### DIFF
--- a/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
@@ -153,6 +153,10 @@ const hasOverlayAboveMain = (ref: typeof rootNavigationRef): boolean => {
   return topRoute?.name !== ERootRoutes.Main;
 };
 
+export const willTabFocusTransition = (route: ETabRoutes): boolean =>
+  hasOverlayAboveMain(rootNavigationRef) ||
+  getActiveTabFromRef(rootNavigationRef) !== route;
+
 /**
  * @deprecated
  * @description Prefer `switchTabAsync` for new code. This synchronous version

--- a/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
@@ -153,9 +153,12 @@ const hasOverlayAboveMain = (ref: typeof rootNavigationRef): boolean => {
   return topRoute?.name !== ERootRoutes.Main;
 };
 
-export const willTabFocusTransition = (route: ETabRoutes): boolean =>
-  hasOverlayAboveMain(rootNavigationRef) ||
-  getActiveTabFromRef(rootNavigationRef) !== route;
+export const willTabFocusTransition = (
+  route: ETabRoutes,
+  navigationRef: typeof rootNavigationRef = rootNavigationRef,
+): boolean =>
+  hasOverlayAboveMain(navigationRef) ||
+  getActiveTabFromRef(navigationRef) !== route;
 
 /**
  * @deprecated

--- a/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
@@ -20,6 +20,7 @@ import { useSettingConfig } from '../../../hocs/Provider/hooks/useProviderValue'
 import {
   ESplitViewType,
   useIsSplitView,
+  useSplitMainView,
   useSplitViewType,
   useTheme,
   useThemeName,
@@ -28,7 +29,11 @@ import { createNativeBottomTabNavigator } from '../BottomTabs';
 import { makeTabScreenOptions } from '../GlobalScreenOptions';
 import { createStackNavigator } from '../StackNavigator';
 
-import { willTabFocusTransition } from './NavigationContainer';
+import {
+  rootNavigationRef,
+  tabletMainViewNavigationRef,
+  willTabFocusTransition,
+} from './NavigationContainer';
 
 import type { ITabNavigatorProps, ITabSubNavigatorConfig } from './types';
 
@@ -108,6 +113,7 @@ export function TabStackNavigator<RouteName extends string>({
   const intl = useIntl();
   const theme = useTheme();
   const { hapticFeedbackEnabled } = useSettingConfig();
+  const isSplitMainView = useSplitMainView();
   // Subscribe to theme name so OS dark/light switch triggers re-render —
   // `theme.*.val` reads are non-reactive on native.
   useThemeName();
@@ -125,25 +131,31 @@ export function TabStackNavigator<RouteName extends string>({
   }, []);
 
   // Handle tab press events for logging and event bus notifications
-  const handleTabPress = useCallback((routeName: string) => {
-    if (routeName === ETabRoutes.Swap) {
-      defaultLogger.swap.enterSwap.enterSwap({
-        enterFrom: ESwapSource.TAB,
-      });
-    }
-    if (routeName === ETabRoutes.Market) {
-      appEventBus.emit(EAppEventBusNames.MarketHomePageEnter, {
-        from: EEnterWay.HomeTab,
-      });
-    }
-    if (
-      (routeName === ETabRoutes.Perp ||
-        routeName === ETabRoutes.WebviewPerpTrade) &&
-      willTabFocusTransition(routeName)
-    ) {
-      setPerpPageEnterSource(EPerpPageEnterSource.TabBar);
-    }
-  }, []);
+  const handleTabPress = useCallback(
+    (routeName: string) => {
+      if (routeName === ETabRoutes.Swap) {
+        defaultLogger.swap.enterSwap.enterSwap({
+          enterFrom: ESwapSource.TAB,
+        });
+      }
+      if (routeName === ETabRoutes.Market) {
+        appEventBus.emit(EAppEventBusNames.MarketHomePageEnter, {
+          from: EEnterWay.HomeTab,
+        });
+      }
+      if (
+        (routeName === ETabRoutes.Perp ||
+          routeName === ETabRoutes.WebviewPerpTrade) &&
+        willTabFocusTransition(
+          routeName,
+          isSplitMainView ? tabletMainViewNavigationRef : rootNavigationRef,
+        )
+      ) {
+        setPerpPageEnterSource(EPerpPageEnterSource.TabBar);
+      }
+    },
+    [isSplitMainView],
+  );
 
   const tabScreens = useMemo(() => {
     const screens = config

--- a/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
@@ -8,6 +8,10 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EEnterWay } from '@onekeyhq/shared/src/logger/scopes/dex';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
 import { ESwapSource } from '@onekeyhq/shared/types/swap/types';
@@ -23,6 +27,8 @@ import {
 import { createNativeBottomTabNavigator } from '../BottomTabs';
 import { makeTabScreenOptions } from '../GlobalScreenOptions';
 import { createStackNavigator } from '../StackNavigator';
+
+import { willTabFocusTransition } from './NavigationContainer';
 
 import type { ITabNavigatorProps, ITabSubNavigatorConfig } from './types';
 
@@ -129,6 +135,13 @@ export function TabStackNavigator<RouteName extends string>({
       appEventBus.emit(EAppEventBusNames.MarketHomePageEnter, {
         from: EEnterWay.HomeTab,
       });
+    }
+    if (
+      (routeName === ETabRoutes.Perp ||
+        routeName === ETabRoutes.WebviewPerpTrade) &&
+      willTabFocusTransition(routeName)
+    ) {
+      setPerpPageEnterSource(EPerpPageEnterSource.TabBar);
     }
   }, []);
 

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
@@ -80,7 +80,11 @@ export default function MobileBottomTabBar({
         });
       }
 
-      if (route.name === ETabRoutes.Perp && !isActive) {
+      if (
+        (route.name === ETabRoutes.Perp ||
+          route.name === ETabRoutes.WebviewPerpTrade) &&
+        !isActive
+      ) {
         setPerpPageEnterSource(EPerpPageEnterSource.TabBar);
       }
 

--- a/packages/kit/src/components/TabPageHeader/components/WebHeaderNavigation/WebHeaderNavigation.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebHeaderNavigation/WebHeaderNavigation.tsx
@@ -171,7 +171,10 @@ function useWebHeaderNavigation({
         return;
       }
 
-      if (tabKey === ETabRoutes.Perp) {
+      if (
+        tabKey === ETabRoutes.Perp ||
+        tabKey === ETabRoutes.WebviewPerpTrade
+      ) {
         setPerpPageEnterSource(EPerpPageEnterSource.TabBar);
       }
       if (tabKey) {

--- a/packages/kit/src/components/TabPageHeader/components/WebHeaderNavigation/WebHeaderNavigation.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebHeaderNavigation/WebHeaderNavigation.tsx
@@ -8,7 +8,10 @@ import {
   Icon,
   XStack,
   rootNavigationRef,
+  tabletMainViewNavigationRef,
   useOnRouterChange,
+  useSplitMainView,
+  willTabFocusTransition,
 } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { usePerpTabConfig } from '@onekeyhq/kit/src/hooks/usePerpTabConfig';
@@ -67,6 +70,7 @@ function useWebHeaderNavigation({
   const intl = useIntl();
   const navigation = useAppNavigation();
   const toReferFriendsModal = useToReferFriendsModalByRootNavigation();
+  const isSplitMainView = useSplitMainView();
   const [currentTab, setCurrentTab] = useState<ETabRoutes | null>(null);
 
   useOnRouterChange((state) => {
@@ -172,8 +176,12 @@ function useWebHeaderNavigation({
       }
 
       if (
-        tabKey === ETabRoutes.Perp ||
-        tabKey === ETabRoutes.WebviewPerpTrade
+        (tabKey === ETabRoutes.Perp ||
+          tabKey === ETabRoutes.WebviewPerpTrade) &&
+        willTabFocusTransition(
+          tabKey,
+          isSplitMainView ? tabletMainViewNavigationRef : rootNavigationRef,
+        )
       ) {
         setPerpPageEnterSource(EPerpPageEnterSource.TabBar);
       }
@@ -181,7 +189,13 @@ function useWebHeaderNavigation({
         navigation.switchTab(tabKey as ETabRoutes);
       }
     },
-    [navigation, onNavigationChange, perpTabShowWeb, toReferFriendsModal],
+    [
+      isSplitMainView,
+      navigation,
+      onNavigationChange,
+      perpTabShowWeb,
+      toReferFriendsModal,
+    ],
   );
 
   const navigationItems: IHeaderNavigationItem[] = useMemo(

--- a/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
+++ b/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
@@ -28,6 +28,10 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   EModalAssetDetailRoutes,
@@ -1102,6 +1106,7 @@ export function useTrayDataProvider() {
       if (action?.type === 'market-detail-v2') {
         if (action.perpsCoin) {
           const coin = action.perpsCoin;
+          setPerpPageEnterSource(EPerpPageEnterSource.DesktopTray);
           void switchTabAsync(ETabRoutes.Perp).then(async () => {
             try {
               await backgroundApiProxy.serviceHyperliquid.changeActiveAsset({

--- a/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
+++ b/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
@@ -6,6 +6,7 @@ import {
   resetAboveMainRoute,
   rootNavigationRef,
   switchTabAsync,
+  willTabFocusTransition,
 } from '@onekeyhq/components/src/layouts/Navigation/Navigator/NavigationContainer';
 import type {
   IDBAccount,
@@ -1106,7 +1107,9 @@ export function useTrayDataProvider() {
       if (action?.type === 'market-detail-v2') {
         if (action.perpsCoin) {
           const coin = action.perpsCoin;
-          setPerpPageEnterSource(EPerpPageEnterSource.DesktopTray);
+          if (willTabFocusTransition(ETabRoutes.Perp)) {
+            setPerpPageEnterSource(EPerpPageEnterSource.DesktopTray);
+          }
           void switchTabAsync(ETabRoutes.Perp).then(async () => {
             try {
               await backgroundApiProxy.serviceHyperliquid.changeActiveAsset({

--- a/packages/kit/src/provider/Container/PageTrackerContainer/index.tsx
+++ b/packages/kit/src/provider/Container/PageTrackerContainer/index.tsx
@@ -28,7 +28,7 @@ export default function PageTrackerContainer() {
         defaultLogger.app.page.pageView(ETabHomeRoutes.TabHome);
       } else {
         const page = getActiveRoute(state as IState);
-        // Perp has its own pageView with source tracking (perp.common.pageView)
+        // Perp has its own page view event with source tracking.
         if (page && page.name !== ETabRoutes.Perp) {
           defaultLogger.app.page.pageView(page.name);
         }

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -34,6 +34,10 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
@@ -545,6 +549,7 @@ export function HomePageView({
   }, [tabConfigs]);
 
   const switchToPerpsWebTab = useCallback(() => {
+    setPerpPageEnterSource(EPerpPageEnterSource.Home);
     navigation.switchTab(ETabRoutes.WebviewPerpTrade);
   }, [navigation]);
 

--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -47,6 +47,10 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ERootRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
@@ -168,6 +172,7 @@ function useOpenPerpAsset() {
         if (infoPanelTab) {
           await perpsPendingInfoPanelTabAtom.set(infoPanelTab);
         }
+        setPerpPageEnterSource(EPerpPageEnterSource.Home);
         navigation.switchTab(ETabRoutes.Perp);
         if (!coin) {
           return;

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -55,7 +55,6 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import type {
   TPerpLocalInvalidReason,
-  TPerpTradeLeverageBucket,
   TPerpTradeOrderType,
   TPerpTradePriceMode,
   TPerpTradeValidationState,
@@ -363,19 +362,6 @@ function getPerpTradeTif(
   return undefined;
 }
 
-function getPerpTradeLeverageBucket(
-  leverage: number | undefined,
-): TPerpTradeLeverageBucket | undefined {
-  if (!leverage || !Number.isFinite(leverage) || leverage <= 0) {
-    return undefined;
-  }
-  if (leverage <= 1) return '1x';
-  if (leverage <= 5) return '2-5x';
-  if (leverage <= 10) return '6-10x';
-  if (leverage <= 20) return '11-20x';
-  return '21x+';
-}
-
 function logPerpTradeButtonClick({
   side,
   canTrade,
@@ -409,7 +395,10 @@ function logPerpTradeButtonClick({
     reduceOnly: getPerpTradeReduceOnly(formData),
     hasTpsl: formData.orderMode === 'standard' ? formData.hasTpsl : undefined,
     tif: getPerpTradeTif(formData),
-    leverageBucket: getPerpTradeLeverageBucket(leverage),
+    leverage:
+      typeof leverage === 'number' && Number.isFinite(leverage) && leverage > 0
+        ? leverage
+        : undefined,
     orderValue:
       orderValue?.isFinite() && orderValue.gt(0)
         ? orderValue.toNumber()

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -2046,16 +2046,17 @@ function EmptySizeSideButton({
         return;
       }
 
-      if (!isSpot) {
+      let hasLoggedDeferredClick = false;
+      if (!isSpot && shouldEnableTradingBeforeOrder) {
         logPerpTradeButtonClick({
           side,
           canTrade: Boolean(perpsAccountStatus.canTrade),
           activatedOk: perpsAccountStatus.details?.activatedOk,
-          validationState: 'invalid',
-          localInvalidReason: 'emptySize',
+          validationState: 'deferred',
           formData,
           symbol: activeTradeInstrument.coin,
         });
+        hasLoggedDeferredClick = true;
       }
 
       if (shouldEnableTradingBeforeOrder) {
@@ -2079,6 +2080,17 @@ function EmptySizeSideButton({
         shouldBlockPerpsTradingForMarketData(marketDataFreshness);
 
       if (shouldBlockForMarketData) {
+        if (!isSpot && !hasLoggedDeferredClick) {
+          logPerpTradeButtonClick({
+            side,
+            canTrade: Boolean(perpsAccountStatus.canTrade),
+            activatedOk: perpsAccountStatus.details?.activatedOk,
+            validationState: 'invalid',
+            localInvalidReason: 'marketDataUnavailable',
+            formData,
+            symbol: activeTradeInstrument.coin,
+          });
+        }
         Toast.error({
           title: intl.formatMessage({
             id: ETranslations.perp_offline,
@@ -2094,6 +2106,17 @@ function EmptySizeSideButton({
         formData.type === 'limit' &&
         (!formData.price || formData.price.trim() === '')
       ) {
+        if (!isSpot && !hasLoggedDeferredClick) {
+          logPerpTradeButtonClick({
+            side,
+            canTrade: Boolean(perpsAccountStatus.canTrade),
+            activatedOk: perpsAccountStatus.details?.activatedOk,
+            validationState: 'invalid',
+            localInvalidReason: 'missingLimitPrice',
+            formData,
+            symbol: activeTradeInstrument.coin,
+          });
+        }
         Toast.message({
           title: intl.formatMessage({
             id: ETranslations.perp_trade_price_place_holder,
@@ -2102,6 +2125,17 @@ function EmptySizeSideButton({
         return;
       }
 
+      if (!isSpot && !hasLoggedDeferredClick) {
+        logPerpTradeButtonClick({
+          side,
+          canTrade: Boolean(perpsAccountStatus.canTrade),
+          activatedOk: perpsAccountStatus.details?.activatedOk,
+          validationState: 'invalid',
+          localInvalidReason: 'emptySize',
+          formData,
+          symbol: activeTradeInstrument.coin,
+        });
+      }
       Toast.message({
         title: intl.formatMessage(
           { id: ETranslations.perp_size_least },

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -52,6 +52,14 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import errorToastUtils from '@onekeyhq/shared/src/errors/utils/errorToastUtils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import type {
+  TPerpLocalInvalidReason,
+  TPerpTradeLeverageBucket,
+  TPerpTradeOrderType,
+  TPerpTradePriceMode,
+  TPerpTradeValidationState,
+} from '@onekeyhq/shared/src/logger/scopes/perp/type';
 import {
   SCALE_ORDER_MAX_COUNT,
   SCALE_ORDER_MIN_COUNT,
@@ -251,6 +259,162 @@ EstLiqPriceLeaf.displayName = 'EstLiqPriceLeaf';
 function getPerpSideButtonStyles(isLong: boolean) {
   const styles = getTradingButtonStyleValues(isLong ? 'long' : 'short');
   return styles;
+}
+
+function getPerpTradeButtonState({
+  canTrade,
+  activatedOk,
+}: {
+  canTrade: boolean;
+  activatedOk?: boolean;
+}) {
+  if (canTrade) {
+    return 'readyToTrade' as const;
+  }
+  if (activatedOk === false) {
+    return 'depositRequired' as const;
+  }
+  return 'enableTrading' as const;
+}
+
+type IPerpTradeAnalyticsFormData = Pick<
+  ITradingFormData,
+  'orderMode' | 'type'
+> &
+  Partial<
+    Pick<
+      ITradingFormData,
+      | 'bboPriceMode'
+      | 'hasTpsl'
+      | 'limitTif'
+      | 'reduceOnly'
+      | 'scaleReduceOnly'
+      | 'scaleTif'
+      | 'triggerOrderType'
+      | 'triggerReduceOnly'
+      | 'twapReduceOnly'
+    >
+  >;
+
+function getPerpTradeOrderType(
+  formData: IPerpTradeAnalyticsFormData,
+): TPerpTradeOrderType {
+  if (formData.orderMode === 'trigger') {
+    return formData.triggerOrderType === ETriggerOrderType.TRIGGER_LIMIT
+      ? 'triggerLimit'
+      : 'triggerMarket';
+  }
+  if (formData.orderMode === 'scale') {
+    return 'scale';
+  }
+  if (formData.orderMode === 'twap') {
+    return 'twap';
+  }
+  return formData.type;
+}
+
+function getPerpTradePriceMode(
+  formData: IPerpTradeAnalyticsFormData,
+): TPerpTradePriceMode {
+  if (
+    formData.orderMode === 'standard' &&
+    formData.type === 'limit' &&
+    formData.bboPriceMode
+  ) {
+    return formData.bboPriceMode.type === 'counterparty'
+      ? 'bboCounterparty'
+      : 'bboQueue';
+  }
+  if (
+    formData.orderMode === 'twap' ||
+    (formData.orderMode === 'standard' && formData.type === 'market') ||
+    (formData.orderMode === 'trigger' &&
+      formData.triggerOrderType !== ETriggerOrderType.TRIGGER_LIMIT)
+  ) {
+    return 'market';
+  }
+  return 'manualLimit';
+}
+
+function getPerpTradeReduceOnly(
+  formData: IPerpTradeAnalyticsFormData,
+): boolean | undefined {
+  if (formData.orderMode === 'trigger') {
+    return formData.triggerReduceOnly;
+  }
+  if (formData.orderMode === 'scale') {
+    return formData.scaleReduceOnly;
+  }
+  if (formData.orderMode === 'twap') {
+    return formData.twapReduceOnly;
+  }
+  return formData.reduceOnly;
+}
+
+function getPerpTradeTif(
+  formData: IPerpTradeAnalyticsFormData,
+): string | undefined {
+  if (formData.orderMode === 'scale') {
+    return formData.scaleTif;
+  }
+  if (formData.orderMode === 'standard' && formData.type === 'limit') {
+    return formData.limitTif;
+  }
+  return undefined;
+}
+
+function getPerpTradeLeverageBucket(
+  leverage: number | undefined,
+): TPerpTradeLeverageBucket | undefined {
+  if (!leverage || !Number.isFinite(leverage) || leverage <= 0) {
+    return undefined;
+  }
+  if (leverage <= 1) return '1x';
+  if (leverage <= 5) return '2-5x';
+  if (leverage <= 10) return '6-10x';
+  if (leverage <= 20) return '11-20x';
+  return '21x+';
+}
+
+function logPerpTradeButtonClick({
+  side,
+  canTrade,
+  activatedOk,
+  validationState,
+  localInvalidReason,
+  formData,
+  symbol,
+  leverage,
+  orderValue,
+}: {
+  side: 'long' | 'short';
+  canTrade: boolean;
+  activatedOk?: boolean;
+  validationState: TPerpTradeValidationState;
+  localInvalidReason?: TPerpLocalInvalidReason;
+  formData: IPerpTradeAnalyticsFormData;
+  symbol: string;
+  leverage?: number;
+  orderValue?: BigNumber;
+}) {
+  defaultLogger.perp.common.perpTradeButtonClick({
+    side,
+    isTradingEnabled: canTrade,
+    buttonState: getPerpTradeButtonState({ canTrade, activatedOk }),
+    validationState,
+    ...(localInvalidReason ? { localInvalidReason } : {}),
+    symbol,
+    orderType: getPerpTradeOrderType(formData),
+    priceMode: getPerpTradePriceMode(formData),
+    reduceOnly: getPerpTradeReduceOnly(formData),
+    hasTpsl: formData.orderMode === 'standard' ? formData.hasTpsl : undefined,
+    tif: getPerpTradeTif(formData),
+    leverageBucket: getPerpTradeLeverageBucket(leverage),
+    orderValue:
+      orderValue?.isFinite() && orderValue.gt(0)
+        ? orderValue.toNumber()
+        : undefined,
+  });
 }
 
 function SideButtonInternal({
@@ -630,6 +794,7 @@ function SideButtonInternal({
     marketDataFreshness,
     midPriceBN,
     orderContextKey,
+    orderValue,
     perpsAccount,
     perpsCustomSettings,
     priceError,
@@ -655,6 +820,7 @@ function SideButtonInternal({
     marketDataFreshness,
     midPriceBN,
     orderContextKey,
+    orderValue,
     perpsAccount,
     perpsCustomSettings,
     priceError,
@@ -705,7 +871,7 @@ function SideButtonInternal({
             id: ETranslations.Perps_BBO_unavailable,
           }),
         });
-        return false;
+        return 'bboUnavailable' as const;
       }
 
       if (latestShouldBlockForMarketData) {
@@ -717,7 +883,7 @@ function SideButtonInternal({
             id: ETranslations.perps_offline_moblie,
           }),
         });
-        return false;
+        return 'marketDataUnavailable' as const;
       }
 
       if (latestIsTriggerMode && latestFormData.triggerOrderType) {
@@ -728,7 +894,7 @@ function SideButtonInternal({
               id: ETranslations.perps_input_trigger_price,
             }),
           });
-          return false;
+          return 'invalidTriggerPrice' as const;
         }
         const isLimitTrigger =
           latestFormData.triggerOrderType === ETriggerOrderType.TRIGGER_LIMIT;
@@ -740,18 +906,18 @@ function SideButtonInternal({
                 id: ETranslations.perp_trade_price_place_holder,
               }),
             });
-            return false;
+            return 'invalidLimitPrice' as const;
           }
         }
         if (!latestMidPriceBN.isFinite() || latestMidPriceBN.lte(0)) {
           Toast.error({ title: 'Market price unavailable, please try again' });
-          return false;
+          return 'marketDataUnavailable' as const;
         }
         if (new BigNumber(tp).eq(latestMidPriceBN)) {
           Toast.error({
             title: 'Trigger price must differ from current price',
           });
-          return false;
+          return 'invalidTriggerPrice' as const;
         }
       }
 
@@ -767,7 +933,7 @@ function SideButtonInternal({
             id: ETranslations.perp_trade_price_place_holder,
           }),
         });
-        return false;
+        return 'missingLimitPrice' as const;
       }
 
       if (latestIsScaleMode) {
@@ -784,7 +950,7 @@ function SideButtonInternal({
               id: ETranslations.perp_scale_price_range_required__msg,
             }),
           });
-          return false;
+          return 'invalidScaleConfig' as const;
         }
         if (lowerPrice.eq(upperPrice)) {
           Toast.message({
@@ -792,7 +958,7 @@ function SideButtonInternal({
               id: ETranslations.perp_scale_price_range_same__msg,
             }),
           });
-          return false;
+          return 'invalidScaleConfig' as const;
         }
         const orderCount = normalizeScaleOrderCount(
           latestFormData.scaleOrderCount ?? 0,
@@ -812,7 +978,7 @@ function SideButtonInternal({
               },
             ),
           });
-          return false;
+          return 'invalidScaleConfig' as const;
         }
       }
 
@@ -826,7 +992,7 @@ function SideButtonInternal({
           Toast.message({
             title: `TWAP duration must be ${TWAP_MIN_DURATION_MINUTES}-${TWAP_MAX_DURATION_MINUTES} minutes`,
           });
-          return false;
+          return 'invalidTwapConfig' as const;
         }
       }
 
@@ -881,12 +1047,14 @@ function SideButtonInternal({
             { amount: minAmount },
           ),
         });
-        return false;
+        return hasSizeEmpty
+          ? ('emptySize' as const)
+          : ('minimumOrderNotMet' as const);
       }
 
       if (latestIsNoEnoughMargin) {
         showNoEnoughMarginToast(latestIsSpot);
-        return false;
+        return 'insufficientMargin' as const;
       }
 
       if (latestIsScaleMode) {
@@ -911,7 +1079,7 @@ function SideButtonInternal({
               fallback: 'Invalid scale order',
             }),
           });
-          return false;
+          return 'invalidScaleConfig' as const;
         }
       }
 
@@ -934,7 +1102,7 @@ function SideButtonInternal({
               id: ETranslations.perp_twap_small_slice__msg,
             }),
           });
-          return false;
+          return 'invalidTwapConfig' as const;
         }
       }
 
@@ -1005,7 +1173,7 @@ function SideButtonInternal({
                 id: ETranslations.perp_invaild_tp_desc_1,
               }),
             });
-            return false;
+            return 'invalidTpsl' as const;
           }
           if (
             validationSide === 'short' &&
@@ -1019,7 +1187,7 @@ function SideButtonInternal({
                 id: ETranslations.perp_invaild_tp_desc_2,
               }),
             });
-            return false;
+            return 'invalidTpsl' as const;
           }
         }
 
@@ -1041,7 +1209,7 @@ function SideButtonInternal({
                 id: ETranslations.perp_invaild_sl_desc_1,
               }),
             });
-            return false;
+            return 'invalidTpsl' as const;
           }
           if (
             validationSide === 'short' &&
@@ -1055,12 +1223,12 @@ function SideButtonInternal({
                 id: ETranslations.perp_invaild_sl_desc_2,
               }),
             });
-            return false;
+            return 'invalidTpsl' as const;
           }
         }
       }
 
-      return true;
+      return undefined;
     },
     [intl, showNoEnoughMarginToast],
   );
@@ -1172,7 +1340,33 @@ function SideButtonInternal({
         return;
       }
 
+      const logTradeClick = ({
+        orderPanelState,
+        validationState,
+        localInvalidReason,
+      }: {
+        orderPanelState: ILatestOrderPanelState;
+        validationState: TPerpTradeValidationState;
+        localInvalidReason?: TPerpLocalInvalidReason;
+      }) => {
+        if (orderPanelState.isSpot) {
+          return;
+        }
+        logPerpTradeButtonClick({
+          side,
+          canTrade: Boolean(perpsAccountStatus.canTrade),
+          activatedOk: perpsAccountStatus.details?.activatedOk,
+          validationState,
+          localInvalidReason,
+          formData: orderPanelState.formData,
+          symbol: orderPanelState.activeTradeInstrument.coin,
+          leverage: orderPanelState.leverage,
+          orderValue: orderPanelState.orderValue,
+        });
+      };
+
       const preEnableOrderPanelState = latestOrderPanelStateRef.current;
+      let hasLoggedDeferredClick = false;
 
       if (shouldEnableTradingBeforeOrder) {
         const isDepositRequired =
@@ -1184,9 +1378,20 @@ function SideButtonInternal({
             isDepositRequired,
           })
         ) {
+          logTradeClick({
+            orderPanelState: preEnableOrderPanelState,
+            validationState: 'invalid',
+            localInvalidReason: 'insufficientMargin',
+          });
           showNoEnoughMarginToast(preEnableOrderPanelState.isSpot);
           return;
         }
+
+        logTradeClick({
+          orderPanelState: preEnableOrderPanelState,
+          validationState: 'deferred',
+        });
+        hasLoggedDeferredClick = !preEnableOrderPanelState.isSpot;
 
         const enableTradingAccountKey = perpsAccountKey;
         const enableTradingSide = side;
@@ -1232,13 +1437,19 @@ function SideButtonInternal({
       // dialog. Running validation here covers both the just-enabled path and
       // accounts that can already trade.
       const validationState = latestOrderPanelStateRef.current;
-      if (
-        !validateOrderPanelState({
-          orderPanelState: validationState,
-          validationSide: side,
-          shouldValidateBboPriceError: true,
-        })
-      ) {
+      const localInvalidReason = validateOrderPanelState({
+        orderPanelState: validationState,
+        validationSide: side,
+        shouldValidateBboPriceError: true,
+      });
+      if (localInvalidReason) {
+        if (!hasLoggedDeferredClick) {
+          logTradeClick({
+            orderPanelState: validationState,
+            validationState: 'invalid',
+            localInvalidReason,
+          });
+        }
         return;
       }
       const submitState = latestOrderPanelStateRef.current;
@@ -1254,6 +1465,13 @@ function SideButtonInternal({
             submitState.activePositionsValue.accountAddress,
         });
         if (snapshotError) {
+          if (!hasLoggedDeferredClick) {
+            logTradeClick({
+              orderPanelState: submitState,
+              validationState: 'invalid',
+              localInvalidReason: 'invalidReduceOnly',
+            });
+          }
           Toast.message({ title: snapshotError });
           return;
         }
@@ -1281,9 +1499,23 @@ function SideButtonInternal({
               }),
         });
         if (reduceOnlyError) {
+          if (!hasLoggedDeferredClick) {
+            logTradeClick({
+              orderPanelState: submitState,
+              validationState: 'invalid',
+              localInvalidReason: 'invalidReduceOnly',
+            });
+          }
           Toast.message({ title: reduceOnlyError });
           return;
         }
+      }
+
+      if (!hasLoggedDeferredClick) {
+        logTradeClick({
+          orderPanelState: submitState,
+          validationState: 'valid',
+        });
       }
 
       if (submitState.perpsCustomSettings.skipOrderConfirm) {
@@ -1823,6 +2055,18 @@ function EmptySizeSideButton({
     async (): Promise<void> => {
       if (!shouldEnableTradingBeforeOrder && !perpsAccountStatus.canTrade) {
         return;
+      }
+
+      if (!isSpot) {
+        logPerpTradeButtonClick({
+          side,
+          canTrade: Boolean(perpsAccountStatus.canTrade),
+          activatedOk: perpsAccountStatus.details?.activatedOk,
+          validationState: 'invalid',
+          localInvalidReason: 'emptySize',
+          formData,
+          symbol: activeTradeInstrument.coin,
+        });
       }
 
       if (shouldEnableTradingBeforeOrder) {

--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -96,7 +96,7 @@ function PerpContent() {
     useCallback(() => {
       if (!firedRef.current) {
         firedRef.current = true;
-        defaultLogger.perp.common.pageView({
+        defaultLogger.perp.common.perpPageView({
           source: consumePerpPageEnterSource(),
         });
       }

--- a/packages/kit/src/views/PerpTrade/pages/PageWebviewPerpTrade.tsx
+++ b/packages/kit/src/views/PerpTrade/pages/PageWebviewPerpTrade.tsx
@@ -94,7 +94,7 @@ function WebviewPerpTradeView() {
     useCallback(() => {
       if (!firedRef.current) {
         firedRef.current = true;
-        defaultLogger.perp.common.pageView({
+        defaultLogger.perp.common.perpPageView({
           source: consumePerpPageEnterSource(),
         });
       }

--- a/packages/shared/src/logger/scopes/perp/scenes/common.ts
+++ b/packages/shared/src/logger/scopes/perp/scenes/common.ts
@@ -1,13 +1,22 @@
 import { BaseScene } from '../../../base/baseScene';
 import { LogToLocal, LogToServer } from '../../../base/decorators';
 
-import type { EPerpPageEnterSource } from '../type';
+import type {
+  EPerpPageEnterSource,
+  IPerpTradeButtonClickParams,
+} from '../type';
 
 export class CommonScene extends BaseScene {
   @LogToServer()
   @LogToLocal({ level: 'info' })
-  public pageView({ source }: { source: EPerpPageEnterSource }) {
+  public perpPageView({ source }: { source: EPerpPageEnterSource }) {
     return { source, pageName: 'Perp' };
+  }
+
+  @LogToServer()
+  @LogToLocal({ level: 'info' })
+  public perpTradeButtonClick(params: IPerpTradeButtonClickParams) {
+    return params;
   }
 
   @LogToServer()

--- a/packages/shared/src/logger/scopes/perp/type.ts
+++ b/packages/shared/src/logger/scopes/perp/type.ts
@@ -58,13 +58,6 @@ export type TPerpTradePriceMode =
   | 'bboCounterparty'
   | 'bboQueue';
 
-export type TPerpTradeLeverageBucket =
-  | '1x'
-  | '2-5x'
-  | '6-10x'
-  | '11-20x'
-  | '21x+';
-
 export interface IPerpTradeButtonClickParams {
   side: 'long' | 'short';
   isTradingEnabled: boolean;
@@ -77,7 +70,7 @@ export interface IPerpTradeButtonClickParams {
   reduceOnly?: boolean;
   hasTpsl?: boolean;
   tif?: string;
-  leverageBucket?: TPerpTradeLeverageBucket;
+  leverage?: number;
   orderValue?: number;
 }
 

--- a/packages/shared/src/logger/scopes/perp/type.ts
+++ b/packages/shared/src/logger/scopes/perp/type.ts
@@ -3,6 +3,8 @@ import type { ESwapTxHistoryStatus } from '@onekeyhq/shared/types/swap/types';
 
 export enum EPerpPageEnterSource {
   TabBar = 'tabBar',
+  Home = 'home',
+  DesktopTray = 'desktopTray',
   Notification = 'notification',
   MarketList = 'marketList',
   MarketBanner = 'marketBanner',
@@ -18,6 +20,65 @@ export enum EPerpPageEnterSource {
   // Handoff from the Swap Pro-mode stock market-closed alert → Perps.
   SwapProStockClosed = 'swapProStockClosed',
   DirectUrl = 'directUrl',
+}
+
+export type TPerpTradeButtonState =
+  | 'readyToTrade'
+  | 'enableTrading'
+  | 'depositRequired';
+
+export type TPerpTradeValidationState = 'valid' | 'invalid' | 'deferred';
+
+export type TPerpLocalInvalidReason =
+  | 'emptySize'
+  | 'minimumOrderNotMet'
+  | 'insufficientMargin'
+  | 'missingLimitPrice'
+  | 'invalidLimitPrice'
+  | 'bboUnavailable'
+  | 'marketDataUnavailable'
+  | 'invalidTriggerPrice'
+  | 'invalidScaleConfig'
+  | 'invalidTwapConfig'
+  | 'invalidTpsl'
+  | 'invalidReduceOnly'
+  | 'unknown';
+
+export type TPerpTradeOrderType =
+  | 'market'
+  | 'limit'
+  | 'triggerMarket'
+  | 'triggerLimit'
+  | 'scale'
+  | 'twap';
+
+export type TPerpTradePriceMode =
+  | 'market'
+  | 'manualLimit'
+  | 'bboCounterparty'
+  | 'bboQueue';
+
+export type TPerpTradeLeverageBucket =
+  | '1x'
+  | '2-5x'
+  | '6-10x'
+  | '11-20x'
+  | '21x+';
+
+export interface IPerpTradeButtonClickParams {
+  side: 'long' | 'short';
+  isTradingEnabled: boolean;
+  buttonState: TPerpTradeButtonState;
+  validationState: TPerpTradeValidationState;
+  localInvalidReason?: TPerpLocalInvalidReason;
+  symbol: string;
+  orderType: TPerpTradeOrderType;
+  priceMode: TPerpTradePriceMode;
+  reduceOnly?: boolean;
+  hasTpsl?: boolean;
+  tif?: string;
+  leverageBucket?: TPerpTradeLeverageBucket;
+  orderValue?: number;
 }
 
 export interface IPerpDepositInitiateParams {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58335](https://onekeyhq.atlassian.net/browse/OK-58335)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Add a dedicated `perpPageView` event for native and WebView Perps page visits across supported entry sources.
- Add `perpTradeButtonClick` to capture Long/Short intent, trading readiness, local validation state, and non-sensitive order context.
- Keep the existing `orderOpen` event unchanged as the final funnel step.

## Intent & Context
[OK-58335](https://onekeyhq.atlassian.net/browse/OK-58335)

The Perps activation funnel needs three unique-user steps: entering Perps, making a valid Long/Short click, and the first accepted open order. The existing generic page view path was not producing a reliable Perps denominator, and there was no unified click event before the enabled-trading, enable-trading, and deposit-required branches.

## Design Decisions
- Use a dedicated `perpPageView` event with `pageName=Perp` and an explicit entry `source` for both native and WebView routes.
- Emit page visits whenever the Perps page regains focus. First visit is derived from the earliest historical event in Mixpanel instead of a client-side `isFirstTime` flag.
- Use one flattened `orderType` field, an exact numeric `leverage`, and an exact numeric `orderValue` rather than separate mode fields or value buckets.
- Record local validation outcomes directly. Enable Trading and Deposit flows use `validationState=deferred` so the original trading intent is retained without duplicate click events.
- Do not attach wallet addresses, signatures, raw order payloads, or Hyperliquid errors to the click event.

## Changes Detail
- Propagate Perps entry sources from tab bar, home, desktop tray, market, search, notification, referral, shortcut, and trade handoffs.
- Log `perpPageView` from native and WebView Perps pages when they receive focus.
- Add typed trade-button analytics fields for side, button state, validation state, local invalid reason, symbol, order type, price mode, reduce-only, TP/SL, TIF, exact leverage, and order value.
- Log one `perpTradeButtonClick` per click for valid, invalid, and deferred paths.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Desktop, Web, Extension
- **Risk Areas**: Entry-source propagation and ensuring one trade-click event is emitted per user action across all validation branches.

## Test plan
- [x] Run `yarn agent:check --profile pr`
- [ ] Verify each supported Perps entry reports the expected `source`
- [ ] Verify Long and Short clicks report valid, invalid, and deferred states without duplicates
- [ ] Validate the events and properties in Mixpanel after deployment

[OK-58335]: https://onekeyhq.atlassian.net/browse/OK-58335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ