### PR TITLE
fix: adjust native chart initial offset OK-58404

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.test.tsx
@@ -168,6 +168,30 @@ describe('TradingViewNativeContainer', () => {
     );
   });
 
+  it('forwards the initial right-offset configuration to the chart', () => {
+    const initialRightOffset = {
+      type: 'chartWidthPercentage' as const,
+      value: 5,
+    };
+
+    render(
+      <TradingViewNativeContainer
+        initialRightOffset={initialRightOffset}
+        source={{
+          kind: 'market',
+          networkId: 'evm--1',
+          tokenAddress: '0xabc',
+          symbol: 'TOKEN',
+          realtime: 'disabled',
+        }}
+      />,
+    );
+
+    expect(mockTradingViewNativeChart).toHaveBeenCalledWith(
+      expect.objectContaining({ initialRightOffset }),
+    );
+  });
+
   it('shows the volume section only when loaded candles contain volume', () => {
     mockDataState = { status: 'live' };
     mockPoints = [

--- a/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/TradingViewNativeContainer.tsx
@@ -47,6 +47,7 @@ export const TradingViewNativeContainer = memo(
     testID,
     source,
     enableNativeChartSettings,
+    initialRightOffset,
     nativeControlsLayoutMode,
     isNativeChartFullscreen,
     nativeChartFullscreenHeader,
@@ -396,6 +397,7 @@ export const TradingViewNativeContainer = memo(
             chartPictureVersion={chartPictureVersion}
             hasVolume={hasVolume}
             indicatorSeries={indicatorSeries}
+            initialRightOffset={initialRightOffset}
             isSwitchingInterval={isSwitchingInterval}
             onChartWidthChange={setChartWidth}
             onViewportRequestApplied={handleViewportRequestApplied}

--- a/packages/kit/src/components/TradingView/TradingViewNative/config.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/config.test.ts
@@ -1,0 +1,14 @@
+import { getTradingViewNativeDefaultInitialRightOffset } from './config';
+
+describe('TradingViewNative configuration', () => {
+  it('selects the initial right offset from the chart width', () => {
+    expect(getTradingViewNativeDefaultInitialRightOffset(767)).toEqual({
+      type: 'pointCount',
+      value: 2,
+    });
+    expect(getTradingViewNativeDefaultInitialRightOffset(768)).toEqual({
+      type: 'chartWidthPercentage',
+      value: 5,
+    });
+  });
+});

--- a/packages/kit/src/components/TradingView/TradingViewNative/config.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/config.ts
@@ -1,0 +1,24 @@
+import type { ITradingViewNativeInitialRightOffset } from './types';
+
+export const TRADING_VIEW_NATIVE_DEFAULT_INITIAL_RIGHT_OFFSET = {
+  largeScreen: {
+    type: 'chartWidthPercentage',
+    value: 5,
+  },
+  largeScreenMinWidth: 768,
+  smallScreen: {
+    type: 'pointCount',
+    value: 2,
+  },
+} as const;
+
+export function getTradingViewNativeDefaultInitialRightOffset(
+  width: number,
+): ITradingViewNativeInitialRightOffset {
+  'worklet';
+
+  return width >=
+    TRADING_VIEW_NATIVE_DEFAULT_INITIAL_RIGHT_OFFSET.largeScreenMinWidth
+    ? TRADING_VIEW_NATIVE_DEFAULT_INITIAL_RIGHT_OFFSET.largeScreen
+    : TRADING_VIEW_NATIVE_DEFAULT_INITIAL_RIGHT_OFFSET.smallScreen;
+}

--- a/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/native/TradingViewNativeChart.tsx
@@ -70,6 +70,7 @@ import {
 import type {
   ITradingViewNativeCandleLabels,
   ITradingViewNativeChartType,
+  ITradingViewNativeInitialRightOffset,
 } from '../types';
 
 const PAN_DRAG_RATIO = 1.1;
@@ -115,6 +116,7 @@ interface ITradingViewNativeChartProps {
   chartPictureVersion: number;
   hasVolume: boolean;
   indicatorSeries: ITradingViewNativeIndicatorSeries[];
+  initialRightOffset?: ITradingViewNativeInitialRightOffset;
   isSwitchingInterval: boolean;
   onChartWidthChange?: (width: number) => void;
   onViewportRequestApplied?: (requestId: number) => void;
@@ -132,16 +134,20 @@ function getInitialRuntime({
   chartType,
   hasVolume,
   indicatorSeries,
+  initialRightOffset,
   points,
 }: {
   candleIntervalSeconds: number;
   chartType: ITradingViewNativeChartType;
   hasVolume: boolean;
   indicatorSeries: ITradingViewNativeIndicatorSeries[];
+  initialRightOffset?: ITradingViewNativeInitialRightOffset;
   points: IMarketTokenKLineDataPoint[];
 }): ITradingViewNativeChartRuntime {
   return {
-    ...createTradingViewNativeChartRuntimeState(),
+    ...createTradingViewNativeChartRuntimeState({
+      initialRightOffset,
+    }),
     candleIntervalSeconds,
     chartType,
     hasVolume,
@@ -170,6 +176,7 @@ export const TradingViewNativeChart = memo(
     chartPictureVersion,
     hasVolume,
     indicatorSeries,
+    initialRightOffset,
     isSwitchingInterval,
     onChartWidthChange,
     onViewportRequestApplied,
@@ -190,6 +197,7 @@ export const TradingViewNativeChart = memo(
         chartType,
         hasVolume,
         indicatorSeries,
+        initialRightOffset,
         points,
       }),
     );
@@ -425,6 +433,13 @@ export const TradingViewNativeChart = memo(
         'worklet';
 
         const runtime = chartRuntime.value;
+        const runtimeAfterInitialMeasure = {
+          ...runtime,
+          ...reduceTradingViewNativeChartRuntime(runtime, {
+            type: 'initialWidthMeasured',
+            width: nextSize.width,
+          }),
+        };
         const nextPoints =
           replacementPoints ??
           (latestPoint ? [...runtime.points.slice(0, -1), latestPoint] : []);
@@ -446,12 +461,15 @@ export const TradingViewNativeChart = memo(
           nextSize.width,
           priceAxisWidth.value,
         );
-        const nextRuntimeState = reduceTradingViewNativeChartRuntime(runtime, {
-          appendedPointCount: dataUpdateMetadata.appendedPointCount,
-          chartWidth: nextChartWidth,
-          pointCount: nextPoints.length,
-          type: 'dataUpdated',
-        });
+        const nextRuntimeState = reduceTradingViewNativeChartRuntime(
+          runtimeAfterInitialMeasure,
+          {
+            appendedPointCount: dataUpdateMetadata.appendedPointCount,
+            chartWidth: nextChartWidth,
+            pointCount: nextPoints.length,
+            type: 'dataUpdated',
+          },
+        );
         const nextOffset = nextRuntimeState.viewport.offset;
         const offsetDelta = nextOffset - runtime.viewport.offset;
         decayOffset.value = nextOffset;
@@ -706,6 +724,7 @@ export const TradingViewNativeChart = memo(
               runtime.size.width,
               priceAxisWidth.value,
             ),
+            initialRightOffset: runtime.viewport.initialRightOffset,
             pointCount: runtime.points.length,
             zoomScale: runtime.viewport.zoomScale,
           });

--- a/packages/kit/src/components/TradingView/TradingViewNative/types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/types.ts
@@ -54,10 +54,21 @@ export interface ITradingViewNativeIntervalChangeData {
   toInterval: ITradingViewNativeChartInterval;
 }
 
+export type ITradingViewNativeInitialRightOffset =
+  | {
+      type: 'chartWidthPercentage';
+      value: number;
+    }
+  | {
+      type: 'pointCount';
+      value: number;
+    };
+
 export interface ITradingViewNativeProps {
   testID?: string;
   source: ITradingViewNativeSource;
   enableNativeChartSettings?: boolean;
+  initialRightOffset?: ITradingViewNativeInitialRightOffset;
   nativeControlsLayoutMode?: 'mobile' | 'desktop';
   isNativeChartFullscreen?: boolean;
   nativeChartFullscreenHeader?: ReactNode;

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartRuntime.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartRuntime.test.ts
@@ -14,6 +14,84 @@ describe('TradingViewNative chart runtime', () => {
     });
   });
 
+  it('accepts a chart-width percentage as initial configuration', () => {
+    expect(
+      createTradingViewNativeChartRuntimeState({
+        initialRightOffset: {
+          type: 'chartWidthPercentage',
+          value: 5,
+        },
+      }).viewport,
+    ).toEqual({
+      initialRightOffset: {
+        type: 'chartWidthPercentage',
+        value: 5,
+      },
+      initialRightOffsetResolved: true,
+      offset: 0,
+      zoomScale: 1,
+    });
+  });
+
+  it('resolves the default from the first measured chart width only', () => {
+    const state = createTradingViewNativeChartRuntimeState();
+    const measuredState = reduceTradingViewNativeChartRuntime(state, {
+      type: 'initialWidthMeasured',
+      width: 500,
+    });
+    const resizedState = reduceTradingViewNativeChartRuntime(measuredState, {
+      type: 'initialWidthMeasured',
+      width: 1000,
+    });
+
+    expect(measuredState.viewport).toEqual({
+      initialRightOffset: { type: 'pointCount', value: 2 },
+      initialRightOffsetResolved: true,
+      offset: 0,
+      zoomScale: 1,
+    });
+    expect(resizedState).toBe(measuredState);
+  });
+
+  it('does not reset a user-adjusted viewport to the initial right offset', () => {
+    const state = createTradingViewNativeChartRuntimeState({
+      initialRightOffset: { type: 'pointCount', value: 2 },
+    });
+    const pannedState = reduceTradingViewNativeChartRuntime(state, {
+      chartWidth: 100,
+      hideCrosshair: false,
+      offset: 10,
+      pointCount: 40,
+      type: 'panMoved',
+      zoomScale: 1,
+    });
+    const updatedState = reduceTradingViewNativeChartRuntime(pannedState, {
+      appendedPointCount: 1,
+      chartWidth: 100,
+      pointCount: 41,
+      type: 'dataUpdated',
+    });
+
+    expect(state.viewport).toEqual({
+      initialRightOffset: { type: 'pointCount', value: 2 },
+      initialRightOffsetResolved: true,
+      offset: 0,
+      zoomScale: 1,
+    });
+    expect(pannedState.viewport).toEqual({
+      initialRightOffset: { type: 'pointCount', value: 2 },
+      initialRightOffsetResolved: true,
+      offset: 10,
+      zoomScale: 1,
+    });
+    expect(updatedState.viewport).toEqual({
+      initialRightOffset: { type: 'pointCount', value: 2 },
+      initialRightOffsetResolved: true,
+      offset: 16,
+      zoomScale: 1,
+    });
+  });
+
   it('preserves a historical viewport when candles are appended', () => {
     const state = {
       crosshair: { visible: false, x: 0, y: 0 },

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartRuntime.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartRuntime.ts
@@ -3,6 +3,7 @@ import {
   TRADING_VIEW_NATIVE_DEFAULT_ZOOM_SCALE,
   TRADING_VIEW_NATIVE_TIME_AXIS_HEIGHT,
 } from '../chartConstants';
+import { getTradingViewNativeDefaultInitialRightOffset } from '../config';
 
 import {
   type ITradingViewNativeViewportPointRange,
@@ -15,7 +16,11 @@ import {
   getTradingViewNativeZoomedViewport,
 } from './chartViewport';
 
+import type { ITradingViewNativeInitialRightOffset } from '../types';
+
 export interface ITradingViewNativeChartRuntimeViewport {
+  initialRightOffset?: ITradingViewNativeInitialRightOffset;
+  initialRightOffsetResolved?: true;
   offset: number;
   zoomScale: number;
 }
@@ -32,6 +37,10 @@ export interface ITradingViewNativeChartRuntimeState {
 }
 
 export type ITradingViewNativeChartRuntimeEvent =
+  | {
+      type: 'initialWidthMeasured';
+      width: number;
+    }
   | {
       appendedPointCount: number;
       chartWidth: number;
@@ -81,12 +90,36 @@ function getHiddenCrosshair(
   return crosshair.visible ? { ...crosshair, visible: false } : crosshair;
 }
 
-export function createTradingViewNativeChartRuntimeState(): ITradingViewNativeChartRuntimeState {
+export function createTradingViewNativeChartRuntimeState({
+  initialRightOffset,
+}: {
+  initialRightOffset?: ITradingViewNativeInitialRightOffset;
+} = {}): ITradingViewNativeChartRuntimeState {
   'worklet';
 
+  let normalizedInitialRightOffset:
+    | ITradingViewNativeInitialRightOffset
+    | undefined;
+  if (initialRightOffset?.type === 'chartWidthPercentage') {
+    const value = Number.isFinite(initialRightOffset.value)
+      ? Math.min(Math.max(initialRightOffset.value, 0), 100)
+      : 0;
+    normalizedInitialRightOffset =
+      value > 0 ? { type: initialRightOffset.type, value } : undefined;
+  } else if (initialRightOffset?.type === 'pointCount') {
+    const value = Number.isFinite(initialRightOffset.value)
+      ? Math.max(Math.floor(initialRightOffset.value), 0)
+      : 0;
+    normalizedInitialRightOffset =
+      value > 0 ? { type: initialRightOffset.type, value } : undefined;
+  }
   return {
     crosshair: { visible: false, x: 0, y: 0 },
     viewport: {
+      ...(normalizedInitialRightOffset
+        ? { initialRightOffset: normalizedInitialRightOffset }
+        : {}),
+      ...(initialRightOffset ? { initialRightOffsetResolved: true } : {}),
       offset: 0,
       zoomScale: TRADING_VIEW_NATIVE_DEFAULT_ZOOM_SCALE,
     },
@@ -100,6 +133,25 @@ export function reduceTradingViewNativeChartRuntime(
   'worklet';
 
   switch (event.type) {
+    case 'initialWidthMeasured': {
+      if (
+        state.viewport.initialRightOffsetResolved ||
+        !Number.isFinite(event.width) ||
+        event.width <= 0
+      ) {
+        return state;
+      }
+      return {
+        crosshair: state.crosshair,
+        viewport: {
+          ...state.viewport,
+          initialRightOffset: getTradingViewNativeDefaultInitialRightOffset(
+            event.width,
+          ),
+          initialRightOffsetResolved: true,
+        },
+      };
+    }
     case 'dataUpdated':
       return {
         crosshair: state.crosshair,
@@ -109,6 +161,7 @@ export function reduceTradingViewNativeChartRuntime(
             appendedPointCount: event.appendedPointCount,
             chartWidth: event.chartWidth,
             currentOffset: state.viewport.offset,
+            initialRightOffset: state.viewport.initialRightOffset,
             pointCount: event.pointCount,
             zoomScale: state.viewport.zoomScale,
           }),
@@ -121,8 +174,10 @@ export function reduceTradingViewNativeChartRuntime(
           ? getHiddenCrosshair(state.crosshair)
           : state.crosshair,
         viewport: {
+          ...state.viewport,
           offset: clampTradingViewNativePanOffset({
             chartWidth: event.chartWidth,
+            initialRightOffset: state.viewport.initialRightOffset,
             offset: event.offset,
             pointCount: event.pointCount,
             zoomScale,
@@ -136,6 +191,7 @@ export function reduceTradingViewNativeChartRuntime(
         ...event.pointRange,
         chartWidth: event.chartWidth,
         currentZoomScale: state.viewport.zoomScale,
+        initialRightOffset: state.viewport.initialRightOffset,
         pointCount: event.pointCount,
       });
       if (!viewport) {
@@ -146,7 +202,7 @@ export function reduceTradingViewNativeChartRuntime(
       }
       return {
         crosshair: getHiddenCrosshair(state.crosshair),
-        viewport,
+        viewport: { ...state.viewport, ...viewport },
       };
     }
     case 'zoomed': {
@@ -155,14 +211,18 @@ export function reduceTradingViewNativeChartRuntime(
         crosshair: event.hideCrosshair
           ? getHiddenCrosshair(state.crosshair)
           : state.crosshair,
-        viewport: getTradingViewNativeZoomedViewport({
-          anchorX: event.anchorX,
-          chartWidth: event.chartWidth,
-          currentOffset: baseViewport.offset,
-          currentZoomScale: baseViewport.zoomScale,
-          nextZoomScale: event.nextZoomScale,
-          pointCount: event.pointCount,
-        }),
+        viewport: {
+          ...state.viewport,
+          ...getTradingViewNativeZoomedViewport({
+            anchorX: event.anchorX,
+            chartWidth: event.chartWidth,
+            currentOffset: baseViewport.offset,
+            currentZoomScale: baseViewport.zoomScale,
+            initialRightOffset: state.viewport.initialRightOffset,
+            nextZoomScale: event.nextZoomScale,
+            pointCount: event.pointCount,
+          }),
+        },
       };
     }
     case 'crosshairMoved': {
@@ -171,6 +231,7 @@ export function reduceTradingViewNativeChartRuntime(
         0,
       );
       const pointIndex = getTradingViewNativePointIndexAtX({
+        initialRightOffset: state.viewport.initialRightOffset,
         offset: state.viewport.offset,
         pointCount: event.pointCount,
         priceAxisX,
@@ -213,6 +274,7 @@ export function getTradingViewNativeChartRuntimeVisiblePointRange({
 
   return getTradingViewNativeVisiblePointRange({
     chartWidth,
+    initialRightOffset: state.viewport.initialRightOffset,
     offset: state.viewport.offset,
     pointCount,
     zoomScale: state.viewport.zoomScale,

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartScene.ts
@@ -466,12 +466,14 @@ export function buildTradingViewNativeChartScene({
   const zoomScale = clampTradingViewNativeZoomScale(viewport.zoomScale);
   const offset = clampTradingViewNativePanOffset({
     chartWidth,
+    initialRightOffset: viewport.initialRightOffset,
     offset: viewport.offset,
     pointCount: points.length,
     zoomScale,
   });
   const visiblePointRange = getTradingViewNativeVisiblePointRange({
     chartWidth,
+    initialRightOffset: viewport.initialRightOffset,
     offset,
     pointCount: points.length,
     zoomScale,
@@ -495,7 +497,16 @@ export function buildTradingViewNativeChartScene({
     });
   }
 
-  const normalizedViewport = { offset, zoomScale };
+  const normalizedViewport = {
+    ...(viewport.initialRightOffset
+      ? { initialRightOffset: viewport.initialRightOffset }
+      : {}),
+    ...(viewport.initialRightOffsetResolved
+      ? { initialRightOffsetResolved: true as const }
+      : {}),
+    offset,
+    zoomScale,
+  };
   const emptyScene = {
     commands,
     crosshairPointIndex: null,
@@ -546,6 +557,7 @@ export function buildTradingViewNativeChartScene({
   const getPointX = (index: number) =>
     getTradingViewNativeCandleX({
       index,
+      initialRightOffset: viewport.initialRightOffset,
       offset,
       pointCount: points.length,
       priceAxisX,
@@ -809,6 +821,7 @@ export function buildTradingViewNativeChartScene({
 
   const crosshairPointIndex = crosshair.visible
     ? getTradingViewNativePointIndexAtX({
+        initialRightOffset: viewport.initialRightOffset,
         offset,
         pointCount: points.length,
         priceAxisX,

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartViewport.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartViewport.test.ts
@@ -99,6 +99,104 @@ describe('TradingViewNative chart viewport', () => {
     ).toBe(maxOffset);
   });
 
+  it('reserves two candle steps to the right of the latest candle', () => {
+    const initialRightOffset = { type: 'pointCount', value: 2 } as const;
+
+    expect(
+      getTradingViewNativeMaxPanOffset({
+        chartWidth: 100,
+        initialRightOffset,
+        pointCount: 20,
+        zoomScale: 1,
+      }),
+    ).toBe(32);
+    expect(
+      getTradingViewNativeCandleX({
+        index: 19,
+        initialRightOffset,
+        offset: 0,
+        pointCount: 20,
+        priceAxisX: 100,
+        zoomScale: 2,
+      }),
+    ).toBe(69);
+    expect(
+      getTradingViewNativeCandleX({
+        index: 19,
+        initialRightOffset,
+        offset: 12,
+        pointCount: 20,
+        priceAxisX: 100,
+        zoomScale: 1,
+      }),
+    ).toBe(96.5);
+    expect(
+      getTradingViewNativePointIndexAtX({
+        initialRightOffset,
+        offset: 0,
+        pointCount: 20,
+        priceAxisX: 100,
+        x: 69,
+        zoomScale: 2,
+      }),
+    ).toBe(19);
+    expect(
+      getTradingViewNativeVisiblePointRange({
+        chartWidth: 45,
+        initialRightOffset,
+        offset: 0,
+        pointCount: 5,
+        zoomScale: 2,
+      }),
+    ).toEqual({ endIndex: 5, startIndex: 3 });
+  });
+
+  it('supports a chart-width percentage for the initial right offset', () => {
+    const initialRightOffset = {
+      type: 'chartWidthPercentage',
+      value: 5,
+    } as const;
+
+    expect(
+      getTradingViewNativeMaxPanOffset({
+        chartWidth: 100,
+        initialRightOffset,
+        pointCount: 20,
+        zoomScale: 1,
+      }),
+    ).toBe(25);
+    expect(
+      getTradingViewNativeCandleX({
+        index: 19,
+        initialRightOffset,
+        offset: 0,
+        pointCount: 20,
+        priceAxisX: 100,
+        zoomScale: 1,
+      }),
+    ).toBe(91.5);
+    expect(
+      getTradingViewNativeCandleX({
+        index: 19,
+        initialRightOffset,
+        offset: 5,
+        pointCount: 20,
+        priceAxisX: 100,
+        zoomScale: 1,
+      }),
+    ).toBe(96.5);
+    expect(
+      getTradingViewNativePointIndexAtX({
+        initialRightOffset,
+        offset: 0,
+        pointCount: 20,
+        priceAxisX: 100,
+        x: 91.5,
+        zoomScale: 1,
+      }),
+    ).toBe(19);
+  });
+
   it('keeps zoom within the supported range', () => {
     expect(clampTradingViewNativeZoomScale(0.1)).toBe(
       TRADING_VIEW_NATIVE_MIN_ZOOM_SCALE,

--- a/packages/kit/src/components/TradingView/TradingViewNative/utils/chartViewport.ts
+++ b/packages/kit/src/components/TradingView/TradingViewNative/utils/chartViewport.ts
@@ -3,11 +3,15 @@ import type { IMarketTokenKLineDataPoint } from '@onekeyhq/shared/types/marketV2
 import {
   TRADING_VIEW_NATIVE_CANDLE_BODY_WIDTH,
   TRADING_VIEW_NATIVE_CANDLE_GAP,
+  TRADING_VIEW_NATIVE_CHART_HORIZONTAL_PADDING,
   TRADING_VIEW_NATIVE_MAX_ZOOM_SCALE,
   TRADING_VIEW_NATIVE_MIN_ZOOM_SCALE,
 } from '../chartConstants';
 
-import type { ITradingViewNativeChartType } from '../types';
+import type {
+  ITradingViewNativeChartType,
+  ITradingViewNativeInitialRightOffset,
+} from '../types';
 
 export interface ITradingViewNativeVisiblePointRange {
   endIndex: number;
@@ -55,6 +59,35 @@ export interface ITradingViewNativeViewportPointRange {
   firstIndex: number;
   fitRange: boolean;
   lastIndex: number;
+}
+
+function getTradingViewNativeRightOffsetWidth({
+  candleGap,
+  chartWidth,
+  initialRightOffset,
+  zoomScale,
+}: {
+  candleGap: number;
+  chartWidth: number;
+  initialRightOffset: ITradingViewNativeInitialRightOffset | undefined;
+  zoomScale: number;
+}) {
+  'worklet';
+
+  if (initialRightOffset?.type === 'chartWidthPercentage') {
+    const percentage = Number.isFinite(initialRightOffset.value)
+      ? Math.min(Math.max(initialRightOffset.value, 0), 100)
+      : 0;
+    return (Math.max(chartWidth, 0) * percentage) / 100;
+  }
+  const pointCount =
+    initialRightOffset?.type === 'pointCount' &&
+    Number.isFinite(initialRightOffset.value)
+      ? Math.max(Math.floor(initialRightOffset.value), 0)
+      : 0;
+  return (
+    pointCount * (TRADING_VIEW_NATIVE_CANDLE_BODY_WIDTH + candleGap) * zoomScale
+  );
 }
 
 function findFirstPointIndexAtOrAfter(
@@ -183,11 +216,13 @@ export function getTradingViewNativeRelativePinchScale({
 export function getTradingViewNativeMaxPanOffset({
   candleGap,
   chartWidth,
+  initialRightOffset,
   pointCount,
   zoomScale,
 }: {
   candleGap?: number;
   chartWidth: number;
+  initialRightOffset?: ITradingViewNativeInitialRightOffset;
   pointCount: number;
   zoomScale: number;
 }) {
@@ -203,23 +238,31 @@ export function getTradingViewNativeMaxPanOffset({
   const dataWidth =
     (TRADING_VIEW_NATIVE_CANDLE_BODY_WIDTH + (pointCount - 1) * candleStep) *
     clampedZoomScale;
+  const rightOffsetWidth = getTradingViewNativeRightOffsetWidth({
+    candleGap: resolvedCandleGap,
+    chartWidth,
+    initialRightOffset,
+    zoomScale: clampedZoomScale,
+  });
   const visibleWidth = Math.max(
     chartWidth - resolvedCandleGap * clampedZoomScale,
     0,
   );
 
-  return Math.max(dataWidth - visibleWidth, 0);
+  return Math.max(dataWidth + rightOffsetWidth - visibleWidth, 0);
 }
 
 export function clampTradingViewNativePanOffset({
   candleGap,
   chartWidth,
+  initialRightOffset,
   offset,
   pointCount,
   zoomScale,
 }: {
   candleGap?: number;
   chartWidth: number;
+  initialRightOffset?: ITradingViewNativeInitialRightOffset;
   offset: number;
   pointCount: number;
   zoomScale: number;
@@ -232,6 +275,7 @@ export function clampTradingViewNativePanOffset({
     getTradingViewNativeMaxPanOffset({
       candleGap: resolvedCandleGap,
       chartWidth,
+      initialRightOffset,
       pointCount,
       zoomScale,
     }),
@@ -244,12 +288,14 @@ export function getTradingViewNativeViewportForPointRange({
   currentZoomScale,
   firstIndex,
   fitRange,
+  initialRightOffset,
   lastIndex,
   pointCount,
 }: ITradingViewNativeViewportPointRange & {
   candleGap?: number;
   chartWidth: number;
   currentZoomScale: number;
+  initialRightOffset?: ITradingViewNativeInitialRightOffset;
   pointCount: number;
 }) {
   'worklet';
@@ -280,18 +326,26 @@ export function getTradingViewNativeViewportForPointRange({
   }
 
   const distanceFromNewest = pointCount - targetIndex - 1;
+  const rightOffsetWidth = getTradingViewNativeRightOffsetWidth({
+    candleGap: resolvedCandleGap,
+    chartWidth,
+    initialRightOffset,
+    zoomScale,
+  });
   const targetOffset =
     chartWidth / 2 -
     chartWidth +
     (resolvedCandleGap +
       TRADING_VIEW_NATIVE_CANDLE_BODY_WIDTH / 2 +
       distanceFromNewest * candleStep) *
-      zoomScale;
+      zoomScale +
+    rightOffsetWidth;
 
   return {
     offset: clampTradingViewNativePanOffset({
       candleGap: resolvedCandleGap,
       chartWidth,
+      initialRightOffset,
       offset: targetOffset,
       pointCount,
       zoomScale,
@@ -345,6 +399,7 @@ export function getTradingViewNativePanOffsetAfterDataUpdate({
   candleGap,
   chartWidth,
   currentOffset,
+  initialRightOffset,
   pointCount,
   zoomScale,
 }: {
@@ -352,6 +407,7 @@ export function getTradingViewNativePanOffsetAfterDataUpdate({
   candleGap?: number;
   chartWidth: number;
   currentOffset: number;
+  initialRightOffset?: ITradingViewNativeInitialRightOffset;
   pointCount: number;
   zoomScale: number;
 }) {
@@ -361,6 +417,7 @@ export function getTradingViewNativePanOffsetAfterDataUpdate({
   const clampedOffset = clampTradingViewNativePanOffset({
     candleGap: resolvedCandleGap,
     chartWidth,
+    initialRightOffset,
     offset: currentOffset,
     pointCount,
     zoomScale,
@@ -378,6 +435,7 @@ export function getTradingViewNativePanOffsetAfterDataUpdate({
   return clampTradingViewNativePanOffset({
     candleGap: resolvedCandleGap,
     chartWidth,
+    initialRightOffset,
     offset: clampedOffset + safeAppendedPointCount * candleStep,
     pointCount,
     zoomScale,
@@ -421,12 +479,14 @@ export function getTradingViewNativePanStartOffsetAfterViewportPreservation({
 export function getTradingViewNativeVisiblePointRange({
   candleGap,
   chartWidth,
+  initialRightOffset,
   offset,
   pointCount,
   zoomScale,
 }: {
   candleGap?: number;
   chartWidth: number;
+  initialRightOffset?: ITradingViewNativeInitialRightOffset;
   offset: number;
   pointCount: number;
   zoomScale: number;
@@ -442,6 +502,7 @@ export function getTradingViewNativeVisiblePointRange({
   const clampedOffset = clampTradingViewNativePanOffset({
     candleGap: resolvedCandleGap,
     chartWidth,
+    initialRightOffset,
     offset,
     pointCount,
     zoomScale: clampedZoomScale,
@@ -451,11 +512,18 @@ export function getTradingViewNativeVisiblePointRange({
     clampedZoomScale;
   const halfCandleBodyWidth =
     (TRADING_VIEW_NATIVE_CANDLE_BODY_WIDTH * clampedZoomScale) / 2;
+  const rightOffsetWidth = getTradingViewNativeRightOffsetWidth({
+    candleGap: resolvedCandleGap,
+    chartWidth,
+    initialRightOffset,
+    zoomScale: clampedZoomScale,
+  });
   const lastCandleCenter =
     chartWidth -
     (resolvedCandleGap + TRADING_VIEW_NATIVE_CANDLE_BODY_WIDTH / 2) *
       clampedZoomScale +
-    clampedOffset;
+    clampedOffset -
+    rightOffsetWidth;
   const newestVisibleDistance = Math.max(
     Math.ceil(
       (lastCandleCenter - chartWidth - halfCandleBodyWidth) / candleStep,
@@ -480,6 +548,7 @@ export function getTradingViewNativeVisiblePointRange({
 export function getTradingViewNativeCandleX({
   candleGap,
   index,
+  initialRightOffset,
   offset,
   pointCount,
   priceAxisX,
@@ -487,6 +556,7 @@ export function getTradingViewNativeCandleX({
 }: {
   candleGap?: number;
   index: number;
+  initialRightOffset?: ITradingViewNativeInitialRightOffset;
   offset: number;
   pointCount: number;
   priceAxisX: number;
@@ -503,6 +573,15 @@ export function getTradingViewNativeCandleX({
   const clampedIndex = Math.min(Math.max(Math.floor(index), 0), pointCount - 1);
   const distanceFromNewest = pointCount - clampedIndex - 1;
   const candleStep = TRADING_VIEW_NATIVE_CANDLE_BODY_WIDTH + resolvedCandleGap;
+  const rightOffsetWidth = getTradingViewNativeRightOffsetWidth({
+    candleGap: resolvedCandleGap,
+    chartWidth: Math.max(
+      priceAxisX - TRADING_VIEW_NATIVE_CHART_HORIZONTAL_PADDING,
+      0,
+    ),
+    initialRightOffset,
+    zoomScale: clampedZoomScale,
+  });
 
   return (
     priceAxisX -
@@ -510,12 +589,14 @@ export function getTradingViewNativeCandleX({
       TRADING_VIEW_NATIVE_CANDLE_BODY_WIDTH / 2 +
       distanceFromNewest * candleStep) *
       clampedZoomScale +
-    offset
+    offset -
+    rightOffsetWidth
   );
 }
 
 export function getTradingViewNativePointIndexAtX({
   candleGap,
+  initialRightOffset,
   offset,
   pointCount,
   priceAxisX,
@@ -523,6 +604,7 @@ export function getTradingViewNativePointIndexAtX({
   zoomScale,
 }: {
   candleGap?: number;
+  initialRightOffset?: ITradingViewNativeInitialRightOffset;
   offset: number;
   pointCount: number;
   priceAxisX: number;
@@ -546,11 +628,21 @@ export function getTradingViewNativePointIndexAtX({
   const candleStep =
     (TRADING_VIEW_NATIVE_CANDLE_BODY_WIDTH + resolvedCandleGap) *
     clampedZoomScale;
+  const rightOffsetWidth = getTradingViewNativeRightOffsetWidth({
+    candleGap: resolvedCandleGap,
+    chartWidth: Math.max(
+      priceAxisX - TRADING_VIEW_NATIVE_CHART_HORIZONTAL_PADDING,
+      0,
+    ),
+    initialRightOffset,
+    zoomScale: clampedZoomScale,
+  });
   const lastCandleCenter =
     priceAxisX -
     (resolvedCandleGap + TRADING_VIEW_NATIVE_CANDLE_BODY_WIDTH / 2) *
       clampedZoomScale +
-    offset;
+    offset -
+    rightOffsetWidth;
   const distanceFromNewest = Math.round((lastCandleCenter - x) / candleStep);
   const index = pointCount - distanceFromNewest - 1;
 
@@ -648,6 +740,7 @@ export function getTradingViewNativeZoomedViewport({
   chartWidth,
   currentOffset,
   currentZoomScale,
+  initialRightOffset,
   nextZoomScale,
   pointCount,
 }: {
@@ -656,6 +749,7 @@ export function getTradingViewNativeZoomedViewport({
   chartWidth: number;
   currentOffset: number;
   currentZoomScale: number;
+  initialRightOffset?: ITradingViewNativeInitialRightOffset;
   nextZoomScale: number;
   pointCount: number;
 }) {
@@ -668,12 +762,27 @@ export function getTradingViewNativeZoomedViewport({
   const offset = clampTradingViewNativePanOffset({
     candleGap: resolvedCandleGap,
     chartWidth,
+    initialRightOffset,
     offset: currentOffset,
     pointCount,
     zoomScale: currentScale,
   });
-  const currentContentRight = chartWidth - resolvedCandleGap * currentScale;
-  const nextContentRight = chartWidth - resolvedCandleGap * zoomScale;
+  const currentRightOffsetWidth = getTradingViewNativeRightOffsetWidth({
+    candleGap: resolvedCandleGap,
+    chartWidth,
+    initialRightOffset,
+    zoomScale: currentScale,
+  });
+  const nextRightOffsetWidth = getTradingViewNativeRightOffsetWidth({
+    candleGap: resolvedCandleGap,
+    chartWidth,
+    initialRightOffset,
+    zoomScale,
+  });
+  const currentContentRight =
+    chartWidth - resolvedCandleGap * currentScale - currentRightOffsetWidth;
+  const nextContentRight =
+    chartWidth - resolvedCandleGap * zoomScale - nextRightOffsetWidth;
   const anchorDistance =
     (currentContentRight + offset - clampedAnchorX) / currentScale;
   const nextOffset =
@@ -683,6 +792,7 @@ export function getTradingViewNativeZoomedViewport({
     offset: clampTradingViewNativePanOffset({
       candleGap: resolvedCandleGap,
       chartWidth,
+      initialRightOffset,
       offset: nextOffset,
       pointCount,
       zoomScale,

--- a/packages/kit/src/components/TradingView/TradingViewNative/web/TradingViewNativeChart.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewNative/web/TradingViewNativeChart.tsx
@@ -65,6 +65,7 @@ import {
 import type {
   ITradingViewNativeCandleLabels,
   ITradingViewNativeChartType,
+  ITradingViewNativeInitialRightOffset,
 } from '../types';
 
 const ONEKEY_WATERMARK_ASSET =
@@ -82,6 +83,7 @@ interface ITradingViewNativeChartProps {
   chartPictureVersion: number;
   hasVolume: boolean;
   indicatorSeries: ITradingViewNativeIndicatorSeries[];
+  initialRightOffset?: ITradingViewNativeInitialRightOffset;
   isSwitchingInterval: boolean;
   onChartWidthChange?: (width: number) => void;
   onViewportRequestApplied?: (requestId: number) => void;
@@ -347,6 +349,7 @@ export const TradingViewNativeChart = memo(
     chartType,
     hasVolume,
     indicatorSeries,
+    initialRightOffset,
     isSwitchingInterval,
     onChartWidthChange,
     onViewportRequestApplied,
@@ -358,7 +361,9 @@ export const TradingViewNativeChart = memo(
   }: ITradingViewNativeChartProps) => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const runtimeStateRef = useRef<ITradingViewNativeChartRuntimeState>(
-      createTradingViewNativeChartRuntimeState(),
+      createTradingViewNativeChartRuntimeState({
+        initialRightOffset,
+      }),
     );
     const pointerDragStateRef = useRef<IPointerDragState | null>(null);
     const wheelDeltaNormalizerRef = useRef(
@@ -501,6 +506,14 @@ export const TradingViewNativeChart = memo(
         return;
       }
       const chartWidth = getCanvasChartWidth(canvas, priceAxisLabels);
+      const runtimeAfterInitialMeasure = reduceTradingViewNativeChartRuntime(
+        runtimeStateRef.current,
+        {
+          type: 'initialWidthMeasured',
+          width: canvas.clientWidth,
+        },
+      );
+      runtimeStateRef.current = runtimeAfterInitialMeasure;
       const runtimeEvent = {
         appendedPointCount: dataUpdateMetadata.appendedPointCount,
         chartWidth,
@@ -511,8 +524,9 @@ export const TradingViewNativeChart = memo(
       if (dragState) {
         dragState.startOffset = reduceTradingViewNativeChartRuntime(
           {
-            ...runtimeStateRef.current,
+            ...runtimeAfterInitialMeasure,
             viewport: {
+              ...runtimeAfterInitialMeasure.viewport,
               offset: dragState.startOffset,
               zoomScale: dragState.zoomScale,
             },
@@ -521,7 +535,7 @@ export const TradingViewNativeChart = memo(
         ).viewport.offset;
       }
       const nextRuntimeState = reduceTradingViewNativeChartRuntime(
-        runtimeStateRef.current,
+        runtimeAfterInitialMeasure,
         runtimeEvent,
       );
       runtimeStateRef.current = nextRuntimeState;
@@ -597,7 +611,19 @@ export const TradingViewNativeChart = memo(
         return undefined;
       }
       const renderCurrentChart = () => {
-        renderChart(runtimeStateRef.current);
+        const currentRuntimeState = runtimeStateRef.current;
+        const measuredRuntimeState = reduceTradingViewNativeChartRuntime(
+          currentRuntimeState,
+          {
+            type: 'initialWidthMeasured',
+            width: canvas.clientWidth,
+          },
+        );
+        if (measuredRuntimeState !== currentRuntimeState) {
+          runtimeStateRef.current = measuredRuntimeState;
+          setViewportState(measuredRuntimeState.viewport);
+        }
+        renderChart(measuredRuntimeState);
         const nextChartWidth = getCanvasChartWidth(canvas, priceAxisLabels);
         setMeasuredChartWidth((currentWidth) =>
           currentWidth === nextChartWidth ? currentWidth : nextChartWidth,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58404](https://onekeyhq.atlassian.net/browse/OK-58404)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- add a configurable initial right offset to `TradingViewNative`
- default to two candle steps below 768px and 5% at or above 768px, based on the chart's first measured width
- keep the initial offset independent from subsequent pan, zoom, data updates, and resize behavior across the Skia and Canvas renderers

## Root cause

`TradingViewNative` had no initial right-side spacing, and its viewport model only represented user pan offset. Using page-level responsive state would also misclassify charts rendered in narrow panels on wide screens.

## Impact

The latest candle starts with appropriate right-side breathing room in Swap and Market without per-caller configuration. Callers can still override `initialRightOffset`.

## Validation

- targeted TradingViewNative Jest suites: 5 suites, 60 tests
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`

[OK-58404]: https://onekeyhq.atlassian.net/browse/OK-58404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ