### PR TITLE
feat: receive token search tokenization, network aliases and search-mode flatten (OK-59366)

### DIFF
--- a/packages/kit/src/components/TokenListView/index.tsx
+++ b/packages/kit/src/components/TokenListView/index.tsx
@@ -632,6 +632,9 @@ function TokenListViewCmp(props: IProps) {
         useNetworkSearch && !showActiveAccountTokenList
           ? tokenSelectorAggregateTokenListMap
           : undefined,
+      // `searchAll` is only produced by the main Receive entry, so this is a
+      // Receive-scoped switch; Send would need its own decoupled param.
+      flattenAggregateTokens: useNetworkSearch,
     });
 
     if (!isTokenSelector) {

--- a/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
+++ b/packages/kit/src/views/AssetSelector/pages/TokenSelector.tsx
@@ -46,7 +46,10 @@ import {
   swrKeys,
 } from '@onekeyhq/shared/src/utils/swrCacheUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
-import { extractCrossNetworkSearchQuery } from '@onekeyhq/shared/src/utils/tokenSelectorCrossNetworkUtils';
+import {
+  extractCrossNetworkSearchQuery,
+  tokenizeTokenSearchKeywords,
+} from '@onekeyhq/shared/src/utils/tokenSelectorCrossNetworkUtils';
 import {
   TOKEN_SELECTOR_LP_TOKEN_FILTER_ENABLED,
   buildTokenSelectorDappTokenFilterParams,
@@ -451,6 +454,13 @@ function TokenSelector() {
     !isSelectorAllNetworks &&
     !network.isCustomNetwork &&
     !showLpTokensOnly;
+  // All-Networks twin of the cross-network case: the backend still matches the
+  // keyword string as a whole, so a combined query ("usdt trc20") sent to
+  // onekeyall verbatim returns nothing. Same stripping applies; only the
+  // fallback networkId differs (already onekeyall). LP filter excluded — its
+  // backend results are network-scoped by design.
+  const allNetworksCrossSearchEnabled =
+    !!searchAll && isSelectorAllNetworks && !showLpTokensOnly;
   // Others (imported / watch-only / external) accounts hold one credential on
   // one impl, so cross-network results must be narrowed to the networks that
   // credential can actually derive an address on. HD/HW accounts are unfiltered
@@ -1096,15 +1106,21 @@ function TokenSelector() {
 
   const searchTokensBySearchKey = useCallback(
     async (keywords: string) => {
+      // Part of the request identity: the gates flip when `network` resolves
+      // or the LP filter toggles, and two runs would otherwise share a context
+      // — letting the earlier (differently scoped) response pass isLatest()
+      // and overwrite the newer one if it lands after the abort.
+      let searchScopeMode = 'scoped';
+      if (crossNetworkSearchEnabled) {
+        searchScopeMode = 'cross';
+      } else if (allNetworksCrossSearchEnabled) {
+        searchScopeMode = 'all-cross';
+      }
       const requestContext = [
         accountId ?? '',
         networkId ?? '',
         tokenSelectorSearchFilterContext,
-        // Part of the identity: the gate flips when `network` resolves, and the
-        // two runs would otherwise share a context — letting the earlier
-        // (differently scoped) response pass isLatest() and overwrite the newer
-        // one if it lands after the abort.
-        crossNetworkSearchEnabled ? 'cross' : 'scoped',
+        searchScopeMode,
         keywords,
       ].join('__');
       latestSearchRequestContextRef.current = requestContext;
@@ -1125,27 +1141,41 @@ function TokenSelector() {
       let searchFailed = false;
       try {
         // Cross-network search: the backend matches the keyword string as a
-        // whole, so combined queries ("usdt trx") first strip an exact network
-        // keyword and scope the request to that network; otherwise query the
-        // backend across all networks (the onekeyall response is a superset of
-        // the scoped one). Results are grouped by network locally.
+        // whole, so combined queries ("usdt trx", "usdt-trc20") first strip an
+        // exact network keyword and scope the request to that network;
+        // otherwise query the backend across all networks (the onekeyall
+        // response is a superset of the scoped one). Results are grouped by
+        // network locally.
+        // Separator-free strings of address-like length skip stripping
+        // entirely: a pasted contract address must reach the backend verbatim.
         // The network catalog is only needed for multi-word queries, so it is
         // fetched here rather than on mount (getAllNetworks is memoized in the
         // background service).
-        const crossNetworkQuery =
-          crossNetworkSearchEnabled && /\s/.test(keywords.trim())
-            ? extractCrossNetworkSearchQuery({
-                keywords,
-                networks: (
-                  await backgroundApiProxy.serviceNetwork.getAllNetworks()
-                ).networks,
-              })
-            : undefined;
+        const trimmedKeywords = keywords.trim();
+        const isAddressLikeKeywords =
+          trimmedKeywords.length >= 20 && !/\s/.test(trimmedKeywords);
+        const keywordStrippingEnabled =
+          (crossNetworkSearchEnabled || allNetworksCrossSearchEnabled) &&
+          !isAddressLikeKeywords &&
+          tokenizeTokenSearchKeywords(trimmedKeywords).length >= 2;
+        const crossNetworkQuery = keywordStrippingEnabled
+          ? extractCrossNetworkSearchQuery({
+              keywords,
+              networks: (
+                await backgroundApiProxy.serviceNetwork.getAllNetworks()
+              ).networks,
+            })
+          : undefined;
+        // Stripping success scopes to the named network in either mode. On
+        // failure, single-network cross mode widens to onekeyall (status quo),
+        // while all-networks mode keeps its own networkId (already onekeyall).
         let result = await backgroundApiProxy.serviceToken.searchTokens({
           accountId,
-          networkId: crossNetworkSearchEnabled
-            ? (crossNetworkQuery?.networkId ?? getNetworkIdsMap().onekeyall)
-            : networkId,
+          networkId:
+            crossNetworkQuery?.networkId ??
+            (crossNetworkSearchEnabled
+              ? getNetworkIdsMap().onekeyall
+              : networkId),
           keywords: crossNetworkQuery?.keywords ?? keywords,
         });
         if (othersAccountForNetworkFilter) {
@@ -1196,6 +1226,7 @@ function TokenSelector() {
     },
     [
       accountId,
+      allNetworksCrossSearchEnabled,
       crossNetworkSearchEnabled,
       isSelectorAllNetworks,
       networkId,

--- a/packages/shared/src/utils/tokenSelectorCrossNetworkUtils.test.ts
+++ b/packages/shared/src/utils/tokenSelectorCrossNetworkUtils.test.ts
@@ -1,8 +1,12 @@
+import { getNetworkIdsMap } from '../config/networkIds';
+
 import {
   ETokenSelectorSyntheticRowType,
   buildCrossNetworkSearchListData,
   extractCrossNetworkSearchQuery,
+  getTokenNetworkAliasMap,
   isTokenSelectorSyntheticRow,
+  tokenizeTokenSearchKeywords,
 } from './tokenSelectorCrossNetworkUtils';
 
 import type { ITokenSelectorListRow } from './tokenSelectorCrossNetworkUtils';
@@ -201,6 +205,35 @@ describe('extractCrossNetworkSearchQuery', () => {
       shortname: 'SOL',
     },
     {
+      id: 'evm--56',
+      name: 'BNB Chain',
+      symbol: 'BNB',
+      code: 'bsc',
+      shortcode: 'bsc',
+      shortname: 'BSC',
+    },
+    // Mirrors presetNetworks bifrostDot: code/shortcode contain a hyphen, which
+    // the tokenizer splits — phrase matching must normalize both sides.
+    {
+      id: 'dot--bifrost',
+      name: 'Bifrost Polkadot',
+      symbol: 'BNC',
+      code: 'dot-bifrost',
+      shortcode: 'dot-bifrost',
+      shortname: 'BNC',
+    },
+    // Custom networks resolve token details via raw RPC contract calls, so
+    // scoping a stripped query to one would turn "no results" into an error.
+    {
+      id: 'evm--98765',
+      name: 'Mycustomnet',
+      symbol: 'MCN',
+      code: 'mycustomnet',
+      shortcode: 'mycustomnet',
+      shortname: 'Mycustomnet',
+      isCustomNetwork: true,
+    },
+    {
       id: 'onekeyall--0',
       name: 'All Networks',
       code: 'onekeyall',
@@ -297,5 +330,126 @@ describe('extractCrossNetworkSearchQuery', () => {
     expect(
       extractCrossNetworkSearchQuery({ keywords: '  USDT   TRX  ', networks }),
     ).toEqual({ networkId: 'tron--0x2b6653dc', keywords: 'usdt' });
+  });
+
+  test('separator-joined queries are tokenized before extraction', () => {
+    expect(
+      extractCrossNetworkSearchQuery({ keywords: 'usdt-trc20', networks }),
+    ).toEqual({ networkId: 'tron--0x2b6653dc', keywords: 'usdt' });
+    expect(
+      extractCrossNetworkSearchQuery({ keywords: 'USDT-Trx', networks }),
+    ).toEqual({ networkId: 'tron--0x2b6653dc', keywords: 'usdt' });
+    expect(
+      extractCrossNetworkSearchQuery({ keywords: 'usdt波场', networks }),
+    ).toEqual({ networkId: 'tron--0x2b6653dc', keywords: 'usdt' });
+  });
+
+  test('network aliases resolve to their preset network, exact-equality only', () => {
+    expect(
+      extractCrossNetworkSearchQuery({ keywords: 'usdt trc20', networks }),
+    ).toEqual({ networkId: 'tron--0x2b6653dc', keywords: 'usdt' });
+    expect(
+      extractCrossNetworkSearchQuery({ keywords: 'usdt 波场', networks }),
+    ).toEqual({ networkId: 'tron--0x2b6653dc', keywords: 'usdt' });
+    expect(
+      extractCrossNetworkSearchQuery({ keywords: 'usdt erc20', networks }),
+    ).toEqual({ networkId: 'evm--1', keywords: 'usdt' });
+    expect(
+      extractCrossNetworkSearchQuery({ keywords: 'usdt bep20', networks }),
+    ).toEqual({ networkId: 'evm--56', keywords: 'usdt' });
+    // Aliases never match on prefix/substring.
+    expect(
+      extractCrossNetworkSearchQuery({ keywords: 'usdt trc', networks }),
+    ).toEqual({ keywords: 'usdt trc' });
+  });
+
+  test('hyphenated network fields still match after tokenization', () => {
+    // code/shortcode 'dot-bifrost' tokenizes to 'dot bifrost' on both sides.
+    expect(
+      extractCrossNetworkSearchQuery({
+        keywords: 'usdt dot-bifrost',
+        networks,
+      }),
+    ).toEqual({ networkId: 'dot--bifrost', keywords: 'usdt' });
+    expect(
+      extractCrossNetworkSearchQuery({
+        keywords: 'usdt dot bifrost',
+        networks,
+      }),
+    ).toEqual({ networkId: 'dot--bifrost', keywords: 'usdt' });
+  });
+
+  test('custom networks are never extraction candidates', () => {
+    expect(
+      extractCrossNetworkSearchQuery({
+        keywords: 'usdt mycustomnet',
+        networks,
+      }),
+    ).toEqual({ keywords: 'usdt mycustomnet' });
+  });
+});
+
+describe('tokenizeTokenSearchKeywords', () => {
+  test('splits on hyphen, underscore, slash, and plus', () => {
+    expect(tokenizeTokenSearchKeywords('USDT-Trc20')).toEqual([
+      'usdt',
+      'trc20',
+    ]);
+    expect(tokenizeTokenSearchKeywords('usdt_trc20')).toEqual([
+      'usdt',
+      'trc20',
+    ]);
+    expect(tokenizeTokenSearchKeywords('usdt/trc20')).toEqual([
+      'usdt',
+      'trc20',
+    ]);
+    expect(tokenizeTokenSearchKeywords('usdt+trc20')).toEqual([
+      'usdt',
+      'trc20',
+    ]);
+  });
+
+  test('splits on the boundary between ASCII and CJK runs', () => {
+    expect(tokenizeTokenSearchKeywords('usdt波场')).toEqual(['usdt', '波场']);
+    expect(tokenizeTokenSearchKeywords('波场usdt')).toEqual(['波场', 'usdt']);
+    expect(tokenizeTokenSearchKeywords('波场')).toEqual(['波场']);
+  });
+
+  test('collapses runs of whitespace and mixed separators', () => {
+    expect(tokenizeTokenSearchKeywords('  USDT   Trc20 ')).toEqual([
+      'usdt',
+      'trc20',
+    ]);
+    expect(tokenizeTokenSearchKeywords('usdt - trc20')).toEqual([
+      'usdt',
+      'trc20',
+    ]);
+    expect(tokenizeTokenSearchKeywords('')).toEqual([]);
+    expect(tokenizeTokenSearchKeywords('  ')).toEqual([]);
+  });
+
+  test('separator-free strings stay one verbatim lowercased token', () => {
+    expect(
+      tokenizeTokenSearchKeywords('0xdAC17F958D2ee523a2206206994597C13D831ec7'),
+    ).toEqual(['0xdac17f958d2ee523a2206206994597c13d831ec7']);
+    // Dots and colons are not separators — they stay inside the token.
+    expect(tokenizeTokenSearchKeywords('0x1::aptos_coin::AptosCoin')).toEqual([
+      '0x1::aptos',
+      'coin::aptoscoin',
+    ]);
+    expect(tokenizeTokenSearchKeywords('usdt.tether-token.near')).toEqual([
+      'usdt.tether',
+      'token.near',
+    ]);
+  });
+});
+
+describe('getTokenNetworkAliasMap', () => {
+  test('first-batch aliases are keyed by preset network ids', () => {
+    const map = getTokenNetworkAliasMap();
+    const networkIds = getNetworkIdsMap();
+    expect(map[networkIds.trx]).toEqual(['trc20', '波场', '波場']);
+    expect(map[networkIds.eth]).toEqual(['erc20']);
+    expect(map[networkIds.bsc]).toEqual(['bep20']);
   });
 });

--- a/packages/shared/src/utils/tokenSelectorCrossNetworkUtils.ts
+++ b/packages/shared/src/utils/tokenSelectorCrossNetworkUtils.ts
@@ -1,9 +1,77 @@
+import { getNetworkIdsMap } from '../config/networkIds';
+
+import { memoFn } from './cacheUtils';
+
 import type { IServerNetwork } from '../../types';
 import type { IAccountToken } from '../../types/token';
 
 // Longest preset network name is 3 words ("Ethereum Sepolia Testnet"); 4 keeps
 // headroom while bounding the span scan.
 const MAX_NETWORK_NAME_WORDS = 4;
+
+const SEPARATOR_CHARS = new Set(['-', '_', '/', '+']);
+
+// CJK detection is a hand-rolled range check: Hermes lacks reliable
+// \p{Script} support, and regex lookbehind is unavailable there too.
+function isCjkCodePoint(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x2e_80 && codePoint <= 0x2f_ff) || // CJK radicals
+    (codePoint >= 0x30_40 && codePoint <= 0x30_ff) || // Hiragana / Katakana
+    (codePoint >= 0x34_00 && codePoint <= 0x4d_bf) || // CJK ext A
+    (codePoint >= 0x4e_00 && codePoint <= 0x9f_ff) || // CJK unified
+    (codePoint >= 0xac_00 && codePoint <= 0xd7_af) || // Hangul syllables
+    (codePoint >= 0xf9_00 && codePoint <= 0xfa_ff) || // CJK compatibility
+    (codePoint >= 0x2_00_00 && codePoint <= 0x3_ff_ff) // CJK ext B and beyond
+  );
+}
+
+// Splits a raw search string into lowercase words on whitespace, common
+// symbol-network separators (- _ / +), and ASCII↔CJK boundaries, so grassroots
+// spellings like "USDT-Trc20" or "usdt波场" become ['usdt', 'trc20'-like]
+// pairs. Anything else (dots, colons, 0x…) stays inside the word, keeping
+// separator-free contract addresses verbatim.
+export function tokenizeTokenSearchKeywords(raw: string): string[] {
+  const text = raw.toLowerCase();
+  const tokens: string[] = [];
+  let current = '';
+  let currentIsCjk = false;
+  const flush = () => {
+    if (current) {
+      tokens.push(current);
+      current = '';
+    }
+  };
+  for (const char of text) {
+    if (SEPARATOR_CHARS.has(char) || /\s/.test(char)) {
+      flush();
+    } else {
+      const isCjk = isCjkCodePoint(char.codePointAt(0) ?? 0);
+      if (current && isCjk !== currentIsCjk) {
+        flush();
+      }
+      current += char;
+      currentIsCjk = isCjk;
+    }
+  }
+  flush();
+  return tokens;
+}
+
+// First batch of user-facing network aliases, sourced from support-ticket
+// vocabulary. Matched with exact equality only — never includes — so "trc"
+// or "c20" cannot accidentally scope a search. Extend per new complaint data.
+export const getTokenNetworkAliasMap = memoFn((): Record<string, string[]> => {
+  const networkIds = getNetworkIdsMap();
+  return {
+    [networkIds.trx]: ['trc20', '波场', '波場'],
+    [networkIds.eth]: ['erc20'],
+    [networkIds.bsc]: ['bep20'],
+  };
+});
+
+function normalizePhrase(value: string): string {
+  return tokenizeTokenSearchKeywords(value).join(' ');
+}
 
 export enum ETokenSelectorSyntheticRowType {
   CurrentNetworkHeader = 'currentNetworkHeader',
@@ -38,10 +106,11 @@ export function isTokenSelectorSyntheticRow(
 
 // The token-search backend matches the keyword string as a whole, so a
 // combined query like "usdt trx" returns nothing from any networkId. When one
-// keyword names a network exactly (name/code/shortcode/shortname), strip it
-// and scope the backend request to that network instead — the local AND filter
-// still applies the full query afterwards. Conservative by design: only
-// extracts when the network is unambiguous and at least one keyword remains.
+// keyword names a network exactly (name/code/shortcode/shortname or a curated
+// alias like "trc20"), strip it and scope the backend request to that network
+// instead — the local AND filter still applies the full query afterwards.
+// Conservative by design: only extracts when the network is unambiguous and at
+// least one keyword remains.
 export function extractCrossNetworkSearchQuery({
   keywords,
   networks,
@@ -49,10 +118,33 @@ export function extractCrossNetworkSearchQuery({
   keywords: string;
   networks: IServerNetwork[];
 }): { networkId?: string; keywords: string } {
-  const words = keywords.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  const words = tokenizeTokenSearchKeywords(keywords);
   if (words.length < 2) {
     return { keywords };
   }
+
+  // Compare tokenizer-normalized phrases on both sides: preset fields may
+  // themselves contain separators ("dot-bifrost"), which the tokenizer splits
+  // in the query. Custom networks are excluded — their token lookup goes
+  // through raw RPC contract calls, so scoping a symbol query to one would
+  // turn an empty result into an error state.
+  const aliasMap = getTokenNetworkAliasMap();
+  const networkMatchers = networks
+    .filter((network) => !network.isAllNetworks && !network.isCustomNetwork)
+    .map((network) => ({
+      network,
+      phrases: new Set(
+        [
+          network.name,
+          network.code,
+          network.shortcode,
+          network.shortname,
+          ...(aliasMap[network.id] ?? []),
+        ]
+          .filter(Boolean)
+          .map((value) => normalizePhrase(value as string)),
+      ),
+    }));
 
   // Network names are often several words ("Bitcoin Cash", "BNB Chain"), so
   // match every contiguous run of words rather than single words only.
@@ -66,14 +158,9 @@ export function extractCrossNetworkSearchQuery({
     const maxEnd = Math.min(words.length, start + MAX_NETWORK_NAME_WORDS);
     for (let end = start + 1; end <= maxEnd; end += 1) {
       const phrase = words.slice(start, end).join(' ');
-      const matched = networks.filter(
-        (network) =>
-          !network.isAllNetworks &&
-          (network.name?.toLowerCase() === phrase ||
-            network.code?.toLowerCase() === phrase ||
-            network.shortcode?.toLowerCase() === phrase ||
-            network.shortname?.toLowerCase() === phrase),
-      );
+      const matched = networkMatchers
+        .filter((matcher) => matcher.phrases.has(phrase))
+        .map((matcher) => matcher.network);
       if (matched.length > 0) {
         spans.push({ start, end, phrase, networks: matched });
       }

--- a/packages/shared/src/utils/tokenUtils.test.ts
+++ b/packages/shared/src/utils/tokenUtils.test.ts
@@ -329,6 +329,114 @@ describe('getFilteredTokenBySearchKey — separators, aliases, address fallback,
     ).toEqual([nearUsdt]);
   });
 
+  test('flattenAggregateTokens: symbol search outputs every sub row, no aggregate row', () => {
+    expect(
+      getFilteredTokenBySearchKey({
+        tokens: [aggregateUsdt],
+        searchKey: 'usdt',
+        aggregateTokenListMap,
+        networksMap,
+        enableNetworkSearch: true,
+        flattenAggregateTokens: true,
+      }),
+    ).toEqual([ethereumUsdt, tronUsdt, nearUsdt]);
+  });
+
+  test('flattenAggregateTokens: owned sub floats to top, unowned keep server config order', () => {
+    const tokenFiatMap = {
+      [tronUsdt.$key]: { fiatValue: '5' } as ITokenFiat,
+    };
+    expect(
+      getFilteredTokenBySearchKey({
+        tokens: [aggregateUsdt],
+        searchKey: 'usdt',
+        aggregateTokenListMap,
+        networksMap,
+        enableNetworkSearch: true,
+        flattenAggregateTokens: true,
+        tokenFiatMap,
+      }),
+    ).toEqual([tronUsdt, ethereumUsdt, nearUsdt]);
+  });
+
+  test('flattenAggregateTokens: symbol/chain-name collision ("eth") also flattens', () => {
+    const aggregateEth = buildTestToken({
+      $key: 'aggregate_ETH_',
+      address: 'aggregate_ETH_',
+      networkId: 'aggregate',
+      isAggregateToken: true,
+      symbol: 'ETH',
+      name: 'Ethereum',
+      commonSymbol: 'ETH',
+    });
+    const ethereumEth = buildTestToken({
+      $key: 'eth-native',
+      address: '',
+      networkId: 'evm--1',
+      symbol: 'ETH',
+      name: 'Ethereum',
+      isNative: true,
+    });
+    const baseEth = buildTestToken({
+      $key: 'base-native',
+      address: '',
+      networkId: 'evm--8453',
+      symbol: 'ETH',
+      name: 'Ethereum',
+      isNative: true,
+    });
+    expect(
+      getFilteredTokenBySearchKey({
+        tokens: [aggregateEth],
+        searchKey: 'eth',
+        aggregateTokenListMap: {
+          [aggregateEth.$key]: { tokens: [ethereumEth, baseEth] },
+        },
+        networksMap,
+        enableNetworkSearch: true,
+        flattenAggregateTokens: true,
+      }),
+    ).toEqual([ethereumEth, baseEth]);
+  });
+
+  test('flattenAggregateTokens: aggregate row survives via self-field match when config is missing', () => {
+    expect(
+      getFilteredTokenBySearchKey({
+        tokens: [aggregateUsdt],
+        searchKey: 'usdt',
+        aggregateTokenListMap: {},
+        networksMap,
+        enableNetworkSearch: true,
+        flattenAggregateTokens: true,
+      }),
+    ).toEqual([aggregateUsdt]);
+  });
+
+  test('flattenAggregateTokens: sub shared by two aggregate configs dedupes by $key', () => {
+    const secondAggregate = buildTestToken({
+      $key: 'aggregate_USDT2_',
+      address: 'aggregate_USDT2_',
+      networkId: 'aggregate',
+      isAggregateToken: true,
+      symbol: 'USDT',
+      name: 'Tether USD',
+      commonSymbol: 'USDT',
+    });
+    expect(
+      getFilteredTokenBySearchKey({
+        tokens: [aggregateUsdt, secondAggregate],
+        searchKey: 'usdt',
+        aggregateTokenListMap: {
+          [aggregateUsdt.$key]: { tokens: [ethereumUsdt, tronUsdt] },
+          [secondAggregate.$key]: { tokens: [tronUsdt, nearUsdt] },
+        },
+        networksMap,
+        enableNetworkSearch: true,
+        flattenAggregateTokens: true,
+      }),
+    ).toEqual([ethereumUsdt, tronUsdt, nearUsdt]);
+  });
+
   test('exact symbol hits sort before includes hits at equal strength, ahead of fiat', () => {
     const ethAusdt = buildTestToken({
       $key: 'eth-ausdt',

--- a/packages/shared/src/utils/tokenUtils.test.ts
+++ b/packages/shared/src/utils/tokenUtils.test.ts
@@ -230,6 +230,129 @@ describe('getFilteredTokenBySearchKey — aggregate token network search', () =>
   });
 });
 
+describe('getFilteredTokenBySearchKey — separators, aliases, address fallback, sort', () => {
+  const aggregateUsdt = buildTestToken({
+    $key: 'aggregate_USDT_',
+    address: 'aggregate_USDT_',
+    networkId: 'aggregate',
+    isAggregateToken: true,
+    symbol: 'USDT',
+    name: 'Tether USD',
+    commonSymbol: 'USDT',
+  });
+  const ethereumUsdt = buildTestToken({
+    $key: 'eth-usdt',
+    address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+    networkId: 'evm--1',
+    symbol: 'USDT',
+    name: 'Tether USD',
+  });
+  const tronUsdt = buildTestToken({
+    $key: 'tron-usdt',
+    address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+    networkId: 'tron--0x2b6653dc',
+    symbol: 'USDT',
+    name: 'Tether USD',
+  });
+  // NEAR-style contract address: contains '-' but no whitespace, so the
+  // tokenizer would split it into several AND-ed words without the fallback.
+  const nearUsdt = buildTestToken({
+    $key: 'near-usdt',
+    address: 'usdt.tether-token.near',
+    networkId: 'near--0',
+    symbol: 'USDT',
+    name: 'Tether USD',
+  });
+  const aggregateTokenListMap = {
+    [aggregateUsdt.$key]: {
+      tokens: [ethereumUsdt, tronUsdt, nearUsdt],
+    },
+  };
+  // The Tron id must be the real preset id — network aliases are keyed by
+  // getNetworkIdsMap() values.
+  const networksMap = {
+    'evm--1': buildTestNetwork({
+      id: 'evm--1',
+      name: 'Ethereum',
+      code: 'eth',
+      shortname: 'ETH',
+    }),
+    'tron--0x2b6653dc': buildTestNetwork({
+      id: 'tron--0x2b6653dc',
+      name: 'Tron',
+      code: 'trx',
+      shortname: 'TRX',
+    }),
+    'near--0': buildTestNetwork({
+      id: 'near--0',
+      name: 'Near',
+      code: 'near',
+      shortname: 'NEAR',
+    }),
+  };
+
+  test.each(['usdt trc20', 'usdt-trc20', 'USDT-Trc20', 'usdt波场', 'usdt trx'])(
+    'splits out the Tron sub row for %s',
+    (searchKey) => {
+      expect(
+        getFilteredTokenBySearchKey({
+          tokens: [aggregateUsdt],
+          searchKey,
+          aggregateTokenListMap,
+          networksMap,
+          enableNetworkSearch: true,
+        }),
+      ).toEqual([tronUsdt]);
+    },
+  );
+
+  test('separator-containing address still matches as a full string (aggregate sub)', () => {
+    expect(
+      getFilteredTokenBySearchKey({
+        tokens: [aggregateUsdt],
+        searchKey: 'usdt.tether-token.near',
+        aggregateTokenListMap,
+        networksMap,
+        enableNetworkSearch: true,
+      }),
+    ).toEqual([aggregateUsdt]);
+  });
+
+  test('separator-containing address still matches as a full string (plain token)', () => {
+    expect(
+      getFilteredTokenBySearchKey({
+        tokens: [nearUsdt],
+        searchKey: 'usdt.tether-token.near',
+        networksMap,
+        enableNetworkSearch: true,
+      }),
+    ).toEqual([nearUsdt]);
+  });
+
+  test('exact symbol hits sort before includes hits at equal strength, ahead of fiat', () => {
+    const ethAusdt = buildTestToken({
+      $key: 'eth-ausdt',
+      address: '0x3ed3b47dd13ec9a98b44e6204a523e766b225811',
+      networkId: 'evm--1',
+      symbol: 'aUSDT',
+      name: 'Aave interest bearing USDT',
+    });
+    const tokenFiatMap = {
+      [ethAusdt.$key]: { fiatValue: '1000' } as ITokenFiat,
+      [ethereumUsdt.$key]: { fiatValue: '1' } as ITokenFiat,
+    };
+    expect(
+      getFilteredTokenBySearchKey({
+        tokens: [ethAusdt, ethereumUsdt],
+        searchKey: 'usdt',
+        networksMap,
+        enableNetworkSearch: true,
+        tokenFiatMap,
+      }),
+    ).toEqual([ethereumUsdt, ethAusdt]);
+  });
+});
+
 describe('calculateAccountTotalValue — tray case (no filters)', () => {
   test('sums all token values + deFi when no filters passed', () => {
     expect(

--- a/packages/shared/src/utils/tokenUtils.ts
+++ b/packages/shared/src/utils/tokenUtils.ts
@@ -14,6 +14,10 @@ import accountUtils from './accountUtils';
 import networkUtils from './networkUtils';
 import tokenRebaseUtils from './tokenRebaseUtils';
 import {
+  getTokenNetworkAliasMap,
+  tokenizeTokenSearchKeywords,
+} from './tokenSelectorCrossNetworkUtils';
+import {
   isUnavailableOrZeroFiatValue,
   isValidNumberValue,
 } from './tokenValueUtils';
@@ -132,6 +136,9 @@ function networkFieldsContainKeyword(
     network.code?.toLowerCase().includes(kw) ||
     network.shortname?.toLowerCase().includes(kw) ||
     network.shortcode?.toLowerCase().includes(kw) ||
+    // Curated aliases ("trc20", "波场") are exact-equality only, so a partial
+    // word like "trc" can never scope a search through them.
+    getTokenNetworkAliasMap()[network.id]?.some((alias) => alias === kw) ||
     false
   );
 }
@@ -174,6 +181,12 @@ function computeSearchStrength(
   token: IAccountToken,
   keywords: string[],
   network: IServerNetwork | undefined,
+  // Original trimmed search string, set ONLY when the tokenizer split a
+  // whitespace-free input (e.g. "usdt.tether-token.near"). Contract addresses
+  // legitimately contain separator chars (TON base64url, NEAR dots, Move ::),
+  // and per-word AND matching would never reassemble them — so an exact
+  // full-string address hit short-circuits as matched.
+  fullSearchKey?: string,
 ): {
   matched: boolean;
   strength: ESearchStrength;
@@ -183,6 +196,14 @@ function computeSearchStrength(
   // qualifier: it is a symbol search that merely collides with a chain name.
   hasPureNetworkKeyword: boolean;
 } {
+  if (fullSearchKey && token.address?.toLowerCase() === fullSearchKey) {
+    return {
+      matched: true,
+      strength: ESearchStrength.TOKEN_ONLY,
+      hasPureNetworkKeyword: false,
+    };
+  }
+
   let anyTokenHit = false;
   let anyNetworkHit = false;
   let hasPureNetworkKeyword = false;
@@ -281,13 +302,28 @@ export function getFilteredTokenBySearchKey({
     });
   }
 
-  const keywords = trimmedSearchKey.split(/\s+/).filter(Boolean);
+  const keywords = tokenizeTokenSearchKeywords(trimmedSearchKey);
   if (keywords.length === 0) return [];
+
+  // A1 fallback: only a whitespace-free input can be a contract address the
+  // tokenizer tore apart, so only then is the full-string check armed.
+  const fullSearchKey =
+    keywords.length > 1 && !/\s/.test(trimmedSearchKey)
+      ? trimmedSearchKey
+      : undefined;
 
   const results: Array<{
     token: IAccountToken;
     strength: ESearchStrength;
+    exactSymbolHit: boolean;
   }> = [];
+
+  const hasExactSymbolKeywordHit = (token: IAccountToken): boolean =>
+    keywords.some(
+      (kw) =>
+        kw === token.symbol?.toLowerCase() ||
+        kw === token.commonSymbol?.toLowerCase(),
+    );
 
   for (const token of mergedTokens) {
     if (token.isAggregateToken) {
@@ -296,12 +332,13 @@ export function getFilteredTokenBySearchKey({
       const matchedSubs: Array<{
         token: IAccountToken;
         strength: ESearchStrength;
+        exactSymbolHit: boolean;
         hasPureNetworkKeyword: boolean;
       }> = [];
       for (const sub of subTokens) {
         const network = networksMap?.[sub.networkId ?? ''];
         const { matched, strength, hasPureNetworkKeyword } =
-          computeSearchStrength(sub, keywords, network);
+          computeSearchStrength(sub, keywords, network, fullSearchKey);
         if (matched) {
           const localSub = localAggregateTokenListMap?.[
             token.$key
@@ -309,6 +346,7 @@ export function getFilteredTokenBySearchKey({
           matchedSubs.push({
             token: localSub ?? sub,
             strength,
+            exactSymbolHit: hasExactSymbolKeywordHit(localSub ?? sub),
             hasPureNetworkKeyword,
           });
         }
@@ -331,6 +369,7 @@ export function getFilteredTokenBySearchKey({
             // double-hit ('eth') is not buried at TOKEN_ONLY below every
             // network-qualified plain row.
             strength: Math.min(...matchedSubs.map((s) => s.strength)),
+            exactSymbolHit: hasExactSymbolKeywordHit(token),
           });
         }
       } else {
@@ -338,9 +377,14 @@ export function getFilteredTokenBySearchKey({
           token,
           keywords,
           undefined,
+          fullSearchKey,
         );
         if (matched) {
-          results.push({ token, strength });
+          results.push({
+            token,
+            strength,
+            exactSymbolHit: hasExactSymbolKeywordHit(token),
+          });
         }
       }
     } else {
@@ -349,9 +393,14 @@ export function getFilteredTokenBySearchKey({
         token,
         keywords,
         network,
+        fullSearchKey,
       );
       if (matched) {
-        results.push({ token, strength });
+        results.push({
+          token,
+          strength,
+          exactSymbolHit: hasExactSymbolKeywordHit(token),
+        });
       }
     }
   }
@@ -359,6 +408,11 @@ export function getFilteredTokenBySearchKey({
   if (tokenFiatMap) {
     results.sort((a, b) => {
       if (a.strength !== b.strength) return a.strength - b.strength;
+      // Exact symbol hits ("usdt" → USDT) outrank includes hits (aUSDT) even
+      // when the includes hit carries more fiat value.
+      if (a.exactSymbolHit !== b.exactSymbolHit) {
+        return a.exactSymbolHit ? -1 : 1;
+      }
       const fa = new BigNumber(tokenFiatMap[a.token.$key]?.fiatValue ?? -1);
       const fb = new BigNumber(tokenFiatMap[b.token.$key]?.fiatValue ?? -1);
       return (fb.isNaN() ? new BigNumber(-1) : fb).comparedTo(

--- a/packages/shared/src/utils/tokenUtils.ts
+++ b/packages/shared/src/utils/tokenUtils.ts
@@ -244,6 +244,7 @@ export function getFilteredTokenBySearchKey({
   enableNetworkSearch,
   tokenFiatMap,
   localAggregateTokenListMap,
+  flattenAggregateTokens,
 }: {
   tokens: IAccountToken[];
   searchKey: string;
@@ -256,6 +257,10 @@ export function getFilteredTokenBySearchKey({
   enableNetworkSearch?: boolean;
   tokenFiatMap?: Record<string, ITokenFiat>;
   localAggregateTokenListMap?: Record<string, { tokens: IAccountToken[] }>;
+  // Search-mode aggregate flatten (Receive): output every matched sub row
+  // instead of the grouped aggregate row. Off by default — all other callers
+  // keep the grouped behavior.
+  flattenAggregateTokens?: boolean;
 }) {
   let mergedTokens = tokens;
 
@@ -353,24 +358,32 @@ export function getFilteredTokenBySearchKey({
       }
 
       if (matchedSubs.length > 0) {
-        // Split into network-specific sub rows ONLY on an EXPLICIT network
-        // qualifier ('usdc eth'). A single word hitting a sub's token AND
-        // network at once ('eth' = ETH symbol + Ethereum chain — same for
-        // sol/trx/bnb/pol) is a symbol search: keep the aggregate row grouped.
-        const networkQualifiedMatches = matchedSubs.filter(
-          (s) => s.hasPureNetworkKeyword,
-        );
-        if (networkQualifiedMatches.length > 0) {
-          results.push(...networkQualifiedMatches);
+        if (flattenAggregateTokens) {
+          // Search-mode flatten: every matched sub becomes its own
+          // per-network row, whether or not the query carried an explicit
+          // network qualifier. Owned copies were already substituted above.
+          results.push(...matchedSubs);
         } else {
-          results.push({
-            token,
-            // Rank the grouped row by its best sub match so a token+network
-            // double-hit ('eth') is not buried at TOKEN_ONLY below every
-            // network-qualified plain row.
-            strength: Math.min(...matchedSubs.map((s) => s.strength)),
-            exactSymbolHit: hasExactSymbolKeywordHit(token),
-          });
+          // Split into network-specific sub rows ONLY on an EXPLICIT network
+          // qualifier ('usdc eth'). A single word hitting a sub's token AND
+          // network at once ('eth' = ETH symbol + Ethereum chain — same for
+          // sol/trx/bnb/pol) is a symbol search: keep the aggregate row
+          // grouped.
+          const networkQualifiedMatches = matchedSubs.filter(
+            (s) => s.hasPureNetworkKeyword,
+          );
+          if (networkQualifiedMatches.length > 0) {
+            results.push(...networkQualifiedMatches);
+          } else {
+            results.push({
+              token,
+              // Rank the grouped row by its best sub match so a token+network
+              // double-hit ('eth') is not buried at TOKEN_ONLY below every
+              // network-qualified plain row.
+              strength: Math.min(...matchedSubs.map((s) => s.strength)),
+              exactSymbolHit: hasExactSymbolKeywordHit(token),
+            });
+          }
         }
       } else {
         const { matched, strength } = computeSearchStrength(
@@ -421,7 +434,12 @@ export function getFilteredTokenBySearchKey({
     });
   }
 
-  return results.map((r) => r.token);
+  // Two server aggregate configs may share one sub token; emitting it twice
+  // would collide FlashList keys. First occurrence wins, preserving sort.
+  return uniqBy(
+    results.map((r) => r.token),
+    (token) => token.$key,
+  );
 }
 
 export function sortTokensByFiatValue({


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59366](https://onekeyhq.atlassian.net/browse/OK-59366)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

Implements OK-59366 (product ticket OK-59323): grassroots spellings like `USDT-Trc20` / `usdt波场` now hit the target token in the main Receive token selector, and search results flatten aggregate tokens into per-network rows (Bitget-style). Client-side only, main Receive selector only.

- **Tokenizer + network aliases** (`tokenSelectorCrossNetworkUtils.ts`): hand-written char-scan splitter (whitespace / `-` `_` `/` `+` / ASCII↔CJK boundary, Hermes-safe), first-batch alias map `trc20/波场/波場→Tron`, `erc20→Ethereum`, `bep20→BNB Chain` (exact-equality only), and `extractCrossNetworkSearchQuery` upgraded to tokenizer-normalized phrase matching (fixes hyphenated preset fields like `dot-bifrost`) with custom networks excluded.
- **Local filter** (`tokenUtils.ts`, network branch only): tokenized keywords + alias equality in network fields, full-string address fallback for separator-containing contract addresses (TON/NEAR/Move), and an exact-symbol-hit sort tiebreaker so `USDT` outranks `aUSDT` at equal strength.
- **Search-mode aggregate flatten**: new `flattenAggregateTokens` param (default off; wired only at the Receive `useNetworkSearch` call site) outputs every matched sub row instead of the grouped aggregate row, with `$key` dedupe. Browse mode (no search) keeps aggregate rows.
- **All-Networks backend stripping** (`TokenSelector.tsx`): keyword stripping now also applies in All Networks mode (previously the combined query went to `onekeyall` verbatim → guaranteed empty), with an address-like heuristic (no whitespace && length ≥ 20 skips stripping) and a 3-state request context to prevent stale-response overwrite.

Red lines held: non-network filter branch, `homeProjection`, `ServiceUniversalSearch`, and `buildTokenSearchKeywordQueries` untouched (homeProjection parity test green); no locale changes, no new UI components.

## Test plan

- [x] 97 unit tests green: `tokenUtils.test.ts`, `tokenSelectorCrossNetworkUtils.test.ts` (24 new cases across tokenizer/aliases/flatten/address-fallback/sort), `homeProjection.test.ts` parity guard
- [x] `yarn agent:check --profile commit` / `--profile pr` pass
- [x] Web dev manual matrix (All Networks account): `USDT-Trc20` / `usdt波场` / `usdt trc20` → USDT-Tron row; `usdt` → per-chain flatten, owned chains float by fiat, zero-balance chains follow server config order, no aggregate row; `eth` → per-chain ETH rows; `usdt tron` regression unchanged; EVM `0x…` and NEAR `usdt.tether-token.near` address pastes hit; single-network (Ethereum) scope shows "no results on Ethereum" + Other networks USDT-Tron; fast type `usdt trc20` → backspace to `usdt` shows final-state results; tapping zero-balance USDT-Tron flattened row lands on the Receive address page; global search and Manage token dialog keep aggregate rows (regression)
- [ ] QA: custom-network case (§8 #7 — D1 covered by unit test), iOS / Android native pass (tokenizer is Hermes-safe by construction)

[OK-59366]: https://onekeyhq.atlassian.net/browse/OK-59366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ