### PR TITLE
fix: stabilize perps token selector badges

### DIFF
--- a/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/MoblieTokenSelector.tsx
@@ -287,8 +287,12 @@ const InitialRowsSnapshotRow = memo(
             <SizableText size="$bodyMdMedium" numberOfLines={1}>
               {displayName}
             </SizableText>
-            {maxLeverage > 0 ? <LeverageBadge leverage={maxLeverage} /> : null}
-            <PerpDexBadge dexLabel={dexLabel} />
+            <XStack gap="$1">
+              {maxLeverage > 0 ? (
+                <LeverageBadge leverage={maxLeverage} />
+              ) : null}
+              <PerpDexBadge dexLabel={dexLabel} />
+            </XStack>
           </XStack>
           <XStack gap="$1" alignItems="center" minWidth={0}>
             {subtitle ? (


### PR DESCRIPTION
## Summary
- Align the mobile cached snapshot row badge layout with the live token selector row.
- Prevent leverage and HIP-3 market badges from shifting horizontally after category tab switches.

## Intent & Context
On Native, switching ticker selector category tabs briefly renders the cached snapshot rows before the live FlashList rows. The leverage and xyz/para badges visibly moved during this handoff.

## Root Cause
The snapshot row rendered the leverage badge and DEX badge as separate siblings using the outer name-row gap. The live row groups those badges in a nested container with a smaller internal gap, so the DEX badge position changed when the live row replaced the snapshot.

## Design Decisions
Keep the existing iOS snapshot mechanism that avoids cold-start blank states. Only align its badge container hierarchy and spacing with the live row to minimize behavioral and performance risk.

## Changes Detail
- Update InitialRowsSnapshotRow in MoblieTokenSelector.tsx to group leverage and DEX badges with the same spacing used by PerpTokenSelectorRow.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Mobile
- **Risk Areas**: Initial cached row layout during Native token selector tab switches

## Test plan
- [x] Run yarn agent:check --profile commit.
- [x] Confirm the cached and live rows use matching badge container gaps.
- [ ] On iOS, switch between Perps category tabs and confirm leverage and xyz/para badges no longer jump.