### PR TITLE
fix: align perps order book bars with rows, instrument iOS scroll lock (OK-59102, OK-59100)

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -325,6 +325,30 @@ export function TradingViewPerpsV2(
   const isChartLinesReady = chartLinesReadyWebviewKey === _webviewKey;
   const isChartContentReady = chartContentReadyWebviewKey === _webviewKey;
 
+  // OK-59100: on iOS this flag gates the page scroller, so a stray `open` that
+  // never receives its matching `close` locks scrolling for the rest of the
+  // session (fail-closed). Before the chart reports ready there is no real
+  // overlay to protect against, and a reload invalidates any pending open
+  // state, so let only `false` through until the chart proves it is live.
+  const isChartContentReadyRef = useRef(isChartContentReady);
+  isChartContentReadyRef.current = isChartContentReady;
+  const guardedInteractionOverlayOpenChange = useCallback(
+    (isOpen: boolean) => {
+      if (isOpen && !isChartContentReadyRef.current) {
+        return;
+      }
+      onInteractionOverlayOpenChange?.(isOpen);
+    },
+    [onInteractionOverlayOpenChange],
+  );
+  // Any transition out of ready (reload, navigation, render-process loss)
+  // discards overlay state the chart can no longer close on its own.
+  useEffect(() => {
+    if (!isChartContentReady) {
+      onInteractionOverlayOpenChange?.(false);
+    }
+  }, [isChartContentReady, onInteractionOverlayOpenChange]);
+
   const prevWebviewKeyRef = useRef(_webviewKey);
   useEffect(() => {
     if (prevWebviewKeyRef.current !== _webviewKey) {
@@ -649,7 +673,7 @@ export function TradingViewPerpsV2(
     onOrderPriceUpdate,
     onChartOrderIntent,
     onTouchScroll,
-    onInteractionOverlayOpenChange,
+    onInteractionOverlayOpenChange: guardedInteractionOverlayOpenChange,
   });
 
   // Chart lines management (liquidation, position, orders)

--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -1078,21 +1078,30 @@ export function OrderBook({
   // REACT-NATIVE-1JZ: build the native depth-bar `percents` arrays once per data
   // change (useMemo) instead of inside JSX on every render, then frame-coalesce
   // them (useRafCoalesced) so high-frequency L2 ticks collapse to ~one Nitro
-  // prop write per displayed frame. Only the depth-bar *visual* data is gated
-  // here — the price/size ladder text below still reads `aggregatedData`
-  // directly, so the numbers the user reads stay maximally fresh.
-  const bidPercentsRaw = useMemo(
-    () =>
-      aggregatedData.bids.map((item) =>
+  // prop write per displayed frame.
+  //
+  // OK-59102: percents and the ladder rows they sit behind must travel through
+  // the SAME coalesced snapshot. Coalescing only the percents while the text
+  // read `aggregatedData` directly published two different books per update —
+  // a stale depth block behind an already-updated row — which on iOS is then
+  // stretched further by the native bar's CADisplayLink easing and reads as
+  // flicker. Bundling them mirrors what the vertical mobile ladder already does.
+  const bidLadderRaw = useMemo(
+    () => ({
+      percents: aggregatedData.bids.map((item) =>
         calculatePercentage(item.cumSize, bidDepth),
       ),
+      levels: aggregatedData.bids,
+    }),
     [aggregatedData.bids, bidDepth],
   );
-  const askPercentsRaw = useMemo(
-    () =>
-      aggregatedData.asks.map((item) =>
+  const askLadderRaw = useMemo(
+    () => ({
+      percents: aggregatedData.asks.map((item) =>
         calculatePercentage(item.cumSize, askDepth),
       ),
+      levels: aggregatedData.asks,
+    }),
     [aggregatedData.asks, askDepth],
   );
   // Vertical layout draws asks top-to-bottom reversed; keep its own derived
@@ -1104,8 +1113,10 @@ export function OrderBook({
         .map((item) => calculatePercentage(item.cumSize, askDepth)),
     [aggregatedData.asks, askDepth],
   );
-  const bidPercents = useRafCoalesced(bidPercentsRaw, depthEpoch);
-  const askPercents = useRafCoalesced(askPercentsRaw, depthEpoch);
+  const bidLadder = useRafCoalesced(bidLadderRaw, depthEpoch);
+  const askLadder = useRafCoalesced(askLadderRaw, depthEpoch);
+  const bidPercents = bidLadder.percents;
+  const askPercents = askLadder.percents;
   const reversedAskPercents = useRafCoalesced(
     reversedAskPercentsRaw,
     depthEpoch,
@@ -1367,7 +1378,7 @@ export function OrderBook({
               <View style={styles.absoluteContainer}>
                 <View style={styles.levelListContainer}>
                   <View style={styles.levelList}>
-                    {aggregatedData.bids.map((item, index) => (
+                    {bidLadder.levels.map((item, index) => (
                       <Pressable
                         key={index}
                         onPress={() => handleSelectLevel('bid', item, index)}
@@ -1401,7 +1412,7 @@ export function OrderBook({
                     ))}
                   </View>
                   <View style={styles.levelList}>
-                    {aggregatedData.asks.map((item, index) => (
+                    {askLadder.levels.map((item, index) => (
                       <Pressable
                         key={index}
                         onPress={() => handleSelectLevel('ask', item, index)}

--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -1078,30 +1078,26 @@ export function OrderBook({
   // REACT-NATIVE-1JZ: build the native depth-bar `percents` arrays once per data
   // change (useMemo) instead of inside JSX on every render, then frame-coalesce
   // them (useRafCoalesced) so high-frequency L2 ticks collapse to ~one Nitro
-  // prop write per displayed frame.
+  // prop write per displayed frame. Only the depth-bar *visual* data is gated
+  // here — the price/size ladder text below still reads `aggregatedData`
+  // directly, so the numbers the user reads stay maximally fresh.
   //
-  // OK-59102: percents and the ladder rows they sit behind must travel through
-  // the SAME coalesced snapshot. Coalescing only the percents while the text
-  // read `aggregatedData` directly published two different books per update —
-  // a stale depth block behind an already-updated row — which on iOS is then
-  // stretched further by the native bar's CADisplayLink easing and reads as
-  // flicker. Bundling them mirrors what the vertical mobile ladder already does.
-  const bidLadderRaw = useMemo(
-    () => ({
-      percents: aggregatedData.bids.map((item) =>
+  // OK-59102: bundling the rows into this same coalesced snapshot was tried and
+  // reverted — on device it made the book read as visibly slower without the
+  // reported flicker reproducing, so the skew is not worth that trade until a
+  // capture actually shows it.
+  const bidPercentsRaw = useMemo(
+    () =>
+      aggregatedData.bids.map((item) =>
         calculatePercentage(item.cumSize, bidDepth),
       ),
-      levels: aggregatedData.bids,
-    }),
     [aggregatedData.bids, bidDepth],
   );
-  const askLadderRaw = useMemo(
-    () => ({
-      percents: aggregatedData.asks.map((item) =>
+  const askPercentsRaw = useMemo(
+    () =>
+      aggregatedData.asks.map((item) =>
         calculatePercentage(item.cumSize, askDepth),
       ),
-      levels: aggregatedData.asks,
-    }),
     [aggregatedData.asks, askDepth],
   );
   // Vertical layout draws asks top-to-bottom reversed; keep its own derived
@@ -1113,10 +1109,8 @@ export function OrderBook({
         .map((item) => calculatePercentage(item.cumSize, askDepth)),
     [aggregatedData.asks, askDepth],
   );
-  const bidLadder = useRafCoalesced(bidLadderRaw, depthEpoch);
-  const askLadder = useRafCoalesced(askLadderRaw, depthEpoch);
-  const bidPercents = bidLadder.percents;
-  const askPercents = askLadder.percents;
+  const bidPercents = useRafCoalesced(bidPercentsRaw, depthEpoch);
+  const askPercents = useRafCoalesced(askPercentsRaw, depthEpoch);
   const reversedAskPercents = useRafCoalesced(
     reversedAskPercentsRaw,
     depthEpoch,
@@ -1378,7 +1372,7 @@ export function OrderBook({
               <View style={styles.absoluteContainer}>
                 <View style={styles.levelListContainer}>
                   <View style={styles.levelList}>
-                    {bidLadder.levels.map((item, index) => (
+                    {aggregatedData.bids.map((item, index) => (
                       <Pressable
                         key={index}
                         onPress={() => handleSelectLevel('bid', item, index)}
@@ -1412,7 +1406,7 @@ export function OrderBook({
                     ))}
                   </View>
                   <View style={styles.levelList}>
-                    {askLadder.levels.map((item, index) => (
+                    {aggregatedData.asks.map((item, index) => (
                       <Pressable
                         key={index}
                         onPress={() => handleSelectLevel('ask', item, index)}

--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -1078,26 +1078,29 @@ export function OrderBook({
   // REACT-NATIVE-1JZ: build the native depth-bar `percents` arrays once per data
   // change (useMemo) instead of inside JSX on every render, then frame-coalesce
   // them (useRafCoalesced) so high-frequency L2 ticks collapse to ~one Nitro
-  // prop write per displayed frame. Only the depth-bar *visual* data is gated
-  // here — the price/size ladder text below still reads `aggregatedData`
-  // directly, so the numbers the user reads stay maximally fresh.
+  // prop write per displayed frame.
   //
-  // OK-59102: bundling the rows into this same coalesced snapshot was tried and
-  // reverted — on device it made the book read as visibly slower without the
-  // reported flicker reproducing, so the skew is not worth that trade until a
-  // capture actually shows it.
-  const bidPercentsRaw = useMemo(
-    () =>
-      aggregatedData.bids.map((item) =>
+  // OK-59102: the bars and the ladder text under them must come from ONE
+  // snapshot, or every update paints a stale depth block behind an
+  // already-updated row — which the native bar's CADisplayLink easing then
+  // stretches into visible flicker. They are bundled here so a single
+  // coalescing decision covers both.
+  const bidLadderRaw = useMemo(
+    () => ({
+      percents: aggregatedData.bids.map((item) =>
         calculatePercentage(item.cumSize, bidDepth),
       ),
+      levels: aggregatedData.bids,
+    }),
     [aggregatedData.bids, bidDepth],
   );
-  const askPercentsRaw = useMemo(
-    () =>
-      aggregatedData.asks.map((item) =>
+  const askLadderRaw = useMemo(
+    () => ({
+      percents: aggregatedData.asks.map((item) =>
         calculatePercentage(item.cumSize, askDepth),
       ),
+      levels: aggregatedData.asks,
+    }),
     [aggregatedData.asks, askDepth],
   );
   // Vertical layout draws asks top-to-bottom reversed; keep its own derived
@@ -1109,8 +1112,18 @@ export function OrderBook({
         .map((item) => calculatePercentage(item.cumSize, askDepth)),
     [aggregatedData.asks, askDepth],
   );
-  const bidPercents = useRafCoalesced(bidPercentsRaw, depthEpoch);
-  const askPercents = useRafCoalesced(askPercentsRaw, depthEpoch);
+  const bidLadderCoalesced = useRafCoalesced(bidLadderRaw, depthEpoch);
+  const askLadderCoalesced = useRafCoalesced(askLadderRaw, depthEpoch);
+  // Mobile already renders a 200ms-throttled visual snapshot
+  // (`enableVisualSnapshot` in PerpOrderBook), so coalescing to the frame here
+  // can never merge two updates — it only costs a frame of latency plus an
+  // extra render, which is what made the book read as slower when the rows
+  // were first bundled in. Desktop has no such throttle and still needs it
+  // against the raw high-frequency L2 feed.
+  const bidLadder = isMobileVariant ? bidLadderRaw : bidLadderCoalesced;
+  const askLadder = isMobileVariant ? askLadderRaw : askLadderCoalesced;
+  const bidPercents = bidLadder.percents;
+  const askPercents = askLadder.percents;
   const reversedAskPercents = useRafCoalesced(
     reversedAskPercentsRaw,
     depthEpoch,
@@ -1372,7 +1385,7 @@ export function OrderBook({
               <View style={styles.absoluteContainer}>
                 <View style={styles.levelListContainer}>
                   <View style={styles.levelList}>
-                    {aggregatedData.bids.map((item, index) => (
+                    {bidLadder.levels.map((item, index) => (
                       <Pressable
                         key={index}
                         onPress={() => handleSelectLevel('bid', item, index)}
@@ -1406,7 +1419,7 @@ export function OrderBook({
                     ))}
                   </View>
                   <View style={styles.levelList}>
-                    {aggregatedData.asks.map((item, index) => (
+                    {askLadder.levels.map((item, index) => (
                       <Pressable
                         key={index}
                         onPress={() => handleSelectLevel('ask', item, index)}

--- a/packages/kit/src/views/Perp/components/PerpMarketFooter.tsx
+++ b/packages/kit/src/views/Perp/components/PerpMarketFooter.tsx
@@ -8,6 +8,7 @@ import platformEnv from '@onekeyhq/shared/src/platformEnv';
 
 import { useHyperliquidActions } from '../../../states/jotai/contexts/hyperliquid';
 import { useActiveTradeDisplay } from '../hooks/useActiveTradeDisplay';
+import { perpsFieldDiagnostics } from '../utils/perpsFieldDiagnostics';
 import { getTradingButtonStyleProps } from '../utils/styleUtils';
 
 const MARKET_FOOTER_BUTTON_HEIGHT = 36;
@@ -33,8 +34,14 @@ function PerpMarketFooter() {
         : ETranslations.perp_trade_short,
   });
 
+  // OK-59100 reports these two buttons as unresponsive alongside the stuck
+  // scroller. They live in Page.Footer, outside the Tabs container, so nothing
+  // in that scroll path should be able to swallow their touches — logging entry
+  // here separates "the tap never arrived" from "the tap ran but goBack() did
+  // not visibly do anything".
   const handleCancel = useCallback(
     (close: () => void) => {
+      perpsFieldDiagnostics('marketFooter.press', { side: 'long' });
       actionsRef.current.updateTradingForm({ side: 'long' });
       close();
     },
@@ -43,6 +50,7 @@ function PerpMarketFooter() {
 
   const handleConfirm = useCallback(
     (close: () => void) => {
+      perpsFieldDiagnostics('marketFooter.press', { side: 'short' });
       actionsRef.current.updateTradingForm({ side: 'short' });
       close();
     },

--- a/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
+++ b/packages/kit/src/views/Perp/components/PerpOrderBook.tsx
@@ -59,6 +59,7 @@ import {
   PERPS_ORDER_BOOK_MOBILE_VISUAL_FRAME_MS,
   getPerpsOrderBookVisualSnapshotDelayMs,
 } from '../utils/orderBookVisualScheduler';
+import { perpsFieldDiagnostics } from '../utils/perpsFieldDiagnostics';
 
 import {
   type IOrderBookSelection,
@@ -828,6 +829,28 @@ export function PerpOrderBook({
   }, [
     activeTradeInstrument.mode,
     formData.hasTpsl,
+    shouldCompactOrderBookForConnectWallet,
+    shouldCompactOrderBookForFirstDeposit,
+    shouldShowEnableTradingButton,
+  ]);
+
+  // OK-59100: the level count drives how tall the order book renders, which is
+  // what the iOS tab scroller has to exceed before the page can scroll at all.
+  // Logged with the account flags that select it so a report can be tied to the
+  // branch it actually took.
+  useEffect(() => {
+    perpsFieldDiagnostics('orderbook.levelCount', {
+      mobileMaxLevelsPerSide,
+      mode: activeTradeInstrument.mode,
+      compactForFirstDeposit: shouldCompactOrderBookForFirstDeposit,
+      compactForConnectWallet: shouldCompactOrderBookForConnectWallet,
+      showEnableTradingButton: shouldShowEnableTradingButton,
+      hasTpsl: formData.hasTpsl,
+    });
+  }, [
+    activeTradeInstrument.mode,
+    formData.hasTpsl,
+    mobileMaxLevelsPerSide,
     shouldCompactOrderBookForConnectWallet,
     shouldCompactOrderBookForFirstDeposit,
     shouldShowEnableTradingButton,

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -60,10 +60,20 @@ import {
   type IMobilePerpMarketTab,
   getMobilePerpMarketPageScrollState,
 } from '../utils/mobilePerpMarketScrollState';
+import { perpsFieldDiagnostics } from '../utils/perpsFieldDiagnostics';
 import { preloadPerpsMobileTokenSelectorPage } from '../utils/preloadPerpsTokenSelector';
 
 const MOBILE_CHART_HEIGHT = 500;
 const IOS_CHART_BOTTOM_OVERLAP = 56;
+
+// OK-59100: `react-native-collapsible-tab-view` sizes its iOS scroller with
+// `contentInset` rather than padding, so its own `contentContainerStyle`
+// carries the minHeight that guarantees there is anything to scroll at all.
+// External styles are merged AFTER the library's, so the previous
+// `minHeight: 0` silently deleted that guarantee and left the order book
+// scrollable only when its intrinsic content happened to be tall enough.
+// `flexGrow: 0` is kept — it is what stops the short content from stretching.
+const IOS_ORDERBOOK_SCROLL_CONTENT_STYLE = { flexGrow: 0 };
 
 const MOBILE_PERP_MARKET_TAB_ITEMS: Array<{
   key: IMobilePerpMarketTab;
@@ -321,8 +331,28 @@ function MobilePerpMarket() {
       ? windowHeight
       : undefined;
   const handleInteractionOverlayOpenChange = useCallback((isOpen: boolean) => {
+    perpsFieldDiagnostics('interactionOverlay.change', {
+      isOpen,
+      at: Date.now(),
+    });
     setIsTradingViewInteractionOverlayOpen(isOpen);
   }, []);
+
+  // Records what the iOS scroller actually has to work with: if
+  // `contentHeight` never exceeds the visible box, the page cannot scroll no
+  // matter what `scrollEnabled` says.
+  const handleOrderbookContentSizeChange = useCallback(
+    (contentWidth: number, contentHeight: number) => {
+      perpsFieldDiagnostics('iosOrderbookTab.contentSize', {
+        contentWidth: Math.round(contentWidth),
+        contentHeight: Math.round(contentHeight),
+        windowHeight: Math.round(windowHeight),
+        chartHeight: MOBILE_CHART_HEIGHT,
+        bottomOverlap: IOS_CHART_BOTTOM_OVERLAP,
+      });
+    },
+    [windowHeight],
+  );
 
   const renderHeaderTitle = useCallback(() => {
     let pairLabel: string;
@@ -633,7 +663,8 @@ function MobilePerpMarket() {
                     <Tabs.ScrollView
                       scrollEnabled={!isTradingViewInteractionOverlayOpen}
                       showsVerticalScrollIndicator={false}
-                      contentContainerStyle={{ flexGrow: 0, minHeight: 0 }}
+                      contentContainerStyle={IOS_ORDERBOOK_SCROLL_CONTENT_STYLE}
+                      onContentSizeChange={handleOrderbookContentSizeChange}
                     >
                       <YStack
                         onLayout={(event) =>

--- a/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
+++ b/packages/kit/src/views/Perp/pages/MobilePerpMarket.tsx
@@ -66,14 +66,12 @@ import { preloadPerpsMobileTokenSelectorPage } from '../utils/preloadPerpsTokenS
 const MOBILE_CHART_HEIGHT = 500;
 const IOS_CHART_BOTTOM_OVERLAP = 56;
 
-// OK-59100: `react-native-collapsible-tab-view` sizes its iOS scroller with
-// `contentInset` rather than padding, so its own `contentContainerStyle`
-// carries the minHeight that guarantees there is anything to scroll at all.
-// External styles are merged AFTER the library's, so the previous
-// `minHeight: 0` silently deleted that guarantee and left the order book
-// scrollable only when its intrinsic content happened to be tall enough.
-// `flexGrow: 0` is kept — it is what stops the short content from stretching.
-const IOS_ORDERBOOK_SCROLL_CONTENT_STYLE = { flexGrow: 0 };
+// `minHeight: 0` is deliberate, and dropping it was wrong: iOS scrollability
+// here comes from the header's contentInset (the 500pt chart), not from the
+// content's own height. Letting the library's minHeight through only padded
+// dead space under the order book and stretched the scroll — field log showed
+// contentHeight 574 against ~390pt of real rows at 7 levels per side.
+const IOS_ORDERBOOK_SCROLL_CONTENT_STYLE = { flexGrow: 0, minHeight: 0 };
 
 const MOBILE_PERP_MARKET_TAB_ITEMS: Array<{
   key: IMobilePerpMarketTab;

--- a/packages/kit/src/views/Perp/utils/perpsFieldDiagnostics.ts
+++ b/packages/kit/src/views/Perp/utils/perpsFieldDiagnostics.ts
@@ -1,0 +1,40 @@
+import {
+  LogLevel,
+  NativeLogger,
+} from '@onekeyhq/shared/src/modules3rdParty/react-native-file-logger';
+import platformEnv from '@onekeyhq/shared/src/platformEnv';
+
+// OK-59100 / OK-59102 field diagnostics.
+//
+// Unlike `tracePerpsMobileLayout`, this stays live in production bundles: both
+// bugs only reproduce on a real device running a release build, where
+// `babel-plugin-transform-remove-console` strips every console call and
+// `isPerpsMobileLayoutTraceEnabled()` short-circuits on NODE_ENV. Writing
+// through NativeLogger puts the records in the same file the in-app
+// "export logs" action ships, which is how these get back off the device.
+//
+// Remove together with its call sites once both tickets are closed.
+const PERPS_FIELD_DIAGNOSTICS_PREFIX = '[PerpsDiag]';
+
+export type IPerpsFieldDiagnosticsDetail = Record<string, unknown>;
+
+export function perpsFieldDiagnostics(
+  label: string,
+  detail?: IPerpsFieldDiagnosticsDetail,
+) {
+  const payload = detail ?? {};
+
+  if (!platformEnv.isNative) {
+    console.log(PERPS_FIELD_DIAGNOSTICS_PREFIX, label, payload);
+    return;
+  }
+
+  try {
+    NativeLogger.write(
+      LogLevel.Info,
+      `${PERPS_FIELD_DIAGNOSTICS_PREFIX} ${label} ${JSON.stringify(payload)}`,
+    );
+  } catch {
+    // Diagnostics must never be able to affect the UI they observe.
+  }
+}


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59102](https://onekeyhq.atlassian.net/browse/OK-59102) [OK-59100](https://onekeyhq.atlassian.net/browse/OK-59100)

----------

<!-- github-pr-monitor:jira-links:end -->


Both bugs are device-only — neither reproduces on the iOS simulator, which is
why an earlier pass on this branch wrongly concluded "not reproducible" and
shipped changes that had to be reverted. QA has since reproduced both on a
device (6.5.0 native shell + this branch's bundle).

## OK-59102 — order book flicker — fixed

**Root cause.** The horizontal book published two snapshots per update. The
native depth bars' `percents` went through `useRafCoalesced`, while the
price/size rows under them read `aggregatedData` live. Every tick therefore
painted a stale depth block behind an already-updated row, and on iOS the
depth bar's `CADisplayLink` easing stretches that one-frame skew into
visible flicker.

Confirmed by two device runs pointing at each other:

| Build | Result |
|---|---|
| stock bundle (QA) | flickers |
| rows bundled into the coalesced snapshot | no flicker, but the book reads visibly slower |

The first row shows the skew is real; the second shows bundling fixes it. Only
the slowness needed solving.

**Why it was slow.** Mobile already renders a 200ms-throttled snapshot
(`enableVisualSnapshot` in `PerpOrderBook.tsx`). Putting a 16ms frame coalescer
downstream of a 200ms throttle can never merge two updates — it only adds a
frame of latency and one extra render per update.

**Fix.** Mobile takes the raw ladder, so bars and rows are same-source and
same-frame with no added delay. Desktop keeps the coalescer: its L2 feed is
unthrottled, and that is the case REACT-NATIVE-1JZ was written for.

## OK-59100 — page unscrollable — not fixed, instrumented

No confirmed root cause. Three theories were tested against a device log and
all three died:

- `orderbook.levelCount` reported 7 levels with every compact flag false, so the
  6.6 level-count change is not involved.
- `interactionOverlay.change` fired three times, all `false` — the flag never
  latched, so a stuck overlay was not the cause.
- Restoring the library's `minHeight` (removed by `minHeight: 0`) padded ~180pt
  of dead space under the book and lengthened the scroll. That change was
  reverted; `minHeight: 0` is deliberate, since iOS scrollability comes from the
  header's `contentInset`, not the content's own height.

Also ruled out: the iOS native scroll path (`Tabs.Container` +
`Tabs.ScrollView` + `HeaderScrollGestureWrapper`) has not changed since the
ticket was filed — every change in that window was web-only or Android-only.
And the native module versions in the 6.5.0 shell match current x exactly
(gesture-handler 2.30.0, reanimated 4.2.1, worklets 0.7.1,
collapsible-tab-view 8.0.1, perp-depth-bar 3.0.78), so this is not a
native-vs-JS skew either.

What ships here is the instrumentation plus one defensive change:

- **chart-ready gate on the interaction-overlay flag.** It gates both the header
  pan gesture and the tab scroller but had no reset path, so a stray `open`
  arriving before the WebView is live could never be closed. Now `open` is only
  accepted once the chart reports ready, and any transition out of ready forces
  it closed. Provably a fail-closed defect even though the log shows it did not
  fire here.

## Diagnostics — remove before merge

`perpsFieldDiagnostics.ts` writes through `NativeLogger`, not `console`:
`build-bundle:ios` runs `--dev false` with `NODE_ENV=production`, where
`babel-plugin-transform-remove-console` strips every console call and
`isPerpsMobileLayoutTraceEnabled()` short-circuits on NODE_ENV — so the existing
`tracePerpsMobileLayout` is silent in exactly the build where these reproduce.
Records land in the file that **Settings → export logs** ships.

Grep the exported log for `[PerpsDiag]`:

| Label | Answers |
|---|---|
| `iosOrderbookTab.contentSize` | does `contentHeight` ever exceed the visible box |
| `interactionOverlay.change` | does the flag latch `true` and never return |
| `marketFooter.press` | did the tap arrive at all, vs `goBack()` doing nothing |
| `orderbook.levelCount` | which level-count branch the account state selected |

## Verification

`yarn tsc:only` passes. **Both fixes need device verification** — the simulator
does not reproduce either bug.

[OK-59102]: https://onekeyhq.atlassian.net/browse/OK-59102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-59100]: https://onekeyhq.atlassian.net/browse/OK-59100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ