### PR TITLE
fix: improve perps confirmation and deposit UX

### DIFF
--- a/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/TradingButtonGroup.tsx
@@ -90,7 +90,10 @@ import {
   useRequestEnableTradingWithDepositFallback,
 } from '../../hooks/useEnableTradingWithDepositFallback';
 import { useLiquidationPrice } from '../../hooks/useLiquidationPrice';
-import { useShowDepositWithdrawModal } from '../../hooks/useShowDepositWithdrawModal';
+import {
+  usePreloadPerpsUnifoldDepositModals,
+  useShowDepositWithdrawModal,
+} from '../../hooks/useShowDepositWithdrawModal';
 import { useTradingCalculationsForSide } from '../../hooks/useTradingCalculationsForSide';
 import { useTradingPrice } from '../../hooks/useTradingPrice';
 import { PerpTestIDs } from '../../testIDs';
@@ -2609,35 +2612,29 @@ function TradingButtonGroup({
   const intl = useIntl();
   const formData = useTradingFormEmptySizeParams();
   const [perpsAccountStatus] = usePerpsActiveAccountStatusAtom();
-  const [perpsAccountLoading] = usePerpsAccountLoadingInfoAtom();
   const [perpsAccount] = usePerpsActiveAccountAtom();
   const [{ perpConfigCommon }] = usePerpsCommonConfigPersistAtom();
   const requestFirstDepositAction = useFirstDepositAction();
   const firstDepositAccountKey = getPerpsAccountKey(perpsAccount);
   const firstDepositAccountKeyRef = useRef(firstDepositAccountKey);
   firstDepositAccountKeyRef.current = firstDepositAccountKey;
-  const isFirstDepositLoading =
-    perpsAccountLoading.selectAccountLoading ||
-    perpsAccountLoading.enableTradingLoading;
   const shouldShowFirstDepositPrompt = shouldShowPerpsFirstDepositPrompt({
     status: perpsAccountStatus,
     isLiveStatusPending,
     isPerpActionDisabled: Boolean(perpConfigCommon?.disablePerpActionPerp),
   });
+  usePreloadPerpsUnifoldDepositModals(
+    shouldShowFirstDepositPrompt &&
+      !perpConfigCommon?.ipDisablePerp &&
+      perpConfigCommon?.unifoldDepositEnabled === true,
+  );
   const handleFirstDepositPress = useCallback(() => {
-    if (isFirstDepositLoading) {
-      return;
-    }
     const accountKey = firstDepositAccountKey;
     void requestFirstDepositAction({
       shouldIgnoreResult: () =>
         Boolean(accountKey && firstDepositAccountKeyRef.current !== accountKey),
     });
-  }, [
-    firstDepositAccountKey,
-    isFirstDepositLoading,
-    requestFirstDepositAction,
-  ]);
+  }, [firstDepositAccountKey, requestFirstDepositAction]);
 
   if (perpConfigCommon?.ipDisablePerp) {
     return <IpRestrictedSingleButton isMobile={isMobile} />;
@@ -2653,9 +2650,7 @@ function TradingButtonGroup({
           childrenAsText={false}
           borderRadius="$full"
           variant="primary"
-          disabled={isFirstDepositLoading}
-          loading={isFirstDepositLoading}
-          onPress={isFirstDepositLoading ? undefined : handleFirstDepositPress}
+          onPress={handleFirstDepositPress}
           testID="perp-new-user-trading-panel-deposit-btn"
           h={36}
         >

--- a/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/modals/OrderConfirmModal.tsx
@@ -859,20 +859,22 @@ function OrderConfirmContent({
         ) : null}
 
         {/* skip order confirm checkbox */}
-        <XStack justifyContent="space-between" alignItems="center" gap="$2">
-          <Checkbox
-            testID="perp-checkbox"
-            labelProps={{
-              fontSize: '$bodyMdMedium',
-              color: '$textSubdued',
-            }}
-            label={intl.formatMessage({
-              id: ETranslations.perp_confirm_not_show,
-            })}
-            value={perpsCustomSettings.skipOrderConfirm}
-            onChange={(checked) => setSkipOrderConfirm(!!checked)}
-          />
-        </XStack>
+        {!aggressiveLimitPriceWarning ? (
+          <XStack justifyContent="space-between" alignItems="center" gap="$2">
+            <Checkbox
+              testID="perp-checkbox"
+              labelProps={{
+                fontSize: '$bodyMdMedium',
+                color: '$textSubdued',
+              }}
+              label={intl.formatMessage({
+                id: ETranslations.perp_confirm_not_show,
+              })}
+              value={perpsCustomSettings.skipOrderConfirm}
+              onChange={(checked) => setSkipOrderConfirm(!!checked)}
+            />
+          </XStack>
+        ) : null}
       </YStack>
 
       <TradingGuardWrapper

--- a/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
+++ b/packages/kit/src/views/Perp/components/TradingPanel/panels/LimitOrderForm.tsx
@@ -82,7 +82,10 @@ import {
 import { calculateOrderPrice } from '../../../hooks/useOrderPrice';
 import { usePerpsAccountScopedActivePositions } from '../../../hooks/usePerpsAccountScopedActivePositions';
 import { usePerpsMarketDataFreshness } from '../../../hooks/usePerpsMarketDataFreshness';
-import { useShowDepositWithdrawModal } from '../../../hooks/useShowDepositWithdrawModal';
+import {
+  usePreloadPerpsUnifoldDepositModals,
+  useShowDepositWithdrawModal,
+} from '../../../hooks/useShowDepositWithdrawModal';
 import { useTradingPrice } from '../../../hooks/useTradingPrice';
 import { PerpsAccountSelectorProviderMirror } from '../../../PerpsAccountSelectorProviderMirror';
 import { PerpsProviderMirror } from '../../../PerpsProviderMirror';
@@ -625,23 +628,19 @@ export function LimitOrderForm({
     isLiveStatusPending: !perpsAccountDisplayReady.statusReady,
     isPerpActionDisabled,
   });
+  usePreloadPerpsUnifoldDepositModals(
+    shouldShowFirstDepositAction &&
+      perpConfigCommon?.unifoldDepositEnabled === true,
+  );
 
   const handleFirstDepositPress = useCallback(() => {
-    if (isTradingActionLoading) {
-      return;
-    }
     const accountKey = firstDepositAccountKey;
     void requestFirstDepositAction({
       beforeDeposit: onClose,
       shouldIgnoreResult: () =>
         Boolean(accountKey && firstDepositAccountKeyRef.current !== accountKey),
     });
-  }, [
-    firstDepositAccountKey,
-    isTradingActionLoading,
-    onClose,
-    requestFirstDepositAction,
-  ]);
+  }, [firstDepositAccountKey, onClose, requestFirstDepositAction]);
 
   const handleConnectWallet = useCallback(async () => {
     onClose();
@@ -1477,11 +1476,7 @@ export function LimitOrderForm({
             childrenAsText={false}
             borderRadius="$full"
             variant="primary"
-            disabled={isTradingActionLoading}
-            loading={isTradingActionLoading}
-            onPress={
-              isTradingActionLoading ? undefined : handleFirstDepositPress
-            }
+            onPress={handleFirstDepositPress}
             testID="chart-limit-deposit-to-trade"
             h={36}
           >

--- a/packages/kit/src/views/Perp/hooks/useEnableTradingWithDepositFallback.test.ts
+++ b/packages/kit/src/views/Perp/hooks/useEnableTradingWithDepositFallback.test.ts
@@ -191,7 +191,13 @@ describe('useFirstDepositAction', () => {
     mockShowHyperliquidTermsDialog.mockResolvedValue(true);
   });
 
-  it('refreshes status and opens deposit without invoking enable trading', async () => {
+  it('opens deposit without waiting for the background status refresh', async () => {
+    let resolveStatusRefresh: (() => void) | undefined;
+    mockCheckPerpsAccountStatus.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveStatusRefresh = resolve;
+      }),
+    );
     mockLatestPerpsAccountStatus = buildPerpsAccountStatus(false);
     const { result } = renderHook(() => useFirstDepositAction());
 
@@ -203,6 +209,11 @@ describe('useFirstDepositAction', () => {
     expect(mockShowDepositWithdrawModal).toHaveBeenCalledTimes(1);
     expect(mockShowHyperliquidTermsDialog).not.toHaveBeenCalled();
     expect(mockEnableTrading).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveStatusRefresh?.();
+      await Promise.resolve();
+    });
   });
 
   it('uses the terms-gated enable flow when the refreshed account needs setup', async () => {

--- a/packages/kit/src/views/Perp/hooks/useEnableTradingWithDepositFallback.ts
+++ b/packages/kit/src/views/Perp/hooks/useEnableTradingWithDepositFallback.ts
@@ -184,7 +184,22 @@ export function useFirstDepositAction() {
       }
 
       return runAccountScopedRequest(async (isRequestCurrent) => {
-        let status: IPerpsActiveAccountStatusAtom | undefined;
+        let status = await perpsActiveAccountStatusAtom.get();
+        if (getEnableTradingDialogConfirmDecision(status) === 'deposit') {
+          if (!isRequestCurrent() || options?.shouldIgnoreResult?.()) {
+            return { shouldContinue: false, status };
+          }
+          const result = await handleEnableTradingPostStatus(status, options);
+          if (isRequestCurrent() && !options?.shouldIgnoreResult?.()) {
+            // Keep the account snapshot fresh without delaying a deposit menu
+            // that already passed the live first-deposit status gate.
+            void backgroundApiProxy.serviceHyperliquid
+              .checkPerpsAccountStatus()
+              .catch(() => undefined);
+          }
+          return result;
+        }
+
         try {
           await errorToastUtils.withErrorAutoToast(() =>
             backgroundApiProxy.serviceHyperliquid.checkPerpsAccountStatus(),

--- a/packages/kit/src/views/Perp/hooks/useShowDepositWithdrawModal.ts
+++ b/packages/kit/src/views/Perp/hooks/useShowDepositWithdrawModal.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
@@ -30,6 +30,15 @@ type IPerpsDepositWithdrawActionType = 'deposit' | 'withdraw';
 
 function isUnifoldDepositFeatureEnabled(remoteEnabled: boolean | undefined) {
   return remoteEnabled === true;
+}
+
+export function usePreloadPerpsUnifoldDepositModals(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    void loadPerpsUnifoldDepositModals().catch(() => undefined);
+  }, [enabled]);
 }
 
 export function useUnifoldDepositTrackerAvailability() {


### PR DESCRIPTION
## Summary

- hide the skip-confirm option when an aggressive limit-price warning forces order confirmation
- keep both first-deposit buttons visually stable without shared loading or disabled state
- preload the Unifold deposit menu and open it before the background account-status refresh completes
- preserve account-scoped stale-result guards and the existing enable-trading fallback for other states

## Testing

- `yarn agent:check --profile commit`
- `yarn agent:check --profile pr`
- `yarn jest packages/kit/src/views/Perp/hooks/useEnableTradingWithDepositFallback.test.ts packages/kit/src/views/Perp/utils/enableTradingDialogConfirm.test.ts packages/kit/src/views/Perp/utils/perpsOrderPanelEnableTrading.test.ts --runInBand`
- Web hot-reload compilation and `http://127.0.0.1:3000` HTTP 200

## Jira Issue

- https://onekeyhq.atlassian.net/browse/OK-60323
