### PR TITLE
fix: label Simplified Chinese as 简体中文（新加坡）in language list

### DIFF
--- a/packages/shared/src/locale/localeOptions.ts
+++ b/packages/shared/src/locale/localeOptions.ts
@@ -5,7 +5,7 @@ import { LOCALE_KEYS } from './localeLoaders';
 import type { ILocaleSymbol } from './type';
 
 const defaultLanguage: Record<string, string> = {
-  'zh-CN': '简体中文',
+  'zh-CN': '简体中文（新加坡）',
   'zh-HK': '繁體中文（香港）',
   'zh-TW': '繁體中文（臺灣）',
   'pt-BR': 'Português(Brasil)',


### PR DESCRIPTION
## What

Rename the `zh-CN` display label in the language list from `简体中文` to `简体中文（新加坡）`.

One line in [`packages/shared/src/locale/localeOptions.ts`](https://github.com/OneKeyHQ/app-monorepo/blob/claude/simplified-chinese-singapore-label-f43278/packages/shared/src/locale/localeOptions.ts#L8):

```diff
 const defaultLanguage: Record<string, string> = {
-  'zh-CN': '简体中文',
+  'zh-CN': '简体中文（新加坡）',
   'zh-HK': '繁體中文（香港）',
   'zh-TW': '繁體中文（臺灣）',
```

Full-width parentheses, matching the neighbouring `繁體中文（香港）` / `繁體中文（臺灣）` entries.

## Why

Product request: the Simplified Chinese entry should carry an explicit region suffix, consistent with the two Traditional Chinese entries that already show theirs.

## Scope

- The locale key (`zh-CN`), the loaded JSON, the ordering in `PRIORITY_LOCALE_KEYS`, and everything else about the locale are unchanged. This is a display-string change only.
- `packages/shared/src/locale/localeOptions.ts` is the single source of the language name across the app — no native strings, extension manifest, or desktop menu duplicates it.

## Reviewer notes

- **Second surface affected:** the same `LOCALES_OPTION` label is read by Discovery's page-translation target-language display ([`usePageTranslation.tsx#L259`](https://github.com/OneKeyHQ/app-monorepo/blob/claude/simplified-chinese-singapore-label-f43278/packages/kit/src/views/Discovery/hooks/usePageTranslation.tsx#L259)), so that label becomes `简体中文（新加坡）` too. If it should only change under Settings → Preferences → Language, the two call sites need to be split — say so and I'll follow up.
- `apps/playground/.storybook/preview.tsx` still says `简体中文` in its Storybook toolbar locale switcher. That's a dev-only tool, not the app's language list, so it was deliberately left alone.

## Verification

Not run on device. This worktree has no `node_modules`, so `yarn agent:check --profile commit` could not be executed here, and the web dev server's port was occupied by another process. Verification was static: the string flows verbatim into `LOCALES_OPTION[].label`, and a repo-wide search confirmed no other definition of the language name. CI will cover lint/tsc.
