### PR TITLE
fix: align perp dex source labels(OK-59905)

### DIFF
--- a/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/PopularTrading.tsx
@@ -73,6 +73,7 @@ import {
   getMarketTokenDisplayPriceChange24h,
   getMarketTokenDisplayVolume24h,
   getTokenKey,
+  mapMarketPerpsTokenToDisplay,
 } from './utils';
 
 import type { IFavoriteTokenDisplay } from './types';
@@ -560,21 +561,10 @@ function PopularTrading({ tableLayout }: { tableLayout?: boolean }) {
               // Perps item
               const perpsToken = perpsTokenMap.get(targetItem.perpsCoin);
               if (!perpsToken) return null;
-              return {
-                chainId: '',
-                contractAddress: '',
-                isNative: false,
-                symbol: perpsToken.displayName,
-                name: perpsToken.displayName,
-                logoUrl: perpsToken.tokenImageUrl ?? '',
-                price: parseFloat(perpsToken.markPrice ?? '0'),
-                priceChange24h: perpsToken.change24hPercent ?? 0,
-                marketCap: 0,
-                perpsCoin: targetItem.perpsCoin,
-                maxLeverage: perpsToken.maxLeverage,
-                perpsSubtitle: getTokenSubtitle(perpsToken.name, perpsAliases),
-                volume24h: parseFloat(perpsToken.volume24h ?? '0'),
-              };
+              return mapMarketPerpsTokenToDisplay({
+                token: perpsToken,
+                subtitle: getTokenSubtitle(perpsToken.name, perpsAliases),
+              });
             }
 
             // Spot item

--- a/packages/kit/src/views/Home/components/PopularTrading/metricColumns.tsx
+++ b/packages/kit/src/views/Home/components/PopularTrading/metricColumns.tsx
@@ -47,6 +47,7 @@ function renderPopularTradingTokenIdentity(
       stock={record.stock}
       maxLeverage={record.maxLeverage}
       perpsSubtitle={record.perpsSubtitle}
+      perpsDexLabel={record.perpsDexLabel}
     />
   );
 }

--- a/packages/kit/src/views/Home/components/PopularTrading/types.ts
+++ b/packages/kit/src/views/Home/components/PopularTrading/types.ts
@@ -15,6 +15,7 @@ interface IFavoriteTokenDisplay {
   perpsCoin?: string;
   maxLeverage?: number;
   perpsSubtitle?: string;
+  perpsDexLabel?: string;
   communityRecognized?: boolean;
   stock?: IMarketStockInfo;
 }

--- a/packages/kit/src/views/Home/components/PopularTrading/utils.test.ts
+++ b/packages/kit/src/views/Home/components/PopularTrading/utils.test.ts
@@ -1,11 +1,30 @@
-import type { IMarketTokenListItem } from '@onekeyhq/shared/types/marketV2';
+import type {
+  IMarketPerpsTokenFromServer,
+  IMarketTokenListItem,
+} from '@onekeyhq/shared/types/marketV2';
 
 import {
   getMarketTokenDisplayPrice,
   getMarketTokenDisplayPriceChange24h,
   getMarketTokenDisplayVolume24h,
+  mapMarketPerpsTokenToDisplay,
   mapMarketTokenToDisplay,
 } from './utils';
+
+function buildServerPerpsToken(name: string): IMarketPerpsTokenFromServer {
+  return {
+    name,
+    displayName: 'UNITREE',
+    maxLeverage: 10,
+    tokenImageUrl: 'unitree.png',
+    markPrice: '90.38',
+    prevDayPrice: '72.58',
+    change24hPercent: 24.52,
+    volume24h: '10940000',
+    openInterest: '6660000',
+    fundingRate: '0.000008',
+  };
+}
 
 describe('PopularTrading market token display utils', () => {
   test('normalizes placeholder market values instead of returning NaN', () => {
@@ -33,5 +52,30 @@ describe('PopularTrading market token display utils', () => {
     expect(Number.isNaN(displayToken?.priceChange24h)).toBe(false);
     expect(displayToken?.logoUrls).toEqual(item.logoUrls);
     expect(displayToken?.communityRecognized).toBe(true);
+  });
+
+  test.each([
+    ['xyz:UNITREE', 'xyz'],
+    ['para:UNITREE', 'para'],
+  ])('preserves the %s perps DEX source label', (name, dexLabel) => {
+    expect(
+      mapMarketPerpsTokenToDisplay({
+        token: buildServerPerpsToken(name),
+        subtitle: 'Unitree Robotics',
+      }),
+    ).toMatchObject({
+      symbol: 'UNITREE',
+      perpsCoin: name,
+      perpsSubtitle: 'Unitree Robotics',
+      perpsDexLabel: dexLabel,
+    });
+  });
+
+  test('does not add a DEX source label to main DEX perps', () => {
+    expect(
+      mapMarketPerpsTokenToDisplay({
+        token: buildServerPerpsToken('BTC'),
+      }).perpsDexLabel,
+    ).toBeUndefined();
   });
 });

--- a/packages/kit/src/views/Home/components/PopularTrading/utils.ts
+++ b/packages/kit/src/views/Home/components/PopularTrading/utils.ts
@@ -1,3 +1,4 @@
+import { parseDexCoin } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type {
   IMarketPerpsTokenFromServer,
   IMarketTokenListItem,
@@ -96,6 +97,8 @@ function mapMarketPerpsTokenToDisplay({
   token: IMarketPerpsTokenFromServer;
   subtitle?: string;
 }): IFavoriteTokenDisplay {
+  const { dexLabel } = parseDexCoin(token.name);
+
   return {
     chainId: '',
     contractAddress: '',
@@ -109,6 +112,7 @@ function mapMarketPerpsTokenToDisplay({
     volume24h: parseMarketValue(token.volume24h) ?? 0,
     perpsCoin: token.name,
     perpsSubtitle: subtitle,
+    perpsDexLabel: dexLabel,
     maxLeverage: token.maxLeverage,
   };
 }

--- a/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
+++ b/packages/kit/src/views/Market/MarketHomeV2/components/MarketTokenList/components/TokenIdentityItem/TokenIdentityItem.tsx
@@ -17,6 +17,7 @@ import { useNetworkLogoUri } from '@onekeyhq/kit/src/hooks/useNetworkLogoUri';
 import { CommunityRecognizedBadge } from '@onekeyhq/kit/src/views/Market/components/CommunityRecognizedBadge';
 import {
   LeverageBadge,
+  PerpDexBadge,
   StockSourceLogo,
   SubtitleText,
 } from '@onekeyhq/kit/src/views/Market/components/PerpsBadges';
@@ -95,6 +96,10 @@ interface ITokenIdentityItemProps {
    */
   perpsSubtitle?: string;
   /**
+   * HIP-3 DEX source label for perpetual tokens (e.g. "xyz", "para").
+   */
+  perpsDexLabel?: string;
+  /**
    * Whether to show the stock subtitle. Defaults to true.
    */
   showStockSubtitle?: boolean;
@@ -116,6 +121,7 @@ const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
   stock,
   maxLeverage,
   perpsSubtitle,
+  perpsDexLabel,
   showStockSubtitle = true,
 }) => {
   const { gtMd } = useMedia();
@@ -209,6 +215,7 @@ const BasicTokenIdentityItem: FC<ITokenIdentityItemProps> = ({
         <XStack alignItems="center" gap="$1">
           {symbolElement}
           {maxLeverage ? <LeverageBadge leverage={maxLeverage} /> : null}
+          <PerpDexBadge dexLabel={perpsDexLabel} />
           {gtMd ? (
             <>
               <StockSourceLogo stock={stock} />

--- a/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
+++ b/packages/kit/src/views/Perp/components/TickerBar/PerpTickerBarMobile.tsx
@@ -204,7 +204,7 @@ function PerpBadgesRow() {
   return (
     <XStack alignItems="center" gap="$1.5" onLayout={handleLayout}>
       <Badge radius="$1" bg="$bgSubdued" px="$1" py={0}>
-        <SizableText color="$textSubdued" fontSize={10}>
+        <SizableText color="$textSubdued" fontSize={10} lineHeight={16}>
           {isSpot
             ? intl.formatMessage({
                 id: ETranslations.dexmarket_spot,
@@ -237,6 +237,7 @@ function PerpBadgesRow() {
               <SizableText
                 color="$textInfo"
                 fontSize={10}
+                lineHeight={16}
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 flexShrink={1}
@@ -256,7 +257,7 @@ function PerpBadgesRow() {
       ) : null}
       {!isSpot && builderFeeRate === 0 ? (
         <Badge radius="$1" bg="$bgSuccess" px="$0.5" py={0}>
-          <SizableText color="$textSuccess" fontSize={10}>
+          <SizableText color="$textSuccess" fontSize={10} lineHeight={16}>
             {intl.formatMessage({
               id: ETranslations.perp_0_fee,
             })}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59905](https://onekeyhq.atlassian.net/browse/OK-59905)

----------

<!-- github-pr-monitor:jira-links:end -->


## Issue

- [OK-59905](https://onekeyhq.atlassian.net/browse/OK-59905)

## Summary

- Preserve and display HIP-3 DEX source labels (`xyz` / `para`) in Wallet Home market favorites and perpetual categories.
- Reuse the existing perps display mapping so favorite and category rows render consistent source badges.
- Align the Native perps ticker badge line heights with the shared DEX badge.

## Intent & Context

[OK-59905](https://onekeyhq.atlassian.net/browse/OK-59905) reports that Wallet Home market favorites and perpetual lists do not show the `xyz` / `para` source labels. During Native verification, the DEX badge in the perps ticker was also visibly shorter than its adjacent badges.

## Root Cause

The Wallet Home perps mapper kept the display symbol but dropped the DEX prefix from the server token name. The Native ticker used implicit React Native text line heights for its local badges while the shared `PerpDexBadge` uses a fixed 16px line height.

## Design Decisions

- Parse the source through the existing `parseDexCoin` utility and render it with the existing `PerpDexBadge` component.
- Reuse the same perps display mapper for favorites and category data to keep both paths consistent.
- Normalize only the local Native ticker badge line heights instead of changing the shared badge sizing across Market and Home surfaces.

## Changes Detail

- Add `perpsDexLabel` to the Wallet Home market display model and forward it to the shared token identity row.
- Preserve `xyz` and `para` labels when mapping server perps tokens, with coverage for main-DEX tokens that should remain unlabeled.
- Set the Native perps ticker labels to a consistent 16px line height.

## Risk Assessment

- **Risk Level**: Low
- **Affected Platforms**: Mobile, Desktop, Web, Extension
- **Risk Areas**: Wallet Home perps row rendering and Native perps ticker badge layout.

## Test plan

- [x] Run focused Jest coverage for Wallet Home and Market perps token mapping (2 suites, 7 tests).
- [x] Run `yarn agent:check --profile commit`.
- [x] Run `yarn agent:check --profile pr`.
- [ ] Verify Wallet Home favorites and perpetual categories show `xyz` / `para` badges on Native.
- [ ] Verify the Native perps ticker badges have matching heights.


[OK-59905]: https://onekeyhq.atlassian.net/browse/OK-59905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-59905]: https://onekeyhq.atlassian.net/browse/OK-59905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ