### PR TITLE
fix: stabilize Swap stock labels and approval flow (OK-59567, OK-57997)

### DIFF
--- a/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.test.ts
+++ b/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.test.ts
@@ -7,6 +7,7 @@ import {
   backfillSwapProTokenStockIdentity,
   buildStockPayTokenDisplaySeed,
   buildStockSwapTokenFromMarketListToken,
+  buildStockSwapTokenFromMarketToken,
   filterStockPayTokenCandidates,
   hasValidStockBalanceForTrade,
   isStockBalanceActionReady,
@@ -511,6 +512,33 @@ describe('swapStockChannelUtils', () => {
     ).toBeUndefined();
   });
 
+  it('backfills incomplete Stock metadata from an identity-matched token detail', () => {
+    const stock = {
+      subtitle: '苹果',
+      sourceLogoUri: '',
+      underlyingAssetTicker: 'AAPL',
+    };
+
+    expect(
+      resolveStockExecutionTokenMetadata({
+        token: {
+          ...appleStockToken,
+          stock: {
+            ...stock,
+            subtitle: '',
+          },
+        },
+        tokenDetail: {
+          ...appleStockToken,
+          stock,
+        },
+      }),
+    ).toEqual({
+      ...appleStockToken,
+      stock,
+    });
+  });
+
   it('resyncs Stock execution tokens when only authoritative metadata changes', () => {
     const cachedStockToken = {
       ...appleStockToken,
@@ -903,6 +931,11 @@ describe('swapStockChannelUtils', () => {
   });
 
   it('marks only stock market tokens as stock swap tokens', () => {
+    const stock = {
+      subtitle: 'Stock',
+      sourceLogoUri: '',
+      underlyingAssetTicker: 'AAPL',
+    };
     const stockToken = buildStockSwapTokenFromMarketListToken({
       address: '0xaapl',
       networkId: 'evm--56',
@@ -910,18 +943,37 @@ describe('swapStockChannelUtils', () => {
       name: 'Apple',
       decimals: 18,
       price: '100',
-      stock: {
-        subtitle: 'Stock',
-        sourceLogoUri: '',
-        underlyingAssetTicker: 'AAPL',
-      },
+      stock,
     });
 
     expect(stockToken?.isStock).toBe(true);
     expect(stockToken).toMatchObject({
       price: '100',
       currency: 'usd',
+      stock,
     });
+
+    expect(
+      buildStockSwapTokenFromMarketToken({
+        id: 'aapl',
+        address: '0xaapl',
+        networkId: 'evm--56',
+        symbol: 'AAPL',
+        name: 'Apple',
+        decimals: 18,
+        price: 100,
+        change24h: 0,
+        marketCap: 0,
+        liquidity: 0,
+        transactions: 0,
+        uniqueTraders: 0,
+        holders: 0,
+        turnover: 0,
+        tokenImageUri: '',
+        networkLogoUri: '',
+        stock,
+      }),
+    ).toMatchObject({ isStock: true, stock });
 
     expect(
       buildStockSwapTokenFromMarketListToken({

--- a/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.test.ts
+++ b/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.test.ts
@@ -539,6 +539,62 @@ describe('swapStockChannelUtils', () => {
     });
   });
 
+  it('preserves cached Stock labels when token detail metadata is partial', () => {
+    const cachedStock = {
+      subtitle: '苹果',
+      sourceLogoUri: 'https://example.com/source.png',
+      underlyingAssetName: 'Apple Inc.',
+      underlyingAssetTicker: 'AAPL',
+      isOpen: true,
+    };
+
+    expect(
+      resolveStockExecutionTokenMetadata({
+        token: {
+          ...appleStockToken,
+          stock: cachedStock,
+        },
+        tokenDetail: {
+          ...appleStockToken,
+          stock: {
+            subtitle: ' ',
+            sourceLogoUri: '',
+            isOpen: false,
+          },
+        },
+      }),
+    ).toEqual({
+      ...appleStockToken,
+      stock: {
+        ...cachedStock,
+        isOpen: false,
+      },
+    });
+  });
+
+  it('keeps the current token reference when partial Stock detail adds no data', () => {
+    const cachedToken = {
+      ...appleStockToken,
+      stock: {
+        subtitle: '苹果',
+        sourceLogoUri: 'https://example.com/source.png',
+      },
+    };
+
+    expect(
+      resolveStockExecutionTokenMetadata({
+        token: cachedToken,
+        tokenDetail: {
+          ...appleStockToken,
+          stock: {
+            subtitle: '',
+            sourceLogoUri: '',
+          },
+        },
+      }),
+    ).toBe(cachedToken);
+  });
+
   it('resyncs Stock execution tokens when only authoritative metadata changes', () => {
     const cachedStockToken = {
       ...appleStockToken,

--- a/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.ts
+++ b/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.ts
@@ -261,6 +261,7 @@ export function buildStockSwapTokenFromMarketToken(
     isNative: !!token.isNative,
     ...buildUsdPriceFields(token.price),
     isStock: Boolean(token.stock),
+    stock: token.stock,
   };
 }
 
@@ -282,10 +283,12 @@ export function resolveStockExecutionTokenMetadata({
     return undefined;
   }
   const isNative = tokenDetail.isNative ?? token.isNative;
+  const stock = tokenDetail.stock ?? token.stock;
   if (
     token.decimals === tokenDetail.decimals &&
     token.isNative === isNative &&
-    token.isStock === true
+    token.isStock === true &&
+    token.stock === stock
   ) {
     return token;
   }
@@ -294,6 +297,7 @@ export function resolveStockExecutionTokenMetadata({
     decimals: tokenDetail.decimals,
     isNative,
     isStock: true,
+    stock,
   };
 }
 
@@ -314,6 +318,7 @@ export function buildStockSwapTokenFromMarketListToken(
     isNative: !!token.isNative,
     ...buildUsdPriceFields(token.price),
     isStock: Boolean(token.stock),
+    stock: token.stock,
   };
 }
 

--- a/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.ts
+++ b/packages/kit/src/views/Swap/hooks/swapStockChannelUtils.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js';
+import { isEqual } from 'lodash';
 
 import type { IToken } from '@onekeyhq/kit/src/views/Market/MarketDetailV2/components/SwapPanel/types';
 import type { IMarketToken } from '@onekeyhq/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/MarketTokenData';
@@ -265,6 +266,32 @@ export function buildStockSwapTokenFromMarketToken(
   };
 }
 
+function mergeStockExecutionMetadata({
+  currentStock,
+  tokenDetailStock,
+}: {
+  currentStock: ISwapToken['stock'];
+  tokenDetailStock: ISwapToken['stock'];
+}): ISwapToken['stock'] {
+  if (!currentStock || !tokenDetailStock) {
+    return tokenDetailStock ?? currentStock;
+  }
+
+  const mergedStock = { ...currentStock };
+  Object.entries(tokenDetailStock).forEach(([key, value]) => {
+    if (
+      value === undefined ||
+      value === null ||
+      (typeof value === 'string' && !value.trim())
+    ) {
+      return;
+    }
+    Object.assign(mergedStock, { [key]: value });
+  });
+
+  return isEqual(mergedStock, currentStock) ? currentStock : mergedStock;
+}
+
 export function resolveStockExecutionTokenMetadata({
   token,
   tokenDetail,
@@ -283,7 +310,10 @@ export function resolveStockExecutionTokenMetadata({
     return undefined;
   }
   const isNative = tokenDetail.isNative ?? token.isNative;
-  const stock = tokenDetail.stock ?? token.stock;
+  const stock = mergeStockExecutionMetadata({
+    currentStock: token.stock,
+    tokenDetailStock: tokenDetail.stock,
+  });
   if (
     token.decimals === tokenDetail.decimals &&
     token.isNative === isNative &&

--- a/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapBuiltTx.ts
@@ -152,6 +152,7 @@ import { isSwapGasSponsored } from '../utils/swapGasUtils';
 import {
   buildCustomSlippageQuoteResultCtx,
   buildRebuiltSwapReviewQuoteResult,
+  resolveSwapReviewNeedFetchGasAfterRebuild,
 } from '../utils/swapReviewState';
 import {
   getStockTradeAnalyticsPayload,
@@ -3636,6 +3637,11 @@ export function useSwapBuildTx({
         const shouldFallback = Boolean(
           estimateNetworkFeeResult.fallbackToSeparateTxConfirm,
         );
+        const needFetchGasAfterRebuild =
+          resolveSwapReviewNeedFetchGasAfterRebuild({
+            fallbackToSeparateTxConfirm: shouldFallback,
+            previousNeedFetchGas: frozenReviewState.preSwapData.needFetchGas,
+          });
         const shouldResetSteps =
           shouldFallback || frozenReviewState.preSwapData.shouldFallback;
         const separateSteps = shouldResetSteps
@@ -3661,13 +3667,13 @@ export function useSwapBuildTx({
             ...(shouldFallback
               ? {
                   shouldFallback: true,
-                  needFetchGas: true,
+                  needFetchGas: needFetchGasAfterRebuild,
                   supportNetworkFeeLevel: false,
                   netWorkFee: undefined,
                 }
               : {
                   shouldFallback: false,
-                  needFetchGas: false,
+                  needFetchGas: needFetchGasAfterRebuild,
                   supportNetworkFeeLevel: true,
                   netWorkFee: estimateNetworkFeeResult.netWorkFee,
                 }),

--- a/packages/kit/src/views/Swap/hooks/useSwapStockChannel.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapStockChannel.ts
@@ -333,6 +333,23 @@ export function useSwapStockChannel() {
   );
 
   useEffect(() => {
+    if (
+      !currentStockToken ||
+      currentStockToken.stock?.subtitle?.trim() ||
+      !stockTokenDetail?.stock?.subtitle?.trim()
+    ) {
+      return;
+    }
+    syncStockTokenDetail({
+      ...currentStockToken,
+      decimals: stockTokenDetail.decimals,
+      isNative: stockTokenDetail.isNative ?? currentStockToken.isNative,
+      isStock: true,
+      stock: stockTokenDetail.stock,
+    });
+  }, [currentStockToken, stockTokenDetail, syncStockTokenDetail]);
+
+  useEffect(() => {
     const handleSwapStockTokenSelected = (token: ISwapToken) => {
       if (!token?.networkId) {
         return;

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -1502,8 +1502,6 @@ function StockMarketTokenHeader({
     tokenDetail?.name ?? currentStockToken?.name ?? tokenSymbol ?? '';
   const tokenSubtitle = getStockMarketTokenSubtitle({
     currentStockSubtitle: currentStockToken?.stock?.subtitle,
-    currentTokenName: currentStockToken?.name,
-    hasTokenDetail: Boolean(tokenDetail),
     tokenDetailStockSubtitle: stock?.subtitle,
   });
   const tokenImageUri = currentStockToken?.logoURI ?? tokenDetail?.logoUrl;

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
@@ -198,8 +198,6 @@ describe('SwapStockDesktopContainer utils', () => {
     expect(
       getStockMarketTokenSubtitle({
         currentStockSubtitle: '英特尔',
-        currentTokenName: 'Intel (Ondo Tokenized)',
-        hasTokenDetail: false,
       }),
     ).toBe('英特尔');
   });
@@ -208,26 +206,13 @@ describe('SwapStockDesktopContainer utils', () => {
     expect(
       getStockMarketTokenSubtitle({
         currentStockSubtitle: '英特尔',
-        currentTokenName: 'Intel (Ondo Tokenized)',
-        hasTokenDetail: true,
         tokenDetailStockSubtitle: '英特尔公司',
       }),
     ).toBe('英特尔公司');
   });
 
-  it('falls back to the raw token name only before Stock metadata loads', () => {
-    expect(
-      getStockMarketTokenSubtitle({
-        currentTokenName: 'Intel (Ondo Tokenized)',
-        hasTokenDetail: false,
-      }),
-    ).toBe('Intel (Ondo Tokenized)');
-    expect(
-      getStockMarketTokenSubtitle({
-        currentTokenName: 'Intel (Ondo Tokenized)',
-        hasTokenDetail: true,
-      }),
-    ).toBeUndefined();
+  it('does not expose the raw token name while Stock metadata loads', () => {
+    expect(getStockMarketTokenSubtitle({})).toBeUndefined();
   });
 
   it('shows Stock action loading until the current quote event settles', () => {

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
@@ -211,6 +211,15 @@ describe('SwapStockDesktopContainer utils', () => {
     ).toBe('英特尔公司');
   });
 
+  it('keeps the selected subtitle when detail returns a blank label', () => {
+    expect(
+      getStockMarketTokenSubtitle({
+        currentStockSubtitle: '英特尔',
+        tokenDetailStockSubtitle: ' ',
+      }),
+    ).toBe('英特尔');
+  });
+
   it('does not expose the raw token name while Stock metadata loads', () => {
     expect(getStockMarketTokenSubtitle({})).toBeUndefined();
   });

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
@@ -122,7 +122,10 @@ export function getStockMarketTokenSubtitle({
   currentStockSubtitle?: string;
   tokenDetailStockSubtitle?: string;
 }) {
-  return tokenDetailStockSubtitle ?? currentStockSubtitle;
+  if (tokenDetailStockSubtitle?.trim()) {
+    return tokenDetailStockSubtitle;
+  }
+  return currentStockSubtitle?.trim() ? currentStockSubtitle : undefined;
 }
 
 export function shouldShowStockQuoteActionLoading({

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
@@ -117,20 +117,12 @@ export function shouldShowStockMarketHeaderSkeleton({
 
 export function getStockMarketTokenSubtitle({
   currentStockSubtitle,
-  currentTokenName,
-  hasTokenDetail,
   tokenDetailStockSubtitle,
 }: {
   currentStockSubtitle?: string;
-  currentTokenName?: string;
-  hasTokenDetail: boolean;
   tokenDetailStockSubtitle?: string;
 }) {
-  return (
-    tokenDetailStockSubtitle ??
-    currentStockSubtitle ??
-    (hasTokenDetail ? undefined : currentTokenName)
-  );
+  return tokenDetailStockSubtitle ?? currentStockSubtitle;
 }
 
 export function shouldShowStockQuoteActionLoading({

--- a/packages/kit/src/views/Swap/utils/buildSwapReviewState.test.ts
+++ b/packages/kit/src/views/Swap/utils/buildSwapReviewState.test.ts
@@ -345,7 +345,7 @@ describe('buildSwapReviewState', () => {
     expect(result.preSwapData.needFetchGas).toBe(false);
   });
 
-  it('builds a continuous approve and swap flow for external accounts', () => {
+  it('waits for external account approval before sending the swap', () => {
     const result = buildSwapReviewState({
       accountId: 'external--60--0xabc',
       networkId: fromToken.networkId,
@@ -371,9 +371,54 @@ describe('buildSwapReviewState', () => {
       ESwapBatchTransferType.CONTINUOUS_APPROVE_AND_SWAP,
     );
     expect(result.steps.map((step) => step.type)).toEqual([
-      ESwapStepType.BATCH_APPROVE_SWAP,
+      ESwapStepType.APPROVE_TX,
+      ESwapStepType.SEND_TX,
     ]);
-    expect(result.steps[0].stepTitle).toContain('[ 0 / 2 ]');
+    expect(result.steps[0].shouldWaitApproved).toBe(true);
+    expect(result.preSwapData.needFetchGas).toBe(true);
+    expect(result.preSwapData.isHWAndExBatchTransfer).toBe(true);
+  });
+
+  it('waits for each external reset approval before sending the swap', () => {
+    const result = buildSwapReviewState({
+      accountId: 'external--60--0xabc',
+      networkId: fromToken.networkId,
+      batchApproveAndSwapEnabled: true,
+      fromToken,
+      toToken,
+      fromTokenAmount: '1',
+      toTokenAmount: '2500',
+      quoteResult: createQuoteResult({
+        allowanceResult: {
+          allowanceTarget: '0xspender',
+          amount: '1',
+          shouldResetApprove: true,
+        },
+      }),
+      swapType: ESwapTabSwitchType.SWAP,
+      shouldFallback: false,
+      supportPreBuild: true,
+      slippage: 1,
+      texts,
+    });
+
+    expect(result.batchTransferType).toBe(
+      ESwapBatchTransferType.CONTINUOUS_APPROVE_AND_SWAP,
+    );
+    expect(result.steps.map((step) => step.type)).toEqual([
+      ESwapStepType.APPROVE_TX,
+      ESwapStepType.APPROVE_TX,
+      ESwapStepType.SEND_TX,
+    ]);
+    expect(result.steps[0]).toMatchObject({
+      isResetApprove: true,
+      shouldWaitApproved: true,
+    });
+    expect(result.steps[1]).toMatchObject({
+      isResetApprove: false,
+      shouldWaitApproved: true,
+    });
+    expect(result.preSwapData.needFetchGas).toBe(true);
     expect(result.preSwapData.isHWAndExBatchTransfer).toBe(true);
   });
 

--- a/packages/kit/src/views/Swap/utils/buildSwapReviewState.ts
+++ b/packages/kit/src/views/Swap/utils/buildSwapReviewState.ts
@@ -279,12 +279,9 @@ export function buildSwapReviewState({
     accountId,
     needApprove,
   });
-  const needFetchGas =
-    needApprove &&
-    !(
-      batchTransferType === ESwapBatchTransferType.BATCH_APPROVE_AND_SWAP ||
-      batchTransferType === ESwapBatchTransferType.CONTINUOUS_APPROVE_AND_SWAP
-    );
+  const isBatchApproveAndSwap =
+    batchTransferType === ESwapBatchTransferType.BATCH_APPROVE_AND_SWAP;
+  const needFetchGas = needApprove && !isBatchApproveAndSwap;
   const reviewRateDifference =
     rateDifference ??
     buildSwapRateDifference({
@@ -324,12 +321,7 @@ export function buildSwapReviewState({
     }
 
     steps = [...steps, createSignStep(texts)];
-  } else if (
-    (batchTransferType === ESwapBatchTransferType.BATCH_APPROVE_AND_SWAP ||
-      batchTransferType ===
-        ESwapBatchTransferType.CONTINUOUS_APPROVE_AND_SWAP) &&
-    quoteResult?.allowanceResult
-  ) {
+  } else if (isBatchApproveAndSwap && quoteResult?.allowanceResult) {
     steps = [
       createBatchApproveSwapStep({
         texts,

--- a/packages/kit/src/views/Swap/utils/swapReviewState.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapReviewState.test.ts
@@ -9,6 +9,7 @@ import {
   buildCustomSlippageQuoteResultCtx,
   buildRebuiltSwapReviewQuoteResult,
   hasInFlightSwapReviewSteps,
+  resolveSwapReviewNeedFetchGasAfterRebuild,
   shouldCloseSwapReviewOnFocusLoss,
   shouldShowSwapReviewToAmountSkeleton,
 } from './swapReviewState';
@@ -70,6 +71,35 @@ describe('buildRebuiltSwapReviewQuoteResult', () => {
         quoteResultCtx,
       }),
     );
+  });
+});
+
+describe('resolveSwapReviewNeedFetchGasAfterRebuild', () => {
+  it('preserves approval-dependent gas refresh after a successful rebuild', () => {
+    expect(
+      resolveSwapReviewNeedFetchGasAfterRebuild({
+        fallbackToSeparateTxConfirm: false,
+        previousNeedFetchGas: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps atomic batch transactions on their cached gas path', () => {
+    expect(
+      resolveSwapReviewNeedFetchGasAfterRebuild({
+        fallbackToSeparateTxConfirm: false,
+        previousNeedFetchGas: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('forces a gas refresh when the rebuilt review falls back', () => {
+    expect(
+      resolveSwapReviewNeedFetchGasAfterRebuild({
+        fallbackToSeparateTxConfirm: true,
+        previousNeedFetchGas: false,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/packages/kit/src/views/Swap/utils/swapReviewState.ts
+++ b/packages/kit/src/views/Swap/utils/swapReviewState.ts
@@ -70,6 +70,16 @@ export function buildRebuiltSwapReviewQuoteResult({
   };
 }
 
+export function resolveSwapReviewNeedFetchGasAfterRebuild({
+  fallbackToSeparateTxConfirm,
+  previousNeedFetchGas,
+}: {
+  fallbackToSeparateTxConfirm: boolean;
+  previousNeedFetchGas?: boolean;
+}) {
+  return fallbackToSeparateTxConfirm || Boolean(previousNeedFetchGas);
+}
+
 export function hasInFlightSwapReviewSteps({ steps }: { steps: ISwapStep[] }) {
   return steps.some(
     (step) =>

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -32,6 +32,7 @@ import type {
   IGasLegacy,
   IGasPayer,
 } from '../fee';
+import type { IMarketStockInfo } from '../marketV2';
 import type { EMessageTypesEth } from '../message';
 import type { IToken } from '../token';
 import type { IDecodedTxActionTokenApprove } from '../tx';
@@ -262,6 +263,7 @@ export interface ISwapToken extends ISwapTokenBase {
   isPopular?: boolean;
   isWrapped?: boolean;
   subtitles?: string;
+  stock?: IMarketStockInfo;
 
   freeFeeObject?: IFreeFeeObject;
 }


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59567](https://onekeyhq.atlassian.net/browse/OK-59567) [OK-57997](https://onekeyhq.atlassian.net/browse/OK-57997)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Preserve structured stock metadata across Market-to-Swap token conversions.
- Backfill legacy selected stock tokens from authoritative Market detail metadata.
- Prevent the stock header from falling back to the raw English token name while localized metadata loads.
- Wait for external and hardware wallet approvals to be confirmed before starting the dependent swap transaction.
- Re-estimate gas after approval while preserving atomic batch behavior for supported internal accounts.

## Root cause
- `OK-59567`: legacy selected stock tokens could temporarily lose authoritative structured subtitle metadata during Market-to-Swap transitions, allowing the raw token name to render.
- `OK-57997`: external and hardware wallets were routed through the continuous batch step, which advanced after the approval transaction was broadcast instead of waiting for its receipt. Swap estimation could therefore run before the allowance became active.

## Issues
- Fixes OK-59567
- Jira: https://onekeyhq.atlassian.net/browse/OK-59567
- Fixes OK-57997
- Jira: https://onekeyhq.atlassian.net/browse/OK-57997

## Test plan
- `yarn jest packages/kit/src/views/Swap/hooks/swapStockChannelUtils.test.ts packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts --runInBand` (83 tests passed)
- `yarn jest packages/kit/src/views/Swap/utils/buildSwapReviewState.test.ts packages/kit/src/views/Swap/utils/swapReviewState.test.ts packages/kit/src/views/Swap/pages/components/SwapReviewDialog.test.tsx --runInBand` (31 tests passed)
- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- Desktop: switch SKHYon to AAPLon and cold reload AAPLon; localized subtitle remains stable without showing the raw English token name.
- iOS Simulator: switch SKHYon to AAPLon and inspect the recorded transition frame by frame; localized subtitle remains stable.
- Local Web: connect an external wallet and select an unapproved USDC-to-ETH route; Review shows `Confirm twice on wallet` and completes network-fee estimation.

## Risk
- Legacy stock tokens without a structured subtitle keep the fixed subtitle slot blank until authoritative detail metadata backfills it; the raw token name is intentionally not used as a subtitle.
- External and hardware wallet swaps now wait for the approval receipt and refresh gas before the dependent transaction, which can increase the time between confirmation prompts.
- The post-fix on-chain approval sequence was not executed locally to avoid changing allowance and spending gas. QA should verify that the second confirmation is not requested before the approval receipt succeeds.

[OK-59567]: https://onekeyhq.atlassian.net/browse/OK-59567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-57997]: https://onekeyhq.atlassian.net/browse/OK-57997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ