### PR TITLE
fix: self-heal unreadable SimpleDB records and support clearing Perps data (OK-59997)

### DIFF
--- a/.skillshare/skills/1k-retrospective/references/case-studies.md
+++ b/.skillshare/skills/1k-retrospective/references/case-studies.md
@@ -40,3 +40,10 @@ Cases are appended by AI after each bug fix. Do NOT reorder or delete entries �
 **Root Cause**: Wallet avatar rendering only read `keylessProvider`, while the refreshed avatar-specific provider was not persisted or prioritized.
 **Fix**: Stored `avatarProvider` in `keylessDetails` during avatar repair and updated avatar rendering to prefer `avatarProvider` before falling back to `keylessProvider`.
 **Catchable by**: Section 4: Type definitions changed -> all consumers updated
+
+## Case: Perps stuck on "Loading tokens..." after IndexedDB blob corruption
+**Date**: 2026-08-11 | **Platforms**: desktop (Electron/Chromium storage; web/ext share the code path)
+**Symptom**: Desktop 6.5.0 user's Perps chart and token selector permanently stuck on "Loading tokens..." across restarts; realtime prices kept updating; mobile unaffected (OK-59997).
+**Root Cause**: All Perps caches live in one `simple_db_v5:perp` record. Chromium stores large IndexedDB values as external blob files; a crash corrupted the blob so every read rejected with `UnknownError: Failed to read large IndexedDB value`. `setRawData(builder)` reads the old record before writing, so all writes failed too — the record could never be repaired by normal usage.
+**Fix**: Opt-in self-heal in `SimpleDbEntityBase` (perp only): on the exact corruption signature, retry once, then remove the record with write-overlap vetoes (writeSeq + pendingWrites snapshot); read generation prevents in-flight reads from resurrecting cleared/overwritten cache; Settings → Clear cache gained a "Perps" item backed by a runtime clear epoch in ServiceWebviewPerp.
+**Catchable by**: NEW — storage-layer read errors need a recovery path for caches that can be rebuilt; read-before-write persistence cannot self-repair a corrupted record

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
@@ -64,3 +64,76 @@ describe('SimpleDbEntityBase clear/set mutex serialization', () => {
     expect(entity.entityKey in store).toBe(false); // cache stays cleared
   });
 });
+
+// A corrupted external blob makes every read reject forever, and builder-based
+// setRawData reads first — without self-heal the record could never be repaired.
+describe('SimpleDbEntityBase unreadable-record self-heal', () => {
+  class HealTestEntity extends SimpleDbEntityBase<{ v: number }> {
+    override readonly entityName = 'test-heal-entity';
+
+    override readonly enableCache = false;
+  }
+
+  // Unreadable until removeItem drops it, mirroring a corrupted blob record.
+  const makeBrokenStorage = (errorName: string) => {
+    const store: Record<string, unknown> = {};
+    const calls: string[] = [];
+    let broken = true;
+    return {
+      store,
+      calls,
+      storage: {
+        getItem: async (k: string) => {
+          calls.push('getItem');
+          if (broken) {
+            const error = new Error('Failed to read large IndexedDB value');
+            error.name = errorName;
+            throw error;
+          }
+          return (k in store ? store[k] : null) as string | null;
+        },
+        setItem: async (k: string, v: unknown) => {
+          calls.push('setItem');
+          store[k] = v;
+        },
+        removeItem: async (k: string) => {
+          calls.push('removeItem');
+          delete store[k];
+          broken = false;
+        },
+      },
+    };
+  };
+
+  test('getRawData drops the unreadable record and returns null', async () => {
+    const entity = new HealTestEntity();
+    const { storage, calls } = makeBrokenStorage('UnknownError');
+    (entity as any).appStorage = storage;
+
+    await expect(entity.getRawData()).resolves.toBeNull();
+    expect(calls).toEqual(['getItem', 'removeItem']);
+  });
+
+  test('setRawData(builder) rebuilds the record after a read failure', async () => {
+    const entity = new HealTestEntity();
+    const { storage, store } = makeBrokenStorage('NotReadableError');
+    (entity as any).appStorage = storage;
+
+    await expect(
+      entity.setRawData((prev) => ({ v: (prev?.v ?? 0) + 1 })),
+    ).resolves.toEqual({ v: 1 });
+    expect(entity.entityKey in store).toBe(true);
+    await expect(entity.getRawData()).resolves.toEqual({ v: 1 });
+  });
+
+  test('non-storage read errors still propagate without deleting the record', async () => {
+    const entity = new HealTestEntity();
+    const { storage, calls } = makeBrokenStorage('SomeRandomError');
+    (entity as any).appStorage = storage;
+
+    await expect(entity.getRawData()).rejects.toThrow(
+      'Failed to read large IndexedDB value',
+    );
+    expect(calls).toEqual(['getItem']);
+  });
+});

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
@@ -219,4 +219,50 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
     expect(calls).not.toContain('removeItem'); // guard kept the fresh write
     expect(entity.entityKey in store).toBe(true);
   });
+
+  test('self-heal delete is skipped while a write is still in flight', async () => {
+    const entity = new HealTestEntity();
+    const store: Record<string, unknown> = {};
+    const calls: string[] = [];
+    let releaseWrite!: () => void;
+    const writeGate = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    let signalWriteStarted!: () => void;
+    const writeStarted = new Promise<void>((resolve) => {
+      signalWriteStarted = resolve;
+    });
+    const makeError = () => {
+      const error = new Error('Failed to read large IndexedDB value');
+      error.name = 'UnknownError';
+      return error;
+    };
+    (entity as any).appStorage = {
+      getItem: () => {
+        calls.push('getItem');
+        return Promise.reject(makeError());
+      },
+      setItem: async (k: string, v: unknown) => {
+        calls.push('setItem');
+        signalWriteStarted();
+        await writeGate; // parked mid-write while the failing read races it
+        store[k] = v;
+      },
+      removeItem: async (k: string) => {
+        calls.push('removeItem');
+        delete store[k];
+      },
+    };
+
+    const writeP = entity.setRawData({ v: 7 }); // non-builder: no read involved
+    await writeStarted; // setRawData is parked inside setItem, seq bumped
+    const readP = entity.getRawData(); // fails while the write is in flight
+
+    await expect(readP).resolves.toBeNull();
+    releaseWrite();
+    await writeP;
+
+    expect(calls).not.toContain('removeItem'); // in-flight write already vetoed
+    expect(entity.entityKey in store).toBe(true);
+  });
 });

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
@@ -4,14 +4,25 @@ import { SimpleDbEntityBase } from './SimpleDbEntityBase';
 yarn jest packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
 */
 
-// Concrete entity over a controllable in-memory appStorage so we can park a
-// setRawData mid-flight (inside the mutex) and fire clearRawData concurrently.
-// This proves clearRawData and setRawData are serialized by the shared mutex, so
-// an in-flight write can never resurrect a just-cleared cache.
+// Single configurable entity over controllable in-memory appStorage mocks —
+// oxlint allows one class per file, so cache/self-heal variants are options.
 class TestEntity extends SimpleDbEntityBase<{ v: number }> {
-  override readonly entityName = 'test-entity';
+  override readonly entityName: string;
 
-  override readonly enableCache = false;
+  override readonly enableCache: boolean;
+
+  protected override readonly enableUnreadableRecordSelfHeal: boolean;
+
+  constructor({
+    name = 'test-entity',
+    enableCache = false,
+    selfHeal = false,
+  }: { name?: string; enableCache?: boolean; selfHeal?: boolean } = {}) {
+    super();
+    this.entityName = name;
+    this.enableCache = enableCache;
+    this.enableUnreadableRecordSelfHeal = selfHeal;
+  }
 }
 
 describe('SimpleDbEntityBase clear/set mutex serialization', () => {
@@ -68,20 +79,8 @@ describe('SimpleDbEntityBase clear/set mutex serialization', () => {
 // A corrupted external blob makes every read reject forever, and builder-based
 // setRawData reads first — without self-heal the record could never be repaired.
 describe('SimpleDbEntityBase unreadable-record self-heal', () => {
-  class HealTestEntity extends SimpleDbEntityBase<{ v: number }> {
-    override readonly entityName = 'test-heal-entity';
-
-    override readonly enableCache = false;
-
-    protected override readonly enableUnreadableRecordSelfHeal = true;
-  }
-
-  // Self-heal is opt-in; this entity keeps the default (off).
-  class NoHealTestEntity extends SimpleDbEntityBase<{ v: number }> {
-    override readonly entityName = 'test-no-heal-entity';
-
-    override readonly enableCache = false;
-  }
+  const makeHealEntity = () =>
+    new TestEntity({ name: 'test-heal-entity', selfHeal: true });
 
   // Unreadable until removeItem drops it (or failTimes runs out), mirroring a
   // corrupted blob record vs a transient IO failure.
@@ -96,15 +95,15 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
   }) => {
     const store: Record<string, unknown> = {};
     const calls: string[] = [];
-    let failed = 0;
+    let remainingFails = failTimes;
     return {
       store,
       calls,
       storage: {
         getItem: async (k: string) => {
           calls.push('getItem');
-          if (failed < failTimes) {
-            failed += 1;
+          if (remainingFails > 0) {
+            remainingFails -= 1;
             const error = new Error(errorMessage);
             error.name = errorName;
             throw error;
@@ -118,14 +117,14 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
         removeItem: async (k: string) => {
           calls.push('removeItem');
           delete store[k];
-          failTimes = 0;
+          remainingFails = 0;
         },
       },
     };
   };
 
   test('getRawData drops the unreadable record and returns null', async () => {
-    const entity = new HealTestEntity();
+    const entity = makeHealEntity();
     const { storage, calls } = makeBrokenStorage({ errorName: 'UnknownError' });
     (entity as any).appStorage = storage;
 
@@ -134,7 +133,7 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
   });
 
   test('setRawData(builder) rebuilds the record after a read failure', async () => {
-    const entity = new HealTestEntity();
+    const entity = makeHealEntity();
     const { storage, store } = makeBrokenStorage({
       errorName: 'UnknownError',
     });
@@ -148,7 +147,7 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
   });
 
   test('non-storage read errors still propagate without deleting the record', async () => {
-    const entity = new HealTestEntity();
+    const entity = makeHealEntity();
     const { storage, calls } = makeBrokenStorage({
       errorName: 'SomeRandomError',
     });
@@ -161,7 +160,7 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
   });
 
   test('NotReadableError propagates without deleting (transient IO condition)', async () => {
-    const entity = new HealTestEntity();
+    const entity = makeHealEntity();
     const { storage, calls } = makeBrokenStorage({
       errorName: 'NotReadableError',
     });
@@ -174,7 +173,7 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
   });
 
   test('UnknownError without the corrupted-blob message propagates without deleting', async () => {
-    const entity = new HealTestEntity();
+    const entity = makeHealEntity();
     const { storage, calls } = makeBrokenStorage({
       errorName: 'UnknownError',
       errorMessage: 'Internal error opening backing store',
@@ -188,7 +187,7 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
   });
 
   test('a transient read failure recovers via retry and keeps the record', async () => {
-    const entity = new HealTestEntity();
+    const entity = makeHealEntity();
     const { storage, store, calls } = makeBrokenStorage({
       errorName: 'UnknownError',
       failTimes: 1,
@@ -202,7 +201,7 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
   });
 
   test('self-heal delete is skipped when a write lands during the failing read', async () => {
-    const entity = new HealTestEntity();
+    const entity = makeHealEntity();
     const store: Record<string, unknown> = {};
     const calls: string[] = [];
     let rejectFirstRead!: (error: Error) => void;
@@ -213,7 +212,7 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
       return error;
     };
     (entity as any).appStorage = {
-      getItem: (k: string) => {
+      getItem: () => {
         readCount += 1;
         calls.push('getItem');
         if (readCount === 1) {
@@ -243,7 +242,7 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
   });
 
   test('self-heal delete is skipped while a write is still in flight', async () => {
-    const entity = new HealTestEntity();
+    const entity = makeHealEntity();
     const store: Record<string, unknown> = {};
     const calls: string[] = [];
     let releaseWrite!: () => void;
@@ -289,7 +288,7 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
   });
 
   test('entities without opt-in propagate the corrupted-blob error and keep the record', async () => {
-    const entity = new NoHealTestEntity();
+    const entity = new TestEntity({ name: 'test-no-heal-entity' });
     const { storage, calls } = makeBrokenStorage({ errorName: 'UnknownError' });
     (entity as any).appStorage = storage;
 
@@ -300,7 +299,7 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
   });
 
   test('delete is skipped when a pre-existing write completes during the failing read', async () => {
-    const entity = new HealTestEntity();
+    const entity = makeHealEntity();
     const store: Record<string, unknown> = {};
     const calls: string[] = [];
     let releaseWrite!: () => void;
@@ -354,12 +353,10 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
   });
 
   test('clearRawData during an in-flight read keeps the stale value out of the cache', async () => {
-    class CachedHealTestEntity extends SimpleDbEntityBase<{ v: number }> {
-      override readonly entityName = 'test-cached-heal-entity';
-
-      override readonly enableCache = true;
-    }
-    const entity = new CachedHealTestEntity();
+    const entity = new TestEntity({
+      name: 'test-cached-heal-entity',
+      enableCache: true,
+    });
     const store: Record<string, unknown> = {};
     let resolveFirstRead!: (value: string) => void;
     let readCount = 0;
@@ -388,5 +385,39 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
 
     // The stale value must not have been cached — a fresh read sees the clear.
     await expect(entity.getRawData()).resolves.toBeNull();
+  });
+
+  test('a slow read finishing after a save cannot revert the cached value', async () => {
+    const entity = new TestEntity({
+      name: 'test-cached-save-entity',
+      enableCache: true,
+    });
+    const store: Record<string, unknown> = {};
+    let resolveFirstRead!: (value: string) => void;
+    let readCount = 0;
+    (entity as any).appStorage = {
+      getItem: (k: string) => {
+        readCount += 1;
+        if (readCount === 1) {
+          return new Promise<string | null>((resolve) => {
+            resolveFirstRead = resolve;
+          });
+        }
+        return Promise.resolve((k in store ? store[k] : null) as string | null);
+      },
+      setItem: async (k: string, v: unknown) => {
+        store[k] = v;
+      },
+      removeItem: async (k: string) => {
+        delete store[k];
+      },
+    };
+
+    const slowReadP = entity.getRawData(); // parked reading the old record
+    await entity.setRawData({ v: 7 }); // save lands while the read is parked
+    resolveFirstRead(JSON.stringify({ data: { v: 1 }, updatedAt: 1 }));
+    await slowReadP; // the old value must not overwrite the cache
+
+    await expect(entity.getRawData()).resolves.toEqual({ v: 7 });
   });
 });

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
@@ -74,19 +74,29 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
     override readonly enableCache = false;
   }
 
-  // Unreadable until removeItem drops it, mirroring a corrupted blob record.
-  const makeBrokenStorage = (errorName: string) => {
+  // Unreadable until removeItem drops it (or failTimes runs out), mirroring a
+  // corrupted blob record vs a transient IO failure.
+  const makeBrokenStorage = ({
+    errorName,
+    errorMessage = 'Failed to read large IndexedDB value',
+    failTimes = Number.POSITIVE_INFINITY,
+  }: {
+    errorName: string;
+    errorMessage?: string;
+    failTimes?: number;
+  }) => {
     const store: Record<string, unknown> = {};
     const calls: string[] = [];
-    let broken = true;
+    let failed = 0;
     return {
       store,
       calls,
       storage: {
         getItem: async (k: string) => {
           calls.push('getItem');
-          if (broken) {
-            const error = new Error('Failed to read large IndexedDB value');
+          if (failed < failTimes) {
+            failed += 1;
+            const error = new Error(errorMessage);
             error.name = errorName;
             throw error;
           }
@@ -99,7 +109,7 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
         removeItem: async (k: string) => {
           calls.push('removeItem');
           delete store[k];
-          broken = false;
+          failTimes = 0;
         },
       },
     };
@@ -107,16 +117,18 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
 
   test('getRawData drops the unreadable record and returns null', async () => {
     const entity = new HealTestEntity();
-    const { storage, calls } = makeBrokenStorage('UnknownError');
+    const { storage, calls } = makeBrokenStorage({ errorName: 'UnknownError' });
     (entity as any).appStorage = storage;
 
     await expect(entity.getRawData()).resolves.toBeNull();
-    expect(calls).toEqual(['getItem', 'removeItem']);
+    expect(calls).toEqual(['getItem', 'getItem', 'removeItem']);
   });
 
   test('setRawData(builder) rebuilds the record after a read failure', async () => {
     const entity = new HealTestEntity();
-    const { storage, store } = makeBrokenStorage('NotReadableError');
+    const { storage, store } = makeBrokenStorage({
+      errorName: 'NotReadableError',
+    });
     (entity as any).appStorage = storage;
 
     await expect(
@@ -128,12 +140,83 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
 
   test('non-storage read errors still propagate without deleting the record', async () => {
     const entity = new HealTestEntity();
-    const { storage, calls } = makeBrokenStorage('SomeRandomError');
+    const { storage, calls } = makeBrokenStorage({
+      errorName: 'SomeRandomError',
+    });
     (entity as any).appStorage = storage;
 
     await expect(entity.getRawData()).rejects.toThrow(
       'Failed to read large IndexedDB value',
     );
     expect(calls).toEqual(['getItem']);
+  });
+
+  test('UnknownError without the corrupted-blob message propagates without deleting', async () => {
+    const entity = new HealTestEntity();
+    const { storage, calls } = makeBrokenStorage({
+      errorName: 'UnknownError',
+      errorMessage: 'Internal error opening backing store',
+    });
+    (entity as any).appStorage = storage;
+
+    await expect(entity.getRawData()).rejects.toThrow(
+      'Internal error opening backing store',
+    );
+    expect(calls).toEqual(['getItem']);
+  });
+
+  test('a transient read failure recovers via retry and keeps the record', async () => {
+    const entity = new HealTestEntity();
+    const { storage, store, calls } = makeBrokenStorage({
+      errorName: 'UnknownError',
+      failTimes: 1,
+    });
+    store[entity.entityKey] = JSON.stringify({ data: { v: 9 }, updatedAt: 1 });
+    (entity as any).appStorage = storage;
+
+    await expect(entity.getRawData()).resolves.toEqual({ v: 9 });
+    expect(calls).toEqual(['getItem', 'getItem']);
+    expect(entity.entityKey in store).toBe(true);
+  });
+
+  test('self-heal delete is skipped when a write lands during the failing read', async () => {
+    const entity = new HealTestEntity();
+    const store: Record<string, unknown> = {};
+    const calls: string[] = [];
+    let rejectFirstRead!: (error: Error) => void;
+    let readCount = 0;
+    const makeError = () => {
+      const error = new Error('Failed to read large IndexedDB value');
+      error.name = 'UnknownError';
+      return error;
+    };
+    (entity as any).appStorage = {
+      getItem: (k: string) => {
+        readCount += 1;
+        calls.push('getItem');
+        if (readCount === 1) {
+          return new Promise<string | null>((_, reject) => {
+            rejectFirstRead = reject;
+          });
+        }
+        return Promise.reject(makeError());
+      },
+      setItem: async (k: string, v: unknown) => {
+        calls.push('setItem');
+        store[k] = v;
+      },
+      removeItem: async (k: string) => {
+        calls.push('removeItem');
+        delete store[k];
+      },
+    };
+
+    const readP = entity.getRawData(); // parked on the hanging first getItem
+    await entity.setRawData({ v: 7 }); // write lands while the read is in flight
+    rejectFirstRead(makeError());
+
+    await expect(readP).resolves.toBeNull();
+    expect(calls).not.toContain('removeItem'); // guard kept the fresh write
+    expect(entity.entityKey in store).toBe(true);
   });
 });

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
@@ -72,6 +72,15 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
     override readonly entityName = 'test-heal-entity';
 
     override readonly enableCache = false;
+
+    protected override readonly enableUnreadableRecordSelfHeal = true;
+  }
+
+  // Self-heal is opt-in; this entity keeps the default (off).
+  class NoHealTestEntity extends SimpleDbEntityBase<{ v: number }> {
+    override readonly entityName = 'test-no-heal-entity';
+
+    override readonly enableCache = false;
   }
 
   // Unreadable until removeItem drops it (or failTimes runs out), mirroring a
@@ -277,5 +286,107 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
 
     expect(calls).not.toContain('removeItem'); // in-flight write already vetoed
     expect(entity.entityKey in store).toBe(true);
+  });
+
+  test('entities without opt-in propagate the corrupted-blob error and keep the record', async () => {
+    const entity = new NoHealTestEntity();
+    const { storage, calls } = makeBrokenStorage({ errorName: 'UnknownError' });
+    (entity as any).appStorage = storage;
+
+    await expect(entity.getRawData()).rejects.toThrow(
+      'Failed to read large IndexedDB value',
+    );
+    expect(calls).toEqual(['getItem']); // no retry, no delete
+  });
+
+  test('delete is skipped when a pre-existing write completes during the failing read', async () => {
+    const entity = new HealTestEntity();
+    const store: Record<string, unknown> = {};
+    const calls: string[] = [];
+    let releaseWrite!: () => void;
+    const writeGate = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    let signalWriteStarted!: () => void;
+    const writeStarted = new Promise<void>((resolve) => {
+      signalWriteStarted = resolve;
+    });
+    let rejectFirstRead!: (error: Error) => void;
+    let readCount = 0;
+    const makeError = () => {
+      const error = new Error('Failed to read large IndexedDB value');
+      error.name = 'UnknownError';
+      return error;
+    };
+    (entity as any).appStorage = {
+      getItem: () => {
+        readCount += 1;
+        calls.push('getItem');
+        if (readCount === 1) {
+          return new Promise<string | null>((_, reject) => {
+            rejectFirstRead = reject;
+          });
+        }
+        return Promise.reject(makeError());
+      },
+      setItem: async (k: string, v: unknown) => {
+        calls.push('setItem');
+        signalWriteStarted();
+        await writeGate;
+        store[k] = v;
+      },
+      removeItem: async (k: string) => {
+        calls.push('removeItem');
+        delete store[k];
+      },
+    };
+
+    const writeP = entity.setRawData({ v: 7 });
+    await writeStarted; // write is in flight before the read begins
+    const readP = entity.getRawData(); // snapshot sees the pending write
+    releaseWrite();
+    await writeP; // write fully lands while the read is still failing
+    rejectFirstRead(makeError());
+
+    await expect(readP).resolves.toBeNull();
+    expect(calls).not.toContain('removeItem'); // snapshot veto kept the value
+    expect(entity.entityKey in store).toBe(true);
+  });
+
+  test('clearRawData during an in-flight read keeps the stale value out of the cache', async () => {
+    class CachedHealTestEntity extends SimpleDbEntityBase<{ v: number }> {
+      override readonly entityName = 'test-cached-heal-entity';
+
+      override readonly enableCache = true;
+    }
+    const entity = new CachedHealTestEntity();
+    const store: Record<string, unknown> = {};
+    let resolveFirstRead!: (value: string) => void;
+    let readCount = 0;
+    (entity as any).appStorage = {
+      getItem: (k: string) => {
+        readCount += 1;
+        if (readCount === 1) {
+          return new Promise<string | null>((resolve) => {
+            resolveFirstRead = resolve;
+          });
+        }
+        return Promise.resolve((k in store ? store[k] : null) as string | null);
+      },
+      setItem: async (k: string, v: unknown) => {
+        store[k] = v;
+      },
+      removeItem: async (k: string) => {
+        delete store[k];
+      },
+    };
+
+    const staleReadP = entity.getRawData(); // parked reading the old record
+    await entity.clearRawData(); // user clears while the read is in flight
+    resolveFirstRead(JSON.stringify({ data: { v: 9 }, updatedAt: 1 }));
+    await expect(staleReadP).resolves.toEqual({ v: 9 }); // its caller still gets the old value
+
+    // The stale value must not have been cached — a fresh read sees the clear.
+    await expect(entity.getRawData()).resolves.toBeNull();
   });
 });

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
@@ -127,7 +127,7 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
   test('setRawData(builder) rebuilds the record after a read failure', async () => {
     const entity = new HealTestEntity();
     const { storage, store } = makeBrokenStorage({
-      errorName: 'NotReadableError',
+      errorName: 'UnknownError',
     });
     (entity as any).appStorage = storage;
 
@@ -142,6 +142,19 @@ describe('SimpleDbEntityBase unreadable-record self-heal', () => {
     const entity = new HealTestEntity();
     const { storage, calls } = makeBrokenStorage({
       errorName: 'SomeRandomError',
+    });
+    (entity as any).appStorage = storage;
+
+    await expect(entity.getRawData()).rejects.toThrow(
+      'Failed to read large IndexedDB value',
+    );
+    expect(calls).toEqual(['getItem']);
+  });
+
+  test('NotReadableError propagates without deleting (transient IO condition)', async () => {
+    const entity = new HealTestEntity();
+    const { storage, calls } = makeBrokenStorage({
+      errorName: 'NotReadableError',
     });
     (entity as any).appStorage = storage;
 

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
@@ -15,19 +15,16 @@ type ISimpleDbEntitySavedData<T> = {
   updatedAt: number;
 };
 
-// Chromium rejects reads with these signatures when a value's external blob
-// file is corrupted (e.g. crash mid-write); the record stays unreadable
-// forever. UnknownError alone is not enough — Chromium also uses it for
-// transient IO failures (disk full, backing store open errors), so it must
-// carry the corrupted-blob message to qualify.
+// Chromium rejects reads with exactly this signature when a value's external
+// blob file is corrupted (e.g. crash mid-write); the record then stays
+// unreadable forever. Match nothing broader: UnknownError without this
+// message and NotReadableError both cover transient IO conditions where
+// deleting would lose recoverable data (OK-59997).
 function isUnreadableStorageValueError(error: unknown): boolean {
   const { name, message } = (error ?? {}) as {
     name?: string;
     message?: string;
   };
-  if (name === 'NotReadableError') {
-    return true;
-  }
   return (
     name === 'UnknownError' &&
     Boolean(message?.includes('Failed to read large IndexedDB value'))

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
@@ -14,6 +14,13 @@ type ISimpleDbEntitySavedData<T> = {
   data: T;
   updatedAt: number;
 };
+
+// Chromium rejects reads with these names when a value's external blob file
+// is corrupted (e.g. crash mid-write); the record stays unreadable forever.
+function isUnreadableStorageValueError(error: unknown): boolean {
+  const name = (error as { name?: string } | null | undefined)?.name;
+  return name === 'UnknownError' || name === 'NotReadableError';
+}
 abstract class SimpleDbEntityBase<T> {
   // Do not use appStorageInstance directly, use this.appStorage instead
   appStorage: AsyncStorageStatic =
@@ -55,7 +62,18 @@ abstract class SimpleDbEntityBase<T> {
     }
     this.cachedRawDataPromise = (async () => {
       dbPerfMonitor.logSimpleDbCall('getRawData', this.entityName);
-      const savedDataStr = await this.appStorage.getItem(this.entityKey);
+      let savedDataStr: string | null = null;
+      try {
+        savedDataStr = await this.appStorage.getItem(this.entityKey);
+      } catch (error) {
+        if (!isUnreadableStorageValueError(error)) {
+          throw error;
+        }
+        console.error(error);
+        // Drop the dead record so builder-based setRawData can rebuild it; use
+        // appStorage directly — clearRawData() would deadlock on the shared mutex.
+        await this.appStorage.removeItem(this.entityKey).catch(() => undefined);
+      }
       let updatedAt = 0;
       // @ts-ignore
       let data: T | undefined | null;

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
@@ -15,11 +15,23 @@ type ISimpleDbEntitySavedData<T> = {
   updatedAt: number;
 };
 
-// Chromium rejects reads with these names when a value's external blob file
-// is corrupted (e.g. crash mid-write); the record stays unreadable forever.
+// Chromium rejects reads with these signatures when a value's external blob
+// file is corrupted (e.g. crash mid-write); the record stays unreadable
+// forever. UnknownError alone is not enough — Chromium also uses it for
+// transient IO failures (disk full, backing store open errors), so it must
+// carry the corrupted-blob message to qualify.
 function isUnreadableStorageValueError(error: unknown): boolean {
-  const name = (error as { name?: string } | null | undefined)?.name;
-  return name === 'UnknownError' || name === 'NotReadableError';
+  const { name, message } = (error ?? {}) as {
+    name?: string;
+    message?: string;
+  };
+  if (name === 'NotReadableError') {
+    return true;
+  }
+  return (
+    name === 'UnknownError' &&
+    Boolean(message?.includes('Failed to read large IndexedDB value'))
+  );
 }
 abstract class SimpleDbEntityBase<T> {
   // Do not use appStorageInstance directly, use this.appStorage instead
@@ -46,6 +58,10 @@ abstract class SimpleDbEntityBase<T> {
 
   updatedAt = 0;
 
+  // Bumped on every persisted write so a failing read can tell whether a
+  // concurrent setRawData landed after it started.
+  private writeSeq = 0;
+
   @backgroundMethod()
   clearRawDataCache() {
     this.cachedRawData = null;
@@ -62,6 +78,7 @@ abstract class SimpleDbEntityBase<T> {
     }
     this.cachedRawDataPromise = (async () => {
       dbPerfMonitor.logSimpleDbCall('getRawData', this.entityName);
+      const writeSeqBefore = this.writeSeq;
       let savedDataStr: string | null = null;
       try {
         savedDataStr = await this.appStorage.getItem(this.entityKey);
@@ -69,10 +86,24 @@ abstract class SimpleDbEntityBase<T> {
         if (!isUnreadableStorageValueError(error)) {
           throw error;
         }
-        console.error(error);
-        // Drop the dead record so builder-based setRawData can rebuild it; use
-        // appStorage directly — clearRawData() would deadlock on the shared mutex.
-        await this.appStorage.removeItem(this.entityKey).catch(() => undefined);
+        try {
+          // One retry separates transient IO failures from true corruption.
+          savedDataStr = await this.appStorage.getItem(this.entityKey);
+        } catch (retryError) {
+          if (!isUnreadableStorageValueError(retryError)) {
+            throw retryError;
+          }
+          console.error(retryError);
+          // Drop the dead record so builder-based setRawData can rebuild it;
+          // use appStorage directly — clearRawData() would deadlock on the
+          // shared mutex. Skip if a write landed after this read started:
+          // deleting would erase that fresh value.
+          if (this.writeSeq === writeSeqBefore) {
+            await this.appStorage
+              .removeItem(this.entityKey)
+              .catch(() => undefined);
+          }
+        }
       }
       let updatedAt = 0;
       // @ts-ignore
@@ -148,6 +179,7 @@ abstract class SimpleDbEntityBase<T> {
           ? (savedData as any)
           : JSON.stringify(savedData),
       );
+      this.writeSeq += 1;
 
       this.updatedAt = updatedAt;
       return data;

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
@@ -41,6 +41,11 @@ abstract class SimpleDbEntityBase<T> {
 
   abstract readonly enableCache: boolean;
 
+  // Deleting an unreadable record is only safe for entities whose data can be
+  // fully rebuilt (OK-59997's perp cache); user-authored entities must keep
+  // failing loudly instead, so self-heal is opt-in per entity.
+  protected readonly enableUnreadableRecordSelfHeal: boolean = false;
+
   get entityKey() {
     return `${SIMPLE_DB_KEY_PREFIX}:${this.entityName}`;
   }
@@ -60,11 +65,16 @@ abstract class SimpleDbEntityBase<T> {
   private writeSeq = 0;
 
   // Writes currently awaiting setItem; a failing read must not delete while
-  // one is in flight, whichever of the two started first.
+  // one is in flight or was in flight when the read began.
   private pendingWrites = 0;
+
+  // Bumped by clearRawDataCache so a read that was already in flight when the
+  // clear happened cannot re-publish the stale value into the memory cache.
+  private readGeneration = 0;
 
   @backgroundMethod()
   clearRawDataCache() {
+    this.readGeneration += 1;
     this.cachedRawData = null;
     this.cachedRawDataPromise = null;
   }
@@ -80,11 +90,16 @@ abstract class SimpleDbEntityBase<T> {
     this.cachedRawDataPromise = (async () => {
       dbPerfMonitor.logSimpleDbCall('getRawData', this.entityName);
       const writeSeqBefore = this.writeSeq;
+      const pendingWritesBefore = this.pendingWrites;
+      const readGenerationBefore = this.readGeneration;
       let savedDataStr: string | null = null;
       try {
         savedDataStr = await this.appStorage.getItem(this.entityKey);
       } catch (error) {
-        if (!isUnreadableStorageValueError(error)) {
+        if (
+          !this.enableUnreadableRecordSelfHeal ||
+          !isUnreadableStorageValueError(error)
+        ) {
           throw error;
         }
         try {
@@ -97,11 +112,15 @@ abstract class SimpleDbEntityBase<T> {
           console.error(retryError);
           // Drop the dead record so builder-based setRawData can rebuild it;
           // use appStorage directly — clearRawData() would deadlock on the
-          // shared mutex. Skip if a write is in flight or started after this
-          // read began: deleting would erase that fresh value. (A write that
-          // starts after this check wins anyway — same-store ops keep issue
-          // order, so its setItem lands after this removeItem.)
-          if (this.pendingWrites === 0 && this.writeSeq === writeSeqBefore) {
+          // shared mutex. Any write overlapping this read vetoes the delete:
+          // pending at read start, still pending now, or started since. (A
+          // write starting after this check wins anyway — same-store ops keep
+          // issue order, so its setItem lands after this removeItem.)
+          if (
+            pendingWritesBefore === 0 &&
+            this.pendingWrites === 0 &&
+            this.writeSeq === writeSeqBefore
+          ) {
             await this.appStorage
               .removeItem(this.entityKey)
               .catch(() => undefined);
@@ -138,7 +157,10 @@ abstract class SimpleDbEntityBase<T> {
         }
       }
       this.updatedAt = updatedAt ?? 0;
-      if (this.enableCache) {
+      // Skip the cache when clearRawData ran while this read was in flight,
+      // otherwise the stale value would resurrect the just-cleared record on
+      // the next builder-based write.
+      if (this.enableCache && this.readGeneration === readGenerationBefore) {
         this.cachedRawData = data;
       }
       return data;

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
@@ -58,9 +58,13 @@ abstract class SimpleDbEntityBase<T> {
 
   updatedAt = 0;
 
-  // Bumped on every persisted write so a failing read can tell whether a
-  // concurrent setRawData landed after it started.
+  // Bumped when a persisted write starts so a failing read can tell whether a
+  // concurrent setRawData started after the read began.
   private writeSeq = 0;
+
+  // Writes currently awaiting setItem; a failing read must not delete while
+  // one is in flight, whichever of the two started first.
+  private pendingWrites = 0;
 
   @backgroundMethod()
   clearRawDataCache() {
@@ -96,9 +100,11 @@ abstract class SimpleDbEntityBase<T> {
           console.error(retryError);
           // Drop the dead record so builder-based setRawData can rebuild it;
           // use appStorage directly — clearRawData() would deadlock on the
-          // shared mutex. Skip if a write landed after this read started:
-          // deleting would erase that fresh value.
-          if (this.writeSeq === writeSeqBefore) {
+          // shared mutex. Skip if a write is in flight or started after this
+          // read began: deleting would erase that fresh value. (A write that
+          // starts after this check wins anyway — same-store ops keep issue
+          // order, so its setItem lands after this removeItem.)
+          if (this.pendingWrites === 0 && this.writeSeq === writeSeqBefore) {
             await this.appStorage
               .removeItem(this.entityKey)
               .catch(() => undefined);
@@ -173,13 +179,18 @@ abstract class SimpleDbEntityBase<T> {
       };
 
       dbPerfMonitor.logSimpleDbCall('setRawData', this.entityName);
-      await this.appStorage.setItem(
-        this.entityKey,
-        appStorageUtils.canSaveAsObject() && !isString(savedData)
-          ? (savedData as any)
-          : JSON.stringify(savedData),
-      );
       this.writeSeq += 1;
+      this.pendingWrites += 1;
+      try {
+        await this.appStorage.setItem(
+          this.entityKey,
+          appStorageUtils.canSaveAsObject() && !isString(savedData)
+            ? (savedData as any)
+            : JSON.stringify(savedData),
+        );
+      } finally {
+        this.pendingWrites -= 1;
+      }
 
       this.updatedAt = updatedAt;
       return data;

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
@@ -68,8 +68,8 @@ abstract class SimpleDbEntityBase<T> {
   // one is in flight or was in flight when the read began.
   private pendingWrites = 0;
 
-  // Bumped by clearRawDataCache so a read that was already in flight when the
-  // clear happened cannot re-publish the stale value into the memory cache.
+  // Bumped by clearRawDataCache and setRawData so a read that was already in
+  // flight cannot re-publish a stale value into the memory cache afterwards.
   private readGeneration = 0;
 
   @backgroundMethod()
@@ -199,6 +199,7 @@ abstract class SimpleDbEntityBase<T> {
 
       dbPerfMonitor.logSimpleDbCall('setRawData', this.entityName);
       this.writeSeq += 1;
+      this.readGeneration += 1;
       this.pendingWrites += 1;
       try {
         await this.appStorage.setItem(

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
@@ -195,6 +195,10 @@ export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
 
   override enableCache = true;
 
+  // Everything here can be rebuilt from server/WS data or cheap re-acceptance,
+  // so dropping a corrupted record is safe (OK-59997).
+  protected override readonly enableUnreadableRecordSelfHeal = true;
+
   private _isCacheEntryFresh(updatedAt: number | undefined, maxAgeMs: number) {
     if (!updatedAt || maxAgeMs <= 0) {
       return false;

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -337,7 +337,9 @@ class ServiceSetting extends ServiceBase {
       await this.backgroundApi.simpleDb.recentNetworks.clearRawData();
     }
     if (values.perpsData) {
-      // Recovery exit for a perp record IndexedDB can no longer read.
+      // Recovery exit for a perp record IndexedDB can no longer read. Runtime
+      // cache first so in-flight fetches cannot write stale data back.
+      await this.backgroundApi.serviceWebviewPerp.clearPerpsDepositTokenListRuntimeCache();
       await this.backgroundApi.simpleDb.perp.clearRawData();
     }
     defaultLogger.setting.page.clearData({ action: 'Cache' });

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -336,6 +336,10 @@ class ServiceSetting extends ServiceBase {
       await this.backgroundApi.simpleDb.serverNetwork.clearRawData();
       await this.backgroundApi.simpleDb.recentNetworks.clearRawData();
     }
+    if (values.perpsData) {
+      // Recovery exit for a perp record IndexedDB can no longer read.
+      await this.backgroundApi.simpleDb.perp.clearRawData();
+    }
     defaultLogger.setting.page.clearData({ action: 'Cache' });
   }
 

--- a/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
@@ -447,6 +447,21 @@ class ServiceWebviewPerp extends ServiceBase {
     );
   }
 
+  @backgroundMethod()
+  async clearPerpsDepositTokenListRuntimeCache() {
+    // Bump every known generation so in-flight fetches skip their simpleDb
+    // write-back; otherwise a "clear Perps data" could be repopulated by a
+    // request that was already running.
+    const cacheKeys = new Set([
+      ...this.perpsDepositTokenListCache.keys(),
+      ...this.perpsDepositTokenListWriteGenerations.keys(),
+    ]);
+    cacheKeys.forEach((cacheKey) =>
+      this.bumpPerpsDepositTokenListWriteGeneration(cacheKey),
+    );
+    this.perpsDepositTokenListCache.clear();
+  }
+
   private buildPerpsDepositTokenListOwnerKey({
     allNetworksAccountId,
     ownerIndexId,

--- a/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
@@ -613,6 +613,7 @@ class ServiceWebviewPerp extends ServiceBase {
           this.isPerpsDepositTokenListWriteGenerationCurrent({
             cacheKey: options.cacheKey,
             writeGeneration: options.writeGeneration,
+            clearEpoch: options.clearEpoch,
           })
         ) {
           void this.backgroundApi.simpleDb.perp.setPerpsDepositTokenListCache({

--- a/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
@@ -338,6 +338,12 @@ const PERPS_DEPOSIT_TOKEN_LIST_COLD_CACHE_MAX_AGE_MS =
     day: 1,
   });
 
+interface IPerpsDepositTokenListWriteOptions {
+  cacheKey: string;
+  writeGeneration: number;
+  clearEpoch: number;
+}
+
 @backgroundClass()
 class ServiceWebviewPerp extends ServiceBase {
   private perpsDepositTokenListCache = new Map<
@@ -346,6 +352,10 @@ class ServiceWebviewPerp extends ServiceBase {
   >();
 
   private perpsDepositTokenListWriteGenerations = new Map<string, number>();
+
+  // Bumped on runtime-cache clear; fetches capture it before their first await
+  // so requests that predate the clear cannot write results back.
+  private perpsDepositTokenListClearEpoch = 0;
 
   constructor({ backgroundApi }: { backgroundApi: any }) {
     super({ backgroundApi });
@@ -438,20 +448,20 @@ class ServiceWebviewPerp extends ServiceBase {
   private isPerpsDepositTokenListWriteGenerationCurrent({
     cacheKey,
     writeGeneration,
-  }: {
-    cacheKey: string;
-    writeGeneration: number;
-  }) {
+    clearEpoch,
+  }: IPerpsDepositTokenListWriteOptions) {
     return (
+      this.perpsDepositTokenListClearEpoch === clearEpoch &&
       this.getPerpsDepositTokenListWriteGeneration(cacheKey) === writeGeneration
     );
   }
 
   @backgroundMethod()
   async clearPerpsDepositTokenListRuntimeCache() {
-    // Bump every known generation so in-flight fetches skip their simpleDb
-    // write-back; otherwise a "clear Perps data" could be repopulated by a
-    // request that was already running.
+    // Bump the epoch so every in-flight fetch — including ones that have not
+    // registered their cache key yet — skips its simpleDb write-back, then
+    // bump known generations and drop the memory cache.
+    this.perpsDepositTokenListClearEpoch += 1;
     const cacheKeys = new Set([
       ...this.perpsDepositTokenListCache.keys(),
       ...this.perpsDepositTokenListWriteGenerations.keys(),
@@ -587,10 +597,7 @@ class ServiceWebviewPerp extends ServiceBase {
 
   private fetchPerpsDepositTokenListDataCached(
     params: IPerpsDepositTokenListCacheParams,
-    options: {
-      cacheKey: string;
-      writeGeneration: number;
-    },
+    options: IPerpsDepositTokenListWriteOptions,
   ): Promise<IPerpsDepositTokenListData> {
     const cacheKey = this.buildPerpsDepositTokenListCacheKey(params);
     const now = Date.now();
@@ -633,10 +640,7 @@ class ServiceWebviewPerp extends ServiceBase {
 
   private async updatePerpsDepositTokenListAtom(
     { ownerKey, tokens, tokensByNetwork }: IPerpsDepositTokenListData,
-    options?: {
-      cacheKey: string;
-      writeGeneration: number;
-    },
+    options?: IPerpsDepositTokenListWriteOptions,
   ) {
     let selectedToken: IPerpsDepositToken | undefined;
     let isStale = false;
@@ -699,10 +703,7 @@ class ServiceWebviewPerp extends ServiceBase {
 
   private refreshPerpsDepositTokenListDataInBackground(
     params: IPerpsDepositTokenListCacheParams,
-    options: {
-      cacheKey: string;
-      writeGeneration: number;
-    },
+    options: IPerpsDepositTokenListWriteOptions,
   ) {
     void this.fetchPerpsDepositTokenListDataCached(params, options)
       .then((data) => this.updatePerpsDepositTokenListAtom(data, options))
@@ -720,6 +721,9 @@ class ServiceWebviewPerp extends ServiceBase {
     indexedAccountId,
     forceRefresh,
   }: IFetchPerpsDepositTokensFromWalletTokenListParams): Promise<IFetchPerpsDepositTokensFromWalletTokenListResult> {
+    // Captured before the first await so a runtime-cache clear that happens
+    // during owner normalization still invalidates this request's write-back.
+    const clearEpoch = this.perpsDepositTokenListClearEpoch;
     const { accountId: allNetworksAccountId, indexedAccountId: ownerIndexId } =
       await this.normalizePerpsDepositAllNetworksOwner({
         accountId,
@@ -747,7 +751,7 @@ class ServiceWebviewPerp extends ServiceBase {
     if (forceRefresh) {
       writeGeneration = this.bumpPerpsDepositTokenListWriteGeneration(cacheKey);
       this.perpsDepositTokenListCache.delete(cacheKey);
-      const writeOptions = { cacheKey, writeGeneration };
+      const writeOptions = { cacheKey, writeGeneration, clearEpoch };
       const data = await this.fetchPerpsDepositTokenListDataCached(
         cacheParams,
         writeOptions,
@@ -765,7 +769,7 @@ class ServiceWebviewPerp extends ServiceBase {
     const memoryCache =
       this.getPerpsDepositTokenListDataMemoryCache(cacheParams);
     if (memoryCache) {
-      const writeOptions = { cacheKey, writeGeneration };
+      const writeOptions = { cacheKey, writeGeneration, clearEpoch };
       const data = await memoryCache;
       const updateResult = await this.updatePerpsDepositTokenListAtom(
         data,
@@ -794,10 +798,12 @@ class ServiceWebviewPerp extends ServiceBase {
       const updateResult = await this.updatePerpsDepositTokenListAtom(data, {
         cacheKey,
         writeGeneration,
+        clearEpoch,
       });
       this.refreshPerpsDepositTokenListDataInBackground(cacheParams, {
         cacheKey,
         writeGeneration,
+        clearEpoch,
       });
       return {
         ...data,
@@ -805,7 +811,7 @@ class ServiceWebviewPerp extends ServiceBase {
       };
     }
 
-    const writeOptions = { cacheKey, writeGeneration };
+    const writeOptions = { cacheKey, writeGeneration, clearEpoch };
     const data = await this.fetchPerpsDepositTokenListDataCached(
       cacheParams,
       writeOptions,

--- a/packages/kit/src/views/Setting/pages/ClearAppCache/index.tsx
+++ b/packages/kit/src/views/Setting/pages/ClearAppCache/index.tsx
@@ -33,6 +33,7 @@ export default function ClearAppCache() {
       customRpc: false,
       customNetworkFee: false,
       serverNetworks: false,
+      perpsData: false,
     } as IClearCacheOnAppState,
   });
   const { copyText } = useClipboard();
@@ -157,6 +158,13 @@ export default function ClearAppCache() {
                   />
                 </Form.Field>
               )}
+              <Form.Field name="perpsData">
+                <Checkbox
+                  label={intl.formatMessage({
+                    id: ETranslations.global_perp,
+                  })}
+                />
+              </Form.Field>
             </YStack>
           </Form>
         </Stack>

--- a/packages/shared/types/setting.ts
+++ b/packages/shared/types/setting.ts
@@ -13,6 +13,7 @@ export type IClearCacheOnAppState = {
   serverNetworks: boolean;
   connectSites: boolean;
   signatureRecord: boolean;
+  perpsData?: boolean;
 };
 
 export enum EReasonForNeedPassword {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59997](https://onekeyhq.atlassian.net/browse/OK-59997)

----------

<!-- github-pr-monitor:jira-links:end -->


## Problem

A desktop 6.5.0 user's Perps chart and token selector were permanently stuck on "Loading tokens..." (OK-59997). Chromium stores large IndexedDB values as external blob files; once the blob backing `simple_db_v5:perp` is corrupted (crash/power loss mid-write), every read rejects with `UnknownError: Failed to read large IndexedDB value`. Because `setRawData(builder)` reads the old record before writing, all writes fail too, so the record can never be repaired — `getTradingUniverse()` and chart symbol resolution both depend on it.

## Fix

- `SimpleDbEntityBase.getRawData`: catch `UnknownError`/`NotReadableError` storage read errors, remove the unreadable record, and return null so builder-based writes rebuild it from empty. Other errors still propagate. Self-heals on the first read after startup.
- Settings → Clear cache: new "Perps" item (reuses existing `global.perp` translation) calling `perp.clearRawData()` as a support escape hatch.

Recovery cost for already-affected users only: Hyperliquid terms re-accept and local toggles like skipOrderConfirm reset. Funds, positions, open orders, and agent approval are unaffected.

## Test

- New unit tests pin the contract: self-heal returns null and drops the record; builder write rebuilds after a read failure; non-whitelisted errors propagate without deleting.
- A/B: same assertions fail on the unfixed code (both read and write reject) and pass with the fix. `yarn jest packages/kit-bg/src/dbs/simple` 34/34.
- Deterministic manual repro for QA (corrupt the profile's IndexedDB blob files) is documented in OK-59997.

[OK-59997]: https://onekeyhq.atlassian.net/browse/OK-59997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ