### PR TITLE
feat: enable scam history filter and approval management for Robinhood chain

### DIFF
--- a/packages/kit/src/components/TxHistoryListView/TxHistoryListHeader.tsx
+++ b/packages/kit/src/components/TxHistoryListView/TxHistoryListHeader.tsx
@@ -10,7 +10,7 @@ import {
   Switch,
 } from '@onekeyhq/components';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { getNetworksSupportFilterScamHistory } from '@onekeyhq/shared/src/config/presetNetworks';
+import { getNetworkIdsSupportFilterScamHistory } from '@onekeyhq/shared/src/config/presetNetworks';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -26,10 +26,8 @@ type IProps = {
   filteredHistory: IAccountHistoryTx[];
 };
 
-const filterScamHistorySupportedNetworks =
-  getNetworksSupportFilterScamHistory();
 const filterScamHistorySupportedNetworkIds = new Set(
-  filterScamHistorySupportedNetworks.map((n) => n.id),
+  getNetworkIdsSupportFilterScamHistory(),
 );
 
 function TxHistoryListHeader({ filteredHistory: _filteredHistory }: IProps) {

--- a/packages/kit/src/views/Home/pages/TabHeaderSettings.tsx
+++ b/packages/kit/src/views/Home/pages/TabHeaderSettings.tsx
@@ -18,7 +18,7 @@ import {
 import { useOneKeyAuth } from '@onekeyhq/kit/src/components/OneKeyAuth/useOneKeyAuth';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import { getNetworksSupportFilterScamHistory } from '@onekeyhq/shared/src/config/presetNetworks';
+import { getNetworkIdsSupportFilterScamHistory } from '@onekeyhq/shared/src/config/presetNetworks';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -72,10 +72,8 @@ function TokenListSettings() {
     />
   ) : null;
 }
-const filterScamHistorySupportedNetworks =
-  getNetworksSupportFilterScamHistory();
 const filterScamHistorySupportedNetworkIds = new Set(
-  filterScamHistorySupportedNetworks.map((n) => n.id),
+  getNetworkIdsSupportFilterScamHistory(),
 );
 
 function TxHistorySettingsContent({

--- a/packages/shared/src/config/presetNetworks.ts
+++ b/packages/shared/src/config/presetNetworks.ts
@@ -2631,22 +2631,25 @@ export const getPresetNetworks = memoFn((): IServerNetwork[] => {
   return networks;
 });
 
-export const getNetworksSupportFilterScamHistory = memoFn(
-  (): IServerNetwork[] => [
-    eth,
-    sol,
-    sepolia,
-    hoodi,
-    base,
-    optimism,
-    avalanche,
-    arbitrum,
-    bsc,
-    polygon,
-    etc,
-    tron,
-  ],
-);
+// Robinhood Chain is delivered via the server network list instead of
+// presetNetworks, so feature switches below reference it by network id.
+const ROBINHOOD_NETWORK_ID = 'evm--4663';
+
+export const getNetworkIdsSupportFilterScamHistory = memoFn((): string[] => [
+  eth.id,
+  sol.id,
+  sepolia.id,
+  hoodi.id,
+  base.id,
+  optimism.id,
+  avalanche.id,
+  arbitrum.id,
+  bsc.id,
+  polygon.id,
+  etc.id,
+  tron.id,
+  ROBINHOOD_NETWORK_ID,
+]);
 
 export const getNetworksSupportMevProtection = memoFn(
   (): Record<
@@ -2691,5 +2694,6 @@ export const getNetworksSupportBulkRevokeApproval = memoFn(
     [avalanche.id]: true,
     [optimism.id]: true,
     [base.id]: true,
+    [ROBINHOOD_NETWORK_ID]: true,
   }),
 );


### PR DESCRIPTION
## Summary
- Enable the "hide risky transactions" history filter for Robinhood Chain (`evm--4663`)
- Enable approval management (home Approvals tab, wallet actions entry, approval list network filter) for Robinhood Chain
- Refactor `getNetworksSupportFilterScamHistory` → `getNetworkIdsSupportFilterScamHistory` (returns network ids) so non-preset, server-delivered networks can be referenced in the whitelist

## Intent & Context
The backend now supports on-chain history, risky-transaction filtering, and approval management for Robinhood Chain. The client gates the latter two features behind hardcoded network whitelists, so they stayed disabled even after the server rollout. This PR opens those client-side switches.

On-chain history needs no client change: it is driven entirely by the `backendIndex` flag on the network object, which for server-delivered networks comes from `/wallet/v1/network/list`. As of 2026-07-31 prod still returns `backendIndex: false` for `evm--4663`; once the server flips it, the client picks it up automatically on the next network-list fetch (verified against the prod endpoint).

## Design Decisions
- **Robinhood is intentionally NOT added to presetNetworks.** It is a server-delivered network, and the `getAllNetworks` merge is first-wins with presets added first — a preset entry would permanently mask server-side field updates (including the upcoming `backendIndex` flip).
- The scam-filter whitelist previously returned `IServerNetwork[]` built from preset network objects, which cannot express a non-preset chain. Since both consumers only ever used `.id`, the helper now returns ids directly (`string[]`); a literal `ROBINHOOD_NETWORK_ID = 'evm--4663'` constant is used, matching how other code (SwapProvider constants) references this chain.
- `getNetworksSupportBulkRevokeApproval` is already keyed by network id, so adding one entry covers every approval-management gate (HomePageView tab visibility, ApprovalListPage, WalletActionMore, ApprovalList network filter). Unknown ids are safe in the network filter: `getNetworksByIds` silently drops networks not yet present locally.

## Changes Detail
- `packages/shared/src/config/presetNetworks.ts`: rename scam-filter helper to id-based form and add Robinhood; add Robinhood to the bulk-revoke approval map
- `packages/kit/src/components/TxHistoryListView/TxHistoryListHeader.tsx`: consume the id-based helper (behavior unchanged for existing networks)
- `packages/kit/src/views/Home/pages/TabHeaderSettings.tsx`: same consumer update

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: The helper rename touches the scam-filter gating for all existing networks; the id list is identical to the previous object list, so behavior for existing chains is unchanged. Robinhood entries only widen the whitelists.

## Test plan
- [ ] On Robinhood Chain (`evm--4663`), the history settings popover shows "Hide risky transactions" enabled (not greyed out) and toggling it filters scam txs
- [ ] On Robinhood Chain, the home Approvals tab and the wallet "more actions" approval entry are visible, and the approval list loads
- [ ] The approval management network filter includes Robinhood
- [ ] Existing whitelisted chains (ETH, SOL, BSC, etc.) behave exactly as before for both features