### PR TITLE
feat: sync gas account analytics to x

### DIFF
--- a/packages/kit/src/states/jotai/contexts/signatureConfirm/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/signatureConfirm/actions.ts
@@ -349,6 +349,7 @@ class ContextJotaiActionsSignatureConfirm extends ContextJotaiActionsBase {
         lockedUserNonce?: number;
         idempotencyKey?: string;
         gasAccountScenarioReason?: string;
+        sponsorDisabledByCustomRpc?: boolean;
       },
     ) => {
       set(gasAccountUiStateAtom(), {

--- a/packages/kit/src/states/jotai/contexts/signatureConfirm/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/signatureConfirm/atoms.ts
@@ -230,6 +230,7 @@ export const defaultGasAccountUiState = {
   selectedPayer: 'user' as const,
   lockedUserNonce: undefined as number | undefined,
   idempotencyKey: '',
+  gasAccountScenarioReason: undefined as string | undefined,
 };
 
 export const { atom: gasAccountUiStateAtom, use: useGasAccountUiStateAtom } =
@@ -240,6 +241,7 @@ export const { atom: gasAccountUiStateAtom, use: useGasAccountUiStateAtom } =
     selectedPayer: 'user' | 'gasAccount';
     lockedUserNonce?: number;
     idempotencyKey: string;
+    gasAccountScenarioReason?: string;
   }>({ ...defaultGasAccountUiState });
 
 export const {

--- a/packages/kit/src/states/jotai/contexts/signatureConfirm/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/signatureConfirm/atoms.ts
@@ -231,6 +231,7 @@ export const defaultGasAccountUiState = {
   lockedUserNonce: undefined as number | undefined,
   idempotencyKey: '',
   gasAccountScenarioReason: undefined as string | undefined,
+  sponsorDisabledByCustomRpc: false,
 };
 
 export const { atom: gasAccountUiStateAtom, use: useGasAccountUiStateAtom } =
@@ -242,6 +243,7 @@ export const { atom: gasAccountUiStateAtom, use: useGasAccountUiStateAtom } =
     lockedUserNonce?: number;
     idempotencyKey: string;
     gasAccountScenarioReason?: string;
+    sponsorDisabledByCustomRpc: boolean;
   }>({ ...defaultGasAccountUiState });
 
 export const {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.test.tsx
@@ -62,6 +62,7 @@ describe('MarketSwapReviewDialog', () => {
 
   it('delegates to the generic swap review shell with market-specific config', () => {
     const onDone = jest.fn();
+    const onConfirmStart = jest.fn();
     const adapter = {
       prepareReview: jest.fn(),
       sendApproveTx: jest.fn(),
@@ -84,6 +85,7 @@ describe('MarketSwapReviewDialog', () => {
     render(
       <MarketSwapReviewDialog
         onDone={onDone}
+        onConfirmStart={onConfirmStart}
         adapter={adapter}
         reviewState={reviewState}
       />,
@@ -91,6 +93,7 @@ describe('MarketSwapReviewDialog', () => {
 
     expect(swapReviewDialogMock).toHaveBeenCalledWith({
       onDone,
+      onConfirmStart,
       adapter,
       reviewState,
       storeName: EJotaiContextStoreNames.marketSwapReview,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/MarketSwapReviewDialog.tsx
@@ -11,6 +11,7 @@ import type { ESwapNetworkFeeLevel } from '@onekeyhq/shared/types/swap/types';
 
 type IMarketSwapReviewDialogProps = {
   onDone: () => void;
+  onConfirmStart?: () => void;
   adapter: ISwapReviewAdapter;
   reviewState: ISwapReviewState;
   defaultNetworkFeeLevel?: ESwapNetworkFeeLevel;
@@ -20,6 +21,7 @@ type IMarketSwapReviewDialogProps = {
 
 export function MarketSwapReviewDialog({
   onDone,
+  onConfirmStart,
   adapter,
   reviewState,
   defaultNetworkFeeLevel,
@@ -29,6 +31,7 @@ export function MarketSwapReviewDialog({
   return (
     <SwapReviewDialog
       onDone={onDone}
+      onConfirmStart={onConfirmStart}
       adapter={adapter}
       reviewState={reviewState}
       defaultNetworkFeeLevel={defaultNetworkFeeLevel}

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
@@ -22,6 +22,11 @@ import {
 } from '@onekeyhq/kit/src/views/Market/components/StockMarketStatusAlert';
 import { isOndoStockSource } from '@onekeyhq/kit/src/views/Market/components/utils/stockSource';
 import { usePerpsNavigation } from '@onekeyhq/kit/src/views/Market/hooks/usePerpsNavigation';
+import {
+  createGasAccountReviewSession,
+  logGasAccountReviewExit,
+  markGasAccountReviewSubmitted,
+} from '@onekeyhq/kit/src/views/Swap/utils/gasAccountAnalytics';
 import type { ISwapReviewAdapter } from '@onekeyhq/kit/src/views/Swap/utils/swapReviewState';
 import { dismissKeyboard } from '@onekeyhq/shared/src/keyboard';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -275,6 +280,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
     speedCheckLoading,
     estimateMarketPresetNetworkFees,
     prepareMarketSwapReview,
+    logMarketReviewGasAccountDecision,
     sendMarketApproveTx,
     sendMarketSwapTx,
     sendMarketWrappedTx,
@@ -556,6 +562,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
           void previousDialog.close();
         }
         setIsReviewDialogOpen(true);
+        const gasAccountReviewSession = createGasAccountReviewSession();
         let dialog: IDialogInstance | null = null;
         dialog = inPageDialog.show({
           title: intl.formatMessage({
@@ -568,6 +575,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
             if (reviewDialogRef.current !== dialog) {
               return;
             }
+            logGasAccountReviewExit(gasAccountReviewSession);
             reviewDialogRef.current = null;
             setIsReviewDialogOpen(false);
           },
@@ -578,6 +586,9 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
               defaultCustomPriorityFee={effectiveCustomPriorityFee}
               showCustomNetworkFeeOption={showReviewCustomNetworkFeeOption}
               reviewState={nextReviewState}
+              onConfirmStart={() =>
+                markGasAccountReviewSubmitted(gasAccountReviewSession)
+              }
               onDone={() => void dialog?.close()}
             />
           ),
@@ -588,6 +599,8 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
           return;
         }
         reviewDialogRef.current = dialog;
+        gasAccountReviewSession.analyticsContext =
+          logMarketReviewGasAccountDecision();
       } catch (error) {
         if (reviewDialogRequestIdRef.current !== requestId) {
           return;
@@ -614,6 +627,7 @@ export function SwapPanelWrap({ onCloseDialog }: ISwapPanelWrapProps) {
       effectiveCustomPriorityFee,
       effectiveNetworkFeeLevel,
       marketPresetSettings,
+      logMarketReviewGasAccountDecision,
       prepareMarketSwapReview,
       reviewAdapter,
     ],

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.test.ts
@@ -372,10 +372,12 @@ describe('marketDirectSendTx', () => {
       },
       gasAccountAnalytics: {
         fiatCurrency: 'usd',
+        nativeBalance: '0.005',
         useGasAccountByDefault: true,
       },
     });
 
+    expect(mockFetchSwapTokenDetails).not.toHaveBeenCalled();
     expect(mockGasAccountDecision).not.toHaveBeenCalled();
     expect(mockGasAccountAction).toHaveBeenNthCalledWith(
       1,
@@ -419,6 +421,8 @@ describe('marketDirectSendTx', () => {
         orderId: 'order-id',
       }),
     );
+    expect(result.gasAccountAnalyticsNativeBalance).toBe('0.005');
+    expect(mockFetchSwapTokenDetails).toHaveBeenCalledTimes(1);
     expect(mockGasAccountDecision).not.toHaveBeenCalled();
   });
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.test.ts
@@ -15,6 +15,21 @@ const mockBuildDecodedTx = jest.fn();
 const mockSaveSendConfirmHistoryTxs = jest.fn();
 const mockPreActionsBeforeSending = jest.fn();
 const mockAfterSendTxAction = jest.fn();
+const mockFetchSwapTokenDetails = jest.fn();
+const mockGetNativeTokenAddress = jest.fn();
+const mockGasAccountDecision = jest.fn();
+const mockGasAccountAction = jest.fn();
+
+jest.mock('@onekeyhq/shared/src/logger/logger', () => ({
+  defaultLogger: {
+    transaction: {
+      send: {
+        gasAccountDecision: mockGasAccountDecision,
+        gasAccountAction: mockGasAccountAction,
+      },
+    },
+  },
+}));
 
 jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
   __esModule: true,
@@ -44,6 +59,12 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
     serviceSignatureConfirm: {
       preActionsBeforeSending: mockPreActionsBeforeSending,
       afterSendTxAction: mockAfterSendTxAction,
+    },
+    serviceSwap: {
+      fetchSwapTokenDetails: mockFetchSwapTokenDetails,
+    },
+    serviceToken: {
+      getNativeTokenAddress: mockGetNativeTokenAddress,
     },
   },
 }));
@@ -94,6 +115,53 @@ function createEstimateFeeResult() {
   };
 }
 
+function createSponsoredUnsignedTx() {
+  return createUnsignedTx({
+    swapInfo: {
+      sender: {
+        amount: '10',
+        token: {
+          networkId: 'evm--1',
+          contractAddress: '0xtoken',
+          symbol: 'USDC',
+          decimals: 6,
+          isNative: false,
+        },
+      },
+      receiver: {
+        amount: '0.003',
+        token: {
+          networkId: 'evm--1',
+          contractAddress: '',
+          symbol: 'ETH',
+          decimals: 18,
+          isNative: true,
+        },
+      },
+      receivingAddress: '0xuser',
+      swapBuildResData: {
+        orderId: 'order-id',
+        result: {
+          gasAccountEnabled: true,
+        },
+      },
+    } as never,
+  });
+}
+
+function createSponsoredEstimateFeeResult(quoteId: string) {
+  return {
+    ...createEstimateFeeResult(),
+    payer: 'gasAccount',
+    gasAccountEligible: true,
+    gasAccountQuote: {
+      quoteId,
+      maxFee: '0.01',
+      expiresAt: '2026-08-10T12:00:00.000Z',
+    },
+  };
+}
+
 function createMarketPresetToken(overrides = {}) {
   return {
     contractAddress: '',
@@ -121,6 +189,10 @@ describe('marketDirectSendTx', () => {
     mockSaveSendConfirmHistoryTxs.mockReset();
     mockPreActionsBeforeSending.mockReset();
     mockAfterSendTxAction.mockReset();
+    mockFetchSwapTokenDetails.mockReset();
+    mockGetNativeTokenAddress.mockReset();
+    mockGasAccountDecision.mockReset();
+    mockGasAccountAction.mockReset();
 
     mockGetVaultSettings.mockResolvedValue({});
     mockBuildUnsignedTx.mockResolvedValue(createUnsignedTx());
@@ -146,6 +218,8 @@ describe('marketDirectSendTx', () => {
     mockSaveSendConfirmHistoryTxs.mockResolvedValue(undefined);
     mockPreActionsBeforeSending.mockResolvedValue(undefined);
     mockAfterSendTxAction.mockResolvedValue(undefined);
+    mockFetchSwapTokenDetails.mockResolvedValue([{ balanceParsed: '0.005' }]);
+    mockGetNativeTokenAddress.mockResolvedValue('');
   });
 
   it('builds market preset fake transfer info as an isolated self-transfer', () => {
@@ -276,6 +350,76 @@ describe('marketDirectSendTx', () => {
     expect(mockSignAndSendTransaction).toHaveBeenCalledTimes(1);
     expect(mockSaveSendConfirmHistoryTxs).toHaveBeenCalledTimes(1);
     expect(mockBatchEstimateFee).not.toHaveBeenCalled();
+  });
+
+  it('tracks Gas Account submission success without repeating the review decision', async () => {
+    const sponsoredUnsignedTx = createSponsoredUnsignedTx();
+    mockPrepareSendConfirmUnsignedTx.mockResolvedValue(sponsoredUnsignedTx);
+    mockEstimateFee.mockResolvedValue(
+      createSponsoredEstimateFeeResult('quote-id'),
+    );
+
+    await sendMarketDirectUnsignedTxs({
+      accountAddress: '0xuser',
+      accountId: 'account-1',
+      networkId: 'evm--1',
+      buildUnsignedParams: {
+        accountId: 'account-1',
+        networkId: 'evm--1',
+        encodedTx: sponsoredUnsignedTx.encodedTx,
+        swapInfo: sponsoredUnsignedTx.swapInfo,
+        isInternalSwap: true,
+      },
+      gasAccountAnalytics: {
+        fiatCurrency: 'usd',
+        useGasAccountByDefault: true,
+      },
+    });
+
+    expect(mockGasAccountDecision).not.toHaveBeenCalled();
+    expect(mockGasAccountAction).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        action: 'submitSucceeded',
+        orderId: 'order-id',
+      }),
+    );
+  });
+
+  it('returns the Gas Account decision context with the direct market review estimate', async () => {
+    const sponsoredUnsignedTx = createSponsoredUnsignedTx();
+    mockPrepareSendConfirmUnsignedTx.mockResolvedValue(sponsoredUnsignedTx);
+    mockEstimateFee.mockResolvedValue(
+      createSponsoredEstimateFeeResult('preview-quote-id'),
+    );
+
+    const result = await estimateMarketDirectGasInfos({
+      accountAddress: '0xuser',
+      accountId: 'account-1',
+      networkId: 'evm--1',
+      buildUnsignedParams: {
+        accountId: 'account-1',
+        networkId: 'evm--1',
+        encodedTx: sponsoredUnsignedTx.encodedTx,
+        swapInfo: sponsoredUnsignedTx.swapInfo,
+        isInternalSwap: true,
+      },
+      gasAccountAnalytics: {
+        fiatCurrency: 'usd',
+        useGasAccountByDefault: true,
+      },
+    });
+
+    expect(result.gasAccountAnalyticsContext).toEqual(
+      expect.objectContaining({
+        entryPoint: 'marketSwapDirect',
+        scenario: 'swap',
+        selectedPayer: 'gasAccount',
+        quoteId: 'preview-quote-id',
+        orderId: 'order-id',
+      }),
+    );
+    expect(mockGasAccountDecision).not.toHaveBeenCalled();
   });
 
   it('sends batch approve plus swap with batch fee estimation when supported', async () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.ts
@@ -3,9 +3,16 @@ import BigNumber from 'bignumber.js';
 import type { IEncodedTx, IUnsignedTxPro } from '@onekeyhq/core/src/types';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import {
-  EGasAccountErrorStrategy,
-  getGasAccountErrorEntry,
-} from '@onekeyhq/kit/src/views/SignatureConfirm/constants/gasAccountErrorCodes';
+  buildDirectSwapGasAccountAnalyticsContext,
+  buildDirectSwapGasAccountUiState,
+  runDirectSwapGasAccountStep,
+  sendDirectSwapWithGasAccountAnalytics,
+} from '@onekeyhq/kit/src/views/Swap/utils/gasAccountAnalytics';
+import {
+  buildNativeTokenFromGasInfo,
+  checkSwapLatestBalanceSufficient,
+} from '@onekeyhq/kit/src/views/Swap/utils/swapBalanceUtils';
+import { EGasAccountErrorStrategy } from '@onekeyhq/kit/src/views/SignatureConfirm/constants/gasAccountErrorCodes';
 import type {
   IBuildUnsignedTxParams,
   ITransferInfo,
@@ -16,7 +23,7 @@ import {
   BATCH_SEND_TXS_FEE_UP_RATIO_FOR_SWAP,
 } from '@onekeyhq/shared/src/consts/walletConsts';
 import { OneKeyError } from '@onekeyhq/shared/src/errors';
-import { getGasAccountErrorCode } from '@onekeyhq/shared/src/errors/utils/gasAccountErrorUtils';
+import type { IGasAccountAnalyticsContext } from '@onekeyhq/shared/src/logger/scopes/transaction/types';
 import { calculateFeeForSend } from '@onekeyhq/shared/src/utils/feeUtils';
 import { applyCustomPriorityFeeToGasInfo } from '@onekeyhq/shared/src/utils/marketPresetFeeUtils';
 import type {
@@ -30,7 +37,6 @@ import type {
   IFeeTron,
   IFeeUTXO,
   IGasAccountQuote,
-  IGasAccountUiState,
   IGasEIP1559,
   IGasLegacy,
   IGasPayer,
@@ -70,6 +76,10 @@ type IMarketDirectSendParams = {
   tronResourceRentalInfo?: ITronResourceRentalInfo;
   useDefaultRpc?: boolean;
   validateFinalGasInfos?: (gasInfos: IMarketGasInfoEntry[]) => Promise<void>;
+  gasAccountAnalytics?: {
+    fiatCurrency?: string;
+    useGasAccountByDefault?: boolean;
+  };
 };
 
 type IEstimateMarketDirectGasInfosParams = Omit<
@@ -156,6 +166,7 @@ function buildGasInfo(
     payer?: IGasPayer;
     gasAccountEligible?: boolean;
     gasAccountQuote?: IGasAccountQuote;
+    gasAccountScenarioReason?: string;
   },
   gasCommon: {
     baseFee?: string;
@@ -192,6 +203,7 @@ function buildGasInfo(
     payer: gasRes.payer,
     gasAccountEligible: gasRes.gasAccountEligible,
     gasAccountQuote: gasRes.gasAccountQuote,
+    gasAccountScenarioReason: gasRes.gasAccountScenarioReason,
   };
 }
 
@@ -919,10 +931,12 @@ export async function estimateMarketDirectGasInfos({
   approveUnsignedTxArr,
   networkFeeLevel,
   customPriorityFee,
+  gasAccountAnalytics,
 }: IEstimateMarketDirectGasInfosParams): Promise<{
   gasInfos: IMarketGasInfoEntry[];
   gasFeeFiatValue?: string;
   preparedUnsignedTx: IUnsignedTxPro;
+  gasAccountAnalyticsContext?: IGasAccountAnalyticsContext;
 }> {
   if (!accountId || !networkId || !accountAddress) {
     throw new OneKeyError('account error');
@@ -950,10 +964,39 @@ export async function estimateMarketDirectGasInfos({
     customPriorityFee,
   });
 
+  let gasAccountAnalyticsContext: IGasAccountAnalyticsContext | undefined;
+  const swapGasInfo = findGasInfo(gasInfos, unsignedTx.encodedTx);
+  if (gasAccountAnalytics && swapGasInfo && unsignedTx.swapInfo) {
+    const nativeToken = buildNativeTokenFromGasInfo({
+      gasInfo: swapGasInfo.gasInfo,
+      networkId,
+      fromToken: unsignedTx.swapInfo.sender.token,
+    });
+    const latestNativeBalance = nativeToken
+      ? await checkSwapLatestBalanceSufficient({
+          token: nativeToken,
+          amount: '0',
+          accountAddress,
+          accountId,
+        })
+      : undefined;
+    gasAccountAnalyticsContext = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'marketSwapDirect',
+      networkId,
+      unsignedTx,
+      gasInfo: swapGasInfo.gasInfo,
+      estimateFeeParams: swapGasInfo.estimateFeeParams,
+      nativeBalance: latestNativeBalance?.balance,
+      useGasAccountByDefault: gasAccountAnalytics.useGasAccountByDefault,
+      fiatCurrency: gasAccountAnalytics.fiatCurrency,
+    });
+  }
+
   return {
     gasInfos,
     gasFeeFiatValue: buildGasFeeFiatValue(gasInfos),
     preparedUnsignedTx: unsignedTx,
+    gasAccountAnalyticsContext,
   };
 }
 
@@ -1002,6 +1045,7 @@ export async function estimateMarketApproveGasInfos({
 }
 
 async function updateUnsignedTxAndSendTx({
+  accountAddress,
   accountId,
   networkId,
   unsignedTxItem,
@@ -1010,7 +1054,9 @@ async function updateUnsignedTxAndSendTx({
   tronResourceRentalInfo,
   useDefaultRpc,
   onBeforeGasAccountFallback,
+  gasAccountAnalytics,
 }: {
+  accountAddress: string;
   accountId: string;
   networkId: string;
   unsignedTxItem: IUnsignedTxPro;
@@ -1019,6 +1065,7 @@ async function updateUnsignedTxAndSendTx({
   tronResourceRentalInfo?: ITronResourceRentalInfo;
   useDefaultRpc?: boolean;
   onBeforeGasAccountFallback?: () => Promise<void>;
+  gasAccountAnalytics?: IMarketDirectSendParams['gasAccountAnalytics'];
 }): Promise<ISendTxOnSuccessData> {
   const feeInfo = buildMarketGasInfoFeeInfo(gasInfo);
 
@@ -1030,20 +1077,6 @@ async function updateUnsignedTxAndSendTx({
       feeInfo,
       tronResourceRentalInfo,
     });
-
-  await backgroundApiProxy.serviceSend.precheckUnsignedTxs({
-    networkId,
-    accountId,
-    unsignedTxs: [updatedUnsignedTxItem],
-    precheckTiming: ESendPreCheckTimingEnum.Confirm,
-  });
-
-  await backgroundApiProxy.serviceSignatureConfirm.preActionsBeforeSending({
-    accountId,
-    networkId,
-    unsignedTxs: [updatedUnsignedTxItem],
-    tronResourceRentalInfo,
-  });
 
   const {
     totalNative,
@@ -1057,37 +1090,75 @@ async function updateUnsignedTxAndSendTx({
     estimateFeeParams,
   });
 
-  await backgroundApiProxy.serviceTransaction.verifyTransaction({
+  const shouldTrackGasAccount = Boolean(unsignedTxItem.swapInfo);
+  const nativeToken = shouldTrackGasAccount
+    ? buildNativeTokenFromGasInfo({
+        gasInfo,
+        networkId,
+        fromToken: unsignedTxItem.swapInfo?.sender.token,
+      })
+    : undefined;
+  const latestNativeBalance = nativeToken
+    ? await checkSwapLatestBalanceSufficient({
+        token: nativeToken,
+        amount: '0',
+        accountAddress,
+        accountId,
+      })
+    : undefined;
+  const gasAccountAnalyticsContext = buildDirectSwapGasAccountAnalyticsContext({
+    entryPoint: 'marketSwapDirect',
     networkId,
-    accountId,
-    verifyTxTasks: ['feeInfo'],
-    verifyTxFeeInfoParams: {
-      feeAmount: totalNative,
-      feeTokenSymbol: feeInfo.common.nativeSymbol,
-      doubleConfirm: true,
-    },
-    encodedTx: updatedUnsignedTxItem.encodedTx,
+    unsignedTx: unsignedTxItem,
+    gasInfo,
+    estimateFeeParams,
+    nativeBalance: latestNativeBalance?.balance,
+    useGasAccountByDefault: gasAccountAnalytics?.useGasAccountByDefault,
+    fiatCurrency: gasAccountAnalytics?.fiatCurrency,
+  });
+  await runDirectSwapGasAccountStep({
+    context: gasAccountAnalyticsContext,
+    failureStage: 'precheck',
+    task: () =>
+      backgroundApiProxy.serviceSend.precheckUnsignedTxs({
+        networkId,
+        accountId,
+        unsignedTxs: [updatedUnsignedTxItem],
+        precheckTiming: ESendPreCheckTimingEnum.Confirm,
+      }),
+  });
+  await runDirectSwapGasAccountStep({
+    context: gasAccountAnalyticsContext,
+    failureStage: 'prepare',
+    task: () =>
+      backgroundApiProxy.serviceSignatureConfirm.preActionsBeforeSending({
+        accountId,
+        networkId,
+        unsignedTxs: [updatedUnsignedTxItem],
+        tronResourceRentalInfo,
+      }),
+  });
+  await runDirectSwapGasAccountStep({
+    context: gasAccountAnalyticsContext,
+    failureStage: 'precheck',
+    task: () =>
+      backgroundApiProxy.serviceTransaction.verifyTransaction({
+        networkId,
+        accountId,
+        verifyTxTasks: ['feeInfo'],
+        verifyTxFeeInfoParams: {
+          feeAmount: totalNative,
+          feeTokenSymbol: feeInfo.common.nativeSymbol,
+          doubleConfirm: true,
+        },
+        encodedTx: updatedUnsignedTxItem.encodedTx,
+      }),
   });
 
-  // When estimate-fee confirmed Gas Account sponsorship, attach the quote so the
-  // broadcast pays via the sponsor. Mirrors the transaction-confirm page.
-  const gasAccountUiState: IGasAccountUiState | undefined =
-    gasInfo.gasAccountEligible &&
-    gasInfo.payer === 'gasAccount' &&
-    gasInfo.gasAccountQuote?.quoteId
-      ? {
-          payer: gasInfo.payer,
-          gasAccountEligible: true,
-          gasAccountQuote: gasInfo.gasAccountQuote,
-          selectedPayer: 'gasAccount',
-          // Same nonce the quote was bound to at estimate-fee time.
-          lockedUserNonce:
-            typeof updatedUnsignedTxItem.nonce === 'number'
-              ? updatedUnsignedTxItem.nonce
-              : undefined,
-          idempotencyKey: `gas-account:${gasInfo.gasAccountQuote.quoteId}`,
-        }
-      : undefined;
+  const gasAccountUiState = buildDirectSwapGasAccountUiState({
+    gasInfo,
+    unsignedTx: updatedUnsignedTxItem,
+  });
 
   const sendTxParams = {
     networkId,
@@ -1097,29 +1168,20 @@ async function updateUnsignedTxAndSendTx({
     tronResourceRentalInfo,
     useDefaultRpc,
   };
-  let signedTx: Awaited<
-    ReturnType<typeof backgroundApiProxy.serviceSend.signAndSendTransaction>
-  >;
-  try {
-    signedTx = await backgroundApiProxy.serviceSend.signAndSendTransaction({
-      ...sendTxParams,
-      gasAccountUiState,
-    });
-  } catch (e) {
-    // Gas Account Fallback codes (pool exhausted, daily limit, sponsor down):
-    // drop the sponsor quote and resend once as user-paid, mirroring the
-    // confirm page. Refresh/Hint and non gas-account errors propagate to the UI
-    // (useSpeedSwapActions maps them to a sponsor toast). See useSwapBuiltTx.
-    const entry = gasAccountUiState
-      ? getGasAccountErrorEntry(getGasAccountErrorCode(e))
-      : undefined;
-    if (entry?.strategy !== EGasAccountErrorStrategy.Fallback) {
-      throw e;
-    }
-    await onBeforeGasAccountFallback?.();
-    signedTx =
-      await backgroundApiProxy.serviceSend.signAndSendTransaction(sendTxParams);
-  }
+  const signedTx = await sendDirectSwapWithGasAccountAnalytics({
+    context: gasAccountAnalyticsContext,
+    gasAccountUiState,
+    send: (uiState) =>
+      backgroundApiProxy.serviceSend.signAndSendTransaction({
+        ...sendTxParams,
+        gasAccountUiState: uiState,
+      }),
+    onGasAccountError: async (_error, entry) => {
+      if (entry.strategy === EGasAccountErrorStrategy.Fallback) {
+        await onBeforeGasAccountFallback?.();
+      }
+    },
+  });
 
   const decodedTx = await backgroundApiProxy.serviceSend.buildDecodedTx({
     networkId,
@@ -1182,6 +1244,7 @@ export async function sendMarketDirectUnsignedTxs({
   tronResourceRentalInfo,
   useDefaultRpc,
   validateFinalGasInfos,
+  gasAccountAnalytics,
 }: IMarketDirectSendParams): Promise<ISendTxOnSuccessData[]> {
   if (!accountId || !networkId || !accountAddress) {
     throw new OneKeyError('account error');
@@ -1243,6 +1306,7 @@ export async function sendMarketDirectUnsignedTxs({
 
     results.push(
       await updateUnsignedTxAndSendTx({
+        accountAddress,
         accountId,
         networkId,
         unsignedTxItem,
@@ -1269,6 +1333,7 @@ export async function sendMarketDirectUnsignedTxs({
                 ),
               )
           : undefined,
+        gasAccountAnalytics,
       }),
     );
   }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.ts
@@ -78,6 +78,7 @@ type IMarketDirectSendParams = {
   validateFinalGasInfos?: (gasInfos: IMarketGasInfoEntry[]) => Promise<void>;
   gasAccountAnalytics?: {
     fiatCurrency?: string;
+    nativeBalance?: string;
     useGasAccountByDefault?: boolean;
   };
 };
@@ -937,6 +938,7 @@ export async function estimateMarketDirectGasInfos({
   gasFeeFiatValue?: string;
   preparedUnsignedTx: IUnsignedTxPro;
   gasAccountAnalyticsContext?: IGasAccountAnalyticsContext;
+  gasAccountAnalyticsNativeBalance?: string;
 }> {
   if (!accountId || !networkId || !accountAddress) {
     throw new OneKeyError('account error');
@@ -965,6 +967,7 @@ export async function estimateMarketDirectGasInfos({
   });
 
   let gasAccountAnalyticsContext: IGasAccountAnalyticsContext | undefined;
+  let gasAccountAnalyticsNativeBalance: string | undefined;
   const swapGasInfo = findGasInfo(gasInfos, unsignedTx.encodedTx);
   if (gasAccountAnalytics && swapGasInfo && unsignedTx.swapInfo) {
     const nativeToken = buildNativeTokenFromGasInfo({
@@ -980,13 +983,14 @@ export async function estimateMarketDirectGasInfos({
           accountId,
         })
       : undefined;
+    gasAccountAnalyticsNativeBalance = latestNativeBalance?.balance;
     gasAccountAnalyticsContext = buildDirectSwapGasAccountAnalyticsContext({
       entryPoint: 'marketSwapDirect',
       networkId,
       unsignedTx,
       gasInfo: swapGasInfo.gasInfo,
       estimateFeeParams: swapGasInfo.estimateFeeParams,
-      nativeBalance: latestNativeBalance?.balance,
+      nativeBalance: gasAccountAnalyticsNativeBalance,
       useGasAccountByDefault: gasAccountAnalytics.useGasAccountByDefault,
       fiatCurrency: gasAccountAnalytics.fiatCurrency,
     });
@@ -997,6 +1001,7 @@ export async function estimateMarketDirectGasInfos({
     gasFeeFiatValue: buildGasFeeFiatValue(gasInfos),
     preparedUnsignedTx: unsignedTx,
     gasAccountAnalyticsContext,
+    gasAccountAnalyticsNativeBalance,
   };
 }
 
@@ -1045,7 +1050,6 @@ export async function estimateMarketApproveGasInfos({
 }
 
 async function updateUnsignedTxAndSendTx({
-  accountAddress,
   accountId,
   networkId,
   unsignedTxItem,
@@ -1056,7 +1060,6 @@ async function updateUnsignedTxAndSendTx({
   onBeforeGasAccountFallback,
   gasAccountAnalytics,
 }: {
-  accountAddress: string;
   accountId: string;
   networkId: string;
   unsignedTxItem: IUnsignedTxPro;
@@ -1090,29 +1093,13 @@ async function updateUnsignedTxAndSendTx({
     estimateFeeParams,
   });
 
-  const shouldTrackGasAccount = Boolean(unsignedTxItem.swapInfo);
-  const nativeToken = shouldTrackGasAccount
-    ? buildNativeTokenFromGasInfo({
-        gasInfo,
-        networkId,
-        fromToken: unsignedTxItem.swapInfo?.sender.token,
-      })
-    : undefined;
-  const latestNativeBalance = nativeToken
-    ? await checkSwapLatestBalanceSufficient({
-        token: nativeToken,
-        amount: '0',
-        accountAddress,
-        accountId,
-      })
-    : undefined;
   const gasAccountAnalyticsContext = buildDirectSwapGasAccountAnalyticsContext({
     entryPoint: 'marketSwapDirect',
     networkId,
     unsignedTx: unsignedTxItem,
     gasInfo,
     estimateFeeParams,
-    nativeBalance: latestNativeBalance?.balance,
+    nativeBalance: gasAccountAnalytics?.nativeBalance,
     useGasAccountByDefault: gasAccountAnalytics?.useGasAccountByDefault,
     fiatCurrency: gasAccountAnalytics?.fiatCurrency,
   });
@@ -1306,7 +1293,6 @@ export async function sendMarketDirectUnsignedTxs({
 
     results.push(
       await updateUnsignedTxAndSendTx({
-        accountAddress,
         accountId,
         networkId,
         unsignedTxItem,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketDirectSendTx.ts
@@ -2,6 +2,7 @@ import BigNumber from 'bignumber.js';
 
 import type { IEncodedTx, IUnsignedTxPro } from '@onekeyhq/core/src/types';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { EGasAccountErrorStrategy } from '@onekeyhq/kit/src/views/SignatureConfirm/constants/gasAccountErrorCodes';
 import {
   buildDirectSwapGasAccountAnalyticsContext,
   buildDirectSwapGasAccountUiState,
@@ -12,7 +13,6 @@ import {
   buildNativeTokenFromGasInfo,
   checkSwapLatestBalanceSufficient,
 } from '@onekeyhq/kit/src/views/Swap/utils/swapBalanceUtils';
-import { EGasAccountErrorStrategy } from '@onekeyhq/kit/src/views/SignatureConfirm/constants/gasAccountErrorCodes';
 import type {
   IBuildUnsignedTxParams,
   ITransferInfo,

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -158,6 +158,7 @@ type IMarketReviewExecutionSnapshot = {
   swapInfo: ISwapTxInfo;
   buildRes?: IFetchBuildTxResponse;
   gasAccountAnalyticsContext?: IGasAccountAnalyticsContext;
+  gasAccountAnalyticsNativeBalance?: string;
   // customPriorityFee is owned by the swapStepNetFeeLevel atom; never snapshot
   // it here, or a cleared preset fee would resurrect via `?? snapshot.value`.
 };
@@ -1345,6 +1346,8 @@ export function useSpeedSwapActions(props: {
           ) {
             snapshot.gasAccountAnalyticsContext =
               feeState.gasAccountAnalyticsContext;
+            snapshot.gasAccountAnalyticsNativeBalance =
+              feeState.gasAccountAnalyticsNativeBalance;
           }
 
           netWorkFee = {
@@ -2277,6 +2280,7 @@ export function useSpeedSwapActions(props: {
           customPriorityFee,
           gasAccountAnalytics: {
             fiatCurrency: settingsAtom.currencyInfo.id,
+            nativeBalance: snapshot.gasAccountAnalyticsNativeBalance,
             useGasAccountByDefault: settingsAtom.useGasAccountByDefault,
           },
         });

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -20,6 +20,7 @@ import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accoun
 import { useSelectedDeriveTypeAtom } from '@onekeyhq/kit/src/states/jotai/contexts/marketV2/atoms';
 import { getGasAccountErrorEntry } from '@onekeyhq/kit/src/views/SignatureConfirm/constants/gasAccountErrorCodes';
 import { type ISwapReviewStepTexts } from '@onekeyhq/kit/src/views/Swap/utils/buildSwapReviewState';
+import { logDirectSwapGasAccountDecision } from '@onekeyhq/kit/src/views/Swap/utils/gasAccountAnalytics';
 import {
   checkSwapLatestBalanceSufficient,
   getSwapRequiredNativeBalanceAmount,
@@ -57,6 +58,7 @@ import {
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
 import { ESwapEventAPIStatus } from '@onekeyhq/shared/src/logger/scopes/swap/scenes/swapEstimateFee';
+import type { IGasAccountAnalyticsContext } from '@onekeyhq/shared/src/logger/scopes/transaction/types';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import stringUtils from '@onekeyhq/shared/src/utils/stringUtils';
 import {
@@ -155,6 +157,7 @@ type IMarketReviewExecutionSnapshot = {
   buildUnsignedParams: ISendTxBaseParams & IBuildUnsignedTxParams;
   swapInfo: ISwapTxInfo;
   buildRes?: IFetchBuildTxResponse;
+  gasAccountAnalyticsContext?: IGasAccountAnalyticsContext;
   // customPriorityFee is owned by the swapStepNetFeeLevel atom; never snapshot
   // it here, or a cleared preset fee would resurrect via `?? snapshot.value`.
 };
@@ -419,6 +422,9 @@ export function useSpeedSwapActions(props: {
   const reviewExecutionSnapshotRef = useRef<
     IMarketReviewExecutionSnapshot | undefined
   >(undefined);
+  const gasAccountDecisionSnapshotsRef = useRef(
+    new WeakSet<IMarketReviewExecutionSnapshot>(),
+  );
   const defaultMarketSpeedCheckState = useMemo(
     () => buildDefaultMarketSpeedCheckState(),
     [],
@@ -1314,6 +1320,13 @@ export function useSpeedSwapActions(props: {
             approveUnsignedTxArr,
             networkFeeLevel,
             customPriorityFee,
+            gasAccountAnalytics:
+              snapshot.kind === 'swap'
+                ? {
+                    fiatCurrency: settingsAtom.currencyInfo.id,
+                    useGasAccountByDefault: settingsAtom.useGasAccountByDefault,
+                  }
+                : undefined,
           });
 
           if (
@@ -1324,6 +1337,14 @@ export function useSpeedSwapActions(props: {
               ...snapshot.buildUnsignedParams,
               encodedTx: feeState.preparedUnsignedTx.encodedTx,
             };
+          }
+
+          if (
+            feeState.gasAccountAnalyticsContext &&
+            reviewExecutionSnapshotRef.current === snapshot
+          ) {
+            snapshot.gasAccountAnalyticsContext =
+              feeState.gasAccountAnalyticsContext;
           }
 
           netWorkFee = {
@@ -1362,6 +1383,7 @@ export function useSpeedSwapActions(props: {
       buildReviewStepTexts,
       currencyMap,
       settingsAtom.currencyInfo.id,
+      settingsAtom.useGasAccountByDefault,
       slippage,
     ],
   );
@@ -1652,6 +1674,19 @@ export function useSpeedSwapActions(props: {
     },
     [],
   );
+
+  const logMarketReviewGasAccountDecision = useCallback(() => {
+    const snapshot = reviewExecutionSnapshotRef.current;
+    if (snapshot?.kind !== 'swap' || !snapshot.gasAccountAnalyticsContext) {
+      return;
+    }
+
+    if (!gasAccountDecisionSnapshotsRef.current.has(snapshot)) {
+      gasAccountDecisionSnapshotsRef.current.add(snapshot);
+      logDirectSwapGasAccountDecision(snapshot.gasAccountAnalyticsContext);
+    }
+    return snapshot.gasAccountAnalyticsContext;
+  }, []);
 
   const openMarketFallbackTxConfirm = useCallback(
     async ({
@@ -2240,6 +2275,10 @@ export function useSpeedSwapActions(props: {
           gasInfos,
           networkFeeLevel,
           customPriorityFee,
+          gasAccountAnalytics: {
+            fiatCurrency: settingsAtom.currencyInfo.id,
+            useGasAccountByDefault: settingsAtom.useGasAccountByDefault,
+          },
         });
         const result = await handleMarketSwapBuildTxSuccess(data);
         if (result) {
@@ -2295,6 +2334,8 @@ export function useSpeedSwapActions(props: {
       logMarketCreateOrder,
       openMarketFallbackTxConfirm,
       requireReviewExecutionSnapshot,
+      settingsAtom.currencyInfo.id,
+      settingsAtom.useGasAccountByDefault,
     ],
   );
 
@@ -3110,6 +3151,7 @@ export function useSpeedSwapActions(props: {
     speedCheckLoading,
     estimateMarketPresetNetworkFees,
     prepareMarketSwapReview,
+    logMarketReviewGasAccountDecision,
     sendMarketApproveTx,
     sendMarketSwapTx,
     sendMarketWrappedTx,

--- a/packages/kit/src/views/Setting/pages/Tab/SubSettingsPage.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/SubSettingsPage.tsx
@@ -92,9 +92,9 @@ export function SubSettingsPage({
   const isMobileAboutPage =
     isMobileLayout && config?.name === ESettingsTabNames.About;
 
+  // Page must not scroll: the inner ScrollView owns scrolling so iPad's
+  // contentInsetAdjustmentBehavior applies to the right scroller (#12813).
   return (
-    {/* Page must not scroll: the inner ScrollView owns scrolling so iPad's
-        contentInsetAdjustmentBehavior applies to the right scroller (#12813). */}
     <Page backgroundColor={pageBackgroundColor}>
       <Page.Header
         {...(headerBackgroundColor

--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmActions/TxConfirmActions.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmActions/TxConfirmActions.tsx
@@ -212,19 +212,38 @@ function TxConfirmActions(props: IProps) {
     gasAccountScenario,
     isPrivateSend: transferPayload?.isPrivateSend === true,
   });
-  const gasAccountAnalyticsContextRef = useRef(gasAccountAnalyticsContext);
-  gasAccountAnalyticsContextRef.current = gasAccountAnalyticsContext;
+  const gasAccountActionSessionKey =
+    unsignedTx?.uuid ??
+    `${networkId}:${gasAccountAnalyticsContext?.scenario ?? gasAccountScenario ?? 'unknown'}`;
+  const gasAccountActionSessionRef = useRef<{
+    key: string;
+    context?: IGasAccountAnalyticsContext;
+    effectiveFeePayer?: IGasAccountAnalyticsContext['effectiveFeePayer'];
+  }>({ key: gasAccountActionSessionKey });
+  if (gasAccountActionSessionRef.current.key !== gasAccountActionSessionKey) {
+    gasAccountActionSessionRef.current = { key: gasAccountActionSessionKey };
+  }
+  if (isGasSponsoredAnalyticsContext(gasAccountAnalyticsContext)) {
+    gasAccountActionSessionRef.current.context = gasAccountAnalyticsContext;
+    gasAccountActionSessionRef.current.effectiveFeePayer =
+      gasAccountAnalyticsContext.effectiveFeePayer;
+  }
 
   const logGasAccountAction = useCallback(
     (details: IGasAccountActionDetails) => {
-      const context = gasAccountAnalyticsContextRef.current;
-      if (!isGasSponsoredAnalyticsContext(context)) {
+      const session = gasAccountActionSessionRef.current;
+      if (!session.context) {
         return;
       }
       defaultLogger.transaction.send.gasAccountAction({
-        ...context,
+        ...session.context,
+        effectiveFeePayer:
+          session.effectiveFeePayer ?? session.context.effectiveFeePayer,
         ...details,
       });
+      if (details.action === 'payerChanged' && details.toPayer) {
+        session.effectiveFeePayer = details.toPayer;
+      }
     },
     [],
   );
@@ -248,17 +267,14 @@ function TxConfirmActions(props: IProps) {
     if (!gasAccountAnalyticsContext) {
       return;
     }
-    const decisionKey =
-      unsignedTxs[0]?.uuid ??
-      `${networkId}:${gasAccountAnalyticsContext.scenario ?? 'unknown'}`;
-    if (gasAccountDecisionKeyRef.current === decisionKey) {
+    if (gasAccountDecisionKeyRef.current === gasAccountActionSessionKey) {
       return;
     }
-    gasAccountDecisionKeyRef.current = decisionKey;
+    gasAccountDecisionKeyRef.current = gasAccountActionSessionKey;
     defaultLogger.transaction.send.gasAccountDecision(
       gasAccountAnalyticsContext,
     );
-  }, [gasAccountAnalyticsContext, networkId, unsignedTxs]);
+  }, [gasAccountActionSessionKey, gasAccountAnalyticsContext]);
 
   const dappApprove = useDappApproveAction({
     id: sourceInfo?.id ?? '',

--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmActions/TxConfirmActions.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmActions/TxConfirmActions.tsx
@@ -41,6 +41,7 @@ import {
   useTxFeeInfoInitAtom,
   useUnsignedTxsAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/signatureConfirm';
+import { useGasAccountAnalyticsContext } from '@onekeyhq/kit/src/views/SignatureConfirm/hooks/useGasAccountAnalyticsContext';
 import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { ITransferPayload } from '@onekeyhq/kit-bg/src/vaults/types';
 import type { IOneKeyError } from '@onekeyhq/shared/src/errors/types/errorTypes';
@@ -54,6 +55,10 @@ import {
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import type {
+  IGasAccountActionParams,
+  IGasAccountAnalyticsContext,
+} from '@onekeyhq/shared/src/logger/scopes/transaction/types';
 import type { IModalSendParamList } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import { checkIsEmptyData } from '@onekeyhq/shared/src/utils/evmUtils';
@@ -78,6 +83,7 @@ import {
 } from '../../constants/gasAccountErrorCodes';
 import { usePreCheckFeeInfo } from '../../hooks/usePreCheckFeeInfo';
 import { SignatureConfirmTestIDs } from '../../testIDs';
+import { isGasSponsoredAnalyticsContext } from '../../utils/gasAccountAnalytics';
 import { showCustomHexDataAlert } from '../CustomHexDataAlert';
 import TxFeeInfo from '../TxFee';
 
@@ -111,6 +117,11 @@ type IProps = {
   // peer can't push through an `eth_sendTransaction` without acknowledgement.
   forceTakeRiskAlert?: boolean;
 };
+
+type IGasAccountActionDetails = Omit<
+  IGasAccountActionParams,
+  keyof IGasAccountAnalyticsContext
+>;
 
 function TxConfirmActions(props: IProps) {
   const {
@@ -196,6 +207,58 @@ function TxConfirmActions(props: IProps) {
     gasAccountUiState.selectedPayer === 'gasAccount' &&
     !!gasAccountUiState.gasAccountQuote?.quoteId;
   const isFeeSponsored = isMegafuelSponsored || isGasAccountSponsored;
+  const gasAccountAnalyticsContext = useGasAccountAnalyticsContext({
+    networkId,
+    gasAccountScenario,
+    isPrivateSend: transferPayload?.isPrivateSend === true,
+  });
+  const gasAccountAnalyticsContextRef = useRef(gasAccountAnalyticsContext);
+  gasAccountAnalyticsContextRef.current = gasAccountAnalyticsContext;
+
+  const logGasAccountAction = useCallback(
+    (details: IGasAccountActionDetails) => {
+      const context = gasAccountAnalyticsContextRef.current;
+      if (!isGasSponsoredAnalyticsContext(context)) {
+        return;
+      }
+      defaultLogger.transaction.send.gasAccountAction({
+        ...context,
+        ...details,
+      });
+    },
+    [],
+  );
+
+  const logGasAccountSubmitFailed = useCallback(
+    (
+      error: unknown,
+      failureStage: NonNullable<IGasAccountActionParams['failureStage']>,
+    ) => {
+      logGasAccountAction({
+        action: 'submitFailed',
+        failureStage,
+        errorCode: getGasAccountErrorCode(error),
+      });
+    },
+    [logGasAccountAction],
+  );
+
+  const gasAccountDecisionKeyRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (!gasAccountAnalyticsContext) {
+      return;
+    }
+    const decisionKey =
+      unsignedTxs[0]?.uuid ??
+      `${networkId}:${gasAccountAnalyticsContext.scenario ?? 'unknown'}`;
+    if (gasAccountDecisionKeyRef.current === decisionKey) {
+      return;
+    }
+    gasAccountDecisionKeyRef.current = decisionKey;
+    defaultLogger.transaction.send.gasAccountDecision(
+      gasAccountAnalyticsContext,
+    );
+  }, [gasAccountAnalyticsContext, networkId, unsignedTxs]);
 
   const dappApprove = useDappApproveAction({
     id: sourceInfo?.id ?? '',
@@ -252,6 +315,14 @@ function TxConfirmActions(props: IProps) {
 
       if (entry.strategy === EGasAccountErrorStrategy.Fallback) {
         muteHandledErrorToast(error);
+        logGasAccountAction({
+          action: 'payerChanged',
+          fromPayer: 'gasAccount',
+          toPayer: 'user',
+          changeSource: 'system',
+          changeReason: 'submitFailed',
+          errorCode: code,
+        });
         updateEffectiveFeePayer('user');
         updateGasAccountTemporarilyDisabled(true);
         resetGasAccountUiState();
@@ -281,6 +352,7 @@ function TxConfirmActions(props: IProps) {
     },
     [
       gasAccountUiState.selectedPayer,
+      logGasAccountAction,
       networkId,
       resetGasAccountTemporarilyDisabled,
       resetGasAccountUiState,
@@ -347,6 +419,7 @@ function TxConfirmActions(props: IProps) {
         feeInfos: sendSelectedFeeInfo?.feeInfos,
       });
     } catch (e: any) {
+      logGasAccountSubmitFailed(e, 'precheck');
       updateSendTxStatus({ isSubmitting: false });
       onFail?.(e as Error);
       isSubmitted.current = false;
@@ -370,6 +443,7 @@ function TxConfirmActions(props: IProps) {
         navigation.popStack();
       }
     } catch (e: any) {
+      logGasAccountSubmitFailed(e, 'prepare');
       updateSendTxStatus({ isSubmitting: false });
       onFail?.(e as Error);
       isSubmitted.current = false;
@@ -409,6 +483,7 @@ function TxConfirmActions(props: IProps) {
         tronResourceRentalInfo,
       });
     } catch (e: any) {
+      logGasAccountSubmitFailed(e, 'prepare');
       updateSendTxStatus({ isSubmitting: false });
       onFail?.(e as Error);
       isSubmitted.current = false;
@@ -442,6 +517,7 @@ function TxConfirmActions(props: IProps) {
       }
     }
 
+    let transactionSubmitted = false;
     try {
       await onBeforeSend?.();
     } catch (error) {
@@ -519,6 +595,9 @@ function TxConfirmActions(props: IProps) {
         isSubmitted.current = false;
         return;
       }
+
+      transactionSubmitted = true;
+      logGasAccountAction({ action: 'submitSucceeded' });
 
       if (vaultSettings?.afterSendTxActionEnabled) {
         await backgroundApiProxy.serviceSignatureConfirm.afterSendTxAction({
@@ -668,6 +747,9 @@ function TxConfirmActions(props: IProps) {
         gasAccountSubmitIdRef.current = null;
         return;
       }
+      if (!transactionSubmitted) {
+        logGasAccountSubmitFailed(e, 'submit');
+      }
       const gasAccountStrategy = handleGasAccountSubmitError(e);
       // Refresh and Fallback both keep the user on the confirm page with a
       // fresh estimate in flight, so the dApp caller should also keep waiting.
@@ -727,6 +809,8 @@ function TxConfirmActions(props: IProps) {
     signOnly,
     transferPayload,
     handleGasAccountSubmitError,
+    logGasAccountAction,
+    logGasAccountSubmitFailed,
     intl,
     onSuccess,
     isQueueMode,
@@ -741,6 +825,7 @@ function TxConfirmActions(props: IProps) {
   ]);
 
   const handleOnConfirm = useCallback(async () => {
+    logGasAccountAction({ action: 'confirmClicked' });
     if (decodedTxs[0]?.isCustomHexData) {
       showCustomHexDataAlert({
         decodedTx: decodedTxs[0],
@@ -752,7 +837,12 @@ function TxConfirmActions(props: IProps) {
     } else {
       await submitTxs();
     }
-  }, [decodedTxs, submitTxs, transferPayload?.originalRecipient]);
+  }, [
+    decodedTxs,
+    logGasAccountAction,
+    submitTxs,
+    transferPayload?.originalRecipient,
+  ]);
 
   const cancelCalledRef = useRef(false);
   // If a 90212 retry loop is in flight, tear it down before the flow
@@ -776,9 +866,12 @@ function TxConfirmActions(props: IProps) {
       return;
     }
     cancelCalledRef.current = true;
+    if (!isSubmitted.current) {
+      logGasAccountAction({ action: 'exited' });
+    }
     abortPendingGasAccountSubmit();
     onCancel?.();
-  }, [abortPendingGasAccountSubmit, onCancel]);
+  }, [abortPendingGasAccountSubmit, logGasAccountAction, onCancel]);
 
   const handleOnCancel = useCallback(
     (close: () => void, closePageStack: () => void) => {
@@ -928,13 +1021,25 @@ function TxConfirmActions(props: IProps) {
     if (isGasAccountQuoteExpired) {
       if (quoteExpiredHandledRef.current) return;
       quoteExpiredHandledRef.current = true;
+      logGasAccountAction({
+        action: 'payerChanged',
+        fromPayer: 'gasAccount',
+        toPayer: 'user',
+        changeSource: 'system',
+        changeReason: 'quoteExpired',
+      });
       resetGasAccountUiState();
       updateTxFeeInfoInit(false);
       appEventBus.emit(EAppEventBusNames.EstimateTxFeeRetry, undefined);
     } else {
       quoteExpiredHandledRef.current = false;
     }
-  }, [isGasAccountQuoteExpired, resetGasAccountUiState, updateTxFeeInfoInit]);
+  }, [
+    isGasAccountQuoteExpired,
+    logGasAccountAction,
+    resetGasAccountUiState,
+    updateTxFeeInfoInit,
+  ]);
 
   const isConfirmInitializing = useMemo(
     () => !txFeeInfoInit || !decodedTxsInit || isBuildingDecodedTxs,

--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmAlert/TxConfirmAlert.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmAlert/TxConfirmAlert.tsx
@@ -76,11 +76,7 @@ function TxConfirmAlert(props: IProps) {
     const isInsufficient =
       sendTxStatus.isInsufficientNativeBalance ||
       sendTxStatus.isInsufficientTokenBalance;
-    if (
-      isInsufficient &&
-      gasAccountAnalyticsContext &&
-      !insufficientFeeLoggedRef.current
-    ) {
+    if (isInsufficient && !insufficientFeeLoggedRef.current) {
       insufficientFeeLoggedRef.current = true;
       defaultLogger.transaction.send.insufficientFeeOnConfirm({
         ...gasAccountAnalyticsContext,

--- a/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmAlert/TxConfirmAlert.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/SignatureConfirmAlert/TxConfirmAlert.tsx
@@ -19,6 +19,7 @@ import {
   useTronResourceRentalInfoAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/signatureConfirm';
 import { showCustomRpcFallbackDialog } from '@onekeyhq/kit/src/views/Send/components/CustomRpcFallbackDialog';
+import { useGasAccountAnalyticsContext } from '@onekeyhq/kit/src/views/SignatureConfirm/hooks/useGasAccountAnalyticsContext';
 import type { ITransferPayload } from '@onekeyhq/kit-bg/src/vaults/types';
 import { getNetworkIdsMap } from '@onekeyhq/shared/src/config/networkIds';
 import {
@@ -31,16 +32,18 @@ import { EModalReceiveRoutes, EModalRoutes } from '@onekeyhq/shared/src/routes';
 import accountUtils from '@onekeyhq/shared/src/utils/accountUtils';
 import networkUtils from '@onekeyhq/shared/src/utils/networkUtils';
 import { ESendFeeStatus } from '@onekeyhq/shared/types/fee';
+import type { IGasAccountScenario } from '@onekeyhq/shared/types/fee';
 import type { IToken } from '@onekeyhq/shared/types/token';
 
 interface IProps {
   accountId: string;
   networkId: string;
   transferPayload?: ITransferPayload;
+  gasAccountScenario?: IGasAccountScenario;
 }
 
 function TxConfirmAlert(props: IProps) {
-  const { networkId, accountId, transferPayload } = props;
+  const { networkId, accountId, transferPayload, gasAccountScenario } = props;
 
   const intl = useIntl();
   const navigation = useAppNavigation();
@@ -57,6 +60,11 @@ function TxConfirmAlert(props: IProps) {
   const [customRpcStatus] = useCustomRpcStatusAtom();
   const { updateCustomRpcStatus, clearCustomRpcStatus } =
     useSignatureConfirmActions().current;
+  const gasAccountAnalyticsContext = useGasAccountAnalyticsContext({
+    networkId,
+    gasAccountScenario,
+    isPrivateSend: transferPayload?.isPrivateSend === true,
+  });
 
   // Single source of truth for the token-fee alert gate so logging and
   // rendering can't drift (pay-with-token disabled → native alert).
@@ -68,9 +76,14 @@ function TxConfirmAlert(props: IProps) {
     const isInsufficient =
       sendTxStatus.isInsufficientNativeBalance ||
       sendTxStatus.isInsufficientTokenBalance;
-    if (isInsufficient && !insufficientFeeLoggedRef.current) {
+    if (
+      isInsufficient &&
+      gasAccountAnalyticsContext &&
+      !insufficientFeeLoggedRef.current
+    ) {
       insufficientFeeLoggedRef.current = true;
       defaultLogger.transaction.send.insufficientFeeOnConfirm({
+        ...gasAccountAnalyticsContext,
         network: networkId,
         tokenSymbol: isTokenFeeAlert
           ? (payWithTokenInfo.symbol ?? network?.symbol)
@@ -87,6 +100,7 @@ function TxConfirmAlert(props: IProps) {
     sendTxStatus.isInsufficientTokenBalance,
     sendTxStatus.fillUpNativeBalance,
     sendTxStatus.fillUpTokenBalance,
+    gasAccountAnalyticsContext,
     networkId,
     network?.symbol,
     payWithTokenInfo.symbol,

--- a/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
@@ -607,7 +607,12 @@ function TxFeeInfo(props: IProps) {
           gasAccountDisabledByScenario
         ) {
           resetGasAccountUiState();
-          if (
+          if (isCustomRpcEnabled) {
+            updateGasAccountUiState({
+              payer: 'user',
+              sponsorDisabledByCustomRpc: true,
+            });
+          } else if (
             gasAccountTemporarilyDisabled ||
             sponsorDisabledForBatch ||
             sponsorDisabledForPrivateSend ||

--- a/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
+++ b/packages/kit/src/views/SignatureConfirm/components/TxFee/TxFeeInfo.tsx
@@ -642,6 +642,7 @@ function TxFeeInfo(props: IProps) {
                 ? buildGasAccountIdempotencyKey(r.gasAccountQuote.quoteId)
                 : '',
             gasAccountScenarioReason: r.gasAccountScenarioReason,
+            sponsorDisabledByCustomRpc: false,
           });
         } else {
           resetGasAccountUiState();

--- a/packages/kit/src/views/SignatureConfirm/hooks/useGasAccountAnalyticsContext.ts
+++ b/packages/kit/src/views/SignatureConfirm/hooks/useGasAccountAnalyticsContext.ts
@@ -62,8 +62,12 @@ export function useGasAccountAnalyticsContext({
       gasAccountScenario as IGasAccountDisabledScenario,
     );
     const disabledForBatch = unsignedTxs.length > 1;
+    const disabledByCustomRpc = gasAccountUiState.sponsorDisabledByCustomRpc;
     const clientUnsupported =
-      disabledByScenario || isPrivateSend || disabledForBatch;
+      disabledByScenario ||
+      isPrivateSend ||
+      disabledForBatch ||
+      disabledByCustomRpc;
     const gasAccountRequested =
       settings.useGasAccountByDefault !== false &&
       !clientUnsupported &&
@@ -84,6 +88,8 @@ export function useGasAccountAnalyticsContext({
     if (!hasEligibleQuote) {
       if (settings.useGasAccountByDefault === false) {
         unavailableReason = 'userDisabled';
+      } else if (disabledByCustomRpc) {
+        unavailableReason = 'customRpcEnabled';
       } else if (disabledByScenario) {
         unavailableReason = 'unsupportedScenario';
       } else if (isPrivateSend) {
@@ -133,6 +139,7 @@ export function useGasAccountAnalyticsContext({
     gasAccountUiState.gasAccountQuote?.quoteId,
     gasAccountUiState.gasAccountScenarioReason,
     gasAccountUiState.selectedPayer,
+    gasAccountUiState.sponsorDisabledByCustomRpc,
     isPrivateSend,
     nativeTokenInfo.balance,
     nativeTokenInfo.isLoading,

--- a/packages/kit/src/views/SignatureConfirm/hooks/useGasAccountAnalyticsContext.ts
+++ b/packages/kit/src/views/SignatureConfirm/hooks/useGasAccountAnalyticsContext.ts
@@ -80,7 +80,10 @@ export function useGasAccountAnalyticsContext({
     let gasAccountSupported: boolean | null = null;
     if (hasEligibleQuote) {
       gasAccountSupported = true;
-    } else if (clientUnsupported) {
+    } else if (
+      clientUnsupported ||
+      gasAccountUiState.gasAccountScenarioReason
+    ) {
       gasAccountSupported = false;
     }
 

--- a/packages/kit/src/views/SignatureConfirm/hooks/useGasAccountAnalyticsContext.ts
+++ b/packages/kit/src/views/SignatureConfirm/hooks/useGasAccountAnalyticsContext.ts
@@ -1,0 +1,149 @@
+import { useMemo } from 'react';
+
+import {
+  useEffectiveFeePayerAtom,
+  useExtraFeeInfoAtom,
+  useGasAccountTemporarilyDisabledAtom,
+  useGasAccountUiStateAtom,
+  useNativeTokenInfoAtom,
+  useNativeTokenTransferAmountToUpdateAtom,
+  useSendFeeStatusAtom,
+  useSendSelectedFeeInfoAtom,
+  useSendTxStatusAtom,
+  useTxFeeInfoInitAtom,
+  useUnsignedTxsAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/signatureConfirm';
+import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import type { IGasAccountAnalyticsContext } from '@onekeyhq/shared/src/logger/scopes/transaction/types';
+import {
+  ESendFeeStatus,
+  GAS_ACCOUNT_DISABLED_SCENARIOS,
+  type IGasAccountDisabledScenario,
+  type IGasAccountScenario,
+} from '@onekeyhq/shared/types/fee';
+
+import { buildGasAccountAnalyticsContext } from '../utils/gasAccountAnalytics';
+
+export function useGasAccountAnalyticsContext({
+  networkId,
+  gasAccountScenario,
+  isPrivateSend,
+}: {
+  networkId: string;
+  gasAccountScenario: IGasAccountScenario | undefined;
+  isPrivateSend: boolean;
+}): IGasAccountAnalyticsContext | undefined {
+  const [settings] = useSettingsPersistAtom();
+  const [txFeeInfoInit] = useTxFeeInfoInitAtom();
+  const [sendFeeStatus] = useSendFeeStatusAtom();
+  const [sendSelectedFeeInfo] = useSendSelectedFeeInfoAtom();
+  const [nativeTokenInfo] = useNativeTokenInfoAtom();
+  const [nativeTokenTransferAmountToUpdate] =
+    useNativeTokenTransferAmountToUpdateAtom();
+  const [extraFeeInfo] = useExtraFeeInfoAtom();
+  const [sendTxStatus] = useSendTxStatusAtom();
+  const [gasAccountUiState] = useGasAccountUiStateAtom();
+  const [effectiveFeePayer] = useEffectiveFeePayerAtom();
+  const [gasAccountTemporarilyDisabled] =
+    useGasAccountTemporarilyDisabledAtom();
+  const [unsignedTxs] = useUnsignedTxsAtom();
+
+  return useMemo(() => {
+    if (
+      !txFeeInfoInit ||
+      sendFeeStatus.status !== ESendFeeStatus.Success ||
+      !sendSelectedFeeInfo ||
+      nativeTokenInfo.isLoading
+    ) {
+      return undefined;
+    }
+
+    const disabledByScenario = GAS_ACCOUNT_DISABLED_SCENARIOS.includes(
+      gasAccountScenario as IGasAccountDisabledScenario,
+    );
+    const disabledForBatch = unsignedTxs.length > 1;
+    const clientUnsupported =
+      disabledByScenario || isPrivateSend || disabledForBatch;
+    const gasAccountRequested =
+      settings.useGasAccountByDefault !== false &&
+      !clientUnsupported &&
+      !gasAccountTemporarilyDisabled;
+    const hasEligibleQuote = Boolean(
+      gasAccountUiState.gasAccountEligible &&
+      gasAccountUiState.gasAccountQuote?.quoteId,
+    );
+    const gasAccountEligible = gasAccountRequested ? hasEligibleQuote : null;
+    let gasAccountSupported: boolean | null = null;
+    if (hasEligibleQuote) {
+      gasAccountSupported = true;
+    } else if (clientUnsupported) {
+      gasAccountSupported = false;
+    }
+
+    let unavailableReason: string | undefined;
+    if (!hasEligibleQuote) {
+      if (settings.useGasAccountByDefault === false) {
+        unavailableReason = 'userDisabled';
+      } else if (disabledByScenario) {
+        unavailableReason = 'unsupportedScenario';
+      } else if (isPrivateSend) {
+        unavailableReason = 'privateSend';
+      } else if (disabledForBatch) {
+        unavailableReason = 'batchTransaction';
+      } else if (gasAccountTemporarilyDisabled) {
+        unavailableReason = 'temporarilyDisabled';
+      } else {
+        unavailableReason =
+          gasAccountUiState.gasAccountScenarioReason ?? 'backend_unknown';
+      }
+    }
+
+    const nativeTokenPrice =
+      sendSelectedFeeInfo.feeInfos[0]?.feeInfo.common?.nativeTokenPrice;
+
+    return buildGasAccountAnalyticsContext({
+      entryPoint: 'txConfirm',
+      network: networkId,
+      scenario: gasAccountScenario,
+      gasAccountRequested,
+      gasAccountSupported,
+      gasAccountEligible,
+      selectedPayer: gasAccountUiState.selectedPayer ?? 'user',
+      effectiveFeePayer,
+      unavailableReason,
+      estimatedGasNative:
+        sendSelectedFeeInfo.originalTotalNative ??
+        sendSelectedFeeInfo.totalNative,
+      nativeBalance: nativeTokenInfo.balance,
+      nativePrincipal: nativeTokenTransferAmountToUpdate.amountToUpdate,
+      extraFeeNative: extraFeeInfo.feeNative,
+      nativeTokenPrice,
+      fiatCurrency: settings.currencyInfo.id,
+      tokenPrincipalInsufficient: Boolean(
+        sendTxStatus.isInsufficientTokenBalance,
+      ),
+      quoteId: gasAccountUiState.gasAccountQuote?.quoteId,
+    });
+  }, [
+    effectiveFeePayer,
+    extraFeeInfo.feeNative,
+    gasAccountScenario,
+    gasAccountTemporarilyDisabled,
+    gasAccountUiState.gasAccountEligible,
+    gasAccountUiState.gasAccountQuote?.quoteId,
+    gasAccountUiState.gasAccountScenarioReason,
+    gasAccountUiState.selectedPayer,
+    isPrivateSend,
+    nativeTokenInfo.balance,
+    nativeTokenInfo.isLoading,
+    nativeTokenTransferAmountToUpdate.amountToUpdate,
+    networkId,
+    sendSelectedFeeInfo,
+    sendFeeStatus.status,
+    sendTxStatus.isInsufficientTokenBalance,
+    settings.currencyInfo.id,
+    settings.useGasAccountByDefault,
+    txFeeInfoInit,
+    unsignedTxs.length,
+  ]);
+}

--- a/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
+++ b/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
@@ -84,6 +84,7 @@ function TxConfirm() {
     unsignedTxs,
     isQueueMode,
     unsignedTxQueue,
+    gasAccountScenario,
   } = route.params;
 
   const {
@@ -460,6 +461,7 @@ function TxConfirm() {
           networkId={networkId}
           accountId={accountId}
           transferPayload={transferPayload}
+          gasAccountScenario={gasAccountScenario}
         />
         {sourceInfo?.origin ? (
           <DAppSiteMark
@@ -499,6 +501,7 @@ function TxConfirm() {
     networkId,
     accountId,
     transferPayload,
+    gasAccountScenario,
     sourceInfo?.origin,
     urlSecurityInfo,
     securityCheckRequestKey,

--- a/packages/kit/src/views/SignatureConfirm/utils/gasAccountAnalytics.test.ts
+++ b/packages/kit/src/views/SignatureConfirm/utils/gasAccountAnalytics.test.ts
@@ -1,0 +1,104 @@
+import {
+  buildGasAccountAnalyticsContext,
+  isGasSponsoredAnalyticsContext,
+} from './gasAccountAnalytics';
+
+const baseParams = {
+  entryPoint: 'txConfirm' as const,
+  network: 'evm--1',
+  scenario: 'send' as const,
+  gasAccountRequested: true,
+  gasAccountSupported: true,
+  gasAccountEligible: true,
+  selectedPayer: 'gasAccount' as const,
+  effectiveFeePayer: 'gasAccount' as const,
+  unavailableReason: undefined,
+  estimatedGasNative: '0.01',
+  nativeBalance: '0.105',
+  nativePrincipal: '0.1',
+  extraFeeNative: '0',
+  nativeTokenPrice: '2000',
+  fiatCurrency: 'usd',
+  tokenPrincipalInsufficient: false,
+  quoteId: 'quote-id',
+};
+
+describe('buildGasAccountAnalyticsContext', () => {
+  it('classifies a same-native-token transfer as a network fee shortage', () => {
+    const result = buildGasAccountAnalyticsContext(baseParams);
+
+    expect(result.shortageType).toBe('networkFee');
+    expect(result.gasShortfallNative).toBe('0.005');
+    expect(result.gasShortfallFiat).toBe('10');
+    expect(result.gasShortfallFiatBucket).toBe('gte_5');
+    expect(result.selfPayGasSufficient).toBe(false);
+  });
+
+  it('uses the first blocking cause for a same-native-token shortage', () => {
+    const result = buildGasAccountAnalyticsContext({
+      ...baseParams,
+      nativeBalance: '0.09',
+    });
+
+    expect(result.shortageType).toBe('principal');
+  });
+
+  it('uses mixed only when token principal and native gas are both short', () => {
+    const result = buildGasAccountAnalyticsContext({
+      ...baseParams,
+      nativePrincipal: '0',
+      nativeBalance: '0.005',
+      tokenPrincipalInsufficient: true,
+    });
+
+    expect(result.shortageType).toBe('mixed');
+  });
+
+  it('marks fiat fields unavailable when the native token has no price', () => {
+    const result = buildGasAccountAnalyticsContext({
+      ...baseParams,
+      nativeTokenPrice: undefined,
+    });
+
+    expect(result.fiatValueAvailable).toBe(false);
+    expect(result.estimatedGasFiat).toBeUndefined();
+    expect(result.gasShortfallFiat).toBeUndefined();
+    expect(result.gasShortfallFiatBucket).toBe('unknown');
+    expect(result.nativeBalanceFiatBucket).toBe('unknown');
+  });
+
+  it('keeps balance-dependent fields unknown when balance is unavailable', () => {
+    const result = buildGasAccountAnalyticsContext({
+      ...baseParams,
+      nativeBalance: undefined,
+    });
+
+    expect(result.nativeBalanceAvailable).toBe(false);
+    expect(result.selfPayGasSufficient).toBeNull();
+    expect(result.shortageType).toBe('unknown');
+    expect(result.gasShortfallNative).toBeUndefined();
+  });
+
+  it('treats MegaFuel as a sponsored fee payer for action telemetry', () => {
+    expect(
+      isGasSponsoredAnalyticsContext({
+        ...buildGasAccountAnalyticsContext(baseParams),
+        selectedPayer: 'user',
+        effectiveFeePayer: 'megafuel',
+        gasAccountEligible: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not treat eligibility or a gas shortage alone as sponsorship', () => {
+    expect(
+      isGasSponsoredAnalyticsContext({
+        ...buildGasAccountAnalyticsContext(baseParams),
+        selectedPayer: 'user',
+        effectiveFeePayer: 'user',
+        gasAccountEligible: true,
+        shortageType: 'networkFee',
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/kit/src/views/SignatureConfirm/utils/gasAccountAnalytics.test.ts
+++ b/packages/kit/src/views/SignatureConfirm/utils/gasAccountAnalytics.test.ts
@@ -79,6 +79,20 @@ describe('buildGasAccountAnalyticsContext', () => {
     expect(result.gasShortfallNative).toBeUndefined();
   });
 
+  it('keeps the client custom RPC unavailable reason', () => {
+    const result = buildGasAccountAnalyticsContext({
+      ...baseParams,
+      gasAccountRequested: false,
+      gasAccountSupported: false,
+      gasAccountEligible: null,
+      selectedPayer: 'user',
+      effectiveFeePayer: 'user',
+      unavailableReason: 'customRpcEnabled',
+    });
+
+    expect(result.unavailableReason).toBe('customRpcEnabled');
+  });
+
   it('treats MegaFuel as a sponsored fee payer for action telemetry', () => {
     expect(
       isGasSponsoredAnalyticsContext({

--- a/packages/kit/src/views/SignatureConfirm/utils/gasAccountAnalytics.ts
+++ b/packages/kit/src/views/SignatureConfirm/utils/gasAccountAnalytics.ts
@@ -1,0 +1,154 @@
+import BigNumber from 'bignumber.js';
+
+import type {
+  IGasAccountAnalyticsContext,
+  IGasAccountFiatBucket,
+  IGasAccountShortageType,
+} from '@onekeyhq/shared/src/logger/scopes/transaction/types';
+import type {
+  IGasAccountScenario,
+  IGasPayer,
+} from '@onekeyhq/shared/types/fee';
+
+export function isGasSponsoredAnalyticsContext(
+  context: IGasAccountAnalyticsContext | undefined,
+): context is IGasAccountAnalyticsContext {
+  return Boolean(
+    context &&
+    (context.selectedPayer === 'gasAccount' ||
+      context.effectiveFeePayer === 'megafuel'),
+  );
+}
+
+function toNonNegativeBigNumber(value: string | number | undefined) {
+  const result = new BigNumber(value ?? 0);
+  if (!result.isFinite() || result.isNegative()) {
+    return new BigNumber(0);
+  }
+  return result;
+}
+
+function toOptionalNonNegativeBigNumber(value: string | undefined) {
+  if (value === undefined) {
+    return undefined;
+  }
+  const result = new BigNumber(value);
+  if (!result.isFinite() || result.isNegative()) {
+    return undefined;
+  }
+  return result;
+}
+
+export function getGasAccountFiatBucket(
+  value: BigNumber | undefined,
+): IGasAccountFiatBucket {
+  if (!value?.isFinite() || value.isNegative()) {
+    return 'unknown';
+  }
+  if (value.lt(0.01)) return 'lt_0_01';
+  if (value.lt(0.1)) return '0_01_0_1';
+  if (value.lt(1)) return '0_1_1';
+  if (value.lt(5)) return '1_5';
+  return 'gte_5';
+}
+
+export function buildGasAccountAnalyticsContext(params: {
+  entryPoint: IGasAccountAnalyticsContext['entryPoint'];
+  network: string;
+  scenario: IGasAccountScenario | undefined;
+  gasAccountRequested: boolean;
+  gasAccountSupported: boolean | null;
+  gasAccountEligible: boolean | null;
+  selectedPayer: 'user' | 'gasAccount';
+  effectiveFeePayer: IGasPayer;
+  unavailableReason: string | undefined;
+  estimatedGasNative: string | undefined;
+  nativeBalance: string | undefined;
+  nativePrincipal: string | undefined;
+  extraFeeNative: string | undefined;
+  nativeTokenPrice: string | number | undefined;
+  fiatCurrency: string | undefined;
+  tokenPrincipalInsufficient: boolean;
+  quoteId: string | undefined;
+  orderId?: string;
+}): IGasAccountAnalyticsContext {
+  const estimatedGasNative = toNonNegativeBigNumber(params.estimatedGasNative);
+  const nativeBalance = toOptionalNonNegativeBigNumber(params.nativeBalance);
+  const nativePrincipal = toNonNegativeBigNumber(params.nativePrincipal);
+  const extraFeeNative = toNonNegativeBigNumber(params.extraFeeNative);
+  const requiredBeforeGas = nativePrincipal.plus(extraFeeNative);
+  const requiredWithGas = requiredBeforeGas.plus(estimatedGasNative);
+
+  const nativePrincipalInsufficient = nativeBalance?.lt(nativePrincipal);
+  const extraFeeInsufficient = Boolean(
+    nativeBalance &&
+    !nativePrincipalInsufficient &&
+    nativeBalance.lt(requiredBeforeGas),
+  );
+  const networkFeeInsufficient = Boolean(
+    nativeBalance &&
+    !nativePrincipalInsufficient &&
+    !extraFeeInsufficient &&
+    nativeBalance.lt(requiredWithGas),
+  );
+
+  let shortageType: IGasAccountShortageType = nativeBalance
+    ? 'none'
+    : 'unknown';
+  if (params.tokenPrincipalInsufficient && networkFeeInsufficient) {
+    shortageType = 'mixed';
+  } else if (params.tokenPrincipalInsufficient || nativePrincipalInsufficient) {
+    shortageType = 'principal';
+  } else if (extraFeeInsufficient) {
+    shortageType = 'extraFee';
+  } else if (networkFeeInsufficient) {
+    shortageType = 'networkFee';
+  }
+
+  const remainingForGas = nativeBalance
+    ? BigNumber.max(nativeBalance.minus(requiredBeforeGas), 0)
+    : undefined;
+  const gasShortfallNative = remainingForGas
+    ? BigNumber.max(estimatedGasNative.minus(remainingForGas), 0)
+    : undefined;
+  const nativeTokenPrice = toNonNegativeBigNumber(params.nativeTokenPrice);
+  const fiatValueAvailable = nativeTokenPrice.gt(0);
+  const estimatedGasFiat = fiatValueAvailable
+    ? estimatedGasNative.times(nativeTokenPrice)
+    : undefined;
+  const gasShortfallFiat =
+    fiatValueAvailable && gasShortfallNative
+      ? gasShortfallNative.times(nativeTokenPrice)
+      : undefined;
+  const nativeBalanceFiat =
+    fiatValueAvailable && nativeBalance
+      ? nativeBalance.times(nativeTokenPrice)
+      : undefined;
+
+  return {
+    entryPoint: params.entryPoint,
+    network: params.network,
+    scenario: params.scenario,
+    gasAccountRequested: params.gasAccountRequested,
+    gasAccountSupported: params.gasAccountSupported,
+    gasAccountEligible: params.gasAccountEligible,
+    selectedPayer: params.selectedPayer,
+    effectiveFeePayer: params.effectiveFeePayer,
+    unavailableReason: params.unavailableReason,
+    nativeBalanceAvailable: Boolean(nativeBalance),
+    selfPayGasSufficient: nativeBalance
+      ? nativeBalance.gte(requiredWithGas)
+      : null,
+    shortageType,
+    estimatedGasNative: estimatedGasNative.toFixed(),
+    estimatedGasFiat: estimatedGasFiat?.toFixed(),
+    gasShortfallNative: gasShortfallNative?.toFixed(),
+    gasShortfallFiat: gasShortfallFiat?.toFixed(),
+    gasShortfallFiatBucket: getGasAccountFiatBucket(gasShortfallFiat),
+    nativeBalanceFiatBucket: getGasAccountFiatBucket(nativeBalanceFiat),
+    fiatCurrency: params.fiatCurrency,
+    fiatValueAvailable,
+    quoteId: params.quoteId,
+    orderId: params.orderId,
+  };
+}

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -726,12 +726,14 @@ export function useSwapBuildTx({
       token,
       amount,
       otherFeeInfos,
+      cachedNativeBalance,
     }: {
       gasInfos?: { gasInfo?: ISwapGasInfo; txSize?: number }[];
       networkId?: string;
       token?: ISwapToken;
       amount?: string;
       otherFeeInfos?: IQuoteResultFeeOtherFeeInfo[];
+      cachedNativeBalance?: string;
     }) => {
       const nativeBalanceRequirement = getSwapRequiredNativeBalanceAmount({
         gasInfos,
@@ -740,6 +742,12 @@ export function useSwapBuildTx({
         fromAmount: amount,
         otherFeeInfos,
       });
+      if (!nativeBalanceRequirement && cachedNativeBalance !== undefined) {
+        return {
+          isSufficient: true,
+          nativeBalance: cachedNativeBalance,
+        };
+      }
       const firstGasInfo = gasInfos?.find((item) => item.gasInfo)?.gasInfo;
       const nativeToken =
         nativeBalanceRequirement?.token ??
@@ -1000,6 +1008,7 @@ export function useSwapBuildTx({
         amount: unsignedTxItem.swapInfo?.sender.amount,
         otherFeeInfos:
           unsignedTxItem.swapInfo?.swapBuildResData.result?.fee?.otherFeeInfos,
+        cachedNativeBalance: gasAccountReviewSessionRef.current?.nativeBalance,
       });
       const gasAccountAnalyticsContext =
         buildDirectSwapGasAccountAnalyticsContext({
@@ -3443,6 +3452,8 @@ export function useSwapBuildTx({
           gasAccountReviewSession &&
           gasAccountReviewSessionRef.current === gasAccountReviewSession
         ) {
+          gasAccountReviewSession.nativeBalance =
+            checkLatestNativeBalanceRes.nativeBalance;
           gasAccountReviewSession.analyticsContext = gasAccountAnalyticsContext;
           if (!gasAccountReviewSession.decisionLogged) {
             gasAccountReviewSession.decisionLogged = true;

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -38,7 +38,6 @@ import {
 import { OneKeyAppError, OneKeyError } from '@onekeyhq/shared/src/errors';
 import { EOneKeyErrorClassNames } from '@onekeyhq/shared/src/errors/types/errorTypes';
 import type { IOneKeyError } from '@onekeyhq/shared/src/errors/types/errorTypes';
-import { getGasAccountErrorCode } from '@onekeyhq/shared/src/errors/utils/gasAccountErrorUtils';
 import { appEventBus } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import { EAppEventBusNames } from '@onekeyhq/shared/src/eventBus/appEventBusNames';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -70,7 +69,6 @@ import type {
   IFeeTron,
   IFeeUTXO,
   IGasAccountQuote,
-  IGasAccountUiState,
   IGasEIP1559,
   IGasLegacy,
   IGasPayer,
@@ -130,13 +128,21 @@ import {
   useSwapToTokenAmountAtom,
   useSwapTypeSwitchAtom,
 } from '../../../states/jotai/contexts/swap';
-import {
-  EGasAccountErrorStrategy,
-  getGasAccountErrorEntry,
-} from '../../SignatureConfirm/constants/gasAccountErrorCodes';
+import { EGasAccountErrorStrategy } from '../../SignatureConfirm/constants/gasAccountErrorCodes';
 import { buildSwapApproveAndSendSteps } from '../utils/buildSwapReviewState';
 import {
+  buildDirectSwapGasAccountAnalyticsContext,
+  buildDirectSwapGasAccountUiState,
+  createGasAccountReviewSession,
+  logDirectSwapGasAccountDecision,
+  logGasAccountReviewExit,
+  markGasAccountReviewSubmitted,
+  runDirectSwapGasAccountStep,
+  sendDirectSwapWithGasAccountAnalytics,
+} from '../utils/gasAccountAnalytics';
+import {
   type ISwapBtcOutputValidationError,
+  buildNativeTokenFromGasInfo,
   checkSwapLatestBalanceSufficient,
   getSwapEncodedTxSize,
   getSwapRequiredNativeBalanceAmount,
@@ -324,7 +330,8 @@ export function useSwapBuildTx({
   const [swapLimitPriceToAmount] = useSwapLimitPriceToAmountAtom();
   const [swapLimitPartiallyFillObj] = useSwapLimitPartiallyFillAtom();
   const [swapSteps, setSwapSteps] = useSwapStepsAtom();
-  const [{ isFirstTimeSwap }, setPersistSettings] = useSettingsPersistAtom();
+  const [persistSettings, setPersistSettings] = useSettingsPersistAtom();
+  const { isFirstTimeSwap } = persistSettings;
   const swapActionState = useSwapActionState();
   const [swapNetWorkFeeLevel] = useSwapStepNetFeeLevelAtom();
   const [, setSwapFromTokenAmount] = useSwapFromTokenAmountAtom();
@@ -343,6 +350,22 @@ export function useSwapBuildTx({
   if (swapStepsRef.current !== swapSteps) {
     swapStepsRef.current = swapSteps;
   }
+  const gasAccountReviewSessionRef = useRef<
+    ReturnType<typeof createGasAccountReviewSession> | undefined
+  >(undefined);
+
+  const beginGasAccountReviewSession = useCallback(() => {
+    gasAccountReviewSessionRef.current = createGasAccountReviewSession();
+  }, []);
+
+  const endGasAccountReviewSession = useCallback(() => {
+    logGasAccountReviewExit(gasAccountReviewSessionRef.current);
+    gasAccountReviewSessionRef.current = undefined;
+  }, []);
+
+  const markCurrentGasAccountReviewSubmitted = useCallback(() => {
+    markGasAccountReviewSubmitted(gasAccountReviewSessionRef.current);
+  }, []);
 
   const isModalPage = useIsOverlayPage();
 
@@ -717,39 +740,54 @@ export function useSwapBuildTx({
         fromAmount: amount,
         otherFeeInfos,
       });
-
-      if (!nativeBalanceRequirement) {
-        return true;
+      const firstGasInfo = gasInfos?.find((item) => item.gasInfo)?.gasInfo;
+      const nativeToken =
+        nativeBalanceRequirement?.token ??
+        (firstGasInfo
+          ? buildNativeTokenFromGasInfo({
+              gasInfo: firstGasInfo,
+              networkId,
+              fromToken: token,
+            })
+          : undefined);
+      if (!nativeToken) {
+        return { isSufficient: true };
       }
 
       const checkResult = await checkSwapLatestBalanceSufficient({
-        token: nativeBalanceRequirement.token,
-        amount: nativeBalanceRequirement.amount,
+        token: nativeToken,
+        amount: nativeBalanceRequirement?.amount ?? '0',
         accountAddress: fromUserAddress,
         accountId: fromAccountId,
       });
       if (!checkResult.isSufficient) {
         const toastId = [
           'swap-native-balance-insufficient',
-          nativeBalanceRequirement.token.networkId,
+          nativeToken.networkId,
           checkResult.tokenSymbol,
-          nativeBalanceRequirement.reserveAmount,
+          nativeBalanceRequirement?.reserveAmount,
         ].join('-');
         const { title, message } = getSwapBalanceInsufficientToast({
-          networkId: nativeBalanceRequirement.token.networkId,
+          networkId: nativeToken.networkId,
           tokenSymbol: checkResult.tokenSymbol,
-          reserveAmount: nativeBalanceRequirement.includesFromAmount
+          reserveAmount: nativeBalanceRequirement?.includesFromAmount
             ? undefined
-            : nativeBalanceRequirement.reserveAmount,
+            : nativeBalanceRequirement?.reserveAmount,
         });
         Toast.error({
           title,
           message,
           toastId,
         });
-        return false;
+        return {
+          isSufficient: false,
+          nativeBalance: checkResult.balance,
+        };
       }
-      return true;
+      return {
+        isSufficient: true,
+        nativeBalance: checkResult.balance,
+      };
     },
     [fromAccountId, fromUserAddress, getSwapBalanceInsufficientToast],
   );
@@ -963,7 +1001,18 @@ export function useSwapBuildTx({
         otherFeeInfos:
           unsignedTxItem.swapInfo?.swapBuildResData.result?.fee?.otherFeeInfos,
       });
-      if (!checkLatestNativeBalanceRes) {
+      const gasAccountAnalyticsContext =
+        buildDirectSwapGasAccountAnalyticsContext({
+          entryPoint: 'swapDirect',
+          networkId,
+          unsignedTx: unsignedTxItem,
+          gasInfo,
+          txSize,
+          nativeBalance: checkLatestNativeBalanceRes.nativeBalance,
+          useGasAccountByDefault: persistSettings.useGasAccountByDefault,
+          fiatCurrency: persistSettings.currencyInfo.id,
+        });
+      if (!checkLatestNativeBalanceRes.isSufficient) {
         throw new OneKeyAppError('checkLatestNativeTokenBalance failed');
       }
       setSwapSteps(
@@ -985,43 +1034,33 @@ export function useSwapBuildTx({
           };
         },
       );
-      await backgroundApiProxy.serviceSend.precheckUnsignedTxs({
-        networkId,
-        accountId,
-        unsignedTxs: [updatedUnsignedTxItem],
-        precheckTiming: ESendPreCheckTimingEnum.Confirm,
-      });
-      await backgroundApiProxy.serviceTransaction.verifyTransaction({
-        networkId,
-        accountId,
-        verifyTxTasks: ['feeInfo'],
-        verifyTxFeeInfoParams: {
-          feeAmount: totalNative,
-          feeTokenSymbol: gasInfo.common?.nativeSymbol ?? '',
-          doubleConfirm: true,
+      await runDirectSwapGasAccountStep({
+        context: gasAccountAnalyticsContext,
+        failureStage: 'precheck',
+        task: async () => {
+          await backgroundApiProxy.serviceSend.precheckUnsignedTxs({
+            networkId,
+            accountId,
+            unsignedTxs: [updatedUnsignedTxItem],
+            precheckTiming: ESendPreCheckTimingEnum.Confirm,
+          });
+          await backgroundApiProxy.serviceTransaction.verifyTransaction({
+            networkId,
+            accountId,
+            verifyTxTasks: ['feeInfo'],
+            verifyTxFeeInfoParams: {
+              feeAmount: totalNative,
+              feeTokenSymbol: gasInfo.common?.nativeSymbol ?? '',
+              doubleConfirm: true,
+            },
+            encodedTx: updatedUnsignedTxItem.encodedTx,
+          });
         },
-        encodedTx: updatedUnsignedTxItem.encodedTx,
       });
-      // When estimate-fee confirmed Gas Account sponsorship, attach the quote so
-      // broadcast pays via the sponsor. Mirrors the transaction-confirm page
-      // (TxFeeInfo): selectedPayer 'gasAccount' + `gas-account:${quoteId}` key.
-      const gasAccountUiState: IGasAccountUiState | undefined =
-        gasInfo.gasAccountEligible &&
-        gasInfo.payer === 'gasAccount' &&
-        gasInfo.gasAccountQuote?.quoteId
-          ? {
-              payer: gasInfo.payer,
-              gasAccountEligible: true,
-              gasAccountQuote: gasInfo.gasAccountQuote,
-              selectedPayer: 'gasAccount',
-              // Same nonce the quote was bound to at estimate-fee time.
-              lockedUserNonce:
-                typeof updatedUnsignedTxItem.nonce === 'number'
-                  ? updatedUnsignedTxItem.nonce
-                  : undefined,
-              idempotencyKey: `gas-account:${gasInfo.gasAccountQuote.quoteId}`,
-            }
-          : undefined;
+      const gasAccountUiState = buildDirectSwapGasAccountUiState({
+        gasInfo,
+        unsignedTx: updatedUnsignedTxItem,
+      });
       let isNetworkFeeSponsored = isSwapGasSponsored(gasInfo);
       const sendTxParams = {
         networkId,
@@ -1029,50 +1068,27 @@ export function useSwapBuildTx({
         unsignedTx: updatedUnsignedTxItem,
         signOnly: false as const,
       };
-      let res: Awaited<
-        ReturnType<typeof backgroundApiProxy.serviceSend.signAndSendTransaction>
-      >;
-      try {
-        res = await backgroundApiProxy.serviceSend.signAndSendTransaction({
-          ...sendTxParams,
-          gasAccountUiState,
-        });
-      } catch (e) {
-        // Broadcast failed at the gas-account layer. Route by the same strategy
-        // table the confirm page (TxConfirmActions) uses. Plain (non
-        // gas-account) errors, and errors on a non-sponsored send, propagate.
-        const entry = gasAccountUiState
-          ? getGasAccountErrorEntry(getGasAccountErrorCode(e))
-          : undefined;
-        if (!entry) {
-          throw e;
-        }
-        // Mute the original bridge error so the global handler doesn't toast it
-        // (would duplicate the mapped message / conflict with suppressToast).
-        (e as IOneKeyError).autoToast = false;
-        const message = intl.formatMessage({ id: entry.messageKey });
-        // Honor the suppressToast contract (e.g. daily-limit codes stay silent).
-        if (!entry.suppressToast) {
-          Toast.error({ title: message });
-        }
-        if (entry.strategy === EGasAccountErrorStrategy.Fallback) {
-          // Sponsor path unavailable for this attempt (pool exhausted, daily
-          // limit, sponsor down …). Mirror the confirm page: drop the sponsor
-          // quote and resend once as user-paid so the swap can still go through
-          // when the user has native for gas. A user-paid failure (e.g. no
-          // native) then propagates honestly.
-          res =
-            await backgroundApiProxy.serviceSend.signAndSendTransaction(
-              sendTxParams,
-            );
-          isNetworkFeeSponsored = false;
-        } else {
-          // Refresh (quote/nonce stale — already prevented in Swap by the
-          // fresh estimate-at-send + locked nonce) and Hint (terminal) fail the
-          // step. OneKeyAppError avoids the tx-confirm fallback and a 2nd toast.
+      const res = await sendDirectSwapWithGasAccountAnalytics({
+        context: gasAccountAnalyticsContext,
+        gasAccountUiState,
+        send: (uiState) =>
+          backgroundApiProxy.serviceSend.signAndSendTransaction({
+            ...sendTxParams,
+            gasAccountUiState: uiState,
+          }),
+        onGasAccountError: (error, entry) => {
+          (error as IOneKeyError).autoToast = false;
+          const message = intl.formatMessage({ id: entry.messageKey });
+          if (!entry.suppressToast) {
+            Toast.error({ title: message });
+          }
+          if (entry.strategy === EGasAccountErrorStrategy.Fallback) {
+            isNetworkFeeSponsored = false;
+            return;
+          }
           throw new OneKeyAppError({ message, autoToast: false });
-        }
-      }
+        },
+      });
       const decodedTx = await backgroundApiProxy.serviceSend.buildDecodedTx({
         networkId,
         accountId,
@@ -1108,6 +1124,8 @@ export function useSwapBuildTx({
       checkLatestNativeTokenBalance,
       getSwapBtcOutputValidationToast,
       intl,
+      persistSettings.currencyInfo.id,
+      persistSettings.useGasAccountByDefault,
       setSwapSteps,
     ],
   );
@@ -1386,6 +1404,7 @@ export function useSwapBuildTx({
         payer?: IGasPayer;
         gasAccountEligible?: boolean;
         gasAccountQuote?: IGasAccountQuote;
+        gasAccountScenarioReason?: string;
       },
       gasCommon: {
         baseFee?: string;
@@ -1462,6 +1481,7 @@ export function useSwapBuildTx({
         payer: gasRes.payer,
         gasAccountEligible: gasRes.gasAccountEligible,
         gasAccountQuote: gasRes.gasAccountQuote,
+        gasAccountScenarioReason: gasRes.gasAccountScenarioReason,
       };
     },
     [
@@ -3131,6 +3151,7 @@ export function useSwapBuildTx({
       if (!fromToken || !fromAccountId || !fromUserAddress) {
         throw new OneKeyError('account error');
       }
+      const gasAccountReviewSession = gasAccountReviewSessionRef.current;
       const swapInfo = buildUnsignedParams?.swapInfo;
       // Gas Account sponsorship pre-check from the build-tx response; forwarded
       // to estimate-fee so the preview can decide whether to show the sponsored
@@ -3404,7 +3425,31 @@ export function useSwapBuildTx({
               swapInfo?.swapBuildResData.result?.fee?.otherFeeInfos,
           },
         );
-        if (!checkLatestNativeBalanceRes) {
+        const swapGasFeeInfo = findGasInfo(gasFeeInfos, unsignedTx.encodedTx);
+        const gasAccountAnalyticsContext = swapGasFeeInfo
+          ? buildDirectSwapGasAccountAnalyticsContext({
+              entryPoint: 'swapDirect',
+              networkId,
+              unsignedTx,
+              gasInfo: swapGasFeeInfo.gasInfo,
+              txSize: swapGasFeeInfo.txSize,
+              nativeBalance: checkLatestNativeBalanceRes.nativeBalance,
+              useGasAccountByDefault: persistSettings.useGasAccountByDefault,
+              fiatCurrency: persistSettings.currencyInfo.id,
+            })
+          : undefined;
+        if (
+          gasAccountAnalyticsContext &&
+          gasAccountReviewSession &&
+          gasAccountReviewSessionRef.current === gasAccountReviewSession
+        ) {
+          gasAccountReviewSession.analyticsContext = gasAccountAnalyticsContext;
+          if (!gasAccountReviewSession.decisionLogged) {
+            gasAccountReviewSession.decisionLogged = true;
+            logDirectSwapGasAccountDecision(gasAccountAnalyticsContext);
+          }
+        }
+        if (!checkLatestNativeBalanceRes.isSufficient) {
           throw new OneKeyAppError('checkLatestNativeTokenBalance failed');
         }
         const gasFeeFiatValues = await Promise.all(
@@ -3456,6 +3501,9 @@ export function useSwapBuildTx({
       fromAccountId,
       fromUserAddress,
       checkLatestNativeTokenBalance,
+      findGasInfo,
+      persistSettings.currencyInfo.id,
+      persistSettings.useGasAccountByDefault,
     ],
   );
 
@@ -3874,5 +3922,12 @@ export function useSwapBuildTx({
     ],
   );
 
-  return { preSwapStepsStart, cancelLimitOrder, preSwapBeforeStepActions };
+  return {
+    preSwapStepsStart,
+    cancelLimitOrder,
+    preSwapBeforeStepActions,
+    beginGasAccountReviewSession,
+    endGasAccountReviewSession,
+    markCurrentGasAccountReviewSubmitted,
+  };
 }

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -193,9 +193,13 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     onPopStack: onPopSwapModal,
     onBroadcast: swapInitParams?.onSwapBroadcast,
   });
-  const { preSwapStepsStart, preSwapBeforeStepActions } = useSwapBuildTx({
-    onSwapBroadcast,
-  });
+  const {
+    preSwapStepsStart,
+    preSwapBeforeStepActions,
+    beginGasAccountReviewSession,
+    endGasAccountReviewSession,
+    markCurrentGasAccountReviewSubmitted,
+  } = useSwapBuildTx({ onSwapBroadcast });
   const [quoteResult] = useSwapQuoteCurrentSelectAtom();
   const [alerts] = useSwapAlertsAtom();
   const [swapTypeSwitch] = useSwapTypeSwitchAtom();
@@ -1059,10 +1063,12 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   ]);
 
   const handleConfirm = useCallback(async () => {
+    markCurrentGasAccountReviewSubmitted();
     onActionHandlerBefore();
-  }, [onActionHandlerBefore]);
+  }, [markCurrentGasAccountReviewSubmitted, onActionHandlerBefore]);
 
   const onPreSwapClose = useCallback(() => {
+    endGasAccountReviewSession();
     dialogClose();
     setSwapBuildTxFetching(false);
     void backgroundApiProxy.serviceGas.abortEstimateFee();
@@ -1072,7 +1078,12 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
         preSwapData: {},
       });
     }, 100);
-  }, [setSwapBuildTxFetching, dialogClose, setSwapSteps]);
+  }, [
+    setSwapBuildTxFetching,
+    endGasAccountReviewSession,
+    dialogClose,
+    setSwapSteps,
+  ]);
 
   const handleSelectAccountClick = useCallback(() => {
     dismissKeyboard();
@@ -1105,6 +1116,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
       cleanQuoteInterval();
       setSwapShouldRefreshQuote(true);
     }
+    beginGasAccountReviewSession();
     parseQuoteResultToSteps();
     setSwapBuildTxFetching(true);
     reviewDialogTimerRef.current = setTimeout(() => {
@@ -1151,6 +1163,7 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
     swapProAccount?.result?.addressDetail.address,
     isSwapProMarketPresetLoading,
     currentQuoteRes,
+    beginGasAccountReviewSession,
     parseQuoteResultToSteps,
     setSwapBuildTxFetching,
     handleSelectAccountClick,

--- a/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapMainLand.tsx
@@ -252,13 +252,14 @@ const SwapMainLoad = ({ swapInitParams, pageType }: ISwapMainLoadProps) => {
   hasInFlightStepsRef.current = hasInFlightSteps;
 
   const resetPendingReview = useCallback(() => {
+    endGasAccountReviewSession();
     setSwapBuildTxFetching(false);
     void backgroundApiProxy.serviceGas.abortEstimateFee();
     setSwapSteps({
       steps: [],
       preSwapData: {},
     });
-  }, [setSwapBuildTxFetching, setSwapSteps]);
+  }, [endGasAccountReviewSession, setSwapBuildTxFetching, setSwapSteps]);
   const dialogClose = useCallback(() => {
     if (reviewDialogTimerRef.current !== undefined) {
       clearTimeout(reviewDialogTimerRef.current);

--- a/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.test.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.test.tsx
@@ -12,6 +12,7 @@ import { SwapReviewDialog } from './SwapReviewDialog';
 
 const useSwapReviewActionsMock = jest.fn();
 const removeStoreMock = jest.fn();
+const reviewConfirmMock = jest.fn();
 
 jest.mock('@onekeyhq/kit/src/states/jotai/utils/jotaiContextStore', () => ({
   jotaiContextStore: {
@@ -102,8 +103,9 @@ jest.mock('./SwapReviewInitializer', () => ({
 describe('SwapReviewDialog', () => {
   beforeEach(() => {
     removeStoreMock.mockClear();
+    reviewConfirmMock.mockClear();
     useSwapReviewActionsMock.mockReturnValue({
-      onConfirm: jest.fn(),
+      onConfirm: reviewConfirmMock,
       preSwapBeforeStepActions: jest.fn(),
       preSwapStepsStart: jest.fn(),
     });
@@ -111,6 +113,7 @@ describe('SwapReviewDialog', () => {
 
   it('renders the reusable swap review shell with the provided store and adapter', () => {
     const onDone = jest.fn();
+    const onConfirmStart = jest.fn();
     const adapter = {
       prepareReview: jest.fn(),
       sendApproveTx: jest.fn(),
@@ -123,6 +126,7 @@ describe('SwapReviewDialog', () => {
     render(
       <SwapReviewDialog
         onDone={onDone}
+        onConfirmStart={onConfirmStart}
         adapter={adapter}
         reviewState={{
           steps: [],
@@ -157,6 +161,11 @@ describe('SwapReviewDialog', () => {
     fireEvent.click(screen.getByTestId('review-confirm'));
     fireEvent.click(screen.getByTestId('review-done'));
 
+    expect(onConfirmStart).toHaveBeenCalledTimes(1);
+    expect(reviewConfirmMock).toHaveBeenCalledTimes(1);
+    expect(onConfirmStart.mock.invocationCallOrder[0]).toBeLessThan(
+      reviewConfirmMock.mock.invocationCallOrder[0],
+    );
     expect(onDone).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapReviewDialog.tsx
@@ -20,6 +20,7 @@ import { SwapReviewInitializer } from './SwapReviewInitializer';
 
 type ISwapReviewDialogProps = {
   onDone: () => void;
+  onConfirmStart?: () => void;
   adapter: ISwapReviewAdapter;
   reviewState: ISwapReviewState;
   storeName: EJotaiContextStoreNames;
@@ -45,6 +46,7 @@ function SwapReviewDialogContent({
   defaultNetworkFeeLevel,
   showCustomNetworkFeeOption,
   onDone,
+  onConfirmStart,
 }: {
   adapter: ISwapReviewAdapter;
   approveTransactionSource: ESwapReviewApproveTransactionSource;
@@ -53,6 +55,7 @@ function SwapReviewDialogContent({
   defaultCustomPriorityFee?: ICustomPriorityFeeOverride;
   showCustomNetworkFeeOption?: boolean;
   onDone: () => void;
+  onConfirmStart?: () => void;
 }) {
   const { onConfirm, preSwapBeforeStepActions, preSwapStepsStart } =
     useSwapReviewActions({
@@ -63,7 +66,10 @@ function SwapReviewDialogContent({
   return (
     <PreSwapDialogContent
       disableGlobalApproveSync={disableGlobalApproveSync}
-      onConfirm={onConfirm}
+      onConfirm={() => {
+        onConfirmStart?.();
+        onConfirm();
+      }}
       onDone={onDone}
       preSwapBeforeStepActions={preSwapBeforeStepActions}
       preSwapStepsStart={preSwapStepsStart}
@@ -76,6 +82,7 @@ function SwapReviewDialogContent({
 
 export function SwapReviewDialog({
   onDone,
+  onConfirmStart,
   adapter,
   reviewState,
   storeName,
@@ -119,6 +126,7 @@ export function SwapReviewDialog({
             defaultCustomPriorityFee={defaultCustomPriorityFee}
             showCustomNetworkFeeOption={showCustomNetworkFeeOption}
             onDone={onDone}
+            onConfirmStart={onConfirmStart}
           />
         </SwapReviewInitializer>
       </SwapProviderMirror>

--- a/packages/kit/src/views/Swap/utils/gasAccountAnalytics.test.ts
+++ b/packages/kit/src/views/Swap/utils/gasAccountAnalytics.test.ts
@@ -1,0 +1,252 @@
+import type { IUnsignedTxPro } from '@onekeyhq/core/src/types';
+import type { ISwapGasInfo } from '@onekeyhq/shared/types/swap/types';
+
+const mockGasAccountAction = jest.fn();
+
+jest.mock('@onekeyhq/shared/src/logger/logger', () => ({
+  defaultLogger: {
+    transaction: {
+      send: {
+        gasAccountAction: mockGasAccountAction,
+      },
+    },
+  },
+}));
+
+const {
+  buildDirectSwapGasAccountAnalyticsContext,
+  buildDirectSwapGasAccountUiState,
+  createGasAccountReviewSession,
+  logGasAccountReviewExit,
+  markGasAccountReviewSubmitted,
+  sendDirectSwapWithGasAccountAnalytics,
+} = require('./gasAccountAnalytics') as typeof import('./gasAccountAnalytics');
+
+const unsignedTx = {
+  encodedTx: {},
+  swapInfo: {
+    sender: {
+      amount: '0.1',
+      token: {
+        isNative: true,
+        networkId: 'evm--1',
+      },
+    },
+    swapBuildResData: {
+      orderId: 'swap-order-id',
+      result: {
+        fee: {
+          otherFeeInfos: [],
+        },
+      },
+    },
+  },
+} as unknown as IUnsignedTxPro;
+
+const gasInfo = {
+  common: {
+    feeDecimals: 18,
+    feeSymbol: 'ETH',
+    nativeDecimals: 18,
+    nativeSymbol: 'ETH',
+    nativeTokenPrice: 2000,
+  },
+  gas: {
+    gasLimit: '1',
+    gasPrice: '0.01',
+  },
+  payer: 'gasAccount',
+  gasAccountEligible: true,
+  gasAccountQuote: {
+    quoteId: 'quote-id',
+    maxFee: '0.01',
+    expiresAt: '2026-08-10T12:00:00.000Z',
+  },
+} as ISwapGasInfo;
+
+describe('buildDirectSwapGasAccountAnalyticsContext', () => {
+  beforeEach(() => {
+    mockGasAccountAction.mockReset();
+  });
+
+  it('classifies the direct swap self-pay gas shortfall', () => {
+    const result = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'swapDirect',
+      networkId: 'evm--1',
+      unsignedTx,
+      gasInfo,
+      nativeBalance: '0.105',
+      useGasAccountByDefault: true,
+      fiatCurrency: 'usd',
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        entryPoint: 'swapDirect',
+        scenario: 'swap',
+        shortageType: 'networkFee',
+        gasShortfallNative: '0.005',
+        selectedPayer: 'gasAccount',
+        quoteId: 'quote-id',
+        orderId: 'swap-order-id',
+      }),
+    );
+  });
+
+  it('keeps decision telemetry when the native balance lookup is unavailable', () => {
+    const result = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'marketSwapDirect',
+      networkId: 'evm--1',
+      unsignedTx,
+      gasInfo,
+      nativeBalance: undefined,
+      useGasAccountByDefault: true,
+      fiatCurrency: 'usd',
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        entryPoint: 'marketSwapDirect',
+        nativeBalanceAvailable: false,
+        selfPayGasSufficient: null,
+        shortageType: 'unknown',
+      }),
+    );
+  });
+
+  it('uses the pre-sponsorship fee and tracks MegaFuel review exits', () => {
+    const context = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'swapDirect',
+      networkId: 'evm--1',
+      unsignedTx,
+      gasInfo: {
+        ...gasInfo,
+        gas: {
+          gasLimit: '1',
+          gasPrice: '0',
+          originalGasPrice: '0.01',
+        },
+        payer: 'megafuel',
+        megafuelEligible: {
+          sponsorable: true,
+          sponsorName: 'OneKey',
+        },
+        gasAccountEligible: false,
+        gasAccountQuote: undefined,
+      },
+      nativeBalance: '0.105',
+      useGasAccountByDefault: true,
+      fiatCurrency: 'usd',
+    });
+    const session = createGasAccountReviewSession();
+    session.analyticsContext = context;
+
+    logGasAccountReviewExit(session);
+
+    expect(context).toEqual(
+      expect.objectContaining({
+        selectedPayer: 'user',
+        effectiveFeePayer: 'megafuel',
+        estimatedGasNative: '0.01',
+        selfPayGasSufficient: false,
+        shortageType: 'networkFee',
+      }),
+    );
+    expect(mockGasAccountAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'exited',
+        effectiveFeePayer: 'megafuel',
+      }),
+    );
+  });
+
+  it('tracks one exit when a Gas Account review closes before submit', () => {
+    const context = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'swapDirect',
+      networkId: 'evm--1',
+      unsignedTx,
+      gasInfo,
+      nativeBalance: '0.105',
+      useGasAccountByDefault: true,
+      fiatCurrency: 'usd',
+    });
+    const session = createGasAccountReviewSession();
+    session.analyticsContext = context;
+
+    logGasAccountReviewExit(session);
+    logGasAccountReviewExit(session);
+
+    expect(mockGasAccountAction).toHaveBeenCalledTimes(1);
+    expect(mockGasAccountAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'exited',
+        entryPoint: 'swapDirect',
+      }),
+    );
+  });
+
+  it('does not track an exit after the review starts submitting', () => {
+    const context = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'marketSwapDirect',
+      networkId: 'evm--1',
+      unsignedTx,
+      gasInfo,
+      nativeBalance: '0.105',
+      useGasAccountByDefault: true,
+      fiatCurrency: 'usd',
+    });
+    const session = createGasAccountReviewSession();
+    session.analyticsContext = context;
+
+    markGasAccountReviewSubmitted(session);
+    logGasAccountReviewExit(session);
+
+    expect(mockGasAccountAction).not.toHaveBeenCalled();
+  });
+
+  it('tracks Gas Account fallback without duplicating send logic in callers', async () => {
+    const context = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'swapDirect',
+      networkId: 'evm--1',
+      unsignedTx,
+      gasInfo,
+      nativeBalance: '0.105',
+      useGasAccountByDefault: true,
+      fiatCurrency: 'usd',
+    });
+    const gasAccountUiState = buildDirectSwapGasAccountUiState({
+      gasInfo,
+      unsignedTx,
+    });
+    const send = jest
+      .fn()
+      .mockRejectedValueOnce({ code: 40_213 })
+      .mockResolvedValueOnce('signed');
+
+    await expect(
+      sendDirectSwapWithGasAccountAnalytics({
+        context,
+        gasAccountUiState,
+        send,
+      }),
+    ).resolves.toBe('signed');
+
+    expect(send).toHaveBeenNthCalledWith(1, gasAccountUiState);
+    expect(send).toHaveBeenNthCalledWith(2);
+    expect(mockGasAccountAction).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ action: 'submitFailed' }),
+    );
+    expect(mockGasAccountAction).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ action: 'payerChanged' }),
+    );
+    expect(mockGasAccountAction).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: 'submitSucceeded',
+        effectiveFeePayer: 'user',
+        orderId: 'swap-order-id',
+      }),
+    );
+  });
+});

--- a/packages/kit/src/views/Swap/utils/gasAccountAnalytics.test.ts
+++ b/packages/kit/src/views/Swap/utils/gasAccountAnalytics.test.ts
@@ -185,7 +185,7 @@ describe('buildDirectSwapGasAccountAnalyticsContext', () => {
     );
   });
 
-  it('does not track an exit after the review starts submitting', () => {
+  it('tracks confirm once and does not track an exit after submit starts', () => {
     const context = buildDirectSwapGasAccountAnalyticsContext({
       entryPoint: 'marketSwapDirect',
       networkId: 'evm--1',
@@ -199,9 +199,16 @@ describe('buildDirectSwapGasAccountAnalyticsContext', () => {
     session.analyticsContext = context;
 
     markGasAccountReviewSubmitted(session);
+    markGasAccountReviewSubmitted(session);
     logGasAccountReviewExit(session);
 
-    expect(mockGasAccountAction).not.toHaveBeenCalled();
+    expect(mockGasAccountAction).toHaveBeenCalledTimes(1);
+    expect(mockGasAccountAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'confirmClicked',
+        entryPoint: 'marketSwapDirect',
+      }),
+    );
   });
 
   it('tracks Gas Account fallback without duplicating send logic in callers', async () => {
@@ -248,5 +255,50 @@ describe('buildDirectSwapGasAccountAnalyticsContext', () => {
         orderId: 'swap-order-id',
       }),
     );
+  });
+
+  it('waits for fallback preparation before retrying as user-paid', async () => {
+    const context = buildDirectSwapGasAccountAnalyticsContext({
+      entryPoint: 'marketSwapDirect',
+      networkId: 'evm--1',
+      unsignedTx,
+      gasInfo,
+      nativeBalance: '0.105',
+      useGasAccountByDefault: true,
+      fiatCurrency: 'usd',
+    });
+    const gasAccountUiState = buildDirectSwapGasAccountUiState({
+      gasInfo,
+      unsignedTx,
+    });
+    const callOrder: string[] = [];
+    const send = jest
+      .fn()
+      .mockImplementationOnce(async () => {
+        callOrder.push('sponsored-send');
+        throw Object.assign(new Error('sponsor unavailable'), {
+          code: 40_213,
+        });
+      })
+      .mockImplementationOnce(async () => {
+        callOrder.push('user-send');
+        return 'signed';
+      });
+
+    await sendDirectSwapWithGasAccountAnalytics({
+      context,
+      gasAccountUiState,
+      send,
+      onGasAccountError: async () => {
+        await Promise.resolve();
+        callOrder.push('fallback-prepared');
+      },
+    });
+
+    expect(callOrder).toEqual([
+      'sponsored-send',
+      'fallback-prepared',
+      'user-send',
+    ]);
   });
 });

--- a/packages/kit/src/views/Swap/utils/gasAccountAnalytics.ts
+++ b/packages/kit/src/views/Swap/utils/gasAccountAnalytics.ts
@@ -1,0 +1,316 @@
+import BigNumber from 'bignumber.js';
+
+import type { IUnsignedTxPro } from '@onekeyhq/core/src/types';
+import { getGasAccountErrorCode } from '@onekeyhq/shared/src/errors/utils/gasAccountErrorUtils';
+import { defaultLogger } from '@onekeyhq/shared/src/logger/logger';
+import type {
+  IGasAccountActionParams,
+  IGasAccountAnalyticsContext,
+  IGasAccountEntryPoint,
+} from '@onekeyhq/shared/src/logger/scopes/transaction/types';
+import { calculateFeeForSend } from '@onekeyhq/shared/src/utils/feeUtils';
+import type {
+  IEstimateFeeParams,
+  IFeeInfoUnit,
+  IGasAccountUiState,
+} from '@onekeyhq/shared/types/fee';
+import type { ISwapGasInfo } from '@onekeyhq/shared/types/swap/types';
+
+import {
+  EGasAccountErrorStrategy,
+  getGasAccountErrorEntry,
+} from '../../SignatureConfirm/constants/gasAccountErrorCodes';
+import {
+  buildGasAccountAnalyticsContext,
+  isGasSponsoredAnalyticsContext,
+} from '../../SignatureConfirm/utils/gasAccountAnalytics';
+
+type IDirectSwapGasAccountActionDetails = Omit<
+  IGasAccountActionParams,
+  keyof IGasAccountAnalyticsContext
+>;
+
+export function logDirectSwapGasAccountAction(
+  context: IGasAccountAnalyticsContext | undefined,
+  details: IDirectSwapGasAccountActionDetails,
+) {
+  if (!context || !isGasSponsoredAnalyticsContext(context)) {
+    return;
+  }
+  defaultLogger.transaction.send.gasAccountAction({
+    ...context,
+    ...details,
+  });
+}
+
+export type IGasAccountReviewSession = {
+  analyticsContext?: IGasAccountAnalyticsContext;
+  decisionLogged: boolean;
+  submitted: boolean;
+  exitLogged: boolean;
+};
+
+export function createGasAccountReviewSession(): IGasAccountReviewSession {
+  return {
+    decisionLogged: false,
+    submitted: false,
+    exitLogged: false,
+  };
+}
+
+export function markGasAccountReviewSubmitted(
+  session: IGasAccountReviewSession | undefined,
+) {
+  if (session) {
+    session.submitted = true;
+  }
+}
+
+export function logGasAccountReviewExit(
+  session: IGasAccountReviewSession | undefined,
+) {
+  if (!session || session.submitted || session.exitLogged) {
+    return;
+  }
+  session.exitLogged = true;
+  logDirectSwapGasAccountAction(session.analyticsContext, {
+    action: 'exited',
+  });
+}
+
+function getNativeOtherFeeAmount({
+  networkId,
+  unsignedTx,
+}: {
+  networkId: string;
+  unsignedTx: IUnsignedTxPro;
+}) {
+  return (
+    unsignedTx.swapInfo?.swapBuildResData.result?.fee?.otherFeeInfos ?? []
+  )
+    .filter((item) => item.token.isNative && item.token.networkId === networkId)
+    .reduce((total, item) => total.plus(item.amount || 0), new BigNumber(0))
+    .toFixed();
+}
+
+function getDirectSwapGasAccountUnavailableReason({
+  hasEligibleQuote,
+  useGasAccountByDefault,
+  gasAccountCandidate,
+  gasAccountScenarioReason,
+}: {
+  hasEligibleQuote: boolean;
+  useGasAccountByDefault: boolean | undefined;
+  gasAccountCandidate: boolean;
+  gasAccountScenarioReason: string | undefined;
+}) {
+  if (hasEligibleQuote) {
+    return undefined;
+  }
+  if (useGasAccountByDefault === false) {
+    return 'userDisabled';
+  }
+  if (gasAccountCandidate) {
+    return gasAccountScenarioReason ?? 'backend_unknown';
+  }
+  return 'swapBuildDisabled';
+}
+
+export function buildDirectSwapGasAccountAnalyticsContext({
+  entryPoint,
+  networkId,
+  unsignedTx,
+  gasInfo,
+  estimateFeeParams,
+  txSize,
+  nativeBalance,
+  useGasAccountByDefault,
+  fiatCurrency,
+}: {
+  entryPoint: Extract<IGasAccountEntryPoint, 'swapDirect' | 'marketSwapDirect'>;
+  networkId: string;
+  unsignedTx: IUnsignedTxPro;
+  gasInfo: ISwapGasInfo;
+  estimateFeeParams?: IEstimateFeeParams;
+  txSize?: number;
+  nativeBalance: string | undefined;
+  useGasAccountByDefault: boolean | undefined;
+  fiatCurrency: string | undefined;
+}): IGasAccountAnalyticsContext | undefined {
+  const swapInfo = unsignedTx.swapInfo;
+  if (!swapInfo || !gasInfo.common) {
+    return undefined;
+  }
+
+  const { originalTotalNative, totalNative } = calculateFeeForSend({
+    feeInfo: gasInfo as IFeeInfoUnit,
+    nativeTokenPrice: gasInfo.common.nativeTokenPrice ?? 0,
+    estimateFeeParams,
+    txSize,
+  });
+  const sender = swapInfo.sender;
+  const nativePrincipal =
+    sender.token.isNative && sender.token.networkId === networkId
+      ? sender.amount
+      : '0';
+  const hasEligibleQuote = Boolean(
+    gasInfo.gasAccountEligible && gasInfo.gasAccountQuote?.quoteId,
+  );
+  const gasAccountCandidate = Boolean(
+    swapInfo.swapBuildResData.result?.gasAccountEnabled,
+  );
+  const gasAccountRequested =
+    gasAccountCandidate && useGasAccountByDefault !== false;
+  const selectedPayer =
+    hasEligibleQuote && gasInfo.payer === 'gasAccount' ? 'gasAccount' : 'user';
+  let gasAccountSupported: boolean | null = null;
+  if (hasEligibleQuote) {
+    gasAccountSupported = true;
+  } else if (gasInfo.gasAccountScenarioReason) {
+    gasAccountSupported = false;
+  }
+
+  return buildGasAccountAnalyticsContext({
+    entryPoint,
+    network: networkId,
+    scenario: 'swap',
+    gasAccountRequested,
+    gasAccountSupported,
+    gasAccountEligible: gasAccountRequested ? hasEligibleQuote : null,
+    selectedPayer,
+    effectiveFeePayer: gasInfo.payer ?? 'user',
+    unavailableReason: getDirectSwapGasAccountUnavailableReason({
+      hasEligibleQuote,
+      useGasAccountByDefault,
+      gasAccountCandidate,
+      gasAccountScenarioReason: gasInfo.gasAccountScenarioReason,
+    }),
+    estimatedGasNative: originalTotalNative ?? totalNative,
+    nativeBalance,
+    nativePrincipal,
+    extraFeeNative: getNativeOtherFeeAmount({ networkId, unsignedTx }),
+    nativeTokenPrice: gasInfo.common.nativeTokenPrice,
+    fiatCurrency,
+    tokenPrincipalInsufficient: false,
+    quoteId: gasInfo.gasAccountQuote?.quoteId,
+    orderId: swapInfo.swapBuildResData.orderId,
+  });
+}
+
+export function logDirectSwapGasAccountDecision(
+  context: IGasAccountAnalyticsContext | undefined,
+) {
+  if (context) {
+    defaultLogger.transaction.send.gasAccountDecision(context);
+  }
+}
+
+export function buildDirectSwapGasAccountUiState({
+  gasInfo,
+  unsignedTx,
+}: {
+  gasInfo: ISwapGasInfo;
+  unsignedTx: IUnsignedTxPro;
+}): IGasAccountUiState | undefined {
+  const quote = gasInfo.gasAccountQuote;
+  if (
+    !gasInfo.gasAccountEligible ||
+    gasInfo.payer !== 'gasAccount' ||
+    !quote?.quoteId
+  ) {
+    return undefined;
+  }
+
+  return {
+    payer: 'gasAccount',
+    gasAccountEligible: true,
+    gasAccountQuote: quote,
+    selectedPayer: 'gasAccount',
+    lockedUserNonce:
+      typeof unsignedTx.nonce === 'number' ? unsignedTx.nonce : undefined,
+    idempotencyKey: `gas-account:${quote.quoteId}`,
+  };
+}
+
+export async function runDirectSwapGasAccountStep<T>({
+  context,
+  failureStage,
+  task,
+}: {
+  context: IGasAccountAnalyticsContext | undefined;
+  failureStage: NonNullable<IGasAccountActionParams['failureStage']>;
+  task: () => Promise<T>;
+}): Promise<T> {
+  try {
+    return await task();
+  } catch (error) {
+    logDirectSwapGasAccountAction(context, {
+      action: 'submitFailed',
+      failureStage,
+      errorCode: getGasAccountErrorCode(error),
+    });
+    throw error;
+  }
+}
+
+export async function sendDirectSwapWithGasAccountAnalytics<T>({
+  context,
+  gasAccountUiState,
+  send,
+  onGasAccountError,
+}: {
+  context: IGasAccountAnalyticsContext | undefined;
+  gasAccountUiState: IGasAccountUiState | undefined;
+  send: (gasAccountUiState?: IGasAccountUiState) => Promise<T>;
+  onGasAccountError?: (
+    error: unknown,
+    entry: NonNullable<ReturnType<typeof getGasAccountErrorEntry>>,
+  ) => void | Promise<void>;
+}): Promise<T> {
+  let result: T;
+  let effectiveFeePayer = context?.effectiveFeePayer ?? 'user';
+  try {
+    result = await send(gasAccountUiState);
+  } catch (error) {
+    const errorCode = getGasAccountErrorCode(error);
+    logDirectSwapGasAccountAction(context, {
+      action: 'submitFailed',
+      failureStage: 'submit',
+      errorCode,
+    });
+    const entry = gasAccountUiState
+      ? getGasAccountErrorEntry(errorCode)
+      : undefined;
+    if (!entry) {
+      throw error;
+    }
+
+    await onGasAccountError?.(error, entry);
+    if (entry.strategy !== EGasAccountErrorStrategy.Fallback) {
+      throw error;
+    }
+
+    logDirectSwapGasAccountAction(context, {
+      action: 'payerChanged',
+      fromPayer: 'gasAccount',
+      toPayer: 'user',
+      changeSource: 'system',
+      changeReason: 'submitFailed',
+      errorCode,
+    });
+    effectiveFeePayer = 'user';
+    result = await runDirectSwapGasAccountStep({
+      context: context ? { ...context, effectiveFeePayer } : undefined,
+      failureStage: 'submit',
+      task: () => send(),
+    });
+  }
+
+  logDirectSwapGasAccountAction(
+    context ? { ...context, effectiveFeePayer } : undefined,
+    {
+      action: 'submitSucceeded',
+    },
+  );
+  return result;
+}

--- a/packages/kit/src/views/Swap/utils/gasAccountAnalytics.ts
+++ b/packages/kit/src/views/Swap/utils/gasAccountAnalytics.ts
@@ -45,6 +45,7 @@ export function logDirectSwapGasAccountAction(
 
 export type IGasAccountReviewSession = {
   analyticsContext?: IGasAccountAnalyticsContext;
+  nativeBalance?: string;
   decisionLogged: boolean;
   submitted: boolean;
   exitLogged: boolean;
@@ -61,9 +62,13 @@ export function createGasAccountReviewSession(): IGasAccountReviewSession {
 export function markGasAccountReviewSubmitted(
   session: IGasAccountReviewSession | undefined,
 ) {
-  if (session) {
-    session.submitted = true;
+  if (!session || session.submitted) {
+    return;
   }
+  logDirectSwapGasAccountAction(session.analyticsContext, {
+    action: 'confirmClicked',
+  });
+  session.submitted = true;
 }
 
 export function logGasAccountReviewExit(
@@ -138,7 +143,7 @@ export function buildDirectSwapGasAccountAnalyticsContext({
   fiatCurrency: string | undefined;
 }): IGasAccountAnalyticsContext | undefined {
   const swapInfo = unsignedTx.swapInfo;
-  if (!swapInfo || !gasInfo.common) {
+  if (!swapInfo?.sender?.token || !gasInfo.common) {
     return undefined;
   }
 

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.test.ts
@@ -3,6 +3,7 @@ import type { ITransferInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
 
 import {
+  buildNativeTokenFromGasInfo,
   checkSwapLatestBalanceSufficient,
   getSwapEncodedTxSize,
   getSwapRequiredNativeBalanceAmount,
@@ -137,6 +138,23 @@ describe('checkSwapLatestBalanceSufficient', () => {
     ).resolves.toEqual({ isSufficient: true });
   });
 
+  it('still fetches balance when sponsored gas requires no self-paid amount', async () => {
+    mockFetchSwapTokenDetails.mockResolvedValue([{ balanceParsed: '0.08' }]);
+
+    await expect(
+      checkSwapLatestBalanceSufficient({
+        token: ethToken,
+        amount: '0',
+        accountId: 'account-id',
+        accountAddress: '0xabc',
+      }),
+    ).resolves.toEqual({
+      isSufficient: true,
+      balance: '0.08',
+      tokenSymbol: 'ETH',
+    });
+  });
+
   it('uses canonical native token address when native token address is empty', async () => {
     mockGetNativeTokenAddress.mockResolvedValue(aptosNativeAddress);
     mockFetchSwapTokenDetails.mockResolvedValue([{ balanceParsed: '6.6044' }]);
@@ -148,7 +166,11 @@ describe('checkSwapLatestBalanceSufficient', () => {
         accountId: 'account-id',
         accountAddress: '0xabc',
       }),
-    ).resolves.toEqual({ isSufficient: true });
+    ).resolves.toEqual({
+      isSufficient: true,
+      balance: '6.6044',
+      tokenSymbol: 'APT',
+    });
     expect(mockGetNativeTokenAddress).toHaveBeenCalledWith({
       networkId: 'aptos--1',
     });
@@ -159,6 +181,18 @@ describe('checkSwapLatestBalanceSufficient', () => {
       accountId: 'account-id',
       currency: 'usd',
     });
+  });
+});
+
+describe('buildNativeTokenFromGasInfo', () => {
+  it('builds the native token from gas info for a token swap', () => {
+    expect(
+      buildNativeTokenFromGasInfo({
+        gasInfo: evmGasInfo,
+        networkId: 'evm--1',
+        fromToken: usdcToken,
+      }),
+    ).toEqual(ethToken);
   });
 });
 

--- a/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
+++ b/packages/kit/src/views/Swap/utils/swapBalanceUtils.ts
@@ -25,6 +25,8 @@ type ISwapLatestBalanceCheckParams = {
 export type ISwapLatestBalanceCheckResult =
   | {
       isSufficient: true;
+      balance?: string;
+      tokenSymbol?: string;
     }
   | {
       isSufficient: false;
@@ -244,7 +246,7 @@ export function validateSwapBtcOutputs({
   return undefined;
 }
 
-function buildNativeTokenFromGasInfo({
+export function buildNativeTokenFromGasInfo({
   gasInfo,
   networkId,
   fromToken,
@@ -376,11 +378,12 @@ export async function checkSwapLatestBalanceSufficient({
     !accountAddress ||
     amountBN.isNaN() ||
     !amountBN.isFinite() ||
-    amountBN.lte(0)
+    amountBN.lt(0)
   ) {
     return { isSufficient: true };
   }
 
+  let balance: string | undefined;
   try {
     const contractAddress = await getSwapTokenBalanceContractAddress(token);
     const tokenBalanceInfo =
@@ -391,26 +394,28 @@ export async function checkSwapLatestBalanceSufficient({
         accountId,
         currency: 'usd',
       });
-    if (!tokenBalanceInfo?.length) {
-      return { isSufficient: true };
-    }
-
-    const balanceBN = new BigNumber(tokenBalanceInfo[0].balanceParsed ?? 0);
-    if (balanceBN.isNaN() || !balanceBN.isFinite()) {
-      return { isSufficient: true };
-    }
-
-    if (amountBN.gt(balanceBN)) {
-      return {
-        isSufficient: false,
-        balance: balanceBN.toFixed(),
-        requiredAmount: amountBN.toFixed(),
-        tokenSymbol: token.symbol,
-      };
+    const balanceBN = new BigNumber(
+      tokenBalanceInfo?.[0]?.balanceParsed ?? NaN,
+    );
+    if (!balanceBN.isNaN() && balanceBN.isFinite() && !balanceBN.isNegative()) {
+      balance = balanceBN.toFixed();
     }
   } catch (error) {
     console.error('checkSwapLatestBalanceSufficient error', error);
   }
 
-  return { isSufficient: true };
+  if (balance === undefined) {
+    return { isSufficient: true };
+  }
+
+  if (amountBN.gt(balance)) {
+    return {
+      isSufficient: false,
+      balance,
+      requiredAmount: amountBN.toFixed(),
+      tokenSymbol: token.symbol,
+    };
+  }
+
+  return { isSufficient: true, balance, tokenSymbol: token.symbol };
 }

--- a/packages/shared/src/logger/scopes/transaction/scenes/send.ts
+++ b/packages/shared/src/logger/scopes/transaction/scenes/send.ts
@@ -4,6 +4,11 @@ import type { EUtxoSelectionStrategy } from '@onekeyhq/shared/types/send';
 import { BaseScene } from '../../../base/baseScene';
 import { LogToLocal, LogToServer } from '../../../base/decorators';
 
+import type {
+  IGasAccountActionParams,
+  IGasAccountAnalyticsContext,
+} from '../types';
+
 type ISendMode = 'public' | 'private';
 type IPrivateSendQuoteStatus = 'success' | 'failed';
 type IPrivateSendFinalStatus = 'done' | 'failed';
@@ -358,23 +363,26 @@ export class SendScene extends BaseScene {
   }
 
   @LogToServer()
-  public insufficientFeeOnConfirm({
-    network,
-    tokenSymbol,
-    fillUpAmount,
-    feeType,
-  }: {
-    network: string | undefined;
-    tokenSymbol: string | undefined;
-    fillUpAmount: string | undefined;
-    feeType: 'native' | 'token';
-  }) {
+  public gasAccountDecision(params: IGasAccountAnalyticsContext) {
+    return params;
+  }
+
+  @LogToServer()
+  public gasAccountAction(params: IGasAccountActionParams) {
+    return params;
+  }
+
+  @LogToServer()
+  public insufficientFeeOnConfirm(
+    params: {
+      tokenSymbol: string | undefined;
+      fillUpAmount: string | undefined;
+      feeType: 'native' | 'token';
+    } & IGasAccountAnalyticsContext,
+  ) {
     return {
       sendFlowId: this._sendFlowId,
-      network,
-      tokenSymbol,
-      fillUpAmount,
-      feeType,
+      ...params,
     };
   }
 

--- a/packages/shared/src/logger/scopes/transaction/scenes/send.ts
+++ b/packages/shared/src/logger/scopes/transaction/scenes/send.ts
@@ -375,10 +375,11 @@ export class SendScene extends BaseScene {
   @LogToServer()
   public insufficientFeeOnConfirm(
     params: {
+      network: string | undefined;
       tokenSymbol: string | undefined;
       fillUpAmount: string | undefined;
       feeType: 'native' | 'token';
-    } & IGasAccountAnalyticsContext,
+    } & Partial<Omit<IGasAccountAnalyticsContext, 'network'>>,
   ) {
     return {
       sendFlowId: this._sendFlowId,

--- a/packages/shared/src/logger/scopes/transaction/types.ts
+++ b/packages/shared/src/logger/scopes/transaction/types.ts
@@ -1,0 +1,72 @@
+import type {
+  IGasAccountScenario,
+  IGasPayer,
+} from '@onekeyhq/shared/types/fee';
+
+export type IGasAccountShortageType =
+  | 'unknown'
+  | 'none'
+  | 'principal'
+  | 'extraFee'
+  | 'networkFee'
+  | 'mixed';
+
+export type IGasAccountEntryPoint =
+  | 'txConfirm'
+  | 'swapDirect'
+  | 'marketSwapDirect';
+
+export type IGasAccountFiatBucket =
+  | 'unknown'
+  | 'lt_0_01'
+  | '0_01_0_1'
+  | '0_1_1'
+  | '1_5'
+  | 'gte_5';
+
+export interface IGasAccountAnalyticsContext {
+  entryPoint: IGasAccountEntryPoint;
+  network: string;
+  scenario: IGasAccountScenario | undefined;
+  gasAccountRequested: boolean;
+  gasAccountSupported: boolean | null;
+  gasAccountEligible: boolean | null;
+  selectedPayer: 'user' | 'gasAccount';
+  effectiveFeePayer: IGasPayer;
+  unavailableReason: string | undefined;
+  nativeBalanceAvailable: boolean;
+  selfPayGasSufficient: boolean | null;
+  shortageType: IGasAccountShortageType;
+  estimatedGasNative: string;
+  estimatedGasFiat: string | undefined;
+  gasShortfallNative: string | undefined;
+  gasShortfallFiat: string | undefined;
+  gasShortfallFiatBucket: IGasAccountFiatBucket;
+  nativeBalanceFiatBucket: IGasAccountFiatBucket;
+  fiatCurrency: string | undefined;
+  fiatValueAvailable: boolean;
+  quoteId: string | undefined;
+  orderId: string | undefined;
+}
+
+export type IGasAccountActionType =
+  | 'confirmClicked'
+  | 'payerChanged'
+  | 'submitSucceeded'
+  | 'submitFailed'
+  | 'exited';
+
+export interface IGasAccountActionParams extends IGasAccountAnalyticsContext {
+  action: IGasAccountActionType;
+  fromPayer?: IGasPayer;
+  toPayer?: IGasPayer;
+  changeSource?: 'user' | 'system';
+  changeReason?:
+    | 'userSelection'
+    | 'quoteExpired'
+    | 'quoteFailed'
+    | 'submitFailed'
+    | 'unknown';
+  failureStage?: 'precheck' | 'prepare' | 'submit' | 'unknown';
+  errorCode?: number;
+}

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -596,6 +596,7 @@ export interface ISwapGasInfo {
   payer?: IGasPayer;
   gasAccountEligible?: boolean;
   gasAccountQuote?: IGasAccountQuote;
+  gasAccountScenarioReason?: string;
 }
 export interface ISwapPreSwapData {
   fromToken?: ISwapToken;


### PR DESCRIPTION
## Summary

- restore the Gas Account funnel analytics from #12823 on top of #12882
- preserve the sync branch sponsor, fallback, fee validation, and recipient changes while adapting the analytics hooks to the current paths
- retain decision, confirm, exit, payer-change, submit success/failure, scenario, and custom-RPC attribution across TxConfirm, Swap, and Market direct swap
- reuse the review balance snapshot for sponsored direct swaps and keep final user-paid validation before Market fallback
- move the existing Settings page JSX comment to a valid position so the sync branch passes TypeScript checks

## Validation

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- 6 focused Jest suites, 58 tests passed