### PR TITLE
fix: stabilize Stock and Swap trade flows (OK-58556, OK-58450, OK-56450, OK-58330)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -340,6 +340,7 @@ export function buildMarketSwapHistoryItem({
       socketBridgeScanUrl: swapInfo.swapBuildResData.socketBridgeScanUrl,
       oneKeyFee: swapInfo.swapBuildResData.result?.fee?.percentageFee,
       protocolFee: swapInfo.swapBuildResData.result?.fee?.protocolFees,
+      hideProtocolFee: true,
       otherFeeInfos: swapInfo.swapBuildResData.result?.fee?.otherFeeInfos ?? [],
       orderId: serviceOrderId,
       supportUrl: swapInfo.swapBuildResData.result?.supportUrl,

--- a/packages/kit/src/views/Swap/components/SwapProviderListItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProviderListItem.tsx
@@ -126,38 +126,6 @@ const SwapProviderListItem = ({
     return null;
   }, [estTime, estimatedTime, intl]);
 
-  const protocolFeeComponent = useMemo(
-    () => (
-      <XStack gap="$1" alignItems="center">
-        <Tooltip
-          renderTrigger={
-            <Icon name="HandCoinsOutline" size="$4" color="$iconSubdued" />
-          }
-          renderContent={
-            <SizableText size="$bodySm" color="$text">
-              {intl.formatMessage({
-                id: ETranslations.provider_protocol_fee,
-              })}
-            </SizableText>
-          }
-          placement="bottom-start"
-        />
-
-        <NumberSizeableText
-          size="$bodyMd"
-          color="$textSubdued"
-          formatter="value"
-          formatterOptions={{
-            currency: currencySymbol,
-          }}
-        >
-          {providerResult.fee?.protocolFees ?? 0}
-        </NumberSizeableText>
-      </XStack>
-    ),
-    [currencySymbol, intl, providerResult.fee?.protocolFees],
-  );
-
   const leftMainLabel = useMemo(() => {
     if (disabled) {
       return (
@@ -394,7 +362,6 @@ const SwapProviderListItem = ({
           <XStack gap="$3.5" alignItems="center">
             {networkFeeComponent}
             {estimatedTimeComponent}
-            {protocolFeeComponent}
             <XStack
               role="button"
               borderRadius="$2"

--- a/packages/kit/src/views/Swap/components/SwapQuoteResultRate.tsx
+++ b/packages/kit/src/views/Swap/components/SwapQuoteResultRate.tsx
@@ -38,7 +38,7 @@ interface ISwapQuoteResultRateProps {
   quoting?: boolean;
   isLoading?: boolean;
   showNoProvider?: boolean;
-  onOpenResult?: () => void;
+  canOpenResult?: boolean;
   refreshAction: (manual?: boolean) => void;
   openResult?: boolean;
 }
@@ -55,7 +55,7 @@ const SwapQuoteResultRate = ({
   providerIcon,
   isLoading,
   showNoProvider,
-  onOpenResult,
+  canOpenResult,
   openResult,
   refreshAction,
 }: ISwapQuoteResultRateProps) => {
@@ -180,7 +180,7 @@ const SwapQuoteResultRate = ({
         {!providerIcon ||
         !fromToken ||
         !toToken ||
-        !onOpenResult ||
+        !canOpenResult ||
         quoting ? null : (
           <XStack
             alignItems="center"
@@ -247,7 +247,7 @@ const SwapQuoteResultRate = ({
             </Stack>
           </XStack>
         )}
-        {!quoting && onOpenResult ? (
+        {!quoting && canOpenResult ? (
           <Stack
             animation="quick"
             animateOnly={ANIMATE_ONLY_TRANSFORM}
@@ -276,7 +276,7 @@ const SwapQuoteResultRate = ({
                 }}
               />
             ) : null}
-            {onOpenResult ? (
+            {canOpenResult ? (
               <Stack
                 animation="quick"
                 animateOnly={ANIMATE_ONLY_TRANSFORM}

--- a/packages/kit/src/views/Swap/hooks/useRefreshQuoteWhenStockMarketReopens.test.tsx
+++ b/packages/kit/src/views/Swap/hooks/useRefreshQuoteWhenStockMarketReopens.test.tsx
@@ -3,6 +3,14 @@ import { act, renderHook } from '@testing-library/react-native';
 import { useRefreshQuoteWhenStockMarketReopens } from './useRefreshQuoteWhenStockMarketReopens';
 
 describe('useRefreshQuoteWhenStockMarketReopens', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('does not refresh for an initially open Stock market', () => {
     const onRefresh = jest.fn();
 
@@ -157,5 +165,141 @@ describe('useRefreshQuoteWhenStockMarketReopens', () => {
       rerender({ marketIsOpen: true, scopeKey: 'pair-b' });
     });
     expect(onRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a current closed quote with a bounded backoff', () => {
+    const onRefresh = jest.fn();
+    const { rerender } = renderHook<void, { quoteMarketClosed: boolean }>(
+      ({ quoteMarketClosed }) =>
+        useRefreshQuoteWhenStockMarketReopens({
+          enabled: true,
+          marketIsOpen: true,
+          onRefresh,
+          quoteMarketClosed,
+          scopeKey: 'stock-a|usdc|22',
+        }),
+      {
+        initialProps: {
+          quoteMarketClosed: false,
+        },
+      },
+    );
+
+    const receiveClosedQuote = () => {
+      rerender({ quoteMarketClosed: false });
+      rerender({ quoteMarketClosed: true });
+    };
+
+    receiveClosedQuote();
+    act(() => {
+      jest.advanceTimersByTime(1999);
+    });
+    expect(onRefresh).not.toHaveBeenCalled();
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    receiveClosedQuote();
+    act(() => {
+      jest.advanceTimersByTime(3999);
+    });
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(onRefresh).toHaveBeenCalledTimes(2);
+
+    receiveClosedQuote();
+    act(() => {
+      jest.advanceTimersByTime(7999);
+    });
+    expect(onRefresh).toHaveBeenCalledTimes(2);
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(onRefresh).toHaveBeenCalledTimes(3);
+
+    receiveClosedQuote();
+    expect(jest.getTimerCount()).toBe(0);
+    expect(onRefresh).toHaveBeenCalledTimes(3);
+  });
+
+  it('cancels a pending closed-quote retry when the market closes', () => {
+    const onRefresh = jest.fn();
+    const { rerender } = renderHook<
+      void,
+      { marketIsOpen: boolean; quoteMarketClosed: boolean }
+    >(
+      ({ marketIsOpen, quoteMarketClosed }) =>
+        useRefreshQuoteWhenStockMarketReopens({
+          enabled: true,
+          marketIsOpen,
+          onRefresh,
+          quoteMarketClosed,
+          scopeKey: 'stock-a|usdc|22',
+        }),
+      {
+        initialProps: {
+          marketIsOpen: true,
+          quoteMarketClosed: true,
+        },
+      },
+    );
+
+    rerender({ marketIsOpen: false, quoteMarketClosed: true });
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('resets the closed-quote retry budget for a new quote identity', () => {
+    const onRefresh = jest.fn();
+    const { rerender } = renderHook<
+      void,
+      { quoteMarketClosed: boolean; scopeKey: string }
+    >(
+      ({ quoteMarketClosed, scopeKey }) =>
+        useRefreshQuoteWhenStockMarketReopens({
+          enabled: true,
+          marketIsOpen: true,
+          onRefresh,
+          quoteMarketClosed,
+          scopeKey,
+        }),
+      {
+        initialProps: {
+          quoteMarketClosed: true,
+          scopeKey: 'stock-a|usdc|22',
+        },
+      },
+    );
+
+    for (let retryCount = 0; retryCount < 3; retryCount += 1) {
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
+      rerender({
+        quoteMarketClosed: false,
+        scopeKey: 'stock-a|usdc|22',
+      });
+      rerender({
+        quoteMarketClosed: true,
+        scopeKey: 'stock-a|usdc|22',
+      });
+    }
+    expect(jest.getTimerCount()).toBe(0);
+
+    rerender({
+      quoteMarketClosed: true,
+      scopeKey: 'stock-a|usdc|23',
+    });
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(onRefresh).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/kit/src/views/Swap/hooks/useRefreshQuoteWhenStockMarketReopens.ts
+++ b/packages/kit/src/views/Swap/hooks/useRefreshQuoteWhenStockMarketReopens.ts
@@ -1,35 +1,42 @@
 import { useEffect, useRef } from 'react';
 
+const STOCK_MARKET_REOPEN_QUOTE_RETRY_DELAYS_MS = [2000, 4000, 8000] as const;
+
 /**
- * Refreshes the active quote once per market-open cycle.
+ * Refreshes the active quote when the market reopens and lets the quote service
+ * converge after a short market-status propagation delay.
  *
  * A fresh quote event remains the execution authority: Market detail only
- * signals that it is worth asking the quote service again. If the services
- * disagree and the new quote is still closed, the same `isOpen === true`
- * snapshot must not create a refresh loop. A later observed closed state
- * rearms the next open transition.
+ * signals that it is worth asking the quote service again. If a current quote
+ * still reports a closed market, retries are bounded to avoid an open-ended
+ * request loop. A later market-closed state or quote-identity change rearms the
+ * retry budget.
  */
 export function useRefreshQuoteWhenStockMarketReopens({
   enabled,
   marketIsOpen,
   onRefresh,
+  quoteMarketClosed = false,
   refreshOnInitialOpen = false,
   scopeKey,
 }: {
   enabled: boolean;
   marketIsOpen?: boolean;
   onRefresh: () => void;
+  quoteMarketClosed?: boolean;
   refreshOnInitialOpen?: boolean;
   scopeKey: string;
 }) {
   const refreshCycleRef = useRef({
     consumed: !refreshOnInitialOpen,
+    quoteRetryCount: 0,
     scopeKey,
   });
 
   if (refreshCycleRef.current.scopeKey !== scopeKey) {
     refreshCycleRef.current = {
       consumed: !refreshOnInitialOpen,
+      quoteRetryCount: 0,
       scopeKey,
     };
   }
@@ -37,6 +44,7 @@ export function useRefreshQuoteWhenStockMarketReopens({
   useEffect(() => {
     if (marketIsOpen === false) {
       refreshCycleRef.current.consumed = false;
+      refreshCycleRef.current.quoteRetryCount = 0;
       return;
     }
     if (
@@ -55,4 +63,26 @@ export function useRefreshQuoteWhenStockMarketReopens({
       onRefresh();
     }
   }, [enabled, marketIsOpen, onRefresh, scopeKey]);
+
+  useEffect(() => {
+    if (!enabled || !scopeKey || marketIsOpen !== true || !quoteMarketClosed) {
+      return;
+    }
+    const retryDelay =
+      STOCK_MARKET_REOPEN_QUOTE_RETRY_DELAYS_MS[
+        refreshCycleRef.current.quoteRetryCount
+      ];
+    if (retryDelay === undefined) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (refreshCycleRef.current.scopeKey !== scopeKey) {
+        return;
+      }
+      refreshCycleRef.current.quoteRetryCount += 1;
+      onRefresh();
+    }, retryDelay);
+    return () => clearTimeout(timer);
+  }, [enabled, marketIsOpen, onRefresh, quoteMarketClosed, scopeKey]);
 }

--- a/packages/kit/src/views/Swap/hooks/useSwapTxHistory.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapTxHistory.ts
@@ -137,6 +137,7 @@ export function useSwapTxHistoryActions() {
               swapTxInfo.swapBuildResData.socketBridgeScanUrl,
             oneKeyFee: swapTxInfo.swapBuildResData.result?.fee?.percentageFee,
             protocolFee: swapTxInfo.swapBuildResData.result?.fee?.protocolFees,
+            hideProtocolFee: true,
             otherFeeInfos:
               swapTxInfo.swapBuildResData.result?.fee?.otherFeeInfos ?? [],
             orderId: serviceOrderId,

--- a/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
+++ b/packages/kit/src/views/Swap/pages/components/PreSwapDialogContent.tsx
@@ -67,6 +67,7 @@ import PreSwapStep from '../../components/PreSwapStep';
 import { PreSwapTipInfo } from '../../components/PreSwapTipInfo';
 import PreSwapTokenItem from '../../components/PreSwapTokenItem';
 import { resolveQuoteShowTip } from '../../utils/quoteShowTipUtils';
+import { shouldShowSwapReviewToAmountSkeleton } from '../../utils/swapReviewState';
 import { getSwapExecutionTypeFromQuoteResult } from '../../utils/swapTypeUtils';
 
 interface IPreSwapDialogContentProps {
@@ -663,7 +664,10 @@ const PreSwapDialogContent = ({
             <PreSwapTokenItem
               token={preSwapData?.toToken}
               amount={toAmount}
-              loading={preSwapData.swapBuildLoading}
+              loading={shouldShowSwapReviewToAmountSkeleton({
+                swapBuildLoading: preSwapData.swapBuildLoading,
+                toTokenAmount: preSwapData.toTokenAmount,
+              })}
               isFloating={quoteResult?.isFloating}
               rateDifference={preSwapData.rateDifference}
             />

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
@@ -82,7 +82,7 @@ const SwapQuoteResult = ({
   quoteResult,
   refreshAction,
 }: ISwapQuoteResultProps) => {
-  const [openResult, setOpenResult] = useState(false);
+  const [isAccordionOpen, setIsAccordionOpen] = useState(false);
   const [fromToken] = useSwapSelectFromTokenAtom();
   const [toToken] = useSwapSelectToTokenAtom();
   const [fromTokenAmount] = useSwapFromTokenAmountAtom();
@@ -223,7 +223,9 @@ const SwapQuoteResult = ({
     !hasQuoteResultForDisplay;
 
   const onValueChange = useCallback((value: string) => {
-    if (value === SWAP_ACCORDION_VALUE) {
+    const isOpen = value === SWAP_ACCORDION_VALUE;
+    setIsAccordionOpen(isOpen);
+    if (isOpen) {
       Keyboard.dismiss();
     }
   }, []);
@@ -351,6 +353,7 @@ const SwapQuoteResult = ({
         <Accordion.Item value={SWAP_ACCORDION_VALUE}>
           <Accordion.Trigger
             unstyled
+            testID={SwapTestIDs.quoteDetailsToggle}
             borderWidth={0}
             bg="$transparent"
             p="$0"
@@ -376,16 +379,15 @@ const SwapQuoteResult = ({
                 isLoading={isQuotePresentationLoading}
                 showNoProvider={showNoProvider}
                 refreshAction={refreshAction}
-                onOpenResult={
-                  quoteResultForDisplay?.info.provider
-                    ? () => setOpenResult(!openResult)
-                    : undefined
-                }
+                canOpenResult={Boolean(quoteResultForDisplay?.info.provider)}
                 openResult={open}
               />
             )}
           </Accordion.Trigger>
-          <Accordion.HeightAnimator animation="quick">
+          <Accordion.HeightAnimator
+            animation="quick"
+            overflow={isAccordionOpen ? 'visible' : 'hidden'}
+          >
             <Accordion.Content
               gap="$4"
               p="$0"

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -170,7 +170,10 @@ import {
   shouldShowStockQuoteActionLoading,
 } from './SwapStockDesktopContainer.utils';
 import { SwapStockTradeAlert } from './SwapStockTradeAlert';
-import { isCurrentStockQuoteEventError } from './SwapStockTradeAlertUtils';
+import {
+  isCurrentStockMarketClosedQuoteEventError,
+  isCurrentStockQuoteEventError,
+} from './SwapStockTradeAlertUtils';
 import {
   SwapStockTradeProvider,
   useSwapStockTradeContext,
@@ -1284,16 +1287,29 @@ function StockTradeTicket({
   compact?: boolean;
 }) {
   const amountInputState = useSwapStockAmountInputState({ stockChannel });
+  const [quoteEventError] = useSwapQuoteEventErrorAtom();
   const hasPositiveInputAmount = new BigNumber(
     amountInputState.inputValue || 0,
   ).gt(0);
+  const isCurrentQuoteMarketClosed = isCurrentStockMarketClosedQuoteEventError({
+    fromToken: stockChannel.fromToken,
+    fromTokenAmount: amountInputState.inputValue,
+    quoteEventError,
+    toToken: stockChannel.toToken,
+  });
+  const quoteScopeKey = [
+    getTokenIdentityKey(stockChannel.fromToken),
+    getTokenIdentityKey(stockChannel.toToken),
+    amountInputState.inputValue,
+  ].join('|');
   useRefreshQuoteWhenStockMarketReopens({
     enabled: stockChannel.readyForQuote && hasPositiveInputAmount,
     // The normalized status stays open while detail is unavailable so quote
     // execution can continue; reopen detection needs the raw tri-state value.
     marketIsOpen: stockChannel.activeStockTokenDetail?.stock?.isOpen,
     onRefresh: refreshAction,
-    scopeKey: getTokenIdentityKey(stockChannel.currentStockToken),
+    quoteMarketClosed: isCurrentQuoteMarketClosed,
+    scopeKey: quoteScopeKey,
   });
 
   return (

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
@@ -1396,6 +1396,9 @@ const SwapHistoryDetailModal = () => {
   );
 
   const renderProtocolFee = useCallback(() => {
+    if (txHistory?.swapInfo.hideProtocolFee) {
+      return null;
+    }
     const protocolFee = txHistory?.swapInfo.protocolFee;
     const protocolFeeBN = new BigNumber(protocolFee ?? 0);
     const positiveOtherFeeInfos = txHistory?.swapInfo.otherFeeInfos?.filter(
@@ -1456,6 +1459,7 @@ const SwapHistoryDetailModal = () => {
     displayCurrencyId,
     displayCurrencySymbol,
     historySourceCurrencyId,
+    txHistory?.swapInfo.hideProtocolFee,
     txHistory?.swapInfo.otherFeeInfos,
     txHistory?.swapInfo.protocolFee,
   ]);

--- a/packages/kit/src/views/Swap/pages/modal/SwapProviderSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapProviderSelectModal.tsx
@@ -289,12 +289,6 @@ const SwapProviderSelectModal = () => {
                   id: ETranslations.provider_swap_duration,
                 })}
               />
-              <InformationItem
-                icon="HandCoinsOutline"
-                content={intl.formatMessage({
-                  id: ETranslations.provider_protocol_fee,
-                })}
-              />
             </Stack>
           </Stack>
         }

--- a/packages/kit/src/views/Swap/testIDs.ts
+++ b/packages/kit/src/views/Swap/testIDs.ts
@@ -27,6 +27,7 @@ export const SwapTestIDs = {
 
   // Provider
   providerSelector: 'swap-provider-selector',
+  quoteDetailsToggle: 'swap-quote-details-toggle',
   providerItem: (name: string) => `swap-provider-${name}`,
 
   // Pro

--- a/packages/kit/src/views/Swap/utils/swapReviewState.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapReviewState.test.ts
@@ -1,0 +1,30 @@
+import { shouldShowSwapReviewToAmountSkeleton } from './swapReviewState';
+
+describe('shouldShowSwapReviewToAmountSkeleton', () => {
+  it('keeps the frozen quote amount visible while the build is loading', () => {
+    expect(
+      shouldShowSwapReviewToAmountSkeleton({
+        swapBuildLoading: true,
+        toTokenAmount: '21.4568',
+      }),
+    ).toBe(false);
+  });
+
+  it('shows a skeleton when the build is loading without an amount', () => {
+    expect(
+      shouldShowSwapReviewToAmountSkeleton({
+        swapBuildLoading: true,
+        toTokenAmount: '',
+      }),
+    ).toBe(true);
+  });
+
+  it('does not show a skeleton after the build settles', () => {
+    expect(
+      shouldShowSwapReviewToAmountSkeleton({
+        swapBuildLoading: false,
+        toTokenAmount: '',
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/kit/src/views/Swap/utils/swapReviewState.ts
+++ b/packages/kit/src/views/Swap/utils/swapReviewState.ts
@@ -20,6 +20,13 @@ export type ISwapReviewState = {
   quoteResult?: IFetchQuoteResult;
 };
 
+export function shouldShowSwapReviewToAmountSkeleton({
+  swapBuildLoading,
+  toTokenAmount,
+}: Pick<ISwapPreSwapData, 'swapBuildLoading' | 'toTokenAmount'>) {
+  return Boolean(swapBuildLoading && !toTokenAmount);
+}
+
 export type ISwapReviewBroadcastResult = {
   txHash?: string;
   orderId?: string;

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -1099,6 +1099,7 @@ export interface ISwapTxHistory {
     chainFlipExplorerUrl?: string;
     instantRate: string;
     protocolFee?: number;
+    hideProtocolFee?: boolean;
     oneKeyFee?: number;
     oneKeyFeeExtraInfo?: IOneKeyFeeInfo;
     otherFeeInfos?: IQuoteResultFeeOtherFeeInfo[];


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58556](https://onekeyhq.atlassian.net/browse/OK-58556) [OK-58450](https://onekeyhq.atlassian.net/browse/OK-58450) [OK-56450](https://onekeyhq.atlassian.net/browse/OK-56450) [OK-58330](https://onekeyhq.atlassian.net/browse/OK-58330)

----------

<!-- github-pr-monitor:jira-links:end -->


## Issues

- [OK-58556](https://onekeyhq.atlassian.net/browse/OK-58556)
- [OK-58450](https://onekeyhq.atlassian.net/browse/OK-58450)
- [OK-56450](https://onekeyhq.atlassian.net/browse/OK-56450)
- [OK-58330](https://onekeyhq.atlassian.net/browse/OK-58330)

## Summary

### OK-58556

- retry a Stock quote when Market detail reports open but the current quote still reports market closed
- bound retries to 2s, 4s, and 8s to avoid an open-ended quote loop
- reset and cancel retry state when the quote identity changes or the market closes

### OK-58450

- keep the frozen quote `toAmount` visible while the review build request is in flight
- show the receive-amount skeleton only when no review amount is available
- preserve the existing confirmation guard until the build finishes

### OK-56450

- hide Provider fee from the provider comparison list and provider information popover
- hide Provider fee for new Swap, Bridge, and Stock history records
- retain fee metadata for accounting while preserving Provider fee visibility for existing history records

### OK-58330

- synchronize the quote-details accordion state with its height-container overflow policy
- clip exiting detail content only while collapsed, while keeping open content visible to avoid truncation
- expose a dedicated quote-details toggle test ID without changing provider-selector semantics

## Root cause

### OK-58556

The market-reopen hook consumed the closed-to-open transition after a single refresh. When Market detail became open before the quote service propagated the same status, the refreshed quote could still return `market closed`, while the unchanged open snapshot prevented another refresh.

### OK-58450

The review state already contained a valid `toTokenAmount`, but `PreSwapDialogContent` mapped every `swapBuildLoading` transition to the amount skeleton. A slower pre-build response therefore hid and re-rendered an otherwise stable quote whenever the review dialog opened.

### OK-56450

The provider comparison item always rendered `protocolFees ?? 0`, so a missing backend field appeared as a misleading zero fee. Swap history also had no per-record visibility marker, making it impossible to hide the fee for new records while preserving the existing-history requirement.

### OK-58330

`Accordion.HeightAnimator` collapses its height before the interrupted content exit animation fully settles. A close-open-close sequence could therefore leave nearly opaque, absolutely positioned details outside a zero-height container. The container intentionally used visible overflow after #10464, so the stale content overlaid the FAQ section.

## User impact

- Stock quotes recover automatically from short market-status propagation delays without creating an unbounded request loop.
- Opening the Swap or Stock review dialog no longer flashes the receive amount.
- Confirmation remains disabled until the existing build gate settles.
- Provider comparison no longer shows a misleading Provider fee value.
- New trade history hides Provider fee, while previous history retains its original display behavior.
- Rapid quote-details toggles collapse cleanly without overlaying the FAQ, while fully expanded details remain unclipped.

## Validation

- combined branch is based on the latest `x`
- `yarn jest packages/kit/src/views/Swap/hooks/useRefreshQuoteWhenStockMarketReopens.test.tsx packages/kit/src/views/Swap/utils/swapReviewState.test.ts packages/kit/src/views/Swap/utils/buildSwapReviewState.test.ts packages/kit/src/views/Swap/pages/components/SwapReviewDialog.test.tsx --runInBand` — 4 suites, 30 tests passed
- `yarn jest packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx --runInBand` — 1 suite, 31 tests passed
- `yarn agent:check --profile commit` — passed after the OK-58330 change
- `yarn agent:check --profile pr` — local checks and 16 existing CI checks passed; code-owner review remains required
- OK-58450 reproduced and verified on Desktop with a deterministic 1.5-second mocked build delay
- OK-56450 verified on Desktop against the development quote API: Provider fee text and icon were absent while received amount, network fee, duration, and route remained visible
- OK-58330 reproduced from the Jira or Slack recording and verified on Desktop across 12 rapid close-open-close cycles with 20–260ms intervals; collapsed content no longer leaked, and expanded content remained fully visible

[OK-58556]: https://onekeyhq.atlassian.net/browse/OK-58556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-58450]: https://onekeyhq.atlassian.net/browse/OK-58450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-56450]: https://onekeyhq.atlassian.net/browse/OK-56450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-58330]: https://onekeyhq.atlassian.net/browse/OK-58330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ