### PR TITLE
fix: prevent swap modal flicker (OK-57605)

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapHeaderContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHeaderContainer.tsx
@@ -32,7 +32,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { ITabSwapParamList } from '@onekeyhq/shared/src/routes';
 import {
   ESwapDirectionType,
-  type ESwapSource,
+  ESwapSource,
   ESwapTabSwitchType,
 } from '@onekeyhq/shared/types/swap/types';
 
@@ -167,7 +167,11 @@ const SwapHeaderContainer = ({
     }
   }, [hasPendingSwapProEntry, navigation]);
   useEffect(() => {
-    if (hadPendingSwapProEntryOnMountRef.current || !defaultSwapType) {
+    if (
+      hadPendingSwapProEntryOnMountRef.current ||
+      !defaultSwapType ||
+      (pageType === 'modal' && enterFrom === ESwapSource.WALLET_HOME_TOKEN_LIST)
+    ) {
       return;
     }
     // Avoid switching the default toToken before it has been loaded,


### PR DESCRIPTION
## Summary

- keep the Home Token List swap pair stable while the modal initializes
- skip the redundant initial swap type switch only for this modal entry
- preserve the existing Swap/Swiper page behavior

## Verification

- verified in the local Electron development environment
- confirmed the selected pair no longer passes through an empty placeholder state
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`

Jira: https://onekeyhq.atlassian.net/browse/OK-57605