### PR TITLE
fix: stabilize mobile chart height OK-58198 OK-58394

### DIFF
--- a/packages/kit-bg/src/states/jotai/atomNames.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.ts
@@ -139,6 +139,7 @@ export enum EAtomNames {
   marketSelectedTabAtom = 'marketSelectedTabAtom',
   marketBannerListSortAtom = 'marketBannerListSortAtom',
   marketTokenSelectorConfigAtom = 'marketTokenSelectorConfigAtom',
+  marketTradingViewSubIndicatorCountPersistAtom = 'marketTradingViewSubIndicatorCountPersistAtom',
   marketCurrentTokenLiveDataAtom = 'marketCurrentTokenLiveDataAtom',
 
   // account selector values (async loaded)

--- a/packages/kit-bg/src/states/jotai/atoms/market.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/market.ts
@@ -72,8 +72,18 @@ export const {
   },
 });
 
+export type IMarketTradingViewStorageNamespace =
+  | 'market'
+  | 'market-hyperliquid';
+
 export interface IMarketTradingViewSubIndicatorCountPersistAtom {
-  subIndicatorCount?: number;
+  subIndicatorCountByStorageNamespace: Partial<
+    Record<IMarketTradingViewStorageNamespace, number>
+  >;
+  storageNamespaceByChartKey: Record<
+    string,
+    IMarketTradingViewStorageNamespace
+  >;
 }
 
 export const {
@@ -82,5 +92,8 @@ export const {
 } = globalAtom<IMarketTradingViewSubIndicatorCountPersistAtom>({
   persist: true,
   name: EAtomNames.marketTradingViewSubIndicatorCountPersistAtom,
-  initialValue: {},
+  initialValue: {
+    subIndicatorCountByStorageNamespace: {},
+    storageNamespaceByChartKey: {},
+  },
 });

--- a/packages/kit-bg/src/states/jotai/atoms/market.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/market.ts
@@ -71,3 +71,16 @@ export const {
     spotNetworkId: '',
   },
 });
+
+export interface IMarketTradingViewSubIndicatorCountPersistAtom {
+  subIndicatorCount?: number;
+}
+
+export const {
+  target: marketTradingViewSubIndicatorCountPersistAtom,
+  use: useMarketTradingViewSubIndicatorCountPersistAtom,
+} = globalAtom<IMarketTradingViewSubIndicatorCountPersistAtom>({
+  persist: true,
+  name: EAtomNames.marketTradingViewSubIndicatorCountPersistAtom,
+  initialValue: {},
+});

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/TradingViewV2ChartControls.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/TradingViewV2ChartControls.tsx
@@ -5,6 +5,7 @@ export {
   TradingViewV2ChartControlsContainer,
   getTradingViewNativeSubIndicatorCount,
   getTradingViewNativeSubIndicatorCountFromOptions,
+  getTradingViewNativeSubIndicatorCountForSnapshot,
   useNativeIndicatorActiveValues,
 } from './chartControls/TradingViewV2ChartControlsContainer';
 export type {

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/chartControls/TradingViewV2ChartControlsContainer.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/chartControls/TradingViewV2ChartControlsContainer.tsx
@@ -44,6 +44,7 @@ export { useNativeIndicatorActiveValues } from '../indicatorControls/hooks/useNa
 export {
   getTradingViewNativeSubIndicatorCount,
   getTradingViewNativeSubIndicatorCountFromOptions,
+  getTradingViewNativeSubIndicatorCountForSnapshot,
 } from '../indicatorControls/hooks/useNativeIndicatorActiveValues';
 export {
   TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT,

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/NativeIndicatorControls.test.tsx
@@ -123,6 +123,7 @@ function createNativeIndicatorState(): ITradingViewNativeIndicatorState {
   return {
     activeIndicatorValues,
     isInitialized: true,
+    sourceIndicators: nativeChartControlsConfig.indicators,
     getActiveIndicatorValues: () => activeIndicatorValues,
     updateActiveIndicatorValue: jest.fn(),
   };

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/hooks/useNativeIndicatorActiveValues.test.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/hooks/useNativeIndicatorActiveValues.test.tsx
@@ -6,6 +6,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 
 import {
   getNativeIndicatorSelectionUpdates,
+  getTradingViewNativeSubIndicatorCountForSnapshot,
   useNativeIndicatorActiveValues,
   useNativeIndicatorControls,
 } from './useNativeIndicatorActiveValues';
@@ -31,6 +32,35 @@ const nativeChartControlsConfig: ITradingViewNativeChartControlsConfigData = {
 };
 
 describe('native indicator controls', () => {
+  it('uses the count from a new config until app state syncs to that snapshot', () => {
+    const provisionalIndicators = indicators.map((indicator, index) => ({
+      ...indicator,
+      active: index === 0,
+    }));
+    const restoredIndicators = indicators.map((indicator, index) => ({
+      ...indicator,
+      active: index < 3,
+    }));
+
+    expect(
+      getTradingViewNativeSubIndicatorCountForSnapshot({
+        activeIndicatorValues: new Set(['VOL']),
+        configIndicators: restoredIndicators,
+        isInitialized: true,
+        sourceIndicators: provisionalIndicators,
+      }),
+    ).toBe(3);
+
+    expect(
+      getTradingViewNativeSubIndicatorCountForSnapshot({
+        activeIndicatorValues: new Set(['VOL', 'MACD', 'RSI', 'StochRSI']),
+        configIndicators: restoredIndicators,
+        isInitialized: true,
+        sourceIndicators: restoredIndicators,
+      }),
+    ).toBe(4);
+  });
+
   it('sends removals before additions when a dialog swaps indicators', () => {
     expect(
       getNativeIndicatorSelectionUpdates({

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/hooks/useNativeIndicatorActiveValues.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/indicatorControls/hooks/useNativeIndicatorActiveValues.ts
@@ -37,6 +37,7 @@ const MAIN_CHART_INDICATOR_LABEL_SET = new Set<string>([
 export interface ITradingViewNativeIndicatorState {
   activeIndicatorValues: Set<string>;
   isInitialized: boolean;
+  sourceIndicators: ITradingViewIndicatorOption[] | undefined;
   getActiveIndicatorValues: () => ReadonlySet<string>;
   updateActiveIndicatorValue: (
     indicatorValue: string,
@@ -124,6 +125,24 @@ export function getTradingViewNativeSubIndicatorCountFromOptions(
   );
 }
 
+export function getTradingViewNativeSubIndicatorCountForSnapshot({
+  activeIndicatorValues,
+  configIndicators,
+  isInitialized,
+  sourceIndicators,
+}: {
+  activeIndicatorValues: ReadonlySet<string>;
+  configIndicators: ITradingViewIndicatorOption[] | undefined;
+  isInitialized: boolean;
+  sourceIndicators: ITradingViewIndicatorOption[] | undefined;
+}) {
+  if (isInitialized && sourceIndicators === configIndicators) {
+    return getTradingViewNativeSubIndicatorCount(activeIndicatorValues);
+  }
+
+  return getTradingViewNativeSubIndicatorCountFromOptions(configIndicators);
+}
+
 function normalizeTradingViewNativeMaxSubIndicatorCount(
   maxSubIndicatorCount: number | undefined,
 ) {
@@ -198,6 +217,9 @@ export function useNativeIndicatorActiveValues(
     () => new Set<string>(),
   );
   const [isInitialized, setIsInitialized] = useState(false);
+  const [sourceIndicators, setSourceIndicators] = useState<
+    ITradingViewIndicatorOption[] | undefined
+  >(undefined);
   const activeIndicatorValuesRef = useRef(new Set<string>());
   const pendingIndicatorActiveStateRef = useRef(new Map<string, boolean>());
 
@@ -208,6 +230,7 @@ export function useNativeIndicatorActiveValues(
       activeIndicatorValuesRef.current = emptyValues;
       setActiveIndicatorValues(emptyValues);
       setIsInitialized(false);
+      setSourceIndicators(undefined);
       return;
     }
 
@@ -229,6 +252,7 @@ export function useNativeIndicatorActiveValues(
     activeIndicatorValuesRef.current = activeValues;
     setActiveIndicatorValues(activeValues);
     setIsInitialized(true);
+    setSourceIndicators(indicators);
   }, [indicators]);
 
   const getActiveIndicatorValues = useCallback(
@@ -255,6 +279,7 @@ export function useNativeIndicatorActiveValues(
     () => ({
       activeIndicatorValues,
       isInitialized,
+      sourceIndicators,
       getActiveIndicatorValues,
       updateActiveIndicatorValue,
     }),
@@ -262,6 +287,7 @@ export function useNativeIndicatorActiveValues(
       activeIndicatorValues,
       getActiveIndicatorValues,
       isInitialized,
+      sourceIndicators,
       updateActiveIndicatorValue,
     ],
   );

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
@@ -128,7 +128,10 @@ interface IBaseTradingViewV2Props {
   enableNativeIntervalSelector?: boolean;
   maxNativeSubIndicatorCount?: number;
   // `null` means the WebView controls configuration is not ready.
-  onNativeSubIndicatorCountChange?: (count: number | null) => void;
+  onNativeSubIndicatorCountChange?: (
+    count: number | null,
+    options?: { layoutRestored?: boolean },
+  ) => void;
   nativeChartTypeControlMode?: ITradingViewNativeChartTypeControlMode;
   nativeIndicatorControlMode?: ITradingViewNativeIndicatorControlMode;
   nativeIntervalControlMode?: ITradingViewNativeIntervalControlMode;
@@ -248,10 +251,14 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
     }
     onNativeSubIndicatorCountChange?.(
       hasNativeChartControlsConfig ? nativeSubIndicatorCount : null,
+      hasNativeChartControlsConfig
+        ? { layoutRestored: nativeChartControlsConfig?.layoutRestored }
+        : undefined,
     );
   }, [
     enableNativeChartControls,
     hasNativeChartControlsConfig,
+    nativeChartControlsConfig?.layoutRestored,
     nativeSubIndicatorCount,
     onNativeSubIndicatorCountChange,
   ]);

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/TradingViewV2.tsx
@@ -36,8 +36,7 @@ import {
   type ITradingViewNativePriceMarketCapControlMode,
   TradingViewNativeIndicatorQuickBar,
   TradingViewV2ChartControlsContainer,
-  getTradingViewNativeSubIndicatorCount,
-  getTradingViewNativeSubIndicatorCountFromOptions,
+  getTradingViewNativeSubIndicatorCountForSnapshot,
   useNativeIndicatorActiveValues,
 } from '../TradingViewV2ChartControls';
 
@@ -219,29 +218,19 @@ export const TradingViewV2 = (props: ITradingViewV2Props & WebViewProps) => {
   const hasNativeChartControlsConfig = Boolean(nativeChartControlsConfig);
   const isNativeChartControlsReady =
     !enableNativeChartControls || hasNativeChartControlsConfig;
-  const nativeSubIndicatorCountFromConfig = useMemo(
-    () =>
-      getTradingViewNativeSubIndicatorCountFromOptions(
-        nativeChartControlsConfig?.indicators,
-      ),
-    [nativeChartControlsConfig?.indicators],
-  );
-  const nativeSubIndicatorCountFromAppState = useMemo(
-    () =>
-      getTradingViewNativeSubIndicatorCount(
-        nativeIndicatorState.activeIndicatorValues,
-      ),
-    [nativeIndicatorState.activeIndicatorValues],
-  );
   const nativeSubIndicatorCount = useMemo(
     () =>
-      nativeIndicatorState.isInitialized
-        ? nativeSubIndicatorCountFromAppState
-        : nativeSubIndicatorCountFromConfig,
+      getTradingViewNativeSubIndicatorCountForSnapshot({
+        activeIndicatorValues: nativeIndicatorState.activeIndicatorValues,
+        configIndicators: nativeChartControlsConfig?.indicators,
+        isInitialized: nativeIndicatorState.isInitialized,
+        sourceIndicators: nativeIndicatorState.sourceIndicators,
+      }),
     [
+      nativeChartControlsConfig?.indicators,
+      nativeIndicatorState.activeIndicatorValues,
       nativeIndicatorState.isInitialized,
-      nativeSubIndicatorCountFromAppState,
-      nativeSubIndicatorCountFromConfig,
+      nativeIndicatorState.sourceIndicators,
     ],
   );
 

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.test.ts
@@ -1,0 +1,13 @@
+import { normalizeTradingViewLayoutRestored } from './nativeChartControlsConfigUtils';
+
+describe('normalizeTradingViewLayoutRestored', () => {
+  it('preserves explicit restoration state', () => {
+    expect(normalizeTradingViewLayoutRestored(true)).toBe(true);
+    expect(normalizeTradingViewLayoutRestored(false)).toBe(false);
+  });
+
+  it('returns undefined for legacy or invalid values', () => {
+    expect(normalizeTradingViewLayoutRestored(undefined)).toBeUndefined();
+    expect(normalizeTradingViewLayoutRestored('true')).toBeUndefined();
+  });
+});

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.ts
@@ -1,0 +1,3 @@
+export function normalizeTradingViewLayoutRestored(value: unknown) {
+  return typeof value === 'boolean' ? value : undefined;
+}

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
@@ -13,6 +13,7 @@ import {
   shouldMockEmptyKLineData,
 } from './klineDataHandler';
 import { handleLayoutUpdate } from './layoutUpdateHandler';
+import { normalizeTradingViewLayoutRestored } from './nativeChartControlsConfigUtils';
 
 import type { IMarksTimeRange, IMessageHandlerContext } from './types';
 import type {
@@ -567,6 +568,9 @@ function normalizeNativeChartControlsConfig(
   const resetLayout = normalizeResetLayout(data.resetLayout);
   const priceMarketCap = normalizePriceMarketCap(data.priceMarketCap);
   const priceScale = normalizePriceScale(data.priceScale);
+  const layoutRestored = normalizeTradingViewLayoutRestored(
+    data.layoutRestored,
+  );
 
   return {
     ...(intervals?.length ? { intervals } : {}),
@@ -583,6 +587,7 @@ function normalizeNativeChartControlsConfig(
     ...(resetLayout ? { resetLayout } : {}),
     ...(priceMarketCap ? { priceMarketCap } : {}),
     ...(priceScale ? { priceScale } : {}),
+    ...(layoutRestored !== undefined ? { layoutRestored } : {}),
     ...(typeof data.timestamp === 'number' && Number.isFinite(data.timestamp)
       ? { timestamp: data.timestamp }
       : {}),

--- a/packages/kit/src/components/TradingView/TradingViewV2/types.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/types.ts
@@ -97,6 +97,7 @@ export interface ITradingViewNativeChartControlsConfigData {
     options: ITradingViewPriceScaleOption[];
     activeMode: ITradingViewPriceScaleMode;
   };
+  layoutRestored?: boolean;
   timestamp?: number;
 }
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketTradingView/MarketTradingView.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketTradingView/MarketTradingView.tsx
@@ -84,6 +84,7 @@ export interface IMarketTradingViewProps {
   onPanesCountChange?: (count: number) => void;
   isNative?: boolean;
   dataSource: 'websocket' | 'polling';
+  storageNamespace?: string;
   pageWidth?: number;
   nativeChartTypeControlMode?: 'toggle' | 'select';
   nativeIndicatorControlMode?: 'dialog' | 'popover';
@@ -111,6 +112,7 @@ export const MarketTradingView = memo(
     tokenSymbol = '',
     decimal = 8,
     dataSource,
+    storageNamespace,
     pageWidth,
     nativeChartTypeControlMode,
     nativeIndicatorControlMode,
@@ -169,6 +171,7 @@ export const MarketTradingView = memo(
         networkId={networkId}
         decimal={decimal}
         dataSource={dataSource}
+        storageNamespace={storageNamespace}
         accountAddress={accountAddress}
         w={pageWidth}
         onTouchScroll={onTouchScroll}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/MarketTradingView/MarketTradingView.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/MarketTradingView/MarketTradingView.tsx
@@ -97,7 +97,10 @@ export interface IMarketTradingViewProps {
   onNativeIndicatorQuickBarChange?: (quickBar: ReactNode | null) => void;
   onIndicatorsDialogOpenChange?: (isOpen: boolean) => void;
   onInteractionOverlayOpenChange?: (isOpen: boolean) => void;
-  onNativeSubIndicatorCountChange?: (count: number | null) => void;
+  onNativeSubIndicatorCountChange?: (
+    count: number | null,
+    options?: { layoutRestored?: boolean },
+  ) => void;
   maxNativeSubIndicatorCount?: number;
 }
 

--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/useTradingViewSubIndicatorCount.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/useTradingViewSubIndicatorCount.test.ts
@@ -7,20 +7,27 @@ import { act, renderHook } from '@testing-library/react';
 import { useTradingViewSubIndicatorCount } from './useTradingViewSubIndicatorCount';
 
 const DEFAULT_COUNT = 1;
+const MAX_COUNT = 4;
 const STABILIZATION_DELAY_MS = 500;
 
 function useTestSubIndicatorCount({
   chartKey = 'chart-a',
+  initialCount = DEFAULT_COUNT,
   stabilizeInitialCount = true,
+  onCountSettled,
 }: {
   chartKey?: string;
+  initialCount?: number;
   stabilizeInitialCount?: boolean;
+  onCountSettled?: (count: number) => void;
 }) {
   return useTradingViewSubIndicatorCount({
     chartKey,
-    defaultCount: DEFAULT_COUNT,
+    initialCount,
+    maxCount: MAX_COUNT,
     stabilizeInitialCount,
     stabilizationDelayMs: STABILIZATION_DELAY_MS,
+    onCountSettled,
   });
 }
 
@@ -47,10 +54,87 @@ describe('useTradingViewSubIndicatorCount', () => {
 
     act(() => {
       jest.advanceTimersByTime(1);
+    });
+
+    expect(result.current[0]).toBe(1);
+
+    act(() => {
       result.current[1](2);
     });
 
     expect(result.current[0]).toBe(2);
+  });
+
+  it('uses the app-persisted count until TradingView confirms layout restoration', () => {
+    const onCountSettled = jest.fn();
+    const { result } = renderHook(() =>
+      useTestSubIndicatorCount({
+        initialCount: 2,
+        onCountSettled,
+      }),
+    );
+
+    act(() => {
+      result.current[1](0, { layoutRestored: false });
+      jest.advanceTimersByTime(250);
+      result.current[1](1, { layoutRestored: false });
+      jest.advanceTimersByTime(STABILIZATION_DELAY_MS);
+    });
+
+    expect(result.current[0]).toBe(2);
+    expect(onCountSettled).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current[1](2, { layoutRestored: true });
+    });
+
+    expect(result.current[0]).toBe(2);
+    expect(onCountSettled).toHaveBeenCalledWith(2);
+
+    act(() => {
+      result.current[1](3, { layoutRestored: true });
+    });
+
+    expect(result.current[0]).toBe(3);
+  });
+
+  it('falls back to a quiet legacy WebView count when the restored marker is unavailable', () => {
+    const onCountSettled = jest.fn();
+    const { result } = renderHook(() =>
+      useTestSubIndicatorCount({
+        initialCount: 2,
+        onCountSettled,
+      }),
+    );
+
+    act(() => {
+      result.current[1](3);
+      jest.advanceTimersByTime(STABILIZATION_DELAY_MS - 1);
+    });
+
+    expect(result.current[0]).toBe(2);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(result.current[0]).toBe(3);
+    expect(onCountSettled).toHaveBeenCalledWith(3);
+  });
+
+  it('persists a settled count even when it matches the initial fallback', () => {
+    const onCountSettled = jest.fn();
+    const { result } = renderHook(() =>
+      useTestSubIndicatorCount({ onCountSettled }),
+    );
+
+    act(() => {
+      result.current[1](DEFAULT_COUNT);
+      jest.advanceTimersByTime(STABILIZATION_DELAY_MS);
+    });
+
+    expect(result.current[0]).toBe(DEFAULT_COUNT);
+    expect(onCountSettled).toHaveBeenCalledWith(DEFAULT_COUNT);
   });
 
   it('commits a stable initial count after the grace period', () => {
@@ -74,6 +158,23 @@ describe('useTradingViewSubIndicatorCount', () => {
     });
 
     expect(result.current[0]).toBe(0);
+  });
+
+  it('clamps persisted and reported counts to the supported mobile range', () => {
+    const { result } = renderHook(() =>
+      useTestSubIndicatorCount({
+        initialCount: 8,
+        stabilizeInitialCount: false,
+      }),
+    );
+
+    expect(result.current[0]).toBe(MAX_COUNT);
+
+    act(() => {
+      result.current[1](9);
+    });
+
+    expect(result.current[0]).toBe(MAX_COUNT);
   });
 
   it('cancels a pending count when the active chart changes', () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/useTradingViewSubIndicatorCount.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/useTradingViewSubIndicatorCount.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook } from '@testing-library/react';
+
+import { useTradingViewSubIndicatorCount } from './useTradingViewSubIndicatorCount';
+
+const DEFAULT_COUNT = 1;
+const STABILIZATION_DELAY_MS = 500;
+
+function useTestSubIndicatorCount({
+  chartKey = 'chart-a',
+  stabilizeInitialCount = true,
+}: {
+  chartKey?: string;
+  stabilizeInitialCount?: boolean;
+}) {
+  return useTradingViewSubIndicatorCount({
+    chartKey,
+    defaultCount: DEFAULT_COUNT,
+    stabilizeInitialCount,
+    stabilizationDelayMs: STABILIZATION_DELAY_MS,
+  });
+}
+
+describe('useTradingViewSubIndicatorCount', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('coalesces provisional TradingView counts during initial layout restoration', () => {
+    const { result } = renderHook(() => useTestSubIndicatorCount({}));
+
+    act(() => {
+      result.current[1](0);
+      jest.advanceTimersByTime(250);
+      result.current[1](1);
+      jest.advanceTimersByTime(STABILIZATION_DELAY_MS - 1);
+    });
+
+    expect(result.current[0]).toBe(DEFAULT_COUNT);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+      result.current[1](2);
+    });
+
+    expect(result.current[0]).toBe(2);
+  });
+
+  it('commits a stable initial count after the grace period', () => {
+    const { result } = renderHook(() => useTestSubIndicatorCount({}));
+
+    act(() => {
+      result.current[1](0);
+      jest.advanceTimersByTime(STABILIZATION_DELAY_MS);
+    });
+
+    expect(result.current[0]).toBe(0);
+  });
+
+  it('applies counts immediately when initial stabilization is disabled', () => {
+    const { result } = renderHook(() =>
+      useTestSubIndicatorCount({ stabilizeInitialCount: false }),
+    );
+
+    act(() => {
+      result.current[1](0);
+    });
+
+    expect(result.current[0]).toBe(0);
+  });
+
+  it('cancels a pending count when the active chart changes', () => {
+    const { result, rerender } = renderHook(
+      ({ chartKey }: { chartKey: string }) =>
+        useTestSubIndicatorCount({ chartKey }),
+      { initialProps: { chartKey: 'chart-a' } },
+    );
+
+    act(() => {
+      result.current[1](2);
+    });
+    rerender({ chartKey: 'chart-b' });
+
+    act(() => {
+      jest.advanceTimersByTime(STABILIZATION_DELAY_MS);
+    });
+
+    expect(result.current[0]).toBe(DEFAULT_COUNT);
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/useTradingViewSubIndicatorCount.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/useTradingViewSubIndicatorCount.test.ts
@@ -7,7 +7,6 @@ import { act, renderHook } from '@testing-library/react';
 import { useTradingViewSubIndicatorCount } from './useTradingViewSubIndicatorCount';
 
 const DEFAULT_COUNT = 1;
-const MAX_COUNT = 4;
 const STABILIZATION_DELAY_MS = 500;
 
 function useTestSubIndicatorCount({
@@ -24,7 +23,6 @@ function useTestSubIndicatorCount({
   return useTradingViewSubIndicatorCount({
     chartKey,
     initialCount,
-    maxCount: MAX_COUNT,
     stabilizeInitialCount,
     stabilizationDelayMs: STABILIZATION_DELAY_MS,
     onCountSettled,
@@ -122,6 +120,35 @@ describe('useTradingViewSubIndicatorCount', () => {
     expect(onCountSettled).toHaveBeenCalledWith(3);
   });
 
+  it('cancels the legacy fallback after detecting the layout restoration marker', () => {
+    const onCountSettled = jest.fn();
+    const { result } = renderHook(() =>
+      useTestSubIndicatorCount({
+        initialCount: 2,
+        onCountSettled,
+      }),
+    );
+
+    act(() => {
+      result.current[1](0);
+      jest.advanceTimersByTime(STABILIZATION_DELAY_MS / 2);
+      result.current[1](1, { layoutRestored: false });
+      jest.advanceTimersByTime(STABILIZATION_DELAY_MS);
+      result.current[1](0);
+      jest.advanceTimersByTime(STABILIZATION_DELAY_MS);
+    });
+
+    expect(result.current[0]).toBe(2);
+    expect(onCountSettled).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current[1](3, { layoutRestored: true });
+    });
+
+    expect(result.current[0]).toBe(3);
+    expect(onCountSettled).toHaveBeenCalledWith(3);
+  });
+
   it('persists a settled count even when it matches the initial fallback', () => {
     const onCountSettled = jest.fn();
     const { result } = renderHook(() =>
@@ -160,7 +187,7 @@ describe('useTradingViewSubIndicatorCount', () => {
     expect(result.current[0]).toBe(0);
   });
 
-  it('clamps persisted and reported counts to the supported mobile range', () => {
+  it('preserves restored counts above the mobile indicator selection cap', () => {
     const { result } = renderHook(() =>
       useTestSubIndicatorCount({
         initialCount: 8,
@@ -168,13 +195,13 @@ describe('useTradingViewSubIndicatorCount', () => {
       }),
     );
 
-    expect(result.current[0]).toBe(MAX_COUNT);
+    expect(result.current[0]).toBe(8);
 
     act(() => {
       result.current[1](9);
     });
 
-    expect(result.current[0]).toBe(MAX_COUNT);
+    expect(result.current[0]).toBe(9);
   });
 
   it('cancels a pending count when the active chart changes', () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/useTradingViewSubIndicatorCount.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/useTradingViewSubIndicatorCount.ts
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+function normalizeTradingViewSubIndicatorCount(count: number) {
+  if (!Number.isFinite(count)) {
+    return 0;
+  }
+  return Math.max(0, Math.floor(count));
+}
+
+export function useTradingViewSubIndicatorCount({
+  chartKey,
+  defaultCount,
+  stabilizeInitialCount,
+  stabilizationDelayMs,
+}: {
+  chartKey: string;
+  defaultCount: number;
+  stabilizeInitialCount: boolean;
+  stabilizationDelayMs: number;
+}) {
+  const activeChartKeyRef = useRef(chartKey);
+  activeChartKeyRef.current = chartKey;
+  const stabilizedChartKeyRef = useRef<string | null>(
+    stabilizeInitialCount ? null : chartKey,
+  );
+  const stabilizationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const [subIndicatorState, setSubIndicatorState] = useState(() => ({
+    key: chartKey,
+    count: defaultCount,
+  }));
+
+  const cancelPendingStabilization = useCallback(() => {
+    if (stabilizationTimerRef.current !== null) {
+      clearTimeout(stabilizationTimerRef.current);
+      stabilizationTimerRef.current = null;
+    }
+  }, []);
+
+  const commitCount = useCallback((targetChartKey: string, count: number) => {
+    if (activeChartKeyRef.current !== targetChartKey) {
+      return;
+    }
+
+    setSubIndicatorState((prevState) =>
+      prevState.key === targetChartKey && prevState.count === count
+        ? prevState
+        : { key: targetChartKey, count },
+    );
+  }, []);
+
+  useEffect(() => {
+    cancelPendingStabilization();
+    stabilizedChartKeyRef.current = stabilizeInitialCount ? null : chartKey;
+
+    return cancelPendingStabilization;
+  }, [cancelPendingStabilization, chartKey, stabilizeInitialCount]);
+
+  const handleSubIndicatorCountChange = useCallback(
+    (count: number | null) => {
+      const targetChartKey = chartKey;
+      if (activeChartKeyRef.current !== targetChartKey) {
+        return;
+      }
+
+      const nextCount =
+        count === null
+          ? defaultCount
+          : normalizeTradingViewSubIndicatorCount(count);
+
+      if (count === null) {
+        cancelPendingStabilization();
+        stabilizedChartKeyRef.current = stabilizeInitialCount
+          ? null
+          : targetChartKey;
+        commitCount(targetChartKey, nextCount);
+        return;
+      }
+
+      if (
+        !stabilizeInitialCount ||
+        stabilizedChartKeyRef.current === targetChartKey
+      ) {
+        cancelPendingStabilization();
+        commitCount(targetChartKey, nextCount);
+        return;
+      }
+
+      // TradingView can publish a pre-layout snapshot before restoring saved studies.
+      cancelPendingStabilization();
+      stabilizationTimerRef.current = setTimeout(() => {
+        stabilizationTimerRef.current = null;
+        if (activeChartKeyRef.current !== targetChartKey) {
+          return;
+        }
+        stabilizedChartKeyRef.current = targetChartKey;
+        commitCount(targetChartKey, nextCount);
+      }, stabilizationDelayMs);
+    },
+    [
+      cancelPendingStabilization,
+      chartKey,
+      commitCount,
+      defaultCount,
+      stabilizationDelayMs,
+      stabilizeInitialCount,
+    ],
+  );
+
+  const subIndicatorCount =
+    subIndicatorState.key === chartKey ? subIndicatorState.count : defaultCount;
+
+  return [subIndicatorCount, handleSubIndicatorCountChange] as const;
+}

--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/useTradingViewSubIndicatorCount.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/useTradingViewSubIndicatorCount.ts
@@ -1,37 +1,27 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-function normalizeTradingViewSubIndicatorCount({
-  count,
-  maxCount,
-}: {
-  count: number;
-  maxCount: number;
-}) {
+function normalizeTradingViewSubIndicatorCount(count: number) {
   if (!Number.isFinite(count)) {
     return 0;
   }
-  return Math.min(maxCount, Math.max(0, Math.floor(count)));
+  return Math.max(0, Math.floor(count));
 }
 
 export function useTradingViewSubIndicatorCount({
   chartKey,
   initialCount,
-  maxCount,
   stabilizeInitialCount,
   stabilizationDelayMs,
   onCountSettled,
 }: {
   chartKey: string;
   initialCount: number;
-  maxCount: number;
   stabilizeInitialCount: boolean;
   stabilizationDelayMs: number;
   onCountSettled?: (count: number) => void;
 }) {
-  const normalizedInitialCount = normalizeTradingViewSubIndicatorCount({
-    count: initialCount,
-    maxCount,
-  });
+  const normalizedInitialCount =
+    normalizeTradingViewSubIndicatorCount(initialCount);
   const activeChartKeyRef = useRef(chartKey);
   activeChartKeyRef.current = chartKey;
   const stabilizedChartKeyRef = useRef<string | null>(
@@ -40,6 +30,7 @@ export function useTradingViewSubIndicatorCount({
   const stabilizationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const supportsLayoutRestoredRef = useRef(false);
   const [subIndicatorState, setSubIndicatorState] = useState(() => ({
     key: chartKey,
     count: normalizedInitialCount,
@@ -77,6 +68,7 @@ export function useTradingViewSubIndicatorCount({
   useEffect(() => {
     cancelPendingStabilization();
     stabilizedChartKeyRef.current = stabilizeInitialCount ? null : chartKey;
+    supportsLayoutRestoredRef.current = false;
 
     return cancelPendingStabilization;
   }, [cancelPendingStabilization, chartKey, stabilizeInitialCount]);
@@ -91,14 +83,33 @@ export function useTradingViewSubIndicatorCount({
       const nextCount =
         count === null
           ? normalizedInitialCount
-          : normalizeTradingViewSubIndicatorCount({ count, maxCount });
+          : normalizeTradingViewSubIndicatorCount(count);
 
       if (count === null) {
         cancelPendingStabilization();
         stabilizedChartKeyRef.current = stabilizeInitialCount
           ? null
           : targetChartKey;
+        supportsLayoutRestoredRef.current = false;
         commitCount(targetChartKey, nextCount);
+        return;
+      }
+
+      if (stabilizeInitialCount && options?.layoutRestored === false) {
+        cancelPendingStabilization();
+        supportsLayoutRestoredRef.current = true;
+        return;
+      }
+
+      if (stabilizeInitialCount && options?.layoutRestored === true) {
+        cancelPendingStabilization();
+        supportsLayoutRestoredRef.current = true;
+        stabilizedChartKeyRef.current = targetChartKey;
+        commitCount(targetChartKey, nextCount, { notifySettled: true });
+        return;
+      }
+
+      if (supportsLayoutRestoredRef.current) {
         return;
       }
 
@@ -107,18 +118,6 @@ export function useTradingViewSubIndicatorCount({
         stabilizedChartKeyRef.current === targetChartKey
       ) {
         cancelPendingStabilization();
-        commitCount(targetChartKey, nextCount, { notifySettled: true });
-        return;
-      }
-
-      // Keep the app-provided initial height while the WebView restores its template.
-      if (options?.layoutRestored === false) {
-        return;
-      }
-
-      if (options?.layoutRestored) {
-        cancelPendingStabilization();
-        stabilizedChartKeyRef.current = targetChartKey;
         commitCount(targetChartKey, nextCount, { notifySettled: true });
         return;
       }
@@ -138,7 +137,6 @@ export function useTradingViewSubIndicatorCount({
       cancelPendingStabilization,
       chartKey,
       commitCount,
-      maxCount,
       normalizedInitialCount,
       stabilizationDelayMs,
       stabilizeInitialCount,

--- a/packages/kit/src/views/Market/MarketDetailV2/hooks/useTradingViewSubIndicatorCount.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/hooks/useTradingViewSubIndicatorCount.ts
@@ -1,23 +1,37 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-function normalizeTradingViewSubIndicatorCount(count: number) {
+function normalizeTradingViewSubIndicatorCount({
+  count,
+  maxCount,
+}: {
+  count: number;
+  maxCount: number;
+}) {
   if (!Number.isFinite(count)) {
     return 0;
   }
-  return Math.max(0, Math.floor(count));
+  return Math.min(maxCount, Math.max(0, Math.floor(count)));
 }
 
 export function useTradingViewSubIndicatorCount({
   chartKey,
-  defaultCount,
+  initialCount,
+  maxCount,
   stabilizeInitialCount,
   stabilizationDelayMs,
+  onCountSettled,
 }: {
   chartKey: string;
-  defaultCount: number;
+  initialCount: number;
+  maxCount: number;
   stabilizeInitialCount: boolean;
   stabilizationDelayMs: number;
+  onCountSettled?: (count: number) => void;
 }) {
+  const normalizedInitialCount = normalizeTradingViewSubIndicatorCount({
+    count: initialCount,
+    maxCount,
+  });
   const activeChartKeyRef = useRef(chartKey);
   activeChartKeyRef.current = chartKey;
   const stabilizedChartKeyRef = useRef<string | null>(
@@ -28,7 +42,7 @@ export function useTradingViewSubIndicatorCount({
   );
   const [subIndicatorState, setSubIndicatorState] = useState(() => ({
     key: chartKey,
-    count: defaultCount,
+    count: normalizedInitialCount,
   }));
 
   const cancelPendingStabilization = useCallback(() => {
@@ -38,17 +52,27 @@ export function useTradingViewSubIndicatorCount({
     }
   }, []);
 
-  const commitCount = useCallback((targetChartKey: string, count: number) => {
-    if (activeChartKeyRef.current !== targetChartKey) {
-      return;
-    }
+  const commitCount = useCallback(
+    (
+      targetChartKey: string,
+      count: number,
+      options?: { notifySettled?: boolean },
+    ) => {
+      if (activeChartKeyRef.current !== targetChartKey) {
+        return;
+      }
 
-    setSubIndicatorState((prevState) =>
-      prevState.key === targetChartKey && prevState.count === count
-        ? prevState
-        : { key: targetChartKey, count },
-    );
-  }, []);
+      setSubIndicatorState((prevState) =>
+        prevState.key === targetChartKey && prevState.count === count
+          ? prevState
+          : { key: targetChartKey, count },
+      );
+      if (options?.notifySettled) {
+        onCountSettled?.(count);
+      }
+    },
+    [onCountSettled],
+  );
 
   useEffect(() => {
     cancelPendingStabilization();
@@ -58,7 +82,7 @@ export function useTradingViewSubIndicatorCount({
   }, [cancelPendingStabilization, chartKey, stabilizeInitialCount]);
 
   const handleSubIndicatorCountChange = useCallback(
-    (count: number | null) => {
+    (count: number | null, options?: { layoutRestored?: boolean }) => {
       const targetChartKey = chartKey;
       if (activeChartKeyRef.current !== targetChartKey) {
         return;
@@ -66,8 +90,8 @@ export function useTradingViewSubIndicatorCount({
 
       const nextCount =
         count === null
-          ? defaultCount
-          : normalizeTradingViewSubIndicatorCount(count);
+          ? normalizedInitialCount
+          : normalizeTradingViewSubIndicatorCount({ count, maxCount });
 
       if (count === null) {
         cancelPendingStabilization();
@@ -83,7 +107,19 @@ export function useTradingViewSubIndicatorCount({
         stabilizedChartKeyRef.current === targetChartKey
       ) {
         cancelPendingStabilization();
-        commitCount(targetChartKey, nextCount);
+        commitCount(targetChartKey, nextCount, { notifySettled: true });
+        return;
+      }
+
+      // Keep the app-provided initial height while the WebView restores its template.
+      if (options?.layoutRestored === false) {
+        return;
+      }
+
+      if (options?.layoutRestored) {
+        cancelPendingStabilization();
+        stabilizedChartKeyRef.current = targetChartKey;
+        commitCount(targetChartKey, nextCount, { notifySettled: true });
         return;
       }
 
@@ -95,21 +131,24 @@ export function useTradingViewSubIndicatorCount({
           return;
         }
         stabilizedChartKeyRef.current = targetChartKey;
-        commitCount(targetChartKey, nextCount);
+        commitCount(targetChartKey, nextCount, { notifySettled: true });
       }, stabilizationDelayMs);
     },
     [
       cancelPendingStabilization,
       chartKey,
       commitCount,
-      defaultCount,
+      maxCount,
+      normalizedInitialCount,
       stabilizationDelayMs,
       stabilizeInitialCount,
     ],
   );
 
   const subIndicatorCount =
-    subIndicatorState.key === chartKey ? subIndicatorState.count : defaultCount;
+    subIndicatorState.key === chartKey
+      ? subIndicatorState.count
+      : normalizedInitialCount;
 
   return [subIndicatorCount, handleSubIndicatorCountChange] as const;
 }

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -165,7 +165,7 @@ const MARKET_DETAIL_MOBILE_TRADING_VIEW_MAX_SUB_INDICATOR_COUNT = 4;
 const MARKET_DETAIL_MOBILE_TRADING_VIEW_SUB_INDICATOR_HEIGHT = 56;
 const MARKET_DETAIL_MOBILE_TRADING_VIEW_BASE_HEIGHT_RATIO = 0.58;
 const MARKET_DETAIL_INDICATOR_QUICK_BAR_VERTICAL_SCROLL_SCALE = 1.2;
-const MARKET_DETAIL_IOS_INITIAL_SUB_INDICATOR_STABILIZATION_MS = 500;
+const MARKET_DETAIL_INITIAL_SUB_INDICATOR_STABILIZATION_MS = 500;
 
 function MobileIndicatorQuickBar({
   children,
@@ -378,10 +378,10 @@ export function MobileLayout({
       chartKey: marketTradingViewKey,
       defaultCount: defaultSubIndicatorCount,
       stabilizeInitialCount: Boolean(
-        platformEnv.isNativeIOS && !useTradingViewNative,
+        platformEnv.isNative && !useTradingViewNative,
       ),
       stabilizationDelayMs:
-        MARKET_DETAIL_IOS_INITIAL_SUB_INDICATOR_STABILIZATION_MS,
+        MARKET_DETAIL_INITIAL_SUB_INDICATOR_STABILIZATION_MS,
     });
   const isTradingViewScrollLocked =
     isTradingViewIndicatorsDialogOpen || isTradingViewInteractionOverlayOpen;

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -60,6 +60,7 @@ import {
   useTokenDetail,
 } from '../hooks/useTokenDetail';
 import { useTradingViewNativeInMarketDetail } from '../hooks/useTradingViewNativeInMarketDetail';
+import { useTradingViewSubIndicatorCount } from '../hooks/useTradingViewSubIndicatorCount';
 import { getMarketDetailTradingViewNativeSource } from '../utils/getMarketDetailTradingViewNativeSource';
 
 import type { IMarketTradingViewProps } from '../components/MarketTradingView/MarketTradingView';
@@ -164,13 +165,7 @@ const MARKET_DETAIL_MOBILE_TRADING_VIEW_MAX_SUB_INDICATOR_COUNT = 4;
 const MARKET_DETAIL_MOBILE_TRADING_VIEW_SUB_INDICATOR_HEIGHT = 56;
 const MARKET_DETAIL_MOBILE_TRADING_VIEW_BASE_HEIGHT_RATIO = 0.58;
 const MARKET_DETAIL_INDICATOR_QUICK_BAR_VERTICAL_SCROLL_SCALE = 1.2;
-
-function normalizeTradingViewSubIndicatorCount(count: number) {
-  if (!Number.isFinite(count)) {
-    return 0;
-  }
-  return Math.max(0, Math.floor(count));
-}
+const MARKET_DETAIL_IOS_INITIAL_SUB_INDICATOR_STABILIZATION_MS = 500;
 
 function MobileIndicatorQuickBar({
   children,
@@ -378,17 +373,16 @@ export function MobileLayout({
   ] = useState(false);
   const [nativeIndicatorQuickBar, setNativeIndicatorQuickBar] =
     useState<ReactNode | null>(null);
-  const [tradingViewSubIndicatorState, setTradingViewSubIndicatorState] =
-    useState(() => ({
-      key: marketTradingViewKey,
-      count: defaultSubIndicatorCount,
-    }));
-  const activeMarketTradingViewKeyRef = useRef(marketTradingViewKey);
-  activeMarketTradingViewKeyRef.current = marketTradingViewKey;
-  const tradingViewSubIndicatorCount =
-    tradingViewSubIndicatorState.key === marketTradingViewKey
-      ? tradingViewSubIndicatorState.count
-      : defaultSubIndicatorCount;
+  const [tradingViewSubIndicatorCount, handleNativeSubIndicatorCountChange] =
+    useTradingViewSubIndicatorCount({
+      chartKey: marketTradingViewKey,
+      defaultCount: defaultSubIndicatorCount,
+      stabilizeInitialCount: Boolean(
+        platformEnv.isNativeIOS && !useTradingViewNative,
+      ),
+      stabilizationDelayMs:
+        MARKET_DETAIL_IOS_INITIAL_SUB_INDICATOR_STABILIZATION_MS,
+    });
   const isTradingViewScrollLocked =
     isTradingViewIndicatorsDialogOpen || isTradingViewInteractionOverlayOpen;
   const secondTabTouchStartRef = useRef<{
@@ -456,25 +450,6 @@ export function MobileLayout({
     },
     [],
   );
-  const handleNativeSubIndicatorCountChange = useCallback(
-    (count: number | null) => {
-      if (activeMarketTradingViewKeyRef.current !== marketTradingViewKey) {
-        return;
-      }
-
-      const nextCount =
-        count === null
-          ? defaultSubIndicatorCount
-          : normalizeTradingViewSubIndicatorCount(count);
-      setTradingViewSubIndicatorState((prevState) =>
-        prevState.key === marketTradingViewKey && prevState.count === nextCount
-          ? prevState
-          : { key: marketTradingViewKey, count: nextCount },
-      );
-    },
-    [defaultSubIndicatorCount, marketTradingViewKey],
-  );
-
   const handleHeaderHorizontalSwipe = useCallback(
     (direction: 'left' | 'right') => {
       const currentIndex = tabNames.indexOf(focusedTab.value);

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -30,6 +30,7 @@ import {
 } from '@onekeyhq/components';
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { TradingViewNative } from '@onekeyhq/kit/src/components/TradingView/TradingViewNative';
+import { useHyperLiquidKlineSource } from '@onekeyhq/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/hooks';
 import {
   TRADING_VIEW_NATIVE_CHART_CONTROLS_HEIGHT,
   TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT,
@@ -39,6 +40,7 @@ import {
   EJotaiContextStoreNames,
   useMarketTradingViewSubIndicatorCountPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import type { IMarketTradingViewStorageNamespace } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -65,6 +67,12 @@ import {
 import { useTradingViewNativeInMarketDetail } from '../hooks/useTradingViewNativeInMarketDetail';
 import { useTradingViewSubIndicatorCount } from '../hooks/useTradingViewSubIndicatorCount';
 import { getMarketDetailTradingViewNativeSource } from '../utils/getMarketDetailTradingViewNativeSource';
+import {
+  getMarketTradingViewStorageNamespace,
+  getMarketTradingViewSubIndicatorCount,
+  setMarketTradingViewStorageNamespace,
+  setMarketTradingViewSubIndicatorCount,
+} from '../utils/marketTradingViewSubIndicatorCount';
 
 import type { IMarketTradingViewProps } from '../components/MarketTradingView/MarketTradingView';
 import type { SwapPanel } from '../components/SwapPanel/SwapPanel';
@@ -201,6 +209,7 @@ function MobileMarketTradingView({
   networkId,
   tokenSymbol,
   dataSource,
+  storageNamespace,
   pageWidth,
   onNativeIndicatorQuickBarChange,
   onNativeSubIndicatorCountChange,
@@ -211,6 +220,7 @@ function MobileMarketTradingView({
   networkId: string;
   tokenSymbol: string;
   dataSource: 'websocket' | 'polling';
+  storageNamespace: IMarketTradingViewStorageNamespace;
   pageWidth?: number;
   onNativeIndicatorQuickBarChange: (quickBar: ReactNode | null) => void;
   onNativeSubIndicatorCountChange: (
@@ -233,6 +243,7 @@ function MobileMarketTradingView({
       networkId={networkId}
       tokenSymbol={tokenSymbol}
       dataSource={dataSource}
+      storageNamespace={storageNamespace}
       pageWidth={pageWidth}
       nativeControlsLayoutMode="mobile"
       onNativeIndicatorQuickBarChange={onNativeIndicatorQuickBarChange}
@@ -283,6 +294,14 @@ export function MobileLayout({
     isNative,
     websocketConfig,
   });
+  const {
+    isHyperLiquidSource,
+    isLoading: isHyperLiquidSourceLoading,
+    symbol: hyperLiquidSymbol,
+  } = useHyperLiquidKlineSource(
+    marketTradingViewParams?.networkId ?? networkId,
+    marketTradingViewParams?.tokenAddress ?? tokenAddress,
+  );
   let marketTradingViewKey = 'v2';
   if (useTradingViewNative) {
     marketTradingViewKey = ['native', networkId, tokenAddress].join(':');
@@ -298,8 +317,45 @@ export function MobileLayout({
     marketTradingViewSubIndicatorCountPersist,
     setMarketTradingViewSubIndicatorCountPersist,
   ] = useMarketTradingViewSubIndicatorCountPersistAtom();
+  const detectedMarketTradingViewStorageNamespace: IMarketTradingViewStorageNamespace =
+    isHyperLiquidSource && hyperLiquidSymbol ? 'market-hyperliquid' : 'market';
+  const marketTradingViewStorageNamespace =
+    getMarketTradingViewStorageNamespace({
+      chartKey: marketTradingViewKey,
+      detectedStorageNamespace: detectedMarketTradingViewStorageNamespace,
+      isSourceLoading: isHyperLiquidSourceLoading,
+      persistState: marketTradingViewSubIndicatorCountPersist,
+    });
+  useEffect(() => {
+    if (
+      !platformEnv.isNative ||
+      useTradingViewNative ||
+      isHyperLiquidSourceLoading ||
+      !marketTradingViewParams
+    ) {
+      return;
+    }
+
+    setMarketTradingViewSubIndicatorCountPersist((prev) =>
+      setMarketTradingViewStorageNamespace({
+        chartKey: marketTradingViewKey,
+        persistState: prev,
+        storageNamespace: detectedMarketTradingViewStorageNamespace,
+      }),
+    );
+  }, [
+    detectedMarketTradingViewStorageNamespace,
+    isHyperLiquidSourceLoading,
+    marketTradingViewKey,
+    marketTradingViewParams,
+    setMarketTradingViewSubIndicatorCountPersist,
+    useTradingViewNative,
+  ]);
   const persistedWebViewSubIndicatorCount = platformEnv.isNative
-    ? marketTradingViewSubIndicatorCountPersist.subIndicatorCount
+    ? getMarketTradingViewSubIndicatorCount({
+        persistState: marketTradingViewSubIndicatorCountPersist,
+        storageNamespace: marketTradingViewStorageNamespace,
+      })
     : undefined;
   let initialSubIndicatorCount =
     MARKET_DETAIL_TRADING_VIEW_DEFAULT_SUB_INDICATOR_COUNT;
@@ -399,18 +455,23 @@ export function MobileLayout({
         return;
       }
       setMarketTradingViewSubIndicatorCountPersist((prev) =>
-        prev.subIndicatorCount === count
-          ? prev
-          : { ...prev, subIndicatorCount: count },
+        setMarketTradingViewSubIndicatorCount({
+          count,
+          persistState: prev,
+          storageNamespace: marketTradingViewStorageNamespace,
+        }),
       );
     },
-    [setMarketTradingViewSubIndicatorCountPersist, useTradingViewNative],
+    [
+      marketTradingViewStorageNamespace,
+      setMarketTradingViewSubIndicatorCountPersist,
+      useTradingViewNative,
+    ],
   );
   const [tradingViewSubIndicatorCount, handleNativeSubIndicatorCountChange] =
     useTradingViewSubIndicatorCount({
-      chartKey: marketTradingViewKey,
+      chartKey: `${marketTradingViewKey}:${marketTradingViewStorageNamespace}`,
       initialCount: initialSubIndicatorCount,
-      maxCount: MARKET_DETAIL_MOBILE_TRADING_VIEW_MAX_SUB_INDICATOR_COUNT,
       stabilizeInitialCount: Boolean(
         platformEnv.isNative && !useTradingViewNative,
       ),
@@ -638,6 +699,7 @@ export function MobileLayout({
                       networkId={marketTradingViewParams.networkId}
                       tokenSymbol={marketTradingViewParams.tokenSymbol}
                       dataSource={marketTradingViewParams.dataSource}
+                      storageNamespace={marketTradingViewStorageNamespace}
                       pageWidth={effectivePageWidth}
                       onNativeIndicatorQuickBarChange={
                         handleNativeIndicatorQuickBarChange
@@ -698,6 +760,7 @@ export function MobileLayout({
     isTradingViewScrollLocked,
     marketTradingViewKey,
     marketTradingViewParams,
+    marketTradingViewStorageNamespace,
     nativeIndicatorQuickBar,
     networkId,
     tradingViewNativeSource,

--- a/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/layouts/MobileLayout.tsx
@@ -35,7 +35,10 @@ import {
   TRADING_VIEW_NATIVE_INDICATOR_QUICK_BAR_HEIGHT,
 } from '@onekeyhq/kit/src/components/TradingView/TradingViewV2/components/TradingViewV2ChartControls';
 import { useMobileTabTouchScrollBridge } from '@onekeyhq/kit/src/hooks/useMobileTabTouchScrollBridge';
-import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  EJotaiContextStoreNames,
+  useMarketTradingViewSubIndicatorCountPersistAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -210,7 +213,10 @@ function MobileMarketTradingView({
   dataSource: 'websocket' | 'polling';
   pageWidth?: number;
   onNativeIndicatorQuickBarChange: (quickBar: ReactNode | null) => void;
-  onNativeSubIndicatorCountChange: (count: number | null) => void;
+  onNativeSubIndicatorCountChange: (
+    count: number | null,
+    options?: { layoutRestored?: boolean },
+  ) => void;
   onIndicatorsDialogOpenChange: (isOpen: boolean) => void;
   onInteractionOverlayOpenChange: (isOpen: boolean) => void;
 }) {
@@ -288,9 +294,23 @@ export function MobileLayout({
       marketTradingViewParams.tokenSymbol,
     ].join(':');
   }
-  const defaultSubIndicatorCount = useTradingViewNative
-    ? 0
-    : MARKET_DETAIL_TRADING_VIEW_DEFAULT_SUB_INDICATOR_COUNT;
+  const [
+    marketTradingViewSubIndicatorCountPersist,
+    setMarketTradingViewSubIndicatorCountPersist,
+  ] = useMarketTradingViewSubIndicatorCountPersistAtom();
+  const persistedWebViewSubIndicatorCount = platformEnv.isNative
+    ? marketTradingViewSubIndicatorCountPersist.subIndicatorCount
+    : undefined;
+  let initialSubIndicatorCount =
+    MARKET_DETAIL_TRADING_VIEW_DEFAULT_SUB_INDICATOR_COUNT;
+  if (useTradingViewNative) {
+    initialSubIndicatorCount = 0;
+  } else if (
+    typeof persistedWebViewSubIndicatorCount === 'number' &&
+    Number.isFinite(persistedWebViewSubIndicatorCount)
+  ) {
+    initialSubIndicatorCount = persistedWebViewSubIndicatorCount;
+  }
   const intl = useIntl();
   const isBTCMainnet = networkUtils.isBTCMainnet(networkId);
   const nativeHyperliquidCoin =
@@ -373,15 +393,30 @@ export function MobileLayout({
   ] = useState(false);
   const [nativeIndicatorQuickBar, setNativeIndicatorQuickBar] =
     useState<ReactNode | null>(null);
+  const persistWebViewSubIndicatorCount = useCallback(
+    (count: number) => {
+      if (!platformEnv.isNative || useTradingViewNative) {
+        return;
+      }
+      setMarketTradingViewSubIndicatorCountPersist((prev) =>
+        prev.subIndicatorCount === count
+          ? prev
+          : { ...prev, subIndicatorCount: count },
+      );
+    },
+    [setMarketTradingViewSubIndicatorCountPersist, useTradingViewNative],
+  );
   const [tradingViewSubIndicatorCount, handleNativeSubIndicatorCountChange] =
     useTradingViewSubIndicatorCount({
       chartKey: marketTradingViewKey,
-      defaultCount: defaultSubIndicatorCount,
+      initialCount: initialSubIndicatorCount,
+      maxCount: MARKET_DETAIL_MOBILE_TRADING_VIEW_MAX_SUB_INDICATOR_COUNT,
       stabilizeInitialCount: Boolean(
         platformEnv.isNative && !useTradingViewNative,
       ),
       stabilizationDelayMs:
         MARKET_DETAIL_INITIAL_SUB_INDICATOR_STABILIZATION_MS,
+      onCountSettled: persistWebViewSubIndicatorCount,
     });
   const isTradingViewScrollLocked =
     isTradingViewIndicatorsDialogOpen || isTradingViewInteractionOverlayOpen;

--- a/packages/kit/src/views/Market/MarketDetailV2/utils/marketTradingViewSubIndicatorCount.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/utils/marketTradingViewSubIndicatorCount.test.ts
@@ -1,0 +1,94 @@
+import type { IMarketTradingViewSubIndicatorCountPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms/market';
+
+import {
+  getMarketTradingViewStorageNamespace,
+  getMarketTradingViewSubIndicatorCount,
+  setMarketTradingViewStorageNamespace,
+  setMarketTradingViewSubIndicatorCount,
+} from './marketTradingViewSubIndicatorCount';
+
+describe('market TradingView sub-indicator count persistence', () => {
+  it('keeps regular Market and Hyperliquid layout counts independent', () => {
+    const initialState: IMarketTradingViewSubIndicatorCountPersistAtom = {
+      subIndicatorCountByStorageNamespace: {},
+      storageNamespaceByChartKey: {},
+    };
+    const marketState = setMarketTradingViewSubIndicatorCount({
+      count: 1,
+      persistState: initialState,
+      storageNamespace: 'market',
+    });
+    const finalState = setMarketTradingViewSubIndicatorCount({
+      count: 3,
+      persistState: marketState,
+      storageNamespace: 'market-hyperliquid',
+    });
+
+    expect(
+      getMarketTradingViewSubIndicatorCount({
+        persistState: finalState,
+        storageNamespace: 'market',
+      }),
+    ).toBe(1);
+    expect(
+      getMarketTradingViewSubIndicatorCount({
+        persistState: finalState,
+        storageNamespace: 'market-hyperliquid',
+      }),
+    ).toBe(3);
+  });
+
+  it('preserves state identity when the stored count is unchanged', () => {
+    const persistState: IMarketTradingViewSubIndicatorCountPersistAtom = {
+      subIndicatorCountByStorageNamespace: { market: 2 },
+      storageNamespaceByChartKey: {},
+    };
+
+    expect(
+      setMarketTradingViewSubIndicatorCount({
+        count: 2,
+        persistState,
+        storageNamespace: 'market',
+      }),
+    ).toBe(persistState);
+  });
+
+  it('uses the persisted chart namespace while source detection is loading', () => {
+    const chartKey = 'v2:btc:btc:BTC';
+    const initialState: IMarketTradingViewSubIndicatorCountPersistAtom = {
+      subIndicatorCountByStorageNamespace: {},
+      storageNamespaceByChartKey: {},
+    };
+    const persistState = setMarketTradingViewStorageNamespace({
+      chartKey,
+      persistState: initialState,
+      storageNamespace: 'market-hyperliquid',
+    });
+
+    expect(
+      getMarketTradingViewStorageNamespace({
+        chartKey,
+        detectedStorageNamespace: 'market',
+        isSourceLoading: true,
+        persistState,
+      }),
+    ).toBe('market-hyperliquid');
+    expect(
+      getMarketTradingViewStorageNamespace({
+        chartKey,
+        detectedStorageNamespace: 'market',
+        isSourceLoading: false,
+        persistState,
+      }),
+    ).toBe('market');
+
+    const regularMarketState = setMarketTradingViewStorageNamespace({
+      chartKey,
+      persistState,
+      storageNamespace: 'market',
+    });
+    expect(
+      regularMarketState.storageNamespaceByChartKey[chartKey],
+    ).toBeUndefined();
+  });
+});

--- a/packages/kit/src/views/Market/MarketDetailV2/utils/marketTradingViewSubIndicatorCount.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/utils/marketTradingViewSubIndicatorCount.ts
@@ -1,0 +1,93 @@
+import type {
+  IMarketTradingViewStorageNamespace,
+  IMarketTradingViewSubIndicatorCountPersistAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms/market';
+
+export function getMarketTradingViewStorageNamespace({
+  chartKey,
+  detectedStorageNamespace,
+  isSourceLoading,
+  persistState,
+}: {
+  chartKey: string;
+  detectedStorageNamespace: IMarketTradingViewStorageNamespace;
+  isSourceLoading: boolean;
+  persistState: IMarketTradingViewSubIndicatorCountPersistAtom;
+}) {
+  if (isSourceLoading) {
+    return persistState.storageNamespaceByChartKey[chartKey] ?? 'market';
+  }
+
+  return detectedStorageNamespace;
+}
+
+export function setMarketTradingViewStorageNamespace({
+  chartKey,
+  persistState,
+  storageNamespace,
+}: {
+  chartKey: string;
+  persistState: IMarketTradingViewSubIndicatorCountPersistAtom;
+  storageNamespace: IMarketTradingViewStorageNamespace;
+}) {
+  const currentStorageNamespace =
+    persistState.storageNamespaceByChartKey[chartKey];
+  if (
+    currentStorageNamespace === storageNamespace ||
+    (storageNamespace === 'market' && currentStorageNamespace === undefined)
+  ) {
+    return persistState;
+  }
+
+  const storageNamespaceByChartKey = {
+    ...persistState.storageNamespaceByChartKey,
+  };
+  if (storageNamespace === 'market') {
+    delete storageNamespaceByChartKey[chartKey];
+  } else {
+    storageNamespaceByChartKey[chartKey] = storageNamespace;
+  }
+
+  return {
+    ...persistState,
+    storageNamespaceByChartKey,
+  };
+}
+
+export function getMarketTradingViewSubIndicatorCount({
+  persistState,
+  storageNamespace,
+}: {
+  persistState: IMarketTradingViewSubIndicatorCountPersistAtom;
+  storageNamespace: IMarketTradingViewStorageNamespace;
+}) {
+  const count =
+    persistState.subIndicatorCountByStorageNamespace[storageNamespace];
+  return typeof count === 'number' && Number.isFinite(count)
+    ? count
+    : undefined;
+}
+
+export function setMarketTradingViewSubIndicatorCount({
+  count,
+  persistState,
+  storageNamespace,
+}: {
+  count: number;
+  persistState: IMarketTradingViewSubIndicatorCountPersistAtom;
+  storageNamespace: IMarketTradingViewStorageNamespace;
+}) {
+  if (
+    persistState.subIndicatorCountByStorageNamespace[storageNamespace] === count
+  ) {
+    return persistState;
+  }
+
+  return {
+    ...persistState,
+    subIndicatorCountByStorageNamespace: {
+      ...persistState.subIndicatorCountByStorageNamespace,
+      [storageNamespace]: count,
+    },
+  };
+}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58198](https://onekeyhq.atlassian.net/browse/OK-58198) [OK-58394](https://onekeyhq.atlassian.net/browse/OK-58394)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- persist the Market Detail TradingView sub-indicator count in the App on iOS and Android
- use the App-persisted count as the initial chart height before the WebView restores its own layout
- ignore provisional WebView counts until TradingView confirms layout restoration, then use the restored count as calibration/fallback
- keep App counts isolated by the Web layout namespaces `market` and `market-hyperliquid`
- retain the quiet-window fallback for older TradingView Web builds that do not send the restoration flag

## Two-copy behavior

1. App copy (native MMKV-backed Jotai atom): primary value for the initial mobile chart height.
2. TradingView Web copy (saved study template/layout): fallback and calibration after restoration completes.

The App also remembers Hyperliquid chart-to-namespace classification so repeat entries select the correct cached height before the async Market basic config returns. The first-ever entry can still adjust once after Web layout restoration.

## Root cause

The App did not have an independent persisted initial count, and the bridge could not distinguish provisional chart-control snapshots from the final restored layout. Market Detail therefore resized for intermediate counts during WebView initialization.

The review follow-up also makes the restored marker and indicator count come from the same config snapshot, preserves existing layouts with more than four sub-indicators, and cancels legacy fallback timers after the marker protocol is detected.

## Cross-platform scope

- iOS and Android `main` UI runtime only
- native MMKV is the persisted backing resource; the background JS runtime does not consume this atom
- TradingView Native keeps its existing fixed initial count and does not write the WebView cache
- desktop and web behavior is unchanged

## Companion PR

- https://github.com/OneKeyHQ/tradingview-charting-library/pull/209

## Validation

- five focused Jest suites covering config/count synchronization, namespace persistence, marker fallback, restored counts, and native indicator controls (20 tests passed)
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr` (all local checks passed)
- final iOS/Android simulator verification pending by requester

Issues: OK-58198, OK-58394

[OK-58198]: https://onekeyhq.atlassian.net/browse/OK-58198
[OK-58394]: https://onekeyhq.atlassian.net/browse/OK-58394