### PR TITLE
fix: onboarding device-ready card leftover after wallet setup close (OK-59994)

### DIFF
--- a/packages/kit/src/views/Onboardingv2/components/setupMotion.ts
+++ b/packages/kit/src/views/Onboardingv2/components/setupMotion.ts
@@ -5,6 +5,12 @@ import { Easing, FadeIn, FadeOut, ReduceMotion } from 'react-native-reanimated';
 // The onboarding's enter/exit transitions all use ease-out cubic — the
 // web-animation rule that content entering or leaving the viewport eases out
 // (an instant, responsive start that settles into place).
+//
+// Web constraint: `exiting` only plays when the element's PARENT survives the
+// unmount (an in-page swap). Exiting views inside a wholesale-removed subtree
+// (route/stack teardown) are dropped without animating — patches/
+// react-native-reanimated+4.2.1.patch disables reanimated's exit-dummy
+// reattach observer, which used to strand such views on screen forever.
 export const EASE_OUT_CUBIC = Easing.out(Easing.cubic);
 
 // A sequenced ("mode=wait") opacity cross-fade: the old content fully fades OUT,

--- a/patches/react-native-reanimated+4.2.1.patch
+++ b/patches/react-native-reanimated+4.2.1.patch
@@ -31,6 +31,33 @@ index 0062693..07a0f0b 100644
    const EventTarget *eventTarget = rawEvent.eventTarget.get();
    if (eventTarget == nullptr) {
      // after app reload scrollView is unmounted and its content offset is set
+diff --git a/node_modules/react-native-reanimated/lib/module/layoutReanimation/web/domUtils.js b/node_modules/react-native-reanimated/lib/module/layoutReanimation/web/domUtils.js
+index ee9e030..c610eb7 100644
+--- a/node_modules/react-native-reanimated/lib/module/layoutReanimation/web/domUtils.js
++++ b/node_modules/react-native-reanimated/lib/module/layoutReanimation/web/domUtils.js
+@@ -148,10 +148,18 @@ export function addHTMLMutationObserver() {
+       findDescendantWithExitingAnimation(rootMutation.removedNodes[i], rootMutation.target);
+     }
+   });
+-  observer.observe(document.body, {
+-    childList: true,
+-    subtree: true
+-  });
++  // OneKey patch: never observe — keep the exit-dummy reattach feature off. On
++  // subtree removal (e.g. closing a navigator stack) it re-parented in-flight
++  // exiting dummies into the surviving ancestor, where cleanup relies entirely
++  // on CSS animation events firing on the re-attached dummy; when the restarted
++  // animation is never created, the dummy is stranded on screen forever at full
++  // opacity (onboarding "device is ready" card left over wallet home). Exiting
++  // dummies inside removed subtrees now simply die with the subtree; in-page
++  // swaps (parent survives) are unaffected.
++  // observer.observe(document.body, {
++  //   childList: true,
++  //   subtree: true
++  // });
+ }
+ export function areDOMRectsEqual(r1, r2) {
+   // There are 4 more fields, but checking these should suffice
 diff --git a/node_modules/react-native-reanimated/src/common/style/processors/colors.ts b/node_modules/react-native-reanimated/src/common/style/processors/colors.ts
 index 42d2c09..57dd400 100644
 --- a/node_modules/react-native-reanimated/src/common/style/processors/colors.ts
@@ -58,3 +85,18 @@ index 7682466..2eef347 100644
 +  }
    throw new ReanimatedError(ERROR_MESSAGES.invalidColor(value));
  };
+diff --git a/node_modules/react-native-reanimated/src/layoutReanimation/web/domUtils.ts b/node_modules/react-native-reanimated/src/layoutReanimation/web/domUtils.ts
+index b2bfc74..b0de118 100644
+--- a/node_modules/react-native-reanimated/src/layoutReanimation/web/domUtils.ts
++++ b/node_modules/react-native-reanimated/src/layoutReanimation/web/domUtils.ts
+@@ -248,7 +248,9 @@ export function addHTMLMutationObserver() {
+     }
+   });
+ 
+-  observer.observe(document.body, { childList: true, subtree: true });
++  // OneKey patch: never observe — exit-dummy reattach disabled; rationale in
++  // lib/module/layoutReanimation/web/domUtils.js.
++  // observer.observe(document.body, { childList: true, subtree: true });
+ }
+ 
+ export function areDOMRectsEqual(r1: DOMRect, r2: DOMRect) {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59994](https://onekeyhq.atlassian.net/browse/OK-59994)

----------

<!-- github-pr-monitor:jira-links:end -->


[OK-59994](https://onekeyhq.atlassian.net/browse/OK-59994)

Cherry-pick of #12844 (merged to `x` as `4ed1e83`) onto `hotfix/v6.5.2`.

Applied cleanly with no conflicts; the resulting tree for both touched files is byte-identical to what merged into `x`.

## Problem

After completing hardware-wallet onboarding on desktop, the "Device is ready" status card from the DeviceSetup page stays floating over the wallet home screen once the onboarding stack closes. The stranded card is fully opaque and never goes away.

## Root cause

react-native-reanimated 4.2.1 (web) implements `exiting` animations by moving the element's children into an `isDummy` clone. A global `MutationObserver` on `document.body` (`addHTMLMutationObserver`) re-parents in-flight dummies from removed subtrees into the surviving ancestor — so when `resetOnboardingModal()` unmounts the whole onboarding stack, the ready card's exit dummy gets re-attached on top of wallet home, absolutely positioned at its old coordinates. Cleanup of the re-attached dummy relies entirely on CSS animation events (`animationend`/`animationcancel`) with no fallback timer; whenever the restarted animation is never created, the dummy is stranded forever at full opacity (FadeOut has no fill-mode, so opacity snaps back to 1).

## Fix

Extend `patches/react-native-reanimated+4.2.1.patch`: comment out the single `observer.observe(...)` call, so the reattach observer is constructed but never observes. Exit dummies inside removed subtrees now die with the subtree. In-page swaps (e.g. DeviceSetup checking → ready cross-fade) are unaffected — their parent survives, so they never used the observer. Patched in both `lib/module` (rspack/web/desktop/ext) and `src` (metro) for parity.

Also documents the constraint at the consumption site (`setupMotion.ts`).

## Verification

- `git cherry-pick` applied with zero conflicts.
- Content diff against `4ed1e83` for both files is empty.
- Original PR #12844 verified on `x`: patch applies cleanly to pristine 4.2.1, `yarn agent:check --profile commit` green, manual desktop onboarding check passed.
- Local `yarn agent:check` was not re-run for this pick (fresh worktree without `node_modules`); relying on PR CI.


[OK-59994]: https://onekeyhq.atlassian.net/browse/OK-59994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ