### PR TITLE
fix: keep the perps first screen height stable on cold start (OK-59662)

### DIFF
--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -795,9 +795,12 @@ export function PerpOrderBook({
   );
 
   const mobileMaxLevelsPerSide = useMemo(() => {
-    if (shouldShowEnableTradingButton) return 7;
+    // Spot settles on its own level count, and the enable-trading flag reads
+    // true until the account address resolves, so checking it first made every
+    // spot cold start render 7 levels and then collapse the first-screen grid.
     if (activeTradeInstrument.mode === 'spot')
       return MOBILE_SPOT_MAX_LEVELS_PER_SIDE;
+    if (shouldShowEnableTradingButton) return 7;
     if (formData.hasTpsl) return 9;
     return 7;
   }, [

--- a/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingPanel.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/PerpTradingPanel.tsx
@@ -24,6 +24,7 @@ import {
   usePerpsCustomSettingsAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { markPerpsColdStartPerfOnce } from '@onekeyhq/shared/src/performance/perpsColdStartPerf';
+import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 
 import { useOrderConfirm } from '../../hooks';
 import { useOrderPrice } from '../../hooks/useOrderPrice';
@@ -226,8 +227,15 @@ function PerpTradingPanel({ isMobile = false }: { isMobile?: boolean }) {
       snapshotLookupIndexedAccountId,
     ],
   );
+  const cachedAccountIsWatching = snapshotEntry?.account.accountId
+    ? accountUtils.isWatchingAccount({
+        accountId: snapshotEntry.account.accountId,
+      })
+    : false;
   const canShowCachedTradingButtons = Boolean(
-    !displayReady.statusReady && snapshotEntry?.account.accountAddress,
+    !displayReady.statusReady &&
+    snapshotEntry?.account.accountAddress &&
+    !cachedAccountIsWatching,
   );
   const isLiveStatusPending = canShowCachedTradingButtons;
   const coldStartEnableTradingMode = useMemo(() => {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59662](https://onekeyhq.atlassian.net/browse/OK-59662)

----------

<!-- github-pr-monitor:jira-links:end -->


Two cold-start height jumps on the mobile Perps first screen. Both were found by capturing `tracePerpsMobileLayout` rects on web mobile view.

## 1. Spot first screen collapses by 118px

`perpsShouldShowEnableTradingButtonAtom` reports `true` while the account address is unresolved:

```ts
const status = get(perpsActiveAccountStatusAtom.atom());
if (!status?.accountAddress) {
  return true;
}
```

`PerpOrderBook` checked that flag before the trading mode, so spot rendered 7 levels per side until the account resolved and only then fell back to `MOBILE_SPOT_MAX_LEVELS_PER_SIDE` (4). Six rows disappearing is the 118px step, and since the trading panel is `flex: 1` inside the row, the whole grid follows the order book.

Spot only — the perp fallback is also 7, so its transient and settled values already matched.

**Fix:** let the trading mode pick the spot level count before the unresolved flag can override it. Perp behaviour (7 / 9 with TPSL / 7) is unchanged in every combination.

```
before  722 -> 756 (+34) -> 656 (-118) -> 702 (+46)     3 steps
after   656 ----------------------------> 702 (+46)     1 step
```

`perpTab.tabContent.y`, where the positions panel starts, went from `568 -> 524 -> 406` (162px of movement) to `408 -> 404 -> 408 -> 406`. Settled values are unchanged: `firstScreenGrid` 310, `tradingPanel` 294, `orderBook` 294.

## 2. Watching accounts jump 22px (QA follow-up on OK-59753)

`canShowCachedTradingButtons` optimistically shows the cached trading buttons whenever live status is not ready, without checking whether the account can ever trade. A watching account therefore goes `false -> true -> false` and the panel grows and shrinks again:

```
i=68   canShowTradingButtons: true    ->  tradingPanel 478   (+22)
i=117  canShowTradingButtons: false   ->  tradingPanel 456   (-22)
```

**Fix:** exclude watching accounts from the cached path, using the account id already present in the snapshot entry. Non-watching accounts are untouched, and a watching account never had usable buttons there anyway — `shouldShowPerpsOrderPanelTradingButtons` rejects it on `accountNotSupport`.

## Behaviour change worth flagging

Watching accounts and accounts without a derived address keep `shouldShowEnableTradingButton` permanently true, so fix 1 moves their spot order book from 7 levels per side to 4. They get no jump either way; the transient and settled counts now simply agree. Distinguishing "status unresolved" from "account genuinely cannot trade" is not possible today — at t0 `accountNotSupport` reads true for both — so the level count has to be picked from the settled case.

## Verification

`oxlint` clean, `tsc --noEmit` clean, `jest packages/kit/src/views/Perp` 35 suites / 267 tests passing. Fix 1 verified on device.

## Known, not addressed here

Both predate this PR and are unchanged by it:

- The positions list renders its empty state for a frame before data arrives, because `isPerpsAccountScopedDataReady` treats "no active address and no data address" as ready. Separating "account still resolving" from "no account at all" needs a readiness signal that does not exist yet.
- The order book reference price shows `--` until the first mark price arrives.

The remaining height changes in the capture — the deposit badge appearing and the positions list growing once data lands — are content arriving, not layout defects.

[OK-59662]: https://onekeyhq.atlassian.net/browse/OK-59662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ