### PR TITLE
feat: improve approval detail token list (OK-58433)

### DIFF
--- a/packages/kit/src/views/ApprovalManagement/components/ApprovedTokenItem.test.tsx
+++ b/packages/kit/src/views/ApprovalManagement/components/ApprovedTokenItem.test.tsx
@@ -1,0 +1,370 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+
+import approvalUtils from '@onekeyhq/shared/src/utils/approvalUtils';
+import type { IApproval } from '@onekeyhq/shared/types/approval';
+import type { IToken } from '@onekeyhq/shared/types/token';
+
+import { ApprovalManagementTestIDs } from '../testIDs';
+
+import ApprovedTokenItem from './ApprovedTokenItem';
+
+const accountId = 'account-1';
+const networkId = 'evm--1';
+const contractAddress = '0xspender';
+const tokenAddress = '0xtoken';
+const permit2Address = '0xpermit2';
+
+const tokenInfo: IToken = {
+  address: tokenAddress,
+  decimals: 6,
+  isNative: false,
+  name: 'USD Coin',
+  symbol: 'USDC',
+};
+
+let mockTokenMap: Record<string, { info: IToken }> = {};
+let mockApprovalContext: {
+  isBuildingRevokeTxs: boolean;
+  selectedTokens: Record<string, boolean>;
+} = {
+  isBuildingRevokeTxs: false,
+  selectedTokens: {},
+};
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: (
+      { id }: { id: string },
+      values?: Record<string, string>,
+    ) => {
+      const messages: Record<string, string> = {
+        'global.approval_time': 'Approval time',
+        'global.revoke': 'Revoke',
+        'swap_page.provider.approve_amount_un_limit': 'Unlimited',
+        wallet_approval_permit2_never_expires__desc: 'Never expires',
+      };
+      if (id === 'global.revoke_approve') {
+        return `Revoke ${values?.symbol ?? ''} allowance`;
+      }
+      if (id === 'wallet_approval_permit2_expires_at__desc') {
+        return `Expires at ${values?.date ?? ''}`;
+      }
+      return messages[id] ?? id;
+    },
+  }),
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/dateUtils', () => ({
+  formatDate: (
+    _date: Date,
+    options?: {
+      hideTheYear?: boolean;
+      hideTimeForever?: boolean;
+      hideYear?: boolean;
+    },
+  ) => {
+    if (options?.hideTheYear) {
+      return '07/17';
+    }
+    if (options?.hideTimeForever) {
+      return '2026/07/17';
+    }
+    if (options?.hideYear) {
+      return '08/16, 12:27';
+    }
+    return '2026/08/16, 12:27';
+  },
+}));
+
+jest.mock('@onekeyhq/components', () => {
+  return {
+    Button: ({
+      accessibilityLabel,
+      children,
+      disabled,
+      loading,
+      onPress,
+      testID,
+    }: {
+      accessibilityLabel?: string;
+      children?: ReactNode;
+      disabled?: boolean;
+      loading?: boolean;
+      onPress?: () => void;
+      testID?: string;
+    }) => (
+      <button
+        aria-label={accessibilityLabel}
+        data-loading={String(Boolean(loading))}
+        data-testid={testID}
+        disabled={disabled}
+        onClick={onPress}
+        type="button"
+      >
+        {children}
+      </button>
+    ),
+    Checkbox: ({
+      accessibilityLabel,
+      onChange,
+      shouldStopPropagation,
+      testID,
+      value,
+    }: {
+      accessibilityLabel?: string;
+      onChange?: (value: boolean) => void;
+      shouldStopPropagation?: boolean;
+      testID?: string;
+      value?: boolean;
+    }) => (
+      <input
+        aria-label={accessibilityLabel}
+        checked={value}
+        data-should-stop-propagation={String(Boolean(shouldStopPropagation))}
+        data-testid={testID}
+        onChange={() => onChange?.(!value)}
+        onClick={(event) => {
+          if (shouldStopPropagation) {
+            event.stopPropagation();
+          }
+        }}
+        type="checkbox"
+      />
+    ),
+    Icon: () => null,
+    NumberSizeableText: ({
+      autoFormatter,
+      children,
+    }: {
+      autoFormatter?: string;
+      children?: ReactNode;
+    }) => (
+      <span data-auto-formatter={autoFormatter} data-testid="allowance-number">
+        {children}
+      </span>
+    ),
+    SizableText: ({ children }: { children?: ReactNode }) => (
+      <span>{children}</span>
+    ),
+    Stack: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    XStack: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    YStack: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  };
+});
+
+jest.mock('../../../components/ListItem', () => {
+  const ListItem = ({
+    children,
+    onPress,
+    renderItemText,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    renderItemText?: ReactNode;
+  }) => {
+    const content = (
+      <>
+        {renderItemText}
+        {children}
+      </>
+    );
+
+    if (onPress) {
+      return (
+        <div
+          data-testid="approval-list-item"
+          onClick={onPress}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              onPress();
+            }
+          }}
+          role="button"
+          tabIndex={0}
+        >
+          {content}
+        </div>
+      );
+    }
+
+    return <div data-testid="approval-list-item">{content}</div>;
+  };
+  return { ListItem };
+});
+
+jest.mock('../../../states/jotai/contexts/approvalList', () => ({
+  useTokenMapAtom: () => [{ tokenMap: mockTokenMap }],
+}));
+
+jest.mock('./ApprovalManagementContext', () => ({
+  useApprovalManagementContext: () => mockApprovalContext,
+}));
+
+function buildApproval(overrides: Partial<IApproval> = {}): IApproval {
+  return {
+    allowance: '1000000',
+    allowanceParsed: '1',
+    isInfiniteAmount: true,
+    networkId,
+    riskLevel: 0,
+    spenderAddress: contractAddress,
+    time: 1_768_492_800_000,
+    tokenAddress,
+    ...overrides,
+  };
+}
+
+function renderItem({
+  approval = buildApproval(),
+  isSelectMode = false,
+  onRevoke = jest.fn(async () => undefined),
+  onSelect = jest.fn(async () => undefined),
+}: {
+  approval?: IApproval;
+  isSelectMode?: boolean;
+  onRevoke?: jest.Mock;
+  onSelect?: jest.Mock;
+} = {}) {
+  return {
+    onRevoke,
+    onSelect,
+    ...render(
+      <ApprovedTokenItem
+        accountId={accountId}
+        networkId={networkId}
+        contractAddress={contractAddress}
+        approval={approval}
+        isSelectMode={isSelectMode}
+        onRevoke={onRevoke}
+        onSelect={onSelect}
+      />,
+    ),
+  };
+}
+
+describe('ApprovedTokenItem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTokenMap = {
+      [approvalUtils.buildTokenMapKey({ networkId, tokenAddress })]: {
+        info: tokenInfo,
+      },
+    };
+    mockApprovalContext = {
+      isBuildingRevokeTxs: false,
+      selectedTokens: {},
+    };
+  });
+
+  it('renders a standard approval and forwards revoke', () => {
+    const approval = buildApproval();
+    const onRevoke = jest.fn(async () => undefined);
+    const { getByLabelText, getByTestId, getByText, queryByText } = renderItem({
+      approval,
+      onRevoke,
+    });
+
+    expect(getByText('USDC')).toBeTruthy();
+    expect(getByText('2026/07/17')).toBeTruthy();
+    expect(getByText('Unlimited')).toBeTruthy();
+    expect(getByText('Revoke')).toBeTruthy();
+    expect(queryByText('Permit2 ·')).toBeNull();
+    expect(getByLabelText('Revoke USDC allowance')).toBeTruthy();
+
+    fireEvent.click(getByTestId(ApprovalManagementTestIDs.tokenRevokeBtn));
+
+    expect(onRevoke).toHaveBeenCalledTimes(1);
+    expect(onRevoke).toHaveBeenCalledWith({ approval, tokenInfo });
+  });
+
+  it('keeps the compact number formatter for finite allowances', () => {
+    const { getByTestId, getByText } = renderItem({
+      approval: buildApproval({
+        allowanceParsed: '1250000',
+        isInfiniteAmount: false,
+      }),
+    });
+
+    expect(
+      getByTestId('allowance-number').getAttribute('data-auto-formatter'),
+    ).toBe('balance-marketCap');
+    expect(getByText('1250000')).toBeTruthy();
+  });
+
+  it.each([
+    {
+      expirationMs: 1_785_444_349_000,
+      expected: 'Expires at 08/16, 12:27',
+    },
+    {
+      expirationMs: 281_474_976_710_655_000,
+      expected: 'Never expires',
+    },
+    { expirationMs: Number.NaN, expected: '--' },
+  ])(
+    'renders Permit2 metadata for expiration $expirationMs',
+    ({ expirationMs, expected }) => {
+      const { getByText } = renderItem({
+        approval: buildApproval({ permit2Address, expirationMs }),
+      });
+
+      expect(getByText('Permit2 ·')).toBeTruthy();
+      expect(getByText('Approval time 07/17')).toBeTruthy();
+      expect(getByText(expected)).toBeTruthy();
+    },
+  );
+
+  it('keeps checkbox selection separate from row selection', () => {
+    const onSelect = jest.fn(async () => undefined);
+    const { getByLabelText, getByTestId, queryByTestId } = renderItem({
+      isSelectMode: true,
+      onSelect,
+    });
+
+    expect(queryByTestId(ApprovalManagementTestIDs.tokenRevokeBtn)).toBeNull();
+
+    const checkbox = getByLabelText('USDC');
+    expect(checkbox.getAttribute('data-should-stop-propagation')).toBe('true');
+    fireEvent.click(checkbox);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith({
+      approval: expect.any(Object),
+      isSelected: true,
+    });
+
+    onSelect.mockClear();
+    fireEvent.click(getByTestId('approval-list-item'));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith({
+      approval: expect.any(Object),
+      isSelected: true,
+    });
+  });
+
+  it('shows loading only on the selected revoke action', () => {
+    const approval = buildApproval({ permit2Address });
+    const selectedKey = approvalUtils.buildSelectedTokenKey({
+      accountId,
+      networkId,
+      contractAddress,
+      tokenAddress,
+      permit2Address,
+    });
+    mockApprovalContext = {
+      isBuildingRevokeTxs: true,
+      selectedTokens: { [selectedKey]: true },
+    };
+
+    const { getByTestId } = renderItem({ approval });
+    const revokeButton = getByTestId(ApprovalManagementTestIDs.tokenRevokeBtn);
+
+    expect((revokeButton as HTMLButtonElement).disabled).toBe(true);
+    expect(revokeButton.getAttribute('data-loading')).toBe('true');
+  });
+});

--- a/packages/kit/src/views/ApprovalManagement/components/ApprovedTokenItem.tsx
+++ b/packages/kit/src/views/ApprovalManagement/components/ApprovedTokenItem.tsx
@@ -1,9 +1,8 @@
-import { memo, useMemo } from 'react';
+import { type ReactNode, memo, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
 import {
-  Badge,
   Button,
   Checkbox,
   Icon,
@@ -12,7 +11,6 @@ import {
   Stack,
   XStack,
   YStack,
-  useMedia,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import approvalUtils from '@onekeyhq/shared/src/utils/approvalUtils';
@@ -63,9 +61,7 @@ function ApprovedTokenItem(props: IProps) {
   const { isBuildingRevokeTxs, selectedTokens } =
     useApprovalManagementContext();
   const intl = useIntl();
-  const { sm } = useMedia();
   const isPermit2Approval = approvalUtils.isPermit2Approval({ approval });
-  const isCompactPermit2Layout = isPermit2Approval && sm;
 
   const isSelected =
     !!selectedTokens[
@@ -89,7 +85,11 @@ function ApprovedTokenItem(props: IProps) {
   const approvalDate = formatDate(new Date(approval.time), {
     hideTimeForever: true,
   });
-  const permit2ExpirationText = useMemo(() => {
+  const compactApprovalDate = formatDate(new Date(approval.time), {
+    hideTheYear: true,
+    hideTimeForever: true,
+  });
+  const permit2ExpirationInfo = useMemo(() => {
     if (!isPermit2Approval) {
       return undefined;
     }
@@ -98,122 +98,225 @@ function ApprovedTokenItem(props: IProps) {
       approval.expirationMs,
     );
     if (!expiration) {
-      return '--';
+      return {
+        displayText: '--',
+        accessibilityText: '--',
+      };
     }
     if (expiration.isNeverExpires) {
-      return intl.formatMessage({
+      const neverExpiresText = intl.formatMessage({
         id: ETranslations.wallet_approval_permit2_never_expires__desc,
       });
+      return {
+        displayText: neverExpiresText,
+        accessibilityText: neverExpiresText,
+      };
     }
 
     const expirationDate = new Date(
       Number(expiration.expirationSeconds) * 1000,
     );
     if (Number.isNaN(expirationDate.getTime())) {
-      return '--';
+      return {
+        displayText: '--',
+        accessibilityText: '--',
+      };
     }
     const formattedExpiration = formatDate(expirationDate, {
       hideSeconds: true,
     });
     if (!formattedExpiration || formattedExpiration === '-') {
-      return '--';
+      return {
+        displayText: '--',
+        accessibilityText: '--',
+      };
     }
 
-    return intl.formatMessage(
-      {
-        id: ETranslations.wallet_approval_permit2_expires_at__desc,
-      },
-      { date: formattedExpiration },
-    );
-  }, [approval.expirationMs, intl, isPermit2Approval]);
+    const approvalYear = new Date(approval.time).getFullYear();
+    const compactExpiration = formatDate(expirationDate, {
+      hideYear: approvalYear === expirationDate.getFullYear(),
+      hideSeconds: true,
+    });
+
+    const displayExpiration =
+      compactExpiration && compactExpiration !== '-'
+        ? compactExpiration
+        : formattedExpiration;
+
+    return {
+      displayText: intl.formatMessage(
+        {
+          id: ETranslations.wallet_approval_permit2_expires_at__desc,
+        },
+        { date: displayExpiration },
+      ),
+      accessibilityText: intl.formatMessage(
+        {
+          id: ETranslations.wallet_approval_permit2_expires_at__desc,
+        },
+        { date: formattedExpiration },
+      ),
+    };
+  }, [approval.expirationMs, approval.time, intl, isPermit2Approval]);
 
   if (!token) {
     return null;
   }
 
   const allowanceContent = approval.isInfiniteAmount ? (
-    intl.formatMessage({
-      id: ETranslations.swap_page_provider_approve_amount_un_limit,
-    })
+    <SizableText
+      size="$bodyMdMedium"
+      numberOfLines={1}
+      ellipsizeMode="tail"
+      flexShrink={1}
+      minWidth={0}
+    >
+      {intl.formatMessage({
+        id: ETranslations.swap_page_provider_approve_amount_un_limit,
+      })}
+    </SizableText>
   ) : (
     <NumberSizeableText
       numberOfLines={1}
-      textAlign="right"
-      size="$bodyLgMedium"
+      ellipsizeMode="tail"
+      size="$bodyMdMedium"
       autoFormatter="balance-marketCap"
+      flexShrink={1}
+      minWidth={0}
     >
       {approval.allowanceParsed}
     </NumberSizeableText>
   );
 
-  const revokeButton = isSelectMode ? null : (
-    <Button
-      testID={ApprovalManagementTestIDs.tokenRevokeBtn}
-      size="small"
-      loading={isBuildingRevokeTxs ? isSelected : null}
-      disabled={isBuildingRevokeTxs}
-      onPress={() => {
-        void onRevoke({ approval, tokenInfo: token.info });
-      }}
-    >
-      {intl.formatMessage({ id: ETranslations.global_revoke })}
-    </Button>
+  const revokeAccessibilityLabel = intl.formatMessage(
+    { id: ETranslations.global_revoke_approve },
+    { symbol: token.info.symbol },
   );
+  const isRevokeLoading = isBuildingRevokeTxs && isSelected;
+  const handleRevokePress = () => {
+    void onRevoke({ approval, tokenInfo: token.info });
+  };
+  let revokeAction: ReactNode;
+  if (isSelectMode) {
+    revokeAction = (
+      <Checkbox
+        testID={ApprovalManagementTestIDs.tokenItemCheckbox}
+        value={isSelected}
+        shouldStopPropagation
+        containerProps={{ py: '$0', flexShrink: 0 }}
+        accessibilityLabel={token.info.symbol}
+        onChange={(value) => {
+          void onSelect({
+            approval,
+            isSelected: value === true,
+          });
+        }}
+      />
+    );
+  } else {
+    revokeAction = (
+      <Button
+        testID={ApprovalManagementTestIDs.tokenRevokeBtn}
+        size="small"
+        accessibilityLabel={revokeAccessibilityLabel}
+        loading={isRevokeLoading}
+        disabled={isBuildingRevokeTxs}
+        onPress={handleRevokePress}
+      >
+        {intl.formatMessage({ id: ETranslations.global_revoke })}
+      </Button>
+    );
+  }
 
   return (
     <ListItem
+      alignItems="center"
+      py="$2.5"
       renderItemText={
-        <ListItem.Text
-          flex={1}
-          minWidth={0}
-          primary={
-            <XStack alignItems="center" gap="$1.5" minWidth={0}>
+        <YStack flex={1} minWidth={0} maxWidth="100%" gap="$0.5">
+          <XStack
+            alignItems="baseline"
+            gap="$1"
+            minWidth={0}
+            maxWidth="100%"
+            overflow="hidden"
+          >
+            {allowanceContent}
+            <SizableText
+              size="$bodyMdMedium"
+              numberOfLines={1}
+              ellipsizeMode="tail"
+              flexShrink={0}
+              minWidth={0}
+              maxWidth="45%"
+            >
+              {token.info.symbol}
+            </SizableText>
+          </XStack>
+
+          <XStack
+            alignItems="center"
+            columnGap="$1.5"
+            minWidth={0}
+            maxWidth="100%"
+            overflow="hidden"
+          >
+            {isPermit2Approval ? (
               <SizableText
-                size="$bodyLgMedium"
+                size="$bodySmMedium"
+                color="$textSubdued"
                 numberOfLines={1}
-                ellipsizeMode="tail"
-                flexShrink={1}
-                minWidth={0}
+                flexShrink={0}
               >
-                {token.info.symbol}
+                Permit2 ·
               </SizableText>
-              {isPermit2Approval ? (
-                <Badge
-                  badgeSize="sm"
-                  bg="$transparent"
-                  borderWidth={1}
-                  borderColor="$borderSubdued"
-                  flexShrink={0}
-                >
-                  <Badge.Text>Permit2</Badge.Text>
-                </Badge>
-              ) : null}
-            </XStack>
-          }
-          secondary={
-            <YStack>
-              <SizableText size="$bodyMd" color="$textSubdued">
-                {approvalDate}
-              </SizableText>
-              {permit2ExpirationText ? (
-                <SizableText size="$bodyMd" color="$textSubdued">
-                  {permit2ExpirationText}
-                </SizableText>
-              ) : null}
-            </YStack>
-          }
-        />
+            ) : null}
+            <SizableText
+              size="$bodySm"
+              color="$textSubdued"
+              numberOfLines={1}
+              ellipsizeMode="tail"
+              flex={1}
+              minWidth={0}
+            >
+              {permit2ExpirationInfo ? (
+                <>
+                  {intl.formatMessage({
+                    id: ETranslations.global_approval_time,
+                  })}{' '}
+                  {compactApprovalDate}
+                </>
+              ) : (
+                approvalDate
+              )}
+            </SizableText>
+          </XStack>
+          {permit2ExpirationInfo ? (
+            <SizableText
+              size="$bodySm"
+              color="$textSubdued"
+              numberOfLines={1}
+              ellipsizeMode="tail"
+              minWidth={0}
+              maxWidth="100%"
+              accessibilityLabel={permit2ExpirationInfo.accessibilityText}
+            >
+              {permit2ExpirationInfo.displayText}
+            </SizableText>
+          ) : null}
+        </YStack>
       }
       avatarProps={{
         src: token.info.logoURI,
+        size: '$8',
         borderRadius: '$full',
         fallbackProps: {
           bg: '$gray5',
-          width: '$10',
-          height: '$10',
+          width: '$8',
+          height: '$8',
           justifyContent: 'center',
           alignItems: 'center',
-          children: <Icon size="$7" name="CryptoCoinOutline" />,
+          children: <Icon size="$5" name="CryptoCoinOutline" />,
         },
       }}
       onPress={
@@ -226,49 +329,15 @@ function ApprovedTokenItem(props: IProps) {
             }
           : undefined
       }
-      childrenBefore={
-        isSelectMode ? (
-          <Stack>
-            <Checkbox
-              testID={ApprovalManagementTestIDs.tokenItemCheckbox}
-              value={isSelected}
-              onChange={() => {
-                void onSelect({
-                  approval,
-                  isSelected: !isSelected,
-                });
-              }}
-            />
-          </Stack>
-        ) : null
-      }
     >
-      {isCompactPermit2Layout ? (
-        <YStack
-          alignItems="flex-end"
-          justifyContent="center"
-          gap="$1"
-          flexShrink={0}
-        >
-          <ListItem.Text
-            align="right"
-            primaryTextProps={{ numberOfLines: 1 }}
-            primary={allowanceContent}
-          />
-          {revokeButton}
-        </YStack>
-      ) : (
-        <>
-          <ListItem.Text
-            align="right"
-            flex={1}
-            minWidth={0}
-            primaryTextProps={{ numberOfLines: 1 }}
-            primary={allowanceContent}
-          />
-          {revokeButton}
-        </>
-      )}
+      <Stack
+        height="$8"
+        flexShrink={0}
+        alignItems="flex-end"
+        justifyContent="center"
+      >
+        {revokeAction}
+      </Stack>
     </ListItem>
   );
 }

--- a/packages/kit/src/views/ApprovalManagement/pages/ApprovalDetails.tsx
+++ b/packages/kit/src/views/ApprovalManagement/pages/ApprovalDetails.tsx
@@ -476,11 +476,18 @@ function ApprovalDetails() {
             <XStack
               justifyContent="space-between"
               alignItems="center"
+              gap="$3"
               mt="$3"
               px="$5"
               py="$2"
             >
-              <SizableText size="$bodyMdMedium" color="$textSubdued">
+              <SizableText
+                size="$bodyMdMedium"
+                color="$textSubdued"
+                numberOfLines={1}
+                flex={1}
+                minWidth={0}
+              >
                 {intl.formatMessage({
                   id: ETranslations.wallet_approval_approved_token,
                 })}
@@ -489,6 +496,7 @@ function ApprovalDetails() {
                 testID={ApprovalManagementTestIDs.bulkRevokeToggleBtn}
                 variant="tertiary"
                 size="small"
+                flexShrink={0}
                 onPress={() => {
                   if (
                     accountUtils.isWatchingAccount({


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58433](https://onekeyhq.atlassian.net/browse/OK-58433)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- refine the approved-token list hierarchy and align the section action
- present normal and Permit2 approvals consistently across narrow and desktop layouts
- show Permit2 approval time and expiration as distinct metadata
- keep direct revoke and bulk-selection interactions stable
- add focused component coverage for approval rendering and actions

## Jira

- [OK-58433](https://onekeyhq.atlassian.net/browse/OK-58433)

## Validation

- `yarn jest packages/kit/src/views/ApprovalManagement/components/ApprovedTokenItem.test.tsx --runInBand`
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`

## Manual verification

- Not run; mobile and desktop visual verification will be completed manually.


[OK-58433]: https://onekeyhq.atlassian.net/browse/OK-58433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ