### PR TITLE
fix: improve market initial rendering

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketListLoadingFallback.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketListLoadingFallback.tsx
@@ -1,0 +1,38 @@
+import { Skeleton, XStack, YStack } from '@onekeyhq/components';
+
+const FALLBACK_ROW_COUNT = 8;
+
+export function MarketListLoadingFallback() {
+  return (
+    <YStack width="100%" pt="$4">
+      <XStack height={44} alignItems="center" gap="$8" px="$3">
+        <Skeleton width={56} height={16} />
+        <Skeleton width={120} height={16} />
+        <Skeleton flex={1} maxWidth={96} height={16} />
+        <Skeleton flex={1} maxWidth={96} height={16} />
+        <Skeleton flex={1} maxWidth={96} height={16} />
+      </XStack>
+      {Array.from({ length: FALLBACK_ROW_COUNT }, (_, index) => (
+        <XStack
+          key={`market-list-loading-row-${index}`}
+          height={60}
+          alignItems="center"
+          gap="$8"
+          px="$3"
+        >
+          <Skeleton width={24} height={24} borderRadius="$full" />
+          <XStack width={152} alignItems="center" gap="$3">
+            <Skeleton width={32} height={32} borderRadius="$full" />
+            <YStack gap="$1">
+              <Skeleton width={72} height={16} />
+              <Skeleton width={88} height={12} />
+            </YStack>
+          </XStack>
+          <Skeleton flex={1} maxWidth={96} height={16} />
+          <Skeleton flex={1} maxWidth={96} height={16} />
+          <Skeleton flex={1} maxWidth={96} height={16} />
+        </XStack>
+      ))}
+    </YStack>
+  );
+}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenListBase.tsx
@@ -66,7 +66,6 @@ const MARKET_HOME_WS_OVERSCAN_ROWS = 5;
 const MARKET_HOME_WS_MAX_SUBSCRIPTIONS = 80;
 const MARKET_HOME_WS_SCROLL_SYNC_DELAY_MS = 120;
 const MARKET_HOME_WS_DEBUG_SUBSCRIPTION_ROW_BG = 'rgba(255, 72, 72, 0.12)';
-const MARKET_HOME_WEB_EAGER_RICH_ROW_COUNT = 4;
 const MARKET_HOME_WEB_INITIAL_RENDER_ROW_COUNT = 12;
 const MARKET_HOME_WEB_ROW_CONTENT_VISIBILITY_STYLE = {
   contentVisibility: 'auto',
@@ -454,15 +453,6 @@ function MarketTokenListBase({
       shouldUseStockMetadataColumnsForTokens(rawData),
     [isWatchlistMode, rawData, showStockSubtitle],
   );
-  // Web tab integration gives the inner FlatList the full tab height so the
-  // outer Tabs.Container can own vertical scroll. During cold start, keep only
-  // the first rows rich and defer extra media/interactive decoration until
-  // after the measured startup window.
-  const deferRichRowAfterIndex =
-    platformEnv.isWeb && webTabIntegrated && !enableDeferredWebFeatures
-      ? MARKET_HOME_WEB_EAGER_RICH_ROW_COUNT
-      : undefined;
-
   const marketTokenColumns = useMarketTokenColumns(
     networkId,
     isWatchlistMode,
@@ -474,7 +464,6 @@ function MarketTokenListBase({
     hiddenDesktopColumns,
     change24hColumnTitle,
     useStockMetadataColumns,
-    deferRichRowAfterIndex,
   );
 
   const data = useMemo(() => {

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketWatchlistTokenList.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketWatchlistTokenList.tsx
@@ -27,6 +27,7 @@ import { MarketRecommendList } from '../MarketRecommendList';
 import { InlineActionBar } from './components/InlineActionBar';
 import { useMarketWatchlistTokenList } from './hooks/useMarketWatchlistTokenList';
 import { useWatchlistFilteredGroups } from './hooks/useWatchlistFilteredGroups';
+import { MarketListLoadingFallback } from './MarketListLoadingFallback';
 import { type IMarketToken } from './MarketTokenData';
 import {
   type IMarketTokenListLiveOverride,
@@ -317,9 +318,13 @@ function MarketWatchlistTokenList({
     // When tab-integrated on native, register a scroll view with collapsible tabs
     // even during loading, so the tab system has a valid scroll ref.
     if (tabIntegrated && platformEnv.isNative) {
-      return <Tabs.ScrollView />;
+      return (
+        <Tabs.ScrollView>
+          <MarketListLoadingFallback />
+        </Tabs.ScrollView>
+      );
     }
-    return null;
+    return <MarketListLoadingFallback />;
   }
 
   // Show recommend list when watchlist is empty

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.initialData.test.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.initialData.test.tsx
@@ -1,29 +1,31 @@
 /** @jest-environment jsdom */
 
-import { render, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 
+import {
+  swrCacheUtils,
+  swrKeys,
+} from '@onekeyhq/shared/src/utils/swrCacheUtils';
+import type { IMarketTokenListResponse } from '@onekeyhq/shared/types/marketV2';
+
+import { fetchMarketTokenListForPlatform } from './marketTokenListPlatformApi';
 import { useMarketTokenList } from './useMarketTokenList';
 
-const mockCachedResponse = {
-  list: [
-    {
-      address: '0xcached',
-      name: 'Cached Token',
-      symbol: 'CACHED',
-    },
-  ],
-  total: 1,
-};
-let mockPromiseResultResponse = mockCachedResponse;
-const mockRun = jest.fn(async () => undefined);
 const mockTrackNetworkLoading = jest.fn();
 
-jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => ({
-  usePromiseResult: () => ({
-    result: mockPromiseResultResponse,
-    isLoading: false,
-    run: mockRun,
+jest.mock('@onekeyhq/components', () => ({
+  getCurrentVisibilityState: () => true,
+  onVisibilityStateChange: () => () => undefined,
+  useDeferredPromise: () => ({
+    promise: Promise.resolve(null),
+    reset: jest.fn(),
+    resolve: jest.fn(),
   }),
+  useNetInfo: () => ({ isRawInternetReachable: true }),
+}));
+
+jest.mock('@onekeyhq/kit/src/hooks/useRouteIsFocused', () => ({
+  useRouteIsFocused: () => true,
 }));
 
 jest.mock('@onekeyhq/kit/src/views/Market/hooks', () => ({
@@ -53,25 +55,12 @@ jest.mock('@onekeyhq/kit/src/views/Market/utils/marketReactPerf', () => ({
 
 jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
   __esModule: true,
-  default: { isWeb: true },
+  default: { isNative: false, isWeb: true },
 }));
 
 jest.mock('@onekeyhq/shared/src/utils/networkUtils', () => ({
   __esModule: true,
   default: { isAllNetwork: () => false },
-}));
-
-jest.mock('@onekeyhq/shared/src/utils/swrCacheUtils', () => ({
-  swrCacheUtils: {
-    getWithTimestamp: () => ({
-      data: mockCachedResponse,
-      updatedAt: Date.now(),
-    }),
-    remove: jest.fn(),
-  },
-  swrKeys: {
-    marketHomeTokenList: () => 'market-home-token-list-test-key',
-  },
 }));
 
 jest.mock('../utils/tokenListHelpers', () => ({
@@ -105,17 +94,61 @@ jest.mock('./marketTokenListPlatformApi', () => ({
   fetchMarketTokenListForPlatform: jest.fn(),
 }));
 
+function createDeferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function createResponse(
+  address: string,
+  name: string,
+  symbol: string,
+): IMarketTokenListResponse {
+  return {
+    list: [{ address, name, symbol, decimals: 18 }],
+    total: 1,
+  };
+}
+
 describe('useMarketTokenList initial data', () => {
+  const cacheKey = swrKeys.marketHomeTokenList({
+    networkId: 'evm--1',
+    sortBy: 'v24hUSD',
+    sortType: 'desc',
+    pageSize: 20,
+    minLiquidity: 5000,
+    type: 'trending',
+  });
+  const mockFetchMarketTokenList = jest.mocked(fetchMarketTokenListForPlatform);
+
   beforeEach(() => {
-    mockPromiseResultResponse = mockCachedResponse;
+    swrCacheUtils.clearAll();
+    swrCacheUtils.flushNow();
+    mockFetchMarketTokenList.mockReset();
+    mockTrackNetworkLoading.mockReset();
   });
 
-  it('exposes cached rows during the first render', () => {
+  afterEach(() => {
+    swrCacheUtils.clearAll();
+    swrCacheUtils.flushNow();
+  });
+
+  it('renders SWR rows on the first frame, then replaces and caches the remote page', async () => {
+    const cachedResponse = createResponse('0xcached', 'Cached Token', 'CACHED');
+    const remoteResponse = createResponse('0xremote', 'Remote Token', 'REMOTE');
+    const remoteRequest = createDeferred<IMarketTokenListResponse>();
     const renderedTokenIds: string[][] = [];
+
+    swrCacheUtils.set(cacheKey, cachedResponse);
+    mockFetchMarketTokenList.mockReturnValueOnce(remoteRequest.promise);
 
     function Probe() {
       const result = useMarketTokenList({
         networkId: 'evm--1',
+        pollingInterval: 0,
         type: 'trending',
       });
       renderedTokenIds.push(result.data.map((item) => item.id));
@@ -125,37 +158,27 @@ describe('useMarketTokenList initial data', () => {
     render(<Probe />);
 
     expect(renderedTokenIds[0]).toEqual(['0xcached']);
-  });
+    await waitFor(() => {
+      expect(mockFetchMarketTokenList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          networkId: 'evm--1',
+          page: 1,
+          type: 'trending',
+        }),
+        { forceRemote: true },
+      );
+    });
 
-  it('replaces the cached rows when the remote first page arrives', async () => {
-    const renderedTokenIds: string[][] = [];
-
-    function Probe({ revision }: { revision: number }) {
-      const result = useMarketTokenList({
-        networkId: 'evm--1',
-        type: 'trending',
-      });
-      renderedTokenIds.push(result.data.map((item) => item.id));
-      return <span>{revision}</span>;
-    }
-
-    const view = render(<Probe revision={0} />);
-    expect(renderedTokenIds[0]).toEqual(['0xcached']);
-
-    mockPromiseResultResponse = {
-      list: [
-        {
-          address: '0xremote',
-          name: 'Remote Token',
-          symbol: 'REMOTE',
-        },
-      ],
-      total: 1,
-    };
-    view.rerender(<Probe revision={1} />);
+    await act(async () => {
+      remoteRequest.resolve(remoteResponse);
+      await remoteRequest.promise;
+    });
 
     await waitFor(() => {
       expect(renderedTokenIds.at(-1)).toEqual(['0xremote']);
     });
+    expect(swrCacheUtils.get<IMarketTokenListResponse>(cacheKey)).toMatchObject(
+      remoteResponse,
+    );
   });
 });

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.initialData.test.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.initialData.test.tsx
@@ -1,0 +1,161 @@
+/** @jest-environment jsdom */
+
+import { render, waitFor } from '@testing-library/react';
+
+import { useMarketTokenList } from './useMarketTokenList';
+
+const mockCachedResponse = {
+  list: [
+    {
+      address: '0xcached',
+      name: 'Cached Token',
+      symbol: 'CACHED',
+    },
+  ],
+  total: 1,
+};
+let mockPromiseResultResponse = mockCachedResponse;
+const mockRun = jest.fn(async () => undefined);
+const mockTrackNetworkLoading = jest.fn();
+
+jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => ({
+  usePromiseResult: () => ({
+    result: mockPromiseResultResponse,
+    isLoading: false,
+    run: mockRun,
+  }),
+}));
+
+jest.mock('@onekeyhq/kit/src/views/Market/hooks', () => ({
+  useMarketBasicConfig: () => ({ minLiquidity: 5000 }),
+}));
+
+jest.mock(
+  '@onekeyhq/kit/src/views/Market/MarketHomeV2/hooks/useNetworkLoadingAnalytics',
+  () => ({
+    useNetworkLoadingAnalytics: () => ({
+      trackNetworkLoading: mockTrackNetworkLoading,
+    }),
+  }),
+);
+
+jest.mock(
+  '@onekeyhq/kit/src/views/Market/utils/marketHomeTokenListSeed',
+  () => ({
+    discardMarketHomeTokenListSeedForInit: jest.fn(),
+    getMarketHomeTokenListSeedForInit: jest.fn(() => undefined),
+  }),
+);
+
+jest.mock('@onekeyhq/kit/src/views/Market/utils/marketReactPerf', () => ({
+  markMarketReactPerf: jest.fn(),
+}));
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: { isWeb: true },
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/networkUtils', () => ({
+  __esModule: true,
+  default: { isAllNetwork: () => false },
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/swrCacheUtils', () => ({
+  swrCacheUtils: {
+    getWithTimestamp: () => ({
+      data: mockCachedResponse,
+      updatedAt: Date.now(),
+    }),
+    remove: jest.fn(),
+  },
+  swrKeys: {
+    marketHomeTokenList: () => 'market-home-token-list-test-key',
+  },
+}));
+
+jest.mock('../utils/tokenListHelpers', () => ({
+  getNetworkLogoUri: () => 'network-logo',
+  transformApiItemToToken: (item: {
+    address: string;
+    name: string;
+    symbol: string;
+  }) => ({
+    id: item.address,
+    name: item.name,
+    symbol: item.symbol,
+    address: item.address,
+    decimals: 18,
+    price: 1,
+    change24h: 0,
+    marketCap: 0,
+    liquidity: 0,
+    transactions: 0,
+    uniqueTraders: 0,
+    holders: 0,
+    turnover: 0,
+    tokenImageUri: '',
+    networkLogoUri: 'network-logo',
+    networkId: 'evm--1',
+    chainId: 'evm--1',
+  }),
+}));
+
+jest.mock('./marketTokenListPlatformApi', () => ({
+  fetchMarketTokenListForPlatform: jest.fn(),
+}));
+
+describe('useMarketTokenList initial data', () => {
+  beforeEach(() => {
+    mockPromiseResultResponse = mockCachedResponse;
+  });
+
+  it('exposes cached rows during the first render', () => {
+    const renderedTokenIds: string[][] = [];
+
+    function Probe() {
+      const result = useMarketTokenList({
+        networkId: 'evm--1',
+        type: 'trending',
+      });
+      renderedTokenIds.push(result.data.map((item) => item.id));
+      return null;
+    }
+
+    render(<Probe />);
+
+    expect(renderedTokenIds[0]).toEqual(['0xcached']);
+  });
+
+  it('replaces the cached rows when the remote first page arrives', async () => {
+    const renderedTokenIds: string[][] = [];
+
+    function Probe({ revision }: { revision: number }) {
+      const result = useMarketTokenList({
+        networkId: 'evm--1',
+        type: 'trending',
+      });
+      renderedTokenIds.push(result.data.map((item) => item.id));
+      return <span>{revision}</span>;
+    }
+
+    const view = render(<Probe revision={0} />);
+    expect(renderedTokenIds[0]).toEqual(['0xcached']);
+
+    mockPromiseResultResponse = {
+      list: [
+        {
+          address: '0xremote',
+          name: 'Remote Token',
+          symbol: 'REMOTE',
+        },
+      ],
+      total: 1,
+    };
+    view.rerender(<Probe revision={1} />);
+
+    await waitFor(() => {
+      expect(renderedTokenIds.at(-1)).toEqual(['0xremote']);
+    });
+  });
+});

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/hooks/useMarketTokenList.ts
@@ -176,6 +176,26 @@ function reuseStableMarketTokenRows({
   return changed ? reused : prev;
 }
 
+function transformMarketTokenListResponse({
+  response,
+  networkId,
+  networkLogoUri,
+  timeRange,
+}: {
+  response: IMarketTokenListResponseWithSource | undefined;
+  networkId: string;
+  networkLogoUri: string;
+  timeRange: IMarketTimeRangeValue | undefined;
+}) {
+  return (response?.list ?? []).map((item) =>
+    transformApiItemToToken(item, {
+      chainId: networkId,
+      networkLogoUri,
+      timeRange,
+    }),
+  );
+}
+
 export function useMarketTokenList({
   networkId,
   initialSortBy = 'v24hUSD',
@@ -192,7 +212,6 @@ export function useMarketTokenList({
   // Get minLiquidity from market config
   const { minLiquidity } = useMarketBasicConfig();
   const { trackNetworkLoading } = useNetworkLoadingAnalytics();
-  const [transformedData, setTransformedData] = useState<IMarketToken[]>([]);
   const [sortBy, setSortBy] = useState<string | undefined>(initialSortBy);
   const [sortType, setSortType] = useState<'asc' | 'desc' | undefined>(
     initialSortType,
@@ -457,6 +476,18 @@ export function useMarketTokenList({
     },
   );
 
+  // Seed and SWR values are available synchronously during render. Initialize
+  // the table rows from that value so remounting Market never starts from an
+  // empty list while the same cached response waits for an effect.
+  const [transformedData, setTransformedData] = useState<IMarketToken[]>(() =>
+    transformMarketTokenListResponse({
+      response: apiResult,
+      networkId,
+      networkLogoUri,
+      timeRange: timeRangeRef.current,
+    }),
+  );
+
   const effectiveIsLoading = hasNetworkId ? isLoading : false;
   const isSeedResult = Boolean(apiResult?.__fromSeed);
   const isColdCacheFallbackResult = Boolean(apiResult?.__fromColdCacheFallback);
@@ -546,13 +577,12 @@ export function useMarketTokenList({
       platformEnv.isWeb && typeof performance !== 'undefined'
         ? performance.now()
         : 0;
-    const transformed = apiResult.list.map((item) =>
-      transformApiItemToToken(item, {
-        chainId: networkId,
-        networkLogoUri,
-        timeRange: timeRangeRef.current,
-      }),
-    );
+    const transformed = transformMarketTokenListResponse({
+      response: apiResult,
+      networkId,
+      networkLogoUri,
+      timeRange: timeRangeRef.current,
+    });
     const transformDuration =
       transformStart > 0 ? performance.now() - transformStart : undefined;
     markMarketReactPerf({

--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/DesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/DesktopLayout.tsx
@@ -16,6 +16,7 @@ import { markMarketPerf } from '../../utils/marketPerf';
 import { useMarketRenderCommitProbe } from '../../utils/marketReactPerf';
 import { CompactNetworkSelector } from '../components/CompactNetworkSelector';
 import { MarketBannerList } from '../components/MarketBanner';
+import { MarketListLoadingFallback } from '../components/MarketTokenList/MarketListLoadingFallback';
 import { MarketNormalTokenList } from '../components/MarketTokenList/MarketNormalTokenList';
 import { MarketStockCategorySelector } from '../components/MarketTokenList/MarketStockCategorySelector';
 import { TimeRangeDropdown } from '../components/TimeRangeDropdown';
@@ -163,12 +164,15 @@ export function DesktopLayout({
   // commit; the other two stay as empty placeholders until first press.
   const everActiveTabsRef = useRef<Set<string>>(new Set([activeTabName]));
   const [, bumpEverActive] = useState(0);
-  useEffect(() => {
-    if (!everActiveTabsRef.current.has(activeTabName)) {
-      everActiveTabsRef.current.add(activeTabName);
-      bumpEverActive((n) => n + 1);
+  const ensureTabActivated = useCallback((tabName: string) => {
+    if (!everActiveTabsRef.current.has(tabName)) {
+      everActiveTabsRef.current.add(tabName);
+      bumpEverActive((version) => version + 1);
     }
-  }, [activeTabName]);
+  }, []);
+  useEffect(() => {
+    ensureTabActivated(activeTabName);
+  }, [activeTabName, ensureTabActivated]);
   const hasActivated = (name: string) => everActiveTabsRef.current.has(name);
 
   // Ref so renderTabBar can update activeTabName immediately on press
@@ -191,6 +195,7 @@ export function DesktopLayout({
       const handleTabPress = (name: string) => {
         // Update immediately on press so the portal clears before the
         // tab-switch animation completes (onTabChange fires after animation).
+        ensureTabActivated(name);
         setActiveTabNameRef.current(name);
         tabBarProps.onTabPress?.(name);
       };
@@ -244,15 +249,16 @@ export function DesktopLayout({
         </YStack>
       );
     },
-    [getSpotCategoryIdByTabName, portalRefCallback],
+    [ensureTabActivated, getSpotCategoryIdByTabName, portalRefCallback],
   );
 
   const onTabChangeHandler = useCallback(
     ({ tabName }: { tabName: string }) => {
+      ensureTabActivated(tabName);
       setActiveTabName(tabName);
       handleTabChange(tabName);
     },
-    [handleTabChange, setActiveTabName],
+    [ensureTabActivated, handleTabChange, setActiveTabName],
   );
 
   const listContainerProps = useMemo(() => {
@@ -300,7 +306,7 @@ export function DesktopLayout({
     <Tabs.Tab key={watchlistTabName} name={watchlistTabName}>
       <YStack px="$4" flex={1}>
         {hasActivated(watchlistTabName) ? (
-          <Suspense fallback={null}>
+          <Suspense fallback={<MarketListLoadingFallback />}>
             <LazyMarketWatchlistTokenList
               tabIntegrated
               tabName={watchlistTabName}


### PR DESCRIPTION
## Summary
- render the complete build-injected Market seed page with full token rows on first visit
- initialize Market rows synchronously from seed/SWR data while preserving the existing remote refresh
- activate Favorites on press and show a table skeleton during lazy loading and watchlist hydration

## Root cause
- web rows after the first four intentionally deferred icons and rich cells behind the delayed feature gate
- transformed table state started empty even when seed or SWR data was synchronously available
- Favorites activation was only recorded in an effect, while both lazy loading and watchlist hydration returned a null fallback

## Impact
- no API contract or persistence format changes
- existing remote revalidation, stable-row reuse, and remote cache writes remain unchanged
- loading fallback covers both the lazy chunk and watchlist storage hydration

## Validation
- `GOMAXPROCS=4 yarn _tsc`
- type-aware Oxlint on all changed files
- Prettier check on all changed files
- 2 focused Jest suites, 4 tests passed
- cached-data integration test uses the real `usePromiseResult`, SWR cache/key, forced remote revalidation, replacement render, and cache write-back
- manual web checks: seed rows/icons render while the remote request is paused, cached rows render immediately on re-entry, and Favorites is nonblank
- `yarn agent:check --profile commit` was attempted, but the current Windows runner could not spawn its `yarn`/`npx.cmd` child processes; the equivalent checks above were run directly