### PR TITLE
fix: declare tabPressAnimationEnabled in Tabs Container props

### DIFF
--- a/packages/components/src/composite/Tabs/Container.tsx
+++ b/packages/components/src/composite/Tabs/Container.tsx
@@ -179,6 +179,11 @@ export interface ITabContainerProps {
   disableWebTabContentVisibility?: boolean;
   /** Only used on native Android, ignored on web */
   useNativeHeaderAnimation?: boolean;
+  /**
+   * Disables the animated pager transition when a native tab is pressed, so the
+   * new tab shows up instantly. Only used on native, ignored on web.
+   */
+  tabPressAnimationEnabled?: boolean;
 }
 
 interface ITabContainerRefProps {
@@ -204,6 +209,7 @@ export function Container({
     | 'disableScroll'
     | 'disableWebTabContentVisibility'
     | 'useNativeHeaderAnimation'
+    | 'tabPressAnimationEnabled'
     | 'renderSubHeader'
   >) {
   const getTabContentHeight = useCallback((element: Element | null) => {


### PR DESCRIPTION
## Summary
- Declare `tabPressAnimationEnabled?: boolean` on `ITabContainerProps` in `packages/components/src/composite/Tabs/Container.tsx`.
- Add `'tabPressAnimationEnabled'` to the `Pick<ITabContainerProps, ...>` union of the web `Container` prop type.
- Type-only change: no runtime behavior is added, removed, or altered on any platform.

## Intent & Context
`MarketHomeV2/layouts/MobileLayout.native.tsx:873` passes `tabPressAnimationEnabled={false}` to `<Tabs.Container>` (added by dc2eeb1113 / #12842, OK-55394 "support instant native market tab switches"). Until now that prop was declared **only** in `patches/react-native-collapsible-tab-view+8.0.1.patch`, which injects it into the library's `CollapsibleProps`.

That makes the app's own source depend on a third-party patch for its type surface. Whenever `node_modules` is present but unpatched — a fresh clone before `postinstall`, a stale worktree, a sibling checkout — `tsc` fails with a TS2322 at that line that reads like a source defect but is not, and the real cause (a missing patch) is not visible from the error.

The sibling prop `useNativeHeaderAnimation` does not have this problem: it was added to the patch in 17c6093227 (#10020) and *separately* to `ITabContainerProps` plus the `Pick<...>` list in 712aea6957 (#10238). This PR mirrors that established precedent for `tabPressAnimationEnabled`.

## Root Cause
The repo's `tsconfig.json` sets no `moduleSuffixes`, so every `Tabs.Container` usage — including files ending in `.native.tsx` — is type-checked against `packages/components/src/composite/Tabs/index.tsx`, i.e. the **web** `Container`. That component's props are `PropsWithChildren<CollapsibleProps> & ITabContainerRefProps & Pick<ITabContainerProps, ...>`, and `tabPressAnimationEnabled` was reachable only through the patched `CollapsibleProps`. Remove the patch hunk and the prop disappears from the whole intersection, so the JSX attribute fails the excess-property check.

Reproduced deterministically by temporarily removing the `tabPressAnimationEnabled` block from `node_modules/react-native-collapsible-tab-view/lib/typescript/src/types.d.ts`:

```
packages/kit/src/views/Market/MarketHomeV2/layouts/MobileLayout.native.tsx:873:9 - error TS2322:
  Property 'tabPressAnimationEnabled' does not exist on type 'IntrinsicAttributes & CollapsibleProps
  & { children?: ReactNode; } & ITabContainerRefProps & Pick<ITabContainerProps, "disableScroll" | ...
  | "useNativeHeaderAnimation">'.
```

That was the only error in the entire project. With the patch hunk still reverted, the fix in this PR brings `yarn tsc:staged` back to exit 0 — which is the actual proof that the type surface no longer depends on patch-package.

## Design Decisions
- **Declared on `ITabContainerProps` + `Pick<...>`, not as a standalone prop type.** This mirrors `useNativeHeaderAnimation` exactly, keeps the component's public API in one interface, and keeps the intersection well-formed. `boolean | undefined` from `ITabContainerProps` intersected with the identical member from the patched `CollapsibleProps` collapses cleanly, so the patch and the local declaration coexist without conflict.
- **The patch hunk is kept.** It is still what makes the prop *work* at runtime inside the vendored `Container.tsx`. This PR only removes the app's compile-time dependency on it, so the two declarations are complementary rather than redundant.
- **No change to `index.native.tsx`.** Its `IExtendedContainerProps` still inherits the prop from the patched `CollapsibleProps`, exactly as it does today. Adding a parity line there is possible, but no code path type-checks a `Tabs.Container` usage through the native entry (see Root Cause), so it would be scope creep with no verifiable effect.
- **Title carries no `OK-` id.** `OK-55394` is the ticket for the original feature that introduced the prop, not for this hardening; linking it here would attribute follow-up work to a closed item.

## Changes Detail
`packages/components/src/composite/Tabs/Container.tsx` (only file touched, +6 lines):
- `ITabContainerProps`: new optional `tabPressAnimationEnabled?: boolean` with an English comment stating that it disables the animated pager transition on native tab press and is ignored on web.
- `Container` prop type: `'tabPressAnimationEnabled'` added to the existing `Pick<ITabContainerProps, 'disableScroll' | 'disableWebTabContentVisibility' | 'useNativeHeaderAnimation' | 'renderSubHeader'>` union.

No forwarding change was needed anywhere:
- `index.native.tsx:61` already spreads `...props` into `NativeTabs.Container`, so native forwarding was and remains correct.
- The web `Container` never destructures the prop (its signature picks a fixed set), so it is accepted and dropped — confirmed harmless, no web behavior change.

## Risk Assessment
- **Risk Level**: Low — type-only, one file, six added lines, no emitted-code change.
- **Affected Platforms**: build/CI type-checking on all platforms; runtime behavior unchanged on Extension / Mobile / Desktop / Web.
- **Risk Areas**: the only surface worth a second look is the `Pick<...>` union edit, since a typo there would silently widen or narrow the accepted prop set. It is covered by the before/after type-check evidence above.

## Test plan
- [x] Reproduce first: revert the `tabPressAnimationEnabled` hunk in `node_modules/react-native-collapsible-tab-view/lib/typescript/src/types.d.ts`, run `yarn tsc:staged` on unmodified source → exactly one error, TS2322 at `MobileLayout.native.tsx:873`.
- [x] With the hunk still reverted, apply this change → `yarn tsc:staged` exits 0 with zero errors.
- [x] Restore `types.d.ts` (verified byte-identical by sha256; `patch-package --check` reports `react-native-collapsible-tab-view@8.0.1 ✔`).
- [x] `yarn agent:check --profile commit` → 5/5 PASS (lint-worktree-ts, format-worktree, agent-context, lint-staged, tsc-staged).
- [x] `yarn jest packages/components` → 7 suites, 52 tests passed. No Tabs suites exist; the change is type-only.
- [ ] Reviewer sanity check on device: native Market tab presses still switch instantly with no pager animation (unchanged behavior from #12842).
