### PR TITLE
fix: force stock table mode OK-59068

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketNormalTokenList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketNormalTokenList.tsx
@@ -19,6 +19,7 @@ import type { IMarketTimeRangeValue } from '../../types';
 type IMarketNormalTokenListProps = {
   networkId?: string;
   selectedCategory?: string;
+  forceStockMetadataColumns?: boolean;
   stockCategory?: string;
   timeRange?: IMarketTimeRangeValue;
   sortBy?: string;
@@ -41,6 +42,7 @@ type IMarketNormalTokenListProps = {
 function MarketNormalTokenList({
   networkId = 'sol--101',
   selectedCategory,
+  forceStockMetadataColumns,
   stockCategory,
   timeRange,
   sortBy: initialSortBy,
@@ -118,6 +120,7 @@ function MarketNormalTokenList({
       tabName={tabName}
       listContainerProps={listContainerProps}
       showStockSubtitle="auto"
+      forceStockMetadataColumns={forceStockMetadataColumns}
       hiddenDesktopColumns={hiddenDesktopColumns}
       liveTokenOverride={liveTokenOverride}
       enableWebSocket={enableWebSocket}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
@@ -250,6 +250,7 @@ type IMarketTokenListBaseProps = {
   ) => void;
   onScrollBegin?: () => void;
   showStockSubtitle?: boolean | 'auto';
+  forceStockMetadataColumns?: boolean;
   hiddenDesktopColumns?: readonly string[];
   change24hColumnTitle?: string;
   liveTokenOverride?: IMarketTokenListLiveOverride;
@@ -279,6 +280,7 @@ function MarketTokenListBase({
   onItemContextMenu,
   onScrollBegin,
   showStockSubtitle = true,
+  forceStockMetadataColumns = false,
   hiddenDesktopColumns,
   change24hColumnTitle,
   liveTokenOverride,
@@ -449,10 +451,13 @@ function MarketTokenListBase({
   }, [rawData, showStockSubtitle]);
   const useStockMetadataColumns = useMemo(
     () =>
-      (showStockSubtitle === 'auto' ||
-        (isWatchlistMode && showStockSubtitle !== false)) &&
-      shouldUseStockMetadataColumnsForTokens(rawData),
-    [isWatchlistMode, rawData, showStockSubtitle],
+      shouldUseStockMetadataColumnsForTokens(rawData, {
+        forceStockMetadataColumns,
+        enableAutoDetection:
+          showStockSubtitle === 'auto' ||
+          (isWatchlistMode && showStockSubtitle !== false),
+      }),
+    [forceStockMetadataColumns, isWatchlistMode, rawData, showStockSubtitle],
   );
   // Web tab integration gives the inner FlatList the full tab height so the
   // outer Tabs.Container can own vertical scroll. During cold start, keep only

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts
@@ -372,4 +372,25 @@ describe('shouldUseStockMetadataColumnsForTokens', () => {
       ]),
     ).toBe(false);
   });
+
+  test('returns true for mixed data when stock columns are forced', () => {
+    expect(
+      shouldUseStockMetadataColumnsForTokens(
+        [
+          { stock: { subtitle: 'Apple', sourceLogoUri: '' } },
+          { stock: undefined },
+        ],
+        { forceStockMetadataColumns: true },
+      ),
+    ).toBe(true);
+  });
+
+  test('returns false when automatic detection is disabled', () => {
+    expect(
+      shouldUseStockMetadataColumnsForTokens(
+        [{ stock: { subtitle: 'Apple', sourceLogoUri: '' } }],
+        { enableAutoDetection: false },
+      ),
+    ).toBe(false);
+  });
 });

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.ts
@@ -76,8 +76,19 @@ export function shouldShowStockSubtitleForTokens(
 
 export function shouldUseStockMetadataColumnsForTokens(
   items: Array<Pick<IMarketToken, 'stock'>>,
+  options?: {
+    forceStockMetadataColumns?: boolean;
+    enableAutoDetection?: boolean;
+  },
 ) {
-  return items.length > 0 && items.every((item) => !!item.stock);
+  const { forceStockMetadataColumns = false, enableAutoDetection = true } =
+    options ?? {};
+  return (
+    forceStockMetadataColumns ||
+    (enableAutoDetection &&
+      items.length > 0 &&
+      items.every((item) => !!item.stock))
+  );
 }
 
 const ONE_HOUR = 60 * 60 * 1000;

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/DesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/DesktopLayout.tsx
@@ -318,6 +318,10 @@ export function DesktopLayout({
             <MarketNormalTokenList
               networkId={selectedNetworkId}
               selectedCategory={item.categoryId}
+              forceStockMetadataColumns={isMarketStockCategoryById(
+                filterBarProps.categories,
+                item.categoryId,
+              )}
               stockCategory={
                 isMarketStockCategoryById(
                   filterBarProps.categories,


### PR DESCRIPTION
## Summary

- Force Market Stocks categories to use stock metadata columns.
- Keep automatic stock-column detection for watchlists and non-stock lists.
- Render missing stock metadata as `--` without downgrading the whole table.

## Root cause

The Stocks → All response can contain rows without a `stock` object. The table previously required every row to include `stock`, so one missing row switched the entire table from Market cap / 24h Volume / P/E TTM to generic market columns.

## Validation

- `yarn jest packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/utils/tokenListHelpers.test.ts --runInBand` (22 tests passed)
- `yarn agent:check --profile commit`
- Verified `/market` Stocks → All with the production 108-row payload: P/E TTM remained visible and BIDUon/EQIXON rendered `--`.
