### PR TITLE
fix: scope k-line source whitelist by entry OK-59253 OK-59252

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewNative/data/getTradingViewNativeSource.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/getTradingViewNativeSource.test.ts
@@ -21,6 +21,41 @@ describe('TradingViewNative source resolver', () => {
     });
   });
 
+  it('applies Hyperliquid mappings only for the requested branch', () => {
+    const tokenIdentity = {
+      hyperliquidCoin: '',
+      isNative: true,
+      marketDataSource: undefined,
+      networkId: 'evm--999',
+      symbol: 'HYPE',
+      tokenAddress: '',
+    } as const;
+
+    expect(
+      getTradingViewNativeSource({
+        ...tokenIdentity,
+        hyperliquidWhitelistBranch: 'swap',
+      }),
+    ).toEqual({
+      kind: 'hyperliquid',
+      coin: '@107',
+      environment: 'mainnet',
+    });
+    expect(
+      getTradingViewNativeSource({
+        ...tokenIdentity,
+        hyperliquidWhitelistBranch: 'market',
+      }),
+    ).toEqual({
+      kind: 'market',
+      isNative: true,
+      networkId: 'evm--999',
+      tokenAddress: '',
+      symbol: 'HYPE',
+      realtime: 'disabled',
+    });
+  });
+
   it('keeps the Market transport in the Market source variant', () => {
     const source = getTradingViewNativeSource({
       hyperliquidCoin: '',

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/getTradingViewNativeSource.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/getTradingViewNativeSource.ts
@@ -1,3 +1,6 @@
+import { getTradingViewNativeWhitelistedHyperliquidSource } from './tradingViewNativeHyperliquidWhitelist';
+
+import type { ITradingViewNativeHyperliquidWhitelistBranch } from './tradingViewNativeHyperliquidWhitelist';
 import type { ITradingViewNativeSource } from '../types';
 
 function normalizeMarketTokenAddress(tokenAddress: string) {
@@ -43,6 +46,7 @@ export function getTradingViewNativeSourceKey(
 export function getTradingViewNativeSource({
   fallbackCoinGeckoId,
   hyperliquidCoin,
+  hyperliquidWhitelistBranch,
   isNative,
   marketDataSource,
   networkId,
@@ -51,13 +55,22 @@ export function getTradingViewNativeSource({
 }: {
   fallbackCoinGeckoId?: string;
   hyperliquidCoin: string;
+  hyperliquidWhitelistBranch?: ITradingViewNativeHyperliquidWhitelistBranch;
   isNative?: boolean;
   marketDataSource: 'polling' | 'websocket' | undefined;
   networkId: string;
   symbol: string;
   tokenAddress: string;
 }): ITradingViewNativeSource {
-  const normalizedHyperliquidCoin = hyperliquidCoin.trim();
+  const whitelistedSource = hyperliquidWhitelistBranch
+    ? getTradingViewNativeWhitelistedHyperliquidSource({
+        branch: hyperliquidWhitelistBranch,
+        token: { isNative, networkId, tokenAddress },
+      })
+    : undefined;
+  const normalizedHyperliquidCoin = (
+    whitelistedSource?.coin ?? hyperliquidCoin
+  ).trim();
   if (normalizedHyperliquidCoin) {
     return {
       kind: 'hyperliquid',

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/tradingViewNativeHyperliquidWhitelist.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/tradingViewNativeHyperliquidWhitelist.test.ts
@@ -1,0 +1,81 @@
+import { getTradingViewNativeWhitelistedHyperliquidSource } from './tradingViewNativeHyperliquidWhitelist';
+
+describe('TradingViewNative Hyperliquid whitelist', () => {
+  it('maps native Bitcoin independently for each configured branch', () => {
+    const token = {
+      isNative: true,
+      networkId: 'btc--0',
+      tokenAddress: '',
+    };
+
+    expect(
+      (['swap', 'market', 'wallet'] as const).map((branch) =>
+        getTradingViewNativeWhitelistedHyperliquidSource({
+          branch,
+          token,
+        }),
+      ),
+    ).toEqual([
+      { coin: 'BTC', type: 'hyperliquid' },
+      { coin: 'BTC', type: 'hyperliquid' },
+      { coin: 'BTC', type: 'hyperliquid' },
+    ]);
+  });
+
+  it('maps native HyperEVM HYPE to its preferred spot market', () => {
+    expect(
+      getTradingViewNativeWhitelistedHyperliquidSource({
+        branch: 'swap',
+        token: {
+          isNative: true,
+          networkId: 'evm--999',
+          tokenAddress: '',
+        },
+      }),
+    ).toEqual({ coin: '@107', type: 'hyperliquid' });
+  });
+
+  it('does not match contract tokens or another network', () => {
+    expect(
+      getTradingViewNativeWhitelistedHyperliquidSource({
+        branch: 'market',
+        token: {
+          isNative: false,
+          networkId: 'btc--0',
+          tokenAddress: 'ordinals-token',
+        },
+      }),
+    ).toBeUndefined();
+    expect(
+      getTradingViewNativeWhitelistedHyperliquidSource({
+        branch: 'market',
+        token: {
+          isNative: true,
+          networkId: 'evm--1',
+          tokenAddress: '',
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('keeps branch enablement independent', () => {
+    const hypeToken = {
+      isNative: true,
+      networkId: 'evm--999',
+      tokenAddress: '',
+    };
+
+    expect(
+      getTradingViewNativeWhitelistedHyperliquidSource({
+        branch: 'market',
+        token: hypeToken,
+      }),
+    ).toBeUndefined();
+    expect(
+      getTradingViewNativeWhitelistedHyperliquidSource({
+        branch: 'wallet',
+        token: hypeToken,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/kit/src/components/TradingView/TradingViewNative/data/tradingViewNativeHyperliquidWhitelist.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/data/tradingViewNativeHyperliquidWhitelist.ts
@@ -1,0 +1,80 @@
+import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
+
+export type ITradingViewNativeHyperliquidWhitelistBranch =
+  | 'market'
+  | 'swap'
+  | 'wallet';
+
+export interface ITradingViewNativeHyperliquidWhitelistSource {
+  coin: string;
+  type: 'hyperliquid';
+}
+
+export interface ITradingViewNativeHyperliquidWhitelistItem {
+  isNative: boolean;
+  market?: ITradingViewNativeHyperliquidWhitelistSource;
+  networkId: string;
+  swap?: ITradingViewNativeHyperliquidWhitelistSource;
+  tokenAddress?: string;
+  wallet?: ITradingViewNativeHyperliquidWhitelistSource;
+}
+
+export interface ITradingViewNativeHyperliquidTokenIdentity {
+  isNative?: boolean;
+  networkId?: string;
+  tokenAddress?: string;
+}
+
+const networkIdsMap = getNetworkIdsMap();
+
+export const TRADING_VIEW_NATIVE_HYPERLIQUID_WHITELIST = {
+  btc: {
+    isNative: true,
+    market: { coin: 'BTC', type: 'hyperliquid' },
+    networkId: networkIdsMap.btc,
+    swap: { coin: 'BTC', type: 'hyperliquid' },
+    wallet: { coin: 'BTC', type: 'hyperliquid' },
+  },
+  hype: {
+    isNative: true,
+    networkId: networkIdsMap.hyperevm,
+    swap: { coin: '@107', type: 'hyperliquid' },
+  },
+} as const satisfies Record<string, ITradingViewNativeHyperliquidWhitelistItem>;
+
+export function getTradingViewNativeWhitelistedHyperliquidSource({
+  branch,
+  token,
+}: {
+  branch: ITradingViewNativeHyperliquidWhitelistBranch;
+  token?: ITradingViewNativeHyperliquidTokenIdentity;
+}): ITradingViewNativeHyperliquidWhitelistSource | undefined {
+  if (!token?.networkId) {
+    return undefined;
+  }
+  const normalizedTokenAddress = token.tokenAddress?.trim().toLowerCase();
+  const whitelistItems: readonly ITradingViewNativeHyperliquidWhitelistItem[] =
+    Object.values(TRADING_VIEW_NATIVE_HYPERLIQUID_WHITELIST);
+  const item = whitelistItems.find((candidate) => {
+    if (
+      candidate.networkId !== token.networkId ||
+      candidate.isNative !== Boolean(token.isNative)
+    ) {
+      return false;
+    }
+    if (candidate.isNative) {
+      return true;
+    }
+    const normalizedWhitelistAddress = candidate.tokenAddress
+      ?.trim()
+      .toLowerCase();
+    return Boolean(
+      normalizedWhitelistAddress &&
+      normalizedTokenAddress &&
+      normalizedWhitelistAddress === normalizedTokenAddress,
+    );
+  });
+  const source = item?.[branch];
+  const coin = source?.coin.trim();
+  return source && coin ? { ...source, coin } : undefined;
+}

--- a/packages/kit/src/views/AssetDetails/pages/MarketChart/index.tsx
+++ b/packages/kit/src/views/AssetDetails/pages/MarketChart/index.tsx
@@ -46,6 +46,7 @@ export default function MarketChart() {
     () =>
       getTradingViewNativeSource({
         hyperliquidCoin: '',
+        hyperliquidWhitelistBranch: 'wallet',
         isNative,
         marketDataSource: undefined,
         networkId,

--- a/packages/kit/src/views/Market/MarketDetailV2/MarketDetailV2.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/MarketDetailV2.tsx
@@ -118,6 +118,7 @@ function MarketDetail({
             isDesktopLayout={isDesktopLayout}
             isChartFullscreen={isChartFullscreen}
             onChartFullscreenChange={onChartFullscreenChange}
+            isNative={isNativeBoolean}
             networkId={networkId}
             tokenAddress={tokenAddress}
             showFavoriteButton={showFavoriteButton}

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/DesktopLayout.tsx
@@ -148,6 +148,7 @@ function useIframeWheelPassthrough({
 export interface IDesktopLayoutProps {
   isChartFullscreen: boolean;
   onChartFullscreenChange: (isFullscreen: boolean) => void;
+  isNative: boolean;
   networkId: string;
   tokenAddress: string;
   showFavoriteButton?: boolean;
@@ -156,6 +157,7 @@ export interface IDesktopLayoutProps {
 export function DesktopLayout({
   isChartFullscreen,
   onChartFullscreenChange,
+  isNative: routeIsNative,
   networkId: routeNetworkId,
   tokenAddress: routeTokenAddress,
   showFavoriteButton = true,
@@ -164,7 +166,7 @@ export function DesktopLayout({
     tokenAddress: storeTokenAddress,
     networkId: storeNetworkId,
     tokenDetail,
-    isNative,
+    isNative: storeIsNative,
     websocketConfig,
     perpsInfo,
     isStockToken,
@@ -172,6 +174,10 @@ export function DesktopLayout({
   const useTradingViewNative = useTradingViewNativeInMarketDetail();
   const networkId = storeNetworkId || routeNetworkId;
   const tokenAddress = storeNetworkId ? storeTokenAddress : routeTokenAddress;
+  const isNative =
+    networkId === routeNetworkId && tokenAddress === routeTokenAddress
+      ? routeIsNative
+      : storeIsNative;
 
   const { accountAddress, xpub } = useNetworkAccount(networkId);
   const chartFullscreenZIndex = useOverlayZIndex(isChartFullscreen);

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MarketDetailResponsiveLayout.native.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MarketDetailResponsiveLayout.native.tsx
@@ -4,12 +4,14 @@ import type { IMarketDetailResponsiveLayoutProps } from './MarketDetailResponsiv
 
 export function MarketDetailResponsiveLayout({
   disableTrade,
+  isNative,
   networkId,
   tokenAddress,
 }: IMarketDetailResponsiveLayoutProps) {
   return (
     <MobileLayout
       disableTrade={disableTrade}
+      isNative={isNative}
       networkId={networkId}
       tokenAddress={tokenAddress}
     />

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MarketDetailResponsiveLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MarketDetailResponsiveLayout.tsx
@@ -7,6 +7,7 @@ export function MarketDetailResponsiveLayout({
   isDesktopLayout,
   isChartFullscreen,
   onChartFullscreenChange,
+  isNative,
   networkId,
   tokenAddress,
   showFavoriteButton,
@@ -17,6 +18,7 @@ export function MarketDetailResponsiveLayout({
       <DesktopLayout
         isChartFullscreen={isChartFullscreen}
         onChartFullscreenChange={onChartFullscreenChange}
+        isNative={isNative}
         networkId={networkId}
         tokenAddress={tokenAddress}
         showFavoriteButton={showFavoriteButton}
@@ -27,6 +29,7 @@ export function MarketDetailResponsiveLayout({
   return (
     <MobileLayout
       disableTrade={disableTrade}
+      isNative={isNative}
       networkId={networkId}
       tokenAddress={tokenAddress}
     />

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MarketDetailResponsiveLayout.types.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MarketDetailResponsiveLayout.types.ts
@@ -2,6 +2,7 @@ export interface IMarketDetailResponsiveLayoutProps {
   isDesktopLayout: boolean;
   isChartFullscreen: boolean;
   onChartFullscreenChange: (isFullscreen: boolean) => void;
+  isNative: boolean;
   networkId: string;
   tokenAddress: string;
   showFavoriteButton?: boolean;

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -247,12 +247,14 @@ function MobileMarketTradingView({
 
 export interface IMobileLayoutProps {
   disableTrade?: boolean;
+  isNative?: boolean;
   networkId?: string;
   tokenAddress?: string;
 }
 
 export function MobileLayout({
   disableTrade,
+  isNative: routeIsNative = false,
   networkId: routeNetworkId = '',
   tokenAddress: routeTokenAddress = '',
 }: IMobileLayoutProps) {
@@ -260,7 +262,7 @@ export function MobileLayout({
     tokenAddress: storeTokenAddress,
     networkId: storeNetworkId,
     tokenDetail,
-    isNative,
+    isNative: storeIsNative,
     websocketConfig,
     perpsInfo,
     isStockToken,
@@ -268,6 +270,10 @@ export function MobileLayout({
   const useTradingViewNative = useTradingViewNativeInMarketDetail();
   const networkId = storeNetworkId || routeNetworkId;
   const tokenAddress = storeNetworkId ? storeTokenAddress : routeTokenAddress;
+  const isNative =
+    networkId === routeNetworkId && tokenAddress === routeTokenAddress
+      ? routeIsNative
+      : storeIsNative;
   const tokenSymbol = tokenDetail?.symbol;
   const marketTradingViewParams = useMarketTradingViewParams({
     tokenAddress,

--- a/packages/kit/src/views/Market/MarketDetailV2/utils/getMarketDetailTradingViewNativeSource.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/utils/getMarketDetailTradingViewNativeSource.test.ts
@@ -34,4 +34,39 @@ describe('Market detail TradingViewNative source', () => {
       realtime: 'websocket',
     });
   });
+
+  it('uses the native Bitcoin whitelist before detail metadata loads', () => {
+    expect(
+      getMarketDetailTradingViewNativeSource({
+        hyperliquidCoin: '',
+        isNative: true,
+        marketDataSource: undefined,
+        networkId: 'btc--0',
+        symbol: 'BTC',
+        tokenAddress: '',
+      }),
+    ).toEqual({
+      kind: 'hyperliquid',
+      coin: 'BTC',
+      environment: 'mainnet',
+    });
+  });
+
+  it('keeps non-whitelisted sources on Market', () => {
+    expect(
+      getMarketDetailTradingViewNativeSource({
+        hyperliquidCoin: '',
+        marketDataSource: 'polling',
+        networkId: 'evm--1',
+        symbol: '',
+        tokenAddress: '',
+      }),
+    ).toEqual({
+      kind: 'market',
+      networkId: 'evm--1',
+      tokenAddress: '',
+      symbol: '',
+      realtime: 'disabled',
+    });
+  });
 });

--- a/packages/kit/src/views/Market/MarketDetailV2/utils/getMarketDetailTradingViewNativeSource.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/utils/getMarketDetailTradingViewNativeSource.ts
@@ -1,1 +1,14 @@
-export { getTradingViewNativeSource as getMarketDetailTradingViewNativeSource } from '@onekeyhq/kit/src/components/TradingView/TradingViewNative/data/getTradingViewNativeSource';
+import { getTradingViewNativeSource } from '@onekeyhq/kit/src/components/TradingView/TradingViewNative/data/getTradingViewNativeSource';
+
+type IGetTradingViewNativeSourceParams = Parameters<
+  typeof getTradingViewNativeSource
+>[0];
+
+export function getMarketDetailTradingViewNativeSource(
+  params: IGetTradingViewNativeSourceParams,
+) {
+  return getTradingViewNativeSource({
+    ...params,
+    hyperliquidWhitelistBranch: 'market',
+  });
+}

--- a/packages/kit/src/views/Market/components/TokenPriceChart.tsx
+++ b/packages/kit/src/views/Market/components/TokenPriceChart.tsx
@@ -62,6 +62,7 @@ function BasicTokenPriceChart({ coinGeckoId, token }: ITokenPriceChartProps) {
       getTradingViewNativeSource({
         fallbackCoinGeckoId: coinGeckoId,
         hyperliquidCoin: '',
+        hyperliquidWhitelistBranch: 'market',
         isNative: marketNetwork?.isNative,
         marketDataSource: undefined,
         networkId: networkId ?? '',

--- a/packages/kit/src/views/Swap/pages/modal/swapKLineTradingViewNativeUtils.test.ts
+++ b/packages/kit/src/views/Swap/pages/modal/swapKLineTradingViewNativeUtils.test.ts
@@ -19,11 +19,10 @@ function buildToken(overrides: Partial<ISwapToken> = {}): ISwapToken {
 }
 
 describe('Swap K-line TradingViewNative source', () => {
-  it('uses Hyperliquid for native BTC when the token detail configures it', () => {
+  it('uses the native BTC Swap whitelist before token detail loads', () => {
     const source = getSwapKLineTradingViewNativeSource({
-      perpsInfo: { hlTicker: 'BTC' },
+      isTokenMarketInfoLoading: true,
       token: buildToken(),
-      websocketConfig: { kline: true, txs: true },
     });
 
     expect(source).toEqual({
@@ -78,13 +77,20 @@ describe('Swap K-line TradingViewNative source', () => {
     });
   });
 
-  it('waits for native BTC metadata before choosing its provider', () => {
+  it('uses the native HyperEVM Swap whitelist independently of Market', () => {
     expect(
       getSwapKLineTradingViewNativeSource({
         isTokenMarketInfoLoading: true,
-        token: buildToken(),
+        token: buildToken({
+          networkId: 'evm--999',
+          symbol: 'HYPE',
+        }),
       }),
-    ).toBeUndefined();
+    ).toEqual({
+      kind: 'hyperliquid',
+      coin: '@107',
+      environment: 'mainnet',
+    });
   });
 
   it('keeps chart fallback ownership out of the Swap source', () => {

--- a/packages/kit/src/views/Swap/pages/modal/swapKLineTradingViewNativeUtils.ts
+++ b/packages/kit/src/views/Swap/pages/modal/swapKLineTradingViewNativeUtils.ts
@@ -2,6 +2,7 @@ import {
   getTradingViewNativeSource,
   getTradingViewNativeSourceKey,
 } from '@onekeyhq/kit/src/components/TradingView/TradingViewNative/data/getTradingViewNativeSource';
+import { getTradingViewNativeWhitelistedHyperliquidSource } from '@onekeyhq/kit/src/components/TradingView/TradingViewNative/data/tradingViewNativeHyperliquidWhitelist';
 import type { ITradingViewNativeSource } from '@onekeyhq/kit/src/components/TradingView/TradingViewNative/types';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import type {
@@ -87,6 +88,25 @@ export function getSwapKLineTradingViewNativeSource({
 }): ITradingViewNativeSource | undefined {
   if (!token?.networkId) {
     return undefined;
+  }
+
+  const whitelistedSource = getTradingViewNativeWhitelistedHyperliquidSource({
+    branch: 'swap',
+    token: {
+      isNative: token.isNative,
+      networkId: token.networkId,
+      tokenAddress: token.contractAddress,
+    },
+  });
+  if (whitelistedSource) {
+    return getTradingViewNativeSource({
+      hyperliquidCoin: whitelistedSource.coin,
+      isNative: token.isNative,
+      marketDataSource: websocketConfig?.kline ? 'websocket' : 'polling',
+      networkId: token.networkId,
+      symbol: token.symbol,
+      tokenAddress: token.contractAddress ?? '',
+    });
   }
 
   const mayUseHyperliquid =


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59253](https://onekeyhq.atlassian.net/browse/OK-59253) [OK-59252](https://onekeyhq.atlassian.net/browse/OK-59252)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- add a shared, entry-scoped TradingView Hyperliquid source whitelist for Swap, Market, and Wallet
- configure native BTC for all three entries and native HyperEVM HYPE (`@107`) for Swap only
- pass the route-native identity into Market Detail so the first render can select the BTC whitelist before token detail metadata resolves

## Root cause

The existing whitelist implementation was scoped to Swap and was not available to Market or Wallet. Market Detail also relied on atom state populated after navigation, so its first render could select the Market history source and display a line chart before BTC metadata arrived.

## User impact

Clicking native BTC from Market now opens the Hyperliquid candlestick source immediately. HYPE uses Hyperliquid `@107` only in Swap; branches without a configured source keep their existing behavior.

## Validation

- 4 targeted Jest suites, 24 tests passed
- `yarn agent:check --profile commit`
- Web UI verification with the token detail response delayed: the Hyperliquid candle request started before detail resolution and no Market K-line request was issued

[OK-59253]: https://onekeyhq.atlassian.net/browse/OK-59253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-59252]: https://onekeyhq.atlassian.net/browse/OK-59252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ