### PR TITLE
fix: support iOS Fabric WebView navigation

### DIFF
--- a/patches/react-native-webview+13.15.0.patch
+++ b/patches/react-native-webview+13.15.0.patch
@@ -342,6 +342,48 @@ index 44d3378..8e0cc1f 100644
      @Override
      protected void addEventEmitters(@NonNull ThemedReactContext reactContext, RNCWebViewWrapper viewWrapper) {
          // Do not register default touch emitter and let WebView implementation handle touches
+diff --git a/node_modules/react-native-webview/apple/RNCWebView.mm b/node_modules/react-native-webview/apple/RNCWebView.mm
+index 95c0fcc..39c353d 100644
+--- a/node_modules/react-native-webview/apple/RNCWebView.mm
++++ b/node_modules/react-native-webview/apple/RNCWebView.mm
+@@ -45,6 +45,7 @@ @interface RNCWebView () <RCTRNCWebViewViewProtocol>
+ 
+ @implementation RNCWebView {
+     RNCWebViewImpl * _view;
++    NSDictionary * _sourceFromProps;
+ }
+ 
+ + (ComponentDescriptorProvider)componentDescriptorProvider
+@@ -56,6 +57,7 @@ + (ComponentDescriptorProvider)componentDescriptorProvider
+ // Reproduce the idea from here: https://github.com/facebook/react-native/blob/8bd3edec88148d0ab1f225d2119435681fbbba33/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm#L142
+ - (void)prepareForRecycle {
+     [super prepareForRecycle];
++    _sourceFromProps = nil;
+     [_view destroyWebView];
+ }
+ #endif // !TARGET_OS_OSX
+@@ -492,7 +494,11 @@ - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &
+     if (!newViewProps.newSource.method.empty()) {
+         [source setValue:RCTNSStringFromString(newViewProps.newSource.method) forKey:@"method"];
+     }
+-    [_view setSource:source];
++    // Keep imperative navigation from being reset by unrelated prop updates.
++    if (![_sourceFromProps isEqualToDictionary:source]) {
++        _sourceFromProps = [source copy];
++        [_view setSource:source];
++    }
+ 
+     [super updateProps:props oldProps:oldProps];
+ }
+@@ -520,7 +526,7 @@ - (void)injectJavaScript:(nonnull NSString *)javascript {
+ }
+ 
+ - (void)loadUrl:(nonnull NSString *)url {
+-    // android only
++    [_view setSource:@{@"uri": url}];
+ }
+ 
+ - (void)postMessage:(nonnull NSString *)data {
 diff --git a/node_modules/react-native-webview/apple/RNCWebViewImpl.h b/node_modules/react-native-webview/apple/RNCWebViewImpl.h
 index 1f6bbfd..e4c9cd7 100644
 --- a/node_modules/react-native-webview/apple/RNCWebViewImpl.h


### PR DESCRIPTION
## Summary
- Implement the `loadUrl` command for the iOS Fabric `react-native-webview` component.
- Track the last declarative `source` value so unrelated prop updates do not undo imperative navigation.
- Keep the stable WebView lifecycle introduced by #12305 without adding a JS remount or declarative URL fallback.

## Intent & Context
In the iOS DApp Browser, navigating the current tab from the address/search flow updated browser state and persisted the target URL, but the visible WebView stayed on the previous page. The issue is independent of the opened DApp.

The fix must address this single navigation failure while retaining the #12305 behavior that keeps the existing WebView instance alive in most scenarios.

## Root Cause
Current-tab navigation reaches `crossWebviewLoadUrl`, which dispatches the native WebView `loadUrl` command. Under the iOS New Architecture/Fabric implementation, `RNCWebView.mm` left this command as an `android only` no-op.

At the same time, #12305 intentionally stopped changing the declarative WebView source after initial creation to avoid recreating the WebView. Therefore, iOS had no declarative fallback when the imperative command was ignored.

## Design Decisions
- Fix the missing command in the existing `react-native-webview` native patch instead of changing the shared browser lifecycle.
- Forward `loadUrl` to `RNCWebViewImpl` through `setSource` on iOS Fabric.
- Store the last source received from React props and only forward it when that declarative value changes. This prevents an unrelated Fabric prop update from restoring the old prop source after an imperative navigation.
- Clear the stored prop source when the component view is recycled.

This keeps the #12305 WebView instance-preservation intent and avoids platform-wide JS behavior changes.

## Changes Detail
- `patches/react-native-webview+13.15.0.patch`: patch `apple/RNCWebView.mm` to implement Fabric `loadUrl`, guard declarative source synchronization, and reset the tracked source during recycling.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile (iOS Fabric only)
- **Risk Areas**: Coordination between imperative navigation and later declarative Fabric prop updates. Android native code, Desktop, Web, and Extension paths are unchanged.

## Test plan
- [x] Verified by the reporter on an iOS device using current-tab DApp navigation.
- [x] Ran `yarn jest packages/kit/src/states/jotai/contexts/discovery/actions.test.tsx packages/kit/src/components/WebView/NativeWebView.test.tsx --runInBand` (2 suites, 30 tests).
- [x] Compiled the `react-native-webview` iOS Pod with the New Architecture/Fabric code path.
- [x] Applied the complete patch to a pristine `react-native-webview@13.15.0` package and verified the resulting `RNCWebView.mm` byte-for-byte.
- [x] Ran `yarn agent:check --profile commit`.
