### PR TITLE
fix: stock trading sessions and market status alerts (OK-58509, OK-58513, OK-58516, OK-58554, OK-58655)

### DIFF
--- a/packages/kit/src/components/TradingHoursPanel/index.tsx
+++ b/packages/kit/src/components/TradingHoursPanel/index.tsx
@@ -2,12 +2,14 @@ import type { ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useIntl } from 'react-intl';
+import { useWindowDimensions } from 'react-native';
 
 import {
   Dialog,
   Icon,
   IconButton,
   Popover,
+  ScrollView,
   SizableText,
   Stack,
   XStack,
@@ -473,17 +475,41 @@ function TradingHoursDialogHeader() {
   );
 }
 
+/**
+ * Vertical space reserved for everything around the scrollable body: the
+ * sheet grabber, the dialog header row and a top gap so the sheet never
+ * covers the full screen.
+ */
+const DIALOG_BODY_RESERVED_HEIGHT = 160;
+
+/**
+ * The sheet dialog uses `snapPointsMode="fit"`, so a panel taller than the
+ * viewport (extension popup, small phones — especially with longer English
+ * copy, OK-58516) would simply clip its bottom. Bound the body by the window
+ * height and let it scroll; when the content fits, the ScrollView collapses
+ * to content height and nothing changes visually.
+ */
+function TradingHoursDialogBody({ stock }: { stock: IMarketStockInfo }) {
+  const { height: windowHeight } = useWindowDimensions();
+  return (
+    <YStack>
+      <TradingHoursDialogHeader />
+      <ScrollView
+        maxHeight={windowHeight - DIALOG_BODY_RESERVED_HEIGHT}
+        nestedScrollEnabled
+      >
+        <TradingHoursContent stock={stock} />
+      </ScrollView>
+    </YStack>
+  );
+}
+
 function showTradingHoursDialog(stock: IMarketStockInfo) {
   Dialog.show({
     showHeader: false,
     showFooter: false,
     contentContainerProps: { px: '$0', pb: '$0' },
-    renderContent: (
-      <YStack>
-        <TradingHoursDialogHeader />
-        <TradingHoursContent stock={stock} />
-      </YStack>
-    ),
+    renderContent: <TradingHoursDialogBody stock={stock} />,
   });
 }
 

--- a/packages/kit/src/components/TradingHoursPanel/index.tsx
+++ b/packages/kit/src/components/TradingHoursPanel/index.tsx
@@ -475,30 +475,33 @@ function TradingHoursDialogHeader() {
   );
 }
 
-/**
- * Vertical space reserved for everything around the scrollable body: the
- * sheet grabber, the dialog header row and a top gap so the sheet never
- * covers the full screen.
- */
+// Sheet chrome around the scrollable body: grabber + header row + a top gap.
 const DIALOG_BODY_RESERVED_HEIGHT = 160;
+// Keep a usable body even on absurdly short windows.
+const DIALOG_BODY_MIN_HEIGHT = 240;
 
 /**
  * The sheet dialog uses `snapPointsMode="fit"`, so a panel taller than the
- * viewport (extension popup, small phones — especially with longer English
- * copy, OK-58516) would simply clip its bottom. Bound the body by the window
- * height and let it scroll; when the content fits, the ScrollView collapses
- * to content height and nothing changes visually.
+ * viewport (extension popup, small phones, longer English copy — OK-58516)
+ * would clip its bottom. Bound the body by the window height and let it
+ * scroll; when the content fits, the ScrollView collapses to content height.
  */
 function TradingHoursDialogBody({ stock }: { stock: IMarketStockInfo }) {
   const { height: windowHeight } = useWindowDimensions();
+  // Window resizes only move the ScrollView bound — keep the panel subtree
+  // from re-reconciling on every resize tick.
+  const content = useMemo(() => <TradingHoursContent stock={stock} />, [stock]);
   return (
     <YStack>
       <TradingHoursDialogHeader />
       <ScrollView
-        maxHeight={windowHeight - DIALOG_BODY_RESERVED_HEIGHT}
+        maxHeight={Math.max(
+          DIALOG_BODY_MIN_HEIGHT,
+          windowHeight - DIALOG_BODY_RESERVED_HEIGHT,
+        )}
         nestedScrollEnabled
       >
-        <TradingHoursContent stock={stock} />
+        {content}
       </ScrollView>
     </YStack>
   );

--- a/packages/kit/src/components/TradingHoursPanel/index.tsx
+++ b/packages/kit/src/components/TradingHoursPanel/index.tsx
@@ -528,9 +528,9 @@ function getNodeRect(node: unknown): DOMRect | null {
 }
 
 /**
- * Desktop hover-card behavior: hovering the badge opens the popover; it stays
- * open while the pointer is inside the badge or the panel and closes shortly
- * after the pointer leaves both. Closing is driven by GEOMETRY (a global
+ * Desktop hover-card behavior: dwelling on the badge opens the popover; it
+ * stays open while the pointer is inside the badge or the panel and closes
+ * shortly after the pointer leaves both. Closing is driven by GEOMETRY (a global
  * mousemove hit-test against both rects) instead of enter/leave events —
  * opening the popover remounts nodes under a stationary cursor, and the
  * resulting synthetic leave/enter storm made event-based closing flicker.
@@ -547,8 +547,29 @@ function TradingHoursHoverPopover({
   const triggerRef = useRef<unknown>(null);
   const contentRef = useRef<unknown>(null);
 
-  // Opening is idempotent — repeated hover-in events are harmless.
-  const handleHoverIn = useCallback(() => setIsOpen(true), []);
+  // Hover-intent delay (OK-58513): the badge sits inside the token-selector
+  // header, so a pointer merely passing through (typically <150 ms) must not
+  // open the card. Opening waits for a short dwell; leaving the badge before
+  // it elapses cancels the open. Clicking still opens instantly via the
+  // Popover's own trigger press.
+  const HOVER_OPEN_DELAY_MS = 300;
+  const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelPendingOpen = useCallback(() => {
+    if (openTimerRef.current) {
+      clearTimeout(openTimerRef.current);
+      openTimerRef.current = null;
+    }
+  }, []);
+  const handleHoverIn = useCallback(() => {
+    if (openTimerRef.current) {
+      return;
+    }
+    openTimerRef.current = setTimeout(() => {
+      openTimerRef.current = null;
+      setIsOpen(true);
+    }, HOVER_OPEN_DELAY_MS);
+  }, []);
+  useEffect(() => cancelPendingOpen, [cancelPendingOpen]);
 
   useEffect(() => {
     if (!isOpen || typeof document === 'undefined') {
@@ -611,7 +632,11 @@ function TradingHoursHoverPopover({
       onOpenChange={setIsOpen}
       title={<TradingHoursTitle />}
       renderTrigger={
-        <Stack {...({ ref: triggerRef } as object)} onHoverIn={handleHoverIn}>
+        <Stack
+          {...({ ref: triggerRef } as object)}
+          onHoverIn={handleHoverIn}
+          onHoverOut={cancelPendingOpen}
+        >
           {renderTrigger}
         </Stack>
       }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
@@ -676,6 +676,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
     <StockMarketStatusAlert
       statusCase={resolveStockMarketStatusCase({
         isOpen: false,
+        isPaused: tokenDetail?.stock?.isPaused,
         hasOpenTime: Boolean(stockClosedTimeText),
         hasPerps: stockHasPerps,
       })}

--- a/packages/kit/src/views/Market/components/StockMarketStatusAlert/StockMarketStatusAlert.tsx
+++ b/packages/kit/src/views/Market/components/StockMarketStatusAlert/StockMarketStatusAlert.tsx
@@ -3,6 +3,7 @@ import { useIntl } from 'react-intl';
 import { Alert } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
+import { stripTrailingSentencePunctuation } from './getStockMarketClosedDescription';
 import { EStockMarketStatusCase } from './resolveStockMarketStatusCase';
 
 export type IStockMarketStatusAlertProps = {
@@ -54,7 +55,7 @@ export function StockMarketStatusAlert({
   const timeWithPerpsText = timeText?.trim()
     ? intl.formatMessage(
         { id: ETranslations.trade_stock_reopen_eta_perps },
-        { time: timeText.trim() },
+        { time: stripTrailingSentencePunctuation(timeText.trim()) },
       )
     : waitWithPerpsText;
   // Perps button (cases 1 & 4); only when the caller provided a handler.

--- a/packages/kit/src/views/Market/components/StockMarketStatusAlert/StockMarketStatusAlert.tsx
+++ b/packages/kit/src/views/Market/components/StockMarketStatusAlert/StockMarketStatusAlert.tsx
@@ -19,7 +19,7 @@ export type IStockMarketStatusAlertProps = {
   timeText?: string | null;
   /**
    * Navigate to the Perps (contract) screen for this underlying. Provide it for
-   * the "with Perps" cases (1 & 4); the Perps button only renders when set.
+   * the "with Perps" cases (1, 4 & 5); the Perps button only renders when set.
    */
   onTradePerps?: () => void;
   testID?: string;
@@ -43,79 +43,76 @@ export function StockMarketStatusAlert({
     return null;
   }
 
-  const waitText = intl.formatMessage({
-    id: ETranslations.trade_stock_wait_for_reopen,
-  });
-  // "Wait for market to reopen, you can still trade Perps" (unknown time + Perps).
-  const waitWithPerpsText = intl.formatMessage({
-    id: ETranslations.trade_stock_wait_reopens_in_perps,
-  });
+  const trimmedTimeText = timeText?.trim();
   // "{countdown}, you can still trade Perps" — backend countdown + Perps suffix.
-  // Falls back to the no-time variant if the countdown is somehow missing.
-  const timeWithPerpsText = timeText?.trim()
-    ? intl.formatMessage(
-        { id: ETranslations.trade_stock_reopen_eta_perps },
-        { time: stripTrailingSentencePunctuation(timeText.trim()) },
-      )
-    : waitWithPerpsText;
-  // Perps button (cases 1 & 4); only when the caller provided a handler.
-  const perpsAction = onTradePerps
-    ? {
-        primary: intl.formatMessage({ id: ETranslations.global_perp }),
-        onPrimaryPress: onTradePerps,
-        primaryVariant: 'secondary' as const,
-        primaryTestID: 'stock-market-status-perps-action',
-      }
-    : undefined;
-
-  let titleId = ETranslations.trade_stock_market_closed;
-  let description = waitText;
-  let action: typeof perpsAction;
-  switch (statusCase) {
-    // 1. known time + Perps: countdown + "you can still trade Perps", offer Perps.
-    case EStockMarketStatusCase.ClosedKnownTimeWithPerps:
-      description = timeWithPerpsText;
-      action = perpsAction;
-      break;
-    // 2. known time, no Perps: show the countdown.
-    case EStockMarketStatusCase.ClosedKnownTimeNoPerps:
-      description = timeText?.trim() || waitText;
-      break;
-    // 4. unknown time + Perps: ask to wait, offer Perps.
-    case EStockMarketStatusCase.ClosedUnknownTimeWithPerps:
-      description = waitWithPerpsText;
-      action = perpsAction;
-      break;
-    // 5. halted (OK-58655): "Trading halts" title; body is the backend halt
-    // sentence (+ Perps suffix when a Perps handoff exists). The "wait for
-    // reopen" copy would be wrong here, so fall back to the generic halts
-    // description instead.
-    case EStockMarketStatusCase.Halted:
-      titleId = ETranslations.trading_hours_trading_halts;
-      if (timeText?.trim()) {
-        description = onTradePerps ? timeWithPerpsText : timeText.trim();
-      } else {
-        description = intl.formatMessage({
+  const formatTimeWithPerps = (time: string) =>
+    intl.formatMessage(
+      { id: ETranslations.trade_stock_reopen_eta_perps },
+      { time: stripTrailingSentencePunctuation(time) },
+    );
+  const getDescription = () => {
+    switch (statusCase) {
+      // 1. known time + Perps: countdown + "you can still trade Perps";
+      // falls back to the no-time variant if the countdown is somehow missing.
+      case EStockMarketStatusCase.ClosedKnownTimeWithPerps:
+        return trimmedTimeText
+          ? formatTimeWithPerps(trimmedTimeText)
+          : intl.formatMessage({
+              id: ETranslations.trade_stock_wait_reopens_in_perps,
+            });
+      // 2. known time, no Perps: show the countdown.
+      case EStockMarketStatusCase.ClosedKnownTimeNoPerps:
+        return (
+          trimmedTimeText ||
+          intl.formatMessage({ id: ETranslations.trade_stock_wait_for_reopen })
+        );
+      // 4. unknown time + Perps: ask to wait, offer Perps.
+      case EStockMarketStatusCase.ClosedUnknownTimeWithPerps:
+        return intl.formatMessage({
+          id: ETranslations.trade_stock_wait_reopens_in_perps,
+        });
+      // 5. halted (OK-58655): backend halt sentence (+ Perps suffix) — the
+      // "wait for market to reopen" copy would be wrong for a halt.
+      case EStockMarketStatusCase.Halted:
+        if (trimmedTimeText) {
+          return onTradePerps
+            ? formatTimeWithPerps(trimmedTimeText)
+            : trimmedTimeText;
+        }
+        return intl.formatMessage({
           id: ETranslations.trading_hours_trading_halts_description,
         });
-      }
-      action = perpsAction;
-      break;
-    // 3. unknown time, no Perps: ask to wait.
-    case EStockMarketStatusCase.ClosedUnknownTimeNoPerps:
-    default:
-      description = waitText;
-      break;
-  }
+      // 3. unknown time, no Perps: ask to wait.
+      case EStockMarketStatusCase.ClosedUnknownTimeNoPerps:
+      default:
+        return intl.formatMessage({
+          id: ETranslations.trade_stock_wait_for_reopen,
+        });
+    }
+  };
 
   return (
     <Alert
       testID={testID}
       type="warning"
       icon="InfoCircleOutline"
-      title={intl.formatMessage({ id: titleId })}
-      description={description}
-      action={action}
+      title={intl.formatMessage({
+        id:
+          statusCase === EStockMarketStatusCase.Halted
+            ? ETranslations.trading_hours_trading_halts
+            : ETranslations.trade_stock_market_closed,
+      })}
+      description={getDescription()}
+      action={
+        onTradePerps
+          ? {
+              primary: intl.formatMessage({ id: ETranslations.global_perp }),
+              onPrimaryPress: onTradePerps,
+              primaryVariant: 'secondary' as const,
+              primaryTestID: 'stock-market-status-perps-action',
+            }
+          : undefined
+      }
       actionLayout="horizontal"
     />
   );

--- a/packages/kit/src/views/Market/components/StockMarketStatusAlert/StockMarketStatusAlert.tsx
+++ b/packages/kit/src/views/Market/components/StockMarketStatusAlert/StockMarketStatusAlert.tsx
@@ -26,10 +26,10 @@ export type IStockMarketStatusAlertProps = {
 };
 
 /**
- * Standard market-status alert for a tokenized stock (open/closed cases).
- * Presentational only — the caller resolves the case and wires navigation, so
- * this can be reused across modules. See `resolveStockMarketStatusCase` for the
- * case definitions (case 5 Halted is reserved for when the backend supports it).
+ * Standard market-status alert for a tokenized stock (open/closed/halted
+ * cases). Presentational only — the caller resolves the case and wires
+ * navigation, so this can be reused across modules. See
+ * `resolveStockMarketStatusCase` for the case definitions.
  */
 export function StockMarketStatusAlert({
   statusCase,
@@ -68,6 +68,7 @@ export function StockMarketStatusAlert({
       }
     : undefined;
 
+  let titleId = ETranslations.trade_stock_market_closed;
   let description = waitText;
   let action: typeof perpsAction;
   switch (statusCase) {
@@ -85,6 +86,21 @@ export function StockMarketStatusAlert({
       description = waitWithPerpsText;
       action = perpsAction;
       break;
+    // 5. halted (OK-58655): "Trading halts" title; body is the backend halt
+    // sentence (+ Perps suffix when a Perps handoff exists). The "wait for
+    // reopen" copy would be wrong here, so fall back to the generic halts
+    // description instead.
+    case EStockMarketStatusCase.Halted:
+      titleId = ETranslations.trading_hours_trading_halts;
+      if (timeText?.trim()) {
+        description = onTradePerps ? timeWithPerpsText : timeText.trim();
+      } else {
+        description = intl.formatMessage({
+          id: ETranslations.trading_hours_trading_halts_description,
+        });
+      }
+      action = perpsAction;
+      break;
     // 3. unknown time, no Perps: ask to wait.
     case EStockMarketStatusCase.ClosedUnknownTimeNoPerps:
     default:
@@ -97,9 +113,7 @@ export function StockMarketStatusAlert({
       testID={testID}
       type="warning"
       icon="InfoCircleOutline"
-      title={intl.formatMessage({
-        id: ETranslations.trade_stock_market_closed,
-      })}
+      title={intl.formatMessage({ id: titleId })}
       description={description}
       action={action}
       actionLayout="horizontal"

--- a/packages/kit/src/views/Market/components/StockMarketStatusAlert/getStockMarketClosedDescription.test.ts
+++ b/packages/kit/src/views/Market/components/StockMarketStatusAlert/getStockMarketClosedDescription.test.ts
@@ -1,26 +1,6 @@
-import {
-  getStockMarketClosedDescription,
-  stripTrailingSentencePunctuation,
-} from './getStockMarketClosedDescription';
-
-describe('getStockMarketClosedDescription', () => {
-  it('returns the first non-empty line', () => {
-    expect(
-      getStockMarketClosedDescription('Reopens in 2h\nProvider description'),
-    ).toBe('Reopens in 2h');
-    expect(getStockMarketClosedDescription('\n\n  Reopens in 2h  \nrest')).toBe(
-      'Reopens in 2h',
-    );
-  });
-
-  it('treats empty or ondo blurbs as no countdown', () => {
-    expect(getStockMarketClosedDescription(undefined)).toBeUndefined();
-    expect(getStockMarketClosedDescription('')).toBeUndefined();
-    expect(
-      getStockMarketClosedDescription('Ondo tokenized stocks trade 7x24'),
-    ).toBeUndefined();
-  });
-});
+// `getStockMarketClosedDescription` itself is covered by
+// SwapStockTradeAlert.utils.test.ts — only the strip helper is tested here.
+import { stripTrailingSentencePunctuation } from './getStockMarketClosedDescription';
 
 describe('stripTrailingSentencePunctuation', () => {
   it('strips CJK and Latin sentence-ending punctuation (OK-58554)', () => {
@@ -35,9 +15,6 @@ describe('stripTrailingSentencePunctuation', () => {
   });
 
   it('keeps countdown lines without trailing punctuation unchanged', () => {
-    expect(
-      stripTrailingSentencePunctuation('美国股票市场将于 9h 24m 后开盘'),
-    ).toBe('美国股票市场将于 9h 24m 后开盘');
     expect(stripTrailingSentencePunctuation('Reopens in 2h')).toBe(
       'Reopens in 2h',
     );

--- a/packages/kit/src/views/Market/components/StockMarketStatusAlert/getStockMarketClosedDescription.test.ts
+++ b/packages/kit/src/views/Market/components/StockMarketStatusAlert/getStockMarketClosedDescription.test.ts
@@ -1,0 +1,45 @@
+import {
+  getStockMarketClosedDescription,
+  stripTrailingSentencePunctuation,
+} from './getStockMarketClosedDescription';
+
+describe('getStockMarketClosedDescription', () => {
+  it('returns the first non-empty line', () => {
+    expect(
+      getStockMarketClosedDescription('Reopens in 2h\nProvider description'),
+    ).toBe('Reopens in 2h');
+    expect(getStockMarketClosedDescription('\n\n  Reopens in 2h  \nrest')).toBe(
+      'Reopens in 2h',
+    );
+  });
+
+  it('treats empty or ondo blurbs as no countdown', () => {
+    expect(getStockMarketClosedDescription(undefined)).toBeUndefined();
+    expect(getStockMarketClosedDescription('')).toBeUndefined();
+    expect(
+      getStockMarketClosedDescription('Ondo tokenized stocks trade 7x24'),
+    ).toBeUndefined();
+  });
+});
+
+describe('stripTrailingSentencePunctuation', () => {
+  it('strips CJK and Latin sentence-ending punctuation (OK-58554)', () => {
+    expect(
+      stripTrailingSentencePunctuation('该股票目前停牌，暂时无法交易。'),
+    ).toBe('该股票目前停牌，暂时无法交易');
+    expect(
+      stripTrailingSentencePunctuation(
+        'This stock is currently halted and cannot be traded.',
+      ),
+    ).toBe('This stock is currently halted and cannot be traded');
+  });
+
+  it('keeps countdown lines without trailing punctuation unchanged', () => {
+    expect(
+      stripTrailingSentencePunctuation('美国股票市场将于 9h 24m 后开盘'),
+    ).toBe('美国股票市场将于 9h 24m 后开盘');
+    expect(stripTrailingSentencePunctuation('Reopens in 2h')).toBe(
+      'Reopens in 2h',
+    );
+  });
+});

--- a/packages/kit/src/views/Market/components/StockMarketStatusAlert/getStockMarketClosedDescription.ts
+++ b/packages/kit/src/views/Market/components/StockMarketStatusAlert/getStockMarketClosedDescription.ts
@@ -19,3 +19,15 @@ export function getStockMarketClosedDescription(reason?: string | null) {
 
   return firstLine;
 }
+
+/**
+ * Backend descriptions can be full sentences ending with sentence punctuation
+ * (e.g. a halted stock's "该股票目前停牌，暂时无法交易。"), while the `{time}`
+ * templates supply their own separator ("{time}，您仍然可以…"). Strip the
+ * trailing punctuation before interpolating so the result never renders a
+ * doubled "。，" / ".," (OK-58554). Countdown lines have no trailing
+ * punctuation, so this is a no-op for them.
+ */
+export function stripTrailingSentencePunctuation(text: string): string {
+  return text.replace(/[。．.！!？?，,、；;：:]+$/u, '');
+}

--- a/packages/kit/src/views/Market/components/StockMarketStatusAlert/resolveStockMarketStatusCase.test.ts
+++ b/packages/kit/src/views/Market/components/StockMarketStatusAlert/resolveStockMarketStatusCase.test.ts
@@ -63,4 +63,44 @@ describe('resolveStockMarketStatusCase', () => {
       }),
     ).toBe(EStockMarketStatusCase.ClosedUnknownTimeWithPerps);
   });
+
+  it('case 5: per-stock halt wins over every closed/open combination (OK-58655)', () => {
+    expect(
+      resolveStockMarketStatusCase({
+        isOpen: false,
+        isPaused: true,
+        hasOpenTime: true,
+        hasPerps: true,
+      }),
+    ).toBe(EStockMarketStatusCase.Halted);
+    // A halt is about the stock, not the market schedule — it applies even
+    // while the market itself is open.
+    expect(
+      resolveStockMarketStatusCase({
+        isOpen: true,
+        isPaused: true,
+        hasOpenTime: false,
+        hasPerps: false,
+      }),
+    ).toBe(EStockMarketStatusCase.Halted);
+  });
+
+  it('only an explicit isPaused === true yields Halted', () => {
+    expect(
+      resolveStockMarketStatusCase({
+        isOpen: false,
+        isPaused: undefined,
+        hasOpenTime: true,
+        hasPerps: true,
+      }),
+    ).toBe(EStockMarketStatusCase.ClosedKnownTimeWithPerps);
+    expect(
+      resolveStockMarketStatusCase({
+        isOpen: false,
+        isPaused: false,
+        hasOpenTime: false,
+        hasPerps: false,
+      }),
+    ).toBe(EStockMarketStatusCase.ClosedUnknownTimeNoPerps);
+  });
 });

--- a/packages/kit/src/views/Market/components/StockMarketStatusAlert/resolveStockMarketStatusCase.ts
+++ b/packages/kit/src/views/Market/components/StockMarketStatusAlert/resolveStockMarketStatusCase.ts
@@ -22,10 +22,6 @@ export function isStockMarketClosed(stock?: IMarketStockInfo): boolean {
  * presentation (see `StockMarketStatusAlert`) stays consistent and reusable
  * across modules (Swap stock panel, Market detail, etc.). Keep the logic here —
  * do not re-derive cases ad hoc at each call site.
- *
- * NOTE: case 5 (Halted/Suspended) is intentionally NOT produced yet — the
- * backend does not return a halted signal today. The enum value is reserved and
- * commented so adding it later is a localized change.
  */
 export enum EStockMarketStatusCase {
   /** Market is open (or status unknown/unavailable) — no closed-status alert. */
@@ -38,11 +34,17 @@ export enum EStockMarketStatusCase {
   ClosedUnknownTimeNoPerps = 'closedUnknownTimeNoPerps',
   /** 4. Closed, next-open time unknown, has a Perps equivalent → wait, but can trade Perps. */
   ClosedUnknownTimeWithPerps = 'closedUnknownTimeWithPerps',
-  // 5. Halted = 'halted' — reserved. Backend halted/suspended signal pending.
+  /**
+   * 5. The individual stock is halted/suspended (`stock.isPaused`, OK-58655).
+   * Overlays the closed cases — a halt is about THIS stock, not the market
+   * schedule, so it wins regardless of open state or countdown.
+   */
+  Halted = 'halted',
 }
 
 export function resolveStockMarketStatusCase({
   isOpen,
+  isPaused,
   hasOpenTime,
   hasPerps,
 }: {
@@ -52,11 +54,16 @@ export function resolveStockMarketStatusCase({
    * "unavailable" is a separate concern the caller handles before calling this.
    */
   isOpen?: boolean;
+  /** `tokenDetail.stock.isPaused`. Only an explicit `true` means halted. */
+  isPaused?: boolean;
   /** Do we know the next market-open time? (e.g. backend gave a countdown.) */
   hasOpenTime: boolean;
   /** Does the same underlying have a Perps equivalent (`perpsInfo.hlTicker`)? */
   hasPerps: boolean;
 }): EStockMarketStatusCase {
+  if (isPaused === true) {
+    return EStockMarketStatusCase.Halted;
+  }
   if (isOpen !== false) {
     return EStockMarketStatusCase.Open;
   }

--- a/packages/kit/src/views/Swap/pages/components/SwapProContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProContainer.tsx
@@ -348,6 +348,7 @@ const SwapProContainer = ({
         <StockMarketStatusAlert
           statusCase={resolveStockMarketStatusCase({
             isOpen: false,
+            isPaused: proTokenDetail?.stock?.isPaused,
             hasOpenTime: Boolean(proStockClosedTimeText),
             hasPerps: proStockHasPerps,
           })}

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteStockMarketStatusAlert.test.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteStockMarketStatusAlert.test.tsx
@@ -25,6 +25,7 @@ type IMockStockTokenDetailResult = {
     stock?: {
       description?: string;
       isOpen?: boolean;
+      isPaused?: boolean;
     };
   };
 };
@@ -32,8 +33,12 @@ const mockStockMarketStatusAlert = jest.fn(
   (_props: IMockStockMarketStatusAlertProps) => null,
 );
 const mockResolveStockMarketStatusCase = jest.fn(
-  (params: { hasOpenTime: boolean; hasPerps: boolean; isOpen?: boolean }) =>
-    JSON.stringify(params),
+  (params: {
+    hasOpenTime: boolean;
+    hasPerps: boolean;
+    isOpen?: boolean;
+    isPaused?: boolean;
+  }) => JSON.stringify(params),
 );
 const mockUseSwapStockTokenDetail = jest.fn(
   (_params: IMockStockTokenDetailParams): IMockStockTokenDetailResult => ({
@@ -92,6 +97,7 @@ jest.mock(
       hasOpenTime: boolean;
       hasPerps: boolean;
       isOpen?: boolean;
+      isPaused?: boolean;
     }) => mockResolveStockMarketStatusCase(params),
   }),
 );
@@ -262,6 +268,31 @@ describe('SwapQuoteStockMarketStatusAlert', () => {
     expect(mockStockMarketStatusAlert.mock.calls[0]?.[0].timeText).toBe(
       'Reopens in 2h',
     );
+  });
+
+  it('forwards the per-stock halt signal to the case resolver (OK-58655)', () => {
+    mockStockDetailResult = {
+      pending: false,
+      perpsInfo: {
+        hlTicker: 'AAPL',
+      },
+      tokenDetail: {
+        stock: {
+          description: 'This stock is currently halted.\nProvider description',
+          isOpen: false,
+          isPaused: true,
+        },
+      },
+    };
+
+    render(<SwapQuoteStockMarketStatusAlert onMarketReopen={jest.fn()} />);
+
+    expect(mockResolveStockMarketStatusCase).toHaveBeenCalledWith({
+      hasOpenTime: true,
+      hasPerps: true,
+      isOpen: false,
+      isPaused: true,
+    });
   });
 
   it('falls back to a generic closed alert after Market detail settles empty', () => {

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteStockMarketStatusAlert.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteStockMarketStatusAlert.tsx
@@ -104,6 +104,7 @@ export function SwapQuoteStockMarketStatusAlert({
     <StockMarketStatusAlert
       statusCase={resolveStockMarketStatusCase({
         isOpen: false,
+        isPaused: stockDetail?.tokenDetail?.stock?.isPaused,
         hasOpenTime: Boolean(closedTimeText),
         hasPerps: Boolean(hlTicker),
       })}

--- a/packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.tsx
@@ -266,6 +266,7 @@ function BasicSwapStockTradeAlert({
     );
     const statusCase = resolveStockMarketStatusCase({
       isOpen: false,
+      isPaused: stockChannel.activeStockTokenDetail?.stock?.isPaused,
       hasOpenTime: Boolean(closedTimeText),
       hasPerps,
     });

--- a/packages/shared/src/utils/tradingHoursUtils.test.ts
+++ b/packages/shared/src/utils/tradingHoursUtils.test.ts
@@ -111,10 +111,24 @@ describe('getUSMarketTradingHours', () => {
     expect(gapMinutes).toEqual([1, 1, 5]);
   });
 
-  it('resolves a now inside an inter-session gap to the upcoming session', () => {
+  it('flags a now inside an inter-session gap', () => {
     // 14:30:30 UTC = 09:30:30 EST — between pre-market end and regular start
     const res = getUSMarketTradingHours(new Date('2026-01-15T14:30:30Z'));
+    expect(res.isNowInSessionGap).toBe(true);
     expect(res.currentSessionKey).toBe(EUSMarketSessionKey.Regular);
+    // Mid-session times are not gaps
+    expect(
+      getUSMarketTradingHours(new Date('2026-01-15T15:00:00Z'))
+        .isNowInSessionGap,
+    ).toBe(false);
+  });
+
+  it('flags the overnight-to-pre-market gap at the cycle edge', () => {
+    // 2026-01-16 08:58 UTC = 03:58 EST — after the 03:56 overnight close and
+    // before the 04:01 pre-market open
+    const res = getUSMarketTradingHours(new Date('2026-01-16T08:58:00Z'));
+    expect(res.isNowInSessionGap).toBe(true);
+    expect(res.cycleStartInstant).toBe(Date.parse('2026-01-15T09:01:00Z'));
   });
 });
 
@@ -278,6 +292,28 @@ describe('resolveUSMarketStatusVariant', () => {
     ).toBe(EUSMarketStatusVariant.ClosedTradable);
   });
 
+  it('marks inter-session gaps as halted', () => {
+    // 14:30:30 UTC = 09:30:30 EST — the opening-cross switch window
+    const gapNow = new Date('2026-01-15T14:30:30Z');
+    // Clock gap overrides the backend session refinement…
+    expect(
+      resolveUSMarketStatusVariant({
+        source: ondo,
+        isOpen: true,
+        status: status('REGULAR'),
+        now: gapNow,
+      }),
+    ).toBe(EUSMarketStatusVariant.Halted);
+    // …and applies on the pure clock fallback as well.
+    expect(
+      resolveUSMarketStatusVariant({
+        source: ondo,
+        isOpen: true,
+        now: gapNow,
+      }),
+    ).toBe(EUSMarketStatusVariant.Halted);
+  });
+
   it('falls back to clock math when the status API is unavailable', () => {
     // Sat 2026-01-17 15:00 UTC is inside the weekend window → ClosedTradable
     expect(
@@ -375,5 +411,28 @@ describe('resolveUSTradingHoursActiveRow', () => {
         now: weekendNow,
       }),
     ).toBe('closed');
+  });
+
+  it('highlights the halts row during inter-session gaps', () => {
+    // 14:30:30 UTC = 09:30:30 EST — the opening-cross switch window
+    const gapNow = new Date('2026-01-15T14:30:30Z');
+    const gapHours = getUSMarketTradingHours(gapNow);
+    // Clock gap overrides the backend session refinement…
+    expect(
+      resolveUSTradingHoursActiveRow({
+        isOpen: true,
+        status: status('REGULAR'),
+        tradingHours: gapHours,
+        now: gapNow,
+      }),
+    ).toBe('halts');
+    // …and applies on the pure clock fallback as well.
+    expect(
+      resolveUSTradingHoursActiveRow({
+        isOpen: true,
+        tradingHours: gapHours,
+        now: gapNow,
+      }),
+    ).toBe('halts');
   });
 });

--- a/packages/shared/src/utils/tradingHoursUtils.test.ts
+++ b/packages/shared/src/utils/tradingHoursUtils.test.ts
@@ -12,6 +12,9 @@ import {
 import type { IFetchUSMarketStatusResult } from '../../types/swap/types';
 
 const HOUR = 60 * 60 * 1000;
+const MINUTE = 60 * 1000;
+// 09:30:30 EST — inside the opening-cross gap between pre-market and regular
+const GAP_NOW = new Date('2026-01-15T14:30:30Z');
 
 describe('getUSMarketTradingHours', () => {
   it('computes EST (winter) cycle boundaries as UTC instants', () => {
@@ -105,15 +108,12 @@ describe('getUSMarketTradingHours', () => {
     // 09:30 (opening cross), 16:00 and 20:00–20:04 ET belong to no session
     const gapMinutes = res.segments
       .slice(1)
-      .map(
-        (s, i) => (s.startInstant - res.segments[i].endInstant) / (60 * 1000),
-      );
+      .map((s, i) => (s.startInstant - res.segments[i].endInstant) / MINUTE);
     expect(gapMinutes).toEqual([1, 1, 5]);
   });
 
   it('flags a now inside an inter-session gap', () => {
-    // 14:30:30 UTC = 09:30:30 EST — between pre-market end and regular start
-    const res = getUSMarketTradingHours(new Date('2026-01-15T14:30:30Z'));
+    const res = getUSMarketTradingHours(GAP_NOW);
     expect(res.isNowInSessionGap).toBe(true);
     expect(res.currentSessionKey).toBe(EUSMarketSessionKey.Regular);
     // Mid-session times are not gaps
@@ -293,15 +293,13 @@ describe('resolveUSMarketStatusVariant', () => {
   });
 
   it('marks inter-session gaps as halted', () => {
-    // 14:30:30 UTC = 09:30:30 EST — the opening-cross switch window
-    const gapNow = new Date('2026-01-15T14:30:30Z');
     // Clock gap overrides the backend session refinement…
     expect(
       resolveUSMarketStatusVariant({
         source: ondo,
         isOpen: true,
         status: status('REGULAR'),
-        now: gapNow,
+        now: GAP_NOW,
       }),
     ).toBe(EUSMarketStatusVariant.Halted);
     // …and applies on the pure clock fallback as well.
@@ -309,7 +307,7 @@ describe('resolveUSMarketStatusVariant', () => {
       resolveUSMarketStatusVariant({
         source: ondo,
         isOpen: true,
-        now: gapNow,
+        now: GAP_NOW,
       }),
     ).toBe(EUSMarketStatusVariant.Halted);
   });
@@ -414,16 +412,14 @@ describe('resolveUSTradingHoursActiveRow', () => {
   });
 
   it('highlights the halts row during inter-session gaps', () => {
-    // 14:30:30 UTC = 09:30:30 EST — the opening-cross switch window
-    const gapNow = new Date('2026-01-15T14:30:30Z');
-    const gapHours = getUSMarketTradingHours(gapNow);
+    const gapHours = getUSMarketTradingHours(GAP_NOW);
     // Clock gap overrides the backend session refinement…
     expect(
       resolveUSTradingHoursActiveRow({
         isOpen: true,
         status: status('REGULAR'),
         tradingHours: gapHours,
-        now: gapNow,
+        now: GAP_NOW,
       }),
     ).toBe('halts');
     // …and applies on the pure clock fallback as well.
@@ -431,7 +427,7 @@ describe('resolveUSTradingHoursActiveRow', () => {
       resolveUSTradingHoursActiveRow({
         isOpen: true,
         tradingHours: gapHours,
-        now: gapNow,
+        now: GAP_NOW,
       }),
     ).toBe('halts');
   });

--- a/packages/shared/src/utils/tradingHoursUtils.test.ts
+++ b/packages/shared/src/utils/tradingHoursUtils.test.ts
@@ -17,55 +17,66 @@ describe('getUSMarketTradingHours', () => {
   it('computes EST (winter) cycle boundaries as UTC instants', () => {
     // 2026-01-15 (Thu) 15:00 UTC = 10:00 EST → regular session
     const res = getUSMarketTradingHours(new Date('2026-01-15T15:00:00Z'));
-    expect(res.cycleStartInstant).toBe(Date.parse('2026-01-15T09:00:00Z'));
-    expect(res.cycleEndInstant).toBe(Date.parse('2026-01-16T09:00:00Z'));
+    expect(res.cycleStartInstant).toBe(Date.parse('2026-01-15T09:01:00Z'));
+    expect(res.cycleEndInstant).toBe(Date.parse('2026-01-16T08:56:00Z'));
     expect(res.segments.map((s) => s.startInstant)).toEqual([
-      Date.parse('2026-01-15T09:00:00Z'),
-      Date.parse('2026-01-15T14:30:00Z'),
-      Date.parse('2026-01-15T21:00:00Z'),
-      Date.parse('2026-01-16T01:00:00Z'),
+      Date.parse('2026-01-15T09:01:00Z'), // 04:01 EST
+      Date.parse('2026-01-15T14:31:00Z'), // 09:31 EST
+      Date.parse('2026-01-15T21:01:00Z'), // 16:01 EST
+      Date.parse('2026-01-16T01:05:00Z'), // 20:05 EST
+    ]);
+    expect(res.segments.map((s) => s.endInstant)).toEqual([
+      Date.parse('2026-01-15T14:30:00Z'), // 09:30 EST → renders 09:29
+      Date.parse('2026-01-15T21:00:00Z'), // 16:00 EST → renders 15:59
+      Date.parse('2026-01-16T01:00:00Z'), // 20:00 EST → renders 19:59
+      Date.parse('2026-01-16T08:56:00Z'), // 03:56 EST → renders 03:55
     ]);
     expect(res.currentSessionKey).toBe(EUSMarketSessionKey.Regular);
-    expect(res.nowRatio).toBeCloseTo(0.25, 10);
+    // Cycle 04:01 → 03:56 next day = 1435 min; now offset = 359 min
+    expect(res.nowRatio).toBeCloseTo(359 / 1435, 10);
     expect(res.segments.map((s) => s.ratio)).toEqual([
-      5.5 / 24,
-      6.5 / 24,
-      4 / 24,
-      8 / 24,
+      329 / 1435,
+      389 / 1435,
+      239 / 1435,
+      471 / 1435,
     ]);
   });
 
   it('attributes early-morning ET hours to the previous cycle day', () => {
-    // 07:00 UTC = 02:00 EST (before the 04:00 anchor) → cycle of Jan 14
+    // 07:00 UTC = 02:00 EST (before the 04:01 anchor) → cycle of Jan 14
     const res = getUSMarketTradingHours(new Date('2026-01-15T07:00:00Z'));
-    expect(res.cycleStartInstant).toBe(Date.parse('2026-01-14T09:00:00Z'));
+    expect(res.cycleStartInstant).toBe(Date.parse('2026-01-14T09:01:00Z'));
     expect(res.currentSessionKey).toBe(EUSMarketSessionKey.Overnight);
   });
 
   it('uses EDT offsets in summer', () => {
     // 2026-07-15 15:00 UTC = 11:00 EDT → regular session
     const res = getUSMarketTradingHours(new Date('2026-07-15T15:00:00Z'));
-    expect(res.cycleStartInstant).toBe(Date.parse('2026-07-15T08:00:00Z'));
+    expect(res.cycleStartInstant).toBe(Date.parse('2026-07-15T08:01:00Z'));
     expect(res.currentSessionKey).toBe(EUSMarketSessionKey.Regular);
   });
 
-  it('produces a 23h cycle across the spring-forward transition', () => {
-    // Cycle anchored 2026-03-07 04:00 EST; DST starts 2026-03-08 02:00 ET
+  it('produces a shortened cycle across the spring-forward transition', () => {
+    // Cycle anchored 2026-03-07 04:01 EST; DST starts 2026-03-08 02:00 ET
     const res = getUSMarketTradingHours(new Date('2026-03-07T15:00:00Z'));
-    expect(res.cycleStartInstant).toBe(Date.parse('2026-03-07T09:00:00Z'));
-    expect(res.cycleEndInstant).toBe(Date.parse('2026-03-08T08:00:00Z'));
+    expect(res.cycleStartInstant).toBe(Date.parse('2026-03-07T09:01:00Z'));
+    // Overnight close 03:56 is EDT after the 1h jump → cycle is 22h55m long
+    expect(res.cycleEndInstant).toBe(Date.parse('2026-03-08T07:56:00Z'));
     const overnight = res.segments[3];
-    expect(overnight.startInstant).toBe(Date.parse('2026-03-08T01:00:00Z'));
-    expect(overnight.ratio).toBeCloseTo(7 / 23, 10);
+    expect(overnight.startInstant).toBe(Date.parse('2026-03-08T01:05:00Z'));
+    // 20:05 EST → 03:56 EDT spans 411 real minutes of a 1375-minute cycle
+    expect(overnight.ratio).toBeCloseTo(411 / 1375, 10);
     const ratioSum = res.segments.reduce((acc, s) => acc + s.ratio, 0);
-    expect(ratioSum).toBeCloseTo(1, 10);
+    // 7 minutes of inter-session gaps stay outside every segment
+    expect(ratioSum).toBeCloseTo(1368 / 1375, 10);
   });
 
-  it('produces a 25h cycle across the fall-back transition', () => {
-    // Cycle anchored 2026-10-31 04:00 EDT; DST ends 2026-11-01 02:00 ET
+  it('produces a lengthened cycle across the fall-back transition', () => {
+    // Cycle anchored 2026-10-31 04:01 EDT; DST ends 2026-11-01 02:00 ET
     const res = getUSMarketTradingHours(new Date('2026-10-31T15:00:00Z'));
-    expect(res.cycleStartInstant).toBe(Date.parse('2026-10-31T08:00:00Z'));
-    expect(res.cycleEndInstant).toBe(Date.parse('2026-11-01T09:00:00Z'));
+    expect(res.cycleStartInstant).toBe(Date.parse('2026-10-31T08:01:00Z'));
+    // Overnight close 03:56 is EST after the 1h repeat → cycle is 24h55m long
+    expect(res.cycleEndInstant).toBe(Date.parse('2026-11-01T08:56:00Z'));
   });
 
   it('computes the upcoming weekend window on a weekday', () => {
@@ -83,7 +94,7 @@ describe('getUSMarketTradingHours', () => {
     expect(res.weekendEndInstant - res.weekendStartInstant).toBe(47 * HOUR);
   });
 
-  it('keeps every boundary aligned with session order', () => {
+  it('keeps every boundary aligned with session order, with fixed gaps', () => {
     const res = getUSMarketTradingHours(new Date('2026-01-15T15:00:00Z'));
     expect(res.segments.map((s) => s.key)).toEqual([
       EUSMarketSessionKey.PreMarket,
@@ -91,9 +102,19 @@ describe('getUSMarketTradingHours', () => {
       EUSMarketSessionKey.PostMarket,
       EUSMarketSessionKey.Overnight,
     ]);
-    for (let i = 1; i < res.segments.length; i += 1) {
-      expect(res.segments[i].startInstant).toBe(res.segments[i - 1].endInstant);
-    }
+    // 09:30 (opening cross), 16:00 and 20:00–20:04 ET belong to no session
+    const gapMinutes = res.segments
+      .slice(1)
+      .map(
+        (s, i) => (s.startInstant - res.segments[i].endInstant) / (60 * 1000),
+      );
+    expect(gapMinutes).toEqual([1, 1, 5]);
+  });
+
+  it('resolves a now inside an inter-session gap to the upcoming session', () => {
+    // 14:30:30 UTC = 09:30:30 EST — between pre-market end and regular start
+    const res = getUSMarketTradingHours(new Date('2026-01-15T14:30:30Z'));
+    expect(res.currentSessionKey).toBe(EUSMarketSessionKey.Regular);
   });
 });
 

--- a/packages/shared/src/utils/tradingHoursUtils.ts
+++ b/packages/shared/src/utils/tradingHoursUtils.ts
@@ -24,6 +24,7 @@ import type { IFetchUSMarketStatusResult } from '../../types/swap/types';
 
 const NY_TIME_ZONE = 'America/New_York';
 const MINUTE_MS = 60 * 1000;
+const MINUTES_PER_DAY = 24 * 60;
 
 export enum EUSMarketSessionKey {
   PreMarket = 'preMarket',
@@ -60,7 +61,7 @@ const SESSIONS_ET_MINUTES: Array<{
   {
     key: EUSMarketSessionKey.Overnight,
     startMinutes: 20 * 60 + 5,
-    endMinutes: 24 * 60 + 3 * 60 + 56,
+    endMinutes: MINUTES_PER_DAY + 3 * 60 + 56,
   },
 ];
 const CYCLE_START_ET_MINUTES = SESSIONS_ET_MINUTES[0].startMinutes;
@@ -242,9 +243,10 @@ export interface IUSMarketTradingHours {
    */
   currentSessionKey: EUSMarketSessionKey;
   /**
-   * True when `now` falls between two sessions (e.g. 03:56 – 04:00 ET):
-   * the underlying venues pause trading while switching session state, so
-   * these minutes surface as a market-wide trading halt.
+   * True when `now` falls between two sessions (e.g. after the 03:55
+   * overnight close and before the 04:01 pre-market open): the underlying
+   * venues pause trading while switching session state, so these minutes
+   * surface as a market-wide trading halt.
    */
   isNowInSessionGap: boolean;
   /** Current-or-upcoming weekend closure: Friday 20:00 ET */
@@ -277,8 +279,11 @@ export function getUSMarketTradingHours(
   const nextDate = shiftNyDate(cycleDate, 1);
 
   const minutesToInstant = (minutes: number) =>
-    minutes >= 24 * 60
-      ? nyWallClockToInstant({ ...nextDate, minutesOfDay: minutes - 24 * 60 })
+    minutes >= MINUTES_PER_DAY
+      ? nyWallClockToInstant({
+          ...nextDate,
+          minutesOfDay: minutes - MINUTES_PER_DAY,
+        })
       : nyWallClockToInstant({ ...cycleDate, minutesOfDay: minutes });
 
   const instants = SESSIONS_ET_MINUTES.map(
@@ -310,9 +315,10 @@ export function getUSMarketTradingHours(
   const currentSegment =
     segments.find((s) => clampedNow < s.endInstant) ??
     segments[segments.length - 1];
-  const isNowInSessionGap = !segments.some(
-    (s) => nowMs >= s.startInstant && nowMs < s.endInstant,
-  );
+  // In a gap, `now` sits before the upcoming session's start (mid-cycle gaps)
+  // or past the overnight close (the cycle-edge gap).
+  const isNowInSessionGap =
+    nowMs < currentSegment.startInstant || nowMs >= currentSegment.endInstant;
 
   // Weekend closure runs Friday 20:00 ET → Sunday 20:00 ET. Pick the ongoing
   // weekend when the cycle day sits inside one, otherwise the upcoming one.
@@ -490,11 +496,13 @@ export function resolveUSMarketStatusVariant({
         return EUSMarketStatusVariant.Open;
     }
   };
-  const tradingHours = getUSMarketTradingHours(now);
+  // The cycle computation below is Intl-heavy — keep it off the early-return
+  // paths above and compute it only where a session/gap decision is needed.
   if (status && !status.unavailable) {
     if (!status.open || status.session === 'CLOSED') {
       return EUSMarketStatusVariant.ClosedTradable;
     }
+    const tradingHours = getUSMarketTradingHours(now);
     // Inter-session gap: the underlying venues pause trading while switching
     // session state (OK-58509), overriding the backend session refinement.
     if (tradingHours.isNowInSessionGap) {
@@ -505,6 +513,7 @@ export function resolveUSMarketStatusVariant({
     // clock session, matching resolveUSTradingHoursActiveRow.
     return sessionKeyToVariant(sessionKey ?? tradingHours.currentSessionKey);
   }
+  const tradingHours = getUSMarketTradingHours(now);
   const nowMs = now.getTime();
   if (
     nowMs >= tradingHours.weekendStartInstant &&
@@ -512,6 +521,7 @@ export function resolveUSMarketStatusVariant({
   ) {
     return EUSMarketStatusVariant.ClosedTradable;
   }
+  // Same gap-to-halt rule as the status branch above.
   if (tradingHours.isNowInSessionGap) {
     return EUSMarketStatusVariant.Halted;
   }

--- a/packages/shared/src/utils/tradingHoursUtils.ts
+++ b/packages/shared/src/utils/tradingHoursUtils.ts
@@ -5,14 +5,20 @@ import type { IFetchUSMarketStatusResult } from '../../types/swap/types';
  * time (the single source of truth per OK-58043). All local rendering must be
  * derived from these constants — never hardcode a user-local time.
  *
- *   Pre-market  04:00 – 09:29 ET
- *   Regular     09:30 – 15:59 ET
- *   Post-market 16:00 – 19:59 ET
- *   Overnight   20:00 – 03:59 ET (next day)
+ * Ranges follow the venue's published windows (OK-58509, aligned with OKX):
  *
- * A "cycle" is one full 24h loop anchored at 04:00 ET. On DST transition days
- * a cycle is 23h/25h long; ratios are computed from real instants so segment
- * widths stay proportional.
+ *   Pre-market  04:01 – 09:29 ET
+ *   Regular     09:31 – 15:59 ET
+ *   Post-market 16:01 – 19:59 ET
+ *   Overnight   20:05 – 03:55 ET (next day)
+ *
+ * Sessions are NOT contiguous: the minutes between them (e.g. 09:30, the
+ * opening cross) belong to no session and are rendered as part of neither
+ * range.
+ *
+ * A "cycle" is one full loop from the pre-market open to the overnight close
+ * the next ET day. On DST transition days a cycle is ±1h long; ratios are
+ * computed from real instants so segment widths stay proportional.
  */
 
 const NY_TIME_ZONE = 'America/New_York';
@@ -25,17 +31,38 @@ export enum EUSMarketSessionKey {
   Overnight = 'overnight',
 }
 
-/** Session boundaries as minutes since ET midnight, in cycle order. */
-const SESSION_STARTS_ET_MINUTES: Array<{
+/**
+ * Session boundaries as minutes since ET midnight, in cycle order. Ends are
+ * exclusive (a `09:30` end renders as `09:29`); a value ≥ 24h means the
+ * session closes on the next ET calendar day.
+ */
+const SESSIONS_ET_MINUTES: Array<{
   key: EUSMarketSessionKey;
   startMinutes: number;
+  endMinutes: number;
 }> = [
-  { key: EUSMarketSessionKey.PreMarket, startMinutes: 4 * 60 },
-  { key: EUSMarketSessionKey.Regular, startMinutes: 9 * 60 + 30 },
-  { key: EUSMarketSessionKey.PostMarket, startMinutes: 16 * 60 },
-  { key: EUSMarketSessionKey.Overnight, startMinutes: 20 * 60 },
+  {
+    key: EUSMarketSessionKey.PreMarket,
+    startMinutes: 4 * 60 + 1,
+    endMinutes: 9 * 60 + 30,
+  },
+  {
+    key: EUSMarketSessionKey.Regular,
+    startMinutes: 9 * 60 + 31,
+    endMinutes: 16 * 60,
+  },
+  {
+    key: EUSMarketSessionKey.PostMarket,
+    startMinutes: 16 * 60 + 1,
+    endMinutes: 20 * 60,
+  },
+  {
+    key: EUSMarketSessionKey.Overnight,
+    startMinutes: 20 * 60 + 5,
+    endMinutes: 24 * 60 + 3 * 60 + 56,
+  },
 ];
-const CYCLE_START_ET_MINUTES = SESSION_STARTS_ET_MINUTES[0].startMinutes;
+const CYCLE_START_ET_MINUTES = SESSIONS_ET_MINUTES[0].startMinutes;
 
 interface INyWallClock {
   year: number;
@@ -201,13 +228,16 @@ export interface IUSMarketSessionSegment {
 }
 
 export interface IUSMarketTradingHours {
-  /** Segments in cycle order: pre → regular → post → overnight */
+  /** Segments in cycle order: pre → regular → post → overnight (with gaps) */
   segments: IUSMarketSessionSegment[];
   cycleStartInstant: number;
   cycleEndInstant: number;
   /** Position of `now` within the cycle, 0..1 */
   nowRatio: number;
-  /** Session containing `now` by pure clock math (ignores holidays/halts) */
+  /**
+   * Session containing `now` by pure clock math (ignores holidays/halts).
+   * A `now` inside an inter-session gap resolves to the upcoming session.
+   */
   currentSessionKey: EUSMarketSessionKey;
   /** Current-or-upcoming weekend closure: Friday 20:00 ET */
   weekendStartInstant: number;
@@ -226,7 +256,8 @@ export function getUSMarketTradingHours(
   const nowMs = now.getTime();
   const nowNy = getNyWallClock(nowMs);
 
-  // The cycle day is the ET calendar date whose 04:00 anchor precedes `now`.
+  // The cycle day is the ET calendar date whose pre-market anchor (04:01)
+  // precedes `now`.
   let cycleDate = {
     year: nowNy.year,
     month: nowNy.month,
@@ -237,25 +268,28 @@ export function getUSMarketTradingHours(
   }
   const nextDate = shiftNyDate(cycleDate, 1);
 
-  const boundaries: number[] = [
-    ...SESSION_STARTS_ET_MINUTES.map(({ startMinutes }) =>
-      nyWallClockToInstant({ ...cycleDate, minutesOfDay: startMinutes }),
-    ),
-    nyWallClockToInstant({
-      ...nextDate,
-      minutesOfDay: CYCLE_START_ET_MINUTES,
+  const minutesToInstant = (minutes: number) =>
+    minutes >= 24 * 60
+      ? nyWallClockToInstant({ ...nextDate, minutesOfDay: minutes - 24 * 60 })
+      : nyWallClockToInstant({ ...cycleDate, minutesOfDay: minutes });
+
+  const instants = SESSIONS_ET_MINUTES.map(
+    ({ key, startMinutes, endMinutes }) => ({
+      key,
+      startInstant: minutesToInstant(startMinutes),
+      endInstant: minutesToInstant(endMinutes),
     }),
-  ];
-  const cycleStartInstant = boundaries[0];
-  const cycleEndInstant = boundaries[boundaries.length - 1];
+  );
+  const cycleStartInstant = instants[0].startInstant;
+  const cycleEndInstant = instants[instants.length - 1].endInstant;
   const cycleDuration = cycleEndInstant - cycleStartInstant;
 
-  const segments: IUSMarketSessionSegment[] = SESSION_STARTS_ET_MINUTES.map(
-    ({ key }, i) => ({
+  const segments: IUSMarketSessionSegment[] = instants.map(
+    ({ key, startInstant, endInstant }) => ({
       key,
-      startInstant: boundaries[i],
-      endInstant: boundaries[i + 1],
-      ratio: (boundaries[i + 1] - boundaries[i]) / cycleDuration,
+      startInstant,
+      endInstant,
+      ratio: (endInstant - startInstant) / cycleDuration,
     }),
   );
 
@@ -263,10 +297,11 @@ export function getUSMarketTradingHours(
     Math.max(nowMs, cycleStartInstant),
     cycleEndInstant - 1,
   );
+  // Sessions are not contiguous — a `now` inside an inter-session gap
+  // resolves to the upcoming session.
   const currentSegment =
-    segments.find(
-      (s) => clampedNow >= s.startInstant && clampedNow < s.endInstant,
-    ) ?? segments[segments.length - 1];
+    segments.find((s) => clampedNow < s.endInstant) ??
+    segments[segments.length - 1];
 
   // Weekend closure runs Friday 20:00 ET → Sunday 20:00 ET. Pick the ongoing
   // weekend when the cycle day sits inside one, otherwise the upcoming one.

--- a/packages/shared/src/utils/tradingHoursUtils.ts
+++ b/packages/shared/src/utils/tradingHoursUtils.ts
@@ -13,8 +13,9 @@ import type { IFetchUSMarketStatusResult } from '../../types/swap/types';
  *   Overnight   20:05 – 03:55 ET (next day)
  *
  * Sessions are NOT contiguous: the minutes between them (e.g. 09:30, the
- * opening cross) belong to no session and are rendered as part of neither
- * range.
+ * opening cross) belong to no session — the underlying venues pause trading
+ * while switching session state, so the UI surfaces those windows as trading
+ * halts.
  *
  * A "cycle" is one full loop from the pre-market open to the overnight close
  * the next ET day. On DST transition days a cycle is ±1h long; ratios are
@@ -236,9 +237,16 @@ export interface IUSMarketTradingHours {
   nowRatio: number;
   /**
    * Session containing `now` by pure clock math (ignores holidays/halts).
-   * A `now` inside an inter-session gap resolves to the upcoming session.
+   * A `now` inside an inter-session gap resolves to the upcoming session —
+   * check `isNowInSessionGap` to tell the two cases apart.
    */
   currentSessionKey: EUSMarketSessionKey;
+  /**
+   * True when `now` falls between two sessions (e.g. 03:56 – 04:00 ET):
+   * the underlying venues pause trading while switching session state, so
+   * these minutes surface as a market-wide trading halt.
+   */
+  isNowInSessionGap: boolean;
   /** Current-or-upcoming weekend closure: Friday 20:00 ET */
   weekendStartInstant: number;
   /** Weekend closure end: Sunday 20:00 ET */
@@ -302,6 +310,9 @@ export function getUSMarketTradingHours(
   const currentSegment =
     segments.find((s) => clampedNow < s.endInstant) ??
     segments[segments.length - 1];
+  const isNowInSessionGap = !segments.some(
+    (s) => nowMs >= s.startInstant && nowMs < s.endInstant,
+  );
 
   // Weekend closure runs Friday 20:00 ET → Sunday 20:00 ET. Pick the ongoing
   // weekend when the cycle day sits inside one, otherwise the upcoming one.
@@ -331,6 +342,7 @@ export function getUSMarketTradingHours(
     cycleEndInstant,
     nowRatio: (clampedNow - cycleStartInstant) / cycleDuration,
     currentSessionKey: currentSegment.key,
+    isNowInSessionGap,
     weekendStartInstant,
     weekendEndInstant,
   };
@@ -431,9 +443,11 @@ export function isOndoUSMarketStock(
  * Signal priority:
  *   1. per-stock halt (`isPaused`) — overlays everything;
  *   2. per-stock `isOpen === false` — the instrument's own window is closed;
- *   3. market-wide session refines HOW it is open. A tradable instrument
- *      (`isOpen === true`) while the US market is closed is the special
- *      7×24-Ondo case → ClosedTradable ("Closed · Tradable").
+ *   3. market-wide closure (backend CLOSED / weekend) → ClosedTradable for a
+ *      tradable instrument (`isOpen === true`) — the special 7×24-Ondo case;
+ *   4. inter-session gap (clock math) → Halted: the underlying venues pause
+ *      trading while switching session state;
+ *   5. market-wide session refines HOW it is open.
  *
  * When the market-status API is unavailable, falls back to pure clock math:
  * weekends are detectable locally, holidays are not.
@@ -476,24 +490,30 @@ export function resolveUSMarketStatusVariant({
         return EUSMarketStatusVariant.Open;
     }
   };
+  const tradingHours = getUSMarketTradingHours(now);
   if (status && !status.unavailable) {
     if (!status.open || status.session === 'CLOSED') {
       return EUSMarketStatusVariant.ClosedTradable;
     }
+    // Inter-session gap: the underlying venues pause trading while switching
+    // session state (OK-58509), overriding the backend session refinement.
+    if (tradingHours.isNowInSessionGap) {
+      return EUSMarketStatusVariant.Halted;
+    }
     const sessionKey = usMarketSessionKeyFromBackendSession(status.session);
     // Unknown session value (future contract addition): fall back to the
     // clock session, matching resolveUSTradingHoursActiveRow.
-    return sessionKeyToVariant(
-      sessionKey ?? getUSMarketTradingHours(now).currentSessionKey,
-    );
+    return sessionKeyToVariant(sessionKey ?? tradingHours.currentSessionKey);
   }
-  const tradingHours = getUSMarketTradingHours(now);
   const nowMs = now.getTime();
   if (
     nowMs >= tradingHours.weekendStartInstant &&
     nowMs < tradingHours.weekendEndInstant
   ) {
     return EUSMarketStatusVariant.ClosedTradable;
+  }
+  if (tradingHours.isNowInSessionGap) {
+    return EUSMarketStatusVariant.Halted;
   }
   return sessionKeyToVariant(tradingHours.currentSessionKey);
 }
@@ -532,6 +552,11 @@ export function resolveUSTradingHoursActiveRow({
     if (!status.open || status.session === 'CLOSED') {
       return 'closed';
     }
+    // Inter-session gap: the underlying venues pause trading while switching
+    // session state (OK-58509), overriding the backend session refinement.
+    if (tradingHours.isNowInSessionGap) {
+      return 'halts';
+    }
     return (
       usMarketSessionKeyFromBackendSession(status.session) ??
       tradingHours.currentSessionKey
@@ -546,6 +571,9 @@ export function resolveUSTradingHoursActiveRow({
     nowMs < tradingHours.weekendEndInstant
   ) {
     return 'closed';
+  }
+  if (tradingHours.isNowInSessionGap) {
+    return 'halts';
   }
   return tradingHours.currentSessionKey;
 }


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58509](https://onekeyhq.atlassian.net/browse/OK-58509) [OK-58513](https://onekeyhq.atlassian.net/browse/OK-58513) [OK-58516](https://onekeyhq.atlassian.net/browse/OK-58516) [OK-58554](https://onekeyhq.atlassian.net/browse/OK-58554) [OK-58655](https://onekeyhq.atlassian.net/browse/OK-58655)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

Five small fixes for tokenized-stock trading, all in the trading-hours / market-status display layer:

- **[OK-58509](https://onekeyhq.atlassian.net/browse/OK-58509)** — Align US stock trading session time ranges with OKX. Sessions are now non-contiguous ET wall-clock ranges (pre-market 04:01–09:29, regular 09:31–15:59, post-market 16:01–19:59, overnight 20:05–03:55 ET); the minutes between sessions (exchange status-switch windows, e.g. 15:56–16:00 UTC+8) surface as **trading halts** on both the trading-hours panel and the market-status badge.
- **[OK-58554](https://onekeyhq.atlassian.net/browse/OK-58554)** — Strip trailing sentence punctuation from the backend text before interpolating it into the `{time}` slot of `trade_stock.reopen_eta_perps`, fixing the doubled "。，" in the market-closed alert.
- **[OK-58655](https://onekeyhq.atlassian.net/browse/OK-58655)** — Wire the backend `stock.isPaused` signal into `resolveStockMarketStatusCase` (new `Halted` case): a halted stock now shows a dedicated "Trading halts" alert instead of "Market closed", consistent with the badge. Reuses existing i18n keys.
- **[OK-58516](https://onekeyhq.atlassian.net/browse/OK-58516)** — Trading-hours sheet dialog body is bounded by the window height and scrolls when content overflows (extension popup / small screens / longer English copy). Desktop popover unchanged.
- **[OK-58513](https://onekeyhq.atlassian.net/browse/OK-58513)** — Add a 300 ms hover-intent delay to the desktop trading-hours popover so a pointer merely passing through the token-selector header no longer opens it; clicking still opens instantly.

Includes a cleanup pass (`refactor: simplify stock trading session fixes`): lazy Intl-heavy cycle computation on closed paths, single-scan gap detection, resize-safe dialog body, and test dedup.

## Test plan

- Unit: `tradingHoursUtils`, `resolveStockMarketStatusCase`, `getStockMarketClosedDescription`, `SwapQuoteStockMarketStatusAlert` — 57 tests passing; boundary instants asserted for EST/EDT and both DST transition cycles.
- Manual (verified): session ranges match OKX in UTC+8; panel highlights "Trading halts" during the 15:56–16:00 inter-session gap; halted stock shows the "Trading halts" alert with no doubled punctuation; extension small-screen dialog scrolls to reveal the bottom notice; desktop hover popover no longer opens on pass-through, opens on dwell or click.

## Jira

OK-58509, OK-58513, OK-58516, OK-58554, OK-58655

[OK-58509]: https://onekeyhq.atlassian.net/browse/OK-58509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-58554]: https://onekeyhq.atlassian.net/browse/OK-58554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-58655]: https://onekeyhq.atlassian.net/browse/OK-58655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-58516]: https://onekeyhq.atlassian.net/browse/OK-58516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OK-58513]: https://onekeyhq.atlassian.net/browse/OK-58513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ