### PR TITLE
feat: add Swap Pro analytics and trade source (OK-58875)

### DIFF
--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -84,7 +84,6 @@ import {
 import type {
   ESwapExtraStatus,
   ESwapQuoteKind,
-  ESwapTradeSource,
   IFetchBuildTxParams,
   IFetchBuildTxResponse,
   IFetchLimitOrderRes,
@@ -122,6 +121,7 @@ import {
   ESwapLimitOrderStatus,
   ESwapLimitOrderUpdateInterval,
   ESwapTabSwitchType,
+  ESwapTradeSource,
   ESwapTxHistoryStatus,
 } from '@onekeyhq/shared/types/swap/types';
 
@@ -3455,6 +3455,7 @@ export default class ServiceSwap extends ServiceBase {
         fromTokenAddress: params.fromTokenAddress,
         userAddress: params.userAddress,
         receivingAddress: params.receivingAddress,
+        tradeSource: ESwapTradeSource.PERPS,
       };
       const client = await this.getClient(EServiceEndpointEnum.Swap);
       const { data } = await client.post<{ data: IPerpDepositQuoteResponse }>(

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -84,6 +84,7 @@ import {
 import type {
   ESwapExtraStatus,
   ESwapQuoteKind,
+  ESwapTradeSource,
   IFetchBuildTxParams,
   IFetchBuildTxResponse,
   IFetchLimitOrderRes,
@@ -1238,6 +1239,7 @@ export default class ServiceSwap extends ServiceBase {
     protocol,
     kind,
     walletType,
+    tradeSource,
   }: {
     fromToken: ISwapToken;
     toToken: ISwapToken;
@@ -1252,6 +1254,7 @@ export default class ServiceSwap extends ServiceBase {
     protocol: EProtocolOfExchange;
     kind: ESwapQuoteKind;
     walletType?: string;
+    tradeSource: ESwapTradeSource;
   }): Promise<IFetchBuildTxResponse | undefined> {
     const referralBuildTxParams = await this.getSwapReferralBuildTxParams({
       accountId,
@@ -1272,6 +1275,7 @@ export default class ServiceSwap extends ServiceBase {
       quoteResultCtx,
       kind,
       walletType,
+      tradeSource,
       ...referralBuildTxParams,
     };
     const client = await this.getClient(EServiceEndpointEnum.Swap);
@@ -3311,6 +3315,7 @@ export default class ServiceSwap extends ServiceBase {
     protocol,
     kind,
     quoteResultCtx,
+    tradeSource,
   }: {
     fromToken: ISwapToken;
     toToken: ISwapToken;
@@ -3324,6 +3329,7 @@ export default class ServiceSwap extends ServiceBase {
     kind: ESwapQuoteKind;
     walletType?: string;
     quoteResultCtx?: any;
+    tradeSource: ESwapTradeSource;
   }): Promise<IFetchBuildTxResponse | undefined> {
     let headers = await getRequestHeaders();
     const walletType =
@@ -3351,6 +3357,7 @@ export default class ServiceSwap extends ServiceBase {
         kind,
         walletType,
         quoteResultCtx,
+        tradeSource,
       }),
       ...(await this.getSwapReferralBuildTxParams({
         accountId,

--- a/packages/kit-bg/src/services/utils/buildSpeedSwapTxParams.test.ts
+++ b/packages/kit-bg/src/services/utils/buildSpeedSwapTxParams.test.ts
@@ -2,6 +2,7 @@ import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 import {
   EProtocolOfExchange,
   ESwapQuoteKind,
+  ESwapTradeSource,
 } from '@onekeyhq/shared/types/swap/types';
 
 import { buildSpeedSwapTxParams } from './buildSpeedSwapTxParams';
@@ -35,6 +36,7 @@ describe('buildSpeedSwapTxParams', () => {
       protocol: EProtocolOfExchange.SWAP,
       kind: ESwapQuoteKind.SELL,
       walletType: 'hd',
+      tradeSource: ESwapTradeSource.MARKET_DEX,
       quoteResultCtx: {
         oneInchFusionOrderCtx: {
           quoteId: 'quote-1',
@@ -55,6 +57,7 @@ describe('buildSpeedSwapTxParams', () => {
       slippagePercentage: 0.5,
       kind: ESwapQuoteKind.SELL,
       walletType: 'hd',
+      tradeSource: ESwapTradeSource.MARKET_DEX,
       quoteResultCtx: {
         oneInchFusionOrderCtx: {
           quoteId: 'quote-1',

--- a/packages/kit-bg/src/services/utils/buildSpeedSwapTxParams.ts
+++ b/packages/kit-bg/src/services/utils/buildSpeedSwapTxParams.ts
@@ -1,6 +1,7 @@
 import type {
   EProtocolOfExchange,
   ESwapQuoteKind,
+  ESwapTradeSource,
   IFetchBuildTxParams,
   ISwapToken,
 } from '@onekeyhq/shared/types/swap/types';
@@ -17,6 +18,7 @@ export function buildSpeedSwapTxParams({
   kind,
   walletType,
   quoteResultCtx,
+  tradeSource,
 }: {
   fromToken: ISwapToken;
   toToken: ISwapToken;
@@ -29,6 +31,7 @@ export function buildSpeedSwapTxParams({
   kind: ESwapQuoteKind;
   walletType?: string;
   quoteResultCtx?: IFetchBuildTxParams['quoteResultCtx'];
+  tradeSource: ESwapTradeSource;
 }): IFetchBuildTxParams {
   return {
     fromTokenAddress: fromToken.contractAddress,
@@ -44,5 +47,6 @@ export function buildSpeedSwapTxParams({
     kind,
     walletType,
     quoteResultCtx,
+    tradeSource,
   };
 }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -87,6 +87,7 @@ import {
   ESwapNetworkFeeLevel,
   ESwapQuoteKind,
   ESwapTabSwitchType,
+  ESwapTradeSource,
   ESwapTxHistoryStatus,
   EWrappedType,
 } from '@onekeyhq/shared/types/swap/types';
@@ -933,6 +934,7 @@ export function useSpeedSwapActions(props: {
             accountId: netAccountRes.result.id,
             protocol: EProtocolOfExchange.SWAP,
             kind: ESwapQuoteKind.SELL,
+            tradeSource: ESwapTradeSource.MARKET_DEX,
           });
 
         if (!buildRes) {
@@ -2359,6 +2361,7 @@ export function useSpeedSwapActions(props: {
             accountId: snapshot.accountId,
             protocol: signedQuoteResult.protocol ?? EProtocolOfExchange.SWAP,
             kind: signedQuoteResult.kind ?? ESwapQuoteKind.SELL,
+            tradeSource: ESwapTradeSource.MARKET_DEX,
           });
 
         if (!buildRes) {

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -127,6 +127,7 @@ import {
   ESwapQuoteKind,
   ESwapSource,
   ESwapTabSwitchType,
+  ESwapTradeSource,
   ESwapTxHistoryStatus,
 } from '@onekeyhq/shared/types/swap/types';
 import type { IToken, ITokenFiat } from '@onekeyhq/shared/types/token';
@@ -2816,6 +2817,7 @@ function SendAmountInputContainer() {
                 quoteResultCtx: privateSendQuote.quoteResultCtx,
                 protocol: EProtocolOfExchange.PRIVATE_SEND,
                 kind: privateSendQuote.kind ?? ESwapQuoteKind.SELL,
+                tradeSource: ESwapTradeSource.UNKNOWN,
               });
 
             if (!buildSwapRes?.changellyOrder) {

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -145,6 +145,7 @@ import {
 import {
   getStockTradeAnalyticsPayload,
   getSwapAnalyticsCategoryFromSwapType,
+  getSwapTradeSource,
 } from '../utils/swapStockAnalytics';
 import { getSwapExecutionTypeFromQuoteResult } from '../utils/swapTypeUtils';
 
@@ -191,6 +192,22 @@ function canFallbackToSeparateTxConfirm({
   );
 }
 
+function getSwapCreateFrom({
+  isSwapPro,
+  isModalPage,
+}: {
+  isSwapPro: boolean;
+  isModalPage: boolean;
+}) {
+  if (isSwapPro) {
+    return 'swapPro';
+  }
+  if (isModalPage) {
+    return 'modal';
+  }
+  return 'swapPage';
+}
+
 /**
  * React hook that manages the full lifecycle of building, approving, signing, and sending swap transactions in a multi-step workflow.
  *
@@ -213,7 +230,9 @@ export function useSwapBuildTx() {
   const swapToAddressInfo = useSwapAddressInfo(ESwapDirectionType.TO);
   const swapProAccount = useSwapProAccount();
   const focusSwapPro = useMemo(() => {
-    return platformEnv.isNative && swapTypeSwitch === ESwapTabSwitchType.LIMIT;
+    return Boolean(
+      platformEnv.isNative && swapTypeSwitch === ESwapTabSwitchType.LIMIT,
+    );
   }, [swapTypeSwitch]);
   const fromUserAddress = useMemo(() => {
     if (focusSwapPro) {
@@ -2092,7 +2111,10 @@ export function useSwapBuildTx() {
         feeType: buildSwapRes.result?.fee?.percentageFee?.toString() ?? '0',
         router: JSON.stringify(buildSwapRes.result?.routesData ?? ''),
         isFirstTime: isFirstTimeSwap,
-        createFrom: isModalPage ? 'modal' : 'swapPage',
+        createFrom: getSwapCreateFrom({
+          isSwapPro: focusSwapPro,
+          isModalPage,
+        }),
         orderId: buildSwapRes?.orderId ?? '',
         orderType: getSwapAnalyticsCategoryFromSwapType(swapType),
         ...getStockTradeAnalyticsPayload({
@@ -2108,6 +2130,7 @@ export function useSwapBuildTx() {
     },
     [
       fromToken,
+      focusSwapPro,
       isFirstTimeSwap,
       isModalPage,
       setPersistSettings,
@@ -2182,6 +2205,10 @@ export function useSwapBuildTx() {
             protocol: data.protocol ?? EProtocolOfExchange.SWAP,
             kind: data.kind ?? ESwapQuoteKind.SELL,
             walletType: swapFromAddressInfo.accountInfo?.wallet?.type ?? '',
+            tradeSource: getSwapTradeSource({
+              protocol: data.protocol,
+              isSwapPro: focusSwapPro,
+            }),
           });
         } catch (e: any) {
           if (!skipLoading) {
@@ -2214,7 +2241,10 @@ export function useSwapBuildTx() {
             feeType: data?.fee?.percentageFee?.toString() ?? '0',
             router: JSON.stringify(data?.routesData ?? ''),
             isFirstTime: isFirstTimeSwap,
-            createFrom: isModalPage ? 'modal' : 'swapPage',
+            createFrom: getSwapCreateFrom({
+              isSwapPro: focusSwapPro,
+              isModalPage,
+            }),
             orderId: buildSwapRes?.orderId ?? '',
             orderType: getSwapAnalyticsCategoryFromSwapType(swapType),
             ...getStockTradeAnalyticsPayload({
@@ -2473,6 +2503,7 @@ export function useSwapBuildTx() {
       checkOtherFee,
       swapFromAddressInfo.accountInfo?.wallet?.type,
       swapFromAddressInfo.accountInfo?.deriveInfo?.addressEncoding,
+      focusSwapPro,
       isFirstTimeSwap,
       isModalPage,
       toAccountId,

--- a/packages/kit/src/views/Swap/pages/components/SwapHeaderContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapHeaderContainer.tsx
@@ -22,6 +22,7 @@ import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useAccountSelectorActions } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector/actions';
 import {
   useSwapActions,
+  useSwapProSelectTokenAtom,
   useSwapSelectFromTokenAtom,
   useSwapTypeSwitchAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
@@ -32,6 +33,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { ITabSwapParamList } from '@onekeyhq/shared/src/routes';
 import {
   ESwapDirectionType,
+  ESwapProAnalyticsEnterFrom,
   type ESwapSource,
   ESwapTabSwitchType,
 } from '@onekeyhq/shared/types/swap/types';
@@ -142,6 +144,7 @@ const SwapHeaderContainer = ({
   const navigation = useAppNavigation<IPageNavigationProp<ITabSwapParamList>>();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
   const [swapProEntryIntent] = useSwapProJumpTokenAtom();
+  const [swapProSelectToken] = useSwapProSelectTokenAtom();
   const { swapTypeSwitchAction } = useSwapActions().current;
   const { networkId } = useSwapAddressInfo(ESwapDirectionType.FROM);
   const { updateSelectedAccountNetwork } = useAccountSelectorActions().current;
@@ -156,6 +159,48 @@ const SwapHeaderContainer = ({
   const hasPendingSwapProEntry = Boolean(
     platformEnv.isNative && pageType !== 'modal' && swapProEntryIntent.token,
   );
+  const isSwapProCategory = Boolean(platformEnv.isNative && showSwapPro);
+  const isSwapProActive = Boolean(
+    isSwapProCategory && swapTypeSwitch === ESwapTabSwitchType.LIMIT,
+  );
+  const swapProEntryFromRef = useRef<ESwapProAnalyticsEnterFrom | undefined>(
+    hasPendingSwapProEntry
+      ? ESwapProAnalyticsEnterFrom.MARKET_DETAIL
+      : undefined,
+  );
+  const wasSwapProActiveRef = useRef<boolean | undefined>(undefined);
+  if (hasPendingSwapProEntry) {
+    swapProEntryFromRef.current = ESwapProAnalyticsEnterFrom.MARKET_DETAIL;
+  }
+  useEffect(() => {
+    if (!isSwapProActive) {
+      wasSwapProActiveRef.current = false;
+      return;
+    }
+    if (wasSwapProActiveRef.current && !hasPendingSwapProEntry) {
+      return;
+    }
+    const token = swapProEntryIntent.token ?? swapProSelectToken;
+    if (!token) {
+      return;
+    }
+    defaultLogger.swap.swapPro.enterSwapPro({
+      enterFrom:
+        swapProEntryFromRef.current ??
+        (wasSwapProActiveRef.current === false
+          ? ESwapProAnalyticsEnterFrom.TRADE_TAB
+          : ESwapProAnalyticsEnterFrom.DEFAULT),
+      tokenSymbol: token.symbol,
+      network: token.networkId,
+    });
+    wasSwapProActiveRef.current = true;
+    swapProEntryFromRef.current = undefined;
+  }, [
+    isSwapProActive,
+    hasPendingSwapProEntry,
+    swapProEntryIntent.token,
+    swapProSelectToken,
+  ]);
   const hadPendingSwapProEntryOnMountRef = useRef(hasPendingSwapProEntry);
   useEffect(() => {
     if (hasPendingSwapProEntry) {
@@ -210,8 +255,14 @@ const SwapHeaderContainer = ({
       if (swapTypeSwitch === newType) return;
 
       defaultLogger.swap.tradeCategorySwitch.tradeCategorySwitch({
-        fromCategory: getSwapAnalyticsCategoryFromSwapType(swapTypeSwitch),
-        toCategory: getSwapAnalyticsCategoryFromSwapType(newType),
+        fromCategory: getSwapAnalyticsCategoryFromSwapType(
+          swapTypeSwitch,
+          isSwapProCategory,
+        ),
+        toCategory: getSwapAnalyticsCategoryFromSwapType(
+          newType,
+          isSwapProCategory,
+        ),
         enterFrom: getSwapAnalyticsEnterFrom(enterFrom),
       });
 
@@ -243,6 +294,7 @@ const SwapHeaderContainer = ({
       fromToken?.networkId,
       updateSelectedAccountNetworkAction,
       enterFrom,
+      isSwapProCategory,
     ],
   );
 

--- a/packages/kit/src/views/Swap/pages/components/SwapProBuySellGroup.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProBuySellGroup.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 
 import { YStack } from '@onekeyhq/components';
 import {
+  useSwapProSelectTokenAtom,
   useSwapProTimeRangeAtom,
   useSwapProTokenMarketDetailInfoAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
@@ -21,6 +22,7 @@ const SwapProBuySellGroup = ({
   supportSpeedSwap?: boolean;
 }) => {
   const [swapProTokenMarketDetailInfo] = useSwapProTokenMarketDetailInfoAtom();
+  const [swapProSelectToken] = useSwapProSelectTokenAtom();
   const [swapProTimeRange, setSwapProTimeRange] = useSwapProTimeRangeAtom();
   const handleTimeRangeChange = useCallback(
     (value: ESwapProTimeRange) => {
@@ -34,10 +36,12 @@ const SwapProBuySellGroup = ({
         value,
       });
       defaultLogger.swap.swapPro.swapProTimeRangeChange({
-        timeRange: value,
+        fromRange: swapProTimeRange.value,
+        toRange: value,
+        tokenSymbol: swapProSelectToken?.symbol ?? '',
       });
     },
-    [setSwapProTimeRange, swapProTimeRange.value],
+    [setSwapProTimeRange, swapProSelectToken?.symbol, swapProTimeRange.value],
   );
   return (
     <YStack testID={SwapTestIDs.proBuySellGroup} gap="$2">

--- a/packages/kit/src/views/Swap/pages/components/SwapProBuySellGroup.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProBuySellGroup.tsx
@@ -1,9 +1,15 @@
+import { useCallback } from 'react';
+
 import { YStack } from '@onekeyhq/components';
 import {
   useSwapProTimeRangeAtom,
   useSwapProTokenMarketDetailInfoAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
-import { swapProTimeRangeItems } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import {
+  type ESwapProTimeRange,
+  swapProTimeRangeItems,
+} from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 
 import SwapProBuySellInfo from '../../components/SwapProBuySellInfo';
 import SwapProTimeRangeSelector from '../../components/SwapProTimeRangeSelector';
@@ -16,6 +22,23 @@ const SwapProBuySellGroup = ({
 }) => {
   const [swapProTokenMarketDetailInfo] = useSwapProTokenMarketDetailInfoAtom();
   const [swapProTimeRange, setSwapProTimeRange] = useSwapProTimeRangeAtom();
+  const handleTimeRangeChange = useCallback(
+    (value: ESwapProTimeRange) => {
+      if (value === swapProTimeRange.value) {
+        return;
+      }
+      setSwapProTimeRange({
+        label:
+          swapProTimeRangeItems.find((item) => item.value === value)?.label ??
+          '',
+        value,
+      });
+      defaultLogger.swap.swapPro.swapProTimeRangeChange({
+        timeRange: value,
+      });
+    },
+    [setSwapProTimeRange, swapProTimeRange.value],
+  );
   return (
     <YStack testID={SwapTestIDs.proBuySellGroup} gap="$2">
       <SwapProBuySellInfo
@@ -27,14 +50,7 @@ const SwapProBuySellGroup = ({
         supportSpeedSwap={supportSpeedSwap}
         items={swapProTimeRangeItems}
         selectedValue={swapProTimeRange}
-        onChange={(value) =>
-          setSwapProTimeRange({
-            label:
-              swapProTimeRangeItems.find((item) => item.value === value)
-                ?.label ?? '',
-            value,
-          })
-        }
+        onChange={handleTimeRangeChange}
       />
     </YStack>
   );

--- a/packages/kit/src/views/Swap/pages/components/SwapProContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProContainer.tsx
@@ -31,6 +31,7 @@ import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms'
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EPerpPageEnterSource } from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import type { IMarketBasicConfigNetwork } from '@onekeyhq/shared/types/marketV2';
 import type {
   IFetchLimitOrderRes,
@@ -195,7 +196,13 @@ const SwapProContainer = ({
 
   const onTokenPressCallback = useCallback(
     (token: ISwapToken) => {
-      if (!token.isStock) {
+      if (
+        !token.isStock &&
+        !equalTokenNoCaseSensitive({
+          token1: token,
+          token2: swapProSelectToken,
+        })
+      ) {
         defaultLogger.swap.swapPro.swapProTokenSwitch({
           selectFrom: ESwapProAnalyticsTokenSelectFrom.POSITIONS,
           tokenSymbol: token.symbol,
@@ -208,7 +215,7 @@ const SwapProContainer = ({
         animated: true,
       });
     },
-    [onTokenPress],
+    [onTokenPress, swapProSelectToken],
   );
 
   const netAccountAddress = netAccountRes.result?.addressDetail.address;

--- a/packages/kit/src/views/Swap/pages/components/SwapProContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProContainer.tsx
@@ -28,6 +28,7 @@ import {
 } from '@onekeyhq/kit/src/views/Market/components/StockMarketStatusAlert';
 import { usePerpsNavigation } from '@onekeyhq/kit/src/views/Market/hooks/usePerpsNavigation';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EPerpPageEnterSource } from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IMarketBasicConfigNetwork } from '@onekeyhq/shared/types/marketV2';
@@ -36,7 +37,10 @@ import type {
   ISwapProSpeedConfig,
   ISwapToken,
 } from '@onekeyhq/shared/types/swap/types';
-import { ESwapProTradeType } from '@onekeyhq/shared/types/swap/types';
+import {
+  ESwapProAnalyticsTokenSelectFrom,
+  ESwapProTradeType,
+} from '@onekeyhq/shared/types/swap/types';
 
 import {
   type IEstimateMarketPresetPriorityFeeFiatValues,
@@ -191,6 +195,13 @@ const SwapProContainer = ({
 
   const onTokenPressCallback = useCallback(
     (token: ISwapToken) => {
+      if (!token.isStock) {
+        defaultLogger.swap.swapPro.swapProTokenSwitch({
+          selectFrom: ESwapProAnalyticsTokenSelectFrom.POSITIONS,
+          tokenSymbol: token.symbol,
+          network: token.networkId,
+        });
+      }
       onTokenPress(token);
       scrollViewRef.current?.scrollTo({
         y: 0,

--- a/packages/kit/src/views/Swap/pages/components/SwapProCurrentSymbolEnable.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProCurrentSymbolEnable.tsx
@@ -5,20 +5,31 @@ import { useIntl } from 'react-intl';
 import { Checkbox, SizableText, XStack } from '@onekeyhq/components';
 import { useSwapProEnableCurrentSymbolAtom } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import type { ESwapProAnalyticsTab } from '@onekeyhq/shared/types/swap/types';
 
 interface ISwapProCurrentSymbolEnableProps {
   isStock?: boolean;
+  analyticsTab?: ESwapProAnalyticsTab;
 }
 
 const SwapProCurrentSymbolEnable = ({
   isStock,
+  analyticsTab,
 }: ISwapProCurrentSymbolEnableProps) => {
   const [swapProEnableCurrentSymbol, setSwapProEnableCurrentSymbol] =
     useSwapProEnableCurrentSymbolAtom();
   const intl = useIntl();
   const toggleSwapProEnableCurrentSymbol = useCallback(() => {
-    setSwapProEnableCurrentSymbol((prev) => !prev);
-  }, [setSwapProEnableCurrentSymbol]);
+    const enabled = !swapProEnableCurrentSymbol;
+    setSwapProEnableCurrentSymbol(enabled);
+    if (analyticsTab) {
+      defaultLogger.swap.swapPro.swapProCurrentSymbolToggle({
+        enabled,
+        tab: analyticsTab,
+      });
+    }
+  }, [analyticsTab, setSwapProEnableCurrentSymbol, swapProEnableCurrentSymbol]);
   // Swap & Bridge and Pro share the same "Current tokens" label; only the Stock
   // tab uses its own "Current stock".
   const labelId = isStock

--- a/packages/kit/src/views/Swap/pages/components/SwapProTabListContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProTabListContainer.tsx
@@ -10,9 +10,13 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IMarketBasicConfigNetwork } from '@onekeyhq/shared/types/marketV2';
-import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
+import {
+  ESwapProAnalyticsTab,
+  ESwapTabSwitchType,
+} from '@onekeyhq/shared/types/swap/types';
 import type {
   IFetchLimitOrderRes,
   ISwapNetwork,
@@ -98,6 +102,32 @@ const SwapProTabListContainer = memo(
     const shouldRenderPositionsContent =
       shouldRenderListContent || hasCachedPositionTokenList;
 
+    const handleTabPress = useCallback(
+      (tab: ETabName) => {
+        if (activeTab === tab) {
+          return;
+        }
+        setActiveTab(tab);
+        if (!focusSwapPro) {
+          return;
+        }
+        if (tab === ETabName.Positions) {
+          defaultLogger.swap.swapPro.swapProTabSwitch({
+            tab: ESwapProAnalyticsTab.POSITIONS,
+          });
+        } else if (tab === ETabName.SwapProOpenOrders) {
+          defaultLogger.swap.swapPro.swapProTabSwitch({
+            tab: ESwapProAnalyticsTab.OPEN_ORDERS,
+          });
+        } else if (tab === ETabName.SwapOrderHistory) {
+          defaultLogger.swap.swapPro.swapProTabSwitch({
+            tab: ESwapProAnalyticsTab.ORDER_HISTORY,
+          });
+        }
+      },
+      [activeTab, focusSwapPro],
+    );
+
     const changeTabToLimitOrderList = useCallback(() => {
       setActiveTab(ETabName.SwapProOpenOrders);
     }, [setActiveTab]);
@@ -150,19 +180,19 @@ const SwapProTabListContainer = memo(
             <TabBarItem
               name={ETabName.Positions}
               isFocused={activeTab === ETabName.Positions}
-              onPress={setActiveTab}
+              onPress={handleTabPress}
             />
             {focusSwapPro ? (
               <TabBarItem
                 name={ETabName.SwapProOpenOrders}
                 isFocused={activeTab === ETabName.SwapProOpenOrders}
-                onPress={setActiveTab}
+                onPress={handleTabPress}
               />
             ) : null}
             <TabBarItem
               name={ETabName.SwapOrderHistory}
               isFocused={activeTab === ETabName.SwapOrderHistory}
-              onPress={setActiveTab}
+              onPress={handleTabPress}
             />
           </XStack>
         </XStack>
@@ -171,7 +201,11 @@ const SwapProTabListContainer = memo(
             display={activeTab === ETabName.Positions ? 'flex' : 'none'}
             flex={1}
           >
-            <SwapProCurrentSymbolEnable />
+            <SwapProCurrentSymbolEnable
+              analyticsTab={
+                focusSwapPro ? ESwapProAnalyticsTab.POSITIONS : undefined
+              }
+            />
             {shouldRenderPositionsContent ? (
               <SwapProPositionsList
                 onTokenPress={onTokenPress}
@@ -191,7 +225,9 @@ const SwapProTabListContainer = memo(
               }
               flex={1}
             >
-              <SwapProCurrentSymbolEnable />
+              <SwapProCurrentSymbolEnable
+                analyticsTab={ESwapProAnalyticsTab.OPEN_ORDERS}
+              />
               {shouldRenderListContent ? (
                 <LimitOrderList
                   onClickCell={onOpenOrdersClick}

--- a/packages/kit/src/views/Swap/pages/components/SwapProTabListContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProTabListContainer.tsx
@@ -58,6 +58,19 @@ function SwapProTabListSkeleton() {
   );
 }
 
+function getSwapProAnalyticsTab(tab: ETabName | string) {
+  if (tab === ETabName.Positions) {
+    return ESwapProAnalyticsTab.POSITIONS;
+  }
+  if (tab === ETabName.SwapProOpenOrders) {
+    return ESwapProAnalyticsTab.OPEN_ORDERS;
+  }
+  if (tab === ETabName.SwapOrderHistory) {
+    return ESwapProAnalyticsTab.ORDER_HISTORY;
+  }
+  return undefined;
+}
+
 const SwapProTabListContainer = memo(
   ({
     onTokenPress,
@@ -111,17 +124,12 @@ const SwapProTabListContainer = memo(
         if (!focusSwapPro) {
           return;
         }
-        if (tab === ETabName.Positions) {
+        const fromTab = getSwapProAnalyticsTab(activeTab);
+        const toTab = getSwapProAnalyticsTab(tab);
+        if (fromTab && toTab) {
           defaultLogger.swap.swapPro.swapProTabSwitch({
-            tab: ESwapProAnalyticsTab.POSITIONS,
-          });
-        } else if (tab === ETabName.SwapProOpenOrders) {
-          defaultLogger.swap.swapPro.swapProTabSwitch({
-            tab: ESwapProAnalyticsTab.OPEN_ORDERS,
-          });
-        } else if (tab === ETabName.SwapOrderHistory) {
-          defaultLogger.swap.swapPro.swapProTabSwitch({
-            tab: ESwapProAnalyticsTab.ORDER_HISTORY,
+            fromTab,
+            toTab,
           });
         }
       },

--- a/packages/kit/src/views/Swap/pages/components/SwapProTradingPanel.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProTradingPanel.tsx
@@ -11,6 +11,7 @@ import {
   useSwapProTradeTypeAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import type { ISwapProSpeedConfig } from '@onekeyhq/shared/types/swap/types';
 import { ESwapProTradeType } from '@onekeyhq/shared/types/swap/types';
 
@@ -97,6 +98,9 @@ const SwapProTradingPanel = ({
       if (value === swapProTradeType) return;
       cleanInputAmount();
       setSwapProTradeType(value);
+      defaultLogger.swap.swapPro.swapProTradeTypeChange({
+        tradeType: value,
+      });
     },
     [cleanInputAmount, setSwapProTradeType, swapProTradeType],
   );

--- a/packages/kit/src/views/Swap/pages/components/SwapProTradingPanel.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProTradingPanel.tsx
@@ -99,7 +99,8 @@ const SwapProTradingPanel = ({
       cleanInputAmount();
       setSwapProTradeType(value);
       defaultLogger.swap.swapPro.swapProTradeTypeChange({
-        tradeType: value,
+        fromType: swapProTradeType,
+        toType: value,
       });
     },
     [cleanInputAmount, setSwapProTradeType, swapProTradeType],

--- a/packages/kit/src/views/Swap/pages/modal/SwapProSelectTokenModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapProSelectTokenModal.tsx
@@ -13,12 +13,14 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import type {
   EModalSwapRoutes,
   IModalSwapParamList,
 } from '@onekeyhq/shared/src/routes';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import type { IMarketSearchV2Token } from '@onekeyhq/shared/types/market';
+import { ESwapProAnalyticsTokenSelectFrom } from '@onekeyhq/shared/types/swap/types';
 
 import {
   MarketNormalTokenList,
@@ -58,6 +60,11 @@ const SwapProSelectTokenPage = ({
   );
   const navigation = useAppNavigation();
   const handleTokenSelect = (token: IMarketToken) => {
+    defaultLogger.swap.swapPro.swapProTokenSwitch({
+      selectFrom: ESwapProAnalyticsTokenSelectFrom.TOKEN_LIST,
+      tokenSymbol: token.symbol,
+      network: token.networkId,
+    });
     navigation.popStack();
     void setSwapProSelectToken({
       networkId: token.networkId,
@@ -74,6 +81,11 @@ const SwapProSelectTokenPage = ({
   const handleSearchTokenSelect = (
     token: IMarketSearchV2Token & { networkLogoURI: string },
   ) => {
+    defaultLogger.swap.swapPro.swapProTokenSwitch({
+      selectFrom: ESwapProAnalyticsTokenSelectFrom.SEARCH,
+      tokenSymbol: token.symbol,
+      network: token.network,
+    });
     navigation.popStack();
     void setSwapProSelectToken({
       networkId: token.network,

--- a/packages/kit/src/views/Swap/pages/modal/SwapProSelectTokenModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapProSelectTokenModal.tsx
@@ -18,6 +18,7 @@ import type {
   EModalSwapRoutes,
   IModalSwapParamList,
 } from '@onekeyhq/shared/src/routes';
+import { equalTokenNoCaseSensitive } from '@onekeyhq/shared/src/utils/tokenUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import type { IMarketSearchV2Token } from '@onekeyhq/shared/types/market';
 import { ESwapProAnalyticsTokenSelectFrom } from '@onekeyhq/shared/types/swap/types';
@@ -60,11 +61,21 @@ const SwapProSelectTokenPage = ({
   );
   const navigation = useAppNavigation();
   const handleTokenSelect = (token: IMarketToken) => {
-    defaultLogger.swap.swapPro.swapProTokenSwitch({
-      selectFrom: ESwapProAnalyticsTokenSelectFrom.TOKEN_LIST,
-      tokenSymbol: token.symbol,
-      network: token.networkId,
-    });
+    if (
+      !equalTokenNoCaseSensitive({
+        token1: swapProTokenSelect,
+        token2: {
+          networkId: token.networkId,
+          contractAddress: token.address,
+        },
+      })
+    ) {
+      defaultLogger.swap.swapPro.swapProTokenSwitch({
+        selectFrom: ESwapProAnalyticsTokenSelectFrom.TOKEN_LIST,
+        tokenSymbol: token.symbol,
+        network: token.networkId,
+      });
+    }
     navigation.popStack();
     void setSwapProSelectToken({
       networkId: token.networkId,
@@ -81,11 +92,21 @@ const SwapProSelectTokenPage = ({
   const handleSearchTokenSelect = (
     token: IMarketSearchV2Token & { networkLogoURI: string },
   ) => {
-    defaultLogger.swap.swapPro.swapProTokenSwitch({
-      selectFrom: ESwapProAnalyticsTokenSelectFrom.SEARCH,
-      tokenSymbol: token.symbol,
-      network: token.network,
-    });
+    if (
+      !equalTokenNoCaseSensitive({
+        token1: swapProTokenSelect,
+        token2: {
+          networkId: token.network,
+          contractAddress: token.address,
+        },
+      })
+    ) {
+      defaultLogger.swap.swapPro.swapProTokenSwitch({
+        selectFrom: ESwapProAnalyticsTokenSelectFrom.SEARCH,
+        tokenSymbol: token.symbol,
+        network: token.network,
+      });
+    }
     navigation.popStack();
     void setSwapProSelectToken({
       networkId: token.network,

--- a/packages/kit/src/views/Swap/utils/swapStockAnalytics.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapStockAnalytics.test.ts
@@ -84,6 +84,7 @@ describe('swapStockAnalytics', () => {
         isSwapPro: false,
       }),
     ).toBe(ESwapTradeSource.UNKNOWN);
+    expect(ESwapTradeSource.PERPS).toBe('perps');
   });
 
   it('maps Swap source values to tradeCategorySwitch enterFrom values', () => {

--- a/packages/kit/src/views/Swap/utils/swapStockAnalytics.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapStockAnalytics.test.ts
@@ -5,6 +5,7 @@ import {
   ESwapAnalyticsEnterFrom,
   ESwapSource,
   ESwapTabSwitchType,
+  ESwapTradeSource,
 } from '@onekeyhq/shared/types/swap/types';
 
 import {
@@ -16,6 +17,7 @@ import {
   getSwapAnalyticsCategory,
   getSwapAnalyticsCategoryFromSwapType,
   getSwapAnalyticsEnterFrom,
+  getSwapTradeSource,
 } from './swapStockAnalytics';
 
 const payToken = {
@@ -52,6 +54,36 @@ describe('swapStockAnalytics', () => {
     expect(getSwapAnalyticsCategoryFromSwapType(ESwapTabSwitchType.LIMIT)).toBe(
       ESwapAnalyticsCategory.LIMIT,
     );
+    expect(
+      getSwapAnalyticsCategoryFromSwapType(ESwapTabSwitchType.LIMIT, true),
+    ).toBe(ESwapAnalyticsCategory.PRO);
+  });
+
+  it('maps build transaction owners to tradeSource values', () => {
+    expect(
+      getSwapTradeSource({
+        protocol: EProtocolOfExchange.SWAP,
+        isSwapPro: false,
+      }),
+    ).toBe(ESwapTradeSource.SWAP_BRIDGE);
+    expect(
+      getSwapTradeSource({
+        protocol: EProtocolOfExchange.LIMIT,
+        isSwapPro: true,
+      }),
+    ).toBe(ESwapTradeSource.SWAP_PRO);
+    expect(
+      getSwapTradeSource({
+        protocol: EProtocolOfExchange.STOCK,
+        isSwapPro: false,
+      }),
+    ).toBe(ESwapTradeSource.STOCK);
+    expect(
+      getSwapTradeSource({
+        protocol: EProtocolOfExchange.PRIVATE_SEND,
+        isSwapPro: false,
+      }),
+    ).toBe(ESwapTradeSource.UNKNOWN);
   });
 
   it('maps Swap source values to tradeCategorySwitch enterFrom values', () => {

--- a/packages/kit/src/views/Swap/utils/swapStockAnalytics.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapStockAnalytics.test.ts
@@ -74,6 +74,12 @@ describe('swapStockAnalytics', () => {
     ).toBe(ESwapTradeSource.SWAP_PRO);
     expect(
       getSwapTradeSource({
+        protocol: EProtocolOfExchange.LIMIT,
+        isSwapPro: false,
+      }),
+    ).toBe(ESwapTradeSource.LIMIT);
+    expect(
+      getSwapTradeSource({
         protocol: EProtocolOfExchange.STOCK,
         isSwapPro: false,
       }),

--- a/packages/kit/src/views/Swap/utils/swapStockAnalytics.ts
+++ b/packages/kit/src/views/Swap/utils/swapStockAnalytics.ts
@@ -60,6 +60,9 @@ export function getSwapTradeSource({
   if (isSwapPro) {
     return ESwapTradeSource.SWAP_PRO;
   }
+  if (protocol === EProtocolOfExchange.LIMIT) {
+    return ESwapTradeSource.LIMIT;
+  }
   return ESwapTradeSource.SWAP_BRIDGE;
 }
 

--- a/packages/kit/src/views/Swap/utils/swapStockAnalytics.ts
+++ b/packages/kit/src/views/Swap/utils/swapStockAnalytics.ts
@@ -10,6 +10,7 @@ import {
   ESwapDirectionType,
   ESwapSource,
   ESwapTabSwitchType,
+  ESwapTradeSource,
 } from '@onekeyhq/shared/types/swap/types';
 
 type IStockAnalyticsToken = Partial<ISwapTokenBase> | undefined;
@@ -26,17 +27,40 @@ export const SWAP_STOCK_ANALYTICS_TRADE_SIDE_SELL = 'Sell';
 
 export function getSwapAnalyticsCategoryFromSwapType(
   swapType?: ESwapTabSwitchType,
+  isSwapPro = false,
 ) {
   if (swapType === ESwapTabSwitchType.BRIDGE) {
     return ESwapAnalyticsCategory.BRIDGE;
   }
   if (swapType === ESwapTabSwitchType.LIMIT) {
+    if (isSwapPro) {
+      return ESwapAnalyticsCategory.PRO;
+    }
     return ESwapAnalyticsCategory.LIMIT;
   }
   if (swapType === ESwapTabSwitchType.STOCK) {
     return ESwapAnalyticsCategory.STOCK;
   }
   return ESwapAnalyticsCategory.SWAP;
+}
+
+export function getSwapTradeSource({
+  protocol,
+  isSwapPro,
+}: {
+  protocol?: EProtocolOfExchange;
+  isSwapPro: boolean;
+}) {
+  if (protocol === EProtocolOfExchange.STOCK) {
+    return ESwapTradeSource.STOCK;
+  }
+  if (protocol === EProtocolOfExchange.PRIVATE_SEND) {
+    return ESwapTradeSource.UNKNOWN;
+  }
+  if (isSwapPro) {
+    return ESwapTradeSource.SWAP_PRO;
+  }
+  return ESwapTradeSource.SWAP_BRIDGE;
 }
 
 export function getSwapAnalyticsCategory({

--- a/packages/shared/src/logger/scopes/swap/index.ts
+++ b/packages/shared/src/logger/scopes/swap/index.ts
@@ -12,6 +12,7 @@ import { StockTradeAlertScene } from './scenes/stockTradeAlert';
 import { SwapEstimateFeeScene } from './scenes/swapEstimateFee';
 import { SwapKlineScene } from './scenes/swapKline';
 import { SwapOrderLongPendingWarningScene } from './scenes/swapOrderLongPendingWarning';
+import { SwapProScene } from './scenes/swapPro';
 import { SwapQuoteScene } from './scenes/swapQuote';
 import { SwapSendTxScene } from './scenes/swapSendTx';
 import { TokenSelectorSearchScene } from './scenes/tokenSelectorSearch';
@@ -64,4 +65,6 @@ export class SwapScope extends BaseScope {
     'swapOrderLongPendingWarning',
     SwapOrderLongPendingWarningScene,
   );
+
+  swapPro = this.createScene('swapPro', SwapProScene);
 }

--- a/packages/shared/src/logger/scopes/swap/scenes/swapPro.ts
+++ b/packages/shared/src/logger/scopes/swap/scenes/swapPro.ts
@@ -22,19 +22,29 @@ export class SwapProScene extends BaseScene {
 
   @LogToServer({ level: 'info' })
   @LogToLocal({ level: 'info' })
-  public swapProTradeTypeChange(params: { tradeType: ESwapProTradeType }) {
+  public swapProTradeTypeChange(params: {
+    fromType: ESwapProTradeType;
+    toType: ESwapProTradeType;
+  }) {
     return params;
   }
 
   @LogToServer({ level: 'info' })
   @LogToLocal({ level: 'info' })
-  public swapProTimeRangeChange(params: { timeRange: ESwapProTimeRange }) {
+  public swapProTimeRangeChange(params: {
+    fromRange: ESwapProTimeRange;
+    toRange: ESwapProTimeRange;
+    tokenSymbol: string;
+  }) {
     return params;
   }
 
   @LogToServer({ level: 'info' })
   @LogToLocal({ level: 'info' })
-  public swapProTabSwitch(params: { tab: ESwapProAnalyticsTab }) {
+  public swapProTabSwitch(params: {
+    fromTab: ESwapProAnalyticsTab;
+    toTab: ESwapProAnalyticsTab;
+  }) {
     return params;
   }
 

--- a/packages/shared/src/logger/scopes/swap/scenes/swapPro.ts
+++ b/packages/shared/src/logger/scopes/swap/scenes/swapPro.ts
@@ -1,0 +1,59 @@
+import type { ESwapProTimeRange } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
+import type {
+  ESwapProAnalyticsEnterFrom,
+  ESwapProAnalyticsTab,
+  ESwapProAnalyticsTokenSelectFrom,
+  ESwapProTradeType,
+} from '@onekeyhq/shared/types/swap/types';
+
+import { BaseScene } from '../../../base/baseScene';
+import { LogToLocal, LogToServer } from '../../../base/decorators';
+
+export class SwapProScene extends BaseScene {
+  @LogToServer({ level: 'info' })
+  @LogToLocal({ level: 'info' })
+  public enterSwapPro(params: {
+    enterFrom: ESwapProAnalyticsEnterFrom;
+    tokenSymbol: string;
+    network: string;
+  }) {
+    return params;
+  }
+
+  @LogToServer({ level: 'info' })
+  @LogToLocal({ level: 'info' })
+  public swapProTradeTypeChange(params: { tradeType: ESwapProTradeType }) {
+    return params;
+  }
+
+  @LogToServer({ level: 'info' })
+  @LogToLocal({ level: 'info' })
+  public swapProTimeRangeChange(params: { timeRange: ESwapProTimeRange }) {
+    return params;
+  }
+
+  @LogToServer({ level: 'info' })
+  @LogToLocal({ level: 'info' })
+  public swapProTabSwitch(params: { tab: ESwapProAnalyticsTab }) {
+    return params;
+  }
+
+  @LogToServer({ level: 'info' })
+  @LogToLocal({ level: 'info' })
+  public swapProCurrentSymbolToggle(params: {
+    enabled: boolean;
+    tab: ESwapProAnalyticsTab;
+  }) {
+    return params;
+  }
+
+  @LogToServer({ level: 'info' })
+  @LogToLocal({ level: 'info' })
+  public swapProTokenSwitch(params: {
+    selectFrom: ESwapProAnalyticsTokenSelectFrom;
+    tokenSymbol: string;
+    network: string;
+  }) {
+    return params;
+  }
+}

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -114,6 +114,7 @@ export enum ESwapTradeSource {
   SWAP_PRO = 'swapPro',
   MARKET_DEX = 'marketDex',
   STOCK = 'stock',
+  PERPS = 'perps',
   UNKNOWN = 'unknown',
 }
 

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -104,8 +104,35 @@ export enum ESwapSource {
 export enum ESwapAnalyticsCategory {
   SWAP = 'Swap',
   BRIDGE = 'Bridge',
+  PRO = 'Pro',
   LIMIT = 'Limit',
   STOCK = 'Stock',
+}
+
+export enum ESwapTradeSource {
+  SWAP_BRIDGE = 'swapBridge',
+  SWAP_PRO = 'swapPro',
+  MARKET_DEX = 'marketDex',
+  STOCK = 'stock',
+  UNKNOWN = 'unknown',
+}
+
+export enum ESwapProAnalyticsEnterFrom {
+  TRADE_TAB = 'tradeTab',
+  MARKET_DETAIL = 'marketDetail',
+  DEFAULT = 'default',
+}
+
+export enum ESwapProAnalyticsTab {
+  POSITIONS = 'positions',
+  OPEN_ORDERS = 'openOrders',
+  ORDER_HISTORY = 'orderHistory',
+}
+
+export enum ESwapProAnalyticsTokenSelectFrom {
+  POSITIONS = 'positions',
+  TOKEN_LIST = 'tokenList',
+  SEARCH = 'search',
 }
 
 export enum ESwapAnalyticsEnterFrom {
@@ -859,6 +886,7 @@ export interface IFetchBuildTxParams extends IFetchSwapQuoteBaseParams {
   userAddress: string;
   receivingAddress: string;
   slippagePercentage: number;
+  tradeSource: ESwapTradeSource;
   toTokenAmount?: string;
   provider: string;
   quoteResultCtx?: any;

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -113,6 +113,7 @@ export enum ESwapTradeSource {
   SWAP_BRIDGE = 'swapBridge',
   SWAP_PRO = 'swapPro',
   MARKET_DEX = 'marketDex',
+  LIMIT = 'limit',
   STOCK = 'stock',
   PERPS = 'perps',
   UNKNOWN = 'unknown',


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58875](https://onekeyhq.atlassian.net/browse/OK-58875)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- add the defined Swap Pro entry, interaction, category-switch, and order-source analytics
- align Swap Pro change events with the documented from/to property contracts and suppress same-token switch noise
- pass typed tradeSource values through /swap/v1/build-tx, /swap/v1/build-tx/speed, and /swap/v1/perp-deposit-quote
- classify Swap & Bridge, Swap Pro, Market DEX, Stock, Perps, and unknown request sources at their owning call sites

## Issues
- Fixes OK-58875

## Tests
- yarn jest packages/kit/src/views/Swap/utils/swapStockAnalytics.test.ts packages/kit-bg/src/services/utils/buildSpeedSwapTxParams.test.ts --runInBand
- yarn agent:check --profile commit
- yarn agent:check --profile pr (local checks passed; Draft release-ready gate remains blocked)

## Pending before ready
- verify analytics delivery and all three endpoint payloads against the shared test environment
- add perps to the authoritative tradeSource value list in Jira/Confluence

## Risk
- analytics and request metadata only; transaction execution behavior is unchanged

[OK-58875]: https://onekeyhq.atlassian.net/browse/OK-58875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ