### PR TITLE
fix: support compact market banner list on v6.5.0 OK-59043

### DIFF
--- a/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
+++ b/packages/kit/src/views/Market/MarketBannerDetail/MarketBannerDetail.tsx
@@ -198,8 +198,9 @@ function MarketBannerDetailContent({ title }: { title: string }) {
         />
       );
     }
-    // Native mobile: use FlatList + TokenListItem to match watchlist layout
-    if (platformEnv.isNative && !gtMd) {
+    // Narrow layouts use the compact list to avoid the desktop table's
+    // intrinsic width overflowing the viewport.
+    if (!gtMd) {
       return (
         <BannerDetailTokenFlatList
           data={mobileData}

--- a/packages/kit/src/views/Market/MarketBannerDetail/PerpsTokenListSection.tsx
+++ b/packages/kit/src/views/Market/MarketBannerDetail/PerpsTokenListSection.tsx
@@ -120,7 +120,7 @@ export function PerpsTokenListSection({
     );
   }, [isLoading, intl]);
 
-  if (platformEnv.isNative && !gtMd) {
+  if (!gtMd) {
     return (
       <BannerDetailTokenFlatList
         data={mobileTokens}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59043](https://onekeyhq.atlassian.net/browse/OK-59043)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- backport the narrow-viewport Market banner detail layout from #12611 to v6.5.0
- use the existing compact token list for Spot and Perps banner details below the `gtMd` breakpoint
- preserve the full desktop table on wide layouts

## Root cause

The v6.5.0 branch still gates the compact banner list behind `platformEnv.isNative`. Mobile Web therefore falls through to the desktop table with its 900px minimum width, clipping the price and change columns outside the viewport.

## User impact

Mobile Web banner detail rows show price and price change in the viewport, matching the app behavior.

## Backport

- reported by OK-59043
- original fix: #12611 / OK-58322
- target: `release/v6.5.0`

## Validation

- `yarn agent:check --profile commit`

[OK-59043]: https://onekeyhq.atlassian.net/browse/OK-59043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ