### PR TITLE
fix: add Perps deposit trade source(OK-59362)

### DIFF
--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -135,6 +135,7 @@ import { vaultFactory } from '../vaults/factory';
 import ServiceBase from './ServiceBase';
 import {
   buildPerpDepositOrderStatusRequestParams,
+  buildPerpDepositQuoteRequestParams,
   buildSwapReferralBuildTxParams,
   buildSwapRequestErrorToastPayload,
   normalizeSwapTokenListCurrency,
@@ -3442,13 +3443,13 @@ export default class ServiceSwap extends ServiceBase {
             }
           : {}),
       };
-      const fetchParams = {
+      const fetchParams = buildPerpDepositQuoteRequestParams({
         fromNetworkId: params.fromNetworkId,
         fromTokenAmount: params.fromTokenAmount,
         fromTokenAddress: params.fromTokenAddress,
         userAddress: params.userAddress,
         receivingAddress: params.receivingAddress,
-      };
+      });
       const client = await this.getClient(EServiceEndpointEnum.Swap);
       const { data } = await client.post<{ data: IPerpDepositQuoteResponse }>(
         '/swap/v1/perp-deposit-quote',

--- a/packages/kit-bg/src/services/ServiceSwap.utils.test.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.utils.test.ts
@@ -2,10 +2,32 @@ import { EProtocolOfExchange } from '@onekeyhq/shared/types/swap/types';
 
 import {
   buildPerpDepositOrderStatusRequestParams,
+  buildPerpDepositQuoteRequestParams,
   buildSwapReferralBuildTxParams,
   buildSwapRequestErrorToastPayload,
   shouldAttachSwapReferralBuildTxParams,
 } from './ServiceSwap.utils';
+
+describe('buildPerpDepositQuoteRequestParams', () => {
+  it('marks Perps deposit quotes with their trade source', () => {
+    expect(
+      buildPerpDepositQuoteRequestParams({
+        fromNetworkId: 'evm--1',
+        fromTokenAmount: '10',
+        fromTokenAddress: '0xtoken',
+        userAddress: '0xuser',
+        receivingAddress: '0xreceiver',
+      }),
+    ).toEqual({
+      fromNetworkId: 'evm--1',
+      fromTokenAmount: '10',
+      fromTokenAddress: '0xtoken',
+      userAddress: '0xuser',
+      receivingAddress: '0xreceiver',
+      tradeSource: 'perps',
+    });
+  });
+});
 
 describe('shouldAttachSwapReferralBuildTxParams', () => {
   it('enables attribution for Swap and Bridge builds', () => {

--- a/packages/kit-bg/src/services/ServiceSwap.utils.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.utils.ts
@@ -48,6 +48,19 @@ export function buildPerpDepositOrderStatusRequestParams(params: {
   };
 }
 
+export function buildPerpDepositQuoteRequestParams(params: {
+  fromNetworkId: string;
+  fromTokenAmount: string;
+  fromTokenAddress: string;
+  userAddress: string;
+  receivingAddress: string;
+}) {
+  return {
+    ...params,
+    tradeSource: 'perps' as const,
+  };
+}
+
 export function buildSwapRequestErrorToastPayload(error?: {
   message?: string;
   requestId?: string;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59362](https://onekeyhq.atlassian.net/browse/OK-59362)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Add `tradeSource: perps` to the `/swap/v1/perp-deposit-quote` request payload.
- Add a focused request-builder test to lock the backend attribution value.

## Intent & Context
The Swap Pro order-source work requires build endpoints to identify the originating trade surface. This PR covers only the Perps deposit quote endpoint for the release hotfix and uses the explicitly agreed `perps` value.

## Root Cause
The Perps deposit quote request did not include `tradeSource`, so routed Perps deposit orders could not be attributed to the Perps surface by the backend.

## Design Decisions
- Attach the fixed source in the background ServiceSwap owner because this endpoint is Perps-specific.
- Keep UI callers free from a redundant parameter that could be omitted or misclassified.
- Build the request through a pure helper so the exact payload contract is covered by a focused unit test.

## Changes Detail
- Update `ServiceSwap.fetchPerpDepositQuote` to use the typed request builder.
- Add `buildPerpDepositQuoteRequestParams` with `tradeSource: perps`.
- Add unit coverage for the complete request shape.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension, Mobile, Desktop, Web
- **Risk Areas**: Routed Perps deposits only; the existing quote fields and response handling are unchanged.

## Test plan
- [x] `yarn jest packages/kit-bg/src/services/ServiceSwap.utils.test.ts --runInBand`
- [x] `yarn agent:check --profile commit`

[OK-59362]: https://onekeyhq.atlassian.net/browse/OK-59362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ