### PR TITLE
feat: improve perps footer ticker marquee

### DIFF
--- a/packages/components/src/content/NetworkStatusBadge/index.tsx
+++ b/packages/components/src/content/NetworkStatusBadge/index.tsx
@@ -17,6 +17,7 @@ export type INetworkStatusBadgeProps = {
   monoLabel?: string;
   badgeSize?: ComponentProps<typeof Badge>['badgeSize'];
   minWidth?: ComponentProps<typeof Badge>['minWidth'];
+  cursor?: ComponentProps<typeof Badge>['cursor'];
 };
 
 export function NetworkStatusBadge({
@@ -26,6 +27,7 @@ export function NetworkStatusBadge({
   monoLabel,
   badgeSize = 'md',
   minWidth,
+  cursor = 'default',
 }: INetworkStatusBadgeProps) {
   const intl = useIntl();
 
@@ -81,7 +83,7 @@ export function NetworkStatusBadge({
       pl="$2"
       px="$3"
       gap={monoLabel ? '$0.5' : '$1.5'}
-      cursor="default"
+      cursor={cursor}
     >
       {indicatorElement}
       <Badge.Text size="$bodySmMedium">{badgeLabel}</Badge.Text>

--- a/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useState } from 'react';
 
 import { SizableText, XStack } from '@onekeyhq/components';
 
@@ -8,10 +8,8 @@ import { getFooterTickerDisplayText } from './footerTickerUtils';
 
 import type { IFooterTickerItemData } from './footerTickerUtils';
 
-const CHANGE_COLUMN_WIDTH = '8ch';
-const PRICE_COLUMN_WIDTH = '10ch';
-const DISPLAY_NAME_CHARACTER_WIDTH_PX = 8;
-const FIXED_ITEM_CONTENT_WIDTH_PX = 156;
+const ITEM_CHARACTER_WIDTH_PX = 7.75;
+const ITEM_INTERNAL_GAPS_WIDTH_PX = 12;
 
 interface IFooterTickerItemProps extends IFooterTickerItemData {
   isDuplicate?: boolean;
@@ -39,10 +37,13 @@ function FooterTickerItem({
     change24hPercent,
     markPrice,
   });
-  // Keep live price updates from changing the item's layout width.
-  const itemWidth =
-    displayName.length * DISPLAY_NAME_CHARACTER_WIDTH_PX +
-    FIXED_ITEM_CONTENT_WIDTH_PX;
+  // Freeze the initial text budget so live prices do not resize the item.
+  const [itemWidth] = useState(
+    () =>
+      (displayName.length + changeText.length + priceText.length) *
+        ITEM_CHARACTER_WIDTH_PX +
+      ITEM_INTERNAL_GAPS_WIDTH_PX,
+  );
   const handlePress = useCallback(() => {
     onPress({
       displayName,
@@ -89,9 +90,7 @@ function FooterTickerItem({
         size="$bodySmMedium"
         color={color}
         style={TABULAR_NUMS_STYLE}
-        width={CHANGE_COLUMN_WIDTH}
         flexShrink={0}
-        overflow="hidden"
         whiteSpace="nowrap"
       >
         {changeText}
@@ -101,9 +100,7 @@ function FooterTickerItem({
         color="$textSubdued"
         $group-hover={{ color: '$text' }}
         style={TABULAR_NUMS_STYLE}
-        width={PRICE_COLUMN_WIDTH}
         flexShrink={0}
-        overflow="hidden"
         whiteSpace="nowrap"
       >
         {priceText}

--- a/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
@@ -6,15 +6,13 @@ import { TABULAR_NUMS_STYLE } from '../FavoritesBar/FavoriteTokenItem';
 
 import { getFooterTickerDisplayText } from './footerTickerUtils';
 
-import type {
-  IFooterTickerItemData,
-  IFooterTickerTextWidthBudget,
-} from './footerTickerUtils';
+import type { IFooterTickerItemData } from './footerTickerUtils';
+
+const CHANGE_COLUMN_WIDTH = '8ch';
+const PRICE_COLUMN_WIDTH = '10ch';
 
 interface IFooterTickerItemProps extends IFooterTickerItemData {
   isDuplicate?: boolean;
-  isMeasure?: boolean;
-  widthBudget?: IFooterTickerTextWidthBudget;
   onPress: (item: IFooterTickerItemData) => void;
 }
 
@@ -27,8 +25,6 @@ function FooterTickerItem({
   change24hPercent,
   markPrice,
   isDuplicate,
-  isMeasure,
-  widthBudget,
   onPress,
 }: IFooterTickerItemProps) {
   const color = change24hPercent >= 0 ? '$textSuccess' : '$textCritical';
@@ -64,18 +60,15 @@ function FooterTickerItem({
 
   return (
     <XStack
-      aria-hidden={isDuplicate || isMeasure || undefined}
-      tabIndex={isDuplicate || isMeasure ? -1 : undefined}
-      onPress={isMeasure ? undefined : handlePress}
+      aria-hidden={isDuplicate || undefined}
+      tabIndex={isDuplicate ? -1 : undefined}
+      onPress={handlePress}
       group
       userSelect="none"
       alignItems="center"
       gap="$1.5"
-      cursor={isMeasure ? 'default' : 'pointer'}
+      cursor="pointer"
       flexShrink={0}
-      style={{
-        width: isMeasure ? 'max-content' : widthBudget?.itemWidth,
-      }}
     >
       <SizableText
         size="$bodySmMedium"
@@ -89,7 +82,7 @@ function FooterTickerItem({
         size="$bodySmMedium"
         color={color}
         style={TABULAR_NUMS_STYLE}
-        width={isMeasure ? undefined : widthBudget?.changeWidth}
+        width={CHANGE_COLUMN_WIDTH}
         flexShrink={0}
         overflow="hidden"
         whiteSpace="nowrap"
@@ -101,7 +94,7 @@ function FooterTickerItem({
         color="$textSubdued"
         $group-hover={{ color: '$text' }}
         style={TABULAR_NUMS_STYLE}
-        width={isMeasure ? undefined : widthBudget?.priceWidth}
+        width={PRICE_COLUMN_WIDTH}
         flexShrink={0}
         overflow="hidden"
         whiteSpace="nowrap"

--- a/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
@@ -10,7 +10,6 @@ import type { IFooterTickerItemData } from './footerTickerUtils';
 
 const CHANGE_COLUMN_WIDTH = '8ch';
 const PRICE_COLUMN_WIDTH = '10ch';
-const MIN_DISPLAY_NAME_WIDTH_PX = 32;
 const DISPLAY_NAME_CHARACTER_WIDTH_PX = 8;
 const FIXED_ITEM_CONTENT_WIDTH_PX = 156;
 
@@ -42,10 +41,8 @@ function FooterTickerItem({
   });
   // Keep live price updates from changing the item's layout width.
   const itemWidth =
-    Math.max(
-      MIN_DISPLAY_NAME_WIDTH_PX,
-      displayName.length * DISPLAY_NAME_CHARACTER_WIDTH_PX,
-    ) + FIXED_ITEM_CONTENT_WIDTH_PX;
+    displayName.length * DISPLAY_NAME_CHARACTER_WIDTH_PX +
+    FIXED_ITEM_CONTENT_WIDTH_PX;
   const handlePress = useCallback(() => {
     onPress({
       displayName,

--- a/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
@@ -10,6 +10,9 @@ import type { IFooterTickerItemData } from './footerTickerUtils';
 
 const CHANGE_COLUMN_WIDTH = '8ch';
 const PRICE_COLUMN_WIDTH = '10ch';
+const MIN_DISPLAY_NAME_WIDTH_PX = 32;
+const DISPLAY_NAME_CHARACTER_WIDTH_PX = 8;
+const FIXED_ITEM_CONTENT_WIDTH_PX = 156;
 
 interface IFooterTickerItemProps extends IFooterTickerItemData {
   isDuplicate?: boolean;
@@ -37,6 +40,12 @@ function FooterTickerItem({
     change24hPercent,
     markPrice,
   });
+  // Keep live price updates from changing the item's layout width.
+  const itemWidth =
+    Math.max(
+      MIN_DISPLAY_NAME_WIDTH_PX,
+      displayName.length * DISPLAY_NAME_CHARACTER_WIDTH_PX,
+    ) + FIXED_ITEM_CONTENT_WIDTH_PX;
   const handlePress = useCallback(() => {
     onPress({
       displayName,
@@ -69,6 +78,7 @@ function FooterTickerItem({
       gap="$1.5"
       cursor="pointer"
       flexShrink={0}
+      width={itemWidth}
     >
       <SizableText
         size="$bodySmMedium"

--- a/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
@@ -1,15 +1,12 @@
 import { memo, useCallback, useState } from 'react';
 
-import { SizableText, XStack } from '@onekeyhq/components';
+import { SizableText } from '@onekeyhq/components';
 
 import { TABULAR_NUMS_STYLE } from '../FavoritesBar/FavoriteTokenItem';
 
 import { getFooterTickerDisplayText } from './footerTickerUtils';
 
 import type { IFooterTickerItemData } from './footerTickerUtils';
-
-const ITEM_CHARACTER_WIDTH_PX = 7.75;
-const ITEM_INTERNAL_GAPS_WIDTH_PX = 12;
 
 interface IFooterTickerItemProps extends IFooterTickerItemData {
   isDuplicate?: boolean;
@@ -27,6 +24,7 @@ function FooterTickerItem({
   isDuplicate,
   onPress,
 }: IFooterTickerItemProps) {
+  const [isHovered, setIsHovered] = useState(false);
   const color = change24hPercent >= 0 ? '$textSuccess' : '$textCritical';
   const { changeText, priceText } = getFooterTickerDisplayText({
     displayName,
@@ -37,13 +35,6 @@ function FooterTickerItem({
     change24hPercent,
     markPrice,
   });
-  // Freeze the initial text budget so live prices do not resize the item.
-  const [itemWidth] = useState(
-    () =>
-      (displayName.length + changeText.length + priceText.length) *
-        ITEM_CHARACTER_WIDTH_PX +
-      ITEM_INTERNAL_GAPS_WIDTH_PX,
-  );
   const handlePress = useCallback(() => {
     onPress({
       displayName,
@@ -66,23 +57,32 @@ function FooterTickerItem({
   ]);
 
   return (
-    <XStack
+    <button
+      type="button"
       aria-hidden={isDuplicate || undefined}
       tabIndex={isDuplicate ? -1 : undefined}
-      onPress={handlePress}
-      group
-      userSelect="none"
-      alignItems="center"
-      gap="$1.5"
-      cursor="pointer"
-      flexShrink={0}
-      width={itemWidth}
+      onClick={handlePress}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      style={{
+        appearance: 'none',
+        display: 'inline-flex',
+        alignItems: 'center',
+        flexShrink: 0,
+        gap: 6,
+        width: 'max-content',
+        padding: 0,
+        border: 0,
+        background: 'transparent',
+        cursor: 'pointer',
+        userSelect: 'none',
+        whiteSpace: 'nowrap',
+      }}
     >
       <SizableText
         size="$bodySmMedium"
-        color="$text"
+        color={isHovered ? '$textInteractive' : '$text'}
         whiteSpace="nowrap"
-        $group-hover={{ color: '$textInteractive' }}
       >
         {displayName}
       </SizableText>
@@ -97,15 +97,14 @@ function FooterTickerItem({
       </SizableText>
       <SizableText
         size="$bodySmMedium"
-        color="$textSubdued"
-        $group-hover={{ color: '$text' }}
+        color={isHovered ? '$text' : '$textSubdued'}
         style={TABULAR_NUMS_STYLE}
         flexShrink={0}
         whiteSpace="nowrap"
       >
         {priceText}
       </SizableText>
-    </XStack>
+    </button>
   );
 }
 

--- a/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.tsx
@@ -1,104 +1,22 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback } from 'react';
 
 import { SizableText, XStack } from '@onekeyhq/components';
-import { useActiveTradeInstrumentAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
-import { usePerpsCtxByCoin } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
-import {
-  usePerpsActiveAssetAtom,
-  usePerpsActiveAssetCtxAtom,
-  useSpotActiveAssetCtxAtom,
-  useSpotAssetCtxsMapAtom,
-} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
-import perpsUtils, {
-  formatSpotPriceEntry,
-} from '@onekeyhq/shared/src/utils/perpsUtils';
 
-import { PriceChangeDisplay } from '../FavoritesBar/FavoriteTokenItem';
+import { TABULAR_NUMS_STYLE } from '../FavoritesBar/FavoriteTokenItem';
 
-interface IFooterTickerItemProps {
-  displayName: string;
-  coinName: string;
-  dexIndex: number;
-  assetId: number;
-  mode: 'perp' | 'spot';
-  onPress: () => void;
+import { getFooterTickerDisplayText } from './footerTickerUtils';
+
+import type {
+  IFooterTickerItemData,
+  IFooterTickerTextWidthBudget,
+} from './footerTickerUtils';
+
+interface IFooterTickerItemProps extends IFooterTickerItemData {
+  isDuplicate?: boolean;
+  isMeasure?: boolean;
+  widthBudget?: IFooterTickerTextWidthBudget;
+  onPress: (item: IFooterTickerItemData) => void;
 }
-
-// Price display for non-active tokens (reads from batch asset ctxs)
-const CtxPrice = memo(
-  ({
-    coinName,
-    dexIndex,
-    assetId,
-    mode,
-  }: {
-    coinName: string;
-    dexIndex: number;
-    assetId: number;
-    mode: 'perp' | 'spot';
-  }) => {
-    const ctx = usePerpsCtxByCoin(dexIndex, assetId);
-    const [spotPriceMap] = useSpotAssetCtxsMapAtom();
-    const formatted = useMemo(() => perpsUtils.formatAssetCtx(ctx), [ctx]);
-    const formattedSpot = useMemo(
-      () => formatSpotPriceEntry(spotPriceMap[coinName]),
-      [coinName, spotPriceMap],
-    );
-    const displayCtx = mode === 'spot' ? formattedSpot : formatted;
-
-    return (
-      <PriceChangeDisplay
-        change={displayCtx?.change24hPercent ?? 0}
-        markPrice={displayCtx?.markPrice}
-      />
-    );
-  },
-);
-CtxPrice.displayName = 'CtxPrice';
-
-// Price display for the currently active token (higher update frequency)
-const ActivePrice = memo(
-  ({
-    coinName,
-    dexIndex,
-    assetId,
-    mode,
-  }: {
-    coinName: string;
-    dexIndex: number;
-    assetId: number;
-    mode: 'perp' | 'spot';
-  }) => {
-    const [assetCtx] = usePerpsActiveAssetCtxAtom();
-    const [spotActiveAssetCtx] = useSpotActiveAssetCtxAtom();
-    const fallbackCtx = usePerpsCtxByCoin(dexIndex, assetId);
-    const [spotPriceMap] = useSpotAssetCtxsMapAtom();
-    const formattedFallback = useMemo(
-      () => perpsUtils.formatAssetCtx(fallbackCtx),
-      [fallbackCtx],
-    );
-    const formattedSpotFallback = useMemo(
-      () => formatSpotPriceEntry(spotPriceMap[coinName]),
-      [coinName, spotPriceMap],
-    );
-
-    const activeCtx = assetCtx?.ctx;
-    const spotCtx = spotActiveAssetCtx?.ctx;
-    let ctx: { markPrice?: string; change24hPercent?: number } =
-      activeCtx?.markPrice ? activeCtx : formattedFallback;
-    if (mode === 'spot') {
-      ctx = spotCtx?.markPrice ? spotCtx : formattedSpotFallback;
-    }
-
-    return (
-      <PriceChangeDisplay
-        change={ctx?.change24hPercent ?? 0}
-        markPrice={ctx?.markPrice}
-      />
-    );
-  },
-);
-ActivePrice.displayName = 'ActivePrice';
 
 function FooterTickerItem({
   displayName,
@@ -106,48 +24,90 @@ function FooterTickerItem({
   dexIndex,
   assetId,
   mode,
+  change24hPercent,
+  markPrice,
+  isDuplicate,
+  isMeasure,
+  widthBudget,
   onPress,
 }: IFooterTickerItemProps) {
-  const [activeTradeInstrument] = useActiveTradeInstrumentAtom();
-  const [activeAsset] = usePerpsActiveAssetAtom();
-  const isActive =
-    mode === 'spot'
-      ? activeTradeInstrument.mode === 'spot' &&
-        activeTradeInstrument.coin === coinName
-      : activeAsset?.coin === coinName;
+  const color = change24hPercent >= 0 ? '$textSuccess' : '$textCritical';
+  const { changeText, priceText } = getFooterTickerDisplayText({
+    displayName,
+    coinName,
+    dexIndex,
+    assetId,
+    mode,
+    change24hPercent,
+    markPrice,
+  });
+  const handlePress = useCallback(() => {
+    onPress({
+      displayName,
+      coinName,
+      dexIndex,
+      assetId,
+      mode,
+      change24hPercent,
+      markPrice,
+    });
+  }, [
+    assetId,
+    change24hPercent,
+    coinName,
+    dexIndex,
+    displayName,
+    markPrice,
+    mode,
+    onPress,
+  ]);
 
   return (
     <XStack
-      onPress={onPress}
-      px="$2"
-      py="$1"
-      mr="$1"
-      borderRadius="$2"
-      hoverStyle={{ bg: '$bgHover' }}
+      aria-hidden={isDuplicate || isMeasure || undefined}
+      tabIndex={isDuplicate || isMeasure ? -1 : undefined}
+      onPress={isMeasure ? undefined : handlePress}
+      group
       userSelect="none"
       alignItems="center"
       gap="$1.5"
-      cursor="default"
+      cursor={isMeasure ? 'default' : 'pointer'}
       flexShrink={0}
+      style={{
+        width: isMeasure ? 'max-content' : widthBudget?.itemWidth,
+      }}
     >
-      <SizableText size="$bodyMdMedium" color="$text">
+      <SizableText
+        size="$bodySmMedium"
+        color="$text"
+        whiteSpace="nowrap"
+        $group-hover={{ color: '$textInteractive' }}
+      >
         {displayName}
       </SizableText>
-      {isActive ? (
-        <ActivePrice
-          coinName={coinName}
-          dexIndex={dexIndex}
-          assetId={assetId}
-          mode={mode}
-        />
-      ) : (
-        <CtxPrice
-          coinName={coinName}
-          dexIndex={dexIndex}
-          assetId={assetId}
-          mode={mode}
-        />
-      )}
+      <SizableText
+        size="$bodySmMedium"
+        color={color}
+        style={TABULAR_NUMS_STYLE}
+        width={isMeasure ? undefined : widthBudget?.changeWidth}
+        flexShrink={0}
+        overflow="hidden"
+        whiteSpace="nowrap"
+      >
+        {changeText}
+      </SizableText>
+      <SizableText
+        size="$bodySmMedium"
+        color="$textSubdued"
+        $group-hover={{ color: '$text' }}
+        style={TABULAR_NUMS_STYLE}
+        width={isMeasure ? undefined : widthBudget?.priceWidth}
+        flexShrink={0}
+        overflow="hidden"
+        whiteSpace="nowrap"
+      >
+        {priceText}
+      </SizableText>
     </XStack>
   );
 }

--- a/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.web.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerItem.web.tsx
@@ -2,7 +2,10 @@ import { memo, useCallback, useState } from 'react';
 
 import { SizableText } from '@onekeyhq/components';
 
-import { TABULAR_NUMS_STYLE } from '../FavoritesBar/FavoriteTokenItem';
+import {
+  TABULAR_NUMS_STYLE,
+  getStablePriceMinWidth,
+} from '../FavoritesBar/FavoriteTokenItem';
 
 import { getFooterTickerDisplayText } from './footerTickerUtils';
 
@@ -35,6 +38,7 @@ function FooterTickerItem({
     change24hPercent,
     markPrice,
   });
+  const priceMinWidth = getStablePriceMinWidth(priceText);
   const handlePress = useCallback(() => {
     onPress({
       displayName,
@@ -91,6 +95,8 @@ function FooterTickerItem({
         color={color}
         style={TABULAR_NUMS_STYLE}
         flexShrink={0}
+        minWidth="7ch"
+        textAlign="right"
         whiteSpace="nowrap"
       >
         {changeText}
@@ -100,6 +106,8 @@ function FooterTickerItem({
         color={isHovered ? '$text' : '$textSubdued'}
         style={TABULAR_NUMS_STYLE}
         flexShrink={0}
+        minWidth={priceMinWidth}
+        textAlign="right"
         whiteSpace="nowrap"
       >
         {priceText}

--- a/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerMarquee.web.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerMarquee.web.tsx
@@ -224,8 +224,8 @@ function FooterTickerMarquee({
         }
         aria-hidden={isDuplicate || undefined}
         alignItems="center"
-        gap="$1"
-        pr="$1"
+        gap="$6"
+        pr="$6"
         flexShrink={0}
         style={{ width: 'max-content' }}
       >

--- a/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerMarquee.web.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerMarquee.web.tsx
@@ -12,19 +12,13 @@ import { XStack } from '@onekeyhq/components';
 
 import { FooterTickerItem } from './FooterTickerItem';
 import {
-  getFooterTickerDisplayText,
   getFooterTickerItemKey,
-  getFooterTickerSnapshotKey,
   getFooterTickerStructureKey,
   mergeFooterTickerLiveValues,
   shouldAnimateFooterTicker,
 } from './footerTickerUtils';
 
-import type {
-  IFooterTickerItemData,
-  IFooterTickerTextMeasure,
-  IFooterTickerTextWidthBudgetMap,
-} from './footerTickerUtils';
+import type { IFooterTickerItemData } from './footerTickerUtils';
 
 const SCROLL_SPEED_PX_PER_SEC = 20;
 
@@ -32,33 +26,6 @@ interface IFooterTickerMarqueeProps {
   items: IFooterTickerItemData[];
   deferStructureUpdates?: boolean;
   onItemPress: (item: IFooterTickerItemData) => void;
-}
-
-interface IWidthBudgetState {
-  snapshotKey: string;
-  budgets: IFooterTickerTextWidthBudgetMap;
-}
-
-function areWidthBudgetMapsEqual(
-  first: IFooterTickerTextWidthBudgetMap,
-  second: IFooterTickerTextWidthBudgetMap,
-) {
-  const firstKeys = Object.keys(first);
-  const secondKeys = Object.keys(second);
-  return (
-    firstKeys.length === secondKeys.length &&
-    firstKeys.every((key) => {
-      const firstBudget = first[key];
-      const secondBudget = second[key];
-      return (
-        firstBudget.itemWidth === secondBudget?.itemWidth &&
-        firstBudget.changeText === secondBudget.changeText &&
-        firstBudget.changeWidth === secondBudget.changeWidth &&
-        firstBudget.priceText === secondBudget.priceText &&
-        firstBudget.priceWidth === secondBudget.priceWidth
-      );
-    })
-  );
 }
 
 function FooterTickerMarquee({
@@ -69,13 +36,8 @@ function FooterTickerMarquee({
   const containerRef = useRef<HTMLDivElement>(null);
   const trackRef = useRef<HTMLDivElement>(null);
   const firstLoopRef = useRef<HTMLDivElement>(null);
-  const measureRef = useRef<HTMLDivElement>(null);
-  const textMeasureCanvasRef = useRef<HTMLCanvasElement | null>(null);
-  const textMeasureFontRef = useRef('');
   const latestItemsRef = useRef(items);
   const displayStructureKeyRef = useRef(getFooterTickerStructureKey(items));
-  const displaySnapshotKeyRef = useRef(getFooterTickerSnapshotKey(items));
-  const widthBudgetsRef = useRef<IFooterTickerTextWidthBudgetMap>({});
   const offsetRef = useRef(0);
   const loopWidthRef = useRef(0);
   const lastFrameTimeRef = useRef<number | null>(null);
@@ -83,122 +45,36 @@ function FooterTickerMarquee({
   const prefersReducedMotionRef = useRef(false);
   const needsScrollRef = useRef(false);
   const [displayItems, setDisplayItems] = useState(items);
-  const [liveDisplayItems, setLiveDisplayItems] = useState(items);
   const [needsScroll, setNeedsScroll] = useState(false);
-  const [widthBudgetState, setWidthBudgetState] = useState<IWidthBudgetState>({
-    snapshotKey: '',
-    budgets: {},
-  });
 
   latestItemsRef.current = items;
 
-  const displaySnapshotKey = useMemo(
-    () => getFooterTickerSnapshotKey(displayItems),
+  const displayStructureKey = useMemo(
+    () => getFooterTickerStructureKey(displayItems),
     [displayItems],
   );
   const latestStructureKey = useMemo(
     () => getFooterTickerStructureKey(items),
     [items],
   );
-  const latestSnapshotKey = useMemo(
-    () => getFooterTickerSnapshotKey(items),
-    [items],
-  );
-  const hasCurrentWidthBudgets =
-    widthBudgetState.snapshotKey === displaySnapshotKey &&
-    displayItems.every(
-      (item) => widthBudgetState.budgets[getFooterTickerItemKey(item)],
-    );
-
-  const measureText = useCallback<IFooterTickerTextMeasure>((text) => {
-    if (!textMeasureCanvasRef.current) {
-      textMeasureCanvasRef.current = document.createElement('canvas');
-    }
-    const context = textMeasureCanvasRef.current.getContext('2d');
-    if (!context || !textMeasureFontRef.current) {
-      return Number.POSITIVE_INFINITY;
-    }
-    context.font = textMeasureFontRef.current;
-    return context.measureText(text).width;
-  }, []);
 
   const commitDisplayItems = useCallback(
-    (nextItems: IFooterTickerItemData[], allowValueOnlyUpdates = false) => {
+    (nextItems: IFooterTickerItemData[]) => {
       const nextStructureKey = getFooterTickerStructureKey(nextItems);
       const structureChanged =
         displayStructureKeyRef.current !== nextStructureKey;
-      if (!structureChanged && !allowValueOnlyUpdates) {
-        return false;
-      }
-
-      const nextSnapshotKey = getFooterTickerSnapshotKey(nextItems);
-      if (displaySnapshotKeyRef.current === nextSnapshotKey) {
-        return false;
-      }
 
       displayStructureKeyRef.current = nextStructureKey;
-      displaySnapshotKeyRef.current = nextSnapshotKey;
-      offsetRef.current = 0;
-      loopWidthRef.current = 0;
-      lastFrameTimeRef.current = null;
-      widthBudgetsRef.current = {};
-      setLiveDisplayItems(nextItems);
       setDisplayItems(nextItems);
-      return true;
+
+      if (structureChanged) {
+        offsetRef.current = 0;
+        loopWidthRef.current = 0;
+        lastFrameTimeRef.current = null;
+      }
     },
     [],
   );
-
-  const syncWidthBudgets = useCallback(() => {
-    const measureContainer = measureRef.current;
-    if (!measureContainer) return;
-
-    const measuredItems = Array.from(
-      measureContainer.children,
-    ) as HTMLElement[];
-    const nextBudgets: IFooterTickerTextWidthBudgetMap = {};
-
-    displayItems.forEach((item, index) => {
-      const measuredItem = measuredItems[index];
-      const changeElement = measuredItem?.children[1] as
-        | HTMLElement
-        | undefined;
-      const priceElement = measuredItem?.children[2] as HTMLElement | undefined;
-      if (!measuredItem || !changeElement || !priceElement) return;
-
-      const itemWidth =
-        measuredItem.getBoundingClientRect().width || measuredItem.scrollWidth;
-      const changeWidth = changeElement.getBoundingClientRect().width;
-      const priceWidth = priceElement.getBoundingClientRect().width;
-      if (!itemWidth || !changeWidth || !priceWidth) return;
-
-      const { changeText, priceText } = getFooterTickerDisplayText(item);
-      nextBudgets[getFooterTickerItemKey(item)] = {
-        itemWidth: Math.ceil(itemWidth),
-        changeText,
-        changeWidth: Math.ceil(changeWidth),
-        priceText,
-        priceWidth: Math.ceil(priceWidth),
-      };
-
-      if (!textMeasureFontRef.current) {
-        const style = globalThis.getComputedStyle(priceElement);
-        textMeasureFontRef.current =
-          style.font ||
-          `${style.fontStyle} ${style.fontVariant} ${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
-      }
-    });
-
-    if (Object.keys(nextBudgets).length !== displayItems.length) return;
-
-    widthBudgetsRef.current = nextBudgets;
-    setWidthBudgetState((previous) =>
-      previous.snapshotKey === displaySnapshotKey &&
-      areWidthBudgetMapsEqual(previous.budgets, nextBudgets)
-        ? previous
-        : { snapshotKey: displaySnapshotKey, budgets: nextBudgets },
-    );
-  }, [displayItems, displaySnapshotKey]);
 
   const syncLoopMetrics = useCallback(() => {
     const container = containerRef.current;
@@ -233,59 +109,45 @@ function FooterTickerMarquee({
   }, []);
 
   useLayoutEffect(() => {
-    syncWidthBudgets();
-  }, [syncWidthBudgets]);
-
-  useLayoutEffect(() => {
-    if (!hasCurrentWidthBudgets) return;
     syncLoopMetrics();
-  }, [hasCurrentWidthBudgets, syncLoopMetrics, widthBudgetState]);
+  }, [displayStructureKey, syncLoopMetrics]);
 
   useEffect(() => {
-    if (!hasCurrentWidthBudgets) return;
-    setLiveDisplayItems((previous) => {
-      const next = mergeFooterTickerLiveValues({
-        displayItems,
-        latestItems: items,
-        previousLiveItems: previous,
-        widthBudgets: widthBudgetsRef.current,
-        measureText,
-      });
-      return getFooterTickerSnapshotKey(previous) ===
-        getFooterTickerSnapshotKey(next)
-        ? previous
-        : next;
-    });
-  }, [displayItems, hasCurrentWidthBudgets, items, measureText]);
+    const structureChanged =
+      displayStructureKeyRef.current !== latestStructureKey;
 
-  useEffect(() => {
-    if (prefersReducedMotionRef.current || !needsScrollRef.current) {
-      commitDisplayItems(latestItemsRef.current, true);
-    } else if (!deferStructureUpdates) {
-      commitDisplayItems(latestItemsRef.current);
+    if (!structureChanged) {
+      setDisplayItems(items);
+      return;
     }
-  }, [
-    commitDisplayItems,
-    deferStructureUpdates,
-    latestSnapshotKey,
-    latestStructureKey,
-  ]);
+
+    if (
+      prefersReducedMotionRef.current ||
+      !needsScrollRef.current ||
+      !deferStructureUpdates
+    ) {
+      commitDisplayItems(items);
+      return;
+    }
+
+    setDisplayItems((previous) =>
+      mergeFooterTickerLiveValues({
+        displayItems: previous,
+        latestItems: items,
+      }),
+    );
+  }, [commitDisplayItems, deferStructureUpdates, items, latestStructureKey]);
 
   useEffect(() => {
     const container = containerRef.current;
     const firstLoop = firstLoopRef.current;
-    const measureContainer = measureRef.current;
-    if (!container || !firstLoop || !measureContainer) return;
+    if (!container || !firstLoop) return;
 
-    const observer = new ResizeObserver(() => {
-      syncWidthBudgets();
-      syncLoopMetrics();
-    });
+    const observer = new ResizeObserver(syncLoopMetrics);
     observer.observe(container);
     observer.observe(firstLoop);
-    observer.observe(measureContainer);
     return () => observer.disconnect();
-  }, [syncLoopMetrics, syncWidthBudgets]);
+  }, [displayStructureKey, syncLoopMetrics]);
 
   useLayoutEffect(() => {
     const track = trackRef.current;
@@ -296,6 +158,9 @@ function FooterTickerMarquee({
     );
     const syncReducedMotion = () => {
       prefersReducedMotionRef.current = Boolean(mediaQuery?.matches);
+      if (prefersReducedMotionRef.current) {
+        commitDisplayItems(latestItemsRef.current);
+      }
       syncLoopMetrics();
     };
     syncReducedMotion();
@@ -314,8 +179,15 @@ function FooterTickerMarquee({
         const nextOffset =
           offsetRef.current + elapsedSeconds * SCROLL_SPEED_PX_PER_SEC;
         if (nextOffset >= loopWidth) {
-          commitDisplayItems(latestItemsRef.current, true);
-          offsetRef.current = 0;
+          const latestItems = latestItemsRef.current;
+          if (
+            displayStructureKeyRef.current !==
+            getFooterTickerStructureKey(latestItems)
+          ) {
+            commitDisplayItems(latestItems);
+          } else {
+            offsetRef.current = 0;
+          }
         } else {
           offsetRef.current = nextOffset;
         }
@@ -341,22 +213,6 @@ function FooterTickerMarquee({
     lastFrameTimeRef.current = null;
   }, []);
 
-  const renderItems = useCallback(
-    (isDuplicate: boolean) =>
-      liveDisplayItems.map((item) => (
-        <FooterTickerItem
-          key={`${getFooterTickerItemKey(item)}${
-            isDuplicate ? '-duplicate' : ''
-          }`}
-          {...item}
-          widthBudget={widthBudgetState.budgets[getFooterTickerItemKey(item)]}
-          isDuplicate={isDuplicate}
-          onPress={onItemPress}
-        />
-      )),
-    [liveDisplayItems, onItemPress, widthBudgetState.budgets],
-  );
-
   const renderLoop = useCallback(
     (isDuplicate: boolean) => (
       <XStack
@@ -373,10 +229,19 @@ function FooterTickerMarquee({
         flexShrink={0}
         style={{ width: 'max-content' }}
       >
-        {renderItems(isDuplicate)}
+        {displayItems.map((item) => (
+          <FooterTickerItem
+            key={`${getFooterTickerItemKey(item)}${
+              isDuplicate ? '-duplicate' : ''
+            }`}
+            {...item}
+            isDuplicate={isDuplicate}
+            onPress={onItemPress}
+          />
+        ))}
       </XStack>
     ),
-    [renderItems],
+    [displayItems, onItemPress],
   );
 
   return (
@@ -397,32 +262,11 @@ function FooterTickerMarquee({
         flexShrink={0}
         style={{
           width: 'max-content',
-          visibility: hasCurrentWidthBudgets ? 'visible' : 'hidden',
           willChange: needsScroll ? 'transform' : undefined,
         }}
       >
         {renderLoop(false)}
         {needsScroll ? renderLoop(true) : null}
-      </XStack>
-      <XStack
-        ref={measureRef as any}
-        aria-hidden
-        position="absolute"
-        left={0}
-        top={0}
-        alignItems="center"
-        gap="$6"
-        pointerEvents="none"
-        style={{ visibility: 'hidden', width: 'max-content' }}
-      >
-        {displayItems.map((item) => (
-          <FooterTickerItem
-            key={`${getFooterTickerItemKey(item)}-measure`}
-            {...item}
-            isMeasure
-            onPress={onItemPress}
-          />
-        ))}
       </XStack>
     </XStack>
   );

--- a/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerMarquee.web.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerMarquee.web.tsx
@@ -224,8 +224,8 @@ function FooterTickerMarquee({
         }
         aria-hidden={isDuplicate || undefined}
         alignItems="center"
-        gap="$3"
-        pr="$3"
+        gap="$1"
+        pr="$1"
         flexShrink={0}
         style={{ width: 'max-content' }}
       >

--- a/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerMarquee.web.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerMarquee.web.tsx
@@ -1,106 +1,388 @@
-import type { ReactNode } from 'react';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { XStack } from '@onekeyhq/components';
 
-const SCROLL_SPEED_PX_PER_SEC = 10;
-const WIDTH_CHANGE_THRESHOLD = 20;
+import { FooterTickerItem } from './FooterTickerItem';
+import {
+  getFooterTickerDisplayText,
+  getFooterTickerItemKey,
+  getFooterTickerSnapshotKey,
+  getFooterTickerStructureKey,
+  mergeFooterTickerLiveValues,
+  shouldAnimateFooterTicker,
+} from './footerTickerUtils';
+
+import type {
+  IFooterTickerItemData,
+  IFooterTickerTextMeasure,
+  IFooterTickerTextWidthBudgetMap,
+} from './footerTickerUtils';
+
+const SCROLL_SPEED_PX_PER_SEC = 20;
 
 interface IFooterTickerMarqueeProps {
-  children: ReactNode;
+  items: IFooterTickerItemData[];
+  deferStructureUpdates?: boolean;
+  onItemPress: (item: IFooterTickerItemData) => void;
 }
 
-function FooterTickerMarquee({ children }: IFooterTickerMarqueeProps) {
+interface IWidthBudgetState {
+  snapshotKey: string;
+  budgets: IFooterTickerTextWidthBudgetMap;
+}
+
+function areWidthBudgetMapsEqual(
+  first: IFooterTickerTextWidthBudgetMap,
+  second: IFooterTickerTextWidthBudgetMap,
+) {
+  const firstKeys = Object.keys(first);
+  const secondKeys = Object.keys(second);
+  return (
+    firstKeys.length === secondKeys.length &&
+    firstKeys.every((key) => {
+      const firstBudget = first[key];
+      const secondBudget = second[key];
+      return (
+        firstBudget.itemWidth === secondBudget?.itemWidth &&
+        firstBudget.changeText === secondBudget.changeText &&
+        firstBudget.changeWidth === secondBudget.changeWidth &&
+        firstBudget.priceText === secondBudget.priceText &&
+        firstBudget.priceWidth === secondBudget.priceWidth
+      );
+    })
+  );
+}
+
+function FooterTickerMarquee({
+  items,
+  deferStructureUpdates = false,
+  onItemPress,
+}: IFooterTickerMarqueeProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
-  const [isPaused, setIsPaused] = useState(false);
-  const lastWidthRef = useRef(0);
-  const styleElRef = useRef<HTMLStyleElement | null>(null);
-  const keyframeIdRef = useRef(0);
-  // Track whether duplicate is rendered — updated synchronously during render
-  // so ResizeObserver callbacks always read the correct value
-  const hasDuplicateRef = useRef(false);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const firstLoopRef = useRef<HTMLDivElement>(null);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const textMeasureCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const textMeasureFontRef = useRef('');
+  const latestItemsRef = useRef(items);
+  const displayStructureKeyRef = useRef(getFooterTickerStructureKey(items));
+  const displaySnapshotKeyRef = useRef(getFooterTickerSnapshotKey(items));
+  const widthBudgetsRef = useRef<IFooterTickerTextWidthBudgetMap>({});
+  const offsetRef = useRef(0);
+  const loopWidthRef = useRef(0);
+  const lastFrameTimeRef = useRef<number | null>(null);
+  const pausedRef = useRef(false);
+  const prefersReducedMotionRef = useRef(false);
+  const needsScrollRef = useRef(false);
+  const [displayItems, setDisplayItems] = useState(items);
+  const [liveDisplayItems, setLiveDisplayItems] = useState(items);
+  const [needsScroll, setNeedsScroll] = useState(false);
+  const [widthBudgetState, setWidthBudgetState] = useState<IWidthBudgetState>({
+    snapshotKey: '',
+    budgets: {},
+  });
 
-  const [scrollState, setScrollState] = useState<{
-    needsScroll: boolean;
-    duration: number;
-    keyframeName: string;
-  }>({ needsScroll: false, duration: 0, keyframeName: '' });
+  latestItemsRef.current = items;
 
-  // Keep ref in sync (set during render, before any observer fires)
-  hasDuplicateRef.current = scrollState.needsScroll;
+  const displaySnapshotKey = useMemo(
+    () => getFooterTickerSnapshotKey(displayItems),
+    [displayItems],
+  );
+  const latestStructureKey = useMemo(
+    () => getFooterTickerStructureKey(items),
+    [items],
+  );
+  const latestSnapshotKey = useMemo(
+    () => getFooterTickerSnapshotKey(items),
+    [items],
+  );
+  const hasCurrentWidthBudgets =
+    widthBudgetState.snapshotKey === displaySnapshotKey &&
+    displayItems.every(
+      (item) => widthBudgetState.budgets[getFooterTickerItemKey(item)],
+    );
 
-  const measureContent = useCallback(() => {
-    const container = containerRef.current;
-    const content = contentRef.current;
-    if (!container || !content) return;
-
-    const singleWidth = hasDuplicateRef.current
-      ? content.scrollWidth / 2
-      : content.scrollWidth;
-    const containerWidth = container.clientWidth;
-
-    if (singleWidth > containerWidth) {
-      const widthDelta = Math.abs(singleWidth - lastWidthRef.current);
-      if (widthDelta < WIDTH_CHANGE_THRESHOLD && lastWidthRef.current > 0) {
-        return;
-      }
-
-      lastWidthRef.current = singleWidth;
-
-      keyframeIdRef.current += 1;
-      const name = `perps-marquee-${keyframeIdRef.current}`;
-      if (!styleElRef.current) {
-        styleElRef.current = document.createElement('style');
-        document.head.appendChild(styleElRef.current);
-      }
-      styleElRef.current.textContent = `
-        @keyframes ${name} {
-          from { transform: translateX(0); }
-          to { transform: translateX(-${singleWidth}px); }
-        }
-      `;
-
-      setScrollState({
-        needsScroll: true,
-        duration: singleWidth / SCROLL_SPEED_PX_PER_SEC,
-        keyframeName: name,
-      });
-    } else if (lastWidthRef.current !== 0) {
-      lastWidthRef.current = 0;
-      setScrollState({ needsScroll: false, duration: 0, keyframeName: '' });
+  const measureText = useCallback<IFooterTickerTextMeasure>((text) => {
+    if (!textMeasureCanvasRef.current) {
+      textMeasureCanvasRef.current = document.createElement('canvas');
     }
+    const context = textMeasureCanvasRef.current.getContext('2d');
+    if (!context || !textMeasureFontRef.current) {
+      return Number.POSITIVE_INFINITY;
+    }
+    context.font = textMeasureFontRef.current;
+    return context.measureText(text).width;
   }, []);
 
-  useEffect(() => {
-    requestAnimationFrame(measureContent);
-  }, [measureContent]);
+  const commitDisplayItems = useCallback(
+    (nextItems: IFooterTickerItemData[], allowValueOnlyUpdates = false) => {
+      const nextStructureKey = getFooterTickerStructureKey(nextItems);
+      const structureChanged =
+        displayStructureKeyRef.current !== nextStructureKey;
+      if (!structureChanged && !allowValueOnlyUpdates) {
+        return false;
+      }
 
-  // Re-measure on container or content resize
+      const nextSnapshotKey = getFooterTickerSnapshotKey(nextItems);
+      if (displaySnapshotKeyRef.current === nextSnapshotKey) {
+        return false;
+      }
+
+      displayStructureKeyRef.current = nextStructureKey;
+      displaySnapshotKeyRef.current = nextSnapshotKey;
+      offsetRef.current = 0;
+      loopWidthRef.current = 0;
+      lastFrameTimeRef.current = null;
+      widthBudgetsRef.current = {};
+      setLiveDisplayItems(nextItems);
+      setDisplayItems(nextItems);
+      return true;
+    },
+    [],
+  );
+
+  const syncWidthBudgets = useCallback(() => {
+    const measureContainer = measureRef.current;
+    if (!measureContainer) return;
+
+    const measuredItems = Array.from(
+      measureContainer.children,
+    ) as HTMLElement[];
+    const nextBudgets: IFooterTickerTextWidthBudgetMap = {};
+
+    displayItems.forEach((item, index) => {
+      const measuredItem = measuredItems[index];
+      const changeElement = measuredItem?.children[1] as
+        | HTMLElement
+        | undefined;
+      const priceElement = measuredItem?.children[2] as HTMLElement | undefined;
+      if (!measuredItem || !changeElement || !priceElement) return;
+
+      const itemWidth =
+        measuredItem.getBoundingClientRect().width || measuredItem.scrollWidth;
+      const changeWidth = changeElement.getBoundingClientRect().width;
+      const priceWidth = priceElement.getBoundingClientRect().width;
+      if (!itemWidth || !changeWidth || !priceWidth) return;
+
+      const { changeText, priceText } = getFooterTickerDisplayText(item);
+      nextBudgets[getFooterTickerItemKey(item)] = {
+        itemWidth: Math.ceil(itemWidth),
+        changeText,
+        changeWidth: Math.ceil(changeWidth),
+        priceText,
+        priceWidth: Math.ceil(priceWidth),
+      };
+
+      if (!textMeasureFontRef.current) {
+        const style = globalThis.getComputedStyle(priceElement);
+        textMeasureFontRef.current =
+          style.font ||
+          `${style.fontStyle} ${style.fontVariant} ${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
+      }
+    });
+
+    if (Object.keys(nextBudgets).length !== displayItems.length) return;
+
+    widthBudgetsRef.current = nextBudgets;
+    setWidthBudgetState((previous) =>
+      previous.snapshotKey === displaySnapshotKey &&
+      areWidthBudgetMapsEqual(previous.budgets, nextBudgets)
+        ? previous
+        : { snapshotKey: displaySnapshotKey, budgets: nextBudgets },
+    );
+  }, [displayItems, displaySnapshotKey]);
+
+  const syncLoopMetrics = useCallback(() => {
+    const container = containerRef.current;
+    const track = trackRef.current;
+    const firstLoop = firstLoopRef.current;
+    if (!container || !firstLoop) return 0;
+
+    const singleLoopWidth =
+      firstLoop.getBoundingClientRect().width || firstLoop.scrollWidth;
+    loopWidthRef.current = singleLoopWidth;
+    const nextNeedsScroll = shouldAnimateFooterTicker({
+      contentWidth: singleLoopWidth,
+      containerWidth: container.clientWidth,
+      prefersReducedMotion: prefersReducedMotionRef.current,
+    });
+    needsScrollRef.current = nextNeedsScroll;
+    setNeedsScroll((previous) =>
+      previous === nextNeedsScroll ? previous : nextNeedsScroll,
+    );
+
+    if (!nextNeedsScroll) {
+      offsetRef.current = 0;
+      lastFrameTimeRef.current = null;
+      if (track) {
+        track.style.transform = 'translate3d(0, 0, 0)';
+      }
+    } else if (offsetRef.current >= singleLoopWidth) {
+      offsetRef.current %= singleLoopWidth;
+    }
+
+    return singleLoopWidth;
+  }, []);
+
+  useLayoutEffect(() => {
+    syncWidthBudgets();
+  }, [syncWidthBudgets]);
+
+  useLayoutEffect(() => {
+    if (!hasCurrentWidthBudgets) return;
+    syncLoopMetrics();
+  }, [hasCurrentWidthBudgets, syncLoopMetrics, widthBudgetState]);
+
+  useEffect(() => {
+    if (!hasCurrentWidthBudgets) return;
+    setLiveDisplayItems((previous) => {
+      const next = mergeFooterTickerLiveValues({
+        displayItems,
+        latestItems: items,
+        previousLiveItems: previous,
+        widthBudgets: widthBudgetsRef.current,
+        measureText,
+      });
+      return getFooterTickerSnapshotKey(previous) ===
+        getFooterTickerSnapshotKey(next)
+        ? previous
+        : next;
+    });
+  }, [displayItems, hasCurrentWidthBudgets, items, measureText]);
+
+  useEffect(() => {
+    if (prefersReducedMotionRef.current || !needsScrollRef.current) {
+      commitDisplayItems(latestItemsRef.current, true);
+    } else if (!deferStructureUpdates) {
+      commitDisplayItems(latestItemsRef.current);
+    }
+  }, [
+    commitDisplayItems,
+    deferStructureUpdates,
+    latestSnapshotKey,
+    latestStructureKey,
+  ]);
+
   useEffect(() => {
     const container = containerRef.current;
-    const content = contentRef.current;
-    if (!container || !content) return;
+    const firstLoop = firstLoopRef.current;
+    const measureContainer = measureRef.current;
+    if (!container || !firstLoop || !measureContainer) return;
+
     const observer = new ResizeObserver(() => {
-      requestAnimationFrame(measureContent);
+      syncWidthBudgets();
+      syncLoopMetrics();
     });
     observer.observe(container);
-    observer.observe(content);
+    observer.observe(firstLoop);
+    observer.observe(measureContainer);
     return () => observer.disconnect();
-  }, [measureContent]);
+  }, [syncLoopMetrics, syncWidthBudgets]);
 
-  useEffect(() => {
-    return () => {
-      styleElRef.current?.remove();
+  useLayoutEffect(() => {
+    const track = trackRef.current;
+    if (!track) return;
+
+    const mediaQuery = globalThis.matchMedia?.(
+      '(prefers-reduced-motion: reduce)',
+    );
+    const syncReducedMotion = () => {
+      prefersReducedMotionRef.current = Boolean(mediaQuery?.matches);
+      syncLoopMetrics();
     };
+    syncReducedMotion();
+    mediaQuery?.addEventListener?.('change', syncReducedMotion);
+
+    let frameId = 0;
+    const step = (timestamp: number) => {
+      const loopWidth = loopWidthRef.current || syncLoopMetrics();
+      const lastTimestamp = lastFrameTimeRef.current ?? timestamp;
+      const elapsedSeconds = Math.min(timestamp - lastTimestamp, 1000) / 1000;
+      lastFrameTimeRef.current = timestamp;
+
+      if (prefersReducedMotionRef.current || !needsScrollRef.current) {
+        track.style.transform = 'translate3d(0, 0, 0)';
+      } else if (!pausedRef.current && loopWidth > 0) {
+        const nextOffset =
+          offsetRef.current + elapsedSeconds * SCROLL_SPEED_PX_PER_SEC;
+        if (nextOffset >= loopWidth) {
+          commitDisplayItems(latestItemsRef.current, true);
+          offsetRef.current = 0;
+        } else {
+          offsetRef.current = nextOffset;
+        }
+        track.style.transform = `translate3d(${-offsetRef.current}px, 0, 0)`;
+      }
+
+      frameId = requestAnimationFrame(step);
+    };
+    frameId = requestAnimationFrame(step);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      mediaQuery?.removeEventListener?.('change', syncReducedMotion);
+      lastFrameTimeRef.current = null;
+    };
+  }, [commitDisplayItems, syncLoopMetrics]);
+
+  const handleMouseEnter = useCallback(() => {
+    pausedRef.current = true;
+  }, []);
+  const handleMouseLeave = useCallback(() => {
+    pausedRef.current = false;
+    lastFrameTimeRef.current = null;
   }, []);
 
-  const handleMouseEnter = useCallback(() => setIsPaused(true), []);
-  const handleMouseLeave = useCallback(() => setIsPaused(false), []);
+  const renderItems = useCallback(
+    (isDuplicate: boolean) =>
+      liveDisplayItems.map((item) => (
+        <FooterTickerItem
+          key={`${getFooterTickerItemKey(item)}${
+            isDuplicate ? '-duplicate' : ''
+          }`}
+          {...item}
+          widthBudget={widthBudgetState.budgets[getFooterTickerItemKey(item)]}
+          isDuplicate={isDuplicate}
+          onPress={onItemPress}
+        />
+      )),
+    [liveDisplayItems, onItemPress, widthBudgetState.budgets],
+  );
+
+  const renderLoop = useCallback(
+    (isDuplicate: boolean) => (
+      <XStack
+        ref={isDuplicate ? undefined : (firstLoopRef as any)}
+        testID={
+          isDuplicate
+            ? 'perp-footer-ticker-loop-duplicate'
+            : 'perp-footer-ticker-loop'
+        }
+        aria-hidden={isDuplicate || undefined}
+        alignItems="center"
+        gap="$6"
+        pr="$6"
+        flexShrink={0}
+        style={{ width: 'max-content' }}
+      >
+        {renderItems(isDuplicate)}
+      </XStack>
+    ),
+    [renderItems],
+  );
 
   return (
     <XStack
       ref={containerRef as any}
+      position="relative"
       flex={1}
       overflow="hidden"
       alignItems="center"
@@ -109,24 +391,38 @@ function FooterTickerMarquee({ children }: IFooterTickerMarqueeProps) {
       onMouseLeave={handleMouseLeave}
     >
       <XStack
-        ref={contentRef as any}
+        ref={trackRef as any}
+        testID="perp-footer-ticker-track"
         alignItems="center"
-        style={
-          scrollState.needsScroll
-            ? {
-                animation: `${scrollState.keyframeName} ${scrollState.duration}s linear infinite`,
-                animationPlayState: isPaused ? 'paused' : 'running',
-                willChange: 'transform',
-              }
-            : undefined
-        }
+        flexShrink={0}
+        style={{
+          width: 'max-content',
+          visibility: hasCurrentWidthBudgets ? 'visible' : 'hidden',
+          willChange: needsScroll ? 'transform' : undefined,
+        }}
       >
-        {children}
-        {scrollState.needsScroll ? (
-          <div aria-hidden="true" style={{ display: 'contents' }}>
-            {children}
-          </div>
-        ) : null}
+        {renderLoop(false)}
+        {needsScroll ? renderLoop(true) : null}
+      </XStack>
+      <XStack
+        ref={measureRef as any}
+        aria-hidden
+        position="absolute"
+        left={0}
+        top={0}
+        alignItems="center"
+        gap="$6"
+        pointerEvents="none"
+        style={{ visibility: 'hidden', width: 'max-content' }}
+      >
+        {displayItems.map((item) => (
+          <FooterTickerItem
+            key={`${getFooterTickerItemKey(item)}-measure`}
+            {...item}
+            isMeasure
+            onPress={onItemPress}
+          />
+        ))}
       </XStack>
     </XStack>
   );

--- a/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerMarquee.web.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerMarquee.web.tsx
@@ -10,7 +10,7 @@ import {
 
 import { XStack } from '@onekeyhq/components';
 
-import { FooterTickerItem } from './FooterTickerItem';
+import { FooterTickerItem } from './FooterTickerItem.web';
 import {
   getFooterTickerItemKey,
   getFooterTickerStructureKey,

--- a/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerMarquee.web.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/FooterTickerMarquee.web.tsx
@@ -224,8 +224,8 @@ function FooterTickerMarquee({
         }
         aria-hidden={isDuplicate || undefined}
         alignItems="center"
-        gap="$6"
-        pr="$6"
+        gap="$3"
+        pr="$3"
         flexShrink={0}
         style={{ width: 'max-content' }}
       >

--- a/packages/kit/src/views/Perp/components/FooterTicker/PerpFooterTicker.web.tsx
+++ b/packages/kit/src/views/Perp/components/FooterTicker/PerpFooterTicker.web.tsx
@@ -1,45 +1,50 @@
-import { memo, useEffect } from 'react';
+import { memo, useCallback, useEffect, useMemo } from 'react';
 
 import { XStack } from '@onekeyhq/components';
 import {
   useActiveTradeInstrumentAtom,
   useHyperliquidActions,
 } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid';
-import { usePerpsFooterTickerModePersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { usePerpsAllAssetCtxsAtom } from '@onekeyhq/kit/src/states/jotai/contexts/hyperliquid/atoms';
+import {
+  usePerpsFooterTickerModePersistAtom,
+  useSpotAssetCtxsMapAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { toCtxIndex } from '@onekeyhq/shared/src/utils/perpsDexUtils';
+import perpsUtils, {
+  formatSpotPriceEntry,
+} from '@onekeyhq/shared/src/utils/perpsUtils';
 
 import { usePerpsFavorites } from '../../hooks/usePerpsFavorites';
 import { usePopularTickers } from '../../hooks/usePopularTickers';
 
-import { FooterTickerItem } from './FooterTickerItem';
 import { FooterTickerMarquee } from './FooterTickerMarquee.web';
 import { FooterTickerSettings } from './FooterTickerSettings';
+
+import type { IFooterTickerItemData } from './footerTickerUtils';
 
 // Ticker list for Popular mode
 const PopularTickerList = memo(() => {
   const popularTickers = usePopularTickers();
   const actions = useHyperliquidActions();
+  const handleItemPress = useCallback(
+    (item: IFooterTickerItemData) => {
+      void actions.current.switchTradeInstrument({
+        coin: item.coinName,
+        mode: item.mode,
+      });
+    },
+    [actions],
+  );
 
   if (!popularTickers.length) return null;
 
   return (
-    <>
-      {popularTickers.map((item) => (
-        <FooterTickerItem
-          key={`${item.dexIndex}-${item.assetId}`}
-          displayName={item.displayName}
-          coinName={item.coinName}
-          dexIndex={item.dexIndex}
-          assetId={item.assetId}
-          mode={item.mode}
-          onPress={() =>
-            void actions.current.switchTradeInstrument({
-              coin: item.coinName,
-              mode: item.mode,
-            })
-          }
-        />
-      ))}
-    </>
+    <FooterTickerMarquee
+      items={popularTickers}
+      deferStructureUpdates
+      onItemPress={handleItemPress}
+    />
   );
 });
 PopularTickerList.displayName = 'PopularTickerList';
@@ -47,29 +52,42 @@ PopularTickerList.displayName = 'PopularTickerList';
 // Ticker list for Favorites mode
 const FavoritesTickerList = memo(() => {
   const { favoriteItems } = usePerpsFavorites({ mode: 'current' });
+  const [allAssetCtxs] = usePerpsAllAssetCtxsAtom();
+  const [spotPriceMap] = useSpotAssetCtxsMapAtom();
   const actions = useHyperliquidActions();
+  const tickerItems = useMemo<IFooterTickerItemData[]>(
+    () =>
+      favoriteItems.map((item) => {
+        const displayCtx =
+          item.mode === 'spot'
+            ? formatSpotPriceEntry(spotPriceMap[item.coinName])
+            : perpsUtils.formatAssetCtx(
+                allAssetCtxs.assetCtxsByDex[item.dexIndex]?.[
+                  toCtxIndex(item.assetId, item.dexIndex)
+                ] ?? null,
+              );
+        return {
+          ...item,
+          change24hPercent: displayCtx?.change24hPercent ?? 0,
+          markPrice: displayCtx?.markPrice,
+        };
+      }),
+    [allAssetCtxs.assetCtxsByDex, favoriteItems, spotPriceMap],
+  );
+  const handleItemPress = useCallback(
+    (item: IFooterTickerItemData) => {
+      void actions.current.switchTradeInstrument({
+        coin: item.coinName,
+        mode: item.mode,
+      });
+    },
+    [actions],
+  );
 
-  if (!favoriteItems.length) return null;
+  if (!tickerItems.length) return null;
 
   return (
-    <>
-      {favoriteItems.map((item) => (
-        <FooterTickerItem
-          key={`${item.dexIndex}-${item.assetId}`}
-          displayName={item.displayName}
-          coinName={item.coinName}
-          dexIndex={item.dexIndex}
-          assetId={item.assetId}
-          mode={item.mode}
-          onPress={() =>
-            void actions.current.switchTradeInstrument({
-              coin: item.coinName,
-              mode: item.mode,
-            })
-          }
-        />
-      ))}
-    </>
+    <FooterTickerMarquee items={tickerItems} onItemPress={handleItemPress} />
   );
 });
 FavoritesTickerList.displayName = 'FavoritesTickerList';
@@ -101,15 +119,13 @@ function PerpFooterTicker() {
   }
 
   return (
-    <XStack flex={1} alignItems="center" gap="$2" overflow="hidden">
+    <XStack flex={1} alignItems="center" gap="$4" overflow="hidden">
       <FooterTickerSettings />
-      <FooterTickerMarquee>
-        {footerMode.mode === 'popular' ? (
-          <PopularTickerList />
-        ) : (
-          <FavoritesTickerList />
-        )}
-      </FooterTickerMarquee>
+      {footerMode.mode === 'popular' ? (
+        <PopularTickerList />
+      ) : (
+        <FavoritesTickerList />
+      )}
     </XStack>
   );
 }

--- a/packages/kit/src/views/Perp/components/FooterTicker/footerTickerUtils.test.ts
+++ b/packages/kit/src/views/Perp/components/FooterTicker/footerTickerUtils.test.ts
@@ -1,0 +1,178 @@
+import {
+  getFooterTickerItemKey,
+  getFooterTickerStructureKey,
+  isFooterTickerTextWithinBudget,
+  mergeFooterTickerLiveValues,
+  shouldAnimateFooterTicker,
+} from './footerTickerUtils';
+
+import type {
+  IFooterTickerItemData,
+  IFooterTickerTextWidthBudgetMap,
+} from './footerTickerUtils';
+
+function createItem(
+  overrides: Partial<IFooterTickerItemData>,
+): IFooterTickerItemData {
+  return {
+    displayName: 'BTC',
+    coinName: 'BTC',
+    dexIndex: 0,
+    assetId: 0,
+    mode: 'perp',
+    change24hPercent: 1,
+    markPrice: '100',
+    ...overrides,
+  };
+}
+
+function createWidthBudgets(
+  items: IFooterTickerItemData[],
+): IFooterTickerTextWidthBudgetMap {
+  return Object.fromEntries(
+    items.map((item) => [
+      getFooterTickerItemKey(item),
+      {
+        itemWidth: 120,
+        changeText: '+1.00%',
+        changeWidth: 60,
+        priceText: '100',
+        priceWidth: 30,
+      },
+    ]),
+  );
+}
+
+const measureText = (text: string) => text.length * 10;
+
+describe('footerTickerUtils', () => {
+  test('structure key ignores live price changes', () => {
+    const first = createItem({});
+    const updated = createItem({
+      change24hPercent: 2,
+      markPrice: '101',
+    });
+
+    expect(getFooterTickerStructureKey([first])).toBe(
+      getFooterTickerStructureKey([updated]),
+    );
+  });
+
+  test('structure key changes when the display order changes', () => {
+    const btc = createItem({});
+    const eth = createItem({
+      displayName: 'ETH',
+      coinName: 'ETH',
+      assetId: 1,
+    });
+
+    expect(getFooterTickerStructureKey([btc, eth])).not.toBe(
+      getFooterTickerStructureKey([eth, btc]),
+    );
+  });
+
+  test('accepts a longer text when its measured pixel width still fits', () => {
+    expect(
+      isFooterTickerTextWithinBudget({
+        text: '1234',
+        baseText: '999',
+        width: 40,
+        measureText,
+      }),
+    ).toBe(true);
+  });
+
+  test('updates safe live values without changing the displayed structure', () => {
+    const btc = createItem({});
+    const eth = createItem({
+      displayName: 'ETH',
+      coinName: 'ETH',
+      assetId: 1,
+      markPrice: '200',
+    });
+    const next = mergeFooterTickerLiveValues({
+      displayItems: [btc, eth],
+      latestItems: [
+        createItem({
+          displayName: 'ETH',
+          coinName: 'ETH',
+          assetId: 1,
+          change24hPercent: 3,
+          markPrice: '201',
+        }),
+        createItem({
+          change24hPercent: 2,
+          markPrice: '101',
+        }),
+      ],
+      widthBudgets: createWidthBudgets([btc, eth]),
+      measureText,
+    });
+
+    expect(next.map((item) => item.coinName)).toEqual(['BTC', 'ETH']);
+    expect(next.map((item) => item.markPrice)).toEqual(['101', '201']);
+    expect(next.map((item) => item.change24hPercent)).toEqual([2, 3]);
+  });
+
+  test('keeps the previous safe live value when the latest value exceeds its pixel budget', () => {
+    const snapshot = createItem({ markPrice: '100' });
+    const previous = createItem({ markPrice: '101' });
+    const latest = createItem({ markPrice: '10000' });
+
+    expect(
+      mergeFooterTickerLiveValues({
+        displayItems: [snapshot],
+        latestItems: [latest],
+        previousLiveItems: [previous],
+        widthBudgets: createWidthBudgets([snapshot]),
+        measureText,
+      }),
+    ).toEqual([previous]);
+  });
+
+  test('keeps the snapshot when no safe live value exists', () => {
+    const snapshot = createItem({ markPrice: '100' });
+    const latest = createItem({ markPrice: '10000' });
+
+    expect(
+      mergeFooterTickerLiveValues({
+        displayItems: [snapshot],
+        latestItems: [latest],
+        widthBudgets: createWidthBudgets([snapshot]),
+        measureText,
+      }),
+    ).toEqual([snapshot]);
+  });
+
+  test('keeps the previous value when an item disappears temporarily', () => {
+    const snapshot = createItem({ markPrice: '100' });
+    const previous = createItem({ markPrice: '101' });
+
+    expect(
+      mergeFooterTickerLiveValues({
+        displayItems: [snapshot],
+        latestItems: [],
+        previousLiveItems: [previous],
+        widthBudgets: createWidthBudgets([snapshot]),
+        measureText,
+      }),
+    ).toEqual([previous]);
+  });
+
+  test('disables the marquee when reduced motion is requested', () => {
+    expect(
+      shouldAnimateFooterTicker({
+        contentWidth: 1000,
+        containerWidth: 500,
+        prefersReducedMotion: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldAnimateFooterTicker({
+        contentWidth: 1000,
+        containerWidth: 500,
+        prefersReducedMotion: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/kit/src/views/Perp/components/FooterTicker/footerTickerUtils.test.ts
+++ b/packages/kit/src/views/Perp/components/FooterTicker/footerTickerUtils.test.ts
@@ -1,15 +1,10 @@
 import {
-  getFooterTickerItemKey,
   getFooterTickerStructureKey,
-  isFooterTickerTextWithinBudget,
   mergeFooterTickerLiveValues,
   shouldAnimateFooterTicker,
 } from './footerTickerUtils';
 
-import type {
-  IFooterTickerItemData,
-  IFooterTickerTextWidthBudgetMap,
-} from './footerTickerUtils';
+import type { IFooterTickerItemData } from './footerTickerUtils';
 
 function createItem(
   overrides: Partial<IFooterTickerItemData>,
@@ -25,25 +20,6 @@ function createItem(
     ...overrides,
   };
 }
-
-function createWidthBudgets(
-  items: IFooterTickerItemData[],
-): IFooterTickerTextWidthBudgetMap {
-  return Object.fromEntries(
-    items.map((item) => [
-      getFooterTickerItemKey(item),
-      {
-        itemWidth: 120,
-        changeText: '+1.00%',
-        changeWidth: 60,
-        priceText: '100',
-        priceWidth: 30,
-      },
-    ]),
-  );
-}
-
-const measureText = (text: string) => text.length * 10;
 
 describe('footerTickerUtils', () => {
   test('structure key ignores live price changes', () => {
@@ -71,18 +47,7 @@ describe('footerTickerUtils', () => {
     );
   });
 
-  test('accepts a longer text when its measured pixel width still fits', () => {
-    expect(
-      isFooterTickerTextWithinBudget({
-        text: '1234',
-        baseText: '999',
-        width: 40,
-        measureText,
-      }),
-    ).toBe(true);
-  });
-
-  test('updates safe live values without changing the displayed structure', () => {
+  test('updates live values without changing the displayed structure', () => {
     const btc = createItem({});
     const eth = createItem({
       displayName: 'ETH',
@@ -105,58 +70,21 @@ describe('footerTickerUtils', () => {
           markPrice: '101',
         }),
       ],
-      widthBudgets: createWidthBudgets([btc, eth]),
-      measureText,
     });
 
     expect(next.map((item) => item.coinName)).toEqual(['BTC', 'ETH']);
     expect(next.map((item) => item.markPrice)).toEqual(['101', '201']);
-    expect(next.map((item) => item.change24hPercent)).toEqual([2, 3]);
   });
 
-  test('keeps the previous safe live value when the latest value exceeds its pixel budget', () => {
-    const snapshot = createItem({ markPrice: '100' });
-    const previous = createItem({ markPrice: '101' });
-    const latest = createItem({ markPrice: '10000' });
+  test('keeps displayed items that temporarily disappear', () => {
+    const btc = createItem({});
 
     expect(
       mergeFooterTickerLiveValues({
-        displayItems: [snapshot],
-        latestItems: [latest],
-        previousLiveItems: [previous],
-        widthBudgets: createWidthBudgets([snapshot]),
-        measureText,
-      }),
-    ).toEqual([previous]);
-  });
-
-  test('keeps the snapshot when no safe live value exists', () => {
-    const snapshot = createItem({ markPrice: '100' });
-    const latest = createItem({ markPrice: '10000' });
-
-    expect(
-      mergeFooterTickerLiveValues({
-        displayItems: [snapshot],
-        latestItems: [latest],
-        widthBudgets: createWidthBudgets([snapshot]),
-        measureText,
-      }),
-    ).toEqual([snapshot]);
-  });
-
-  test('keeps the previous value when an item disappears temporarily', () => {
-    const snapshot = createItem({ markPrice: '100' });
-    const previous = createItem({ markPrice: '101' });
-
-    expect(
-      mergeFooterTickerLiveValues({
-        displayItems: [snapshot],
+        displayItems: [btc],
         latestItems: [],
-        previousLiveItems: [previous],
-        widthBudgets: createWidthBudgets([snapshot]),
-        measureText,
       }),
-    ).toEqual([previous]);
+    ).toEqual([btc]);
   });
 
   test('disables the marquee when reduced motion is requested', () => {

--- a/packages/kit/src/views/Perp/components/FooterTicker/footerTickerUtils.ts
+++ b/packages/kit/src/views/Perp/components/FooterTicker/footerTickerUtils.ts
@@ -1,0 +1,172 @@
+import { formatPriceToSignificantDigits } from '@onekeyhq/shared/src/utils/perpsUtils';
+
+export interface IFooterTickerItemData {
+  displayName: string;
+  coinName: string;
+  dexIndex: number;
+  assetId: number;
+  mode: 'perp' | 'spot';
+  change24hPercent: number;
+  markPrice?: string;
+}
+
+export interface IFooterTickerTextWidthBudget {
+  itemWidth: number;
+  changeText: string;
+  changeWidth: number;
+  priceText: string;
+  priceWidth: number;
+}
+
+export type IFooterTickerTextWidthBudgetMap = Record<
+  string,
+  IFooterTickerTextWidthBudget
+>;
+
+export type IFooterTickerTextMeasure = (text: string) => number;
+
+export function getFooterTickerItemKey(item: IFooterTickerItemData) {
+  return `${item.mode}:${item.dexIndex}:${item.assetId}:${item.coinName}`;
+}
+
+export function getFooterTickerStructureKey(items: IFooterTickerItemData[]) {
+  return items
+    .map((item) => `${getFooterTickerItemKey(item)}:${item.displayName}`)
+    .join('|');
+}
+
+export function getFooterTickerDisplayText(item: IFooterTickerItemData) {
+  const sign = item.change24hPercent >= 0 ? '+' : '';
+  return {
+    changeText: `${sign}${item.change24hPercent.toFixed(2)}%`,
+    priceText: item.markPrice
+      ? formatPriceToSignificantDigits(item.markPrice)
+      : '-',
+  };
+}
+
+export function getFooterTickerSnapshotKey(items: IFooterTickerItemData[]) {
+  return items
+    .map(
+      (item) =>
+        `${getFooterTickerItemKey(item)}:${item.displayName}:${
+          item.change24hPercent
+        }:${item.markPrice ?? ''}`,
+    )
+    .join('|');
+}
+
+export function isFooterTickerTextWithinBudget({
+  text,
+  baseText,
+  width,
+  measureText,
+  tolerance = 1,
+}: {
+  text: string;
+  baseText: string;
+  width: number;
+  measureText: IFooterTickerTextMeasure;
+  tolerance?: number;
+}) {
+  return (
+    text.length <= baseText.length || measureText(text) <= width + tolerance
+  );
+}
+
+export function isFooterTickerValueWidthSafe({
+  item,
+  widthBudget,
+  measureText,
+}: {
+  item: IFooterTickerItemData;
+  widthBudget: IFooterTickerTextWidthBudget;
+  measureText: IFooterTickerTextMeasure;
+}) {
+  const { changeText, priceText } = getFooterTickerDisplayText(item);
+  return (
+    isFooterTickerTextWithinBudget({
+      text: changeText,
+      baseText: widthBudget.changeText,
+      width: widthBudget.changeWidth,
+      measureText,
+    }) &&
+    isFooterTickerTextWithinBudget({
+      text: priceText,
+      baseText: widthBudget.priceText,
+      width: widthBudget.priceWidth,
+      measureText,
+    })
+  );
+}
+
+function isSameFooterTickerStructure(
+  first: IFooterTickerItemData,
+  second: IFooterTickerItemData,
+) {
+  return (
+    getFooterTickerItemKey(first) === getFooterTickerItemKey(second) &&
+    first.displayName === second.displayName
+  );
+}
+
+export function mergeFooterTickerLiveValues({
+  displayItems,
+  latestItems,
+  previousLiveItems = [],
+  widthBudgets,
+  measureText,
+}: {
+  displayItems: IFooterTickerItemData[];
+  latestItems: IFooterTickerItemData[];
+  previousLiveItems?: IFooterTickerItemData[];
+  widthBudgets: IFooterTickerTextWidthBudgetMap;
+  measureText: IFooterTickerTextMeasure;
+}) {
+  const latestByKey = new Map(
+    latestItems.map((item) => [getFooterTickerItemKey(item), item]),
+  );
+  const previousByKey = new Map(
+    previousLiveItems.map((item) => [getFooterTickerItemKey(item), item]),
+  );
+
+  return displayItems.map((displayItem) => {
+    const itemKey = getFooterTickerItemKey(displayItem);
+    const latestItem = latestByKey.get(itemKey);
+    const widthBudget = widthBudgets[itemKey];
+    if (
+      latestItem &&
+      widthBudget &&
+      isSameFooterTickerStructure(displayItem, latestItem) &&
+      isFooterTickerValueWidthSafe({
+        item: latestItem,
+        widthBudget,
+        measureText,
+      })
+    ) {
+      return {
+        ...displayItem,
+        change24hPercent: latestItem.change24hPercent,
+        markPrice: latestItem.markPrice,
+      };
+    }
+
+    const previousItem = previousByKey.get(itemKey);
+    return previousItem &&
+      isSameFooterTickerStructure(displayItem, previousItem)
+      ? previousItem
+      : displayItem;
+  });
+}
+
+export function shouldAnimateFooterTicker({
+  contentWidth,
+  containerWidth,
+  prefersReducedMotion,
+}: {
+  contentWidth: number;
+  containerWidth: number;
+  prefersReducedMotion: boolean;
+}) {
+  return !prefersReducedMotion && contentWidth > containerWidth;
+}

--- a/packages/kit/src/views/Perp/components/FooterTicker/footerTickerUtils.ts
+++ b/packages/kit/src/views/Perp/components/FooterTicker/footerTickerUtils.ts
@@ -10,21 +10,6 @@ export interface IFooterTickerItemData {
   markPrice?: string;
 }
 
-export interface IFooterTickerTextWidthBudget {
-  itemWidth: number;
-  changeText: string;
-  changeWidth: number;
-  priceText: string;
-  priceWidth: number;
-}
-
-export type IFooterTickerTextWidthBudgetMap = Record<
-  string,
-  IFooterTickerTextWidthBudget
->;
-
-export type IFooterTickerTextMeasure = (text: string) => number;
-
 export function getFooterTickerItemKey(item: IFooterTickerItemData) {
   return `${item.mode}:${item.dexIndex}:${item.assetId}:${item.coinName}`;
 }
@@ -45,116 +30,21 @@ export function getFooterTickerDisplayText(item: IFooterTickerItemData) {
   };
 }
 
-export function getFooterTickerSnapshotKey(items: IFooterTickerItemData[]) {
-  return items
-    .map(
-      (item) =>
-        `${getFooterTickerItemKey(item)}:${item.displayName}:${
-          item.change24hPercent
-        }:${item.markPrice ?? ''}`,
-    )
-    .join('|');
-}
-
-export function isFooterTickerTextWithinBudget({
-  text,
-  baseText,
-  width,
-  measureText,
-  tolerance = 1,
-}: {
-  text: string;
-  baseText: string;
-  width: number;
-  measureText: IFooterTickerTextMeasure;
-  tolerance?: number;
-}) {
-  return (
-    text.length <= baseText.length || measureText(text) <= width + tolerance
-  );
-}
-
-export function isFooterTickerValueWidthSafe({
-  item,
-  widthBudget,
-  measureText,
-}: {
-  item: IFooterTickerItemData;
-  widthBudget: IFooterTickerTextWidthBudget;
-  measureText: IFooterTickerTextMeasure;
-}) {
-  const { changeText, priceText } = getFooterTickerDisplayText(item);
-  return (
-    isFooterTickerTextWithinBudget({
-      text: changeText,
-      baseText: widthBudget.changeText,
-      width: widthBudget.changeWidth,
-      measureText,
-    }) &&
-    isFooterTickerTextWithinBudget({
-      text: priceText,
-      baseText: widthBudget.priceText,
-      width: widthBudget.priceWidth,
-      measureText,
-    })
-  );
-}
-
-function isSameFooterTickerStructure(
-  first: IFooterTickerItemData,
-  second: IFooterTickerItemData,
-) {
-  return (
-    getFooterTickerItemKey(first) === getFooterTickerItemKey(second) &&
-    first.displayName === second.displayName
-  );
-}
-
 export function mergeFooterTickerLiveValues({
   displayItems,
   latestItems,
-  previousLiveItems = [],
-  widthBudgets,
-  measureText,
 }: {
   displayItems: IFooterTickerItemData[];
   latestItems: IFooterTickerItemData[];
-  previousLiveItems?: IFooterTickerItemData[];
-  widthBudgets: IFooterTickerTextWidthBudgetMap;
-  measureText: IFooterTickerTextMeasure;
 }) {
   const latestByKey = new Map(
     latestItems.map((item) => [getFooterTickerItemKey(item), item]),
   );
-  const previousByKey = new Map(
-    previousLiveItems.map((item) => [getFooterTickerItemKey(item), item]),
-  );
 
   return displayItems.map((displayItem) => {
-    const itemKey = getFooterTickerItemKey(displayItem);
-    const latestItem = latestByKey.get(itemKey);
-    const widthBudget = widthBudgets[itemKey];
-    if (
-      latestItem &&
-      widthBudget &&
-      isSameFooterTickerStructure(displayItem, latestItem) &&
-      isFooterTickerValueWidthSafe({
-        item: latestItem,
-        widthBudget,
-        measureText,
-      })
-    ) {
-      return {
-        ...displayItem,
-        change24hPercent: latestItem.change24hPercent,
-        markPrice: latestItem.markPrice,
-      };
-    }
-
-    const previousItem = previousByKey.get(itemKey);
-    return previousItem &&
-      isSameFooterTickerStructure(displayItem, previousItem)
-      ? previousItem
+    const latestItem = latestByKey.get(getFooterTickerItemKey(displayItem));
+    return latestItem?.displayName === displayItem.displayName
+      ? latestItem
       : displayItem;
   });
 }

--- a/packages/kit/src/views/Perp/components/PerpContentFooter.tsx
+++ b/packages/kit/src/views/Perp/components/PerpContentFooter.tsx
@@ -1,8 +1,19 @@
 import { useMemo } from 'react';
 
-import { Page, XStack, useMedia } from '@onekeyhq/components';
+import { useIntl } from 'react-intl';
+
+import {
+  Page,
+  SizableText,
+  Tooltip,
+  XStack,
+  YStack,
+  useMedia,
+} from '@onekeyhq/components';
 import { usePerpsNetworkStatusAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
+import { formatTime } from '@onekeyhq/shared/src/utils/dateUtils';
 
 import { PerpFooterActions } from '../../../components/Footer';
 import { NetworkStatusBadge } from '../../../components/NetworkStatusBadge';
@@ -10,7 +21,10 @@ import { PerpRefreshButton } from '../../../components/PerpRefreshButton';
 
 import { PerpFooterTicker } from './FooterTicker/PerpFooterTicker';
 
+const monoFontVariant: ['tabular-nums'] = ['tabular-nums'];
+
 function PerpNetworkStatus() {
+  const intl = useIntl();
   const [networkStatus] = usePerpsNetworkStatusAtom();
   const connected = networkStatus?.connected !== false;
   const pingMs = networkStatus?.pingMs;
@@ -25,8 +39,58 @@ function PerpNetworkStatus() {
     }
     return undefined;
   }, [networkStatus?.connected, pingMs]);
+  const statusLabel = intl.formatMessage({
+    id: connected ? ETranslations.perp_online : ETranslations.perp_offline,
+  });
+  const lastMessageLabel = networkStatus?.lastMessageAt
+    ? formatTime(new Date(networkStatus.lastMessageAt), {
+        formatTemplate: 'HH:mm:ss',
+      })
+    : '--';
 
-  return <NetworkStatusBadge connected={connected} monoLabel={monoLabel} />;
+  return (
+    <Tooltip
+      placement="top"
+      renderContent={
+        <YStack minWidth={180} gap="$2">
+          <XStack justifyContent="space-between" alignItems="center" gap="$6">
+            <SizableText size="$bodySm" color="$textSubdued">
+              {intl.formatMessage({ id: ETranslations.global_status })}
+            </SizableText>
+            <XStack alignItems="center" gap="$1.5">
+              <SizableText
+                size="$bodySmMedium"
+                color={connected ? '$textSuccess' : '$textCritical'}
+              >
+                {statusLabel}
+              </SizableText>
+              <SizableText
+                size="$bodySmMedium"
+                color="$textSubdued"
+                fontFamily="$monoRegular"
+                fontVariant={monoFontVariant}
+              >
+                {monoLabel ?? '--ms'}
+              </SizableText>
+            </XStack>
+          </XStack>
+          <XStack justifyContent="space-between" alignItems="center" gap="$6">
+            <SizableText size="$bodySm" color="$textSubdued">
+              {intl.formatMessage({ id: ETranslations.market_last_updated })}
+            </SizableText>
+            <SizableText
+              size="$bodySmMedium"
+              fontFamily="$monoRegular"
+              fontVariant={monoFontVariant}
+            >
+              {lastMessageLabel}
+            </SizableText>
+          </XStack>
+        </YStack>
+      }
+      renderTrigger={<NetworkStatusBadge connected={connected} cursor="help" />}
+    />
+  );
 }
 
 export function PerpContentFooter() {

--- a/packages/kit/src/views/Perp/hooks/usePopularTickers.ts
+++ b/packages/kit/src/views/Perp/hooks/usePopularTickers.ts
@@ -14,8 +14,9 @@ import {
   isPerpsUniverseCacheComplete,
   toCtxIndex,
 } from '@onekeyhq/shared/src/utils/perpsDexUtils';
-import {
+import perpsUtils, {
   formatSpotPairDisplayName,
+  formatSpotPriceEntry,
   getSpotMarketCapValue,
   parseDexCoin,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
@@ -26,13 +27,15 @@ import type {
 
 import { usePromiseResult } from '../../../hooks/usePromiseResult';
 import {
-  type IPopularTickerItem,
-  POPULAR_TICKER_COUNT,
+  type IPopularTickerItem as IPopularTickerRankItem,
   pickPopularPerpTickers,
 } from '../utils/popularTickers';
 import { getPerpTokenSelectorHotTab } from '../utils/tokenSelectorTabs';
 
-export type { IPopularTickerItem };
+export type IPopularTickerItem = IPopularTickerRankItem & {
+  change24hPercent: number;
+  markPrice?: string;
+};
 
 /**
  * Computes top popular tickers ranked by turnover rate:
@@ -128,15 +131,20 @@ export function usePopularTickers(): IPopularTickerItem[] {
       scored.sort(
         (a, b) => b.hotScore - a.hotScore || b.marketCap - a.marketCap,
       );
-      return scored
-        .slice(0, POPULAR_TICKER_COUNT)
-        .map(({ marketCap, ...item }) => item);
+      return scored.map(({ marketCap, ...item }) => {
+        const displayCtx = formatSpotPriceEntry(spotPriceMap[item.coinName]);
+        return {
+          ...item,
+          change24hPercent: displayCtx?.change24hPercent ?? 0,
+          markPrice: displayCtx?.markPrice,
+        };
+      });
     }
 
     const perpUniverse = taggedUniverse.data;
     if (!perpUniverse?.length) return [];
     const { assetCtxsByDex } = allAssetCtxs;
-    const items: IPopularTickerItem[] = [];
+    const items: IPopularTickerRankItem[] = [];
 
     for (let dexIndex = 0; dexIndex < perpUniverse.length; dexIndex += 1) {
       const assets = perpUniverse[dexIndex] ?? [];
@@ -178,6 +186,17 @@ export function usePopularTickers(): IPopularTickerItem[] {
     return pickPopularPerpTickers({
       items,
       hotTabTokens: hotTab?.tokens,
+    }).map((item) => {
+      const ctx =
+        assetCtxsByDex[item.dexIndex]?.[
+          toCtxIndex(item.assetId, item.dexIndex)
+        ] ?? null;
+      const displayCtx = perpsUtils.formatAssetCtx(ctx);
+      return {
+        ...item,
+        change24hPercent: displayCtx?.change24hPercent ?? 0,
+        markPrice: displayCtx?.markPrice,
+      };
     });
   }, [
     allAssetCtxs,

--- a/packages/kit/src/views/Perp/utils/popularTickers.test.ts
+++ b/packages/kit/src/views/Perp/utils/popularTickers.test.ts
@@ -45,4 +45,28 @@ describe('pickPopularPerpTickers', () => {
       }).map((item) => item.coinName),
     ).toEqual(['ETH', 'BTC']);
   });
+
+  it('does not limit the number of matching hot tab tokens', () => {
+    const items = Array.from({ length: 12 }, (_, index) =>
+      createTicker(`TOKEN_${index}`, index + 1),
+    );
+    const hotTabTokens = items.map((item) => item.coinName).toReversed();
+
+    expect(
+      pickPopularPerpTickers({
+        items,
+        hotTabTokens,
+      }).map((item) => item.coinName),
+    ).toEqual(hotTabTokens);
+  });
+
+  it('does not limit the number of fallback hot score results', () => {
+    const items = Array.from({ length: 12 }, (_, index) =>
+      createTicker(`TOKEN_${index}`, index + 1),
+    );
+
+    expect(
+      pickPopularPerpTickers({ items }).map((item) => item.coinName),
+    ).toHaveLength(items.length);
+  });
 });

--- a/packages/kit/src/views/Perp/utils/popularTickers.ts
+++ b/packages/kit/src/views/Perp/utils/popularTickers.ts
@@ -1,5 +1,3 @@
-const POPULAR_TICKER_COUNT = 10;
-
 export interface IPopularTickerItem {
   mode: 'perp' | 'spot';
   coinName: string;
@@ -35,14 +33,11 @@ export function pickPopularPerpTickers({
           b.hotScore - a.hotScore,
       );
     if (hotTabItems.length) {
-      return hotTabItems.slice(0, POPULAR_TICKER_COUNT);
+      return hotTabItems;
     }
   }
 
   return items
     .filter((item) => item.hotScore > 0)
-    .toSorted((a, b) => b.hotScore - a.hotScore)
-    .slice(0, POPULAR_TICKER_COUNT);
+    .toSorted((a, b) => b.hotScore - a.hotScore);
 }
-
-export { POPULAR_TICKER_COUNT };


### PR DESCRIPTION
## Summary

- Rework the Web Perps footer ticker into a smooth requestAnimationFrame marquee with hover pause and reduced-motion support.
- Use compact fixed-width numeric columns with tabular figures and no wrapping so live prices do not shift item widths.
- Align popular tickers with the server Hot tab without a local item limit, and move connection details into a status tooltip.

## Test Plan

- yarn agent:check --profile commit
- yarn agent:check --profile pr
- yarn jest packages/kit/src/views/Perp/components/FooterTicker/footerTickerUtils.test.ts packages/kit/src/views/Perp/utils/popularTickers.test.ts --runInBand
- Web Rspack dev compilation (passes with 52 existing third-party warnings)