### PR TITLE
fix: gate pre-release firmware artifact hosts behind developer mode

### DIFF
--- a/packages/kit-bg/src/desktopApis/DesktopApiFirmwareArtifact.test.ts
+++ b/packages/kit-bg/src/desktopApis/DesktopApiFirmwareArtifact.test.ts
@@ -29,15 +29,13 @@ describe('DesktopApiFirmwareArtifact URL admission', () => {
     ).toBe(true);
     expect(
       isFirmwareArtifactUrlAllowed(
-        new URL(
-          'https://pub-568cac7a13bf4c42b7a8113ffffc6793.r2.dev/firmware.bin',
-        ),
+        new URL('https://common.onekey-asset.com/firmware.bin'),
       ),
     ).toBe(true);
     expect(
       isFirmwareArtifactUrlAllowed(
         new URL(
-          'https://pub-d5c080673b4e4e9dae7e03680340378d.r2.dev/firmware.bin',
+          'https://pub-568cac7a13bf4c42b7a8113ffffc6793.r2.dev/firmware.bin',
         ),
       ),
     ).toBe(false);
@@ -53,6 +51,90 @@ describe('DesktopApiFirmwareArtifact URL admission', () => {
     ).toBe(false);
   });
 
+  it('skips hostname pinning only for pre-release downloads', () => {
+    const allow = { allowPreReleaseHosts: true };
+    expect(
+      isFirmwareArtifactUrlAllowed(
+        new URL(
+          'https://pub-568cac7a13bf4c42b7a8113ffffc6793.r2.dev/firmware.bin',
+        ),
+        allow,
+      ),
+    ).toBe(true);
+    expect(
+      isFirmwareArtifactUrlAllowed(
+        new URL('https://leonbucket.blob.core.windows.net/pro2/resource.zip'),
+        allow,
+      ),
+    ).toBe(true);
+    expect(
+      isFirmwareArtifactUrlAllowed(
+        new URL('https://web.onekey-asset.com/firmware.bin'),
+        allow,
+      ),
+    ).toBe(true);
+    expect(
+      isFirmwareArtifactUrlAllowed(
+        new URL(
+          'https://pub-568cac7a13bf4c42b7a8113ffffc6793.r2.dev/firmware.bin',
+        ),
+        { allowPreReleaseHosts: false },
+      ),
+    ).toBe(false);
+    // Structural checks still apply while hostname pinning is skipped.
+    expect(
+      isFirmwareArtifactUrlAllowed(
+        new URL('http://leonbucket.blob.core.windows.net/resource.zip'),
+        allow,
+      ),
+    ).toBe(false);
+    expect(
+      isFirmwareArtifactUrlAllowed(
+        new URL('https://leonbucket.blob.core.windows.net:8443/resource.zip'),
+        allow,
+      ),
+    ).toBe(false);
+    expect(
+      isFirmwareArtifactUrlAllowed(
+        new URL('https://user:pass@leonbucket.blob.core.windows.net/res.zip'),
+        allow,
+      ),
+    ).toBe(false);
+    expect(
+      isFirmwareArtifactUrlAllowed(
+        new URL('https://leonbucket.blob.core.windows.net/res.zip#fragment'),
+        allow,
+      ),
+    ).toBe(false);
+  });
+
+  it('opens the pre-release admission only for the literal boolean true', () => {
+    // The flag crosses an IPC boundary, so it may arrive as any JSON value.
+    // Only `true` may widen the allowlist: a truthy coercion here would let a
+    // malformed or hostile payload skip hostname pinning.
+    const devUrl = new URL('https://leonbucket.blob.core.windows.net/res.zip');
+    for (const value of [
+      undefined,
+      null,
+      false,
+      0,
+      1,
+      'true',
+      'false',
+      {},
+      [],
+    ]) {
+      expect(
+        isFirmwareArtifactUrlAllowed(devUrl, {
+          allowPreReleaseHosts: value as never,
+        }),
+      ).toBe(false);
+    }
+    expect(
+      isFirmwareArtifactUrlAllowed(devUrl, { allowPreReleaseHosts: true }),
+    ).toBe(true);
+  });
+
   it('probes its root and keeps the minimum lease lifecycle in memory', async () => {
     const adapter = new DesktopApiFirmwareArtifact({
       desktopApi: {} as never,
@@ -64,6 +146,54 @@ describe('DesktopApiFirmwareArtifact URL admission', () => {
     });
     const transactionId = 'fwtx:00000000-0000-4000-8000-000000000001';
     const lease = await adapter.createLease(transactionId);
+    await adapter.releaseLease({
+      leaseRef: lease.leaseRef,
+      disposition: 'safeCancelled',
+    });
+  });
+
+  it('enforces host admission at the download entry point, not just the predicate', async () => {
+    const adapter = new DesktopApiFirmwareArtifact({
+      desktopApi: {} as never,
+    });
+    const transactionId = 'fwtx:00000000-0000-4000-8000-000000000009';
+    const lease = await adapter.createLease(transactionId);
+    const input = {
+      taskId: 'resource',
+      transactionId,
+      leaseRef: lease.leaseRef,
+      artifactId: 'resource',
+      url: 'https://leonbucket.blob.core.windows.net/pro2/resource.zip',
+      route: { routeType: 'domain' } as const,
+      expectedSize: 1,
+      expectedSha256: 'a'.repeat(64),
+      maxBytes: 1,
+      overallDeadlineSeconds: 1,
+    };
+
+    await expect(adapter.download(input)).rejects.toThrow(
+      'ARTIFACT_INVALID_INPUT',
+    );
+    // A non-boolean value must not coerce its way past hostname pinning.
+    await expect(
+      adapter.download({
+        ...input,
+        allowPreReleaseHosts: 'true' as never,
+      }),
+    ).rejects.toThrow('ARTIFACT_INVALID_INPUT');
+    // Skipping hostname pinning requires pinned content.
+    await expect(
+      adapter.download({
+        ...input,
+        expectedSha256: undefined,
+        allowPreReleaseHosts: true,
+      }),
+    ).rejects.toThrow('ARTIFACT_INVALID_INPUT');
+    // Admitted: dev flag plus a pinned SHA-256 reaches the network stage.
+    await expect(
+      adapter.download({ ...input, allowPreReleaseHosts: true }),
+    ).rejects.toThrow('ARTIFACT_NETWORK_FAILED');
+
     await adapter.releaseLease({
       leaseRef: lease.leaseRef,
       disposition: 'safeCancelled',

--- a/packages/kit-bg/src/desktopApis/DesktopApiFirmwareArtifact.ts
+++ b/packages/kit-bg/src/desktopApis/DesktopApiFirmwareArtifact.ts
@@ -50,7 +50,6 @@ const FINAL_ARTIFACT_GRACE_MS = 24 * 60 * 60 * 1000;
 const PARTIAL_ARTIFACT_GRACE_MS = 7 * 24 * 60 * 60 * 1000;
 const FIRMWARE_ARTIFACT_HOSTNAMES = new Set([
   'common.onekey-asset.com',
-  'pub-568cac7a13bf4c42b7a8113ffffc6793.r2.dev',
   'web.onekey-asset.com',
 ]);
 
@@ -91,13 +90,23 @@ const assertSafeInteger = (value: number, label: string): void => {
   }
 };
 
-export const isFirmwareArtifactUrlAllowed = (url: URL): boolean =>
+// allowPreReleaseHosts is only sent by bg while developer mode +
+// "Use pre-release config" are on: pre-release artifacts live in
+// developer-owned buckets whose hostnames cannot be pinned in advance. The
+// structural checks below still apply, and validateDownloadInput additionally
+// requires a pinned SHA-256 for these downloads, so every admitted artifact is
+// covered by a reviewed hostname or by pinned content.
+export const isFirmwareArtifactUrlAllowed = (
+  url: URL,
+  options?: { allowPreReleaseHosts?: boolean },
+): boolean =>
   url.protocol === 'https:' &&
   url.port === '' &&
   !url.username &&
   !url.password &&
   !url.hash &&
-  FIRMWARE_ARTIFACT_HOSTNAMES.has(url.hostname.toLowerCase());
+  (options?.allowPreReleaseHosts === true ||
+    FIRMWARE_ARTIFACT_HOSTNAMES.has(url.hostname.toLowerCase()));
 
 const validatePortableEntryName = (
   name: string,
@@ -487,7 +496,16 @@ class DesktopApiFirmwareArtifact implements IFirmwareArtifactAdapter {
 
   private validateDownloadInput(input: IDownloadInput): void {
     const url = new URL(input.url);
-    if (!isFirmwareArtifactUrlAllowed(url)) {
+    const allowPreReleaseHosts = input.allowPreReleaseHosts === true;
+    // Dropping hostname pinning is only acceptable against pinned content, so
+    // an unfingerprinted pre-release artifact must never be admitted.
+    if (allowPreReleaseHosts && input.expectedSha256 === undefined) {
+      throw new FirmwareArtifactDesktopError(
+        'ARTIFACT_INVALID_INPUT',
+        'Pre-release firmware artifacts require a pinned SHA-256',
+      );
+    }
+    if (!isFirmwareArtifactUrlAllowed(url, { allowPreReleaseHosts })) {
       throw new FirmwareArtifactDesktopError(
         'ARTIFACT_INVALID_INPUT',
         'Firmware URL is outside the reviewed artifact host allowlist',

--- a/packages/kit-bg/src/services/ServiceDevSetting.ts
+++ b/packages/kit-bg/src/services/ServiceDevSetting.ts
@@ -24,6 +24,7 @@ import {
   devSettingsPersistAtom,
   firmwareUpdateDevSettingsPersistAtom,
   getDevSettingsNetworkThrottleEnabled,
+  getGatedFirmwareUpdateDevSetting,
 } from '../states/jotai/atoms/devSettings';
 
 import ServiceBase from './ServiceBase';
@@ -308,12 +309,7 @@ class ServiceDevSetting extends ServiceBase {
   public async getFirmwareUpdateDevSettings<
     T extends IFirmwareUpdateDevSettingsKeys,
   >(key: T): Promise<IFirmwareUpdateDevSettings[T] | undefined> {
-    const dev = await devSettingsPersistAtom.get();
-    if (!dev.enabled) {
-      return undefined;
-    }
-    const fwDev = await firmwareUpdateDevSettingsPersistAtom.get();
-    return fwDev[key];
+    return getGatedFirmwareUpdateDevSetting(key);
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceFirmwareUpdate/FirmwareArtifactAdapter.types.ts
+++ b/packages/kit-bg/src/services/ServiceFirmwareUpdate/FirmwareArtifactAdapter.types.ts
@@ -48,6 +48,9 @@ export interface IFirmwareArtifactAdapter {
     expectedSha256?: string;
     maxBytes: number;
     overallDeadlineSeconds: number;
+    // Set by bg only while developer mode + "Use pre-release config" are on;
+    // pre-release artifact hosts (developer buckets) are not pinned in advance.
+    allowPreReleaseHosts?: boolean;
   }): Promise<IFirmwareArtifactReceipt>;
   cancelDownloads(transactionId: string): Promise<void>;
   materialize(input: {

--- a/packages/kit-bg/src/services/ServiceFirmwareUpdate/FirmwareArtifactPreflight.ts
+++ b/packages/kit-bg/src/services/ServiceFirmwareUpdate/FirmwareArtifactPreflight.ts
@@ -1,5 +1,7 @@
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 
+import { getGatedFirmwareUpdateDevSetting } from '../../states/jotai/atoms/devSettings';
+
 import { firmwareArtifactAdapter } from './FirmwareArtifactAdapter';
 import { firmwareUpdateTrace } from './FirmwareUpdateTrace';
 
@@ -201,6 +203,10 @@ export const downloadFirmwareArtifact = async ({
       artifactRole: artifact.role,
       expectedBytes: artifact.expectedSize,
     });
+    // Pre-release artifacts resolved from pre-config.json live in
+    // developer-owned buckets outside the reviewed host allowlist.
+    const allowPreReleaseHosts =
+      (await getGatedFirmwareUpdateDevSetting('usePreReleaseConfig')) === true;
     try {
       const receipt = await firmwareArtifactAdapter.download({
         taskId,
@@ -215,6 +221,7 @@ export const downloadFirmwareArtifact = async ({
         ...(artifact.expectedSha256
           ? { expectedSha256: artifact.expectedSha256 }
           : {}),
+        ...(allowPreReleaseHosts ? { allowPreReleaseHosts } : {}),
         maxBytes: artifact.expectedSize ?? MAX_ARTIFACT_BYTES,
         overallDeadlineSeconds: remainingMs / 1000,
       });

--- a/packages/kit-bg/src/services/ServiceFirmwareUpdate/FirmwareUpdateCapabilities.test.ts
+++ b/packages/kit-bg/src/services/ServiceFirmwareUpdate/FirmwareUpdateCapabilities.test.ts
@@ -6,6 +6,8 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EHardwareTransportType } from '@onekeyhq/shared/types';
 import type { ICheckAllFirmwareReleaseResult } from '@onekeyhq/shared/types/device';
 
+import { getGatedFirmwareUpdateDevSetting } from '../../states/jotai/atoms/devSettings';
+
 import { firmwareArtifactAdapter } from './FirmwareArtifactAdapter';
 import {
   cancelFirmwareArtifactPreparations,
@@ -32,6 +34,10 @@ import type {
   FirmwareUpdatePlan,
   FirmwareUpdatePreparedPlan,
 } from '@onekeyfe/hd-core';
+
+jest.mock('../../states/jotai/atoms/devSettings', () => ({
+  getGatedFirmwareUpdateDevSetting: jest.fn(async () => undefined),
+}));
 
 const ready = {
   planSchemaVersion: 2,
@@ -685,6 +691,37 @@ describe('downloadFirmwareArtifact', () => {
     expect(trace).toHaveBeenCalledWith(
       expect.stringContaining('"stage":"artifact-download-complete"'),
     );
+    expect(download.mock.calls[0][0].allowPreReleaseHosts).toBeUndefined();
+  });
+
+  test('forwards the pre-release host admission only while the dev setting is on', async () => {
+    jest.spyOn(loggerUtils, 'consoleFunc').mockImplementation(() => undefined);
+    jest
+      .mocked(getGatedFirmwareUpdateDevSetting)
+      .mockResolvedValueOnce(true as never);
+    const artifact = testFirmwareArtifact;
+    const download = jest
+      .spyOn(firmwareArtifactAdapter, 'download')
+      .mockResolvedValue({
+        artifactRef: `fw:${artifact.expectedSha256}`,
+        size: artifact.expectedSize,
+        sha256: artifact.expectedSha256,
+        expectedSha256Verified: true,
+      });
+
+    await downloadFirmwareArtifact({
+      artifact,
+      artifactId: 'bootloader',
+      taskId: 'bootloader-download',
+      transactionId: 'fwtx:pre-release-hosts',
+      leaseRef: 'fwlease:pre-release-hosts',
+      deadlineAt: Date.now() + 20 * 60 * 1000,
+    });
+
+    expect(getGatedFirmwareUpdateDevSetting).toHaveBeenCalledWith(
+      'usePreReleaseConfig',
+    );
+    expect(download.mock.calls[0][0].allowPreReleaseHosts).toBe(true);
   });
 
   test('records a bounded error code when the native download fails', async () => {

--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.test.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.test.ts
@@ -1,0 +1,61 @@
+import {
+  devSettingsPersistAtom,
+  firmwareUpdateDevSettingsPersistAtom,
+  getGatedFirmwareUpdateDevSetting,
+} from './devSettings';
+
+jest.mock('../utils', () => ({
+  globalAtom: jest.fn(() => ({
+    target: { get: jest.fn(), set: jest.fn() },
+    use: jest.fn(),
+  })),
+  globalAtomComputed: jest.fn(() => ({ target: {}, use: jest.fn() })),
+  globalAtomComputedRW: jest.fn(() => ({ target: {}, use: jest.fn() })),
+}));
+
+const mockedDevSettings = jest.mocked(devSettingsPersistAtom.get);
+const mockedFirmwareDevSettings = jest.mocked(
+  firmwareUpdateDevSettingsPersistAtom.get,
+);
+
+describe('getGatedFirmwareUpdateDevSetting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reads the value only while global developer mode is enabled', async () => {
+    mockedDevSettings.mockResolvedValue({ enabled: true, settings: {} });
+    mockedFirmwareDevSettings.mockResolvedValue({
+      usePreReleaseConfig: true,
+    } as never);
+
+    await expect(
+      getGatedFirmwareUpdateDevSetting('usePreReleaseConfig'),
+    ).resolves.toBe(true);
+  });
+
+  it('never leaks a stale value once developer mode is off', async () => {
+    // The persisted firmware settings may still hold `true` from an earlier
+    // session; the global gate must win.
+    mockedDevSettings.mockResolvedValue({ enabled: false, settings: {} });
+    mockedFirmwareDevSettings.mockResolvedValue({
+      usePreReleaseConfig: true,
+    } as never);
+
+    await expect(
+      getGatedFirmwareUpdateDevSetting('usePreReleaseConfig'),
+    ).resolves.toBeUndefined();
+    expect(mockedFirmwareDevSettings).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined for a disabled firmware setting under developer mode', async () => {
+    mockedDevSettings.mockResolvedValue({ enabled: true, settings: {} });
+    mockedFirmwareDevSettings.mockResolvedValue({
+      usePreReleaseConfig: false,
+    } as never);
+
+    await expect(
+      getGatedFirmwareUpdateDevSetting('usePreReleaseConfig'),
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/devSettings.ts
@@ -231,6 +231,19 @@ export const {
   },
 });
 
+// Firmware update dev settings only take effect while global developer mode is
+// enabled; callers outside ServiceDevSetting must go through this gate too.
+export async function getGatedFirmwareUpdateDevSetting<
+  T extends IFirmwareUpdateDevSettingsKeys,
+>(key: T): Promise<IFirmwareUpdateDevSettings[T] | undefined> {
+  const dev = await devSettingsPersistAtom.get();
+  if (!dev.enabled) {
+    return undefined;
+  }
+  const fwDev = await firmwareUpdateDevSettingsPersistAtom.get();
+  return fwDev[key];
+}
+
 export type INotificationsDevSettings = {
   showMessagePushSource?: boolean;
   disabledWebSocket?: boolean;


### PR DESCRIPTION
## Background

`DesktopApiFirmwareArtifact.ts` (Electron main process) admits firmware artifact downloads against a hardcoded hostname allowlist. The allowlist currently on `hotfix/v6.5.2` carries a developer object-storage bucket alongside the two production asset hosts, and #12788 swaps that bucket for a different hardcoded one. That leaves two problems:

1. **The hostnames keep changing.** Pre-release firmware artifacts are published by developers to their own buckets across several object-storage providers, and the bucket changes from build to build. Every new bucket means a code change and a release.
2. **A developer host sits in the production allowlist.** Scanning the current production firmware manifest, the only artifact hostnames it references are the two official OneKey asset hosts — no developer bucket appears anywhere — and the Pro2 / Neo sections do not exist in the production manifest at all. So that bucket serves no production purpose; it is pure admission surface. Removing it has zero impact on production users.

On top of that, most bucket hostnames in the pre-release manifest are not on the allowlist at all, so once a developer turns on "Use pre-release config" those downloads are rejected outright by the main process.

## Changes

Take developer hostnames out of the static allowlist entirely and admit them through the developer-mode switch instead:

- **Narrow the production allowlist** to the two official OneKey asset hosts, dropping every developer bucket entry. The production path ends up stricter than before this PR.
- `isFirmwareArtifactUrlAllowed(url, options?)` gains `allowPreReleaseHosts`: when `true`, the hostname-set comparison is skipped. **Structural checks are unaffected** — `https:`, empty port, no username/password, no hash still always run, and `redirect: 'error'` and `maxBytes` are untouched.
- **Skipping hostname pinning now requires content pinning.** `validateDownloadInput` rejects outright when `allowPreReleaseHosts` is true and `expectedSha256` is missing. Every admitted download therefore satisfies at least one of "hostname is on the reviewed allowlist" or "content is SHA-256 pinned" — there is no path where neither holds. Every artifact in the current pre-release manifest already carries a hash (`fingerprint` for components, `archiveSha256` for resource archives, zero exceptions), so this constraint does not block the real developer flow.
- bg has exactly one injection point: `FirmwareArtifactPreflight.downloadFirmwareArtifact()` reads `usePreReleaseConfig` and passes it through. This is the only `firmwareArtifactAdapter.download()` call site in the repository, so no other caller can forget it or route around it.
- Extract `getGatedFirmwareUpdateDevSetting()` into `states/jotai/atoms/devSettings.ts`, preserving the existing "global developer mode must be enabled" two-atom gate. `ServiceDevSetting.getFirmwareUpdateDevSettings` now delegates to it so the gate is not written twice.

## The switch has exactly one way in

`allowPreReleaseHosts` can only be true when both of these hold:

1. Global developer mode: `devSettingsPersistAtom.enabled === true`
2. The firmware dev setting `usePreReleaseConfig === true` (Settings → Developer options → Firmware Update → "Use pre-release config")

If either is false, `getGatedFirmwareUpdateDevSetting` returns `undefined`, the `=== true` comparison fails, the field never appears in the download input, and the main process evaluates `input.allowPreReleaseHosts === true` as false and applies the full allowlist.

On defaults: `devSettingsPersistAtom.enabled` defaults to `false` in production builds (`true` in dev/E2E builds), while `usePreReleaseConfig` defaults to `false` unconditionally in every build. Either way an explicit user action is required before the switch can open.

`ServiceDevSetting.switchDevMode(false)` also resets `usePreReleaseConfig` to `false` when developer mode is turned off, so there is no "developer mode off but a stale true value persisted" state.

Admission uses a strict `=== true` at both layers (`validateDownloadInput` and `isFirmwareArtifactUrlAllowed`). The field crosses an IPC boundary and can in principle arrive as any JSON value, so a test locks this down: `undefined` / `null` / `false` / `0` / `1` / `'true'` / `'false'` / `{}` / `[]` are all rejected, and only the literal boolean `true` skips hostname pinning. Anyone who later rewrites this as `Boolean(x)` or `!!x` will fail the test.

This matches what the switch already means: turning it on already redirects the entire firmware manifest to the pre-release one, so widening host admission is an extension of the same trust decision.

## Runtime boundaries

- The Electron main process owns URL admission and on-disk verification; it never touches the bg JS heap.
- The bg runtime reads the dev setting and drives download, verification and extraction; that data is deserialized only into the bg heap.
- The native (iOS/Android) adapter builds its payload field by field and does not forward the flag, so native modules need no change — native has no hostname allowlist to begin with, only HTTPS plus a same-host response check.

## Known trade-off

The main process trusts the boolean bg sends it. A fully compromised renderer can call the desktopApi bridge directly and bypass the dev setting — that is inherent to the bridge (`DESKTOP_API_CALL` in `apps/desktop/app/app.ts` does not authorize per method on allowlisted modules) and is not introduced by this PR.

In that scenario the ceiling for an attacker is: fetch bytes from an arbitrary https host **whose SHA-256 matches a digest they chose**, and have them written to the artifact store. They cannot obtain arbitrary content, because skipping hostname pinning now requires a SHA-256 (above) and the main process verifies against it before the file is promoted, deleting it on mismatch. Installing firmware onto a device still has to pass device-side signature verification afterwards. Relative to today — a developer bucket permanently on the production allowlist, with no such requirement — the production path is a net tightening.

One scoping note: the flag is derived from the global switch rather than from each artifact's provenance, so while developer mode is on a stable-manifest download also takes the relaxed comparison. In practice that is a no-op, since stable-manifest URLs are already on the allowlist; making it provenance-driven would mean adding a field to `IFirmwareDownloadArtifact`, which is a design change rather than a fix.

## Verification

- [x] `desktopApis/` + `ServiceFirmwareUpdate/` + `ServiceDevSetting` + `states/jotai`: 302/302 passing
- [x] `yarn agent:check --profile commit`
- [x] `yarn agent:check --profile pr` — all local checks pass
- [ ] On device: with developer mode and "Use pre-release config" on, download Pro2/Neo resources from a bucket referenced by the pre-release manifest; with the switch off, confirm the same URL is rejected by the main process

Note that `lint.yml` and `unittest.yml` only trigger for PRs whose base branch is `onekey`, `x`, `hotfix/*` or `release/*`, so they do not run on this stacked PR. Unit tests were dispatched manually against this branch instead, and CI will cover the change again through #12788 once this merges.

New tests are deliberately spread across three levels rather than only covering the pure function:

1. **The admission predicate**: with the switch on, an arbitrary bucket host is admitted and production hosts are unaffected; with it off, the bucket host is rejected. With the switch on, `http:` / a port / userinfo / a fragment are all still rejected. Plus the strict `=== true` fail-closed behaviour described above.
2. **The `download()` entry point** (where an IPC caller actually lands, not the pure function): a non-allowlisted host is rejected; `allowPreReleaseHosts: 'true'` as a string does not sneak through; the switch on without a SHA-256 is rejected; the switch on with a SHA-256 reaches the network stage. This exists specifically so that rewriting `=== true` as `Boolean(...)` cannot pass while the predicate tests stay green.
3. **The gate itself** (`devSettings.test.ts`, mocking only the two atoms and running the real gate): with developer mode off it returns `undefined` even when a stale `usePreReleaseConfig: true` is persisted, and it does not read the firmware settings atom at all.

A bg-side test additionally asserts that `downloadFirmwareArtifact` passes the field to the adapter only when the dev setting is true, and omits it entirely otherwise.

Test fixtures use reserved `.test` hostnames rather than any real bucket, so no developer storage endpoint is named in this repository.
