### PR TITLE
fix: require devOnlyPassword for Infini subscription reset

### DIFF
--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts
@@ -20,6 +20,8 @@ const mockPrimeLoginDialogAtom = {
   set: jest.fn(async () => undefined),
 };
 
+const VALID_DEV_ONLY_PASSWORD = 'valid-dev-only-password';
+
 jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
   backgroundClass: () => (target: unknown) => target,
   backgroundMethod:
@@ -30,6 +32,21 @@ jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
     () =>
     (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) =>
       descriptor,
+  // Mirrors the real guard: throws unless the caller passes the devOnlyPassword.
+  // The literal is inlined because a jest.mock factory cannot read outer scope.
+  checkDevOnlyPassword: (
+    params: { $$devOnlyPassword?: string } | undefined,
+    methodName?: string,
+  ) => {
+    if (params?.$$devOnlyPassword !== 'valid-dev-only-password') {
+      const { OneKeyLocalError } = require('@onekeyhq/shared/src/errors');
+      throw new OneKeyLocalError(
+        `You are not allowed to call this method, devOnlyPassword is wrong. method=${
+          methodName || ''
+        }`,
+      );
+    }
+  },
   toastIfError:
     () =>
     (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) =>
@@ -383,9 +400,29 @@ describe('ServicePrime.apiResetInfiniSubscription', () => {
     const post = jest.fn(async () => undefined);
     service.getPrimeClient = jest.fn(async () => ({ post }));
 
-    await service.apiResetInfiniSubscription();
+    await service.apiResetInfiniSubscription({
+      $$devOnlyPassword: VALID_DEV_ONLY_PASSWORD,
+    });
 
     expect(post).toHaveBeenCalledWith('/prime/v1/infini/test/reset');
+  });
+
+  // The decorator only guards the INTERNAL_ dispatch entry, which desktop/web
+  // and native main->bg calls skip, so the method body must reject a missing or
+  // wrong devOnlyPassword before the destructive request is sent.
+  it.each([
+    ['missing devOnlyPassword', {} as any],
+    ['wrong devOnlyPassword', { $$devOnlyPassword: 'wrong-password' } as any],
+  ])('rejects a direct call with %s', async (_title, params) => {
+    const { service } = createService();
+    const post = jest.fn(async () => undefined);
+    service.getPrimeClient = jest.fn(async () => ({ post }));
+
+    await expect(service.apiResetInfiniSubscription(params)).rejects.toThrow(
+      /devOnlyPassword is wrong/,
+    );
+
+    expect(post).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
+++ b/packages/kit-bg/src/services/ServicePrime/ServicePrime.tsx
@@ -5,9 +5,11 @@ import BigNumber from 'bignumber.js';
 import { chunk, cloneDeep, isString } from 'lodash';
 
 import { ensureSensitiveTextEncoded } from '@onekeyhq/core/src/secret';
+import type { IBackgroundMethodWithDevOnlyPassword } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import {
   backgroundMethod,
   backgroundMethodForDev,
+  checkDevOnlyPassword,
   toastIfError,
 } from '@onekeyhq/shared/src/background/backgroundDecorators';
 import type { EOAuthSocialLoginProvider } from '@onekeyhq/shared/src/consts/authConsts';
@@ -4260,7 +4262,15 @@ class ServicePrime extends ServiceBase {
 
   @backgroundMethodForDev()
   @toastIfError()
-  async apiResetInfiniSubscription(): Promise<void> {
+  async apiResetInfiniSubscription(
+    params: IBackgroundMethodWithDevOnlyPassword,
+  ): Promise<void> {
+    // This destructively deletes the current user's Infini subscription and is
+    // reachable from a production build, so the devOnlyPassword must be checked
+    // in the method body: @backgroundMethodForDev() only wraps the
+    // INTERNAL_ dispatch entry, which the extension main->bg bridge uses but
+    // desktop/web single-runtime and native main->bg calls do not go through.
+    checkDevOnlyPassword(params, 'apiResetInfiniSubscription');
     const client = await this.getPrimeClient();
     await client.post('/prime/v1/infini/test/reset');
   }

--- a/packages/kit/src/views/Prime/components/PrimeDevUtils/PrimeInfiniSubscriptionResetButton.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeDevUtils/PrimeInfiniSubscriptionResetButton.tsx
@@ -1,6 +1,7 @@
 /* cspell:ignore Infini */
-import { Button, Dialog, Toast } from '@onekeyhq/components';
+import { Button, Toast } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { showDevOnlyPasswordDialog } from '@onekeyhq/kit/src/views/Setting/pages/Tab/DevSettingsSection/showDevOnlyPasswordDialog';
 
 export function PrimeInfiniSubscriptionResetButton({
   testID = 'prime-infini-reset-subscription',
@@ -12,15 +13,17 @@ export function PrimeInfiniSubscriptionResetButton({
       variant="destructive"
       testID={testID}
       onPress={() => {
-        Dialog.confirm({
+        // This entry is reachable in production builds, so the destructive
+        // reset is gated behind the devOnlyPassword prompt instead of a plain
+        // confirmation dialog.
+        showDevOnlyPasswordDialog({
           title: 'Reset Infini Subscription',
           description:
             "Permanently delete the current Prime user's Infini subscription so the subscription flow can be tested again?",
-          confirmButtonProps: {
-            variant: 'destructive',
-          },
-          onConfirm: async () => {
-            await backgroundApiProxy.servicePrime.apiResetInfiniSubscription();
+          onConfirm: async (params) => {
+            await backgroundApiProxy.servicePrime.apiResetInfiniSubscription(
+              params,
+            );
             await backgroundApiProxy.servicePrime.apiFetchPrimeUserInfo();
             Toast.success({
               title: 'Infini subscription reset',


### PR DESCRIPTION
Follow-up to #12648, addressing the P1 review finding on `PrimeInfiniSubscriptionResetButton`. Targets `codex/prime-infini-reset-shortcut` so the diff is only the security fix.

## Problem

`apiResetInfiniSubscription` is reachable from a production build through the new hidden multi-click entry, but the destructive call was effectively unguarded.

`@backgroundMethodForDev()` does not protect the method itself — it only installs a password-checking wrapper on the `INTERNAL_apiResetInfiniSubscription` dispatch entry (`packages/shared/src/background/backgroundDecorators.ts:97-105`). Which code path reaches that wrapper differs per target:

- **desktop / web** (single runtime) and **iOS / Android** `main`→`bg`: `BackgroundApiProxyBase` resolves the call with `serviceApi[methodName].call(...)` (`packages/kit-bg/src/apis/BackgroundApiProxyBase.ts:220-224`), i.e. the raw method — the wrapper and its password check are skipped, so any logged-in user who found the entry could delete the subscription.
- **browser extension** `main`→`bg`: the bridge sends `INTERNAL_...` (`BackgroundApiProxyBase.ts:183-198`), so the wrapper runs and throws because no `$$devOnlyPassword` was passed — the entry was simply broken there.

## Changes

- `ServicePrime.apiResetInfiniSubscription` now takes `IBackgroundMethodWithDevOnlyPassword` and calls `checkDevOnlyPassword(params, 'apiResetInfiniSubscription')` in the method body, before the reset request is sent. This is the same in-body guard `ServiceE2E` and `ServiceReferralCode.devUnbindWallet` use, and it holds on every target regardless of which dispatch path was taken.
- `PrimeInfiniSubscriptionResetButton` collects the password through the existing `showDevOnlyPasswordDialog` and forwards `{ $$devOnlyPassword }`, replacing the plain `Dialog.confirm`. The dialog already keeps the destructive confirm-button styling and the original warning copy.
- `ServicePrime.test.ts` covers the authorized call plus rejection on a missing and on a wrong password, asserting no request is sent in the rejected cases.

## Test plan

- `yarn jest packages/kit-bg/src/services/ServicePrime/ServicePrime.test.ts -t "apiResetInfiniSubscription" --runInBand` — 3 passed
- `yarn agent:check --profile commit` — all local checks pass

Not exercised: the reset itself was not executed against a server, and the dialog was not driven in a running app.

## Notes for the reviewer

Two things this PR deliberately does not change:

1. **The entry is still revealed to any production user.** `MultipleClickStack` fires `onPress` unconditionally once the click threshold is reached; `devSettings.enabled` gates only the `debugComponent` branch (`MultipleClickStack.tsx:34-43`). If the reset button should require developer mode as well, passing it as `debugComponent` instead of driving `isResetButtonVisible` from `onPress` would do that with no new prop.
2. **The devOnly password is derived in open-source code** (`isCorrectDevOnlyPassword`, a `yyyyMMdd`-based string), so it is a speed bump for accidental or casual use, not an authorization boundary. `/prime/v1/infini/test/reset` should also be disabled server-side outside test environments.

The other open review finding on #12648 — stale subscription detail after a successful reset, which needs an `onReset` callback so `PrimeInfiniSubscription` re-runs its own `apiGetInfiniSubscription` fetch — is not addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G5gHjF4DHzssJb1WwnwtB)_