### PR TITLE
fix: OK-58984 OK-58138 OK-58104 OK-58103 address, balance, allowance, and dialog issues

### DIFF
--- a/packages/kit-bg/src/services/ServiceToken.fetchAccountTokens.test.ts
+++ b/packages/kit-bg/src/services/ServiceToken.fetchAccountTokens.test.ts
@@ -1,0 +1,190 @@
+import {
+  ETokenDappType,
+  type IAccountToken,
+  type IFetchAccountTokensResp,
+  type ITokenData,
+} from '@onekeyhq/shared/types/token';
+
+import ServiceToken from './ServiceToken';
+
+type IMockVault = {
+  fetchTokenList: (
+    params: unknown,
+  ) => Promise<{ data: { data: IFetchAccountTokensResp } }>;
+};
+
+const mockGetVault = jest.fn<Promise<IMockVault>, [unknown]>();
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundClass: () => (target: unknown) => target,
+  backgroundMethod:
+    () => (_target: unknown, _key: string, descriptor: unknown) =>
+      descriptor,
+  backgroundMethodForDev:
+    () => (_target: unknown, _key: string, descriptor: unknown) =>
+      descriptor,
+  checkDevOnlyPassword: jest.fn(),
+}));
+
+jest.mock('@onekeyhq/shared/src/eventBus/appEventBus', () => ({
+  EAppEventBusNames: {
+    MemoryPressureWarning: 'MemoryPressureWarning',
+  },
+  appEventBus: {
+    on: jest.fn(),
+  },
+}));
+
+jest.mock('../states/jotai/atoms', () => ({
+  currencyPersistAtom: {
+    get: jest.fn(async () => ({ currencyMap: {} })),
+  },
+  settingsPersistAtom: {
+    get: jest.fn(async () => ({ currencyInfo: { id: 'usd' } })),
+  },
+}));
+
+jest.mock('../vaults/factory', () => ({
+  vaultFactory: {
+    getVault: (params: unknown) => mockGetVault(params),
+  },
+}));
+
+const networkId = 'evm--1';
+
+const walletToken: IAccountToken = {
+  $key: 'wallet-token',
+  address: '0xwallet',
+  decimals: 18,
+  isNative: false,
+  name: 'Wallet token',
+  symbol: 'WALLET',
+  dappType: ETokenDappType.WalletToken,
+  networkId,
+};
+
+const dappToken: IAccountToken = {
+  $key: 'dapp-token',
+  address: '0xdapp',
+  decimals: 18,
+  isNative: false,
+  name: 'DeFi token',
+  symbol: 'DEFI',
+  dappName: 'DeFi protocol',
+  networkId,
+};
+
+function buildTokenData(): ITokenData {
+  return {
+    data: [walletToken, dappToken],
+    keys: `${walletToken.$key},${dappToken.$key}`,
+    map: {
+      [walletToken.$key]: {
+        balance: '3',
+        balanceParsed: '3',
+        fiatValue: '3',
+        price: 1,
+      },
+      [dappToken.$key]: {
+        balance: '10',
+        balanceParsed: '10',
+        fiatValue: '10',
+        price: 1,
+      },
+    },
+    fiatValue: '13',
+    currency: 'usd',
+  };
+}
+
+describe('ServiceToken.fetchAccountTokens', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('removes an explicit custom wallet token from every dApp-only token group', async () => {
+    const response: IFetchAccountTokensResp = {
+      tokens: buildTokenData(),
+      riskTokens: buildTokenData(),
+      smallBalanceTokens: buildTokenData(),
+      allTokens: buildTokenData(),
+    };
+    const fetchTokenList = jest.fn(async () => ({
+      data: { data: response },
+    }));
+    mockGetVault.mockResolvedValue({ fetchTokenList });
+
+    const service = new ServiceToken({
+      backgroundApi: {
+        serviceAccount: {
+          getAccountXpub: jest.fn(async () => ''),
+          getAccountAddressForApi: jest.fn(async () => '0xaccount'),
+          buildAccountXpubOrAddress: jest.fn(
+            async ({
+              getAccountAddressFn,
+            }: {
+              getAccountAddressFn: () => Promise<string>;
+            }) => getAccountAddressFn(),
+          ),
+        },
+        serviceCustomToken: {
+          getCustomTokens: jest.fn(
+            async ({ networkId: requestedNetworkId }: { networkId: string }) =>
+              requestedNetworkId === networkId ? [walletToken] : [],
+          ),
+          getHiddenTokens: jest.fn(async () => []),
+        },
+        serviceNetwork: {
+          getVaultSettings: jest.fn(async () => ({
+            mergeDeriveAssetsEnabled: false,
+          })),
+          getNetworkSafe: jest.fn(async () => ({ name: 'Ethereum' })),
+        },
+        serviceToken: {
+          getUnblockedTokens: jest.fn(async () => []),
+          getBlockedTokens: jest.fn(async () => []),
+          getAllAggregateTokenInfo: jest.fn(async () => ({
+            allAggregateTokenMap: {},
+            allAggregateTokens: [],
+          })),
+        },
+      },
+    });
+
+    const result = await service.fetchAccountTokens({
+      accountId: "hd-1--m/44'/60'/0'/0/0",
+      networkId,
+      withoutDappToken: false,
+      withoutWalletToken: true,
+      saveToLocal: false,
+    });
+
+    expect(fetchTokenList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestApiParams: expect.objectContaining({
+          contractList: [walletToken.address],
+          withoutDappToken: false,
+          withoutWalletToken: true,
+        }),
+      }),
+    );
+
+    for (const groupName of [
+      'tokens',
+      'riskTokens',
+      'smallBalanceTokens',
+      'allTokens',
+    ] as const) {
+      expect(result[groupName]).toEqual(
+        expect.objectContaining({
+          data: [expect.objectContaining({ $key: dappToken.$key })],
+          keys: dappToken.$key,
+          map: {
+            [dappToken.$key]: expect.objectContaining({ fiatValue: '10' }),
+          },
+          fiatValue: '10',
+        }),
+      );
+    }
+  });
+});

--- a/packages/kit-bg/src/services/ServiceToken.ts
+++ b/packages/kit-bg/src/services/ServiceToken.ts
@@ -480,6 +480,7 @@ class ServiceToken extends ServiceBase {
     // cache and account-worth consumers see them.
     const tokenSelectorFilterParams = {
       withoutDappToken: rest.withoutDappToken,
+      withoutWalletToken: rest.withoutWalletToken,
     };
     resp.data.data.tokens = filterTokenSelectorTokenDataByDappTokenFilterParams(
       {

--- a/packages/kit-bg/src/services/ServiceToken.ts
+++ b/packages/kit-bg/src/services/ServiceToken.ts
@@ -24,6 +24,7 @@ import perfUtils, {
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import tokenRebaseUtils from '@onekeyhq/shared/src/utils/tokenRebaseUtils';
+import { filterTokenSelectorTokenDataByDappTokenFilterParams } from '@onekeyhq/shared/src/utils/tokenSelectorFilterUtils';
 import {
   buildTokenSearchKeywordQueries,
   filterAccountTokenListByLimit,
@@ -473,6 +474,36 @@ class ServiceToken extends ServiceBase {
           mergeAssets: vaultSettings.mergeDeriveAssetsEnabled,
         };
       });
+
+    // Explicit custom contracts may still be returned when the wallet-token
+    // request excludes dApp tokens. Normalize the complete groups before
+    // cache and account-worth consumers see them.
+    const tokenSelectorFilterParams = {
+      withoutDappToken: rest.withoutDappToken,
+    };
+    resp.data.data.tokens = filterTokenSelectorTokenDataByDappTokenFilterParams(
+      {
+        tokenData: resp.data.data.tokens,
+        tokenSelectorFilterParams,
+      },
+    );
+    resp.data.data.riskTokens =
+      filterTokenSelectorTokenDataByDappTokenFilterParams({
+        tokenData: resp.data.data.riskTokens,
+        tokenSelectorFilterParams,
+      });
+    resp.data.data.smallBalanceTokens =
+      filterTokenSelectorTokenDataByDappTokenFilterParams({
+        tokenData: resp.data.data.smallBalanceTokens,
+        tokenSelectorFilterParams,
+      });
+    if (resp.data.data.allTokens) {
+      resp.data.data.allTokens =
+        filterTokenSelectorTokenDataByDappTokenFilterParams({
+          tokenData: resp.data.data.allTokens,
+          tokenSelectorFilterParams,
+        });
+    }
 
     if (mergeTokens) {
       const { tokens, riskTokens, smallBalanceTokens } = resp.data.data as any;

--- a/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
@@ -38,6 +38,7 @@ import { useManagePage } from '@onekeyhq/kit/src/views/Staking/pages/ManagePosit
 import { buildBorrowTag } from '@onekeyhq/kit/src/views/Staking/utils/utils';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IDeFiProtocolLendingActionSource } from '@onekeyhq/shared/src/routes/assetDetails';
 import defiActionUtils from '@onekeyhq/shared/src/utils/defiActionUtils';
 import earnUtils from '@onekeyhq/shared/src/utils/earnUtils';
@@ -979,8 +980,10 @@ function ProtocolLendingActionBorrowContent({
 }) {
   const intl = useIntl();
   const { gtMd } = useMedia();
-  const { bodyMaxHeight, feedbackMaxHeight } =
+  const { bodyMaxHeight: defaultBodyMaxHeight, feedbackMaxHeight } =
     resolveProtocolPositionActionDialogLayout({ gtMd });
+  const bodyMaxHeight =
+    platformEnv.isDesktop && gtMd ? 480 : defaultBodyMaxHeight;
   const [
     {
       currencyInfo: { symbol: currencySymbol },
@@ -1735,7 +1738,7 @@ function ProtocolLendingActionBorrowContent({
                   id: ETranslations.defi_health_factor,
                 })}
                 valueNode={
-                  <Skeleton height="$4" width="$16" borderRadius="$1" />
+                  <Skeleton height={24} width="$16" borderRadius="$1" />
                 }
               />
               {remainingDebtChange ? (

--- a/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
+import { useWindowDimensions } from 'react-native';
 
 import {
   Alert,
@@ -133,6 +134,8 @@ const EMPTY_BORROW_ASSETS_LIST: IBorrowAssetsList = {
 // Mirrors DEFI_ACTION_HERO_MIN_HEIGHT in ProtocolPositionActionDialog so the
 // loading skeleton reserves the same amount-hero height.
 const BORROW_HERO_SKELETON_HEIGHT = 128;
+// 32px viewport inset + 70px header + 58px footer + 20px body host padding.
+const DESKTOP_LENDING_DIALOG_CHROME_HEIGHT = 180;
 
 // Focus ring for the keyboard-focusable asset selector rows (matches Button).
 const LENDING_SELECTOR_FOCUS_STYLE = {
@@ -980,10 +983,14 @@ function ProtocolLendingActionBorrowContent({
 }) {
   const intl = useIntl();
   const { gtMd } = useMedia();
+  const { height: windowHeight } = useWindowDimensions();
   const { bodyMaxHeight: defaultBodyMaxHeight, feedbackMaxHeight } =
     resolveProtocolPositionActionDialogLayout({ gtMd });
   const bodyMaxHeight =
     platformEnv.isDesktop && gtMd ? 480 : defaultBodyMaxHeight;
+  const dialogBodyMaxHeight = platformEnv.isDesktop
+    ? Math.max(0, windowHeight - DESKTOP_LENDING_DIALOG_CHROME_HEIGHT)
+    : undefined;
   const [
     {
       currencyInfo: { symbol: currencySymbol },
@@ -1833,7 +1840,11 @@ function ProtocolLendingActionBorrowContent({
   }
 
   return (
-    <YStack gap="$5">
+    <YStack
+      gap="$5"
+      maxHeight={dialogBodyMaxHeight}
+      minHeight={dialogBodyMaxHeight === undefined ? undefined : 0}
+    >
       <Dialog.Header>
         <Dialog.Title>{actionLabel}</Dialog.Title>
       </Dialog.Header>

--- a/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
@@ -3677,7 +3677,7 @@ describe('useSwapActions', () => {
     });
   });
 
-  it('creates a missing recipient address on the resolved target network', async () => {
+  it('creates a missing recipient address with the resolved target identity', async () => {
     const hdWallet: IDBWallet = {
       id: 'hd-1',
       name: 'HD Wallet 1',
@@ -3689,6 +3689,7 @@ describe('useSwapActions', () => {
     };
     const ethActiveAccountInfo: IAccountSelectorActiveAccountInfo = {
       ...activeAccountInfo,
+      deriveType: 'default',
       wallet: hdWallet,
       indexedAccount: {
         id: 'hd-1--0',
@@ -3703,6 +3704,7 @@ describe('useSwapActions', () => {
     };
     const ethAddressInfo: ISwapAddressInfo = {
       ...fromAddressInfo,
+      deriveType: ethActiveAccountInfo.deriveType,
       accountInfo: ethActiveAccountInfo,
       activeAccount: ethActiveAccountInfo,
     };
@@ -3710,6 +3712,7 @@ describe('useSwapActions', () => {
       ...ethAddressInfo,
       address: undefined,
       networkId: ltcToken.networkId,
+      deriveType: 'BIP84',
     };
     const { store, Wrapper } = createWrapperWithStore((storeInstance) => {
       storeInstance.set(swapNetworks(), [evmSwapNetwork, ltcSwapNetwork]);
@@ -3735,6 +3738,7 @@ describe('useSwapActions', () => {
           actionData: expect.objectContaining({
             account: expect.objectContaining({
               networkId: ltcToken.networkId,
+              deriveType: 'BIP84',
             }),
           }),
         }),

--- a/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
@@ -16,7 +16,10 @@ import {
 import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import { settingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { globalJotaiStorageReadyHandler } from '@onekeyhq/kit-bg/src/states/jotai/jotaiStorage';
-import { WALLET_TYPE_EXTERNAL } from '@onekeyhq/shared/src/consts/dbConsts';
+import {
+  WALLET_TYPE_EXTERNAL,
+  WALLET_TYPE_HD,
+} from '@onekeyhq/shared/src/consts/dbConsts';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { INetworkAccount } from '@onekeyhq/shared/types/account';
 import {
@@ -198,6 +201,13 @@ const bnbToken: ISwapToken = {
   decimals: 18,
   isNative: true,
 };
+const ltcToken: ISwapToken = {
+  networkId: 'ltc--0',
+  contractAddress: '',
+  symbol: 'LTC',
+  decimals: 8,
+  isNative: true,
+};
 const ethProToken: IToken = {
   ...ethToken,
   speedSwapDefaultAmount: [0.001, 0.01, 0.1],
@@ -240,6 +250,11 @@ const evmSwapNetwork: ISwapNetwork = {
   networkId: 'evm--1',
   name: 'Ethereum',
   symbol: 'ETH',
+};
+const ltcSwapNetwork: ISwapNetwork = {
+  networkId: 'ltc--0',
+  name: 'Litecoin',
+  symbol: 'LTC',
 };
 const evmAccount: INetworkAccount = {
   id: 'hd-1--m/44/60/0/0/0',
@@ -3660,6 +3675,71 @@ describe('useSwapActions', () => {
       quoteId: '',
       states: [],
     });
+  });
+
+  it('creates a missing recipient address on the resolved target network', async () => {
+    const hdWallet: IDBWallet = {
+      id: 'hd-1',
+      name: 'HD Wallet 1',
+      type: WALLET_TYPE_HD,
+      backuped: true,
+      accounts: [],
+      nextIds: {},
+      walletNo: 1,
+    };
+    const ethActiveAccountInfo: IAccountSelectorActiveAccountInfo = {
+      ...activeAccountInfo,
+      wallet: hdWallet,
+      indexedAccount: {
+        id: 'hd-1--0',
+        name: 'Account 1',
+        walletId: hdWallet.id,
+        index: 0,
+        idHash: 'indexed-account-hash',
+      },
+      network: { id: ethToken.networkId } as NonNullable<
+        IAccountSelectorActiveAccountInfo['network']
+      >,
+    };
+    const ethAddressInfo: ISwapAddressInfo = {
+      ...fromAddressInfo,
+      accountInfo: ethActiveAccountInfo,
+      activeAccount: ethActiveAccountInfo,
+    };
+    const missingLtcAddressInfo: ISwapAddressInfo = {
+      ...ethAddressInfo,
+      address: undefined,
+      networkId: ltcToken.networkId,
+    };
+    const { store, Wrapper } = createWrapperWithStore((storeInstance) => {
+      storeInstance.set(swapNetworks(), [evmSwapNetwork, ltcSwapNetwork]);
+      storeInstance.set(swapSelectToTokenAtom(), ltcToken);
+    });
+    const { result } = renderHook(() => useSwapActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await withMutedConsoleError(async () => {
+      await act(async () => {
+        await result.current.checkSwapWarning(
+          ethAddressInfo,
+          missingLtcAddressInfo,
+        );
+      });
+    });
+
+    expect(store.get(swapAlertsAtom()).states).toEqual([
+      expect.objectContaining({
+        action: expect.objectContaining({
+          directionType: ESwapDirectionType.TO,
+          actionData: expect.objectContaining({
+            account: expect.objectContaining({
+              networkId: ltcToken.networkId,
+            }),
+          }),
+        }),
+      }),
+    ]);
   });
 
   it('keeps the unsupported-account alert after address resolution completes', async () => {

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -1908,19 +1908,14 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
 
   checkAddressNeedCreate = (
     swapSupportAllNetworks: ISwapNetwork[],
-    fromToken: ISwapToken,
+    token: ISwapToken,
     addressInfo: ReturnType<typeof useSwapAddressInfo>,
     directionType: ESwapDirectionType,
   ) => {
+    const networkId = addressInfo.networkId || token.networkId;
     const netInfo = swapSupportAllNetworks.find(
-      (net) => net.networkId === fromToken.networkId,
+      (net) => net.networkId === networkId,
     );
-    const isAllNetwork = networkUtils.isAllNetwork({
-      networkId: addressInfo.accountInfo?.network?.id,
-    });
-    const networkId = isAllNetwork
-      ? fromToken.networkId
-      : addressInfo.accountInfo?.network?.id;
     const walletId = addressInfo.accountInfo?.wallet?.id;
     const indexedAccountId = addressInfo.accountInfo?.indexedAccount?.id;
     const deriveType = addressInfo.accountInfo?.deriveType;

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -1918,7 +1918,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
     );
     const walletId = addressInfo.accountInfo?.wallet?.id;
     const indexedAccountId = addressInfo.accountInfo?.indexedAccount?.id;
-    const deriveType = addressInfo.accountInfo?.deriveType;
+    const deriveType = addressInfo.deriveType;
     const account = {
       walletId,
       indexedAccountId,

--- a/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.test.tsx
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.test.tsx
@@ -89,6 +89,7 @@ jest.mock('@onekeyhq/kit/src/views/Staking/hooks/useUtilsHooks', () => {
         allowance?: string;
         loadingAllowance?: boolean;
         fetchAllowanceResponse?: jest.Mock;
+        initialValue?: string;
         trackAllowance?: jest.Mock;
       };
     }
@@ -98,12 +99,15 @@ jest.mock('@onekeyhq/kit/src/views/Staking/hooks/useUtilsHooks', () => {
 
   return {
     __esModule: true,
-    useTrackTokenAllowance: () => ({
-      allowance: mockBag.allowance ?? '0',
-      loading: mockBag.loadingAllowance ?? false,
-      trackAllowance: mockBag.trackAllowance,
-      fetchAllowanceResponse: mockBag.fetchAllowanceResponse,
-    }),
+    useTrackTokenAllowance: ({ initialValue }: { initialValue?: string }) => {
+      mockBag.initialValue = initialValue;
+      return {
+        allowance: mockBag.allowance ?? '0',
+        loading: mockBag.loadingAllowance ?? false,
+        trackAllowance: mockBag.trackAllowance,
+        fetchAllowanceResponse: mockBag.fetchAllowanceResponse,
+      };
+    },
   };
 });
 
@@ -129,6 +133,7 @@ type IBorrowApproveHookMock = {
   loadingAllowance?: boolean;
   fetchAllowanceResponse: jest.Mock;
   getAccount: jest.Mock;
+  initialValue?: string;
   navigationToTxConfirm: jest.Mock;
   trackAllowance: jest.Mock;
 };
@@ -157,6 +162,7 @@ describe('useBorrowApproveAndSubmit', () => {
   beforeEach(() => {
     mockBag.allowance = '0';
     mockBag.loadingAllowance = false;
+    mockBag.initialValue = undefined;
     mockBag.fetchAllowanceResponse.mockReset();
     mockBag.getAccount.mockReset();
     mockBag.navigationToTxConfirm.mockReset();
@@ -243,5 +249,20 @@ describe('useBorrowApproveAndSubmit', () => {
     expect(onBeforeNavigateConfirm).not.toHaveBeenCalled();
     expect(mockBag.navigationToTxConfirm).not.toHaveBeenCalled();
     expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves an omitted allowance for the allowance tracker', () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+    renderHook(() =>
+      useBorrowApproveAndSubmit({
+        approveTarget,
+        currentAllowance: undefined,
+        amountValue: '10',
+        onSubmit,
+      }),
+    );
+
+    expect(mockBag.initialValue).toBeUndefined();
   });
 });

--- a/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.ts
+++ b/packages/kit/src/views/Borrow/components/ManagePosition/hooks/useBorrowApproveAndSubmit.ts
@@ -52,18 +52,19 @@ export function useBorrowApproveAndSubmit({
     networkId: approveTarget?.networkId ?? '',
     tokenAddress: approveTarget?.token?.address ?? '',
     spenderAddress: approveTarget?.spenderAddress ?? '',
-    initialValue: currentAllowance ?? '0',
+    initialValue: currentAllowance,
     approveType: EApproveType.Legacy,
   });
   const isFocus = useIsFocused();
 
   const needsApproval = useMemo(() => {
     if (!useApprove) return false;
+    if (loadingAllowance) return false;
     if (!isFocus) return true;
     const amountBN = new BigNumber(amountValue || '0');
     const allowanceBN = new BigNumber(allowance || '0');
     return !amountBN.isNaN() && amountBN.gt(0) && allowanceBN.lt(amountBN);
-  }, [allowance, amountValue, isFocus, useApprove]);
+  }, [allowance, amountValue, isFocus, loadingAllowance, useApprove]);
   const approveSnapshotKey = useMemo(
     () =>
       [

--- a/packages/kit/src/views/Staking/hooks/useUtilsHooks.test.tsx
+++ b/packages/kit/src/views/Staking/hooks/useUtilsHooks.test.tsx
@@ -1,0 +1,73 @@
+/* eslint-disable import/first */
+
+jest.mock('../../../background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceHistory: {
+      fetchTxDetails: jest.fn(),
+    },
+    serviceStaking: {
+      fetchTokenAllowance: jest.fn(),
+    },
+  },
+}));
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
+
+import { useTrackTokenAllowance } from './useUtilsHooks';
+
+const serviceStaking = jest.mocked(backgroundApiProxy.serviceStaking);
+
+const params = {
+  accountId: 'account-1',
+  networkId: 'evm--1',
+  spenderAddress: '0xspender',
+  tokenAddress: '0xtoken',
+};
+
+describe('useTrackTokenAllowance', () => {
+  beforeEach(() => {
+    serviceStaking.fetchTokenAllowance.mockReset();
+    serviceStaking.fetchTokenAllowance.mockResolvedValue({
+      allowance: '10000000',
+      allowanceParsed: '10',
+    });
+  });
+
+  it('fetches the allowance when its initial value is unknown', async () => {
+    const { result } = renderHook(() =>
+      useTrackTokenAllowance({ ...params, initialValue: undefined }),
+    );
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.allowance).toBe('10');
+    });
+    expect(serviceStaking.fetchTokenAllowance.mock.calls).toHaveLength(1);
+  });
+
+  it('uses a known initial allowance without fetching it again', () => {
+    const { result } = renderHook(() =>
+      useTrackTokenAllowance({ ...params, initialValue: '5' }),
+    );
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.allowance).toBe('5');
+    expect(serviceStaking.fetchTokenAllowance.mock.calls).toHaveLength(0);
+  });
+
+  it('keeps the fallback allowance when the initial fetch fails', async () => {
+    serviceStaking.fetchTokenAllowance.mockRejectedValue(
+      new Error('network error'),
+    );
+    const { result } = renderHook(() =>
+      useTrackTokenAllowance({ ...params, initialValue: undefined }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.allowance).toBe('0');
+  });
+});

--- a/packages/kit/src/views/Staking/hooks/useUtilsHooks.test.tsx
+++ b/packages/kit/src/views/Staking/hooks/useUtilsHooks.test.tsx
@@ -12,7 +12,7 @@ jest.mock('../../../background/instance/backgroundApiProxy', () => ({
   },
 }));
 
-import { renderHook, waitFor } from '@testing-library/react-native';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 
@@ -69,5 +69,69 @@ describe('useTrackTokenAllowance', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.allowance).toBe('0');
+  });
+
+  it('ignores an outdated request while loading the current target', async () => {
+    let resolveFirstRequest:
+      | ((value: { allowance: string; allowanceParsed: string }) => void)
+      | undefined;
+    let resolveSecondRequest:
+      | ((value: { allowance: string; allowanceParsed: string }) => void)
+      | undefined;
+    serviceStaking.fetchTokenAllowance
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstRequest = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecondRequest = resolve;
+          }),
+      );
+
+    const { result, rerender } = renderHook(
+      ({ accountId }: { accountId: string }) =>
+        useTrackTokenAllowance({
+          ...params,
+          accountId,
+          initialValue: undefined,
+        }),
+      { initialProps: { accountId: 'account-1' } },
+    );
+
+    await waitFor(() =>
+      expect(serviceStaking.fetchTokenAllowance.mock.calls).toHaveLength(1),
+    );
+    rerender({ accountId: 'account-2' });
+    await waitFor(() =>
+      expect(serviceStaking.fetchTokenAllowance.mock.calls).toHaveLength(2),
+    );
+
+    await act(async () => {
+      resolveFirstRequest?.({
+        allowance: '10000000',
+        allowanceParsed: '10',
+      });
+      await Promise.resolve();
+    });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.allowance).toBe('0');
+
+    await act(async () => {
+      resolveSecondRequest?.({
+        allowance: '20000000',
+        allowanceParsed: '20',
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.allowance).toBe('20');
+    });
   });
 });

--- a/packages/kit/src/views/Staking/hooks/useUtilsHooks.ts
+++ b/packages/kit/src/views/Staking/hooks/useUtilsHooks.ts
@@ -129,15 +129,19 @@ export function useTrackTokenAllowance({
     [accountId, approveType, networkId, spenderAddress, tokenAddress],
   );
   useEffect(() => {
+    let cancelled = false;
     if (isExistApproveTarget) {
       const fetchAllowance = async () => {
         if (!txDetails && !shouldFetchInitialAllowance) {
-          setLoading(false);
+          if (!cancelled) {
+            setLoading(false);
+          }
           return;
         }
         try {
           const allowanceInfo = await fetchAllowanceResponse();
           if (
+            !cancelled &&
             allowanceInfo &&
             allowanceTargetKeyRef.current === allowanceTargetKey
           ) {
@@ -147,11 +151,19 @@ export function useTrackTokenAllowance({
             });
           }
         } finally {
-          setLoading(false);
+          if (
+            !cancelled &&
+            allowanceTargetKeyRef.current === allowanceTargetKey
+          ) {
+            setLoading(false);
+          }
         }
       };
       void fetchAllowance().catch(() => undefined);
     }
+    return () => {
+      cancelled = true;
+    };
   }, [
     txDetails,
     networkId,

--- a/packages/kit/src/views/Staking/hooks/useUtilsHooks.ts
+++ b/packages/kit/src/views/Staking/hooks/useUtilsHooks.ts
@@ -70,13 +70,15 @@ export function useTrackTokenAllowance({
 }: {
   networkId: string;
   accountId: string;
-  initialValue: string;
+  initialValue?: string;
   tokenAddress: string;
   spenderAddress: string;
   approveType?: EApproveType;
 }) {
   const isLegacyApprove = approveType === EApproveType.Legacy;
   const isExistApproveTarget = !!spenderAddress;
+  const shouldFetchInitialAllowance =
+    initialValue === undefined && isExistApproveTarget;
   const allowanceTargetKey = [
     accountId,
     networkId,
@@ -91,14 +93,14 @@ export function useTrackTokenAllowance({
     value: string;
   }>(() => ({
     targetKey: allowanceTargetKey,
-    value: initialValue,
+    value: initialValue ?? '0',
   }));
   const allowance =
     allowanceState.targetKey === allowanceTargetKey
       ? allowanceState.value
       : '0';
   const [trackTxId, setTrackTxId] = useState<string>('');
-  const [loading, setLoading] = useState<boolean>();
+  const [loading, setLoading] = useState(shouldFetchInitialAllowance);
   const txDetails = useTxTrack({
     accountId,
     networkId,
@@ -106,12 +108,13 @@ export function useTrackTokenAllowance({
   });
   useEffect(() => {
     setTrackTxId('');
-    setLoading(false);
+    setLoading(shouldFetchInitialAllowance);
     setAllowanceState((prev) => ({
       targetKey: allowanceTargetKey,
-      value: prev.targetKey === allowanceTargetKey ? initialValue : '0',
+      value:
+        prev.targetKey === allowanceTargetKey ? (initialValue ?? '0') : '0',
     }));
-  }, [allowanceTargetKey, initialValue]);
+  }, [allowanceTargetKey, initialValue, shouldFetchInitialAllowance]);
   const fetchAllowanceResponse = useCallback(
     async () =>
       backgroundApiProxy.serviceStaking.fetchTokenAllowance({
@@ -128,7 +131,7 @@ export function useTrackTokenAllowance({
   useEffect(() => {
     if (isExistApproveTarget) {
       const fetchAllowance = async () => {
-        if (!txDetails) {
+        if (!txDetails && !shouldFetchInitialAllowance) {
           setLoading(false);
           return;
         }
@@ -147,7 +150,7 @@ export function useTrackTokenAllowance({
           setLoading(false);
         }
       };
-      void fetchAllowance();
+      void fetchAllowance().catch(() => undefined);
     }
   }, [
     txDetails,
@@ -160,6 +163,7 @@ export function useTrackTokenAllowance({
     allowanceTargetKey,
     isLegacyApprove,
     isExistApproveTarget,
+    shouldFetchInitialAllowance,
   ]);
   const trackAllowance = useCallback((txid: string) => {
     setTrackTxId(txid);

--- a/packages/kit/src/views/Staking/pages/ManagePosition/hooks/useManagePage.utils.test.ts
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/hooks/useManagePage.utils.test.ts
@@ -1,11 +1,22 @@
 import { EManagePositionType } from '@onekeyhq/shared/types/staking';
 
 import {
+  buildManagePageApproveInfo,
   buildManagePageRequestKey,
   shouldBlockManagePageAction,
 } from './useManagePage.utils';
 
 describe('useManagePage utils', () => {
+  it('preserves an unknown allowance when only the approve target is provided', () => {
+    expect(
+      buildManagePageApproveInfo({
+        approve: undefined,
+        approveAsset: undefined,
+        approveTarget: '0xspender',
+      })?.allowance,
+    ).toBeUndefined();
+  });
+
   it('includes indexed account identity in the request key', () => {
     const baseParams = {
       accountId: '',

--- a/packages/kit/src/views/Staking/pages/ManagePosition/hooks/useManagePage.utils.ts
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/hooks/useManagePage.utils.ts
@@ -76,7 +76,7 @@ export function buildManagePageApproveInfo({
   }
 
   return {
-    allowance: approve?.allowance ?? '0',
+    allowance: approve?.allowance,
     approveType: normalizeApproveType(approve?.approveType),
     approveAsset: approve?.approveAsset ?? approveAsset,
     approveTarget: resolvedApproveTarget,

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.ts
@@ -5,6 +5,7 @@ import { debounce } from 'lodash';
 import { useIsOverlayPage } from '@onekeyhq/components';
 import { useRouteIsFocused as useIsFocused } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
 import { useSettingsAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
@@ -277,6 +278,9 @@ export function useSwapAddressInfo(type: ESwapDirectionType) {
   const [accountForTargetNetwork, setAccountForTargetNetwork] = useState<
     INetworkAccount | undefined
   >(undefined);
+  const [deriveTypeForTargetNetwork, setDeriveTypeForTargetNetwork] = useState<
+    IAccountDeriveTypes | undefined
+  >(undefined);
   const [resolvedTargetNetworkAccountKey, setResolvedTargetNetworkAccountKey] =
     useState<string | undefined>(undefined);
 
@@ -379,14 +383,17 @@ export function useSwapAddressInfo(type: ESwapDirectionType) {
 
     if (!shouldResolveTargetNetworkAccount || !tokenNetworkId) {
       setAccountForTargetNetwork(undefined);
+      setDeriveTypeForTargetNetwork(undefined);
       setResolvedTargetNetworkAccountKey(undefined);
       return;
     }
+    setDeriveTypeForTargetNetwork(undefined);
     setResolvedTargetNetworkAccountKey(undefined);
 
     void (async () => {
+      let targetDeriveType: IAccountDeriveTypes | undefined;
       try {
-        const targetDeriveType =
+        targetDeriveType =
           await backgroundApiProxy.serviceNetwork.getGlobalDeriveTypeOfNetwork({
             networkId: tokenNetworkId,
           });
@@ -402,11 +409,13 @@ export function useSwapAddressInfo(type: ESwapDirectionType) {
           });
         if (!cancelled) {
           setAccountForTargetNetwork(targetAccount);
+          setDeriveTypeForTargetNetwork(targetDeriveType);
           setResolvedTargetNetworkAccountKey(targetNetworkAccountResolveKey);
         }
       } catch (_e) {
         if (!cancelled) {
           setAccountForTargetNetwork(undefined);
+          setDeriveTypeForTargetNetwork(targetDeriveType);
           setResolvedTargetNetworkAccountKey(targetNetworkAccountResolveKey);
         }
       }
@@ -430,11 +439,15 @@ export function useSwapAddressInfo(type: ESwapDirectionType) {
     const res: {
       address: undefined | string;
       networkId: undefined | string;
+      deriveType?: IAccountDeriveTypes;
       accountInfo: IAccountSelectorActiveAccountInfo | undefined;
       activeAccount: IAccountSelectorActiveAccountInfo | undefined;
       isAddressInfoReady: boolean;
     } = {
       networkId: undefined,
+      deriveType: shouldResolveTargetNetworkAccount
+        ? deriveTypeForTargetNetwork
+        : activeAccount.deriveType,
       address: undefined,
       accountInfo: undefined,
       activeAccount: undefined,
@@ -563,6 +576,7 @@ export function useSwapAddressInfo(type: ESwapDirectionType) {
     activeAccount,
     isAllNetwork,
     accountForTargetNetwork,
+    deriveTypeForTargetNetwork,
     isAddressInfoReady,
     tokenNetworkId,
     currentSelectNetwork?.networkId,

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.ts
@@ -45,6 +45,7 @@ import {
 
 import {
   getSwapAddressAccountSelectorNum,
+  resolveSwapTargetNetworkAccount,
   shouldResetSwapRecipientOnAccountNetworkSync,
   shouldShowSwapRecipientAddressInfo,
   shouldUseSwapCustomRecipientAddress,
@@ -391,21 +392,23 @@ export function useSwapAddressInfo(type: ESwapDirectionType) {
     setResolvedTargetNetworkAccountKey(undefined);
 
     void (async () => {
-      let targetDeriveType: IAccountDeriveTypes | undefined;
       try {
-        targetDeriveType =
-          await backgroundApiProxy.serviceNetwork.getGlobalDeriveTypeOfNetwork({
-            networkId: tokenNetworkId,
-          });
-        const targetAccount =
-          await backgroundApiProxy.serviceAccount.getNetworkAccount({
-            deriveType: targetDeriveType,
-            indexedAccountId: activeAccount.indexedAccount?.id,
-            accountId: activeAccount.indexedAccount?.id
-              ? undefined
-              : activeAccount.account?.id,
-            dbAccount: activeAccount.dbAccount,
-            networkId: tokenNetworkId,
+        const { account: targetAccount, deriveType: targetDeriveType } =
+          await resolveSwapTargetNetworkAccount({
+            getDeriveType: () =>
+              backgroundApiProxy.serviceNetwork.getGlobalDeriveTypeOfNetwork({
+                networkId: tokenNetworkId,
+              }),
+            getNetworkAccount: (deriveType) =>
+              backgroundApiProxy.serviceAccount.getNetworkAccount({
+                deriveType,
+                indexedAccountId: activeAccount.indexedAccount?.id,
+                accountId: activeAccount.indexedAccount?.id
+                  ? undefined
+                  : activeAccount.account?.id,
+                dbAccount: activeAccount.dbAccount,
+                networkId: tokenNetworkId,
+              }),
           });
         if (!cancelled) {
           setAccountForTargetNetwork(targetAccount);
@@ -415,8 +418,7 @@ export function useSwapAddressInfo(type: ESwapDirectionType) {
       } catch (_e) {
         if (!cancelled) {
           setAccountForTargetNetwork(undefined);
-          setDeriveTypeForTargetNetwork(targetDeriveType);
-          setResolvedTargetNetworkAccountKey(targetNetworkAccountResolveKey);
+          setDeriveTypeForTargetNetwork(undefined);
         }
       }
     })();

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts
@@ -12,19 +12,53 @@ import {
 } from './useSwapAccount.utils';
 
 describe('resolveSwapTargetNetworkAccount', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('keeps derive lookup failures unresolved', async () => {
     const getDeriveType = jest.fn(async () => {
       throw new OneKeyLocalError('derive lookup failed');
     });
     const getNetworkAccount = jest.fn(async () => ({ id: 'account-1' }));
 
-    await expect(
-      resolveSwapTargetNetworkAccount({
-        getDeriveType,
-        getNetworkAccount,
-      }),
-    ).rejects.toThrow('derive lookup failed');
+    const resolvePromise = resolveSwapTargetNetworkAccount({
+      getDeriveType,
+      getNetworkAccount,
+    });
+    const resolveErrorPromise = resolvePromise.catch((error: unknown) => error);
+    await jest.runAllTimersAsync();
+
+    await expect(resolveErrorPromise).resolves.toMatchObject({
+      message: 'derive lookup failed',
+    });
+    expect(getDeriveType).toHaveBeenCalledTimes(2);
     expect(getNetworkAccount).not.toHaveBeenCalled();
+  });
+
+  it('retries one transient derive lookup failure', async () => {
+    const getDeriveType = jest
+      .fn()
+      .mockRejectedValueOnce(new OneKeyLocalError('derive lookup failed'))
+      .mockResolvedValueOnce('BIP84');
+    const getNetworkAccount = jest.fn(async () => ({ id: 'account-1' }));
+
+    const resolvePromise = resolveSwapTargetNetworkAccount({
+      getDeriveType,
+      getNetworkAccount,
+    });
+    await jest.runAllTimersAsync();
+
+    await expect(resolvePromise).resolves.toEqual({
+      account: { id: 'account-1' },
+      deriveType: 'BIP84',
+    });
+    expect(getDeriveType).toHaveBeenCalledTimes(2);
+    expect(getNetworkAccount).toHaveBeenCalledWith('BIP84');
   });
 
   it('preserves the target derive type when its account is missing', async () => {

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts
@@ -1,13 +1,50 @@
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 
 import {
   getSwapAddressAccountSelectorNum,
   getSwapRecipientActionState,
   getSwapRecipientValidationAccountId,
+  resolveSwapTargetNetworkAccount,
   shouldResetSwapRecipientOnAccountNetworkSync,
   shouldShowSwapRecipientAddressInfo,
   shouldUseSwapCustomRecipientAddress,
 } from './useSwapAccount.utils';
+
+describe('resolveSwapTargetNetworkAccount', () => {
+  it('keeps derive lookup failures unresolved', async () => {
+    const getDeriveType = jest.fn(async () => {
+      throw new OneKeyLocalError('derive lookup failed');
+    });
+    const getNetworkAccount = jest.fn(async () => ({ id: 'account-1' }));
+
+    await expect(
+      resolveSwapTargetNetworkAccount({
+        getDeriveType,
+        getNetworkAccount,
+      }),
+    ).rejects.toThrow('derive lookup failed');
+    expect(getNetworkAccount).not.toHaveBeenCalled();
+  });
+
+  it('preserves the target derive type when its account is missing', async () => {
+    const getDeriveType = jest.fn(async () => 'BIP84' as const);
+    const getNetworkAccount = jest.fn(async () => {
+      throw new OneKeyLocalError('account not found');
+    });
+
+    await expect(
+      resolveSwapTargetNetworkAccount({
+        getDeriveType,
+        getNetworkAccount,
+      }),
+    ).resolves.toEqual({
+      account: undefined,
+      deriveType: 'BIP84',
+    });
+    expect(getNetworkAccount).toHaveBeenCalledWith('BIP84');
+  });
+});
 
 describe('getSwapRecipientActionState', () => {
   const validState = {

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
@@ -1,3 +1,4 @@
+import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { equalsIgnoreCase } from '@onekeyhq/shared/src/utils/stringUtils';
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
@@ -56,6 +57,27 @@ type IGetSwapRecipientActionStateParams = {
   isAddressInfoReady: boolean;
   providerSupportReceiveAddress?: boolean;
 };
+
+export async function resolveSwapTargetNetworkAccount<TAccount>({
+  getDeriveType,
+  getNetworkAccount,
+}: {
+  getDeriveType: () => Promise<IAccountDeriveTypes>;
+  getNetworkAccount: (deriveType: IAccountDeriveTypes) => Promise<TAccount>;
+}) {
+  const deriveType = await getDeriveType();
+  try {
+    return {
+      account: await getNetworkAccount(deriveType),
+      deriveType,
+    };
+  } catch {
+    return {
+      account: undefined,
+      deriveType,
+    };
+  }
+}
 
 export function getSwapRecipientActionState({
   isActionDisabled,

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
@@ -1,7 +1,10 @@
 import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { equalsIgnoreCase } from '@onekeyhq/shared/src/utils/stringUtils';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
+
+const SWAP_TARGET_DERIVE_TYPE_RETRY_DELAY_MS = 500;
 
 type IShouldUseSwapCustomRecipientAddressParams = {
   type: ESwapDirectionType;
@@ -65,7 +68,13 @@ export async function resolveSwapTargetNetworkAccount<TAccount>({
   getDeriveType: () => Promise<IAccountDeriveTypes>;
   getNetworkAccount: (deriveType: IAccountDeriveTypes) => Promise<TAccount>;
 }) {
-  const deriveType = await getDeriveType();
+  let deriveType: IAccountDeriveTypes;
+  try {
+    deriveType = await getDeriveType();
+  } catch {
+    await timerUtils.wait(SWAP_TARGET_DERIVE_TYPE_RETRY_DELAY_MS);
+    deriveType = await getDeriveType();
+  }
   try {
     return {
       account: await getNetworkAccount(deriveType),

--- a/packages/shared/src/utils/tokenSelectorFilterUtils.test.ts
+++ b/packages/shared/src/utils/tokenSelectorFilterUtils.test.ts
@@ -1,9 +1,12 @@
 import {
   buildSwapAllNetworkTokenListCacheKey,
   dedupeTokenSelectorNetworkAccounts,
+  filterTokenSelectorTokenDataByDappTokenFilterParams,
   filterTokenSelectorTokensByBackendIndexedNetworks,
   isTokenSelectorDappTokenFilterSupportedNetworkBase,
 } from './tokenSelectorFilterUtils';
+
+import type { ITokenData } from '../../types/token';
 
 describe('tokenSelectorFilterUtils', () => {
   describe('isTokenSelectorDappTokenFilterSupportedNetworkBase', () => {
@@ -80,6 +83,96 @@ describe('tokenSelectorFilterUtils', () => {
           networkId: 'evm--56',
         },
       ]);
+    });
+  });
+
+  describe('filterTokenSelectorTokenDataByDappTokenFilterParams', () => {
+    const walletToken = {
+      $key: 'wallet-token',
+      address: '0xwallet',
+      decimals: 18,
+      isNative: false,
+      name: 'Wallet token',
+      symbol: 'WALLET',
+      dappType: 'walletToken',
+    };
+    const dappToken = {
+      $key: 'dapp-token',
+      address: '0xdapp',
+      decimals: 18,
+      isNative: false,
+      name: 'DeFi token',
+      symbol: 'DEFI',
+      dappName: 'DeFi protocol',
+    };
+    const tokenData: ITokenData = {
+      data: [walletToken, dappToken],
+      keys: 'server-token-list-key',
+      map: {
+        [walletToken.$key]: {
+          balance: '3',
+          balanceParsed: '3',
+          fiatValue: '3',
+          price: 1,
+        },
+        [dappToken.$key]: {
+          balance: '10',
+          balanceParsed: '10',
+          fiatValue: '10',
+          price: 1,
+        },
+      },
+      fiatValue: '13',
+      currency: 'usd',
+    };
+
+    it('removes dApp tokens from data, map, keys, and fiatValue together', () => {
+      expect(
+        filterTokenSelectorTokenDataByDappTokenFilterParams({
+          tokenData,
+          tokenSelectorFilterParams: {
+            withoutDappToken: true,
+            withoutWalletToken: false,
+          },
+        }),
+      ).toEqual({
+        data: [walletToken],
+        keys: walletToken.$key,
+        map: {
+          [walletToken.$key]: tokenData.map[walletToken.$key],
+        },
+        fiatValue: '3',
+        currency: 'usd',
+      });
+    });
+
+    it('removes wallet tokens when requesting the dApp-only list', () => {
+      expect(
+        filterTokenSelectorTokenDataByDappTokenFilterParams({
+          tokenData,
+          tokenSelectorFilterParams: {
+            withoutDappToken: false,
+            withoutWalletToken: true,
+          },
+        }),
+      ).toEqual({
+        data: [dappToken],
+        keys: dappToken.$key,
+        map: {
+          [dappToken.$key]: tokenData.map[dappToken.$key],
+        },
+        fiatValue: '10',
+        currency: 'usd',
+      });
+    });
+
+    it('keeps the original token data when no token is filtered out', () => {
+      expect(
+        filterTokenSelectorTokenDataByDappTokenFilterParams({
+          tokenData,
+          tokenSelectorFilterParams: {},
+        }),
+      ).toBe(tokenData);
     });
   });
 

--- a/packages/shared/src/utils/tokenSelectorFilterUtils.ts
+++ b/packages/shared/src/utils/tokenSelectorFilterUtils.ts
@@ -1,7 +1,9 @@
 import { ETokenDappType } from '../../types/token';
 
+import { sumFiatValuesIgnoringUnavailable } from './tokenValueUtils';
+
 import type { IServerNetwork } from '../../types';
-import type { ITokenDappType } from '../../types/token';
+import type { ITokenDappType, ITokenData } from '../../types/token';
 
 export const TOKEN_SELECTOR_LP_TOKEN_FILTER_ENABLED = true;
 
@@ -152,6 +154,36 @@ export function filterTokenSelectorTokensByDappTokenFilterParams<
     return tokens.filter((token) => isTokenSelectorDappToken(token));
   }
   return tokens;
+}
+
+export function filterTokenSelectorTokenDataByDappTokenFilterParams({
+  tokenData,
+  tokenSelectorFilterParams,
+}: {
+  tokenData: ITokenData;
+  tokenSelectorFilterParams: ITokenSelectorDappTokenFilterParams;
+}): ITokenData {
+  const data = filterTokenSelectorTokensByDappTokenFilterParams({
+    tokens: tokenData.data,
+    tokenSelectorFilterParams,
+  });
+
+  if (data.length === tokenData.data.length) {
+    return tokenData;
+  }
+
+  const tokenKeys = new Set(data.map((token) => token.$key));
+  const map = Object.fromEntries(
+    Object.entries(tokenData.map).filter(([key]) => tokenKeys.has(key)),
+  );
+
+  return {
+    ...tokenData,
+    data,
+    keys: data.map((token) => token.$key).join(','),
+    map,
+    fiatValue: sumFiatValuesIgnoringUnavailable(map),
+  };
 }
 
 export function buildSwapAllNetworkTokenListCacheKey({


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58984](https://onekeyhq.atlassian.net/browse/OK-58984) [OK-58138](https://onekeyhq.atlassian.net/browse/OK-58138) [OK-58104](https://onekeyhq.atlassian.net/browse/OK-58104) [OK-58103](https://onekeyhq.atlassian.net/browse/OK-58103)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- [OK-58984](https://onekeyhq.atlassian.net/browse/OK-58984): create missing Swap recipient addresses from the target network context instead of reusing the source-token network.
- [OK-58138](https://onekeyhq.atlassian.net/browse/OK-58138): remove dApp-scoped tokens from wallet token groups before cache and account-worth consumers aggregate them.
- [OK-58104](https://onekeyhq.atlassian.net/browse/OK-58104): preserve an unknown Aave repay allowance and refresh it through the shared allowance tracker before choosing Repay or Approve.
- [OK-58103](https://onekeyhq.atlassian.net/browse/OK-58103): stabilize the Aave withdraw and repay dialogs while their health-factor estimate refreshes.

## Root cause

- Swap address creation derived the network from the source side even when the missing address belonged to the target side.
- Explicit custom contracts could remain in wallet token responses after requesting withoutDappToken, leaving their map, keys, and fiat totals visible to downstream consumers.
- The manage-page adapter converted a missing allowance into 0; the UI therefore rendered Approve while the submit preflight fetched the real on-chain allowance and submitted Repay directly.
- The health-factor loading skeleton reserved a different height from the rendered value, and the Desktop body max height was too small for the full repay content.

## Changes

- Resolve Swap address creation with the address info or token network for the relevant direction.
- Filter every wallet token group consistently and rebuild its data, keys, map, and fiat total.
- Keep missing allowance as unknown, let useTrackTokenAllowance own the initial refresh, and use its existing loading and tracked allowance state.
- Match the shared withdraw/repay health-factor skeleton to the 24 px loaded value and raise the wide Desktop Borrow-dialog body max height from 420 px to 480 px.

## Validation

- yarn agent:check --profile commit
- Targeted Swap address-creation, wallet token-filtering, and Borrow allowance unit tests.
- Borrow/ManagePosition regression run: 8 suites, 43 tests passed.
- Desktop Aave V3 USDC:
  - 25% repay displayed Repay and opened the Aave repay confirmation directly.
  - Max repay displayed Approve and opened the USDC approval confirmation.
  - Both confirmation flows were cancelled without signing or broadcasting.
- Desktop Aave V3 dialog stability:
  - Withdraw: health-factor skeleton and loaded value both measured 24 px; the content region remained 386 px with no vertical overflow.
  - Repay: health-factor skeleton and loaded value both measured 24 px; the content region remained 456 px with no vertical overflow.


## Review follow-up

- Preserve the target-network deriveType for missing Swap recipient accounts and pair it with the target networkId in CREATE_ADDRESS.
- Apply withoutWalletToken alongside withoutDappToken during ServiceToken response normalization.
- Ignore stale allowance completions so an older target cannot clear the current target loading state.
- Clamp the Desktop lending-dialog body to the live viewport while retaining the 480 px normal-window limit.

Follow-up validation: Swap actions 67/67, allowance hook 4/4, ServiceToken 1/1, TypeScript, commit-profile checks, and Desktop repay at 1372x812 plus the 1024x450 minimum viewport. At minimum height the dialog is 418 px, the body scrolls, and the enabled confirm footer remains visible and hit-testable.

[OK-58984]: https://onekeyhq.atlassian.net/browse/OK-58984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-58138]: https://onekeyhq.atlassian.net/browse/OK-58138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-58104]: https://onekeyhq.atlassian.net/browse/OK-58104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-58103]: https://onekeyhq.atlassian.net/browse/OK-58103