### PR TITLE
fix: stabilize Stock chart loading(OK-58814)

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -158,10 +158,12 @@ import SwapProCurrentSymbolEnable from './SwapProCurrentSymbolEnable';
 import SwapProPositionsList from './SwapProPositionsList';
 import SwapQuoteResult from './SwapQuoteResult';
 import {
+  type IStockChartCoinGeckoIdLookupResult,
   type IStockChartRange,
   STOCK_CHART_DEFAULT_RANGE,
   STOCK_CHART_RANGE_ITEMS,
   STOCK_DESKTOP_HEADER_SLOT_PROPS,
+  getStockChartCoinGeckoIdState,
   getStockChartDisplayState,
   getStockDisabledActionButtonProps,
   getStockMarketTokenSubtitle,
@@ -291,39 +293,43 @@ function useStockChartCoinGeckoId({
     getStockChartTokenDetailCoinGeckoId(tokenDetail);
   const tokenScope = `${networkId ?? ''}:${tokenAddress ?? ''}`;
   const { result } = usePromiseResult<
-    | {
-        tokenScope: string;
-        coinGeckoId?: string;
-      }
-    | undefined
+    IStockChartCoinGeckoIdLookupResult | undefined
   >(
     async () => {
       if (tokenDetailCoinGeckoId || !networkId) {
         return undefined;
       }
 
-      const tokenInfo =
-        await backgroundApiProxy.serviceToken.fetchTokenInfoOnly({
-          networkId,
-          tokenAddress: tokenAddress ?? '',
-        });
-      return {
-        tokenScope,
-        coinGeckoId: tokenInfo?.info?.coingeckoId?.trim() || undefined,
-      };
+      try {
+        const tokenInfo =
+          await backgroundApiProxy.serviceToken.fetchTokenInfoOnly({
+            networkId,
+            tokenAddress: tokenAddress ?? '',
+          });
+        return {
+          tokenScope,
+          coinGeckoId: tokenInfo?.info?.coingeckoId?.trim() || undefined,
+        };
+      } catch (_error) {
+        return {
+          tokenScope,
+          coinGeckoId: undefined,
+        };
+      }
     },
     [networkId, tokenAddress, tokenDetailCoinGeckoId, tokenScope],
     {
       checkIsFocused: false,
-      undefinedResultIfError: true,
       undefinedResultIfReRun: true,
     },
   );
 
-  return (
-    tokenDetailCoinGeckoId ||
-    (result?.tokenScope === tokenScope ? result.coinGeckoId : undefined)
-  );
+  return getStockChartCoinGeckoIdState({
+    lookupResult: result,
+    networkId,
+    tokenDetailCoinGeckoId,
+    tokenScope,
+  });
 }
 
 function StockMarketDataItem({
@@ -1625,6 +1631,7 @@ function StockMarketTokenHeader({
 
 function StockPriceChart({
   coinGeckoId,
+  coinGeckoIdLoading,
   isNative,
   networkId,
   onRangeChange,
@@ -1634,6 +1641,7 @@ function StockPriceChart({
   tokenAddress,
 }: {
   coinGeckoId?: string;
+  coinGeckoIdLoading: boolean;
   isNative?: boolean;
   networkId?: string;
   onRangeChange: (range: IStockChartRange) => void;
@@ -1709,7 +1717,10 @@ function StockPriceChart({
             assetScope: chartAssetScope,
             range,
             data: [] as IMarketTokenChart,
-            status: 'pending' as const,
+            status:
+              chartCacheReady && !coinGeckoIdLoading
+                ? ('success' as const)
+                : ('pending' as const),
           }
         );
       }
@@ -1754,6 +1765,7 @@ function StockPriceChart({
       chartCacheReady,
       chartRequestReady,
       chartScope,
+      coinGeckoIdLoading,
       normalizedCoinGeckoId,
       range,
     ],
@@ -1819,8 +1831,15 @@ function StockPriceChart({
       realtimeChartPoint,
     ],
   );
+  const chartRetryPendingRef = useRef(false);
   const handleChartRetry = useCallback(() => {
-    void retryChart();
+    if (chartRetryPendingRef.current) {
+      return;
+    }
+    chartRetryPendingRef.current = true;
+    void retryChart().finally(() => {
+      chartRetryPendingRef.current = false;
+    });
   }, [retryChart]);
   const priceFormatter = useCallback(
     (price: number) =>
@@ -2226,11 +2245,12 @@ function StockMarketContextPanel({
 }) {
   const { stockChannel, tokenDetail, tokenAddress, networkId, isNative } =
     useCurrentStockMarketDetail();
-  const coinGeckoId = useStockChartCoinGeckoId({
-    networkId,
-    tokenAddress,
-    tokenDetail,
-  });
+  const { coinGeckoId, isLoading: isCoinGeckoIdLoading } =
+    useStockChartCoinGeckoId({
+      networkId,
+      tokenAddress,
+      tokenDetail,
+    });
   const [range, setRange] = useState<IStockChartRange>(
     STOCK_CHART_DEFAULT_RANGE,
   );
@@ -2246,6 +2266,7 @@ function StockMarketContextPanel({
     chartContent = (
       <StockPriceChart
         coinGeckoId={coinGeckoId}
+        coinGeckoIdLoading={isCoinGeckoIdLoading}
         tokenAddress={tokenAddress ?? ''}
         networkId={networkId ?? ''}
         isNative={isNative}

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -241,6 +241,9 @@ type IStockChartState = {
   data: IMarketTokenChart;
   range: IStockChartRange;
   scope: string;
+  // Optional for compatibility with existing SWR entries written before the
+  // request lifecycle became explicit.
+  status?: 'pending' | 'success' | 'error';
 };
 
 function useOpenStockTokenSelector({
@@ -1622,7 +1625,6 @@ function StockMarketTokenHeader({
 
 function StockPriceChart({
   coinGeckoId,
-  forceLoading,
   isNative,
   networkId,
   onRangeChange,
@@ -1632,7 +1634,6 @@ function StockPriceChart({
   tokenAddress,
 }: {
   coinGeckoId?: string;
-  forceLoading?: boolean;
   isNative?: boolean;
   networkId?: string;
   onRangeChange: (range: IStockChartRange) => void;
@@ -1688,11 +1689,16 @@ function StockPriceChart({
     data: [],
     range,
     scope: '',
+    status: 'pending',
   });
   useEffect(() => {
     setHoverData(null);
   }, [chartScope]);
-  const { result: chartState, isLoading } = usePromiseResult(
+  const {
+    result: chartState,
+    isLoading,
+    run: retryChart,
+  } = usePromiseResult(
     async () => {
       if (!chartRequestReady || !activeRange || !normalizedCoinGeckoId) {
         return (
@@ -1703,27 +1709,44 @@ function StockPriceChart({
             assetScope: chartAssetScope,
             range,
             data: [] as IMarketTokenChart,
+            status: 'pending' as const,
           }
         );
       }
-      const timeTo = Math.floor(Date.now() / 1000);
-      const timeFrom = timeTo - activeRange.seconds;
-      const days = getSwapKLineWalletChartDays({ timeFrom, timeTo });
-      const response = await backgroundApiProxy.serviceMarket.fetchTokenChart(
-        normalizedCoinGeckoId,
-        days,
-        { requestCurrency: 'usd' },
-      );
-      return {
-        scope: chartScope,
-        assetScope: chartAssetScope,
-        range,
-        data: normalizeSwapKLineWalletChartData({
-          chartData: response,
-          timeFrom,
-          timeTo,
-        }),
-      };
+      try {
+        const timeTo = Math.floor(Date.now() / 1000);
+        const timeFrom = timeTo - activeRange.seconds;
+        const days = getSwapKLineWalletChartDays({ timeFrom, timeTo });
+        const response = await backgroundApiProxy.serviceMarket.fetchTokenChart(
+          normalizedCoinGeckoId,
+          days,
+          { requestCurrency: 'usd' },
+        );
+        return {
+          scope: chartScope,
+          assetScope: chartAssetScope,
+          range,
+          data: normalizeSwapKLineWalletChartData({
+            chartData: response,
+            timeFrom,
+            timeTo,
+          }),
+          status: 'success' as const,
+        };
+      } catch (_error) {
+        const cachedChartState =
+          swrCacheUtils.get<IStockChartState>(chartScope);
+        if (cachedChartState) {
+          return cachedChartState;
+        }
+        return {
+          scope: chartScope,
+          assetScope: chartAssetScope,
+          range,
+          data: [] as IMarketTokenChart,
+          status: 'error' as const,
+        };
+      }
     },
     [
       activeRange,
@@ -1740,12 +1763,16 @@ function StockPriceChart({
         assetScope: '',
         range,
         data: [] as IMarketTokenChart,
+        status: 'pending',
       },
       swrKey: chartCacheReady ? chartScope : undefined,
       // A missing CoinGecko lookup id is a request-readiness gap, not a real
       // empty chart response. Keep the existing display snapshot untouched
       // until the request can actually run.
-      swrShouldPersist: () => chartRequestReady,
+      swrShouldPersist: (state) =>
+        chartRequestReady &&
+        state.status !== 'pending' &&
+        state.status !== 'error',
       watchLoading: true,
     },
   );
@@ -1775,21 +1802,26 @@ function StockPriceChart({
     () => (isVisibleChartStateForCurrentAsset ? displayChartState.data : []),
     [displayChartState.data, isVisibleChartStateForCurrentAsset],
   );
-  const { chartData, shouldShowChartLoading } = useMemo(
+  const { chartData, shouldShowChartError, shouldShowChartLoading } = useMemo(
     () =>
       getStockChartDisplayState({
         baseChartData,
         isChartStateForCurrentScope: isVisibleChartStateForCurrentScope,
         isLoading,
+        requestStatus: displayChartState.status ?? 'success',
         realtimeChartPoint,
       }),
     [
       baseChartData,
+      displayChartState.status,
       isLoading,
       isVisibleChartStateForCurrentScope,
       realtimeChartPoint,
     ],
   );
+  const handleChartRetry = useCallback(() => {
+    void retryChart();
+  }, [retryChart]);
   const priceFormatter = useCallback(
     (price: number) =>
       numberFormat(String(price), {
@@ -1860,7 +1892,13 @@ function StockPriceChart({
   }, [hoverData, intl]);
 
   let chartContent: ReactNode = (
-    <YStack flex={1} alignItems="center" justifyContent="center" gap="$2">
+    <YStack
+      testID={SwapTestIDs.stockChartEmpty}
+      flex={1}
+      alignItems="center"
+      justifyContent="center"
+      gap="$2"
+    >
       <YStack
         w="$10"
         h="$10"
@@ -1883,11 +1921,41 @@ function StockPriceChart({
       </SizableText>
     </YStack>
   );
-  if (forceLoading || shouldShowChartLoading) {
-    chartContent = <Skeleton w="100%" h="100%" />;
+  if (shouldShowChartLoading) {
+    chartContent = (
+      <YStack testID={SwapTestIDs.stockChartLoading} w="100%" h="100%">
+        <Skeleton w="100%" h="100%" />
+      </YStack>
+    );
+  } else if (shouldShowChartError) {
+    chartContent = (
+      <YStack
+        testID={SwapTestIDs.stockChartError}
+        flex={1}
+        alignItems="center"
+        justifyContent="center"
+        gap="$2"
+      >
+        <Icon name="InfoCircleOutline" size="$6" color="$iconSubdued" />
+        <SizableText size="$bodySm" color="$textSubdued" textAlign="center">
+          {intl.formatMessage({
+            id: ETranslations.global_unknown_error_retry_message,
+          })}
+        </SizableText>
+        <Button
+          testID={SwapTestIDs.stockChartRetry}
+          size="small"
+          variant="tertiary"
+          onPress={handleChartRetry}
+        >
+          {intl.formatMessage({ id: ETranslations.global_retry })}
+        </Button>
+      </YStack>
+    );
   } else if (chartData.length > 0) {
     chartContent = (
       <YStack
+        testID={SwapTestIDs.stockChartContent}
         position="relative"
         h={STOCK_CHART_VISIBLE_HEIGHT}
         onLayout={(event) => {
@@ -2178,7 +2246,6 @@ function StockMarketContextPanel({
     chartContent = (
       <StockPriceChart
         coinGeckoId={coinGeckoId}
-        forceLoading={!chartReady}
         tokenAddress={tokenAddress ?? ''}
         networkId={networkId ?? ''}
         isNative={isNative}

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -1622,6 +1622,7 @@ function StockMarketTokenHeader({
 
 function StockPriceChart({
   coinGeckoId,
+  forceLoading,
   isNative,
   networkId,
   onRangeChange,
@@ -1631,6 +1632,7 @@ function StockPriceChart({
   tokenAddress,
 }: {
   coinGeckoId?: string;
+  forceLoading?: boolean;
   isNative?: boolean;
   networkId?: string;
   onRangeChange: (range: IStockChartRange) => void;
@@ -1881,7 +1883,7 @@ function StockPriceChart({
       </SizableText>
     </YStack>
   );
-  if (shouldShowChartLoading) {
+  if (forceLoading || shouldShowChartLoading) {
     chartContent = <Skeleton w="100%" h="100%" />;
   } else if (chartData.length > 0) {
     chartContent = (
@@ -2172,10 +2174,11 @@ function StockMarketContextPanel({
   // Only pulse the chart tail while the market is open (live updating).
   const isMarketOpen = stockChannel.stockMarketStatus?.open === true;
   let chartContent: ReactNode;
-  if (chartReady) {
+  if (chartReady || marketPanelLoading) {
     chartContent = (
       <StockPriceChart
         coinGeckoId={coinGeckoId}
+        forceLoading={!chartReady}
         tokenAddress={tokenAddress ?? ''}
         networkId={networkId ?? ''}
         isNative={isNative}
@@ -2185,8 +2188,6 @@ function StockMarketContextPanel({
         realtimeChartPoint={stockChannel.realtimeChartPoint}
       />
     );
-  } else if (marketPanelLoading) {
-    chartContent = <Skeleton w="100%" h={274} />;
   } else {
     chartContent = <StockMarketChartEmptyState />;
   }

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
@@ -9,6 +9,7 @@ import {
   STOCK_CHART_DEFAULT_RANGE,
   STOCK_CHART_RANGE_ITEMS,
   STOCK_DESKTOP_HEADER_SLOT_PROPS,
+  getStockChartCoinGeckoIdState,
   getStockChartDisplayState,
   getStockDisabledActionButtonProps,
   getStockMarketTokenSubtitle,
@@ -54,6 +55,66 @@ describe('SwapStockDesktopContainer utils', () => {
         networkLogoUri: 'https://example.com/custom-network.png',
       }),
     ).toBe('https://example.com/custom-network.png');
+  });
+
+  it('settles the CoinGecko lookup when the fallback has no id', () => {
+    const tokenScope = 'evm--1:0xstock';
+
+    expect(
+      getStockChartCoinGeckoIdState({
+        networkId: 'evm--1',
+        tokenScope,
+      }),
+    ).toEqual({
+      coinGeckoId: undefined,
+      isLoading: true,
+    });
+    expect(
+      getStockChartCoinGeckoIdState({
+        lookupResult: {
+          tokenScope,
+          coinGeckoId: undefined,
+        },
+        networkId: 'evm--1',
+        tokenScope,
+      }),
+    ).toEqual({
+      coinGeckoId: undefined,
+      isLoading: false,
+    });
+  });
+
+  it('ignores a completed CoinGecko lookup from another token scope', () => {
+    expect(
+      getStockChartCoinGeckoIdState({
+        lookupResult: {
+          tokenScope: 'evm--1:0xprevious',
+          coinGeckoId: 'previous-stock',
+        },
+        networkId: 'evm--1',
+        tokenScope: 'evm--1:0xcurrent',
+      }),
+    ).toEqual({
+      coinGeckoId: undefined,
+      isLoading: true,
+    });
+  });
+
+  it('prefers the token detail CoinGecko id without waiting for fallback', () => {
+    expect(
+      getStockChartCoinGeckoIdState({
+        lookupResult: {
+          tokenScope: 'evm--1:0xstock',
+          coinGeckoId: undefined,
+        },
+        networkId: 'evm--1',
+        tokenDetailCoinGeckoId: 'stock-detail-id',
+        tokenScope: 'evm--1:0xstock',
+      }),
+    ).toEqual({
+      coinGeckoId: 'stock-detail-id',
+      isLoading: false,
+    });
   });
 
   it('keeps disabled buy actions in the buy color family', () => {
@@ -294,6 +355,21 @@ describe('SwapStockDesktopContainer utils', () => {
       chartData: [],
       shouldShowChartError: false,
       shouldShowChartLoading: false,
+    });
+  });
+
+  it('shows loading instead of a stale error while retrying', () => {
+    expect(
+      getStockChartDisplayState({
+        baseChartData: [],
+        isChartStateForCurrentScope: true,
+        isLoading: true,
+        requestStatus: 'error',
+      }),
+    ).toEqual({
+      chartData: [],
+      shouldShowChartError: false,
+      shouldShowChartLoading: true,
     });
   });
 

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
@@ -250,7 +250,50 @@ describe('SwapStockDesktopContainer utils', () => {
       }),
     ).toEqual({
       chartData: [],
+      shouldShowChartError: false,
       shouldShowChartLoading: true,
+    });
+  });
+
+  it('keeps a current pending chart request in loading state', () => {
+    expect(
+      getStockChartDisplayState({
+        baseChartData: [],
+        isChartStateForCurrentScope: true,
+        isLoading: false,
+        requestStatus: 'pending',
+      }),
+    ).toEqual({
+      chartData: [],
+      shouldShowChartError: false,
+      shouldShowChartLoading: true,
+    });
+  });
+
+  it('shows chart errors separately from successful empty responses', () => {
+    expect(
+      getStockChartDisplayState({
+        baseChartData: [],
+        isChartStateForCurrentScope: true,
+        isLoading: false,
+        requestStatus: 'error',
+      }),
+    ).toEqual({
+      chartData: [],
+      shouldShowChartError: true,
+      shouldShowChartLoading: false,
+    });
+    expect(
+      getStockChartDisplayState({
+        baseChartData: [],
+        isChartStateForCurrentScope: true,
+        isLoading: false,
+        requestStatus: 'success',
+      }),
+    ).toEqual({
+      chartData: [],
+      shouldShowChartError: false,
+      shouldShowChartLoading: false,
     });
   });
 
@@ -269,6 +312,7 @@ describe('SwapStockDesktopContainer utils', () => {
       }),
     ).toEqual({
       chartData: previousChartData,
+      shouldShowChartError: false,
       shouldShowChartLoading: false,
     });
   });
@@ -287,6 +331,7 @@ describe('SwapStockDesktopContainer utils', () => {
       }),
     ).toEqual({
       chartData: cachedChartData,
+      shouldShowChartError: false,
       shouldShowChartLoading: false,
     });
   });
@@ -308,6 +353,7 @@ describe('SwapStockDesktopContainer utils', () => {
         [1_725_003_600, 311],
         [1_725_007_200, 312.15],
       ],
+      shouldShowChartError: false,
       shouldShowChartLoading: false,
     });
   });

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
@@ -173,13 +173,19 @@ export function getStockChartDisplayState({
   baseChartData,
   isChartStateForCurrentScope,
   isLoading,
+  requestStatus,
   realtimeChartPoint,
 }: {
   baseChartData: IMarketTokenChart;
   isChartStateForCurrentScope: boolean;
   isLoading?: boolean;
+  requestStatus?: 'pending' | 'success' | 'error';
   realtimeChartPoint?: IMarketTokenChart[number];
 }) {
+  const shouldShowChartError =
+    baseChartData.length === 0 &&
+    isChartStateForCurrentScope &&
+    requestStatus === 'error';
   return {
     chartData: mergeStockChartRealtimePoint({
       baseChartData,
@@ -187,8 +193,12 @@ export function getStockChartDisplayState({
         ? realtimeChartPoint
         : undefined,
     }),
+    shouldShowChartError,
     shouldShowChartLoading:
       baseChartData.length === 0 &&
-      (Boolean(isLoading) || !isChartStateForCurrentScope),
+      !shouldShowChartError &&
+      (requestStatus === 'pending' ||
+        Boolean(isLoading) ||
+        !isChartStateForCurrentScope),
   };
 }

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
@@ -20,6 +20,11 @@ export const STOCK_DESKTOP_HEADER_SLOT_PROPS = {
   pb: '$4',
 } as const;
 
+export type IStockChartCoinGeckoIdLookupResult = {
+  tokenScope: string;
+  coinGeckoId?: string;
+};
+
 export const STOCK_CHART_RANGE_ITEMS: {
   label: IStockChartRange;
   interval: string;
@@ -44,6 +49,28 @@ export function getStockNetworkLogoUri({
   return networkId
     ? networkUtils.getLocalNetworkInfo(networkId)?.logoURI
     : undefined;
+}
+
+export function getStockChartCoinGeckoIdState({
+  lookupResult,
+  networkId,
+  tokenDetailCoinGeckoId,
+  tokenScope,
+}: {
+  lookupResult?: IStockChartCoinGeckoIdLookupResult;
+  networkId?: string;
+  tokenDetailCoinGeckoId?: string;
+  tokenScope: string;
+}) {
+  const currentLookupResult =
+    lookupResult?.tokenScope === tokenScope ? lookupResult : undefined;
+  return {
+    coinGeckoId:
+      tokenDetailCoinGeckoId || currentLookupResult?.coinGeckoId || undefined,
+    isLoading: Boolean(
+      networkId && !tokenDetailCoinGeckoId && !currentLookupResult,
+    ),
+  };
 }
 
 export function getStockDisabledActionButtonProps(
@@ -185,6 +212,7 @@ export function getStockChartDisplayState({
   const shouldShowChartError =
     baseChartData.length === 0 &&
     isChartStateForCurrentScope &&
+    !isLoading &&
     requestStatus === 'error';
   return {
     chartData: mergeStockChartRealtimePoint({

--- a/packages/kit/src/views/Swap/testIDs.ts
+++ b/packages/kit/src/views/Swap/testIDs.ts
@@ -46,6 +46,11 @@ export const SwapTestIDs = {
   stockMarketTokenHeader: 'swap-stock-market-token-header',
   stockMarketPanel: 'swap-stock-market-panel',
   stockMarketDataGrid: 'swap-stock-market-data-grid',
+  stockChartLoading: 'swap-stock-chart-loading',
+  stockChartContent: 'swap-stock-chart-content',
+  stockChartEmpty: 'swap-stock-chart-empty',
+  stockChartError: 'swap-stock-chart-error',
+  stockChartRetry: 'swap-stock-chart-retry',
   stockTradeStatusAlert: 'swap-stock-trade-status-alert',
 
   // Limit order


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58814](https://onekeyhq.atlassian.net/browse/OK-58814)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- keep the Desktop Stock chart in one stable shell while the active asset/range request settles
- distinguish chart loading, successful empty data, and retryable request errors
- preserve valid cached chart data during same-scope revalidation

## Intent & Context

OK-58814 reports a two-stage skeleton transition while the Stock K-line chart loads. This Draft PR replaces #12690 with a clean branch created from `x` and contains only the OK-58814 Stock chart lifecycle changes.

## Root Cause

The parent market panel and the chart component owned separate loading placeholders. Request readiness, network failure, and successful empty responses were also represented by the same empty chart state, allowing the chart shell to switch presentation during initialization.

## Design Decisions

- keep loading ownership inside the real chart shell so its height and range controls remain stable
- model request status explicitly as `pending`, `success`, or `error`
- persist only successful chart results and retain valid cached data during revalidation
- expose an explicit retry action for request failures

## Changes Detail

- update `SwapStockDesktopContainer` to use one stable chart shell and an explicit request lifecycle
- extend `getStockChartDisplayState` to separate loading and error presentation
- add focused display-state regression tests
- add Stock chart test IDs for loading, content, empty, error, and retry states

## Risk Assessment

- **Risk Level**: Medium
- **Affected Platforms**: Desktop
- **Risk Areas**: Stock chart cache reuse, request retry behavior, and transitions between loading, empty, error, and content states

## Test plan

- [x] `yarn jest packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts --runInBand` (24/24)
- [x] `yarn agent:check --profile commit`
- [ ] Verify an uncached Desktop Stock chart keeps one stable 274px shell with no intermediate empty state
- [ ] Verify request failure shows retry and successful retry restores the chart

Fixes OK-58814

[OK-58814]: https://onekeyhq.atlassian.net/browse/OK-58814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ