### PR TITLE
fix: improve perps deposit and order guidance OK-58852

### DIFF
--- a/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/PerpsBalancePill.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/PerpsBalancePill.tsx
@@ -19,7 +19,7 @@ export function PerpsBalancePill({ userAddress }: { userAddress?: string }) {
   const [computedValue] = usePerpsComputedAccountValueAtom();
   const { showPortfolio } = useShowPortfolio();
   const { showDepositWithdrawModal, isDepositDisabled } =
-    useShowDepositWithdrawModal();
+    useShowDepositWithdrawModal('webAccountPanel');
 
   const isForThisAccount =
     !!userAddress &&

--- a/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelMain.tsx
+++ b/packages/kit/src/components/TabPageHeader/components/WebAccountPanel/WebAccountPanelMain.tsx
@@ -83,7 +83,8 @@ function PerpsSection({
   onRequestClose: () => void;
 }) {
   const intl = useIntl();
-  const { showDepositWithdrawModal } = useShowDepositWithdrawModal();
+  const { showDepositWithdrawModal } =
+    useShowDepositWithdrawModal('webAccountPanel');
 
   // Prefer the live computed value — it's the exact source the header Trigger
   // pill renders, and it's correct for unified accounts (spot total). It's only

--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -932,7 +932,7 @@ function PerpsDepositButton({
   isDepositDisabled: boolean;
 }) {
   const intl = useIntl();
-  const { showDepositWithdrawModal } = useShowDepositWithdrawModal();
+  const { showDepositWithdrawModal } = useShowDepositWithdrawModal('home');
   const ensureHomePerpsAccount = useEnsureHomePerpsAccount();
 
   const handleDeposit = useCallback(async () => {

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/AddPositionModal.tsx
@@ -18,6 +18,7 @@ import {
   getFontSize,
   useKeyboardHeight,
 } from '@onekeyhq/components';
+import type { IInputRef } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import {
   useConnectionStateAtom,
@@ -32,6 +33,7 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   calculateLiquidationPrice,
   formatPriceToSignificantDigits,
@@ -60,7 +62,11 @@ import { PerpKeyboardAwareDialogContent } from '../PerpKeyboardAwareDialogConten
 import { PerpsSlider } from '../PerpsSlider';
 import { TradingGuardWrapper } from '../TradingGuardWrapper';
 import { PriceInput } from '../TradingPanel/inputs/PriceInput';
-import { SizeInput } from '../TradingPanel/inputs/SizeInput';
+import {
+  type ISizeInputMinimumOrderAction,
+  SizeInput,
+  getMinimumOrderToastActionProps,
+} from '../TradingPanel/inputs/SizeInput';
 import { TpSlFormInput } from '../TradingPanel/inputs/TpSlFormInput';
 import { AggressiveLimitPriceWarning } from '../TradingPanel/modals/AggressiveLimitPriceWarning';
 
@@ -129,6 +135,10 @@ const AddPositionForm = memo(
     const orderBookTop = useCoinOrderBookTop(coin);
     const requestIdRef = useRef(0);
     const isLimitPriceInitializedRef = useRef(false);
+    const sizeInputRef = useRef<IInputRef>(null);
+    const minimumOrderActionRef = useRef<
+      ISizeInputMinimumOrderAction | undefined
+    >(undefined);
 
     const midPrice = allMids?.mids?.[coin] ?? '';
     const displayName = parseDexCoin(coin).displayName;
@@ -368,6 +378,11 @@ const AddPositionForm = memo(
       setAmount('');
     }, [sizeInputMode]);
 
+    const requestSizeInputFocus = useCallback(() => {
+      if (!platformEnv.isNative) return;
+      requestAnimationFrame(() => sizeInputRef.current?.focus());
+    }, []);
+
     // Size problems keep the button pressable and surface a toast on press,
     // matching the main trading panel instead of silently disabling it.
     const showValidationToast = useCallback(
@@ -396,6 +411,7 @@ const AddPositionForm = memo(
           });
           return;
         }
+        const minimumOrderAction = minimumOrderActionRef.current;
         Toast.message({
           title: intl.formatMessage(
             { id: ETranslations.perp_size_least },
@@ -409,9 +425,16 @@ const AddPositionForm = memo(
               }),
             },
           ),
+          ...getMinimumOrderToastActionProps(
+            minimumOrderAction,
+            intl.formatMessage({
+              id: ETranslations.fill_minimum_amount__action,
+            }),
+          ),
         });
+        requestSizeInputFocus();
       },
-      [displayName, intl, leverage, sizeInputUnit],
+      [displayName, intl, leverage, requestSizeInputFocus, sizeInputUnit],
     );
 
     const handleTpslCheckboxChange = useCallback(
@@ -693,6 +716,8 @@ const AddPositionForm = memo(
           leverage={leverage}
           allowMarginInput
           ifOnDialog
+          inputRef={sizeInputRef}
+          minimumOrderActionRef={minimumOrderActionRef}
         />
         <YStack gap="$1.5">
           <PerpsSlider

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpHoldingsEmptyState.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpHoldingsEmptyState.tsx
@@ -59,7 +59,7 @@ export function PerpHoldingsEmptyState({ isMobile }: { isMobile?: boolean }) {
   const intl = useIntl();
   const { gtMd } = useMedia();
   const { showDepositWithdrawModal, isDepositDisabled } =
-    useShowDepositWithdrawModal();
+    useShowDepositWithdrawModal('holdings');
   const { showGuide } = useShowGuide();
   const [activeAccount] = usePerpsActiveAccountAtom();
 

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpPositionsEmptyState.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PerpPositionsEmptyState.tsx
@@ -72,7 +72,7 @@ export function PerpPositionsEmptyState({ isMobile }: { isMobile?: boolean }) {
   >({});
   const { gtMd } = useMedia();
   const { showDepositWithdrawModal, isDepositDisabled } =
-    useShowDepositWithdrawModal();
+    useShowDepositWithdrawModal('positions');
   const { showGuide } = useShowGuide();
   const [activeAccount] = usePerpsActiveAccountAtom();
 

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -1331,6 +1331,8 @@ const PositionRowMobileActions = memo(
           variant="secondary"
           onPress={onAddPosition}
           flex={1}
+          flexBasis={platformEnv.isWeb ? 0 : undefined}
+          minWidth={platformEnv.isWeb ? 0 : undefined}
           childrenAsText={false}
         >
           <SizableText
@@ -1352,6 +1354,8 @@ const PositionRowMobileActions = memo(
           variant="secondary"
           onPress={onSetTpsl}
           flex={1}
+          flexBasis={platformEnv.isWeb ? 0 : undefined}
+          minWidth={platformEnv.isWeb ? 0 : undefined}
           childrenAsText={false}
           testID="perp-intl-btn"
         >
@@ -1375,6 +1379,8 @@ const PositionRowMobileActions = memo(
           variant="secondary"
           onPress={() => onClosePosition('market')}
           flex={1}
+          flexBasis={platformEnv.isWeb ? 0 : undefined}
+          minWidth={platformEnv.isWeb ? 0 : undefined}
           childrenAsText={false}
         >
           <SizableText

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/Components/PositionsRow.tsx
@@ -1331,8 +1331,8 @@ const PositionRowMobileActions = memo(
           variant="secondary"
           onPress={onAddPosition}
           flex={1}
-          flexBasis={platformEnv.isWeb ? 0 : undefined}
-          minWidth={platformEnv.isWeb ? 0 : undefined}
+          flexBasis={0}
+          minWidth={0}
           childrenAsText={false}
         >
           <SizableText
@@ -1354,8 +1354,8 @@ const PositionRowMobileActions = memo(
           variant="secondary"
           onPress={onSetTpsl}
           flex={1}
-          flexBasis={platformEnv.isWeb ? 0 : undefined}
-          minWidth={platformEnv.isWeb ? 0 : undefined}
+          flexBasis={0}
+          minWidth={0}
           childrenAsText={false}
           testID="perp-intl-btn"
         >
@@ -1379,8 +1379,8 @@ const PositionRowMobileActions = memo(
           variant="secondary"
           onPress={() => onClosePosition('market')}
           flex={1}
-          flexBasis={platformEnv.isWeb ? 0 : undefined}
-          minWidth={platformEnv.isWeb ? 0 : undefined}
+          flexBasis={0}
+          minWidth={0}
           childrenAsText={false}
         >
           <SizableText

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/List/SpotBalanceList.tsx
@@ -106,7 +106,7 @@ function SpotBalanceList({
   const [priceMap] = useSpotAssetCtxsMapAtom();
   const actions = useHyperliquidActions();
   const { showDepositWithdrawModal, isDepositDisabled } =
-    useShowDepositWithdrawModal();
+    useShowDepositWithdrawModal('balance');
   const { spotUniverses, universeByBaseName, tokenContractMap } =
     useSpotMetaMaps();
   const [currentListPage, setCurrentListPage] = useState(1);

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/utils/addPosition.test.ts
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/utils/addPosition.test.ts
@@ -109,13 +109,21 @@ describe('add position guards', () => {
     };
     expect(
       buildAddPositionMinimumAmountLabel({ ...base, sizeInputUnit: 'usd' }),
-    ).toBe('$10');
+    ).toBe('$10.00');
     expect(
       buildAddPositionMinimumAmountLabel({ ...base, sizeInputUnit: 'token' }),
     ).toBe('0.10 ETH');
     expect(
       buildAddPositionMinimumAmountLabel({ ...base, sizeInputUnit: 'margin' }),
     ).toBe('$2.00');
+    expect(
+      buildAddPositionMinimumAmountLabel({
+        ...base,
+        price: '3.39',
+        szDecimals: 1,
+        sizeInputUnit: 'usd',
+      }),
+    ).toBe('$10.17');
   });
 
   it('falls back to the usd minimum when price or leverage is unusable', () => {

--- a/packages/kit/src/views/Perp/components/OrderInfoPanel/utils/addPosition.ts
+++ b/packages/kit/src/views/Perp/components/OrderInfoPanel/utils/addPosition.ts
@@ -114,7 +114,7 @@ export function buildAddPositionMinimumAmountLabel({
 }): string {
   const fallback = `$${ADD_POSITION_MIN_ORDER_NOTIONAL}`;
   const priceBN = new BigNumber(price);
-  if (!priceBN.isFinite() || priceBN.lte(0) || sizeInputUnit === 'usd') {
+  if (!priceBN.isFinite() || priceBN.lte(0)) {
     return fallback;
   }
 
@@ -126,12 +126,18 @@ export function buildAddPositionMinimumAmountLabel({
     return `${minSize.toFixed(szDecimals)} ${symbol}`;
   }
 
+  const minimumOrderValue = minSize.multipliedBy(priceBN);
+  if (sizeInputUnit === 'usd') {
+    return `$${minimumOrderValue
+      .decimalPlaces(2, BigNumber.ROUND_UP)
+      .toFixed(2)}`;
+  }
+
   const leverageBN = new BigNumber(leverage);
   if (!leverageBN.isFinite() || leverageBN.lte(0)) {
     return fallback;
   }
-  return `$${minSize
-    .multipliedBy(priceBN)
+  return `$${minimumOrderValue
     .dividedBy(leverageBN)
     .decimalPlaces(2, BigNumber.ROUND_UP)
     .toFixed(2)}`;

--- a/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
+++ b/packages/kit/src/views/Perp/components/Portfolio/PerpPortfolioContent.tsx
@@ -282,7 +282,7 @@ function PerpPortfolioContentComponent({
   const intl = useIntl();
   const theme = useTheme();
   const { showDepositWithdrawModal, isDepositDisabled } =
-    useShowDepositWithdrawModal();
+    useShowDepositWithdrawModal('portfolio');
   const portfolioPalette = useMemo(
     () => ({
       positive: theme.bgAccent?.val ?? '#31E72F',

--- a/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
+++ b/packages/kit/src/views/Perp/components/TradingGuardWrapper.tsx
@@ -48,7 +48,8 @@ function TradingGuardWrapperInternal({
   const confirmHyperliquidTerms = useConfirmHyperliquidTerms();
   const requestEnableTradingWithDepositFallback =
     useRequestEnableTradingWithDepositFallback();
-  const { showDepositWithdrawModal } = useShowDepositWithdrawModal();
+  const { showDepositWithdrawModal } =
+    useShowDepositWithdrawModal('tradingGuard');
 
   const shouldShowEnableTrading = useMemo(() => {
     if (bypassEnableTradingGuard) {

--- a/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingButton.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingButton.tsx
@@ -110,7 +110,7 @@ export function PerpTradingButton({
     perpsAccountLoading.selectAccountLoading,
   ]);
   const { showDepositWithdrawModal, isDepositDisabled } =
-    useShowDepositWithdrawModal();
+    useShowDepositWithdrawModal('tradingPanel');
 
   const handleDepositFromToast = useCallback(() => {
     void showDepositWithdrawModal('deposit');

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -59,7 +59,6 @@ import type {
   TPerpTradePriceMode,
   TPerpTradeValidationState,
 } from '@onekeyhq/shared/src/logger/scopes/perp/type';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   SCALE_ORDER_MAX_COUNT,
   SCALE_ORDER_MIN_COUNT,
@@ -121,10 +120,13 @@ import {
 import { getScaleOrderValidationErrorMessage } from '../../utils/scaleOrderValidation';
 import { getTradingButtonStyleValues } from '../../utils/styleUtils';
 
+import {
+  type ISizeInputMinimumOrderAction,
+  getMinimumOrderToastActionProps,
+} from './inputs/SizeInput';
 import { showEnableTradingStepsDialog } from './modals/EnableTradingStepsDialog';
 import { showOrderConfirmDialog } from './modals/OrderConfirmModal';
 
-import type { ISizeInputMinimumOrderAction } from './inputs/SizeInput';
 import type { LayoutChangeEvent } from 'react-native';
 
 const TWAP_MIN_DURATION_MINUTES = 5;
@@ -139,26 +141,6 @@ interface ITradingButtonGroupProps {
   minimumOrderActionRef?: MutableRefObject<
     ISizeInputMinimumOrderAction | undefined
   >;
-}
-
-function getMinimumOrderToastActionProps(
-  action?: ISizeInputMinimumOrderAction,
-  actionLabel?: string,
-) {
-  if (platformEnv.isNative || !action || !actionLabel) return {};
-  return {
-    actionsAlign: 'left' as const,
-    actions: (
-      <Button
-        testID="perp-minimum-order-toast-action"
-        size="small"
-        variant="primary"
-        onPress={action.onPress}
-      >
-        {actionLabel}
-      </Button>
-    ),
-  };
 }
 
 function IpRestrictedSingleButton({ isMobile }: { isMobile: boolean }) {

--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -484,7 +484,7 @@ function SideButtonInternal({
   const requestEnableTradingWithDepositFallback =
     useRequestEnableTradingWithDepositFallback();
   const { showDepositWithdrawModal, isDepositDisabled } =
-    useShowDepositWithdrawModal();
+    useShowDepositWithdrawModal('tradingPanel');
   const handleDepositFromToast = useCallback(() => {
     void showDepositWithdrawModal('deposit');
   }, [showDepositWithdrawModal]);
@@ -1856,7 +1856,8 @@ function EmptySizeSideButton({
   const confirmHyperliquidTerms = useConfirmHyperliquidTerms();
   const requestEnableTradingWithDepositFallback =
     useRequestEnableTradingWithDepositFallback();
-  const { showDepositWithdrawModal } = useShowDepositWithdrawModal();
+  const { showDepositWithdrawModal } =
+    useShowDepositWithdrawModal('tradingPanel');
   const perpsAccountKey = useMemo(
     () => getPerpsAccountKey(perpsAccount),
     [perpsAccount],

--- a/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/components/PerpsHeaderRight.tsx
@@ -111,7 +111,7 @@ function DepositButton() {
   const [activeAccount] = usePerpsActiveAccountAtom();
   const { showPortfolio } = useShowPortfolio();
   const { showDepositWithdrawModal, isDepositDisabled } =
-    useShowDepositWithdrawModal();
+    useShowDepositWithdrawModal('header');
   const lastAccountValueRef = useRef<
     | {
         accountKey: string;

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.test.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.test.tsx
@@ -1,0 +1,70 @@
+/* eslint-disable import/first */
+
+import { act, render } from '@testing-library/react-native';
+
+import type { IPerpsActiveAssetAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { EPerpsSizeInputMode } from '@onekeyhq/shared/types/hyperliquid';
+
+import { type ISizeInputMinimumOrderAction, SizeInput } from './SizeInput';
+
+const mockSetTradingPreferences = jest.fn();
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }, values?: Record<string, string>) =>
+      `${id}:${values?.amount ?? ''}`,
+  }),
+}));
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms', () => ({
+  usePerpsTradingPreferencesAtom: () => [
+    { sizeInputUnit: 'usd' },
+    mockSetTradingPreferences,
+  ],
+}));
+
+jest.mock('../selectors/SizeInputModeSelector', () => ({
+  SizeInputModeSelector: () => null,
+}));
+
+jest.mock('./TradingFormInput', () => ({
+  TradingFormInput: () => null,
+}));
+
+describe('SizeInput minimum order action', () => {
+  it('switches a slider value to the precision-safe minimum manual value', () => {
+    const onChange = jest.fn();
+    const onRequestManualMode = jest.fn();
+    const minimumOrderActionRef: {
+      current: ISizeInputMinimumOrderAction | undefined;
+    } = { current: undefined };
+
+    render(
+      <SizeInput
+        value=""
+        side="long"
+        symbol="NVDA"
+        onChange={onChange}
+        activeAsset={
+          {
+            universe: { szDecimals: 1 },
+          } as IPerpsActiveAssetAtom
+        }
+        isAssetCtxReady
+        referencePrice="3.39"
+        sizeInputMode={EPerpsSizeInputMode.SLIDER}
+        sliderPercent={11}
+        onRequestManualMode={onRequestManualMode}
+        leverage={20}
+        minimumOrderActionRef={minimumOrderActionRef}
+      />,
+    );
+
+    expect(minimumOrderActionRef.current?.amountLabel).toBe('$10.17');
+
+    act(() => minimumOrderActionRef.current?.onPress());
+
+    expect(onRequestManualMode).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('3');
+  });
+});

--- a/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/inputs/SizeInput.tsx
@@ -12,11 +12,18 @@ import type { MutableRefObject, Ref } from 'react';
 import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
-import { Divider, Icon, SizableText, XStack } from '@onekeyhq/components';
+import {
+  Button,
+  Divider,
+  Icon,
+  SizableText,
+  XStack,
+} from '@onekeyhq/components';
 import type { IInputRef } from '@onekeyhq/components';
 import type { IPerpsActiveAssetAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { usePerpsTradingPreferencesAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import {
   formatWithPrecision,
   validateSizeInput,
@@ -47,6 +54,26 @@ export type ISizeInputMinimumOrderAction = {
   label: string;
   onPress: () => void;
 };
+
+export function getMinimumOrderToastActionProps(
+  action?: ISizeInputMinimumOrderAction,
+  actionLabel?: string,
+) {
+  if (platformEnv.isNativeIOS || !action || !actionLabel) return {};
+  return {
+    actionsAlign: 'left' as const,
+    actions: (
+      <Button
+        testID="perp-minimum-order-toast-action"
+        size="small"
+        variant="primary"
+        onPress={action.onPress}
+      >
+        {actionLabel}
+      </Button>
+    ),
+  };
+}
 
 interface ISizeInputProps {
   testID?: string;
@@ -390,14 +417,8 @@ export const SizeInput = memo(
       return () => clearTimeout(timer);
     }, [isUserTyping]);
 
-    const handleInputChange = useCallback(
+    const applyManualInputValue = useCallback(
       (newValue: string) => {
-        if (isSliderMode) {
-          setTokenAmount('');
-          onChange('');
-          return;
-        }
-
         setIsUserTyping(true);
         onRequestManualMode?.();
 
@@ -436,7 +457,6 @@ export const SizeInput = memo(
         }
       },
       [
-        isSliderMode,
         inputMode,
         onChange,
         onDisplayValueChange,
@@ -446,8 +466,20 @@ export const SizeInput = memo(
       ],
     );
 
+    const handleInputChange = useCallback(
+      (newValue: string) => {
+        if (isSliderMode) {
+          setTokenAmount('');
+          onChange('');
+          return;
+        }
+        applyManualInputValue(newValue);
+      },
+      [applyManualInputValue, isSliderMode, onChange],
+    );
+
     const minimumOrderSuggestion = useMemo(() => {
-      if (!hasValidPrice || isDisabled || isSliderMode) return undefined;
+      if (!hasValidPrice || isDisabled) return undefined;
 
       const tokenValue = new BigNumber(MINIMUM_ORDER_NOTIONAL)
         .dividedBy(priceBN)
@@ -471,7 +503,6 @@ export const SizeInput = memo(
       hasValidPrice,
       inputMode,
       isDisabled,
-      isSliderMode,
       leverageBN,
       priceBN,
       symbol,
@@ -488,10 +519,10 @@ export const SizeInput = memo(
                 { amount: minimumOrderSuggestion.label },
               ),
               onPress: () =>
-                handleInputChange(minimumOrderSuggestion.displayValue),
+                applyManualInputValue(minimumOrderSuggestion.displayValue),
             }
           : undefined,
-      [handleInputChange, intl, minimumOrderSuggestion],
+      [applyManualInputValue, intl, minimumOrderSuggestion],
     );
     useLayoutEffect(() => {
       if (!minimumOrderActionRef) return;

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/DepositWithdrawModal.tsx
@@ -58,6 +58,7 @@ import { PERPS_NETWORK_ID } from '@onekeyhq/shared/src/consts/perp';
 import { dismissKeyboardWithDelay } from '@onekeyhq/shared/src/keyboard';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import type { TPerpDepositErrorStage } from '@onekeyhq/shared/src/logger/scopes/perp/type';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import type { IModalPerpParamList } from '@onekeyhq/shared/src/routes/perp';
@@ -76,12 +77,16 @@ import {
   WITHDRAW_FEE,
 } from '@onekeyhq/shared/types/hyperliquid/perp.constants';
 import { swapDefaultSetTokens } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
-import type { ISwapNativeTokenConfig } from '@onekeyhq/shared/types/swap/types';
+import {
+  ESwapTxHistoryStatus,
+  type ISwapNativeTokenConfig,
+} from '@onekeyhq/shared/types/swap/types';
 import type { ISendTxOnSuccessData } from '@onekeyhq/shared/types/tx';
 
 import usePerpDeposit from '../../../hooks/usePerpDeposit';
 import { PerpsAccountSelectorProviderMirror } from '../../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
+import { getPerpDepositErrorCode } from '../../../utils/perpDepositAnalytics';
 import { preloadPerpsDepositSelectTokenModal } from '../../../utils/preloadPerpsDepositSelectTokenModal';
 import {
   PERP_DIALOG_BUTTON_SIZE,
@@ -1334,6 +1339,40 @@ function DepositWithdrawContent({
       }
     }
 
+    const directDepositAmount = tokenAmount || amount;
+    const directDepositToken =
+      currentPerpsDepositSelectedTokenRef.current ??
+      ({
+        networkId: PERPS_NETWORK_ID,
+        contractAddress: USDC_TOKEN_INFO.address,
+        name: USDC_TOKEN_INFO.name,
+        symbol: USDC_TOKEN_INFO.symbol,
+        decimals: USDC_TOKEN_INFO.decimals,
+        networkLogoURI:
+          swapDefaultSetTokens[PERPS_NETWORK_ID].toToken?.networkLogoURI ?? '',
+      } satisfies IPerpsDepositToken);
+    let directDepositResultLogged = false;
+    let directDepositErrorStage: TPerpDepositErrorStage = 'build';
+    const logDirectDepositFailure = (
+      errorStage: TPerpDepositErrorStage,
+      errorCode: string,
+    ) => {
+      if (directDepositResultLogged) {
+        return;
+      }
+      directDepositResultLogged = true;
+      defaultLogger.perp.deposit.perpDepositInitiate({
+        walletType: selectedAccount.walletType ?? 'unknown',
+        token: directDepositToken,
+        amount: directDepositAmount,
+        toAmount: directDepositAmount,
+        depositRoute: 'directArbitrum',
+        status: ESwapTxHistoryStatus.FAILED,
+        errorStage,
+        errorCode,
+      });
+    };
+
     try {
       if (isDepositQuotePendingDebounce) {
         return;
@@ -1353,30 +1392,30 @@ function DepositWithdrawContent({
         if (isArbitrumUsdcToken) {
           await normalizeTxConfirm({
             onSuccess: async (data: ISendTxOnSuccessData[]) => {
-              await backgroundApiProxy.serviceHyperliquid.checkPerpsAccountStatus();
               if (data?.[0]) {
                 const fromTxId = data[0].signedTx.txid;
-                const usdcToken = {
-                  networkId: PERPS_NETWORK_ID,
-                  contractAddress: USDC_TOKEN_INFO.address,
-                  name: USDC_TOKEN_INFO.name,
-                  symbol: USDC_TOKEN_INFO.symbol,
-                  decimals: USDC_TOKEN_INFO.decimals,
-                  networkLogoURI:
-                    swapDefaultSetTokens[PERPS_NETWORK_ID].toToken
-                      ?.networkLogoURI ?? '',
-                };
-                const depositAmount = tokenAmount || amount;
                 void handlePerpDepositTxSuccess({
-                  fromToken:
-                    currentPerpsDepositSelectedTokenRef.current ?? usdcToken,
+                  fromToken: directDepositToken,
                   fromTxId,
-                  toAmount: depositAmount,
-                  fromAmount: depositAmount,
+                  toAmount: directDepositAmount,
+                  fromAmount: directDepositAmount,
                   isArbUSDCOrder: true,
                   skipToast: true,
                 });
+                directDepositResultLogged = true;
+                defaultLogger.perp.deposit.perpDepositInitiate({
+                  walletType: selectedAccount.walletType ?? 'unknown',
+                  token: directDepositToken,
+                  amount: directDepositAmount,
+                  toAmount: directDepositAmount,
+                  depositRoute: 'directArbitrum',
+                  status: ESwapTxHistoryStatus.SUCCESS,
+                  txId: fromTxId,
+                });
+              } else {
+                logDirectDepositFailure('broadcast', 'txidNotFound');
               }
+              await backgroundApiProxy.serviceHyperliquid.checkPerpsAccountStatus();
               void backgroundApiProxy.serviceHyperliquidSubscription.enableLedgerUpdatesSubscription();
               onClose?.();
             },
@@ -1384,12 +1423,22 @@ function DepositWithdrawContent({
               {
                 from: selectedAccount.accountAddress,
                 to: HYPERLIQUID_DEPOSIT_ADDRESS,
-                amount: tokenAmount || amount,
+                amount: directDepositAmount,
                 tokenInfo: USDC_TOKEN_INFO,
               },
             ],
             gasAccountScenario: 'perps',
+            onFail: (error) => {
+              logDirectDepositFailure(
+                directDepositErrorStage,
+                getPerpDepositErrorCode(error),
+              );
+            },
+            onCancel: () => {
+              logDirectDepositFailure('sign', 'userRejected');
+            },
           });
+          directDepositErrorStage = 'sign';
         } else {
           await buildPerpDepositTx();
           void backgroundApiProxy.serviceHyperliquidSubscription.enableLedgerUpdatesSubscription();
@@ -1405,6 +1454,13 @@ function DepositWithdrawContent({
         onClose?.();
       }
     } catch (error) {
+      if (
+        selectedAction === 'deposit' &&
+        isArbitrumUsdcToken &&
+        !directDepositResultLogged
+      ) {
+        logDirectDepositFailure('build', getPerpDepositErrorCode(error));
+      }
       console.error(`[DepositWithdrawModal.${selectedAction}] Failed:`, error);
       throw error;
     } finally {
@@ -1415,6 +1471,7 @@ function DepositWithdrawContent({
     checkAccountSupport,
     selectedAccount.accountAddress,
     selectedAccount.accountId,
+    selectedAccount.walletType,
     validateAmountBeforeSubmit,
     selectedAction,
     checkDepositWalletNotBackedUp,

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldDepositTransferModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/MobileUnifoldDepositTransferModal.tsx
@@ -181,6 +181,10 @@ export default function MobileUnifoldDepositTransferModal() {
             ref={transferContentRef}
             expectedRecipient={expectedRecipient}
             onOpenTracker={openTracker}
+            analyticsEntrySource={route.params?.analyticsEntrySource}
+            trackDefaultSourceSelection={
+              !route.params?.openSourceSelectorOnReady
+            }
             sourceSelectorResult={route.params?.sourceSelectorResult}
             onSourceSelectorResultHandled={clearSourceSelectorResult}
             onSourceSelectorReady={prepareInitialSourceSelector}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/UnifoldSourceSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/UnifoldSourceSelector.tsx
@@ -460,9 +460,12 @@ export function UnifoldSourceSelector({
             dashThickness={0.5}
             textAlign="right"
             flexShrink={0}
-            tooltip={intl.formatMessage({
-              id: ETranslations.perp_unifold_minimum_deposit_network__desc,
-            })}
+            tooltip={intl.formatMessage(
+              {
+                id: ETranslations.perp_unifold_minimum_deposit_network__desc,
+              },
+              { amount: `$${minUsd}` },
+            )}
             tooltipTitle={intl.formatMessage({
               id: ETranslations.perp_unifold_minimum_deposit__title,
             })}

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/UnifoldTransferContent.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/UnifoldTransferContent.tsx
@@ -1,6 +1,7 @@
 // cspell: words unifold Unifold hypercore Hypercore
 import {
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -34,9 +35,15 @@ import type {
   IUnifoldDepositErrorType,
   IUnifoldSourceSelection,
 } from '@onekeyhq/kit/src/views/Perp/hooks/usePerpsUnifoldDepositSession';
+import { usePerpsActiveAccountAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { getPresetNetworks } from '@onekeyhq/shared/src/config/presetNetworks';
 import { UNIFOLD_THIRD_PARTY_CONVERSION_FEE_PERCENT } from '@onekeyhq/shared/src/consts/perp';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import type {
+  TPerpDepositAddressSelectionSource,
+  TPerpDepositEntrySource,
+} from '@onekeyhq/shared/src/logger/scopes/perp/type';
 import type { IUnifoldSourceSelectorResult } from '@onekeyhq/shared/src/routes/perp';
 import { parseUnifoldExecutionCreatedAtMs } from '@onekeyhq/shared/src/utils/unifoldDepositUtils';
 import type {
@@ -327,6 +334,8 @@ export const UnifoldTransferContent = forwardRef<
     onSourceSelectorUnavailable?: () => void;
     onOpenMobileTokenSelector?: () => void;
     onOpenMobileChainSelector?: () => void;
+    analyticsEntrySource?: TPerpDepositEntrySource;
+    trackDefaultSourceSelection?: boolean;
   }
 >(
   (
@@ -344,10 +353,13 @@ export const UnifoldTransferContent = forwardRef<
       onSourceSelectorUnavailable,
       onOpenMobileTokenSelector,
       onOpenMobileChainSelector,
+      analyticsEntrySource,
+      trackDefaultSourceSelection = false,
     },
     ref,
   ) => {
     const intl = useIntl();
+    const [activePerpsAccount] = usePerpsActiveAccountAtom();
     const {
       recipientAddress,
       isLiveAccountAligned,
@@ -375,7 +387,78 @@ export const UnifoldTransferContent = forwardRef<
     );
     const [historyCardNow, setHistoryCardNow] = useState(() => Date.now());
 
-    useImperativeHandle(ref, () => ({ selectSource }), [selectSource]);
+    const lastTrackedSourceRef = useRef<string | null>(null);
+    const trackSourceSelection = useCallback(
+      (
+        asset: IUnifoldSupportedAsset,
+        chain: IUnifoldSupportedAssetChain,
+        selectionSource: TPerpDepositAddressSelectionSource,
+      ) => {
+        if (!analyticsEntrySource) {
+          return;
+        }
+        const sourceKey = [asset.symbol, chain.chain_type, chain.chain_id].join(
+          ':',
+        );
+        if (lastTrackedSourceRef.current === sourceKey) {
+          return;
+        }
+        lastTrackedSourceRef.current = sourceKey;
+        defaultLogger.perp.deposit.perpDepositAddressSourceSelect({
+          entrySource: analyticsEntrySource,
+          walletType: activePerpsAccount.walletType ?? 'unknown',
+          sourceTokenSymbol: asset.symbol,
+          sourceChainType: chain.chain_type,
+          sourceChainId: chain.chain_id,
+          sourceChainName: chain.chain_name,
+          selectionSource,
+        });
+      },
+      [activePerpsAccount.walletType, analyticsEntrySource],
+    );
+
+    const handleSelectToken = useCallback(
+      (asset: IUnifoldSupportedAsset) => {
+        const chain =
+          asset.chains.find(
+            (item) => item.chain_id === selection?.chain.chain_id,
+          ) ?? asset.chains[0];
+        selectToken(asset);
+        if (chain) {
+          trackSourceSelection(asset, chain, 'user');
+        }
+      },
+      [selectToken, selection?.chain.chain_id, trackSourceSelection],
+    );
+
+    const handleSelectChain = useCallback(
+      (chain: IUnifoldSupportedAssetChain) => {
+        selectChain(chain);
+        if (selection?.asset) {
+          trackSourceSelection(selection.asset, chain, 'user');
+        }
+      },
+      [selectChain, selection?.asset, trackSourceSelection],
+    );
+
+    const handleSelectSource = useCallback(
+      (asset: IUnifoldSupportedAsset, chain: IUnifoldSupportedAssetChain) => {
+        selectSource(asset, chain);
+        trackSourceSelection(asset, chain, 'user');
+      },
+      [selectSource, trackSourceSelection],
+    );
+
+    useImperativeHandle(ref, () => ({ selectSource: handleSelectSource }), [
+      handleSelectSource,
+    ]);
+
+    useEffect(() => {
+      if (!trackDefaultSourceSelection || !selection) {
+        return;
+      }
+      trackSourceSelection(selection.asset, selection.chain, 'default');
+    }, [selection, trackDefaultSourceSelection, trackSourceSelection]);
 
     useEffect(() => {
       if (!supportedAssets || !selection) {
@@ -431,16 +514,17 @@ export const UnifoldTransferContent = forwardRef<
         onSourceSelectorResultHandled?.();
         return;
       }
-      selectToken(asset);
       if (chain) {
-        selectChain(chain);
+        handleSelectSource(asset, chain);
+      } else {
+        handleSelectToken(asset);
       }
       onSourceSelectorResultHandled?.();
     }, [
+      handleSelectSource,
+      handleSelectToken,
       intl,
       onSourceSelectorResultHandled,
-      selectChain,
-      selectToken,
       sourceSelectorResult,
       supportedAssets,
     ]);
@@ -664,8 +748,8 @@ export const UnifoldTransferContent = forwardRef<
           assets={supportedAssets}
           selection={displaySelection}
           loading={Boolean(assetsLoading && !selection)}
-          onSelectToken={selectToken}
-          onSelectChain={selectChain}
+          onSelectToken={handleSelectToken}
+          onSelectChain={handleSelectChain}
           onOpenMobileTokenSelector={onOpenMobileTokenSelector}
           onOpenMobileChainSelector={onOpenMobileChainSelector}
         />

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/showUnifoldDepositModals.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/UnifoldDeposit/showUnifoldDepositModals.tsx
@@ -20,6 +20,7 @@ import {
   usePerpsDepositTokensAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type { TPerpDepositEntrySource } from '@onekeyhq/shared/src/logger/scopes/perp/type';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { getUnifoldDesktopDialogBodyMaxHeight } from './unifoldDialogLayout';
@@ -64,9 +65,11 @@ function useDesktopDialogBodyMaxHeight() {
 function DesktopTransferBody({
   expectedRecipient,
   onOpenTracker,
+  analyticsEntrySource,
 }: {
   expectedRecipient: string;
   onOpenTracker: () => void;
+  analyticsEntrySource?: TPerpDepositEntrySource;
 }) {
   const bodyMaxHeight = useDesktopDialogBodyMaxHeight();
   return (
@@ -74,6 +77,8 @@ function DesktopTransferBody({
       expectedRecipient={expectedRecipient}
       bodyMaxHeight={bodyMaxHeight}
       onOpenTracker={onOpenTracker}
+      analyticsEntrySource={analyticsEntrySource}
+      trackDefaultSourceSelection
       useDialogHeader
     />
   );
@@ -423,10 +428,12 @@ export function showUnifoldTransferDialog({
   dialogInTab,
   expectedRecipient,
   intl,
+  analyticsEntrySource,
 }: {
   dialogInTab: IDialogInTab;
   expectedRecipient: string;
   intl: IntlShape;
+  analyticsEntrySource?: TPerpDepositEntrySource;
 }) {
   // The whole UnifoldDeposit module already sits behind the deposit-entry
   // lazy chunk (preloadPerpsUnifoldDeposit), so static imports are fine here.
@@ -442,6 +449,7 @@ export function showUnifoldTransferDialog({
           dialogInTab,
           expectedRecipient,
           intl,
+          analyticsEntrySource,
         });
       },
       onBackPress: () => {
@@ -449,6 +457,7 @@ export function showUnifoldTransferDialog({
           dialogInTab,
           expectedRecipient,
           intl,
+          analyticsEntrySource,
         });
       },
     });
@@ -467,6 +476,7 @@ export function showUnifoldTransferDialog({
     renderContent: (
       <DesktopTransferBody
         expectedRecipient={expectedRecipient}
+        analyticsEntrySource={analyticsEntrySource}
         onOpenTracker={() => {
           void handleOpenTracker();
         }}

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
@@ -179,7 +179,8 @@ export function LimitOrderForm({
   const confirmHyperliquidTerms = useConfirmHyperliquidTerms();
   const requestEnableTradingWithDepositFallback =
     useRequestEnableTradingWithDepositFallback();
-  const { showDepositWithdrawModal } = useShowDepositWithdrawModal();
+  const { showDepositWithdrawModal } =
+    useShowDepositWithdrawModal('tradingPanel');
 
   // Spot has its own asset/balance atoms; perpsActiveAssetAtom is stale-perp
   // when the active instrument is spot.

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
@@ -16,7 +16,7 @@ import {
   resetToRoute,
   useMedia,
 } from '@onekeyhq/components';
-import type { IButtonProps } from '@onekeyhq/components';
+import type { IButtonProps, IInputRef } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { AccountSelectorCreateAddressButton } from '@onekeyhq/kit/src/components/AccountSelector/AccountSelectorCreateAddressButton';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
@@ -41,6 +41,7 @@ import {
   usePerpsActiveAssetCtxReadyAtom,
   usePerpsActiveAssetDataAtom,
   usePerpsCustomSettingsAtom,
+  usePerpsTradingPreferencesAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   useSpotActiveAssetAtom,
@@ -86,6 +87,7 @@ import { shouldShowOrderConfirm } from '../../../utils/aggressiveLimitPrice';
 import { getEnableTradingDialogConfirmDecision } from '../../../utils/enableTradingDialogConfirm';
 import { shouldApplyMinimumOrderGuard } from '../../../utils/minimumOrderGuard';
 import { shouldBlockPerpsTradingForMarketData } from '../../../utils/perpsMarketDataFreshness';
+import { shouldDisablePerpsOrderPanelTradingButtonForAccountLoading } from '../../../utils/perpsOrderPanelEnableTrading';
 import { resolveTpSlTriggerPx } from '../../../utils/resolveTpSlTriggerPx';
 import {
   getTradingButtonStyleValues,
@@ -96,7 +98,11 @@ import { PERP_MOBILE_DIALOG_CONTENT_CONTAINER_PROPS } from '../../PerpDialogLayo
 import { PerpsSlider } from '../../PerpsSlider';
 import { PerpsAccountNumberValue } from '../components/PerpsAccountNumberValue';
 import { PriceInput } from '../inputs/PriceInput';
-import { SizeInput } from '../inputs/SizeInput';
+import {
+  type ISizeInputMinimumOrderAction,
+  SizeInput,
+  getMinimumOrderToastActionProps,
+} from '../inputs/SizeInput';
 import { TpSlFormInput } from '../inputs/TpSlFormInput';
 import { showEnableTradingStepsDialog } from '../modals/EnableTradingStepsDialog';
 import { showOrderConfirmDialog } from '../modals/OrderConfirmModal';
@@ -179,11 +185,16 @@ export function LimitOrderForm({
   // when the active instrument is spot.
   const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const [perpsCustomSettings] = usePerpsCustomSettingsAtom();
+  const [tradingPreferences] = usePerpsTradingPreferencesAtom();
   const hyperliquidActions = useHyperliquidActions();
   // Prevents a double press from double-submitting on the direct (skip-confirm)
   // path; the dialog path is already serialized by the dialog itself.
   const isDirectPlacingRef = useRef(false);
   const isSpot = activeTradeInstrument.mode === 'spot';
+  const resolvedSizeInputUnit =
+    isSpot && tradingPreferences.sizeInputUnit === 'margin'
+      ? 'usd'
+      : tradingPreferences.sizeInputUnit;
   const [spotActiveAsset] = useSpotActiveAssetAtom();
   const [isSpotActiveAssetCtxReady] = useSpotActiveAssetCtxReadyAtom();
   const [{ balances: spotBalances }] = useSpotBalancesAtom();
@@ -214,6 +225,10 @@ export function LimitOrderForm({
   const [tpValue, setTpValue] = useState('');
   const [slType, setSlType] = useState<'price' | 'percentage'>('price');
   const [slValue, setSlValue] = useState('');
+  const sizeInputRef = useRef<IInputRef>(null);
+  const minimumOrderActionRef = useRef<
+    ISizeInputMinimumOrderAction | undefined
+  >(undefined);
 
   const isBBOActive = Boolean(bboPriceMode);
 
@@ -442,22 +457,28 @@ export function LimitOrderForm({
   }, [isSpot, spotHoldingBaseBN, spotUniverse?.baseName]);
   const sideStats = useMemo(() => {
     const buildStats = (targetSide: ITradeSide) => {
-      if (isSpot) {
-        return {
-          liquidationPriceBN: null,
-          marginRequiredBN: new BigNumber(0),
-        };
-      }
-
       const sidePriceBN = resolvePriceForSide(targetSide).price;
       const sideSizeBN = computeSizeBN(targetSide, sidePriceBN);
-      const sideMarginRequiredBN =
+      const sideOrderValueBN =
         !sideSizeBN.isFinite() ||
         sideSizeBN.lte(0) ||
         !sidePriceBN.isFinite() ||
         sidePriceBN.lte(0)
           ? new BigNumber(0)
-          : sideSizeBN.multipliedBy(sidePriceBN).dividedBy(leverage || 1);
+          : sideSizeBN.multipliedBy(sidePriceBN);
+
+      if (isSpot) {
+        return {
+          liquidationPriceBN: null,
+          marginRequiredBN: new BigNumber(0),
+          orderValueBN: sideOrderValueBN,
+          sizeBN: sideSizeBN,
+        };
+      }
+
+      const sideMarginRequiredBN = sideOrderValueBN.isZero()
+        ? new BigNumber(0)
+        : sideOrderValueBN.dividedBy(leverage || 1);
 
       const sideLiquidationPriceBN =
         !activeAssetData?.leverage?.type ||
@@ -499,6 +520,8 @@ export function LimitOrderForm({
           ? sideLiquidationPriceBN
           : null,
         marginRequiredBN: sideMarginRequiredBN,
+        orderValueBN: sideOrderValueBN,
+        sizeBN: sideSizeBN,
       };
     };
 
@@ -520,6 +543,29 @@ export function LimitOrderForm({
     resolvePriceForSide,
   ]);
 
+  const buttonSecondaryText = useMemo(() => {
+    const formatSecondaryText = (stats: (typeof sideStats)[ITradeSide]) => {
+      if (stats.orderValueBN.isZero() || !stats.orderValueBN.isFinite()) {
+        return null;
+      }
+
+      if (resolvedSizeInputUnit === 'usd') {
+        return `≈ $${stats.orderValueBN
+          .decimalPlaces(2, BigNumber.ROUND_DOWN)
+          .toFixed(2)}`;
+      }
+
+      return `${stats.sizeBN
+        .decimalPlaces(szDecimals, BigNumber.ROUND_DOWN)
+        .toFixed(szDecimals)} ${displayName}`;
+    };
+
+    return {
+      long: formatSecondaryText(sideStats.long),
+      short: formatSecondaryText(sideStats.short),
+    };
+  }, [displayName, resolvedSizeInputUnit, sideStats, szDecimals]);
+
   const shouldShowEnableTrading = useMemo(
     () => isAgentReady === false || !perpsAccountStatus.canTrade,
     [isAgentReady, perpsAccountStatus.canTrade],
@@ -528,8 +574,17 @@ export function LimitOrderForm({
     perpsAccountLoading.selectAccountLoading ||
     perpsAccountLoading.enableTradingLoading,
   );
+  const shouldDisableForAccountLoading =
+    shouldDisablePerpsOrderPanelTradingButtonForAccountLoading({
+      selectAccountLoading: perpsAccountLoading.selectAccountLoading,
+      enableTradingLoading: perpsAccountLoading.enableTradingLoading,
+      enableTradingTriggered: perpsAccountLoading.enableTradingTriggered,
+      enableTradingStatusPending:
+        perpsAccountLoading.enableTradingStatusPending,
+      isLiveStatusPending: false,
+    });
   const shouldDisableActionButtons = Boolean(
-    isTradingActionLoading || perpsAccountStatus.accountNotSupport,
+    shouldDisableForAccountLoading || perpsAccountStatus.accountNotSupport,
   );
   const accountActionType = useMemo(
     () =>
@@ -749,8 +804,31 @@ export function LimitOrderForm({
     [slType, slValue, tpType, tpValue],
   );
 
+  const requestSizeInputFocus = useCallback(() => {
+    if (!platformEnv.isNative) return;
+    requestAnimationFrame(() => sizeInputRef.current?.focus());
+  }, []);
+
+  const showMinimumOrderToast = useCallback(() => {
+    const minimumOrderAction = minimumOrderActionRef.current;
+    Toast.message({
+      title: intl.formatMessage(
+        { id: ETranslations.perp_size_least },
+        { amount: minimumOrderAction?.amountLabel ?? '$10' },
+      ),
+      ...getMinimumOrderToastActionProps(
+        minimumOrderAction,
+        intl.formatMessage({
+          id: ETranslations.fill_minimum_amount__action,
+        }),
+      ),
+    });
+    requestSizeInputFocus();
+  }, [intl, requestSizeInputFocus]);
+
   const handlePlace = useCallback(
     async (pressedSide: ITradeSide) => {
+      setSide(pressedSide);
       const isTradingReady = await ensureEnableTrading();
       if (!isTradingReady) {
         return;
@@ -765,8 +843,6 @@ export function LimitOrderForm({
         onClose();
         return;
       }
-
-      setSide(pressedSide);
 
       // Same blocks as the main panel (validateOrderPanelState): the order
       // ticket holds independent state, so it must enforce them itself instead
@@ -826,12 +902,7 @@ export function LimitOrderForm({
         orderValueBN.gt(0) &&
         orderValueBN.lt(10)
       ) {
-        Toast.message({
-          title: intl.formatMessage(
-            { id: ETranslations.perp_size_least },
-            { amount: '$10' },
-          ),
-        });
+        showMinimumOrderToast();
         return;
       }
 
@@ -980,6 +1051,7 @@ export function LimitOrderForm({
       perpsCustomSettings.skipOrderConfirm,
       reduceOnly,
       resolvePriceForSide,
+      showMinimumOrderToast,
       sizeInputMode,
       sizePercent,
       slType,
@@ -1017,6 +1089,7 @@ export function LimitOrderForm({
       pressBg,
       textColor,
       defaultText,
+      secondaryText,
       onDefaultPress,
     }: {
       sideKey: ITradeSide;
@@ -1025,6 +1098,7 @@ export function LimitOrderForm({
       pressBg: ColorTokens;
       textColor: ColorTokens;
       defaultText: string;
+      secondaryText: string | null;
       onDefaultPress: () => void;
     }) => {
       return (
@@ -1038,13 +1112,34 @@ export function LimitOrderForm({
           pressStyle={shouldDisableActionButtons ? undefined : { bg: pressBg }}
           onPress={onDefaultPress}
           disabled={shouldDisableActionButtons}
-          disabledStyle={{ opacity: 1, bg }}
+          disabledStyle={
+            shouldDisableActionButtons ? { opacity: 1, bg } : undefined
+          }
           opacity={shouldDisableActionButtons ? 1 : undefined}
           h={36}
+          py={secondaryText ? '$0.5' : undefined}
         >
-          <SizableText size="$bodyMdMedium" color={textColor}>
-            {defaultText}
-          </SizableText>
+          <YStack alignItems="center" gap={2} minWidth={0}>
+            <SizableText
+              size="$bodyMdMedium"
+              lineHeight={18}
+              color={textColor}
+              numberOfLines={1}
+            >
+              {defaultText}
+            </SizableText>
+            {secondaryText ? (
+              <SizableText
+                fontSize={11}
+                lineHeight={11}
+                color={textColor}
+                opacity={0.8}
+                numberOfLines={1}
+              >
+                {secondaryText}
+              </SizableText>
+            ) : null}
+          </YStack>
         </Button>
       );
     },
@@ -1195,6 +1290,8 @@ export function LimitOrderForm({
         onRequestManualMode={switchToManual}
         allowMarginInput={!isSpot}
         leverage={leverage}
+        inputRef={sizeInputRef}
+        minimumOrderActionRef={minimumOrderActionRef}
       />
       <PerpsSlider
         min={0}
@@ -1330,7 +1427,7 @@ export function LimitOrderForm({
         </YStack>
       ) : (
         <XStack gap="$2.5" {...(!isSpot && { mt: '$1.5' })}>
-          <YStack flex={1} gap="$2">
+          <YStack flex={1} flexBasis={0} minWidth={0} gap="$2">
             {renderActionButton({
               sideKey: 'long',
               bg: longButtonStyles.bg,
@@ -1342,6 +1439,7 @@ export function LimitOrderForm({
                   ? ETranslations.dexmarket_details_transactions_buy
                   : ETranslations.perp_trade_long,
               }),
+              secondaryText: buttonSecondaryText.long,
               onDefaultPress: () => void handlePlace('long'),
             })}
             {!isSpot ? (
@@ -1399,7 +1497,7 @@ export function LimitOrderForm({
               </YStack>
             ) : null}
           </YStack>
-          <YStack flex={1} gap="$2">
+          <YStack flex={1} flexBasis={0} minWidth={0} gap="$2">
             {renderActionButton({
               sideKey: 'short',
               bg: shortButtonStyles.bg,
@@ -1411,6 +1509,7 @@ export function LimitOrderForm({
                   ? ETranslations.dexmarket_details_transactions_sell
                   : ETranslations.perp_trade_short,
               }),
+              secondaryText: buttonSecondaryText.short,
               onDefaultPress: () => void handlePlace('short'),
             })}
             {!isSpot ? (

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpAccountPanel.tsx
@@ -105,7 +105,7 @@ function PerpAccountPanel() {
   const { copyText } = useClipboard();
   const { showPortfolio } = useShowPortfolio();
   const { showDepositWithdrawModal, isDepositDisabled } =
-    useShowDepositWithdrawModal();
+    useShowDepositWithdrawModal('accountPanel');
 
   const unrealizedPnlInfo = useMemo(() => {
     const pnlBn = new BigNumber(accountSummary?.totalUnrealizedPnl || '0');

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -517,7 +517,7 @@ function PerpTradingForm({
     priceSource: tradingPriceSource,
   });
   const { showDepositWithdrawModal, isDepositDisabled } =
-    useShowDepositWithdrawModal();
+    useShowDepositWithdrawModal('tradingPanel');
   const enableTrading = useEnableTradingWithDepositFallback();
   const { universeByBaseName } = useSpotMetaMaps();
   const perpsPositions = usePerpsAccountScopedActivePositions();

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/PerpTradingForm.tsx
@@ -2891,7 +2891,7 @@ function PerpTradingForm({
               <YStack flex={1} flexBasis={0} minWidth={0}>
                 <LeverageAdjustModal isMobile={isMobile} />
               </YStack>
-              <YStack flex={1} flexBasis={0} minWidth={0}>
+              <YStack flex={1.2} flexBasis={0} minWidth={0}>
                 <AccountModeSelector
                   disabled={isSubmitting}
                   isMobile={isMobile}

--- a/packages/kit/src/views/Perp/hooks/useEnableTradingWithDepositFallback.ts
+++ b/packages/kit/src/views/Perp/hooks/useEnableTradingWithDepositFallback.ts
@@ -49,7 +49,8 @@ export function useRequestEnableTrading() {
 export function useHandleEnableTradingPostStatus() {
   const intl = useIntl();
   const [perpsAccount] = usePerpsActiveAccountAtom();
-  const { showDepositWithdrawModal } = useShowDepositWithdrawModal();
+  const { showDepositWithdrawModal } =
+    useShowDepositWithdrawModal('enableTrading');
 
   return useCallback(
     async (

--- a/packages/kit/src/views/Perp/hooks/usePerpDeposit.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpDeposit.ts
@@ -28,6 +28,7 @@ import {
 import { OneKeyError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import type { TPerpDepositErrorStage } from '@onekeyhq/shared/src/logger/scopes/perp/type';
 import { EScanQrCodeModalPages } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { calculateFeeForSend } from '@onekeyhq/shared/src/utils/feeUtils';
@@ -62,6 +63,7 @@ import type { ISendTxBaseParams } from '@onekeyhq/shared/types/tx';
 
 import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
+import { getPerpDepositErrorCode } from '../utils/perpDepositAnalytics';
 
 import { shouldWaitForPerpsDepositQuoteAccount } from './usePerpDepositUtils';
 
@@ -1210,25 +1212,29 @@ const usePerpDeposit = (
     if (!token?.networkId) {
       throw new OneKeyError('token.networkId is required');
     }
-    const { transferInfo, encodedTx, swapInfo } =
-      await buildQuoteRes(perpDepositQuote);
-    const { unsignedTxArr } = await getApproveUnSignedTxArr(
-      perpDepositQuote?.result,
-    );
-    const gasFeeInfos = await estimateNetworkFee(
-      {
-        networkId: token?.networkId,
-        accountId,
-        transfersInfo: transferInfo ? [transferInfo] : undefined,
-        encodedTx,
-        swapInfo,
-      },
-      unsignedTxArr,
-    );
+    let errorStage: TPerpDepositErrorStage = 'build';
     try {
+      const { transferInfo, encodedTx, swapInfo } =
+        await buildQuoteRes(perpDepositQuote);
+      errorStage = 'approve';
+      const { unsignedTxArr } = await getApproveUnSignedTxArr(
+        perpDepositQuote.result,
+      );
+      errorStage = 'build';
+      const gasFeeInfos = await estimateNetworkFee(
+        {
+          networkId: token.networkId,
+          accountId,
+          transfersInfo: transferInfo ? [transferInfo] : undefined,
+          encodedTx,
+          swapInfo,
+        },
+        unsignedTxArr,
+      );
+      errorStage = 'sign';
       const res = await perpSendTxAction(
         {
-          networkId: token?.networkId,
+          networkId: token.networkId,
           accountId,
           transfersInfo: transferInfo ? [transferInfo] : undefined,
           encodedTx,
@@ -1259,38 +1265,36 @@ const usePerpDeposit = (
           fromAmount: amount,
         });
         defaultLogger.perp.deposit.perpDepositInitiate({
-          userAddress: result?.fromUserAddress ?? '',
-          receiverAddress: result?.perpReceiverAddress ?? '',
           walletType: activePerpsAccount.walletType ?? 'unknown',
           token,
           amount,
           toAmount: perpDepositQuote.result.toAmount,
+          depositRoute: 'relay',
           status: ESwapTxHistoryStatus.SUCCESS,
           txId: res.txid,
         });
       } else {
         defaultLogger.perp.deposit.perpDepositInitiate({
-          userAddress: result?.fromUserAddress ?? '',
-          receiverAddress: result?.perpReceiverAddress ?? '',
           walletType: activePerpsAccount.walletType ?? 'unknown',
           token,
           amount,
           toAmount: perpDepositQuote.result.toAmount,
+          depositRoute: 'relay',
           status: ESwapTxHistoryStatus.FAILED,
-          errorMessage: 'txid not found',
+          errorStage: 'broadcast',
+          errorCode: 'txidNotFound',
         });
       }
-    } catch (e: any) {
+    } catch (error) {
       defaultLogger.perp.deposit.perpDepositInitiate({
-        userAddress: result?.fromUserAddress ?? '',
-        receiverAddress: result?.perpReceiverAddress ?? '',
         walletType: activePerpsAccount.walletType ?? 'unknown',
         token,
         amount,
         toAmount: perpDepositQuote.result.toAmount,
+        depositRoute: 'relay',
         status: ESwapTxHistoryStatus.FAILED,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        errorMessage: e?.message ?? '',
+        errorStage,
+        errorCode: getPerpDepositErrorCode(error),
       });
     }
   }, [
@@ -1305,8 +1309,6 @@ const usePerpDeposit = (
     handlePerpDepositTxSuccess,
     activePerpsAccount.walletType,
     amount,
-    result?.fromUserAddress,
-    result?.perpReceiverAddress,
   ]);
 
   const shouldSignEveryTime = useMemo(() => {

--- a/packages/kit/src/views/Perp/hooks/usePerpDeposit.ts
+++ b/packages/kit/src/views/Perp/hooks/usePerpDeposit.ts
@@ -1296,6 +1296,11 @@ const usePerpDeposit = (
         errorStage,
         errorCode: getPerpDepositErrorCode(error),
       });
+      // Preserve the legacy send/sign behavior while allowing preparation
+      // failures to reach the modal's error handling instead of closing it.
+      if (errorStage === 'build' || errorStage === 'approve') {
+        throw error;
+      }
     }
   }, [
     perpDepositQuote,

--- a/packages/kit/src/views/Perp/hooks/useShowDepositWithdrawModal.ts
+++ b/packages/kit/src/views/Perp/hooks/useShowDepositWithdrawModal.ts
@@ -12,6 +12,8 @@ import {
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { jotaiDefaultStore } from '@onekeyhq/kit-bg/src/states/jotai/utils/jotaiDefaultStore';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import type { TPerpDepositEntrySource } from '@onekeyhq/shared/src/logger/scopes/perp/type';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
@@ -97,7 +99,9 @@ export function useShowUnifoldDepositTracker() {
   };
 }
 
-export function useShowDepositWithdrawModal() {
+export function useShowDepositWithdrawModal(
+  entrySource: TPerpDepositEntrySource,
+) {
   const intl = useIntl();
   const navigation = useAppNavigation();
   const { gtMd } = useMedia();
@@ -182,14 +186,28 @@ export function useShowDepositWithdrawModal() {
             id: ETranslations.perp_unifold_deposit_menu_connected_wallet__title,
           })
         : 'OneKey Wallet';
+      const analyticsContext = {
+        entrySource,
+        walletType: selectedAccount.walletType ?? 'unknown',
+      };
       showPerpsUnifoldDepositMenuDialog({
         intl,
         walletName,
         showTrackerAction: false,
         onAction: (action) => {
           if (action === 'onekey') {
+            defaultLogger.perp.deposit.perpDepositMethodSelect({
+              ...analyticsContext,
+              depositMethod: 'connectedWallet',
+            });
             void openDepositWithdrawForm('deposit');
             return;
+          }
+          if (action === 'transfer') {
+            defaultLogger.perp.deposit.perpDepositMethodSelect({
+              ...analyticsContext,
+              depositMethod: 'depositAddress',
+            });
           }
           if (gtMd) {
             if (action === 'transfer') {
@@ -197,6 +215,7 @@ export function useShowDepositWithdrawModal() {
                 dialogInTab,
                 expectedRecipient: safeRecipient,
                 intl,
+                analyticsEntrySource: entrySource,
               });
             } else {
               showUnifoldTrackerDialog({
@@ -213,6 +232,7 @@ export function useShowDepositWithdrawModal() {
               params: {
                 expectedRecipient: safeRecipient,
                 openSourceSelectorOnReady: true,
+                analyticsEntrySource: entrySource,
               },
             });
             return;
@@ -223,10 +243,12 @@ export function useShowDepositWithdrawModal() {
           });
         },
       });
+      defaultLogger.perp.deposit.perpDepositMethodPanelView(analyticsContext);
     },
     [
       getLatestDepositDisabled,
       openDepositWithdrawForm,
+      entrySource,
       gtMd,
       dialogInTab,
       intl,

--- a/packages/kit/src/views/Perp/utils/perpDepositAnalytics.test.ts
+++ b/packages/kit/src/views/Perp/utils/perpDepositAnalytics.test.ts
@@ -1,0 +1,17 @@
+import { getPerpDepositErrorCode } from './perpDepositAnalytics';
+
+describe('getPerpDepositErrorCode', () => {
+  it('normalizes string and numeric codes', () => {
+    expect(getPerpDepositErrorCode({ code: ' 4001 ' })).toBe('4001');
+    expect(getPerpDepositErrorCode({ code: 4100 })).toBe('4100');
+  });
+
+  it('falls back to the error name without exposing its message', () => {
+    const error = new TypeError('sensitive provider response');
+    expect(getPerpDepositErrorCode(error)).toBe('TypeError');
+  });
+
+  it('uses unknown for unsupported values', () => {
+    expect(getPerpDepositErrorCode('raw error message')).toBe('unknown');
+  });
+});

--- a/packages/kit/src/views/Perp/utils/perpDepositAnalytics.ts
+++ b/packages/kit/src/views/Perp/utils/perpDepositAnalytics.ts
@@ -1,0 +1,15 @@
+export function getPerpDepositErrorCode(error: unknown): string {
+  if (typeof error === 'object' && error !== null && 'code' in error) {
+    const code = error.code;
+    if (typeof code === 'string' || typeof code === 'number') {
+      const normalizedCode = String(code).trim();
+      if (normalizedCode) {
+        return normalizedCode.slice(0, 64);
+      }
+    }
+  }
+  if (error instanceof Error && error.name) {
+    return error.name.slice(0, 64);
+  }
+  return 'unknown';
+}

--- a/packages/shared/src/logger/scopes/perp/scenes/deposit.ts
+++ b/packages/shared/src/logger/scopes/perp/scenes/deposit.ts
@@ -2,25 +2,49 @@ import { BaseScene } from '../../../base/baseScene';
 import { LogToLocal, LogToServer } from '../../../base/decorators';
 
 import type {
+  IPerpDepositAddressSourceSelectParams,
   IPerpDepositInitiateParams,
+  IPerpDepositMethodPanelViewParams,
+  IPerpDepositMethodSelectParams,
   IPerpUserSelectDepositTokenParams,
 } from '../type';
 
 export class PerpDepositScene extends BaseScene {
+  /** Track a visible deposit-method selection panel. */
+  @LogToServer()
+  @LogToLocal({ level: 'info' })
+  public perpDepositMethodPanelView(params: IPerpDepositMethodPanelViewParams) {
+    return params;
+  }
+
+  /** Track the deposit method explicitly selected from the panel. */
+  @LogToServer()
+  @LogToLocal({ level: 'info' })
+  public perpDepositMethodSelect(params: IPerpDepositMethodSelectParams) {
+    return params;
+  }
+
+  /** Track the effective source token and chain for deposit-address flows. */
+  @LogToServer()
+  @LogToLocal({ level: 'info' })
+  public perpDepositAddressSourceSelect(
+    params: IPerpDepositAddressSourceSelectParams,
+  ) {
+    return params;
+  }
+
   @LogToServer()
   @LogToLocal({ level: 'info' })
   public perpDepositInitiate(params: IPerpDepositInitiateParams) {
-    const { userAddress, receiverAddress, ...rest } = params;
-    void userAddress;
-    void receiverAddress;
+    const { token, ...rest } = params;
     return {
       ...rest,
-      tokenSymbol: params.token?.symbol,
-      tokenAddress: params.token?.contractAddress,
-      tokenNetworkId: params.token?.networkId,
-      tokenDecimals: params.token?.decimals,
-      tokenName: params.token?.name,
-      tokenIsNative: params.token?.isNative,
+      tokenSymbol: token.symbol,
+      tokenAddress: token.contractAddress,
+      tokenNetworkId: token.networkId,
+      tokenDecimals: token.decimals,
+      tokenName: token.name,
+      tokenIsNative: token.isNative,
     };
   }
 

--- a/packages/shared/src/logger/scopes/perp/type.ts
+++ b/packages/shared/src/logger/scopes/perp/type.ts
@@ -77,6 +77,27 @@ export interface IPerpTradeButtonClickParams {
 
 export type TPerpAccountSnapshotStatus = 'ready' | 'notCreated' | 'unsupported';
 
+export type TPerpDepositEntrySource =
+  | 'header'
+  | 'home'
+  | 'webAccountPanel'
+  | 'tradingPanel'
+  | 'portfolio'
+  | 'positions'
+  | 'holdings'
+  | 'balance'
+  | 'accountPanel'
+  | 'tradingGuard'
+  | 'enableTrading';
+
+export type TPerpDepositMethod = 'connectedWallet' | 'depositAddress';
+
+export type TPerpDepositAddressSelectionSource = 'default' | 'user';
+
+export type TPerpDepositRoute = 'directArbitrum' | 'relay';
+
+export type TPerpDepositErrorStage = 'build' | 'approve' | 'sign' | 'broadcast';
+
 export interface IPerpAccountStatusParams {
   source: EPerpPageEnterSource;
   walletType: string;
@@ -94,15 +115,32 @@ export interface IPerpAccountStatusParams {
 }
 
 export interface IPerpDepositInitiateParams {
-  userAddress: string;
-  receiverAddress: string;
   walletType: string;
   txId?: string;
   token: IPerpsDepositToken;
   amount: string;
   toAmount: string;
+  depositRoute: TPerpDepositRoute;
   status: ESwapTxHistoryStatus;
-  errorMessage?: string;
+  errorStage?: TPerpDepositErrorStage;
+  errorCode?: string;
+}
+
+export interface IPerpDepositMethodPanelViewParams {
+  entrySource: TPerpDepositEntrySource;
+  walletType: string;
+}
+
+export interface IPerpDepositMethodSelectParams extends IPerpDepositMethodPanelViewParams {
+  depositMethod: TPerpDepositMethod;
+}
+
+export interface IPerpDepositAddressSourceSelectParams extends IPerpDepositMethodPanelViewParams {
+  sourceTokenSymbol: string;
+  sourceChainType: string;
+  sourceChainId: string;
+  sourceChainName: string;
+  selectionSource: TPerpDepositAddressSelectionSource;
 }
 
 export interface IPerpUserSelectDepositTokenParams {

--- a/packages/shared/src/routes/perp.ts
+++ b/packages/shared/src/routes/perp.ts
@@ -1,5 +1,7 @@
 import type { ISetTpslParams } from '@onekeyhq/kit/src/views/Perp/components/OrderInfoPanel/SetTpslModal';
 
+import type { TPerpDepositEntrySource } from '../logger/scopes/perp/type';
+
 export enum EModalPerpRoutes {
   PerpTradersHistoryList = 'PerpTradersHistoryList',
   MobilePerpMarket = 'MobilePerpMarket',
@@ -68,6 +70,7 @@ export type IModalPerpParamList = {
     expectedRecipient: string;
     sourceSelectorResult?: IUnifoldSourceSelectorResult;
     openSourceSelectorOnReady?: boolean;
+    analyticsEntrySource?: TPerpDepositEntrySource;
   };
   [EModalPerpRoutes.MobileUnifoldDepositTracker]: {
     expectedRecipient: string;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58852](https://onekeyhq.atlassian.net/browse/OK-58852)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- clarify the Perps minimum-deposit tooltip, including delayed conversion after future deposits reach the threshold
- extend minimum-order guidance across the trading panel, add-position flow, slider input, and chart limit-order dialog
- add client-side Perps deposit funnel analytics for panel entry, deposit method selection, and on-chain network/token selection
- refine responsive Perps action layouts on mobile and small Web screens

## Issue

- https://onekeyhq.atlassian.net/browse/OK-58852

## Verification

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`

[OK-58852]: https://onekeyhq.atlassian.net/browse/OK-58852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ