### PR TITLE
chore: auto-post qualifying review inline comments

### DIFF
--- a/.skillshare/skills/1k-code-review-pr/SKILL.md
+++ b/.skillshare/skills/1k-code-review-pr/SKILL.md
@@ -24,7 +24,7 @@ allowed-tools: Read, Grep, Glob, Bash, WebFetch
 7. **Merge Findings** — Combine primary + Codex + PR comment findings, deduplicate, annotate confidence
 8. **Score** — Rate the PR across 4 dimensions (see Scoring System). **This step is MANDATORY — every report MUST include the scoring table.**
 9. **Report** — Generate structured report using the unified format. **Follow the template exactly — every section is required.**
-10. **GH Comment** — For Blocker issues, offer to post inline PR comments (with confirmation)
+10. **GH Comment** — Post qualifying findings as inline PR comments immediately (do not wait for confirmation)
 
 ## Codex Cross-Review Integration
 
@@ -241,7 +241,7 @@ Do NOT generate auto-fix for:
 
 ## GH CLI Inline Comments
 
-After generating the report, if there are findings that meet the comment threshold:
+After generating the report, if there are findings that meet the comment threshold, **post them immediately**. Do not ask "是否确认？" and do not wait for a follow-up message. New conversations have no memory of a verbal "以后都自动发" — this section is the source of truth.
 
 **Comment threshold**: 🔴 高 priority (any confidence) OR 🟡 中 priority with 🔵 High confidence. This means:
 - All 🔴 高 findings (regardless of confidence)
@@ -249,8 +249,7 @@ After generating the report, if there are findings that meet the comment thresho
 - Excludes: 🟢 低 findings, and 🟡 中 with 🟠 Medium or ⚪ Low confidence
 
 1. List the qualifying findings that warrant PR comments
-2. **Ask the reviewer**: "以下问题建议直接评论到 PR 上，是否确认？"
-3. **Only after explicit yes**, post via:
+2. Post them in the same turn as the report, using `ManagePullRequest` `post_comment` (path + line) when available, otherwise:
 
 ```bash
 # Inline comment on specific file:line
@@ -270,10 +269,12 @@ _— Auto-review by Claude_" \
 ```
 
 **Rules:**
-- Never post without explicit reviewer confirmation
+- Always post qualifying findings in the same turn as the review report
 - Only post findings meeting the comment threshold (see above)
 - Include auto-fix in `suggestion` block when available
 - Maximum 5 inline comments per PR
+- GitHub can only attach review comments to lines in the PR diff; if the real site is unchanged, comment on the nearest changed line and name the unchanged site in the body
+- If an existing inline thread already states the same issue, reply to that thread instead of opening a duplicate
 
 ## Unified Report Format
 
@@ -354,7 +355,7 @@ _— Auto-review by Claude_" \
 - [ ] 问题1 — `file.tsx:42`
 - [ ] 问题2 — `file.tsx:88`
 
-> 确认后将通过 `gh` CLI 发送 inline comments。
+> 达标问题已在本回合直接发为 inline comments，无需再确认。
 ```
 
 ## Priority Definitions


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

New review conversations do not inherit a verbal “always post inline comments” preference. This updates the PR review skill so qualifying findings are posted in the same turn as the report, without waiting for confirmation.

## Intent & Context

Asked during #12918 review: auto-post inline comments, including in new chats. The previous skill required an explicit “是否确认？” before posting.

## Changes Detail

- `.skillshare/skills/1k-code-review-pr/SKILL.md` (`.claude/skills` and `.agents/skills` symlink here)
  - Post 🔴 高, or 🟡 中 + 🔵 High, immediately
  - Prefer `ManagePullRequest` `post_comment`; fall back to `gh api`
  - Reply to an existing equivalent thread instead of duplicating
  - If GitHub cannot attach to an unchanged line, comment on the nearest changed line

## Test plan

- [ ] Start a new review conversation on a PR with a 🟡 中 / 🔵 High finding
- [ ] Confirm inline comments appear in the same turn, with no confirmation prompt
- [ ] Confirm 🟢 低 findings are still report-only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb18b4a3-52bb-4fba-8612-8991b73e2530?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb18b4a3-52bb-4fba-8612-8991b73e2530&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

