### PR TITLE
fix: correct Pro2 settings and label sync(OK-60188, OK-59745, OK-60258)

### DIFF
--- a/packages/components/src/composite/SegmentSlider/index.native.tsx
+++ b/packages/components/src/composite/SegmentSlider/index.native.tsx
@@ -81,6 +81,8 @@ export interface ISegmentSliderProps {
   max?: number;
   disabled?: boolean;
   showBubble?: boolean;
+  /** Web-only alignment option. Native segment geometry remains evenly spaced. */
+  alignSegmentMarksToIntegerValues?: boolean;
   /**
    * When true, the slider fills from center (0) instead of left edge.
    * Negative values fill left from center, positive values fill right from center.

--- a/packages/components/src/composite/SegmentSlider/index.native.tsx
+++ b/packages/components/src/composite/SegmentSlider/index.native.tsx
@@ -81,6 +81,8 @@ export interface ISegmentSliderProps {
   max?: number;
   disabled?: boolean;
   showBubble?: boolean;
+  /** Uses the active track color for the thumb instead of the page background. */
+  activeThumb?: boolean;
   /**
    * When true, the slider fills from center (0) instead of left edge.
    * Negative values fill left from center, positive values fill right from center.
@@ -115,6 +117,7 @@ function SegmentSliderComponent({
   max = 100,
   disabled = false,
   showBubble = true,
+  activeThumb = false,
   centerOrigin = false,
   snapTapToSegment = false,
 }: ISegmentSliderProps) {
@@ -130,7 +133,7 @@ function SegmentSliderComponent({
     () => ({
       fillColor: bgPrimary,
       trackColor: neutral5,
-      thumbColor: bg,
+      thumbColor: activeThumb ? bgPrimary : bg,
       thumbBorderColor: borderStrong,
       markActiveColor: bgPrimary,
       markInactiveColor: bg,
@@ -138,7 +141,7 @@ function SegmentSliderComponent({
       bubbleColor: bgPrimary,
       bubbleTextColor: bg,
     }),
-    [bgPrimary, neutral5, bg, borderStrong],
+    [activeThumb, bgPrimary, neutral5, bg, borderStrong],
   );
 
   // Always holds the latest external `value`, so the hybridRef callback can push

--- a/packages/components/src/composite/SegmentSlider/index.native.tsx
+++ b/packages/components/src/composite/SegmentSlider/index.native.tsx
@@ -81,8 +81,6 @@ export interface ISegmentSliderProps {
   max?: number;
   disabled?: boolean;
   showBubble?: boolean;
-  /** Uses the active track color for the thumb instead of the page background. */
-  activeThumb?: boolean;
   /**
    * When true, the slider fills from center (0) instead of left edge.
    * Negative values fill left from center, positive values fill right from center.
@@ -117,7 +115,6 @@ function SegmentSliderComponent({
   max = 100,
   disabled = false,
   showBubble = true,
-  activeThumb = false,
   centerOrigin = false,
   snapTapToSegment = false,
 }: ISegmentSliderProps) {
@@ -133,7 +130,7 @@ function SegmentSliderComponent({
     () => ({
       fillColor: bgPrimary,
       trackColor: neutral5,
-      thumbColor: activeThumb ? bgPrimary : bg,
+      thumbColor: bg,
       thumbBorderColor: borderStrong,
       markActiveColor: bgPrimary,
       markInactiveColor: bg,
@@ -141,7 +138,7 @@ function SegmentSliderComponent({
       bubbleColor: bgPrimary,
       bubbleTextColor: bg,
     }),
-    [activeThumb, bgPrimary, neutral5, bg, borderStrong],
+    [bgPrimary, neutral5, bg, borderStrong],
   );
 
   // Always holds the latest external `value`, so the hybridRef callback can push

--- a/packages/components/src/composite/SegmentSlider/index.test.tsx
+++ b/packages/components/src/composite/SegmentSlider/index.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render } from '@testing-library/react';
+
+import { SegmentSlider } from '.';
+
+jest.mock('../../hooks/useStyle', () => ({
+  useTheme: () => ({
+    bgPrimary: { val: '#ffffff' },
+    neutral5: { val: '#555555' },
+    bg: { val: '#000000' },
+    borderStrong: { val: '#777777' },
+    borderActive: { val: '#999999' },
+  }),
+}));
+
+describe('SegmentSlider integer-aligned segment marks', () => {
+  it('moves through the same integer values used by the brightness marks', () => {
+    const onChange = jest.fn();
+    const { getByRole } = render(
+      <SegmentSlider
+        value={10}
+        min={10}
+        max={100}
+        segments={4}
+        alignSegmentMarksToIntegerValues
+        onChange={onChange}
+      />,
+    );
+    const slider = getByRole('slider');
+
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+
+    expect(onChange).toHaveBeenNthCalledWith(1, 32);
+    expect(onChange).toHaveBeenNthCalledWith(2, 55);
+    expect(onChange).toHaveBeenNthCalledWith(3, 78);
+    expect(onChange).toHaveBeenNthCalledWith(4, 100);
+  });
+});

--- a/packages/components/src/composite/SegmentSlider/index.test.tsx
+++ b/packages/components/src/composite/SegmentSlider/index.test.tsx
@@ -2,9 +2,9 @@
  * @jest-environment jsdom
  */
 
-import { fireEvent, render } from '@testing-library/react';
-
 import { SegmentSlider } from '.';
+
+import { fireEvent, render } from '@testing-library/react';
 
 jest.mock('../../hooks/useStyle', () => ({
   useTheme: () => ({

--- a/packages/components/src/composite/SegmentSlider/index.tsx
+++ b/packages/components/src/composite/SegmentSlider/index.tsx
@@ -21,6 +21,15 @@ const MARK_HIT_AREA = 24;
 const DEFAULT_TRACK_HEIGHT = 4;
 const HIT_AREA_HEIGHT = 24;
 
+// Keep half-step marks symmetric when the slider emits integer values.
+function roundHalfToEven(value: number) {
+  const lower = Math.floor(value);
+  if (value - lower !== 0.5) {
+    return Math.round(value);
+  }
+  return lower % 2 === 0 ? lower : lower + 1;
+}
+
 export interface ISegmentSliderProps {
   value: number;
   sliderHeight?: number;
@@ -36,6 +45,8 @@ export interface ISegmentSliderProps {
   max?: number;
   disabled?: boolean;
   showBubble?: boolean;
+  /** Aligns fractional segment marks to the integer values emitted by the web slider. */
+  alignSegmentMarksToIntegerValues?: boolean;
   /**
    * When true, the slider fills from center (0) instead of left edge.
    * Negative values fill left from center, positive values fill right from
@@ -166,6 +177,7 @@ function SegmentSliderComponent({
   max = 100,
   disabled = false,
   showBubble = true,
+  alignSegmentMarksToIntegerValues = false,
   centerOrigin = false,
 }: ISegmentSliderProps) {
   const trackRef = useRef<HTMLDivElement>(null);
@@ -209,13 +221,26 @@ function SegmentSliderComponent({
   const centerPct = useMemo(() => valueToPct(0), [valueToPct]);
 
   const segmentIndexToValue = useCallback(
-    (index: number) => Math.round(min + index * stepValue),
-    [min, stepValue],
+    (index: number) => {
+      const segmentValue = min + index * stepValue;
+      return alignSegmentMarksToIntegerValues
+        ? roundHalfToEven(segmentValue)
+        : Math.round(segmentValue);
+    },
+    [alignSegmentMarksToIntegerValues, min, stepValue],
   );
 
   const segmentIndexToPct = useCallback(
-    (index: number) => valueToPct(segmentIndexToValue(index)),
-    [segmentIndexToValue, valueToPct],
+    (index: number) =>
+      alignSegmentMarksToIntegerValues
+        ? valueToPct(segmentIndexToValue(index))
+        : (index / segments) * 100,
+    [
+      alignSegmentMarksToIntegerValues,
+      segmentIndexToValue,
+      segments,
+      valueToPct,
+    ],
   );
 
   const applyMarkActiveStates = useCallback(
@@ -338,14 +363,16 @@ function SegmentSliderComponent({
   const emit = useCallback(
     (rawValue: number) => {
       const snapped = snap(rawValue);
-      const rounded = Math.round(snapped);
+      const rounded = alignSegmentMarksToIntegerValues
+        ? roundHalfToEven(snapped)
+        : Math.round(snapped);
       applyVisual(rounded);
       if (rounded !== lastEmittedRef.current) {
         lastEmittedRef.current = rounded;
         onChange(rounded);
       }
     },
-    [snap, onChange, applyVisual],
+    [alignSegmentMarksToIntegerValues, snap, onChange, applyVisual],
   );
 
   const setBubbleVisible = useCallback((visible: boolean) => {
@@ -469,10 +496,26 @@ function SegmentSliderComponent({
       }
       if (delta !== 0) {
         e.preventDefault();
-        emit(lastEmittedRef.current + delta);
+        if (alignSegmentMarksToIntegerValues && hasSegments) {
+          const currentIndex = Math.round(
+            (lastEmittedRef.current - min) / stepValue,
+          );
+          const nextIndex = currentIndex + (delta > 0 ? 1 : -1);
+          emit(min + nextIndex * stepValue);
+        } else {
+          emit(lastEmittedRef.current + delta);
+        }
       }
     },
-    [disabled, hasSegments, stepValue, emit, min, max],
+    [
+      disabled,
+      alignSegmentMarksToIntegerValues,
+      hasSegments,
+      stepValue,
+      emit,
+      min,
+      max,
+    ],
   );
 
   const handleFocus = useCallback((e: React.FocusEvent<HTMLDivElement>) => {

--- a/packages/components/src/composite/SegmentSlider/index.tsx
+++ b/packages/components/src/composite/SegmentSlider/index.tsx
@@ -36,8 +36,6 @@ export interface ISegmentSliderProps {
   max?: number;
   disabled?: boolean;
   showBubble?: boolean;
-  /** Uses the active track color for the thumb instead of the page background. */
-  activeThumb?: boolean;
   /**
    * When true, the slider fills from center (0) instead of left edge.
    * Negative values fill left from center, positive values fill right from
@@ -168,7 +166,6 @@ function SegmentSliderComponent({
   max = 100,
   disabled = false,
   showBubble = true,
-  activeThumb = false,
   centerOrigin = false,
 }: ISegmentSliderProps) {
   const trackRef = useRef<HTMLDivElement>(null);
@@ -211,14 +208,23 @@ function SegmentSliderComponent({
 
   const centerPct = useMemo(() => valueToPct(0), [valueToPct]);
 
+  const segmentIndexToValue = useCallback(
+    (index: number) => Math.round(min + index * stepValue),
+    [min, stepValue],
+  );
+
+  const segmentIndexToPct = useCallback(
+    (index: number) => valueToPct(segmentIndexToValue(index)),
+    [segmentIndexToValue, valueToPct],
+  );
+
   const applyMarkActiveStates = useCallback(
     (v: number) => {
       if (!hasSegments) return;
-      const total = segments;
       const valuePct = valueToPct(v);
       markRefs.current.forEach((el, idx) => {
         if (!el) return;
-        const markPct = (idx / total) * 100;
+        const markPct = segmentIndexToPct(idx);
         let active = false;
         if (centerOrigin) {
           if (v === 0) {
@@ -239,8 +245,8 @@ function SegmentSliderComponent({
     },
     [
       hasSegments,
-      segments,
       valueToPct,
+      segmentIndexToPct,
       centerOrigin,
       centerPct,
       bgPrimary,
@@ -351,14 +357,14 @@ function SegmentSliderComponent({
   const snapToStep = useCallback(
     (idx: number) => {
       if (!hasSegments) return;
-      const snapped = Math.round(min + idx * stepValue);
+      const snapped = segmentIndexToValue(idx);
       applyVisual(snapped);
       if (snapped !== lastEmittedRef.current) {
         lastEmittedRef.current = snapped;
         onChange(snapped);
       }
     },
-    [hasSegments, min, stepValue, applyVisual, onChange],
+    [hasSegments, segmentIndexToValue, applyVisual, onChange],
   );
 
   const handlePointerDown = useCallback(
@@ -557,12 +563,12 @@ function SegmentSliderComponent({
       width: THUMB_SIZE,
       height: THUMB_SIZE,
       borderRadius: '50%',
-      background: activeThumb ? bgPrimary : bg,
+      background: bg,
       border: `1px solid ${borderStrong}`,
       boxShadow: '0 1px 2px rgba(0, 0, 0, 0.08)',
       boxSizing: 'border-box',
     }),
-    [activeThumb, bg, bgPrimary, borderStrong],
+    [bg, borderStrong],
   );
 
   const thumbWrapperStyle = useMemo<CSSProperties>(
@@ -625,7 +631,7 @@ function SegmentSliderComponent({
           <SegmentMark
             key={idx}
             index={idx}
-            pct={(idx / segments) * 100}
+            pct={segmentIndexToPct(idx)}
             hoverGlowColor={markHoverGlow}
             disabled={disabled}
             registerRef={registerMarkRef}

--- a/packages/components/src/composite/SegmentSlider/index.tsx
+++ b/packages/components/src/composite/SegmentSlider/index.tsx
@@ -36,6 +36,8 @@ export interface ISegmentSliderProps {
   max?: number;
   disabled?: boolean;
   showBubble?: boolean;
+  /** Uses the active track color for the thumb instead of the page background. */
+  activeThumb?: boolean;
   /**
    * When true, the slider fills from center (0) instead of left edge.
    * Negative values fill left from center, positive values fill right from
@@ -166,6 +168,7 @@ function SegmentSliderComponent({
   max = 100,
   disabled = false,
   showBubble = true,
+  activeThumb = false,
   centerOrigin = false,
 }: ISegmentSliderProps) {
   const trackRef = useRef<HTMLDivElement>(null);
@@ -554,12 +557,12 @@ function SegmentSliderComponent({
       width: THUMB_SIZE,
       height: THUMB_SIZE,
       borderRadius: '50%',
-      background: bg,
+      background: activeThumb ? bgPrimary : bg,
       border: `1px solid ${borderStrong}`,
       boxShadow: '0 1px 2px rgba(0, 0, 0, 0.08)',
       boxSizing: 'border-box',
     }),
-    [bg, borderStrong],
+    [activeThumb, bg, bgPrimary, borderStrong],
   );
 
   const thumbWrapperStyle = useMemo<CSSProperties>(

--- a/packages/kit-bg/src/dbs/local/LocalDbBase.test.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.test.ts
@@ -1,4 +1,3 @@
-import { EDeviceType, EFirmwareType } from '@onekeyfe/hd-shared';
 import { IDBFactory } from 'fake-indexeddb';
 
 import {
@@ -653,70 +652,6 @@ describe('LocalDbBase.createHDWallet', () => {
         layer.kind === adapter.kind ? adapter : undefined,
     });
     expect(innerCredential.credential).toBe(rs);
-  });
-});
-
-describe('LocalDbBase.createHwWallet', () => {
-  it('refreshes an existing standard wallet name from the current device label', async () => {
-    const db = new TestLocalDb();
-    db.wallets = [
-      {
-        id: 'hw-device-db-1',
-        name: 'Previous device name',
-        type: 'hw',
-        backuped: true,
-        accounts: [],
-        nextIds: {},
-        associatedDevice: 'device-db-1',
-        walletNo: 1,
-      },
-    ];
-    jest.spyOn(db, 'buildHwWalletId').mockResolvedValue({
-      dbDeviceId: 'device-db-1',
-      dbWalletId: 'hw-device-db-1',
-      deviceUUID: 'PRO2_SERIAL',
-      rawDeviceId: 'PRO2_DEVICE_ID',
-    });
-    jest.spyOn(db, 'timeNow').mockResolvedValue(1);
-
-    await db.createHwWallet({
-      device: {
-        connectId: 'PRO2_USB',
-        uuid: 'PRO2_SERIAL',
-        deviceId: 'PRO2_DEVICE_ID',
-        deviceType: EDeviceType.Pro2,
-        name: 'Pro2 6136',
-      },
-      features: {
-        label: 'Current device name',
-        bleName: 'Pro2 6136',
-        deviceType: EDeviceType.Pro2,
-        deviceId: 'PRO2_DEVICE_ID',
-        serialNo: 'PRO2_SERIAL',
-      } as never,
-      deviceState: {
-        schemaVersion: 1,
-        revision: 1,
-        updatedAt: 1,
-        protocol: 'V2',
-        identity: {
-          deviceType: EDeviceType.Pro2,
-          firmwareType: EFirmwareType.Universal,
-          model: 'pro2',
-          vendor: 'onekey.so',
-          deviceId: 'PRO2_DEVICE_ID',
-          serialNo: 'PRO2_SERIAL',
-          label: 'Current device name',
-          bleName: 'Pro2 6136',
-        },
-        status: { mode: 'normal' },
-        settings: {},
-        versions: {},
-        capabilities: [],
-      } as never,
-    });
-
-    expect(db.wallets[0].name).toBe('Current device name');
   });
 });
 

--- a/packages/kit-bg/src/dbs/local/LocalDbBase.test.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.test.ts
@@ -1,3 +1,4 @@
+import { EDeviceType, EFirmwareType } from '@onekeyfe/hd-shared';
 import { IDBFactory } from 'fake-indexeddb';
 
 import {
@@ -652,6 +653,70 @@ describe('LocalDbBase.createHDWallet', () => {
         layer.kind === adapter.kind ? adapter : undefined,
     });
     expect(innerCredential.credential).toBe(rs);
+  });
+});
+
+describe('LocalDbBase.createHwWallet', () => {
+  it('refreshes an existing standard wallet name from the current device label', async () => {
+    const db = new TestLocalDb();
+    db.wallets = [
+      {
+        id: 'hw-device-db-1',
+        name: 'Previous device name',
+        type: 'hw',
+        backuped: true,
+        accounts: [],
+        nextIds: {},
+        associatedDevice: 'device-db-1',
+        walletNo: 1,
+      },
+    ];
+    jest.spyOn(db, 'buildHwWalletId').mockResolvedValue({
+      dbDeviceId: 'device-db-1',
+      dbWalletId: 'hw-device-db-1',
+      deviceUUID: 'PRO2_SERIAL',
+      rawDeviceId: 'PRO2_DEVICE_ID',
+    });
+    jest.spyOn(db, 'timeNow').mockResolvedValue(1);
+
+    await db.createHwWallet({
+      device: {
+        connectId: 'PRO2_USB',
+        uuid: 'PRO2_SERIAL',
+        deviceId: 'PRO2_DEVICE_ID',
+        deviceType: EDeviceType.Pro2,
+        name: 'Pro2 6136',
+      },
+      features: {
+        label: 'Current device name',
+        bleName: 'Pro2 6136',
+        deviceType: EDeviceType.Pro2,
+        deviceId: 'PRO2_DEVICE_ID',
+        serialNo: 'PRO2_SERIAL',
+      } as never,
+      deviceState: {
+        schemaVersion: 1,
+        revision: 1,
+        updatedAt: 1,
+        protocol: 'V2',
+        identity: {
+          deviceType: EDeviceType.Pro2,
+          firmwareType: EFirmwareType.Universal,
+          model: 'pro2',
+          vendor: 'onekey.so',
+          deviceId: 'PRO2_DEVICE_ID',
+          serialNo: 'PRO2_SERIAL',
+          label: 'Current device name',
+          bleName: 'Pro2 6136',
+        },
+        status: { mode: 'normal' },
+        settings: {},
+        versions: {},
+        capabilities: [],
+      } as never,
+    });
+
+    expect(db.wallets[0].name).toBe('Current device name');
   });
 });
 

--- a/packages/kit-bg/src/dbs/local/LocalDbBase.test.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.test.ts
@@ -1,3 +1,4 @@
+import { EDeviceType, EFirmwareType } from '@onekeyfe/hd-shared';
 import { IDBFactory } from 'fake-indexeddb';
 
 import {
@@ -107,6 +108,11 @@ class TestLocalDb extends LocalDbBase {
   removedDeviceIds: string[] = [];
 
   addHDNextIndexedAccountCalls = 0;
+
+  buildCreateResultCalls: {
+    walletId: string;
+    withoutRefillWallet?: boolean;
+  }[] = [];
 
   constructor() {
     super();
@@ -374,9 +380,12 @@ class TestLocalDb extends LocalDbBase {
 
   override async buildCreateHDAndHWWalletResult({
     walletId,
+    withoutRefillWallet,
   }: {
     walletId: string;
+    withoutRefillWallet?: boolean;
   }) {
+    this.buildCreateResultCalls.push({ walletId, withoutRefillWallet });
     return {
       wallet: this.wallets.find((wallet) => wallet.id === walletId)!,
       indexedAccount: undefined,
@@ -652,6 +661,74 @@ describe('LocalDbBase.createHDWallet', () => {
         layer.kind === adapter.kind ? adapter : undefined,
     });
     expect(innerCredential.credential).toBe(rs);
+  });
+});
+
+describe('LocalDbBase.createHwWallet', () => {
+  it('returns the persisted wallet before refill for label synchronization', async () => {
+    const db = new TestLocalDb();
+    db.wallets = [
+      {
+        id: 'hw-device-db-1',
+        name: 'Previous device name',
+        type: 'hw',
+        backuped: true,
+        accounts: [],
+        nextIds: {},
+        associatedDevice: 'device-db-1',
+        walletNo: 1,
+      },
+    ];
+    jest.spyOn(db, 'buildHwWalletId').mockResolvedValue({
+      dbDeviceId: 'device-db-1',
+      dbWalletId: 'hw-device-db-1',
+      deviceUUID: 'PRO2_SERIAL',
+      rawDeviceId: 'PRO2_DEVICE_ID',
+    });
+    jest.spyOn(db, 'timeNow').mockResolvedValue(1);
+
+    const result = await db.createHwWallet({
+      device: {
+        connectId: 'PRO2_USB',
+        uuid: 'PRO2_SERIAL',
+        deviceId: 'PRO2_DEVICE_ID',
+        deviceType: EDeviceType.Pro2,
+        name: 'Pro2 6136',
+      },
+      features: {
+        label: 'Current device name',
+        bleName: 'Pro2 6136',
+        deviceType: EDeviceType.Pro2,
+        deviceId: 'PRO2_DEVICE_ID',
+        serialNo: 'PRO2_SERIAL',
+      } as never,
+      deviceState: {
+        schemaVersion: 1,
+        revision: 1,
+        updatedAt: 1,
+        protocol: 'V2',
+        identity: {
+          deviceType: EDeviceType.Pro2,
+          firmwareType: EFirmwareType.Universal,
+          model: 'pro2',
+          vendor: 'onekey.so',
+          deviceId: 'PRO2_DEVICE_ID',
+          serialNo: 'PRO2_SERIAL',
+          label: 'Current device name',
+          bleName: 'Pro2 6136',
+        },
+        status: { mode: 'normal' },
+        settings: {},
+        versions: {},
+        capabilities: [],
+      } as never,
+    });
+
+    expect(result.wallet.name).toBe('Previous device name');
+    expect(db.buildCreateResultCalls.at(-1)).toEqual({
+      walletId: 'hw-device-db-1',
+      withoutRefillWallet: true,
+    });
   });
 });
 

--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -6447,6 +6447,16 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
             tx,
             walletId: dbWalletId,
             updater: (item) => {
+              const currentDeviceLabel = initialDeviceState?.identity.label;
+              if (
+                existingWallet &&
+                !isExistingHiddenWallet &&
+                !passphraseState &&
+                !name &&
+                currentDeviceLabel
+              ) {
+                item.name = currentDeviceLabel;
+              }
               if (passphraseState) {
                 item.isTemp = false;
               } else if (item.isTemp) {

--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -4432,10 +4432,12 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
     walletId,
     addedHdAccountIndex,
     isOverrideWallet,
+    withoutRefillWallet,
   }: {
     walletId: string;
     addedHdAccountIndex: number;
     isOverrideWallet?: boolean;
+    withoutRefillWallet?: boolean;
   }): Promise<{
     wallet: IDBWallet;
     indexedAccount: IDBIndexedAccount | undefined;
@@ -4444,6 +4446,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
   }> {
     const dbWallet = await this.getWallet({
       walletId,
+      withoutRefill: withoutRefillWallet,
     });
 
     let dbIndexedAccount: IDBIndexedAccount | undefined;
@@ -5936,6 +5939,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       walletId: dbWalletId,
       addedHdAccountIndex,
       isOverrideWallet: Boolean(existingWallet && !existingWallet?.isMocked),
+      withoutRefillWallet: true,
       // isOverrideWallet: existingWallet && !isExistingHiddenWallet,
     });
   }
@@ -6447,16 +6451,6 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
             tx,
             walletId: dbWalletId,
             updater: (item) => {
-              const currentDeviceLabel = initialDeviceState?.identity.label;
-              if (
-                existingWallet &&
-                !isExistingHiddenWallet &&
-                !passphraseState &&
-                !name &&
-                currentDeviceLabel
-              ) {
-                item.name = currentDeviceLabel;
-              }
               if (passphraseState) {
                 item.isTemp = false;
               } else if (item.isTemp) {

--- a/packages/kit-bg/src/dbs/local/LocalDbBase.ts
+++ b/packages/kit-bg/src/dbs/local/LocalDbBase.ts
@@ -5939,7 +5939,6 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       walletId: dbWalletId,
       addedHdAccountIndex,
       isOverrideWallet: Boolean(existingWallet && !existingWallet?.isMocked),
-      withoutRefillWallet: true,
       // isOverrideWallet: existingWallet && !isExistingHiddenWallet,
     });
   }
@@ -6507,6 +6506,7 @@ export abstract class LocalDbBase extends LocalDbBaseContainer {
       walletId: dbWalletId,
       addedHdAccountIndex,
       isOverrideWallet: Boolean(existingWallet && !existingWallet?.isMocked),
+      withoutRefillWallet: true,
       // isOverrideWallet: existingWallet && !isExistingHiddenWallet,
     });
   }

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.hwWalletCreateAddress.test.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.hwWalletCreateAddress.test.ts
@@ -1,5 +1,7 @@
 import { EHardwareVendor } from '@onekeyhq/shared/types/device';
 
+import localDb from '../../dbs/local/localDb';
+
 import ServiceAccount from './ServiceAccount';
 
 jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
@@ -29,10 +31,15 @@ jest.mock('@onekeyhq/shared/src/eventBus/appEventBus', () => ({
 
 jest.mock('../../dbs/local/localDb', () => ({
   __esModule: true,
-  default: {},
+  default: {
+    createHwWallet: jest.fn(),
+  },
 }));
 
 type IHwWalletCreateAddressService = {
+  createHWWalletBase(params: unknown): Promise<{ wallet: { name: string } }>;
+  setWalletNameAndAvatar(params: unknown): Promise<{ name: string }>;
+  getWallet(params: unknown): Promise<{ name: string }>;
   getFeaturesForHwWalletCreate(params: {
     dbDevice: {
       vendor: EHardwareVendor;
@@ -54,6 +61,89 @@ type IHwWalletCreateAddressService = {
 };
 
 describe('ServiceAccount hardware wallet creation address', () => {
+  const createHwWalletMock = jest.spyOn(localDb, 'createHwWallet');
+
+  beforeEach(() => {
+    createHwWalletMock.mockReset();
+  });
+
+  it('persists the current Pro2 label after reading the stored wallet name', async () => {
+    createHwWalletMock.mockResolvedValue({
+      wallet: { id: 'hw-wallet-1', name: 'Previous device name' },
+    } as never);
+    const service = new ServiceAccount({
+      backgroundApi: {
+        serviceHardware: {
+          getCompatibleConnectId: jest.fn().mockResolvedValue('PRO2_USB'),
+        },
+      },
+    }) as unknown as IHwWalletCreateAddressService;
+    const setWalletNameAndAvatarMock = jest.fn().mockResolvedValue({
+      id: 'hw-wallet-1',
+      name: 'Current device name',
+    });
+    service.setWalletNameAndAvatar = setWalletNameAndAvatarMock;
+
+    await expect(
+      service.createHWWalletBase({
+        device: { connectId: 'PRO2_USB', deviceId: 'PRO2_DEVICE_ID' },
+        features: { deviceId: 'PRO2_DEVICE_ID' },
+        deviceState: {
+          protocol: 'V2',
+          identity: {
+            deviceId: 'PRO2_DEVICE_ID',
+            label: 'Current device name',
+          },
+        },
+        isMockedStandardHwWallet: true,
+      }),
+    ).resolves.toMatchObject({ wallet: { name: 'Current device name' } });
+    expect(setWalletNameAndAvatarMock).toHaveBeenCalledWith({
+      walletId: 'hw-wallet-1',
+      name: 'Current device name',
+      shouldCheckDuplicate: false,
+    });
+  });
+
+  it('keeps wallet creation successful when Pro2 label persistence fails', async () => {
+    createHwWalletMock.mockResolvedValue({
+      wallet: { id: 'hw-wallet-1', name: 'Previous device name' },
+    } as never);
+    const service = new ServiceAccount({
+      backgroundApi: {
+        serviceHardware: {
+          getCompatibleConnectId: jest.fn().mockResolvedValue('PRO2_USB'),
+        },
+      },
+    }) as unknown as IHwWalletCreateAddressService;
+    service.setWalletNameAndAvatar = jest
+      .fn()
+      .mockRejectedValue(new Error('sync failed'));
+    const getWalletMock = jest.fn().mockResolvedValue({
+      id: 'hw-wallet-1',
+      name: 'Previous device name',
+    });
+    service.getWallet = getWalletMock;
+
+    await expect(
+      service.createHWWalletBase({
+        device: { connectId: 'PRO2_USB', deviceId: 'PRO2_DEVICE_ID' },
+        features: { deviceId: 'PRO2_DEVICE_ID' },
+        deviceState: {
+          protocol: 'V2',
+          identity: {
+            deviceId: 'PRO2_DEVICE_ID',
+            label: 'Current device name',
+          },
+        },
+        isMockedStandardHwWallet: true,
+      }),
+    ).resolves.toMatchObject({ wallet: { name: 'Previous device name' } });
+    expect(getWalletMock).toHaveBeenCalledWith({
+      walletId: 'hw-wallet-1',
+    });
+  });
+
   it('创建 Pro1 隐藏钱包时复用已持久化状态，避免打断刚建立的 passphrase 会话', async () => {
     const getDeviceState = jest.fn();
     const service = new ServiceAccount({

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -214,6 +214,7 @@ import {
 } from './botWalletCreateUtils';
 import { buildBtcOnlyFirmwareCacheKey } from './btcOnlyFirmwareCacheUtils';
 import {
+  getStandardHwWalletLabelForNameSync,
   refreshDeviceStateAfterStandardWalletUnlock,
   resolveDeviceStateForHwWalletCreate,
 } from './deviceStateForHwWalletCreate';
@@ -3898,6 +3899,22 @@ class ServiceAccount extends ServiceBase {
         : undefined,
       transportType,
     });
+    const deviceLabel = getStandardHwWalletLabelForNameSync({
+      currentWalletName: result.wallet.name,
+      deviceState,
+      explicitName: params.name,
+      isThirdParty: Boolean(vendorProfile?.isThirdParty),
+      passphraseState,
+    });
+    if (deviceLabel) {
+      result.wallet = await this.setWalletNameAndAvatar({
+        walletId: result.wallet.id,
+        name: deviceLabel,
+        shouldCheckDuplicate: false,
+      });
+    } else {
+      result.wallet = await this.getWallet({ walletId: result.wallet.id });
+    }
     // Third-party chain fingerprints are generated lazily by the keyring via SDK.
 
     // Trezor: THP pairing credentials were minted while probing the device above

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -3907,11 +3907,19 @@ class ServiceAccount extends ServiceBase {
       passphraseState,
     });
     if (deviceLabel) {
-      result.wallet = await this.setWalletNameAndAvatar({
-        walletId: result.wallet.id,
-        name: deviceLabel,
-        shouldCheckDuplicate: false,
-      });
+      try {
+        result.wallet = await this.setWalletNameAndAvatar({
+          walletId: result.wallet.id,
+          name: deviceLabel,
+          shouldCheckDuplicate: false,
+        });
+      } catch (error) {
+        defaultLogger.hardware.sdkLog.log(
+          'createHWWalletBase: unable to persist device label',
+          error instanceof Error ? error.message : 'Unknown error',
+        );
+        result.wallet = await this.getWallet({ walletId: result.wallet.id });
+      }
     } else {
       result.wallet = await this.getWallet({ walletId: result.wallet.id });
     }

--- a/packages/kit-bg/src/services/ServiceAccount/deviceStateForHwWalletCreate.test.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/deviceStateForHwWalletCreate.test.ts
@@ -1,7 +1,51 @@
 import {
+  getStandardHwWalletLabelForNameSync,
   refreshDeviceStateAfterStandardWalletUnlock,
   resolveDeviceStateForHwWalletCreate,
 } from './deviceStateForHwWalletCreate';
+
+describe('getStandardHwWalletLabelForNameSync', () => {
+  const deviceState = {
+    protocol: 'V2',
+    identity: { label: 'Current device name' },
+  } as never;
+
+  it('returns a changed Pro2 standard-wallet label for persisted name sync', () => {
+    expect(
+      getStandardHwWalletLabelForNameSync({
+        currentWalletName: 'Previous device name',
+        deviceState,
+        isThirdParty: false,
+      }),
+    ).toBe('Current device name');
+  });
+
+  it('skips sync when the wallet already has the current label', () => {
+    expect(
+      getStandardHwWalletLabelForNameSync({
+        currentWalletName: 'Current device name',
+        deviceState,
+        isThirdParty: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    { explicitName: 'Custom name' },
+    { passphraseState: 'hidden-session' },
+    { isThirdParty: true },
+    { deviceState: { protocol: 'V1', identity: { label: 'Classic' } } },
+  ])('does not sync outside a Pro2 standard-wallet restore', (overrides) => {
+    expect(
+      getStandardHwWalletLabelForNameSync({
+        currentWalletName: 'Previous device name',
+        deviceState,
+        isThirdParty: false,
+        ...overrides,
+      } as never),
+    ).toBeUndefined();
+  });
+});
 
 describe('resolveDeviceStateForHwWalletCreate', () => {
   it('loads the canonical OneKey state before creating the DB record', async () => {

--- a/packages/kit-bg/src/services/ServiceAccount/deviceStateForHwWalletCreate.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/deviceStateForHwWalletCreate.ts
@@ -6,6 +6,33 @@ type IGetDeviceStateForHwWalletCreate = (
   params: { scope: 'runtime' },
 ) => Promise<IOneKeyDeviceState>;
 
+export function getStandardHwWalletLabelForNameSync({
+  currentWalletName,
+  deviceState,
+  explicitName,
+  isThirdParty,
+  passphraseState,
+}: {
+  currentWalletName: string;
+  deviceState?: IOneKeyDeviceState;
+  explicitName?: string;
+  isThirdParty: boolean;
+  passphraseState?: string;
+}): string | undefined {
+  const label = deviceState?.identity.label;
+  if (
+    deviceState?.protocol !== 'V2' ||
+    isThirdParty ||
+    passphraseState ||
+    explicitName ||
+    !label ||
+    label === currentWalletName
+  ) {
+    return undefined;
+  }
+  return label;
+}
+
 export async function resolveDeviceStateForHwWalletCreate({
   existingState,
   preserveWalletSession,

--- a/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.pro2DeviceManagement.test.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.pro2DeviceManagement.test.ts
@@ -91,6 +91,9 @@ jest.mock('../../dbs/simple/simpleDb', () => ({
       getRawData: jest.fn().mockResolvedValue({}),
       setRawData: jest.fn().mockResolvedValue({}),
     },
+    legacyWalletNames: {
+      setRawData: jest.fn().mockResolvedValue({}),
+    },
   },
 }));
 
@@ -1485,7 +1488,8 @@ describe('ServiceHardware SDK DeviceState synchronization', () => {
     expect(emitMock).toHaveBeenCalledTimes(2);
   });
 
-  it('does not duplicate label persistence after the SDK state event', async () => {
+  it('waits for the wallet name to persist after changing the device label', async () => {
+    const setWalletNameAndAvatar = jest.fn().mockResolvedValue(undefined);
     const service = new ServiceHardware({
       backgroundApi: {
         serviceAccount: {
@@ -1493,6 +1497,7 @@ describe('ServiceHardware SDK DeviceState synchronization', () => {
             associatedDevice: 'db-device-1',
             name: 'Wallet',
           }),
+          setWalletNameAndAvatar,
         },
       } as unknown as IBackgroundApi,
     });
@@ -1502,7 +1507,7 @@ describe('ServiceHardware SDK DeviceState synchronization', () => {
     // oxlint-disable-next-line typescript/unbound-method -- Jest mock does not depend on a bound this
     jest.mocked(appEventBus.emit).mockClear();
     await service.setDeviceLabel({
-      walletId: 'wallet-1',
+      walletId: 'hw-wallet-1',
       label: 'Renamed Pro 2',
     });
 
@@ -1512,9 +1517,14 @@ describe('ServiceHardware SDK DeviceState synchronization', () => {
       expect.anything(),
     );
     // oxlint-disable-next-line typescript/unbound-method -- Jest mock does not depend on a bound this
-    expect(appEventBus.emit).toHaveBeenCalledWith(
+    expect(setWalletNameAndAvatar).toHaveBeenCalledWith({
+      walletId: 'hw-wallet-1',
+      name: 'Renamed Pro 2',
+      shouldCheckDuplicate: false,
+    });
+    expect(appEventBus.emit).not.toHaveBeenCalledWith(
       EAppEventBusNames.SyncDeviceLabelToWalletName,
-      expect.objectContaining({ label: 'Renamed Pro 2' }),
+      expect.anything(),
     );
   });
 });

--- a/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
@@ -3098,8 +3098,7 @@ class ServiceHardware extends ServiceBase {
       const walletName = wallet?.name;
       const dbDeviceId = wallet?.associatedDevice;
       if (dbDeviceId) {
-        // SDK DEVICE.STATE drives both persistence and UI refreshes.
-        appEventBus.emit(EAppEventBusNames.SyncDeviceLabelToWalletName, {
+        await this.handleHardwareLabelChanged({
           walletId: p.walletId,
           dbDeviceId,
           label: p.label,

--- a/packages/kit/src/states/jotai/contexts/deviceDetails/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/deviceDetails/actions.ts
@@ -124,6 +124,9 @@ async function buildDeviceMetaStatic(
 
   return {
     deviceName,
+    bleName: isThirdParty
+      ? undefined
+      : deviceUtils.buildDeviceBleName({ features }),
     serialNo: device.uuid,
     deviceType,
     firmwareType,

--- a/packages/kit/src/states/jotai/contexts/deviceDetails/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/deviceDetails/atoms.ts
@@ -49,6 +49,7 @@ export const { atom: deviceAtom, use: useDeviceAtom } = contextAtomComputed(
 
 export type IDeviceMetaStatic = {
   deviceName?: string;
+  bleName?: string;
   serialNo?: string;
   deviceType?: EDeviceType;
   firmwareType?: Awaited<ReturnType<typeof deviceUtils.getFirmwareType>>;
@@ -60,6 +61,7 @@ export type IDeviceMetaStatic = {
 
 export const emptyMetaStatic: IDeviceMetaStatic = {
   deviceName: undefined,
+  bleName: undefined,
   serialNo: undefined,
   deviceType: undefined,
   firmwareType: undefined,

--- a/packages/kit/src/states/jotai/contexts/deviceDetails/deviceStateManagement.test.ts
+++ b/packages/kit/src/states/jotai/contexts/deviceDetails/deviceStateManagement.test.ts
@@ -4,6 +4,7 @@ import { emptyMetaState } from './atoms';
 import {
   buildDeviceMetaStateFromState,
   getDeviceMetaStaticDataFromState,
+  getDeviceSecondaryIdentifier,
   getDeviceStateSnapshotFromEvent,
   isDeviceManagementWalletUsable,
   mergeDeviceSettingState,
@@ -447,11 +448,30 @@ describe('DeviceState metadata projection', () => {
       } as never),
     ).toEqual({
       deviceName: 'My OneKey',
+      bleName: 'Pro2 6136',
       serialNo: 'PR9999999999',
       deviceType: 'pro2',
       firmwareType: 'universal',
       firmwareVersion: '1.0.0',
     });
+  });
+
+  it('uses the BLE name as the Pro2 secondary identifier', () => {
+    expect(
+      getDeviceSecondaryIdentifier({
+        deviceType: EDeviceType.Pro2,
+        bleName: 'Pro2 6136',
+        serialNo: 'P2D33C0005B',
+      }),
+    ).toBe('Pro2 6136');
+
+    expect(
+      getDeviceSecondaryIdentifier({
+        deviceType: EDeviceType.Pro,
+        bleName: 'Pro 6136',
+        serialNo: 'SERIAL',
+      }),
+    ).toBe('SERIAL');
   });
 
   it('uses canonical state fields while retaining the V1 software-PIN preference', () => {

--- a/packages/kit/src/states/jotai/contexts/deviceDetails/deviceStateManagement.test.ts
+++ b/packages/kit/src/states/jotai/contexts/deviceDetails/deviceStateManagement.test.ts
@@ -467,6 +467,14 @@ describe('DeviceState metadata projection', () => {
 
     expect(
       getDeviceSecondaryIdentifier({
+        deviceType: EDeviceType.Pro2,
+        bleName: '',
+        serialNo: 'P2D33C0005B',
+      }),
+    ).toBe('P2D33C0005B');
+
+    expect(
+      getDeviceSecondaryIdentifier({
         deviceType: EDeviceType.Pro,
         bleName: 'Pro 6136',
         serialNo: 'SERIAL',

--- a/packages/kit/src/states/jotai/contexts/deviceDetails/deviceStateManagement.ts
+++ b/packages/kit/src/states/jotai/contexts/deviceDetails/deviceStateManagement.ts
@@ -1,4 +1,4 @@
-import { EFirmwareType } from '@onekeyfe/hd-shared';
+import { EDeviceType, EFirmwareType } from '@onekeyfe/hd-shared';
 
 import {
   hasDeviceStateIdentityMismatch,
@@ -9,9 +9,8 @@ import { isProtocolV2ProductType } from '@onekeyhq/shared/src/utils/hardwareDevi
 import type { IHwQrWalletWithDevice } from '@onekeyhq/shared/types/account';
 import type { IOneKeyDeviceState } from '@onekeyhq/shared/types/device';
 
-import type { IDeviceMetaState } from './atoms';
+import type { IDeviceMetaState, IDeviceMetaStatic } from './atoms';
 import type { DeviceStateEvent } from '@onekeyfe/hd-core';
-import type { EDeviceType } from '@onekeyfe/hd-shared';
 
 export type IDeviceStateSnapshot = {
   state: IOneKeyDeviceState;
@@ -200,11 +199,23 @@ export function canEditPro2DeviceWideSettings({
 export function getDeviceMetaStaticDataFromState(state: IOneKeyDeviceState) {
   return {
     deviceName: deviceUtils.getDeviceDisplayName({ state }),
+    bleName: state.identity.bleName ?? undefined,
     serialNo: state.identity.serialNo ?? undefined,
     deviceType: state.identity.deviceType,
     firmwareType: state.identity.firmwareType,
     firmwareVersion: state.versions.firmware ?? undefined,
   };
+}
+
+export function getDeviceSecondaryIdentifier(
+  deviceMetaStatic: Pick<
+    IDeviceMetaStatic,
+    'bleName' | 'deviceType' | 'serialNo'
+  >,
+) {
+  return deviceMetaStatic.deviceType === EDeviceType.Pro2
+    ? deviceMetaStatic.bleName || deviceMetaStatic.serialNo
+    : deviceMetaStatic.serialNo;
 }
 
 export function buildDeviceMetaStateFromState({

--- a/packages/kit/src/states/jotai/contexts/deviceDetails/index.tsx
+++ b/packages/kit/src/states/jotai/contexts/deviceDetails/index.tsx
@@ -2,5 +2,6 @@ export * from './atoms';
 export * from './actions';
 export {
   canEditPro2DeviceWideSettings,
+  getDeviceSecondaryIdentifier,
   resolveDeviceWithCurrentType,
 } from './deviceStateManagement';

--- a/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/DeviceBasicInfo.tsx
+++ b/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/DeviceBasicInfo.tsx
@@ -13,6 +13,7 @@ import {
 } from '@onekeyhq/components';
 import { WalletAvatar } from '@onekeyhq/kit/src/components/WalletAvatar';
 import {
+  getDeviceSecondaryIdentifier,
   useCurrentWalletIdAtom,
   useDeviceMetaStateAtom,
   useDeviceMetaStaticAtom,
@@ -93,6 +94,8 @@ function DeviceBasicInfo({
   const [deviceMetaStatic] = useDeviceMetaStaticAtom();
   const [deviceMetaState] = useDeviceMetaStateAtom();
   const [refreshSettled] = useRefreshSettledAtom();
+  const deviceSecondaryIdentifier =
+    getDeviceSecondaryIdentifier(deviceMetaStatic);
 
   const isQrWallet = accountUtils.isQrWallet({ walletId: currentWalletId });
 
@@ -154,9 +157,9 @@ function DeviceBasicInfo({
           <XStack ml={-5} pr="$5">
             <DeviceWalletRenameButton textSize={titleTextSize} />
           </XStack>
-          {deviceMetaStatic.serialNo ? (
+          {deviceSecondaryIdentifier ? (
             <SizableText size="$bodyMd" color="$textSubdued" pl="$0.5">
-              {deviceMetaStatic.serialNo}
+              {deviceSecondaryIdentifier}
             </SizableText>
           ) : null}
           {isQrWallet || !showFirmwareVersion ? null : (

--- a/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/DeviceBrightnessSlider.tsx
+++ b/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/DeviceBrightnessSlider.tsx
@@ -140,6 +140,7 @@ export function DeviceBrightnessSlider({
         segments={4}
         sliderHeight={4}
         showBubble
+        activeThumb
         disabled={disabled}
         onChange={handleChange}
         onSlideComplete={handleSlideComplete}

--- a/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/DeviceBrightnessSlider.tsx
+++ b/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/DeviceBrightnessSlider.tsx
@@ -140,6 +140,7 @@ export function DeviceBrightnessSlider({
         segments={4}
         sliderHeight={4}
         showBubble
+        alignSegmentMarksToIntegerValues
         disabled={disabled}
         onChange={handleChange}
         onSlideComplete={handleSlideComplete}

--- a/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/DeviceBrightnessSlider.tsx
+++ b/packages/kit/src/views/DeviceManagement/pages/DeviceDetailsModal/DeviceBrightnessSlider.tsx
@@ -140,7 +140,6 @@ export function DeviceBrightnessSlider({
         segments={4}
         sliderHeight={4}
         showBubble
-        activeThumb
         disabled={disabled}
         onChange={handleChange}
         onSlideComplete={handleSlideComplete}

--- a/packages/shared/src/utils/deviceUtils.test.ts
+++ b/packages/shared/src/utils/deviceUtils.test.ts
@@ -106,6 +106,18 @@ describe('deviceUtils', () => {
     });
   });
 
+  it('formats a serial-like Pro2 BLE name for display', () => {
+    const state = {
+      identity: {
+        label: null,
+        bleName: 'P2D33C0005B',
+        deviceType: EDeviceType.Pro2,
+      },
+    } as never;
+
+    expect(deviceUtils.getDeviceDisplayName({ state })).toBe('Pro2 005B');
+  });
+
   it('prefers persisted DeviceState versions over stale legacy Features', async () => {
     await expect(
       deviceUtils.getDeviceVersion({

--- a/packages/shared/src/utils/deviceUtils.test.ts
+++ b/packages/shared/src/utils/deviceUtils.test.ts
@@ -106,18 +106,6 @@ describe('deviceUtils', () => {
     });
   });
 
-  it('formats a serial-like Pro2 BLE name for display', () => {
-    const state = {
-      identity: {
-        label: null,
-        bleName: 'P2D33C0005B',
-        deviceType: EDeviceType.Pro2,
-      },
-    } as never;
-
-    expect(deviceUtils.getDeviceDisplayName({ state })).toBe('Pro2 005B');
-  });
-
   it('prefers persisted DeviceState versions over stale legacy Features', async () => {
     await expect(
       deviceUtils.getDeviceVersion({

--- a/packages/shared/src/utils/deviceUtils.ts
+++ b/packages/shared/src/utils/deviceUtils.ts
@@ -79,16 +79,12 @@ function getDeviceDisplayName({ state }: { state: DeviceState }): string {
   const defaultName = identity.deviceType
     ? getDefaultDeviceLabel(identity.deviceType)
     : undefined;
-  const rawBleName = identity.bleName?.trim();
-  // Early Pro2 firmware can expose its serial as the BLE advertising name.
-  const bleName =
-    identity.deviceType === EDeviceType.Pro2 &&
-    rawBleName &&
-    /^P2[A-Z0-9]{8,}$/iu.test(rawBleName)
-      ? `Pro2 ${rawBleName.slice(-4).toUpperCase()}`
-      : rawBleName;
   return (
-    identity.label || bleName || defaultName || identity.model || 'OneKey'
+    identity.label ||
+    identity.bleName ||
+    defaultName ||
+    identity.model ||
+    'OneKey'
   );
 }
 

--- a/packages/shared/src/utils/deviceUtils.ts
+++ b/packages/shared/src/utils/deviceUtils.ts
@@ -79,12 +79,16 @@ function getDeviceDisplayName({ state }: { state: DeviceState }): string {
   const defaultName = identity.deviceType
     ? getDefaultDeviceLabel(identity.deviceType)
     : undefined;
+  const rawBleName = identity.bleName?.trim();
+  // Early Pro2 firmware can expose its serial as the BLE advertising name.
+  const bleName =
+    identity.deviceType === EDeviceType.Pro2 &&
+    rawBleName &&
+    /^P2[A-Z0-9]{8,}$/iu.test(rawBleName)
+      ? `Pro2 ${rawBleName.slice(-4).toUpperCase()}`
+      : rawBleName;
   return (
-    identity.label ||
-    identity.bleName ||
-    defaultName ||
-    identity.model ||
-    'OneKey'
+    identity.label || bleName || defaultName || identity.model || 'OneKey'
   );
 }
 

--- a/packages/shared/src/utils/portfolioPayload.test.ts
+++ b/packages/shared/src/utils/portfolioPayload.test.ts
@@ -221,6 +221,28 @@ describe('buildPortfolioPayload', () => {
   });
 
   test.each([
+    ['gtq', 'Q'],
+    ['zmw', 'ZK'],
+  ])(
+    'separates alphabetic %s currency symbol %s from the amount',
+    (id, symbol) => {
+      const payload = buildPortfolioPayload({
+        account: { label: 'Account #1', addressMasked: '0x12...ab' },
+        aggregateTokenMap: {},
+        currencyMap,
+        displayCurrency: { id, symbol },
+        totalFiat: '0.04',
+        totalTokenCount: 0,
+        timestamp: 1_780_900_000,
+        tokenMap: {},
+        tokens: [],
+      });
+
+      expect(payload.totalFiat).toBe(`${symbol} 0.04`);
+    },
+  );
+
+  test.each([
     ['eur', '€'],
     ['krw', '₩'],
     ['inr', '₹'],

--- a/packages/shared/src/utils/portfolioPayload.ts
+++ b/packages/shared/src/utils/portfolioPayload.ts
@@ -202,7 +202,7 @@ function getPortfolioCurrencyPrefix({
 }: IPortfolioDisplayCurrency): string {
   const normalizedSymbol = symbol.trim();
   if (normalizedSymbol && isPortfolioFirmwareFontSupported(normalizedSymbol)) {
-    return /^[a-z]{2,6}$/iu.test(normalizedSymbol)
+    return /^[a-z]{1,6}$/iu.test(normalizedSymbol)
       ? `${normalizedSymbol.toUpperCase()} `
       : normalizedSymbol;
   }


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60188](https://onekeyhq.atlassian.net/browse/OK-60188) [OK-59745](https://onekeyhq.atlassian.net/browse/OK-59745) [OK-60258](https://onekeyhq.atlassian.net/browse/OK-60258)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Align the Pro2 brightness thumb and segment marks on Desktop/Web at the integer values emitted by the slider.
- Show the real Pro2 Bluetooth name as the device-details secondary identifier, with the serial number used only as a fallback.
- Separate one- and multi-letter Portfolio currency symbols from their amounts consistently.
- Persist the current Protocol V2 device label when an existing standard hardware wallet is re-imported.
- Wait for wallet-name persistence after changing the device label so the UI cannot read stale state.

## Intent & Context
The Pro2 brightness slider could render two nearby circles because its range (`10...100`) produces fractional quarter marks while the UI emits integer brightness values. A Pro2 created over USB also showed its serial number in the secondary line instead of its Bluetooth name. Portfolio totals rendered one-letter alphabetic currency symbols such as `Q` without a separator while multi-letter symbols such as `ZK` included one. Separately, resetting and re-importing the same wallet or changing the device label could leave the App showing the previous wallet name.

Related issues: OK-60188, OK-59745, OK-60258.

## Root Cause
- The Web/Desktop SegmentSlider drew marks at fractional percentages but emitted rounded integer values, so `32%` and `78%` could not share the same position as their visual marks.
- The Pro2 device-details secondary line always selected `serialNo`, even though Protocol V2 state keeps `bleName` and `serialNo` as independent fields.
- Portfolio formatting classified only alphabetic symbols with two to six letters as units requiring a separator.
- Hardware-wallet creation originally returned a refilled wallet whose in-memory name had already been replaced by the current device label, preventing comparison with the persisted old name.
- Device-label changes previously emitted asynchronous wallet synchronization without awaiting persistence.

## Design Decisions
- Keep the shared SegmentSlider default behavior unchanged. Integer-aligned segment values are opt-in and enabled only by the Pro2 brightness control on Desktop/Web.
- Use symmetric half-even rounding for fractional brightness nodes, yielding `10 / 32 / 55 / 78 / 100`, and use the same values for marks, clicks, snapping, and keyboard navigation.
- Preserve Bluetooth name, serial number, and device label as independent raw values; do not normalize or rewrite SDK data.
- Change only the Pro2 device-details secondary identifier to prefer `bleName`, with `serialNo` as degraded-data fallback.
- Return the raw persisted hardware-wallet record only inside the background creation flow, then use the existing wallet rename API so the DB record, Cloud Sync item, change history, and UI events remain consistent.
- Treat post-create label persistence as best-effort so a display-name failure cannot turn an already committed wallet into a reported creation failure.

## Changes Detail
- Add a Web/Desktop-only opt-in for integer-aligned segment marks and enable it for Pro2 brightness.
- Add a component regression test covering `10 → 32 → 55 → 78 → 100` keyboard navigation.
- Project `bleName` into device-detail metadata and use it for the Pro2 secondary line, including empty-name serial fallback coverage.
- Format both `Q` and `ZK` Portfolio totals with a separator before the amount.
- Compare the persisted hardware-wallet name with the current Protocol V2 device label during re-import.
- Keep QR wallet creation on the normal fully refilled return path.
- Add integration coverage for successful Pro2 label persistence and best-effort fallback when rename persistence fails.
- Await wallet-name persistence after a successful device-label change.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop, Web, Extension for brightness geometry; all App platforms for metadata, Portfolio formatting, and wallet-label persistence.
- **Not affected**: Native segment geometry is rendered by the native slider and is not changed by the Desktop/Web alignment option. Protocol V1, hidden wallets, third-party hardware wallets, and explicitly named wallets do not enter the automatic label-sync path.

## Verification
- Independent Codex cross-review completed against the latest implementation; no remaining blocker was found for OK-59745 or OK-60258, and the OK-60188 implementation was narrowed to an opt-in after review.
- Focused tests passed for brightness state, integer segment navigation, Pro2 BLE/serial metadata, Portfolio formatting, LocalDb hardware creation wiring, ServiceAccount label persistence/fallback, and device-label synchronization.
- Focused lint and formatting checks passed.
- Repository-wide TypeScript checking is currently blocked by unrelated dirty-worktree errors and the existing missing declaration for `@onekeyfe/hd-common-connect-sdk`; none point to the files in this change.

## Test plan
- [x] Verify the brightness component emits `10 / 32 / 55 / 78 / 100` for its four segment steps on Desktop/Web.
- [x] Verify Pro2 uses `bleName` for its secondary identifier and falls back to unchanged `serialNo` when the BLE name is empty.
- [x] Verify `Q 0.04` and `ZK 0.04` formatting while glyph symbols retain their existing format.
- [x] Verify re-import reads the persisted wallet name, calls the existing rename path, and still returns the created wallet if label persistence fails.
- [ ] Verify brightness thumb/mark alignment against a physical Pro2 on Desktop/Web at both `32%` and `78%`.
- [ ] Verify a USB-created Pro2 shows its Bluetooth name while its serial number remains unchanged in device data.
- [ ] Reset and re-import the same mnemonic after changing the Pro2 label; verify the App shows the current label.
- [ ] Change the Pro2 label from the App; verify the wallet selector updates immediately after the dialog completes.
- [ ] Sync GTQ and ZMW Portfolio data to a physical Pro2 and verify the displayed separator.

[OK-60188]: https://onekeyhq.atlassian.net/browse/OK-60188
[OK-59745]: https://onekeyhq.atlassian.net/browse/OK-59745
[OK-60258]: https://onekeyhq.atlassian.net/browse/OK-60258