### PR TITLE
[OK-58614][OK-58443] Fix Swap recipient entry and token search

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts
@@ -2,10 +2,122 @@ import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 
 import {
   getSwapAddressAccountSelectorNum,
+  getSwapRecipientActionState,
+  getSwapRecipientValidationAccountId,
   shouldResetSwapRecipientOnAccountNetworkSync,
   shouldShowSwapRecipientAddressInfo,
   shouldUseSwapCustomRecipientAddress,
 } from './useSwapAccount.utils';
+
+describe('getSwapRecipientActionState', () => {
+  const validState = {
+    isActionDisabled: false,
+    isRefreshAction: false,
+    noConnectWallet: false,
+    hasQuoteToAmount: true,
+    recipientAddress: undefined,
+    isAddressInfoReady: true,
+    providerSupportReceiveAddress: true,
+  };
+
+  it('allows recipient entry after target address resolution completes', () => {
+    expect(getSwapRecipientActionState(validState)).toEqual({
+      shouldEnterRecipient: true,
+      shouldDisableAction: false,
+    });
+  });
+
+  it('disables the action while target address resolution is pending', () => {
+    expect(
+      getSwapRecipientActionState({
+        ...validState,
+        isAddressInfoReady: false,
+      }),
+    ).toEqual({
+      shouldEnterRecipient: false,
+      shouldDisableAction: true,
+    });
+  });
+
+  it('disables the action when the provider does not support a recipient', () => {
+    expect(
+      getSwapRecipientActionState({
+        ...validState,
+        providerSupportReceiveAddress: false,
+      }),
+    ).toEqual({
+      shouldEnterRecipient: false,
+      shouldDisableAction: true,
+    });
+  });
+
+  it('preserves an existing disabled state when recipient entry is otherwise allowed', () => {
+    expect(
+      getSwapRecipientActionState({
+        ...validState,
+        isActionDisabled: true,
+      }),
+    ).toEqual({
+      shouldEnterRecipient: false,
+      shouldDisableAction: true,
+    });
+  });
+
+  it('preserves a refresh action when the recipient address is missing', () => {
+    expect(
+      getSwapRecipientActionState({
+        ...validState,
+        isRefreshAction: true,
+      }),
+    ).toEqual({
+      shouldEnterRecipient: false,
+      shouldDisableAction: false,
+    });
+  });
+
+  it('preserves a connect-wallet action when the recipient address is missing', () => {
+    expect(
+      getSwapRecipientActionState({
+        ...validState,
+        noConnectWallet: true,
+      }),
+    ).toEqual({
+      shouldEnterRecipient: false,
+      shouldDisableAction: false,
+    });
+  });
+});
+
+describe('getSwapRecipientValidationAccountId', () => {
+  it('uses the account when it owns the resolved recipient address', () => {
+    expect(
+      getSwapRecipientValidationAccountId({
+        accountId: 'account-1',
+        accountAddress: '0xABCD',
+        recipientAddress: '0xabcd',
+      }),
+    ).toBe('account-1');
+  });
+
+  it('omits a source account that could not resolve on the recipient network', () => {
+    expect(
+      getSwapRecipientValidationAccountId({
+        accountId: 'watching--ltc',
+        accountAddress: 'ltc1source',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('omits an account that does not own the recipient address', () => {
+    expect(
+      getSwapRecipientValidationAccountId({
+        accountId: 'account-1',
+        accountAddress: '0xaaaa',
+        recipientAddress: '0xbbbb',
+      }),
+    ).toBeUndefined();
+  });
+});
 
 describe('getSwapAddressAccountSelectorNum', () => {
   it('uses the source account for the FROM address', () => {

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
@@ -1,4 +1,5 @@
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
+import { equalsIgnoreCase } from '@onekeyhq/shared/src/utils/stringUtils';
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 
 type IShouldUseSwapCustomRecipientAddressParams = {
@@ -35,10 +36,70 @@ type IShouldResetSwapRecipientOnAccountNetworkSyncParams = {
   providerSupportReceiveAddress?: boolean;
 };
 
+type IGetSwapRecipientValidationAccountIdParams = {
+  accountId?: string;
+  accountAddress?: string;
+  recipientAddress?: string;
+};
+
 type IGetSwapAddressAccountSelectorNumParams = {
   type: ESwapDirectionType;
   swapToAnotherAccountSwitchOn: boolean;
 };
+
+type IGetSwapRecipientActionStateParams = {
+  isActionDisabled: boolean;
+  isRefreshAction: boolean;
+  noConnectWallet: boolean;
+  hasQuoteToAmount: boolean;
+  recipientAddress?: string;
+  isAddressInfoReady: boolean;
+  providerSupportReceiveAddress?: boolean;
+};
+
+export function getSwapRecipientActionState({
+  isActionDisabled,
+  isRefreshAction,
+  noConnectWallet,
+  hasQuoteToAmount,
+  recipientAddress,
+  isAddressInfoReady,
+  providerSupportReceiveAddress,
+}: IGetSwapRecipientActionStateParams) {
+  const needsRecipient =
+    !isRefreshAction &&
+    !noConnectWallet &&
+    hasQuoteToAmount &&
+    !recipientAddress;
+  if (!needsRecipient) {
+    return {
+      shouldEnterRecipient: false,
+      shouldDisableAction: isActionDisabled,
+    };
+  }
+
+  const shouldEnterRecipient = Boolean(
+    !isActionDisabled && isAddressInfoReady && providerSupportReceiveAddress,
+  );
+  return {
+    shouldEnterRecipient,
+    shouldDisableAction: !shouldEnterRecipient,
+  };
+}
+
+export function getSwapRecipientValidationAccountId({
+  accountId,
+  accountAddress,
+  recipientAddress,
+}: IGetSwapRecipientValidationAccountIdParams) {
+  if (!accountId || !accountAddress || !recipientAddress) {
+    return undefined;
+  }
+
+  return equalsIgnoreCase(accountAddress, recipientAddress)
+    ? accountId
+    : undefined;
+}
 
 export function getSwapAddressAccountSelectorNum({
   type,

--- a/packages/kit/src/views/Swap/hooks/useSwapState.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapState.ts
@@ -48,6 +48,7 @@ import {
   useSwapFromTokenAmountAtom,
   useSwapLimitPriceUseRateAtom,
   useSwapProTradeTypeAtom,
+  useSwapProviderSupportReceiveAddressAtom,
   useSwapQuoteActionLockAtom,
   useSwapQuoteApproveAllowanceUnLimitAtom,
   useSwapQuoteCurrentEventProviderKeysAtom,
@@ -93,6 +94,7 @@ import {
 
 import { hasValidStockBalanceForTrade } from './swapStockChannelUtils';
 import { useSwapAddressInfo } from './useSwapAccount';
+import { getSwapRecipientActionState } from './useSwapAccount.utils';
 
 function useSwapWarningCheck() {
   const swapFromAddressInfo = useSwapAddressInfo(ESwapDirectionType.FROM);
@@ -412,6 +414,8 @@ export function useSwapActionState() {
   const [toTokenAmount] = useSwapToTokenAmountAtom();
   const [shouldRefreshQuote] = useSwapShouldRefreshQuoteAtom();
   const [{ swapSlippagePercentageMode }] = useSettingsAtom();
+  const [swapProviderSupportReceiveAddress] =
+    useSwapProviderSupportReceiveAddressAtom();
   const [quoteEventTotalCount] = useSwapQuoteEventTotalCountAtom();
   const [quoteEventCompleted] = useSwapQuoteEventCompletedAtom();
   const [swapQuoteApproveAllowanceUnLimit] =
@@ -661,12 +665,9 @@ export function useSwapActionState() {
       disable: !(!hasError && !!quoteCurrentSelect),
       noConnectWallet,
       label: intl.formatMessage({ id: ETranslations.global_review }),
+      shouldEnterRecipient: false,
     };
-    if (
-      !swapFromAddressInfo.address ||
-      !swapToAddressInfo.address ||
-      quoteInputAmountNoMatch
-    ) {
+    if (!swapFromAddressInfo.address || quoteInputAmountNoMatch) {
       infoRes.disable = true;
     }
     if (
@@ -736,17 +737,6 @@ export function useSwapActionState() {
           });
         }
       }
-      if (
-        quoteCurrentSelect &&
-        quoteCurrentSelect.toAmount &&
-        !swapToAddressInfo.address
-      ) {
-        infoRes.label = intl.formatMessage({
-          id: ETranslations.swap_page_button_enter_a_recipient,
-        });
-        infoRes.disable = true;
-      }
-
       const balanceBN = new BigNumber(selectedFromTokenBalance ?? 0);
       const fromTokenAmountBN = new BigNumber(fromTokenAmount.value);
       const stockBalanceUnavailable =
@@ -802,6 +792,22 @@ export function useSwapActionState() {
         });
         infoRes.disable = false;
       }
+      const recipientActionState = getSwapRecipientActionState({
+        isActionDisabled: infoRes.disable,
+        isRefreshAction: shouldOfferQuoteRefreshAction,
+        noConnectWallet: infoRes.noConnectWallet,
+        hasQuoteToAmount: Boolean(quoteCurrentSelect?.toAmount),
+        recipientAddress: swapToAddressInfo.address,
+        isAddressInfoReady: swapToAddressInfo.isAddressInfoReady,
+        providerSupportReceiveAddress: swapProviderSupportReceiveAddress,
+      });
+      infoRes.disable = recipientActionState.shouldDisableAction;
+      if (recipientActionState.shouldEnterRecipient) {
+        infoRes.label = intl.formatMessage({
+          id: ETranslations.swap_page_button_enter_a_recipient,
+        });
+        infoRes.shouldEnterRecipient = true;
+      }
     }
     return infoRes;
   }, [
@@ -812,6 +818,8 @@ export function useSwapActionState() {
     intl,
     swapFromAddressInfo.address,
     swapToAddressInfo.address,
+    swapToAddressInfo.isAddressInfoReady,
+    swapProviderSupportReceiveAddress,
     fromTokenAmount.value,
     quoteInputAmountNoMatch,
     swapTypeSwitchValue,
@@ -846,6 +854,7 @@ export function useSwapActionState() {
     // disabled with "no provider supports trade". (OK-57545)
     isRefreshQuote: shouldOfferQuoteRefreshAction,
     isWaitingAutoSlippage,
+    shouldEnterRecipient: actionInfo.shouldEnterRecipient,
   };
   return stepState;
 }

--- a/packages/kit/src/views/Swap/hooks/useSwapTokens.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapTokens.ts
@@ -57,6 +57,10 @@ import {
 import { buildSwapTokenFetchParams } from './swapTokenFetchParamsUtils';
 import { useSwapAddressInfo } from './useSwapAccount';
 import { shouldUseSwapAddressForTokenFetch } from './useSwapAccount.utils';
+import {
+  getSwapTokenSearchResults,
+  releaseSwapTokenListFetchEffectKey,
+} from './useSwapTokens.utils';
 
 const EMPTY_SWAP_SUPPORT_ALL_ACCOUNTS: IAllNetworkAccountInfo[] = [];
 
@@ -432,6 +436,7 @@ export function useSwapTokenList(
     }
 
     let isCancelled = false;
+    let isRequestSettled = false;
     void (async () => {
       try {
         await Promise.all([
@@ -449,6 +454,7 @@ export function useSwapTokenList(
           tokenListFetchAction(tokenFetchParams),
         ]);
       } finally {
+        isRequestSettled = true;
         if (
           !isCancelled &&
           latestTokenListFetchEffectKeyRef.current === tokenListFetchEffectKey
@@ -467,6 +473,13 @@ export function useSwapTokenList(
     })();
     return () => {
       isCancelled = true;
+      if (!isRequestSettled) {
+        latestTokenListFetchEffectKeyRef.current =
+          releaseSwapTokenListFetchEffectKey({
+            effectKey: tokenListFetchEffectKey,
+            latestEffectKey: latestTokenListFetchEffectKeyRef.current,
+          });
+      }
     };
   }, [
     indexedAccountId,
@@ -620,22 +633,18 @@ export function useSwapTokenList(
       return unfilteredTokens;
     }
     const remoteTokens = fuseRemoteTokensSearch.search(keywords);
-    if (
-      !useLocalSearchFallback ||
-      remoteTokens.length > 0 ||
-      isTokenListFetchSettled
-    ) {
-      return remoteTokens;
-    }
-    const localTokens = fuseSearchBaseTokens.search(keywords);
-    return localTokens.length > 0 ? localTokens : searchBaseTokens;
+    return getSwapTokenSearchResults({
+      isTokenListFetchSettled,
+      remoteTokens,
+      searchLocalTokens: () => fuseSearchBaseTokens.search(keywords),
+      useLocalSearchFallback,
+    });
   }, [
     fuseRemoteTokensSearch,
     fuseSearchBaseTokens,
     isSwapSupportAllAccountsReady,
     isTokenListFetchSettled,
     keywords,
-    searchBaseTokens,
     unfilteredTokens,
     useLocalSearchFallback,
   ]);

--- a/packages/kit/src/views/Swap/hooks/useSwapTokens.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapTokens.ts
@@ -71,6 +71,7 @@ export function useSwapTokenList(
     tokenListType?: string;
   },
   supportNetworksOverride?: ISwapNetwork[],
+  useLocalSearchFallback = false,
 ) {
   const [{ tokenCatch }] = useSwapTokenMapAtom();
   const [swapAllNetworkTokenListMap] = useSwapAllNetworkTokenListMapAtom();
@@ -245,6 +246,8 @@ export function useSwapTokenList(
     tokenFetchParams,
   ]);
   const latestTokenListFetchEffectKeyRef = useRef('');
+  const [settledTokenListFetchEffectKey, setSettledTokenListFetchEffectKey] =
+    useState('');
 
   const swapAllNetworkTokenListCacheKey = useMemo(
     () =>
@@ -428,6 +431,7 @@ export function useSwapTokenList(
       setLpTokenRequestLoading(true);
     }
 
+    let isCancelled = false;
     void (async () => {
       try {
         await Promise.all([
@@ -446,6 +450,13 @@ export function useSwapTokenList(
         ]);
       } finally {
         if (
+          !isCancelled &&
+          latestTokenListFetchEffectKeyRef.current === tokenListFetchEffectKey
+        ) {
+          setSettledTokenListFetchEffectKey(tokenListFetchEffectKey);
+        }
+        if (
+          !isCancelled &&
           lpTokenRequestLoadingRef.current &&
           latestTokenListFetchEffectKeyRef.current === tokenListFetchEffectKey
         ) {
@@ -454,6 +465,9 @@ export function useSwapTokenList(
         }
       }
     })();
+    return () => {
+      isCancelled = true;
+    };
   }, [
     indexedAccountId,
     otherWalletTypeAccountId,
@@ -543,14 +557,15 @@ export function useSwapTokenList(
     swapTokenFetching,
   ]);
 
-  const currentTokens = useMemo(() => {
+  const isTokenListFetchSettled =
+    settledTokenListFetchEffectKey === tokenListFetchEffectKey;
+  const unfilteredTokens = useMemo(() => {
     if (!isSwapSupportAllAccountsReady) {
       return [];
     }
     if (keywords) {
-      return fuseRemoteTokensSearch.search(keywords);
+      return [];
     }
-
     return networkUtils.isAllNetwork({ networkId: tokenFetchParams.networkId })
       ? mergedAllNetworkTokenList({
           swapAllNetRecommend:
@@ -558,16 +573,76 @@ export function useSwapTokenList(
         })
       : tokenCatch?.[JSON.stringify(tokenFetchParams)]?.data || [];
   }, [
-    fuseRemoteTokensSearch,
     keywords,
     mergedAllNetworkTokenList,
     tokenCatch,
     tokenFetchParams,
     isSwapSupportAllAccountsReady,
   ]);
+  const searchBaseContextKey = [
+    indexedAccountId ?? otherWalletTypeAccountId ?? '',
+    currentSelectNetwork?.networkId ?? currentNetworkId ?? '',
+    selectTokenModalType,
+    from ?? '',
+    lpToken === undefined ? '' : String(lpToken),
+    requestCurrency,
+    swapSupportAllNetworks.map((network) => network.networkId).join(','),
+  ].join('__');
+  const searchBaseTokensRef = useRef<{
+    contextKey: string;
+    tokens: ISwapToken[];
+  }>({
+    contextKey: searchBaseContextKey,
+    tokens: [],
+  });
+  if (searchBaseTokensRef.current.contextKey !== searchBaseContextKey) {
+    searchBaseTokensRef.current = {
+      contextKey: searchBaseContextKey,
+      tokens: [],
+    };
+  }
+  if (!keywords && isTokenListFetchSettled) {
+    searchBaseTokensRef.current = {
+      contextKey: searchBaseContextKey,
+      tokens: unfilteredTokens,
+    };
+  }
+  const searchBaseTokens = searchBaseTokensRef.current.tokens;
+  const fuseSearchBaseTokens = useFuse(searchBaseTokens, {
+    shouldSort: false,
+    keys: ['symbol', 'contractAddress'],
+  });
+  const currentTokens = useMemo(() => {
+    if (!isSwapSupportAllAccountsReady) {
+      return [];
+    }
+    if (!keywords) {
+      return unfilteredTokens;
+    }
+    const remoteTokens = fuseRemoteTokensSearch.search(keywords);
+    if (
+      !useLocalSearchFallback ||
+      remoteTokens.length > 0 ||
+      isTokenListFetchSettled
+    ) {
+      return remoteTokens;
+    }
+    const localTokens = fuseSearchBaseTokens.search(keywords);
+    return localTokens.length > 0 ? localTokens : searchBaseTokens;
+  }, [
+    fuseRemoteTokensSearch,
+    fuseSearchBaseTokens,
+    isSwapSupportAllAccountsReady,
+    isTokenListFetchSettled,
+    keywords,
+    searchBaseTokens,
+    unfilteredTokens,
+    useLocalSearchFallback,
+  ]);
 
   const fetchLoading =
     !isSwapSupportAllAccountsReady ||
+    !isTokenListFetchSettled ||
     (swapTokenFetching && currentTokens.length === 0) ||
     (networkUtils.isAllNetwork({ networkId: tokenFetchParams.networkId }) &&
       (!allNetworkTokenListReady || !swapAllNetworkTokenList));

--- a/packages/kit/src/views/Swap/hooks/useSwapTokens.utils.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapTokens.utils.test.ts
@@ -1,0 +1,76 @@
+import {
+  getSwapTokenSearchResults,
+  releaseSwapTokenListFetchEffectKey,
+} from './useSwapTokens.utils';
+
+describe('releaseSwapTokenListFetchEffectKey', () => {
+  it('releases the active key so a cancelled request can restart', () => {
+    expect(
+      releaseSwapTokenListFetchEffectKey({
+        effectKey: 'request-1',
+        latestEffectKey: 'request-1',
+      }),
+    ).toBe('');
+  });
+
+  it('does not release a newer request', () => {
+    expect(
+      releaseSwapTokenListFetchEffectKey({
+        effectKey: 'request-1',
+        latestEffectKey: 'request-2',
+      }),
+    ).toBe('request-2');
+  });
+});
+
+describe('getSwapTokenSearchResults', () => {
+  it('uses matching local results while the remote search is pending', () => {
+    expect(
+      getSwapTokenSearchResults({
+        isTokenListFetchSettled: false,
+        remoteTokens: [],
+        searchLocalTokens: () => ['local-match'],
+        useLocalSearchFallback: true,
+      }),
+    ).toEqual(['local-match']);
+  });
+
+  it('keeps the list empty when neither local nor remote search matches', () => {
+    expect(
+      getSwapTokenSearchResults({
+        isTokenListFetchSettled: false,
+        remoteTokens: [],
+        searchLocalTokens: () => [],
+        useLocalSearchFallback: true,
+      }),
+    ).toEqual([]);
+  });
+
+  it('uses remote results without evaluating the local fallback', () => {
+    const searchLocalTokens = jest.fn(() => ['local-match']);
+
+    expect(
+      getSwapTokenSearchResults({
+        isTokenListFetchSettled: false,
+        remoteTokens: ['remote-match'],
+        searchLocalTokens,
+        useLocalSearchFallback: true,
+      }),
+    ).toEqual(['remote-match']);
+    expect(searchLocalTokens).not.toHaveBeenCalled();
+  });
+
+  it('keeps an authoritative empty remote result after the request settles', () => {
+    const searchLocalTokens = jest.fn(() => ['stale-local-match']);
+
+    expect(
+      getSwapTokenSearchResults({
+        isTokenListFetchSettled: true,
+        remoteTokens: [],
+        searchLocalTokens,
+        useLocalSearchFallback: true,
+      }),
+    ).toEqual([]);
+    expect(searchLocalTokens).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kit/src/views/Swap/hooks/useSwapTokens.utils.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapTokens.utils.ts
@@ -1,0 +1,31 @@
+export function releaseSwapTokenListFetchEffectKey({
+  effectKey,
+  latestEffectKey,
+}: {
+  effectKey: string;
+  latestEffectKey: string;
+}) {
+  return latestEffectKey === effectKey ? '' : latestEffectKey;
+}
+
+export function getSwapTokenSearchResults<T>({
+  isTokenListFetchSettled,
+  remoteTokens,
+  searchLocalTokens,
+  useLocalSearchFallback,
+}: {
+  isTokenListFetchSettled: boolean;
+  remoteTokens: T[];
+  searchLocalTokens: () => T[];
+  useLocalSearchFallback: boolean;
+}) {
+  if (
+    !useLocalSearchFallback ||
+    remoteTokens.length > 0 ||
+    isTokenListFetchSettled
+  ) {
+    return remoteTokens;
+  }
+
+  return searchLocalTokens();
+}

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -342,15 +342,21 @@ const SwapActionsState = ({
       );
       return;
     }
+    if (swapActionState.shouldEnterRecipient) {
+      onOpenRecipientAddress();
+      return;
+    }
     onPreSwap();
   }, [
     currentQuoteRes?.kind,
     navigation,
+    onOpenRecipientAddress,
     onPreSwap,
     quoteAction,
     shouldBlockIncognitoRecipientAction,
     swapActionState.isRefreshQuote,
     swapActionState.noConnectWallet,
+    swapActionState.shouldEnterRecipient,
     swapIncognitoMode,
     swapFromAddressInfo?.accountInfo?.account?.id,
     swapFromAddressInfo?.address,

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -164,6 +164,7 @@ import {
   STOCK_DESKTOP_HEADER_SLOT_PROPS,
   getStockChartDisplayState,
   getStockDisabledActionButtonProps,
+  getStockMarketTokenSubtitle,
   getStockNetworkLogoUri,
   isStockMarketPanelLoadingStage,
   shouldShowStockMarketHeaderSkeleton,
@@ -206,6 +207,9 @@ interface ISwapStockDesktopContainerProps {
 }
 
 type IStockMarketTokenDetail = IMarketTokenDetail | undefined;
+type ISwapStockTokenWithMetadata = ISwapToken & {
+  stock?: IMarketTokenDetail['stock'];
+};
 type IStockMarketDataRow = {
   label: string;
   value: string;
@@ -440,7 +444,9 @@ function buildStockMarketDataRows({
 
 function useCurrentStockMarketDetail() {
   const stockChannel = useSwapStockTradeContext();
-  const currentStockToken = stockChannel.currentStockToken;
+  const currentStockToken = stockChannel.currentStockToken as
+    | ISwapStockTokenWithMetadata
+    | undefined;
 
   return {
     stockChannel,
@@ -1470,8 +1476,12 @@ function StockMarketTokenHeader({
     });
   const tokenName =
     tokenDetail?.name ?? currentStockToken?.name ?? tokenSymbol ?? '';
-  const tokenSubtitle =
-    stock?.subtitle ?? (tokenDetail ? undefined : currentStockToken?.name);
+  const tokenSubtitle = getStockMarketTokenSubtitle({
+    currentStockSubtitle: currentStockToken?.stock?.subtitle,
+    currentTokenName: currentStockToken?.name,
+    hasTokenDetail: Boolean(tokenDetail),
+    tokenDetailStockSubtitle: stock?.subtitle,
+  });
   const tokenImageUri = currentStockToken?.logoURI ?? tokenDetail?.logoUrl;
   const handleOpenStockTokenSelector = useOpenStockTokenSelector({
     defaultNetworkId: stockTokenNetworkId,

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
@@ -11,6 +11,7 @@ import {
   STOCK_DESKTOP_HEADER_SLOT_PROPS,
   getStockChartDisplayState,
   getStockDisabledActionButtonProps,
+  getStockMarketTokenSubtitle,
   getStockNetworkLogoUri,
   isStockMarketPanelLoadingStage,
   mergeStockChartRealtimePoint,
@@ -136,6 +137,42 @@ describe('SwapStockDesktopContainer utils', () => {
         hasStockIdentity: false,
       }),
     ).toBe(false);
+  });
+
+  it('keeps the selected localized Stock subtitle while detail loads', () => {
+    expect(
+      getStockMarketTokenSubtitle({
+        currentStockSubtitle: '英特尔',
+        currentTokenName: 'Intel (Ondo Tokenized)',
+        hasTokenDetail: false,
+      }),
+    ).toBe('英特尔');
+  });
+
+  it('prefers the localized detail subtitle after detail loads', () => {
+    expect(
+      getStockMarketTokenSubtitle({
+        currentStockSubtitle: '英特尔',
+        currentTokenName: 'Intel (Ondo Tokenized)',
+        hasTokenDetail: true,
+        tokenDetailStockSubtitle: '英特尔公司',
+      }),
+    ).toBe('英特尔公司');
+  });
+
+  it('falls back to the raw token name only before Stock metadata loads', () => {
+    expect(
+      getStockMarketTokenSubtitle({
+        currentTokenName: 'Intel (Ondo Tokenized)',
+        hasTokenDetail: false,
+      }),
+    ).toBe('Intel (Ondo Tokenized)');
+    expect(
+      getStockMarketTokenSubtitle({
+        currentTokenName: 'Intel (Ondo Tokenized)',
+        hasTokenDetail: true,
+      }),
+    ).toBeUndefined();
   });
 
   it('shows Stock action loading until the current quote event settles', () => {

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
@@ -91,6 +91,24 @@ export function shouldShowStockMarketHeaderSkeleton({
   );
 }
 
+export function getStockMarketTokenSubtitle({
+  currentStockSubtitle,
+  currentTokenName,
+  hasTokenDetail,
+  tokenDetailStockSubtitle,
+}: {
+  currentStockSubtitle?: string;
+  currentTokenName?: string;
+  hasTokenDetail: boolean;
+  tokenDetailStockSubtitle?: string;
+}) {
+  return (
+    tokenDetailStockSubtitle ??
+    currentStockSubtitle ??
+    (hasTokenDetail ? undefined : currentTokenName)
+  );
+}
+
 export function shouldShowStockQuoteActionLoading({
   inputAmount,
   quoteEventCompleted,

--- a/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
@@ -39,6 +39,7 @@ import RecipientQuickSelect from '../../../Send/pages/SendDataInput/RecipientQui
 import { shouldSkipResolvedRecipientUpdate } from '../../../Send/pages/SendDataInput/recipientSelectionUtils';
 import { useWebDappRecipientOptions } from '../../../Send/pages/SendDataInput/useWebDappRecipientOptions';
 import { useSwapAddressInfo } from '../../hooks/useSwapAccount';
+import { getSwapRecipientValidationAccountId } from '../../hooks/useSwapAccount.utils';
 import { SwapProviderMirror } from '../SwapProviderMirror';
 
 import type { IRecipientQuickSelectTab } from '../../../Send/pages/SendDataInput/recipientQuickSelectTabUtils';
@@ -55,9 +56,17 @@ const SwapToAnotherAddressPage = () => {
   const navigation =
     useAppNavigation<IPageNavigationProp<IModalSwapParamList>>();
 
-  const { accountInfo, activeAccount, networkId } = useSwapAddressInfo(
-    ESwapDirectionType.TO,
-  );
+  const {
+    accountInfo,
+    activeAccount,
+    address: recipientAccountAddress,
+    networkId,
+  } = useSwapAddressInfo(ESwapDirectionType.TO);
+  const validationAccountId = getSwapRecipientValidationAccountId({
+    accountId: accountInfo?.account?.id,
+    accountAddress: accountInfo?.account?.addressDetail?.address,
+    recipientAddress: recipientAccountAddress,
+  });
 
   const [, setSettings] = useSettingsAtom();
   const [, setSwapToAddress] = useSwapToAnotherAccountAddressAtom();
@@ -190,7 +199,7 @@ const SwapToAnotherAddressPage = () => {
             enableAddressInteractionStatus
             enableAddressContract
             enableAllowListValidation
-            accountId={accountInfo?.account?.id}
+            accountId={validationAccountId}
             hasQuickSelectMatches={hasQuickSelectMatches}
           />
           <XStack gap="$1.5" alignItems="center">
@@ -202,7 +211,7 @@ const SwapToAnotherAddressPage = () => {
             </SizableText>
           </XStack>
           <RecipientQuickSelect
-            accountId={accountInfo?.account?.id ?? ''}
+            accountId={validationAccountId ?? ''}
             networkId={networkId}
             senderDeriveType={activeAccount?.deriveType}
             searchKey={toAddressRaw}

--- a/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
@@ -145,6 +145,7 @@ const SwapToAnotherAddressPage = () => {
       }
       setSettings((v) => ({
         ...v,
+        swapEnableRecipientAddress: true,
         swapToAnotherAccountSwitchOn: true,
       }));
       setSwapToAddress((v) => ({

--- a/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapTokenSelectModal.tsx
@@ -181,6 +181,7 @@ const SwapTokenSelectPage = ({
     ? route.params?.defaultNetworkId
     : undefined;
   const intl = useIntl();
+  const [searchInputValue, setSearchInputValue] = useState<string>('');
   const [searchKeyword, setSearchKeyword] = useState<string>('');
   const searchKeywordDebounce = useDebounce(searchKeyword, 500);
   // Reset to the default token list immediately when the input is cleared.
@@ -418,6 +419,7 @@ const SwapTokenSelectPage = ({
         : undefined,
     [isSwapStockSelectTarget],
   );
+  const useLocalSearchFallback = !isSwapStockSelectTarget;
   const { fetchLoading, currentTokens } = useSwapTokenList(
     type,
     currentSelectNetwork?.networkId,
@@ -426,6 +428,7 @@ const SwapTokenSelectPage = ({
     requestLpToken,
     searchAnalyticsOverride,
     swapNetworksIncludeAllNetwork,
+    useLocalSearchFallback,
   );
   const stockSearchBaseNetworkId = currentSelectNetwork?.networkId;
   const stockSearchBaseTokensRef = useRef<{
@@ -733,7 +736,9 @@ const SwapTokenSelectPage = ({
   const handlePaste = useCallback(async () => {
     const text = await getClipboard();
     if (text) {
-      setSearchKeyword(text.trim());
+      const trimmedText = text.trim();
+      setSearchInputValue(trimmedText);
+      setSearchKeyword(trimmedText);
     }
   }, [getClipboard]);
 
@@ -997,11 +1002,13 @@ const SwapTokenSelectPage = ({
             id: ETranslations.token_selector_search_placeholder,
           }),
           onChangeText: ({ nativeEvent }) => {
-            const afterTrim = nativeEvent.text.trim();
-            setSearchKeyword(afterTrim);
+            setSearchInputValue(nativeEvent.text);
+          },
+          onSearchTextChange: (text) => {
+            setSearchKeyword(text.trim());
           },
           ...(autoSearch ? { autoFocus: true } : {}),
-          searchBarInputValue: searchKeyword,
+          searchBarInputValue: searchInputValue,
           ...(searchKeyword?.length === 0 && !platformEnv.isExtension
             ? {
                 addOns: [

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -777,6 +777,7 @@ export interface ISwapState {
   approveUnLimit?: boolean;
   isRefreshQuote?: boolean;
   isWaitingAutoSlippage?: boolean;
+  shouldEnterRecipient?: boolean;
 }
 
 export interface ISwapApproveAllowanceResponse {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58614](https://onekeyhq.atlassian.net/browse/OK-58614) [OK-58443](https://onekeyhq.atlassian.net/browse/OK-58443)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- OK-58614: keep the Swap action available for watch-only accounts that still need a recipient, then open the existing recipient flow before any transaction submission.
- OK-58443: separate the raw IME display value from the normalized search keyword so Desktop composition is gated and iOS marked text is preserved.

## Root cause

- OK-58614 treated a missing recipient as a terminal disabled state, so the existing recipient modal could never be reached.
- OK-58443 fed the search callback and the controlled input from one state. Desktop searched intermediate composition text; iOS lost its native composition separator when the normalized value was written back.

## Validation

- Desktop: LTC watch-only quote shows an enabled recipient action and opens the recipient modal.
- Desktop: token list stays stable through `yitai` composition and searches only after the final Chinese text is committed.
- iOS Simulator: LTC watch-only quote enables `Enter a recipient` and opens the real recipient selector; no signing or submission was attempted.
- iOS Simulator: native Pinyin composition preserves phrase candidates and commits the final Chinese text correctly.
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`

## Pending in this Draft

- OK-58790 is reproduced on Desktop and iOS, but its quote payload is assembled in `server-service-swap`: `StockLiquidMesh` returns `estTime: 0`, no `estimatedTime`, no `estimatedFeeFiatValue`, and `gasLimit: 0`. The app shared provider row already renders fee/time when those fields exist. A truthful fix therefore requires a separate backend branch/PR; no client-side placeholder or fabricated estimate is included here.

[OK-58614]: https://onekeyhq.atlassian.net/browse/OK-58614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-58443]: https://onekeyhq.atlassian.net/browse/OK-58443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ