### PR TITLE
fix: hide the empty liquidity column in spot banner detail lists

### DIFF
--- a/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
+++ b/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
@@ -55,6 +55,17 @@ type IMarketBannerDetailRouteParams = RouteProp<
   ETabMarketRoutes.MarketBannerDetail | EModalMarketRoutes.MarketBannerDetail
 >;
 
+// Spot banner lists are dominated by tokenized stocks, whose liquidity is not
+// reported by the market API, so the column is dropped instead of rendering a
+// near-empty one. Perps banners use their own columns and never had it.
+//
+// The `liquidity` dataIndex is shared: in stock metadata mode the same column
+// renders 24h volume instead. This list keeps the default `showStockSubtitle`
+// (not 'auto'), so that mode is currently unreachable here. Revisit this
+// constant before enabling stock metadata columns, or 24h volume disappears
+// with no type or test failure.
+const BANNER_DETAIL_HIDDEN_DESKTOP_COLUMNS = ['liquidity'] as const;
+
 function MarketBannerDetailContent({ title }: { title: string }) {
   const route = useRoute<IMarketBannerDetailRouteParams>();
   const { tokenListId, type } = route.params;
@@ -211,6 +222,7 @@ function MarketBannerDetailContent({ title }: { title: string }) {
         copyFrom={ECopyFrom.BannerList}
         showEndReachedIndicator
         change24hColumnTitle={change24hColumnTitle}
+        hiddenDesktopColumns={BANNER_DETAIL_HIDDEN_DESKTOP_COLUMNS}
       />
     );
     if (platformEnv.isNative) {


### PR DESCRIPTION
## Summary

Backport of #12713 to `release/v6.5.0` for the v6.5.0 hot update.

- Hide the `Liquidity` desktop column in spot banner detail lists by using the existing `hiddenDesktopColumns` mechanism.
- Keep the change scoped to wide web/desktop spot banner details; native, narrow layouts, perps banners, Market Home, and Watchlist are unaffected.

## Root cause

Spot banner lists are dominated by tokenized stocks whose liquidity is not reported by the market API. The API returns `"--"`, which is normalized to `0` and rendered back as `--`, leaving a mostly empty column.

## User impact

Spot banner detail tables no longer reserve width for an unhelpful, mostly empty liquidity column.

## Validation

- `yarn agent:check --profile pr`: local `lint-staged`, `tsc-staged`, and branch checks passed.
- Remote PR detection, repository/PR metadata lookup, CI query, inline comment scan, and review-thread scan passed.
- At validation time CI had 2 passed, 0 failed, and 12 pending checks; the release gate remains expectedly blocked while this PR is a draft and awaits review.
- `git diff --check origin/release/v6.5.0...HEAD`
- Confirmed the backport contains only commit `47b4f72dcd` and one modified file.