### PR TITLE
feat: track universal search source

### DIFF
--- a/packages/kit/src/components/TabPageHeader/DappHeader.tsx
+++ b/packages/kit/src/components/TabPageHeader/DappHeader.tsx
@@ -44,6 +44,7 @@ import {
 } from '../../states/jotai/contexts/accountSelector/atoms';
 import { HomeTokenListProviderMirror } from '../../views/Home/components/HomeTokenListProvider/HomeTokenListProviderMirror';
 import { useLanguageSelector } from '../../views/Setting/hooks/useLanguageSelector';
+import { getUniversalSearchSource } from '../../views/UniversalSearch/universalSearchSource';
 import { AccountSelectorProviderMirror } from '../AccountSelector/AccountSelectorProvider';
 import { ListItem } from '../ListItem';
 
@@ -430,8 +431,11 @@ function RightActions({
   const handleSearchPress = useCallback(() => {
     navigation.pushModal(EModalRoutes.UniversalSearchModal, {
       screen: EUniversalSearchPages.UniversalSearch,
+      params: {
+        source: getUniversalSearchSource(tabRoute),
+      },
     });
-  }, [navigation]);
+  }, [navigation, tabRoute]);
 
   return (
     <XStack ai="center" gap="$5">
@@ -582,7 +586,7 @@ export function DappHeader({
       />
       {!hideSearch ? (
         <XStack px="$pagePadding" pt="$2" pb="$2">
-          <UniversalSearchInput />
+          <UniversalSearchInput tabRoute={tabRoute} />
         </XStack>
       ) : null}
       <XStack h="$px" bg="$borderSubdued" />

--- a/packages/kit/src/components/TabPageHeader/HeaderMDSearch.tsx
+++ b/packages/kit/src/components/TabPageHeader/HeaderMDSearch.tsx
@@ -9,6 +9,6 @@ export function HeaderMDSearch({
   tabRoute,
 }: ITabPageHeaderProp) {
   return tabRoute === ETabRoutes.Home || tabRoute === ETabRoutes.Market ? (
-    <MDUniversalSearchInput />
+    <MDUniversalSearchInput tabRoute={tabRoute} />
   ) : null;
 }

--- a/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
+++ b/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
@@ -65,7 +65,11 @@ export function SelectorTrigger() {
 
 export function SearchInput({
   isUrlWallet = false,
-}: { isUrlWallet?: boolean } = {}) {
+  tabRoute,
+}: {
+  isUrlWallet?: boolean;
+  tabRoute: ETabRoutes;
+}) {
   const { gtXl, gtLg, gt2xl } = useMedia();
 
   let size: boolean;
@@ -75,7 +79,12 @@ export function SearchInput({
     size = platformEnv.isWeb ? gtXl : gtLg;
   }
 
-  return <LegacyUniversalSearchInput size={size ? 'large' : 'small'} />;
+  return (
+    <LegacyUniversalSearchInput
+      size={size ? 'large' : 'small'}
+      tabRoute={tabRoute}
+    />
+  );
 }
 
 export function HeaderRight({

--- a/packages/kit/src/components/TabPageHeader/LegacyUniversalSearchInput.tsx
+++ b/packages/kit/src/components/TabPageHeader/LegacyUniversalSearchInput.tsx
@@ -14,12 +14,14 @@ import {
   useIsWebHorizontalLayout,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
 import { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
 import type { EUniversalSearchType } from '@onekeyhq/shared/types/search';
 
 import useAppNavigation from '../../hooks/useAppNavigation';
+import { getUniversalSearchSource } from '../../views/UniversalSearch/universalSearchSource';
 
 // Fully-rounded pill matching SearchBar's own borderRadius="$full"; the bar's
 // fill is made transparent (below) so this Liquid Glass material shows through.
@@ -34,22 +36,27 @@ export function LegacyUniversalSearchInput({
   // its search doesn't surface market/perp/wallet results (OK-56756).
   filterTypes,
   glass = false,
+  tabRoute,
 }: {
   containerProps?: IStackStyle;
   size?: 'large' | 'medium' | 'small';
   initialTab?: 'market' | 'dapp';
   filterTypes?: EUniversalSearchType[];
   glass?: boolean;
+  tabRoute: ETabRoutes;
 }) {
   const intl = useIntl();
   const navigation = useAppNavigation();
   const toUniversalSearchPage = useCallback(() => {
     navigation.pushModal(EModalRoutes.UniversalSearchModal, {
       screen: EUniversalSearchPages.UniversalSearch,
-      params:
-        initialTab || filterTypes ? { initialTab, filterTypes } : undefined,
+      params: {
+        source: getUniversalSearchSource(tabRoute),
+        ...(initialTab ? { initialTab } : {}),
+        ...(filterTypes ? { filterTypes } : {}),
+      },
     });
-  }, [navigation, initialTab, filterTypes]);
+  }, [filterTypes, initialTab, navigation, tabRoute]);
 
   // iOS 26 only: host the search bar inside a Liquid Glass capsule. Off iOS 26
   // (and every other platform) isLiquidGlassAvailable() is false, so this stays
@@ -147,12 +154,13 @@ export function LegacyUniversalSearchInput({
   );
 }
 
-export function MDUniversalSearchInput() {
+export function MDUniversalSearchInput({ tabRoute }: { tabRoute: ETabRoutes }) {
   const isHorizontal = useIsWebHorizontalLayout();
   return isHorizontal ? null : (
     <XStack px="$pagePadding" pt="$0.5">
       <LegacyUniversalSearchInput
         size="medium"
+        tabRoute={tabRoute}
         containerProps={{
           width: '100%',
           $gtLg: undefined,

--- a/packages/kit/src/components/TabPageHeader/MDHeader.tsx
+++ b/packages/kit/src/components/TabPageHeader/MDHeader.tsx
@@ -157,6 +157,7 @@ export function MDHeader({
                   <LegacyUniversalSearchInput
                     size="medium"
                     glass
+                    tabRoute={tabRoute}
                     containerProps={{
                       width: '100%',
                       $gtLg: undefined,

--- a/packages/kit/src/components/TabPageHeader/UniversalSearchInput.tsx
+++ b/packages/kit/src/components/TabPageHeader/UniversalSearchInput.tsx
@@ -13,29 +13,36 @@ import {
 import { HeaderIconButton } from '@onekeyhq/components/src/layouts/Navigation/Header';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
 import { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
 
 import useAppNavigation from '../../hooks/useAppNavigation';
+import { getUniversalSearchSource } from '../../views/UniversalSearch/universalSearchSource';
 
 export function UniversalSearchInput({
   containerProps,
   size = 'large',
   initialTab,
+  tabRoute,
 }: {
   containerProps?: IStackStyle;
   size?: 'large' | 'medium' | 'small';
   initialTab?: 'market' | 'dapp';
+  tabRoute: ETabRoutes;
 }) {
   const intl = useIntl();
   const navigation = useAppNavigation();
   const toUniversalSearchPage = useCallback(() => {
     navigation.pushModal(EModalRoutes.UniversalSearchModal, {
       screen: EUniversalSearchPages.UniversalSearch,
-      params: initialTab ? { initialTab } : undefined,
+      params: {
+        source: getUniversalSearchSource(tabRoute),
+        ...(initialTab ? { initialTab } : {}),
+      },
     });
-  }, [navigation, initialTab]);
+  }, [initialTab, navigation, tabRoute]);
 
   if (size === 'small') {
     return (
@@ -88,12 +95,13 @@ export function UniversalSearchInput({
   );
 }
 
-export function MDUniversalSearchInput() {
+export function MDUniversalSearchInput({ tabRoute }: { tabRoute: ETabRoutes }) {
   const isHorizontal = useIsWebHorizontalLayout();
   return isHorizontal ? null : (
     <XStack px="$pagePadding" pt="$0.5">
       <UniversalSearchInput
         size="medium"
+        tabRoute={tabRoute}
         containerProps={{
           width: '100%',
           $gtLg: undefined,

--- a/packages/kit/src/components/TabPageHeader/index.tsx
+++ b/packages/kit/src/components/TabPageHeader/index.tsx
@@ -97,8 +97,8 @@ function BaseDesktopTabPageHeader({
   const theme = useTheme();
 
   const renderUniversalSearchInput = useCallback(
-    () => <UniversalSearchInput />,
-    [],
+    () => <UniversalSearchInput tabRoute={tabRoute} />,
+    [tabRoute],
   );
 
   const renderDesktopModeRightButtons = useCallback(() => {

--- a/packages/kit/src/hooks/useGlobalShortcuts.desktop.test.ts
+++ b/packages/kit/src/hooks/useGlobalShortcuts.desktop.test.ts
@@ -1,0 +1,81 @@
+/** @jest-environment jsdom */
+
+import { act, renderHook } from '@testing-library/react';
+
+import { useShortcuts } from '@onekeyhq/components';
+import { EModalRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
+import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
+import { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
+import { EUniversalSearchSource } from '@onekeyhq/shared/types/search';
+
+import useAppNavigation from './useAppNavigation';
+import { useGlobalShortcuts } from './useGlobalShortcuts.desktop';
+import { useShortcutsRouteStatus } from './useListenTabFocusState';
+
+jest.mock('@onekeyhq/components', () => ({
+  useShortcuts: jest.fn(),
+}));
+
+jest.mock('./useAppNavigation', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('./useListenTabFocusState', () => ({
+  useShortcutsRouteStatus: jest.fn(),
+}));
+
+const mockUseShortcuts = useShortcuts as jest.Mock;
+const mockUseAppNavigation = useAppNavigation as jest.Mock;
+const mockUseShortcutsRouteStatus = useShortcutsRouteStatus as jest.Mock;
+
+describe('useGlobalShortcuts', () => {
+  it('attributes universal search to the current tab when the shortcut fires', () => {
+    const pushModal = jest.fn();
+    const currentTabRoute = { current: ETabRoutes.Home };
+    let shortcutHandler: ((event: EShortcutEvents) => void) | undefined;
+
+    mockUseAppNavigation.mockReturnValue({ pushModal });
+    mockUseShortcutsRouteStatus.mockReturnValue({
+      currentTabRoute,
+      isAtBrowserTab: { current: false },
+      shouldReloadAppByCmdR: { current: true },
+    });
+    mockUseShortcuts.mockImplementation(
+      (_scope: unknown, handler: (event: EShortcutEvents) => void) => {
+        shortcutHandler = handler;
+      },
+    );
+
+    renderHook(() => useGlobalShortcuts());
+
+    act(() => shortcutHandler?.(EShortcutEvents.UniversalSearch));
+    expect(pushModal).toHaveBeenLastCalledWith(
+      EModalRoutes.UniversalSearchModal,
+      {
+        screen: EUniversalSearchPages.UniversalSearch,
+        params: { source: EUniversalSearchSource.Wallet },
+      },
+    );
+
+    currentTabRoute.current = ETabRoutes.Perp;
+    act(() => shortcutHandler?.(EShortcutEvents.UniversalSearch));
+    expect(pushModal).toHaveBeenLastCalledWith(
+      EModalRoutes.UniversalSearchModal,
+      {
+        screen: EUniversalSearchPages.UniversalSearch,
+        params: { source: EUniversalSearchSource.Perps },
+      },
+    );
+
+    currentTabRoute.current = ETabRoutes.MultiTabBrowser;
+    act(() => shortcutHandler?.(EShortcutEvents.UniversalSearch));
+    expect(pushModal).toHaveBeenLastCalledWith(
+      EModalRoutes.UniversalSearchModal,
+      {
+        screen: EUniversalSearchPages.UniversalSearch,
+        params: { source: EUniversalSearchSource.Browser },
+      },
+    );
+  });
+});

--- a/packages/kit/src/hooks/useGlobalShortcuts.desktop.ts
+++ b/packages/kit/src/hooks/useGlobalShortcuts.desktop.ts
@@ -5,12 +5,15 @@ import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
 import { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
 
+import { getUniversalSearchSource } from '../views/UniversalSearch/universalSearchSource';
+
 import useAppNavigation from './useAppNavigation';
 import { useShortcutsRouteStatus } from './useListenTabFocusState';
 
 export const useGlobalShortcuts = () => {
   const navigation = useAppNavigation();
-  const { isAtBrowserTab, shouldReloadAppByCmdR } = useShortcutsRouteStatus();
+  const { currentTabRoute, isAtBrowserTab, shouldReloadAppByCmdR } =
+    useShortcutsRouteStatus();
 
   const handleShortcuts = useCallback(
     (data: EShortcutEvents) => {
@@ -18,6 +21,9 @@ export const useGlobalShortcuts = () => {
         case EShortcutEvents.UniversalSearch:
           navigation.pushModal(EModalRoutes.UniversalSearchModal, {
             screen: EUniversalSearchPages.UniversalSearch,
+            params: {
+              source: getUniversalSearchSource(currentTabRoute.current),
+            },
           });
           break;
         case EShortcutEvents.Refresh:
@@ -34,7 +40,7 @@ export const useGlobalShortcuts = () => {
           break;
       }
     },
-    [isAtBrowserTab, navigation, shouldReloadAppByCmdR],
+    [currentTabRoute, isAtBrowserTab, navigation, shouldReloadAppByCmdR],
   );
 
   useShortcuts(undefined, handleShortcuts);

--- a/packages/kit/src/hooks/useListenTabFocusState.ts
+++ b/packages/kit/src/hooks/useListenTabFocusState.ts
@@ -3,15 +3,21 @@ import { useCallback, useRef } from 'react';
 import { useOnRouterChange } from '@onekeyhq/components';
 import { ERootRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
 
+const ALL_TAB_ROUTES = Object.values(ETabRoutes);
+
 export default function useListenTabFocusState(
   tabName: ETabRoutes | ETabRoutes[],
-  callback: (isFocus: boolean, isHideByModal: boolean) => void, // do NOT useCallback to wrap the callback
+  callback: (
+    isFocus: boolean,
+    isHideByModal: boolean,
+    currentTabName: ETabRoutes | undefined,
+  ) => void, // do NOT useCallback to wrap the callback
 ) {
   const tabNames = Array.isArray(tabName) ? tabName : [tabName];
   useOnRouterChange((state) => {
     // the state may be undefined when initializing the interface on the Ext.
     if (!state) {
-      callback(tabName === ETabRoutes.Home, false);
+      callback(tabNames.includes(ETabRoutes.Home), false, ETabRoutes.Home);
       return;
     }
     const rootState = state?.routes.find(
@@ -28,10 +34,11 @@ export default function useListenTabFocusState(
     )?.key;
     const currentTabName = rootState?.routeNames
       ? (rootState?.routeNames?.[rootState?.index || 0] as ETabRoutes)
-      : (rootState?.routes[0].name as ETabRoutes);
+      : (rootState?.routes[0]?.name as ETabRoutes | undefined);
     callback(
-      tabNames.includes(currentTabName),
+      !!currentTabName && tabNames.includes(currentTabName),
       !!(modalRoutes || fullModalRoutes || fullScreenPushRoutes),
+      currentTabName,
     );
   });
 }
@@ -41,6 +48,7 @@ export function useShortcutsRouteStatus() {
   const isAtBrowserTab = useRef(false);
   const isAtPerpTab = useRef(false);
   const isAtDiscoveryTab = useRef(false);
+  const currentTabRoute = useRef<ETabRoutes | undefined>(undefined);
 
   const updateShouldReloadAppByCmdR = useCallback(() => {
     shouldReloadAppByCmdR.current =
@@ -68,7 +76,15 @@ export function useShortcutsRouteStatus() {
     updateShouldReloadAppByCmdR();
   });
 
+  useListenTabFocusState(
+    ALL_TAB_ROUTES,
+    (_isFocus, _isHideByModal, currentTabName) => {
+      currentTabRoute.current = currentTabName;
+    },
+  );
+
   return {
+    currentTabRoute,
     isAtDiscoveryTab,
     isAtBrowserTab,
     isAtPerpTab,

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.ext.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.ext.tsx
@@ -108,7 +108,11 @@ function MobileBrowser() {
         {/* custom header */}
         <YStack my="$2">
           <XStack mx="$5">
-            <LegacyUniversalSearchInput size="medium" initialTab="market" />
+            <LegacyUniversalSearchInput
+              size="medium"
+              initialTab="market"
+              tabRoute={ETabRoutes.Discovery}
+            />
           </XStack>
           <TabPageHeader
             sceneName={EAccountSelectorSceneName.home}

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.ext.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.ext.tsx
@@ -24,22 +24,15 @@ import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { EarnHomeWithProvider } from '../../../Earn/EarnHome';
 import { MarketHomeWithProvider } from '../../../Market/MarketHomeV2/MarketHomeV2';
 
+import {
+  getExploreTabName,
+  getExploreUniversalSearchTabRoute,
+} from './exploreTabUtils';
 import { withBrowserProvider } from './WithBrowserProvider';
 
 import type { RouteProp } from '@react-navigation/core';
 
-type IExploreTabName = 'market' | 'earn' | 'browser';
 type IExploreTabSwitchType = 'default' | 'tap' | 'swipe';
-
-function getExploreTabName(tab: ETranslations): IExploreTabName {
-  if (tab === ETranslations.global_market) {
-    return 'market';
-  }
-  if (tab === ETranslations.global_earn) {
-    return 'earn';
-  }
-  return 'browser';
-}
 
 function MobileBrowser() {
   const route =
@@ -51,6 +44,8 @@ function MobileBrowser() {
   const [selectedHeaderTab, setSelectedHeaderTab] = useState<ETranslations>(
     defaultTab || settings.selectedBrowserTab || ETranslations.global_market,
   );
+  const universalSearchTabRoute =
+    getExploreUniversalSearchTabRoute(selectedHeaderTab);
   const exploreTabSwitchTypeRef = useRef<IExploreTabSwitchType>('default');
   const hasLoggedExploreTabViewRef = useRef(false);
 
@@ -111,7 +106,7 @@ function MobileBrowser() {
             <LegacyUniversalSearchInput
               size="medium"
               initialTab="market"
-              tabRoute={ETabRoutes.Discovery}
+              tabRoute={universalSearchTabRoute}
             />
           </XStack>
           <TabPageHeader

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -81,6 +81,10 @@ import { checkAndCreateFolder } from '../../utils/screenshot';
 import { showTabBar, useNotifyTabBarDisplay } from '../../utils/tabBarUtils';
 import DashboardContent from '../Dashboard/DashboardContent';
 
+import {
+  getExploreTabName,
+  getExploreUniversalSearchTabRoute,
+} from './exploreTabUtils';
 import MobileBrowserContent from './MobileBrowserContent';
 import { withBrowserProvider } from './WithBrowserProvider';
 
@@ -88,26 +92,7 @@ import type { IEarnBorrowPagerViewRef } from '../../../Earn/components/EarnBorro
 import type { RouteProp } from '@react-navigation/core';
 import type { WebView } from 'react-native-webview';
 
-type IExploreTabName = 'market' | 'earn' | 'browser';
 type IExploreTabSwitchType = 'default' | 'tap' | 'swipe';
-
-function getExploreTabName(tab: ETranslations): IExploreTabName {
-  if (tab === ETranslations.global_market) {
-    return 'market';
-  }
-  if (tab === ETranslations.global_earn) {
-    return 'earn';
-  }
-  return 'browser';
-}
-
-// Native Discovery hosts three business tabs under one route. Pass the active
-// business route to universal search so analytics can distinguish the entry.
-const UNIVERSAL_SEARCH_TAB_ROUTE_MAP: Record<IExploreTabName, ETabRoutes> = {
-  market: ETabRoutes.Market,
-  earn: ETabRoutes.Earn,
-  browser: ETabRoutes.Discovery,
-};
 
 const styles = StyleSheet.create({
   // iOS WKWebViews must stay in the native layout tree. In nested layouts,
@@ -261,7 +246,7 @@ function MobileBrowser() {
     return undefined;
   }, [selectedHeaderTab]);
   const universalSearchTabRoute =
-    UNIVERSAL_SEARCH_TAB_ROUTE_MAP[getExploreTabName(selectedHeaderTab)];
+    getExploreUniversalSearchTabRoute(selectedHeaderTab);
 
   const { tabs } = useWebTabs();
   const { activeTabId } = useActiveTabId();

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -101,6 +101,14 @@ function getExploreTabName(tab: ETranslations): IExploreTabName {
   return 'browser';
 }
 
+// Native Discovery hosts three business tabs under one route. Pass the active
+// business route to universal search so analytics can distinguish the entry.
+const UNIVERSAL_SEARCH_TAB_ROUTE_MAP: Record<IExploreTabName, ETabRoutes> = {
+  market: ETabRoutes.Market,
+  earn: ETabRoutes.Earn,
+  browser: ETabRoutes.Discovery,
+};
+
 const styles = StyleSheet.create({
   // iOS WKWebViews must stay in the native layout tree. In nested layouts,
   // display:none can reload the page even though React keeps it mounted.
@@ -252,6 +260,8 @@ function MobileBrowser() {
     }
     return undefined;
   }, [selectedHeaderTab]);
+  const universalSearchTabRoute =
+    UNIVERSAL_SEARCH_TAB_ROUTE_MAP[getExploreTabName(selectedHeaderTab)];
 
   const { tabs } = useWebTabs();
   const { activeTabId } = useActiveTabId();
@@ -760,6 +770,7 @@ function MobileBrowser() {
               size="medium"
               glass
               initialTab={searchInitialTab}
+              tabRoute={universalSearchTabRoute}
             />
           </Stack>
           <TabPageHeader

--- a/packages/kit/src/views/Discovery/pages/Browser/exploreTabUtils.test.ts
+++ b/packages/kit/src/views/Discovery/pages/Browser/exploreTabUtils.test.ts
@@ -1,0 +1,21 @@
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+
+import {
+  getExploreTabName,
+  getExploreUniversalSearchTabRoute,
+} from './exploreTabUtils';
+
+describe('exploreTabUtils', () => {
+  it.each([
+    [ETranslations.global_market, 'market', ETabRoutes.Market],
+    [ETranslations.global_earn, 'earn', ETabRoutes.Earn],
+    [ETranslations.global_browser, 'browser', ETabRoutes.Discovery],
+  ] as const)(
+    'maps %s to %s and %s',
+    (tab, expectedTabName, expectedTabRoute) => {
+      expect(getExploreTabName(tab)).toBe(expectedTabName);
+      expect(getExploreUniversalSearchTabRoute(tab)).toBe(expectedTabRoute);
+    },
+  );
+});

--- a/packages/kit/src/views/Discovery/pages/Browser/exploreTabUtils.ts
+++ b/packages/kit/src/views/Discovery/pages/Browser/exploreTabUtils.ts
@@ -1,0 +1,26 @@
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+
+export type IExploreTabName = 'market' | 'earn' | 'browser';
+
+const UNIVERSAL_SEARCH_TAB_ROUTE_MAP: Record<IExploreTabName, ETabRoutes> = {
+  market: ETabRoutes.Market,
+  earn: ETabRoutes.Earn,
+  browser: ETabRoutes.Discovery,
+};
+
+export function getExploreTabName(tab: ETranslations): IExploreTabName {
+  if (tab === ETranslations.global_market) {
+    return 'market';
+  }
+  if (tab === ETranslations.global_earn) {
+    return 'earn';
+  }
+  return 'browser';
+}
+
+export function getExploreUniversalSearchTabRoute(
+  tab: ETranslations,
+): ETabRoutes {
+  return UNIVERSAL_SEARCH_TAB_ROUTE_MAP[getExploreTabName(tab)];
+}

--- a/packages/kit/src/views/Earn/components/EarnPageContainer.tsx
+++ b/packages/kit/src/views/Earn/components/EarnPageContainer.tsx
@@ -203,7 +203,11 @@ export function EarnPageContainer({
       ) : (
         <YStack mx="$pagePadding" mt="$2" mb="$1">
           <Page.Header headerShown={false} />
-          <LegacyUniversalSearchInput size="medium" initialTab="dapp" />
+          <LegacyUniversalSearchInput
+            size="medium"
+            initialTab="dapp"
+            tabRoute={tabRoute}
+          />
         </YStack>
       )}
       {body}

--- a/packages/kit/src/views/Market/components/MarketHomeHeaderSearchBar.tsx
+++ b/packages/kit/src/views/Market/components/MarketHomeHeaderSearchBar.tsx
@@ -5,10 +5,11 @@ import { useIntl } from 'react-intl';
 import { SearchBar, Shortcut, View, XStack } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { EModalRoutes } from '@onekeyhq/shared/src/routes';
+import { EModalRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
 import { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
 
+import { getUniversalSearchSource } from '../../UniversalSearch/universalSearchSource';
 import { MarketTestIDs } from '../testIDs';
 
 export function MarketHomeHeaderSearchBar() {
@@ -17,6 +18,9 @@ export function MarketHomeHeaderSearchBar() {
   const toUniversalSearchPage = useCallback(() => {
     navigation.pushModal(EModalRoutes.UniversalSearchModal, {
       screen: EUniversalSearchPages.UniversalSearch,
+      params: {
+        source: getUniversalSearchSource(ETabRoutes.Market),
+      },
     });
   }, [navigation]);
 

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchAccountAssetItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchAccountAssetItem.tsx
@@ -20,19 +20,24 @@ import {
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { getTokenPriceChangeStyle } from '@onekeyhq/shared/src/utils/tokenUtils';
-import type { IUniversalSearchAccountAssets } from '@onekeyhq/shared/types/search';
+import type {
+  EUniversalSearchSource,
+  IUniversalSearchAccountAssets,
+} from '@onekeyhq/shared/types/search';
 import type { IAccountToken } from '@onekeyhq/shared/types/token';
 
 interface IUniversalSearchAccountAssetItemProps {
   item: IUniversalSearchAccountAssets;
   allAggregateTokenMap?: Record<string, { tokens: IAccountToken[] }>;
   getSearchInput: () => string;
+  source: EUniversalSearchSource;
 }
 
 export function UniversalSearchAccountAssetItem({
   item,
   allAggregateTokenMap,
   getSearchInput,
+  source,
 }: IUniversalSearchAccountAssetItemProps) {
   const navigation = useAppNavigation();
   const { activeAccount } = useActiveAccount({ num: 0 });
@@ -56,6 +61,7 @@ export function UniversalSearchAccountAssetItem({
 
   const handlePress = useCallback(async () => {
     defaultLogger.universalSearch.search.universalSearchClick({
+      source,
       searchText: getSearchInput(),
       type: item.type,
       itemId: token.address ?? token.symbol ?? '',
@@ -112,6 +118,7 @@ export function UniversalSearchAccountAssetItem({
     getSearchInput,
     item.type,
     navigation,
+    source,
     token,
     universalSearchActions,
   ]);

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchAddressItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchAddressItem.tsx
@@ -15,7 +15,10 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
-import type { IUniversalSearchAddress } from '@onekeyhq/shared/types/search';
+import type {
+  EUniversalSearchSource,
+  IUniversalSearchAddress,
+} from '@onekeyhq/shared/types/search';
 
 import { AccountAddress } from '../../../AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountAddress';
 import { AccountValueWithSpotlight } from '../../../AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountValue';
@@ -25,12 +28,14 @@ interface IUniversalSearchAddressItemProps {
   item: IUniversalSearchAddress;
   contextNetworkId?: string;
   getSearchInput: () => string;
+  source: EUniversalSearchSource;
 }
 
 export function UniversalSearchAddressItem({
   item,
   contextNetworkId,
   getSearchInput,
+  source,
 }: IUniversalSearchAddressItemProps) {
   const navigation = useAppNavigation();
   const accountSelectorActions = useAccountSelectorActions();
@@ -67,6 +72,7 @@ export function UniversalSearchAddressItem({
 
   const handleAccountPress = useCallback(async () => {
     defaultLogger.universalSearch.search.universalSearchClick({
+      source,
       searchText: getSearchInput(),
       type: item.type,
       itemId:
@@ -145,11 +151,13 @@ export function UniversalSearchAddressItem({
     item.payload,
     item.type,
     navigation,
+    source,
     universalSearchActions,
   ]);
 
   const handleAddressPress = useCallback(() => {
     defaultLogger.universalSearch.search.universalSearchClick({
+      source,
       searchText: getSearchInput(),
       type: item.type,
       itemId: item.payload.addressInfo?.displayAddress ?? '',
@@ -192,6 +200,7 @@ export function UniversalSearchAddressItem({
     item.payload,
     item.type,
     navigation,
+    source,
     universalSearchActions,
   ]);
 

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchDappItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchDappItem.tsx
@@ -8,18 +8,23 @@ import { useUniversalSearchActions } from '@onekeyhq/kit/src/states/jotai/contex
 import { isGoogleSearchItem } from '@onekeyhq/shared/src/consts/discovery';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EEnterMethod } from '@onekeyhq/shared/src/logger/scopes/discovery/scenes/dapp';
-import type { IUniversalSearchDapp } from '@onekeyhq/shared/types/search';
+import type {
+  EUniversalSearchSource,
+  IUniversalSearchDapp,
+} from '@onekeyhq/shared/types/search';
 
 import { useWebSiteHandler } from '../../../Discovery/hooks/useWebSiteHandler';
 
 interface IUniversalSearchDappItemProps {
   item: IUniversalSearchDapp;
   getSearchInput: () => string;
+  source: EUniversalSearchSource;
 }
 
 export function UniversalSearchDappItem({
   item,
   getSearchInput,
+  source,
 }: IUniversalSearchDappItemProps) {
   const { name, dappId, logo } = item.payload;
   const isGoogle = isGoogleSearchItem(dappId);
@@ -81,6 +86,7 @@ export function UniversalSearchDappItem({
 
   const handlePress = useCallback(() => {
     defaultLogger.universalSearch.search.universalSearchClick({
+      source,
       searchText: getSearchInput(),
       type: item.type,
       itemId: dappId ?? '',
@@ -157,6 +163,7 @@ export function UniversalSearchDappItem({
     dappId,
     universalSearchActions,
     processSearchInput,
+    source,
   ]);
 
   return (

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchPerpItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchPerpItem.tsx
@@ -22,7 +22,10 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { buildCoinFromSearchAssetType } from '@onekeyhq/shared/src/utils/perpsDexUtils';
 import { getHyperliquidTokenImageUris } from '@onekeyhq/shared/src/utils/perpsUtils';
-import type { IUniversalSearchPerp } from '@onekeyhq/shared/types/search';
+import type {
+  EUniversalSearchSource,
+  IUniversalSearchPerp,
+} from '@onekeyhq/shared/types/search';
 
 import { MarketPerpsStarV2 } from '../../../Market/components/MarketStarV2';
 
@@ -32,11 +35,13 @@ const shouldShowFavoriteButton =
 interface IUniversalSearchPerpItemProps {
   item: IUniversalSearchPerp;
   getSearchInput: () => string;
+  source: EUniversalSearchSource;
 }
 
 export function UniversalSearchPerpItem({
   item,
   getSearchInput,
+  source,
 }: IUniversalSearchPerpItemProps) {
   const [{ isMounted }] = useMarketWatchListV2Atom();
   const navigation = useAppNavigation();
@@ -61,6 +66,7 @@ export function UniversalSearchPerpItem({
 
   const handlePress = useCallback(() => {
     defaultLogger.universalSearch.search.universalSearchClick({
+      source,
       searchText: getSearchInput(),
       type: item.type,
       itemId: coin,
@@ -99,6 +105,7 @@ export function UniversalSearchPerpItem({
     name,
     assetType,
     navigation,
+    source,
     universalSearchActions,
   ]);
 

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchSettingsItem.test.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchSettingsItem.test.tsx
@@ -1,0 +1,115 @@
+/** @jest-environment jsdom */
+
+import { fireEvent, render } from '@testing-library/react';
+
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import {
+  EUniversalSearchSource,
+  EUniversalSearchType,
+  type IUniversalSearchSettings,
+} from '@onekeyhq/shared/types/search';
+
+import { UniversalSearchSettingsItem } from './UniversalSearchSettingsItem';
+
+const mockPop = jest.fn();
+const mockPushModal = jest.fn();
+const mockAddIntoRecentSearchList = jest.fn();
+
+jest.mock('@onekeyhq/components', () => ({
+  Icon: () => null,
+  SizableText: ({ children }: { children?: React.ReactNode }) => children,
+}));
+
+jest.mock('@onekeyhq/kit/src/components/ListItem', () => {
+  const ReactModule = jest.requireActual<typeof import('react')>('react');
+  const ListItem = ({
+    children,
+    onPress,
+  }: {
+    children?: React.ReactNode;
+    onPress?: () => void;
+  }) =>
+    ReactModule.createElement(
+      'button',
+      { 'data-testid': 'settings-result', onClick: onPress },
+      children,
+    );
+  ListItem.Text = ({ primary }: { primary?: React.ReactNode }) =>
+    ReactModule.createElement('span', null, primary);
+  return { ListItem };
+});
+
+jest.mock('@onekeyhq/kit/src/hooks/useAppNavigation', () => ({
+  __esModule: true,
+  default: () => ({
+    pop: mockPop,
+    pushModal: mockPushModal,
+  }),
+}));
+
+jest.mock('@onekeyhq/kit/src/states/jotai/contexts/universalSearch', () => ({
+  useUniversalSearchActions: () => ({
+    current: {
+      addIntoRecentSearchList: mockAddIntoRecentSearchList,
+    },
+  }),
+}));
+
+jest.mock('@onekeyhq/shared/src/logger/logger', () => ({
+  defaultLogger: {
+    universalSearch: {
+      search: {
+        universalSearchClick: jest.fn(),
+      },
+    },
+  },
+}));
+
+const mockUniversalSearchClick = jest.spyOn(
+  defaultLogger.universalSearch.search,
+  'universalSearchClick',
+);
+
+jest.mock('@onekeyhq/shared/src/utils/timerUtils', () => ({
+  __esModule: true,
+  default: {
+    wait: jest.fn(async () => undefined),
+  },
+}));
+
+const settingsResult: IUniversalSearchSettings = {
+  type: EUniversalSearchType.Settings,
+  payload: {
+    title: 'Notifications',
+    icon: 'BellOutline',
+    sectionName: 'Preferences',
+    sectionTitle: 'Preferences',
+    sectionIcon: 'SliderThreeOutline',
+  },
+};
+
+describe('UniversalSearchSettingsItem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps the modal entry source on result click events', () => {
+    const { getByTestId } = render(
+      <UniversalSearchSettingsItem
+        item={settingsResult}
+        getSearchInput={() => 'notifications'}
+        source={EUniversalSearchSource.Browser}
+      />,
+    );
+
+    fireEvent.click(getByTestId('settings-result'));
+
+    expect(mockUniversalSearchClick).toHaveBeenCalledWith({
+      source: EUniversalSearchSource.Browser,
+      searchText: 'notifications',
+      type: EUniversalSearchType.Settings,
+      itemId: 'Preferences',
+      itemTitle: 'Notifications',
+    });
+  });
+});

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchSettingsItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchSettingsItem.tsx
@@ -10,16 +10,21 @@ import type { IModalSettingParamList } from '@onekeyhq/shared/src/routes';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalSettingRoutes } from '@onekeyhq/shared/src/routes/setting';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
-import type { IUniversalSearchSettings } from '@onekeyhq/shared/types/search';
+import type {
+  EUniversalSearchSource,
+  IUniversalSearchSettings,
+} from '@onekeyhq/shared/types/search';
 
 interface IUniversalSearchSettingsItemProps {
   item: IUniversalSearchSettings;
   getSearchInput: () => string;
+  source: EUniversalSearchSource;
 }
 
 export function UniversalSearchSettingsItem({
   item,
   getSearchInput,
+  source,
 }: IUniversalSearchSettingsItemProps) {
   const navigation = useAppNavigation();
   const universalSearchActions = useUniversalSearchActions();
@@ -27,6 +32,7 @@ export function UniversalSearchSettingsItem({
     item.payload;
   const handlePress = useCallback(async () => {
     defaultLogger.universalSearch.search.universalSearchClick({
+      source,
       searchText: getSearchInput(),
       type: item.type,
       itemId: settingRoute ?? sectionName ?? title,
@@ -74,6 +80,7 @@ export function UniversalSearchSettingsItem({
     title,
     item.type,
     getSearchInput,
+    source,
   ]);
 
   return (

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -37,7 +37,10 @@ import {
   formatTokenSymbolForDisplay,
   getTokenPriceChangeStyle,
 } from '@onekeyhq/shared/src/utils/tokenUtils';
-import type { IUniversalSearchV2MarketToken } from '@onekeyhq/shared/types/search';
+import type {
+  EUniversalSearchSource,
+  IUniversalSearchV2MarketToken,
+} from '@onekeyhq/shared/types/search';
 
 import { MarketStarV2Deferred } from '../../../Market/components/MarketStarV2Deferred';
 import { MarketTokenIcon } from '../../../Market/components/MarketTokenIcon';
@@ -154,12 +157,14 @@ interface IUniversalSearchMarketTokenItemProps {
   item: IUniversalSearchV2MarketToken;
   isTrending?: boolean;
   getSearchInput?: () => string;
+  source: EUniversalSearchSource;
 }
 
 export function UniversalSearchV2MarketTokenItem({
   item,
   isTrending,
   getSearchInput,
+  source,
 }: IUniversalSearchMarketTokenItemProps) {
   // Ensure market watch list atom is initialized
   const [{ isMounted }] = useMarketWatchListV2Atom();
@@ -212,6 +217,7 @@ export function UniversalSearchV2MarketTokenItem({
     const searchText = getSearchInput?.();
     if (searchText) {
       defaultLogger.universalSearch.search.universalSearchClick({
+        source,
         searchText,
         type: item.type,
         itemId: address ?? symbol ?? '',
@@ -269,6 +275,7 @@ export function UniversalSearchV2MarketTokenItem({
     item.type,
     toMarketDetailPage,
     appNavigation,
+    source,
   ]);
 
   if (!isMounted) {

--- a/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
+++ b/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
@@ -39,6 +39,7 @@ import type {
 } from '@onekeyhq/shared/types/search';
 import {
   ESearchStatus,
+  EUniversalSearchSource,
   EUniversalSearchType,
 } from '@onekeyhq/shared/types/search';
 
@@ -166,9 +167,11 @@ const isMarketSection = (tabIndex: number) => tabIndex === MARKET_TAB_INDEX;
 export function UniversalSearch({
   filterTypes,
   initialTab,
+  source,
 }: {
   filterTypes?: EUniversalSearchType[];
   initialTab?: 'market' | 'dapp';
+  source: EUniversalSearchSource;
 }) {
   const intl = useIntl();
   const { activeAccount } = useActiveAccount({ num: 0 });
@@ -609,12 +612,13 @@ export function UniversalSearch({
         .map((s) => `${getSearchTypeTrackingName(s.type)}:${s.count}`)
         .join(',');
       defaultLogger.universalSearch.search.universalSearchQuery({
+        source,
         searchText: input,
         resultCount,
         exposedTypes,
       });
     },
-    [],
+    [source],
   );
 
   const isSearchResultStale = useCallback((input: string) => {
@@ -827,6 +831,7 @@ export function UniversalSearch({
               item={item}
               contextNetworkId={activeAccount?.network?.id}
               getSearchInput={getSearchInput}
+              source={source}
             />
           );
         case EUniversalSearchType.V2MarketToken:
@@ -841,6 +846,7 @@ export function UniversalSearch({
                 item={item}
                 isTrending={searchStatus === ESearchStatus.init}
                 getSearchInput={getSearchInput}
+                source={source}
               />
             </>
           );
@@ -850,6 +856,7 @@ export function UniversalSearch({
               item={item}
               allAggregateTokenMap={allAggregateTokenMap}
               getSearchInput={getSearchInput}
+              source={source}
             />
           );
         case EUniversalSearchType.Dapp:
@@ -857,6 +864,7 @@ export function UniversalSearch({
             <UniversalSearchDappItem
               item={item}
               getSearchInput={getSearchInput}
+              source={source}
             />
           );
         case EUniversalSearchType.Perp:
@@ -864,6 +872,7 @@ export function UniversalSearch({
             <UniversalSearchPerpItem
               item={item}
               getSearchInput={getSearchInput}
+              source={source}
             />
           );
         case EUniversalSearchType.Settings:
@@ -871,6 +880,7 @@ export function UniversalSearch({
             <UniversalSearchSettingsItem
               item={item}
               getSearchInput={getSearchInput}
+              source={source}
             />
           );
         default:
@@ -882,6 +892,7 @@ export function UniversalSearch({
       searchStatus,
       allAggregateTokenMap,
       getSearchInput,
+      source,
     ],
   );
 
@@ -1091,6 +1102,7 @@ const UniversalSearchWithHomeTokenListProvider = ({
   // array, so computing it inline in the prop would rebuild the downstream
   // allowedSearchTypeSet memo (and its dependents) on every wrapper re-render.
   const routeFilterTypes = route?.params?.filterTypes;
+  const source = route?.params?.source ?? EUniversalSearchSource.Unknown;
   const filterTypes = useMemo(
     () => routeFilterTypes || getDefaultFilterTypes(),
     [routeFilterTypes],
@@ -1103,6 +1115,7 @@ const UniversalSearchWithHomeTokenListProvider = ({
       <UniversalSearch
         filterTypes={filterTypes}
         initialTab={route?.params?.initialTab}
+        source={source}
       />
     </HomeTokenListProviderMirrorWrapper>
   );

--- a/packages/kit/src/views/UniversalSearch/universalSearchSource.test.ts
+++ b/packages/kit/src/views/UniversalSearch/universalSearchSource.test.ts
@@ -1,0 +1,44 @@
+import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import { EUniversalSearchSource } from '@onekeyhq/shared/types/search';
+
+import { getUniversalSearchSource } from './universalSearchSource';
+
+describe('getUniversalSearchSource', () => {
+  it.each([
+    [ETabRoutes.Home, EUniversalSearchSource.Wallet],
+    [ETabRoutes.BulkSend, EUniversalSearchSource.Wallet],
+    [ETabRoutes.SubPage, EUniversalSearchSource.Wallet],
+    [ETabRoutes.Market, EUniversalSearchSource.Market],
+    [ETabRoutes.Swap, EUniversalSearchSource.Swap],
+    [ETabRoutes.Perp, EUniversalSearchSource.Perps],
+    [ETabRoutes.WebviewPerpTrade, EUniversalSearchSource.Perps],
+    [ETabRoutes.Earn, EUniversalSearchSource.Earn],
+    [ETabRoutes.Discovery, EUniversalSearchSource.Browser],
+    [ETabRoutes.MultiTabBrowser, EUniversalSearchSource.Browser],
+    [ETabRoutes.DeviceManagement, EUniversalSearchSource.DeviceManagement],
+    [ETabRoutes.ReferFriends, EUniversalSearchSource.ReferFriends],
+    [ETabRoutes.Developer, EUniversalSearchSource.Developer],
+  ])('maps desktop tab %s to %s', (tabRoute, expected) => {
+    expect(getUniversalSearchSource(tabRoute)).toBe(expected);
+  });
+
+  it.each([
+    [ETabRoutes.Market, EUniversalSearchSource.Market],
+    [ETabRoutes.Earn, EUniversalSearchSource.Earn],
+    [ETabRoutes.Discovery, EUniversalSearchSource.Browser],
+  ])('maps native Discovery sub-tab %s to %s', (tabRoute, expected) => {
+    expect(getUniversalSearchSource(tabRoute)).toBe(expected);
+  });
+
+  it('maps the current desktop shortcut tab at invocation time', () => {
+    expect(getUniversalSearchSource(ETabRoutes.Swap)).toBe(
+      EUniversalSearchSource.Swap,
+    );
+  });
+
+  it('falls back to unknown when no tab route is available', () => {
+    expect(getUniversalSearchSource(undefined)).toBe(
+      EUniversalSearchSource.Unknown,
+    );
+  });
+});

--- a/packages/kit/src/views/UniversalSearch/universalSearchSource.ts
+++ b/packages/kit/src/views/UniversalSearch/universalSearchSource.ts
@@ -1,0 +1,33 @@
+import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import { EUniversalSearchSource } from '@onekeyhq/shared/types/search';
+
+export function getUniversalSearchSource(
+  tabRoute: ETabRoutes | undefined,
+): EUniversalSearchSource {
+  switch (tabRoute) {
+    case ETabRoutes.Home:
+    case ETabRoutes.BulkSend:
+    case ETabRoutes.SubPage:
+      return EUniversalSearchSource.Wallet;
+    case ETabRoutes.Market:
+      return EUniversalSearchSource.Market;
+    case ETabRoutes.Swap:
+      return EUniversalSearchSource.Swap;
+    case ETabRoutes.Perp:
+    case ETabRoutes.WebviewPerpTrade:
+      return EUniversalSearchSource.Perps;
+    case ETabRoutes.Earn:
+      return EUniversalSearchSource.Earn;
+    case ETabRoutes.Discovery:
+    case ETabRoutes.MultiTabBrowser:
+      return EUniversalSearchSource.Browser;
+    case ETabRoutes.DeviceManagement:
+      return EUniversalSearchSource.DeviceManagement;
+    case ETabRoutes.ReferFriends:
+      return EUniversalSearchSource.ReferFriends;
+    case ETabRoutes.Developer:
+      return EUniversalSearchSource.Developer;
+    default:
+      return EUniversalSearchSource.Unknown;
+  }
+}

--- a/packages/shared/src/logger/scopes/universalSearch/scenes/search.test.ts
+++ b/packages/shared/src/logger/scopes/universalSearch/scenes/search.test.ts
@@ -1,0 +1,64 @@
+import {
+  EUniversalSearchSource,
+  EUniversalSearchType,
+} from '@onekeyhq/shared/types/search';
+
+import { SearchScene } from './search';
+
+describe('SearchScene', () => {
+  it('keeps the source on universal search query events', () => {
+    const scene = new SearchScene();
+    const emitLog = jest
+      .spyOn(scene, '_emitLog')
+      .mockImplementation(() => undefined);
+    const params = {
+      source: EUniversalSearchSource.Wallet,
+      searchText: 'one',
+      resultCount: 2,
+      exposedTypes: 'market:2',
+    };
+
+    scene.universalSearchQuery(params);
+
+    expect(emitLog).toHaveBeenCalledWith(
+      'universalSearchQuery',
+      [params],
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'server' }),
+        expect.objectContaining({ type: 'local' }),
+      ]),
+    );
+  });
+
+  it('keeps the source while normalizing click result types', () => {
+    const scene = new SearchScene();
+    const emitLog = jest
+      .spyOn(scene, '_emitLog')
+      .mockImplementation(() => undefined);
+
+    scene.universalSearchClick({
+      source: EUniversalSearchSource.Browser,
+      searchText: 'eth',
+      type: EUniversalSearchType.V2MarketToken,
+      itemId: 'eth',
+      itemTitle: 'ETH',
+    });
+
+    expect(emitLog).toHaveBeenCalledWith(
+      'universalSearchClick',
+      [
+        {
+          source: EUniversalSearchSource.Browser,
+          searchText: 'eth',
+          type: 'market',
+          itemId: 'eth',
+          itemTitle: 'ETH',
+        },
+      ],
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'server' }),
+        expect.objectContaining({ type: 'local' }),
+      ]),
+    );
+  });
+});

--- a/packages/shared/src/logger/scopes/universalSearch/types.ts
+++ b/packages/shared/src/logger/scopes/universalSearch/types.ts
@@ -1,3 +1,4 @@
+import type { EUniversalSearchSource } from '@onekeyhq/shared/types/search';
 import { EUniversalSearchType } from '@onekeyhq/shared/types/search';
 
 const searchTypeTrackingNameMap: Record<EUniversalSearchType, string> = {
@@ -16,6 +17,10 @@ export function getSearchTypeTrackingName(type: EUniversalSearchType): string {
 
 export interface IUniversalSearchParams {
   /**
+   * Business page where the search modal was opened
+   */
+  source: EUniversalSearchSource;
+  /**
    * The search text entered by the user
    */
   searchText: string;
@@ -30,6 +35,7 @@ export interface IUniversalSearchParams {
 }
 
 export interface ISearchResultClickParams {
+  source: EUniversalSearchSource;
   searchText: string;
   type: EUniversalSearchType;
   itemId: string;

--- a/packages/shared/src/routes/universalSearch.ts
+++ b/packages/shared/src/routes/universalSearch.ts
@@ -1,4 +1,7 @@
-import type { EUniversalSearchType } from '../../types/search';
+import type {
+  EUniversalSearchSource,
+  EUniversalSearchType,
+} from '../../types/search';
 
 export enum EUniversalSearchPages {
   UniversalSearch = 'UniversalSearch',
@@ -7,6 +10,7 @@ export enum EUniversalSearchPages {
 
 export type IUniversalSearchParamList = {
   [EUniversalSearchPages.UniversalSearch]: {
+    source: EUniversalSearchSource;
     filterTypes?: EUniversalSearchType[];
     initialTab?: 'market' | 'dapp';
   };

--- a/packages/shared/types/search.ts
+++ b/packages/shared/types/search.ts
@@ -21,6 +21,19 @@ export enum EUniversalSearchType {
   Settings = 'Settings',
 }
 
+export enum EUniversalSearchSource {
+  Wallet = 'wallet',
+  Market = 'market',
+  Swap = 'swap',
+  Perps = 'perps',
+  Earn = 'earn',
+  Browser = 'browser',
+  DeviceManagement = 'deviceManagement',
+  ReferFriends = 'referFriends',
+  Developer = 'developer',
+  Unknown = 'unknown',
+}
+
 export enum ESearchStatus {
   init = 'init',
   loading = 'loading',


### PR DESCRIPTION
## Summary
- Add a stable `source` property to the existing `universalSearchQuery` and `universalSearchClick` events.
- Attribute desktop header entries and keyboard shortcuts to the active business tab, and distinguish the native Discovery segments as `market`, `earn`, and `browser`.
- Preserve existing event names, trigger frequency, click result type normalization, and legacy navigation compatibility through the `unknown` fallback.

## Intent & Context
Growth needs to identify which product page a user was on when using Universal Search. This is intended for the release 6.5.0 hot update and extends the existing events instead of introducing a new search-open event.

## Root Cause
The existing query and click events recorded search content and result metadata but did not retain the route context where the search modal was opened. Universal Search has multiple platform-specific entry points, so the originating page was lost once navigation entered the modal.

## Design Decisions
- Resolve and freeze `source` when opening the search modal, then reuse it for all query and result-click events in that modal session.
- Use a typed shared enum and one route resolver for stable analytics values. Missing legacy route state falls back to `unknown`.
- Map desktop Discovery and MultiTabBrowser to `browser`; on native, map the active Discovery segment to `market`, `earn`, or `browser`.
- Read the current desktop tab at shortcut invocation time.
- Keep UI, search behavior, event names, and event frequency unchanged.

## Changes Detail
- Extend shared Universal Search route and logger contracts with the required `source` property.
- Pass the source through desktop, mobile, web, and extension search entry points.
- Propagate the same source to query events and every result item click event.
- Add resolver, shortcut, logger-scene, and result-click regression coverage.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile / Desktop / Web / Extension
- **Risk Areas**: Route-to-source attribution and platform-specific search entry coverage; user-facing search behavior is unchanged.

## Test plan
- [x] Focused Jest: 4 suites, 22 tests
- [x] `yarn agent:check --profile commit`
- [ ] Manually verify every desktop business tab and the Universal Search shortcut
- [ ] Manually verify iOS/Android Wallet and Discovery Market, Earn, and Browser entries
- [ ] Confirm Query and Click payloads contain the expected `source` in PostHog