### PR TITLE
chore: sync release/v6.5.0 to x

### DIFF
--- a/packages/kit/src/views/Home/pages/PerpsContainer.tsx
+++ b/packages/kit/src/views/Home/pages/PerpsContainer.tsx
@@ -28,6 +28,7 @@ import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import {
   LeverageBadge,
+  PerpDexBadge,
   SubtitleText,
 } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
 import { useNavigateToMarketTab } from '@onekeyhq/kit/src/views/Market/hooks';
@@ -720,6 +721,7 @@ function PerpsEmptyRecommendSection() {
                       {token.displayName}
                     </SizableText>
                     <LeverageBadge leverage={token.maxLeverage} />
+                    <PerpDexBadge dexLabel={token.dexLabel} />
                   </XStack>
                   {token.subtitle ? (
                     <XStack alignItems="center" minWidth={0}>
@@ -843,6 +845,7 @@ function PerpsEmptyRecommendSection() {
                         {token.displayName}
                       </SizableText>
                       <LeverageBadge leverage={token.maxLeverage} />
+                      <PerpDexBadge dexLabel={token.dexLabel} />
                     </XStack>
                     <XStack alignItems="center" gap="$1" minWidth={0}>
                       {token.subtitle ? (

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsTokenListItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/MarketPerpsTokenListItem.tsx
@@ -10,7 +10,11 @@ import {
 } from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 
-import { LeverageBadge, SubtitleText } from '../../../components/PerpsBadges';
+import {
+  LeverageBadge,
+  PerpDexBadge,
+  SubtitleText,
+} from '../../../components/PerpsBadges';
 import { PriceChangeBadge } from '../PriceChangeBadge';
 
 import type { IMarketPerpsToken } from './hooks/useMarketPerpsTokenList';
@@ -30,12 +34,20 @@ const BasicMarketPerpsTokenListItem: FC<IMarketPerpsTokenListItemProps> = ({
     <XStack
       pressStyle={{ opacity: 0.8 }}
       onPress={onPress}
-      px="$5"
+      px="$4"
       py="$3"
       alignItems="center"
+      gap="$3"
     >
       {/* Left side: Token Icon + Name + Badges + Volume */}
-      <XStack flex={1} alignItems="center" gap="$3" minWidth={0}>
+      <XStack
+        flexGrow={1}
+        flexBasis={0}
+        alignItems="center"
+        gap="$2"
+        minWidth={0}
+        overflow="hidden"
+      >
         <Token
           size="md"
           borderRadius="$full"
@@ -49,19 +61,29 @@ const BasicMarketPerpsTokenListItem: FC<IMarketPerpsTokenListItemProps> = ({
               numberOfLines={1}
               flexShrink={1}
               ellipsizeMode="tail"
+              adjustsFontSizeToFit
+              minimumFontScale={0.85}
               userSelect="none"
             >
               {item.displayName}
             </SizableText>
-            <LeverageBadge leverage={item.maxLeverage} />
+            <LeverageBadge leverage={item.maxLeverage} compact />
+            <PerpDexBadge dexLabel={item.dexLabel} compact />
           </XStack>
-          <XStack alignItems="center" gap="$1" minWidth={0}>
+          <XStack
+            alignItems="center"
+            gap="$1"
+            minWidth={0}
+            overflow="hidden"
+            pr="$3"
+          >
             {item.subtitle ? <SubtitleText subtitle={item.subtitle} /> : null}
             <SkeletonContainer isLoading={!hasRealTimeData}>
               <NumberSizeableText
-                size="$bodyMd"
+                size="$bodySm"
                 color="$textSubdued"
                 numberOfLines={1}
+                flexShrink={0}
                 formatter="marketCap"
                 formatterOptions={{ currency: '$' }}
                 userSelect="none"
@@ -75,7 +97,7 @@ const BasicMarketPerpsTokenListItem: FC<IMarketPerpsTokenListItemProps> = ({
 
       {/* Right side: Price + Change */}
       <SkeletonContainer isLoading={!hasRealTimeData}>
-        <XStack alignItems="center" gap="$2">
+        <XStack alignItems="center" gap="$2" flexShrink={0}>
           <NumberSizeableText
             userSelect="none"
             flexShrink={1}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/marketPerpsTokenUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/marketPerpsTokenUtils.test.ts
@@ -1,0 +1,37 @@
+import type { IMarketPerpsTokenFromServer } from '@onekeyhq/shared/types/marketV2';
+
+import { mapServerToken } from './marketPerpsTokenUtils';
+
+function buildServerToken(name: string): IMarketPerpsTokenFromServer {
+  return {
+    name,
+    displayName: 'UNITREE',
+    maxLeverage: 10,
+    tokenImageUrl: 'https://example.com/unitree.png',
+    markPrice: '90.38',
+    prevDayPrice: '72.58',
+    change24hPercent: 24.52,
+    volume24h: '10940000',
+    openInterest: '6660000',
+    fundingRate: '0.000008',
+  };
+}
+
+describe('mapServerToken', () => {
+  it.each([
+    ['xyz:UNITREE', 'xyz'],
+    ['para:UNITREE', 'para'],
+  ])('maps the dex prefix from %s for the market badge', (name, dexLabel) => {
+    expect(mapServerToken(buildServerToken(name), undefined)).toMatchObject({
+      name,
+      displayName: 'UNITREE',
+      dexLabel,
+    });
+  });
+
+  it('leaves main-dex tokens without a dex label', () => {
+    expect(
+      mapServerToken(buildServerToken('BTC'), undefined).dexLabel,
+    ).toBeUndefined();
+  });
+});

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/marketPerpsTokenUtils.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/marketPerpsTokenUtils.ts
@@ -1,0 +1,43 @@
+import {
+  getTokenSubtitle,
+  parseDexCoin,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
+import type { ITokenSearchAliases } from '@onekeyhq/shared/src/utils/perpsUtils';
+import type { IMarketPerpsTokenFromServer } from '@onekeyhq/shared/types/marketV2';
+
+export interface IMarketPerpsToken {
+  name: string;
+  displayName: string;
+  dexLabel?: string;
+  maxLeverage: number;
+  subtitle?: string;
+  tokenImageUrl: string;
+  markPrice: string;
+  prevDayPrice: string;
+  change24hPercent: number;
+  volume24h: string;
+  openInterest: string;
+  fundingRate: string;
+}
+
+export function mapServerToken(
+  token: IMarketPerpsTokenFromServer,
+  tokenSearchAliases: ITokenSearchAliases | undefined,
+): IMarketPerpsToken {
+  const { dexLabel } = parseDexCoin(token.name);
+
+  return {
+    name: token.name,
+    displayName: token.displayName,
+    dexLabel,
+    maxLeverage: token.maxLeverage,
+    subtitle: getTokenSubtitle(token.name, tokenSearchAliases),
+    tokenImageUrl: token.tokenImageUrl,
+    markPrice: token.markPrice,
+    prevDayPrice: token.prevDayPrice,
+    change24hPercent: token.change24hPercent,
+    volume24h: token.volume24h,
+    openInterest: token.openInterest,
+    fundingRate: token.fundingRate,
+  };
+}

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/useMarketPerpsTokenList.ts
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/useMarketPerpsTokenList.ts
@@ -2,48 +2,19 @@ import { useMemo } from 'react';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
-import { getTokenSubtitle } from '@onekeyhq/shared/src/utils/perpsUtils';
-import type { ITokenSearchAliases } from '@onekeyhq/shared/src/utils/perpsUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
-import type { IMarketPerpsTokenFromServer } from '@onekeyhq/shared/types/marketV2';
 
 import { MARKET_PERPS_DEFAULT_CATEGORY_ID } from '../constants';
 
-export interface IMarketPerpsToken {
-  name: string;
-  displayName: string;
-  maxLeverage: number;
-  subtitle?: string;
-  tokenImageUrl: string;
-  markPrice: string;
-  prevDayPrice: string;
-  change24hPercent: number;
-  volume24h: string;
-  openInterest: string;
-  fundingRate: string;
-}
+import { mapServerToken } from './marketPerpsTokenUtils';
+
+import type { IMarketPerpsToken } from './marketPerpsTokenUtils';
+
+export { mapServerToken };
+export type { IMarketPerpsToken };
 
 interface IUseMarketPerpsTokenListParams {
   selectedCategoryId: string;
-}
-
-export function mapServerToken(
-  token: IMarketPerpsTokenFromServer,
-  tokenSearchAliases: ITokenSearchAliases | undefined,
-): IMarketPerpsToken {
-  return {
-    name: token.name,
-    displayName: token.displayName,
-    maxLeverage: token.maxLeverage,
-    subtitle: getTokenSubtitle(token.name, tokenSearchAliases),
-    tokenImageUrl: token.tokenImageUrl,
-    markPrice: token.markPrice,
-    prevDayPrice: token.prevDayPrice,
-    change24hPercent: token.change24hPercent,
-    volume24h: token.volume24h,
-    openInterest: token.openInterest,
-    fundingRate: token.fundingRate,
-  };
 }
 
 export function useMarketPerpsTokenList({

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/usePerpsColumns.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/usePerpsColumns.tsx
@@ -16,6 +16,7 @@ import { Token } from '@onekeyhq/kit/src/components/Token';
 import { MarketPerpsStarV2 } from '@onekeyhq/kit/src/views/Market/components/MarketStarV2';
 import {
   LeverageBadge,
+  PerpDexBadge,
   SubtitleText,
 } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -76,6 +77,7 @@ export function usePerpsColumnsDesktop(): ITableColumn<IMarketPerpsToken>[] {
                     {record.displayName}
                   </SizableText>
                   <LeverageBadge leverage={record.maxLeverage} />
+                  <PerpDexBadge dexLabel={record.dexLabel} />
                 </XStack>
                 {record.subtitle ? (
                   <SubtitleText subtitle={record.subtitle} />

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/usePerpsColumnsMobile.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketPerpsList/hooks/usePerpsColumnsMobile.tsx
@@ -13,6 +13,7 @@ import type { ITableColumn } from '@onekeyhq/components';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import {
   LeverageBadge,
+  PerpDexBadge,
   SubtitleText,
 } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -56,6 +57,7 @@ export function usePerpsColumnsMobile(): ITableColumn<IMarketPerpsToken>[] {
                   {record.displayName}
                 </SizableText>
                 <LeverageBadge leverage={record.maxLeverage} />
+                <PerpDexBadge dexLabel={record.dexLabel} />
               </XStack>
               <XStack alignItems="center" gap="$1" minWidth={0}>
                 {record.subtitle ? (

--- a/packages/kit/src/views/Market/components/PerpsBadges.tsx
+++ b/packages/kit/src/views/Market/components/PerpsBadges.tsx
@@ -3,7 +3,6 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import {
-  Badge,
   Icon,
   Image,
   SizableText,
@@ -29,19 +28,21 @@ import type { IMarketStockInfo } from '@onekeyhq/shared/types/marketV2';
 
 import { truncatePerpsSubtitle } from './utils/perpsSubtitle';
 
-const LeverageBadge = memo(({ leverage }: { leverage: number }) => (
-  <XStack
-    borderRadius="$1"
-    bg="$bgInfo"
-    justifyContent="center"
-    alignItems="center"
-    px="$1.5"
-  >
-    <SizableText fontSize={10} color="$textInfo" lineHeight={16}>
-      {leverage}x
-    </SizableText>
-  </XStack>
-));
+const LeverageBadge = memo(
+  ({ leverage, compact }: { leverage: number; compact?: boolean }) => (
+    <XStack
+      borderRadius="$1"
+      bg="$bgInfo"
+      justifyContent="center"
+      alignItems="center"
+      px={compact ? '$1' : '$1.5'}
+    >
+      <SizableText fontSize={10} color="$textInfo" lineHeight={16}>
+        {leverage}x
+      </SizableText>
+    </XStack>
+  ),
+);
 LeverageBadge.displayName = 'LeverageBadge';
 
 function getPerpDexDescriptionId(dexLabel?: string) {
@@ -75,25 +76,17 @@ const PerpDexBadge = memo(
     const label = dexLabel.toLowerCase();
     const description = intl.formatMessage({ id: descriptionId });
     const badgeText = (
-      <SizableText
-        color="$textInfo"
-        fontSize={10}
-        {...(!compact && { lineHeight: 16 })}
-      >
+      <SizableText color="$textInfo" fontSize={10} lineHeight={16}>
         {label}
       </SizableText>
     );
-    const badge = compact ? (
-      <Badge radius="$1" bg="$bgInfo" px="$1" py={0} testID={testID}>
-        {badgeText}
-      </Badge>
-    ) : (
+    const badge = (
       <XStack
         borderRadius="$1"
         bg="$bgInfo"
         justifyContent="center"
         alignItems="center"
-        px="$1.5"
+        px={compact ? '$1' : '$1.5'}
         testID={testID}
       >
         {badgeText}


### PR DESCRIPTION
Sync bundle release changes from `release/v6.5.0` to `x` (after release #6).

## Synced
- `8d21ef27f1` feat: add dex labels to perps market lists (#12792)

## Deliberately skipped

| Commit | Reason |
|---|---|
| `3f3f50f6af` Feat/spark bitway (#12765) | Backport of #12463, which is **already on `x`**. Cherry-picking it produced 46 conflict hunks across 17 files, 9 of them pure deletions of x-only work — it would have removed `BinanceSmartChainBTW`, `vbUSDC`/katana support and Aave changes that the backport explicitly excluded ("Exclude unrelated Aave changes, BTW support, and generated locale files"). |
| `54197b5967` chore: release #6 (#12811) | Release-tracking only (`RELEASES.json`), must not sync to `x`. |

## ⚠️ Follow-up required (not in this PR)

`release/v6.5.0` carries Earn withdrawal hardening that `x` does **not** have:

- `UniversalWithdraw/checkAmountRequestUtils.ts`
- `UniversalWithdraw/withdrawPathSelectionUtils.ts`

These guard `checkAmount` and withdraw-path responses by full request identity, preventing stale cross-vault/provider state. They are wired only through `UniversalWithdraw/index.tsx`, which conflicts on `x`. Porting them needs to be done against `x`'s current Earn code by the module owner — a mechanical sync would regress `x`.

## Conflict resolved in this PR

`packages/kit/src/views/Market/components/PerpsBadges.tsx` — import-list conflict. #12792 refactors `PerpDexBadge` from `Badge` to `XStack`, so `Badge` becomes unused; `Icon` was kept because `x`'s `StockIsOpenBadge` (x-only) still uses it.

## Verification
- Files added vs `origin/x`: only #12792's two new util files
- No `RELEASES.json` / `.env.version` in the diff (`x` is already on `VERSION=6.6.0`)
- All imports in the resolved file are used; no unimported JSX
- Prettier: clean on all changed files except a **pre-existing** issue in `usePerpsColumnsMobile.tsx` present on both `x` and `release/v6.5.0` — left untouched to avoid unrelated churn