### PR TITLE
fix: preserve swap review output during build (OK-58450)

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -67,6 +67,7 @@ import PreSwapStep from '../../components/PreSwapStep';
 import { PreSwapTipInfo } from '../../components/PreSwapTipInfo';
 import PreSwapTokenItem from '../../components/PreSwapTokenItem';
 import { resolveQuoteShowTip } from '../../utils/quoteShowTipUtils';
+import { shouldShowSwapReviewToAmountSkeleton } from '../../utils/swapReviewState';
 import { getSwapExecutionTypeFromQuoteResult } from '../../utils/swapTypeUtils';
 
 interface IPreSwapDialogContentProps {
@@ -663,7 +664,10 @@ const PreSwapDialogContent = ({
             <PreSwapTokenItem
               token={preSwapData?.toToken}
               amount={toAmount}
-              loading={preSwapData.swapBuildLoading}
+              loading={shouldShowSwapReviewToAmountSkeleton({
+                swapBuildLoading: preSwapData.swapBuildLoading,
+                toTokenAmount: preSwapData.toTokenAmount,
+              })}
               isFloating={quoteResult?.isFloating}
               rateDifference={preSwapData.rateDifference}
             />

--- a/packages/kit/src/views/Swap/utils/swapReviewState.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapReviewState.test.ts
@@ -1,0 +1,30 @@
+import { shouldShowSwapReviewToAmountSkeleton } from './swapReviewState';
+
+describe('shouldShowSwapReviewToAmountSkeleton', () => {
+  it('keeps the frozen quote amount visible while the build is loading', () => {
+    expect(
+      shouldShowSwapReviewToAmountSkeleton({
+        swapBuildLoading: true,
+        toTokenAmount: '21.4568',
+      }),
+    ).toBe(false);
+  });
+
+  it('shows a skeleton when the build is loading without an amount', () => {
+    expect(
+      shouldShowSwapReviewToAmountSkeleton({
+        swapBuildLoading: true,
+        toTokenAmount: '',
+      }),
+    ).toBe(true);
+  });
+
+  it('does not show a skeleton after the build settles', () => {
+    expect(
+      shouldShowSwapReviewToAmountSkeleton({
+        swapBuildLoading: false,
+        toTokenAmount: '',
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/kit/src/views/Swap/utils/swapReviewState.ts
+++ b/packages/kit/src/views/Swap/utils/swapReviewState.ts
@@ -20,6 +20,13 @@ export type ISwapReviewState = {
   quoteResult?: IFetchQuoteResult;
 };
 
+export function shouldShowSwapReviewToAmountSkeleton({
+  swapBuildLoading,
+  toTokenAmount,
+}: Pick<ISwapPreSwapData, 'swapBuildLoading' | 'toTokenAmount'>) {
+  return Boolean(swapBuildLoading && !toTokenAmount);
+}
+
 export type ISwapReviewBroadcastResult = {
   txHash?: string;
   orderId?: string;


### PR DESCRIPTION
## Issue

- [OK-58450](https://onekeyhq.atlassian.net/browse/OK-58450)

## Summary

- keep the frozen quote `toAmount` visible while the review build request is in flight
- show the receive-amount skeleton only when no review amount is available
- preserve the existing confirmation guard until the build finishes

## Root cause

The review state already contained a valid `toTokenAmount`, but `PreSwapDialogContent` mapped every `swapBuildLoading` transition to the amount skeleton. Providers with a slower pre-build response therefore hid and re-rendered an otherwise stable quote whenever the review dialog opened.

## User impact

Opening the Swap/Stock review dialog no longer flashes the receive amount. The reviewed quote remains visible while the build completes, and confirmation stays disabled until the existing build gate settles.

## Validation

- reproduced from the OK-58450 Jira recording and on Desktop
- reproduced deterministically with a 1.5-second mocked build delay and lifecycle logs
- verified the same delayed build keeps `toAmount` visible after the fix
- `yarn jest packages/kit/src/views/Swap/utils/swapReviewState.test.ts packages/kit/src/views/Swap/utils/buildSwapReviewState.test.ts packages/kit/src/views/Swap/pages/components/SwapReviewDialog.test.tsx --runInBand` — 21 tests passed
- `yarn agent:check --profile commit` — passed lint, format, agent-context, staged lint, and staged TypeScript checks

[OK-58450]: https://onekeyhq.atlassian.net/browse/OK-58450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ