### PR TITLE
fix: restore Stock action spacing (OK-59072)

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -86,7 +86,6 @@ interface ISwapActionsStateProps {
   onPreSwap: () => void;
   onOpenRecipientAddress: () => void;
   onSelectPercentageStage?: (stage: number) => void;
-  reserveCostSavingsSlot?: boolean;
 }
 
 // cspell:ignore ellipsize
@@ -96,7 +95,6 @@ const SwapActionsState = ({
   onPreSwap,
   onOpenRecipientAddress,
   onSelectPercentageStage,
-  reserveCostSavingsSlot,
 }: ISwapActionsStateProps) => {
   const intl = useIntl();
   const navigation = useAppNavigation();
@@ -905,14 +903,7 @@ const SwapActionsState = ({
             {actionButtonChildren}
           </Button>
           {/* In regular pages and non-desktop modal: show savings below button */}
-          {!isDesktopModalPage &&
-            (reserveCostSavingsSlot ? (
-              <Stack minHeight="$5" alignItems="center" justifyContent="center">
-                {costSavingsComponent}
-              </Stack>
-            ) : (
-              costSavingsComponent
-            ))}
+          {!isDesktopModalPage ? costSavingsComponent : null}
         </Stack>
       </Stack>
     ),
@@ -924,7 +915,6 @@ const SwapActionsState = ({
       recipientComponent,
       shouldShowRecipientInActionRow,
       costSavingsComponent,
-      reserveCostSavingsSlot,
     ],
   );
 

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -817,7 +817,6 @@ function StockActionGate({
   onPreSwap,
   onToAnotherAddressModal,
   onSelectPercentageStage,
-  reserveCostSavingsSlot,
 }: {
   alerts: ISwapStockDesktopContainerProps['alerts'];
   balanceActionsReady: boolean;
@@ -825,7 +824,6 @@ function StockActionGate({
   onPreSwap: () => void;
   onToAnotherAddressModal: () => void;
   onSelectPercentageStage: (stage: number) => void;
-  reserveCostSavingsSlot?: boolean;
 }) {
   const intl = useIntl();
   const navigation = useAppNavigation();
@@ -955,7 +953,6 @@ function StockActionGate({
         onSelectPercentageStage={
           balanceActionsReady ? onSelectPercentageStage : undefined
         }
-        reserveCostSavingsSlot={reserveCostSavingsSlot}
       />
     );
   }
@@ -1364,7 +1361,6 @@ function StockTradeTicket({
         onPreSwap={onPreSwap}
         onToAnotherAddressModal={onToAnotherAddressModal}
         onSelectPercentageStage={amountInputState.onSelectPercentageStage}
-        reserveCostSavingsSlot={!compact}
       />
       <SwapStockTradeAlert
         alerts={alerts}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59072](https://onekeyhq.atlassian.net/browse/OK-59072)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Remove the permanent fee-savings placeholder below the Stock action button.
- Restore the compact spacing between the Stock action area and Recent Trades, matching the normal Swap flow.

## Issues
- Fixes OK-59072
- Rollback requested by OK-58846

## Intent & Context
OK-58846 introduced a reserved slot to prevent the fee-savings label from shifting the page after a fee-free quote. The latest Jira decision requests reverting that change because the permanent slot causes other layout regressions, including the excessive Stock action-to-history spacing reported in OK-59072.

## Root Cause
The Stock non-compact layout passed `reserveCostSavingsSlot`, which always rendered a `$5` minimum-height container below the action button even when no savings label was present. That empty container pushed Recent Trades farther down the card.

## Design Decisions
- Reverse only the granular OK-58846 patch from `1cccf34663`.
- Do not revert squash commit `a623020f82`, because it also contains the unrelated OK-58261 and OK-58227 fixes.
- Keep a replacement for the original fee-free quote layout shift out of this rollback; a future solution should stabilize the label lifecycle without permanent empty space.

## Changes Detail
- `SwapActionsState.tsx`: remove the `reserveCostSavingsSlot` prop and permanent minimum-height wrapper.
- `SwapStockDesktopContainer.tsx`: remove the Stock-specific reserved-slot wiring.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop and Web non-compact Stock trade layouts
- **Risk Areas**: The original OK-58846 fee-savings label may shift the page again when it appears after quoting. This is the explicitly requested rollback trade-off.

## Test plan
- [x] Run `yarn agent:check --profile commit`
- [x] Verify the two resulting file blobs exactly match the parent of `1cccf34663`
- [ ] Verify Stock action-to-Recent Trades spacing in Desktop runtime
- [ ] Verify the fee-free quote transition and document the intentionally restored layout-shift behavior

[OK-59072]: https://onekeyhq.atlassian.net/browse/OK-59072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ