### PR TITLE
fix: support tab-targeted swap tips (OK-57985)

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -1231,6 +1231,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     ) {
       return (
         <SwapStockDesktopContainer
+          pageType={pageType}
           storeName={storeName}
           onSelectToken={onSelectToken}
           onTokenPress={onTokenPress}
@@ -1261,6 +1262,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     if (swapTypeSwitch === ESwapTabSwitchType.STOCK) {
       return (
         <SwapStockMobileContainer
+          pageType={pageType}
           storeName={storeName}
           onSelectToken={onSelectToken}
           onTokenPress={onTokenPress}

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@tamagui/core';
 import { useIntl } from 'react-intl';
 import { InputAccessoryView } from 'react-native';
 
-import type { IPageNavigationProp } from '@onekeyhq/components';
+import type { EPageType, IPageNavigationProp } from '@onekeyhq/components';
 import {
   Button,
   Divider,
@@ -172,10 +172,12 @@ import {
   SwapStockTradeProvider,
   useSwapStockTradeContext,
 } from './SwapStockTradeProvider';
+import SwapTipsContainer from './SwapTipsContainer';
 
 import type { KeyboardAwareScrollViewRef } from 'react-native-keyboard-controller';
 
 interface ISwapStockDesktopContainerProps {
+  pageType?: EPageType;
   headerContent?: ReactNode;
   storeName: EJotaiContextStoreNames;
   onSelectToken: (type: ESwapDirectionType) => void;
@@ -2215,6 +2217,7 @@ function useSwapStockRecentTokenPairs() {
 }
 
 function SwapStockDesktopContent({
+  pageType,
   headerContent,
   storeName,
   onSelectToken,
@@ -2294,6 +2297,7 @@ function SwapStockDesktopContent({
 
   return (
     <ScrollView flex={1} contentContainerStyle={{ flexGrow: 1 }}>
+      <SwapTipsContainer pageType={pageType} />
       <YStack
         width="100%"
         alignItems="center"
@@ -2466,6 +2470,7 @@ function SwapStockMobileContent(props: ISwapStockDesktopContainerProps) {
       contentContainerStyle={{ paddingBottom: tabBarHeight }}
       bottomOffset={bottomOffset}
     >
+      <SwapTipsContainer pageType={props.pageType} />
       <YStack
         testID={SwapTestIDs.stockMobileContainer}
         // pt $1 + the header pill's py $1 puts the stock symbol at the same

--- a/packages/kit/src/views/Swap/pages/components/SwapTipsContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapTipsContainer.tsx
@@ -2,10 +2,15 @@ import { useIntl } from 'react-intl';
 
 import { Alert, EPageType, YStack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
-import { useSwapTipsAtom } from '@onekeyhq/kit/src/states/jotai/contexts/swap/atoms';
+import {
+  useSwapTipsAtom,
+  useSwapTypeSwitchAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/swap/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
+
+import { shouldShowSwapTips } from './SwapTipsContainer.utils';
 
 interface ISwapTipsContainerProps {
   pageType?: EPageType;
@@ -15,6 +20,7 @@ const SWAP_TIPS_RESERVED_HEIGHT = platformEnv.isNative ? 56 : 58;
 
 const SwapTipsContainer = ({ pageType }: ISwapTipsContainerProps) => {
   const [swapTipsState, setSwapTipsState] = useSwapTipsAtom();
+  const [swapTypeSwitch] = useSwapTypeSwitchAtom();
   const intl = useIntl();
   // Don't show tips in modal
   if (pageType === EPageType.modal || swapTipsState.status === 'empty') {
@@ -22,7 +28,13 @@ const SwapTipsContainer = ({ pageType }: ISwapTipsContainerProps) => {
   }
   const swapTips = swapTipsState.tips;
 
-  if (!swapTips) {
+  if (
+    !swapTips ||
+    !shouldShowSwapTips({
+      effectiveTab: swapTips.effectiveTab,
+      swapType: swapTypeSwitch,
+    })
+  ) {
     return null;
   }
 

--- a/packages/kit/src/views/Swap/pages/components/SwapTipsContainer.utils.test.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapTipsContainer.utils.test.ts
@@ -1,0 +1,121 @@
+import {
+  ESwapTabSwitchType,
+  ESwapTipsEffectiveTab,
+} from '@onekeyhq/shared/types/swap/types';
+
+import { shouldShowSwapTips } from './SwapTipsContainer.utils';
+
+describe('SwapTipsContainer utils', () => {
+  it('keeps the legacy display behavior when effectiveTab is missing or empty', () => {
+    expect(
+      shouldShowSwapTips({
+        swapType: ESwapTabSwitchType.SWAP,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowSwapTips({
+        effectiveTab: [],
+        swapType: ESwapTabSwitchType.STOCK,
+      }),
+    ).toBe(true);
+  });
+
+  it('shows All tips on every supported trade tab', () => {
+    const effectiveTab = [ESwapTipsEffectiveTab.ALL];
+
+    expect(
+      shouldShowSwapTips({
+        effectiveTab,
+        swapType: ESwapTabSwitchType.SWAP,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowSwapTips({
+        effectiveTab,
+        swapType: ESwapTabSwitchType.STOCK,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowSwapTips({
+        effectiveTab,
+        swapType: ESwapTabSwitchType.LIMIT,
+      }),
+    ).toBe(true);
+  });
+
+  it('maps Swap&Bridge tips to both execution types', () => {
+    const effectiveTab = [ESwapTipsEffectiveTab.SWAP_AND_BRIDGE];
+
+    expect(
+      shouldShowSwapTips({
+        effectiveTab,
+        swapType: ESwapTabSwitchType.SWAP,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowSwapTips({
+        effectiveTab,
+        swapType: ESwapTabSwitchType.BRIDGE,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowSwapTips({
+        effectiveTab,
+        swapType: ESwapTabSwitchType.STOCK,
+      }),
+    ).toBe(false);
+  });
+
+  it('shows Stocks and Limit tips only on their configured tabs', () => {
+    expect(
+      shouldShowSwapTips({
+        effectiveTab: [ESwapTipsEffectiveTab.STOCKS],
+        swapType: ESwapTabSwitchType.STOCK,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowSwapTips({
+        effectiveTab: [ESwapTipsEffectiveTab.STOCKS],
+        swapType: ESwapTabSwitchType.SWAP,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowSwapTips({
+        effectiveTab: [ESwapTipsEffectiveTab.LIMIT],
+        swapType: ESwapTabSwitchType.LIMIT,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowSwapTips({
+        effectiveTab: [ESwapTipsEffectiveTab.LIMIT],
+        swapType: ESwapTabSwitchType.STOCK,
+      }),
+    ).toBe(false);
+  });
+
+  it('supports multiple configured tabs without adding page-level conditions', () => {
+    const effectiveTab = [
+      ESwapTipsEffectiveTab.STOCKS,
+      ESwapTipsEffectiveTab.LIMIT,
+    ];
+
+    expect(
+      shouldShowSwapTips({
+        effectiveTab,
+        swapType: ESwapTabSwitchType.STOCK,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowSwapTips({
+        effectiveTab,
+        swapType: ESwapTabSwitchType.LIMIT,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowSwapTips({
+        effectiveTab,
+        swapType: ESwapTabSwitchType.SWAP,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/kit/src/views/Swap/pages/components/SwapTipsContainer.utils.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapTipsContainer.utils.ts
@@ -1,0 +1,37 @@
+import {
+  ESwapTabSwitchType,
+  ESwapTipsEffectiveTab,
+} from '@onekeyhq/shared/types/swap/types';
+
+export function shouldShowSwapTips({
+  effectiveTab,
+  swapType,
+}: {
+  effectiveTab?: ESwapTipsEffectiveTab[];
+  swapType: ESwapTabSwitchType;
+}) {
+  if (!effectiveTab?.length) {
+    return true;
+  }
+
+  if (effectiveTab.includes(ESwapTipsEffectiveTab.ALL)) {
+    return true;
+  }
+
+  if (
+    swapType === ESwapTabSwitchType.SWAP ||
+    swapType === ESwapTabSwitchType.BRIDGE
+  ) {
+    return effectiveTab.includes(ESwapTipsEffectiveTab.SWAP_AND_BRIDGE);
+  }
+
+  if (swapType === ESwapTabSwitchType.STOCK) {
+    return effectiveTab.includes(ESwapTipsEffectiveTab.STOCKS);
+  }
+
+  if (swapType === ESwapTabSwitchType.LIMIT) {
+    return effectiveTab.includes(ESwapTipsEffectiveTab.LIMIT);
+  }
+
+  return false;
+}

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -59,6 +59,13 @@ export enum ESwapTabSwitchType {
   STOCK = 'stock',
 }
 
+export enum ESwapTipsEffectiveTab {
+  ALL = 'All',
+  SWAP_AND_BRIDGE = 'Swap&Bridge',
+  STOCKS = 'Stocks',
+  LIMIT = 'Limit',
+}
+
 export enum ESwapDirectionType {
   FROM = 'from',
   TO = 'to',
@@ -949,6 +956,7 @@ export interface IPerpDepositQuoteRes {
 export interface ISwapTips {
   tipsId: string;
   title: string;
+  effectiveTab?: ESwapTipsEffectiveTab[];
   detailLink?: string;
   userCanClose?: boolean;
   iconImage?: string;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57985](https://onekeyhq.atlassian.net/browse/OK-57985)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- add the typed `effectiveTab` contract for Swap Tips
- centralize tab visibility in `SwapTipsContainer`
- render configured Tips on Stock across desktop and mobile layouts

## Issues

- Fixes OK-57985
- Parent: OK-57914

## Verification

- `yarn jest packages/kit/src/views/Swap/pages/components/SwapTipsContainer.utils.test.ts --runInBand`
- `yarn agent:check --profile pr`
- Desktop runtime: with the current `Swap&Bridge` response, the banner is visible on Swap and hidden on Stock and Limit
- Mobile final runtime: pending manual verification

## Compatibility

- missing or empty `effectiveTab` keeps the previous all-tabs behavior
- modal suppression and user-close persistence are unchanged

[OK-57985]: https://onekeyhq.atlassian.net/browse/OK-57985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ