### PR TITLE
feat: enable scam filter, approval management, NFT and backend index for HyperEVM

### DIFF
--- a/packages/shared/src/config/presetNetworks.ts
+++ b/packages/shared/src/config/presetNetworks.ts
@@ -1263,7 +1263,7 @@ const hyperEvm: IServerNetwork = {
   },
   'logoURI': 'https://uni.onekey-asset.com/static/chain/hyper-evm.png',
   'defaultEnabled': false,
-  'backendIndex': false,
+  'backendIndex': true,
 };
 
 const hoodi: IServerNetwork = {

--- a/packages/shared/src/config/presetNetworks.ts
+++ b/packages/shared/src/config/presetNetworks.ts
@@ -1259,7 +1259,7 @@ const hyperEvm: IServerNetwork = {
   'extensions': {
     'position': 999,
     'isTokenSupported': true,
-    'isNFTEnabled': false,
+    'isNFTEnabled': true,
   },
   'logoURI': 'https://uni.onekey-asset.com/static/chain/hyper-evm.png',
   'defaultEnabled': false,
@@ -2648,6 +2648,7 @@ export const getNetworkIdsSupportFilterScamHistory = memoFn((): string[] => [
   polygon.id,
   etc.id,
   tron.id,
+  hyperEvm.id,
   ROBINHOOD_NETWORK_ID,
 ]);
 
@@ -2694,6 +2695,7 @@ export const getNetworksSupportBulkRevokeApproval = memoFn(
     [avalanche.id]: true,
     [optimism.id]: true,
     [base.id]: true,
+    [hyperEvm.id]: true,
     [ROBINHOOD_NETWORK_ID]: true,
   }),
 );

--- a/packages/shared/src/utils/networkUtils.ts
+++ b/packages/shared/src/utils/networkUtils.ts
@@ -266,6 +266,7 @@ function getEnabledNFTNetworkIds(): string[] {
     networkIdsMap.arbitrum,
     networkIdsMap.avalanche,
     networkIdsMap.sol,
+    networkIdsMap.hyperevm,
   ];
 }
 


### PR DESCRIPTION
## Summary
- Enable three client-side feature gates for HyperEVM (`evm--999`): risky-transaction filter (hide scam history), approval management (bulk revoke), and NFT support.
- Mark HyperEVM as a backend-indexed network (`backendIndex: true`) now that the server indexer supports it.

## Intent & Context
The backend indexer now supports HyperEVM (and Robinhood Chain) with scam-history labeling, approval data and NFT data. The client keeps per-network feature gates that must be switched on explicitly, so this PR flips those gates for HyperEVM.

Robinhood Chain (`evm--4663`) needs no client change for indexer status: it is delivered via the server network list (never defined in `presetNetworks.ts`), and no local snapshot hardcodes its `backendIndex`, so the server-side flag takes effect automatically. Its scam-filter/approval gates were already enabled previously.

## Design Decisions
- NFT enablement requires both `extensions.isNFTEnabled` on the network entry and membership in `networkUtils.getEnabledNFTNetworkIds()` — the latter is the effective gate consumed by the Home NFT tab, the EVM vault and All-Networks aggregation, so both were updated together.
- All consumers of `backendIndex` (history pagination in `ServiceHistory`, post-send nonce handling in `ServiceSend`, All-Networks aggregation, swap history, token selector filter) read the flag dynamically from the network object, so flipping the preset value is sufficient; no per-feature changes needed.
- Existing users' locally cached HyperEVM network record is refreshed from the preset on app update, so no migration is required.

## Changes Detail
- `packages/shared/src/config/presetNetworks.ts`:
  - `hyperEvm.extensions.isNFTEnabled`: `false` → `true`
  - `hyperEvm.backendIndex`: `false` → `true`
  - Add `hyperEvm.id` to `getNetworkIdsSupportFilterScamHistory` (history "hide risky transactions" toggle)
  - Add `hyperEvm.id` to `getNetworksSupportBulkRevokeApproval` (approval management entry + bulk revoke)
- `packages/shared/src/utils/networkUtils.ts`:
  - Add `networkIdsMap.hyperevm` to `getEnabledNFTNetworkIds()`

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: `backendIndex: true` switches HyperEVM history to indexer-style pagination and pending-tx handling; if the server indexer data is incomplete, history/NFT/approval views would show gaps. Config-only change otherwise.

## Test plan
- [ ] HyperEVM history list shows the "hide risky transactions" filter and it filters scam txs
- [ ] Approval management entry appears for HyperEVM accounts and bulk revoke lists approvals
- [ ] NFT tab appears on Home for HyperEVM and NFTs load
- [ ] HyperEVM tx history paginates correctly and pending txs finalize after send (backendIndex path)
- [ ] Robinhood Chain history/approval behavior unchanged and driven by server config