### PR TITLE
fix: harden bitcoin psbt signing

### DIFF
--- a/packages/core/src/chains/btc/CoreChainSoftware.test.ts
+++ b/packages/core/src/chains/btc/CoreChainSoftware.test.ts
@@ -1,3 +1,5 @@
+import { Psbt, Transaction } from 'bitcoinjs-lib';
+
 import { NotImplemented } from '@onekeyhq/shared/src/errors';
 
 import coreTestsUtils from '../../../@tests/coreTestsUtils';
@@ -5,6 +7,7 @@ import coreTestsFixtures from '../../../@tests/fixtures/coreTestsFixtures';
 import { EAddressEncodings } from '../../types';
 
 import CoreChainHd from './CoreChainHd';
+import { getBtcForkNetwork } from './sdkBtc';
 
 const {
   hdCredential,
@@ -114,5 +117,40 @@ describe('BTC Core tests', () => {
     // const coreApi = new CoreChainHd();
     // coreApi.signMessage
     throw new NotImplemented();
+  });
+
+  it('rejects SIGHASH_NONE before reaching the software signer', async () => {
+    const network = getBtcForkNetwork('tbtc');
+    const psbt = new Psbt({ network });
+    psbt.addInput({
+      hash: Buffer.alloc(32),
+      index: 0,
+      sighashType: Transaction.SIGHASH_NONE,
+      witnessUtxo: {
+        script: Buffer.from(`0014${'00'.repeat(20)}`, 'hex'),
+        value: BigInt(1000),
+      },
+    });
+    psbt.addOutput({
+      script: Buffer.from(`0014${'11'.repeat(20)}`, 'hex'),
+      value: BigInt(900),
+    });
+
+    const coreApi = new CoreChainHd();
+    await expect(
+      coreApi.signPsbt({
+        encodedTx: null,
+        network,
+        psbt,
+        signers: {},
+        inputsToSign: [
+          {
+            index: 0,
+            publicKey: '',
+            address: '',
+          },
+        ],
+      }),
+    ).rejects.toThrow('SIGHASH_NONE is not supported for input 0');
   });
 });

--- a/packages/core/src/chains/btc/CoreChainSoftware.ts
+++ b/packages/core/src/chains/btc/CoreChainSoftware.ts
@@ -49,6 +49,7 @@ import { slicePathTemplate } from '../../utils';
 import {
   btcForkVersionBytesToBuffer,
   buildBtcXpubSegwitAsync,
+  findBtcSighashNoneInput,
   getAddressFromXpub,
   getBitcoinBip32,
   getBitcoinECPair,
@@ -746,6 +747,16 @@ export default class CoreChainSoftwareBtc extends CoreChainApiBase {
     inputsToSign: ITxInputToSign[];
     signOnly?: boolean;
   }) {
+    const sighashNoneInput = findBtcSighashNoneInput({
+      psbt,
+      inputsToSign,
+    });
+    if (sighashNoneInput) {
+      throw new OneKeyLocalError(
+        `SIGHASH_NONE is not supported for input ${sighashNoneInput.index}`,
+      );
+    }
+
     for (let i = 0, len = inputsToSign.length; i < len; i += 1) {
       const input = inputsToSign[i];
       const signer = this.pickSigner(signers, input.address);

--- a/packages/core/src/chains/btc/sdkBtc/index.test.ts
+++ b/packages/core/src/chains/btc/sdkBtc/index.test.ts
@@ -1,11 +1,12 @@
 import {
   convertLtcXpub,
+  findBtcSighashNoneInput,
   getBtcForkNetwork,
   getInputsToSignFromPsbt,
   getSignPsbtOptionsForPsbtIndex,
 } from '.';
 
-import { Psbt } from 'bitcoinjs-lib';
+import { Psbt, Transaction } from 'bitcoinjs-lib';
 
 import type { ISignPsbtOptions } from '@onekeyhq/shared/types/ProviderApis/ProviderApiBtc.type';
 
@@ -170,5 +171,66 @@ describe('getInputsToSignFromPsbt - Babylon signPsbts regression', () => {
         isBtcWalletProvider: fixedOptions?.isBtcWalletProvider ?? false,
       }),
     ).toHaveLength(1);
+  });
+});
+
+describe('findBtcSighashNoneInput', () => {
+  const psbtNetwork = getBtcForkNetwork('tbtc');
+  const buildPsbt = (sighashType?: number) => {
+    const psbt = Psbt.fromHex(BABYLON_SINGLE_PSBT_HEX, {
+      network: psbtNetwork,
+    });
+    if (sighashType !== undefined) {
+      psbt.updateInput(0, { sighashType });
+    }
+    return psbt;
+  };
+
+  it('detects SIGHASH_NONE selected by automatic input discovery', () => {
+    const psbt = buildPsbt(Transaction.SIGHASH_NONE);
+    const inputsToSign = getInputsToSignFromPsbt({
+      psbt,
+      psbtNetwork,
+      account: BABYLON_ACCOUNT,
+      isBtcWalletProvider: true,
+    });
+
+    expect(inputsToSign[0].sighashTypes).toEqual([Transaction.SIGHASH_NONE]);
+    expect(findBtcSighashNoneInput({ psbt, inputsToSign })).toBe(
+      inputsToSign[0],
+    );
+  });
+
+  it('detects SIGHASH_NONE with ANYONECANPAY for explicit inputs', () => {
+    const psbt = buildPsbt(
+      Transaction.SIGHASH_NONE | Transaction.SIGHASH_ANYONECANPAY,
+    );
+    const inputsToSign = [{ index: 0 }];
+
+    expect(findBtcSighashNoneInput({ psbt, inputsToSign })).toBe(
+      inputsToSign[0],
+    );
+  });
+
+  it('preserves an implicit SIGHASH_DEFAULT', () => {
+    const psbt = buildPsbt();
+
+    expect(psbt.data.inputs[0].sighashType).toBeUndefined();
+    expect(
+      findBtcSighashNoneInput({ psbt, inputsToSign: [{ index: 0 }] }),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    Transaction.SIGHASH_ALL,
+    Transaction.SIGHASH_SINGLE,
+    Transaction.SIGHASH_ALL | Transaction.SIGHASH_ANYONECANPAY,
+    Transaction.SIGHASH_SINGLE | Transaction.SIGHASH_ANYONECANPAY,
+  ])('preserves compatible sighash type %s', (sighashType) => {
+    const psbt = buildPsbt(sighashType);
+
+    expect(
+      findBtcSighashNoneInput({ psbt, inputsToSign: [{ index: 0 }] }),
+    ).toBeUndefined();
   });
 });

--- a/packages/core/src/chains/btc/sdkBtc/index.ts
+++ b/packages/core/src/chains/btc/sdkBtc/index.ts
@@ -229,6 +229,25 @@ export function getInputsToSignFromPsbt({
   return inputsToSign;
 }
 
+export function findBtcSighashNoneInput({
+  psbt,
+  inputsToSign,
+}: {
+  psbt: Psbt;
+  inputsToSign: readonly Pick<ITxInputToSign, 'index'>[];
+}) {
+  return inputsToSign.find((input) => {
+    const sighashType = psbt.data.inputs[input.index]?.sighashType;
+    if (typeof sighashType !== 'number') {
+      return false;
+    }
+
+    // Mask off ANYONECANPAY so NONE and NONE|ANYONECANPAY are both rejected.
+    const outputType = sighashType & Transaction.SIGHASH_OUTPUT_MASK;
+    return outputType === Transaction.SIGHASH_NONE;
+  });
+}
+
 // UniSat-compatible `signPsbts` passes `options` as an array (one entry per
 // psbt); OneKey/legacy callers pass a single shared options object. Return the
 // options that apply to the psbt at `index` for both shapes. Dropping the

--- a/packages/kit-bg/src/providers/ProviderApiBtc.ts
+++ b/packages/kit-bg/src/providers/ProviderApiBtc.ts
@@ -6,6 +6,7 @@ import { Psbt } from 'bitcoinjs-lib';
 import { isEmpty, isNil } from 'lodash';
 
 import {
+  findBtcSighashNoneInput,
   getInputsToSignFromPsbt,
   getSignPsbtOptionsForPsbtIndex,
 } from '@onekeyhq/core/src/chains/btc/sdkBtc';
@@ -780,6 +781,16 @@ class ProviderApiBtc extends ProviderApiBase {
         account,
         isBtcWalletProvider: options?.isBtcWalletProvider ?? false,
       });
+    }
+
+    const sighashNoneInput = findBtcSighashNoneInput({
+      psbt,
+      inputsToSign,
+    });
+    if (sighashNoneInput) {
+      throw web3Errors.rpc.invalidParams(
+        `SIGHASH_NONE is not supported for input ${sighashNoneInput.index}`,
+      );
     }
 
     const inputAddresses = new Map<string, BigNumber>();


### PR DESCRIPTION
## Summary
- Harden Bitcoin PSBT signing validation.
- Reject unsafe output-uncommitted sighash modes before confirmation and signing.

## Intent & Context
Strengthen PSBT signing safety across wallet provider flows.

## Root Cause
PSBT input sighash modes were forwarded to signing without enforcing an output-commitment policy.

## Design Decisions
- Validate the actual PSBT input sighash values after resolving the selected signing inputs.
- Apply the same validation at the software signing boundary for defense in depth.
- Preserve compatible DEFAULT, ALL, and SINGLE modes, including supported ANYONECANPAY combinations.

## Changes Detail
- Add shared detection for SIGHASH_NONE and SIGHASH_NONE with ANYONECANPAY.
- Reject unsafe inputs in the Bitcoin provider before opening the confirmation flow.
- Reject unsafe inputs again before software signing.
- Add regression tests for automatic and explicit input selection and compatible sighash modes.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: Bitcoin DApp PSBT signing and software-wallet signing validation.

## Test plan
- [x] Run targeted Bitcoin PSBT and software signer unit tests.
- [x] Run the repository commit-profile checks for lint, formatting, and TypeScript.