### PR TITLE
fix: improve market indicator quick bar gestures(OK-58973)

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
@@ -14,6 +14,7 @@ import {
   useDialogInstance,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { HEADER_ICON_BUTTON_STYLE_PROPS } from '../utils/NativeChartControlsShared';
 
@@ -29,6 +30,7 @@ import type {
   ITradingViewIndicatorOption,
   ITradingViewNativeChartControlsConfigData,
 } from '../../types';
+import type { GestureResponderEvent } from 'react-native';
 
 const INDICATOR_GRID_COLUMN_COUNT = 4;
 const INDICATOR_GRID_ITEM_LAYOUT_PROPS = {
@@ -40,6 +42,14 @@ const INDICATOR_GRID_ITEM_LAYOUT_PROPS = {
   borderWidth: 1,
 } as const;
 export const TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT = 31;
+const INDICATOR_QUICK_BAR_VERTICAL_PAN_THRESHOLD = 4;
+
+type IIndicatorQuickBarTouchState = {
+  direction: 'pending' | 'horizontal' | 'vertical';
+  previousY: number;
+  startX: number;
+  startY: number;
+};
 
 function buildIndicatorItemTestID(value: string): string {
   return `trading-view-native-indicator-item-${value
@@ -254,13 +264,55 @@ export const TradingViewNativeIndicatorQuickBar = memo(
     maxSubIndicatorCount,
     onIndicatorSelect,
     onControlInteraction,
+    onTouchScroll,
   }: {
     nativeChartControlsConfig: ITradingViewNativeChartControlsConfigData | null;
     nativeIndicatorState: ITradingViewNativeIndicatorState;
     maxSubIndicatorCount?: number;
     onIndicatorSelect: (indicatorName: string, desiredActive: boolean) => void;
     onControlInteraction?: () => void;
+    onTouchScroll?: (deltaY: number) => void;
   }) => {
+    const touchStateRef = useRef<IIndicatorQuickBarTouchState | null>(null);
+    const handleTouchStart = useCallback((event: GestureResponderEvent) => {
+      const { pageX, pageY } = event.nativeEvent;
+      touchStateRef.current = {
+        direction: 'pending',
+        previousY: pageY,
+        startX: pageX,
+        startY: pageY,
+      };
+    }, []);
+    const handleTouchMove = useCallback(
+      (event: GestureResponderEvent) => {
+        const touchState = touchStateRef.current;
+        if (!touchState || !onTouchScroll) {
+          return;
+        }
+
+        const { pageX, pageY } = event.nativeEvent;
+        if (touchState.direction === 'pending') {
+          const absDx = Math.abs(pageX - touchState.startX);
+          const absDy = Math.abs(pageY - touchState.startY);
+          if (
+            Math.max(absDx, absDy) <= INDICATOR_QUICK_BAR_VERTICAL_PAN_THRESHOLD
+          ) {
+            return;
+          }
+          touchState.direction = absDy > absDx ? 'vertical' : 'horizontal';
+        }
+
+        if (touchState.direction === 'vertical') {
+          onTouchScroll(touchState.previousY - pageY);
+          touchState.previousY = pageY;
+        }
+      },
+      [onTouchScroll],
+    );
+    const handleTouchEnd = useCallback(() => {
+      touchStateRef.current = null;
+    }, []);
+
     const {
       activeIndicatorValues,
       mainIndicators,
@@ -322,8 +374,16 @@ export const TradingViewNativeIndicatorQuickBar = memo(
         h={TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT}
         bg="$bgApp"
         zIndex={3}
+        onTouchStart={onTouchScroll ? handleTouchStart : undefined}
+        onTouchMove={onTouchScroll ? handleTouchMove : undefined}
+        onTouchEnd={onTouchScroll ? handleTouchEnd : undefined}
+        onTouchCancel={onTouchScroll ? handleTouchEnd : undefined}
       >
-        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          directionalLockEnabled={platformEnv.isNativeIOS}
+        >
           {quickBarContent}
         </ScrollView>
       </Stack>

--- a/packages/kit/src/hooks/useMobileTabTouchScrollBridge.ts
+++ b/packages/kit/src/hooks/useMobileTabTouchScrollBridge.ts
@@ -16,22 +16,6 @@ export function useMobileTabTouchScrollBridge() {
   const scrollYCurrent = tabsContext?.scrollYCurrent;
   const tabContentInset = tabsContext?.contentInset ?? 0;
   const scrollDelta = useSharedValue(0);
-  const targetScrollY = useSharedValue(0);
-
-  useAnimatedReaction(
-    () => targetScrollY.value,
-    (currentValue) => {
-      if (!refMap || !focusedTabShared) {
-        return;
-      }
-
-      const ref = refMap[focusedTabShared.value];
-      if (ref) {
-        scrollTo(ref, 0, Math.max(0, currentValue - tabContentInset), false);
-      }
-    },
-    [refMap, focusedTabShared, tabContentInset],
-  );
 
   useAnimatedReaction(
     () => scrollDelta.value,
@@ -40,16 +24,19 @@ export function useMobileTabTouchScrollBridge() {
         delta === 0 ||
         delta === prevDelta ||
         !scrollYCurrent ||
-        !targetScrollY
+        !refMap ||
+        !focusedTabShared
       ) {
         return;
       }
 
-      const currentScrollY = Math.max(scrollYCurrent.value, tabContentInset);
-      targetScrollY.value = currentScrollY + delta;
+      const ref = refMap[focusedTabShared.value];
+      if (ref) {
+        scrollTo(ref, 0, scrollYCurrent.value + delta - tabContentInset, false);
+      }
       scrollDelta.value = 0;
     },
-    [scrollYCurrent, targetScrollY, tabContentInset],
+    [focusedTabShared, refMap, scrollYCurrent, scrollDelta, tabContentInset],
   );
 
   return useCallback(

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -168,7 +168,13 @@ function normalizeTradingViewSubIndicatorCount(count: number) {
   return Math.max(0, Math.floor(count));
 }
 
-function MobileIndicatorQuickBar({ children }: { children: ReactNode }) {
+function MobileIndicatorQuickBar({
+  children,
+  disabled,
+}: {
+  children: ReactNode;
+  disabled: boolean;
+}) {
   const handleTouchScroll = useMobileTabTouchScrollBridge();
   const handleIndicatorQuickBarTouchScroll = useCallback(
     (deltaY: number) => {
@@ -181,7 +187,7 @@ function MobileIndicatorQuickBar({ children }: { children: ReactNode }) {
 
   if (isValidElement<{ onTouchScroll?: (deltaY: number) => void }>(children)) {
     return cloneElement(children, {
-      onTouchScroll: handleIndicatorQuickBarTouchScroll,
+      onTouchScroll: disabled ? undefined : handleIndicatorQuickBarTouchScroll,
     });
   }
 
@@ -580,7 +586,7 @@ export function MobileLayout({ disableTrade }: IMobileLayoutProps) {
             </Stack>
           </HeaderScrollGestureWrapper>
           {nativeIndicatorQuickBar && platformEnv.isNative ? (
-            <MobileIndicatorQuickBar>
+            <MobileIndicatorQuickBar disabled={isTradingViewScrollLocked}>
               {nativeIndicatorQuickBar}
             </MobileIndicatorQuickBar>
           ) : (

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { ComponentProps, ReactNode } from 'react';
 
 import { noop } from 'lodash';
@@ -25,6 +33,7 @@ import {
   TRADING_VIEW_NATIVE_CHART_CONTROLS_HEIGHT,
   TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT,
 } from '@onekeyhq/kit/src/components/TradingView/TradingViewV2/components/TradingViewNativeChartControls';
+import { useMobileTabTouchScrollBridge } from '@onekeyhq/kit/src/hooks/useMobileTabTouchScrollBridge';
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   EAppEventBusNames,
@@ -150,12 +159,33 @@ const MARKET_DETAIL_TRADING_VIEW_DEFAULT_SUB_INDICATOR_COUNT = 1;
 const MARKET_DETAIL_MOBILE_TRADING_VIEW_MAX_SUB_INDICATOR_COUNT = 4;
 const MARKET_DETAIL_MOBILE_TRADING_VIEW_SUB_INDICATOR_HEIGHT = 56;
 const MARKET_DETAIL_MOBILE_TRADING_VIEW_BASE_HEIGHT_RATIO = 0.58;
+const MARKET_DETAIL_INDICATOR_QUICK_BAR_VERTICAL_SCROLL_SCALE = 1.2;
 
 function normalizeTradingViewSubIndicatorCount(count: number) {
   if (!Number.isFinite(count)) {
     return 0;
   }
   return Math.max(0, Math.floor(count));
+}
+
+function MobileIndicatorQuickBar({ children }: { children: ReactNode }) {
+  const handleTouchScroll = useMobileTabTouchScrollBridge();
+  const handleIndicatorQuickBarTouchScroll = useCallback(
+    (deltaY: number) => {
+      handleTouchScroll(
+        deltaY * MARKET_DETAIL_INDICATOR_QUICK_BAR_VERTICAL_SCROLL_SCALE,
+      );
+    },
+    [handleTouchScroll],
+  );
+
+  if (isValidElement<{ onTouchScroll?: (deltaY: number) => void }>(children)) {
+    return cloneElement(children, {
+      onTouchScroll: handleIndicatorQuickBarTouchScroll,
+    });
+  }
+
+  return children;
 }
 
 function MobileMarketTradingView({
@@ -549,7 +579,13 @@ export function MobileLayout({ disableTrade }: IMobileLayoutProps) {
               })()}
             </Stack>
           </HeaderScrollGestureWrapper>
-          {nativeIndicatorQuickBar}
+          {nativeIndicatorQuickBar && platformEnv.isNative ? (
+            <MobileIndicatorQuickBar>
+              {nativeIndicatorQuickBar}
+            </MobileIndicatorQuickBar>
+          ) : (
+            nativeIndicatorQuickBar
+          )}
           {platformEnv.isNativeIOS ? (
             <View
               style={{


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58973](https://onekeyhq.atlassian.net/browse/OK-58973)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Add direction locking to the TradingView V2 native indicator quick bar so vertical swipes scroll the Market Detail page while horizontal swipes remain native.
- Correct the mobile tab scroll bridge offset calculation for iOS content insets.
- Preserve quick-bar indicator taps and horizontal scrolling on both mobile platforms.

## Intent & Context
The horizontally scrollable indicator quick bar below the mobile Market Detail chart intercepted touch gestures. Users trying to scroll the page vertically from this area could not move the page freely. The fix must cover Android and iOS without breaking horizontal indicator browsing or indicator toggles.

## Root Cause
The nested horizontal ScrollView became the touch target before the surrounding collapsible page could recognize vertical intent. In addition, the existing touch-scroll bridge treated the adjusted tab scroll position as a raw native offset. On iOS, that ignored the negative content inset at the top and could collapse or jump the header instead of scrolling naturally.

## Design Decisions
- Detect the gesture direction after a 4 px threshold and lock it for the rest of the touch sequence.
- Forward only incremental vertical deltas to the collapsible tab scroll bridge; leave horizontal gestures with the native ScrollView.
- Apply iOS directional locking to reduce diagonal gesture ambiguity.
- Inject the bridge callback where the quick bar is rendered inside the collapsible tab context, keeping the behavior scoped to native Market Detail.
- Convert the adjusted scroll position back to the platform raw offset with scrollYCurrent + delta - contentInset and remove the mount-time target reaction that could change the initial scroll position.

## Changes Detail
- NativeIndicatorControls.tsx: add touch direction tracking and native horizontal direction locking to the indicator quick bar.
- MobileLayout.tsx: connect the native quick bar vertical deltas to the Market Detail collapsible tab scroll bridge.
- useMobileTabTouchScrollBridge.ts: correct iOS content inset handling and perform incremental scrolling without an initial target update.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile iOS and Android
- **Risk Areas**: Gesture arbitration between the horizontal indicator list and the vertical collapsible page, plus iOS content inset offset conversion.

## Test plan
- [x] Run yarn agent:check --profile commit.
- [x] Verify iOS vertical swipes from the quick bar scroll up and down, and indicator taps still toggle.
- [x] Verify Android vertical swipes from the quick bar scroll up and down.
- [x] Verify Android horizontal scrolling still moves the quick-bar indicator list and does not move the page vertically.
- [x] Verify Android indicator taps still toggle.

[OK-58973]: https://onekeyhq.atlassian.net/browse/OK-58973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ