### PR TITLE
fix: close device setting select after change(OK-59982)

### DIFF
--- a/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/DeviceSectionGeneral.tsx
+++ b/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/DeviceSectionGeneral.tsx
@@ -226,10 +226,10 @@ export function AutoLockListItem({
 
   const isDisabled = disabled || stateful.loading;
   const handleOpen = useCallback(() => {
-    if (!isDisabled) {
+    if (!isDisabled && !isOpen) {
       setIsOpen(true);
     }
-  }, [isDisabled]);
+  }, [isDisabled, isOpen]);
 
   return (
     <ListItem
@@ -323,10 +323,10 @@ export function AutoShutDownListItem({
 
   const isDisabled = disabled || stateful.loading;
   const handleOpen = useCallback(() => {
-    if (!isDisabled) {
+    if (!isDisabled && !isOpen) {
       setIsOpen(true);
     }
-  }, [isDisabled]);
+  }, [isDisabled, isOpen]);
 
   return (
     <ListItem


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59982](https://onekeyhq.atlassian.net/browse/OK-59982)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Close the Auto lock and Auto shutdown selects after a new duration is chosen.
- Keep the selected value and checkmark synchronized when the select is reopened.

## Intent & Context
Fix [OK-59982](https://onekeyhq.atlassian.net/browse/OK-59982). On OneKey Pro device details, changing the auto-lock or auto-shutdown duration updated the row label, but the select stayed open and continued to show the previous option as selected.

## Root Cause
Each controlled `Select` is nested inside a row-level `ListItem` that opens the select from its `onPress` handler. Selecting an option first closed the select, then the portal event bubbled to the parent row and reopened it in the same interaction. The reopened content retained the previous rendered selection state.

## Design Decisions
Guard the row-level open handler when the select is already open. This preserves the existing full-row click target while preventing a bubbled option click from reopening the controlled select. No component API, device command, or persistence behavior changes are required.

## Changes Detail
- Update the Auto lock and Auto shutdown row handlers to open their selects only from the closed state.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop and Mobile
- **Risk Areas**: Device details select open-state handling only; background device operations and persisted settings are unchanged.

## Test plan
- [x] Reproduced the stale open/checkmark state with a connected OneKey Pro.
- [x] Verified Auto lock closes after changing from 1 to 2 minutes and reopens with the 2-minute option checked.
- [x] Verified Auto shutdown closes after changing from 10 to 20 minutes and reopens with the 20-minute option checked.
- [x] Confirmed the fix with user self-testing.
- [x] Ran `yarn agent:check --profile commit`.


[OK-59982]: https://onekeyhq.atlassian.net/browse/OK-59982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ