### PR TITLE
feat: add perps account status analytics OK-58963

### DIFF
--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -19,6 +19,8 @@ import { HeaderIconButton } from '@onekeyhq/components/src/layouts/Navigation/He
 import { TabletHomeContainer } from '@onekeyhq/kit/src/components/TabletHomeContainer';
 import { usePerpsActivePositionAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
 import {
+  useAccountIsAutoCreatingAtom,
+  useIndexedAccountAddressCreationStateAtom,
   usePerpsAbstractionModeAtom,
   usePerpsAccountLoadingInfoAtom,
   usePerpsActiveAccountAtom,
@@ -94,6 +96,9 @@ function PerpBodyContent() {
 function PerpAnalyticsTracker() {
   const isFocused = useIsFocused();
   const [activePerpsAccount] = usePerpsActiveAccountAtom();
+  const [accountIsAutoCreating] = useAccountIsAutoCreatingAtom();
+  const [indexedAccountAddressCreationState] =
+    useIndexedAccountAddressCreationStateAtom();
   const [perpsAccountStatus] = usePerpsActiveAccountStatusAtom();
   const [accountLoadingInfo] = usePerpsAccountLoadingInfoAtom();
   const [computedAccountValue] = usePerpsComputedAccountValueAtom();
@@ -141,6 +146,13 @@ function PerpAnalyticsTracker() {
       walletType: activePerpsAccount.walletType ?? 'unknown',
       accountStatus: perpsAccountStatus,
       selectAccountLoading: accountLoadingInfo.selectAccountLoading,
+      accountCreationPending: Boolean(
+        activePerpsAccount.indexedAccountId &&
+          (accountIsAutoCreating?.indexedAccountId ===
+            activePerpsAccount.indexedAccountId ||
+            indexedAccountAddressCreationState?.indexedAccountId ===
+              activePerpsAccount.indexedAccountId),
+      ),
       computedAccountValue,
       positionsState,
       abstractionMode,
@@ -164,9 +176,11 @@ function PerpAnalyticsTracker() {
     activePerpsAccount.accountId,
     activePerpsAccount.indexedAccountId,
     activePerpsAccount.walletType,
+    accountIsAutoCreating?.indexedAccountId,
     accountLoadingInfo.selectAccountLoading,
     computedAccountValue,
     isFocused,
+    indexedAccountAddressCreationState?.indexedAccountId,
     pageSession,
     perpsAccountStatus,
     positionsState,

--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -17,12 +17,20 @@ import {
 } from '@onekeyhq/components';
 import { HeaderIconButton } from '@onekeyhq/components/src/layouts/Navigation/Header';
 import { TabletHomeContainer } from '@onekeyhq/kit/src/components/TabletHomeContainer';
-import { usePerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { usePerpsActivePositionAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import {
+  usePerpsAbstractionModeAtom,
+  usePerpsAccountLoadingInfoAtom,
+  usePerpsActiveAccountAtom,
+  usePerpsActiveAccountStatusAtom,
+  usePerpsComputedAccountValueAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { DOWNLOAD_MOBILE_APP_URL } from '@onekeyhq/shared/src/config/appConfig';
 import { FLOAT_NAV_BAR_Z_INDEX } from '@onekeyhq/shared/src/consts/zIndexConsts';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { consumePerpPageEnterSource } from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
+import type { EPerpPageEnterSource } from '@onekeyhq/shared/src/logger/scopes/perp/type';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes/tab';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
@@ -48,6 +56,7 @@ import {
   isPerpsMobileLayoutTraceRectChanged,
   tracePerpsMobileLayout,
 } from '../utils/mobileLayoutTrace';
+import { buildPerpAccountStatusAnalyticsParams } from '../utils/perpAccountStatusAnalytics';
 import { preloadPerpsDepositSelectTokenModal } from '../utils/preloadPerpsDepositSelectTokenModal';
 import { preloadPerpsDepositWithdrawModal } from '../utils/preloadPerpsDepositWithdrawModal';
 import { preloadPerpsMobileTokenSelectorPage } from '../utils/preloadPerpsTokenSelector';
@@ -82,25 +91,31 @@ function PerpBodyContent() {
   );
 }
 
-function PerpContent() {
-  const { gtMd } = useMedia();
+function PerpAnalyticsTracker() {
+  const isFocused = useIsFocused();
   const [activePerpsAccount] = usePerpsActiveAccountAtom();
+  const [perpsAccountStatus] = usePerpsActiveAccountStatusAtom();
+  const [accountLoadingInfo] = usePerpsAccountLoadingInfoAtom();
+  const [computedAccountValue] = usePerpsComputedAccountValueAtom();
+  const [positionsState] = usePerpsActivePositionAtom();
+  const [abstractionMode] = usePerpsAbstractionModeAtom();
   const walletTypeRef = useRef(activePerpsAccount.walletType);
   walletTypeRef.current = activePerpsAccount.walletType;
-  const { top: safeAreaTop } = useSafeAreaInsets();
-  const resolvedSafeAreaTop =
-    safeAreaTop || initialWindowMetrics?.insets.top || 0;
   const firedRef = useRef(false);
-  const headerLayoutRef = useRef<IPerpsMobileLayoutTraceRect | undefined>(
-    undefined,
-  );
+  const trackedAccountSnapshotsRef = useRef(new Set<string>());
+  const [pageSession, setPageSession] = useState<{
+    source: EPerpPageEnterSource;
+  }>();
 
   useFocusEffect(
     useCallback(() => {
       if (!firedRef.current) {
         firedRef.current = true;
-        defaultLogger.perp.common.pageView({
-          source: consumePerpPageEnterSource(),
+        trackedAccountSnapshotsRef.current.clear();
+        const source = consumePerpPageEnterSource();
+        setPageSession({ source });
+        defaultLogger.perp.common.perpPageView({
+          source,
           walletType: walletTypeRef.current ?? 'unknown',
         });
       }
@@ -108,6 +123,65 @@ function PerpContent() {
         firedRef.current = false;
       };
     }, []),
+  );
+
+  useEffect(() => {
+    if (!isFocused || !pageSession) {
+      return;
+    }
+    if (
+      !activePerpsAccount.accountAddress &&
+      !activePerpsAccount.indexedAccountId &&
+      !activePerpsAccount.accountId
+    ) {
+      return;
+    }
+    const params = buildPerpAccountStatusAnalyticsParams({
+      source: pageSession.source,
+      walletType: activePerpsAccount.walletType ?? 'unknown',
+      accountStatus: perpsAccountStatus,
+      selectAccountLoading: accountLoadingInfo.selectAccountLoading,
+      computedAccountValue,
+      positionsState,
+      abstractionMode,
+    });
+    if (!params) {
+      return;
+    }
+    const accountKey =
+      activePerpsAccount.indexedAccountId ??
+      activePerpsAccount.accountId ??
+      activePerpsAccount.accountAddress?.toLowerCase() ??
+      params.snapshotStatus;
+    if (trackedAccountSnapshotsRef.current.has(accountKey)) {
+      return;
+    }
+    trackedAccountSnapshotsRef.current.add(accountKey);
+    defaultLogger.perp.common.perpAccountStatus(params);
+  }, [
+    abstractionMode,
+    activePerpsAccount.accountAddress,
+    activePerpsAccount.accountId,
+    activePerpsAccount.indexedAccountId,
+    activePerpsAccount.walletType,
+    accountLoadingInfo.selectAccountLoading,
+    computedAccountValue,
+    isFocused,
+    pageSession,
+    perpsAccountStatus,
+    positionsState,
+  ]);
+
+  return null;
+}
+
+function PerpContent() {
+  const { gtMd } = useMedia();
+  const { top: safeAreaTop } = useSafeAreaInsets();
+  const resolvedSafeAreaTop =
+    safeAreaTop || initialWindowMetrics?.insets.top || 0;
+  const headerLayoutRef = useRef<IPerpsMobileLayoutTraceRect | undefined>(
+    undefined,
   );
 
   useEffect(() => {
@@ -230,6 +304,7 @@ function PerpView() {
   ) : (
     <>
       <PerpsGlobalEffects />
+      <PerpAnalyticsTracker />
       <PerpContent />
     </>
   );

--- a/packages/kit/src/views/Perp/pages/Perp.tsx
+++ b/packages/kit/src/views/Perp/pages/Perp.tsx
@@ -148,10 +148,10 @@ function PerpAnalyticsTracker() {
       selectAccountLoading: accountLoadingInfo.selectAccountLoading,
       accountCreationPending: Boolean(
         activePerpsAccount.indexedAccountId &&
-          (accountIsAutoCreating?.indexedAccountId ===
-            activePerpsAccount.indexedAccountId ||
-            indexedAccountAddressCreationState?.indexedAccountId ===
-              activePerpsAccount.indexedAccountId),
+        (accountIsAutoCreating?.indexedAccountId ===
+          activePerpsAccount.indexedAccountId ||
+          indexedAccountAddressCreationState?.indexedAccountId ===
+            activePerpsAccount.indexedAccountId),
       ),
       computedAccountValue,
       positionsState,

--- a/packages/kit/src/views/Perp/utils/perpAccountStatusAnalytics.test.ts
+++ b/packages/kit/src/views/Perp/utils/perpAccountStatusAnalytics.test.ts
@@ -13,6 +13,7 @@ function buildReadyParams() {
     source,
     walletType,
     selectAccountLoading: false,
+    accountCreationPending: false,
     accountStatus: {
       accountAddress,
       canTrade: true,
@@ -37,7 +38,9 @@ function buildReadyParams() {
       activePositions: [{ coin: 'BTC' }, { coin: 'ETH' }],
     },
     abstractionMode: {
+      accountAddress,
       mode: EHyperLiquidAbstractionMode.UNIFIED_ACCOUNT,
+      source: 'live' as const,
     },
   };
 }
@@ -75,6 +78,15 @@ describe('buildPerpAccountStatusAnalyticsParams', () => {
       buildPerpAccountStatusAnalyticsParams({
         ...readyParams,
         selectAccountLoading: true,
+      }),
+    ).toBeUndefined();
+    expect(
+      buildPerpAccountStatusAnalyticsParams({
+        ...readyParams,
+        abstractionMode: {
+          ...readyParams.abstractionMode,
+          source: 'cache',
+        },
       }),
     ).toBeUndefined();
     expect(

--- a/packages/kit/src/views/Perp/utils/perpAccountStatusAnalytics.test.ts
+++ b/packages/kit/src/views/Perp/utils/perpAccountStatusAnalytics.test.ts
@@ -1,0 +1,90 @@
+import { EPerpPageEnterSource } from '@onekeyhq/shared/src/logger/scopes/perp/type';
+import { EHyperLiquidAbstractionMode } from '@onekeyhq/shared/types/hyperliquid';
+
+import { buildPerpAccountStatusAnalyticsParams } from './perpAccountStatusAnalytics';
+
+const source = EPerpPageEnterSource.TabBar;
+const walletType = 'hd';
+const accountAddress =
+  '0x1111111111111111111111111111111111111111' as `0x${string}`;
+
+function buildReadyParams() {
+  return {
+    source,
+    walletType,
+    selectAccountLoading: false,
+    accountStatus: {
+      accountAddress,
+      canTrade: true,
+      canCreateAddress: false,
+      accountNotSupport: false,
+      details: {
+        activatedOk: true,
+        agentOk: true,
+        referralCodeOk: true,
+        builderFeeOk: true,
+        internalRebateBoundOk: true,
+        abstractionOk: false,
+      },
+    },
+    computedAccountValue: {
+      accountValue: '125.5',
+      withdrawable: '80.25',
+      isLoading: false,
+    },
+    positionsState: {
+      accountAddress,
+      activePositions: [{ coin: 'BTC' }, { coin: 'ETH' }],
+    },
+    abstractionMode: {
+      mode: EHyperLiquidAbstractionMode.UNIFIED_ACCOUNT,
+    },
+  };
+}
+
+describe('buildPerpAccountStatusAnalyticsParams', () => {
+  it('builds a ready account snapshot', () => {
+    expect(buildPerpAccountStatusAnalyticsParams(buildReadyParams())).toEqual(
+      expect.objectContaining({
+        snapshotStatus: 'ready',
+        isTradingEnabled: true,
+        abstractionOk: true,
+        accountMode: EHyperLiquidAbstractionMode.UNIFIED_ACCOUNT,
+        accountValue: 125.5,
+        withdrawable: 80.25,
+        positionCount: 2,
+      }),
+    );
+  });
+
+  it('waits until status and account-scoped positions are ready', () => {
+    const readyParams = buildReadyParams();
+    expect(
+      buildPerpAccountStatusAnalyticsParams({
+        ...readyParams,
+        accountStatus: {
+          ...readyParams.accountStatus,
+          details: {
+            ...readyParams.accountStatus.details,
+            activatedOk: undefined,
+          },
+        },
+      }),
+    ).toBeUndefined();
+    expect(
+      buildPerpAccountStatusAnalyticsParams({
+        ...readyParams,
+        selectAccountLoading: true,
+      }),
+    ).toBeUndefined();
+    expect(
+      buildPerpAccountStatusAnalyticsParams({
+        ...readyParams,
+        positionsState: {
+          ...readyParams.positionsState,
+          accountAddress: '0x2222222222222222222222222222222222222222',
+        },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/kit/src/views/Perp/utils/perpAccountStatusAnalytics.ts
+++ b/packages/kit/src/views/Perp/utils/perpAccountStatusAnalytics.ts
@@ -11,6 +11,7 @@ type IBuildPerpAccountStatusAnalyticsParams = {
   walletType: string;
   accountStatus: IPerpsActiveAccountStatusAtom;
   selectAccountLoading: boolean;
+  accountCreationPending: boolean;
   computedAccountValue: {
     accountValue?: string;
     withdrawable?: string;
@@ -21,7 +22,9 @@ type IBuildPerpAccountStatusAnalyticsParams = {
     activePositions: unknown[];
   };
   abstractionMode?: {
+    accountAddress?: string;
     mode?: EHyperLiquidAbstractionMode;
+    source?: 'live' | 'cache';
   };
 };
 
@@ -30,13 +33,14 @@ export function buildPerpAccountStatusAnalyticsParams({
   walletType,
   accountStatus,
   selectAccountLoading,
+  accountCreationPending,
   computedAccountValue,
   positionsState,
   abstractionMode,
 }: IBuildPerpAccountStatusAnalyticsParams):
   | IPerpAccountStatusParams
   | undefined {
-  if (selectAccountLoading) {
+  if (selectAccountLoading || accountCreationPending) {
     return undefined;
   }
   const baseParams = {
@@ -70,11 +74,18 @@ export function buildPerpAccountStatusAnalyticsParams({
   const positionsAddress = normalizePerpsAccountAddress(
     positionsState.accountAddress,
   );
+  const modeAddress = normalizePerpsAccountAddress(
+    abstractionMode?.accountAddress,
+  );
+  const liveAccountMode =
+    abstractionMode?.source !== 'cache' && modeAddress === accountAddress
+      ? abstractionMode?.mode
+      : undefined;
   if (
     isActivated &&
     (computedAccountValue.isLoading ||
       positionsAddress !== accountAddress ||
-      !abstractionMode?.mode)
+      !liveAccountMode)
   ) {
     return undefined;
   }
@@ -89,7 +100,7 @@ export function buildPerpAccountStatusAnalyticsParams({
     return undefined;
   }
 
-  const accountMode = isActivated ? abstractionMode?.mode : undefined;
+  const accountMode = isActivated ? liveAccountMode : undefined;
   const abstractionOk = accountMode
     ? accountMode === EHyperLiquidAbstractionMode.UNIFIED_ACCOUNT ||
       accountMode === EHyperLiquidAbstractionMode.PORTFOLIO_MARGIN

--- a/packages/kit/src/views/Perp/utils/perpAccountStatusAnalytics.ts
+++ b/packages/kit/src/views/Perp/utils/perpAccountStatusAnalytics.ts
@@ -1,0 +1,113 @@
+import type { IPerpsActiveAccountStatusAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import type {
+  EPerpPageEnterSource,
+  IPerpAccountStatusParams,
+} from '@onekeyhq/shared/src/logger/scopes/perp/type';
+import { normalizePerpsAccountAddress } from '@onekeyhq/shared/src/utils/perpsUtils';
+import { EHyperLiquidAbstractionMode } from '@onekeyhq/shared/types/hyperliquid';
+
+type IBuildPerpAccountStatusAnalyticsParams = {
+  source: EPerpPageEnterSource;
+  walletType: string;
+  accountStatus: IPerpsActiveAccountStatusAtom;
+  selectAccountLoading: boolean;
+  computedAccountValue: {
+    accountValue?: string;
+    withdrawable?: string;
+    isLoading: boolean;
+  };
+  positionsState: {
+    accountAddress?: string;
+    activePositions: unknown[];
+  };
+  abstractionMode?: {
+    mode?: EHyperLiquidAbstractionMode;
+  };
+};
+
+export function buildPerpAccountStatusAnalyticsParams({
+  source,
+  walletType,
+  accountStatus,
+  selectAccountLoading,
+  computedAccountValue,
+  positionsState,
+  abstractionMode,
+}: IBuildPerpAccountStatusAnalyticsParams):
+  | IPerpAccountStatusParams
+  | undefined {
+  if (selectAccountLoading) {
+    return undefined;
+  }
+  const baseParams = {
+    source,
+    walletType,
+    isTradingEnabled: false,
+  };
+  if (accountStatus.accountNotSupport) {
+    return { ...baseParams, snapshotStatus: 'unsupported' };
+  }
+  if (accountStatus.canCreateAddress) {
+    return {
+      ...baseParams,
+      snapshotStatus: 'notCreated',
+      isActivated: false,
+      accountValue: 0,
+      withdrawable: 0,
+      positionCount: 0,
+    };
+  }
+
+  const accountAddress = normalizePerpsAccountAddress(
+    accountStatus.accountAddress,
+  );
+  const details = accountStatus.details;
+  if (!accountAddress || !details || details.activatedOk === undefined) {
+    return undefined;
+  }
+
+  const isActivated = details.activatedOk === true;
+  const positionsAddress = normalizePerpsAccountAddress(
+    positionsState.accountAddress,
+  );
+  if (
+    isActivated &&
+    (computedAccountValue.isLoading ||
+      positionsAddress !== accountAddress ||
+      !abstractionMode?.mode)
+  ) {
+    return undefined;
+  }
+
+  const accountValue = isActivated
+    ? Number(computedAccountValue.accountValue)
+    : 0;
+  const withdrawable = isActivated
+    ? Number(computedAccountValue.withdrawable)
+    : 0;
+  if (!Number.isFinite(accountValue)) {
+    return undefined;
+  }
+
+  const accountMode = isActivated ? abstractionMode?.mode : undefined;
+  const abstractionOk = accountMode
+    ? accountMode === EHyperLiquidAbstractionMode.UNIFIED_ACCOUNT ||
+      accountMode === EHyperLiquidAbstractionMode.PORTFOLIO_MARGIN
+    : details.abstractionOk;
+  const positionCount = isActivated ? positionsState.activePositions.length : 0;
+  return {
+    source,
+    walletType,
+    snapshotStatus: 'ready',
+    isTradingEnabled: accountStatus.canTrade === true,
+    isActivated,
+    agentOk: details.agentOk,
+    builderFeeOk: details.builderFeeOk,
+    referralCodeOk: details.referralCodeOk,
+    abstractionOk,
+    accountMode: isActivated ? accountMode : undefined,
+    accountValue,
+    withdrawable: Number.isFinite(withdrawable) ? withdrawable : undefined,
+    positionCount,
+  };
+}

--- a/packages/kit/src/views/PerpTrade/pages/PageWebviewPerpTrade.tsx
+++ b/packages/kit/src/views/PerpTrade/pages/PageWebviewPerpTrade.tsx
@@ -98,7 +98,7 @@ function WebviewPerpTradeView() {
     useCallback(() => {
       if (!firedRef.current) {
         firedRef.current = true;
-        defaultLogger.perp.common.pageView({
+        defaultLogger.perp.common.perpPageView({
           source: consumePerpPageEnterSource(),
           walletType: walletTypeRef.current ?? 'unknown',
         });

--- a/packages/shared/src/logger/scopes/perp/scenes/common.ts
+++ b/packages/shared/src/logger/scopes/perp/scenes/common.ts
@@ -3,13 +3,14 @@ import { LogToLocal, LogToServer } from '../../../base/decorators';
 
 import type {
   EPerpPageEnterSource,
+  IPerpAccountStatusParams,
   IPerpTradeButtonClickParams,
 } from '../type';
 
 export class CommonScene extends BaseScene {
   @LogToServer()
   @LogToLocal({ level: 'info' })
-  public pageView({
+  public perpPageView({
     source,
     walletType,
   }: {
@@ -22,6 +23,12 @@ export class CommonScene extends BaseScene {
   @LogToServer()
   @LogToLocal({ level: 'info' })
   public perpTradeButtonClick(params: IPerpTradeButtonClickParams) {
+    return params;
+  }
+
+  @LogToServer()
+  @LogToLocal({ level: 'info' })
+  public perpAccountStatus(params: IPerpAccountStatusParams) {
     return params;
   }
 

--- a/packages/shared/src/logger/scopes/perp/type.ts
+++ b/packages/shared/src/logger/scopes/perp/type.ts
@@ -1,4 +1,5 @@
 import type { IPerpsDepositToken } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import type { EHyperLiquidAbstractionMode } from '@onekeyhq/shared/types/hyperliquid';
 import type { ESwapTxHistoryStatus } from '@onekeyhq/shared/types/swap/types';
 
 export enum EPerpPageEnterSource {
@@ -72,6 +73,24 @@ export interface IPerpTradeButtonClickParams {
   tif?: string;
   leverage?: number;
   orderValue?: number;
+}
+
+export type TPerpAccountSnapshotStatus = 'ready' | 'notCreated' | 'unsupported';
+
+export interface IPerpAccountStatusParams {
+  source: EPerpPageEnterSource;
+  walletType: string;
+  snapshotStatus: TPerpAccountSnapshotStatus;
+  isTradingEnabled: boolean;
+  isActivated?: boolean;
+  agentOk?: boolean;
+  builderFeeOk?: boolean;
+  referralCodeOk?: boolean;
+  abstractionOk?: boolean;
+  accountMode?: EHyperLiquidAbstractionMode;
+  accountValue?: number;
+  withdrawable?: number;
+  positionCount?: number;
 }
 
 export interface IPerpDepositInitiateParams {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58963](https://onekeyhq.atlassian.net/browse/OK-58963)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Rename the Perps page view event from `pageView` to `perpPageView` for native and WebView pages.
- Add a deduplicated `perpAccountStatus` snapshot after account status, balance, positions, and account mode are ready.
- Track activation, trading readiness, authorization state, account value, withdrawable balance, and position state.
- Resolve `abstractionOk` from the latest live account mode to keep snapshot fields consistent.

## Test Plan

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- `yarn jest packages/kit/src/views/Perp/utils/perpAccountStatusAnalytics.test.ts --runInBand`

## Issue

- https://onekeyhq.atlassian.net/browse/OK-58963

[OK-58963]: https://onekeyhq.atlassian.net/browse/OK-58963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ