### PR TITLE
fix: hide the empty liquidity column in spot banner detail lists

### DIFF
--- a/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
+++ b/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
@@ -55,6 +55,17 @@ type IMarketBannerDetailRouteParams = RouteProp<
   ETabMarketRoutes.MarketBannerDetail | EModalMarketRoutes.MarketBannerDetail
 >;
 
+// Spot banner lists are dominated by tokenized stocks, whose liquidity is not
+// reported by the market API, so the column is dropped instead of rendering a
+// near-empty one. Perps banners use their own columns and never had it.
+//
+// The `liquidity` dataIndex is shared: in stock metadata mode the same column
+// renders 24h volume instead. This list keeps the default `showStockSubtitle`
+// (not 'auto'), so that mode is currently unreachable here. Revisit this
+// constant before enabling stock metadata columns, or 24h volume disappears
+// with no type or test failure.
+const BANNER_DETAIL_HIDDEN_DESKTOP_COLUMNS = ['liquidity'] as const;
+
 function MarketBannerDetailContent({ title }: { title: string }) {
   const route = useRoute<IMarketBannerDetailRouteParams>();
   const { tokenListId, type } = route.params;
@@ -212,6 +223,7 @@ function MarketBannerDetailContent({ title }: { title: string }) {
         copyFrom={ECopyFrom.BannerList}
         showEndReachedIndicator
         change24hColumnTitle={change24hColumnTitle}
+        hiddenDesktopColumns={BANNER_DETAIL_HIDDEN_DESKTOP_COLUMNS}
       />
     );
     if (platformEnv.isNative) {


### PR DESCRIPTION
## Summary

Market > banner (topic) detail lists showed a Liquidity column that was almost always empty. These lists are dominated by Ondo tokenized stocks, and the market API does not report on-chain liquidity for them — it returns the placeholder string `"--"`, which `safeNumber()` turns into `0`, rendered as `--`.

Current data across all 9 spot banners (`/utility/v2/market/banner/token-list/{id}`):

| Banner | Rows | With `stock` | Liquidity has a number | Placeholder `"--"` |
| --- | --- | --- | --- | --- |
| US Mega Caps | 20 | 20 | 1 | 19 |
| Crypto Stocks | 29 | 28 | 4 | 25 |
| WallStreet Bets | 12 | 12 | 0 | 12 |
| AI Tech | 18 | 18 | 0 | 18 |
| Robinhood Meme | 15 | 0 | 15 | 0 |
| Trump Picks | 26 | 25 | 2 | 24 |
| Precious Metals | 8 | 7 | 1 | 7 |
| Healthcare | 6 | 6 | 0 | 6 |
| Semiconductor | 16 | 14 | 2 | 14 |

Only Robinhood Meme (pure DEX tokens) has real liquidity throughout. Everywhere else the column occupies width to print `--`.

### Changes

- `MarketBannerDetail`: pass `hiddenDesktopColumns={['liquidity']}` to `MarketTokenListBase`, reusing the existing column-filter mechanism already used by `DesktopLayout` via `COMPACT_SPOT_HIDDEN_DESKTOP_COLUMNS`.
- Document why, plus a warning that the `liquidity` dataIndex is shared: in stock metadata mode the same column renders 24h volume. This list keeps the default `showStockSubtitle` (not `'auto'`), so that mode is unreachable here today, but enabling it later without revisiting this constant would silently drop 24h volume with no type or test failure.

### Not affected

- Native (iOS/Android, incl. iPad): `useMarketTokenColumns.native.tsx` always returns the mobile columns, which never had a liquidity column. This change only affects web and desktop.
- Narrow layouts (`!gtMd`): use `BannerDetailTokenFlatList` with its own header (Name/Turnover, Price, 24h change) — no liquidity column before or after.
- Perps banners: rendered by `PerpsTokenListSection` with `usePerpsColumns` (star/name/price/change24h/volume24h/openInterest/fundingRate) — never had one.
- Market Home and Watchlist lists: untouched, the change is scoped to the banner detail call site. Verified the Trending tab still shows its liquidity column.

## Test

- `yarn agent:check --profile commit`: `lint-worktree-ts`, `format-worktree`, `agent-context`, `lint-staged` pass. `tsc-staged` fails only on pre-existing errors in `packages/components/**/*.stories.tsx` (missing local `@storybook/*` deps) and two kaspa files; 0 hits under `views/Market`, and a baseline run with the change stashed fails identically.
- Verified live on the local web dev server, Market > "US Mega Caps" banner, before/after on the same page:
  - before: `# | Name | Price | Market Cap | 24h change | Liquidity | Turnover | Txns | Traders | Holders` — every visible row's liquidity cell rendered `--`
  - after: `# | Name | Price | Market Cap | 24h change | Turnover | Txns | Traders | Holders`
