### PR TITLE
fix: avoid legacy inputs in prepared firmware V3

### DIFF
--- a/packages/kit-bg/src/services/ServiceFirmwareUpdate/FirmwareArtifactSelfTest.test.ts
+++ b/packages/kit-bg/src/services/ServiceFirmwareUpdate/FirmwareArtifactSelfTest.test.ts
@@ -252,17 +252,17 @@ describe('FirmwareArtifactSelfTest', () => {
     expect(sdkFixture.firmwareUpdateV3).toHaveBeenCalledTimes(1);
     expect(sdkFixture.firmwareUpdateV3).toHaveBeenCalledWith(
       '__firmware_sdk_self_test_no_device__',
-      expect.objectContaining({
+      {
         preparedPlan: expect.any(Object),
         platform: expect.any(String),
-        firmwareVersion: [4, 21, 0],
+        firmwareType: expect.any(String),
         hostBindingGeneration: 7,
         artifacts: expect.objectContaining({
           firmware: expect.objectContaining({
             size: fixture.artifact.expectedSize,
           }),
         }),
-      }),
+      },
     );
     expect(progress).toHaveBeenLastCalledWith(
       expect.objectContaining({ phase: 'sweeping', progress: 99 }),

--- a/packages/kit-bg/src/services/ServiceFirmwareUpdate/FirmwarePreparedExecution.ts
+++ b/packages/kit-bg/src/services/ServiceFirmwareUpdate/FirmwarePreparedExecution.ts
@@ -338,9 +338,6 @@ export const executePreparedFirmwareUpdateV3 = ({
         params: {
           preparedPlan: FirmwareUpdatePreparedPlan;
           platform: string;
-          bleVersion: number[] | undefined;
-          firmwareVersion: number[] | undefined;
-          bootloaderVersion: number[] | undefined;
           firmwareType: EFirmwareType | undefined;
           hostBindingGeneration: number;
           artifacts: {
@@ -357,9 +354,6 @@ export const executePreparedFirmwareUpdateV3 = ({
     )(connectId, {
       preparedPlan: preparedArtifacts.preparedPlan,
       platform,
-      bleVersion,
-      firmwareVersion,
-      bootloaderVersion,
       firmwareType,
       hostBindingGeneration: requireHostBindingGeneration(
         preparedArtifacts,

--- a/packages/kit-bg/src/services/ServiceFirmwareUpdate/FirmwareUpdateCapabilities.test.ts
+++ b/packages/kit-bg/src/services/ServiceFirmwareUpdate/FirmwareUpdateCapabilities.test.ts
@@ -266,7 +266,7 @@ describe('prepared firmware execution', () => {
     );
   });
 
-  test('logs and passes matching prepared firmware and resource inputs to V3', async () => {
+  test('passes prepared V3 inputs without legacy version fields', async () => {
     const firmwareUpdateV3 = jest.fn();
     const sdk = { firmwareUpdateV3 } as unknown as CoreApi;
     const firmware = {
@@ -303,22 +303,21 @@ describe('prepared firmware execution', () => {
       ...executionArtifacts,
       platform: 'native',
       firmwareType: EFirmwareType.Universal,
-      bleVersion: undefined,
+      bleVersion: [2, 3, 7],
       firmwareVersion: [4, 21, 0],
-      bootloaderVersion: undefined,
+      bootloaderVersion: [2, 8, 4],
     });
 
-    expect(firmwareUpdateV3).toHaveBeenCalledWith(
-      'device',
-      expect.objectContaining({
-        preparedPlan: prepared.preparedPlan,
-        hostBindingGeneration: 105,
-        artifacts: {
-          firmware,
-          resourceEntries: [{ entryName: 'resource.bin', artifact: resource }],
-        },
-      }),
-    );
+    expect(firmwareUpdateV3).toHaveBeenCalledWith('device', {
+      preparedPlan: prepared.preparedPlan,
+      platform: 'native',
+      firmwareType: EFirmwareType.Universal,
+      hostBindingGeneration: 105,
+      artifacts: {
+        firmware,
+        resourceEntries: [{ entryName: 'resource.bin', artifact: resource }],
+      },
+    });
     expect(localLog).toHaveBeenCalledWith(
       expect.stringContaining(
         '"stage":"sdk-handoff","executor":"v3","sdkMethod":"firmwareUpdateV3"',
@@ -356,7 +355,7 @@ describe('prepared firmware execution', () => {
     });
   });
 
-  test('logs and passes Desktop Bridge binaries without claiming a resource input', async () => {
+  test('passes Desktop Bridge binaries with legacy version fields', async () => {
     const firmwareUpdateV3 = jest.fn();
     const sdk = { firmwareUpdateV3 } as unknown as CoreApi;
     const firmware = new ArrayBuffer(4);
@@ -385,12 +384,14 @@ describe('prepared firmware execution', () => {
       bootloaderVersion: undefined,
     });
 
-    expect(firmwareUpdateV3).toHaveBeenCalledWith(
-      'device',
-      expect.objectContaining({
-        firmwareBinary: firmware,
-      }),
-    );
+    expect(firmwareUpdateV3).toHaveBeenCalledWith('device', {
+      platform: 'desktop',
+      bleVersion: undefined,
+      firmwareVersion: [4, 21, 0],
+      bootloaderVersion: undefined,
+      firmwareType: EFirmwareType.Universal,
+      firmwareBinary: firmware,
+    });
     expect(firmwareUpdateV3.mock.calls[0][1]).not.toHaveProperty(
       'resourceBinary',
     );


### PR DESCRIPTION
## Summary
- Stop sending legacy V3 version fields when executing an App-prepared firmware plan.
- Preserve the existing SDK-managed and Desktop Bridge legacy V3 inputs.
- Add exact call-shape coverage for both prepared and legacy V3 execution.

## Intent & Context
A OneKey Pro TF firmware update on Desktop failed at SDK handoff with error 405: `Prepared firmware plans cannot be combined with legacy firmware inputs`. The host had already downloaded and verified the firmware artifacts, so the failure occurred before Bootloader transition or device writes.

This change is intentionally limited to V3. V4 behavior and the Web/Extension SDK-managed download model are outside this PR.

## Root Cause
The App-prepared V3 branch passed `preparedPlan` and prepared artifacts together with the legacy `bleVersion`, `firmwareVersion`, and `bootloaderVersion` fields. The current hardware SDK treats the presence of any of those top-level fields as legacy input and rejects mixed prepared/legacy calls before execution.

## Design Decisions
- Use `preparedArtifacts` as the execution-mode boundary: prepared calls contain only the plan, host binding, artifact handles, platform, and firmware type.
- Keep all version fields and binaries in the existing non-prepared branch so Web/Extension SDK-managed flows and Desktop Bridge remain compatible.
- Leave V4 untouched, per the scoped V3-only fix.
- Assert the full SDK argument object in tests so reintroducing legacy fields into the prepared path fails explicitly.

## Changes Detail
- `FirmwarePreparedExecution.ts`: remove legacy version fields from the prepared V3 SDK payload while preserving them in the legacy branch.
- `FirmwareUpdateCapabilities.test.ts`: verify prepared V3 omits legacy fields and Desktop Bridge still receives them.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop and Mobile prepared V3 flows
- **Risk Areas**: V3 SDK handoff parameter shape. Web, Extension, Desktop Bridge legacy execution, and V4 are unchanged.

## Test plan
- [x] `yarn jest packages/kit-bg/src/services/ServiceFirmwareUpdate/FirmwareUpdateCapabilities.test.ts --runInBand --watch=false`
- [x] `yarn agent:check --profile commit`
- [ ] Retry the OneKey Pro TF firmware update on Desktop WebUSB and confirm the flow passes SDK handoff without error 405.
