### PR TITLE
fix: correct Pro device setup step order OK-60126

### DIFF
--- a/packages/kit/src/views/Onboardingv2/pages/DeviceSetup.tsx
+++ b/packages/kit/src/views/Onboardingv2/pages/DeviceSetup.tsx
@@ -155,12 +155,24 @@ function DeviceSetupPage({
       details: [] as string[],
     };
 
-    // For Classic or Mini devices, swap the order of PIN and recovery phrase
+    // The order follows each device's own setup wizard, so there is no single
+    // house order — Pro's matches the device onboarding protocol
+    // (personalization → PIN → setup). Touch keeps the legacy order until it
+    // is checked against a real device.
     if (isClassicOrMini) {
       return [
         chooseOptionStep,
         recoveryPhraseStep,
         pinStep,
+        finishOnboardingOnDevice,
+      ];
+    }
+
+    if (deviceType === EDeviceType.Pro) {
+      return [
+        pinStep,
+        chooseOptionStep,
+        recoveryPhraseStep,
         finishOnboardingOnDevice,
       ];
     }


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60126](https://onekeyhq.atlassian.net/browse/OK-60126)

----------

<!-- github-pr-monitor:jira-links:end -->


## What

On the "Set up your device" card shown when a hardware wallet is not yet initialized, **Pro** now lists `Setup PIN` as step 1, before `Choose your setup option`:

| | Before | After |
|---|---|---|
| 1 | Choose your setup option | **Setup PIN** |
| 2 | Setup PIN | **Choose your setup option** |
| 3 | Setup recovery phrase | Setup recovery phrase |
| 4 | Follow the instructions on your device | Follow the instructions on your device |

## Why

OK-60126: on a real Pro the on-device wizard asks for the PIN **before** the create/import choice, so the card's first step did not match what the user was looking at. The new order also matches the device onboarding protocol's own step model (personalization → PIN → setup).

This card is guidance text only — it does not affect device communication or the initialization flow.

## Not changed

- Classic / Classic1s / ClassicPure / Mini keep their order (choice → recovery phrase → PIN).
- **Touch** deliberately keeps the previous order. Its order has never been checked against a real device and the two in-repo sources disagree, so changing it would be a guess — tracked separately in OK-60187.
- No copy or translation changes; still four steps, numbering is derived from the array.

## Verification

Pro was verified on a real device: the on-device wizard asks for the PIN first, and the card now matches.

The Classic family has no device on hand, so its branch was checked by rendering the page per device type and comparing the resulting step order before and after — unchanged. That check was a one-off; it is not committed, since it would only assert the shape of a literal array while the real source of truth is the device itself.

## Notes for reviewers

- The older tutorial page `Onboarding/pages/ConnectHardwareWallet/ActivateDevice.tsx` (reachable in web dapp mode) still lists PIN last for Pro. That divergence pre-dates this change and is left out of scope.

[OK-60126]: https://onekeyhq.atlassian.net/browse/OK-60126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ