### PR TITLE
fix: don't interrupt DApp approvals with What's New in extension (OK-58962)

### DIFF
--- a/apps/ext/src/background/sidePanel.ts
+++ b/apps/ext/src/background/sidePanel.ts
@@ -25,9 +25,9 @@ import {
 import extUtils from '@onekeyhq/shared/src/utils/extUtils';
 import { waitForDataLoaded } from '@onekeyhq/shared/src/utils/promiseUtils';
 import {
-  PENDING_SIDE_PANEL_MESSAGE_TTL_MS,
   clearPendingSidePanelBgToUiMessage,
   pendingSidePanelBgToUiMessage,
+  shouldFlushPendingSidePanelMessage,
   sidePanelState,
   sidePanelUiState,
 } from '@onekeyhq/shared/src/utils/sidePanelUtils';
@@ -487,20 +487,15 @@ export const setupSidePanelPortInBg = () => {
       }
 
       // Flush a push produced while no port existed (the panel was still
-      // booting). Consumed either way — delivered only to the panel it was
-      // meant for, dropped otherwise, never left behind for a later connect.
+      // booting). Consumed either way — a stale entry is dropped here, never
+      // left behind for a later connect to pick up.
       if (pendingSidePanelBgToUiMessage.value) {
-        const isFresh =
-          Date.now() - pendingSidePanelBgToUiMessage.stashedAt <
-          PENDING_SIDE_PANEL_MESSAGE_TTL_MS;
-        // When the port does not report a window we cannot tell the panels
-        // apart, so freshness is the only remaining guard.
-        const portWindowId = port.sender?.tab?.windowId;
-        const isTargetWindow =
-          pendingSidePanelBgToUiMessage.targetWindowId === undefined ||
-          portWindowId === undefined ||
-          portWindowId === pendingSidePanelBgToUiMessage.targetWindowId;
-        if (isFresh && isTargetWindow && !didPushOnboardingModal) {
+        const shouldFlush = shouldFlushPendingSidePanelMessage({
+          now: Date.now(),
+          stashedAt: pendingSidePanelBgToUiMessage.stashedAt,
+          didPushOnboardingModal,
+        });
+        if (shouldFlush) {
           port.postMessage(pendingSidePanelBgToUiMessage.value);
         }
         clearPendingSidePanelBgToUiMessage();

--- a/apps/ext/src/background/sidePanel.ts
+++ b/apps/ext/src/background/sidePanel.ts
@@ -24,7 +24,10 @@ import {
 } from '@onekeyhq/shared/src/routes/onboardingv2';
 import extUtils from '@onekeyhq/shared/src/utils/extUtils';
 import { waitForDataLoaded } from '@onekeyhq/shared/src/utils/promiseUtils';
-import { sidePanelState } from '@onekeyhq/shared/src/utils/sidePanelUtils';
+import {
+  sidePanelState,
+  sidePanelUiState,
+} from '@onekeyhq/shared/src/utils/sidePanelUtils';
 
 const SIDE_PANEL_PORT_NAME = 'ONEKEY_SIDE_PANEL';
 const SIDE_PANEL_DAPP_MOUNT_ACK_TIMEOUT_MS = 3000;
@@ -601,6 +604,11 @@ export const setupSidePanelPortInUI = () => {
       switch (type) {
         case 'pushModal':
           {
+            // OK-58962: record synchronously, before any await. This message
+            // routinely arrives before React has rendered, and it is the only
+            // signal a Keyless-hosted panel gets — that flow page-loads the
+            // panel without going through ServiceDApp.openModal.
+            sidePanelUiState.isHostingPushedModal = true;
             const { screen, params } = payload.modalParams;
             const rejectId = extractDappRejectIdFromModalParams(
               payload.modalParams,

--- a/apps/ext/src/background/sidePanel.ts
+++ b/apps/ext/src/background/sidePanel.ts
@@ -26,6 +26,7 @@ import extUtils from '@onekeyhq/shared/src/utils/extUtils';
 import { waitForDataLoaded } from '@onekeyhq/shared/src/utils/promiseUtils';
 import {
   PENDING_SIDE_PANEL_MESSAGE_TTL_MS,
+  clearPendingSidePanelBgToUiMessage,
   pendingSidePanelBgToUiMessage,
   sidePanelState,
   sidePanelUiState,
@@ -476,25 +477,33 @@ export const setupSidePanelPortInBg = () => {
   chrome.runtime.onConnect.addListener((port) => {
     if (port.name === SIDE_PANEL_PORT_NAME) {
       sidePanelState.isOpen = true;
+      let didPushOnboardingModal = false;
       if (pendingKeylessGetStartedParams) {
         port.postMessage(
           buildKeylessGetStartedModalMessage(pendingKeylessGetStartedParams),
         );
         pendingKeylessGetStartedParams = undefined;
+        didPushOnboardingModal = true;
       }
 
-      // Flush a push that was produced while no port existed (the panel was
-      // still booting). Dropped rather than replayed once stale, so a failed
-      // open cannot inject an unrelated modal into a much later boot.
+      // Flush a push produced while no port existed (the panel was still
+      // booting). Consumed either way — delivered only to the panel it was
+      // meant for, dropped otherwise, never left behind for a later connect.
       if (pendingSidePanelBgToUiMessage.value) {
         const isFresh =
           Date.now() - pendingSidePanelBgToUiMessage.stashedAt <
           PENDING_SIDE_PANEL_MESSAGE_TTL_MS;
-        if (isFresh) {
+        // When the port does not report a window we cannot tell the panels
+        // apart, so freshness is the only remaining guard.
+        const portWindowId = port.sender?.tab?.windowId;
+        const isTargetWindow =
+          pendingSidePanelBgToUiMessage.targetWindowId === undefined ||
+          portWindowId === undefined ||
+          portWindowId === pendingSidePanelBgToUiMessage.targetWindowId;
+        if (isFresh && isTargetWindow && !didPushOnboardingModal) {
           port.postMessage(pendingSidePanelBgToUiMessage.value);
         }
-        pendingSidePanelBgToUiMessage.value = undefined;
-        pendingSidePanelBgToUiMessage.stashedAt = 0;
+        clearPendingSidePanelBgToUiMessage();
       }
 
       let dappRejectId: string | number | undefined;

--- a/apps/ext/src/background/sidePanel.ts
+++ b/apps/ext/src/background/sidePanel.ts
@@ -25,6 +25,8 @@ import {
 import extUtils from '@onekeyhq/shared/src/utils/extUtils';
 import { waitForDataLoaded } from '@onekeyhq/shared/src/utils/promiseUtils';
 import {
+  PENDING_SIDE_PANEL_MESSAGE_TTL_MS,
+  pendingSidePanelBgToUiMessage,
   sidePanelState,
   sidePanelUiState,
 } from '@onekeyhq/shared/src/utils/sidePanelUtils';
@@ -481,6 +483,20 @@ export const setupSidePanelPortInBg = () => {
         pendingKeylessGetStartedParams = undefined;
       }
 
+      // Flush a push that was produced while no port existed (the panel was
+      // still booting). Dropped rather than replayed once stale, so a failed
+      // open cannot inject an unrelated modal into a much later boot.
+      if (pendingSidePanelBgToUiMessage.value) {
+        const isFresh =
+          Date.now() - pendingSidePanelBgToUiMessage.stashedAt <
+          PENDING_SIDE_PANEL_MESSAGE_TTL_MS;
+        if (isFresh) {
+          port.postMessage(pendingSidePanelBgToUiMessage.value);
+        }
+        pendingSidePanelBgToUiMessage.value = undefined;
+        pendingSidePanelBgToUiMessage.stashedAt = 0;
+      }
+
       let dappRejectId: string | number | undefined;
       const closeSidePanel = () => {
         sidePanelState.isOpen = false;
@@ -604,11 +620,11 @@ export const setupSidePanelPortInUI = () => {
       switch (type) {
         case 'pushModal':
           {
-            // OK-58962: record synchronously, before any await. This message
-            // routinely arrives before React has rendered, and it is the only
-            // signal a Keyless-hosted panel gets — that flow page-loads the
-            // panel without going through ServiceDApp.openModal.
-            sidePanelUiState.isHostingPushedModal = true;
+            // OK-58962: record synchronously, before any await. Latches for
+            // the page's lifetime — see the note on sidePanelUiState. This is
+            // the only signal a Keyless-hosted panel gets, since that flow
+            // page-loads the panel without going through ServiceDApp.openModal.
+            sidePanelUiState.hasReceivedPushedModal = true;
             const { screen, params } = payload.modalParams;
             const rejectId = extractDappRejectIdFromModalParams(
               payload.modalParams,

--- a/packages/kit-bg/src/providers/ProviderApiPrivate.ts
+++ b/packages/kit-bg/src/providers/ProviderApiPrivate.ts
@@ -35,7 +35,10 @@ import {
 } from '@onekeyhq/shared/src/routes/onboardingv2';
 import { generateUUID } from '@onekeyhq/shared/src/utils/miscUtils';
 import { waitForDataLoaded } from '@onekeyhq/shared/src/utils/promiseUtils';
-import { sidePanelState } from '@onekeyhq/shared/src/utils/sidePanelUtils';
+import {
+  pendingSidePanelBgToUiMessage,
+  sidePanelState,
+} from '@onekeyhq/shared/src/utils/sidePanelUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { EHostSecurityLevel } from '@onekeyhq/shared/types/discovery';
 import type { IEndpointEnv } from '@onekeyhq/shared/types/endpoint';
@@ -788,25 +791,40 @@ class ProviderApiPrivate extends ProviderApiBase {
       throw new OneKeyLocalError('provider and nonce are required');
     }
     await this.wallet_keylessOpenSidePanel(request);
-    await timerUtils.wait(600);
 
-    if (sidePanelState.isOpen) {
-      appEventBus.emit(EAppEventBusNames.SidePanel_BgToUI, {
-        type: 'pushModal',
-        payload: {
-          modalParams: {
-            screen: EModalRoutes.OnboardingModal,
+    const loginModalMessage = {
+      type: 'pushModal',
+      payload: {
+        modalParams: {
+          screen: EModalRoutes.OnboardingModal,
+          params: {
+            screen: EOnboardingPagesV2.OneKeyIDLogin,
             params: {
-              screen: EOnboardingPagesV2.OneKeyIDLogin,
-              params: {
-                mode: EOnboardingV2OneKeyIDLoginMode.KeylessCreateOrRestore,
-                provider,
-              },
+              mode: EOnboardingV2OneKeyIDLoginMode.KeylessCreateOrRestore,
+              provider,
             },
           },
         },
-      });
+      },
+    } as const;
+
+    if (sidePanelState.isOpen) {
+      // Panel was already open, so it booted long ago — the delay only gives
+      // the existing page a beat to settle.
+      await timerUtils.wait(600);
+      if (sidePanelState.isOpen) {
+        appEventBus.emit(EAppEventBusNames.SidePanel_BgToUI, loginModalMessage);
+      }
+      return this.getKeylessSessionState({ request, provider, nonce });
     }
+
+    // OK-58962: the panel is still booting from the open() above, so there is
+    // no port to emit into yet. Racing a fixed delay here also races the
+    // panel's own boot-time gates — the post-update changelog could win and
+    // land on top of this login screen. Stash instead: the port-connect handler
+    // flushes it before the page renders.
+    pendingSidePanelBgToUiMessage.value = loginModalMessage;
+    pendingSidePanelBgToUiMessage.stashedAt = Date.now();
 
     return this.getKeylessSessionState({
       request,

--- a/packages/kit-bg/src/providers/ProviderApiPrivate.ts
+++ b/packages/kit-bg/src/providers/ProviderApiPrivate.ts
@@ -790,7 +790,7 @@ class ProviderApiPrivate extends ProviderApiBase {
     if (!provider || !nonce) {
       throw new OneKeyLocalError('provider and nonce are required');
     }
-    await this.wallet_keylessOpenSidePanel(request);
+    const openResult = await this.wallet_keylessOpenSidePanel(request);
 
     const loginModalMessage = {
       type: 'pushModal',
@@ -808,23 +808,34 @@ class ProviderApiPrivate extends ProviderApiBase {
       },
     } as const;
 
+    const stashForNextConnect = () => {
+      // OK-58962: no port to emit into, so hand the push to the port-connect
+      // handler. It flushes before the page renders, which a fixed delay
+      // cannot guarantee — and a delay would also race the panel's own
+      // boot-time gates, letting the post-update changelog land on top of this
+      // login screen.
+      pendingSidePanelBgToUiMessage.value = loginModalMessage;
+      pendingSidePanelBgToUiMessage.stashedAt = Date.now();
+      pendingSidePanelBgToUiMessage.targetWindowId = openResult.windowId;
+    };
+
+    // `isOpen` only means a port is connected right now. The call above always
+    // runs setOptions({ path }), which reloads an open panel, so the page may
+    // already be on its way out — never assume this one booted long ago.
     if (sidePanelState.isOpen) {
-      // Panel was already open, so it booted long ago — the delay only gives
-      // the existing page a beat to settle.
       await timerUtils.wait(600);
       if (sidePanelState.isOpen) {
         appEventBus.emit(EAppEventBusNames.SidePanel_BgToUI, loginModalMessage);
+      } else {
+        // Disconnected inside the wait (reload, or the user closed it). Fall
+        // back rather than dropping the push — otherwise the user clicks
+        // Keyless login and the panel just sits on the wallet home.
+        stashForNextConnect();
       }
       return this.getKeylessSessionState({ request, provider, nonce });
     }
 
-    // OK-58962: the panel is still booting from the open() above, so there is
-    // no port to emit into yet. Racing a fixed delay here also races the
-    // panel's own boot-time gates — the post-update changelog could win and
-    // land on top of this login screen. Stash instead: the port-connect handler
-    // flushes it before the page renders.
-    pendingSidePanelBgToUiMessage.value = loginModalMessage;
-    pendingSidePanelBgToUiMessage.stashedAt = Date.now();
+    stashForNextConnect();
 
     return this.getKeylessSessionState({
       request,

--- a/packages/kit-bg/src/providers/ProviderApiPrivate.ts
+++ b/packages/kit-bg/src/providers/ProviderApiPrivate.ts
@@ -790,7 +790,7 @@ class ProviderApiPrivate extends ProviderApiBase {
     if (!provider || !nonce) {
       throw new OneKeyLocalError('provider and nonce are required');
     }
-    const openResult = await this.wallet_keylessOpenSidePanel(request);
+    await this.wallet_keylessOpenSidePanel(request);
 
     const loginModalMessage = {
       type: 'pushModal',
@@ -816,7 +816,6 @@ class ProviderApiPrivate extends ProviderApiBase {
       // login screen.
       pendingSidePanelBgToUiMessage.value = loginModalMessage;
       pendingSidePanelBgToUiMessage.stashedAt = Date.now();
-      pendingSidePanelBgToUiMessage.targetWindowId = openResult.windowId;
     };
 
     // `isOpen` only means a port is connected right now. The call above always

--- a/packages/kit-bg/src/services/ServiceDApp.ts
+++ b/packages/kit-bg/src/services/ServiceDApp.ts
@@ -244,6 +244,15 @@ class ServiceDApp extends ServiceBase {
             routeNames,
             routeParams,
             modalParams,
+            // Without this the request can never settle when the push itself
+            // fails (chrome.windows.create rejected, or openSidePanel throwing
+            // because the panel closed inside the debounce window). The
+            // debounced call returns undefined to this caller and invokes on a
+            // later timer, so its rejection is unreachable from here — the
+            // callback has to be handed down. Left unsettled, `finally` never
+            // runs and existingWindowOrigin stays set, which now also gates
+            // user-visible update UI.
+            onError: (error) => reject(error),
           });
         });
       } finally {
@@ -254,6 +263,34 @@ class ServiceDApp extends ServiceBase {
   }
 
   _openModalByRouteParams = async ({
+    modalParams,
+    routeParams,
+    routeNames,
+    onError,
+  }: {
+    routeNames: any[];
+    routeParams: { query: string };
+    modalParams: { screen: any; params: any };
+    onError?: (error: unknown) => void;
+  }) => {
+    try {
+      await this._doOpenModalByRouteParams({
+        modalParams,
+        routeParams,
+        routeNames,
+      });
+    } catch (error) {
+      // Surface the failure to the waiting request instead of leaving it (and
+      // the pending-approval bookkeeping) hanging until the 30-minute sweep.
+      if (onError) {
+        onError(error);
+        return;
+      }
+      throw error;
+    }
+  };
+
+  _doOpenModalByRouteParams = async ({
     modalParams,
     routeParams,
     routeNames,

--- a/packages/kit-bg/src/services/ServiceDApp.ts
+++ b/packages/kit-bg/src/services/ServiceDApp.ts
@@ -305,6 +305,14 @@ class ServiceDApp extends ServiceBase {
     },
   );
 
+  // True from the moment a DApp approval is queued — set before the debounced
+  // modal push and cleared when the request settles — so it already reads true
+  // in the window before the modal actually appears.
+  @backgroundMethod()
+  async hasPendingDappRequest(): Promise<boolean> {
+    return !!this.existingWindowOrigin;
+  }
+
   // Public so provider APIs that queue connect requests on their own
   // semaphore (e.g. eth_requestAccounts) can surface the pending approval
   // window before the queued call ever reaches openModal. Focusing requires

--- a/packages/kit-bg/src/services/ServiceDApp.ts
+++ b/packages/kit-bg/src/services/ServiceDApp.ts
@@ -252,7 +252,17 @@ class ServiceDApp extends ServiceBase {
             // callback has to be handed down. Left unsettled, `finally` never
             // runs and existingWindowOrigin stays set, which now also gates
             // user-visible update UI.
-            onError: (error) => reject(error),
+            //
+            // Goes through servicePromise rather than the raw `reject` so the
+            // registration is removed too; rejecting the promise directly would
+            // settle the caller but leave the entry dangling until the
+            // 30-minute expiry sweep re-rejects an already-settled promise.
+            onError: (error) => {
+              void this.backgroundApi.servicePromise.rejectCallback({
+                id,
+                error,
+              });
+            },
           });
         });
       } finally {

--- a/packages/kit/src/components/AppUpdate/AppUpdateForeground.tsx
+++ b/packages/kit/src/components/AppUpdate/AppUpdateForeground.tsx
@@ -66,8 +66,10 @@ async function shouldDeferPostUpdateUi(): Promise<boolean> {
   if (platformEnv.isExtensionUiSidePanel) {
     // Checked first: it is local, synchronous, and the only signal covering the
     // Keyless / OneKey-ID hand-off, which page-loads a panel purely to host its
-    // approval without ever reaching ServiceDApp.openModal.
-    if (sidePanelUiState.isHostingPushedModal) return true;
+    // approval without ever reaching ServiceDApp.openModal. Safe to read as a
+    // latch here because this gate runs once, before the page can have handled
+    // anything the user did themselves.
+    if (sidePanelUiState.hasReceivedPushedModal) return true;
     return backgroundApiProxy.serviceDApp.hasPendingDappRequest();
   }
   return false;

--- a/packages/kit/src/components/AppUpdate/AppUpdateForeground.tsx
+++ b/packages/kit/src/components/AppUpdate/AppUpdateForeground.tsx
@@ -25,6 +25,7 @@ import { BundleUpdate } from '@onekeyhq/shared/src/modules3rdParty/auto-update';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EAppUpdateRoutes, EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { openUrlExternal } from '@onekeyhq/shared/src/utils/openUrlUtils';
+import { sidePanelUiState } from '@onekeyhq/shared/src/utils/sidePanelUtils';
 
 import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
 import useAppNavigation from '../../hooks/useAppNavigation';
@@ -51,6 +52,26 @@ let didRunFirstLaunchDispatch = false;
 // watcher effect below can react to a late hydration / in-session status
 // transition without re-running the full first-launch dispatch.
 let silentReadyDialogShown = false;
+
+/**
+ * OK-58962: on the extension every UI surface is its own page load, so a window
+ * opened purely to host a DApp approval boots the same first-launch dispatch as
+ * the wallet and pops the post-update changelog over the signing screen.
+ * ServiceDApp is the standalone window's sole opener, so it stands down
+ * unconditionally; the side panel is a normal wallet surface, so it stands down
+ * only while it is actually hosting an approval.
+ */
+async function shouldDeferPostUpdateUi(): Promise<boolean> {
+  if (platformEnv.isExtensionUiStandaloneWindow) return true;
+  if (platformEnv.isExtensionUiSidePanel) {
+    // Checked first: it is local, synchronous, and the only signal covering the
+    // Keyless / OneKey-ID hand-off, which page-loads a panel purely to host its
+    // approval without ever reaching ServiceDApp.openModal.
+    if (sidePanelUiState.isHostingPushedModal) return true;
+    return backgroundApiProxy.serviceDApp.hasPendingDappRequest();
+  }
+  return false;
+}
 
 /**
  * Mount-once foreground container for app-update side effects.
@@ -332,6 +353,11 @@ export function useAppUpdateForegroundEffects(enabled = true) {
       if (cancelled) return;
 
       if (isFirstLaunchAfterUpdated(info)) {
+        // Defer, don't skip: everything below is one-shot (analytics event,
+        // whatsNew marker, refreshUpdateStatus reset), so returning before any
+        // of it leaves this version's changelog intact for the next surface the
+        // user opens themselves.
+        if ((await shouldDeferPostUpdateUi()) || cancelled) return;
         // After the update has completed, current == target, so
         // getUpdateFileType always returns appShell. Derive the actual type
         // from the persisted info so bundle (hot-update) successes aren't

--- a/packages/kit/src/components/AppUpdate/useAppUpdate.test.ts
+++ b/packages/kit/src/components/AppUpdate/useAppUpdate.test.ts
@@ -135,7 +135,7 @@ jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => {
 // identity is stable across isolation, as with the other shared singletons.
 jest.mock('@onekeyhq/shared/src/utils/sidePanelUtils', () => ({
   sidePanelState: { isOpen: false },
-  sidePanelUiState: { isHostingPushedModal: false },
+  sidePanelUiState: { hasReceivedPushedModal: false },
 }));
 
 jest.mock('@onekeyhq/shared/src/platformEnv', () => {
@@ -401,7 +401,7 @@ function resetAllMocks() {
   // a stale `true` here would silently defer every later first-launch test.
   mockPlatformEnv.isExtensionUiStandaloneWindow = false;
   mockPlatformEnv.isExtensionUiSidePanel = false;
-  sidePanelUiState.isHostingPushedModal = false;
+  sidePanelUiState.hasReceivedPushedModal = false;
   dappSvc.hasPendingDappRequest.mockResolvedValue(false);
 
   // Default resolved values. getUpdateInfo uses mockImplementation so it
@@ -2360,7 +2360,7 @@ describe('useAppUpdateInfo useEffect', () => {
         // flag stays false — the panel's own pushed-modal state is the only
         // signal, and it is set before React renders.
         mockPlatformEnv.isExtensionUiSidePanel = true;
-        sidePanelUiState.isHostingPushedModal = true;
+        sidePanelUiState.hasReceivedPushedModal = true;
         dappSvc.hasPendingDappRequest.mockResolvedValue(false);
         setFirstLaunchAfterUpdate();
 

--- a/packages/kit/src/components/AppUpdate/useAppUpdate.test.ts
+++ b/packages/kit/src/components/AppUpdate/useAppUpdate.test.ts
@@ -55,11 +55,21 @@ jest.mock('../../background/instance/backgroundApiProxy', () => {
   const dev = {
     getSkipBundleGPGVerification: jest.fn(),
   };
+  // OK-58962: the post-update gate asks ServiceDApp whether an approval is in
+  // flight before it will run the first-launch block on an extension surface.
+  const dapp = {
+    hasPendingDappRequest: jest.fn(),
+  };
   (globalThis as any).__mockSvc = svc;
   (globalThis as any).__mockDevSvc = dev;
+  (globalThis as any).__mockDappSvc = dapp;
   return {
     __esModule: true,
-    default: { serviceAppUpdate: svc, serviceDevSetting: dev },
+    default: {
+      serviceAppUpdate: svc,
+      serviceDevSetting: dev,
+      serviceDApp: dapp,
+    },
   };
 });
 
@@ -119,6 +129,15 @@ jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => {
   };
 });
 
+// requireFreshHooks() reloads the module under test via jest.isolateModules,
+// which re-requires every UNMOCKED module — so a plain import here would hand
+// the test a different object than the one the hook reads. Mock it so the
+// identity is stable across isolation, as with the other shared singletons.
+jest.mock('@onekeyhq/shared/src/utils/sidePanelUtils', () => ({
+  sidePanelState: { isOpen: false },
+  sidePanelUiState: { isHostingPushedModal: false },
+}));
+
 jest.mock('@onekeyhq/shared/src/platformEnv', () => {
   // Created inline — cannot reference __mocks here because jest hoists this
   // factory above the __mocks assignment.
@@ -129,6 +148,11 @@ jest.mock('@onekeyhq/shared/src/platformEnv', () => {
     isNativeAndroid: false,
     isDesktop: false,
     isExtension: false,
+    // OK-58962: the two extension surfaces the post-update gate branches on.
+    // Declared here (not just left undefined) so a test can flip them and
+    // actually exercise the branch instead of silently short-circuiting.
+    isExtensionUiStandaloneWindow: false,
+    isExtensionUiSidePanel: false,
     isE2E: false,
     buildNumber: 1,
   };
@@ -307,6 +331,11 @@ import {
 } from '@onekeyhq/shared/src/appUpdate';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+// Resolves to the jest.mock above. Imported directly rather than bridged via
+// globalThis so the alias exists even if production code stops importing it —
+// otherwise removing that import turns every test in the file into a confusing
+// "cannot set property of undefined" instead of a clean failure.
+import { sidePanelUiState } from '@onekeyhq/shared/src/utils/sidePanelUtils';
 
 import {
   DownloadGaveUpError,
@@ -341,6 +370,7 @@ import {
 const g = globalThis as any;
 const svc = g.__mockSvc;
 const devSvc = g.__mockDevSvc;
+const dappSvc = g.__mockDappSvc;
 const nav = g.__mockNav;
 const appUpd = g.__mockAppUpd;
 const bundleUpd = g.__mockBundleUpd;
@@ -366,6 +396,13 @@ function setAtom(partial: Record<string, any>) {
 function resetAllMocks() {
   jest.clearAllMocks();
   setAtom({});
+
+  // OK-58962: these are module-level and leak across tests if not reset —
+  // a stale `true` here would silently defer every later first-launch test.
+  mockPlatformEnv.isExtensionUiStandaloneWindow = false;
+  mockPlatformEnv.isExtensionUiSidePanel = false;
+  sidePanelUiState.isHostingPushedModal = false;
+  dappSvc.hasPendingDappRequest.mockResolvedValue(false);
 
   // Default resolved values. getUpdateInfo uses mockImplementation so it
   // always returns the CURRENT mockAtomHolder.value — tests that reassign
@@ -2257,6 +2294,101 @@ describe('useAppUpdateInfo useEffect', () => {
       const successCall = resultCalls.find((c) => c[0]?.status === 'success');
       expect(successCall).toBeDefined();
       expect(successCall?.[0]?.attemptId).toBe(persistedId);
+    });
+
+    // ----- OK-58962: DApp-summoned extension surfaces stand down -----
+    //
+    // These pin the load-bearing half of the fix: the gate must DEFER, not
+    // skip. Everything in the first-launch block is one-shot — the
+    // softwareUpdateResult analytics event, the whatsNew marker, and the
+    // refreshUpdateStatus reset that flips status to `done` and makes
+    // isFirstLaunchAfterUpdated false forever. Consuming any of it on a
+    // surface that shows nothing retires the changelog for every later
+    // surface, and nothing in the type system stops a future edit from
+    // moving the guard below one of them.
+    describe('DApp-summoned surfaces defer the post-update block', () => {
+      // Shared assertion: the branch was entered, and nothing one-shot burned.
+      function expectDeferredNotConsumed() {
+        expect(svc.refreshUpdateStatus).not.toHaveBeenCalled();
+        const successCall = (
+          defaultLogger.app.appUpdate.softwareUpdateResult as jest.Mock
+        ).mock.calls.find((c) => c[0]?.status === 'success');
+        expect(successCall).toBeUndefined();
+      }
+
+      function setFirstLaunchAfterUpdate() {
+        setAtom({
+          status: EAppUpdateStatus.notify,
+          latestVersion: '1.0.0', // same as platformEnv.version
+          updateStrategy: EUpdateStrategy.manual,
+        });
+        svc.fetchAppUpdateInfo.mockResolvedValue(mockAtomHolder.value);
+      }
+
+      async function runFirstLaunchDispatch() {
+        const hooks = requireFreshHooks();
+        renderHook(() => hooks.useAppUpdateInfo(false, true));
+        await act(async () => {
+          await jest.runAllTimersAsync();
+        });
+      }
+
+      test('standalone window defers without consuming the one-shot state', async () => {
+        mockPlatformEnv.isExtensionUiStandaloneWindow = true;
+        setFirstLaunchAfterUpdate();
+
+        await runFirstLaunchDispatch();
+
+        expectDeferredNotConsumed();
+        // Decided unconditionally from the surface — no bg round trip.
+        expect(dappSvc.hasPendingDappRequest).not.toHaveBeenCalled();
+      });
+
+      test('side panel hosting a DApp approval defers', async () => {
+        mockPlatformEnv.isExtensionUiSidePanel = true;
+        dappSvc.hasPendingDappRequest.mockResolvedValue(true);
+        setFirstLaunchAfterUpdate();
+
+        await runFirstLaunchDispatch();
+
+        expectDeferredNotConsumed();
+      });
+
+      test('side panel hosting a Keyless hand-off defers without asking bg', async () => {
+        // The Keyless / OneKey-ID flow page-loads a panel purely to host its
+        // approval but never goes through ServiceDApp.openModal, so the bg
+        // flag stays false — the panel's own pushed-modal state is the only
+        // signal, and it is set before React renders.
+        mockPlatformEnv.isExtensionUiSidePanel = true;
+        sidePanelUiState.isHostingPushedModal = true;
+        dappSvc.hasPendingDappRequest.mockResolvedValue(false);
+        setFirstLaunchAfterUpdate();
+
+        await runFirstLaunchDispatch();
+
+        expectDeferredNotConsumed();
+        expect(dappSvc.hasPendingDappRequest).not.toHaveBeenCalled();
+      });
+
+      test('idle side panel does NOT defer — the block still runs', async () => {
+        mockPlatformEnv.isExtensionUiSidePanel = true;
+        dappSvc.hasPendingDappRequest.mockResolvedValue(false);
+        setFirstLaunchAfterUpdate();
+
+        await runFirstLaunchDispatch();
+
+        expect(dappSvc.hasPendingDappRequest).toHaveBeenCalled();
+        expect(svc.refreshUpdateStatus).toHaveBeenCalled();
+      });
+
+      test('non-extension platforms are untouched and never reach the bridge', async () => {
+        setFirstLaunchAfterUpdate();
+
+        await runFirstLaunchDispatch();
+
+        expect(dappSvc.hasPendingDappRequest).not.toHaveBeenCalled();
+        expect(svc.refreshUpdateStatus).toHaveBeenCalled();
+      });
     });
 
     test('isFirstLaunchAfterUpdated + seamless → no WhatsNew dialog', async () => {

--- a/packages/shared/src/utils/sidePanelUtils.test.ts
+++ b/packages/shared/src/utils/sidePanelUtils.test.ts
@@ -1,0 +1,75 @@
+import {
+  PENDING_SIDE_PANEL_MESSAGE_TTL_MS,
+  clearPendingSidePanelBgToUiMessage,
+  pendingSidePanelBgToUiMessage,
+  shouldFlushPendingSidePanelMessage,
+} from './sidePanelUtils';
+
+// OK-58962. The stash decides which side panel receives a pushed modal, and a
+// wrong answer is user-visible in both directions: deliver too late and someone
+// gets a login screen they never asked for, drop too eagerly and the login they
+// did ask for never appears. The predicate is pure precisely so these branches
+// are pinned without a Chrome environment.
+
+const STASHED_AT = 1_000_000;
+
+function flushAt(elapsedMs: number, didPushOnboardingModal = false) {
+  return shouldFlushPendingSidePanelMessage({
+    now: STASHED_AT + elapsedMs,
+    stashedAt: STASHED_AT,
+    didPushOnboardingModal,
+  });
+}
+
+describe('shouldFlushPendingSidePanelMessage', () => {
+  describe('TTL boundary', () => {
+    test('flushes immediately after stashing', () => {
+      expect(flushAt(0)).toBe(true);
+    });
+
+    test('flushes at one tick before the TTL', () => {
+      expect(flushAt(PENDING_SIDE_PANEL_MESSAGE_TTL_MS - 1)).toBe(true);
+    });
+
+    test('does NOT flush exactly at the TTL — the bound is exclusive', () => {
+      expect(flushAt(PENDING_SIDE_PANEL_MESSAGE_TTL_MS)).toBe(false);
+    });
+
+    test('does not flush past the TTL', () => {
+      expect(flushAt(PENDING_SIDE_PANEL_MESSAGE_TTL_MS + 1)).toBe(false);
+    });
+  });
+
+  describe('onboarding modal suppression', () => {
+    test('does not stack on a keyless get-started push from the same connect', () => {
+      expect(flushAt(0, true)).toBe(false);
+    });
+
+    test('suppression wins even while fresh', () => {
+      expect(flushAt(PENDING_SIDE_PANEL_MESSAGE_TTL_MS - 1, true)).toBe(false);
+    });
+  });
+
+  // Guards the window this predicate actually bounds. Freshness is the only
+  // thing separating the panel a push was meant for from a panel the user opens
+  // right after, so a change here widens a real mis-delivery window rather than
+  // just tuning a constant.
+  test('TTL stays tight enough to bound mis-delivery', () => {
+    expect(PENDING_SIDE_PANEL_MESSAGE_TTL_MS).toBeLessThanOrEqual(5 * 1000);
+  });
+});
+
+describe('clearPendingSidePanelBgToUiMessage', () => {
+  test('resets every field so a dropped entry cannot be picked up later', () => {
+    pendingSidePanelBgToUiMessage.value = {
+      type: 'pushModal',
+      payload: { modalParams: { screen: 'x', params: {} } },
+    } as unknown as typeof pendingSidePanelBgToUiMessage.value;
+    pendingSidePanelBgToUiMessage.stashedAt = STASHED_AT;
+
+    clearPendingSidePanelBgToUiMessage();
+
+    expect(pendingSidePanelBgToUiMessage.value).toBeUndefined();
+    expect(pendingSidePanelBgToUiMessage.stashedAt).toBe(0);
+  });
+});

--- a/packages/shared/src/utils/sidePanelUtils.ts
+++ b/packages/shared/src/utils/sidePanelUtils.ts
@@ -3,3 +3,19 @@ export const sidePanelState: {
 } = {
   isOpen: false,
 };
+
+// OK-58962. Deliberately separate from `sidePanelState`: the two are written in
+// different runtimes. `isOpen` is owned by bg; this is owned by the side
+// panel's own UI runtime and is set when bg asks that page to host a pushed
+// modal — a DApp approval, or the Keyless / OneKey-ID onboarding hand-off,
+// which never goes through ServiceDApp.openModal.
+//
+// Boot-time interruptive UI reads it to stand down. It has to be a UI-local
+// flag rather than a bg query: the push routinely lands before React has
+// rendered, so there is no navigation state to inspect yet, and bg has already
+// cleared its own pending-keyless marker by that point.
+export const sidePanelUiState: {
+  isHostingPushedModal: boolean;
+} = {
+  isHostingPushedModal: false,
+};

--- a/packages/shared/src/utils/sidePanelUtils.ts
+++ b/packages/shared/src/utils/sidePanelUtils.ts
@@ -1,3 +1,8 @@
+import type {
+  EAppEventBusNames,
+  IAppEventBusPayload,
+} from '../eventBus/appEventBus';
+
 export const sidePanelState: {
   isOpen: boolean;
 } = {
@@ -6,16 +11,39 @@ export const sidePanelState: {
 
 // OK-58962. Deliberately separate from `sidePanelState`: the two are written in
 // different runtimes. `isOpen` is owned by bg; this is owned by the side
-// panel's own UI runtime and is set when bg asks that page to host a pushed
-// modal — a DApp approval, or the Keyless / OneKey-ID onboarding hand-off,
-// which never goes through ServiceDApp.openModal.
+// panel's own UI runtime and is set when bg pushes a modal into that page.
 //
-// Boot-time interruptive UI reads it to stand down. It has to be a UI-local
-// flag rather than a bg query: the push routinely lands before React has
-// rendered, so there is no navigation state to inspect yet, and bg has already
-// cleared its own pending-keyless marker by that point.
+// LATCH, not live state: it is set once and never cleared for the page's
+// lifetime, and it fires for *any* pushed modal — a DApp approval, the Keyless
+// hand-off, or a notification opening an ordinary page. That is correct for a
+// boot-time gate that reads it once before the page can have handled anything
+// else. It is NOT a "currently hosting an approval" signal: a consumer that
+// re-reads it later in the session will see a stale `true` for any push that
+// ever happened, so do not reuse it for repeated checks without narrowing it
+// first.
 export const sidePanelUiState: {
-  isHostingPushedModal: boolean;
+  hasReceivedPushedModal: boolean;
 } = {
-  isHostingPushedModal: false,
+  hasReceivedPushedModal: false,
 };
+
+type ISidePanelBgToUiMessage =
+  IAppEventBusPayload[EAppEventBusNames.SidePanel_BgToUI];
+
+// bg runtime only. A bg->UI push produced while no side panel port is connected
+// would otherwise be dropped: the forwarding listener is registered per-port
+// inside onConnect. Stashing it here lets the port-connect handler flush it, so
+// callers do not have to guess a delay long enough for the panel to boot — and
+// the UI sees the push before it renders rather than racing it.
+//
+// TTL'd because the flush is not guaranteed: if the open fails and no port ever
+// connects, a stale entry must not be replayed into an unrelated later boot.
+export const pendingSidePanelBgToUiMessage: {
+  value: ISidePanelBgToUiMessage | undefined;
+  stashedAt: number;
+} = {
+  value: undefined,
+  stashedAt: 0,
+};
+
+export const PENDING_SIDE_PANEL_MESSAGE_TTL_MS = 30 * 1000;

--- a/packages/shared/src/utils/sidePanelUtils.ts
+++ b/packages/shared/src/utils/sidePanelUtils.ts
@@ -36,14 +36,30 @@ type ISidePanelBgToUiMessage =
 // callers do not have to guess a delay long enough for the panel to boot — and
 // the UI sees the push before it renders rather than racing it.
 //
-// TTL'd because the flush is not guaranteed: if the open fails and no port ever
-// connects, a stale entry must not be replayed into an unrelated later boot.
+// The flush is not guaranteed — the intended panel may never connect (the open
+// landed on another window, the user closed it immediately, chrome refused).
+// A stale entry must not then be delivered to whatever panel happens to connect
+// next, so it carries both a target window and a TTL: mis-delivering an
+// login modal the user never asked for is worse than dropping one they can
+// simply trigger again.
 export const pendingSidePanelBgToUiMessage: {
   value: ISidePanelBgToUiMessage | undefined;
   stashedAt: number;
+  targetWindowId: number | undefined;
 } = {
   value: undefined,
   stashedAt: 0,
+  targetWindowId: undefined,
 };
 
-export const PENDING_SIDE_PANEL_MESSAGE_TTL_MS = 30 * 1000;
+export function clearPendingSidePanelBgToUiMessage() {
+  pendingSidePanelBgToUiMessage.value = undefined;
+  pendingSidePanelBgToUiMessage.stashedAt = 0;
+  pendingSidePanelBgToUiMessage.targetWindowId = undefined;
+}
+
+// Sized for a panel that is already opening — the open() call has resolved by
+// the time anything is stashed, so a connect is normally under a second away.
+// Kept short because the window doubles as the exposure window for delivering
+// to a panel the user opened themselves.
+export const PENDING_SIDE_PANEL_MESSAGE_TTL_MS = 10 * 1000;

--- a/packages/shared/src/utils/sidePanelUtils.ts
+++ b/packages/shared/src/utils/sidePanelUtils.ts
@@ -35,31 +35,58 @@ type ISidePanelBgToUiMessage =
 // inside onConnect. Stashing it here lets the port-connect handler flush it, so
 // callers do not have to guess a delay long enough for the panel to boot — and
 // the UI sees the push before it renders rather than racing it.
-//
-// The flush is not guaranteed — the intended panel may never connect (the open
-// landed on another window, the user closed it immediately, chrome refused).
-// A stale entry must not then be delivered to whatever panel happens to connect
-// next, so it carries both a target window and a TTL: mis-delivering an
-// login modal the user never asked for is worse than dropping one they can
-// simply trigger again.
 export const pendingSidePanelBgToUiMessage: {
   value: ISidePanelBgToUiMessage | undefined;
   stashedAt: number;
-  targetWindowId: number | undefined;
 } = {
   value: undefined,
   stashedAt: 0,
-  targetWindowId: undefined,
 };
 
 export function clearPendingSidePanelBgToUiMessage() {
   pendingSidePanelBgToUiMessage.value = undefined;
   pendingSidePanelBgToUiMessage.stashedAt = 0;
-  pendingSidePanelBgToUiMessage.targetWindowId = undefined;
 }
 
-// Sized for a panel that is already opening — the open() call has resolved by
-// the time anything is stashed, so a connect is normally under a second away.
-// Kept short because the window doubles as the exposure window for delivering
-// to a panel the user opened themselves.
-export const PENDING_SIDE_PANEL_MESSAGE_TTL_MS = 10 * 1000;
+// Freshness is the ONLY thing separating the panel a push was meant for from a
+// panel the user happens to open right afterwards.
+//
+// An earlier revision also compared a stashed target window against
+// `port.sender.tab.windowId`. That check never ran: `sender.tab` is only
+// populated when a connection originates from a tab or content script, and a
+// side panel is an extension page — so the comparison silently fell through to
+// its fail-open branch every time. Removed rather than left in place, because a
+// guard that never fires reads like protection that exists.
+//
+// The real fix is an identity handshake (bg mints a nonce into the panel URL,
+// the panel echoes it back as its first port message, still ahead of render).
+// That is not shipped here: it changes the side panel URL and the port
+// protocol, and this path cannot be exercised without a live Keyless flow.
+//
+// So the window is kept deliberately tight instead. The open() call has already
+// resolved by the time anything is stashed, so the intended panel normally
+// connects well inside a second.
+export const PENDING_SIDE_PANEL_MESSAGE_TTL_MS = 5 * 1000;
+
+/**
+ * Whether a stashed bg->UI push should be delivered to the panel that just
+ * connected. Pure so the branches can be tested without a Chrome environment —
+ * the caller clears the stash either way, so a `false` here means dropped, not
+ * deferred.
+ */
+export function shouldFlushPendingSidePanelMessage({
+  now,
+  stashedAt,
+  didPushOnboardingModal,
+}: {
+  now: number;
+  stashedAt: number;
+  /** An onboarding modal already went out on this same connect. */
+  didPushOnboardingModal: boolean;
+}): boolean {
+  // Never stack two onboarding modals onto one boot.
+  if (didPushOnboardingModal) {
+    return false;
+  }
+  return now - stashedAt < PENDING_SIDE_PANEL_MESSAGE_TTL_MS;
+}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58962](https://onekeyhq.atlassian.net/browse/OK-58962)

----------

<!-- github-pr-monitor:jira-links:end -->


Jira: [OK-58962](https://onekeyhq.atlassian.net/browse/OK-58962)

## Problem

On the extension every UI surface (popup / side panel / standalone window / expand tab) is its own page load sharing one entry, so a window opened purely to host a DApp approval boots the same post-update dispatch as the wallet — and pops the "What's New" changelog over the signing screen. Reported with a screenshot of the changelog covering a Contract Interaction approval.

## Change

Stand down on DApp-summoned surfaces:

- **Standalone window** — always. `ServiceDApp._openModalByRouteParams` is its only opener repo-wide, so that surface is an approval by definition.
- **Side panel** — only while it is actually hosting an approval. It is a normal wallet surface, so a blanket rule would be wrong.

Two signals, because one does not cover both cases:

- `ServiceDApp.hasPendingDappRequest()` — reads the existing `existingWindowOrigin`, which is set before the debounced modal push, so it is already true during the window where a booting panel can receive an approval.
- `sidePanelUiState.hasReceivedPushedModal` — UI-runtime-local, set synchronously when bg pushes a modal into this page. The Keyless / OneKey-ID hand-off page-loads a panel to host its approval **without** going through `ServiceDApp.openModal`, so the bg flag never sees it; and by the time the gate runs, bg has already cleared its own pending-keyless marker. Checked first, so that path costs no bridge round trip. It is a latch, never reset, and fires for any pushed modal — correct for a gate that reads it once at boot, not a live "currently hosting" signal.

## Defer, don't skip

The gate returns before the **whole** first-launch block, not just the dialog. That block is one-shot — the `softwareUpdateResult` analytics event, the `markWhatsNewShown` marker, and the `refreshUpdateStatus` reset that flips status to `done` (after which `isFirstLaunchAfterUpdated` is false forever). Suppressing only the dialog while letting that state burn would retire the changelog for **every** later surface, silently and with no error.

Non-extension platforms are untouched: both flags require `isExtension`, so the predicate returns `false` after one microtask on desktop / iOS / Android / web.

## Tests

Five cases pinning the contract, mutation-verified:

- removing the whole gate kills 4 of 5
- removing only the Keyless branch kills exactly 1
- the non-extension control correctly survives both

Getting there required mocking `sidePanelUtils` — `requireFreshHooks()` uses `jest.isolateModules`, which re-requires unmocked modules, so a plain import handed the test a different object than the hook read. The suite mock also gained `serviceDApp` and the two ext platform flags, all reset in `resetAllMocks` so they cannot leak between tests.

`yarn agent:check --profile commit` 5/5, 160/160 tests.

## Known gaps (deliberate, not oversights)

- The force-update preview and `ready` dialog still push over a signing window when status is not first-launch-after-update. Excluded by product decision on this ticket.
- The floating-icon launch dialog has the same defect class in `Bootstrap.tsx` `useLaunchEvents`, and `updateLaunchTimes()` runs outside its surface gate so approval-only windows inflate the counter. Tracked separately. An earlier revision of this description offered `hasReceivedPushedModal` as a ready-made signal for it — that was wrong and has been retracted: the flag is a never-reset latch, so a consumer that re-reads it during the session would permanently swallow the dialog. That fix needs its own narrowed signal.
- A review pass surfaced further items — a newer `latestVersion` landing mid-deferral can destroy the deferred changelog, the deferring surface performs no update check for its page lifetime, and the new bridge call has no catch or timeout. All logged, none addressed here.

[OK-58962]: https://onekeyhq.atlassian.net/browse/OK-58962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Review follow-ups (2nd commit)

- **Second Keyless entry was not actually covered.** `wallet_keylessStartLogin` opened the panel and pushed its login modal only after `wait(600)`, so a booting panel had no marker during that window and the gate could decline to defer — reproducing the exact overlap this PR fixes. Now the push is stashed and flushed on port connect (before the page renders) instead of racing a fixed delay; the already-open path keeps its settle delay. The stash is TTL'd so a failed open cannot replay a stale modal into a later boot.
- **Failed modal pushes now settle the request.** `_openModalByRouteParams` takes an `onError` and rejects the waiting DApp promise. The reviewer's suggested `.catch()` on the debounced call does not work: with `{leading:false, trailing:true}` the call returns `undefined` synchronously (so `.catch` TypeErrors) and the real invocation happens on a later timer, out of reach of the caller — verified by running it. Without this, `finally` never ran and `existingWindowOrigin` stayed set, which now gates user-visible update UI.

## Review follow-ups (3rd/4th commits)

- **The already-open branch dropped the push.** `isOpen` only means a port is connected *right now*, and `wallet_keylessOpenSidePanel` always calls `setOptions({path})`, which reloads an open panel — so the page can be on its way out and the user would click Keyless login only to have the panel sit on the wallet home. Falls back to the stash instead of discarding.
- **Failed pushes now go through `servicePromise.rejectCallback`** rather than the raw executor `reject`, so the registration is removed instead of being left for the 30-minute sweep to re-reject an already-settled promise.
- **A panel-target check I added did not work and has been removed.** It compared a stashed window id against `port.sender.tab.windowId`, but `MessageSender.tab` is only populated for connections from a tab or content script — a side panel is an extension page, so it was always `undefined` and the comparison fell through its fail-open branch every time, silently. Freshness is now the stated single guard and the TTL is tightened to 5s.
- **Stash logic is now unit-tested.** `shouldFlushPendingSidePanelMessage` is a pure predicate in `sidePanelUtils.ts` with coverage for the TTL boundary on both sides, onboarding suppression, and stash clearing.

### Known follow-up, not shipped here

Delivery is bounded only by a 5s TTL. The correct fix is an identity handshake — bg mints a nonce into the panel URL and the panel echoes it back as its first port message, still ahead of render. It is not in this PR because it changes both the side panel URL and the port protocol, and the Keyless path cannot be exercised without a live flow.

### Verification boundary

The Keyless timing changes in this PR are supported by static reasoning and unit tests only. There is no automated or manual coverage of a real OneKey ID login round-trip, and `wallet_keylessStartLogin`'s ordering has now been revised across several commits. Worth an eye from someone who can run that flow before merge; QA case 3 exercises it end to end.
