### PR TITLE
fix: support market charts without CoinGecko IDs OK-58421

### DIFF
--- a/packages/kit/src/views/AssetDetails/pages/MarketChart/index.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/MarketChart/index.tsx
@@ -1,0 +1,93 @@
+import { useCallback, useMemo } from 'react';
+
+import { type RouteProp, useRoute } from '@react-navigation/core';
+
+import {
+  Badge,
+  Page,
+  SizableText,
+  Stack,
+  XStack,
+  useMedia,
+} from '@onekeyhq/components';
+import { Token } from '@onekeyhq/kit/src/components/Token';
+import {
+  TradingViewNative,
+  getTradingViewNativeSource,
+} from '@onekeyhq/kit/src/components/TradingView/TradingViewNative';
+import { useAccountData } from '@onekeyhq/kit/src/hooks/useAccountData';
+import type {
+  EModalAssetDetailRoutes,
+  IModalAssetDetailsParamList,
+} from '@onekeyhq/shared/src/routes/assetDetails';
+
+import { MarketTestIDs } from '../../../Market/testIDs';
+
+export default function MarketChart() {
+  const route =
+    useRoute<
+      RouteProp<
+        IModalAssetDetailsParamList,
+        EModalAssetDetailRoutes.MarketChart
+      >
+    >();
+  const { networkId, networkName, symbol, tokenAddress, tokenImageUri } =
+    route.params;
+  const { gtMd } = useMedia();
+  const { network } = useAccountData({ networkId });
+  const resolvedNetworkName = networkName || network?.name || '';
+  const source = useMemo(
+    () =>
+      getTradingViewNativeSource({
+        hyperliquidCoin: '',
+        marketDataSource: undefined,
+        networkId,
+        symbol,
+        tokenAddress,
+      }),
+    [networkId, symbol, tokenAddress],
+  );
+  const renderHeaderTitle = useCallback(
+    () => (
+      <XStack alignItems="center" gap="$2">
+        <Token
+          size="sm"
+          tokenImageUri={tokenImageUri}
+          networkImageUri={!gtMd ? network?.logoURI : undefined}
+          networkId={networkId}
+        />
+        <SizableText size="$headingLg" numberOfLines={1}>
+          {symbol}
+        </SizableText>
+        {gtMd && resolvedNetworkName ? (
+          <Badge badgeSize="sm">
+            <Badge.Text>{resolvedNetworkName}</Badge.Text>
+          </Badge>
+        ) : null}
+      </XStack>
+    ),
+    [
+      gtMd,
+      network?.logoURI,
+      networkId,
+      resolvedNetworkName,
+      symbol,
+      tokenImageUri,
+    ],
+  );
+
+  return (
+    <Page>
+      <Page.Header headerTitle={renderHeaderTitle} />
+      <Page.Body>
+        <Stack flex={1} minHeight={0} overflow="hidden">
+          <TradingViewNative
+            testID={MarketTestIDs.detailChart}
+            source={source}
+            nativeControlsLayoutMode="mobile"
+          />
+        </Stack>
+      </Page.Body>
+    </Page>
+  );
+}

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsContext.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsContext.tsx
@@ -7,6 +7,8 @@ export interface ITokenDetailsContextValue {
     price?: number;
     priceChange24h?: number;
     coingeckoId?: string;
+    networkId?: string;
+    tokenAddress?: string;
     // Source currency of `price` — 'usd' for new data (post-normalize),
     // user's then-active display currency for pre-migration hydrate.
     currency?: string;

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsFooter.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsFooter.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
@@ -23,16 +23,81 @@ import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { AssetDetailsTestIDs } from '../../testIDs';
 
 import { useTokenDetailsContext } from './TokenDetailsContext';
+import {
+  buildTokenDetailsMarketNavigationTarget,
+  isTokenDetailsMarketMetadataForToken,
+} from './tokenDetailsMarketNavigation';
 
-function TokenDetailsFooter(props: { networkId: string }) {
-  const { networkId } = props;
+function TokenDetailsFooter(props: {
+  isNative?: boolean;
+  networkId: string;
+  networkName?: string;
+  symbol?: string;
+  tokenAddress?: string;
+  tokenImageUri?: string;
+}) {
+  const {
+    isNative,
+    networkId,
+    networkName,
+    symbol,
+    tokenAddress,
+    tokenImageUri,
+  } = props;
   const intl = useIntl();
   const { bottom } = useSafeAreaInsets();
   const { tokenMetadata } = useTokenDetailsContext();
   const navigation = useAppNavigation();
 
+  const marketNavigationTarget = useMemo(
+    () =>
+      buildTokenDetailsMarketNavigationTarget({
+        isNative,
+        networkId,
+        networkName,
+        symbol,
+        tokenAddress,
+        tokenImageUri,
+        tokenMetadata,
+      }),
+    [
+      isNative,
+      networkId,
+      networkName,
+      symbol,
+      tokenAddress,
+      tokenImageUri,
+      tokenMetadata,
+    ],
+  );
+  const matchedTokenMetadata = isTokenDetailsMarketMetadataForToken({
+    networkId,
+    tokenAddress,
+    tokenMetadata,
+  })
+    ? tokenMetadata
+    : undefined;
+
+  const handleMarketPress = useCallback(() => {
+    if (marketNavigationTarget?.type === 'detail') {
+      navigation.push(EModalAssetDetailRoutes.MarketDetail, {
+        token: marketNavigationTarget.token,
+      });
+    } else if (marketNavigationTarget?.type === 'chart') {
+      navigation.push(EModalAssetDetailRoutes.MarketChart, {
+        networkId: marketNavigationTarget.networkId,
+        networkName: marketNavigationTarget.networkName,
+        symbol: marketNavigationTarget.symbol,
+        tokenAddress: marketNavigationTarget.tokenAddress,
+        tokenImageUri: marketNavigationTarget.tokenImageUri,
+      });
+    }
+  }, [marketNavigationTarget, navigation]);
+
   const priceChangeColor = useMemo(() => {
-    const priceChangeBN = new BigNumber(tokenMetadata?.priceChange24h ?? 0);
+    const priceChangeBN = new BigNumber(
+      matchedTokenMetadata?.priceChange24h ?? 0,
+    );
     if (priceChangeBN.isGreaterThan(0)) {
       return '$textSuccess';
     }
@@ -40,15 +105,15 @@ function TokenDetailsFooter(props: { networkId: string }) {
       return '$textCritical';
     }
     return '$textSubdued';
-  }, [tokenMetadata?.priceChange24h]);
+  }, [matchedTokenMetadata?.priceChange24h]);
 
   if (networkUtils.isLightningNetworkByNetworkId(networkId)) {
     return null;
   }
 
   if (
-    new BigNumber(tokenMetadata?.priceChange24h ?? 0).isZero() &&
-    new BigNumber(tokenMetadata?.price ?? 0).isZero()
+    new BigNumber(matchedTokenMetadata?.priceChange24h ?? 0).isZero() &&
+    new BigNumber(matchedTokenMetadata?.price ?? 0).isZero()
   ) {
     return null;
   }
@@ -65,26 +130,20 @@ function TokenDetailsFooter(props: { networkId: string }) {
         borderTopWidth={StyleSheet.hairlineWidth}
         borderTopColor="$borderSubdued"
         userSelect="none"
-        onPress={() => {
-          if (tokenMetadata?.coingeckoId) {
-            navigation.push(EModalAssetDetailRoutes.MarketDetail, {
-              token: tokenMetadata.coingeckoId,
-            });
-          }
-        }}
-        {...(tokenMetadata?.coingeckoId ? listItemPressStyle : null)}
+        onPress={marketNavigationTarget ? handleMarketPress : undefined}
+        {...(marketNavigationTarget ? listItemPressStyle : null)}
       >
         <SizableText flex={1} size="$bodyMd">
           {intl.formatMessage({ id: ETranslations.global_market })}
         </SizableText>
-        {tokenMetadata ? (
+        {matchedTokenMetadata ? (
           <XStack alignItems="center" gap="$2">
             <Currency
               size="$bodyMd"
               formatter="price"
-              sourceCurrency={tokenMetadata?.currency}
+              sourceCurrency={matchedTokenMetadata.currency}
             >
-              {tokenMetadata?.price}
+              {matchedTokenMetadata.price}
             </Currency>
             <NumberSizeableText
               size="$bodyMd"
@@ -94,9 +153,9 @@ function TokenDetailsFooter(props: { networkId: string }) {
               }}
               color={priceChangeColor}
             >
-              {tokenMetadata?.priceChange24h}
+              {matchedTokenMetadata.priceChange24h}
             </NumberSizeableText>
-            {tokenMetadata.coingeckoId ? (
+            {marketNavigationTarget ? (
               <Icon name="ChevronRightSmallOutline" color="$iconSubdued" />
             ) : null}
           </XStack>

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/TokenDetailsHeader.tsx
@@ -330,15 +330,6 @@ function TokenDetailsHeaderContent({
 
         const data = tokensDetails?.[0];
 
-        // Chart price-line surface cannot render '--'; coerce to 0. Header
-        // price/balance render '--' via TokenDetailsBalanceHero below.
-        updateTokenMetadata({
-          price: data?.price ?? 0,
-          priceChange24h: data?.price24h ?? 0,
-          coingeckoId: data?.info?.coingeckoId ?? '',
-          currency: data?.currency,
-        });
-
         if (!data) {
           tokenDetailsCache.delete(tokenDetailsCacheKey);
           return undefined;
@@ -357,7 +348,6 @@ function TokenDetailsHeaderContent({
         accountId,
         networkId,
         tokenInfo.address,
-        updateTokenMetadata,
         updateTokenDetails,
         tokenDetailsCacheKey,
       ],
@@ -367,21 +357,25 @@ function TokenDetailsHeaderContent({
   const tokenDetails = tokenDetailsResult ?? cachedTokenDetails;
 
   useEffect(() => {
-    if (!cachedTokenDetails || tokenDetailsResult) {
+    if (!tokenDetails || (isTabView && !focusParam)) {
       return;
     }
 
-    // Cached-only path: same '--' coercion rationale as the fetch path above.
     updateTokenMetadata({
-      price: cachedTokenDetails.price ?? 0,
-      priceChange24h: cachedTokenDetails.price24h ?? 0,
+      price: tokenDetails.price ?? 0,
+      priceChange24h: tokenDetails.price24h ?? 0,
       coingeckoId:
-        cachedTokenDetails.info?.coingeckoId ?? tokenInfo.coingeckoId ?? '',
-      currency: cachedTokenDetails.currency,
+        tokenDetails.info?.coingeckoId ?? tokenInfo.coingeckoId ?? '',
+      networkId,
+      tokenAddress: tokenInfo.address,
+      currency: tokenDetails.currency,
     });
   }, [
-    cachedTokenDetails,
-    tokenDetailsResult,
+    focusParam,
+    isTabView,
+    networkId,
+    tokenDetails,
+    tokenInfo.address,
     tokenInfo.coingeckoId,
     updateTokenMetadata,
   ]);

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/index.tsx
@@ -608,31 +608,38 @@ function TokenDetailsView() {
     [uniqueTabNames],
   );
 
+  // The Overview descriptor has no token; fall back to the largest member
+  // for its market data (tokens are fiat-sorted, tokens[0] is the largest
+  // holding).
+  const activeFooterToken = useMemo(
+    () =>
+      (aggregateTabs
+        ? aggregateTabs[activeTabIndex]?.token
+        : tokens[activeTabIndex]) ?? tokens[0],
+    [activeTabIndex, aggregateTabs, tokens],
+  );
+  const activeFooterNetworkId = activeFooterToken?.networkId ?? networkId;
+
   // Updating the context from the hook result (not inside the promise body)
   // keeps usePromiseResult's stale-run protection: a slow response for a
   // previously active tab can no longer overwrite the current tab's market
   // data during fast tab switches.
   const { result: footerTokenMetadata } = usePromiseResult(async () => {
-    // The Overview descriptor has no token; fall back to the largest member
-    // for its market data (tokens are fiat-sorted, tokens[0] is the largest
-    // holding).
-    const activeToken =
-      (aggregateTabs
-        ? aggregateTabs[activeTabIndex]?.token
-        : tokens[activeTabIndex]) ?? tokens[0];
-    if (!activeToken) return undefined;
+    if (!activeFooterToken) return undefined;
 
     const resp = await backgroundApiProxy.serviceToken.fetchTokenInfoOnly({
-      networkId: activeToken.networkId ?? '',
-      tokenAddress: activeToken.address,
+      networkId: activeFooterNetworkId,
+      tokenAddress: activeFooterToken.address,
     });
     return {
       price: resp?.price ?? 0,
       priceChange24h: resp?.price24h ?? 0,
       coingeckoId: resp?.info?.coingeckoId ?? '',
+      networkId: activeFooterNetworkId,
+      tokenAddress: activeFooterToken.address,
       currency: resp?.currency,
     };
-  }, [activeTabIndex, tokens, aggregateTabs]);
+  }, [activeFooterNetworkId, activeFooterToken]);
 
   useEffect(() => {
     if (footerTokenMetadata) {
@@ -748,6 +755,8 @@ function TokenDetailsView() {
 
   const handleTabIndexChange = useCallback(
     async (index: number) => {
+      setActiveTabIndex(index);
+
       // The Overview descriptor has no token, so only member tabs can trigger
       // the auto-enable below.
       const activeToken = aggregateTabs?.[index]?.token;
@@ -773,8 +782,6 @@ function TokenDetailsView() {
         });
         void refreshAllNetworkState();
       }
-
-      setActiveTabIndex(index);
     },
     [
       isAllNetworks,
@@ -953,7 +960,14 @@ function TokenDetailsView() {
     <Page lazyLoad safeAreaEnabled={false}>
       <Page.Header headerRight={headerRight} headerTitle={headerTitle} />
       <Page.Body>{tokenDetailsViewElement}</Page.Body>
-      <TokenDetailsFooter networkId={networkId} />
+      <TokenDetailsFooter
+        isNative={activeFooterToken?.isNative}
+        networkId={activeFooterNetworkId}
+        networkName={activeFooterToken?.networkName}
+        symbol={activeFooterToken?.symbol}
+        tokenAddress={activeFooterToken?.address}
+        tokenImageUri={activeFooterToken?.logoURI}
+      />
     </Page>
   );
 }

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/tokenDetailsMarketNavigation.test.ts
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/tokenDetailsMarketNavigation.test.ts
@@ -1,0 +1,109 @@
+import { buildTokenDetailsMarketNavigationTarget } from './tokenDetailsMarketNavigation';
+
+describe('buildTokenDetailsMarketNavigationTarget', () => {
+  it('preserves the legacy route when a CoinGecko ID is available', () => {
+    expect(
+      buildTokenDetailsMarketNavigationTarget({
+        isNative: false,
+        networkId: 'evm--1',
+        symbol: 'TOKEN',
+        tokenAddress: '0x1234',
+        tokenMetadata: {
+          coingeckoId: 'legacy-token-id',
+          networkId: 'evm--1',
+          tokenAddress: '0x1234',
+        },
+      }),
+    ).toEqual({
+      type: 'detail',
+      token: 'legacy-token-id',
+    });
+  });
+
+  it('uses the chart route when only a network identity is available', () => {
+    expect(
+      buildTokenDetailsMarketNavigationTarget({
+        isNative: false,
+        networkId: 'evm--1',
+        networkName: 'Ethereum',
+        symbol: 'TOKEN',
+        tokenAddress: '0x1234',
+        tokenImageUri: 'https://example.com/token.png',
+      }),
+    ).toEqual({
+      type: 'chart',
+      networkId: 'evm--1',
+      networkName: 'Ethereum',
+      symbol: 'TOKEN',
+      tokenAddress: '0x1234',
+      tokenImageUri: 'https://example.com/token.png',
+    });
+  });
+
+  it('does not use a stale CoinGecko ID from another token', () => {
+    expect(
+      buildTokenDetailsMarketNavigationTarget({
+        isNative: false,
+        networkId: 'evm--1',
+        symbol: 'TOKEN-B',
+        tokenAddress: '0xBBBB',
+        tokenMetadata: {
+          coingeckoId: 'token-a',
+          networkId: 'evm--1',
+          tokenAddress: '0xAAAA',
+        },
+      }),
+    ).toEqual({
+      type: 'chart',
+      networkId: 'evm--1',
+      symbol: 'TOKEN-B',
+      tokenAddress: '0xBBBB',
+    });
+  });
+
+  it('supports native tokens without a contract address', () => {
+    expect(
+      buildTokenDetailsMarketNavigationTarget({
+        isNative: true,
+        networkId: 'custom--native',
+        symbol: 'NATIVE',
+        tokenAddress: '',
+      }),
+    ).toEqual({
+      type: 'chart',
+      networkId: 'custom--native',
+      symbol: 'NATIVE',
+      tokenAddress: '',
+    });
+  });
+
+  it('infers a native token from an empty address when isNative is absent', () => {
+    expect(
+      buildTokenDetailsMarketNavigationTarget({
+        networkId: 'custom--native',
+        symbol: 'NATIVE',
+        tokenAddress: '',
+      }),
+    ).toEqual({
+      type: 'chart',
+      networkId: 'custom--native',
+      symbol: 'NATIVE',
+      tokenAddress: '',
+    });
+  });
+
+  it('keeps the market footer disabled without a routable identity', () => {
+    expect(buildTokenDetailsMarketNavigationTarget({})).toBeUndefined();
+  });
+
+  it('rejects a non-native token without a contract address', () => {
+    expect(
+      buildTokenDetailsMarketNavigationTarget({
+        isNative: false,
+        networkId: 'evm--1',
+        symbol: 'TOKEN',
+        tokenAddress: '',
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/kit/src/views/AssetDetails/pages/TokenDetails/tokenDetailsMarketNavigation.ts
+++ b/packages/kit/src/views/AssetDetails/pages/TokenDetails/tokenDetailsMarketNavigation.ts
@@ -1,0 +1,81 @@
+export type ITokenDetailsMarketNavigationTarget =
+  | {
+      type: 'detail';
+      token: string;
+    }
+  | {
+      type: 'chart';
+      networkId: string;
+      networkName?: string;
+      symbol: string;
+      tokenAddress: string;
+      tokenImageUri?: string;
+    };
+
+type ITokenDetailsMarketMetadata = {
+  coingeckoId?: string;
+  networkId?: string;
+  tokenAddress?: string;
+};
+
+export function isTokenDetailsMarketMetadataForToken({
+  networkId,
+  tokenAddress,
+  tokenMetadata,
+}: {
+  networkId?: string;
+  tokenAddress?: string;
+  tokenMetadata?: ITokenDetailsMarketMetadata;
+}) {
+  return Boolean(
+    networkId &&
+    tokenMetadata?.networkId === networkId &&
+    tokenMetadata.tokenAddress === (tokenAddress ?? ''),
+  );
+}
+
+export function buildTokenDetailsMarketNavigationTarget({
+  isNative,
+  networkId,
+  networkName,
+  symbol,
+  tokenAddress,
+  tokenImageUri,
+  tokenMetadata,
+}: {
+  isNative?: boolean;
+  networkId?: string;
+  networkName?: string;
+  symbol?: string;
+  tokenAddress?: string;
+  tokenImageUri?: string;
+  tokenMetadata?: ITokenDetailsMarketMetadata;
+}): ITokenDetailsMarketNavigationTarget | undefined {
+  if (
+    tokenMetadata?.coingeckoId &&
+    isTokenDetailsMarketMetadataForToken({
+      networkId,
+      tokenAddress,
+      tokenMetadata,
+    })
+  ) {
+    return {
+      type: 'detail',
+      token: tokenMetadata.coingeckoId,
+    };
+  }
+
+  const resolvedIsNative = isNative ?? !tokenAddress;
+  if (networkId && symbol && (tokenAddress || resolvedIsNative)) {
+    return {
+      type: 'chart',
+      networkId,
+      networkName,
+      symbol,
+      tokenAddress: tokenAddress ?? '',
+      tokenImageUri,
+    };
+  }
+
+  return undefined;
+}

--- a/packages/kit/src/views/AssetDetails/router/index.ts
+++ b/packages/kit/src/views/AssetDetails/router/index.ts
@@ -11,6 +11,7 @@ const HistoryDetails = LazyLoadPage(
 const TokenDetails = LazyLoadPage(() => import('../pages/TokenDetails'));
 const UTXODetails = LazyLoadPage(() => import('../pages/UTXODetails'));
 const MarketDetail = LazyLoadPage(() => import('../../Market/MarketDetail'));
+const MarketChart = LazyLoadPage(() => import('../pages/MarketChart'));
 const DeFiProtocolDetails = LazyLoadPage(
   () => import('../pages/DeFiProtocolDetails'),
 );
@@ -38,6 +39,10 @@ export const ModalAssetDetailsStack: IModalFlowNavigatorConfig<
   {
     name: EModalAssetDetailRoutes.MarketDetail,
     component: MarketDetail,
+  },
+  {
+    name: EModalAssetDetailRoutes.MarketChart,
+    component: MarketChart,
   },
   {
     name: EModalAssetDetailRoutes.NFTDetails,

--- a/packages/shared/src/routes/assetDetails.ts
+++ b/packages/shared/src/routes/assetDetails.ts
@@ -19,6 +19,7 @@ export enum EModalAssetDetailRoutes {
   HistoryDetails = 'AssetDetail_HistoryDetails',
   UTXODetails = 'AssetDetail_UTXODetails',
   MarketDetail = 'AssetDetail_MarketDetail',
+  MarketChart = 'AssetDetail_MarketChart',
   KytRiskDetail = 'AssetDetail_KytRiskDetail',
 }
 
@@ -62,6 +63,13 @@ export type IModalAssetDetailsParamList = {
   };
   [EModalAssetDetailRoutes.MarketDetail]: {
     token: string;
+  };
+  [EModalAssetDetailRoutes.MarketChart]: {
+    networkId: string;
+    networkName?: string;
+    symbol: string;
+    tokenAddress: string;
+    tokenImageUri?: string;
   };
   [EModalAssetDetailRoutes.NFTDetails]: {
     networkId: string;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58421](https://onekeyhq.atlassian.net/browse/OK-58421)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- keep the legacy V1 market detail navigation when the active token has a matching CoinGecko ID
- add a dedicated K-line-only `MarketChart` route for tokens without a CoinGecko ID
- preserve the token image, symbol, and network name in the new page header
- bind footer metadata to `networkId + tokenAddress` and fix aggregate-tab async ordering so stale token data cannot navigate to the wrong page
- support native tokens with an empty address, including legacy records without an explicit `isNative` value

## Root cause

The Asset Details market footer used `coingeckoId` as both its clickability guard and the V1 route key. Tokens without that identifier were rendered as disabled even when K-line data could be queried by network and address. The shared footer metadata also had no token identity, so fast aggregate-tab switches could temporarily combine a previous token's CoinGecko ID with the newly active token.

## User impact

Tokens without a CoinGecko ID can now open a focused chart page instead of showing a disabled market row. Tokens with a matching CoinGecko ID continue to use the existing V1 detail page. This does not navigate to `MarketDetailV2`; the chart page reuses the existing TradingViewNative market K-line provider.

## Validation

- `npx jest packages/kit/src/views/AssetDetails/pages/TokenDetails/tokenDetailsMarketNavigation.test.ts packages/kit/src/components/TradingView/TradingViewNative/data/getTradingViewNativeSource.test.ts packages/kit/src/components/TradingView/TradingViewNative/data/providers/createTradingViewNativeDataProvider.test.ts --runInBand` (23 tests passed)
- `yarn agent:check --profile commit`
- two independent code-review agents reviewed the route flow and chart/header behavior; confirmed findings were fixed and revalidated

[OK-58421]: https://onekeyhq.atlassian.net/browse/OK-58421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ