### PR TITLE
feat: add TradingViewNative debug event log

### DIFF
--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -81,6 +81,8 @@ export interface IDevSettings {
   useLocalTradingViewUrl?: boolean;
   // use the data-only native chart in Market Detail
   useTradingViewNativeInMarketDetail?: boolean;
+  // show the TradingViewNative event log panel
+  showTradingViewNativeDebugPanel?: boolean;
   showPerpsRenderStats?: boolean;
   // Route Unifold deposits to the Arbitrum USDC destination instead of
   // HyperCore, so the whole deposit pipeline can be exercised for source-chain
@@ -176,6 +178,7 @@ export const {
       },
       useLocalTradingViewUrl: false,
       useTradingViewNativeInMarketDetail: false,
+      showTradingViewNativeDebugPanel: true,
       mockTradingViewKLineEmptyEnabled: false,
       mockTradingViewKLineEmptyIntervals: ['1m'],
       showMarketHomeWsDebug: false,

--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -178,7 +178,7 @@ export const {
       },
       useLocalTradingViewUrl: false,
       useTradingViewNativeInMarketDetail: false,
-      showTradingViewNativeDebugPanel: true,
+      showTradingViewNativeDebugPanel: false,
       mockTradingViewKLineEmptyEnabled: false,
       mockTradingViewKLineEmptyIntervals: ['1m'],
       showMarketHomeWsDebug: false,

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.test.tsx
@@ -105,6 +105,10 @@ jest.mock('./TradingViewNativeChartControlsContainer', () => ({
     mockTradingViewNativeChartControlsContainer(props),
 }));
 
+jest.mock('./TradingViewNativeDebugPanel', () => ({
+  TradingViewNativeDebugPanel: () => null,
+}));
+
 describe('TradingViewNativeContainer', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.test.tsx
@@ -105,10 +105,6 @@ jest.mock('./TradingViewNativeChartControlsContainer', () => ({
     mockTradingViewNativeChartControlsContainer(props),
 }));
 
-jest.mock('./TradingViewNativeDebugPanel', () => ({
-  TradingViewNativeDebugPanel: () => null,
-}));
-
 describe('TradingViewNativeContainer', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
@@ -6,6 +6,10 @@ import { Button, SizableText, Stack, YStack } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 import {
+  emitTradingViewNativeDebugEvent,
+  getTradingViewNativeDebugErrorMessage,
+} from './data/tradingViewNativeDebugLogger';
+import {
   buildTradingViewNativeGoToDateTimeRange,
   getTradingViewNativeKLineInterval,
   getTradingViewNativeKLineIntervalForTimeRange,
@@ -13,6 +17,7 @@ import {
 import { useTradingViewNativeKLine } from './data/useTradingViewNativeKLine';
 import { TradingViewNativeChart } from './TradingViewNativeChart';
 import { TradingViewNativeChartControlsContainer } from './TradingViewNativeChartControlsContainer';
+import { TradingViewNativeDebugPanel } from './TradingViewNativeDebugPanel';
 import {
   DEFAULT_TRADING_VIEW_NATIVE_INDICATORS,
   type ITradingViewNativeIndicator,
@@ -21,9 +26,22 @@ import {
 import { hasTradingViewNativeVolume } from './utils/chartLayout';
 
 import type { ITradingViewNativeChartInterval } from './data/tradingViewNativeIntervals';
-import type { ITradingViewNativeProps } from './types';
+import type {
+  ITradingViewNativeDataState,
+  ITradingViewNativeProps,
+} from './types';
 import type { ITradingViewNativeViewportTarget } from './utils/chartViewport';
 import type { ICalendarPanelSubmitPayload } from '../TradingViewChartControls/calendarControls/CalendarPanelPopover';
+
+function getDataStateDebugLevel(status: ITradingViewNativeDataState['status']) {
+  if (status === 'error') {
+    return 'error' as const;
+  }
+  if (status === 'stale' || status === 'reconnecting') {
+    return 'warning' as const;
+  }
+  return 'info' as const;
+}
 
 export const TradingViewNativeContainer = memo(
   ({
@@ -120,6 +138,72 @@ export const TradingViewNativeContainer = memo(
     const latestPoint = points[points.length - 1];
     const latestPrice = latestPoint?.c;
     const latestPriceTimestamp = latestPoint?.t;
+    const sourceCoin = source.kind === 'hyperliquid' ? source.coin : undefined;
+    const sourceEnvironment =
+      source.kind === 'hyperliquid' ? source.environment : undefined;
+    const sourceNetworkId =
+      source.kind === 'market' ? source.networkId : undefined;
+    const sourceRealtime =
+      source.kind === 'market' ? source.realtime : undefined;
+    const sourceSymbol = source.kind === 'market' ? source.symbol : undefined;
+    const sourceTokenAddress =
+      source.kind === 'market' ? source.tokenAddress : undefined;
+
+    useEffect(() => {
+      emitTradingViewNativeDebugEvent({ name: 'chart.mount' });
+      return () => {
+        emitTradingViewNativeDebugEvent({ name: 'chart.unmount' });
+      };
+    }, []);
+
+    useEffect(() => {
+      emitTradingViewNativeDebugEvent({
+        details: {
+          coin: sourceCoin,
+          environment: sourceEnvironment,
+          kind: source.kind,
+          networkId: sourceNetworkId,
+          providerKey: dataProviderKey,
+          realtime: sourceRealtime,
+          symbol: sourceSymbol,
+          tokenAddress: sourceTokenAddress,
+        },
+        name: 'source.selected',
+      });
+    }, [
+      dataProviderKey,
+      source.kind,
+      sourceCoin,
+      sourceEnvironment,
+      sourceNetworkId,
+      sourceRealtime,
+      sourceSymbol,
+      sourceTokenAddress,
+    ]);
+
+    useEffect(() => {
+      emitTradingViewNativeDebugEvent({
+        details: {
+          error: dataState.error
+            ? getTradingViewNativeDebugErrorMessage(dataState.error)
+            : undefined,
+          interval: intervalConfig.activeInterval,
+          lastUpdatedAt: dataState.lastUpdatedAt,
+          points: points.length,
+          providerKey: dataProviderKey,
+          status: dataState.status,
+        },
+        level: getDataStateDebugLevel(dataState.status),
+        name: 'data.state',
+      });
+    }, [
+      dataProviderKey,
+      dataState.error,
+      dataState.lastUpdatedAt,
+      dataState.status,
+      intervalConfig.activeInterval,
+      points.length,
+    ]);
 
     useEffect(() => {
       realtimePointRef.current = undefined;
@@ -155,9 +239,26 @@ export const TradingViewNativeContainer = memo(
         const nextInterval = getTradingViewNativeKLineInterval(interval);
         const fromInterval = intervalConfig.activeInterval;
         if (!nextInterval || nextInterval.value === fromInterval) {
+          emitTradingViewNativeDebugEvent({
+            details: {
+              fromInterval,
+              requestedInterval: interval,
+              resolvedInterval: nextInterval?.value,
+            },
+            level: 'warning',
+            name: 'interval.change.ignored',
+          });
           return;
         }
 
+        emitTradingViewNativeDebugEvent({
+          details: {
+            fromInterval,
+            skipNextHistoryRequest: Boolean(options?.skipNextHistoryRequest),
+            toInterval: nextInterval.value,
+          },
+          name: 'interval.change.requested',
+        });
         handleIntervalChange(nextInterval.value, options);
         onIntervalChange?.({
           fromInterval,
@@ -332,6 +433,7 @@ export const TradingViewNativeContainer = memo(
             </YStack>
           ) : null}
         </Stack>
+        <TradingViewNativeDebugPanel />
       </Stack>
     );
   },

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
@@ -17,7 +17,6 @@ import {
 import { useTradingViewNativeKLine } from './data/useTradingViewNativeKLine';
 import { TradingViewNativeChart } from './TradingViewNativeChart';
 import { TradingViewNativeChartControlsContainer } from './TradingViewNativeChartControlsContainer';
-import { TradingViewNativeDebugPanel } from './TradingViewNativeDebugPanel';
 import {
   DEFAULT_TRADING_VIEW_NATIVE_INDICATORS,
   type ITradingViewNativeIndicator,
@@ -433,7 +432,6 @@ export const TradingViewNativeContainer = memo(
             </YStack>
           ) : null}
         </Stack>
-        <TradingViewNativeDebugPanel />
       </Stack>
     );
   },

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeDebugPanel.native.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeDebugPanel.native.tsx
@@ -1,3 +1,5 @@
 export function TradingViewNativeDebugPanel() {
   return null;
 }
+
+export default TradingViewNativeDebugPanel;

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeDebugPanel.native.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeDebugPanel.native.tsx
@@ -1,0 +1,3 @@
+export function TradingViewNativeDebugPanel() {
+  return null;
+}

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeDebugPanel.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeDebugPanel.test.tsx
@@ -18,36 +18,6 @@ import {
 } from './data/tradingViewNativeDebugLogger';
 import { TradingViewNativeDebugPanel } from './TradingViewNativeDebugPanel';
 
-jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings', () => {
-  const React = jest.requireActual<typeof import('react')>('react');
-  const mockDevSettings: {
-    enabled: boolean;
-    settings: { showTradingViewNativeDebugPanel?: boolean };
-  } = {
-    enabled: true,
-    settings: { showTradingViewNativeDebugPanel: true },
-  };
-  return {
-    mockDevSettings,
-    useDevSettingsPersistAtom: () => {
-      const [value, setValue] = React.useState(mockDevSettings);
-      const setPersistedValue = React.useCallback(
-        (
-          updater: (previous: typeof mockDevSettings) => typeof mockDevSettings,
-        ) => {
-          setValue((previous) => {
-            const next = updater(previous);
-            Object.assign(mockDevSettings, next);
-            return next;
-          });
-        },
-        [],
-      );
-      return [value, setPersistedValue];
-    },
-  };
-});
-
 jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
   __esModule: true,
   default: {
@@ -56,27 +26,14 @@ jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
   },
 }));
 
-const mockDevSettings = jest.requireMock(
-  '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings',
-).mockDevSettings as {
-  enabled: boolean;
-  settings: { showTradingViewNativeDebugPanel?: boolean };
-};
-const mockPlatformEnv = jest.requireMock('@onekeyhq/shared/src/platformEnv')
-  .default as {
-  isDev: boolean;
-  isWeb: boolean;
-};
 const mockWriteClipboardText = jest.fn<Promise<void>, [string]>();
+const mockOnClose = jest.fn();
 const originalResizeObserver = globalThis.ResizeObserver;
 let triggerResizeObserver: (() => void) | undefined;
 
 describe('TradingViewNativeDebugPanel', () => {
   beforeEach(() => {
-    mockDevSettings.enabled = true;
-    mockDevSettings.settings = { showTradingViewNativeDebugPanel: true };
-    mockPlatformEnv.isDev = true;
-    mockPlatformEnv.isWeb = true;
+    mockOnClose.mockReset();
     clearTradingViewNativeDebugEvents();
     globalThis.localStorage.clear();
     Object.defineProperty(globalThis, 'innerHeight', {
@@ -126,7 +83,7 @@ describe('TradingViewNativeDebugPanel', () => {
       name: 'history.response',
     });
 
-    render(<TradingViewNativeDebugPanel />);
+    render(<TradingViewNativeDebugPanel onClose={mockOnClose} />);
 
     const panel = screen.getByTestId('trading-view-native-debug-panel');
     expect(panel.style.zIndex).toBe(
@@ -141,7 +98,7 @@ describe('TradingViewNativeDebugPanel', () => {
   });
 
   it('can be dragged and persists its position', () => {
-    render(<TradingViewNativeDebugPanel />);
+    render(<TradingViewNativeDebugPanel onClose={mockOnClose} />);
     const panel = screen.getByTestId('trading-view-native-debug-panel');
     const dragHandle = screen.getByTestId(
       'trading-view-native-debug-panel-drag-handle',
@@ -183,7 +140,7 @@ describe('TradingViewNativeDebugPanel', () => {
       level: 'warning',
       name: 'history.response',
     });
-    render(<TradingViewNativeDebugPanel />);
+    render(<TradingViewNativeDebugPanel onClose={mockOnClose} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Copy event log' }));
 
@@ -204,7 +161,7 @@ describe('TradingViewNativeDebugPanel', () => {
       new Error('Clipboard unavailable'),
     );
     emitTradingViewNativeDebugEvent({ name: 'chart.mount' });
-    render(<TradingViewNativeDebugPanel />);
+    render(<TradingViewNativeDebugPanel onClose={mockOnClose} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Copy event log' }));
 
@@ -212,7 +169,7 @@ describe('TradingViewNativeDebugPanel', () => {
   });
 
   it('uses native resize and persists the observed size', () => {
-    render(<TradingViewNativeDebugPanel />);
+    render(<TradingViewNativeDebugPanel onClose={mockOnClose} />);
     const panel = screen.getByTestId('trading-view-native-debug-panel');
     expect(panel.style.resize).toBe('both');
     expect(panel.style.minHeight).toBe('180px');
@@ -243,7 +200,7 @@ describe('TradingViewNativeDebugPanel', () => {
 
   it('does not force the event list to the bottom after the user scrolls up', () => {
     emitTradingViewNativeDebugEvent({ name: 'chart.mount' });
-    render(<TradingViewNativeDebugPanel />);
+    render(<TradingViewNativeDebugPanel onClose={mockOnClose} />);
 
     const eventList = screen.getByTestId(
       'trading-view-native-debug-event-list',
@@ -277,39 +234,11 @@ describe('TradingViewNativeDebugPanel', () => {
     expect(eventList.scrollTop).toBe(scrollHeight);
   });
 
-  it('closes the panel and persists the developer setting', () => {
-    const { unmount } = render(<TradingViewNativeDebugPanel />);
+  it('notifies the global owner when the panel is closed', () => {
+    render(<TradingViewNativeDebugPanel onClose={mockOnClose} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Close event log' }));
 
-    expect(screen.queryByTestId('trading-view-native-debug-panel')).toBeNull();
-    expect(mockDevSettings.settings.showTradingViewNativeDebugPanel).toBe(
-      false,
-    );
-
-    unmount();
-    render(<TradingViewNativeDebugPanel />);
-    expect(screen.queryByTestId('trading-view-native-debug-panel')).toBeNull();
-  });
-
-  it('defaults the panel to visible when the setting is missing', () => {
-    mockDevSettings.settings = {};
-    render(<TradingViewNativeDebugPanel />);
-
-    expect(screen.getByTestId('trading-view-native-debug-panel')).toBeTruthy();
-  });
-
-  it('stays hidden when developer mode is disabled', () => {
-    mockDevSettings.enabled = false;
-    render(<TradingViewNativeDebugPanel />);
-
-    expect(screen.queryByTestId('trading-view-native-debug-panel')).toBeNull();
-  });
-
-  it('stays hidden outside a local Web development build', () => {
-    mockPlatformEnv.isDev = false;
-    render(<TradingViewNativeDebugPanel />);
-
-    expect(screen.queryByTestId('trading-view-native-debug-panel')).toBeNull();
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeDebugPanel.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeDebugPanel.test.tsx
@@ -1,0 +1,315 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+
+import { DEV_OVERLAY_FLOAT_BUTTON_Z_INDEX } from '@onekeyhq/shared/src/consts/zIndexConsts';
+
+import {
+  clearTradingViewNativeDebugEvents,
+  emitTradingViewNativeDebugEvent,
+} from './data/tradingViewNativeDebugLogger';
+import { TradingViewNativeDebugPanel } from './TradingViewNativeDebugPanel';
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const mockDevSettings: {
+    enabled: boolean;
+    settings: { showTradingViewNativeDebugPanel?: boolean };
+  } = {
+    enabled: true,
+    settings: { showTradingViewNativeDebugPanel: true },
+  };
+  return {
+    mockDevSettings,
+    useDevSettingsPersistAtom: () => {
+      const [value, setValue] = React.useState(mockDevSettings);
+      const setPersistedValue = React.useCallback(
+        (
+          updater: (previous: typeof mockDevSettings) => typeof mockDevSettings,
+        ) => {
+          setValue((previous) => {
+            const next = updater(previous);
+            Object.assign(mockDevSettings, next);
+            return next;
+          });
+        },
+        [],
+      );
+      return [value, setPersistedValue];
+    },
+  };
+});
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: {
+    isDev: true,
+    isWeb: true,
+  },
+}));
+
+const mockDevSettings = jest.requireMock(
+  '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings',
+).mockDevSettings as {
+  enabled: boolean;
+  settings: { showTradingViewNativeDebugPanel?: boolean };
+};
+const mockPlatformEnv = jest.requireMock('@onekeyhq/shared/src/platformEnv')
+  .default as {
+  isDev: boolean;
+  isWeb: boolean;
+};
+const mockWriteClipboardText = jest.fn<Promise<void>, [string]>();
+const originalResizeObserver = globalThis.ResizeObserver;
+let triggerResizeObserver: (() => void) | undefined;
+
+describe('TradingViewNativeDebugPanel', () => {
+  beforeEach(() => {
+    mockDevSettings.enabled = true;
+    mockDevSettings.settings = { showTradingViewNativeDebugPanel: true };
+    mockPlatformEnv.isDev = true;
+    mockPlatformEnv.isWeb = true;
+    clearTradingViewNativeDebugEvents();
+    globalThis.localStorage.clear();
+    Object.defineProperty(globalThis, 'innerHeight', {
+      configurable: true,
+      value: 800,
+    });
+    Object.defineProperty(globalThis, 'innerWidth', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(globalThis, 'PointerEvent', {
+      configurable: true,
+      value: MouseEvent,
+    });
+    triggerResizeObserver = undefined;
+    globalThis.ResizeObserver = class ResizeObserverMock {
+      constructor(callback: ResizeObserverCallback) {
+        triggerResizeObserver = () => callback([], this);
+      }
+
+      observe() {}
+
+      unobserve() {}
+
+      disconnect() {}
+    };
+    mockWriteClipboardText.mockReset().mockResolvedValue();
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: mockWriteClipboardText,
+      },
+    });
+  });
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver;
+  });
+
+  it('shows chart events at the highest development overlay layer', () => {
+    emitTradingViewNativeDebugEvent({
+      details: {
+        historySource: 'fallback',
+        points: 120,
+      },
+      level: 'warning',
+      name: 'history.response',
+    });
+
+    render(<TradingViewNativeDebugPanel />);
+
+    const panel = screen.getByTestId('trading-view-native-debug-panel');
+    expect(panel.style.zIndex).toBe(
+      DEV_OVERLAY_FLOAT_BUTTON_Z_INDEX.toString(),
+    );
+    expect(screen.getByText(/history\.response/)).toBeTruthy();
+    expect(screen.getByText(/historySource=fallback/)).toBeTruthy();
+    expect(screen.getByText(/points=120/)).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Clear'));
+    expect(screen.getByText('Waiting for chart events…')).toBeTruthy();
+  });
+
+  it('can be dragged and persists its position', () => {
+    render(<TradingViewNativeDebugPanel />);
+    const panel = screen.getByTestId('trading-view-native-debug-panel');
+    const dragHandle = screen.getByTestId(
+      'trading-view-native-debug-panel-drag-handle',
+    );
+    const initialLeft = Number.parseFloat(panel.style.left);
+    const initialTop = Number.parseFloat(panel.style.top);
+
+    fireEvent.pointerDown(dragHandle, {
+      clientX: initialLeft + 20,
+      clientY: initialTop + 20,
+      pointerId: 1,
+    });
+    fireEvent.pointerMove(dragHandle, {
+      clientX: initialLeft - 80,
+      clientY: initialTop + 100,
+      pointerId: 1,
+    });
+    fireEvent.pointerUp(dragHandle, {
+      clientX: initialLeft - 80,
+      clientY: initialTop + 100,
+      pointerId: 1,
+    });
+
+    expect(Number.parseFloat(panel.style.left)).toBeLessThan(initialLeft);
+    expect(Number.parseFloat(panel.style.top)).toBeGreaterThan(initialTop);
+    expect(
+      globalThis.localStorage.getItem(
+        'trading_view_native_debug_panel_position',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('copies the complete event log as plain text', async () => {
+    emitTradingViewNativeDebugEvent({
+      details: {
+        historySource: 'fallback',
+        points: 120,
+      },
+      level: 'warning',
+      name: 'history.response',
+    });
+    render(<TradingViewNativeDebugPanel />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy event log' }));
+
+    await waitFor(() => {
+      expect(mockWriteClipboardText).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('Copied')).toBeTruthy();
+    });
+    const copiedText = mockWriteClipboardText.mock.calls[0][0];
+    expect(copiedText).toMatch(
+      /^\d{4}-\d{2}-\d{2}T.* \[WARNING\] history\.response /,
+    );
+    expect(copiedText).toContain('historySource=fallback');
+    expect(copiedText).toContain('points=120');
+  });
+
+  it('shows a failure state when clipboard access fails', async () => {
+    mockWriteClipboardText.mockRejectedValueOnce(
+      new Error('Clipboard unavailable'),
+    );
+    emitTradingViewNativeDebugEvent({ name: 'chart.mount' });
+    render(<TradingViewNativeDebugPanel />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy event log' }));
+
+    await waitFor(() => expect(screen.getByText('Failed')).toBeTruthy());
+  });
+
+  it('uses native resize and persists the observed size', () => {
+    render(<TradingViewNativeDebugPanel />);
+    const panel = screen.getByTestId('trading-view-native-debug-panel');
+    expect(panel.style.resize).toBe('both');
+    expect(panel.style.minHeight).toBe('180px');
+    expect(panel.style.minWidth).toBe('300px');
+
+    jest.spyOn(panel, 'getBoundingClientRect').mockReturnValue({
+      bottom: 0,
+      height: 240,
+      left: 0,
+      right: 0,
+      toJSON: () => ({}),
+      top: 0,
+      width: 340,
+      x: 0,
+      y: 0,
+    });
+    act(() => triggerResizeObserver?.());
+
+    expect(panel.style.height).toBe('240px');
+    expect(panel.style.width).toBe('340px');
+    expect(
+      globalThis.localStorage.getItem('trading_view_native_debug_panel_size'),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse event log' }));
+    expect(panel.style.resize).toBe('none');
+  });
+
+  it('does not force the event list to the bottom after the user scrolls up', () => {
+    emitTradingViewNativeDebugEvent({ name: 'chart.mount' });
+    render(<TradingViewNativeDebugPanel />);
+
+    const eventList = screen.getByTestId(
+      'trading-view-native-debug-event-list',
+    );
+    let scrollHeight = 1000;
+    Object.defineProperty(eventList, 'clientHeight', {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(eventList, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    eventList.scrollTop = 300;
+    fireEvent.scroll(eventList);
+
+    scrollHeight = 1100;
+    act(() => {
+      emitTradingViewNativeDebugEvent({ name: 'history.response' });
+    });
+
+    expect(eventList.scrollTop).toBe(300);
+
+    eventList.scrollTop = scrollHeight - eventList.clientHeight;
+    fireEvent.scroll(eventList);
+    scrollHeight = 1200;
+    act(() => {
+      emitTradingViewNativeDebugEvent({ name: 'realtime.update' });
+    });
+
+    expect(eventList.scrollTop).toBe(scrollHeight);
+  });
+
+  it('closes the panel and persists the developer setting', () => {
+    const { unmount } = render(<TradingViewNativeDebugPanel />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close event log' }));
+
+    expect(screen.queryByTestId('trading-view-native-debug-panel')).toBeNull();
+    expect(mockDevSettings.settings.showTradingViewNativeDebugPanel).toBe(
+      false,
+    );
+
+    unmount();
+    render(<TradingViewNativeDebugPanel />);
+    expect(screen.queryByTestId('trading-view-native-debug-panel')).toBeNull();
+  });
+
+  it('defaults the panel to visible when the setting is missing', () => {
+    mockDevSettings.settings = {};
+    render(<TradingViewNativeDebugPanel />);
+
+    expect(screen.getByTestId('trading-view-native-debug-panel')).toBeTruthy();
+  });
+
+  it('stays hidden when developer mode is disabled', () => {
+    mockDevSettings.enabled = false;
+    render(<TradingViewNativeDebugPanel />);
+
+    expect(screen.queryByTestId('trading-view-native-debug-panel')).toBeNull();
+  });
+
+  it('stays hidden outside a local Web development build', () => {
+    mockPlatformEnv.isDev = false;
+    render(<TradingViewNativeDebugPanel />);
+
+    expect(screen.queryByTestId('trading-view-native-debug-panel')).toBeNull();
+  });
+});

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeDebugPanel.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeDebugPanel.test.tsx
@@ -15,6 +15,7 @@ import { DEV_OVERLAY_FLOAT_BUTTON_Z_INDEX } from '@onekeyhq/shared/src/consts/zI
 import {
   clearTradingViewNativeDebugEvents,
   emitTradingViewNativeDebugEvent,
+  setTradingViewNativeDebugEventCollectionEnabled,
 } from './data/tradingViewNativeDebugLogger';
 import { TradingViewNativeDebugPanel } from './TradingViewNativeDebugPanel';
 
@@ -33,6 +34,7 @@ let triggerResizeObserver: (() => void) | undefined;
 
 describe('TradingViewNativeDebugPanel', () => {
   beforeEach(() => {
+    setTradingViewNativeDebugEventCollectionEnabled(true);
     mockOnClose.mockReset();
     clearTradingViewNativeDebugEvents();
     globalThis.localStorage.clear();
@@ -70,6 +72,7 @@ describe('TradingViewNativeDebugPanel', () => {
   });
 
   afterEach(() => {
+    setTradingViewNativeDebugEventCollectionEnabled(false);
     globalThis.ResizeObserver = originalResizeObserver;
   });
 

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeDebugPanel.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeDebugPanel.tsx
@@ -13,9 +13,7 @@ import {
 
 import { createPortal } from 'react-dom';
 
-import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import { DEV_OVERLAY_FLOAT_BUTTON_Z_INDEX } from '@onekeyhq/shared/src/consts/zIndexConsts';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import {
   clearTradingViewNativeDebugEvents,
@@ -267,8 +265,13 @@ function getEventColor(level: ITradingViewNativeDebugEvent['level']) {
   return '#8b949e';
 }
 
-function BasicTradingViewNativeDebugPanel() {
-  const [devSettings, setDevSettings] = useDevSettingsPersistAtom();
+export interface ITradingViewNativeDebugPanelProps {
+  onClose: () => void;
+}
+
+function BasicTradingViewNativeDebugPanel({
+  onClose,
+}: ITradingViewNativeDebugPanelProps) {
   const events = useSyncExternalStore(
     subscribeTradingViewNativeDebugEvents,
     getTradingViewNativeDebugEvents,
@@ -400,16 +403,6 @@ function BasicTradingViewNativeDebugPanel() {
     [],
   );
 
-  const handleClose = useCallback(() => {
-    setDevSettings((current) => ({
-      ...current,
-      settings: {
-        ...current.settings,
-        showTradingViewNativeDebugPanel: false,
-      },
-    }));
-  }, [setDevSettings]);
-
   const handlePointerDown = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
       if ((event.target as HTMLElement).closest('button')) {
@@ -466,16 +459,6 @@ function BasicTradingViewNativeDebugPanel() {
     },
     [],
   );
-
-  if (
-    !platformEnv.isDev ||
-    !platformEnv.isWeb ||
-    !devSettings.enabled ||
-    devSettings.settings?.showTradingViewNativeDebugPanel === false ||
-    !globalThis.document?.body
-  ) {
-    return null;
-  }
 
   const panelSize = getPanelSize(size, isCollapsed);
   const panelSizeLimits = getPanelSizeLimits(position);
@@ -604,7 +587,7 @@ function BasicTradingViewNativeDebugPanel() {
         </button>
         <button
           aria-label="Close event log"
-          onClick={handleClose}
+          onClick={onClose}
           style={{
             background: 'transparent',
             border: 0,
@@ -668,3 +651,5 @@ function BasicTradingViewNativeDebugPanel() {
 export const TradingViewNativeDebugPanel = memo(
   BasicTradingViewNativeDebugPanel,
 );
+
+export default TradingViewNativeDebugPanel;

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeDebugPanel.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeDebugPanel.tsx
@@ -1,0 +1,670 @@
+import type {
+  PointerEvent as ReactPointerEvent,
+  UIEvent as ReactUIEvent,
+} from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+
+import { createPortal } from 'react-dom';
+
+import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
+import { DEV_OVERLAY_FLOAT_BUTTON_Z_INDEX } from '@onekeyhq/shared/src/consts/zIndexConsts';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import {
+  clearTradingViewNativeDebugEvents,
+  getTradingViewNativeDebugEvents,
+  subscribeTradingViewNativeDebugEvents,
+} from './data/tradingViewNativeDebugLogger';
+
+import type {
+  ITradingViewNativeDebugEvent,
+  ITradingViewNativeDebugEventDetails,
+} from './data/tradingViewNativeDebugLogger';
+
+const PANEL_STORAGE_KEY = 'trading_view_native_debug_panel_position';
+const PANEL_SIZE_STORAGE_KEY = 'trading_view_native_debug_panel_size';
+const PANEL_MARGIN = 12;
+const PANEL_WIDTH = 420;
+const PANEL_HEIGHT = 320;
+const PANEL_MIN_WIDTH = 300;
+const PANEL_MIN_HEIGHT = 180;
+const PANEL_COLLAPSED_HEIGHT = 42;
+const COPY_STATUS_RESET_DELAY_MS = 1500;
+const AUTO_SCROLL_BOTTOM_THRESHOLD_PX = 1;
+
+interface IPanelPosition {
+  x: number;
+  y: number;
+}
+
+interface IPanelSize {
+  height: number;
+  width: number;
+}
+
+interface IDragState {
+  offsetX: number;
+  offsetY: number;
+  pointerId: number;
+}
+
+type ICopyStatus = 'copied' | 'failed' | 'idle';
+
+const COPY_STATUS_LABEL: Record<ICopyStatus, string> = {
+  copied: 'Copied',
+  failed: 'Failed',
+  idle: 'Copy',
+};
+
+function getViewportSize() {
+  return {
+    height: globalThis.innerHeight || PANEL_HEIGHT + PANEL_MARGIN * 2,
+    width: globalThis.innerWidth || PANEL_WIDTH + PANEL_MARGIN * 2,
+  };
+}
+
+function getPanelSizeLimits(
+  position: IPanelPosition = { x: PANEL_MARGIN, y: PANEL_MARGIN },
+) {
+  const viewport = getViewportSize();
+  const maxHeight = Math.max(
+    viewport.height - position.y - PANEL_MARGIN,
+    PANEL_COLLAPSED_HEIGHT,
+  );
+  const maxWidth = Math.max(
+    viewport.width - position.x - PANEL_MARGIN,
+    PANEL_MARGIN,
+  );
+  return {
+    maxHeight,
+    maxWidth,
+    minHeight: Math.min(PANEL_MIN_HEIGHT, maxHeight),
+    minWidth: Math.min(PANEL_MIN_WIDTH, maxWidth),
+  };
+}
+
+function clampPanelSize(
+  size: IPanelSize,
+  position: IPanelPosition = { x: PANEL_MARGIN, y: PANEL_MARGIN },
+) {
+  const limits = getPanelSizeLimits(position);
+  return {
+    height: Math.min(Math.max(size.height, limits.minHeight), limits.maxHeight),
+    width: Math.min(Math.max(size.width, limits.minWidth), limits.maxWidth),
+  };
+}
+
+function getPanelSize(size: IPanelSize, isCollapsed: boolean) {
+  const clampedSize = clampPanelSize(size);
+  return {
+    height: isCollapsed ? PANEL_COLLAPSED_HEIGHT : clampedSize.height,
+    width: clampedSize.width,
+  };
+}
+
+function clampPanelPosition(
+  position: IPanelPosition,
+  isCollapsed: boolean,
+  size: IPanelSize,
+): IPanelPosition {
+  const viewport = getViewportSize();
+  const panel = getPanelSize(size, isCollapsed);
+  return {
+    x: Math.min(
+      Math.max(position.x, PANEL_MARGIN),
+      Math.max(viewport.width - panel.width - PANEL_MARGIN, PANEL_MARGIN),
+    ),
+    y: Math.min(
+      Math.max(position.y, PANEL_MARGIN),
+      Math.max(viewport.height - panel.height - PANEL_MARGIN, PANEL_MARGIN),
+    ),
+  };
+}
+
+function getDefaultPanelSize() {
+  return clampPanelSize({ height: PANEL_HEIGHT, width: PANEL_WIDTH });
+}
+
+function getDefaultPanelPosition(size: IPanelSize) {
+  const viewport = getViewportSize();
+  const panel = getPanelSize(size, false);
+  return clampPanelPosition(
+    {
+      x: viewport.width - panel.width - PANEL_MARGIN,
+      y: 72,
+    },
+    false,
+    size,
+  );
+}
+
+function loadPanelSize() {
+  try {
+    const storedSize = globalThis.localStorage?.getItem(PANEL_SIZE_STORAGE_KEY);
+    if (!storedSize) {
+      return getDefaultPanelSize();
+    }
+    const parsedSize = JSON.parse(storedSize) as Partial<IPanelSize>;
+    if (
+      typeof parsedSize.height === 'number' &&
+      Number.isFinite(parsedSize.height) &&
+      typeof parsedSize.width === 'number' &&
+      Number.isFinite(parsedSize.width)
+    ) {
+      return clampPanelSize({
+        height: parsedSize.height,
+        width: parsedSize.width,
+      });
+    }
+  } catch {
+    // Ignore invalid development-only persisted state.
+  }
+  return getDefaultPanelSize();
+}
+
+function loadPanelPosition(size: IPanelSize) {
+  try {
+    const storedPosition = globalThis.localStorage?.getItem(PANEL_STORAGE_KEY);
+    if (!storedPosition) {
+      return getDefaultPanelPosition(size);
+    }
+    const parsedPosition = JSON.parse(
+      storedPosition,
+    ) as Partial<IPanelPosition>;
+    if (
+      typeof parsedPosition.x === 'number' &&
+      Number.isFinite(parsedPosition.x) &&
+      typeof parsedPosition.y === 'number' &&
+      Number.isFinite(parsedPosition.y)
+    ) {
+      return clampPanelPosition(
+        { x: parsedPosition.x, y: parsedPosition.y },
+        false,
+        size,
+      );
+    }
+  } catch {
+    // Ignore invalid development-only persisted state.
+  }
+  return getDefaultPanelPosition(size);
+}
+
+function savePanelPosition(position: IPanelPosition) {
+  try {
+    globalThis.localStorage?.setItem(
+      PANEL_STORAGE_KEY,
+      JSON.stringify(position),
+    );
+  } catch {
+    // Ignore unavailable development-only storage.
+  }
+}
+
+function savePanelSize(size: IPanelSize) {
+  try {
+    globalThis.localStorage?.setItem(
+      PANEL_SIZE_STORAGE_KEY,
+      JSON.stringify(size),
+    );
+  } catch {
+    // Ignore unavailable development-only storage.
+  }
+}
+
+function padTimePart(value: number, width = 2) {
+  return value.toString().padStart(width, '0');
+}
+
+function formatEventTime(timestamp: number) {
+  const date = new Date(timestamp);
+  return `${padTimePart(date.getHours())}:${padTimePart(
+    date.getMinutes(),
+  )}:${padTimePart(date.getSeconds())}.${padTimePart(
+    date.getMilliseconds(),
+    3,
+  )}`;
+}
+
+function formatDebugEventDetails(
+  details?: ITradingViewNativeDebugEventDetails,
+) {
+  if (!details) {
+    return '';
+  }
+  return Object.entries(details)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .join(' ');
+}
+
+function formatDebugEventsForClipboard(
+  events: readonly ITradingViewNativeDebugEvent[],
+) {
+  return events
+    .map((event) => {
+      const details = formatDebugEventDetails(event.details);
+      return `${new Date(event.timestamp).toISOString()} [${event.level.toUpperCase()}] ${event.name}${
+        details ? ` ${details}` : ''
+      }`;
+    })
+    .join('\n');
+}
+
+function getEventColor(level: ITradingViewNativeDebugEvent['level']) {
+  if (level === 'error') {
+    return '#ff7b72';
+  }
+  if (level === 'warning') {
+    return '#d29922';
+  }
+  return '#8b949e';
+}
+
+function BasicTradingViewNativeDebugPanel() {
+  const [devSettings, setDevSettings] = useDevSettingsPersistAtom();
+  const events = useSyncExternalStore(
+    subscribeTradingViewNativeDebugEvents,
+    getTradingViewNativeDebugEvents,
+    getTradingViewNativeDebugEvents,
+  );
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [size, setSize] = useState<IPanelSize>(() => loadPanelSize());
+  const [position, setPosition] = useState<IPanelPosition>(() =>
+    loadPanelPosition(size),
+  );
+  const [copyStatus, setCopyStatus] = useState<ICopyStatus>('idle');
+  const dragStateRef = useRef<IDragState | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const eventListRef = useRef<HTMLDivElement | null>(null);
+  const shouldFollowLatestEventsRef = useRef(true);
+  const copyStatusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const positionRef = useRef(position);
+  const sizeRef = useRef(size);
+  positionRef.current = position;
+  sizeRef.current = size;
+
+  useEffect(() => {
+    const eventList = eventListRef.current;
+    if (eventList && shouldFollowLatestEventsRef.current) {
+      eventList.scrollTop = eventList.scrollHeight;
+    }
+  }, [events]);
+
+  useEffect(() => {
+    const panel = panelRef.current;
+    if (isCollapsed || !panel || !globalThis.ResizeObserver) {
+      return undefined;
+    }
+    const resizeObserver = new ResizeObserver(() => {
+      const panelRect = panel.getBoundingClientRect();
+      if (panelRect.width <= 0 || panelRect.height <= 0) {
+        return;
+      }
+      const nextSize = clampPanelSize(
+        { height: panelRect.height, width: panelRect.width },
+        positionRef.current,
+      );
+      const currentSize = sizeRef.current;
+      if (
+        Math.abs(currentSize.height - nextSize.height) < 0.5 &&
+        Math.abs(currentSize.width - nextSize.width) < 0.5
+      ) {
+        return;
+      }
+      sizeRef.current = nextSize;
+      setSize(nextSize);
+      savePanelSize(nextSize);
+    });
+    resizeObserver.observe(panel);
+    return () => resizeObserver.disconnect();
+  }, [isCollapsed]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const nextSize = clampPanelSize(sizeRef.current);
+      const nextPosition = clampPanelPosition(
+        positionRef.current,
+        isCollapsed,
+        nextSize,
+      );
+      sizeRef.current = nextSize;
+      positionRef.current = nextPosition;
+      setSize(nextSize);
+      setPosition(nextPosition);
+    };
+    globalThis.addEventListener('resize', handleResize);
+    return () => globalThis.removeEventListener('resize', handleResize);
+  }, [isCollapsed]);
+
+  useEffect(
+    () => () => {
+      if (copyStatusTimeoutRef.current) {
+        clearTimeout(copyStatusTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  const showCopyStatus = useCallback((status: ICopyStatus) => {
+    if (copyStatusTimeoutRef.current) {
+      clearTimeout(copyStatusTimeoutRef.current);
+      copyStatusTimeoutRef.current = null;
+    }
+    setCopyStatus(status);
+    if (status !== 'idle') {
+      copyStatusTimeoutRef.current = setTimeout(() => {
+        setCopyStatus('idle');
+        copyStatusTimeoutRef.current = null;
+      }, COPY_STATUS_RESET_DELAY_MS);
+    }
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    const clipboardText = formatDebugEventsForClipboard(events);
+    const clipboard = globalThis.navigator?.clipboard;
+    if (!clipboardText || !clipboard?.writeText) {
+      showCopyStatus('failed');
+      return;
+    }
+    try {
+      await clipboard.writeText(clipboardText);
+      showCopyStatus('copied');
+    } catch {
+      showCopyStatus('failed');
+    }
+  }, [events, showCopyStatus]);
+
+  const handleClear = useCallback(() => {
+    shouldFollowLatestEventsRef.current = true;
+    clearTradingViewNativeDebugEvents();
+    showCopyStatus('idle');
+  }, [showCopyStatus]);
+
+  const handleEventListScroll = useCallback(
+    (event: ReactUIEvent<HTMLDivElement>) => {
+      const eventList = event.currentTarget;
+      const distanceFromBottom =
+        eventList.scrollHeight - eventList.scrollTop - eventList.clientHeight;
+      shouldFollowLatestEventsRef.current =
+        distanceFromBottom <= AUTO_SCROLL_BOTTOM_THRESHOLD_PX;
+    },
+    [],
+  );
+
+  const handleClose = useCallback(() => {
+    setDevSettings((current) => ({
+      ...current,
+      settings: {
+        ...current.settings,
+        showTradingViewNativeDebugPanel: false,
+      },
+    }));
+  }, [setDevSettings]);
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if ((event.target as HTMLElement).closest('button')) {
+        return;
+      }
+      event.preventDefault();
+      const currentPosition = positionRef.current;
+      dragStateRef.current = {
+        offsetX: event.clientX - currentPosition.x,
+        offsetY: event.clientY - currentPosition.y,
+        pointerId: event.pointerId,
+      };
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      } catch {
+        // Pointer capture is optional in older development browsers.
+      }
+    },
+    [],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const dragState = dragStateRef.current;
+      if (!dragState || dragState.pointerId !== event.pointerId) {
+        return;
+      }
+      const nextPosition = clampPanelPosition(
+        {
+          x: event.clientX - dragState.offsetX,
+          y: event.clientY - dragState.offsetY,
+        },
+        isCollapsed,
+        sizeRef.current,
+      );
+      positionRef.current = nextPosition;
+      setPosition(nextPosition);
+    },
+    [isCollapsed],
+  );
+
+  const handlePointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (dragStateRef.current?.pointerId !== event.pointerId) {
+        return;
+      }
+      dragStateRef.current = null;
+      savePanelPosition(positionRef.current);
+      try {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      } catch {
+        // Pointer capture is optional in older development browsers.
+      }
+    },
+    [],
+  );
+
+  if (
+    !platformEnv.isDev ||
+    !platformEnv.isWeb ||
+    !devSettings.enabled ||
+    devSettings.settings?.showTradingViewNativeDebugPanel === false ||
+    !globalThis.document?.body
+  ) {
+    return null;
+  }
+
+  const panelSize = getPanelSize(size, isCollapsed);
+  const panelSizeLimits = getPanelSizeLimits(position);
+  return createPortal(
+    <div
+      data-testid="trading-view-native-debug-panel"
+      ref={panelRef}
+      style={{
+        background: 'rgba(13, 17, 23, 0.96)',
+        border: '1px solid rgba(139, 148, 158, 0.45)',
+        borderRadius: 8,
+        boxSizing: 'border-box',
+        boxShadow: '0 8px 32px rgba(0, 0, 0, 0.4)',
+        color: '#c9d1d9',
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily:
+          'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+        fontSize: 11,
+        height: panelSize.height,
+        left: position.x,
+        maxHeight: panelSizeLimits.maxHeight,
+        maxWidth: panelSizeLimits.maxWidth,
+        minHeight: isCollapsed
+          ? PANEL_COLLAPSED_HEIGHT
+          : panelSizeLimits.minHeight,
+        minWidth: panelSizeLimits.minWidth,
+        overflow: 'hidden',
+        pointerEvents: 'auto',
+        position: 'fixed',
+        resize: isCollapsed ? 'none' : 'both',
+        top: position.y,
+        width: panelSize.width,
+        zIndex: DEV_OVERLAY_FLOAT_BUTTON_Z_INDEX,
+      }}
+    >
+      <div
+        data-testid="trading-view-native-debug-panel-drag-handle"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        style={{
+          alignItems: 'center',
+          background: '#161b22',
+          borderBottom: isCollapsed
+            ? undefined
+            : '1px solid rgba(139, 148, 158, 0.25)',
+          cursor: dragStateRef.current ? 'grabbing' : 'grab',
+          display: 'flex',
+          flexShrink: 0,
+          height: PANEL_COLLAPSED_HEIGHT,
+          padding: '0 8px 0 10px',
+          userSelect: 'none',
+        }}
+      >
+        <strong
+          style={{
+            color: '#58a6ff',
+            flex: 1,
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          TradingViewNative events ({events.length})
+        </strong>
+        <button
+          aria-label="Copy event log"
+          disabled={!events.length}
+          onClick={() => void handleCopy()}
+          style={{
+            background: 'transparent',
+            border: 0,
+            color: copyStatus === 'failed' ? '#ff7b72' : '#8b949e',
+            cursor: events.length ? 'pointer' : 'default',
+            font: 'inherit',
+            opacity: events.length ? 1 : 0.45,
+            padding: '5px 7px',
+          }}
+          type="button"
+        >
+          {COPY_STATUS_LABEL[copyStatus]}
+        </button>
+        <button
+          onClick={handleClear}
+          style={{
+            background: 'transparent',
+            border: 0,
+            color: '#8b949e',
+            cursor: 'pointer',
+            font: 'inherit',
+            padding: '5px 7px',
+          }}
+          type="button"
+        >
+          Clear
+        </button>
+        <button
+          aria-label={isCollapsed ? 'Expand event log' : 'Collapse event log'}
+          onClick={() => {
+            const nextValue = !isCollapsed;
+            setIsCollapsed(nextValue);
+            setPosition((currentPosition) => {
+              const nextPosition = clampPanelPosition(
+                currentPosition,
+                nextValue,
+                sizeRef.current,
+              );
+              positionRef.current = nextPosition;
+              return nextPosition;
+            });
+          }}
+          style={{
+            background: 'transparent',
+            border: 0,
+            color: '#c9d1d9',
+            cursor: 'pointer',
+            font: 'inherit',
+            padding: '5px 7px',
+          }}
+          type="button"
+        >
+          {isCollapsed ? '+' : '−'}
+        </button>
+        <button
+          aria-label="Close event log"
+          onClick={handleClose}
+          style={{
+            background: 'transparent',
+            border: 0,
+            color: '#8b949e',
+            cursor: 'pointer',
+            font: 'inherit',
+            padding: '5px 7px',
+          }}
+          type="button"
+        >
+          ×
+        </button>
+      </div>
+      {isCollapsed ? null : (
+        <div
+          data-testid="trading-view-native-debug-event-list"
+          onScroll={handleEventListScroll}
+          ref={eventListRef}
+          style={{
+            flex: 1,
+            minHeight: 0,
+            overflow: 'auto',
+            padding: '6px 8px 10px',
+          }}
+        >
+          {events.length ? (
+            events.map((event) => {
+              const formattedDetails = formatDebugEventDetails(event.details);
+              return (
+                <div
+                  data-event-name={event.name}
+                  key={event.id}
+                  style={{
+                    lineHeight: 1.45,
+                    overflowWrap: 'anywhere',
+                    padding: '2px 0',
+                  }}
+                >
+                  <span style={{ color: '#6e7681' }}>
+                    {formatEventTime(event.timestamp)}
+                  </span>{' '}
+                  <span style={{ color: getEventColor(event.level) }}>
+                    {event.name}
+                  </span>
+                  {formattedDetails ? ` ${formattedDetails}` : ''}
+                </div>
+              );
+            })
+          ) : (
+            <div style={{ color: '#6e7681', padding: '8px 2px' }}>
+              Waiting for chart events…
+            </div>
+          )}
+        </div>
+      )}
+    </div>,
+    globalThis.document.body,
+  );
+}
+
+export const TradingViewNativeDebugPanel = memo(
+  BasicTradingViewNativeDebugPanel,
+);

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/tradingViewNativeDebugLogger.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/tradingViewNativeDebugLogger.test.ts
@@ -3,6 +3,7 @@ import {
   emitTradingViewNativeDebugEvent,
   getTradingViewNativeDebugErrorMessage,
   getTradingViewNativeDebugEvents,
+  setTradingViewNativeDebugEventCollectionEnabled,
   subscribeTradingViewNativeDebugEvents,
 } from './tradingViewNativeDebugLogger';
 
@@ -24,7 +25,12 @@ describe('TradingViewNative debug event logger', () => {
   beforeEach(() => {
     mockPlatformEnv.isDev = true;
     mockPlatformEnv.isWeb = true;
+    setTradingViewNativeDebugEventCollectionEnabled(true);
     clearTradingViewNativeDebugEvents();
+  });
+
+  afterEach(() => {
+    setTradingViewNativeDebugEventCollectionEnabled(false);
   });
 
   it('keeps a bounded chronological event list and notifies subscribers', () => {
@@ -58,6 +64,13 @@ describe('TradingViewNative debug event logger', () => {
     mockPlatformEnv.isDev = true;
     mockPlatformEnv.isWeb = false;
     emitTradingViewNativeDebugEvent({ name: 'native-event' });
+
+    expect(getTradingViewNativeDebugEvents()).toEqual([]);
+  });
+
+  it('does not collect when the diagnostics setting is disabled', () => {
+    setTradingViewNativeDebugEventCollectionEnabled(false);
+    emitTradingViewNativeDebugEvent({ name: 'disabled-event' });
 
     expect(getTradingViewNativeDebugEvents()).toEqual([]);
   });

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/tradingViewNativeDebugLogger.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/tradingViewNativeDebugLogger.test.ts
@@ -1,0 +1,71 @@
+import {
+  clearTradingViewNativeDebugEvents,
+  emitTradingViewNativeDebugEvent,
+  getTradingViewNativeDebugErrorMessage,
+  getTradingViewNativeDebugEvents,
+  subscribeTradingViewNativeDebugEvents,
+} from './tradingViewNativeDebugLogger';
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: {
+    isDev: true,
+    isWeb: true,
+  },
+}));
+
+const mockPlatformEnv = jest.requireMock('@onekeyhq/shared/src/platformEnv')
+  .default as {
+  isDev: boolean;
+  isWeb: boolean;
+};
+
+describe('TradingViewNative debug event logger', () => {
+  beforeEach(() => {
+    mockPlatformEnv.isDev = true;
+    mockPlatformEnv.isWeb = true;
+    clearTradingViewNativeDebugEvents();
+  });
+
+  it('keeps a bounded chronological event list and notifies subscribers', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeTradingViewNativeDebugEvents(listener);
+
+    for (let index = 0; index < 260; index += 1) {
+      emitTradingViewNativeDebugEvent({
+        details: { index },
+        name: `history.response.${index}`,
+      });
+    }
+
+    const events = getTradingViewNativeDebugEvents();
+    expect(events).toHaveLength(250);
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        details: { index: 10 },
+        name: 'history.response.10',
+      }),
+    );
+    expect(events.at(-1)?.name).toBe('history.response.259');
+    expect(listener).toHaveBeenCalledTimes(260);
+
+    unsubscribe();
+  });
+
+  it('does not collect outside a local Web development build', () => {
+    mockPlatformEnv.isDev = false;
+    emitTradingViewNativeDebugEvent({ name: 'production-event' });
+    mockPlatformEnv.isDev = true;
+    mockPlatformEnv.isWeb = false;
+    emitTradingViewNativeDebugEvent({ name: 'native-event' });
+
+    expect(getTradingViewNativeDebugEvents()).toEqual([]);
+  });
+
+  it('normalizes error values for safe display', () => {
+    expect(getTradingViewNativeDebugErrorMessage(new Error('failed'))).toBe(
+      'failed',
+    );
+    expect(getTradingViewNativeDebugErrorMessage('offline')).toBe('offline');
+  });
+});

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/tradingViewNativeDebugLogger.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/tradingViewNativeDebugLogger.ts
@@ -21,10 +21,19 @@ type ITradingViewNativeDebugEventListener = () => void;
 
 let debugEventSequence = 0;
 let debugEvents: readonly ITradingViewNativeDebugEvent[] = [];
+let isDebugEventCollectionEnabled = false;
 const debugEventListeners = new Set<ITradingViewNativeDebugEventListener>();
 
 function isTradingViewNativeDebugLoggerEnabled() {
-  return Boolean(platformEnv.isDev && platformEnv.isWeb);
+  return Boolean(
+    platformEnv.isDev && platformEnv.isWeb && isDebugEventCollectionEnabled,
+  );
+}
+
+export function setTradingViewNativeDebugEventCollectionEnabled(
+  enabled: boolean,
+) {
+  isDebugEventCollectionEnabled = enabled;
 }
 
 function notifyTradingViewNativeDebugEventListeners() {

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/tradingViewNativeDebugLogger.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/tradingViewNativeDebugLogger.ts
@@ -1,0 +1,82 @@
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+const TRADING_VIEW_NATIVE_DEBUG_EVENT_LIMIT = 250;
+
+export type ITradingViewNativeDebugEventLevel = 'error' | 'info' | 'warning';
+
+export type ITradingViewNativeDebugEventDetails = Record<
+  string,
+  boolean | null | number | string | undefined
+>;
+
+export interface ITradingViewNativeDebugEvent {
+  details?: ITradingViewNativeDebugEventDetails;
+  id: number;
+  level: ITradingViewNativeDebugEventLevel;
+  name: string;
+  timestamp: number;
+}
+
+type ITradingViewNativeDebugEventListener = () => void;
+
+let debugEventSequence = 0;
+let debugEvents: readonly ITradingViewNativeDebugEvent[] = [];
+const debugEventListeners = new Set<ITradingViewNativeDebugEventListener>();
+
+function isTradingViewNativeDebugLoggerEnabled() {
+  return Boolean(platformEnv.isDev && platformEnv.isWeb);
+}
+
+function notifyTradingViewNativeDebugEventListeners() {
+  debugEventListeners.forEach((listener) => listener());
+}
+
+export function emitTradingViewNativeDebugEvent({
+  details,
+  level = 'info',
+  name,
+}: {
+  details?: ITradingViewNativeDebugEventDetails;
+  level?: ITradingViewNativeDebugEventLevel;
+  name: string;
+}) {
+  if (!isTradingViewNativeDebugLoggerEnabled()) {
+    return;
+  }
+
+  debugEventSequence += 1;
+  const nextEvent: ITradingViewNativeDebugEvent = {
+    details,
+    id: debugEventSequence,
+    level,
+    name,
+    timestamp: Date.now(),
+  };
+  debugEvents = [...debugEvents, nextEvent].slice(
+    -TRADING_VIEW_NATIVE_DEBUG_EVENT_LIMIT,
+  );
+  notifyTradingViewNativeDebugEventListeners();
+}
+
+export function getTradingViewNativeDebugEvents() {
+  return debugEvents;
+}
+
+export function subscribeTradingViewNativeDebugEvents(
+  listener: ITradingViewNativeDebugEventListener,
+) {
+  debugEventListeners.add(listener);
+  return () => debugEventListeners.delete(listener);
+}
+
+export function clearTradingViewNativeDebugEvents() {
+  if (!debugEvents.length) {
+    return;
+  }
+  debugEvents = [];
+  notifyTradingViewNativeDebugEventListeners();
+}
+
+export function getTradingViewNativeDebugErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.test.ts
@@ -11,6 +11,7 @@ import type {
 
 import { getTradingViewNativeSourceKey } from './getTradingViewNativeSource';
 import { createTradingViewNativeDataProvider } from './providers/createTradingViewNativeDataProvider';
+import { emitTradingViewNativeDebugEvent } from './tradingViewNativeDebugLogger';
 import {
   readTradingViewNativeActiveInterval,
   saveTradingViewNativeActiveInterval,
@@ -73,6 +74,12 @@ jest.mock('./providers/createTradingViewNativeDataProvider', () => ({
   createTradingViewNativeDataProvider: jest.fn(),
 }));
 
+jest.mock('./tradingViewNativeDebugLogger', () => ({
+  emitTradingViewNativeDebugEvent: jest.fn(),
+  getTradingViewNativeDebugErrorMessage: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
+}));
+
 jest.mock('./tradingViewNativeIntervalStorage', () => {
   const actual = jest.requireActual<
     typeof import('./tradingViewNativeIntervalStorage')
@@ -88,6 +95,9 @@ const mockCreateTradingViewNativeDataProvider =
   createTradingViewNativeDataProvider as jest.MockedFunction<
     typeof createTradingViewNativeDataProvider
   >;
+const mockEmitTradingViewNativeDebugEvent = jest.mocked(
+  emitTradingViewNativeDebugEvent,
+);
 const mockReadTradingViewNativeActiveInterval = jest.mocked(
   readTradingViewNativeActiveInterval,
 );
@@ -267,6 +277,35 @@ describe('TradingViewNative K-line data state machine', () => {
       expect.objectContaining({
         timeFrom: 89_200,
         timeTo: 100_000,
+      }),
+    );
+  });
+
+  it('publishes history and fallback decisions to the development event log', async () => {
+    mockFetchHistory.mockResolvedValue({
+      ...buildResponse(100, 100_000),
+      historySource: 'fallback',
+    });
+
+    const { result } = renderHook(() =>
+      useTradingViewNativeKLine({ source: buildMarketSource() }),
+    );
+
+    await waitFor(() => expect(result.current.points).toHaveLength(1));
+    expect(mockEmitTradingViewNativeDebugEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'history.request' }),
+    );
+    expect(mockEmitTradingViewNativeDebugEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ historySource: 'fallback' }),
+        level: 'warning',
+        name: 'history.response',
+      }),
+    );
+    expect(mockEmitTradingViewNativeDebugEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'warning',
+        name: 'history.fallback.used',
       }),
     );
   });

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.test.ts
@@ -310,6 +310,87 @@ describe('TradingViewNative K-line data state machine', () => {
     );
   });
 
+  it('logs a fallback response as dropped after primary history is selected', async () => {
+    mockFetchHistory
+      .mockResolvedValueOnce(buildResponse(100, 100_000))
+      .mockResolvedValueOnce({
+        ...buildResponse(110, 100_000),
+        historySource: 'fallback',
+      });
+
+    const { result } = renderHook(() =>
+      useTradingViewNativeKLine({ source: buildMarketSource() }),
+    );
+    await waitFor(() => expect(result.current.points[0]?.c).toBe(100));
+    mockEmitTradingViewNativeDebugEvent.mockClear();
+
+    updateVisibility(false);
+    updateVisibility(true);
+    await waitFor(() => expect(mockFetchHistory).toHaveBeenCalledTimes(2));
+
+    expect(result.current.points[0]?.c).toBe(100);
+    expect(mockEmitTradingViewNativeDebugEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          historySource: 'fallback',
+          reason: 'source-mismatch',
+          selectedHistorySource: 'primary',
+        }),
+        level: 'warning',
+        name: 'history.response.dropped',
+      }),
+    );
+    expect(
+      mockEmitTradingViewNativeDebugEvent.mock.calls.some(
+        ([event]) => event.name === 'history.fallback.used',
+      ),
+    ).toBe(false);
+    expect(
+      mockEmitTradingViewNativeDebugEvent.mock.calls.some(
+        ([event]) =>
+          event.name === 'history.response' &&
+          event.details?.historySource === 'fallback',
+      ),
+    ).toBe(false);
+  });
+
+  it('logs a resolved response as aborted after its request is cancelled', async () => {
+    const historyRequest =
+      createDeferred<ITradingViewNativeHistoryResponse | null>();
+    mockFetchHistory.mockReturnValue(historyRequest.promise);
+
+    const { unmount } = renderHook(() =>
+      useTradingViewNativeKLine({ source: buildMarketSource() }),
+    );
+    await waitFor(() => expect(mockFetchHistory).toHaveBeenCalledTimes(1));
+    const request = mockFetchHistory.mock.calls[0]?.[0];
+
+    unmount();
+    expect(request?.signal.aborted).toBe(true);
+    mockEmitTradingViewNativeDebugEvent.mockClear();
+    historyRequest.resolve({
+      ...buildResponse(100, 100_000),
+      historySource: 'fallback',
+    });
+
+    await waitFor(() =>
+      expect(mockEmitTradingViewNativeDebugEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: expect.objectContaining({ historySource: 'fallback' }),
+          level: 'warning',
+          name: 'history.response.aborted',
+        }),
+      ),
+    );
+    expect(
+      mockEmitTradingViewNativeDebugEvent.mock.calls.some(
+        ([event]) =>
+          event.name === 'history.response' ||
+          event.name === 'history.fallback.used',
+      ),
+    ).toBe(false);
+  });
+
   it('selects a line chart from single-value history metadata', async () => {
     mockHistoryBatchSize = 2;
     mockHistoryRequestCandleCount = 2;

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.ts
@@ -1333,45 +1333,46 @@ export function useTradingViewNativeKLine({
         });
         try {
           const data = await rawHistoryProvider.fetchHistory(request);
-          emitTradingViewNativeDebugEvent({
-            details: {
-              durationMs: Date.now() - startedAt,
-              historySource: data?.historySource ?? 'primary',
-              interval: request.interval.value,
-              pointType: data?.pointType,
-              points: data?.points.length ?? 0,
-              providerKey: seriesKey,
-              requestId: debugRequestId,
-            },
-            level: data?.historySource === 'fallback' ? 'warning' : 'info',
-            name: 'history.response',
-          });
+          const responseDataSource: IHistoryDataSource =
+            data?.historySource === 'fallback' ? 'fallback' : 'primary';
+          const responseDetails = {
+            durationMs: Date.now() - startedAt,
+            historySource: responseDataSource,
+            interval: request.interval.value,
+            pointType: data?.pointType,
+            points: data?.points.length ?? 0,
+            providerKey: seriesKey,
+            requestId: debugRequestId,
+          };
 
-          if (data?.historySource === 'fallback') {
+          if (request.signal.aborted) {
             emitTradingViewNativeDebugEvent({
-              details: {
-                interval: request.interval.value,
-                points: data.points.length,
-                providerKey: seriesKey,
-                requestId: debugRequestId,
-              },
+              details: responseDetails,
               level: 'warning',
-              name: 'history.fallback.used',
+              name: 'history.response.aborted',
             });
+            return data;
           }
 
-          if (!request.signal.aborted && data && data.points.length > 0) {
+          if (data && data.points.length > 0) {
             const scopeKey = getHistoryPointTypeScopeKey(
               seriesKey,
               request.interval.value,
             );
-            const responseDataSource: IHistoryDataSource =
-              data.historySource === 'fallback' ? 'fallback' : 'primary';
             const selectedDataSource = historyDataSourceScopes.get(scopeKey);
             if (
               selectedDataSource &&
               selectedDataSource !== responseDataSource
             ) {
+              emitTradingViewNativeDebugEvent({
+                details: {
+                  ...responseDetails,
+                  reason: 'source-mismatch',
+                  selectedHistorySource: selectedDataSource,
+                },
+                level: 'warning',
+                name: 'history.response.dropped',
+              });
               return { ...data, points: [], total: 0 };
             }
             historyDataSourceScopes.set(scopeKey, responseDataSource);
@@ -1388,6 +1389,24 @@ export function useTradingViewNativeKLine({
                 scopes: new Map(historyPointTypeScopes),
               });
             }
+          }
+
+          emitTradingViewNativeDebugEvent({
+            details: responseDetails,
+            level: responseDataSource === 'fallback' ? 'warning' : 'info',
+            name: 'history.response',
+          });
+          if (responseDataSource === 'fallback') {
+            emitTradingViewNativeDebugEvent({
+              details: {
+                interval: request.interval.value,
+                points: data?.points.length ?? 0,
+                providerKey: seriesKey,
+                requestId: debugRequestId,
+              },
+              level: 'warning',
+              name: 'history.fallback.used',
+            });
           }
           return data;
         } catch (error) {

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.ts
@@ -16,6 +16,10 @@ import {
 import { createTradingViewNativeDataProvider } from './providers/createTradingViewNativeDataProvider';
 import { logTradingViewNativeDataError } from './tradingViewNativeDataLogger';
 import {
+  emitTradingViewNativeDebugEvent,
+  getTradingViewNativeDebugErrorMessage,
+} from './tradingViewNativeDebugLogger';
+import {
   TRADING_VIEW_NATIVE_KLINE_INTERVALS,
   TRADING_VIEW_NATIVE_TIME_RANGE_MAX_CANDLE_COUNT,
   getTradingViewNativeKLineInterval,
@@ -65,6 +69,7 @@ const VIEWPORT_TARGET_FORWARD_CANDLE_COUNT =
   TRADING_VIEW_NATIVE_TIME_RANGE_MAX_CANDLE_COUNT;
 
 let realtimeSubscriberSequence = 0;
+let historyDebugRequestSequence = 0;
 
 function getHistoryPointTypeScopeKey(
   seriesKey: string,
@@ -1313,34 +1318,96 @@ export function useTradingViewNativeKLine({
     return {
       ...rawHistoryProvider,
       fetchHistory: async (request) => {
-        const data = await rawHistoryProvider.fetchHistory(request);
-        if (!request.signal.aborted && data && data.points.length > 0) {
-          const scopeKey = getHistoryPointTypeScopeKey(
-            seriesKey,
-            request.interval.value,
-          );
-          const responseDataSource: IHistoryDataSource =
-            data.historySource === 'fallback' ? 'fallback' : 'primary';
-          const selectedDataSource = historyDataSourceScopes.get(scopeKey);
-          if (selectedDataSource && selectedDataSource !== responseDataSource) {
-            return { ...data, points: [], total: 0 };
-          }
-          historyDataSourceScopes.set(scopeKey, responseDataSource);
-          const currentClassification = historyPointTypeScopes.get(scopeKey);
-          const nextClassification = resolveHistoryPointTypeClassification({
-            currentClassification,
-            historySource: data.historySource,
-            pointType: data.pointType,
+        historyDebugRequestSequence += 1;
+        const debugRequestId = historyDebugRequestSequence;
+        const startedAt = Date.now();
+        emitTradingViewNativeDebugEvent({
+          details: {
+            interval: request.interval.value,
+            providerKey: seriesKey,
+            requestId: debugRequestId,
+            timeFrom: request.timeFrom,
+            timeTo: request.timeTo,
+          },
+          name: 'history.request',
+        });
+        try {
+          const data = await rawHistoryProvider.fetchHistory(request);
+          emitTradingViewNativeDebugEvent({
+            details: {
+              durationMs: Date.now() - startedAt,
+              historySource: data?.historySource ?? 'primary',
+              interval: request.interval.value,
+              pointType: data?.pointType,
+              points: data?.points.length ?? 0,
+              providerKey: seriesKey,
+              requestId: debugRequestId,
+            },
+            level: data?.historySource === 'fallback' ? 'warning' : 'info',
+            name: 'history.response',
           });
-          if (nextClassification !== currentClassification) {
-            historyPointTypeScopes.set(scopeKey, nextClassification);
-            setHistoryPointTypeScopeState({
-              historyProvider: rawHistoryProvider,
-              scopes: new Map(historyPointTypeScopes),
+
+          if (data?.historySource === 'fallback') {
+            emitTradingViewNativeDebugEvent({
+              details: {
+                interval: request.interval.value,
+                points: data.points.length,
+                providerKey: seriesKey,
+                requestId: debugRequestId,
+              },
+              level: 'warning',
+              name: 'history.fallback.used',
             });
           }
+
+          if (!request.signal.aborted && data && data.points.length > 0) {
+            const scopeKey = getHistoryPointTypeScopeKey(
+              seriesKey,
+              request.interval.value,
+            );
+            const responseDataSource: IHistoryDataSource =
+              data.historySource === 'fallback' ? 'fallback' : 'primary';
+            const selectedDataSource = historyDataSourceScopes.get(scopeKey);
+            if (
+              selectedDataSource &&
+              selectedDataSource !== responseDataSource
+            ) {
+              return { ...data, points: [], total: 0 };
+            }
+            historyDataSourceScopes.set(scopeKey, responseDataSource);
+            const currentClassification = historyPointTypeScopes.get(scopeKey);
+            const nextClassification = resolveHistoryPointTypeClassification({
+              currentClassification,
+              historySource: data.historySource,
+              pointType: data.pointType,
+            });
+            if (nextClassification !== currentClassification) {
+              historyPointTypeScopes.set(scopeKey, nextClassification);
+              setHistoryPointTypeScopeState({
+                historyProvider: rawHistoryProvider,
+                scopes: new Map(historyPointTypeScopes),
+              });
+            }
+          }
+          return data;
+        } catch (error) {
+          const wasAborted = request.signal.aborted || isAbortError(error);
+          emitTradingViewNativeDebugEvent({
+            details: {
+              aborted: wasAborted,
+              durationMs: Date.now() - startedAt,
+              error: getTradingViewNativeDebugErrorMessage(error),
+              interval: request.interval.value,
+              providerKey: seriesKey,
+              requestId: debugRequestId,
+            },
+            level: wasAborted ? 'warning' : 'error',
+            name: wasAborted
+              ? 'history.request.aborted'
+              : 'history.request.error',
+          });
+          throw error;
         }
-        return data;
       },
     };
   }, [rawHistoryProvider, seriesKey]);
@@ -1480,6 +1547,30 @@ export function useTradingViewNativeKLine({
   chartDataRef.current = chartData;
 
   useEffect(() => {
+    emitTradingViewNativeDebugEvent({
+      details: {
+        historyReady: providerIsReady,
+        providerKey: seriesKey,
+        sourceKind,
+        supportsRealtime,
+      },
+      level: providerIsReady ? 'info' : 'warning',
+      name: 'provider.configured',
+    });
+  }, [providerIsReady, seriesKey, sourceKind, supportsRealtime]);
+
+  useEffect(() => {
+    emitTradingViewNativeDebugEvent({
+      details: {
+        interval: activeInterval,
+        namespace: intervalStorageNamespace,
+        providerKey: seriesKey,
+      },
+      name: 'interval.active',
+    });
+  }, [activeInterval, intervalStorageNamespace, seriesKey]);
+
+  useEffect(() => {
     setActiveIntervalState((currentState) =>
       currentState.namespace === intervalStorageNamespace
         ? currentState
@@ -1492,10 +1583,18 @@ export function useTradingViewNativeKLine({
 
   useEffect(() => {
     const currentVisibility = getCurrentVisibilityState();
+    emitTradingViewNativeDebugEvent({
+      details: { visible: currentVisibility },
+      name: 'visibility.initial',
+    });
     isVisibleRef.current = currentVisibility;
     setIsVisible(currentVisibility);
     return onVisibilityStateChange((nextVisibility) => {
       const wasVisible = isVisibleRef.current;
+      emitTradingViewNativeDebugEvent({
+        details: { from: wasVisible, to: nextVisibility },
+        name: 'visibility.changed',
+      });
       isVisibleRef.current = nextVisibility;
       setIsVisible(nextVisibility);
       if (!wasVisible && nextVisibility) {
@@ -1616,6 +1715,7 @@ export function useTradingViewNativeKLine({
   );
 
   const handleRetry = useCallback(() => {
+    emitTradingViewNativeDebugEvent({ name: 'data.retry.requested' });
     setHistoryRefreshRevision((current) => current + 1);
     setRealtimeRetryRevision((current) => current + 1);
   }, []);
@@ -2976,9 +3076,30 @@ export function useTradingViewNativeKLine({
         realtimeScope.seriesKey !== seriesKey ||
         realtimeScope.interval !== activeInterval
       ) {
+        emitTradingViewNativeDebugEvent({
+          details: {
+            activeInterval,
+            activeProviderKey: seriesKey,
+            pointTimestamp: point.t,
+            scopeInterval: realtimeScope.interval,
+            scopeProviderKey: realtimeScope.seriesKey,
+          },
+          level: 'warning',
+          name: 'realtime.point.ignored',
+        });
         return;
       }
 
+      emitTradingViewNativeDebugEvent({
+        details: {
+          close: point.c,
+          interval: activeInterval,
+          providerKey: seriesKey,
+          timestamp: point.t,
+          volume: point.v,
+        },
+        name: 'realtime.point',
+      });
       const interval =
         getTradingViewNativeKLineInterval(activeInterval) ??
         TRADING_VIEW_NATIVE_KLINE_INTERVALS[4];
@@ -3042,6 +3163,16 @@ export function useTradingViewNativeKLine({
 
   useEffect(() => {
     if (!realtimeProvider || !supportsRealtime || !isVisible) {
+      emitTradingViewNativeDebugEvent({
+        details: {
+          providerAvailable: Boolean(realtimeProvider),
+          providerKey: seriesKey,
+          supportsRealtime,
+          visible: isVisible,
+        },
+        level: supportsRealtime && !isVisible ? 'warning' : 'info',
+        name: 'realtime.subscription.skipped',
+      });
       realtimeSubscriptionRef.current = null;
       setRealtimeState((current) => ({
         interval: activeInterval,
@@ -3060,6 +3191,15 @@ export function useTradingViewNativeKLine({
       chartDataRef.current?.seriesKey === seriesKey &&
       chartDataRef.current.points.length,
     );
+    emitTradingViewNativeDebugEvent({
+      details: {
+        hasCurrentPoints,
+        interval: activeInterval,
+        providerKey: seriesKey,
+        subscriberId,
+      },
+      name: 'realtime.subscription.start',
+    });
     setRealtimeState((current) => ({
       interval: activeInterval,
       lastUpdatedAt:
@@ -3085,6 +3225,16 @@ export function useTradingViewNativeKLine({
 
         ownedSubscription = nextSubscription;
         realtimeSubscriptionRef.current = nextSubscription;
+        emitTradingViewNativeDebugEvent({
+          details: {
+            interval: activeInterval,
+            providerKey: seriesKey,
+            subscribed: Boolean(nextSubscription),
+            subscriberId,
+          },
+          level: nextSubscription ? 'info' : 'warning',
+          name: 'realtime.subscription.ready',
+        });
         setRealtimeState((current) => {
           return {
             interval: activeInterval,
@@ -3105,6 +3255,16 @@ export function useTradingViewNativeKLine({
           'Failed to subscribe to native TradingView realtime data',
           error,
         );
+        emitTradingViewNativeDebugEvent({
+          details: {
+            error: getTradingViewNativeDebugErrorMessage(error),
+            interval: activeInterval,
+            providerKey: seriesKey,
+            subscriberId,
+          },
+          level: 'error',
+          name: 'realtime.subscription.error',
+        });
         setRealtimeState((current) => ({
           error,
           interval: activeInterval,
@@ -3120,6 +3280,15 @@ export function useTradingViewNativeKLine({
     return () => {
       isCancelled = true;
       abortController.abort();
+      emitTradingViewNativeDebugEvent({
+        details: {
+          hadSubscription: Boolean(ownedSubscription),
+          interval: activeInterval,
+          providerKey: seriesKey,
+          subscriberId,
+        },
+        name: 'realtime.subscription.dispose',
+      });
       if (realtimeSubscriptionRef.current === ownedSubscription) {
         realtimeSubscriptionRef.current = null;
       }
@@ -3155,10 +3324,20 @@ export function useTradingViewNativeKLine({
       lastRealtimeActivityAtRef.current = Date.now();
       const subscription = realtimeSubscriptionRef.current;
       if (!subscription) {
+        emitTradingViewNativeDebugEvent({
+          details: { providerKey: seriesKey },
+          level: 'warning',
+          name: 'realtime.self-heal.resubscribe',
+        });
         setRealtimeRetryRevision((current) => current + 1);
         return;
       }
 
+      emitTradingViewNativeDebugEvent({
+        details: { providerKey: seriesKey },
+        level: 'warning',
+        name: 'realtime.self-heal.start',
+      });
       setRealtimeState((current) => ({
         ...current,
         error: undefined,
@@ -3171,6 +3350,10 @@ export function useTradingViewNativeKLine({
             return;
           }
           lastRealtimeActivityAtRef.current = Date.now();
+          emitTradingViewNativeDebugEvent({
+            details: { providerKey: seriesKey },
+            name: 'realtime.self-heal.ready',
+          });
           setRealtimeState((current) => ({
             ...current,
             error: undefined,
@@ -3185,6 +3368,14 @@ export function useTradingViewNativeKLine({
             'Failed to recover native TradingView realtime data',
             error,
           );
+          emitTradingViewNativeDebugEvent({
+            details: {
+              error: getTradingViewNativeDebugErrorMessage(error),
+              providerKey: seriesKey,
+            },
+            level: 'error',
+            name: 'realtime.self-heal.error',
+          });
           setRealtimeState((current) => ({
             ...current,
             error,
@@ -3202,12 +3393,21 @@ export function useTradingViewNativeKLine({
       skippedRequest?.seriesKey === seriesKey &&
       skippedRequest.interval === activeInterval
     ) {
+      emitTradingViewNativeDebugEvent({
+        details: { interval: activeInterval, providerKey: seriesKey },
+        name: 'history.initial.skipped',
+      });
       return;
     }
 
     const requestId = latestRequestIdRef.current + 1;
     latestRequestIdRef.current = requestId;
     if (!providerIsReady) {
+      emitTradingViewNativeDebugEvent({
+        details: { interval: activeInterval, providerKey: seriesKey },
+        level: 'warning',
+        name: 'history.provider.not-ready',
+      });
       setHistoryState({
         interval: activeInterval,
         seriesKey,
@@ -3246,6 +3446,16 @@ export function useTradingViewNativeKLine({
         currentChartData?.seriesKey === seriesKey &&
         currentChartData.interval !== requestedInterval.value
       ) {
+        emitTradingViewNativeDebugEvent({
+          details: {
+            error: getTradingViewNativeDebugErrorMessage(error),
+            fromInterval: requestedInterval.value,
+            providerKey: seriesKey,
+            toInterval: currentChartData.interval,
+          },
+          level: 'warning',
+          name: 'interval.change.rolled-back',
+        });
         skipNextRequestRef.current = {
           interval: currentChartData.interval,
           seriesKey,
@@ -3263,6 +3473,15 @@ export function useTradingViewNativeKLine({
             : currentInterval,
         );
       } else {
+        emitTradingViewNativeDebugEvent({
+          details: {
+            error: getTradingViewNativeDebugErrorMessage(error),
+            interval: requestedInterval.value,
+            providerKey: seriesKey,
+          },
+          level: 'error',
+          name: 'history.initial.failed',
+        });
         setHistoryState({
           error,
           interval: requestedInterval.value,

--- a/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.ext.tsx
+++ b/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.ext.tsx
@@ -1,0 +1,3 @@
+export function TradingViewNativeDebugPanelContainer() {
+  return null;
+}

--- a/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.test.tsx
+++ b/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.test.tsx
@@ -14,19 +14,15 @@ const mockDevSettings: {
   settings: { showTradingViewNativeDebugPanel: true },
 };
 const mockSetDevSettings = jest.fn(
-  (
-    updater: (current: typeof mockDevSettings) => typeof mockDevSettings,
-  ) => {
+  (updater: (current: typeof mockDevSettings) => typeof mockDevSettings) => {
     Object.assign(mockDevSettings, updater(mockDevSettings));
   },
 );
-const mockPanelRender = jest.fn(
-  ({ onClose }: { onClose: () => void }) => (
-    <button data-testid="trading-view-native-debug-panel" onClick={onClose}>
-      Close
-    </button>
-  ),
-);
+const mockPanelRender = jest.fn(({ onClose }: { onClose: () => void }) => (
+  <button data-testid="trading-view-native-debug-panel" onClick={onClose}>
+    Close
+  </button>
+));
 
 jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings', () => ({
   useDevSettingsPersistAtom: () => {
@@ -50,10 +46,7 @@ jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings', () => ({
 
 jest.mock('@onekeyhq/shared/src/lazyLoad', () => ({
   __esModule: true,
-  default:
-    () =>
-    (props: { onClose: () => void }) =>
-      mockPanelRender(props),
+  default: () => (props: { onClose: () => void }) => mockPanelRender(props),
 }));
 
 jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
@@ -83,9 +76,7 @@ describe('TradingViewNativeDebugPanelContainer', () => {
   it('mounts the panel from the global owner when debug mode is enabled', () => {
     render(<TradingViewNativeDebugPanelContainer />);
 
-    expect(
-      screen.getByTestId('trading-view-native-debug-panel'),
-    ).toBeTruthy();
+    expect(screen.getByTestId('trading-view-native-debug-panel')).toBeTruthy();
     expect(mockPanelRender).toHaveBeenCalledTimes(1);
   });
 
@@ -93,9 +84,7 @@ describe('TradingViewNativeDebugPanelContainer', () => {
     mockDevSettings.settings.showTradingViewNativeDebugPanel = false;
     render(<TradingViewNativeDebugPanelContainer />);
 
-    expect(
-      screen.queryByTestId('trading-view-native-debug-panel'),
-    ).toBeNull();
+    expect(screen.queryByTestId('trading-view-native-debug-panel')).toBeNull();
     expect(mockPanelRender).not.toHaveBeenCalled();
   });
 
@@ -113,17 +102,13 @@ describe('TradingViewNativeDebugPanelContainer', () => {
   it('persists close through the global developer setting gate', () => {
     const { rerender } = render(<TradingViewNativeDebugPanelContainer />);
 
-    fireEvent.click(
-      screen.getByTestId('trading-view-native-debug-panel'),
-    );
+    fireEvent.click(screen.getByTestId('trading-view-native-debug-panel'));
     expect(mockDevSettings.settings.showTradingViewNativeDebugPanel).toBe(
       false,
     );
 
     rerender(<TradingViewNativeDebugPanelContainer />);
-    expect(
-      screen.queryByTestId('trading-view-native-debug-panel'),
-    ).toBeNull();
+    expect(screen.queryByTestId('trading-view-native-debug-panel')).toBeNull();
     expect(mockPanelRender).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.test.tsx
+++ b/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.test.tsx
@@ -23,6 +23,7 @@ const mockPanelRender = jest.fn(({ onClose }: { onClose: () => void }) => (
     Close
   </button>
 ));
+const mockSetDebugEventCollectionEnabled = jest.fn();
 
 jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings', () => ({
   useDevSettingsPersistAtom: () => {
@@ -57,6 +58,17 @@ jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
   },
 }));
 
+jest.mock(
+  '../../../components/TradingView/TradingViewNative/data/tradingViewNativeDebugLogger',
+  () => ({
+    setTradingViewNativeDebugEventCollectionEnabled: (
+      enabled: boolean,
+    ): void => {
+      mockSetDebugEventCollectionEnabled(enabled);
+    },
+  }),
+);
+
 const mockPlatformEnv = jest.requireMock('@onekeyhq/shared/src/platformEnv')
   .default as {
   isDev: boolean;
@@ -71,6 +83,7 @@ describe('TradingViewNativeDebugPanelContainer', () => {
     mockPlatformEnv.isWeb = true;
     mockPanelRender.mockClear();
     mockSetDevSettings.mockClear();
+    mockSetDebugEventCollectionEnabled.mockClear();
   });
 
   it('mounts the panel from the global owner when debug mode is enabled', () => {
@@ -78,6 +91,7 @@ describe('TradingViewNativeDebugPanelContainer', () => {
 
     expect(screen.getByTestId('trading-view-native-debug-panel')).toBeTruthy();
     expect(mockPanelRender).toHaveBeenCalledTimes(1);
+    expect(mockSetDebugEventCollectionEnabled).toHaveBeenCalledWith(true);
   });
 
   it('keeps the panel unmounted when the developer setting is disabled', () => {
@@ -86,6 +100,16 @@ describe('TradingViewNativeDebugPanelContainer', () => {
 
     expect(screen.queryByTestId('trading-view-native-debug-panel')).toBeNull();
     expect(mockPanelRender).not.toHaveBeenCalled();
+    expect(mockSetDebugEventCollectionEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('defaults a missing diagnostics setting to disabled', () => {
+    mockDevSettings.settings = {};
+    render(<TradingViewNativeDebugPanelContainer />);
+
+    expect(screen.queryByTestId('trading-view-native-debug-panel')).toBeNull();
+    expect(mockPanelRender).not.toHaveBeenCalled();
+    expect(mockSetDebugEventCollectionEnabled).toHaveBeenCalledWith(false);
   });
 
   it('keeps the panel unmounted outside a local Web development build', () => {

--- a/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.test.tsx
+++ b/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { TradingViewNativeDebugPanelContainer } from './TradingViewNativeDebugPanelContainer';
+
+const mockDevSettings: {
+  enabled: boolean;
+  settings: { showTradingViewNativeDebugPanel?: boolean };
+} = {
+  enabled: true,
+  settings: { showTradingViewNativeDebugPanel: true },
+};
+const mockSetDevSettings = jest.fn(
+  (
+    updater: (current: typeof mockDevSettings) => typeof mockDevSettings,
+  ) => {
+    Object.assign(mockDevSettings, updater(mockDevSettings));
+  },
+);
+const mockPanelRender = jest.fn(
+  ({ onClose }: { onClose: () => void }) => (
+    <button data-testid="trading-view-native-debug-panel" onClick={onClose}>
+      Close
+    </button>
+  ),
+);
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings', () => ({
+  useDevSettingsPersistAtom: () => {
+    const React = jest.requireActual<typeof import('react')>('react');
+    const [value, setValue] = React.useState(mockDevSettings);
+    const setPersistedValue = React.useCallback(
+      (
+        updater: (current: typeof mockDevSettings) => typeof mockDevSettings,
+      ) => {
+        mockSetDevSettings(updater);
+        setValue({
+          ...mockDevSettings,
+          settings: { ...mockDevSettings.settings },
+        });
+      },
+      [],
+    );
+    return [value, setPersistedValue];
+  },
+}));
+
+jest.mock('@onekeyhq/shared/src/lazyLoad', () => ({
+  __esModule: true,
+  default:
+    () =>
+    (props: { onClose: () => void }) =>
+      mockPanelRender(props),
+}));
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: {
+    isDev: true,
+    isWeb: true,
+  },
+}));
+
+const mockPlatformEnv = jest.requireMock('@onekeyhq/shared/src/platformEnv')
+  .default as {
+  isDev: boolean;
+  isWeb: boolean;
+};
+
+describe('TradingViewNativeDebugPanelContainer', () => {
+  beforeEach(() => {
+    mockDevSettings.enabled = true;
+    mockDevSettings.settings = { showTradingViewNativeDebugPanel: true };
+    mockPlatformEnv.isDev = true;
+    mockPlatformEnv.isWeb = true;
+    mockPanelRender.mockClear();
+    mockSetDevSettings.mockClear();
+  });
+
+  it('mounts the panel from the global owner when debug mode is enabled', () => {
+    render(<TradingViewNativeDebugPanelContainer />);
+
+    expect(
+      screen.getByTestId('trading-view-native-debug-panel'),
+    ).toBeTruthy();
+    expect(mockPanelRender).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the panel unmounted when the developer setting is disabled', () => {
+    mockDevSettings.settings.showTradingViewNativeDebugPanel = false;
+    render(<TradingViewNativeDebugPanelContainer />);
+
+    expect(
+      screen.queryByTestId('trading-view-native-debug-panel'),
+    ).toBeNull();
+    expect(mockPanelRender).not.toHaveBeenCalled();
+  });
+
+  it('keeps the panel unmounted outside a local Web development build', () => {
+    mockPlatformEnv.isDev = false;
+    const { rerender } = render(<TradingViewNativeDebugPanelContainer />);
+    expect(mockPanelRender).not.toHaveBeenCalled();
+
+    mockPlatformEnv.isDev = true;
+    mockPlatformEnv.isWeb = false;
+    rerender(<TradingViewNativeDebugPanelContainer />);
+    expect(mockPanelRender).not.toHaveBeenCalled();
+  });
+
+  it('persists close through the global developer setting gate', () => {
+    const { rerender } = render(<TradingViewNativeDebugPanelContainer />);
+
+    fireEvent.click(
+      screen.getByTestId('trading-view-native-debug-panel'),
+    );
+    expect(mockDevSettings.settings.showTradingViewNativeDebugPanel).toBe(
+      false,
+    );
+
+    rerender(<TradingViewNativeDebugPanelContainer />);
+    expect(
+      screen.queryByTestId('trading-view-native-debug-panel'),
+    ).toBeNull();
+    expect(mockPanelRender).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.tsx
+++ b/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.tsx
@@ -1,0 +1,53 @@
+import { memo, useCallback } from 'react';
+
+import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
+import LazyLoad from '@onekeyhq/shared/src/lazyLoad';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import type { ITradingViewNativeDebugPanelProps } from '../../../components/TradingView/TradingViewNative/TradingViewNativeDebugPanel';
+
+const TradingViewNativeDebugPanel =
+  LazyLoad<ITradingViewNativeDebugPanelProps>(
+    () =>
+      import(
+        '../../../components/TradingView/TradingViewNative/TradingViewNativeDebugPanel'
+      ),
+  );
+
+function TradingViewNativeDebugPanelSettingGate() {
+  const [devSettings, setDevSettings] = useDevSettingsPersistAtom();
+  const handleClose = useCallback(() => {
+    setDevSettings((current) => ({
+      ...current,
+      settings: {
+        ...current.settings,
+        showTradingViewNativeDebugPanel: false,
+      },
+    }));
+  }, [setDevSettings]);
+
+  if (
+    !devSettings.enabled ||
+    devSettings.settings?.showTradingViewNativeDebugPanel === false
+  ) {
+    return null;
+  }
+
+  return <TradingViewNativeDebugPanel onClose={handleClose} />;
+}
+
+function BasicTradingViewNativeDebugPanelContainer() {
+  if (
+    !platformEnv.isDev ||
+    !platformEnv.isWeb ||
+    !globalThis.document?.body
+  ) {
+    return null;
+  }
+
+  return <TradingViewNativeDebugPanelSettingGate />;
+}
+
+export const TradingViewNativeDebugPanelContainer = memo(
+  BasicTradingViewNativeDebugPanelContainer,
+);

--- a/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.tsx
+++ b/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.tsx
@@ -1,8 +1,10 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import LazyLoad from '@onekeyhq/shared/src/lazyLoad';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import { setTradingViewNativeDebugEventCollectionEnabled } from '../../../components/TradingView/TradingViewNative/data/tradingViewNativeDebugLogger';
 
 import type { ITradingViewNativeDebugPanelProps } from '../../../components/TradingView/TradingViewNative/TradingViewNativeDebugPanel';
 
@@ -13,6 +15,10 @@ const TradingViewNativeDebugPanel = LazyLoad<ITradingViewNativeDebugPanelProps>(
 
 function TradingViewNativeDebugPanelSettingGate() {
   const [devSettings, setDevSettings] = useDevSettingsPersistAtom();
+  const isEnabled = Boolean(
+    devSettings.enabled &&
+    devSettings.settings?.showTradingViewNativeDebugPanel === true,
+  );
   const handleClose = useCallback(() => {
     setDevSettings((current) => ({
       ...current,
@@ -23,10 +29,14 @@ function TradingViewNativeDebugPanelSettingGate() {
     }));
   }, [setDevSettings]);
 
-  if (
-    !devSettings.enabled ||
-    devSettings.settings?.showTradingViewNativeDebugPanel === false
-  ) {
+  useEffect(() => {
+    setTradingViewNativeDebugEventCollectionEnabled(isEnabled);
+    return () => {
+      setTradingViewNativeDebugEventCollectionEnabled(false);
+    };
+  }, [isEnabled]);
+
+  if (!isEnabled) {
     return null;
   }
 

--- a/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.tsx
+++ b/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.tsx
@@ -6,13 +6,10 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import type { ITradingViewNativeDebugPanelProps } from '../../../components/TradingView/TradingViewNative/TradingViewNativeDebugPanel';
 
-const TradingViewNativeDebugPanel =
-  LazyLoad<ITradingViewNativeDebugPanelProps>(
-    () =>
-      import(
-        '../../../components/TradingView/TradingViewNative/TradingViewNativeDebugPanel'
-      ),
-  );
+const TradingViewNativeDebugPanel = LazyLoad<ITradingViewNativeDebugPanelProps>(
+  () =>
+    import('../../../components/TradingView/TradingViewNative/TradingViewNativeDebugPanel'),
+);
 
 function TradingViewNativeDebugPanelSettingGate() {
   const [devSettings, setDevSettings] = useDevSettingsPersistAtom();
@@ -37,11 +34,7 @@ function TradingViewNativeDebugPanelSettingGate() {
 }
 
 function BasicTradingViewNativeDebugPanelContainer() {
-  if (
-    !platformEnv.isDev ||
-    !platformEnv.isWeb ||
-    !globalThis.document?.body
-  ) {
+  if (!platformEnv.isDev || !platformEnv.isWeb || !globalThis.document?.body) {
     return null;
   }
 

--- a/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.tsx
+++ b/packages/kit/src/provider/Container/FullWindowOverlayContainer/TradingViewNativeDebugPanelContainer.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect } from 'react';
+import { memo, useCallback, useLayoutEffect } from 'react';
 
 import { useDevSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/devSettings';
 import LazyLoad from '@onekeyhq/shared/src/lazyLoad';
@@ -29,7 +29,8 @@ function TradingViewNativeDebugPanelSettingGate() {
     }));
   }, [setDevSettings]);
 
-  useEffect(() => {
+  // Enable collection before chart passive effects emit initial lifecycle events.
+  useLayoutEffect(() => {
     setTradingViewNativeDebugEventCollectionEnabled(isEnabled);
     return () => {
       setTradingViewNativeDebugEventCollectionEnabled(false);

--- a/packages/kit/src/provider/Container/FullWindowOverlayContainer/index.tsx
+++ b/packages/kit/src/provider/Container/FullWindowOverlayContainer/index.tsx
@@ -9,6 +9,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ScreenshotBranding } from '../../../components/ScreenshotBranding';
 
 import { DevOverlayWindowContainer } from './DevOverlayWindowContainer';
+import { TradingViewNativeDebugPanelContainer } from './TradingViewNativeDebugPanelContainer';
 
 export function FullWindowOverlayContainer() {
   return (
@@ -18,6 +19,7 @@ export function FullWindowOverlayContainer() {
         <Portal.Container name={Portal.Constant.FULL_WINDOW_OVERLAY_PORTAL} />
         <ShowToastProvider />
         <DevOverlayWindowContainer />
+        <TradingViewNativeDebugPanelContainer />
         {/* E2E mode, enable tap in iOS */}
         {platformEnv.isE2E ? <></> : <Toaster />}
         <ScreenshotBranding />

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -881,7 +881,7 @@ const BaseDevSettingsSection = () => {
         title: 'Webview & WebEmbed & TrandingView',
         description: 'Webview WebEmbed TrandingView',
         keywords:
-          'WebEmbedDevConfig 禁止WebEmbedApi Electron Webview调试工具 Enable Native Webview Debugging check webview version 使用本地TradingView URL',
+          'WebEmbedDevConfig 禁止WebEmbedApi Electron Webview调试工具 Enable Native Webview Debugging check webview version 使用本地TradingView URL TradingViewNative 事件日志 event log',
       },
       {
         key: 'galleries',
@@ -2211,6 +2211,29 @@ const BaseDevSettingsSection = () => {
                       >
                         <Switch size={ESwitchSize.small} />
                       </SectionFieldItem>
+                      {platformEnv.isWeb ? (
+                        <SearchFilterItem keywords="TradingViewNative event log debug panel 事件日志 调试窗口">
+                          <ListItem
+                            icon="CodeOutline"
+                            title="显示 TradingViewNative 事件日志"
+                            subtitle="关闭浮窗会同步关闭此开关"
+                          >
+                            <Switch
+                              size={ESwitchSize.small}
+                              value={
+                                devSettings.settings
+                                  ?.showTradingViewNativeDebugPanel ?? true
+                              }
+                              onChange={(value) => {
+                                void backgroundApiProxy.serviceDevSetting.updateDevSetting(
+                                  'showTradingViewNativeDebugPanel',
+                                  value,
+                                );
+                              }}
+                            />
+                          </ListItem>
+                        </SearchFilterItem>
+                      ) : null}
                       <SectionPressItem
                         icon="TradeOutline"
                         title="Mock TradingView 空 K 线"

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/index.tsx
@@ -2222,7 +2222,7 @@ const BaseDevSettingsSection = () => {
                               size={ESwitchSize.small}
                               value={
                                 devSettings.settings
-                                  ?.showTradingViewNativeDebugPanel ?? true
+                                  ?.showTradingViewNativeDebugPanel ?? false
                               }
                               onChange={(value) => {
                                 void backgroundApiProxy.serviceDevSetting.updateDevSetting(


### PR DESCRIPTION
## Summary

- add a local Web development event panel for TradingViewNative source, history, realtime, interval, visibility, and error diagnostics
- own the panel once in `FullWindowOverlayContainer` and lazy-load it only after the local Web development and developer-setting gates pass
- keep diagnostics disabled by default and collect no events until the developer setting is explicitly enabled
- support filtering, copying, dragging, collapsing, browser-native resizing, and persisted panel visibility/position/size
- keep native builds unchanged through the platform-specific no-op panel implementation

## Why

TradingViewNative provider transitions, history fallback decisions, realtime lifecycle, and interval changes were difficult to diagnose from one place during local development.

## Impact

The diagnostics panel only collects and renders events in a local Web development build with developer mode enabled. Production and native behavior is unchanged.

## Validation

- targeted Jest: 5 suites, 98 tests passed
- `yarn agent:check --profile commit`: lint, format, TypeScript, and agent-context checks passed
