### PR TITLE
fix(shared): correct null and undefined handling in equalsIgnoreCase

### DIFF
--- a/packages/shared/src/utils/stringUtils.test.ts
+++ b/packages/shared/src/utils/stringUtils.test.ts
@@ -1,9 +1,31 @@
-import stringUtils, { stableStringify } from './stringUtils';
+import stringUtils, { equalsIgnoreCase, stableStringify } from './stringUtils';
 
 test('stableStringify', () => {
   expect(stableStringify({ a: '1', b: '2' })).toBe(
     stableStringify({ b: '2', a: '1' }),
   );
+});
+
+describe('equalsIgnoreCase', () => {
+  test('returns true for case-insensitive matching strings', () => {
+    expect(equalsIgnoreCase('hello', 'HELLO')).toBe(true);
+    expect(equalsIgnoreCase('OneKey', 'onekey')).toBe(true);
+    expect(equalsIgnoreCase('', '')).toBe(true);
+  });
+
+  test('returns false for non-matching strings', () => {
+    expect(equalsIgnoreCase('hello', 'world')).toBe(false);
+    expect(equalsIgnoreCase('onekey', 'twoKey')).toBe(false);
+  });
+
+  test('handles null and undefined correctly', () => {
+    expect(equalsIgnoreCase(null, null)).toBe(true);
+    expect(equalsIgnoreCase(undefined, undefined)).toBe(true);
+    expect(equalsIgnoreCase(null, undefined)).toBe(false);
+    expect(equalsIgnoreCase(undefined, null)).toBe(false);
+    expect(equalsIgnoreCase('hello', null)).toBe(false);
+    expect(equalsIgnoreCase('hello', undefined)).toBe(false);
+  });
 });
 
 describe('isValidEmail', () => {

--- a/packages/shared/src/utils/stringUtils.ts
+++ b/packages/shared/src/utils/stringUtils.ts
@@ -12,7 +12,10 @@ export function equalsIgnoreCase(
   a: string | undefined | null,
   b: string | undefined | null,
 ): boolean {
-  return a?.toUpperCase() === b?.toUpperCase();
+  if (a === undefined || a === null || b === undefined || b === null) {
+    return a === b;
+  }
+  return a.toUpperCase() === b.toUpperCase();
 }
 
 const STRINGIFY_REPLACER = {


### PR DESCRIPTION
## Context
`equalsIgnoreCase(a, b)` in `packages/shared/src/utils/stringUtils.ts` relied on optional chaining `a?.toUpperCase() === b?.toUpperCase()`. When `a` was `null` and `b` was `undefined`, optional chaining evaluated both operands to `undefined`, causing `equalsIgnoreCase(null, undefined)` to incorrectly return `true`.

## Changes
- Updated `equalsIgnoreCase` in `packages/shared/src/utils/stringUtils.ts` to check `if (a === undefined || a === null || b === undefined || b === null) return a === b;` before performing upper-case comparison.
- Added `equalsIgnoreCase` unit test suite to `packages/shared/src/utils/stringUtils.test.ts` covering string equality, non-matching strings, and `null`/`undefined` edge cases.

## Verification
- Ran `npx yarn test packages/shared/src/utils/stringUtils.test.ts`: **8/8 tests passed in 1.62s**.
- Ran `npx oxlint packages/shared/src/utils/stringUtils.ts packages/shared/src/utils/stringUtils.test.ts`: **0 errors, 0 warnings**.
