### PR TITLE
fix(perps): follow up on add position and TP/SL (OK-58389, OK-58391, OK-58396)

### DIFF
--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
@@ -30,6 +30,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
   formatPriceToSignificantDigits,
   parseDexCoin,
+  resolveTradingSize,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import { EPerpsSizeInputMode } from '@onekeyhq/shared/types/hyperliquid';
 import type {
@@ -47,6 +48,7 @@ import {
   PERP_DIALOG_BUTTON_SIZE,
   PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
 } from '../PerpDialogLayout';
+import { PerpsSlider } from '../PerpsSlider';
 import { TradingGuardWrapper } from '../TradingGuardWrapper';
 import { PriceInput } from '../TradingPanel/inputs/PriceInput';
 import { SizeInput } from '../TradingPanel/inputs/SizeInput';
@@ -94,6 +96,10 @@ const AddPositionForm = memo(
 
     const [orderType, setOrderType] = useState<IAddPositionOrderType>('market');
     const [amount, setAmount] = useState('');
+    const [sizeInputMode, setSizeInputMode] = useState<EPerpsSizeInputMode>(
+      EPerpsSizeInputMode.MANUAL,
+    );
+    const [sizePercent, setSizePercent] = useState(0);
     const [limitPrice, setLimitPrice] = useState('');
     const [hasTpsl, setHasTpsl] = useState(false);
     const [tpType, setTpType] = useState<'price' | 'percentage'>('price');
@@ -204,6 +210,41 @@ const AddPositionForm = memo(
       szDecimals !== undefined &&
       isAddPositionAssetDataScoped({ data: assetData, coin, accountAddress }),
     );
+    const resolvedSize = useMemo(
+      () =>
+        resolveTradingSize({
+          sizeInputMode,
+          manualSize: amount,
+          sizePercent,
+          side: isBuy ? 'long' : 'short',
+          maxSize,
+          szDecimals,
+        }),
+      [amount, isBuy, maxSize, sizeInputMode, sizePercent, szDecimals],
+    );
+
+    const handleManualSizeChange = useCallback((value: string) => {
+      setAmount(value);
+      setSizeInputMode(EPerpsSizeInputMode.MANUAL);
+      setSizePercent(0);
+    }, []);
+
+    const handleSliderPercentChange = useCallback((value: number) => {
+      const percent = Number.isFinite(value) ? value : 0;
+      setSizeInputMode(EPerpsSizeInputMode.SLIDER);
+      setSizePercent(Math.max(0, Math.min(100, percent)));
+      setAmount('');
+    }, []);
+
+    const switchToManual = useCallback(() => {
+      if (sizeInputMode !== EPerpsSizeInputMode.SLIDER) {
+        return;
+      }
+      setSizeInputMode(EPerpsSizeInputMode.MANUAL);
+      setSizePercent(0);
+      setAmount('');
+    }, [sizeInputMode]);
+
     // Size problems keep the button pressable and surface a toast on press,
     // matching the main trading panel instead of silently disabling it.
     const showValidationToast = useCallback(
@@ -282,7 +323,7 @@ const AddPositionForm = memo(
         return;
       }
       const localValidation = validateAddPositionOrder({
-        size: amount,
+        size: resolvedSize,
         price: effectivePrice,
         maxSize,
         szDecimals: szDecimals ?? 0,
@@ -320,10 +361,21 @@ const AddPositionForm = memo(
           orderType === 'market' ? latestAssetData.markPx : limitPrice;
         const latestSzDecimals =
           latestTargetData.targetAsset.universe?.szDecimals ?? 0;
+        const latestMaxSize = latestAssetData.maxTradeSzs[isBuy ? 0 : 1];
+        // Re-resolve slider sizes against the refreshed max so a 100% drag
+        // cannot fall out of range while the dialog was open.
+        const latestSize = resolveTradingSize({
+          sizeInputMode,
+          manualSize: amount,
+          sizePercent,
+          side: isBuy ? 'long' : 'short',
+          maxSize: latestMaxSize,
+          szDecimals: latestSzDecimals,
+        });
         const latestValidation = validateAddPositionOrder({
-          size: amount,
+          size: latestSize,
           price: latestPrice,
-          maxSize: latestAssetData.maxTradeSzs[isBuy ? 0 : 1],
+          maxSize: latestMaxSize,
           szDecimals: latestSzDecimals,
         });
         if (latestValidation.error) {
@@ -391,7 +443,10 @@ const AddPositionForm = memo(
       maxSize,
       onClose,
       orderType,
+      resolvedSize,
       showValidationToast,
+      sizeInputMode,
+      sizePercent,
       slType,
       slValue,
       szDecimals,
@@ -487,12 +542,24 @@ const AddPositionForm = memo(
           isAssetCtxReady={isTargetAssetReady}
           symbol={displayName}
           value={amount}
-          onChange={setAmount}
-          sizeInputMode={EPerpsSizeInputMode.MANUAL}
-          sliderPercent={0}
+          onChange={handleManualSizeChange}
+          sizeInputMode={sizeInputMode}
+          sliderPercent={sizePercent}
+          onRequestManualMode={switchToManual}
           leverage={leverage}
           allowMarginInput
           ifOnDialog
+        />
+        <PerpsSlider
+          min={0}
+          max={100}
+          value={sizeInputMode === EPerpsSizeInputMode.SLIDER ? sizePercent : 0}
+          onChange={handleSliderPercentChange}
+          disabled={isSubmitting || !isTargetAssetReady}
+          segments={4}
+          snapTapToSegment
+          showBubble={false}
+          sliderHeight={4}
         />
         <Checkbox
           testID="perp-add-position-tpsl-checkbox"

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
@@ -253,11 +253,13 @@ const AddPositionForm = memo(
 
         const latestPrice =
           orderType === 'market' ? latestAssetData.markPx : limitPrice;
+        const latestSzDecimals =
+          latestTargetData.targetAsset.universe?.szDecimals ?? 0;
         const latestValidation = validateAddPositionOrder({
           size: amount,
           price: latestPrice,
           maxSize: latestAssetData.maxTradeSzs[isBuy ? 0 : 1],
-          szDecimals: latestTargetData.targetAsset.universe?.szDecimals ?? 0,
+          szDecimals: latestSzDecimals,
         });
         if (latestValidation.error) {
           throw new OneKeyLocalError(
@@ -283,6 +285,7 @@ const AddPositionForm = memo(
           referencePrice: new BigNumber(latestPrice),
           side: isBuy ? 'long' : 'short',
           leverage: latestLeverage,
+          szDecimals: latestSzDecimals,
         });
 
         await actions.current.placeOrderByCoin({

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
@@ -21,7 +21,10 @@ import {
   usePerpsAllMidsAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import type { IPerpsActiveAssetAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { usePerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  usePerpsActiveAccountAtom,
+  usePerpsTradingPreferencesAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import {
@@ -50,11 +53,13 @@ import { SizeInput } from '../TradingPanel/inputs/SizeInput';
 import { TpSlFormInput } from '../TradingPanel/inputs/TpSlFormInput';
 
 import {
+  buildAddPositionMinimumAmountLabel,
   isAddPositionAssetDataScoped,
   isAddPositionScopeValid,
   validateAddPositionOrder,
 } from './utils/addPosition';
 
+import type { IAddPositionValidationError } from './utils/addPosition';
 import type { IntlShape } from 'react-intl';
 type IAddPositionOrderType = 'market' | 'limit';
 
@@ -73,6 +78,8 @@ const AddPositionForm = memo(
     const intl = useIntl();
     const actions = useHyperliquidActions();
     const [activeAccount] = usePerpsActiveAccountAtom();
+    const [tradingPreferences] = usePerpsTradingPreferencesAtom();
+    const sizeInputUnit = tradingPreferences.sizeInputUnit ?? 'usd';
     const [allMids] = usePerpsAllMidsAtom();
     const activePositions = usePerpsAccountScopedActivePositions();
     const currentPosition = useMemo(
@@ -197,14 +204,50 @@ const AddPositionForm = memo(
       szDecimals !== undefined &&
       isAddPositionAssetDataScoped({ data: assetData, coin, accountAddress }),
     );
-    const validation = validateAddPositionOrder({
-      size: amount,
-      price: effectivePrice,
-      maxSize,
-      szDecimals: szDecimals ?? 0,
-    });
-    const isFormValid = Boolean(
-      isScopeValid && isTargetAssetReady && !validation.error,
+    // Size problems keep the button pressable and surface a toast on press,
+    // matching the main trading panel instead of silently disabling it.
+    const showValidationToast = useCallback(
+      ({
+        error,
+        price,
+        decimals,
+      }: {
+        error: IAddPositionValidationError;
+        price: string;
+        decimals: number;
+      }) => {
+        if (error === 'invalidPrice') {
+          Toast.message({
+            title: intl.formatMessage({
+              id: ETranslations.perp_trade_price_place_holder,
+            }),
+          });
+          return;
+        }
+        if (error === 'insufficientMargin') {
+          Toast.error({
+            title: intl.formatMessage({
+              id: ETranslations.perp_insufficient_margin__title,
+            }),
+          });
+          return;
+        }
+        Toast.message({
+          title: intl.formatMessage(
+            { id: ETranslations.perp_size_least },
+            {
+              amount: buildAddPositionMinimumAmountLabel({
+                price,
+                szDecimals: decimals,
+                sizeInputUnit,
+                leverage,
+                symbol: displayName,
+              }),
+            },
+          ),
+        });
+      },
+      [displayName, intl, leverage, sizeInputUnit],
     );
 
     const handleTpslCheckboxChange = useCallback(
@@ -227,7 +270,29 @@ const AddPositionForm = memo(
     );
 
     const handleSubmit = useCallback(async () => {
-      if (!isFormValid || isSubmitting) {
+      if (isSubmitting || !isTargetAssetReady) {
+        return;
+      }
+      if (!isScopeValid) {
+        Toast.error({
+          title: intl.formatMessage({
+            id: ETranslations.position_or_account_changed__msg,
+          }),
+        });
+        return;
+      }
+      const localValidation = validateAddPositionOrder({
+        size: amount,
+        price: effectivePrice,
+        maxSize,
+        szDecimals: szDecimals ?? 0,
+      });
+      if (localValidation.error) {
+        showValidationToast({
+          error: localValidation.error,
+          price: effectivePrice,
+          decimals: szDecimals ?? 0,
+        });
         return;
       }
       setIsSubmitting(true);
@@ -262,16 +327,12 @@ const AddPositionForm = memo(
           szDecimals: latestSzDecimals,
         });
         if (latestValidation.error) {
-          throw new OneKeyLocalError(
-            latestValidation.error === 'minimumOrder'
-              ? intl.formatMessage(
-                  { id: ETranslations.perp_order_size_small },
-                  { amount: '$10' },
-                )
-              : intl.formatMessage({
-                  id: ETranslations.position_increase_amount_unavailable__msg,
-                }),
-          );
+          showValidationToast({
+            error: latestValidation.error,
+            price: latestPrice,
+            decimals: latestSzDecimals,
+          });
+          return;
         }
 
         const latestPosition = currentPositionRef.current;
@@ -317,18 +378,23 @@ const AddPositionForm = memo(
       actions,
       amount,
       coin,
+      effectivePrice,
       fetchTargetAssetData,
       hasTpsl,
       intl,
       isBuy,
-      isFormValid,
+      isScopeValid,
       isSubmitting,
+      isTargetAssetReady,
       limitPrice,
       leverage,
+      maxSize,
       onClose,
       orderType,
+      showValidationToast,
       slType,
       slValue,
+      szDecimals,
       tpType,
       tpValue,
     ]);
@@ -471,22 +537,12 @@ const AddPositionForm = memo(
             />
           </YStack>
         ) : null}
-        <XStack justifyContent="space-between">
-          <SizableText size="$bodySm" color="$textSubdued">
-            {intl.formatMessage({
-              id: ETranslations.perp_trading_adjust_margin_max,
-            })}
-          </SizableText>
-          <SizableText size="$bodySmMedium">
-            {maxSize} {displayName}
-          </SizableText>
-        </XStack>
         <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
           <Button
             testID={PerpTestIDs.AddPositionConfirmButton}
             size={PERP_DIALOG_BUTTON_SIZE}
             variant="primary"
-            disabled={!isFormValid || isSubmitting}
+            disabled={isSubmitting || !isTargetAssetReady}
             loading={isSubmitting}
             onPress={handleSubmit}
           >

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal.tsx
@@ -43,6 +43,7 @@ import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 import { isPerpsAccountAddressMatched } from '../../utils/accountScopedData';
 import { resolveTpSlTriggerPx } from '../../utils/resolveTpSlTriggerPx';
 import {
+  DEFAULT_TPSL_ROE_PERCENT,
   buildDefaultTpSlPercent,
   shouldSeedPositionTpSlLeg,
 } from '../../utils/tpslSeed';
@@ -66,6 +67,13 @@ import {
 
 import type { RouteProp } from '@react-navigation/core';
 import type { IntlShape } from 'react-intl';
+
+// The position TP/SL seed defaults each empty leg to a 10% ROE; a stable
+// reference lets TpslInput display "10" verbatim on the seeded price.
+const POSITION_TPSL_SEED_PERCENT = {
+  tp: DEFAULT_TPSL_ROE_PERCENT,
+  sl: DEFAULT_TPSL_ROE_PERCENT,
+};
 
 export interface ISetTpslParams {
   coin: string;
@@ -353,6 +361,7 @@ const SetTpslForm = memo(
         referencePrice: new BigNumber(entryPrice),
         side: isLongPosition ? 'long' : 'short',
         leverage,
+        szDecimals,
       });
       setFormData((previous) => {
         const shouldSeedTp = shouldSeedPositionTpSlLeg({
@@ -395,6 +404,7 @@ const SetTpslForm = memo(
       presetTpsl,
       presetTriggerPrice,
       slOrder,
+      szDecimals,
       tpOrder,
     ]);
 
@@ -739,6 +749,7 @@ const SetTpslForm = memo(
             side={isLongPosition ? 'long' : 'short'}
             szDecimals={szDecimals}
             leverage={leverage}
+            seedPercent={POSITION_TPSL_SEED_PERCENT}
             tpsl={{ tpPrice: formData.tpPrice, slPrice: formData.slPrice }}
             onChange={handleTpslChange}
             amount={

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/utils/addPosition.test.ts
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/utils/addPosition.test.ts
@@ -1,6 +1,7 @@
 import type { IActiveAssetData } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 import {
+  buildAddPositionMinimumAmountLabel,
   getPositionDirection,
   isAddPositionAssetDataScoped,
   isAddPositionScopeValid,
@@ -97,5 +98,44 @@ describe('add position guards', () => {
         szDecimals: 2,
       }).error,
     ).toBe('minimumOrder');
+  });
+
+  it('expresses the minimum order hint in the active size unit', () => {
+    const base = {
+      price: '100',
+      szDecimals: 2,
+      leverage: 5,
+      symbol: 'ETH',
+    };
+    expect(
+      buildAddPositionMinimumAmountLabel({ ...base, sizeInputUnit: 'usd' }),
+    ).toBe('$10');
+    expect(
+      buildAddPositionMinimumAmountLabel({ ...base, sizeInputUnit: 'token' }),
+    ).toBe('0.10 ETH');
+    expect(
+      buildAddPositionMinimumAmountLabel({ ...base, sizeInputUnit: 'margin' }),
+    ).toBe('$2.00');
+  });
+
+  it('falls back to the usd minimum when price or leverage is unusable', () => {
+    expect(
+      buildAddPositionMinimumAmountLabel({
+        price: '0',
+        szDecimals: 2,
+        leverage: 5,
+        symbol: 'ETH',
+        sizeInputUnit: 'token',
+      }),
+    ).toBe('$10');
+    expect(
+      buildAddPositionMinimumAmountLabel({
+        price: '100',
+        szDecimals: 2,
+        leverage: 0,
+        symbol: 'ETH',
+        sizeInputUnit: 'margin',
+      }),
+    ).toBe('$10');
   });
 });

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/utils/addPosition.ts
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/utils/addPosition.ts
@@ -6,6 +6,8 @@ import {
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { IActiveAssetData } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
+export const ADD_POSITION_MIN_ORDER_NOTIONAL = 10;
+
 export type IAddPositionValidationError =
   | 'invalidSize'
   | 'invalidPrice'
@@ -85,8 +87,52 @@ export function validateAddPositionOrder({
   if (!maxSizeBN.isFinite() || new BigNumber(formattedSize).gt(maxSizeBN)) {
     return { size: formattedSize, error: 'insufficientMargin' };
   }
-  if (new BigNumber(formattedSize).multipliedBy(priceBN).lt(10)) {
+  if (
+    new BigNumber(formattedSize)
+      .multipliedBy(priceBN)
+      .lt(ADD_POSITION_MIN_ORDER_NOTIONAL)
+  ) {
     return { size: formattedSize, error: 'minimumOrder' };
   }
   return { size: formattedSize };
+}
+
+// Mirrors the main trading panel: the minimum order hint is expressed in the
+// unit the size field is currently showing, not always in USD.
+export function buildAddPositionMinimumAmountLabel({
+  price,
+  szDecimals,
+  sizeInputUnit,
+  leverage,
+  symbol,
+}: {
+  price: string;
+  szDecimals: number;
+  sizeInputUnit: 'token' | 'usd' | 'margin';
+  leverage: number;
+  symbol: string;
+}): string {
+  const fallback = `$${ADD_POSITION_MIN_ORDER_NOTIONAL}`;
+  const priceBN = new BigNumber(price);
+  if (!priceBN.isFinite() || priceBN.lte(0) || sizeInputUnit === 'usd') {
+    return fallback;
+  }
+
+  const minSize = new BigNumber(ADD_POSITION_MIN_ORDER_NOTIONAL)
+    .dividedBy(priceBN)
+    .decimalPlaces(szDecimals, BigNumber.ROUND_UP);
+
+  if (sizeInputUnit === 'token') {
+    return `${minSize.toFixed(szDecimals)} ${symbol}`;
+  }
+
+  const leverageBN = new BigNumber(leverage);
+  if (!leverageBN.isFinite() || leverageBN.lte(0)) {
+    return fallback;
+  }
+  return `$${minSize
+    .multipliedBy(priceBN)
+    .dividedBy(leverageBN)
+    .decimalPlaces(2, BigNumber.ROUND_UP)
+    .toFixed(2)}`;
 }

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/TpslInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/TpslInput.tsx
@@ -20,6 +20,7 @@ import {
   calculateProfitLoss,
   formatPercentage,
   formatPriceToSignificantDigits,
+  snapHlPriceToGrid,
   validatePriceInput,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 
@@ -98,6 +99,10 @@ interface ITpslInputProps {
   isMobile?: boolean;
   // Optional props for profit/loss calculation
   amount?: string | number;
+  // When a leg's price equals the price derived from this percent, show this
+  // percent verbatim instead of the value reverse-computed from the snapped
+  // price, so a seeded 10% default reads as "10" like manual percent entry.
+  seedPercent?: { tp?: string; sl?: string };
 }
 
 export const TpslInput = memo(
@@ -114,6 +119,7 @@ export const TpslInput = memo(
     hiddenSl = false,
     isMobile = false,
     amount,
+    seedPercent,
   }: ITpslInputProps) => {
     const referencePrice = useMemo(() => {
       return new BigNumber(price || 0);
@@ -188,20 +194,32 @@ export const TpslInput = memo(
           (side === 'long') === isTP
             ? new BigNumber(100).plus(adjustedPercent)
             : new BigNumber(100).minus(adjustedPercent);
-        return formatPriceToSignificantDigits(
-          referencePrice.multipliedBy(multiplier).dividedBy(100),
-          szDecimals,
-        );
+        const rawPrice = referencePrice.multipliedBy(multiplier).dividedBy(100);
+        // Snap to the nearest valid price so the typed percentage survives the
+        // round-trip instead of always truncating toward zero.
+        const snappedPrice =
+          snapHlPriceToGrid(rawPrice, 'nearest', szDecimals) ?? rawPrice;
+        return formatPriceToSignificantDigits(snappedPrice, szDecimals);
       },
       [referencePrice, side, szDecimals, leverage],
     );
 
     useEffect(() => {
+      // Keep the seeded percent (e.g. 10) as-is while the leg still sits on its
+      // seeded price; fall back to the reverse-computed percent once the user
+      // moves the price off that seed.
+      const resolveDisplayPercent = (priceValue: string, isTP: boolean) => {
+        const seed = isTP ? seedPercent?.tp : seedPercent?.sl;
+        if (seed && calculatePrice(seed, isTP) === priceValue) {
+          return seed;
+        }
+        return calculatePercent(priceValue, isTP);
+      };
       const newTpPercent = tpsl.tpPrice
-        ? calculatePercent(tpsl.tpPrice, true)
+        ? resolveDisplayPercent(tpsl.tpPrice, true)
         : '';
       const newSlPercent = tpsl.slPrice
-        ? calculatePercent(tpsl.slPrice, false)
+        ? resolveDisplayPercent(tpsl.slPrice, false)
         : '';
 
       setInternalState((prev) => {

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
@@ -857,6 +857,7 @@ export function LimitOrderForm({
         referencePrice: resolvedPriceBN,
         side: pressedSide,
         leverage,
+        szDecimals: isSpot ? undefined : szDecimals,
       });
 
       // Normalize to a concrete manual token size so the confirm dialog display

--- a/packages/kit/src/views/Perp/hooks/useOrderConfirm.ts
+++ b/packages/kit/src/views/Perp/hooks/useOrderConfirm.ts
@@ -488,6 +488,10 @@ function useOrderConfirmWithMarketDataFreshness({
             : new BigNumber(effectiveFormData.price || '0'),
         side,
         leverage,
+        szDecimals:
+          activeTradeInstrument.mode === 'spot'
+            ? undefined
+            : activeTradeInstrument.universe?.szDecimals,
       });
       if (tpTriggerPx !== undefined || slTriggerPx !== undefined) {
         effectiveFormData = {

--- a/packages/kit/src/views/Perp/utils/resolveTpSlTriggerPx.ts
+++ b/packages/kit/src/views/Perp/utils/resolveTpSlTriggerPx.ts
@@ -1,6 +1,9 @@
 import { BigNumber } from 'bignumber.js';
 
-import { formatPriceToSignificantDigits } from '@onekeyhq/shared/src/utils/perpsUtils';
+import {
+  formatPriceToSignificantDigits,
+  snapHlPriceToGrid,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
 
 export interface IResolveTpSlTriggerPxInput {
   hasTpsl: boolean;
@@ -12,6 +15,20 @@ export interface IResolveTpSlTriggerPxInput {
   referencePrice: BigNumber;
   side: 'long' | 'short';
   leverage?: number;
+  szDecimals?: number;
+}
+
+// Percent-derived triggers must land on the nearest valid price, otherwise the
+// significant-figure truncation always shifts the trigger toward zero and the
+// realized ROE drifts off the requested percentage by up to one tick x leverage.
+function roundPercentDerivedTriggerPx(
+  price: BigNumber,
+  szDecimals?: number,
+): BigNumber {
+  if (szDecimals === undefined) {
+    return price;
+  }
+  return snapHlPriceToGrid(price, 'nearest', szDecimals) ?? price;
 }
 
 export interface IResolveTpSlTriggerPxResult {
@@ -30,6 +47,7 @@ export function resolveTpSlTriggerPx({
   referencePrice,
   side,
   leverage = 1,
+  szDecimals,
 }: IResolveTpSlTriggerPxInput): IResolveTpSlTriggerPxResult {
   const leverageBN = new BigNumber(leverage);
   if (!hasTpsl || !(tpValue || slValue)) {
@@ -55,7 +73,7 @@ export function resolveTpSlTriggerPx({
         side === 'long'
           ? entryPrice.plus(percentChange)
           : entryPrice.minus(percentChange);
-      calculatedTpTriggerPx = tpPrice;
+      calculatedTpTriggerPx = roundPercentDerivedTriggerPx(tpPrice, szDecimals);
     }
   }
 
@@ -73,16 +91,16 @@ export function resolveTpSlTriggerPx({
         side === 'long'
           ? entryPrice.minus(percentChange)
           : entryPrice.plus(percentChange);
-      calculatedSlTriggerPx = slPrice;
+      calculatedSlTriggerPx = roundPercentDerivedTriggerPx(slPrice, szDecimals);
     }
   }
 
   return {
     tpTriggerPx: calculatedTpTriggerPx
-      ? formatPriceToSignificantDigits(calculatedTpTriggerPx)
+      ? formatPriceToSignificantDigits(calculatedTpTriggerPx, szDecimals)
       : '',
     slTriggerPx: calculatedSlTriggerPx
-      ? formatPriceToSignificantDigits(calculatedSlTriggerPx)
+      ? formatPriceToSignificantDigits(calculatedSlTriggerPx, szDecimals)
       : '',
   };
 }

--- a/packages/kit/src/views/Perp/utils/tpslSeed.test.ts
+++ b/packages/kit/src/views/Perp/utils/tpslSeed.test.ts
@@ -1,7 +1,46 @@
 import { BigNumber } from 'bignumber.js';
 
+import {
+  formatPriceToSignificantDigits,
+  getHlPriceTick,
+  snapHlPriceToGrid,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
+
 import { resolveTpSlTriggerPx } from './resolveTpSlTriggerPx';
-import { buildDefaultTpSlPercent, shouldSeedPositionTpSlLeg } from './tpslSeed';
+import {
+  DEFAULT_TPSL_ROE_PERCENT,
+  buildDefaultTpSlPercent,
+  shouldSeedPositionTpSlLeg,
+} from './tpslSeed';
+
+// Mirrors TpslInput.calculatePrice: the seeded-percent display hint only reads
+// as "10" when the seeded price matches this manual percent->price conversion.
+function manualPercentToPrice({
+  percent,
+  entry,
+  leverage,
+  side,
+  isTP,
+  szDecimals,
+}: {
+  percent: string;
+  entry: string;
+  leverage: number;
+  side: 'long' | 'short';
+  isTP: boolean;
+  szDecimals: number;
+}): string {
+  const referencePrice = new BigNumber(entry);
+  const adjustedPercent = new BigNumber(percent).dividedBy(leverage);
+  const multiplier =
+    (side === 'long') === isTP
+      ? new BigNumber(100).plus(adjustedPercent)
+      : new BigNumber(100).minus(adjustedPercent);
+  const rawPrice = referencePrice.multipliedBy(multiplier).dividedBy(100);
+  const snapped =
+    snapHlPriceToGrid(rawPrice, 'nearest', szDecimals) ?? rawPrice;
+  return formatPriceToSignificantDigits(snapped, szDecimals);
+}
 
 describe('TP/SL default seeds', () => {
   it('fills empty legs with ten-percent ROE and preserves existing values', () => {
@@ -45,6 +84,118 @@ describe('TP/SL default seeds', () => {
           leverage,
         }),
       ).toEqual({ tpTriggerPx, slTriggerPx });
+    },
+  );
+
+  it.each([
+    ['3.4567', 20, 1],
+    ['3.4567', 40, 1],
+    ['2456.7', 25, 4],
+    ['118342', 20, 5],
+  ] as const)(
+    'keeps the realized ROE within one tick of ten percent for entry %s at %sx',
+    (entryPrice, leverage, szDecimals) => {
+      const { tpTriggerPx, slTriggerPx } = resolveTpSlTriggerPx({
+        hasTpsl: true,
+        ...buildDefaultTpSlPercent(),
+        referencePrice: new BigNumber(entryPrice),
+        side: 'long',
+        leverage,
+        szDecimals,
+      });
+      const entry = new BigNumber(entryPrice);
+      const tickRoe = (getHlPriceTick(entry, szDecimals) ?? new BigNumber(0))
+        .dividedBy(entry)
+        .multipliedBy(leverage)
+        .multipliedBy(100);
+      const roeOf = (triggerPx: string) =>
+        new BigNumber(triggerPx)
+          .minus(entry)
+          .dividedBy(entry)
+          .multipliedBy(leverage)
+          .multipliedBy(100);
+
+      expect(
+        roeOf(tpTriggerPx ?? '0')
+          .minus(10)
+          .abs()
+          .lte(tickRoe),
+      ).toBe(true);
+      expect(
+        roeOf(slTriggerPx ?? '0')
+          .plus(10)
+          .abs()
+          .lte(tickRoe),
+      ).toBe(true);
+    },
+  );
+
+  it('rounds percent-derived triggers to the nearest valid price', () => {
+    // 3.4567 + 0.5% is 3.4739835: truncation would emit 3.4739 (9.95% ROE).
+    expect(
+      resolveTpSlTriggerPx({
+        hasTpsl: true,
+        ...buildDefaultTpSlPercent(),
+        referencePrice: new BigNumber('3.4567'),
+        side: 'long',
+        leverage: 20,
+        szDecimals: 1,
+      }),
+    ).toEqual({ tpTriggerPx: '3.474', slTriggerPx: '3.4394' });
+  });
+
+  it('leaves user-entered trigger prices untouched', () => {
+    expect(
+      resolveTpSlTriggerPx({
+        hasTpsl: true,
+        tpType: 'price',
+        tpValue: '3.4739',
+        slType: 'price',
+        slValue: '3.4394',
+        referencePrice: new BigNumber('3.4567'),
+        side: 'long',
+        leverage: 20,
+        szDecimals: 1,
+      }),
+    ).toEqual({ tpTriggerPx: '3.4739', slTriggerPx: '3.4394' });
+  });
+
+  it.each([
+    ['3.4567', 20, 1],
+    ['324.6', 20, 2],
+    ['118342', 20, 5],
+    ['2456.7', 25, 4],
+  ] as const)(
+    'keeps the seeded price equal to the manual percent path for entry %s',
+    (entry, leverage, szDecimals) => {
+      const seeded = resolveTpSlTriggerPx({
+        hasTpsl: true,
+        ...buildDefaultTpSlPercent(),
+        referencePrice: new BigNumber(entry),
+        side: 'long',
+        leverage,
+        szDecimals,
+      });
+      expect(seeded.tpTriggerPx).toBe(
+        manualPercentToPrice({
+          percent: DEFAULT_TPSL_ROE_PERCENT,
+          entry,
+          leverage,
+          side: 'long',
+          isTP: true,
+          szDecimals,
+        }),
+      );
+      expect(seeded.slTriggerPx).toBe(
+        manualPercentToPrice({
+          percent: DEFAULT_TPSL_ROE_PERCENT,
+          entry,
+          leverage,
+          side: 'long',
+          isTP: false,
+          szDecimals,
+        }),
+      );
     },
   );
 

--- a/packages/shared/src/utils/perpsUtils.test.ts
+++ b/packages/shared/src/utils/perpsUtils.test.ts
@@ -641,6 +641,18 @@ describe('HyperLiquid BBO price ticks', () => {
     expect(snapHlPriceToGrid('1.23456', 'up', 2)?.toFixed()).toBe('1.2346');
     expect(snapHlPriceToGrid('1.23456', 'down', 2)?.toFixed()).toBe('1.2345');
   });
+
+  test('snaps to the closest tick in nearest mode', () => {
+    expect(snapHlPriceToGrid('1.23456', 'nearest', 2)?.toFixed()).toBe(
+      '1.2346',
+    );
+    expect(snapHlPriceToGrid('1.23454', 'nearest', 2)?.toFixed()).toBe(
+      '1.2345',
+    );
+    expect(snapHlPriceToGrid('3.4739835', 'nearest', 1)?.toFixed()).toBe(
+      '3.474',
+    );
+  });
 });
 
 describe('formatPriceToSignificantDigits - HyperLiquid Price Formatting', () => {

--- a/packages/shared/src/utils/perpsUtils.ts
+++ b/packages/shared/src/utils/perpsUtils.ts
@@ -586,7 +586,7 @@ function getHlPriceTick(
 
 function snapHlPriceToGrid(
   price: BigNumber.Value,
-  direction: 'up' | 'down',
+  direction: 'up' | 'down' | 'nearest',
   szDecimals: number,
   type: 'perp' | 'spot' = 'perp',
 ): BigNumber | null {
@@ -596,8 +596,12 @@ function snapHlPriceToGrid(
     return null;
   }
 
-  const roundingMode =
-    direction === 'up' ? BigNumber.ROUND_CEIL : BigNumber.ROUND_FLOOR;
+  let roundingMode: BigNumber.RoundingMode = BigNumber.ROUND_HALF_UP;
+  if (direction === 'up') {
+    roundingMode = BigNumber.ROUND_CEIL;
+  } else if (direction === 'down') {
+    roundingMode = BigNumber.ROUND_FLOOR;
+  }
   const snappedPrice = priceBN
     .dividedBy(tick)
     .integerValue(roundingMode)


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58389](https://onekeyhq.atlassian.net/browse/OK-58389) [OK-58391](https://onekeyhq.atlassian.net/browse/OK-58391) [OK-58396](https://onekeyhq.atlassian.net/browse/OK-58396)

----------

<!-- github-pr-monitor:jira-links:end -->


Follow-ups to #12554.

## OK-58396 — TP/SL seeded at a strict 10% ROE

Percent-derived TP/SL triggers were truncated to five significant figures. Truncation always shifts the trigger toward zero, and leverage amplifies the remainder:

| Entry | Leverage | TP ROE | SL ROE |
| --- | --- | --- | --- |
| 3.4567 | 20x | 9.95% | -10.01% |
| 3.4567 | 40x | 9.95% | -10.07% |
| 0.0012345 | 25x | 9.11% | -11.14% |

Percent-derived triggers now snap to the *nearest* valid price instead (`snapHlPriceToGrid` gained a `nearest` mode). User-entered trigger prices are untouched, and spot paths do not pass `szDecimals`, so their behaviour is unchanged.

Separately, the position TP/SL dialog seeded a price and then reverse-computed the percent field, so a seeded 10% ROE displayed as `9.98`, while typing `10` manually kept `10`. Both paths compute the identical price; only the display differed. `TpslInput` now accepts an optional `seedPercent` and shows the seeded percent verbatim while the leg still sits on its seeded price, falling back to the reverse-computed value once the user moves the price. Only `SetTpslModal` passes it, so every other caller is unaffected.

Where the price grid cannot express 10% exactly, the nearest tick is used — e.g. AAPL at 324.6/20x wants 326.223, the grid allows 326.22 (9.98%) or 326.23 (10.04%), so 326.22 wins. The percent field still reads `10` because that is the requested intent, matching manual entry.

## OK-58391 — Explain unavailable Add Position amounts

The confirm button was disabled whenever the size failed validation, so a below-minimum or over-balance amount gave no reason at all, and the max-addable row beside it only restated the balance.

The button now stays pressable and toasts on press, matching the main trading panel: below-minimum and insufficient-margin are separate messages, and the minimum is expressed in the size unit currently selected (`$10`, `0.10 ETH`, or the margin equivalent). The max-addable row is gone.

## OK-58389 — Size slider in Add Position

Add Position only accepted a typed size. It now reuses the trading panel's slider (4 segments, tap-to-snap), mapping 0-100% onto the max tradable size; typing or focusing the size field returns to manual entry. On submit the slider size is re-resolved against the refreshed max, so a 100% drag cannot fall out of range while the dialog is open.

## Validation

- 42 suites / 396 tests pass across `views/Perp` and the shared perps utils, including new coverage for nearest-tick snapping, realized-ROE drift bounds, the minimum-amount label per size unit, and an invariant test asserting the seeded price equals the manual percent→price conversion (the `seedPercent` display depends on that equality, and would silently regress to `9.98` if the two ever diverged).
- `yarn agent:check --profile commit` passes; it was run per commit, and each commit is independently coherent.

## Not verified

Runtime behaviour of both dialogs was not exercised here — they require a connected Hyperliquid account with an open position, which this environment cannot drive. Correctness rests on the unit tests and type checks above. The author confirmed both dialogs behave correctly in manual testing.

Still worth a look on device:
- Slider tap-snap on iOS/Android, and the manual/slider hand-off.
- Toast copy for each size unit.
- Seeded TP/SL reading `10`, reverting to the real percent after a manual price edit, and chart-originated preset prices staying untouched.

[OK-58389]: https://onekeyhq.atlassian.net/browse/OK-58389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-58391]: https://onekeyhq.atlassian.net/browse/OK-58391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-58396]: https://onekeyhq.atlassian.net/browse/OK-58396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ