### PR TITLE
fix: align stock status and BTC pro trading (OK-58986, OK-57059)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -114,7 +114,6 @@ import {
   swapNetworks,
   swapNetworksIncludeAllNetworkAtom,
   swapProDirectionAtom,
-  swapProErrorAlertAtom,
   swapProInputAmountAtom,
   swapProPositionsCacheAtom,
   swapProPositionsCurrentOwnerKeyAtom,
@@ -705,14 +704,13 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
           });
         if (!isSameToken) {
           // These atoms belong to the previous selected token. Clear them in
-          // the same state transition so its detail, websocket and warning
-          // cannot render under the next token while new data is loading.
+          // the same state transition so its detail, websocket and
+          // transaction price cannot render under the next token.
           set(swapProTokenMarketDetailInfoAtom(), undefined);
           set(swapProTokenMarketDetailPerpsInfoAtom(), undefined);
           set(swapProTokenDetailWebsocketAtom(), undefined);
           set(swapProTokenTransactionPriceAtom(), '');
           set(swapProTokenMarketDetailInfoLoadingAtom(), false);
-          set(swapProErrorAlertAtom(), undefined);
         }
         set(swapProSelectTokenAtom(), nextToken);
       };

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -114,6 +114,7 @@ import {
   swapNetworks,
   swapNetworksIncludeAllNetworkAtom,
   swapProDirectionAtom,
+  swapProErrorAlertAtom,
   swapProInputAmountAtom,
   swapProPositionsCacheAtom,
   swapProPositionsCurrentOwnerKeyAtom,
@@ -129,6 +130,7 @@ import {
   swapProTokenMarketDetailInfoAtom,
   swapProTokenMarketDetailInfoLoadingAtom,
   swapProTokenMarketDetailPerpsInfoAtom,
+  swapProTokenTransactionPriceAtom,
   swapProTradeTypeAtom,
   swapProUseSelectBuyTokenAtom,
   swapQuoteActionLockAtom,
@@ -693,8 +695,30 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         return rest;
       };
 
+      const setSelectedToken = (nextToken: ISwapToken) => {
+        const currentToken = get(swapProSelectTokenAtom());
+        const isSameToken =
+          currentToken &&
+          equalTokenNoCaseSensitive({
+            token1: currentToken,
+            token2: nextToken,
+          });
+        if (!isSameToken) {
+          // These atoms belong to the previous selected token. Clear them in
+          // the same state transition so its detail, websocket and warning
+          // cannot render under the next token while new data is loading.
+          set(swapProTokenMarketDetailInfoAtom(), undefined);
+          set(swapProTokenMarketDetailPerpsInfoAtom(), undefined);
+          set(swapProTokenDetailWebsocketAtom(), undefined);
+          set(swapProTokenTransactionPriceAtom(), '');
+          set(swapProTokenMarketDetailInfoLoadingAtom(), false);
+          set(swapProErrorAlertAtom(), undefined);
+        }
+        set(swapProSelectTokenAtom(), nextToken);
+      };
+
       if (token) {
-        set(swapProSelectTokenAtom(), token);
+        setSelectedToken(token);
         await backgroundApiProxy.simpleDb.swapProSelectToken.setSwapProSelectToken(
           getTokenForStorage(token),
         );
@@ -702,9 +726,9 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         const savedToken =
           await backgroundApiProxy.simpleDb.swapProSelectToken.getSwapProSelectToken();
         if (savedToken) {
-          set(swapProSelectTokenAtom(), savedToken);
+          setSelectedToken(savedToken);
         } else if (defaultToken) {
-          set(swapProSelectTokenAtom(), defaultToken);
+          setSelectedToken(defaultToken);
           await backgroundApiProxy.simpleDb.swapProSelectToken.setSwapProSelectToken(
             getTokenForStorage(defaultToken),
           );
@@ -3757,6 +3781,18 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         const tokenData = responseData.data.token;
         const websocketConfig = responseData.data.websocket;
         const currentSelectToken = get(swapProSelectTokenAtom());
+        if (
+          !currentSelectToken ||
+          !equalTokenNoCaseSensitive({
+            token1: {
+              networkId,
+              contractAddress,
+            },
+            token2: currentSelectToken,
+          })
+        ) {
+          return;
+        }
         const currentTokenDetail = get(swapProTokenMarketDetailInfoAtom());
         const isSameToken =
           currentTokenDetail &&
@@ -3806,7 +3842,19 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       } catch (error) {
         console.error('swap__tokenDetail error', error);
       } finally {
-        set(swapProTokenMarketDetailInfoLoadingAtom(), false);
+        const currentSelectToken = get(swapProSelectTokenAtom());
+        if (
+          currentSelectToken &&
+          equalTokenNoCaseSensitive({
+            token1: {
+              networkId,
+              contractAddress,
+            },
+            token2: currentSelectToken,
+          })
+        ) {
+          set(swapProTokenMarketDetailInfoLoadingAtom(), false);
+        }
       }
     },
   );

--- a/packages/kit/src/views/Swap/components/SwapProTimeRangeSelector.tsx
+++ b/packages/kit/src/views/Swap/components/SwapProTimeRangeSelector.tsx
@@ -13,14 +13,14 @@ interface ISwapProTimeRangeSelectorProps {
   items: { label: string; value: ESwapProTimeRange }[];
   selectedValue: { label: string; value: ESwapProTimeRange };
   onChange: (value: ESwapProTimeRange) => void;
-  supportSpeedSwap?: boolean;
+  disabled?: boolean;
 }
 
 const SwapProTimeRangeSelector = ({
   items,
   selectedValue,
   onChange,
-  supportSpeedSwap,
+  disabled,
 }: ISwapProTimeRangeSelectorProps) => {
   const intl = useIntl();
 
@@ -31,7 +31,7 @@ const SwapProTimeRangeSelector = ({
         cursor="pointer"
         userSelect="none"
         borderRadius="$2"
-        onPress={!supportSpeedSwap ? undefined : props.onPress}
+        onPress={disabled ? undefined : props.onPress}
         h="$8"
         alignItems="center"
         justifyContent="space-between"
@@ -47,14 +47,14 @@ const SwapProTimeRangeSelector = ({
         }}
       >
         <SizableText size="$bodyMd">
-          {!supportSpeedSwap ? defaultTimeRangeItem.label : selectedValue.label}
+          {disabled ? defaultTimeRangeItem.label : selectedValue.label}
         </SizableText>
-        {!supportSpeedSwap ? null : (
+        {disabled ? null : (
           <Icon name="ChevronDownSmallOutline" size="$4" color="$iconSubdued" />
         )}
       </XStack>
     ),
-    [supportSpeedSwap, selectedValue.label],
+    [disabled, selectedValue.label],
   );
 
   return (
@@ -65,7 +65,7 @@ const SwapProTimeRangeSelector = ({
       onChange={(value) => {
         onChange(value as ESwapProTimeRange);
       }}
-      disabled={!supportSpeedSwap}
+      disabled={disabled}
       title={intl.formatMessage({ id: ETranslations.global_time_range })}
       renderTrigger={renderTrigger}
       floatingPanelProps={{

--- a/packages/kit/src/views/Swap/hooks/useSwapPro.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapPro.ts
@@ -27,7 +27,6 @@ import type { IMarketSearchV2Token } from '@onekeyhq/shared/types/market';
 import type {
   IMarketBasicConfigNetwork,
   IMarketTokenListItem,
-  IMarketTokenTransaction,
 } from '@onekeyhq/shared/types/marketV2';
 import {
   SWAP_PRO_QUOTE_INPUT_DEBOUNCE_MS,
@@ -74,7 +73,6 @@ import {
   useSwapProTokenBalanceLoadingAtom,
   useSwapProTokenMarketDetailInfoAtom,
   useSwapProTokenSupportLimitAtom,
-  useSwapProTokenTransactionPriceAtom,
   useSwapProTradeTypeAtom,
   useSwapProUseSelectBuyTokenAtom,
   useSwapQuoteCurrentSelectAtom,
@@ -85,7 +83,6 @@ import {
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
 import { useMarketBasicConfig } from '../../Market/hooks';
-import { useTransactionsWebSocket } from '../../Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/hooks/useTransactionsWebSocket';
 import { useSpeedSwapInit } from '../../Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapInit';
 import { ESwapDirection } from '../../Market/MarketDetailV2/components/SwapPanel/hooks/useTradeType';
 import {
@@ -1462,108 +1459,6 @@ export function useSwapProTokenDetailInfo() {
   };
 }
 
-export function useSwapProTokenTransactionList(
-  tokenAddress: string,
-  networkId: string,
-  enableWebSocket: boolean,
-  supportSpeedSwap?: boolean,
-) {
-  const currencyInfo = useCurrency();
-  const [, setSwapProTokenTransactionPrice] =
-    useSwapProTokenTransactionPriceAtom();
-  const [swapProTokenTransactionList, setSwapProTokenTransactionList] =
-    useState<IMarketTokenTransaction[]>([]);
-  const swapProTokenTransactionListRef = useRef<IMarketTokenTransaction[]>(
-    swapProTokenTransactionList,
-  );
-  if (swapProTokenTransactionListRef.current !== swapProTokenTransactionList) {
-    swapProTokenTransactionListRef.current = [...swapProTokenTransactionList];
-  }
-  const {
-    result: transactionsData,
-    isLoading: isRefreshing,
-    run: fetchTransactions,
-  } = usePromiseResult(
-    async () => {
-      if (!networkId || !supportSpeedSwap) {
-        return undefined;
-      }
-      try {
-        const response =
-          await backgroundApiProxy.serviceMarketV2.fetchMarketTokenTransactions(
-            {
-              tokenAddress,
-              networkId,
-              limit: 10,
-            },
-          );
-        return response;
-      } catch (_e) {
-        return { list: [] };
-      }
-    },
-    [networkId, supportSpeedSwap, tokenAddress],
-    {
-      watchLoading: true,
-    },
-  );
-  useEffect(() => {
-    const newTransactions = transactionsData?.list;
-    if (!newTransactions || newTransactions.length === 0) {
-      setSwapProTokenTransactionList([]);
-      setSwapProTokenTransactionPrice('');
-      return;
-    }
-    setSwapProTokenTransactionList(newTransactions);
-    setSwapProTokenTransactionPrice(newTransactions[0].to.price ?? '');
-  }, [transactionsData?.list, setSwapProTokenTransactionPrice]);
-
-  const addNewTransactions = useCallback(
-    (newTransactions: IMarketTokenTransaction[]) => {
-      if (newTransactions.length === 0) {
-        return;
-      }
-
-      const prev = swapProTokenTransactionListRef.current;
-      const seenHashes = new Set(prev.map((tx) => tx.hash));
-      const nextTransactions = newTransactions.filter((tx) => {
-        if (seenHashes.has(tx.hash)) {
-          return false;
-        }
-        seenHashes.add(tx.hash);
-        return true;
-      });
-
-      if (nextTransactions.length === 0) {
-        return;
-      }
-
-      const updatedTransactions = [...nextTransactions, ...prev].toSorted(
-        (a, b) => b.timestamp - a.timestamp,
-      );
-      setSwapProTokenTransactionList(updatedTransactions);
-      setSwapProTokenTransactionPrice(updatedTransactions[0].to.price ?? '');
-    },
-    [setSwapProTokenTransactionPrice],
-  );
-
-  // Subscribe to real-time transaction updates
-  // Only enable if websocket.txs is enabled and other conditions are met
-  useTransactionsWebSocket({
-    networkId,
-    tokenAddress,
-    enabled: enableWebSocket && supportSpeedSwap,
-    currency: currencyInfo.id,
-    onNewTransactions: addNewTransactions,
-  });
-
-  return {
-    swapProTokenTransactionList,
-    isRefreshing,
-    fetchTransactions,
-  };
-}
-
 function useSwapProPositionAccountIdentity() {
   const { activeAccount } = useActiveAccount({ num: 0 });
   const { selectedAccount } = useSelectedAccount({ num: 0 });
@@ -2001,10 +1896,12 @@ export function useSwapProActionsQuote() {
 
 export function useSwapProErrorAlert({
   isSwapProActive,
+  isAccountContextReady,
   accountScope,
   accountStatus,
 }: {
   isSwapProActive: boolean;
+  isAccountContextReady: boolean;
   accountScope: string;
   accountStatus: ESwapProAccountStatus;
 }) {
@@ -2021,6 +1918,11 @@ export function useSwapProErrorAlert({
   }, [swapProTradeType, swapProQuoteResult, swapCurrentQuote]);
   const previousAccountScopeRef = useRef('');
   useEffect(() => {
+    if (!isAccountContextReady) {
+      previousAccountScopeRef.current = '';
+      setSwapProErrorAlert(undefined);
+      return;
+    }
     const alertAction = getSwapProErrorAlertAction({
       isSwapProActive,
       previousAccountScope: previousAccountScopeRef.current,
@@ -2054,6 +1956,7 @@ export function useSwapProErrorAlert({
     accountStatus,
     currentQuoteRes,
     intl,
+    isAccountContextReady,
     isSwapProActive,
     setSwapProErrorAlert,
   ]);

--- a/packages/kit/src/views/Swap/hooks/useSwapProTokenTransactionList.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapProTokenTransactionList.ts
@@ -209,11 +209,13 @@ export function useSwapProTokenTransactionList({
     };
     currentTransactionStateRef.current = nextState;
     setTransactionState(nextState);
-    setSwapProTokenTransactionPrice(
-      nextTransactions[0]
-        ? getSwapProTransactionTokenPrice(nextTransactions[0])
-        : '',
-    );
+    if (transactionSource === 'market') {
+      setSwapProTokenTransactionPrice(
+        nextTransactions[0]
+          ? getSwapProTransactionTokenPrice(nextTransactions[0])
+          : '',
+      );
+    }
   }, [feedKey, feedResult, setSwapProTokenTransactionPrice, transactionSource]);
 
   const handleNewTransactions = useCallback(

--- a/packages/kit/src/views/Swap/hooks/useSwapProTokenTransactionList.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapProTokenTransactionList.ts
@@ -1,0 +1,274 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useSwapProTokenTransactionPriceAtom } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+import type { IMarketTokenTransaction } from '@onekeyhq/shared/types/marketV2';
+
+import backgroundApiProxy from '../../../background/instance/backgroundApiProxy';
+import { useCurrency } from '../../../components/Currency';
+import { usePromiseResult } from '../../../hooks/usePromiseResult';
+import { useTransactionsWebSocket } from '../../Market/MarketDetailV2/components/InformationTabs/components/TransactionsHistory/hooks/useTransactionsWebSocket';
+import {
+  getSwapProTransactionSource,
+  getSwapProTransactionTokenPrice,
+  mapHyperliquidTradesToSwapProTransactions,
+} from '../utils/swapProTransactionSource';
+
+type ISwapProTokenTransactionListParams = {
+  tokenAddress: string;
+  networkId: string;
+  symbol: string;
+  isNative?: boolean;
+  enableWebSocket: boolean;
+  supportSpeedSwap?: boolean;
+};
+
+type ISwapProTransactionFeedResult = {
+  feedKey: string;
+  list: IMarketTokenTransaction[];
+  isError: boolean;
+};
+
+type ISwapProTransactionState = {
+  feedKey: string;
+  list: IMarketTokenTransaction[];
+};
+
+const SWAP_PRO_TRANSACTION_LIMIT = 10;
+
+function getTransactionIdentity(transaction: IMarketTokenTransaction) {
+  return (
+    transaction.hash ||
+    `${transaction.timestamp}:${transaction.type}:${transaction.from.amount}:${transaction.to.amount}`
+  );
+}
+
+function mergeTransactions(
+  ...transactionLists: IMarketTokenTransaction[][]
+): IMarketTokenTransaction[] {
+  const seen = new Set<string>();
+  const merged: IMarketTokenTransaction[] = [];
+
+  for (const transactions of transactionLists) {
+    for (const transaction of transactions) {
+      const identity = getTransactionIdentity(transaction);
+      if (!seen.has(identity)) {
+        seen.add(identity);
+        merged.push(transaction);
+      }
+    }
+  }
+
+  return merged
+    .toSorted((a, b) => b.timestamp - a.timestamp)
+    .slice(0, SWAP_PRO_TRANSACTION_LIMIT);
+}
+
+function useSwapProTransactionFeed({
+  tokenAddress,
+  networkId,
+  symbol,
+  isNative,
+  supportSpeedSwap,
+}: Omit<ISwapProTokenTransactionListParams, 'enableWebSocket'>) {
+  const transactionSource = getSwapProTransactionSource({
+    token: {
+      contractAddress: tokenAddress,
+      networkId,
+      symbol,
+      isNative,
+    },
+    supportSpeedSwap,
+  });
+  const feedKey = [
+    transactionSource ?? 'none',
+    networkId,
+    tokenAddress,
+    symbol,
+    isNative ? 'native' : 'token',
+  ].join(':');
+  const { result: feedResult } =
+    usePromiseResult<ISwapProTransactionFeedResult>(
+      async () => {
+        if (!networkId || !transactionSource) {
+          return {
+            feedKey,
+            list: [],
+            isError: false,
+          };
+        }
+        try {
+          if (transactionSource === 'hyperliquid') {
+            const trades =
+              await backgroundApiProxy.serviceHyperliquid.getPerpRecentTrades({
+                coin: 'BTC',
+              });
+            return {
+              feedKey,
+              list: mapHyperliquidTradesToSwapProTransactions(trades).slice(
+                0,
+                SWAP_PRO_TRANSACTION_LIMIT,
+              ),
+              isError: false,
+            };
+          }
+          const response =
+            await backgroundApiProxy.serviceMarketV2.fetchMarketTokenTransactions(
+              {
+                tokenAddress,
+                networkId,
+                limit: SWAP_PRO_TRANSACTION_LIMIT,
+              },
+            );
+          return {
+            feedKey,
+            list: response.list,
+            isError: false,
+          };
+        } catch (_error) {
+          return {
+            feedKey,
+            list: [],
+            isError: true,
+          };
+        }
+      },
+      [feedKey, networkId, tokenAddress, transactionSource],
+      {
+        pollingInterval:
+          transactionSource === 'hyperliquid'
+            ? timerUtils.getTimeDurationMs({ seconds: 3 })
+            : undefined,
+      },
+    );
+
+  return {
+    feedKey,
+    feedResult,
+    transactionSource,
+    hasLoadedTransactionSource: feedResult?.feedKey === feedKey,
+  };
+}
+
+export function useSwapProTokenTransactionList({
+  tokenAddress,
+  networkId,
+  symbol,
+  isNative,
+  enableWebSocket,
+  supportSpeedSwap,
+}: ISwapProTokenTransactionListParams) {
+  const currencyInfo = useCurrency();
+  const [, setSwapProTokenTransactionPrice] =
+    useSwapProTokenTransactionPriceAtom();
+  const { feedKey, feedResult, transactionSource, hasLoadedTransactionSource } =
+    useSwapProTransactionFeed({
+      tokenAddress,
+      networkId,
+      symbol,
+      isNative,
+      supportSpeedSwap,
+    });
+  const [transactionState, setTransactionState] =
+    useState<ISwapProTransactionState>({
+      feedKey,
+      list: [],
+    });
+  const currentTransactionState: ISwapProTransactionState =
+    transactionState.feedKey === feedKey
+      ? transactionState
+      : { feedKey, list: [] };
+  const currentTransactionStateRef = useRef(currentTransactionState);
+  const activeFeedKeyRef = useRef(feedKey);
+  currentTransactionStateRef.current = currentTransactionState;
+  activeFeedKeyRef.current = feedKey;
+
+  useEffect(() => {
+    setSwapProTokenTransactionPrice('');
+  }, [feedKey, setSwapProTokenTransactionPrice]);
+
+  useEffect(() => {
+    if (
+      feedResult?.feedKey !== feedKey ||
+      feedResult.isError ||
+      activeFeedKeyRef.current !== feedKey
+    ) {
+      return;
+    }
+
+    const nextTransactions =
+      transactionSource === 'market'
+        ? mergeTransactions(
+            feedResult.list,
+            currentTransactionStateRef.current.list,
+          )
+        : feedResult.list;
+    const nextState = {
+      feedKey,
+      list: nextTransactions,
+    };
+    currentTransactionStateRef.current = nextState;
+    setTransactionState(nextState);
+    setSwapProTokenTransactionPrice(
+      nextTransactions[0]
+        ? getSwapProTransactionTokenPrice(nextTransactions[0])
+        : '',
+    );
+  }, [feedKey, feedResult, setSwapProTokenTransactionPrice, transactionSource]);
+
+  const handleNewTransactions = useCallback(
+    (newTransactions: IMarketTokenTransaction[]) => {
+      if (
+        newTransactions.length === 0 ||
+        activeFeedKeyRef.current !== feedKey
+      ) {
+        return;
+      }
+
+      const previousState = currentTransactionStateRef.current;
+      const previousTransactions =
+        previousState.feedKey === feedKey ? previousState.list : [];
+      const seenTransactions = new Set(
+        previousTransactions.map(getTransactionIdentity),
+      );
+      const uniqueNewTransactions = newTransactions.filter(
+        (transaction) =>
+          !seenTransactions.has(getTransactionIdentity(transaction)),
+      );
+      if (uniqueNewTransactions.length === 0) {
+        return;
+      }
+
+      const updatedTransactions = mergeTransactions(
+        uniqueNewTransactions,
+        previousTransactions,
+      );
+      const nextState = {
+        feedKey,
+        list: updatedTransactions,
+      };
+      currentTransactionStateRef.current = nextState;
+      setTransactionState(nextState);
+      setSwapProTokenTransactionPrice(
+        getSwapProTransactionTokenPrice(updatedTransactions[0]),
+      );
+    },
+    [feedKey, setSwapProTokenTransactionPrice],
+  );
+
+  useTransactionsWebSocket({
+    networkId,
+    tokenAddress,
+    enabled: enableWebSocket && transactionSource === 'market',
+    currency: currencyInfo.id,
+    maxPendingTransactions: SWAP_PRO_TRANSACTION_LIMIT,
+    onNewTransactions: handleNewTransactions,
+  });
+
+  return {
+    swapProTokenTransactionList: currentTransactionState.list,
+    isTransactionSourceSupported: Boolean(transactionSource),
+    isHyperliquidTransactionSource: transactionSource === 'hyperliquid',
+    hasLoadedTransactionSource,
+  };
+}

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -242,6 +242,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   const incomingMarketPresetToken =
     swapInitParams?.marketPresetToken ?? swapProJumpToken.marketPresetToken;
   const {
+    defaultTokensFromType,
     isLoading,
     speedConfig,
     speedConfigReady,
@@ -250,6 +251,30 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     hasEnoughBalance,
     supportSpeedSwap,
   } = useSwapProTokenInit();
+
+  const isSwapProAccountContextReady = useMemo(() => {
+    if (!speedConfigReady || !swapProSelectToken || !swapProFromToken) {
+      return false;
+    }
+    if (swapProDirection === ESwapDirection.SELL) {
+      return equalTokenNoCaseSensitive({
+        token1: swapProFromToken,
+        token2: swapProSelectToken,
+      });
+    }
+    return defaultTokensFromType.some((token) =>
+      equalTokenNoCaseSensitive({
+        token1: token,
+        token2: swapProFromToken,
+      }),
+    );
+  }, [
+    defaultTokensFromType,
+    speedConfigReady,
+    swapProDirection,
+    swapProFromToken,
+    swapProSelectToken,
+  ]);
 
   useEffect(() => {
     if (incomingMarketPresetToken) {
@@ -1208,6 +1233,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
 
   useSwapProErrorAlert({
     isSwapProActive: Boolean(focusSwapPro),
+    isAccountContextReady: isSwapProAccountContextReady,
     accountScope: swapProAccount.accountScope,
     accountStatus: swapProAccount.accountStatus,
   });
@@ -1457,6 +1483,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
               }
               config={{
                 isLoading,
+                isAccountContextReady: isSwapProAccountContextReady,
                 speedConfigReady,
                 speedConfig,
                 balanceLoading,

--- a/packages/kit/src/views/Swap/pages/components/SwapProBuySellGroup.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProBuySellGroup.tsx
@@ -1,5 +1,6 @@
 import { YStack } from '@onekeyhq/components';
 import {
+  useSwapProSelectTokenAtom,
   useSwapProTimeRangeAtom,
   useSwapProTokenMarketDetailInfoAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
@@ -8,6 +9,7 @@ import { swapProTimeRangeItems } from '@onekeyhq/shared/types/swap/SwapProvider.
 import SwapProBuySellInfo from '../../components/SwapProBuySellInfo';
 import SwapProTimeRangeSelector from '../../components/SwapProTimeRangeSelector';
 import { SwapTestIDs } from '../../testIDs';
+import { isSwapProHyperliquidBtcToken } from '../../utils/swapProTransactionSource';
 
 const SwapProBuySellGroup = ({
   supportSpeedSwap,
@@ -15,16 +17,20 @@ const SwapProBuySellGroup = ({
   supportSpeedSwap?: boolean;
 }) => {
   const [swapProTokenMarketDetailInfo] = useSwapProTokenMarketDetailInfoAtom();
+  const [swapProSelectToken] = useSwapProSelectTokenAtom();
   const [swapProTimeRange, setSwapProTimeRange] = useSwapProTimeRangeAtom();
+  const isHyperliquidBtc = isSwapProHyperliquidBtcToken(swapProSelectToken);
   return (
     <YStack testID={SwapTestIDs.proBuySellGroup} gap="$2">
-      <SwapProBuySellInfo
-        supportSpeedSwap={supportSpeedSwap}
-        tokenDetailInfo={swapProTokenMarketDetailInfo}
-        timeRange={swapProTimeRange.value}
-      />
+      {isHyperliquidBtc ? null : (
+        <SwapProBuySellInfo
+          supportSpeedSwap={supportSpeedSwap}
+          tokenDetailInfo={swapProTokenMarketDetailInfo}
+          timeRange={swapProTimeRange.value}
+        />
+      )}
       <SwapProTimeRangeSelector
-        supportSpeedSwap={supportSpeedSwap}
+        disabled={!supportSpeedSwap && !isHyperliquidBtc}
         items={swapProTimeRangeItems}
         selectedValue={swapProTimeRange}
         onChange={(value) =>

--- a/packages/kit/src/views/Swap/pages/components/SwapProContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProContainer.tsx
@@ -78,6 +78,7 @@ interface ISwapProContainerProps {
   marketPresetSettings?: IMarketPresetSettingsState;
   config: {
     isLoading: boolean;
+    isAccountContextReady: boolean;
     speedConfigReady: boolean;
     speedConfig: ISwapProSpeedConfig;
     balanceLoading: boolean;
@@ -104,6 +105,7 @@ const SwapProContainer = ({
 }: ISwapProContainerProps) => {
   const {
     isLoading,
+    isAccountContextReady,
     speedConfigReady,
     speedConfig,
     balanceLoading,
@@ -361,8 +363,10 @@ const SwapProContainer = ({
         />
       ) : (
         <SwapProErrorAlert
-          title={swapProErrorAlert?.title}
-          message={swapProErrorAlert?.message}
+          title={isAccountContextReady ? swapProErrorAlert?.title : undefined}
+          message={
+            isAccountContextReady ? swapProErrorAlert?.message : undefined
+          }
         />
       )}
       <SwapProTabListContainer

--- a/packages/kit/src/views/Swap/pages/components/SwapProTokenTransactionList.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProTokenTransactionList.tsx
@@ -2,7 +2,14 @@ import { useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { SizableText, Skeleton, XStack, YStack } from '@onekeyhq/components';
+import {
+  Image,
+  SizableText,
+  Skeleton,
+  Stack,
+  XStack,
+  YStack,
+} from '@onekeyhq/components';
 import {
   useSwapProSelectTokenAtom,
   useSwapProTokenDetailWebsocketAtom,
@@ -16,7 +23,7 @@ import {
 } from '@onekeyhq/shared/types/swap/types';
 
 import SwapProTokenTransactionItem from '../../components/SwapProTokenTransactionItem';
-import { useSwapProTokenTransactionList } from '../../hooks/useSwapPro';
+import { useSwapProTokenTransactionList } from '../../hooks/useSwapProTokenTransactionList';
 
 const SwapProTokenTransactionList = ({
   supportSpeedSwap,
@@ -33,64 +40,101 @@ const SwapProTokenTransactionList = ({
       swapProTokenWebsocket?.txs && swapTypeSwitch === ESwapTabSwitchType.LIMIT
     );
   }, [swapProTokenWebsocket?.txs, swapTypeSwitch]);
-  const { swapProTokenTransactionList, isRefreshing } =
-    useSwapProTokenTransactionList(
-      swapProSelectToken?.contractAddress ?? '',
-      swapProSelectToken?.networkId ?? '',
-      Boolean(enableWebSocket),
-      supportSpeedSwap,
-    );
+  const {
+    swapProTokenTransactionList,
+    isTransactionSourceSupported,
+    isHyperliquidTransactionSource,
+    hasLoadedTransactionSource,
+  } = useSwapProTokenTransactionList({
+    tokenAddress: swapProSelectToken?.contractAddress ?? '',
+    networkId: swapProSelectToken?.networkId ?? '',
+    symbol: swapProSelectToken?.symbol ?? '',
+    isNative: swapProSelectToken?.isNative,
+    enableWebSocket: Boolean(enableWebSocket),
+    supportSpeedSwap,
+  });
 
   // Row caps tuned so the left column bottom-aligns with the trading column
   // in each trade-type layout; the loading skeleton uses the same counts.
-  const maxRows = swapProTradeType === ESwapProTradeType.LIMIT ? 9 : 5;
+  const isLimitOrder = swapProTradeType === ESwapProTradeType.LIMIT;
+  const maxRows = isLimitOrder ? 9 : 5;
   const finallyTransactionList = useMemo(
     () => swapProTokenTransactionList?.slice(0, maxRows) ?? [],
     [swapProTokenTransactionList, maxRows],
   );
+  let transactionListContent = (
+    <XStack justifyContent="space-between">
+      <SizableText size="$bodySm" color="$textSubdued">
+        --
+      </SizableText>
+      <SizableText size="$bodySm" color="$textSubdued">
+        --
+      </SizableText>
+    </XStack>
+  );
+  if (
+    isTransactionSourceSupported &&
+    !hasLoadedTransactionSource &&
+    finallyTransactionList.length === 0
+  ) {
+    transactionListContent = (
+      <YStack>
+        {Array.from({ length: maxRows }).map((_, index) => (
+          <Skeleton w="100%" h={22} radius="square" key={index} />
+        ))}
+      </YStack>
+    );
+  } else if (
+    isTransactionSourceSupported &&
+    finallyTransactionList.length > 0
+  ) {
+    transactionListContent = (
+      <YStack>
+        {finallyTransactionList.map((item, index) => (
+          <SwapProTokenTransactionItem
+            key={`${item.hash}-${index}`}
+            item={item}
+          />
+        ))}
+      </YStack>
+    );
+  }
   return (
     <YStack>
       <XStack justifyContent="space-between" py="$1">
-        <SizableText size="$bodySm" color="$textSubdued">
-          {intl.formatMessage({
-            id: ETranslations.global_price,
-          })}
-        </SizableText>
+        <XStack gap="$1" alignItems="center">
+          <SizableText size="$bodySm" color="$textSubdued">
+            {intl.formatMessage({
+              id: ETranslations.global_price,
+            })}
+          </SizableText>
+          {isHyperliquidTransactionSource ? (
+            <Stack
+              w={13}
+              h={13}
+              overflow="hidden"
+              borderRadius={6.5}
+              bg="#072723"
+            >
+              <Image
+                position="absolute"
+                left={2}
+                top={2}
+                w={48}
+                h={9}
+                contentFit="fill"
+                source={require('@onekeyhq/kit/assets/perps/hyperliquid-logo-dark.png')}
+              />
+            </Stack>
+          ) : null}
+        </XStack>
         <SizableText size="$bodySm" color="$textSubdued">
           {intl.formatMessage({
             id: ETranslations.global_value,
           })}
         </SizableText>
       </XStack>
-      {!supportSpeedSwap ? (
-        <XStack justifyContent="space-between">
-          <SizableText size="$bodySm" color="$textSubdued">
-            --
-          </SizableText>
-          <SizableText size="$bodySm" color="$textSubdued">
-            --
-          </SizableText>
-        </XStack>
-      ) : (
-        <>
-          {isRefreshing || finallyTransactionList.length === 0 ? (
-            <YStack>
-              {Array.from({ length: maxRows }).map((_, index) => (
-                <Skeleton w="100%" h={22} radius="square" key={index} />
-              ))}
-            </YStack>
-          ) : (
-            <YStack>
-              {finallyTransactionList.map((item, index) => (
-                <SwapProTokenTransactionItem
-                  key={`${item.hash}-${index}`}
-                  item={item}
-                />
-              ))}
-            </YStack>
-          )}
-        </>
-      )}
+      <YStack minHeight={maxRows * 22}>{transactionListContent}</YStack>
     </YStack>
   );
 };

--- a/packages/kit/src/views/Swap/pages/components/SwapProTradeInfoPanel.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapProTradeInfoPanel.tsx
@@ -1,4 +1,7 @@
 import { YStack } from '@onekeyhq/components';
+import { useSwapProSelectTokenAtom } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
+
+import { isSwapProHyperliquidBtcToken } from '../../utils/swapProTransactionSource';
 
 import SwapProBuySellGroup from './SwapProBuySellGroup';
 import SwapProPriceInfo from './SwapProPriceInfo';
@@ -13,12 +16,14 @@ const SwapProTradeInfoPanel = ({
   onPricePress,
   supportSpeedSwap,
 }: ISwapProTradeInfoPanelProps) => {
+  const [swapProSelectToken] = useSwapProSelectTokenAtom();
+  const isHyperliquidBtc = isSwapProHyperliquidBtcToken(swapProSelectToken);
   return (
-    // The info block flexes so any residual column height sits between it and
-    // the buy/sell group, pinning the group (and the 24H selector) to the
-    // column bottom — flush with the action button in the trading column.
+    // Regular tokens keep the existing bottom alignment. BTC has no buy/sell
+    // ratio block, so let the 24H selector follow the fixed-height trade list
+    // instead of placing the missing ratio block's space between them.
     <YStack gap="$2.5" flex={1}>
-      <YStack gap="$3" flex={1}>
+      <YStack gap="$3" flex={isHyperliquidBtc ? undefined : 1}>
         <SwapProTokenDetailGroup />
         <SwapProPriceInfo onPricePress={onPricePress} />
         <SwapProTokenTransactionList supportSpeedSwap={supportSpeedSwap} />

--- a/packages/kit/src/views/Swap/utils/swapProTransactionSource.ts
+++ b/packages/kit/src/views/Swap/utils/swapProTransactionSource.ts
@@ -1,0 +1,85 @@
+import BigNumber from 'bignumber.js';
+
+import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
+import type { IRecentTrade } from '@onekeyhq/shared/types/hyperliquid/sdk';
+import type { IMarketTokenTransaction } from '@onekeyhq/shared/types/marketV2';
+import type { ISwapTokenBase } from '@onekeyhq/shared/types/swap/types';
+
+export type ISwapProTransactionSource = 'market' | 'hyperliquid';
+
+type ISwapProTransactionToken = Pick<
+  ISwapTokenBase,
+  'networkId' | 'contractAddress' | 'isNative' | 'symbol'
+>;
+
+export function isSwapProHyperliquidBtcToken(
+  token: Partial<ISwapProTransactionToken> | undefined,
+) {
+  return Boolean(
+    token?.isNative &&
+    networkUtils.isBTCMainnet(token.networkId) &&
+    !token.contractAddress &&
+    token.symbol?.toUpperCase() === 'BTC',
+  );
+}
+
+export function getSwapProTransactionSource({
+  token,
+  supportSpeedSwap,
+}: {
+  token: Partial<ISwapProTransactionToken> | undefined;
+  supportSpeedSwap?: boolean;
+}): ISwapProTransactionSource | undefined {
+  if (isSwapProHyperliquidBtcToken(token)) {
+    return 'hyperliquid';
+  }
+  return supportSpeedSwap ? 'market' : undefined;
+}
+
+export function getSwapProTransactionTokenPrice(
+  transaction: IMarketTokenTransaction,
+) {
+  return transaction.type === 'buy'
+    ? transaction.to.price
+    : transaction.from.price;
+}
+
+export function mapHyperliquidTradeToSwapProTransaction(
+  trade: IRecentTrade,
+): IMarketTokenTransaction {
+  const isBuy = trade.side === 'B';
+  const quoteAmount = new BigNumber(trade.px).multipliedBy(trade.sz).toFixed();
+  const token = {
+    symbol: trade.coin,
+    amount: trade.sz,
+    address: '',
+    price: trade.px,
+  };
+  const quote = {
+    symbol: 'USD',
+    amount: quoteAmount,
+    address: '',
+    price: '1',
+  };
+
+  return {
+    pairAddress: '',
+    // A single Hyperliquid transaction can contain multiple fills. Include
+    // the trade ID so list deduplication does not collapse them.
+    hash: `${trade.hash}:${trade.tid}`,
+    owner: trade.users[1],
+    type: isBuy ? 'buy' : 'sell',
+    timestamp: Math.floor(trade.time / 1000),
+    url: '',
+    from: isBuy ? quote : token,
+    to: isBuy ? token : quote,
+  };
+}
+
+export function mapHyperliquidTradesToSwapProTransactions(
+  trades: IRecentTrade[],
+) {
+  return trades
+    .map(mapHyperliquidTradeToSwapProTransaction)
+    .toSorted((a, b) => b.timestamp - a.timestamp);
+}

--- a/packages/shared/src/utils/tradingHoursUtils.test.ts
+++ b/packages/shared/src/utils/tradingHoursUtils.test.ts
@@ -230,7 +230,18 @@ describe('resolveUSMarketStatusVariant', () => {
     ).toBeUndefined();
   });
 
-  it('prioritizes halt over everything', () => {
+  it('keeps an explicitly non-tradable paused instrument halted', () => {
+    expect(
+      resolveUSMarketStatusVariant({
+        source: ondo,
+        isOpen: false,
+        isPaused: true,
+        status: status('REGULAR'),
+      }),
+    ).toBe(EUSMarketStatusVariant.Halted);
+  });
+
+  it('marks a paused but explicitly tradable instrument as ClosedTradable', () => {
     expect(
       resolveUSMarketStatusVariant({
         source: ondo,
@@ -238,7 +249,7 @@ describe('resolveUSMarketStatusVariant', () => {
         isPaused: true,
         status: status('REGULAR'),
       }),
-    ).toBe(EUSMarketStatusVariant.Halted);
+    ).toBe(EUSMarketStatusVariant.ClosedTradable);
   });
 
   it('honors the per-stock closed signal', () => {
@@ -292,7 +303,7 @@ describe('resolveUSMarketStatusVariant', () => {
     ).toBe(EUSMarketStatusVariant.ClosedTradable);
   });
 
-  it('marks inter-session gaps as halted', () => {
+  it('keeps explicitly tradable instruments tradable during session gaps', () => {
     // Clock gap overrides the backend session refinement…
     expect(
       resolveUSMarketStatusVariant({
@@ -301,7 +312,7 @@ describe('resolveUSMarketStatusVariant', () => {
         status: status('REGULAR'),
         now: GAP_NOW,
       }),
-    ).toBe(EUSMarketStatusVariant.Halted);
+    ).toBe(EUSMarketStatusVariant.ClosedTradable);
     // …and applies on the pure clock fallback as well.
     expect(
       resolveUSMarketStatusVariant({
@@ -309,7 +320,7 @@ describe('resolveUSMarketStatusVariant', () => {
         isOpen: true,
         now: GAP_NOW,
       }),
-    ).toBe(EUSMarketStatusVariant.Halted);
+    ).toBe(EUSMarketStatusVariant.ClosedTradable);
   });
 
   it('falls back to clock math when the status API is unavailable', () => {

--- a/packages/shared/src/utils/tradingHoursUtils.ts
+++ b/packages/shared/src/utils/tradingHoursUtils.ts
@@ -447,12 +447,13 @@ export function isOndoUSMarketStock(
  * two-state badge) and for tokens without stock signals.
  *
  * Signal priority:
- *   1. per-stock halt (`isPaused`) — overlays everything;
+ *   1. per-stock halt (`isPaused`) — Halted unless the token is still
+ *      explicitly tradable (`isOpen === true`), then ClosedTradable;
  *   2. per-stock `isOpen === false` — the instrument's own window is closed;
  *   3. market-wide closure (backend CLOSED / weekend) → ClosedTradable for a
  *      tradable instrument (`isOpen === true`) — the special 7×24-Ondo case;
- *   4. inter-session gap (clock math) → Halted: the underlying venues pause
- *      trading while switching session state;
+ *   4. inter-session gap (clock math) → ClosedTradable: the underlying venues
+ *      pause while the token remains explicitly tradable;
  *   5. market-wide session refines HOW it is open.
  *
  * When the market-status API is unavailable, falls back to pure clock math:
@@ -475,7 +476,9 @@ export function resolveUSMarketStatusVariant({
     return undefined;
   }
   if (isPaused === true) {
-    return EUSMarketStatusVariant.Halted;
+    return isOpen === true
+      ? EUSMarketStatusVariant.ClosedTradable
+      : EUSMarketStatusVariant.Halted;
   }
   if (isOpen === undefined) {
     return undefined;
@@ -503,10 +506,11 @@ export function resolveUSMarketStatusVariant({
       return EUSMarketStatusVariant.ClosedTradable;
     }
     const tradingHours = getUSMarketTradingHours(now);
-    // Inter-session gap: the underlying venues pause trading while switching
-    // session state (OK-58509), overriding the backend session refinement.
+    // The underlying venues pause during a session switch, but `isOpen ===
+    // true` is the token-level trading contract. Keep the badge aligned
+    // with the executable quote path instead of declaring a full halt.
     if (tradingHours.isNowInSessionGap) {
-      return EUSMarketStatusVariant.Halted;
+      return EUSMarketStatusVariant.ClosedTradable;
     }
     const sessionKey = usMarketSessionKeyFromBackendSession(status.session);
     // Unknown session value (future contract addition): fall back to the
@@ -521,9 +525,9 @@ export function resolveUSMarketStatusVariant({
   ) {
     return EUSMarketStatusVariant.ClosedTradable;
   }
-  // Same gap-to-halt rule as the status branch above.
+  // Same tradable-gap rule as the status branch above.
   if (tradingHours.isNowInSessionGap) {
-    return EUSMarketStatusVariant.Halted;
+    return EUSMarketStatusVariant.ClosedTradable;
   }
   return sessionKeyToVariant(tradingHours.currentSessionKey);
 }


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58986](https://onekeyhq.atlassian.net/browse/OK-58986) [OK-57059](https://onekeyhq.atlassian.net/browse/OK-57059)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- show `Closed · Tradable` when an Ondo stock token remains explicitly tradable during an underlying pause or an inter-session gap
- keep explicitly non-tradable paused instruments in the halted state
- add native BTC recent trades to Pro mode through the existing Hyperliquid recent-trades service
- keep the market trade list at five rows with stable loading, empty, and data-state height
- clear token-scoped detail and alert state during selection changes, and reject stale responses from the previously selected token
- hide the unavailable BTC buy/sell ratio while keeping the 24H selector adjacent to the trade list

## Root cause

### OK-58986

The Stock header badge combined the token-detail `stock.isOpen` / `stock.isPaused` signals with the global US market status and local session clock. It always mapped `isPaused` and local inter-session gaps to `Halted`.

The Stock quote channel independently treats the token-detail `isOpen` value as the execution contract and only blocks quotes when it is explicitly `false`. During the overnight-to-pre-market gap reported in this issue, the token remained `isOpen: true` and quotes were available, while the clock-derived badge incorrectly declared a full pause.

### OK-57059

Native BTC had no transaction source in Swap Pro. The first App integration also allowed loading, empty, and populated trade states to use different row counts and heights.

During a token switch, the selected-token atom changed before the previous token detail and account context had settled. The old unsupported-account alert or market detail could therefore render under BTC, and a late response from the previous token could overwrite the new selection.

The fix isolates transaction-source lifecycle in a dedicated hook, uses the existing Hyperliquid BTC recent-trades API, clears token-owned state in the same selection transition, gates the account alert on the current counterparty context, and discards responses whose token identity is no longer current.

## Issues

- Fixes OK-58986
- Fixes OK-57059

## Test plan

- `yarn agent:check --profile commit`
- `yarn _tsc`
- `yarn jest packages/shared/src/utils/tradingHoursUtils.test.ts packages/kit/src/views/Swap/hooks/swapStockChannelUtils.test.ts packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts --runInBand` (3 suites, 111 tests)
- Electron Desktop: fix the clock at 03:58 ET with `isOpen: true`; confirm the header shows `Closed · Tradable` instead of `Halted`
- Electron Desktop: open the trading-hours panel in the same gap and confirm the underlying `Trading Halted` row remains current
- Electron Desktop: restore the real clock and live services; confirm the current `Overnight` badge returns
- iOS Simulator: switch from an unsupported Solana token to native BTC and confirm no unsupported-account alert or previous-token market data appears under BTC
- iOS Simulator: confirm the BTC trade list keeps the same height from skeleton to populated data and displays exactly five market rows

## Runtime scope

OK-58986 changes the shared main-JS display resolver used by Desktop and foreground UI runtimes. Quote eligibility and execution guards are unchanged.

OK-57059 changes foreground Swap Pro state and presentation. On iOS, UI atoms live in the main runtime and the existing Hyperliquid service call is proxied to background; responses are accepted only when they still match the current main-runtime token identity. No server API, native resource, or transaction execution contract changes are required.

## Risk

Medium: the PR now contains two independently scoped display/state fixes. Trading execution is unchanged. The BTC path uses an existing service contract, limits visible market trades to five rows, preserves prior data on transient polling errors, and rejects stale cross-token responses.

[OK-58986]: https://onekeyhq.atlassian.net/browse/OK-58986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-57059]: https://onekeyhq.atlassian.net/browse/OK-57059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ