### PR TITLE
fix: split mobile TradingView indicator bar OK-57045

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { ReactNode, TouchEvent } from 'react';
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+import { TradingViewNativeIndicatorQuickBar } from './NativeIndicatorControls';
+
+import type { ITradingViewNativeIndicatorState } from './hooks/useNativeIndicatorActiveValues';
+import type { ITradingViewNativeChartControlsConfigData } from '../../types';
+
+jest.mock('@onekeyhq/components', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+
+  type IMockTouchHandler = (event: {
+    nativeEvent: { pageX: number; pageY: number };
+  }) => void;
+
+  function forwardTouchEvent(handler?: IMockTouchHandler) {
+    if (!handler) {
+      return undefined;
+    }
+
+    return (event: TouchEvent<HTMLDivElement>) => {
+      const touch = event.touches[0] ?? event.changedTouches[0];
+      handler({
+        nativeEvent: {
+          pageX: touch?.pageX ?? 0,
+          pageY: touch?.pageY ?? 0,
+        },
+      });
+    };
+  }
+
+  function MockStack({
+    children,
+    testID,
+    width,
+    flex,
+    onTouchStart,
+    onTouchMove,
+    onTouchEnd,
+    onTouchCancel,
+  }: {
+    children?: ReactNode;
+    testID?: string;
+    width?: number | string;
+    flex?: number;
+    onTouchStart?: IMockTouchHandler;
+    onTouchMove?: IMockTouchHandler;
+    onTouchEnd?: IMockTouchHandler;
+    onTouchCancel?: IMockTouchHandler;
+  }) {
+    return React.createElement(
+      'div',
+      {
+        'data-testid': testID,
+        'data-width': width,
+        'data-flex': flex,
+        onTouchStart: forwardTouchEvent(onTouchStart),
+        onTouchMove: forwardTouchEvent(onTouchMove),
+        onTouchEnd: forwardTouchEvent(onTouchEnd),
+        onTouchCancel: forwardTouchEvent(onTouchCancel),
+      },
+      children,
+    );
+  }
+
+  function MockText({ children }: { children?: ReactNode }) {
+    return React.createElement('span', undefined, children);
+  }
+
+  function MockScrollView({
+    children,
+    testID,
+    flex,
+  }: {
+    children?: ReactNode;
+    testID?: string;
+    flex?: number;
+  }) {
+    return React.createElement(
+      'div',
+      {
+        'data-testid': testID,
+        'data-flex': flex,
+        'data-scrollable': 'true',
+      },
+      children,
+    );
+  }
+
+  return {
+    ScrollView: MockScrollView,
+    SizableText: MockText,
+    Stack: MockStack,
+    XStack: MockStack,
+  };
+});
+
+jest.mock(
+  '../../../TradingViewChartControls/indicatorSelector/NativeIndicatorSelector',
+  () => ({
+    IndicatorListDialogContent: () => null,
+    IndicatorPopover: () => null,
+  }),
+);
+
+const nativeChartControlsConfig: ITradingViewNativeChartControlsConfigData = {
+  indicators: [
+    { label: 'MA', value: 'MA', active: true },
+    { label: 'VOL', value: 'VOL', active: true },
+  ],
+  chartTypes: [],
+  activeChartType: 0,
+};
+
+function createNativeIndicatorState(): ITradingViewNativeIndicatorState {
+  const activeIndicatorValues = new Set(['MA', 'VOL']);
+
+  return {
+    activeIndicatorValues,
+    isInitialized: true,
+    getActiveIndicatorValues: () => activeIndicatorValues,
+    updateActiveIndicatorValue: jest.fn(),
+  };
+}
+
+describe('TradingView native indicator quick bar', () => {
+  it('keeps the main indicators fixed and scrolls the sub indicators', () => {
+    render(
+      <TradingViewNativeIndicatorQuickBar
+        nativeChartControlsConfig={nativeChartControlsConfig}
+        nativeIndicatorState={createNativeIndicatorState()}
+        splitSections
+        onIndicatorSelect={jest.fn()}
+      />,
+    );
+
+    const mainSection = screen.getByTestId(
+      'trading-view-native-indicator-quick-bar-main',
+    );
+    const divider = screen.getByTestId(
+      'trading-view-native-indicator-quick-bar-divider',
+    );
+    const subSection = screen.getByTestId(
+      'trading-view-native-indicator-quick-bar-sub',
+    );
+
+    expect(within(mainSection).getByText('MA')).toBeTruthy();
+    expect(within(mainSection).queryByText('VOL')).toBeNull();
+    expect(within(subSection).getByText('VOL')).toBeTruthy();
+    expect(within(subSection).queryByText('MA')).toBeNull();
+    expect(mainSection.getAttribute('data-width')).toBe('184');
+    expect(mainSection.getAttribute('data-scrollable')).toBeNull();
+    expect(subSection.getAttribute('data-flex')).toBe('1');
+    expect(subSection.getAttribute('data-scrollable')).toBe('true');
+    expect(divider.parentElement).toBe(mainSection.parentElement);
+    expect(divider.parentElement).toBe(subSection.parentElement);
+  });
+
+  it('bridges vertical movement without rerouting a horizontal gesture', () => {
+    const onTouchScroll = jest.fn();
+    render(
+      <TradingViewNativeIndicatorQuickBar
+        nativeChartControlsConfig={nativeChartControlsConfig}
+        nativeIndicatorState={createNativeIndicatorState()}
+        splitSections
+        onIndicatorSelect={jest.fn()}
+        onTouchScroll={onTouchScroll}
+      />,
+    );
+
+    const quickBar = screen.getByTestId(
+      'trading-view-native-indicator-quick-bar',
+    );
+    fireEvent.touchStart(quickBar, {
+      touches: [{ pageX: 100, pageY: 100 }],
+    });
+    fireEvent.touchMove(quickBar, {
+      touches: [{ pageX: 102, pageY: 90 }],
+    });
+    fireEvent.touchMove(quickBar, {
+      touches: [{ pageX: 103, pageY: 82 }],
+    });
+    fireEvent.touchEnd(quickBar, { changedTouches: [] });
+
+    expect(onTouchScroll).toHaveBeenNthCalledWith(1, 10);
+    expect(onTouchScroll).toHaveBeenNthCalledWith(2, 8);
+
+    fireEvent.touchStart(quickBar, {
+      touches: [{ pageX: 100, pageY: 100 }],
+    });
+    fireEvent.touchMove(quickBar, {
+      touches: [{ pageX: 110, pageY: 102 }],
+    });
+    fireEvent.touchMove(quickBar, {
+      touches: [{ pageX: 112, pageY: 80 }],
+    });
+
+    expect(onTouchScroll).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.tsx
@@ -1,6 +1,7 @@
-import { memo } from 'react';
+import { memo, useCallback, useRef } from 'react';
 
 import { ScrollView, SizableText, Stack, XStack } from '@onekeyhq/components';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { useNativeIndicatorControls } from './hooks/useNativeIndicatorActiveValues';
 
@@ -9,8 +10,18 @@ import type {
   ITradingViewIndicatorOption,
   ITradingViewNativeChartControlsConfigData,
 } from '../../types';
+import type { GestureResponderEvent } from 'react-native';
 
 export const TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT = 31;
+const TRADING_VIEW_NATIVE_MAIN_INDICATOR_QUICK_BAR_WIDTH = 184;
+const INDICATOR_QUICK_BAR_VERTICAL_PAN_THRESHOLD = 4;
+
+type IIndicatorQuickBarTouchState = {
+  direction: 'pending' | 'horizontal' | 'vertical';
+  previousY: number;
+  startX: number;
+  startY: number;
+};
 
 function buildIndicatorQuickBarItemTestID(value: string): string {
   return `trading-view-native-indicator-quick-bar-item-${value
@@ -72,20 +83,101 @@ function IndicatorQuickBarItem({
   );
 }
 
+function IndicatorQuickBarItems({
+  indicators,
+  activeIndicatorValues,
+  canToggleIndicatorOn,
+  handleIndicatorPress,
+  onControlInteraction,
+}: {
+  indicators: ITradingViewIndicatorOption[];
+  activeIndicatorValues: ReadonlySet<string>;
+  canToggleIndicatorOn: (indicatorValue: string) => boolean;
+  handleIndicatorPress: (indicator: ITradingViewIndicatorOption) => void;
+  onControlInteraction?: () => void;
+}) {
+  return (
+    <XStack
+      h={TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT}
+      px="$5"
+      gap="$4"
+      alignItems="center"
+      flexShrink={0}
+    >
+      {indicators.map((indicator) => (
+        <IndicatorQuickBarItem
+          key={indicator.value}
+          indicator={indicator}
+          isActive={activeIndicatorValues.has(indicator.value)}
+          isDisabled={!canToggleIndicatorOn(indicator.value)}
+          onPress={() => {
+            onControlInteraction?.();
+            handleIndicatorPress(indicator);
+          }}
+        />
+      ))}
+    </XStack>
+  );
+}
+
 export const TradingViewNativeIndicatorQuickBar = memo(
   ({
     nativeChartControlsConfig,
     nativeIndicatorState,
     maxSubIndicatorCount,
+    splitSections = false,
     onIndicatorSelect,
     onControlInteraction,
+    onTouchScroll,
   }: {
     nativeChartControlsConfig: ITradingViewNativeChartControlsConfigData | null;
     nativeIndicatorState: ITradingViewNativeIndicatorState;
     maxSubIndicatorCount?: number;
+    splitSections?: boolean;
     onIndicatorSelect: (indicatorName: string, desiredActive: boolean) => void;
     onControlInteraction?: () => void;
+    onTouchScroll?: (deltaY: number) => void;
   }) => {
+    const touchStateRef = useRef<IIndicatorQuickBarTouchState | null>(null);
+    const handleTouchStart = useCallback((event: GestureResponderEvent) => {
+      const { pageX, pageY } = event.nativeEvent;
+      touchStateRef.current = {
+        direction: 'pending',
+        previousY: pageY,
+        startX: pageX,
+        startY: pageY,
+      };
+    }, []);
+    const handleTouchMove = useCallback(
+      (event: GestureResponderEvent) => {
+        const touchState = touchStateRef.current;
+        if (!touchState || !onTouchScroll) {
+          return;
+        }
+
+        const { pageX, pageY } = event.nativeEvent;
+        if (touchState.direction === 'pending') {
+          const absDx = Math.abs(pageX - touchState.startX);
+          const absDy = Math.abs(pageY - touchState.startY);
+          if (
+            Math.max(absDx, absDy) <= INDICATOR_QUICK_BAR_VERTICAL_PAN_THRESHOLD
+          ) {
+            return;
+          }
+          touchState.direction = absDy > absDx ? 'vertical' : 'horizontal';
+        }
+
+        if (touchState.direction === 'vertical') {
+          onTouchScroll(touchState.previousY - pageY);
+          touchState.previousY = pageY;
+        }
+      },
+      [onTouchScroll],
+    );
+    const handleTouchEnd = useCallback(() => {
+      touchStateRef.current = null;
+    }, []);
+
     const {
       activeIndicatorValues,
       mainIndicators,
@@ -103,6 +195,9 @@ export const TradingViewNativeIndicatorQuickBar = memo(
     if (!hasVisibleIndicators) {
       return null;
     }
+
+    const shouldSplitSections =
+      splitSections && mainIndicators.length > 0 && subIndicators.length > 0;
 
     const quickBarContent = (
       <XStack
@@ -147,10 +242,67 @@ export const TradingViewNativeIndicatorQuickBar = memo(
         h={TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT}
         bg="$bgApp"
         zIndex={3}
+        onTouchStart={onTouchScroll ? handleTouchStart : undefined}
+        onTouchMove={onTouchScroll ? handleTouchMove : undefined}
+        onTouchEnd={onTouchScroll ? handleTouchEnd : undefined}
+        onTouchCancel={onTouchScroll ? handleTouchEnd : undefined}
       >
-        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-          {quickBarContent}
-        </ScrollView>
+        {shouldSplitSections ? (
+          <XStack
+            h={TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT}
+            width="100%"
+            alignItems="center"
+          >
+            <Stack
+              testID="trading-view-native-indicator-quick-bar-main"
+              width={TRADING_VIEW_NATIVE_MAIN_INDICATOR_QUICK_BAR_WIDTH}
+              h={TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT}
+              flexShrink={0}
+              overflow="hidden"
+            >
+              <IndicatorQuickBarItems
+                indicators={mainIndicators}
+                activeIndicatorValues={activeIndicatorValues}
+                canToggleIndicatorOn={canToggleIndicatorOn}
+                handleIndicatorPress={handleIndicatorPress}
+                onControlInteraction={onControlInteraction}
+              />
+            </Stack>
+            <Stack
+              testID="trading-view-native-indicator-quick-bar-divider"
+              h="$4"
+              w="$px"
+              flexShrink={0}
+              bg="$borderSubdued"
+              pointerEvents="none"
+            />
+            <ScrollView
+              testID="trading-view-native-indicator-quick-bar-sub"
+              horizontal
+              flex={1}
+              flexBasis={0}
+              minWidth={0}
+              showsHorizontalScrollIndicator={false}
+              directionalLockEnabled={platformEnv.isNativeIOS}
+            >
+              <IndicatorQuickBarItems
+                indicators={subIndicators}
+                activeIndicatorValues={activeIndicatorValues}
+                canToggleIndicatorOn={canToggleIndicatorOn}
+                handleIndicatorPress={handleIndicatorPress}
+                onControlInteraction={onControlInteraction}
+              />
+            </ScrollView>
+          </XStack>
+        ) : (
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            directionalLockEnabled={platformEnv.isNativeIOS}
+          >
+            {quickBarContent}
+          </ScrollView>
+        )}
       </Stack>
     );
   },

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
@@ -689,6 +689,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
         nativeChartControlsConfig={nativeChartControlsConfig}
         nativeIndicatorState={nativeIndicatorState}
         maxSubIndicatorCount={maxNativeSubIndicatorCount}
+        splitSections={nativeControlsLayoutMode === 'mobile'}
         onIndicatorSelect={handleNativeIndicatorSelect}
         onControlInteraction={handleNativeControlInteraction}
       />
@@ -700,6 +701,7 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     maxNativeSubIndicatorCount,
     nativeChartControlsConfig,
     nativeIndicatorState,
+    nativeControlsLayoutMode,
     showNativeIndicatorQuickBar,
   ]);
 

--- a/packages/kit/src/hooks/useMobileTabTouchScrollBridge.ts
+++ b/packages/kit/src/hooks/useMobileTabTouchScrollBridge.ts
@@ -16,22 +16,6 @@ export function useMobileTabTouchScrollBridge() {
   const scrollYCurrent = tabsContext?.scrollYCurrent;
   const tabContentInset = tabsContext?.contentInset ?? 0;
   const scrollDelta = useSharedValue(0);
-  const targetScrollY = useSharedValue(0);
-
-  useAnimatedReaction(
-    () => targetScrollY.value,
-    (currentValue) => {
-      if (!refMap || !focusedTabShared) {
-        return;
-      }
-
-      const ref = refMap[focusedTabShared.value];
-      if (ref) {
-        scrollTo(ref, 0, Math.max(0, currentValue - tabContentInset), false);
-      }
-    },
-    [refMap, focusedTabShared, tabContentInset],
-  );
 
   useAnimatedReaction(
     () => scrollDelta.value,
@@ -40,16 +24,19 @@ export function useMobileTabTouchScrollBridge() {
         delta === 0 ||
         delta === prevDelta ||
         !scrollYCurrent ||
-        !targetScrollY
+        !refMap ||
+        !focusedTabShared
       ) {
         return;
       }
 
-      const currentScrollY = Math.max(scrollYCurrent.value, tabContentInset);
-      targetScrollY.value = currentScrollY + delta;
+      const ref = refMap[focusedTabShared.value];
+      if (ref) {
+        scrollTo(ref, 0, scrollYCurrent.value + delta - tabContentInset, false);
+      }
       scrollDelta.value = 0;
     },
-    [scrollYCurrent, targetScrollY, tabContentInset],
+    [focusedTabShared, refMap, scrollYCurrent, scrollDelta, tabContentInset],
   );
 
   return useCallback(

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { ComponentProps, ReactNode } from 'react';
 
 import { noop } from 'lodash';
@@ -26,6 +34,7 @@ import {
   TRADING_VIEW_NATIVE_CHART_CONTROLS_HEIGHT,
   TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT,
 } from '@onekeyhq/kit/src/components/TradingView/TradingViewV2/components/TradingViewV2ChartControls';
+import { useMobileTabTouchScrollBridge } from '@onekeyhq/kit/src/hooks/useMobileTabTouchScrollBridge';
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   EAppEventBusNames,
@@ -154,12 +163,39 @@ const MARKET_DETAIL_TRADING_VIEW_DEFAULT_SUB_INDICATOR_COUNT = 1;
 const MARKET_DETAIL_MOBILE_TRADING_VIEW_MAX_SUB_INDICATOR_COUNT = 4;
 const MARKET_DETAIL_MOBILE_TRADING_VIEW_SUB_INDICATOR_HEIGHT = 56;
 const MARKET_DETAIL_MOBILE_TRADING_VIEW_BASE_HEIGHT_RATIO = 0.58;
+const MARKET_DETAIL_INDICATOR_QUICK_BAR_VERTICAL_SCROLL_SCALE = 1.2;
 
 function normalizeTradingViewSubIndicatorCount(count: number) {
   if (!Number.isFinite(count)) {
     return 0;
   }
   return Math.max(0, Math.floor(count));
+}
+
+function MobileIndicatorQuickBar({
+  children,
+  disabled,
+}: {
+  children: ReactNode;
+  disabled: boolean;
+}) {
+  const handleTouchScroll = useMobileTabTouchScrollBridge();
+  const handleIndicatorQuickBarTouchScroll = useCallback(
+    (deltaY: number) => {
+      handleTouchScroll(
+        deltaY * MARKET_DETAIL_INDICATOR_QUICK_BAR_VERTICAL_SCROLL_SCALE,
+      );
+    },
+    [handleTouchScroll],
+  );
+
+  if (isValidElement<{ onTouchScroll?: (deltaY: number) => void }>(children)) {
+    return cloneElement(children, {
+      onTouchScroll: disabled ? undefined : handleIndicatorQuickBarTouchScroll,
+    });
+  }
+
+  return children;
 }
 
 function MobileMarketTradingView({
@@ -197,6 +233,7 @@ function MobileMarketTradingView({
       tokenSymbol={tokenSymbol}
       dataSource={dataSource}
       pageWidth={pageWidth}
+      nativeControlsLayoutMode="mobile"
       onNativeIndicatorQuickBarChange={onNativeIndicatorQuickBarChange}
       onNativeSubIndicatorCountChange={onNativeSubIndicatorCountChange}
       maxNativeSubIndicatorCount={
@@ -613,7 +650,13 @@ export function MobileLayout({
               })()}
             </Stack>
           </HeaderScrollGestureWrapper>
-          {nativeIndicatorQuickBar}
+          {nativeIndicatorQuickBar && platformEnv.isNative ? (
+            <MobileIndicatorQuickBar disabled={isTradingViewScrollLocked}>
+              {nativeIndicatorQuickBar}
+            </MobileIndicatorQuickBar>
+          ) : (
+            nativeIndicatorQuickBar
+          )}
           {platformEnv.isNativeIOS ? (
             <View
               style={{


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-57045](https://onekeyhq.atlassian.net/browse/OK-57045)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- split the mobile TradingView indicator quick bar into a fixed 184px main-indicator section and an independently scrollable sub-indicator section
- keep the center divider fixed while preserving the existing single-scroll layout for non-mobile consumers
- forward vertical quick-bar gestures to the Market Detail collapsible page without rerouting horizontal indicator scrolling

## Root cause

The mobile quick bar was rendered as one horizontal `ScrollView`. After splitting the bar, the right-side horizontal scroller still consumed vertical touches, and the prior vertical-scroll bridge was not present on the current `x` lineage.

## User impact

Users can scroll the Market Detail page vertically when starting the gesture over the indicator bar, while horizontal gestures continue to scroll only the right-side sub indicators. The four left-side main indicators and divider remain fixed.

## Validation

- `yarn jest packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.test.tsx --runInBand --verbose`
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- verified on the iOS simulator in the real Market Detail screen that a vertical swipe over the right indicator section moves the outer page

[OK-57045]: https://onekeyhq.atlassian.net/browse/OK-57045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ