### PR TITLE
chore: sync release/v6.5.0 to x

### DIFF
--- a/development/spellCheckerSkipWords.txt
+++ b/development/spellCheckerSkipWords.txt
@@ -644,6 +644,7 @@ Outout
 p2pkh
 p2wpkh
 pageview
+pancakeswap
 passcode
 passpharse
 passphrase

--- a/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/NavigationContainer.tsx
@@ -153,6 +153,13 @@ const hasOverlayAboveMain = (ref: typeof rootNavigationRef): boolean => {
   return topRoute?.name !== ERootRoutes.Main;
 };
 
+export const willTabFocusTransition = (
+  route: ETabRoutes,
+  navigationRef: typeof rootNavigationRef = rootNavigationRef,
+): boolean =>
+  hasOverlayAboveMain(navigationRef) ||
+  getActiveTabFromRef(navigationRef) !== route;
+
 /**
  * @deprecated
  * @description Prefer `switchTabAsync` for new code. This synchronous version

--- a/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
+++ b/packages/components/src/layouts/Navigation/Navigator/TabStackNavigator.native.tsx
@@ -8,6 +8,10 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EEnterWay } from '@onekeyhq/shared/src/logger/scopes/dex';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
 import { ESwapSource } from '@onekeyhq/shared/types/swap/types';
@@ -16,6 +20,7 @@ import { useSettingConfig } from '../../../hocs/Provider/hooks/useProviderValue'
 import {
   ESplitViewType,
   useIsSplitView,
+  useSplitMainView,
   useSplitViewType,
   useTheme,
   useThemeName,
@@ -23,6 +28,12 @@ import {
 import { createNativeBottomTabNavigator } from '../BottomTabs';
 import { makeTabScreenOptions } from '../GlobalScreenOptions';
 import { createStackNavigator } from '../StackNavigator';
+
+import {
+  rootNavigationRef,
+  tabletMainViewNavigationRef,
+  willTabFocusTransition,
+} from './NavigationContainer';
 
 import type { ITabNavigatorProps, ITabSubNavigatorConfig } from './types';
 
@@ -102,6 +113,7 @@ export function TabStackNavigator<RouteName extends string>({
   const intl = useIntl();
   const theme = useTheme();
   const { hapticFeedbackEnabled } = useSettingConfig();
+  const isSplitMainView = useSplitMainView();
   // Subscribe to theme name so OS dark/light switch triggers re-render —
   // `theme.*.val` reads are non-reactive on native.
   useThemeName();
@@ -119,18 +131,31 @@ export function TabStackNavigator<RouteName extends string>({
   }, []);
 
   // Handle tab press events for logging and event bus notifications
-  const handleTabPress = useCallback((routeName: string) => {
-    if (routeName === ETabRoutes.Swap) {
-      defaultLogger.swap.enterSwap.enterSwap({
-        enterFrom: ESwapSource.TAB,
-      });
-    }
-    if (routeName === ETabRoutes.Market) {
-      appEventBus.emit(EAppEventBusNames.MarketHomePageEnter, {
-        from: EEnterWay.HomeTab,
-      });
-    }
-  }, []);
+  const handleTabPress = useCallback(
+    (routeName: string) => {
+      if (routeName === ETabRoutes.Swap) {
+        defaultLogger.swap.enterSwap.enterSwap({
+          enterFrom: ESwapSource.TAB,
+        });
+      }
+      if (routeName === ETabRoutes.Market) {
+        appEventBus.emit(EAppEventBusNames.MarketHomePageEnter, {
+          from: EEnterWay.HomeTab,
+        });
+      }
+      if (
+        (routeName === ETabRoutes.Perp ||
+          routeName === ETabRoutes.WebviewPerpTrade) &&
+        willTabFocusTransition(
+          routeName,
+          isSplitMainView ? tabletMainViewNavigationRef : rootNavigationRef,
+        )
+      ) {
+        setPerpPageEnterSource(EPerpPageEnterSource.TabBar);
+      }
+    },
+    [isSplitMainView],
+  );
 
   const tabScreens = useMemo(() => {
     const screens = config

--- a/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
+++ b/packages/components/src/layouts/Navigation/Tab/TabBar/MobileBottomTabBar.tsx
@@ -80,7 +80,11 @@ export default function MobileBottomTabBar({
         });
       }
 
-      if (route.name === ETabRoutes.Perp && !isActive) {
+      if (
+        (route.name === ETabRoutes.Perp ||
+          route.name === ETabRoutes.WebviewPerpTrade) &&
+        !isActive
+      ) {
         setPerpPageEnterSource(EPerpPageEnterSource.TabBar);
       }
 

--- a/packages/kit-bg/src/services/ServiceMarketV2.ts
+++ b/packages/kit-bg/src/services/ServiceMarketV2.ts
@@ -26,6 +26,7 @@ import type {
   IMarketChainsResponse,
   IMarketPerpsTokenListData,
   IMarketPerpsTokenListResponse,
+  IMarketStockDetail,
   IMarketTokenBatchListResponse,
   IMarketTokenDetailResponse,
   IMarketTokenHoldersResponse,
@@ -48,6 +49,10 @@ import { perpTokenFavoritesPersistAtom } from '../states/jotai/atoms/perps';
 
 import ServiceBase from './ServiceBase';
 import { MOCK_MARKET_BANNER_LIST } from './ServiceMarketV2.const';
+import {
+  type IMarketStockAssetApiData,
+  buildMarketStockDetail,
+} from './utils/marketStockUtils';
 import { resolveMarketTokenDetailRequestTokenAddress } from './utils/marketTokenDetailUtils';
 
 type IMarketTokenListRequestParams = {
@@ -92,6 +97,7 @@ class ServiceMarketV2 extends ServiceBase {
       if (event.level !== 'critical') return;
       this._marketTokenBatchCache.clear();
       void this.memoizedFetchMarketTokenList.clear();
+      void this.memoizedFetchMarketStockByTicker.clear();
     });
   }
 
@@ -109,6 +115,31 @@ class ServiceMarketV2 extends ServiceBase {
   private _marketTokenListCacheTTL = timerUtils.getTimeDurationMs({
     seconds: 20,
   });
+
+  private memoizedFetchMarketStockByTicker = memoizee(
+    async (ticker: string, locale: string) => {
+      const client = await this.getClient(EServiceEndpointEnum.Utility);
+      const response = await client.get<{
+        code: number;
+        message: string;
+        data?: IMarketStockAssetApiData | null;
+      }>('/utility/v1/market/stock', {
+        params: {
+          ticker,
+        },
+        headers: {
+          'x-onekey-request-currency': 'usd',
+          'x-onekey-request-locale': locale,
+        },
+      });
+      const data = response.data?.data;
+      return data ? buildMarketStockDetail(data) : undefined;
+    },
+    {
+      maxAge: timerUtils.getTimeDurationMs({ hour: 1 }),
+      promise: true,
+    },
+  );
 
   private _cleanExpiredMarketTokenBatchCache() {
     const now = Date.now();
@@ -228,6 +259,28 @@ class ServiceMarketV2 extends ServiceBase {
       },
     );
     return response.data;
+  }
+
+  @backgroundMethod()
+  async fetchMarketStockByTicker(
+    ticker: string,
+  ): Promise<IMarketStockDetail | undefined> {
+    const normalizedTicker = ticker.trim().toUpperCase();
+    if (!normalizedTicker) {
+      return undefined;
+    }
+    const locale = await this._getMarketTokenBatchCacheLocale();
+    const detail = await this.memoizedFetchMarketStockByTicker(
+      normalizedTicker,
+      locale,
+    );
+    if (!detail) {
+      await this.memoizedFetchMarketStockByTicker.delete(
+        normalizedTicker,
+        locale,
+      );
+    }
+    return detail;
   }
 
   private memoizedFetchMarketChains = memoizee(

--- a/packages/kit-bg/src/services/utils/marketStockUtils.test.ts
+++ b/packages/kit-bg/src/services/utils/marketStockUtils.test.ts
@@ -1,0 +1,68 @@
+import { buildMarketStockDetail } from './marketStockUtils';
+
+describe('buildMarketStockDetail', () => {
+  it('maps stock asset fundamentals to the shared Market stock model', () => {
+    const detail = buildMarketStockDetail({
+      ticker: 'AAPL',
+      name: 'Apple Inc.',
+      logoUrl: 'https://example.com/aapl.png',
+      underlyingUpdatedAt: '2026-07-15T08:00:00.000Z',
+      underlyingMeta: {
+        introduction: 'Apple introduction',
+        marketCap: '4624460910160',
+        volume24h: '11438536975.32',
+        volumeShares: '36328962',
+        turnoverRate24h: '0.2473485493',
+        averageVolume1y: '51723904',
+        weekHigh52: '323.45',
+        weekLow52: '201.5',
+        peRatioTTM: '38.28',
+        priceToBookRatioTTM: '43.83',
+        priceToSalesRatioTTM: '10.32',
+        returnOnEquityTTM: '1.4669',
+        returnOnAssetsTTM: '0.3303',
+        netProfitMarginTTM: '0.2715',
+        debtToEquityRatioTTM: '0.7955',
+        dividendYieldTTM: '0.0033',
+        dividendPerShareTTM: '1.05',
+        sharesOutstanding: '14687356000',
+      },
+    });
+
+    expect(detail).toEqual({
+      ticker: 'AAPL',
+      name: 'Apple Inc.',
+      logoUrl: 'https://example.com/aapl.png',
+      introduction: 'Apple introduction',
+      underlyingUpdatedAt: '2026-07-15T08:00:00.000Z',
+      stock: {
+        title: 'AAPL',
+        subtitle: 'Apple Inc.',
+        sourceLogoUri: 'https://example.com/aapl.png',
+        assetAnalysis: {
+          volume24h: '11438536975.32',
+          volumeShares: '36328962',
+          turnoverRate: '0.2473485493',
+          avgDailyVolume1y: '51723904',
+          weekHigh52: '323.45',
+          weekLow52: '201.5',
+        },
+        tradingActivity: {
+          peRatio: '38.28',
+          pbRatio: '43.83',
+          psRatio: '10.32',
+          roe: '1.4669',
+          roa: '0.3303',
+          netProfitMargin: '0.2715',
+          debtToEquity: '0.7955',
+          dividendYield: '0.0033',
+        },
+        dividendPerShare: '1.05',
+        marketCap: '4624460910160',
+        sharesOutstanding: '14687356000',
+        underlyingAssetTicker: 'AAPL',
+        underlyingAssetName: 'Apple Inc.',
+      },
+    });
+  });
+});

--- a/packages/kit-bg/src/services/utils/marketStockUtils.ts
+++ b/packages/kit-bg/src/services/utils/marketStockUtils.ts
@@ -1,0 +1,76 @@
+import type {
+  IMarketStockDetail,
+  IMarketStockInfo,
+} from '@onekeyhq/shared/types/marketV2';
+
+export interface IMarketStockUnderlyingMetaApiData {
+  averageVolume1y?: string;
+  debtToEquityRatioTTM?: string;
+  dividendPerShareTTM?: string;
+  dividendYieldTTM?: string;
+  introduction?: string;
+  marketCap?: string;
+  netProfitMarginTTM?: string;
+  peRatioTTM?: string;
+  priceToBookRatioTTM?: string;
+  priceToSalesRatioTTM?: string;
+  returnOnAssetsTTM?: string;
+  returnOnEquityTTM?: string;
+  sharesOutstanding?: string;
+  turnoverRate24h?: string;
+  volume24h?: string;
+  volumeShares?: string;
+  weekHigh52?: string;
+  weekLow52?: string;
+}
+
+export interface IMarketStockAssetApiData {
+  ticker: string;
+  name: string;
+  logoUrl?: string;
+  underlyingMeta?: IMarketStockUnderlyingMetaApiData;
+  underlyingUpdatedAt?: string;
+}
+
+export function buildMarketStockDetail(
+  data: IMarketStockAssetApiData,
+): IMarketStockDetail {
+  const meta = data.underlyingMeta;
+  const stock: IMarketStockInfo = {
+    title: data.ticker,
+    subtitle: data.name,
+    sourceLogoUri: data.logoUrl ?? '',
+    assetAnalysis: {
+      volume24h: meta?.volume24h,
+      volumeShares: meta?.volumeShares,
+      turnoverRate: meta?.turnoverRate24h,
+      avgDailyVolume1y: meta?.averageVolume1y,
+      weekHigh52: meta?.weekHigh52,
+      weekLow52: meta?.weekLow52,
+    },
+    tradingActivity: {
+      peRatio: meta?.peRatioTTM,
+      pbRatio: meta?.priceToBookRatioTTM,
+      psRatio: meta?.priceToSalesRatioTTM,
+      roe: meta?.returnOnEquityTTM,
+      roa: meta?.returnOnAssetsTTM,
+      netProfitMargin: meta?.netProfitMarginTTM,
+      debtToEquity: meta?.debtToEquityRatioTTM,
+      dividendYield: meta?.dividendYieldTTM,
+    },
+    dividendPerShare: meta?.dividendPerShareTTM,
+    marketCap: meta?.marketCap,
+    sharesOutstanding: meta?.sharesOutstanding,
+    underlyingAssetTicker: data.ticker,
+    underlyingAssetName: data.name,
+  };
+
+  return {
+    ticker: data.ticker,
+    name: data.name,
+    logoUrl: data.logoUrl,
+    introduction: meta?.introduction,
+    underlyingUpdatedAt: data.underlyingUpdatedAt,
+    stock,
+  };
+}

--- a/packages/kit-bg/src/vaults/impls/evm/approveTransactionUtils.test.ts
+++ b/packages/kit-bg/src/vaults/impls/evm/approveTransactionUtils.test.ts
@@ -82,6 +82,39 @@ describe('approval transaction utils', () => {
     ).toBeUndefined();
   });
 
+  test('resolves the PancakeSwap Permit2 deployment on trusted networks', () => {
+    // The server-side approvals whitelist returns Uniswap AND PancakeSwap
+    // Permit2 contracts; only trusting Uniswap blocked PancakeSwap Permit2
+    // revocations at _assertPermit2ApproveInfo.
+    const pancakePermit2Address = '0x31c2f6fcff4f8759b3bd5bf0e1084a055615c768';
+    const networkIdsMap = getNetworkIdsMap();
+    const supportedNetworkIds = [
+      networkIdsMap.eth,
+      networkIdsMap.bsc,
+      networkIdsMap.polygon,
+      networkIdsMap.arbitrum,
+      networkIdsMap.avalanche,
+      networkIdsMap.optimism,
+      networkIdsMap.base,
+    ];
+
+    for (const networkId of supportedNetworkIds) {
+      expect(
+        resolveTrustedPermit2Address({
+          networkId,
+          permit2Address: pancakePermit2Address,
+        }),
+      ).toBe('0x31c2F6fcFf4F8759b3Bd5Bf0e1084A055615c768');
+    }
+
+    expect(
+      resolveTrustedPermit2Address({
+        networkId: networkIdsMap.zksyncera,
+        permit2Address: pancakePermit2Address,
+      }),
+    ).toBeUndefined();
+  });
+
   test('encodes the on-chain Permit2 revoke example', () => {
     expect(buildPermit2Tx()).toEqual({
       from: owner,

--- a/packages/kit-bg/src/vaults/impls/evm/approveTransactionUtils.ts
+++ b/packages/kit-bg/src/vaults/impls/evm/approveTransactionUtils.ts
@@ -14,18 +14,27 @@ import type { BigNumber as EthersBigNumber } from '@ethersproject/bignumber';
 
 export const PERMIT2_APPROVE_SELECTOR = '0x87517c45';
 
-const PERMIT2_ADDRESS = '0x000000000022D473030F116dDEE9F6B43aC78BA3';
+const UNISWAP_PERMIT2_ADDRESS = '0x000000000022D473030F116dDEE9F6B43aC78BA3';
+const PANCAKESWAP_PERMIT2_ADDRESS =
+  '0x31c2F6fcFf4F8759b3Bd5Bf0e1084A055615c768';
 const PERMIT2_APPROVE_DATA_LENGTH = 2 + 8 + 64 * 4;
 const UINT48_MAX = new BigNumber(2).pow(48).minus(1);
 const networkIdsMap = getNetworkIdsMap();
-const TRUSTED_PERMIT2_ADDRESSES: Readonly<Record<string, string>> = {
-  [networkIdsMap.eth]: PERMIT2_ADDRESS,
-  [networkIdsMap.bsc]: PERMIT2_ADDRESS,
-  [networkIdsMap.polygon]: PERMIT2_ADDRESS,
-  [networkIdsMap.arbitrum]: PERMIT2_ADDRESS,
-  [networkIdsMap.avalanche]: PERMIT2_ADDRESS,
-  [networkIdsMap.optimism]: PERMIT2_ADDRESS,
-  [networkIdsMap.base]: PERMIT2_ADDRESS,
+// The server-side approvals whitelist only returns these two Permit2
+// deployments (>99.9% of Permit2 approval records); both are deterministic
+// CREATE2 deployments sharing one address across chains.
+const TRUSTED_PERMIT2_ADDRESS_LIST: readonly string[] = [
+  UNISWAP_PERMIT2_ADDRESS,
+  PANCAKESWAP_PERMIT2_ADDRESS,
+];
+const TRUSTED_PERMIT2_ADDRESSES: Readonly<Record<string, readonly string[]>> = {
+  [networkIdsMap.eth]: TRUSTED_PERMIT2_ADDRESS_LIST,
+  [networkIdsMap.bsc]: TRUSTED_PERMIT2_ADDRESS_LIST,
+  [networkIdsMap.polygon]: TRUSTED_PERMIT2_ADDRESS_LIST,
+  [networkIdsMap.arbitrum]: TRUSTED_PERMIT2_ADDRESS_LIST,
+  [networkIdsMap.avalanche]: TRUSTED_PERMIT2_ADDRESS_LIST,
+  [networkIdsMap.optimism]: TRUSTED_PERMIT2_ADDRESS_LIST,
+  [networkIdsMap.base]: TRUSTED_PERMIT2_ADDRESS_LIST,
 };
 
 function isSameEvmAddress(left?: string, right?: string) {
@@ -46,10 +55,10 @@ export function resolveTrustedPermit2Address({
   networkId: string;
   permit2Address?: string;
 }) {
-  const trustedPermit2Address = TRUSTED_PERMIT2_ADDRESSES[networkId];
-  return isSameEvmAddress(permit2Address, trustedPermit2Address)
-    ? trustedPermit2Address
-    : undefined;
+  const trustedPermit2Addresses = TRUSTED_PERMIT2_ADDRESSES[networkId] ?? [];
+  return trustedPermit2Addresses.find((trustedPermit2Address) =>
+    isSameEvmAddress(permit2Address, trustedPermit2Address),
+  );
 }
 
 export function buildErc20ApproveEncodedTx({

--- a/packages/kit/src/components/TabPageHeader/components/WebHeaderNavigation/WebHeaderNavigation.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebHeaderNavigation/WebHeaderNavigation.tsx
@@ -8,7 +8,10 @@ import {
   Icon,
   XStack,
   rootNavigationRef,
+  tabletMainViewNavigationRef,
   useOnRouterChange,
+  useSplitMainView,
+  willTabFocusTransition,
 } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { usePerpTabConfig } from '@onekeyhq/kit/src/hooks/usePerpTabConfig';
@@ -67,6 +70,7 @@ function useWebHeaderNavigation({
   const intl = useIntl();
   const navigation = useAppNavigation();
   const toReferFriendsModal = useToReferFriendsModalByRootNavigation();
+  const isSplitMainView = useSplitMainView();
   const [currentTab, setCurrentTab] = useState<ETabRoutes | null>(null);
 
   useOnRouterChange((state) => {
@@ -171,14 +175,27 @@ function useWebHeaderNavigation({
         return;
       }
 
-      if (tabKey === ETabRoutes.Perp) {
+      if (
+        (tabKey === ETabRoutes.Perp ||
+          tabKey === ETabRoutes.WebviewPerpTrade) &&
+        willTabFocusTransition(
+          tabKey,
+          isSplitMainView ? tabletMainViewNavigationRef : rootNavigationRef,
+        )
+      ) {
         setPerpPageEnterSource(EPerpPageEnterSource.TabBar);
       }
       if (tabKey) {
         navigation.switchTab(tabKey as ETabRoutes);
       }
     },
-    [navigation, onNavigationChange, perpTabShowWeb, toReferFriendsModal],
+    [
+      isSplitMainView,
+      navigation,
+      onNavigationChange,
+      perpTabShowWeb,
+      toReferFriendsModal,
+    ],
   );
 
   const navigationItems: IHeaderNavigationItem[] = useMemo(

--- a/packages/kit/src/components/TradingView/utils/tradingViewTimezone.test.ts
+++ b/packages/kit/src/components/TradingView/utils/tradingViewTimezone.test.ts
@@ -1,0 +1,18 @@
+import { getTradingViewTimezone } from './tradingViewTimezone';
+
+import type { Calendar } from 'expo-localization';
+
+describe('getTradingViewTimezone', () => {
+  it('uses the shared device time zone resolution for calendar data', () => {
+    const calendars: Calendar[] = [
+      {
+        calendar: null,
+        uses24hourClock: null,
+        firstWeekday: null,
+        timeZone: 'Asia/Shanghai',
+      },
+    ];
+
+    expect(getTradingViewTimezone(calendars)).toBe('Asia/Shanghai');
+  });
+});

--- a/packages/kit/src/components/TradingView/utils/tradingViewTimezone.ts
+++ b/packages/kit/src/components/TradingView/utils/tradingViewTimezone.ts
@@ -1,3 +1,5 @@
+import { getDeviceTimeZone } from '@onekeyhq/shared/src/utils/timeZoneUtils';
+
 import type { Calendar } from 'expo-localization';
 
 /**
@@ -5,9 +7,5 @@ import type { Calendar } from 'expo-localization';
  * Uses expo-localization first, fallback to Intl API, then to UTC
  */
 export const getTradingViewTimezone = (calendars?: Calendar[]): string => {
-  return (
-    calendars?.[0]?.timeZone ||
-    Intl.DateTimeFormat().resolvedOptions().timeZone ||
-    'Etc/UTC'
-  );
+  return getDeviceTimeZone(calendars?.[0]?.timeZone);
 };

--- a/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
+++ b/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
@@ -6,6 +6,7 @@ import {
   resetAboveMainRoute,
   rootNavigationRef,
   switchTabAsync,
+  willTabFocusTransition,
 } from '@onekeyhq/components/src/layouts/Navigation/Navigator/NavigationContainer';
 import type {
   IDBAccount,
@@ -28,6 +29,10 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   EModalAssetDetailRoutes,
@@ -1102,6 +1107,9 @@ export function useTrayDataProvider() {
       if (action?.type === 'market-detail-v2') {
         if (action.perpsCoin) {
           const coin = action.perpsCoin;
+          if (willTabFocusTransition(ETabRoutes.Perp)) {
+            setPerpPageEnterSource(EPerpPageEnterSource.DesktopTray);
+          }
           void switchTabAsync(ETabRoutes.Perp).then(async () => {
             try {
               await backgroundApiProxy.serviceHyperliquid.changeActiveAsset({

--- a/packages/kit/src/provider/Container/PageTrackerContainer/index.tsx
+++ b/packages/kit/src/provider/Container/PageTrackerContainer/index.tsx
@@ -28,7 +28,7 @@ export default function PageTrackerContainer() {
         defaultLogger.app.page.pageView(ETabHomeRoutes.TabHome);
       } else {
         const page = getActiveRoute(state as IState);
-        // Perp has its own pageView with source tracking (perp.common.pageView)
+        // Perp has its own page view event with source tracking.
         if (page && page.name !== ETabRoutes.Perp) {
           defaultLogger.app.page.pageView(page.name);
         }

--- a/packages/kit/src/routes/Tab/Marktet/router.ts
+++ b/packages/kit/src/routes/Tab/Marktet/router.ts
@@ -9,13 +9,17 @@ import {
   LazyLoadRootTabPage,
 } from '../../../components/LazyLoadPage';
 import { createMarketDetailV2Route } from '../../../views/Market/MarketDetailV2/MarketDetailV2Route';
+import { MarketHomeLoadingFallback } from '../../../views/Market/MarketHomeV2/components/MarketHomeLoadingFallback';
 import { RootTabLoadingFallback } from '../RootTabLoadingFallback';
 
 import { MarketDetailV2LoadingFallback } from './MarketDetailV2LoadingFallback';
 
 const MarketHome = LazyLoadRootTabPage(
   () => import(/* webpackPrefetch: true */ '../../../views/Market/MarketHome'),
-  createElement(RootTabLoadingFallback, { tabRoute: ETabRoutes.Market }),
+  createElement(RootTabLoadingFallback, {
+    tabRoute: ETabRoutes.Market,
+    mobileContentFallback: createElement(MarketHomeLoadingFallback),
+  }),
 );
 
 const MarketDetail = LazyLoadPage(

--- a/packages/kit/src/routes/Tab/RootTabLoadingFallback.test.tsx
+++ b/packages/kit/src/routes/Tab/RootTabLoadingFallback.test.tsx
@@ -1,0 +1,108 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
+
+import { RootTabLoadingFallback } from './RootTabLoadingFallback';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __rootTabLoadingFallbackMedia: { md: boolean };
+  // eslint-disable-next-line no-var
+  var __rootTabLoadingFallbackPlatformEnv: { isNative: boolean };
+}
+
+jest.mock('@onekeyhq/components', () => ({
+  Page: {
+    Header: () => <div data-testid="page-header" />,
+  },
+  Spinner: () => <div data-testid="loading-spinner" />,
+  Stack: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  useMedia: () => globalThis.__rootTabLoadingFallbackMedia,
+}));
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => {
+  const platformEnv = { isNative: false };
+  globalThis.__rootTabLoadingFallbackPlatformEnv = platformEnv;
+  return {
+    __esModule: true,
+    default: platformEnv,
+  };
+});
+
+jest.mock('../../components/AccountSelector', () => ({
+  AccountSelectorProviderMirror: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+jest.mock('../../components/TabPageHeader', () => ({
+  TabPageHeader: () => <div data-testid="tab-page-header" />,
+}));
+
+const marketTabRoute = 'Market' as ETabRoutes;
+
+beforeEach(() => {
+  globalThis.__rootTabLoadingFallbackMedia = { md: false };
+  globalThis.__rootTabLoadingFallbackPlatformEnv.isNative = false;
+});
+
+describe('RootTabLoadingFallback', () => {
+  it('keeps the web header and route-specific chrome mounted on small screens', () => {
+    globalThis.__rootTabLoadingFallbackMedia = { md: true };
+
+    render(
+      <RootTabLoadingFallback
+        tabRoute={marketTabRoute}
+        mobileContentFallback={<div data-testid="mobile-content-fallback" />}
+      />,
+    );
+
+    expect(screen.getByTestId('mobile-content-fallback')).toBeTruthy();
+    expect(screen.getByTestId('tab-page-header')).toBeTruthy();
+    expect(screen.queryByTestId('loading-spinner')).toBeNull();
+    expect(screen.queryByTestId('page-header')).toBeNull();
+  });
+
+  it('uses the neutral spinner on native', () => {
+    globalThis.__rootTabLoadingFallbackMedia = { md: true };
+    globalThis.__rootTabLoadingFallbackPlatformEnv.isNative = true;
+
+    render(
+      <RootTabLoadingFallback
+        tabRoute={marketTabRoute}
+        mobileContentFallback={<div data-testid="mobile-content-fallback" />}
+      />,
+    );
+
+    expect(screen.getByTestId('loading-spinner')).toBeTruthy();
+    expect(screen.queryByTestId('mobile-content-fallback')).toBeNull();
+    expect(screen.queryByTestId('tab-page-header')).toBeNull();
+  });
+
+  it('preserves the neutral fallback for small web routes without custom chrome', () => {
+    globalThis.__rootTabLoadingFallbackMedia = { md: true };
+
+    render(<RootTabLoadingFallback tabRoute={marketTabRoute} />);
+
+    expect(screen.getByTestId('page-header')).toBeTruthy();
+    expect(screen.getByTestId('loading-spinner')).toBeTruthy();
+    expect(screen.queryByTestId('tab-page-header')).toBeNull();
+  });
+
+  it('preserves the desktop tab page header on wide web screens', () => {
+    render(
+      <RootTabLoadingFallback
+        tabRoute={marketTabRoute}
+        mobileContentFallback={<div data-testid="mobile-content-fallback" />}
+      />,
+    );
+
+    expect(screen.getByTestId('tab-page-header')).toBeTruthy();
+    expect(screen.getByTestId('loading-spinner')).toBeTruthy();
+    expect(screen.queryByTestId('mobile-content-fallback')).toBeNull();
+  });
+});

--- a/packages/kit/src/routes/Tab/RootTabLoadingFallback.tsx
+++ b/packages/kit/src/routes/Tab/RootTabLoadingFallback.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 import { Page, Spinner, Stack, useMedia } from '@onekeyhq/components';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
@@ -20,16 +22,18 @@ type IRootTabLoadingFallbackProps = {
   tabRoute: ETabRoutes;
   sceneName?: EAccountSelectorSceneName;
   enabledNum?: number[];
+  mobileContentFallback?: ReactNode;
 };
 
 export function RootTabLoadingFallback({
   tabRoute,
   sceneName = EAccountSelectorSceneName.home,
   enabledNum = DEFAULT_ENABLED_NUM,
+  mobileContentFallback,
 }: IRootTabLoadingFallbackProps) {
   const media = useMedia();
 
-  if (platformEnv.isNative || media.md) {
+  if (platformEnv.isNative || (media.md && !mobileContentFallback)) {
     return (
       <>
         <Page.Header headerShown={false} />
@@ -47,7 +51,11 @@ export function RootTabLoadingFallback({
       enabledNum={enabledNum}
     >
       <TabPageHeader sceneName={sceneName} tabRoute={tabRoute} />
-      <LoadingSpinner />
+      {media.md && mobileContentFallback ? (
+        mobileContentFallback
+      ) : (
+        <LoadingSpinner />
+      )}
     </AccountSelectorProviderMirror>
   );
 }

--- a/packages/kit/src/views/Discovery/hooks/useMobileBottomBarAnimation.ts
+++ b/packages/kit/src/views/Discovery/hooks/useMobileBottomBarAnimation.ts
@@ -95,15 +95,12 @@ function useMobileBottomBarAnimation(activeTabId: string | null) {
         Math.round(contentOffsetY) > Math.round(scrollableHeight);
       const canScroll =
         Math.round(contentSize.height) >
-        Math.round(
-          layoutMeasurement.height + contentInset.top + contentInset.bottom,
-        ) +
-          MIN_TOGGLE_BROWSER_VISIBLE_DISTANCE +
-          fullBarHeight;
+        Math.round(layoutMeasurement.height) +
+          MIN_TOGGLE_BROWSER_VISIBLE_DISTANCE;
 
       runOnUI(processScroll)(contentOffsetY, canScroll, isOutOfBounds);
     },
-    [fullBarHeight, processScroll],
+    [processScroll],
   );
 
   const toolbarAnimatedStyle = useAnimatedStyle(() => ({

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -6,10 +6,8 @@ import { Freeze } from 'react-freeze';
 import {
   BackHandler,
   type LayoutChangeEvent,
-  type StyleProp,
   StyleSheet,
   View,
-  type ViewStyle,
 } from 'react-native';
 import Animated, { useSharedValue } from 'react-native-reanimated';
 
@@ -69,7 +67,6 @@ import { HandleRebuildBrowserData } from '../../components/HandleData/HandleRebu
 import HeaderRightToolBar from '../../components/HeaderRightToolBar';
 import MobileBrowserBottomBar from '../../components/MobileBrowser/MobileBrowserBottomBar';
 import { OuterTabPagerView } from '../../components/OuterTabPagerView';
-import { BROWSER_BOTTOM_BAR_HEIGHT } from '../../config/Animation.constants';
 import { useDAppNotifyChanges } from '../../hooks/useDAppNotifyChanges';
 // import { useEdgeSwipeDetection } from '../../hooks/useEdgeSwipeDetection';
 import useMobileBottomBarAnimation from '../../hooks/useMobileBottomBarAnimation';
@@ -112,6 +109,13 @@ const styles = StyleSheet.create({
   webPageRootLayer: {
     ...StyleSheet.absoluteFillObject,
     zIndex: 3,
+  },
+  webPageRootToolbar: {
+    position: 'absolute',
+    right: 0,
+    bottom: 0,
+    left: 0,
+    zIndex: 4,
   },
 });
 
@@ -404,7 +408,7 @@ function MobileBrowser() {
     [tabs, navigation, activeTabId],
   );
 
-  const { top, bottom } = useSafeAreaInsets();
+  const { top } = useSafeAreaInsets();
   // iOS 26: the Discover search bar opts into the Liquid Glass capsule (so it
   // matches the Wallet header's glass search bar) and is nudged down so its
   // center vertically aligns with the Wallet search bar — which sits centered in
@@ -514,13 +518,6 @@ function MobileBrowser() {
 
   const displayBottomBar = !showDiscoveryPage;
   const shouldShowRootWebPageLayer = useOuterPager && isBrowserWebPageVisible;
-  const rootWebPageLayerStyle: StyleProp<ViewStyle> = [
-    styles.webPageRootLayer,
-    {
-      bottom: BROWSER_BOTTOM_BAR_HEIGHT + bottom,
-      display: shouldShowRootWebPageLayer ? 'flex' : 'none',
-    },
-  ];
 
   return (
     <Page fullPage>
@@ -586,26 +583,12 @@ function MobileBrowser() {
                       <DashboardContent onScroll={handleScroll} />
                     </View>
                   </Stack>
-                  <Freeze freeze={!displayBottomBar}>
-                    <Animated.View
-                      style={[
-                        toolbarAnimatedStyle,
-                        {
-                          bottom: 0,
-                          left: 0,
-                          right: 0,
-                        },
-                      ]}
-                    >
-                      <MobileBrowserBottomBar
-                        id={activeTabId ?? ''}
-                        onGoBackHomePage={handleGoBackHome}
-                      />
-                    </Animated.View>
-                  </Freeze>
                 </Stack>
               }
             />
+            {/* Keep the native WebView full-height while the toolbar reveals or
+                covers its bottom edge. Resizing the WebView during a scroll
+                changes its viewport and causes a visible jump. */}
             <View
               collapsable={false}
               pointerEvents={shouldShowRootWebPageLayer ? 'auto' : 'none'}
@@ -613,10 +596,32 @@ function MobileBrowser() {
               importantForAccessibility={
                 shouldShowRootWebPageLayer ? 'auto' : 'no-hide-descendants'
               }
-              style={rootWebPageLayerStyle}
+              style={[
+                styles.webPageRootLayer,
+                {
+                  display: shouldShowRootWebPageLayer ? 'flex' : 'none',
+                },
+              ]}
             >
               {content}
             </View>
+            <Freeze freeze={!displayBottomBar}>
+              <Animated.View
+                pointerEvents={shouldShowRootWebPageLayer ? 'auto' : 'none'}
+                style={[
+                  styles.webPageRootToolbar,
+                  toolbarAnimatedStyle,
+                  {
+                    display: shouldShowRootWebPageLayer ? 'flex' : 'none',
+                  },
+                ]}
+              >
+                <MobileBrowserBottomBar
+                  id={activeTabId ?? ''}
+                  onGoBackHomePage={handleGoBackHome}
+                />
+              </Animated.View>
+            </Freeze>
           </>
         ) : (
           <>

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -102,6 +102,8 @@ function getExploreTabName(tab: ETranslations): IExploreTabName {
 }
 
 const styles = StyleSheet.create({
+  // iOS WKWebViews must stay in the native layout tree. In nested layouts,
+  // display:none can reload the page even though React keeps it mounted.
   webPageLayer: {
     ...StyleSheet.absoluteFillObject,
     zIndex: 3,
@@ -109,6 +111,14 @@ const styles = StyleSheet.create({
   webPageRootLayer: {
     ...StyleSheet.absoluteFillObject,
     zIndex: 3,
+  },
+  iosWebPageRootLayerVisible: {
+    opacity: 1,
+    zIndex: 3,
+  },
+  iosWebPageRootLayerHidden: {
+    opacity: 0,
+    zIndex: 0,
   },
   webPageRootToolbar: {
     position: 'absolute',
@@ -518,6 +528,16 @@ function MobileBrowser() {
 
   const displayBottomBar = !showDiscoveryPage;
   const shouldShowRootWebPageLayer = useOuterPager && isBrowserWebPageVisible;
+  const browserDashboardContent = (
+    <View
+      style={{
+        display: showDiscoveryPage ? 'flex' : 'none',
+        flex: showDiscoveryPage ? 1 : undefined,
+      }}
+    >
+      <DashboardContent onScroll={handleScroll} />
+    </View>
+  );
 
   return (
     <Page fullPage>
@@ -574,37 +594,35 @@ function MobileBrowser() {
               browserContent={
                 <Stack flex={1} zIndex={3}>
                   <Stack flex={1}>
-                    <View
-                      style={{
-                        display: showDiscoveryPage ? 'flex' : 'none',
-                        flex: showDiscoveryPage ? 1 : undefined,
-                      }}
-                    >
-                      <DashboardContent onScroll={handleScroll} />
-                    </View>
+                    {browserDashboardContent}
+                    {platformEnv.isNativeAndroid ? (
+                      <Freeze freeze={showDiscoveryPage}>{content}</Freeze>
+                    ) : null}
                   </Stack>
                 </Stack>
               }
             />
-            {/* Keep the native WebView full-height while the toolbar reveals or
-                covers its bottom edge. Resizing the WebView during a scroll
+            {/* Keep native WebViews full-height while the toolbar reveals or
+                covers their bottom edge. Resizing a WebView during scroll
                 changes its viewport and causes a visible jump. */}
-            <View
-              collapsable={false}
-              pointerEvents={shouldShowRootWebPageLayer ? 'auto' : 'none'}
-              accessibilityElementsHidden={!shouldShowRootWebPageLayer}
-              importantForAccessibility={
-                shouldShowRootWebPageLayer ? 'auto' : 'no-hide-descendants'
-              }
-              style={[
-                styles.webPageRootLayer,
-                {
-                  display: shouldShowRootWebPageLayer ? 'flex' : 'none',
-                },
-              ]}
-            >
-              {content}
-            </View>
+            {platformEnv.isNativeIOS ? (
+              <View
+                collapsable={false}
+                pointerEvents={shouldShowRootWebPageLayer ? 'auto' : 'none'}
+                accessibilityElementsHidden={!shouldShowRootWebPageLayer}
+                importantForAccessibility={
+                  shouldShowRootWebPageLayer ? 'auto' : 'no-hide-descendants'
+                }
+                style={[
+                  styles.webPageRootLayer,
+                  shouldShowRootWebPageLayer
+                    ? styles.iosWebPageRootLayerVisible
+                    : styles.iosWebPageRootLayerHidden,
+                ]}
+              >
+                {content}
+              </View>
+            ) : null}
             <Freeze freeze={!displayBottomBar}>
               <Animated.View
                 pointerEvents={shouldShowRootWebPageLayer ? 'auto' : 'none'}

--- a/packages/kit/src/views/Discovery/pages/Browser/MobileBrowserContent.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/MobileBrowserContent.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { Freeze } from 'react-freeze';
 import { StyleSheet, View } from 'react-native';
 import ViewShot from 'react-native-view-shot';
 
@@ -17,8 +18,17 @@ import {
 import { captureViewRefs } from '../../utils/explorerUtils';
 
 const styles = StyleSheet.create({
+  // Opacity preserves the iOS WKWebView instance when switching tabs.
   webPageLayer: {
     ...StyleSheet.absoluteFillObject,
+  },
+  iosWebPageLayerVisible: {
+    opacity: 1,
+    zIndex: 1,
+  },
+  iosWebPageLayerHidden: {
+    opacity: 0,
+    zIndex: 0,
   },
 });
 
@@ -103,6 +113,37 @@ function MobileBrowserContent({
     if (!keepAlive || !shouldMountWebView) {
       return null;
     }
+    const webView = (
+      <ViewShot ref={initCaptureViewRef} style={{ flex: 1 }}>
+        <Stack
+          flex={1}
+          mt="$3"
+          // https://github.com/gre/react-native-view-shot/issues/7
+          collapsable={platformEnv.isNativeAndroid ? false : undefined}
+          bg={platformEnv.isNativeAndroid ? '$bgApp' : undefined}
+        >
+          <WebContent
+            id={tab.id}
+            url={webViewInitialUrl}
+            siteMode={tab.siteMode}
+            isCurrent={isCurrent}
+            setBackEnabled={setBackEnabled}
+            setForwardEnabled={setForwardEnabled}
+            onScroll={onScroll}
+            customReceiveHandler={customReceiveHandler}
+          />
+        </Stack>
+      </ViewShot>
+    );
+
+    if (platformEnv.isNativeAndroid) {
+      return (
+        <Freeze key={tab.id} freeze={!isActive}>
+          {webView}
+        </Freeze>
+      );
+    }
+
     return (
       <View
         key={tab.id}
@@ -110,28 +151,14 @@ function MobileBrowserContent({
         pointerEvents={isActive ? 'auto' : 'none'}
         accessibilityElementsHidden={!isActive}
         importantForAccessibility={isActive ? 'auto' : 'no-hide-descendants'}
-        style={[styles.webPageLayer, { display: isActive ? 'flex' : 'none' }]}
+        style={[
+          styles.webPageLayer,
+          isActive
+            ? styles.iosWebPageLayerVisible
+            : styles.iosWebPageLayerHidden,
+        ]}
       >
-        <ViewShot ref={initCaptureViewRef} style={{ flex: 1 }}>
-          <Stack
-            flex={1}
-            mt="$3"
-            // https://github.com/gre/react-native-view-shot/issues/7
-            collapsable={platformEnv.isNativeAndroid ? false : undefined}
-            bg={platformEnv.isNativeAndroid ? '$bgApp' : undefined}
-          >
-            <WebContent
-              id={tab.id}
-              url={webViewInitialUrl}
-              siteMode={tab.siteMode}
-              isCurrent={isCurrent}
-              setBackEnabled={setBackEnabled}
-              setForwardEnabled={setForwardEnabled}
-              onScroll={onScroll}
-              customReceiveHandler={customReceiveHandler}
-            />
-          </Stack>
-        </ViewShot>
+        {webView}
       </View>
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.test.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.test.ts
@@ -140,6 +140,96 @@ describe('buildMergedAllNetworkSnapshot', () => {
     expect(snap.orderedTokens.map((t) => t.$key)).toEqual(['dup']);
   });
 
+  it('does not double a cache-floor round worth whose groups share one map', () => {
+    // seedAndFlushCache builds cache-floor rounds with the ONE cached full
+    // tokenListMap as tokens.map, smallBalanceTokens.map AND riskTokens.map
+    // (the cache stores a single merged map). The per-round worth must count
+    // each $key once — summing tokens.map + smallBalanceTokens.map verbatim
+    // doubled every cache-floor network on the Home total (desktop "assets
+    // doubled" report, ticket 906970).
+    const fullCachedMap = {
+      usdt: makeFiat('5000'),
+      trx: makeFiat('150'),
+    };
+    const rounds: IAllNetworkSnapshotRound[] = [
+      makeRound({
+        networkId: 'tron--0.9',
+        accountId: 'acc1',
+        tokens: {
+          data: [makeToken('usdt'), makeToken('trx')],
+          keys: 'k',
+          map: fullCachedMap,
+        },
+        smallBalanceTokens: { data: [], keys: '', map: fullCachedMap },
+        riskTokens: { data: [], keys: '', map: fullCachedMap },
+      }),
+    ];
+
+    const snap = buildMergedAllNetworkSnapshot({
+      rounds,
+      mergeDeriveAssetsByNetworkId: {},
+      accountId: 'acc1',
+    });
+
+    expect(
+      snap.accountsWorth[
+        accountUtils.buildAccountValueKey({
+          accountId: 'acc1',
+          networkId: 'tron--0.9',
+        })
+      ],
+    ).toBe('5150');
+  });
+
+  it('prefers the explicit round accountWorth so risk-only keys stay out of the worth', () => {
+    // Cache-floor rounds share the ONE cached full tokenListMap — which also
+    // holds risk-only entries — across all three group maps. Per-$key dedup
+    // fixes the doubling, but a map-derived sum would still count risk-only
+    // keys, while the cached tokenListValue counts tokens + smallBalanceTokens
+    // only. The explicit accountWorth must win so the authoritative snapshot
+    // matches the cache-hydrate overview write.
+    const fullCachedMap = {
+      usdt: makeFiat('5000'),
+      trx: makeFiat('150'),
+      scam: makeFiat('999'),
+    };
+    const rounds: IAllNetworkSnapshotRound[] = [
+      makeRound({
+        networkId: 'tron--0.9',
+        accountId: 'acc1',
+        accountWorth: '5150',
+        tokens: {
+          data: [makeToken('usdt'), makeToken('trx')],
+          keys: 'k',
+          map: fullCachedMap,
+        },
+        smallBalanceTokens: { data: [], keys: '', map: fullCachedMap },
+        riskTokens: {
+          data: [makeToken('scam')],
+          keys: 'kr',
+          map: fullCachedMap,
+        },
+      }),
+    ];
+
+    const snap = buildMergedAllNetworkSnapshot({
+      rounds,
+      mergeDeriveAssetsByNetworkId: {},
+      accountId: 'acc1',
+    });
+
+    expect(
+      snap.accountsWorth[
+        accountUtils.buildAccountValueKey({
+          accountId: 'acc1',
+          networkId: 'tron--0.9',
+        })
+      ],
+    ).toBe('5150');
+    // the explicit worth also feeds the createAtNetworkWorth accumulation
+    expect(new BigNumber(snap.createAtNetworkWorth).toNumber()).toBe(5150);
+  });
+
   it('carries and sorts the risky slice', () => {
     const rounds: IAllNetworkSnapshotRound[] = [
       makeRound({

--- a/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/buildMergedAllNetworkSnapshot.ts
@@ -15,6 +15,7 @@ import {
 } from '@onekeyhq/shared/src/utils/tokenUtils';
 import {
   isUnavailableOrZeroFiatValue,
+  isValidNumberValue,
   sumFiatValuesFromTokens,
   sumTokenGroupsFiatValueIgnoringUnavailable,
 } from '@onekeyhq/shared/src/utils/tokenValueUtils';
@@ -54,6 +55,15 @@ export interface IAllNetworkSnapshotRound {
    * round, not be looked up per-networkId.
    */
   mergeDeriveAssets?: boolean;
+  /**
+   * Explicit precomputed worth for THIS round, taking precedence over the
+   * map-derived sum. Cache-floor rounds
+   * (useTokenListReactivePipeline.seedAndFlushCache) MUST carry the cached
+   * `tokenListValue` (tokens + smallBalanceTokens only): their three group
+   * maps share the ONE cached full tokenListMap, so a map-derived sum would
+   * leak risk-only keys into the account worth even after per-$key dedup.
+   */
+  accountWorth?: string;
 }
 
 /**
@@ -197,7 +207,13 @@ export function buildMergedAllNetworkSnapshot({
       mergeDeriveAssets: mergeDeriveAssetsEnabled,
     });
 
-    const accountWorth = sumTokenGroupsFiatValueIgnoringUnavailable(r);
+    // Prefer the round's explicit precomputed worth (see the
+    // `IAllNetworkSnapshotRound.accountWorth` contract): summing a cache-floor
+    // round's maps would count risk-only keys the cached tokenListValue
+    // deliberately excludes.
+    const accountWorth = isValidNumberValue(r.accountWorth)
+      ? r.accountWorth
+      : sumTokenGroupsFiatValueIgnoringUnavailable(r);
 
     accountsWorth[
       accountUtils.buildAccountValueKey({

--- a/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.test.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.test.ts
@@ -18,6 +18,8 @@ import type { MutableRefObject } from 'react';
 
 import { act, renderHook } from '@testing-library/react';
 
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
+
 const mockIngestRound = jest.fn();
 const mockGetVaultSettings = jest.fn(async () => ({
   mergeDeriveAssetsEnabled: false,
@@ -350,6 +352,64 @@ describe('useTokenListReactivePipeline', () => {
     expect(
       (mockIngestRound.mock.calls[0][0] as { source: string }).source,
     ).toBe('authoritative');
+  });
+
+  it('cache seed: explicit tokenListValue keeps risk-only map keys out of the worth', async () => {
+    // The cache stores ONE full tokenListMap (normal + small + risk entries)
+    // that seedAndFlushCache reuses for all three group maps. The cached
+    // tokenListValue counts tokens + smallBalanceTokens only, so it must be
+    // carried as the round's explicit accountWorth — a map-derived sum would
+    // add risk-only keys and write the authoritative worth too high.
+    const { result } = render(true);
+    act(() => {
+      result.current.setEnabledKeys([OWNER]);
+    });
+    let worth: string | undefined;
+    await act(async () => {
+      await result.current.seedAndFlushCache({
+        data: [
+          makeCacheItem({
+            riskyTokenList: [
+              {
+                $key: 'scam',
+                name: 'Scam',
+                symbol: 'SCAM',
+                decimals: 18,
+                address: '0xscam',
+                isNative: false,
+              },
+            ] as ICacheSeedItem['riskyTokenList'],
+            tokenListMap: {
+              a1: {
+                balance: '1',
+                balanceParsed: '1',
+                fiatValue: '10',
+                price: 1,
+              },
+              scam: {
+                balance: '1',
+                balanceParsed: '1',
+                fiatValue: '999',
+                price: 1,
+              },
+            },
+            tokenListValue: '10',
+          }),
+        ],
+        accountId: OWNER.accountId,
+        networkId: OWNER.networkId,
+        generation: 1,
+      });
+      const snap = await result.current.buildAuthoritativeSnapshot();
+      worth =
+        snap.accountsWorth[
+          accountUtils.buildAccountValueKey({
+            accountId: OWNER.accountId,
+            networkId: OWNER.networkId,
+          })
+        ];
+    });
+    expect(worth).toBe('10');
   });
 
   it('P1-g: a throttled live flush is SUPERSEDED by an authoritative commit (epoch bump)', async () => {

--- a/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.ts
+++ b/packages/kit/src/views/Home/components/TokenListBlock/useTokenListReactivePipeline.ts
@@ -81,6 +81,14 @@ export interface ICacheSeedItem {
   smallBalanceTokenList: IAccountToken[];
   riskyTokenList: IAccountToken[];
   tokenListMap: Record<string, ITokenFiat>;
+  /**
+   * Cached per-network worth counting tokens + smallBalanceTokens ONLY (risk
+   * excluded — ServiceToken computes it from the two group fiat subtotals).
+   * Seeded onto the floor round as its explicit `accountWorth` because the
+   * shared full `tokenListMap` below also contains risk-only entries a
+   * map-derived sum would wrongly include. Optional: legacy caches predate it.
+   */
+  tokenListValue?: string;
   aggregateTokenListMap?: { [key: string]: { tokens: IAccountToken[] } };
   aggregateTokenMap?: Record<string, ITokenFiat>;
   accountId: string;
@@ -368,6 +376,7 @@ export function useTokenListReactivePipeline(
               keys: item.riskyTokenList.map((t) => t.$key).join(','),
               map: item.tokenListMap,
             },
+            accountWorth: item.tokenListValue,
             aggregateTokenListMap: item.aggregateTokenListMap,
             aggregateTokenMap: item.aggregateTokenMap,
             ownerAccountId,

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -34,6 +34,10 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
@@ -545,6 +549,7 @@ export function HomePageView({
   }, [tabConfigs]);
 
   const switchToPerpsWebTab = useCallback(() => {
+    setPerpPageEnterSource(EPerpPageEnterSource.Home);
     navigation.switchTab(ETabRoutes.WebviewPerpTrade);
   }, [navigation]);
 

--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -47,6 +47,10 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import {
+  EPerpPageEnterSource,
+  setPerpPageEnterSource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ERootRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
@@ -168,6 +172,7 @@ function useOpenPerpAsset() {
         if (infoPanelTab) {
           await perpsPendingInfoPanelTabAtom.set(infoPanelTab);
         }
+        setPerpPageEnterSource(EPerpPageEnterSource.Home);
         navigation.switchTab(ETabRoutes.Perp);
         if (!coin) {
           return;

--- a/packages/kit/src/views/Market/MarketHomeV2/MarketHomeV2.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/MarketHomeV2.tsx
@@ -31,6 +31,7 @@ import { preloadMarketHomeTokenListSeed } from '../utils/marketHomeTokenListSeed
 import { markMarketPerf } from '../utils/marketPerf';
 import { useMarketRenderCommitProbe } from '../utils/marketReactPerf';
 
+import { MarketHomeLoadingFallback } from './components/MarketHomeLoadingFallback';
 import { useNetworkAnalytics, useTabAnalytics } from './hooks';
 import { DesktopLayout } from './layouts/DesktopLayout';
 import { shouldRestoreSpotCategoryFromAtom } from './layouts/marketTabSelectionGuards';
@@ -310,7 +311,9 @@ function BaseMarketHomeLayout() {
 
   if (shouldWaitForSpotCategoryReady) {
     return (
-      <LazyPageContainer eager={platformEnv.isWeb}>{null}</LazyPageContainer>
+      <LazyPageContainer eager={platformEnv.isWeb}>
+        {md && !platformEnv.isNative ? <MarketHomeLoadingFallback /> : null}
+      </LazyPageContainer>
     );
   }
 

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketHomeLoadingFallback.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketHomeLoadingFallback.tsx
@@ -1,0 +1,58 @@
+import {
+  Divider,
+  Skeleton,
+  Spinner,
+  Stack,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
+
+const MARKET_HOME_TAB_BAR_HEIGHT = 44;
+const MARKET_HOME_BANNER_HEIGHT = 134;
+const MARKET_HOME_BANNER_ITEM_HEIGHT = 118;
+const MARKET_HOME_BANNER_ITEM_WIDTH = 128;
+const BANNER_SKELETON_COUNT = 3;
+const TAB_LABEL_SKELETON_WIDTHS = [32, 32, 32, 32] as const;
+
+export function MarketHomeLoadingFallback() {
+  return (
+    <YStack flex={1} bg="$bgApp" testID="market-home-loading-fallback">
+      <XStack
+        h={MARKET_HOME_BANNER_HEIGHT}
+        flexShrink={0}
+        alignItems="center"
+        px="$4"
+        py="$2"
+        gap="$3"
+        overflow="hidden"
+        testID="market-home-banner-skeleton"
+      >
+        {Array.from({ length: BANNER_SKELETON_COUNT }, (_, index) => (
+          <Skeleton
+            key={index}
+            h={MARKET_HOME_BANNER_ITEM_HEIGHT}
+            w={MARKET_HOME_BANNER_ITEM_WIDTH}
+            flexShrink={0}
+            radius={12}
+          />
+        ))}
+      </XStack>
+      <YStack flexShrink={0} testID="market-home-tab-bar-skeleton">
+        <XStack
+          h={MARKET_HOME_TAB_BAR_HEIGHT}
+          alignItems="center"
+          px="$5"
+          gap="$5"
+        >
+          {TAB_LABEL_SKELETON_WIDTHS.map((width, index) => (
+            <Skeleton key={index} h="$4" w={width} radius="round" />
+          ))}
+        </XStack>
+        <Divider />
+      </YStack>
+      <Stack flex={1} alignItems="center" justifyContent="center">
+        <Spinner size="large" />
+      </Stack>
+    </YStack>
+  );
+}

--- a/packages/kit/src/views/Onboarding/components/PhaseInputArea.tsx
+++ b/packages/kit/src/views/Onboarding/components/PhaseInputArea.tsx
@@ -48,10 +48,15 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import useRecoveryPhraseProtected from '@onekeyhq/kit/src/hooks/useRecoveryPhraseProtected';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import { parseSecretRecoveryPhrase } from '@onekeyhq/shared/src/utils/phrase';
+import { parseSecretRecoveryPhraseToWords } from '@onekeyhq/shared/src/utils/phrase';
 import type { EMnemonicType } from '@onekeyhq/shared/src/utils/secret';
 
-import { PHRASE_LENGTHS, useSuggestion } from './hooks';
+import {
+  PHRASE_LENGTHS,
+  getMnemonicPasteWordsFromChangeText,
+} from '../utils/mnemonicPasteUtils';
+
+import { useSuggestion } from './hooks';
 
 import type { ReturnKeyTypeOptions, TextInput, ViewProps } from 'react-native';
 
@@ -202,7 +207,6 @@ function BasicPhaseInput(
     onChange,
     value,
     isShowError = false,
-    phraseLength,
     onInputChange,
     onInputFocus,
     onInputBlur,
@@ -218,12 +222,11 @@ function BasicPhaseInput(
   }: IPropsWithTestId<{
     value?: string;
     index: number;
-    phraseLength: number;
     isShowError: boolean;
     onInputChange: (value: string) => string;
     onChange?: (value: string) => void;
     onInputFocus: (index: number) => void;
-    onPasteMnemonic: (text: string, index: number) => boolean;
+    onPasteMnemonic: (words: string[], index: number) => boolean;
     onInputBlur: (index: number) => void;
     suggestionsRef: RefObject<string[]>;
     selectInputIndex: number;
@@ -261,13 +264,13 @@ function BasicPhaseInput(
 
   const handleChangeText = useCallback(
     (v: string) => {
-      // Supports inputting mnemonic phrases via drag-and-drop text or toolbar of keyboard, such as 1Password.
-      const trimmedValue = v ? parseSecretRecoveryPhrase(v) : '';
-      if (
-        trimmedValue &&
-        trimmedValue.split(' ').filter(Boolean).length === phraseLength
-      ) {
-        if (onPasteMnemonic(trimmedValue, 0)) {
+      // Native fallback for multi-word input from keyboard toolbars such as 1Password.
+      const phraseWords = getMnemonicPasteWordsFromChangeText({
+        value: v,
+        isNative: platformEnv.isNative,
+      });
+      if (phraseWords) {
+        if (onPasteMnemonic(phraseWords, 0)) {
           onInputChange('');
           onChange?.('');
           return;
@@ -278,7 +281,7 @@ function BasicPhaseInput(
       const text = onInputChange(rawText);
       onChange?.(text);
     },
-    [onChange, onInputChange, onPasteMnemonic, phraseLength],
+    [onChange, onInputChange, onPasteMnemonic],
   );
 
   const handleOpenChange = useCallback(
@@ -312,7 +315,10 @@ function BasicPhaseInput(
       if (!platformEnv.isNative) {
         const item = event.nativeEvent?.items?.[0];
         if (item?.type === EPasteEventPayloadItemType.TextPlain && item.data) {
-          onPasteMnemonic(parseSecretRecoveryPhrase(item?.data || ''), index);
+          onPasteMnemonic(
+            parseSecretRecoveryPhraseToWords(item?.data || ''),
+            index,
+          );
         }
       }
     },
@@ -613,7 +619,6 @@ export function PhaseInputArea({
                     index={index}
                     isShowError={isShowErrors[index]}
                     onInputBlur={onInputBlur}
-                    phraseLength={phraseLengthNumber}
                     onInputChange={onInputChange}
                     onInputFocus={onInputFocus}
                     onPasteMnemonic={onPasteMnemonic}

--- a/packages/kit/src/views/Onboarding/components/hooks.ts
+++ b/packages/kit/src/views/Onboarding/components/hooks.ts
@@ -9,9 +9,15 @@ import { dismissKeyboard } from '@onekeyhq/shared/src/keyboard';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
-const isValidWord = (word: string) => wordLists.includes(word);
+import {
+  buildPhraseFormValues,
+  getInvalidWordErrors,
+  mergePastedPhraseWords,
+  resolvePhraseLengthAfterPaste,
+} from '../utils/mnemonicPasteUtils';
 
-export const PHRASE_LENGTHS = [12, 15, 18, 21, 24];
+const wordListSet = new Set(wordLists);
+const isValidWord = (word: string) => wordListSet.has(word);
 export const useSearchWords = () => {
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const ref = useRef(new Map<string, string[]>());
@@ -69,19 +75,6 @@ export const useSuggestion = (
   const openStatusRef = useRef(false);
 
   const updateByPressLock = useRef(false);
-
-  const checkAllWords = useCallback(() => {
-    const values = form.getValues() as Record<string, string>;
-    const errors: Record<string, boolean> = {};
-    for (let i = 0; i < phraseLength; i += 1) {
-      const key = `phrase${i + 1}`;
-      const value = values[key];
-      if (value && !isValidWord(value)) {
-        errors[i] = true;
-      }
-    }
-    setIsShowErrors(errors);
-  }, [form, phraseLength]);
 
   const checkIsValidWord = useCallback(
     (index: number, text?: string, isBlur = false) => {
@@ -246,52 +239,41 @@ export const useSuggestion = (
   const { clearText } = useClipboard();
 
   const onPasteMnemonic = useCallback(
-    (value: string, inputIndex: number) => {
-      const arrays = value.trim().split(' ');
-      if (arrays.length > 1) {
-        Haptics.success();
-        let currentPhraseLength = phraseLength;
-        setTimeout(async () => {
-          clearText();
-          if (
-            PHRASE_LENGTHS.includes(arrays.length) &&
-            arrays.length > currentPhraseLength
-          ) {
-            currentPhraseLength = arrays.length;
-            setPhraseLength(currentPhraseLength.toString());
-            await timerUtils.wait(30);
-          }
-          const formValues = Object.values(form.getValues());
-          const values: string[] = formValues.slice(0, inputIndex);
-          const words = [...values, ...arrays].slice(0, currentPhraseLength);
-          if (words.length < currentPhraseLength) {
-            words.push(...formValues.slice(words.length, currentPhraseLength));
-          }
-          form.reset(
-            words.reduce(
-              (prev, next, index) => {
-                prev[`phrase${index + 1}`] = next;
-                return prev;
-              },
-              {} as Record<`phrase${number}`, string>,
-            ),
-          );
-          resetSuggestions();
-          await timerUtils.wait(10);
-          checkAllWords();
-        }, 30);
-        return true;
+    (pastedWords: string[], inputIndex: number) => {
+      const currentPhraseLength = resolvePhraseLengthAfterPaste({
+        pastedWordCount: pastedWords.length,
+        currentPhraseLength: phraseLength,
+        inputIndex,
+      });
+      if (currentPhraseLength === null) {
+        return false;
       }
-      return false;
+
+      Haptics.success();
+      setTimeout(() => {
+        clearText();
+        const currentValues = form.getValues() as Record<string, string>;
+        const currentWords = Array.from(
+          { length: phraseLength },
+          (_, index) => currentValues[`phrase${index + 1}`] ?? '',
+        );
+        const words = mergePastedPhraseWords({
+          currentWords,
+          pastedWords,
+          inputIndex,
+          phraseLength: currentPhraseLength,
+        });
+
+        form.reset(buildPhraseFormValues(words));
+        if (currentPhraseLength !== phraseLength) {
+          setPhraseLength(currentPhraseLength.toString());
+        }
+        resetSuggestions();
+        setIsShowErrors(getInvalidWordErrors(words, wordListSet));
+      }, 30);
+      return true;
     },
-    [
-      checkAllWords,
-      clearText,
-      form,
-      phraseLength,
-      resetSuggestions,
-      setPhraseLength,
-    ],
+    [clearText, form, phraseLength, resetSuggestions, setPhraseLength],
   );
 
   const closePopover = useCallback(() => {

--- a/packages/kit/src/views/Onboarding/utils/mnemonicPasteUtils.test.ts
+++ b/packages/kit/src/views/Onboarding/utils/mnemonicPasteUtils.test.ts
@@ -1,0 +1,129 @@
+import {
+  buildPhraseFormValues,
+  getInvalidWordErrors,
+  getMnemonicPasteWordsFromChangeText,
+  mergePastedPhraseWords,
+  resolvePhraseLengthAfterPaste,
+} from './mnemonicPasteUtils';
+
+describe('mnemonicPasteUtils', () => {
+  it('uses change text as a paste fallback only on native', () => {
+    const value = Array.from({ length: 12 }, () => 'abandon').join(' ');
+
+    expect(
+      getMnemonicPasteWordsFromChangeText({ value, isNative: false }),
+    ).toBeNull();
+    expect(
+      getMnemonicPasteWordsFromChangeText({ value, isNative: true }),
+    ).toHaveLength(12);
+    expect(
+      getMnemonicPasteWordsFromChangeText({
+        value: 'abandon',
+        isNative: true,
+      }),
+    ).toBeNull();
+  });
+
+  it('updates the selected phrase length for a full phrase replacement', () => {
+    expect(
+      resolvePhraseLengthAfterPaste({
+        pastedWordCount: 15,
+        currentPhraseLength: 12,
+        inputIndex: 0,
+      }),
+    ).toBe(15);
+    expect(
+      resolvePhraseLengthAfterPaste({
+        pastedWordCount: 12,
+        currentPhraseLength: 24,
+        inputIndex: 0,
+      }),
+    ).toBe(12);
+  });
+
+  it('rejects a non-standard word count', () => {
+    expect(
+      resolvePhraseLengthAfterPaste({
+        pastedWordCount: 13,
+        currentPhraseLength: 12,
+        inputIndex: 0,
+      }),
+    ).toBeNull();
+  });
+
+  it('keeps the selected length when a non-first paste fits', () => {
+    expect(
+      resolvePhraseLengthAfterPaste({
+        pastedWordCount: 12,
+        currentPhraseLength: 24,
+        inputIndex: 1,
+      }),
+    ).toBe(24);
+  });
+
+  it('rejects a non-first paste that would overflow the current phrase', () => {
+    expect(
+      resolvePhraseLengthAfterPaste({
+        pastedWordCount: 12,
+        currentPhraseLength: 12,
+        inputIndex: 1,
+      }),
+    ).toBeNull();
+  });
+
+  it('builds every dynamic field before the phrase length changes', () => {
+    const pastedWords = Array.from(
+      { length: 21 },
+      (_, index) => `word-${index + 1}`,
+    );
+    const words = mergePastedPhraseWords({
+      currentWords: Array.from({ length: 12 }, () => ''),
+      pastedWords,
+      inputIndex: 0,
+      phraseLength: 21,
+    });
+
+    expect(buildPhraseFormValues(words)).toMatchObject({
+      phrase1: 'word-1',
+      phrase12: 'word-12',
+      phrase13: 'word-13',
+      phrase21: 'word-21',
+    });
+  });
+
+  it('overwrites only the pasted range for a non-first paste', () => {
+    const words = mergePastedPhraseWords({
+      currentWords: Array.from(
+        { length: 24 },
+        (_, index) => `current-${index + 1}`,
+      ),
+      pastedWords: Array.from(
+        { length: 12 },
+        (_, index) => `pasted-${index + 1}`,
+      ),
+      inputIndex: 1,
+      phraseLength: 24,
+    });
+
+    expect(words[0]).toBe('current-1');
+    expect(words[1]).toBe('pasted-1');
+    expect(words[12]).toBe('pasted-12');
+    expect(words[13]).toBe('current-14');
+    expect(words).toHaveLength(24);
+  });
+
+  it('checks invalid words across the entire pasted phrase', () => {
+    const words = [
+      ...Array.from({ length: 12 }, () => 'valid'),
+      'invalid-13',
+      'invalid-14',
+      'invalid-15',
+    ];
+
+    expect(getInvalidWordErrors(words, new Set(['valid']))).toEqual({
+      12: true,
+      13: true,
+      14: true,
+    });
+  });
+});

--- a/packages/kit/src/views/Onboarding/utils/mnemonicPasteUtils.ts
+++ b/packages/kit/src/views/Onboarding/utils/mnemonicPasteUtils.ts
@@ -1,0 +1,87 @@
+import { parseSecretRecoveryPhraseToWords } from '@onekeyhq/shared/src/utils/phrase';
+
+export const PHRASE_LENGTHS = [12, 15, 18, 21, 24] as const;
+
+export function getMnemonicPasteWordsFromChangeText({
+  value,
+  isNative,
+}: {
+  value: string;
+  isNative?: boolean;
+}) {
+  // Web receives a separate paste event with the actual input index.
+  if (!isNative) {
+    return null;
+  }
+
+  const phraseWords = value ? parseSecretRecoveryPhraseToWords(value) : [];
+  return phraseWords.length > 1 ? phraseWords : null;
+}
+
+export function resolvePhraseLengthAfterPaste({
+  pastedWordCount,
+  currentPhraseLength,
+  inputIndex,
+}: {
+  pastedWordCount: number;
+  currentPhraseLength: number;
+  inputIndex: number;
+}) {
+  if (
+    !PHRASE_LENGTHS.includes(pastedWordCount as (typeof PHRASE_LENGTHS)[number])
+  ) {
+    return null;
+  }
+
+  if (inputIndex === 0) {
+    return pastedWordCount;
+  }
+
+  return inputIndex + pastedWordCount <= currentPhraseLength
+    ? currentPhraseLength
+    : null;
+}
+
+export function mergePastedPhraseWords({
+  currentWords,
+  pastedWords,
+  inputIndex,
+  phraseLength,
+}: {
+  currentWords: string[];
+  pastedWords: string[];
+  inputIndex: number;
+  phraseLength: number;
+}) {
+  const words = [...currentWords];
+  pastedWords.forEach((word, index) => {
+    words[inputIndex + index] = word;
+  });
+
+  return Array.from({ length: phraseLength }, (_, index) => words[index] ?? '');
+}
+
+export function buildPhraseFormValues(words: string[]) {
+  return words.reduce(
+    (values, word, index) => {
+      values[`phrase${index + 1}`] = word;
+      return values;
+    },
+    {} as Record<`phrase${number}`, string>,
+  );
+}
+
+export function getInvalidWordErrors(
+  words: string[],
+  validWords: ReadonlySet<string>,
+) {
+  return words.reduce(
+    (errors, word, index) => {
+      if (word && !validWords.has(word)) {
+        errors[index] = true;
+      }
+      return errors;
+    },
+    {} as Record<string, boolean>,
+  );
+}

--- a/packages/kit/src/views/Onboardingv2/components/PhaseInputArea.tsx
+++ b/packages/kit/src/views/Onboardingv2/components/PhaseInputArea.tsx
@@ -48,12 +48,16 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import useRecoveryPhraseProtected from '@onekeyhq/kit/src/hooks/useRecoveryPhraseProtected';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import { parseSecretRecoveryPhrase } from '@onekeyhq/shared/src/utils/phrase';
+import { parseSecretRecoveryPhraseToWords } from '@onekeyhq/shared/src/utils/phrase';
 import type { EMnemonicType } from '@onekeyhq/shared/src/utils/secret';
 
+import {
+  PHRASE_LENGTHS,
+  getMnemonicPasteWordsFromChangeText,
+} from '../../Onboarding/utils/mnemonicPasteUtils';
 import { OnboardingTestIDs } from '../testIDs';
 
-import { PHRASE_LENGTHS, useSuggestion } from './useSuggestion';
+import { useSuggestion } from './useSuggestion';
 
 import type { ReturnKeyTypeOptions, TextInput, ViewProps } from 'react-native';
 
@@ -213,7 +217,6 @@ function BasicPhaseInput(
     onChange,
     value,
     isShowError = false,
-    phraseLength,
     onInputChange,
     onInputFocus,
     onInputBlur,
@@ -229,12 +232,11 @@ function BasicPhaseInput(
   }: IPropsWithTestId<{
     value?: string;
     index: number;
-    phraseLength: number;
     isShowError: boolean;
     onInputChange: (value: string) => string;
     onChange?: (value: string) => void;
     onInputFocus: (index: number) => void;
-    onPasteMnemonic: (text: string, index: number) => boolean;
+    onPasteMnemonic: (words: string[], index: number) => boolean;
     onInputBlur: (index: number) => void;
     suggestionsRef: RefObject<string[]>;
     selectInputIndex: number;
@@ -272,13 +274,13 @@ function BasicPhaseInput(
 
   const handleChangeText = useCallback(
     (v: string) => {
-      // Supports inputting mnemonic phrases via drag-and-drop text or toolbar of keyboard, such as 1Password.
-      const trimmedValue = v ? parseSecretRecoveryPhrase(v) : '';
-      if (
-        trimmedValue &&
-        trimmedValue.split(' ').filter(Boolean).length === phraseLength
-      ) {
-        if (onPasteMnemonic(trimmedValue, 0)) {
+      // Native fallback for multi-word input from keyboard toolbars such as 1Password.
+      const phraseWords = getMnemonicPasteWordsFromChangeText({
+        value: v,
+        isNative: platformEnv.isNative,
+      });
+      if (phraseWords) {
+        if (onPasteMnemonic(phraseWords, 0)) {
           onInputChange('');
           onChange?.('');
           return;
@@ -289,7 +291,7 @@ function BasicPhaseInput(
       const text = onInputChange(rawText);
       onChange?.(text);
     },
-    [onChange, onInputChange, onPasteMnemonic, phraseLength],
+    [onChange, onInputChange, onPasteMnemonic],
   );
 
   const handleOpenChange = useCallback(
@@ -323,7 +325,10 @@ function BasicPhaseInput(
       if (!platformEnv.isNative) {
         const item = event.nativeEvent?.items?.[0];
         if (item?.type === EPasteEventPayloadItemType.TextPlain && item.data) {
-          onPasteMnemonic(parseSecretRecoveryPhrase(item?.data || ''), index);
+          onPasteMnemonic(
+            parseSecretRecoveryPhraseToWords(item?.data || ''),
+            index,
+          );
         }
       }
     },
@@ -643,7 +648,6 @@ export function PhaseInputArea({
                   index={index}
                   isShowError={isShowErrors[index]}
                   onInputBlur={onInputBlur}
-                  phraseLength={phraseLengthNumber}
                   onInputChange={onInputChange}
                   onInputFocus={onInputFocus}
                   onPasteMnemonic={onPasteMnemonic}

--- a/packages/kit/src/views/Onboardingv2/components/useSuggestion.ts
+++ b/packages/kit/src/views/Onboardingv2/components/useSuggestion.ts
@@ -9,6 +9,13 @@ import { dismissKeyboard } from '@onekeyhq/shared/src/keyboard';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
+import {
+  buildPhraseFormValues,
+  getInvalidWordErrors,
+  mergePastedPhraseWords,
+  resolvePhraseLengthAfterPaste,
+} from '../../Onboarding/utils/mnemonicPasteUtils';
+
 // Force the BIP39 JSON module to evaluate synchronously at this module's
 // load time. With split-thread bundles the original `wordLists.includes(...)`
 // deferred evaluation until the first call inside setTimeout, and that
@@ -16,7 +23,6 @@ import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 const wordListSet = new Set(wordLists);
 const isValidWord = (word: string) => wordListSet.has(word);
 
-export const PHRASE_LENGTHS = [12, 15, 18, 21, 24];
 export const useSearchWords = () => {
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const ref = useRef(new Map<string, string[]>());
@@ -74,19 +80,6 @@ export const useSuggestion = (
   const openStatusRef = useRef(false);
 
   const updateByPressLock = useRef(false);
-
-  const checkAllWords = useCallback(() => {
-    const values = form.getValues() as Record<string, string>;
-    const errors: Record<string, boolean> = {};
-    for (let i = 0; i < phraseLength; i += 1) {
-      const key = `phrase${i + 1}`;
-      const value = values[key];
-      if (value && !isValidWord(value)) {
-        errors[i] = true;
-      }
-    }
-    setIsShowErrors(errors);
-  }, [form, phraseLength]);
 
   const checkIsValidWord = useCallback(
     (index: number, text?: string, isBlur = false) => {
@@ -251,52 +244,43 @@ export const useSuggestion = (
   const { clearText } = useClipboard();
 
   const onPasteMnemonic = useCallback(
-    (value: string, inputIndex: number) => {
-      const arrays = value.trim().split(' ');
-      if (arrays.length > 1) {
-        Haptics.success();
-        let currentPhraseLength = phraseLength;
-        setTimeout(async () => {
-          clearText();
-          if (
-            PHRASE_LENGTHS.includes(arrays.length) &&
-            arrays.length > currentPhraseLength
-          ) {
-            currentPhraseLength = arrays.length;
-            setPhraseLength(currentPhraseLength.toString());
-            await timerUtils.wait(30);
-          }
-          const formValues = Object.values(form.getValues());
-          const values: string[] = formValues.slice(0, inputIndex);
-          const words = [...values, ...arrays].slice(0, currentPhraseLength);
-          if (words.length < currentPhraseLength) {
-            words.push(...formValues.slice(words.length, currentPhraseLength));
-          }
-          form.reset(
-            words.reduce(
-              (prev, next, index) => {
-                prev[`phrase${index + 1}`] = next;
-                return prev;
-              },
-              {} as Record<`phrase${number}`, string>,
-            ),
-          );
-          resetSuggestions();
-          await timerUtils.wait(10);
-          checkAllWords();
-        }, 30);
-        return true;
+    (pastedWords: string[], inputIndex: number) => {
+      const currentPhraseLength = resolvePhraseLengthAfterPaste({
+        pastedWordCount: pastedWords.length,
+        currentPhraseLength: phraseLength,
+        inputIndex,
+      });
+      if (currentPhraseLength === null) {
+        return false;
       }
-      return false;
+
+      Haptics.success();
+      setTimeout(() => {
+        clearText();
+        const currentValues = form.getValues() as Record<string, string>;
+        const currentWords = Array.from(
+          { length: phraseLength },
+          (_, index) => currentValues[`phrase${index + 1}`] ?? '',
+        );
+        const words = mergePastedPhraseWords({
+          currentWords,
+          pastedWords,
+          inputIndex,
+          phraseLength: currentPhraseLength,
+        });
+
+        // Reset before mounting dynamic fields so Controllers read the
+        // pasted values instead of registering their empty defaults.
+        form.reset(buildPhraseFormValues(words));
+        if (currentPhraseLength !== phraseLength) {
+          setPhraseLength(currentPhraseLength.toString());
+        }
+        resetSuggestions();
+        setIsShowErrors(getInvalidWordErrors(words, wordListSet));
+      }, 30);
+      return true;
     },
-    [
-      checkAllWords,
-      clearText,
-      form,
-      phraseLength,
-      resetSuggestions,
-      setPhraseLength,
-    ],
+    [clearText, form, phraseLength, resetSuggestions, setPhraseLength],
   );
 
   const closePopover = useCallback(() => {

--- a/packages/kit/src/views/Perp/components/MarketDetail/PerpMarketDetailContent.tsx
+++ b/packages/kit/src/views/Perp/components/MarketDetail/PerpMarketDetailContent.tsx
@@ -21,6 +21,7 @@ import {
 } from '@onekeyhq/components';
 import { LightweightChart } from '@onekeyhq/kit/src/components/LightweightChart';
 import { Token } from '@onekeyhq/kit/src/components/Token';
+import { useStockSecurityStats } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/hooks/useStockSecurityStats';
 import { PerpTestIDs } from '@onekeyhq/kit/src/views/Perp/testIDs';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatDate } from '@onekeyhq/shared/src/utils/dateUtils';
@@ -289,28 +290,24 @@ function DetailInfoTable({
           justifyContent="space-between"
           gap="$4"
         >
-          {item.tooltip ? (
-            <Tooltip
-              placement="top"
-              renderTrigger={
-                <SizableText
-                  size="$bodyMd"
-                  color="$textSubdued"
-                  cursor="help"
-                  flex={1}
-                >
-                  {item.label}
-                </SizableText>
-              }
-              renderContent={
-                <SizableText size="$bodySm">{item.tooltip}</SizableText>
-              }
-            />
-          ) : (
-            <SizableText size="$bodyMd" color="$textSubdued" flex={1}>
-              {item.label}
-            </SizableText>
-          )}
+          <XStack flex={1} minWidth={0}>
+            {item.tooltip ? (
+              <DashText
+                size="$bodyMd"
+                color="$textSubdued"
+                dashColor="$borderStrong"
+                dashThickness={0.5}
+                tooltip={item.tooltip}
+                tooltipTitle={item.label}
+              >
+                {item.label}
+              </DashText>
+            ) : (
+              <SizableText size="$bodyMd" color="$textSubdued">
+                {item.label}
+              </SizableText>
+            )}
+          </XStack>
           <YStack flex={1} alignItems="flex-end" minWidth={0} gap="$0.5">
             <SizableText
               size="$bodyMdMedium"
@@ -691,16 +688,25 @@ export function PerpMarketDetailContent({
     | undefined;
 
   const marketDetail = resolvedMarketDetail.result?.detail;
+  const stockDetail = resolvedMarketDetail.result?.stockDetail;
   const localizedDescription = resolvedMarketDetail.result?.localizedMessage;
+  const {
+    assetAnalysisRows: stockAssetAnalysisRows,
+    tradingActivityRows: stockTradingActivityRows,
+    descriptionRows: stockDescriptionRows,
+  } = useStockSecurityStats(stockDetail?.stock);
   const marketDetailReferenceNote = intl.formatMessage({
     id: ETranslations.perp_market_info_reference_note__desc,
   });
 
   const aboutText = useMemo(
     () =>
-      sanitizeDescriptionText(localizedDescription || marketDetail?.about) ||
-      '',
-    [localizedDescription, marketDetail?.about],
+      sanitizeDescriptionText(
+        localizedDescription ||
+          stockDetail?.introduction ||
+          marketDetail?.about,
+      ) || '',
+    [localizedDescription, marketDetail?.about, stockDetail?.introduction],
   );
 
   const fundingHistoryItems = useMemo(
@@ -834,7 +840,9 @@ export function PerpMarketDetailContent({
 
   const renderInfoCombined = () => {
     const isInitialLoading = resolvedMarketDetail.isLoading;
-    const hasMarketInfoContent = Boolean(marketDetail || aboutText);
+    const hasMarketInfoContent = Boolean(
+      marketDetail || stockDetail || aboutText,
+    );
     const showRawSourceNote = Boolean(
       marketDetail?.about && !localizedDescription,
     );
@@ -1007,6 +1015,14 @@ export function PerpMarketDetailContent({
 
     const showDescriptionToggle = aboutText.length > 320;
     const hasAnyLinks = linkRows.some((item) => item.items.length > 0);
+    const stockAssetReferenceRows = [
+      ...stockDescriptionRows,
+      ...stockAssetAnalysisRows.flat(),
+    ];
+    const stockTradingReferenceRows = stockTradingActivityRows.flat();
+    const hasStockTradingActivity = stockTradingReferenceRows.some(
+      (item) => Boolean(item.value) && item.value !== '--',
+    );
     const renderReferenceNote = () => (
       <SizableText
         size="$bodyXs"
@@ -1032,14 +1048,52 @@ export function PerpMarketDetailContent({
             }
           />
           <SizableText size="$headingLg">
-            {displayName || marketDetail?.symbol?.toUpperCase() || coin || '--'}
+            {displayName ||
+              stockDetail?.ticker ||
+              marketDetail?.symbol?.toUpperCase() ||
+              coin ||
+              '--'}
           </SizableText>
-          {marketDetail?.name ? (
+          {stockDetail?.name || marketDetail?.name ? (
             <SizableText size="$bodyLg" color="$textSubdued">
-              {marketDetail.name}
+              {stockDetail?.name || marketDetail?.name}
             </SizableText>
           ) : null}
         </XStack>
+
+        {stockDetail ? (
+          <XStack
+            flexWrap="wrap"
+            gap="$6"
+            alignItems="flex-start"
+            $gtMd={{ flexWrap: 'nowrap', gap: '$16' } as any}
+          >
+            <YStack flex={1} flexBasis={0} minWidth={0} width="100%" gap="$2.5">
+              <SizableText size="$headingSm">
+                {intl.formatMessage({
+                  id: ETranslations.dexmarket_stock_asset_analysis,
+                })}
+              </SizableText>
+              <DetailInfoTable rows={stockAssetReferenceRows} />
+            </YStack>
+
+            <YStack flex={1} flexBasis={0} minWidth={0} width="100%" gap="$2.5">
+              {hasStockTradingActivity ? (
+                <SizableText size="$headingSm">
+                  {intl.formatMessage({
+                    id: ETranslations.dexmarket_stock_trading_activity,
+                  })}
+                </SizableText>
+              ) : null}
+              <YStack gap="$3">
+                {hasStockTradingActivity ? (
+                  <DetailInfoTable rows={stockTradingReferenceRows} />
+                ) : null}
+                {renderReferenceNote()}
+              </YStack>
+            </YStack>
+          </XStack>
+        ) : null}
 
         {marketDetail ? (
           <XStack
@@ -1153,7 +1207,7 @@ export function PerpMarketDetailContent({
                 />
               </XStack>
             ) : null}
-            {hasAnyLinks ? null : renderReferenceNote()}
+            {hasAnyLinks || stockDetail ? null : renderReferenceNote()}
           </YStack>
         ) : null}
       </YStack>

--- a/packages/kit/src/views/Perp/components/MarketDetail/PerpMarketIntroContent.tsx
+++ b/packages/kit/src/views/Perp/components/MarketDetail/PerpMarketIntroContent.tsx
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 
 import {
   Button,
+  DashText,
   Icon,
   Illustration,
   SizableText,
@@ -12,6 +13,7 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
+import { useStockSecurityStats } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/hooks/useStockSecurityStats';
 import { PerpTestIDs } from '@onekeyhq/kit/src/views/Perp/testIDs';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { formatDate } from '@onekeyhq/shared/src/utils/dateUtils';
@@ -104,16 +106,19 @@ type IIntroInfoItemData = {
   label: string;
   value: string;
   secondaryValue?: string;
+  tooltip?: string;
 };
 
 function IntroInfoItem({
   label,
   value,
   secondaryValue,
+  tooltip,
 }: {
   label: string;
   value: string;
   secondaryValue?: string;
+  tooltip?: string;
 }) {
   if (!value || value === '--') {
     return null;
@@ -121,9 +126,23 @@ function IntroInfoItem({
 
   return (
     <YStack flex={1} flexBasis={0} minWidth={0} gap="$1">
-      <SizableText size="$bodyMd" color="$textSubdued" numberOfLines={1}>
-        {label}
-      </SizableText>
+      {tooltip ? (
+        <DashText
+          size="$bodyMd"
+          color="$textSubdued"
+          dashColor="$borderStrong"
+          dashThickness={0.5}
+          tooltip={tooltip}
+          tooltipTitle={label}
+          numberOfLines={1}
+        >
+          {label}
+        </DashText>
+      ) : (
+        <SizableText size="$bodyMd" color="$textSubdued" numberOfLines={1}>
+          {label}
+        </SizableText>
+      )}
       <SizableText size="$headingSm" numberOfLines={1}>
         {value}
       </SizableText>
@@ -137,6 +156,49 @@ function IntroInfoItem({
           {secondaryValue}
         </SizableText>
       ) : null}
+    </YStack>
+  );
+}
+
+function IntroInfoRows({
+  rows,
+}: {
+  rows: Array<
+    Array<{
+      label: string;
+      value: string;
+      tooltip?: string;
+    }>
+  >;
+}) {
+  const visibleRows = rows.filter((row) =>
+    row.some((item) => item.value && item.value !== '--'),
+  );
+
+  return (
+    <YStack gap="$4">
+      {visibleRows.map((row) => (
+        <XStack
+          key={row[0]?.label}
+          gap={INTRO_INFO_COLUMN_GAP}
+          justifyContent="space-between"
+          alignItems="flex-start"
+        >
+          {row.map((item) =>
+            item.value && item.value !== '--' ? (
+              <IntroInfoItem
+                key={item.label}
+                label={item.label}
+                value={item.value}
+                tooltip={item.tooltip}
+              />
+            ) : (
+              <YStack key={item.label} flex={1} flexBasis={0} />
+            ),
+          )}
+          {row.length === 1 ? <YStack flex={1} flexBasis={0} /> : null}
+        </XStack>
+      ))}
     </YStack>
   );
 }
@@ -243,16 +305,25 @@ export function PerpMarketIntroContent({
     resolvedMarketDetail ?? internalResolvedMarketDetail;
 
   const marketDetail = effectiveResolvedMarketDetail.result?.detail;
+  const stockDetail = effectiveResolvedMarketDetail.result?.stockDetail;
   const localizedDescription =
     effectiveResolvedMarketDetail.result?.localizedMessage;
+  const { assetAnalysisRows, tradingActivityRows, descriptionRows } =
+    useStockSecurityStats(stockDetail?.stock);
+  const hasTradingActivity = tradingActivityRows.some((row) =>
+    row.some((item) => Boolean(item.value) && item.value !== '--'),
+  );
   const marketDetailReferenceNote = intl.formatMessage({
     id: ETranslations.perp_market_info_reference_note__desc,
   });
   const aboutText = useMemo(
     () =>
-      sanitizeDescriptionText(localizedDescription || marketDetail?.about) ||
-      '',
-    [localizedDescription, marketDetail?.about],
+      sanitizeDescriptionText(
+        localizedDescription ||
+          stockDetail?.introduction ||
+          marketDetail?.about,
+      ) || '',
+    [localizedDescription, marketDetail?.about, stockDetail?.introduction],
   );
 
   const infoItems = useMemo(
@@ -411,8 +482,15 @@ export function PerpMarketIntroContent({
         : [],
     [infoItems],
   );
+  const stockAssetRows = useMemo(
+    () => [
+      descriptionRows.map(({ label, value }) => ({ label, value })),
+      ...assetAnalysisRows,
+    ],
+    [assetAnalysisRows, descriptionRows],
+  );
   const showDescriptionToggle = aboutText.length > 320;
-  const showReferenceNote = Boolean(marketDetail || aboutText);
+  const showReferenceNote = Boolean(marketDetail || stockDetail || aboutText);
 
   if (!enabled) {
     return null;
@@ -439,7 +517,7 @@ export function PerpMarketIntroContent({
     );
   }
 
-  if (!marketDetail && !aboutText) {
+  if (!marketDetail && !stockDetail && !aboutText) {
     return (
       <YStack
         px={paddingX}
@@ -486,15 +564,42 @@ export function PerpMarketIntroContent({
         />
         <XStack flex={1} minWidth={0} alignItems="baseline" gap="$2.5">
           <SizableText size="$headingLg" numberOfLines={1}>
-            {displayName || marketDetail?.symbol?.toUpperCase() || coin || '--'}
+            {displayName ||
+              stockDetail?.ticker ||
+              marketDetail?.symbol?.toUpperCase() ||
+              coin ||
+              '--'}
           </SizableText>
-          {marketDetail?.name ? (
+          {stockDetail?.name || marketDetail?.name ? (
             <SizableText size="$bodyMd" color="$textSubdued" numberOfLines={1}>
-              {marketDetail.name}
+              {stockDetail?.name || marketDetail?.name}
             </SizableText>
           ) : null}
         </XStack>
       </XStack>
+
+      {stockDetail ? (
+        <YStack gap="$6">
+          <YStack gap="$3.5">
+            <SizableText size="$headingSm">
+              {intl.formatMessage({
+                id: ETranslations.dexmarket_stock_asset_analysis,
+              })}
+            </SizableText>
+            <IntroInfoRows rows={stockAssetRows} />
+          </YStack>
+          {hasTradingActivity ? (
+            <YStack gap="$3.5">
+              <SizableText size="$headingSm">
+                {intl.formatMessage({
+                  id: ETranslations.dexmarket_stock_trading_activity,
+                })}
+              </SizableText>
+              <IntroInfoRows rows={tradingActivityRows} />
+            </YStack>
+          ) : null}
+        </YStack>
+      ) : null}
 
       {infoRows.length ? (
         <YStack gap="$3.5">

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -52,6 +52,13 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import errorToastUtils from '@onekeyhq/shared/src/errors/utils/errorToastUtils';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import type {
+  TPerpLocalInvalidReason,
+  TPerpTradeOrderType,
+  TPerpTradePriceMode,
+  TPerpTradeValidationState,
+} from '@onekeyhq/shared/src/logger/scopes/perp/type';
 import {
   SCALE_ORDER_MAX_COUNT,
   SCALE_ORDER_MIN_COUNT,
@@ -251,6 +258,152 @@ EstLiqPriceLeaf.displayName = 'EstLiqPriceLeaf';
 function getPerpSideButtonStyles(isLong: boolean) {
   const styles = getTradingButtonStyleValues(isLong ? 'long' : 'short');
   return styles;
+}
+
+function getPerpTradeButtonState({
+  canTrade,
+  activatedOk,
+}: {
+  canTrade: boolean;
+  activatedOk?: boolean;
+}) {
+  if (canTrade) {
+    return 'readyToTrade' as const;
+  }
+  if (activatedOk === false) {
+    return 'depositRequired' as const;
+  }
+  return 'enableTrading' as const;
+}
+
+type IPerpTradeAnalyticsFormData = Pick<
+  ITradingFormData,
+  'orderMode' | 'type'
+> &
+  Partial<
+    Pick<
+      ITradingFormData,
+      | 'bboPriceMode'
+      | 'hasTpsl'
+      | 'limitTif'
+      | 'reduceOnly'
+      | 'scaleReduceOnly'
+      | 'scaleTif'
+      | 'triggerOrderType'
+      | 'triggerReduceOnly'
+      | 'twapReduceOnly'
+    >
+  >;
+
+function getPerpTradeOrderType(
+  formData: IPerpTradeAnalyticsFormData,
+): TPerpTradeOrderType {
+  if (formData.orderMode === 'trigger') {
+    return formData.triggerOrderType === ETriggerOrderType.TRIGGER_LIMIT
+      ? 'triggerLimit'
+      : 'triggerMarket';
+  }
+  if (formData.orderMode === 'scale') {
+    return 'scale';
+  }
+  if (formData.orderMode === 'twap') {
+    return 'twap';
+  }
+  return formData.type;
+}
+
+function getPerpTradePriceMode(
+  formData: IPerpTradeAnalyticsFormData,
+): TPerpTradePriceMode {
+  if (
+    formData.orderMode === 'standard' &&
+    formData.type === 'limit' &&
+    formData.bboPriceMode
+  ) {
+    return formData.bboPriceMode.type === 'counterparty'
+      ? 'bboCounterparty'
+      : 'bboQueue';
+  }
+  if (
+    formData.orderMode === 'twap' ||
+    (formData.orderMode === 'standard' && formData.type === 'market') ||
+    (formData.orderMode === 'trigger' &&
+      formData.triggerOrderType !== ETriggerOrderType.TRIGGER_LIMIT)
+  ) {
+    return 'market';
+  }
+  return 'manualLimit';
+}
+
+function getPerpTradeReduceOnly(
+  formData: IPerpTradeAnalyticsFormData,
+): boolean | undefined {
+  if (formData.orderMode === 'trigger') {
+    return formData.triggerReduceOnly;
+  }
+  if (formData.orderMode === 'scale') {
+    return formData.scaleReduceOnly;
+  }
+  if (formData.orderMode === 'twap') {
+    return formData.twapReduceOnly;
+  }
+  return formData.reduceOnly;
+}
+
+function getPerpTradeTif(
+  formData: IPerpTradeAnalyticsFormData,
+): string | undefined {
+  if (formData.orderMode === 'scale') {
+    return formData.scaleTif;
+  }
+  if (formData.orderMode === 'standard' && formData.type === 'limit') {
+    return formData.limitTif;
+  }
+  return undefined;
+}
+
+function logPerpTradeButtonClick({
+  side,
+  canTrade,
+  activatedOk,
+  validationState,
+  localInvalidReason,
+  formData,
+  symbol,
+  leverage,
+  orderValue,
+}: {
+  side: 'long' | 'short';
+  canTrade: boolean;
+  activatedOk?: boolean;
+  validationState: TPerpTradeValidationState;
+  localInvalidReason?: TPerpLocalInvalidReason;
+  formData: IPerpTradeAnalyticsFormData;
+  symbol: string;
+  leverage?: number;
+  orderValue?: BigNumber;
+}) {
+  defaultLogger.perp.common.perpTradeButtonClick({
+    side,
+    isTradingEnabled: canTrade,
+    buttonState: getPerpTradeButtonState({ canTrade, activatedOk }),
+    validationState,
+    ...(localInvalidReason ? { localInvalidReason } : {}),
+    symbol,
+    orderType: getPerpTradeOrderType(formData),
+    priceMode: getPerpTradePriceMode(formData),
+    reduceOnly: getPerpTradeReduceOnly(formData),
+    hasTpsl: formData.orderMode === 'standard' ? formData.hasTpsl : undefined,
+    tif: getPerpTradeTif(formData),
+    leverage:
+      typeof leverage === 'number' && Number.isFinite(leverage) && leverage > 0
+        ? leverage
+        : undefined,
+    orderValue:
+      orderValue?.isFinite() && orderValue.gt(0)
+        ? orderValue.toNumber()
+        : undefined,
+  });
 }
 
 function SideButtonInternal({
@@ -630,6 +783,7 @@ function SideButtonInternal({
     marketDataFreshness,
     midPriceBN,
     orderContextKey,
+    orderValue,
     perpsAccount,
     perpsCustomSettings,
     priceError,
@@ -655,6 +809,7 @@ function SideButtonInternal({
     marketDataFreshness,
     midPriceBN,
     orderContextKey,
+    orderValue,
     perpsAccount,
     perpsCustomSettings,
     priceError,
@@ -705,7 +860,7 @@ function SideButtonInternal({
             id: ETranslations.Perps_BBO_unavailable,
           }),
         });
-        return false;
+        return 'bboUnavailable' as const;
       }
 
       if (latestShouldBlockForMarketData) {
@@ -717,7 +872,7 @@ function SideButtonInternal({
             id: ETranslations.perps_offline_moblie,
           }),
         });
-        return false;
+        return 'marketDataUnavailable' as const;
       }
 
       if (latestIsTriggerMode && latestFormData.triggerOrderType) {
@@ -728,7 +883,7 @@ function SideButtonInternal({
               id: ETranslations.perps_input_trigger_price,
             }),
           });
-          return false;
+          return 'invalidTriggerPrice' as const;
         }
         const isLimitTrigger =
           latestFormData.triggerOrderType === ETriggerOrderType.TRIGGER_LIMIT;
@@ -740,18 +895,18 @@ function SideButtonInternal({
                 id: ETranslations.perp_trade_price_place_holder,
               }),
             });
-            return false;
+            return 'invalidLimitPrice' as const;
           }
         }
         if (!latestMidPriceBN.isFinite() || latestMidPriceBN.lte(0)) {
           Toast.error({ title: 'Market price unavailable, please try again' });
-          return false;
+          return 'marketDataUnavailable' as const;
         }
         if (new BigNumber(tp).eq(latestMidPriceBN)) {
           Toast.error({
             title: 'Trigger price must differ from current price',
           });
-          return false;
+          return 'invalidTriggerPrice' as const;
         }
       }
 
@@ -767,7 +922,7 @@ function SideButtonInternal({
             id: ETranslations.perp_trade_price_place_holder,
           }),
         });
-        return false;
+        return 'missingLimitPrice' as const;
       }
 
       if (latestIsScaleMode) {
@@ -784,7 +939,7 @@ function SideButtonInternal({
               id: ETranslations.perp_scale_price_range_required__msg,
             }),
           });
-          return false;
+          return 'invalidScaleConfig' as const;
         }
         if (lowerPrice.eq(upperPrice)) {
           Toast.message({
@@ -792,7 +947,7 @@ function SideButtonInternal({
               id: ETranslations.perp_scale_price_range_same__msg,
             }),
           });
-          return false;
+          return 'invalidScaleConfig' as const;
         }
         const orderCount = normalizeScaleOrderCount(
           latestFormData.scaleOrderCount ?? 0,
@@ -812,7 +967,7 @@ function SideButtonInternal({
               },
             ),
           });
-          return false;
+          return 'invalidScaleConfig' as const;
         }
       }
 
@@ -826,7 +981,7 @@ function SideButtonInternal({
           Toast.message({
             title: `TWAP duration must be ${TWAP_MIN_DURATION_MINUTES}-${TWAP_MAX_DURATION_MINUTES} minutes`,
           });
-          return false;
+          return 'invalidTwapConfig' as const;
         }
       }
 
@@ -881,12 +1036,14 @@ function SideButtonInternal({
             { amount: minAmount },
           ),
         });
-        return false;
+        return hasSizeEmpty
+          ? ('emptySize' as const)
+          : ('minimumOrderNotMet' as const);
       }
 
       if (latestIsNoEnoughMargin) {
         showNoEnoughMarginToast(latestIsSpot);
-        return false;
+        return 'insufficientMargin' as const;
       }
 
       if (latestIsScaleMode) {
@@ -911,7 +1068,7 @@ function SideButtonInternal({
               fallback: 'Invalid scale order',
             }),
           });
-          return false;
+          return 'invalidScaleConfig' as const;
         }
       }
 
@@ -934,7 +1091,7 @@ function SideButtonInternal({
               id: ETranslations.perp_twap_small_slice__msg,
             }),
           });
-          return false;
+          return 'invalidTwapConfig' as const;
         }
       }
 
@@ -1005,7 +1162,7 @@ function SideButtonInternal({
                 id: ETranslations.perp_invaild_tp_desc_1,
               }),
             });
-            return false;
+            return 'invalidTpsl' as const;
           }
           if (
             validationSide === 'short' &&
@@ -1019,7 +1176,7 @@ function SideButtonInternal({
                 id: ETranslations.perp_invaild_tp_desc_2,
               }),
             });
-            return false;
+            return 'invalidTpsl' as const;
           }
         }
 
@@ -1041,7 +1198,7 @@ function SideButtonInternal({
                 id: ETranslations.perp_invaild_sl_desc_1,
               }),
             });
-            return false;
+            return 'invalidTpsl' as const;
           }
           if (
             validationSide === 'short' &&
@@ -1055,12 +1212,12 @@ function SideButtonInternal({
                 id: ETranslations.perp_invaild_sl_desc_2,
               }),
             });
-            return false;
+            return 'invalidTpsl' as const;
           }
         }
       }
 
-      return true;
+      return undefined;
     },
     [intl, showNoEnoughMarginToast],
   );
@@ -1172,7 +1329,33 @@ function SideButtonInternal({
         return;
       }
 
+      const logTradeClick = ({
+        orderPanelState,
+        validationState,
+        localInvalidReason,
+      }: {
+        orderPanelState: ILatestOrderPanelState;
+        validationState: TPerpTradeValidationState;
+        localInvalidReason?: TPerpLocalInvalidReason;
+      }) => {
+        if (orderPanelState.isSpot) {
+          return;
+        }
+        logPerpTradeButtonClick({
+          side,
+          canTrade: Boolean(perpsAccountStatus.canTrade),
+          activatedOk: perpsAccountStatus.details?.activatedOk,
+          validationState,
+          localInvalidReason,
+          formData: orderPanelState.formData,
+          symbol: orderPanelState.activeTradeInstrument.coin,
+          leverage: orderPanelState.leverage,
+          orderValue: orderPanelState.orderValue,
+        });
+      };
+
       const preEnableOrderPanelState = latestOrderPanelStateRef.current;
+      let hasLoggedDeferredClick = false;
 
       if (shouldEnableTradingBeforeOrder) {
         const isDepositRequired =
@@ -1184,9 +1367,20 @@ function SideButtonInternal({
             isDepositRequired,
           })
         ) {
+          logTradeClick({
+            orderPanelState: preEnableOrderPanelState,
+            validationState: 'invalid',
+            localInvalidReason: 'insufficientMargin',
+          });
           showNoEnoughMarginToast(preEnableOrderPanelState.isSpot);
           return;
         }
+
+        logTradeClick({
+          orderPanelState: preEnableOrderPanelState,
+          validationState: 'deferred',
+        });
+        hasLoggedDeferredClick = !preEnableOrderPanelState.isSpot;
 
         const enableTradingAccountKey = perpsAccountKey;
         const enableTradingSide = side;
@@ -1232,13 +1426,19 @@ function SideButtonInternal({
       // dialog. Running validation here covers both the just-enabled path and
       // accounts that can already trade.
       const validationState = latestOrderPanelStateRef.current;
-      if (
-        !validateOrderPanelState({
-          orderPanelState: validationState,
-          validationSide: side,
-          shouldValidateBboPriceError: true,
-        })
-      ) {
+      const localInvalidReason = validateOrderPanelState({
+        orderPanelState: validationState,
+        validationSide: side,
+        shouldValidateBboPriceError: true,
+      });
+      if (localInvalidReason) {
+        if (!hasLoggedDeferredClick) {
+          logTradeClick({
+            orderPanelState: validationState,
+            validationState: 'invalid',
+            localInvalidReason,
+          });
+        }
         return;
       }
       const submitState = latestOrderPanelStateRef.current;
@@ -1254,6 +1454,13 @@ function SideButtonInternal({
             submitState.activePositionsValue.accountAddress,
         });
         if (snapshotError) {
+          if (!hasLoggedDeferredClick) {
+            logTradeClick({
+              orderPanelState: submitState,
+              validationState: 'invalid',
+              localInvalidReason: 'invalidReduceOnly',
+            });
+          }
           Toast.message({ title: snapshotError });
           return;
         }
@@ -1281,9 +1488,23 @@ function SideButtonInternal({
               }),
         });
         if (reduceOnlyError) {
+          if (!hasLoggedDeferredClick) {
+            logTradeClick({
+              orderPanelState: submitState,
+              validationState: 'invalid',
+              localInvalidReason: 'invalidReduceOnly',
+            });
+          }
           Toast.message({ title: reduceOnlyError });
           return;
         }
+      }
+
+      if (!hasLoggedDeferredClick) {
+        logTradeClick({
+          orderPanelState: submitState,
+          validationState: 'valid',
+        });
       }
 
       if (submitState.perpsCustomSettings.skipOrderConfirm) {
@@ -1825,6 +2046,19 @@ function EmptySizeSideButton({
         return;
       }
 
+      let hasLoggedDeferredClick = false;
+      if (!isSpot && shouldEnableTradingBeforeOrder) {
+        logPerpTradeButtonClick({
+          side,
+          canTrade: Boolean(perpsAccountStatus.canTrade),
+          activatedOk: perpsAccountStatus.details?.activatedOk,
+          validationState: 'deferred',
+          formData,
+          symbol: activeTradeInstrument.coin,
+        });
+        hasLoggedDeferredClick = true;
+      }
+
       if (shouldEnableTradingBeforeOrder) {
         const enableTradingAccountKey = perpsAccountKey;
         const shouldIgnoreEnableTradingResult = () =>
@@ -1846,6 +2080,17 @@ function EmptySizeSideButton({
         shouldBlockPerpsTradingForMarketData(marketDataFreshness);
 
       if (shouldBlockForMarketData) {
+        if (!isSpot && !hasLoggedDeferredClick) {
+          logPerpTradeButtonClick({
+            side,
+            canTrade: Boolean(perpsAccountStatus.canTrade),
+            activatedOk: perpsAccountStatus.details?.activatedOk,
+            validationState: 'invalid',
+            localInvalidReason: 'marketDataUnavailable',
+            formData,
+            symbol: activeTradeInstrument.coin,
+          });
+        }
         Toast.error({
           title: intl.formatMessage({
             id: ETranslations.perp_offline,
@@ -1861,6 +2106,17 @@ function EmptySizeSideButton({
         formData.type === 'limit' &&
         (!formData.price || formData.price.trim() === '')
       ) {
+        if (!isSpot && !hasLoggedDeferredClick) {
+          logPerpTradeButtonClick({
+            side,
+            canTrade: Boolean(perpsAccountStatus.canTrade),
+            activatedOk: perpsAccountStatus.details?.activatedOk,
+            validationState: 'invalid',
+            localInvalidReason: 'missingLimitPrice',
+            formData,
+            symbol: activeTradeInstrument.coin,
+          });
+        }
         Toast.message({
           title: intl.formatMessage({
             id: ETranslations.perp_trade_price_place_holder,
@@ -1869,6 +2125,17 @@ function EmptySizeSideButton({
         return;
       }
 
+      if (!isSpot && !hasLoggedDeferredClick) {
+        logPerpTradeButtonClick({
+          side,
+          canTrade: Boolean(perpsAccountStatus.canTrade),
+          activatedOk: perpsAccountStatus.details?.activatedOk,
+          validationState: 'invalid',
+          localInvalidReason: 'emptySize',
+          formData,
+          symbol: activeTradeInstrument.coin,
+        });
+      }
       Toast.message({
         title: intl.formatMessage(
           { id: ETranslations.perp_size_least },

--- a/packages/kit/src/views/Perp/hooks/usePerpMarketDetail.test.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpMarketDetail.test.ts
@@ -1,0 +1,157 @@
+/* cspell:ignore SKHX SKHY */
+
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import type { IMarketTokenDetail } from '@onekeyhq/shared/types/market';
+
+import { resolvePerpMarketDetail } from './usePerpMarketDetail';
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceHyperliquid: {
+      getPerpsAssetMetaMap: jest.fn(),
+    },
+    serviceMarket: {
+      fetchMarketTokenDetail: jest.fn(),
+    },
+    serviceMarketV2: {
+      fetchMarketStockByTicker: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => ({
+  usePromiseResult: jest.fn(),
+}));
+
+const mockServiceHyperliquid = jest.mocked(
+  backgroundApiProxy.serviceHyperliquid,
+);
+const mockServiceMarket = jest.mocked(backgroundApiProxy.serviceMarket);
+const mockServiceMarketV2 = jest.mocked(backgroundApiProxy.serviceMarketV2);
+
+describe('resolvePerpMarketDetail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads stock details by the configured ticker', async () => {
+    const stockDetail = {
+      ticker: 'SKHY',
+      name: 'SK hynix Inc.',
+      stock: {
+        subtitle: 'SK hynix Inc.',
+        sourceLogoUri: '',
+      },
+    };
+    mockServiceHyperliquid.getPerpsAssetMetaMap.mockResolvedValue({
+      SKHX: {
+        assetId: 'SKHY',
+        assetType: 'stock',
+        localizedMessage: 'Fallback introduction',
+      },
+    });
+    mockServiceMarketV2.fetchMarketStockByTicker.mockResolvedValue(stockDetail);
+
+    await expect(
+      resolvePerpMarketDetail({ coin: 'xyz:SKHX', displayName: 'SKHX' }),
+    ).resolves.toEqual({
+      assetMetaKey: 'SKHX',
+      assetId: 'SKHY',
+      assetType: 'stock',
+      localizedMessage: 'Fallback introduction',
+      detail: undefined,
+      stockDetail,
+    });
+    expect(mockServiceMarketV2.fetchMarketStockByTicker.mock.calls).toEqual([
+      ['SKHY'],
+    ]);
+    expect(mockServiceMarket.fetchMarketTokenDetail.mock.calls).toHaveLength(0);
+  });
+
+  it('keeps the existing CoinGecko detail path', async () => {
+    const detail: IMarketTokenDetail = {
+      name: 'Bitcoin',
+      image: '',
+      symbol: 'BTC',
+      about: '',
+      explorers: [],
+      links: {
+        homePageUrl: '',
+        discordUrl: '',
+        twitterUrl: '',
+        whitepaper: '',
+        telegramUrl: '',
+      },
+      stats: {
+        performance: {
+          priceChangePercentage1h: 0,
+          priceChangePercentage24h: 0,
+          priceChangePercentage7d: 0,
+          priceChangePercentage14d: 0,
+          priceChangePercentage30d: 0,
+          priceChangePercentage1y: 0,
+        },
+        marketCap: 0,
+        marketCapRank: 0,
+        volume24h: 0,
+        low24h: 0,
+        high24h: 0,
+        atl: { time: new Date(0), value: 0 },
+        ath: { time: new Date(0), value: 0 },
+        fdv: 0,
+        circulatingSupply: 0,
+        totalSupply: 0,
+        maxSupply: 0,
+        currentPrice: '0',
+        lastUpdated: '',
+      },
+      fallbackToChart: false,
+      detailPlatforms: {},
+      platforms: {},
+    };
+    mockServiceHyperliquid.getPerpsAssetMetaMap.mockResolvedValue({
+      BTC: {
+        assetId: 'bitcoin',
+        assetType: 'coingecko',
+      },
+    });
+    mockServiceMarket.fetchMarketTokenDetail.mockResolvedValue(detail);
+
+    await expect(
+      resolvePerpMarketDetail({ coin: 'BTC', displayName: 'BTC' }),
+    ).resolves.toMatchObject({
+      assetId: 'bitcoin',
+      assetType: 'coingecko',
+      detail,
+    });
+    expect(mockServiceMarket.fetchMarketTokenDetail.mock.calls).toEqual([
+      ['bitcoin'],
+    ]);
+    expect(
+      mockServiceMarketV2.fetchMarketStockByTicker.mock.calls,
+    ).toHaveLength(0);
+  });
+
+  it('does not fetch remote details for non-CoinGecko assets', async () => {
+    mockServiceHyperliquid.getPerpsAssetMetaMap.mockResolvedValue({
+      GOLD: {
+        assetId: 'GOLD',
+        assetType: 'non_coingecko',
+        localizedMessage: 'Gold introduction',
+      },
+    });
+
+    await expect(
+      resolvePerpMarketDetail({ coin: 'xyz:GOLD', displayName: 'GOLD' }),
+    ).resolves.toMatchObject({
+      assetId: 'GOLD',
+      assetType: 'non_coingecko',
+      localizedMessage: 'Gold introduction',
+    });
+    expect(mockServiceMarket.fetchMarketTokenDetail.mock.calls).toHaveLength(0);
+    expect(
+      mockServiceMarketV2.fetchMarketStockByTicker.mock.calls,
+    ).toHaveLength(0);
+  });
+});

--- a/packages/kit/src/views/Perp/hooks/usePerpMarketDetail.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpMarketDetail.ts
@@ -15,6 +15,7 @@ import type {
   IPerpsAssetMetaMap,
 } from '@onekeyhq/shared/types/hyperliquid/types';
 import type { IMarketTokenDetail } from '@onekeyhq/shared/types/market';
+import type { IMarketStockDetail } from '@onekeyhq/shared/types/marketV2';
 
 export type IPerpFundingHistoryRange = '24h' | '7d' | '30d';
 
@@ -24,6 +25,7 @@ export type IPerpResolvedMarketDetail = {
   assetType?: IPerpAssetMetaAssetType;
   localizedMessage?: string;
   detail?: IMarketTokenDetail;
+  stockDetail?: IMarketStockDetail;
 };
 
 function addPerpAssetMetaLookupCandidate(
@@ -87,7 +89,7 @@ function resolvePerpAssetMeta({
   return undefined;
 }
 
-async function resolvePerpMarketDetail({
+export async function resolvePerpMarketDetail({
   coin,
   displayName,
 }: {
@@ -113,12 +115,22 @@ async function resolvePerpMarketDetail({
 
   const localizedMessage =
     resolvedAssetMeta.meta.localizedMessage || resolvedAssetMeta.meta.message;
-  // Legacy cached configs only have assetId, so only explicit non-CoinGecko skips fetching.
-  const shouldFetchMarketDetail =
-    resolvedAssetMeta.meta.assetType !== 'non_coingecko';
   let detail: IMarketTokenDetail | undefined;
+  let stockDetail: IMarketStockDetail | undefined;
 
-  if (shouldFetchMarketDetail) {
+  if (resolvedAssetMeta.meta.assetType === 'stock') {
+    try {
+      stockDetail =
+        await backgroundApiProxy.serviceMarketV2.fetchMarketStockByTicker(
+          resolvedAssetMeta.meta.assetId,
+        );
+    } catch (error) {
+      if (!localizedMessage) {
+        throw error;
+      }
+    }
+  } else if (resolvedAssetMeta.meta.assetType !== 'non_coingecko') {
+    // Legacy cached configs only have assetId, so they continue using CoinGecko.
     try {
       detail = await backgroundApiProxy.serviceMarket.fetchMarketTokenDetail(
         resolvedAssetMeta.meta.assetId,
@@ -136,6 +148,7 @@ async function resolvePerpMarketDetail({
     assetType: resolvedAssetMeta.meta.assetType,
     localizedMessage,
     detail,
+    stockDetail,
   };
 }
 

--- a/packages/shared/src/analytics/deviceInfo.desktop.ts
+++ b/packages/shared/src/analytics/deviceInfo.desktop.ts
@@ -1,11 +1,17 @@
 // oxlint-disable unicorn/prefer-global-this
 /* eslint-disable unicorn/prefer-global-this */
 import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
+import {
+  getDeviceTimeZone,
+  getDeviceUtcOffsetMinutes,
+} from '@onekeyhq/shared/src/utils/timeZoneUtils';
 
 import type { IDeviceInfo, IGetDeviceInfo } from './type';
 
 const deviceInfo = {
   deviceId: generateUUID(),
+  deviceTimeZone: getDeviceTimeZone(),
+  deviceUtcOffsetMinutes: getDeviceUtcOffsetMinutes(),
   arch: globalThis.desktopApi?.arch || 'unknown',
   os: globalThis.desktopApi?.platform,
   osVersion: globalThis.desktopApi?.systemVersion,

--- a/packages/shared/src/analytics/deviceInfo.native.ts
+++ b/packages/shared/src/analytics/deviceInfo.native.ts
@@ -6,22 +6,33 @@ import {
   osVersion,
   supportedCpuArchitectures,
 } from 'expo-device';
+import { getCalendars } from 'expo-localization';
 import { Dimensions } from 'react-native';
 
 import platformEnv from '../platformEnv';
+import {
+  getDeviceTimeZone,
+  getDeviceUtcOffsetMinutes,
+} from '../utils/timeZoneUtils';
 
 import type { IGetDeviceInfo } from './type';
 
-export const getDeviceInfo: IGetDeviceInfo = async () => ({
-  deviceId:
-    (platformEnv.isNativeIOS
-      ? await getIosIdForVendorAsync()
-      : getAndroidId()) ?? '',
-  arch: supportedCpuArchitectures ? supportedCpuArchitectures?.join(',') : '',
-  manufacturer: manufacturer ?? '',
-  model: modelName ?? '',
-  os: osName ?? '',
-  osVersion: osVersion ?? '',
-  screenHeight: Dimensions.get('window').height,
-  screenWidth: Dimensions.get('window').width,
-});
+export const getDeviceInfo: IGetDeviceInfo = async () => {
+  const deviceTimeZone = getCalendars()?.[0]?.timeZone;
+
+  return {
+    deviceId:
+      (platformEnv.isNativeIOS
+        ? await getIosIdForVendorAsync()
+        : getAndroidId()) ?? '',
+    deviceTimeZone: getDeviceTimeZone(deviceTimeZone),
+    deviceUtcOffsetMinutes: getDeviceUtcOffsetMinutes(),
+    arch: supportedCpuArchitectures ? supportedCpuArchitectures?.join(',') : '',
+    manufacturer: manufacturer ?? '',
+    model: modelName ?? '',
+    os: osName ?? '',
+    osVersion: osVersion ?? '',
+    screenHeight: Dimensions.get('window').height,
+    screenWidth: Dimensions.get('window').width,
+  };
+};

--- a/packages/shared/src/analytics/deviceInfo.test.ts
+++ b/packages/shared/src/analytics/deviceInfo.test.ts
@@ -1,0 +1,14 @@
+import { getDeviceInfo } from './deviceInfo';
+
+describe('getDeviceInfo', () => {
+  it('includes the device time zone in common analytics properties', async () => {
+    const deviceInfo = await getDeviceInfo();
+
+    expect(deviceInfo.deviceTimeZone).toBe(
+      Intl.DateTimeFormat().resolvedOptions().timeZone,
+    );
+    expect(deviceInfo.deviceUtcOffsetMinutes).toBe(
+      -new Date().getTimezoneOffset(),
+    );
+  });
+});

--- a/packages/shared/src/analytics/deviceInfo.ts
+++ b/packages/shared/src/analytics/deviceInfo.ts
@@ -1,11 +1,17 @@
 // oxlint-disable unicorn/prefer-global-this
 /* eslint-disable unicorn/prefer-global-this */
 import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
+import {
+  getDeviceTimeZone,
+  getDeviceUtcOffsetMinutes,
+} from '@onekeyhq/shared/src/utils/timeZoneUtils';
 
 import type { IDeviceInfo, IGetDeviceInfo } from './type';
 
 const deviceInfo = {
   deviceId: generateUUID(),
+  deviceTimeZone: getDeviceTimeZone(),
+  deviceUtcOffsetMinutes: getDeviceUtcOffsetMinutes(),
   screenHeight: typeof window !== 'undefined' ? window.innerHeight : undefined,
   screenWidth: typeof window !== 'undefined' ? window.innerWidth : undefined,
   referrer: typeof document !== 'undefined' ? document.referrer : undefined,

--- a/packages/shared/src/analytics/type.ts
+++ b/packages/shared/src/analytics/type.ts
@@ -1,5 +1,7 @@
 export interface IDeviceInfo {
   deviceId?: string;
+  deviceTimeZone?: string;
+  deviceUtcOffsetMinutes?: number;
   manufacturer?: string;
   model?: string;
   os?: string;

--- a/packages/shared/src/logger/scopes/perp/scenes/common.ts
+++ b/packages/shared/src/logger/scopes/perp/scenes/common.ts
@@ -1,7 +1,10 @@
 import { BaseScene } from '../../../base/baseScene';
 import { LogToLocal, LogToServer } from '../../../base/decorators';
 
-import type { EPerpPageEnterSource } from '../type';
+import type {
+  EPerpPageEnterSource,
+  IPerpTradeButtonClickParams,
+} from '../type';
 
 export class CommonScene extends BaseScene {
   @LogToServer()
@@ -14,6 +17,12 @@ export class CommonScene extends BaseScene {
     walletType: string;
   }) {
     return { source, walletType, pageName: 'Perp' };
+  }
+
+  @LogToServer()
+  @LogToLocal({ level: 'info' })
+  public perpTradeButtonClick(params: IPerpTradeButtonClickParams) {
+    return params;
   }
 
   @LogToServer()

--- a/packages/shared/src/logger/scopes/perp/type.ts
+++ b/packages/shared/src/logger/scopes/perp/type.ts
@@ -3,6 +3,8 @@ import type { ESwapTxHistoryStatus } from '@onekeyhq/shared/types/swap/types';
 
 export enum EPerpPageEnterSource {
   TabBar = 'tabBar',
+  Home = 'home',
+  DesktopTray = 'desktopTray',
   Notification = 'notification',
   MarketList = 'marketList',
   MarketBanner = 'marketBanner',
@@ -18,6 +20,58 @@ export enum EPerpPageEnterSource {
   // Handoff from the Swap Pro-mode stock market-closed alert → Perps.
   SwapProStockClosed = 'swapProStockClosed',
   DirectUrl = 'directUrl',
+}
+
+export type TPerpTradeButtonState =
+  | 'readyToTrade'
+  | 'enableTrading'
+  | 'depositRequired';
+
+export type TPerpTradeValidationState = 'valid' | 'invalid' | 'deferred';
+
+export type TPerpLocalInvalidReason =
+  | 'emptySize'
+  | 'minimumOrderNotMet'
+  | 'insufficientMargin'
+  | 'missingLimitPrice'
+  | 'invalidLimitPrice'
+  | 'bboUnavailable'
+  | 'marketDataUnavailable'
+  | 'invalidTriggerPrice'
+  | 'invalidScaleConfig'
+  | 'invalidTwapConfig'
+  | 'invalidTpsl'
+  | 'invalidReduceOnly'
+  | 'unknown';
+
+export type TPerpTradeOrderType =
+  | 'market'
+  | 'limit'
+  | 'triggerMarket'
+  | 'triggerLimit'
+  | 'scale'
+  | 'twap';
+
+export type TPerpTradePriceMode =
+  | 'market'
+  | 'manualLimit'
+  | 'bboCounterparty'
+  | 'bboQueue';
+
+export interface IPerpTradeButtonClickParams {
+  side: 'long' | 'short';
+  isTradingEnabled: boolean;
+  buttonState: TPerpTradeButtonState;
+  validationState: TPerpTradeValidationState;
+  localInvalidReason?: TPerpLocalInvalidReason;
+  symbol: string;
+  orderType: TPerpTradeOrderType;
+  priceMode: TPerpTradePriceMode;
+  reduceOnly?: boolean;
+  hasTpsl?: boolean;
+  tif?: string;
+  leverage?: number;
+  orderValue?: number;
 }
 
 export interface IPerpDepositInitiateParams {

--- a/packages/shared/src/utils/phrase.test.ts
+++ b/packages/shared/src/utils/phrase.test.ts
@@ -1,4 +1,7 @@
-import { parseSecretRecoveryPhrase } from './phrase';
+import {
+  parseSecretRecoveryPhrase,
+  parseSecretRecoveryPhraseToWords,
+} from './phrase';
 
 describe('parseSecretRecoveryPhrase', () => {
   it('should handle a regular Secret Recovery Phrase', () => {
@@ -61,5 +64,17 @@ describe('parseSecretRecoveryPhrase', () => {
     expect(parseSecretRecoveryPhrase(null as unknown as string)).toStrictEqual(
       '',
     );
+  });
+});
+
+describe('parseSecretRecoveryPhraseToWords', () => {
+  it('should return normalized words using the canonical phrase parser', () => {
+    expect(
+      parseSecretRecoveryPhraseToWords('  FOO,\tbar\r\n baz!  '),
+    ).toStrictEqual(['foo', 'bar', 'baz']);
+  });
+
+  it('should return an empty array when the phrase has no words', () => {
+    expect(parseSecretRecoveryPhraseToWords(' \t$\r\n ')).toStrictEqual([]);
   });
 });

--- a/packages/shared/src/utils/phrase.ts
+++ b/packages/shared/src/utils/phrase.ts
@@ -1,2 +1,7 @@
 export const parseSecretRecoveryPhrase = (seedPhrase: string) =>
   (seedPhrase || '').trim().toLowerCase().match(/\w+/gu)?.join(' ') || '';
+
+export const parseSecretRecoveryPhraseToWords = (seedPhrase: string) => {
+  const phrase = parseSecretRecoveryPhrase(seedPhrase);
+  return phrase ? phrase.split(' ') : [];
+};

--- a/packages/shared/src/utils/timeZoneUtils.test.ts
+++ b/packages/shared/src/utils/timeZoneUtils.test.ts
@@ -1,0 +1,30 @@
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
+import { getDeviceTimeZone, getDeviceUtcOffsetMinutes } from './timeZoneUtils';
+
+describe('timeZoneUtils', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('prefers the time zone provided by the platform', () => {
+    const dateTimeFormatSpy = jest.spyOn(Intl, 'DateTimeFormat');
+
+    expect(getDeviceTimeZone('Asia/Shanghai')).toBe('Asia/Shanghai');
+    expect(dateTimeFormatSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to UTC when Intl cannot resolve a time zone', () => {
+    jest.spyOn(Intl, 'DateTimeFormat').mockImplementation(() => {
+      throw new OneKeyLocalError('Intl is unavailable');
+    });
+
+    expect(getDeviceTimeZone()).toBe('Etc/UTC');
+  });
+
+  it('uses positive minutes for time zones east of UTC', () => {
+    jest.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-480);
+
+    expect(getDeviceUtcOffsetMinutes()).toBe(480);
+  });
+});

--- a/packages/shared/src/utils/timeZoneUtils.ts
+++ b/packages/shared/src/utils/timeZoneUtils.ts
@@ -1,0 +1,20 @@
+const FALLBACK_TIME_ZONE = 'Etc/UTC';
+
+export function getDeviceTimeZone(preferredTimeZone?: string | null): string {
+  if (preferredTimeZone) {
+    return preferredTimeZone;
+  }
+
+  try {
+    return (
+      Intl.DateTimeFormat().resolvedOptions().timeZone || FALLBACK_TIME_ZONE
+    );
+  } catch {
+    return FALLBACK_TIME_ZONE;
+  }
+}
+
+export function getDeviceUtcOffsetMinutes(): number {
+  // Date#getTimezoneOffset uses the inverse sign of conventional UTC offsets.
+  return -new Date().getTimezoneOffset();
+}

--- a/packages/shared/src/utils/tokenValueUtils.test.ts
+++ b/packages/shared/src/utils/tokenValueUtils.test.ts
@@ -193,4 +193,32 @@ describe('sumTokenGroupsFiatValueIgnoringUnavailable', () => {
   test('handles missing token group shapes', () => {
     expect(sumTokenGroupsFiatValueIgnoringUnavailable({})).toBe('0');
   });
+
+  test('counts a $key present in both maps only once', () => {
+    // Cache-floor rounds (useTokenListReactivePipeline.seedAndFlushCache) carry
+    // the ONE cached full tokenListMap as BOTH tokens.map and
+    // smallBalanceTokens.map — summing both verbatim doubled every
+    // cache-floor network's account worth on the Home overview.
+    const fullCachedMap = {
+      usdt: { fiatValue: '5000' },
+      trx: { fiatValue: '150' },
+    };
+    expect(
+      sumTokenGroupsFiatValueIgnoringUnavailable({
+        tokens: { map: fullCachedMap },
+        smallBalanceTokens: { map: fullCachedMap },
+      }),
+    ).toBe('5150');
+  });
+
+  test('overlapping keys are counted once while distinct keys still sum', () => {
+    expect(
+      sumTokenGroupsFiatValueIgnoringUnavailable({
+        tokens: { map: { a: { fiatValue: '10' }, b: { fiatValue: '2' } } },
+        smallBalanceTokens: {
+          map: { b: { fiatValue: '2' }, c: { fiatValue: '0.5' } },
+        },
+      }),
+    ).toBe('12.5');
+  });
 });

--- a/packages/shared/src/utils/tokenValueUtils.ts
+++ b/packages/shared/src/utils/tokenValueUtils.ts
@@ -83,6 +83,12 @@ export function sumFiatValuesIgnoringUnavailable(
 // collapses the duplicated `tokens.map + smallBalanceTokens.map` sum at every
 // accountWorth write site. Single pass over both maps to avoid the
 // toFixed → reparse round trip.
+//
+// Each $key is counted ONCE across both maps: cache-floor rounds
+// (useTokenListReactivePipeline.seedAndFlushCache) reuse the ONE cached full
+// tokenListMap as both tokens.map and smallBalanceTokens.map — summing them
+// verbatim doubled every cache-floor network's worth on the Home overview.
+// Live rounds carry disjoint maps, so the dedup is a no-op for them.
 export function sumTokenGroupsFiatValueIgnoringUnavailable(r: {
   tokens?: { map?: Record<string, ITokenFiatValueShape | undefined> };
   smallBalanceTokens?: {
@@ -90,13 +96,17 @@ export function sumTokenGroupsFiatValueIgnoringUnavailable(r: {
   };
 }): string {
   let acc = new BigNumber(0);
+  const seenKeys = new Set<string>();
   const addAll = (
     map: Record<string, ITokenFiatValueShape | undefined> | undefined,
   ) => {
     if (!map) return;
-    for (const entry of Object.values(map)) {
-      if (entry && isValidNumberValue(entry.fiatValue)) {
-        acc = acc.plus(entry.fiatValue);
+    for (const [key, entry] of Object.entries(map)) {
+      if (!seenKeys.has(key)) {
+        seenKeys.add(key);
+        if (entry && isValidNumberValue(entry.fiatValue)) {
+          acc = acc.plus(entry.fiatValue);
+        }
       }
     }
   };

--- a/packages/shared/types/hyperliquid/types.ts
+++ b/packages/shared/types/hyperliquid/types.ts
@@ -343,7 +343,7 @@ export interface IPerpActivityCard {
   url: string;
 }
 
-export type IPerpAssetMetaAssetType = 'coingecko' | 'non_coingecko';
+export type IPerpAssetMetaAssetType = 'coingecko' | 'non_coingecko' | 'stock';
 
 export interface IPerpAssetMeta {
   assetId: string;

--- a/packages/shared/types/marketV2.ts
+++ b/packages/shared/types/marketV2.ts
@@ -202,6 +202,15 @@ export interface IMarketStockInfo {
   underlyingAssetName?: string;
 }
 
+export interface IMarketStockDetail {
+  ticker: string;
+  name: string;
+  logoUrl?: string;
+  introduction?: string;
+  underlyingUpdatedAt?: string;
+  stock: IMarketStockInfo;
+}
+
 export interface IMarketTokenListItem extends IMarketTokenHistoricalPriceFields {
   address: string;
   logoUrl?: string;


### PR DESCRIPTION
## Summary

- Sync Release #3 code from `release/v6.5.0` range `987fffa003..5d1872fb06` onto `x`.
- Replay 8 business commits in release order.
- Exclude `07a7ebcf61` because it only updates `RELEASES.json`.
- Confirm prior sync PR #12518 covers Release #1 and PR #12582 covers Release #2; do not replay those already-synced commits.
- Resolve the Perps analytics conflict by preserving the newer `x` `pageView`/`perpWebviewPlaceOrder` events and their wallet/status fields while adding the release `perpTradeButtonClick` funnel event.

## Commits synced

- feat: add device timezone analytics properties (#12578)
- feat: add stock market data to perps (#12528)
- fix: stabilize market loading fallback (#12603)
- fix: prevent browser toolbar scroll jump (#12594)
- fix: preserve browser webviews across tab switches (#12581)
- fix: dedupe all-network worth summing and trust PancakeSwap Permit2 (#12595)
- feat: add perps conversion funnel analytics (#12609)
- fix: sync mnemonic word count after paste (#12576)

## Verification

- `git range-diff`: 7 patches exact; #12609 contains only the reviewed `x`-preserving logger resolution.
- Targeted Jest: 12 suites, 85 tests passed.
- `yarn agent:check --profile pr` passed.
- `git diff --check` passed.
- Added-file review passed; no `RELEASES.json`, `.env.version`, audit report, firmware docs, or other main-worktree files are included.

## Audit Notice

- The bundle audit found no new Critical, High, or Medium issue in Release #3, but the dependency tree retains the previously reported inherited advisory baseline.