### PR TITLE
fix: warn on aggressive perps limit prices

### DIFF
--- a/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/atoms.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { BigNumber } from 'bignumber.js';
 import { selectAtom } from 'jotai/utils';
 
@@ -38,6 +40,7 @@ const {
   contextAtom,
   contextAtomComputed,
   contextAtomMethod,
+  useContextData: useHyperliquidContextData,
 } = createJotaiContext();
 export { contextAtomMethod, ProviderJotaiContextHyperliquid };
 
@@ -188,6 +191,14 @@ export function useBboForOrderPrice(
   const { use } = getOrCreateBboForOrderPriceAtom(enabled);
   const [bbo] = use();
   return bbo;
+}
+
+export function useGetBboForOrderPrice() {
+  const { store } = useHyperliquidContextData();
+  return useCallback(
+    (): IPerpsBboWithLocalReceivedAt | null => store?.get(bboAtom()) ?? null,
+    [store],
+  );
 }
 
 // TODO remove

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
@@ -14,6 +14,7 @@ import {
   XStack,
   YStack,
   getFontSize,
+  useKeyboardHeight,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import {
@@ -46,8 +47,9 @@ import { resolveTpSlTriggerPx } from '../../utils/resolveTpSlTriggerPx';
 import { buildDefaultTpSlPercent } from '../../utils/tpslSeed';
 import {
   PERP_DIALOG_BUTTON_SIZE,
-  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+  PERP_KEYBOARD_AWARE_DIALOG_CONTENT_CONTAINER_PROPS,
 } from '../PerpDialogLayout';
+import { PerpKeyboardAwareDialogContent } from '../PerpKeyboardAwareDialogContent';
 import { PerpsSlider } from '../PerpsSlider';
 import { TradingGuardWrapper } from '../TradingGuardWrapper';
 import { PriceInput } from '../TradingPanel/inputs/PriceInput';
@@ -78,10 +80,12 @@ interface IAddPositionFormProps extends IAddPositionParams {
 const AddPositionForm = memo(
   ({ coin, isBuy, accountAddress, onClose }: IAddPositionFormProps) => {
     const intl = useIntl();
+    const keyboardHeight = useKeyboardHeight();
     const actions = useHyperliquidActions();
     const [activeAccount] = usePerpsActiveAccountAtom();
     const [tradingPreferences] = usePerpsTradingPreferencesAtom();
     const sizeInputUnit = tradingPreferences.sizeInputUnit ?? 'usd';
+    const tpslButtonPaddingTop = keyboardHeight > 0 ? 0 : '$4';
     const [allMids] = usePerpsAllMidsAtom();
     const activePositions = usePerpsAccountScopedActivePositions();
     const currentPosition = useMemo(
@@ -550,74 +554,82 @@ const AddPositionForm = memo(
           allowMarginInput
           ifOnDialog
         />
-        <PerpsSlider
-          min={0}
-          max={100}
-          value={sizeInputMode === EPerpsSizeInputMode.SLIDER ? sizePercent : 0}
-          onChange={handleSliderPercentChange}
-          disabled={isSubmitting || !isTargetAssetReady}
-          segments={4}
-          snapTapToSegment
-          showBubble={false}
-          sliderHeight={4}
-        />
-        <Checkbox
-          testID="perp-add-position-tpsl-checkbox"
-          value={hasTpsl}
-          onChange={(checked) => handleTpslCheckboxChange(Boolean(checked))}
-          label={intl.formatMessage({
-            id: ETranslations.perp_position_tp_sl,
-          })}
-          labelProps={{
-            fontSize: getFontSize('$bodyMd'),
-            color: '$textSubdued',
-          }}
-          containerProps={{ alignItems: 'center' }}
-          width="$4"
-          height="$4"
-        />
-        {hasTpsl ? (
-          <YStack gap="$2">
-            <TpSlFormInput
-              type="tp"
-              label={intl.formatMessage({
-                id: ETranslations.perp_trade_tp_price,
-              })}
-              value={tpValue}
-              inputType={tpType}
-              referencePrice={effectivePrice}
-              szDecimals={szDecimals ?? 0}
-              onChange={setTpValue}
-              onTypeChange={setTpType}
-            />
-            <TpSlFormInput
-              type="sl"
-              label={intl.formatMessage({
-                id: ETranslations.perp_trade_sl_price,
-              })}
-              value={slValue}
-              inputType={slType}
-              referencePrice={effectivePrice}
-              szDecimals={szDecimals ?? 0}
-              onChange={setSlValue}
-              onTypeChange={setSlType}
-            />
-          </YStack>
-        ) : null}
-        <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
-          <Button
-            testID={PerpTestIDs.AddPositionConfirmButton}
-            size={PERP_DIALOG_BUTTON_SIZE}
-            variant="primary"
+        <YStack gap="$1.5">
+          <PerpsSlider
+            min={0}
+            max={100}
+            value={
+              sizeInputMode === EPerpsSizeInputMode.SLIDER ? sizePercent : 0
+            }
+            onChange={handleSliderPercentChange}
             disabled={isSubmitting || !isTargetAssetReady}
-            loading={isSubmitting}
-            onPress={handleSubmit}
-          >
-            {intl.formatMessage({
-              id: ETranslations.perp_confirm_order_action,
-            })}
-          </Button>
-        </TradingGuardWrapper>
+            segments={4}
+            snapTapToSegment
+            showBubble={false}
+            sliderHeight={4}
+          />
+          <YStack gap="$2">
+            <Checkbox
+              testID="perp-add-position-tpsl-checkbox"
+              value={hasTpsl}
+              onChange={(checked) => handleTpslCheckboxChange(Boolean(checked))}
+              label={intl.formatMessage({
+                id: ETranslations.perp_position_tp_sl,
+              })}
+              labelProps={{
+                fontSize: getFontSize('$bodyMd'),
+                color: '$textSubdued',
+              }}
+              containerProps={{ alignItems: 'center' }}
+              width="$4"
+              height="$4"
+            />
+            {hasTpsl ? (
+              <YStack gap="$4">
+                <TpSlFormInput
+                  type="tp"
+                  label={intl.formatMessage({
+                    id: ETranslations.perp_trade_tp_price,
+                  })}
+                  value={tpValue}
+                  inputType={tpType}
+                  referencePrice={effectivePrice}
+                  szDecimals={szDecimals ?? 0}
+                  onChange={setTpValue}
+                  onTypeChange={setTpType}
+                />
+                <TpSlFormInput
+                  type="sl"
+                  label={intl.formatMessage({
+                    id: ETranslations.perp_trade_sl_price,
+                  })}
+                  value={slValue}
+                  inputType={slType}
+                  referencePrice={effectivePrice}
+                  szDecimals={szDecimals ?? 0}
+                  onChange={setSlValue}
+                  onTypeChange={setSlType}
+                />
+              </YStack>
+            ) : null}
+          </YStack>
+        </YStack>
+        <YStack pt={hasTpsl ? tpslButtonPaddingTop : undefined}>
+          <TradingGuardWrapper buttonSize={PERP_DIALOG_BUTTON_SIZE}>
+            <Button
+              testID={PerpTestIDs.AddPositionConfirmButton}
+              size={PERP_DIALOG_BUTTON_SIZE}
+              variant="primary"
+              disabled={isSubmitting || !isTargetAssetReady}
+              loading={isSubmitting}
+              onPress={handleSubmit}
+            >
+              {intl.formatMessage({
+                id: ETranslations.perp_confirm_order_action,
+              })}
+            </Button>
+          </TradingGuardWrapper>
+        </YStack>
       </YStack>
     );
   },
@@ -641,16 +653,18 @@ export function showAddPositionDialog({
     renderContent: (
       <PerpsAccountSelectorProviderMirror>
         <PerpsProviderMirror>
-          <AddPositionForm
-            coin={coin}
-            isBuy={isBuy}
-            accountAddress={accountAddress}
-            onClose={() => dialogInstance.close()}
-          />
+          <PerpKeyboardAwareDialogContent>
+            <AddPositionForm
+              coin={coin}
+              isBuy={isBuy}
+              accountAddress={accountAddress}
+              onClose={() => dialogInstance.close()}
+            />
+          </PerpKeyboardAwareDialogContent>
         </PerpsProviderMirror>
       </PerpsAccountSelectorProviderMirror>
     ),
-    contentContainerProps: PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+    contentContainerProps: PERP_KEYBOARD_AWARE_DIALOG_CONTENT_CONTAINER_PROPS,
     showFooter: false,
   });
   return dialogInstance;

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
@@ -39,8 +39,8 @@ import type {
   IHex,
 } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
-import { usePerpsAccountScopedActivePositions } from '../../hooks/usePerpsAccountScopedActivePositions';
 import { useCoinOrderBookTop } from '../../hooks/useCoinOrderBookTop';
+import { usePerpsAccountScopedActivePositions } from '../../hooks/usePerpsAccountScopedActivePositions';
 import { PerpsAccountSelectorProviderMirror } from '../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 import { PerpTestIDs } from '../../testIDs';

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { BigNumber } from 'bignumber.js';
-import { useIntl } from 'react-intl';
+import { type IntlShape, useIntl } from 'react-intl';
 
 import {
   Button,
@@ -43,6 +43,7 @@ import { usePerpsAccountScopedActivePositions } from '../../hooks/usePerpsAccoun
 import { PerpsAccountSelectorProviderMirror } from '../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 import { PerpTestIDs } from '../../testIDs';
+import { getAggressiveLimitPriceWarning } from '../../utils/aggressiveLimitPrice';
 import { resolveTpSlTriggerPx } from '../../utils/resolveTpSlTriggerPx';
 import { buildDefaultTpSlPercent } from '../../utils/tpslSeed';
 import {
@@ -55,6 +56,7 @@ import { TradingGuardWrapper } from '../TradingGuardWrapper';
 import { PriceInput } from '../TradingPanel/inputs/PriceInput';
 import { SizeInput } from '../TradingPanel/inputs/SizeInput';
 import { TpSlFormInput } from '../TradingPanel/inputs/TpSlFormInput';
+import { AggressiveLimitPriceWarning } from '../TradingPanel/modals/AggressiveLimitPriceWarning';
 
 import {
   buildAddPositionMinimumAmountLabel,
@@ -64,7 +66,7 @@ import {
 } from './utils/addPosition';
 
 import type { IAddPositionValidationError } from './utils/addPosition';
-import type { IntlShape } from 'react-intl';
+
 type IAddPositionOrderType = 'market' | 'limit';
 
 export interface IAddPositionParams {
@@ -114,6 +116,10 @@ const AddPositionForm = memo(
     const [targetAsset, setTargetAsset] = useState<IPerpsActiveAssetAtom>();
     const [isLoadingAssetData, setIsLoadingAssetData] = useState(true);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [orderBookTop, setOrderBookTop] = useState<{
+      bestBid?: string;
+      bestAsk?: string;
+    }>({});
     const requestIdRef = useRef(0);
     const isLimitPriceInitializedRef = useRef(false);
 
@@ -181,6 +187,25 @@ const AddPositionForm = memo(
     }, [fetchTargetAssetData]);
 
     useEffect(() => {
+      let disposed = false;
+      setOrderBookTop({});
+      void backgroundApiProxy.serviceHyperliquid
+        .fetchL2BookByCoin({ coin })
+        .then((book) => {
+          if (!disposed) {
+            setOrderBookTop({
+              bestBid: book?.levels?.[0]?.[0]?.px,
+              bestAsk: book?.levels?.[1]?.[0]?.px,
+            });
+          }
+        })
+        .catch(() => undefined);
+      return () => {
+        disposed = true;
+      };
+    }, [coin]);
+
+    useEffect(() => {
       if (midPrice && !isLimitPriceInitializedRef.current) {
         setLimitPrice(formatPriceToSignificantDigits(midPrice));
         isLimitPriceInitializedRef.current = true;
@@ -213,6 +238,24 @@ const AddPositionForm = memo(
       targetAsset.assetId !== undefined &&
       szDecimals !== undefined &&
       isAddPositionAssetDataScoped({ data: assetData, coin, accountAddress }),
+    );
+    const aggressiveLimitPriceWarning = useMemo(
+      () =>
+        orderType === 'limit'
+          ? getAggressiveLimitPriceWarning({
+              side: isBuy ? 'long' : 'short',
+              limitPrice,
+              bestBid: orderBookTop.bestBid,
+              bestAsk: orderBookTop.bestAsk,
+            })
+          : undefined,
+      [
+        isBuy,
+        limitPrice,
+        orderBookTop.bestAsk,
+        orderBookTop.bestBid,
+        orderType,
+      ],
     );
     const resolvedSize = useMemo(
       () =>
@@ -405,7 +448,7 @@ const AddPositionForm = memo(
           szDecimals: latestSzDecimals,
         });
 
-        await actions.current.placeOrderByCoin({
+        const orderParams = {
           coin,
           expectedAccountAddress: accountAddress,
           isBuy,
@@ -415,8 +458,12 @@ const AddPositionForm = memo(
           tif: orderType === 'limit' ? 'Gtc' : undefined,
           tpTriggerPx,
           slTriggerPx,
-        });
-        onClose();
+        } as const;
+        const placeOrder = async () => {
+          await actions.current.placeOrderByCoin(orderParams);
+          onClose();
+        };
+        await placeOrder();
       } catch (error) {
         Toast.error({
           title:
@@ -460,6 +507,10 @@ const AddPositionForm = memo(
 
     return (
       <YStack gap="$4">
+        {aggressiveLimitPriceWarning ? (
+          <AggressiveLimitPriceWarning warning={aggressiveLimitPriceWarning} />
+        ) : null}
+
         <YStack gap="$3">
           <XStack justifyContent="space-between" alignItems="center">
             <SizableText size="$bodyMd" color="$textSubdued">

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
@@ -40,6 +40,7 @@ import type {
 } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 import { usePerpsAccountScopedActivePositions } from '../../hooks/usePerpsAccountScopedActivePositions';
+import { useCoinOrderBookTop } from '../../hooks/useCoinOrderBookTop';
 import { PerpsAccountSelectorProviderMirror } from '../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 import { PerpTestIDs } from '../../testIDs';
@@ -116,10 +117,7 @@ const AddPositionForm = memo(
     const [targetAsset, setTargetAsset] = useState<IPerpsActiveAssetAtom>();
     const [isLoadingAssetData, setIsLoadingAssetData] = useState(true);
     const [isSubmitting, setIsSubmitting] = useState(false);
-    const [orderBookTop, setOrderBookTop] = useState<{
-      bestBid?: string;
-      bestAsk?: string;
-    }>({});
+    const orderBookTop = useCoinOrderBookTop(coin);
     const requestIdRef = useRef(0);
     const isLimitPriceInitializedRef = useRef(false);
 
@@ -185,25 +183,6 @@ const AddPositionForm = memo(
         disposed = true;
       };
     }, [fetchTargetAssetData]);
-
-    useEffect(() => {
-      let disposed = false;
-      setOrderBookTop({});
-      void backgroundApiProxy.serviceHyperliquid
-        .fetchL2BookByCoin({ coin })
-        .then((book) => {
-          if (!disposed) {
-            setOrderBookTop({
-              bestBid: book?.levels?.[0]?.[0]?.px,
-              bestAsk: book?.levels?.[1]?.[0]?.px,
-            });
-          }
-        })
-        .catch(() => undefined);
-      return () => {
-        disposed = true;
-      };
-    }, [coin]);
 
     useEffect(() => {
       if (midPrice && !isLimitPriceInitializedRef.current) {

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
@@ -34,8 +34,9 @@ import type { IWsWebData2 } from '@onekeyhq/shared/types/hyperliquid/sdk';
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 import {
   PERP_DIALOG_BUTTON_SIZE,
-  PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+  PERP_KEYBOARD_AWARE_DIALOG_CONTENT_CONTAINER_PROPS,
 } from '../PerpDialogLayout';
+import { PerpKeyboardAwareDialogContent } from '../PerpKeyboardAwareDialogContent';
 import { PerpsSlider } from '../PerpsSlider';
 import { TradingGuardWrapper } from '../TradingGuardWrapper';
 import { PriceInput } from '../TradingPanel/inputs/PriceInput';
@@ -543,14 +544,16 @@ export function showClosePositionDialog({
     disableDrag: true,
     renderContent: (
       <PerpsProviderMirror>
-        <ClosePositionForm
-          position={position}
-          type={type}
-          onClose={() => dialogInstance.close()}
-        />
+        <PerpKeyboardAwareDialogContent>
+          <ClosePositionForm
+            position={position}
+            type={type}
+            onClose={() => dialogInstance.close()}
+          />
+        </PerpKeyboardAwareDialogContent>
       </PerpsProviderMirror>
     ),
-    contentContainerProps: PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS,
+    contentContainerProps: PERP_KEYBOARD_AWARE_DIALOG_CONTENT_CONTAINER_PROPS,
     showFooter: false,
   });
 

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { BigNumber } from 'bignumber.js';
 import { isNil } from 'lodash';
-import { useIntl } from 'react-intl';
+import { type IntlShape, useIntl } from 'react-intl';
 
 import {
   Button,
@@ -32,6 +32,7 @@ import {
 import type { IWsWebData2 } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
+import { getAggressiveLimitPriceWarning } from '../../utils/aggressiveLimitPrice';
 import {
   PERP_DIALOG_BUTTON_SIZE,
   PERP_KEYBOARD_AWARE_DIALOG_CONTENT_CONTAINER_PROPS,
@@ -41,8 +42,7 @@ import { PerpsSlider } from '../PerpsSlider';
 import { TradingGuardWrapper } from '../TradingGuardWrapper';
 import { PriceInput } from '../TradingPanel/inputs/PriceInput';
 import { TradingFormInput } from '../TradingPanel/inputs/TradingFormInput';
-
-import type { IntlShape } from 'react-intl';
+import { AggressiveLimitPriceWarning } from '../TradingPanel/modals/AggressiveLimitPriceWarning';
 
 type IPosition =
   IWsWebData2['clearinghouseState']['assetPositions'][number]['position'];
@@ -136,6 +136,48 @@ const ClosePositionForm = memo(
     }, []);
 
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [orderBookTop, setOrderBookTop] = useState<{
+      bestBid?: string;
+      bestAsk?: string;
+    }>({});
+
+    useEffect(() => {
+      let disposed = false;
+      setOrderBookTop({});
+      void backgroundApiProxy.serviceHyperliquid
+        .fetchL2BookByCoin({ coin: position.coin })
+        .then((book) => {
+          if (!disposed) {
+            setOrderBookTop({
+              bestBid: book?.levels?.[0]?.[0]?.px,
+              bestAsk: book?.levels?.[1]?.[0]?.px,
+            });
+          }
+        })
+        .catch(() => undefined);
+      return () => {
+        disposed = true;
+      };
+    }, [position.coin]);
+
+    const aggressiveLimitPriceWarning = useMemo(
+      () =>
+        formData.type === 'limit'
+          ? getAggressiveLimitPriceWarning({
+              side: isLongPosition ? 'short' : 'long',
+              limitPrice: formData.limitPrice,
+              bestBid: orderBookTop.bestBid,
+              bestAsk: orderBookTop.bestAsk,
+            })
+          : undefined,
+      [
+        formData.limitPrice,
+        formData.type,
+        isLongPosition,
+        orderBookTop.bestAsk,
+        orderBookTop.bestBid,
+      ],
+    );
 
     const calculatedAmount = useMemo(() => {
       const percentage = Number.isNaN(formData.percentage)
@@ -254,6 +296,13 @@ const ClosePositionForm = memo(
           return;
         }
 
+        const finishClosePosition = () => {
+          hyperliquidActions.current.resetTradingForm();
+          if (isMountedRef.current) {
+            onClose();
+          }
+        };
+
         if (formData.type === 'market') {
           const latestMidPrice = midPrice;
           if (!latestMidPrice || latestMidPrice === '0') {
@@ -271,6 +320,7 @@ const ClosePositionForm = memo(
               midPx: latestMidPrice,
             },
           ]);
+          finishClosePosition();
         } else {
           const limitPriceBN = new BigNumber(formData.limitPrice || '0');
           if (!formData.limitPrice || limitPriceBN.lte(0)) {
@@ -280,19 +330,19 @@ const ClosePositionForm = memo(
             return;
           }
 
-          await hyperliquidActions.current.ordersClose([
+          const closeOrderParams = [
             {
               assetId,
               isBuy: isLongPosition,
               size: closeAmount,
               limitPx: formData.limitPrice,
             },
-          ]);
-        }
-
-        hyperliquidActions.current.resetTradingForm();
-        if (isMountedRef.current) {
-          onClose();
+          ];
+          const closePosition = async () => {
+            await hyperliquidActions.current.ordersClose(closeOrderParams);
+            finishClosePosition();
+          };
+          await closePosition();
         }
       } finally {
         if (isMountedRef.current) {
@@ -387,6 +437,10 @@ const ClosePositionForm = memo(
 
     return (
       <YStack gap="$4">
+        {aggressiveLimitPriceWarning ? (
+          <AggressiveLimitPriceWarning warning={aggressiveLimitPriceWarning} />
+        ) : null}
+
         <YStack gap="$3">
           <XStack justifyContent="space-between" alignItems="center">
             <SizableText size="$bodyMd" color="$textSubdued">

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
@@ -32,6 +32,7 @@ import {
 import type { IWsWebData2 } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
 import { PerpsProviderMirror } from '../../PerpsProviderMirror';
+import { useCoinOrderBookTop } from '../../hooks/useCoinOrderBookTop';
 import { getAggressiveLimitPriceWarning } from '../../utils/aggressiveLimitPrice';
 import {
   PERP_DIALOG_BUTTON_SIZE,
@@ -136,29 +137,7 @@ const ClosePositionForm = memo(
     }, []);
 
     const [isSubmitting, setIsSubmitting] = useState(false);
-    const [orderBookTop, setOrderBookTop] = useState<{
-      bestBid?: string;
-      bestAsk?: string;
-    }>({});
-
-    useEffect(() => {
-      let disposed = false;
-      setOrderBookTop({});
-      void backgroundApiProxy.serviceHyperliquid
-        .fetchL2BookByCoin({ coin: position.coin })
-        .then((book) => {
-          if (!disposed) {
-            setOrderBookTop({
-              bestBid: book?.levels?.[0]?.[0]?.px,
-              bestAsk: book?.levels?.[1]?.[0]?.px,
-            });
-          }
-        })
-        .catch(() => undefined);
-      return () => {
-        disposed = true;
-      };
-    }, [position.coin]);
+    const orderBookTop = useCoinOrderBookTop(position.coin);
 
     const aggressiveLimitPriceWarning = useMemo(
       () =>

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/ClosePositionModal.tsx
@@ -31,8 +31,8 @@ import {
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { IWsWebData2 } from '@onekeyhq/shared/types/hyperliquid/sdk';
 
-import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 import { useCoinOrderBookTop } from '../../hooks/useCoinOrderBookTop';
+import { PerpsProviderMirror } from '../../PerpsProviderMirror';
 import { getAggressiveLimitPriceWarning } from '../../utils/aggressiveLimitPrice';
 import {
   PERP_DIALOG_BUTTON_SIZE,

--- a/packages/kit/src/views/Perp/components/PerpDialogLayout.ts
+++ b/packages/kit/src/views/Perp/components/PerpDialogLayout.ts
@@ -4,6 +4,9 @@ export const PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS = platformEnv.isNative
   ? ({ pb: '$5' } as const)
   : undefined;
 
+export const PERP_KEYBOARD_AWARE_DIALOG_CONTENT_CONTAINER_PROPS =
+  platformEnv.isNative ? ({ pb: 0 } as const) : undefined;
+
 export const PERP_DIALOG_BUTTON_SIZE = platformEnv.isNative
   ? ('large' as const)
   : ('medium' as const);

--- a/packages/kit/src/views/Perp/components/PerpKeyboardAwareDialogContent.tsx
+++ b/packages/kit/src/views/Perp/components/PerpKeyboardAwareDialogContent.tsx
@@ -1,0 +1,59 @@
+import { type ReactNode, useMemo } from 'react';
+
+import { useWindowDimensions } from 'react-native';
+
+import {
+  Keyboard,
+  YStack,
+  useKeyboardHeight,
+  useSafeAreaInsets,
+} from '@onekeyhq/components';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+const PERP_DIALOG_TOP_SAFE_GAP = 16;
+const PERP_DIALOG_CHROME_HEIGHT = 176;
+const PERP_DIALOG_MIN_CONTENT_HEIGHT = 120;
+
+export function PerpKeyboardAwareDialogContent({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const keyboardHeight = useKeyboardHeight();
+  const { top: safeAreaTop } = useSafeAreaInsets();
+  const { height: windowHeight } = useWindowDimensions();
+  const contentMaxHeight = useMemo(() => {
+    if (!platformEnv.isNative) {
+      return undefined;
+    }
+
+    const availableHeight =
+      windowHeight -
+      Math.max(keyboardHeight, 0) -
+      safeAreaTop -
+      PERP_DIALOG_TOP_SAFE_GAP -
+      PERP_DIALOG_CHROME_HEIGHT;
+
+    return Math.max(availableHeight, PERP_DIALOG_MIN_CONTENT_HEIGHT);
+  }, [keyboardHeight, safeAreaTop, windowHeight]);
+
+  if (!platformEnv.isNative) {
+    return children;
+  }
+
+  return (
+    <Keyboard.AwareScrollView
+      style={{ maxHeight: contentMaxHeight }}
+      // The dialog viewport already excludes the keyboard height.
+      extraKeyboardSpace={-keyboardHeight}
+      bounces={false}
+      keyboardDismissMode="none"
+      keyboardShouldPersistTaps="handled"
+      showsVerticalScrollIndicator={false}
+    >
+      <YStack width="100%" pb={keyboardHeight > 0 ? 0 : '$5'}>
+        {children}
+      </YStack>
+    </Keyboard.AwareScrollView>
+  );
+}

--- a/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingPanel.tsx
@@ -25,7 +25,9 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 
 import { useOrderConfirm } from '../../hooks';
+import { useGetAggressiveLimitPriceWarning } from '../../hooks/useAggressiveLimitPriceWarning';
 import { useOrderPrice } from '../../hooks/useOrderPrice';
+import { shouldShowOrderConfirm } from '../../utils/aggressiveLimitPrice';
 import { getPerpsFormLeverage } from '../../utils/leverageDisplay';
 import { shouldApplyMinimumOrderGuard } from '../../utils/minimumOrderGuard';
 import {
@@ -56,6 +58,7 @@ function PerpTradingDisabledPlaceOrderButton() {
   const computedSizeBN = useTradingFormComputedSize();
   const { isSubmitting, handleConfirm } = useOrderConfirm();
   const { price: effectivePriceBN } = useOrderPrice(formData.side);
+  const getAggressiveLimitPriceWarning = useGetAggressiveLimitPriceWarning();
 
   const [perpsCustomSettings] = usePerpsCustomSettingsAtom();
   const [tradingMode] = useTradingModeAtom();
@@ -152,13 +155,26 @@ function PerpTradingDisabledPlaceOrderButton() {
       );
       return;
     }
-    if (perpsCustomSettings.skipOrderConfirm) {
+    const aggressiveLimitPriceWarning = getAggressiveLimitPriceWarning({
+      formData,
+      side: formData.side,
+      price: effectivePriceBN.toFixed(),
+    });
+    if (
+      shouldShowOrderConfirm({
+        skipOrderConfirm: perpsCustomSettings.skipOrderConfirm,
+        aggressiveLimitPriceWarning,
+      })
+    ) {
+      showOrderConfirmDialog({ intl, aggressiveLimitPriceWarning });
+    } else {
       void handleConfirm();
-      return;
     }
-    showOrderConfirmDialog({ intl });
   }, [
     activeAssetData,
+    effectivePriceBN,
+    formData,
+    getAggressiveLimitPriceWarning,
     perpsCustomSettings.skipOrderConfirm,
     handleConfirm,
     intl,

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -83,6 +83,7 @@ import {
   useOrderConfirmWithMarketDataFreshness,
   usePerpsMarketDataFreshness,
 } from '../../hooks';
+import { useGetAggressiveLimitPriceWarning } from '../../hooks/useAggressiveLimitPriceWarning';
 import {
   type IEnableTradingWithDepositFallbackResult,
   useConfirmHyperliquidTerms,
@@ -94,6 +95,7 @@ import { useTradingCalculationsForSide } from '../../hooks/useTradingCalculation
 import { useTradingPrice } from '../../hooks/useTradingPrice';
 import { PerpTestIDs } from '../../testIDs';
 import { shouldPreserveColdStartButtonVisualState } from '../../utils/accountScopedData';
+import { shouldShowOrderConfirm } from '../../utils/aggressiveLimitPrice';
 import { getEnableTradingDialogConfirmDecision } from '../../utils/enableTradingDialogConfirm';
 import { shouldApplyMinimumOrderGuard } from '../../utils/minimumOrderGuard';
 import {
@@ -457,6 +459,7 @@ function SideButtonInternal({
 
   const [isSubmitting] = useTradingLoadingAtom();
   const { midPriceBN } = useTradingPrice();
+  const getAggressiveLimitPriceWarning = useGetAggressiveLimitPriceWarning();
   const shouldBlockForMarketData =
     shouldBlockPerpsTradingForMarketData(marketDataFreshness);
   const confirmHyperliquidTerms = useConfirmHyperliquidTerms();
@@ -1478,13 +1481,24 @@ function SideButtonInternal({
         });
       }
 
-      if (submitState.perpsCustomSettings.skipOrderConfirm) {
-        void handleConfirmRef.current(side);
-      } else {
+      const aggressiveLimitPriceWarning = getAggressiveLimitPriceWarning({
+        formData: submitState.formData,
+        side,
+        price: submitState.effectivePriceBN.toFixed(),
+      });
+      if (
+        shouldShowOrderConfirm({
+          skipOrderConfirm: submitState.perpsCustomSettings.skipOrderConfirm,
+          aggressiveLimitPriceWarning,
+        })
+      ) {
         showOrderConfirmDialog({
           overrideSide: side,
           intl,
+          aggressiveLimitPriceWarning,
         });
+      } else {
+        void handleConfirmRef.current(side);
       }
     },
     1000,

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/TradingFormInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/TradingFormInput.tsx
@@ -26,23 +26,25 @@ export const InputAccessoryDoneButton = ({
   const isKeyboardShown = useIsKeyboardShown();
   if (!platformEnv.isNativeIOS && !isKeyboardShown) return null;
   return (
-    <XStack
-      p="$2.5"
-      px="$3.5"
-      justifyContent={leftContent ? 'space-between' : 'flex-end'}
-      bg="$bgSubdued"
-      borderTopWidth="$px"
-      borderTopColor="$borderSubduedLight"
-    >
-      {leftContent}
-      <Button
-        variant="tertiary"
-        onPress={() => Keyboard.dismiss()}
-        testID="perp-is-keyboard-shown-btn"
+    <YStack pt="$2" bg="$bgApp">
+      <XStack
+        p="$2.5"
+        px="$3.5"
+        justifyContent={leftContent ? 'space-between' : 'flex-end'}
+        bg="$bgSubdued"
+        borderTopWidth="$px"
+        borderTopColor="$borderSubduedLight"
       >
-        {intl.formatMessage({ id: ETranslations.global_done })}
-      </Button>
-    </XStack>
+        {leftContent}
+        <Button
+          variant="tertiary"
+          onPress={() => Keyboard.dismiss()}
+          testID="perp-is-keyboard-shown-btn"
+        >
+          {intl.formatMessage({ id: ETranslations.global_done })}
+        </Button>
+      </XStack>
+    </YStack>
   );
 };
 

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/AggressiveLimitPriceWarning.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/AggressiveLimitPriceWarning.tsx
@@ -1,0 +1,56 @@
+import { useIntl } from 'react-intl';
+
+import { Icon, SizableText, XStack } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { numberFormat } from '@onekeyhq/shared/src/utils/numberUtils';
+
+import type { IAggressiveLimitPriceWarning } from '../../../utils/aggressiveLimitPrice';
+
+export function AggressiveLimitPriceWarning({
+  warning,
+}: {
+  warning: IAggressiveLimitPriceWarning;
+}) {
+  const intl = useIntl();
+  const percentage = intl.formatNumber(warning.deviationPercent, {
+    style: 'decimal',
+    maximumFractionDigits: 2,
+  });
+  const referencePrice = numberFormat(warning.referencePrice, {
+    formatter: 'value',
+    formatterOptions: { currency: '$' },
+  });
+
+  return (
+    <XStack
+      borderRadius="$3"
+      backgroundColor="$bgCriticalSubdued"
+      px="$3"
+      py="$2.5"
+      alignItems="flex-start"
+      gap="$2"
+    >
+      <Icon
+        name="InfoCircleOutline"
+        size="$4"
+        color="$iconCritical"
+        flexShrink={0}
+        mt="$0.5"
+      />
+      <SizableText size="$bodySm" color="$textCritical" flex={1}>
+        {intl.formatMessage(
+          {
+            id:
+              warning.side === 'long'
+                ? ETranslations.perp_aggressive_limit_buy_price_warning__msg
+                : ETranslations.perp_aggressive_limit_sell_warning__msg,
+          },
+          {
+            percentage,
+            referencePrice,
+          },
+        )}
+      </SizableText>
+    </XStack>
+  );
+}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -55,7 +55,10 @@ import { TradingGuardWrapper } from '../../TradingGuardWrapper';
 import { LiquidationPriceDisplay } from '../components/LiquidationPriceDisplay';
 import { formatBboModeLabel } from '../selectors/bboDisplay';
 
+import { AggressiveLimitPriceWarning } from './AggressiveLimitPriceWarning';
+
 import type { IEnableTradingWithDepositFallbackResult } from '../../../hooks/useEnableTradingWithDepositFallback';
+import type { IAggressiveLimitPriceWarning } from '../../../utils/aggressiveLimitPrice';
 import type { IntlShape } from 'react-intl';
 
 const SAVED_FEE_BENCHMARK_RATE = 0.0004;
@@ -89,6 +92,7 @@ interface IOrderConfirmContentProps {
   // Coin the override ticket was built for; submit aborts if the live active
   // instrument no longer matches (active-asset switch between press and confirm).
   expectedCoin?: string;
+  aggressiveLimitPriceWarning?: IAggressiveLimitPriceWarning;
   // Fired only after a successful override submit (chart popover closes itself).
   onConfirmSuccess?: () => void;
 }
@@ -120,6 +124,7 @@ function OrderConfirmContent({
   formDataOverride,
   priceOverride,
   expectedCoin,
+  aggressiveLimitPriceWarning,
   onConfirmSuccess,
 }: IOrderConfirmContentProps) {
   const [isPreparingEnableTrading, setIsPreparingEnableTrading] =
@@ -571,6 +576,10 @@ function OrderConfirmContent({
 
   return (
     <YStack gap="$4" p="$1">
+      {aggressiveLimitPriceWarning ? (
+        <AggressiveLimitPriceWarning warning={aggressiveLimitPriceWarning} />
+      ) : null}
+
       {/* Order Details */}
       <YStack gap="$3">
         {/* Action */}
@@ -897,6 +906,7 @@ export function showOrderConfirmDialog({
   formData,
   price,
   expectedCoin,
+  aggressiveLimitPriceWarning,
   onConfirmSuccess,
 }: {
   overrideSide?: 'long' | 'short';
@@ -911,6 +921,7 @@ export function showOrderConfirmDialog({
   price?: string;
   // Coin the override ticket was built for; submit aborts on a live-coin mismatch.
   expectedCoin?: string;
+  aggressiveLimitPriceWarning?: IAggressiveLimitPriceWarning;
   // Fired only after a successful override submit (chart popover closes itself).
   onConfirmSuccess?: () => void;
 }) {
@@ -931,6 +942,7 @@ export function showOrderConfirmDialog({
             formDataOverride={formData}
             priceOverride={price}
             expectedCoin={expectedCoin}
+            aggressiveLimitPriceWarning={aggressiveLimitPriceWarning}
             onConfirmSuccess={onConfirmSuccess}
           />
         </PerpsProviderMirror>

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
@@ -78,6 +78,7 @@ import { useShowDepositWithdrawModal } from '../../../hooks/useShowDepositWithdr
 import { useTradingPrice } from '../../../hooks/useTradingPrice';
 import { PerpsAccountSelectorProviderMirror } from '../../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
+import { getAggressiveLimitPriceWarningFromBbo } from '../../../utils/aggressiveLimitPrice';
 import { getEnableTradingDialogConfirmDecision } from '../../../utils/enableTradingDialogConfirm';
 import { shouldApplyMinimumOrderGuard } from '../../../utils/minimumOrderGuard';
 import { shouldBlockPerpsTradingForMarketData } from '../../../utils/perpsMarketDataFreshness';
@@ -255,7 +256,7 @@ export function LimitOrderForm({
 
   // Track BBO + mid in refs so the side-button press handlers can resolve the
   // concrete price without depending on the latest render closure.
-  const bbo = useBboForOrderPrice(isBBOActive);
+  const bbo = useBboForOrderPrice(!isSpot);
   const bboRef = useRef(bbo);
   bboRef.current = bbo;
   const midPriceBNRef = useRef(midPriceBN);
@@ -886,6 +887,18 @@ export function LimitOrderForm({
         slValue,
         orderMode: 'standard',
       };
+      const aggressiveLimitPriceWarning = isSpot
+        ? undefined
+        : getAggressiveLimitPriceWarningFromBbo({
+            coin: symbol,
+            side: pressedSide,
+            type: builtFormData.type,
+            orderMode: builtFormData.orderMode,
+            limitPrice: resolvedPrice,
+            limitTif: builtFormData.limitTif,
+            bboPriceMode: builtFormData.bboPriceMode,
+            bbo: bboRef.current,
+          });
 
       showOrderConfirmDialog({
         overrideSide: pressedSide,
@@ -893,6 +906,7 @@ export function LimitOrderForm({
         price: resolvedPrice,
         expectedCoin: symbol,
         intl,
+        aggressiveLimitPriceWarning,
         onConfirmSuccess: onClose,
       });
     },

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
@@ -76,9 +76,9 @@ import { usePerpsAccountScopedActivePositions } from '../../../hooks/usePerpsAcc
 import { usePerpsMarketDataFreshness } from '../../../hooks/usePerpsMarketDataFreshness';
 import { useShowDepositWithdrawModal } from '../../../hooks/useShowDepositWithdrawModal';
 import { useTradingPrice } from '../../../hooks/useTradingPrice';
+import { useGetAggressiveLimitPriceWarning } from '../../../hooks/useAggressiveLimitPriceWarning';
 import { PerpsAccountSelectorProviderMirror } from '../../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
-import { getAggressiveLimitPriceWarningFromBbo } from '../../../utils/aggressiveLimitPrice';
 import { getEnableTradingDialogConfirmDecision } from '../../../utils/enableTradingDialogConfirm';
 import { shouldApplyMinimumOrderGuard } from '../../../utils/minimumOrderGuard';
 import { shouldBlockPerpsTradingForMarketData } from '../../../utils/perpsMarketDataFreshness';
@@ -256,11 +256,12 @@ export function LimitOrderForm({
 
   // Track BBO + mid in refs so the side-button press handlers can resolve the
   // concrete price without depending on the latest render closure.
-  const bbo = useBboForOrderPrice(!isSpot);
+  const bbo = useBboForOrderPrice(isBBOActive);
   const bboRef = useRef(bbo);
   bboRef.current = bbo;
   const midPriceBNRef = useRef(midPriceBN);
   midPriceBNRef.current = midPriceBN;
+  const getAggressiveLimitPriceWarning = useGetAggressiveLimitPriceWarning();
 
   // With a BBO mode the price comes from the live orderbook; otherwise the typed input.
   const resolvePriceForSide = useCallback(
@@ -889,15 +890,11 @@ export function LimitOrderForm({
       };
       const aggressiveLimitPriceWarning = isSpot
         ? undefined
-        : getAggressiveLimitPriceWarningFromBbo({
+        : getAggressiveLimitPriceWarning({
             coin: symbol,
+            formData: builtFormData,
             side: pressedSide,
-            type: builtFormData.type,
-            orderMode: builtFormData.orderMode,
-            limitPrice: resolvedPrice,
-            limitTif: builtFormData.limitTif,
-            bboPriceMode: builtFormData.bboPriceMode,
-            bbo: bboRef.current,
+            price: resolvedPrice,
           });
 
       showOrderConfirmDialog({
@@ -919,6 +916,7 @@ export function LimitOrderForm({
       hasTpsl,
       intl,
       isSpot,
+      getAggressiveLimitPriceWarning,
       leverage,
       limitTif,
       marketDataFreshness,

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
@@ -67,6 +67,7 @@ import {
 import type { ITIF } from '@onekeyhq/shared/types/hyperliquid/sdk';
 import { EPerpsSizeInputMode } from '@onekeyhq/shared/types/hyperliquid/types';
 
+import { useGetAggressiveLimitPriceWarning } from '../../../hooks/useAggressiveLimitPriceWarning';
 import {
   useConfirmHyperliquidTerms,
   useRequestEnableTradingWithDepositFallback,
@@ -76,7 +77,6 @@ import { usePerpsAccountScopedActivePositions } from '../../../hooks/usePerpsAcc
 import { usePerpsMarketDataFreshness } from '../../../hooks/usePerpsMarketDataFreshness';
 import { useShowDepositWithdrawModal } from '../../../hooks/useShowDepositWithdrawModal';
 import { useTradingPrice } from '../../../hooks/useTradingPrice';
-import { useGetAggressiveLimitPriceWarning } from '../../../hooks/useAggressiveLimitPriceWarning';
 import { PerpsAccountSelectorProviderMirror } from '../../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
 import { getEnableTradingDialogConfirmDecision } from '../../../utils/enableTradingDialogConfirm';

--- a/packages/kit/src/views/Perp/hooks/useAggressiveLimitPriceWarning.ts
+++ b/packages/kit/src/views/Perp/hooks/useAggressiveLimitPriceWarning.ts
@@ -1,0 +1,46 @@
+import { useCallback, useRef } from 'react';
+
+import {
+  type ITradingFormData,
+  useActiveTradeInstrumentAtom,
+  useBboForOrderPrice,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+
+import {
+  type IAggressiveLimitPriceWarning,
+  getAggressiveLimitPriceWarningFromBbo,
+} from '../utils/aggressiveLimitPrice';
+
+export function useGetAggressiveLimitPriceWarning() {
+  const [activeInstrument] = useActiveTradeInstrumentAtom();
+  const bbo = useBboForOrderPrice(activeInstrument.mode === 'perp');
+  const bboRef = useRef(bbo);
+  bboRef.current = bbo;
+
+  return useCallback(
+    ({
+      formData,
+      side,
+      price,
+    }: {
+      formData: ITradingFormData;
+      side: 'long' | 'short';
+      price?: string;
+    }): IAggressiveLimitPriceWarning | undefined => {
+      if (activeInstrument.mode !== 'perp') {
+        return undefined;
+      }
+      return getAggressiveLimitPriceWarningFromBbo({
+        coin: activeInstrument.coin,
+        side,
+        type: formData.type,
+        orderMode: formData.orderMode,
+        limitPrice: price ?? formData.price,
+        limitTif: formData.limitTif,
+        bboPriceMode: formData.bboPriceMode,
+        bbo: bboRef.current,
+      });
+    },
+    [activeInstrument.coin, activeInstrument.mode],
+  );
+}

--- a/packages/kit/src/views/Perp/hooks/useAggressiveLimitPriceWarning.ts
+++ b/packages/kit/src/views/Perp/hooks/useAggressiveLimitPriceWarning.ts
@@ -1,11 +1,11 @@
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 
 import {
   type ITradingFormData,
   useActiveTradeInstrumentAtom,
-  useBboForOrderPrice,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 
+import { useGetBboForOrderPrice } from '../../../states/jotai/contexts/hyperliquid/atoms';
 import {
   type IAggressiveLimitPriceWarning,
   getAggressiveLimitPriceWarningFromBbo,
@@ -13,16 +13,16 @@ import {
 
 export function useGetAggressiveLimitPriceWarning() {
   const [activeInstrument] = useActiveTradeInstrumentAtom();
-  const bbo = useBboForOrderPrice(activeInstrument.mode === 'perp');
-  const bboRef = useRef(bbo);
-  bboRef.current = bbo;
+  const getBbo = useGetBboForOrderPrice();
 
   return useCallback(
     ({
+      coin,
       formData,
       side,
       price,
     }: {
+      coin?: string;
       formData: ITradingFormData;
       side: 'long' | 'short';
       price?: string;
@@ -31,16 +31,16 @@ export function useGetAggressiveLimitPriceWarning() {
         return undefined;
       }
       return getAggressiveLimitPriceWarningFromBbo({
-        coin: activeInstrument.coin,
+        coin: coin ?? activeInstrument.coin,
         side,
         type: formData.type,
         orderMode: formData.orderMode,
         limitPrice: price ?? formData.price,
         limitTif: formData.limitTif,
         bboPriceMode: formData.bboPriceMode,
-        bbo: bboRef.current,
+        bbo: getBbo(),
       });
     },
-    [activeInstrument.coin, activeInstrument.mode],
+    [activeInstrument.coin, activeInstrument.mode, getBbo],
   );
 }

--- a/packages/kit/src/views/Perp/hooks/useCoinOrderBookTop.ts
+++ b/packages/kit/src/views/Perp/hooks/useCoinOrderBookTop.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { PERPS_L2_BOOK_INTERACTIVE_MAX_AGE_MS } from '@onekeyhq/shared/src/consts/perpCache';
+
+interface IOrderBookTop {
+  bestBid?: string;
+  bestAsk?: string;
+}
+
+const ORDER_BOOK_RETRY_DELAY_MS = 5000;
+
+export function useCoinOrderBookTop(coin: string): IOrderBookTop {
+  const [orderBookTop, setOrderBookTop] = useState<IOrderBookTop>({});
+
+  useEffect(() => {
+    let disposed = false;
+    let refreshTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const fetchOrderBookTop = async () => {
+      setOrderBookTop({});
+      try {
+        const book =
+          await backgroundApiProxy.serviceHyperliquid.fetchL2BookByCoin({
+            coin,
+          });
+        if (disposed) {
+          return;
+        }
+        setOrderBookTop({
+          bestBid: book?.levels?.[0]?.[0]?.px,
+          bestAsk: book?.levels?.[1]?.[0]?.px,
+        });
+        refreshTimer = setTimeout(
+          fetchOrderBookTop,
+          PERPS_L2_BOOK_INTERACTIVE_MAX_AGE_MS,
+        );
+      } catch {
+        if (!disposed) {
+          refreshTimer = setTimeout(
+            fetchOrderBookTop,
+            ORDER_BOOK_RETRY_DELAY_MS,
+          );
+        }
+      }
+    };
+
+    void fetchOrderBookTop();
+    return () => {
+      disposed = true;
+      if (refreshTimer) {
+        clearTimeout(refreshTimer);
+      }
+    };
+  }, [coin]);
+
+  return orderBookTop;
+}

--- a/packages/kit/src/views/Perp/utils/aggressiveLimitPrice.test.ts
+++ b/packages/kit/src/views/Perp/utils/aggressiveLimitPrice.test.ts
@@ -1,0 +1,160 @@
+import type { IPerpsBboWithLocalReceivedAt } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/utils/l2BookUtils';
+
+import {
+  getAggressiveLimitPriceWarning,
+  getAggressiveLimitPriceWarningFromBbo,
+  shouldShowOrderConfirm,
+} from './aggressiveLimitPrice';
+
+const NOW = 10_000;
+const freshBbo: IPerpsBboWithLocalReceivedAt = {
+  coin: 'BTC',
+  time: NOW,
+  localReceivedAt: NOW,
+  bbo: [
+    { px: '99', sz: '1', n: 1 },
+    { px: '100', sz: '1', n: 1 },
+  ],
+};
+
+describe('aggressiveLimitPrice', () => {
+  it('warns when a long limit is at least 3% above the best ask', () => {
+    expect(
+      getAggressiveLimitPriceWarning({
+        side: 'long',
+        limitPrice: '103',
+        bestAsk: '100',
+      }),
+    ).toEqual({
+      side: 'long',
+      deviationPercent: 3,
+      referencePrice: '100',
+    });
+  });
+
+  it('warns when a short limit is at least 3% below the best bid', () => {
+    expect(
+      getAggressiveLimitPriceWarning({
+        side: 'short',
+        limitPrice: '96.03',
+        bestBid: '99',
+      }),
+    ).toEqual({
+      side: 'short',
+      deviationPercent: 3,
+      referencePrice: '99',
+    });
+  });
+
+  it('does not warn below the threshold or for invalid prices', () => {
+    expect(
+      getAggressiveLimitPriceWarning({
+        side: 'long',
+        limitPrice: '102.99',
+        bestAsk: '100',
+      }),
+    ).toBeUndefined();
+    expect(
+      getAggressiveLimitPriceWarning({
+        side: 'short',
+        limitPrice: '0',
+        bestBid: '99',
+      }),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    { type: 'market' as const, orderMode: 'standard' as const },
+    { type: 'limit' as const, orderMode: 'trigger' as const },
+  ])('ignores unsupported order shape %#', ({ type, orderMode }) => {
+    expect(
+      getAggressiveLimitPriceWarningFromBbo({
+        coin: 'BTC',
+        side: 'long',
+        type,
+        orderMode,
+        limitPrice: '110',
+        bbo: freshBbo,
+        now: NOW,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('ignores post-only, BBO-priced, mismatched, or stale orders', () => {
+    const baseParams = {
+      coin: 'BTC',
+      side: 'long' as const,
+      type: 'limit' as const,
+      orderMode: 'standard' as const,
+      limitPrice: '110',
+      bbo: freshBbo,
+      now: NOW,
+    };
+    expect(
+      getAggressiveLimitPriceWarningFromBbo({
+        ...baseParams,
+        limitTif: 'Alo',
+      }),
+    ).toBeUndefined();
+    expect(
+      getAggressiveLimitPriceWarningFromBbo({
+        ...baseParams,
+        bboPriceMode: { type: 'counterparty', offsetTicks: 0 },
+      }),
+    ).toBeUndefined();
+    expect(
+      getAggressiveLimitPriceWarningFromBbo({
+        ...baseParams,
+        coin: 'ETH',
+      }),
+    ).toBeUndefined();
+    expect(
+      getAggressiveLimitPriceWarningFromBbo({
+        ...baseParams,
+        now: NOW + 60_000,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('forces confirmation for an aggressive order even when confirmations are skipped', () => {
+    expect(
+      shouldShowOrderConfirm({
+        skipOrderConfirm: true,
+        aggressiveLimitPriceWarning: {
+          side: 'long',
+          deviationPercent: 3,
+          referencePrice: '100',
+        },
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowOrderConfirm({
+        skipOrderConfirm: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowOrderConfirm({
+        skipOrderConfirm: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('detects a supported standard GTC order from a fresh BBO', () => {
+    expect(
+      getAggressiveLimitPriceWarningFromBbo({
+        coin: 'BTC',
+        side: 'long',
+        type: 'limit',
+        orderMode: 'standard',
+        limitPrice: '103',
+        limitTif: 'Gtc',
+        bbo: freshBbo,
+        now: NOW,
+      }),
+    ).toEqual({
+      side: 'long',
+      deviationPercent: 3,
+      referencePrice: '100',
+    });
+  });
+});

--- a/packages/kit/src/views/Perp/utils/aggressiveLimitPrice.ts
+++ b/packages/kit/src/views/Perp/utils/aggressiveLimitPrice.ts
@@ -1,0 +1,127 @@
+import BigNumber from 'bignumber.js';
+
+import type {
+  IBBOPriceMode,
+  ITradingFormData,
+} from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import { getPerpsMarketDataLocalReceivedAt } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/utils/l2BookUtils';
+import type { IPerpsBboWithLocalReceivedAt } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/utils/l2BookUtils';
+import type { ITIF } from '@onekeyhq/shared/types/hyperliquid/sdk';
+
+import { isPerpsBboInteractive } from './l2BookFreshness';
+
+export const PERPS_AGGRESSIVE_LIMIT_PRICE_THRESHOLD_PERCENT = 3;
+
+export interface IAggressiveLimitPriceWarning {
+  side: 'long' | 'short';
+  deviationPercent: number;
+  referencePrice: string;
+}
+
+export function shouldShowOrderConfirm({
+  skipOrderConfirm,
+  aggressiveLimitPriceWarning,
+}: {
+  skipOrderConfirm: boolean;
+  aggressiveLimitPriceWarning?: IAggressiveLimitPriceWarning;
+}) {
+  return !skipOrderConfirm || Boolean(aggressiveLimitPriceWarning);
+}
+
+interface IGetAggressiveLimitPriceWarningParams {
+  side: 'long' | 'short';
+  limitPrice: string;
+  bestBid?: string;
+  bestAsk?: string;
+  thresholdPercent?: number;
+}
+
+export function getAggressiveLimitPriceWarning({
+  side,
+  limitPrice,
+  bestBid,
+  bestAsk,
+  thresholdPercent = PERPS_AGGRESSIVE_LIMIT_PRICE_THRESHOLD_PERCENT,
+}: IGetAggressiveLimitPriceWarningParams):
+  | IAggressiveLimitPriceWarning
+  | undefined {
+  const price = new BigNumber(limitPrice);
+  const referencePrice = new BigNumber(
+    side === 'long' ? (bestAsk ?? '') : (bestBid ?? ''),
+  );
+  const threshold = new BigNumber(thresholdPercent);
+  if (
+    !price.isFinite() ||
+    price.lte(0) ||
+    !referencePrice.isFinite() ||
+    referencePrice.lte(0) ||
+    !threshold.isFinite() ||
+    threshold.lt(0)
+  ) {
+    return undefined;
+  }
+
+  const deviation =
+    side === 'long'
+      ? price.minus(referencePrice).dividedBy(referencePrice).multipliedBy(100)
+      : referencePrice.minus(price).dividedBy(referencePrice).multipliedBy(100);
+  if (!deviation.isFinite() || deviation.lt(threshold)) {
+    return undefined;
+  }
+
+  return {
+    side,
+    deviationPercent: deviation.toNumber(),
+    referencePrice: referencePrice.toFixed(),
+  };
+}
+
+interface IGetAggressiveLimitPriceWarningFromBboParams {
+  coin: string;
+  side: 'long' | 'short';
+  type: ITradingFormData['type'];
+  orderMode: ITradingFormData['orderMode'];
+  limitPrice: string;
+  limitTif?: ITIF;
+  bboPriceMode?: IBBOPriceMode;
+  bbo: IPerpsBboWithLocalReceivedAt | null;
+  now?: number;
+}
+
+export function getAggressiveLimitPriceWarningFromBbo({
+  coin,
+  side,
+  type,
+  orderMode,
+  limitPrice,
+  limitTif,
+  bboPriceMode,
+  bbo,
+  now = Date.now(),
+}: IGetAggressiveLimitPriceWarningFromBboParams):
+  | IAggressiveLimitPriceWarning
+  | undefined {
+  if (
+    type !== 'limit' ||
+    orderMode !== 'standard' ||
+    bboPriceMode ||
+    limitTif === 'Alo' ||
+    bbo?.coin !== coin ||
+    !bbo.bbo?.[0] ||
+    !bbo.bbo?.[1] ||
+    !isPerpsBboInteractive({
+      bboTime: bbo.time,
+      bboReceivedAt: getPerpsMarketDataLocalReceivedAt(bbo),
+      now,
+    })
+  ) {
+    return undefined;
+  }
+
+  return getAggressiveLimitPriceWarning({
+    side,
+    limitPrice,
+    bestBid: bbo.bbo[0].px,
+    bestAsk: bbo.bbo[1].px,
+  });
+}


### PR DESCRIPTION
## What changed

- Warn when a Perps limit price deviates from the current BBO by 3% or more.
- Compare buy/long orders with the best ask and sell/short orders with the best bid.
- Cover the main trading panel, chart orders, add-position, and close-position flows.
- Force order confirmation for risky limit prices even when normal confirmations are disabled.
- Improve mobile add/close-position dialog keyboard avoidance, scrolling, and input spacing.
- Add localized warning copy.

## Testing

- Aggressive limit price tests: 8 passed
- Formatting and ESLint checks passed for changed TypeScript files

## Issue

https://onekeyhq.atlassian.net/browse/OK-58628