### PR TITLE
fix: address Swap Pro badges and stock charts (OK-59240, OK-59108)

### DIFF
--- a/packages/kit-bg/src/services/ServiceMarket.ts
+++ b/packages/kit-bg/src/services/ServiceMarket.ts
@@ -179,10 +179,12 @@ class ServiceMarket extends ServiceBase {
 
   @backgroundMethod()
   async fetchTokenChart(
-    coingeckoId: string,
+    coingeckoId: string | undefined,
     days: string,
     options?: {
+      networkId?: string;
       requestCurrency?: string;
+      tokenAddress?: string;
     },
   ) {
     const client = await this.getClient(EServiceEndpointEnum.Utility);
@@ -192,7 +194,9 @@ class ServiceMarket extends ServiceBase {
       params: {
         coingeckoId,
         days,
+        networkId: options?.networkId,
         points: !platformEnv.isNative || platformEnv.isNativeIOSPad ? 500 : 200,
+        tokenAddress: options?.tokenAddress,
       },
       ...(options?.requestCurrency
         ? {

--- a/packages/kit/src/views/Swap/components/SwapProPositionItem.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProPositionItem.tsx
@@ -12,12 +12,12 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import { listItemPressStyle } from '@onekeyhq/shared/src/style';
-import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import type { IMarketAccountPortfolioPnl } from '@onekeyhq/shared/types/marketV2';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
 import { Currency, useCurrency } from '../../../components/Currency';
 import { Token } from '../../../components/Token';
+import { useNetworkLogoUri } from '../../../hooks/useNetworkLogoUri';
 
 interface ISwapProPositionItemProps {
   token: ISwapToken;
@@ -36,16 +36,10 @@ const SwapProPositionItem = ({
 }: ISwapProPositionItemProps) => {
   const currencyInfo = useCurrency();
 
-  const tokenNetworkImageUri = useMemo(() => {
-    if (token.networkLogoURI) {
-      return token.networkLogoURI;
-    }
-    if (token.networkId) {
-      const localNetwork = networkUtils.getLocalNetworkInfo(token.networkId);
-      return localNetwork?.logoURI;
-    }
-    return '';
-  }, [token.networkLogoURI, token.networkId]);
+  const tokenNetworkImageUri = useNetworkLogoUri({
+    logoUri: token.networkLogoURI,
+    networkId: token.networkId,
+  });
 
   const handlePress = useCallback(() => {
     if (!disabled) {

--- a/packages/kit/src/views/Swap/pages/components/SwapProTokenSelect.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProTokenSelect.tsx
@@ -8,12 +8,12 @@ import {
   YStack,
 } from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
+import { useNetworkLogoUri } from '@onekeyhq/kit/src/hooks/useNetworkLogoUri';
 import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import {
   useSwapProSelectTokenAtom,
   useSwapProTokenMarketDetailInfoAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
-import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 
 import {
@@ -33,18 +33,10 @@ const SwapProTokenSelector = ({
   const [swapProTokenSelect] = useSwapProSelectTokenAtom();
   const [tokenMarketDetailInfo] = useSwapProTokenMarketDetailInfoAtom();
   const themeVariant = useThemeVariant();
-  const swapProTokenNetworkImageUri = useMemo(() => {
-    if (swapProTokenSelect?.networkLogoURI) {
-      return swapProTokenSelect.networkLogoURI;
-    }
-    if (swapProTokenSelect?.networkId) {
-      const localNetwork = networkUtils.getLocalNetworkInfo(
-        swapProTokenSelect?.networkId,
-      );
-      return localNetwork?.logoURI;
-    }
-    return undefined;
-  }, [swapProTokenSelect]);
+  const swapProTokenNetworkImageUri = useNetworkLogoUri({
+    logoUri: swapProTokenSelect?.networkLogoURI,
+    networkId: swapProTokenSelect?.networkId,
+  });
   const selectedTokenStock = useMemo(() => {
     if (!swapProTokenSelect || !tokenMarketDetailInfo?.stock) {
       return undefined;

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -1536,12 +1536,7 @@ function StockPriceChart({
   }, [chartScope]);
   const { result: chartState, isLoading } = usePromiseResult(
     async () => {
-      if (
-        !networkId ||
-        !normalizedCoinGeckoId ||
-        (!tokenAddress && !isNative) ||
-        !activeRange
-      ) {
+      if (!networkId || (!tokenAddress && !isNative) || !activeRange) {
         return {
           scope: chartScope,
           assetScope: chartAssetScope,
@@ -1555,7 +1550,11 @@ function StockPriceChart({
       const response = await backgroundApiProxy.serviceMarket.fetchTokenChart(
         normalizedCoinGeckoId,
         days,
-        { requestCurrency: 'usd' },
+        {
+          networkId,
+          requestCurrency: 'usd',
+          tokenAddress,
+        },
       );
       return {
         scope: chartScope,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59240](https://onekeyhq.atlassian.net/browse/OK-59240) [OK-59108](https://onekeyhq.atlassian.net/browse/OK-59108)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Show network badges for dynamic networks such as Robinhood in the Swap Pro selected-token header and position rows.
- Load Stock K-line data for tokens without a CoinGecko ID by passing networkId and tokenAddress to the existing market chart endpoint.
- Preserve the existing CoinGecko chart path when a CoinGecko ID is available.

## Intent & Context

- [OK-59240](https://onekeyhq.atlassian.net/browse/OK-59240) reports that Robinhood token network badges are visible in the selector but disappear from the Swap Pro header and position list.
- [OK-59108](https://onekeyhq.atlassian.net/browse/OK-59108) reports that Solana xStocks without a CoinGecko ID show an empty K-line chart on Desktop.

## Root Cause

- Swap Pro used a preset-only local network lookup when networkLogoURI was empty, so dynamically configured networks such as Robinhood could not resolve a badge.
- StockPriceChart stopped before requesting data whenever coinGeckoId was absent, although the chart endpoint supports an OKX fallback with networkId and tokenAddress.

## Design Decisions

- Reuse useNetworkLogoUri for dynamic network badge resolution without changing network presets or token-selection state.
- Keep CoinGecko as the preferred chart source when coinGeckoId exists.
- When coinGeckoId is absent, reuse the existing chart endpoint and pass the token identity required by its OKX fallback contract.
- Preserve the existing chart scope and stale-response guards.

## Changes Detail

- SwapProTokenSelect: resolve the selected token network logo with useNetworkLogoUri.
- SwapProPositionItem: resolve position-row network logos with the same hook.
- ServiceMarket.fetchTokenChart: accept an optional CoinGecko ID and forward networkId and tokenAddress.
- SwapStockDesktopContainer: allow the Stock chart request without a CoinGecko ID and provide its network/address identity.

## Risk Assessment

- **Risk Level**: Low
- **Affected Platforms**: Mobile, Desktop, Web, Extension for network badges; Desktop Stock chart for the reported K-line issue.
- **Risk Areas**: Asynchronous badge hydration and chart source selection. Existing CoinGecko callers remain unchanged, and the server prioritizes CoinGecko whenever its ID is present.

## Test plan

- [x] Run yarn agent:check --profile commit.
- [x] Reload and cold relaunch iOS, then verify the Robinhood ETH badge in Swap Pro.
- [x] Verify the live Swap Pro selected-token component receives the Robinhood networkImageUri.
- [x] Run Desktop locally and select the reported VOOx token by its exact Solana address.
- [x] Verify the Stock chart request omits coinGeckoId, sends networkId and tokenAddress, returns HTTP 200, and renders the K-line.
- [x] Verify all four reported Solana xStock addresses return non-empty chart data from the fallback endpoint.
- [x] Re-select CRCLon and verify the existing CoinGecko request still returns HTTP 200 and renders data.
- [ ] Verify a Robinhood position row with an account that has a Robinhood token balance. The current test account has no Robinhood position.


[OK-59240]: https://onekeyhq.atlassian.net/browse/OK-59240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-59108]: https://onekeyhq.atlassian.net/browse/OK-59108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ