### PR TITLE
fix: preserve deprecated wallet account selection(OK-58315)

### DIFF
--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx
@@ -477,6 +477,46 @@ describe('useAccountSelectorActions', () => {
     jest.restoreAllMocks();
   });
 
+  it('selects deprecated wallets but rejects unavailable wallets', async () => {
+    const { store, Wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+    const confirm = async (wallet: IWallet | undefined, walletId: string) => {
+      mockGetWalletSafe.mockResolvedValueOnce(wallet);
+      let confirmed = true;
+      await act(async () => {
+        confirmed = await result.current.confirmAccountSelect({
+          num: 0,
+          indexedAccount: {
+            id: `${walletId}--0`,
+            walletId,
+          } as IIndexedAccount,
+          othersWalletAccount: undefined,
+        });
+      });
+      return confirmed;
+    };
+
+    expect(
+      await confirm(
+        { id: 'hw-deprecated', deprecated: true } as IWallet,
+        'hw-deprecated',
+      ),
+    ).toBe(true);
+    expect(store.get(selectedAccountsAtom())[0]).toMatchObject({
+      walletId: 'hw-deprecated',
+      indexedAccountId: 'hw-deprecated--0',
+    });
+    expect(
+      await confirm(
+        { id: 'hw-mocked', isMocked: true } as IWallet,
+        'hw-mocked',
+      ),
+    ).toBe(false);
+    expect(await confirm(undefined, 'hw-missing')).toBe(false);
+  });
+
   it('marks active account init done when reload finishes before storage init', async () => {
     const selectedAccountsMapDeferred = createDeferred<
       ISelectedAccountsMap | undefined
@@ -861,6 +901,7 @@ describe('useAccountSelectorActions', () => {
           othersWalletAccount: undefined,
           num: 0,
         });
+        await Promise.resolve();
         // The later selection resolves first...
         resolvers.get('qr-1')?.('btc--0');
         await latestSelect;
@@ -1425,6 +1466,49 @@ describe('useAccountSelectorActions', () => {
         }),
       }),
     );
+  });
+
+  it('preserves a deprecated wallet during init and auto-select', async () => {
+    const selectedAccount = createHdSelectedAccount('hd-1--0');
+    const deprecatedWallet = { id: 'hd-1', deprecated: true } as IWallet;
+    const indexedAccount = {
+      id: 'hd-1--0',
+      walletId: 'hd-1',
+    } as IIndexedAccount;
+    mockGetSelectedAccountsMap.mockResolvedValue({ 0: selectedAccount });
+    mockGetWalletSafe.mockResolvedValue(deprecatedWallet);
+
+    const { store, Wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountSelectorActions().current, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.initFromStorage({
+        sceneName: EAccountSelectorSceneName.home,
+      });
+    });
+    store.set(activeAccountsAtom(), {
+      0: {
+        ...defaultActiveAccountInfo(),
+        ready: true,
+        wallet: deprecatedWallet,
+        indexedAccount,
+        network: { id: selectedAccount.networkId } as NonNullable<
+          ReturnType<typeof defaultActiveAccountInfo>['network']
+        >,
+      },
+    });
+    await act(async () => {
+      await result.current.autoSelectNextAccount({
+        num: 0,
+        sceneName: EAccountSelectorSceneName.swap,
+      });
+    });
+
+    expect(store.get(selectedAccountsAtom())[0]).toMatchObject(selectedAccount);
+    expect(mockSaveSelectedAccount).not.toHaveBeenCalled();
+    expect(mockGetAllHdHwQrWallets).not.toHaveBeenCalled();
   });
 
   it('syncs home when storage init clears an unavailable home-sync source wallet', async () => {

--- a/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
+++ b/packages/kit/src/states/jotai/contexts/accountSelector/actions.tsx
@@ -903,10 +903,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
 
     const wallet = await serviceAccount.getWalletSafe({ walletId });
     const isMissingWallet = !wallet;
-    const isDeprecatedOrMocked = Boolean(
-      wallet && accountUtils.isWalletDeprecatedOrMocked(wallet),
-    );
-    return isMissingWallet || isDeprecatedOrMocked;
+    return isMissingWallet || Boolean(wallet?.isMocked);
   };
 
   clearUnavailableWalletSelectionsInStorage = async ({
@@ -1391,6 +1388,22 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
         confirmRequestId,
       );
 
+      let wallet: IDBWallet | undefined;
+      try {
+        wallet = await serviceAccount.getWalletSafe({ walletId });
+      } catch {
+        return false;
+      }
+      if (!wallet || wallet.isMocked) {
+        return false;
+      }
+      if (
+        this.confirmAccountSelectLatestRequestIdMap.get(confirmRequestKey) !==
+        confirmRequestId
+      ) {
+        return false;
+      }
+
       const accountNetworkId: string =
         forceSelectToNetworkId ||
         this.getAutoSelectNetworkIdForAccount.call(set, {
@@ -1436,7 +1449,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
         this.confirmAccountSelectLatestRequestIdMap.get(confirmRequestKey) !==
         confirmRequestId
       ) {
-        return;
+        return false;
       }
 
       const newSelectedAccount: IAccountSelectorSelectedAccount = {
@@ -1546,6 +1559,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
         indexedAccountId: indexedAccount?.id,
         othersWalletAccountId: othersWalletAccount?.id,
       });
+      return true;
     },
   );
 
@@ -3557,14 +3571,12 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
           activeAccount;
         const selectedAccount = this.getSelectedAccount.call(set, { num });
         const isAccountExist = Boolean(indexedAccount || account || dbAccount);
-        // Mocked / deprecated wallets are no longer user-facing — treat them
-        // as needing replacement so the auto-select loop runs and either picks
-        // the next valid wallet or resets to undefined (OK-51091).
+        // Mocked wallets need replacement. Deprecated wallets remain readable.
         const shouldAutoSelectNextAccount =
           !selectedAccount?.focusedWallet ||
           !network ||
           !wallet ||
-          accountUtils.isWalletDeprecatedOrMocked(wallet) ||
+          wallet.isMocked ||
           !isAccountExist;
 
         if (shouldAutoSelectNextAccount) {
@@ -3621,7 +3633,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
           if (
             !selectedWalletId ||
             !hasIndexedAccounts ||
-            accountUtils.isWalletDeprecatedOrMocked(selectedWallet)
+            selectedWallet?.isMocked
           ) {
             let shouldSelectHdHwWallet = true;
             if (
@@ -3683,10 +3695,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
                 selectedAccountNew.focusedWallet = selectedWalletId;
               }
               // maybe no hd hw wallet found, reset walletId and indexedAccountId
-              if (
-                !selectedWallet ||
-                accountUtils.isWalletDeprecatedOrMocked(selectedWallet)
-              ) {
+              if (!selectedWallet || selectedWallet.isMocked) {
                 defaultLogger.accountSelector.autoSelect.resetSelectedWalletToUndefined(
                   {
                     selectedAccount: selectedAccountNew,
@@ -3810,7 +3819,7 @@ class AccountSelectorActions extends ContextJotaiActionsBase {
             });
             if (
               !finalWallet ||
-              accountUtils.isWalletDeprecatedOrMocked(finalWallet) ||
+              finalWallet.isMocked ||
               (await serviceAccount.isTempWalletRemoved({
                 wallet: finalWallet,
               }))

--- a/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
+++ b/packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.tsx
@@ -423,19 +423,25 @@ export function AccountSelectorAccountListItem({
                 autoChangeToAccountMatchedNetworkId =
                   selectedAccount?.networkId;
               }
-              await actions.current.confirmAccountSelect({
+              const confirmed = await actions.current.confirmAccountSelect({
                 num,
                 indexedAccount: undefined,
                 othersWalletAccount: account,
                 autoChangeToAccountMatchedNetworkId,
               });
+              if (!confirmed) {
+                return;
+              }
             } else if (focusedWalletInfo) {
-              await actions.current.confirmAccountSelect({
+              const confirmed = await actions.current.confirmAccountSelect({
                 num,
                 indexedAccount,
                 othersWalletAccount: undefined,
                 autoChangeToAccountMatchedNetworkId: undefined,
               });
+              if (!confirmed) {
+                return;
+              }
             }
             resetAccountManagerStacksModal();
           },

--- a/packages/shared/src/utils/accountUtils.test.ts
+++ b/packages/shared/src/utils/accountUtils.test.ts
@@ -21,6 +21,26 @@ function testWithRandomAccountIndexes(
     testFunc(accountIndex);
   }
 }
+
+describe('hasNoUsableWallet', () => {
+  type IWallet = Parameters<typeof accountUtils.hasNoUsableWallet>[0]['wallet'];
+
+  test('keeps deprecated wallets viewable but hides mocked wallets', () => {
+    expect(
+      accountUtils.hasNoUsableWallet({
+        wallet: { id: 'hw-1', deprecated: true } as IWallet,
+        account: undefined,
+      }),
+    ).toBe(false);
+    expect(
+      accountUtils.hasNoUsableWallet({
+        wallet: { id: 'hw-1', isMocked: true } as IWallet,
+        account: undefined,
+      }),
+    ).toBe(true);
+  });
+});
+
 describe('Lightning Path Transformation', () => {
   test('buildBtcToLnPath transforms mainnet path correctly', () => {
     testWithRandomAccountIndexes((accountIndex) => {

--- a/packages/shared/src/utils/accountUtils.ts
+++ b/packages/shared/src/utils/accountUtils.ts
@@ -870,12 +870,8 @@ function isOthersWallet({ walletId }: { walletId: string }): boolean {
   );
 }
 
-// A wallet is considered deprecated-or-mocked when it still has a DB record
-// but is no longer user-facing. Hardware wallets are marked `isMocked=true`
-// on removal (OneKey keeps the metadata so re-connecting the device restores
-// account names / ordering); `deprecated=true` covers the stale-device
-// variant (same connection, different deviceId). Both forms are "zombie"
-// wallets that callers should treat as if the wallet is gone (OK-51091).
+// Mocked and deprecated wallets both require write-path restrictions. A
+// deprecated wallet may still be shown for historical asset viewing.
 function isWalletDeprecatedOrMocked(wallet: IDBWallet | undefined): boolean {
   if (!wallet) return false;
   return !!(wallet.isMocked || wallet.deprecated);
@@ -889,7 +885,7 @@ function hasNoUsableWallet({
   account: { id: string } | undefined;
 }): boolean {
   if (!wallet) return true;
-  if (isWalletDeprecatedOrMocked(wallet)) return true;
+  if (wallet.isMocked) return true;
   if (isOthersWallet({ walletId: wallet.id ?? '' }) && !account) return true;
   return false;
 }


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58315](https://onekeyhq.atlassian.net/browse/OK-58315)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Keep reset-device (`deprecated`) hardware wallets visible and explicitly selectable so users can inspect historical accounts and assets.
- Reject only missing or mocked target wallets at the `confirmAccountSelect` write boundary, and close the account selector modal only after a successful selection.
- Preserve an explicitly selected deprecated account during storage initialization and reload, while continuing to exclude deprecated and mocked wallets from automatic fallback candidates.
- Keep the account selector available and render wallet content or a recovery spinner instead of leaving Home on a permanent empty stack.

## Root Cause

A deprecated wallet represents a historical wallet whose device identity changed after reset. It is unavailable for signing and address creation, but its existing accounts remain valid for read-only asset viewing.

The account selector, storage cleanup, auto-selection, and Home rendering paths used the deprecated-or-mocked predicate as if both states were identical. This caused a persisted deprecated selection to be cleared or replaced during reload. When a deprecated wallet was active, Home also classified it as having no usable wallet, suppressed wallet content and the selector trigger, and could leave only the default empty stack. At the same time, `confirmAccountSelect` had no final lookup guard for genuinely missing or mocked wallets.

The fix separates these boundaries:

- Explicit selection/viewing: wallet must exist and must not be mocked; deprecated is allowed.
- Automatic fallback: deprecated and mocked wallets remain excluded.
- Signing, address creation, and hardware operations: existing deprecated-wallet restrictions remain unchanged.

No Wallet, Account, Device, Credential, or key data is deleted, migrated, or rebound.

## Runtime And State Flow

- Desktop/Web use a single JavaScript runtime/thread, but LocalDbIndexed records returned through background services and the main Jotai snapshots are separate data snapshots. Direct IndexedDB mutation does not mutate an already-held Jotai value; initialization and wallet events must reconcile it explicitly.
- Extension uses isolated main/background JavaScript heaps. Native uses Realm and isolated main/background heaps; each side initializes independently and the main side receives serialized active-account data.
- Main and background bundles are version-locked, so this is a state-transition and timing issue rather than a bundle-version skew.

## Risk

Medium. The change touches account selection, reload recovery, and Home fallback rendering across Desktop, Web, Extension, and Native. The main risk is switching or retaining the wrong active account; the write boundary, automatic-candidate filtering, stale-request result, and regression tests cover those cases.

## Test Plan

- [x] `yarn jest packages/kit/src/views/Home/pages/homePageNoWalletContent.test.ts packages/kit/src/states/jotai/contexts/accountSelector/actions.test.tsx packages/kit/src/components/AccountSelector/hooks/useAutoSelectAccount.test.tsx packages/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountSelectorAccountListItem.test.tsx --runInBand` (69 tests)
- [x] `yarn agent:check --profile commit`
- [x] Equivalent hotfix Desktop bundle validated with the existing reproduction database: the deprecated wallet remains visible with its reset warning, its historical account can be selected to view assets, the selection survives reload, Home does not become blank, and normal wallet switching remains unaffected. Workflow: https://github.com/OneKeyHQ/app-monorepo/actions/runs/31361967357

## Affected Platforms

- Desktop
- Web
- Extension
- Mobile

## Jira

https://onekeyhq.atlassian.net/browse/OK-58315

[OK-58315]: https://onekeyhq.atlassian.net/browse/OK-58315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ