### PR TITLE
fix: inject JPUSH_KEY into native bundle builds

### DIFF
--- a/.github/workflows/release-app-bundles.yml
+++ b/.github/workflows/release-app-bundles.yml
@@ -290,6 +290,7 @@ jobs:
       checkout_ref: ${{ needs.prepare-params.outputs.commit }}
     secrets:
       COVALENT_KEY: ${{ secrets.COVALENT_KEY }}
+      JPUSH_KEY: ${{ secrets.JPUSH_KEY }}
       SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
       SENTRY_DSN_REACT_NATIVE: ${{ secrets.SENTRY_DSN_REACT_NATIVE }}
       SENTRY_DSN_WEB: ${{ secrets.SENTRY_DSN_WEB }}
@@ -321,6 +322,7 @@ jobs:
       checkout_ref: ${{ needs.prepare-params.outputs.commit }}
     secrets:
       COVALENT_KEY: ${{ secrets.COVALENT_KEY }}
+      JPUSH_KEY: ${{ secrets.JPUSH_KEY }}
       SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
       SENTRY_DSN_REACT_NATIVE: ${{ secrets.SENTRY_DSN_REACT_NATIVE }}
       SENTRY_DSN_WEB: ${{ secrets.SENTRY_DSN_WEB }}

--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -53,6 +53,8 @@ on:
     secrets:
       COVALENT_KEY:
         required: false
+      JPUSH_KEY:
+        required: false
       SENTRY_TOKEN:
         required: false
       SENTRY_DSN_REACT_NATIVE:
@@ -370,13 +372,19 @@ jobs:
       - name: Build Bundle
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'
+          JPUSH_KEY: ${{ secrets.JPUSH_KEY }}
           APPLEID: ${{ secrets.APPLEID }}
           APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
           ASC_PROVIDER: ${{ secrets.ASC_PROVIDER }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UNION_BUILD: 'true'
           ENABLE_NATIVE_BACKGROUND_THREAD: 'true'
-        run: 'yarn app:build-bundle:${{ matrix.platform }}'
+        run: |
+          if [ -z "$JPUSH_KEY" ]; then
+            echo "::error::JPUSH_KEY is required to build native bundles"
+            exit 1
+          fi
+          yarn app:build-bundle:${{ matrix.platform }}
 
       - name: Validate split-bundle integrity
         # Hard gate: fails the job if any segment ships un-rewritten Metro


### PR DESCRIPTION
## Summary

- pass `JPUSH_KEY` from `release-app-bundles` into both reusable native bundle jobs
- expose the secret to the native bundle build step
- fail fast when `JPUSH_KEY` is missing instead of publishing an unusable OTA bundle

## Root cause

The standalone native bundle workflow built the background JavaScript runtime without receiving `JPUSH_KEY`. Babel therefore inlined an empty value into `PushProviderJPush`, while EAS-based iOS and Android releases received the key through their separate EAS environment.

## Impact

Native OTA bundles can no longer silently ship with an empty JPush AppKey. The GitHub Actions repository or organization secret named `JPUSH_KEY` must be configured and made available to this repository.

## Validation

- `yarn agent:check --profile commit`
- `actionlint` on the modified workflows
- local iOS native bundle built with a non-sensitive sentinel and verified in both source JavaScript and the final Hermes bytecode
- `release-app-bundles` run `31689419649` confirmed the new guard executes; it currently fails as expected because the repository does not yet expose a `JPUSH_KEY` Actions secret
