### PR TITLE
fix: prevent iPad dapp touch freeze

### DIFF
--- a/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
@@ -38,7 +38,6 @@ import {
   EModalRoutes,
   ETabRoutes,
 } from '@onekeyhq/shared/src/routes';
-import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 import MobileTabListItem from '../../components/MobileTabListItem';
 import MobileTabListPinnedItem from '../../components/MobileTabListItem/MobileTabListPinnedItem';
@@ -146,7 +145,6 @@ function MobileTabListModal() {
     platformEnv.isNativeIOSPad && shouldUseSplitView && isLandscape;
 
   const revealTabletBrowser = useCallback(async () => {
-    await timerUtils.wait(100);
     await switchTabAsync(ETabRoutes.Discovery);
     appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
       tab: ETranslations.global_browser,
@@ -387,9 +385,10 @@ function MobileTabListModal() {
         onSelectedItem={(id) => {
           void setCurrentWebTab(id);
           setDisplayHomePage(false);
-          navigation.pop();
           if (shouldRevealTabletBrowser) {
             void revealTabletBrowser();
+          } else {
+            navigation.pop();
           }
         }}
         onCloseItem={handleCloseTab}
@@ -418,9 +417,10 @@ function MobileTabListModal() {
         onSelectedItem={(id) => {
           setCurrentWebTab(id);
           setDisplayHomePage(false);
-          navigation.pop();
           if (shouldRevealTabletBrowser) {
             void revealTabletBrowser();
+          } else {
+            navigation.pop();
           }
         }}
         onCloseItem={handleCloseTab}


### PR DESCRIPTION
## Summary

- dismiss the iPad browser tab modal through `switchTabAsync` before revealing the selected DApp
- remove the redundant pre-switch delay
- keep the existing `navigation.pop()` behavior on non-iPad split-view paths

## Root cause

In iPad landscape split view, selecting a browser tab first called `navigation.pop()`, then delayed and switched to Discovery. Repeated tab changes could overlap the modal dismissal with native ScreenStack reattachment, leaving the visible WKWebView unable to receive touches while the Discovery UI remained interactive.

## User impact

DApps remain interactive after switching browser tabs in iPad landscape split view. Other platforms retain their existing navigation path.

## Validation

- reproduced with four DApp tabs in iPad landscape split view
- before the fix, repeated switching caused the Pendle WKWebView to stop receiving touches
- after the fix, completed 32 alternating tab switches and verified the Pendle menu remained clickable
- `yarn agent:check --profile commit`
