### PR TITLE
fix: restore desktop usb routing(OK-60693)

### DIFF
--- a/packages/kit-bg/src/services/ServiceHardware/HardwareConnectionManager.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/HardwareConnectionManager.ts
@@ -139,7 +139,7 @@ export class HardwareConnectionManager {
   }
 
   // WebUSB detection
-  async detectWebUSBAvailability(connectId?: string): Promise<boolean> {
+  async detectWebUSBAvailability(_connectId?: string): Promise<boolean> {
     if (!platformEnv.isSupportDesktopBle) return true;
     try {
       const usb = globalThis?.navigator?.usb;
@@ -156,18 +156,13 @@ export class HardwareConnectionManager {
           dev.serialNumber.trim().length > 0;
         return isOneKey && hasSerialNumber;
       });
-      const expectedConnectId = connectId?.trim().toLowerCase();
-      return onekeyDevices.some(
-        (device) =>
-          !expectedConnectId ||
-          device.serialNumber?.trim().toLowerCase() === expectedConnectId,
-      );
+      return onekeyDevices.length > 0;
     } catch {
       return false;
     }
   }
 
-  async detectBridgeAvailability(connectId?: string): Promise<boolean> {
+  async detectBridgeAvailability(_connectId?: string): Promise<boolean> {
     if (!platformEnv.isSupportDesktopBle) {
       return true;
     }
@@ -185,14 +180,7 @@ export class HardwareConnectionManager {
       if (!Array.isArray(devices)) {
         return false;
       }
-      const expectedConnectId = connectId?.trim().toLowerCase();
-      return devices.some((device) => {
-        if (!expectedConnectId) return true;
-        return (
-          typeof device.path === 'string' &&
-          device.path.trim().toLowerCase() === expectedConnectId
-        );
-      });
+      return devices.length > 0;
     } catch (_error) {
       return false;
     }

--- a/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.getCompatibleConnectId.test.ts
+++ b/packages/kit-bg/src/services/ServiceHardware/ServiceHardware.getCompatibleConnectId.test.ts
@@ -1137,7 +1137,7 @@ describe('ServiceHardware.getCompatibleConnectId', () => {
     ]);
   });
 
-  it('uses USB only when the selected authorized OneKey WebUSB device is available', async () => {
+  it('uses USB when any authorized OneKey WebUSB device is available', async () => {
     const originalNavigator = Object.getOwnPropertyDescriptor(
       globalThis,
       'navigator',
@@ -1191,7 +1191,7 @@ describe('ServiceHardware.getCompatibleConnectId', () => {
 
       await expect(
         service.connectionManager.detectWebUSBAvailability('OTHER_USB_ID'),
-      ).resolves.toBe(false);
+      ).resolves.toBe(true);
       await expect(
         service.connectionManager.detectWebUSBAvailability('PRO2_USB_ID'),
       ).resolves.toBe(true);
@@ -1335,7 +1335,7 @@ describe('ServiceHardware.getCompatibleConnectId', () => {
     }
   });
 
-  it('uses Bridge only when the selected device is enumerated', async () => {
+  it('uses Bridge when any Bridge device is enumerated', async () => {
     mockedAxios.post.mockResolvedValue({
       data: [{ path: 'UNRELATED_USB_ID' }],
     });
@@ -1374,7 +1374,7 @@ describe('ServiceHardware.getCompatibleConnectId', () => {
 
     await expect(
       service.connectionManager.detectBridgeAvailability('OTHER_USB_ID'),
-    ).resolves.toBe(false);
+    ).resolves.toBe(true);
     await expect(
       service.connectionManager.detectBridgeAvailability('UNRELATED_USB_ID'),
     ).resolves.toBe(true);


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60693](https://onekeyhq.atlassian.net/browse/OK-60693)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Restore device-independent desktop USB availability: any authorized OneKey WebUSB or Bridge device keeps hardware calls on USB.
- Preserve the existing firmware-update USB override and Protocol V2 transport selection.
- Update the focused hardware connection tests to cover the intended global USB-presence behavior.

## Intent & Context

OK-60693 reports that a OneKey Classic 1S connected by USB still used Bluetooth during BTC signing. The intended desktop policy is deliberately simple: when any usable OneKey USB device is present, hardware calls should prefer USB.

PR #12905 changed the shared USB availability probe to require the enumerated WebUSB serial or Bridge path to exactly match the current `connectId`. That review-driven change conflicted with the established transport policy and caused the signing path to fall back to Desktop BLE when the current identity did not match the USB transport identity.

## Root Cause

`detectWebUSBAvailability()` and `detectBridgeAvailability()` are generic transport-selection probes, not selected-device ownership validators. Exact `connectId` matching made their result device-specific even though callers and the two-second routing cache were designed around a global USB-presence signal.

For the reproduced Classic 1S flow, WebUSB discovery and pre-initialization succeeded with USB connect ID `CLA45F0023`, but the exact-match probe could still report USB unavailable and route the formal signing call through NobleBLE.

## Design Decisions

- Revert only the selected-device equality checks in the generic WebUSB and Bridge probes.
- Keep the OneKey VID/PID and non-empty serial filtering for WebUSB, so only authorized devices usable by the transport count as present.
- Keep the `UPDATE_FIRMWARE` USB-only branch and explicit Protocol V2 preflight parameters. The entire firmware-related change is not reverted.
- Keep the existing method signatures to avoid changing callers; the now-intentionally-unused `connectId` parameters are prefixed with `_`.
- Accept the multi-device behavior as intentional product policy: the presence of any OneKey USB device forces USB routing.

## Changes Detail

- `HardwareConnectionManager.ts`: restore global OneKey WebUSB/Bridge presence checks.
- `ServiceHardware.getCompatibleConnectId.test.ts`: assert that an unrelated selected `connectId` still resolves USB/Bridge as available when a OneKey device is enumerated.

## Risk Assessment

- **Risk Level**: Low
- **Affected Platforms**: Desktop
- **Risk Areas**: Desktop automatic transport selection when multiple hardware devices are nearby. The global USB preference is intentional; firmware update transport selection remains unchanged.

## Test plan

- [x] `yarn jest packages/kit-bg/src/services/ServiceHardware/ServiceHardware.getCompatibleConnectId.test.ts --runInBand` — 58 tests passed.
- [x] `yarn agent:check --profile commit` — worktree lint, staged lint, and TypeScript checks passed.
- [x] `release-app-bundles.yml` run `32247325784` completed successfully for commit `b46849499bffacc1c9dd5bf3f35fbf602940bad1`.
- [x] TF bundle `19913008`: pre-initialization and `btcSignTransaction` both used WebUSB connect ID `CLA45F0023`; no NobleBLE or Desktop BLE fallback occurred.
- [x] The device reached the signing confirmation step over WebUSB and returned only user cancellation (`803`), not a transport failure.

Jira: https://onekeyhq.atlassian.net/browse/OK-60693
Regression source: https://github.com/OneKeyHQ/app-monorepo/pull/12905

[OK-60693]: https://onekeyhq.atlassian.net/browse/OK-60693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ