### PR TITLE
fix: improve Aave and Swap loading states (OK-57834, OK-57605)

### DIFF
--- a/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
@@ -1601,7 +1601,9 @@ function ProtocolLendingActionBorrowContent({
     actionResult.checkAmountResult === false ||
     actionResult.checkAmountLoading;
   const shouldShowHealthFactorSkeleton =
-    !healthFactor && isAmountPositive && !actionResult.transactionConfirmation;
+    !healthFactor &&
+    isAmountPositive &&
+    actionResult.transactionConfirmationLoading;
   // Belt-and-suspenders: a selectable Aave entry whose asset fetch AND protocol
   // info both come back empty falls back to the empty state instead of crashing.
   const isEmpty =

--- a/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
+++ b/packages/kit/src/components/DeFi/ProtocolLendingActionDialogContent.tsx
@@ -426,12 +426,10 @@ function LendingActionAlerts({
   showLiquidationWarning,
   errorMessage,
   checkAmountAlerts = [],
-  riskOfLiquidationAlert,
 }: {
   showLiquidationWarning: boolean;
   errorMessage?: string;
   checkAmountAlerts?: ICheckAmountAlert[];
-  riskOfLiquidationAlert?: boolean;
 }) {
   const intl = useIntl();
   const liquidationWarningText = intl.formatMessage({
@@ -440,9 +438,6 @@ function LendingActionAlerts({
   const visibleCheckAmountAlerts = checkAmountAlerts.filter((alert) => {
     if (!showLiquidationWarning) {
       return true;
-    }
-    if (riskOfLiquidationAlert && checkAmountAlerts.length === 1) {
-      return false;
     }
     return ![alert.title?.text, alert.text?.text, alert.description?.text].some(
       (text) => text?.trim() === liquidationWarningText.trim(),
@@ -1772,7 +1767,6 @@ function ProtocolLendingActionBorrowContent({
       showLiquidationWarning={Boolean(hasDebts && isWithdraw)}
       errorMessage={inlineErrorMessage}
       checkAmountAlerts={checkAmountAlerts}
-      riskOfLiquidationAlert={actionResult.riskOfLiquidationAlert}
     />
   ) : null;
   const contentNode = (

--- a/packages/kit/src/views/Borrow/components/UniversalBorrowAction/index.tsx
+++ b/packages/kit/src/views/Borrow/components/UniversalBorrowAction/index.tsx
@@ -30,6 +30,7 @@ export type IUniversalBorrowActionParams = {
 export type IUniversalBorrowActionState = {
   estimateFeeResp?: IEarnEstimateFeeResp;
   transactionConfirmation?: IBorrowTransactionConfirmation;
+  transactionConfirmationLoading: boolean;
   checkAmountMessage: string;
   checkAmountAlerts: ICheckAmountAlert[];
   checkAmountLoading: boolean;
@@ -110,6 +111,8 @@ export function useUniversalBorrowAction({
   const [transactionConfirmation, setTransactionConfirmation] = useState<
     IBorrowTransactionConfirmation | undefined
   >();
+  const [transactionConfirmationLoading, setTransactionConfirmationLoading] =
+    useState(false);
   const [checkAmountState, setCheckAmountState] =
     useState<IBorrowCheckAmountState>(() =>
       createEmptyBorrowCheckAmountState({ requestKey: '' }),
@@ -220,10 +223,12 @@ export function useUniversalBorrowAction({
         const resp = await fetchTransactionConfirmation(value);
         if (transactionConfirmationRequestNonceRef.current === requestNonce) {
           setTransactionConfirmation(resp);
+          setTransactionConfirmationLoading(false);
         }
       } catch {
         if (transactionConfirmationRequestNonceRef.current === requestNonce) {
           setTransactionConfirmation(undefined);
+          setTransactionConfirmationLoading(false);
         }
       }
     },
@@ -235,11 +240,13 @@ export function useUniversalBorrowAction({
     transactionConfirmationRequestNonceRef.current += 1;
     const requestNonce = transactionConfirmationRequestNonceRef.current;
     setTransactionConfirmation(undefined);
+    setTransactionConfirmationLoading(false);
 
     if (!isReady || isDisabled) {
       return;
     }
 
+    setTransactionConfirmationLoading(true);
     void debouncedFetchTransactionConfirmation(normalizedAmount, requestNonce);
     return () => {
       debouncedFetchTransactionConfirmation.cancel();
@@ -469,6 +476,7 @@ export function useUniversalBorrowAction({
   return {
     estimateFeeResp,
     transactionConfirmation,
+    transactionConfirmationLoading,
     checkAmountMessage: effectiveCheckAmountState.checkAmountMessage,
     checkAmountAlerts: effectiveCheckAmountState.checkAmountAlerts,
     checkAmountLoading: effectiveCheckAmountState.checkAmountLoading,

--- a/packages/kit/src/views/Swap/pages/components/SwapHeaderContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHeaderContainer.tsx
@@ -32,7 +32,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { ITabSwapParamList } from '@onekeyhq/shared/src/routes';
 import {
   ESwapDirectionType,
-  type ESwapSource,
+  ESwapSource,
   ESwapTabSwitchType,
 } from '@onekeyhq/shared/types/swap/types';
 
@@ -167,7 +167,11 @@ const SwapHeaderContainer = ({
     }
   }, [hasPendingSwapProEntry, navigation]);
   useEffect(() => {
-    if (hadPendingSwapProEntryOnMountRef.current || !defaultSwapType) {
+    if (
+      hadPendingSwapProEntryOnMountRef.current ||
+      !defaultSwapType ||
+      (pageType === 'modal' && enterFrom === ESwapSource.WALLET_HOME_TOKEN_LIST)
+    ) {
       return;
     }
     // Avoid switching the default toToken before it has been loaded,

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -1315,6 +1315,12 @@ function StockTradeTicket({
   compact?: boolean;
 }) {
   const amountInputState = useSwapStockAmountInputState({ stockChannel });
+  const isModalPage = useIsOverlayPage();
+  const { md } = useMedia();
+  // The desktop modal action renders through Page.Footer. Keep its portal
+  // placeholder outside this gapped stack so channel readiness cannot add an
+  // empty gap above Recent Trades.
+  const renderActionGateOutsideTicket = isModalPage && !md;
   const [quoteEventError] = useSwapQuoteEventErrorAtom();
   const hasPositiveInputAmount = new BigNumber(
     amountInputState.inputValue || 0,
@@ -1339,50 +1345,56 @@ function StockTradeTicket({
     quoteMarketClosed: isCurrentQuoteMarketClosed,
     scopeKey: quoteScopeKey,
   });
+  const stockActionGate = (
+    <StockActionGate
+      alerts={alerts}
+      balanceActionsReady={amountInputState.balanceActionsReady}
+      stockChannel={stockChannel}
+      onPreSwap={onPreSwap}
+      onToAnotherAddressModal={onToAnotherAddressModal}
+      onSelectPercentageStage={amountInputState.onSelectPercentageStage}
+    />
+  );
 
   return (
-    <YStack gap={compact ? '$3' : '$4'}>
-      <StockTradeSideSwitch value={tradeSide} onChange={onTradeSideChange} />
-      <StockAmountInput
-        fetchLoading={fetchLoading}
-        amountInputState={amountInputState}
-        storeName={storeName}
-      />
-      <StockEstimatedReceive
-        quoteResult={quoteResult}
-        quoteLoading={quoteLoading}
-        quoteEventFetching={quoteEventFetching}
-        stockChannel={stockChannel}
-      />
-      <StockActionGate
-        alerts={alerts}
-        balanceActionsReady={amountInputState.balanceActionsReady}
-        stockChannel={stockChannel}
-        onPreSwap={onPreSwap}
-        onToAnotherAddressModal={onToAnotherAddressModal}
-        onSelectPercentageStage={amountInputState.onSelectPercentageStage}
-      />
-      <SwapStockTradeAlert
-        alerts={alerts}
-        quoteEventFetching={quoteEventFetching}
-        quoteLoading={quoteLoading}
-        quoteResult={quoteResult}
-        stockChannel={stockChannel}
-      />
-      {stockChannel.readyForQuote ? (
-        <SwapQuoteResult
-          refreshAction={refreshAction}
-          onOpenProviderList={onOpenProviderList}
-          quoteResult={quoteResult}
+    <>
+      <YStack gap={compact ? '$3' : '$4'}>
+        <StockTradeSideSwitch value={tradeSide} onChange={onTradeSideChange} />
+        <StockAmountInput
+          fetchLoading={fetchLoading}
+          amountInputState={amountInputState}
+          storeName={storeName}
         />
-      ) : null}
-      <SwapRecentTokenPairsGroup
-        onSelectTokenPairs={onSelectRecentTokenPairs}
-        tokenPairs={recentTokenPairs}
-        fromTokenAmount={amountInputState.inputValue}
-        visibleSwapTypes={STOCK_RECENT_TOKEN_PAIR_SWAP_TYPES}
-      />
-    </YStack>
+        <StockEstimatedReceive
+          quoteResult={quoteResult}
+          quoteLoading={quoteLoading}
+          quoteEventFetching={quoteEventFetching}
+          stockChannel={stockChannel}
+        />
+        {renderActionGateOutsideTicket ? null : stockActionGate}
+        <SwapStockTradeAlert
+          alerts={alerts}
+          quoteEventFetching={quoteEventFetching}
+          quoteLoading={quoteLoading}
+          quoteResult={quoteResult}
+          stockChannel={stockChannel}
+        />
+        {stockChannel.readyForQuote ? (
+          <SwapQuoteResult
+            refreshAction={refreshAction}
+            onOpenProviderList={onOpenProviderList}
+            quoteResult={quoteResult}
+          />
+        ) : null}
+        <SwapRecentTokenPairsGroup
+          onSelectTokenPairs={onSelectRecentTokenPairs}
+          tokenPairs={recentTokenPairs}
+          fromTokenAmount={amountInputState.inputValue}
+          visibleSwapTypes={STOCK_RECENT_TOKEN_PAIR_SWAP_TYPES}
+        />
+      </YStack>
+      {renderActionGateOutsideTicket ? stockActionGate : null}
+    </>
   );
 }
 


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57834](https://onekeyhq.atlassian.net/browse/OK-57834) [OK-57605](https://onekeyhq.atlassian.net/browse/OK-57605)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Track transaction-confirmation loading explicitly in the universal borrow action state.
- Show the Aave health-factor skeleton only while a confirmation request is actually in flight.
- Hide the empty health-factor region for insufficient-balance, blocked, and failed confirmation states.
- Keep the Home Token List swap pair stable while the modal initializes.
- Skip the redundant initial swap type switch only for this modal entry, preserving the existing Swap/Swiper page behavior.

## Issues
- Fixes OK-57834
- Fixes OK-57605

## Test plan
- Desktop Electron: Aave repay with 0.1 USDC shows the health factor; 100 USDC shows insufficient balance without the health-factor skeleton and keeps the action disabled.
- Desktop Electron: Aave withdraw with 0.001 USDT shows the health factor; 100 USDT shows insufficient balance without the health-factor skeleton and keeps the action disabled.
- Desktop Electron: opening Swap from the Home Token List keeps the selected pair visible without an empty placeholder transition.
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`

## Risk
- Low. Both changes are scoped presentation/state-transition guards. Transaction submission, approval, balance calculations, and the existing Swap/Swiper page behavior are unchanged.

[OK-57834]: https://onekeyhq.atlassian.net/browse/OK-57834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-57605]: https://onekeyhq.atlassian.net/browse/OK-57605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ