### PR TITLE
fix: prevent mixed TradingView history sources OK-59237

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewNative/data/providers/createTradingViewNativeDataProvider.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/providers/createTradingViewNativeDataProvider.test.ts
@@ -553,7 +553,7 @@ describe('TradingViewNative data providers', () => {
     expect(mocks?.tokenInfoFetch).toHaveBeenCalledTimes(1);
   });
 
-  it('retries Market after a transient fallback succeeds', async () => {
+  it('keeps using CoinGecko after fallback selects the history source', async () => {
     const mocks = globalMockBag.__tradingViewNativeProviderMocks;
     mocks?.coinGeckoFetchChart.mockResolvedValue([[7200, 10]]);
     mocks?.marketFetchHistory.mockImplementation((params) =>
@@ -595,17 +595,51 @@ describe('TradingViewNative data providers', () => {
         receivedPointCount: 500,
       }),
     ).toBe(false);
-    expect(provider.getHistoryRequestCandleCount(getInterval('60'))).toBe(2000);
+    expect(provider.getHistoryRequestCandleCount(getInterval('60'))).toBe(720);
 
-    const nextProvider = createTradingViewNativeDataProvider(source);
-    await nextProvider.fetchHistory(request);
-    expect(nextProvider.getHistoryRequestCandleCount(getInterval('60'))).toBe(
-      2000,
-    );
+    await provider.fetchHistory(request);
     expect(mocks?.marketFetchHistory).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({ primaryKLineDataUnavailable: false }),
+      expect.objectContaining({ primaryKLineDataUnavailable: true }),
     );
+  });
+
+  it('does not use CoinGecko after Market selects the history source', async () => {
+    const mocks = globalMockBag.__tradingViewNativeProviderMocks;
+    mocks?.marketFetchHistory
+      .mockResolvedValueOnce({
+        points: [{ o: 10, h: 12, l: 9, c: 11, v: 1, t: 7200 }],
+        total: 1,
+      })
+      .mockImplementationOnce(async (params) => {
+        expect(params.kLineDataFallback).toBeUndefined();
+        return { points: [], total: 0 };
+      });
+    const provider = createTradingViewNativeDataProvider({
+      kind: 'market',
+      fallbackCoinGeckoId: 'bitcoin',
+      networkId: 'btc--0',
+      tokenAddress: '',
+      symbol: 'BTC',
+      realtime: 'disabled',
+    });
+    const request = {
+      interval: getInterval('60'),
+      signal: new AbortController().signal,
+      timeFrom: 3600,
+      timeTo: 10_800,
+    };
+
+    await expect(provider.fetchHistory(request)).resolves.toEqual({
+      points: [{ o: 10, h: 12, l: 9, c: 11, v: 1, t: 7200 }],
+      total: 1,
+    });
+    await expect(provider.fetchHistory(request)).resolves.toEqual({
+      points: [],
+      total: 0,
+    });
+    expect(mocks?.coinGeckoFetchChart).not.toHaveBeenCalled();
+    expect(mocks?.tokenInfoFetch).not.toHaveBeenCalled();
   });
 
   it('adapts validated Market WS candles and owns subscription cleanup', async () => {

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/providers/market/marketDataProvider.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/providers/market/marketDataProvider.ts
@@ -77,6 +77,7 @@ export function createTradingViewNativeMarketDataProvider({
   let primaryHistoryUnavailable =
     !canUseMarketHistory ||
     unavailableMarketHistoryTokenKeys.has(marketTokenKey);
+  const selectedHistorySources = new Map<string, 'fallback' | 'primary'>();
   const marketHistoryPageSize =
     source.isNative || !source.tokenAddress.trim()
       ? MARKET_NATIVE_HISTORY_PAGE_SIZE
@@ -90,6 +91,7 @@ export function createTradingViewNativeMarketDataProvider({
 
   return {
     getHistoryRequestCandleCount: (interval) =>
+      selectedHistorySources.get(interval.value) === 'fallback' ||
       primaryHistoryUnavailable
         ? fallbackHistoryProvider.getHistoryRequestCandleCount(interval)
         : MARKET_HISTORY_REQUEST_CANDLE_COUNT,
@@ -103,6 +105,12 @@ export function createTradingViewNativeMarketDataProvider({
     supportsRealtime: source.realtime === 'websocket',
     fetchHistory: async (request) => {
       const { interval, signal, timeFrom, timeTo } = request;
+      const selectedHistorySource = selectedHistorySources.get(interval.value);
+      const selectHistorySource = (historySource: 'fallback' | 'primary') => {
+        if (!selectedHistorySources.has(interval.value)) {
+          selectedHistorySources.set(interval.value, historySource);
+        }
+      };
       let pointType: IMarketKLinePointType | undefined;
       let usedFallback = false;
       const data = await fetchMarketKLineData({
@@ -112,25 +120,31 @@ export function createTradingViewNativeMarketDataProvider({
         timeFrom,
         timeTo,
         autoHandleError: false,
-        kLineDataFallback: async (fallbackRequest: {
-          timeFrom: number;
-          timeTo: number;
-        }) => {
-          const fallbackTimeFrom = Math.max(
-            fallbackRequest.timeTo -
-              interval.seconds *
-                fallbackHistoryProvider.getHistoryRequestCandleCount(interval),
-            0,
-          );
-          return fallbackHistoryProvider.fetchHistory({
-            interval,
-            signal,
-            timeFrom: Math.min(fallbackRequest.timeFrom, fallbackTimeFrom),
-            timeTo: fallbackRequest.timeTo,
-          });
-        },
+        kLineDataFallback:
+          selectedHistorySource === 'primary'
+            ? undefined
+            : async (fallbackRequest: { timeFrom: number; timeTo: number }) => {
+                const fallbackTimeFrom = Math.max(
+                  fallbackRequest.timeTo -
+                    interval.seconds *
+                      fallbackHistoryProvider.getHistoryRequestCandleCount(
+                        interval,
+                      ),
+                  0,
+                );
+                return fallbackHistoryProvider.fetchHistory({
+                  interval,
+                  signal,
+                  timeFrom: Math.min(
+                    fallbackRequest.timeFrom,
+                    fallbackTimeFrom,
+                  ),
+                  timeTo: fallbackRequest.timeTo,
+                });
+              },
         onFallbackKLineData: () => {
           usedFallback = true;
+          selectHistorySource('fallback');
         },
         onPrimaryKLineDataUnavailable: () => {
           primaryHistoryUnavailable = true;
@@ -139,10 +153,14 @@ export function createTradingViewNativeMarketDataProvider({
         onPointType: (nextPointType) => {
           pointType = nextPointType;
         },
-        primaryKLineDataUnavailable: primaryHistoryUnavailable,
+        primaryKLineDataUnavailable:
+          selectedHistorySource === 'fallback' || primaryHistoryUnavailable,
       });
       if (!data) {
         return null;
+      }
+      if (!usedFallback && data.points.length) {
+        selectHistorySource('primary');
       }
       return {
         ...data,

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.test.ts
@@ -340,7 +340,7 @@ describe('TradingViewNative K-line data state machine', () => {
     expect(result.current.chartType).toBe('line');
   });
 
-  it('restores an OHLC chart when primary history replaces a transient fallback', async () => {
+  it('does not splice primary history into CoinGecko fallback history', async () => {
     mockHistoryBatchSize = 2;
     mockHistoryRequestCandleCount = 2;
     mockFetchHistory
@@ -368,7 +368,8 @@ describe('TradingViewNative K-line data state machine', () => {
     updateVisibility(true);
 
     await waitFor(() => expect(mockFetchHistory).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(result.current.chartType).toBe('candlestick'));
+    expect(result.current.chartType).toBe('line');
+    expect(result.current.points.map((point) => point.c)).toEqual([100, 110]);
   });
 
   it('restores the saved interval before the initial history request', async () => {
@@ -1059,9 +1060,7 @@ describe('TradingViewNative K-line data state machine', () => {
         ].filter(
           ({ timestamp }) => timestamp >= timeFrom && timestamp <= timeTo,
         );
-        return timeTo === currentTimestamp
-          ? buildFallbackMultiPointResponse(filteredCandles)
-          : buildMultiPointResponse(filteredCandles);
+        return buildMultiPointResponse(filteredCandles);
       },
     );
     const { result } = renderHook(() =>
@@ -3032,7 +3031,7 @@ describe('TradingViewNative K-line data state machine', () => {
     expect(mockFetchHistory).toHaveBeenCalledTimes(2);
   });
 
-  it('keeps an OHLC chart when an older page uses single-value fallback history', async () => {
+  it('does not prepend CoinGecko fallback history to Market history', async () => {
     mockHistoryBatchSize = 2;
     mockHistoryRequestCandleCount = 2;
     mockFetchHistory
@@ -3057,7 +3056,9 @@ describe('TradingViewNative K-line data state machine', () => {
     await waitFor(() => expect(result.current.points).toHaveLength(2));
     expect(result.current.chartType).toBe('candlestick');
     act(() => result.current.handleVisiblePointRangeChange({ startIndex: 0 }));
-    await waitFor(() => expect(result.current.points).toHaveLength(4));
+    await waitFor(() => expect(mockFetchHistory).toHaveBeenCalledTimes(2));
+    expect(result.current.points).toHaveLength(2);
+    expect(result.current.points.map((point) => point.c)).toEqual([100, 110]);
     expect(result.current.chartType).toBe('candlestick');
   });
 

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.test.ts
@@ -3285,6 +3285,31 @@ describe('TradingViewNative K-line data state machine', () => {
     expect(result.current.chartType).toBe('candlestick');
   });
 
+  it('resets history source selection when a series lifecycle restarts', async () => {
+    mockFetchHistory
+      .mockResolvedValueOnce(
+        buildFallbackMultiPointResponse([{ close: 100, timestamp: 1_000_000 }]),
+      )
+      .mockResolvedValueOnce(buildResponse(200, 2_000_000))
+      .mockResolvedValueOnce(buildResponse(120, 1_100_000));
+    const { result, rerender } = renderHook(
+      ({ tokenAddress }: { tokenAddress: string }) =>
+        useTradingViewNativeKLine({
+          source: buildMarketSource({ tokenAddress }),
+        }),
+      { initialProps: { tokenAddress: '0x123' } },
+    );
+
+    await waitFor(() => expect(result.current.points[0]?.c).toBe(100));
+
+    rerender({ tokenAddress: '0x456' });
+    await waitFor(() => expect(result.current.points[0]?.c).toBe(200));
+
+    rerender({ tokenAddress: '0x123' });
+    await waitFor(() => expect(result.current.points[0]?.c).toBe(120));
+    expect(mockFetchHistory).toHaveBeenCalledTimes(3);
+  });
+
   it('resets the series when the CoinGecko fallback identity changes', async () => {
     const olderHistoryRequest =
       createDeferred<IMarketTokenKLineResponse | null>();

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.test.ts
@@ -3310,6 +3310,50 @@ describe('TradingViewNative K-line data state machine', () => {
     expect(mockFetchHistory).toHaveBeenCalledTimes(3);
   });
 
+  it('resets chart type classification when a series lifecycle restarts', async () => {
+    mockHistoryBatchSize = 2;
+    mockHistoryRequestCandleCount = 2;
+    mockFetchHistory
+      .mockResolvedValueOnce(
+        buildMultiPointResponse([
+          { close: 100, timestamp: 1_000_000 },
+          { close: 110, timestamp: 1_003_600 },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        buildMultiPointResponse([
+          { close: 200, timestamp: 2_000_000 },
+          { close: 210, timestamp: 2_003_600 },
+        ]),
+      )
+      .mockResolvedValueOnce({
+        ...buildFallbackMultiPointResponse([
+          { close: 120, timestamp: 1_100_000 },
+          { close: 130, timestamp: 1_103_600 },
+        ]),
+        pointType: 'single',
+      });
+    const { result, rerender } = renderHook(
+      ({ tokenAddress }: { tokenAddress: string }) =>
+        useTradingViewNativeKLine({
+          source: buildMarketSource({ tokenAddress }),
+        }),
+      { initialProps: { tokenAddress: '0x123' } },
+    );
+
+    await waitFor(() => expect(result.current.points).toHaveLength(2));
+    expect(result.current.points[0]?.c).toBe(100);
+    expect(result.current.chartType).toBe('candlestick');
+
+    rerender({ tokenAddress: '0x456' });
+    await waitFor(() => expect(result.current.points[0]?.c).toBe(200));
+
+    rerender({ tokenAddress: '0x123' });
+    await waitFor(() => expect(result.current.points[0]?.c).toBe(120));
+    expect(result.current.chartType).toBe('line');
+    expect(mockFetchHistory).toHaveBeenCalledTimes(3);
+  });
+
   it('resets the series when the CoinGecko fallback identity changes', async () => {
     const olderHistoryRequest =
       createDeferred<IMarketTokenKLineResponse | null>();

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.ts
@@ -1296,14 +1296,12 @@ export function useTradingViewNativeKLine({
     sourceKind,
   ]);
   const seriesKey = rawHistoryProvider.key;
-  const historyDataSourceScopesRef = useRef(
-    new Map<string, IHistoryDataSource>(),
-  );
   const [historyPointTypeScopes, setHistoryPointTypeScopes] = useState<
     ReadonlyMap<string, IHistoryPointTypeClassification>
   >(() => new Map());
-  const historyProvider = useMemo<ITradingViewNativeDataProvider>(
-    () => ({
+  const historyProvider = useMemo<ITradingViewNativeDataProvider>(() => {
+    const historyDataSourceScopes = new Map<string, IHistoryDataSource>();
+    return {
       ...rawHistoryProvider,
       fetchHistory: async (request) => {
         const data = await rawHistoryProvider.fetchHistory(request);
@@ -1314,12 +1312,11 @@ export function useTradingViewNativeKLine({
           );
           const responseDataSource: IHistoryDataSource =
             data.historySource === 'fallback' ? 'fallback' : 'primary';
-          const selectedDataSource =
-            historyDataSourceScopesRef.current.get(scopeKey);
+          const selectedDataSource = historyDataSourceScopes.get(scopeKey);
           if (selectedDataSource && selectedDataSource !== responseDataSource) {
             return { ...data, points: [], total: 0 };
           }
-          historyDataSourceScopesRef.current.set(scopeKey, responseDataSource);
+          historyDataSourceScopes.set(scopeKey, responseDataSource);
           setHistoryPointTypeScopes((currentScopes) => {
             const currentClassification = currentScopes.get(scopeKey);
             const nextClassification = resolveHistoryPointTypeClassification({
@@ -1337,9 +1334,8 @@ export function useTradingViewNativeKLine({
         }
         return data;
       },
-    }),
-    [rawHistoryProvider, seriesKey],
-  );
+    };
+  }, [rawHistoryProvider, seriesKey]);
   const realtimeProvider = useMemo(() => {
     if (sourceKind === 'hyperliquid') {
       return historyProvider;

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.ts
@@ -1296,11 +1296,20 @@ export function useTradingViewNativeKLine({
     sourceKind,
   ]);
   const seriesKey = rawHistoryProvider.key;
-  const [historyPointTypeScopes, setHistoryPointTypeScopes] = useState<
-    ReadonlyMap<string, IHistoryPointTypeClassification>
-  >(() => new Map());
+  const [historyPointTypeScopeState, setHistoryPointTypeScopeState] = useState<{
+    historyProvider: ITradingViewNativeDataProvider;
+    scopes: ReadonlyMap<string, IHistoryPointTypeClassification>;
+  }>(() => ({ historyProvider: rawHistoryProvider, scopes: new Map() }));
+  const visibleHistoryPointTypeScopes =
+    historyPointTypeScopeState.historyProvider === rawHistoryProvider
+      ? historyPointTypeScopeState.scopes
+      : undefined;
   const historyProvider = useMemo<ITradingViewNativeDataProvider>(() => {
     const historyDataSourceScopes = new Map<string, IHistoryDataSource>();
+    const historyPointTypeScopes = new Map<
+      string,
+      IHistoryPointTypeClassification
+    >();
     return {
       ...rawHistoryProvider,
       fetchHistory: async (request) => {
@@ -1317,20 +1326,19 @@ export function useTradingViewNativeKLine({
             return { ...data, points: [], total: 0 };
           }
           historyDataSourceScopes.set(scopeKey, responseDataSource);
-          setHistoryPointTypeScopes((currentScopes) => {
-            const currentClassification = currentScopes.get(scopeKey);
-            const nextClassification = resolveHistoryPointTypeClassification({
-              currentClassification,
-              historySource: data.historySource,
-              pointType: data.pointType,
-            });
-            if (nextClassification === currentClassification) {
-              return currentScopes;
-            }
-            const nextScopes = new Map(currentScopes);
-            nextScopes.set(scopeKey, nextClassification);
-            return nextScopes;
+          const currentClassification = historyPointTypeScopes.get(scopeKey);
+          const nextClassification = resolveHistoryPointTypeClassification({
+            currentClassification,
+            historySource: data.historySource,
+            pointType: data.pointType,
           });
+          if (nextClassification !== currentClassification) {
+            historyPointTypeScopes.set(scopeKey, nextClassification);
+            setHistoryPointTypeScopeState({
+              historyProvider: rawHistoryProvider,
+              scopes: new Map(historyPointTypeScopes),
+            });
+          }
         }
         return data;
       },
@@ -3446,7 +3454,7 @@ export function useTradingViewNativeKLine({
     candleIntervalSeconds: displayedInterval.seconds,
     chartType: getTradingViewNativeChartType({
       hasSingleValueHistory: isSingleValueHistoryClassification(
-        historyPointTypeScopes.get(
+        visibleHistoryPointTypeScopes?.get(
           getHistoryPointTypeScopeKey(
             visibleChartData?.seriesKey ?? seriesKey,
             visibleChartData?.interval ?? activeInterval,

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.ts
@@ -73,6 +73,7 @@ function getHistoryPointTypeScopeKey(
   return `${seriesKey}:${interval}`;
 }
 
+type IHistoryDataSource = 'fallback' | 'primary';
 type IHistoryPointTypeClassification = 'fallbackSingle' | 'ohlc' | 'single';
 
 function resolveHistoryPointTypeClassification({
@@ -1295,6 +1296,9 @@ export function useTradingViewNativeKLine({
     sourceKind,
   ]);
   const seriesKey = rawHistoryProvider.key;
+  const historyDataSourceScopesRef = useRef(
+    new Map<string, IHistoryDataSource>(),
+  );
   const [historyPointTypeScopes, setHistoryPointTypeScopes] = useState<
     ReadonlyMap<string, IHistoryPointTypeClassification>
   >(() => new Map());
@@ -1308,6 +1312,14 @@ export function useTradingViewNativeKLine({
             seriesKey,
             request.interval.value,
           );
+          const responseDataSource: IHistoryDataSource =
+            data.historySource === 'fallback' ? 'fallback' : 'primary';
+          const selectedDataSource =
+            historyDataSourceScopesRef.current.get(scopeKey);
+          if (selectedDataSource && selectedDataSource !== responseDataSource) {
+            return { ...data, points: [], total: 0 };
+          }
+          historyDataSourceScopesRef.current.set(scopeKey, responseDataSource);
           setHistoryPointTypeScopes((currentScopes) => {
             const currentClassification = currentScopes.get(scopeKey);
             const nextClassification = resolveHistoryPointTypeClassification({


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59237](https://onekeyhq.atlassian.net/browse/OK-59237)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- keep the existing CoinGecko provider and full-history fallback behavior
- lock each TradingView Native Market interval to its first non-empty history source
- ignore late responses from the other source so Market and CoinGecko candles are never merged by timestamp

## Root cause

When a later Market history request returned no candles, the CoinGecko fallback page could be merged with already loaded Market candles. Concurrent requests could also return different sources and reach the same merge path.

## Validation

- `npx jest --runInBand packages/kit/src/components/TradingView/TradingViewNative/data/getTradingViewNativeSource.test.ts packages/kit/src/components/TradingView/TradingViewNative/data/providers/createTradingViewNativeDataProvider.test.ts packages/kit/src/components/TradingView/TradingViewNative/data/useTradingViewNativeKLine.test.ts` (84 tests passed)
- `yarn agent:check --profile commit`

[OK-59237]: https://onekeyhq.atlassian.net/browse/OK-59237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ