### PR TITLE
feat: consolidate perps header actions

### DIFF
--- a/packages/kit/src/components/TabPageHeader/DappHeader.tsx
+++ b/packages/kit/src/components/TabPageHeader/DappHeader.tsx
@@ -1,10 +1,11 @@
-import { Suspense, lazy, useCallback } from 'react';
+import { useCallback } from 'react';
 
 import { useIntl } from 'react-intl';
 
 import { HeaderIconButton, Page, XStack } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { EModalRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
+import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
 
 import useAppNavigation from '../../hooks/useAppNavigation';
@@ -27,12 +28,6 @@ import { HeaderTitle } from './HeaderTitle';
 
 import type { ITabPageHeaderProp } from './type';
 
-const LazyPerpsActivityCenterAction = lazy(async () => {
-  const { PerpsActivityCenterAction } =
-    await import('../../views/Perp/components/PerpsActivityCenterAction');
-  return { default: PerpsActivityCenterAction };
-});
-
 function RightActions({ tabRoute }: { tabRoute: ETabRoutes }) {
   const intl = useIntl();
   const navigation = useAppNavigation();
@@ -43,12 +38,6 @@ function RightActions({ tabRoute }: { tabRoute: ETabRoutes }) {
   });
 
   const isWalletConnected = !!wallet && !!account;
-  // The remote perps config can serve /perps as the webview impl, which the tab
-  // router exposes as WebviewPerpTrade (hiding ETabRoutes.Perp). Match both so
-  // the relocated Activity Hub stays in the header in either configuration.
-  const isPerpsTab =
-    tabRoute === ETabRoutes.Perp || tabRoute === ETabRoutes.WebviewPerpTrade;
-
   const handleSearchPress = useCallback(() => {
     navigation.pushModal(EModalRoutes.UniversalSearchModal, {
       screen: EUniversalSearchPages.UniversalSearch,
@@ -70,11 +59,6 @@ function RightActions({ tabRoute }: { tabRoute: ETabRoutes }) {
         testID="header-right-notification"
         size="medium"
       />
-      {isPerpsTab && isWalletConnected ? (
-        <Suspense fallback={null}>
-          <LazyPerpsActivityCenterAction copyAsUrl size="medium" />
-        </Suspense>
-      ) : null}
       <KeylessWebConnectAlertContainer />
       {isWalletConnected ? (
         <WebAccountSelectorTrigger tabRoute={tabRoute} />

--- a/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelMain.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelMain.tsx
@@ -65,6 +65,7 @@ export interface IWebAccountPanelMainProps {
   onNavigateAccountList: () => void;
   onNavigateSettings: () => void;
   onNavigateArticles: () => void;
+  onNavigatePerpsActivityCenter?: () => void;
   onHelp?: () => void;
   onDownloadApp?: () => void;
   onRequestClose: () => void;
@@ -268,6 +269,7 @@ export function WebAccountPanelMain({
   onNavigateAccountList,
   onNavigateSettings,
   onNavigateArticles,
+  onNavigatePerpsActivityCenter,
   onHelp,
   onDownloadApp,
   onRequestClose,
@@ -695,6 +697,7 @@ export function WebAccountPanelMain({
       <WebAccountPanelFooter
         connected
         onDownloadApp={onDownloadApp}
+        onPerpsActivityCenter={onNavigatePerpsActivityCenter}
         onArticles={onNavigateArticles}
         onHelp={onHelp}
         onSettings={onNavigateSettings}

--- a/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelPopover.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelPopover.tsx
@@ -11,6 +11,7 @@ export interface IWebAccountPanelPopoverProps {
   renderTrigger: ReactNode;
   initialView?: IWebAccountPanelView;
   connected?: boolean;
+  showPerpsActivityCenter?: boolean;
 }
 
 const PANEL_WIDTH = 352;
@@ -33,6 +34,7 @@ export function WebAccountPanelPopover({
   renderTrigger,
   initialView = 'main',
   connected = true,
+  showPerpsActivityCenter = false,
 }: IWebAccountPanelPopoverProps) {
   const { config } = useAccountSelectorContextData();
   // Popover renders `renderContent` as a component (<RenderContent/> in
@@ -49,12 +51,13 @@ export function WebAccountPanelPopover({
             <LazyWebAccountPanelPopoverContent
               initialView={initialView}
               connected={connected}
+              showPerpsActivityCenter={showPerpsActivityCenter}
               closePopover={closePopover}
             />
           </Suspense>
         </AccountSelectorProviderMirror>
       ) : null,
-    [config, initialView, connected],
+    [config, initialView, connected, showPerpsActivityCenter],
   );
   return (
     <Popover

--- a/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelPopoverContent.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelPopoverContent.tsx
@@ -4,6 +4,7 @@ import { styled } from '@tamagui/core';
 import { useIntl } from 'react-intl';
 
 import { AnimatePresence, Stack, YStack } from '@onekeyhq/components';
+import { PerpsActivityCenterContent } from '@onekeyhq/kit/src/views/Perp/components/PerpsActivityCenterAction';
 import { DOWNLOAD_MOBILE_APP_URL } from '@onekeyhq/shared/src/config/appConfig';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { showIntercom } from '@onekeyhq/shared/src/modules3rdParty/intercom';
@@ -22,7 +23,8 @@ export type IWebAccountPanelView =
   | 'main'
   | 'accountList'
   | 'settings'
-  | 'articles';
+  | 'articles'
+  | 'perpsActivityCenter';
 
 const PANEL_WIDTH = 352;
 
@@ -46,10 +48,12 @@ const AnimatedPanelView = styled(Stack, {
 export default function WebAccountPanelPopoverContent({
   initialView,
   connected,
+  showPerpsActivityCenter,
   closePopover,
 }: {
   initialView: IWebAccountPanelView;
   connected: boolean;
+  showPerpsActivityCenter: boolean;
   closePopover: () => void;
 }) {
   const intl = useIntl();
@@ -109,6 +113,11 @@ export default function WebAccountPanelPopoverContent({
           onNavigateAccountList={() => navigate('accountList')}
           onNavigateSettings={() => navigate('settings')}
           onNavigateArticles={() => navigate('articles')}
+          onNavigatePerpsActivityCenter={
+            showPerpsActivityCenter
+              ? () => navigate('perpsActivityCenter')
+              : undefined
+          }
           onHelp={handleHelp}
           onDownloadApp={handleDownloadApp}
           onRequestClose={closePopover}
@@ -142,6 +151,18 @@ export default function WebAccountPanelPopoverContent({
         </YStack>
       );
     }
+    if (view === 'perpsActivityCenter') {
+      return (
+        <YStack w="100%">
+          <WebAccountPanelHeader title={backLabel} onBack={back} />
+          <PerpsActivityCenterContent
+            copyAsUrl
+            closePopover={closePopover}
+            showTitle={false}
+          />
+        </YStack>
+      );
+    }
     return (
       <YStack w="100%">
         <WebAccountPanelHeader title={backLabel} onBack={back} />
@@ -158,6 +179,7 @@ export default function WebAccountPanelPopoverContent({
     closePopover,
     connected,
     backLabel,
+    showPerpsActivityCenter,
   ]);
 
   const presenceCustom = useMemo(() => ({ going }), [going]);

--- a/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountSelectorTrigger.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountSelectorTrigger.tsx
@@ -89,5 +89,11 @@ export function WebAccountSelectorTrigger({
     </XStack>
   );
 
-  return <WebAccountPanelPopover renderTrigger={trigger} connected />;
+  return (
+    <WebAccountPanelPopover
+      renderTrigger={trigger}
+      connected
+      showPerpsActivityCenter={isPerpsRoute}
+    />
+  );
 }

--- a/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/atoms/WebAccountPanelFooter.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/atoms/WebAccountPanelFooter.tsx
@@ -7,6 +7,7 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 export interface IWebAccountPanelFooterProps extends IXStackProps {
   connected?: boolean;
   onDownloadApp?: () => void;
+  onPerpsActivityCenter?: () => void;
   onArticles?: () => void;
   onHelp?: () => void;
   onSettings?: () => void;
@@ -15,6 +16,7 @@ export interface IWebAccountPanelFooterProps extends IXStackProps {
 export function WebAccountPanelFooter({
   connected = true,
   onDownloadApp,
+  onPerpsActivityCenter,
   onArticles,
   onHelp,
   onSettings,
@@ -43,6 +45,19 @@ export function WebAccountPanelFooter({
         {intl.formatMessage({ id: ETranslations.global_download_app })}
       </Button>
       <XStack ai="center" gap="$5">
+        {onPerpsActivityCenter ? (
+          <IconButton
+            icon="GiftOutline"
+            size="small"
+            variant="tertiary"
+            iconSize="$5"
+            title={intl.formatMessage({
+              id: ETranslations.perps_activity_hub,
+            })}
+            onPress={onPerpsActivityCenter}
+            testID="web-account-panel-footer-perps-activity"
+          />
+        ) : null}
         <IconButton
           icon="BookOpenOutline"
           size="small"

--- a/packages/kit/src/views/Perp/components/Guide/PerpGuideContent.tsx
+++ b/packages/kit/src/views/Perp/components/Guide/PerpGuideContent.tsx
@@ -42,7 +42,7 @@ function GuideArticleItem({
   return (
     <XStack
       onPress={handlePress}
-      px="$3"
+      px="$5"
       py="$2.5"
       alignItems="center"
       gap="$3"
@@ -83,7 +83,7 @@ function GuideCategorySection({
   const intl = useIntl();
   return (
     <YStack>
-      <SizableText size="$bodySm" color="$textSubdued" px="$3" pt="$4" pb="$1">
+      <SizableText size="$bodySm" color="$textSubdued" px="$5" pt="$4" pb="$1">
         {intl.formatMessage({ id: category.titleId })}
       </SizableText>
       <YStack>
@@ -95,7 +95,7 @@ function GuideCategorySection({
           />
         ))}
       </YStack>
-      {isLast ? null : <Divider mx="$3" mt="$1" />}
+      {isLast ? null : <Divider mx="$5" mt="$1" />}
     </YStack>
   );
 }
@@ -120,7 +120,7 @@ export function PerpGuideContent({ onClose }: { onClose?: () => void }) {
 
   return (
     <YStack flex={1}>
-      <YStack px="$3" pt="$2" pb="$1">
+      <YStack px="$5" pt="$2" pb="$1">
         <SearchBar
           testID="perp-url-input"
           placeholder={intl.formatMessage({

--- a/packages/kit/src/views/Perp/components/PerpSettingsButton.tsx
+++ b/packages/kit/src/views/Perp/components/PerpSettingsButton.tsx
@@ -1,20 +1,92 @@
-import { DebugRenderTracker, IconButton } from '@onekeyhq/components';
-import type { IIconButtonProps } from '@onekeyhq/components/src/actions/IconButton';
+import { useCallback, useState } from 'react';
 
-import { PerpSettingsPopover } from './PerpSettingsDialog';
+import { useIntl } from 'react-intl';
+
+import {
+  DebugRenderTracker,
+  IconButton,
+  Stack,
+  useMedia,
+} from '@onekeyhq/components';
+import type { IIconButtonProps } from '@onekeyhq/components/src/actions/IconButton';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import { useShowGuide } from '../hooks/useShowGuide';
+
+import { PerpsActivityCenterAction } from './PerpsActivityCenterAction';
+import {
+  PerpSettingsPopover,
+  showPerpSettingsDialog,
+} from './PerpSettingsDialog';
 
 type IPerpSettingsButtonProps = Omit<IIconButtonProps, 'icon' | 'onPress'>;
 
 export function PerpSettingsButton({
   size = 'small',
   variant = 'tertiary',
+  showActivityCenterEntry = false,
   showGuideEntry = false,
   ...rest
 }: IPerpSettingsButtonProps & {
+  showActivityCenterEntry?: boolean;
   showGuideEntry?: boolean;
 }) {
+  const intl = useIntl();
+  const { gtXl } = useMedia();
+  const { showGuide } = useShowGuide({ forceModal: !gtXl });
+  const [isActivityCenterOpen, setIsActivityCenterOpen] = useState(false);
+  const handleOpenActivityCenter = useCallback(() => {
+    setIsActivityCenterOpen(true);
+  }, []);
+  const handleOpenDialog = useCallback(() => {
+    showPerpSettingsDialog({
+      title: intl.formatMessage({
+        id: ETranslations.address_book_menu_title,
+      }),
+      onOpenActivityCenter: handleOpenActivityCenter,
+      onOpenGuide: showGuide,
+      showActivityCenterEntry,
+      showGuideEntry,
+    });
+  }, [
+    handleOpenActivityCenter,
+    intl,
+    showActivityCenterEntry,
+    showGuide,
+    showGuideEntry,
+  ]);
+
+  if (!gtXl) {
+    return (
+      <DebugRenderTracker name="PerpSettingsButton">
+        <>
+          <IconButton
+            testID="perp-content-icon-btn"
+            icon="DotHorOutline"
+            size={size}
+            variant={variant}
+            iconColor="$iconSubdued"
+            onPress={handleOpenDialog}
+            {...rest}
+            cursor={platformEnv.isNative ? undefined : 'pointer'}
+          />
+          {showActivityCenterEntry ? (
+            <PerpsActivityCenterAction
+              copyAsUrl
+              open={isActivityCenterOpen}
+              onOpenChange={setIsActivityCenterOpen}
+              renderTrigger={<Stack display="none" />}
+            />
+          ) : null}
+        </>
+      </DebugRenderTracker>
+    );
+  }
+
   const content = (
     <PerpSettingsPopover
+      showActivityCenterEntry={showActivityCenterEntry}
       showGuideEntry={showGuideEntry}
       renderTrigger={
         <IconButton
@@ -23,8 +95,8 @@ export function PerpSettingsButton({
           size={size}
           variant={variant}
           iconColor="$iconSubdued"
-          cursor="default"
           {...rest}
+          cursor="pointer"
         />
       }
     />

--- a/packages/kit/src/views/Perp/components/PerpSettingsDialog.tsx
+++ b/packages/kit/src/views/Perp/components/PerpSettingsDialog.tsx
@@ -1,13 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 
+import { styled } from '@tamagui/core';
 import { useIntl } from 'react-intl';
+import { useReducedMotion } from 'react-native-reanimated';
 
 import {
+  AnimatePresence,
+  Dialog,
   ESwitchSize,
   Icon,
   Popover,
   SizableText,
+  Stack,
   Switch,
   Toast,
   XStack,
@@ -15,6 +20,7 @@ import {
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
+import { WebAccountPanelHeader } from '@onekeyhq/kit/src/components/TabPageHeader/components/WebAccountPanel/atoms/WebAccountPanelHeader';
 import {
   usePerpsAbstractionModeAtom,
   usePerpsActiveAccountAtom,
@@ -28,6 +34,36 @@ import { EHyperLiquidAbstractionMode } from '@onekeyhq/shared/types/hyperliquid'
 
 import { useShowGuide } from '../hooks/useShowGuide';
 import { PerpsProviderMirror } from '../PerpsProviderMirror';
+import { PerpTestIDs } from '../testIDs';
+
+import { PerpGuideContent } from './Guide/PerpGuideContent';
+import { PerpsActivityCenterContent } from './PerpsActivityCenterAction';
+
+import type { LayoutChangeEvent } from 'react-native';
+
+type IPerpSettingsView = 'settings' | 'activityCenter' | 'guide';
+
+const SETTINGS_PANEL_WIDTH = 360;
+const ANIMATE_ONLY_HEIGHT: string[] = ['height'];
+
+const AnimatedSettingsPanelView = styled(Stack, {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  variants: {
+    going: {
+      ':number': (going: number) => ({
+        enterStyle: {
+          x: going >= 0 ? SETTINGS_PANEL_WIDTH : -SETTINGS_PANEL_WIDTH,
+        },
+        exitStyle: {
+          x: going >= 0 ? -SETTINGS_PANEL_WIDTH : SETTINGS_PANEL_WIDTH,
+        },
+      }),
+    },
+  } as const,
+});
 
 const ABSTRACTION_MODE_OPTIONS = [
   {
@@ -81,7 +117,7 @@ function DevAbstractionModeSelector() {
 
   return (
     <YStack
-      px="$2.5"
+      mx="$3"
       pt="$2"
       gap="$2"
       borderTopWidth={1}
@@ -117,7 +153,10 @@ function DevAbstractionModeSelector() {
 }
 
 interface IPerpSettingsPopoverContentProps {
-  closePopover: () => void;
+  closePopover: () => void | Promise<void>;
+  onOpenActivityCenter?: () => void;
+  onOpenGuide?: () => void;
+  showActivityCenterEntry?: boolean;
   showGuideEntry?: boolean;
 }
 
@@ -286,7 +325,7 @@ function SpotDustingOptOutSetting() {
   return (
     <ListItem
       mx="$0"
-      px="$2.5"
+      px="$3"
       titleProps={{ size: '$bodyMdMedium' }}
       subtitleProps={{ size: '$bodySm' }}
       title={copy.title}
@@ -304,20 +343,24 @@ function SpotDustingOptOutSetting() {
   );
 }
 
-function PerpSettingsPopoverContent({
-  closePopover,
+function PerpSettingsMainContent({
+  showActivityCenterEntry = false,
   showGuideEntry = false,
-}: IPerpSettingsPopoverContentProps) {
+  onOpenActivityCenter,
+  onOpenGuide,
+}: Omit<IPerpSettingsPopoverContentProps, 'closePopover'> & {
+  onOpenActivityCenter: () => void;
+  onOpenGuide: () => void;
+}) {
   const [perpsCustomSettings, setPerpsCustomSettings] =
     usePerpsCustomSettingsAtom();
   const intl = useIntl();
-  const { showGuide } = useShowGuide();
 
   return (
     <YStack py="$3" px="$2">
       <ListItem
         mx="$0"
-        px="$2.5"
+        px="$3"
         titleProps={{ size: '$bodyMdMedium' }}
         subtitleProps={{ size: '$bodySm' }}
         title={intl.formatMessage({
@@ -345,7 +388,7 @@ function PerpSettingsPopoverContent({
 
       <ListItem
         mx="$0"
-        px="$2.5"
+        px="$3"
         titleProps={{ size: '$bodyMdMedium' }}
         subtitleProps={{ size: '$bodySm' }}
         title={intl.formatMessage({
@@ -368,7 +411,7 @@ function PerpSettingsPopoverContent({
 
       <ListItem
         mx="$0"
-        px="$2.5"
+        px="$3"
         titleProps={{ size: '$bodyMdMedium' }}
         subtitleProps={{ size: '$bodySm' }}
         title={intl.formatMessage({
@@ -389,18 +432,32 @@ function PerpSettingsPopoverContent({
         />
       </ListItem>
 
+      {showActivityCenterEntry ? (
+        <ListItem
+          testID={PerpTestIDs.ActivityCenterButton}
+          mx="$0"
+          px="$3"
+          titleProps={{ size: '$bodyMdMedium' }}
+          title={intl.formatMessage({
+            id: ETranslations.perps_activity_hub,
+          })}
+          onPress={onOpenActivityCenter}
+          cursor="default"
+        >
+          <Icon name="ChevronRightOutline" size="$4" color="$iconSubdued" />
+        </ListItem>
+      ) : null}
+
       {showGuideEntry ? (
         <ListItem
+          testID={PerpTestIDs.GuideButton}
           mx="$0"
-          px="$2.5"
+          px="$3"
           titleProps={{ size: '$bodyMdMedium' }}
           title={intl.formatMessage({
             id: ETranslations.perp_guide_title,
           })}
-          onPress={() => {
-            closePopover();
-            showGuide();
-          }}
+          onPress={onOpenGuide}
           cursor="default"
         >
           <Icon name="ChevronRightOutline" size="$4" color="$iconSubdued" />
@@ -412,13 +469,203 @@ function PerpSettingsPopoverContent({
   );
 }
 
+function PerpSettingsPopoverContent({
+  closePopover,
+  onOpenActivityCenter,
+  onOpenGuide,
+  showActivityCenterEntry = false,
+  showGuideEntry = false,
+}: IPerpSettingsPopoverContentProps) {
+  const intl = useIntl();
+  const reducedMotion = useReducedMotion();
+  const { showGuide } = useShowGuide();
+  const [view, setView] = useState<IPerpSettingsView>('settings');
+  const [going, setGoing] = useState(1);
+  const [navSeq, setNavSeq] = useState(0);
+  const [contentHeight, setContentHeight] = useState<number | undefined>(
+    undefined,
+  );
+  const [heightReady, setHeightReady] = useState(false);
+  const navSeqRef = useRef(navSeq);
+  navSeqRef.current = navSeq;
+
+  const navigate = useCallback((nextView: IPerpSettingsView) => {
+    setGoing(1);
+    setNavSeq((seq) => seq + 1);
+    setView(nextView);
+  }, []);
+
+  const back = useCallback(() => {
+    setGoing(-1);
+    setNavSeq((seq) => seq + 1);
+    setView('settings');
+  }, []);
+
+  const handleViewLayout = useCallback((seq: number, height: number) => {
+    if (height > 0 && navSeqRef.current === seq) {
+      setContentHeight(height);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (contentHeight !== undefined && !heightReady) {
+      setHeightReady(true);
+    }
+  }, [contentHeight, heightReady]);
+
+  const handleOpenActivityCenter = useCallback(() => {
+    if (onOpenActivityCenter) {
+      void Promise.resolve(closePopover()).then(onOpenActivityCenter);
+      return;
+    }
+    navigate('activityCenter');
+  }, [closePopover, navigate, onOpenActivityCenter]);
+
+  const handleOpenGuide = useCallback(() => {
+    if (onOpenGuide) {
+      void Promise.resolve(closePopover()).then(onOpenGuide);
+      return;
+    }
+    if (showActivityCenterEntry) {
+      navigate('guide');
+      return;
+    }
+    void closePopover();
+    showGuide();
+  }, [closePopover, navigate, onOpenGuide, showActivityCenterEntry, showGuide]);
+
+  const rendered = useMemo(() => {
+    if (view === 'settings') {
+      return (
+        <PerpSettingsMainContent
+          showActivityCenterEntry={showActivityCenterEntry}
+          showGuideEntry={showGuideEntry}
+          onOpenActivityCenter={handleOpenActivityCenter}
+          onOpenGuide={handleOpenGuide}
+        />
+      );
+    }
+
+    const backLabel = intl.formatMessage({
+      id: ETranslations.global_back,
+    });
+    if (view === 'activityCenter') {
+      return (
+        <YStack w="100%">
+          <WebAccountPanelHeader title={backLabel} onBack={back} />
+          <PerpsActivityCenterContent
+            copyAsUrl
+            closePopover={closePopover}
+            showTitle={false}
+          />
+        </YStack>
+      );
+    }
+
+    return (
+      <YStack w="100%">
+        <WebAccountPanelHeader title={backLabel} onBack={back} />
+        <YStack h={640}>
+          <PerpGuideContent onClose={closePopover} />
+        </YStack>
+      </YStack>
+    );
+  }, [
+    back,
+    closePopover,
+    handleOpenActivityCenter,
+    handleOpenGuide,
+    intl,
+    showActivityCenterEntry,
+    showGuideEntry,
+    view,
+  ]);
+
+  const animation = reducedMotion || !heightReady ? '0ms' : 'smooth';
+  const presenceCustom = useMemo(() => ({ going }), [going]);
+
+  return (
+    <Stack
+      position="relative"
+      width="100%"
+      overflow="hidden"
+      height={contentHeight}
+      animation={animation}
+      animateOnly={ANIMATE_ONLY_HEIGHT}
+    >
+      <AnimatePresence custom={presenceCustom} initial={false}>
+        <AnimatedSettingsPanelView
+          key={navSeq}
+          going={going}
+          animation={reducedMotion ? '0ms' : 'smooth'}
+          onLayout={(event: LayoutChangeEvent) =>
+            handleViewLayout(navSeq, event.nativeEvent.layout.height)
+          }
+        >
+          {rendered}
+        </AnimatedSettingsPanelView>
+      </AnimatePresence>
+    </Stack>
+  );
+}
+
 export interface IPerpSettingsPopoverProps {
   renderTrigger: ReactNode;
+  showActivityCenterEntry?: boolean;
   showGuideEntry?: boolean;
+}
+
+export function showPerpSettingsDialog({
+  title,
+  onOpenActivityCenter,
+  onOpenGuide,
+  showActivityCenterEntry = false,
+  showGuideEntry = false,
+}: {
+  title: string;
+  onOpenActivityCenter?: () => void;
+  onOpenGuide?: () => void;
+  showActivityCenterEntry?: boolean;
+  showGuideEntry?: boolean;
+}) {
+  const dialogInstanceRef: {
+    current: ReturnType<typeof Dialog.show> | undefined;
+  } = {
+    current: undefined,
+  };
+  const closeDialog = () => {
+    return dialogInstanceRef.current?.close();
+  };
+
+  const dialogInstance = Dialog.show({
+    title,
+    showFooter: false,
+    contentContainerProps: {
+      p: '$0',
+    },
+    floatingPanelProps: {
+      overflow: 'hidden',
+    },
+    renderContent: (
+      <PerpsProviderMirror>
+        <PerpSettingsPopoverContent
+          closePopover={closeDialog}
+          onOpenActivityCenter={onOpenActivityCenter}
+          onOpenGuide={onOpenGuide}
+          showActivityCenterEntry={showActivityCenterEntry}
+          showGuideEntry={showGuideEntry}
+        />
+      </PerpsProviderMirror>
+    ),
+  });
+  dialogInstanceRef.current = dialogInstance;
+
+  return dialogInstance;
 }
 
 export function PerpSettingsPopover({
   renderTrigger,
+  showActivityCenterEntry = false,
   showGuideEntry = false,
 }: IPerpSettingsPopoverProps) {
   const intl = useIntl();
@@ -433,11 +680,15 @@ export function PerpSettingsPopover({
         renderContent={({ closePopover }) => (
           <PerpSettingsPopoverContent
             closePopover={closePopover}
+            showActivityCenterEntry={showActivityCenterEntry}
             showGuideEntry={showGuideEntry}
           />
         )}
         floatingPanelProps={{
-          width: 360,
+          width: SETTINGS_PANEL_WIDTH,
+          maxWidth: SETTINGS_PANEL_WIDTH,
+          overflow: 'hidden',
+          style: { transformOrigin: 'top right' },
         }}
       />
     </PerpsProviderMirror>

--- a/packages/kit/src/views/Perp/components/PerpsActivityCenterAction.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsActivityCenterAction.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import type { ReactNode } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -137,12 +138,14 @@ function ActivityCampaignCard({
   );
 }
 
-export function PerpsActivityCenterAction({
-  size = 'medium',
+export function PerpsActivityCenterContent({
   copyAsUrl = false,
+  closePopover,
+  showTitle = true,
 }: {
-  size?: IButtonProps['size'];
   copyAsUrl?: boolean;
+  closePopover: () => void;
+  showTitle?: boolean;
 }) {
   const intl = useIntl();
   const { gtMd } = useMedia();
@@ -169,89 +172,118 @@ export function PerpsActivityCenterAction({
   }, [showInviteeRewardModal]);
 
   return (
+    <YStack mb="$2">
+      {isDesktop && showTitle ? (
+        <XStack px="$5" pt="$4" pb="$1">
+          <SizableText size="$headingMd" color="$text" userSelect="none">
+            {activityCenterTitle}
+          </SizableText>
+        </XStack>
+      ) : null}
+      <YStack px="$4" pt={isDesktop && showTitle ? '$3.5' : '$3'} pb="$3.5">
+        <XStack width="100%" flexWrap="nowrap">
+          <ActivityShortcutCard
+            lottieSrc={
+              themeVariant === 'light' ? GiftExpandOnLight : GiftExpandOnDark
+            }
+            title={intl.formatMessage({
+              id: ETranslations.sidebar_refer_a_friend,
+            })}
+            onPress={() => {
+              closePopover();
+              handleOpenReferReward();
+            }}
+          />
+          <ActivityShortcutCard
+            iconName="HandCoinsOutline"
+            title={intl.formatMessage({
+              id: ETranslations.perps_trade_reward,
+            })}
+            onPress={() => {
+              closePopover();
+              handleOpenTradeReward();
+            }}
+          />
+        </XStack>
+        {hasActivityCards ? (
+          <YStack gap="$2.5" mt="$4">
+            <SizableText size="$headingXs" color="$text">
+              {`${intl.formatMessage({ id: ETranslations.perps_ongoing_events })} (${activityCards.length})`}
+            </SizableText>
+            <YStack gap="$2">
+              {activityCards.map((item) => (
+                <ActivityCampaignCard
+                  key={item.id}
+                  imageUrl={item.imageUrl}
+                  fallbackIconName={
+                    (item.iconName as IButtonProps['icon']) ?? 'GiftOutline'
+                  }
+                  title={item.title}
+                  subtitle={item.subtitle}
+                  onPress={() => {
+                    closePopover();
+                    void openUrlExternal(item.url);
+                  }}
+                />
+              ))}
+            </YStack>
+          </YStack>
+        ) : null}
+      </YStack>
+    </YStack>
+  );
+}
+
+export function PerpsActivityCenterAction({
+  size = 'medium',
+  copyAsUrl = false,
+  renderTrigger,
+  open,
+  onOpenChange,
+}: {
+  size?: IButtonProps['size'];
+  copyAsUrl?: boolean;
+  renderTrigger?: ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const intl = useIntl();
+  const { gtMd } = useMedia();
+  const activityCenterTitle = intl.formatMessage({
+    id: ETranslations.perps_activity_hub,
+  });
+
+  return (
     <Popover
+      open={open}
+      onOpenChange={onOpenChange}
       title={activityCenterTitle}
-      showHeader={!isDesktop}
+      showHeader={!gtMd}
       placement="bottom-end"
       sheetProps={
-        isDesktop
+        gtMd
           ? undefined
           : {
               dismissOnSnapToBottom: true,
             }
       }
       floatingPanelProps={{
-        width: isDesktop ? 384 : undefined,
+        width: gtMd ? 384 : undefined,
       }}
       renderTrigger={
-        <HeaderIconButton
-          title={activityCenterTitle}
-          icon="GiftOutline"
-          size={size}
-        />
+        renderTrigger ?? (
+          <HeaderIconButton
+            title={activityCenterTitle}
+            icon="GiftOutline"
+            size={size}
+          />
+        )
       }
       renderContent={({ closePopover }) => (
-        <YStack mb="$2">
-          {isDesktop ? (
-            <XStack px="$5" pt="$4" pb="$1">
-              <SizableText size="$headingMd" color="$text" userSelect="none">
-                {activityCenterTitle}
-              </SizableText>
-            </XStack>
-          ) : null}
-          <YStack px="$4" pt={isDesktop ? '$3.5' : null} pb="$3.5">
-            <XStack width="100%" flexWrap="nowrap">
-              <ActivityShortcutCard
-                lottieSrc={
-                  themeVariant === 'light'
-                    ? GiftExpandOnLight
-                    : GiftExpandOnDark
-                }
-                title={intl.formatMessage({
-                  id: ETranslations.sidebar_refer_a_friend,
-                })}
-                onPress={() => {
-                  closePopover();
-                  handleOpenReferReward();
-                }}
-              />
-              <ActivityShortcutCard
-                iconName="HandCoinsOutline"
-                title={intl.formatMessage({
-                  id: ETranslations.perps_trade_reward,
-                })}
-                onPress={() => {
-                  closePopover();
-                  handleOpenTradeReward();
-                }}
-              />
-            </XStack>
-            {hasActivityCards ? (
-              <YStack gap="$2.5" mt="$4">
-                <SizableText size="$headingXs" color="$text">
-                  {`${intl.formatMessage({ id: ETranslations.perps_ongoing_events })} (${activityCards.length})`}
-                </SizableText>
-                <YStack gap="$2">
-                  {activityCards.map((item) => (
-                    <ActivityCampaignCard
-                      key={item.id}
-                      imageUrl={item.imageUrl}
-                      fallbackIconName={
-                        (item.iconName as IButtonProps['icon']) ?? 'GiftOutline'
-                      }
-                      title={item.title}
-                      subtitle={item.subtitle}
-                      onPress={() => {
-                        closePopover();
-                        void openUrlExternal(item.url);
-                      }}
-                    />
-                  ))}
-                </YStack>
-              </YStack>
-            ) : null}
-          </YStack>
-        </YStack>
+        <PerpsActivityCenterContent
+          copyAsUrl={copyAsUrl}
+          closePopover={closePopover}
+        />
       )}
     />
   );

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
@@ -32,7 +32,6 @@ import {
   isPerpsMobileLayoutTraceRectChanged,
   tracePerpsMobileLayout,
 } from '../../utils/mobileLayoutTrace';
-import { PerpsActivityCenterAction } from '../PerpsActivityCenterAction';
 import { PerpSettingsButton } from '../PerpSettingsButton';
 import { PerpTokenSelectorMobile } from '../TokenSelector/PerpTokenSelector';
 
@@ -287,10 +286,10 @@ export function PerpTickerBarMobile() {
       </YStack>
 
       <XStack pt="$0.5" gap="$3" alignItems="center">
-        <PerpsActivityCenterAction size="small" copyAsUrl />
         <PerpCandleChartButtonMobile />
         <PerpSettingsButton
           testID={PerpTestIDs.MobileSettingsButton}
+          showActivityCenterEntry
           showGuideEntry
         />
       </XStack>

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
@@ -43,8 +43,6 @@ import {
   isPerpsMobileLayoutTraceRectChanged,
   tracePerpsMobileLayout,
 } from '../../../utils/mobileLayoutTrace';
-import { PerpGuidePopover } from '../../Guide/PerpGuidePopover';
-import { PerpsActivityCenterAction } from '../../PerpsActivityCenterAction';
 import { PerpSettingsButton } from '../../PerpSettingsButton';
 
 import { PerpsAccountNumberValue } from './PerpsAccountNumberValue';
@@ -294,7 +292,15 @@ function DepositButton() {
       // In the glass capsule, drop the solid fill (the glass provides it) and
       // the press/hover feedback (the glass material handles it).
       bg={glassActive ? '$transparent' : nonGlassBg}
-      cursor="default"
+      cursor={platformEnv.isNative ? 'default' : 'pointer'}
+      borderWidth={platformEnv.isNative ? 0 : 1}
+      borderColor="$transparent"
+      hoverStyle={
+        platformEnv.isNative ? undefined : { borderColor: '$borderHover' }
+      }
+      pressStyle={
+        platformEnv.isNative ? undefined : { borderColor: '$borderActive' }
+      }
       onLayout={handleLayout}
       {...(glassActive && { hoverStyle: undefined, pressStyle: undefined })}
     >
@@ -367,11 +373,11 @@ export function PerpsHeaderRight() {
         if (platformEnv.isWebDappMode) return null;
         if (gtMd) {
           return (
-            <>
-              <PerpsActivityCenterAction copyAsUrl />
-              <PerpGuidePopover />
-              <PerpSettingsButton testID={PerpTestIDs.HeaderSettingsButton} />
-            </>
+            <PerpSettingsButton
+              testID={PerpTestIDs.HeaderSettingsButton}
+              showActivityCenterEntry
+              showGuideEntry
+            />
           );
         }
         return null;

--- a/packages/kit/src/views/Perp/hooks/useShowGuide.ts
+++ b/packages/kit/src/views/Perp/hooks/useShowGuide.ts
@@ -5,17 +5,21 @@ import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
 
-export function useShowGuide() {
+export function useShowGuide({
+  forceModal = false,
+}: {
+  forceModal?: boolean;
+} = {}) {
   const navigation = useAppNavigation();
   const { gtMd } = useMedia();
 
   const showGuide = useCallback(() => {
-    if (!gtMd) {
+    if (forceModal || !gtMd) {
       navigation.pushModal(EModalRoutes.PerpModal, {
         screen: EModalPerpRoutes.PerpGuidePage,
       });
     }
-  }, [gtMd, navigation]);
+  }, [forceModal, gtMd, navigation]);
 
   return { showGuide };
 }

--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -32,7 +32,6 @@ import { LazyLoadPage } from '../../../components/LazyLoadPage';
 import { LazyPageContainer } from '../../../components/LazyPageContainer';
 import { TabPageHeader } from '../../../components/TabPageHeader';
 import { useNativePerpFeatureGuard } from '../../../hooks/usePerpFeatureGuard';
-import { PerpGuidePopover } from '../components/Guide/PerpGuidePopover';
 import { PerpContentFooter } from '../components/PerpContentFooter';
 import { PerpsActivityCenterAction } from '../components/PerpsActivityCenterAction';
 import { PerpSettingsButton } from '../components/PerpSettingsButton';
@@ -168,11 +167,15 @@ function PerpContent() {
       }
       customToolbarItems={
         <>
-          <PerpsActivityCenterAction size="small" copyAsUrl />
-          {gtMd ? <PerpGuidePopover /> : null}
+          {!gtMd && !platformEnv.isNative ? (
+            <PerpsActivityCenterAction size="small" copyAsUrl />
+          ) : null}
           <PerpSettingsButton
             testID={PerpTestIDs.HeaderSettingsButton}
-            showGuideEntry={!gtMd}
+            showActivityCenterEntry={
+              platformEnv.isNative || (gtMd && !platformEnv.isWebDappMode)
+            }
+            showGuideEntry
           />
           <HeaderIconButton
             icon="DownloadOutline"


### PR DESCRIPTION
## Summary

- consolidate Perps Activity Hub and Trading Guide into the settings menu
- use Dialog for compact layouts and Popover for wide layouts while preserving mobile navigation behavior
- move the Web Activity Hub entry into the account panel footer
- align Guide/menu spacing and add desktop pointer, hover, and press feedback

## Related issue

- https://onekeyhq.atlassian.net/browse/OK-58565

## Test plan

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- Web dev server returns HTTP 200
- Native Metro reports `packager-status:running`

## Platforms

- Desktop/Web: single-runtime UI-only changes
- iOS/Android: main UI runtime only; no background or native resource changes