### PR TITLE
chore: sync release/v6.5.0 to x

### DIFF
--- a/.skillshare/skills/1k-retrospective/references/case-studies.md
+++ b/.skillshare/skills/1k-retrospective/references/case-studies.md
@@ -47,3 +47,9 @@ Cases are appended by AI after each bug fix. Do NOT reorder or delete entries �
 **Root Cause**: The client treated `totalBonus`, which already includes `undistributed`, as the distributed amount instead of deriving the distributed portion.
 **Fix**: Derived `distributedBonus` with BigNumber as `totalBonus - undistributed` and passed it explicitly to the summary card, with regression coverage for partially, fully, and zero undistributed rewards.
 **Catchable by**: Section 4: Data flow end-to-end: API -> state -> UI
+## Case: Perps stuck on "Loading tokens..." after IndexedDB blob corruption
+**Date**: 2026-08-11 | **Platforms**: desktop (Electron/Chromium storage; web/ext share the code path)
+**Symptom**: Desktop 6.5.0 user's Perps chart and token selector permanently stuck on "Loading tokens..." across restarts; realtime prices kept updating; mobile unaffected (OK-59997).
+**Root Cause**: All Perps caches live in one `simple_db_v5:perp` record. Chromium stores large IndexedDB values as external blob files; a crash corrupted the blob so every read rejected with `UnknownError: Failed to read large IndexedDB value`. `setRawData(builder)` reads the old record before writing, so all writes failed too — the record could never be repaired by normal usage.
+**Fix**: Opt-in self-heal in `SimpleDbEntityBase` (perp only): on the exact corruption signature, retry once, then remove the record with write-overlap vetoes (writeSeq + pendingWrites snapshot); read generation prevents in-flight reads from resurrecting cleared/overwritten cache; Settings → Clear cache gained a "Perps" item backed by a runtime clear epoch in ServiceWebviewPerp.
+**Catchable by**: NEW — storage-layer read errors need a recovery path for caches that can be rebuilt; read-before-write persistence cannot self-repair a corrupted record

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
@@ -4,14 +4,25 @@ import { SimpleDbEntityBase } from './SimpleDbEntityBase';
 yarn jest packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.test.ts
 */
 
-// Concrete entity over a controllable in-memory appStorage so we can park a
-// setRawData mid-flight (inside the mutex) and fire clearRawData concurrently.
-// This proves clearRawData and setRawData are serialized by the shared mutex, so
-// an in-flight write can never resurrect a just-cleared cache.
+// Single configurable entity over controllable in-memory appStorage mocks —
+// oxlint allows one class per file, so cache/self-heal variants are options.
 class TestEntity extends SimpleDbEntityBase<{ v: number }> {
-  override readonly entityName = 'test-entity';
+  override readonly entityName: string;
 
-  override readonly enableCache = false;
+  override readonly enableCache: boolean;
+
+  protected override readonly enableUnreadableRecordSelfHeal: boolean;
+
+  constructor({
+    name = 'test-entity',
+    enableCache = false,
+    selfHeal = false,
+  }: { name?: string; enableCache?: boolean; selfHeal?: boolean } = {}) {
+    super();
+    this.entityName = name;
+    this.enableCache = enableCache;
+    this.enableUnreadableRecordSelfHeal = selfHeal;
+  }
 }
 
 describe('SimpleDbEntityBase clear/set mutex serialization', () => {
@@ -62,5 +73,351 @@ describe('SimpleDbEntityBase clear/set mutex serialization', () => {
 
     expect(order).toEqual(['setItem', 'removeItem']); // serialized, clear last
     expect(entity.entityKey in store).toBe(false); // cache stays cleared
+  });
+});
+
+// A corrupted external blob makes every read reject forever, and builder-based
+// setRawData reads first — without self-heal the record could never be repaired.
+describe('SimpleDbEntityBase unreadable-record self-heal', () => {
+  const makeHealEntity = () =>
+    new TestEntity({ name: 'test-heal-entity', selfHeal: true });
+
+  // Unreadable until removeItem drops it (or failTimes runs out), mirroring a
+  // corrupted blob record vs a transient IO failure.
+  const makeBrokenStorage = ({
+    errorName,
+    errorMessage = 'Failed to read large IndexedDB value',
+    failTimes = Number.POSITIVE_INFINITY,
+  }: {
+    errorName: string;
+    errorMessage?: string;
+    failTimes?: number;
+  }) => {
+    const store: Record<string, unknown> = {};
+    const calls: string[] = [];
+    let remainingFails = failTimes;
+    return {
+      store,
+      calls,
+      storage: {
+        getItem: async (k: string) => {
+          calls.push('getItem');
+          if (remainingFails > 0) {
+            remainingFails -= 1;
+            const error = new Error(errorMessage);
+            error.name = errorName;
+            throw error;
+          }
+          return (k in store ? store[k] : null) as string | null;
+        },
+        setItem: async (k: string, v: unknown) => {
+          calls.push('setItem');
+          store[k] = v;
+        },
+        removeItem: async (k: string) => {
+          calls.push('removeItem');
+          delete store[k];
+          remainingFails = 0;
+        },
+      },
+    };
+  };
+
+  test('getRawData drops the unreadable record and returns null', async () => {
+    const entity = makeHealEntity();
+    const { storage, calls } = makeBrokenStorage({ errorName: 'UnknownError' });
+    (entity as any).appStorage = storage;
+
+    await expect(entity.getRawData()).resolves.toBeNull();
+    expect(calls).toEqual(['getItem', 'getItem', 'removeItem']);
+  });
+
+  test('setRawData(builder) rebuilds the record after a read failure', async () => {
+    const entity = makeHealEntity();
+    const { storage, store } = makeBrokenStorage({
+      errorName: 'UnknownError',
+    });
+    (entity as any).appStorage = storage;
+
+    await expect(
+      entity.setRawData((prev) => ({ v: (prev?.v ?? 0) + 1 })),
+    ).resolves.toEqual({ v: 1 });
+    expect(entity.entityKey in store).toBe(true);
+    await expect(entity.getRawData()).resolves.toEqual({ v: 1 });
+  });
+
+  test('non-storage read errors still propagate without deleting the record', async () => {
+    const entity = makeHealEntity();
+    const { storage, calls } = makeBrokenStorage({
+      errorName: 'SomeRandomError',
+    });
+    (entity as any).appStorage = storage;
+
+    await expect(entity.getRawData()).rejects.toThrow(
+      'Failed to read large IndexedDB value',
+    );
+    expect(calls).toEqual(['getItem']);
+  });
+
+  test('NotReadableError propagates without deleting (transient IO condition)', async () => {
+    const entity = makeHealEntity();
+    const { storage, calls } = makeBrokenStorage({
+      errorName: 'NotReadableError',
+    });
+    (entity as any).appStorage = storage;
+
+    await expect(entity.getRawData()).rejects.toThrow(
+      'Failed to read large IndexedDB value',
+    );
+    expect(calls).toEqual(['getItem']);
+  });
+
+  test('UnknownError without the corrupted-blob message propagates without deleting', async () => {
+    const entity = makeHealEntity();
+    const { storage, calls } = makeBrokenStorage({
+      errorName: 'UnknownError',
+      errorMessage: 'Internal error opening backing store',
+    });
+    (entity as any).appStorage = storage;
+
+    await expect(entity.getRawData()).rejects.toThrow(
+      'Internal error opening backing store',
+    );
+    expect(calls).toEqual(['getItem']);
+  });
+
+  test('a transient read failure recovers via retry and keeps the record', async () => {
+    const entity = makeHealEntity();
+    const { storage, store, calls } = makeBrokenStorage({
+      errorName: 'UnknownError',
+      failTimes: 1,
+    });
+    store[entity.entityKey] = JSON.stringify({ data: { v: 9 }, updatedAt: 1 });
+    (entity as any).appStorage = storage;
+
+    await expect(entity.getRawData()).resolves.toEqual({ v: 9 });
+    expect(calls).toEqual(['getItem', 'getItem']);
+    expect(entity.entityKey in store).toBe(true);
+  });
+
+  test('self-heal delete is skipped when a write lands during the failing read', async () => {
+    const entity = makeHealEntity();
+    const store: Record<string, unknown> = {};
+    const calls: string[] = [];
+    let rejectFirstRead!: (error: Error) => void;
+    let readCount = 0;
+    const makeError = () => {
+      const error = new Error('Failed to read large IndexedDB value');
+      error.name = 'UnknownError';
+      return error;
+    };
+    (entity as any).appStorage = {
+      getItem: () => {
+        readCount += 1;
+        calls.push('getItem');
+        if (readCount === 1) {
+          return new Promise<string | null>((_, reject) => {
+            rejectFirstRead = reject;
+          });
+        }
+        return Promise.reject(makeError());
+      },
+      setItem: async (k: string, v: unknown) => {
+        calls.push('setItem');
+        store[k] = v;
+      },
+      removeItem: async (k: string) => {
+        calls.push('removeItem');
+        delete store[k];
+      },
+    };
+
+    const readP = entity.getRawData(); // parked on the hanging first getItem
+    await entity.setRawData({ v: 7 }); // write lands while the read is in flight
+    rejectFirstRead(makeError());
+
+    await expect(readP).resolves.toBeNull();
+    expect(calls).not.toContain('removeItem'); // guard kept the fresh write
+    expect(entity.entityKey in store).toBe(true);
+  });
+
+  test('self-heal delete is skipped while a write is still in flight', async () => {
+    const entity = makeHealEntity();
+    const store: Record<string, unknown> = {};
+    const calls: string[] = [];
+    let releaseWrite!: () => void;
+    const writeGate = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    let signalWriteStarted!: () => void;
+    const writeStarted = new Promise<void>((resolve) => {
+      signalWriteStarted = resolve;
+    });
+    const makeError = () => {
+      const error = new Error('Failed to read large IndexedDB value');
+      error.name = 'UnknownError';
+      return error;
+    };
+    (entity as any).appStorage = {
+      getItem: () => {
+        calls.push('getItem');
+        return Promise.reject(makeError());
+      },
+      setItem: async (k: string, v: unknown) => {
+        calls.push('setItem');
+        signalWriteStarted();
+        await writeGate; // parked mid-write while the failing read races it
+        store[k] = v;
+      },
+      removeItem: async (k: string) => {
+        calls.push('removeItem');
+        delete store[k];
+      },
+    };
+
+    const writeP = entity.setRawData({ v: 7 }); // non-builder: no read involved
+    await writeStarted; // setRawData is parked inside setItem, seq bumped
+    const readP = entity.getRawData(); // fails while the write is in flight
+
+    await expect(readP).resolves.toBeNull();
+    releaseWrite();
+    await writeP;
+
+    expect(calls).not.toContain('removeItem'); // in-flight write already vetoed
+    expect(entity.entityKey in store).toBe(true);
+  });
+
+  test('entities without opt-in propagate the corrupted-blob error and keep the record', async () => {
+    const entity = new TestEntity({ name: 'test-no-heal-entity' });
+    const { storage, calls } = makeBrokenStorage({ errorName: 'UnknownError' });
+    (entity as any).appStorage = storage;
+
+    await expect(entity.getRawData()).rejects.toThrow(
+      'Failed to read large IndexedDB value',
+    );
+    expect(calls).toEqual(['getItem']); // no retry, no delete
+  });
+
+  test('delete is skipped when a pre-existing write completes during the failing read', async () => {
+    const entity = makeHealEntity();
+    const store: Record<string, unknown> = {};
+    const calls: string[] = [];
+    let releaseWrite!: () => void;
+    const writeGate = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    let signalWriteStarted!: () => void;
+    const writeStarted = new Promise<void>((resolve) => {
+      signalWriteStarted = resolve;
+    });
+    let rejectFirstRead!: (error: Error) => void;
+    let readCount = 0;
+    const makeError = () => {
+      const error = new Error('Failed to read large IndexedDB value');
+      error.name = 'UnknownError';
+      return error;
+    };
+    (entity as any).appStorage = {
+      getItem: () => {
+        readCount += 1;
+        calls.push('getItem');
+        if (readCount === 1) {
+          return new Promise<string | null>((_, reject) => {
+            rejectFirstRead = reject;
+          });
+        }
+        return Promise.reject(makeError());
+      },
+      setItem: async (k: string, v: unknown) => {
+        calls.push('setItem');
+        signalWriteStarted();
+        await writeGate;
+        store[k] = v;
+      },
+      removeItem: async (k: string) => {
+        calls.push('removeItem');
+        delete store[k];
+      },
+    };
+
+    const writeP = entity.setRawData({ v: 7 });
+    await writeStarted; // write is in flight before the read begins
+    const readP = entity.getRawData(); // snapshot sees the pending write
+    releaseWrite();
+    await writeP; // write fully lands while the read is still failing
+    rejectFirstRead(makeError());
+
+    await expect(readP).resolves.toBeNull();
+    expect(calls).not.toContain('removeItem'); // snapshot veto kept the value
+    expect(entity.entityKey in store).toBe(true);
+  });
+
+  test('clearRawData during an in-flight read keeps the stale value out of the cache', async () => {
+    const entity = new TestEntity({
+      name: 'test-cached-heal-entity',
+      enableCache: true,
+    });
+    const store: Record<string, unknown> = {};
+    let resolveFirstRead!: (value: string) => void;
+    let readCount = 0;
+    (entity as any).appStorage = {
+      getItem: (k: string) => {
+        readCount += 1;
+        if (readCount === 1) {
+          return new Promise<string | null>((resolve) => {
+            resolveFirstRead = resolve;
+          });
+        }
+        return Promise.resolve((k in store ? store[k] : null) as string | null);
+      },
+      setItem: async (k: string, v: unknown) => {
+        store[k] = v;
+      },
+      removeItem: async (k: string) => {
+        delete store[k];
+      },
+    };
+
+    const staleReadP = entity.getRawData(); // parked reading the old record
+    await entity.clearRawData(); // user clears while the read is in flight
+    resolveFirstRead(JSON.stringify({ data: { v: 9 }, updatedAt: 1 }));
+    await expect(staleReadP).resolves.toEqual({ v: 9 }); // its caller still gets the old value
+
+    // The stale value must not have been cached — a fresh read sees the clear.
+    await expect(entity.getRawData()).resolves.toBeNull();
+  });
+
+  test('a slow read finishing after a save cannot revert the cached value', async () => {
+    const entity = new TestEntity({
+      name: 'test-cached-save-entity',
+      enableCache: true,
+    });
+    const store: Record<string, unknown> = {};
+    let resolveFirstRead!: (value: string) => void;
+    let readCount = 0;
+    (entity as any).appStorage = {
+      getItem: (k: string) => {
+        readCount += 1;
+        if (readCount === 1) {
+          return new Promise<string | null>((resolve) => {
+            resolveFirstRead = resolve;
+          });
+        }
+        return Promise.resolve((k in store ? store[k] : null) as string | null);
+      },
+      setItem: async (k: string, v: unknown) => {
+        store[k] = v;
+      },
+      removeItem: async (k: string) => {
+        delete store[k];
+      },
+    };
+
+    const slowReadP = entity.getRawData(); // parked reading the old record
+    await entity.setRawData({ v: 7 }); // save lands while the read is parked
+    resolveFirstRead(JSON.stringify({ data: { v: 1 }, updatedAt: 1 }));
+    await slowReadP; // the old value must not overwrite the cache
+
+    await expect(entity.getRawData()).resolves.toEqual({ v: 7 });
   });
 });

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
@@ -72,8 +72,10 @@ abstract class SimpleDbEntityBase<T> {
   // flight cannot re-publish a stale value into the memory cache afterwards.
   private readGeneration = 0;
 
-  @backgroundMethod()
-  clearRawDataCache() {
+  // Stays protected and sync: both call sites need the cache cleared within the
+  // same tick, and SimpleDbEntityAsyncMethods requires every *public* entity
+  // method to be async — widening this would break that contract.
+  protected clearRawDataCache() {
     this.readGeneration += 1;
     this.cachedRawData = null;
     this.cachedRawDataPromise = null;

--- a/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
+++ b/packages/kit-bg/src/dbs/simple/base/SimpleDbEntityBase.ts
@@ -14,6 +14,22 @@ type ISimpleDbEntitySavedData<T> = {
   data: T;
   updatedAt: number;
 };
+
+// Chromium rejects reads with exactly this signature when a value's external
+// blob file is corrupted (e.g. crash mid-write); the record then stays
+// unreadable forever. Match nothing broader: UnknownError without this
+// message and NotReadableError both cover transient IO conditions where
+// deleting would lose recoverable data (OK-59997).
+function isUnreadableStorageValueError(error: unknown): boolean {
+  const { name, message } = (error ?? {}) as {
+    name?: string;
+    message?: string;
+  };
+  return (
+    name === 'UnknownError' &&
+    Boolean(message?.includes('Failed to read large IndexedDB value'))
+  );
+}
 abstract class SimpleDbEntityBase<T> {
   // Do not use appStorageInstance directly, use this.appStorage instead
   appStorage: AsyncStorageStatic =
@@ -24,6 +40,11 @@ abstract class SimpleDbEntityBase<T> {
   abstract readonly entityName: string;
 
   abstract readonly enableCache: boolean;
+
+  // Deleting an unreadable record is only safe for entities whose data can be
+  // fully rebuilt (OK-59997's perp cache); user-authored entities must keep
+  // failing loudly instead, so self-heal is opt-in per entity.
+  protected readonly enableUnreadableRecordSelfHeal: boolean = false;
 
   get entityKey() {
     return getSimpleDbEntityKey(this.entityName);
@@ -39,7 +60,21 @@ abstract class SimpleDbEntityBase<T> {
 
   updatedAt = 0;
 
-  protected clearRawDataCache() {
+  // Bumped when a persisted write starts so a failing read can tell whether a
+  // concurrent setRawData started after the read began.
+  private writeSeq = 0;
+
+  // Writes currently awaiting setItem; a failing read must not delete while
+  // one is in flight or was in flight when the read began.
+  private pendingWrites = 0;
+
+  // Bumped by clearRawDataCache and setRawData so a read that was already in
+  // flight cannot re-publish a stale value into the memory cache afterwards.
+  private readGeneration = 0;
+
+  @backgroundMethod()
+  clearRawDataCache() {
+    this.readGeneration += 1;
     this.cachedRawData = null;
     this.cachedRawDataPromise = null;
   }
@@ -54,7 +89,44 @@ abstract class SimpleDbEntityBase<T> {
     }
     this.cachedRawDataPromise = (async () => {
       dbPerfMonitor.logSimpleDbCall('getRawData', this.entityName);
-      const savedDataStr = await this.appStorage.getItem(this.entityKey);
+      const writeSeqBefore = this.writeSeq;
+      const pendingWritesBefore = this.pendingWrites;
+      const readGenerationBefore = this.readGeneration;
+      let savedDataStr: string | null = null;
+      try {
+        savedDataStr = await this.appStorage.getItem(this.entityKey);
+      } catch (error) {
+        if (
+          !this.enableUnreadableRecordSelfHeal ||
+          !isUnreadableStorageValueError(error)
+        ) {
+          throw error;
+        }
+        try {
+          // One retry separates transient IO failures from true corruption.
+          savedDataStr = await this.appStorage.getItem(this.entityKey);
+        } catch (retryError) {
+          if (!isUnreadableStorageValueError(retryError)) {
+            throw retryError;
+          }
+          console.error(retryError);
+          // Drop the dead record so builder-based setRawData can rebuild it;
+          // use appStorage directly — clearRawData() would deadlock on the
+          // shared mutex. Any write overlapping this read vetoes the delete:
+          // pending at read start, still pending now, or started since. (A
+          // write starting after this check wins anyway — same-store ops keep
+          // issue order, so its setItem lands after this removeItem.)
+          if (
+            pendingWritesBefore === 0 &&
+            this.pendingWrites === 0 &&
+            this.writeSeq === writeSeqBefore
+          ) {
+            await this.appStorage
+              .removeItem(this.entityKey)
+              .catch(() => undefined);
+          }
+        }
+      }
       let updatedAt = 0;
       // @ts-ignore
       let data: T | undefined | null;
@@ -85,7 +157,10 @@ abstract class SimpleDbEntityBase<T> {
         }
       }
       this.updatedAt = updatedAt ?? 0;
-      if (this.enableCache) {
+      // Skip the cache when clearRawData ran while this read was in flight,
+      // otherwise the stale value would resurrect the just-cleared record on
+      // the next builder-based write.
+      if (this.enableCache && this.readGeneration === readGenerationBefore) {
         this.cachedRawData = data;
       }
       return data;
@@ -123,12 +198,19 @@ abstract class SimpleDbEntityBase<T> {
       };
 
       dbPerfMonitor.logSimpleDbCall('setRawData', this.entityName);
-      await this.appStorage.setItem(
-        this.entityKey,
-        appStorageUtils.canSaveAsObject() && !isString(savedData)
-          ? (savedData as any)
-          : JSON.stringify(savedData),
-      );
+      this.writeSeq += 1;
+      this.readGeneration += 1;
+      this.pendingWrites += 1;
+      try {
+        await this.appStorage.setItem(
+          this.entityKey,
+          appStorageUtils.canSaveAsObject() && !isString(savedData)
+            ? (savedData as any)
+            : JSON.stringify(savedData),
+        );
+      } finally {
+        this.pendingWrites -= 1;
+      }
 
       this.updatedAt = updatedAt;
       return data;

--- a/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
+++ b/packages/kit-bg/src/dbs/simple/entity/SimpleDbEntityPerp.ts
@@ -195,6 +195,10 @@ export class SimpleDbEntityPerp extends SimpleDbEntityBase<ISimpleDbPerpData> {
 
   override enableCache = true;
 
+  // Everything here can be rebuilt from server/WS data or cheap re-acceptance,
+  // so dropping a corrupted record is safe (OK-59997).
+  protected override readonly enableUnreadableRecordSelfHeal = true;
+
   private _isCacheEntryFresh(updatedAt: number | undefined, maxAgeMs: number) {
     if (!updatedAt || maxAgeMs <= 0) {
       return false;

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -351,6 +351,12 @@ class ServiceSetting extends ServiceBase {
       await this.backgroundApi.simpleDb.serverNetwork.clearRawData();
       await this.backgroundApi.simpleDb.recentNetworks.clearRawData();
     }
+    if (values.perpsData) {
+      // Recovery exit for a perp record IndexedDB can no longer read. Runtime
+      // cache first so in-flight fetches cannot write stale data back.
+      await this.backgroundApi.serviceWebviewPerp.clearPerpsDepositTokenListRuntimeCache();
+      await this.backgroundApi.simpleDb.perp.clearRawData();
+    }
     // This is an account-level logout and intentionally runs after the pure
     // cache operations so a failure cannot prevent the selected cache clears.
     if (values.oneKeyId) {

--- a/packages/kit-bg/src/services/ServiceStaking.getAllProtocolList.test.ts
+++ b/packages/kit-bg/src/services/ServiceStaking.getAllProtocolList.test.ts
@@ -1,3 +1,4 @@
+import { OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import { EStakeProtocolGroupEnum } from '@onekeyhq/shared/types/staking';
 import type { IStakeProtocolListItem } from '@onekeyhq/shared/types/staking';
 
@@ -8,10 +9,13 @@ import type { AxiosInstance } from 'axios';
 // The full-list fast path must reuse getProtocolList's enabled gating
 // (review P1): locally disabled or client-unsupported protocols must never
 // surface on the aggregation pages. WithdrawOnly rows are kept (OK-59305) so
-// sunset protocols stay reachable for redeem. Rows without a symbol cannot be
-// config-checked so they are dropped (which makes old symbol-less servers
-// yield an empty list and pushes callers onto the per-symbol fan-out
-// fallback).
+// sunset protocols stay reachable for redeem.
+//
+// An empty array is the "response not usable, fall back to the per-symbol
+// fan-out" signal. It is returned whenever the fast path cannot produce a
+// complete list — a response missing symbols on any row, or a config lookup
+// that threw — rather than silently handing back a subset the caller would
+// treat as complete (PR 12791 review P1).
 
 function createProtocolItem({
   symbol,
@@ -145,6 +149,52 @@ describe('ServiceStaking.getAllProtocolList gating', () => {
 
     expect(result).toEqual([]);
     expect(getStakingConfigs).not.toHaveBeenCalled();
+  });
+
+  it('reports a partially symbol-less response as unusable rather than a subset (PR 12791 review P1)', async () => {
+    const { service, getStakingConfigs } = createServiceHarness({
+      protocols: [
+        createProtocolItem({ symbol: 'USDT', provider: 'enabled-provider' }),
+        createProtocolItem({ provider: 'symbol-less-provider' }),
+      ],
+      enabledByProvider: {
+        'enabled-provider': true,
+        'symbol-less-provider': true,
+      },
+    });
+
+    const result = await service.getAllProtocolList();
+
+    // Returning only the symbol-bearing row would look complete to the caller
+    // and silently hide the rest of the providers
+    expect(result).toEqual([]);
+    expect(getStakingConfigs).not.toHaveBeenCalled();
+  });
+
+  it('reports the fast path as unusable when a config lookup throws (PR 12791 review P1)', async () => {
+    const { service } = createServiceHarness({
+      protocols: [
+        createProtocolItem({ symbol: 'USDT', provider: 'enabled-provider' }),
+        createProtocolItem({ symbol: 'USDC', provider: 'throwing-provider' }),
+      ],
+      enabledByProvider: { 'enabled-provider': true },
+    });
+    jest
+      .spyOn(service, 'getStakingConfigs')
+      .mockImplementation(async ({ provider }) => {
+        if (provider === 'throwing-provider') {
+          throw new OneKeyLocalError('vault settings unavailable');
+        }
+        return { enabled: true } as Awaited<
+          ReturnType<ServiceStaking['getStakingConfigs']>
+        >;
+      });
+
+    const result = await service.getAllProtocolList();
+
+    // A transient lookup failure must not silently drop that provider from the
+    // aggregation pages while the rest still renders as if complete
+    expect(result).toEqual([]);
   });
 
   it('checks the config with each row own symbol/network/provider', async () => {

--- a/packages/kit-bg/src/services/ServiceStaking.ts
+++ b/packages/kit-bg/src/services/ServiceStaking.ts
@@ -970,13 +970,19 @@ class ServiceStaking extends ServiceBase {
     // (review P1) so locally disabled / client-unsupported protocols never
     // surface. WithdrawOnly rows are KEPT (OK-59305): sunset protocols like
     // lido/babylon are withdraw-only, and users with existing positions need
-    // the aggregation pages to reach the redeem flow. Rows without a symbol
-    // cannot be checked against the config, so they are dropped — an old
-    // server that returns symbol-less rows then yields an empty list and the
-    // caller falls back to the per-symbol fan-out path.
-    const visibleItems = allItems.filter((item) => Boolean(item.symbol));
+    // the aggregation pages to reach the redeem flow.
+    //
+    // Usability is decided BEFORE anything is dropped (PR 12791 review P1).
+    // Filtering symbol-less rows away first would make the caller's own
+    // "every row has a symbol" completeness check vacuously true, so a
+    // response the client cannot fully aggregate would look complete and the
+    // pages would silently render a subset instead of falling back to the
+    // per-symbol path. An empty result is the agreed "not usable" signal.
+    if (allItems.length === 0 || allItems.some((item) => !item.symbol)) {
+      return [];
+    }
     const itemsWithEnabledStatus = await promiseAllSettledEnhanced(
-      visibleItems.map((item) => async () => {
+      allItems.map((item) => async () => {
         const stakingConfig = await this.getStakingConfigs({
           networkId: item.network.networkId,
           symbol: item.symbol ?? '',
@@ -986,6 +992,15 @@ class ServiceStaking extends ServiceBase {
       }),
       { continueOnError: true, concurrency: PROMISE_CONCURRENCY_LIMIT },
     );
+    // continueOnError turns a rejected config lookup into null, which is
+    // indistinguishable from "config says disabled". Hiding a provider because
+    // its lookup happened to throw is a silent data loss on a primary surface,
+    // so treat the whole fast path as unusable instead and let the caller fall
+    // back to the per-symbol aggregation, which re-evaluates gating per symbol
+    // (PR 12791 review P1).
+    if (itemsWithEnabledStatus.some((r) => r === null || r === undefined)) {
+      return [];
+    }
     return itemsWithEnabledStatus
       .filter(
         (r): r is NonNullable<typeof r> =>
@@ -1119,7 +1134,7 @@ class ServiceStaking extends ServiceBase {
     provider: string;
     vault?: string;
   }) {
-    const { networkId, accountId, symbol, ...rest } = params;
+    const { networkId, accountId, symbol, vault, ...rest } = params;
     const accountVault = await vaultFactory.getVault({ networkId, accountId });
     const acc = await accountVault.getAccount();
     const client = await this.getClient(EServiceEndpointEnum.Earn);
@@ -1131,6 +1146,12 @@ class ServiceStaking extends ServiceBase {
         accountAddress: acc.address,
         symbol,
         publicKey: networkUtils.isBTCNetwork(networkId) ? acc.pub : undefined,
+        // Several call sites normalize a missing vault to '' before it gets
+        // here. Forwarding that empty string made the backend reject the whole
+        // request with `"vault" is not allowed to be empty` for providers that
+        // have no vault at all (Stakefish SOL). undefined is dropped from the
+        // query string, which is what "no vault" is supposed to mean.
+        vault: vault || undefined,
         ...rest,
       },
     });

--- a/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
+++ b/packages/kit-bg/src/services/ServiceWebviewPerp/ServiceWebviewPerp.ts
@@ -339,6 +339,12 @@ const PERPS_DEPOSIT_TOKEN_LIST_COLD_CACHE_MAX_AGE_MS =
     day: 1,
   });
 
+interface IPerpsDepositTokenListWriteOptions {
+  cacheKey: string;
+  writeGeneration: number;
+  clearEpoch: number;
+}
+
 @backgroundClass()
 class ServiceWebviewPerp extends ServiceBase {
   private perpsDepositTokenListCache = new Map<
@@ -347,6 +353,10 @@ class ServiceWebviewPerp extends ServiceBase {
   >();
 
   private perpsDepositTokenListWriteGenerations = new Map<string, number>();
+
+  // Bumped on runtime-cache clear; fetches capture it before their first await
+  // so requests that predate the clear cannot write results back.
+  private perpsDepositTokenListClearEpoch = 0;
 
   constructor({ backgroundApi }: { backgroundApi: any }) {
     super({ backgroundApi });
@@ -439,13 +449,28 @@ class ServiceWebviewPerp extends ServiceBase {
   private isPerpsDepositTokenListWriteGenerationCurrent({
     cacheKey,
     writeGeneration,
-  }: {
-    cacheKey: string;
-    writeGeneration: number;
-  }) {
+    clearEpoch,
+  }: IPerpsDepositTokenListWriteOptions) {
     return (
+      this.perpsDepositTokenListClearEpoch === clearEpoch &&
       this.getPerpsDepositTokenListWriteGeneration(cacheKey) === writeGeneration
     );
+  }
+
+  @backgroundMethod()
+  async clearPerpsDepositTokenListRuntimeCache() {
+    // Bump the epoch so every in-flight fetch — including ones that have not
+    // registered their cache key yet — skips its simpleDb write-back, then
+    // bump known generations and drop the memory cache.
+    this.perpsDepositTokenListClearEpoch += 1;
+    const cacheKeys = new Set([
+      ...this.perpsDepositTokenListCache.keys(),
+      ...this.perpsDepositTokenListWriteGenerations.keys(),
+    ]);
+    cacheKeys.forEach((cacheKey) =>
+      this.bumpPerpsDepositTokenListWriteGeneration(cacheKey),
+    );
+    this.perpsDepositTokenListCache.clear();
   }
 
   private buildPerpsDepositTokenListOwnerKey({
@@ -573,10 +598,7 @@ class ServiceWebviewPerp extends ServiceBase {
 
   private fetchPerpsDepositTokenListDataCached(
     params: IPerpsDepositTokenListCacheParams,
-    options: {
-      cacheKey: string;
-      writeGeneration: number;
-    },
+    options: IPerpsDepositTokenListWriteOptions,
   ): Promise<IPerpsDepositTokenListData> {
     const cacheKey = this.buildPerpsDepositTokenListCacheKey(params);
     const now = Date.now();
@@ -592,6 +614,7 @@ class ServiceWebviewPerp extends ServiceBase {
           this.isPerpsDepositTokenListWriteGenerationCurrent({
             cacheKey: options.cacheKey,
             writeGeneration: options.writeGeneration,
+            clearEpoch: options.clearEpoch,
           })
         ) {
           void this.backgroundApi.simpleDb.perp.setPerpsDepositTokenListCache({
@@ -619,10 +642,7 @@ class ServiceWebviewPerp extends ServiceBase {
 
   private async updatePerpsDepositTokenListAtom(
     { ownerKey, tokens, tokensByNetwork }: IPerpsDepositTokenListData,
-    options?: {
-      cacheKey: string;
-      writeGeneration: number;
-    },
+    options?: IPerpsDepositTokenListWriteOptions,
   ) {
     let selectedToken: IPerpsDepositToken | undefined;
     let isStale = false;
@@ -685,10 +705,7 @@ class ServiceWebviewPerp extends ServiceBase {
 
   private refreshPerpsDepositTokenListDataInBackground(
     params: IPerpsDepositTokenListCacheParams,
-    options: {
-      cacheKey: string;
-      writeGeneration: number;
-    },
+    options: IPerpsDepositTokenListWriteOptions,
   ) {
     void this.fetchPerpsDepositTokenListDataCached(params, options)
       .then((data) => this.updatePerpsDepositTokenListAtom(data, options))
@@ -706,6 +723,9 @@ class ServiceWebviewPerp extends ServiceBase {
     indexedAccountId,
     forceRefresh,
   }: IFetchPerpsDepositTokensFromWalletTokenListParams): Promise<IFetchPerpsDepositTokensFromWalletTokenListResult> {
+    // Captured before the first await so a runtime-cache clear that happens
+    // during owner normalization still invalidates this request's write-back.
+    const clearEpoch = this.perpsDepositTokenListClearEpoch;
     const { accountId: allNetworksAccountId, indexedAccountId: ownerIndexId } =
       await this.normalizePerpsDepositAllNetworksOwner({
         accountId,
@@ -733,7 +753,7 @@ class ServiceWebviewPerp extends ServiceBase {
     if (forceRefresh) {
       writeGeneration = this.bumpPerpsDepositTokenListWriteGeneration(cacheKey);
       this.perpsDepositTokenListCache.delete(cacheKey);
-      const writeOptions = { cacheKey, writeGeneration };
+      const writeOptions = { cacheKey, writeGeneration, clearEpoch };
       const data = await this.fetchPerpsDepositTokenListDataCached(
         cacheParams,
         writeOptions,
@@ -751,7 +771,7 @@ class ServiceWebviewPerp extends ServiceBase {
     const memoryCache =
       this.getPerpsDepositTokenListDataMemoryCache(cacheParams);
     if (memoryCache) {
-      const writeOptions = { cacheKey, writeGeneration };
+      const writeOptions = { cacheKey, writeGeneration, clearEpoch };
       const data = await memoryCache;
       const updateResult = await this.updatePerpsDepositTokenListAtom(
         data,
@@ -780,10 +800,12 @@ class ServiceWebviewPerp extends ServiceBase {
       const updateResult = await this.updatePerpsDepositTokenListAtom(data, {
         cacheKey,
         writeGeneration,
+        clearEpoch,
       });
       this.refreshPerpsDepositTokenListDataInBackground(cacheParams, {
         cacheKey,
         writeGeneration,
+        clearEpoch,
       });
       return {
         ...data,
@@ -791,7 +813,7 @@ class ServiceWebviewPerp extends ServiceBase {
       };
     }
 
-    const writeOptions = { cacheKey, writeGeneration };
+    const writeOptions = { cacheKey, writeGeneration, clearEpoch };
     const data = await this.fetchPerpsDepositTokenListDataCached(
       cacheParams,
       writeOptions,

--- a/packages/kit/src/components/AmountInput/index.tsx
+++ b/packages/kit/src/components/AmountInput/index.tsx
@@ -70,6 +70,14 @@ export type IAmountInputFormItemProps = IFormFieldProps<
     };
     tokenSelectorTriggerProps?: {
       selectedTokenImageUri?: string;
+      /**
+       * Skeleton just the token image while its URI is still being resolved,
+       * keeping the symbol readable. `loading` above blanks the whole trigger;
+       * this is for callers that already know the symbol but not the logo
+       * (e.g. Earn entered from a deep link without a tokenImageUri param) and
+       * would otherwise flash Image.Fallback's placeholder coin (OK-59961).
+       */
+      selectedTokenImageLoading?: boolean;
       selectedNetworkImageUri?: string;
       selectedTokenSymbol?: string;
       selectedNetworkName?: string;
@@ -203,6 +211,7 @@ export function AmountInput({
     const {
       popover: popoverProps,
       selectedTokenImageUri,
+      selectedTokenImageLoading,
       selectedNetworkImageUri,
       selectedTokenSymbol,
       selectedNetworkName,
@@ -253,28 +262,32 @@ export function AmountInput({
         onPress={hasPopover ? undefined : onPress}
       >
         <Stack mr="$2">
-          <Image
-            size="$7"
-            borderRadius="$full"
-            source={{
-              uri: selectedTokenImageUri,
-            }}
-            fallback={
-              <Image.Fallback
-                borderRadius="$full"
-                alignItems="center"
-                justifyContent="center"
-                bg="$gray5"
-              >
-                <Icon
-                  size="$6"
-                  m="$1"
-                  name="CryptoCoinOutline"
-                  color="$iconSubdued"
-                />
-              </Image.Fallback>
-            }
-          />
+          {selectedTokenImageLoading ? (
+            <Skeleton w="$7" h="$7" radius="round" />
+          ) : (
+            <Image
+              size="$7"
+              borderRadius="$full"
+              source={{
+                uri: selectedTokenImageUri,
+              }}
+              fallback={
+                <Image.Fallback
+                  borderRadius="$full"
+                  alignItems="center"
+                  justifyContent="center"
+                  bg="$gray5"
+                >
+                  <Icon
+                    size="$6"
+                    m="$1"
+                    name="CryptoCoinOutline"
+                    color="$iconSubdued"
+                  />
+                </Image.Fallback>
+              }
+            />
+          )}
           {selectedNetworkImageUri ? (
             <Stack
               position="absolute"

--- a/packages/kit/src/components/TabPageHeader/DappHeader.tsx
+++ b/packages/kit/src/components/TabPageHeader/DappHeader.tsx
@@ -15,6 +15,7 @@ import {
   useActiveAccount,
 } from '../../states/jotai/contexts/accountSelector/atoms';
 import { HomeTokenListProviderMirror } from '../../views/Home/components/HomeTokenListProvider/HomeTokenListProviderMirror';
+import { getUniversalSearchSource } from '../../views/UniversalSearch/universalSearchSource';
 import { AccountSelectorProviderMirror } from '../AccountSelector/AccountSelectorProvider';
 
 import {
@@ -45,8 +46,11 @@ function RightActions({ tabRoute }: { tabRoute: ETabRoutes }) {
   const handleSearchPress = useCallback(() => {
     navigation.pushModal(EModalRoutes.UniversalSearchModal, {
       screen: EUniversalSearchPages.UniversalSearch,
+      params: {
+        source: getUniversalSearchSource(tabRoute),
+      },
     });
-  }, [navigation]);
+  }, [navigation, tabRoute]);
 
   return (
     <XStack ai="center" gap="$3" $gtMd={{ gap: '$5' }}>

--- a/packages/kit/src/components/TabPageHeader/HeaderMDSearch.tsx
+++ b/packages/kit/src/components/TabPageHeader/HeaderMDSearch.tsx
@@ -9,6 +9,6 @@ export function HeaderMDSearch({
   tabRoute,
 }: ITabPageHeaderProp) {
   return tabRoute === ETabRoutes.Home || tabRoute === ETabRoutes.Market ? (
-    <MDUniversalSearchInput />
+    <MDUniversalSearchInput tabRoute={tabRoute} />
   ) : null;
 }

--- a/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
+++ b/packages/kit/src/components/TabPageHeader/HeaderRight.tsx
@@ -65,7 +65,11 @@ export function SelectorTrigger() {
 
 export function SearchInput({
   isUrlWallet = false,
-}: { isUrlWallet?: boolean } = {}) {
+  tabRoute,
+}: {
+  isUrlWallet?: boolean;
+  tabRoute: ETabRoutes;
+}) {
   const { gtXl, gtLg, gt2xl } = useMedia();
 
   let size: boolean;
@@ -75,7 +79,12 @@ export function SearchInput({
     size = platformEnv.isWeb ? gtXl : gtLg;
   }
 
-  return <LegacyUniversalSearchInput size={size ? 'large' : 'small'} />;
+  return (
+    <LegacyUniversalSearchInput
+      size={size ? 'large' : 'small'}
+      tabRoute={tabRoute}
+    />
+  );
 }
 
 export function HeaderRight({

--- a/packages/kit/src/components/TabPageHeader/LegacyUniversalSearchInput.tsx
+++ b/packages/kit/src/components/TabPageHeader/LegacyUniversalSearchInput.tsx
@@ -14,12 +14,14 @@ import {
   useIsWebHorizontalLayout,
 } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
 import { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
 import type { EUniversalSearchType } from '@onekeyhq/shared/types/search';
 
 import useAppNavigation from '../../hooks/useAppNavigation';
+import { getUniversalSearchSource } from '../../views/UniversalSearch/universalSearchSource';
 
 // Fully-rounded pill matching SearchBar's own borderRadius="$full"; the bar's
 // fill is made transparent (below) so this Liquid Glass material shows through.
@@ -34,22 +36,27 @@ export function LegacyUniversalSearchInput({
   // its search doesn't surface market/perp/wallet results (OK-56756).
   filterTypes,
   glass = false,
+  tabRoute,
 }: {
   containerProps?: IStackStyle;
   size?: 'large' | 'medium' | 'small';
   initialTab?: 'market' | 'dapp';
   filterTypes?: EUniversalSearchType[];
   glass?: boolean;
+  tabRoute: ETabRoutes;
 }) {
   const intl = useIntl();
   const navigation = useAppNavigation();
   const toUniversalSearchPage = useCallback(() => {
     navigation.pushModal(EModalRoutes.UniversalSearchModal, {
       screen: EUniversalSearchPages.UniversalSearch,
-      params:
-        initialTab || filterTypes ? { initialTab, filterTypes } : undefined,
+      params: {
+        source: getUniversalSearchSource(tabRoute),
+        ...(initialTab ? { initialTab } : {}),
+        ...(filterTypes ? { filterTypes } : {}),
+      },
     });
-  }, [navigation, initialTab, filterTypes]);
+  }, [filterTypes, initialTab, navigation, tabRoute]);
 
   // iOS 26 only: host the search bar inside a Liquid Glass capsule. Off iOS 26
   // (and every other platform) isLiquidGlassAvailable() is false, so this stays
@@ -147,12 +154,13 @@ export function LegacyUniversalSearchInput({
   );
 }
 
-export function MDUniversalSearchInput() {
+export function MDUniversalSearchInput({ tabRoute }: { tabRoute: ETabRoutes }) {
   const isHorizontal = useIsWebHorizontalLayout();
   return isHorizontal ? null : (
     <XStack px="$pagePadding" pt="$0.5">
       <LegacyUniversalSearchInput
         size="medium"
+        tabRoute={tabRoute}
         containerProps={{
           width: '100%',
           $gtLg: undefined,

--- a/packages/kit/src/components/TabPageHeader/MDHeader.tsx
+++ b/packages/kit/src/components/TabPageHeader/MDHeader.tsx
@@ -157,6 +157,7 @@ export function MDHeader({
                   <LegacyUniversalSearchInput
                     size="medium"
                     glass
+                    tabRoute={tabRoute}
                     containerProps={{
                       width: '100%',
                       $gtLg: undefined,

--- a/packages/kit/src/components/TabPageHeader/UniversalSearchInput.tsx
+++ b/packages/kit/src/components/TabPageHeader/UniversalSearchInput.tsx
@@ -13,11 +13,13 @@ import {
 import { HeaderIconButton } from '@onekeyhq/components/src/layouts/Navigation/Header';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
 import { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
 
 import useAppNavigation from '../../hooks/useAppNavigation';
+import { getUniversalSearchSource } from '../../views/UniversalSearch/universalSearchSource';
 
 import { HEADER_SEARCH_MIN_WIDTH, HEADER_WIDE_MEDIA_KEY } from './headerLayout';
 
@@ -31,19 +33,24 @@ export function UniversalSearchInput({
   containerProps,
   size = 'large',
   initialTab,
+  tabRoute,
 }: {
   containerProps?: IStackStyle;
   size?: 'large' | 'medium' | 'small';
   initialTab?: 'market' | 'dapp';
+  tabRoute: ETabRoutes;
 }) {
   const intl = useIntl();
   const navigation = useAppNavigation();
   const toUniversalSearchPage = useCallback(() => {
     navigation.pushModal(EModalRoutes.UniversalSearchModal, {
       screen: EUniversalSearchPages.UniversalSearch,
-      params: initialTab ? { initialTab } : undefined,
+      params: {
+        source: getUniversalSearchSource(tabRoute),
+        ...(initialTab ? { initialTab } : {}),
+      },
     });
-  }, [navigation, initialTab]);
+  }, [initialTab, navigation, tabRoute]);
 
   if (size === 'small') {
     return (
@@ -96,12 +103,13 @@ export function UniversalSearchInput({
   );
 }
 
-export function MDUniversalSearchInput() {
+export function MDUniversalSearchInput({ tabRoute }: { tabRoute: ETabRoutes }) {
   const isHorizontal = useIsWebHorizontalLayout();
   return isHorizontal ? null : (
     <XStack px="$pagePadding" pt="$0.5">
       <UniversalSearchInput
         size="medium"
+        tabRoute={tabRoute}
         containerProps={{
           width: '100%',
           // Clear whichever breakpoint HEADER_WIDE_MEDIA_KEY resolved to.

--- a/packages/kit/src/components/TabPageHeader/index.tsx
+++ b/packages/kit/src/components/TabPageHeader/index.tsx
@@ -103,8 +103,8 @@ function BaseDesktopTabPageHeader({
   );
 
   const renderUniversalSearchInput = useCallback(
-    () => <UniversalSearchInput />,
-    [],
+    () => <UniversalSearchInput tabRoute={tabRoute} />,
+    [tabRoute],
   );
 
   const renderDesktopModeRightButtons = useCallback(() => {

--- a/packages/kit/src/hooks/useGlobalShortcuts.desktop.test.ts
+++ b/packages/kit/src/hooks/useGlobalShortcuts.desktop.test.ts
@@ -1,0 +1,81 @@
+/** @jest-environment jsdom */
+
+import { act, renderHook } from '@testing-library/react';
+
+import { useShortcuts } from '@onekeyhq/components';
+import { EModalRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
+import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
+import { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
+import { EUniversalSearchSource } from '@onekeyhq/shared/types/search';
+
+import useAppNavigation from './useAppNavigation';
+import { useGlobalShortcuts } from './useGlobalShortcuts.desktop';
+import { useShortcutsRouteStatus } from './useListenTabFocusState';
+
+jest.mock('@onekeyhq/components', () => ({
+  useShortcuts: jest.fn(),
+}));
+
+jest.mock('./useAppNavigation', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('./useListenTabFocusState', () => ({
+  useShortcutsRouteStatus: jest.fn(),
+}));
+
+const mockUseShortcuts = useShortcuts as jest.Mock;
+const mockUseAppNavigation = useAppNavigation as jest.Mock;
+const mockUseShortcutsRouteStatus = useShortcutsRouteStatus as jest.Mock;
+
+describe('useGlobalShortcuts', () => {
+  it('attributes universal search to the current tab when the shortcut fires', () => {
+    const pushModal = jest.fn();
+    const currentTabRoute = { current: ETabRoutes.Home };
+    let shortcutHandler: ((event: EShortcutEvents) => void) | undefined;
+
+    mockUseAppNavigation.mockReturnValue({ pushModal });
+    mockUseShortcutsRouteStatus.mockReturnValue({
+      currentTabRoute,
+      isAtBrowserTab: { current: false },
+      shouldReloadAppByCmdR: { current: true },
+    });
+    mockUseShortcuts.mockImplementation(
+      (_scope: unknown, handler: (event: EShortcutEvents) => void) => {
+        shortcutHandler = handler;
+      },
+    );
+
+    renderHook(() => useGlobalShortcuts());
+
+    act(() => shortcutHandler?.(EShortcutEvents.UniversalSearch));
+    expect(pushModal).toHaveBeenLastCalledWith(
+      EModalRoutes.UniversalSearchModal,
+      {
+        screen: EUniversalSearchPages.UniversalSearch,
+        params: { source: EUniversalSearchSource.Wallet },
+      },
+    );
+
+    currentTabRoute.current = ETabRoutes.Perp;
+    act(() => shortcutHandler?.(EShortcutEvents.UniversalSearch));
+    expect(pushModal).toHaveBeenLastCalledWith(
+      EModalRoutes.UniversalSearchModal,
+      {
+        screen: EUniversalSearchPages.UniversalSearch,
+        params: { source: EUniversalSearchSource.Perps },
+      },
+    );
+
+    currentTabRoute.current = ETabRoutes.MultiTabBrowser;
+    act(() => shortcutHandler?.(EShortcutEvents.UniversalSearch));
+    expect(pushModal).toHaveBeenLastCalledWith(
+      EModalRoutes.UniversalSearchModal,
+      {
+        screen: EUniversalSearchPages.UniversalSearch,
+        params: { source: EUniversalSearchSource.Browser },
+      },
+    );
+  });
+});

--- a/packages/kit/src/hooks/useGlobalShortcuts.desktop.ts
+++ b/packages/kit/src/hooks/useGlobalShortcuts.desktop.ts
@@ -5,12 +5,15 @@ import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
 import { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
 
+import { getUniversalSearchSource } from '../views/UniversalSearch/universalSearchSource';
+
 import useAppNavigation from './useAppNavigation';
 import { useShortcutsRouteStatus } from './useListenTabFocusState';
 
 export const useGlobalShortcuts = () => {
   const navigation = useAppNavigation();
-  const { isAtBrowserTab, shouldReloadAppByCmdR } = useShortcutsRouteStatus();
+  const { currentTabRoute, isAtBrowserTab, shouldReloadAppByCmdR } =
+    useShortcutsRouteStatus();
 
   const handleShortcuts = useCallback(
     (data: EShortcutEvents) => {
@@ -18,6 +21,9 @@ export const useGlobalShortcuts = () => {
         case EShortcutEvents.UniversalSearch:
           navigation.pushModal(EModalRoutes.UniversalSearchModal, {
             screen: EUniversalSearchPages.UniversalSearch,
+            params: {
+              source: getUniversalSearchSource(currentTabRoute.current),
+            },
           });
           break;
         case EShortcutEvents.Refresh:
@@ -34,7 +40,7 @@ export const useGlobalShortcuts = () => {
           break;
       }
     },
-    [isAtBrowserTab, navigation, shouldReloadAppByCmdR],
+    [currentTabRoute, isAtBrowserTab, navigation, shouldReloadAppByCmdR],
   );
 
   useShortcuts(undefined, handleShortcuts);

--- a/packages/kit/src/hooks/useListenTabFocusState.ts
+++ b/packages/kit/src/hooks/useListenTabFocusState.ts
@@ -3,15 +3,21 @@ import { useCallback, useRef } from 'react';
 import { useOnRouterChange } from '@onekeyhq/components';
 import { ERootRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
 
+const ALL_TAB_ROUTES = Object.values(ETabRoutes);
+
 export default function useListenTabFocusState(
   tabName: ETabRoutes | ETabRoutes[],
-  callback: (isFocus: boolean, isHideByModal: boolean) => void, // do NOT useCallback to wrap the callback
+  callback: (
+    isFocus: boolean,
+    isHideByModal: boolean,
+    currentTabName: ETabRoutes | undefined,
+  ) => void, // do NOT useCallback to wrap the callback
 ) {
   const tabNames = Array.isArray(tabName) ? tabName : [tabName];
   useOnRouterChange((state) => {
     // the state may be undefined when initializing the interface on the Ext.
     if (!state) {
-      callback(tabName === ETabRoutes.Home, false);
+      callback(tabNames.includes(ETabRoutes.Home), false, ETabRoutes.Home);
       return;
     }
     const rootState = state?.routes.find(
@@ -28,10 +34,11 @@ export default function useListenTabFocusState(
     )?.key;
     const currentTabName = rootState?.routeNames
       ? (rootState?.routeNames?.[rootState?.index || 0] as ETabRoutes)
-      : (rootState?.routes[0].name as ETabRoutes);
+      : (rootState?.routes[0]?.name as ETabRoutes | undefined);
     callback(
-      tabNames.includes(currentTabName),
+      !!currentTabName && tabNames.includes(currentTabName),
       !!(modalRoutes || fullModalRoutes || fullScreenPushRoutes),
+      currentTabName,
     );
   });
 }
@@ -41,6 +48,7 @@ export function useShortcutsRouteStatus() {
   const isAtBrowserTab = useRef(false);
   const isAtPerpTab = useRef(false);
   const isAtDiscoveryTab = useRef(false);
+  const currentTabRoute = useRef<ETabRoutes | undefined>(undefined);
 
   const updateShouldReloadAppByCmdR = useCallback(() => {
     shouldReloadAppByCmdR.current =
@@ -68,7 +76,15 @@ export function useShortcutsRouteStatus() {
     updateShouldReloadAppByCmdR();
   });
 
+  useListenTabFocusState(
+    ALL_TAB_ROUTES,
+    (_isFocus, _isHideByModal, currentTabName) => {
+      currentTabRoute.current = currentTabName;
+    },
+  );
+
   return {
+    currentTabRoute,
     isAtDiscoveryTab,
     isAtBrowserTab,
     isAtPerpTab,

--- a/packages/kit/src/routes/Tab/Discovery/router.ts
+++ b/packages/kit/src/routes/Tab/Discovery/router.ts
@@ -10,6 +10,7 @@ import {
   LazyLoadPage,
   LazyLoadRootTabPage,
 } from '../../../components/LazyLoadPage';
+import { earnLazyPageFallback } from '../../../views/Earn/components/EarnLazyPageFallback';
 import { createMarketDetailV2Route } from '../../../views/Market/MarketDetailV2/MarketDetailV2Route';
 
 const Browser = LazyLoadRootTabPage(
@@ -20,6 +21,23 @@ const DiscoveryDashboard = LazyLoadRootTabPage(
 );
 const EarnProtocols = LazyLoadRootTabPage(
   () => import('../../../views/Earn/pages/EarnProtocols'),
+  earnLazyPageFallback,
+);
+const EarnTokens = LazyLoadRootTabPage(
+  () => import('../../../views/Earn/pages/EarnTokens'),
+  earnLazyPageFallback,
+);
+const EarnFixedRateTokens = LazyLoadRootTabPage(
+  () => import('../../../views/Earn/pages/EarnFixedRateTokens'),
+  earnLazyPageFallback,
+);
+const EarnAllProtocols = LazyLoadRootTabPage(
+  () => import('../../../views/Earn/pages/EarnAllProtocols'),
+  earnLazyPageFallback,
+);
+const EarnProtocolTokens = LazyLoadRootTabPage(
+  () => import('../../../views/Earn/pages/EarnProtocolTokens'),
+  earnLazyPageFallback,
 );
 const EarnTokens = LazyLoadRootTabPage(
   () => import('../../../views/Earn/pages/EarnTokens'),
@@ -35,6 +53,16 @@ const EarnProtocolTokens = LazyLoadRootTabPage(
 );
 const EarnProtocolDetails = LazyLoadRootTabPage(
   () => import('../../../views/Earn/pages/EarnProtocolDetails'),
+  earnLazyPageFallback,
+);
+const BorrowHome = LazyLoadRootTabPage(
+  () => import('../../../views/Borrow/pages/BorrowHomePage'),
+);
+const EarnPositions = LazyLoadRootTabPage(
+  () => import('../../../views/Earn/pages/EarnPositions'),
+);
+const BorrowReserveDetails = LazyLoadRootTabPage(
+  () => import('../../../views/Borrow/pages/ReserveDetails'),
 );
 const BorrowHome = LazyLoadRootTabPage(
   () => import('../../../views/Borrow/pages/BorrowHomePage'),

--- a/packages/kit/src/routes/Tab/Discovery/router.ts
+++ b/packages/kit/src/routes/Tab/Discovery/router.ts
@@ -39,30 +39,9 @@ const EarnProtocolTokens = LazyLoadRootTabPage(
   () => import('../../../views/Earn/pages/EarnProtocolTokens'),
   earnLazyPageFallback,
 );
-const EarnTokens = LazyLoadRootTabPage(
-  () => import('../../../views/Earn/pages/EarnTokens'),
-);
-const EarnFixedRateTokens = LazyLoadRootTabPage(
-  () => import('../../../views/Earn/pages/EarnFixedRateTokens'),
-);
-const EarnAllProtocols = LazyLoadRootTabPage(
-  () => import('../../../views/Earn/pages/EarnAllProtocols'),
-);
-const EarnProtocolTokens = LazyLoadRootTabPage(
-  () => import('../../../views/Earn/pages/EarnProtocolTokens'),
-);
 const EarnProtocolDetails = LazyLoadRootTabPage(
   () => import('../../../views/Earn/pages/EarnProtocolDetails'),
   earnLazyPageFallback,
-);
-const BorrowHome = LazyLoadRootTabPage(
-  () => import('../../../views/Borrow/pages/BorrowHomePage'),
-);
-const EarnPositions = LazyLoadRootTabPage(
-  () => import('../../../views/Earn/pages/EarnPositions'),
-);
-const BorrowReserveDetails = LazyLoadRootTabPage(
-  () => import('../../../views/Borrow/pages/ReserveDetails'),
 );
 const BorrowHome = LazyLoadRootTabPage(
   () => import('../../../views/Borrow/pages/BorrowHomePage'),

--- a/packages/kit/src/states/jotai/contexts/signatureConfirm/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/signatureConfirm/actions.ts
@@ -349,6 +349,7 @@ class ContextJotaiActionsSignatureConfirm extends ContextJotaiActionsBase {
         lockedUserNonce?: number;
         idempotencyKey?: string;
         gasAccountScenarioReason?: string;
+        sponsorDisabledByCustomRpc?: boolean;
       },
     ) => {
       set(gasAccountUiStateAtom(), {

--- a/packages/kit/src/states/jotai/contexts/signatureConfirm/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/signatureConfirm/atoms.ts
@@ -230,6 +230,8 @@ export const defaultGasAccountUiState = {
   selectedPayer: 'user' as const,
   lockedUserNonce: undefined as number | undefined,
   idempotencyKey: '',
+  gasAccountScenarioReason: undefined as string | undefined,
+  sponsorDisabledByCustomRpc: false,
 };
 
 export const { atom: gasAccountUiStateAtom, use: useGasAccountUiStateAtom } =
@@ -240,6 +242,8 @@ export const { atom: gasAccountUiStateAtom, use: useGasAccountUiStateAtom } =
     selectedPayer: 'user' | 'gasAccount';
     lockedUserNonce?: number;
     idempotencyKey: string;
+    gasAccountScenarioReason?: string;
+    sponsorDisabledByCustomRpc: boolean;
   }>({ ...defaultGasAccountUiState });
 
 export const {

--- a/packages/kit/src/views/Borrow/BorrowProvider.tsx
+++ b/packages/kit/src/views/Borrow/BorrowProvider.tsx
@@ -105,6 +105,14 @@ export const BorrowProvider = ({
   const [reserves, setReserves] = useState<
     IAsyncData<IBorrowReserveItem | null>
   >(defaultAsyncData(null));
+  // OK-60105: BorrowDataGate publishes the real status from an effect, so this
+  // initial value is what every consumer sees on the first commit. Idle is not
+  // in any card's loading set, so it made them paint their real empty-state
+  // copy for a frame before loading had even been acknowledged — inside Card's
+  // Accordion (height driven by a lagging onLayout, overflow hidden) that frame
+  // shows up as clipped copy. Nothing has been loaded yet at this point, so
+  // LoadingMarkets is the honest starting status; the gate overwrites it on the
+  // next commit either way.
   const [borrowDataStatus, setBorrowDataStatus] = useState<EBorrowDataStatus>(
     EBorrowDataStatus.Initializing,
   );

--- a/packages/kit/src/views/Borrow/components/BorrowDataGate.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowDataGate.tsx
@@ -224,7 +224,12 @@ export const BorrowDataGate = ({
 
   const {
     result: reservesResult,
-    isLoading: reservesLoading,
+    // OK-60105: undefined until usePromiseResult's effect has fired, which left
+    // dataStatus falling through to Idle between markets resolving and the
+    // reserves request starting. useBorrowMarkets already defaults the same
+    // way; the terminal Idle (settled with no result, e.g. after an error) is
+    // untouched, so a failed load still reaches the real empty state.
+    isLoading: reservesLoading = true,
     run: refreshReserves,
   } = usePromiseResult(
     async () => {

--- a/packages/kit/src/views/Borrow/components/BorrowRewardsMetric.tsx
+++ b/packages/kit/src/views/Borrow/components/BorrowRewardsMetric.tsx
@@ -13,6 +13,7 @@ import { buildBorrowTag } from '../../Staking/utils/utils';
 import { getBorrowEarnAccountId } from '../borrowEarnAccount';
 import { useBorrowContext } from '../BorrowProvider';
 import { useBorrowPlaceholderAmountText } from '../hooks/useBorrowPlaceholderAmountText';
+import { useLoadedOnce } from '../hooks/useLoadedOnce';
 import { useUniversalBorrowClaim } from '../hooks/useUniversalBorrowHooks';
 import { BorrowTestIDs } from '../testIDs';
 
@@ -39,6 +40,7 @@ export function BorrowRewardsMetric({
   widthMode?: IOverviewMetricProps['widthMode'];
 }) {
   const intl = useIntl();
+  const hasLoadedRewardsOnce = useLoadedOnce(Boolean(borrowRewards));
   const placeholderAmountText = useBorrowPlaceholderAmountText();
   const { market, earnAccount, pendingTxs } = useBorrowContext();
 
@@ -156,7 +158,7 @@ export function BorrowRewardsMetric({
         }
       }
       text={borrowRewards?.description ?? placeholderAmountText}
-      isLoading={Boolean(isLoading && !borrowRewards)}
+      isLoading={Boolean(isLoading && !hasLoadedRewardsOnce)}
       widthMode={widthMode}
       action={
         borrowRewards && !borrowRewards.button.disabled ? (

--- a/packages/kit/src/views/Borrow/components/Overview.tsx
+++ b/packages/kit/src/views/Borrow/components/Overview.tsx
@@ -13,6 +13,7 @@ import {
 } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import type { IBorrowEModeStatus } from '@onekeyhq/shared/types/staking';
 
 import { EarnActionIcon } from '../../Staking/components/ProtocolDetails/EarnActionIcon';
@@ -22,6 +23,7 @@ import { getBorrowEarnAccountId } from '../borrowEarnAccount';
 import { useBorrowContext } from '../BorrowProvider';
 import { BorrowNavigation } from '../borrowUtils';
 import { useBorrowPlaceholderAmountText } from '../hooks/useBorrowPlaceholderAmountText';
+import { useLoadedOnce } from '../hooks/useLoadedOnce';
 import { BorrowTestIDs } from '../testIDs';
 
 import { BorrowBonusMetric } from './BorrowBonusMetric';
@@ -120,19 +122,28 @@ export const Overview = ({
   };
   const isNetWorthLoading = reserves.loading && !reserves.data?.overview;
   const isNetApyLoading = reserves.loading && !reserves.data?.overview;
+  const hasLoadedHealthFactorOnce = useLoadedOnce(Boolean(healthFactorData));
   const healthFactorDetail =
     healthFactorData?.healthFactor?.button?.data.healthFactorDetail;
   const healthSummaryProps = {
     detail: healthFactorDetail,
     fallbackText: healthFactorData?.healthFactor?.text,
-    isLoading: isHealthFactorLoading && !healthFactorData,
+    isLoading: isHealthFactorLoading && !hasLoadedHealthFactorOnce,
   };
 
   const pendingCount = pendingTxs.length;
   const historyAction = reserves.data?.overview?.history;
   const historyVisible = !historyAction?.disabled && pendingCount === 0;
-  const showMobileHeaderHistoryAction =
-    !gtMd && (pendingCount > 0 || !historyAction?.disabled);
+  const hasHistoryAction = pendingCount > 0 || !historyAction?.disabled;
+  // Narrow layouts drop the inline entry and let the host hoist it into the
+  // title bar — but only the native BorrowHomePage passes
+  // onBorrowHistoryActionChange, so on web / WebDapp / a narrow desktop window
+  // that left no way at all to reach history or see the pending count. Keep the
+  // inline entry wherever nothing can hoist it.
+  const showMobileHeaderHistoryAction = Boolean(
+    !gtMd && platformEnv.isNative && hasHistoryAction,
+  );
+  const showInlineHistoryTools = gtMd || !platformEnv.isNative;
 
   useEffect(() => {
     if (!onBorrowHistoryActionChange) {
@@ -164,10 +175,10 @@ export const Overview = ({
 
   const historyTools = (
     <XStack ai="center" gap="$3" flexShrink={0}>
-      {gtMd && pendingCount > 0 ? (
+      {showInlineHistoryTools && pendingCount > 0 ? (
         <PendingIndicator num={pendingCount} onPress={handleHistoryPress} />
       ) : null}
-      {gtMd && historyVisible ? (
+      {showInlineHistoryTools && historyVisible ? (
         <XStack testID={BorrowTestIDs.overviewHistoryBtn} ai="center">
           {historyAction ? (
             <EarnActionIcon

--- a/packages/kit/src/views/Borrow/hooks/useLoadedOnce.ts
+++ b/packages/kit/src/views/Borrow/hooks/useLoadedOnce.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Latches on the first time data arrives.
+ *
+ * The borrow overview's side requests poll on their own cadence, and each
+ * re-run drops its result back to undefined for a moment. Gating a skeleton on
+ * "no data right now" therefore lets a value that has already rendered flip
+ * back to a skeleton mid-load, with each metric flipping at a different time.
+ *
+ * Once a field has rendered a value it should never show a skeleton again; a
+ * request that genuinely finishes empty still falls through to the placeholder,
+ * because its own loading flag is false by then.
+ */
+export function useLoadedOnce(hasData: boolean) {
+  const [loadedOnce, setLoadedOnce] = useState(hasData);
+  useEffect(() => {
+    if (hasData) {
+      setLoadedOnce(true);
+    }
+  }, [hasData]);
+  return loadedOnce;
+}

--- a/packages/kit/src/views/Borrow/pages/BorrowHome.tsx
+++ b/packages/kit/src/views/Borrow/pages/BorrowHome.tsx
@@ -210,7 +210,23 @@ const BorrowHomeContent = memo(
         earnAccount.data?.accountAddress,
       ],
     );
-    const hasAlerts = Boolean(alerts.length) || showNoAddressWarning;
+    const hasAlertsNow = Boolean(alerts.length) || showNoAddressWarning;
+    // The two alert sources settle independently (reserves + health factor),
+    // and each re-run briefly drops its result, so this flag flips more than
+    // once during a single load. Every flip swaps Overview's $10 bottom
+    // spacing for the alert block's own margins — a ~32pt gap that opens
+    // below Claimable Rewards and is taken back again.
+    //
+    // Hold the last settled answer while a load is in flight, so the layout
+    // moves once, when the data is actually final.
+    const lastSettledHasAlertsRef = useRef(false);
+    const isBorrowDataSettled = borrowDataStatus === EBorrowDataStatus.Ready;
+    if (isBorrowDataSettled) {
+      lastSettledHasAlertsRef.current = hasAlertsNow;
+    }
+    const hasAlerts = isBorrowDataSettled
+      ? hasAlertsNow
+      : lastSettledHasAlertsRef.current;
 
     const refreshEarnAccount = earnAccount.refresh;
     const refreshReserves = reserves.refresh;

--- a/packages/kit/src/views/Borrow/pages/modal/BorrowTokenSelectModal.tsx
+++ b/packages/kit/src/views/Borrow/pages/modal/BorrowTokenSelectModal.tsx
@@ -40,6 +40,28 @@ const emptyBalance: IBorrowBalance = {
   description: emptyText,
 };
 
+const EMPTY_ASSETS_LIST: IBorrowAssetsList = { assets: [] };
+
+// OK-60106: usePromiseResult restarts from initResult on every mount, so
+// re-entering the selector rendered an "empty + loading" frame before the
+// already-warm request came back — the empty state QA saw flash past.
+// Remembering the last result per request identity lets a re-entry render the
+// list on its first frame instead. The key carries accountId, so one account's
+// balances can never seed another's, and the entry is refreshed by the request
+// that runs right behind it.
+const borrowAssetsListCache = new Map<string, IBorrowAssetsList>();
+
+function buildBorrowAssetsCacheKey(params: {
+  accountId?: string;
+  networkId?: string;
+  provider?: string;
+  marketAddress?: string;
+  action?: string;
+}) {
+  const { accountId, networkId, provider, marketAddress, action } = params;
+  return [accountId, networkId, provider, marketAddress, action].join('|');
+}
+
 export default function BorrowTokenSelectModal() {
   const navigation =
     useAppNavigation<IPageNavigationProp<IModalStakingParamList>>();
@@ -64,22 +86,38 @@ export default function BorrowTokenSelectModal() {
   } = route.params;
   const [searchKeyword, setSearchKeyword] = useState('');
 
+  const cacheKey = buildBorrowAssetsCacheKey({
+    accountId,
+    networkId,
+    provider,
+    marketAddress,
+    action,
+  });
+  // Read once per mount: the first render is the only one that matters here,
+  // and a later key change is picked up by the request that re-runs anyway.
+  const [initialAssetsList] = useState<IBorrowAssetsList>(
+    () => borrowAssetsListCache.get(cacheKey) ?? EMPTY_ASSETS_LIST,
+  );
+
   const { result: assetsList, isLoading } = usePromiseResult<IBorrowAssetsList>(
     async () => {
       if (!accountId || !networkId || !provider || !marketAddress) {
-        return { assets: [] };
+        return EMPTY_ASSETS_LIST;
       }
-      return backgroundApiProxy.serviceStaking.getBorrowAssetsList({
-        accountId,
-        networkId,
-        provider,
-        marketAddress,
-        action: action as EBorrowActionsEnum,
-      });
+      const result =
+        await backgroundApiProxy.serviceStaking.getBorrowAssetsList({
+          accountId,
+          networkId,
+          provider,
+          marketAddress,
+          action: action as EBorrowActionsEnum,
+        });
+      borrowAssetsListCache.set(cacheKey, result);
+      return result;
     },
-    [accountId, networkId, provider, marketAddress, action],
+    [accountId, networkId, provider, marketAddress, action, cacheKey],
     {
-      initResult: { assets: [] },
+      initResult: initialAssetsList,
       watchLoading: true,
     },
   );

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.ext.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.ext.tsx
@@ -24,22 +24,15 @@ import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { EarnHomeWithProvider } from '../../../Earn/EarnHome';
 import { MarketHomeWithProvider } from '../../../Market/MarketHomeV2/MarketHomeV2';
 
+import {
+  getExploreTabName,
+  getExploreUniversalSearchTabRoute,
+} from './exploreTabUtils';
 import { withBrowserProvider } from './WithBrowserProvider';
 
 import type { RouteProp } from '@react-navigation/core';
 
-type IExploreTabName = 'market' | 'earn' | 'browser';
 type IExploreTabSwitchType = 'default' | 'tap' | 'swipe';
-
-function getExploreTabName(tab: ETranslations): IExploreTabName {
-  if (tab === ETranslations.global_market) {
-    return 'market';
-  }
-  if (tab === ETranslations.global_earn) {
-    return 'earn';
-  }
-  return 'browser';
-}
 
 function MobileBrowser() {
   const route =
@@ -51,6 +44,8 @@ function MobileBrowser() {
   const [selectedHeaderTab, setSelectedHeaderTab] = useState<ETranslations>(
     defaultTab || settings.selectedBrowserTab || ETranslations.global_market,
   );
+  const universalSearchTabRoute =
+    getExploreUniversalSearchTabRoute(selectedHeaderTab);
   const exploreTabSwitchTypeRef = useRef<IExploreTabSwitchType>('default');
   const hasLoggedExploreTabViewRef = useRef(false);
 
@@ -108,7 +103,11 @@ function MobileBrowser() {
         {/* custom header */}
         <YStack my="$2">
           <XStack mx="$5">
-            <LegacyUniversalSearchInput size="medium" initialTab="market" />
+            <LegacyUniversalSearchInput
+              size="medium"
+              initialTab="market"
+              tabRoute={universalSearchTabRoute}
+            />
           </XStack>
           <TabPageHeader
             sceneName={EAccountSelectorSceneName.home}

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -81,6 +81,10 @@ import { checkAndCreateFolder } from '../../utils/screenshot';
 import { showTabBar, useNotifyTabBarDisplay } from '../../utils/tabBarUtils';
 import DashboardContent from '../Dashboard/DashboardContent';
 
+import {
+  getExploreTabName,
+  getExploreUniversalSearchTabRoute,
+} from './exploreTabUtils';
 import MobileBrowserContent from './MobileBrowserContent';
 import { withBrowserProvider } from './WithBrowserProvider';
 
@@ -88,18 +92,7 @@ import type { IEarnBorrowPagerViewRef } from '../../../Earn/components/EarnBorro
 import type { RouteProp } from '@react-navigation/core';
 import type { WebView } from 'react-native-webview';
 
-type IExploreTabName = 'market' | 'earn' | 'browser';
 type IExploreTabSwitchType = 'default' | 'tap' | 'swipe';
-
-function getExploreTabName(tab: ETranslations): IExploreTabName {
-  if (tab === ETranslations.global_market) {
-    return 'market';
-  }
-  if (tab === ETranslations.global_earn) {
-    return 'earn';
-  }
-  return 'browser';
-}
 
 const styles = StyleSheet.create({
   // iOS WKWebViews must stay in the native layout tree. In nested layouts,
@@ -252,6 +245,8 @@ function MobileBrowser() {
     }
     return undefined;
   }, [selectedHeaderTab]);
+  const universalSearchTabRoute =
+    getExploreUniversalSearchTabRoute(selectedHeaderTab);
 
   const { tabs } = useWebTabs();
   const { activeTabId } = useActiveTabId();
@@ -760,6 +755,7 @@ function MobileBrowser() {
               size="medium"
               glass
               initialTab={searchInitialTab}
+              tabRoute={universalSearchTabRoute}
             />
           </Stack>
           <TabPageHeader

--- a/packages/kit/src/views/Discovery/pages/Browser/exploreTabUtils.test.ts
+++ b/packages/kit/src/views/Discovery/pages/Browser/exploreTabUtils.test.ts
@@ -1,0 +1,21 @@
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+
+import {
+  getExploreTabName,
+  getExploreUniversalSearchTabRoute,
+} from './exploreTabUtils';
+
+describe('exploreTabUtils', () => {
+  it.each([
+    [ETranslations.global_market, 'market', ETabRoutes.Market],
+    [ETranslations.global_earn, 'earn', ETabRoutes.Earn],
+    [ETranslations.global_browser, 'browser', ETabRoutes.Discovery],
+  ] as const)(
+    'maps %s to %s and %s',
+    (tab, expectedTabName, expectedTabRoute) => {
+      expect(getExploreTabName(tab)).toBe(expectedTabName);
+      expect(getExploreUniversalSearchTabRoute(tab)).toBe(expectedTabRoute);
+    },
+  );
+});

--- a/packages/kit/src/views/Discovery/pages/Browser/exploreTabUtils.ts
+++ b/packages/kit/src/views/Discovery/pages/Browser/exploreTabUtils.ts
@@ -1,0 +1,26 @@
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+
+export type IExploreTabName = 'market' | 'earn' | 'browser';
+
+const UNIVERSAL_SEARCH_TAB_ROUTE_MAP: Record<IExploreTabName, ETabRoutes> = {
+  market: ETabRoutes.Market,
+  earn: ETabRoutes.Earn,
+  browser: ETabRoutes.Discovery,
+};
+
+export function getExploreTabName(tab: ETranslations): IExploreTabName {
+  if (tab === ETranslations.global_market) {
+    return 'market';
+  }
+  if (tab === ETranslations.global_earn) {
+    return 'earn';
+  }
+  return 'browser';
+}
+
+export function getExploreUniversalSearchTabRoute(
+  tab: ETranslations,
+): ETabRoutes {
+  return UNIVERSAL_SEARCH_TAB_ROUTE_MAP[getExploreTabName(tab)];
+}

--- a/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContent.tsx
+++ b/packages/kit/src/views/Discovery/pages/Dashboard/DashboardContent.tsx
@@ -125,7 +125,7 @@ function DashboardContent({
           banner={
             hasActiveBanners ? (
               <View
-                style={{ width: '100%' }}
+                style={{ width: '100%', alignItems: 'center' }}
                 onTouchStart={(e) => e.stopPropagation()}
                 onTouchMove={(e) => e.stopPropagation()}
                 onTouchEnd={(e) => e.stopPropagation()}

--- a/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
+++ b/packages/kit/src/views/Discovery/pages/MobileTabListModal/index.tsx
@@ -38,7 +38,6 @@ import {
   EModalRoutes,
   ETabRoutes,
 } from '@onekeyhq/shared/src/routes';
-import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 
 import MobileTabListItem from '../../components/MobileTabListItem';
 import MobileTabListPinnedItem from '../../components/MobileTabListItem/MobileTabListPinnedItem';
@@ -146,7 +145,6 @@ function MobileTabListModal() {
     platformEnv.isNativeIOSPad && shouldUseSplitView && isLandscape;
 
   const revealTabletBrowser = useCallback(async () => {
-    await timerUtils.wait(100);
     await switchTabAsync(ETabRoutes.Discovery);
     appEventBus.emit(EAppEventBusNames.SwitchDiscoveryTabInNative, {
       tab: ETranslations.global_browser,
@@ -387,9 +385,10 @@ function MobileTabListModal() {
         onSelectedItem={(id) => {
           void setCurrentWebTab(id);
           setDisplayHomePage(false);
-          navigation.pop();
           if (shouldRevealTabletBrowser) {
             void revealTabletBrowser();
+          } else {
+            navigation.pop();
           }
         }}
         onCloseItem={handleCloseTab}
@@ -418,9 +417,10 @@ function MobileTabListModal() {
         onSelectedItem={(id) => {
           setCurrentWebTab(id);
           setDisplayHomePage(false);
-          navigation.pop();
           if (shouldRevealTabletBrowser) {
             void revealTabletBrowser();
+          } else {
+            navigation.pop();
           }
         }}
         onCloseItem={handleCloseTab}

--- a/packages/kit/src/views/Earn/EarnHome.tsx
+++ b/packages/kit/src/views/Earn/EarnHome.tsx
@@ -18,6 +18,7 @@ import {
 } from '@onekeyhq/shared/src/routes';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
+import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
 import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
 import { EEarnLabels } from '@onekeyhq/shared/types/staking';
 
@@ -218,32 +219,29 @@ function BasicEarnHome({
       EAvailableAssetsTypeEnum.Staking,
     ] as const;
 
-    const results = await Promise.all(
+    await Promise.all(
       types.map(async (type) => {
         actions.current.setLoadingState(`availableAssets-${type}`, true);
+        let assets: IEarnAvailableAsset[] = [];
         try {
-          const assets =
-            await backgroundApiProxy.serviceStaking.getAvailableAssets({
-              type,
-            });
-          return {
+          assets = await backgroundApiProxy.serviceStaking.getAvailableAssets({
             type,
-            assets,
-          };
+          });
         } catch {
-          return {
-            type,
-            assets: [],
-          };
-        } finally {
-          actions.current.setLoadingState(`availableAssets-${type}`, false);
+          assets = [];
         }
+        // Store before clearing the flag, and per type rather than after
+        // Promise.all: AvailableAssetsFlatList only shows its skeleton while
+        // `loading && assets.length === 0` and otherwise renders nothing for an
+        // empty section, so clearing the flag first left every section that had
+        // already resolved blank until the slowest sibling landed — the home
+        // looked like it dropped its sections and popped them back in
+        // (PR 12791 review). Releasing each type as it arrives also lets a fast
+        // section paint without waiting on the others.
+        actions.current.updateAvailableAssetsByType(type, assets);
+        actions.current.setLoadingState(`availableAssets-${type}`, false);
       }),
     );
-
-    results.forEach(({ type, assets }) => {
-      actions.current.updateAvailableAssetsByType(type, assets);
-    });
   }, [actions]);
 
   const refreshEarnData = useCallback(

--- a/packages/kit/src/views/Earn/components/AvailableAssetsFlatList.tsx
+++ b/packages/kit/src/views/Earn/components/AvailableAssetsFlatList.tsx
@@ -25,23 +25,29 @@ import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
 import { EarnNavigation } from '../earnUtils';
 import { useNavigateToEarnAsset } from '../hooks/useNavigateToEarnAsset';
 import { EarnTestIDs } from '../testIDs';
+import { mergeSimpleEarnWithStakingAssets } from '../utils/availableAssetsUtils';
 
 import { AprText } from './AprText';
 import { buildEarnHomeFlatSections } from './earnCategoryTabs';
+import { EARN_LIST_ROW_GAP, EARN_SECTION_GAP } from './earnListRhythm';
 
 const MAX_INLINE_ASSETS = 4;
 function AvailableAssetsSectionSkeleton() {
   return (
+    // Heading-to-rows and row-to-row use the same two gaps as the loaded
+    // section, so the skeleton swap does not shift the list (OK-59904)
     <YStack gap="$3">
       <Skeleton width={120} height={28} borderRadius="$2" />
-      {Array.from({ length: 3 }).map((_, index) => (
-        <XStack key={index} px="$1" py="$2" ai="center" gap="$3">
-          <Skeleton width="$8" height="$8" radius="round" />
-          <Skeleton width={64} height={24} borderRadius="$2" />
-          <YStack flex={1} />
-          <Skeleton width={88} height={24} borderRadius="$2" />
-        </XStack>
-      ))}
+      <YStack gap={EARN_LIST_ROW_GAP}>
+        {Array.from({ length: 3 }).map((_, index) => (
+          <XStack key={index} px="$1" py="$2" ai="center" gap="$3">
+            <Skeleton width="$8" height="$8" radius="round" />
+            <Skeleton width={64} height={24} borderRadius="$2" />
+            <YStack flex={1} />
+            <Skeleton width={88} height={24} borderRadius="$2" />
+          </XStack>
+        ))}
+      </YStack>
     </YStack>
   );
 }
@@ -101,7 +107,10 @@ export function AvailableAssetItem({
         }
       />
       {/* Fixed rate: right side uses APY/APR as title and Liquidity as subtitle (OK-58879) */}
-      <YStack flex={1} ai="flex-end" jc="center" gap="$0.5">
+      {/* No flex here (OK-59904): ListItem.Text above already claims flex={1},
+          so a second flex={1} splits the row in half and wraps long APR ranges
+          such as "14.33% - 17.38% APR". The column sizes to its content. */}
+      <YStack ai="flex-end" jc="center" gap="$0.5">
         <AprText asset={asset} />
         {showLiquidity ? (
           <SizableText size="$bodySm" color="$textSubdued" numberOfLines={1}>
@@ -141,29 +150,22 @@ function AvailableAssetsFlatListComponent() {
   // having their own section (OK-58506). De-dup by symbol: for a duplicated
   // symbol the SimpleEarn list wins.
   const sectionAssetsByType = useMemo(() => {
-    const simpleEarnAssets =
-      availableAssetsByType[EAvailableAssetsTypeEnum.SimpleEarn] ?? [];
-    const stakingAssets =
-      availableAssetsByType[EAvailableAssetsTypeEnum.Staking] ?? [];
-    const simpleEarnSymbols = new Set(
-      simpleEarnAssets.map((asset) => asset.symbol),
-    );
-    // Trending tokens exclude fixed rate (OK-58879): fixed-rate assets
-    // (PT-like, separate symbols) get their own section/page, so drop them
-    // from the merged Trending result
-    const fixedRateSymbols = new Set(
-      (availableAssetsByType[EAvailableAssetsTypeEnum.FixedRate] ?? []).map(
-        (asset) => asset.symbol,
-      ),
-    );
+    // Trending used to subtract every symbol present in the fixed-rate dataset
+    // (OK-58879), on the assumption that fixed rate uses distinct PT-only
+    // symbols. It does not: the server stores a Pendle protocol under its
+    // *underlying* asset symbol (the PT symbol lives in vaultName), so that
+    // subtraction dropped tokens like USDe from Trending even though their
+    // simple-earn / staking offering still exists. Same defect OK-59338 fixed
+    // on the Tokens page; keeping it here also made the home section show
+    // strictly less than the page it links to (PR 12791 review P2).
+    // A dual-product symbol legitimately appears in both sections — they link
+    // to different pages and show different yields.
     const merged: typeof availableAssetsByType = {
       ...availableAssetsByType,
-      [EAvailableAssetsTypeEnum.SimpleEarn]: [
-        ...simpleEarnAssets,
-        ...stakingAssets.filter(
-          (asset) => !simpleEarnSymbols.has(asset.symbol),
-        ),
-      ].filter((asset) => !fixedRateSymbols.has(asset.symbol)),
+      [EAvailableAssetsTypeEnum.SimpleEarn]: mergeSimpleEarnWithStakingAssets(
+        availableAssetsByType[EAvailableAssetsTypeEnum.SimpleEarn] ?? [],
+        availableAssetsByType[EAvailableAssetsTypeEnum.Staking] ?? [],
+      ),
     };
     return merged;
   }, [availableAssetsByType]);
@@ -196,7 +198,9 @@ function AvailableAssetsFlatListComponent() {
   );
 
   return (
-    <YStack gap="$8">
+    // Same gap as the home section container so trending / fixed rate keep the
+    // rhythm of their siblings (OK-59904)
+    <YStack gap={EARN_SECTION_GAP}>
       {sections.map(({ type, title }) => {
         const assets = sectionAssetsByType[type] ?? [];
         const isLoading =
@@ -240,7 +244,7 @@ function AvailableAssetsFlatListComponent() {
                 pointerEvents="none"
               />
             </XStack>
-            <YStack>
+            <YStack gap={EARN_LIST_ROW_GAP}>
               {assets.slice(0, MAX_INLINE_ASSETS).map((asset) => (
                 <AvailableAssetItem
                   key={`${type}-${asset.symbol}`}

--- a/packages/kit/src/views/Earn/components/AvailableAssetsTabViewList.tsx
+++ b/packages/kit/src/views/Earn/components/AvailableAssetsTabViewList.tsx
@@ -408,7 +408,10 @@ export function AvailableAssetsTabViewList({
               ) : undefined
             }
           />
-          <XStack flex={1} ai="center" jc="flex-end">
+          {/* No flex here (OK-59904): ListItem.Text above already claims
+              flex={1}, so a second flex={1} splits the row in half and wraps
+              long APR ranges such as "14.33% - 17.38% APR". */}
+          <XStack ai="center" jc="flex-end">
             <AprText asset={asset} />
           </XStack>
         </ListItem>

--- a/packages/kit/src/views/Earn/components/EarnHomeShortcuts.tsx
+++ b/packages/kit/src/views/Earn/components/EarnHomeShortcuts.tsx
@@ -21,7 +21,12 @@ function EarnHomeShortcut({
     <YStack
       testID={testID}
       role={onPress ? 'button' : undefined}
-      w={73.667}
+      // OK-60104: the tile used to be pinned to the design's 73.667pt, which
+      // only ever fit the English labels — the Portuguese "Loans" needs ~82pt
+      // and was cut off mid-word with an ellipsis. Splitting the row into
+      // thirds gives each label ~117pt without touching the type scale, and the
+      // labels stay centered on their own third.
+      flex={1}
       gap="$1"
       ai="center"
       jc="center"

--- a/packages/kit/src/views/Earn/components/EarnLazyPageFallback.tsx
+++ b/packages/kit/src/views/Earn/components/EarnLazyPageFallback.tsx
@@ -1,0 +1,40 @@
+import { Page, Spinner, Stack } from '@onekeyhq/components';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+/**
+ * Suspense fallback for the lazily loaded Earn push pages (OK-59841).
+ *
+ * Those routes are registered with `headerShown: !platformEnv.isNative`, and
+ * the nav bar is turned on by the page itself — `EarnPageContainer` renders
+ * `<Page.Header headerShown />` on iOS 26. While the split-bundle segment is
+ * still resolving, the screen therefore has no header at all, and the
+ * `setOptions({ headerShown: true })` that follows lands after the push has
+ * already presented the screen. react-native-screens then calls
+ * `setNavigationBarHidden:NO animated:YES` (RNSScreenStackHeaderConfig.mm,
+ * always animated), whose UIKit animation slides the bar in from above — the
+ * "header falls from the top" QA reported on the first open of every DeFi page.
+ *
+ * Declaring the header here makes the bar part of the push from the first
+ * frame; the real page then only updates the title, which is not a
+ * visibility toggle and so is not animated.
+ *
+ * Gated to iOS 26+: on other native versions `EarnPageContainer` renders
+ * `TabPageHeader` inside the body instead, and a native bar shown here would
+ * have to be hidden again — the same toggle, in the other direction.
+ */
+export function EarnLazyPageFallback() {
+  return (
+    <Page>
+      {platformEnv.isNativeIOS26Plus ? <Page.Header headerShown /> : null}
+      <Page.Body>
+        <Stack flex={1} alignItems="center" justifyContent="center">
+          <Spinner size="large" />
+        </Stack>
+      </Page.Body>
+    </Page>
+  );
+}
+
+// The routers are plain .ts modules and cannot spell JSX, so the element is
+// built here and shared by every Earn route that needs it.
+export const earnLazyPageFallback = <EarnLazyPageFallback />;

--- a/packages/kit/src/views/Earn/components/EarnListEmptyState.tsx
+++ b/packages/kit/src/views/Earn/components/EarnListEmptyState.tsx
@@ -1,0 +1,37 @@
+import { useIntl } from 'react-intl';
+
+import { Empty } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+
+/**
+ * The Earn list pages rendered `null` once loading finished, so a search or
+ * network filter that matched nothing left a blank page.
+ *
+ * The two empty states are deliberately different. A filtered miss is the
+ * user's own query coming back empty. An unfiltered miss means the data itself
+ * is absent — telling the user "no search results" there would misread an
+ * outage or an empty category as something they typed.
+ */
+export function EarnListEmptyState({ isFiltered }: { isFiltered: boolean }) {
+  const intl = useIntl();
+
+  if (isFiltered) {
+    return (
+      <Empty
+        px="$pagePadding"
+        icon="SearchOutline"
+        title={intl.formatMessage({
+          id: ETranslations.global_search_no_results_title,
+        })}
+      />
+    );
+  }
+
+  return (
+    <Empty
+      px="$pagePadding"
+      icon="PlaceholderOutline"
+      title={intl.formatMessage({ id: ETranslations.global_no_data })}
+    />
+  );
+}

--- a/packages/kit/src/views/Earn/components/EarnMobileHomeContent.tsx
+++ b/packages/kit/src/views/Earn/components/EarnMobileHomeContent.tsx
@@ -16,6 +16,7 @@ import type { IEarnPageBannerListItem } from '@onekeyhq/shared/types/earn';
 import { AvailableAssetsFlatList } from './AvailableAssetsFlatList';
 import { EarnHomeBanner } from './EarnHomeBanner';
 import { EarnHomeShortcuts } from './EarnHomeShortcuts';
+import { EARN_SECTION_GAP } from './earnListRhythm';
 import { FAQContent } from './FAQContent';
 import { Overview } from './Overview';
 import { Recommended } from './Recommended';
@@ -75,9 +76,22 @@ function EarnMobileHomeContentComponent({
         <RefreshControl refreshing={isPullRefreshing} onRefresh={onRefresh} />
       }
     >
-      <HeaderScrollGestureWrapper onHorizontalSwipe={onHeaderHorizontalSwipe}>
-        <YStack pt={24} bg="$bgApp" pointerEvents="box-none">
-          <YStack px="$pagePadding" pb={26}>
+      {/* disableVerticalScroll is required here (OK-59963): this wrapper drives
+          scrolling through CollapsibleTabContext, but the Earn home is a plain
+          ScrollView with no Tabs.Container above it, so the context is
+          undefined and the vertical pan swallows the drag (cancelsTouchesInView)
+          without scrolling anything — the whole header block, banner included,
+          became unscrollable. Only the horizontal tab-switch swipe is wanted
+          here; its failOffsetY lets vertical drags fall through to the
+          ScrollView. */}
+      <HeaderScrollGestureWrapper
+        onHorizontalSwipe={onHeaderHorizontalSwipe}
+        disableVerticalScroll
+      >
+        {/* Token spacing, not raw numbers: narrow Android screens scale the
+            token scale by 0.9 and a literal would not follow (OK-59904) */}
+        <YStack pt="$6" bg="$bgApp" pointerEvents="box-none">
+          <YStack px="$pagePadding" pb="$6">
             <Overview
               onRefresh={onRefresh}
               isLoading={isRefreshing}
@@ -95,7 +109,10 @@ function EarnMobileHomeContentComponent({
         </YStack>
       </HeaderScrollGestureWrapper>
 
-      <YStack gap="$8">
+      {/* AvailableAssetsFlatList contributes two more sections of its own and
+          must keep the same gap, otherwise trending/fixed-rate sit tighter
+          than their siblings (OK-59904) */}
+      <YStack gap={EARN_SECTION_GAP}>
         <Recommended isActive={isActive} />
         <AvailableAssetsFlatList />
         <YStack px="$pagePadding" gap="$2">

--- a/packages/kit/src/views/Earn/components/EarnPageContainer.tsx
+++ b/packages/kit/src/views/Earn/components/EarnPageContainer.tsx
@@ -1,6 +1,7 @@
 import { Fragment, isValidElement, useCallback, useMemo } from 'react';
 
 import { useHeaderHeight } from '@react-navigation/elements';
+import { useWindowDimensions } from 'react-native';
 
 import type { IBreadcrumbProps, IScrollViewProps } from '@onekeyhq/components';
 import {
@@ -20,9 +21,20 @@ import type { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import type { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import { LegacyUniversalSearchInput } from '../../../components/TabPageHeader/LegacyUniversalSearchInput';
+import { useSettledHeaderHeight } from '../hooks/useSettledHeaderHeight';
 import { EarnTestIDs } from '../testIDs';
 
 import type { RefreshControlProps } from 'react-native';
+
+// Leading back button and trailing action button each occupy roughly a 44pt
+// glass control plus its margins; reserving both keeps the centred title clear
+// of them on every device width.
+const NATIVE_HEADER_BUTTON_ZONE = 64;
+// Reserving only the buttons let a truncated title stop exactly at the trailing
+// button's edge, so the ellipsis sat flush against the share icon. Keep a
+// visible gap between the two.
+const NATIVE_HEADER_TITLE_GAP = 16;
+const NATIVE_HEADER_TITLE_MIN_WIDTH = 120;
 
 interface IEarnPageContainerProps {
   pageTitle?: React.ReactNode;
@@ -71,6 +83,7 @@ export function EarnPageContainer({
   bodyListMode = false,
 }: IEarnPageContainerProps) {
   const media = useMedia();
+  const { width: windowWidth } = useWindowDimensions();
   const navigation = useAppNavigation();
   const { top: safeAreaTop } = useSafeAreaInsets();
 
@@ -80,21 +93,39 @@ export function EarnPageContainer({
 
   const shouldCenterTitle = centerPageTitle && !!pageTitle;
 
+  // TabPageHeader lays its left group out in a plain <View> with no flex and no
+  // minWidth (MDHeader), and React Native defaults flexShrink to 0, so the
+  // group sizes to its content and never yields — a long page title runs
+  // straight into the trailing actions. Bound the group here instead of
+  // touching the shared header, which every mobile tab depends on. Only the
+  // trailing actions have to be cleared; the back button lives inside this
+  // group and is already accounted for by its own width.
+  const headerLeftMaxWidth = Math.max(
+    windowWidth - NATIVE_HEADER_BUTTON_ZONE - NATIVE_HEADER_TITLE_GAP * 2,
+    NATIVE_HEADER_TITLE_MIN_WIDTH,
+  );
+
   const customHeaderLeft = useMemo(() => {
     if (showBackButton) {
       return (
-        <XStack gap="$3" ai="center">
+        <XStack gap="$3" ai="center" maxWidth={headerLeftMaxWidth} minWidth={0}>
           <NavBackButton onPress={handleBack} />
           {shouldCenterTitle ? null : pageTitle}
         </XStack>
       );
     }
     return pageTitle ? (
-      <XStack gap="$3" ai="center">
+      <XStack gap="$3" ai="center" maxWidth={headerLeftMaxWidth} minWidth={0}>
         {pageTitle}
       </XStack>
     ) : null;
-  }, [pageTitle, showBackButton, handleBack, shouldCenterTitle]);
+  }, [
+    pageTitle,
+    showBackButton,
+    handleBack,
+    shouldCenterTitle,
+    headerLeftMaxWidth,
+  ]);
 
   const showBreadcrumb = useMemo(
     () => breadcrumbProps && media.gtSm,
@@ -117,16 +148,42 @@ export function EarnPageContainer({
   // under it, so the ScrollView needs a top inset equal to the bar
   // height — without it, the first content item sits clipped behind
   // the navbar at scroll offset 0.
-  const nativeHeaderHeight = useHeaderHeight();
+  const headerHeight = useHeaderHeight();
+  // OK-59841: useHeaderHeight() reports react-navigation's synchronous estimate
+  // (97.67 on a Dynamic Island device) before the native measurement (113)
+  // lands, so a body laid out against the raw value drops by 15.33pt a beat
+  // later — the whole-page jump QA sees when re-entering a pushed Earn page.
+  // Same gate EarnPositions already uses; the settled height is remembered per
+  // device, so only the first push of a session is ever held.
+  const { paddingTop: nativeHeaderHeight, isSettled: isHeaderHeightSettled } =
+    useSettledHeaderHeight(headerHeight, { enabled: useNativeHeader });
+
+  // This element becomes UIKit's custom titleView, and a titleView
+  // inherits no width constraint from the bar. Without an explicit bound the
+  // title lays out at its intrinsic width, so a long one (e.g. the vault symbol
+  // "Morpho-cbBTC-USDC-wrapper") runs underneath the trailing bar button
+  // instead of truncating — callers' numberOfLines/flexShrink have nothing to
+  // shrink against. Reserve the leading and trailing button zones (a ~44pt
+  // glass button plus its margins on each side) and let the title ellipsize
+  // inside what is left.
+  const nativeHeaderTitleMaxWidth = Math.max(
+    windowWidth - NATIVE_HEADER_BUTTON_ZONE * 2 - NATIVE_HEADER_TITLE_GAP * 2,
+    NATIVE_HEADER_TITLE_MIN_WIDTH,
+  );
 
   const renderNativeHeaderTitle = useCallback(
     () =>
       pageTitle ? (
-        <XStack gap="$2" ai="center">
+        <XStack
+          gap="$2"
+          ai="center"
+          maxWidth={nativeHeaderTitleMaxWidth}
+          minWidth={0}
+        >
           {pageTitle}
         </XStack>
       ) : null,
-    [pageTitle],
+    [pageTitle, nativeHeaderTitleMaxWidth],
   );
 
   // Callers (e.g. EarnProtocols) pass <></> on native to mean "hide the
@@ -157,12 +214,17 @@ export function EarnPageContainer({
     [hasNativeHeaderRight, customHeaderRightItems],
   );
 
+  // Hidden only while the very first header measurement of the app session is
+  // still moving (see useSettledHeaderHeight); off-target platforms and every
+  // later mount are settled from the first render and never hide.
+  const bodyOpacity = isHeaderHeightSettled ? 1 : 0;
+
   // List mode: children (a virtualized list) own the scrolling. The iOS 26
   // translucent native header inset becomes top padding here — the list is
   // clipped at the bar's bottom edge instead of scrolling under the glass,
   // which is visually equivalent since nothing scrolls behind it.
   const body = bodyListMode ? (
-    <Page.Body>
+    <Page.Body opacity={bodyOpacity}>
       <Page.Container
         testID={EarnTestIDs.earnPage}
         padded={false}
@@ -174,7 +236,7 @@ export function EarnPageContainer({
       </Page.Container>
     </Page.Body>
   ) : (
-    <Page.Body>
+    <Page.Body opacity={bodyOpacity}>
       <ScrollView
         testID={EarnTestIDs.earnPage}
         contentContainerStyle={{

--- a/packages/kit/src/views/Earn/components/EarnPageContainer.tsx
+++ b/packages/kit/src/views/Earn/components/EarnPageContainer.tsx
@@ -258,7 +258,11 @@ export function EarnPageContainer({
       ) : (
         <YStack mx="$pagePadding" mt="$2" mb="$1">
           <Page.Header headerShown={false} />
-          <LegacyUniversalSearchInput size="medium" initialTab="dapp" />
+          <LegacyUniversalSearchInput
+            size="medium"
+            initialTab="dapp"
+            tabRoute={tabRoute}
+          />
         </YStack>
       )}
       {body}

--- a/packages/kit/src/views/Earn/components/NetworkFilterControl.tsx
+++ b/packages/kit/src/views/Earn/components/NetworkFilterControl.tsx
@@ -85,8 +85,12 @@ function NetworkFilterControl({
         <NetworkAvatar networkId={singleSelectedNetworkId} size="$4" />
       );
     } else {
+      // OK-59960: the app-wide all-networks glyph is AllNetworksSolid (same as
+      // NetworkAvatarBase / NetworksFilterItem). The generic globe icon is the
+      // fallback drawn when a network logo fails to load, so using it here read
+      // as a different, inconsistent icon.
       compactLeadingIcon = (
-        <Icon name="GlobusOutline" size="$4" color="$iconSubdued" />
+        <Icon name="AllNetworksSolid" size="$4" color="$iconActive" />
       );
     }
   }
@@ -181,7 +185,8 @@ function NetworkFilterControl({
                 containerProps={{ py: '$0', flexShrink: 0 }}
                 shouldStopPropagation
               />
-              <Icon name="GlobusOutline" size="$5" color="$iconSubdued" />
+              {/* Same all-networks glyph as the trigger above (OK-59960) */}
+              <Icon name="AllNetworksSolid" size="$5" color="$iconActive" />
               <SizableText size="$bodyLgMedium" flex={1}>
                 {intl.formatMessage({
                   id: ETranslations.global_all_networks,

--- a/packages/kit/src/views/Earn/components/Recommended.tsx
+++ b/packages/kit/src/views/Earn/components/Recommended.tsx
@@ -48,6 +48,7 @@ function useRecommendedTokens({
   accountId,
   indexedAccountId,
   enableFetch,
+  refreshTrigger,
   cachedRecommendedTokens,
   onBaseRecommendedTokensLoaded,
 }: {
@@ -55,6 +56,13 @@ function useRecommendedTokens({
   accountId?: string;
   indexedAccountId?: string;
   enableFetch: boolean;
+  /**
+   * Bumped by explicit Earn refreshes (pull-to-refresh, pending-tx settlement).
+   * Part of the fetch key so those refreshes bypass the focus-revalidation
+   * window below — the rows carry account balances, which move exactly when
+   * those refreshes fire (PR 12791 review P2).
+   */
+  refreshTrigger: number;
   cachedRecommendedTokens: IRecommendAsset[];
   onBaseRecommendedTokensLoaded: (tokens: IRecommendAsset[]) => void;
 }) {
@@ -68,8 +76,12 @@ function useRecommendedTokens({
     }
 
     // OK-59247: reuse the last result for focus-driven revalidation within
-    // the window; account/network changes use a different key and bypass it
-    const fetchKey = `${networkId}|${accountId ?? ''}|${indexedAccountId ?? ''}`;
+    // the window; account/network changes use a different key and bypass it.
+    // refreshTrigger is in the key too so an explicit Earn refresh always
+    // re-fetches the balances (PR 12791 review P2).
+    const fetchKey = `${networkId}|${accountId ?? ''}|${
+      indexedAccountId ?? ''
+    }|${refreshTrigger}`;
     const last = lastFetchRef.current;
     if (
       last &&
@@ -95,7 +107,7 @@ function useRecommendedTokens({
       tokens,
       networkId,
     };
-  }, [enableFetch, networkId, accountId, indexedAccountId]);
+  }, [enableFetch, networkId, accountId, indexedAccountId, refreshTrigger]);
 
   const {
     result: baseRecommendedResult = { tokens: [], networkId: '' },
@@ -166,7 +178,9 @@ export function Recommended(
   const allNetworkId = getNetworkIdsMap().onekeyall;
   const { activeAccount } = useActiveAccount({ num: 0 });
   const actions = useEarnActions();
-  const [{ recommendedTokens: cachedRecommendedTokens = [] }] = useEarnAtom();
+  const [
+    { recommendedTokens: cachedRecommendedTokens = [], refreshTrigger = 0 },
+  ] = useEarnAtom();
 
   const handleBaseRecommendedTokensLoaded = useCallback(
     (tokens: IRecommendAsset[]) => {
@@ -188,11 +202,22 @@ export function Recommended(
       accountId: activeAccount?.account?.id,
       indexedAccountId: activeAccount?.indexedAccount?.id,
       enableFetch: shouldFetch,
+      refreshTrigger,
       cachedRecommendedTokens,
       onBaseRecommendedTokensLoaded: handleBaseRecommendedTokensLoaded,
     });
 
-  const recommendedLoadScopeKey = allNetworkId;
+  // The request is already scoped by account (see useRecommendedTokens'
+  // fetchKey), but this gate was not: keyed on the network alone, switching
+  // accounts left `hasCompletedInitialRecommendedLoadRef` matching, so no
+  // skeleton was shown while usePromiseResult kept serving the previous
+  // account's result — account B briefly read account A's balances. Scope the
+  // gate the same way the request is scoped.
+  const recommendedLoadScopeKey = [
+    allNetworkId,
+    activeAccount?.account?.id ?? '',
+    activeAccount?.indexedAccount?.id ?? '',
+  ].join('|');
   const hasCompletedInitialRecommendedLoadRef = useRef<string | undefined>(
     undefined,
   );

--- a/packages/kit/src/views/Earn/components/RecommendedSection.tsx
+++ b/packages/kit/src/views/Earn/components/RecommendedSection.tsx
@@ -41,6 +41,7 @@ import {
 } from '../utils/recommendedAssetsUtils';
 
 import { AprText } from './AprText';
+import { EARN_LIST_ROW_GAP } from './earnListRhythm';
 
 const CARD_WIDTH = 240;
 const CARD_GAP = 12;
@@ -232,7 +233,17 @@ RecommendedItem.displayName = 'RecommendedItem';
 
 // Extract the number from the server-side available.text (a localized label
 // followed by the amount, e.g. "Active 220.09") and build "Balance {number}"
-// on the client, so we do not depend on the server copy format (OK-58877)
+// on the client, so we do not depend on the server copy format (OK-58877).
+//
+// This scrape rests on an invariant the server currently guarantees: the
+// amount is produced by formatNumberWithFlag, which hard-codes '.' as the
+// decimal separator and ',' as the group separator, so the digits are always
+// ASCII regardless of locale — only the surrounding label is translated, and
+// no locale pack embeds a digit in that label. If the server ever switches to
+// locale-aware number formatting (comma decimals, non-Latin digits), this
+// silently truncates or blanks the balance. The durable fix is a structured
+// numeric field on IRecommendV2Token rather than parsing display copy
+// (PR 12791 review P2).
 const AVAILABLE_NUMBER_PATTERN = /\d[\d,]*(?:\.\d+)?/;
 function extractAvailableNumber(text?: string) {
   return text?.match(AVAILABLE_NUMBER_PATTERN)?.[0];
@@ -614,7 +625,7 @@ function RecommendedSectionSkeleton({
         variant={variant}
         disableHorizontalBleed={disableHorizontalBleed}
       >
-        <YStack>
+        <YStack gap={EARN_LIST_ROW_GAP}>
           {Array.from({
             length: EARN_MOBILE_RECOMMENDED_ASSET_COUNT,
           }).map((_, index) => (
@@ -705,9 +716,13 @@ export function RecommendedSection({
         disableHorizontalBleed={disableHorizontalBleed}
       >
         <YStack>
-          {visibleTokens.map((token) => (
-            <RecommendedListItem key={token.symbol} token={token} />
-          ))}
+          {/* The gap wraps the rows only — the show-more button keeps its own
+              pt, so pulling it inside would stack gap + pt above it (OK-59904) */}
+          <YStack gap={EARN_LIST_ROW_GAP}>
+            {visibleTokens.map((token) => (
+              <RecommendedListItem key={token.symbol} token={token} />
+            ))}
+          </YStack>
           {showMoreButton}
         </YStack>
       </RecommendedSectionContainer>

--- a/packages/kit/src/views/Earn/components/earnListRhythm.tsx
+++ b/packages/kit/src/views/Earn/components/earnListRhythm.tsx
@@ -1,0 +1,40 @@
+import { Stack } from '@onekeyhq/components';
+
+/**
+ * Shared vertical rhythm for the mobile Earn surfaces (OK-59904).
+ *
+ * The home and its list pages used a flush ListItem cadence that read as
+ * cramped. One scale, three levels:
+ *
+ *   section -> section   $10 (40)  home sections: recommended / trending /
+ *                                  fixed rate / FAQ
+ *   heading -> rows      $3  (12)  unchanged
+ *   row -> row           $2  (8)   was flush
+ *
+ * Everything is expressed as space/size tokens rather than raw numbers: narrow
+ * Android screens apply a 0.9 uiScale inside the token scale (see
+ * packages/components/src/utils/scale.ts), so a raw number would keep its
+ * unscaled value and drift out of alignment with its neighbors.
+ *
+ * Skeletons must consume the same constants as the real rows — a skeleton with
+ * its own spacing makes the list shift when the loading state swaps to content.
+ */
+export const EARN_LIST_ROW_GAP = '$2' as const;
+
+export const EARN_SECTION_GAP = '$10' as const;
+
+/**
+ * ListItem's own metrics (minHeight $11 + py $2) put a populated row at ~60;
+ * the separator adds the row gap on top. Only a virtualization hint — FlashList
+ * measures for real — but keeping it honest avoids scroll-extent jumps.
+ */
+export const EARN_LIST_ESTIMATED_ITEM_SIZE = 68;
+
+/**
+ * Row separator for the virtualized Earn list pages. A separator rather than a
+ * per-row margin so the last row does not leave a dangling gap above the tab
+ * bar padding.
+ */
+export function EarnListRowSeparator() {
+  return <Stack h={EARN_LIST_ROW_GAP} />;
+}

--- a/packages/kit/src/views/Earn/components/showProtocolListDialog.tsx
+++ b/packages/kit/src/views/Earn/components/showProtocolListDialog.tsx
@@ -32,6 +32,8 @@ import {
 } from '../../Staking/components/ProtocolDisplayShared';
 
 import { AprText } from './AprText';
+import { EarnAprSuffixText } from './EarnAprSuffixText';
+import { getProtocolAprColor } from './showProtocolListDialog.utils';
 
 import type { IntlShape } from 'react-intl';
 
@@ -159,6 +161,19 @@ const groupProtocolsByGroup = (
   });
 
   return sections;
+};
+
+// Keep the APY/APR suffix; EarnAprSuffixText splits it into "value + smaller
+// unit" rendering (OK-58854)
+const getProtocolAprText = (item: IStakeProtocolListItem) => {
+  return (
+    item.aprInfo?.highlight?.text ||
+    item.aprInfo?.normal?.text ||
+    item.aprInfo?.deprecated?.text ||
+    `${BigNumber(item.provider.aprWithoutFee || 0).toFixed(2)}% ${
+      item.provider.rewardUnit || 'APR'
+    }`
+  );
 };
 
 // Quick-switcher provider grouping (OK-58854): native is hidden; bitway is
@@ -397,6 +412,7 @@ export function ProtocolListContent({
         selectedProtocolKey !== undefined &&
         protocolKey === selectedProtocolKey;
       const tvlText = formatTvl(item.provider.tvl);
+      const aprColor = getProtocolAprColor(item.aprInfo);
       // TVL moved to the bottom-right; bottom-left keeps only vaultName (OK-58854)
       const secondaryText = item.provider.vaultName || '';
 
@@ -454,7 +470,10 @@ export function ProtocolListContent({
             ) : null}
           </YStack>
           <YStack alignItems="flex-end" gap="$0.5" flexShrink={0}>
-            <AprText asset={createAssetFromProtocol(item)} />
+            <EarnAprSuffixText
+              text={getProtocolAprText(item)}
+              color={aprColor}
+            />
             {tvlText ? (
               <SizableText size="$bodySm" color="$textSubdued">
                 {`TVL ${tvlText}`}

--- a/packages/kit/src/views/Earn/components/showProtocolListDialog.utils.test.ts
+++ b/packages/kit/src/views/Earn/components/showProtocolListDialog.utils.test.ts
@@ -1,4 +1,7 @@
-import { shouldShowProtocolListBalances } from './showProtocolListDialog.utils';
+import {
+  getProtocolAprColor,
+  shouldShowProtocolListBalances,
+} from './showProtocolListDialog.utils';
 
 function buildProtocol(networkId?: string) {
   return {
@@ -9,6 +12,46 @@ function buildProtocol(networkId?: string) {
 }
 
 describe('showProtocolListDialog utils', () => {
+  it('uses the server-provided normal APR color for bonus protocols', () => {
+    expect(
+      getProtocolAprColor({
+        normal: {
+          text: '22.61% APY',
+          color: '$textSuccess',
+        },
+      }),
+    ).toBe('$textSuccess');
+  });
+
+  it('keeps the APR style defaults when the server does not provide a color', () => {
+    expect(
+      getProtocolAprColor({
+        normal: {
+          text: '2.12% APY',
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('uses the same priority as the visible APR value', () => {
+    expect(
+      getProtocolAprColor({
+        highlight: {
+          text: '3.12% APY',
+          color: '$textSuccess',
+        },
+        normal: {
+          text: '2.61% APY',
+          color: '$textInfo',
+        },
+        deprecated: {
+          text: '2.12% APY',
+          color: '$textSubdued',
+        },
+      }),
+    ).toBe('$textSuccess');
+  });
+
   it('hides balances when all protocols are on the same network', () => {
     expect(
       shouldShowProtocolListBalances([

--- a/packages/kit/src/views/Earn/components/showProtocolListDialog.utils.ts
+++ b/packages/kit/src/views/Earn/components/showProtocolListDialog.utils.ts
@@ -1,3 +1,23 @@
+import type { IEarnAvailableAssetAprInfo } from '@onekeyhq/shared/types/earn';
+
+export function getProtocolAprColor(
+  aprInfo?: IEarnAvailableAssetAprInfo,
+): NonNullable<IEarnAvailableAssetAprInfo['normal']>['color'] | undefined {
+  if (aprInfo?.highlight?.text) {
+    return aprInfo.highlight.color;
+  }
+
+  if (aprInfo?.normal?.text) {
+    return aprInfo.normal.color;
+  }
+
+  if (aprInfo?.deprecated?.text) {
+    return aprInfo.deprecated.color;
+  }
+
+  return undefined;
+}
+
 export function shouldShowProtocolListBalances(
   protocols: Array<{ network?: { networkId?: string } }>,
 ) {

--- a/packages/kit/src/views/Earn/hooks/useNavigateToEarnAsset.ts
+++ b/packages/kit/src/views/Earn/hooks/useNavigateToEarnAsset.ts
@@ -1,14 +1,20 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
-import { prewarmTokenImages } from '@onekeyhq/kit/src/utils/tokenImagePrewarm';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import { waitAsync } from '@onekeyhq/shared/src/utils/promiseUtils';
 import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
 import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
 
 import { EarnNavigation } from '../earnUtils';
+
+// OK-59303: the protocol-count probe below only decides which route to open,
+// so it must never hold the tap hostage. Past this budget the asset's own
+// protocol list is authoritative enough to navigate on, and the request keeps
+// warming ServiceStaking's 5s memoize for the next tap.
+const PROTOCOL_COUNT_PROBE_TIMEOUT = 800;
 
 export function useNavigateToEarnAsset() {
   const navigation = useAppNavigation();
@@ -16,21 +22,21 @@ export function useNavigateToEarnAsset() {
   const accountId = activeAccount.account?.id;
   const accountReady = activeAccount.ready;
   const activeNetworkId = activeAccount.network?.id;
+  // A tap that is still resolving must not queue another navigation: repeated
+  // taps on an unresponsive row used to stack pushes that all landed at once.
+  const isNavigatingRef = useRef(false);
 
   return useCallback(
     async (
       asset: IEarnAvailableAsset,
       categoryType?: EAvailableAssetsTypeEnum,
     ) => {
-      defaultLogger.staking.page.selectAsset({ tokenSymbol: asset.symbol });
+      if (isNavigatingRef.current) {
+        return;
+      }
+      isNavigatingRef.current = true;
 
-      // OK-59304: the protocol list / detail page renders the same logo as the
-      // row that was just tapped. Warm it here — this is the single funnel for
-      // every earn asset list — so the destination does not start from a cold
-      // async image load and flash a placeholder. Fire-and-forget; the
-      // single-protocol branch below also awaits a request first, which gives
-      // the decode extra head start.
-      prewarmTokenImages({ tokenImageUri: asset.logoURI });
+      defaultLogger.staking.page.selectAsset({ tokenSymbol: asset.symbol });
 
       const defaultCategory =
         categoryType === EAvailableAssetsTypeEnum.SimpleEarn ||
@@ -48,44 +54,54 @@ export function useNavigateToEarnAsset() {
         });
       };
 
-      if (asset.protocols.length === 1) {
-        const accountNetworkId =
-          activeNetworkId ?? asset.protocols[0]?.networkId;
-        const canQueryWithAccount =
-          accountReady && Boolean(accountId) && Boolean(accountNetworkId);
-        if (!canQueryWithAccount) {
-          navigateToProtocolList();
-          return;
-        }
+      try {
+        if (asset.protocols.length === 1) {
+          const accountNetworkId =
+            activeNetworkId ?? asset.protocols[0]?.networkId;
+          const canQueryWithAccount =
+            accountReady && Boolean(accountId) && Boolean(accountNetworkId);
+          if (!canQueryWithAccount) {
+            navigateToProtocolList();
+            return;
+          }
 
-        let totalProtocols = 1;
-        try {
-          const allProtocols =
-            await backgroundApiProxy.serviceStaking.getProtocolList({
+          let totalProtocols = 1;
+          try {
+            const allProtocols = await Promise.race([
+              backgroundApiProxy.serviceStaking.getProtocolList({
+                symbol: asset.symbol,
+                accountId,
+                networkId: accountNetworkId,
+                includeWithdrawOnly: true,
+              }),
+              waitAsync(PROTOCOL_COUNT_PROBE_TIMEOUT).then(() => {
+                // Resolving to undefined keeps the asset's own protocol count
+                // instead of pretending the symbol has no protocol at all.
+                return undefined;
+              }),
+            ]);
+            totalProtocols = allProtocols?.length ?? 1;
+          } catch {
+            // Fall back to the protocol count already returned with the asset.
+          }
+
+          if (totalProtocols <= 1) {
+            const protocol = asset.protocols[0];
+            await EarnNavigation.pushToEarnProtocolDetails(navigation, {
+              networkId: protocol.networkId,
               symbol: asset.symbol,
-              accountId,
-              networkId: accountNetworkId,
-              includeWithdrawOnly: true,
+              provider: protocol.provider,
+              vault: protocol.vault,
+              logoURI: asset.logoURI,
             });
-          totalProtocols = allProtocols?.length ?? 1;
-        } catch {
-          // Fall back to the protocol count already returned with the asset.
+            return;
+          }
         }
 
-        if (totalProtocols <= 1) {
-          const protocol = asset.protocols[0];
-          await EarnNavigation.pushToEarnProtocolDetails(navigation, {
-            networkId: protocol.networkId,
-            symbol: asset.symbol,
-            provider: protocol.provider,
-            vault: protocol.vault,
-            logoURI: asset.logoURI,
-          });
-          return;
-        }
+        navigateToProtocolList();
+      } finally {
+        isNavigatingRef.current = false;
       }
-
-      navigateToProtocolList();
     },
     [accountId, accountReady, activeNetworkId, navigation],
   );

--- a/packages/kit/src/views/Earn/hooks/usePortfolioAction.ts
+++ b/packages/kit/src/views/Earn/hooks/usePortfolioAction.ts
@@ -134,6 +134,9 @@ export const usePortfolioAction = ({
           protocolInfo: {
             symbol,
             provider,
+            // IProtocolInfo.vault is a required string, so a provider with no
+            // vault (Stakefish) still travels as ''. ServiceStaking drops that
+            // empty string before it reaches the backend — see getClaimableList.
             vault: vault || '',
             networkId,
             stakeTag: stakeTag || '',

--- a/packages/kit/src/views/Earn/hooks/useSettledHeaderHeight.test.ts
+++ b/packages/kit/src/views/Earn/hooks/useSettledHeaderHeight.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react';
+
+import {
+  resetDeviceSettledHeaderHeightForTest,
+  useSettledHeaderHeight,
+} from './useSettledHeaderHeight';
+
+// OK-59958 / PR 12791 review P2. Two competing failures are covered here:
+//   - revealing the body before the height is final lets paddingTop move under
+//     visible content, which is the vertical jump this hook exists to remove;
+//   - holding the body for as long as the height keeps moving blanked the page
+//     for ~1s on a real device, so the hold is bounded and re-entry never waits.
+
+const SETTLE_MS = 64;
+const MAX_HOLD_MS = 250;
+const opts = {
+  enabled: true,
+  settleMs: SETTLE_MS,
+  maxHoldMs: MAX_HOLD_MS,
+};
+
+describe('useSettledHeaderHeight', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    resetDeviceSettledHeaderHeightForTest();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('holds until the height has been quiet for the settle window', () => {
+    const { result } = renderHook(() => useSettledHeaderHeight(97.67, opts));
+
+    expect(result.current.isSettled).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(SETTLE_MS - 1);
+    });
+    expect(result.current.isSettled).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current.isSettled).toBe(true);
+    expect(result.current.paddingTop).toBe(97.67);
+  });
+
+  it('re-arms while the height is still moving, then reports the final value', () => {
+    const { result, rerender } = renderHook(
+      ({ height }) => useSettledHeaderHeight(height, opts),
+      { initialProps: { height: 97.67 } },
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(SETTLE_MS - 10);
+    });
+    expect(result.current.isSettled).toBe(false);
+
+    rerender({ height: 113 });
+    act(() => {
+      jest.advanceTimersByTime(10);
+    });
+    expect(result.current.isSettled).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(SETTLE_MS);
+    });
+    expect(result.current.isSettled).toBe(true);
+    expect(result.current.paddingTop).toBe(113);
+  });
+
+  it('reveals at the cap when the height never stops moving', () => {
+    const { result, rerender } = renderHook(
+      ({ height }) => useSettledHeaderHeight(height, opts),
+      { initialProps: { height: 90 } },
+    );
+
+    // Keep nudging the height so the settle window can never elapse
+    for (let elapsed = 0; elapsed < MAX_HOLD_MS; elapsed += 50) {
+      rerender({ height: 90 + elapsed });
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
+    }
+
+    expect(result.current.isSettled).toBe(true);
+  });
+
+  it('never hides again once settled, even if a late height lands', () => {
+    const { result, rerender } = renderHook(
+      ({ height }) => useSettledHeaderHeight(height, opts),
+      { initialProps: { height: 97.67 } },
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(SETTLE_MS);
+    });
+    expect(result.current.isSettled).toBe(true);
+
+    // Never hides again; the new height is adopted through the same quiet
+    // window rather than snapping the padding under visible content
+    rerender({ height: 113 });
+    expect(result.current.isSettled).toBe(true);
+    expect(result.current.paddingTop).toBe(97.67);
+
+    act(() => {
+      jest.advanceTimersByTime(SETTLE_MS);
+    });
+    expect(result.current.isSettled).toBe(true);
+    expect(result.current.paddingTop).toBe(113);
+  });
+
+  it('is settled from the first render on re-entry, with the known height', () => {
+    const first = renderHook(
+      ({ height }) => useSettledHeaderHeight(height, opts),
+      {
+        initialProps: { height: 113 },
+      },
+    );
+    act(() => {
+      jest.advanceTimersByTime(SETTLE_MS);
+    });
+    expect(first.result.current.isSettled).toBe(true);
+    first.unmount();
+
+    // Re-entry reports the estimate again for the first renders — it must
+    // neither hide nor adopt it before the real height comes back
+    const second = renderHook(
+      ({ height }) => useSettledHeaderHeight(height, opts),
+      { initialProps: { height: 97.67 } },
+    );
+    expect(second.result.current.isSettled).toBe(true);
+    expect(second.result.current.paddingTop).toBe(113);
+
+    second.rerender({ height: 113 });
+    act(() => {
+      jest.advanceTimersByTime(SETTLE_MS * 2);
+    });
+    expect(second.result.current.isSettled).toBe(true);
+    expect(second.result.current.paddingTop).toBe(113);
+  });
+
+  it('settles immediately when disabled, so other platforms never hide', () => {
+    const { result } = renderHook(() =>
+      useSettledHeaderHeight(44, { ...opts, enabled: false }),
+    );
+
+    expect(result.current.isSettled).toBe(true);
+    expect(result.current.paddingTop).toBe(0);
+  });
+});

--- a/packages/kit/src/views/Earn/hooks/useSettledHeaderHeight.ts
+++ b/packages/kit/src/views/Earn/hooks/useSettledHeaderHeight.ts
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from 'react';
+
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+// OK-59958: on iOS 26 the nav bar is transparent and pages offset their body by
+// useHeaderHeight(). That hook reports react-navigation's synchronous estimate
+// for the first renders (97.67 on a Dynamic Island device) and the natively
+// measured height (113) only once the header lays out, so a body painted
+// straight away drops by the 15.33pt difference a beat later.
+export const HEADER_HEIGHT_SETTLE_MS = 64;
+
+// Waiting for quiet is only safe if it is bounded. On a real device the height
+// kept moving for ~1s, and holding the body for all of it read as a blank page.
+// Measured from mount, not from the last change: past this point reveal
+// whatever we have, because a settle we cannot observe is not worth a second of
+// white.
+const HEADER_HEIGHT_MAX_HOLD_MS = 250;
+
+// The measured height is a property of the device, not of the screen, so the
+// first page that settles it can hand the value to every later mount. Without
+// this, re-entering a page gated again from scratch and blanked the body a
+// second time even though the answer was already known.
+let deviceSettledHeaderHeight: number | undefined;
+
+export function resetDeviceSettledHeaderHeightForTest() {
+  deviceSettledHeaderHeight = undefined;
+}
+
+/**
+ * Resolves the top inset a page body should be laid out against, plus whether
+ * that value can be trusted yet.
+ *
+ * `isSettled` is false only while the very first measurement of the app session
+ * is still moving; callers hide their body for that window so the padding never
+ * changes under visible content. Later mounts reuse the remembered height and
+ * are settled from their first render, so re-entry never blanks.
+ *
+ * Off-target platforms have a constant 0 inset — they settle immediately and
+ * must never hide.
+ */
+export function useSettledHeaderHeight(
+  headerHeight: number,
+  {
+    enabled = platformEnv.isNativeIOS26Plus,
+    settleMs = HEADER_HEIGHT_SETTLE_MS,
+    maxHoldMs = HEADER_HEIGHT_MAX_HOLD_MS,
+  }: { enabled?: boolean; settleMs?: number; maxHoldMs?: number } = {},
+): { paddingTop: number; isSettled: boolean } {
+  const [settledHeight, setSettledHeight] = useState<number | undefined>(() =>
+    enabled ? deviceSettledHeaderHeight : 0,
+  );
+  const holdDeadlineRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (!enabled) {
+      setSettledHeight(0);
+      return undefined;
+    }
+
+    if (settledHeight === headerHeight) {
+      return undefined;
+    }
+
+    const accept = () => {
+      deviceSettledHeaderHeight = headerHeight;
+      setSettledHeight(headerHeight);
+    };
+
+    // Height already known for this device: adopt changes (rotation, a
+    // genuinely late measurement) through the same quiet window, but never go
+    // back to hidden. Debouncing matters on re-entry too — the first renders
+    // report the estimate again, and taking it immediately would replace a good
+    // remembered height with a transient one.
+    if (settledHeight !== undefined) {
+      const timer = setTimeout(accept, settleMs);
+      return () => clearTimeout(timer);
+    }
+
+    if (holdDeadlineRef.current === undefined) {
+      holdDeadlineRef.current = Date.now() + maxHoldMs;
+    }
+    const remainingHold = Math.max(0, holdDeadlineRef.current - Date.now());
+    const timer = setTimeout(accept, Math.min(settleMs, remainingHold));
+    return () => clearTimeout(timer);
+  }, [enabled, headerHeight, settleMs, maxHoldMs, settledHeight]);
+
+  return {
+    // Before anything is known the live estimate is the best guess, and the
+    // body is hidden anyway.
+    paddingTop: settledHeight ?? headerHeight,
+    isSettled: settledHeight !== undefined,
+  };
+}

--- a/packages/kit/src/views/Earn/pages/EarnAllProtocols/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnAllProtocols/index.tsx
@@ -16,13 +16,22 @@ import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/Acco
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
-import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  EJotaiContextStoreNames,
+  useSettingsPersistAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 
 import { EarnAprSuffixText } from '../../components/EarnAprSuffixText';
+import { EarnListEmptyState } from '../../components/EarnListEmptyState';
+import {
+  EARN_LIST_ESTIMATED_ITEM_SIZE,
+  EARN_LIST_ROW_GAP,
+  EarnListRowSeparator,
+} from '../../components/earnListRhythm';
 import { earnListScrollBehaviorProps } from '../../components/earnListScrollProps';
 import { EarnMobileSortControl } from '../../components/EarnMobileSortControl';
 import { EarnPageContainer } from '../../components/EarnPageContainer';
@@ -51,17 +60,29 @@ type IFilteredProvider = IEarnAggregatedProvider & {
   // Server-driven highlight color of that same row (OK-59344): only boosted
   // rows carry a highlight color, everything else renders in default text
   maxApyColor?: string;
+  // Server copy of that same row (OK-59855). Protocols without a numeric
+  // yield (babylon returns the translated "Earn points") carry their whole
+  // value as text, so re-formatting from the parsed number would drop it.
+  maxApyText?: string;
 };
 
 function getRowApy(row: IEarnProtocolTokenRow): number {
   return parseAprPercentValue(row.item.provider.aprWithoutFee);
 }
 
+function getRowAprText(row: IEarnProtocolTokenRow): string | undefined {
+  const text =
+    row.item.aprInfo?.highlight?.text ?? row.item.aprInfo?.normal?.text;
+  return text?.trim() || undefined;
+}
+
 function EarnAllProtocolsSkeleton() {
   return (
-    <YStack px="$pagePadding" gap="$4" pt="$4">
+    // Same box metrics and row gap as the real ListItem rows so the
+    // skeleton-to-content swap does not shift the list (OK-59904)
+    <YStack px="$pagePadding" gap={EARN_LIST_ROW_GAP}>
       {Array.from({ length: 8 }).map((_, index) => (
-        <XStack key={index} ai="center" gap="$3">
+        <XStack key={index} minHeight="$11" py="$2" ai="center" gap="$3">
           <Skeleton w="$10" h="$10" borderRadius="$full" />
           <YStack gap="$1.5" flex={1}>
             <Skeleton h="$4" w="$24" />
@@ -75,6 +96,10 @@ function EarnAllProtocolsSkeleton() {
 
 function EarnAllProtocolsContent() {
   const intl = useIntl();
+  // TVL is returned by the server already converted to the user's selected
+  // fiat, so the symbol has to follow the same setting — it used to be a
+  // hard-coded "$", which left the number changing and the symbol stuck.
+  const [settings] = useSettingsPersistAtom();
   const navigation = useAppNavigation();
   const tabBarHeight = useScrollContentTabBarOffset();
   const { providers, isLoading } = useEarnAllProtocols();
@@ -123,13 +148,26 @@ function EarnAllProtocolsContent() {
       let maxApy = 0;
       let maxApyUnit = 'APY';
       let maxApyColor: string | undefined;
+      let maxApyText: string | undefined;
+      // Text-only yields parse to 0, so they can never win the numeric
+      // comparison; remember the first one as a fallback for providers whose
+      // every row is text-only (OK-59855)
+      let textOnlyRow: IEarnProtocolTokenRow | undefined;
       for (const row of rows) {
         const apy = getRowApy(row);
         if (apy > maxApy) {
           maxApy = apy;
           maxApyUnit = row.item.provider.rewardUnit || 'APY';
           maxApyColor = row.item.aprInfo?.highlight?.color;
+          maxApyText = getRowAprText(row);
+        } else if (!textOnlyRow && apy <= 0 && getRowAprText(row)) {
+          textOnlyRow = row;
         }
+      }
+      if (maxApy <= 0 && textOnlyRow) {
+        maxApyUnit = textOnlyRow.item.provider.rewardUnit || 'APY';
+        maxApyColor = textOnlyRow.item.aprInfo?.highlight?.color;
+        maxApyText = getRowAprText(textOnlyRow);
       }
       return [
         {
@@ -138,6 +176,7 @@ function EarnAllProtocolsContent() {
           maxApy,
           maxApyUnit,
           maxApyColor,
+          maxApyText,
         },
       ];
     });
@@ -213,59 +252,71 @@ function EarnAllProtocolsContent() {
   );
 
   const renderItem = useCallback(
-    ({ item: provider }: { item: IFilteredProvider }) => (
-      <ListItem
-        testID={EarnTestIDs.allProtocolsItem(provider.provider)}
-        userSelect="none"
-        onPress={() => handleProviderPress(provider)}
-        renderAvatar={
-          <Token
-            size="md"
-            tokenImageUri={provider.logoURI}
-            borderRadius="$full"
-          />
-        }
-      >
-        <ListItem.Text
-          flex={1}
-          primary={
-            <SizableText size="$bodyLgMedium" numberOfLines={1}>
-              {provider.providerName}
-            </SizableText>
-          }
-        />
-        <YStack ai="flex-end" jc="center">
-          {provider.maxApy > 0 ? (
-            // Value + smaller APY suffix via the shared renderer instead
-            // of hard-coding the unit into the copy (review feedback).
-            // OK-59344: default text color — green is reserved for boosted
-            // rows and is driven by the server-side aprInfo color, so a
-            // hardcoded success color made every protocol look boosted.
-            <EarnAprSuffixText
-              text={`${provider.maxApy.toFixed(2)}%`}
-              fallbackUnit={provider.maxApyUnit}
-              size="$bodyMdMedium"
-              suffixSize="$bodySmMedium"
-              color={provider.maxApyColor ?? '$text'}
+    ({ item: provider }: { item: IFilteredProvider }) => {
+      // Prefer the server copy so text-only yields survive (OK-59855); the
+      // parsed number stays the sort key and the numeric fallback.
+      const yieldText =
+        provider.maxApyText ??
+        (provider.maxApy > 0 ? `${provider.maxApy.toFixed(2)}%` : undefined);
+      // Appending a unit only makes sense for a numeric value — "Earn points
+      // APY" would be nonsense.
+      const yieldUnit =
+        yieldText && /\d/.test(yieldText) ? provider.maxApyUnit : undefined;
+
+      return (
+        <ListItem
+          testID={EarnTestIDs.allProtocolsItem(provider.provider)}
+          userSelect="none"
+          onPress={() => handleProviderPress(provider)}
+          renderAvatar={
+            <Token
+              size="md"
+              tokenImageUri={provider.logoURI}
+              borderRadius="$full"
             />
-          ) : null}
-          <XStack ai="center" gap="$1">
-            <NumberSizeableText
-              size="$bodySm"
-              color="$textSubdued"
-              formatter="marketCap"
-              formatterOptions={{ currency: '$' }}
-            >
-              {provider.filteredTvlValue}
-            </NumberSizeableText>
-            <SizableText size="$bodySm" color="$textSubdued">
-              {intl.formatMessage({ id: ETranslations.earn_tvl })}
-            </SizableText>
-          </XStack>
-        </YStack>
-      </ListItem>
-    ),
-    [handleProviderPress, intl],
+          }
+        >
+          <ListItem.Text
+            flex={1}
+            primary={
+              <SizableText size="$bodyLgMedium" numberOfLines={1}>
+                {provider.providerName}
+              </SizableText>
+            }
+          />
+          <YStack ai="flex-end" jc="center">
+            {yieldText ? (
+              // Value + smaller APY suffix via the shared renderer instead
+              // of hard-coding the unit into the copy (review feedback).
+              // OK-59344: default text color — green is reserved for boosted
+              // rows and is driven by the server-side aprInfo color, so a
+              // hardcoded success color made every protocol look boosted.
+              <EarnAprSuffixText
+                text={yieldText}
+                fallbackUnit={yieldUnit}
+                size="$bodyMdMedium"
+                suffixSize="$bodySmMedium"
+                color={provider.maxApyColor ?? '$text'}
+              />
+            ) : null}
+            <XStack ai="center" gap="$1">
+              <NumberSizeableText
+                size="$bodySm"
+                color="$textSubdued"
+                formatter="marketCap"
+                formatterOptions={{ currency: settings.currencyInfo.symbol }}
+              >
+                {provider.filteredTvlValue}
+              </NumberSizeableText>
+              <SizableText size="$bodySm" color="$textSubdued">
+                {intl.formatMessage({ id: ETranslations.earn_tvl })}
+              </SizableText>
+            </XStack>
+          </YStack>
+        </ListItem>
+      );
+    },
+    [handleProviderPress, intl, settings.currencyInfo.symbol],
   );
 
   const keyExtractor = useCallback(
@@ -327,11 +378,22 @@ function EarnAllProtocolsContent() {
         flex={1}
         {...earnListScrollBehaviorProps}
         data={sortedProviders}
-        estimatedItemSize={60}
+        estimatedItemSize={EARN_LIST_ESTIMATED_ITEM_SIZE}
         keyExtractor={keyExtractor}
         renderItem={renderItem}
+        ItemSeparatorComponent={EarnListRowSeparator}
         ListHeaderComponent={listHeader}
-        ListEmptyComponent={isLoading ? <EarnAllProtocolsSkeleton /> : null}
+        ListEmptyComponent={
+          isLoading ? (
+            <EarnAllProtocolsSkeleton />
+          ) : (
+            <EarnListEmptyState
+              isFiltered={
+                searchText.trim().length > 0 || selectedNetworkIds.length > 0
+              }
+            />
+          )
+        }
         contentContainerStyle={{ pb: tabBarHeight }}
       />
     </EarnPageContainer>

--- a/packages/kit/src/views/Earn/pages/EarnFixedRateTokens/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnFixedRateTokens/index.tsx
@@ -23,6 +23,12 @@ import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
 import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
 
 import { AvailableAssetItem } from '../../components/AvailableAssetsFlatList';
+import { EarnListEmptyState } from '../../components/EarnListEmptyState';
+import {
+  EARN_LIST_ESTIMATED_ITEM_SIZE,
+  EARN_LIST_ROW_GAP,
+  EarnListRowSeparator,
+} from '../../components/earnListRhythm';
 import { earnListScrollBehaviorProps } from '../../components/earnListScrollProps';
 import { EarnMobileSortControl } from '../../components/EarnMobileSortControl';
 import { EarnPageContainer } from '../../components/EarnPageContainer';
@@ -53,9 +59,11 @@ function getAssetSortValue(
 
 function EarnFixedRateTokensSkeleton() {
   return (
-    <YStack px="$pagePadding" gap="$4" pt="$4">
+    // Same box metrics and row gap as the real ListItem rows so the
+    // skeleton-to-content swap does not shift the list (OK-59904)
+    <YStack px="$pagePadding" gap={EARN_LIST_ROW_GAP}>
       {Array.from({ length: 8 }).map((_, index) => (
-        <XStack key={index} ai="center" gap="$3">
+        <XStack key={index} minHeight="$11" py="$2" ai="center" gap="$3">
           <Skeleton w="$10" h="$10" borderRadius="$full" />
           <YStack gap="$1.5" flex={1}>
             <Skeleton h="$4" w="$24" />
@@ -274,11 +282,22 @@ function EarnFixedRateTokensContent() {
         flex={1}
         {...earnListScrollBehaviorProps}
         data={sortedAssets}
-        estimatedItemSize={60}
+        estimatedItemSize={EARN_LIST_ESTIMATED_ITEM_SIZE}
         keyExtractor={keyExtractor}
         renderItem={renderItem}
+        ItemSeparatorComponent={EarnListRowSeparator}
         ListHeaderComponent={listHeader}
-        ListEmptyComponent={isLoading ? <EarnFixedRateTokensSkeleton /> : null}
+        ListEmptyComponent={
+          isLoading ? (
+            <EarnFixedRateTokensSkeleton />
+          ) : (
+            <EarnListEmptyState
+              isFiltered={
+                searchText.trim().length > 0 || selectedNetworkIds.length > 0
+              }
+            />
+          )
+        }
         contentContainerStyle={{ pb: tabBarHeight }}
       />
     </EarnPageContainer>

--- a/packages/kit/src/views/Earn/pages/EarnPositions/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnPositions/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useHeaderHeight } from '@react-navigation/elements';
 import { useIsFocused } from '@react-navigation/native';
@@ -14,7 +14,6 @@ import {
 import { AccountSelectorProviderMirror } from '@onekeyhq/kit/src/components/AccountSelector';
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { EEarnLabels } from '@onekeyhq/shared/types/staking';
 
@@ -23,6 +22,7 @@ import { PortfolioTabContent } from '../../components/PortfolioTabContent';
 import { EarnProviderMirror } from '../../EarnProviderMirror';
 import { useEarnHideSmallAssets } from '../../hooks/useEarnHideSmallAssets';
 import { useEarnPortfolio } from '../../hooks/useEarnPortfolio';
+import { useSettledHeaderHeight } from '../../hooks/useSettledHeaderHeight';
 import { useStakingPendingTxsByInfo } from '../../hooks/useStakingPendingTxs';
 
 import type { IStakePendingTx } from '../../hooks/useStakingPendingTxs';
@@ -32,10 +32,14 @@ function EarnPositionsContent() {
   const isFocused = useIsFocused();
   const headerHeight = useHeaderHeight();
   const tabBarHeight = useScrollContentTabBarOffset();
-  const bodyPaddingTop = platformEnv.isNativeIOS26Plus ? headerHeight : 0;
+  // Owns both the inset and whether it can be trusted yet (OK-59958): on
+  // re-entry it returns the height this device already settled on, so the body
+  // is never hidden a second time.
+  const { paddingTop: bodyPaddingTop, isSettled: isHeaderHeightSettled } =
+    useSettledHeaderHeight(headerHeight);
   const portfolioData = useEarnPortfolio({ isActive: isFocused });
   const { hideSmallAssets, setHideSmallAssets } = useEarnHideSmallAssets();
-  const { refresh, isLoading } = portfolioData;
+  const { refresh } = portfolioData;
 
   const pendingTxsFilter = useCallback((tx: IStakePendingTx) => {
     return [EEarnLabels.Stake, EEarnLabels.Withdraw, EEarnLabels.Sell].includes(
@@ -55,7 +59,25 @@ function EarnPositionsContent() {
     previousIsPendingRef.current = isPending;
   }, [isPending, refresh]);
 
-  const handleRefresh = useCallback(() => refresh(), [refresh]);
+  // OK-59958: RefreshControl.refreshing must track user-initiated pulls only.
+  // It used to be wired to useEarnPortfolio's general isLoading, which also
+  // goes true on mount, on focus revalidation, when a pending tx settles, and
+  // on account change (useEarnPortfolio sets it in the hasAccountChanged
+  // branch). Starting UIRefreshControl programmatically grows the scroll
+  // view's content inset, and that inset was not restored when the flag
+  // cleared — the spinner vanished but the content stayed pushed down.
+  // EarnHome already separates these two concerns; this page did not.
+  // Content loading states stay with portfolioData — PortfolioTabContent
+  // renders its own skeleton from the same isLoading.
+  const [isManualRefreshing, setIsManualRefreshing] = useState(false);
+  const handleRefresh = useCallback(async () => {
+    setIsManualRefreshing(true);
+    try {
+      await refresh();
+    } finally {
+      setIsManualRefreshing(false);
+    }
+  }, [refresh]);
   const setHideSmallAssetsRef = useRef(setHideSmallAssets);
   setHideSmallAssetsRef.current = setHideSmallAssets;
   const handleHideSmallAssetsChange = useCallback((nextValue: boolean) => {
@@ -77,7 +99,9 @@ function EarnPositionsContent() {
         title={intl.formatMessage({ id: ETranslations.earn_positions })}
         headerRight={renderHeaderRight}
       />
-      <Page.Body pt={bodyPaddingTop}>
+      {/* Hidden rather than unmounted so the ScrollView and its RefreshControl
+          are set up once and never rebuilt (OK-59958) */}
+      <Page.Body pt={bodyPaddingTop} opacity={isHeaderHeightSettled ? 1 : 0}>
         <ScrollView
           flex={1}
           showsVerticalScrollIndicator={false}
@@ -87,7 +111,7 @@ function EarnPositionsContent() {
           }}
           refreshControl={
             <RefreshControl
-              refreshing={Boolean(isLoading)}
+              refreshing={isManualRefreshing}
               onRefresh={handleRefresh}
             />
           }

--- a/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolDetails/index.tsx
@@ -12,6 +12,7 @@ import {
   Page,
   ScrollView,
   SizableText,
+  Skeleton,
   Stack,
   XStack,
   YStack,
@@ -166,17 +167,27 @@ const ProtocolHeader = ({
   return (
     <YStack gap="$2.5">
       <XStack jc="space-between" ai="center">
+        {/* Vault symbols can be as long as
+            "Morpho-cbBTC-USDC-wrapper". The name group used to be
+            flexShrink={0} with no truncation on its text, so it pushed the
+            divider and the maturity date off the right edge. The date is
+            short and load-bearing, so it and the divider hold their size and
+            the name truncates into whatever is left. */}
         <XStack gap="$3" ai="center" minWidth={0} flex={1}>
-          <XStack gap="$2" ai="center" flexShrink={0}>
+          <XStack gap="$2" ai="center" flexShrink={1} minWidth={0}>
             <Token size="xs" tokenImageUri={tokenInfo?.token.logoURI} />
-            <SizableText size="$bodyLgMedium">
+            <SizableText size="$bodyLgMedium" numberOfLines={1} flexShrink={1}>
               {tokenInfo?.token.symbol || symbol}
             </SizableText>
           </XStack>
           {formattedMaturityDate ? (
             <>
-              <Divider vertical h="$6" />
-              <SizableText size="$bodyLgMedium" numberOfLines={1}>
+              <Divider vertical h="$6" flexShrink={0} />
+              <SizableText
+                size="$bodyLgMedium"
+                numberOfLines={1}
+                flexShrink={0}
+              >
                 {formattedMaturityDate}
               </SizableText>
             </>
@@ -840,17 +851,29 @@ const EarnProtocolDetailsPage = ({ route }: { route: IRouteProps }) => {
   // without the logo the entry list handed over the header would render the
   // placeholder icon on every entry and swap to the real logo on response.
   const headerTokenLogoURI = tokenInfo?.token?.logoURI ?? logoURI;
+  // OK-59961: entries that carry no logoURI route param (a banner deep link)
+  // have nothing to draw until getProtocolDetailsV2 resolves, so the header
+  // rendered Token's placeholder coin and swapped in the real logo a beat
+  // later. Skeleton it instead while the request is still in flight — gated on
+  // isLoading rather than on the URI alone, so a token that genuinely has no
+  // logo still falls back to the placeholder instead of pulsing forever.
+  const isHeaderTokenLogoPending = !headerTokenLogoURI && isLoading;
 
   const pageTitle = useMemo(
     () => (
       <XStack gap="$3" ai="center">
-        <Token size="md" tokenImageUri={headerTokenLogoURI} />
+        {isHeaderTokenLogoPending ? (
+          // Matches Token size="md" (tokenImageSize $8) so nothing shifts
+          <Skeleton w="$8" h="$8" radius="round" />
+        ) : (
+          <Token size="md" tokenImageUri={headerTokenLogoURI} />
+        )}
         <SizableText size="$headingXl" numberOfLines={1} flexShrink={1}>
           {symbol}
         </SizableText>
       </XStack>
     ),
-    [symbol, headerTokenLogoURI],
+    [symbol, headerTokenLogoURI, isHeaderTokenLogoPending],
   );
 
   const handleOpenManageModal = useCallback(

--- a/packages/kit/src/views/Earn/pages/EarnProtocolTokens/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocolTokens/index.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import {
+  Badge,
   ListView,
   SizableText,
   Skeleton,
@@ -16,7 +17,6 @@ import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { Token } from '@onekeyhq/kit/src/components/Token';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
-import { prewarmTokenImages } from '@onekeyhq/kit/src/utils/tokenImagePrewarm';
 import { EJotaiContextStoreNames } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -28,8 +28,15 @@ import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { EAccountSelectorSceneName } from '@onekeyhq/shared/types';
 import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
 import { getEarnProviderDisplayName } from '@onekeyhq/shared/types/earn/earnProvider.constants';
+import { EStakeProtocolGroupEnum } from '@onekeyhq/shared/types/staking';
 
 import { EarnAprSuffixText } from '../../components/EarnAprSuffixText';
+import { EarnListEmptyState } from '../../components/EarnListEmptyState';
+import {
+  EARN_LIST_ESTIMATED_ITEM_SIZE,
+  EARN_LIST_ROW_GAP,
+  EarnListRowSeparator,
+} from '../../components/earnListRhythm';
 import { earnListScrollBehaviorProps } from '../../components/earnListScrollProps';
 import { EarnMobileSortControl } from '../../components/EarnMobileSortControl';
 import { EarnPageContainer } from '../../components/EarnPageContainer';
@@ -39,6 +46,7 @@ import { EarnNavigation } from '../../earnUtils';
 import { useEarnAllProtocols } from '../../hooks/useEarnAllProtocols';
 import { EarnTestIDs } from '../../testIDs';
 import { parseAprPercentValue } from '../../utils/availableAssetsUtils';
+import { isDisplayableMetricText } from '../../utils/protocolListUtils';
 
 import type {
   IEarnSortDirection,
@@ -68,9 +76,11 @@ function getRowKey(row: IEarnProtocolTokenRow): string {
 
 function EarnProtocolTokensSkeleton() {
   return (
-    <YStack px="$pagePadding" gap="$4" pt="$4">
+    // Same box metrics and row gap as the real ListItem rows so the
+    // skeleton-to-content swap does not shift the list (OK-59904)
+    <YStack px="$pagePadding" gap={EARN_LIST_ROW_GAP}>
       {Array.from({ length: 8 }).map((_, index) => (
-        <XStack key={index} ai="center" gap="$3">
+        <XStack key={index} minHeight="$11" py="$2" ai="center" gap="$3">
           <Skeleton w="$10" h="$10" borderRadius="$full" />
           <YStack gap="$1.5" flex={1}>
             <Skeleton h="$4" w="$24" />
@@ -209,7 +219,6 @@ function EarnProtocolTokensContent({ route }: { route: IRouteProps }) {
       // Note this is the token logo, not the page's `logoURI` route param,
       // which is the protocol's.
       const tokenLogoURI = assetLogoMap.get(row.symbol.toLowerCase());
-      prewarmTokenImages({ tokenImageUri: tokenLogoURI });
       void EarnNavigation.pushToEarnProtocolDetails(navigation, {
         networkId: row.item.network.networkId,
         symbol: row.symbol,
@@ -245,16 +254,43 @@ function EarnProtocolTokensContent({ route }: { route: IRouteProps }) {
         <ListItem.Text
           flex={1}
           primary={
-            <SizableText size="$bodyLgMedium" numberOfLines={1}>
-              {row.symbol}
-            </SizableText>
+            <XStack ai="center" gap="$1.5" minWidth={0}>
+              <SizableText
+                size="$bodyLgMedium"
+                numberOfLines={1}
+                flexShrink={1}
+              >
+                {row.symbol}
+              </SizableText>
+              {/* Sunset protocols (lido/babylon) come back as WithdrawOnly and
+                  are deliberately kept in the aggregation (OK-59305), but this
+                  page never surfaced that state, so their rows looked as if
+                  they still accepted deposits (OK-59959). The protocol list and
+                  the switcher already label the same group with this copy. */}
+              {row.item.provider.group ===
+              EStakeProtocolGroupEnum.WithdrawOnly ? (
+                <Badge badgeType="default" badgeSize="sm" flexShrink={0}>
+                  <Badge.Text>
+                    {intl.formatMessage({
+                      id: ETranslations.earn_withdrawal_only,
+                    })}
+                  </Badge.Text>
+                </Badge>
+              ) : null}
+            </XStack>
           }
         />
         <YStack ai="flex-end" jc="center" gap="$0.5">
           <EarnAprSuffixText
+            // aprInfo is optional. When a row only carries
+            // provider.aprWithoutFee the text was empty and fallbackUnit does
+            // not render on its own, so the whole yield column went blank —
+            // while this page's own sorting already reads that field, and
+            // EarnProtocols falls back to it through AprText.
             text={
               row.item.aprInfo?.highlight?.text ??
               row.item.aprInfo?.normal?.text ??
+              row.item.provider.aprWithoutFee ??
               ''
             }
             // Append rewardUnit when the server copy has no suffix so
@@ -266,7 +302,10 @@ function EarnProtocolTokensContent({ route }: { route: IRouteProps }) {
                 : (row.item.aprInfo?.normal?.color ?? '$text')
             }
           />
-          {row.item.tvl?.text ? (
+          {/* Guard, not a fix: the server owns this string and has shipped
+              "NaN" for some Pendle vaults. Rendering it verbatim put NaN in
+              front of users, so drop any metric copy that carries no digit. */}
+          {isDisplayableMetricText(row.item.tvl?.text) ? (
             <SizableText size="$bodySm" color="$textSubdued">
               {`${row.item.tvl.text} ${intl.formatMessage({
                 id: ETranslations.earn_tvl,
@@ -332,12 +371,17 @@ function EarnProtocolTokensContent({ route }: { route: IRouteProps }) {
         flex={1}
         {...earnListScrollBehaviorProps}
         data={showSkeleton ? [] : sortedTokens}
-        estimatedItemSize={60}
+        estimatedItemSize={EARN_LIST_ESTIMATED_ITEM_SIZE}
         keyExtractor={getRowKey}
         renderItem={renderItem}
+        ItemSeparatorComponent={EarnListRowSeparator}
         ListHeaderComponent={listHeader}
         ListEmptyComponent={
-          showSkeleton ? <EarnProtocolTokensSkeleton /> : null
+          showSkeleton ? (
+            <EarnProtocolTokensSkeleton />
+          ) : (
+            <EarnListEmptyState isFiltered={selectedNetworkIds.length > 0} />
+          )
         }
         contentContainerStyle={{ pb: tabBarHeight }}
       />

--- a/packages/kit/src/views/Earn/pages/EarnProtocols/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnProtocols/index.tsx
@@ -51,6 +51,7 @@ import { EarnTestIDs } from '../../testIDs';
 import {
   filterAndSortProtocols,
   getProtocolNetworkData,
+  isDisplayableMetricText,
 } from '../../utils/protocolListUtils';
 
 import type { IEarnSortOption } from '../../components/EarnMobileSortControl';
@@ -555,8 +556,12 @@ function BasicEarnProtocols({ route }: { route: IRouteProps }) {
           });
           // Walkthrough r3: on mobile, TVL renders under APY in the right
           // column (fixed-rate keeps its liquidity line instead)
+          // Same guard as the protocol Tokens page: the server has shipped
+          // "NaN" TVL copy, and this string is rendered verbatim
           const showMobileTvl =
-            !isFixedRateCategory && !isDesktopLayout && Boolean(item.tvl?.text);
+            !isFixedRateCategory &&
+            !isDesktopLayout &&
+            isDisplayableMetricText(item.tvl?.text);
           const mobileTvl = showMobileTvl ? (
             <SizableText size="$bodySm" color="$textSubdued" numberOfLines={1}>
               {`${item.tvl?.text ?? ''} ${intl.formatMessage({

--- a/packages/kit/src/views/Earn/pages/EarnTokens/index.tsx
+++ b/packages/kit/src/views/Earn/pages/EarnTokens/index.tsx
@@ -23,6 +23,12 @@ import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
 import { EAvailableAssetsTypeEnum } from '@onekeyhq/shared/types/earn';
 
 import { AvailableAssetItem } from '../../components/AvailableAssetsFlatList';
+import { EarnListEmptyState } from '../../components/EarnListEmptyState';
+import {
+  EARN_LIST_ESTIMATED_ITEM_SIZE,
+  EARN_LIST_ROW_GAP,
+  EarnListRowSeparator,
+} from '../../components/earnListRhythm';
 import { earnListScrollBehaviorProps } from '../../components/earnListScrollProps';
 import { EarnMobileSortControl } from '../../components/EarnMobileSortControl';
 import { EarnPageContainer } from '../../components/EarnPageContainer';
@@ -31,7 +37,10 @@ import { EarnProviderMirror } from '../../EarnProviderMirror';
 import { useEarnAllProtocols } from '../../hooks/useEarnAllProtocols';
 import { useNavigateToEarnAsset } from '../../hooks/useNavigateToEarnAsset';
 import { EarnTestIDs } from '../../testIDs';
-import { parseAprPercentValue } from '../../utils/availableAssetsUtils';
+import {
+  mergeSimpleEarnWithStakingAssets,
+  parseAprPercentValue,
+} from '../../utils/availableAssetsUtils';
 
 import type {
   IEarnSortDirection,
@@ -64,17 +73,25 @@ function getAssetAprSortValue(asset: IEarnAvailableAsset): number {
   return parseAprPercentValue(asset.aprWithoutFee || asset.apr);
 }
 
+// Stable identity so gating the first paint never re-creates the list data
+const EMPTY_ASSETS: IEarnAvailableAsset[] = [];
+
 function EarnTokensSkeleton() {
   return (
-    <YStack px="$pagePadding" gap="$4" pt="$4">
+    // Mirrors the real row: same layout (symbol left, APY over TVL right), same
+    // ListItem box metrics and the same row gap, so the skeleton-to-content
+    // swap shifts neither row heights nor row rhythm (OK-59841, OK-59904)
+    <YStack px="$pagePadding" gap={EARN_LIST_ROW_GAP}>
       {Array.from({ length: 8 }).map((_, index) => (
-        <XStack key={index} ai="center" gap="$3">
+        <XStack key={index} minHeight="$11" py="$2" ai="center" gap="$3">
           <Skeleton w="$10" h="$10" borderRadius="$full" />
-          <YStack gap="$1.5" flex={1}>
+          <YStack flex={1}>
             <Skeleton h="$4" w="$24" />
+          </YStack>
+          <YStack ai="flex-end" gap="$1.5">
+            <Skeleton h="$4" w="$20" />
             <Skeleton h="$3" w="$16" />
           </YStack>
-          <Skeleton h="$4" w="$20" />
         </XStack>
       ))}
     </YStack>
@@ -94,13 +111,17 @@ function EarnTokensContent() {
   const [sortDirection, setSortDirection] =
     useState<IEarnSortDirection>('desc');
 
-  // Fetch SimpleEarn + StableCoins once; every category derives from these
-  // two datasets client-side, so switching chips never re-requests the server.
-  // OK-59338: the base dataset is SimpleEarn (a server-side category that
-  // already excludes fixed-rate PT products) instead of All minus a
-  // fixed-rate symbol set — that subtraction also removed simple-earn
-  // products of symbols that happen to have a PT variant too (USDe), making
-  // them unsearchable here.
+  // Fetch SimpleEarn + Staking + StableCoins once; every category derives from
+  // these datasets client-side, so switching chips never re-requests the
+  // server.
+  // OK-59338: the base dataset is a server-side category (which already
+  // excludes fixed-rate PT products) instead of All minus a fixed-rate symbol
+  // set — that subtraction also removed simple-earn products of symbols that
+  // happen to have a PT variant too (USDe), making them unsearchable here.
+  // OK-59854: SimpleEarn alone is not the whole base though. Server categories
+  // are disjoint, so native-staking assets (SOL/BTC/ETH/APT/POL/ATOM) only
+  // appear under Staking; without them this page showed strictly fewer tokens
+  // than the Earn home Trending section that links to it.
   const { result: assets, isLoading } = usePromiseResult(
     () =>
       backgroundApiProxy.serviceStaking.getAvailableAssets({
@@ -109,6 +130,15 @@ function EarnTokensContent() {
     [],
     { watchLoading: true, undefinedResultIfError: true },
   );
+  const { result: stakingAssets, isLoading: isStakingLoading } =
+    usePromiseResult(
+      () =>
+        backgroundApiProxy.serviceStaking.getAvailableAssets({
+          type: EAvailableAssetsTypeEnum.Staking,
+        }),
+      [],
+      { watchLoading: true, undefinedResultIfError: true },
+    );
   const { result: stableAssets, isLoading: isStableLoading } = usePromiseResult(
     () =>
       backgroundApiProxy.serviceStaking.getAvailableAssets({
@@ -117,26 +147,30 @@ function EarnTokensContent() {
     [],
     { watchLoading: true, undefinedResultIfError: true },
   );
+  const baseAssets = useMemo(
+    () => mergeSimpleEarnWithStakingAssets(assets ?? [], stakingAssets ?? []),
+    [assets, stakingAssets],
+  );
   const stableSymbols = useMemo(
     () => new Set((stableAssets ?? []).map((asset) => asset.symbol)),
     [stableAssets],
   );
-  // Category view over the two datasets (review P2)
+  // Category view over the merged dataset (review P2)
   const categoryAssets = useMemo(() => {
-    const list = assets ?? [];
     if (categoryType === 'stable') {
-      return list.filter((asset) => stableSymbols.has(asset.symbol));
+      return baseAssets.filter((asset) => stableSymbols.has(asset.symbol));
     }
     if (categoryType === 'nonStable') {
-      return list.filter((asset) => !stableSymbols.has(asset.symbol));
+      return baseAssets.filter((asset) => !stableSymbols.has(asset.symbol));
     }
-    return list;
-  }, [assets, categoryType, stableSymbols]);
+    return baseAssets;
+  }, [baseAssets, categoryType, stableSymbols]);
 
   // Data source for the default sort (OK-58880): total TVL of all providers
   // under each symbol. Reuses the all-protocol aggregation (single request +
-  // 5-minute cache); not shown on rows, used for sorting only
-  const { providers: aggregatedProviders } = useEarnAllProtocols();
+  // 5-minute cache)
+  const { providers: aggregatedProviders, isLoading: isAggregationLoading } =
+    useEarnAllProtocols();
   const symbolTvlMap = useMemo(() => {
     const map = new Map<string, number>();
     for (const aggregated of aggregatedProviders) {
@@ -282,32 +316,39 @@ function EarnTokensContent() {
     [navigateToAsset],
   );
 
-  const tvlLabel = useMemo(
-    () => intl.formatMessage({ id: ETranslations.earn_tvl }),
-    [intl],
-  );
-
+  // Product dropped the TVL sub-line from this aggregated page. Only the
+  // display goes — symbolTvlMap still backs the TVL sort options and the
+  // TVL-desc default, so it must stay.
   const renderItem = useCallback(
     ({ item }: { item: IEarnAvailableAsset }) => (
       <AvailableAssetItem
         asset={item}
         categoryType={EAvailableAssetsTypeEnum.SimpleEarn}
         totalLiquidityLabel={totalLiquidityLabel}
-        // Walkthrough r3: show the summed provider TVL under APY so the
-        // default TVL-desc sort is visible on the row
-        tvlValue={symbolTvlMap.get(item.symbol.toLowerCase())}
-        tvlLabel={tvlLabel}
         testID={EarnTestIDs.tokensPageItem(item.symbol)}
         onPress={() => handleAssetPress(item)}
       />
     ),
-    [handleAssetPress, totalLiquidityLabel, symbolTvlMap, tvlLabel],
+    [handleAssetPress, totalLiquidityLabel],
   );
 
   const keyExtractor = useCallback(
     (item: IEarnAvailableAsset) => item.symbol,
     [],
   );
+
+  // OK-59841: available-assets resolves well before the protocol aggregation,
+  // but the aggregation owns both the TVL sub-line on every row and the values
+  // the default TVL sort reads. Painting as soon as available-assets lands
+  // therefore draws one-line rows in a provisional (all-zero) order, then
+  // grows every row by a line and reorders the whole list — which reads as a
+  // jitter under the page title. Keep the skeleton until every field the rows
+  // render and sort by is settled, so the list is painted exactly once.
+  const isInitialLoading =
+    isLoading ||
+    isStakingLoading ||
+    isAggregationLoading ||
+    (categoryType !== 'all' && isStableLoading);
 
   // Passed as an element (stable component type), so re-renders reconcile
   // in place and the SearchBar keeps focus while typing
@@ -390,15 +431,22 @@ function EarnTokensContent() {
       <ListView
         flex={1}
         {...earnListScrollBehaviorProps}
-        data={sortedAssets}
-        estimatedItemSize={60}
+        data={isInitialLoading ? EMPTY_ASSETS : sortedAssets}
+        estimatedItemSize={EARN_LIST_ESTIMATED_ITEM_SIZE}
         keyExtractor={keyExtractor}
         renderItem={renderItem}
+        ItemSeparatorComponent={EarnListRowSeparator}
         ListHeaderComponent={listHeader}
         ListEmptyComponent={
-          isLoading || (categoryType !== 'all' && isStableLoading) ? (
+          isInitialLoading ? (
             <EarnTokensSkeleton />
-          ) : null
+          ) : (
+            <EarnListEmptyState
+              isFiltered={
+                searchText.trim().length > 0 || selectedNetworkIds.length > 0
+              }
+            />
+          )
         }
         contentContainerStyle={{ pb: tabBarHeight }}
       />

--- a/packages/kit/src/views/Earn/utils/availableAssetsUtils.test.ts
+++ b/packages/kit/src/views/Earn/utils/availableAssetsUtils.test.ts
@@ -1,4 +1,21 @@
-import { parseFormattedLiquidityValue } from './availableAssetsUtils';
+import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
+
+import {
+  mergeSimpleEarnWithStakingAssets,
+  parseFormattedLiquidityValue,
+} from './availableAssetsUtils';
+
+function buildAsset(symbol: string, apr = '1'): IEarnAvailableAsset {
+  return {
+    name: symbol,
+    symbol,
+    logoURI: '',
+    apr,
+    aprWithoutFee: apr,
+    tags: [],
+    protocols: [],
+  } as unknown as IEarnAvailableAsset;
+}
 
 describe('availableAssetsUtils', () => {
   it('parses formatted liquidity values and tolerates missing data', () => {
@@ -6,5 +23,40 @@ describe('availableAssetsUtils', () => {
     expect(parseFormattedLiquidityValue('850K')).toBe(850_000);
     expect(parseFormattedLiquidityValue(undefined)).toBe(0);
     expect(parseFormattedLiquidityValue('not-a-number')).toBe(0);
+  });
+
+  describe('mergeSimpleEarnWithStakingAssets', () => {
+    it('keeps native-staking-only symbols that simpleEarn omits (OK-59854)', () => {
+      const merged = mergeSimpleEarnWithStakingAssets(
+        [buildAsset('USDC'), buildAsset('WETH')],
+        [buildAsset('SOL'), buildAsset('ATOM')],
+      );
+      expect(merged.map((asset) => asset.symbol)).toEqual([
+        'USDC',
+        'WETH',
+        'SOL',
+        'ATOM',
+      ]);
+    });
+
+    it('lets the simpleEarn entry win for a symbol in both categories', () => {
+      const merged = mergeSimpleEarnWithStakingAssets(
+        [buildAsset('ETH', '3')],
+        [buildAsset('ETH', '9'), buildAsset('APT')],
+      );
+      expect(merged).toHaveLength(2);
+      expect(merged[0].symbol).toBe('ETH');
+      expect(merged[0].apr).toBe('3');
+      expect(merged[1].symbol).toBe('APT');
+    });
+
+    it('tolerates either dataset being empty', () => {
+      expect(mergeSimpleEarnWithStakingAssets([], [])).toEqual([]);
+      expect(
+        mergeSimpleEarnWithStakingAssets([], [buildAsset('BTC')]).map(
+          (asset) => asset.symbol,
+        ),
+      ).toEqual(['BTC']);
+    });
   });
 });

--- a/packages/kit/src/views/Earn/utils/availableAssetsUtils.ts
+++ b/packages/kit/src/views/Earn/utils/availableAssetsUtils.ts
@@ -1,3 +1,5 @@
+import type { IEarnAvailableAsset } from '@onekeyhq/shared/types/earn';
+
 const liquidityUnitMultiplierMap: Record<string, number> = {
   k: 10 ** 3,
   m: 10 ** 6,
@@ -40,4 +42,22 @@ export function parseAprPercentValue(value?: string): number {
     return 0;
   }
   return Math.max(...matches.map(Number).filter(Number.isFinite), 0);
+}
+
+// OK-59854: the server splits protocols into disjoint categories, so
+// `simpleEarn` on its own drops every native-staking asset (SOL/BTC/ETH/APT/
+// POL/ATOM live under `staking`). Both surfaces that present "tokens you can
+// earn on" need the union; a symbol offered by both categories keeps its
+// simple-earn entry, which carries the richer protocol list.
+export function mergeSimpleEarnWithStakingAssets(
+  simpleEarnAssets: IEarnAvailableAsset[],
+  stakingAssets: IEarnAvailableAsset[],
+): IEarnAvailableAsset[] {
+  const simpleEarnSymbols = new Set(
+    simpleEarnAssets.map((asset) => asset.symbol),
+  );
+  return [
+    ...simpleEarnAssets,
+    ...stakingAssets.filter((asset) => !simpleEarnSymbols.has(asset.symbol)),
+  ];
 }

--- a/packages/kit/src/views/Earn/utils/protocolListUtils.ts
+++ b/packages/kit/src/views/Earn/utils/protocolListUtils.ts
@@ -1,12 +1,28 @@
 import type { IStakeProtocolListItem } from '@onekeyhq/shared/types/staking';
 
-import { parseFormattedLiquidityValue } from './availableAssetsUtils';
+import {
+  parseAprPercentValue,
+  parseFormattedLiquidityValue,
+} from './availableAssetsUtils';
 
 export type IEarnProtocolSortKey = 'tvl' | 'yield';
 export type IEarnProtocolSortDirection = 'asc' | 'desc';
 
+/**
+ * Server metric copy (TVL, liquidity, APR) is rendered verbatim — the client
+ * does no arithmetic on it — so a value the server failed to compute reaches
+ * the screen as-is — QA saw "NaN TVL" on Pendle rows for exactly that reason.
+ * A metric string with no digit in it is not something a user should ever be
+ * shown, whatever the server sent.
+ */
+export function isDisplayableMetricText(
+  value?: string | null,
+): value is string {
+  return typeof value === 'string' && /\d/.test(value);
+}
+
 function parseProtocolMetric(value?: string | null) {
-  if (!value || !/\d/.test(value)) {
+  if (!isDisplayableMetricText(value)) {
     return undefined;
   }
   const parsed = parseFormattedLiquidityValue(value);
@@ -22,7 +38,11 @@ function getProtocolMetric(
       item.provider.totalFiatValue || item.provider.tvl || item.tvl?.text,
     );
   }
-  return parseProtocolMetric(item.provider.aprWithoutFee);
+  // Yields come as ranges too ("2.00% - 10.00% APR"). parseProtocolMetric
+  // reads the first number, so a range sorted by its lower bound and landed
+  // below a single 5.00% — while EarnTokens and EarnProtocolTokens sort the
+  // same data by its upper bound. Share one parser so the three pages agree.
+  return parseAprPercentValue(item.provider.aprWithoutFee) || undefined;
 }
 
 export function getProtocolNetworkData(items: IStakeProtocolListItem[]) {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.test.tsx
@@ -62,6 +62,7 @@ describe('MarketSwapReviewDialog', () => {
 
   it('delegates to the generic swap review shell with market-specific config', () => {
     const onDone = jest.fn();
+    const onConfirmStart = jest.fn();
     const adapter = {
       prepareReview: jest.fn(),
       sendApproveTx: jest.fn(),
@@ -84,6 +85,7 @@ describe('MarketSwapReviewDialog', () => {
     render(
       <MarketSwapReviewDialog
         onDone={onDone}
+        onConfirmStart={onConfirmStart}
         adapter={adapter}
         reviewState={reviewState}
       />,
@@ -91,6 +93,7 @@ describe('MarketSwapReviewDialog', () => {
 
     expect(swapReviewDialogMock).toHaveBeenCalledWith({
       onDone,
+      onConfirmStart,
       adapter,
       reviewState,
       storeName: EJotaiContextStoreNames.marketSwapReview,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.tsx
@@ -11,6 +11,7 @@ import type { ESwapNetworkFeeLevel } from '@onekeyhq/shared/types/swap/types';
 
 type IMarketSwapReviewDialogProps = {
   onDone: () => void;
+  onConfirmStart?: () => void;
   adapter: ISwapReviewAdapter;
   reviewState: ISwapReviewState;
   defaultNetworkFeeLevel?: ESwapNetworkFeeLevel;
@@ -20,6 +21,7 @@ type IMarketSwapReviewDialogProps = {
 
 export function MarketSwapReviewDialog({
   onDone,
+  onConfirmStart,
   adapter,
   reviewState,
   defaultNetworkFeeLevel,
@@ -29,6 +31,7 @@ export function MarketSwapReviewDialog({
   return (
     <SwapReviewDialog
       onDone={onDone}
+      onConfirmStart={onConfirmStart}
       adapter={adapter}
       reviewState={reviewState}
       defaultNetworkFeeLevel={defaultNetworkFeeLevel}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
@@ -22,6 +22,11 @@ import {
 } from '@onekeyhq/kit/src/views/Market/components/StockMarketStatusAlert';
 import { isOndoStockSource } from '@onekeyhq/kit/src/views/Market/components/utils/stockSource';
 import { usePerpsNavigation } from '@onekeyhq/kit/src/views/Market/hooks/usePerpsNavigation';
+import {
+  createGasAccountReviewSession,
+  logGasAccountReviewExit,
+  markGasAccountReviewSubmitted,
+} from '@onekeyhq/kit/src/views/Swap/utils/gasAccountAnalytics';
 import type { ISwapReviewAdapter } from '@onekeyhq/kit/src/views/Swap/utils/swapReviewState';
 import { dismissKeyboard } from '@onekeyhq/shared/src/keyboard';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -275,6 +280,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
     speedCheckLoading,
     estimateMarketPresetNetworkFees,
     prepareMarketSwapReview,
+    logMarketReviewGasAccountDecision,
     sendMarketApproveTx,
     sendMarketSwapTx,
     sendMarketWrappedTx,
@@ -556,6 +562,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
           void previousDialog.close();
         }
         setIsReviewDialogOpen(true);
+        const gasAccountReviewSession = createGasAccountReviewSession();
         let dialog: IDialogInstance | null = null;
         dialog = inPageDialog.show({
           title: intl.formatMessage({
@@ -568,6 +575,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
             if (reviewDialogRef.current !== dialog) {
               return;
             }
+            logGasAccountReviewExit(gasAccountReviewSession);
             reviewDialogRef.current = null;
             setIsReviewDialogOpen(false);
           },
@@ -578,6 +586,9 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
               defaultCustomPriorityFee={effectiveCustomPriorityFee}
               showCustomNetworkFeeOption={showReviewCustomNetworkFeeOption}
               reviewState={nextReviewState}
+              onConfirmStart={() =>
+                markGasAccountReviewSubmitted(gasAccountReviewSession)
+              }
               onDone={() => void dialog?.close()}
             />
           ),
@@ -588,6 +599,8 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
           return;
         }
         reviewDialogRef.current = dialog;
+        gasAccountReviewSession.analyticsContext =
+          logMarketReviewGasAccountDecision();
       } catch (error) {
         if (reviewDialogRequestIdRef.current !== requestId) {
           return;
@@ -614,6 +627,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
       effectiveCustomPriorityFee,
       effectiveNetworkFeeLevel,
       marketPresetSettings,
+      logMarketReviewGasAccountDecision,
       prepareMarketSwapReview,
       reviewAdapter,
     ],

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.test.ts
@@ -15,6 +15,21 @@ const mockBuildDecodedTx = jest.fn();
 const mockSaveSendConfirmHistoryTxs = jest.fn();
 const mockPreActionsBeforeSending = jest.fn();
 const mockAfterSendTxAction = jest.fn();
+const mockFetchSwapTokenDetails = jest.fn();
+const mockGetNativeTokenAddress = jest.fn();
+const mockGasAccountDecision = jest.fn();
+const mockGasAccountAction = jest.fn();
+
+jest.mock('@onekeyhq/shared/src/logger/logger', () => ({
+  defaultLogger: {
+    transaction: {
+      send: {
+        gasAccountDecision: mockGasAccountDecision,
+        gasAccountAction: mockGasAccountAction,
+      },
+    },
+  },
+}));
 
 jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
   __esModule: true,
@@ -44,6 +59,12 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
     serviceSignatureConfirm: {
       preActionsBeforeSending: mockPreActionsBeforeSending,
       afterSendTxAction: mockAfterSendTxAction,
+    },
+    serviceSwap: {
+      fetchSwapTokenDetails: mockFetchSwapTokenDetails,
+    },
+    serviceToken: {
+      getNativeTokenAddress: mockGetNativeTokenAddress,
     },
   },
 }));
@@ -94,6 +115,53 @@ function createEstimateFeeResult() {
   };
 }
 
+function createSponsoredUnsignedTx() {
+  return createUnsignedTx({
+    swapInfo: {
+      sender: {
+        amount: '10',
+        token: {
+          networkId: 'evm--1',
+          contractAddress: '0xtoken',
+          symbol: 'USDC',
+          decimals: 6,
+          isNative: false,
+        },
+      },
+      receiver: {
+        amount: '0.003',
+        token: {
+          networkId: 'evm--1',
+          contractAddress: '',
+          symbol: 'ETH',
+          decimals: 18,
+          isNative: true,
+        },
+      },
+      receivingAddress: '0xuser',
+      swapBuildResData: {
+        orderId: 'order-id',
+        result: {
+          gasAccountEnabled: true,
+        },
+      },
+    } as never,
+  });
+}
+
+function createSponsoredEstimateFeeResult(quoteId: string) {
+  return {
+    ...createEstimateFeeResult(),
+    payer: 'gasAccount',
+    gasAccountEligible: true,
+    gasAccountQuote: {
+      quoteId,
+      maxFee: '0.01',
+      expiresAt: '2026-08-10T12:00:00.000Z',
+    },
+  };
+}
+
 function createMarketPresetToken(overrides = {}) {
   return {
     contractAddress: '',
@@ -121,6 +189,10 @@ describe('marketDirectSendTx', () => {
     mockSaveSendConfirmHistoryTxs.mockReset();
     mockPreActionsBeforeSending.mockReset();
     mockAfterSendTxAction.mockReset();
+    mockFetchSwapTokenDetails.mockReset();
+    mockGetNativeTokenAddress.mockReset();
+    mockGasAccountDecision.mockReset();
+    mockGasAccountAction.mockReset();
 
     mockGetVaultSettings.mockResolvedValue({});
     mockBuildUnsignedTx.mockResolvedValue(createUnsignedTx());
@@ -146,6 +218,8 @@ describe('marketDirectSendTx', () => {
     mockSaveSendConfirmHistoryTxs.mockResolvedValue(undefined);
     mockPreActionsBeforeSending.mockResolvedValue(undefined);
     mockAfterSendTxAction.mockResolvedValue(undefined);
+    mockFetchSwapTokenDetails.mockResolvedValue([{ balanceParsed: '0.005' }]);
+    mockGetNativeTokenAddress.mockResolvedValue('');
   });
 
   it('builds market preset fake transfer info as an isolated self-transfer', () => {
@@ -276,6 +350,80 @@ describe('marketDirectSendTx', () => {
     expect(mockSignAndSendTransaction).toHaveBeenCalledTimes(1);
     expect(mockSaveSendConfirmHistoryTxs).toHaveBeenCalledTimes(1);
     expect(mockBatchEstimateFee).not.toHaveBeenCalled();
+  });
+
+  it('tracks Gas Account submission success without repeating the review decision', async () => {
+    const sponsoredUnsignedTx = createSponsoredUnsignedTx();
+    mockPrepareSendConfirmUnsignedTx.mockResolvedValue(sponsoredUnsignedTx);
+    mockEstimateFee.mockResolvedValue(
+      createSponsoredEstimateFeeResult('quote-id'),
+    );
+
+    await sendMarketDirectUnsignedTxs({
+      accountAddress: '0xuser',
+      accountId: 'account-1',
+      networkId: 'evm--1',
+      buildUnsignedParams: {
+        accountId: 'account-1',
+        networkId: 'evm--1',
+        encodedTx: sponsoredUnsignedTx.encodedTx,
+        swapInfo: sponsoredUnsignedTx.swapInfo,
+        isInternalSwap: true,
+      },
+      gasAccountAnalytics: {
+        fiatCurrency: 'usd',
+        nativeBalance: '0.005',
+        useGasAccountByDefault: true,
+      },
+    });
+
+    expect(mockFetchSwapTokenDetails).not.toHaveBeenCalled();
+    expect(mockGasAccountDecision).not.toHaveBeenCalled();
+    expect(mockGasAccountAction).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        action: 'submitSucceeded',
+        orderId: 'order-id',
+      }),
+    );
+  });
+
+  it('returns the Gas Account decision context with the direct market review estimate', async () => {
+    const sponsoredUnsignedTx = createSponsoredUnsignedTx();
+    mockPrepareSendConfirmUnsignedTx.mockResolvedValue(sponsoredUnsignedTx);
+    mockEstimateFee.mockResolvedValue(
+      createSponsoredEstimateFeeResult('preview-quote-id'),
+    );
+
+    const result = await estimateMarketDirectGasInfos({
+      accountAddress: '0xuser',
+      accountId: 'account-1',
+      networkId: 'evm--1',
+      buildUnsignedParams: {
+        accountId: 'account-1',
+        networkId: 'evm--1',
+        encodedTx: sponsoredUnsignedTx.encodedTx,
+        swapInfo: sponsoredUnsignedTx.swapInfo,
+        isInternalSwap: true,
+      },
+      gasAccountAnalytics: {
+        fiatCurrency: 'usd',
+        useGasAccountByDefault: true,
+      },
+    });
+
+    expect(result.gasAccountAnalyticsContext).toEqual(
+      expect.objectContaining({
+        entryPoint: 'marketSwapDirect',
+        scenario: 'swap',
+        selectedPayer: 'gasAccount',
+        quoteId: 'preview-quote-id',
+        orderId: 'order-id',
+      }),
+    );
+    expect(result.gasAccountAnalyticsNativeBalance).toBe('0.005');
+    expect(mockFetchSwapTokenDetails).toHaveBeenCalledTimes(1);
+    expect(mockGasAccountDecision).not.toHaveBeenCalled();
   });
 
   it('sends batch approve plus swap with batch fee estimation when supported', async () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.ts
@@ -2,10 +2,17 @@ import BigNumber from 'bignumber.js';
 
 import type { IEncodedTx, IUnsignedTxPro } from '@onekeyhq/core/src/types';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { EGasAccountErrorStrategy } from '@onekeyhq/kit/src/views/SignatureConfirm/constants/gasAccountErrorCodes';
 import {
-  EGasAccountErrorStrategy,
-  getGasAccountErrorEntry,
-} from '@onekeyhq/kit/src/views/SignatureConfirm/constants/gasAccountErrorCodes';
+  buildDirectSwapGasAccountAnalyticsContext,
+  buildDirectSwapGasAccountUiState,
+  runDirectSwapGasAccountStep,
+  sendDirectSwapWithGasAccountAnalytics,
+} from '@onekeyhq/kit/src/views/Swap/utils/gasAccountAnalytics';
+import {
+  buildNativeTokenFromGasInfo,
+  checkSwapLatestBalanceSufficient,
+} from '@onekeyhq/kit/src/views/Swap/utils/swapBalanceUtils';
 import type {
   IBuildUnsignedTxParams,
   ITransferInfo,
@@ -16,7 +23,7 @@ import {
   BATCH_SEND_TXS_FEE_UP_RATIO_FOR_SWAP,
 } from '@onekeyhq/shared/src/consts/walletConsts';
 import { OneKeyError } from '@onekeyhq/shared/src/errors';
-import { getGasAccountErrorCode } from '@onekeyhq/shared/src/errors/utils/gasAccountErrorUtils';
+import type { IGasAccountAnalyticsContext } from '@onekeyhq/shared/src/logger/scopes/transaction/types';
 import { calculateFeeForSend } from '@onekeyhq/shared/src/utils/feeUtils';
 import { applyCustomPriorityFeeToGasInfo } from '@onekeyhq/shared/src/utils/marketPresetFeeUtils';
 import type {
@@ -30,7 +37,6 @@ import type {
   IFeeTron,
   IFeeUTXO,
   IGasAccountQuote,
-  IGasAccountUiState,
   IGasEIP1559,
   IGasLegacy,
   IGasPayer,
@@ -70,6 +76,11 @@ type IMarketDirectSendParams = {
   tronResourceRentalInfo?: ITronResourceRentalInfo;
   useDefaultRpc?: boolean;
   validateFinalGasInfos?: (gasInfos: IMarketGasInfoEntry[]) => Promise<void>;
+  gasAccountAnalytics?: {
+    fiatCurrency?: string;
+    nativeBalance?: string;
+    useGasAccountByDefault?: boolean;
+  };
 };
 
 type IEstimateMarketDirectGasInfosParams = Omit<
@@ -156,6 +167,7 @@ function buildGasInfo(
     payer?: IGasPayer;
     gasAccountEligible?: boolean;
     gasAccountQuote?: IGasAccountQuote;
+    gasAccountScenarioReason?: string;
   },
   gasCommon: {
     baseFee?: string;
@@ -192,6 +204,7 @@ function buildGasInfo(
     payer: gasRes.payer,
     gasAccountEligible: gasRes.gasAccountEligible,
     gasAccountQuote: gasRes.gasAccountQuote,
+    gasAccountScenarioReason: gasRes.gasAccountScenarioReason,
   };
 }
 
@@ -919,10 +932,13 @@ export async function estimateMarketDirectGasInfos({
   approveUnsignedTxArr,
   networkFeeLevel,
   customPriorityFee,
+  gasAccountAnalytics,
 }: IEstimateMarketDirectGasInfosParams): Promise<{
   gasInfos: IMarketGasInfoEntry[];
   gasFeeFiatValue?: string;
   preparedUnsignedTx: IUnsignedTxPro;
+  gasAccountAnalyticsContext?: IGasAccountAnalyticsContext;
+  gasAccountAnalyticsNativeBalance?: string;
 }> {
   if (!accountId || !networkId || !accountAddress) {
     throw new OneKeyError('account error');
@@ -950,10 +966,42 @@ export async function estimateMarketDirectGasInfos({
     customPriorityFee,
   });
 
+  let gasAccountAnalyticsContext: IGasAccountAnalyticsContext | undefined;
+  let gasAccountAnalyticsNativeBalance: string | undefined;
+  const swapGasInfo = findGasInfo(gasInfos, unsignedTx.encodedTx);
+  if (gasAccountAnalytics && swapGasInfo && unsignedTx.swapInfo) {
+    const nativeToken = buildNativeTokenFromGasInfo({
+      gasInfo: swapGasInfo.gasInfo,
+      networkId,
+      fromToken: unsignedTx.swapInfo.sender.token,
+    });
+    const latestNativeBalance = nativeToken
+      ? await checkSwapLatestBalanceSufficient({
+          token: nativeToken,
+          amount: '0',
+          accountAddress,
+          accountId,
+        })
+      : undefined;
+    gasAccountAnalyticsNativeBalance = latestNativeBalance?.balance;
+    gasAccountAnalyticsContext = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'marketSwapDirect',
+      networkId,
+      unsignedTx,
+      gasInfo: swapGasInfo.gasInfo,
+      estimateFeeParams: swapGasInfo.estimateFeeParams,
+      nativeBalance: gasAccountAnalyticsNativeBalance,
+      useGasAccountByDefault: gasAccountAnalytics.useGasAccountByDefault,
+      fiatCurrency: gasAccountAnalytics.fiatCurrency,
+    });
+  }
+
   return {
     gasInfos,
     gasFeeFiatValue: buildGasFeeFiatValue(gasInfos),
     preparedUnsignedTx: unsignedTx,
+    gasAccountAnalyticsContext,
+    gasAccountAnalyticsNativeBalance,
   };
 }
 
@@ -1010,6 +1058,7 @@ async function updateUnsignedTxAndSendTx({
   tronResourceRentalInfo,
   useDefaultRpc,
   onBeforeGasAccountFallback,
+  gasAccountAnalytics,
 }: {
   accountId: string;
   networkId: string;
@@ -1019,6 +1068,7 @@ async function updateUnsignedTxAndSendTx({
   tronResourceRentalInfo?: ITronResourceRentalInfo;
   useDefaultRpc?: boolean;
   onBeforeGasAccountFallback?: () => Promise<void>;
+  gasAccountAnalytics?: IMarketDirectSendParams['gasAccountAnalytics'];
 }): Promise<ISendTxOnSuccessData> {
   const feeInfo = buildMarketGasInfoFeeInfo(gasInfo);
 
@@ -1030,20 +1080,6 @@ async function updateUnsignedTxAndSendTx({
       feeInfo,
       tronResourceRentalInfo,
     });
-
-  await backgroundApiProxy.serviceSend.precheckUnsignedTxs({
-    networkId,
-    accountId,
-    unsignedTxs: [updatedUnsignedTxItem],
-    precheckTiming: ESendPreCheckTimingEnum.Confirm,
-  });
-
-  await backgroundApiProxy.serviceSignatureConfirm.preActionsBeforeSending({
-    accountId,
-    networkId,
-    unsignedTxs: [updatedUnsignedTxItem],
-    tronResourceRentalInfo,
-  });
 
   const {
     totalNative,
@@ -1057,37 +1093,59 @@ async function updateUnsignedTxAndSendTx({
     estimateFeeParams,
   });
 
-  await backgroundApiProxy.serviceTransaction.verifyTransaction({
+  const gasAccountAnalyticsContext = buildDirectSwapGasAccountAnalyticsContext({
+    entryPoint: 'marketSwapDirect',
     networkId,
-    accountId,
-    verifyTxTasks: ['feeInfo'],
-    verifyTxFeeInfoParams: {
-      feeAmount: totalNative,
-      feeTokenSymbol: feeInfo.common.nativeSymbol,
-      doubleConfirm: true,
-    },
-    encodedTx: updatedUnsignedTxItem.encodedTx,
+    unsignedTx: unsignedTxItem,
+    gasInfo,
+    estimateFeeParams,
+    nativeBalance: gasAccountAnalytics?.nativeBalance,
+    useGasAccountByDefault: gasAccountAnalytics?.useGasAccountByDefault,
+    fiatCurrency: gasAccountAnalytics?.fiatCurrency,
+  });
+  await runDirectSwapGasAccountStep({
+    context: gasAccountAnalyticsContext,
+    failureStage: 'precheck',
+    task: () =>
+      backgroundApiProxy.serviceSend.precheckUnsignedTxs({
+        networkId,
+        accountId,
+        unsignedTxs: [updatedUnsignedTxItem],
+        precheckTiming: ESendPreCheckTimingEnum.Confirm,
+      }),
+  });
+  await runDirectSwapGasAccountStep({
+    context: gasAccountAnalyticsContext,
+    failureStage: 'prepare',
+    task: () =>
+      backgroundApiProxy.serviceSignatureConfirm.preActionsBeforeSending({
+        accountId,
+        networkId,
+        unsignedTxs: [updatedUnsignedTxItem],
+        tronResourceRentalInfo,
+      }),
+  });
+  await runDirectSwapGasAccountStep({
+    context: gasAccountAnalyticsContext,
+    failureStage: 'precheck',
+    task: () =>
+      backgroundApiProxy.serviceTransaction.verifyTransaction({
+        networkId,
+        accountId,
+        verifyTxTasks: ['feeInfo'],
+        verifyTxFeeInfoParams: {
+          feeAmount: totalNative,
+          feeTokenSymbol: feeInfo.common.nativeSymbol,
+          doubleConfirm: true,
+        },
+        encodedTx: updatedUnsignedTxItem.encodedTx,
+      }),
   });
 
-  // When estimate-fee confirmed Gas Account sponsorship, attach the quote so the
-  // broadcast pays via the sponsor. Mirrors the transaction-confirm page.
-  const gasAccountUiState: IGasAccountUiState | undefined =
-    gasInfo.gasAccountEligible &&
-    gasInfo.payer === 'gasAccount' &&
-    gasInfo.gasAccountQuote?.quoteId
-      ? {
-          payer: gasInfo.payer,
-          gasAccountEligible: true,
-          gasAccountQuote: gasInfo.gasAccountQuote,
-          selectedPayer: 'gasAccount',
-          // Same nonce the quote was bound to at estimate-fee time.
-          lockedUserNonce:
-            typeof updatedUnsignedTxItem.nonce === 'number'
-              ? updatedUnsignedTxItem.nonce
-              : undefined,
-          idempotencyKey: `gas-account:${gasInfo.gasAccountQuote.quoteId}`,
-        }
-      : undefined;
+  const gasAccountUiState = buildDirectSwapGasAccountUiState({
+    gasInfo,
+    unsignedTx: updatedUnsignedTxItem,
+  });
 
   const sendTxParams = {
     networkId,
@@ -1097,29 +1155,20 @@ async function updateUnsignedTxAndSendTx({
     tronResourceRentalInfo,
     useDefaultRpc,
   };
-  let signedTx: Awaited<
-    ReturnType<typeof backgroundApiProxy.serviceSend.signAndSendTransaction>
-  >;
-  try {
-    signedTx = await backgroundApiProxy.serviceSend.signAndSendTransaction({
-      ...sendTxParams,
-      gasAccountUiState,
-    });
-  } catch (e) {
-    // Gas Account Fallback codes (pool exhausted, daily limit, sponsor down):
-    // drop the sponsor quote and resend once as user-paid, mirroring the
-    // confirm page. Refresh/Hint and non gas-account errors propagate to the UI
-    // (useSpeedSwapActions maps them to a sponsor toast). See useSwapBuiltTx.
-    const entry = gasAccountUiState
-      ? getGasAccountErrorEntry(getGasAccountErrorCode(e))
-      : undefined;
-    if (entry?.strategy !== EGasAccountErrorStrategy.Fallback) {
-      throw e;
-    }
-    await onBeforeGasAccountFallback?.();
-    signedTx =
-      await backgroundApiProxy.serviceSend.signAndSendTransaction(sendTxParams);
-  }
+  const signedTx = await sendDirectSwapWithGasAccountAnalytics({
+    context: gasAccountAnalyticsContext,
+    gasAccountUiState,
+    send: (uiState) =>
+      backgroundApiProxy.serviceSend.signAndSendTransaction({
+        ...sendTxParams,
+        gasAccountUiState: uiState,
+      }),
+    onGasAccountError: async (_error, entry) => {
+      if (entry.strategy === EGasAccountErrorStrategy.Fallback) {
+        await onBeforeGasAccountFallback?.();
+      }
+    },
+  });
 
   const decodedTx = await backgroundApiProxy.serviceSend.buildDecodedTx({
     networkId,
@@ -1182,6 +1231,7 @@ export async function sendMarketDirectUnsignedTxs({
   tronResourceRentalInfo,
   useDefaultRpc,
   validateFinalGasInfos,
+  gasAccountAnalytics,
 }: IMarketDirectSendParams): Promise<ISendTxOnSuccessData[]> {
   if (!accountId || !networkId || !accountAddress) {
     throw new OneKeyError('account error');
@@ -1269,6 +1319,7 @@ export async function sendMarketDirectUnsignedTxs({
                 ),
               )
           : undefined,
+        gasAccountAnalytics,
       }),
     );
   }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -20,6 +20,7 @@ import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accoun
 import { useSelectedDeriveTypeAtom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2/atoms';
 import { getGasAccountErrorEntry } from '@onekeyhq/kit/src/views/SignatureConfirm/constants/gasAccountErrorCodes';
 import { type ISwapReviewStepTexts } from '@onekeyhq/kit/src/views/Swap/utils/buildSwapReviewState';
+import { logDirectSwapGasAccountDecision } from '@onekeyhq/kit/src/views/Swap/utils/gasAccountAnalytics';
 import {
   checkSwapLatestBalanceSufficient,
   getSwapRequiredNativeBalanceAmount,
@@ -57,6 +58,7 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { ESwapEventAPIStatus } from '@onekeyhq/shared/src/logger/scopes/swap/scenes/swapEstimateFee';
+import type { IGasAccountAnalyticsContext } from '@onekeyhq/shared/src/logger/scopes/transaction/types';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import stringUtils from '@onekeyhq/shared/src/utils/stringUtils';
 import {
@@ -155,6 +157,8 @@ type IMarketReviewExecutionSnapshot = {
   buildUnsignedParams: ISendTxBaseParams & IBuildUnsignedTxParams;
   swapInfo: ISwapTxInfo;
   buildRes?: IFetchBuildTxResponse;
+  gasAccountAnalyticsContext?: IGasAccountAnalyticsContext;
+  gasAccountAnalyticsNativeBalance?: string;
   // customPriorityFee is owned by the swapStepNetFeeLevel atom; never snapshot
   // it here, or a cleared preset fee would resurrect via `?? snapshot.value`.
 };
@@ -419,6 +423,9 @@ export function useSpeedSwapActions(props: {
   const reviewExecutionSnapshotRef = useRef<
     IMarketReviewExecutionSnapshot | undefined
   >(undefined);
+  const gasAccountDecisionSnapshotsRef = useRef(
+    new WeakSet<IMarketReviewExecutionSnapshot>(),
+  );
   const defaultMarketSpeedCheckState = useMemo(
     () => buildDefaultMarketSpeedCheckState(),
     [],
@@ -1314,6 +1321,13 @@ export function useSpeedSwapActions(props: {
             approveUnsignedTxArr,
             networkFeeLevel,
             customPriorityFee,
+            gasAccountAnalytics:
+              snapshot.kind === 'swap'
+                ? {
+                    fiatCurrency: settingsAtom.currencyInfo.id,
+                    useGasAccountByDefault: settingsAtom.useGasAccountByDefault,
+                  }
+                : undefined,
           });
 
           if (
@@ -1324,6 +1338,16 @@ export function useSpeedSwapActions(props: {
               ...snapshot.buildUnsignedParams,
               encodedTx: feeState.preparedUnsignedTx.encodedTx,
             };
+          }
+
+          if (
+            feeState.gasAccountAnalyticsContext &&
+            reviewExecutionSnapshotRef.current === snapshot
+          ) {
+            snapshot.gasAccountAnalyticsContext =
+              feeState.gasAccountAnalyticsContext;
+            snapshot.gasAccountAnalyticsNativeBalance =
+              feeState.gasAccountAnalyticsNativeBalance;
           }
 
           netWorkFee = {
@@ -1362,6 +1386,7 @@ export function useSpeedSwapActions(props: {
       buildReviewStepTexts,
       currencyMap,
       settingsAtom.currencyInfo.id,
+      settingsAtom.useGasAccountByDefault,
       slippage,
     ],
   );
@@ -1652,6 +1677,19 @@ export function useSpeedSwapActions(props: {
     },
     [],
   );
+
+  const logMarketReviewGasAccountDecision = useCallback(() => {
+    const snapshot = reviewExecutionSnapshotRef.current;
+    if (snapshot?.kind !== 'swap' || !snapshot.gasAccountAnalyticsContext) {
+      return;
+    }
+
+    if (!gasAccountDecisionSnapshotsRef.current.has(snapshot)) {
+      gasAccountDecisionSnapshotsRef.current.add(snapshot);
+      logDirectSwapGasAccountDecision(snapshot.gasAccountAnalyticsContext);
+    }
+    return snapshot.gasAccountAnalyticsContext;
+  }, []);
 
   const openMarketFallbackTxConfirm = useCallback(
     async ({
@@ -2240,6 +2278,11 @@ export function useSpeedSwapActions(props: {
           gasInfos,
           networkFeeLevel,
           customPriorityFee,
+          gasAccountAnalytics: {
+            fiatCurrency: settingsAtom.currencyInfo.id,
+            nativeBalance: snapshot.gasAccountAnalyticsNativeBalance,
+            useGasAccountByDefault: settingsAtom.useGasAccountByDefault,
+          },
         });
         const result = await handleMarketSwapBuildTxSuccess(data);
         if (result) {
@@ -2295,6 +2338,8 @@ export function useSpeedSwapActions(props: {
       logMarketCreateOrder,
       openMarketFallbackTxConfirm,
       requireReviewExecutionSnapshot,
+      settingsAtom.currencyInfo.id,
+      settingsAtom.useGasAccountByDefault,
     ],
   );
 
@@ -3110,6 +3155,7 @@ export function useSpeedSwapActions(props: {
     speedCheckLoading,
     estimateMarketPresetNetworkFees,
     prepareMarketSwapReview,
+    logMarketReviewGasAccountDecision,
     sendMarketApproveTx,
     sendMarketSwapTx,
     sendMarketWrappedTx,

--- a/packages/kit/src/views/Market/components/MarketHomeHeaderSearchBar.tsx
+++ b/packages/kit/src/views/Market/components/MarketHomeHeaderSearchBar.tsx
@@ -5,10 +5,11 @@ import { useIntl } from 'react-intl';
 import { SearchBar, Shortcut, View, XStack } from '@onekeyhq/components';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
-import { EModalRoutes } from '@onekeyhq/shared/src/routes';
+import { EModalRoutes, ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { EUniversalSearchPages } from '@onekeyhq/shared/src/routes/universalSearch';
 import { EShortcutEvents } from '@onekeyhq/shared/src/shortcuts/shortcuts.enum';
 
+import { getUniversalSearchSource } from '../../UniversalSearch/universalSearchSource';
 import { MarketTestIDs } from '../testIDs';
 
 export function MarketHomeHeaderSearchBar() {
@@ -17,6 +18,9 @@ export function MarketHomeHeaderSearchBar() {
   const toUniversalSearchPage = useCallback(() => {
     navigation.pushModal(EModalRoutes.UniversalSearchModal, {
       screen: EUniversalSearchPages.UniversalSearch,
+      params: {
+        source: getUniversalSearchSource(ETabRoutes.Market),
+      },
     });
   }, [navigation]);
 

--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -814,12 +814,15 @@ export function PerpOrderBook({
   );
 
   const mobileMaxLevelsPerSide = useMemo(() => {
+    // Spot settles on its own level count, and the perps account flags read
+    // true until the account address resolves, so checking them first made every
+    // spot cold start render 7 levels and then collapse the first-screen grid.
+    if (activeTradeInstrument.mode === 'spot')
+      return MOBILE_SPOT_MAX_LEVELS_PER_SIDE;
     if (shouldCompactOrderBookForFirstDeposit) return 5;
     if (shouldShowEnableTradingButton) {
       return shouldCompactOrderBookForConnectWallet ? 6 : 7;
     }
-    if (activeTradeInstrument.mode === 'spot')
-      return MOBILE_SPOT_MAX_LEVELS_PER_SIDE;
     if (formData.hasTpsl) return 9;
     return 7;
   }, [

--- a/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
+++ b/packages/kit/src/views/Perp/components/TokenSelector/PerpTokenSelector.tsx
@@ -27,6 +27,7 @@ import {
   Tooltip,
   XStack,
   YStack,
+  useIsSplitMainActive,
   usePopoverContext,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
@@ -1584,6 +1585,7 @@ const BasePerpTokenSelectorMobileView = memo(
     return (
       <DebugRenderTracker name="BasePerpTokenSelectorMobileView">
         <XStack
+          testID={PerpTestIDs.TokenSelectorMobile}
           gap="$1"
           bg="$bgApp"
           justifyContent="center"
@@ -1603,6 +1605,7 @@ BasePerpTokenSelectorMobileView.displayName = 'BasePerpTokenSelectorMobileView';
 function BasePerpTokenSelectorMobile() {
   const navigation = useAppNavigation();
   const [activePerpsAccount] = usePerpsActiveAccountAtom();
+  const isSplitMainActive = useIsSplitMainActive();
   const prewarmTokenSelectorImages = usePrewarmPerpsTokenSelectorImages();
   const isOpeningRef = useRef(false);
   // Only low-frequency fields here (coin/displayName/mode change on coin
@@ -1633,12 +1636,16 @@ function BasePerpTokenSelectorMobile() {
       tradeMode: mode === 'spot' ? 'spot' : 'perp',
       walletType: activePerpsAccount.walletType ?? 'unknown',
     });
-    navigation.pushModal(EModalRoutes.PerpModal, {
+    const openTokenSelector = isSplitMainActive
+      ? navigation.pushFullModal
+      : navigation.pushModal;
+    openTokenSelector(EModalRoutes.PerpModal, {
       screen: EModalPerpRoutes.MobileTokenSelector,
     });
   }, [
     activePerpsAccount.walletType,
     coin,
+    isSplitMainActive,
     mode,
     navigation,
     prewarmTokenSelectorImages,

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -2,7 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useHeaderHeight } from '@react-navigation/elements';
 import { useIntl } from 'react-intl';
-import { Dimensions, type LayoutChangeEvent } from 'react-native';
+import {
+  Dimensions,
+  type LayoutChangeEvent,
+  useWindowDimensions,
+} from 'react-native';
 
 import type { IScrollViewRef } from '@onekeyhq/components';
 import {
@@ -309,7 +313,13 @@ function MobilePerpMarket() {
   ]);
 
   const isSplitDetailActive = useIsSplitDetailActive();
-
+  const { height: windowHeight } = useWindowDimensions();
+  // Android native tabs measure the inline SUB page by intrinsic content, so
+  // its flex-only chart needs an explicit viewport bound to avoid collapsing.
+  const splitDetailPageMinHeight =
+    isSplitDetailActive && platformEnv.isNativeAndroid
+      ? windowHeight
+      : undefined;
   const handleInteractionOverlayOpenChange = useCallback((isOpen: boolean) => {
     setIsTradingViewInteractionOverlayOpen(isOpen);
   }, []);
@@ -558,7 +568,7 @@ function MobilePerpMarket() {
       scrollProps={pageScrollProps}
     >
       {pageHeader}
-      <Page.Body p="$0">
+      <Page.Body p="$0" minHeight={splitDetailPageMinHeight}>
         {inlineHeader}
         <YStack
           flex={1}

--- a/packages/kit/src/views/Setting/pages/ClearAppCache/index.tsx
+++ b/packages/kit/src/views/Setting/pages/ClearAppCache/index.tsx
@@ -37,6 +37,7 @@ export default function ClearAppCache() {
       customRpc: false,
       customNetworkFee: false,
       serverNetworks: false,
+      perpsData: false,
     } as IClearCacheOnAppState,
   });
   const { copyText } = useClipboard();
@@ -171,6 +172,13 @@ export default function ClearAppCache() {
                   />
                 </Form.Field>
               )}
+              <Form.Field name="perpsData">
+                <Checkbox
+                  label={intl.formatMessage({
+                    id: ETranslations.global_perp,
+                  })}
+                />
+              </Form.Field>
             </YStack>
           </Form>
         </Stack>

--- a/packages/kit/src/views/Setting/pages/Tab/SubSettingsPage.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/SubSettingsPage.tsx
@@ -93,7 +93,9 @@ export function SubSettingsPage({
     isMobileLayout && config?.name === ESettingsTabNames.About;
 
   return (
-    <Page scrollEnabled backgroundColor={pageBackgroundColor}>
+    {/* Page must not scroll: the inner ScrollView owns scrolling so iPad's
+        contentInsetAdjustmentBehavior applies to the right scroller (#12813). */}
+    <Page backgroundColor={pageBackgroundColor}>
       <Page.Header
         {...(headerBackgroundColor
           ? { headerContainerBackgroundColor: headerBackgroundColor }
@@ -114,6 +116,7 @@ export function SubSettingsPage({
       />
       <Page.Body>
         <ScrollView
+          contentInsetAdjustmentBehavior="automatic"
           keyboardShouldPersistTaps="handled"
           contentContainerStyle={{ pb: '$10' }}
         >

--- a/packages/kit/src/views/Setting/pages/Tab/SubSettingsPage.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/SubSettingsPage.tsx
@@ -92,9 +92,9 @@ export function SubSettingsPage({
   const isMobileAboutPage =
     isMobileLayout && config?.name === ESettingsTabNames.About;
 
+  // Page must not scroll: the inner ScrollView owns scrolling so iPad's
+  // contentInsetAdjustmentBehavior applies to the right scroller (#12813).
   return (
-    {/* Page must not scroll: the inner ScrollView owns scrolling so iPad's
-        contentInsetAdjustmentBehavior applies to the right scroller (#12813). */}
     <Page backgroundColor={pageBackgroundColor}>
       <Page.Header
         {...(headerBackgroundColor

--- a/packages/kit/src/views/Setting/pages/Tab/config.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/config.tsx
@@ -207,6 +207,7 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
       updateStatus: appUpdateInfo.data.status,
     });
   }, [appUpdateInfo.data.updateStrategy, appUpdateInfo.data.status]);
+  const shouldShowUpdate = isShowAppUpdateUI && appUpdateInfo.isNeedUpdate;
   const intl = useIntl();
   const { isMobileLayout } = useSettingsLayout();
   const onPressAddressBook = useShowAddressBook({
@@ -870,14 +871,14 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
         title: intl.formatMessage({
           id: ETranslations.about_onekey__title,
         }),
-        showDot: isShowAppUpdateUI && !!appUpdateInfo.isNeedUpdate,
+        showDot: shouldShowUpdate,
         configs: [
           [
             {
               id: 'whats-new',
               icon: 'InfoCircleOutline',
               title: intl.formatMessage({
-                id: appUpdateInfo.isNeedUpdate
+                id: shouldShowUpdate
                   ? ETranslations.settings_app_update_available
                   : ETranslations.settings_whats_new,
               }),
@@ -1093,8 +1094,7 @@ export const useSettingsConfig: () => ISettingsConfig = () => {
     biometricAuthInfo.title,
     biometricAuthInfo.icon,
     settings.hardwareTransportType,
-    isShowAppUpdateUI,
-    appUpdateInfo.isNeedUpdate,
+    shouldShowUpdate,
     devSettings.enabled,
     isKeylessWalletExistsLocal,
     startBackup,

--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmActions/TxConfirmActions.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmActions/TxConfirmActions.tsx
@@ -41,6 +41,7 @@ import {
   useTxFeeInfoInitAtom,
   useUnsignedTxsAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/signatureConfirm';
+import { useGasAccountAnalyticsContext } from '@onekeyhq/kit/src/views/SignatureConfirm/hooks/useGasAccountAnalyticsContext';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { ITransferPayload } from '@onekeyhq/kit-bg/src/vaults/types';
 import type { IOneKeyError } from '@onekeyhq/shared/src/errors/types/errorTypes';
@@ -54,6 +55,10 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import type {
+  IGasAccountActionParams,
+  IGasAccountAnalyticsContext,
+} from '@onekeyhq/shared/src/logger/scopes/transaction/types';
 import type { IModalSendParamList } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { checkIsEmptyData } from '@onekeyhq/shared/src/utils/evmUtils';
@@ -78,6 +83,7 @@ import {
 } from '../../constants/gasAccountErrorCodes';
 import { usePreCheckFeeInfo } from '../../hooks/usePreCheckFeeInfo';
 import { SignatureConfirmTestIDs } from '../../testIDs';
+import { isGasSponsoredAnalyticsContext } from '../../utils/gasAccountAnalytics';
 import { showCustomHexDataAlert } from '../CustomHexDataAlert';
 import TxFeeInfo from '../TxFee';
 
@@ -111,6 +117,11 @@ type IProps = {
   // peer can't push through an `eth_sendTransaction` without acknowledgement.
   forceTakeRiskAlert?: boolean;
 };
+
+type IGasAccountActionDetails = Omit<
+  IGasAccountActionParams,
+  keyof IGasAccountAnalyticsContext
+>;
 
 function TxConfirmActions(props: IProps) {
   const {
@@ -196,6 +207,74 @@ function TxConfirmActions(props: IProps) {
     gasAccountUiState.selectedPayer === 'gasAccount' &&
     !!gasAccountUiState.gasAccountQuote?.quoteId;
   const isFeeSponsored = isMegafuelSponsored || isGasAccountSponsored;
+  const gasAccountAnalyticsContext = useGasAccountAnalyticsContext({
+    networkId,
+    gasAccountScenario,
+    isPrivateSend: transferPayload?.isPrivateSend === true,
+  });
+  const gasAccountActionSessionKey =
+    unsignedTx?.uuid ??
+    `${networkId}:${gasAccountAnalyticsContext?.scenario ?? gasAccountScenario ?? 'unknown'}`;
+  const gasAccountActionSessionRef = useRef<{
+    key: string;
+    context?: IGasAccountAnalyticsContext;
+    effectiveFeePayer?: IGasAccountAnalyticsContext['effectiveFeePayer'];
+  }>({ key: gasAccountActionSessionKey });
+  if (gasAccountActionSessionRef.current.key !== gasAccountActionSessionKey) {
+    gasAccountActionSessionRef.current = { key: gasAccountActionSessionKey };
+  }
+  if (isGasSponsoredAnalyticsContext(gasAccountAnalyticsContext)) {
+    gasAccountActionSessionRef.current.context = gasAccountAnalyticsContext;
+    gasAccountActionSessionRef.current.effectiveFeePayer =
+      gasAccountAnalyticsContext.effectiveFeePayer;
+  }
+
+  const logGasAccountAction = useCallback(
+    (details: IGasAccountActionDetails) => {
+      const session = gasAccountActionSessionRef.current;
+      if (!session.context) {
+        return;
+      }
+      defaultLogger.transaction.send.gasAccountAction({
+        ...session.context,
+        effectiveFeePayer:
+          session.effectiveFeePayer ?? session.context.effectiveFeePayer,
+        ...details,
+      });
+      if (details.action === 'payerChanged' && details.toPayer) {
+        session.effectiveFeePayer = details.toPayer;
+      }
+    },
+    [],
+  );
+
+  const logGasAccountSubmitFailed = useCallback(
+    (
+      error: unknown,
+      failureStage: NonNullable<IGasAccountActionParams['failureStage']>,
+    ) => {
+      logGasAccountAction({
+        action: 'submitFailed',
+        failureStage,
+        errorCode: getGasAccountErrorCode(error),
+      });
+    },
+    [logGasAccountAction],
+  );
+
+  const gasAccountDecisionKeyRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (!gasAccountAnalyticsContext) {
+      return;
+    }
+    if (gasAccountDecisionKeyRef.current === gasAccountActionSessionKey) {
+      return;
+    }
+    gasAccountDecisionKeyRef.current = gasAccountActionSessionKey;
+    defaultLogger.transaction.send.gasAccountDecision(
+      gasAccountAnalyticsContext,
+    );
+  }, [gasAccountActionSessionKey, gasAccountAnalyticsContext]);
 
   const dappApprove = useDappApproveAction({
     id: sourceInfo?.id ?? '',
@@ -252,6 +331,14 @@ function TxConfirmActions(props: IProps) {
 
       if (entry.strategy === EGasAccountErrorStrategy.Fallback) {
         muteHandledErrorToast(error);
+        logGasAccountAction({
+          action: 'payerChanged',
+          fromPayer: 'gasAccount',
+          toPayer: 'user',
+          changeSource: 'system',
+          changeReason: 'submitFailed',
+          errorCode: code,
+        });
         updateEffectiveFeePayer('user');
         updateGasAccountTemporarilyDisabled(true);
         resetGasAccountUiState();
@@ -281,6 +368,7 @@ function TxConfirmActions(props: IProps) {
     },
     [
       gasAccountUiState.selectedPayer,
+      logGasAccountAction,
       networkId,
       resetGasAccountTemporarilyDisabled,
       resetGasAccountUiState,
@@ -347,6 +435,7 @@ function TxConfirmActions(props: IProps) {
         feeInfos: sendSelectedFeeInfo?.feeInfos,
       });
     } catch (e: any) {
+      logGasAccountSubmitFailed(e, 'precheck');
       updateSendTxStatus({ isSubmitting: false });
       onFail?.(e as Error);
       isSubmitted.current = false;
@@ -370,6 +459,7 @@ function TxConfirmActions(props: IProps) {
         navigation.popStack();
       }
     } catch (e: any) {
+      logGasAccountSubmitFailed(e, 'prepare');
       updateSendTxStatus({ isSubmitting: false });
       onFail?.(e as Error);
       isSubmitted.current = false;
@@ -409,6 +499,7 @@ function TxConfirmActions(props: IProps) {
         tronResourceRentalInfo,
       });
     } catch (e: any) {
+      logGasAccountSubmitFailed(e, 'prepare');
       updateSendTxStatus({ isSubmitting: false });
       onFail?.(e as Error);
       isSubmitted.current = false;
@@ -442,6 +533,7 @@ function TxConfirmActions(props: IProps) {
       }
     }
 
+    let transactionSubmitted = false;
     try {
       await onBeforeSend?.();
     } catch (error) {
@@ -519,6 +611,9 @@ function TxConfirmActions(props: IProps) {
         isSubmitted.current = false;
         return;
       }
+
+      transactionSubmitted = true;
+      logGasAccountAction({ action: 'submitSucceeded' });
 
       if (vaultSettings?.afterSendTxActionEnabled) {
         await backgroundApiProxy.serviceSignatureConfirm.afterSendTxAction({
@@ -668,6 +763,9 @@ function TxConfirmActions(props: IProps) {
         gasAccountSubmitIdRef.current = null;
         return;
       }
+      if (!transactionSubmitted) {
+        logGasAccountSubmitFailed(e, 'submit');
+      }
       const gasAccountStrategy = handleGasAccountSubmitError(e);
       // Refresh and Fallback both keep the user on the confirm page with a
       // fresh estimate in flight, so the dApp caller should also keep waiting.
@@ -727,6 +825,8 @@ function TxConfirmActions(props: IProps) {
     signOnly,
     transferPayload,
     handleGasAccountSubmitError,
+    logGasAccountAction,
+    logGasAccountSubmitFailed,
     intl,
     onSuccess,
     isQueueMode,
@@ -741,6 +841,7 @@ function TxConfirmActions(props: IProps) {
   ]);
 
   const handleOnConfirm = useCallback(async () => {
+    logGasAccountAction({ action: 'confirmClicked' });
     if (decodedTxs[0]?.isCustomHexData) {
       showCustomHexDataAlert({
         decodedTx: decodedTxs[0],
@@ -752,7 +853,12 @@ function TxConfirmActions(props: IProps) {
     } else {
       await submitTxs();
     }
-  }, [decodedTxs, submitTxs, transferPayload?.originalRecipient]);
+  }, [
+    decodedTxs,
+    logGasAccountAction,
+    submitTxs,
+    transferPayload?.originalRecipient,
+  ]);
 
   const cancelCalledRef = useRef(false);
   // If a 90212 retry loop is in flight, tear it down before the flow
@@ -776,9 +882,12 @@ function TxConfirmActions(props: IProps) {
       return;
     }
     cancelCalledRef.current = true;
+    if (!isSubmitted.current) {
+      logGasAccountAction({ action: 'exited' });
+    }
     abortPendingGasAccountSubmit();
     onCancel?.();
-  }, [abortPendingGasAccountSubmit, onCancel]);
+  }, [abortPendingGasAccountSubmit, logGasAccountAction, onCancel]);
 
   const handleOnCancel = useCallback(
     (close: () => void, closePageStack: () => void) => {
@@ -928,13 +1037,25 @@ function TxConfirmActions(props: IProps) {
     if (isGasAccountQuoteExpired) {
       if (quoteExpiredHandledRef.current) return;
       quoteExpiredHandledRef.current = true;
+      logGasAccountAction({
+        action: 'payerChanged',
+        fromPayer: 'gasAccount',
+        toPayer: 'user',
+        changeSource: 'system',
+        changeReason: 'quoteExpired',
+      });
       resetGasAccountUiState();
       updateTxFeeInfoInit(false);
       appEventBus.emit(EAppEventBusNames.EstimateTxFeeRetry, undefined);
     } else {
       quoteExpiredHandledRef.current = false;
     }
-  }, [isGasAccountQuoteExpired, resetGasAccountUiState, updateTxFeeInfoInit]);
+  }, [
+    isGasAccountQuoteExpired,
+    logGasAccountAction,
+    resetGasAccountUiState,
+    updateTxFeeInfoInit,
+  ]);
 
   const isConfirmInitializing = useMemo(
     () => !txFeeInfoInit || !decodedTxsInit || isBuildingDecodedTxs,

--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmAlert/TxConfirmAlert.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmAlert/TxConfirmAlert.tsx
@@ -19,6 +19,7 @@ import {
   useTronResourceRentalInfoAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/signatureConfirm';
 import { showCustomRpcFallbackDialog } from '@onekeyhq/kit/src/views/Send/components/CustomRpcFallbackDialog';
+import { useGasAccountAnalyticsContext } from '@onekeyhq/kit/src/views/SignatureConfirm/hooks/useGasAccountAnalyticsContext';
 import type { ITransferPayload } from '@onekeyhq/kit-bg/src/vaults/types';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import {
@@ -31,16 +32,18 @@ import { EModalReceiveRoutes, EModalRoutes } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { ESendFeeStatus } from '@onekeyhq/shared/types/fee';
+import type { IGasAccountScenario } from '@onekeyhq/shared/types/fee';
 import type { IToken } from '@onekeyhq/shared/types/token';
 
 interface IProps {
   accountId: string;
   networkId: string;
   transferPayload?: ITransferPayload;
+  gasAccountScenario?: IGasAccountScenario;
 }
 
 function TxConfirmAlert(props: IProps) {
-  const { networkId, accountId, transferPayload } = props;
+  const { networkId, accountId, transferPayload, gasAccountScenario } = props;
 
   const intl = useIntl();
   const navigation = useAppNavigation();
@@ -57,6 +60,11 @@ function TxConfirmAlert(props: IProps) {
   const [customRpcStatus] = useCustomRpcStatusAtom();
   const { updateCustomRpcStatus, clearCustomRpcStatus } =
     useSignatureConfirmActions().current;
+  const gasAccountAnalyticsContext = useGasAccountAnalyticsContext({
+    networkId,
+    gasAccountScenario,
+    isPrivateSend: transferPayload?.isPrivateSend === true,
+  });
 
   // Single source of truth for the token-fee alert gate so logging and
   // rendering can't drift (pay-with-token disabled → native alert).
@@ -71,6 +79,7 @@ function TxConfirmAlert(props: IProps) {
     if (isInsufficient && !insufficientFeeLoggedRef.current) {
       insufficientFeeLoggedRef.current = true;
       defaultLogger.transaction.send.insufficientFeeOnConfirm({
+        ...gasAccountAnalyticsContext,
         network: networkId,
         tokenSymbol: isTokenFeeAlert
           ? (payWithTokenInfo.symbol ?? network?.symbol)
@@ -87,6 +96,7 @@ function TxConfirmAlert(props: IProps) {
     sendTxStatus.isInsufficientTokenBalance,
     sendTxStatus.fillUpNativeBalance,
     sendTxStatus.fillUpTokenBalance,
+    gasAccountAnalyticsContext,
     networkId,
     network?.symbol,
     payWithTokenInfo.symbol,

--- a/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
@@ -607,7 +607,12 @@ function TxFeeInfo(props: IProps) {
           gasAccountDisabledByScenario
         ) {
           resetGasAccountUiState();
-          if (
+          if (isCustomRpcEnabled) {
+            updateGasAccountUiState({
+              payer: 'user',
+              sponsorDisabledByCustomRpc: true,
+            });
+          } else if (
             gasAccountTemporarilyDisabled ||
             sponsorDisabledForBatch ||
             sponsorDisabledForPrivateSend ||
@@ -637,6 +642,7 @@ function TxFeeInfo(props: IProps) {
                 ? buildGasAccountIdempotencyKey(r.gasAccountQuote.quoteId)
                 : '',
             gasAccountScenarioReason: r.gasAccountScenarioReason,
+            sponsorDisabledByCustomRpc: false,
           });
         } else {
           resetGasAccountUiState();

--- a/packages/kit/src/views/SignatureConfirm/hooks/useGasAccountAnalyticsContext.ts
+++ b/packages/kit/src/views/SignatureConfirm/hooks/useGasAccountAnalyticsContext.ts
@@ -1,0 +1,159 @@
+import { useMemo } from 'react';
+
+import {
+  useEffectiveFeePayerAtom,
+  useExtraFeeInfoAtom,
+  useGasAccountTemporarilyDisabledAtom,
+  useGasAccountUiStateAtom,
+  useNativeTokenInfoAtom,
+  useNativeTokenTransferAmountToUpdateAtom,
+  useSendFeeStatusAtom,
+  useSendSelectedFeeInfoAtom,
+  useSendTxStatusAtom,
+  useTxFeeInfoInitAtom,
+  useUnsignedTxsAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/signatureConfirm';
+import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import type { IGasAccountAnalyticsContext } from '@onekeyhq/shared/src/logger/scopes/transaction/types';
+import {
+  ESendFeeStatus,
+  GAS_ACCOUNT_DISABLED_SCENARIOS,
+  type IGasAccountDisabledScenario,
+  type IGasAccountScenario,
+} from '@onekeyhq/shared/types/fee';
+
+import { buildGasAccountAnalyticsContext } from '../utils/gasAccountAnalytics';
+
+export function useGasAccountAnalyticsContext({
+  networkId,
+  gasAccountScenario,
+  isPrivateSend,
+}: {
+  networkId: string;
+  gasAccountScenario: IGasAccountScenario | undefined;
+  isPrivateSend: boolean;
+}): IGasAccountAnalyticsContext | undefined {
+  const [settings] = useSettingsPersistAtom();
+  const [txFeeInfoInit] = useTxFeeInfoInitAtom();
+  const [sendFeeStatus] = useSendFeeStatusAtom();
+  const [sendSelectedFeeInfo] = useSendSelectedFeeInfoAtom();
+  const [nativeTokenInfo] = useNativeTokenInfoAtom();
+  const [nativeTokenTransferAmountToUpdate] =
+    useNativeTokenTransferAmountToUpdateAtom();
+  const [extraFeeInfo] = useExtraFeeInfoAtom();
+  const [sendTxStatus] = useSendTxStatusAtom();
+  const [gasAccountUiState] = useGasAccountUiStateAtom();
+  const [effectiveFeePayer] = useEffectiveFeePayerAtom();
+  const [gasAccountTemporarilyDisabled] =
+    useGasAccountTemporarilyDisabledAtom();
+  const [unsignedTxs] = useUnsignedTxsAtom();
+
+  return useMemo(() => {
+    if (
+      !txFeeInfoInit ||
+      sendFeeStatus.status !== ESendFeeStatus.Success ||
+      !sendSelectedFeeInfo ||
+      nativeTokenInfo.isLoading
+    ) {
+      return undefined;
+    }
+
+    const disabledByScenario = GAS_ACCOUNT_DISABLED_SCENARIOS.includes(
+      gasAccountScenario as IGasAccountDisabledScenario,
+    );
+    const disabledForBatch = unsignedTxs.length > 1;
+    const disabledByCustomRpc = gasAccountUiState.sponsorDisabledByCustomRpc;
+    const clientUnsupported =
+      disabledByScenario ||
+      isPrivateSend ||
+      disabledForBatch ||
+      disabledByCustomRpc;
+    const gasAccountRequested =
+      settings.useGasAccountByDefault !== false &&
+      !clientUnsupported &&
+      !gasAccountTemporarilyDisabled;
+    const hasEligibleQuote = Boolean(
+      gasAccountUiState.gasAccountEligible &&
+      gasAccountUiState.gasAccountQuote?.quoteId,
+    );
+    const gasAccountEligible = gasAccountRequested ? hasEligibleQuote : null;
+    let gasAccountSupported: boolean | null = null;
+    if (hasEligibleQuote) {
+      gasAccountSupported = true;
+    } else if (
+      clientUnsupported ||
+      gasAccountUiState.gasAccountScenarioReason
+    ) {
+      gasAccountSupported = false;
+    }
+
+    let unavailableReason: string | undefined;
+    if (!hasEligibleQuote) {
+      if (settings.useGasAccountByDefault === false) {
+        unavailableReason = 'userDisabled';
+      } else if (disabledByCustomRpc) {
+        unavailableReason = 'customRpcEnabled';
+      } else if (disabledByScenario) {
+        unavailableReason = 'unsupportedScenario';
+      } else if (isPrivateSend) {
+        unavailableReason = 'privateSend';
+      } else if (disabledForBatch) {
+        unavailableReason = 'batchTransaction';
+      } else if (gasAccountTemporarilyDisabled) {
+        unavailableReason = 'temporarilyDisabled';
+      } else {
+        unavailableReason =
+          gasAccountUiState.gasAccountScenarioReason ?? 'backend_unknown';
+      }
+    }
+
+    const nativeTokenPrice =
+      sendSelectedFeeInfo.feeInfos[0]?.feeInfo.common?.nativeTokenPrice;
+
+    return buildGasAccountAnalyticsContext({
+      entryPoint: 'txConfirm',
+      network: networkId,
+      scenario: gasAccountScenario,
+      gasAccountRequested,
+      gasAccountSupported,
+      gasAccountEligible,
+      selectedPayer: gasAccountUiState.selectedPayer ?? 'user',
+      effectiveFeePayer,
+      unavailableReason,
+      estimatedGasNative:
+        sendSelectedFeeInfo.originalTotalNative ??
+        sendSelectedFeeInfo.totalNative,
+      nativeBalance: nativeTokenInfo.balance,
+      nativePrincipal: nativeTokenTransferAmountToUpdate.amountToUpdate,
+      extraFeeNative: extraFeeInfo.feeNative,
+      nativeTokenPrice,
+      fiatCurrency: settings.currencyInfo.id,
+      tokenPrincipalInsufficient: Boolean(
+        sendTxStatus.isInsufficientTokenBalance,
+      ),
+      quoteId: gasAccountUiState.gasAccountQuote?.quoteId,
+    });
+  }, [
+    effectiveFeePayer,
+    extraFeeInfo.feeNative,
+    gasAccountScenario,
+    gasAccountTemporarilyDisabled,
+    gasAccountUiState.gasAccountEligible,
+    gasAccountUiState.gasAccountQuote?.quoteId,
+    gasAccountUiState.gasAccountScenarioReason,
+    gasAccountUiState.selectedPayer,
+    gasAccountUiState.sponsorDisabledByCustomRpc,
+    isPrivateSend,
+    nativeTokenInfo.balance,
+    nativeTokenInfo.isLoading,
+    nativeTokenTransferAmountToUpdate.amountToUpdate,
+    networkId,
+    sendSelectedFeeInfo,
+    sendFeeStatus.status,
+    sendTxStatus.isInsufficientTokenBalance,
+    settings.currencyInfo.id,
+    settings.useGasAccountByDefault,
+    txFeeInfoInit,
+    unsignedTxs.length,
+  ]);
+}

--- a/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
+++ b/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
@@ -84,6 +84,7 @@ function TxConfirm() {
     unsignedTxs,
     isQueueMode,
     unsignedTxQueue,
+    gasAccountScenario,
   } = route.params;
 
   const {
@@ -460,6 +461,7 @@ function TxConfirm() {
           networkId={networkId}
           accountId={accountId}
           transferPayload={transferPayload}
+          gasAccountScenario={gasAccountScenario}
         />
         {sourceInfo?.origin ? (
           <DAppSiteMark
@@ -499,6 +501,7 @@ function TxConfirm() {
     networkId,
     accountId,
     transferPayload,
+    gasAccountScenario,
     sourceInfo?.origin,
     urlSecurityInfo,
     securityCheckRequestKey,

--- a/packages/kit/src/views/SignatureConfirm/utils/gasAccountAnalytics.test.ts
+++ b/packages/kit/src/views/SignatureConfirm/utils/gasAccountAnalytics.test.ts
@@ -1,0 +1,118 @@
+import {
+  buildGasAccountAnalyticsContext,
+  isGasSponsoredAnalyticsContext,
+} from './gasAccountAnalytics';
+
+const baseParams = {
+  entryPoint: 'txConfirm' as const,
+  network: 'evm--1',
+  scenario: 'send' as const,
+  gasAccountRequested: true,
+  gasAccountSupported: true,
+  gasAccountEligible: true,
+  selectedPayer: 'gasAccount' as const,
+  effectiveFeePayer: 'gasAccount' as const,
+  unavailableReason: undefined,
+  estimatedGasNative: '0.01',
+  nativeBalance: '0.105',
+  nativePrincipal: '0.1',
+  extraFeeNative: '0',
+  nativeTokenPrice: '2000',
+  fiatCurrency: 'usd',
+  tokenPrincipalInsufficient: false,
+  quoteId: 'quote-id',
+};
+
+describe('buildGasAccountAnalyticsContext', () => {
+  it('classifies a same-native-token transfer as a network fee shortage', () => {
+    const result = buildGasAccountAnalyticsContext(baseParams);
+
+    expect(result.shortageType).toBe('networkFee');
+    expect(result.gasShortfallNative).toBe('0.005');
+    expect(result.gasShortfallFiat).toBe('10');
+    expect(result.gasShortfallFiatBucket).toBe('gte_5');
+    expect(result.selfPayGasSufficient).toBe(false);
+  });
+
+  it('uses the first blocking cause for a same-native-token shortage', () => {
+    const result = buildGasAccountAnalyticsContext({
+      ...baseParams,
+      nativeBalance: '0.09',
+    });
+
+    expect(result.shortageType).toBe('principal');
+  });
+
+  it('uses mixed only when token principal and native gas are both short', () => {
+    const result = buildGasAccountAnalyticsContext({
+      ...baseParams,
+      nativePrincipal: '0',
+      nativeBalance: '0.005',
+      tokenPrincipalInsufficient: true,
+    });
+
+    expect(result.shortageType).toBe('mixed');
+  });
+
+  it('marks fiat fields unavailable when the native token has no price', () => {
+    const result = buildGasAccountAnalyticsContext({
+      ...baseParams,
+      nativeTokenPrice: undefined,
+    });
+
+    expect(result.fiatValueAvailable).toBe(false);
+    expect(result.estimatedGasFiat).toBeUndefined();
+    expect(result.gasShortfallFiat).toBeUndefined();
+    expect(result.gasShortfallFiatBucket).toBe('unknown');
+    expect(result.nativeBalanceFiatBucket).toBe('unknown');
+  });
+
+  it('keeps balance-dependent fields unknown when balance is unavailable', () => {
+    const result = buildGasAccountAnalyticsContext({
+      ...baseParams,
+      nativeBalance: undefined,
+    });
+
+    expect(result.nativeBalanceAvailable).toBe(false);
+    expect(result.selfPayGasSufficient).toBeNull();
+    expect(result.shortageType).toBe('unknown');
+    expect(result.gasShortfallNative).toBeUndefined();
+  });
+
+  it('keeps the client custom RPC unavailable reason', () => {
+    const result = buildGasAccountAnalyticsContext({
+      ...baseParams,
+      gasAccountRequested: false,
+      gasAccountSupported: false,
+      gasAccountEligible: null,
+      selectedPayer: 'user',
+      effectiveFeePayer: 'user',
+      unavailableReason: 'customRpcEnabled',
+    });
+
+    expect(result.unavailableReason).toBe('customRpcEnabled');
+  });
+
+  it('treats MegaFuel as a sponsored fee payer for action telemetry', () => {
+    expect(
+      isGasSponsoredAnalyticsContext({
+        ...buildGasAccountAnalyticsContext(baseParams),
+        selectedPayer: 'user',
+        effectiveFeePayer: 'megafuel',
+        gasAccountEligible: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not treat eligibility or a gas shortage alone as sponsorship', () => {
+    expect(
+      isGasSponsoredAnalyticsContext({
+        ...buildGasAccountAnalyticsContext(baseParams),
+        selectedPayer: 'user',
+        effectiveFeePayer: 'user',
+        gasAccountEligible: true,
+        shortageType: 'networkFee',
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/kit/src/views/SignatureConfirm/utils/gasAccountAnalytics.ts
+++ b/packages/kit/src/views/SignatureConfirm/utils/gasAccountAnalytics.ts
@@ -1,0 +1,154 @@
+import BigNumber from 'bignumber.js';
+
+import type {
+  IGasAccountAnalyticsContext,
+  IGasAccountFiatBucket,
+  IGasAccountShortageType,
+} from '@onekeyhq/shared/src/logger/scopes/transaction/types';
+import type {
+  IGasAccountScenario,
+  IGasPayer,
+} from '@onekeyhq/shared/types/fee';
+
+export function isGasSponsoredAnalyticsContext(
+  context: IGasAccountAnalyticsContext | undefined,
+): context is IGasAccountAnalyticsContext {
+  return Boolean(
+    context &&
+    (context.selectedPayer === 'gasAccount' ||
+      context.effectiveFeePayer === 'megafuel'),
+  );
+}
+
+function toNonNegativeBigNumber(value: string | number | undefined) {
+  const result = new BigNumber(value ?? 0);
+  if (!result.isFinite() || result.isNegative()) {
+    return new BigNumber(0);
+  }
+  return result;
+}
+
+function toOptionalNonNegativeBigNumber(value: string | undefined) {
+  if (value === undefined) {
+    return undefined;
+  }
+  const result = new BigNumber(value);
+  if (!result.isFinite() || result.isNegative()) {
+    return undefined;
+  }
+  return result;
+}
+
+export function getGasAccountFiatBucket(
+  value: BigNumber | undefined,
+): IGasAccountFiatBucket {
+  if (!value?.isFinite() || value.isNegative()) {
+    return 'unknown';
+  }
+  if (value.lt(0.01)) return 'lt_0_01';
+  if (value.lt(0.1)) return '0_01_0_1';
+  if (value.lt(1)) return '0_1_1';
+  if (value.lt(5)) return '1_5';
+  return 'gte_5';
+}
+
+export function buildGasAccountAnalyticsContext(params: {
+  entryPoint: IGasAccountAnalyticsContext['entryPoint'];
+  network: string;
+  scenario: IGasAccountScenario | undefined;
+  gasAccountRequested: boolean;
+  gasAccountSupported: boolean | null;
+  gasAccountEligible: boolean | null;
+  selectedPayer: 'user' | 'gasAccount';
+  effectiveFeePayer: IGasPayer;
+  unavailableReason: string | undefined;
+  estimatedGasNative: string | undefined;
+  nativeBalance: string | undefined;
+  nativePrincipal: string | undefined;
+  extraFeeNative: string | undefined;
+  nativeTokenPrice: string | number | undefined;
+  fiatCurrency: string | undefined;
+  tokenPrincipalInsufficient: boolean;
+  quoteId: string | undefined;
+  orderId?: string;
+}): IGasAccountAnalyticsContext {
+  const estimatedGasNative = toNonNegativeBigNumber(params.estimatedGasNative);
+  const nativeBalance = toOptionalNonNegativeBigNumber(params.nativeBalance);
+  const nativePrincipal = toNonNegativeBigNumber(params.nativePrincipal);
+  const extraFeeNative = toNonNegativeBigNumber(params.extraFeeNative);
+  const requiredBeforeGas = nativePrincipal.plus(extraFeeNative);
+  const requiredWithGas = requiredBeforeGas.plus(estimatedGasNative);
+
+  const nativePrincipalInsufficient = nativeBalance?.lt(nativePrincipal);
+  const extraFeeInsufficient = Boolean(
+    nativeBalance &&
+    !nativePrincipalInsufficient &&
+    nativeBalance.lt(requiredBeforeGas),
+  );
+  const networkFeeInsufficient = Boolean(
+    nativeBalance &&
+    !nativePrincipalInsufficient &&
+    !extraFeeInsufficient &&
+    nativeBalance.lt(requiredWithGas),
+  );
+
+  let shortageType: IGasAccountShortageType = nativeBalance
+    ? 'none'
+    : 'unknown';
+  if (params.tokenPrincipalInsufficient && networkFeeInsufficient) {
+    shortageType = 'mixed';
+  } else if (params.tokenPrincipalInsufficient || nativePrincipalInsufficient) {
+    shortageType = 'principal';
+  } else if (extraFeeInsufficient) {
+    shortageType = 'extraFee';
+  } else if (networkFeeInsufficient) {
+    shortageType = 'networkFee';
+  }
+
+  const remainingForGas = nativeBalance
+    ? BigNumber.max(nativeBalance.minus(requiredBeforeGas), 0)
+    : undefined;
+  const gasShortfallNative = remainingForGas
+    ? BigNumber.max(estimatedGasNative.minus(remainingForGas), 0)
+    : undefined;
+  const nativeTokenPrice = toNonNegativeBigNumber(params.nativeTokenPrice);
+  const fiatValueAvailable = nativeTokenPrice.gt(0);
+  const estimatedGasFiat = fiatValueAvailable
+    ? estimatedGasNative.times(nativeTokenPrice)
+    : undefined;
+  const gasShortfallFiat =
+    fiatValueAvailable && gasShortfallNative
+      ? gasShortfallNative.times(nativeTokenPrice)
+      : undefined;
+  const nativeBalanceFiat =
+    fiatValueAvailable && nativeBalance
+      ? nativeBalance.times(nativeTokenPrice)
+      : undefined;
+
+  return {
+    entryPoint: params.entryPoint,
+    network: params.network,
+    scenario: params.scenario,
+    gasAccountRequested: params.gasAccountRequested,
+    gasAccountSupported: params.gasAccountSupported,
+    gasAccountEligible: params.gasAccountEligible,
+    selectedPayer: params.selectedPayer,
+    effectiveFeePayer: params.effectiveFeePayer,
+    unavailableReason: params.unavailableReason,
+    nativeBalanceAvailable: Boolean(nativeBalance),
+    selfPayGasSufficient: nativeBalance
+      ? nativeBalance.gte(requiredWithGas)
+      : null,
+    shortageType,
+    estimatedGasNative: estimatedGasNative.toFixed(),
+    estimatedGasFiat: estimatedGasFiat?.toFixed(),
+    gasShortfallNative: gasShortfallNative?.toFixed(),
+    gasShortfallFiat: gasShortfallFiat?.toFixed(),
+    gasShortfallFiatBucket: getGasAccountFiatBucket(gasShortfallFiat),
+    nativeBalanceFiatBucket: getGasAccountFiatBucket(nativeBalanceFiat),
+    fiatCurrency: params.fiatCurrency,
+    fiatValueAvailable,
+    quoteId: params.quoteId,
+    orderId: params.orderId,
+  };
+}

--- a/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalStake/index.tsx
@@ -185,6 +185,7 @@ function ProtocolSwitchTriggerRow({
   fallbackAprText,
   isLoading,
   isSwitchEnabled,
+  canSwitchProtocols,
   onPress,
 }: {
   currentProtocol?: IManagePositionProtocolSwitchConfig['currentProtocol'];
@@ -192,7 +193,11 @@ function ProtocolSwitchTriggerRow({
   fallbackProviderLogoUri?: string;
   fallbackAprText?: string;
   isLoading?: boolean;
+  /** Interactive right now — false while a tx is in flight (OK-58029) */
   isSwitchEnabled: boolean;
+  /** Switchable in principle. Drives layout only, so a transient lock cannot
+      change the rendered shape and remount the icon (OK-59957) */
+  canSwitchProtocols: boolean;
   onPress: () => void;
 }) {
   const providerName = getEarnProviderDisplayName(
@@ -206,7 +211,9 @@ function ProtocolSwitchTriggerRow({
     protocol: currentProtocol,
     fallbackText: fallbackAprText,
   });
-  const showChevron = isSwitchEnabled || isLoading;
+  // Presence follows canSwitchProtocols so locking the switcher mid-tx dims the
+  // chevron instead of removing it (its removal reflowed the row) (OK-59957)
+  const showChevron = canSwitchProtocols || isLoading;
   let aprElement = null;
 
   if (aprDisplay) {
@@ -316,7 +323,14 @@ function ProtocolSwitcher({
     protocols,
     selectedProtocol,
   } = protocolSwitchConfig;
-  const isSwitchEnabled = protocols.length > 1 && !disabled;
+  // Split structural from interactive (OK-59957). canSwitchProtocols decides
+  // whether the Popover wrapper exists; disabled only removes interactivity.
+  // Deriving the tree shape from `disabled` made pressing the stake button
+  // swap <Popover renderTrigger={trigger}/> for a bare <trigger/>, which
+  // unmounted and remounted the row — reloading the remote protocol image
+  // (the visible flicker) and reflowing it as the chevron vanished.
+  const canSwitchProtocols = protocols.length > 1;
+  const isSwitchEnabled = canSwitchProtocols && !disabled;
   const renderProtocolListContent = useCallback(
     ({
       closePopover,
@@ -350,6 +364,23 @@ function ProtocolSwitcher({
       tokenSymbol,
     ],
   );
+  // Always-controlled open state (OK-59957). Passing `open` only while locked
+  // would flip Popover between controlled and uncontrolled: its internal
+  // isOpen would stay true through the lock and the list would pop itself open
+  // again when the tx finished.
+  const [isProtocolListOpen, setIsProtocolListOpen] = useState(false);
+  const handleProtocolListOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setIsProtocolListOpen(nextOpen && isSwitchEnabled);
+    },
+    [isSwitchEnabled],
+  );
+  useEffect(() => {
+    if (!isSwitchEnabled) {
+      setIsProtocolListOpen(false);
+    }
+  }, [isSwitchEnabled]);
+
   const trigger = (
     <ProtocolSwitchTriggerRow
       currentProtocol={currentProtocol}
@@ -358,11 +389,15 @@ function ProtocolSwitcher({
       fallbackAprText={fallbackAprText}
       isLoading={isLoading}
       isSwitchEnabled={isSwitchEnabled}
+      canSwitchProtocols={canSwitchProtocols}
       onPress={() => {}}
     />
   );
 
-  if (!isSwitchEnabled) {
+  // Only a genuinely single-protocol asset drops the Popover wrapper — that is
+  // stable for the lifetime of the screen, so the trigger is never remounted
+  // mid-interaction (OK-59957)
+  if (!canSwitchProtocols) {
     return trigger;
   }
 
@@ -370,6 +405,10 @@ function ProtocolSwitcher({
     <Popover
       title={intl.formatMessage({ id: ETranslations.defi_select_protocol })}
       placement="bottom-end"
+      // Locked mid-tx (OK-58029) simply stays closed, rather than unmounting
+      // the Popover and changing the tree shape (OK-59957)
+      open={isProtocolListOpen}
+      onOpenChange={handleProtocolListOpenChange}
       renderTrigger={trigger}
       floatingPanelProps={{
         w: 360,
@@ -386,6 +425,11 @@ type IUniversalStakeProps = {
   balance: string;
 
   tokenImageUri?: string;
+  /**
+   * Token metadata still resolving and no image came in via route params —
+   * skeleton the icon instead of flashing the placeholder coin (OK-59961)
+   */
+  tokenImageLoading?: boolean;
   tokenSymbol?: string;
 
   decimals?: number;
@@ -448,6 +492,7 @@ export function UniversalStake({
   decimals,
   minTransactionFee = '0',
   tokenImageUri,
+  tokenImageLoading,
   tokenSymbol,
   providerName = '',
   providerLogo,
@@ -1010,7 +1055,6 @@ export function UniversalStake({
           slippage: pendleSlippage,
           stakeType,
         });
-
         if (requestId !== checkAmountRequestIdRef.current) {
           return;
         }
@@ -2262,6 +2306,7 @@ export function UniversalStake({
               onBlur={onBlurAmountValue}
               tokenSelectorTriggerProps={{
                 selectedTokenImageUri: tokenImageUri,
+                selectedTokenImageLoading: tokenImageLoading,
                 selectedTokenSymbol: tokenSymbol?.toUpperCase(),
                 selectedNetworkImageUri: networkLogoURI,
                 ...tokenSelectorTriggerProps,

--- a/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
+++ b/packages/kit/src/views/Staking/components/UniversalWithdraw/index.tsx
@@ -1255,6 +1255,26 @@ export function UniversalWithdraw({
   useEffect(() => {
     transactionConfirmationRequestIdRef.current += 1;
     const requestId = transactionConfirmationRequestIdRef.current;
+    // OK-59850: an empty / "0" / "0.000" field used to reach the server here.
+    // isInvalidAmount only rejects NaN and a trailing dot, and the fetch itself
+    // falls back to '0', so clearing the input still issued a request and lit
+    // the spinner (quoteLoading covers this flag too). The server resolves the
+    // withdraw path on-chain regardless of how small the amount is, so the wait
+    // was real — and nothing it returns for a non-positive amount is rendered.
+    // Cancelling a queued withdrawal is the one flow with no amount to enter,
+    // so it still has to be quoted.
+    const isQuotableAmount =
+      isCancelWithdrawal ||
+      (!isInvalidAmount(amountValue) &&
+        new BigNumber(amountValue).isGreaterThan(0));
+
+    if (!isQuotableAmount) {
+      // Bumping the id above already invalidates anything in flight; the
+      // previous run's cleanup cancelled any pending debounce.
+      setTransactionConfirmationLoading(false);
+      return undefined;
+    }
+
     setTransactionConfirmationLoading(true);
     void debouncedFetchTransactionConfirmation({
       amount: amountValue,
@@ -1271,6 +1291,7 @@ export function UniversalWithdraw({
   }, [
     amountValue,
     debouncedFetchTransactionConfirmation,
+    isCancelWithdrawal,
     selectedWithdrawType,
     transactionConfirmationRequestKey,
   ]);
@@ -1296,6 +1317,9 @@ export function UniversalWithdraw({
       const valueBN = new BigNumber(value);
       if (valueBN.isNaN()) {
         if (value === '') {
+          // OK-59850 is handled by the checkAmount effect now: clearing the
+          // field re-runs it, whose cleanup cancels the pending debounce and
+          // whose non-checkable branch resets the loading state.
           setCheckoutAmountMessage('');
           setCheckAmountAlerts([]);
           setIgnoreAllowanceCheck(false);

--- a/packages/kit/src/views/Staking/pages/ManagePosition/components/ManagePositionContent.tsx
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/components/ManagePositionContent.tsx
@@ -212,8 +212,24 @@ const ManageSectionShell = ({
           <XStack h="$11" ai="center" jc="space-between">
             <Skeleton h="$6" w="$24" borderRadius="$2" />
             <XStack ai="center" gap="$1.5">
-              <Token size="sm" tokenImageUri={fallbackTokenImageUri} />
-              <SizableText size="$headingXl">{symbol}</SizableText>
+              {/* Everything else in this frame is a Skeleton, but the token
+                  icon was rendered straight away — entries that carry no
+                  tokenImageUri route param (e.g. a banner deep link) then drew
+                  Token's empty placeholder and popped the real logo in once
+                  tokenInfo resolved. Skeleton it at the same size instead so
+                  the swap costs no layout shift (OK-59961). */}
+              {fallbackTokenImageUri ? (
+                <Token size="sm" tokenImageUri={fallbackTokenImageUri} />
+              ) : (
+                <Skeleton w="$6" h="$6" radius="round" />
+              )}
+              {/* The symbol is the one real string this frame used to draw, and
+                  a vault symbol can be as long as "Morpho-cbBTC-USDC-wrapper" —
+                  a full-width name sitting among skeleton bars reads worse than
+                  no name at all, and the page title already carries it. Skeleton
+                  it like everything else and let the real symbol land with the
+                  rest of the data. */}
+              <Skeleton h="$6" w="$20" borderRadius="$2" />
             </XStack>
           </XStack>
           <XStack jc="space-between" ai="center">

--- a/packages/kit/src/views/Staking/pages/ManagePosition/components/StakeSection.tsx
+++ b/packages/kit/src/views/Staking/pages/ManagePosition/components/StakeSection.tsx
@@ -814,6 +814,7 @@ export const StakeSection = ({
         networkId={networkId}
         balance="0"
         tokenImageUri={fallbackTokenImageUri}
+        tokenImageLoading={!tokenInfo?.token && !fallbackTokenImageUri}
         tokenSymbol={tokenInfo?.token.symbol}
         isDisabled
         approveTarget={{
@@ -889,6 +890,14 @@ export const StakeSection = ({
           balance={effectiveStakeTokenInfo?.balanceParsed ?? ''}
           tokenImageUri={
             effectiveStakeTokenInfo?.token.logoURI || fallbackTokenImageUri
+          }
+          // Token metadata not in yet and no image came from route params:
+          // skeleton the icon rather than flashing the placeholder coin.
+          // Guarded on the metadata being absent (not merely on a missing
+          // image) so a token that genuinely has no logo still renders its
+          // fallback instead of a skeleton that never resolves (OK-59961).
+          tokenImageLoading={
+            !effectiveStakeTokenInfo?.token && !fallbackTokenImageUri
           }
           tokenSymbol={effectiveStakeTokenInfo?.token.symbol}
           providerLogo={protocolInfo?.providerDetail.logoURI}

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts
@@ -4,12 +4,86 @@ import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 import {
   getSwapAddressAccountSelectorNum,
   getSwapRecipientActionState,
+  getSwapRecipientEditorAccountInfo,
   getSwapRecipientValidationAccountId,
   resolveSwapTargetNetworkAccount,
   shouldResetSwapRecipientOnAccountNetworkSync,
   shouldShowSwapRecipientAddressInfo,
   shouldUseSwapCustomRecipientAddress,
 } from './useSwapAccount.utils';
+
+import type { IAccountSelectorActiveAccountInfo } from '../../../states/jotai/contexts/accountSelector';
+
+function buildAccountInfo({
+  accountId,
+  ready = true,
+}: {
+  accountId?: string;
+  ready?: boolean;
+} = {}): IAccountSelectorActiveAccountInfo {
+  return {
+    ready,
+    account: accountId
+      ? ({ id: accountId } as IAccountSelectorActiveAccountInfo['account'])
+      : undefined,
+    indexedAccount: undefined,
+    dbAccount: undefined,
+    accountName: '',
+    wallet: undefined,
+    device: undefined,
+    network: undefined,
+    vaultSettings: undefined,
+    deriveType: undefined,
+    deriveInfoItems: [],
+  };
+}
+
+describe('getSwapRecipientEditorAccountInfo', () => {
+  it('prefers ready recipient ownership information', () => {
+    const recipientAccountInfo = buildAccountInfo({
+      accountId: 'recipient-account',
+    });
+    const activeAccount = buildAccountInfo({ accountId: 'active-account' });
+
+    expect(
+      getSwapRecipientEditorAccountInfo({
+        recipientAccountInfo,
+        activeAccount,
+      }),
+    ).toBe(recipientAccountInfo);
+  });
+
+  it('falls back to a ready active account for an external recipient', () => {
+    const activeAccount = buildAccountInfo({ accountId: 'active-account' });
+
+    expect(
+      getSwapRecipientEditorAccountInfo({
+        recipientAccountInfo: undefined,
+        activeAccount,
+      }),
+    ).toBe(activeAccount);
+  });
+
+  it('allows a ready editor context before its network account is created', () => {
+    const activeAccount = buildAccountInfo();
+
+    expect(
+      getSwapRecipientEditorAccountInfo({
+        recipientAccountInfo: undefined,
+        activeAccount,
+      }),
+    ).toBe(activeAccount);
+  });
+
+  it('waits until an account context is ready', () => {
+    expect(
+      getSwapRecipientEditorAccountInfo({
+        recipientAccountInfo: buildAccountInfo({ ready: false }),
+        activeAccount: buildAccountInfo({ ready: false }),
+      }),
+    ).toBeUndefined();
+  });
+});
 
 describe('resolveSwapTargetNetworkAccount', () => {
   beforeEach(() => {

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
@@ -4,6 +4,8 @@ import { equalsIgnoreCase } from '@onekeyhq/shared/src/utils/stringUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 
+import type { IAccountSelectorActiveAccountInfo } from '../../../states/jotai/contexts/accountSelector';
+
 const SWAP_TARGET_DERIVE_TYPE_RETRY_DELAY_MS = 500;
 
 type IShouldUseSwapCustomRecipientAddressParams = {
@@ -44,6 +46,11 @@ type IGetSwapRecipientValidationAccountIdParams = {
   accountId?: string;
   accountAddress?: string;
   recipientAddress?: string;
+};
+
+type IGetSwapRecipientEditorAccountInfoParams = {
+  recipientAccountInfo?: IAccountSelectorActiveAccountInfo;
+  activeAccount?: IAccountSelectorActiveAccountInfo;
 };
 
 type IGetSwapAddressAccountSelectorNumParams = {
@@ -116,6 +123,21 @@ export function getSwapRecipientActionState({
     shouldEnterRecipient,
     shouldDisableAction: !shouldEnterRecipient,
   };
+}
+
+export function getSwapRecipientEditorAccountInfo({
+  recipientAccountInfo,
+  activeAccount,
+}: IGetSwapRecipientEditorAccountInfoParams) {
+  if (recipientAccountInfo?.ready) {
+    return recipientAccountInfo;
+  }
+
+  if (activeAccount?.ready) {
+    return activeAccount;
+  }
+
+  return undefined;
 }
 
 export function getSwapRecipientValidationAccountId({

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -38,7 +38,6 @@ import {
 import { OneKeyAppError, OneKeyError } from '@onekeyhq/shared/src/errors';
 import { EOneKeyErrorClassNames } from '@onekeyhq/shared/src/errors/types/errorTypes';
 import type { IOneKeyError } from '@onekeyhq/shared/src/errors/types/errorTypes';
-import { getGasAccountErrorCode } from '@onekeyhq/shared/src/errors/utils/gasAccountErrorUtils';
 import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -70,7 +69,6 @@ import type {
   IFeeTron,
   IFeeUTXO,
   IGasAccountQuote,
-  IGasAccountUiState,
   IGasEIP1559,
   IGasLegacy,
   IGasPayer,
@@ -130,13 +128,21 @@ import {
   useSwapToTokenAmountAtom,
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
-import {
-  EGasAccountErrorStrategy,
-  getGasAccountErrorEntry,
-} from '../../SignatureConfirm/constants/gasAccountErrorCodes';
+import { EGasAccountErrorStrategy } from '../../SignatureConfirm/constants/gasAccountErrorCodes';
 import { buildSwapApproveAndSendSteps } from '../utils/buildSwapReviewState';
 import {
+  buildDirectSwapGasAccountAnalyticsContext,
+  buildDirectSwapGasAccountUiState,
+  createGasAccountReviewSession,
+  logDirectSwapGasAccountDecision,
+  logGasAccountReviewExit,
+  markGasAccountReviewSubmitted,
+  runDirectSwapGasAccountStep,
+  sendDirectSwapWithGasAccountAnalytics,
+} from '../utils/gasAccountAnalytics';
+import {
   type ISwapBtcOutputValidationError,
+  buildNativeTokenFromGasInfo,
   checkSwapLatestBalanceSufficient,
   getSwapEncodedTxSize,
   getSwapRequiredNativeBalanceAmount,
@@ -324,7 +330,8 @@ export function useSwapBuildTx({
   const [swapLimitPriceToAmount] = useSwapLimitPriceToAmountAtom();
   const [swapLimitPartiallyFillObj] = useSwapLimitPartiallyFillAtom();
   const [swapSteps, setSwapSteps] = useSwapStepsAtom();
-  const [{ isFirstTimeSwap }, setPersistSettings] = useSettingsPersistAtom();
+  const [persistSettings, setPersistSettings] = useSettingsPersistAtom();
+  const { isFirstTimeSwap } = persistSettings;
   const swapActionState = useSwapActionState();
   const [swapNetWorkFeeLevel] = useSwapStepNetFeeLevelAtom();
   const [, setSwapFromTokenAmount] = useSwapFromTokenAmountAtom();
@@ -343,6 +350,22 @@ export function useSwapBuildTx({
   if (swapStepsRef.current !== swapSteps) {
     swapStepsRef.current = swapSteps;
   }
+  const gasAccountReviewSessionRef = useRef<
+    ReturnType<typeof createGasAccountReviewSession> | undefined
+  >(undefined);
+
+  const beginGasAccountReviewSession = useCallback(() => {
+    gasAccountReviewSessionRef.current = createGasAccountReviewSession();
+  }, []);
+
+  const endGasAccountReviewSession = useCallback(() => {
+    logGasAccountReviewExit(gasAccountReviewSessionRef.current);
+    gasAccountReviewSessionRef.current = undefined;
+  }, []);
+
+  const markCurrentGasAccountReviewSubmitted = useCallback(() => {
+    markGasAccountReviewSubmitted(gasAccountReviewSessionRef.current);
+  }, []);
 
   const isModalPage = useIsOverlayPage();
 
@@ -703,12 +726,14 @@ export function useSwapBuildTx({
       token,
       amount,
       otherFeeInfos,
+      cachedNativeBalance,
     }: {
       gasInfos?: { gasInfo?: ISwapGasInfo; txSize?: number }[];
       networkId?: string;
       token?: ISwapToken;
       amount?: string;
       otherFeeInfos?: IQuoteResultFeeOtherFeeInfo[];
+      cachedNativeBalance?: string;
     }) => {
       const nativeBalanceRequirement = getSwapRequiredNativeBalanceAmount({
         gasInfos,
@@ -717,39 +742,60 @@ export function useSwapBuildTx({
         fromAmount: amount,
         otherFeeInfos,
       });
-
-      if (!nativeBalanceRequirement) {
-        return true;
+      if (!nativeBalanceRequirement && cachedNativeBalance !== undefined) {
+        return {
+          isSufficient: true,
+          nativeBalance: cachedNativeBalance,
+        };
+      }
+      const firstGasInfo = gasInfos?.find((item) => item.gasInfo)?.gasInfo;
+      const nativeToken =
+        nativeBalanceRequirement?.token ??
+        (firstGasInfo
+          ? buildNativeTokenFromGasInfo({
+              gasInfo: firstGasInfo,
+              networkId,
+              fromToken: token,
+            })
+          : undefined);
+      if (!nativeToken) {
+        return { isSufficient: true };
       }
 
       const checkResult = await checkSwapLatestBalanceSufficient({
-        token: nativeBalanceRequirement.token,
-        amount: nativeBalanceRequirement.amount,
+        token: nativeToken,
+        amount: nativeBalanceRequirement?.amount ?? '0',
         accountAddress: fromUserAddress,
         accountId: fromAccountId,
       });
       if (!checkResult.isSufficient) {
         const toastId = [
           'swap-native-balance-insufficient',
-          nativeBalanceRequirement.token.networkId,
+          nativeToken.networkId,
           checkResult.tokenSymbol,
-          nativeBalanceRequirement.reserveAmount,
+          nativeBalanceRequirement?.reserveAmount,
         ].join('-');
         const { title, message } = getSwapBalanceInsufficientToast({
-          networkId: nativeBalanceRequirement.token.networkId,
+          networkId: nativeToken.networkId,
           tokenSymbol: checkResult.tokenSymbol,
-          reserveAmount: nativeBalanceRequirement.includesFromAmount
+          reserveAmount: nativeBalanceRequirement?.includesFromAmount
             ? undefined
-            : nativeBalanceRequirement.reserveAmount,
+            : nativeBalanceRequirement?.reserveAmount,
         });
         Toast.error({
           title,
           message,
           toastId,
         });
-        return false;
+        return {
+          isSufficient: false,
+          nativeBalance: checkResult.balance,
+        };
       }
-      return true;
+      return {
+        isSufficient: true,
+        nativeBalance: checkResult.balance,
+      };
     },
     [fromAccountId, fromUserAddress, getSwapBalanceInsufficientToast],
   );
@@ -962,8 +1008,20 @@ export function useSwapBuildTx({
         amount: unsignedTxItem.swapInfo?.sender.amount,
         otherFeeInfos:
           unsignedTxItem.swapInfo?.swapBuildResData.result?.fee?.otherFeeInfos,
+        cachedNativeBalance: gasAccountReviewSessionRef.current?.nativeBalance,
       });
-      if (!checkLatestNativeBalanceRes) {
+      const gasAccountAnalyticsContext =
+        buildDirectSwapGasAccountAnalyticsContext({
+          entryPoint: 'swapDirect',
+          networkId,
+          unsignedTx: unsignedTxItem,
+          gasInfo,
+          txSize,
+          nativeBalance: checkLatestNativeBalanceRes.nativeBalance,
+          useGasAccountByDefault: persistSettings.useGasAccountByDefault,
+          fiatCurrency: persistSettings.currencyInfo.id,
+        });
+      if (!checkLatestNativeBalanceRes.isSufficient) {
         throw new OneKeyAppError('checkLatestNativeTokenBalance failed');
       }
       setSwapSteps(
@@ -985,43 +1043,33 @@ export function useSwapBuildTx({
           };
         },
       );
-      await backgroundApiProxy.serviceSend.precheckUnsignedTxs({
-        networkId,
-        accountId,
-        unsignedTxs: [updatedUnsignedTxItem],
-        precheckTiming: ESendPreCheckTimingEnum.Confirm,
-      });
-      await backgroundApiProxy.serviceTransaction.verifyTransaction({
-        networkId,
-        accountId,
-        verifyTxTasks: ['feeInfo'],
-        verifyTxFeeInfoParams: {
-          feeAmount: totalNative,
-          feeTokenSymbol: gasInfo.common?.nativeSymbol ?? '',
-          doubleConfirm: true,
+      await runDirectSwapGasAccountStep({
+        context: gasAccountAnalyticsContext,
+        failureStage: 'precheck',
+        task: async () => {
+          await backgroundApiProxy.serviceSend.precheckUnsignedTxs({
+            networkId,
+            accountId,
+            unsignedTxs: [updatedUnsignedTxItem],
+            precheckTiming: ESendPreCheckTimingEnum.Confirm,
+          });
+          await backgroundApiProxy.serviceTransaction.verifyTransaction({
+            networkId,
+            accountId,
+            verifyTxTasks: ['feeInfo'],
+            verifyTxFeeInfoParams: {
+              feeAmount: totalNative,
+              feeTokenSymbol: gasInfo.common?.nativeSymbol ?? '',
+              doubleConfirm: true,
+            },
+            encodedTx: updatedUnsignedTxItem.encodedTx,
+          });
         },
-        encodedTx: updatedUnsignedTxItem.encodedTx,
       });
-      // When estimate-fee confirmed Gas Account sponsorship, attach the quote so
-      // broadcast pays via the sponsor. Mirrors the transaction-confirm page
-      // (TxFeeInfo): selectedPayer 'gasAccount' + `gas-account:${quoteId}` key.
-      const gasAccountUiState: IGasAccountUiState | undefined =
-        gasInfo.gasAccountEligible &&
-        gasInfo.payer === 'gasAccount' &&
-        gasInfo.gasAccountQuote?.quoteId
-          ? {
-              payer: gasInfo.payer,
-              gasAccountEligible: true,
-              gasAccountQuote: gasInfo.gasAccountQuote,
-              selectedPayer: 'gasAccount',
-              // Same nonce the quote was bound to at estimate-fee time.
-              lockedUserNonce:
-                typeof updatedUnsignedTxItem.nonce === 'number'
-                  ? updatedUnsignedTxItem.nonce
-                  : undefined,
-              idempotencyKey: `gas-account:${gasInfo.gasAccountQuote.quoteId}`,
-            }
-          : undefined;
+      const gasAccountUiState = buildDirectSwapGasAccountUiState({
+        gasInfo,
+        unsignedTx: updatedUnsignedTxItem,
+      });
       let isNetworkFeeSponsored = isSwapGasSponsored(gasInfo);
       const sendTxParams = {
         networkId,
@@ -1029,50 +1077,27 @@ export function useSwapBuildTx({
         unsignedTx: updatedUnsignedTxItem,
         signOnly: false as const,
       };
-      let res: Awaited<
-        ReturnType<typeof backgroundApiProxy.serviceSend.signAndSendTransaction>
-      >;
-      try {
-        res = await backgroundApiProxy.serviceSend.signAndSendTransaction({
-          ...sendTxParams,
-          gasAccountUiState,
-        });
-      } catch (e) {
-        // Broadcast failed at the gas-account layer. Route by the same strategy
-        // table the confirm page (TxConfirmActions) uses. Plain (non
-        // gas-account) errors, and errors on a non-sponsored send, propagate.
-        const entry = gasAccountUiState
-          ? getGasAccountErrorEntry(getGasAccountErrorCode(e))
-          : undefined;
-        if (!entry) {
-          throw e;
-        }
-        // Mute the original bridge error so the global handler doesn't toast it
-        // (would duplicate the mapped message / conflict with suppressToast).
-        (e as IOneKeyError).autoToast = false;
-        const message = intl.formatMessage({ id: entry.messageKey });
-        // Honor the suppressToast contract (e.g. daily-limit codes stay silent).
-        if (!entry.suppressToast) {
-          Toast.error({ title: message });
-        }
-        if (entry.strategy === EGasAccountErrorStrategy.Fallback) {
-          // Sponsor path unavailable for this attempt (pool exhausted, daily
-          // limit, sponsor down …). Mirror the confirm page: drop the sponsor
-          // quote and resend once as user-paid so the swap can still go through
-          // when the user has native for gas. A user-paid failure (e.g. no
-          // native) then propagates honestly.
-          res =
-            await backgroundApiProxy.serviceSend.signAndSendTransaction(
-              sendTxParams,
-            );
-          isNetworkFeeSponsored = false;
-        } else {
-          // Refresh (quote/nonce stale — already prevented in Swap by the
-          // fresh estimate-at-send + locked nonce) and Hint (terminal) fail the
-          // step. OneKeyAppError avoids the tx-confirm fallback and a 2nd toast.
+      const res = await sendDirectSwapWithGasAccountAnalytics({
+        context: gasAccountAnalyticsContext,
+        gasAccountUiState,
+        send: (uiState) =>
+          backgroundApiProxy.serviceSend.signAndSendTransaction({
+            ...sendTxParams,
+            gasAccountUiState: uiState,
+          }),
+        onGasAccountError: (error, entry) => {
+          (error as IOneKeyError).autoToast = false;
+          const message = intl.formatMessage({ id: entry.messageKey });
+          if (!entry.suppressToast) {
+            Toast.error({ title: message });
+          }
+          if (entry.strategy === EGasAccountErrorStrategy.Fallback) {
+            isNetworkFeeSponsored = false;
+            return;
+          }
           throw new OneKeyAppError({ message, autoToast: false });
-        }
-      }
+        },
+      });
       const decodedTx = await backgroundApiProxy.serviceSend.buildDecodedTx({
         networkId,
         accountId,
@@ -1108,6 +1133,8 @@ export function useSwapBuildTx({
       checkLatestNativeTokenBalance,
       getSwapBtcOutputValidationToast,
       intl,
+      persistSettings.currencyInfo.id,
+      persistSettings.useGasAccountByDefault,
       setSwapSteps,
     ],
   );
@@ -1386,6 +1413,7 @@ export function useSwapBuildTx({
         payer?: IGasPayer;
         gasAccountEligible?: boolean;
         gasAccountQuote?: IGasAccountQuote;
+        gasAccountScenarioReason?: string;
       },
       gasCommon: {
         baseFee?: string;
@@ -1462,6 +1490,7 @@ export function useSwapBuildTx({
         payer: gasRes.payer,
         gasAccountEligible: gasRes.gasAccountEligible,
         gasAccountQuote: gasRes.gasAccountQuote,
+        gasAccountScenarioReason: gasRes.gasAccountScenarioReason,
       };
     },
     [
@@ -3131,6 +3160,7 @@ export function useSwapBuildTx({
       if (!fromToken || !fromAccountId || !fromUserAddress) {
         throw new OneKeyError('account error');
       }
+      const gasAccountReviewSession = gasAccountReviewSessionRef.current;
       const swapInfo = buildUnsignedParams?.swapInfo;
       // Gas Account sponsorship pre-check from the build-tx response; forwarded
       // to estimate-fee so the preview can decide whether to show the sponsored
@@ -3404,7 +3434,33 @@ export function useSwapBuildTx({
               swapInfo?.swapBuildResData.result?.fee?.otherFeeInfos,
           },
         );
-        if (!checkLatestNativeBalanceRes) {
+        const swapGasFeeInfo = findGasInfo(gasFeeInfos, unsignedTx.encodedTx);
+        const gasAccountAnalyticsContext = swapGasFeeInfo
+          ? buildDirectSwapGasAccountAnalyticsContext({
+              entryPoint: 'swapDirect',
+              networkId,
+              unsignedTx,
+              gasInfo: swapGasFeeInfo.gasInfo,
+              txSize: swapGasFeeInfo.txSize,
+              nativeBalance: checkLatestNativeBalanceRes.nativeBalance,
+              useGasAccountByDefault: persistSettings.useGasAccountByDefault,
+              fiatCurrency: persistSettings.currencyInfo.id,
+            })
+          : undefined;
+        if (
+          gasAccountAnalyticsContext &&
+          gasAccountReviewSession &&
+          gasAccountReviewSessionRef.current === gasAccountReviewSession
+        ) {
+          gasAccountReviewSession.nativeBalance =
+            checkLatestNativeBalanceRes.nativeBalance;
+          gasAccountReviewSession.analyticsContext = gasAccountAnalyticsContext;
+          if (!gasAccountReviewSession.decisionLogged) {
+            gasAccountReviewSession.decisionLogged = true;
+            logDirectSwapGasAccountDecision(gasAccountAnalyticsContext);
+          }
+        }
+        if (!checkLatestNativeBalanceRes.isSufficient) {
           throw new OneKeyAppError('checkLatestNativeTokenBalance failed');
         }
         const gasFeeFiatValues = await Promise.all(
@@ -3456,6 +3512,9 @@ export function useSwapBuildTx({
       fromAccountId,
       fromUserAddress,
       checkLatestNativeTokenBalance,
+      findGasInfo,
+      persistSettings.currencyInfo.id,
+      persistSettings.useGasAccountByDefault,
     ],
   );
 
@@ -3874,5 +3933,12 @@ export function useSwapBuildTx({
     ],
   );
 
-  return { preSwapStepsStart, cancelLimitOrder, preSwapBeforeStepActions };
+  return {
+    preSwapStepsStart,
+    cancelLimitOrder,
+    preSwapBeforeStepActions,
+    beginGasAccountReviewSession,
+    endGasAccountReviewSession,
+    markCurrentGasAccountReviewSubmitted,
+  };
 }

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -193,9 +193,13 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     onPopStack: onPopSwapModal,
     onBroadcast: swapInitParams?.onSwapBroadcast,
   });
-  const { preSwapStepsStart, preSwapBeforeStepActions } = useSwapBuildTx({
-    onSwapBroadcast,
-  });
+  const {
+    preSwapStepsStart,
+    preSwapBeforeStepActions,
+    beginGasAccountReviewSession,
+    endGasAccountReviewSession,
+    markCurrentGasAccountReviewSubmitted,
+  } = useSwapBuildTx({ onSwapBroadcast });
   const [quoteResult] = useSwapQuoteCurrentSelectAtom();
   const [alerts] = useSwapAlertsAtom();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
@@ -248,13 +252,14 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   hasInFlightStepsRef.current = hasInFlightSteps;
 
   const resetPendingReview = useCallback(() => {
+    endGasAccountReviewSession();
     setSwapBuildTxFetching(false);
     void backgroundApiProxy.serviceGas.abortEstimateFee();
     setSwapSteps({
       steps: [],
       preSwapData: {},
     });
-  }, [setSwapBuildTxFetching, setSwapSteps]);
+  }, [endGasAccountReviewSession, setSwapBuildTxFetching, setSwapSteps]);
   const dialogClose = useCallback(() => {
     if (reviewDialogTimerRef.current !== undefined) {
       clearTimeout(reviewDialogTimerRef.current);
@@ -1059,10 +1064,12 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   ]);
 
   const handleConfirm = useCallback(async () => {
+    markCurrentGasAccountReviewSubmitted();
     onActionHandlerBefore();
-  }, [onActionHandlerBefore]);
+  }, [markCurrentGasAccountReviewSubmitted, onActionHandlerBefore]);
 
   const onPreSwapClose = useCallback(() => {
+    endGasAccountReviewSession();
     dialogClose();
     setSwapBuildTxFetching(false);
     void backgroundApiProxy.serviceGas.abortEstimateFee();
@@ -1072,7 +1079,12 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
         preSwapData: {},
       });
     }, 100);
-  }, [setSwapBuildTxFetching, dialogClose, setSwapSteps]);
+  }, [
+    setSwapBuildTxFetching,
+    endGasAccountReviewSession,
+    dialogClose,
+    setSwapSteps,
+  ]);
 
   const handleSelectAccountClick = useCallback(() => {
     dismissKeyboard();
@@ -1105,6 +1117,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
       cleanQuoteInterval();
       setSwapShouldRefreshQuote(true);
     }
+    beginGasAccountReviewSession();
     parseQuoteResultToSteps();
     setSwapBuildTxFetching(true);
     reviewDialogTimerRef.current = setTimeout(() => {
@@ -1151,6 +1164,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     swapProAccount?.result?.addressDetail.address,
     isSwapProMarketPresetLoading,
     currentQuoteRes,
+    beginGasAccountReviewSession,
     parseQuoteResultToSteps,
     setSwapBuildTxFetching,
     handleSelectAccountClick,

--- a/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.test.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.test.tsx
@@ -12,6 +12,7 @@ import { SwapReviewDialog } from './SwapReviewDialog';
 
 const useSwapReviewActionsMock = jest.fn();
 const removeStoreMock = jest.fn();
+const reviewConfirmMock = jest.fn();
 
 jest.mock('@onekeyhq/kit/src/states/jotai/utils/jotaiContextStore', () => ({
   jotaiContextStore: {
@@ -102,8 +103,9 @@ jest.mock('./SwapReviewInitializer', () => ({
 describe('SwapReviewDialog', () => {
   beforeEach(() => {
     removeStoreMock.mockClear();
+    reviewConfirmMock.mockClear();
     useSwapReviewActionsMock.mockReturnValue({
-      onConfirm: jest.fn(),
+      onConfirm: reviewConfirmMock,
       preSwapBeforeStepActions: jest.fn(),
       preSwapStepsStart: jest.fn(),
     });
@@ -111,6 +113,7 @@ describe('SwapReviewDialog', () => {
 
   it('renders the reusable swap review shell with the provided store and adapter', () => {
     const onDone = jest.fn();
+    const onConfirmStart = jest.fn();
     const adapter = {
       prepareReview: jest.fn(),
       sendApproveTx: jest.fn(),
@@ -123,6 +126,7 @@ describe('SwapReviewDialog', () => {
     render(
       <SwapReviewDialog
         onDone={onDone}
+        onConfirmStart={onConfirmStart}
         adapter={adapter}
         reviewState={{
           steps: [],
@@ -157,6 +161,11 @@ describe('SwapReviewDialog', () => {
     fireEvent.click(screen.getByTestId('review-confirm'));
     fireEvent.click(screen.getByTestId('review-done'));
 
+    expect(onConfirmStart).toHaveBeenCalledTimes(1);
+    expect(reviewConfirmMock).toHaveBeenCalledTimes(1);
+    expect(onConfirmStart.mock.invocationCallOrder[0]).toBeLessThan(
+      reviewConfirmMock.mock.invocationCallOrder[0],
+    );
     expect(onDone).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.tsx
@@ -20,6 +20,7 @@ import { SwapReviewInitializer } from './SwapReviewInitializer';
 
 type ISwapReviewDialogProps = {
   onDone: () => void;
+  onConfirmStart?: () => void;
   adapter: ISwapReviewAdapter;
   reviewState: ISwapReviewState;
   storeName: EJotaiContextStoreNames;
@@ -45,6 +46,7 @@ function SwapReviewDialogContent({
   defaultNetworkFeeLevel,
   showCustomNetworkFeeOption,
   onDone,
+  onConfirmStart,
 }: {
   adapter: ISwapReviewAdapter;
   approveTransactionSource: ESwapReviewApproveTransactionSource;
@@ -53,6 +55,7 @@ function SwapReviewDialogContent({
   defaultCustomPriorityFee?: ICustomPriorityFeeOverride;
   showCustomNetworkFeeOption?: boolean;
   onDone: () => void;
+  onConfirmStart?: () => void;
 }) {
   const { onConfirm, preSwapBeforeStepActions, preSwapStepsStart } =
     useSwapReviewActions({
@@ -63,7 +66,10 @@ function SwapReviewDialogContent({
   return (
     <PreSwapDialogContent
       disableGlobalApproveSync={disableGlobalApproveSync}
-      onConfirm={onConfirm}
+      onConfirm={() => {
+        onConfirmStart?.();
+        onConfirm();
+      }}
       onDone={onDone}
       preSwapBeforeStepActions={preSwapBeforeStepActions}
       preSwapStepsStart={preSwapStepsStart}
@@ -76,6 +82,7 @@ function SwapReviewDialogContent({
 
 export function SwapReviewDialog({
   onDone,
+  onConfirmStart,
   adapter,
   reviewState,
   storeName,
@@ -119,6 +126,7 @@ export function SwapReviewDialog({
             defaultCustomPriorityFee={defaultCustomPriorityFee}
             showCustomNetworkFeeOption={showCustomNetworkFeeOption}
             onDone={onDone}
+            onConfirmStart={onConfirmStart}
           />
         </SwapReviewInitializer>
       </SwapProviderMirror>

--- a/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
@@ -39,7 +39,10 @@ import RecipientQuickSelect from '../../../Send/pages/SendDataInput/RecipientQui
 import { shouldSkipResolvedRecipientUpdate } from '../../../Send/pages/SendDataInput/recipientSelectionUtils';
 import { useWebDappRecipientOptions } from '../../../Send/pages/SendDataInput/useWebDappRecipientOptions';
 import { useSwapAddressInfo } from '../../hooks/useSwapAccount';
-import { getSwapRecipientValidationAccountId } from '../../hooks/useSwapAccount.utils';
+import {
+  getSwapRecipientEditorAccountInfo,
+  getSwapRecipientValidationAccountId,
+} from '../../hooks/useSwapAccount.utils';
 import { SwapProviderMirror } from '../SwapProviderMirror';
 
 import type { IRecipientQuickSelectTab } from '../../../Send/pages/SendDataInput/recipientQuickSelectTabUtils';
@@ -62,6 +65,10 @@ const SwapToAnotherAddressPage = () => {
     address: recipientAccountAddress,
     networkId,
   } = useSwapAddressInfo(ESwapDirectionType.TO);
+  const editorAccountInfo = getSwapRecipientEditorAccountInfo({
+    recipientAccountInfo: accountInfo,
+    activeAccount,
+  });
   const validationAccountId = getSwapRecipientValidationAccountId({
     accountId: accountInfo?.account?.id,
     accountAddress: accountInfo?.account?.addressDetail?.address,
@@ -178,7 +185,7 @@ const SwapToAnotherAddressPage = () => {
     setSwapToAddress((v) => ({ ...v, address: undefined }));
   }, [setSwapToAddress, setSettings]);
 
-  return accountInfo && networkId ? (
+  return editorAccountInfo && networkId ? (
     <Page scrollEnabled>
       <Page.Header
         title={intl.formatMessage({

--- a/packages/kit/src/views/Swap/utils/gasAccountAnalytics.test.ts
+++ b/packages/kit/src/views/Swap/utils/gasAccountAnalytics.test.ts
@@ -1,0 +1,304 @@
+import type { IUnsignedTxPro } from '@onekeyhq/core/src/types';
+import type { ISwapGasInfo } from '@onekeyhq/shared/types/swap/types';
+
+const mockGasAccountAction = jest.fn();
+
+jest.mock('@onekeyhq/shared/src/logger/logger', () => ({
+  defaultLogger: {
+    transaction: {
+      send: {
+        gasAccountAction: mockGasAccountAction,
+      },
+    },
+  },
+}));
+
+const {
+  buildDirectSwapGasAccountAnalyticsContext,
+  buildDirectSwapGasAccountUiState,
+  createGasAccountReviewSession,
+  logGasAccountReviewExit,
+  markGasAccountReviewSubmitted,
+  sendDirectSwapWithGasAccountAnalytics,
+} = require('./gasAccountAnalytics') as typeof import('./gasAccountAnalytics');
+
+const unsignedTx = {
+  encodedTx: {},
+  swapInfo: {
+    sender: {
+      amount: '0.1',
+      token: {
+        isNative: true,
+        networkId: 'evm--1',
+      },
+    },
+    swapBuildResData: {
+      orderId: 'swap-order-id',
+      result: {
+        fee: {
+          otherFeeInfos: [],
+        },
+      },
+    },
+  },
+} as unknown as IUnsignedTxPro;
+
+const gasInfo = {
+  common: {
+    feeDecimals: 18,
+    feeSymbol: 'ETH',
+    nativeDecimals: 18,
+    nativeSymbol: 'ETH',
+    nativeTokenPrice: 2000,
+  },
+  gas: {
+    gasLimit: '1',
+    gasPrice: '0.01',
+  },
+  payer: 'gasAccount',
+  gasAccountEligible: true,
+  gasAccountQuote: {
+    quoteId: 'quote-id',
+    maxFee: '0.01',
+    expiresAt: '2026-08-10T12:00:00.000Z',
+  },
+} as ISwapGasInfo;
+
+describe('buildDirectSwapGasAccountAnalyticsContext', () => {
+  beforeEach(() => {
+    mockGasAccountAction.mockReset();
+  });
+
+  it('classifies the direct swap self-pay gas shortfall', () => {
+    const result = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'swapDirect',
+      networkId: 'evm--1',
+      unsignedTx,
+      gasInfo,
+      nativeBalance: '0.105',
+      useGasAccountByDefault: true,
+      fiatCurrency: 'usd',
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        entryPoint: 'swapDirect',
+        scenario: 'swap',
+        shortageType: 'networkFee',
+        gasShortfallNative: '0.005',
+        selectedPayer: 'gasAccount',
+        quoteId: 'quote-id',
+        orderId: 'swap-order-id',
+      }),
+    );
+  });
+
+  it('keeps decision telemetry when the native balance lookup is unavailable', () => {
+    const result = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'marketSwapDirect',
+      networkId: 'evm--1',
+      unsignedTx,
+      gasInfo,
+      nativeBalance: undefined,
+      useGasAccountByDefault: true,
+      fiatCurrency: 'usd',
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        entryPoint: 'marketSwapDirect',
+        nativeBalanceAvailable: false,
+        selfPayGasSufficient: null,
+        shortageType: 'unknown',
+      }),
+    );
+  });
+
+  it('uses the pre-sponsorship fee and tracks MegaFuel review exits', () => {
+    const context = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'swapDirect',
+      networkId: 'evm--1',
+      unsignedTx,
+      gasInfo: {
+        ...gasInfo,
+        gas: {
+          gasLimit: '1',
+          gasPrice: '0',
+          originalGasPrice: '0.01',
+        },
+        payer: 'megafuel',
+        megafuelEligible: {
+          sponsorable: true,
+          sponsorName: 'OneKey',
+        },
+        gasAccountEligible: false,
+        gasAccountQuote: undefined,
+      },
+      nativeBalance: '0.105',
+      useGasAccountByDefault: true,
+      fiatCurrency: 'usd',
+    });
+    const session = createGasAccountReviewSession();
+    session.analyticsContext = context;
+
+    logGasAccountReviewExit(session);
+
+    expect(context).toEqual(
+      expect.objectContaining({
+        selectedPayer: 'user',
+        effectiveFeePayer: 'megafuel',
+        estimatedGasNative: '0.01',
+        selfPayGasSufficient: false,
+        shortageType: 'networkFee',
+      }),
+    );
+    expect(mockGasAccountAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'exited',
+        effectiveFeePayer: 'megafuel',
+      }),
+    );
+  });
+
+  it('tracks one exit when a Gas Account review closes before submit', () => {
+    const context = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'swapDirect',
+      networkId: 'evm--1',
+      unsignedTx,
+      gasInfo,
+      nativeBalance: '0.105',
+      useGasAccountByDefault: true,
+      fiatCurrency: 'usd',
+    });
+    const session = createGasAccountReviewSession();
+    session.analyticsContext = context;
+
+    logGasAccountReviewExit(session);
+    logGasAccountReviewExit(session);
+
+    expect(mockGasAccountAction).toHaveBeenCalledTimes(1);
+    expect(mockGasAccountAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'exited',
+        entryPoint: 'swapDirect',
+      }),
+    );
+  });
+
+  it('tracks confirm once and does not track an exit after submit starts', () => {
+    const context = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'marketSwapDirect',
+      networkId: 'evm--1',
+      unsignedTx,
+      gasInfo,
+      nativeBalance: '0.105',
+      useGasAccountByDefault: true,
+      fiatCurrency: 'usd',
+    });
+    const session = createGasAccountReviewSession();
+    session.analyticsContext = context;
+
+    markGasAccountReviewSubmitted(session);
+    markGasAccountReviewSubmitted(session);
+    logGasAccountReviewExit(session);
+
+    expect(mockGasAccountAction).toHaveBeenCalledTimes(1);
+    expect(mockGasAccountAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'confirmClicked',
+        entryPoint: 'marketSwapDirect',
+      }),
+    );
+  });
+
+  it('tracks Gas Account fallback without duplicating send logic in callers', async () => {
+    const context = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'swapDirect',
+      networkId: 'evm--1',
+      unsignedTx,
+      gasInfo,
+      nativeBalance: '0.105',
+      useGasAccountByDefault: true,
+      fiatCurrency: 'usd',
+    });
+    const gasAccountUiState = buildDirectSwapGasAccountUiState({
+      gasInfo,
+      unsignedTx,
+    });
+    const send = jest
+      .fn()
+      .mockRejectedValueOnce({ code: 40_213 })
+      .mockResolvedValueOnce('signed');
+
+    await expect(
+      sendDirectSwapWithGasAccountAnalytics({
+        context,
+        gasAccountUiState,
+        send,
+      }),
+    ).resolves.toBe('signed');
+
+    expect(send).toHaveBeenNthCalledWith(1, gasAccountUiState);
+    expect(send).toHaveBeenNthCalledWith(2);
+    expect(mockGasAccountAction).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ action: 'submitFailed' }),
+    );
+    expect(mockGasAccountAction).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ action: 'payerChanged' }),
+    );
+    expect(mockGasAccountAction).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: 'submitSucceeded',
+        effectiveFeePayer: 'user',
+        orderId: 'swap-order-id',
+      }),
+    );
+  });
+
+  it('waits for fallback preparation before retrying as user-paid', async () => {
+    const context = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'marketSwapDirect',
+      networkId: 'evm--1',
+      unsignedTx,
+      gasInfo,
+      nativeBalance: '0.105',
+      useGasAccountByDefault: true,
+      fiatCurrency: 'usd',
+    });
+    const gasAccountUiState = buildDirectSwapGasAccountUiState({
+      gasInfo,
+      unsignedTx,
+    });
+    const callOrder: string[] = [];
+    const send = jest
+      .fn()
+      .mockImplementationOnce(async () => {
+        callOrder.push('sponsored-send');
+        throw Object.assign(new Error('sponsor unavailable'), {
+          code: 40_213,
+        });
+      })
+      .mockImplementationOnce(async () => {
+        callOrder.push('user-send');
+        return 'signed';
+      });
+
+    await sendDirectSwapWithGasAccountAnalytics({
+      context,
+      gasAccountUiState,
+      send,
+      onGasAccountError: async () => {
+        await Promise.resolve();
+        callOrder.push('fallback-prepared');
+      },
+    });
+
+    expect(callOrder).toEqual([
+      'sponsored-send',
+      'fallback-prepared',
+      'user-send',
+    ]);
+  });
+});

--- a/packages/kit/src/views/Swap/utils/gasAccountAnalytics.ts
+++ b/packages/kit/src/views/Swap/utils/gasAccountAnalytics.ts
@@ -1,0 +1,321 @@
+import BigNumber from 'bignumber.js';
+
+import type { IUnsignedTxPro } from '@onekeyhq/core/src/types';
+import { getGasAccountErrorCode } from '@onekeyhq/shared/src/errors/utils/gasAccountErrorUtils';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import type {
+  IGasAccountActionParams,
+  IGasAccountAnalyticsContext,
+  IGasAccountEntryPoint,
+} from '@onekeyhq/shared/src/logger/scopes/transaction/types';
+import { calculateFeeForSend } from '@onekeyhq/shared/src/utils/feeUtils';
+import type {
+  IEstimateFeeParams,
+  IFeeInfoUnit,
+  IGasAccountUiState,
+} from '@onekeyhq/shared/types/fee';
+import type { ISwapGasInfo } from '@onekeyhq/shared/types/swap/types';
+
+import {
+  EGasAccountErrorStrategy,
+  getGasAccountErrorEntry,
+} from '../../SignatureConfirm/constants/gasAccountErrorCodes';
+import {
+  buildGasAccountAnalyticsContext,
+  isGasSponsoredAnalyticsContext,
+} from '../../SignatureConfirm/utils/gasAccountAnalytics';
+
+type IDirectSwapGasAccountActionDetails = Omit<
+  IGasAccountActionParams,
+  keyof IGasAccountAnalyticsContext
+>;
+
+export function logDirectSwapGasAccountAction(
+  context: IGasAccountAnalyticsContext | undefined,
+  details: IDirectSwapGasAccountActionDetails,
+) {
+  if (!context || !isGasSponsoredAnalyticsContext(context)) {
+    return;
+  }
+  defaultLogger.transaction.send.gasAccountAction({
+    ...context,
+    ...details,
+  });
+}
+
+export type IGasAccountReviewSession = {
+  analyticsContext?: IGasAccountAnalyticsContext;
+  nativeBalance?: string;
+  decisionLogged: boolean;
+  submitted: boolean;
+  exitLogged: boolean;
+};
+
+export function createGasAccountReviewSession(): IGasAccountReviewSession {
+  return {
+    decisionLogged: false,
+    submitted: false,
+    exitLogged: false,
+  };
+}
+
+export function markGasAccountReviewSubmitted(
+  session: IGasAccountReviewSession | undefined,
+) {
+  if (!session || session.submitted) {
+    return;
+  }
+  logDirectSwapGasAccountAction(session.analyticsContext, {
+    action: 'confirmClicked',
+  });
+  session.submitted = true;
+}
+
+export function logGasAccountReviewExit(
+  session: IGasAccountReviewSession | undefined,
+) {
+  if (!session || session.submitted || session.exitLogged) {
+    return;
+  }
+  session.exitLogged = true;
+  logDirectSwapGasAccountAction(session.analyticsContext, {
+    action: 'exited',
+  });
+}
+
+function getNativeOtherFeeAmount({
+  networkId,
+  unsignedTx,
+}: {
+  networkId: string;
+  unsignedTx: IUnsignedTxPro;
+}) {
+  return (
+    unsignedTx.swapInfo?.swapBuildResData.result?.fee?.otherFeeInfos ?? []
+  )
+    .filter((item) => item.token.isNative && item.token.networkId === networkId)
+    .reduce((total, item) => total.plus(item.amount || 0), new BigNumber(0))
+    .toFixed();
+}
+
+function getDirectSwapGasAccountUnavailableReason({
+  hasEligibleQuote,
+  useGasAccountByDefault,
+  gasAccountCandidate,
+  gasAccountScenarioReason,
+}: {
+  hasEligibleQuote: boolean;
+  useGasAccountByDefault: boolean | undefined;
+  gasAccountCandidate: boolean;
+  gasAccountScenarioReason: string | undefined;
+}) {
+  if (hasEligibleQuote) {
+    return undefined;
+  }
+  if (useGasAccountByDefault === false) {
+    return 'userDisabled';
+  }
+  if (gasAccountCandidate) {
+    return gasAccountScenarioReason ?? 'backend_unknown';
+  }
+  return 'swapBuildDisabled';
+}
+
+export function buildDirectSwapGasAccountAnalyticsContext({
+  entryPoint,
+  networkId,
+  unsignedTx,
+  gasInfo,
+  estimateFeeParams,
+  txSize,
+  nativeBalance,
+  useGasAccountByDefault,
+  fiatCurrency,
+}: {
+  entryPoint: Extract<IGasAccountEntryPoint, 'swapDirect' | 'marketSwapDirect'>;
+  networkId: string;
+  unsignedTx: IUnsignedTxPro;
+  gasInfo: ISwapGasInfo;
+  estimateFeeParams?: IEstimateFeeParams;
+  txSize?: number;
+  nativeBalance: string | undefined;
+  useGasAccountByDefault: boolean | undefined;
+  fiatCurrency: string | undefined;
+}): IGasAccountAnalyticsContext | undefined {
+  const swapInfo = unsignedTx.swapInfo;
+  if (!swapInfo?.sender?.token || !gasInfo.common) {
+    return undefined;
+  }
+
+  const { originalTotalNative, totalNative } = calculateFeeForSend({
+    feeInfo: gasInfo as IFeeInfoUnit,
+    nativeTokenPrice: gasInfo.common.nativeTokenPrice ?? 0,
+    estimateFeeParams,
+    txSize,
+  });
+  const sender = swapInfo.sender;
+  const nativePrincipal =
+    sender.token.isNative && sender.token.networkId === networkId
+      ? sender.amount
+      : '0';
+  const hasEligibleQuote = Boolean(
+    gasInfo.gasAccountEligible && gasInfo.gasAccountQuote?.quoteId,
+  );
+  const gasAccountCandidate = Boolean(
+    swapInfo.swapBuildResData.result?.gasAccountEnabled,
+  );
+  const gasAccountRequested =
+    gasAccountCandidate && useGasAccountByDefault !== false;
+  const selectedPayer =
+    hasEligibleQuote && gasInfo.payer === 'gasAccount' ? 'gasAccount' : 'user';
+  let gasAccountSupported: boolean | null = null;
+  if (hasEligibleQuote) {
+    gasAccountSupported = true;
+  } else if (gasInfo.gasAccountScenarioReason) {
+    gasAccountSupported = false;
+  }
+
+  return buildGasAccountAnalyticsContext({
+    entryPoint,
+    network: networkId,
+    scenario: 'swap',
+    gasAccountRequested,
+    gasAccountSupported,
+    gasAccountEligible: gasAccountRequested ? hasEligibleQuote : null,
+    selectedPayer,
+    effectiveFeePayer: gasInfo.payer ?? 'user',
+    unavailableReason: getDirectSwapGasAccountUnavailableReason({
+      hasEligibleQuote,
+      useGasAccountByDefault,
+      gasAccountCandidate,
+      gasAccountScenarioReason: gasInfo.gasAccountScenarioReason,
+    }),
+    estimatedGasNative: originalTotalNative ?? totalNative,
+    nativeBalance,
+    nativePrincipal,
+    extraFeeNative: getNativeOtherFeeAmount({ networkId, unsignedTx }),
+    nativeTokenPrice: gasInfo.common.nativeTokenPrice,
+    fiatCurrency,
+    tokenPrincipalInsufficient: false,
+    quoteId: gasInfo.gasAccountQuote?.quoteId,
+    orderId: swapInfo.swapBuildResData.orderId,
+  });
+}
+
+export function logDirectSwapGasAccountDecision(
+  context: IGasAccountAnalyticsContext | undefined,
+) {
+  if (context) {
+    defaultLogger.transaction.send.gasAccountDecision(context);
+  }
+}
+
+export function buildDirectSwapGasAccountUiState({
+  gasInfo,
+  unsignedTx,
+}: {
+  gasInfo: ISwapGasInfo;
+  unsignedTx: IUnsignedTxPro;
+}): IGasAccountUiState | undefined {
+  const quote = gasInfo.gasAccountQuote;
+  if (
+    !gasInfo.gasAccountEligible ||
+    gasInfo.payer !== 'gasAccount' ||
+    !quote?.quoteId
+  ) {
+    return undefined;
+  }
+
+  return {
+    payer: 'gasAccount',
+    gasAccountEligible: true,
+    gasAccountQuote: quote,
+    selectedPayer: 'gasAccount',
+    lockedUserNonce:
+      typeof unsignedTx.nonce === 'number' ? unsignedTx.nonce : undefined,
+    idempotencyKey: `gas-account:${quote.quoteId}`,
+  };
+}
+
+export async function runDirectSwapGasAccountStep<T>({
+  context,
+  failureStage,
+  task,
+}: {
+  context: IGasAccountAnalyticsContext | undefined;
+  failureStage: NonNullable<IGasAccountActionParams['failureStage']>;
+  task: () => Promise<T>;
+}): Promise<T> {
+  try {
+    return await task();
+  } catch (error) {
+    logDirectSwapGasAccountAction(context, {
+      action: 'submitFailed',
+      failureStage,
+      errorCode: getGasAccountErrorCode(error),
+    });
+    throw error;
+  }
+}
+
+export async function sendDirectSwapWithGasAccountAnalytics<T>({
+  context,
+  gasAccountUiState,
+  send,
+  onGasAccountError,
+}: {
+  context: IGasAccountAnalyticsContext | undefined;
+  gasAccountUiState: IGasAccountUiState | undefined;
+  send: (gasAccountUiState?: IGasAccountUiState) => Promise<T>;
+  onGasAccountError?: (
+    error: unknown,
+    entry: NonNullable<ReturnType<typeof getGasAccountErrorEntry>>,
+  ) => void | Promise<void>;
+}): Promise<T> {
+  let result: T;
+  let effectiveFeePayer = context?.effectiveFeePayer ?? 'user';
+  try {
+    result = await send(gasAccountUiState);
+  } catch (error) {
+    const errorCode = getGasAccountErrorCode(error);
+    logDirectSwapGasAccountAction(context, {
+      action: 'submitFailed',
+      failureStage: 'submit',
+      errorCode,
+    });
+    const entry = gasAccountUiState
+      ? getGasAccountErrorEntry(errorCode)
+      : undefined;
+    if (!entry) {
+      throw error;
+    }
+
+    await onGasAccountError?.(error, entry);
+    if (entry.strategy !== EGasAccountErrorStrategy.Fallback) {
+      throw error;
+    }
+
+    logDirectSwapGasAccountAction(context, {
+      action: 'payerChanged',
+      fromPayer: 'gasAccount',
+      toPayer: 'user',
+      changeSource: 'system',
+      changeReason: 'submitFailed',
+      errorCode,
+    });
+    effectiveFeePayer = 'user';
+    result = await runDirectSwapGasAccountStep({
+      context: context ? { ...context, effectiveFeePayer } : undefined,
+      failureStage: 'submit',
+      task: () => send(),
+    });
+  }
+
+  logDirectSwapGasAccountAction(
+    context ? { ...context, effectiveFeePayer } : undefined,
+    {
+      action: 'submitSucceeded',
+    },
+  );
+  return result;
+}

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -3,6 +3,7 @@ import type { ITransferInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
 import {
+  buildNativeTokenFromGasInfo,
   checkSwapLatestBalanceSufficient,
   getSwapEncodedTxSize,
   getSwapRequiredNativeBalanceAmount,
@@ -137,6 +138,23 @@ describe('checkSwapLatestBalanceSufficient', () => {
     ).resolves.toEqual({ isSufficient: true });
   });
 
+  it('still fetches balance when sponsored gas requires no self-paid amount', async () => {
+    mockFetchSwapTokenDetails.mockResolvedValue([{ balanceParsed: '0.08' }]);
+
+    await expect(
+      checkSwapLatestBalanceSufficient({
+        token: ethToken,
+        amount: '0',
+        accountId: 'account-id',
+        accountAddress: '0xabc',
+      }),
+    ).resolves.toEqual({
+      isSufficient: true,
+      balance: '0.08',
+      tokenSymbol: 'ETH',
+    });
+  });
+
   it('uses canonical native token address when native token address is empty', async () => {
     mockGetNativeTokenAddress.mockResolvedValue(aptosNativeAddress);
     mockFetchSwapTokenDetails.mockResolvedValue([{ balanceParsed: '6.6044' }]);
@@ -148,7 +166,11 @@ describe('checkSwapLatestBalanceSufficient', () => {
         accountId: 'account-id',
         accountAddress: '0xabc',
       }),
-    ).resolves.toEqual({ isSufficient: true });
+    ).resolves.toEqual({
+      isSufficient: true,
+      balance: '6.6044',
+      tokenSymbol: 'APT',
+    });
     expect(mockGetNativeTokenAddress).toHaveBeenCalledWith({
       networkId: 'aptos--1',
     });
@@ -159,6 +181,18 @@ describe('checkSwapLatestBalanceSufficient', () => {
       accountId: 'account-id',
       currency: 'usd',
     });
+  });
+});
+
+describe('buildNativeTokenFromGasInfo', () => {
+  it('builds the native token from gas info for a token swap', () => {
+    expect(
+      buildNativeTokenFromGasInfo({
+        gasInfo: evmGasInfo,
+        networkId: 'evm--1',
+        fromToken: usdcToken,
+      }),
+    ).toEqual(ethToken);
   });
 });
 

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -25,6 +25,8 @@ type ISwapLatestBalanceCheckParams = {
 export type ISwapLatestBalanceCheckResult =
   | {
       isSufficient: true;
+      balance?: string;
+      tokenSymbol?: string;
     }
   | {
       isSufficient: false;
@@ -244,7 +246,7 @@ export function validateSwapBtcOutputs({
   return undefined;
 }
 
-function buildNativeTokenFromGasInfo({
+export function buildNativeTokenFromGasInfo({
   gasInfo,
   networkId,
   fromToken,
@@ -376,11 +378,12 @@ export async function checkSwapLatestBalanceSufficient({
     !accountAddress ||
     amountBN.isNaN() ||
     !amountBN.isFinite() ||
-    amountBN.lte(0)
+    amountBN.lt(0)
   ) {
     return { isSufficient: true };
   }
 
+  let balance: string | undefined;
   try {
     const contractAddress = await getSwapTokenBalanceContractAddress(token);
     const tokenBalanceInfo =
@@ -391,26 +394,28 @@ export async function checkSwapLatestBalanceSufficient({
         accountId,
         currency: 'usd',
       });
-    if (!tokenBalanceInfo?.length) {
-      return { isSufficient: true };
-    }
-
-    const balanceBN = new BigNumber(tokenBalanceInfo[0].balanceParsed ?? 0);
-    if (balanceBN.isNaN() || !balanceBN.isFinite()) {
-      return { isSufficient: true };
-    }
-
-    if (amountBN.gt(balanceBN)) {
-      return {
-        isSufficient: false,
-        balance: balanceBN.toFixed(),
-        requiredAmount: amountBN.toFixed(),
-        tokenSymbol: token.symbol,
-      };
+    const balanceBN = new BigNumber(
+      tokenBalanceInfo?.[0]?.balanceParsed ?? NaN,
+    );
+    if (!balanceBN.isNaN() && balanceBN.isFinite() && !balanceBN.isNegative()) {
+      balance = balanceBN.toFixed();
     }
   } catch (error) {
     console.error('checkSwapLatestBalanceSufficient error', error);
   }
 
-  return { isSufficient: true };
+  if (balance === undefined) {
+    return { isSufficient: true };
+  }
+
+  if (amountBN.gt(balance)) {
+    return {
+      isSufficient: false,
+      balance,
+      requiredAmount: amountBN.toFixed(),
+      tokenSymbol: token.symbol,
+    };
+  }
+
+  return { isSufficient: true, balance, tokenSymbol: token.symbol };
 }

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchAccountAssetItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchAccountAssetItem.tsx
@@ -21,19 +21,24 @@ import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import tokenRebaseUtils from '@onekeyhq/shared/src/utils/tokenRebaseUtils';
 import { getTokenPriceChangeStyle } from '@onekeyhq/shared/src/utils/tokenUtils';
-import type { IUniversalSearchAccountAssets } from '@onekeyhq/shared/types/search';
+import type {
+  EUniversalSearchSource,
+  IUniversalSearchAccountAssets,
+} from '@onekeyhq/shared/types/search';
 import type { IAccountToken } from '@onekeyhq/shared/types/token';
 
 interface IUniversalSearchAccountAssetItemProps {
   item: IUniversalSearchAccountAssets;
   allAggregateTokenMap?: Record<string, { tokens: IAccountToken[] }>;
   getSearchInput: () => string;
+  source: EUniversalSearchSource;
 }
 
 export function UniversalSearchAccountAssetItem({
   item,
   allAggregateTokenMap,
   getSearchInput,
+  source,
 }: IUniversalSearchAccountAssetItemProps) {
   const navigation = useAppNavigation();
   const { activeAccount } = useActiveAccount({ num: 0 });
@@ -57,6 +62,7 @@ export function UniversalSearchAccountAssetItem({
 
   const handlePress = useCallback(async () => {
     defaultLogger.universalSearch.search.universalSearchClick({
+      source,
       searchText: getSearchInput(),
       type: item.type,
       itemId: token.address ?? token.symbol ?? '',
@@ -113,6 +119,7 @@ export function UniversalSearchAccountAssetItem({
     getSearchInput,
     item.type,
     navigation,
+    source,
     token,
     universalSearchActions,
   ]);

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchAddressItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchAddressItem.tsx
@@ -15,7 +15,10 @@ import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
-import type { IUniversalSearchAddress } from '@onekeyhq/shared/types/search';
+import type {
+  EUniversalSearchSource,
+  IUniversalSearchAddress,
+} from '@onekeyhq/shared/types/search';
 
 import { AccountAddress } from '../../../AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountAddress';
 import { AccountValueWithSpotlight } from '../../../AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/AccountValue';
@@ -25,12 +28,14 @@ interface IUniversalSearchAddressItemProps {
   item: IUniversalSearchAddress;
   contextNetworkId?: string;
   getSearchInput: () => string;
+  source: EUniversalSearchSource;
 }
 
 export function UniversalSearchAddressItem({
   item,
   contextNetworkId,
   getSearchInput,
+  source,
 }: IUniversalSearchAddressItemProps) {
   const navigation = useAppNavigation();
   const accountSelectorActions = useAccountSelectorActions();
@@ -67,6 +72,7 @@ export function UniversalSearchAddressItem({
 
   const handleAccountPress = useCallback(async () => {
     defaultLogger.universalSearch.search.universalSearchClick({
+      source,
       searchText: getSearchInput(),
       type: item.type,
       itemId:
@@ -145,11 +151,13 @@ export function UniversalSearchAddressItem({
     item.payload,
     item.type,
     navigation,
+    source,
     universalSearchActions,
   ]);
 
   const handleAddressPress = useCallback(() => {
     defaultLogger.universalSearch.search.universalSearchClick({
+      source,
       searchText: getSearchInput(),
       type: item.type,
       itemId: item.payload.addressInfo?.displayAddress ?? '',
@@ -192,6 +200,7 @@ export function UniversalSearchAddressItem({
     item.payload,
     item.type,
     navigation,
+    source,
     universalSearchActions,
   ]);
 

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchDappItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchDappItem.tsx
@@ -8,18 +8,23 @@ import { useUniversalSearchActions } from '@onekeyhq/kit/src/states/jotai/contex
 import { isGoogleSearchItem } from '@onekeyhq/shared/src/consts/discovery';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { EEnterMethod } from '@onekeyhq/shared/src/logger/scopes/discovery/scenes/dapp';
-import type { IUniversalSearchDapp } from '@onekeyhq/shared/types/search';
+import type {
+  EUniversalSearchSource,
+  IUniversalSearchDapp,
+} from '@onekeyhq/shared/types/search';
 
 import { useWebSiteHandler } from '../../../Discovery/hooks/useWebSiteHandler';
 
 interface IUniversalSearchDappItemProps {
   item: IUniversalSearchDapp;
   getSearchInput: () => string;
+  source: EUniversalSearchSource;
 }
 
 export function UniversalSearchDappItem({
   item,
   getSearchInput,
+  source,
 }: IUniversalSearchDappItemProps) {
   const { name, dappId, logo } = item.payload;
   const isGoogle = isGoogleSearchItem(dappId);
@@ -81,6 +86,7 @@ export function UniversalSearchDappItem({
 
   const handlePress = useCallback(() => {
     defaultLogger.universalSearch.search.universalSearchClick({
+      source,
       searchText: getSearchInput(),
       type: item.type,
       itemId: dappId ?? '',
@@ -157,6 +163,7 @@ export function UniversalSearchDappItem({
     dappId,
     universalSearchActions,
     processSearchInput,
+    source,
   ]);
 
   return (

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchPerpItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchPerpItem.tsx
@@ -22,7 +22,10 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 import { ETabRoutes } from '@onekeyhq/shared/src/routes';
 import { buildCoinFromSearchAssetType } from '@onekeyhq/shared/src/utils/perpsDexUtils';
 import { getHyperliquidTokenImageUris } from '@onekeyhq/shared/src/utils/perpsUtils';
-import type { IUniversalSearchPerp } from '@onekeyhq/shared/types/search';
+import type {
+  EUniversalSearchSource,
+  IUniversalSearchPerp,
+} from '@onekeyhq/shared/types/search';
 
 import { MarketPerpsStarV2 } from '../../../Market/components/MarketStarV2';
 
@@ -32,11 +35,13 @@ const shouldShowFavoriteButton =
 interface IUniversalSearchPerpItemProps {
   item: IUniversalSearchPerp;
   getSearchInput: () => string;
+  source: EUniversalSearchSource;
 }
 
 export function UniversalSearchPerpItem({
   item,
   getSearchInput,
+  source,
 }: IUniversalSearchPerpItemProps) {
   const [{ isMounted }] = useMarketWatchListV2Atom();
   const navigation = useAppNavigation();
@@ -61,6 +66,7 @@ export function UniversalSearchPerpItem({
 
   const handlePress = useCallback(() => {
     defaultLogger.universalSearch.search.universalSearchClick({
+      source,
       searchText: getSearchInput(),
       type: item.type,
       itemId: coin,
@@ -99,6 +105,7 @@ export function UniversalSearchPerpItem({
     name,
     assetType,
     navigation,
+    source,
     universalSearchActions,
   ]);
 

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchSettingsItem.test.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchSettingsItem.test.tsx
@@ -2,6 +2,7 @@
 
 import { fireEvent, render, waitFor } from '@testing-library/react';
 
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import {
   EModalRoutes,
   EModalSettingRoutes,
@@ -9,6 +10,7 @@ import {
   ESettingsTabNames,
 } from '@onekeyhq/shared/src/routes';
 import {
+  EUniversalSearchSource,
   EUniversalSearchType,
   type IUniversalSearchSettings,
 } from '@onekeyhq/shared/types/search';
@@ -79,7 +81,6 @@ jest.mock(
     useIsTabNavigator: () => mockIsTabNavigator,
   }),
 );
-
 jest.mock('@onekeyhq/shared/src/logger/logger', () => ({
   defaultLogger: {
     universalSearch: {
@@ -90,6 +91,10 @@ jest.mock('@onekeyhq/shared/src/logger/logger', () => ({
   },
 }));
 
+const mockUniversalSearchClick = jest.spyOn(
+  defaultLogger.universalSearch.search,
+  'universalSearchClick',
+);
 jest.mock('@onekeyhq/shared/src/utils/timerUtils', () => ({
   __esModule: true,
   default: {
@@ -146,6 +151,7 @@ describe('UniversalSearchSettingsItem settings tab navigation', () => {
       <UniversalSearchSettingsItem
         item={settingsResult}
         getSearchInput={() => 'notifications'}
+        source={EUniversalSearchSource.Browser}
       />,
     );
     fireEvent.click(getByTestId('settings-result'));
@@ -157,6 +163,13 @@ describe('UniversalSearchSettingsItem settings tab navigation', () => {
       );
     });
     expect(mockPushModal).not.toHaveBeenCalled();
+    expect(mockUniversalSearchClick).toHaveBeenCalledWith({
+      source: EUniversalSearchSource.Browser,
+      searchText: 'notifications',
+      type: EUniversalSearchType.Settings,
+      itemId: 'notifications',
+      itemTitle: 'Notifications',
+    });
   });
 
   it('opens Settings at the target tab when Settings is not already active', async () => {
@@ -169,6 +182,7 @@ describe('UniversalSearchSettingsItem settings tab navigation', () => {
       <UniversalSearchSettingsItem
         item={settingsResult}
         getSearchInput={() => 'notifications'}
+        source={EUniversalSearchSource.Browser}
       />,
     );
     fireEvent.click(getByTestId('settings-result'));
@@ -201,6 +215,7 @@ describe('UniversalSearchSettingsItem settings tab navigation', () => {
       <UniversalSearchSettingsItem
         item={sectionFallbackResult}
         getSearchInput={() => 'theme'}
+        source={EUniversalSearchSource.Browser}
       />,
     );
     fireEvent.click(getByTestId('settings-result'));
@@ -224,6 +239,7 @@ describe('UniversalSearchSettingsItem settings tab navigation', () => {
       <UniversalSearchSettingsItem
         item={sectionFallbackResult}
         getSearchInput={() => 'theme'}
+        source={EUniversalSearchSource.Browser}
       />,
     );
     fireEvent.click(getByTestId('settings-result'));
@@ -244,6 +260,7 @@ describe('UniversalSearchSettingsItem settings tab navigation', () => {
       <UniversalSearchSettingsItem
         item={sectionFallbackResult}
         getSearchInput={() => 'theme'}
+        source={EUniversalSearchSource.Browser}
       />,
     );
     fireEvent.click(getByTestId('settings-result'));

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchSettingsItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchSettingsItem.tsx
@@ -15,16 +15,21 @@ import type {
 import { EModalRoutes } from '@onekeyhq/shared/src/routes';
 import { EModalSettingRoutes } from '@onekeyhq/shared/src/routes/setting';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
-import type { IUniversalSearchSettings } from '@onekeyhq/shared/types/search';
+import type {
+  EUniversalSearchSource,
+  IUniversalSearchSettings,
+} from '@onekeyhq/shared/types/search';
 
 interface IUniversalSearchSettingsItemProps {
   item: IUniversalSearchSettings;
   getSearchInput: () => string;
+  source: EUniversalSearchSource;
 }
 
 export function UniversalSearchSettingsItem({
   item,
   getSearchInput,
+  source,
 }: IUniversalSearchSettingsItemProps) {
   const navigation = useAppNavigation();
   const universalSearchActions = useUniversalSearchActions();
@@ -41,6 +46,7 @@ export function UniversalSearchSettingsItem({
   const isTabNavigator = useIsTabNavigator();
   const handlePress = useCallback(async () => {
     defaultLogger.universalSearch.search.universalSearchClick({
+      source,
       searchText: getSearchInput(),
       type: item.type,
       // Prefer stable identities (route, then explicit id) over localized
@@ -111,6 +117,7 @@ export function UniversalSearchSettingsItem({
     title,
     item.type,
     getSearchInput,
+    source,
   ]);
 
   return (

--- a/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
+++ b/packages/kit/src/views/UniversalSearch/components/SearchResultItems/UniversalSearchV2MarketTokenItem.tsx
@@ -37,7 +37,10 @@ import {
   formatTokenSymbolForDisplay,
   getTokenPriceChangeStyle,
 } from '@onekeyhq/shared/src/utils/tokenUtils';
-import type { IUniversalSearchV2MarketToken } from '@onekeyhq/shared/types/search';
+import type {
+  EUniversalSearchSource,
+  IUniversalSearchV2MarketToken,
+} from '@onekeyhq/shared/types/search';
 
 import { MarketStarV2Deferred } from '../../../Market/components/MarketStarV2Deferred';
 import { MarketTokenIcon } from '../../../Market/components/MarketTokenIcon';
@@ -154,12 +157,14 @@ interface IUniversalSearchMarketTokenItemProps {
   item: IUniversalSearchV2MarketToken;
   isTrending?: boolean;
   getSearchInput?: () => string;
+  source: EUniversalSearchSource;
 }
 
 export function UniversalSearchV2MarketTokenItem({
   item,
   isTrending,
   getSearchInput,
+  source,
 }: IUniversalSearchMarketTokenItemProps) {
   // Ensure market watch list atom is initialized
   const [{ isMounted }] = useMarketWatchListV2Atom();
@@ -212,6 +217,7 @@ export function UniversalSearchV2MarketTokenItem({
     const searchText = getSearchInput?.();
     if (searchText) {
       defaultLogger.universalSearch.search.universalSearchClick({
+        source,
         searchText,
         type: item.type,
         itemId: address ?? symbol ?? '',
@@ -269,6 +275,7 @@ export function UniversalSearchV2MarketTokenItem({
     item.type,
     toMarketDetailPage,
     appNavigation,
+    source,
   ]);
 
   if (!isMounted) {

--- a/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
+++ b/packages/kit/src/views/UniversalSearch/pages/UniversalSearch.tsx
@@ -39,6 +39,7 @@ import type {
 } from '@onekeyhq/shared/types/search';
 import {
   ESearchStatus,
+  EUniversalSearchSource,
   EUniversalSearchType,
 } from '@onekeyhq/shared/types/search';
 
@@ -166,9 +167,11 @@ const isMarketSection = (tabIndex: number) => tabIndex === MARKET_TAB_INDEX;
 export function UniversalSearch({
   filterTypes,
   initialTab,
+  source,
 }: {
   filterTypes?: EUniversalSearchType[];
   initialTab?: 'market' | 'dapp';
+  source: EUniversalSearchSource;
 }) {
   const intl = useIntl();
   const { activeAccount } = useActiveAccount({ num: 0 });
@@ -609,12 +612,13 @@ export function UniversalSearch({
         .map((s) => `${getSearchTypeTrackingName(s.type)}:${s.count}`)
         .join(',');
       defaultLogger.universalSearch.search.universalSearchQuery({
+        source,
         searchText: input,
         resultCount,
         exposedTypes,
       });
     },
-    [],
+    [source],
   );
 
   const isSearchResultStale = useCallback((input: string) => {
@@ -827,6 +831,7 @@ export function UniversalSearch({
               item={item}
               contextNetworkId={activeAccount?.network?.id}
               getSearchInput={getSearchInput}
+              source={source}
             />
           );
         case EUniversalSearchType.V2MarketToken:
@@ -841,6 +846,7 @@ export function UniversalSearch({
                 item={item}
                 isTrending={searchStatus === ESearchStatus.init}
                 getSearchInput={getSearchInput}
+                source={source}
               />
             </>
           );
@@ -850,6 +856,7 @@ export function UniversalSearch({
               item={item}
               allAggregateTokenMap={allAggregateTokenMap}
               getSearchInput={getSearchInput}
+              source={source}
             />
           );
         case EUniversalSearchType.Dapp:
@@ -857,6 +864,7 @@ export function UniversalSearch({
             <UniversalSearchDappItem
               item={item}
               getSearchInput={getSearchInput}
+              source={source}
             />
           );
         case EUniversalSearchType.Perp:
@@ -864,6 +872,7 @@ export function UniversalSearch({
             <UniversalSearchPerpItem
               item={item}
               getSearchInput={getSearchInput}
+              source={source}
             />
           );
         case EUniversalSearchType.Settings:
@@ -871,6 +880,7 @@ export function UniversalSearch({
             <UniversalSearchSettingsItem
               item={item}
               getSearchInput={getSearchInput}
+              source={source}
             />
           );
         default:
@@ -882,6 +892,7 @@ export function UniversalSearch({
       searchStatus,
       allAggregateTokenMap,
       getSearchInput,
+      source,
     ],
   );
 
@@ -1091,6 +1102,7 @@ const UniversalSearchWithHomeTokenListProvider = ({
   // array, so computing it inline in the prop would rebuild the downstream
   // allowedSearchTypeSet memo (and its dependents) on every wrapper re-render.
   const routeFilterTypes = route?.params?.filterTypes;
+  const source = route?.params?.source ?? EUniversalSearchSource.Unknown;
   const filterTypes = useMemo(
     () => routeFilterTypes || getDefaultFilterTypes(),
     [routeFilterTypes],
@@ -1103,6 +1115,7 @@ const UniversalSearchWithHomeTokenListProvider = ({
       <UniversalSearch
         filterTypes={filterTypes}
         initialTab={route?.params?.initialTab}
+        source={source}
       />
     </HomeTokenListProviderMirrorWrapper>
   );

--- a/packages/kit/src/views/UniversalSearch/universalSearchSource.test.ts
+++ b/packages/kit/src/views/UniversalSearch/universalSearchSource.test.ts
@@ -1,0 +1,44 @@
+import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import { EUniversalSearchSource } from '@onekeyhq/shared/types/search';
+
+import { getUniversalSearchSource } from './universalSearchSource';
+
+describe('getUniversalSearchSource', () => {
+  it.each([
+    [ETabRoutes.Home, EUniversalSearchSource.Wallet],
+    [ETabRoutes.BulkSend, EUniversalSearchSource.Wallet],
+    [ETabRoutes.SubPage, EUniversalSearchSource.Wallet],
+    [ETabRoutes.Market, EUniversalSearchSource.Market],
+    [ETabRoutes.Swap, EUniversalSearchSource.Swap],
+    [ETabRoutes.Perp, EUniversalSearchSource.Perps],
+    [ETabRoutes.WebviewPerpTrade, EUniversalSearchSource.Perps],
+    [ETabRoutes.Earn, EUniversalSearchSource.Earn],
+    [ETabRoutes.Discovery, EUniversalSearchSource.Browser],
+    [ETabRoutes.MultiTabBrowser, EUniversalSearchSource.Browser],
+    [ETabRoutes.DeviceManagement, EUniversalSearchSource.DeviceManagement],
+    [ETabRoutes.ReferFriends, EUniversalSearchSource.ReferFriends],
+    [ETabRoutes.Developer, EUniversalSearchSource.Developer],
+  ])('maps desktop tab %s to %s', (tabRoute, expected) => {
+    expect(getUniversalSearchSource(tabRoute)).toBe(expected);
+  });
+
+  it.each([
+    [ETabRoutes.Market, EUniversalSearchSource.Market],
+    [ETabRoutes.Earn, EUniversalSearchSource.Earn],
+    [ETabRoutes.Discovery, EUniversalSearchSource.Browser],
+  ])('maps native Discovery sub-tab %s to %s', (tabRoute, expected) => {
+    expect(getUniversalSearchSource(tabRoute)).toBe(expected);
+  });
+
+  it('maps the current desktop shortcut tab at invocation time', () => {
+    expect(getUniversalSearchSource(ETabRoutes.Swap)).toBe(
+      EUniversalSearchSource.Swap,
+    );
+  });
+
+  it('falls back to unknown when no tab route is available', () => {
+    expect(getUniversalSearchSource(undefined)).toBe(
+      EUniversalSearchSource.Unknown,
+    );
+  });
+});

--- a/packages/kit/src/views/UniversalSearch/universalSearchSource.ts
+++ b/packages/kit/src/views/UniversalSearch/universalSearchSource.ts
@@ -1,0 +1,33 @@
+import { ETabRoutes } from '@onekeyhq/shared/src/routes';
+import { EUniversalSearchSource } from '@onekeyhq/shared/types/search';
+
+export function getUniversalSearchSource(
+  tabRoute: ETabRoutes | undefined,
+): EUniversalSearchSource {
+  switch (tabRoute) {
+    case ETabRoutes.Home:
+    case ETabRoutes.BulkSend:
+    case ETabRoutes.SubPage:
+      return EUniversalSearchSource.Wallet;
+    case ETabRoutes.Market:
+      return EUniversalSearchSource.Market;
+    case ETabRoutes.Swap:
+      return EUniversalSearchSource.Swap;
+    case ETabRoutes.Perp:
+    case ETabRoutes.WebviewPerpTrade:
+      return EUniversalSearchSource.Perps;
+    case ETabRoutes.Earn:
+      return EUniversalSearchSource.Earn;
+    case ETabRoutes.Discovery:
+    case ETabRoutes.MultiTabBrowser:
+      return EUniversalSearchSource.Browser;
+    case ETabRoutes.DeviceManagement:
+      return EUniversalSearchSource.DeviceManagement;
+    case ETabRoutes.ReferFriends:
+      return EUniversalSearchSource.ReferFriends;
+    case ETabRoutes.Developer:
+      return EUniversalSearchSource.Developer;
+    default:
+      return EUniversalSearchSource.Unknown;
+  }
+}

--- a/packages/shared/src/logger/scopes/transaction/scenes/send.ts
+++ b/packages/shared/src/logger/scopes/transaction/scenes/send.ts
@@ -4,6 +4,11 @@ import type { EUtxoSelectionStrategy } from '@onekeyhq/shared/types/send';
 import { BaseScene } from '../../../base/baseScene';
 import { LogToLocal, LogToServer } from '../../../base/decorators';
 
+import type {
+  IGasAccountActionParams,
+  IGasAccountAnalyticsContext,
+} from '../types';
+
 type ISendMode = 'public' | 'private';
 type IPrivateSendQuoteStatus = 'success' | 'failed';
 type IPrivateSendFinalStatus = 'done' | 'failed';
@@ -358,23 +363,27 @@ export class SendScene extends BaseScene {
   }
 
   @LogToServer()
-  public insufficientFeeOnConfirm({
-    network,
-    tokenSymbol,
-    fillUpAmount,
-    feeType,
-  }: {
-    network: string | undefined;
-    tokenSymbol: string | undefined;
-    fillUpAmount: string | undefined;
-    feeType: 'native' | 'token';
-  }) {
+  public gasAccountDecision(params: IGasAccountAnalyticsContext) {
+    return params;
+  }
+
+  @LogToServer()
+  public gasAccountAction(params: IGasAccountActionParams) {
+    return params;
+  }
+
+  @LogToServer()
+  public insufficientFeeOnConfirm(
+    params: {
+      network: string | undefined;
+      tokenSymbol: string | undefined;
+      fillUpAmount: string | undefined;
+      feeType: 'native' | 'token';
+    } & Partial<Omit<IGasAccountAnalyticsContext, 'network'>>,
+  ) {
     return {
       sendFlowId: this._sendFlowId,
-      network,
-      tokenSymbol,
-      fillUpAmount,
-      feeType,
+      ...params,
     };
   }
 

--- a/packages/shared/src/logger/scopes/transaction/types.ts
+++ b/packages/shared/src/logger/scopes/transaction/types.ts
@@ -1,0 +1,72 @@
+import type {
+  IGasAccountScenario,
+  IGasPayer,
+} from '@onekeyhq/shared/types/fee';
+
+export type IGasAccountShortageType =
+  | 'unknown'
+  | 'none'
+  | 'principal'
+  | 'extraFee'
+  | 'networkFee'
+  | 'mixed';
+
+export type IGasAccountEntryPoint =
+  | 'txConfirm'
+  | 'swapDirect'
+  | 'marketSwapDirect';
+
+export type IGasAccountFiatBucket =
+  | 'unknown'
+  | 'lt_0_01'
+  | '0_01_0_1'
+  | '0_1_1'
+  | '1_5'
+  | 'gte_5';
+
+export interface IGasAccountAnalyticsContext {
+  entryPoint: IGasAccountEntryPoint;
+  network: string;
+  scenario: IGasAccountScenario | undefined;
+  gasAccountRequested: boolean;
+  gasAccountSupported: boolean | null;
+  gasAccountEligible: boolean | null;
+  selectedPayer: 'user' | 'gasAccount';
+  effectiveFeePayer: IGasPayer;
+  unavailableReason: string | undefined;
+  nativeBalanceAvailable: boolean;
+  selfPayGasSufficient: boolean | null;
+  shortageType: IGasAccountShortageType;
+  estimatedGasNative: string;
+  estimatedGasFiat: string | undefined;
+  gasShortfallNative: string | undefined;
+  gasShortfallFiat: string | undefined;
+  gasShortfallFiatBucket: IGasAccountFiatBucket;
+  nativeBalanceFiatBucket: IGasAccountFiatBucket;
+  fiatCurrency: string | undefined;
+  fiatValueAvailable: boolean;
+  quoteId: string | undefined;
+  orderId: string | undefined;
+}
+
+export type IGasAccountActionType =
+  | 'confirmClicked'
+  | 'payerChanged'
+  | 'submitSucceeded'
+  | 'submitFailed'
+  | 'exited';
+
+export interface IGasAccountActionParams extends IGasAccountAnalyticsContext {
+  action: IGasAccountActionType;
+  fromPayer?: IGasPayer;
+  toPayer?: IGasPayer;
+  changeSource?: 'user' | 'system';
+  changeReason?:
+    | 'userSelection'
+    | 'quoteExpired'
+    | 'quoteFailed'
+    | 'submitFailed'
+    | 'unknown';
+  failureStage?: 'precheck' | 'prepare' | 'submit' | 'unknown';
+  errorCode?: number;
+}

--- a/packages/shared/src/logger/scopes/universalSearch/scenes/search.test.ts
+++ b/packages/shared/src/logger/scopes/universalSearch/scenes/search.test.ts
@@ -1,0 +1,64 @@
+import {
+  EUniversalSearchSource,
+  EUniversalSearchType,
+} from '@onekeyhq/shared/types/search';
+
+import { SearchScene } from './search';
+
+describe('SearchScene', () => {
+  it('keeps the source on universal search query events', () => {
+    const scene = new SearchScene();
+    const emitLog = jest
+      .spyOn(scene, '_emitLog')
+      .mockImplementation(() => undefined);
+    const params = {
+      source: EUniversalSearchSource.Wallet,
+      searchText: 'one',
+      resultCount: 2,
+      exposedTypes: 'market:2',
+    };
+
+    scene.universalSearchQuery(params);
+
+    expect(emitLog).toHaveBeenCalledWith(
+      'universalSearchQuery',
+      [params],
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'server' }),
+        expect.objectContaining({ type: 'local' }),
+      ]),
+    );
+  });
+
+  it('keeps the source while normalizing click result types', () => {
+    const scene = new SearchScene();
+    const emitLog = jest
+      .spyOn(scene, '_emitLog')
+      .mockImplementation(() => undefined);
+
+    scene.universalSearchClick({
+      source: EUniversalSearchSource.Browser,
+      searchText: 'eth',
+      type: EUniversalSearchType.V2MarketToken,
+      itemId: 'eth',
+      itemTitle: 'ETH',
+    });
+
+    expect(emitLog).toHaveBeenCalledWith(
+      'universalSearchClick',
+      [
+        {
+          source: EUniversalSearchSource.Browser,
+          searchText: 'eth',
+          type: 'market',
+          itemId: 'eth',
+          itemTitle: 'ETH',
+        },
+      ],
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'server' }),
+        expect.objectContaining({ type: 'local' }),
+      ]),
+    );
+  });
+});

--- a/packages/shared/src/logger/scopes/universalSearch/types.ts
+++ b/packages/shared/src/logger/scopes/universalSearch/types.ts
@@ -1,3 +1,4 @@
+import type { EUniversalSearchSource } from '@onekeyhq/shared/types/search';
 import { EUniversalSearchType } from '@onekeyhq/shared/types/search';
 
 const searchTypeTrackingNameMap: Record<EUniversalSearchType, string> = {
@@ -16,6 +17,10 @@ export function getSearchTypeTrackingName(type: EUniversalSearchType): string {
 
 export interface IUniversalSearchParams {
   /**
+   * Business page where the search modal was opened
+   */
+  source: EUniversalSearchSource;
+  /**
    * The search text entered by the user
    */
   searchText: string;
@@ -30,6 +35,7 @@ export interface IUniversalSearchParams {
 }
 
 export interface ISearchResultClickParams {
+  source: EUniversalSearchSource;
   searchText: string;
   type: EUniversalSearchType;
   itemId: string;

--- a/packages/shared/src/routes/universalSearch.ts
+++ b/packages/shared/src/routes/universalSearch.ts
@@ -1,4 +1,7 @@
-import type { EUniversalSearchType } from '../../types/search';
+import type {
+  EUniversalSearchSource,
+  EUniversalSearchType,
+} from '../../types/search';
 
 export enum EUniversalSearchPages {
   UniversalSearch = 'UniversalSearch',
@@ -7,6 +10,7 @@ export enum EUniversalSearchPages {
 
 export type IUniversalSearchParamList = {
   [EUniversalSearchPages.UniversalSearch]: {
+    source: EUniversalSearchSource;
     filterTypes?: EUniversalSearchType[];
     initialTab?: 'market' | 'dapp';
   };

--- a/packages/shared/types/search.ts
+++ b/packages/shared/types/search.ts
@@ -24,6 +24,19 @@ export enum EUniversalSearchType {
   Settings = 'Settings',
 }
 
+export enum EUniversalSearchSource {
+  Wallet = 'wallet',
+  Market = 'market',
+  Swap = 'swap',
+  Perps = 'perps',
+  Earn = 'earn',
+  Browser = 'browser',
+  DeviceManagement = 'deviceManagement',
+  ReferFriends = 'referFriends',
+  Developer = 'developer',
+  Unknown = 'unknown',
+}
+
 export enum ESearchStatus {
   init = 'init',
   loading = 'loading',

--- a/packages/shared/types/setting.ts
+++ b/packages/shared/types/setting.ts
@@ -14,6 +14,7 @@ export type IClearCacheOnAppState = {
   serverNetworks: boolean;
   connectSites: boolean;
   signatureRecord: boolean;
+  perpsData?: boolean;
 };
 
 export enum EReasonForNeedPassword {

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -596,6 +596,7 @@ export interface ISwapGasInfo {
   payer?: IGasPayer;
   gasAccountEligible?: boolean;
   gasAccountQuote?: IGasAccountQuote;
+  gasAccountScenarioReason?: string;
 }
 export interface ISwapPreSwapData {
   fromToken?: ISwapToken;


### PR DESCRIPTION
Sync bundle release changes from `release/v6.5.0` to `x` (after release #7).

Baseline: `bc5d83e3b1` (#12792), the last commit synced by #12812.

## Synced (6)

| Commit | PR |
|---|---|
| `ee380a24fa` | fix: prevent iPad dapp touch freeze (#12806) |
| `ca178118af` | fix: keep the perps first screen height stable on cold start (#12793) — **partial, see follow-up** |
| `4c0efaff64` | fix: correct iPad settings scrolling (#12813) |
| `794447804a` | fix: center desktop browser banner (#12826) |
| `fdd51b0607` | fix: restore perps chart on Android foldables (#12821) |
| `8cd90afe6e` | fix: self-heal unreadable SimpleDB records and support clearing Perps data (#12827) |

## Deliberately skipped

| Commit | Reason |
|---|---|
| `3f3f50f6af` Feat/spark bitway (#12765) | Already skipped by #12812 — backport of #12463, which is on `x`. Unchanged decision. |
| `54197b5967` / `1a75a3823f` chore: release #6 / #7 | Release-tracking only (`RELEASES.json`), must not sync to `x`. |

## ⚠️ Needs module owner (not in this PR)

These four carry real fixes `x` lacks, but `x` refactored the same code independently — a mechanical merge would regress `x`.

| PR | Conflict | Why it needs an owner |
|---|---|---|
| #12823 gas account funnel analytics | 10 hunks / 4 files | `x`'s #12837 (*improve Swap quote and sponsored fee states*, 08-12) rewrote the gas-account sponsorship path in `useSwapBuiltTx.ts` and `marketDirectSendTx.ts`. #12823 instruments the pre-#12837 shape. Needs someone across both. |
| #12834 track universal search source | 2 files | `x`'s `DappHeader.tsx` no longer renders `UniversalSearchInput`; applying the hunk would re-add UI `x` removed. `universalSearchSource.ts` is genuinely absent from `x`, so the tracking needs re-wiring to `x`'s entry points. |
| #12791 DeFi revamp for mobile 1.0 | 41 files | Earn/Borrow/Staking evolved independently on `x`. Largest single change in the release (93 files). |
| #12848 harden Swap recipient and warning flows | 7 files | `states/jotai/contexts/swap/actions.ts` was rewritten on `x` by #12862 (*stabilize Swap flows*) on the same day. Swap recipient resolution — not safe to merge mechanically. |

### Follow-up from #12793 (partial sync)

Only the `PerpOrderBook.tsx` half was applied. The `PerpTradingPanel.tsx` half — excluding **watch-only accounts** from cached trading buttons during cold start — was dropped: `x` replaced that condition with `canShowCachedTradingButtons = isLiveStatusPending`, so the release patch has nowhere to land.

Verified `x` has **no** watch-only guard on this path (`perpsOrderPanelEnableTrading.ts`, `usePerpsAccountDisplayState.ts`, and the panel itself are all clear of `isWatchingAccount`), so the gap is real and still open.

## Conflicts resolved in this PR

1. **`PerpOrderBook.tsx`** (#12793) — `x` added `shouldCompactOrderBookForFirstDeposit`/`ForConnectWallet` branches ahead of the spot check. Both derive from perps account state, which is exactly the class of flag #12793 fixed (reads true until the account address resolves → spot cold start renders 7 levels then collapses). Hoisted the spot check above all three flags and generalised the comment; `x`'s branches kept intact for perps mode.
2. **`SubSettingsPage.tsx`** (#12813) — kept `x`'s richer `Page.Header`, applied only the fix: dropped `scrollEnabled` so the inner `ScrollView` owns scrolling and `contentInsetAdjustmentBehavior` applies to the right scroller.
3. **`config.tsx`** (#12813) — kept `x`'s desktop link-tab derivation; folded the `shouldShowUpdate` refactor into its dep array.
4. **`PerpTokenSelector.tsx`** (#12821) — additive: `x` added `activePerpsAccount`, release added `isSplitMainActive`. Kept both hooks and unioned the dep array (`activePerpsAccount.walletType` is still read by the analytics call in the callback).
5. **`ServiceSetting.ts`** (#12827) — additive: kept `x`'s `values.oneKeyId` branch and the release's `values.perpsData` branch, preserving the ordering comment on the `oneKeyId` logout.
6. **`SimpleDbEntityBase.ts`** (#12827) — took the release side (superset adding `writeSeq`/`pendingWrites`/`readGeneration`). Widens `clearRawDataCache` from `protected` to public + `@backgroundMethod()`; the one external caller (`SimpleDbEntityBTCFreshAddress.ts`) uses `this.`, so widening is safe.
7. **`case-studies.md`** — kept both retrospective entries.

## Verification

- No conflict markers in any changed file
- No `RELEASES.json` / `.env.version` in the diff
- No files added vs `origin/x`
- 15 files changed, +559 / -50

⚠️ **Tests were not run.** The worktree used for this sync has no `node_modules`, so jest could not start (`react-native-gesture-handler/jestSetup.js` not found). The conflict resolutions above are unverified by test — `SimpleDbEntityBase.test.ts` in particular is worth running before merge.