### PR TITLE
fix: harden Pro2 portfolio binary synchronization

### DIFF
--- a/apps/ext/src/offscreen/offscreenSetup.ts
+++ b/apps/ext/src/offscreen/offscreenSetup.ts
@@ -2,6 +2,10 @@
 import { bridgeSetup } from '@onekeyfe/extension-bridge-hosted';
 
 import type { IOffscreenApiMessagePayload } from '@onekeyhq/kit-bg/src/apis/IBackgroundApi';
+import {
+  decodeOffscreenApiPayload,
+  encodeOffscreenApiPayload,
+} from '@onekeyhq/kit-bg/src/offscreens/offscreenApiBinaryCodec';
 import offscreenApi from '@onekeyhq/kit-bg/src/offscreens/instance/offscreenApi';
 import { OFFSCREEN_API_MESSAGE_TYPE } from '@onekeyhq/kit-bg/src/offscreens/types';
 import appGlobals from '@onekeyhq/shared/src/appGlobals';
@@ -13,11 +17,13 @@ export function offscreenSetup() {
   const offscreenBridge = bridgeSetup.offscreen.createOffscreenJsBridge({
     onPortConnect() {},
     async receiveHandler(payload, bridge) {
-      const msg = payload.data as IOffscreenApiMessagePayload | undefined;
+      const msg = decodeOffscreenApiPayload(payload.data) as
+        | IOffscreenApiMessagePayload
+        | undefined;
       if (msg && msg.type === OFFSCREEN_API_MESSAGE_TYPE) {
         const result = await offscreenApi.callOffscreenApiMethod(msg);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return result;
+        return encodeOffscreenApiPayload(result);
       }
     },
   });

--- a/packages/kit-bg/src/offscreens/OffscreenApiProxyBase.ts
+++ b/packages/kit-bg/src/offscreens/OffscreenApiProxyBase.ts
@@ -8,6 +8,10 @@ import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 import { RemoteApiProxyBase } from '../apis/RemoteApiProxyBase';
 
+import {
+  decodeOffscreenApiPayload,
+  encodeOffscreenApiPayload,
+} from './offscreenApiBinaryCodec';
 import { OFFSCREEN_API_MESSAGE_TYPE } from './types';
 
 import type { IOffscreenApiMessagePayload } from '../apis/IBackgroundApi';
@@ -49,7 +53,11 @@ export class OffscreenApiProxyBase extends RemoteApiProxyBase {
     };
     const bridge = backgroundApiProxy?.backgroundApi?.bridgeExtBg;
     // TODO move to bridges hub
-    return bridge?.requestToOffscreen(message);
+    return (async () => {
+      const encodedMessage = await encodeOffscreenApiPayload(message);
+      const response = await bridge?.requestToOffscreen(encodedMessage);
+      return decodeOffscreenApiPayload(response);
+    })();
   }
 
   // _moduleCreatedNames: Record<string, boolean> = {};

--- a/packages/kit-bg/src/offscreens/offscreenApiBinaryCodec.test.ts
+++ b/packages/kit-bg/src/offscreens/offscreenApiBinaryCodec.test.ts
@@ -1,0 +1,115 @@
+import {
+  decodeOffscreenApiPayload,
+  encodeOffscreenApiPayload,
+} from './offscreenApiBinaryCodec';
+
+function crossJsonOnlyBridge(value: unknown): unknown {
+  return JSON.parse(JSON.stringify(value));
+}
+
+describe('offscreenApiBinaryCodec', () => {
+  test('preserves portfolio, wallpaper and NFT bytes across a JSON-only bridge', async () => {
+    const portfolioBytes = new Uint8Array([1, 2, 3]).buffer;
+    const wallpaperBacking = new Uint8Array([90, 4, 5, 6, 91]);
+    const nftBacking = new Uint8Array([80, 7, 8, 9, 10, 81]);
+    const payload = {
+      portfolio: { packageBytes: portfolioBytes },
+      wallpaper: { rgba: wallpaperBacking.subarray(1, 4) },
+      nft: {
+        image: { rgba: nftBacking.subarray(1, 3) },
+        thumbnail: { rgba: nftBacking.subarray(3, 5) },
+      },
+    };
+
+    const encoded = await encodeOffscreenApiPayload(payload);
+    const decoded = decodeOffscreenApiPayload(
+      crossJsonOnlyBridge(encoded),
+    ) as typeof payload;
+
+    expect(decoded.portfolio.packageBytes).toBeInstanceOf(ArrayBuffer);
+    expect(Array.from(new Uint8Array(decoded.portfolio.packageBytes))).toEqual([
+      1, 2, 3,
+    ]);
+    expect(decoded.wallpaper.rgba).toBeInstanceOf(Uint8Array);
+    expect(Array.from(decoded.wallpaper.rgba)).toEqual([4, 5, 6]);
+    expect(Array.from(decoded.nft.image.rgba)).toEqual([7, 8]);
+    expect(Array.from(decoded.nft.thumbnail.rgba)).toEqual([9, 10]);
+  });
+
+  test('encodes Blob input as byte data', async () => {
+    const encoded = await encodeOffscreenApiPayload(
+      new Blob([new Uint8Array([11, 12])]),
+    );
+    const decoded = decodeOffscreenApiPayload(crossJsonOnlyBridge(encoded));
+
+    expect(decoded).toBeInstanceOf(Uint8Array);
+    expect(Array.from(decoded as Uint8Array)).toEqual([11, 12]);
+  });
+
+  test('preserves firmware update binaries across a JSON-only bridge', async () => {
+    const binary = (...bytes: number[]) => Uint8Array.from(bytes).buffer;
+    const payload = {
+      firmwareUpdate: { binary: binary(1), updateType: 'firmware' },
+      firmwareUpdateV2: { binary: binary(2), updateType: 'firmware' },
+      firmwareUpdateV3: {
+        bleBinary: binary(3),
+        firmwareBinary: binary(4),
+        bootloaderBinary: binary(5),
+        resourceBinary: binary(6),
+      },
+      firmwareUpdateV4: {
+        romloaderBinary: binary(7),
+        bootloaderBinary: binary(8),
+        applicationP1Binary: binary(9),
+        applicationP2Binary: binary(10),
+        coprocessorBinary: binary(11),
+        se01Binary: binary(12),
+        se02Binary: binary(13),
+        se03Binary: binary(14),
+        se04Binary: binary(15),
+        resourceArchiveBinary: binary(16),
+      },
+      deviceUpdateBootloader: { binary: binary(17) },
+      deviceFullyUploadResource: { binary: binary(18) },
+    };
+
+    const encoded = await encodeOffscreenApiPayload(payload);
+    const decoded = decodeOffscreenApiPayload(
+      crossJsonOnlyBridge(encoded),
+    ) as typeof payload;
+
+    const restoredBinaries = [
+      decoded.firmwareUpdate.binary,
+      decoded.firmwareUpdateV2.binary,
+      decoded.firmwareUpdateV3.bleBinary,
+      decoded.firmwareUpdateV3.firmwareBinary,
+      decoded.firmwareUpdateV3.bootloaderBinary,
+      decoded.firmwareUpdateV3.resourceBinary,
+      decoded.firmwareUpdateV4.romloaderBinary,
+      decoded.firmwareUpdateV4.bootloaderBinary,
+      decoded.firmwareUpdateV4.applicationP1Binary,
+      decoded.firmwareUpdateV4.applicationP2Binary,
+      decoded.firmwareUpdateV4.coprocessorBinary,
+      decoded.firmwareUpdateV4.se01Binary,
+      decoded.firmwareUpdateV4.se02Binary,
+      decoded.firmwareUpdateV4.se03Binary,
+      decoded.firmwareUpdateV4.se04Binary,
+      decoded.firmwareUpdateV4.resourceArchiveBinary,
+      decoded.deviceUpdateBootloader.binary,
+      decoded.deviceFullyUploadResource.binary,
+    ];
+    expect(
+      restoredBinaries.map((value) => Array.from(new Uint8Array(value))),
+    ).toEqual(Array.from({ length: 18 }, (_, index) => [index + 1]));
+  });
+
+  test('rejects malformed tagged binary data', () => {
+    expect(() =>
+      decodeOffscreenApiPayload({
+        __onekey_offscreen_binary_payload__: 1,
+        data: 'not-base64',
+        type: 'uint8-array',
+      }),
+    ).toThrow('Invalid offscreen binary payload data');
+  });
+});

--- a/packages/kit-bg/src/offscreens/offscreenApiBinaryCodec.ts
+++ b/packages/kit-bg/src/offscreens/offscreenApiBinaryCodec.ts
@@ -1,0 +1,173 @@
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
+import bufferUtils from '@onekeyhq/shared/src/utils/bufferUtils';
+
+// Chrome extension Port messages use JSON serialization, so binary values need
+// an explicit wire representation between the background and offscreen pages.
+const OFFSCREEN_BINARY_PAYLOAD_MARKER = '__onekey_offscreen_binary_payload__';
+
+type IOffscreenBinaryPayload = {
+  [OFFSCREEN_BINARY_PAYLOAD_MARKER]: 1;
+  data: string;
+  type: 'array-buffer' | 'uint8-array';
+};
+
+const BASE64_PATTERN =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isArrayBufferValue(value: unknown): value is ArrayBuffer {
+  return Boolean(
+    typeof ArrayBuffer !== 'undefined' &&
+    (value instanceof ArrayBuffer ||
+      Object.prototype.toString.call(value) === '[object ArrayBuffer]'),
+  );
+}
+
+function isBlobValue(value: unknown): value is Blob {
+  return Boolean(
+    typeof Blob !== 'undefined' &&
+    (value instanceof Blob ||
+      Object.prototype.toString.call(value) === '[object Blob]') &&
+    typeof (value as Blob).arrayBuffer === 'function',
+  );
+}
+
+function readBinaryPayload(
+  value: unknown,
+): IOffscreenBinaryPayload | undefined {
+  if (!isPlainObject(value) || !(OFFSCREEN_BINARY_PAYLOAD_MARKER in value)) {
+    return undefined;
+  }
+  const payload = value as Partial<IOffscreenBinaryPayload>;
+  if (
+    payload[OFFSCREEN_BINARY_PAYLOAD_MARKER] !== 1 ||
+    (payload.type !== 'array-buffer' && payload.type !== 'uint8-array') ||
+    typeof payload.data !== 'string'
+  ) {
+    throw new OneKeyLocalError('Invalid offscreen binary payload');
+  }
+  return payload as IOffscreenBinaryPayload;
+}
+
+function bytesToPayload(
+  bytes: Uint8Array,
+  type: IOffscreenBinaryPayload['type'],
+): IOffscreenBinaryPayload {
+  return {
+    [OFFSCREEN_BINARY_PAYLOAD_MARKER]: 1,
+    data: bufferUtils.bytesToBase64(bytes),
+    type,
+  };
+}
+
+function payloadToBytes(payload: IOffscreenBinaryPayload): Uint8Array {
+  if (payload.data.length % 4 !== 0 || !BASE64_PATTERN.test(payload.data)) {
+    throw new OneKeyLocalError('Invalid offscreen binary payload data');
+  }
+  const decoded = bufferUtils.base64ToBytes(payload.data);
+  if (bufferUtils.bytesToBase64(decoded) !== payload.data) {
+    throw new OneKeyLocalError('Invalid offscreen binary payload data');
+  }
+  return Uint8Array.from(decoded);
+}
+
+async function encodeValue(
+  value: unknown,
+  seen: WeakSet<object>,
+): Promise<unknown> {
+  if (isArrayBufferValue(value)) {
+    return bytesToPayload(new Uint8Array(value), 'array-buffer');
+  }
+  if (typeof ArrayBuffer !== 'undefined' && ArrayBuffer.isView(value)) {
+    return bytesToPayload(
+      new Uint8Array(value.buffer, value.byteOffset, value.byteLength),
+      'uint8-array',
+    );
+  }
+  if (isBlobValue(value)) {
+    return bytesToPayload(
+      new Uint8Array(await value.arrayBuffer()),
+      'uint8-array',
+    );
+  }
+
+  const encodedPayload = readBinaryPayload(value);
+  if (encodedPayload) {
+    return encodedPayload;
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      throw new OneKeyLocalError('Circular offscreen API payload');
+    }
+    seen.add(value);
+    try {
+      const encoded: unknown[] = [];
+      for (const item of value) {
+        encoded.push(await encodeValue(item, seen));
+      }
+      return encoded.some((item, index) => item !== value[index])
+        ? encoded
+        : value;
+    } finally {
+      seen.delete(value);
+    }
+  }
+  if (!isPlainObject(value)) {
+    return value;
+  }
+  if (seen.has(value)) {
+    throw new OneKeyLocalError('Circular offscreen API payload');
+  }
+  seen.add(value);
+  try {
+    const entries: [string, unknown][] = [];
+    for (const [key, item] of Object.entries(value)) {
+      entries.push([key, await encodeValue(item, seen)]);
+    }
+    return entries.some(([key, item]) => item !== value[key])
+      ? Object.fromEntries(entries)
+      : value;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+function decodeValue(value: unknown): unknown {
+  const payload = readBinaryPayload(value);
+  if (payload) {
+    const bytes = payloadToBytes(payload);
+    return payload.type === 'array-buffer' ? bytes.buffer : bytes;
+  }
+  if (Array.isArray(value)) {
+    const decoded = value.map(decodeValue);
+    return decoded.some((item, index) => item !== value[index])
+      ? decoded
+      : value;
+  }
+  if (!isPlainObject(value)) {
+    return value;
+  }
+  const entries = Object.entries(value).map(
+    ([key, item]) => [key, decodeValue(item)] as const,
+  );
+  return entries.some(([key, item]) => item !== value[key])
+    ? Object.fromEntries(entries)
+    : value;
+}
+
+export async function encodeOffscreenApiPayload(
+  value: unknown,
+): Promise<unknown> {
+  return encodeValue(value, new WeakSet());
+}
+
+export function decodeOffscreenApiPayload(value: unknown): unknown {
+  return decodeValue(value);
+}

--- a/packages/kit-bg/src/services/ServiceHardware/serviceHardwarePortfolioSync/ServiceHardwarePortfolioSync.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/serviceHardwarePortfolioSync/ServiceHardwarePortfolioSync.ts
@@ -185,6 +185,7 @@ class ServiceHardwarePortfolioSync extends ServiceBase {
     if (
       !wallet ||
       wallet.id !== walletId ||
+      accountUtils.isWalletDeprecatedOrMocked(wallet) ||
       !accountUtils.isHwWallet({ walletId: wallet.id })
     ) {
       return undefined;

--- a/packages/kit-bg/src/services/ServiceHardware/serviceHardwarePortfolioSync/ServiceHardwarePortfolioSync.wait.test.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/serviceHardwarePortfolioSync/ServiceHardwarePortfolioSync.wait.test.ts
@@ -42,6 +42,11 @@ jest.mock('@onekeyhq/shared/src/utils/accountUtils', () => ({
   __esModule: true,
   default: {
     isHwWallet: jest.fn(),
+    isWalletDeprecatedOrMocked: jest.fn(
+      (
+        wallet: { deprecated?: boolean; isMocked?: boolean } | null | undefined,
+      ) => Boolean(wallet?.deprecated || wallet?.isMocked),
+    ),
     shortenAddress: jest.fn(({ address }: { address: string }) => address),
   },
 }));
@@ -617,6 +622,38 @@ describe('ServiceHardwarePortfolioSync.syncSettledPortfolio', () => {
 
     expect(serviceInternals.submitPortfolioJsonToServer).not.toHaveBeenCalled();
     expect(uploadPortfolioPackage).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['deprecated', { deprecated: true }],
+    ['mocked', { isMocked: true }],
+  ])('does not sync a %s hardware wallet', async (_label, walletState) => {
+    jest.mocked(localDb.getWalletSafe).mockResolvedValue({
+      id: 'hw-1',
+      name: 'OneKey Wallet',
+      type: 'hw',
+      ...walletState,
+    } as never);
+    jest.mocked(localDb.getWalletDeviceSafe).mockClear();
+    const {
+      getDeviceState,
+      service,
+      serviceInternals,
+      uploadPortfolioPackage,
+    } = prepareHardwareSync({ busyResults: [false] });
+
+    await serviceInternals.syncSettledPortfolio(buildHardwarePayload());
+
+    expect(localDb.getWalletDeviceSafe).not.toHaveBeenCalled();
+    expect(getDeviceState).not.toHaveBeenCalled();
+    expect(serviceInternals.submitPortfolioJsonToServer).not.toHaveBeenCalled();
+    expect(uploadPortfolioPackage).not.toHaveBeenCalled();
+    expect((service as unknown as { lastResult: unknown }).lastResult).toEqual(
+      expect.objectContaining({
+        status: 'disabled',
+        walletId: 'hw-1',
+      }),
+    );
   });
 
   test.each([


### PR DESCRIPTION
## What changed

- skip stale Pro2 portfolio synchronization work
- encode `ArrayBuffer`, typed-array views, and `Blob` values before the MV3 background/offscreen JSON bridge
- decode the tagged Base64 representation on both sides of the bridge
- preserve exact typed-array slice boundaries and reject malformed payloads before hardware I/O
- add regression coverage for Portfolio, wallpaper, NFT, firmware V1–V4, bootloader, and full resource uploads

## Why

Chrome Extension Port JSON serialization does not preserve native binary objects. Portfolio synchronization reached the SDK as an empty object and failed validation with `Unsupported FilesystemFileWrite data` before any device command was sent.

## Impact

MV3 plugin hardware calls can safely transport binary payloads through the offscreen boundary. The generic codec also protects wallpaper, NFT, and explicit firmware/resource binary inputs; non-MV3 direct calls retain their existing behavior.

## Validation

- offscreen codec Jest suite: 4 tests passed
- targeted ESLint passed
- App `tsc:only` passed
- `git diff --check` passed