### PR TITLE
fix: evm nonce chaining drops prevNonce 0 causing duplicate nonce in approve+transfer flows(OK-59064)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -71,7 +71,7 @@ module.exports = async () => {
     },
     // TODO unify with transpile modules
     transformIgnorePatterns: [
-      'node_modules/(?!(react-native-reanimated|react-native-aes-crypto|@keystonehq/bc-ur-registry-eth|@mysten/(sui|bcs|utils)|@noble/hashes|@scure/(base|bip32|bip39))/)',
+      'node_modules/(?!(react-native-reanimated|react-native-aes-crypto|@keystonehq/bc-ur-registry-eth|@mysten/(sui|bcs|utils)|@noble/hashes|@scure/(base|bip32|bip39)|timeout-signal)/)',
     ],
     transform: {
       'node_modules/(@mysten/(sui|bcs|utils)|@noble/hashes|@scure/(base|bip32|bip39))/.+\\.m?js$':

--- a/packages/kit-bg/src/vaults/impls/evm/Vault.test.ts
+++ b/packages/kit-bg/src/vaults/impls/evm/Vault.test.ts
@@ -1,0 +1,58 @@
+import type { IEncodedTxEvm } from '@onekeyhq/core/src/chains/evm/types';
+
+// Importing the vault pulls in the localDb singleton, whose constructor opens
+// IndexedDB at module load and crashes under jest's node environment.
+jest.mock('../../../dbs/local/localDbInstance', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+// eslint-disable-next-line import/first
+import EvmVault from './Vault';
+
+// Instantiating the full vault requires a backgroundApi context; the
+// buildUnsignedTx nonce-chaining path only touches networkId, so a bare
+// prototype instance is enough.
+const buildVault = () => {
+  const vault = Object.create(EvmVault.prototype) as EvmVault;
+  vault.networkId = 'evm--8453';
+  return vault;
+};
+
+const baseEncodedTx: IEncodedTxEvm = {
+  from: '0x1111111111111111111111111111111111111111',
+  to: '0x2222222222222222222222222222222222222222',
+  value: '0x0',
+  data: '0x',
+};
+
+describe('EvmVault.buildUnsignedTx nonce chaining', () => {
+  it('assigns nonce prevNonce + 1 when prevNonce is 0', async () => {
+    const vault = buildVault();
+    const unsignedTx = await vault.buildUnsignedTx({
+      encodedTx: { ...baseEncodedTx },
+      prevNonce: 0,
+    });
+    expect(unsignedTx.nonce).toBe(1);
+    expect((unsignedTx.encodedTx as IEncodedTxEvm).nonce).toBe(1);
+  });
+
+  it('assigns nonce prevNonce + 1 when prevNonce is positive', async () => {
+    const vault = buildVault();
+    const unsignedTx = await vault.buildUnsignedTx({
+      encodedTx: { ...baseEncodedTx },
+      prevNonce: 5,
+    });
+    expect(unsignedTx.nonce).toBe(6);
+    expect((unsignedTx.encodedTx as IEncodedTxEvm).nonce).toBe(6);
+  });
+
+  it('leaves nonce unset when prevNonce is not provided', async () => {
+    const vault = buildVault();
+    const unsignedTx = await vault.buildUnsignedTx({
+      encodedTx: { ...baseEncodedTx },
+    });
+    expect(unsignedTx.nonce).toBeUndefined();
+    expect((unsignedTx.encodedTx as IEncodedTxEvm).nonce).toBeUndefined();
+  });
+});

--- a/packages/kit-bg/src/vaults/impls/evm/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/evm/Vault.ts
@@ -424,7 +424,9 @@ export default class Vault extends VaultBase {
         encodedTx as IEncodedTxEvm,
       );
 
-      if (params.prevNonce && isNumber(params.prevNonce)) {
+      // prevNonce may legitimately be 0 (first tx of a fresh account), so a
+      // truthiness check would drop it and let the next tx reuse the same nonce.
+      if (isNumber(params.prevNonce) && !Number.isNaN(params.prevNonce)) {
         return this.updateUnsignedTx({
           unsignedTx,
           nonceInfo: {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59064](https://onekeyhq.atlassian.net/browse/OK-59064)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Fix EVM `buildUnsignedTx` nonce chaining: `prevNonce === 0` was dropped by a truthiness check, so the tx following an approve reused the same nonce on fresh accounts
- Add regression tests covering `prevNonce: 0`, positive `prevNonce`, and absent `prevNonce`
- Allow jest to transform the ESM-only `timeout-signal` package so tests can import the EVM vault

## Intent & Context
A user ran Bulk Send for cbBTC on Base from a brand-new address (on-chain nonce 0). The approve tx to the OneKey Bulk Send contract succeeded, but the follow-up transfer was rejected by the broadcast backend with "Nonce (0) already used, next valid nonce is 1". Retrying later succeeded because the allowance was already on-chain (no approve tx needed) and a fresh build fetched the correct on-chain nonce 1.

## Root Cause
`packages/kit-bg/src/vaults/impls/evm/Vault.ts` `buildUnsignedTx` used `if (params.prevNonce && isNumber(params.prevNonce))`. When `prevNonce === 0` (the approve tx of a fresh account), `0` is falsy, so the `nonce = prevNonce + 1` chaining was skipped. The transfer tx then fell into `ServiceSend.prepareSendConfirmUnsignedTx`'s fallback `getNextNonce`, which still returned 0 (the approve had not been broadcast yet, and there was no local pending tx), so both txs were built with nonce 0. BulkSend broadcasts approve and transfer via two separate `batchSignAndSendTransaction` calls and EVM has no `refreshUnsignedTxBeforeBatchSign` override, so the stale nonce was never re-validated before signing.

Diagnosed by tracing the BulkSend build path (`BulkSendAmountsInput` -> `prepareSendConfirmUnsignedTx` -> EVM `buildUnsignedTx`). The exported app log is a 1000-line ring buffer and had already rotated out the incident window, so the analysis is code-based, but it matches all observed symptoms exactly (error text, next valid nonce 1, retry success).

## Design Decisions
- Fix at the single vault-level check instead of touching every caller: `prevNonce = unsignedTx.nonce` chaining is used by BulkSend, useSignatureConfirm, useSwapBuiltTx, usePerpDeposit, useSpeedSwapActions and the DeFi action dialog, and all of them funnel into this one condition. EVM is the only impl that consumes `prevNonce`.
- Kept the `!Number.isNaN` guard because the old truthiness check incidentally excluded NaN; the new check preserves that safety while accepting 0.
- Deliberately did NOT change `ServiceSend.prepareSendConfirmUnsignedTx`'s `new BigNumber(nonce ?? 0).isZero()` fallback condition (it conflates "unset" with a legit nonce 0). It is not part of this failure chain and changing it affects DApp tx paths; left for a separate evaluation.
- Test instantiates the vault via `Object.create(Vault.prototype)` with only `networkId` set: the nonce path is pure (`getNetworkChainId` derives from `networkId`), so no backgroundApi mocking is needed. `localDbInstance` is mocked because importing the vault pulls in the localDb singleton whose constructor opens IndexedDB at module load and crashes under jest's node environment.

## Changes Detail
- `packages/kit-bg/src/vaults/impls/evm/Vault.ts`: replace the truthiness check with `isNumber(params.prevNonce) && !Number.isNaN(params.prevNonce)` so nonce 0 chains to 1.
- `packages/kit-bg/src/vaults/impls/evm/Vault.test.ts` (new): regression tests for the nonce chaining (0 -> 1 failed before the fix, passed after; 5 -> 6 and absent-prevNonce guard existing behavior).
- `jest.config.js`: add `timeout-signal` to `transformIgnorePatterns` allowlist; it is ESM-only and previously broke any test importing the EVM vault (via `ClientEvm` -> `JsonRPCRequest`).

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web (all EVM approve+action flows)
- **Risk Areas**: Nonce assignment for the tx following an approve. The only behavior change is when `prevNonce` is exactly 0: previously the follow-up tx silently re-fetched (and collided); now it correctly chains to 1. Non-zero and absent `prevNonce` behavior is unchanged and covered by tests.

## Test plan
- [x] `yarn jest packages/kit-bg/src/vaults/impls/evm` — 5 suites, 25 tests pass (new `prevNonce: 0` case failed before the fix, passes after)
- [x] `yarn agent:check --profile commit` — all checks pass
- [ ] Manual: from a fresh EVM address (nonce 0), bulk-send an ERC-20 requiring approval; verify approve gets nonce 0, transfer gets nonce 1 and broadcasts successfully

[OK-59064]: https://onekeyhq.atlassian.net/browse/OK-59064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ