### PR TITLE
fix: prevent mobile market tabs from jumping OK-55394

### DIFF
--- a/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx
@@ -870,6 +870,7 @@ function MobileLayoutComponent({
         renderTabBar={renderTabBar}
         initialTabName={selectedTabName}
         onTabChange={onTabChangeHandler}
+        tabPressAnimationEnabled={false}
         useNativeHeaderAnimation={useNativeHeaderAnimation}
         pagerProps={pagerProps}
         {...containerProps}

--- a/patches/react-native-collapsible-tab-view+8.0.1.patch
+++ b/patches/react-native-collapsible-tab-view+8.0.1.patch
@@ -12,10 +12,10 @@ index 83c5549..f0b35e5 100644
  export { MaterialTabBar } from './MaterialTabBar/TabBar';
  export { MaterialTabItem } from './MaterialTabBar/TabItem';
 diff --git a/node_modules/react-native-collapsible-tab-view/lib/typescript/src/types.d.ts b/node_modules/react-native-collapsible-tab-view/lib/typescript/src/types.d.ts
-index 7a739fc..10c5d9a 100644
+index 7a739fc..60d1ba0 100644
 --- a/node_modules/react-native-collapsible-tab-view/lib/typescript/src/types.d.ts
 +++ b/node_modules/react-native-collapsible-tab-view/lib/typescript/src/types.d.ts
-@@ -94,6 +94,14 @@ export type CollapsibleProps = {
+@@ -94,6 +94,20 @@ export type CollapsibleProps = {
       * @default false
       */
      allowHeaderOverscroll?: boolean;
@@ -27,10 +27,16 @@ index 7a739fc..10c5d9a 100644
 +     * @default false
 +     */
 +    useNativeHeaderAnimation?: boolean;
++    /**
++     * Whether tab presses should animate the underlying pager between pages.
++     *
++     * @default true
++     */
++    tabPressAnimationEnabled?: boolean;
  };
  export type ContextType<T extends TabName = TabName> = {
      headerHeight: number;
-@@ -174,6 +182,8 @@ export type ContextType<T extends TabName = TabName> = {
+@@ -174,6 +188,8 @@ export type ContextType<T extends TabName = TabName> = {
       */
      allowHeaderOverscroll?: boolean;
      minHeaderHeight: number;
@@ -40,7 +46,7 @@ index 7a739fc..10c5d9a 100644
  export type ScrollViewProps = ComponentProps<typeof Animated.ScrollView>;
  export type CollapsibleStyle = {
 diff --git a/node_modules/react-native-collapsible-tab-view/src/Container.tsx b/node_modules/react-native-collapsible-tab-view/src/Container.tsx
-index e782b90..5b8fc73 100644
+index e782b90..9aa41a4 100644
 --- a/node_modules/react-native-collapsible-tab-view/src/Container.tsx
 +++ b/node_modules/react-native-collapsible-tab-view/src/Container.tsx
 @@ -1,9 +1,15 @@
@@ -60,15 +66,16 @@ index e782b90..5b8fc73 100644
    useAnimatedReaction,
    useAnimatedStyle,
    useDerivedValue,
-@@ -78,6 +84,7 @@ export const Container = React.memo(
+@@ -78,6 +84,8 @@ export const Container = React.memo(
          onTabChange,
          width: customWidth,
          allowHeaderOverscroll,
 +        useNativeHeaderAnimation = false,
++        tabPressAnimationEnabled = true,
        },
        ref
      ) => {
-@@ -95,7 +102,7 @@ export const Container = React.memo(
+@@ -95,7 +103,7 @@ export const Container = React.memo(
        const [tabBarHeight, getTabBarHeight] =
          useLayoutHeight(initialTabBarHeight)
  
@@ -77,7 +84,7 @@ index e782b90..5b8fc73 100644
          !renderHeader ? 0 : initialHeaderHeight
        )
        const initialIndex = React.useMemo(
-@@ -139,10 +146,13 @@ export const Container = React.memo(
+@@ -139,10 +147,13 @@ export const Container = React.memo(
            return tabNames.value[index.value]
          }, [tabNames])
        const calculateNextOffset = useSharedValue(initialIndex)
@@ -93,7 +100,7 @@ index e782b90..5b8fc73 100644
  
        const indexDecimal: ContextType['indexDecimal'] = useSharedValue(
          index.value
-@@ -174,12 +184,15 @@ export const Container = React.memo(
+@@ -174,12 +185,15 @@ export const Container = React.memo(
            return afterRender.value === 1
          },
          (trigger) => {
@@ -111,7 +118,7 @@ index e782b90..5b8fc73 100644
        )
  
        // derived from scrollX
-@@ -194,6 +207,15 @@ export const Container = React.memo(
+@@ -194,6 +208,15 @@ export const Container = React.memo(
          },
          (nextIndex) => {
            if (nextIndex !== null && nextIndex !== index.value) {
@@ -127,7 +134,7 @@ index e782b90..5b8fc73 100644
              calculateNextOffset.value = nextIndex
            }
          },
-@@ -212,25 +234,46 @@ export const Container = React.memo(
+@@ -212,25 +235,46 @@ export const Container = React.memo(
          'worklet'
  
          const name = tabNamesArray[index.value]
@@ -180,7 +187,7 @@ index e782b90..5b8fc73 100644
            runOnJS(toggleSyncScrollFrame)(false)
          }
        }, false)
-@@ -241,54 +284,289 @@ export const Container = React.memo(
+@@ -241,54 +285,298 @@ export const Container = React.memo(
          },
          (i) => {
            if (i !== index.value) {
@@ -459,9 +466,18 @@ index e782b90..5b8fc73 100644
 +      )
 +
 +      const setPageWithFallback = React.useCallback(
-+        (nextIndex: number) => {
++        (nextIndex: number, animated = true) => {
 +          clearPendingPageFallback()
 +          programmaticPageTarget.value = nextIndex
++          if (!animated) {
++            containerRef.current?.setPageWithoutAnimation(nextIndex)
++            if (index.value !== nextIndex) {
++              calculateNextOffset.value = nextIndex
++              indexDecimal.value = nextIndex
++            }
++            programmaticPageTarget.value = null
++            return
++          }
 +          containerRef.current?.setPage(nextIndex)
 +
 +          if (Platform.OS !== 'ios') {
@@ -484,32 +500,32 @@ index e782b90..5b8fc73 100644
 +      )
 +
 +      const syncToTabIndex = React.useCallback(
-+        (nextIndex: number) => {
++        (nextIndex: number, animated = true) => {
 +          if (nextIndex === index.value) {
 +            return
 +          }
-+          setPageWithFallback(nextIndex)
++          setPageWithFallback(nextIndex, animated)
 +        },
 +        [index, setPageWithFallback]
 +      )
  
        const onTabPress = React.useCallback(
          (name: TabName) => {
-@@ -303,11 +581,11 @@ export const Container = React.memo(
+@@ -303,11 +591,11 @@ export const Container = React.memo(
                true
              )
            } else {
 -            containerRef.current?.setPage(i)
-+            syncToTabIndex(i)
++            syncToTabIndex(i, tabPressAnimationEnabled)
            }
          },
          // eslint-disable-next-line react-hooks/exhaustive-deps
 -        [containerRef, refMap, contentInset]
-+        [contentInset, refMap, syncToTabIndex]
++        [contentInset, refMap, syncToTabIndex, tabPressAnimationEnabled]
        )
  
        useAnimatedReaction(
-@@ -344,57 +622,96 @@ export const Container = React.memo(
+@@ -344,57 +632,96 @@ export const Container = React.memo(
            getCurrentIndex: () => {
              return index.value
            },
@@ -645,7 +661,7 @@ index e782b90..5b8fc73 100644
                  pointerEvents="box-none"
                >
                  {renderHeader &&
-@@ -407,10 +724,11 @@ export const Container = React.memo(
+@@ -407,10 +734,11 @@ export const Container = React.memo(
                      onTabPress,
                      tabProps,
                    })}
@@ -659,7 +675,7 @@ index e782b90..5b8fc73 100644
                  pointerEvents="box-none"
                >
                  {renderTabBar &&
-@@ -425,13 +743,15 @@ export const Container = React.memo(
+@@ -425,13 +753,15 @@ export const Container = React.memo(
                      tabProps,
                    })}
                </View>
@@ -1304,10 +1320,10 @@ index 3d0be9d..f9ac35e 100644
  export type { HeaderMeasurements } from './hooks'
  
 diff --git a/node_modules/react-native-collapsible-tab-view/src/types.ts b/node_modules/react-native-collapsible-tab-view/src/types.ts
-index 00fbafc..f1e5c74 100644
+index 00fbafc..c8a4639 100644
 --- a/node_modules/react-native-collapsible-tab-view/src/types.ts
 +++ b/node_modules/react-native-collapsible-tab-view/src/types.ts
-@@ -132,6 +132,15 @@ export type CollapsibleProps = {
+@@ -132,6 +132,22 @@ export type CollapsibleProps = {
     * @default false
     */
    allowHeaderOverscroll?: boolean
@@ -1320,10 +1336,17 @@ index 00fbafc..f1e5c74 100644
 +   * @default false
 +   */
 +  useNativeHeaderAnimation?: boolean
++
++  /**
++   * Whether tab presses should animate the underlying pager between pages.
++   *
++   * @default true
++   */
++  tabPressAnimationEnabled?: boolean
  }
  
  export type ContextType<T extends TabName = TabName> = {
-@@ -223,6 +232,9 @@ export type ContextType<T extends TabName = TabName> = {
+@@ -223,6 +239,9 @@ export type ContextType<T extends TabName = TabName> = {
    allowHeaderOverscroll?: boolean
  
    minHeaderHeight: number


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-55394](https://onekeyhq.atlassian.net/browse/OK-55394)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- disable animated native pager transitions when pressing Market Home tabs
- keep tab presses aligned with the requested destination instead of emitting intermediate page selections

## Root cause

The native pager used animated `setPage` transitions for tab presses. When jumping across multiple positions, Android emitted callbacks for intermediate pages, which briefly updated the active Market tab before the pager reached the requested tab.

## Impact

Market Home tab presses on iOS and Android now switch directly to the selected tab. Web and desktop behavior is unchanged.

## Validation

- verified on an Android emulator by switching repeatedly between Favorites, Trending, Stocks, and Perps; each transition emitted only the requested target and rendered its content
- `yarn jest packages/kit/src/views/Market/MarketHomeV2/layouts/hooks/useSyncedMarketTab.test.ts packages/kit/src/views/Market/MarketHomeV2/layouts/marketTabSelectionGuards.test.ts packages/kit/src/views/Market/MarketHomeV2/layouts/marketTabChangeGuards.test.ts --runInBand` (21 tests passed)
- `yarn agent:check --profile commit`

Issue: OK-55394

[OK-55394]: https://onekeyhq.atlassian.net/browse/OK-55394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ