### PR TITLE
fix: center desktop browser banner

### DIFF
--- a/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContent.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContent.tsx
@@ -125,7 +125,7 @@ function DashboardContent({
           banner={
             hasActiveBanners ? (
               <View
-                style={{ width: '100%' }}
+                style={{ width: '100%', alignItems: 'center' }}
                 onTouchStart={(e) => e.stopPropagation()}
                 onTouchMove={(e) => e.stopPropagation()}
                 onTouchEnd={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Summary

- Center the fixed-width Discovery banner inside its full-width touch wrapper on desktop.
- Preserve the existing 360px banner, 384px search input, and mobile full-width behavior.

## Root cause

The touch wrapper was given `width: 100%` to avoid a zero-width Yoga layout on mobile. On desktop, the center column is 384px wide while the banner remains 360px. Without horizontal alignment on the wrapper, the banner stays left-aligned and its center shifts 12px to the left.

## Impact

The desktop Browser home banner is centered with the search input. The Banner component, advertising badge, close button, and touch handlers are unchanged.

## Validation

- `yarn agent:check --profile pr`
- Desktop v6.5.0 manual verification passed for banner/search alignment and the advertising badge.
- Code review confirmed that the mobile 100% width behavior remains unchanged.
