### PR TITLE
fix: resolve referral QA issues (OK-59624, OK-59625, OK-59626, OK-59627, OK-59629, OK-59635)

### DIFF
--- a/packages/kit/src/components/OneKeyAuth/useOneKeyAuth.test.tsx
+++ b/packages/kit/src/components/OneKeyAuth/useOneKeyAuth.test.tsx
@@ -1,0 +1,227 @@
+/** @jest-environment jsdom */
+
+import { isValidElement } from 'react';
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { Dialog } from '@onekeyhq/components';
+import {
+  OneKeyLocalError,
+  PrimeLoginDialogCancelError,
+} from '@onekeyhq/shared/src/errors';
+import {
+  EOneKeyIdLoginWithLocalKeylessPrepareStatus,
+  type IOneKeyIdLoginWithLocalKeylessPrepareResult,
+} from '@onekeyhq/shared/src/keylessWallet/keylessWalletTypes';
+
+import { useOneKeyAuth } from './useOneKeyAuth';
+
+const mockIsLoggedIn = jest.fn<Promise<boolean>, []>();
+const mockPrepareOneKeyIdLoginWithLocalKeyless = jest.fn<
+  Promise<IOneKeyIdLoginWithLocalKeylessPrepareResult>,
+  []
+>();
+const mockDialogCloses: jest.Mock[] = [];
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+jest.mock('@onekeyhq/components', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const Container = ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('div', null, children);
+
+  return {
+    Dialog: {
+      show: jest.fn(),
+    },
+    Spinner: () => null,
+    Stack: Container,
+  };
+});
+
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceKeylessWallet: {
+      prepareOneKeyIdLoginWithLocalKeyless: () =>
+        mockPrepareOneKeyIdLoginWithLocalKeyless(),
+    },
+    servicePrime: {
+      isLoggedIn: () => mockIsLoggedIn(),
+    },
+  },
+}));
+
+jest.mock('@onekeyhq/kit/src/components/LazyLoadPage', () => ({
+  LazyLoadPage: () =>
+    function MockLazyPage() {
+      return null;
+    },
+}));
+
+jest.mock(
+  '@onekeyhq/kit/src/components/OneKeyAuth/supabase/useSupabaseAuth',
+  () => ({
+    useSupabaseAuth: () => ({
+      getAccessToken: jest.fn(),
+      getSupabaseClient: jest.fn(),
+      isLoggedIn: false,
+      isReady: true,
+      persistKeylessOAuthSession: jest.fn(),
+      signInWithOtp: jest.fn(),
+      signInWithSocialLogin: jest.fn(),
+      supabaseUser: undefined,
+      verifyOtp: jest.fn(),
+    }),
+  }),
+);
+
+jest.mock(
+  '@onekeyhq/kit/src/views/Prime/components/oneKeyIdLoginToastUtils',
+  () => ({
+    getSanitizedAuthErrorText: jest.fn(() => ''),
+    logOneKeyIdLoginFailureReason: jest.fn(),
+  }),
+);
+
+jest.mock('@onekeyhq/kit-bg/src/states/jotai/atoms/prime', () => ({
+  usePrimePersistAtom: () => [undefined],
+}));
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: {
+    isDesktop: false,
+  },
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/timerUtils', () => ({
+  __esModule: true,
+  default: {
+    wait: jest.fn(async () => undefined),
+  },
+}));
+
+jest.mock('../../hooks/useAppNavigation', () => ({
+  __esModule: true,
+  default: () => ({
+    pushModal: jest.fn(),
+  }),
+}));
+
+jest.mock('./extOneKeyIdAuthExpandTab', () => ({
+  redirectOneKeyIdAuthToExtExpandTab: jest.fn(),
+  shouldRunOneKeyIdAuthInExtExpandTab: () => false,
+}));
+
+type ILoginDialogContentProps = {
+  initialShowKeylessLogoutAction?: boolean;
+  onCancel: () => void;
+  onComplete: () => Promise<void>;
+  onLoginSuccess: () => Promise<void>;
+  onReopenAfterOAuthFailure: (options?: {
+    showKeylessLogoutAction?: boolean;
+  }) => void;
+};
+
+function getDialogContentProps(index: number): ILoginDialogContentProps {
+  const options = jest.mocked(Dialog.show).mock.calls[index]?.[0];
+  if (!isValidElement<ILoginDialogContentProps>(options?.renderContent)) {
+    throw new OneKeyLocalError(`Dialog content ${index} was not rendered`);
+  }
+  return options.renderContent.props;
+}
+
+describe('useOneKeyAuth login dialog lifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDialogCloses.length = 0;
+    mockIsLoggedIn.mockResolvedValue(false);
+    mockPrepareOneKeyIdLoginWithLocalKeyless.mockResolvedValue({
+      status: EOneKeyIdLoginWithLocalKeylessPrepareStatus.NoLocalKeyless,
+    });
+    jest.mocked(Dialog.show).mockImplementation(() => {
+      const close = jest.fn(async () => undefined);
+      mockDialogCloses.push(close);
+      return {
+        close,
+        getForm: () => undefined,
+        isExist: () => true,
+      };
+    });
+  });
+
+  test('reopens after OAuth failure and resolves through the new dialog', async () => {
+    const { result } = renderHook(() => useOneKeyAuth());
+    const onResolved = jest.fn();
+    const onRejected = jest.fn();
+
+    const loginPromise = result.current.loginOneKeyId();
+    void loginPromise.then(onResolved, onRejected);
+
+    await waitFor(() => {
+      expect(Dialog.show).toHaveBeenCalledTimes(1);
+    });
+    const firstDialog = getDialogContentProps(0);
+
+    await act(async () => {
+      await firstDialog.onComplete();
+    });
+    expect(mockDialogCloses[0]).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      firstDialog.onReopenAfterOAuthFailure({
+        showKeylessLogoutAction: true,
+      });
+    });
+
+    await waitFor(() => {
+      expect(Dialog.show).toHaveBeenCalledTimes(2);
+    });
+    expect(onResolved).not.toHaveBeenCalled();
+    expect(onRejected).not.toHaveBeenCalled();
+
+    const reopenedDialog = getDialogContentProps(1);
+    expect(reopenedDialog.initialShowKeylessLogoutAction).toBe(true);
+
+    await act(async () => {
+      await reopenedDialog.onLoginSuccess();
+    });
+    await expect(loginPromise).resolves.toBeUndefined();
+    expect(onResolved).toHaveBeenCalledTimes(1);
+    expect(onRejected).not.toHaveBeenCalled();
+  });
+
+  test('rejects as cancel only when the reopened dialog is cancelled', async () => {
+    const { result } = renderHook(() => useOneKeyAuth());
+    const loginPromise = result.current.loginOneKeyId();
+
+    await waitFor(() => {
+      expect(Dialog.show).toHaveBeenCalledTimes(1);
+    });
+    const firstDialog = getDialogContentProps(0);
+
+    await act(async () => {
+      await firstDialog.onComplete();
+    });
+    act(() => {
+      firstDialog.onReopenAfterOAuthFailure();
+    });
+
+    await waitFor(() => {
+      expect(Dialog.show).toHaveBeenCalledTimes(2);
+    });
+    const reopenedDialog = getDialogContentProps(1);
+    act(() => {
+      reopenedDialog.onCancel();
+    });
+
+    await expect(loginPromise).rejects.toBeInstanceOf(
+      PrimeLoginDialogCancelError,
+    );
+  });
+});

--- a/packages/kit/src/components/OneKeyAuth/useOneKeyAuth.tsx
+++ b/packages/kit/src/components/OneKeyAuth/useOneKeyAuth.tsx
@@ -139,6 +139,10 @@ export function useOneKeyAuth() {
         onComplete: () => Promise<void>;
         onLoginSuccess: () => Promise<void>;
         onCancel: () => void;
+        onReopenAfterOAuthFailure: (options?: {
+          showKeylessLogoutAction?: boolean;
+        }) => void;
+        initialShowKeylessLogoutAction?: boolean;
       }) => ReactNode;
     }) => {
       const isLoggedIn = await backgroundApiProxy.servicePrime.isLoggedIn();
@@ -164,10 +168,12 @@ export function useOneKeyAuth() {
       }
 
       return new Promise<void>((resolve, reject) => {
-        let isClosedByNextStep = false;
-        let isResolved = false;
+        let isSettled = false;
         const onLoginSuccessFn = async () => {
-          isResolved = true;
+          if (isSettled) {
+            return;
+          }
+          isSettled = true;
           await timerUtils.wait(200);
           if (toOneKeyIdPageOnLoginSuccess) {
             toOneKeyIdPage();
@@ -175,39 +181,52 @@ export function useOneKeyAuth() {
           resolve();
         };
         const onCancelFn = () => {
-          if (isResolved) {
+          if (isSettled) {
             return;
           }
+          isSettled = true;
           reject(new PrimeLoginDialogCancelError());
         };
-        const onCancelFirstStepFn = () => {
-          if (isClosedByNextStep) {
+        const showLoginDialog = (
+          options: { showKeylessLogoutAction?: boolean } = {},
+        ): void => {
+          if (isSettled) {
             return;
           }
-          onCancelFn();
+          let isThisDialogClosedByNextStep = false;
+          const onCancelThisDialog = () => {
+            if (isThisDialogClosedByNextStep) {
+              return;
+            }
+            onCancelFn();
+          };
+          const loginDialog = Dialog.show({
+            onCancel: onCancelThisDialog,
+            onClose: onCancelThisDialog,
+            floatingPanelProps: platformEnv.isDesktop
+              ? { width: 440 }
+              : undefined,
+            renderContent: renderContent({
+              onComplete: async () => {
+                isThisDialogClosedByNextStep = true;
+                try {
+                  await loginDialog.close();
+                } catch (error) {
+                  // The close handoff owns settling the outer login promise.
+                  // A failed close must not leave it pending forever.
+                  onCancelFn();
+                  throw error;
+                }
+              },
+              onLoginSuccess: onLoginSuccessFn,
+              onCancel: onCancelFn,
+              onReopenAfterOAuthFailure: showLoginDialog,
+              initialShowKeylessLogoutAction: options.showKeylessLogoutAction,
+            }),
+          });
         };
-        const loginDialog = Dialog.show({
-          onCancel: onCancelFirstStepFn,
-          onClose: onCancelFirstStepFn,
-          floatingPanelProps: platformEnv.isDesktop
-            ? { width: 440 }
-            : undefined,
-          renderContent: renderContent({
-            onComplete: async () => {
-              isClosedByNextStep = true;
-              try {
-                await loginDialog.close();
-              } catch (error) {
-                // The close handoff owns settling the outer login promise.
-                // A failed close must not leave it pending forever.
-                onCancelFn();
-                throw error;
-              }
-            },
-            onLoginSuccess: onLoginSuccessFn,
-            onCancel: onCancelFn,
-          }),
-        });
+
+        showLoginDialog();
       });
     },
     [toOneKeyIdPage],
@@ -248,11 +267,19 @@ export function useOneKeyAuth() {
       }
       return showOneKeyIdLoginDialog({
         toOneKeyIdPageOnLoginSuccess,
-        renderContent: ({ onComplete, onLoginSuccess, onCancel }) => (
+        renderContent: ({
+          onComplete,
+          onLoginSuccess,
+          onCancel,
+          onReopenAfterOAuthFailure,
+          initialShowKeylessLogoutAction,
+        }) => (
           <PrimeLoginOAuthDialog
             onComplete={onComplete}
             onLoginSuccess={onLoginSuccess}
             onCancel={onCancel}
+            onReopenAfterOAuthFailure={onReopenAfterOAuthFailure}
+            initialShowKeylessLogoutAction={initialShowKeylessLogoutAction}
             localKeylessLoginPrepareResult={localKeylessLoginPrepareResult}
             localKeylessLoginPrepareErrorMessage={
               localKeylessLoginPrepareErrorMessage

--- a/packages/kit/src/views/Prime/components/PrimeLoginOAuthDialog/PrimeLoginOAuthDialog.test.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeLoginOAuthDialog/PrimeLoginOAuthDialog.test.tsx
@@ -1,6 +1,14 @@
 /** @jest-environment jsdom */
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 
 import PrimeLoginOAuthDialog from './PrimeLoginOAuthDialog';
 
@@ -26,6 +34,58 @@ jest.mock('@onekeyhq/components', () => {
 
   function Container({ children }: { children?: import('react').ReactNode }) {
     return React.createElement('div', null, children);
+  }
+
+  function AccordionHeightAnimator({
+    children,
+  }: {
+    children?: import('react').ReactNode;
+  }) {
+    const accordion = React.useContext(AccordionContext);
+    const itemValue = React.useContext(AccordionItemContext);
+    const open = accordion.value === itemValue;
+    const [height, setHeight] = React.useState(0);
+    const hasMeasured = React.useRef(false);
+
+    React.useEffect(() => {
+      if (!open) {
+        setHeight(0);
+      }
+    }, [open]);
+
+    // Tamagui measures force-mounted content after the closed-state effect.
+    React.useEffect(() => {
+      if (!hasMeasured.current) {
+        hasMeasured.current = true;
+        setHeight(240);
+      }
+    }, []);
+
+    return React.createElement(
+      'div',
+      {
+        'data-height': String(height),
+        'data-testid': 'prime-login-more-methods-height-transition',
+      },
+      children,
+    );
+  }
+
+  function HeightTransition({
+    children,
+    hide,
+  }: {
+    children?: import('react').ReactNode;
+    hide?: boolean;
+  }) {
+    return React.createElement(
+      'div',
+      {
+        'data-height': hide ? '0' : '240',
+        'data-testid': 'prime-login-more-methods-height-transition',
+      },
+      children,
+    );
   }
 
   function AccordionRoot({
@@ -130,7 +190,7 @@ jest.mock('@onekeyhq/components', () => {
 
   const Accordion = Object.assign(AccordionRoot, {
     Content: AccordionContent,
-    HeightAnimator: Container,
+    HeightAnimator: AccordionHeightAnimator,
     Item: AccordionItem,
     Trigger: AccordionTrigger,
   });
@@ -165,6 +225,7 @@ jest.mock('@onekeyhq/components', () => {
       Icon: () => null,
       Title: Container,
     },
+    HeightTransition,
     Icon: () => null,
     SizableText: Container,
     Stack: Container,
@@ -175,10 +236,16 @@ jest.mock('@onekeyhq/components', () => {
   };
 });
 
-jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
-  __esModule: true,
-  default: {},
-}));
+jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => {
+  const servicePrime = {
+    apiOAuthLogin: jest.fn(),
+  };
+  return {
+    __esModule: true,
+    __servicePrime: servicePrime,
+    default: { servicePrime },
+  };
+});
 
 jest.mock(
   '@onekeyhq/kit/src/components/OneKeyAuth/extOneKeyIdAuthExpandTab',
@@ -195,10 +262,17 @@ jest.mock(
   }),
 );
 
-jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
-  __esModule: true,
-  default: { isNative: false },
-}));
+jest.mock('@onekeyhq/shared/src/platformEnv', () => {
+  const platformEnv = {
+    isNative: false,
+    isNativeIOS: false,
+  };
+  return {
+    __esModule: true,
+    __platformEnv: platformEnv,
+    default: platformEnv,
+  };
+});
 
 jest.mock('../oneKeyIdLoginToastUtils', () => ({
   getSanitizedAuthErrorText: jest.fn(),
@@ -229,24 +303,194 @@ jest.mock('../PrimeLoginEmailDialogV2/PrimeLoginEmailDialogV2', () => {
   };
 });
 
-jest.mock('../useOneKeyIdLocalKeylessOAuth', () => ({
-  useOneKeyIdLocalKeylessOAuth: () => ({
+jest.mock('../useOneKeyIdLocalKeylessOAuth', () => {
+  let onAccountMismatch: (() => void) | undefined;
+  const oauthMocks = {
     getFreshOAuthTokensForRegularLogin: jest.fn(),
     getOAuthAccessToken: jest.fn(),
-    isLocalKeylessOAuthMode: false,
-    localKeylessProvider: undefined,
-    localKeylessProviderName: '',
-    localKeylessWalletId: undefined,
     rollbackProvisionalOAuthSession: jest.fn(),
-  }),
-}));
+    triggerAccountMismatch: () => onAccountMismatch?.(),
+  };
+  return {
+    __oauthMocks: oauthMocks,
+    useOneKeyIdLocalKeylessOAuth: (options: {
+      onAccountMismatch?: () => void;
+    }) => {
+      onAccountMismatch = options.onAccountMismatch;
+      return {
+        ...oauthMocks,
+        isLocalKeylessOAuthMode: false,
+        localKeylessProvider: undefined,
+        localKeylessProviderName: '',
+        localKeylessWalletId: undefined,
+      };
+    },
+  };
+});
+
+function getPlatformEnvMock() {
+  return jest.requireMock('@onekeyhq/shared/src/platformEnv').__platformEnv as {
+    isNative: boolean;
+    isNativeIOS: boolean;
+  };
+}
+
+function getOAuthMocks() {
+  return jest.requireMock('../useOneKeyIdLocalKeylessOAuth').__oauthMocks as {
+    getOAuthAccessToken: jest.Mock;
+    triggerAccountMismatch: () => void;
+  };
+}
+
+function getBackgroundApiMocks() {
+  return jest.requireMock(
+    '@onekeyhq/kit/src/background/instance/backgroundApiProxy',
+  ).__servicePrime as {
+    apiOAuthLogin: jest.Mock;
+  };
+}
 
 describe('PrimeLoginOAuthDialog', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    const platformEnv = getPlatformEnvMock();
+    platformEnv.isNative = false;
+    platformEnv.isNativeIOS = false;
+    getOAuthMocks().getOAuthAccessToken.mockReset();
+    getBackgroundApiMocks().apiOAuthLogin.mockReset();
   });
 
-  test('keeps the embedded email flow mounted while sign-in methods are collapsed', () => {
+  test('completes native Google OAuth after closing the iOS dialog', async () => {
+    const callOrder: string[] = [];
+    const platformEnv = getPlatformEnvMock();
+    const { getOAuthAccessToken } = getOAuthMocks();
+    let finishClosingDialog!: () => void;
+    const closingDialog = new Promise<void>((resolve) => {
+      finishClosingDialog = resolve;
+    });
+    platformEnv.isNative = true;
+    platformEnv.isNativeIOS = true;
+    getOAuthAccessToken.mockImplementation(async () => {
+      callOrder.push('launchOAuth');
+      return {
+        accessToken: 'access-token',
+        didUseOAuthSignIn: true,
+        rollbackHandle: undefined,
+      };
+    });
+    getBackgroundApiMocks().apiOAuthLogin.mockImplementation(async () => {
+      callOrder.push('apiLogin');
+    });
+    const onComplete = jest.fn(() => {
+      callOrder.push('closeDialog');
+      return closingDialog;
+    });
+    const onLoginSuccess = jest.fn(async () => {
+      callOrder.push('loginSuccess');
+    });
+    const onReopenAfterOAuthFailure = jest.fn();
+
+    render(
+      <PrimeLoginOAuthDialog
+        onComplete={onComplete}
+        onLoginSuccess={onLoginSuccess}
+        onReopenAfterOAuthFailure={onReopenAfterOAuthFailure}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('prime-login-oauth-google-btn'));
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+    expect(getOAuthAccessToken).not.toHaveBeenCalled();
+
+    await act(async () => {
+      finishClosingDialog();
+      await closingDialog;
+    });
+    await waitFor(() => {
+      expect(onLoginSuccess).toHaveBeenCalledTimes(1);
+    });
+    expect(callOrder).toEqual([
+      'closeDialog',
+      'launchOAuth',
+      'apiLogin',
+      'loginSuccess',
+    ]);
+    expect(onReopenAfterOAuthFailure).not.toHaveBeenCalled();
+  });
+
+  test('reopens the iOS dialog with recovery after account mismatch', async () => {
+    const platformEnv = getPlatformEnvMock();
+    const oauthMocks = getOAuthMocks();
+    platformEnv.isNative = true;
+    platformEnv.isNativeIOS = true;
+    oauthMocks.getOAuthAccessToken.mockImplementation(async () => {
+      oauthMocks.triggerAccountMismatch();
+      throw new OneKeyLocalError('Account mismatch');
+    });
+    const onComplete = jest.fn().mockResolvedValue(undefined);
+    const onCancel = jest.fn();
+    const onReopenAfterOAuthFailure = jest.fn();
+
+    render(
+      <PrimeLoginOAuthDialog
+        onComplete={onComplete}
+        onCancel={onCancel}
+        onReopenAfterOAuthFailure={onReopenAfterOAuthFailure}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('prime-login-oauth-google-btn'));
+
+    await waitFor(() => {
+      expect(onReopenAfterOAuthFailure).toHaveBeenCalledWith({
+        showKeylessLogoutAction: true,
+      });
+    });
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  test('keeps the existing success-then-close order outside iOS', async () => {
+    const callOrder: string[] = [];
+    const { getOAuthAccessToken } = getOAuthMocks();
+    getOAuthAccessToken.mockImplementation(async () => {
+      callOrder.push('launchOAuth');
+      return {
+        accessToken: 'access-token',
+        didUseOAuthSignIn: true,
+        rollbackHandle: undefined,
+      };
+    });
+    getBackgroundApiMocks().apiOAuthLogin.mockImplementation(async () => {
+      callOrder.push('apiLogin');
+    });
+    const onComplete = jest.fn(async () => {
+      callOrder.push('closeDialog');
+    });
+    const onLoginSuccess = jest.fn(async () => {
+      callOrder.push('loginSuccess');
+    });
+
+    render(
+      <PrimeLoginOAuthDialog
+        onComplete={onComplete}
+        onLoginSuccess={onLoginSuccess}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('prime-login-oauth-google-btn'));
+
+    await waitFor(() => {
+      expect(onLoginSuccess).toHaveBeenCalledTimes(1);
+    });
+    expect(callOrder).toEqual([
+      'launchOAuth',
+      'apiLogin',
+      'closeDialog',
+      'loginSuccess',
+    ]);
+  });
+
+  test('starts collapsed and can reopen without remounting the email flow', () => {
     render(
       <PrimeLoginOAuthDialog
         onComplete={jest.fn().mockResolvedValue(undefined)}
@@ -256,9 +500,14 @@ describe('PrimeLoginOAuthDialog', () => {
     const trigger = screen.getByTestId('prime-login-more-methods-trigger');
     const getContent = () =>
       screen.getByTestId('prime-login-more-methods-content');
+    const getTransitionHeight = () =>
+      screen
+        .getByTestId('prime-login-more-methods-height-transition')
+        .getAttribute('data-height');
 
     expect(mockEmailDialogMount).toHaveBeenCalledTimes(1);
     expect(mockEmailDialogUnmount).not.toHaveBeenCalled();
+    expect(getTransitionHeight()).toBe('0');
     expect(getContent().getAttribute('aria-hidden')).toBe('true');
     expect(getContent().getAttribute('data-pointer-events')).toBe('none');
     expect(getContent().getAttribute('data-inert')).toBe('true');
@@ -271,13 +520,20 @@ describe('PrimeLoginOAuthDialog', () => {
 
     fireEvent.click(trigger);
 
+    expect(getTransitionHeight()).toBe('240');
     expect(getContent().getAttribute('aria-hidden')).toBe('false');
     expect(getContent().getAttribute('data-pointer-events')).toBe('auto');
     expect(getContent().getAttribute('data-inert')).toBe('false');
 
     fireEvent.click(trigger);
+
+    expect(getTransitionHeight()).toBe('0');
+    expect(getContent().getAttribute('aria-hidden')).toBe('true');
+
     fireEvent.click(trigger);
 
+    expect(getTransitionHeight()).toBe('240');
+    expect(getContent().getAttribute('aria-hidden')).toBe('false');
     expect(mockEmailDialogMount).toHaveBeenCalledTimes(1);
     expect(mockEmailDialogUnmount).not.toHaveBeenCalled();
     expect(screen.getByTestId('mock-prime-login-email-dialog')).toBeTruthy();

--- a/packages/kit/src/views/Prime/components/PrimeLoginOAuthDialog/PrimeLoginOAuthDialog.tsx
+++ b/packages/kit/src/views/Prime/components/PrimeLoginOAuthDialog/PrimeLoginOAuthDialog.tsx
@@ -6,6 +6,7 @@ import {
   Accordion,
   Button,
   Dialog,
+  HeightTransition,
   Icon,
   SizableText,
   Stack,
@@ -60,6 +61,10 @@ function PrimeLoginOAuthDialog(props: {
   onComplete: () => Promise<void>;
   onLoginSuccess?: () => void | Promise<void>;
   onCancel?: () => void | Promise<void>;
+  onReopenAfterOAuthFailure?: (options?: {
+    showKeylessLogoutAction?: boolean;
+  }) => void | Promise<void>;
+  initialShowKeylessLogoutAction?: boolean;
   localKeylessLoginPrepareResult?: IOneKeyIdLoginWithLocalKeylessPrepareResult;
   localKeylessLoginPrepareErrorMessage?: string;
   toOneKeyIdPageOnLoginSuccess?: boolean;
@@ -68,6 +73,8 @@ function PrimeLoginOAuthDialog(props: {
     onComplete,
     onLoginSuccess,
     onCancel,
+    onReopenAfterOAuthFailure,
+    initialShowKeylessLogoutAction,
     localKeylessLoginPrepareResult,
     localKeylessLoginPrepareErrorMessage,
     toOneKeyIdPageOnLoginSuccess,
@@ -81,9 +88,15 @@ function PrimeLoginOAuthDialog(props: {
     string | undefined
   >();
   const [expandedSignInMethod, setExpandedSignInMethod] = useState('');
-  const [showKeylessLogoutAction, setShowKeylessLogoutAction] = useState(false);
+  const [showKeylessLogoutAction, setShowKeylessLogoutAction] = useState(
+    initialShowKeylessLogoutAction ?? false,
+  );
   const loggingInProviderRef = useRef<EOAuthSocialLoginProvider | null>(null);
   const isEmailLoginStartingRef = useRef(false);
+  const accountMismatchDetectedRef = useRef(
+    initialShowKeylessLogoutAction ?? false,
+  );
+  const isDialogClosedForOAuthRef = useRef(false);
   loggingInProviderRef.current = loggingInProvider;
   const handleEmailSubmittingChange = useCallback(
     (nextIsEmailLoginStarting: boolean) => {
@@ -93,7 +106,16 @@ function PrimeLoginOAuthDialog(props: {
     [],
   );
   const handleAccountMismatch = useCallback(() => {
-    setShowKeylessLogoutAction(true);
+    accountMismatchDetectedRef.current = true;
+    if (!isDialogClosedForOAuthRef.current) {
+      setShowKeylessLogoutAction(true);
+    }
+  }, []);
+  const resetAccountMismatch = useCallback(() => {
+    accountMismatchDetectedRef.current = false;
+    if (!isDialogClosedForOAuthRef.current) {
+      setShowKeylessLogoutAction(false);
+    }
   }, []);
   const {
     localKeylessProvider,
@@ -169,8 +191,16 @@ function PrimeLoginOAuthDialog(props: {
     }) => {
       let isOneKeyIdLoginCommitted = false;
       let didUseOAuthSignIn = false;
+      let didCloseDialogBeforeOAuth = false;
       let rollbackHandle: IKeylessOAuthSessionRollbackHandle | undefined;
       try {
+        if (platformEnv.isNativeIOS && closeDialogOnSuccess) {
+          // The iOS FullWindowOverlay sits above native auth controllers.
+          // Wait for the dialog to disappear before presenting OAuth.
+          await onComplete();
+          didCloseDialogBeforeOAuth = true;
+          isDialogClosedForOAuthRef.current = true;
+        }
         let accessToken = '';
         let refreshToken = '';
         if (useRegularOAuthLogin) {
@@ -223,13 +253,22 @@ function PrimeLoginOAuthDialog(props: {
           throw error;
         }
         showOneKeyIdLoginSuccessToast(intl);
-        if (closeDialogOnSuccess) {
+        if (closeDialogOnSuccess && !didCloseDialogBeforeOAuth) {
           await onComplete();
         }
         await onLoginSuccess?.();
       } catch (error) {
         if (!isOneKeyIdLoginCommitted) {
           showOneKeyIdLoginFailedToast({ error, intl });
+        }
+        if (didCloseDialogBeforeOAuth && !isOneKeyIdLoginCommitted) {
+          if (onReopenAfterOAuthFailure) {
+            await onReopenAfterOAuthFailure({
+              showKeylessLogoutAction: accountMismatchDetectedRef.current,
+            });
+          } else {
+            await onCancel?.();
+          }
         }
         throw error;
       }
@@ -238,8 +277,10 @@ function PrimeLoginOAuthDialog(props: {
       getFreshOAuthTokensForRegularLogin,
       getOAuthAccessToken,
       intl,
+      onCancel,
       onComplete,
       onLoginSuccess,
+      onReopenAfterOAuthFailure,
       rollbackProvisionalOAuthSession,
     ],
   );
@@ -251,19 +292,21 @@ function PrimeLoginOAuthDialog(props: {
       }
       loggingInProviderRef.current = provider;
       try {
-        setShowKeylessLogoutAction(false);
+        resetAccountMismatch();
         setLoggingInProvider(provider);
         await performOAuthLogin({
           provider,
           useRegularOAuthLogin: false,
           closeDialogOnSuccess: true,
         });
+      } catch {
+        // performOAuthLogin owns user feedback and restores the iOS dialog.
       } finally {
         loggingInProviderRef.current = null;
         setLoggingInProvider(null);
       }
     },
-    [performOAuthLogin],
+    [performOAuthLogin, resetAccountMismatch],
   );
 
   const handleSwitchOAuthProvider = useCallback(
@@ -287,7 +330,7 @@ function PrimeLoginOAuthDialog(props: {
       let didCloseDialogForNextStep = false;
       let didCompleteOAuthContinuation = false;
       try {
-        setShowKeylessLogoutAction(false);
+        resetAccountMismatch();
         setLoggingInProvider(provider);
         const result = await runIdentityExit(
           {
@@ -351,6 +394,7 @@ function PrimeLoginOAuthDialog(props: {
       onCancel,
       onComplete,
       performOAuthLogin,
+      resetAccountMismatch,
       runIdentityExit,
     ],
   );
@@ -361,7 +405,7 @@ function PrimeLoginOAuthDialog(props: {
         return;
       }
       loggingInProviderRef.current = provider;
-      setShowKeylessLogoutAction(false);
+      resetAccountMismatch();
       setLoggingInProvider(provider);
 
       let inspection;
@@ -496,6 +540,7 @@ function PrimeLoginOAuthDialog(props: {
       onCancel,
       onComplete,
       performOAuthLogin,
+      resetAccountMismatch,
       runIdentityExit,
     ],
   );
@@ -583,7 +628,7 @@ function PrimeLoginOAuthDialog(props: {
               id: ETranslations.sign_in_to_onekey_id__title,
             })}
           </Dialog.Title>
-          <Dialog.Description>
+          <Dialog.Description color="$textSubdued">
             {intl.formatMessage({
               id: ETranslations.prime_onekeyid_continue_description,
             })}
@@ -656,7 +701,7 @@ function PrimeLoginOAuthDialog(props: {
                 )}
               </Accordion.Trigger>
             )}
-            <Accordion.HeightAnimator animation="quick" overflow="hidden">
+            <HeightTransition hide={!isSignInMethodsExpanded}>
               <Accordion.Content
                 unstyled
                 forceMount
@@ -684,7 +729,7 @@ function PrimeLoginOAuthDialog(props: {
                   onCancel={onCancel}
                 />
               </Accordion.Content>
-            </Accordion.HeightAnimator>
+            </HeightTransition>
           </Accordion.Item>
         </Accordion>
         {!isEmailVerificationStep &&

--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/components/SwapReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/components/SwapReward/index.tsx
@@ -26,7 +26,7 @@ export function SwapReward({ swapRewards }: ISwapRewardProps) {
       <Card.Title
         icon="SwitchHorOutline"
         title={intl.formatMessage({
-          id: ETranslations.global_swap,
+          id: ETranslations.global_trade,
         })}
         onPress={navigateToSwapReward}
       />

--- a/packages/kit/src/views/ReferFriends/pages/InviteReward/components/shared/ReferralLinkPopoverContent.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/InviteReward/components/shared/ReferralLinkPopoverContent.tsx
@@ -110,7 +110,7 @@ const REFERRAL_LINKS = [
   },
   {
     pathSuffix: '/app/swap',
-    titleId: ETranslations.swap_referral_link__title,
+    titleId: ETranslations.global_trade,
     descId: ETranslations.swap_referral_link__desc,
     useWebAppUrl: true,
   },

--- a/packages/kit/src/views/ReferFriends/pages/SwapReward/components/SwapEmptyData.test.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/SwapReward/components/SwapEmptyData.test.tsx
@@ -17,30 +17,40 @@ jest.mock('@onekeyhq/components', () => {
   const React = jest.requireActual<typeof import('react')>('react');
   const copyUrl = jest.fn();
 
+  const TestButton = ({
+    children,
+    loading,
+    onPress,
+    testID,
+  }: {
+    children?: ReactNode;
+    loading?: boolean;
+    onPress?: () => void;
+    testID?: string;
+  }) => (
+    <button
+      data-loading={String(Boolean(loading))}
+      disabled={loading}
+      onClick={onPress}
+      data-testid={testID}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+
   return {
     __copyUrl: copyUrl,
-    Button: ({
-      children,
-      loading,
-      onPress,
-      testID,
+    Button: TestButton,
+    Empty: ({
+      buttonProps,
     }: {
-      children?: ReactNode;
-      loading?: boolean;
-      onPress?: () => void;
-      testID?: string;
+      buttonProps?: React.ComponentProps<typeof TestButton>;
     }) => (
-      <button
-        data-loading={String(Boolean(loading))}
-        disabled={loading}
-        onClick={onPress}
-        data-testid={testID}
-        type="button"
-      >
-        {children}
-      </button>
+      <div data-testid="swap-reward-empty-content">
+        {buttonProps ? <TestButton {...buttonProps} /> : null}
+      </div>
     ),
-    Empty: () => React.createElement('div'),
     YStack: ({ children }: { children?: ReactNode }) =>
       React.createElement('div', null, children),
     useClipboard: () => ({ copyUrl }),
@@ -79,7 +89,9 @@ describe('SwapEmptyData', () => {
 
     const { rerender } = render(<SwapEmptyData />);
     const copyButton = screen.getByTestId('swap-reward-copy-link-btn');
+    const emptyContent = screen.getByTestId('swap-reward-empty-content');
 
+    expect(emptyContent.contains(copyButton)).toBe(true);
     expect((copyButton as HTMLButtonElement).disabled).toBe(true);
     expect(copyButton.getAttribute('data-loading')).toBe('true');
     fireEvent.click(copyButton);

--- a/packages/kit/src/views/ReferFriends/pages/SwapReward/components/SwapEmptyData.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/SwapReward/components/SwapEmptyData.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import { Button, Empty, YStack, useClipboard } from '@onekeyhq/components';
+import { Empty, useClipboard } from '@onekeyhq/components';
 import { useReferralUrl } from '@onekeyhq/kit/src/views/Perp/components/PositionShare/useReferralUrl';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
@@ -16,25 +16,22 @@ export function SwapEmptyData() {
   }, [copyUrl, referralQrCodeUrl]);
 
   return (
-    <YStack ai="center">
-      <Empty
-        mt="$-10"
-        illustration="ShakeHands"
-        title={intl.formatMessage({
-          id: ETranslations.referral_referred_empty,
-        })}
-        description={intl.formatMessage({
-          id: ETranslations.referral_referred_empty_desc,
-        })}
-      />
-      <Button
-        testID="swap-reward-copy-link-btn"
-        variant="primary"
-        loading={!isReady}
-        onPress={handleCopyLink}
-      >
-        {intl.formatMessage({ id: ETranslations.browser_copy_link })}
-      </Button>
-    </YStack>
+    <Empty
+      mt="$-10"
+      illustration="ShakeHands"
+      title={intl.formatMessage({
+        id: ETranslations.referral_referred_empty,
+      })}
+      description={intl.formatMessage({
+        id: ETranslations.referral_referred_empty_desc,
+      })}
+      buttonProps={{
+        testID: 'swap-reward-copy-link-btn',
+        variant: 'primary',
+        loading: !isReady,
+        onPress: handleCopyLink,
+        children: intl.formatMessage({ id: ETranslations.browser_copy_link }),
+      }}
+    />
   );
 }

--- a/packages/kit/src/views/ReferFriends/pages/SwapReward/components/SwapInviteRecord.test.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/SwapReward/components/SwapInviteRecord.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/first */
+
+import type { ReactNode } from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import type { ISwapInviteItem } from '@onekeyhq/shared/src/referralCode/type';
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+jest.mock('react-native', () => ({
+  StyleSheet: { hairlineWidth: 1 },
+}));
+
+jest.mock('@onekeyhq/components', () => {
+  const Stack = ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  );
+  const SizableText = ({
+    children,
+    ellipsizeMode,
+    numberOfLines,
+    width,
+  }: {
+    children?: ReactNode;
+    ellipsizeMode?: string;
+    numberOfLines?: number;
+    width?: string | number;
+  }) => (
+    <span
+      data-ellipsize-mode={ellipsizeMode}
+      data-number-of-lines={numberOfLines}
+      data-width={width}
+    >
+      {children}
+    </span>
+  );
+  const YStack = ({
+    children,
+    width,
+  }: {
+    children?: ReactNode;
+    width?: string | number;
+  }) => <div data-width={width}>{children}</div>;
+
+  return {
+    Badge: Stack,
+    Button: Stack,
+    Icon: () => null,
+    NumberSizeableText: SizableText,
+    SizableText,
+    Spinner: () => null,
+    Stack,
+    XStack: Stack,
+    YStack,
+  };
+});
+
+jest.mock('@onekeyhq/kit/src/components/Currency', () => ({
+  Currency: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}));
+
+jest.mock('@onekeyhq/kit/src/utils/explorerUtils', () => ({
+  openTransactionDetailsUrl: jest.fn(),
+}));
+
+jest.mock('../hooks/useSwapRecordDetails', () => ({
+  useSwapRecordDetails: () => ({
+    hasError: false,
+    isLoading: false,
+    records: undefined,
+    retry: jest.fn(),
+  }),
+}));
+
+jest.mock('./SwapRewardStatusBadge', () => ({
+  SwapRewardStatusBadge: () => null,
+}));
+
+import { SwapInviteRecord } from './SwapInviteRecord';
+
+const LONG_REMARK =
+  'https://onekey.example/r/remark-that-is-much-longer-than-the-column-width';
+
+const inviteItem: ISwapInviteItem = {
+  _id: 'invitee-id',
+  address: '0x12...7890',
+  invitationTime: null,
+  inviteCode: 'ONEKEY',
+  inviteCodeRemark: LONG_REMARK,
+  firstTradeTime: null,
+  volume: '1',
+  volumeFiatValue: '1',
+  fee: '0.01',
+  feeFiatValue: '0.01',
+  reward: '0.005',
+  rewardFiatValue: '0.005',
+  hasUndistributed: true,
+  token: {
+    networkId: 'evm--1',
+    address: '0xtoken',
+    logoURI: 'https://example.com/token.png',
+    name: 'USD Coin',
+    symbol: 'USDC',
+  },
+};
+
+describe('SwapInviteRecord', () => {
+  it('constrains long invite-code remarks to a single ellipsized line', () => {
+    render(
+      <SwapInviteRecord
+        item={inviteItem}
+        query={{}}
+        status={undefined}
+        variant="desktop"
+      />,
+    );
+
+    const remark = screen.getByText(LONG_REMARK);
+    expect(remark.getAttribute('data-number-of-lines')).toBe('1');
+    expect(remark.getAttribute('data-ellipsize-mode')).toBe('tail');
+    expect(remark.getAttribute('data-width')).toBe('100%');
+    expect(remark.parentElement?.getAttribute('data-width')).toBe('100%');
+  });
+});

--- a/packages/kit/src/views/ReferFriends/pages/SwapReward/components/SwapInviteRecord.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/SwapReward/components/SwapInviteRecord.tsx
@@ -112,14 +112,34 @@ function TokenAmount({ item }: { item: ISwapRecordItem }) {
   );
 }
 
-function InviteCodeValue({ item }: { item: ISwapInviteItem }) {
+function InviteCodeValue({
+  fillAvailableWidth = false,
+  item,
+}: {
+  fillAvailableWidth?: boolean;
+  item: ISwapInviteItem;
+}) {
   return (
-    <YStack gap="$0.5" ai="flex-start" minWidth={0}>
+    <YStack
+      gap="$0.5"
+      ai="flex-start"
+      minWidth={0}
+      maxWidth="100%"
+      width={fillAvailableWidth ? '100%' : undefined}
+      flexShrink={1}
+    >
       <Badge badgeType="default" badgeSize="sm">
         {item.inviteCode}
       </Badge>
       {item.inviteCodeRemark ? (
-        <SizableText size="$bodySm" color="$textSubdued" numberOfLines={1}>
+        <SizableText
+          size="$bodySm"
+          color="$textSubdued"
+          width={fillAvailableWidth ? '100%' : undefined}
+          maxWidth="100%"
+          numberOfLines={1}
+          ellipsizeMode="tail"
+        >
           {item.inviteCodeRemark}
         </SizableText>
       ) : null}
@@ -593,7 +613,7 @@ export function SwapInviteRecord({
           </SizableText>
         </XStack>
         <XStack w={columnWidths.referralCode} minWidth={0}>
-          <InviteCodeValue item={item} />
+          <InviteCodeValue item={item} fillAvailableWidth />
         </XStack>
         <XStack w={columnWidths.firstTrade} minWidth={0}>
           <SizableText size="$bodyMd" color={firstTradeTimeColor}>

--- a/packages/kit/src/views/ReferFriends/pages/SwapReward/index.test.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/SwapReward/index.test.tsx
@@ -30,6 +30,7 @@ const mockGetSwapInvites = jest.fn<
   [ISwapInvitesRequest]
 >();
 const mockSwapDetailsSection = jest.fn();
+const mockReferFriendsDetailHeader = jest.fn();
 const mockIntl = {
   formatMessage: ({ id }: { id: string }) => id,
 };
@@ -102,7 +103,10 @@ jest.mock(
 jest.mock('../../components', () => ({
   ExportButton: () => null,
   FilterButton: () => null,
-  ReferFriendsDetailHeader: () => null,
+  ReferFriendsDetailHeader: (props: unknown) => {
+    mockReferFriendsDetailHeader(props);
+    return null;
+  },
   ReferFriendsPageContainer: ({ children }: { children?: ReactNode }) =>
     children,
 }));
@@ -185,6 +189,20 @@ describe('SwapReward refresh feedback', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockRouteFocused = true;
+  });
+
+  it('uses the Trade product name in the reward page title', async () => {
+    mockGetSwapCumulativeRewards.mockResolvedValue(cumulativeRewards);
+    mockGetSwapInvites.mockResolvedValue(invites);
+
+    render(<SwapReward />);
+    await completeInitialLoad();
+
+    expect(mockReferFriendsDetailHeader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: ETranslations.global_trade,
+      }),
+    );
   });
 
   it('shows one error toast when the inactive tab count refresh fails', async () => {

--- a/packages/kit/src/views/ReferFriends/pages/SwapReward/index.tsx
+++ b/packages/kit/src/views/ReferFriends/pages/SwapReward/index.tsx
@@ -500,7 +500,7 @@ function SwapRewardPageWrapper() {
     <Page>
       <ReferFriendsDetailHeader
         title={intl.formatMessage({
-          id: ETranslations.global_swap,
+          id: ETranslations.global_trade,
         })}
         toolbar={toolbar}
       />


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59624](https://onekeyhq.atlassian.net/browse/OK-59624) [OK-59625](https://onekeyhq.atlassian.net/browse/OK-59625) [OK-59626](https://onekeyhq.atlassian.net/browse/OK-59626) [OK-59627](https://onekeyhq.atlassian.net/browse/OK-59627) [OK-59629](https://onekeyhq.atlassian.net/browse/OK-59629) [OK-59635](https://onekeyhq.atlassian.net/browse/OK-59635)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Start **More sign-in methods** collapsed while keeping the email flow mounted, and use the subdued text color for the OneKey ID description.
- On iOS, close the OneKey ID dialog before presenting native OAuth; preserve the success callback, reopen the dialog after OAuth failure/cancel, and carry account-mismatch recovery into the reopened dialog.
- Align referral product naming to **Trade**, ellipsize long invite-link remarks, and restore the standard empty-state spacing around the copy-link action.

## Root causes

- The force-mounted accordion content was initialized through the height animator in an expanded/measured state, and its previous lifecycle made repeated reopening unreliable.
- The iOS dialog uses a full-window overlay, which remained above the native Google authentication controller.
- Referral table text did not have a constrained shrinkable width, and the copy-link action was rendered outside the standard `Empty` action container.

## Validation

- [x] Related Jest regression set: 13 suites, 39 tests passed
- [x] `yarn agent:check --profile commit`
- [x] `yarn agent:check --profile pr`
- [x] Manual UI and Google OAuth verification completed by the requester

## Related issues

- OK-59624
- OK-59625
- OK-59626
- OK-59627
- OK-59629
- OK-59635

[OK-59624]: https://onekeyhq.atlassian.net/browse/OK-59624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-59625]: https://onekeyhq.atlassian.net/browse/OK-59625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-59626]: https://onekeyhq.atlassian.net/browse/OK-59626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-59627]: https://onekeyhq.atlassian.net/browse/OK-59627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-59629]: https://onekeyhq.atlassian.net/browse/OK-59629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-59635]: https://onekeyhq.atlassian.net/browse/OK-59635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ