### PR TITLE
feat: localize chart settings

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewChartControls/chartSettings/TradingViewChartSettings.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/chartSettings/TradingViewChartSettings.tsx
@@ -1,41 +1,715 @@
 import { useCallback, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 
-import { Icon, SizableText, Stack, XStack, YStack } from '@onekeyhq/components';
+import { useIntl } from 'react-intl';
+import { useWindowDimensions } from 'react-native';
 
 import {
-  AppearanceCandleSettingsContent,
-  AppearanceCoordinatesSettingsContent,
-  AppearanceEventsSettingsContent,
-  AppearanceLayoutSettingsContent,
-  AppearanceSidebar,
-  applyOkxChartTrendColors,
-} from './TradingViewChartAppearance';
-import { OkxChartColorSettingsPanel } from './TradingViewChartColorSettings';
+  Button,
+  Checkbox,
+  ColorPicker,
+  Divider,
+  Icon,
+  IconButton,
+  Page,
+  Popover,
+  ScrollView,
+  SizableText,
+  XStack,
+  YStack,
+  useMedia,
+} from '@onekeyhq/components';
+import { DesktopTabItem } from '@onekeyhq/components/src/layouts/Navigation/Tab/TabBar/DesktopTabItem';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
 import {
   createTradingViewChartSettingsValue,
   toggleTradingViewSettingsMockAppearanceItem,
   updateTradingViewSettingsMockAppearanceItemColor,
 } from './TradingViewSettingsMockState';
-import {
-  OKX_CHART_BG,
-  OKX_CHART_BORDER,
-  OKX_CHART_DIVIDER,
-  OKX_CHART_TEXT,
-  useSettingsDraftValue,
-} from './TradingViewSettingsShared';
+import { useSettingsDraftValue } from './TradingViewSettingsShared';
 
 import type {
   ITradingViewChartSettingsOptions,
+  ITradingViewChartSettingsPriceColorMode,
   ITradingViewChartSettingsValue,
+  ITradingViewSettingsMockAppearanceItem,
   ITradingViewSettingsMockAppearanceSectionId,
+  ITradingViewSettingsMockColorRole,
 } from './TradingViewSettingsMockState';
 
-const OKX_CHART_SETTINGS_WIDTH = 552;
-const OKX_CHART_SETTINGS_HEIGHT = 517;
-const OKX_CHART_HEADER_HEIGHT = 49;
-const OKX_CHART_BODY_HEIGHT = 400;
-const OKX_CHART_FOOTER_HEIGHT = 66;
-const OKX_CHART_SIDEBAR_WIDTH = 130;
+const CHART_COLOR_PALETTE = [
+  '#FFFFFF',
+  '#B2B5BF',
+  '#83858F',
+  '#555966',
+  '#2B2E38',
+  '#0F1013',
+  '#E5484D',
+  '#C33759',
+  '#D64073',
+  '#FF3CD9',
+  '#FBA43A',
+  '#FDEB5B',
+  '#D6FF00',
+  '#6AAF63',
+  '#219D46',
+  '#4E9F8A',
+  '#5CB8D1',
+  '#3D63DD',
+  '#6747C7',
+  '#953EA8',
+] as const;
+
+const NAVIGATION_TRANSLATION_IDS: Record<
+  ITradingViewSettingsMockAppearanceSectionId,
+  ETranslations
+> = {
+  candles: ETranslations.market_chart_settings__candles,
+  coordinates: ETranslations.market_chart_settings__scales,
+  events: ETranslations.market_chart_settings__events,
+  layout: ETranslations.market_chart_settings__canvas,
+};
+
+const OPTION_TRANSLATION_IDS: Record<
+  keyof ITradingViewChartSettingsOptions,
+  ETranslations
+> = {
+  countdown: ETranslations.market_chart_settings__countdown,
+  depth: ETranslations.market_chart_settings__depth,
+  priceChange: ETranslations.market_chart_settings__price_change,
+  latestPrice: ETranslations.market_chart_settings__latest_price,
+  futureEvents: ETranslations.market_chart_settings__show_upcoming_events,
+  pastEvents: ETranslations.market_chart_settings__show_past_events,
+  clickInteraction: ETranslations.market_chart_settings__chart_interaction,
+  crossLine: ETranslations.market_chart_settings__crosshair,
+};
+
+const SELECT_OPTION_TRANSLATION_IDS: Record<string, ETranslations> = {
+  solid: ETranslations.market_chart_settings__solid_line,
+  dashed: ETranslations.market_chart_settings__dotted_line,
+  gradient: ETranslations.market_chart_settings__gradient,
+  both: ETranslations.market_chart_settings__vertical_and_horizontal,
+  horizontal: ETranslations.market_chart_settings__horizontal,
+  vertical: ETranslations.market_chart_settings__vertical,
+  none: ETranslations.market_chart_settings__none,
+  greenUpRedDown: ETranslations.market_chart_settings__green_up_red_down,
+  redUpGreenDown: ETranslations.market_chart_settings__red_up_green_down,
+};
+
+const APPEARANCE_ITEM_TRANSLATION_IDS: Record<string, ETranslations> = {
+  body: ETranslations.market_chart_settings__body,
+  border: ETranslations.market_chart_settings__border,
+  wick: ETranslations.market_chart_settings__wick,
+};
+
+const TREND_COLOR_PRESETS = {
+  modern: {
+    positive: '#D6FF00',
+    negative: '#FF3CD9',
+  },
+  classic: {
+    positive: '#219D46',
+    negative: '#C33759',
+  },
+} as const;
+
+function applyChartTrendColors(
+  value: ITradingViewChartSettingsValue,
+  priceColorMode: ITradingViewChartSettingsPriceColorMode,
+): ITradingViewChartSettingsValue {
+  const preset = TREND_COLOR_PRESETS.classic;
+  const trendColors =
+    priceColorMode === 'greenUpRedDown'
+      ? {
+          upColor: preset.positive,
+          downColor: preset.negative,
+        }
+      : {
+          upColor: preset.negative,
+          downColor: preset.positive,
+        };
+
+  return {
+    ...value,
+    colorMode: 'classic',
+    priceColorMode,
+    appearanceSections: value.appearanceSections.map((section) =>
+      section.id === 'candles'
+        ? {
+            ...section,
+            items: section.items.map((item) => ({
+              ...item,
+              ...trendColors,
+            })),
+          }
+        : section,
+    ),
+    latestPriceLine: {
+      ...value.latestPriceLine,
+      ...trendColors,
+    },
+  };
+}
+
+function formatOptionLabel(
+  intl: ReturnType<typeof useIntl>,
+  value: string,
+  optionTranslationIds?: Partial<Record<string, ETranslations>>,
+) {
+  const translationId =
+    optionTranslationIds?.[value] ?? SELECT_OPTION_TRANSLATION_IDS[value];
+  if (translationId) {
+    return intl.formatMessage({ id: translationId });
+  }
+
+  return value;
+}
+
+function formatTestID(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-');
+}
+
+function SettingsGroup({
+  title,
+  children,
+  showDivider = true,
+}: {
+  title?: string;
+  children: ReactNode;
+  showDivider?: boolean;
+}) {
+  const { md } = useMedia();
+
+  return (
+    <YStack width="100%">
+      <YStack py="$5">
+        {title ? (
+          <XStack px="$5" pb="$3" width="100%">
+            <SizableText flex={1} size="$bodyMd" color="$textSubdued">
+              {title}
+            </SizableText>
+          </XStack>
+        ) : null}
+        <YStack gap={md ? '$1' : '$0'}>{children}</YStack>
+      </YStack>
+      {md && showDivider ? <Divider mx="$5" /> : null}
+    </YStack>
+  );
+}
+
+function SettingsRow({
+  label,
+  children,
+  onPress,
+  testID,
+}: {
+  label: string;
+  children: ReactNode;
+  onPress?: () => void;
+  testID?: string;
+}) {
+  const interactive = Boolean(onPress);
+
+  return (
+    <XStack
+      testID={testID}
+      minHeight={38}
+      mx="$2.5"
+      px="$2.5"
+      py="$1.5"
+      gap="$3"
+      alignItems="center"
+      justifyContent="space-between"
+      borderRadius="$3"
+      role={interactive ? 'button' : undefined}
+      cursor={interactive ? 'pointer' : undefined}
+      hoverStyle={interactive ? { bg: '$bgHover' } : undefined}
+      pressStyle={interactive ? { bg: '$bgActive' } : undefined}
+      onPress={onPress}
+    >
+      <SizableText size="$bodyMdMedium" flex={1}>
+        {label}
+      </SizableText>
+      {children}
+    </XStack>
+  );
+}
+
+function SettingsCheckboxRow({
+  label,
+  testID,
+  value,
+  disabled,
+  children,
+  onChange,
+}: {
+  label: string;
+  testID?: string;
+  value: boolean;
+  disabled: boolean;
+  children?: ReactNode;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <XStack
+      minHeight={38}
+      mx="$2.5"
+      px="$2.5"
+      py="$1.5"
+      gap="$3"
+      alignItems="center"
+      justifyContent="space-between"
+    >
+      <Checkbox
+        testID={`trading-view-settings-checkbox-${
+          testID ?? formatTestID(label)
+        }`}
+        label={label}
+        value={value}
+        disabled={disabled}
+        labelProps={{ variant: '$bodyMdMedium' }}
+        containerProps={{ alignItems: 'center' }}
+        labelContainerProps={{ py: '$0', my: '$0', justifyContent: 'center' }}
+        onChange={(checked) => onChange(Boolean(checked))}
+      />
+      {children}
+    </XStack>
+  );
+}
+
+function SettingsColorPicker({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: string;
+  disabled: boolean;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <ColorPicker
+      value={value}
+      colors={CHART_COLOR_PALETTE}
+      columns={5}
+      triggerSize={32}
+      disabled={disabled}
+      onChange={onChange}
+    />
+  );
+}
+
+function SettingsColorField({
+  label,
+  value,
+  disabled,
+  onChange,
+}: {
+  label?: string;
+  value: string;
+  disabled: boolean;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <XStack gap={label ? '$2' : '$0'} alignItems="center">
+      {label ? (
+        <SizableText size="$bodyMd" color="$textSubdued">
+          {label}
+        </SizableText>
+      ) : null}
+      <SettingsColorPicker
+        value={value}
+        disabled={disabled}
+        onChange={onChange}
+      />
+    </XStack>
+  );
+}
+
+function SettingsPriceColorPicker({
+  upColor,
+  downColor,
+  disabled,
+  onChange,
+}: {
+  upColor: string;
+  downColor: string;
+  disabled: boolean;
+  onChange: (color: string) => void;
+}) {
+  return (
+    <ColorPicker
+      value={upColor}
+      colors={CHART_COLOR_PALETTE}
+      columns={5}
+      triggerSize={32}
+      disabled={disabled}
+      renderTrigger={() => (
+        <YStack
+          width={32}
+          height={32}
+          p="$1"
+          borderWidth="$px"
+          borderColor="$borderSubdued"
+          borderRadius="$2"
+          bg="$bgStrong"
+        >
+          <YStack
+            flex={1}
+            borderRadius="$1"
+            style={{
+              background: `linear-gradient(45deg, ${downColor} 0 50%, ${upColor} 50% 100%)`,
+            }}
+          />
+        </YStack>
+      )}
+      onChange={onChange}
+    />
+  );
+}
+
+function SettingsLineStylePreview({ style }: { style: 'solid' | 'dashed' }) {
+  if (style === 'solid') {
+    return <XStack width="$8" height={2} bg="$iconSubdued" />;
+  }
+
+  return (
+    <XStack width="$8" gap="$0.5" alignItems="center">
+      {Array.from({ length: 5 }).map((_, index) => (
+        <XStack key={index} width="$1" height={2} bg="$iconSubdued" />
+      ))}
+    </XStack>
+  );
+}
+
+function SettingsColorPair({
+  item,
+  disabled,
+  onToggle,
+  onColorChange,
+}: {
+  item: ITradingViewSettingsMockAppearanceItem;
+  disabled: boolean;
+  onToggle: (itemId: string, enabled: boolean) => void;
+  onColorChange: (
+    itemId: string,
+    role: ITradingViewSettingsMockColorRole,
+    color: string,
+  ) => void;
+}) {
+  const intl = useIntl();
+  const label =
+    APPEARANCE_ITEM_TRANSLATION_IDS[item.id] !== undefined
+      ? intl.formatMessage({
+          id: APPEARANCE_ITEM_TRANSLATION_IDS[item.id],
+        })
+      : item.label;
+
+  return (
+    <SettingsCheckboxRow
+      label={label}
+      testID={item.id}
+      value={item.enabled}
+      disabled={disabled}
+      onChange={(enabled) => onToggle(item.id, enabled)}
+    >
+      <XStack
+        gap="$4"
+        alignItems="center"
+        opacity={item.enabled ? 1 : 0.5}
+        pointerEvents={item.enabled && !disabled ? 'auto' : 'none'}
+      >
+        <SettingsColorField
+          label={intl.formatMessage({
+            id: ETranslations.market_chart_settings__up,
+          })}
+          value={item.upColor}
+          disabled={disabled || !item.enabled}
+          onChange={(color) => onColorChange(item.id, 'up', color)}
+        />
+        <SettingsColorField
+          label={intl.formatMessage({
+            id: ETranslations.market_chart_settings__down,
+          })}
+          value={item.downColor}
+          disabled={disabled || !item.enabled}
+          onChange={(color) => onColorChange(item.id, 'down', color)}
+        />
+      </XStack>
+    </SettingsCheckboxRow>
+  );
+}
+
+function SettingsSelect<TValue extends string>({
+  testID,
+  title,
+  value,
+  options,
+  disabled,
+  onChange,
+  showLinePreview = false,
+  renderOption,
+  renderTriggerContent,
+  optionTranslationIds,
+}: {
+  testID: string;
+  title: string;
+  value: TValue;
+  options: readonly TValue[];
+  disabled: boolean;
+  onChange: (value: TValue) => void;
+  showLinePreview?: boolean;
+  renderOption?: (value: TValue) => ReactNode;
+  renderTriggerContent?: (value: TValue) => ReactNode;
+  optionTranslationIds?: Partial<Record<TValue, ETranslations>>;
+}) {
+  const intl = useIntl();
+  const [isOpen, setIsOpen] = useState(false);
+  const { md } = useMedia();
+
+  return (
+    <Popover
+      title={title}
+      showHeader={md}
+      open={disabled ? false : isOpen}
+      onOpenChange={(nextOpen) => {
+        if (!disabled) {
+          setIsOpen(nextOpen);
+        }
+      }}
+      placement="bottom-end"
+      floatingPanelProps={{ width: 240 }}
+      renderTrigger={
+        <XStack
+          testID={`trading-view-settings-select-${testID}`}
+          gap="$1.5"
+          alignItems="center"
+          cursor={disabled ? 'default' : 'pointer'}
+          opacity={disabled ? 0.5 : 1}
+        >
+          {renderTriggerContent
+            ? renderTriggerContent(value)
+            : (renderOption?.(value) ?? (
+                <>
+                  {showLinePreview ? (
+                    <SettingsLineStylePreview
+                      style={value as 'solid' | 'dashed'}
+                    />
+                  ) : null}
+                  <SizableText size="$bodyMd" color="$textSubdued">
+                    {formatOptionLabel(intl, value, optionTranslationIds)}
+                  </SizableText>
+                </>
+              ))}
+          <Icon
+            name={isOpen ? 'ChevronTopSmallOutline' : 'ChevronDownSmallOutline'}
+            size="$4.5"
+            color="$iconSubdued"
+          />
+        </XStack>
+      }
+      renderContent={({ closePopover }) => (
+        <YStack p={md ? '$3' : '$1'} gap={md ? '$1' : '$0.5'}>
+          {options.map((option) => {
+            const selected = value === option;
+            return (
+              <XStack
+                key={option}
+                testID={`trading-view-settings-select-${testID}-${option}`}
+                minHeight={md ? 48 : 36}
+                px={md ? '$2.5' : '$2'}
+                py={md ? '$2.5' : '$1.5'}
+                alignItems="center"
+                justifyContent="space-between"
+                borderRadius="$2"
+                cursor="pointer"
+                hoverStyle={{ bg: '$bgHover' }}
+                pressStyle={{ bg: '$bgActive' }}
+                onPress={() => {
+                  onChange(option);
+                  closePopover();
+                }}
+              >
+                {renderOption ? (
+                  renderOption(option)
+                ) : (
+                  <XStack gap="$2" alignItems="center">
+                    {showLinePreview ? (
+                      <SettingsLineStylePreview
+                        style={option as 'solid' | 'dashed'}
+                      />
+                    ) : null}
+                    <SizableText size="$bodyMd">
+                      {formatOptionLabel(intl, option, optionTranslationIds)}
+                    </SizableText>
+                  </XStack>
+                )}
+                {selected ? (
+                  <Icon
+                    name="CheckLargeOutline"
+                    size="$4"
+                    color="$iconActive"
+                  />
+                ) : null}
+              </XStack>
+            );
+          })}
+        </YStack>
+      )}
+    />
+  );
+}
+
+function ChartSettingsNavigation({
+  sections,
+  selectedSectionId,
+  disabled,
+  compact,
+  onSelect,
+}: {
+  sections: ITradingViewChartSettingsValue['appearanceSections'];
+  selectedSectionId: ITradingViewSettingsMockAppearanceSectionId;
+  disabled: boolean;
+  compact: boolean;
+  onSelect: (sectionId: ITradingViewSettingsMockAppearanceSectionId) => void;
+}) {
+  const intl = useIntl();
+
+  if (compact) {
+    return (
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        flexGrow={0}
+        borderBottomWidth="$px"
+        borderBottomColor="$borderSubdued"
+        contentContainerStyle={{
+          px: '$4',
+          py: '$2',
+          gap: '$1',
+        }}
+      >
+        {sections.map((section) => {
+          const selected = section.id === selectedSectionId;
+          return (
+            <Button
+              key={section.id}
+              testID={`trading-view-settings-section-${section.id}`}
+              size="medium"
+              icon={section.icon}
+              variant={selected ? 'secondary' : 'tertiary'}
+              disabled={disabled}
+              onPress={() => onSelect(section.id)}
+            >
+              {intl.formatMessage({
+                id: NAVIGATION_TRANSLATION_IDS[section.id],
+              })}
+            </Button>
+          );
+        })}
+      </ScrollView>
+    );
+  }
+
+  return (
+    <>
+      {sections.map((section) => (
+        <DesktopTabItem
+          key={section.id}
+          testID={`trading-view-settings-section-${section.id}`}
+          icon={section.icon}
+          label={intl.formatMessage({
+            id: NAVIGATION_TRANSLATION_IDS[section.id],
+          })}
+          selected={section.id === selectedSectionId}
+          size="medium"
+          showTooltip={false}
+          pointerEvents={disabled ? 'none' : 'auto'}
+          opacity={disabled ? 0.5 : 1}
+          onPress={() => onSelect(section.id)}
+        />
+      ))}
+    </>
+  );
+}
+
+function PriceMovementColorSelector({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: ITradingViewChartSettingsValue;
+  disabled: boolean;
+  onChange: (priceColorMode: ITradingViewChartSettingsPriceColorMode) => void;
+}) {
+  const intl = useIntl();
+  const renderOption = (
+    priceColorMode: ITradingViewChartSettingsPriceColorMode,
+  ) => {
+    const greenUp = priceColorMode === 'greenUpRedDown';
+    return (
+      <XStack gap="$2" alignItems="center">
+        <XStack gap="$0.5" alignItems="center">
+          <Icon
+            name="ArrowTopOutline"
+            size="$4.5"
+            color={greenUp ? '$iconSuccess' : '$iconCritical'}
+          />
+          <Icon
+            name="ArrowBottomOutline"
+            size="$4.5"
+            color={greenUp ? '$iconCritical' : '$iconSuccess'}
+          />
+        </XStack>
+        <SizableText size="$bodyMd">
+          {intl.formatMessage({
+            id: greenUp
+              ? ETranslations.market_chart_settings__green_up_red_down
+              : ETranslations.market_chart_settings__red_up_green_down,
+          })}
+        </SizableText>
+      </XStack>
+    );
+  };
+
+  const renderTriggerContent = (
+    priceColorMode: ITradingViewChartSettingsPriceColorMode,
+  ) => {
+    const greenUp = priceColorMode === 'greenUpRedDown';
+    return (
+      <XStack mr="$2" gap="$0.5" alignItems="center">
+        <Icon
+          name="ArrowTopOutline"
+          size="$4.5"
+          color={greenUp ? '$iconSuccess' : '$iconCritical'}
+        />
+        <Icon
+          name="ArrowBottomOutline"
+          size="$4.5"
+          color={greenUp ? '$iconCritical' : '$iconSuccess'}
+        />
+      </XStack>
+    );
+  };
+
+  return (
+    <SettingsSelect
+      testID="price-change-colors"
+      title={intl.formatMessage({
+        id: ETranslations.market_chart_settings__price_change_colors,
+      })}
+      value={value.priceColorMode}
+      options={['greenUpRedDown', 'redUpGreenDown']}
+      disabled={disabled}
+      renderOption={renderOption}
+      renderTriggerContent={renderTriggerContent}
+      onChange={onChange}
+    />
+  );
+}
 
 export type ITradingViewChartSettingsProps = {
   /** Use value for controlled committed state, or defaultValue for local state. */
@@ -50,6 +724,10 @@ export type ITradingViewChartSettingsProps = {
   onConfirmError?: (error: unknown) => void;
   onCancel?: () => void;
   onClose?: () => void;
+  /** Render the actions through the surrounding OneKey modal page. */
+  usePageFooter?: boolean;
+  /** Render the mobile settings as a single vertically scrolling list. */
+  mobileLayout?: boolean;
 };
 
 export function TradingViewChartSettings({
@@ -61,7 +739,13 @@ export function TradingViewChartSettings({
   onConfirmError,
   onCancel,
   onClose,
+  usePageFooter = false,
+  mobileLayout = false,
 }: ITradingViewChartSettingsProps) {
+  const intl = useIntl();
+  const { md } = useMedia();
+  const { height: windowHeight } = useWindowDimensions();
+  const dialogHeight = Math.min(600, Math.max(windowHeight - 32, 420));
   const [
     settingsValue,
     updateSettingsValue,
@@ -75,9 +759,6 @@ export function TradingViewChartSettings({
   });
   const [selectedAppearanceSectionId, setSelectedAppearanceSectionId] =
     useState<ITradingViewSettingsMockAppearanceSectionId>('candles');
-  const [contentResetVersion, setContentResetVersion] = useState(0);
-  const [isColorSettingsPanelOpen, setIsColorSettingsPanelOpen] =
-    useState(false);
   const [isConfirming, setIsConfirming] = useState(false);
   const submitInProgress = isSubmitting || isConfirming;
 
@@ -91,8 +772,6 @@ export function TradingViewChartSettings({
 
   const handleReset = useCallback(() => {
     updateSettingsValue(() => createTradingViewChartSettingsValue());
-    setContentResetVersion((currentVersion) => currentVersion + 1);
-    setIsColorSettingsPanelOpen(false);
   }, [updateSettingsValue]);
 
   const handleOptionChange = useCallback(
@@ -108,149 +787,36 @@ export function TradingViewChartSettings({
     [updateSettingsValue],
   );
 
-  const renderAppearanceContent = () => {
-    if (selectedAppearanceSectionId === 'candles') {
-      return (
-        <AppearanceCandleSettingsContent
-          key={contentResetVersion}
-          items={selectedAppearanceSection?.items ?? []}
-          colorMode={settingsValue.colorMode}
-          priceColorMode={settingsValue.priceColorMode}
-          onOpenColorSettings={() => setIsColorSettingsPanelOpen(true)}
-          onToggleItem={(itemId, enabled) => {
-            updateSettingsValue((currentValue) =>
-              toggleTradingViewSettingsMockAppearanceItem(
-                currentValue,
-                itemId,
-                enabled,
-              ),
-            );
-          }}
-          onColorChange={(itemId, role, color) => {
-            updateSettingsValue((currentValue) =>
-              updateTradingViewSettingsMockAppearanceItemColor(
-                currentValue,
-                itemId,
-                role,
-                color,
-              ),
-            );
-          }}
-        />
+  const handleToggleAppearanceItem = useCallback(
+    (itemId: string, enabled: boolean) => {
+      updateSettingsValue((currentValue) =>
+        toggleTradingViewSettingsMockAppearanceItem(
+          currentValue,
+          itemId,
+          enabled,
+        ),
       );
-    }
+    },
+    [updateSettingsValue],
+  );
 
-    if (selectedAppearanceSectionId === 'coordinates') {
-      return (
-        <AppearanceCoordinatesSettingsContent
-          key={contentResetVersion}
-          optionState={settingsValue.options}
-          latestPriceLine={settingsValue.latestPriceLine}
-          onOptionChange={handleOptionChange}
-          onLatestPriceColorChange={(upColor, downColor) => {
-            updateSettingsValue((currentValue) => ({
-              ...currentValue,
-              latestPriceLine: {
-                ...currentValue.latestPriceLine,
-                upColor,
-                downColor,
-              },
-            }));
-          }}
-          onLatestPriceLineStyleChange={(style) => {
-            updateSettingsValue((currentValue) => ({
-              ...currentValue,
-              latestPriceLine: {
-                ...currentValue.latestPriceLine,
-                style,
-              },
-            }));
-          }}
-        />
+  const handleAppearanceItemColorChange = useCallback(
+    (
+      itemId: string,
+      role: ITradingViewSettingsMockColorRole,
+      color: string,
+    ) => {
+      updateSettingsValue((currentValue) =>
+        updateTradingViewSettingsMockAppearanceItemColor(
+          currentValue,
+          itemId,
+          role,
+          color,
+        ),
       );
-    }
-
-    if (selectedAppearanceSectionId === 'events') {
-      return (
-        <AppearanceEventsSettingsContent
-          key={contentResetVersion}
-          optionState={settingsValue.options}
-          onOptionChange={handleOptionChange}
-        />
-      );
-    }
-
-    return (
-      <AppearanceLayoutSettingsContent
-        key={contentResetVersion}
-        optionState={settingsValue.options}
-        background={settingsValue.background}
-        grid={settingsValue.grid}
-        crossLine={settingsValue.crossLine}
-        onOptionChange={handleOptionChange}
-        onBackgroundStyleChange={(style) => {
-          updateSettingsValue((currentValue) => ({
-            ...currentValue,
-            background: {
-              ...currentValue.background,
-              style,
-            },
-          }));
-        }}
-        onBackgroundColorChange={(index, color) => {
-          updateSettingsValue((currentValue) => {
-            const colors: [string, string] = [
-              ...currentValue.background.colors,
-            ];
-            colors[index] = color;
-            return {
-              ...currentValue,
-              background: {
-                ...currentValue.background,
-                colors,
-              },
-            };
-          });
-        }}
-        onGridStyleChange={(style) => {
-          updateSettingsValue((currentValue) => ({
-            ...currentValue,
-            grid: {
-              ...currentValue.grid,
-              style,
-            },
-          }));
-        }}
-        onGridColorChange={(role, color) => {
-          updateSettingsValue((currentValue) => ({
-            ...currentValue,
-            grid: {
-              ...currentValue.grid,
-              [role]: color,
-            },
-          }));
-        }}
-        onCrossLineColorChange={(color) => {
-          updateSettingsValue((currentValue) => ({
-            ...currentValue,
-            crossLine: {
-              ...currentValue.crossLine,
-              color,
-            },
-          }));
-        }}
-        onCrossLineStyleChange={(style) => {
-          updateSettingsValue((currentValue) => ({
-            ...currentValue,
-            crossLine: {
-              ...currentValue.crossLine,
-              style,
-            },
-          }));
-        }}
-      />
-    );
-  };
+    },
+    [updateSettingsValue],
+  );
 
   const handleCancel = () => {
     cancelSettingsValue();
@@ -264,201 +830,563 @@ export function TradingViewChartSettings({
 
   const handleConfirm = async () => {
     if (submitInProgress) {
-      return;
+      return false;
     }
 
     setIsConfirming(true);
     try {
       await onConfirm?.(settingsValue);
       commitSettingsValue();
+      return true;
     } catch (error) {
       onConfirmError?.(error);
+      return false;
     } finally {
       setIsConfirming(false);
     }
   };
 
-  return (
-    <YStack
-      testID="trading-view-chart-settings-okx-dialog"
-      w={OKX_CHART_SETTINGS_WIDTH}
-      h={OKX_CHART_SETTINGS_HEIGHT}
-      position="relative"
-      overflow="visible"
-      borderWidth={1}
-      borderColor={OKX_CHART_BORDER}
-      borderRadius={0}
-      bg={OKX_CHART_BG}
-    >
-      <XStack
-        h={OKX_CHART_HEADER_HEIGHT}
-        px={24}
-        alignItems="center"
-        justifyContent="space-between"
-        borderBottomWidth={1}
-        borderBottomColor={OKX_CHART_BORDER}
+  const renderCandleSettings = () => (
+    <YStack>
+      <SettingsGroup
+        title={intl.formatMessage({
+          id: ETranslations.market_chart_settings__color_preferences,
+        })}
       >
-        <SizableText
-          fontSize={16}
-          lineHeight={22}
-          fontWeight="700"
-          color={OKX_CHART_TEXT}
+        <SettingsRow
+          label={intl.formatMessage({
+            id: ETranslations.market_chart_settings__price_change_colors,
+          })}
         >
-          图表设置
-        </SizableText>
-        <Stack
-          w={28}
-          h={28}
-          alignItems="center"
-          justifyContent="center"
-          cursor={submitInProgress ? 'default' : 'pointer'}
-          pointerEvents={submitInProgress ? 'none' : 'auto'}
-          onPress={handleClose}
-        >
-          <Icon name="CrossedSmallOutline" size="$5" color="$icon" />
-        </Stack>
-      </XStack>
-
-      <XStack
-        h={OKX_CHART_BODY_HEIGHT}
-        minHeight={0}
-        pointerEvents={submitInProgress ? 'none' : 'auto'}
-      >
-        <Stack
-          w={OKX_CHART_SIDEBAR_WIDTH}
-          position="relative"
-          bg={OKX_CHART_BG}
-        >
-          <AppearanceSidebar
-            sections={settingsValue.appearanceSections}
-            selectedSectionId={selectedAppearanceSectionId}
-            onSelect={(sectionId) => {
-              setIsColorSettingsPanelOpen(false);
-              setSelectedAppearanceSectionId(sectionId);
+          <PriceMovementColorSelector
+            value={settingsValue}
+            disabled={submitInProgress}
+            onChange={(priceColorMode) => {
+              updateSettingsValue((currentValue) =>
+                applyChartTrendColors(currentValue, priceColorMode),
+              );
             }}
           />
-          <Stack
-            position="absolute"
-            top={0}
-            right={0}
-            bottom={0}
-            w={1}
-            zIndex={2}
-            bg={OKX_CHART_DIVIDER}
-            pointerEvents="none"
+        </SettingsRow>
+      </SettingsGroup>
+
+      <SettingsGroup
+        title={intl.formatMessage({
+          id: ETranslations.market_chart_settings__candles,
+        })}
+      >
+        {(selectedAppearanceSection?.items ?? []).map((item) => (
+          <SettingsColorPair
+            key={item.id}
+            item={item}
+            disabled={submitInProgress}
+            onToggle={handleToggleAppearanceItem}
+            onColorChange={handleAppearanceItemColorChange}
           />
-        </Stack>
+        ))}
+      </SettingsGroup>
+    </YStack>
+  );
 
-        <Stack flex={1} bg={OKX_CHART_BG}>
-          {renderAppearanceContent()}
-        </Stack>
-      </XStack>
+  const renderCoordinateSettings = () => (
+    <YStack>
+      <SettingsGroup
+        title={intl.formatMessage({
+          id: ETranslations.market_chart_settings__price_scales,
+        })}
+      >
+        {(['countdown', 'depth', 'priceChange'] as const).map((option) => (
+          <SettingsCheckboxRow
+            key={option}
+            label={intl.formatMessage({
+              id: OPTION_TRANSLATION_IDS[option],
+            })}
+            testID={option}
+            value={settingsValue.options[option]}
+            disabled={submitInProgress}
+            onChange={(checked) => handleOptionChange(option, checked)}
+          />
+        ))}
+      </SettingsGroup>
 
-      {isColorSettingsPanelOpen ? (
-        <OkxChartColorSettingsPanel
-          colorMode={settingsValue.colorMode}
-          priceColorMode={settingsValue.priceColorMode}
-          onColorModeChange={(colorMode) => {
-            updateSettingsValue((currentValue) =>
-              applyOkxChartTrendColors(
-                currentValue,
-                colorMode,
-                currentValue.priceColorMode,
-              ),
-            );
-          }}
-          onPriceColorModeChange={(priceColorMode) => {
-            updateSettingsValue((currentValue) =>
-              applyOkxChartTrendColors(
-                currentValue,
-                currentValue.colorMode,
-                priceColorMode,
-              ),
-            );
-          }}
-          onClose={() => setIsColorSettingsPanelOpen(false)}
-          isDisabled={submitInProgress}
+      <SettingsGroup
+        title={intl.formatMessage({
+          id: ETranslations.market_chart_settings__price_label_and_line,
+        })}
+      >
+        <SettingsCheckboxRow
+          label={intl.formatMessage({
+            id: OPTION_TRANSLATION_IDS.latestPrice,
+          })}
+          testID="latest-price"
+          value={settingsValue.options.latestPrice}
+          disabled={submitInProgress}
+          onChange={(checked) => handleOptionChange('latestPrice', checked)}
+        >
+          <XStack
+            gap="$3"
+            alignItems="center"
+            opacity={settingsValue.options.latestPrice ? 1 : 0.5}
+          >
+            <SettingsSelect
+              testID="latest-price-line-style"
+              title={intl.formatMessage({
+                id: ETranslations.market_chart_settings__line_style,
+              })}
+              value={settingsValue.latestPriceLine.style}
+              options={['solid', 'dashed']}
+              disabled={submitInProgress || !settingsValue.options.latestPrice}
+              showLinePreview
+              onChange={(style) => {
+                updateSettingsValue((currentValue) => ({
+                  ...currentValue,
+                  latestPriceLine: {
+                    ...currentValue.latestPriceLine,
+                    style,
+                  },
+                }));
+              }}
+            />
+            <SettingsPriceColorPicker
+              upColor={settingsValue.latestPriceLine.upColor}
+              downColor={settingsValue.latestPriceLine.downColor}
+              disabled={submitInProgress || !settingsValue.options.latestPrice}
+              onChange={(color) => {
+                updateSettingsValue((currentValue) => ({
+                  ...currentValue,
+                  latestPriceLine: {
+                    ...currentValue.latestPriceLine,
+                    upColor: color,
+                    downColor: color,
+                  },
+                }));
+              }}
+            />
+          </XStack>
+        </SettingsCheckboxRow>
+      </SettingsGroup>
+    </YStack>
+  );
+
+  const renderEventSettings = () => (
+    <YStack>
+      <SettingsGroup
+        title={intl.formatMessage({
+          id: ETranslations.market_chart_settings__economic_calendar,
+        })}
+      >
+        {(['futureEvents', 'pastEvents'] as const).map((option) => (
+          <SettingsCheckboxRow
+            key={option}
+            label={intl.formatMessage({
+              id: OPTION_TRANSLATION_IDS[option],
+            })}
+            testID={option}
+            value={settingsValue.options[option]}
+            disabled={submitInProgress}
+            onChange={(checked) => handleOptionChange(option, checked)}
+          />
+        ))}
+      </SettingsGroup>
+    </YStack>
+  );
+
+  const renderLayoutSettings = () => (
+    <YStack>
+      <SettingsGroup
+        title={intl.formatMessage({
+          id: ETranslations.market_chart_settings__chart_interface,
+        })}
+      >
+        <SettingsCheckboxRow
+          label={intl.formatMessage({
+            id: OPTION_TRANSLATION_IDS.clickInteraction,
+          })}
+          testID="click-interaction"
+          value={settingsValue.options.clickInteraction}
+          disabled={submitInProgress}
+          onChange={(checked) =>
+            handleOptionChange('clickInteraction', checked)
+          }
         />
-      ) : null}
+      </SettingsGroup>
 
+      <SettingsGroup
+        title={intl.formatMessage({
+          id: ETranslations.market_chart_style,
+        })}
+        showDivider={false}
+      >
+        <SettingsRow
+          label={intl.formatMessage({
+            id: ETranslations.market_chart_settings__background,
+          })}
+        >
+          <XStack gap="$3" alignItems="center">
+            <SettingsSelect
+              testID="background-style"
+              title={intl.formatMessage({
+                id: ETranslations.market_chart_settings__background_style,
+              })}
+              value={settingsValue.background.style}
+              options={['solid', 'gradient']}
+              disabled={submitInProgress}
+              optionTranslationIds={{
+                solid: ETranslations.market_chart_settings__solid_color,
+                gradient: ETranslations.market_chart_settings__gradient,
+              }}
+              onChange={(style) => {
+                updateSettingsValue((currentValue) => ({
+                  ...currentValue,
+                  background: {
+                    ...currentValue.background,
+                    style,
+                  },
+                }));
+              }}
+            />
+            <SettingsColorField
+              label=""
+              value={settingsValue.background.colors[0]}
+              disabled={submitInProgress}
+              onChange={(color) => {
+                updateSettingsValue((currentValue) => ({
+                  ...currentValue,
+                  background: {
+                    ...currentValue.background,
+                    colors: [color, currentValue.background.colors[1]],
+                  },
+                }));
+              }}
+            />
+            {settingsValue.background.style === 'gradient' ? (
+              <SettingsColorField
+                label=""
+                value={settingsValue.background.colors[1]}
+                disabled={submitInProgress}
+                onChange={(color) => {
+                  updateSettingsValue((currentValue) => ({
+                    ...currentValue,
+                    background: {
+                      ...currentValue.background,
+                      colors: [currentValue.background.colors[0], color],
+                    },
+                  }));
+                }}
+              />
+            ) : null}
+          </XStack>
+        </SettingsRow>
+
+        <SettingsRow
+          label={intl.formatMessage({
+            id: ETranslations.market_chart_settings__grid_lines,
+          })}
+        >
+          <XStack gap="$3" alignItems="center">
+            <SettingsSelect
+              testID="grid-lines"
+              title={intl.formatMessage({
+                id: ETranslations.market_chart_settings__grid_lines,
+              })}
+              value={settingsValue.grid.style}
+              options={['both', 'horizontal', 'vertical', 'none']}
+              disabled={submitInProgress}
+              onChange={(style) => {
+                updateSettingsValue((currentValue) => ({
+                  ...currentValue,
+                  grid: {
+                    ...currentValue.grid,
+                    style,
+                  },
+                }));
+              }}
+            />
+            {['both', 'horizontal'].includes(settingsValue.grid.style) ? (
+              <SettingsColorField
+                label=""
+                value={settingsValue.grid.horizontalColor}
+                disabled={submitInProgress}
+                onChange={(horizontalColor) => {
+                  updateSettingsValue((currentValue) => ({
+                    ...currentValue,
+                    grid: {
+                      ...currentValue.grid,
+                      horizontalColor,
+                    },
+                  }));
+                }}
+              />
+            ) : null}
+            {['both', 'vertical'].includes(settingsValue.grid.style) ? (
+              <SettingsColorField
+                label=""
+                value={settingsValue.grid.verticalColor}
+                disabled={submitInProgress}
+                onChange={(verticalColor) => {
+                  updateSettingsValue((currentValue) => ({
+                    ...currentValue,
+                    grid: {
+                      ...currentValue.grid,
+                      verticalColor,
+                    },
+                  }));
+                }}
+              />
+            ) : null}
+          </XStack>
+        </SettingsRow>
+
+        <SettingsCheckboxRow
+          label={intl.formatMessage({
+            id: OPTION_TRANSLATION_IDS.crossLine,
+          })}
+          testID="crosshair"
+          value={settingsValue.options.crossLine}
+          disabled={submitInProgress}
+          onChange={(checked) => handleOptionChange('crossLine', checked)}
+        >
+          <XStack
+            gap="$3"
+            alignItems="center"
+            opacity={settingsValue.options.crossLine ? 1 : 0.5}
+          >
+            <SettingsSelect
+              testID="crosshair-line-style"
+              title={intl.formatMessage({
+                id: ETranslations.market_chart_settings__crosshair_line_style,
+              })}
+              value={settingsValue.crossLine.style}
+              options={['solid', 'dashed']}
+              disabled={submitInProgress || !settingsValue.options.crossLine}
+              showLinePreview
+              onChange={(style) => {
+                updateSettingsValue((currentValue) => ({
+                  ...currentValue,
+                  crossLine: {
+                    ...currentValue.crossLine,
+                    style,
+                  },
+                }));
+              }}
+            />
+            <SettingsColorPicker
+              value={settingsValue.crossLine.color}
+              disabled={submitInProgress || !settingsValue.options.crossLine}
+              onChange={(color) => {
+                updateSettingsValue((currentValue) => ({
+                  ...currentValue,
+                  crossLine: {
+                    ...currentValue.crossLine,
+                    color,
+                  },
+                }));
+              }}
+            />
+          </XStack>
+        </SettingsCheckboxRow>
+      </SettingsGroup>
+    </YStack>
+  );
+
+  const renderSettingsContent = () => {
+    if (selectedAppearanceSectionId === 'candles') {
+      return renderCandleSettings();
+    }
+    if (selectedAppearanceSectionId === 'coordinates') {
+      return renderCoordinateSettings();
+    }
+    if (selectedAppearanceSectionId === 'events') {
+      return renderEventSettings();
+    }
+    return renderLayoutSettings();
+  };
+
+  const handleSectionSelect = (
+    sectionId: ITradingViewSettingsMockAppearanceSectionId,
+  ) => {
+    setSelectedAppearanceSectionId(sectionId);
+  };
+
+  const resetButton = (
+    <Button
+      testID="trading-view-settings-mock-reset"
+      size="medium"
+      icon="RotateCounterclockwiseOutline"
+      variant="tertiary"
+      disabled={submitInProgress}
+      onPress={handleReset}
+    >
+      {intl.formatMessage({ id: ETranslations.global_reset })}
+    </Button>
+  );
+
+  const settingsBody = (
+    <XStack flex={1} minHeight={0} flexDirection={md ? 'column' : 'row'}>
+      {md ? (
+        <ChartSettingsNavigation
+          sections={settingsValue.appearanceSections}
+          selectedSectionId={selectedAppearanceSectionId}
+          disabled={submitInProgress}
+          compact
+          onSelect={handleSectionSelect}
+        />
+      ) : (
+        <YStack
+          width={192}
+          flexShrink={0}
+          px="$3"
+          py="$4"
+          gap="$1"
+          borderRightWidth="$px"
+          borderRightColor="$neutral3"
+        >
+          <ChartSettingsNavigation
+            sections={settingsValue.appearanceSections}
+            selectedSectionId={selectedAppearanceSectionId}
+            disabled={submitInProgress}
+            compact={false}
+            onSelect={handleSectionSelect}
+          />
+        </YStack>
+      )}
+
+      <ScrollView
+        flex={1}
+        minHeight={0}
+        contentContainerStyle={{
+          pb: '$5',
+        }}
+      >
+        {renderSettingsContent()}
+      </ScrollView>
+    </XStack>
+  );
+
+  const mobileSettingsBody = (
+    <ScrollView
+      testID="trading-view-chart-settings-mobile"
+      flex={1}
+      minHeight={0}
+      contentContainerStyle={{
+        pb: '$8',
+      }}
+    >
+      {renderCandleSettings()}
+      {renderCoordinateSettings()}
+      {renderEventSettings()}
+      {renderLayoutSettings()}
+    </ScrollView>
+  );
+
+  if (mobileLayout) {
+    return mobileSettingsBody;
+  }
+
+  if (usePageFooter) {
+    return (
+      <>
+        <Page.Footer>
+          <Page.FooterActions
+            onCancel={(close) => {
+              handleCancel();
+              close({ flag: 'cancel' });
+            }}
+            onConfirm={(close) => {
+              void handleConfirm().then((confirmed) => {
+                if (confirmed) {
+                  close({ flag: 'confirm' });
+                }
+              });
+            }}
+            cancelButtonProps={{
+              disabled: submitInProgress,
+            }}
+            confirmButtonProps={{
+              disabled: submitInProgress,
+            }}
+          >
+            {resetButton}
+          </Page.FooterActions>
+        </Page.Footer>
+        <XStack
+          testID="trading-view-chart-settings-dialog"
+          width="100%"
+          flex={1}
+          minHeight={0}
+        >
+          {settingsBody}
+        </XStack>
+      </>
+    );
+  }
+
+  return (
+    <YStack
+      testID="trading-view-chart-settings-dialog"
+      width="100%"
+      maxWidth={640}
+      height={dialogHeight}
+      maxHeight="100%"
+      overflow="hidden"
+      borderWidth={md ? 0 : '$px'}
+      borderColor="$borderSubdued"
+      borderRadius={md ? 0 : '$5'}
+      borderCurve="continuous"
+      bg="$bgApp"
+    >
       <XStack
-        h={OKX_CHART_FOOTER_HEIGHT}
+        minHeight={64}
+        px="$6"
         alignItems="center"
         justifyContent="space-between"
-        borderTopWidth={1}
-        borderTopColor={OKX_CHART_BORDER}
-        bg={OKX_CHART_BG}
       >
-        <XStack
-          testID="trading-view-settings-mock-reset"
-          h={41}
-          w={90}
-          ml={24}
-          gap={8}
-          alignItems="center"
-          justifyContent="center"
-          borderRadius={20}
-          cursor={submitInProgress ? 'default' : 'pointer'}
-          opacity={submitInProgress ? 0.5 : 1}
-          pointerEvents={submitInProgress ? 'none' : 'auto'}
-          userSelect="none"
-          hoverStyle={{ bg: '$bgHover' }}
-          pressStyle={{ bg: '$bgActive' }}
-          onPress={handleReset}
-        >
-          <Icon name="RotateCounterclockwiseOutline" size="$5" color="$icon" />
-          <SizableText fontSize={15} lineHeight={20} color={OKX_CHART_TEXT}>
-            重置
-          </SizableText>
-        </XStack>
+        <SizableText size="$headingLg">
+          {intl.formatMessage({
+            id: ETranslations.market_chart_settings,
+          })}
+        </SizableText>
+        <IconButton
+          testID="trading-view-settings-close"
+          title={intl.formatMessage({ id: ETranslations.global_cancel })}
+          icon="CrossedSmallOutline"
+          variant="tertiary"
+          disabled={submitInProgress}
+          onPress={handleClose}
+        />
+      </XStack>
 
-        <XStack mr={24} gap={12} alignItems="center">
-          <XStack
+      {settingsBody}
+      <XStack
+        minHeight={72}
+        px="$6"
+        py="$3"
+        gap="$3"
+        alignItems="center"
+        justifyContent="space-between"
+        bg="$bgApp"
+      >
+        {resetButton}
+        <XStack gap="$3">
+          <Button
             testID="trading-view-settings-mock-cancel"
-            w={81}
-            h={36}
-            alignItems="center"
-            justifyContent="center"
-            borderRadius={18}
-            borderWidth={1}
-            borderColor="$borderStrong"
-            bg={OKX_CHART_BG}
-            cursor={submitInProgress ? 'default' : 'pointer'}
-            opacity={submitInProgress ? 0.5 : 1}
-            pointerEvents={submitInProgress ? 'none' : 'auto'}
+            size="medium"
+            variant="secondary"
+            disabled={submitInProgress}
             onPress={handleCancel}
           >
-            <SizableText
-              fontSize={14}
-              lineHeight={20}
-              fontWeight="600"
-              color={OKX_CHART_TEXT}
-            >
-              取消
-            </SizableText>
-          </XStack>
-          <XStack
+            {intl.formatMessage({ id: ETranslations.global_cancel })}
+          </Button>
+          <Button
             testID="trading-view-settings-mock-confirm"
-            w={81}
-            h={36}
-            alignItems="center"
-            justifyContent="center"
-            borderRadius={18}
-            bg="$bgInverse"
-            cursor={submitInProgress ? 'default' : 'pointer'}
-            opacity={submitInProgress ? 0.5 : 1}
-            pointerEvents={submitInProgress ? 'none' : 'auto'}
+            size="medium"
+            variant="primary"
+            loading={submitInProgress}
+            disabled={submitInProgress}
             onPress={() => void handleConfirm()}
           >
-            <SizableText
-              fontSize={14}
-              lineHeight={20}
-              fontWeight="600"
-              color="$textInverse"
-            >
-              确认
-            </SizableText>
-          </XStack>
+            {intl.formatMessage({ id: ETranslations.global_confirm })}
+          </Button>
         </XStack>
       </XStack>
     </YStack>

--- a/packages/kit/src/components/TradingView/TradingViewChartControls/chartSettings/TradingViewSettingsMockState.ts
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/chartSettings/TradingViewSettingsMockState.ts
@@ -23,6 +23,8 @@ export type ITradingViewSettingsMockIcon =
   | 'TradingViewCandlesOutline'
   | 'RandomCrossoverOutline'
   | 'ClockTimeHistoryOutline'
+  | 'MoveOutline'
+  | 'CalendarDaysOutline'
   | 'LayoutGrid2Outline';
 
 export type ITradingViewSettingsMockLine = {
@@ -178,7 +180,7 @@ const DEFAULT_APPEARANCE_SECTIONS: ITradingViewSettingsMockAppearanceSection[] =
     {
       id: 'coordinates',
       label: 'Coordinates',
-      icon: 'RandomCrossoverOutline',
+      icon: 'MoveOutline',
       items: [
         {
           id: 'crosshair',
@@ -199,7 +201,7 @@ const DEFAULT_APPEARANCE_SECTIONS: ITradingViewSettingsMockAppearanceSection[] =
     {
       id: 'events',
       label: 'Events',
-      icon: 'ClockTimeHistoryOutline',
+      icon: 'CalendarDaysOutline',
       items: [
         {
           id: 'orders',

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewMobileChartSettingsDialogContent.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewMobileChartSettingsDialogContent.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useState } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import {
+  Checkbox,
+  Divider,
+  Icon,
+  SizableText,
+  XStack,
+  YStack,
+  useDialogInstance,
+} from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+import { createTradingViewChartSettingsValue } from '../TradingViewChartControls/chartSettings';
+
+import type { ITradingViewChartSettingsOptions } from '../TradingViewChartControls/chartSettings/TradingViewSettingsMockState';
+
+type IQuickSettingOptions = Pick<
+  ITradingViewChartSettingsOptions,
+  'countdown' | 'futureEvents' | 'pastEvents'
+> & {
+  yAxis: boolean;
+};
+
+const QUICK_SETTING_OPTIONS: Array<keyof IQuickSettingOptions> = [
+  'yAxis',
+  'countdown',
+  'futureEvents',
+  'pastEvents',
+];
+
+const OPTION_TRANSLATION_IDS: Record<
+  keyof IQuickSettingOptions,
+  ETranslations
+> = {
+  yAxis: ETranslations.market_chart_settings__y_axis,
+  countdown: ETranslations.market_chart_settings__countdown,
+  futureEvents: ETranslations.market_chart_settings__upcoming_events,
+  pastEvents: ETranslations.market_chart_settings__past_events,
+};
+
+function SettingsEntry({ onPress }: { onPress: () => void }) {
+  const intl = useIntl();
+
+  return (
+    <XStack
+      testID="trading-view-native-chart-settings-dialog-open-settings"
+      width="100%"
+      minHeight={48}
+      gap="$3"
+      alignItems="center"
+      cursor="pointer"
+      onPress={onPress}
+    >
+      <Icon name="SettingsOutline" size="$5" color="$iconSubdued" />
+      <SizableText size="$bodyMdMedium" color="$text">
+        {intl.formatMessage({ id: ETranslations.market_chart_settings })}
+      </SizableText>
+      <XStack flex={1} />
+      <Icon name="ChevronRightOutline" size="$4.5" color="$iconSubdued" />
+    </XStack>
+  );
+}
+
+function QuickSettingOption({
+  option,
+  label,
+  value,
+  onChange,
+}: {
+  option: keyof IQuickSettingOptions;
+  label: string;
+  value: boolean;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <XStack width="50%" minHeight={40} pr="$2" alignItems="center">
+      <Checkbox
+        testID={`trading-view-native-chart-settings-dialog-option-${option}`}
+        label={label}
+        value={value}
+        labelProps={{ variant: '$bodyMdMedium' }}
+        containerProps={{ alignItems: 'center' }}
+        labelContainerProps={{ py: '$0', my: '$0', justifyContent: 'center' }}
+        onChange={(checked) => onChange(Boolean(checked))}
+      />
+    </XStack>
+  );
+}
+
+export function TradingViewMobileChartSettingsDialogContent({
+  onOpenSettings,
+}: {
+  onOpenSettings: () => void;
+}) {
+  const intl = useIntl();
+  const dialog = useDialogInstance();
+  const [options, setOptions] = useState<IQuickSettingOptions>(() => {
+    const defaultOptions = createTradingViewChartSettingsValue().options;
+    return {
+      yAxis: true,
+      countdown: defaultOptions.countdown,
+      futureEvents: defaultOptions.futureEvents,
+      pastEvents: defaultOptions.pastEvents,
+    };
+  });
+
+  const handleOpenSettings = useCallback(async () => {
+    await dialog.close();
+    onOpenSettings();
+  }, [dialog, onOpenSettings]);
+
+  const handleOptionChange = useCallback(
+    (key: keyof IQuickSettingOptions, value: boolean) => {
+      setOptions((currentOptions) => ({
+        ...currentOptions,
+        [key]: value,
+      }));
+    },
+    [],
+  );
+
+  return (
+    <YStack gap="$4" pb="$6">
+      <SettingsEntry onPress={() => void handleOpenSettings()} />
+      <Divider />
+
+      <YStack gap="$3" pt="$1">
+        <SizableText size="$bodyMd" color="$textSubdued">
+          {intl.formatMessage({
+            id: ETranslations.market_chart_settings__chart_display,
+          })}
+        </SizableText>
+        <XStack flexWrap="wrap" rowGap="$1">
+          {QUICK_SETTING_OPTIONS.map((option) => (
+            <QuickSettingOption
+              key={option}
+              option={option}
+              label={intl.formatMessage({
+                id: OPTION_TRANSLATION_IDS[option],
+              })}
+              value={options[option]}
+              onChange={(value) => handleOptionChange(option, value)}
+            />
+          ))}
+        </XStack>
+      </YStack>
+    </YStack>
+  );
+}

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.test.tsx
@@ -9,7 +9,7 @@ import { render } from '@testing-library/react';
 import { TradingViewNativeChartControlsContainer } from './TradingViewNativeChartControlsContainer';
 
 const mockTradingViewChartControls = jest.fn<null, [unknown]>(() => null);
-const mockShowTradingViewChartSettingsDialog = jest.fn<void, []>();
+const mockPushModal = jest.fn();
 
 jest.mock('react-intl', () => ({
   useIntl: () => ({
@@ -25,14 +25,9 @@ jest.mock(
   }),
 );
 
-jest.mock(
-  '@onekeyhq/kit/src/components/TradingView/TradingViewChartControls/chartSettings',
-  () => ({
-    showTradingViewChartSettingsDialog: () => {
-      mockShowTradingViewChartSettingsDialog();
-    },
-  }),
-);
+jest.mock('@onekeyhq/kit/src/hooks/useAppNavigation', () => () => ({
+  pushModal: mockPushModal,
+}));
 
 describe('TradingViewNative chart controls', () => {
   beforeEach(() => {
@@ -94,7 +89,9 @@ describe('TradingViewNative chart controls', () => {
     };
     controlsProps.onSettingsPress();
 
-    expect(mockShowTradingViewChartSettingsDialog).toHaveBeenCalledTimes(1);
+    expect(mockPushModal).toHaveBeenCalledWith('MarketModal', {
+      screen: 'MarketChartSettings',
+    });
   });
 
   it('enables calendar navigation in desktop controls', () => {

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeChartControlsContainer.tsx
@@ -3,11 +3,16 @@ import { type ReactNode, memo, useCallback } from 'react';
 import { noop } from 'lodash';
 import { useIntl } from 'react-intl';
 
+import { Dialog } from '@onekeyhq/components';
 import { TradingViewChartControls } from '@onekeyhq/kit/src/components/TradingView/TradingViewChartControls';
 import type { ITradingViewChartControlsProps } from '@onekeyhq/kit/src/components/TradingView/TradingViewChartControls';
-import { showTradingViewChartSettingsDialog } from '@onekeyhq/kit/src/components/TradingView/TradingViewChartControls/chartSettings';
 import { getTradingViewTimezone } from '@onekeyhq/kit/src/components/TradingView/utils/tradingViewTimezone';
+import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
+import { EModalMarketRoutes } from '@onekeyhq/kit/src/views/Market/router/types';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { EModalRoutes } from '@onekeyhq/shared/src/routes';
+
+import { TradingViewMobileChartSettingsDialogContent } from './TradingViewMobileChartSettingsDialogContent';
 
 const ACTIVE_INDICATOR_VALUES = new Set<string>();
 
@@ -38,14 +43,33 @@ export const TradingViewNativeChartControlsContainer = memo(
     onFullscreenChange,
   }: ITradingViewNativeChartControlsContainerProps) => {
     const intl = useIntl();
+    const navigation = useAppNavigation();
     const chartStyleTitle = intl.formatMessage({
       id: ETranslations.market_chart_style,
     });
-    const settingsEnabled =
-      enableNativeChartSettings && layoutMode === 'desktop';
+    const settingsEnabled = enableNativeChartSettings;
+    const openChartSettingsModal = useCallback(() => {
+      navigation.pushModal(EModalRoutes.MarketModal, {
+        screen: EModalMarketRoutes.MarketChartSettings,
+      });
+    }, [navigation]);
     const handleSettingsPress = useCallback(() => {
-      showTradingViewChartSettingsDialog();
-    }, []);
+      if (layoutMode !== 'mobile') {
+        openChartSettingsModal();
+        return;
+      }
+
+      Dialog.show({
+        title: intl.formatMessage({ id: ETranslations.global_settings }),
+        showFooter: false,
+        testID: 'trading-view-native-chart-settings-quick-dialog',
+        renderContent: (
+          <TradingViewMobileChartSettingsDialogContent
+            onOpenSettings={openChartSettingsModal}
+          />
+        ),
+      });
+    }, [intl, layoutMode, openChartSettingsModal]);
     const handleFullscreenToggle = useCallback(() => {
       onFullscreenChange?.(!isFullscreen);
     }, [isFullscreen, onFullscreenChange]);

--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketChartSettingsModal.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketChartSettingsModal.tsx
@@ -1,0 +1,21 @@
+import { useIntl } from 'react-intl';
+
+import { Page, useMedia } from '@onekeyhq/components';
+import { TradingViewChartSettings } from '@onekeyhq/kit/src/components/TradingView/TradingViewChartControls/chartSettings';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+export default function MarketChartSettingsModal() {
+  const intl = useIntl();
+  const { md } = useMedia();
+
+  return (
+    <Page>
+      <Page.Header
+        title={intl.formatMessage({ id: ETranslations.market_chart_settings })}
+      />
+      <Page.Body minHeight={0}>
+        <TradingViewChartSettings usePageFooter={!md} mobileLayout={md} />
+      </Page.Body>
+    </Page>
+  );
+}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketTradingView/MarketTradingView.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketTradingView/MarketTradingView.tsx
@@ -176,7 +176,7 @@ export const MarketTradingView = memo(
         onPriceUpdate={handlePriceUpdate}
         disabledFeatures={MARKET_NATIVE_CHART_CONTROL_DISABLED_FEATURES}
         enableNativeChartControls
-        enableNativeChartSettings={nativeControlsLayoutMode === 'desktop'}
+        enableNativeChartSettings
         nativeChartTypeControlMode={nativeChartTypeControlMode}
         nativeIndicatorControlMode={nativeIndicatorControlMode}
         nativeIntervalControlMode={nativeIntervalControlMode}

--- a/packages/kit/src/views/Market/components/TokenPriceChart.tsx
+++ b/packages/kit/src/views/Market/components/TokenPriceChart.tsx
@@ -90,7 +90,7 @@ function BasicTokenPriceChart({ coinGeckoId, token }: ITokenPriceChartProps) {
         <TradingViewNative
           testID={MarketTestIDs.detailChart}
           source={source}
-          enableNativeChartSettings={layoutMode === 'desktop'}
+          enableNativeChartSettings
           nativeControlsLayoutMode={layoutMode}
         />
       ) : (

--- a/packages/kit/src/views/Market/router/index.tsx
+++ b/packages/kit/src/views/Market/router/index.tsx
@@ -18,6 +18,9 @@ const MobileTokenSelectorModal = LazyLoadPage(
   () =>
     import('../MarketDetailV2/components/TokenSelector/MobileTokenSelector'),
 );
+const MarketChartSettingsModal = LazyLoadPage(
+  () => import('../MarketDetailV2/components/MarketChartSettingsModal'),
+);
 
 export { EModalMarketRoutes };
 export type { IModalMarketParamList };
@@ -38,5 +41,10 @@ export const ModalMarketStack: IModalFlowNavigatorConfig<
   {
     name: EModalMarketRoutes.MobileTokenSelector,
     component: MobileTokenSelectorModal,
+  },
+  {
+    name: EModalMarketRoutes.MarketChartSettings,
+    component: MarketChartSettingsModal,
+    modalContentMaxHeight: 544,
   },
 ];

--- a/packages/kit/src/views/Market/router/types.ts
+++ b/packages/kit/src/views/Market/router/types.ts
@@ -4,6 +4,7 @@ export enum EModalMarketRoutes {
   MarketDetailV2 = 'MarketDetailV2',
   MarketBannerDetail = 'MarketBannerDetail',
   MobileTokenSelector = 'MobileTokenSelector',
+  MarketChartSettings = 'MarketChartSettings',
 }
 
 export type IModalMarketParamList = {
@@ -23,4 +24,5 @@ export type IModalMarketParamList = {
         showFavoriteButton?: boolean;
       }
     | undefined;
+  [EModalMarketRoutes.MarketChartSettings]: undefined;
 };


### PR DESCRIPTION
## Summary
- add mobile chart settings entry and full settings layout
- localize chart settings across desktop and mobile
- sync chart settings translations from Lokalise

## Validation
- yarn agent:check --profile commit

<img width="1402" height="1156" alt="CleanShot 2026-07-24 at 02 51 07@2x" src="https://github.com/user-attachments/assets/0e5feadf-b855-4cfd-b275-9fb197e83277" />
