### PR TITLE
feat: add Prime subscription reset shortcut

### DIFF
--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
@@ -407,9 +407,9 @@ describe('ServicePrime.apiResetInfiniSubscription', () => {
     expect(post).toHaveBeenCalledWith('/prime/v1/infini/test/reset');
   });
 
-  // The decorator only guards the INTERNAL_ dispatch entry, which desktop/web
-  // and native main->bg calls skip, so the method body must reject a missing or
-  // wrong devOnlyPassword before the destructive request is sent.
+  // The method is production-callable and no decorator guards it, so the method
+  // body itself must reject a missing or wrong devOnlyPassword before the
+  // destructive request is sent.
   it.each([
     ['missing devOnlyPassword', {} as any],
     ['wrong devOnlyPassword', { $$devOnlyPassword: 'wrong-password' } as any],

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
@@ -20,6 +20,8 @@ const mockPrimeLoginDialogAtom = {
   set: jest.fn(async () => undefined),
 };
 
+const VALID_DEV_ONLY_PASSWORD = 'valid-dev-only-password';
+
 jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
   backgroundClass: () => (target: unknown) => target,
   backgroundMethod:
@@ -30,6 +32,21 @@ jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
     () =>
     (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) =>
       descriptor,
+  // Mirrors the real guard: throws unless the caller passes the devOnlyPassword.
+  // The literal is inlined because a jest.mock factory cannot read outer scope.
+  checkDevOnlyPassword: (
+    params: { $$devOnlyPassword?: string } | undefined,
+    methodName?: string,
+  ) => {
+    if (params?.$$devOnlyPassword !== 'valid-dev-only-password') {
+      const { OneKeyLocalError } = require('@onekeyhq/shared/src/errors');
+      throw new OneKeyLocalError(
+        `You are not allowed to call this method, devOnlyPassword is wrong. method=${
+          methodName || ''
+        }`,
+      );
+    }
+  },
   toastIfError:
     () =>
     (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) =>
@@ -383,9 +400,29 @@ describe('ServicePrime.apiResetInfiniSubscription', () => {
     const post = jest.fn(async () => undefined);
     service.getPrimeClient = jest.fn(async () => ({ post }));
 
-    await service.apiResetInfiniSubscription();
+    await service.apiResetInfiniSubscription({
+      $$devOnlyPassword: VALID_DEV_ONLY_PASSWORD,
+    });
 
     expect(post).toHaveBeenCalledWith('/prime/v1/infini/test/reset');
+  });
+
+  // The decorator only guards the INTERNAL_ dispatch entry, which desktop/web
+  // and native main->bg calls skip, so the method body must reject a missing or
+  // wrong devOnlyPassword before the destructive request is sent.
+  it.each([
+    ['missing devOnlyPassword', {} as any],
+    ['wrong devOnlyPassword', { $$devOnlyPassword: 'wrong-password' } as any],
+  ])('rejects a direct call with %s', async (_title, params) => {
+    const { service } = createService();
+    const post = jest.fn(async () => undefined);
+    service.getPrimeClient = jest.fn(async () => ({ post }));
+
+    await expect(service.apiResetInfiniSubscription(params)).rejects.toThrow(
+      /devOnlyPassword is wrong/,
+    );
+
+    expect(post).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
@@ -391,20 +391,76 @@ describe('ServicePrime.apiFetchPrimeUserInfo', () => {
 });
 
 describe('ServicePrime.apiResetInfiniSubscription', () => {
+  const userA = {
+    isLoggedIn: true,
+    onekeyUserId: 'user-a',
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockPrimePersistAtom.get.mockResolvedValue(userA);
+    mockReadPersistedAccessTokenBySessionSourceStrict.mockResolvedValue({
+      status: 'ok',
+      accessToken: 'token-a',
+    });
   });
 
-  it('posts to the Infini test reset endpoint without a request body', async () => {
-    const { service } = createService();
+  afterEach(() => {
+    mockPrimePersistAtom.get.mockImplementation(async () => ({}));
+    mockReadPersistedAccessTokenBySessionSourceStrict.mockResolvedValue({
+      status: 'ok',
+      accessToken: 'persisted-access-token',
+    });
+  });
+
+  function createResetService() {
+    const { service, simpleDbPrime } = createService();
+    simpleDbPrime.getActiveAuthToken.mockResolvedValue('token-a');
+    simpleDbPrime.getAuthSessionSource.mockResolvedValue(
+      EPrimeAuthSessionSource.KeylessOAuth,
+    );
+    simpleDbPrime.getAuthStateGeneration.mockResolvedValue(3);
     const post = jest.fn(async () => undefined);
     service.getPrimeClient = jest.fn(async () => ({ post }));
+    return { service, simpleDbPrime, post };
+  }
 
-    await service.apiResetInfiniSubscription({
-      $$devOnlyPassword: VALID_DEV_ONLY_PASSWORD,
+  it('pins the confirming user session on the reset request', async () => {
+    const { service, post } = createResetService();
+
+    await service.apiResetInfiniSubscription(
+      { $$devOnlyPassword: VALID_DEV_ONLY_PASSWORD },
+      { expectedOneKeyUserId: 'user-a' },
+    );
+
+    expect(post).toHaveBeenCalledWith(
+      '/prime/v1/infini/test/reset',
+      undefined,
+      {
+        headers: {
+          'X-Onekey-Request-Token': 'token-a',
+        },
+      },
+    );
+  });
+
+  // An account switch between the confirmation and the send must abort the
+  // delete, never redirect it onto the account that is current by then.
+  it('rejects when the logged-in user is no longer the confirming user', async () => {
+    const { service, post } = createResetService();
+    mockPrimePersistAtom.get.mockResolvedValue({
+      isLoggedIn: true,
+      onekeyUserId: 'user-b',
     });
 
-    expect(post).toHaveBeenCalledWith('/prime/v1/infini/test/reset');
+    await expect(
+      service.apiResetInfiniSubscription(
+        { $$devOnlyPassword: VALID_DEV_ONLY_PASSWORD },
+        { expectedOneKeyUserId: 'user-a' },
+      ),
+    ).rejects.toThrow('Prime purchase user changed');
+
+    expect(post).not.toHaveBeenCalled();
   });
 
   // The method is production-callable and no decorator guards it, so the method
@@ -414,13 +470,13 @@ describe('ServicePrime.apiResetInfiniSubscription', () => {
     ['missing devOnlyPassword', {} as any],
     ['wrong devOnlyPassword', { $$devOnlyPassword: 'wrong-password' } as any],
   ])('rejects a direct call with %s', async (_title, params) => {
-    const { service } = createService();
-    const post = jest.fn(async () => undefined);
-    service.getPrimeClient = jest.fn(async () => ({ post }));
+    const { service, post } = createResetService();
 
-    await expect(service.apiResetInfiniSubscription(params)).rejects.toThrow(
-      /devOnlyPassword is wrong/,
-    );
+    await expect(
+      service.apiResetInfiniSubscription(params, {
+        expectedOneKeyUserId: 'user-a',
+      }),
+    ).rejects.toThrow(/devOnlyPassword is wrong/);
 
     expect(post).not.toHaveBeenCalled();
   });

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -4270,11 +4270,22 @@ class ServicePrime extends ServiceBase {
   @toastIfError()
   async apiResetInfiniSubscription(
     params: IBackgroundMethodWithDevOnlyPassword,
+    { expectedOneKeyUserId }: { expectedOneKeyUserId: string },
   ): Promise<void> {
     // Destructively deletes the current user's Infini subscription.
     checkDevOnlyPassword(params, 'apiResetInfiniSubscription');
+    // Pin the request to the user who confirmed the dialog: an account switch
+    // between confirmation and send would otherwise let the interceptor attach
+    // the new user's live token and delete a subscription nobody consented to.
+    const authSnapshot =
+      await this.captureInfiniPurchaseAuthSnapshot(expectedOneKeyUserId);
     const client = await this.getPrimeClient();
-    await client.post('/prime/v1/infini/test/reset');
+    await client.post(
+      '/prime/v1/infini/test/reset',
+      undefined,
+      this.getInfiniPurchaseRequestConfig(authSnapshot),
+    );
+    await this.assertInfiniPurchaseAuthSnapshot(authSnapshot);
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -5,9 +5,11 @@ import BigNumber from 'bignumber.js';
 import { chunk, cloneDeep, isString } from 'lodash';
 
 import { ensureSensitiveTextEncoded } from '@onekeyhq/core/src/secret';
+import type { IBackgroundMethodWithDevOnlyPassword } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import {
   backgroundMethod,
   backgroundMethodForDev,
+  checkDevOnlyPassword,
   toastIfError,
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import type { EOAuthSocialLoginProvider } from '@onekeyhq/shared/src/consts/authConsts';
@@ -4260,7 +4262,15 @@ class ServicePrime extends ServiceBase {
 
   @backgroundMethodForDev()
   @toastIfError()
-  async apiResetInfiniSubscription(): Promise<void> {
+  async apiResetInfiniSubscription(
+    params: IBackgroundMethodWithDevOnlyPassword,
+  ): Promise<void> {
+    // This destructively deletes the current user's Infini subscription and is
+    // reachable from a production build, so the devOnlyPassword must be checked
+    // in the method body: @backgroundMethodForDev() only wraps the
+    // INTERNAL_ dispatch entry, which the extension main->bg bridge uses but
+    // desktop/web single-runtime and native main->bg calls do not go through.
+    checkDevOnlyPassword(params, 'apiResetInfiniSubscription');
     const client = await this.getPrimeClient();
     await client.post('/prime/v1/infini/test/reset');
   }

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -8,7 +8,6 @@ import { ensureSensitiveTextEncoded } from '@onekeyhq/core/src/secret';
 import type { IBackgroundMethodWithDevOnlyPassword } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import {
   backgroundMethod,
-  backgroundMethodForDev,
   checkDevOnlyPassword,
   toastIfError,
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
@@ -4260,16 +4259,19 @@ class ServicePrime extends ServiceBase {
     });
   }
 
-  @backgroundMethodForDev()
+  // Intentionally @backgroundMethod() and not @backgroundMethodForDev(): this
+  // entry is reachable from a production build, so a dev-only decorator would
+  // be a wrong description of it. Its password wrapper also only guards the
+  // INTERNAL_ dispatch entry, which the extension main->bg bridge uses but
+  // desktop/web single-runtime and native main->bg calls skip. The
+  // devOnlyPassword is therefore checked in the method body, which holds on
+  // every platform.
+  @backgroundMethod()
   @toastIfError()
   async apiResetInfiniSubscription(
     params: IBackgroundMethodWithDevOnlyPassword,
   ): Promise<void> {
-    // This destructively deletes the current user's Infini subscription and is
-    // reachable from a production build, so the devOnlyPassword must be checked
-    // in the method body: @backgroundMethodForDev() only wraps the
-    // INTERNAL_ dispatch entry, which the extension main->bg bridge uses but
-    // desktop/web single-runtime and native main->bg calls do not go through.
+    // Destructively deletes the current user's Infini subscription.
     checkDevOnlyPassword(params, 'apiResetInfiniSubscription');
     const client = await this.getPrimeClient();
     await client.post('/prime/v1/infini/test/reset');

--- a/packages/kit/src/components/MultipleClickStack/MultipleClickStack.test.tsx
+++ b/packages/kit/src/components/MultipleClickStack/MultipleClickStack.test.tsx
@@ -69,6 +69,29 @@ describe.each([3, 10])(
       expect(onPress).toHaveBeenCalledTimes(1);
       expect(screen.queryByText('Debug component')).not.toBeNull();
     });
+
+    // The threshold is a floor, not a one-shot: callers keep receiving onPress
+    // for every click past it. Pinned so the contract cannot drift silently.
+    it(`keeps firing after click ${triggerAt}`, () => {
+      const onPress = jest.fn();
+
+      render(
+        <MultipleClickStack
+          testID="multiple-click-target"
+          triggerAt={triggerAt}
+          onPress={onPress}
+        >
+          Target
+        </MultipleClickStack>,
+      );
+
+      const target = screen.getByTestId('multiple-click-target');
+      for (let clickIndex = 0; clickIndex < triggerAt + 1; clickIndex += 1) {
+        fireEvent.click(target);
+      }
+
+      expect(onPress).toHaveBeenCalledTimes(2);
+    });
   },
 );
 

--- a/packages/kit/src/components/MultipleClickStack/MultipleClickStack.test.tsx
+++ b/packages/kit/src/components/MultipleClickStack/MultipleClickStack.test.tsx
@@ -72,18 +72,59 @@ describe.each([3, 10])(
   },
 );
 
-// debugComponent is the only devSettings-gated way to reveal something behind
-// the multi-click. Callers that must not expose an entry to ordinary users have
-// to use it instead of onPress, which fires regardless of developer mode.
 describe('MultipleClickStack with developer mode disabled', () => {
-  it('keeps debugComponent hidden past the click threshold', () => {
+  beforeEach(() => {
     mockDevSettings.enabled = false;
+  });
+
+  function renderTarget(props: { devSettingsOnly?: boolean }) {
+    const onPress = jest.fn();
+    render(
+      <MultipleClickStack
+        testID="multiple-click-target"
+        triggerAt={3}
+        onPress={onPress}
+        debugComponent={<span>Debug component</span>}
+        {...props}
+      >
+        Target
+      </MultipleClickStack>,
+    );
+    const target = screen.getByTestId('multiple-click-target');
+    for (let clickIndex = 0; clickIndex < 5; clickIndex += 1) {
+      fireEvent.click(target);
+    }
+    return { onPress };
+  }
+
+  // debugComponent has always been gated on developer mode, onPress never was,
+  // so an entry that relies on onPress alone stays reachable by any user.
+  it('keeps debugComponent hidden but still fires onPress by default', () => {
+    const { onPress } = renderTarget({});
+
+    expect(screen.queryByText('Debug component')).toBeNull();
+    expect(onPress).toHaveBeenCalled();
+  });
+
+  // devSettingsOnly is what a caller opts into to gate the whole trigger,
+  // so a hidden entry cannot be found by tapping around a production build.
+  it('suppresses the whole trigger with devSettingsOnly', () => {
+    const { onPress } = renderTarget({ devSettingsOnly: true });
+
+    expect(screen.queryByText('Debug component')).toBeNull();
+    expect(onPress).not.toHaveBeenCalled();
+  });
+});
+
+describe('MultipleClickStack with devSettingsOnly and developer mode enabled', () => {
+  it('triggers once the click threshold is reached', () => {
     const onPress = jest.fn();
 
     render(
       <MultipleClickStack
         testID="multiple-click-target"
         triggerAt={3}
+        devSettingsOnly
         onPress={onPress}
         debugComponent={<span>Debug component</span>}
       >
@@ -92,12 +133,14 @@ describe('MultipleClickStack with developer mode disabled', () => {
     );
 
     const target = screen.getByTestId('multiple-click-target');
-    for (let clickIndex = 0; clickIndex < 5; clickIndex += 1) {
-      fireEvent.click(target);
-    }
+    fireEvent.click(target);
+    fireEvent.click(target);
 
-    expect(screen.queryByText('Debug component')).toBeNull();
-    // onPress is intentionally not gated on developer mode.
-    expect(onPress).toHaveBeenCalled();
+    expect(onPress).not.toHaveBeenCalled();
+
+    fireEvent.click(target);
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Debug component')).not.toBeNull();
   });
 });

--- a/packages/kit/src/components/MultipleClickStack/MultipleClickStack.test.tsx
+++ b/packages/kit/src/components/MultipleClickStack/MultipleClickStack.test.tsx
@@ -22,8 +22,10 @@ jest.mock('@onekeyhq/components', () => ({
   ),
 }));
 
+const mockDevSettings = { enabled: true };
+
 jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
-  useDevSettingsPersistAtom: () => [{ enabled: true }],
+  useDevSettingsPersistAtom: () => [mockDevSettings],
 }));
 
 jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
@@ -32,6 +34,10 @@ jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
     isDev: true,
   },
 }));
+
+beforeEach(() => {
+  mockDevSettings.enabled = true;
+});
 
 describe.each([3, 10])(
   'MultipleClickStack with triggerAt=$triggerAt',
@@ -65,3 +71,33 @@ describe.each([3, 10])(
     });
   },
 );
+
+// debugComponent is the only devSettings-gated way to reveal something behind
+// the multi-click. Callers that must not expose an entry to ordinary users have
+// to use it instead of onPress, which fires regardless of developer mode.
+describe('MultipleClickStack with developer mode disabled', () => {
+  it('keeps debugComponent hidden past the click threshold', () => {
+    mockDevSettings.enabled = false;
+    const onPress = jest.fn();
+
+    render(
+      <MultipleClickStack
+        testID="multiple-click-target"
+        triggerAt={3}
+        onPress={onPress}
+        debugComponent={<span>Debug component</span>}
+      >
+        Target
+      </MultipleClickStack>,
+    );
+
+    const target = screen.getByTestId('multiple-click-target');
+    for (let clickIndex = 0; clickIndex < 5; clickIndex += 1) {
+      fireEvent.click(target);
+    }
+
+    expect(screen.queryByText('Debug component')).toBeNull();
+    // onPress is intentionally not gated on developer mode.
+    expect(onPress).toHaveBeenCalled();
+  });
+});

--- a/packages/kit/src/components/MultipleClickStack/MultipleClickStack.test.tsx
+++ b/packages/kit/src/components/MultipleClickStack/MultipleClickStack.test.tsx
@@ -1,0 +1,67 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { MultipleClickStack } from './MultipleClickStack';
+
+jest.mock('@onekeyhq/components', () => ({
+  Stack: ({
+    children,
+    onPress,
+    testID,
+  }: {
+    children: ReactNode;
+    onPress?: () => void;
+    testID?: string;
+  }) => (
+    <button data-testid={testID} onClick={onPress} type="button">
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
+  useDevSettingsPersistAtom: () => [{ enabled: true }],
+}));
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: {
+    isDev: true,
+  },
+}));
+
+describe.each([3, 10])(
+  'MultipleClickStack with triggerAt=$triggerAt',
+  (triggerAt) => {
+    it(`triggers on click ${triggerAt}`, () => {
+      const onPress = jest.fn();
+
+      render(
+        <MultipleClickStack
+          testID="multiple-click-target"
+          triggerAt={triggerAt}
+          onPress={onPress}
+          debugComponent={<span>Debug component</span>}
+        >
+          Target
+        </MultipleClickStack>,
+      );
+
+      const target = screen.getByTestId('multiple-click-target');
+      for (let clickIndex = 1; clickIndex < triggerAt; clickIndex += 1) {
+        fireEvent.click(target);
+      }
+
+      expect(onPress).not.toHaveBeenCalled();
+      expect(screen.queryByText('Debug component')).toBeNull();
+
+      fireEvent.click(target);
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+      expect(screen.queryByText('Debug component')).not.toBeNull();
+    });
+  },
+);

--- a/packages/kit/src/components/MultipleClickStack/MultipleClickStack.tsx
+++ b/packages/kit/src/components/MultipleClickStack/MultipleClickStack.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps, ReactNode } from 'react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { Stack } from '@onekeyhq/components';
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -28,7 +28,11 @@ export function MultipleClickStack({
   // onPress alone is NOT gated on devSettings, only debugComponent is.
   devSettingsOnly?: boolean;
 } & ComponentProps<typeof Stack>) {
-  const [clickCount, setClickCount] = useState(0);
+  // Counted in a ref, not in state: two presses landing in the same React
+  // batch (RNW dispatching onPress and onClick, or consecutive presses in one
+  // native event batch) would both read the same stale render value and the
+  // count would advance once, making the entry unreachable on some platforms.
+  const clickCountRef = useRef(0);
   const [debugComponentVisible, setDebugComponentVisible] = useState(false);
   const [devSettings] = useDevSettingsPersistAtom();
   const isTriggerAllowed = !devSettingsOnly || devSettings.enabled;
@@ -40,14 +44,14 @@ export function MultipleClickStack({
         bg={showDevBgColor && platformEnv.isDev ? '$bgCritical' : undefined}
         {...others}
         onPress={(event) => {
-          const nextClickCount = clickCount + 1;
-          if (nextClickCount >= triggerAt && isTriggerAllowed) {
+          clickCountRef.current += 1;
+          // Fires on the configured click and on every click after it
+          if (clickCountRef.current >= triggerAt && isTriggerAllowed) {
             onPress?.(event);
             if (debugComponent && devSettings.enabled) {
               setDebugComponentVisible(true);
             }
           }
-          setClickCount(nextClickCount);
         }}
       >
         {children}

--- a/packages/kit/src/components/MultipleClickStack/MultipleClickStack.tsx
+++ b/packages/kit/src/components/MultipleClickStack/MultipleClickStack.tsx
@@ -13,6 +13,7 @@ export function MultipleClickStack({
   showDevBgColor = false,
   triggerAt = platformEnv.isDev ? 3 : 10,
   debugComponent,
+  devSettingsOnly = false,
   ...others
 }: {
   showDevBgColor?: boolean;
@@ -20,10 +21,17 @@ export function MultipleClickStack({
   onPress?: ((event: GestureResponderEvent) => void) | null | undefined;
   children?: ReactNode;
   debugComponent?: ReactNode;
+  // Restrict the whole trigger to developer mode. Off by default so entries
+  // that are meant to stay reachable for ordinary users (log upload on the
+  // lock screen, web dapp mode switch) keep working. Turn it on for entries
+  // that must not be discoverable by tapping around a production build:
+  // onPress alone is NOT gated on devSettings, only debugComponent is.
+  devSettingsOnly?: boolean;
 } & ComponentProps<typeof Stack>) {
   const [clickCount, setClickCount] = useState(0);
   const [debugComponentVisible, setDebugComponentVisible] = useState(false);
   const [devSettings] = useDevSettingsPersistAtom();
+  const isTriggerAllowed = !devSettingsOnly || devSettings.enabled;
 
   return (
     <>
@@ -33,7 +41,7 @@ export function MultipleClickStack({
         {...others}
         onPress={(event) => {
           const nextClickCount = clickCount + 1;
-          if (nextClickCount >= triggerAt) {
+          if (nextClickCount >= triggerAt && isTriggerAllowed) {
             onPress?.(event);
             if (debugComponent && devSettings.enabled) {
               setDebugComponentVisible(true);

--- a/packages/kit/src/components/MultipleClickStack/MultipleClickStack.tsx
+++ b/packages/kit/src/components/MultipleClickStack/MultipleClickStack.tsx
@@ -32,13 +32,14 @@ export function MultipleClickStack({
         bg={showDevBgColor && platformEnv.isDev ? '$bgCritical' : undefined}
         {...others}
         onPress={(event) => {
-          if (clickCount > triggerAt) {
+          const nextClickCount = clickCount + 1;
+          if (nextClickCount >= triggerAt) {
             onPress?.(event);
             if (debugComponent && devSettings.enabled) {
               setDebugComponentVisible(true);
             }
           }
-          setClickCount((prev) => prev + 1);
+          setClickCount(nextClickCount);
         }}
       >
         {children}

--- a/packages/kit/src/provider/Container/AppStateLockContainer/components/AppStateLock.tsx
+++ b/packages/kit/src/provider/Container/AppStateLockContainer/components/AppStateLock.tsx
@@ -205,8 +205,8 @@ const AppStateLock = ({
             <Stack gap="$4" alignItems="center">
               {/* Hidden support entry: a continuous multi-click on the logo
                   (NOT a long-press) opens the state-log upload dialog. Uses
-                  MultipleClickStack's default threshold — it fires on the 12th
-                  consecutive tap in production (5th in dev). Keep it
+                  MultipleClickStack's default threshold — it fires on the 10th
+                  consecutive tap in production (3rd in dev). Keep it
                   deliberately hard to trigger so it is not hit by accident on
                   the lock screen. (OK-56874) */}
               <MultipleClickStack onPress={handleExportLogs}>

--- a/packages/kit/src/views/Prime/components/PrimeDevUtils/PrimeInfiniSubscriptionResetButton.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeDevUtils/PrimeInfiniSubscriptionResetButton.tsx
@@ -1,6 +1,7 @@
 /* cspell:ignore Infini */
-import { Button, Dialog, Toast } from '@onekeyhq/components';
+import { Button, Toast } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { showDevOnlyPasswordDialog } from '@onekeyhq/kit/src/views/Setting/pages/Tab/DevSettingsSection/showDevOnlyPasswordDialog';
 
 export function PrimeInfiniSubscriptionResetButton({
   testID = 'prime-infini-reset-subscription',
@@ -12,15 +13,17 @@ export function PrimeInfiniSubscriptionResetButton({
       variant="destructive"
       testID={testID}
       onPress={() => {
-        Dialog.confirm({
+        // This entry is reachable in production builds, so the destructive
+        // reset is gated behind the devOnlyPassword prompt instead of a plain
+        // confirmation dialog.
+        showDevOnlyPasswordDialog({
           title: 'Reset Infini Subscription',
           description:
             "Permanently delete the current Prime user's Infini subscription so the subscription flow can be tested again?",
-          confirmButtonProps: {
-            variant: 'destructive',
-          },
-          onConfirm: async () => {
-            await backgroundApiProxy.servicePrime.apiResetInfiniSubscription();
+          onConfirm: async (params) => {
+            await backgroundApiProxy.servicePrime.apiResetInfiniSubscription(
+              params,
+            );
             await backgroundApiProxy.servicePrime.apiFetchPrimeUserInfo();
             Toast.success({
               title: 'Infini subscription reset',

--- a/packages/kit/src/views/Prime/components/PrimeDevUtils/PrimeInfiniSubscriptionResetButton.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeDevUtils/PrimeInfiniSubscriptionResetButton.tsx
@@ -1,0 +1,35 @@
+/* cspell:ignore Infini */
+import { Button, Dialog, Toast } from '@onekeyhq/components';
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+
+export function PrimeInfiniSubscriptionResetButton({
+  testID = 'prime-infini-reset-subscription',
+}: {
+  testID?: string;
+}) {
+  return (
+    <Button
+      variant="destructive"
+      testID={testID}
+      onPress={() => {
+        Dialog.confirm({
+          title: 'Reset Infini Subscription',
+          description:
+            "Permanently delete the current Prime user's Infini subscription so the subscription flow can be tested again?",
+          confirmButtonProps: {
+            variant: 'destructive',
+          },
+          onConfirm: async () => {
+            await backgroundApiProxy.servicePrime.apiResetInfiniSubscription();
+            await backgroundApiProxy.servicePrime.apiFetchPrimeUserInfo();
+            Toast.success({
+              title: 'Infini subscription reset',
+            });
+          },
+        });
+      }}
+    >
+      apiResetInfiniSubscription
+    </Button>
+  );
+}

--- a/packages/kit/src/views/Prime/components/PrimeDevUtils/PrimeInfiniSubscriptionResetButton.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeDevUtils/PrimeInfiniSubscriptionResetButton.tsx
@@ -2,12 +2,22 @@
 import { Button, Toast } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { showDevOnlyPasswordDialog } from '@onekeyhq/kit/src/views/Setting/pages/Tab/DevSettingsSection/showDevOnlyPasswordDialog';
+import { usePrimePersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 
 export function PrimeInfiniSubscriptionResetButton({
   testID = 'prime-infini-reset-subscription',
+  onReset,
 }: {
   testID?: string;
+  // Awaited after the reset so the caller can refetch whatever it renders:
+  // apiFetchPrimeUserInfo alone does not refresh a page whose subscription
+  // comes from its own apiGetInfiniSubscription call.
+  onReset?: () => Promise<void>;
 }) {
+  const [primeUserInfo] = usePrimePersistAtom();
+  const expectedOneKeyUserId = primeUserInfo.onekeyUserId;
+
   return (
     <Button
       variant="destructive"
@@ -21,10 +31,19 @@ export function PrimeInfiniSubscriptionResetButton({
           description:
             "Permanently delete the current Prime user's Infini subscription so the subscription flow can be tested again?",
           onConfirm: async (params) => {
+            if (!expectedOneKeyUserId) {
+              throw new OneKeyLocalError('OneKey ID not found');
+            }
             await backgroundApiProxy.servicePrime.apiResetInfiniSubscription(
               params,
+              { expectedOneKeyUserId },
             );
-            await backgroundApiProxy.servicePrime.apiFetchPrimeUserInfo();
+            // The reset just invalidated the server state, so bypass the
+            // short TTL instead of reading a pre-reset cached user info.
+            await backgroundApiProxy.servicePrime.apiFetchPrimeUserInfo({
+              forceRefresh: true,
+            });
+            await onReset?.();
             Toast.success({
               title: 'Infini subscription reset',
             });

--- a/packages/kit/src/views/Prime/components/PrimeDevUtils/index.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeDevUtils/index.tsx
@@ -1,2 +1,3 @@
 export * from './DevOTPAutoFill';
 export * from './DevTestAccountSelector';
+export * from './PrimeInfiniSubscriptionResetButton';

--- a/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeDebugPanel.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeDashboard/PrimeDebugPanel.tsx
@@ -20,6 +20,7 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EPrimePages } from '@onekeyhq/shared/src/routes/prime';
 
+import { PrimeInfiniSubscriptionResetButton } from '../../components/PrimeDevUtils';
 import { usePrimePurchaseCallback } from '../../components/PrimePurchaseDialog/PrimePurchaseDialog';
 
 function CloudSyncDebugTest() {
@@ -259,28 +260,7 @@ export function PrimeDebugPanel({
           ServerPrimeUserInfo
         </Button>
 
-        <Button
-          variant="destructive"
-          onPress={() => {
-            Dialog.confirm({
-              title: 'Reset Infini Subscription',
-              description:
-                "Permanently delete the current Prime user's Infini subscription so the subscription flow can be tested again?",
-              confirmButtonProps: {
-                variant: 'destructive',
-              },
-              onConfirm: async () => {
-                await backgroundApiProxy.servicePrime.apiResetInfiniSubscription();
-                await backgroundApiProxy.servicePrime.apiFetchPrimeUserInfo();
-                Toast.success({
-                  title: 'Infini subscription reset',
-                });
-              },
-            });
-          }}
-        >
-          apiResetInfiniSubscription
-        </Button>
+        <PrimeInfiniSubscriptionResetButton />
 
         <Button
           onPress={() => {

--- a/packages/kit/src/views/Prime/pages/PrimeInfiniSubscription/PrimeInfiniSubscription.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeInfiniSubscription/PrimeInfiniSubscription.tsx
@@ -171,7 +171,6 @@ export default function PrimeInfiniSubscription() {
   const intl = useIntl();
   const navigation = useAppNavigation();
   const [primeUserInfo] = usePrimePersistAtom();
-  const [isResetButtonVisible, setIsResetButtonVisible] = useState(false);
 
   useFocusEffect(
     useCallback(() => {
@@ -245,10 +244,6 @@ export default function PrimeInfiniSubscription() {
   const refreshSubscription = useCallback(() => {
     void run();
   }, [run]);
-
-  const handleSubscriptionTitleMultipleClick = useCallback(() => {
-    setIsResetButtonVisible(true);
-  }, []);
 
   const handleCancelRenewal = useCallback(
     (currentSubscription: IPrimeInfiniSubscription) => {
@@ -374,10 +369,17 @@ export default function PrimeInfiniSubscription() {
             borderColor="$borderSubdued"
             gap="$3"
           >
+            {/* Hidden reset entry: revealed by repeated clicks on the title,
+                and only when developer mode is enabled. MultipleClickStack
+                gates debugComponent on devSettings.enabled, unlike onPress
+                which fires for every user. (Enabling developer mode itself
+                requires the devOnly password plus the app password.) */}
             <MultipleClickStack
               alignSelf="flex-start"
               testID="prime-infini-subscription-title"
-              onPress={handleSubscriptionTitleMultipleClick}
+              debugComponent={
+                <PrimeInfiniSubscriptionResetButton testID="prime-infini-subscription-reset" />
+              }
             >
               <XStack alignItems="center" gap="$2">
                 <SizableText size="$headingLg" flexShrink={1}>
@@ -388,9 +390,6 @@ export default function PrimeInfiniSubscription() {
                 </Badge>
               </XStack>
             </MultipleClickStack>
-            {isResetButtonVisible ? (
-              <PrimeInfiniSubscriptionResetButton testID="prime-infini-subscription-reset" />
-            ) : null}
             <SizableText size="$headingXl">{priceText}</SizableText>
             <Divider />
             <YStack gap="$2.5">
@@ -439,12 +438,7 @@ export default function PrimeInfiniSubscription() {
         </YStack>
       );
     },
-    [
-      handleSubscriptionTitleMultipleClick,
-      intl,
-      isResetButtonVisible,
-      primeUserInfo.displayEmail,
-    ],
+    [intl, primeUserInfo.displayEmail],
   );
 
   const renderContent = () => {

--- a/packages/kit/src/views/Prime/pages/PrimeInfiniSubscription/PrimeInfiniSubscription.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeInfiniSubscription/PrimeInfiniSubscription.tsx
@@ -22,6 +22,7 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { MultipleClickStack } from '@onekeyhq/kit/src/components/MultipleClickStack';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { usePrimePersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
@@ -33,6 +34,8 @@ import type {
   IPrimeInfiniSubscription,
   IPrimeInfiniSubscriptionPlan,
 } from '@onekeyhq/shared/types/prime/primeTypes';
+
+import { PrimeInfiniSubscriptionResetButton } from '../../components/PrimeDevUtils';
 
 import {
   isInfiniSubscriptionRenewalStopped,
@@ -168,6 +171,7 @@ export default function PrimeInfiniSubscription() {
   const intl = useIntl();
   const navigation = useAppNavigation();
   const [primeUserInfo] = usePrimePersistAtom();
+  const [isResetButtonVisible, setIsResetButtonVisible] = useState(false);
 
   useFocusEffect(
     useCallback(() => {
@@ -241,6 +245,10 @@ export default function PrimeInfiniSubscription() {
   const refreshSubscription = useCallback(() => {
     void run();
   }, [run]);
+
+  const handleSubscriptionTitleMultipleClick = useCallback(() => {
+    setIsResetButtonVisible(true);
+  }, []);
 
   const handleCancelRenewal = useCallback(
     (currentSubscription: IPrimeInfiniSubscription) => {
@@ -366,14 +374,23 @@ export default function PrimeInfiniSubscription() {
             borderColor="$borderSubdued"
             gap="$3"
           >
-            <XStack alignItems="center" gap="$2">
-              <SizableText size="$headingLg" flexShrink={1}>
-                {planLabel}
-              </SizableText>
-              <Badge badgeType={badgeType} badgeSize="sm">
-                {statusLabel}
-              </Badge>
-            </XStack>
+            <MultipleClickStack
+              alignSelf="flex-start"
+              testID="prime-infini-subscription-title"
+              onPress={handleSubscriptionTitleMultipleClick}
+            >
+              <XStack alignItems="center" gap="$2">
+                <SizableText size="$headingLg" flexShrink={1}>
+                  {planLabel}
+                </SizableText>
+                <Badge badgeType={badgeType} badgeSize="sm">
+                  {statusLabel}
+                </Badge>
+              </XStack>
+            </MultipleClickStack>
+            {isResetButtonVisible ? (
+              <PrimeInfiniSubscriptionResetButton testID="prime-infini-subscription-reset" />
+            ) : null}
             <SizableText size="$headingXl">{priceText}</SizableText>
             <Divider />
             <YStack gap="$2.5">
@@ -422,7 +439,12 @@ export default function PrimeInfiniSubscription() {
         </YStack>
       );
     },
-    [intl, primeUserInfo.displayEmail],
+    [
+      handleSubscriptionTitleMultipleClick,
+      intl,
+      isResetButtonVisible,
+      primeUserInfo.displayEmail,
+    ],
   );
 
   const renderContent = () => {

--- a/packages/kit/src/views/Prime/pages/PrimeInfiniSubscription/PrimeInfiniSubscription.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeInfiniSubscription/PrimeInfiniSubscription.tsx
@@ -245,6 +245,14 @@ export default function PrimeInfiniSubscription() {
     void run();
   }, [run]);
 
+  // Awaited by the reset button: the subscription shown here comes from this
+  // page's own apiGetInfiniSubscription call, which only re-runs when the
+  // OneKey ID or primeExpiresAt changes, so a reset would otherwise leave the
+  // deleted subscription (and its cancel-renewal entry) on screen.
+  const handleSubscriptionReset = useCallback(async () => {
+    await run();
+  }, [run]);
+
   const handleCancelRenewal = useCallback(
     (currentSubscription: IPrimeInfiniSubscription) => {
       const purchaseUserId = currentOneKeyUserId;
@@ -379,7 +387,10 @@ export default function PrimeInfiniSubscription() {
               testID="prime-infini-subscription-title"
               devSettingsOnly
               debugComponent={
-                <PrimeInfiniSubscriptionResetButton testID="prime-infini-subscription-reset" />
+                <PrimeInfiniSubscriptionResetButton
+                  testID="prime-infini-subscription-reset"
+                  onReset={handleSubscriptionReset}
+                />
               }
             >
               <XStack alignItems="center" gap="$2">
@@ -439,7 +450,7 @@ export default function PrimeInfiniSubscription() {
         </YStack>
       );
     },
-    [intl, primeUserInfo.displayEmail],
+    [handleSubscriptionReset, intl, primeUserInfo.displayEmail],
   );
 
   const renderContent = () => {

--- a/packages/kit/src/views/Prime/pages/PrimeInfiniSubscription/PrimeInfiniSubscription.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeInfiniSubscription/PrimeInfiniSubscription.tsx
@@ -189,7 +189,40 @@ export default function PrimeInfiniSubscription() {
   const primeExpiresAt = primeUserInfo.primeSubscription?.expiresAt;
   const currentOneKeyUserId = primeUserInfo.onekeyUserId;
 
-  const { result, run } = usePromiseResult(
+  // Extracted so a caller that must observe the fresh server state can await
+  // the request itself. The run() returned by usePromiseResult is debounced,
+  // and a debounced call resolves with lodash's previous return value instead
+  // of the pending trailing request, so awaiting it proves nothing.
+  const loadSubscription = useCallback(async () => {
+    if (!currentOneKeyUserId) {
+      return {
+        onekeyUserId: currentOneKeyUserId,
+        subscription: undefined,
+        hasError: true,
+      };
+    }
+    try {
+      const subscription =
+        await backgroundApiProxy.servicePrime.apiGetInfiniSubscription({
+          expectedOneKeyUserId: currentOneKeyUserId,
+        });
+      return {
+        onekeyUserId: currentOneKeyUserId,
+        subscription,
+        hasError: false,
+      };
+    } catch {
+      // Fold the error into the result: usePromiseResult clears the result
+      // on throw, and the page needs an explicit retry state
+      return {
+        onekeyUserId: currentOneKeyUserId,
+        subscription: undefined,
+        hasError: true,
+      };
+    }
+  }, [currentOneKeyUserId]);
+
+  const { result, run, setResult } = usePromiseResult(
     async () => {
       // primeExpiresAt is a real dependency: a successful (renewal) payment
       // bumps the merged Prime expiry in primePersistAtom (via the waiting
@@ -198,34 +231,9 @@ export default function PrimeInfiniSubscription() {
       // reflect the new billing period instead of staying stale
       noopObject(primeExpiresAt);
       noopObject(currentOneKeyUserId);
-      if (!currentOneKeyUserId) {
-        return {
-          onekeyUserId: currentOneKeyUserId,
-          subscription: undefined,
-          hasError: true,
-        };
-      }
-      try {
-        const subscription =
-          await backgroundApiProxy.servicePrime.apiGetInfiniSubscription({
-            expectedOneKeyUserId: currentOneKeyUserId,
-          });
-        return {
-          onekeyUserId: currentOneKeyUserId,
-          subscription,
-          hasError: false,
-        };
-      } catch {
-        // Fold the error into the result: usePromiseResult clears the result
-        // on throw, and the page needs an explicit retry state
-        return {
-          onekeyUserId: currentOneKeyUserId,
-          subscription: undefined,
-          hasError: true,
-        };
-      }
+      return loadSubscription();
     },
-    [currentOneKeyUserId, primeExpiresAt],
+    [currentOneKeyUserId, loadSubscription, primeExpiresAt],
     // Debounced so the renew flow's overlapping triggers (waiting-dialog
     // onClose refresh, the atom expiry bump, and the focus refetch) collapse
     // into a single apiGetInfiniSubscription call instead of firing several
@@ -248,10 +256,13 @@ export default function PrimeInfiniSubscription() {
   // Awaited by the reset button: the subscription shown here comes from this
   // page's own apiGetInfiniSubscription call, which only re-runs when the
   // OneKey ID or primeExpiresAt changes, so a reset would otherwise leave the
-  // deleted subscription (and its cancel-renewal entry) on screen.
+  // deleted subscription (and its cancel-renewal entry) on screen. Bypasses
+  // the debounced run() on purpose: this refresh has to be finished before the
+  // success toast, and it must not be dropped by the focus gate if the dialog
+  // hands focus back during the debounce window.
   const handleSubscriptionReset = useCallback(async () => {
-    await run();
-  }, [run]);
+    setResult(await loadSubscription());
+  }, [loadSubscription, setResult]);
 
   const handleCancelRenewal = useCallback(
     (currentSubscription: IPrimeInfiniSubscription) => {

--- a/packages/kit/src/views/Prime/pages/PrimeInfiniSubscription/PrimeInfiniSubscription.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeInfiniSubscription/PrimeInfiniSubscription.tsx
@@ -370,13 +370,14 @@ export default function PrimeInfiniSubscription() {
             gap="$3"
           >
             {/* Hidden reset entry: revealed by repeated clicks on the title,
-                and only when developer mode is enabled. MultipleClickStack
-                gates debugComponent on devSettings.enabled, unlike onPress
-                which fires for every user. (Enabling developer mode itself
-                requires the devOnly password plus the app password.) */}
+                and only when developer mode is enabled. devSettingsOnly keeps
+                the gate in place even if an onPress is added here later.
+                (Enabling developer mode itself requires the devOnly password
+                plus the app password.) */}
             <MultipleClickStack
               alignSelf="flex-start"
               testID="prime-infini-subscription-title"
+              devSettingsOnly
               debugComponent={
                 <PrimeInfiniSubscriptionResetButton testID="prime-infini-subscription-reset" />
               }

--- a/packages/kit/src/views/Prime/pages/PrimeInfiniSubscription/PrimeInfiniSubscription.tsx
+++ b/packages/kit/src/views/Prime/pages/PrimeInfiniSubscription/PrimeInfiniSubscription.tsx
@@ -1,7 +1,8 @@
 /* cspell:ignore Infini */
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useFocusEffect } from '@react-navigation/core';
+import { debounce } from 'lodash';
 import { useIntl } from 'react-intl';
 
 import type { IBadgeType } from '@onekeyhq/components';
@@ -189,40 +190,7 @@ export default function PrimeInfiniSubscription() {
   const primeExpiresAt = primeUserInfo.primeSubscription?.expiresAt;
   const currentOneKeyUserId = primeUserInfo.onekeyUserId;
 
-  // Extracted so a caller that must observe the fresh server state can await
-  // the request itself. The run() returned by usePromiseResult is debounced,
-  // and a debounced call resolves with lodash's previous return value instead
-  // of the pending trailing request, so awaiting it proves nothing.
-  const loadSubscription = useCallback(async () => {
-    if (!currentOneKeyUserId) {
-      return {
-        onekeyUserId: currentOneKeyUserId,
-        subscription: undefined,
-        hasError: true,
-      };
-    }
-    try {
-      const subscription =
-        await backgroundApiProxy.servicePrime.apiGetInfiniSubscription({
-          expectedOneKeyUserId: currentOneKeyUserId,
-        });
-      return {
-        onekeyUserId: currentOneKeyUserId,
-        subscription,
-        hasError: false,
-      };
-    } catch {
-      // Fold the error into the result: usePromiseResult clears the result
-      // on throw, and the page needs an explicit retry state
-      return {
-        onekeyUserId: currentOneKeyUserId,
-        subscription: undefined,
-        hasError: true,
-      };
-    }
-  }, [currentOneKeyUserId]);
-
-  const { result, run, setResult } = usePromiseResult(
+  const { result, run } = usePromiseResult(
     async () => {
       // primeExpiresAt is a real dependency: a successful (renewal) payment
       // bumps the merged Prime expiry in primePersistAtom (via the waiting
@@ -231,16 +199,41 @@ export default function PrimeInfiniSubscription() {
       // reflect the new billing period instead of staying stale
       noopObject(primeExpiresAt);
       noopObject(currentOneKeyUserId);
-      return loadSubscription();
+      if (!currentOneKeyUserId) {
+        return {
+          onekeyUserId: currentOneKeyUserId,
+          subscription: undefined,
+          hasError: true,
+        };
+      }
+      try {
+        const subscription =
+          await backgroundApiProxy.servicePrime.apiGetInfiniSubscription({
+            expectedOneKeyUserId: currentOneKeyUserId,
+          });
+        return {
+          onekeyUserId: currentOneKeyUserId,
+          subscription,
+          hasError: false,
+        };
+      } catch {
+        // Fold the error into the result: usePromiseResult clears the result
+        // on throw, and the page needs an explicit retry state
+        return {
+          onekeyUserId: currentOneKeyUserId,
+          subscription: undefined,
+          hasError: true,
+        };
+      }
     },
-    [currentOneKeyUserId, loadSubscription, primeExpiresAt],
-    // Debounced so the renew flow's overlapping triggers (waiting-dialog
-    // onClose refresh, the atom expiry bump, and the focus refetch) collapse
-    // into a single apiGetInfiniSubscription call instead of firing several
-    // back to back. watchLoading is intentionally omitted: refreshes keep the
-    // current content in place (see renderContent) rather than flipping the
-    // page into a full spinner.
-    { debounced: 300 },
+    [currentOneKeyUserId, primeExpiresAt],
+    // Debounce lives on the refresh callback below, not here: a hook-level
+    // debounce also wraps the run() that the reset flow has to await, and a
+    // debounced call resolves with lodash's previous return value rather than
+    // the pending request. watchLoading is intentionally omitted: refreshes
+    // keep the current content in place (see renderContent) rather than
+    // flipping the page into a full spinner.
+    {},
   );
   const isResultForCurrentUser = Boolean(
     currentOneKeyUserId && result?.onekeyUserId === currentOneKeyUserId,
@@ -249,20 +242,35 @@ export default function PrimeInfiniSubscription() {
     ? result?.subscription
     : undefined;
 
-  const refreshSubscription = useCallback(() => {
-    void run();
-  }, [run]);
+  const runRef = useRef(run);
+  runRef.current = run;
+
+  // Debounced so the renew flow's overlapping triggers collapse into a single
+  // apiGetInfiniSubscription call instead of firing several back to back.
+  // Reads run() through a ref so the debounced instance stays stable and its
+  // pending call cannot be dropped by a re-render.
+  const refreshSubscription = useMemo(
+    () =>
+      debounce(() => {
+        void runRef.current();
+      }, 300),
+    [],
+  );
+
+  useEffect(() => () => refreshSubscription.cancel(), [refreshSubscription]);
 
   // Awaited by the reset button: the subscription shown here comes from this
   // page's own apiGetInfiniSubscription call, which only re-runs when the
   // OneKey ID or primeExpiresAt changes, so a reset would otherwise leave the
-  // deleted subscription (and its cancel-renewal entry) on screen. Bypasses
-  // the debounced run() on purpose: this refresh has to be finished before the
-  // success toast, and it must not be dropped by the focus gate if the dialog
-  // hands focus back during the debounce window.
+  // deleted subscription (and its cancel-renewal entry) on screen. Goes through
+  // run() rather than writing state directly, so this refresh mints a fresh
+  // nonce inside the hook: an apiGetInfiniSubscription still in flight from an
+  // earlier trigger is invalidated instead of landing afterwards and restoring
+  // the pre-reset subscription.
   const handleSubscriptionReset = useCallback(async () => {
-    setResult(await loadSubscription());
-  }, [loadSubscription, setResult]);
+    refreshSubscription.cancel();
+    await run();
+  }, [refreshSubscription, run]);
 
   const handleCancelRenewal = useCallback(
     (currentSubscription: IPrimeInfiniSubscription) => {

--- a/packages/kit/src/views/ScanQrCode/pages/ScanQrCodeModal.tsx
+++ b/packages/kit/src/views/ScanQrCode/pages/ScanQrCodeModal.tsx
@@ -87,7 +87,7 @@ function DebugInput({ onText }: { onText: (text: string) => void }) {
   return (
     <YStack pb={bottom}>
       <MultipleClickStack
-        triggerAt={process.env.NODE_ENV === 'production' ? 10 : 1}
+        triggerAt={process.env.NODE_ENV === 'production' ? 10 : 3}
         showDevBgColor
         w="$8"
         h="$8"


### PR DESCRIPTION
## Summary

- add a hidden repeated-click shortcut on the Infini subscription title that works in development and production
- reuse the existing `apiResetInfiniSubscription` confirmation action from the Prime debug panel
- make `MultipleClickStack.triggerAt` fire on the exact configured click and cover the 3/10-click thresholds with regression tests

## Test plan

- `yarn jest packages/kit/src/components/MultipleClickStack/MultipleClickStack.test.tsx --runInBand`
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr` (local checks passed; GitHub checks skipped before PR creation)
- Chrome: verified the reset button is absent after clicks 1 and 2, then appears on click 3 in development

The destructive reset confirmation was not executed during manual verification.