### PR TITLE
fix: preserve optional prerelease firmware integrity

### DIFF
--- a/packages/kit-bg/src/desktopApis/DesktopApiFirmwareArtifact.test.ts
+++ b/packages/kit-bg/src/desktopApis/DesktopApiFirmwareArtifact.test.ts
@@ -181,14 +181,16 @@ describe('DesktopApiFirmwareArtifact URL admission', () => {
         allowPreReleaseHosts: 'true' as never,
       }),
     ).rejects.toThrow('ARTIFACT_INVALID_INPUT');
-    // Skipping hostname pinning requires pinned content.
+    // Pre-release admission preserves the optional integrity contract used by
+    // the production config path.
     await expect(
       adapter.download({
         ...input,
+        expectedSize: undefined,
         expectedSha256: undefined,
         allowPreReleaseHosts: true,
       }),
-    ).rejects.toThrow('ARTIFACT_INVALID_INPUT');
+    ).rejects.toThrow('ARTIFACT_NETWORK_FAILED');
     // Admitted: dev flag plus a pinned SHA-256 reaches the network stage.
     await expect(
       adapter.download({ ...input, allowPreReleaseHosts: true }),

--- a/packages/kit-bg/src/desktopApis/DesktopApiFirmwareArtifact.ts
+++ b/packages/kit-bg/src/desktopApis/DesktopApiFirmwareArtifact.ts
@@ -92,10 +92,9 @@ const assertSafeInteger = (value: number, label: string): void => {
 
 // allowPreReleaseHosts is only sent by bg while developer mode +
 // "Use pre-release config" are on: pre-release artifacts live in
-// developer-owned buckets whose hostnames cannot be pinned in advance. The
-// structural checks below still apply, and validateDownloadInput additionally
-// requires a pinned SHA-256 for these downloads, so every admitted artifact is
-// covered by a reviewed hostname or by pinned content.
+// developer-owned buckets whose hostnames cannot be pinned in advance. It only
+// widens hostname admission; all other validation, including optional integrity
+// metadata, stays identical to the production config path.
 export const isFirmwareArtifactUrlAllowed = (
   url: URL,
   options?: { allowPreReleaseHosts?: boolean },
@@ -497,14 +496,6 @@ class DesktopApiFirmwareArtifact implements IFirmwareArtifactAdapter {
   private validateDownloadInput(input: IDownloadInput): void {
     const url = new URL(input.url);
     const allowPreReleaseHosts = input.allowPreReleaseHosts === true;
-    // Dropping hostname pinning is only acceptable against pinned content, so
-    // a pre-release artifact without a pinned digest must never be admitted.
-    if (allowPreReleaseHosts && input.expectedSha256 === undefined) {
-      throw new FirmwareArtifactDesktopError(
-        'ARTIFACT_INVALID_INPUT',
-        'Pre-release firmware artifacts require a pinned SHA-256',
-      );
-    }
     if (!isFirmwareArtifactUrlAllowed(url, { allowPreReleaseHosts })) {
       throw new FirmwareArtifactDesktopError(
         'ARTIFACT_INVALID_INPUT',


### PR DESCRIPTION
## Summary
- Remove the Desktop-only requirement that prerelease firmware downloads include `expectedSha256`.
- Keep `allowPreReleaseHosts` limited to hostname admission while preserving the same optional integrity contract as `config.json`.
- Add regression coverage for prerelease downloads without `fingerprint` or `expectedSize`.

## Intent & Context
QA reproduced a Classic 1S firmware update failure on Desktop 6.5.2 build 2026081129. The update failed before the artifact network request with `ARTIFACT_INVALID_INPUT: Pre-release firmware artifacts require a pinned SHA-256`. Both the live stable and prerelease Classic 1S 3.20.0 entries omit `fingerprint` and `expectedSize`, which are optional for legacy V2/V3 firmware plans.

The intended behavior is for `allowPreReleaseHosts` to widen only hostname admission for developer buckets. Once a URL is admitted, validation must match the stable `data.onekey.so/config.json` path.

## Root Cause
PR #12800 added a Desktop main-process guard requiring `expectedSha256` whenever `allowPreReleaseHosts` was true. The bg runtime sets that flag whenever developer mode and Use pre-release config are enabled, so the guard made optional legacy integrity metadata mandatory only on Desktop prerelease flows. The Classic 1S V2 plan therefore failed before download, SDK execution, bootloader transition, or device write.

## Design Decisions
- Keep the literal-boolean developer gate and hostname bypass unchanged.
- Remove only the extra SHA-256 requirement; do not change manifest parsing, SDK plan construction, native adapters, or firmware execution.
- Preserve HTTPS-only URLs, structural URL validation, redirect rejection, request deadlines, `maxBytes`, response validation, actual SHA-256 calculation, and device-side firmware verification.
- Do not add hashes or sizes to the manifest because legacy V2/V3 integrity metadata remains optional by contract.

## Changes Detail
- `DesktopApiFirmwareArtifact.ts`: make `allowPreReleaseHosts` affect hostname admission only and remove the prerelease digest guard.
- `DesktopApiFirmwareArtifact.test.ts`: verify that an admitted prerelease URL without expected size or SHA-256 reaches the network stage while disabled or malformed flags remain rejected.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Desktop
- **Risk Areas**: With the explicit developer prerelease switch enabled, Desktop can download an unpinned artifact from an HTTPS developer host. Existing size bounds, transport constraints, computed artifact receipts, and device-side firmware verification remain in place. Native already treats these integrity fields as optional, and Web/Extension do not use this external artifact adapter.

## Test plan
- [x] `yarn jest packages/kit-bg/src/desktopApis/DesktopApiFirmwareArtifact.test.ts --runInBand` (8/8)
- [x] `yarn jest packages/kit-bg/src/services/ServiceFirmwareUpdate/FirmwareUpdateCapabilities.test.ts --runInBand` (33/33)
- [x] `yarn agent:check --profile commit`
- [ ] On Desktop, enable developer mode and Use pre-release config, then complete a Classic 1S forced firmware update with the live 3.20.0 entry.