### PR TITLE
fix: handle onboarding device scan errors

### DIFF
--- a/packages/kit/src/hooks/onboardingDeviceScanErrorUtils.test.ts
+++ b/packages/kit/src/hooks/onboardingDeviceScanErrorUtils.test.ts
@@ -1,0 +1,19 @@
+import { BluetoothUnavailableWhileUsbConnectedError } from '@onekeyhq/shared/src/errors';
+
+import { shouldContinueOnboardingDeviceScan } from './onboardingDeviceScanErrorUtils';
+
+describe('shouldContinueOnboardingDeviceScan', () => {
+  it('keeps polling while USB temporarily blocks desktop Bluetooth', () => {
+    expect(
+      shouldContinueOnboardingDeviceScan(
+        new BluetoothUnavailableWhileUsbConnectedError(),
+      ),
+    ).toBe(true);
+  });
+
+  it('stops polling for terminal scan failures', () => {
+    expect(
+      shouldContinueOnboardingDeviceScan(new Error('transport unavailable')),
+    ).toBe(false);
+  });
+});

--- a/packages/kit/src/hooks/onboardingDeviceScanErrorUtils.ts
+++ b/packages/kit/src/hooks/onboardingDeviceScanErrorUtils.ts
@@ -1,0 +1,5 @@
+import { BluetoothUnavailableWhileUsbConnectedError } from '@onekeyhq/shared/src/errors';
+
+export function shouldContinueOnboardingDeviceScan(error: Error) {
+  return error instanceof BluetoothUnavailableWhileUsbConnectedError;
+}

--- a/packages/kit/src/hooks/useOnboardingDeviceScanErrorHandler.test.tsx
+++ b/packages/kit/src/hooks/useOnboardingDeviceScanErrorHandler.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/first */
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+jest.mock('react-native', () => ({
+  Linking: { openURL: jest.fn() },
+}));
+
+jest.mock('@onekeyhq/components', () => ({
+  Dialog: { confirm: jest.fn() },
+  Stack: jest.fn(),
+  Toast: { error: jest.fn() },
+}));
+
+jest.mock('@onekeyhq/kit/src/components/HyperlinkText', () => ({
+  HyperlinkText: jest.fn(),
+}));
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: { isSupportWebUSB: false },
+}));
+
+import { act, renderHook } from '@testing-library/react-native';
+
+import { Toast } from '@onekeyhq/components';
+import { BluetoothUnavailableWhileUsbConnectedError } from '@onekeyhq/shared/src/errors';
+
+import { useOnboardingDeviceScanErrorHandler } from './useOnboardingDeviceScanErrorHandler';
+
+const toastError = jest.mocked(Toast.error);
+
+describe('useOnboardingDeviceScanErrorHandler', () => {
+  beforeEach(() => {
+    toastError.mockClear();
+  });
+
+  it('keeps scanning and de-duplicates the USB conflict toast', () => {
+    const stopScan = jest.fn();
+    const { result } = renderHook(() =>
+      useOnboardingDeviceScanErrorHandler({ stopScan }),
+    );
+    const error = new BluetoothUnavailableWhileUsbConnectedError();
+
+    act(() => {
+      result.current.handleScanError(error);
+      result.current.handleScanError(error);
+    });
+
+    expect(stopScan).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows the USB conflict toast again after a successful scan', () => {
+    const { result } = renderHook(() =>
+      useOnboardingDeviceScanErrorHandler({ stopScan: jest.fn() }),
+    );
+    const error = new BluetoothUnavailableWhileUsbConnectedError();
+
+    act(() => {
+      result.current.handleScanError(error);
+      result.current.resetScanError();
+      result.current.handleScanError(error);
+    });
+
+    expect(toastError).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops scanning after a terminal error', () => {
+    const stopScan = jest.fn();
+    const { result } = renderHook(() =>
+      useOnboardingDeviceScanErrorHandler({ stopScan }),
+    );
+
+    act(() => {
+      result.current.handleScanError(new Error('transport unavailable'));
+    });
+
+    expect(stopScan).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kit/src/hooks/useOnboardingDeviceScanErrorHandler.tsx
+++ b/packages/kit/src/hooks/useOnboardingDeviceScanErrorHandler.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useRef } from 'react';
+
+import { useIntl } from 'react-intl';
+import { Linking } from 'react-native';
+
+import { Dialog, Stack, Toast } from '@onekeyhq/components';
+import { HyperlinkText } from '@onekeyhq/kit/src/components/HyperlinkText';
+import { HARDWARE_BRIDGE_DOWNLOAD_URL } from '@onekeyhq/shared/src/config/appConfig';
+import {
+  BleLocationServiceError,
+  BridgeTimeoutError,
+  BridgeTimeoutErrorForDesktop,
+  ConnectTimeoutError,
+  DeviceMethodCallTimeout,
+  InitIframeLoadFail,
+  InitIframeTimeout,
+  NeedBluetoothPermissions,
+  NeedBluetoothTurnedOn,
+  NeedOneKeyBridge,
+} from '@onekeyhq/shared/src/errors';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+import { shouldContinueOnboardingDeviceScan } from './onboardingDeviceScanErrorUtils';
+
+import type { IntlShape } from 'react-intl';
+
+function BridgeNotInstalledDialogContent(_props: { error: NeedOneKeyBridge }) {
+  return (
+    <Stack>
+      <HyperlinkText
+        size="$bodyLg"
+        mt="$1.5"
+        translationId={
+          platformEnv.isSupportWebUSB
+            ? ETranslations.device_communication_failed
+            : ETranslations.onboarding_install_onekey_bridge_help_text
+        }
+      />
+    </Stack>
+  );
+}
+
+function isBluetoothSetupError(error: Error) {
+  return (
+    error instanceof NeedBluetoothTurnedOn ||
+    error instanceof NeedBluetoothPermissions ||
+    error instanceof BleLocationServiceError
+  );
+}
+
+function isConnectionTimeoutError(error: Error) {
+  return (
+    error instanceof BridgeTimeoutError ||
+    error instanceof BridgeTimeoutErrorForDesktop ||
+    error instanceof ConnectTimeoutError ||
+    error instanceof DeviceMethodCallTimeout
+  );
+}
+
+function showStoppedScanError(error: Error, intl: IntlShape) {
+  if (isBluetoothSetupError(error)) {
+    return;
+  }
+  if (
+    error instanceof InitIframeLoadFail ||
+    error instanceof InitIframeTimeout
+  ) {
+    Toast.error({
+      title: intl.formatMessage({ id: ETranslations.global_network_error }),
+      message: error.message || 'DeviceScanError',
+    });
+    return;
+  }
+  if (isConnectionTimeoutError(error)) {
+    Toast.error({
+      title: intl.formatMessage({ id: ETranslations.global_connection_failed }),
+      message: error.message || 'DeviceScanError',
+    });
+    return;
+  }
+  if (error instanceof NeedOneKeyBridge) {
+    Dialog.confirm({
+      icon: 'OnekeyBrand',
+      title: intl.formatMessage({
+        id: ETranslations.onboarding_install_onekey_bridge,
+      }),
+      renderContent: <BridgeNotInstalledDialogContent error={error} />,
+      onConfirmText: intl.formatMessage({
+        id: ETranslations.global_download_and_install,
+      }),
+      onConfirm: () => Linking.openURL(HARDWARE_BRIDGE_DOWNLOAD_URL),
+    });
+    return;
+  }
+  Toast.error({ title: error.message || 'DeviceScanError' });
+}
+
+export function useOnboardingDeviceScanErrorHandler({
+  stopScan,
+}: {
+  stopScan: () => void;
+}) {
+  const intl = useIntl();
+  const hasShownBluetoothUnavailableToastRef = useRef(false);
+
+  const resetScanError = useCallback(() => {
+    hasShownBluetoothUnavailableToastRef.current = false;
+  }, []);
+
+  const handleScanError = useCallback(
+    (error: Error) => {
+      if (shouldContinueOnboardingDeviceScan(error)) {
+        if (!hasShownBluetoothUnavailableToastRef.current) {
+          hasShownBluetoothUnavailableToastRef.current = true;
+          Toast.error({
+            title: intl.formatMessage({
+              id: ETranslations.troubleshooting_desktop_bluetooth_usb_priority,
+            }),
+          });
+        }
+        return;
+      }
+
+      resetScanError();
+      stopScan();
+      showStoppedScanError(error, intl);
+    },
+    [intl, resetScanError, stopScan],
+  );
+
+  return { handleScanError, resetScanError };
+}

--- a/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/ConnectYourDevice.tsx
+++ b/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/ConnectYourDevice.tsx
@@ -38,38 +38,22 @@ import {
   OpenBleSettingsDialog,
   RequireBlePermissionDialog,
 } from '@onekeyhq/kit/src/components/Hardware/HardwareDialog';
-import { HyperlinkText } from '@onekeyhq/kit/src/components/HyperlinkText';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { MultipleClickStack } from '@onekeyhq/kit/src/components/MultipleClickStack';
 import type { ITutorialsListItem } from '@onekeyhq/kit/src/components/TutorialsList';
 import { TutorialsList } from '@onekeyhq/kit/src/components/TutorialsList';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useHelpLink } from '@onekeyhq/kit/src/hooks/useHelpLink';
+import { useOnboardingDeviceScanErrorHandler } from '@onekeyhq/kit/src/hooks/useOnboardingDeviceScanErrorHandler';
 import { usePromptWebDeviceAccess } from '@onekeyhq/kit/src/hooks/usePromptWebDeviceAccess';
 import { useRouteIsFocused as useIsFocused } from '@onekeyhq/kit/src/hooks/useRouteIsFocused';
 import { useUserWalletProfile } from '@onekeyhq/kit/src/hooks/useUserWalletProfile';
 import { useAccountSelectorActions } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector/actions';
 import type { IDBCreateHwWalletParamsBase } from '@onekeyhq/kit-bg/src/dbs/local/types';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import {
-  HARDWARE_BRIDGE_DOWNLOAD_URL,
-  ONEKEY_BUY_HARDWARE_URL,
-} from '@onekeyhq/shared/src/config/appConfig';
+import { ONEKEY_BUY_HARDWARE_URL } from '@onekeyhq/shared/src/config/appConfig';
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
-import {
-  BleLocationServiceError,
-  BluetoothUnavailableWhileUsbConnectedError,
-  BridgeTimeoutError,
-  BridgeTimeoutErrorForDesktop,
-  ConnectTimeoutError,
-  DeviceMethodCallTimeout,
-  InitIframeLoadFail,
-  InitIframeTimeout,
-  NeedBluetoothPermissions,
-  NeedBluetoothTurnedOn,
-  NeedOneKeyBridge,
-  OneKeyHardwareError,
-} from '@onekeyhq/shared/src/errors/errors/hardwareErrors';
+import { OneKeyHardwareError } from '@onekeyhq/shared/src/errors/errors/hardwareErrors';
 import errorToastUtils from '@onekeyhq/shared/src/errors/utils/errorToastUtils';
 import bleManagerInstance from '@onekeyhq/shared/src/hardware/bleManager';
 import { checkBLEPermissions } from '@onekeyhq/shared/src/hardware/blePermissions';
@@ -352,23 +336,6 @@ function ConnectByQrCodeComingSoon() {
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function BridgeNotInstalledDialogContent(_props: { error: NeedOneKeyBridge }) {
-  return (
-    <Stack>
-      <HyperlinkText
-        size="$bodyLg"
-        mt="$1.5"
-        translationId={
-          platformEnv.isSupportWebUSB
-            ? ETranslations.device_communication_failed
-            : ETranslations.onboarding_install_onekey_bridge_help_text
-        }
-      />
-    </Stack>
-  );
-}
-
 enum EConnectionStatus {
   init = 'init',
   searching = 'searching',
@@ -386,7 +353,6 @@ function useDeviceConnection({
   tabValue,
   onDeviceConnect,
 }: IDeviceConnectionProps) {
-  const intl = useIntl();
   const [connectStatus, setConnectStatus] = useState(EConnectionStatus.init);
   const [searchedDevices, setSearchedDevices] = useState<SearchDevice[]>([]);
   const [isCheckingDeviceLoading, setIsChecking] = useState(false);
@@ -440,78 +406,18 @@ function useDeviceConnection({
     currentTabValueRef.current = tabValue;
   }, [tabValue, deviceScanner]);
 
-  const handleScanError = useCallback(
-    (error: Error) => {
-      isSearchingRef.current = false;
-      setConnectStatus(EConnectionStatus.init);
-      deviceScanner.stopScan();
+  const stopScan = useCallback(() => {
+    isSearchingRef.current = false;
+    deviceScanner.stopScan();
+  }, [deviceScanner]);
 
-      if (
-        error instanceof NeedBluetoothTurnedOn ||
-        error instanceof NeedBluetoothPermissions ||
-        error instanceof BleLocationServiceError
-      ) {
-        return;
-      }
+  const stopScanAfterError = useCallback(() => {
+    setConnectStatus(EConnectionStatus.init);
+    stopScan();
+  }, [stopScan]);
 
-      if (error instanceof BluetoothUnavailableWhileUsbConnectedError) {
-        Toast.error({
-          title: intl.formatMessage({
-            id: ETranslations.troubleshooting_desktop_bluetooth_usb_priority,
-          }),
-        });
-        return;
-      }
-
-      if (
-        error instanceof InitIframeLoadFail ||
-        error instanceof InitIframeTimeout
-      ) {
-        Toast.error({
-          title: intl.formatMessage({
-            id: ETranslations.global_network_error,
-          }),
-          message: error.message || 'DeviceScanError',
-        });
-        return;
-      }
-
-      if (
-        error instanceof BridgeTimeoutError ||
-        error instanceof BridgeTimeoutErrorForDesktop ||
-        error instanceof ConnectTimeoutError ||
-        error instanceof DeviceMethodCallTimeout
-      ) {
-        Toast.error({
-          title: intl.formatMessage({
-            id: ETranslations.global_connection_failed,
-          }),
-          message: error.message || 'DeviceScanError',
-        });
-        return;
-      }
-
-      if (error instanceof NeedOneKeyBridge) {
-        Dialog.confirm({
-          icon: 'OnekeyBrand',
-          title: intl.formatMessage({
-            id: ETranslations.onboarding_install_onekey_bridge,
-          }),
-          renderContent: <BridgeNotInstalledDialogContent error={error} />,
-          onConfirmText: intl.formatMessage({
-            id: ETranslations.global_download_and_install,
-          }),
-          onConfirm: () => Linking.openURL(HARDWARE_BRIDGE_DOWNLOAD_URL),
-        });
-        return;
-      }
-
-      Toast.error({
-        title: error.message || 'DeviceScanError',
-      });
-    },
-    [deviceScanner, intl],
-  );
+  const { handleScanError, resetScanError } =
+    useOnboardingDeviceScanErrorHandler({ stopScan: stopScanAfterError });
 
   const scanDevice = useCallback(async () => {
     if (isSearchingRef.current) {
@@ -532,6 +438,7 @@ function useDeviceConnection({
         if (!response.success) {
           return;
         }
+        resetScanError();
 
         const sortedDevices = response.payload.toSorted((a, b) =>
           natsort({ insensitive: true })(
@@ -560,12 +467,7 @@ function useDeviceConnection({
       undefined, // vendor
       { onError: handleScanError },
     );
-  }, [deviceScanner, handleScanError, tabValue]);
-
-  const stopScan = useCallback(() => {
-    isSearchingRef.current = false;
-    deviceScanner.stopScan();
-  }, [deviceScanner]);
+  }, [deviceScanner, handleScanError, resetScanError, tabValue]);
 
   const ensureStopScan = useCallback(async () => {
     // Force stop scanning and wait for any ongoing search to complete
@@ -1044,7 +946,13 @@ function ConnectByBluetooth({
     onDeviceConnect: handleBluetoothDeviceConnect,
   });
 
-  const { devicesData, scanDevice, stopScan } = deviceConnection;
+  const { connectStatus, setConnectStatus, devicesData, scanDevice, stopScan } =
+    deviceConnection;
+
+  const listingDevice = useCallback(async () => {
+    setConnectStatus(EConnectionStatus.listing);
+    await scanDevice();
+  }, [scanDevice, setConnectStatus]);
 
   const handleOpenPrivacySettings = useCallback(() => {
     void globalThis.desktopApiProxy.bluetooth.openPrivacySettings();
@@ -1086,11 +994,11 @@ function ConnectByBluetooth({
   // Start scanning when bluetooth is enabled and focused
   useEffect(() => {
     if (isFocused && bluetoothStatus === 'enabled') {
-      void scanDevice();
+      void listingDevice();
     } else if (!isFocused) {
       stopScan();
     }
-  }, [bluetoothStatus, isFocused, scanDevice, stopScan]);
+  }, [bluetoothStatus, isFocused, listingDevice, stopScan]);
 
   // Cleanup on unmount
   useEffect(
@@ -1167,15 +1075,29 @@ function ConnectByBluetooth({
     <>
       <AnimationView
         lottieSource={BluetoothSignalSpreading}
-        connectStatus={EConnectionStatus.listing}
+        connectStatus={connectStatus}
         connectionType="bluetooth"
       />
-      <DeviceListView
-        description={intl.formatMessage({
-          id: ETranslations.bluetooth_keep_near,
-        })}
-        devicesData={devicesData}
-      />
+      {connectStatus === EConnectionStatus.init ? (
+        <YStack pt="$8">
+          <Button
+            testID="onboarding-bluetooth-retry-btn"
+            mx="auto"
+            size="large"
+            variant="primary"
+            onPress={listingDevice}
+          >
+            {intl.formatMessage({ id: ETranslations.global_retry })}
+          </Button>
+        </YStack>
+      ) : (
+        <DeviceListView
+          description={intl.formatMessage({
+            id: ETranslations.bluetooth_keep_near,
+          })}
+          devicesData={devicesData}
+        />
+      )}
     </>
   );
 }

--- a/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/ConnectYourDevice.tsx
+++ b/packages/kit/src/views/Onboarding/pages/ConnectHardwareWallet/ConnectYourDevice.tsx
@@ -58,6 +58,7 @@ import {
 import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import {
   BleLocationServiceError,
+  BluetoothUnavailableWhileUsbConnectedError,
   BridgeTimeoutError,
   BridgeTimeoutErrorForDesktop,
   ConnectTimeoutError,
@@ -69,7 +70,6 @@ import {
   NeedOneKeyBridge,
   OneKeyHardwareError,
 } from '@onekeyhq/shared/src/errors/errors/hardwareErrors';
-import { convertDeviceError } from '@onekeyhq/shared/src/errors/utils/deviceErrorUtils';
 import errorToastUtils from '@onekeyhq/shared/src/errors/utils/errorToastUtils';
 import bleManagerInstance from '@onekeyhq/shared/src/hardware/bleManager';
 import { checkBLEPermissions } from '@onekeyhq/shared/src/hardware/blePermissions';
@@ -440,6 +440,79 @@ function useDeviceConnection({
     currentTabValueRef.current = tabValue;
   }, [tabValue, deviceScanner]);
 
+  const handleScanError = useCallback(
+    (error: Error) => {
+      isSearchingRef.current = false;
+      setConnectStatus(EConnectionStatus.init);
+      deviceScanner.stopScan();
+
+      if (
+        error instanceof NeedBluetoothTurnedOn ||
+        error instanceof NeedBluetoothPermissions ||
+        error instanceof BleLocationServiceError
+      ) {
+        return;
+      }
+
+      if (error instanceof BluetoothUnavailableWhileUsbConnectedError) {
+        Toast.error({
+          title: intl.formatMessage({
+            id: ETranslations.troubleshooting_desktop_bluetooth_usb_priority,
+          }),
+        });
+        return;
+      }
+
+      if (
+        error instanceof InitIframeLoadFail ||
+        error instanceof InitIframeTimeout
+      ) {
+        Toast.error({
+          title: intl.formatMessage({
+            id: ETranslations.global_network_error,
+          }),
+          message: error.message || 'DeviceScanError',
+        });
+        return;
+      }
+
+      if (
+        error instanceof BridgeTimeoutError ||
+        error instanceof BridgeTimeoutErrorForDesktop ||
+        error instanceof ConnectTimeoutError ||
+        error instanceof DeviceMethodCallTimeout
+      ) {
+        Toast.error({
+          title: intl.formatMessage({
+            id: ETranslations.global_connection_failed,
+          }),
+          message: error.message || 'DeviceScanError',
+        });
+        return;
+      }
+
+      if (error instanceof NeedOneKeyBridge) {
+        Dialog.confirm({
+          icon: 'OnekeyBrand',
+          title: intl.formatMessage({
+            id: ETranslations.onboarding_install_onekey_bridge,
+          }),
+          renderContent: <BridgeNotInstalledDialogContent error={error} />,
+          onConfirmText: intl.formatMessage({
+            id: ETranslations.global_download_and_install,
+          }),
+          onConfirm: () => Linking.openURL(HARDWARE_BRIDGE_DOWNLOAD_URL),
+        });
+        return;
+      }
+
+      Toast.error({
+        title: error.message || 'DeviceScanError',
+      });
+    },
+    [deviceScanner, intl],
+  );
+
   const scanDevice = useCallback(async () => {
     if (isSearchingRef.current) {
       return;
@@ -457,73 +530,6 @@ function useDeviceConnection({
     deviceScanner.startDeviceScan(
       (response) => {
         if (!response.success) {
-          const error = convertDeviceError(response.payload);
-          if (platformEnv.isNative) {
-            if (
-              !(error instanceof NeedBluetoothTurnedOn) &&
-              !(error instanceof NeedBluetoothPermissions) &&
-              !(error instanceof BleLocationServiceError)
-            ) {
-              Toast.error({
-                title: error.message || 'DeviceScanError',
-              });
-            } else {
-              deviceScanner.stopScan();
-            }
-          } else if (
-            error instanceof InitIframeLoadFail ||
-            error instanceof InitIframeTimeout
-          ) {
-            Toast.error({
-              title: intl.formatMessage({
-                id: ETranslations.global_network_error,
-              }),
-              message: error.message || 'DeviceScanError',
-            });
-            deviceScanner.stopScan();
-          }
-
-          if (
-            error instanceof BridgeTimeoutError ||
-            error instanceof BridgeTimeoutErrorForDesktop
-          ) {
-            Toast.error({
-              title: intl.formatMessage({
-                id: ETranslations.global_connection_failed,
-              }),
-              message: error.message || 'DeviceScanError',
-            });
-            deviceScanner.stopScan();
-          }
-
-          if (
-            error instanceof ConnectTimeoutError ||
-            error instanceof DeviceMethodCallTimeout
-          ) {
-            Toast.error({
-              title: intl.formatMessage({
-                id: ETranslations.global_connection_failed,
-              }),
-              message: error.message || 'DeviceScanError',
-            });
-            deviceScanner.stopScan();
-          }
-
-          if (error instanceof NeedOneKeyBridge) {
-            Dialog.confirm({
-              icon: 'OnekeyBrand',
-              title: intl.formatMessage({
-                id: ETranslations.onboarding_install_onekey_bridge,
-              }),
-              renderContent: <BridgeNotInstalledDialogContent error={error} />,
-              onConfirmText: intl.formatMessage({
-                id: ETranslations.global_download_and_install,
-              }),
-              onConfirm: () => Linking.openURL(HARDWARE_BRIDGE_DOWNLOAD_URL),
-            });
-
-            deviceScanner.stopScan();
-          }
           return;
         }
 
@@ -551,8 +557,10 @@ function useDeviceConnection({
       undefined, // pollIntervalRate
       undefined, // pollInterval
       undefined, // maxTryCount
+      undefined, // vendor
+      { onError: handleScanError },
     );
-  }, [deviceScanner, intl, tabValue]);
+  }, [deviceScanner, handleScanError, tabValue]);
 
   const stopScan = useCallback(() => {
     isSearchingRef.current = false;

--- a/packages/kit/src/views/Onboardingv2/pages/ConnectYourDevice.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ConnectYourDevice.tsx
@@ -20,7 +20,6 @@ import {
   Popover,
   SegmentControl,
   SizableText,
-  Stack,
   Toast,
   Video,
   XStack,
@@ -29,26 +28,11 @@ import {
   usePopoverContext,
   useThemeName,
 } from '@onekeyhq/components';
+import { useOnboardingDeviceScanErrorHandler } from '@onekeyhq/kit/src/hooks/useOnboardingDeviceScanErrorHandler';
 import { usePromptWebDeviceAccess } from '@onekeyhq/kit/src/hooks/usePromptWebDeviceAccess';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import {
-  HARDWARE_BRIDGE_DOWNLOAD_URL,
-  HARDWARE_TROUBLESHOOTING_URL,
-} from '@onekeyhq/shared/src/config/appConfig';
-import {
-  BleLocationServiceError,
-  BluetoothUnavailableWhileUsbConnectedError,
-  BridgeTimeoutError,
-  BridgeTimeoutErrorForDesktop,
-  ConnectTimeoutError,
-  DeviceMethodCallTimeout,
-  InitIframeLoadFail,
-  InitIframeTimeout,
-  NeedBluetoothPermissions,
-  NeedBluetoothTurnedOn,
-  NeedOneKeyBridge,
-  OneKeyHardwareError,
-} from '@onekeyhq/shared/src/errors';
+import { HARDWARE_TROUBLESHOOTING_URL } from '@onekeyhq/shared/src/config/appConfig';
+import { OneKeyHardwareError } from '@onekeyhq/shared/src/errors';
 import bleManagerInstance from '@onekeyhq/shared/src/hardware/bleManager';
 import { checkBLEPermissions } from '@onekeyhq/shared/src/hardware/blePermissions';
 import { BLE_ONBOARDING_ENSURE_CONNECTED_TIMEOUT_MS } from '@onekeyhq/shared/src/hardware/connectionTimeouts';
@@ -81,7 +65,6 @@ import {
   OpenBleSettingsDialog,
   RequireBlePermissionDialog,
 } from '../../../components/Hardware/HardwareDialog';
-import { HyperlinkText } from '../../../components/HyperlinkText';
 import { ListItem } from '../../../components/ListItem';
 import { WalletAvatar } from '../../../components/WalletAvatar';
 import useAppNavigation from '../../../hooks/useAppNavigation';
@@ -113,22 +96,6 @@ enum EConnectionStatus {
   listing = 'listing',
 }
 
-function BridgeNotInstalledDialogContent(_props: { error: NeedOneKeyBridge }) {
-  return (
-    <Stack>
-      <HyperlinkText
-        size="$bodyLg"
-        mt="$1.5"
-        translationId={
-          platformEnv.isSupportWebUSB
-            ? ETranslations.device_communication_failed
-            : ETranslations.onboarding_install_onekey_bridge_help_text
-        }
-      />
-    </Stack>
-  );
-}
-
 interface IDeviceConnectionProps {
   tabValue: EConnectDeviceChannel;
   deviceTypeItems: EDeviceType[];
@@ -149,7 +116,6 @@ function useDeviceConnection({
   onDeviceSelect?: (item: IConnectYourDeviceItem) => Promise<void> | void;
   vendor?: EHardwareVendor;
 }) {
-  const intl = useIntl();
   const [connectStatus, setConnectStatus] = useState(EConnectionStatus.init);
   const [searchedDevices, setSearchedDevices] = useState<SearchDevice[]>([]);
   const [isCheckingDeviceLoading, setIsChecking] = useState(false);
@@ -203,78 +169,18 @@ function useDeviceConnection({
     currentTabValueRef.current = tabValue;
   }, [tabValue, deviceScanner]);
 
-  const handleScanError = useCallback(
-    (error: Error) => {
-      isSearchingRef.current = false;
-      setConnectStatus(EConnectionStatus.init);
-      deviceScanner.stopScan();
+  const stopScan = useCallback(() => {
+    isSearchingRef.current = false;
+    deviceScanner.stopScan();
+  }, [deviceScanner]);
 
-      if (
-        error instanceof NeedBluetoothTurnedOn ||
-        error instanceof NeedBluetoothPermissions ||
-        error instanceof BleLocationServiceError
-      ) {
-        return;
-      }
+  const stopScanAfterError = useCallback(() => {
+    setConnectStatus(EConnectionStatus.init);
+    stopScan();
+  }, [stopScan]);
 
-      if (error instanceof BluetoothUnavailableWhileUsbConnectedError) {
-        Toast.error({
-          title: intl.formatMessage({
-            id: ETranslations.troubleshooting_desktop_bluetooth_usb_priority,
-          }),
-        });
-        return;
-      }
-
-      if (
-        error instanceof InitIframeLoadFail ||
-        error instanceof InitIframeTimeout
-      ) {
-        Toast.error({
-          title: intl.formatMessage({
-            id: ETranslations.global_network_error,
-          }),
-          message: error.message || 'DeviceScanError',
-        });
-        return;
-      }
-
-      if (
-        error instanceof BridgeTimeoutError ||
-        error instanceof BridgeTimeoutErrorForDesktop ||
-        error instanceof ConnectTimeoutError ||
-        error instanceof DeviceMethodCallTimeout
-      ) {
-        Toast.error({
-          title: intl.formatMessage({
-            id: ETranslations.global_connection_failed,
-          }),
-          message: error.message || 'DeviceScanError',
-        });
-        return;
-      }
-
-      if (error instanceof NeedOneKeyBridge) {
-        Dialog.confirm({
-          icon: 'OnekeyBrand',
-          title: intl.formatMessage({
-            id: ETranslations.onboarding_install_onekey_bridge,
-          }),
-          renderContent: <BridgeNotInstalledDialogContent error={error} />,
-          onConfirmText: intl.formatMessage({
-            id: ETranslations.global_download_and_install,
-          }),
-          onConfirm: () => Linking.openURL(HARDWARE_BRIDGE_DOWNLOAD_URL),
-        });
-        return;
-      }
-
-      Toast.error({
-        title: error.message || 'DeviceScanError',
-      });
-    },
-    [deviceScanner, intl],
-  );
+  const { handleScanError, resetScanError } =
+    useOnboardingDeviceScanErrorHandler({ stopScan: stopScanAfterError });
 
   const scanDevice = useCallback(async () => {
     if (isSearchingRef.current) {
@@ -300,6 +206,7 @@ function useDeviceConnection({
         if (!response.success) {
           return;
         }
+        resetScanError();
 
         const sortedDevices = response.payload.toSorted((a, b) =>
           natsort({ insensitive: true })(
@@ -328,12 +235,7 @@ function useDeviceConnection({
       vendor,
       { transportType, onError: handleScanError },
     );
-  }, [deviceScanner, handleScanError, tabValue, vendor]);
-
-  const stopScan = useCallback(() => {
-    isSearchingRef.current = false;
-    deviceScanner.stopScan();
-  }, [deviceScanner]);
+  }, [deviceScanner, handleScanError, resetScanError, tabValue, vendor]);
 
   const ensureStopScan = useCallback(async () => {
     // Force stop scanning and wait for any ongoing search to complete
@@ -910,8 +812,19 @@ function BluetoothConnectionIndicator({
     vendor,
   });
 
-  const { devicesData, scanDevice, stopScan, handleDeviceSelect } =
-    deviceConnection;
+  const {
+    connectStatus,
+    setConnectStatus,
+    devicesData,
+    scanDevice,
+    stopScan,
+    handleDeviceSelect,
+  } = deviceConnection;
+
+  const listingDevice = useCallback(async () => {
+    setConnectStatus(EConnectionStatus.listing);
+    await scanDevice();
+  }, [scanDevice, setConnectStatus]);
 
   const handleOpenPrivacySettings = useCallback(() => {
     void globalThis.desktopApiProxy.bluetooth.openPrivacySettings();
@@ -936,11 +849,11 @@ function BluetoothConnectionIndicator({
   // Start scanning when bluetooth is enabled and focused
   useEffect(() => {
     if (isFocused && bluetoothStatus === EBluetoothStatus.enabled) {
-      void scanDevice();
+      void listingDevice();
     } else if (!isFocused) {
       stopScan();
     }
-  }, [bluetoothStatus, isFocused, scanDevice, stopScan]);
+  }, [bluetoothStatus, isFocused, listingDevice, stopScan]);
 
   // Cleanup on unmount
   useEffect(
@@ -1013,7 +926,10 @@ function BluetoothConnectionIndicator({
   return (
     <>
       <ConnectionIndicator>
-        <BluetoothCard />
+        <BluetoothCard
+          onConnect={listingDevice}
+          connectStatus={connectStatus}
+        />
         <ConnectionIndicator.Footer>
           <YStack px="$5">
             <XStack alignItems="center" justifyContent="space-between">

--- a/packages/kit/src/views/Onboardingv2/pages/ConnectYourDevice.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/ConnectYourDevice.tsx
@@ -37,6 +37,7 @@ import {
 } from '@onekeyhq/shared/src/config/appConfig';
 import {
   BleLocationServiceError,
+  BluetoothUnavailableWhileUsbConnectedError,
   BridgeTimeoutError,
   BridgeTimeoutErrorForDesktop,
   ConnectTimeoutError,
@@ -48,7 +49,6 @@ import {
   NeedOneKeyBridge,
   OneKeyHardwareError,
 } from '@onekeyhq/shared/src/errors';
-import { convertDeviceError } from '@onekeyhq/shared/src/errors/utils/deviceErrorUtils';
 import bleManagerInstance from '@onekeyhq/shared/src/hardware/bleManager';
 import { checkBLEPermissions } from '@onekeyhq/shared/src/hardware/blePermissions';
 import { BLE_ONBOARDING_ENSURE_CONNECTED_TIMEOUT_MS } from '@onekeyhq/shared/src/hardware/connectionTimeouts';
@@ -203,6 +203,79 @@ function useDeviceConnection({
     currentTabValueRef.current = tabValue;
   }, [tabValue, deviceScanner]);
 
+  const handleScanError = useCallback(
+    (error: Error) => {
+      isSearchingRef.current = false;
+      setConnectStatus(EConnectionStatus.init);
+      deviceScanner.stopScan();
+
+      if (
+        error instanceof NeedBluetoothTurnedOn ||
+        error instanceof NeedBluetoothPermissions ||
+        error instanceof BleLocationServiceError
+      ) {
+        return;
+      }
+
+      if (error instanceof BluetoothUnavailableWhileUsbConnectedError) {
+        Toast.error({
+          title: intl.formatMessage({
+            id: ETranslations.troubleshooting_desktop_bluetooth_usb_priority,
+          }),
+        });
+        return;
+      }
+
+      if (
+        error instanceof InitIframeLoadFail ||
+        error instanceof InitIframeTimeout
+      ) {
+        Toast.error({
+          title: intl.formatMessage({
+            id: ETranslations.global_network_error,
+          }),
+          message: error.message || 'DeviceScanError',
+        });
+        return;
+      }
+
+      if (
+        error instanceof BridgeTimeoutError ||
+        error instanceof BridgeTimeoutErrorForDesktop ||
+        error instanceof ConnectTimeoutError ||
+        error instanceof DeviceMethodCallTimeout
+      ) {
+        Toast.error({
+          title: intl.formatMessage({
+            id: ETranslations.global_connection_failed,
+          }),
+          message: error.message || 'DeviceScanError',
+        });
+        return;
+      }
+
+      if (error instanceof NeedOneKeyBridge) {
+        Dialog.confirm({
+          icon: 'OnekeyBrand',
+          title: intl.formatMessage({
+            id: ETranslations.onboarding_install_onekey_bridge,
+          }),
+          renderContent: <BridgeNotInstalledDialogContent error={error} />,
+          onConfirmText: intl.formatMessage({
+            id: ETranslations.global_download_and_install,
+          }),
+          onConfirm: () => Linking.openURL(HARDWARE_BRIDGE_DOWNLOAD_URL),
+        });
+        return;
+      }
+
+      Toast.error({
+        title: error.message || 'DeviceScanError',
+      });
+    },
+    [deviceScanner, intl],
+  );
+
   const scanDevice = useCallback(async () => {
     if (isSearchingRef.current) {
       return;
@@ -225,73 +298,6 @@ function useDeviceConnection({
     deviceScanner.startDeviceScan(
       (response) => {
         if (!response.success) {
-          const error = convertDeviceError(response.payload);
-          if (platformEnv.isNative) {
-            if (
-              !(error instanceof NeedBluetoothTurnedOn) &&
-              !(error instanceof NeedBluetoothPermissions) &&
-              !(error instanceof BleLocationServiceError)
-            ) {
-              Toast.error({
-                title: error.message || 'DeviceScanError',
-              });
-            } else {
-              deviceScanner.stopScan();
-            }
-          } else if (
-            error instanceof InitIframeLoadFail ||
-            error instanceof InitIframeTimeout
-          ) {
-            Toast.error({
-              title: intl.formatMessage({
-                id: ETranslations.global_network_error,
-              }),
-              message: error.message || 'DeviceScanError',
-            });
-            deviceScanner.stopScan();
-          }
-
-          if (
-            error instanceof BridgeTimeoutError ||
-            error instanceof BridgeTimeoutErrorForDesktop
-          ) {
-            Toast.error({
-              title: intl.formatMessage({
-                id: ETranslations.global_connection_failed,
-              }),
-              message: error.message || 'DeviceScanError',
-            });
-            deviceScanner.stopScan();
-          }
-
-          if (
-            error instanceof ConnectTimeoutError ||
-            error instanceof DeviceMethodCallTimeout
-          ) {
-            Toast.error({
-              title: intl.formatMessage({
-                id: ETranslations.global_connection_failed,
-              }),
-              message: error.message || 'DeviceScanError',
-            });
-            deviceScanner.stopScan();
-          }
-
-          if (error instanceof NeedOneKeyBridge) {
-            Dialog.confirm({
-              icon: 'OnekeyBrand',
-              title: intl.formatMessage({
-                id: ETranslations.onboarding_install_onekey_bridge,
-              }),
-              renderContent: <BridgeNotInstalledDialogContent error={error} />,
-              onConfirmText: intl.formatMessage({
-                id: ETranslations.global_download_and_install,
-              }),
-              onConfirm: () => Linking.openURL(HARDWARE_BRIDGE_DOWNLOAD_URL),
-            });
-
-            deviceScanner.stopScan();
-          }
           return;
         }
 
@@ -320,9 +326,9 @@ function useDeviceConnection({
       undefined, // pollInterval
       undefined, // maxTryCount
       vendor,
-      { transportType },
+      { transportType, onError: handleScanError },
     );
-  }, [deviceScanner, intl, tabValue, vendor]);
+  }, [deviceScanner, handleScanError, tabValue, vendor]);
 
   const stopScan = useCallback(() => {
     isSearchingRef.current = false;

--- a/packages/shared/src/utils/DeviceScannerUtils.test.ts
+++ b/packages/shared/src/utils/DeviceScannerUtils.test.ts
@@ -1,8 +1,12 @@
+import { HardwareErrorCode } from '@onekeyfe/hd-shared';
+
 import { EHardwareVendor } from '@onekeyhq/shared/types/device';
+
+import { BluetoothUnavailableWhileUsbConnectedError } from '../errors/errors/hardwareErrors';
 
 import { DeviceScannerUtils } from './DeviceScannerUtils';
 
-import type { SearchDevice, Success } from '@onekeyfe/hd-core';
+import type { SearchDevice, Success, Unsuccessful } from '@onekeyfe/hd-core';
 
 function createDeferred<T>() {
   let resolve: (value: T) => void = () => undefined;
@@ -317,6 +321,59 @@ describe('DeviceScannerUtils', () => {
     search.resolve(successResponse('pro2'));
     await flushMicrotasks();
     scanner.stopScan();
+  });
+
+  it('routes unsuccessful responses through the normalized error handler', async () => {
+    const search = createDeferred<Unsuccessful>();
+    const searchDevices = jest.fn(() => search.promise);
+    const scanner = createScanner(searchDevices);
+    const callback = jest.fn();
+    const onError = jest.fn();
+
+    scanner.startDeviceScan(callback, jest.fn(), 1, 60_000, 1, undefined, {
+      onError,
+    });
+    await flushMicrotasks();
+
+    search.resolve({
+      success: false,
+      payload: {
+        code: HardwareErrorCode.RuntimeError,
+        error: 'Failure_ProcessError,link disabled',
+      },
+    });
+    await flushMicrotasks();
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(
+      BluetoothUnavailableWhileUsbConnectedError,
+    );
+    scanner.stopScan();
+  });
+
+  it('reports rejected searches and stops polling', async () => {
+    const searchError = new Error('search transport unavailable');
+    const searchDevices = jest.fn().mockRejectedValue(searchError);
+    const scanner = createScanner(searchDevices);
+    const onError = jest.fn();
+    const onSearchStateChange = jest.fn();
+
+    scanner.startDeviceScan(
+      jest.fn(),
+      onSearchStateChange,
+      1,
+      60_000,
+      1,
+      undefined,
+      { onError },
+    );
+    await flushMicrotasks();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(searchError);
+    expect(onSearchStateChange).toHaveBeenLastCalledWith('stop');
+    expect(Object.values(scanner.scanMap).every((value) => !value)).toBe(true);
   });
 
   it('waits for the active search and Noble scan cleanup before stopping', async () => {

--- a/packages/shared/src/utils/DeviceScannerUtils.ts
+++ b/packages/shared/src/utils/DeviceScannerUtils.ts
@@ -2,6 +2,8 @@ import { getVendorProfile } from '@onekeyhq/shared/src/hardware/vendorProfile';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { EHardwareVendor } from '@onekeyhq/shared/types/device';
 
+import { convertDeviceError } from '../errors/utils/deviceErrorUtils';
+
 import type { SearchDevice, Success, Unsuccessful } from '@onekeyfe/hd-core';
 import type { HardwareConnectProtocol } from '@onekeyfe/hd-shared';
 
@@ -21,6 +23,7 @@ type IDeviceScanOptions = {
   resetSession?: boolean;
   waitForAllTransports?: boolean;
   transportType?: 'usb' | 'ble';
+  onError?: (error: Error) => void;
 };
 type IDeviceScannerBackgroundApi = {
   serviceHardware: {
@@ -76,6 +79,39 @@ export class DeviceScannerUtils {
       transportType: options?.transportType,
     });
     let shouldResetSession = options?.resetSession ?? false;
+    const reportError = (error: unknown) => {
+      const normalizedError =
+        error instanceof Error
+          ? error
+          : Object.assign(
+              new Error(
+                typeof (error as { message?: unknown })?.message === 'string'
+                  ? (error as { message: string }).message
+                  : String(error),
+              ),
+              typeof error === 'object' && error !== null ? error : {},
+            );
+      try {
+        if (options?.onError) {
+          options.onError(normalizedError);
+        } else {
+          console.error('Device scan failed:', normalizedError);
+        }
+      } catch (handlerError) {
+        console.error('Device scan error handler failed:', handlerError);
+      }
+    };
+    const deliverSearchResponse = (searchResponse: ISearchResponse) => {
+      if (!searchResponse.success && options?.onError) {
+        reportError(
+          convertDeviceError(searchResponse.payload, {
+            vendor,
+          }),
+        );
+        return;
+      }
+      callback(searchResponse);
+    };
     const searchDevices = async () => {
       const currentSearchTask = this.currentSearchTask;
       if (currentSearchTask) {
@@ -86,7 +122,7 @@ export class DeviceScannerUtils {
           return sharedSearchResponse;
         }
         if (currentSearchIdentity === searchIdentity) {
-          callback(sharedSearchResponse);
+          deliverSearchResponse(sharedSearchResponse);
           this.tryCount += 1;
           return sharedSearchResponse;
         }
@@ -134,7 +170,7 @@ export class DeviceScannerUtils {
       if (!this.scanMap[scanIndex]) {
         return searchResponse;
       }
-      callback(searchResponse);
+      deliverSearchResponse(searchResponse);
 
       this.tryCount += 1;
       onSearchStateChange('stop');
@@ -154,7 +190,14 @@ export class DeviceScannerUtils {
         return;
       }
 
-      await searchDevices();
+      try {
+        await searchDevices();
+      } catch (error) {
+        reportError(error);
+        this.stopScan();
+        onSearchStateChange('stop');
+        return;
+      }
       const nextTime = isThirdPartyVendor
         ? Math.min(time * rate, MAX_POLL_INTERVAL)
         : time * rate;


### PR DESCRIPTION
## Summary

- add a compatible `onError` channel to `DeviceScannerUtils`
- normalize unsuccessful scan responses through `convertDeviceError`
- catch rejected scan promises and stop polling cleanly
- handle `link disabled` consistently in onboarding V1 and V2
- reset onboarding scan state so users can retry

## Root cause

Device discovery returns some hardware failures as `success: false` responses instead of rejected promises. Onboarding converted those payloads locally but did not handle `BluetoothUnavailableWhileUsbConnectedError` on desktop, so the error was effectively ignored and scanning could continue. Rejected scan promises were also not caught by the fire-and-forget polling task.

## User impact

When Bluetooth is unavailable because USB is connected, onboarding now shows the existing localized troubleshooting message, stops the current scan, and returns to a retryable state. Other scan failures also use a single delivery path without changing legacy Scanner callers that do not opt into `onError`.

## Validation

- `yarn jest packages/shared/src/utils/DeviceScannerUtils.test.ts packages/shared/src/errors/utils/deviceErrorUtils.bluetooth.test.ts --runInBand` — 11 tests passed
- type-aware Oxlint on the four changed files — 0 warnings, 0 errors
- `git diff --check` passed