### PR TITLE
fix: seed canonical device state before hidden wallet passphrase session (OK-59992)

### DIFF
--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.hiddenWalletStateSeeding.test.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.hiddenWalletStateSeeding.test.ts
@@ -76,13 +76,14 @@ function buildService({
     callOrder.push('waitForDeviceStateSync');
     return Promise.resolve();
   });
+  const getDeviceByConnectIdMock = jest.fn().mockResolvedValue(latestDbDevice);
   const service = new ServiceAccount({
     backgroundApi: {
       serviceHardware: {
         getCompatibleConnectId: jest.fn().mockResolvedValue('CONNECT_ID_1'),
         getDeviceState: getDeviceStateMock,
         getPassphraseState: getPassphraseStateMock,
-        getDeviceByConnectId: jest.fn().mockResolvedValue(latestDbDevice),
+        getDeviceByConnectId: getDeviceByConnectIdMock,
         waitForDeviceStateSync: waitForDeviceStateSyncMock,
       },
       serviceThirdPartyHardware: {},
@@ -116,7 +117,12 @@ function buildService({
     .fn()
     .mockResolvedValue({ wallet: { id: 'hw-wallet-hidden-1' } });
   service.setWalletTempStatus = jest.fn().mockResolvedValue(undefined);
-  return { service, getDeviceStateMock, getPassphraseStateMock };
+  return {
+    service,
+    getDeviceStateMock,
+    getPassphraseStateMock,
+    getDeviceByConnectIdMock,
+  };
 }
 
 describe('createHWHiddenWallet canonical device state seeding', () => {
@@ -268,6 +274,31 @@ describe('createHWHiddenWallet canonical device state seeding', () => {
     });
     expect(service.createHWWalletBase).toHaveBeenCalledWith(
       expect.objectContaining({ deviceState: postUnlockState }),
+    );
+  });
+
+  it('never queries by an empty connectId for the post-unlock refresh', async () => {
+    const callOrder: string[] = [];
+    // Third-party USB records may legitimately have no connectId; an empty
+    // connectId lookup would degenerate to "first OneKey device" in the DB.
+    const dbDevice = buildDbDevice({ connectProtocol: 'V1', connectId: '' });
+    const { service, getDeviceByConnectIdMock } = buildService({
+      dbDevice,
+      callOrder,
+      latestDbDevice: {
+        deviceStateInfo: {
+          ...SEEDED_STATE,
+          identity: { deviceId: 'UNRELATED_DEVICE', serialNo: 'UNRELATED' },
+        } as unknown as IOneKeyDeviceState,
+      },
+    });
+
+    await service.createHWHiddenWallet({ walletId: 'hw-wallet-1' });
+
+    expect(getDeviceByConnectIdMock).not.toHaveBeenCalled();
+    // The seeded state stays in place instead of an unrelated device's record.
+    expect(service.createHWWalletBase).toHaveBeenCalledWith(
+      expect.objectContaining({ deviceState: SEEDED_STATE }),
     );
   });
 

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.hiddenWalletStateSeeding.test.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.hiddenWalletStateSeeding.test.ts
@@ -72,6 +72,10 @@ function buildService({
     callOrder.push('getPassphraseState');
     return Promise.resolve('passphrase-state-1');
   });
+  const waitForDeviceStateSyncMock = jest.fn().mockImplementation(() => {
+    callOrder.push('waitForDeviceStateSync');
+    return Promise.resolve();
+  });
   const service = new ServiceAccount({
     backgroundApi: {
       serviceHardware: {
@@ -79,6 +83,7 @@ function buildService({
         getDeviceState: getDeviceStateMock,
         getPassphraseState: getPassphraseStateMock,
         getDeviceByConnectId: jest.fn().mockResolvedValue(latestDbDevice),
+        waitForDeviceStateSync: waitForDeviceStateSyncMock,
       },
       serviceThirdPartyHardware: {},
       serviceHardwareUI: {
@@ -131,11 +136,14 @@ describe('createHWHiddenWallet canonical device state seeding', () => {
       params: { scope: 'runtime', connectProtocol: 'V1' },
     });
     // The live read must happen before the hidden-wallet session is opened,
-    // otherwise it restores the standard Protocol V1 session.
+    // otherwise it restores the standard Protocol V1 session. Persistence
+    // drains happen after the passphrase call and before the final status read.
     expect(callOrder).toEqual([
       'getDeviceState',
       'getPassphraseState',
+      'waitForDeviceStateSync',
       'getFeaturesForHwWalletCreate',
+      'waitForDeviceStateSync',
     ]);
     expect(service.getFeaturesForHwWalletCreate).toHaveBeenCalledWith({
       dbDevice: expect.objectContaining({ deviceStateInfo: SEEDED_STATE }),
@@ -235,6 +243,32 @@ describe('createHWHiddenWallet canonical device state seeding', () => {
     // Fail fast: the guard fires before the passphrase prompt or any creation.
     expect(getPassphraseStateMock).not.toHaveBeenCalled();
     expect(service.createHWWalletBase).not.toHaveBeenCalled();
+  });
+
+  it('prefers the persisted post-unlock snapshot over the pre-unlock seed', async () => {
+    const callOrder: string[] = [];
+    const dbDevice = buildDbDevice({ connectProtocol: 'V1' });
+    const postUnlockState = {
+      ...SEEDED_STATE,
+      status: { mode: 'normal', unlocked: true, unlockedAttachPin: false },
+    } as unknown as IOneKeyDeviceState;
+    const { service } = buildService({
+      dbDevice,
+      callOrder,
+      latestDbDevice: { deviceStateInfo: postUnlockState },
+    });
+
+    await service.createHWHiddenWallet({ walletId: 'hw-wallet-1' });
+
+    // Downstream steps must consume the persisted post-unlock snapshot, not
+    // the pre-unlock seed captured before the passphrase prompt.
+    expect(service.getFeaturesForHwWalletCreate).toHaveBeenCalledWith({
+      dbDevice: expect.objectContaining({ deviceStateInfo: postUnlockState }),
+      compatibleConnectId: 'CONNECT_ID_1',
+    });
+    expect(service.createHWWalletBase).toHaveBeenCalledWith(
+      expect.objectContaining({ deviceState: postUnlockState }),
+    );
   });
 
   it('reports isAttachPinMode from the freshest persisted post-unlock state', async () => {

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.hiddenWalletStateSeeding.test.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.hiddenWalletStateSeeding.test.ts
@@ -1,0 +1,262 @@
+import { EHardwareVendor } from '@onekeyhq/shared/types/device';
+import type { IOneKeyDeviceState } from '@onekeyhq/shared/types/device';
+
+import ServiceAccount from './ServiceAccount';
+
+import type { IDBDevice } from '../../dbs/local/types';
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundClass: () => (target: unknown) => target,
+  backgroundMethod:
+    () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+  backgroundMethodForDev:
+    () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+  toastIfError:
+    () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+}));
+
+jest.mock('@onekeyhq/shared/src/eventBus/appEventBus', () => ({
+  EAppEventBusNames: {
+    AccountUpdate: 'AccountUpdate',
+    WalletUpdate: 'WalletUpdate',
+  },
+  appEventBus: {
+    on: jest.fn(),
+    off: jest.fn(),
+    emit: jest.fn(),
+  },
+}));
+
+jest.mock('../../dbs/local/localDb', () => ({
+  __esModule: true,
+  default: {
+    createHwWallet: jest.fn(),
+  },
+}));
+
+const SEEDED_STATE = {
+  protocol: 'V1',
+  identity: { deviceId: 'DEVICE_ID_1', serialNo: 'SERIAL_1' },
+  status: { mode: 'normal' },
+} as unknown as IOneKeyDeviceState;
+
+function buildDbDevice(overrides: Partial<IDBDevice> = {}): IDBDevice {
+  return {
+    id: 'device-db-id',
+    connectId: 'CONNECT_ID_1',
+    deviceId: 'DEVICE_ID_1',
+    vendor: EHardwareVendor.onekey,
+    ...overrides,
+  } as unknown as IDBDevice;
+}
+
+function buildService({
+  dbDevice,
+  callOrder,
+  seededState = SEEDED_STATE,
+  latestDbDevice,
+}: {
+  dbDevice: IDBDevice;
+  callOrder: string[];
+  seededState?: IOneKeyDeviceState;
+  latestDbDevice?: Partial<IDBDevice>;
+}) {
+  const getDeviceStateMock = jest.fn().mockImplementation(() => {
+    callOrder.push('getDeviceState');
+    return Promise.resolve(seededState);
+  });
+  const getPassphraseStateMock = jest.fn().mockImplementation(() => {
+    callOrder.push('getPassphraseState');
+    return Promise.resolve('passphrase-state-1');
+  });
+  const service = new ServiceAccount({
+    backgroundApi: {
+      serviceHardware: {
+        getCompatibleConnectId: jest.fn().mockResolvedValue('CONNECT_ID_1'),
+        getDeviceState: getDeviceStateMock,
+        getPassphraseState: getPassphraseStateMock,
+        getDeviceByConnectId: jest.fn().mockResolvedValue(latestDbDevice),
+      },
+      serviceThirdPartyHardware: {},
+      serviceHardwareUI: {
+        withHardwareProcessing: (fn: () => Promise<unknown>) => fn(),
+      },
+      serviceSetting: {
+        getHiddenWalletImmediately: jest.fn().mockResolvedValue(true),
+      },
+      serviceAccountProfile: {
+        isSoftwareWalletOnlyUser: jest.fn().mockResolvedValue(false),
+      },
+    },
+  } as never) as unknown as {
+    createHWHiddenWallet(params: { walletId: string }): Promise<unknown>;
+    getWallet: jest.Mock;
+    getWalletDevice: jest.Mock;
+    getFeaturesForHwWalletCreate: jest.Mock;
+    createHWWalletBase: jest.Mock;
+    setWalletTempStatus: jest.Mock;
+  };
+  service.getWallet = jest
+    .fn()
+    .mockResolvedValue({ id: 'hw-wallet-1', deprecated: false });
+  service.getWalletDevice = jest.fn().mockResolvedValue(dbDevice);
+  service.getFeaturesForHwWalletCreate = jest.fn().mockImplementation(() => {
+    callOrder.push('getFeaturesForHwWalletCreate');
+    return Promise.resolve({ deviceId: 'DEVICE_ID_1' });
+  });
+  service.createHWWalletBase = jest
+    .fn()
+    .mockResolvedValue({ wallet: { id: 'hw-wallet-hidden-1' } });
+  service.setWalletTempStatus = jest.fn().mockResolvedValue(undefined);
+  return { service, getDeviceStateMock, getPassphraseStateMock };
+}
+
+describe('createHWHiddenWallet canonical device state seeding', () => {
+  it('seeds device state before the passphrase session when no snapshot is persisted', async () => {
+    const callOrder: string[] = [];
+    const dbDevice = buildDbDevice({ connectProtocol: 'V1' });
+    const { service, getDeviceStateMock } = buildService({
+      dbDevice,
+      callOrder,
+    });
+
+    await service.createHWHiddenWallet({ walletId: 'hw-wallet-1' });
+
+    expect(getDeviceStateMock).toHaveBeenCalledTimes(1);
+    expect(getDeviceStateMock).toHaveBeenCalledWith({
+      connectId: 'CONNECT_ID_1',
+      params: { scope: 'runtime', connectProtocol: 'V1' },
+    });
+    // The live read must happen before the hidden-wallet session is opened,
+    // otherwise it restores the standard Protocol V1 session.
+    expect(callOrder).toEqual([
+      'getDeviceState',
+      'getPassphraseState',
+      'getFeaturesForHwWalletCreate',
+    ]);
+    expect(service.getFeaturesForHwWalletCreate).toHaveBeenCalledWith({
+      dbDevice: expect.objectContaining({ deviceStateInfo: SEEDED_STATE }),
+      compatibleConnectId: 'CONNECT_ID_1',
+    });
+    expect(service.createHWWalletBase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectProtocol: 'V1',
+        deviceState: SEEDED_STATE,
+        passphraseState: 'passphrase-state-1',
+      }),
+    );
+  });
+
+  it('skips the live read when a snapshot is already persisted', async () => {
+    const callOrder: string[] = [];
+    const persistedState = {
+      ...SEEDED_STATE,
+      identity: { deviceId: 'DEVICE_ID_1', serialNo: 'SERIAL_PERSISTED' },
+    } as unknown as IOneKeyDeviceState;
+    const dbDevice = buildDbDevice({
+      connectProtocol: 'V1',
+      deviceStateInfo: persistedState,
+    });
+    const { service, getDeviceStateMock } = buildService({
+      dbDevice,
+      callOrder,
+    });
+
+    await service.createHWHiddenWallet({ walletId: 'hw-wallet-1' });
+
+    expect(getDeviceStateMock).not.toHaveBeenCalled();
+    expect(service.createHWWalletBase).toHaveBeenCalledWith(
+      expect.objectContaining({ deviceState: persistedState }),
+    );
+  });
+
+  it('skips seeding for known Protocol V2 devices', async () => {
+    const callOrder: string[] = [];
+    const dbDevice = buildDbDevice({ connectProtocol: 'V2' });
+    const { service, getDeviceStateMock } = buildService({
+      dbDevice,
+      callOrder,
+    });
+
+    await service.createHWHiddenWallet({ walletId: 'hw-wallet-1' });
+
+    expect(getDeviceStateMock).not.toHaveBeenCalled();
+    expect(service.createHWWalletBase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectProtocol: 'V2',
+        deviceState: undefined,
+      }),
+    );
+  });
+
+  it('backfills the connect protocol from the seeded state when unknown', async () => {
+    const callOrder: string[] = [];
+    const dbDevice = buildDbDevice();
+    const { service, getDeviceStateMock } = buildService({
+      dbDevice,
+      callOrder,
+    });
+
+    await service.createHWHiddenWallet({ walletId: 'hw-wallet-1' });
+
+    expect(getDeviceStateMock).toHaveBeenCalledWith({
+      connectId: 'CONNECT_ID_1',
+      params: { scope: 'runtime' },
+    });
+    expect(service.createHWWalletBase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectProtocol: 'V1',
+        deviceState: SEEDED_STATE,
+      }),
+    );
+  });
+
+  it('rejects a seeded normal-mode state without a live device identity', async () => {
+    const callOrder: string[] = [];
+    const dbDevice = buildDbDevice({ connectProtocol: 'V1' });
+    const anonymousState = {
+      protocol: 'V1',
+      identity: { deviceId: null, serialNo: 'SERIAL_1' },
+      status: { mode: 'normal' },
+    } as unknown as IOneKeyDeviceState;
+    const { service, getPassphraseStateMock } = buildService({
+      dbDevice,
+      callOrder,
+      seededState: anonymousState,
+    });
+
+    await expect(
+      service.createHWHiddenWallet({ walletId: 'hw-wallet-1' }),
+    ).rejects.toThrow('Unable to resolve live hardware device identity');
+
+    // Fail fast: the guard fires before the passphrase prompt or any creation.
+    expect(getPassphraseStateMock).not.toHaveBeenCalled();
+    expect(service.createHWWalletBase).not.toHaveBeenCalled();
+  });
+
+  it('reports isAttachPinMode from the freshest persisted post-unlock state', async () => {
+    const callOrder: string[] = [];
+    const dbDevice = buildDbDevice({ connectProtocol: 'V1' });
+    const { service } = buildService({
+      dbDevice,
+      callOrder,
+      // The seeded pre-unlock snapshot says no attach-PIN unlock, but the
+      // state persisted during the passphrase/derivation calls says yes.
+      latestDbDevice: {
+        deviceStateInfo: {
+          ...SEEDED_STATE,
+          status: { mode: 'normal', unlockedAttachPin: true },
+        } as unknown as IOneKeyDeviceState,
+      },
+    });
+
+    const result = (await service.createHWHiddenWallet({
+      walletId: 'hw-wallet-1',
+    })) as { isAttachPinMode?: boolean };
+
+    expect(result.isAttachPinMode).toBe(true);
+  });
+});

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -3606,10 +3606,61 @@ class ServiceAccount extends ServiceBase {
     // createHWHiddenWallet
     return this.backgroundApi.serviceHardwareUI.withHardwareProcessing(
       async () => {
+        // Seed the canonical device state BEFORE opening the hidden-wallet
+        // passphrase session: a live state read on Protocol V1 restores the
+        // standard session, so reading it after getPassphraseState would
+        // clobber the hidden session and cost extra device round trips to
+        // re-establish it (see getFeaturesForHwWalletCreate). Known-V2 devices
+        // are excluded — their flow always reads live state by design. An
+        // unknown-protocol device that turns out V2 pays one redundant read,
+        // but that class is practically empty: V2 device records have always
+        // stored connectProtocol since the protocol field was introduced.
+        let seededDbDevice = dbDevice;
+        let seededConnectProtocol = connectProtocol;
+        const hiddenWalletVendorProfile = getVendorProfile(
+          dbDevice.vendor ?? EHardwareVendor.onekey,
+        );
+        if (
+          !seededDbDevice.deviceStateInfo &&
+          !hiddenWalletVendorProfile.isThirdParty &&
+          seededConnectProtocol !== 'V2'
+        ) {
+          const seededState =
+            await this.backgroundApi.serviceHardware.getDeviceState({
+              connectId: compatibleConnectId,
+              params: {
+                scope: 'runtime',
+                ...(seededConnectProtocol
+                  ? { connectProtocol: seededConnectProtocol }
+                  : {}),
+              },
+            });
+          // Mirror the live-identity guard in resolveDeviceStateForHwWalletCreate:
+          // with a seeded snapshot its fast path returns early, so the guard
+          // must run here to keep the old no-snapshot fail-fast behavior.
+          if (
+            seededState.status.mode === 'normal' &&
+            !seededState.identity.deviceId
+          ) {
+            throw new OneKeyLocalError(
+              'Unable to resolve live hardware device identity',
+            );
+          }
+          // DEVICE.STATE persistence is async; carry the snapshot in memory so
+          // downstream steps take their fast paths deterministically.
+          seededDbDevice = { ...seededDbDevice, deviceStateInfo: seededState };
+          if (
+            !seededConnectProtocol &&
+            (seededState.protocol === 'V1' || seededState.protocol === 'V2')
+          ) {
+            seededConnectProtocol = seededState.protocol;
+          }
+        }
+
         const passphraseState = await getHwHiddenWalletPassphraseState({
           vendor: dbDevice.vendor,
           connectId: compatibleConnectId,
-          dbDevice,
+          dbDevice: seededDbDevice,
           serviceHardware: this.backgroundApi.serviceHardware,
           serviceThirdPartyHardware:
             this.backgroundApi.serviceThirdPartyHardware,
@@ -3630,14 +3681,14 @@ class ServiceAccount extends ServiceBase {
 
         // TODO save remember states
         const resolvedFeatures = await this.getFeaturesForHwWalletCreate({
-          dbDevice,
+          dbDevice: seededDbDevice,
           compatibleConnectId,
         });
         const dbWallet = await this.createHWWalletBase({
-          device: deviceUtils.dbDeviceToSearchDevice(dbDevice),
+          device: deviceUtils.dbDeviceToSearchDevice(seededDbDevice),
           features: resolvedFeatures,
-          connectProtocol,
-          deviceState: dbDevice.deviceStateInfo,
+          connectProtocol: seededConnectProtocol,
+          deviceState: seededDbDevice.deviceStateInfo,
           passphraseState,
           fillingXfpByCallingSdk: true,
         });
@@ -3666,9 +3717,28 @@ class ServiceAccount extends ServiceBase {
             await this.backgroundApi.serviceAccountProfile.isSoftwareWalletOnlyUser(),
         });
 
+        // The seeded snapshot predates the passphrase prompt, so its
+        // unlockedAttachPin can be stale when the device was unlocked with the
+        // attach PIN during this flow. Prefer the state persisted from the
+        // DEVICE.STATE events emitted by the passphrase/derivation calls above.
+        let isAttachPinMode = resolvedFeatures.unlockedAttachPin;
+        try {
+          const latestDbDevice =
+            await this.backgroundApi.serviceHardware.getDeviceByConnectId({
+              connectId,
+            });
+          const latestUnlockedAttachPin =
+            latestDbDevice?.deviceStateInfo?.status?.unlockedAttachPin;
+          if (typeof latestUnlockedAttachPin === 'boolean') {
+            isAttachPinMode = latestUnlockedAttachPin;
+          }
+        } catch {
+          // keep the resolved-features fallback
+        }
+
         return {
           ...dbWallet,
-          isAttachPinMode: resolvedFeatures.unlockedAttachPin,
+          isAttachPinMode,
         };
       },
       {

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -3683,24 +3683,30 @@ class ServiceAccount extends ServiceBase {
         // unlock / attach-PIN status); wait for their persistence and prefer
         // the persisted post-unlock snapshot over the pre-unlock seed for
         // everything derived or stored below. Pure DB reads — no device I/O,
-        // so the hidden session established above is never touched.
-        await this.backgroundApi.serviceHardware.waitForDeviceStateSync({
-          connectIds: [
-            compatibleConnectId,
-            dbDevice.connectId,
-            dbDevice.deviceId,
-            seededDbDevice.deviceStateInfo?.identity.serialNo,
-          ],
-        });
-        const postUnlockDbDevice =
-          await this.backgroundApi.serviceHardware.getDeviceByConnectId({
-            connectId,
+        // so the hidden session established above is never touched. Gated like
+        // the seeding block: third-party vendors are excluded, and an empty
+        // connectId must not reach getDeviceByConnectId — getDeviceByQuery
+        // would degenerate to "first OneKey device" and overlay an unrelated
+        // device's state.
+        if (connectId && !hiddenWalletVendorProfile.isThirdParty) {
+          await this.backgroundApi.serviceHardware.waitForDeviceStateSync({
+            connectIds: [
+              compatibleConnectId,
+              dbDevice.connectId,
+              dbDevice.deviceId,
+              seededDbDevice.deviceStateInfo?.identity.serialNo,
+            ],
           });
-        if (postUnlockDbDevice?.deviceStateInfo) {
-          seededDbDevice = {
-            ...seededDbDevice,
-            deviceStateInfo: postUnlockDbDevice.deviceStateInfo,
-          };
+          const postUnlockDbDevice =
+            await this.backgroundApi.serviceHardware.getDeviceByConnectId({
+              connectId,
+            });
+          if (postUnlockDbDevice?.deviceStateInfo) {
+            seededDbDevice = {
+              ...seededDbDevice,
+              deviceStateInfo: postUnlockDbDevice.deviceStateInfo,
+            };
+          }
         }
 
         // TODO save remember states
@@ -3746,26 +3752,30 @@ class ServiceAccount extends ServiceBase {
         // createHWWalletBase may have emitted newer DEVICE.STATE events; drain
         // the persistence queue once more and prefer the latest stored status.
         let isAttachPinMode = resolvedFeatures.unlockedAttachPin;
-        try {
-          await this.backgroundApi.serviceHardware.waitForDeviceStateSync({
-            connectIds: [
-              compatibleConnectId,
-              dbDevice.connectId,
-              dbDevice.deviceId,
-              seededDbDevice.deviceStateInfo?.identity.serialNo,
-            ],
-          });
-          const latestDbDevice =
-            await this.backgroundApi.serviceHardware.getDeviceByConnectId({
-              connectId,
+        // Same gate as the post-unlock refresh above: attach-PIN is
+        // OneKey-specific, and an empty connectId must not reach the lookup.
+        if (connectId && !hiddenWalletVendorProfile.isThirdParty) {
+          try {
+            await this.backgroundApi.serviceHardware.waitForDeviceStateSync({
+              connectIds: [
+                compatibleConnectId,
+                dbDevice.connectId,
+                dbDevice.deviceId,
+                seededDbDevice.deviceStateInfo?.identity.serialNo,
+              ],
             });
-          const latestUnlockedAttachPin =
-            latestDbDevice?.deviceStateInfo?.status?.unlockedAttachPin;
-          if (typeof latestUnlockedAttachPin === 'boolean') {
-            isAttachPinMode = latestUnlockedAttachPin;
+            const latestDbDevice =
+              await this.backgroundApi.serviceHardware.getDeviceByConnectId({
+                connectId,
+              });
+            const latestUnlockedAttachPin =
+              latestDbDevice?.deviceStateInfo?.status?.unlockedAttachPin;
+            if (typeof latestUnlockedAttachPin === 'boolean') {
+              isAttachPinMode = latestUnlockedAttachPin;
+            }
+          } catch {
+            // keep the resolved-features fallback
           }
-        } catch {
-          // keep the resolved-features fallback
         }
 
         return {

--- a/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
+++ b/packages/kit-bg/src/services/ServiceAccount/ServiceAccount.ts
@@ -3679,6 +3679,30 @@ class ServiceAccount extends ServiceBase {
           throw deviceNotOpenedPassphraseError;
         }
 
+        // The passphrase call above emitted DEVICE.STATE events (including the
+        // unlock / attach-PIN status); wait for their persistence and prefer
+        // the persisted post-unlock snapshot over the pre-unlock seed for
+        // everything derived or stored below. Pure DB reads — no device I/O,
+        // so the hidden session established above is never touched.
+        await this.backgroundApi.serviceHardware.waitForDeviceStateSync({
+          connectIds: [
+            compatibleConnectId,
+            dbDevice.connectId,
+            dbDevice.deviceId,
+            seededDbDevice.deviceStateInfo?.identity.serialNo,
+          ],
+        });
+        const postUnlockDbDevice =
+          await this.backgroundApi.serviceHardware.getDeviceByConnectId({
+            connectId,
+          });
+        if (postUnlockDbDevice?.deviceStateInfo) {
+          seededDbDevice = {
+            ...seededDbDevice,
+            deviceStateInfo: postUnlockDbDevice.deviceStateInfo,
+          };
+        }
+
         // TODO save remember states
         const resolvedFeatures = await this.getFeaturesForHwWalletCreate({
           dbDevice: seededDbDevice,
@@ -3717,12 +3741,20 @@ class ServiceAccount extends ServiceBase {
             await this.backgroundApi.serviceAccountProfile.isSoftwareWalletOnlyUser(),
         });
 
-        // The seeded snapshot predates the passphrase prompt, so its
-        // unlockedAttachPin can be stale when the device was unlocked with the
-        // attach PIN during this flow. Prefer the state persisted from the
-        // DEVICE.STATE events emitted by the passphrase/derivation calls above.
+        // resolvedFeatures already reflects the post-unlock snapshot refreshed
+        // above, but the XFP / address derivation calls inside
+        // createHWWalletBase may have emitted newer DEVICE.STATE events; drain
+        // the persistence queue once more and prefer the latest stored status.
         let isAttachPinMode = resolvedFeatures.unlockedAttachPin;
         try {
+          await this.backgroundApi.serviceHardware.waitForDeviceStateSync({
+            connectIds: [
+              compatibleConnectId,
+              dbDevice.connectId,
+              dbDevice.deviceId,
+              seededDbDevice.deviceStateInfo?.identity.serialNo,
+            ],
+          });
           const latestDbDevice =
             await this.backgroundApi.serviceHardware.getDeviceByConnectId({
               connectId,


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59992](https://onekeyhq.atlassian.net/browse/OK-59992)

----------

<!-- github-pr-monitor:jira-links:end -->


## Problem

OK-59992: creating a hidden wallet became noticeably slower. The app-side contributor: `createHWHiddenWallet` performed uncached live `getDeviceState` reads AFTER the hidden-wallet passphrase session was opened (V1 devices with no persisted snapshot). This costs extra device round trips, and a live V1 state read without the passphrase context restores the standard session — forcing the subsequent XFP derivation to re-establish the hidden session (the hazard already documented in the code comment inside `getFeaturesForHwWalletCreate`).

## Changes

- `createHWHiddenWallet`: when `deviceStateInfo` is missing (first run after upgrade), the vendor is not third-party, and the device is not known-V2, read the canonical device state ONCE BEFORE `getPassphraseState`, carry the snapshot in memory, and let every downstream step take its existing fast path — fewer device round trips and no hidden-session clobbering
- Replicate `resolveDeviceStateForHwWalletCreate`'s live-identity guard at the seed site (the seeded fast path would otherwise skip it; behavior stays equivalent to the old no-snapshot flow)
- `isAttachPinMode` now prefers the freshest persisted post-unlock device state (the seeded snapshot predates the PIN prompt, so using it directly would report a stale value in attach-PIN scenarios)
- Backfill `connectProtocol` from the seeded state when it was unknown
- Bump hardware SDK to `1.2.0-alpha.134`, which carries the companion SDK fixes (WebUSB protocol-probe caching + single-round-trip identity validation, see OneKeyHQ/hardware-js-sdk#884)

## Measurements (desktop, same OneKey Pro, same UX flow, silent-call totals)

| Phase | 6.5.0 baseline | Regression (alpha.129) | This PR + SDK fixes |
|---|---|---|---|
| Onboarding wallet creation | 14.0s | 25.6s | **14.7s** |
| Enable passphrase + create hidden wallet | 18.1s | 27.2s | **18.9s** |

Pro2 (V2): no regression on any metric (V2 is explicitly excluded from the seeding path by design).

## Notes

- 6 new unit tests cover seed ordering, fast paths, V2 exclusion, the identity guard, and attach-PIN value sourcing
- This PR no longer carries any SDK version change: the base branch already pins `1.2.0-alpha.142`, which was released from `onekey` after OneKeyHQ/hardware-js-sdk#884 merged and verifiably contains all of its changes (tarball-checked: probe cache, USBDevice identity binding, forced-detection bypass, session gate, Initialize identity merge). Only the three app-side fix commits remain
- Extension release requires deploying the matching iframe version to `jssdk.onekey.so` (`deploy-release-iframe-web`); desktop/TF uses the bundled `static/js-sdk` and is unaffected

[OK-59992]: https://onekeyhq.atlassian.net/browse/OK-59992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

