### PR TITLE
fix: sync hardware connection status after reset(OK-60117)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.pro2DeviceManagement.test.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.pro2DeviceManagement.test.ts
@@ -81,6 +81,7 @@ jest.mock('../../dbs/local/localDb', () => ({
   default: {
     getDeviceSafe: jest.fn(),
     getDeviceByQuery: jest.fn(),
+    updateDevice: jest.fn(),
     updateDeviceState: jest.fn(),
   },
 }));
@@ -840,6 +841,124 @@ describe('ServiceHardware SDK DeviceState synchronization', () => {
     expect(notifyHardwareDeviceDisconnected).toHaveBeenCalledWith({
       identityKeys: ['PRO2_USB', 'PRO2_UUID', 'PRO2_SERIAL'],
     });
+  });
+
+  it('features 到达后补录设备身份并广播连接状态', async () => {
+    const listeners = new Map<string, (payload: unknown) => void>();
+    const service = new ServiceHardware({
+      backgroundApi: {} as unknown as IBackgroundApi,
+    });
+    await service.registerSdkEvents({
+      on: jest.fn((event: string, listener: (payload: unknown) => void) =>
+        listeners.set(event, listener),
+      ),
+    } as never);
+
+    // DEVICE.CONNECT arrives before features are complete
+    listeners.get(DEVICE.CONNECT)?.({
+      device: { connectId: 'PRO2_USB' },
+    });
+    await expect(
+      service.getConnectedHardwareDeviceIdentityKeys(),
+    ).resolves.toEqual(['PRO2_USB']);
+    jest.mocked(appEventBus.emit).mockClear();
+
+    listeners.get(DEVICE.SUPPORT_FEATURES)?.({
+      device: {
+        connectId: 'PRO2_USB',
+        uuid: 'PRO2_UUID',
+        deviceId: 'PRO2_DEVICE_ID',
+        features: { device_id: 'PRO2_DEVICE_ID' },
+      },
+    });
+
+    await expect(
+      service.getConnectedHardwareDeviceIdentityKeys(),
+    ).resolves.toEqual(
+      expect.arrayContaining(['PRO2_USB', 'PRO2_UUID', 'PRO2_DEVICE_ID']),
+    );
+    expect(appEventBus.emit).toHaveBeenCalledWith(
+      EAppEventBusNames.HardwareConnectionStateUpdate,
+      undefined,
+    );
+
+    // An identical features event must not re-broadcast
+    jest.mocked(appEventBus.emit).mockClear();
+    listeners.get(DEVICE.SUPPORT_FEATURES)?.({
+      device: {
+        connectId: 'PRO2_USB',
+        uuid: 'PRO2_UUID',
+        deviceId: 'PRO2_DEVICE_ID',
+        features: { device_id: 'PRO2_DEVICE_ID' },
+      },
+    });
+    expect(appEventBus.emit).not.toHaveBeenCalledWith(
+      EAppEventBusNames.HardwareConnectionStateUpdate,
+      undefined,
+    );
+  });
+
+  it('SDK 实例替换时清空连接身份并广播连接状态', async () => {
+    const listeners = new Map<string, (payload: unknown) => void>();
+    const service = new ServiceHardware({
+      backgroundApi: {} as unknown as IBackgroundApi,
+    });
+    await service.registerSdkEvents({
+      on: jest.fn((event: string, listener: (payload: unknown) => void) =>
+        listeners.set(event, listener),
+      ),
+    } as never);
+    listeners.get(DEVICE.CONNECT)?.({
+      device: { connectId: 'PRO2_USB' },
+    });
+    await expect(
+      service.getConnectedHardwareDeviceIdentityKeys(),
+    ).resolves.toEqual(['PRO2_USB']);
+    jest.mocked(appEventBus.emit).mockClear();
+
+    // A replaced SDK instance no longer tracks the previous connections
+    await service.registerSdkEvents({ on: jest.fn() } as never);
+
+    await expect(
+      service.getConnectedHardwareDeviceIdentityKeys(),
+    ).resolves.toEqual([]);
+    expect(appEventBus.emit).toHaveBeenCalledWith(
+      EAppEventBusNames.HardwareConnectionStateUpdate,
+      undefined,
+    );
+  });
+
+  it('resetHardwareSDK 时清空连接身份并广播连接状态', async () => {
+    const listeners = new Map<string, (payload: unknown) => void>();
+    const service = new ServiceHardware({
+      backgroundApi: {
+        serviceHardwareUI: {
+          runExclusiveOneKeyOperation: (fn: () => Promise<void>) => fn(),
+        },
+      } as unknown as IBackgroundApi,
+    });
+    await service.registerSdkEvents({
+      on: jest.fn((event: string, listener: (payload: unknown) => void) =>
+        listeners.set(event, listener),
+      ),
+    } as never);
+    listeners.get(DEVICE.CONNECT)?.({
+      device: { connectId: 'PRO2_USB' },
+    });
+    await expect(
+      service.getConnectedHardwareDeviceIdentityKeys(),
+    ).resolves.toEqual(['PRO2_USB']);
+    jest.mocked(appEventBus.emit).mockClear();
+
+    await service.resetHardwareSDK();
+
+    await expect(
+      service.getConnectedHardwareDeviceIdentityKeys(),
+    ).resolves.toEqual([]);
+    expect(appEventBus.emit).toHaveBeenCalledWith(
+      EAppEventBusNames.HardwareConnectionStateUpdate,
+      undefined,
+    );
   });
 
   it('普通断连后保留已确认协议，供重连继续固定使用', async () => {

--- a/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.pro2DeviceManagement.test.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.pro2DeviceManagement.test.ts
@@ -38,6 +38,7 @@ jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
 
 jest.mock('@onekeyhq/shared/src/eventBus/appEventBus', () => ({
   EAppEventBusNames: {
+    HardwareConnectionStateUpdate: 'HardwareConnectionStateUpdate',
     HardwareDeviceStateUpdate: 'HardwareDeviceStateUpdate',
     SyncDeviceLabelToWalletName: 'SyncDeviceLabelToWalletName',
     WalletUpdate: 'WalletUpdate',
@@ -780,6 +781,11 @@ describe('ServiceHardware SDK DeviceState synchronization', () => {
       device: { connectId: 'DEVICE_A_USB' },
     });
     await expect(
+      service.getConnectedHardwareDeviceIdentityKeys(),
+    ).resolves.toEqual(
+      expect.arrayContaining(['DEVICE_A_USB', 'DEVICE_B_USB']),
+    );
+    await expect(
       service.isHardwareDeviceConnected({ deviceDbId: 'db-device-a' }),
     ).resolves.toBe(true);
 
@@ -787,8 +793,15 @@ describe('ServiceHardware SDK DeviceState synchronization', () => {
       device: { connectId: 'DEVICE_A_USB' },
     });
     await expect(
+      service.getConnectedHardwareDeviceIdentityKeys(),
+    ).resolves.toEqual(['DEVICE_B_USB']);
+    await expect(
       service.isHardwareDeviceConnected({ deviceDbId: 'db-device-a' }),
     ).resolves.toBe(false);
+    expect(appEventBus.emit).toHaveBeenCalledWith(
+      EAppEventBusNames.HardwareConnectionStateUpdate,
+      undefined,
+    );
   });
 
   it('forwards all tracked identity keys when a device disconnects', async () => {

--- a/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
@@ -1603,6 +1603,10 @@ class ServiceHardware extends ServiceBase {
         this.recordLiveConnectIdEvidence(message.device?.connectId);
         const connectedIdentityKeys = this.trackConnectedDevice(message.device);
         if (connectedIdentityKeys.length > 0) {
+          appEventBus.emit(
+            EAppEventBusNames.HardwareConnectionStateUpdate,
+            undefined,
+          );
           void this.backgroundApi.serviceHardwarePortfolioSync
             ?.notifyHardwareDeviceConnected({
               identityKeys: connectedIdentityKeys,
@@ -1676,6 +1680,10 @@ class ServiceHardware extends ServiceBase {
           message.device,
         );
         if (disconnectedIdentityKeys.length > 0) {
+          appEventBus.emit(
+            EAppEventBusNames.HardwareConnectionStateUpdate,
+            undefined,
+          );
           void this.backgroundApi.serviceHardwarePortfolioSync
             ?.notifyHardwareDeviceDisconnected({
               identityKeys: disconnectedIdentityKeys,
@@ -1864,6 +1872,17 @@ class ServiceHardware extends ServiceBase {
   @backgroundMethod()
   async isDeviceSearchInProgress() {
     return this.deviceSearchInProgressCount > 0;
+  }
+
+  @backgroundMethod()
+  async getConnectedHardwareDeviceIdentityKeys() {
+    return [
+      ...new Set(
+        [...this.connectedDeviceIdentityKeysByConnection.values()].flatMap(
+          (identityKeys) => [...identityKeys],
+        ),
+      ),
+    ];
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
@@ -861,16 +861,42 @@ class ServiceHardware extends ServiceBase {
     );
   }
 
-  private trackConnectedDevice(device: KnownDevice | undefined) {
+  private trackConnectedDevice(device: KnownDevice | undefined): {
+    identityKeys: string[];
+    identityKeysChanged: boolean;
+  } {
     const identityKeys = this.getConnectedDeviceIdentityKeys(device);
     const connectionKey = device?.connectId || identityKeys[0];
-    if (connectionKey && identityKeys.length > 0) {
+    if (!connectionKey || identityKeys.length === 0) {
+      return { identityKeys, identityKeysChanged: false };
+    }
+    const existingIdentityKeys =
+      this.connectedDeviceIdentityKeysByConnection.get(connectionKey);
+    const identityKeysChanged =
+      !existingIdentityKeys ||
+      existingIdentityKeys.size !== identityKeys.length ||
+      identityKeys.some((key) => !existingIdentityKeys.has(key));
+    if (identityKeysChanged) {
       this.connectedDeviceIdentityKeysByConnection.set(
         connectionKey,
         new Set(identityKeys),
       );
     }
-    return identityKeys;
+    return { identityKeys, identityKeysChanged };
+  }
+
+  private clearTrackedConnectedDevices() {
+    if (this.connectedDeviceIdentityKeysByConnection.size === 0) {
+      return;
+    }
+    // The identity map is a bg-runtime JS copy; UI runtimes cache their own
+    // snapshot, so every clear must broadcast or the green indicator goes
+    // stale after an SDK reset or transport switch.
+    this.connectedDeviceIdentityKeysByConnection.clear();
+    appEventBus.emit(
+      EAppEventBusNames.HardwareConnectionStateUpdate,
+      undefined,
+    );
   }
 
   private untrackConnectedDevice(device: KnownDevice | undefined) {
@@ -1007,6 +1033,7 @@ class ServiceHardware extends ServiceBase {
       refreshedFirmwareManifestKey !== this.loadedFirmwareManifestKey
     ) {
       await resetHardwareSDKInstance();
+      this.clearTrackedConnectedDevices();
       this.registeredEvents = false;
     }
 
@@ -1073,6 +1100,7 @@ class ServiceHardware extends ServiceBase {
       );
       this.resetHardwareUiEventQueue();
       await resetHardwareSDKInstance();
+      this.clearTrackedConnectedDevices();
       this.registeredEvents = false;
       this.activeHardwareSDKInstance = undefined;
       console.log('✅ TRANSPORT SWITCH: SDK reset completed');
@@ -1283,7 +1311,7 @@ class ServiceHardware extends ServiceBase {
   ) {
     if (this.registeredSdkEventsInstance !== instance) {
       this.resetHardwareUiEventQueue();
-      this.connectedDeviceIdentityKeysByConnection.clear();
+      this.clearTrackedConnectedDevices();
       this.registeredEvents = false;
     }
 
@@ -1585,6 +1613,19 @@ class ServiceHardware extends ServiceBase {
             return;
           }
 
+          // DEVICE.CONNECT can fire before features are complete, so the
+          // tracked identity may miss the raw deviceId; re-track once features
+          // arrive so deviceId-based consumers see the device as connected.
+          const { identityKeysChanged } = this.trackConnectedDevice(
+            (message.device ?? undefined),
+          );
+          if (identityKeysChanged) {
+            appEventBus.emit(
+              EAppEventBusNames.HardwareConnectionStateUpdate,
+              undefined,
+            );
+          }
+
           // TODO: save features to dbDevice
           // Full features dumps are dev-only; production logs keep the event
           // name without the device blob.
@@ -1601,7 +1642,8 @@ class ServiceHardware extends ServiceBase {
 
       instance.on(DEVICE.CONNECT, (message: { device: KnownDevice }) => {
         this.recordLiveConnectIdEvidence(message.device?.connectId);
-        const connectedIdentityKeys = this.trackConnectedDevice(message.device);
+        const { identityKeys: connectedIdentityKeys } =
+          this.trackConnectedDevice(message.device);
         if (connectedIdentityKeys.length > 0) {
           appEventBus.emit(
             EAppEventBusNames.HardwareConnectionStateUpdate,
@@ -1775,6 +1817,7 @@ class ServiceHardware extends ServiceBase {
     await this.backgroundApi.serviceHardwareUI.runExclusiveOneKeyOperation(() =>
       this.sdkInstanceMutex.runExclusive(async () => {
         this.resetHardwareUiEventQueue();
+        this.clearTrackedConnectedDevices();
         this.registeredEvents = false;
         await resetHardwareSDKInstance();
         this.activeHardwareSDKInstance = undefined;

--- a/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.ts
@@ -1617,7 +1617,7 @@ class ServiceHardware extends ServiceBase {
           // tracked identity may miss the raw deviceId; re-track once features
           // arrive so deviceId-based consumers see the device as connected.
           const { identityKeysChanged } = this.trackConnectedDevice(
-            (message.device ?? undefined),
+            message.device ?? undefined,
           );
           if (identityKeysChanged) {
             appEventBus.emit(

--- a/packages/kit/src/hooks/useHardwareWalletConnectStatus.ts
+++ b/packages/kit/src/hooks/useHardwareWalletConnectStatus.ts
@@ -33,10 +33,10 @@ async function fetchConnectedDevices(): Promise<Set<string>> {
   const [webUsbDevices, backgroundIdentityKeys] = await Promise.all([
     usb && typeof usb.getDevices === 'function'
       ? usb.getDevices()
-      : Promise.resolve([]),
+      : Promise.resolve<USBDevice[]>([]),
     backgroundApiProxy.serviceHardware
       .getConnectedHardwareDeviceIdentityKeys()
-      .catch(() => []),
+      .catch((): string[] => []),
   ]);
   const deviceIds = buildHardwareConnectedDeviceKeys({
     backgroundIdentityKeys,

--- a/packages/kit/src/hooks/useHardwareWalletConnectStatus.ts
+++ b/packages/kit/src/hooks/useHardwareWalletConnectStatus.ts
@@ -1,10 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import type { IDBWallet } from '@onekeyhq/kit-bg/src/dbs/local/types';
+import {
+  EAppEventBusNames,
+  appEventBus,
+} from '@onekeyhq/shared/src/eventBus/appEventBus';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import {
-  getWebUsbConnectedDeviceKey,
+  buildHardwareConnectedDeviceKeys,
   isSupportedHardwareWebUsbDevice,
   isWalletConnectedByHardwareStatus,
 } from './useHardwareWalletConnectStatusUtils';
@@ -25,19 +30,18 @@ async function fetchConnectedDevices(): Promise<Set<string>> {
   }
 
   const usb = globalThis?.navigator?.usb;
-  if (!usb || typeof usb.getDevices !== 'function') {
-    return EMPTY_SET;
-  }
-
-  const devices = await usb.getDevices();
-  const deviceIds = new Set<string>();
-
-  for (const device of devices) {
-    const key = getWebUsbConnectedDeviceKey(device);
-    if (key) {
-      deviceIds.add(key);
-    }
-  }
+  const [webUsbDevices, backgroundIdentityKeys] = await Promise.all([
+    usb && typeof usb.getDevices === 'function'
+      ? usb.getDevices()
+      : Promise.resolve([]),
+    backgroundApiProxy.serviceHardware
+      .getConnectedHardwareDeviceIdentityKeys()
+      .catch(() => []),
+  ]);
+  const deviceIds = buildHardwareConnectedDeviceKeys({
+    backgroundIdentityKeys,
+    webUsbDevices,
+  });
 
   return deviceIds.size > 0 ? deviceIds : EMPTY_SET;
 }
@@ -69,32 +73,35 @@ export function useHardwareWalletConnectStatus() {
   );
 
   useEffect(() => {
-    void refreshDevices();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
     if (!platformEnv.isSupportWebUSB) {
       return;
     }
 
     const usb = globalThis?.navigator?.usb;
-    if (!usb) {
-      return;
-    }
-
     const handleUSBEvent = (event: USBConnectionEvent) => {
       if (isSupportedHardwareWebUsbDevice(event.device)) {
         void refreshDevices();
       }
     };
+    const handleHardwareConnectionStateUpdate = () => {
+      void refreshDevices();
+    };
 
-    usb.addEventListener('connect', handleUSBEvent);
-    usb.addEventListener('disconnect', handleUSBEvent);
+    usb?.addEventListener('connect', handleUSBEvent);
+    usb?.addEventListener('disconnect', handleUSBEvent);
+    appEventBus.on(
+      EAppEventBusNames.HardwareConnectionStateUpdate,
+      handleHardwareConnectionStateUpdate,
+    );
+    void refreshDevices();
 
     return () => {
-      usb.removeEventListener('connect', handleUSBEvent);
-      usb.removeEventListener('disconnect', handleUSBEvent);
+      usb?.removeEventListener('connect', handleUSBEvent);
+      usb?.removeEventListener('disconnect', handleUSBEvent);
+      appEventBus.off(
+        EAppEventBusNames.HardwareConnectionStateUpdate,
+        handleHardwareConnectionStateUpdate,
+      );
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/kit/src/hooks/useHardwareWalletConnectStatusUtils.test.ts
+++ b/packages/kit/src/hooks/useHardwareWalletConnectStatusUtils.test.ts
@@ -4,6 +4,7 @@ import { TREZOR_WEBUSB_FILTERS } from '@onekeyfe/hwk-trezor-connector-webusb';
 import { EHardwareVendor } from '@onekeyhq/shared/types/device';
 
 import {
+  buildHardwareConnectedDeviceKeys,
   getWalletHardwareConnectionKeys,
   getWebUsbConnectedDeviceKey,
   isSupportedHardwareWebUsbDevice,
@@ -117,6 +118,49 @@ describe('hardware wallet connect status utils', () => {
         connectedDeviceKeys: new Set(['pro2-serial-number']),
       }),
     ).toBe(true);
+  });
+
+  it('matches a reset OneKey wallet by the connected SDK identity', () => {
+    const connectedDeviceKeys = buildHardwareConnectedDeviceKeys({
+      backgroundIdentityKeys: [
+        'stable-device-serial',
+        'reset-features-device-id',
+      ],
+      webUsbDevices: [
+        usbDevice({
+          vendorId: ONEKEY_WEBUSB_FILTER[0].vendorId ?? 0,
+          productId: ONEKEY_WEBUSB_FILTER[0].productId ?? 0,
+          serialNumber: 'pre-reset-usb-serial',
+        }),
+      ],
+    });
+    const resetWallet = {
+      associatedDeviceInfo: {
+        vendor: EHardwareVendor.onekey,
+        deviceId: 'reset-features-device-id',
+        connectId: 'stable-device-serial',
+      },
+    };
+    const otherWallet = {
+      associatedDeviceInfo: {
+        vendor: EHardwareVendor.onekey,
+        deviceId: 'other-device-id',
+        connectId: 'other-device-serial',
+      },
+    };
+
+    expect(
+      isWalletConnectedByHardwareStatus({
+        wallet: resetWallet,
+        connectedDeviceKeys,
+      }),
+    ).toBe(true);
+    expect(
+      isWalletConnectedByHardwareStatus({
+        wallet: otherWallet,
+        connectedDeviceKeys,
+      }),
+    ).toBe(false);
   });
 
   it('does not mark hidden wallets connected', () => {

--- a/packages/kit/src/hooks/useHardwareWalletConnectStatusUtils.ts
+++ b/packages/kit/src/hooks/useHardwareWalletConnectStatusUtils.ts
@@ -30,6 +30,23 @@ export function getWebUsbConnectedDeviceKey(
   return device.serialNumber || undefined;
 }
 
+export function buildHardwareConnectedDeviceKeys({
+  backgroundIdentityKeys,
+  webUsbDevices,
+}: {
+  backgroundIdentityKeys: readonly string[];
+  webUsbDevices: readonly IUsbDeviceIdentity[];
+}): Set<string> {
+  const connectedDeviceKeys = new Set(backgroundIdentityKeys);
+  for (const device of webUsbDevices) {
+    const key = getWebUsbConnectedDeviceKey(device);
+    if (key) {
+      connectedDeviceKeys.add(key);
+    }
+  }
+  return connectedDeviceKeys;
+}
+
 export function getWalletHardwareConnectionKeys(
   wallet: IWalletHardwareIdentity | undefined,
 ): string[] {

--- a/packages/shared/src/eventBus/appEventBus.ts
+++ b/packages/shared/src/eventBus/appEventBus.ts
@@ -500,6 +500,7 @@ export interface IAppEventBusPayload {
     deviceId: string;
   };
   [EAppEventBusNames.HardwareDeviceStateUpdate]: DeviceStateEvent;
+  [EAppEventBusNames.HardwareConnectionStateUpdate]: undefined;
   [EAppEventBusNames.UnlockApp]: undefined;
   [EAppEventBusNames.LockApp]: undefined;
   [EAppEventBusNames.AddressBookUpdate]: undefined;

--- a/packages/shared/src/eventBus/appEventBusNames.ts
+++ b/packages/shared/src/eventBus/appEventBusNames.ts
@@ -122,6 +122,7 @@ export enum EAppEventBusNames {
   doubleConfirmTxFeeInfo = 'doubleConfirmTxFeeInfo',
   HardwareFeaturesUpdate = 'HardwareFeaturesUpdate',
   HardwareDeviceStateUpdate = 'HardwareDeviceStateUpdate',
+  HardwareConnectionStateUpdate = 'HardwareConnectionStateUpdate',
   UnlockApp = 'UnlockApp',
   LockApp = 'LockApp',
   // AccountNameChanged = 'AccountNameChanged',


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60117](https://onekeyhq.atlassian.net/browse/OK-60117)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Track hardware identities reported by the SDK connection lifecycle.
- Merge background SDK identities with WebUSB enumeration when computing wallet connection indicators.
- Refresh the wallet connection indicator when the background hardware connection state changes.

## Intent & Context

Fix OK-60117 on Desktop 6.5.2. After resetting a OneKey Pro, re-importing the wallet, and successfully communicating with the device, the wallet selector could still omit the green connected indicator until macOS re-authorized and re-enumerated the USB device.

## Root Cause

The UI connection hook only used `navigator.usb.getDevices()` and matched its serial number against the wallet's stored hardware identity. A reset changes the device identity, while WebUSB can retain a stale or unavailable identity until a new macOS USB permission flow occurs. The background hardware service already had the current SDK connection identities after successful communication, but the UI did not consume that state.

## Design Decisions

- Keep WebUSB enumeration as a fallback for existing OneKey and Trezor behavior.
- Expose the SDK-tracked identity snapshot from the background service instead of duplicating hardware communication in the UI runtime.
- Emit a payload-free cross-runtime refresh event on SDK connect and disconnect; device identities remain available only through the background method.
- Match only known hardware identity keys and preserve hidden-wallet filtering.

## Changes Detail

- Add `HardwareConnectionStateUpdate` to the typed app event bus.
- Emit connection-state refresh events and expose connected hardware identity keys from `ServiceHardware`.
- Merge SDK identity keys with supported WebUSB serials in `useHardwareWalletConnectStatus`.
- Add regression coverage for a reset device with stale WebUSB identity and for connect/disconnect identity tracking.

## Risk Assessment

- **Risk Level**: Medium
- **Affected Platforms**: Desktop and WebUSB-capable clients
- **Risk Areas**: Hardware identity matching and cross-runtime connection-state refresh timing

## Test plan

- [x] Reset a OneKey Pro, re-import the wallet, complete device communication, and verify the green indicator appears without another USB permission flow.
- [x] Verify the green indicator disappears after clearing the SDK connection state.
- [x] Run the focused hardware connection test suites (46 tests).
- [x] Run `yarn agent:check --profile commit` on the latest `hotfix/v6.5.2` base.
- [x] Verify the QA bundle on Desktop; bundle version 1282 fixed the reported issue.

## QA Evidence

- QA bundle run: https://github.com/OneKeyHQ/app-monorepo/actions/runs/31787864368
- Desktop QA bundle: https://bundle-test.onekey-asset.com/utility/js-bundle/6.5.2/966eba6c-1282/electron.zip
- The QA bundle contains the functional fix commit before rebasing onto the latest `hotfix/v6.5.2`; the rebased PR head was revalidated with the focused tests and commit checks.

[OK-60117]: https://onekeyhq.atlassian.net/browse/OK-60117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ