### PR TITLE
feat: add dex labels to perps market lists

### DIFF
--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -27,6 +27,7 @@ import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import {
   LeverageBadge,
+  PerpDexBadge,
   SubtitleText,
 } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
 import { useNavigateToMarketTab } from '@onekeyhq/kit/src/views/Market/hooks';
@@ -720,6 +721,7 @@ function PerpsEmptyRecommendSection() {
                       {token.displayName}
                     </SizableText>
                     <LeverageBadge leverage={token.maxLeverage} />
+                    <PerpDexBadge dexLabel={token.dexLabel} />
                   </XStack>
                   {token.subtitle ? (
                     <SubtitleText subtitle={token.subtitle} />
@@ -841,6 +843,7 @@ function PerpsEmptyRecommendSection() {
                         {token.displayName}
                       </SizableText>
                       <LeverageBadge leverage={token.maxLeverage} />
+                      <PerpDexBadge dexLabel={token.dexLabel} />
                     </XStack>
                     <XStack alignItems="center" gap="$1" minWidth={0}>
                       {token.subtitle ? (

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsTokenListItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsTokenListItem.tsx
@@ -10,7 +10,11 @@ import {
 } from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 
-import { LeverageBadge, SubtitleText } from '../../../components/PerpsBadges';
+import {
+  LeverageBadge,
+  PerpDexBadge,
+  SubtitleText,
+} from '../../../components/PerpsBadges';
 import { PriceChangeBadge } from '../PriceChangeBadge';
 
 import type { IMarketPerpsToken } from './hooks/useMarketPerpsTokenList';
@@ -30,12 +34,20 @@ const BasicMarketPerpsTokenListItem: FC<IMarketPerpsTokenListItemProps> = ({
     <XStack
       pressStyle={{ opacity: 0.8 }}
       onPress={onPress}
-      px="$5"
+      px="$4"
       py="$3"
       alignItems="center"
+      gap="$3"
     >
       {/* Left side: Token Icon + Name + Badges + Volume */}
-      <XStack flex={1} alignItems="center" gap="$3" minWidth={0}>
+      <XStack
+        flexGrow={1}
+        flexBasis={0}
+        alignItems="center"
+        gap="$2"
+        minWidth={0}
+        overflow="hidden"
+      >
         <Token
           size="md"
           borderRadius="$full"
@@ -49,19 +61,29 @@ const BasicMarketPerpsTokenListItem: FC<IMarketPerpsTokenListItemProps> = ({
               numberOfLines={1}
               flexShrink={1}
               ellipsizeMode="tail"
+              adjustsFontSizeToFit
+              minimumFontScale={0.85}
               userSelect="none"
             >
               {item.displayName}
             </SizableText>
-            <LeverageBadge leverage={item.maxLeverage} />
+            <LeverageBadge leverage={item.maxLeverage} compact />
+            <PerpDexBadge dexLabel={item.dexLabel} compact />
           </XStack>
-          <XStack alignItems="center" gap="$1" minWidth={0}>
+          <XStack
+            alignItems="center"
+            gap="$1"
+            minWidth={0}
+            overflow="hidden"
+            pr="$3"
+          >
             {item.subtitle ? <SubtitleText subtitle={item.subtitle} /> : null}
             <SkeletonContainer isLoading={!hasRealTimeData}>
               <NumberSizeableText
-                size="$bodyMd"
+                size="$bodySm"
                 color="$textSubdued"
                 numberOfLines={1}
+                flexShrink={0}
                 formatter="marketCap"
                 formatterOptions={{ currency: '$' }}
                 userSelect="none"
@@ -75,7 +97,7 @@ const BasicMarketPerpsTokenListItem: FC<IMarketPerpsTokenListItemProps> = ({
 
       {/* Right side: Price + Change */}
       <SkeletonContainer isLoading={!hasRealTimeData}>
-        <XStack alignItems="center" gap="$2">
+        <XStack alignItems="center" gap="$2" flexShrink={0}>
           <NumberSizeableText
             userSelect="none"
             flexShrink={1}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/marketPerpsTokenUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/marketPerpsTokenUtils.test.ts
@@ -1,0 +1,37 @@
+import type { IMarketPerpsTokenFromServer } from '@onekeyhq/shared/types/marketV2';
+
+import { mapServerToken } from './marketPerpsTokenUtils';
+
+function buildServerToken(name: string): IMarketPerpsTokenFromServer {
+  return {
+    name,
+    displayName: 'UNITREE',
+    maxLeverage: 10,
+    tokenImageUrl: 'https://example.com/unitree.png',
+    markPrice: '90.38',
+    prevDayPrice: '72.58',
+    change24hPercent: 24.52,
+    volume24h: '10940000',
+    openInterest: '6660000',
+    fundingRate: '0.000008',
+  };
+}
+
+describe('mapServerToken', () => {
+  it.each([
+    ['xyz:UNITREE', 'xyz'],
+    ['para:UNITREE', 'para'],
+  ])('maps the dex prefix from %s for the market badge', (name, dexLabel) => {
+    expect(mapServerToken(buildServerToken(name), undefined)).toMatchObject({
+      name,
+      displayName: 'UNITREE',
+      dexLabel,
+    });
+  });
+
+  it('leaves main-dex tokens without a dex label', () => {
+    expect(
+      mapServerToken(buildServerToken('BTC'), undefined).dexLabel,
+    ).toBeUndefined();
+  });
+});

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/marketPerpsTokenUtils.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/marketPerpsTokenUtils.ts
@@ -1,0 +1,43 @@
+import {
+  getTokenSubtitle,
+  parseDexCoin,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
+import type { ITokenSearchAliases } from '@onekeyhq/shared/src/utils/perpsUtils';
+import type { IMarketPerpsTokenFromServer } from '@onekeyhq/shared/types/marketV2';
+
+export interface IMarketPerpsToken {
+  name: string;
+  displayName: string;
+  dexLabel?: string;
+  maxLeverage: number;
+  subtitle?: string;
+  tokenImageUrl: string;
+  markPrice: string;
+  prevDayPrice: string;
+  change24hPercent: number;
+  volume24h: string;
+  openInterest: string;
+  fundingRate: string;
+}
+
+export function mapServerToken(
+  token: IMarketPerpsTokenFromServer,
+  tokenSearchAliases: ITokenSearchAliases | undefined,
+): IMarketPerpsToken {
+  const { dexLabel } = parseDexCoin(token.name);
+
+  return {
+    name: token.name,
+    displayName: token.displayName,
+    dexLabel,
+    maxLeverage: token.maxLeverage,
+    subtitle: getTokenSubtitle(token.name, tokenSearchAliases),
+    tokenImageUrl: token.tokenImageUrl,
+    markPrice: token.markPrice,
+    prevDayPrice: token.prevDayPrice,
+    change24hPercent: token.change24hPercent,
+    volume24h: token.volume24h,
+    openInterest: token.openInterest,
+    fundingRate: token.fundingRate,
+  };
+}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/useMarketPerpsTokenList.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/useMarketPerpsTokenList.ts
@@ -2,48 +2,19 @@ import { useMemo } from 'react';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
-import { getTokenSubtitle } from '@onekeyhq/shared/src/utils/perpsUtils';
-import type { ITokenSearchAliases } from '@onekeyhq/shared/src/utils/perpsUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
-import type { IMarketPerpsTokenFromServer } from '@onekeyhq/shared/types/marketV2';
 
 import { MARKET_PERPS_DEFAULT_CATEGORY_ID } from '../constants';
 
-export interface IMarketPerpsToken {
-  name: string;
-  displayName: string;
-  maxLeverage: number;
-  subtitle?: string;
-  tokenImageUrl: string;
-  markPrice: string;
-  prevDayPrice: string;
-  change24hPercent: number;
-  volume24h: string;
-  openInterest: string;
-  fundingRate: string;
-}
+import { mapServerToken } from './marketPerpsTokenUtils';
+
+import type { IMarketPerpsToken } from './marketPerpsTokenUtils';
+
+export { mapServerToken };
+export type { IMarketPerpsToken };
 
 interface IUseMarketPerpsTokenListParams {
   selectedCategoryId: string;
-}
-
-export function mapServerToken(
-  token: IMarketPerpsTokenFromServer,
-  tokenSearchAliases: ITokenSearchAliases | undefined,
-): IMarketPerpsToken {
-  return {
-    name: token.name,
-    displayName: token.displayName,
-    maxLeverage: token.maxLeverage,
-    subtitle: getTokenSubtitle(token.name, tokenSearchAliases),
-    tokenImageUrl: token.tokenImageUrl,
-    markPrice: token.markPrice,
-    prevDayPrice: token.prevDayPrice,
-    change24hPercent: token.change24hPercent,
-    volume24h: token.volume24h,
-    openInterest: token.openInterest,
-    fundingRate: token.fundingRate,
-  };
 }
 
 export function useMarketPerpsTokenList({

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/usePerpsColumns.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/usePerpsColumns.tsx
@@ -16,6 +16,7 @@ import { Token } from '@onekeyhq/kit/src/components/Token';
 import { MarketPerpsStarV2 } from '@onekeyhq/kit/src/views/Market/components/MarketStarV2';
 import {
   LeverageBadge,
+  PerpDexBadge,
   SubtitleText,
 } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -76,6 +77,7 @@ export function usePerpsColumnsDesktop(): ITableColumn<IMarketPerpsToken>[] {
                     {record.displayName}
                   </SizableText>
                   <LeverageBadge leverage={record.maxLeverage} />
+                  <PerpDexBadge dexLabel={record.dexLabel} />
                 </XStack>
                 {record.subtitle ? (
                   <SubtitleText subtitle={record.subtitle} />

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/usePerpsColumnsMobile.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/usePerpsColumnsMobile.tsx
@@ -13,6 +13,7 @@ import type { ITableColumn } from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import {
   LeverageBadge,
+  PerpDexBadge,
   SubtitleText,
 } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -56,6 +57,7 @@ export function usePerpsColumnsMobile(): ITableColumn<IMarketPerpsToken>[] {
                   {record.displayName}
                 </SizableText>
                 <LeverageBadge leverage={record.maxLeverage} />
+                <PerpDexBadge dexLabel={record.dexLabel} />
               </XStack>
               <XStack alignItems="center" gap="$1" minWidth={0}>
                 {record.subtitle ? (

--- a/packages/kit/src/views/Market/components/PerpsBadges.tsx
+++ b/packages/kit/src/views/Market/components/PerpsBadges.tsx
@@ -3,7 +3,6 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import {
-  Badge,
   Image,
   SizableText,
   Stack,
@@ -20,19 +19,21 @@ import type { IMarketStockInfo } from '@onekeyhq/shared/types/marketV2';
 
 import { truncatePerpsSubtitle } from './utils/perpsSubtitle';
 
-const LeverageBadge = memo(({ leverage }: { leverage: number }) => (
-  <XStack
-    borderRadius="$1"
-    bg="$bgInfo"
-    justifyContent="center"
-    alignItems="center"
-    px="$1.5"
-  >
-    <SizableText fontSize={10} color="$textInfo" lineHeight={16}>
-      {leverage}x
-    </SizableText>
-  </XStack>
-));
+const LeverageBadge = memo(
+  ({ leverage, compact }: { leverage: number; compact?: boolean }) => (
+    <XStack
+      borderRadius="$1"
+      bg="$bgInfo"
+      justifyContent="center"
+      alignItems="center"
+      px={compact ? '$1' : '$1.5'}
+    >
+      <SizableText fontSize={10} color="$textInfo" lineHeight={16}>
+        {leverage}x
+      </SizableText>
+    </XStack>
+  ),
+);
 LeverageBadge.displayName = 'LeverageBadge';
 
 function getPerpDexDescriptionId(dexLabel?: string) {
@@ -66,25 +67,17 @@ const PerpDexBadge = memo(
     const label = dexLabel.toLowerCase();
     const description = intl.formatMessage({ id: descriptionId });
     const badgeText = (
-      <SizableText
-        color="$textInfo"
-        fontSize={10}
-        {...(!compact && { lineHeight: 16 })}
-      >
+      <SizableText color="$textInfo" fontSize={10} lineHeight={16}>
         {label}
       </SizableText>
     );
-    const badge = compact ? (
-      <Badge radius="$1" bg="$bgInfo" px="$1" py={0} testID={testID}>
-        {badgeText}
-      </Badge>
-    ) : (
+    const badge = (
       <XStack
         borderRadius="$1"
         bg="$bgInfo"
         justifyContent="center"
         alignItems="center"
-        px="$1.5"
+        px={compact ? '$1' : '$1.5'}
         testID={testID}
       >
         {badgeText}


### PR DESCRIPTION
## Summary
- Show `xyz` and `para` source badges in Market Perps lists and Home hot markets.
- Parse the DEX source from the server token name through the existing `parseDexCoin` utility.
- Improve the mobile market row spacing and truncation so long symbols and subtitles do not crowd price data.

## Related Issue
https://onekeyhq.atlassian.net/browse/OK-59751

## Intent & Context
Perps assets from the main DEX, xyz, and para were visually indistinguishable in Market and Home lists. The source badge needs to remain visible next to leverage while price and change values stay readable on narrow mobile layouts.

## Root Cause
The server token name already contains the DEX prefix, but the Market display mapper discarded it. As a result, list rows had no source metadata to render. Adding another badge also exposed existing width competition between long asset metadata and the fixed price/change area on mobile.

## Design Decisions
- Reuse `parseDexCoin` instead of introducing new prefix parsing.
- Reuse `PerpDexBadge` across Market and Home so descriptions and styling stay consistent.
- Keep the current two-line mobile row structure. Use opt-in compact badges, bounded symbol scaling, explicit overflow clipping, and reserved spacing before the price area.
- Keep price-to-change spacing unchanged and preserve non-compact badge behavior for existing call sites.

## Changes Detail
- Extract the Market Perps display mapper into a testable utility and expose `dexLabel`.
- Render source badges in desktop, responsive, native Market lists, and Home hot markets.
- Add compact leverage/source badge support and align badge heights.
- Reduce mobile volume typography and reserve space between metadata and price columns.
- Add mapper coverage for xyz, para, and main-DEX assets.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Web, Desktop, Extension
- **Risk Areas**: Responsive row truncation and spacing on narrow layouts; source prefix mapping.

## Test plan
- [x] `yarn agent:check --profile commit`
- [x] Focused `marketPerpsTokenUtils.test.ts` Jest suite
- [ ] Verify xyz and para badges in Market lists on Web and Native
- [ ] Verify Home hot-market badges on Web and Native
- [ ] Verify long symbols and subtitles keep separation from price/change values