### PR TITLE
fix: improve mobile Unifold deposit selector flow

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldDepositTransferModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldDepositTransferModal.tsx
@@ -8,13 +8,13 @@ import {
   type IPageNavigationProp,
   NavBackButton,
   Page,
+  Stack,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import {
+import type {
   EModalPerpRoutes,
-  type IModalPerpParamList,
+  IModalPerpParamList,
 } from '@onekeyhq/shared/src/routes/perp';
-import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
 import type {
   IUnifoldSupportedAsset,
   IUnifoldSupportedAssetChain,
@@ -22,13 +22,23 @@ import type {
 
 import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../../../PerpDialogLayout';
 
-import { UnifoldTransferContent } from './UnifoldTransferContent';
+import { MobileUnifoldSourceSelectorContent } from './MobileUnifoldSourceSelectorContent';
+import {
+  type IUnifoldTransferContentRef,
+  UnifoldTransferContent,
+} from './UnifoldTransferContent';
 
 import type { RouteProp } from '@react-navigation/core';
+
+type IMobileUnifoldFlowStep = 'transfer' | 'token' | 'chain';
+const MOBILE_PAGE_SCROLL_PROPS = {
+  contentContainerStyle: { flexGrow: 1 },
+} as const;
 
 export default function MobileUnifoldDepositTransferModal() {
   const intl = useIntl();
   const navigation = useNavigation<IPageNavigationProp<IModalPerpParamList>>();
+  const transferContentRef = useRef<IUnifoldTransferContentRef>(null);
   const [detailExecutionId, setDetailExecutionId] = useState<string | null>(
     null,
   );
@@ -39,7 +49,22 @@ export default function MobileUnifoldDepositTransferModal() {
         EModalPerpRoutes.MobileUnifoldDepositTransfer
       >
     >();
-  const initialSourceSelectorOpenedRef = useRef(false);
+  const [flowHistory, setFlowHistory] = useState<IMobileUnifoldFlowStep[]>(() =>
+    route.params?.openSourceSelectorOnReady ? ['token'] : ['transfer'],
+  );
+  const currentFlowStep = flowHistory[flowHistory.length - 1] ?? 'transfer';
+  const initialSelectorMode =
+    currentFlowStep === 'transfer' ? null : currentFlowStep;
+  const isTransientSelector = flowHistory.includes('transfer');
+  const [initialSelectorAssets, setInitialSelectorAssets] = useState<
+    IUnifoldSupportedAsset[] | undefined
+  >(undefined);
+  const [initialSelectedAssetSymbol, setInitialSelectedAssetSymbol] = useState<
+    string | undefined
+  >(undefined);
+  const [initialSelectedChain, setInitialSelectedChain] = useState<
+    IUnifoldSupportedAssetChain | undefined
+  >(undefined);
   const closeDetail = useCallback(() => {
     setDetailExecutionId(null);
   }, []);
@@ -48,16 +73,47 @@ export default function MobileUnifoldDepositTransferModal() {
     [closeDetail],
   );
   const goBack = useCallback(() => {
+    if (flowHistory.length > 1) {
+      setFlowHistory((current) => current.slice(0, -1));
+      return;
+    }
     navigation.goBack();
-  }, [navigation]);
+  }, [flowHistory.length, navigation]);
   const renderBackHeaderLeft = useCallback(
     () => <NavBackButton onPress={goBack} />,
     [goBack],
   );
+  const pushFlowStep = useCallback((step: IMobileUnifoldFlowStep) => {
+    setFlowHistory((current) =>
+      current[current.length - 1] === step ? current : [...current, step],
+    );
+  }, []);
+  const showInitialTokenSelector = useCallback(() => {
+    pushFlowStep('token');
+  }, [pushFlowStep]);
+  const showInitialChainSelector = useCallback(() => {
+    pushFlowStep('chain');
+  }, [pushFlowStep]);
+  const closeTransientSelector = useCallback(() => {
+    setFlowHistory((current) => {
+      const transferIndex = current.lastIndexOf('transfer');
+      return transferIndex === -1
+        ? current
+        : current.slice(0, transferIndex + 1);
+    });
+  }, []);
+  const showTransferUnavailableState = useCallback(() => {
+    setFlowHistory((current) => {
+      const transferIndex = current.lastIndexOf('transfer');
+      return transferIndex === -1
+        ? ['transfer']
+        : current.slice(0, transferIndex + 1);
+    });
+  }, []);
   const clearSourceSelectorResult = useCallback(() => {
     navigation.setParams({ sourceSelectorResult: undefined });
   }, [navigation]);
-  const openInitialSourceSelector = useCallback(
+  const prepareInitialSourceSelector = useCallback(
     ({
       assets,
       asset,
@@ -67,52 +123,118 @@ export default function MobileUnifoldDepositTransferModal() {
       asset: IUnifoldSupportedAsset;
       chain: IUnifoldSupportedAssetChain;
     }) => {
-      if (
-        !route.params?.openSourceSelectorOnReady ||
-        initialSourceSelectorOpenedRef.current
-      ) {
-        return;
+      setInitialSelectorAssets(assets);
+      if (currentFlowStep === 'transfer') {
+        setInitialSelectedAssetSymbol(asset.symbol);
+        setInitialSelectedChain(chain);
+      } else {
+        setInitialSelectedAssetSymbol((current) => current ?? asset.symbol);
+        setInitialSelectedChain((current) => current ?? chain);
       }
-      initialSourceSelectorOpenedRef.current = true;
-      navigation.setParams({ openSourceSelectorOnReady: undefined });
-      navigation.push(EModalPerpRoutes.MobileUnifoldSourceSelector, {
-        requestId: generateUUID(),
-        mode: 'token',
-        assets,
-        selectedAssetSymbol: asset.symbol,
-        selectedChainType: chain.chain_type,
-        selectedChainId: chain.chain_id,
-        continueToChain: true,
-      });
     },
-    [navigation, route.params?.openSourceSelectorOnReady],
+    [currentFlowStep],
   );
+  const isInitialSelectorVisible = initialSelectorMode !== null;
+  let headerTitleId = ETranslations.perp_unifold_transfer_crypto__title;
+  let headerLeft = renderBackHeaderLeft;
+  if (detailExecutionId) {
+    headerTitleId = ETranslations.perp_unifold_deposit_details__title;
+    headerLeft = renderDetailHeaderLeft;
+  } else if (initialSelectorMode === 'token') {
+    headerTitleId = ETranslations.token_selector_title;
+  } else if (initialSelectorMode === 'chain') {
+    headerTitleId = ETranslations.global_select_network;
+  }
 
   return (
-    <Page scrollEnabled safeAreaEnabled>
+    <Page scrollEnabled scrollProps={MOBILE_PAGE_SCROLL_PROPS} safeAreaEnabled>
       <Page.Header
-        title={intl.formatMessage({
-          id: detailExecutionId
-            ? ETranslations.perp_unifold_deposit_details__title
-            : ETranslations.perp_unifold_transfer_crypto__title,
-        })}
-        headerLeft={
-          detailExecutionId ? renderDetailHeaderLeft : renderBackHeaderLeft
-        }
+        title={intl.formatMessage({ id: headerTitleId })}
+        headerLeft={headerLeft}
       />
-      <Page.Body px="$4" {...PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS}>
-        {/* The page scrolls, so an absolute overlay would ride the content
-            instead of the screen — the cards go in the page footer here. */}
-        <UnifoldTransferContent
-          expectedRecipient={route.params?.expectedRecipient}
-          sourceSelectorResult={route.params?.sourceSelectorResult}
-          onSourceSelectorResultHandled={clearSourceSelectorResult}
-          onSourceSelectorReady={openInitialSourceSelector}
-          statusCardsPlacement="pageFooter"
-          useExternalHeader
-          detailExecutionId={detailExecutionId}
-          onDetailExecutionIdChange={setDetailExecutionId}
-        />
+      <Page.Body
+        flex={1}
+        minHeight={0}
+        position="relative"
+        {...PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS}
+      >
+        <Stack px="$4">
+          <UnifoldTransferContent
+            ref={transferContentRef}
+            expectedRecipient={route.params?.expectedRecipient}
+            sourceSelectorResult={route.params?.sourceSelectorResult}
+            onSourceSelectorResultHandled={clearSourceSelectorResult}
+            onSourceSelectorReady={prepareInitialSourceSelector}
+            onSourceSelectorUnavailable={
+              isInitialSelectorVisible
+                ? showTransferUnavailableState
+                : undefined
+            }
+            statusCardsPlacement={
+              isInitialSelectorVisible ? 'overlay' : 'pageFooter'
+            }
+            useExternalHeader
+            detailExecutionId={detailExecutionId}
+            onDetailExecutionIdChange={setDetailExecutionId}
+            onOpenMobileTokenSelector={showInitialTokenSelector}
+            onOpenMobileChainSelector={showInitialChainSelector}
+          />
+        </Stack>
+        {initialSelectorMode ? (
+          <Stack
+            position="absolute"
+            top={0}
+            bottom={0}
+            left={0}
+            right={0}
+            zIndex={1}
+            bg="$bgApp"
+          >
+            <MobileUnifoldSourceSelectorContent
+              key={initialSelectorMode}
+              mode={initialSelectorMode}
+              assets={initialSelectorAssets}
+              loading={!initialSelectorAssets}
+              selectedAssetSymbol={initialSelectedAssetSymbol}
+              selectedChainType={initialSelectedChain?.chain_type}
+              selectedChainId={initialSelectedChain?.chain_id}
+              onSelectToken={(asset) => {
+                setInitialSelectedAssetSymbol(asset.symbol);
+                if (isTransientSelector) {
+                  const chain =
+                    asset.chains.find(
+                      (item) =>
+                        item.chain_type === initialSelectedChain?.chain_type &&
+                        item.chain_id === initialSelectedChain?.chain_id,
+                    ) ?? asset.chains[0];
+                  if (!chain) {
+                    return;
+                  }
+                  setInitialSelectedChain(chain);
+                  transferContentRef.current?.selectSource(asset, chain);
+                  navigation.setParams({
+                    openSourceSelectorOnReady: undefined,
+                  });
+                  closeTransientSelector();
+                  return;
+                }
+                setInitialSelectedChain(undefined);
+                pushFlowStep('chain');
+              }}
+              onSelectChain={(asset, chain) => {
+                setInitialSelectedAssetSymbol(asset.symbol);
+                setInitialSelectedChain(chain);
+                transferContentRef.current?.selectSource(asset, chain);
+                navigation.setParams({ openSourceSelectorOnReady: undefined });
+                if (isTransientSelector) {
+                  closeTransientSelector();
+                } else {
+                  pushFlowStep('transfer');
+                }
+              }}
+            />
+          </Stack>
+        ) : null}
       </Page.Body>
     </Page>
   );

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldDepositTransferModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldDepositTransferModal.tsx
@@ -9,8 +9,10 @@ import {
   NavBackButton,
   Page,
   Stack,
+  useBackHandler,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type {
   EModalPerpRoutes,
   IModalPerpParamList,
@@ -79,6 +81,14 @@ export default function MobileUnifoldDepositTransferModal() {
     }
     navigation.goBack();
   }, [flowHistory.length, navigation]);
+  const handleSystemBackPress = useCallback(() => {
+    goBack();
+    return true;
+  }, [goBack]);
+  useBackHandler(
+    handleSystemBackPress,
+    platformEnv.isNativeAndroid && Boolean(initialSelectorMode),
+  );
   const renderBackHeaderLeft = useCallback(
     () => <NavBackButton onPress={goBack} />,
     [goBack],

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldDepositTransferModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldDepositTransferModal.tsx
@@ -87,7 +87,9 @@ export default function MobileUnifoldDepositTransferModal() {
   }, [goBack]);
   useBackHandler(
     handleSystemBackPress,
-    platformEnv.isNativeAndroid && Boolean(initialSelectorMode),
+    platformEnv.isNativeAndroid &&
+      !detailExecutionId &&
+      (Boolean(initialSelectorMode) || flowHistory.length > 1),
   );
   const renderBackHeaderLeft = useCallback(
     () => <NavBackButton onPress={goBack} />,

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldSourceSelectorContent.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldSourceSelectorContent.tsx
@@ -1,20 +1,14 @@
-import { type ReactNode, useCallback, useMemo, useState } from 'react';
+import { type ReactNode, useMemo, useState } from 'react';
 
-import {
-  StackActions,
-  useNavigation,
-  useRoute,
-} from '@react-navigation/native';
 import { useIntl } from 'react-intl';
 
 import {
   Empty,
-  type IPageNavigationProp,
   Icon,
-  Page,
   ScrollView,
   SearchBar,
   SizableText,
+  Skeleton,
   Stack,
   XStack,
   YStack,
@@ -22,16 +16,38 @@ import {
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import {
-  EModalPerpRoutes,
-  type IModalPerpParamList,
-  type IUnifoldSourceSelectorResult,
-} from '@onekeyhq/shared/src/routes/perp';
-import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
+import type {
+  IUnifoldSupportedAsset,
+  IUnifoldSupportedAssetChain,
+} from '@onekeyhq/shared/types/unifoldDeposit';
 
 import { normalizeUnifoldIconUrl } from './unifoldFormat';
 
-import type { RouteProp } from '@react-navigation/native';
+function MobileSourceSelectorSkeletonList() {
+  return (
+    <YStack testID="perps-unifold-source-selector-loading">
+      {[...Array(6)].map((_, index) => (
+        <XStack
+          // The index is stable because these placeholders never reorder.
+          key={index}
+          mx="$-2"
+          px="$2"
+          width="100%"
+          alignItems="center"
+          gap="$3"
+          py="$2.5"
+        >
+          <Skeleton radius="round" w="$10" h="$10" />
+          <YStack flex={1} gap="$1">
+            <Skeleton h="$4" w="$24" />
+            <Skeleton h="$3" w="$16" />
+          </YStack>
+          <Stack width="$5" />
+        </XStack>
+      ))}
+    </YStack>
+  );
+}
 
 function MobileSourceSelectorRow({
   testID,
@@ -80,28 +96,32 @@ function MobileSourceSelectorRow({
   );
 }
 
-export default function MobileUnifoldSourceSelectorModal() {
+export function MobileUnifoldSourceSelectorContent({
+  mode,
+  assets,
+  loading = false,
+  selectedAssetSymbol,
+  selectedChainType,
+  selectedChainId,
+  onSelectToken,
+  onSelectChain,
+}: {
+  mode: 'token' | 'chain';
+  assets: IUnifoldSupportedAsset[] | undefined;
+  loading?: boolean;
+  selectedAssetSymbol?: string;
+  selectedChainType?: string;
+  selectedChainId?: string;
+  onSelectToken: (asset: IUnifoldSupportedAsset) => void;
+  onSelectChain: (
+    asset: IUnifoldSupportedAsset,
+    chain: IUnifoldSupportedAssetChain,
+  ) => void;
+}) {
   const intl = useIntl();
   const [searchValue, setSearchValue] = useState('');
-  const navigation = useNavigation<IPageNavigationProp<IModalPerpParamList>>();
-  const route =
-    useRoute<
-      RouteProp<
-        IModalPerpParamList,
-        EModalPerpRoutes.MobileUnifoldSourceSelector
-      >
-    >();
-  const {
-    requestId,
-    mode,
-    assets,
-    selectedAssetSymbol,
-    selectedChainType,
-    selectedChainId,
-    continueToChain,
-  } = route.params;
   const usableAssets = useMemo(
-    () => assets.filter((asset) => asset.chains.length > 0),
+    () => (assets ?? []).filter((asset) => asset.chains.length > 0),
     [assets],
   );
   const filteredAssets = useMemo(() => {
@@ -136,29 +156,6 @@ export default function MobileUnifoldSourceSelectorModal() {
       ),
     );
   }, [chainOptions, searchValue]);
-  const returnSelection = useCallback(
-    (sourceSelectorResult: IUnifoldSourceSelectorResult) => {
-      navigation.dispatch(
-        StackActions.popTo(
-          EModalPerpRoutes.MobileUnifoldDepositTransfer,
-          { sourceSelectorResult },
-          { merge: true },
-        ),
-      );
-    },
-    [navigation],
-  );
-  const selectTokenAndContinue = useCallback(
-    (assetSymbol: string) => {
-      navigation.push(EModalPerpRoutes.MobileUnifoldSourceSelector, {
-        requestId: generateUUID(),
-        mode: 'chain',
-        assets: usableAssets,
-        selectedAssetSymbol: assetSymbol,
-      });
-    },
-    [navigation, usableAssets],
-  );
   let optionRows: ReactNode = null;
   if (mode === 'token') {
     optionRows = filteredAssets.map((asset) => (
@@ -179,15 +176,7 @@ export default function MobileUnifoldSourceSelectorModal() {
         }
         selected={asset.symbol === selectedAssetSymbol}
         onPress={() => {
-          if (continueToChain) {
-            selectTokenAndContinue(asset.symbol);
-          } else {
-            returnSelection({
-              requestId,
-              mode: 'token',
-              assetSymbol: asset.symbol,
-            });
-          }
+          onSelectToken(asset);
         }}
       />
     ));
@@ -206,16 +195,7 @@ export default function MobileUnifoldSourceSelectorModal() {
           chain.chain_id === selectedChainId
         }
         onPress={() => {
-          const result = {
-            assetSymbol: selectedAsset.symbol,
-            chainType: chain.chain_type,
-            chainId: chain.chain_id,
-          };
-          returnSelection({
-            requestId,
-            mode: 'chain',
-            ...result,
-          });
+          onSelectChain(selectedAsset, chain);
         }}
       />
     ));
@@ -232,45 +212,35 @@ export default function MobileUnifoldSourceSelectorModal() {
       />
     </YStack>
   );
-  if (hasResults) {
+  if (loading) {
+    listContent = <MobileSourceSelectorSkeletonList />;
+  } else if (hasResults) {
     listContent = optionRows;
   }
 
   return (
-    <Page>
-      <Page.Header
-        title={intl.formatMessage({
-          id:
-            mode === 'token'
-              ? ETranslations.token_selector_title
-              : ETranslations.global_select_network,
-        })}
-      />
-      <Page.Body>
-        <YStack px="$4" flex={1} minHeight={0}>
-          <YStack pb="$3">
-            <SearchBar
-              value={searchValue}
-              onChangeText={setSearchValue}
-              placeholder={intl.formatMessage({
-                id:
-                  mode === 'token'
-                    ? ETranslations.global_search_tokens
-                    : ETranslations.form_search_network_placeholder,
-              })}
-              containerProps={{
-                bg: '$bgStrong',
-                borderRadius: '$full',
-              }}
-            />
-          </YStack>
-          <Stack flex={1} minHeight={0} mx="$-2">
-            <ScrollView flex={1} showsVerticalScrollIndicator={false}>
-              <YStack px="$2">{listContent}</YStack>
-            </ScrollView>
-          </Stack>
-        </YStack>
-      </Page.Body>
-    </Page>
+    <YStack px="$4" flex={1} minHeight={0}>
+      <YStack pb="$3">
+        <SearchBar
+          value={searchValue}
+          onChangeText={setSearchValue}
+          placeholder={intl.formatMessage({
+            id:
+              mode === 'token'
+                ? ETranslations.global_search_tokens
+                : ETranslations.form_search_network_placeholder,
+          })}
+          containerProps={{
+            bg: '$bgStrong',
+            borderRadius: '$full',
+          }}
+        />
+      </YStack>
+      <Stack flex={1} minHeight={0} mx="$-2">
+        <ScrollView flex={1} showsVerticalScrollIndicator={false}>
+          <YStack px="$2">{listContent}</YStack>
+        </ScrollView>
+      </Stack>
+    </YStack>
   );
 }

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/UnifoldDepositQRCard.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/UnifoldDepositQRCard.tsx
@@ -22,7 +22,7 @@ import { normalizeUnifoldIconUrl } from './unifoldFormat';
 const QR_SIZE = 200;
 const QR_CODE_PADDING = 10;
 const QR_CODE_SIZE = QR_SIZE - QR_CODE_PADDING;
-const QR_QUIET_ZONE_MODULES = 4;
+const QR_QUIET_ZONE_MODULES = 2;
 const QR_LOGO_SIZE = 56;
 const QR_LOGO_MARGIN = 4;
 const UNIFOLD_TERMS_URL = 'https://unifold.io/terms';

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/UnifoldDepositQRCard.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/UnifoldDepositQRCard.tsx
@@ -19,9 +19,11 @@ import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 
 import { normalizeUnifoldIconUrl } from './unifoldFormat';
 
-const QR_SIZE = 200;
+const QR_CANVAS_SIZE = 200;
+const QR_CARD_BORDER_WIDTH = 1;
+const QR_CARD_SIZE = QR_CANVAS_SIZE + QR_CARD_BORDER_WIDTH * 2;
 const QR_CODE_PADDING = 10;
-const QR_CODE_SIZE = QR_SIZE - QR_CODE_PADDING;
+const QR_CODE_SIZE = QR_CANVAS_SIZE - QR_CODE_PADDING;
 const QR_QUIET_ZONE_MODULES = 2;
 const QR_LOGO_SIZE = 56;
 const QR_LOGO_MARGIN = 4;
@@ -72,8 +74,8 @@ export function UnifoldDepositQRCard({
     >
       {!loading && !address ? (
         <YStack
-          width={QR_SIZE}
-          height={QR_SIZE}
+          width={QR_CARD_SIZE}
+          height={QR_CARD_SIZE}
           alignItems="center"
           justifyContent="center"
           gap="$2"
@@ -106,13 +108,15 @@ export function UnifoldDepositQRCard({
         </YStack>
       ) : null}
       {loading ? (
-        <Skeleton width={QR_SIZE} height={QR_SIZE} radius={8} />
+        <Skeleton width={QR_CARD_SIZE} height={QR_CARD_SIZE} radius={8} />
       ) : null}
       {!loading && address ? (
         <Stack
           testID="perps-unifold-qr-visual"
-          width={QR_SIZE}
-          height={QR_SIZE}
+          width={QR_CARD_SIZE}
+          height={QR_CARD_SIZE}
+          borderWidth={QR_CARD_BORDER_WIDTH}
+          borderColor="$borderSubdued"
           borderRadius="$2"
           overflow="hidden"
         >

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/UnifoldSourceSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/UnifoldSourceSelector.tsx
@@ -1,13 +1,11 @@
 // cspell: words unifold Unifold
 import { useState } from 'react';
 
-import { useNavigation } from '@react-navigation/native';
 import { useIntl } from 'react-intl';
 
 import {
   Button,
   DashText,
-  type IPageNavigationProp,
   Icon,
   IconButton,
   Popover,
@@ -24,11 +22,6 @@ import { Token } from '@onekeyhq/kit/src/components/Token';
 import type { IUnifoldSourceSelection } from '@onekeyhq/kit/src/views/Perp/hooks/usePerpsUnifoldDepositSession';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import {
-  EModalPerpRoutes,
-  type IModalPerpParamList,
-} from '@onekeyhq/shared/src/routes/perp';
-import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
 import type {
   IUnifoldSupportedAsset,
   IUnifoldSupportedAssetChain,
@@ -68,7 +61,6 @@ function SelectorTrigger({
       borderRadius="$2"
       borderWidth="$px"
       borderColor="$borderSubdued"
-      opacity={disabled ? 0.6 : 1}
       disabled={disabled}
       cursor={disabled ? 'default' : 'pointer'}
       hoverStyle={
@@ -108,12 +100,7 @@ function SelectorTrigger({
           </SizableText>
         </>
       )}
-      <Icon
-        name="ChevronDownSmallOutline"
-        size="$4"
-        color="$iconSubdued"
-        opacity={0.6}
-      />
+      <Icon name="ChevronDownSmallOutline" size="$4" color="$icon" />
     </XStack>
   );
 }
@@ -309,18 +296,20 @@ export function UnifoldSourceSelector({
   loading,
   onSelectToken,
   onSelectChain,
+  onOpenMobileTokenSelector,
+  onOpenMobileChainSelector,
 }: {
   assets: IUnifoldSupportedAsset[] | undefined;
   selection: IUnifoldSourceSelection | null;
   loading: boolean;
   onSelectToken: (asset: IUnifoldSupportedAsset) => void;
   onSelectChain: (chain: IUnifoldSupportedAssetChain) => void;
+  onOpenMobileTokenSelector?: () => void;
+  onOpenMobileChainSelector?: () => void;
 }) {
   const intl = useIntl();
   const [tokenOpen, setTokenOpen] = useState(false);
   const [chainOpen, setChainOpen] = useState(false);
-  const navigation = useNavigation<IPageNavigationProp<IModalPerpParamList>>();
-
   const usableAssets = (assets ?? []).filter((a) => (a.chains ?? []).length);
   const chainOptions = selection?.asset.chains ?? [];
   const minUsd = selection?.chain.minimum_deposit_amount_usd ?? 3;
@@ -345,14 +334,7 @@ export function UnifoldSourceSelector({
           return;
         }
 
-        navigation.push(EModalPerpRoutes.MobileUnifoldSourceSelector, {
-          requestId: generateUUID(),
-          mode: 'token',
-          assets: usableAssets,
-          selectedAssetSymbol: selection?.asset.symbol,
-          selectedChainType: selection?.chain.chain_type,
-          selectedChainId: selection?.chain.chain_id,
-        });
+        onOpenMobileTokenSelector?.();
       }}
     />
   );
@@ -373,14 +355,7 @@ export function UnifoldSourceSelector({
           return;
         }
 
-        navigation.push(EModalPerpRoutes.MobileUnifoldSourceSelector, {
-          requestId: generateUUID(),
-          mode: 'chain',
-          assets: usableAssets,
-          selectedAssetSymbol: selection?.asset.symbol,
-          selectedChainType: selection?.chain.chain_type,
-          selectedChainId: selection?.chain.chain_id,
-        });
+        onOpenMobileChainSelector?.();
       }}
     />
   );

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/UnifoldSourceSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/UnifoldSourceSelector.tsx
@@ -329,12 +329,12 @@ export function UnifoldSourceSelector({
         if (!canSelectToken) {
           return;
         }
-        if (!platformEnv.isNative) {
-          setTokenOpen(true);
+        if (onOpenMobileTokenSelector) {
+          onOpenMobileTokenSelector();
           return;
         }
 
-        onOpenMobileTokenSelector?.();
+        setTokenOpen(true);
       }}
     />
   );
@@ -350,12 +350,12 @@ export function UnifoldSourceSelector({
         if (!canSelectChain) {
           return;
         }
-        if (!platformEnv.isNative) {
-          setChainOpen(true);
+        if (onOpenMobileChainSelector) {
+          onOpenMobileChainSelector();
           return;
         }
 
-        onOpenMobileChainSelector?.();
+        setChainOpen(true);
       }}
     />
   );
@@ -383,7 +383,7 @@ export function UnifoldSourceSelector({
           </SizableText>
           <TokenContractDisclosure selection={selection} />
         </XStack>
-        {platformEnv.isNative ? (
+        {onOpenMobileTokenSelector ? (
           tokenTrigger
         ) : (
           <Popover
@@ -465,7 +465,7 @@ export function UnifoldSourceSelector({
             )}
           </DashText>
         </XStack>
-        {platformEnv.isNative ? (
+        {onOpenMobileChainSelector ? (
           chainTrigger
         ) : (
           <Popover

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/UnifoldTransferContent.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/UnifoldTransferContent.tsx
@@ -1,5 +1,13 @@
 // cspell: words unifold Unifold hypercore Hypercore
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -36,6 +44,7 @@ import type { IUnifoldSourceSelectorResult } from '@onekeyhq/shared/src/routes/p
 import type {
   IUnifoldDepositExecution,
   IUnifoldSupportedAsset,
+  IUnifoldSupportedAssetChain,
 } from '@onekeyhq/shared/types/unifoldDeposit';
 
 import { UnifoldDepositQRCard } from './UnifoldDepositQRCard';
@@ -292,42 +301,61 @@ function BodyFrame({
   );
 }
 
-export function UnifoldTransferContent({
-  expectedRecipient,
-  onPressExecution,
-  bodyMaxHeight,
-  statusCardsPlacement = 'overlay',
-  useDialogHeader = false,
-  useExternalHeader = false,
-  detailExecutionId: controlledDetailExecutionId,
-  onDetailExecutionIdChange,
-  sourceSelectorResult,
-  onSourceSelectorResultHandled,
-  onSourceSelectorReady,
-}: {
-  expectedRecipient: string | null | undefined;
-  onPressExecution?: (execution: IUnifoldDepositExecution) => void;
-  bodyMaxHeight?: number;
-  // 'pageFooter' pins the cards to a mobile Page footer; the default overlay
-  // mode floats them over the panel. Only a host that owns a <Page> may ask
-  // for the footer, so this must stay a prop rather than a platform check.
-  statusCardsPlacement?: 'overlay' | 'pageFooter';
-  useDialogHeader?: boolean;
-  useExternalHeader?: boolean;
-  detailExecutionId?: string | null;
-  onDetailExecutionIdChange?: (executionId: string | null) => void;
-  sourceSelectorResult?: IUnifoldSourceSelectorResult;
-  onSourceSelectorResultHandled?: () => void;
-  onSourceSelectorReady?: ({
-    assets,
-    asset,
-    chain,
-  }: {
-    assets: IUnifoldSupportedAsset[];
-    asset: IUnifoldSourceSelection['asset'];
-    chain: IUnifoldSourceSelection['chain'];
-  }) => void;
-}) {
+export type IUnifoldTransferContentRef = {
+  selectSource: (
+    asset: IUnifoldSupportedAsset,
+    chain: IUnifoldSupportedAssetChain,
+  ) => void;
+};
+
+export const UnifoldTransferContent = forwardRef<
+  IUnifoldTransferContentRef,
+  {
+    expectedRecipient: string | null | undefined;
+    onPressExecution?: (execution: IUnifoldDepositExecution) => void;
+    bodyMaxHeight?: number;
+    // 'pageFooter' pins the cards to a mobile Page footer; the default overlay
+    // mode floats them over the panel. Only a host that owns a <Page> may ask
+    // for the footer, so this must stay a prop rather than a platform check.
+    statusCardsPlacement?: 'overlay' | 'pageFooter';
+    useDialogHeader?: boolean;
+    useExternalHeader?: boolean;
+    detailExecutionId?: string | null;
+    onDetailExecutionIdChange?: (executionId: string | null) => void;
+    sourceSelectorResult?: IUnifoldSourceSelectorResult;
+    onSourceSelectorResultHandled?: () => void;
+    onSourceSelectorReady?: ({
+      assets,
+      asset,
+      chain,
+    }: {
+      assets: IUnifoldSupportedAsset[];
+      asset: IUnifoldSourceSelection['asset'];
+      chain: IUnifoldSourceSelection['chain'];
+    }) => void;
+    onSourceSelectorUnavailable?: () => void;
+    onOpenMobileTokenSelector?: () => void;
+    onOpenMobileChainSelector?: () => void;
+  }
+>(function UnifoldTransferContent(
+  {
+    expectedRecipient,
+    onPressExecution,
+    bodyMaxHeight,
+    statusCardsPlacement = 'overlay',
+    useDialogHeader = false,
+    useExternalHeader = false,
+    detailExecutionId: controlledDetailExecutionId,
+    onDetailExecutionIdChange,
+    sourceSelectorResult,
+    onSourceSelectorResultHandled,
+    onSourceSelectorReady,
+    onSourceSelectorUnavailable,
+    onOpenMobileTokenSelector,
+    onOpenMobileChainSelector,
+  },
+  ref,
+) {
   const intl = useIntl();
   const [dismissedExecutionStatuses, setDismissedExecutionStatuses] = useState<
     Partial<Record<string, IUnifoldDepositExecution['status']>>
@@ -345,6 +373,7 @@ export function UnifoldTransferContent({
     selection,
     selectToken,
     selectChain,
+    selectSource,
     qrAddress,
     sessionExecutions,
     acknowledgePresentedExecution,
@@ -353,6 +382,8 @@ export function UnifoldTransferContent({
     activationRetrying,
   } = usePerpsUnifoldDepositSession({ enabled: true, expectedRecipient });
   const handledSourceSelectorRequestIdRef = useRef<string | null>(null);
+
+  useImperativeHandle(ref, () => ({ selectSource }), [selectSource]);
 
   useEffect(() => {
     if (!supportedAssets || !selection) {
@@ -364,6 +395,15 @@ export function UnifoldTransferContent({
       chain: selection.chain,
     });
   }, [onSourceSelectorReady, selection, supportedAssets]);
+
+  useEffect(() => {
+    if (
+      addressState.status === 'error' &&
+      addressState.errorType !== 'network'
+    ) {
+      onSourceSelectorUnavailable?.();
+    }
+  }, [addressState, onSourceSelectorUnavailable]);
 
   useEffect(() => {
     if (
@@ -469,7 +509,30 @@ export function UnifoldTransferContent({
     platformEnv.isNativeAndroid && Boolean(detailExecutionId),
   );
 
-  const chain = selection?.chain;
+  const pendingSelection = useMemo(() => {
+    if (!sourceSelectorResult || !supportedAssets) {
+      return null;
+    }
+    const asset = supportedAssets.find(
+      (item) => item.symbol === sourceSelectorResult.assetSymbol,
+    );
+    if (!asset) {
+      return null;
+    }
+    const chain =
+      sourceSelectorResult.mode === 'chain'
+        ? asset.chains.find(
+            (item) =>
+              item.chain_type === sourceSelectorResult.chainType &&
+              item.chain_id === sourceSelectorResult.chainId,
+          )
+        : (asset.chains.find(
+            (item) => item.chain_id === selection?.chain.chain_id,
+          ) ?? asset.chains[0]);
+    return chain ? { asset, chain } : null;
+  }, [selection?.chain.chain_id, sourceSelectorResult, supportedAssets]);
+  const displaySelection = pendingSelection ?? selection;
+  const chain = displaySelection?.chain;
   const receiveAsset = supportedAssets?.find(
     (asset) =>
       asset.symbol.toUpperCase() === UNIFOLD_ARBITRUM_USDC_SYMBOL.toUpperCase(),
@@ -638,10 +701,12 @@ export function UnifoldTransferContent({
     <YStack gap="$3">
       <UnifoldSourceSelector
         assets={supportedAssets}
-        selection={selection}
+        selection={displaySelection}
         loading={Boolean(assetsLoading && !selection)}
         onSelectToken={selectToken}
         onSelectChain={selectChain}
+        onOpenMobileTokenSelector={onOpenMobileTokenSelector}
+        onOpenMobileChainSelector={onOpenMobileChainSelector}
       />
 
       {addressState.status === 'error' &&
@@ -707,8 +772,8 @@ export function UnifoldTransferContent({
       <UnifoldDepositQRCard
         address={qrAddress}
         chainIconUri={chain?.icon_url}
-        sourceTokenSymbol={selection?.asset.symbol}
-        sourceTokenIconUri={selection?.asset.icon_url}
+        sourceTokenSymbol={displaySelection?.asset.symbol}
+        sourceTokenIconUri={displaySelection?.asset.icon_url}
         receiveTokenSymbol={receiveTokenSymbol}
         receiveTokenIconUri={receiveAsset?.icon_url}
         receiveNetworkIconUri={receiveNetworkIconUri}
@@ -718,8 +783,9 @@ export function UnifoldTransferContent({
         // message instead of shimmering forever.
         loading={
           Boolean(assetsLoading) ||
+          Boolean(sourceSelectorResult) ||
           addressState.status === 'loading' ||
-          (addressState.status === 'ready' && !selection)
+          (addressState.status === 'ready' && !displaySelection)
         }
       />
 
@@ -757,11 +823,11 @@ export function UnifoldTransferContent({
         py="$2"
         overflow="hidden"
       >
-        {useCompactLayout && selection?.asset.symbol ? (
+        {useCompactLayout && displaySelection?.asset.symbol ? (
           <DepositRouteRow
-            sourceTokenSymbol={selection.asset.symbol}
+            sourceTokenSymbol={displaySelection.asset.symbol}
             sourceNetworkName={chain?.chain_name}
-            sourceTokenIconUri={selection.asset.icon_url}
+            sourceTokenIconUri={displaySelection.asset.icon_url}
             sourceNetworkIconUri={chain?.icon_url}
             receiveTokenSymbol={receiveTokenSymbol}
             receiveNetworkName={receiveNetworkName}
@@ -816,4 +882,4 @@ export function UnifoldTransferContent({
       </YStack>
     </YStack>,
   );
-}
+});

--- a/packages/kit/src/views/Perp/hooks/usePerpsUnifoldDepositSession.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpsUnifoldDepositSession.ts
@@ -492,6 +492,15 @@ export function usePerpsUnifoldDepositSession({
     [destination],
   );
 
+  const selectSource = useCallback(
+    (asset: IUnifoldSupportedAsset, chain: IUnifoldSupportedAssetChain) => {
+      const next = { asset, chain };
+      cacheSourceSelection(destination, next);
+      setSelection(next);
+    },
+    [destination],
+  );
+
   // ── Deposit address (echo-checked in bg); 5s auto-retry on failure ──
   const [addressAttempt, setAddressAttempt] = useState(0);
   useEffect(() => {
@@ -969,6 +978,7 @@ export function usePerpsUnifoldDepositSession({
     selection,
     selectToken,
     selectChain,
+    selectSource,
     qrAddress,
     sessionExecutions: isLiveAccountAligned ? sessionExecutions : [],
     acknowledgePresentedExecution,

--- a/packages/kit/src/views/Perp/router/index.ts
+++ b/packages/kit/src/views/Perp/router/index.ts
@@ -74,11 +74,6 @@ const MobileUnifoldDepositTransferModal = LazyLoadPage(
     import('../components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldDepositTransferModal'),
 );
 
-const MobileUnifoldSourceSelectorModal = LazyLoadPage(
-  () =>
-    import('../components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldSourceSelectorModal'),
-);
-
 const MobileUnifoldDepositTrackerModal = LazyLoadPage(
   () =>
     import('../components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldDepositTrackerModal'),
@@ -121,10 +116,6 @@ export const perpRouters: ITabSubNavigatorConfig<any, any>[] = [
   {
     name: EModalPerpRoutes.MobileUnifoldDepositTransfer,
     component: MobileUnifoldDepositTransferModal,
-  },
-  {
-    name: EModalPerpRoutes.MobileUnifoldSourceSelector,
-    component: MobileUnifoldSourceSelectorModal,
   },
   {
     name: EModalPerpRoutes.MobileUnifoldDepositTracker,
@@ -176,10 +167,6 @@ export const ModalPerpStack: IModalFlowNavigatorConfig<
   {
     name: EModalPerpRoutes.MobileUnifoldDepositTransfer,
     component: MobileUnifoldDepositTransferModal,
-  },
-  {
-    name: EModalPerpRoutes.MobileUnifoldSourceSelector,
-    component: MobileUnifoldSourceSelectorModal,
   },
   {
     name: EModalPerpRoutes.MobileUnifoldDepositTracker,

--- a/packages/shared/src/routes/perp.ts
+++ b/packages/shared/src/routes/perp.ts
@@ -1,7 +1,5 @@
 import type { ISetTpslParams } from '@onekeyhq/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal';
 
-import type { IUnifoldSupportedAsset } from '../../types/unifoldDeposit';
-
 export enum EModalPerpRoutes {
   PerpTradersHistoryList = 'PerpTradersHistoryList',
   MobilePerpMarket = 'MobilePerpMarket',
@@ -10,7 +8,6 @@ export enum EModalPerpRoutes {
   MobileDepositWithdrawModal = 'MobileDepositWithdrawModal',
   MobileDepositSelectToken = 'MobileDepositSelectToken',
   MobileUnifoldDepositTransfer = 'MobileUnifoldDepositTransfer',
-  MobileUnifoldSourceSelector = 'MobileUnifoldSourceSelector',
   MobileUnifoldDepositTracker = 'MobileUnifoldDepositTracker',
   PerpsInviteeRewardModal = 'PerpsInviteeRewardModal',
   MobilePortfolioPage = 'MobilePortfolioPage',
@@ -71,15 +68,6 @@ export type IModalPerpParamList = {
     expectedRecipient: string;
     sourceSelectorResult?: IUnifoldSourceSelectorResult;
     openSourceSelectorOnReady?: boolean;
-  };
-  [EModalPerpRoutes.MobileUnifoldSourceSelector]: {
-    requestId: string;
-    mode: 'token' | 'chain';
-    assets: IUnifoldSupportedAsset[];
-    selectedAssetSymbol?: string;
-    selectedChainType?: string;
-    selectedChainId?: string;
-    continueToChain?: boolean;
   };
   [EModalPerpRoutes.MobileUnifoldDepositTracker]: {
     expectedRecipient: string;


### PR DESCRIPTION
## Summary

- open the mobile token selector before the transfer page and keep token/network selection inside one modal flow
- make transient selectors close immediately without participating in back navigation
- keep the transfer session mounted so same-address selections do not reload the address or QR code
- refine selector loading, icon contrast, and QR-code spacing

## Validation

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- iOS simulator: token → network → transfer, transient token/network switching, and back navigation

Follow-up to https://github.com/OneKeyHQ/app-monorepo/pull/12674