### PR TITLE
fix: align TradingView wheel interactions OK-58408

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartViewport.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartViewport.test.ts
@@ -432,6 +432,20 @@ describe('TradingViewNative chart viewport', () => {
     );
   });
 
+  it('keeps the right edge fixed when zooming without a focused anchor', () => {
+    const chartWidth = 100;
+    const viewport = getTradingViewNativeZoomedViewport({
+      anchorX: chartWidth,
+      chartWidth,
+      currentOffset: 24,
+      currentZoomScale: 1,
+      nextZoomScale: 2,
+      pointCount: 100,
+    });
+
+    expect(viewport).toEqual({ offset: 48, zoomScale: 2 });
+  });
+
   it('resolves timestamp and time-range targets to candle indices', () => {
     const points = [
       buildPoint(1, 2, 100),

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/TradingViewNativeChart.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/TradingViewNativeChart.tsx
@@ -9,6 +9,7 @@ import {
 import type { PointerEvent as ReactPointerEvent } from 'react';
 
 import { Stack, useTheme, useThemeName } from '@onekeyhq/components';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IMarketTokenKLineDataPoint } from '@onekeyhq/shared/types/marketV2';
 
 import {
@@ -42,12 +43,15 @@ import {
   getTradingViewNativeViewportPointRange,
 } from '../utils/chartViewport';
 
+import {
+  TradingViewNativeWheelDeltaNormalizer,
+  getTradingViewNativeWheelPanOffsetDelta,
+  getTradingViewNativeWheelZoomAnchorX,
+  getTradingViewNativeWheelZoomScale,
+} from './chartWheel';
+
 import type { ITradingViewNativeChartType } from '../types';
 
-const WHEEL_ZOOM_SENSITIVITY = 0.0015;
-const WHEEL_DELTA_MODE_LINE = 1;
-const WHEEL_DELTA_MODE_PAGE = 2;
-const WHEEL_DELTA_LINE_HEIGHT = 16;
 const ONEKEY_WATERMARK_ASSET =
   require('@onekeyhq/components/svg/illus/logo.svg') as
     | string
@@ -93,16 +97,6 @@ interface IDrawKLineChartOptions {
 
 function getCanvasChartWidth(canvas: HTMLCanvasElement) {
   return getTradingViewNativeChartWidth(canvas.getBoundingClientRect().width);
-}
-
-function getWheelDeltaYInPixels(event: WheelEvent, canvas: HTMLCanvasElement) {
-  if (event.deltaMode === WHEEL_DELTA_MODE_LINE) {
-    return event.deltaY * WHEEL_DELTA_LINE_HEIGHT;
-  }
-  if (event.deltaMode === WHEEL_DELTA_MODE_PAGE) {
-    return event.deltaY * canvas.clientHeight;
-  }
-  return event.deltaY;
 }
 
 function getCanvasFont(font: ITradingViewNativeChartSceneFont) {
@@ -296,6 +290,9 @@ export const TradingViewNativeChart = memo(
       createTradingViewNativeChartRuntimeState(),
     );
     const pointerDragStateRef = useRef<IPointerDragState | null>(null);
+    const wheelDeltaNormalizerRef = useRef(
+      new TradingViewNativeWheelDeltaNormalizer(),
+    );
     const appliedViewportRequestRef = useRef({
       chartWidth: 0,
       requestId: 0,
@@ -631,29 +628,64 @@ export const TradingViewNativeChart = memo(
 
     const handleWheel = useCallback(
       (event: WheelEvent) => {
-        event.preventDefault();
         const canvas = canvasRef.current;
-        if (!canvas) {
+        if (!canvas || pointCount <= 0) {
           return;
         }
+        const isMacOS = Boolean(platformEnv.isRuntimeMacOSBrowser);
+        const wheelDelta = wheelDeltaNormalizerRef.current.processWheel({
+          deltaMode: event.deltaMode,
+          deltaX: event.deltaX,
+          deltaY: event.deltaY,
+          isMacOS,
+          shiftKey: event.shiftKey,
+          timeStamp: event.timeStamp,
+        });
+        if (wheelDelta.deltaX === 0 && wheelDelta.deltaY === 0) {
+          return;
+        }
+        event.preventDefault();
+
         const canvasRect = canvas.getBoundingClientRect();
         const chartWidth = getCanvasChartWidth(canvas);
-        const deltaY = getWheelDeltaYInPixels(event, canvas);
-        const anchorX =
-          event.clientX - canvasRect.left - CHART_HORIZONTAL_PADDING;
         const currentRuntimeState = runtimeStateRef.current;
-        const nextRuntimeState = reduceTradingViewNativeChartRuntime(
-          currentRuntimeState,
-          {
-            anchorX,
-            chartWidth,
-            nextZoomScale:
-              currentRuntimeState.viewport.zoomScale *
-              Math.exp(-deltaY * WHEEL_ZOOM_SENSITIVITY),
-            pointCount,
-            type: 'zoomed',
-          },
-        );
+        let nextRuntimeState = currentRuntimeState;
+        if (wheelDelta.deltaY !== 0) {
+          const cursorX =
+            event.clientX - canvasRect.left - CHART_HORIZONTAL_PADDING;
+          nextRuntimeState = reduceTradingViewNativeChartRuntime(
+            nextRuntimeState,
+            {
+              anchorX: getTradingViewNativeWheelZoomAnchorX({
+                chartWidth,
+                ctrlKey: event.ctrlKey,
+                cursorX,
+                isMacOS,
+                metaKey: event.metaKey,
+              }),
+              chartWidth,
+              nextZoomScale: getTradingViewNativeWheelZoomScale({
+                currentZoomScale: nextRuntimeState.viewport.zoomScale,
+                deltaY: wheelDelta.deltaY,
+              }),
+              pointCount,
+              type: 'zoomed',
+            },
+          );
+        }
+        if (wheelDelta.deltaX !== 0) {
+          nextRuntimeState = reduceTradingViewNativeChartRuntime(
+            nextRuntimeState,
+            {
+              chartWidth,
+              offset:
+                nextRuntimeState.viewport.offset +
+                getTradingViewNativeWheelPanOffsetDelta(wheelDelta.deltaX),
+              pointCount,
+              type: 'panMoved',
+            },
+          );
+        }
         runtimeStateRef.current = nextRuntimeState;
         setViewportState((currentState) =>
           currentState.offset === nextRuntimeState.viewport.offset &&

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/chartWheel.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/chartWheel.test.ts
@@ -1,0 +1,154 @@
+import {
+  TradingViewNativeWheelDeltaNormalizer,
+  getTradingViewNativeWheelPanOffsetDelta,
+  getTradingViewNativeWheelZoomAnchorX,
+  getTradingViewNativeWheelZoomScale,
+} from './chartWheel';
+
+describe('TradingViewNative chart wheel', () => {
+  it('normalizes pixel, line, and page wheel deltas', () => {
+    expect(
+      new TradingViewNativeWheelDeltaNormalizer().processWheel({
+        deltaMode: 0,
+        deltaX: 50,
+        deltaY: -100,
+        isMacOS: false,
+        shiftKey: false,
+        timeStamp: 1,
+      }),
+    ).toEqual({ deltaX: 0.5, deltaY: -1 });
+    expect(
+      new TradingViewNativeWheelDeltaNormalizer().processWheel({
+        deltaMode: 1,
+        deltaX: 0,
+        deltaY: 3,
+        isMacOS: false,
+        shiftKey: false,
+        timeStamp: 1,
+      }),
+    ).toEqual({ deltaX: 0, deltaY: 0.96 });
+    expect(
+      new TradingViewNativeWheelDeltaNormalizer().processWheel({
+        deltaMode: 2,
+        deltaX: 0,
+        deltaY: 1,
+        isMacOS: false,
+        shiftKey: false,
+        timeStamp: 1,
+      }),
+    ).toEqual({ deltaX: 0, deltaY: 1.2 });
+  });
+
+  it('maps Shift plus a vertical wheel to horizontal scrolling off macOS', () => {
+    expect(
+      new TradingViewNativeWheelDeltaNormalizer().processWheel({
+        deltaMode: 0,
+        deltaX: 0,
+        deltaY: 100,
+        isMacOS: false,
+        shiftKey: true,
+        timeStamp: 1,
+      }),
+    ).toEqual({ deltaX: -1, deltaY: 0 });
+  });
+
+  it('uses the horizontal delta supplied by macOS for Shift scrolling', () => {
+    expect(
+      new TradingViewNativeWheelDeltaNormalizer().processWheel({
+        deltaMode: 0,
+        deltaX: -100,
+        deltaY: 0,
+        isMacOS: true,
+        shiftKey: true,
+        timeStamp: 1,
+      }),
+    ).toEqual({ deltaX: -1, deltaY: 0 });
+  });
+
+  it('filters minor movement on the non-dominant trackpad axis', () => {
+    const normalizer = new TradingViewNativeWheelDeltaNormalizer();
+
+    expect(
+      normalizer.processWheel({
+        deltaMode: 0,
+        deltaX: 100,
+        deltaY: 10,
+        isMacOS: false,
+        shiftKey: false,
+        timeStamp: 1,
+      }),
+    ).toEqual({ deltaX: 1, deltaY: 0 });
+    expect(
+      normalizer.processWheel({
+        deltaMode: 0,
+        deltaX: 10,
+        deltaY: 100,
+        isMacOS: false,
+        shiftKey: false,
+        timeStamp: 102,
+      }),
+    ).toEqual({ deltaX: 0, deltaY: 1 });
+  });
+
+  it('matches TradingView wheel pan distance and capped zoom steps', () => {
+    expect(getTradingViewNativeWheelPanOffsetDelta(-1)).toBe(80);
+    expect(
+      getTradingViewNativeWheelZoomScale({
+        currentZoomScale: 2,
+        deltaY: -1,
+      }),
+    ).toBe(2.2);
+    expect(
+      getTradingViewNativeWheelZoomScale({
+        currentZoomScale: 2,
+        deltaY: 5,
+      }),
+    ).toBe(1.8);
+    expect(
+      getTradingViewNativeWheelZoomScale({
+        currentZoomScale: 2,
+        deltaY: -0.25,
+      }),
+    ).toBe(2.05);
+  });
+
+  it('uses the platform modifier only for focused zoom', () => {
+    const commonOptions = {
+      chartWidth: 300,
+      cursorX: 120,
+    };
+
+    expect(
+      getTradingViewNativeWheelZoomAnchorX({
+        ...commonOptions,
+        ctrlKey: false,
+        isMacOS: false,
+        metaKey: false,
+      }),
+    ).toBe(300);
+    expect(
+      getTradingViewNativeWheelZoomAnchorX({
+        ...commonOptions,
+        ctrlKey: true,
+        isMacOS: false,
+        metaKey: false,
+      }),
+    ).toBe(120);
+    expect(
+      getTradingViewNativeWheelZoomAnchorX({
+        ...commonOptions,
+        ctrlKey: true,
+        isMacOS: true,
+        metaKey: false,
+      }),
+    ).toBe(300);
+    expect(
+      getTradingViewNativeWheelZoomAnchorX({
+        ...commonOptions,
+        ctrlKey: false,
+        isMacOS: true,
+        metaKey: true,
+      }),
+    ).toBe(120);
+  });
+});

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/chartWheel.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/chartWheel.ts
@@ -1,0 +1,132 @@
+const WHEEL_AXIS_DOMINANCE_RATIO = 3;
+const WHEEL_GESTURE_RESET_DELAY = 100;
+const WHEEL_DELTA_NORMALIZATION_FACTOR = 100;
+const WHEEL_DELTA_MODE_LINE = 1;
+const WHEEL_DELTA_MODE_PAGE = 2;
+const WHEEL_DELTA_LINE_MULTIPLIER = 32;
+const WHEEL_DELTA_PAGE_MULTIPLIER = 120;
+const WHEEL_PAN_MULTIPLIER = 80;
+const WHEEL_ZOOM_STEP = 0.1;
+
+interface ITradingViewNativeWheelEventData {
+  deltaMode: number;
+  deltaX: number;
+  deltaY: number;
+  isMacOS: boolean;
+  shiftKey: boolean;
+  timeStamp: number;
+}
+
+export interface ITradingViewNativeWheelDelta {
+  deltaX: number;
+  deltaY: number;
+}
+
+function normalizeWheelDeltaMode({
+  deltaMode,
+  deltaX,
+  deltaY,
+}: Pick<
+  ITradingViewNativeWheelEventData,
+  'deltaMode' | 'deltaX' | 'deltaY'
+>): ITradingViewNativeWheelDelta {
+  let normalizedDeltaX = deltaX / WHEEL_DELTA_NORMALIZATION_FACTOR;
+  let normalizedDeltaY = deltaY / WHEEL_DELTA_NORMALIZATION_FACTOR;
+
+  if (deltaMode === WHEEL_DELTA_MODE_PAGE) {
+    normalizedDeltaX *= WHEEL_DELTA_PAGE_MULTIPLIER;
+    normalizedDeltaY *= WHEEL_DELTA_PAGE_MULTIPLIER;
+  } else if (deltaMode === WHEEL_DELTA_MODE_LINE) {
+    normalizedDeltaX *= WHEEL_DELTA_LINE_MULTIPLIER;
+    normalizedDeltaY *= WHEEL_DELTA_LINE_MULTIPLIER;
+  }
+
+  return { deltaX: normalizedDeltaX, deltaY: normalizedDeltaY };
+}
+
+export class TradingViewNativeWheelDeltaNormalizer {
+  private previousWheelTime = 0;
+
+  private totalDeltaX = 0;
+
+  private totalDeltaY = 0;
+
+  processWheel({
+    deltaMode,
+    deltaX,
+    deltaY,
+    isMacOS,
+    shiftKey,
+    timeStamp,
+  }: ITradingViewNativeWheelEventData): ITradingViewNativeWheelDelta {
+    if (timeStamp - this.previousWheelTime > WHEEL_GESTURE_RESET_DELAY) {
+      this.reset();
+    }
+
+    const shouldSwapWheelAxes = !isMacOS && shiftKey;
+    const resolvedDeltaX = shouldSwapWheelAxes ? -deltaY : deltaX;
+    const resolvedDeltaY = shouldSwapWheelAxes ? deltaX : deltaY;
+    this.totalDeltaX += resolvedDeltaX;
+    this.totalDeltaY += resolvedDeltaY;
+    this.previousWheelTime = timeStamp;
+
+    const delta = {
+      deltaX: resolvedDeltaX,
+      deltaY: resolvedDeltaY,
+    };
+    if (this.totalDeltaX !== 0 && this.totalDeltaY !== 0) {
+      if (
+        Math.abs(this.totalDeltaX) >=
+        Math.abs(WHEEL_AXIS_DOMINANCE_RATIO * this.totalDeltaY)
+      ) {
+        delta.deltaY = 0;
+      }
+      if (
+        Math.abs(this.totalDeltaY) >=
+        Math.abs(WHEEL_AXIS_DOMINANCE_RATIO * this.totalDeltaX)
+      ) {
+        delta.deltaX = 0;
+      }
+    }
+
+    return normalizeWheelDeltaMode({ deltaMode, ...delta });
+  }
+
+  private reset() {
+    this.totalDeltaX = 0;
+    this.totalDeltaY = 0;
+  }
+}
+
+export function getTradingViewNativeWheelPanOffsetDelta(deltaX: number) {
+  return -WHEEL_PAN_MULTIPLIER * deltaX;
+}
+
+export function getTradingViewNativeWheelZoomAnchorX({
+  chartWidth,
+  ctrlKey,
+  cursorX,
+  isMacOS,
+  metaKey,
+}: {
+  chartWidth: number;
+  ctrlKey: boolean;
+  cursorX: number;
+  isMacOS: boolean;
+  metaKey: boolean;
+}) {
+  const isFocusedZoom = isMacOS ? metaKey : ctrlKey;
+  return isFocusedZoom ? cursorX : chartWidth;
+}
+
+export function getTradingViewNativeWheelZoomScale({
+  currentZoomScale,
+  deltaY,
+}: {
+  currentZoomScale: number;
+  deltaY: number;
+}) {
+  const zoomDelta =
+    Math.sign(-deltaY) * Math.min(1, Math.abs(deltaY)) * WHEEL_ZOOM_STEP;
+  return currentZoomScale * (1 + zoomDelta);
+}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58408](https://onekeyhq.atlassian.net/browse/OK-58408)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- align the native TradingView canvas wheel normalization and gesture routing with TradingView desktop behavior
- keep normal wheel zoom anchored to the chart's right edge
- use cursor-focused zoom for Command + wheel on macOS and Control + wheel elsewhere
- support horizontal trackpad scrolling and Shift + wheel panning with dominant-axis filtering
- add focused unit coverage for wheel normalization, modifier behavior, pan distance, zoom steps, and right-edge anchoring

## Root cause

The custom canvas chart only consumed `deltaY` and always applied exponential, cursor-anchored zoom. It did not handle horizontal wheel deltas, platform-specific modifier keys, or gesture-level axis normalization, so desktop mouse and trackpad interactions diverged from TradingView.

## User impact

Desktop and web users now get TradingView-compatible zoom and horizontal navigation behavior from mouse wheels and trackpads.

## Validation

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr` (local checks passed; remote checks were skipped before the PR existed)
- `yarn jest packages/kit/src/components/TradingView/TradingViewNative/web/chartWheel.test.ts packages/kit/src/components/TradingView/TradingViewNative/utils/chartViewport.test.ts packages/kit/src/components/TradingView/TradingViewNative/utils/chartRuntime.test.ts --runInBand` — 35 tests passed
- Electron desktop CDP verification for plain wheel, Command, Control, Alt, and Shift/horizontal wheel scenarios; all viewport and rendered-pixel assertions passed with no interaction-time console or page errors

[OK-58408]: https://onekeyhq.atlassian.net/browse/OK-58408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ