### PR TITLE
fix: improve Prime Infini payment flow

### DIFF
--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.test.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.test.ts
@@ -1988,6 +1988,113 @@ describe('SimpleDbEntityPrime Infini pending payment session', () => {
     );
   });
 
+  const makeLatchEntity = () => {
+    const entity = new SimpleDbEntityPrime();
+    let persisted = {
+      infiniPendingPaymentSessionByUserId: {
+        'user-1': {
+          ...session,
+          schemaVersion: 2 as const,
+          updatedAt: Date.now() - 1000,
+        },
+      },
+    };
+    jest.spyOn(entity, 'setRawData').mockImplementation((async (
+      updater: (rawData: typeof persisted) => typeof persisted,
+    ) => {
+      persisted = updater(persisted);
+      return persisted;
+    }) as never);
+    return {
+      entity,
+      getStoredSession: () =>
+        persisted.infiniPendingPaymentSessionByUserId['user-1'],
+    };
+  };
+
+  test('latches server-observed progress onto an unsent session', async () => {
+    const { entity, getStoredSession } = makeLatchEntity();
+
+    const result = await entity.latchInfiniPendingPaymentSessionProgress({
+      onekeyUserId: 'user-1',
+      paymentCacheKey: session.paymentCacheKey,
+      latestPayment: {
+        ...session.payment,
+        amountConfirming: '0.5',
+      },
+    });
+
+    expect(result?.sendStarted).toBe(true);
+    expect(result?.payment.amountConfirming).toBe('0.5');
+    expect(getStoredSession().sendStarted).toBe(true);
+  });
+
+  test('does not refresh the session when no new progress is observed', async () => {
+    const { entity, getStoredSession } = makeLatchEntity();
+    const updatedAtBefore = getStoredSession().updatedAt;
+
+    const result = await entity.latchInfiniPendingPaymentSessionProgress({
+      onekeyUserId: 'user-1',
+      paymentCacheKey: session.paymentCacheKey,
+      latestPayment: session.payment,
+    });
+
+    expect(result?.sendStarted).toBe(false);
+    expect(getStoredSession().updatedAt).toBe(updatedAtBefore);
+  });
+
+  test('ignores a latch for a session the cache key no longer matches', async () => {
+    const { entity, getStoredSession } = makeLatchEntity();
+
+    const result = await entity.latchInfiniPendingPaymentSessionProgress({
+      onekeyUserId: 'user-1',
+      paymentCacheKey: {
+        ...session.paymentCacheKey,
+        paymentId: 'payment-2',
+      },
+      latestPayment: {
+        ...session.payment,
+        amountConfirming: '0.5',
+      },
+    });
+
+    expect(result).toBeUndefined();
+    expect(getStoredSession().sendStarted).toBe(false);
+  });
+
+  test('keeps a latched session undiscardable when a later snapshot reports zero progress', async () => {
+    const { entity, getStoredSession } = makeLatchEntity();
+
+    await entity.latchInfiniPendingPaymentSessionProgress({
+      onekeyUserId: 'user-1',
+      paymentCacheKey: session.paymentCacheKey,
+      latestPayment: {
+        ...session.payment,
+        amountConfirming: '0.5',
+      },
+    });
+    // Final consistency can report the confirming amount back as zero; the
+    // merge would then see no progress, so only the persisted sendStarted
+    // latch keeps the session from being replaced by a second invoice.
+    await entity.latchInfiniPendingPaymentSessionProgress({
+      onekeyUserId: 'user-1',
+      paymentCacheKey: session.paymentCacheKey,
+      latestPayment: {
+        ...session.payment,
+        amountConfirming: '0',
+      },
+    });
+
+    expect(getStoredSession().sendStarted).toBe(true);
+    await expect(
+      entity.discardUnsentInfiniPendingPaymentSession({
+        onekeyUserId: 'user-1',
+        expectedPaymentCacheIdentity: session.paymentCacheKey,
+      }),
+    ).resolves.toBe(false);
+    expect(getStoredSession().sendStarted).toBe(true);
+  });
+
   test('atomically marks the matching session before transaction broadcast', async () => {
     const entity = new SimpleDbEntityPrime();
     const persistedSession = {

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.test.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.test.ts
@@ -2012,6 +2012,30 @@ describe('SimpleDbEntityPrime Infini pending payment session', () => {
     };
   };
 
+  const makeTerminalDiscardEntity = () => {
+    const entity = new SimpleDbEntityPrime();
+    let persisted = {
+      infiniPendingPaymentSessionByUserId: {
+        'user-1': {
+          ...session,
+          schemaVersion: 2 as const,
+          updatedAt: Date.now(),
+          sendStarted: true,
+        },
+      } as Record<
+        string,
+        typeof session & { schemaVersion: 2; updatedAt: number }
+      >,
+    };
+    jest.spyOn(entity, 'setRawData').mockImplementation((async (
+      updater: (rawData: typeof persisted) => typeof persisted,
+    ) => {
+      persisted = updater(persisted);
+      return persisted;
+    }) as never);
+    return { entity, getRawData: () => persisted };
+  };
+
   test('latches server-observed progress onto an unsent session', async () => {
     const { entity, getStoredSession } = makeLatchEntity();
 
@@ -2093,6 +2117,51 @@ describe('SimpleDbEntityPrime Infini pending payment session', () => {
       }),
     ).resolves.toBe(false);
     expect(getStoredSession().sendStarted).toBe(true);
+  });
+
+  test('releases a claimed session once the server closes the invoice unpaid', async () => {
+    const { entity, getStoredSession } = makeLatchEntity();
+    await entity.latchInfiniPendingPaymentSessionProgress({
+      onekeyUserId: 'user-1',
+      paymentCacheKey: session.paymentCacheKey,
+      latestPayment: { ...session.payment, amountConfirming: '0.5' },
+    });
+    expect(getStoredSession().sendStarted).toBe(true);
+
+    await expect(
+      entity.discardTerminalInfiniPendingPaymentSession({
+        onekeyUserId: 'user-1',
+        expectedPaymentCacheIdentity: session.paymentCacheKey,
+        latestPayment: { ...session.payment, status: 'expired' },
+      }),
+    ).resolves.toBe(false);
+
+    const { entity: freshEntity, getRawData } = makeTerminalDiscardEntity();
+    await expect(
+      freshEntity.discardTerminalInfiniPendingPaymentSession({
+        onekeyUserId: 'user-1',
+        expectedPaymentCacheIdentity: session.paymentCacheKey,
+        latestPayment: { ...session.payment, status: 'expired' },
+      }),
+    ).resolves.toBe(true);
+    expect(
+      getRawData().infiniPendingPaymentSessionByUserId['user-1'],
+    ).toBeUndefined();
+  });
+
+  test('refuses to release a claimed session that only expired on the local clock', async () => {
+    const { entity, getRawData } = makeTerminalDiscardEntity();
+
+    await expect(
+      entity.discardTerminalInfiniPendingPaymentSession({
+        onekeyUserId: 'user-1',
+        expectedPaymentCacheIdentity: session.paymentCacheKey,
+        latestPayment: { ...session.payment, expiresAt: 1 },
+      }),
+    ).resolves.toBe(false);
+    expect(
+      getRawData().infiniPendingPaymentSessionByUserId['user-1'],
+    ).toBeDefined();
   });
 
   test('atomically marks the matching session before transaction broadcast', async () => {

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.ts
@@ -1592,6 +1592,87 @@ export class SimpleDbEntityPrime extends SimpleDbEntityBase<ISimpleDBPrime> {
     return didDiscard;
   }
 
+  // The payment-entry guard is the first place that observes server-side
+  // progress for a session that was never marked locally. Latch that progress
+  // durably here: a later snapshot that transiently reports zero progress must
+  // not make the session replaceable again and let a second invoice be
+  // created. Writes only on new information so the session TTL is not
+  // refreshed by every read.
+  @backgroundMethod()
+  async latchInfiniPendingPaymentSessionProgress({
+    onekeyUserId,
+    paymentCacheKey,
+    latestPayment,
+  }: {
+    onekeyUserId: string;
+    paymentCacheKey: IPrimeInfiniPaymentCacheKey;
+    latestPayment: IPrimeInfiniPayment;
+  }): Promise<IPrimeInfiniPendingPaymentSession | undefined> {
+    if (!onekeyUserId || !isValidInfiniPaymentCacheKey(paymentCacheKey)) {
+      return undefined;
+    }
+    let latchedSession: IPrimeInfiniPendingPaymentSession | undefined;
+    await this.setRawData((rawData) => {
+      const now = Date.now();
+      const currentSession =
+        rawData?.infiniPendingPaymentSessionByUserId?.[onekeyUserId];
+      if (
+        !currentSession ||
+        !isValidInfiniPendingPaymentSession(currentSession, {
+          onekeyUserId,
+          now,
+        }) ||
+        !isSamePrimeInfiniPaymentCacheKey(
+          paymentCacheKey,
+          currentSession.paymentCacheKey,
+        ) ||
+        !isSamePrimeInfiniPaymentTransferSnapshot({
+          first: currentSession.payment,
+          second: latestPayment,
+          networkId: currentSession.asset.networkId,
+        }) ||
+        !isPrimeInfiniPaymentForAssetSnapshot({
+          payment: latestPayment,
+          asset: currentSession.asset,
+        })
+      ) {
+        return rawData ?? {};
+      }
+      const paymentWithDurableProgress =
+        mergePrimeInfiniPaymentProgressSnapshot({
+          previous: currentSession.payment,
+          latest: latestPayment,
+        });
+      const sendStarted =
+        currentSession.sendStarted ||
+        hasPrimeInfiniPaymentProgressSnapshot(paymentWithDurableProgress);
+      const hasNewDurableProgress =
+        sendStarted !== currentSession.sendStarted ||
+        paymentWithDurableProgress.amountConfirmed !==
+          currentSession.payment.amountConfirmed ||
+        paymentWithDurableProgress.amountConfirming !==
+          currentSession.payment.amountConfirming;
+      if (!hasNewDurableProgress) {
+        latchedSession = currentSession;
+        return rawData ?? {};
+      }
+      latchedSession = {
+        ...currentSession,
+        payment: paymentWithDurableProgress,
+        sendStarted,
+        updatedAt: now,
+      };
+      return {
+        ...rawData,
+        infiniPendingPaymentSessionByUserId: {
+          ...rawData?.infiniPendingPaymentSessionByUserId,
+          [onekeyUserId]: latchedSession,
+        },
+      };
+    });
+    return latchedSession;
+  }
+
   @backgroundMethod()
   async markInfiniPendingPaymentSessionSendStarted({
     onekeyUserId,

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPrime.ts
@@ -7,6 +7,7 @@ import {
   getPrimeInfiniPaymentAssetKey,
   hasPrimeInfiniPaymentProgressSnapshot,
   isPrimeInfiniPaymentCacheKeyForContext,
+  isPrimeInfiniPaymentClosedUnpaidSnapshot,
   isPrimeInfiniPaymentForAssetSnapshot,
   isPrimeInfiniPaymentPreBroadcastSnapshotSendable,
   isPrimeInfiniPaymentTransferClaimForSession,
@@ -1587,6 +1588,78 @@ export class SimpleDbEntityPrime extends SimpleDbEntityBase<ISimpleDBPrime> {
       return retireExpectedPayment({
         ...rawData,
         infiniPendingPaymentSessionByUserId: nextSessions,
+      });
+    });
+    return didDiscard;
+  }
+
+  // Releases a session whose invoice the server has closed with nothing
+  // collected, including one that already claimed sendStarted. That claim is
+  // set before broadcast and is never cleared except on purchase completion, so
+  // a transaction that reverted or ran out of gas would otherwise pin the
+  // session for its whole TTL and block every purchase channel behind the
+  // payment-entry guard. The progress merge runs against the stored session so
+  // a transient zero-progress snapshot cannot release a payment that is
+  // actually moving, and a tombstone is retired alongside it so a stale writer
+  // cannot resurrect the session.
+  @backgroundMethod()
+  async discardTerminalInfiniPendingPaymentSession({
+    onekeyUserId,
+    expectedPaymentCacheIdentity,
+    latestPayment,
+  }: {
+    onekeyUserId: string;
+    expectedPaymentCacheIdentity: IPrimeInfiniPaymentCacheKey;
+    latestPayment: IPrimeInfiniPayment;
+  }): Promise<boolean> {
+    if (
+      !onekeyUserId ||
+      !isValidInfiniPaymentCacheKey(expectedPaymentCacheIdentity)
+    ) {
+      return false;
+    }
+    let didDiscard = false;
+    await this.setRawData((rawData) => {
+      const now = Date.now();
+      const currentSession =
+        rawData?.infiniPendingPaymentSessionByUserId?.[onekeyUserId];
+      if (
+        !currentSession ||
+        !isValidInfiniPendingPaymentSession(currentSession, {
+          onekeyUserId,
+          now,
+        }) ||
+        !isSamePrimeInfiniPaymentCacheKey(
+          expectedPaymentCacheIdentity,
+          currentSession.paymentCacheKey,
+        ) ||
+        currentSession.payment.paymentId !== latestPayment.paymentId
+      ) {
+        return rawData ?? {};
+      }
+      const paymentWithDurableProgress =
+        mergePrimeInfiniPaymentProgressSnapshot({
+          previous: currentSession.payment,
+          latest: latestPayment,
+        });
+      if (
+        !isPrimeInfiniPaymentClosedUnpaidSnapshot(paymentWithDurableProgress)
+      ) {
+        return rawData ?? {};
+      }
+      const nextSessions = {
+        ...rawData?.infiniPendingPaymentSessionByUserId,
+      };
+      delete nextSessions[onekeyUserId];
+      didDiscard = true;
+      return retireInfiniPaymentCache({
+        rawData: {
+          ...rawData,
+          infiniPendingPaymentSessionByUserId: nextSessions,
+        },
+        onekeyUserId,
+        paymentCacheKey: expectedPaymentCacheIdentity,
+        now,
       });
     });
     return didDiscard;

--- a/packages/kit-bg/src/services/ServiceSend.broadcastDeadline.test.ts
+++ b/packages/kit-bg/src/services/ServiceSend.broadcastDeadline.test.ts
@@ -371,14 +371,7 @@ describe('ServiceSend.signAndSendTransaction broadcastDeadline', () => {
       vault.buildDecodedTx.mock.invocationCallOrder[0],
     );
     expect(vault.buildDecodedTx.mock.invocationCallOrder[0]).toBeLessThan(
-      (
-        backgroundApi as unknown as {
-          servicePrime: {
-            apiGetInfiniPaymentPreBroadcastSnapshot: jest.Mock;
-          };
-        }
-      ).servicePrime.apiGetInfiniPaymentPreBroadcastSnapshot.mock
-        .invocationCallOrder[0],
+      mark.mock.invocationCallOrder[0],
     );
     expect(
       (
@@ -393,6 +386,39 @@ describe('ServiceSend.signAndSendTransaction broadcastDeadline', () => {
     expect(mark.mock.invocationCallOrder[0]).toBeLessThan(
       vault.broadcastTransaction.mock.invocationCallOrder[0],
     );
+  });
+
+  test('loads the Infini snapshot while decoding the signed transaction', async () => {
+    const { service, vault } = makeService();
+    const backgroundApi = service.backgroundApi as unknown as {
+      servicePrime: {
+        apiGetInfiniPaymentPreBroadcastSnapshot: jest.Mock;
+      };
+    };
+    const decodedTxDeferred = createDeferred<IDecodedTx>();
+    const snapshotStarted = createDeferred<void>();
+    vault.buildDecodedTx.mockReturnValueOnce(decodedTxDeferred.promise);
+    backgroundApi.servicePrime.apiGetInfiniPaymentPreBroadcastSnapshot.mockImplementationOnce(
+      async () => {
+        snapshotStarted.resolve();
+        return {
+          payment: latestPayment,
+          purchaseStatusSnapshot,
+        };
+      },
+    );
+
+    const sendPromise = signAndSend(service, {
+      beforeBroadcastAction,
+    });
+    await snapshotStarted.promise;
+
+    expect(vault.buildDecodedTx).toHaveBeenCalledTimes(1);
+    expect(vault.broadcastTransaction).not.toHaveBeenCalled();
+
+    decodedTxDeferred.resolve(decodedTx);
+    await expect(sendPromise).resolves.toMatchObject({ txid: '0xtxid' });
+    expect(vault.broadcastTransaction).toHaveBeenCalledTimes(1);
   });
 
   test('rejects a signed TRON Infini transaction with multiple native contracts', async () => {

--- a/packages/kit-bg/src/services/ServiceSend.ts
+++ b/packages/kit-bg/src/services/ServiceSend.ts
@@ -480,21 +480,31 @@ class ServiceSend extends ServiceBase {
             autoToast: false,
           });
         }
-        let decodedTx: IDecodedTx;
-        try {
-          decodedTx = await vault.buildDecodedTx({
+        ensureBroadcastDeadline();
+        await ensurePrimePaymentUserIsCurrent();
+        const decodedTxPromise = vault
+          .buildDecodedTx({
             unsignedTx: {
               ...unsignedTx,
               encodedTx: signedTx.encodedTx,
             },
             transferPayload,
+          })
+          .catch(() => {
+            throw new OneKeyLocalError({
+              message: 'Infini payment transaction cannot be verified',
+              autoToast: false,
+            });
           });
-        } catch {
-          throw new OneKeyLocalError({
-            message: 'Infini payment transaction cannot be verified',
-            autoToast: false,
-          });
-        }
+        const preBroadcastSnapshotPromise =
+          this.backgroundApi.servicePrime.apiGetInfiniPaymentPreBroadcastSnapshot(
+            {
+              paymentId: paymentCacheKey.paymentId,
+              expectedOneKeyUserId: paymentCacheKey.onekeyUserId,
+            },
+          );
+        const [decodedTx, { payment: latestPayment, purchaseStatusSnapshot }] =
+          await Promise.all([decodedTxPromise, preBroadcastSnapshotPromise]);
         const action = decodedTx.actions[0];
         const transfer = action?.assetTransfer?.sends[0];
         const isExpectedSingleTokenTransfer =
@@ -546,15 +556,6 @@ class ServiceSend extends ServiceBase {
           contractAddress: transfer.tokenIdOnNetwork,
           amount: transfer.amount,
         };
-        ensureBroadcastDeadline();
-        await ensurePrimePaymentUserIsCurrent();
-        const { payment: latestPayment, purchaseStatusSnapshot } =
-          await this.backgroundApi.servicePrime.apiGetInfiniPaymentPreBroadcastSnapshot(
-            {
-              paymentId: paymentCacheKey.paymentId,
-              expectedOneKeyUserId: paymentCacheKey.onekeyUserId,
-            },
-          );
         ensureBroadcastDeadline();
         if (
           !isPrimeInfiniPaymentPreBroadcastSnapshotSendable({

--- a/packages/kit/src/views/Prime/components/PrimeInfiniWalletPayment.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeInfiniWalletPayment.tsx
@@ -2488,10 +2488,15 @@ function PrimeInfiniWalletPaymentContent({
             setPhase('polling');
             throw new OneKeyLocalError('Infini payment send already started');
           }
-          const persistedSession =
-            await backgroundApiProxy.simpleDb.prime.getInfiniPendingPaymentSession(
-              { onekeyUserId: purchaseUserIdForSend },
-            );
+          const [persistedSession, latestPayment] = await Promise.all([
+            backgroundApiProxy.simpleDb.prime.getInfiniPendingPaymentSession({
+              onekeyUserId: purchaseUserIdForSend,
+            }),
+            backgroundApiProxy.servicePrime.apiGetInfiniPayment({
+              paymentId: paymentForSend.paymentId,
+              expectedOneKeyUserId: purchaseUserIdForSend,
+            }),
+          ]);
           if (
             !persistedSession ||
             !isSamePrimeInfiniPaymentCacheKey(
@@ -2510,11 +2515,6 @@ function PrimeInfiniWalletPaymentContent({
             setPhase('polling');
             throw new OneKeyLocalError('Infini payment send already started');
           }
-          const latestPayment =
-            await backgroundApiProxy.servicePrime.apiGetInfiniPayment({
-              paymentId: paymentForSend.paymentId,
-              expectedOneKeyUserId: purchaseUserIdForSend,
-            });
           if (!isAttemptCurrent()) {
             preSendBlockedPhase = 'failed';
             throw new OneKeyLocalError('Infini payment attempt is stale');
@@ -2536,7 +2536,6 @@ function PrimeInfiniWalletPaymentContent({
           }
           paymentRef.current = latestPayment;
           setPayment(latestPayment);
-          await persistPaymentSession({ nextPayment: latestPayment });
           const latestOutcome = getPrimeInfiniPaymentOutcome({
             payment: latestPayment,
           });
@@ -2562,6 +2561,10 @@ function PrimeInfiniWalletPaymentContent({
           ) {
             preSendBlockedPhase =
               latestOutcome === 'failed' ? 'failed' : 'expired';
+            await persistPaymentSession({
+              nextPayment: latestPayment,
+              nextSendStarted: false,
+            });
             setPhase(preSendBlockedPhase);
             throw new OneKeyLocalError('Infini payment is no longer sendable');
           }

--- a/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.test.tsx
+++ b/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.test.tsx
@@ -1,0 +1,238 @@
+/** @jest-environment jsdom */
+/* cspell:ignore Infini */
+
+import type { ReactElement, ReactNode } from 'react';
+
+import { act, cleanup, renderHook } from '@testing-library/react';
+
+import { usePrimePurchaseCallback } from './PrimePurchaseDialog';
+
+type IPrimeInfiniPaymentEntryGuard = {
+  isLoggedIn: boolean;
+  hasPendingPayment: boolean;
+  onekeyUserId: string | undefined;
+};
+
+type IMockDialogConfig = {
+  renderContent?: ReactNode;
+};
+
+type IMockDialogInstance = {
+  close: () => Promise<void>;
+};
+
+const mockDialogShow = jest.fn<
+  IMockDialogInstance,
+  [config: IMockDialogConfig]
+>();
+const mockPaymentMethodDialogClose = jest.fn(async () => undefined);
+const mockGetPrimeInfiniPaymentEntryGuard = jest.fn<
+  Promise<IPrimeInfiniPaymentEntryGuard>,
+  []
+>();
+const mockPurchaseByCrypto = jest.fn(async () => undefined);
+const mockPurchasePackageWeb = jest.fn(async () => undefined);
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    locale: 'en-US',
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+jest.mock('@onekeyhq/components', () => {
+  function Passthrough({ children }: { children?: ReactNode }) {
+    return children ?? null;
+  }
+  return {
+    Dialog: {
+      show: (config: IMockDialogConfig) => mockDialogShow(config),
+    },
+    Skeleton: () => null,
+    Stack: Passthrough,
+    YStack: Passthrough,
+  };
+});
+
+jest.mock('@onekeyhq/kit/src/components/ListItem', () => ({
+  ListItem: () => null,
+}));
+
+jest.mock('@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth', () => ({
+  useOneKeyAuth: () => ({
+    supabaseUser: {
+      email: 'user@example.com',
+    },
+    user: {
+      onekeyUserId: 'user-1',
+    },
+  }),
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => ({
+  usePromiseResult: () => ({
+    result: undefined,
+  }),
+}));
+
+jest.mock('@onekeyhq/shared/src/googlePlayService/googlePlayService', () => ({
+  __esModule: true,
+  default: {
+    isAvailable: jest.fn(async () => false),
+  },
+}));
+
+jest.mock('@onekeyhq/shared/src/logger/logger', () => ({
+  defaultLogger: {
+    prime: {
+      subscription: {
+        primeSubscribeIntent: jest.fn(),
+      },
+    },
+  },
+}));
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: {
+    isNativeAndroid: false,
+    isNativeAndroidGooglePlay: false,
+    isNativeIOS: false,
+  },
+}));
+
+jest.mock('../../hooks/primeInfiniExternalCheckoutGuard', () => ({
+  getPrimeInfiniPaymentEntryGuard: () => mockGetPrimeInfiniPaymentEntryGuard(),
+}));
+
+jest.mock('../../hooks/usePrimeInfiniPurchase', () => ({
+  usePrimeInfiniPurchase: () => ({
+    purchaseByCrypto: mockPurchaseByCrypto,
+  }),
+}));
+
+jest.mock('../../hooks/usePrimePayment', () => ({
+  usePrimePayment: () => ({
+    purchasePackageWeb: mockPurchasePackageWeb,
+  }),
+}));
+
+jest.mock('../../primeInfiniPaymentLogger', () => ({
+  logPrimeInfiniPaymentFlow: jest.fn(),
+}));
+
+jest.mock('../../primePurchaseEligibility', () => ({
+  ensurePrimePurchaseEligible: jest.fn(async () => true),
+}));
+
+jest.mock('../../primeSubscriptionPurchaseSuccess', () => ({
+  finishPrimeSubscriptionPurchaseSuccess: jest.fn(async () => undefined),
+  preparePrimeSubscriptionPurchaseSuccess: jest.fn(async () => undefined),
+}));
+
+jest.mock('./PrimeSubscriptionPlans', () => ({
+  PrimeSubscriptionPlans: () => null,
+}));
+
+jest.mock('./usePurchasePackageWebview', () => ({
+  usePurchasePackageWebview: () => jest.fn(async () => undefined),
+}));
+
+type IPaymentMethodDialogContent = ReactElement<{
+  children: ReactElement<{
+    onSelect: (method: 'webStripe') => Promise<boolean>;
+  }>;
+}>;
+
+describe('usePrimePurchaseCallback pending payment entry guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDialogShow.mockReturnValue({
+      close: mockPaymentMethodDialogClose,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('resumes the crypto flow before showing payment methods', async () => {
+    mockGetPrimeInfiniPaymentEntryGuard.mockResolvedValue({
+      isLoggedIn: true,
+      hasPendingPayment: true,
+      onekeyUserId: 'user-1',
+    });
+    const onPurchase = jest.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      usePrimePurchaseCallback({ onPurchase }),
+    );
+
+    await act(async () => {
+      await result.current.purchase({
+        selectedSubscriptionPeriod: 'P1Y',
+      });
+    });
+
+    expect(onPurchase).toHaveBeenCalledTimes(1);
+    expect(mockPurchaseByCrypto).toHaveBeenCalledWith({
+      selectedSubscriptionPeriod: 'P1Y',
+      featureName: undefined,
+    });
+    expect(mockDialogShow).not.toHaveBeenCalled();
+  });
+
+  it('shows payment methods when no blocking payment exists', async () => {
+    mockGetPrimeInfiniPaymentEntryGuard.mockResolvedValue({
+      isLoggedIn: true,
+      hasPendingPayment: false,
+      onekeyUserId: 'user-1',
+    });
+    const { result } = renderHook(() => usePrimePurchaseCallback());
+
+    await act(async () => {
+      await result.current.purchase({
+        selectedSubscriptionPeriod: 'P1M',
+      });
+    });
+
+    expect(mockDialogShow).toHaveBeenCalledTimes(1);
+    expect(mockPurchaseByCrypto).not.toHaveBeenCalled();
+  });
+
+  it('reroutes a payment method selection when a payment starts while the picker is open', async () => {
+    mockGetPrimeInfiniPaymentEntryGuard
+      .mockResolvedValueOnce({
+        isLoggedIn: true,
+        hasPendingPayment: false,
+        onekeyUserId: 'user-1',
+      })
+      .mockResolvedValueOnce({
+        isLoggedIn: true,
+        hasPendingPayment: true,
+        onekeyUserId: 'user-1',
+      });
+    const { result } = renderHook(() => usePrimePurchaseCallback());
+
+    await act(async () => {
+      await result.current.purchase({
+        selectedSubscriptionPeriod: 'P1Y',
+      });
+    });
+
+    const dialogConfig = mockDialogShow.mock.calls[0][0] as {
+      renderContent: IPaymentMethodDialogContent;
+    };
+    const paymentMethodItems = dialogConfig.renderContent.props.children;
+
+    await act(async () => {
+      await paymentMethodItems.props.onSelect('webStripe');
+    });
+
+    expect(mockPaymentMethodDialogClose).toHaveBeenCalledTimes(1);
+    expect(mockPurchaseByCrypto).toHaveBeenCalledWith({
+      selectedSubscriptionPeriod: 'P1Y',
+      featureName: undefined,
+    });
+    expect(mockPurchasePackageWeb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.test.tsx
+++ b/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.test.tsx
@@ -32,6 +32,7 @@ const mockGetPrimeInfiniPaymentEntryGuard = jest.fn<
 >();
 const mockPurchaseByCrypto = jest.fn(async () => undefined);
 const mockPurchasePackageWeb = jest.fn(async () => undefined);
+const mockToastError = jest.fn<void, [config: { title: string }]>();
 
 jest.mock('react-intl', () => ({
   useIntl: () => ({
@@ -50,6 +51,9 @@ jest.mock('@onekeyhq/components', () => {
     },
     Skeleton: () => null,
     Stack: Passthrough,
+    Toast: {
+      error: (config: { title: string }) => mockToastError(config),
+    },
     YStack: Passthrough,
   };
 });
@@ -197,6 +201,30 @@ describe('usePrimePurchaseCallback pending payment entry guard', () => {
 
     expect(mockDialogShow).toHaveBeenCalledTimes(1);
     expect(mockPurchaseByCrypto).not.toHaveBeenCalled();
+  });
+
+  it('blocks the purchase with a visible error when the guard request fails', async () => {
+    mockGetPrimeInfiniPaymentEntryGuard.mockRejectedValue(
+      new Error('network down'),
+    );
+    const onPurchase = jest.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      usePrimePurchaseCallback({ onPurchase }),
+    );
+
+    await act(async () => {
+      await expect(
+        result.current.purchase({
+          selectedSubscriptionPeriod: 'P1Y',
+        }),
+      ).rejects.toThrow('Unable to verify the Infini payment session');
+    });
+
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    expect(mockDialogShow).not.toHaveBeenCalled();
+    expect(mockPurchaseByCrypto).not.toHaveBeenCalled();
+    expect(mockPurchasePackageWeb).not.toHaveBeenCalled();
+    expect(onPurchase).not.toHaveBeenCalled();
   });
 
   it('reroutes a payment method selection when a payment starts while the picker is open', async () => {

--- a/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.tsx
+++ b/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.tsx
@@ -289,7 +289,12 @@ export function usePrimePurchaseCallback({
         }
         await beforeContinue();
         await purchaseByCryptoUnchecked({
-          selectedSubscriptionPeriod,
+          // Resume the in-flight invoice on its own period. Passing the period
+          // the user just picked would restore a monthly invoice under a
+          // yearly request, which the restore path tracks without complaint
+          // once the payment is no longer replaceable.
+          selectedSubscriptionPeriod:
+            entryGuard.pendingSubscriptionPeriod ?? selectedSubscriptionPeriod,
           featureName,
         });
         return true;

--- a/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.tsx
+++ b/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.tsx
@@ -4,10 +4,11 @@ import { useCallback, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import type { IActionListItemProps } from '@onekeyhq/components';
-import { Dialog, Skeleton, Stack, YStack } from '@onekeyhq/components';
+import { Dialog, Skeleton, Stack, Toast, YStack } from '@onekeyhq/components';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { useOneKeyAuth } from '@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import googlePlayService from '@onekeyhq/shared/src/googlePlayService/googlePlayService';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
@@ -264,7 +265,25 @@ export function usePrimePurchaseCallback({
       }: {
         beforeContinue: () => void | Promise<void>;
       }) => {
-        const entryGuard = await getPrimeInfiniPaymentEntryGuard();
+        // The guard hits the network, so a failure means the active-payment
+        // state is unknown. Block the attempt instead of falling through to a
+        // second channel: a duplicate charge is worse than a retryable error.
+        let entryGuard: Awaited<
+          ReturnType<typeof getPrimeInfiniPaymentEntryGuard>
+        >;
+        try {
+          entryGuard = await getPrimeInfiniPaymentEntryGuard();
+        } catch {
+          Toast.error({
+            title: intl.formatMessage({
+              id: ETranslations.global_network_error,
+            }),
+          });
+          throw new OneKeyLocalError({
+            message: 'Unable to verify the Infini payment session',
+            autoToast: false,
+          });
+        }
         if (!entryGuard.hasPendingPayment) {
           return false;
         }
@@ -386,6 +405,7 @@ export function usePrimePurchaseCallback({
       });
     },
     [
+      intl,
       onPurchase,
       purchaseByCryptoUnchecked,
       purchaseByNativeUnchecked,

--- a/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.tsx
+++ b/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.tsx
@@ -15,6 +15,7 @@ import type { IPrimePaymentMethod } from '@onekeyhq/shared/src/logger/scopes/pri
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { EPrimeFeatures } from '@onekeyhq/shared/src/routes/prime';
 
+import { getPrimeInfiniPaymentEntryGuard } from '../../hooks/primeInfiniExternalCheckoutGuard';
 import { usePrimeInfiniPurchase } from '../../hooks/usePrimeInfiniPurchase';
 import { usePrimePayment } from '../../hooks/usePrimePayment';
 import { logPrimeInfiniPaymentFlow } from '../../primeInfiniPaymentLogger';
@@ -258,6 +259,32 @@ export function usePrimePurchaseCallback({
           paymentMethod,
         });
       };
+      const continuePendingCryptoPayment = async ({
+        beforeContinue,
+      }: {
+        beforeContinue: () => void | Promise<void>;
+      }) => {
+        const entryGuard = await getPrimeInfiniPaymentEntryGuard();
+        if (!entryGuard.hasPendingPayment) {
+          return false;
+        }
+        await beforeContinue();
+        await purchaseByCryptoUnchecked({
+          selectedSubscriptionPeriod,
+          featureName,
+        });
+        return true;
+      };
+
+      if (
+        await continuePendingCryptoPayment({
+          beforeContinue: async () => {
+            await onPurchase?.();
+          },
+        })
+      ) {
+        return;
+      }
 
       if (platformEnv.isNativeIOS || platformEnv.isNativeAndroidGooglePlay) {
         if (
@@ -296,6 +323,15 @@ export function usePrimePurchaseCallback({
             <PrimePaymentMethodItems
               methods={paymentMethods}
               onSelect={async (method) => {
+                if (
+                  await continuePendingCryptoPayment({
+                    beforeContinue: async () => {
+                      await paymentMethodDialog.close();
+                    },
+                  })
+                ) {
+                  return true;
+                }
                 if (
                   !(await ensurePrimePurchaseEligible({
                     expectedOneKeyUserId: user?.onekeyUserId,

--- a/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.tsx
+++ b/packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.tsx
@@ -295,6 +295,16 @@ export function usePrimePurchaseCallback({
         return true;
       };
 
+      // This gate is deliberately channel-wide and runs before the IAP and
+      // Google Play branches, not only on the crypto path.
+      // entryGuard.hasPendingPayment answers "is the user's money already
+      // committed to an Infini invoice" (a broadcast was claimed, or the chain
+      // and server report progress on it) — it does not answer "does the user
+      // want to pay with crypto". Starting IAP, Stripe or the WebView checkout
+      // while such an invoice is in flight charges for one subscription twice,
+      // and the crypto leg cannot be cancelled once broadcast, so the in-flight
+      // payment has to be resumed first. Narrowing this to the crypto channel
+      // reintroduces exactly the double charge it exists to prevent.
       if (
         await continuePendingCryptoPayment({
           beforeContinue: async () => {

--- a/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.test.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.test.ts
@@ -16,6 +16,16 @@ const mockApiGetInfiniPayment = jest.fn<
   Promise<unknown>,
   [{ paymentId: string; expectedOneKeyUserId: string }]
 >();
+const mockLatchPendingPaymentProgress = jest.fn<
+  Promise<unknown>,
+  [
+    {
+      onekeyUserId: string;
+      paymentCacheKey: { paymentId: string };
+      latestPayment: unknown;
+    },
+  ]
+>();
 
 jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
   __esModule: true,
@@ -31,6 +41,11 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
       prime: {
         getInfiniPendingPaymentSession: (params: { onekeyUserId: string }) =>
           mockGetPendingPaymentSession(params),
+        latchInfiniPendingPaymentSessionProgress: (params: {
+          onekeyUserId: string;
+          paymentCacheKey: { paymentId: string };
+          latestPayment: unknown;
+        }) => mockLatchPendingPaymentProgress(params),
       },
     },
   },
@@ -105,6 +120,41 @@ describe('getPrimeInfiniExternalCheckoutGuard', () => {
     });
   });
 
+  it('latches the observed server progress before blocking', async () => {
+    mockGetLocalUserInfo.mockResolvedValue({
+      isLoggedIn: true,
+      onekeyUserId: 'user-1',
+    });
+    mockGetPendingPaymentSession.mockResolvedValue({
+      sendStarted: false,
+      paymentCacheKey: {
+        paymentId: 'payment-1',
+      },
+      payment: {
+        paymentId: 'payment-1',
+        amountDue: '1',
+        amountConfirmed: '0',
+        amountConfirming: '0',
+      },
+    });
+    const latestPayment = {
+      paymentId: 'payment-1',
+      amountDue: '1',
+      amountConfirmed: '0',
+      amountConfirming: '0.5',
+    };
+    mockApiGetInfiniPayment.mockResolvedValue(latestPayment);
+
+    await getPrimeInfiniPaymentEntryGuard();
+
+    expect(mockLatchPendingPaymentProgress).toHaveBeenCalledTimes(1);
+    expect(mockLatchPendingPaymentProgress).toHaveBeenCalledWith({
+      onekeyUserId: 'user-1',
+      paymentCacheKey: { paymentId: 'payment-1' },
+      latestPayment,
+    });
+  });
+
   it('blocks the payment method picker when the server reports payment progress', async () => {
     mockGetLocalUserInfo.mockResolvedValue({
       isLoggedIn: true,
@@ -165,5 +215,6 @@ describe('getPrimeInfiniExternalCheckoutGuard', () => {
       hasPendingPayment: false,
       onekeyUserId: 'user-1',
     });
+    expect(mockLatchPendingPaymentProgress).not.toHaveBeenCalled();
   });
 });

--- a/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.test.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.test.ts
@@ -1,5 +1,8 @@
 /* cspell:ignore Infini */
-import { getPrimeInfiniExternalCheckoutGuard } from './primeInfiniExternalCheckoutGuard';
+import {
+  getPrimeInfiniExternalCheckoutGuard,
+  getPrimeInfiniPaymentEntryGuard,
+} from './primeInfiniExternalCheckoutGuard';
 
 const mockGetLocalUserInfo = jest.fn<
   Promise<{ isLoggedIn: boolean; onekeyUserId?: string }>,
@@ -9,12 +12,20 @@ const mockGetPendingPaymentSession = jest.fn<
   Promise<unknown>,
   [{ onekeyUserId: string }]
 >();
+const mockApiGetInfiniPayment = jest.fn<
+  Promise<unknown>,
+  [{ paymentId: string; expectedOneKeyUserId: string }]
+>();
 
 jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
   __esModule: true,
   default: {
     servicePrime: {
       getLocalUserInfo: () => mockGetLocalUserInfo(),
+      apiGetInfiniPayment: (params: {
+        paymentId: string;
+        expectedOneKeyUserId: string;
+      }) => mockApiGetInfiniPayment(params),
     },
     simpleDb: {
       prime: {
@@ -61,5 +72,98 @@ describe('getPrimeInfiniExternalCheckoutGuard', () => {
       onekeyUserId: undefined,
     });
     expect(mockGetPendingPaymentSession).not.toHaveBeenCalled();
+  });
+
+  it('blocks the payment method picker after a send has started', async () => {
+    mockGetLocalUserInfo.mockResolvedValue({
+      isLoggedIn: true,
+      onekeyUserId: 'user-1',
+    });
+    mockGetPendingPaymentSession.mockResolvedValue({
+      sendStarted: true,
+      paymentCacheKey: {
+        paymentId: 'payment-1',
+      },
+      payment: {
+        paymentId: 'payment-1',
+        amountDue: '1',
+        amountConfirmed: '0',
+        amountConfirming: '0',
+      },
+    });
+    mockApiGetInfiniPayment.mockResolvedValue({
+      paymentId: 'payment-1',
+      amountDue: '1',
+      amountConfirmed: '0',
+      amountConfirming: '0',
+    });
+
+    await expect(getPrimeInfiniPaymentEntryGuard()).resolves.toEqual({
+      isLoggedIn: true,
+      hasPendingPayment: true,
+      onekeyUserId: 'user-1',
+    });
+  });
+
+  it('blocks the payment method picker when the server reports payment progress', async () => {
+    mockGetLocalUserInfo.mockResolvedValue({
+      isLoggedIn: true,
+      onekeyUserId: 'user-1',
+    });
+    mockGetPendingPaymentSession.mockResolvedValue({
+      sendStarted: false,
+      paymentCacheKey: {
+        paymentId: 'payment-1',
+      },
+      payment: {
+        paymentId: 'payment-1',
+        amountDue: '1',
+        amountConfirmed: '0',
+        amountConfirming: '0',
+      },
+    });
+    mockApiGetInfiniPayment.mockResolvedValue({
+      paymentId: 'payment-1',
+      amountDue: '1',
+      amountConfirmed: '0',
+      amountConfirming: '0.5',
+    });
+
+    await expect(getPrimeInfiniPaymentEntryGuard()).resolves.toEqual({
+      isLoggedIn: true,
+      hasPendingPayment: true,
+      onekeyUserId: 'user-1',
+    });
+  });
+
+  it('allows the payment method picker for an unsent replaceable invoice', async () => {
+    mockGetLocalUserInfo.mockResolvedValue({
+      isLoggedIn: true,
+      onekeyUserId: 'user-1',
+    });
+    mockGetPendingPaymentSession.mockResolvedValue({
+      sendStarted: false,
+      paymentCacheKey: {
+        paymentId: 'payment-1',
+      },
+      payment: {
+        paymentId: 'payment-1',
+        amountDue: '1',
+        amountConfirmed: '0',
+        amountConfirming: '0',
+      },
+    });
+    mockApiGetInfiniPayment.mockResolvedValue({
+      paymentId: 'payment-1',
+      amountDue: '1',
+      amountConfirmed: '0',
+      amountConfirming: '0',
+    });
+
+    await expect(getPrimeInfiniPaymentEntryGuard()).resolves.toEqual({
+      isLoggedIn: true,
+      hasPendingPayment: false,
+      onekeyUserId: 'user-1',
+    });
   });
 });

--- a/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.test.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.test.ts
@@ -16,6 +16,16 @@ const mockApiGetInfiniPayment = jest.fn<
   Promise<unknown>,
   [{ paymentId: string; expectedOneKeyUserId: string }]
 >();
+const mockDiscardTerminalPaymentSession = jest.fn<
+  Promise<boolean>,
+  [
+    {
+      onekeyUserId: string;
+      expectedPaymentCacheIdentity: { paymentId: string };
+      latestPayment: unknown;
+    },
+  ]
+>();
 const mockLatchPendingPaymentProgress = jest.fn<
   Promise<unknown>,
   [
@@ -41,6 +51,11 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
       prime: {
         getInfiniPendingPaymentSession: (params: { onekeyUserId: string }) =>
           mockGetPendingPaymentSession(params),
+        discardTerminalInfiniPendingPaymentSession: (params: {
+          onekeyUserId: string;
+          expectedPaymentCacheIdentity: { paymentId: string };
+          latestPayment: unknown;
+        }) => mockDiscardTerminalPaymentSession(params),
         latchInfiniPendingPaymentSessionProgress: (params: {
           onekeyUserId: string;
           paymentCacheKey: { paymentId: string };
@@ -96,6 +111,7 @@ describe('getPrimeInfiniExternalCheckoutGuard', () => {
     });
     mockGetPendingPaymentSession.mockResolvedValue({
       sendStarted: true,
+      selectedSubscriptionPeriod: 'P1M',
       paymentCacheKey: {
         paymentId: 'payment-1',
       },
@@ -117,6 +133,7 @@ describe('getPrimeInfiniExternalCheckoutGuard', () => {
       isLoggedIn: true,
       hasPendingPayment: true,
       onekeyUserId: 'user-1',
+      pendingSubscriptionPeriod: 'P1M',
     });
   });
 
@@ -127,6 +144,7 @@ describe('getPrimeInfiniExternalCheckoutGuard', () => {
     });
     mockGetPendingPaymentSession.mockResolvedValue({
       sendStarted: false,
+      selectedSubscriptionPeriod: 'P1M',
       paymentCacheKey: {
         paymentId: 'payment-1',
       },
@@ -162,6 +180,7 @@ describe('getPrimeInfiniExternalCheckoutGuard', () => {
     });
     mockGetPendingPaymentSession.mockResolvedValue({
       sendStarted: false,
+      selectedSubscriptionPeriod: 'P1M',
       paymentCacheKey: {
         paymentId: 'payment-1',
       },
@@ -183,6 +202,7 @@ describe('getPrimeInfiniExternalCheckoutGuard', () => {
       isLoggedIn: true,
       hasPendingPayment: true,
       onekeyUserId: 'user-1',
+      pendingSubscriptionPeriod: 'P1M',
     });
   });
 
@@ -193,6 +213,7 @@ describe('getPrimeInfiniExternalCheckoutGuard', () => {
     });
     mockGetPendingPaymentSession.mockResolvedValue({
       sendStarted: false,
+      selectedSubscriptionPeriod: 'P1M',
       paymentCacheKey: {
         paymentId: 'payment-1',
       },
@@ -214,7 +235,84 @@ describe('getPrimeInfiniExternalCheckoutGuard', () => {
       isLoggedIn: true,
       hasPendingPayment: false,
       onekeyUserId: 'user-1',
+      pendingSubscriptionPeriod: 'P1M',
     });
     expect(mockLatchPendingPaymentProgress).not.toHaveBeenCalled();
+  });
+
+  it('releases a claimed session once the server closes the invoice unpaid', async () => {
+    mockGetLocalUserInfo.mockResolvedValue({
+      isLoggedIn: true,
+      onekeyUserId: 'user-1',
+    });
+    mockGetPendingPaymentSession.mockResolvedValue({
+      sendStarted: true,
+      selectedSubscriptionPeriod: 'P1M',
+      paymentCacheKey: {
+        paymentId: 'payment-1',
+      },
+      payment: {
+        paymentId: 'payment-1',
+        amountDue: '1',
+        amountConfirmed: '0',
+        amountConfirming: '0',
+      },
+    });
+    const latestPayment = {
+      paymentId: 'payment-1',
+      amountDue: '1',
+      amountConfirmed: '0',
+      amountConfirming: '0',
+      status: 'expired',
+    };
+    mockApiGetInfiniPayment.mockResolvedValue(latestPayment);
+
+    await expect(getPrimeInfiniPaymentEntryGuard()).resolves.toEqual({
+      isLoggedIn: true,
+      hasPendingPayment: false,
+      onekeyUserId: 'user-1',
+      pendingSubscriptionPeriod: undefined,
+    });
+    expect(mockDiscardTerminalPaymentSession).toHaveBeenCalledWith({
+      onekeyUserId: 'user-1',
+      expectedPaymentCacheIdentity: { paymentId: 'payment-1' },
+      latestPayment,
+    });
+    expect(mockLatchPendingPaymentProgress).not.toHaveBeenCalled();
+  });
+
+  it('keeps blocking a claimed session that only expired on the local clock', async () => {
+    mockGetLocalUserInfo.mockResolvedValue({
+      isLoggedIn: true,
+      onekeyUserId: 'user-1',
+    });
+    mockGetPendingPaymentSession.mockResolvedValue({
+      sendStarted: true,
+      selectedSubscriptionPeriod: 'P1Y',
+      paymentCacheKey: {
+        paymentId: 'payment-1',
+      },
+      payment: {
+        paymentId: 'payment-1',
+        amountDue: '1',
+        amountConfirmed: '0',
+        amountConfirming: '0',
+      },
+    });
+    mockApiGetInfiniPayment.mockResolvedValue({
+      paymentId: 'payment-1',
+      amountDue: '1',
+      amountConfirmed: '0',
+      amountConfirming: '0',
+      expiresAt: 1,
+    });
+
+    await expect(getPrimeInfiniPaymentEntryGuard()).resolves.toEqual({
+      isLoggedIn: true,
+      hasPendingPayment: true,
+      onekeyUserId: 'user-1',
+      pendingSubscriptionPeriod: 'P1Y',
+    });
+    expect(mockDiscardTerminalPaymentSession).not.toHaveBeenCalled();
   });
 });

--- a/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.test.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.test.ts
@@ -69,6 +69,8 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
 describe('getPrimeInfiniExternalCheckoutGuard', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockLatchPendingPaymentProgress.mockResolvedValue({ sendStarted: true });
+    mockDiscardTerminalPaymentSession.mockResolvedValue(true);
   });
 
   it('blocks external checkout when another context has persisted a payment', async () => {
@@ -314,5 +316,70 @@ describe('getPrimeInfiniExternalCheckoutGuard', () => {
       pendingSubscriptionPeriod: 'P1Y',
     });
     expect(mockDiscardTerminalPaymentSession).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the session is replaced while the payment is fetched', async () => {
+    mockGetLocalUserInfo.mockResolvedValue({
+      isLoggedIn: true,
+      onekeyUserId: 'user-1',
+    });
+    mockGetPendingPaymentSession.mockResolvedValue({
+      sendStarted: false,
+      selectedSubscriptionPeriod: 'P1M',
+      paymentCacheKey: {
+        paymentId: 'payment-1',
+      },
+      payment: {
+        paymentId: 'payment-1',
+        amountDue: '1',
+        amountConfirmed: '0',
+        amountConfirming: '0',
+      },
+    });
+    mockApiGetInfiniPayment.mockResolvedValue({
+      paymentId: 'payment-1',
+      amountDue: '1',
+      amountConfirmed: '0',
+      amountConfirming: '0.5',
+    });
+    // Another window swapped the stored session, so no matching session takes
+    // the latch and the observed progress is recorded nowhere.
+    mockLatchPendingPaymentProgress.mockResolvedValue(undefined);
+
+    await expect(getPrimeInfiniPaymentEntryGuard()).rejects.toThrow(
+      'Infini payment session changed while it was being verified',
+    );
+  });
+
+  it('fails closed when a terminal session cannot be discarded', async () => {
+    mockGetLocalUserInfo.mockResolvedValue({
+      isLoggedIn: true,
+      onekeyUserId: 'user-1',
+    });
+    mockGetPendingPaymentSession.mockResolvedValue({
+      sendStarted: true,
+      selectedSubscriptionPeriod: 'P1M',
+      paymentCacheKey: {
+        paymentId: 'payment-1',
+      },
+      payment: {
+        paymentId: 'payment-1',
+        amountDue: '1',
+        amountConfirmed: '0',
+        amountConfirming: '0',
+      },
+    });
+    mockApiGetInfiniPayment.mockResolvedValue({
+      paymentId: 'payment-1',
+      amountDue: '1',
+      amountConfirmed: '0',
+      amountConfirming: '0',
+      status: 'expired',
+    });
+    mockDiscardTerminalPaymentSession.mockResolvedValue(false);
+
+    await expect(getPrimeInfiniPaymentEntryGuard()).rejects.toThrow(
+      'Infini payment session changed while it was being verified',
+    );
   });
 });

--- a/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.ts
@@ -64,13 +64,29 @@ export async function getPrimeInfiniPaymentEntryGuard() {
   const sendStarted =
     pendingPaymentSession.sendStarted ||
     hasPrimeInfiniPaymentProgress(paymentWithDurableProgress);
+  const hasPendingPayment = !isPrimeInfiniPaymentReplaceable({
+    payment: paymentWithDurableProgress,
+    sendStarted,
+  });
+
+  if (hasPendingPayment) {
+    // Latch the observed progress before returning, otherwise a later snapshot
+    // that transiently reports zero progress would make this session
+    // replaceable again and a second invoice could be sent while the first
+    // transaction is still processing. The raw payment is passed through so
+    // the merge runs atomically against the stored session.
+    await backgroundApiProxy.simpleDb.prime.latchInfiniPendingPaymentSessionProgress(
+      {
+        onekeyUserId,
+        paymentCacheKey: pendingPaymentSession.paymentCacheKey,
+        latestPayment,
+      },
+    );
+  }
 
   return {
     isLoggedIn: true,
-    hasPendingPayment: !isPrimeInfiniPaymentReplaceable({
-      payment: paymentWithDurableProgress,
-      sendStarted,
-    }),
+    hasPendingPayment,
     onekeyUserId,
   };
 }

--- a/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.ts
@@ -1,22 +1,76 @@
 /* cspell:ignore Infini */
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { mergePrimeInfiniPaymentProgressSnapshot } from '@onekeyhq/shared/src/utils/primeInfiniPaymentCacheUtils';
+import type { IPrimeInfiniPendingPaymentSession } from '@onekeyhq/shared/types/prime/primeTypes';
 
-export async function getPrimeInfiniExternalCheckoutGuard() {
+import {
+  hasPrimeInfiniPaymentProgress,
+  isPrimeInfiniPaymentReplaceable,
+} from './primeInfiniPaymentUtils';
+
+async function getPrimeInfiniPendingPaymentContext(): Promise<{
+  isLoggedIn: boolean;
+  onekeyUserId: string | undefined;
+  pendingPaymentSession: IPrimeInfiniPendingPaymentSession | undefined;
+}> {
   const userInfo = await backgroundApiProxy.servicePrime.getLocalUserInfo();
   if (!userInfo.isLoggedIn || !userInfo.onekeyUserId) {
     return {
       isLoggedIn: false,
-      hasPendingPayment: false,
       onekeyUserId: undefined,
+      pendingPaymentSession: undefined,
     };
   }
-  const pendingPaymentSession =
+  const pendingPaymentSession: IPrimeInfiniPendingPaymentSession | undefined =
     await backgroundApiProxy.simpleDb.prime.getInfiniPendingPaymentSession({
       onekeyUserId: userInfo.onekeyUserId,
     });
   return {
     isLoggedIn: true,
-    hasPendingPayment: Boolean(pendingPaymentSession),
     onekeyUserId: userInfo.onekeyUserId,
+    pendingPaymentSession,
+  };
+}
+
+export async function getPrimeInfiniExternalCheckoutGuard() {
+  const context = await getPrimeInfiniPendingPaymentContext();
+  return {
+    isLoggedIn: context.isLoggedIn,
+    hasPendingPayment: Boolean(context.pendingPaymentSession),
+    onekeyUserId: context.onekeyUserId,
+  };
+}
+
+export async function getPrimeInfiniPaymentEntryGuard() {
+  const context = await getPrimeInfiniPendingPaymentContext();
+  const { pendingPaymentSession, onekeyUserId } = context;
+  if (!pendingPaymentSession || !onekeyUserId) {
+    return {
+      isLoggedIn: context.isLoggedIn,
+      hasPendingPayment: false,
+      onekeyUserId,
+    };
+  }
+
+  const latestPayment =
+    await backgroundApiProxy.servicePrime.apiGetInfiniPayment({
+      paymentId: pendingPaymentSession.paymentCacheKey.paymentId,
+      expectedOneKeyUserId: onekeyUserId,
+    });
+  const paymentWithDurableProgress = mergePrimeInfiniPaymentProgressSnapshot({
+    previous: pendingPaymentSession.payment,
+    latest: latestPayment,
+  });
+  const sendStarted =
+    pendingPaymentSession.sendStarted ||
+    hasPrimeInfiniPaymentProgress(paymentWithDurableProgress);
+
+  return {
+    isLoggedIn: true,
+    hasPendingPayment: !isPrimeInfiniPaymentReplaceable({
+      payment: paymentWithDurableProgress,
+      sendStarted,
+    }),
+    onekeyUserId,
   };
 }

--- a/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.ts
@@ -41,6 +41,13 @@ export async function getPrimeInfiniExternalCheckoutGuard() {
   };
 }
 
+// Entry gate for every Prime purchase channel, not just the crypto one.
+// hasPendingPayment reports whether the user's money is already committed to
+// an Infini invoice: replaceable means the invoice was never sent and shows no
+// progress, so it can be swapped for a new one, while anything else means a
+// broadcast was claimed or funds are moving and a second purchase through any
+// channel would charge twice for one subscription. Callers are expected to
+// resume the existing crypto flow instead of offering a payment method choice.
 export async function getPrimeInfiniPaymentEntryGuard() {
   const context = await getPrimeInfiniPendingPaymentContext();
   const { pendingPaymentSession, onekeyUserId } = context;

--- a/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.ts
@@ -5,6 +5,7 @@ import type { IPrimeInfiniPendingPaymentSession } from '@onekeyhq/shared/types/p
 
 import {
   hasPrimeInfiniPaymentProgress,
+  isPrimeInfiniPaymentClosedUnpaid,
   isPrimeInfiniPaymentReplaceable,
 } from './primeInfiniPaymentUtils';
 
@@ -56,6 +57,7 @@ export async function getPrimeInfiniPaymentEntryGuard() {
       isLoggedIn: context.isLoggedIn,
       hasPendingPayment: false,
       onekeyUserId,
+      pendingSubscriptionPeriod: undefined,
     };
   }
 
@@ -71,6 +73,25 @@ export async function getPrimeInfiniPaymentEntryGuard() {
   const sendStarted =
     pendingPaymentSession.sendStarted ||
     hasPrimeInfiniPaymentProgress(paymentWithDurableProgress);
+  if (isPrimeInfiniPaymentClosedUnpaid(paymentWithDurableProgress)) {
+    // The invoice is closed server-side with nothing collected. Release the
+    // session so the entry gate stops blocking every channel; a claimed but
+    // reverted broadcast would otherwise pin it until the session TTL.
+    await backgroundApiProxy.simpleDb.prime.discardTerminalInfiniPendingPaymentSession(
+      {
+        onekeyUserId,
+        expectedPaymentCacheIdentity: pendingPaymentSession.paymentCacheKey,
+        latestPayment,
+      },
+    );
+    return {
+      isLoggedIn: true,
+      hasPendingPayment: false,
+      onekeyUserId,
+      pendingSubscriptionPeriod: undefined,
+    };
+  }
+
   const hasPendingPayment = !isPrimeInfiniPaymentReplaceable({
     payment: paymentWithDurableProgress,
     sendStarted,
@@ -95,5 +116,9 @@ export async function getPrimeInfiniPaymentEntryGuard() {
     isLoggedIn: true,
     hasPendingPayment,
     onekeyUserId,
+    // Resuming has to follow the invoice that is already in flight, not a
+    // period the user picked afterwards, otherwise the restore silently
+    // continues a monthly invoice for a yearly selection.
+    pendingSubscriptionPeriod: pendingPaymentSession.selectedSubscriptionPeriod,
   };
 }

--- a/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.ts
@@ -1,5 +1,6 @@
 /* cspell:ignore Infini */
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { mergePrimeInfiniPaymentProgressSnapshot } from '@onekeyhq/shared/src/utils/primeInfiniPaymentCacheUtils';
 import type { IPrimeInfiniPendingPaymentSession } from '@onekeyhq/shared/types/prime/primeTypes';
 
@@ -77,13 +78,20 @@ export async function getPrimeInfiniPaymentEntryGuard() {
     // The invoice is closed server-side with nothing collected. Release the
     // session so the entry gate stops blocking every channel; a claimed but
     // reverted broadcast would otherwise pin it until the session TTL.
-    await backgroundApiProxy.simpleDb.prime.discardTerminalInfiniPendingPaymentSession(
-      {
-        onekeyUserId,
-        expectedPaymentCacheIdentity: pendingPaymentSession.paymentCacheKey,
-        latestPayment,
-      },
-    );
+    const didDiscard =
+      await backgroundApiProxy.simpleDb.prime.discardTerminalInfiniPendingPaymentSession(
+        {
+          onekeyUserId,
+          expectedPaymentCacheIdentity: pendingPaymentSession.paymentCacheKey,
+          latestPayment,
+        },
+      );
+    if (!didDiscard) {
+      throw new OneKeyLocalError({
+        message: 'Infini payment session changed while it was being verified',
+        autoToast: false,
+      });
+    }
     return {
       isLoggedIn: true,
       hasPendingPayment: false,
@@ -103,13 +111,25 @@ export async function getPrimeInfiniPaymentEntryGuard() {
     // replaceable again and a second invoice could be sent while the first
     // transaction is still processing. The raw payment is passed through so
     // the merge runs atomically against the stored session.
-    await backgroundApiProxy.simpleDb.prime.latchInfiniPendingPaymentSessionProgress(
-      {
-        onekeyUserId,
-        paymentCacheKey: pendingPaymentSession.paymentCacheKey,
-        latestPayment,
-      },
-    );
+    const latchedSession =
+      await backgroundApiProxy.simpleDb.prime.latchInfiniPendingPaymentSessionProgress(
+        {
+          onekeyUserId,
+          paymentCacheKey: pendingPaymentSession.paymentCacheKey,
+          latestPayment,
+        },
+      );
+    // No matching session took the latch, so another window discarded or
+    // replaced it while the payment was being fetched and the progress just
+    // observed is recorded nowhere. Resuming here would act on a snapshot that
+    // no longer describes local state, so fail closed and let the caller retry
+    // against a fresh read.
+    if (!latchedSession) {
+      throw new OneKeyLocalError({
+        message: 'Infini payment session changed while it was being verified',
+        autoToast: false,
+      });
+    }
   }
 
   return {

--- a/packages/kit/src/views/Prime/hooks/primeInfiniPaymentUtils.ts
+++ b/packages/kit/src/views/Prime/hooks/primeInfiniPaymentUtils.ts
@@ -9,6 +9,7 @@ import { getListedNetworkMap } from '@onekeyhq/shared/src/config/networkIds';
 import {
   getPrimeInfiniPaymentAssetKey,
   hasPrimeInfiniPaymentProgressSnapshot,
+  isPrimeInfiniPaymentClosedUnpaidSnapshot,
   isPrimeInfiniPaymentExplicitlyExpiredSnapshot,
   isPrimeInfiniPaymentExplicitlyFailedSnapshot,
   isPrimeInfiniPaymentForAssetSnapshot,
@@ -313,6 +314,10 @@ export function isPrimeInfiniPaymentReplaceable({
   return !sendStarted && !hasPrimeInfiniPaymentProgress(payment);
 }
 
+export function isPrimeInfiniPaymentClosedUnpaid(payment: IPrimeInfiniPayment) {
+  return isPrimeInfiniPaymentClosedUnpaidSnapshot(payment);
+}
+
 export function canChangePrimeInfiniPaymentSelection({
   phase,
   payment,
@@ -334,7 +339,10 @@ export function canChangePrimeInfiniPaymentSelection({
       isPrimeInfiniPaymentReplaceable({
         payment,
         sendStarted,
-      }))
+      }) ||
+      // A claimed send whose invoice the server closed with nothing collected
+      // would otherwise leave the user stranded on a dead payment.
+      isPrimeInfiniPaymentClosedUnpaid(payment))
   );
 }
 

--- a/packages/shared/src/utils/primeInfiniPaymentCacheUtils.ts
+++ b/packages/shared/src/utils/primeInfiniPaymentCacheUtils.ts
@@ -420,6 +420,23 @@ export function isPrimeInfiniPaymentExplicitlyExpiredSnapshot(
   );
 }
 
+// An invoice the server has closed with nothing collected, so the local
+// session pinned to it can be released even after it claimed sendStarted.
+// A locally elapsed `expiresAt` deliberately does not qualify: a transaction
+// broadcast shortly before expiry can still land and be credited, and only the
+// server declaring the invoice dead proves that no money moved.
+export function isPrimeInfiniPaymentClosedUnpaidSnapshot(
+  payment: IPrimeInfiniPayment,
+) {
+  return (
+    !hasPrimeInfiniPaymentProgressSnapshot(payment) &&
+    !isPrimeInfiniPaymentExplicitlySuccessfulSnapshot(payment) &&
+    !isPrimeInfiniPaymentFullyConfirmedSnapshot(payment) &&
+    (isPrimeInfiniPaymentExplicitlyExpiredSnapshot(payment) ||
+      isPrimeInfiniPaymentExplicitlyFailedSnapshot(payment))
+  );
+}
+
 export function isPrimeInfiniPaymentExplicitlySuccessfulSnapshot(
   payment: IPrimeInfiniPayment,
 ) {


### PR DESCRIPTION
## Summary

- detect an active Infini crypto payment before opening the payment-method picker, so users cannot start a credit-card purchase while a crypto payment is already in progress
- re-check the active-payment guard when a payment method is selected to cover cross-window races
- parallelize independent Infini pre-send verification work to reduce the Send confirmation wait without moving safety checks after broadcast
- preserve the latest payment state without transient empty values during pre-send refreshes
- add focused coverage for the payment-entry guard, picker race, and parallel pre-broadcast verification

## Why

Follow-up to #12630. After that PR was merged, the remaining local changes addressed two related issues in the Prime Infini flow: active payments were only detected after entering the crypto path, and independent pre-broadcast checks were still running serially.

The entry gate now combines the locally persisted payment session with the latest server payment progress. A non-replaceable crypto payment resumes the existing crypto flow before the payment-method picker is shown. Unsent invoices with no progress remain replaceable.

## Validation

- `yarn jest packages/kit-bg/src/services/ServiceSend.broadcastDeadline.test.ts packages/kit/src/views/Prime/hooks/primeInfiniExternalCheckoutGuard.test.ts packages/kit/src/views/Prime/components/PrimePurchaseDialog/PrimePurchaseDialog.test.tsx --runInBand` (38 tests passed)
- `yarn agent:check --profile commit`
- `git diff --check`