### PR TITLE
fix: smooth Earn and Borrow UI (OK-60172, OK-59844, OK-59337)

### DIFF
--- a/packages/kit/src/components/PercentageStageOnKeyboard/index.test.tsx
+++ b/packages/kit/src/components/PercentageStageOnKeyboard/index.test.tsx
@@ -1,0 +1,73 @@
+/** @jest-environment jsdom */
+
+import type { ReactNode } from 'react';
+
+import { PercentageStageOnKeyboard } from '.';
+
+import { render, screen } from '@testing-library/react';
+
+const mockPlatformEnv = { isNative: false };
+const mockUseIsKeyboardShown = jest.fn(() => false);
+
+jest.mock('@onekeyhq/components', () => ({
+  XStack: ({
+    children,
+    opacity,
+  }: {
+    children?: ReactNode;
+    opacity?: number;
+  }) => (
+    <div data-opacity={opacity} data-testid="percentage-stage">
+      {children}
+    </div>
+  ),
+  useIsKeyboardShown: () => mockUseIsKeyboardShown(),
+}));
+
+jest.mock(
+  '@onekeyhq/kit/src/views/Swap/components/SwapPercentageStageBadge',
+  () =>
+    ({ stage }: { stage: number }) => <span>{stage}</span>,
+);
+
+jest.mock('@onekeyhq/shared/src/platformEnv', () => ({
+  __esModule: true,
+  default: {
+    get isNative() {
+      return mockPlatformEnv.isNative;
+    },
+  },
+}));
+
+describe('PercentageStageOnKeyboard', () => {
+  beforeEach(() => {
+    mockPlatformEnv.isNative = false;
+    mockUseIsKeyboardShown.mockReturnValue(false);
+  });
+
+  it('does not reserve keyboard space on non-native platforms', () => {
+    render(<PercentageStageOnKeyboard reserveSpaceUntilKeyboardShown />);
+
+    expect(screen.queryByTestId('percentage-stage')).toBeNull();
+  });
+
+  it('reserves hidden space before an expected native keyboard opens', () => {
+    mockPlatformEnv.isNative = true;
+
+    render(<PercentageStageOnKeyboard reserveSpaceUntilKeyboardShown />);
+
+    expect(
+      screen.getByTestId('percentage-stage').getAttribute('data-opacity'),
+    ).toBe('0');
+  });
+
+  it('does not reserve native space when auto-focus is disabled', () => {
+    mockPlatformEnv.isNative = true;
+
+    render(
+      <PercentageStageOnKeyboard reserveSpaceUntilKeyboardShown={false} />,
+    );
+
+    expect(screen.queryByTestId('percentage-stage')).toBeNull();
+  });
+});

--- a/packages/kit/src/components/PercentageStageOnKeyboard/index.tsx
+++ b/packages/kit/src/components/PercentageStageOnKeyboard/index.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import BigNumber from 'bignumber.js';
 
 import { XStack, useIsKeyboardShown } from '@onekeyhq/components';
@@ -81,17 +83,34 @@ export const calcPercentBalance = ({
 };
 export function PercentageStageOnKeyboard({
   onSelectPercentageStage,
+  reserveSpaceUntilKeyboardShown,
 }: {
   onSelectPercentageStage?: (stage: number) => void;
+  /** Keep the footer height stable while an auto-focused input opens the keyboard. */
+  reserveSpaceUntilKeyboardShown?: boolean;
 }) {
   const isShow = useIsKeyboardShown();
-  return isShow ? (
+  const [hasKeyboardShown, setHasKeyboardShown] = useState(false);
+
+  useEffect(() => {
+    if (isShow) {
+      setHasKeyboardShown(true);
+    }
+  }, [isShow]);
+
+  const shouldRender =
+    isShow || (reserveSpaceUntilKeyboardShown && !hasKeyboardShown);
+
+  return shouldRender ? (
     <XStack
+      animation="quick"
       alignItems="center"
       gap="$1"
       justifyContent="space-around"
       bg="$bgSubdued"
       h="$10"
+      opacity={isShow ? 1 : 0}
+      pointerEvents={isShow ? 'auto' : 'none'}
     >
       <>
         {PercentageInputStageForNative.map((stage) => (

--- a/packages/kit/src/components/PercentageStageOnKeyboard/index.tsx
+++ b/packages/kit/src/components/PercentageStageOnKeyboard/index.tsx
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js';
 
 import { XStack, useIsKeyboardShown } from '@onekeyhq/components';
 import SwapPercentageStageBadge from '@onekeyhq/kit/src/views/Swap/components/SwapPercentageStageBadge';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 const countLeadingZeroDecimals = (value: string) => {
   const num = new BigNumber(value);
@@ -98,8 +99,9 @@ export function PercentageStageOnKeyboard({
     }
   }, [isShow]);
 
-  const shouldRender =
-    isShow || (reserveSpaceUntilKeyboardShown && !hasKeyboardShown);
+  const shouldReserveSpace =
+    platformEnv.isNative && reserveSpaceUntilKeyboardShown && !hasKeyboardShown;
+  const shouldRender = isShow || shouldReserveSpace;
 
   return shouldRender ? (
     <XStack

--- a/packages/kit/src/views/Borrow/components/BorrowHealthFactorSummary.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowHealthFactorSummary.tsx
@@ -59,7 +59,11 @@ export function BorrowHealthFactorSummary({
       tooltip={detail ? <BorrowHealthFactorTooltip detail={detail} /> : null}
       action={
         detail?.status ? (
-          <Badge badgeType={detail.status.badge} flexShrink={0}>
+          <Badge
+            badgeType={detail.status.badge}
+            flexShrink={widthMode === 'equal' ? 1 : 0}
+            minWidth={0}
+          >
             {detail.status.tag}
           </Badge>
         ) : null

--- a/packages/kit/src/views/Borrow/components/Overview.tsx
+++ b/packages/kit/src/views/Borrow/components/Overview.tsx
@@ -276,10 +276,9 @@ export const Overview = ({
           </XStack>
         </YStack>
       ) : (
-        /* Phones give the three headline numbers the same weight on one row,
-           wrapping onto a second only when they stop fitting, with the tools
-           pinned to the right of that first row. Top-aligned rather than
-           centred so they stay on the net worth line once the numbers wrap. */
+        /* Phones keep the three headline numbers in equal-width columns so
+           staggered loading results cannot move the later metrics. The tools
+           stay pinned to the right and top-aligned with that row. */
         <>
           <XStack ai="flex-start" gap="$2">
             <XStack flex={1} flexWrap="wrap" ml="$-3" pl="$4">
@@ -287,18 +286,18 @@ export const Overview = ({
                 title={{ text: labels.netWorth }}
                 text={netWorthText}
                 isLoading={isNetWorthLoading}
-                widthMode="hug"
+                widthMode="equal"
               />
               <BorrowHealthFactorSummary
                 {...healthSummaryProps}
-                widthMode="hug"
+                widthMode="equal"
               />
               <OverviewMetric
                 testID={BorrowTestIDs.overviewNetApy}
                 title={{ text: labels.netApy }}
                 text={netApyText}
                 isLoading={isNetApyLoading}
-                widthMode="hug"
+                widthMode="equal"
               />
             </XStack>
             {/* Clears the metric cells' own $3 of top padding */}

--- a/packages/kit/src/views/Borrow/components/OverviewMetric.test.tsx
+++ b/packages/kit/src/views/Borrow/components/OverviewMetric.test.tsx
@@ -69,7 +69,22 @@ jest.mock('@onekeyhq/components', () => ({
 }));
 
 jest.mock('../../Staking/components/ProtocolDetails/EarnText', () => ({
-  EarnText: ({ text }: { text: { text: string } }) => <span>{text.text}</span>,
+  EarnText: ({
+    adjustsFontSizeToFit,
+    minimumFontScale,
+    text,
+  }: {
+    adjustsFontSizeToFit?: boolean;
+    minimumFontScale?: number;
+    text: { text: string };
+  }) => (
+    <span
+      data-adjusts-font-size-to-fit={adjustsFontSizeToFit}
+      data-minimum-font-scale={minimumFontScale}
+    >
+      {text.text}
+    </span>
+  ),
 }));
 
 describe('OverviewMetric', () => {
@@ -133,5 +148,20 @@ describe('OverviewMetric', () => {
     const skeleton = screen.getByTestId('skeleton');
     expect(skeleton.getAttribute('data-width')).toBe('100%');
     expect(skeleton.getAttribute('data-max-width')).toBe('72');
+  });
+
+  it('scales long equal-width values instead of relying on truncation', () => {
+    render(
+      <OverviewMetric
+        testID="equal-metric"
+        title={{ text: 'Net worth' }}
+        text={{ text: '$1,234,567.89' }}
+        widthMode="equal"
+      />,
+    );
+
+    const value = screen.getByText('$1,234,567.89');
+    expect(value.getAttribute('data-adjusts-font-size-to-fit')).toBe('true');
+    expect(value.getAttribute('data-minimum-font-scale')).toBe('0.75');
   });
 });

--- a/packages/kit/src/views/Borrow/components/OverviewMetric.test.tsx
+++ b/packages/kit/src/views/Borrow/components/OverviewMetric.test.tsx
@@ -40,10 +40,31 @@ jest.mock('@onekeyhq/components', () => ({
       {children}
     </button>
   ),
-  Skeleton: () => <div data-testid="skeleton" />,
+  Skeleton: ({ maxWidth, w }: { maxWidth?: number; w?: number | string }) => (
+    <div data-max-width={maxWidth} data-testid="skeleton" data-width={w} />
+  ),
   XStack: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
-  YStack: ({ children, testID }: { children?: ReactNode; testID?: string }) => (
-    <div data-testid={testID}>{children}</div>
+  YStack: ({
+    children,
+    flexBasis,
+    flexGrow,
+    minWidth,
+    testID,
+  }: {
+    children?: ReactNode;
+    flexBasis?: number | string;
+    flexGrow?: number;
+    minWidth?: number;
+    testID?: string;
+  }) => (
+    <div
+      data-flex-basis={flexBasis}
+      data-flex-grow={flexGrow}
+      data-min-width={minWidth}
+      data-testid={testID}
+    >
+      {children}
+    </div>
   ),
 }));
 
@@ -92,5 +113,25 @@ describe('OverviewMetric', () => {
 
     expect(screen.queryByRole('button')).toBeNull();
     expect(screen.getByTestId('static-metric').tagName).toBe('DIV');
+  });
+
+  it('keeps loading and loaded content inside the same equal-width column', () => {
+    render(
+      <OverviewMetric
+        isLoading
+        testID="equal-metric"
+        title={{ text: 'Net APY' }}
+        widthMode="equal"
+      />,
+    );
+
+    const metric = screen.getByTestId('equal-metric');
+    expect(metric.getAttribute('data-flex-basis')).toBe('0');
+    expect(metric.getAttribute('data-flex-grow')).toBe('1');
+    expect(metric.getAttribute('data-min-width')).toBe('0');
+
+    const skeleton = screen.getByTestId('skeleton');
+    expect(skeleton.getAttribute('data-width')).toBe('100%');
+    expect(skeleton.getAttribute('data-max-width')).toBe('72');
   });
 });

--- a/packages/kit/src/views/Borrow/components/OverviewMetric.tsx
+++ b/packages/kit/src/views/Borrow/components/OverviewMetric.tsx
@@ -48,6 +48,8 @@ export function OverviewMetric({
           color="$text"
           flexShrink={1}
           numberOfLines={1}
+          adjustsFontSizeToFit={widthMode === 'equal'}
+          minimumFontScale={widthMode === 'equal' ? 0.75 : undefined}
         />
       ) : null}
       {action}

--- a/packages/kit/src/views/Borrow/components/OverviewMetric.tsx
+++ b/packages/kit/src/views/Borrow/components/OverviewMetric.tsx
@@ -3,6 +3,12 @@ import type { IEarnText } from '@onekeyhq/shared/types/staking';
 
 import { EarnText } from '../../Staking/components/ProtocolDetails/EarnText';
 
+const flexBasisByWidthMode = {
+  columns: '50%',
+  equal: 0,
+  hug: 'auto',
+} as const;
+
 export type IOverviewMetricProps = {
   title: IEarnText;
   text?: IEarnText;
@@ -12,7 +18,7 @@ export type IOverviewMetricProps = {
   onPress?: () => void;
   testID?: string;
   valueLayout?: 'inline' | 'stacked';
-  widthMode?: 'columns' | 'hug';
+  widthMode?: 'columns' | 'equal' | 'hug';
 };
 
 export function OverviewMetric({
@@ -28,7 +34,7 @@ export function OverviewMetric({
 }: IOverviewMetricProps) {
   const valueContent = isLoading ? (
     <>
-      <Skeleton w={72} h="$6" borderRadius="$1" />
+      <Skeleton w="100%" maxWidth={72} h="$6" borderRadius="$1" />
       {valueLayout === 'stacked' ? (
         <Skeleton w={56} h="$5" borderRadius="$1" />
       ) : null}
@@ -53,8 +59,10 @@ export function OverviewMetric({
     <MetricFrame
       testID={testID}
       p="$3"
-      flexBasis={widthMode === 'hug' ? 'auto' : '50%'}
-      $gtMd={{ flexBasis: 'auto', minWidth: 168 }}
+      flexBasis={flexBasisByWidthMode[widthMode]}
+      flexGrow={widthMode === 'equal' ? 1 : 0}
+      minWidth={widthMode === 'equal' ? 0 : undefined}
+      $gtMd={{ flexBasis: 'auto', flexGrow: 0, minWidth: 168 }}
       {...(onPress && {
         onPress,
         accessibilityLabel: title.text,
@@ -89,7 +97,7 @@ export function OverviewMetric({
           {valueContent}
         </YStack>
       ) : (
-        <XStack ai="center" gap="$1" minHeight="$6">
+        <XStack ai="center" gap="$1" minHeight="$6" width="100%">
           {valueContent}
         </XStack>
       )}

--- a/packages/kit/src/views/Earn/components/showProtocolListDialog.tsx
+++ b/packages/kit/src/views/Earn/components/showProtocolListDialog.tsx
@@ -32,7 +32,6 @@ import {
 } from '../../Staking/components/ProtocolDisplayShared';
 
 import { AprText } from './AprText';
-import { EarnAprSuffixText } from './EarnAprSuffixText';
 
 import type { IntlShape } from 'react-intl';
 
@@ -160,19 +159,6 @@ const groupProtocolsByGroup = (
   });
 
   return sections;
-};
-
-// Keep the APY/APR suffix; EarnAprSuffixText splits it into "value + smaller
-// unit" rendering (OK-58854)
-const getProtocolAprText = (item: IStakeProtocolListItem) => {
-  return (
-    item.aprInfo?.highlight?.text ||
-    item.aprInfo?.normal?.text ||
-    item.aprInfo?.deprecated?.text ||
-    `${BigNumber(item.provider.aprWithoutFee || 0).toFixed(2)}% ${
-      item.provider.rewardUnit || 'APR'
-    }`
-  );
 };
 
 // Quick-switcher provider grouping (OK-58854): native is hidden; bitway is
@@ -439,9 +425,24 @@ export function ProtocolListContent({
             networkLogoURI={item.network.logoURI}
           />
           <YStack flex={1} minWidth={0} gap="$0.5">
-            <SizableText size="$bodyLgMedium" numberOfLines={1}>
-              {getEarnProviderDisplayName(item.provider.name)}
-            </SizableText>
+            <XStack alignItems="center" gap="$1.5" minWidth={0}>
+              <SizableText
+                size="$bodyLgMedium"
+                numberOfLines={1}
+                flexShrink={1}
+              >
+                {getEarnProviderDisplayName(item.provider.name)}
+              </SizableText>
+              {item.provider.badges?.map((badge) => (
+                <Badge
+                  key={badge.tag}
+                  badgeType={badge.badgeType}
+                  badgeSize="sm"
+                >
+                  <Badge.Text>{badge.tag}</Badge.Text>
+                </Badge>
+              ))}
+            </XStack>
             {secondaryText ? (
               <SizableText
                 size="$bodySm"
@@ -453,7 +454,7 @@ export function ProtocolListContent({
             ) : null}
           </YStack>
           <YStack alignItems="flex-end" gap="$0.5" flexShrink={0}>
-            <EarnAprSuffixText text={getProtocolAprText(item)} />
+            <AprText asset={createAssetFromProtocol(item)} />
             {tvlText ? (
               <SizableText size="$bodySm" color="$textSubdued">
                 {`TVL ${tvlText}`}

--- a/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
@@ -966,19 +966,29 @@ export function UniversalStake({
     ICheckAmountAlert[]
   >([]);
   const [checkAmountLoading, setCheckAmountLoading] = useState(false);
+  const checkAmountRequestIdRef = useRef(0);
 
   const quoteLoading = checkAmountLoading || transactionConfirmationLoading;
 
   const checkAmount = useDebouncedCallback(
-    async ({ amount, identity }: { amount: string; identity?: string }) => {
-      if (isInvalidAmount(amount)) {
+    async ({
+      amount,
+      identity,
+      requestId,
+    }: {
+      amount: string;
+      identity?: string;
+      requestId: number;
+    }) => {
+      if (
+        requestId !== checkAmountRequestIdRef.current ||
+        isInvalidAmount(amount)
+      ) {
         return;
       }
       // An empty form is represented as "0" by the initial effect. Treat it as
       // not entered yet so the disabled CTA does not flash a loading spinner.
       if (new BigNumber(amount).isLessThanOrEqualTo(0)) {
-        setCheckoutAmountMessage('');
-        setCheckAmountAlerts([]);
         return;
       }
       setCheckAmountLoading(true);
@@ -1001,6 +1011,10 @@ export function UniversalStake({
           stakeType,
         });
 
+        if (requestId !== checkAmountRequestIdRef.current) {
+          return;
+        }
+
         if (Number(response.code) === 0) {
           setCheckoutAmountMessage('');
           setCheckAmountAlerts(response.data?.alerts || []);
@@ -1009,17 +1023,40 @@ export function UniversalStake({
           setCheckAmountAlerts([]);
         }
       } finally {
-        setCheckAmountLoading(false);
+        if (requestId === checkAmountRequestIdRef.current) {
+          setCheckAmountLoading(false);
+        }
       }
     },
     300,
   );
 
   useEffect(() => {
-    void checkAmount({
-      amount: amountValue || '0',
-      identity: stakefishIdentity,
-    });
+    checkAmount.cancel();
+    checkAmountRequestIdRef.current += 1;
+    const requestId = checkAmountRequestIdRef.current;
+    const amount = amountValue || '0';
+    const cleanup = () => {
+      checkAmount.cancel();
+      if (requestId === checkAmountRequestIdRef.current) {
+        checkAmountRequestIdRef.current += 1;
+      }
+    };
+
+    if (isInvalidAmount(amount)) {
+      setCheckAmountLoading(false);
+      return cleanup;
+    }
+
+    if (new BigNumber(amount).isLessThanOrEqualTo(0)) {
+      setCheckoutAmountMessage('');
+      setCheckAmountAlerts([]);
+      setCheckAmountLoading(false);
+      return cleanup;
+    }
+
+    void checkAmount({ amount, identity: stakefishIdentity, requestId });
+    return cleanup;
   }, [checkAmount, stakefishIdentity, amountValue]);
 
   const onChangeAmountValue = useCallback(
@@ -1045,10 +1082,9 @@ export function UniversalStake({
       if (!isOverflowDecimals) {
         setAmountValue(value);
         void debouncedFetchEstimateFeeResp(value);
-        void checkAmount({ amount: value, identity: stakefishIdentity });
       }
     },
-    [decimals, debouncedFetchEstimateFeeResp, checkAmount, stakefishIdentity],
+    [decimals, debouncedFetchEstimateFeeResp],
   );
 
   const onBlurAmountValue = useOnBlurAmountValue(amountValue, setAmountValue);
@@ -2514,7 +2550,7 @@ export function UniversalStake({
           </Stack>
           <PercentageStageOnKeyboard
             onSelectPercentageStage={onSelectPercentageStage}
-            reserveSpaceUntilKeyboardShown
+            reserveSpaceUntilKeyboardShown={!amountInputDisabled}
           />
         </Page.Footer>
       ) : (

--- a/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
@@ -514,6 +514,8 @@ export function UniversalStake({
       }),
     [networkId],
   ).result;
+  const networkLogoURI =
+    protocolSwitchConfig?.currentProtocol?.network.logoURI ?? network?.logoURI;
 
   const [estimateFeeResp, setEstimateFeeResp] = useState<
     undefined | IEarnEstimateFeeResp
@@ -970,6 +972,13 @@ export function UniversalStake({
   const checkAmount = useDebouncedCallback(
     async ({ amount, identity }: { amount: string; identity?: string }) => {
       if (isInvalidAmount(amount)) {
+        return;
+      }
+      // An empty form is represented as "0" by the initial effect. Treat it as
+      // not entered yet so the disabled CTA does not flash a loading spinner.
+      if (new BigNumber(amount).isLessThanOrEqualTo(0)) {
+        setCheckoutAmountMessage('');
+        setCheckAmountAlerts([]);
         return;
       }
       setCheckAmountLoading(true);
@@ -1795,7 +1804,7 @@ export function UniversalStake({
     amountValue,
     showApyDetail,
     receiveInputConfig,
-    networkLogoURI: network?.logoURI,
+    networkLogoURI,
     isQuoteExpired,
     loading: quoteLoading,
   });
@@ -2218,7 +2227,7 @@ export function UniversalStake({
               tokenSelectorTriggerProps={{
                 selectedTokenImageUri: tokenImageUri,
                 selectedTokenSymbol: tokenSymbol?.toUpperCase(),
-                selectedNetworkImageUri: network?.logoURI,
+                selectedNetworkImageUri: networkLogoURI,
                 ...tokenSelectorTriggerProps,
               }}
               balanceProps={{
@@ -2505,6 +2514,7 @@ export function UniversalStake({
           </Stack>
           <PercentageStageOnKeyboard
             onSelectPercentageStage={onSelectPercentageStage}
+            reserveSpaceUntilKeyboardShown
           />
         </Page.Footer>
       ) : (

--- a/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
@@ -2081,7 +2081,7 @@ export function UniversalWithdraw({
           />
           <PercentageStageOnKeyboard
             onSelectPercentageStage={onSelectPercentageStage}
-            reserveSpaceUntilKeyboardShown
+            reserveSpaceUntilKeyboardShown={!amountInputDisabled}
           />
         </Page.Footer>
       ) : (

--- a/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
@@ -2081,6 +2081,7 @@ export function UniversalWithdraw({
           />
           <PercentageStageOnKeyboard
             onSelectPercentageStage={onSelectPercentageStage}
+            reserveSpaceUntilKeyboardShown
           />
         </Page.Footer>
       ) : (

--- a/packages/kit/src/views/Staking/pages/ManagePosition/components/ManagePositionContent.tsx
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/components/ManagePositionContent.tsx
@@ -7,6 +7,7 @@ import { StyleSheet } from 'react-native';
 import {
   Button,
   Divider,
+  Page,
   SizableText,
   Skeleton,
   XStack,
@@ -14,6 +15,7 @@ import {
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useAccountSelectorTrigger } from '@onekeyhq/kit/src/components/AccountSelector/hooks/useAccountSelectorTrigger';
+import { PercentageStageOnKeyboard } from '@onekeyhq/kit/src/components/PercentageStageOnKeyboard';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
@@ -167,6 +169,8 @@ const ManageSectionShell = ({
   // gap deterministically here (a single wrapping YStack means the parent gap
   // can't apply to us), so the tab→input spacing matches the loaded state
   // exactly and doesn't jump on load.
+  const reserveKeyboardAccessorySpace = type === EManagePositionType.Staking;
+
   return (
     <YStack gap={isInModalContext ? undefined : '$1.5'}>
       {hideTypeSwitch ? null : (
@@ -349,6 +353,17 @@ const ManageSectionShell = ({
           </Button>
         )}
       </YStack>
+      {isInModalContext ? (
+        <Page.Footer>
+          <Page.FooterActions
+            onConfirmText={activeLabel}
+            confirmButtonProps={{ disabled: true }}
+          />
+          <PercentageStageOnKeyboard
+            reserveSpaceUntilKeyboardShown={reserveKeyboardAccessorySpace}
+          />
+        </Page.Footer>
+      ) : null}
     </YStack>
   );
 };


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60172](https://onekeyhq.atlassian.net/browse/OK-60172) [OK-59844](https://onekeyhq.atlassian.net/browse/OK-59844) [OK-59337](https://onekeyhq.atlassian.net/browse/OK-59337)

----------

<!-- github-pr-monitor:jira-links:end -->


## Issues

- OK-60172
- OK-59844
- OK-59337

## Summary

- smooth the Earn manage-position initial render by keeping the loading footer, keyboard accessory, validation state, and protocol network logo stable while data becomes ready
- keep Borrow overview metrics in equal-width columns and use the same layout for their loading skeletons to avoid content-size shifts
- show protocol reward badges and apply the API-provided APR color semantics in the Earn protocol quick switcher

## Root cause

- OK-60172: several pieces of the mobile Earn form became ready on independent timelines, producing consecutive layout and visual changes
- OK-59844: Borrow overview metric columns were sized by their loading or loaded content instead of sharing a stable width
- OK-59337: the protocol quick switcher rendered a plain APR string and omitted `provider.badges`, discarding the semantic presentation returned by the API

## User impact

Earn and Borrow surfaces now keep a stable layout during initial loading, and rewarded protocols consistently display their reward badge and highlighted APR in the protocol switcher.

## Validation

- `yarn agent:check --profile pr`
- `yarn jest packages/kit/src/views/Borrow/components/OverviewMetric.test.tsx packages/kit/src/views/Earn/components/AprText.utils.test.ts packages/kit/src/views/Earn/components/showProtocolListDialog.utils.test.ts --runInBand`
- iPhone 17 Simulator validation for the Earn manage-position and USDT protocol quick-switcher flows

## Review focus

- native keyboard show/hide behavior after the first reveal
- Borrow metric alignment across loading and loaded values
- rewarded and ordinary protocol APR/badge styles in the quick switcher

[OK-60172]: https://onekeyhq.atlassian.net/browse/OK-60172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-59844]: https://onekeyhq.atlassian.net/browse/OK-59844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-59337]: https://onekeyhq.atlassian.net/browse/OK-59337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ