### PR TITLE
fix: stabilize swap tips banner layout (OK-58504)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -6,7 +6,6 @@ import { isStockQuoteInputAmountMatched } from '@onekeyhq/kit/src/views/Swap/uti
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { dangerAllNetworkRepresent } from '@onekeyhq/shared/src/config/presetNetworks';
 import { CONTEXT_ATOM_COLD_START_CACHE_KEYS } from '@onekeyhq/shared/src/consts/jotaiConsts';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { ICustomPriorityFeeOverride } from '@onekeyhq/shared/src/utils/marketPresetFeeUtils';
 import type { ISwapSelectedTokensColdStartContext } from '@onekeyhq/shared/src/utils/swapColdStartCacheSnapshotUtils';
 import { sortSwapQuotes } from '@onekeyhq/shared/src/utils/swapQuoteSortUtils';
@@ -658,16 +657,6 @@ export type ISwapTipsState = {
   updatedAt: number;
 };
 
-// Native main/bg runtimes initialize independently. Preserve the last settled
-// presentation in the main runtime until the fresh bg result arrives so cold
-// start does not insert the banner after first paint.
-const swapTipsColdStartCacheOptions = platformEnv.isNative
-  ? {
-      coldStartCache: true as const,
-      coldStartCacheKey: CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapTipsStateAtom,
-    }
-  : undefined;
-
 // swap tips
 export const { atom: swapTipsAtom, use: useSwapTipsAtom } =
   contextAtom<ISwapTipsState>(
@@ -675,7 +664,10 @@ export const { atom: swapTipsAtom, use: useSwapTipsAtom } =
       status: 'unknown',
       updatedAt: 0,
     },
-    swapTipsColdStartCacheOptions,
+    {
+      coldStartCache: true,
+      coldStartCacheKey: CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapTipsStateAtom,
+    },
   );
 
 export const {

--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -6,6 +6,7 @@ import { isStockQuoteInputAmountMatched } from '@onekeyhq/kit/src/views/Swap/uti
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import { dangerAllNetworkRepresent } from '@onekeyhq/shared/src/config/presetNetworks';
 import { CONTEXT_ATOM_COLD_START_CACHE_KEYS } from '@onekeyhq/shared/src/consts/jotaiConsts';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { ICustomPriorityFeeOverride } from '@onekeyhq/shared/src/utils/marketPresetFeeUtils';
 import type { ISwapSelectedTokensColdStartContext } from '@onekeyhq/shared/src/utils/swapColdStartCacheSnapshotUtils';
 import { sortSwapQuotes } from '@onekeyhq/shared/src/utils/swapQuoteSortUtils';
@@ -657,6 +658,16 @@ export type ISwapTipsState = {
   updatedAt: number;
 };
 
+// Native main/bg runtimes initialize independently. Preserve the last settled
+// presentation in the main runtime until the fresh bg result arrives so cold
+// start does not insert the banner after first paint.
+const swapTipsColdStartCacheOptions = platformEnv.isNative
+  ? {
+      coldStartCache: true as const,
+      coldStartCacheKey: CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapTipsStateAtom,
+    }
+  : undefined;
+
 // swap tips
 export const { atom: swapTipsAtom, use: useSwapTipsAtom } =
   contextAtom<ISwapTipsState>(
@@ -664,10 +675,7 @@ export const { atom: swapTipsAtom, use: useSwapTipsAtom } =
       status: 'unknown',
       updatedAt: 0,
     },
-    {
-      coldStartCache: true,
-      coldStartCacheKey: CONTEXT_ATOM_COLD_START_CACHE_KEYS.swapTipsStateAtom,
-    },
+    swapTipsColdStartCacheOptions,
   );
 
 export const {

--- a/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
@@ -1467,14 +1467,14 @@ export function useSwapInit(params?: ISwapInitParams) {
           });
           return;
         }
+        setSwapTips({
+          status: 'empty',
+          updatedAt: Date.now(),
+        });
       } catch (_error) {
-        // Tips are non-critical. Keep Swap usable when remote config or local
+        // Keep the last settled presentation when remote config or local
         // dismissal state cannot be loaded.
       }
-      setSwapTips({
-        status: 'empty',
-        updatedAt: Date.now(),
-      });
     })();
   }, [setSwapTips]);
 

--- a/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapGlobal.ts
@@ -1455,16 +1455,21 @@ export function useSwapInit(params?: ISwapInitParams) {
 
   useEffect(() => {
     void (async () => {
-      const tips = await backgroundApiProxy.serviceSwap.fetchSwapTips();
-      const simpleDbTips =
-        await backgroundApiProxy.simpleDb.swapConfigs.getSwapUserCloseTips();
-      if (tips && !simpleDbTips.includes(tips.tipsId)) {
-        setSwapTips({
-          tips,
-          status: 'ready',
-          updatedAt: Date.now(),
-        });
-        return;
+      try {
+        const tips = await backgroundApiProxy.serviceSwap.fetchSwapTips();
+        const simpleDbTips =
+          await backgroundApiProxy.simpleDb.swapConfigs.getSwapUserCloseTips();
+        if (tips && !simpleDbTips.includes(tips.tipsId)) {
+          setSwapTips({
+            tips,
+            status: 'ready',
+            updatedAt: Date.now(),
+          });
+          return;
+        }
+      } catch (_error) {
+        // Tips are non-critical. Keep Swap usable when remote config or local
+        // dismissal state cannot be loaded.
       }
       setSwapTips({
         status: 'empty',

--- a/packages/kit/src/views/Swap/pages/components/SwapTipsContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapTipsContainer.tsx
@@ -35,6 +35,9 @@ const SwapTipsContainer = ({ pageType }: ISwapTipsContainerProps) => {
     effectiveTab: swapTips.effectiveTab,
     swapType: swapTypeSwitch,
   });
+  if (!shouldShowTips && platformEnv.isNative) {
+    return null;
+  }
 
   const handleClose = async () => {
     const optimisticUpdatedAt = Date.now();
@@ -69,8 +72,8 @@ const SwapTipsContainer = ({ pageType }: ISwapTipsContainerProps) => {
       }
     : undefined;
 
-  // Keep the real Alert in layout on inactive tabs so wrapped copy and
-  // optional actions reserve exactly the same height as the active tab.
+  // On non-native platforms, keep the real Alert in layout on inactive tabs
+  // so wrapped copy and optional actions reserve the active tab's exact height.
   return (
     <YStack
       testID={SwapTestIDs.tipsContainer}

--- a/packages/kit/src/views/Swap/pages/components/SwapTipsContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapTipsContainer.tsx
@@ -10,45 +10,55 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
 
+import { SwapTestIDs } from '../../testIDs';
+
 import { shouldShowSwapTips } from './SwapTipsContainer.utils';
 
 interface ISwapTipsContainerProps {
   pageType?: EPageType;
 }
 
-const SWAP_TIPS_RESERVED_HEIGHT = platformEnv.isNative ? 56 : 58;
-
 const SwapTipsContainer = ({ pageType }: ISwapTipsContainerProps) => {
   const [swapTipsState, setSwapTipsState] = useSwapTipsAtom();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
   const intl = useIntl();
   // Don't show tips in modal
-  if (pageType === EPageType.modal || swapTipsState.status === 'empty') {
+  if (pageType === EPageType.modal || swapTipsState.status !== 'ready') {
     return null;
   }
   const swapTips = swapTipsState.tips;
 
-  if (
-    !swapTips ||
-    !shouldShowSwapTips({
-      effectiveTab: swapTips.effectiveTab,
-      swapType: swapTypeSwitch,
-    })
-  ) {
+  if (!swapTips) {
     return null;
   }
+  const shouldShowTips = shouldShowSwapTips({
+    effectiveTab: swapTips.effectiveTab,
+    swapType: swapTypeSwitch,
+  });
 
   const handleClose = async () => {
+    const optimisticUpdatedAt = Date.now();
     try {
       setSwapTipsState({
         status: 'empty',
-        updatedAt: Date.now(),
+        updatedAt: optimisticUpdatedAt,
       });
       await backgroundApiProxy.simpleDb.swapConfigs.setSwapUserCloseTips(
         swapTips.tipsId,
       );
     } catch (_error) {
-      setSwapTipsState(swapTipsState);
+      setSwapTipsState((current) =>
+        current.status === 'empty' && current.updatedAt === optimisticUpdatedAt
+          ? {
+              ...swapTipsState,
+              updatedAt: Math.max(
+                Date.now(),
+                optimisticUpdatedAt + 1,
+                swapTipsState.updatedAt + 1,
+              ),
+            }
+          : current,
+      );
     }
   };
 
@@ -59,13 +69,25 @@ const SwapTipsContainer = ({ pageType }: ISwapTipsContainerProps) => {
       }
     : undefined;
 
+  // Keep the real Alert in layout on inactive tabs so wrapped copy and
+  // optional actions reserve exactly the same height as the active tab.
   return (
-    <YStack minHeight={SWAP_TIPS_RESERVED_HEIGHT}>
+    <YStack
+      testID={SwapTestIDs.tipsContainer}
+      opacity={shouldShowTips ? 1 : 0}
+      pointerEvents={shouldShowTips ? 'auto' : 'none'}
+      aria-hidden={!shouldShowTips}
+      accessibilityElementsHidden={!shouldShowTips}
+      importantForAccessibility={
+        shouldShowTips ? 'auto' : 'no-hide-descendants'
+      }
+      {...(platformEnv.isNative ? {} : { inert: !shouldShowTips })}
+    >
       <Alert
+        key={swapTipsState.updatedAt}
         type="info"
         fullBleed
         borderWidth={0}
-        minHeight={SWAP_TIPS_RESERVED_HEIGHT}
         icon="InfoCircleSolid"
         title={swapTips.title}
         description={swapTips.description}

--- a/packages/kit/src/views/Swap/testIDs.ts
+++ b/packages/kit/src/views/Swap/testIDs.ts
@@ -27,6 +27,7 @@ export const SwapTestIDs = {
   // Provider
   providerSelector: 'swap-provider-selector',
   providerItem: (name: string) => `swap-provider-${name}`,
+  tipsContainer: 'swap-tips-container',
 
   // Pro
   proContainer: 'swap-pro-container',


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58504](https://onekeyhq.atlassian.net/browse/OK-58504)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- keep the rendered Swap Tips alert mounted on inactive configured tabs on Desktop, Web, and Extension so tab switches preserve its exact layout height
- preserve the existing Tips cold-start cache across all platforms so first entry does not insert the banner after first paint
- keep Native behavior unchanged on inactive tabs, without reserving hidden Tips layout space
- restore the current tips presentation if dismissal persistence fails
- extracted from #12690 without carrying the Stock chart changes

## Issues

- Fixes OK-58504

## Validation

- `yarn jest packages/kit/src/views/Swap/pages/components/SwapTipsContainer.utils.test.ts --runInBand` (5/5)
- `yarn agent:check --profile commit`
- source-branch Desktop validation covered partial-tab height stability and dismissal persistence rejection

## Risk

- inactive-tab layout reservation affects Desktop, Web, and Extension only
- iOS and Android continue to render no Tips space when the current tab is not configured
- active Tips and cold-start persistence remain enabled on all platforms
- no API, tips payload, dismissal schema, or generated translation changes
- release-branch runtime validation remains a QA gate
- the corresponding `x` change should be synced after this release PR is merged

[OK-58504]: https://onekeyhq.atlassian.net/browse/OK-58504