### PR TITLE
fix: restore mobile analytics in split bundles

### DIFF
--- a/apps/mobile/scripts/__tests__/unionBuildHelpers.test.js
+++ b/apps/mobile/scripts/__tests__/unionBuildHelpers.test.js
@@ -277,6 +277,38 @@ describe('unionBuildHelpers', () => {
     );
   });
 
+  it('overrides a merged background segment path when the module is eager in main', () => {
+    const tierPath =
+      '/repo/packages/shared/src/performance/devicePerformanceTier.native.ts';
+    const wrappedModules = [
+      [1, 'module.exports={"paths":{"1932":"old-tier-path"}};'],
+    ];
+
+    rewriteAsyncRequirePaths(wrappedModules, {
+      moduleToSegment: new Map([
+        [1932, 'seg:shared.performance.devicePerformanceTier.native'],
+      ]),
+      moduleIdToAbsPath: new Map([[1932, tierPath]]),
+      eagerAbsPaths: new Set([tierPath]),
+      runtimeVariants: {
+        main: {
+          absPathToSegment: new Map(),
+          eagerAbsPaths: new Set([tierPath]),
+        },
+        background: {
+          absPathToSegment: new Map([
+            [tierPath, 'seg:shared.performance.devicePerformanceTier.native'],
+          ]),
+          eagerAbsPaths: new Set(),
+        },
+      },
+    });
+
+    expect(wrappedModules[0][1]).toContain(
+      '"1932":{"main":null,"background":"seg:shared.performance.devicePerformanceTier.native"}',
+    );
+  });
+
   it('prefers segment keys over eager nulling when a module is split out', () => {
     const splitPath = '/repo/src/feature/split.js';
     const wrappedModules = [

--- a/apps/mobile/scripts/unionBuild.js
+++ b/apps/mobile/scripts/unionBuild.js
@@ -2102,14 +2102,14 @@ async function main() {
         moduleIdToAbsPath: backgroundModuleIndex.moduleIdToAbsPath,
         absPathToSegment: backgroundAbsPathToSegment,
       });
-    const _mainRuntimeAsyncPaths = {
+    const mainRuntimeAsyncPaths = {
       absPathToSegment: mainAbsPathToSegment,
       eagerAbsPaths: new Set([
         ...runtimeOwnership.sharedStartupAbsPaths,
         ...runtimeOwnership.mainStartupAbsPaths,
       ]),
     };
-    const _backgroundRuntimeAsyncPaths = {
+    const backgroundRuntimeAsyncPaths = {
       absPathToSegment: backgroundAbsPathToSegment,
       eagerAbsPaths: new Set([
         ...runtimeOwnership.sharedStartupAbsPaths,
@@ -2216,15 +2216,13 @@ async function main() {
     // loading (common.bundle first, then the runtime-specific bundle).
     //
     // Async require path strategy:
-    //   Common code runs in both runtimes, so its import() paths must
-    //   work everywhere. We use the MERGED segment map (main ∪ background)
-    //   instead of per-runtime variants. Shared segments (like locale JSON)
-    //   get a simple segment key — no {"main":…,"background":…} branching.
-    //   Both runtimes resolve the same key via the merged manifest.
+    //   Common code runs in both runtimes, so every import() path must reflect
+    //   the module's ownership in each runtime. A module may be eager in one
+    //   runtime but segmented in the other; that case requires a dispatch
+    //   record such as {"main":null,"background":"seg:key"}.
     //
-    //   For modules that are eager in main/background (not in a segment),
-    //   externalModulePaths covers both runtimes' eager sets so the
-    //   rewriter marks them as null (already loaded).
+    //   runtimeVariants collapses identical ownership to a simple segment key
+    //   or null, while preserving per-runtime records for asymmetric modules.
     const commonModuleToSegment = new Map([
       ...mainSerializedModuleToSegment,
       ...backgroundSerializedModuleToSegment,
@@ -2250,9 +2248,10 @@ async function main() {
         ...runtimeOwnership.mainStartupAbsPaths,
         ...runtimeOwnership.bgStartupAbsPaths,
       ]),
-      // No runtimeVariants — common code uses the merged segment map
-      // directly. Both runtimes share the same manifest and can load
-      // any shared segment by key.
+      runtimeVariants: {
+        main: mainRuntimeAsyncPaths,
+        background: backgroundRuntimeAsyncPaths,
+      },
     });
 
     // Main bundle: main-only eager modules + entry require

--- a/packages/shared/src/analytics/index.test.ts
+++ b/packages/shared/src/analytics/index.test.ts
@@ -1,5 +1,7 @@
 import { Analytics } from '.';
 
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+
 const mockPost = jest.fn(() => Promise.resolve());
 const mockGetDeviceCpuTier = jest.fn(() => 'high');
 const mockGetDeviceInfo = jest.fn(() =>
@@ -62,10 +64,19 @@ async function waitForPostCount(expectedCount: number) {
 }
 
 describe('Analytics tier', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
   beforeEach(() => {
     mockPost.mockClear();
     mockGetDeviceCpuTier.mockClear();
     mockGetDeviceInfo.mockClear();
+    mockGetDeviceCpuTier.mockReturnValue('high');
+    mockGetDeviceInfo.mockResolvedValue({ deviceId: 'device-id' });
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
   });
 
   it('adds the resolved tier to event and profile requests', async () => {
@@ -128,6 +139,55 @@ describe('Analytics tier', () => {
       expect.objectContaining({
         attributes: expect.objectContaining({ tier: 3 }),
       }),
+    );
+  });
+
+  it('sends events with the medium fallback when tier enrichment fails', async () => {
+    mockGetDeviceCpuTier.mockImplementationOnce(() => {
+      throw new OneKeyLocalError('segment runtime mismatch');
+    });
+    const analytics = new Analytics();
+    analytics.init({ instanceId: 'instance-id', baseURL: 'https://utility' });
+
+    analytics.trackEvent('testEvent');
+    await waitForPostCount(1);
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/utility/v1/track/event',
+      expect.objectContaining({
+        eventName: 'testEvent',
+        eventProps: expect.objectContaining({
+          deviceId: 'device-id',
+          tier: 2,
+        }),
+      }),
+    );
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      '[Analytics] Failed to load device performance tier:',
+      expect.any(Error),
+    );
+  });
+
+  it('sends events when device info enrichment fails', async () => {
+    mockGetDeviceInfo.mockRejectedValueOnce(
+      new OneKeyLocalError('device info unavailable'),
+    );
+    const analytics = new Analytics();
+    analytics.init({ instanceId: 'instance-id', baseURL: 'https://utility' });
+
+    analytics.trackEvent('testEvent');
+    await waitForPostCount(1);
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/utility/v1/track/event',
+      expect.objectContaining({
+        eventName: 'testEvent',
+        eventProps: expect.objectContaining({ tier: 3 }),
+      }),
+    );
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      '[Analytics] Failed to load device info:',
+      expect.any(Error),
     );
   });
 });

--- a/packages/shared/src/analytics/index.ts
+++ b/packages/shared/src/analytics/index.ts
@@ -12,7 +12,7 @@ import { headerPlatform } from '../request/InterceptorConsts';
 import { getDeviceInfo } from './deviceInfo';
 import { type TAnalyticsTier, getAnalyticsTier } from './tier';
 
-import type { IAnalyticsUserProfile } from './type';
+import type { IAnalyticsUserProfile, IDeviceInfo } from './type';
 import type { AxiosInstance } from 'axios';
 
 export const ANALYTICS_EVENT_PATH = '/utility/v1/track';
@@ -125,20 +125,35 @@ export class Analytics {
     let deviceInfoPromise = this.deviceInfoPromise;
     if (!deviceInfoPromise) {
       deviceInfoPromise = (async () => {
-        const deviceInfo = await getDeviceInfo();
-        const { getDeviceCpuTier } =
-          await import('../performance/devicePerformanceTier');
+        let deviceInfo: IDeviceInfo = {};
+        let tier: TAnalyticsTier = 2;
+
+        try {
+          deviceInfo = await getDeviceInfo();
+        } catch (error) {
+          console.warn('[Analytics] Failed to load device info:', error);
+        }
+
+        try {
+          const { getDeviceCpuTier } =
+            await import('../performance/devicePerformanceTier');
+          tier = getAnalyticsTier(getDeviceCpuTier());
+        } catch (error) {
+          // Optional enrichment must never block the analytics request.
+          console.warn(
+            '[Analytics] Failed to load device performance tier:',
+            error,
+          );
+        }
+
         return {
           ...deviceInfo,
-          tier: getAnalyticsTier(getDeviceCpuTier()),
+          tier,
           platform: headerPlatform,
           appBuildNumber: platformEnv.buildNumber,
           appVersion: platformEnv.version,
         };
-      })().catch((error) => {
-        this.deviceInfoPromise = null;
-        throw error;
-      });
+      })();
       this.deviceInfoPromise = deviceInfoPromise;
     }
     const deviceInfo = await deviceInfoPromise;


### PR DESCRIPTION
## Summary

- preserve runtime-specific async module ownership in the native common bundle
- emit `main: null` / `background: segment` routing when a shared module is eager only in main
- make Analytics device metadata and CPU tier enrichment fail-open so optional enrichment cannot suppress events
- add regression coverage for the asymmetric runtime mapping and both Analytics fallbacks

## Root cause

The common bundle merged main and background async-module maps, allowing the background segment path to overwrite main runtime ownership. `devicePerformanceTier.native` was already registered eagerly in main, but the common dependency map still told `asyncRequire` to load its background-only segment. The native segment loader rejected that runtime mismatch before Metro reached the registered module, and the rejected Analytics initialization promise caused all mobile main-runtime events to disappear.

## Impact

Restores iOS and Android main-runtime analytics, including `appStart` and `uiVisibleTime`, while retaining the `tier` field when performance-tier enrichment succeeds. If optional enrichment fails, events continue with the medium-tier fallback.

## Validation

- `yarn jest apps/mobile/scripts/__tests__/unionBuildHelpers.test.js packages/shared/src/analytics/index.test.ts --runInBand` (56 tests passed)
- `yarn agent:check --profile commit`
- generated complete iOS and Android union bundles
- confirmed both products contain `{"main":null,"background":"seg:shared.performance.devicePerformanceTier.native"}` for the tier module
- `node scripts/check-split-bundle-integrity.js` passed for iOS and Android with zero violations