### PR TITLE
fix: color line chart price change OK-59251

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLegend.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLegend.test.ts
@@ -25,7 +25,11 @@ describe('TradingViewNative chart legend', () => {
         { label: 'H', value: '125.00' },
         { label: 'L', value: '119.50' },
         { label: 'C', value: '123.46' },
-        { label: '', value: '+3.45679 (+2.88%)' },
+        {
+          label: '',
+          value: '+3.45679 (+2.88%)',
+          valueColorRole: 'trend',
+        },
       ],
       volumeItem: { label: 'Volume', value: '1.25M' },
     });
@@ -61,7 +65,7 @@ describe('TradingViewNative chart legend', () => {
       isUp: false,
       priceItems: [
         { label: 'Price', value: '9.00' },
-        { label: '', value: '-1 (-10%)' },
+        { label: '', value: '-1 (-10%)', valueColorRole: 'trend' },
       ],
       volumeItem: { label: 'Volume', value: '500' },
     });
@@ -85,6 +89,7 @@ describe('TradingViewNative chart legend', () => {
     expect(legend.priceItems.at(-1)).toEqual({
       label: '',
       value: '+1 (+1%)',
+      valueColorRole: 'trend',
     });
   });
 

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLegend.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartLegend.ts
@@ -17,6 +17,7 @@ import type { ITradingViewNativeChartType } from '../types';
 export interface ITradingViewNativeLegendItem {
   label: string;
   value: string;
+  valueColorRole?: 'trend';
 }
 
 export interface ITradingViewNativeChartLegend {
@@ -228,12 +229,13 @@ export function getTradingViewNativeChartLegend(
   // TradingView compares each close with the prior bar's close and falls back
   // to the current bar's open when there is no prior bar.
   const changeReference = previousClose ?? point.o;
-  const priceChangeItem = {
+  const priceChangeItem: ITradingViewNativeLegendItem = {
     label: '',
     value: formatTradingViewNativePriceChange({
       close: point.c,
       open: changeReference,
     }),
+    valueColorRole: 'trend',
   };
   return {
     isUp: point.c >= changeReference,

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.test.ts
@@ -293,6 +293,15 @@ describe('TradingViewNative shared chart scene', () => {
     const text = scene.commands.flatMap((command) =>
       command.kind === 'text' ? [command.text] : [],
     );
+    const linePrice = scene.commands.find(
+      (command) =>
+        command.kind === 'text' &&
+        command.font === 'legend' &&
+        command.text === '110.00',
+    );
+    const linePriceChange = scene.commands.find(
+      (command) => command.kind === 'text' && command.text === '+10 (+10%)',
+    );
 
     expect(line).toMatchObject({
       kind: 'polyline',
@@ -306,6 +315,8 @@ describe('TradingViewNative shared chart scene', () => {
       paint: 'line',
       radius: 2.5,
     });
+    expect(linePrice).toMatchObject({ paint: 'line' });
+    expect(linePriceChange).toMatchObject({ paint: 'up' });
     expect(text).toEqual(expect.arrayContaining(['Price', '+10 (+10%)']));
     expect(text).not.toEqual(expect.arrayContaining(['O', 'H', 'L', 'C']));
     expect(
@@ -319,6 +330,38 @@ describe('TradingViewNative shared chart scene', () => {
         (command) => command.kind === 'line' && command.paint === 'axisText',
       ),
     ).toBe(false);
+  });
+
+  it('colors a negative line price change with the down paint', () => {
+    const scene = buildTradingViewNativeChartScene({
+      candleIntervalSeconds: 3600,
+      chartType: 'line',
+      crosshair: { visible: false, x: 0, y: 0 },
+      hasVolume: false,
+      height: 240,
+      measureTextWidth: (text) => text.length * 6,
+      points: [
+        { c: 100, h: 100, l: 100, o: 100, t: 1_700_000_000, v: 0 },
+        { c: 90, h: 100, l: 90, o: 100, t: 1_700_003_600, v: 0 },
+      ],
+      viewport: { offset: 0, zoomScale: 1 },
+      watermarkOpacity: 0.16,
+      width: 320,
+    });
+
+    expect(
+      scene.commands.find(
+        (command) =>
+          command.kind === 'text' &&
+          command.font === 'legend' &&
+          command.text === '90.00',
+      ),
+    ).toMatchObject({ paint: 'line' });
+    expect(
+      scene.commands.find(
+        (command) => command.kind === 'text' && command.text === '-10 (-10%)',
+      ),
+    ).toMatchObject({ paint: 'down' });
   });
 
   it('keeps a long price change visible on narrow charts', () => {

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.ts
@@ -268,10 +268,12 @@ export function getTradingViewNativeChartScenePaintStyles({
 function appendLegendCommands({
   commands,
   layout,
+  trendValuePaint,
   valuePaint,
 }: {
   commands: ITradingViewNativeChartSceneCommand[];
   layout: ITradingViewNativeChartLegendRowLayout | null;
+  trendValuePaint: ITradingViewNativeChartScenePaint;
   valuePaint: ITradingViewNativeChartScenePaint;
 }) {
   'worklet';
@@ -301,7 +303,8 @@ function appendLegendCommands({
       {
         font: 'legend',
         kind: 'text',
-        paint: valuePaint,
+        paint:
+          segment.valueColorRole === 'trend' ? trendValuePaint : valuePaint,
         text: segment.value,
         x: segment.valueX,
         y: textBaselineY,
@@ -735,10 +738,11 @@ export function buildTradingViewNativeChartScene({
     chartType,
     previousLegendPoint?.c,
   );
-  let legendValuePaint: ITradingViewNativeChartScenePaint = 'line';
-  if (chartType !== 'line') {
-    legendValuePaint = legend.isUp ? 'up' : 'down';
-  }
+  const trendValuePaint: ITradingViewNativeChartScenePaint = legend.isUp
+    ? 'up'
+    : 'down';
+  const legendValuePaint: ITradingViewNativeChartScenePaint =
+    chartType === 'line' ? 'line' : trendValuePaint;
   const measureLegendTextWidth = (text: string) =>
     measureTextWidth(text, 'legend');
   const appendLegendRows = (
@@ -748,6 +752,7 @@ export function buildTradingViewNativeChartScene({
       appendLegendCommands({
         commands,
         layout: rowLayout,
+        trendValuePaint,
         valuePaint: legendValuePaint,
       });
     }


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59251](https://onekeyhq.atlassian.net/browse/OK-59251)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- color the line-chart legend price change green or red based on the previous close
- keep the current price value in the configured line color
- cover both positive and negative line-chart changes

## Root cause

Line charts used a single line-color paint for every legend value, so the price-change segment ignored the direction already calculated by the legend model.

## Impact

The top-left price change now reflects its direction in both renderers backed by the shared TradingViewNative scene. Candlestick and volume legend colors remain unchanged.

## Validation

- `yarn jest --runInBand --runTestsByPath packages/kit/src/components/TradingView/TradingViewNative/utils/chartLegend.test.ts packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.test.ts` (24 tests passed)
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr` (local checks passed; PR detection was expected to be empty before creation)

Issue: OK-59251

[OK-59251]: https://onekeyhq.atlassian.net/browse/OK-59251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ