### PR TITLE
fix: stabilize Market quote and Stock metadata flows (OK-60467, OK-60471)

### DIFF
--- a/packages/kit-bg/src/services/ServiceSwap.quoteEvents.test.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.quoteEvents.test.ts
@@ -40,7 +40,10 @@ jest.mock('@onekeyhq/shared/src/request/customUA', () => ({
 }));
 
 import type { ISwapToken } from '@onekeyhq/shared/types/swap/types';
-import { ESwapTabSwitchType } from '@onekeyhq/shared/types/swap/types';
+import {
+  ESwapQuoteSource,
+  ESwapTabSwitchType,
+} from '@onekeyhq/shared/types/swap/types';
 
 import ServiceSwap from './ServiceSwap';
 
@@ -68,11 +71,12 @@ function createService() {
       },
     },
   });
+  const getUri = jest.fn(() => 'https://example.com/swap/v1/quote/events');
   jest.spyOn(service, 'getDenySingleSwapProvider').mockResolvedValue(undefined);
   jest.spyOn(service, 'getClient').mockResolvedValue({
-    getUri: jest.fn(() => 'https://example.com/swap/v1/quote/events'),
+    getUri,
   } as never);
-  return service;
+  return { getUri, service };
 }
 
 function createQuoteParams(quoteRequestId: string) {
@@ -107,7 +111,7 @@ describe('ServiceSwap quote event request ownership', () => {
   });
 
   it('keeps independently owned quote streams active', async () => {
-    const service = createService();
+    const { service } = createService();
     let resolveFirstPreparation: ((value: undefined) => void) | undefined;
     const firstPreparation = new Promise<undefined>((resolve) => {
       resolveFirstPreparation = resolve;
@@ -141,7 +145,7 @@ describe('ServiceSwap quote event request ownership', () => {
   });
 
   it('cancels a request while it is still preparing without affecting another request', async () => {
-    const service = createService();
+    const { service } = createService();
     let resolveFirstPreparation: ((value: undefined) => void) | undefined;
     const firstPreparation = new Promise<undefined>((resolve) => {
       resolveFirstPreparation = resolve;
@@ -164,5 +168,24 @@ describe('ServiceSwap quote event request ownership', () => {
     expect(globalMockBag.__swapQuoteEventSources).toHaveLength(1);
     const activeEventSource = globalMockBag.__swapQuoteEventSources?.[0];
     expect(activeEventSource?.close).not.toHaveBeenCalled();
+  });
+
+  it('forwards the Market source to the quote event request', async () => {
+    const { getUri, service } = createService();
+
+    await service.fetchQuotesEvents({
+      ...createQuoteParams('market-quote-request'),
+      source: ESwapQuoteSource.MARKET,
+    });
+
+    expect(getUri).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: '/swap/v1/quote/events',
+        params: expect.objectContaining({
+          source: 'Market',
+        }),
+      }),
+    );
+    await service.cancelFetchQuoteEvents('market-quote-request');
   });
 });

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -1142,6 +1142,7 @@ export default class ServiceSwap extends ServiceBase {
   @backgroundMethod()
   @toastIfError()
   async fetchQuotesEvents({
+    source,
     fromToken,
     toToken,
     fromTokenAmount,
@@ -1178,6 +1179,7 @@ export default class ServiceSwap extends ServiceBase {
         accountId: accountId ?? '',
       });
     const params: IFetchQuotesParams = {
+      source,
       fromTokenAddress: fromToken.contractAddress,
       toTokenAddress: toToken.contractAddress,
       fromTokenAmount,

--- a/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.test.tsx
@@ -42,6 +42,7 @@ import {
   ESwapAlertLevel,
   ESwapDirectionType,
   ESwapQuoteKind,
+  ESwapQuoteSource,
   ESwapSlippageSegmentKey,
   ESwapTabSwitchType,
 } from '@onekeyhq/shared/types/swap/types';
@@ -2040,7 +2041,7 @@ describe('useSwapActions', () => {
     );
   });
 
-  it('rearms automatic quote refresh from quote events without remounting the UI', async () => {
+  it('rearms automatic quote refresh and preserves its Market source', async () => {
     jest.useFakeTimers();
     try {
       const approvedBlockNumber = 123_456;
@@ -2057,6 +2058,7 @@ describe('useSwapActions', () => {
         wrapper: Wrapper,
       });
       const quoteParams: IFetchQuotesParams = {
+        source: ESwapQuoteSource.MARKET,
         autoSlippage: true,
         blockNumber: approvedBlockNumber,
         fromNetworkId: ethToken.networkId,
@@ -2076,6 +2078,16 @@ describe('useSwapActions', () => {
           approvedBlockNumber,
           undefined,
           ESwapQuoteKind.SELL,
+          undefined,
+          undefined,
+          undefined,
+          {
+            fromToken: ethToken,
+            toToken: bnbToken,
+            fromTokenAmount: '1',
+            type: ESwapTabSwitchType.SWAP,
+            source: ESwapQuoteSource.MARKET,
+          },
         );
         await Promise.resolve();
       });
@@ -2083,6 +2095,7 @@ describe('useSwapActions', () => {
       expect(mockFetchQuotesEvents).toHaveBeenLastCalledWith(
         expect.objectContaining({
           blockNumber: approvedBlockNumber,
+          source: ESwapQuoteSource.MARKET,
         }),
       );
 
@@ -2139,6 +2152,7 @@ describe('useSwapActions', () => {
         expect(mockFetchQuotesEvents).toHaveBeenLastCalledWith(
           expect.objectContaining({
             blockNumber: undefined,
+            source: ESwapQuoteSource.MARKET,
           }),
         );
         expect(store.get(swapQuoteIntervalCountAtom())).toBe(round + 1);

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -1760,6 +1760,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       set(swapQuoteActionLockAtom(), (v) => ({
         ...v,
         type: swapTabSwitchType,
+        source: quoteOverride?.source,
         actionLock: true,
         fromToken,
         toToken,

--- a/packages/kit/src/states/jotai/contexts/swap/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/actions.ts
@@ -56,6 +56,7 @@ import {
   swapTokenCatchMapMaxCount,
 } from '@onekeyhq/shared/types/swap/SwapProvider.constants';
 import type {
+  ESwapQuoteSource,
   IFetchQuoteResult,
   IFetchQuotesParams,
   IFetchTokensParams,
@@ -325,6 +326,7 @@ type ISwapQuoteActionOverride = {
   fromTokenAmount: string;
   toTokenAmount?: string;
   type: ESwapTabSwitchType;
+  source?: ESwapQuoteSource;
 };
 
 function isQuoteEventProtocolForCurrentSwapType({
@@ -627,6 +629,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
             fromTokenAmount: event.params.fromTokenAmount ?? '',
             toTokenAmount: event.params.toTokenAmount,
             type: activeSwapType,
+            source: event.params.source,
           },
         );
       }, swapRefreshInterval);
@@ -1495,6 +1498,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       incognito?: boolean,
       quoteRequestId?: string,
       protocolOverride?: ESwapTabSwitchType,
+      source?: ESwapQuoteSource,
     ) => {
       const shouldRefreshQuote = get(swapShouldRefreshQuoteAtom());
       const protocol = protocolOverride ?? get(swapTypeSwitchAtom());
@@ -1558,6 +1562,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
       });
       try {
         await backgroundApiProxy.serviceSwap.fetchQuotesEvents({
+          source,
           fromToken,
           toToken,
           fromTokenAmount,
@@ -1782,6 +1787,7 @@ class ContentJotaiActionsSwap extends ContextJotaiActionsBase {
         incognito,
         quoteRequestId,
         swapTabSwitchType,
+        quoteOverride?.source,
       );
     },
   );

--- a/packages/kit/src/states/jotai/contexts/swap/atoms.ts
+++ b/packages/kit/src/states/jotai/contexts/swap/atoms.ts
@@ -37,6 +37,7 @@ import {
   ESwapNetworkFeeLevel,
   ESwapProTradeType,
   type ESwapQuoteKind,
+  ESwapQuoteSource,
   type ESwapRateDifferenceUnit,
   type ESwapSlippageSegmentKey,
   ESwapTabSwitchType,
@@ -382,6 +383,7 @@ export const {
   use: useSwapQuoteActionLockAtom,
 } = contextAtom<{
   type?: ESwapTabSwitchType;
+  source?: ESwapQuoteSource;
   actionLock: boolean;
   fromToken?: ISwapToken;
   toToken?: ISwapToken;
@@ -501,7 +503,8 @@ export const {
     currentEventProviderKeys,
     quoteEventCompleted,
     deferNonActionableQuoteUntilEventSettled:
-      activeSwapType === ESwapTabSwitchType.STOCK,
+      activeSwapType === ESwapTabSwitchType.STOCK ||
+      quoteActionLock.source === ESwapQuoteSource.MARKET,
   });
 });
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
@@ -10,14 +10,25 @@ import {
 import BigNumber from 'bignumber.js';
 import { createStore } from 'jotai';
 
-import { ProviderJotaiContextSwap } from '@onekeyhq/kit/src/states/jotai/contexts/swap/atoms';
-import type { ISwapReviewGasInfoEntry } from '@onekeyhq/kit/src/views/Swap/utils/swapReviewState';
+import {
+  ProviderJotaiContextSwap,
+  swapQuoteActionLockAtom,
+  swapQuoteEventCompletedAtom,
+  swapQuoteFetchingAtom,
+  swapQuoteListAtom,
+} from '@onekeyhq/kit/src/states/jotai/contexts/swap/atoms';
+import type {
+  ISwapReviewGasInfoEntry,
+  ISwapReviewState,
+} from '@onekeyhq/kit/src/views/Swap/utils/swapReviewState';
 import { OneKeyError, OneKeyLocalError } from '@onekeyhq/shared/src/errors';
 import {
   EAppEventBusNames,
   appEventBus,
 } from '@onekeyhq/shared/src/eventBus/appEventBus';
 import type {
+  IFetchBuildTxResponse,
+  IFetchQuoteResult,
   ISwapToken,
   ISwapTokenBase,
   ISwapTxInfo,
@@ -25,6 +36,7 @@ import type {
 import {
   EProtocolOfExchange,
   ESwapQuoteSource,
+  ESwapStepType,
   ESwapTxHistoryStatus,
 } from '@onekeyhq/shared/types/swap/types';
 
@@ -79,6 +91,9 @@ const mockFetchSwapNativeTokenConfig: jest.MockedFunction<
 const mockFetchQuotesEvents: jest.MockedFunction<
   (params: unknown) => Promise<void>
 > = jest.fn();
+const mockFetchBuildTx: jest.MockedFunction<
+  (params: unknown) => Promise<IFetchBuildTxResponse | undefined>
+> = jest.fn();
 const mockCloseApproving: jest.MockedFunction<() => Promise<void>> = jest.fn();
 const mockCancelFetchQuoteEvents: jest.MockedFunction<
   (quoteRequestId?: string) => Promise<void>
@@ -120,6 +135,7 @@ let mockCurrencyInfo = {
   id: 'usd',
   symbol: '$',
 };
+let mockSwapStore: ReturnType<typeof createStore>;
 
 jest.mock('react-intl', () => ({
   useIntl: () => ({
@@ -136,6 +152,7 @@ jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
       fetchSwapNativeTokenConfig: (params: IFetchSwapNativeTokenConfigParams) =>
         mockFetchSwapNativeTokenConfig(params),
       fetchQuotesEvents: (params: unknown) => mockFetchQuotesEvents(params),
+      fetchBuildTx: (params: unknown) => mockFetchBuildTx(params),
       closeApproving: () => mockCloseApproving(),
       cancelFetchQuoteEvents: (quoteRequestId?: string) =>
         mockCancelFetchQuoteEvents(quoteRequestId),
@@ -365,7 +382,11 @@ function createHookProps({
 }
 
 function SwapContextWrapper({ children }: { children?: ReactNode }) {
-  const store = useMemo(() => createStore(), []);
+  const store = useMemo(() => {
+    const nextStore = createStore();
+    mockSwapStore = nextStore;
+    return nextStore;
+  }, []);
   return (
     <ProviderJotaiContextSwap store={store}>
       {children}
@@ -417,6 +438,7 @@ describe('useSpeedSwapActions', () => {
     mockFetchSwapNativeTokenConfig.mockReset();
     mockFetchQuotesEvents.mockReset();
     mockFetchQuotesEvents.mockResolvedValue();
+    mockFetchBuildTx.mockReset();
     mockCloseApproving.mockReset();
     mockCloseApproving.mockResolvedValue();
     mockCancelFetchQuoteEvents.mockReset();
@@ -596,6 +618,74 @@ describe('useSpeedSwapActions', () => {
     await waitFor(() => {
       expect(mockFetchQuotesEvents).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it('opens signed quote review without building before the signature', async () => {
+    mockFetchSwapTokenDetails.mockImplementation(({ accountId }) =>
+      Promise.resolve(
+        accountId ? createTokenDetail({ balanceParsed: '100' }) : [],
+      ),
+    );
+
+    const { result } = renderSwapHook(() =>
+      useSpeedSwapActions({
+        ...createHookProps(),
+        fromTokenAmount: '1',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockFetchQuotesEvents).toHaveBeenCalledTimes(1);
+      expect(result.current.fetchBalanceLoading).toBe(false);
+    });
+
+    const quoteRequest = mockSwapStore.get(swapQuoteActionLockAtom());
+    const signedQuote: IFetchQuoteResult = {
+      protocol: EProtocolOfExchange.SWAP,
+      info: {
+        provider: 'oneInchFusion',
+        providerName: '1inch Fusion',
+      },
+      fromTokenInfo: quoteRequest.fromToken ?? usdcToken,
+      toTokenInfo: quoteRequest.toToken ?? btcToken,
+      fromAmount: '1',
+      toAmount: '0.00001',
+      swapShouldSignedData: {
+        unSignedInfo: {
+          origin: 'https://app.onekey.so',
+          scope: 'swap',
+          signedType: 'eth_signTypedData_v4' as never,
+        },
+        oneInchFusionOrder: {
+          makerAddress: '0xuser',
+          typedData: {} as never,
+        },
+      },
+    };
+
+    act(() => {
+      mockSwapStore.set(swapQuoteListAtom(), [signedQuote]);
+      mockSwapStore.set(swapQuoteFetchingAtom(), false);
+      mockSwapStore.set(swapQuoteEventCompletedAtom(), true);
+      mockSwapStore.set(swapQuoteActionLockAtom(), {
+        ...quoteRequest,
+        actionLock: false,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.quoteReadyForReview).toBe(true);
+    });
+
+    let reviewState: ISwapReviewState | undefined;
+    await act(async () => {
+      reviewState = await result.current.prepareMarketSwapReview();
+    });
+
+    expect(mockFetchBuildTx).not.toHaveBeenCalled();
+    expect(reviewState?.steps.map((step) => step.type)).toEqual([
+      ESwapStepType.SIGN_MESSAGE,
+    ]);
   });
 
   it('clears a previous token balance while the next balance is loading', async () => {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.test.tsx
@@ -24,6 +24,7 @@ import type {
 } from '@onekeyhq/shared/types/swap/types';
 import {
   EProtocolOfExchange,
+  ESwapQuoteSource,
   ESwapTxHistoryStatus,
 } from '@onekeyhq/shared/types/swap/types';
 
@@ -586,6 +587,9 @@ describe('useSpeedSwapActions', () => {
     await waitFor(() => {
       expect(mockFetchQuotesEvents).toHaveBeenCalledTimes(1);
     });
+    expect(mockFetchQuotesEvents).toHaveBeenLastCalledWith(
+      expect.objectContaining({ source: ESwapQuoteSource.MARKET }),
+    );
 
     rerender({ stockIsOpen: true });
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -1138,6 +1138,46 @@ export function useSpeedSwapActions(props: {
         );
       }
 
+      if (selectedQuote.swapShouldSignedData) {
+        const reviewBuildRes: IFetchBuildTxResponse = {
+          ...(selectedQuote.quoteId ? { orderId: selectedQuote.quoteId } : {}),
+          result: {
+            ...selectedQuote,
+            slippage: selectedQuote.slippage ?? slippage,
+          },
+        };
+        const swapInfo: ISwapTxInfo = {
+          protocol: selectedQuote.protocol ?? EProtocolOfExchange.SWAP,
+          sender: {
+            amount: selectedQuote.fromAmount ?? amount,
+            token: fromTokenFinal,
+            accountInfo: {
+              accountId: netAccountRes.result.id,
+              networkId: fromTokenFinal.networkId,
+            },
+          },
+          receiver: {
+            amount: selectedQuote.toAmount,
+            token: toTokenFinal,
+            accountInfo: {
+              accountId: netAccountRes.result.id,
+              networkId: toTokenFinal.networkId,
+            },
+          },
+          accountAddress: userAddress,
+          receivingAddress: userAddress,
+          swapBuildResData: reviewBuildRes,
+        };
+
+        return {
+          buildRes: reviewBuildRes,
+          encodedTx: undefined,
+          transferInfo: undefined,
+          swapInfo,
+          userAddress,
+        };
+      }
+
       setSpeedSwapBuildTxLoading(true);
       try {
         const buildRes = await backgroundApiProxy.serviceSwap.fetchBuildTx({

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -120,6 +120,7 @@ import {
   ESwapFetchCancelCause,
   ESwapNetworkFeeLevel,
   ESwapQuoteKind,
+  ESwapQuoteSource,
   ESwapSlippageSegmentKey,
   ESwapTabSwitchType,
   ESwapTradeSource,
@@ -730,12 +731,23 @@ export function useSpeedSwapActions(props: {
       ESwapQuoteKind.SELL,
       true,
       userAddress,
+      undefined,
+      {
+        fromToken,
+        toToken,
+        fromTokenAmount: fromTokenAmountDebounced,
+        type: ESwapTabSwitchType.SWAP,
+        source: ESwapQuoteSource.MARKET,
+      },
     );
   }, [
+    fromToken,
+    fromTokenAmountDebounced,
     netAccountRes.result?.addressDetail.address,
     netAccountRes.result?.id,
     quoteAction,
     slippage,
+    toToken,
   ]);
 
   const buildReviewStepTexts = useCallback(
@@ -3268,6 +3280,14 @@ export function useSpeedSwapActions(props: {
         ESwapQuoteKind.SELL,
         undefined,
         userAddress,
+        undefined,
+        {
+          fromToken: fromTokenRef.current,
+          toToken: toTokenRef.current,
+          fromTokenAmount: fromTokenAmountDebounced,
+          type: ESwapTabSwitchType.SWAP,
+          source: ESwapQuoteSource.MARKET,
+        },
       );
     } else {
       const quoteRequestId = quoteRequestIdRef.current;

--- a/packages/kit/src/views/Swap/hooks/useSwapStockChannel.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapStockChannel.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { useLocaleVariant } from '@onekeyhq/kit/src/hooks/useLocaleVariant';
 import {
   useSwapActions,
   useSwapFromTokenAmountAtom,
@@ -77,6 +78,9 @@ type ISelectStockSwapTokenOptions = {
 };
 
 export function useSwapStockChannel() {
+  const locale = useLocaleVariant().toLowerCase();
+  const localeRef = useRef(locale);
+  localeRef.current = locale;
   const [fromToken] = useSwapSelectFromTokenAtom();
   const [toToken] = useSwapSelectToTokenAtom();
   const [stockExecutionTokens] = useSwapStockExecutionTokensAtom();
@@ -99,6 +103,9 @@ export function useSwapStockChannel() {
   const manualStockPayTokenKeyRef = useRef('');
   const stockTokenSnapshotRef = useRef<ISwapToken | undefined>(undefined);
   const payTokenSnapshotRef = useRef<ISwapToken | undefined>(undefined);
+  // Token-selector metadata is already localized. Keep its locale separate
+  // from the persisted token so a cold-start snapshot cannot flash old copy.
+  const stockTokenMetadataLocaleRef = useRef<string | undefined>(undefined);
 
   const selectedTokensStockPair = useMemo(
     () =>
@@ -298,6 +305,7 @@ export function useSwapStockChannel() {
       ) {
         resetStockTradeReceiveAmount();
       }
+      stockTokenMetadataLocaleRef.current = localeRef.current;
       setStockTokenState(nextStockToken);
       setStockSelectedToken(nextStockToken);
       stockTokenSnapshotRef.current = nextStockToken;
@@ -322,6 +330,7 @@ export function useSwapStockChannel() {
       if (!nextStockToken || nextStockToken === currentToken) {
         return;
       }
+      stockTokenMetadataLocaleRef.current = localeRef.current;
       setStockTokenState(nextStockToken);
       setStockSelectedToken(nextStockToken);
       stockTokenSnapshotRef.current = nextStockToken;
@@ -333,19 +342,25 @@ export function useSwapStockChannel() {
   );
 
   useEffect(() => {
+    const detail = stockTokenDetail;
+    const currentSubtitle = currentStockToken?.stock?.subtitle?.trim();
+    const detailSubtitle = detail?.stock?.subtitle?.trim();
+    // Detail is authoritative after a locale change; keep the selected token
+    // and its execution snapshot aligned with the current-language metadata.
     if (
       !currentStockToken ||
-      currentStockToken.stock?.subtitle?.trim() ||
-      !stockTokenDetail?.stock?.subtitle?.trim()
+      !detail ||
+      !detailSubtitle ||
+      currentSubtitle === detailSubtitle
     ) {
       return;
     }
     syncStockTokenDetail({
       ...currentStockToken,
-      decimals: stockTokenDetail.decimals,
-      isNative: stockTokenDetail.isNative ?? currentStockToken.isNative,
+      decimals: detail.decimals,
+      isNative: detail.isNative ?? currentStockToken.isNative,
       isStock: true,
-      stock: stockTokenDetail.stock,
+      stock: detail.stock,
     });
   }, [currentStockToken, stockTokenDetail, syncStockTokenDetail]);
 
@@ -529,6 +544,7 @@ export function useSwapStockChannel() {
       resetStockTradeAmounts();
       setTradeSideState(nextTradeSide);
       setStockTokenState(nextStockToken);
+      stockTokenMetadataLocaleRef.current = localeRef.current;
       setStockSelectedToken(nextStockToken);
       stockTokenSnapshotRef.current = nextStockToken;
       manualStockPayTokenKeyRef.current = getTokenIdentityKey(nextPayToken);
@@ -618,6 +634,9 @@ export function useSwapStockChannel() {
     stockTokenStatus,
   });
 
+  const hasCurrentLocaleStockMetadata =
+    stockTokenMetadataLocaleRef.current === locale;
+
   useEffect(() => {
     const executionTokensToSync = resolveStockExecutionTokensToSync({
       currentFromToken: fromToken,
@@ -660,6 +679,7 @@ export function useSwapStockChannel() {
       displayStockTokenDetail,
       realtimeChartPoint,
       currentStockToken,
+      hasCurrentLocaleStockMetadata,
       payToken,
       fromToken,
       toToken,
@@ -679,6 +699,7 @@ export function useSwapStockChannel() {
     [
       channelStage,
       currentStockToken,
+      hasCurrentLocaleStockMetadata,
       defaultStockTokenLoading,
       fromToken,
       marketStatusStatus,

--- a/packages/kit/src/views/Swap/hooks/useSwapStockTokenDetail.test.tsx
+++ b/packages/kit/src/views/Swap/hooks/useSwapStockTokenDetail.test.tsx
@@ -22,6 +22,10 @@ jest.mock('@onekeyhq/kit/src/hooks/useRouteIsFocused', () => ({
   useRouteIsFocused: () => true,
 }));
 
+jest.mock('@onekeyhq/kit/src/hooks/useLocaleVariant', () => ({
+  useLocaleVariant: () => 'en',
+}));
+
 jest.mock('@onekeyhq/components', () => {
   const deferredPromiseModule = require('../../../../../components/src/hooks/useDeferredPromise');
 

--- a/packages/kit/src/views/Swap/hooks/useSwapStockTokenDetail.ts
+++ b/packages/kit/src/views/Swap/hooks/useSwapStockTokenDetail.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
+import { useLocaleVariant } from '@onekeyhq/kit/src/hooks/useLocaleVariant';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import {
   swrCacheUtils,
@@ -46,9 +47,12 @@ export function useSwapStockTokenDetail({
   enabled?: boolean;
   token?: ISwapToken;
 }) {
+  const locale = useLocaleVariant().toLowerCase();
   const tokenKey = getTokenIdentityKey(token);
   const isActive = Boolean(enabled && token?.networkId && tokenKey);
-  const tokenDetailScope = isActive ? tokenKey : '';
+  // Stock metadata contains localized fields. Include the active locale in the
+  // scope so a locale switch cannot hydrate the previous language's detail.
+  const tokenDetailScope = isActive ? `${tokenKey}:${locale}` : '';
   const lastGoodTokenDetailRef = useRef<IStockTokenDetailFetchState | null>(
     null,
   );

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.tsx
@@ -170,6 +170,7 @@ import {
   getStockNetworkLogoUri,
   isStockMarketPanelLoadingStage,
   shouldShowStockMarketHeaderSkeleton,
+  shouldShowStockMarketTokenLabelsSkeleton,
   shouldShowStockQuoteActionLoading,
 } from './SwapStockDesktopContainer.utils';
 import { SwapStockTokenDetails } from './SwapStockTokenDetails';
@@ -464,6 +465,7 @@ function useCurrentStockMarketDetail() {
     // continues to use activeStockTokenDetail and the fresh channel stage.
     tokenDetail: stockChannel.displayStockTokenDetail,
     currentStockToken,
+    hasCurrentLocaleStockMetadata: stockChannel.hasCurrentLocaleStockMetadata,
     tokenAddress: currentStockToken?.contractAddress,
     networkId: currentStockToken?.networkId,
     isNative: currentStockToken?.isNative,
@@ -1437,11 +1439,7 @@ function StockMarketHeaderSkeleton({ proAligned }: { proAligned?: boolean }) {
               <Skeleton h="$5" w="$20" />
               <Skeleton h="$5" w="$5" />
             </XStack>
-            <XStack h={18} alignItems="center" gap="$1" maxWidth="100%">
-              <Skeleton h="$4" w="$18" />
-              <Skeleton h="$4" w="$5" radius="round" />
-              <Skeleton h="$4" w="$12" />
-            </XStack>
+            <StockMarketTokenLabelsSkeleton />
           </YStack>
         </XStack>
       </XStack>
@@ -1455,6 +1453,16 @@ function StockMarketHeaderSkeleton({ proAligned }: { proAligned?: boolean }) {
         <Skeleton h="$6" w="$16" />
         <Skeleton h="$4" w="$12" />
       </YStack>
+    </XStack>
+  );
+}
+
+function StockMarketTokenLabelsSkeleton() {
+  return (
+    <XStack h={18} alignItems="center" gap="$1" maxWidth="100%">
+      <Skeleton h="$4" w="$18" />
+      <Skeleton h="$4" w="$5" radius="round" />
+      <Skeleton h="$4" w="$12" />
     </XStack>
   );
 }
@@ -1475,8 +1483,12 @@ function StockMarketTokenHeader({
   proAligned?: boolean;
 }) {
   const intl = useIntl();
-  const { currentStockToken, tokenDetail, networkId } =
-    useCurrentStockMarketDetail();
+  const {
+    currentStockToken,
+    hasCurrentLocaleStockMetadata,
+    tokenDetail,
+    networkId,
+  } = useCurrentStockMarketDetail();
   const stockTokenNetworkId =
     currentStockToken?.networkId ?? tokenDetail?.networkId ?? networkId;
   const stockTokenNetworkLogoUri = useMemo(
@@ -1491,7 +1503,10 @@ function StockMarketTokenHeader({
     logoUri: stockTokenNetworkLogoUri,
     networkId: stockTokenNetworkId,
   });
-  const stock = tokenDetail?.stock;
+  const selectedStock = hasCurrentLocaleStockMetadata
+    ? currentStockToken?.stock
+    : undefined;
+  const stock = tokenDetail?.stock ?? selectedStock;
   const tokenSymbol = tokenDetail?.symbol ?? currentStockToken?.symbol;
   const tokenDisplaySymbol =
     tokenSymbol ??
@@ -1501,8 +1516,13 @@ function StockMarketTokenHeader({
   const tokenName =
     tokenDetail?.name ?? currentStockToken?.name ?? tokenSymbol ?? '';
   const tokenSubtitle = getStockMarketTokenSubtitle({
-    currentStockSubtitle: currentStockToken?.stock?.subtitle,
+    currentStockSubtitle: selectedStock?.subtitle,
     tokenDetailStockSubtitle: stock?.subtitle,
+    tokenDetailStockUnderlyingAssetName: stock?.underlyingAssetName,
+  });
+  const showTokenLabelsSkeleton = shouldShowStockMarketTokenLabelsSkeleton({
+    channelStage,
+    hasTokenData: Boolean(stock || tokenSubtitle),
   });
   const tokenImageUri = currentStockToken?.logoURI ?? tokenDetail?.logoUrl;
   const handleOpenStockTokenSelector = useOpenStockTokenSelector({
@@ -1555,7 +1575,8 @@ function StockMarketTokenHeader({
   );
   const tokenLabelsRow = (
     <XStack h={18} alignItems="center" gap="$1" maxWidth="100%">
-      {tokenSubtitle ? (
+      {showTokenLabelsSkeleton ? <StockMarketTokenLabelsSkeleton /> : null}
+      {!showTokenLabelsSkeleton && tokenSubtitle ? (
         <SizableText
           size="$bodySm"
           color="$textSubdued"
@@ -1565,8 +1586,10 @@ function StockMarketTokenHeader({
           {tokenSubtitle}
         </SizableText>
       ) : null}
-      <StockSourceLogo stock={stock} />
-      <StockMarketStatusBadge stock={stock} />
+      {!showTokenLabelsSkeleton ? <StockSourceLogo stock={stock} /> : null}
+      {!showTokenLabelsSkeleton ? (
+        <StockMarketStatusBadge stock={stock} />
+      ) : null}
     </XStack>
   );
   const tokenInfoContent = (

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.test.ts
@@ -17,6 +17,7 @@ import {
   isStockMarketPanelLoadingStage,
   mergeStockChartRealtimePoint,
   shouldShowStockMarketHeaderSkeleton,
+  shouldShowStockMarketTokenLabelsSkeleton,
   shouldShowStockQuoteActionLoading,
 } from './SwapStockDesktopContainer.utils';
 
@@ -194,33 +195,61 @@ describe('SwapStockDesktopContainer utils', () => {
     ).toBe(false);
   });
 
-  it('keeps the selected localized Stock subtitle while detail loads', () => {
+  it('shows token-label skeletons while the selected Stock detail is loading', () => {
     expect(
-      getStockMarketTokenSubtitle({
-        currentStockSubtitle: '英特尔',
+      shouldShowStockMarketTokenLabelsSkeleton({
+        channelStage: ESwapStockChannelStage.CheckingMarketStatus,
+        hasTokenData: false,
       }),
-    ).toBe('英特尔');
+    ).toBe(true);
+    expect(
+      shouldShowStockMarketTokenLabelsSkeleton({
+        channelStage: ESwapStockChannelStage.CheckingMarketStatus,
+        hasTokenData: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowStockMarketTokenLabelsSkeleton({
+        channelStage: ESwapStockChannelStage.MarketUnavailable,
+        hasTokenData: false,
+      }),
+    ).toBe(false);
   });
 
-  it('prefers the localized detail subtitle after detail loads', () => {
+  it('does not reuse the selected token subtitle while detail loads', () => {
     expect(
       getStockMarketTokenSubtitle({
-        currentStockSubtitle: '英特尔',
+        tokenDetailStockSubtitle: undefined,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('prefers the detail subtitle after detail loads', () => {
+    expect(
+      getStockMarketTokenSubtitle({
         tokenDetailStockSubtitle: '英特尔公司',
       }),
     ).toBe('英特尔公司');
   });
 
-  it('keeps the selected subtitle when detail returns a blank label', () => {
+  it('uses the selected token subtitle while detail silently refreshes', () => {
     expect(
       getStockMarketTokenSubtitle({
-        currentStockSubtitle: '英特尔',
-        tokenDetailStockSubtitle: ' ',
+        currentStockSubtitle: 'Apple',
       }),
-    ).toBe('英特尔');
+    ).toBe('Apple');
   });
 
-  it('does not expose the raw token name while Stock metadata loads', () => {
+  it('falls back to the detail underlying asset name when subtitle is missing', () => {
+    expect(
+      getStockMarketTokenSubtitle({
+        tokenDetailStockSubtitle: ' ',
+        tokenDetailStockUnderlyingAssetName: 'SK hynix Inc.',
+      }),
+    ).toBe('SK hynix Inc.');
+  });
+
+  it('does not expose a raw token name when detail metadata is missing', () => {
     expect(getStockMarketTokenSubtitle({})).toBeUndefined();
   });
 

--- a/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
+++ b/packages/kit/src/views/Swap/pages/components/SwapStockDesktopContainer.utils.ts
@@ -115,17 +115,35 @@ export function shouldShowStockMarketHeaderSkeleton({
   );
 }
 
+export function shouldShowStockMarketTokenLabelsSkeleton({
+  channelStage,
+  hasTokenData,
+}: {
+  channelStage: ESwapStockChannelStage;
+  hasTokenData: boolean;
+}) {
+  return (
+    !hasTokenData &&
+    channelStage === ESwapStockChannelStage.CheckingMarketStatus
+  );
+}
+
 export function getStockMarketTokenSubtitle({
   currentStockSubtitle,
   tokenDetailStockSubtitle,
+  tokenDetailStockUnderlyingAssetName,
 }: {
   currentStockSubtitle?: string;
   tokenDetailStockSubtitle?: string;
+  tokenDetailStockUnderlyingAssetName?: string;
 }) {
   if (tokenDetailStockSubtitle?.trim()) {
     return tokenDetailStockSubtitle;
   }
-  return currentStockSubtitle?.trim() ? currentStockSubtitle : undefined;
+  if (currentStockSubtitle?.trim()) {
+    return currentStockSubtitle;
+  }
+  return tokenDetailStockUnderlyingAssetName?.trim() || undefined;
 }
 
 export function shouldShowStockQuoteActionLoading({

--- a/packages/shared/types/swap/types.ts
+++ b/packages/shared/types/swap/types.ts
@@ -89,6 +89,10 @@ export enum ESwapQuoteKind {
   BUY = 'buy',
 }
 
+export enum ESwapQuoteSource {
+  MARKET = 'Market',
+}
+
 export enum ESwapSource {
   WALLET_TAB = 'wallet_tab',
   WALLET_HOME = 'wallet_home',
@@ -394,6 +398,7 @@ export interface ISwapApproveTransaction {
   blockNumber?: number;
 }
 export interface IFetchQuotesParams extends IFetchSwapQuoteBaseParams {
+  source?: ESwapQuoteSource;
   userAddress?: string;
   receivingAddress?: string;
   incognito?: boolean;
@@ -643,6 +648,7 @@ export interface ISwapPreSwapData {
 }
 
 export interface IFetchSwapQuoteParams {
+  source?: ESwapQuoteSource;
   fromToken: ISwapToken;
   toToken: ISwapToken;
   requestScopeKey?: string;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60467](https://onekeyhq.atlassian.net/browse/OK-60467) [OK-60471](https://onekeyhq.atlassian.net/browse/OK-60471)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- **OK-60467**: pass `source=Market` through the quote-event pipeline so Market only receives the approved provider set.
- **OK-60471**: defer `build-tx` for signed Market quotes until after the user signs the 1inch Fusion/CowSwap payload.
- Market quote selection now defers transient non-actionable provider errors until an actionable provider arrives or the quote event reaches a terminal state.
- Stock token metadata now renders the current-language selector data immediately, refreshes detail metadata silently, and only shows label skeletons when no display data exists.
- Stock detail scope now includes locale, preventing stale localized metadata from flashing during language changes.

## Root cause

- Market quote requests did not identify themselves as Market requests, so provider filtering was not applied.
- Signed quotes were eagerly sent to `/swap/v1/build-tx` during Review preparation, before the required signature existed.
- Market uses the SWAP execution type, so its quote-selection state did not retain `source=Market`; the first provider error could therefore become the selected quote and flash in the UI before a later provider succeeded.
- Stock detail SWR scope did not include locale, while the selected token could still carry localized metadata from the previous language.
- Some Stock detail responses omit `stock.subtitle` even though the selector list has it; `underlyingAssetName` is used as the stable fallback.
- The locale-aware detail hook was not isolated in its Jest test, so the jsdom React Native mock tried to call the unavailable `AppState.addEventListener`.

## Validation

- Desktop runtime: Market quote URL contained `source=Market`; provider list was restricted to the expected providers.
- Desktop runtime: 1inch Fusion entered Review order with zero `/swap/v1/build-tx` requests before signing.
- Desktop runtime: selecting `MUon` immediately showed `Micron / Overnight`; selecting `SKHYon` showed `SK hynix Inc. / Overnight`.
- Desktop runtime: language-switch probes did not show the previous-language subtitle; local language was restored to English.
- Focused Swap quote tests: 2 suites, 106 tests passed.
- Focused Stock/detail/cache tests: 3 suites, 54 tests passed.
- `yarn agent:check --profile commit` passed.

## Delivery

- `ba76fc6fa1 fix: stabilize Stock metadata loading`
- `7afa40d4a9 test: mock locale in Stock detail hook`
- Branch: `fix/zhaono1-081801`

[OK-60467]: https://onekeyhq.atlassian.net/browse/OK-60467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-60471]: https://onekeyhq.atlassian.net/browse/OK-60471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ