### PR TITLE
fix: refine iOS 26 unifold selector

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldDepositTransferModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldDepositTransferModal.tsx
@@ -9,6 +9,7 @@ import {
   NavBackButton,
   Page,
   Stack,
+  glassBarItem,
   useBackHandler,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -157,12 +158,21 @@ export default function MobileUnifoldDepositTransferModal() {
   } else if (initialSelectorMode === 'chain') {
     headerTitleId = ETranslations.global_select_network;
   }
+  const buildNativeHeaderLeftItems = useCallback(
+    () => [glassBarItem(headerLeft())],
+    [headerLeft],
+  );
 
   return (
     <Page scrollEnabled scrollProps={MOBILE_PAGE_SCROLL_PROPS} safeAreaEnabled>
       <Page.Header
         title={intl.formatMessage({ id: headerTitleId })}
-        headerLeft={headerLeft}
+        {...(platformEnv.isNativeIOS26Plus
+          ? {
+              scrollEdgeEffects: { top: 'hidden' },
+              unstable_headerLeftItems: buildNativeHeaderLeftItems,
+            }
+          : { headerLeft })}
       />
       <Page.Body
         flex={1}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldSourceSelectorContent.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldSourceSelectorContent.tsx
@@ -26,7 +26,7 @@ import { normalizeUnifoldIconUrl } from './unifoldFormat';
 function MobileSourceSelectorSkeletonList() {
   return (
     <YStack testID="perps-unifold-source-selector-loading">
-      {[...Array(6)].map((_, index) => (
+      {[...Array(4)].map((_, index) => (
         <XStack
           // The index is stable because these placeholders never reorder.
           key={index}


### PR DESCRIPTION
## Summary

- preserve the flow back button in the iOS 26 native header
- disable the iOS 26 top scroll-edge blur for this modal
- reduce selector loading skeletons from six rows to four

## Validation

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`