### PR TITLE
fix: correct swap invitee reward amount OK-60133

### DIFF
--- a/.skillshare/skills/1k-retrospective/references/case-studies.md
+++ b/.skillshare/skills/1k-retrospective/references/case-studies.md
@@ -40,3 +40,10 @@ Cases are appended by AI after each bug fix. Do NOT reorder or delete entries â€
 **Root Cause**: Wallet avatar rendering only read `keylessProvider`, while the refreshed avatar-specific provider was not persisted or prioritized.
 **Fix**: Stored `avatarProvider` in `keylessDetails` during avatar repair and updated avatar rendering to prefer `avatarProvider` before falling back to `keylessProvider`.
 **Catchable by**: Section 4: Type definitions changed -> all consumers updated
+
+## Case: Swap invitee reward counted undistributed bonus twice
+**Date**: 2026-08-13 | **Platforms**: mobile, desktop, web, extension
+**Symptom**: The Swap invitee reward summary showed the cumulative total as distributed and then added the undistributed reward again, so a fully undistributed reward appeared as already distributed.
+**Root Cause**: The client treated `totalBonus`, which already includes `undistributed`, as the distributed amount instead of deriving the distributed portion.
+**Fix**: Derived `distributedBonus` with BigNumber as `totalBonus - undistributed` and passed it explicitly to the summary card, with regression coverage for partially, fully, and zero undistributed rewards.
+**Catchable by**: Section 4: Data flow end-to-end: API -> state -> UI

--- a/packages/kit/src/views/Swap/components/InviteeReward/SwapInviteeRewardContent.test.tsx
+++ b/packages/kit/src/views/Swap/components/InviteeReward/SwapInviteeRewardContent.test.tsx
@@ -120,20 +120,8 @@ jest.mock('@onekeyhq/kit/src/utils/explorerUtils', () => ({
   openTransactionDetailsUrl: jest.fn(),
 }));
 
-jest.mock('./components/RewardSummaryCard', () => ({
-  RewardSummaryCard: ({
-    totalBonus,
-    undistributed,
-    tokenSymbol,
-  }: {
-    totalBonus?: string;
-    undistributed?: string;
-    tokenSymbol?: string;
-  }) => (
-    <div data-testid="reward-summary">
-      {totalBonus}:{undistributed}:{tokenSymbol}
-    </div>
-  ),
+jest.mock('@onekeyhq/kit/src/components/InfoIcon', () => ({
+  InfoIcon: () => <div data-testid="reward-summary-info" />,
 }));
 
 import { SwapInviteeRewardContent } from './SwapInviteeRewardContent';
@@ -164,10 +152,56 @@ describe('SwapInviteeRewardContent', () => {
       />,
     );
 
-    expect(screen.getByTestId('reward-summary').textContent).toBe('12:3:USDC');
+    expect(screen.getByText('9')).toBeTruthy();
+    expect(screen.getByText('3')).toBeTruthy();
+    expect(screen.queryByText('12')).toBeNull();
     expect(screen.queryByText('referral.reward_history')).toBeNull();
     expect(screen.queryByText('0xtransa...action')).toBeNull();
     expect(screen.queryByTestId('scroll-view')).toBeNull();
+  });
+
+  it('does not treat fully undistributed rewards as distributed', () => {
+    mockPromiseResult.result = {
+      status: 'success',
+      data: {
+        totalBonus: '0.46',
+        undistributed: '0.46',
+        token: { symbol: 'USDC' },
+        history: [],
+      },
+    };
+
+    render(
+      <SwapInviteeRewardContent
+        accountId="hd-1--account"
+        currentEvmAddress="0xcurrent"
+      />,
+    );
+
+    expect(screen.getByText('0')).toBeTruthy();
+    expect(screen.getAllByText('0.46')).toHaveLength(1);
+  });
+
+  it('shows only the total bonus when no rewards are undistributed', () => {
+    mockPromiseResult.result = {
+      status: 'success',
+      data: {
+        totalBonus: '0.46',
+        undistributed: '0',
+        token: { symbol: 'USDC' },
+        history: [],
+      },
+    };
+
+    render(
+      <SwapInviteeRewardContent
+        accountId="hd-1--account"
+        currentEvmAddress="0xcurrent"
+      />,
+    );
+
+    expect(screen.getAllByText('0.46')).toHaveLength(1);
+    expect(screen.queryByText('0')).toBeNull();
   });
 
   it('keeps the no-wallet state', () => {

--- a/packages/kit/src/views/Swap/components/InviteeReward/SwapInviteeRewardContent.tsx
+++ b/packages/kit/src/views/Swap/components/InviteeReward/SwapInviteeRewardContent.tsx
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js';
 import { useIntl } from 'react-intl';
 
 import { Button, Empty, SizableText, YStack } from '@onekeyhq/components';
@@ -104,12 +105,15 @@ export function SwapInviteeRewardContent({
   }
 
   const data = result?.status === 'success' ? result.data : undefined;
+  const distributedBonus = data
+    ? new BigNumber(data.totalBonus).minus(data.undistributed).toFixed()
+    : undefined;
   const showLoading = Boolean(isLoading || !result);
   const content = (
     <YStack gap="$5">
       <RewardSummaryCard
         isLoading={showLoading}
-        totalBonus={data?.totalBonus}
+        distributedBonus={distributedBonus}
         undistributed={data?.undistributed}
         tokenSymbol={data?.token.symbol}
       />

--- a/packages/kit/src/views/Swap/components/InviteeReward/components/RewardSummaryCard.tsx
+++ b/packages/kit/src/views/Swap/components/InviteeReward/components/RewardSummaryCard.tsx
@@ -13,19 +13,19 @@ import { ETranslations } from '@onekeyhq/shared/src/locale';
 
 interface IRewardSummaryCardProps {
   isLoading?: boolean;
-  totalBonus?: string;
+  distributedBonus?: string;
   undistributed?: string;
   tokenSymbol?: string;
 }
 
 export function RewardSummaryCard({
   isLoading,
-  totalBonus,
+  distributedBonus,
   undistributed,
   tokenSymbol,
 }: IRewardSummaryCardProps) {
   const intl = useIntl();
-  const displayTotalBonus = totalBonus ?? '0';
+  const displayDistributedBonus = distributedBonus ?? '0';
   const displayUndistributed = undistributed ?? '0';
   const displayTokenSymbol = tokenSymbol ?? 'USDC';
   const hasUndistributed = new BigNumber(displayUndistributed).gt(0);
@@ -53,7 +53,7 @@ export function RewardSummaryCard({
             }}
             numberOfLines={1}
           >
-            {displayTotalBonus}
+            {displayDistributedBonus}
           </NumberSizeableText>
         )}
 

--- a/packages/shared/src/referralCode/type.ts
+++ b/packages/shared/src/referralCode/type.ts
@@ -353,7 +353,9 @@ export interface ISwapInviteeRewardHistoryItem {
 }
 
 export interface ISwapInviteeRewardsResponse {
+  /** Cumulative reward amount, including the undistributed amount. */
   totalBonus: string;
+  /** Confirmed reward amount that has not been distributed yet. */
   undistributed: string;
   token: IRewardToken;
   history: ISwapInviteeRewardHistoryItem[];


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60133](https://onekeyhq.atlassian.net/browse/OK-60133)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

Fixes [OK-60133](https://onekeyhq.atlassian.net/browse/OK-60133) by deriving the distributed Swap invitee reward as `totalBonus - undistributed`, because the API total already includes the undistributed amount.
The reward card now consumes an explicit `distributedBonus`, and the shared response type documents the field semantics.
Regression coverage checks partially distributed, fully undistributed, and fully distributed reward states while preserving existing empty and error handling.

## Validation

- `yarn jest packages/kit/src/views/Swap/components/InviteeReward/SwapInviteeRewardContent.test.tsx --runInBand`
- `yarn tsc:only`
- `yarn agent:check --profile commit`
- `git diff --check`


[OK-60133]: https://onekeyhq.atlassian.net/browse/OK-60133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ