### PR TITLE
feat: improve hip-3 market badges and navigation

### DIFF
--- a/packages/kit/src/views/Market/components/PerpsBadges.tsx
+++ b/packages/kit/src/views/Market/components/PerpsBadges.tsx
@@ -3,6 +3,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import {
+  Badge,
   Image,
   SizableText,
   Stack,
@@ -46,7 +47,15 @@ function getPerpDexDescriptionId(dexLabel?: string) {
 }
 
 const PerpDexBadge = memo(
-  ({ dexLabel, testID }: { dexLabel?: string; testID?: string }) => {
+  ({
+    compact,
+    dexLabel,
+    testID,
+  }: {
+    compact?: boolean;
+    dexLabel?: string;
+    testID?: string;
+  }) => {
     const intl = useIntl();
     const descriptionId = getPerpDexDescriptionId(dexLabel);
 
@@ -56,7 +65,20 @@ const PerpDexBadge = memo(
 
     const label = dexLabel.toLowerCase();
     const description = intl.formatMessage({ id: descriptionId });
-    const badge = (
+    const badgeText = (
+      <SizableText
+        color="$textInfo"
+        fontSize={10}
+        {...(!compact && { lineHeight: 16 })}
+      >
+        {label}
+      </SizableText>
+    );
+    const badge = compact ? (
+      <Badge radius="$1" bg="$bgInfo" px="$1" py={0} testID={testID}>
+        {badgeText}
+      </Badge>
+    ) : (
       <XStack
         borderRadius="$1"
         bg="$bgInfo"
@@ -65,9 +87,7 @@ const PerpDexBadge = memo(
         px="$1.5"
         testID={testID}
       >
-        <SizableText color="$textInfo" fontSize={10} lineHeight={16}>
-          {label}
-        </SizableText>
+        {badgeText}
       </XStack>
     );
 

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
@@ -212,7 +212,11 @@ function PerpBadgesRow() {
               })}
         </SizableText>
       </Badge>
-      <PerpDexBadge dexLabel={dexLabel} testID={PerpTestIDs.ActiveDexBadge} />
+      <PerpDexBadge
+        compact
+        dexLabel={dexLabel}
+        testID={PerpTestIDs.ActiveDexBadge}
+      />
       {subtitle ? (
         <Popover
           title={intl.formatMessage({

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -19,6 +19,7 @@ import {
   useSafeAreaInsets,
 } from '@onekeyhq/components';
 import { useActiveTradeInstrumentAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
+import { PerpDexBadge } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -237,6 +238,7 @@ function MobilePerpMarket() {
   const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
   const {
     baseName,
+    dexLabel,
     displayName,
     coin: activeCoin,
     mode,
@@ -339,6 +341,7 @@ function MobilePerpMarket() {
         />
         <SizableText size="$headingLg">{pairLabel}</SizableText>
         <TradingModeBadge isSpot={mode === 'spot'} px="$1.5" />
+        <PerpDexBadge dexLabel={dexLabel} />
         {isSplitDetailActive ? null : (
           <Icon name="ChevronDownSmallOutline" size="$4" color="$iconSubdued" />
         )}
@@ -347,6 +350,7 @@ function MobilePerpMarket() {
   }, [
     activeCoin,
     baseName,
+    dexLabel,
     displayName,
     isSplitDetailActive,
     mode,

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -29,14 +29,8 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
-import {
-  getHyperliquidTokenImageUris,
-  getHyperliquidTokenImageUrl,
-} from '@onekeyhq/shared/src/utils/perpsUtils';
 
-import { Token } from '../../../components/Token';
 import useAppNavigation from '../../../hooks/useAppNavigation';
-import { useThemeVariant } from '../../../hooks/useThemeVariant';
 import { PerpMarketIntroContent } from '../components/MarketDetail/PerpMarketIntroContent';
 import { PerpCandles } from '../components/PerpCandles';
 import PerpMarketFooter from '../components/PerpMarketFooter';
@@ -236,14 +230,7 @@ function MobilePerpCandlesStatic({
 
 function MobilePerpMarket() {
   const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
-  const {
-    baseName,
-    dexLabel,
-    displayName,
-    coin: activeCoin,
-    mode,
-  } = useActiveTradeDisplay();
-  const themeVariant = useThemeVariant();
+  const { baseName, dexLabel, displayName, mode } = useActiveTradeDisplay();
   const navigation = useAppNavigation();
   const [activeTab, setActiveTab] = useState<IMobilePerpMarketTab>('orderbook');
   const [hasInfoTabMounted, setHasInfoTabMounted] = useState(false);
@@ -310,7 +297,7 @@ function MobilePerpMarket() {
     } else {
       pairLabel = '--';
     }
-    // Match the MarketDetailV2 layout: Token + Symbol + dropdown sit
+    // Match the MarketDetailV2 layout: Symbol + badges + dropdown sit
     // in the native headerTitle slot. The system back chevron renders
     // separately on the left via HeaderScreenOptions
     // (headerBackButtonDisplayMode: 'minimal'), so we no longer wrap
@@ -326,20 +313,7 @@ function MobilePerpMarket() {
         pressStyle={isSplitDetailActive ? undefined : { opacity: 0.6 }}
         cursor="default"
       >
-        <Token
-          size="sm"
-          borderRadius="$full"
-          bg={themeVariant === 'light' ? undefined : '$bgInverse'}
-          {...(mode === 'spot'
-            ? {
-                tokenImageUri: baseName
-                  ? getHyperliquidTokenImageUrl(baseName)
-                  : undefined,
-              }
-            : { tokenImageUris: getHyperliquidTokenImageUris(activeCoin) })}
-          fallbackIcon="CryptoCoinOutline"
-        />
-        <SizableText size="$headingLg">{pairLabel}</SizableText>
+        <SizableText size="$headingMd">{pairLabel}</SizableText>
         <TradingModeBadge isSpot={mode === 'spot'} px="$1.5" />
         <PerpDexBadge dexLabel={dexLabel} />
         {isSplitDetailActive ? null : (
@@ -347,16 +321,7 @@ function MobilePerpMarket() {
         )}
       </XStack>
     );
-  }, [
-    activeCoin,
-    baseName,
-    dexLabel,
-    displayName,
-    isSplitDetailActive,
-    mode,
-    onPressTokenSelector,
-    themeVariant,
-  ]);
+  }, [dexLabel, displayName, isSplitDetailActive, mode, onPressTokenSelector]);
   useEffect(() => {
     appEventBus.emit(EAppEventBusNames.HideTabBar, true);
 

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchPerpItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchPerpItem.tsx
@@ -1,11 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import {
-  NumberSizeableText,
-  SizableText,
-  XStack,
-  rootNavigationRef,
-} from '@onekeyhq/components';
+import { NumberSizeableText, SizableText, XStack } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { Token } from '@onekeyhq/kit/src/components/Token';
@@ -24,8 +19,7 @@ import {
   setPerpPageEnterSource,
 } from '@onekeyhq/shared/src/logger/scopes/perp/perpPageSource';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
-import { ERootRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
-import { EModalPerpRoutes } from '@onekeyhq/shared/src/routes/perp';
+import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { buildCoinFromSearchAssetType } from '@onekeyhq/shared/src/utils/perpsDexUtils';
 import { getHyperliquidTokenImageUris } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { IUniversalSearchPerp } from '@onekeyhq/shared/types/search';
@@ -87,17 +81,6 @@ export function UniversalSearchPerpItem({
       } catch (error) {
         console.error('Failed to change active asset:', error);
         return;
-      }
-      if (platformEnv.isNative) {
-        // rootNavigationRef needed because search modal's navigation context can't push into Perp tab's stack
-        setTimeout(() => {
-          rootNavigationRef.current?.navigate(ERootRoutes.Main, {
-            screen: ETabRoutes.Perp,
-            params: {
-              screen: EModalPerpRoutes.MobilePerpMarket,
-            },
-          });
-        }, 500);
       }
       setTimeout(() => {
         universalSearchActions.current.addIntoRecentSearchList({
@@ -162,31 +145,15 @@ export function UniversalSearchPerpItem({
                 <LeverageBadge leverage={maxLeverage} />
               ) : null}
               <PerpDexBadge dexLabel={dexLabel} />
-              {subtitle ? (
-                <XStack
-                  borderRadius="$1"
-                  bg="$bgInfo"
-                  justifyContent="center"
-                  alignItems="center"
-                  px="$1.5"
-                >
-                  <SizableText
-                    fontSize={10}
-                    alignSelf="center"
-                    color="$textInfo"
-                    lineHeight={16}
-                  >
-                    {subtitle}
-                  </SizableText>
-                </XStack>
-              ) : null}
             </XStack>
           </XStack>
         }
         secondary={
-          <SizableText size="$bodyMd" color="$textSubdued">
-            {`${name} - USDC`}
-          </SizableText>
+          subtitle ? (
+            <SizableText size="$bodyMd" color="$textSubdued" numberOfLines={1}>
+              {subtitle}
+            </SizableText>
+          ) : undefined
         }
       />
       <NumberSizeableText


### PR DESCRIPTION
## Summary
- Standardize HIP-3 dex and leverage badges in Perps mobile surfaces.
- Show the active xyz or para market source in a simplified mobile market header without the token logo and with smaller title typography.
- Simplify global-search Perps navigation and align result rows with the title, badges, and optional subtitle layout.

## Intent & Context
HIP-3 tickers can exist on multiple markets, so users need a consistent xyz or para source label wherever they select or inspect a contract. Mobile global search should select the requested contract and land on the Perps main page instead of immediately pushing the secondary market-data page. The mobile market header should keep the symbol and market badges readable without a small low-detail logo competing for horizontal space.

## Root Cause
- The dex badge used a fixed line height that did not match adjacent compact badges in the mobile ticker.
- The mobile market header did not render the active dex source and used a logo plus large title that crowded long symbols.
- Native global search performed a second delayed navigation to MobilePerpMarket after switching to the Perps tab.
- Search-result subtitles were rendered as a third badge while the secondary line showed a redundant TOKEN - USDC fallback.

## Design Decisions
- Add an opt-in compact PerpDexBadge variant so existing default badge sizing remains unchanged.
- Reuse useActiveTradeDisplay dexLabel for market-source display.
- Remove the mobile market header logo and reduce the title from headingLg to headingMd.
- Preserve active-instrument selection and PerpSwitchActiveInstrument while removing only the Native secondary-page navigation.
- Render a real subtitle as plain secondary text and omit the secondary row when no subtitle exists.

## Changes Detail
- PerpsBadges.tsx: add compact dex-badge rendering.
- PerpTickerBarMobile.tsx: use the compact dex badge next to the Perp and alias badges.
- MobilePerpMarket.tsx: add the xyz or para badge, remove the token logo, and reduce title typography in the mobile market header.
- UniversalSearchPerpItem.tsx: keep Native search navigation on the Perps main page and update the shared search-result layout.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Desktop, Web, Extension
- **Risk Areas**: Native tab navigation after selecting a search result and shared global-search row layout.

## Test plan
- [x] Run yarn agent:check --profile commit.
- [x] Run yarn agent:check --profile pr local gates.
- [ ] Verify compact leverage and xyz or para badges in the mobile Perps ticker.
- [ ] Verify the mobile market header omits the token logo, uses smaller title typography, and shows the correct xyz or para source.
- [ ] Verify Native global-search contract taps select the instrument and remain on the Perps main page.
- [ ] Verify global-search aliases render on the second line and no second line appears without an alias.