### PR TITLE
feat: localize market chart styles OK-59939

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewChartControls/utils/NativeChartControlsShared.ts
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/utils/NativeChartControlsShared.ts
@@ -94,6 +94,9 @@ export function getChartTypeIconName(chartType?: ITradingViewChartTypeOption) {
   if (normalizedLabel.includes('hlc')) {
     return 'TradingViewCandlesHlcOutline';
   }
+  if (normalizedLabel.includes('heikin')) {
+    return 'TradingViewBarsOutline';
+  }
   if (normalizedLabel.includes('bar')) {
     return 'TradingViewCandlesHlcOutline';
   }

--- a/packages/kit/src/components/TradingView/TradingViewChartControls/utils/NativeChartControlsShared.ts
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/utils/NativeChartControlsShared.ts
@@ -73,8 +73,17 @@ export function formatChartTypeOptionLabel(
   if (normalizedLabel === 'candle' || normalizedLabel === 'candles') {
     return intl.formatMessage({ id: ETranslations.market_candle });
   }
+  if (normalizedLabel === 'heikin ashi') {
+    return intl.formatMessage({ id: ETranslations.market_heikin_ashi });
+  }
+  if (normalizedLabel === 'bars') {
+    return intl.formatMessage({ id: ETranslations.market_bars });
+  }
   if (normalizedLabel === 'line') {
     return intl.formatMessage({ id: ETranslations.market_line });
+  }
+  if (normalizedLabel === 'area') {
+    return intl.formatMessage({ id: ETranslations.market_area });
   }
 
   return label;
@@ -86,7 +95,7 @@ export function getChartTypeIconName(chartType?: ITradingViewChartTypeOption) {
     return 'TradingViewCandlesHlcOutline';
   }
   if (normalizedLabel.includes('bar')) {
-    return 'TradingViewBarsOutline';
+    return 'TradingViewCandlesHlcOutline';
   }
   if (normalizedLabel.includes('line')) {
     return 'TradingViewLineOutline';

--- a/packages/kit/src/components/TradingView/TradingViewChartControls/utils/NativeChartControlsShared.ts
+++ b/packages/kit/src/components/TradingView/TradingViewChartControls/utils/NativeChartControlsShared.ts
@@ -91,9 +91,6 @@ export function formatChartTypeOptionLabel(
 
 export function getChartTypeIconName(chartType?: ITradingViewChartTypeOption) {
   const normalizedLabel = chartType?.label.trim().toLowerCase() ?? '';
-  if (normalizedLabel.includes('hlc')) {
-    return 'TradingViewCandlesHlcOutline';
-  }
   if (normalizedLabel.includes('heikin')) {
     return 'TradingViewBarsOutline';
   }

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.test.ts
@@ -1,4 +1,5 @@
 import {
+  normalizeTradingViewActiveChartType,
   normalizeTradingViewChartTypes,
   normalizeTradingViewLayoutRestored,
 } from './nativeChartControlsConfigUtils';
@@ -12,6 +13,35 @@ describe('normalizeTradingViewLayoutRestored', () => {
   it('returns undefined for legacy or invalid values', () => {
     expect(normalizeTradingViewLayoutRestored(undefined)).toBeUndefined();
     expect(normalizeTradingViewLayoutRestored('true')).toBeUndefined();
+  });
+});
+
+describe('normalizeTradingViewActiveChartType', () => {
+  it('falls back to a surviving chart type when the active option was removed', () => {
+    const chartTypes = normalizeTradingViewChartTypes([
+      { label: 'Candles', value: 1 },
+      { label: 'Candles HLC', value: 21 },
+      { label: 'Line', value: 2 },
+    ]);
+
+    expect(chartTypes).not.toBeNull();
+    expect(normalizeTradingViewActiveChartType(chartTypes ?? [], 21)).toBe(1);
+  });
+
+  it('preserves active values that remain in the normalized options', () => {
+    expect(
+      normalizeTradingViewActiveChartType(
+        [
+          { label: 'Candles', value: 1 },
+          { label: 'Legacy Style', value: 21 },
+        ],
+        21,
+      ),
+    ).toBe(21);
+  });
+
+  it('rejects invalid active values', () => {
+    expect(normalizeTradingViewActiveChartType([], 'invalid')).toBeNull();
   });
 });
 

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.test.ts
@@ -1,6 +1,5 @@
 import {
-  normalizeTradingViewActiveChartType,
-  normalizeTradingViewChartTypes,
+  normalizeTradingViewChartTypeState,
   normalizeTradingViewLayoutRestored,
 } from './nativeChartControlsConfigUtils';
 
@@ -16,63 +15,110 @@ describe('normalizeTradingViewLayoutRestored', () => {
   });
 });
 
-describe('normalizeTradingViewActiveChartType', () => {
-  it('falls back to a surviving chart type when the active option was removed', () => {
-    const chartTypes = normalizeTradingViewChartTypes([
-      { label: 'Candles', value: 1 },
-      { label: 'Candles HLC', value: 21 },
-      { label: 'Line', value: 2 },
-    ]);
-
-    expect(chartTypes).not.toBeNull();
-    expect(normalizeTradingViewActiveChartType(chartTypes ?? [], 21)).toBe(1);
+describe('normalizeTradingViewChartTypeState', () => {
+  it('falls back to Candles when the retired active option is removed', () => {
+    expect(
+      normalizeTradingViewChartTypeState(
+        [
+          { label: 'Bars', value: 0 },
+          { label: 'Candles HLC', value: 21 },
+          { label: 'Candles', value: 1 },
+          { label: 'Line', value: 2 },
+        ],
+        21,
+      ),
+    ).toEqual({
+      chartTypes: [
+        { label: 'Bars', value: 0 },
+        { label: 'Candles', value: 1 },
+        { label: 'Line', value: 2 },
+      ],
+      activeChartType: 1,
+      chartTypeToSync: 1,
+    });
   });
 
-  it('preserves active values that remain in the normalized options', () => {
+  it('preserves an unrelated active value missing from the options', () => {
     expect(
-      normalizeTradingViewActiveChartType(
+      normalizeTradingViewChartTypeState(
         [
           { label: 'Candles', value: 1 },
+          { label: 'Line', value: 2 },
+        ],
+        100,
+      ),
+    ).toEqual({
+      chartTypes: [
+        { label: 'Candles', value: 1 },
+        { label: 'Line', value: 2 },
+      ],
+      activeChartType: 100,
+    });
+  });
+
+  it('preserves an active value that remains after filtering', () => {
+    expect(
+      normalizeTradingViewChartTypeState(
+        [
+          { label: 'Candles', value: 1 },
+          { label: 'Candles HLC', value: 21 },
           { label: 'Legacy Style', value: 21 },
         ],
         21,
       ),
-    ).toBe(21);
+    ).toEqual({
+      chartTypes: [
+        { label: 'Candles', value: 1 },
+        { label: 'Legacy Style', value: 21 },
+      ],
+      activeChartType: 21,
+    });
   });
 
-  it('rejects invalid active values', () => {
-    expect(normalizeTradingViewActiveChartType([], 'invalid')).toBeNull();
-  });
-});
-
-describe('normalizeTradingViewChartTypes', () => {
   it('removes only the retired Candles HLC bridge option', () => {
     expect(
-      normalizeTradingViewChartTypes([
+      normalizeTradingViewChartTypeState(
+        [
+          { label: 'Candles', value: 1 },
+          { label: 'Heikin Ashi', value: 8 },
+          { label: 'Bars', value: 0 },
+          { label: 'Candles HLC', value: 21 },
+          { label: 'Legacy Style', value: 21 },
+          { label: 'Candles HLC', value: 100 },
+          { label: 'HLC Area', value: 16 },
+          { label: 'Line', value: 2 },
+          { label: 'Area', value: 3 },
+        ],
+        1,
+      ),
+    ).toEqual({
+      chartTypes: [
         { label: 'Candles', value: 1 },
         { label: 'Heikin Ashi', value: 8 },
         { label: 'Bars', value: 0 },
-        { label: 'Candles HLC', value: 21 },
         { label: 'Legacy Style', value: 21 },
+        { label: 'Candles HLC', value: 100 },
         { label: 'HLC Area', value: 16 },
         { label: 'Line', value: 2 },
         { label: 'Area', value: 3 },
-      ]),
-    ).toEqual([
-      { label: 'Candles', value: 1 },
-      { label: 'Heikin Ashi', value: 8 },
-      { label: 'Bars', value: 0 },
-      { label: 'Legacy Style', value: 21 },
-      { label: 'HLC Area', value: 16 },
-      { label: 'Line', value: 2 },
-      { label: 'Area', value: 3 },
-    ]);
+      ],
+      activeChartType: 1,
+    });
   });
 
-  it('rejects invalid chart type payloads', () => {
-    expect(normalizeTradingViewChartTypes(null)).toBeNull();
+  it('rejects invalid chart type state', () => {
+    expect(normalizeTradingViewChartTypeState(null, 1)).toBeNull();
     expect(
-      normalizeTradingViewChartTypes([{ label: 'Candles', value: 'invalid' }]),
+      normalizeTradingViewChartTypeState(
+        [{ label: 'Candles', value: 'invalid' }],
+        1,
+      ),
+    ).toBeNull();
+    expect(
+      normalizeTradingViewChartTypeState(
+        [{ label: 'Candles', value: 1 }],
+        'invalid',
+      ),
     ).toBeNull();
   });
 });

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.test.ts
@@ -16,14 +16,15 @@ describe('normalizeTradingViewLayoutRestored', () => {
 });
 
 describe('normalizeTradingViewChartTypes', () => {
-  it('removes HLC chart types from legacy or cached chart bundles', () => {
+  it('removes only the retired Candles HLC bridge option', () => {
     expect(
       normalizeTradingViewChartTypes([
         { label: 'Candles', value: 1 },
         { label: 'Heikin Ashi', value: 8 },
         { label: 'Bars', value: 0 },
+        { label: 'Candles HLC', value: 21 },
         { label: 'Legacy Style', value: 21 },
-        { label: 'Legacy HLC', value: 100 },
+        { label: 'HLC Area', value: 16 },
         { label: 'Line', value: 2 },
         { label: 'Area', value: 3 },
       ]),
@@ -31,6 +32,8 @@ describe('normalizeTradingViewChartTypes', () => {
       { label: 'Candles', value: 1 },
       { label: 'Heikin Ashi', value: 8 },
       { label: 'Bars', value: 0 },
+      { label: 'Legacy Style', value: 21 },
+      { label: 'HLC Area', value: 16 },
       { label: 'Line', value: 2 },
       { label: 'Area', value: 3 },
     ]);

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.test.ts
@@ -1,4 +1,7 @@
-import { normalizeTradingViewLayoutRestored } from './nativeChartControlsConfigUtils';
+import {
+  normalizeTradingViewChartTypes,
+  normalizeTradingViewLayoutRestored,
+} from './nativeChartControlsConfigUtils';
 
 describe('normalizeTradingViewLayoutRestored', () => {
   it('preserves explicit restoration state', () => {
@@ -9,5 +12,34 @@ describe('normalizeTradingViewLayoutRestored', () => {
   it('returns undefined for legacy or invalid values', () => {
     expect(normalizeTradingViewLayoutRestored(undefined)).toBeUndefined();
     expect(normalizeTradingViewLayoutRestored('true')).toBeUndefined();
+  });
+});
+
+describe('normalizeTradingViewChartTypes', () => {
+  it('removes HLC chart types from legacy or cached chart bundles', () => {
+    expect(
+      normalizeTradingViewChartTypes([
+        { label: 'Candles', value: 1 },
+        { label: 'Heikin Ashi', value: 8 },
+        { label: 'Bars', value: 0 },
+        { label: 'Legacy Style', value: 21 },
+        { label: 'Legacy HLC', value: 100 },
+        { label: 'Line', value: 2 },
+        { label: 'Area', value: 3 },
+      ]),
+    ).toEqual([
+      { label: 'Candles', value: 1 },
+      { label: 'Heikin Ashi', value: 8 },
+      { label: 'Bars', value: 0 },
+      { label: 'Line', value: 2 },
+      { label: 'Area', value: 3 },
+    ]);
+  });
+
+  it('rejects invalid chart type payloads', () => {
+    expect(normalizeTradingViewChartTypes(null)).toBeNull();
+    expect(
+      normalizeTradingViewChartTypes([{ label: 'Candles', value: 'invalid' }]),
+    ).toBeNull();
   });
 });

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.ts
@@ -45,3 +45,22 @@ export function normalizeTradingViewChartTypes(
 
   return normalizedChartTypes;
 }
+
+export function normalizeTradingViewActiveChartType(
+  chartTypes: ITradingViewNativeChartControlsConfigData['chartTypes'],
+  activeChartType: unknown,
+): number | null {
+  const value = Number(activeChartType);
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  if (
+    !chartTypes.length ||
+    chartTypes.some((chartType) => chartType.value === value)
+  ) {
+    return value;
+  }
+
+  return chartTypes[0].value;
+}

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.ts
@@ -1,6 +1,7 @@
 import type { ITradingViewNativeChartControlsConfigData } from '../../../types';
 
-// TradingView Charting Library defines SeriesType.HLCBars as 21.
+// TradingView defines SeriesType.HLCBars as 21; the app bridge fixture was
+// introduced in c1bb2df6c5.
 const REMOVED_HLC_CHART_TYPE = {
   label: 'candles hlc',
   value: 21,
@@ -14,15 +15,22 @@ export function normalizeTradingViewLayoutRestored(value: unknown) {
   return typeof value === 'boolean' ? value : undefined;
 }
 
-export function normalizeTradingViewChartTypes(
+export function normalizeTradingViewChartTypeState(
   chartTypes: unknown,
-): ITradingViewNativeChartControlsConfigData['chartTypes'] | null {
-  if (!Array.isArray(chartTypes)) {
+  activeChartType: unknown,
+): {
+  chartTypes: ITradingViewNativeChartControlsConfigData['chartTypes'];
+  activeChartType: number;
+  chartTypeToSync?: number;
+} | null {
+  const activeValue = Number(activeChartType);
+  if (!Array.isArray(chartTypes) || !Number.isFinite(activeValue)) {
     return null;
   }
 
   const normalizedChartTypes: ITradingViewNativeChartControlsConfigData['chartTypes'] =
     [];
+  let removedActiveHlcChartType = false;
   for (const chartType of chartTypes) {
     if (!isRecord(chartType)) {
       return null;
@@ -38,29 +46,35 @@ export function normalizeTradingViewChartTypes(
     const isRemovedHlcChartType =
       value === REMOVED_HLC_CHART_TYPE.value &&
       label.toLowerCase() === REMOVED_HLC_CHART_TYPE.label;
-    if (!isRemovedHlcChartType) {
+    if (isRemovedHlcChartType) {
+      removedActiveHlcChartType ||= value === activeValue;
+    } else {
       normalizedChartTypes.push({ label, value });
     }
   }
 
-  return normalizedChartTypes;
-}
-
-export function normalizeTradingViewActiveChartType(
-  chartTypes: ITradingViewNativeChartControlsConfigData['chartTypes'],
-  activeChartType: unknown,
-): number | null {
-  const value = Number(activeChartType);
-  if (!Number.isFinite(value)) {
-    return null;
-  }
-
+  const activeChartTypeStillExists = normalizedChartTypes.some(
+    (chartType) => chartType.value === activeValue,
+  );
+  const fallbackChartType =
+    normalizedChartTypes.find((chartType) => {
+      const normalizedLabel = chartType.label.toLowerCase();
+      return normalizedLabel === 'candle' || normalizedLabel === 'candles';
+    }) ?? normalizedChartTypes[0];
   if (
-    !chartTypes.length ||
-    chartTypes.some((chartType) => chartType.value === value)
+    removedActiveHlcChartType &&
+    !activeChartTypeStillExists &&
+    fallbackChartType
   ) {
-    return value;
+    return {
+      chartTypes: normalizedChartTypes,
+      activeChartType: fallbackChartType.value,
+      chartTypeToSync: fallbackChartType.value,
+    };
   }
 
-  return chartTypes[0].value;
+  return {
+    chartTypes: normalizedChartTypes,
+    activeChartType: activeValue,
+  };
 }

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.ts
@@ -1,6 +1,10 @@
 import type { ITradingViewNativeChartControlsConfigData } from '../../../types';
 
-const REMOVED_HLC_CHART_TYPE_VALUE = 21;
+// TradingView Charting Library defines SeriesType.HLCBars as 21.
+const REMOVED_HLC_CHART_TYPE = {
+  label: 'candles hlc',
+  value: 21,
+} as const;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -32,8 +36,8 @@ export function normalizeTradingViewChartTypes(
     }
 
     const isRemovedHlcChartType =
-      value === REMOVED_HLC_CHART_TYPE_VALUE ||
-      label.toLowerCase().includes('hlc');
+      value === REMOVED_HLC_CHART_TYPE.value &&
+      label.toLowerCase() === REMOVED_HLC_CHART_TYPE.label;
     if (!isRemovedHlcChartType) {
       normalizedChartTypes.push({ label, value });
     }

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.ts
@@ -1,3 +1,43 @@
+import type { ITradingViewNativeChartControlsConfigData } from '../../../types';
+
+const REMOVED_HLC_CHART_TYPE_VALUE = 21;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 export function normalizeTradingViewLayoutRestored(value: unknown) {
   return typeof value === 'boolean' ? value : undefined;
+}
+
+export function normalizeTradingViewChartTypes(
+  chartTypes: unknown,
+): ITradingViewNativeChartControlsConfigData['chartTypes'] | null {
+  if (!Array.isArray(chartTypes)) {
+    return null;
+  }
+
+  const normalizedChartTypes: ITradingViewNativeChartControlsConfigData['chartTypes'] =
+    [];
+  for (const chartType of chartTypes) {
+    if (!isRecord(chartType)) {
+      return null;
+    }
+
+    const label =
+      typeof chartType.label === 'string' ? chartType.label.trim() : '';
+    const value = Number(chartType.value);
+    if (!label || !Number.isFinite(value)) {
+      return null;
+    }
+
+    const isRemovedHlcChartType =
+      value === REMOVED_HLC_CHART_TYPE_VALUE ||
+      label.toLowerCase().includes('hlc');
+    if (!isRemovedHlcChartType) {
+      normalizedChartTypes.push({ label, value });
+    }
+  }
+
+  return normalizedChartTypes;
 }

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
@@ -13,7 +13,10 @@ import {
   shouldMockEmptyKLineData,
 } from './klineDataHandler';
 import { handleLayoutUpdate } from './layoutUpdateHandler';
-import { normalizeTradingViewLayoutRestored } from './nativeChartControlsConfigUtils';
+import {
+  normalizeTradingViewChartTypes,
+  normalizeTradingViewLayoutRestored,
+} from './nativeChartControlsConfigUtils';
 
 import type { IMarksTimeRange, IMessageHandlerContext } from './types';
 import type {
@@ -376,33 +379,6 @@ function normalizeIndicators(
   });
 }
 
-function normalizeChartTypes(
-  chartTypes: unknown,
-): ITradingViewNativeChartControlsConfigData['chartTypes'] | null {
-  if (!Array.isArray(chartTypes)) {
-    return null;
-  }
-
-  const normalizedChartTypes: ITradingViewNativeChartControlsConfigData['chartTypes'] =
-    [];
-  for (const chartType of chartTypes) {
-    if (!isRecord(chartType)) {
-      return null;
-    }
-
-    const label =
-      typeof chartType.label === 'string' ? chartType.label.trim() : '';
-    const value = Number(chartType.value);
-    if (!label || !Number.isFinite(value)) {
-      return null;
-    }
-
-    normalizedChartTypes.push({ label, value });
-  }
-
-  return normalizedChartTypes;
-}
-
 function normalizeResetLayout(
   resetLayout: unknown,
 ): ITradingViewNativeChartControlsConfigData['resetLayout'] | undefined {
@@ -549,7 +525,7 @@ function normalizeNativeChartControlsConfig(
   }
 
   const indicators = normalizeIndicators(data.indicators);
-  const chartTypes = normalizeChartTypes(data.chartTypes);
+  const chartTypes = normalizeTradingViewChartTypes(data.chartTypes);
   const activeChartType = Number(data.activeChartType);
   if (!indicators || !chartTypes || !Number.isFinite(activeChartType)) {
     return null;

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
@@ -14,6 +14,7 @@ import {
 } from './klineDataHandler';
 import { handleLayoutUpdate } from './layoutUpdateHandler';
 import {
+  normalizeTradingViewActiveChartType,
   normalizeTradingViewChartTypes,
   normalizeTradingViewLayoutRestored,
 } from './nativeChartControlsConfigUtils';
@@ -39,6 +40,7 @@ const TRADINGVIEW_PRICE_UPDATE = 'tradingview_priceUpdate';
 const TRADINGVIEW_INTERVAL_CONFIG = 'tradingview_intervalConfig';
 const TRADINGVIEW_NATIVE_CHART_CONTROLS_CONFIG =
   'tradingview_nativeChartControlsConfig';
+const TRADINGVIEW_CHART_TYPE_CHANGE = 'TRADINGVIEW_CHART_TYPE_CHANGE';
 
 interface IUseTradingViewMessageHandlerParams {
   tokenAddress?: string;
@@ -526,8 +528,10 @@ function normalizeNativeChartControlsConfig(
 
   const indicators = normalizeIndicators(data.indicators);
   const chartTypes = normalizeTradingViewChartTypes(data.chartTypes);
-  const activeChartType = Number(data.activeChartType);
-  if (!indicators || !chartTypes || !Number.isFinite(activeChartType)) {
+  const activeChartType = chartTypes
+    ? normalizeTradingViewActiveChartType(chartTypes, data.activeChartType)
+    : null;
+  if (!indicators || !chartTypes || activeChartType === null) {
     return null;
   }
 
@@ -696,6 +700,21 @@ export function useTradingViewMessageHandler({
         const nativeChartControlsConfigData =
           normalizeNativeChartControlsConfig(data.data);
         if (nativeChartControlsConfigData) {
+          const reportedActiveChartType = isRecord(data.data)
+            ? Number(data.data.activeChartType)
+            : Number.NaN;
+          if (
+            Number.isFinite(reportedActiveChartType) &&
+            nativeChartControlsConfigData.activeChartType !==
+              reportedActiveChartType
+          ) {
+            webRef.current?.sendMessageViaInjectedScript({
+              type: TRADINGVIEW_CHART_TYPE_CHANGE,
+              payload: {
+                chartType: nativeChartControlsConfigData.activeChartType,
+              },
+            });
+          }
           onNativeChartControlsConfigChange?.(nativeChartControlsConfigData);
         }
       }

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/useTradingViewMessageHandler.ts
@@ -14,8 +14,7 @@ import {
 } from './klineDataHandler';
 import { handleLayoutUpdate } from './layoutUpdateHandler';
 import {
-  normalizeTradingViewActiveChartType,
-  normalizeTradingViewChartTypes,
+  normalizeTradingViewChartTypeState,
   normalizeTradingViewLayoutRestored,
 } from './nativeChartControlsConfigUtils';
 
@@ -68,6 +67,11 @@ interface IUseTradingViewMessageHandlerParams {
   onKLineDataReady?: (data: ITradingViewKLineDataReadyData) => void;
   onKLineLoadError?: (data: ITradingViewKLineLoadErrorData) => void;
   onKLinePeriodChange?: (data: ITradingViewKLinePeriodChangeData) => void;
+}
+
+interface INormalizedNativeChartControlsConfig {
+  config: ITradingViewNativeChartControlsConfigData;
+  chartTypeToSync?: number;
 }
 
 async function handleGetHyperliquidPriceScale({
@@ -521,17 +525,17 @@ function normalizePriceScale(
 
 function normalizeNativeChartControlsConfig(
   data: unknown,
-): ITradingViewNativeChartControlsConfigData | null {
+): INormalizedNativeChartControlsConfig | null {
   if (!isRecord(data)) {
     return null;
   }
 
   const indicators = normalizeIndicators(data.indicators);
-  const chartTypes = normalizeTradingViewChartTypes(data.chartTypes);
-  const activeChartType = chartTypes
-    ? normalizeTradingViewActiveChartType(chartTypes, data.activeChartType)
-    : null;
-  if (!indicators || !chartTypes || activeChartType === null) {
+  const chartTypeState = normalizeTradingViewChartTypeState(
+    data.chartTypes,
+    data.activeChartType,
+  );
+  if (!indicators || !chartTypeState) {
     return null;
   }
 
@@ -553,23 +557,28 @@ function normalizeNativeChartControlsConfig(
   );
 
   return {
-    ...(intervals?.length ? { intervals } : {}),
-    ...(activeInterval ? { activeInterval } : {}),
-    ...(typeof data.indicatorsEnabled === 'boolean'
-      ? { indicatorsEnabled: data.indicatorsEnabled }
-      : {}),
-    indicators,
-    ...(typeof data.chartTypesEnabled === 'boolean'
-      ? { chartTypesEnabled: data.chartTypesEnabled }
-      : {}),
-    chartTypes,
-    activeChartType,
-    ...(resetLayout ? { resetLayout } : {}),
-    ...(priceMarketCap ? { priceMarketCap } : {}),
-    ...(priceScale ? { priceScale } : {}),
-    ...(layoutRestored !== undefined ? { layoutRestored } : {}),
-    ...(typeof data.timestamp === 'number' && Number.isFinite(data.timestamp)
-      ? { timestamp: data.timestamp }
+    config: {
+      ...(intervals?.length ? { intervals } : {}),
+      ...(activeInterval ? { activeInterval } : {}),
+      ...(typeof data.indicatorsEnabled === 'boolean'
+        ? { indicatorsEnabled: data.indicatorsEnabled }
+        : {}),
+      indicators,
+      ...(typeof data.chartTypesEnabled === 'boolean'
+        ? { chartTypesEnabled: data.chartTypesEnabled }
+        : {}),
+      chartTypes: chartTypeState.chartTypes,
+      activeChartType: chartTypeState.activeChartType,
+      ...(resetLayout ? { resetLayout } : {}),
+      ...(priceMarketCap ? { priceMarketCap } : {}),
+      ...(priceScale ? { priceScale } : {}),
+      ...(layoutRestored !== undefined ? { layoutRestored } : {}),
+      ...(typeof data.timestamp === 'number' && Number.isFinite(data.timestamp)
+        ? { timestamp: data.timestamp }
+        : {}),
+    },
+    ...(chartTypeState.chartTypeToSync !== undefined
+      ? { chartTypeToSync: chartTypeState.chartTypeToSync }
       : {}),
   };
 }
@@ -697,25 +706,22 @@ export function useTradingViewMessageHandler({
         data.scope === '$private' &&
         data.method === TRADINGVIEW_NATIVE_CHART_CONTROLS_CONFIG
       ) {
-        const nativeChartControlsConfigData =
+        const normalizedNativeChartControlsConfig =
           normalizeNativeChartControlsConfig(data.data);
-        if (nativeChartControlsConfigData) {
-          const reportedActiveChartType = isRecord(data.data)
-            ? Number(data.data.activeChartType)
-            : Number.NaN;
+        if (normalizedNativeChartControlsConfig) {
           if (
-            Number.isFinite(reportedActiveChartType) &&
-            nativeChartControlsConfigData.activeChartType !==
-              reportedActiveChartType
+            normalizedNativeChartControlsConfig.chartTypeToSync !== undefined
           ) {
             webRef.current?.sendMessageViaInjectedScript({
               type: TRADINGVIEW_CHART_TYPE_CHANGE,
               payload: {
-                chartType: nativeChartControlsConfigData.activeChartType,
+                chartType: normalizedNativeChartControlsConfig.chartTypeToSync,
               },
             });
           }
-          onNativeChartControlsConfigChange?.(nativeChartControlsConfigData);
+          onNativeChartControlsConfigChange?.(
+            normalizedNativeChartControlsConfig.config,
+          );
         }
       }
 

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/utils/NativeChartControlsShared.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/utils/NativeChartControlsShared.test.ts
@@ -46,8 +46,8 @@ describe('NativeChartControlsShared', () => {
       'AREA_I18N',
     );
     expect(
-      formatChartTypeOptionLabel(intl, { label: 'Candles HLC', value: 21 }),
-    ).toBe('Candles HLC');
+      formatChartTypeOptionLabel(intl, { label: 'Baseline', value: 10 }),
+    ).toBe('Baseline');
   });
 
   it('uses distinct icons for supported chart type labels', () => {
@@ -58,9 +58,6 @@ describe('NativeChartControlsShared', () => {
       'TradingViewBarsOutline',
     );
     expect(getChartTypeIconName({ label: 'Bars', value: 0 })).toBe(
-      'TradingViewCandlesHlcOutline',
-    );
-    expect(getChartTypeIconName({ label: 'Candles HLC', value: 21 })).toBe(
       'TradingViewCandlesHlcOutline',
     );
     expect(getChartTypeIconName({ label: 'Line', value: 2 })).toBe(

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/utils/NativeChartControlsShared.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/utils/NativeChartControlsShared.test.ts
@@ -12,15 +12,24 @@ const intl = {
     if (id === ETranslations.market_candle) {
       return 'Candles';
     }
+    if (id === ETranslations.market_heikin_ashi) {
+      return 'Heikin Ashi';
+    }
+    if (id === ETranslations.market_bars) {
+      return 'Bars';
+    }
     if (id === ETranslations.market_line) {
       return 'Line';
+    }
+    if (id === ETranslations.market_area) {
+      return 'Area';
     }
     return id ?? '';
   },
 } as IntlShape;
 
 describe('NativeChartControlsShared', () => {
-  it('formats only exact candle and line chart type labels', () => {
+  it('formats all supported chart type labels', () => {
     expect(
       formatChartTypeOptionLabel(intl, { label: 'Candle', value: 1 }),
     ).toBe('Candles');
@@ -28,19 +37,28 @@ describe('NativeChartControlsShared', () => {
       'Line',
     );
     expect(
-      formatChartTypeOptionLabel(intl, { label: 'Candles HLC', value: 21 }),
-    ).toBe('Candles HLC');
+      formatChartTypeOptionLabel(intl, { label: 'Heikin Ashi', value: 8 }),
+    ).toBe('Heikin Ashi');
+    expect(formatChartTypeOptionLabel(intl, { label: 'Bars', value: 0 })).toBe(
+      'Bars',
+    );
     expect(formatChartTypeOptionLabel(intl, { label: 'Area', value: 3 })).toBe(
       'Area',
     );
+    expect(
+      formatChartTypeOptionLabel(intl, { label: 'Candles HLC', value: 21 }),
+    ).toBe('Candles HLC');
   });
 
   it('uses distinct icons for supported chart type labels', () => {
     expect(getChartTypeIconName({ label: 'Candles', value: 1 })).toBe(
       'TradingViewCandlesOutline',
     );
+    expect(getChartTypeIconName({ label: 'Heikin Ashi', value: 8 })).toBe(
+      'TradingViewCandlesOutline',
+    );
     expect(getChartTypeIconName({ label: 'Bars', value: 0 })).toBe(
-      'TradingViewBarsOutline',
+      'TradingViewCandlesHlcOutline',
     );
     expect(getChartTypeIconName({ label: 'Candles HLC', value: 21 })).toBe(
       'TradingViewCandlesHlcOutline',

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/utils/NativeChartControlsShared.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/utils/NativeChartControlsShared.test.ts
@@ -55,7 +55,7 @@ describe('NativeChartControlsShared', () => {
       'TradingViewCandlesOutline',
     );
     expect(getChartTypeIconName({ label: 'Heikin Ashi', value: 8 })).toBe(
-      'TradingViewCandlesOutline',
+      'TradingViewBarsOutline',
     );
     expect(getChartTypeIconName({ label: 'Bars', value: 0 })).toBe(
       'TradingViewCandlesHlcOutline',

--- a/packages/kit/src/components/TradingView/TradingViewV2/components/utils/NativeChartControlsShared.test.ts
+++ b/packages/kit/src/components/TradingView/TradingViewV2/components/utils/NativeChartControlsShared.test.ts
@@ -13,16 +13,16 @@ const intl = {
       return 'Candles';
     }
     if (id === ETranslations.market_heikin_ashi) {
-      return 'Heikin Ashi';
+      return 'HEIKIN_ASHI_I18N';
     }
     if (id === ETranslations.market_bars) {
-      return 'Bars';
+      return 'BARS_I18N';
     }
     if (id === ETranslations.market_line) {
       return 'Line';
     }
     if (id === ETranslations.market_area) {
-      return 'Area';
+      return 'AREA_I18N';
     }
     return id ?? '';
   },
@@ -38,12 +38,12 @@ describe('NativeChartControlsShared', () => {
     );
     expect(
       formatChartTypeOptionLabel(intl, { label: 'Heikin Ashi', value: 8 }),
-    ).toBe('Heikin Ashi');
+    ).toBe('HEIKIN_ASHI_I18N');
     expect(formatChartTypeOptionLabel(intl, { label: 'Bars', value: 0 })).toBe(
-      'Bars',
+      'BARS_I18N',
     );
     expect(formatChartTypeOptionLabel(intl, { label: 'Area', value: 3 })).toBe(
-      'Area',
+      'AREA_I18N',
     );
     expect(
       formatChartTypeOptionLabel(intl, { label: 'Candles HLC', value: 21 }),


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59939](https://onekeyhq.atlassian.net/browse/OK-59939)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- localize Candles, Heikin Ashi, Bars, Line, and Area in native Market chart controls
- use the existing averaged-candle icon for Heikin Ashi and OHLC/American-bar icon for Bars
- filter the retired Candles HLC/21 option from legacy or cached TradingView bundles
- reconcile a retired active HLC style to Candles in both App state and the WebView
- add coverage for localization, icons, exact legacy filtering, and active-style convergence

## Why

Chart style labels from the remote TradingView surface need host-app localization. The previous Bars icon visually represented hollow candles rather than OHLC/American bars. Because the TradingView bundle is deployed independently, the App also needs a narrow compatibility boundary for older bundles that still publish Candles HLC.

## Impact

The Market chart style menu shows the requested five localized styles with matching icons. Older bundles cannot reintroduce Candles HLC, and a saved active HLC style converges to Candles without changing unrelated unknown styles.

## Validation

- `yarn jest packages/kit/src/components/TradingView/TradingViewV2/components/tradingViewV2/messageHandlers/nativeChartControlsConfigUtils.test.ts packages/kit/src/components/TradingView/TradingViewV2/components/utils/NativeChartControlsShared.test.ts --runInBand`
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`

## Related

- Jira: [OK-59939](https://onekeyhq.atlassian.net/browse/OK-59939)
- TradingView implementation: [OneKeyHQ/tradingview-charting-library#210](https://github.com/OneKeyHQ/tradingview-charting-library/pull/210)

[OK-59939]: https://onekeyhq.atlassian.net/browse/OK-59939