### PR TITLE
fix: annotate owned btc protocol outputs in psbt signing

### DIFF
--- a/packages/kit-bg/src/vaults/impls/btc/KeyringHardwareBtcBase.ts
+++ b/packages/kit-bg/src/vaults/impls/btc/KeyringHardwareBtcBase.ts
@@ -36,6 +36,10 @@ import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
 
 import { KeyringHardwareBase } from '../../base/KeyringHardwareBase';
 
+import {
+  type IPsbtTaprootAddressDerivation,
+  resolvePsbtTaprootOwnedOutputs,
+} from './resolvePsbtTaprootOwnedOutputs';
 import { appendClaimedAddressPaths } from './sdkBtc/findAddressUtils';
 
 import type VaultBtc from './Vault';
@@ -231,6 +235,10 @@ export abstract class KeyringHardwareBtcBase extends KeyringHardwareBase {
       fallbackPubkeyHex: string;
     }) => string;
     resolvePathByAddress: (address: string | undefined) => string;
+    resolveOwnedAddressDerivation: (params: {
+      address: string | undefined;
+      fallbackPubkeyHex: string | undefined;
+    }) => IPsbtTaprootAddressDerivation | undefined;
   }> {
     const vault = this.vault as VaultBtc;
     const { btcExtraInfo } = await vault.prepareBtcSignExtraInfo({
@@ -285,7 +293,49 @@ export abstract class KeyringHardwareBtcBase extends KeyringHardwareBase {
     const resolvePathByAddress = (address: string | undefined): string =>
       (address ? addressToPath[address]?.fullPath : undefined) ?? fallbackPath;
 
-    return { resolvePubkeyHexByAddress, resolvePathByAddress };
+    const resolveOwnedAddressDerivation = ({
+      address,
+      fallbackPubkeyHex,
+    }: {
+      address: string | undefined;
+      fallbackPubkeyHex: string | undefined;
+    }): IPsbtTaprootAddressDerivation | undefined => {
+      if (!address) {
+        return undefined;
+      }
+
+      if (address === dbAccount.address) {
+        if (!fallbackPubkeyHex) {
+          return undefined;
+        }
+
+        return {
+          fullPath: fallbackPath,
+          pubkey: fallbackPubkeyHex,
+        };
+      }
+
+      const addressPath = addressToPath[address];
+      if (!addressPath) {
+        return undefined;
+      }
+
+      const derivedPubkey = derivedPublicKeys[addressPath.relPath];
+      if (!derivedPubkey) {
+        return undefined;
+      }
+
+      return {
+        fullPath: addressPath.fullPath,
+        pubkey: derivedPubkey,
+      };
+    };
+
+    return {
+      resolvePubkeyHexByAddress,
+      resolvePathByAddress,
+      resolveOwnedAddressDerivation,
+    };
   }
 
   async signPsbt(params: ISignTransactionParams): Promise<ISignedTxPro> {
@@ -339,16 +389,19 @@ export abstract class KeyringHardwareBtcBase extends KeyringHardwareBase {
     // spends from the account's main address. Inputs from fresh or claimed
     // (find-address) addresses would otherwise be fed the wrong derivation
     // path and the device would produce an invalid signature.
-    const { resolvePubkeyHexByAddress, resolvePathByAddress } =
-      await this.resolvePsbtAddressDerivation({
-        unsignedTx,
-        dbAccount,
-        btcNetwork,
-        addresses: [
-          ...inputsToSign.map((input) => input.address),
-          ...psbt.txOutputs.map((output) => output.address),
-        ],
-      });
+    const {
+      resolvePubkeyHexByAddress,
+      resolvePathByAddress,
+      resolveOwnedAddressDerivation,
+    } = await this.resolvePsbtAddressDerivation({
+      unsignedTx,
+      dbAccount,
+      btcNetwork,
+      addresses: [
+        ...inputsToSign.map((input) => input.address),
+        ...psbt.txOutputs.map((output) => output.address),
+      ],
+    });
 
     const resolveTapBip32Derivation = ({
       address,
@@ -381,26 +434,33 @@ export abstract class KeyringHardwareBtcBase extends KeyringHardwareBase {
       });
     }
 
-    for (let i = 0, len = psbt.txOutputs.length; i < len; i += 1) {
-      const output = psbt.txOutputs[i];
-      try {
-        // If the address is the change address
-        if (output.address === dbAccount.address && len > 1) {
-          const outputPubkeyHex = resolvePubkeyHexByAddress({
-            address: output.address,
-            fallbackPubkeyHex: checkIsDefined(dbAccount.pub),
-          });
-          psbt.updateOutput(i, {
-            tapInternalKey: Buffer.from(outputPubkeyHex, 'hex').subarray(1, 33),
-            tapBip32Derivation: resolveTapBip32Derivation({
-              address: output.address,
-              fallbackPubkeyHex: checkIsDefined(dbAccount.pub),
-            }),
-          });
-        }
-      } catch (err) {
-        //
-      }
+    const ownedOutputs = resolvePsbtTaprootOwnedOutputs({
+      outputAddresses: psbt.txOutputs.map((output) => output.address),
+      encodedOutputs: (unsignedTx.encodedTx as IEncodedTxBtc).outputs,
+      accountAddress: dbAccount.address,
+      resolveAddressDerivation: (address) =>
+        resolveOwnedAddressDerivation({
+          address,
+          fallbackPubkeyHex: dbAccount.pub,
+        }),
+    });
+
+    for (const ownedOutput of ownedOutputs) {
+      const taprootPubkey = Buffer.from(ownedOutput.pubkey, 'hex').subarray(
+        1,
+        33,
+      );
+      psbt.updateOutput(ownedOutput.index, {
+        tapInternalKey: taprootPubkey,
+        tapBip32Derivation: [
+          {
+            masterFingerprint: Buffer.from(fingerprint, 'hex'),
+            pubkey: taprootPubkey,
+            path: ownedOutput.fullPath,
+            leafHashes: [],
+          },
+        ],
+      });
     }
 
     const response = await convertDeviceResponse(() =>

--- a/packages/kit-bg/src/vaults/impls/btc/resolvePsbtTaprootOwnedOutputs.test.ts
+++ b/packages/kit-bg/src/vaults/impls/btc/resolvePsbtTaprootOwnedOutputs.test.ts
@@ -1,0 +1,132 @@
+import { resolvePsbtTaprootOwnedOutputs } from './resolvePsbtTaprootOwnedOutputs';
+
+const accountAddress = 'bc1pselected';
+const accountDerivation = {
+  fullPath: "m/86'/0'/0'/0/7",
+  pubkey: '033333333333333333333333333333333333333333333333333333333333333333',
+};
+const inscriptionDerivation = {
+  fullPath: "m/86'/0'/0'/0/12",
+  pubkey: '032222222222222222222222222222222222222222222222222222222222222222',
+};
+
+describe('resolvePsbtTaprootOwnedOutputs', () => {
+  it('resolves a wallet-owned inscription output at a different derived address', () => {
+    const resolveAddressDerivation = jest.fn((address: string) =>
+      address === 'bc1pownedinscription' ? inscriptionDerivation : undefined,
+    );
+
+    const result = resolvePsbtTaprootOwnedOutputs({
+      outputAddresses: ['bc1pexternal', 'bc1pownedinscription'],
+      encodedOutputs: [
+        { address: 'bc1pexternal', value: '1000' },
+        {
+          address: 'bc1pownedinscription',
+          value: '546',
+          payload: { isInscriptionStructure: true },
+        },
+      ],
+      accountAddress,
+      resolveAddressDerivation,
+    });
+
+    expect(result).toEqual([
+      {
+        index: 1,
+        ...inscriptionDerivation,
+      },
+    ]);
+    expect(resolveAddressDerivation).toHaveBeenCalledTimes(1);
+    expect(resolveAddressDerivation).toHaveBeenCalledWith(
+      'bc1pownedinscription',
+    );
+  });
+
+  it('preserves the selected-account output behavior without a payload hint', () => {
+    const resolveAddressDerivation = jest.fn(() => accountDerivation);
+
+    const result = resolvePsbtTaprootOwnedOutputs({
+      outputAddresses: ['bc1pexternal', accountAddress],
+      encodedOutputs: [
+        { address: 'bc1pexternal', value: '1000' },
+        { address: accountAddress, value: '546' },
+      ],
+      accountAddress,
+      resolveAddressDerivation,
+    });
+
+    expect(result).toEqual([{ index: 1, ...accountDerivation }]);
+  });
+
+  it('rejects a hinted output that has no wallet derivation', () => {
+    const resolveAddressDerivation = jest.fn(() => undefined);
+
+    const result = resolvePsbtTaprootOwnedOutputs({
+      outputAddresses: ['bc1pexternal', 'bc1pnotowned'],
+      encodedOutputs: [
+        { address: 'bc1pexternal', value: '1000' },
+        {
+          address: 'bc1pnotowned',
+          value: '546',
+          payload: { isInscriptionStructure: true },
+        },
+      ],
+      accountAddress,
+      resolveAddressDerivation,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('rejects a wallet-owned output without an ownership hint', () => {
+    const resolveAddressDerivation = jest.fn(() => inscriptionDerivation);
+
+    const result = resolvePsbtTaprootOwnedOutputs({
+      outputAddresses: ['bc1pexternal', 'bc1powned'],
+      encodedOutputs: [
+        { address: 'bc1pexternal', value: '1000' },
+        { address: 'bc1powned', value: '546' },
+      ],
+      accountAddress,
+      resolveAddressDerivation,
+    });
+
+    expect(result).toEqual([]);
+    expect(resolveAddressDerivation).not.toHaveBeenCalled();
+  });
+
+  it('rejects a payload hint whose encoded address does not match the PSBT', () => {
+    const resolveAddressDerivation = jest.fn(() => inscriptionDerivation);
+
+    const result = resolvePsbtTaprootOwnedOutputs({
+      outputAddresses: ['bc1pexternal', 'bc1pactual'],
+      encodedOutputs: [
+        { address: 'bc1pexternal', value: '1000' },
+        {
+          address: 'bc1pdifferent',
+          value: '546',
+          payload: { isInscriptionStructure: true },
+        },
+      ],
+      accountAddress,
+      resolveAddressDerivation,
+    });
+
+    expect(result).toEqual([]);
+    expect(resolveAddressDerivation).not.toHaveBeenCalled();
+  });
+
+  it('does not annotate single-output transactions', () => {
+    const resolveAddressDerivation = jest.fn(() => accountDerivation);
+
+    const result = resolvePsbtTaprootOwnedOutputs({
+      outputAddresses: [accountAddress],
+      encodedOutputs: [{ address: accountAddress, value: '546' }],
+      accountAddress,
+      resolveAddressDerivation,
+    });
+
+    expect(result).toEqual([]);
+    expect(resolveAddressDerivation).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kit-bg/src/vaults/impls/btc/resolvePsbtTaprootOwnedOutputs.ts
+++ b/packages/kit-bg/src/vaults/impls/btc/resolvePsbtTaprootOwnedOutputs.ts
@@ -1,0 +1,54 @@
+import type { IBtcOutput } from '@onekeyhq/core/src/chains/btc/types';
+
+export type IPsbtTaprootAddressDerivation = {
+  fullPath: string;
+  pubkey: string;
+};
+
+export type IResolvedPsbtTaprootOwnedOutput = IPsbtTaprootAddressDerivation & {
+  index: number;
+};
+
+export function resolvePsbtTaprootOwnedOutputs({
+  outputAddresses,
+  encodedOutputs,
+  accountAddress,
+  resolveAddressDerivation,
+}: {
+  outputAddresses: Array<string | undefined>;
+  encodedOutputs: IBtcOutput[];
+  accountAddress: string;
+  resolveAddressDerivation: (
+    address: string,
+  ) => IPsbtTaprootAddressDerivation | undefined;
+}): IResolvedPsbtTaprootOwnedOutput[] {
+  if (outputAddresses.length <= 1) {
+    return [];
+  }
+
+  const resolvedOutputs: IResolvedPsbtTaprootOwnedOutput[] = [];
+
+  outputAddresses.forEach((outputAddress, index) => {
+    if (!outputAddress) {
+      return;
+    }
+
+    const encodedOutput = encodedOutputs[index];
+    const isSelectedAccountOutput = outputAddress === accountAddress;
+    const hasOwnedOutputHint =
+      encodedOutput?.address === outputAddress &&
+      (encodedOutput.payload?.isChange ||
+        encodedOutput.payload?.isInscriptionStructure);
+
+    if (!isSelectedAccountOutput && !hasOwnedOutputHint) {
+      return;
+    }
+
+    const derivation = resolveAddressDerivation(outputAddress);
+    if (derivation) {
+      resolvedOutputs.push({ index, ...derivation });
+    }
+  });
+
+  return resolvedOutputs;
+}


### PR DESCRIPTION
## Summary
- annotate wallet-owned Taproot protocol outputs with the correct derivation metadata before hardware signing
- preserve selected-account change handling while supporting outputs returned to a different derived wallet address
- reject unowned, unhinted, or encoded/PSBT-mismatched outputs

## Intent & Context
Bitcoin protocol transactions can return an inscription output to a Taproot address owned by the same wallet but different from the currently selected account address. Without output derivation metadata, the hardware signing UI can misclassify that output and present a misleading fee or OP_RETURN amount. This replaces #11171 on the current `x` branch and closes #9757.

## Root Cause
`KeyringHardwareBtcBase.signPsbt` only added `tapInternalKey` and `tapBip32Derivation` when a PSBT output address exactly matched `dbAccount.address`. The current codebase already resolves paths and pubkeys for wallet-owned input addresses, but the output loop did not use that resolver for protocol outputs sent back to another owned derivation.

## Design Decisions
- reuse the current shared PSBT address resolver instead of porting the obsolete standalone resolver from #11171
- require a change/inscription hint, an exact encoded-output/PSBT address match, and a resolved wallet derivation before annotating non-selected outputs
- require an actual derived pubkey/path pair for non-selected outputs; do not fall back to account-level metadata
- preserve the existing multi-output and selected-account behavior
- allow annotation failures to surface instead of silently continuing with potentially misleading device review metadata

## Changes Detail
- `KeyringHardwareBtcBase.ts`: expose verified owned-address derivations and apply them to eligible Taproot outputs
- `resolvePsbtTaprootOwnedOutputs.ts`: select only safely attributable output derivations
- `resolvePsbtTaprootOwnedOutputs.test.ts`: cover derived inscription outputs and rejection guards

## Risk Assessment
- **Risk Level**: High
- **Affected Platforms**: Extension, Mobile, Desktop, Web
- **Runtime Scope**: background runtime on iOS, Android, and extension; single runtime on desktop and web
- **Risk Areas**: PSBT output metadata shown during hardware-wallet transaction review

## Test plan
- [x] `node node_modules/jest/bin/jest.js packages/kit-bg/src/vaults/impls/btc/resolvePsbtTaprootOwnedOutputs.test.ts --runInBand` (6 passed)
- [x] `yarn agent:check --profile commit`
- [x] `yarn agent:check --profile pr`
- [x] `git diff --check`

Closes #9757
Replaces #11171