### PR TITLE
ci: upgrade Codacy scan and add Trivy

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -1,4 +1,4 @@
-name: CodeQL Security Scan
+name: Trivy Security Scan
 
 on:
   push:
@@ -16,8 +16,8 @@ permissions:
   contents: read
 
 jobs:
-  codeql-security-scan:
-    name: CodeQL Security Scan
+  trivy-security-scan:
+    name: Trivy Security Scan
     runs-on: ubuntu-24.04
     permissions:
       actions: read
@@ -25,13 +25,23 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+      - name: Run Trivy security scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          languages: javascript-typescript
-          queries: security-extended
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,misconfig,secret
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: '0'
+          timeout: 20m0s
 
-      - name: Analyze code
-        uses: github/codeql-action/analyze@v4
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -1,46 +1,61 @@
-name: Trivy Security Scan
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow checks out code, performs a Codacy security scan
+# and integrates the results with the
+# GitHub Advanced Security code scanning feature.  For more information on
+# the Codacy security scan action usage and parameters, see
+# https://github.com/codacy/codacy-analysis-cli-action.
+# For more information on Codacy Analysis CLI in general, see
+# https://github.com/codacy/codacy-analysis-cli.
+
+name: Codacy Security Scan
 
 on:
   push:
-    branches:
-      - onekey
+    branches: [ "onekey" ]
   pull_request:
-    branches:
-      - onekey
+    # The branches below must be a subset of the branches above
+    branches: [ "onekey" ]
   schedule:
     - cron: '36 17 * * 0'
-  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  trivy-security-scan:
-    name: Trivy Security Scan
-    runs-on: ubuntu-24.04
+  codacy-security-scan:
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Codacy Security Scan
+    runs-on: ubuntu-24.04
     steps:
+      # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
-      - name: Run Trivy security scan
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
+      - name: Run Codacy Analysis CLI
+        uses: codacy/codacy-analysis-cli-action@d840f886c4bd4edc059706d09c6a1586111c540b
         with:
-          scan-type: fs
-          scan-ref: .
-          scanners: vuln,misconfig,secret
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
+          # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
+          # You can also omit the token and run the tools that support default configurations
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          verbose: true
+          output: results.sarif
           format: sarif
-          output: trivy-results.sarif
-          exit-code: '0'
-          timeout: 20m0s
+          # Adjust severity of non-security issues
+          gh-code-scanning-compat: true
+          # Force 0 exit code to allow SARIF file generation
+          # This will handover control about PR rejection to the GitHub side
+          max-allowed-issues: 2147483647
 
-      - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@v4
+      # Upload the SARIF file generated in the previous step
+      - name: Upload SARIF results file
+        uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: trivy-results.sarif
-          category: trivy
+          sarif_file: results.sarif

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -9,6 +9,10 @@ on:
     - cron: "36 17 * * 0"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - onekey
-      - codex/fix-codacy-security-scan
   pull_request:
     branches:
       - onekey

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -2,9 +2,9 @@ name: Codacy Security Scan
 
 on:
   push:
-    branches: [ "x" ]
+    branches: [ "x", "hotfix/*", "release/*" ]
   pull_request:
-    branches: [ "x" ]
+    branches: [ "x", "hotfix/*", "release/*" ]
   schedule:
     - cron: "36 17 * * 0"
   workflow_dispatch:
@@ -42,17 +42,30 @@ jobs:
         run: "${RUNNER_TEMP}/codacy-cli-v2 init"
 
       - name: Run Codacy security analysis
-        run: >-
-          "${RUNNER_TEMP}/codacy-cli-v2" analyze
-          --tool opengrep
-          --format sarif
-          --output results.sarif
-          .
+        run: |
+          set -euo pipefail
+          "${RUNNER_TEMP}/codacy-cli-v2" analyze \
+            --tool opengrep \
+            --format sarif \
+            --output results.sarif \
+            .
+          test -s results.sarif
+          if ! jq -e '.runs | type == "array" and length > 0' results.sarif > /dev/null; then
+            echo "::error::Codacy Opengrep produced no SARIF runs; analysis did not execute"
+            exit 1
+          fi
 
       - name: Normalize SARIF for GitHub
         run: |
+          set -euo pipefail
           jq '(.runs[].tool.driver.rules //= [])' \
             results.sarif > normalized-results.sarif
+          test -s normalized-results.sarif
+          jq -e '
+            .version == "2.1.0" and
+            (.runs | type == "array" and length > 0) and
+            all(.runs[]; (.tool.driver.rules | type) == "array")
+          ' normalized-results.sarif > /dev/null
           mv normalized-results.sarif results.sarif
 
       - name: Upload SARIF results

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -1,16 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# This workflow checks out code, performs a Codacy security scan
-# and integrates the results with the
-# GitHub Advanced Security code scanning feature.  For more information on
-# the Codacy security scan action usage and parameters, see
-# https://github.com/codacy/codacy-analysis-cli-action.
-# For more information on Codacy Analysis CLI in general, see
-# https://github.com/codacy/codacy-analysis-cli.
-
 name: Codacy Security Scan
 
 on:
@@ -20,42 +7,51 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ "onekey" ]
   schedule:
-    - cron: '36 17 * * 0'
+    - cron: "36 17 * * 0"
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   codacy-security-scan:
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: Codacy Security Scan
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    env:
+      CODACY_CLI_VERSION: 1.0.0-main.380.sha.27e119a
+      CODACY_CLI_SHA256: 3811e1240381a0414de43ecfea3fdbd660ef72f793019a1d2c0ee3a1b0fb980e
     steps:
-      # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
-      - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@d840f886c4bd4edc059706d09c6a1586111c540b
-        with:
-          # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
-          # You can also omit the token and run the tools that support default configurations
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          verbose: true
-          output: results.sarif
-          format: sarif
-          # Adjust severity of non-security issues
-          gh-code-scanning-compat: true
-          # Force 0 exit code to allow SARIF file generation
-          # This will handover control about PR rejection to the GitHub side
-          max-allowed-issues: 2147483647
+      - name: Install Codacy CLI v2
+        run: |
+          archive="${RUNNER_TEMP}/codacy-cli-v2.tar.gz"
+          curl --fail --location --silent --show-error \
+            "https://github.com/codacy/codacy-cli-v2/releases/download/${CODACY_CLI_VERSION}/codacy-cli-v2_${CODACY_CLI_VERSION}_linux_amd64.tar.gz" \
+            --output "${archive}"
+          echo "${CODACY_CLI_SHA256}  ${archive}" | sha256sum --check
+          tar -xzf "${archive}" -C "${RUNNER_TEMP}"
+          "${RUNNER_TEMP}/codacy-cli-v2" version
 
-      # Upload the SARIF file generated in the previous step
-      - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v2
+      - name: Initialize Codacy default configuration
+        run: "${RUNNER_TEMP}/codacy-cli-v2 init"
+
+      - name: Run Codacy security analysis
+        run: >-
+          "${RUNNER_TEMP}/codacy-cli-v2" analyze
+          --tool opengrep
+          --format sarif
+          --output results.sarif
+          .
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif
+          category: codacy-opengrep

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -2,10 +2,9 @@ name: Codacy Security Scan
 
 on:
   push:
-    branches: [ "onekey" ]
+    branches: [ "x" ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "onekey" ]
+    branches: [ "x" ]
   schedule:
     - cron: "36 17 * * 0"
   workflow_dispatch:

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -1,61 +1,37 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# This workflow checks out code, performs a Codacy security scan
-# and integrates the results with the
-# GitHub Advanced Security code scanning feature.  For more information on
-# the Codacy security scan action usage and parameters, see
-# https://github.com/codacy/codacy-analysis-cli-action.
-# For more information on Codacy Analysis CLI in general, see
-# https://github.com/codacy/codacy-analysis-cli.
-
-name: Codacy Security Scan
+name: CodeQL Security Scan
 
 on:
   push:
-    branches: [ "onekey" ]
+    branches:
+      - onekey
+      - codex/fix-codacy-security-scan
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "onekey" ]
+    branches:
+      - onekey
   schedule:
     - cron: '36 17 * * 0'
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  codacy-security-scan:
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    name: Codacy Security Scan
+  codeql-security-scan:
+    name: CodeQL Security Scan
     runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
-      # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
-      - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@d840f886c4bd4edc059706d09c6a1586111c540b
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
         with:
-          # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
-          # You can also omit the token and run the tools that support default configurations
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          verbose: true
-          output: results.sarif
-          format: sarif
-          # Adjust severity of non-security issues
-          gh-code-scanning-compat: true
-          # Force 0 exit code to allow SARIF file generation
-          # This will handover control about PR rejection to the GitHub side
-          max-allowed-issues: 2147483647
+          languages: javascript-typescript
+          queries: security-extended
 
-      # Upload the SARIF file generated in the previous step
-      - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: results.sarif
+      - name: Analyze code
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -50,6 +50,12 @@ jobs:
           --output results.sarif
           .
 
+      - name: Normalize SARIF for GitHub
+        run: |
+          jq '(.runs[].tool.driver.rules //= [])' \
+            results.sarif > normalized-results.sarif
+          mv normalized-results.sarif results.sarif
+
       - name: Upload SARIF results
         uses: github/codeql-action/upload-sarif@v4
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -3,10 +3,10 @@ name: Trivy Security Scan
 on:
   push:
     branches:
-      - onekey
+      - x
   pull_request:
     branches:
-      - onekey
+      - x
   schedule:
     - cron: "36 17 * * 0"
   workflow_dispatch:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -41,6 +41,7 @@ jobs:
           scan-ref: .
           scanners: vuln,misconfig,secret
           severity: HIGH,CRITICAL
+          limit-severities-for-sarif: true
           ignore-unfixed: true
           format: sarif
           output: trivy-results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,46 @@
+name: Trivy Security Scan
+
+on:
+  push:
+    branches:
+      - onekey
+  pull_request:
+    branches:
+      - onekey
+  schedule:
+    - cron: "36 17 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trivy-security-scan:
+    name: Trivy Security Scan
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run Trivy security scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,misconfig,secret
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: "0"
+          timeout: 20m0s
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -15,6 +15,10 @@ on:
     - cron: "36 17 * * 0"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - x
+      - hotfix/*
+      - release/*
   pull_request:
     branches:
       - x
+      - hotfix/*
+      - release/*
   schedule:
     - cron: "36 17 * * 0"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Keep the standalone Trivy filesystem scan for dependency vulnerabilities, misconfigurations, and secrets.
- Upgrade the Codacy workflow from the legacy CLI action to a checksum-pinned Codacy CLI v2 binary.
- Run Codacy Opengrep with public default configuration and no project/API token.
- Normalize the CLI v2 empty SARIF rules field before uploading results to GitHub code scanning.

## Root cause

The legacy Codacy CLI v1 action crashed while formatting SARIF with a MalformedInputException. CLI v2 avoids that formatter failure. CLI v2 currently emits a null rules field when no rules are present, so the workflow normalizes it to an empty array required by GitHub SARIF validation.

## Validation

- yarn agent:check --profile commit
- yarn agent:check --profile pr (local checks passed; GitHub checks tracked on this PR)
- Trivy scan and SARIF upload: https://github.com/OneKeyHQ/app-monorepo/actions/runs/31479215089
- Codacy CLI v2 no-token scan and SARIF upload: https://github.com/OneKeyHQ/app-monorepo/actions/runs/31482857180