### PR TITLE
fix: re-enable the perps subscriptions handler when the UI is provably live

### DIFF
--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.test.ts
@@ -1,3 +1,8 @@
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
+
 import ServiceHyperliquidSubscription from './ServiceHyperliquidSubscription';
 
 import type { IBackgroundApi } from '../../apis/IBackgroundApi';
@@ -75,6 +80,103 @@ describe('ServiceHyperliquidSubscription liveness recovery', () => {
     ).resolves.toBe(false);
     expect(service.subscriptionsHandlerDisabled).toBe(true);
     expect(update).not.toHaveBeenCalled();
+  });
+
+  it('announces a successful recovery on the event bus', async () => {
+    const service = createService();
+    const internals = service as unknown as {
+      _watchSubscriptionAtoms: () => void;
+    };
+    jest
+      .spyOn(internals, '_watchSubscriptionAtoms')
+      .mockImplementation(() => {});
+    jest.spyOn(service, 'updateSubscriptions').mockResolvedValue(undefined);
+    const emit = jest.spyOn(appEventBus, 'emit').mockReturnValue(true);
+    try {
+      await service.disableSubscriptionsHandler();
+      const proofCount = await service.getSubscriptionsHandlerDisabledCount();
+
+      await expect(
+        service.recoverSubscriptionsAfterLivenessProof({
+          disabledCount: proofCount,
+        }),
+      ).resolves.toBe(true);
+      expect(emit).toHaveBeenCalledWith(
+        EAppEventBusNames.PerpsSubscriptionsRecovered,
+        undefined,
+      );
+    } finally {
+      emit.mockRestore();
+    }
+  });
+
+  it('does not announce a rejected recovery', async () => {
+    const service = createService();
+    jest.spyOn(service, 'updateSubscriptions').mockResolvedValue(undefined);
+    const emit = jest.spyOn(appEventBus, 'emit').mockReturnValue(true);
+    try {
+      await service.disableSubscriptionsHandler();
+      const proofCount = await service.getSubscriptionsHandlerDisabledCount();
+      await service.disableSubscriptionsHandler();
+
+      await expect(
+        service.recoverSubscriptionsAfterLivenessProof({
+          disabledCount: proofCount,
+        }),
+      ).resolves.toBe(false);
+      expect(emit).not.toHaveBeenCalledWith(
+        EAppEventBusNames.PerpsSubscriptionsRecovered,
+        undefined,
+      );
+    } finally {
+      emit.mockRestore();
+    }
+  });
+
+  it('reinstalls the atom watcher before reconciling on a successful recovery', async () => {
+    const service = createService();
+    const internals = service as unknown as {
+      _watchSubscriptionAtoms: () => void;
+    };
+    const watch = jest
+      .spyOn(internals, '_watchSubscriptionAtoms')
+      .mockImplementation(() => {});
+    const update = jest
+      .spyOn(service, 'updateSubscriptions')
+      .mockResolvedValue(undefined);
+    await service.disableSubscriptionsHandler();
+    const proofCount = await service.getSubscriptionsHandlerDisabledCount();
+
+    await expect(
+      service.recoverSubscriptionsAfterLivenessProof({
+        disabledCount: proofCount,
+      }),
+    ).resolves.toBe(true);
+    expect(watch).toHaveBeenCalledTimes(1);
+    expect(watch.mock.invocationCallOrder[0]).toBeLessThan(
+      update.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('does not touch the atom watcher when the proof is stale', async () => {
+    const service = createService();
+    const internals = service as unknown as {
+      _watchSubscriptionAtoms: () => void;
+    };
+    const watch = jest
+      .spyOn(internals, '_watchSubscriptionAtoms')
+      .mockImplementation(() => {});
+    jest.spyOn(service, 'updateSubscriptions').mockResolvedValue(undefined);
+    await service.disableSubscriptionsHandler();
+    const proofCount = await service.getSubscriptionsHandlerDisabledCount();
+    await service.disableSubscriptionsHandler();
+
+    await expect(
+      service.recoverSubscriptionsAfterLivenessProof({
+        disabledCount: proofCount,
+      }),
+    ).resolves.toBe(false);
+    expect(watch).not.toHaveBeenCalled();
   });
 
   it('enables and reconciles when the proof matches the latest generation', async () => {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.test.ts
@@ -3,6 +3,8 @@ import {
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 
+import { ESubscriptionType } from '@onekeyhq/shared/types/hyperliquid/types';
+
 import ServiceHyperliquidSubscription from './ServiceHyperliquidSubscription';
 
 import type { IBackgroundApi } from '../../apis/IBackgroundApi';
@@ -60,6 +62,132 @@ describe('ServiceHyperliquidSubscription Fast L2 lifecycle', () => {
     await internals._closeClient();
 
     expect(internals._fastL2RecoveryGeneration).toBe(5);
+  });
+});
+
+describe('ServiceHyperliquidSubscription resume stream liveness', () => {
+  type IResumeInternals = {
+    _lastMessageAt: number | null;
+    _lastFrameAt: number | null;
+    _socketOpenedAt: number | null;
+    _forceReconnectTransport: () => Promise<void>;
+    _reconcileOpenSocketSubscriptionsOnResume: (p?: unknown) => Promise<void>;
+    _watchSubscriptionAtoms: () => void;
+    getWebSocketClient: () => Promise<unknown>;
+  };
+
+  const setupOpenSocketService = () => {
+    const service = createService();
+    const internals = service as unknown as IResumeInternals;
+    jest
+      .spyOn(internals, 'getWebSocketClient')
+      .mockResolvedValue({ transport: { socket: { readyState: 1 } } });
+    const force = jest
+      .spyOn(internals, '_forceReconnectTransport')
+      .mockResolvedValue(undefined);
+    const reconcile = jest
+      .spyOn(internals, '_reconcileOpenSocketSubscriptionsOnResume')
+      .mockResolvedValue(undefined);
+    jest
+      .spyOn(internals, '_watchSubscriptionAtoms')
+      .mockImplementation(() => {});
+    return { service, internals, force, reconcile };
+  };
+
+  beforeAll(() => {
+    const g = globalThis as { WebSocket?: unknown };
+    if (typeof g.WebSocket === 'undefined') {
+      g.WebSocket = { CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3 };
+    }
+  });
+
+  it('forces a reconnect when the open socket stream went stale', async () => {
+    const { service, internals, force, reconcile } = setupOpenSocketService();
+    internals._lastMessageAt = Date.now() - 60_000;
+    internals._socketOpenedAt = Date.now() - 60_000;
+
+    await service.resumeSubscriptions();
+
+    expect(force).toHaveBeenCalledTimes(1);
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+
+  it('reuses the open socket while the stream is fresh', async () => {
+    const { service, internals, force, reconcile } = setupOpenSocketService();
+    internals._lastFrameAt = Date.now() - 1_000;
+
+    await service.resumeSubscriptions();
+
+    expect(force).not.toHaveBeenCalled();
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the legacy reuse when no liveness evidence exists', async () => {
+    const { service, internals, force, reconcile } = setupOpenSocketService();
+    internals._lastMessageAt = null;
+    internals._socketOpenedAt = null;
+
+    await service.resumeSubscriptions();
+
+    expect(force).not.toHaveBeenCalled();
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps trusting the socket when frames arrived while the handler was disabled', async () => {
+    const { service, internals, force, reconcile } = setupOpenSocketService();
+    internals._lastMessageAt = Date.now() - 60_000;
+    internals._socketOpenedAt = Date.now() - 60_000;
+    await service.disableSubscriptionsHandler();
+    await (
+      service as unknown as {
+        _handleSubscriptionData: (
+          t: ESubscriptionType,
+          e: CustomEvent,
+        ) => Promise<void>;
+      }
+    )._handleSubscriptionData(
+      ESubscriptionType.ALL_MIDS,
+      { detail: {} } as unknown as CustomEvent,
+    );
+
+    await service.resumeSubscriptions();
+
+    expect(force).not.toHaveBeenCalled();
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes concurrent stale-stream reconnects into one transport rebuild', async () => {
+    const { service, internals, force } = setupOpenSocketService();
+    let release: (() => void) | undefined;
+    force.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+    internals._lastMessageAt = Date.now() - 60_000;
+    internals._socketOpenedAt = Date.now() - 60_000;
+
+    const first = service.resumeSubscriptions();
+    const second = service.resumeSubscriptions();
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    release?.();
+    await Promise.all([first, second]);
+
+    expect(force).toHaveBeenCalledTimes(1);
+  });
+
+  it('trusts a freshly opened socket that has not received messages yet', async () => {
+    const { service, internals, force, reconcile } = setupOpenSocketService();
+    internals._lastMessageAt = Date.now() - 60_000;
+    internals._socketOpenedAt = Date.now() - 1_000;
+
+    await service.resumeSubscriptions();
+
+    expect(force).not.toHaveBeenCalled();
+    expect(reconcile).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.test.ts
@@ -23,11 +23,15 @@ jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => {
   };
 });
 
+function createService() {
+  return new ServiceHyperliquidSubscription({
+    backgroundApi: {} as IBackgroundApi,
+  });
+}
+
 describe('ServiceHyperliquidSubscription Fast L2 lifecycle', () => {
   it('invalidates delayed recovery when the socket closes', () => {
-    const service = new ServiceHyperliquidSubscription({
-      backgroundApi: {} as IBackgroundApi,
-    });
+    const service = createService();
     const internals = service as unknown as {
       _fastL2RecoveryGeneration: number;
     };
@@ -41,9 +45,7 @@ describe('ServiceHyperliquidSubscription Fast L2 lifecycle', () => {
   });
 
   it('invalidates delayed recovery when the client closes explicitly', async () => {
-    const service = new ServiceHyperliquidSubscription({
-      backgroundApi: {} as IBackgroundApi,
-    });
+    const service = createService();
     const internals = service as unknown as {
       _closeClient: () => Promise<void>;
       _fastL2RecoveryGeneration: number;
@@ -53,5 +55,42 @@ describe('ServiceHyperliquidSubscription Fast L2 lifecycle', () => {
     await internals._closeClient();
 
     expect(internals._fastL2RecoveryGeneration).toBe(5);
+  });
+});
+
+describe('ServiceHyperliquidSubscription liveness recovery', () => {
+  it('rejects a proof older than the latest disable', async () => {
+    const service = createService();
+    const update = jest
+      .spyOn(service, 'updateSubscriptions')
+      .mockResolvedValue(undefined);
+    await service.disableSubscriptionsHandler();
+    const proofCount = await service.getSubscriptionsHandlerDisabledCount();
+    await service.disableSubscriptionsHandler();
+
+    await expect(
+      service.recoverSubscriptionsAfterLivenessProof({
+        disabledCount: proofCount,
+      }),
+    ).resolves.toBe(false);
+    expect(service.subscriptionsHandlerDisabled).toBe(true);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('enables and reconciles when the proof matches the latest generation', async () => {
+    const service = createService();
+    const update = jest
+      .spyOn(service, 'updateSubscriptions')
+      .mockResolvedValue(undefined);
+    await service.disableSubscriptionsHandler();
+    const proofCount = await service.getSubscriptionsHandlerDisabledCount();
+
+    await expect(
+      service.recoverSubscriptionsAfterLivenessProof({
+        disabledCount: proofCount,
+      }),
+    ).resolves.toBe(true);
+    expect(service.subscriptionsHandlerDisabled).toBe(false);
+    expect(update).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.test.ts
@@ -2,7 +2,6 @@ import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
-
 import { ESubscriptionType } from '@onekeyhq/shared/types/hyperliquid/types';
 
 import ServiceHyperliquidSubscription from './ServiceHyperliquidSubscription';
@@ -114,7 +113,7 @@ describe('ServiceHyperliquidSubscription resume stream liveness', () => {
 
   it('reuses the open socket while the stream is fresh', async () => {
     const { service, internals, force, reconcile } = setupOpenSocketService();
-    internals._lastFrameAt = Date.now() - 1_000;
+    internals._lastFrameAt = Date.now() - 1000;
 
     await service.resumeSubscriptions();
 
@@ -145,10 +144,9 @@ describe('ServiceHyperliquidSubscription resume stream liveness', () => {
           e: CustomEvent,
         ) => Promise<void>;
       }
-    )._handleSubscriptionData(
-      ESubscriptionType.ALL_MIDS,
-      { detail: {} } as unknown as CustomEvent,
-    );
+    )._handleSubscriptionData(ESubscriptionType.ALL_MIDS, {
+      detail: {},
+    } as unknown as CustomEvent);
 
     await service.resumeSubscriptions();
 
@@ -182,7 +180,7 @@ describe('ServiceHyperliquidSubscription resume stream liveness', () => {
   it('trusts a freshly opened socket that has not received messages yet', async () => {
     const { service, internals, force, reconcile } = setupOpenSocketService();
     internals._lastMessageAt = Date.now() - 60_000;
-    internals._socketOpenedAt = Date.now() - 1_000;
+    internals._socketOpenedAt = Date.now() - 1000;
 
     await service.resumeSubscriptions();
 

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -1090,7 +1090,24 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   }
 
   @backgroundMethod()
-  async enableSubscriptionsHandler(): Promise<void> {
+  async getSubscriptionsHandlerDisabledCount(): Promise<number> {
+    return this.subscriptionsHandlerDisabledCount;
+  }
+
+  @backgroundMethod()
+  async enableSubscriptionsHandler(options?: {
+    ifDisabledCountAtMost?: number;
+  }): Promise<void> {
+    // Callers holding a liveness proof pass the disable count they observed
+    // when it was captured; a disable landing after that (blur, lock) bumps
+    // the count and wins over the now-stale proof. The count is monotonic in
+    // this runtime, so no cross-runtime clock comparison is involved.
+    if (
+      options?.ifDisabledCountAtMost !== undefined &&
+      this.subscriptionsHandlerDisabledCount > options.ifDisabledCountAtMost
+    ) {
+      return;
+    }
     this.subscriptionsHandlerDisabled = false;
     if (this.hasNewUserFills) {
       this.hasNewUserFills = false;

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -1090,11 +1090,6 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   }
 
   @backgroundMethod()
-  async getSubscriptionsHandlerDisabledCount(): Promise<number> {
-    return this.subscriptionsHandlerDisabledCount;
-  }
-
-  @backgroundMethod()
   async enableSubscriptionsHandler(options?: {
     ifDisabledCountAtMost?: number;
   }): Promise<void> {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -188,6 +188,14 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   private _lastMessageAt: number | null = null;
 
+  // Raw pipe liveness, unlike _lastMessageAt which freezes while the handler
+  // is disabled (blur mutes processing, not the stream).
+  private _lastFrameAt: number | null = null;
+
+  private _socketOpenedAt: number | null = null;
+
+  private _resumeReconnectPromise: Promise<void> | null = null;
+
   private _postOpenDataCheckTimer: ReturnType<typeof setTimeout> | null = null;
 
   private _postOpenDataCheckRetries = 0;
@@ -714,6 +722,20 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
 
   lastRefreshAllPerpsDataAt: number | null = null;
 
+  // OS suspension can leave the socket half-dead while readyState still says
+  // OPEN; without recent traffic (or a recent open) the pipe cannot be
+  // trusted on resume. No evidence at all keeps the legacy reuse path.
+  private _isResumeStreamStale(): boolean {
+    const lastLifeAt = Math.max(
+      this._lastFrameAt ?? 0,
+      this._socketOpenedAt ?? 0,
+    );
+    if (!lastLifeAt) {
+      return false;
+    }
+    return Date.now() - lastLifeAt > HYPERLIQUID_REFRESH_DATA_FLOW_THRESHOLD_MS;
+  }
+
   private _hasRecentDataFlow(): boolean {
     return (
       this._lastMessageAt !== null &&
@@ -1042,10 +1064,20 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       isOpen: readyState === WebSocket.OPEN,
       isClosedOrClosing:
         readyState === WebSocket.CLOSED || readyState === WebSocket.CLOSING,
+      isStreamStale: this._isResumeStreamStale(),
     });
     if (action === 'reconnect') {
       console.log('resumeSubscriptions__force_reconnect_transport');
-      await this._forceReconnectTransport();
+      // Prewarm and AutoPause both fire resume on foreground; single-flight
+      // so they cannot race two concurrent transport rebuilds.
+      if (!this._resumeReconnectPromise) {
+        this._resumeReconnectPromise = this._forceReconnectTransport().finally(
+          () => {
+            this._resumeReconnectPromise = null;
+          },
+        );
+      }
+      await this._resumeReconnectPromise;
       return;
     }
     if (action === 'waitForOpen') {
@@ -1478,6 +1510,9 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
       const socket = event.target as WebSocket | undefined;
       const readyState = socket?.readyState;
       this._lastReadyState = readyState;
+      // Grace for the stale-stream resume check: a just-opened socket has no
+      // messages yet but must not be judged dead.
+      this._socketOpenedAt = Date.now();
       // OK-53208: SDK transport wrapper reports readyState=undefined in the
       // open event, which keeps perpsWebSocketConnectedAtom false forever.
       await perpsWebSocketReadyStateAtom.set({
@@ -2078,6 +2113,9 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     event: CustomEvent,
   ): Promise<void> {
     try {
+      // Stamp before the disabled early-return: a muted-but-alive stream
+      // must not be judged dead by the resume staleness check.
+      this._lastFrameAt = Date.now();
       const shouldUpdateWsDataUpdateTimes = this._showPerpsRenderStats;
 
       if (shouldUpdateWsDataUpdateTimes) {

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -1125,6 +1125,12 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
     if (this.subscriptionsHandlerDisabled) {
       return false;
     }
+    // AutoPause in the UI runtime still reads a stale blur; announce so it
+    // drops the pending pause timer that would tear this recovery down.
+    appEventBus.emit(EAppEventBusNames.PerpsSubscriptionsRecovered, undefined);
+    // A prior pauseSubscriptions() may have unwatched the atoms; reinstall
+    // before the reconcile (OK-53014 ordering).
+    this._watchSubscriptionAtoms();
     await this.updateSubscriptions();
     return true;
   }

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/ServiceHyperliquidSubscription.ts
@@ -1113,6 +1113,23 @@ export default class ServiceHyperliquidSubscription extends ServiceBase {
   }
 
   @backgroundMethod()
+  async recoverSubscriptionsAfterLivenessProof(params: {
+    disabledCount: number;
+  }): Promise<boolean> {
+    if (this.subscriptionsHandlerDisabledCount > params.disabledCount) {
+      return false;
+    }
+    await this.enableSubscriptionsHandler({
+      ifDisabledCountAtMost: params.disabledCount,
+    });
+    if (this.subscriptionsHandlerDisabled) {
+      return false;
+    }
+    await this.updateSubscriptions();
+    return true;
+  }
+
+  @backgroundMethod()
   async enableLedgerUpdatesSubscription(): Promise<void> {
     this._currentState.enableLedgerUpdates = true;
     await this.updateSubscriptions();

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.test.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.test.ts
@@ -21,6 +21,26 @@ describe('getSubscriptionResumeAction', () => {
     ).toBe('waitForOpen');
   });
 
+  it('reconnects an open transport whose stream has gone stale', () => {
+    expect(
+      getSubscriptionResumeAction({
+        isOpen: true,
+        isClosedOrClosing: false,
+        isStreamStale: true,
+      }),
+    ).toBe('reconnect');
+  });
+
+  it('reconciles an open transport while the stream is fresh', () => {
+    expect(
+      getSubscriptionResumeAction({
+        isOpen: true,
+        isClosedOrClosing: false,
+        isStreamStale: false,
+      }),
+    ).toBe('reconcile');
+  });
+
   it('reconciles open transports and reconnects closed transports', () => {
     expect(
       getSubscriptionResumeAction({

--- a/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
+++ b/packages/kit-bg/src/services/ServiceHyperLiquid/utils/SubscriptionConfig.ts
@@ -167,12 +167,16 @@ export function getOrderBookSubscriptionCoin(
 export function getSubscriptionResumeAction({
   isOpen,
   isClosedOrClosing,
+  isStreamStale,
 }: {
   isOpen: boolean;
   isClosedOrClosing: boolean;
+  isStreamStale?: boolean;
 }): 'reconcile' | 'reconnect' | 'waitForOpen' {
   if (isOpen) {
-    return 'reconcile';
+    // A half-dead socket after app suspension still reports OPEN; only trust
+    // it while the stream has shown recent life.
+    return isStreamStale ? 'reconnect' : 'reconcile';
   }
   return isClosedOrClosing ? 'reconnect' : 'waitForOpen';
 }

--- a/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
+++ b/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { Dialog } from '@onekeyhq/components';
-import { tradingModeAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  appIsLocked,
+  tradingModeAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -157,15 +160,21 @@ function BaseNotificationHandlerContainer() {
           });
           // Start the reconnect now so it overlaps the ~350ms of
           // popToMainRoute + wait, rather than waiting for route focus.
-          void backgroundApiProxy.serviceHyperliquidSubscription
-            .resumeSubscriptions()
-            .catch((error) => {
-              defaultLogger.perp.hyperliquid.coldStartInitializationError({
-                type: 'prewarm_subscriptions',
-                coin: perpToken,
-                error,
+          // Never while locked: resumeSubscriptions enables the handler
+          // unconditionally, and the user has to unlock before anything
+          // renders anyway — unlock recovery resumes on its own.
+          const isAppLocked = await appIsLocked.get();
+          if (!isAppLocked) {
+            void backgroundApiProxy.serviceHyperliquidSubscription
+              .resumeSubscriptions()
+              .catch((error) => {
+                defaultLogger.perp.hyperliquid.coldStartInitializationError({
+                  type: 'prewarm_subscriptions',
+                  coin: perpToken,
+                  error,
+                });
               });
-            });
+          }
         } catch (error) {
           console.error('Failed to change perps active asset:', error);
         }

--- a/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
+++ b/packages/kit/src/provider/Container/NotificationHandlerContainer/index.tsx
@@ -18,12 +18,14 @@ import {
   ETabRoutes,
   type IWebViewPageParams,
 } from '@onekeyhq/shared/src/routes';
+import { getCurrentVisibilityState } from '@onekeyhq/shared/src/utils/appVisibility';
 import {
   type INotificationPageNavigationEvent,
   navigateToNotificationDetailByLocalParams,
   registerNotificationPageNavigationProcessor,
 } from '@onekeyhq/shared/src/utils/notificationsUtils';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import {
   ENotificationViewDialogActionType,
@@ -44,6 +46,7 @@ import {
   NotificationHandlerDiscoveryProvider,
   useNotificationDappNavigation,
 } from './NotificationDappNavigation';
+import { recoverPerpsSubscriptionsAfterNavigation } from './perpsSubscriptionRecovery';
 
 function BaseNotificationHandlerContainer() {
   const { showFallbackUpdateDialog } = useVersionCompatible();
@@ -180,15 +183,30 @@ function BaseNotificationHandlerContainer() {
         }
       }
 
-      navigateToNotificationDetailByLocalParams({
-        payload: payloadObj,
-        localParams,
-        getEarnAccount: (props) =>
-          backgroundApiProxy.serviceStaking.getEarnAccount(props),
-      }).catch((error) => {
+      try {
+        await navigateToNotificationDetailByLocalParams({
+          payload: payloadObj,
+          localParams,
+          getEarnAccount: (props) =>
+            backgroundApiProxy.serviceStaking.getEarnAccount(props),
+        });
+        await timerUtils.wait(0);
+        if (isPerpNavigation) {
+          await recoverPerpsSubscriptionsAfterNavigation({
+            isAppVisible: getCurrentVisibilityState,
+            isAppLocked: () => appIsLocked.get(),
+            readDisabledCount: () =>
+              backgroundApiProxy.serviceHyperliquidSubscription.getSubscriptionsHandlerDisabledCount(),
+            recover: (disabledCount) =>
+              backgroundApiProxy.serviceHyperliquidSubscription.recoverSubscriptionsAfterLivenessProof(
+                { disabledCount },
+              ),
+          });
+        }
+      } catch (error) {
         console.error(error);
         showFallbackUpdateDialog(null);
-      });
+      }
     };
     const handleShowNotificationInWebViewOverlay = (
       params: IWebViewPageParams,

--- a/packages/kit/src/provider/Container/NotificationHandlerContainer/perpsSubscriptionRecovery.test.ts
+++ b/packages/kit/src/provider/Container/NotificationHandlerContainer/perpsSubscriptionRecovery.test.ts
@@ -1,0 +1,70 @@
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
+import { recoverPerpsSubscriptionsAfterNavigation } from './perpsSubscriptionRecovery';
+
+describe('recoverPerpsSubscriptionsAfterNavigation', () => {
+  it('reads the generation after navigation and recovers while visible', async () => {
+    const calls: string[] = [];
+
+    await expect(
+      recoverPerpsSubscriptionsAfterNavigation({
+        isAppVisible: () => true,
+        isAppLocked: async () => false,
+        readDisabledCount: async () => {
+          calls.push('read');
+          return 7;
+        },
+        recover: async (disabledCount) => {
+          calls.push(`recover:${disabledCount}`);
+          return true;
+        },
+      }),
+    ).resolves.toBe(true);
+    expect(calls).toEqual(['read', 'recover:7']);
+  });
+
+  it('does not recover after the app becomes hidden', async () => {
+    let visible = true;
+    const recover = jest.fn<Promise<boolean>, [number]>();
+
+    await expect(
+      recoverPerpsSubscriptionsAfterNavigation({
+        isAppVisible: () => visible,
+        isAppLocked: async () => false,
+        readDisabledCount: async () => {
+          visible = false;
+          return 7;
+        },
+        recover,
+      }),
+    ).resolves.toBe(false);
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it('does not read the generation while the app is locked', async () => {
+    const readDisabledCount = jest.fn<Promise<number>, []>();
+
+    await expect(
+      recoverPerpsSubscriptionsAfterNavigation({
+        isAppVisible: () => true,
+        isAppLocked: async () => true,
+        readDisabledCount,
+        recover: async () => true,
+      }),
+    ).resolves.toBe(false);
+    expect(readDisabledCount).not.toHaveBeenCalled();
+  });
+
+  it('falls back safely when the bg bridge rejects', async () => {
+    await expect(
+      recoverPerpsSubscriptionsAfterNavigation({
+        isAppVisible: () => true,
+        isAppLocked: async () => false,
+        readDisabledCount: async () => {
+          throw new OneKeyLocalError('bridge unavailable');
+        },
+        recover: async () => true,
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/kit/src/provider/Container/NotificationHandlerContainer/perpsSubscriptionRecovery.ts
+++ b/packages/kit/src/provider/Container/NotificationHandlerContainer/perpsSubscriptionRecovery.ts
@@ -1,0 +1,21 @@
+export async function recoverPerpsSubscriptionsAfterNavigation(params: {
+  isAppVisible: () => boolean;
+  isAppLocked: () => Promise<boolean>;
+  readDisabledCount: () => Promise<number>;
+  recover: (disabledCount: number) => Promise<boolean>;
+}): Promise<boolean> {
+  try {
+    if (!params.isAppVisible() || (await params.isAppLocked())) {
+      return false;
+    }
+
+    const disabledCount = await params.readDisabledCount();
+    if (!params.isAppVisible() || (await params.isAppLocked())) {
+      return false;
+    }
+
+    return params.recover(disabledCount);
+  } catch {
+    return false;
+  }
+}

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -551,6 +551,12 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       return;
     }
 
+    // Reaching here proves the Perp UI is live (route focused, token selector
+    // open, or favorites bar active), so a disabled handler can only be a
+    // stale blur verdict — without this the reconcile below is silently
+    // skipped and the book starves until the next focus event.
+    await backgroundApiProxy.serviceHyperliquidSubscription.enableSubscriptionsHandler();
+
     try {
       await backgroundApiProxy.serviceHyperliquidSubscription.updateSubscriptions();
     } catch (error) {

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -126,6 +126,7 @@ import {
 import {
   captureSubscriptionRecoveryProof,
   publishLatestOrderBookOptions,
+  recoverSubscriptionsWithProof,
   shouldSyncSubscriptionsAfterInstrumentChange,
 } from './utils/instrumentSwitch';
 import {
@@ -1642,6 +1643,15 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
           ) {
             set(activeTradeInstrumentAtom(), next);
           }
+          // This branch skips syncSubscriptionsAfterInstrumentChange, so
+          // consume the proof here or the stale disable survives.
+          await recoverSubscriptionsWithProof({
+            recoveryProof: subscriptionRecoveryProof,
+            recover: (disabledCount) =>
+              backgroundApiProxy.serviceHyperliquidSubscription.recoverSubscriptionsAfterLivenessProof(
+                { disabledCount },
+              ),
+          });
           return true;
         }
       }
@@ -1764,6 +1774,15 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
           ) {
             set(activeTradeInstrumentAtom(), next);
           }
+          // This branch skips syncSubscriptionsAfterInstrumentChange, so
+          // consume the proof here or the stale disable survives.
+          await recoverSubscriptionsWithProof({
+            recoveryProof: subscriptionRecoveryProof,
+            recover: (disabledCount) =>
+              backgroundApiProxy.serviceHyperliquidSubscription.recoverSubscriptionsAfterLivenessProof(
+                { disabledCount },
+              ),
+          });
           return true;
         }
       }

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -9,6 +9,7 @@ import type { IAppNavigation } from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { ContextJotaiActionsBase } from '@onekeyhq/kit/src/states/jotai/utils/ContextJotaiActionsBase';
 import { showEnableTradingDialog } from '@onekeyhq/kit/src/views/Perp/components/TradingPanel/modals/EnableTradingModal';
 import {
+  appIsLocked,
   perpsActiveAccountAtom,
   perpsActiveAccountIsAgentReadyAtom,
   perpsActiveAssetAtom,
@@ -521,6 +522,11 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     if (!this.isLatestActiveInstrumentChange(params.requestId)) {
       return;
     }
+    // Captured before the publish awaits: any disable (blur, lock) landing
+    // after this bumps the count and outranks the liveness proof carried by
+    // params.viewState.
+    const disabledCountAtProof =
+      await backgroundApiProxy.serviceHyperliquidSubscription.getSubscriptionsHandlerDisabledCount();
 
     // Unconditional: the BG reconcile aborts every channel while this atom
     // still names the previous coin, so gating the publish on route focus
@@ -554,8 +560,15 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     // Reaching here proves the Perp UI is live (route focused, token selector
     // open, or favorites bar active), so a disabled handler can only be a
     // stale blur verdict — without this the reconcile below is silently
-    // skipped and the book starves until the next focus event.
-    await backgroundApiProxy.serviceHyperliquidSubscription.enableSubscriptionsHandler();
+    // skipped and the book starves until the next focus event. App lock is
+    // the one state these signals cannot see (the navigation tree is retained
+    // under the lock screen), so it is checked explicitly.
+    const isAppLocked = await appIsLocked.get();
+    if (!isAppLocked) {
+      await backgroundApiProxy.serviceHyperliquidSubscription.enableSubscriptionsHandler(
+        { ifDisabledCountAtMost: disabledCountAtProof },
+      );
+    }
 
     try {
       await backgroundApiProxy.serviceHyperliquidSubscription.updateSubscriptions();

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -560,12 +560,17 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
 
     try {
       if (params.subscriptionRecoveryProof) {
-        await backgroundApiProxy.serviceHyperliquidSubscription.recoverSubscriptionsAfterLivenessProof(
-          {
-            disabledCount: params.subscriptionRecoveryProof.disabledCount,
-          },
-        );
-        return;
+        const recovered =
+          await backgroundApiProxy.serviceHyperliquidSubscription.recoverSubscriptionsAfterLivenessProof(
+            {
+              disabledCount: params.subscriptionRecoveryProof.disabledCount,
+            },
+          );
+        if (recovered) {
+          return;
+        }
+        // A rejected proof only means it went stale; the handler may have
+        // been re-enabled meanwhile, so fall back to the normal reconcile.
       }
       await backgroundApiProxy.serviceHyperliquidSubscription.updateSubscriptions();
     } catch (error) {

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -45,6 +45,7 @@ import {
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
+import { getCurrentVisibilityState } from '@onekeyhq/shared/src/utils/appVisibility';
 import { memoFn } from '@onekeyhq/shared/src/utils/cacheUtils';
 import {
   SCALE_ORDER_MIN_NOTIONAL,
@@ -122,7 +123,11 @@ import {
   shouldResetOpenOrdersForAccount,
   sortActivePerpsPositions,
 } from './utils/coldStartMergeUtils';
-import { publishLatestOrderBookOptions } from './utils/instrumentSwitch';
+import {
+  captureSubscriptionRecoveryProof,
+  publishLatestOrderBookOptions,
+  shouldSyncSubscriptionsAfterInstrumentChange,
+} from './utils/instrumentSwitch';
 import {
   shouldClearPerpsMarketDataForInstrument,
   shouldUpdatePerpsBbo,
@@ -140,6 +145,10 @@ import type {
   ITradeRouteViewState,
   ITradingFormData,
 } from './atoms';
+import type {
+  ISubscriptionRecoveryProof,
+  ISubscriptionRecoveryProofSource,
+} from './utils/instrumentSwitch';
 
 type IChStateLite = {
   assetPositions?: HL.IPerpsAssetPosition[];
@@ -503,36 +512,15 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     return this.isLatestActiveInstrumentChange(requestId);
   }
 
-  private shouldSyncSubscriptionsAfterInstrumentChange(
-    viewState: ITradeRouteViewState,
-  ): boolean {
-    return (
-      viewState.routeFocused ||
-      viewState.tokenSelectorOpen ||
-      viewState.favoritesBarSpotActive
-    );
-  }
-
   private async syncSubscriptionsAfterInstrumentChange(params: {
     instrument: IActiveTradeInstrument;
     orderBookTickOptions: Record<string, IPerpOrderBookTickOptionPersist>;
     requestId: number;
     viewState: ITradeRouteViewState;
+    subscriptionRecoveryProof?: ISubscriptionRecoveryProof;
   }): Promise<void> {
     if (!this.isLatestActiveInstrumentChange(params.requestId)) {
       return;
-    }
-    // Captured before the publish awaits: any disable (blur, lock) landing
-    // after this bumps the count and outranks the liveness proof carried by
-    // params.viewState. Callers fire-and-forget this method, so a bridge
-    // failure must not escape; without a trustworthy epoch the re-enable is
-    // simply skipped — pre-fix behavior, recovered by the next focus event.
-    let disabledCountAtProof: number | undefined;
-    try {
-      disabledCountAtProof =
-        await backgroundApiProxy.serviceHyperliquidSubscription.getSubscriptionsHandlerDisabledCount();
-    } catch {
-      // keep the epoch undefined; the enable below stays skipped
     }
 
     // Unconditional: the BG reconcile aborts every channel while this atom
@@ -560,26 +548,23 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     // Best-effort saving only: extension and native reconcile off the atom
     // watcher regardless. Desktop and web have no watcher, so this is their
     // only gate.
-    if (!this.shouldSyncSubscriptionsAfterInstrumentChange(params.viewState)) {
+    if (
+      !shouldSyncSubscriptionsAfterInstrumentChange({
+        viewState: params.viewState,
+        recoveryProof: params.subscriptionRecoveryProof,
+      })
+    ) {
       return;
     }
 
     try {
-      // A disabled handler here can only be a stale blur verdict — without
-      // the re-enable the reconcile below is silently skipped and the book
-      // starves until the next focus event. Only route focus and an open
-      // token selector prove the UI is on screen: the web favorites bar
-      // keeps its flag true while unfocused, so it gates the reconcile but
-      // must not clear a blur/lock disable. Lock is checked explicitly (the
-      // navigation tree is retained under the lock screen).
-      if (
-        disabledCountAtProof !== undefined &&
-        (params.viewState.routeFocused || params.viewState.tokenSelectorOpen) &&
-        !(await appIsLocked.get())
-      ) {
-        await backgroundApiProxy.serviceHyperliquidSubscription.enableSubscriptionsHandler(
-          { ifDisabledCountAtMost: disabledCountAtProof },
+      if (params.subscriptionRecoveryProof) {
+        await backgroundApiProxy.serviceHyperliquidSubscription.recoverSubscriptionsAfterLivenessProof(
+          {
+            disabledCount: params.subscriptionRecoveryProof.disabledCount,
+          },
         );
+        return;
       }
       await backgroundApiProxy.serviceHyperliquidSubscription.updateSubscriptions();
     } catch (error) {
@@ -1587,7 +1572,13 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         coin,
         force,
         requestId: existingRequestId,
-      }: { coin: string; force?: boolean; requestId?: number },
+        subscriptionRecoveryProof,
+      }: {
+        coin: string;
+        force?: boolean;
+        requestId?: number;
+        subscriptionRecoveryProof?: ISubscriptionRecoveryProof;
+      },
     ) => {
       const requestId = existingRequestId ?? this.beginActiveInstrumentChange();
       const optimisticInstrument: IActiveTradeInstrument = {
@@ -1712,6 +1703,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         orderBookTickOptions: get(orderBookTickOptionsAtom()),
         requestId,
         viewState: get(tradeRouteViewStateAtom()),
+        subscriptionRecoveryProof,
       });
       hydrateL2BookFromSwr(nextInstrument.coin);
       return true;
@@ -1727,11 +1719,13 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         spotUniverse,
         force,
         requestId: existingRequestId,
+        subscriptionRecoveryProof,
       }: {
         coin: string;
         spotUniverse: ISpotUniverse | undefined;
         force?: boolean;
         requestId?: number;
+        subscriptionRecoveryProof?: ISubscriptionRecoveryProof;
       },
     ) => {
       const requestId = existingRequestId ?? this.beginActiveInstrumentChange();
@@ -1800,6 +1794,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         orderBookTickOptions: get(orderBookTickOptionsAtom()),
         requestId,
         viewState: get(tradeRouteViewStateAtom()),
+        subscriptionRecoveryProof,
       });
       await this.clearActiveAssetData.call(set);
       if (!this.isLatestActiveInstrumentChange(requestId)) {
@@ -1880,6 +1875,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         coin: string;
         force?: boolean;
         spotUniverse?: ISpotUniverse;
+        subscriptionRecoveryProof?: ISubscriptionRecoveryProof;
       },
     ) => {
       markPerpsColdStartPerf('action_switch_trade_instrument_start', {
@@ -1903,6 +1899,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
           spotUniverse,
           force: params.force,
           requestId,
+          subscriptionRecoveryProof: params.subscriptionRecoveryProof,
         });
         markPerpsColdStartPerf('action_switch_trade_instrument_end', {
           mode: params.mode,
@@ -1916,6 +1913,7 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
         coin: params.coin,
         force: params.force,
         requestId,
+        subscriptionRecoveryProof: params.subscriptionRecoveryProof,
       });
       markPerpsColdStartPerf('action_switch_trade_instrument_end', {
         mode: params.mode,
@@ -1924,6 +1922,32 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       });
       return result;
     },
+  );
+
+  captureInstrumentSwitchSubscriptionProof = contextAtomMethod(
+    (
+      get,
+      _set,
+      params: {
+        source: Extract<
+          ISubscriptionRecoveryProofSource,
+          'route-focused' | 'token-selector'
+        >;
+      },
+    ) =>
+      captureSubscriptionRecoveryProof({
+        source: params.source,
+        isSourceLive: () => {
+          const state = get(tradeRouteViewStateAtom());
+          return params.source === 'token-selector'
+            ? state.tokenSelectorOpen
+            : state.routeFocused;
+        },
+        isAppVisible: getCurrentVisibilityState,
+        isAppLocked: () => appIsLocked.get(),
+        readDisabledCount: () =>
+          backgroundApiProxy.serviceHyperliquidSubscription.getSubscriptionsHandlerDisabledCount(),
+      }),
   );
 
   setTradeRouteViewState = contextAtomMethod(
@@ -3732,6 +3756,8 @@ export function useHyperliquidActions() {
   const changeActiveAsset = actions.changeActiveAsset.use();
   const changeActiveSpotAsset = actions.changeActiveSpotAsset.use();
   const switchTradeInstrument = actions.switchTradeInstrument.use();
+  const captureInstrumentSwitchSubscriptionProof =
+    actions.captureInstrumentSwitchSubscriptionProof.use();
   const setTradeRouteViewState = actions.setTradeRouteViewState.use();
   const changeActivePerpsAccount = actions.changeActivePerpsAccount.use();
   const updateAllAssetsFiltered = actions.updateAllAssetsFiltered.use();
@@ -3806,6 +3832,7 @@ export function useHyperliquidActions() {
     getTokenSzDecimals,
     getMidPrice,
     switchTradeInstrument,
+    captureInstrumentSwitchSubscriptionProof,
     setTradeRouteViewState,
     updateTwapStates,
     updateTwapHistory,

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -524,9 +524,16 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
     }
     // Captured before the publish awaits: any disable (blur, lock) landing
     // after this bumps the count and outranks the liveness proof carried by
-    // params.viewState.
-    const disabledCountAtProof =
-      await backgroundApiProxy.serviceHyperliquidSubscription.getSubscriptionsHandlerDisabledCount();
+    // params.viewState. Callers fire-and-forget this method, so a bridge
+    // failure must not escape; without a trustworthy epoch the re-enable is
+    // simply skipped — pre-fix behavior, recovered by the next focus event.
+    let disabledCountAtProof: number | undefined;
+    try {
+      disabledCountAtProof =
+        await backgroundApiProxy.serviceHyperliquidSubscription.getSubscriptionsHandlerDisabledCount();
+    } catch {
+      // keep the epoch undefined; the enable below stays skipped
+    }
 
     // Unconditional: the BG reconcile aborts every channel while this atom
     // still names the previous coin, so gating the publish on route focus
@@ -557,20 +564,23 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       return;
     }
 
-    // Reaching here proves the Perp UI is live (route focused, token selector
-    // open, or favorites bar active), so a disabled handler can only be a
-    // stale blur verdict — without this the reconcile below is silently
-    // skipped and the book starves until the next focus event. App lock is
-    // the one state these signals cannot see (the navigation tree is retained
-    // under the lock screen), so it is checked explicitly.
-    const isAppLocked = await appIsLocked.get();
-    if (!isAppLocked) {
-      await backgroundApiProxy.serviceHyperliquidSubscription.enableSubscriptionsHandler(
-        { ifDisabledCountAtMost: disabledCountAtProof },
-      );
-    }
-
     try {
+      // A disabled handler here can only be a stale blur verdict — without
+      // the re-enable the reconcile below is silently skipped and the book
+      // starves until the next focus event. Only route focus and an open
+      // token selector prove the UI is on screen: the web favorites bar
+      // keeps its flag true while unfocused, so it gates the reconcile but
+      // must not clear a blur/lock disable. Lock is checked explicitly (the
+      // navigation tree is retained under the lock screen).
+      if (
+        disabledCountAtProof !== undefined &&
+        (params.viewState.routeFocused || params.viewState.tokenSelectorOpen) &&
+        !(await appIsLocked.get())
+      ) {
+        await backgroundApiProxy.serviceHyperliquidSubscription.enableSubscriptionsHandler(
+          { ifDisabledCountAtMost: disabledCountAtProof },
+        );
+      }
       await backgroundApiProxy.serviceHyperliquidSubscription.updateSubscriptions();
     } catch (error) {
       console.error(

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/utils/instrumentSwitch.test.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/utils/instrumentSwitch.test.ts
@@ -1,4 +1,73 @@
-import { publishLatestOrderBookOptions } from './instrumentSwitch';
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
+import {
+  captureSubscriptionRecoveryProof,
+  publishLatestOrderBookOptions,
+  shouldSyncSubscriptionsAfterInstrumentChange,
+} from './instrumentSwitch';
+
+describe('captureSubscriptionRecoveryProof', () => {
+  it('captures the bg generation while the UI source stays live', async () => {
+    await expect(
+      captureSubscriptionRecoveryProof({
+        source: 'token-selector',
+        isSourceLive: () => true,
+        isAppVisible: () => true,
+        isAppLocked: async () => false,
+        readDisabledCount: async () => 4,
+      }),
+    ).resolves.toEqual({
+      disabledCount: 4,
+      source: 'token-selector',
+    });
+  });
+
+  it('drops the proof when the UI source disappears during the bridge read', async () => {
+    let live = true;
+
+    await expect(
+      captureSubscriptionRecoveryProof({
+        source: 'token-selector',
+        isSourceLive: () => live,
+        isAppVisible: () => true,
+        isAppLocked: async () => false,
+        readDisabledCount: async () => {
+          live = false;
+          return 4;
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ['hidden', false, false],
+    ['locked', true, true],
+  ])('drops the proof when the app is %s', async (_name, visible, locked) => {
+    await expect(
+      captureSubscriptionRecoveryProof({
+        source: 'token-selector',
+        isSourceLive: () => true,
+        isAppVisible: () => visible,
+        isAppLocked: async () => locked,
+        readDisabledCount: async () => 4,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('falls back safely when the bg generation read rejects', async () => {
+    await expect(
+      captureSubscriptionRecoveryProof({
+        source: 'token-selector',
+        isSourceLive: () => true,
+        isAppVisible: () => true,
+        isAppLocked: async () => false,
+        readDisabledCount: async () => {
+          throw new OneKeyLocalError('bridge unavailable');
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
 
 describe('publishLatestOrderBookOptions', () => {
   it('does not publish stale options after a newer instrument switch starts', async () => {
@@ -82,5 +151,25 @@ describe('publishLatestOrderBookOptions', () => {
     await expect(first).resolves.toBe(false);
     await expect(latest).resolves.toBe(true);
     expect(committed).toEqual({ coin: '@108' });
+  });
+});
+
+describe('shouldSyncSubscriptionsAfterInstrumentChange', () => {
+  it('keeps a token-selector proof valid after the selector closes', () => {
+    expect(
+      shouldSyncSubscriptionsAfterInstrumentChange({
+        viewState: {
+          routeFocused: false,
+          tokenSelectorOpen: false,
+          tokenSelectorTab: 'perps',
+          infoPanelTab: 'Positions',
+          favoritesBarSpotActive: false,
+        },
+        recoveryProof: {
+          disabledCount: 3,
+          source: 'token-selector',
+        },
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/utils/instrumentSwitch.test.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/utils/instrumentSwitch.test.ts
@@ -3,8 +3,48 @@ import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import {
   captureSubscriptionRecoveryProof,
   publishLatestOrderBookOptions,
+  recoverSubscriptionsWithProof,
   shouldSyncSubscriptionsAfterInstrumentChange,
 } from './instrumentSwitch';
+
+describe('recoverSubscriptionsWithProof', () => {
+  it('does not call recover when no proof is present', async () => {
+    const recover = jest.fn<Promise<boolean>, [number]>();
+
+    await expect(
+      recoverSubscriptionsWithProof({
+        recoveryProof: undefined,
+        recover,
+      }),
+    ).resolves.toBe(false);
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it('forwards the proof generation to recover and returns its result', async () => {
+    const recover = jest
+      .fn<Promise<boolean>, [number]>()
+      .mockResolvedValue(true);
+
+    await expect(
+      recoverSubscriptionsWithProof({
+        recoveryProof: { disabledCount: 6, source: 'token-selector' },
+        recover,
+      }),
+    ).resolves.toBe(true);
+    expect(recover).toHaveBeenCalledWith(6);
+  });
+
+  it('falls back safely when recover rejects', async () => {
+    await expect(
+      recoverSubscriptionsWithProof({
+        recoveryProof: { disabledCount: 6, source: 'token-selector' },
+        recover: async () => {
+          throw new OneKeyLocalError('bridge unavailable');
+        },
+      }),
+    ).resolves.toBe(false);
+  });
+});
 
 describe('captureSubscriptionRecoveryProof', () => {
   it('captures the bg generation while the UI source stays live', async () => {

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/utils/instrumentSwitch.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/utils/instrumentSwitch.ts
@@ -1,6 +1,68 @@
 import { isEqual } from 'lodash';
 
+import type { ITradeRouteViewState } from '../atoms';
+
 let orderBookOptionsWriteQueue = Promise.resolve();
+
+export type ISubscriptionRecoveryProofSource =
+  | 'route-focused'
+  | 'token-selector'
+  | 'notification-navigation';
+
+export interface ISubscriptionRecoveryProof {
+  disabledCount: number;
+  source: ISubscriptionRecoveryProofSource;
+}
+
+interface ICaptureSubscriptionRecoveryProofParams {
+  source: ISubscriptionRecoveryProofSource;
+  isSourceLive: () => boolean;
+  isAppVisible: () => boolean;
+  isAppLocked: () => Promise<boolean>;
+  readDisabledCount: () => Promise<number>;
+}
+
+export async function captureSubscriptionRecoveryProof(
+  params: ICaptureSubscriptionRecoveryProofParams,
+): Promise<ISubscriptionRecoveryProof | undefined> {
+  try {
+    if (
+      !params.isSourceLive() ||
+      !params.isAppVisible() ||
+      (await params.isAppLocked())
+    ) {
+      return undefined;
+    }
+
+    const disabledCount = await params.readDisabledCount();
+    if (
+      !params.isSourceLive() ||
+      !params.isAppVisible() ||
+      (await params.isAppLocked())
+    ) {
+      return undefined;
+    }
+
+    return {
+      disabledCount,
+      source: params.source,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export function shouldSyncSubscriptionsAfterInstrumentChange(params: {
+  viewState: ITradeRouteViewState;
+  recoveryProof?: ISubscriptionRecoveryProof;
+}): boolean {
+  return Boolean(
+    params.recoveryProof ||
+    params.viewState.routeFocused ||
+    params.viewState.tokenSelectorOpen ||
+    params.viewState.favoritesBarSpotActive,
+  );
+}
 
 export function publishLatestOrderBookOptions<T>(params: {
   read: () => Promise<T | undefined>;

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/utils/instrumentSwitch.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/utils/instrumentSwitch.ts
@@ -64,6 +64,21 @@ export function shouldSyncSubscriptionsAfterInstrumentChange(params: {
   );
 }
 
+export async function recoverSubscriptionsWithProof(params: {
+  recoveryProof: ISubscriptionRecoveryProof | undefined;
+  recover: (disabledCount: number) => Promise<boolean>;
+}): Promise<boolean> {
+  if (!params.recoveryProof) {
+    return false;
+  }
+  try {
+    return await params.recover(params.recoveryProof.disabledCount);
+  } catch {
+    // A dropped recovery is safe: the next real switch captures a fresh proof.
+    return false;
+  }
+}
+
 export function publishLatestOrderBookOptions<T>(params: {
   read: () => Promise<T | undefined>;
   write: (value: T) => Promise<void>;

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -1305,6 +1305,8 @@ function AutoPauseSubscriptions() {
   // handled by useHandleAppStateActive.
 
   const [isLocked] = useAppIsLockedAtom();
+  const isLockedRef = useRef(isLocked);
+  isLockedRef.current = isLocked;
 
   useEffect(() => {
     if (isLocked) {
@@ -1320,6 +1322,11 @@ function AutoPauseSubscriptions() {
     // Drop the pending pause timer so it cannot tear the recovery down, and
     // update the dedup state so the next real blur/lock disable gets through.
     const handleRecovered = () => {
+      // The announce and the lock disable cross the bridge unordered; a lock
+      // already in effect outranks it, so keep its freshly armed pause timer.
+      if (isLockedRef.current) {
+        return;
+      }
       clearTimeout(pauseSubscriptionsTimerRef.current);
       lastFocusStateRef.current = true;
       if (!isFocusedRef.current) {

--- a/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
+++ b/packages/kit/src/views/Perp/components/PerpsGlobalEffects.tsx
@@ -1270,17 +1270,21 @@ function AutoPauseSubscriptions() {
   );
 
   const isFocusedRef = useRef(shouldTreatPerpAsFocusedOnMount);
+  // BG confirmed a liveness recovery while the focus derivation still read
+  // blurred; unlock/app-resume then treat Perp as focused until a real edge.
+  const recoveredWhileBlurredRef = useRef(false);
   useListenTabFocusState(ETabRoutes.Perp, (isFocus: boolean) => {
     const nextFocused = resolvePerpRouteFocused(isFocus);
     const isFocusPrev = isFocusedRef.current;
     isFocusedRef.current = nextFocused;
     if (isFocusPrev !== nextFocused) {
+      recoveredWhileBlurredRef.current = false;
       void onFocusHandler({ isFocus: isFocusedRef.current });
     }
   });
 
   const handleAppActiveFromBackground = useCallback(() => {
-    if (isFocusedRef.current) {
+    if (isFocusedRef.current || recoveredWhileBlurredRef.current) {
       // Native doesn't set lastFocusStateRef to false on background,
       // so reset it here to prevent dedup guard from blocking resume
       lastFocusStateRef.current = false;
@@ -1306,9 +1310,33 @@ function AutoPauseSubscriptions() {
     if (isLocked) {
       void onFocusHandler({ isFocus: false });
     } else {
-      void onFocusHandler({ isFocus: isFocusedRef.current });
+      void onFocusHandler({
+        isFocus: isFocusedRef.current || recoveredWhileBlurredRef.current,
+      });
     }
   }, [isLocked, onFocusHandler]);
+
+  useEffect(() => {
+    // Drop the pending pause timer so it cannot tear the recovery down, and
+    // update the dedup state so the next real blur/lock disable gets through.
+    const handleRecovered = () => {
+      clearTimeout(pauseSubscriptionsTimerRef.current);
+      lastFocusStateRef.current = true;
+      if (!isFocusedRef.current) {
+        recoveredWhileBlurredRef.current = true;
+      }
+    };
+    appEventBus.on(
+      EAppEventBusNames.PerpsSubscriptionsRecovered,
+      handleRecovered,
+    );
+    return () => {
+      appEventBus.off(
+        EAppEventBusNames.PerpsSubscriptionsRecovered,
+        handleRecovered,
+      );
+    };
+  }, []);
 
   useEffect(() => {
     return () => {

--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -381,6 +381,10 @@ function MobileTokenSelectorModal({
       const isSpotToken = isSpotInstrument(symbol);
       try {
         onLoadingChange(true);
+        const subscriptionRecoveryProof =
+          await actions.current.captureInstrumentSwitchSubscriptionProof({
+            source: 'token-selector',
+          });
         navigation.popStack();
         if (isSpotToken) {
           const universe = spotUniverses.find((u) => u.name === symbol);
@@ -390,11 +394,13 @@ function MobileTokenSelectorModal({
             mode: 'spot',
             coin: symbol,
             spotUniverse: universe,
+            subscriptionRecoveryProof,
           });
         } else {
           await actions.current.switchTradeInstrument({
             mode: 'perp',
             coin: symbol,
+            subscriptionRecoveryProof,
           });
         }
       } catch (error) {

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -517,6 +517,7 @@ export interface IAppEventBusPayload {
     data: unknown;
   };
   [EAppEventBusNames.PerpsWebSocketRecovered]: undefined;
+  [EAppEventBusNames.PerpsSubscriptionsRecovered]: undefined;
   [EAppEventBusNames.PerpSwitchActiveInstrument]: {
     mode: 'perp' | 'spot';
     coin: string;

--- a/packages/shared/src/eventBus/appEventBusNames.ts
+++ b/packages/shared/src/eventBus/appEventBusNames.ts
@@ -158,6 +158,7 @@ export enum EAppEventBusNames {
   HyperliquidDataUpdate = 'HyperliquidDataUpdate',
   HyperliquidConnectionChange = 'HyperliquidConnectionChange',
   PerpsWebSocketRecovered = 'PerpsWebSocketRecovered',
+  PerpsSubscriptionsRecovered = 'PerpsSubscriptionsRecovered',
   PerpSwitchActiveInstrument = 'PerpSwitchActiveInstrument',
   PerpSwitchInfoPanelTab = 'PerpSwitchInfoPanelTab',
   BtcFreshAddressUpdated = 'BtcFreshAddressUpdated',


### PR DESCRIPTION
## Summary

QA (Redmi, Android, this hot-update bundle): after entering Perps from a notification and then switching coins, the order book flapped between `--` and values for ~20 seconds. Reported as *"订单簿快速闪烁 - 和数值，太快了，一直闪"*.

One line of change: when the instrument-switch sync gate passes, re-enable the background subscriptions handler before reconciling.

## Root cause, from the QA log (2026-07-28, flicker window 15:14:14–15:14:38)

Four layers, each with direct log evidence:

**1. What painted `--`↔values:** the UI alternated cache reads between two precisions for the same coin — `nSigFigs=None → hit` on an aging in-memory snapshot (ageMs grew 45s → 65s, never refreshed) and `nSigFigs=4 → miss` on every storage layer. The render gate flips `visibleL2Book` between that stale book and `null` accordingly.

**2. Why precision 4 never had data:** the background subscriptions handler was disabled. Every `service_update_subscriptions_start` in the window is immediately followed by `service_update_subscriptions_skipped_disabled`. No live L2 flowed at all.

**3. Why it stayed disabled:** re-enabling only happens on a `route_focused` event, and the parsed navigation state produced **no events at all** between 15:14:01 and 15:14:37 — frozen at "non-Perp tab + modal open".

**4. The decisive part — that parsed state contradicts reality.** While the parse claimed the Perp tab was blurred and covered, the same log shows the Perp order book UI issuing ~20 cache reads/sec for 24 seconds and rendering ticker updates — and QA was watching the book flicker. On Android `freezeOnBlur` is on: a genuinely blurred tab is frozen and cannot run effects. So `routeFocused=false` was a **stale verdict**, not a fact. The disable keyed off it; nothing contradicted it until route events resumed at 15:14:37 (which is exactly when the flicker stopped).

The trigger of the stale parse itself is not recoverable from these logs (they do not record raw `rootState`); it correlates with notification-entry navigation (`popToMainRoute` + `pop: true` reset). Neither of us could reproduce it organically — normal tab switches, coin switches and modal open/close all produce correct focus transitions on a real device (verified with a temporary probe).

## Why this fix does not need the trigger

At 15:14:10 the user picked a coin in the token selector. That switch reached `syncSubscriptionsAfterInstrumentChange`, and the gate passed — `tokenSelectorOpen` is maintained by the selector component itself, not by the navigation parse, so it stays truthful when the parse goes stale. The reconcile was then dropped by the disabled flag alone.

The gate passing **is** a liveness proof: route focused, token selector open, or favorites bar active — every one of them means the Perp UI is on screen. A disabled handler at that point can only be the stale verdict. So: enable it right there.

```ts
if (!this.shouldSyncSubscriptionsAfterInstrumentChange(params.viewState)) {
  return;
}
await backgroundApiProxy.serviceHyperliquidSubscription.enableSubscriptionsHandler();
```

With this in place, QA's own coin switch at 15:14:10 would have re-enabled the handler and the reconcile at 15:14:12 would have rebuilt the subscriptions — the 24-second starvation window never forms.

## Scope and risk

- `enableSubscriptionsHandler()` sets a flag (plus flushing a pending fills-refresh hook). No teardown, no resubscribe of its own, idempotent. In the normal case the handler is already enabled and this is a no-op.
- The call sits on a path that already invokes `updateSubscriptions()` — no new call frequency.
- Known edge: a background-driven instrument switch while the token selector is open during app lock could re-enable subscriptions under the lock screen. The pre-existing `routeFocused` arm of the same gate already had this exposure; the pause timer semantics are unchanged.

## Stacked on #12649

This branch is based on `fix/perps-notification-orderbook` because both edit the same hunk of `syncSubscriptionsAfterInstrumentChange`. GitHub will retarget this PR to `release/v6.5.0` automatically when #12649 merges. The test bundle built from this branch therefore contains both fixes — which matches how they will ship.

## Verification

- Root-cause chain is deterministic from the QA log (the gate passed; the only blocker was the flag; the fix removes the blocker on a liveness-proven path).
- 65 suites / 526 tests across `ServiceHyperLiquid|hyperliquid|Perp|perps` pass; type check clean (the pre-existing `TS2688 'web'` workspace error only).
- Not verified on device: the original stale-parse trigger is not organically reproducible (probe-verified that normal navigation produces correct transitions), so the broken state itself could not be entered. A forced-state device experiment was set up but abandoned to keep scope tight.

## Deliberately not in this PR

- `useListenTabFocusState`'s `routes[0].name` fallback is Home-biased and the likely shape of the stale parse — but it feeds every tab listener in the app (Swap, Home, shortcuts, search), so hardening it is a follow-up on `x`, not a hot-update change.
- The render gate (`hasInitializedTickOption` → `visibleL2Book = null`) that turns missing tick options into a full-book `--` — amplification, not cause.
