### PR TITLE
fix: load sparse market kline history OK-58202

### DIFF
--- a/.skillshare/skills/1k-tradingview-communication/SKILL.md
+++ b/.skillshare/skills/1k-tradingview-communication/SKILL.md
@@ -77,6 +77,7 @@ Chart requests history with:
     resolution,
     from,
     to,
+    countBack,
     firstDataRequest,
   },
 }

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/klineDataHandler.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/klineDataHandler.test.ts
@@ -33,8 +33,10 @@ const mockFetchTradingViewV2DataWithSlicing =
 
 function buildHistoryMessage({
   firstDataRequest,
+  countBack = 300,
 }: {
   firstDataRequest: boolean;
+  countBack?: number;
 }): ICustomReceiveHandlerData['data'] {
   return {
     scope: '$private',
@@ -45,6 +47,7 @@ function buildHistoryMessage({
       resolution: '1',
       from: 1000,
       to: 2000,
+      countBack,
       firstDataRequest,
     },
   };
@@ -91,6 +94,9 @@ describe('handleKLineDataRequest', () => {
 
     expect(context.onKLineLoadError).not.toHaveBeenCalled();
     expect(context.onKLineDataReady).not.toHaveBeenCalled();
+    expect(mockFetchTradingViewV2DataWithSlicing).toHaveBeenCalledWith(
+      expect.objectContaining({ countBack: 300 }),
+    );
     expect(sendMessageViaInjectedScript).toHaveBeenCalledWith({
       type: 'kLineData',
       payload: expect.objectContaining({

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/klineDataHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/klineDataHandler.ts
@@ -284,6 +284,13 @@ export async function handleKLineDataRequest({
     const resolution = safeData.resolution as string;
     const from = safeData.from as number;
     const to = safeData.to as number;
+    const rawCountBack = safeData.countBack;
+    const countBack =
+      typeof rawCountBack === 'number' &&
+      Number.isFinite(rawCountBack) &&
+      rawCountBack > 0
+        ? Math.floor(rawCountBack)
+        : undefined;
     const isFirstDataRequest = safeData.firstDataRequest === true;
 
     if (context.onCurrentKLineResolutionChange) {
@@ -317,6 +324,7 @@ export async function handleKLineDataRequest({
             interval: resolution,
             timeFrom: from,
             timeTo: to,
+            countBack,
             autoHandleError: shouldSuppressKLineError ? false : undefined,
             kLineDataFallback: context.kLineDataFallback,
             primaryKLineDataUnavailable: context.primaryKLineDataUnavailable,

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/types.ts
@@ -13,6 +13,7 @@ export interface IKLineDataRequest {
   resolution: string;
   from: number;
   to: number;
+  countBack?: number;
   firstDataRequest: boolean;
 }
 

--- a/packages/kit/src/components/TradingView/TradingViewV2/types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/types.ts
@@ -3,6 +3,7 @@ export interface ITradingViewHistoryData {
   resolution: string;
   from: number;
   to: number;
+  countBack?: number;
   firstDataRequest: boolean;
 }
 

--- a/packages/kit/src/components/TradingView/utils/fetchMarketKLineData.test.ts
+++ b/packages/kit/src/components/TradingView/utils/fetchMarketKLineData.test.ts
@@ -3,7 +3,10 @@ import type {
   IMarketTokenKLineResponse,
 } from '@onekeyhq/shared/types/marketV2';
 
-import { fetchMarketKLineData } from './fetchMarketKLineData';
+import {
+  fetchMarketKLineData,
+  fetchMarketKLineDataWithSlicing,
+} from './fetchMarketKLineData';
 
 type IFetchMarketTokenKline = (params: {
   tokenAddress: string;
@@ -30,6 +33,17 @@ function asRuntimeKLineResponse(points: unknown[]): IMarketTokenKLineResponse {
   return {
     points: points as IMarketTokenKLineDataPoint[],
     total: points.length,
+  };
+}
+
+function buildKLinePoint(t: number): IMarketTokenKLineDataPoint {
+  return {
+    o: t,
+    h: t,
+    l: t,
+    c: t,
+    v: 1,
+    t,
   };
 }
 
@@ -154,5 +168,50 @@ describe('fetchMarketKLineData', () => {
       total: 1,
     });
     expect(onFallbackKLineData).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('fetchMarketKLineDataWithSlicing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('backfills points before timeFrom to satisfy countBack', async () => {
+    mockFetchMarketTokenKline
+      .mockResolvedValueOnce(
+        asRuntimeKLineResponse([buildKLinePoint(700), buildKLinePoint(900)]),
+      )
+      .mockResolvedValueOnce(asRuntimeKLineResponse([buildKLinePoint(1020)]));
+
+    const result = await fetchMarketKLineDataWithSlicing({
+      tokenAddress: '0x123',
+      networkId: 'evm--1',
+      interval: '1m',
+      timeFrom: 1000,
+      timeTo: 1060,
+      countBack: 3,
+    });
+
+    expect(result?.points.map((point) => point.t)).toEqual([700, 900, 1020]);
+    expect(result?.total).toBe(3);
+  });
+
+  it('keeps the original time range when countBack is unavailable', async () => {
+    mockFetchMarketTokenKline
+      .mockResolvedValueOnce(
+        asRuntimeKLineResponse([buildKLinePoint(700), buildKLinePoint(900)]),
+      )
+      .mockResolvedValueOnce(asRuntimeKLineResponse([buildKLinePoint(1020)]));
+
+    const result = await fetchMarketKLineDataWithSlicing({
+      tokenAddress: '0x123',
+      networkId: 'evm--1',
+      interval: '1m',
+      timeFrom: 1000,
+      timeTo: 1060,
+    });
+
+    expect(result?.points.map((point) => point.t)).toEqual([1020]);
+    expect(result?.total).toBe(1);
   });
 });

--- a/packages/kit/src/components/TradingView/utils/fetchMarketKLineData.ts
+++ b/packages/kit/src/components/TradingView/utils/fetchMarketKLineData.ts
@@ -52,6 +52,7 @@ export interface IFetchMarketKLineDataParams {
   interval: string;
   timeFrom: number;
   timeTo: number;
+  countBack?: number;
   autoHandleError?: boolean;
   kLineDataFallback?: IMarketKLineDataFallback;
   onPointType?: (pointType: IMarketKLinePointType) => void;
@@ -64,20 +65,26 @@ function normalizeKLinePoints({
   points,
   timeFrom = Number.NEGATIVE_INFINITY,
   timeTo = Number.POSITIVE_INFINITY,
+  countBack,
 }: {
   points: IMarketTokenKLineDataPoint[];
   timeFrom?: number;
   timeTo?: number;
+  countBack?: number;
 }): {
   pointType: IMarketKLinePointType;
   points: IMarketTokenKLineDataPoint[];
 } {
+  const normalizedCountBack =
+    typeof countBack === 'number' && Number.isFinite(countBack) && countBack > 0
+      ? Math.floor(countBack)
+      : undefined;
   const pointsByTimestamp = new Map<number, INormalizedKLineValues>();
 
   for (const point of points) {
     const normalizedValues = getNormalizedKLineValues({
       point,
-      timeFrom,
+      timeFrom: normalizedCountBack ? Number.NEGATIVE_INFINITY : timeFrom,
       timeTo,
     });
     if (normalizedValues) {
@@ -85,9 +92,25 @@ function normalizeKLinePoints({
     }
   }
 
-  const normalizedValues = Array.from(pointsByTimestamp.values()).toSorted(
+  let normalizedValues = Array.from(pointsByTimestamp.values()).toSorted(
     (a, b) => a.t - b.t,
   );
+  if (normalizedCountBack) {
+    const requestedValues = normalizedValues.filter(
+      (point) => point.t >= timeFrom,
+    );
+    const missingCount = Math.max(
+      normalizedCountBack - requestedValues.length,
+      0,
+    );
+    const earlierValues =
+      missingCount > 0
+        ? normalizedValues
+            .filter((point) => point.t < timeFrom)
+            .slice(-missingCount)
+        : [];
+    normalizedValues = [...earlierValues, ...requestedValues];
+  }
   const pointType =
     normalizedValues.length > 0 &&
     normalizedValues.every((point) => point.pointType === 'single')
@@ -375,6 +398,7 @@ export async function fetchMarketKLineDataWithSlicing({
   interval,
   timeFrom,
   timeTo,
+  countBack,
   autoHandleError,
   kLineDataFallback,
   onPointType,
@@ -433,6 +457,7 @@ export async function fetchMarketKLineDataWithSlicing({
         points: mergedPoints,
         timeFrom,
         timeTo,
+        countBack,
       });
       mergedData = {
         ...mergedData,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58202](https://onekeyhq.atlassian.net/browse/OK-58202)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- accept and validate TradingView's `countBack` value in market history requests
- retain older sliced candles and backfill before `from` until the requested bar count is satisfied
- keep the previous `[from, to]` behavior for chart builds that do not send `countBack`
- add focused handler and sparse-history regression tests

## Root cause

The chart bridge did not forward `countBack`, and the app filtered merged slice data back to `[from, to]`. For sparse 1m ranges, the exact viewport window could be empty even though earlier candles had already been fetched. TradingView then received an empty response and incorrectly treated it as the end of server history.

## Impact

AAVE 1m and other sparse market series continue loading historical candles while users pan left.

## Companion PR

- TradingView bridge: https://github.com/OneKeyHQ/tradingview-charting-library/pull/206

## Validation

- `yarn agent:check --profile commit`
- focused Jest suites — 2 suites, 7 tests passed
- local AAVE 1m verification — 8 consecutive left-pan requests continued loading and each response matched `countBack`
- diff whitespace checks passed

[OK-58202]: https://onekeyhq.atlassian.net/browse/OK-58202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ