### PR TITLE
fix: refine home market add tokens button OK-58290

### DIFF
--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -997,24 +997,12 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
     totalFavoritesCount,
   ]);
 
-  // Header action button (only show "Add tokens" button in empty state)
-  const headerActions = useMemo(() => {
-    if (selectedMarketCategoryId) {
-      return null;
-    }
-
-    // No header action when user has favorites (View more is shown in footer)
-    if (hasUserFavorites) {
-      return null;
-    }
-
-    // Show "Add tokens" button in empty state
-    return (
+  const addTokensButton = useMemo(
+    () => (
       <Button
         testID="home-header-actions-btn"
         size="small"
-        variant="tertiary"
-        icon="PlusSmallOutline"
+        variant="secondary"
         disabled={selectedTokens.length === 0}
         onPress={handleAddTokens}
       >
@@ -1023,14 +1011,9 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
           { number: selectedTokens.length || 0 },
         )}
       </Button>
-    );
-  }, [
-    hasUserFavorites,
-    selectedMarketCategoryId,
-    selectedTokens.length,
-    handleAddTokens,
-    intl,
-  ]);
+    ),
+    [selectedTokens.length, handleAddTokens, intl],
+  );
 
   const renderContent = useCallback(() => {
     const listContent = (() => {
@@ -1094,7 +1077,14 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
           );
         }
 
-        return <YStack px="$pagePadding">{renderEmptyStateCards()}</YStack>;
+        return (
+          <YStack px="$pagePadding">
+            {renderEmptyStateCards()}
+            <YStack pt="$4" alignItems="center">
+              {addTokensButton}
+            </YStack>
+          </YStack>
+        );
       }
 
       // User has favorites: show table/list layout
@@ -1135,6 +1125,7 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
     renderEmptyStateCards,
     renderUserFavoritesList,
     selectedMarketCategoryId,
+    addTokensButton,
     resolvedSelectedCategoryId,
     shouldHideCategorySelector,
     shouldUseTableLayout,
@@ -1143,7 +1134,6 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
   return (
     <RichBlock
       title={intl.formatMessage({ id: ETranslations.global_market })}
-      headerActions={headerActions}
       headerContainerProps={{ px: '$pagePadding' }}
       content={renderContent()}
       plainContentContainer


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58290](https://onekeyhq.atlassian.net/browse/OK-58290)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- move the **Add {number} tokens** action from the Home Market block header to below the recommended token cards
- use the secondary button style and remove the leading plus icon
- keep the action available only in the empty-watchlist recommendation state

## Why

The action belongs to the recommended-token selection flow, but rendering it beside the Market section title makes it visually detached from the selected cards.

## Impact

Users with an empty Market watchlist now see the add action directly below the recommended tokens. Existing watchlists and Market category views are unchanged.

## Root cause

The button was passed through `RichBlock.headerActions`, which always places it in the section header. Its tertiary style and plus icon also differed from the intended recommendation-flow action.

## Validation

- `yarn agent:check --profile pr`
  - agent context passed
  - staged lint passed
  - staged TypeScript check passed
  - GitHub checks were skipped before PR creation because no PR existed yet
- `git diff --check origin/x...HEAD`

[OK-58290](https://onekeyhq.atlassian.net/browse/OK-58290)

[OK-58290]: https://onekeyhq.atlassian.net/browse/OK-58290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ