### PR TITLE
fix: smooth trade layout transitions OK-58846 OK-58690 OK-58977

### DIFF
--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -33,6 +33,7 @@ import {
   useSwapProviderSupportReceiveAddressAtom,
   useSwapQuoteActionLockAtom,
   useSwapQuoteCurrentSelectAtom,
+  useSwapQuoteEventCompletedAtom,
   useSwapQuoteEventTotalCountAtom,
   useSwapQuoteListAtom,
   useSwapSelectFromTokenAtom,
@@ -122,6 +123,7 @@ const SwapActionsState = ({
   const [quoteActionLock] = useSwapQuoteActionLockAtom();
   const [fromTokenAmount] = useSwapFromTokenAmountAtom();
   const [toTokenAmount] = useSwapToTokenAmountAtom();
+  const [quoteEventCompleted] = useSwapQuoteEventCompletedAtom();
   const [, setSwapManualSelectQuoteProvider] =
     useSwapManualSelectQuoteProvidersAtom();
   const [, setSwapQuoteEventTotalCount] = useSwapQuoteEventTotalCountAtom();
@@ -212,12 +214,17 @@ const SwapActionsState = ({
   // pending, and adopt the atom value once that quote settles — either with
   // a result (the provider's real support) or definitively without one
   // (back to the fallback) — so a previous pair's value cannot outlive its
-  // own quote cycle. `quoteActionLock` matching the current input is what
-  // separates "settled with no result" from the pre-quote debounce window.
+  // own quote cycle. `quoteActionLock` matching the current input separates
+  // "settled with no result" from the pre-quote debounce window, and
+  // `actionLock`/`quoteEventCompleted` keep the request-starting interval
+  // (lock written, fetching flag not yet set while `closeApproving` awaits)
+  // counted as pending.
   const isQuoteSettledWithoutResult =
     !currentQuoteRes &&
     !quoteLoading &&
     !quoteEventFetching &&
+    !quoteActionLock.actionLock &&
+    quoteEventCompleted &&
     isSwapQuoteRequestForCurrentInput({
       currentAccountId: swapFromAddressInfo?.accountInfo?.account?.id,
       currentAddress: swapFromAddressInfo?.address,

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -4,7 +4,6 @@ import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
 import {
-  AnimatePresence,
   Badge,
   Button,
   DashText,
@@ -93,19 +92,6 @@ interface ISwapActionsStateProps {
   onOpenRecipientAddress: () => void;
   onSelectPercentageStage?: (stage: number) => void;
 }
-
-// OK-58846: the fee-save badge appears only after the quote resolves, which
-// used to push the content around it abruptly. Its wrapper expands from 0
-// height instead. The wrapper permanently carries a negative margin that
-// cancels the parent Stack gap ("$2" = 8px) and re-adds that spacing as inner
-// padding, so the total occupied space is driven purely by the animated
-// height (margins are not animatable by the moti driver and would snap).
-// Badge (sm) height: bodySm lineHeight 16 + 2 * 2 vertical padding.
-const COST_SAVINGS_BADGE_HEIGHT = 20;
-const COST_SAVINGS_GAP_OFFSET = -8;
-const COST_SAVINGS_EXPANDED_HEIGHT =
-  COST_SAVINGS_BADGE_HEIGHT - COST_SAVINGS_GAP_OFFSET;
-const ANIMATE_ONLY_COST_SAVINGS = ['height', 'opacity'] as string[];
 
 // cspell:ignore ellipsize
 
@@ -875,50 +861,28 @@ const SwapActionsState = ({
     intl,
   ]);
 
+  // OK-58846: reveal the fee-save badge smoothly instead of letting it shove
+  // the surrounding layout; height is measured so localized or wrapped badge
+  // content can never be clipped. parentGap offsets the hosting Stack gap
+  // ("$2" = 8), which sits below the badge when it renders above the button.
   const costSavingsAboveButtonComponent = useMemo(
     () => (
-      <AnimatePresence>
-        {costSavingsComponent ? (
-          <Stack
-            key="costSavingsAboveButton"
-            animation="smooth"
-            animateOnly={ANIMATE_ONLY_COST_SAVINGS}
-            overflow="hidden"
-            mb={COST_SAVINGS_GAP_OFFSET}
-            height={COST_SAVINGS_EXPANDED_HEIGHT}
-            enterStyle={{ height: 0, opacity: 0 }}
-            exitStyle={{ height: 0, opacity: 0 }}
-          >
-            {/* spacing lives on the inner element: padding on the animated
-              wrapper would clamp its border-box height above 0 */}
-            <Stack pb="$2">{costSavingsComponent}</Stack>
-          </Stack>
-        ) : null}
-      </AnimatePresence>
+      <SwapSmoothReveal
+        visible={!!costSavingsComponent}
+        parentGap={8}
+        gapSide="bottom"
+      >
+        {costSavingsComponent}
+      </SwapSmoothReveal>
     ),
     [costSavingsComponent],
   );
 
   const costSavingsBelowButtonComponent = useMemo(
     () => (
-      <AnimatePresence>
-        {costSavingsComponent ? (
-          <Stack
-            key="costSavingsBelowButton"
-            animation="smooth"
-            animateOnly={ANIMATE_ONLY_COST_SAVINGS}
-            overflow="hidden"
-            mt={COST_SAVINGS_GAP_OFFSET}
-            height={COST_SAVINGS_EXPANDED_HEIGHT}
-            enterStyle={{ height: 0, opacity: 0 }}
-            exitStyle={{ height: 0, opacity: 0 }}
-          >
-            {/* spacing lives on the inner element: padding on the animated
-              wrapper would clamp its border-box height above 0 */}
-            <Stack pt="$2">{costSavingsComponent}</Stack>
-          </Stack>
-        ) : null}
-      </AnimatePresence>
+      <SwapSmoothReveal visible={!!costSavingsComponent} parentGap={8}>
+        {costSavingsComponent}
+      </SwapSmoothReveal>
     ),
     [costSavingsComponent],
   );
@@ -1097,38 +1061,23 @@ const SwapActionsState = ({
     () => (
       <Page.Footer>
         <Stack p="$5" bg="$bgApp" gap="$2">
-          <AnimatePresence>
-            {costSavingsComponent ? (
-              <XStack
-                key="costSavingsFooter"
-                width="100%"
-                justifyContent="flex-end"
-                animation="smooth"
-                animateOnly={ANIMATE_ONLY_COST_SAVINGS}
-                overflow="hidden"
-                mb={COST_SAVINGS_GAP_OFFSET}
-                height={COST_SAVINGS_EXPANDED_HEIGHT}
-                enterStyle={{ height: 0, opacity: 0 }}
-                exitStyle={{ height: 0, opacity: 0 }}
+          <SwapSmoothReveal
+            visible={!!costSavingsComponent}
+            parentGap={8}
+            gapSide="bottom"
+          >
+            <XStack width="100%" justifyContent="flex-end">
+              <Stack
+                flexShrink={0}
+                alignItems="stretch"
+                {...desktopActionWidthProps}
               >
-                {/* spacing lives on the inner element: padding on the animated
-                  wrapper would clamp its border-box height above 0 */}
-                <Stack
-                  flexShrink={0}
-                  alignItems="stretch"
-                  pb="$2"
-                  {...desktopActionWidthProps}
-                >
-                  <Stack
-                    alignItems="center"
-                    onLayout={onDesktopActionTagLayout}
-                  >
-                    {costSavingsComponent}
-                  </Stack>
+                <Stack alignItems="center" onLayout={onDesktopActionTagLayout}>
+                  {costSavingsComponent}
                 </Stack>
-              </XStack>
-            ) : null}
-          </AnimatePresence>
+              </Stack>
+            </XStack>
+          </SwapSmoothReveal>
           <XStack width="100%" alignItems="center" gap="$4">
             <XStack
               flex={1}

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -255,10 +255,10 @@ const SwapActionsState = ({
     () =>
       shouldShowSwapIncognitoRecipientInput({
         incognitoMode: swapIncognitoMode,
-        providerSupportsRecipient: swapProviderSupportReceiveAddress,
+        providerSupportsRecipient: providerSupportReceiveAddressSettled,
         swapType: swapTypeSwitch,
       }),
-    [swapIncognitoMode, swapProviderSupportReceiveAddress, swapTypeSwitch],
+    [swapIncognitoMode, providerSupportReceiveAddressSettled, swapTypeSwitch],
   );
 
   const incognitoRecipientNetworkId =
@@ -270,14 +270,14 @@ const SwapActionsState = ({
         hasToToken: Boolean(toToken),
         isAddressInfoReady: swapToAddressInfo.isAddressInfoReady,
         networkId: incognitoRecipientNetworkId,
-        providerSupportsRecipient: swapProviderSupportReceiveAddress,
+        providerSupportsRecipient: providerSupportReceiveAddressSettled,
         visible: shouldShowIncognitoRecipientInput,
       }),
     [
       fromToken,
       incognitoRecipientNetworkId,
       shouldShowIncognitoRecipientInput,
-      swapProviderSupportReceiveAddress,
+      providerSupportReceiveAddressSettled,
       swapToAddressInfo.isAddressInfoReady,
       toToken,
     ],

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
 import {
+  AnimatePresence,
   Badge,
   Button,
   DashText,
@@ -80,6 +81,7 @@ import { buildSwapIncognitoSettingsUpdate } from '../../utils/incognitoSettings'
 
 import { SwapIncognitoRecipientInput } from './SwapIncognitoRecipientInput';
 import { PercentageStageOnKeyboard } from './SwapInputContainer';
+import { SwapSmoothReveal } from './SwapSmoothReveal';
 
 interface ISwapActionsStateProps {
   forceQuoteActionLoading?: boolean;
@@ -87,6 +89,19 @@ interface ISwapActionsStateProps {
   onOpenRecipientAddress: () => void;
   onSelectPercentageStage?: (stage: number) => void;
 }
+
+// OK-58846: the fee-save badge appears only after the quote resolves, which
+// used to push the content around it abruptly. Its wrapper expands from 0
+// height instead. The wrapper permanently carries a negative margin that
+// cancels the parent Stack gap ("$2" = 8px) and re-adds that spacing as inner
+// padding, so the total occupied space is driven purely by the animated
+// height (margins are not animatable by the moti driver and would snap).
+// Badge (sm) height: bodySm lineHeight 16 + 2 * 2 vertical padding.
+const COST_SAVINGS_BADGE_HEIGHT = 20;
+const COST_SAVINGS_GAP_OFFSET = -8;
+const COST_SAVINGS_EXPANDED_HEIGHT =
+  COST_SAVINGS_BADGE_HEIGHT - COST_SAVINGS_GAP_OFFSET;
+const ANIMATE_ONLY_COST_SAVINGS = ['height', 'opacity'] as string[];
 
 // cspell:ignore ellipsize
 
@@ -183,6 +198,20 @@ const SwapActionsState = ({
     [incognitoTooltipContent],
   );
 
+  // OK-58977: `swapProviderSupportReceiveAddressAtom` is computed from the
+  // currently selected quote and falls back to "supported" whenever no quote
+  // result is selected — which is the case for the whole input-debounce plus
+  // quoting window on every quote refresh. Trusting that fallback used to
+  // expand the recipient entry mid-quote and collapse it again right after.
+  // Hold the last definitive value instead; only a settled quote result may
+  // change it.
+  const settledProviderSupportRef = useRef(swapProviderSupportReceiveAddress);
+  if (currentQuoteRes) {
+    settledProviderSupportRef.current = swapProviderSupportReceiveAddress;
+  }
+  const providerSupportReceiveAddressSettled =
+    settledProviderSupportRef.current;
+
   const shouldShowRecipient = useMemo(
     () =>
       !!(
@@ -190,14 +219,14 @@ const SwapActionsState = ({
           swapTypeSwitch === ESwapTabSwitchType.STOCK ||
           !swapIncognitoMode) &&
         swapEnableRecipientAddress &&
-        swapProviderSupportReceiveAddress &&
+        providerSupportReceiveAddressSettled &&
         fromToken &&
         toToken
       ),
     [
       swapIncognitoMode,
       swapEnableRecipientAddress,
-      swapProviderSupportReceiveAddress,
+      providerSupportReceiveAddressSettled,
       fromToken,
       swapTypeSwitch,
       toToken,
@@ -587,45 +616,50 @@ const SwapActionsState = ({
       : null;
 
   const recipientComponent = useMemo(() => {
-    if (shouldShowRecipientInActionRow) {
-      return (
-        <XStack
-          gap="$1.5"
-          {...(isDesktopModalPage ? { flex: 1 } : { pb: '$4' })}
-        >
-          <Stack>
-            <Icon name="AddedPeopleOutline" size="$5" color="$iconSubdued" />
-          </Stack>
-          <XStack flex={1} flexWrap="wrap" gap="$1.5" minWidth={0}>
-            <SizableText flexShrink={0} size="$bodyMd" color="$textSubdued">
-              {recipientSendToLabel}
-            </SizableText>
+    const recipientRow = (
+      <XStack gap="$1.5" {...(isDesktopModalPage ? { flex: 1 } : { pb: '$4' })}>
+        <Stack>
+          <Icon name="AddedPeopleOutline" size="$5" color="$iconSubdued" />
+        </Stack>
+        <XStack flex={1} flexWrap="wrap" gap="$1.5" minWidth={0}>
+          <SizableText flexShrink={0} size="$bodyMd" color="$textSubdued">
+            {recipientSendToLabel}
+          </SizableText>
+          <SizableText
+            flexShrink={0}
+            size="$bodyMd"
+            cursor="pointer"
+            textDecorationLine="underline"
+            onPress={onOpenRecipientAddress}
+          >
+            {recipientAddressDisplayLabel}
+          </SizableText>
+          {recipientAccountDisplayLabel ? (
             <SizableText
-              flexShrink={0}
+              flexShrink={1}
+              minWidth={0}
               size="$bodyMd"
-              cursor="pointer"
-              textDecorationLine="underline"
-              onPress={onOpenRecipientAddress}
+              color="$textSubdued"
+              numberOfLines={1}
+              ellipsizeMode="middle"
             >
-              {recipientAddressDisplayLabel}
+              {recipientAccountDisplayLabel}
             </SizableText>
-            {recipientAccountDisplayLabel ? (
-              <SizableText
-                flexShrink={1}
-                minWidth={0}
-                size="$bodyMd"
-                color="$textSubdued"
-                numberOfLines={1}
-                ellipsizeMode="middle"
-              >
-                {recipientAccountDisplayLabel}
-              </SizableText>
-            ) : null}
-          </XStack>
+          ) : null}
         </XStack>
-      );
+      </XStack>
+    );
+    if (isDesktopModalPage) {
+      return shouldShowRecipientInActionRow ? recipientRow : null;
     }
-    return null;
+    // OK-58977: provider support for a custom recipient varies per token, so
+    // this row mounts/unmounts on token switches; reveal it smoothly. Its
+    // spacing (pb) sits inside the measured content, so no gap offset needed.
+    return (
+      <SwapSmoothReveal visible={shouldShowRecipientInActionRow}>
+        {recipientRow}
+      </SwapSmoothReveal>
+    );
   }, [
     recipientAccountDisplayLabel,
     recipientAddressDisplayLabel,
@@ -809,6 +843,54 @@ const SwapActionsState = ({
     intl,
   ]);
 
+  const costSavingsAboveButtonComponent = useMemo(
+    () => (
+      <AnimatePresence>
+        {costSavingsComponent ? (
+          <Stack
+            key="costSavingsAboveButton"
+            animation="smooth"
+            animateOnly={ANIMATE_ONLY_COST_SAVINGS}
+            overflow="hidden"
+            mb={COST_SAVINGS_GAP_OFFSET}
+            height={COST_SAVINGS_EXPANDED_HEIGHT}
+            enterStyle={{ height: 0, opacity: 0 }}
+            exitStyle={{ height: 0, opacity: 0 }}
+          >
+            {/* spacing lives on the inner element: padding on the animated
+              wrapper would clamp its border-box height above 0 */}
+            <Stack pb="$2">{costSavingsComponent}</Stack>
+          </Stack>
+        ) : null}
+      </AnimatePresence>
+    ),
+    [costSavingsComponent],
+  );
+
+  const costSavingsBelowButtonComponent = useMemo(
+    () => (
+      <AnimatePresence>
+        {costSavingsComponent ? (
+          <Stack
+            key="costSavingsBelowButton"
+            animation="smooth"
+            animateOnly={ANIMATE_ONLY_COST_SAVINGS}
+            overflow="hidden"
+            mt={COST_SAVINGS_GAP_OFFSET}
+            height={COST_SAVINGS_EXPANDED_HEIGHT}
+            enterStyle={{ height: 0, opacity: 0 }}
+            exitStyle={{ height: 0, opacity: 0 }}
+          >
+            {/* spacing lives on the inner element: padding on the animated
+              wrapper would clamp its border-box height above 0 */}
+            <Stack pt="$2">{costSavingsComponent}</Stack>
+          </Stack>
+        ) : null}
+      </AnimatePresence>
+    ),
+    [costSavingsComponent],
+  );
+
   useEffect(() => {
     if (!costSavingsComponent) {
       setDesktopActionWidth(undefined);
@@ -890,7 +972,7 @@ const SwapActionsState = ({
         {recipientComponent}
         <Stack gap="$2">
           {/* In desktop modal: show savings above button; otherwise show below */}
-          {isDesktopModalPage ? costSavingsComponent : null}
+          {isDesktopModalPage ? costSavingsAboveButtonComponent : null}
           <Button
             testID={SwapTestIDs.swapButton}
             onPress={onActionHandlerBefore}
@@ -903,7 +985,7 @@ const SwapActionsState = ({
             {actionButtonChildren}
           </Button>
           {/* In regular pages and non-desktop modal: show savings below button */}
-          {!isDesktopModalPage ? costSavingsComponent : null}
+          {!isDesktopModalPage ? costSavingsBelowButtonComponent : null}
         </Stack>
       </Stack>
     ),
@@ -914,7 +996,8 @@ const SwapActionsState = ({
       isDesktopModalPage,
       recipientComponent,
       shouldShowRecipientInActionRow,
-      costSavingsComponent,
+      costSavingsAboveButtonComponent,
+      costSavingsBelowButtonComponent,
     ],
   );
 
@@ -982,19 +1065,38 @@ const SwapActionsState = ({
     () => (
       <Page.Footer>
         <Stack p="$5" bg="$bgApp" gap="$2">
-          {costSavingsComponent ? (
-            <XStack width="100%" justifyContent="flex-end">
-              <Stack
-                flexShrink={0}
-                alignItems="stretch"
-                {...desktopActionWidthProps}
+          <AnimatePresence>
+            {costSavingsComponent ? (
+              <XStack
+                key="costSavingsFooter"
+                width="100%"
+                justifyContent="flex-end"
+                animation="smooth"
+                animateOnly={ANIMATE_ONLY_COST_SAVINGS}
+                overflow="hidden"
+                mb={COST_SAVINGS_GAP_OFFSET}
+                height={COST_SAVINGS_EXPANDED_HEIGHT}
+                enterStyle={{ height: 0, opacity: 0 }}
+                exitStyle={{ height: 0, opacity: 0 }}
               >
-                <Stack alignItems="center" onLayout={onDesktopActionTagLayout}>
-                  {costSavingsComponent}
+                {/* spacing lives on the inner element: padding on the animated
+                  wrapper would clamp its border-box height above 0 */}
+                <Stack
+                  flexShrink={0}
+                  alignItems="stretch"
+                  pb="$2"
+                  {...desktopActionWidthProps}
+                >
+                  <Stack
+                    alignItems="center"
+                    onLayout={onDesktopActionTagLayout}
+                  >
+                    {costSavingsComponent}
+                  </Stack>
                 </Stack>
-              </Stack>
-            </XStack>
-          ) : null}
+              </XStack>
+            ) : null}
+          </AnimatePresence>
           <XStack width="100%" alignItems="center" gap="$4">
             <XStack
               flex={1}

--- a/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapActionsState.tsx
@@ -28,6 +28,7 @@ import { useHelpLink } from '@onekeyhq/kit/src/hooks/useHelpLink';
 import { useThemeVariant } from '@onekeyhq/kit/src/hooks/useThemeVariant';
 import {
   useSwapActions,
+  useSwapFromTokenAmountAtom,
   useSwapManualSelectQuoteProvidersAtom,
   useSwapProviderSupportReceiveAddressAtom,
   useSwapQuoteActionLockAtom,
@@ -37,8 +38,10 @@ import {
   useSwapSelectFromTokenAtom,
   useSwapSelectToTokenAtom,
   useSwapToAnotherAccountAddressAtom,
+  useSwapToTokenAmountAtom,
   useSwapTypeSwitchAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
+import { isSwapQuoteRequestForCurrentInput } from '@onekeyhq/kit/src/states/jotai/contexts/swap/quoteProgress';
 import {
   useSettingsAtom,
   useSettingsPersistAtom,
@@ -117,6 +120,8 @@ const SwapActionsState = ({
   const [toToken] = useSwapSelectToTokenAtom();
   const [currentQuoteRes] = useSwapQuoteCurrentSelectAtom();
   const [quoteActionLock] = useSwapQuoteActionLockAtom();
+  const [fromTokenAmount] = useSwapFromTokenAmountAtom();
+  const [toTokenAmount] = useSwapToTokenAmountAtom();
   const [, setSwapManualSelectQuoteProvider] =
     useSwapManualSelectQuoteProvidersAtom();
   const [, setSwapQuoteEventTotalCount] = useSwapQuoteEventTotalCountAtom();
@@ -203,10 +208,30 @@ const SwapActionsState = ({
   // result is selected — which is the case for the whole input-debounce plus
   // quoting window on every quote refresh. Trusting that fallback used to
   // expand the recipient entry mid-quote and collapse it again right after.
-  // Hold the last definitive value instead; only a settled quote result may
-  // change it.
+  // Hold the last definitive value while a quote for the current input is
+  // pending, and adopt the atom value once that quote settles — either with
+  // a result (the provider's real support) or definitively without one
+  // (back to the fallback) — so a previous pair's value cannot outlive its
+  // own quote cycle. `quoteActionLock` matching the current input is what
+  // separates "settled with no result" from the pre-quote debounce window.
+  const isQuoteSettledWithoutResult =
+    !currentQuoteRes &&
+    !quoteLoading &&
+    !quoteEventFetching &&
+    isSwapQuoteRequestForCurrentInput({
+      currentAccountId: swapFromAddressInfo?.accountInfo?.account?.id,
+      currentAddress: swapFromAddressInfo?.address,
+      currentReceivingAddress: swapToAddressInfo?.address,
+      currentSwapType: swapTypeSwitch,
+      fromAmount: fromTokenAmount.value,
+      toAmount: toTokenAmount.value,
+      fromToken,
+      toToken,
+      quoteKind: quoteActionLock?.kind ?? ESwapQuoteKind.SELL,
+      quoteRequest: quoteActionLock,
+    });
   const settledProviderSupportRef = useRef(swapProviderSupportReceiveAddress);
-  if (currentQuoteRes) {
+  if (currentQuoteRes || isQuoteSettledWithoutResult) {
     settledProviderSupportRef.current = swapProviderSupportReceiveAddress;
   }
   const providerSupportReceiveAddressSettled =

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
@@ -274,9 +274,16 @@ const SwapQuoteResult = ({
   const isWaitingForQuote =
     quoteUiPhase === ESwapQuoteUiPhase.Waiting && !hasQuoteResultForDisplay;
   const isStaleRefreshing = quoteUiPhase === ESwapQuoteUiPhase.StaleRefreshing;
+  // OK-58690: a quote event error without any displayable result used to
+  // render nothing at all here, which removed the manual refresh entry and
+  // made this row pop in/out around auto refreshes. Treat it like the
+  // zero-provider case so the row (with its refresh entry) stays on screen.
+  const isQuoteEventErrorWithoutResult =
+    quoteUiPhase === ESwapQuoteUiPhase.Error && !quoteResultForDisplay;
   const showNoProvider =
-    quoteUiPhase === ESwapQuoteUiPhase.ZeroProvider &&
-    !hasQuoteResultForDisplay;
+    (quoteUiPhase === ESwapQuoteUiPhase.ZeroProvider &&
+      !hasQuoteResultForDisplay) ||
+    isQuoteEventErrorWithoutResult;
 
   const fromAmountDebounce = useDebounce(
     fromTokenAmount,
@@ -330,9 +337,6 @@ const SwapQuoteResult = ({
         </XStack>
       </XStack>
     );
-  }
-  if (quoteUiPhase === ESwapQuoteUiPhase.Error && !quoteResultForDisplay) {
-    return null;
   }
   if (swapTypeSwitch === ESwapTabSwitchType.LIMIT) {
     if (

--- a/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapQuoteResult.tsx
@@ -276,14 +276,15 @@ const SwapQuoteResult = ({
   const isStaleRefreshing = quoteUiPhase === ESwapQuoteUiPhase.StaleRefreshing;
   // OK-58690: a quote event error without any displayable result used to
   // render nothing at all here, which removed the manual refresh entry and
-  // made this row pop in/out around auto refreshes. Treat it like the
-  // zero-provider case so the row (with its refresh entry) stays on screen.
+  // made this row pop in/out around auto refreshes. Keep the row mounted;
+  // with no rate available it falls into the "failed to fetch the quote"
+  // copy — an event failure is not a liquidity problem, so it must not
+  // reuse the no-provider presentation.
   const isQuoteEventErrorWithoutResult =
     quoteUiPhase === ESwapQuoteUiPhase.Error && !quoteResultForDisplay;
   const showNoProvider =
-    (quoteUiPhase === ESwapQuoteUiPhase.ZeroProvider &&
-      !hasQuoteResultForDisplay) ||
-    isQuoteEventErrorWithoutResult;
+    quoteUiPhase === ESwapQuoteUiPhase.ZeroProvider &&
+    !hasQuoteResultForDisplay;
 
   const fromAmountDebounce = useDebounce(
     fromTokenAmount,
@@ -394,7 +395,8 @@ const SwapQuoteResult = ({
   if (
     (swapTypeSwitch !== ESwapTabSwitchType.LIMIT ||
       quoteResultForDisplay?.isWrapped ||
-      showNoProvider) &&
+      showNoProvider ||
+      isQuoteEventErrorWithoutResult) &&
     fromToken &&
     toToken &&
     !new BigNumber(fromAmountDebounce.value).isZero() &&

--- a/packages/kit/src/views/Swap/pages/components/SwapSmoothReveal.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapSmoothReveal.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { AnimatePresence, Stack } from '@onekeyhq/components';
+
+const ANIMATE_ONLY_SMOOTH_REVEAL = ['height', 'opacity'] as string[];
+
+/**
+ * Expands/collapses `children` smoothly instead of letting them pop in and
+ * shove the surrounding layout (OK-58690). The wrapper permanently offsets
+ * the parent Stack gap with a negative margin and re-adds it as padding on
+ * the inner (measured) node, so the occupied space is driven purely by the
+ * animated height: margins are not animatable by the moti driver (they
+ * snap), and padding on the animated node itself would clamp its border-box
+ * height above 0. Content height is measured via onLayout, so
+ * variable-height children (multi-line or stacked alerts) are supported.
+ */
+export function SwapSmoothReveal({
+  visible,
+  parentGap = 0,
+  children,
+}: {
+  visible: boolean;
+  /**
+   * px value of the parent Stack gap to offset ("$3" = 12, "$4" = 16).
+   * Leave 0 when the children carry their own spacing (e.g. padding), which
+   * is then simply part of the measured height.
+   */
+  parentGap?: number;
+  children: ReactNode;
+}) {
+  const [measuredHeight, setMeasuredHeight] = useState(0);
+
+  const onContentLayout = useCallback(
+    (event: { nativeEvent: { layout: { height: number } } }) => {
+      const nextHeight = event?.nativeEvent?.layout?.height;
+      if (typeof nextHeight !== 'number' || Number.isNaN(nextHeight)) {
+        return;
+      }
+      setMeasuredHeight((prev) => (prev === nextHeight ? prev : nextHeight));
+    },
+    [],
+  );
+
+  return (
+    <AnimatePresence>
+      {visible ? (
+        <Stack
+          key="swapSmoothReveal"
+          animation="smooth"
+          animateOnly={ANIMATE_ONLY_SMOOTH_REVEAL}
+          overflow="hidden"
+          mt={-parentGap}
+          height={measuredHeight}
+          enterStyle={{ height: 0, opacity: 0 }}
+          exitStyle={{ height: 0, opacity: 0 }}
+        >
+          <Stack pt={parentGap} onLayout={onContentLayout}>
+            {children}
+          </Stack>
+        </Stack>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/packages/kit/src/views/Swap/pages/components/SwapSmoothReveal.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapSmoothReveal.tsx
@@ -18,6 +18,7 @@ const ANIMATE_ONLY_SMOOTH_REVEAL = ['height', 'opacity'] as string[];
 export function SwapSmoothReveal({
   visible,
   parentGap = 0,
+  gapSide = 'top',
   children,
 }: {
   visible: boolean;
@@ -27,6 +28,11 @@ export function SwapSmoothReveal({
    * is then simply part of the measured height.
    */
   parentGap?: number;
+  /**
+   * Which edge of the wrapper faces the parent gap being offset: 'top' when
+   * a sibling sits above the revealed content, 'bottom' when below.
+   */
+  gapSide?: 'top' | 'bottom';
   children: ReactNode;
 }) {
   const [measuredHeight, setMeasuredHeight] = useState(0);
@@ -42,6 +48,7 @@ export function SwapSmoothReveal({
     [],
   );
 
+  const isGapTop = gapSide === 'top';
   return (
     <AnimatePresence>
       {visible ? (
@@ -50,12 +57,17 @@ export function SwapSmoothReveal({
           animation="smooth"
           animateOnly={ANIMATE_ONLY_SMOOTH_REVEAL}
           overflow="hidden"
-          mt={-parentGap}
+          mt={isGapTop && parentGap ? -parentGap : undefined}
+          mb={!isGapTop && parentGap ? -parentGap : undefined}
           height={measuredHeight}
           enterStyle={{ height: 0, opacity: 0 }}
           exitStyle={{ height: 0, opacity: 0 }}
         >
-          <Stack pt={parentGap} onLayout={onContentLayout}>
+          <Stack
+            pt={isGapTop && parentGap ? parentGap : undefined}
+            pb={!isGapTop && parentGap ? parentGap : undefined}
+            onLayout={onContentLayout}
+          >
             {children}
           </Stack>
         </Stack>

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -1379,6 +1379,8 @@ function StockTradeTicket({
           quoteLoading={quoteLoading}
           quoteResult={quoteResult}
           stockChannel={stockChannel}
+          // px of the hosting YStack gap above: "$3" = 12, "$4" = 16
+          parentGap={compact ? 12 : 16}
         />
         {stockChannel.readyForQuote ? (
           <SwapQuoteResult

--- a/packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockTradeAlert.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useMemo, useRef } from 'react';
+import type { ReactNode } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -31,6 +32,7 @@ import { getStockTradeAlertAnalyticsPayload } from '../../utils/swapStockAnalyti
 import { getStockQuoteTradeControl } from '../../utils/swapStockTradeControl';
 
 import SwapAlertContainer from './SwapAlertContainer';
+import { SwapSmoothReveal } from './SwapSmoothReveal';
 import {
   getStockErrorAlertLevel,
   getStockTradeAlertType,
@@ -50,6 +52,8 @@ type ISwapStockTradeAlertProps = {
   quoteLoading: boolean;
   quoteResult?: IFetchQuoteResult;
   stockChannel: IUseSwapStockChannelReturn;
+  /** px value of the hosting Stack gap, offset by SwapSmoothReveal */
+  parentGap: number;
 };
 
 function useStockQuoteAlert({
@@ -101,6 +105,7 @@ function BasicSwapStockTradeAlert({
   quoteLoading,
   quoteResult,
   stockChannel,
+  parentGap,
 }: ISwapStockTradeAlertProps) {
   const intl = useIntl();
   const [quoteEventError] = useSwapQuoteEventErrorAtom();
@@ -258,6 +263,7 @@ function BasicSwapStockTradeAlert({
     stockTradeDisabled,
   ]);
 
+  let alertContent: ReactNode = null;
   if (isStockMarketClosed) {
     // Backend returns a localized countdown string (the first line of
     // stock.description); its presence means "we know the next open time".
@@ -270,7 +276,7 @@ function BasicSwapStockTradeAlert({
       hasOpenTime: Boolean(closedTimeText),
       hasPerps,
     });
-    return (
+    alertContent = (
       <StockMarketStatusAlert
         testID={SwapTestIDs.stockTradeStatusAlert}
         statusCase={statusCase}
@@ -278,10 +284,10 @@ function BasicSwapStockTradeAlert({
         onTradePerps={hlTicker ? () => navigateToPerps(hlTicker) : undefined}
       />
     );
-  }
-
-  if (stockChannel.channelStage === ESwapStockChannelStage.MissingPayToken) {
-    return (
+  } else if (
+    stockChannel.channelStage === ESwapStockChannelStage.MissingPayToken
+  ) {
+    alertContent = (
       <Alert
         testID={SwapTestIDs.stockTradeStatusAlert}
         type="warning"
@@ -291,16 +297,23 @@ function BasicSwapStockTradeAlert({
         })}
       />
     );
+  } else if (mergedQuoteAlerts.some((item) => item.message || item.title)) {
+    // Marker-only states (e.g. noConnectWallet) render nothing in
+    // SwapAlertContainer, so they must not open the reveal wrapper.
+    alertContent = (
+      <YStack testID={SwapTestIDs.stockTradeStatusAlert}>
+        <SwapAlertContainer alerts={mergedQuoteAlerts} />
+      </YStack>
+    );
   }
 
-  if (!mergedQuoteAlerts.length) {
-    return null;
-  }
-
+  // OK-58690: the alert hides while a quote refresh is in flight and comes
+  // back if the error persists; SwapSmoothReveal expands/collapses it
+  // smoothly so the content below is eased instead of shoved.
   return (
-    <YStack testID={SwapTestIDs.stockTradeStatusAlert}>
-      <SwapAlertContainer alerts={mergedQuoteAlerts} />
-    </YStack>
+    <SwapSmoothReveal visible={!!alertContent} parentGap={parentGap}>
+      {alertContent}
+    </SwapSmoothReveal>
   );
 }
 


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58846](https://onekeyhq.atlassian.net/browse/OK-58846) [OK-58690](https://onekeyhq.atlassian.net/browse/OK-58690) [OK-58977](https://onekeyhq.atlassian.net/browse/OK-58977)

----------

<!-- github-pr-monitor:jira-links:end -->


## 背景

三个 Jira issue 都属于同一类问题：Trade 页面上依赖询价结果的元素（提示条/警告/入口行）在出现或消失时瞬间插入布局，把周围内容"顶"得跳动。

- [OK-58846](https://onekeyhq.atlassian.net/browse/OK-58846) 询价结束后"0 手续费"提示条出现时页面跳动
- [OK-58690](https://onekeyhq.atlassian.net/browse/OK-58690) 没有渠道商报价时，刷新报价页面抖动
- [OK-58977](https://onekeyhq.atlassian.net/browse/OK-58977) 切换代币时"自定义收款地址"入口出现/消失跳动

## 改动

1. **新增 `SwapSmoothReveal` 组件**：通用的平滑展开/收起容器（约 300ms），内容高度动态测量，并抵消父容器 gap，出现瞬间占位从 0 平滑增长。
2. **OK-58846**：零手续费提示条以高度+透明度动画进出场（三个渲染位置：按钮上方/下方/桌面弹窗页脚）。
3. **OK-58690**：
   - 股票 tab 报错警告接入 `SwapSmoothReveal`，刷新报价时平滑收起、错误持续则平滑重现；
   - 报价事件出错且无结果时，底部报价行不再整行消失，改为显示"无提供商支持"+手动刷新入口（该行为对兑换&跨链、限价 tab 同样生效）。
4. **OK-58977**：
   - 收款地址入口接入 `SwapSmoothReveal`；
   - "渠道商是否支持自定义地址"在没有报价结果期间保持上一次的确定值（该状态是计算属性，无报价时会退化为"支持"的默认值，曾导致重新询价过程中入口闪现一次）。

## 测试要点

1. 三个 tab（兑换&跨链/股票/限价）各触发一次"报价错误且无结果"，确认底部显示"无提供商支持"行且无跳动。
2. 股票 tab：渠道商异常时点刷新，警告平滑收起，错误持续则平滑重现；下方内容跟随滑动而非跳动。
3. 开启自定义收款地址：在支持/不支持的代币间切换、修改金额重新询价，入口全程不闪现，仅在新结果落地时平滑变化。
4. 零手续费提示条：首次报价出现、切换交易对消失，两个方向均平滑。
5. 建议 iOS/Android 实机抽查上述场景（动画驱动为 reanimated，桌面端已验证）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[OK-58846]: https://onekeyhq.atlassian.net/browse/OK-58846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-58690]: https://onekeyhq.atlassian.net/browse/OK-58690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-58977]: https://onekeyhq.atlassian.net/browse/OK-58977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ