### PR TITLE
fix: localize TradingView candle labels OK-58586

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.test.tsx
@@ -143,6 +143,31 @@ describe('TradingViewNativeContainer', () => {
     expect(mockHandleRetry).toHaveBeenCalledTimes(1);
   });
 
+  it('passes localized candle abbreviations to the chart', () => {
+    render(
+      <TradingViewNativeContainer
+        source={{
+          kind: 'market',
+          networkId: 'evm--1',
+          tokenAddress: '0xabc',
+          symbol: 'TOKEN',
+          realtime: 'disabled',
+        }}
+      />,
+    );
+
+    expect(mockTradingViewNativeChart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candleLabels: {
+          close: 'market.close_abbr',
+          high: 'market.high_abbr',
+          low: 'market.low_abbr',
+          open: 'market.open_abbr',
+        },
+      }),
+    );
+  });
+
   it('shows the volume section only when loaded candles contain volume', () => {
     mockDataState = { status: 'live' };
     mockPoints = [

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
@@ -100,6 +100,23 @@ export const TradingViewNativeContainer = memo(
         }),
       [activeIndicatorValues, points],
     );
+    const candleLabels = useMemo(
+      () => ({
+        close: intl.formatMessage({
+          id: ETranslations.market_close_abbr,
+        }),
+        high: intl.formatMessage({
+          id: ETranslations.market_high_abbr,
+        }),
+        low: intl.formatMessage({
+          id: ETranslations.market_low_abbr,
+        }),
+        open: intl.formatMessage({
+          id: ETranslations.market_open_abbr,
+        }),
+      }),
+      [intl],
+    );
     const latestPoint = points[points.length - 1];
     const latestPrice = latestPoint?.c;
     const latestPriceTimestamp = latestPoint?.t;
@@ -283,6 +300,7 @@ export const TradingViewNativeContainer = memo(
             onChartWidthChange={setChartWidth}
             onViewportRequestApplied={handleViewportRequestApplied}
             onVisiblePointRangeChange={handleVisiblePointRangeChange}
+            candleLabels={candleLabels}
             points={points}
             testID={testID}
             viewportRequest={viewportRequest}

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
@@ -67,7 +67,10 @@ import {
   createTradingViewNativeSkiaResources,
 } from './chartSkiaRenderer';
 
-import type { ITradingViewNativeChartType } from '../types';
+import type {
+  ITradingViewNativeCandleLabels,
+  ITradingViewNativeChartType,
+} from '../types';
 
 const PAN_DRAG_RATIO = 1.1;
 const PAN_DECELERATION = 0.9982;
@@ -118,6 +121,7 @@ interface ITradingViewNativeChartProps {
   onVisiblePointRangeChange?: (
     range: ITradingViewNativeVisiblePointRange,
   ) => void;
+  candleLabels: ITradingViewNativeCandleLabels;
   points: IMarketTokenKLineDataPoint[];
   testID?: string;
   viewportRequest?: ITradingViewNativeViewportRequest | null;
@@ -170,6 +174,7 @@ export const TradingViewNativeChart = memo(
     onChartWidthChange,
     onViewportRequestApplied,
     onVisiblePointRangeChange,
+    candleLabels,
     points,
     testID,
     viewportRequest,
@@ -291,6 +296,7 @@ export const TradingViewNativeChart = memo(
         crosshair: runtime.crosshair,
         hasVolume: runtime.hasVolume,
         height: runtime.size.height,
+        candleLabels,
         indicatorSeries: runtime.indicatorSeries,
         points: runtime.points,
         priceAxisWidth: priceAxisWidth.value,
@@ -299,7 +305,7 @@ export const TradingViewNativeChart = memo(
         watermarkOpacity,
         width: runtime.size.width,
       });
-    }, [priceAxisWidth, resources, watermarkOpacity]);
+    }, [candleLabels, priceAxisWidth, resources, watermarkOpacity]);
 
     const handleChartWidthChange = useCallback((nextChartWidth: number) => {
       setChartWidth((currentChartWidth) =>

--- a/packages/kit/src/components/TradingView/TradingViewNative/types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/types.ts
@@ -5,6 +5,13 @@ import type { ITradingViewNativeChartInterval } from './data/tradingViewNativeIn
 export type ITradingViewNativeHyperliquidEnvironment = 'mainnet' | 'testnet';
 export type ITradingViewNativeChartType = 'candlestick' | 'line';
 
+export interface ITradingViewNativeCandleLabels {
+  close: string;
+  high: string;
+  low: string;
+  open: string;
+}
+
 export type ITradingViewNativeSource =
   | {
       kind: 'hyperliquid';

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLegend.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLegend.test.ts
@@ -7,24 +7,34 @@ import {
   getTradingViewNativeVolumeAxisLabel,
 } from './chartLegend';
 
+const CANDLE_LABELS = {
+  close: '收',
+  high: '高',
+  low: '低',
+  open: '开',
+};
+
 describe('TradingViewNative chart legend', () => {
   it('builds colored price and volume values from an up candle', () => {
     expect(
-      getTradingViewNativeChartLegend({
-        c: 123.456_789,
-        h: 125,
-        l: 119.5,
-        o: 120,
-        t: 1,
-        v: 1_250_000,
-      }),
+      getTradingViewNativeChartLegend(
+        {
+          c: 123.456_789,
+          h: 125,
+          l: 119.5,
+          o: 120,
+          t: 1,
+          v: 1_250_000,
+        },
+        CANDLE_LABELS,
+      ),
     ).toEqual({
       isUp: true,
       priceItems: [
-        { label: 'O', value: '120.00' },
-        { label: 'H', value: '125.00' },
-        { label: 'L', value: '119.50' },
-        { label: 'C', value: '123.46' },
+        { label: '开', value: '120.00' },
+        { label: '高', value: '125.00' },
+        { label: '低', value: '119.50' },
+        { label: '收', value: '123.46' },
         {
           label: '',
           value: '+3.45679 (+2.88%)',
@@ -37,14 +47,17 @@ describe('TradingViewNative chart legend', () => {
 
   it('uses the down direction when the candle closes below its open', () => {
     expect(
-      getTradingViewNativeChartLegend({
-        c: 9,
-        h: 11,
-        l: 8,
-        o: 10,
-        t: 1,
-        v: 500,
-      }).isUp,
+      getTradingViewNativeChartLegend(
+        {
+          c: 9,
+          h: 11,
+          l: 8,
+          o: 10,
+          t: 1,
+          v: 500,
+        },
+        CANDLE_LABELS,
+      ).isUp,
     ).toBe(false);
   });
 
@@ -59,6 +72,7 @@ describe('TradingViewNative chart legend', () => {
           t: 1,
           v: 500,
         },
+        CANDLE_LABELS,
         'line',
       ),
     ).toEqual({
@@ -81,6 +95,7 @@ describe('TradingViewNative chart legend', () => {
         t: 1,
         v: 10,
       },
+      CANDLE_LABELS,
       'candlestick',
       100,
     );

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLegend.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLegend.ts
@@ -12,7 +12,10 @@ import {
 
 import { formatTradingViewNativePriceTick } from './chartLayout';
 
-import type { ITradingViewNativeChartType } from '../types';
+import type {
+  ITradingViewNativeCandleLabels,
+  ITradingViewNativeChartType,
+} from '../types';
 
 export interface ITradingViewNativeLegendItem {
   label: string;
@@ -221,6 +224,7 @@ export function getTradingViewNativeVolumeAxisLabel(
 
 export function getTradingViewNativeChartLegend(
   point: IMarketTokenKLineDataPoint,
+  candleLabels: ITradingViewNativeCandleLabels,
   chartType: ITradingViewNativeChartType = 'candlestick',
   previousClose?: number,
 ): ITradingViewNativeChartLegend {
@@ -243,10 +247,10 @@ export function getTradingViewNativeChartLegend(
       chartType === 'line'
         ? [{ label: 'Price', value: formatPrice(point.c) }, priceChangeItem]
         : [
-            { label: 'O', value: formatPrice(point.o) },
-            { label: 'H', value: formatPrice(point.h) },
-            { label: 'L', value: formatPrice(point.l) },
-            { label: 'C', value: formatPrice(point.c) },
+            { label: candleLabels.open, value: formatPrice(point.o) },
+            { label: candleLabels.high, value: formatPrice(point.h) },
+            { label: candleLabels.low, value: formatPrice(point.l) },
+            { label: candleLabels.close, value: formatPrice(point.c) },
             priceChangeItem,
           ],
     volumeItem: {

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.test.ts
@@ -19,6 +19,13 @@ const POINTS: IMarketTokenKLineDataPoint[] = [
   { c: 104, h: 105, l: 98, o: 99, t: 1_700_007_200, v: 15 },
 ];
 
+const CANDLE_LABELS = {
+  close: 'C',
+  high: 'H',
+  low: 'L',
+  open: 'O',
+};
+
 function buildLinearPoints(count: number): IMarketTokenKLineDataPoint[] {
   return Array.from({ length: count }, (_, index) => ({
     c: 100 + index,
@@ -39,6 +46,7 @@ describe('TradingViewNative shared chart scene', () => {
       hasVolume: true,
       height: 240,
       measureTextWidth: (text) => text.length * 6,
+      candleLabels: CANDLE_LABELS,
       points: POINTS,
       viewport: { offset: 0, zoomScale: 1 },
       watermarkOpacity: 0.16,
@@ -112,6 +120,7 @@ describe('TradingViewNative shared chart scene', () => {
       hasVolume: false,
       height: 240,
       measureTextWidth: () => 0,
+      candleLabels: CANDLE_LABELS,
       points: [],
       viewport: { offset: 999, zoomScale: 999 },
       watermarkOpacity: 0.08,
@@ -154,6 +163,7 @@ describe('TradingViewNative shared chart scene', () => {
       height: 240,
       indicatorSeries,
       measureTextWidth: (text) => text.length * 6,
+      candleLabels: CANDLE_LABELS,
       points: indicatorPoints,
       viewport: { offset: 0, zoomScale: 1 },
       watermarkOpacity: 0.16,
@@ -191,6 +201,7 @@ describe('TradingViewNative shared chart scene', () => {
       hasVolume: true,
       height: 240,
       measureTextWidth: (text) => text.length * 6,
+      candleLabels: CANDLE_LABELS,
       points: [
         { c: 100_000, h: 100_500, l: 99_500, o: 99_800, t: 1, v: 10 },
         { c: 101_000, h: 102_500, l: 101_000, o: 102_000, t: 2, v: 10 },
@@ -220,6 +231,7 @@ describe('TradingViewNative shared chart scene', () => {
       hasVolume: true,
       height: 240,
       measureTextWidth: () => 0,
+      candleLabels: CANDLE_LABELS,
       points: [
         { ...POINTS[0], v: 0 },
         { ...POINTS[1], v: 100 },
@@ -248,6 +260,7 @@ describe('TradingViewNative shared chart scene', () => {
       hasVolume: true,
       height: 300,
       measureTextWidth: (text) => text.length * 6,
+      candleLabels: CANDLE_LABELS,
       points: POINTS,
       priceAxisWidth: 44,
       viewport: { offset: 0, zoomScale: 1 },
@@ -281,6 +294,7 @@ describe('TradingViewNative shared chart scene', () => {
       hasVolume: false,
       height: 240,
       measureTextWidth: (text) => text.length * 6,
+      candleLabels: CANDLE_LABELS,
       points: POINTS.map((point) => ({ ...point, v: 0 })),
       viewport: { offset: 0, zoomScale: 1 },
       watermarkOpacity: 0.16,
@@ -335,6 +349,7 @@ describe('TradingViewNative shared chart scene', () => {
       hasVolume: true,
       height: 240,
       measureTextWidth: (text) => text.length * 6,
+      candleLabels: CANDLE_LABELS,
       points: linePoints,
       viewport: { offset: 0, zoomScale: 1 },
       watermarkOpacity: 0.16,
@@ -394,6 +409,7 @@ describe('TradingViewNative shared chart scene', () => {
       hasVolume: false,
       height: 240,
       measureTextWidth: (text) => text.length * 6,
+      candleLabels: CANDLE_LABELS,
       points: [
         { c: 100, h: 100, l: 100, o: 100, t: 1_700_000_000, v: 0 },
         { c: 90, h: 100, l: 90, o: 100, t: 1_700_003_600, v: 0 },
@@ -454,6 +470,7 @@ describe('TradingViewNative shared chart scene', () => {
         hasVolume: true,
         height: 240,
         measureTextWidth: (text) => text.length * 6,
+        candleLabels: CANDLE_LABELS,
         points,
         viewport: { offset: 0, zoomScale: 1 },
         watermarkOpacity: 0.16,
@@ -487,6 +504,7 @@ describe('TradingViewNative shared chart scene', () => {
         hasVolume: true,
         height: 240,
         measureTextWidth: (text) => text.length * 6,
+        candleLabels: CANDLE_LABELS,
         points,
         viewport: { offset: 0, zoomScale: 1 },
         watermarkOpacity: 0.16,

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.ts
@@ -85,7 +85,10 @@ import type {
   ITradingViewNativeChartRuntimeCrosshair,
   ITradingViewNativeChartRuntimeViewport,
 } from './chartRuntime';
-import type { ITradingViewNativeChartType } from '../types';
+import type {
+  ITradingViewNativeCandleLabels,
+  ITradingViewNativeChartType,
+} from '../types';
 
 export type ITradingViewNativeChartSceneFont = 'axis' | 'legend' | 'priceAxis';
 
@@ -196,6 +199,7 @@ export interface IBuildTradingViewNativeChartSceneOptions {
     text: string,
     font: ITradingViewNativeChartSceneFont,
   ) => number;
+  candleLabels: ITradingViewNativeCandleLabels;
   points: IMarketTokenKLineDataPoint[];
   priceAxisWidth?: number;
   viewport: ITradingViewNativeChartRuntimeViewport;
@@ -430,6 +434,7 @@ export function buildTradingViewNativeChartScene({
   height,
   indicatorSeries = [],
   measureTextWidth,
+  candleLabels,
   points,
   priceAxisWidth,
   viewport,
@@ -856,6 +861,7 @@ export function buildTradingViewNativeChartScene({
     legendPointIndex > 0 ? points[legendPointIndex - 1] : undefined;
   const legend = getTradingViewNativeChartLegend(
     crosshairPoint ?? legendPoint,
+    candleLabels,
     chartType,
     previousLegendPoint?.c,
   );

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/TradingViewNativeChart.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/TradingViewNativeChart.tsx
@@ -62,7 +62,10 @@ import {
   getTradingViewNativeWheelZoomScale,
 } from './chartWheel';
 
-import type { ITradingViewNativeChartType } from '../types';
+import type {
+  ITradingViewNativeCandleLabels,
+  ITradingViewNativeChartType,
+} from '../types';
 
 const ONEKEY_WATERMARK_ASSET =
   require('@onekeyhq/components/svg/illus/logo.svg') as
@@ -85,6 +88,7 @@ interface ITradingViewNativeChartProps {
   onVisiblePointRangeChange?: (
     range: ITradingViewNativeVisiblePointRange,
   ) => void;
+  candleLabels: ITradingViewNativeCandleLabels;
   points: IMarketTokenKLineDataPoint[];
   testID?: string;
   viewportRequest?: ITradingViewNativeViewportRequest | null;
@@ -104,6 +108,7 @@ interface IDrawKLineChartOptions {
   chartType: ITradingViewNativeChartType;
   colors: ITradingViewNativeChartSceneColors;
   hasVolume: boolean;
+  candleLabels: ITradingViewNativeCandleLabels;
   indicatorSeries: ITradingViewNativeIndicatorSeries[];
   points: IMarketTokenKLineDataPoint[];
   priceAxisWidth: number;
@@ -283,6 +288,7 @@ function drawKLineChart({
   chartType,
   colors,
   hasVolume,
+  candleLabels,
   indicatorSeries,
   points,
   priceAxisWidth,
@@ -320,6 +326,7 @@ function drawKLineChart({
       context.font = getCanvasFont(font);
       return context.measureText(text).width;
     },
+    candleLabels,
     points,
     priceAxisWidth,
     viewport: runtimeState.viewport,
@@ -344,6 +351,7 @@ export const TradingViewNativeChart = memo(
     onChartWidthChange,
     onViewportRequestApplied,
     onVisiblePointRangeChange,
+    candleLabels,
     points,
     testID,
     viewportRequest,
@@ -455,6 +463,7 @@ export const TradingViewNativeChart = memo(
             up: CHART_UP_COLOR,
           },
           hasVolume,
+          candleLabels,
           indicatorSeries,
           points,
           priceAxisWidth,
@@ -472,6 +481,7 @@ export const TradingViewNativeChart = memo(
         hasVolume,
         indicatorSeries,
         line,
+        candleLabels,
         points,
         priceAxisLabels,
         watermarkImage,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58586](https://onekeyhq.atlassian.net/browse/OK-58586)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Localize TradingViewNative candle open, high, low, and close abbreviations with existing market translation keys.
- Pass translated labels through the shared chart scene to both Web Canvas and Native Skia renderers.
- Add regression coverage for localized labels and renderer propagation.

## Root cause

TradingViewNative built the candle legend labels as hardcoded `O`, `H`, `L`, and `C` strings inside renderer-independent worklet code, so the active app locale could not reach the chart legend.

## User impact

Candle legend abbreviations now follow the active app locale across web/desktop and iOS/Android. Generated translation files remain unchanged.

## Validation

- `yarn jest packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.test.tsx packages/kit/src/components/TradingView/TradingViewNative/utils/chartLegend.test.ts packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.test.ts --runInBand` (32 tests passed)
- `yarn agent:check --profile commit`

Jira: OK-58586

[OK-58586]: https://onekeyhq.atlassian.net/browse/OK-58586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ