### PR TITLE
fix: recognize Pro2 QR wallets by official device name

### DIFF
--- a/packages/shared/src/utils/deviceUtils.test.ts
+++ b/packages/shared/src/utils/deviceUtils.test.ts
@@ -223,8 +223,9 @@ describe('deviceUtils', () => {
   test.each([
     ['OneKey Pro2', EDeviceType.Pro2],
     ['OneKey Pro2:SERIAL:universal', EDeviceType.Pro2],
+    ['OneKey Pro 2', EDeviceType.Pro2],
+    ['OneKey Pro 2:SERIAL', EDeviceType.Pro2],
     ['OneKey Pro', EDeviceType.Pro],
-    ['OneKey Pro 2', EDeviceType.Pro],
     ['QR Wallet', EDeviceType.Pro],
     [undefined, EDeviceType.Pro],
   ])('resolves QR wallet device name %s to %s', (deviceName, expected) => {

--- a/packages/shared/src/utils/hardwareDeviceTypes.ts
+++ b/packages/shared/src/utils/hardwareDeviceTypes.ts
@@ -27,7 +27,10 @@ export function resolveQrWalletDeviceType({
     return deviceType;
   }
 
-  if (deviceName?.startsWith('OneKey Pro2')) {
+  if (
+    deviceName?.startsWith('OneKey Pro2') ||
+    deviceName?.startsWith('OneKey Pro 2')
+  ) {
     return EDeviceType.Pro2;
   }
 


### PR DESCRIPTION
## What changed

- Recognize both `OneKey Pro2` and the official `OneKey Pro 2` QR device-name prefixes as Pro2.
- Add regression coverage for the official name with and without a serial suffix.

## Why

Pro2 firmware exports QR wallet metadata with the product name. When the spaced official name was classified as Pro1, QR-created wallets used the wrong device type, icon, firmware update resources, and homescreen resources.

This keeps the legacy `OneKey Pro2` spelling compatible while mapping the official Pro2 name to `EDeviceType.Pro2`.

## Impact

Pro2 `crypto-multi-accounts` QR connections follow the standard QR wallet path and retain Pro2-specific device resources. Existing Pro QR wallets remain classified as Pro.

## Validation

- `yarn jest packages/shared/src/utils/deviceUtils.test.ts --runInBand`
- 50 tests passed.