### PR TITLE
fix: reserve gas for private max send (OK-59161)

### DIFF
--- a/packages/kit-bg/src/services/ServiceSwap.nativeTokenConfig.test.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.nativeTokenConfig.test.ts
@@ -1,0 +1,55 @@
+import ServiceSwap from './ServiceSwap';
+
+describe('ServiceSwap native token config', () => {
+  const previousBackgroundScope = globalThis.$onekeyIsInBackground;
+
+  beforeAll(() => {
+    globalThis.$onekeyIsInBackground = true;
+  });
+
+  afterAll(() => {
+    globalThis.$onekeyIsInBackground = previousBackgroundScope;
+  });
+
+  it('preserves the zero-reserve fallback for existing callers', async () => {
+    const service = new ServiceSwap({ backgroundApi: {} });
+    const error = new Error('native token config unavailable');
+    jest
+      .spyOn(service, 'fetchSwapNativeTokenConfigMemo')
+      .mockRejectedValue(error);
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    await expect(
+      service.fetchSwapNativeTokenConfig({ networkId: 'evm--1' }),
+    ).resolves.toEqual({
+      networkId: 'evm--1',
+      reserveGas: 0,
+    });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('rejects failed strict queries so callers do not treat fallback data as ready', async () => {
+    const service = new ServiceSwap({ backgroundApi: {} });
+    const error = new Error('native token config unavailable');
+    jest
+      .spyOn(service, 'fetchSwapNativeTokenConfigMemo')
+      .mockRejectedValue(error);
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    await expect(
+      service.fetchSwapNativeTokenConfig({
+        networkId: 'evm--1',
+        throwOnError: true,
+      }),
+    ).rejects.toBe(error);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1503,11 +1503,20 @@ export default class ServiceSwap extends ServiceBase {
   }
 
   @backgroundMethod()
-  async fetchSwapNativeTokenConfig({ networkId }: { networkId: string }) {
+  async fetchSwapNativeTokenConfig({
+    networkId,
+    throwOnError,
+  }: {
+    networkId: string;
+    throwOnError?: boolean;
+  }) {
     try {
       return await this.fetchSwapNativeTokenConfigMemo(networkId);
     } catch (e) {
       console.error(e);
+      if (throwOnError) {
+        throw e;
+      }
       return {
         networkId,
         reserveGas: 0,

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -1060,11 +1060,13 @@ function SendAmountInputContainer() {
       }
       return backgroundApiProxy.serviceSwap.fetchSwapNativeTokenConfig({
         networkId: privateSendNativeTokenNetworkId,
+        throwOnError: true,
       });
     },
     [privateSendNativeTokenNetworkId],
     {
       watchLoading: true,
+      undefinedResultIfError: true,
       undefinedResultIfReRun: true,
     },
   );

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -111,6 +111,7 @@ import type {
   IFetchQuoteInfo,
   IFetchQuoteResult,
   IFetchQuotesParams,
+  ISwapNativeTokenConfig,
   ISwapQuoteEvent,
   ISwapQuoteEventAutoSlippage,
   ISwapQuoteEventData,
@@ -148,6 +149,7 @@ import {
   type ISiblingDeriveBalance,
   useSiblingDeriveBalances,
 } from './hooks/useSiblingDeriveBalances';
+import { calcPrivateSendNativeTokenMaxAmount } from './privateSendMaxAmountUtils';
 
 import type { RouteProp } from '@react-navigation/core';
 
@@ -1043,6 +1045,32 @@ function SendAmountInputContainer() {
     () => convertTokenToSwapToken({ networkId, tokenDetails }),
     [networkId, tokenDetails],
   );
+  const isPrivateSendNativeToken =
+    sendMode === ESendMode.PRIVATE && privateSendToken?.isNative === true;
+  const privateSendNativeTokenNetworkId = isPrivateSendNativeToken
+    ? privateSendToken.networkId
+    : undefined;
+  const {
+    result: privateSendNativeTokenConfig,
+    isLoading: isPrivateSendNativeTokenConfigLoading,
+  } = usePromiseResult<ISwapNativeTokenConfig | undefined>(
+    async () => {
+      if (!privateSendNativeTokenNetworkId) {
+        return undefined;
+      }
+      return backgroundApiProxy.serviceSwap.fetchSwapNativeTokenConfig({
+        networkId: privateSendNativeTokenNetworkId,
+      });
+    },
+    [privateSendNativeTokenNetworkId],
+    {
+      watchLoading: true,
+      undefinedResultIfReRun: true,
+    },
+  );
+  const isPrivateSendNativeTokenConfigReady =
+    !isPrivateSendNativeToken ||
+    privateSendNativeTokenConfig?.networkId === privateSendNativeTokenNetworkId;
   const sendSwapTargetToken = useMemo(
     () =>
       privateSendToken ??
@@ -1196,6 +1224,39 @@ function SendAmountInputContainer() {
     return tokenDetails.fiatValue ?? '0';
   }, [tokenDetails, selectedUtxoTotalAmount]);
 
+  const privateSendMaxTokenAmount = useMemo(() => {
+    if (!isPrivateSendNativeToken || !isPrivateSendNativeTokenConfigReady) {
+      return undefined;
+    }
+    return calcPrivateSendNativeTokenMaxAmount({
+      balance: maxBalance,
+      reserveGas: privateSendNativeTokenConfig?.reserveGas,
+      decimals: privateSendToken?.decimals,
+    });
+  }, [
+    isPrivateSendNativeToken,
+    isPrivateSendNativeTokenConfigReady,
+    maxBalance,
+    privateSendNativeTokenConfig?.reserveGas,
+    privateSendToken?.decimals,
+  ]);
+
+  const privateSendMaxInputAmount = useMemo(() => {
+    if (privateSendMaxTokenAmount === undefined) {
+      return undefined;
+    }
+    if (!isUseFiat) {
+      return privateSendMaxTokenAmount;
+    }
+    const priceBN = new BigNumber(tokenDetails?.price ?? '');
+    if (!priceBN.isFinite() || priceBN.lte(0)) {
+      return undefined;
+    }
+    return new BigNumber(privateSendMaxTokenAmount)
+      .multipliedBy(priceBN)
+      .toFixed();
+  }, [isUseFiat, privateSendMaxTokenAmount, tokenDetails?.price]);
+
   const linkedAmount = useMemo(() => {
     const amountBN = new BigNumber(amount || 0);
     // For Lightning in BTC mode, the input is in BTC but price is per-sat.
@@ -1267,6 +1328,45 @@ function SendAmountInputContainer() {
     () => new BigNumber(privateSendAmount || 0),
     [privateSendAmount],
   );
+  const shouldApplyPrivateSendNativeMax = isPrivateSendNativeToken && isMaxSend;
+  const isPrivateSendNativeMaxAmountReady = useMemo(() => {
+    if (!shouldApplyPrivateSendNativeMax) {
+      return true;
+    }
+    if (
+      !isPrivateSendNativeTokenConfigReady ||
+      privateSendMaxTokenAmount === undefined ||
+      privateSendAmountBN.isNaN()
+    ) {
+      return false;
+    }
+    return privateSendAmountBN.lte(privateSendMaxTokenAmount);
+  }, [
+    isPrivateSendNativeTokenConfigReady,
+    privateSendAmountBN,
+    privateSendMaxTokenAmount,
+    shouldApplyPrivateSendNativeMax,
+  ]);
+
+  useEffect(() => {
+    if (
+      !shouldApplyPrivateSendNativeMax ||
+      privateSendMaxInputAmount === undefined ||
+      privateSendMaxTokenAmount === undefined ||
+      privateSendAmountBN.lte(privateSendMaxTokenAmount)
+    ) {
+      return;
+    }
+    form.setValue('amount', privateSendMaxInputAmount, {
+      shouldValidate: true,
+    });
+  }, [
+    form,
+    privateSendAmountBN,
+    privateSendMaxInputAmount,
+    privateSendMaxTokenAmount,
+    shouldApplyPrivateSendNativeMax,
+  ]);
   const {
     result: privateSendQuoteRecipientResult,
     isLoading: isPrivateSendRecipientResolving,
@@ -1341,10 +1441,12 @@ function SendAmountInputContainer() {
       !!privateSendToken &&
       !!account?.address &&
       !!recipientAddress &&
+      isPrivateSendNativeMaxAmountReady &&
       !privateSendAmountBN.isNaN() &&
       privateSendAmountBN.isGreaterThan(0),
     [
       account?.address,
+      isPrivateSendNativeMaxAmountReady,
       isPrivateSendSupported,
       privateSendAmountBN,
       privateSendToken,
@@ -2136,6 +2238,16 @@ function SendAmountInputContainer() {
 
   const onSelectPercentageStage = useCallback(
     (stage: number) => {
+      if (stage === 100 && isPrivateSendNativeToken) {
+        if (privateSendMaxInputAmount === undefined) {
+          return;
+        }
+        form.setValue('amount', privateSendMaxInputAmount, {
+          shouldValidate: true,
+        });
+        setIsMaxSend(true);
+        return;
+      }
       const balance = isUseFiat ? maxBalanceFiat : maxBalance;
       let decimals = tokenDetails?.info.decimals;
       if (isUseFiat) {
@@ -2161,10 +2273,12 @@ function SendAmountInputContainer() {
       form,
       isIntegerAmount,
       isLightningNetwork,
+      isPrivateSendNativeToken,
       isUseFiat,
       lnUnit,
       maxBalance,
       maxBalanceFiat,
+      privateSendMaxInputAmount,
       tokenDetails?.info.decimals,
     ],
   );
@@ -3827,8 +3941,25 @@ function SendAmountInputContainer() {
           variant="secondary"
           size="small"
           ml="$2"
+          disabled={
+            isPrivateSendNativeToken && privateSendMaxInputAmount === undefined
+          }
+          loading={
+            isPrivateSendNativeToken &&
+            (isPrivateSendNativeTokenConfigLoading ||
+              !isPrivateSendNativeTokenConfigReady)
+          }
           onPress={() => {
-            form.setValue('amount', isUseFiat ? maxBalanceFiat : maxBalance, {
+            let maxInputAmount: string | undefined = isUseFiat
+              ? maxBalanceFiat
+              : maxBalance;
+            if (isPrivateSendNativeToken) {
+              maxInputAmount = privateSendMaxInputAmount;
+            }
+            if (maxInputAmount === undefined) {
+              return;
+            }
+            form.setValue('amount', maxInputAmount, {
               shouldValidate: true,
             });
             setIsMaxSend(true);
@@ -3845,11 +3976,15 @@ function SendAmountInputContainer() {
     form,
     intl,
     isLoadingAssets,
+    isPrivateSendNativeToken,
+    isPrivateSendNativeTokenConfigLoading,
+    isPrivateSendNativeTokenConfigReady,
     isUseFiat,
     maxBalance,
     maxBalanceFiat,
     network?.logoURI,
     nftDetails,
+    privateSendMaxInputAmount,
     sendMode,
     tokenDetails,
     tokenInfo?.logoURI,

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -149,7 +149,10 @@ import {
   type ISiblingDeriveBalance,
   useSiblingDeriveBalances,
 } from './hooks/useSiblingDeriveBalances';
-import { calcPrivateSendNativeTokenMaxAmount } from './privateSendMaxAmountUtils';
+import {
+  calcPrivateSendNativeTokenMaxAmount,
+  getMaxSendStateAfterModeChange,
+} from './privateSendMaxAmountUtils';
 
 import type { RouteProp } from '@react-navigation/core';
 
@@ -1140,6 +1143,13 @@ function SendAmountInputContainer() {
 
   useEffect(() => {
     if (!showPrivateSendModeSwitch && sendMode === ESendMode.PRIVATE) {
+      setIsMaxSend((currentIsMaxSend) =>
+        getMaxSendStateAfterModeChange({
+          isMaxSend: currentIsMaxSend,
+          isCurrentModePrivate: true,
+          isNextModePrivate: false,
+        }),
+      );
       setSendMode(ESendMode.PUBLIC);
     }
   }, [sendMode, showPrivateSendModeSwitch]);
@@ -3332,6 +3342,13 @@ function SendAmountInputContainer() {
       const nextMode =
         value === ESendMode.PRIVATE ? ESendMode.PRIVATE : ESendMode.PUBLIC;
       if (nextMode !== sendMode) {
+        setIsMaxSend((currentIsMaxSend) =>
+          getMaxSendStateAfterModeChange({
+            isMaxSend: currentIsMaxSend,
+            isCurrentModePrivate: sendMode === ESendMode.PRIVATE,
+            isNextModePrivate: nextMode === ESendMode.PRIVATE,
+          }),
+        );
         defaultLogger.transaction.send.sendModeSwitch({
           fromMode: sendMode,
           toMode: nextMode,

--- a/packages/kit/src/views/Send/pages/SendAmountInput/privateSendMaxAmountUtils.test.ts
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/privateSendMaxAmountUtils.test.ts
@@ -1,4 +1,39 @@
-import { calcPrivateSendNativeTokenMaxAmount } from './privateSendMaxAmountUtils';
+import {
+  calcPrivateSendNativeTokenMaxAmount,
+  getMaxSendStateAfterModeChange,
+} from './privateSendMaxAmountUtils';
+
+describe('getMaxSendStateAfterModeChange', () => {
+  it('clears Private Max when switching to Public', () => {
+    expect(
+      getMaxSendStateAfterModeChange({
+        isMaxSend: true,
+        isCurrentModePrivate: true,
+        isNextModePrivate: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('preserves Public Max when switching to Private', () => {
+    expect(
+      getMaxSendStateAfterModeChange({
+        isMaxSend: true,
+        isCurrentModePrivate: false,
+        isNextModePrivate: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('preserves the current state when the mode does not change', () => {
+    expect(
+      getMaxSendStateAfterModeChange({
+        isMaxSend: true,
+        isCurrentModePrivate: true,
+        isNextModePrivate: true,
+      }),
+    ).toBe(true);
+  });
+});
 
 describe('calcPrivateSendNativeTokenMaxAmount', () => {
   it('deducts the configured gas reserve before quoting a max send', () => {

--- a/packages/kit/src/views/Send/pages/SendAmountInput/privateSendMaxAmountUtils.test.ts
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/privateSendMaxAmountUtils.test.ts
@@ -1,0 +1,53 @@
+import { calcPrivateSendNativeTokenMaxAmount } from './privateSendMaxAmountUtils';
+
+describe('calcPrivateSendNativeTokenMaxAmount', () => {
+  it('deducts the configured gas reserve before quoting a max send', () => {
+    expect(
+      calcPrivateSendNativeTokenMaxAmount({
+        balance: '1',
+        reserveGas: '0.005',
+        decimals: 18,
+      }),
+    ).toBe('0.995');
+  });
+
+  it('rounds down to the native token precision', () => {
+    expect(
+      calcPrivateSendNativeTokenMaxAmount({
+        balance: '1.123456789',
+        reserveGas: '0.000000001',
+        decimals: 6,
+      }),
+    ).toBe('1.123456');
+  });
+
+  it('never produces a negative amount when the reserve exceeds the balance', () => {
+    expect(
+      calcPrivateSendNativeTokenMaxAmount({
+        balance: '0.001',
+        reserveGas: '0.005',
+        decimals: 18,
+      }),
+    ).toBe('0');
+  });
+
+  it('keeps the full balance when the configured reserve is not positive', () => {
+    expect(
+      calcPrivateSendNativeTokenMaxAmount({
+        balance: '2.5',
+        reserveGas: 0,
+        decimals: 18,
+      }),
+    ).toBe('2.5');
+  });
+
+  it('returns zero for an invalid balance', () => {
+    expect(
+      calcPrivateSendNativeTokenMaxAmount({
+        balance: 'invalid',
+        reserveGas: '0.005',
+        decimals: 18,
+      }),
+    ).toBe('0');
+  });
+});

--- a/packages/kit/src/views/Send/pages/SendAmountInput/privateSendMaxAmountUtils.ts
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/privateSendMaxAmountUtils.ts
@@ -1,5 +1,20 @@
 import BigNumber from 'bignumber.js';
 
+export function getMaxSendStateAfterModeChange({
+  isMaxSend,
+  isCurrentModePrivate,
+  isNextModePrivate,
+}: {
+  isMaxSend: boolean;
+  isCurrentModePrivate: boolean;
+  isNextModePrivate: boolean;
+}) {
+  if (isCurrentModePrivate && !isNextModePrivate) {
+    return false;
+  }
+  return isMaxSend;
+}
+
 export function calcPrivateSendNativeTokenMaxAmount({
   balance,
   reserveGas,

--- a/packages/kit/src/views/Send/pages/SendAmountInput/privateSendMaxAmountUtils.ts
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/privateSendMaxAmountUtils.ts
@@ -1,0 +1,30 @@
+import BigNumber from 'bignumber.js';
+
+export function calcPrivateSendNativeTokenMaxAmount({
+  balance,
+  reserveGas,
+  decimals,
+}: {
+  balance?: string;
+  reserveGas?: string | number;
+  decimals?: number;
+}) {
+  const balanceBN = new BigNumber(balance ?? '');
+  if (!balanceBN.isFinite() || balanceBN.lte(0)) {
+    return '0';
+  }
+
+  const reserveGasBN = new BigNumber(reserveGas ?? '');
+  const maxAmountBN =
+    reserveGasBN.isFinite() && reserveGasBN.gt(0)
+      ? BigNumber.max(0, balanceBN.minus(reserveGasBN))
+      : balanceBN;
+  const amountDecimals =
+    Number.isInteger(decimals) && Number(decimals) >= 0
+      ? Number(decimals)
+      : (balanceBN.decimalPlaces() ?? 0);
+
+  return maxAmountBN
+    .decimalPlaces(amountDecimals, BigNumber.ROUND_DOWN)
+    .toFixed();
+}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59161](https://onekeyhq.atlassian.net/browse/OK-59161)

----------

<!-- github-pr-monitor:jira-links:end -->


## Issues

- Fixes OK-59161
- Jira: https://onekeyhq.atlassian.net/browse/OK-59161

## Summary

- load the network-scoped native token reserve before Private Send Max quoting
- deduct the configured reserve and round down to native token precision
- keep the quote amount, provider expected pay-in, and transaction value aligned
- keep native Private Send Max disabled when the reserve configuration request fails
- clear the Private Max state when returning to Public Send so preview does not deduct the fee twice

## Verification

- `yarn jest packages/kit-bg/src/services/ServiceSwap.nativeTokenConfig.test.ts packages/kit/src/views/Send/pages/SendAmountInput/privateSendMaxAmountUtils.test.ts --runInBand` (10 passed)
- `yarn agent:check --profile commit`
- Electron on `release/v6.5.0`: Private ETH Max was lower than the available balance; the confirmation page showed no insufficient-ETH warning and enabled Confirm
- no transaction was signed or broadcast

## Release evidence

- target branch: `release/v6.5.0`
- bundle QA: in progress
- Action: https://github.com/OneKeyHQ/app-monorepo/actions/runs/30868675282
- `BUILD_NUMBER=2026071325`
- `BUILD_BUNDLE_VERSION=18581106`
- `BUILD_SOURCE=bundle-release`
- `BRANCH=fix/OK-59161`
- `COMMIT=38e7bdb2c8804799ab9205211d30820bb61d8a37`
- `x` follow-up: required after this PR merges

## Risk

- scoped to native-token Private Send Max and its Private-to-Public mode transition; non-native token sends are unchanged
- the provider order amount remains frozen to the pre-reserved quote amount

[OK-59161]: https://onekeyhq.atlassian.net/browse/OK-59161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ