### PR TITLE
fix: recover native notification permissions

### DIFF
--- a/packages/kit-bg/src/services/ServiceNotification/NotificationProvider/NotificationProvider.native.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/NotificationProvider/NotificationProvider.native.ts
@@ -149,7 +149,10 @@ export default class NotificationProvider extends NotificationProviderBase {
       status.ios?.status === IosAuthorizationStatus.PROVISIONAL
     ) {
       permission = ENotificationPermission.granted;
-    } else if (status.status === PermissionStatus.DENIED) {
+    } else if (
+      status.status === PermissionStatus.DENIED &&
+      !status.canAskAgain
+    ) {
       permission = ENotificationPermission.denied;
     }
 

--- a/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
@@ -29,6 +29,9 @@ import type {
   ENotificationPushTopicTypes,
   INotificationClickParams,
   INotificationPermissionDetail,
+  INotificationPermissionRecoveryActionResult,
+  INotificationPermissionRecoveryCheckParams,
+  INotificationPermissionRecoveryResult,
   INotificationPushClient,
   INotificationPushMessageAckParams,
   INotificationPushMessageInfo,
@@ -43,6 +46,9 @@ import type {
 } from '@onekeyhq/shared/types/notification';
 import {
   ENotificationPermission,
+  ENotificationPermissionRecoveryAction,
+  ENotificationPermissionRecoveryReason,
+  ENotificationPermissionRecoveryTestScenario,
   ENotificationPushMessageAckAction,
   ENotificationPushSyncMethod,
   EPushProviderEventNames,
@@ -57,6 +63,7 @@ import {
 } from '../../states/jotai/atoms';
 import ServiceBase from '../ServiceBase';
 
+import { buildNotificationPermissionRecoveryResult } from './notificationPermissionRecovery';
 import NotificationProvider from './NotificationProvider/NotificationProvider';
 
 import type NotificationProviderBase from './NotificationProvider/NotificationProviderBase';
@@ -406,6 +413,258 @@ export default class ServiceNotification extends ServiceBase {
     // TODO desktop mas,standalone prod support
     await this.openPermissionSettings();
     return this.getPermission();
+  }
+
+  notificationPermissionRecoveryTestScenario =
+    ENotificationPermissionRecoveryTestScenario.real;
+
+  private getNotificationPermissionRecoveryTestData():
+    | {
+        permissionDetail: INotificationPermissionDetail | undefined;
+        pushEnabled: boolean | undefined;
+        queryFailed: boolean;
+      }
+    | undefined {
+    switch (this.notificationPermissionRecoveryTestScenario) {
+      case ENotificationPermissionRecoveryTestScenario.pushOnGranted:
+        return {
+          permissionDetail: {
+            isSupported: true,
+            permission: ENotificationPermission.granted,
+          },
+          pushEnabled: true,
+          queryFailed: false,
+        };
+      case ENotificationPermissionRecoveryTestScenario.pushOnDefault:
+        return {
+          permissionDetail: {
+            isSupported: true,
+            permission: ENotificationPermission.default,
+          },
+          pushEnabled: true,
+          queryFailed: false,
+        };
+      case ENotificationPermissionRecoveryTestScenario.pushOnDenied:
+        return {
+          permissionDetail: {
+            isSupported: true,
+            permission: ENotificationPermission.denied,
+          },
+          pushEnabled: true,
+          queryFailed: false,
+        };
+      case ENotificationPermissionRecoveryTestScenario.pushOff:
+        return {
+          permissionDetail: {
+            isSupported: true,
+            permission: ENotificationPermission.granted,
+          },
+          pushEnabled: false,
+          queryFailed: false,
+        };
+      case ENotificationPermissionRecoveryTestScenario.unsupported:
+        return {
+          permissionDetail: {
+            isSupported: false,
+            permission: ENotificationPermission.default,
+          },
+          pushEnabled: true,
+          queryFailed: false,
+        };
+      case ENotificationPermissionRecoveryTestScenario.queryFailed:
+        return {
+          permissionDetail: undefined,
+          pushEnabled: undefined,
+          queryFailed: true,
+        };
+      case ENotificationPermissionRecoveryTestScenario.real:
+      default:
+        return undefined;
+    }
+  }
+
+  private getNotificationPermissionRecoveryPlatform() {
+    if (platformEnv.isNativeIOS) {
+      return 'ios' as const;
+    }
+    if (platformEnv.isNativeAndroid) {
+      return 'android' as const;
+    }
+    return 'other' as const;
+  }
+
+  @backgroundMethod()
+  async setNotificationPermissionRecoveryTestScenario(
+    scenario: ENotificationPermissionRecoveryTestScenario,
+  ) {
+    this.notificationPermissionRecoveryTestScenario = scenario;
+    return scenario;
+  }
+
+  @backgroundMethod()
+  async getNotificationPermissionRecoveryTestScenario() {
+    return this.notificationPermissionRecoveryTestScenario;
+  }
+
+  @backgroundMethod()
+  async resetNotificationPermissionRecoveryState() {
+    await notificationsAtom.set((value) => ({
+      ...value,
+      permissionRecoveryDismissedAt: undefined,
+      permissionRecoveryLastPermission: undefined,
+    }));
+  }
+
+  @backgroundMethod()
+  async dismissNotificationPermissionRecovery() {
+    await notificationsAtom.set((value) => ({
+      ...value,
+      permissionRecoveryDismissedAt: Date.now(),
+    }));
+  }
+
+  @backgroundMethod()
+  async checkNotificationPermissionRecovery({
+    source,
+    ignoreCooldown = false,
+  }: INotificationPermissionRecoveryCheckParams): Promise<INotificationPermissionRecoveryResult> {
+    const checkedAt = Date.now();
+    const testData = this.getNotificationPermissionRecoveryTestData();
+    const isTestMode = Boolean(testData);
+    let permissionDetail: INotificationPermissionDetail | undefined;
+    let pushEnabled: boolean | undefined;
+    let isServerSettingsAvailable = false;
+    let queryFailed = false;
+
+    if (testData) {
+      permissionDetail = testData.permissionDetail;
+      pushEnabled = testData.pushEnabled;
+      queryFailed = testData.queryFailed;
+      isServerSettingsAvailable = !queryFailed;
+    } else if (platformEnv.isNative) {
+      try {
+        const [serverSettings, permission] = await Promise.all([
+          this.fetchServerNotificationSettingsWithCache(),
+          this.getPermissionWithoutLog(),
+        ]);
+        permissionDetail = permission;
+        pushEnabled = serverSettings?.pushEnabled;
+        isServerSettingsAvailable = Boolean(serverSettings);
+      } catch {
+        queryFailed = true;
+      }
+    }
+
+    const notificationState = await notificationsAtom.get();
+    const previousPermission =
+      notificationState.permissionRecoveryLastPermission;
+    const currentPermission = permissionDetail?.permission;
+    const hasPermissionChanged = Boolean(
+      previousPermission &&
+      currentPermission &&
+      previousPermission !== currentPermission,
+    );
+    const dismissedAt = hasPermissionChanged
+      ? undefined
+      : notificationState.permissionRecoveryDismissedAt;
+    const result = buildNotificationPermissionRecoveryResult({
+      checkedAt,
+      dismissedAt,
+      ignoreCooldown,
+      isNative: Boolean(platformEnv.isNative),
+      isServerSettingsAvailable,
+      isTestMode,
+      permissionDetail,
+      pushEnabled,
+      queryFailed,
+    });
+
+    if (!queryFailed && currentPermission) {
+      const shouldClearDismissal =
+        hasPermissionChanged ||
+        result.reason ===
+          ENotificationPermissionRecoveryReason.permissionGranted ||
+        result.reason === ENotificationPermissionRecoveryReason.pushDisabled;
+      await notificationsAtom.set((value) => ({
+        ...value,
+        permissionRecoveryDismissedAt: shouldClearDismissal
+          ? undefined
+          : value.permissionRecoveryDismissedAt,
+        permissionRecoveryLastPermission: currentPermission,
+      }));
+
+      if (
+        !isTestMode &&
+        pushEnabled &&
+        previousPermission &&
+        previousPermission !== ENotificationPermission.granted &&
+        currentPermission === ENotificationPermission.granted
+      ) {
+        void this.registerClientWithOverrideAllAccounts();
+      }
+    }
+
+    defaultLogger.notification.common.permissionRecoveryCheck({
+      ...result,
+      platform: this.getNotificationPermissionRecoveryPlatform(),
+      source,
+    });
+    return result;
+  }
+
+  @backgroundMethod()
+  @toastIfError()
+  async recoverNotificationPermission(): Promise<INotificationPermissionRecoveryActionResult> {
+    const testData = this.getNotificationPermissionRecoveryTestData();
+    const isTestMode = Boolean(testData);
+    let permissionDetail = testData
+      ? (testData.permissionDetail ?? {
+          isSupported: false,
+          permission: ENotificationPermission.default,
+        })
+      : await this.getPermissionWithoutLog();
+    const permissionBefore = permissionDetail.permission;
+    let action = ENotificationPermissionRecoveryAction.none;
+
+    if (permissionBefore === ENotificationPermission.default) {
+      action = ENotificationPermissionRecoveryAction.requestPermission;
+      if (isTestMode) {
+        this.notificationPermissionRecoveryTestScenario =
+          ENotificationPermissionRecoveryTestScenario.pushOnGranted;
+        permissionDetail = {
+          isSupported: true,
+          permission: ENotificationPermission.granted,
+        };
+      } else {
+        permissionDetail = await this.requestPermission();
+      }
+    } else if (permissionBefore === ENotificationPermission.denied) {
+      action = ENotificationPermissionRecoveryAction.openSettings;
+      if (!isTestMode) {
+        await this.openPermissionSettings();
+      }
+    }
+
+    if (
+      !isTestMode &&
+      permissionBefore !== ENotificationPermission.granted &&
+      permissionDetail.permission === ENotificationPermission.granted
+    ) {
+      void this.registerClientWithOverrideAllAccounts();
+    }
+
+    const result = {
+      action,
+      isSupported: permissionDetail.isSupported,
+      isTestMode,
+      permission: permissionDetail.permission,
+    };
+    defaultLogger.notification.common.permissionRecoveryAction({
+      ...result,
+      permissionBefore,
+      platform: this.getNotificationPermissionRecoveryPlatform(),
+    });
+    return result;
   }
 
   desktopNotificationCache: {
@@ -1281,7 +1540,8 @@ export default class ServiceNotification extends ServiceBase {
   // TODO clear cache if prime expired, onekeyID logout
   getServerSettingsWithCache = memoizee(
     async () => {
-      const serverSettings = await this.fetchServerNotificationSettings();
+      const serverSettings =
+        await this.fetchServerNotificationSettingsWithoutToast();
 
       let supportNetworks:
         | {
@@ -1378,14 +1638,18 @@ export default class ServiceNotification extends ServiceBase {
     },
   );
 
-  @backgroundMethod()
-  @toastIfError()
-  async fetchServerNotificationSettings() {
+  private async fetchServerNotificationSettingsWithoutToast() {
     const client = await this.getClient(EServiceEndpointEnum.Notification);
     const result = await client.post<
       IApiClientResponse<INotificationPushSettings>
     >('/notification/v1/config/query');
     return result?.data?.data;
+  }
+
+  @backgroundMethod()
+  @toastIfError()
+  async fetchServerNotificationSettings() {
+    return this.fetchServerNotificationSettingsWithoutToast();
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
@@ -418,6 +418,8 @@ export default class ServiceNotification extends ServiceBase {
   notificationPermissionRecoveryTestScenario =
     ENotificationPermissionRecoveryTestScenario.real;
 
+  private notificationPermissionRecoveryCheckSequence = 0;
+
   private getNotificationPermissionRecoveryTestData():
     | {
         permissionDetail: INotificationPermissionDetail | undefined;
@@ -497,6 +499,7 @@ export default class ServiceNotification extends ServiceBase {
   async setNotificationPermissionRecoveryTestScenario(
     scenario: ENotificationPermissionRecoveryTestScenario,
   ) {
+    this.notificationPermissionRecoveryCheckSequence += 1;
     this.notificationPermissionRecoveryTestScenario = scenario;
     return scenario;
   }
@@ -508,6 +511,7 @@ export default class ServiceNotification extends ServiceBase {
 
   @backgroundMethod()
   async resetNotificationPermissionRecoveryState() {
+    this.notificationPermissionRecoveryCheckSequence += 1;
     await notificationsAtom.set((value) => ({
       ...value,
       permissionRecoveryDismissedAt: undefined,
@@ -517,6 +521,7 @@ export default class ServiceNotification extends ServiceBase {
 
   @backgroundMethod()
   async dismissNotificationPermissionRecovery() {
+    this.notificationPermissionRecoveryCheckSequence += 1;
     await notificationsAtom.set((value) => ({
       ...value,
       permissionRecoveryDismissedAt: Date.now(),
@@ -527,7 +532,10 @@ export default class ServiceNotification extends ServiceBase {
   async checkNotificationPermissionRecovery({
     source,
     ignoreCooldown = false,
+    pushEnabled: pushEnabledSnapshot,
   }: INotificationPermissionRecoveryCheckParams): Promise<INotificationPermissionRecoveryResult> {
+    const checkSequence = this.notificationPermissionRecoveryCheckSequence + 1;
+    this.notificationPermissionRecoveryCheckSequence = checkSequence;
     const checkedAt = Date.now();
     const testData = this.getNotificationPermissionRecoveryTestData();
     const isTestMode = Boolean(testData);
@@ -543,13 +551,20 @@ export default class ServiceNotification extends ServiceBase {
       isServerSettingsAvailable = !queryFailed;
     } else if (platformEnv.isNative) {
       try {
-        const [serverSettings, permission] = await Promise.all([
-          this.fetchServerNotificationSettingsWithCache(),
-          this.getPermissionWithoutLog(),
-        ]);
-        permissionDetail = permission;
-        pushEnabled = serverSettings?.pushEnabled;
-        isServerSettingsAvailable = Boolean(serverSettings);
+        const permissionPromise = this.getPermissionWithoutLog();
+        if (pushEnabledSnapshot === undefined) {
+          const [serverSettings, permission] = await Promise.all([
+            this.fetchServerNotificationSettingsWithCache(),
+            permissionPromise,
+          ]);
+          permissionDetail = permission;
+          pushEnabled = serverSettings?.pushEnabled;
+          isServerSettingsAvailable = Boolean(serverSettings);
+        } else {
+          permissionDetail = await permissionPromise;
+          pushEnabled = pushEnabledSnapshot;
+          isServerSettingsAvailable = true;
+        }
       } catch {
         queryFailed = true;
       }
@@ -579,21 +594,33 @@ export default class ServiceNotification extends ServiceBase {
       queryFailed,
     });
 
-    if (!queryFailed && currentPermission) {
+    if (
+      !queryFailed &&
+      currentPermission &&
+      checkSequence === this.notificationPermissionRecoveryCheckSequence
+    ) {
       const shouldClearDismissal =
         hasPermissionChanged ||
         result.reason ===
           ENotificationPermissionRecoveryReason.permissionGranted ||
         result.reason === ENotificationPermissionRecoveryReason.pushDisabled;
-      await notificationsAtom.set((value) => ({
-        ...value,
-        permissionRecoveryDismissedAt: shouldClearDismissal
-          ? undefined
-          : value.permissionRecoveryDismissedAt,
-        permissionRecoveryLastPermission: currentPermission,
-      }));
+      await notificationsAtom.set((value) => {
+        if (
+          checkSequence !== this.notificationPermissionRecoveryCheckSequence
+        ) {
+          return value;
+        }
+        return {
+          ...value,
+          permissionRecoveryDismissedAt: shouldClearDismissal
+            ? undefined
+            : value.permissionRecoveryDismissedAt,
+          permissionRecoveryLastPermission: currentPermission,
+        };
+      });
 
       if (
+        checkSequence === this.notificationPermissionRecoveryCheckSequence &&
         !isTestMode &&
         pushEnabled &&
         previousPermission &&
@@ -615,6 +642,7 @@ export default class ServiceNotification extends ServiceBase {
   @backgroundMethod()
   @toastIfError()
   async recoverNotificationPermission(): Promise<INotificationPermissionRecoveryActionResult> {
+    this.notificationPermissionRecoveryCheckSequence += 1;
     const testData = this.getNotificationPermissionRecoveryTestData();
     const isTestMode = Boolean(testData);
     let permissionDetail = testData

--- a/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
@@ -606,11 +606,11 @@ export default class ServiceNotification extends ServiceBase {
         ) {
           return value;
         }
-        return {
+        return perfUtils.buildNewValueIfChanged(value, {
           ...value,
           permissionRecoveryDismissedAt: stateTransition.nextDismissedAt,
           permissionRecoveryLastPermission: currentPermission,
-        };
+        });
       });
 
       if (
@@ -1600,6 +1600,7 @@ export default class ServiceNotification extends ServiceBase {
       maxAge: timerUtils.getTimeDurationMs({
         hour: 1,
       }),
+      promise: true,
     },
   );
 

--- a/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
@@ -65,6 +65,7 @@ import ServiceBase from '../ServiceBase';
 import {
   buildNotificationPermissionRecoveryResult,
   buildNotificationPermissionRecoveryStateTransition,
+  resolveNotificationPermissionRecoveryLastPermission,
 } from './notificationPermissionRecovery';
 import NotificationProvider from './NotificationProvider/NotificationProvider';
 
@@ -594,12 +595,21 @@ export default class ServiceNotification extends ServiceBase {
       pushEnabled,
       queryFailed,
     });
+    let registrationFailed = false;
 
     if (
       !queryFailed &&
       currentPermission &&
       checkSequence === this.notificationPermissionRecoveryCheckSequence
     ) {
+      if (stateTransition.shouldRegisterClient) {
+        try {
+          await this.registerClientWithOverrideAllAccountsImmediate();
+        } catch {
+          registrationFailed = true;
+        }
+      }
+
       await notificationsAtom.set((value) => {
         if (
           checkSequence !== this.notificationPermissionRecoveryCheckSequence
@@ -609,21 +619,20 @@ export default class ServiceNotification extends ServiceBase {
         return perfUtils.buildNewValueIfChanged(value, {
           ...value,
           permissionRecoveryDismissedAt: stateTransition.nextDismissedAt,
-          permissionRecoveryLastPermission: currentPermission,
+          permissionRecoveryLastPermission:
+            resolveNotificationPermissionRecoveryLastPermission({
+              currentPermission,
+              previousPermission,
+              registrationFailed,
+            }),
         });
       });
-
-      if (
-        checkSequence === this.notificationPermissionRecoveryCheckSequence &&
-        stateTransition.shouldRegisterClient
-      ) {
-        void this.registerClientWithOverrideAllAccounts();
-      }
     }
 
     defaultLogger.notification.common.permissionRecoveryCheck({
       ...result,
       platform: this.getNotificationPermissionRecoveryPlatform(),
+      registrationFailed,
       source,
     });
     return result;
@@ -661,14 +670,6 @@ export default class ServiceNotification extends ServiceBase {
       if (!isTestMode) {
         await this.openPermissionSettings();
       }
-    }
-
-    if (
-      !isTestMode &&
-      permissionBefore !== ENotificationPermission.granted &&
-      permissionDetail.permission === ENotificationPermission.granted
-    ) {
-      void this.registerClientWithOverrideAllAccounts();
     }
 
     const result = {

--- a/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
@@ -983,17 +983,16 @@ export default class ServiceNotification extends ServiceBase {
 
   private async _registerClientWithOverrideAllAccountsCore() {
     console.log('registerClientWithOverrideAllAccountsCore');
-    await timerUtils.setTimeoutPromised(async () => {
-      await this.registerClientWithSyncAccounts({
-        syncMethod: ENotificationPushSyncMethod.override,
-      });
-      await notificationsAtom.set((v) =>
-        perfUtils.buildNewValueIfChanged(v, {
-          ...v,
-          lastRegisterTime: Date.now(),
-        }),
-      );
+    await timerUtils.wait(0);
+    await this.registerClientWithSyncAccounts({
+      syncMethod: ENotificationPushSyncMethod.override,
     });
+    await notificationsAtom.set((v) =>
+      perfUtils.buildNewValueIfChanged(v, {
+        ...v,
+        lastRegisterTime: Date.now(),
+      }),
+    );
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/ServiceNotification.ts
@@ -47,7 +47,6 @@ import type {
 import {
   ENotificationPermission,
   ENotificationPermissionRecoveryAction,
-  ENotificationPermissionRecoveryReason,
   ENotificationPermissionRecoveryTestScenario,
   ENotificationPushMessageAckAction,
   ENotificationPushSyncMethod,
@@ -63,7 +62,10 @@ import {
 } from '../../states/jotai/atoms';
 import ServiceBase from '../ServiceBase';
 
-import { buildNotificationPermissionRecoveryResult } from './notificationPermissionRecovery';
+import {
+  buildNotificationPermissionRecoveryResult,
+  buildNotificationPermissionRecoveryStateTransition,
+} from './notificationPermissionRecovery';
 import NotificationProvider from './NotificationProvider/NotificationProvider';
 
 import type NotificationProviderBase from './NotificationProvider/NotificationProviderBase';
@@ -574,17 +576,16 @@ export default class ServiceNotification extends ServiceBase {
     const previousPermission =
       notificationState.permissionRecoveryLastPermission;
     const currentPermission = permissionDetail?.permission;
-    const hasPermissionChanged = Boolean(
-      previousPermission &&
-      currentPermission &&
-      previousPermission !== currentPermission,
-    );
-    const dismissedAt = hasPermissionChanged
-      ? undefined
-      : notificationState.permissionRecoveryDismissedAt;
+    const stateTransition = buildNotificationPermissionRecoveryStateTransition({
+      currentPermission,
+      dismissedAt: notificationState.permissionRecoveryDismissedAt,
+      isTestMode,
+      previousPermission,
+      pushEnabled,
+    });
     const result = buildNotificationPermissionRecoveryResult({
       checkedAt,
-      dismissedAt,
+      dismissedAt: stateTransition.dismissedAtForCheck,
       ignoreCooldown,
       isNative: Boolean(platformEnv.isNative),
       isServerSettingsAvailable,
@@ -599,11 +600,6 @@ export default class ServiceNotification extends ServiceBase {
       currentPermission &&
       checkSequence === this.notificationPermissionRecoveryCheckSequence
     ) {
-      const shouldClearDismissal =
-        hasPermissionChanged ||
-        result.reason ===
-          ENotificationPermissionRecoveryReason.permissionGranted ||
-        result.reason === ENotificationPermissionRecoveryReason.pushDisabled;
       await notificationsAtom.set((value) => {
         if (
           checkSequence !== this.notificationPermissionRecoveryCheckSequence
@@ -612,20 +608,14 @@ export default class ServiceNotification extends ServiceBase {
         }
         return {
           ...value,
-          permissionRecoveryDismissedAt: shouldClearDismissal
-            ? undefined
-            : value.permissionRecoveryDismissedAt,
+          permissionRecoveryDismissedAt: stateTransition.nextDismissedAt,
           permissionRecoveryLastPermission: currentPermission,
         };
       });
 
       if (
         checkSequence === this.notificationPermissionRecoveryCheckSequence &&
-        !isTestMode &&
-        pushEnabled &&
-        previousPermission &&
-        previousPermission !== ENotificationPermission.granted &&
-        currentPermission === ENotificationPermission.granted
+        stateTransition.shouldRegisterClient
       ) {
         void this.registerClientWithOverrideAllAccounts();
       }

--- a/packages/kit-bg/src/services/ServiceNotification/notificationPermissionRecovery.test.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/notificationPermissionRecovery.test.ts
@@ -9,6 +9,13 @@ import {
   buildNotificationPermissionRecoveryStateTransition,
   resolveNotificationPermissionRecoveryLastPermission,
 } from './notificationPermissionRecovery';
+import ServiceNotification from './ServiceNotification';
+
+jest.mock('@onekeyhq/shared/src/utils/notificationsUtils', () => ({
+  __esModule: true,
+  default: {},
+  NOTIFICATION_ACCOUNT_ACTIVITY_DEFAULT_MAX_ACCOUNT_COUNT: 20,
+}));
 
 const checkedAt = 1_000_000;
 
@@ -190,5 +197,24 @@ describe('resolveNotificationPermissionRecoveryLastPermission', () => {
         registrationFailed: true,
       }),
     ).toBe(ENotificationPermission.denied);
+  });
+});
+
+describe('registerClientWithOverrideAllAccountsImmediate', () => {
+  it('rejects when client registration fails', async () => {
+    const previousIsInBackground = globalThis.$onekeyIsInBackground;
+    globalThis.$onekeyIsInBackground = true;
+    try {
+      const service = new ServiceNotification({ backgroundApi: {} });
+      jest
+        .spyOn(service, 'registerClientWithSyncAccounts')
+        .mockRejectedValue(new Error('registration failed'));
+
+      await expect(
+        service.registerClientWithOverrideAllAccountsImmediate(),
+      ).rejects.toThrow('registration failed');
+    } finally {
+      globalThis.$onekeyIsInBackground = previousIsInBackground;
+    }
   });
 });

--- a/packages/kit-bg/src/services/ServiceNotification/notificationPermissionRecovery.test.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/notificationPermissionRecovery.test.ts
@@ -7,6 +7,7 @@ import {
   NOTIFICATION_PERMISSION_RECOVERY_COOLDOWN_MS,
   buildNotificationPermissionRecoveryResult,
   buildNotificationPermissionRecoveryStateTransition,
+  resolveNotificationPermissionRecoveryLastPermission,
 } from './notificationPermissionRecovery';
 
 const checkedAt = 1_000_000;
@@ -171,4 +172,23 @@ describe('buildNotificationPermissionRecoveryStateTransition', () => {
       ).toBe(false);
     },
   );
+});
+
+describe('resolveNotificationPermissionRecoveryLastPermission', () => {
+  it('commits granted only after registration succeeds', () => {
+    expect(
+      resolveNotificationPermissionRecoveryLastPermission({
+        currentPermission: ENotificationPermission.granted,
+        previousPermission: ENotificationPermission.denied,
+        registrationFailed: false,
+      }),
+    ).toBe(ENotificationPermission.granted);
+    expect(
+      resolveNotificationPermissionRecoveryLastPermission({
+        currentPermission: ENotificationPermission.granted,
+        previousPermission: ENotificationPermission.denied,
+        registrationFailed: true,
+      }),
+    ).toBe(ENotificationPermission.denied);
+  });
 });

--- a/packages/kit-bg/src/services/ServiceNotification/notificationPermissionRecovery.test.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/notificationPermissionRecovery.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   NOTIFICATION_PERMISSION_RECOVERY_COOLDOWN_MS,
   buildNotificationPermissionRecoveryResult,
+  buildNotificationPermissionRecoveryStateTransition,
 } from './notificationPermissionRecovery';
 
 const checkedAt = 1_000_000;
@@ -112,4 +113,62 @@ describe('buildNotificationPermissionRecoveryResult', () => {
       shouldShow: true,
     });
   });
+});
+
+describe('buildNotificationPermissionRecoveryStateTransition', () => {
+  it('clears the cooldown and registers after permission is restored', () => {
+    expect(
+      buildNotificationPermissionRecoveryStateTransition({
+        currentPermission: ENotificationPermission.granted,
+        dismissedAt: checkedAt,
+        isTestMode: false,
+        previousPermission: ENotificationPermission.denied,
+        pushEnabled: true,
+      }),
+    ).toEqual({
+      dismissedAtForCheck: undefined,
+      nextDismissedAt: undefined,
+      shouldRegisterClient: true,
+    });
+  });
+
+  it('keeps the cooldown when the missing permission is unchanged', () => {
+    expect(
+      buildNotificationPermissionRecoveryStateTransition({
+        currentPermission: ENotificationPermission.denied,
+        dismissedAt: checkedAt,
+        isTestMode: false,
+        previousPermission: ENotificationPermission.denied,
+        pushEnabled: true,
+      }),
+    ).toEqual({
+      dismissedAtForCheck: checkedAt,
+      nextDismissedAt: checkedAt,
+      shouldRegisterClient: false,
+    });
+  });
+
+  it.each([
+    {
+      isTestMode: true,
+      pushEnabled: true,
+    },
+    {
+      isTestMode: false,
+      pushEnabled: false,
+    },
+  ])(
+    'does not register for $isTestMode test mode with pushEnabled=$pushEnabled',
+    ({ isTestMode, pushEnabled }) => {
+      expect(
+        buildNotificationPermissionRecoveryStateTransition({
+          currentPermission: ENotificationPermission.granted,
+          dismissedAt: checkedAt,
+          isTestMode,
+          previousPermission: ENotificationPermission.denied,
+          pushEnabled,
+        }).shouldRegisterClient,
+      ).toBe(false);
+    },
+  );
 });

--- a/packages/kit-bg/src/services/ServiceNotification/notificationPermissionRecovery.test.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/notificationPermissionRecovery.test.ts
@@ -1,0 +1,115 @@
+import {
+  ENotificationPermission,
+  ENotificationPermissionRecoveryReason,
+} from '@onekeyhq/shared/types/notification';
+
+import {
+  NOTIFICATION_PERMISSION_RECOVERY_COOLDOWN_MS,
+  buildNotificationPermissionRecoveryResult,
+} from './notificationPermissionRecovery';
+
+const checkedAt = 1_000_000;
+
+function buildResult(
+  overrides: Partial<
+    Parameters<typeof buildNotificationPermissionRecoveryResult>[0]
+  > = {},
+) {
+  return buildNotificationPermissionRecoveryResult({
+    checkedAt,
+    dismissedAt: undefined,
+    ignoreCooldown: false,
+    isNative: true,
+    isServerSettingsAvailable: true,
+    isTestMode: false,
+    permissionDetail: {
+      isSupported: true,
+      permission: ENotificationPermission.default,
+    },
+    pushEnabled: true,
+    queryFailed: false,
+    ...overrides,
+  });
+}
+
+describe('buildNotificationPermissionRecoveryResult', () => {
+  it('shows recovery when push is enabled but native permission is missing', () => {
+    expect(buildResult()).toMatchObject({
+      reason: ENotificationPermissionRecoveryReason.permissionRequired,
+      shouldShow: true,
+    });
+    expect(
+      buildResult({
+        permissionDetail: {
+          isSupported: true,
+          permission: ENotificationPermission.denied,
+        },
+      }),
+    ).toMatchObject({
+      reason: ENotificationPermissionRecoveryReason.permissionRequired,
+      shouldShow: true,
+    });
+  });
+
+  it.each([
+    {
+      expected: ENotificationPermissionRecoveryReason.pushDisabled,
+      overrides: { pushEnabled: false },
+    },
+    {
+      expected: ENotificationPermissionRecoveryReason.permissionGranted,
+      overrides: {
+        permissionDetail: {
+          isSupported: true,
+          permission: ENotificationPermission.granted,
+        },
+      },
+    },
+    {
+      expected: ENotificationPermissionRecoveryReason.permissionUnsupported,
+      overrides: {
+        permissionDetail: {
+          isSupported: false,
+          permission: ENotificationPermission.default,
+        },
+      },
+    },
+    {
+      expected: ENotificationPermissionRecoveryReason.serverSettingsUnavailable,
+      overrides: { isServerSettingsAvailable: false },
+    },
+    {
+      expected: ENotificationPermissionRecoveryReason.queryFailed,
+      overrides: { queryFailed: true },
+    },
+    {
+      expected: ENotificationPermissionRecoveryReason.nonNative,
+      overrides: { isNative: false },
+    },
+  ])('does not show for $expected', ({ expected, overrides }) => {
+    expect(buildResult(overrides)).toMatchObject({
+      reason: expected,
+      shouldShow: false,
+    });
+  });
+
+  it('honors and can bypass the dismissal cooldown', () => {
+    const dismissedAt =
+      checkedAt - NOTIFICATION_PERMISSION_RECOVERY_COOLDOWN_MS;
+
+    expect(buildResult({ dismissedAt: dismissedAt + 1 })).toMatchObject({
+      reason: ENotificationPermissionRecoveryReason.cooldown,
+      shouldShow: false,
+    });
+    expect(buildResult({ dismissedAt })).toMatchObject({
+      reason: ENotificationPermissionRecoveryReason.permissionRequired,
+      shouldShow: true,
+    });
+    expect(
+      buildResult({ dismissedAt: dismissedAt + 1, ignoreCooldown: true }),
+    ).toMatchObject({
+      reason: ENotificationPermissionRecoveryReason.permissionRequired,
+      shouldShow: true,
+    });
+  });
+});

--- a/packages/kit-bg/src/services/ServiceNotification/notificationPermissionRecovery.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/notificationPermissionRecovery.ts
@@ -9,6 +9,18 @@ import {
 
 export const NOTIFICATION_PERMISSION_RECOVERY_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
+export function resolveNotificationPermissionRecoveryLastPermission({
+  currentPermission,
+  previousPermission,
+  registrationFailed,
+}: {
+  currentPermission: ENotificationPermission;
+  previousPermission: ENotificationPermission | undefined;
+  registrationFailed: boolean;
+}) {
+  return registrationFailed ? previousPermission : currentPermission;
+}
+
 export function buildNotificationPermissionRecoveryStateTransition({
   currentPermission,
   dismissedAt,

--- a/packages/kit-bg/src/services/ServiceNotification/notificationPermissionRecovery.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/notificationPermissionRecovery.ts
@@ -9,6 +9,41 @@ import {
 
 export const NOTIFICATION_PERMISSION_RECOVERY_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
+export function buildNotificationPermissionRecoveryStateTransition({
+  currentPermission,
+  dismissedAt,
+  isTestMode,
+  previousPermission,
+  pushEnabled,
+}: {
+  currentPermission: ENotificationPermission | undefined;
+  dismissedAt: number | undefined;
+  isTestMode: boolean;
+  previousPermission: ENotificationPermission | undefined;
+  pushEnabled: boolean | undefined;
+}) {
+  const hasPermissionChanged = Boolean(
+    previousPermission &&
+    currentPermission &&
+    previousPermission !== currentPermission,
+  );
+  const shouldClearDismissal =
+    hasPermissionChanged ||
+    currentPermission === ENotificationPermission.granted ||
+    pushEnabled === false;
+  return {
+    dismissedAtForCheck: hasPermissionChanged ? undefined : dismissedAt,
+    nextDismissedAt: shouldClearDismissal ? undefined : dismissedAt,
+    shouldRegisterClient: Boolean(
+      !isTestMode &&
+      pushEnabled &&
+      previousPermission &&
+      previousPermission !== ENotificationPermission.granted &&
+      currentPermission === ENotificationPermission.granted,
+    ),
+  };
+}
+
 export function buildNotificationPermissionRecoveryResult({
   checkedAt,
   dismissedAt,

--- a/packages/kit-bg/src/services/ServiceNotification/notificationPermissionRecovery.ts
+++ b/packages/kit-bg/src/services/ServiceNotification/notificationPermissionRecovery.ts
@@ -1,0 +1,99 @@
+import type {
+  INotificationPermissionDetail,
+  INotificationPermissionRecoveryResult,
+} from '@onekeyhq/shared/types/notification';
+import {
+  ENotificationPermission,
+  ENotificationPermissionRecoveryReason,
+} from '@onekeyhq/shared/types/notification';
+
+export const NOTIFICATION_PERMISSION_RECOVERY_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
+export function buildNotificationPermissionRecoveryResult({
+  checkedAt,
+  dismissedAt,
+  ignoreCooldown,
+  isNative,
+  isServerSettingsAvailable,
+  isTestMode,
+  permissionDetail,
+  pushEnabled,
+  queryFailed,
+}: {
+  checkedAt: number;
+  dismissedAt: number | undefined;
+  ignoreCooldown: boolean;
+  isNative: boolean;
+  isServerSettingsAvailable: boolean;
+  isTestMode: boolean;
+  permissionDetail: INotificationPermissionDetail | undefined;
+  pushEnabled: boolean | undefined;
+  queryFailed: boolean;
+}): INotificationPermissionRecoveryResult {
+  const buildResult = ({
+    reason,
+    shouldShow = false,
+  }: {
+    reason: ENotificationPermissionRecoveryReason;
+    shouldShow?: boolean;
+  }): INotificationPermissionRecoveryResult => ({
+    checkedAt,
+    isSupported: permissionDetail?.isSupported,
+    isTestMode,
+    permission: permissionDetail?.permission,
+    pushEnabled,
+    reason,
+    shouldShow,
+  });
+
+  if (!isNative) {
+    return buildResult({
+      reason: ENotificationPermissionRecoveryReason.nonNative,
+    });
+  }
+
+  if (queryFailed) {
+    return buildResult({
+      reason: ENotificationPermissionRecoveryReason.queryFailed,
+    });
+  }
+
+  if (!isServerSettingsAvailable) {
+    return buildResult({
+      reason: ENotificationPermissionRecoveryReason.serverSettingsUnavailable,
+    });
+  }
+
+  if (!pushEnabled) {
+    return buildResult({
+      reason: ENotificationPermissionRecoveryReason.pushDisabled,
+    });
+  }
+
+  if (!permissionDetail?.isSupported) {
+    return buildResult({
+      reason: ENotificationPermissionRecoveryReason.permissionUnsupported,
+    });
+  }
+
+  if (permissionDetail.permission === ENotificationPermission.granted) {
+    return buildResult({
+      reason: ENotificationPermissionRecoveryReason.permissionGranted,
+    });
+  }
+
+  if (
+    !ignoreCooldown &&
+    dismissedAt &&
+    checkedAt - dismissedAt < NOTIFICATION_PERMISSION_RECOVERY_COOLDOWN_MS
+  ) {
+    return buildResult({
+      reason: ENotificationPermissionRecoveryReason.cooldown,
+    });
+  }
+
+  return buildResult({
+    reason: ENotificationPermissionRecoveryReason.permissionRequired,
+    shouldShow: true,
+  });
+}

--- a/packages/kit-bg/src/states/jotai/atoms/notifications.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/notifications.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import type { ENotificationPermission } from '@onekeyhq/shared/types/notification';
+
 import { EAtomNames } from '../atomNames';
 import { globalAtom } from '../utils';
 
@@ -9,6 +11,8 @@ export type INotificationsPersistAtomData = {
   lastRegisterTime: number | undefined;
   maxAccountCount: number | undefined;
   lastSettingsUpdateTime: number | undefined;
+  permissionRecoveryDismissedAt: number | undefined;
+  permissionRecoveryLastPermission: ENotificationPermission | undefined;
   // Alert dismissed states for different history lists
   txHistoryAlertDismissed: boolean | undefined;
   swapHistoryAlertDismissed: boolean | undefined;
@@ -26,6 +30,8 @@ export const {
     lastReceivedTime: undefined,
     lastRegisterTime: undefined,
     lastSettingsUpdateTime: undefined,
+    permissionRecoveryDismissedAt: undefined,
+    permissionRecoveryLastPermission: undefined,
     maxAccountCount: undefined,
     txHistoryAlertDismissed: undefined,
     swapHistoryAlertDismissed: undefined,

--- a/packages/kit/src/components/NotificationPermissionRecoveryAlert/index.native.test.tsx
+++ b/packages/kit/src/components/NotificationPermissionRecoveryAlert/index.native.test.tsx
@@ -13,6 +13,9 @@ import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
 import { NotificationPermissionRecoveryAlert } from './index.native';
 
 type IMockAlertProps = {
+  action?: {
+    onPrimaryPress?: () => void;
+  };
   title?: string;
 };
 
@@ -195,5 +198,43 @@ describe('NotificationPermissionRecoveryAlert', () => {
       pushEnabled: true,
       source: ENotificationPermissionRecoverySource.settings,
     });
+  });
+
+  it('does not re-check after a recovery action loses focus', async () => {
+    const recoveryDeferred = createDeferred<void>();
+    notificationService.checkNotificationPermissionRecovery.mockResolvedValueOnce(
+      visibleResult,
+    );
+    notificationService.recoverNotificationPermission.mockReturnValueOnce(
+      recoveryDeferred.promise,
+    );
+
+    render(
+      <NotificationPermissionRecoveryAlert scene="home" initialDelayMs={0} />,
+    );
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      mockAlertProps?.action?.onPrimaryPress?.();
+    });
+    expect(
+      notificationService.recoverNotificationPermission,
+    ).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      focusControl.__setFocus(false);
+    });
+    await act(async () => {
+      recoveryDeferred.resolve();
+      await recoveryDeferred.promise;
+      await Promise.resolve();
+    });
+
+    expect(
+      notificationService.checkNotificationPermissionRecovery,
+    ).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/kit/src/components/NotificationPermissionRecoveryAlert/index.native.test.tsx
+++ b/packages/kit/src/components/NotificationPermissionRecoveryAlert/index.native.test.tsx
@@ -1,0 +1,199 @@
+import type { ReactNode } from 'react';
+
+import { act, render } from '@testing-library/react-native';
+
+import {
+  ENotificationPermission,
+  ENotificationPermissionRecoveryReason,
+  ENotificationPermissionRecoverySource,
+} from '@onekeyhq/shared/types/notification';
+
+import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
+
+import { NotificationPermissionRecoveryAlert } from './index.native';
+
+type IMockAlertProps = {
+  title?: string;
+};
+
+let mockAlertProps: IMockAlertProps | undefined;
+
+jest.mock('react-intl', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+jest.mock('@onekeyhq/components', () => {
+  function Alert(props: IMockAlertProps) {
+    mockAlertProps = props;
+    return null;
+  }
+
+  function Stack({ children }: { children?: ReactNode }) {
+    return <>{children}</>;
+  }
+
+  return { Alert, Stack };
+});
+
+jest.mock('@onekeyhq/shared/src/locale', () => ({
+  ETranslations: {
+    backup_go_system_settings: 'backup_go_system_settings',
+    global_enable: 'global_enable',
+    notifications_intro_title: 'notifications_intro_title',
+  },
+}));
+
+jest.mock('@onekeyhq/shared/src/utils/timerUtils', () => ({
+  __esModule: true,
+  default: {
+    wait: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('../../background/instance/backgroundApiProxy', () => ({
+  __esModule: true,
+  default: {
+    serviceNotification: {
+      checkNotificationPermissionRecovery: jest.fn(),
+      dismissNotificationPermissionRecovery: jest.fn(),
+      recoverNotificationPermission: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../hooks/useHandleAppStateActive', () => ({
+  useHandleAppStateActive: jest.fn(),
+}));
+
+jest.mock('../../hooks/useRouteIsFocused', () => {
+  const ReactModule = jest.requireActual<typeof import('react')>('react');
+  let currentFocus = true;
+  const listeners: Array<(value: boolean) => void> = [];
+
+  const useRouteIsFocused = () => {
+    const [isFocused, setIsFocused] =
+      ReactModule.useState<boolean>(currentFocus);
+    ReactModule.useEffect(() => {
+      listeners.push(setIsFocused);
+      return () => {
+        const index = listeners.indexOf(setIsFocused);
+        if (index >= 0) {
+          listeners.splice(index, 1);
+        }
+      };
+    }, [setIsFocused]);
+    return isFocused;
+  };
+
+  return {
+    useRouteIsFocused,
+    __resetFocus: () => {
+      currentFocus = true;
+    },
+    __setFocus: (value: boolean) => {
+      currentFocus = value;
+      listeners.slice().forEach((listener) => listener(value));
+    },
+  };
+});
+
+const focusControl = jest.requireMock('../../hooks/useRouteIsFocused') as {
+  __resetFocus: () => void;
+  __setFocus: (value: boolean) => void;
+};
+
+const notificationService =
+  backgroundApiProxy.serviceNotification as unknown as {
+    checkNotificationPermissionRecovery: jest.Mock;
+    dismissNotificationPermissionRecovery: jest.Mock;
+    recoverNotificationPermission: jest.Mock;
+  };
+
+const visibleResult = {
+  checkedAt: 1,
+  isSupported: true,
+  isTestMode: false,
+  permission: ENotificationPermission.denied,
+  pushEnabled: true,
+  reason: ENotificationPermissionRecoveryReason.permissionRequired,
+  shouldShow: true,
+};
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+describe('NotificationPermissionRecoveryAlert', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    focusControl.__resetFocus();
+    mockAlertProps = undefined;
+    notificationService.dismissNotificationPermissionRecovery.mockResolvedValue(
+      undefined,
+    );
+    notificationService.recoverNotificationPermission.mockResolvedValue(
+      undefined,
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('discards an in-flight check after the route loses focus', async () => {
+    const deferred = createDeferred<typeof visibleResult>();
+    notificationService.checkNotificationPermissionRecovery.mockReturnValueOnce(
+      deferred.promise,
+    );
+
+    render(
+      <NotificationPermissionRecoveryAlert scene="home" initialDelayMs={0} />,
+    );
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(
+      notificationService.checkNotificationPermissionRecovery,
+    ).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      focusControl.__setFocus(false);
+    });
+    await act(async () => {
+      deferred.resolve(visibleResult);
+      await deferred.promise;
+    });
+
+    expect(mockAlertProps).toBeUndefined();
+  });
+
+  it('passes the freshly loaded settings snapshot to the background check', async () => {
+    notificationService.checkNotificationPermissionRecovery.mockResolvedValueOnce(
+      visibleResult,
+    );
+
+    render(
+      <NotificationPermissionRecoveryAlert scene="settings" pushEnabled />,
+    );
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+      await Promise.resolve();
+    });
+
+    expect(
+      notificationService.checkNotificationPermissionRecovery,
+    ).toHaveBeenCalledWith({
+      ignoreCooldown: true,
+      pushEnabled: true,
+      source: ENotificationPermissionRecoverySource.settings,
+    });
+  });
+});

--- a/packages/kit/src/components/NotificationPermissionRecoveryAlert/index.native.tsx
+++ b/packages/kit/src/components/NotificationPermissionRecoveryAlert/index.native.tsx
@@ -1,0 +1,181 @@
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { Alert, Stack } from '@onekeyhq/components';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
+import timerUtils from '@onekeyhq/shared/src/utils/timerUtils';
+import type { INotificationPermissionRecoveryResult } from '@onekeyhq/shared/types/notification';
+import {
+  ENotificationPermission,
+  ENotificationPermissionRecoverySource,
+} from '@onekeyhq/shared/types/notification';
+
+import backgroundApiProxy from '../../background/instance/backgroundApiProxy';
+import { useHandleAppStateActive } from '../../hooks/useHandleAppStateActive';
+import { useRouteIsFocused } from '../../hooks/useRouteIsFocused';
+
+import type { INotificationPermissionRecoveryAlertProps } from './types';
+
+const FOREGROUND_CHECK_DELAY_MS = 500;
+
+function BasicNotificationPermissionRecoveryAlert({
+  scene,
+  initialDelayMs = 0,
+}: INotificationPermissionRecoveryAlertProps) {
+  const intl = useIntl();
+  const isFocused = useRouteIsFocused();
+  const [result, setResult] = useState<INotificationPermissionRecoveryResult>();
+  const [isActionLoading, setIsActionLoading] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+
+  const clearPendingCheck = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = undefined;
+    }
+  }, []);
+
+  const checkPermissionRecovery = useCallback(
+    async ({
+      ignoreCooldown = scene === 'settings',
+      source,
+    }: {
+      ignoreCooldown?: boolean;
+      source: ENotificationPermissionRecoverySource;
+    }) => {
+      try {
+        const nextResult =
+          await backgroundApiProxy.serviceNotification.checkNotificationPermissionRecovery(
+            {
+              ignoreCooldown,
+              source,
+            },
+          );
+        setResult(nextResult);
+        return nextResult;
+      } catch {
+        setResult(undefined);
+        return undefined;
+      }
+    },
+    [scene],
+  );
+
+  const scheduleCheck = useCallback(
+    ({
+      delayMs,
+      source,
+    }: {
+      delayMs: number;
+      source: ENotificationPermissionRecoverySource;
+    }) => {
+      clearPendingCheck();
+      timeoutRef.current = setTimeout(() => {
+        timeoutRef.current = undefined;
+        void checkPermissionRecovery({ source });
+      }, delayMs);
+    },
+    [checkPermissionRecovery, clearPendingCheck],
+  );
+
+  useEffect(() => {
+    if (!isFocused) {
+      clearPendingCheck();
+      setResult(undefined);
+      return undefined;
+    }
+    scheduleCheck({
+      delayMs: initialDelayMs,
+      source:
+        scene === 'home'
+          ? ENotificationPermissionRecoverySource.homeStartup
+          : ENotificationPermissionRecoverySource.settings,
+    });
+    return clearPendingCheck;
+  }, [clearPendingCheck, initialDelayMs, isFocused, scene, scheduleCheck]);
+
+  const handleAppActive = useCallback(() => {
+    if (isFocused) {
+      scheduleCheck({
+        delayMs: FOREGROUND_CHECK_DELAY_MS,
+        source: ENotificationPermissionRecoverySource.appActive,
+      });
+    }
+  }, [isFocused, scheduleCheck]);
+  const appActiveHandlers = useMemo(
+    () => ({ onActiveFromBlur: handleAppActive }),
+    [handleAppActive],
+  );
+  useHandleAppStateActive(handleAppActive, appActiveHandlers);
+
+  const handleClose = useCallback(() => {
+    setResult(undefined);
+    void backgroundApiProxy.serviceNotification
+      .dismissNotificationPermissionRecovery()
+      .catch(() => undefined);
+  }, []);
+
+  const handleRecovery = useCallback(async () => {
+    try {
+      setIsActionLoading(true);
+      await backgroundApiProxy.serviceNotification.recoverNotificationPermission();
+      await timerUtils.wait(300);
+      await checkPermissionRecovery({
+        ignoreCooldown: true,
+        source:
+          scene === 'home'
+            ? ENotificationPermissionRecoverySource.homeStartup
+            : ENotificationPermissionRecoverySource.settings,
+      });
+    } catch {
+      // The background method already displays the user-facing error toast.
+    } finally {
+      setIsActionLoading(false);
+    }
+  }, [checkPermissionRecovery, scene]);
+
+  if (!result?.shouldShow) {
+    return null;
+  }
+
+  const isPermissionDenied =
+    result.permission === ENotificationPermission.denied;
+
+  return (
+    <Stack
+      testID="notification-permission-recovery-alert"
+      pt="$2"
+      px="$pagePadding"
+      bg="$bgApp"
+    >
+      <Alert
+        type="info"
+        icon="BellOutline"
+        title={intl.formatMessage({
+          id: ETranslations.notifications_intro_title,
+        })}
+        closable={scene === 'home'}
+        onClose={handleClose}
+        action={{
+          isPrimaryLoading: isActionLoading,
+          primary: intl.formatMessage({
+            id: isPermissionDenied
+              ? ETranslations.backup_go_system_settings
+              : ETranslations.global_enable,
+          }),
+          primaryTestID: 'notification-permission-recovery-enable',
+          onPrimaryPress: () => {
+            void handleRecovery();
+          },
+        }}
+      />
+    </Stack>
+  );
+}
+
+export const NotificationPermissionRecoveryAlert = memo(
+  BasicNotificationPermissionRecoveryAlert,
+);

--- a/packages/kit/src/components/NotificationPermissionRecoveryAlert/index.native.tsx
+++ b/packages/kit/src/components/NotificationPermissionRecoveryAlert/index.native.tsx
@@ -32,6 +32,7 @@ function BasicNotificationPermissionRecoveryAlert({
     undefined,
   );
   const requestSequenceRef = useRef(0);
+  const isMountedRef = useRef(false);
 
   const clearPendingCheck = useCallback(() => {
     if (timeoutRef.current) {
@@ -98,6 +99,13 @@ function BasicNotificationPermissionRecoveryAlert({
   );
 
   useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
     if (!isFocused) {
       invalidatePendingCheck();
       setResult(undefined);
@@ -136,10 +144,18 @@ function BasicNotificationPermissionRecoveryAlert({
   }, [invalidatePendingCheck]);
 
   const handleRecovery = useCallback(async () => {
+    invalidatePendingCheck();
+    const actionSequence = requestSequenceRef.current;
     try {
       setIsActionLoading(true);
       await backgroundApiProxy.serviceNotification.recoverNotificationPermission();
       await timerUtils.wait(300);
+      if (
+        actionSequence !== requestSequenceRef.current ||
+        !isMountedRef.current
+      ) {
+        return;
+      }
       await checkPermissionRecovery({
         ignoreCooldown: true,
         source:
@@ -150,9 +166,11 @@ function BasicNotificationPermissionRecoveryAlert({
     } catch {
       // The background method already displays the user-facing error toast.
     } finally {
-      setIsActionLoading(false);
+      if (isMountedRef.current) {
+        setIsActionLoading(false);
+      }
     }
-  }, [checkPermissionRecovery, scene]);
+  }, [checkPermissionRecovery, invalidatePendingCheck, scene]);
 
   if (!result?.shouldShow) {
     return null;

--- a/packages/kit/src/components/NotificationPermissionRecoveryAlert/index.native.tsx
+++ b/packages/kit/src/components/NotificationPermissionRecoveryAlert/index.native.tsx
@@ -22,6 +22,7 @@ const FOREGROUND_CHECK_DELAY_MS = 500;
 function BasicNotificationPermissionRecoveryAlert({
   scene,
   initialDelayMs = 0,
+  pushEnabled,
 }: INotificationPermissionRecoveryAlertProps) {
   const intl = useIntl();
   const isFocused = useRouteIsFocused();
@@ -30,6 +31,7 @@ function BasicNotificationPermissionRecoveryAlert({
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
+  const requestSequenceRef = useRef(0);
 
   const clearPendingCheck = useCallback(() => {
     if (timeoutRef.current) {
@@ -37,6 +39,11 @@ function BasicNotificationPermissionRecoveryAlert({
       timeoutRef.current = undefined;
     }
   }, []);
+
+  const invalidatePendingCheck = useCallback(() => {
+    requestSequenceRef.current += 1;
+    clearPendingCheck();
+  }, [clearPendingCheck]);
 
   const checkPermissionRecovery = useCallback(
     async ({
@@ -46,22 +53,31 @@ function BasicNotificationPermissionRecoveryAlert({
       ignoreCooldown?: boolean;
       source: ENotificationPermissionRecoverySource;
     }) => {
+      const requestSequence = requestSequenceRef.current + 1;
+      requestSequenceRef.current = requestSequence;
       try {
         const nextResult =
           await backgroundApiProxy.serviceNotification.checkNotificationPermissionRecovery(
             {
               ignoreCooldown,
+              pushEnabled,
               source,
             },
           );
+        if (requestSequence !== requestSequenceRef.current) {
+          return undefined;
+        }
         setResult(nextResult);
         return nextResult;
       } catch {
+        if (requestSequence !== requestSequenceRef.current) {
+          return undefined;
+        }
         setResult(undefined);
         return undefined;
       }
     },
-    [scene],
+    [pushEnabled, scene],
   );
 
   const scheduleCheck = useCallback(
@@ -72,18 +88,18 @@ function BasicNotificationPermissionRecoveryAlert({
       delayMs: number;
       source: ENotificationPermissionRecoverySource;
     }) => {
-      clearPendingCheck();
+      invalidatePendingCheck();
       timeoutRef.current = setTimeout(() => {
         timeoutRef.current = undefined;
         void checkPermissionRecovery({ source });
       }, delayMs);
     },
-    [checkPermissionRecovery, clearPendingCheck],
+    [checkPermissionRecovery, invalidatePendingCheck],
   );
 
   useEffect(() => {
     if (!isFocused) {
-      clearPendingCheck();
+      invalidatePendingCheck();
       setResult(undefined);
       return undefined;
     }
@@ -94,8 +110,8 @@ function BasicNotificationPermissionRecoveryAlert({
           ? ENotificationPermissionRecoverySource.homeStartup
           : ENotificationPermissionRecoverySource.settings,
     });
-    return clearPendingCheck;
-  }, [clearPendingCheck, initialDelayMs, isFocused, scene, scheduleCheck]);
+    return invalidatePendingCheck;
+  }, [initialDelayMs, invalidatePendingCheck, isFocused, scene, scheduleCheck]);
 
   const handleAppActive = useCallback(() => {
     if (isFocused) {
@@ -112,11 +128,12 @@ function BasicNotificationPermissionRecoveryAlert({
   useHandleAppStateActive(handleAppActive, appActiveHandlers);
 
   const handleClose = useCallback(() => {
+    invalidatePendingCheck();
     setResult(undefined);
     void backgroundApiProxy.serviceNotification
       .dismissNotificationPermissionRecovery()
       .catch(() => undefined);
-  }, []);
+  }, [invalidatePendingCheck]);
 
   const handleRecovery = useCallback(async () => {
     try {

--- a/packages/kit/src/components/NotificationPermissionRecoveryAlert/index.tsx
+++ b/packages/kit/src/components/NotificationPermissionRecoveryAlert/index.tsx
@@ -1,0 +1,7 @@
+import type { INotificationPermissionRecoveryAlertProps } from './types';
+
+export function NotificationPermissionRecoveryAlert(
+  _props: INotificationPermissionRecoveryAlertProps,
+) {
+  return null;
+}

--- a/packages/kit/src/components/NotificationPermissionRecoveryAlert/types.ts
+++ b/packages/kit/src/components/NotificationPermissionRecoveryAlert/types.ts
@@ -1,4 +1,5 @@
 export type INotificationPermissionRecoveryAlertProps = {
   scene: 'home' | 'settings';
   initialDelayMs?: number;
+  pushEnabled?: boolean;
 };

--- a/packages/kit/src/components/NotificationPermissionRecoveryAlert/types.ts
+++ b/packages/kit/src/components/NotificationPermissionRecoveryAlert/types.ts
@@ -1,0 +1,4 @@
+export type INotificationPermissionRecoveryAlertProps = {
+  scene: 'home' | 'settings';
+  initialDelayMs?: number;
+};

--- a/packages/kit/src/views/Home/pages/HomePageView.tsx
+++ b/packages/kit/src/views/Home/pages/HomePageView.tsx
@@ -49,6 +49,7 @@ import backgroundApiProxy from '../../../background/instance/backgroundApiProxy'
 import { EmptyAccount, EmptyWallet } from '../../../components/Empty';
 import { NetworkAlert } from '../../../components/NetworkAlert';
 import { NotificationEnableAlert } from '../../../components/NotificationEnableAlert';
+import { NotificationPermissionRecoveryAlert } from '../../../components/NotificationPermissionRecoveryAlert';
 import { RiskApprovalAlert } from '../../../components/RiskApprovalAlert';
 import { TabPageHeader } from '../../../components/TabPageHeader';
 import { WatchOnlyAlert } from '../../../components/WatchOnlyAlert';
@@ -1125,6 +1126,10 @@ export function HomePageView({
               <RiskApprovalAlert />
               <WatchOnlyAlert />
               <NetworkAlert />
+              <NotificationPermissionRecoveryAlert
+                scene="home"
+                initialDelayMs={6000}
+              />
             </Stack>
             {content}
             {platformEnv.isNative ? (

--- a/packages/kit/src/views/Setting/pages/Notifications/NotificationsSettings.tsx
+++ b/packages/kit/src/views/Setting/pages/Notifications/NotificationsSettings.tsx
@@ -16,6 +16,7 @@ import {
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { ListItem } from '@onekeyhq/kit/src/components/ListItem';
 import { MultipleClickStack } from '@onekeyhq/kit/src/components/MultipleClickStack';
+import { NotificationPermissionRecoveryAlert } from '@onekeyhq/kit/src/components/NotificationPermissionRecoveryAlert';
 import { showNotificationPermissionsDialog } from '@onekeyhq/kit/src/components/PermissionsDialog';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
@@ -193,6 +194,10 @@ export default function NotificationsSettings() {
                 }}
               />
             </ListItem>
+
+            {settings?.pushEnabled ? (
+              <NotificationPermissionRecoveryAlert scene="settings" />
+            ) : null}
 
             {settings?.pushEnabled ? (
               <>

--- a/packages/kit/src/views/Setting/pages/Notifications/NotificationsSettings.tsx
+++ b/packages/kit/src/views/Setting/pages/Notifications/NotificationsSettings.tsx
@@ -196,7 +196,10 @@ export default function NotificationsSettings() {
             </ListItem>
 
             {settings?.pushEnabled ? (
-              <NotificationPermissionRecoveryAlert scene="settings" />
+              <NotificationPermissionRecoveryAlert
+                scene="settings"
+                pushEnabled={settings.pushEnabled}
+              />
             ) : null}
 
             {settings?.pushEnabled ? (

--- a/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/NotificationDevSettings.tsx
+++ b/packages/kit/src/views/Setting/pages/Tab/DevSettingsSection/NotificationDevSettings.tsx
@@ -1,13 +1,22 @@
 import type { PropsWithChildren, ReactElement } from 'react';
-import { Children, cloneElement, useCallback } from 'react';
+import {
+  Children,
+  cloneElement,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 
 import type { IPropsWithTestId } from '@onekeyhq/components';
 import {
   Button,
   ESwitchSize,
+  Select,
+  SizableText,
   Stack,
   Switch,
   Toast,
+  YStack,
 } from '@onekeyhq/components';
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import type { IListItemProps } from '@onekeyhq/kit/src/components/ListItem';
@@ -17,6 +26,12 @@ import {
   useNotificationsAtom,
   useNotificationsDevSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import type { INotificationPermissionRecoveryResult } from '@onekeyhq/shared/types/notification';
+import {
+  ENotificationPermissionRecoverySource,
+  ENotificationPermissionRecoveryTestScenario,
+} from '@onekeyhq/shared/types/notification';
 
 interface INotificationSectionFieldItem extends PropsWithChildren {
   name?: INotificationsDevSettingsKeys;
@@ -24,6 +39,37 @@ interface INotificationSectionFieldItem extends PropsWithChildren {
   titleProps?: IListItemProps['titleProps'];
   onValueChange?: (v: any) => void;
 }
+
+const permissionRecoveryScenarioOptions = [
+  {
+    label: 'Real system',
+    value: ENotificationPermissionRecoveryTestScenario.real,
+  },
+  {
+    label: 'Push ON + Granted',
+    value: ENotificationPermissionRecoveryTestScenario.pushOnGranted,
+  },
+  {
+    label: 'Push ON + Default',
+    value: ENotificationPermissionRecoveryTestScenario.pushOnDefault,
+  },
+  {
+    label: 'Push ON + Denied',
+    value: ENotificationPermissionRecoveryTestScenario.pushOnDenied,
+  },
+  {
+    label: 'Push OFF',
+    value: ENotificationPermissionRecoveryTestScenario.pushOff,
+  },
+  {
+    label: 'Unsupported',
+    value: ENotificationPermissionRecoveryTestScenario.unsupported,
+  },
+  {
+    label: 'Permission query failed',
+    value: ENotificationPermissionRecoveryTestScenario.queryFailed,
+  },
+];
 
 function NotificationSectionFieldItem({
   name,
@@ -61,6 +107,76 @@ function NotificationSectionFieldItem({
 
 export function NotificationDevSettings() {
   const [, setData] = useNotificationsAtom();
+  const [permissionRecoveryScenario, setPermissionRecoveryScenario] = useState(
+    ENotificationPermissionRecoveryTestScenario.real,
+  );
+  const [permissionRecoveryResult, setPermissionRecoveryResult] =
+    useState<INotificationPermissionRecoveryResult>();
+
+  useEffect(() => {
+    if (!platformEnv.isNative) {
+      return;
+    }
+    void backgroundApiProxy.serviceNotification
+      .getNotificationPermissionRecoveryTestScenario()
+      .then(setPermissionRecoveryScenario)
+      .catch(() => undefined);
+  }, []);
+
+  const runPermissionRecoveryCheck = useCallback(async () => {
+    const result =
+      await backgroundApiProxy.serviceNotification.checkNotificationPermissionRecovery(
+        {
+          ignoreCooldown: true,
+          source: ENotificationPermissionRecoverySource.qaManual,
+        },
+      );
+    setPermissionRecoveryResult(result);
+    return result;
+  }, []);
+
+  const handlePermissionRecoveryScenarioChange = useCallback(
+    async (scenario: ENotificationPermissionRecoveryTestScenario) => {
+      try {
+        await backgroundApiProxy.serviceNotification.setNotificationPermissionRecoveryTestScenario(
+          scenario,
+        );
+        await backgroundApiProxy.serviceNotification.resetNotificationPermissionRecoveryState();
+        setPermissionRecoveryScenario(scenario);
+        const result = await runPermissionRecoveryCheck();
+        Toast.success({
+          title: 'Permission recovery scenario applied',
+          message: `${result.reason}: shouldShow=${String(result.shouldShow)}`,
+        });
+      } catch (error) {
+        Toast.error({
+          title: 'Failed to apply permission recovery scenario',
+          message: String(error),
+        });
+      }
+    },
+    [runPermissionRecoveryCheck],
+  );
+
+  const handleResetPermissionRecovery = useCallback(async () => {
+    try {
+      await backgroundApiProxy.serviceNotification.setNotificationPermissionRecoveryTestScenario(
+        ENotificationPermissionRecoveryTestScenario.real,
+      );
+      await backgroundApiProxy.serviceNotification.resetNotificationPermissionRecoveryState();
+      setPermissionRecoveryScenario(
+        ENotificationPermissionRecoveryTestScenario.real,
+      );
+      setPermissionRecoveryResult(undefined);
+      Toast.success({ title: 'Permission recovery state reset' });
+    } catch (error) {
+      Toast.error({
+        title: 'Failed to reset permission recovery state',
+        message: String(error),
+      });
+    }
+  }, []);
+
   return (
     <Stack>
       <NotificationSectionFieldItem
@@ -131,6 +247,58 @@ export function NotificationDevSettings() {
       >
         重置每日同步账户时间戳
       </Button>
+
+      {platformEnv.isNative ? (
+        <YStack gap="$3" py="$4">
+          <SizableText size="$headingSm">
+            Notification Permission Recovery QA
+          </SizableText>
+          <SizableText size="$bodySm" color="$textSubdued">
+            Apply a scenario, return to Home, and wait 6 seconds. Test mode
+            never opens system settings or registers a real push client.
+          </SizableText>
+          <Select
+            testID="notification-permission-recovery-scenario"
+            title="Permission Recovery Scenario"
+            items={permissionRecoveryScenarioOptions}
+            value={permissionRecoveryScenario}
+            onChange={(value) => {
+              void handlePermissionRecoveryScenarioChange(value);
+            }}
+          />
+          <Button
+            testID="notification-permission-recovery-check-now"
+            onPress={() => {
+              void runPermissionRecoveryCheck().catch((error) => {
+                Toast.error({
+                  title: 'Permission recovery check failed',
+                  message: String(error),
+                });
+              });
+            }}
+          >
+            Run Recovery Check Now
+          </Button>
+          <Button
+            testID="notification-permission-recovery-reset"
+            variant="secondary"
+            onPress={() => {
+              void handleResetPermissionRecovery();
+            }}
+          >
+            Restore Real System and Reset State
+          </Button>
+          {permissionRecoveryResult ? (
+            <SizableText
+              testID="notification-permission-recovery-result"
+              size="$bodySm"
+              color="$textSubdued"
+            >
+              {JSON.stringify(permissionRecoveryResult, null, 2)}
+            </SizableText>
+          ) : null}
+        </YStack>
+      ) : null}
     </Stack>
   );
 }

--- a/packages/shared/src/logger/scopes/notification/scenes/common.ts
+++ b/packages/shared/src/logger/scopes/notification/scenes/common.ts
@@ -2,6 +2,8 @@ import { devOnlyData } from '@onekeyhq/shared/src/utils/devModeUtils';
 import type {
   ENotificationPushTopicTypes,
   INotificationPermissionDetail,
+  INotificationPermissionRecoveryActionResult,
+  INotificationPermissionRecoveryResult,
   INotificationPushMessageAckParams,
   INotificationPushMessageInfo,
   INotificationPushRegisterParams,
@@ -143,5 +145,25 @@ export class CommonScene extends BaseScene {
   @LogToLocal()
   getPermission(params: INotificationPermissionDetail) {
     return [params.permission, params.isSupported];
+  }
+
+  @LogToLocal()
+  permissionRecoveryCheck(
+    params: INotificationPermissionRecoveryResult & {
+      platform: 'ios' | 'android' | 'other';
+      source: string;
+    },
+  ) {
+    return params;
+  }
+
+  @LogToLocal()
+  permissionRecoveryAction(
+    params: INotificationPermissionRecoveryActionResult & {
+      permissionBefore: INotificationPermissionDetail['permission'];
+      platform: 'ios' | 'android' | 'other';
+    },
+  ) {
+    return params;
   }
 }

--- a/packages/shared/src/logger/scopes/notification/scenes/common.ts
+++ b/packages/shared/src/logger/scopes/notification/scenes/common.ts
@@ -151,6 +151,7 @@ export class CommonScene extends BaseScene {
   permissionRecoveryCheck(
     params: INotificationPermissionRecoveryResult & {
       platform: 'ios' | 'android' | 'other';
+      registrationFailed: boolean;
       source: string;
     },
   ) {

--- a/packages/shared/types/notification.ts
+++ b/packages/shared/types/notification.ts
@@ -73,6 +73,7 @@ export enum ENotificationPermissionRecoveryTestScenario {
 export type INotificationPermissionRecoveryCheckParams = {
   source: ENotificationPermissionRecoverySource;
   ignoreCooldown?: boolean;
+  pushEnabled?: boolean;
 };
 
 export type INotificationPermissionRecoveryResult = {

--- a/packages/shared/types/notification.ts
+++ b/packages/shared/types/notification.ts
@@ -35,6 +35,62 @@ export type INotificationPermissionDetail = {
   permission: ENotificationPermission;
   isSupported: boolean;
 };
+
+export enum ENotificationPermissionRecoverySource {
+  homeStartup = 'homeStartup',
+  appActive = 'appActive',
+  settings = 'settings',
+  qaManual = 'qaManual',
+}
+
+export enum ENotificationPermissionRecoveryReason {
+  permissionRequired = 'permissionRequired',
+  permissionGranted = 'permissionGranted',
+  permissionUnsupported = 'permissionUnsupported',
+  pushDisabled = 'pushDisabled',
+  cooldown = 'cooldown',
+  serverSettingsUnavailable = 'serverSettingsUnavailable',
+  queryFailed = 'queryFailed',
+  nonNative = 'nonNative',
+}
+
+export enum ENotificationPermissionRecoveryAction {
+  none = 'none',
+  requestPermission = 'requestPermission',
+  openSettings = 'openSettings',
+}
+
+export enum ENotificationPermissionRecoveryTestScenario {
+  real = 'real',
+  pushOnGranted = 'pushOnGranted',
+  pushOnDefault = 'pushOnDefault',
+  pushOnDenied = 'pushOnDenied',
+  pushOff = 'pushOff',
+  unsupported = 'unsupported',
+  queryFailed = 'queryFailed',
+}
+
+export type INotificationPermissionRecoveryCheckParams = {
+  source: ENotificationPermissionRecoverySource;
+  ignoreCooldown?: boolean;
+};
+
+export type INotificationPermissionRecoveryResult = {
+  shouldShow: boolean;
+  reason: ENotificationPermissionRecoveryReason;
+  permission: ENotificationPermission | undefined;
+  isSupported: boolean | undefined;
+  pushEnabled: boolean | undefined;
+  isTestMode: boolean;
+  checkedAt: number;
+};
+
+export type INotificationPermissionRecoveryActionResult = {
+  action: ENotificationPermissionRecoveryAction;
+  permission: ENotificationPermission;
+  isSupported: boolean;
+  isTestMode: boolean;
+};
 export type INotificationSetBadgeParams = {
   // null: clear badge
   // undefined: dot badge


### PR DESCRIPTION
## Summary

- Detect iOS and Android cases where server-side push remains enabled but the OS notification permission is no longer granted.
- Show a non-blocking recovery alert after Home has been stable for 6 seconds, re-check after returning to the foreground, and show the same guidance immediately in Notification Settings.
- Request permission for the default state, open system notification settings for the denied state, and re-register the push client after permission is restored.
- Add deterministic Dev Settings scenarios and local structured logs for QA and troubleshooting.

## Root cause

The in-app push switch reflects the server notification preference, but it did not reconcile that state with the current iOS/Android notification authorization. After an OS upgrade removes or resets the system permission entry, push can therefore remain enabled in the app while delivery is unavailable.

## User impact

Affected users receive an unobtrusive recovery prompt instead of needing to toggle push off and on. Dismissing the Home prompt applies a 24-hour cooldown, while the Notification Settings page remains available for immediate recovery.

## QA

In Dev Settings, use **Notification Permission Recovery QA** to select a scenario, return to Home, and wait 6 seconds. Test mode does not open real system settings or register a real push client.

Covered scenarios:

- Push ON + Granted
- Push ON + Default
- Push ON + Denied
- Push OFF
- Unsupported
- Permission query failed

## Validation

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- `yarn tsc:only --pretty false`
- Focused ESLint checks for all changed files
- `yarn jest packages/kit-bg/src/services/ServiceNotification/notificationPermissionRecovery.test.ts --runInBand` (8 tests passed)

Real-device iOS/Android interaction verification is left for QA.