### PR TITLE
fix: mute nft list video and show perp dex venue tag in menu bar watchlist(OK-60010, OK-60691)

### DIFF
--- a/packages/components/src/content/Video/index.native.tsx
+++ b/packages/components/src/content/Video/index.native.tsx
@@ -10,7 +10,7 @@ import type { ViewStyle } from 'react-native';
 import type { VideoRef } from 'react-native-video';
 
 function VideoComponent(
-  { muted, ...rawProps }: IVideoProps,
+  { muted, autoPlay, paused, ...rawProps }: IVideoProps,
   ref: ForwardedRef<IVideoRef>,
 ) {
   const videoRef = useRef<VideoRef>(null);
@@ -32,6 +32,9 @@ function VideoComponent(
       ref={videoRef}
       style={style as ViewStyle}
       muted={muted}
+      // react-native-video has no `autoPlay`; map `autoPlay={false}` to its
+      // `paused` prop so both platforms honor it.
+      paused={paused ?? (autoPlay === false ? true : undefined)}
       {...props}
     />
   );

--- a/packages/components/src/content/Video/index.tsx
+++ b/packages/components/src/content/Video/index.tsx
@@ -94,7 +94,9 @@ function VideoComponent(rawProps: IVideoProps, ref: ForwardedRef<IVideoRef>) {
     // eslint-disable-next-line jsx-a11y/media-has-caption -- decorative UI video, no captions needed
     <video
       ref={videoRef}
-      autoPlay={autoPlay ?? true}
+      // Match native's "paused wins" semantics: an initial paused={true}
+      // must suppress browser autoplay even when autoPlay is not passed.
+      autoPlay={autoPlay ?? paused !== true}
       muted={muted}
       style={style as any}
       {...(props as any)}

--- a/packages/components/src/content/Video/index.tsx
+++ b/packages/components/src/content/Video/index.tsx
@@ -14,6 +14,7 @@ function VideoComponent(rawProps: IVideoProps, ref: ForwardedRef<IVideoRef>) {
       rate,
       muted,
       paused,
+      autoPlay,
       onEnd,
       onProgress,
       ...props
@@ -48,6 +49,9 @@ function VideoComponent(rawProps: IVideoProps, ref: ForwardedRef<IVideoRef>) {
   }, [rate]);
 
   useEffect(() => {
+    // Sync playback only when the caller controls `paused`; otherwise
+    // `autoPlay` alone decides whether the video starts.
+    if (paused === undefined) return;
     const video = videoRef.current;
     if (!video) return;
     if (paused && !video.paused) {
@@ -90,7 +94,7 @@ function VideoComponent(rawProps: IVideoProps, ref: ForwardedRef<IVideoRef>) {
     // eslint-disable-next-line jsx-a11y/media-has-caption -- decorative UI video, no captions needed
     <video
       ref={videoRef}
-      autoPlay
+      autoPlay={autoPlay ?? true}
       muted={muted}
       style={style as any}
       {...(props as any)}

--- a/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
+++ b/packages/kit/src/hooks/useTrayDataProvider.desktop.ts
@@ -848,6 +848,7 @@ export function useTrayDataProvider() {
                         type: 'perps',
                         perpsCoin: item.perpsCoin,
                         maxLeverage: coin.maxLeverage,
+                        dexLabel: parsedCoin.dexLabel || parsedDisplay.dexLabel,
                         subtitle: getTokenSubtitle(
                           coin.name || item.perpsCoin || '',
                           tokenSearchAliases,

--- a/packages/kit/src/views/Home/components/NFTListView/NFTListItem.tsx
+++ b/packages/kit/src/views/Home/components/NFTListView/NFTListItem.tsx
@@ -65,6 +65,7 @@ function BasicNFTListItem(props: IProps) {
                   zIndex: 1,
                 }}
                 autoPlay={false}
+                muted
                 source={{ uri: nft.metadata?.image }}
               />
             </Stack>

--- a/packages/kit/src/views/Tray/components/WatchlistTickers.tsx
+++ b/packages/kit/src/views/Tray/components/WatchlistTickers.tsx
@@ -122,10 +122,9 @@ function TickerTags({
   const hasTags =
     ticker.type === 'perps' ||
     ticker.maxLeverage ||
-    ticker.subtitle ||
+    ticker.dexLabel ||
     ticker.stock?.sourceLogoUri ||
     ticker.stock?.isOpen !== undefined ||
-    ticker.stock?.subtitle ||
     ticker.communityRecognized;
 
   if (!hasTags) return null;
@@ -142,9 +141,9 @@ function TickerTags({
           {ticker.maxLeverage}x
         </TickerTag>
       ) : null}
-      {ticker.subtitle ? (
-        <TickerTag bg="$bgStrong" color="$textSubdued">
-          {ticker.subtitle}
+      {ticker.dexLabel ? (
+        <TickerTag bg="$bgInfo" color="$textInfo">
+          {ticker.dexLabel.toLowerCase()}
         </TickerTag>
       ) : null}
       {ticker.stock?.sourceLogoUri ? (
@@ -161,11 +160,6 @@ function TickerTags({
           color={ticker.stock.isOpen ? '$textSuccess' : '$textCaution'}
         >
           {ticker.stock.isOpen ? stockOpenText : stockClosedText}
-        </TickerTag>
-      ) : null}
-      {ticker.stock?.subtitle ? (
-        <TickerTag bg="$bgStrong" color="$textSubdued">
-          {ticker.stock.subtitle}
         </TickerTag>
       ) : null}
       {ticker.communityRecognized ? (
@@ -196,6 +190,10 @@ function TickerRow({
     ticker.name.trim().toLowerCase() !== ticker.symbol.trim().toLowerCase()
       ? ticker.name
       : '';
+  // Market/Perps lists show the localized name (e.g. company name) as plain
+  // subdued text under the symbol, never as a badge — mirror that here.
+  const secondaryText =
+    ticker.subtitle || ticker.stock?.subtitle || secondaryName;
 
   return (
     <Stack
@@ -226,14 +224,14 @@ function TickerRow({
             stockClosedText={stockClosedText}
           />
         </XStack>
-        {secondaryName ? (
+        {secondaryText ? (
           <SizableText
             fontSize="$bodySm"
             color="$textSubdued"
             numberOfLines={1}
             ellipsizeMode="tail"
           >
-            {secondaryName}
+            {secondaryText}
           </SizableText>
         ) : null}
       </Stack>

--- a/packages/shared/src/types/desktop/tray.ts
+++ b/packages/shared/src/types/desktop/tray.ts
@@ -29,6 +29,9 @@ export interface ITrayWatchlistItem {
   isNative?: boolean;
   perpsCoin?: string;
   maxLeverage?: number;
+  // Perp dex venue label parsed from the prefixed coin name
+  // (e.g. "xyz:UNITREE" -> "xyz"); distinguishes same-symbol contracts.
+  dexLabel?: string;
   subtitle?: string;
   communityRecognized?: boolean;
   stock?: IMarketStockInfo;


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60010](https://onekeyhq.atlassian.net/browse/OK-60010) [OK-60691](https://onekeyhq.atlassian.net/browse/OK-60691)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Stop video NFTs from auto-playing with sound in the wallet Home NFT list: the shared `Video` component now honors `autoPlay={false}` on both web and native, and NFT list previews are muted (OK-60010).
- Show the perp dex venue tag (e.g. `xyz`) for perps tickers in the desktop menu bar watchlist, aligned with how the Perps/Market lists display it (OK-60691).

## Intent & Context
- **OK-60010**: Video NFTs played audio immediately when the NFT list rendered. List previews should be silent and not auto-play.
- **OK-60691**: In the menu bar watchlist, same-symbol perp contracts from different dex venues were indistinguishable. The venue label was requested to match the Perps list display (venue badge next to the symbol, localized name as plain secondary text).

## Root Cause
- `packages/components/src/content/Video/index.tsx` (web) hardcoded the `autoPlay` attribute on `<video>`, ignoring the `autoPlay` prop callers passed. Its `paused`-sync effect also force-called `play()` when `paused` was undefined, defeating `autoPlay={false}`.
- `packages/components/src/content/Video/index.native.tsx` dropped `autoPlay` entirely — `react-native-video` has no such prop and defaults to playing.
- The NFT list item passed `autoPlay={false}` (which was ignored) and never passed `muted`.
- The tray watchlist rendered the perps ticker `subtitle` (localized token name) as a badge and had no access to the dex venue label, which is parsed from the prefixed coin name (e.g. `xyz:UNITREE`) but was not forwarded into `ITrayWatchlistItem`.

## Design Decisions
- Fixed `autoPlay` semantics inside the shared `Video` component rather than special-casing the NFT list, so both platforms honor the same prop: web defaults `autoPlay` to `true` (preserving existing callers), native maps `autoPlay={false}` to `react-native-video`'s `paused` prop.
- The web `paused`-sync effect now only runs when the caller actually controls `paused`, so uncontrolled usage is decided by `autoPlay` alone.
- Added a dedicated `dexLabel` field to `ITrayWatchlistItem` instead of overloading `subtitle`, keeping badge content (venue) separate from secondary text (localized name). `subtitle`/`stock.subtitle` moved from badges to the subdued secondary line to mirror Market/Perps list rows.

## Changes Detail
- `packages/components/src/content/Video/index.tsx`: honor the `autoPlay` prop (default `true`); skip the play/pause sync effect when `paused` is uncontrolled.
- `packages/components/src/content/Video/index.native.tsx`: map `autoPlay={false}` to `paused` for `react-native-video`.
- `packages/kit/src/views/Home/components/NFTListView/NFTListItem.tsx`: pass `muted` to video previews.
- `packages/kit/src/hooks/useTrayDataProvider.desktop.ts`: forward the parsed perp dex venue label as `dexLabel`.
- `packages/kit/src/views/Tray/components/WatchlistTickers.tsx`: render `dexLabel` as an info-colored badge (lowercase); show `subtitle`/`stock.subtitle` as plain secondary text instead of badges.
- `packages/shared/src/types/desktop/tray.ts`: add optional `dexLabel` to `ITrayWatchlistItem`.

## Risk Assessment
- **Risk Level**: Low
- **Affected Platforms**: Desktop (menu bar watchlist) / Mobile / Web / Extension (NFT list)
- **Risk Areas**: The `Video` component change affects all its callers — web now respects `autoPlay={false}` and skips the forced `play()` for uncontrolled `paused`; callers relying on the old always-autoplay behavior keep it via the `true` default.

## Test plan
- [ ] Open wallet Home → NFT tab with a video NFT (e.g. Solana `6yNphS8rCv6qieg8AF9JUmT83DPDKd33HDK2P2EoqD6K`): list preview does not play audio.
- [ ] Open the NFT details page: video playback still works there.
- [ ] Desktop menu bar watchlist: a perps ticker with a dex-prefixed coin (e.g. `xyz:UNITREE`) shows the venue tag next to the leverage tag, matching the Perps list.
- [ ] Watchlist rows still show the localized name / stock subtitle as plain secondary text under the symbol; stock open/closed tags unchanged.

[OK-60010]: https://onekeyhq.atlassian.net/browse/OK-60010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-60691]: https://onekeyhq.atlassian.net/browse/OK-60691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ