### PR TITLE
fix: restore Swap recipient editor context (OK-60100)

### DIFF
--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts
@@ -4,12 +4,86 @@ import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 import {
   getSwapAddressAccountSelectorNum,
   getSwapRecipientActionState,
+  getSwapRecipientEditorAccountInfo,
   getSwapRecipientValidationAccountId,
   resolveSwapTargetNetworkAccount,
   shouldResetSwapRecipientOnAccountNetworkSync,
   shouldShowSwapRecipientAddressInfo,
   shouldUseSwapCustomRecipientAddress,
 } from './useSwapAccount.utils';
+
+import type { IAccountSelectorActiveAccountInfo } from '../../../states/jotai/contexts/accountSelector';
+
+function buildAccountInfo({
+  accountId,
+  ready = true,
+}: {
+  accountId?: string;
+  ready?: boolean;
+} = {}): IAccountSelectorActiveAccountInfo {
+  return {
+    ready,
+    account: accountId
+      ? ({ id: accountId } as IAccountSelectorActiveAccountInfo['account'])
+      : undefined,
+    indexedAccount: undefined,
+    dbAccount: undefined,
+    accountName: '',
+    wallet: undefined,
+    device: undefined,
+    network: undefined,
+    vaultSettings: undefined,
+    deriveType: undefined,
+    deriveInfoItems: [],
+  };
+}
+
+describe('getSwapRecipientEditorAccountInfo', () => {
+  it('prefers ready recipient ownership information', () => {
+    const recipientAccountInfo = buildAccountInfo({
+      accountId: 'recipient-account',
+    });
+    const activeAccount = buildAccountInfo({ accountId: 'active-account' });
+
+    expect(
+      getSwapRecipientEditorAccountInfo({
+        recipientAccountInfo,
+        activeAccount,
+      }),
+    ).toBe(recipientAccountInfo);
+  });
+
+  it('falls back to a ready active account for an external recipient', () => {
+    const activeAccount = buildAccountInfo({ accountId: 'active-account' });
+
+    expect(
+      getSwapRecipientEditorAccountInfo({
+        recipientAccountInfo: undefined,
+        activeAccount,
+      }),
+    ).toBe(activeAccount);
+  });
+
+  it('allows a ready editor context before its network account is created', () => {
+    const activeAccount = buildAccountInfo();
+
+    expect(
+      getSwapRecipientEditorAccountInfo({
+        recipientAccountInfo: undefined,
+        activeAccount,
+      }),
+    ).toBe(activeAccount);
+  });
+
+  it('waits until an account context is ready', () => {
+    expect(
+      getSwapRecipientEditorAccountInfo({
+        recipientAccountInfo: buildAccountInfo({ ready: false }),
+        activeAccount: buildAccountInfo({ ready: false }),
+      }),
+    ).toBeUndefined();
+  });
+});
 
 describe('resolveSwapTargetNetworkAccount', () => {
   beforeEach(() => {

--- a/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapAccount.utils.ts
@@ -4,6 +4,8 @@ import { equalsIgnoreCase } from '@onekeyhq/shared/src/utils/stringUtils';
 import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
 import { ESwapDirectionType } from '@onekeyhq/shared/types/swap/types';
 
+import type { IAccountSelectorActiveAccountInfo } from '../../../states/jotai/contexts/accountSelector';
+
 const SWAP_TARGET_DERIVE_TYPE_RETRY_DELAY_MS = 500;
 
 type IShouldUseSwapCustomRecipientAddressParams = {
@@ -44,6 +46,11 @@ type IGetSwapRecipientValidationAccountIdParams = {
   accountId?: string;
   accountAddress?: string;
   recipientAddress?: string;
+};
+
+type IGetSwapRecipientEditorAccountInfoParams = {
+  recipientAccountInfo?: IAccountSelectorActiveAccountInfo;
+  activeAccount?: IAccountSelectorActiveAccountInfo;
 };
 
 type IGetSwapAddressAccountSelectorNumParams = {
@@ -116,6 +123,21 @@ export function getSwapRecipientActionState({
     shouldEnterRecipient,
     shouldDisableAction: !shouldEnterRecipient,
   };
+}
+
+export function getSwapRecipientEditorAccountInfo({
+  recipientAccountInfo,
+  activeAccount,
+}: IGetSwapRecipientEditorAccountInfoParams) {
+  if (recipientAccountInfo?.ready) {
+    return recipientAccountInfo;
+  }
+
+  if (activeAccount?.ready) {
+    return activeAccount;
+  }
+
+  return undefined;
 }
 
 export function getSwapRecipientValidationAccountId({

--- a/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapToAnotherAddressModal.tsx
@@ -39,7 +39,10 @@ import RecipientQuickSelect from '../../../Send/pages/SendDataInput/RecipientQui
 import { shouldSkipResolvedRecipientUpdate } from '../../../Send/pages/SendDataInput/recipientSelectionUtils';
 import { useWebDappRecipientOptions } from '../../../Send/pages/SendDataInput/useWebDappRecipientOptions';
 import { useSwapAddressInfo } from '../../hooks/useSwapAccount';
-import { getSwapRecipientValidationAccountId } from '../../hooks/useSwapAccount.utils';
+import {
+  getSwapRecipientEditorAccountInfo,
+  getSwapRecipientValidationAccountId,
+} from '../../hooks/useSwapAccount.utils';
 import { SwapProviderMirror } from '../SwapProviderMirror';
 
 import type { IRecipientQuickSelectTab } from '../../../Send/pages/SendDataInput/recipientQuickSelectTabUtils';
@@ -62,6 +65,10 @@ const SwapToAnotherAddressPage = () => {
     address: recipientAccountAddress,
     networkId,
   } = useSwapAddressInfo(ESwapDirectionType.TO);
+  const editorAccountInfo = getSwapRecipientEditorAccountInfo({
+    recipientAccountInfo: accountInfo,
+    activeAccount,
+  });
   const validationAccountId = getSwapRecipientValidationAccountId({
     accountId: accountInfo?.account?.id,
     accountAddress: accountInfo?.account?.addressDetail?.address,
@@ -178,7 +185,7 @@ const SwapToAnotherAddressPage = () => {
     setSwapToAddress((v) => ({ ...v, address: undefined }));
   }, [setSwapToAddress, setSettings]);
 
-  return accountInfo && networkId ? (
+  return editorAccountInfo && networkId ? (
     <Page scrollEnabled>
       <Page.Header
         title={intl.formatMessage({


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60100](https://onekeyhq.atlassian.net/browse/OK-60100)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Port only the `OK-60100` recipient-editor fix from #12848 onto the #12882 sync branch.
- Keep `x`'s evolved Swap recipient/action/quote state and strict recipient ownership validation.
- Allow the editor to render with a ready active-account context when an external or address-book recipient has no owned `accountInfo`.

## Conflict resolution

- Updated only the three recipient-editor owner files.
- Deliberately left the other #12848 conflict areas unchanged because their behavior already evolved independently on `x` or belongs to other module-owner follow-ups.

## Issues

- Fixes OK-60100

## Validation

- `yarn jest packages/kit/src/views/Swap/hooks/useSwapAccount.utils.test.ts --runInBand` — 32/32 passed.
- `yarn agent:check --profile commit` — changed-file lint, format, agent context, and lint-staged passed; `tsc-staged` is blocked by the unchanged #12882 base syntax error in `packages/kit/src/views/Setting/pages/Tab/SubSettingsPage.tsx:98`.
- `yarn agent:check --profile pr` — same base-only `tsc-staged` blocker.
- Runtime UI verification was not rerun for this conflict-resolution PR.

## Risk

Low and localized. The fallback only controls editor readiness; `getSwapRecipientValidationAccountId` still requires the account address to match the selected recipient, so the fallback account is not treated as transaction ownership.

[OK-60100]: https://onekeyhq.atlassian.net/browse/OK-60100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ