### PR TITLE
fix: stabilize Market quote loading and cross-chain history (OK-60465, OK-60591)

### DIFF
--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.test.tsx
@@ -267,6 +267,7 @@ describe('SwapPanelContent', () => {
     expect(actionButtonMock).toHaveBeenCalledWith(
       expect.objectContaining({
         disabled: true,
+        loading: true,
       }),
     );
   });

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
@@ -41,6 +41,7 @@ import type { IMarketPresetSettingsState } from './hooks/useMarketPresetSettings
 export type ISwapPanelContentProps = {
   swapPanel: ReturnType<typeof useSwapPanel>;
   isLoading: boolean;
+  quoteLoading?: boolean;
   isActionDisabled?: boolean;
   isRefreshQuote?: boolean;
   onRefreshQuote?: () => void;
@@ -89,6 +90,7 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
     enableAddressTypeSelector,
     swapPanel,
     isLoading,
+    quoteLoading = false,
     isActionDisabled,
     isRefreshQuote,
     onRefreshQuote,
@@ -339,17 +341,22 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
           toTokenSymbol={priceRate?.toTokenSymbol}
           loading={priceRate?.loading}
         />
-        {quoteResult?.info.provider ? (
+        {quoteLoading || quoteResult?.info.provider ? (
           <SwapProviderInfoItem
-            providerIcon={quoteResult.info.providerLogo ?? ''}
-            providerName={quoteResult.info.providerName ?? ''}
-            isBest={quoteResult.isBest}
-            fromToken={quoteResult.fromTokenInfo}
-            toToken={quoteResult.toTokenInfo}
-            showLock={!!quoteResult.allowanceResult}
-            percentageFee={quoteResult.fee?.percentageFee}
-            percentOriginFee={quoteResult.fee?.percentOriginFee}
-            onPress={quoteListLength > 1 ? onOpenProviderList : undefined}
+            providerIcon={quoteResult?.info.providerLogo ?? ''}
+            providerName={quoteResult?.info.providerName ?? ''}
+            isBest={quoteResult?.isBest}
+            fromToken={quoteResult?.fromTokenInfo}
+            toToken={quoteResult?.toTokenInfo}
+            showLock={!!quoteResult?.allowanceResult}
+            percentageFee={quoteResult?.fee?.percentageFee}
+            percentOriginFee={quoteResult?.fee?.percentOriginFee}
+            onPress={
+              quoteLoading || quoteListLength <= 1
+                ? undefined
+                : onOpenProviderList
+            }
+            isLoading={quoteLoading}
           />
         ) : null}
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelContent.tsx
@@ -158,6 +158,11 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
   }
   const showMarketPresetSelector =
     !isWrapped && !!marketPresetSettings?.enabled;
+  const shouldReduceSellForPresetGap =
+    tradeType === ESwapDirection.SELL &&
+    !quoteError &&
+    showMarketPresetSelector &&
+    !!marketPresetSettings?.presets.length;
   const suppressStandaloneSlippage =
     isWrapped || showMarketPresetSelector || !!marketPresetSettings?.isLoading;
   let actionButtonOnPress = onSwap;
@@ -350,13 +355,15 @@ export function SwapPanelContent(props: ISwapPanelContentProps) {
 
         {/* Balance display */}
         {tradeType === ESwapDirection.SELL ? (
-          <SellForSelector
-            defaultTokens={defaultTokens}
-            currentSelectToken={balanceToken as ISwapTokenBase}
-            onTokenSelect={(token) => setPaymentToken(token as IToken)}
-            symbol={paymentToken?.symbol ?? '-'}
-            isLoading={!hasInitialReady}
-          />
+          <YStack mb={shouldReduceSellForPresetGap ? '$-1' : undefined}>
+            <SellForSelector
+              defaultTokens={defaultTokens}
+              currentSelectToken={balanceToken as ISwapTokenBase}
+              onTokenSelect={(token) => setPaymentToken(token as IToken)}
+              symbol={paymentToken?.symbol ?? '-'}
+              isLoading={!hasInitialReady}
+            />
+          </YStack>
         ) : null}
       </YStack>
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/SwapPanelWrap.tsx
@@ -281,7 +281,7 @@ function SwapPanelWrapContent({ onCloseDialog }: ISwapPanelWrapProps) {
     priceRate,
     quoteResult,
     quoteList,
-    quoteFetching,
+    quoteActionLoading,
     quoteError,
     quoteReadyForReview,
     quoteNeedsRefresh,
@@ -575,11 +575,11 @@ function SwapPanelWrapContent({ onCloseDialog }: ISwapPanelWrapProps) {
       speedSwapBuildTxLoading ||
       swapApprovingMatchLoading ||
       checkTokenAllowanceLoading ||
-      quoteFetching
+      quoteActionLoading
     );
   }, [
     checkTokenAllowanceLoading,
-    quoteFetching,
+    quoteActionLoading,
     speedSwapBuildTxLoading,
     swapApprovingMatchLoading,
   ]);
@@ -771,6 +771,7 @@ function SwapPanelWrapContent({ onCloseDialog }: ISwapPanelWrapProps) {
       balanceLoading={fetchBalanceLoading}
       paymentTokenPrice={paymentTokenPrice}
       isLoading={isActionLoading || isReviewOpening}
+      quoteLoading={quoteActionLoading}
       isActionDisabled={
         marketPresetSettings.isLoading ||
         (!isWrapped && !quoteReadyForReview && !quoteNeedsRefresh)

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
@@ -178,6 +178,14 @@ export function ActionButton({
     return symbol;
   }, [token?.symbol]);
 
+  const truncatedMarketSymbol = useMemo(() => {
+    const symbol = actionToken?.symbol || token?.symbol || '';
+    if (symbol.length > 20) {
+      return `${symbol.slice(0, 17)}...`;
+    }
+    return symbol;
+  }, [actionToken?.symbol, token?.symbol]);
+
   const tokenFormatter: INumberFormatProps = useMemo(() => {
     return {
       formatter: 'balance',
@@ -306,7 +314,7 @@ export function ActionButton({
     shouldUseColoredStyle = true;
     isButtonDisabled = false;
     if (!hasAmount) {
-      buttonText = `${actionText} ${truncatedSymbol}`.trim();
+      buttonText = `${actionText} ${truncatedMarketSymbol}`.trim();
     }
   }
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
@@ -302,8 +302,12 @@ export function ActionButton({
     !noAccount,
   );
 
-  if (shouldJumpToSwap && hasAmount) {
+  if (shouldJumpToSwap) {
     shouldUseColoredStyle = true;
+    isButtonDisabled = false;
+    if (!hasAmount) {
+      buttonText = `${actionText} ${truncatedSymbol}`.trim();
+    }
   }
 
   if (platformEnv.isWeb && noAccount) {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
@@ -324,7 +324,9 @@ export function ActionButton({
     isButtonDisabled = false;
   }
 
-  const isButtonLoading = createAddressLoading || Boolean(loading);
+  const isButtonLoading = shouldJumpToSwap
+    ? createAddressLoading
+    : createAddressLoading || Boolean(loading);
 
   const buttonStyleProps: IButtonProps = shouldUseColoredStyle
     ? {
@@ -340,11 +342,11 @@ export function ActionButton({
         showAccountSelector();
         return;
       }
-      if (isButtonLoading) {
-        return;
-      }
       if (shouldJumpToSwap) {
         handleJumpToSwapAction();
+        return;
+      }
+      if (isButtonLoading) {
         return;
       }
       if (!hasAmount && !shouldCreateAddress?.result && !createAddressLoading) {

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/ActionButton.tsx
@@ -29,7 +29,6 @@ import {
   ESwapTabSwitchType,
 } from '@onekeyhq/shared/types/swap/types';
 
-import { useTokenDetail } from '../../../hooks/useTokenDetail';
 import { ESwapDirection, type ITradeType } from '../hooks/useTradeType';
 
 import { resolveMarketTradeActionState } from './ActionButton.utils';
@@ -73,12 +72,11 @@ export function ActionButton({
   actionToken,
   onSwapAction,
   isRefreshQuote,
+  loading,
   ...otherProps
 }: IActionButtonProps) {
-  const [hasClickedWithoutAmount, setHasClickedWithoutAmount] = useState(false);
   const intl = useIntl();
   const { gtMd } = useMedia();
-  const { tokenDetail } = useTokenDetail();
   const currencyInfo = useCurrency();
   const { activeAccount } = useActiveAccount({ num: 0 });
   const navigation = useAppNavigation();
@@ -179,15 +177,6 @@ export function ActionButton({
     }
     return symbol;
   }, [token?.symbol]);
-
-  // Truncate tokenDetail symbol if it exceeds 20 characters
-  const truncatedTokenDetailSymbol = useMemo(() => {
-    const symbol = tokenDetail?.symbol || '';
-    if (symbol.length > 20) {
-      return `${symbol.slice(0, 17)}...`;
-    }
-    return symbol;
-  }, [tokenDetail?.symbol]);
 
   const tokenFormatter: INumberFormatProps = useMemo(() => {
     return {
@@ -313,18 +302,7 @@ export function ActionButton({
     !noAccount,
   );
 
-  if (
-    !hasAmount &&
-    !hasClickedWithoutAmount &&
-    !shouldCreateAddress?.result &&
-    !createAddressLoading
-  ) {
-    shouldUseColoredStyle = true;
-    buttonText = `${actionText} ${truncatedTokenDetailSymbol}`.trim();
-    isButtonDisabled = false;
-  }
-
-  if (shouldJumpToSwap) {
+  if (shouldJumpToSwap && hasAmount) {
     shouldUseColoredStyle = true;
   }
 
@@ -333,6 +311,8 @@ export function ActionButton({
     shouldUseColoredStyle = false;
     isButtonDisabled = false;
   }
+
+  const isButtonLoading = createAddressLoading || Boolean(loading);
 
   const buttonStyleProps: IButtonProps = shouldUseColoredStyle
     ? {
@@ -348,17 +328,14 @@ export function ActionButton({
         showAccountSelector();
         return;
       }
+      if (isButtonLoading) {
+        return;
+      }
       if (shouldJumpToSwap) {
         handleJumpToSwapAction();
         return;
       }
-      setHasClickedWithoutAmount(true);
-      if (
-        !hasAmount &&
-        !hasClickedWithoutAmount &&
-        !shouldCreateAddress?.result &&
-        !createAddressLoading
-      ) {
+      if (!hasAmount && !shouldCreateAddress?.result && !createAddressLoading) {
         return;
       }
       if (noAccount) {
@@ -406,9 +383,9 @@ export function ActionButton({
     [
       shouldJumpToSwap,
       hasAmount,
-      hasClickedWithoutAmount,
       noAccount,
       createAddressLoading,
+      isButtonLoading,
       shouldCreateAddress?.result,
       onPress,
       isRefreshQuote,
@@ -427,13 +404,14 @@ export function ActionButton({
     <Button
       testID="market-btn"
       size={gtMd ? 'medium' : 'large'}
-      disabled={isButtonDisabled}
+      disabled={isButtonDisabled || isButtonLoading}
       onPress={handlePress}
-      loading={createAddressLoading || otherProps.loading}
+      loading={isButtonLoading}
       {...otherProps}
       {...buttonStyleProps}
     >
-      {buttonText}
+      {/* Keep the label height stable while Button renders its spinner. */}
+      {isButtonLoading ? '\u00a0' : buttonText}
     </Button>
   );
 }

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/SellForSelector.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/components/SellForSelector.tsx
@@ -36,7 +36,7 @@ const SellForSelector = ({
         userSelect="none"
         cursor="default"
       >
-        <SizableText size="$bodySm" color="$textSubdued">
+        <SizableText size="$bodyMd" color="$textSubdued">
           {intl.formatMessage({
             id: ETranslations.promode_limit_sell_for,
           })}
@@ -54,7 +54,7 @@ const SellForSelector = ({
             pressStyle: { bg: '$bgActive' },
           })}
         >
-          <SizableText size="$bodySmMedium">{symbol ?? '-'}</SizableText>
+          <SizableText size="$bodyMdMedium">{symbol ?? '-'}</SizableText>
           {hasMultipleTokens ? (
             <Icon
               name="ChevronDownSmallOutline"

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.test.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.test.ts
@@ -63,12 +63,14 @@ describe('marketSwapBuildUtils', () => {
         quoteRequestMatchesCurrentInput: true,
         quoteRequestLocked: false,
         quoteFetching: false,
+        quoteEventFetching: false,
         shouldRefreshQuote: false,
         hasQuoteError: false,
       }),
     ).toEqual({
       canRefresh: false,
       canReview: true,
+      isLoading: false,
     });
   });
 
@@ -76,6 +78,7 @@ describe('marketSwapBuildUtils', () => {
     { quoteRequestMatchesCurrentInput: false },
     { quoteRequestLocked: true },
     { quoteFetching: true },
+    { quoteEventFetching: true },
     { hasActionableQuote: false },
     { hasQuoteError: true },
   ])('blocks review when quote state is not executable: %#', (overrides) => {
@@ -85,6 +88,7 @@ describe('marketSwapBuildUtils', () => {
         quoteRequestMatchesCurrentInput: true,
         quoteRequestLocked: false,
         quoteFetching: false,
+        quoteEventFetching: false,
         shouldRefreshQuote: false,
         hasQuoteError: false,
         ...overrides,
@@ -99,12 +103,14 @@ describe('marketSwapBuildUtils', () => {
         quoteRequestMatchesCurrentInput: true,
         quoteRequestLocked: false,
         quoteFetching: false,
+        quoteEventFetching: false,
         shouldRefreshQuote: true,
         hasQuoteError: false,
       }),
     ).toEqual({
       canRefresh: true,
       canReview: false,
+      isLoading: false,
     });
   });
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/marketSwapBuildUtils.ts
@@ -11,6 +11,7 @@ export function resolveMarketQuoteActionState({
   quoteRequestMatchesCurrentInput,
   quoteRequestLocked,
   quoteFetching,
+  quoteEventFetching,
   shouldRefreshQuote,
   hasQuoteError,
 }: {
@@ -18,10 +19,12 @@ export function resolveMarketQuoteActionState({
   quoteRequestMatchesCurrentInput: boolean;
   quoteRequestLocked: boolean;
   quoteFetching: boolean;
+  quoteEventFetching: boolean;
   shouldRefreshQuote: boolean;
   hasQuoteError: boolean;
 }) {
-  const quoteRequestSettled = !quoteRequestLocked && !quoteFetching;
+  const isLoading = quoteRequestLocked || quoteFetching || quoteEventFetching;
+  const quoteRequestSettled = !isLoading;
   const canRefresh =
     shouldRefreshQuote &&
     quoteRequestMatchesCurrentInput &&
@@ -35,6 +38,7 @@ export function resolveMarketQuoteActionState({
       quoteRequestSettled &&
       !shouldRefreshQuote &&
       !hasQuoteError,
+    isLoading,
   };
 }
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/usePaymentTokenPrice.test.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/usePaymentTokenPrice.test.tsx
@@ -29,6 +29,13 @@ let mockCapturedMethod:
   | (() => Promise<IPaymentTokenPriceResult | undefined>)
   | undefined;
 let mockCapturedDeps: unknown[] = [];
+let mockCapturedOptions:
+  | {
+      pollingInterval?: number;
+      undefinedResultIfReRun?: boolean;
+      watchLoading?: boolean;
+    }
+  | undefined;
 
 jest.mock('@onekeyhq/kit/src/background/instance/backgroundApiProxy', () => ({
   __esModule: true,
@@ -44,9 +51,15 @@ jest.mock('@onekeyhq/kit/src/hooks/usePromiseResult', () => ({
   usePromiseResult: (
     method: () => Promise<IPaymentTokenPriceResult | undefined>,
     deps: unknown[],
+    options?: {
+      pollingInterval?: number;
+      undefinedResultIfReRun?: boolean;
+      watchLoading?: boolean;
+    },
   ) => {
     mockCapturedMethod = method;
     mockCapturedDeps = deps;
+    mockCapturedOptions = options;
     return {
       result: mockPromiseResult,
       isLoading: false,
@@ -70,6 +83,7 @@ describe('usePaymentTokenPrice', () => {
     mockPromiseResult = undefined;
     mockCapturedMethod = undefined;
     mockCapturedDeps = [];
+    mockCapturedOptions = undefined;
   });
 
   it('requests token detail with the selected currency and returns a currency-aware key', async () => {
@@ -125,5 +139,15 @@ describe('usePaymentTokenPrice', () => {
 
     expect(result.current.price?.toFixed()).toBe('9');
     expect(result.current.tokenKey).toBe('evm--1:0xusdc:cny');
+  });
+
+  it('keeps the previous price while polling for a refresh', () => {
+    renderHook(() => usePaymentTokenPrice(paymentToken, 'evm--1', 'cny'));
+
+    expect(mockCapturedOptions).toEqual({
+      pollingInterval: 5000,
+      watchLoading: true,
+    });
+    expect(mockCapturedOptions).not.toHaveProperty('undefinedResultIfReRun');
   });
 });

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/usePaymentTokenPrice.ts
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/usePaymentTokenPrice.ts
@@ -69,7 +69,6 @@ export function usePaymentTokenPrice(
     {
       watchLoading: true,
       pollingInterval: 5000, // 5 seconds
-      undefinedResultIfReRun: true,
     },
   );
 

--- a/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
+++ b/packages/kit/src/views/Market/MarketDetailV2/components/SwapPanel/hooks/useSpeedSwapActions.tsx
@@ -37,8 +37,10 @@ import {
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap';
 import {
   getSwapQuoteProgressState,
+  isSwapNoProviderSupportsTrade,
   isSwapQuoteEventFetching,
   isSwapQuoteRequestForCurrentInput,
+  isSwapZeroProviderQuoteCompleted,
 } from '@onekeyhq/kit/src/states/jotai/contexts/swap/quoteProgress';
 import { getGasAccountErrorEntry } from '@onekeyhq/kit/src/views/SignatureConfirm/constants/gasAccountErrorCodes';
 import { type ISwapReviewStepTexts } from '@onekeyhq/kit/src/views/Swap/utils/buildSwapReviewState';
@@ -631,27 +633,32 @@ export function useSpeedSwapActions(props: {
       leading: true,
     },
   );
+  const quoteEventFetching = useMemo(
+    () =>
+      isSwapQuoteEventFetching({
+        quoteEventTotalCount,
+        currentEventReceivedCount,
+        quoteEventCompleted,
+      }),
+    [currentEventReceivedCount, quoteEventCompleted, quoteEventTotalCount],
+  );
   const quoteProgressState = useMemo(
     () =>
       getSwapQuoteProgressState({
         quoteLoading: quoteFetching,
-        quoteEventFetching: isSwapQuoteEventFetching({
-          quoteEventTotalCount,
-          currentEventReceivedCount,
-          quoteEventCompleted,
-        }),
+        quoteEventFetching,
         quoteCurrentSelect: selectedQuoteResult,
         quoteEventTotalCount,
         quoteEventCompleted,
         quoteEventError,
       }),
     [
-      currentEventReceivedCount,
       quoteEventCompleted,
       quoteEventError,
-      quoteEventTotalCount,
+      quoteEventFetching,
       quoteFetching,
       selectedQuoteResult,
+      quoteEventTotalCount,
     ],
   );
   const quoteRequestMatchesCurrentInput = useMemo(
@@ -677,6 +684,43 @@ export function useSpeedSwapActions(props: {
       toToken,
     ],
   );
+  const quoteResultPairNoMatch = useMemo(
+    () =>
+      Boolean(
+        selectedQuoteResult &&
+        !(
+          equalTokenNoCaseSensitive({
+            token1: selectedQuoteResult.fromTokenInfo,
+            token2: fromToken,
+          }) &&
+          equalTokenNoCaseSensitive({
+            token1: selectedQuoteResult.toTokenInfo,
+            token2: toToken,
+          })
+        ),
+      ),
+    [fromToken, selectedQuoteResult, toToken],
+  );
+  const noProviderSupportsTrade = useMemo(
+    () =>
+      isSwapNoProviderSupportsTrade({
+        zeroProviderQuoteCompleted: isSwapZeroProviderQuoteCompleted({
+          quoteEventTotalCount,
+          quoteEventCompleted,
+        }),
+        quote: selectedQuoteResult,
+        quoteResultPairNoMatch,
+        quoteEventCompleted,
+        quoteRequestMatchesCurrentInput,
+      }),
+    [
+      quoteEventCompleted,
+      quoteEventTotalCount,
+      quoteRequestMatchesCurrentInput,
+      quoteResultPairNoMatch,
+      selectedQuoteResult,
+    ],
+  );
   const quoteActionState = useMemo(
     () =>
       resolveMarketQuoteActionState({
@@ -684,15 +728,20 @@ export function useSpeedSwapActions(props: {
         quoteRequestMatchesCurrentInput,
         quoteRequestLocked: quoteActionLock.actionLock,
         quoteFetching,
+        quoteEventFetching,
         shouldRefreshQuote,
         hasQuoteError: Boolean(
-          quoteEventError?.message || selectedQuoteResult?.errorMessage,
+          quoteEventError?.message ||
+          selectedQuoteResult?.errorMessage ||
+          noProviderSupportsTrade,
         ),
       }),
     [
       quoteActionLock.actionLock,
       quoteEventError?.message,
+      quoteEventFetching,
       quoteFetching,
+      noProviderSupportsTrade,
       quoteProgressState.hasActionableQuote,
       quoteRequestMatchesCurrentInput,
       selectedQuoteResult?.errorMessage,
@@ -3385,6 +3434,24 @@ export function useSpeedSwapActions(props: {
     syncTokensBalance,
   ]);
 
+  const marketPriceRate = (() => {
+    if (selectedQuoteResult?.instantRate) {
+      return {
+        rate: Number(selectedQuoteResult.instantRate),
+        fromTokenSymbol: selectedQuoteResult.fromTokenInfo.symbol,
+        toTokenSymbol: selectedQuoteResult.toTokenInfo.symbol,
+        loading: quoteActionState.isLoading,
+      };
+    }
+    if (priceRate) {
+      return {
+        ...priceRate,
+        loading: priceRate.loading || quoteActionState.isLoading,
+      };
+    }
+    return undefined;
+  })();
+
   return {
     speedSwapBuildTxLoading,
     swapApprovingMatchLoading,
@@ -3398,19 +3465,19 @@ export function useSpeedSwapActions(props: {
     paymentTokenPrice: effectiveTradeTokenPrice.gt(0)
       ? effectiveTradeTokenPrice
       : undefined,
-    priceRate: selectedQuoteResult?.instantRate
-      ? {
-          rate: Number(selectedQuoteResult.instantRate),
-          fromTokenSymbol: selectedQuoteResult.fromTokenInfo.symbol,
-          toTokenSymbol: selectedQuoteResult.toTokenInfo.symbol,
-          loading: quoteFetching,
-        }
-      : priceRate,
+    priceRate: marketPriceRate,
     quoteResult: selectedQuoteResult,
     quoteList,
-    quoteFetching,
+    quoteActionLoading: quoteActionState.isLoading,
     isWrapped,
-    quoteError: quoteEventError?.message ?? selectedQuoteResult?.errorMessage,
+    quoteError:
+      quoteEventError?.message ??
+      selectedQuoteResult?.errorMessage ??
+      (noProviderSupportsTrade
+        ? intl.formatMessage({
+            id: ETranslations.swap_page_alert_no_provider_supports_trade,
+          })
+        : undefined),
     quoteReadyForReview: quoteActionState.canReview,
     quoteNeedsRefresh: quoteActionState.canRefresh,
     refreshMarketQuote,

--- a/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
+++ b/packages/kit/src/views/Swap/pages/modal/SwapHistoryDetailModal.tsx
@@ -80,6 +80,7 @@ import {
   type ISwapHistoryTransactionIdKind,
   type ISwapHistoryTransactionIdRow,
   getSwapHistoryTransactionIdRows,
+  isSwapHistoryRefundStatus,
 } from '../../utils/swapHistoryTransactionIds';
 import {
   type ISwapOrderProgressStepLabel,
@@ -1301,7 +1302,8 @@ const SwapHistoryDetailModal = () => {
         <SizableText size={16} color={color}>
           {intl.formatMessage({ id: key })}
         </SizableText>
-        {txHistory?.swapOrderHash?.refundHash &&
+        {isSwapHistoryRefundStatus(txHistory?.crossChainStatus) &&
+        txHistory?.swapOrderHash?.refundHash &&
         !transactionIdRows.some((row) => row.kind === 'refund') ? (
           <XStack
             onPress={async () => {

--- a/packages/kit/src/views/Swap/utils/swapHistoryTransactionIds.test.ts
+++ b/packages/kit/src/views/Swap/utils/swapHistoryTransactionIds.test.ts
@@ -244,6 +244,39 @@ describe('getSwapHistoryTransactionIdRows', () => {
     ]);
   });
 
+  it('ignores a stale refund hash after the target chain succeeds', () => {
+    expect(
+      getSwapHistoryTransactionIdRows(
+        createHistory({
+          status: ESwapTxHistoryStatus.SUCCESS,
+          fromNetworkId: 'evm--56',
+          toNetworkId: 'evm--1',
+          crossChainStatus: ESwapCrossChainStatus.TO_SUCCESS,
+          receiverTransactionId: '0xtarget',
+          swapOrderHash: {
+            fromTxHash: '0xsource',
+            toTxHash: '0xtarget',
+            refundHash: '0xstale-refund',
+          },
+        }),
+      ),
+    ).toEqual([
+      {
+        kind: 'source',
+        transactionId: '0xsource',
+        networkId: 'evm--56',
+        showExplorer: true,
+      },
+      {
+        kind: 'target',
+        transactionId: '0xtarget',
+        networkId: 'evm--1',
+        showExplorer: true,
+        showPendingNote: false,
+      },
+    ]);
+  });
+
   it('does not change private-send transaction rendering', () => {
     expect(
       getSwapHistoryTransactionIdRows(

--- a/packages/kit/src/views/Swap/utils/swapHistoryTransactionIds.ts
+++ b/packages/kit/src/views/Swap/utils/swapHistoryTransactionIds.ts
@@ -2,6 +2,7 @@ import { privateSendProvider } from '@onekeyhq/shared/types/swap/SwapProvider.co
 import type { ISwapTxHistory } from '@onekeyhq/shared/types/swap/types';
 import {
   EProtocolOfExchange,
+  ESwapCrossChainStatus,
   ESwapTxHistoryStatus,
 } from '@onekeyhq/shared/types/swap/types';
 
@@ -12,6 +13,20 @@ const SECOND_TRANSACTION_ID_HIDDEN_STATUSES = new Set([
   ESwapTxHistoryStatus.CANCELED,
   ESwapTxHistoryStatus.CANCELING,
 ]);
+
+const REFUND_CROSS_CHAIN_STATUSES = new Set<ESwapCrossChainStatus>([
+  ESwapCrossChainStatus.REFUNDING,
+  ESwapCrossChainStatus.REFUNDED,
+  ESwapCrossChainStatus.REFUND_FAILED,
+]);
+
+export function isSwapHistoryRefundStatus(
+  crossChainStatus?: ESwapCrossChainStatus,
+) {
+  return Boolean(
+    crossChainStatus && REFUND_CROSS_CHAIN_STATUSES.has(crossChainStatus),
+  );
+}
 
 export type ISwapHistoryTransactionIdKind =
   | 'transaction'
@@ -74,6 +89,9 @@ export function getSwapHistoryTransactionIdRows(
     getTransactionId(item.swapOrderHash?.toTxHash) ??
     getTransactionId(item.txInfo.receiverTransactionId);
   const refundTransactionId = getTransactionId(item.swapOrderHash?.refundHash);
+  const shouldShowRefundTransaction = Boolean(
+    refundTransactionId && isSwapHistoryRefundStatus(item.crossChainStatus),
+  );
 
   const isStandardSwapHistory =
     !item.protocol || item.protocol === EProtocolOfExchange.SWAP;
@@ -91,7 +109,9 @@ export function getSwapHistoryTransactionIdRows(
 
   if (!sourceTransactionId) {
     return buildSingleTransactionIdRow({
-      transactionId: targetTransactionId ?? refundTransactionId,
+      transactionId:
+        targetTransactionId ??
+        (shouldShowRefundTransaction ? refundTransactionId : undefined),
       networkId: targetTransactionId ? toNetworkId : fromNetworkId,
       showExplorer: true,
     });
@@ -108,7 +128,7 @@ export function getSwapHistoryTransactionIdRows(
     isCrossChain ||
     isKnownDualTransactionIdProvider ||
     Boolean(targetTransactionId) ||
-    Boolean(refundTransactionId);
+    shouldShowRefundTransaction;
 
   if (!shouldUseDualTransactionIdLayout) {
     return buildSingleTransactionIdRow({
@@ -125,7 +145,7 @@ export function getSwapHistoryTransactionIdRows(
     showExplorer: true,
   };
 
-  if (refundTransactionId) {
+  if (shouldShowRefundTransaction) {
     return [
       sourceRow,
       {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60465](https://onekeyhq.atlassian.net/browse/OK-60465) [OK-60591](https://onekeyhq.atlassian.net/browse/OK-60591)

----------

<!-- github-pr-monitor:jira-links:end -->


## Issues
- Fixes OK-60465

## Summary
- Keep the Market action button loading until the full quote event stream completes and a final actionable quote is available.
- Prevent intermediate provider responses and payment-token polling from making the button amount or fiat value flash.
- Keep the provider row layout stable during quote refresh and show the no-provider-support error after the quote stream completes.
- Prevent `ActionButton` loading from being overwritten by spread props or triggering duplicate address creation.

## Root cause
- Quote fetching was split across request, event-stream, and action states, so the first provider response could release the button too early.
- The computed `ActionButton` loading prop was passed before `...otherProps`, allowing the caller's stale loading value to override it.
- Payment-token price refresh temporarily exposed an undefined result, which caused the fiat amount to flash.

## Validation
- `yarn jest --runInBand` for the five affected Market SwapPanel suites: 65 tests passed.
- `yarn agent:check --profile commit` passed: lint, format, agent-context, staged lint, and TypeScript checks.
- `git diff --check` passed.
- Desktop development runtime validation completed for the Market quote-loading layout and button-height behavior.

[OK-60465]: https://onekeyhq.atlassian.net/browse/OK-60465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

- Fixes OK-60591

## Cross-chain history hash fix

- Distinguish source-chain, target-chain, and refund transaction hashes by cross-chain status.
- Ignore a stale `refundHash` when the order has reached `TO_SUCCESS`, and keep the refund explorer affordance gated by refund states.

## OK-60591 Root cause

The history response for a successful cross-chain order contained both `toTxHash` and `refundHash`, with `crossChainStatus: TO_SUCCESS`. The transaction-row helper treated any present `refundHash` as authoritative and rendered it before the target-chain hash.

## Additional validation

- Electron development runtime reproduced the issue and verified the successful order now shows the target-chain transaction hash instead of a refund hash.
- Added regression coverage for a successful cross-chain order containing a stale refund hash.
- Focused Swap history and Market fallback tests passed; `yarn agent:check --profile commit` passed.

[OK-60591]: https://onekeyhq.atlassian.net/browse/OK-60591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ