### PR TITLE
chore: release #5

### DIFF
--- a/RELEASES.json
+++ b/RELEASES.json
@@ -53,12 +53,11 @@
   },
   {
     "seq": 4,
-    "commit": "0f078ef58a5a35d5de71b78141e0b1b22b911c00",
+    "commit": "dbb7c15425cb0e529fac5e52f04ab1b4a322f2c9",
     "date": "2026-08-03T11:53:05Z",
     "prs": [
       "#12530",
       "#12564",
-      "#12585",
       "#12623",
       "#12638",
       "#12649",
@@ -66,6 +65,26 @@
       "#12660",
       "#12695"
     ],
-    "notes": "Keep Tabs scroll extent in sync after tab switches and async refreshes (#12530); reset OTA retry gate on cold restart (#12564); collect Swap referral attribution (#12585); support tab-targeted swap tips (#12623); restore risk approval alert dismissal (#12638); restore Perps orderbook and dead banner taps on notification entry (#12649); track Google Play install attribution (#12652); keep browser content above toolbar (#12660); stabilize swap tips banner layout (#12695)"
+    "notes": "Keep Tabs scroll extent in sync after tab switches and async refreshes (#12530); reset OTA retry gate on cold restart (#12564); support tab-targeted swap tips (#12623); restore risk approval alert dismissal (#12638); restore Perps orderbook and dead banner taps on notification entry (#12649); track Google Play install attribution (#12652); keep browser content above toolbar (#12660); stabilize swap tips banner layout (#12695)"
+  },
+  {
+    "seq": 5,
+    "commit": "8769be8503073afcf767c1ca12f90a0fac7cfb89",
+    "date": "2026-08-08T15:37:01Z",
+    "prs": [
+      "#12585",
+      "#12680",
+      "#12683",
+      "#12725",
+      "#12728",
+      "#12729",
+      "#12740",
+      "#12747",
+      "#12748",
+      "#12753",
+      "#12764",
+      "#12769"
+    ],
+    "notes": "Collect swap referral attribution (#12585); keep Perps cold-start data and trade mode consistent across runtimes (#12680); re-enable the Perps subscriptions handler when the UI is provably live (#12683); force stock table mode (#12725); improve market indicator quick bar gestures (#12728); hide liquidity column in spot banner detail list (#12729); reserve gas for private max send (#12740); address Swap Pro badges and stock charts (#12747); improve market initial rendering (#12748); support Paragon HIP-3 markets (#12753); add Swap Pro analytics and trade source (#12764); support compact market banner list (#12769)"
   }
 ]


### PR DESCRIPTION
## Summary

Record bundle release **#5** in `RELEASES.json`, and correct the commit recorded for release #4.

### Release #5
- Commit: `8769be8503073afcf767c1ca12f90a0fac7cfb89`
- 13 commits, 136 files, +5,436 / −792 since #4
- 12 PRs: #12585, #12680, #12683, #12725, #12728, #12729, #12740, #12747, #12748, #12753, #12764, #12769
- No native, dependency, `.env`, patch, or build-config changes — JS-only, safe as a bundle

### Correction to release #4
Release #4 recorded `0f078ef` as the published commit, but the bundle was actually published from its **direct parent** `dbb7c15` (#12652). That over-recorded exactly one commit — #12585 `feat: collect swap referral attribution` — as shipped when it was not.

- `commit`: `0f078ef58a…` → `dbb7c15425…`
- `prs`: `#12585` removed (now correctly matches the range `5d1872f..dbb7c15`)
- `notes`: the `#12585` clause removed
- `date` unchanged — it records the publish timestamp, not the commit date

#12585 therefore ships in #5 instead.

## Release Notes

Collect swap referral attribution (#12585); keep Perps cold-start data and trade mode consistent across runtimes (#12680); re-enable the Perps subscriptions handler when the UI is provably live (#12683); force stock table mode (#12725); improve market indicator quick bar gestures (#12728); hide liquidity column in spot banner detail list (#12729); reserve gas for private max send (#12740); address Swap Pro badges and stock charts (#12747); improve market initial rendering (#12748); support Paragon HIP-3 markets (#12753); add Swap Pro analytics and trade source (#12764); support compact market banner list (#12769)

## Smoke-test priority

1. **Send / private max send** (#12740) — only money path in this bundle; verify max-send reserves enough gas and broadcasts.
2. **Perps cross-runtime state** (#12680, #12683) — touches `SimpleDbEntityPerp`, `jotaiStorage`, `atomNames`. Needs a native cold start plus kill-and-relaunch, `main` and `bg` both.
3. **Market list rendering** (#12748, #12769, #12725, #12728) — four PRs in the same `MarketTokenList` area; test as a cluster.
4. **Swap analytics** (#12585, #12764) — two tracking changes in one bundle; confirm no double-reported swap events.