### PR TITLE
fix: sync stock token metadata for max amount(OK-58721)

### DIFF
--- a/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.test.ts
+++ b/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.test.ts
@@ -5,12 +5,14 @@ import {
   ESwapStockTradeSide,
   buildStockSwapTokenFromMarketListToken,
   filterStockPayTokenCandidates,
+  isStockBalanceActionReady,
   isStockBalanceInitializing,
   isStockPayTokenReadyForTradeInput,
   isStockTradeReadyForQuote,
   resolveStockBalanceSeed,
   resolveStockBalanceSnapshot,
   resolveStockChannelSwapPair,
+  resolveStockExecutionTokenMetadata,
   resolveStockKLineToken,
   shouldLoadDefaultStockToken,
   shouldRenderStockTradeInputSkeleton,
@@ -272,6 +274,62 @@ describe('swapStockChannelUtils', () => {
         stockTokenStatus: ESwapStockChannelAsyncStatus.Ready,
       }),
     ).toBe(false);
+  });
+
+  it('refreshes Stock execution metadata from an identity-matched token detail', () => {
+    const cachedStockToken = {
+      ...appleStockToken,
+      decimals: 0,
+    };
+    const tokenDetail = {
+      ...appleStockToken,
+      balanceParsed: '0.168058487842240859',
+    };
+
+    expect(
+      resolveStockExecutionTokenMetadata({
+        token: cachedStockToken,
+        tokenDetail,
+      }),
+    ).toEqual(appleStockToken);
+    expect(
+      resolveStockExecutionTokenMetadata({
+        token: cachedStockToken,
+        tokenDetail: {
+          ...tokenDetail,
+          contractAddress: micronStockToken.contractAddress,
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('keeps balance actions unavailable until authoritative execution state is ready', () => {
+    expect(
+      isStockBalanceActionReady({
+        authoritativeBalance: undefined,
+        authoritativeStockToken: appleStockToken,
+        isBuySide: false,
+      }),
+    ).toBe(false);
+    expect(
+      isStockBalanceActionReady({
+        authoritativeBalance: '0.24',
+        isBuySide: false,
+      }),
+    ).toBe(false);
+    expect(
+      isStockBalanceActionReady({
+        authoritativeBalance: '0.24',
+        authoritativeStockToken: appleStockToken,
+        isBuySide: false,
+      }),
+    ).toBe(true);
+    expect(
+      isStockBalanceActionReady({
+        authoritativeBalance: '0.24',
+        isBuySide: true,
+      }),
+    ).toBe(true);
   });
 
   it('keeps the buy-side pay token visible during non-initial readiness refreshes', () => {

--- a/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.ts
+++ b/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.ts
@@ -132,6 +132,39 @@ export function buildStockSwapTokenFromMarketToken(
   };
 }
 
+export function resolveStockExecutionTokenMetadata({
+  token,
+  tokenDetail,
+}: {
+  token?: ISwapToken;
+  tokenDetail?: ISwapToken;
+}): ISwapToken | undefined {
+  if (
+    !token ||
+    !tokenDetail ||
+    !equalTokenNoCaseSensitive({
+      token1: token,
+      token2: tokenDetail,
+    })
+  ) {
+    return undefined;
+  }
+  const isNative = tokenDetail.isNative ?? token.isNative;
+  if (
+    token.decimals === tokenDetail.decimals &&
+    token.isNative === isNative &&
+    token.isStock === true
+  ) {
+    return token;
+  }
+  return {
+    ...token,
+    decimals: tokenDetail.decimals,
+    isNative,
+    isStock: true,
+  };
+}
+
 export function buildStockSwapTokenFromMarketListToken(
   token: IMarketTokenListItem,
 ): ISwapToken | undefined {
@@ -268,6 +301,21 @@ export function shouldRenderStockTradeInputSkeleton({
     return false;
   }
   return isBuySide ? !inputTokenVisible : !inputTokenReady;
+}
+
+export function isStockBalanceActionReady({
+  authoritativeBalance,
+  authoritativeStockToken,
+  isBuySide,
+}: {
+  authoritativeBalance?: string;
+  authoritativeStockToken?: ISwapToken;
+  isBuySide: boolean;
+}) {
+  return Boolean(
+    authoritativeBalance !== undefined &&
+    (isBuySide || authoritativeStockToken),
+  );
 }
 
 export function isStockBalanceInitializing({

--- a/packages/kit/src/views/Swap/hooks/useSwapStockChannel.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapStockChannel.ts
@@ -49,6 +49,7 @@ import {
   getTokenIdentityKey,
   isStockTradeReadyForQuote,
   resolveStockChannelSwapPair,
+  resolveStockExecutionTokenMetadata,
   shouldResetStockTradeReceiveAmount,
 } from './swapStockChannelUtils';
 import { useSwapStockDefaultToken } from './useSwapStockDefaultToken';
@@ -416,6 +417,26 @@ export function useSwapStockChannel() {
     ],
   );
 
+  const syncStockTokenDetail = useCallback(
+    (tokenDetail: ISwapToken) => {
+      const currentToken = stockTokenSnapshotRef.current ?? currentStockToken;
+      const nextStockToken = resolveStockExecutionTokenMetadata({
+        token: currentToken,
+        tokenDetail,
+      });
+      if (!nextStockToken || nextStockToken === currentToken) {
+        return;
+      }
+      setStockTokenState(nextStockToken);
+      setStockSelectedToken(nextStockToken);
+      stockTokenSnapshotRef.current = nextStockToken;
+      void syncStockExecutionTokens({
+        stockToken: nextStockToken,
+      });
+    },
+    [currentStockToken, setStockSelectedToken, syncStockExecutionTokens],
+  );
+
   useEffect(() => {
     const handleSwapStockTokenSelected = (token: ISwapToken) => {
       if (!token?.networkId) {
@@ -705,7 +726,15 @@ export function useSwapStockChannel() {
         token2: stockExecutionToToken,
       }),
     );
-    if (executionPairSynced) {
+    const currentStockExecutionToken =
+      tradeSide === ESwapStockTradeSide.Buy ? toToken : fromToken;
+    const stockExecutionMetadataSynced = Boolean(
+      currentStockToken &&
+      currentStockExecutionToken?.decimals === currentStockToken.decimals &&
+      Boolean(currentStockExecutionToken?.isStock) ===
+        Boolean(currentStockToken.isStock),
+    );
+    if (executionPairSynced && stockExecutionMetadataSynced) {
       return;
     }
 
@@ -751,6 +780,7 @@ export function useSwapStockChannel() {
       selectPayToken,
       switchTradeSide,
       selectRecentTokenPair,
+      syncStockTokenDetail,
     }),
     [
       channelStage,
@@ -769,6 +799,7 @@ export function useSwapStockChannel() {
       selectRecentTokenPair,
       selectStockSwapToken,
       selectStockToken,
+      syncStockTokenDetail,
       switchTradeSide,
       speedConfigReady,
       activeStockTokenDetail,

--- a/packages/kit/src/views/Swap/hooks/useSwapStockTradeInputs.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapStockTradeInputs.ts
@@ -33,10 +33,12 @@ import { buildSwapRateDifference } from '../utils/swapRateDifferenceUtils';
 
 import {
   type IStockBalanceSnapshot,
+  isStockBalanceActionReady,
   isStockBalanceInitializing,
   isStockPayTokenReadyForTradeInput,
   resolveStockBalanceSeed,
   resolveStockBalanceSnapshot,
+  resolveStockExecutionTokenMetadata,
   shouldRenderStockTradeInputSkeleton,
 } from './swapStockChannelUtils';
 import {
@@ -254,11 +256,13 @@ function useStockInputTokenBalance({
 
   const balanceReady =
     detailState.scope === balanceScope && detailState.balance !== undefined;
+  const authoritativeBalance = balanceReady ? detailState.balance : undefined;
+  const authoritativeTokenDetail = balanceReady
+    ? detailState.tokenDetail
+    : undefined;
   const balanceState = resolveStockBalanceSnapshot({
-    authoritativeBalance: balanceReady ? detailState.balance : undefined,
-    authoritativeTokenDetail: balanceReady
-      ? detailState.tokenDetail
-      : undefined,
+    authoritativeBalance,
+    authoritativeTokenDetail,
     ownerScope: balanceOwnerScope,
     previousSnapshot: lastValidBalanceStateRef.current,
     seededBalance: enabled ? seededBalance : undefined,
@@ -271,6 +275,8 @@ function useStockInputTokenBalance({
   const tokenDetail = balanceState?.tokenDetail;
 
   return {
+    authoritativeBalance,
+    authoritativeTokenDetail,
     balance,
     tokenDetail,
     loading: isStockBalanceInitializing({
@@ -476,6 +482,7 @@ export function useSwapStockAmountInputState({
     disableNativePayToken,
     selectPayToken,
     stockTokenStatus,
+    syncStockTokenDetail,
     tradeSide,
   } = stockChannel;
   const isBuySide = tradeSide === ESwapStockTradeSide.Buy;
@@ -496,6 +503,18 @@ export function useSwapStockAmountInputState({
   const stockInputTokenBalance = useStockInputTokenBalance({
     enabled: inputTokenReady,
     token: inputToken,
+  });
+  const authoritativeStockInputToken = isBuySide
+    ? undefined
+    : resolveStockExecutionTokenMetadata({
+        token: inputToken,
+        tokenDetail: stockInputTokenBalance.authoritativeTokenDetail,
+      });
+  const amountInputToken = authoritativeStockInputToken ?? inputToken;
+  const balanceActionsReady = isStockBalanceActionReady({
+    authoritativeBalance: stockInputTokenBalance.authoritativeBalance,
+    authoritativeStockToken: authoritativeStockInputToken,
+    isBuySide,
   });
   const resolvedInputTokenBalance =
     stockInputTokenBalance.balance ?? inputToken?.balanceParsed ?? '0';
@@ -543,7 +562,7 @@ export function useSwapStockAmountInputState({
     settingsPersistAtom.currencyInfo.symbol;
   const onAmountChange = useCallback(
     (value: string) => {
-      if (validateAmountInput(value, inputToken?.decimals)) {
+      if (validateAmountInput(value, amountInputToken?.decimals)) {
         setSwapAlerts({
           quoteId: '',
           states: [],
@@ -554,17 +573,17 @@ export function useSwapStockAmountInputState({
         });
       }
     },
-    [inputToken?.decimals, setFromTokenAmount, setSwapAlerts],
+    [amountInputToken?.decimals, setFromTokenAmount, setSwapAlerts],
   );
   const setInputAmount = useCallback(
     (amount: BigNumber) => {
-      if (!inputToken || !amount.isFinite() || amount.isNaN()) {
+      if (!amountInputToken || !amount.isFinite() || amount.isNaN()) {
         return;
       }
       const amountValue = amount
-        .decimalPlaces(Number(inputToken.decimals ?? 6), BigNumber.ROUND_DOWN)
+        .decimalPlaces(amountInputToken.decimals, BigNumber.ROUND_DOWN)
         .toFixed();
-      if (!validateAmountInput(amountValue, inputToken.decimals)) {
+      if (!validateAmountInput(amountValue, amountInputToken.decimals)) {
         return;
       }
       setSwapAlerts({
@@ -576,17 +595,47 @@ export function useSwapStockAmountInputState({
         isInput: true,
       });
     },
-    [inputToken, setFromTokenAmount, setSwapAlerts],
+    [amountInputToken, setFromTokenAmount, setSwapAlerts],
   );
+  useEffect(() => {
+    if (!authoritativeStockInputToken) {
+      return;
+    }
+    syncStockTokenDetail(authoritativeStockInputToken);
+  }, [authoritativeStockInputToken, syncStockTokenDetail]);
   const onBalanceMaxPress = useCallback(() => {
-    setInputAmount(new BigNumber(displayBalance ?? '0'));
-  }, [displayBalance, setInputAmount]);
+    if (!balanceActionsReady) {
+      return;
+    }
+    if (authoritativeStockInputToken) {
+      syncStockTokenDetail(authoritativeStockInputToken);
+    }
+    setInputAmount(new BigNumber(resolvedInputTokenBalance));
+  }, [
+    authoritativeStockInputToken,
+    balanceActionsReady,
+    resolvedInputTokenBalance,
+    setInputAmount,
+    syncStockTokenDetail,
+  ]);
   const onSelectPercentageStage = useCallback(
     (stage: number) => {
-      const balanceBN = new BigNumber(displayBalance ?? '0');
+      if (!balanceActionsReady) {
+        return;
+      }
+      if (authoritativeStockInputToken) {
+        syncStockTokenDetail(authoritativeStockInputToken);
+      }
+      const balanceBN = new BigNumber(resolvedInputTokenBalance);
       setInputAmount(balanceBN.multipliedBy(stage / 100));
     },
-    [displayBalance, setInputAmount],
+    [
+      authoritativeStockInputToken,
+      balanceActionsReady,
+      resolvedInputTokenBalance,
+      setInputAmount,
+      syncStockTokenDetail,
+    ],
   );
   const hasBalanceError = useMemo(() => {
     if (!isBuySide || !inputToken) {
@@ -623,12 +672,13 @@ export function useSwapStockAmountInputState({
 
   return {
     amountFiatValue,
+    balanceActionsReady,
     balanceLoading: stockInputTokenBalance.loading,
     currencySymbol,
     disableNativePayToken,
     displayBalance,
     hasBalanceError,
-    inputToken,
+    inputToken: amountInputToken,
     inputTokenNetworkLogoURI,
     inputValue: fromTokenAmount.value,
     isBuySide,

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -743,12 +743,14 @@ function StockEstimatedReceive({
 
 function StockActionGate({
   alerts,
+  balanceActionsReady,
   stockChannel,
   onPreSwap,
   onToAnotherAddressModal,
   onSelectPercentageStage,
 }: {
   alerts: ISwapStockDesktopContainerProps['alerts'];
+  balanceActionsReady: boolean;
   stockChannel: IUseSwapStockChannelReturn;
   onPreSwap: () => void;
   onToAnotherAddressModal: () => void;
@@ -787,12 +789,12 @@ function StockActionGate({
   }, [navigation]);
   const keyboardPercentageStage = useMemo(
     () =>
-      !platformEnv.isNativeIOS ? (
+      !platformEnv.isNativeIOS && balanceActionsReady ? (
         <PercentageStageOnKeyboard
           onSelectPercentageStage={onSelectPercentageStage}
         />
       ) : null,
-    [onSelectPercentageStage],
+    [balanceActionsReady, onSelectPercentageStage],
   );
   const renderActionButton = useCallback(
     (button: ReactNode) => {
@@ -863,7 +865,9 @@ function StockActionGate({
       <SwapActionsState
         onPreSwap={onPreSwap}
         onOpenRecipientAddress={onToAnotherAddressModal}
-        onSelectPercentageStage={onSelectPercentageStage}
+        onSelectPercentageStage={
+          balanceActionsReady ? onSelectPercentageStage : undefined
+        }
       />
     );
   }
@@ -1005,6 +1009,7 @@ function StockAmountInput({
   const [, setInAppNotification] = useInAppNotificationAtom();
   const {
     amountFiatValue,
+    balanceActionsReady,
     balanceLoading,
     currencySymbol,
     disableNativePayToken,
@@ -1097,7 +1102,9 @@ function StockAmountInput({
         <SwapInputActions
           fromToken={inputToken}
           accountInfo={swapFromAddressInfo.accountInfo}
-          showPercentageInput={showPercentageInputDebounce}
+          showPercentageInput={
+            showPercentageInputDebounce && balanceActionsReady
+          }
           showActionBuy={showActionBuy}
           onSelectStage={onSelectPercentageStage}
         />
@@ -1117,17 +1124,18 @@ function StockAmountInput({
         balanceProps={{
           value: inputToken ? displayBalance : undefined,
           loading: balanceLoading,
-          onPress: onBalanceMaxPress,
+          onPress: balanceActionsReady ? onBalanceMaxPress : undefined,
           hideIcon: true,
           tokenSymbol: inputToken?.symbol,
-          testID: SwapTestIDs.maxButton,
+          testID: balanceActionsReady ? SwapTestIDs.maxButton : undefined,
         }}
         maxAmountText={intl.formatMessage({ id: ETranslations.global_max })}
         inputProps={{
           placeholder: '0.0',
-          inputAccessoryViewID: platformEnv.isNativeIOS
-            ? SwapAmountInputAccessoryViewID
-            : undefined,
+          inputAccessoryViewID:
+            platformEnv.isNativeIOS && balanceActionsReady
+              ? SwapAmountInputAccessoryViewID
+              : undefined,
           onFocus: handleAmountInputFocus,
           onBlur: handleAmountInputBlur,
           testID: SwapTestIDs.fromAmountInput,
@@ -1167,9 +1175,9 @@ function StockAmountInput({
                 }
               : undefined,
         }}
-        enableMaxAmount
+        enableMaxAmount={balanceActionsReady}
       />
-      {platformEnv.isNativeIOS ? (
+      {platformEnv.isNativeIOS && balanceActionsReady ? (
         <InputAccessoryView nativeID={SwapAmountInputAccessoryViewID}>
           <PercentageStageOnKeyboard
             onSelectPercentageStage={onSelectPercentageStage}
@@ -1225,6 +1233,7 @@ function StockTradeTicket({
       />
       <StockActionGate
         alerts={alerts}
+        balanceActionsReady={amountInputState.balanceActionsReady}
         stockChannel={stockChannel}
         onPreSwap={onPreSwap}
         onToAnotherAddressModal={onToAnotherAddressModal}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-58721](https://onekeyhq.atlassian.net/browse/OK-58721)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Synchronize the selected stock token's execution metadata with authoritative token details before percentage-based amount actions.
- Use the authoritative balance and decimals for Sell Max, and keep balance actions unavailable until the stock balance metadata is ready.
- Preserve Max behavior after a cold start and after reselecting the stock token.

## Intent & Context

Fixes OK-58721

The first visit to the Stocks Sell page after an app restart could leave Max unable to populate the amount. The same failure could recur after opening the network/token selector and reselecting the stock token.

QA verification issue: [OK-58833](https://onekeyhq.atlassian.net/browse/OK-58833) (closed).

## Root Cause

The selected/execution stock token could retain list or cached metadata while the balance token detail carried the authoritative decimals and stock identity. Max then calculated and validated the amount against stale execution metadata, so the input update could be rejected. Token reselection could recreate the same metadata mismatch.

## Design Decisions

- Treat the identity-matched balance token detail as the authoritative source for stock decimals and `isStock` metadata.
- Synchronize only execution metadata; do not change token identity, quote routing, or regular Swap behavior.
- Hide or disable Max and percentage actions until authoritative balance metadata is ready, avoiding writes from stale loading state.

## Changes Detail

- Added pure helpers and coverage for stock execution metadata resolution and balance-action readiness.
- Synchronized authoritative stock token details into selected and execution token state.
- Updated stock trade inputs to calculate and validate amounts using authoritative balance and decimals.
- Gated Max and percentage controls while balance metadata is initializing.

## Risk Assessment

- **Risk Level**: Medium
- **Affected Platforms**: Mobile, Desktop, Web, and Extension through the shared Swap UI main runtime
- **Runtime Scope**: Main/UI runtime only; no background or native resource ownership changes
- **Risk Areas**: Async token-detail timing, Sell balance formatting, Max/percentage actions, and stock token reselection
- **Regression Boundary**: Regular Swap quote, history, and non-stock token paths are unchanged

## Test plan

- [x] `yarn agent:check --profile commit`
- [x] Stock-focused Jest coverage: 6 suites and 77 tests passed
- [x] iOS Simulator (iPhone 17): cold start -> Trade -> Stocks -> Sell; Max was visible, enabled, and updated the amount field
- [x] iOS Simulator: open selector, search and reselect AAPL, then press Max successfully
- [x] No app error/fatal/exception log lines were observed around the verified Max interactions
- [ ] QA account with a nonzero AAPL balance: verify the exact nonzero amount after cold start and after token reselection

## Delivery Notes

- Target branch: `release/v6.5.0`
- The source fix already exists on `x`; no follow-up sync to `x` is required.
- No bundle was built as part of this PR creation task.


[OK-58833]: https://onekeyhq.atlassian.net/browse/OK-58833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OK-58721]: https://onekeyhq.atlassian.net/browse/OK-58721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ