### PR TITLE
fix: stabilize Stock chart loading (OK-58814)

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -241,6 +241,9 @@ type IStockChartState = {
   data: IMarketTokenChart;
   range: IStockChartRange;
   scope: string;
+  // Optional for compatibility with existing SWR entries written before the
+  // request lifecycle became explicit.
+  status?: 'pending' | 'success' | 'error';
 };
 
 function useOpenStockTokenSelector({
@@ -1622,7 +1625,6 @@ function StockMarketTokenHeader({
 
 function StockPriceChart({
   coinGeckoId,
-  forceLoading,
   isNative,
   networkId,
   onRangeChange,
@@ -1632,7 +1634,6 @@ function StockPriceChart({
   tokenAddress,
 }: {
   coinGeckoId?: string;
-  forceLoading?: boolean;
   isNative?: boolean;
   networkId?: string;
   onRangeChange: (range: IStockChartRange) => void;
@@ -1688,11 +1689,16 @@ function StockPriceChart({
     data: [],
     range,
     scope: '',
+    status: 'pending',
   });
   useEffect(() => {
     setHoverData(null);
   }, [chartScope]);
-  const { result: chartState, isLoading } = usePromiseResult(
+  const {
+    result: chartState,
+    isLoading,
+    run: retryChart,
+  } = usePromiseResult(
     async () => {
       if (!chartRequestReady || !activeRange || !normalizedCoinGeckoId) {
         return (
@@ -1703,27 +1709,44 @@ function StockPriceChart({
             assetScope: chartAssetScope,
             range,
             data: [] as IMarketTokenChart,
+            status: 'pending' as const,
           }
         );
       }
-      const timeTo = Math.floor(Date.now() / 1000);
-      const timeFrom = timeTo - activeRange.seconds;
-      const days = getSwapKLineWalletChartDays({ timeFrom, timeTo });
-      const response = await backgroundApiProxy.serviceMarket.fetchTokenChart(
-        normalizedCoinGeckoId,
-        days,
-        { requestCurrency: 'usd' },
-      );
-      return {
-        scope: chartScope,
-        assetScope: chartAssetScope,
-        range,
-        data: normalizeSwapKLineWalletChartData({
-          chartData: response,
-          timeFrom,
-          timeTo,
-        }),
-      };
+      try {
+        const timeTo = Math.floor(Date.now() / 1000);
+        const timeFrom = timeTo - activeRange.seconds;
+        const days = getSwapKLineWalletChartDays({ timeFrom, timeTo });
+        const response = await backgroundApiProxy.serviceMarket.fetchTokenChart(
+          normalizedCoinGeckoId,
+          days,
+          { requestCurrency: 'usd' },
+        );
+        return {
+          scope: chartScope,
+          assetScope: chartAssetScope,
+          range,
+          data: normalizeSwapKLineWalletChartData({
+            chartData: response,
+            timeFrom,
+            timeTo,
+          }),
+          status: 'success' as const,
+        };
+      } catch (_error) {
+        const cachedChartState =
+          swrCacheUtils.get<IStockChartState>(chartScope);
+        if (cachedChartState) {
+          return cachedChartState;
+        }
+        return {
+          scope: chartScope,
+          assetScope: chartAssetScope,
+          range,
+          data: [] as IMarketTokenChart,
+          status: 'error' as const,
+        };
+      }
     },
     [
       activeRange,
@@ -1740,12 +1763,16 @@ function StockPriceChart({
         assetScope: '',
         range,
         data: [] as IMarketTokenChart,
+        status: 'pending',
       },
       swrKey: chartCacheReady ? chartScope : undefined,
       // A missing CoinGecko lookup id is a request-readiness gap, not a real
       // empty chart response. Keep the existing display snapshot untouched
       // until the request can actually run.
-      swrShouldPersist: () => chartRequestReady,
+      swrShouldPersist: (state) =>
+        chartRequestReady &&
+        state.status !== 'pending' &&
+        state.status !== 'error',
       watchLoading: true,
     },
   );
@@ -1775,21 +1802,26 @@ function StockPriceChart({
     () => (isVisibleChartStateForCurrentAsset ? displayChartState.data : []),
     [displayChartState.data, isVisibleChartStateForCurrentAsset],
   );
-  const { chartData, shouldShowChartLoading } = useMemo(
+  const { chartData, shouldShowChartError, shouldShowChartLoading } = useMemo(
     () =>
       getStockChartDisplayState({
         baseChartData,
         isChartStateForCurrentScope: isVisibleChartStateForCurrentScope,
         isLoading,
+        requestStatus: displayChartState.status ?? 'success',
         realtimeChartPoint,
       }),
     [
       baseChartData,
+      displayChartState.status,
       isLoading,
       isVisibleChartStateForCurrentScope,
       realtimeChartPoint,
     ],
   );
+  const handleChartRetry = useCallback(() => {
+    void retryChart();
+  }, [retryChart]);
   const priceFormatter = useCallback(
     (price: number) =>
       numberFormat(String(price), {
@@ -1860,7 +1892,13 @@ function StockPriceChart({
   }, [hoverData, intl]);
 
   let chartContent: ReactNode = (
-    <YStack flex={1} alignItems="center" justifyContent="center" gap="$2">
+    <YStack
+      testID={SwapTestIDs.stockChartEmpty}
+      flex={1}
+      alignItems="center"
+      justifyContent="center"
+      gap="$2"
+    >
       <YStack
         w="$10"
         h="$10"
@@ -1883,11 +1921,41 @@ function StockPriceChart({
       </SizableText>
     </YStack>
   );
-  if (forceLoading || shouldShowChartLoading) {
-    chartContent = <Skeleton w="100%" h="100%" />;
+  if (shouldShowChartLoading) {
+    chartContent = (
+      <YStack testID={SwapTestIDs.stockChartLoading} w="100%" h="100%">
+        <Skeleton w="100%" h="100%" />
+      </YStack>
+    );
+  } else if (shouldShowChartError) {
+    chartContent = (
+      <YStack
+        testID={SwapTestIDs.stockChartError}
+        flex={1}
+        alignItems="center"
+        justifyContent="center"
+        gap="$2"
+      >
+        <Icon name="InfoCircleOutline" size="$6" color="$iconSubdued" />
+        <SizableText size="$bodySm" color="$textSubdued" textAlign="center">
+          {intl.formatMessage({
+            id: ETranslations.global_unknown_error_retry_message,
+          })}
+        </SizableText>
+        <Button
+          testID={SwapTestIDs.stockChartRetry}
+          size="small"
+          variant="tertiary"
+          onPress={handleChartRetry}
+        >
+          {intl.formatMessage({ id: ETranslations.global_retry })}
+        </Button>
+      </YStack>
+    );
   } else if (chartData.length > 0) {
     chartContent = (
       <YStack
+        testID={SwapTestIDs.stockChartContent}
         position="relative"
         h={STOCK_CHART_VISIBLE_HEIGHT}
         onLayout={(event) => {
@@ -2178,7 +2246,6 @@ function StockMarketContextPanel({
     chartContent = (
       <StockPriceChart
         coinGeckoId={coinGeckoId}
-        forceLoading={!chartReady}
         tokenAddress={tokenAddress ?? ''}
         networkId={networkId ?? ''}
         isNative={isNative}

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -1622,6 +1622,7 @@ function StockMarketTokenHeader({
 
 function StockPriceChart({
   coinGeckoId,
+  forceLoading,
   isNative,
   networkId,
   onRangeChange,
@@ -1631,6 +1632,7 @@ function StockPriceChart({
   tokenAddress,
 }: {
   coinGeckoId?: string;
+  forceLoading?: boolean;
   isNative?: boolean;
   networkId?: string;
   onRangeChange: (range: IStockChartRange) => void;
@@ -1881,7 +1883,7 @@ function StockPriceChart({
       </SizableText>
     </YStack>
   );
-  if (shouldShowChartLoading) {
+  if (forceLoading || shouldShowChartLoading) {
     chartContent = <Skeleton w="100%" h="100%" />;
   } else if (chartData.length > 0) {
     chartContent = (
@@ -2172,10 +2174,11 @@ function StockMarketContextPanel({
   // Only pulse the chart tail while the market is open (live updating).
   const isMarketOpen = stockChannel.stockMarketStatus?.open === true;
   let chartContent: ReactNode;
-  if (chartReady) {
+  if (chartReady || marketPanelLoading) {
     chartContent = (
       <StockPriceChart
         coinGeckoId={coinGeckoId}
+        forceLoading={!chartReady}
         tokenAddress={tokenAddress ?? ''}
         networkId={networkId ?? ''}
         isNative={isNative}
@@ -2185,8 +2188,6 @@ function StockMarketContextPanel({
         realtimeChartPoint={stockChannel.realtimeChartPoint}
       />
     );
-  } else if (marketPanelLoading) {
-    chartContent = <Skeleton w="100%" h={274} />;
   } else {
     chartContent = <StockMarketChartEmptyState />;
   }

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
@@ -250,7 +250,50 @@ describe('SwapStockDesktopContainer utils', () => {
       }),
     ).toEqual({
       chartData: [],
+      shouldShowChartError: false,
       shouldShowChartLoading: true,
+    });
+  });
+
+  it('keeps a current pending chart request in loading state', () => {
+    expect(
+      getStockChartDisplayState({
+        baseChartData: [],
+        isChartStateForCurrentScope: true,
+        isLoading: false,
+        requestStatus: 'pending',
+      }),
+    ).toEqual({
+      chartData: [],
+      shouldShowChartError: false,
+      shouldShowChartLoading: true,
+    });
+  });
+
+  it('shows chart errors separately from successful empty responses', () => {
+    expect(
+      getStockChartDisplayState({
+        baseChartData: [],
+        isChartStateForCurrentScope: true,
+        isLoading: false,
+        requestStatus: 'error',
+      }),
+    ).toEqual({
+      chartData: [],
+      shouldShowChartError: true,
+      shouldShowChartLoading: false,
+    });
+    expect(
+      getStockChartDisplayState({
+        baseChartData: [],
+        isChartStateForCurrentScope: true,
+        isLoading: false,
+        requestStatus: 'success',
+      }),
+    ).toEqual({
+      chartData: [],
+      shouldShowChartError: false,
+      shouldShowChartLoading: false,
     });
   });
 
@@ -269,6 +312,7 @@ describe('SwapStockDesktopContainer utils', () => {
       }),
     ).toEqual({
       chartData: previousChartData,
+      shouldShowChartError: false,
       shouldShowChartLoading: false,
     });
   });
@@ -287,6 +331,7 @@ describe('SwapStockDesktopContainer utils', () => {
       }),
     ).toEqual({
       chartData: cachedChartData,
+      shouldShowChartError: false,
       shouldShowChartLoading: false,
     });
   });
@@ -308,6 +353,7 @@ describe('SwapStockDesktopContainer utils', () => {
         [1_725_003_600, 311],
         [1_725_007_200, 312.15],
       ],
+      shouldShowChartError: false,
       shouldShowChartLoading: false,
     });
   });

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
@@ -173,13 +173,19 @@ export function getStockChartDisplayState({
   baseChartData,
   isChartStateForCurrentScope,
   isLoading,
+  requestStatus,
   realtimeChartPoint,
 }: {
   baseChartData: IMarketTokenChart;
   isChartStateForCurrentScope: boolean;
   isLoading?: boolean;
+  requestStatus?: 'pending' | 'success' | 'error';
   realtimeChartPoint?: IMarketTokenChart[number];
 }) {
+  const shouldShowChartError =
+    baseChartData.length === 0 &&
+    isChartStateForCurrentScope &&
+    requestStatus === 'error';
   return {
     chartData: mergeStockChartRealtimePoint({
       baseChartData,
@@ -187,8 +193,12 @@ export function getStockChartDisplayState({
         ? realtimeChartPoint
         : undefined,
     }),
+    shouldShowChartError,
     shouldShowChartLoading:
       baseChartData.length === 0 &&
-      (Boolean(isLoading) || !isChartStateForCurrentScope),
+      !shouldShowChartError &&
+      (requestStatus === 'pending' ||
+        Boolean(isLoading) ||
+        !isChartStateForCurrentScope),
   };
 }

--- a/packages/kit/src/views/Swap/testIDs.ts
+++ b/packages/kit/src/views/Swap/testIDs.ts
@@ -46,6 +46,11 @@ export const SwapTestIDs = {
   stockMarketTokenHeader: 'swap-stock-market-token-header',
   stockMarketPanel: 'swap-stock-market-panel',
   stockMarketDataGrid: 'swap-stock-market-data-grid',
+  stockChartLoading: 'swap-stock-chart-loading',
+  stockChartContent: 'swap-stock-chart-content',
+  stockChartEmpty: 'swap-stock-chart-empty',
+  stockChartError: 'swap-stock-chart-error',
+  stockChartRetry: 'swap-stock-chart-retry',
   stockTradeStatusAlert: 'swap-stock-trade-status-alert',
 
   // Limit order


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58814](https://onekeyhq.atlassian.net/browse/OK-58814)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- keep the Stock chart in one stable shell until the current asset/range request settles
- distinguish Stock chart loading, successful empty data, and retryable request errors

## Issues

- Fixes OK-58814

## Validation

- `yarn jest packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts --runInBand` (24/24)
- `yarn agent:check --profile commit`
- Desktop uncached Stock chart: 492 animation-frame samples, stable 274px shell and four range controls, no empty-state frame
- Desktop chart failure/retry: explicit retryable error and successful chart recovery, no empty-state frame

## Risk

- scoped to the Desktop Stock chart presentation/request lifecycle
- endpoint and cache key are unchanged

[OK-58814]: https://onekeyhq.atlassian.net/browse/OK-58814