### PR TITLE
fix: filter unmatched perps results for short search queries (OK-60751)

### DIFF
--- a/packages/kit-bg/src/services/ServiceUniversalSearch.perpsAssetCapability.test.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.perpsAssetCapability.test.ts
@@ -130,6 +130,8 @@ describe('ServiceUniversalSearch perps asset capability', () => {
     // An exact dex prefix browses that sub-dex, a fragment of one does not.
     ['xyz', ['AMAT', 'EWJ']],
     ['ar', []],
+    // Only the row's description carries this one.
+    ['etf', ['EWJ']],
     // Longer and non-ASCII queries stay on the endpoint's own ranking.
     ['japan', ['BTC', 'AMAT', 'EWJ', 'UNITREE']],
     ['比特币', ['BTC', 'AMAT', 'EWJ', 'UNITREE']],

--- a/packages/kit-bg/src/services/ServiceUniversalSearch.perpsAssetCapability.test.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.perpsAssetCapability.test.ts
@@ -19,38 +19,6 @@ jest.mock('./ServiceBase', () => ({
 // eslint-disable-next-line import/first
 import ServiceUniversalSearch from './ServiceUniversalSearch';
 
-function buildService(assets: any[]) {
-  const client = {
-    get: jest.fn().mockResolvedValue({ data: { data: assets } }),
-  };
-  const backgroundApi = {
-    simpleDb: {
-      perp: {
-        getTradingUniverse: jest.fn().mockResolvedValue({
-          universesByDex: [
-            [{ name: 'BTC', maxLeverage: 40 }],
-            [
-              { name: 'xyz:AMAT', maxLeverage: 10 },
-              { name: 'xyz:EWJ', maxLeverage: 10 },
-            ],
-            [{ name: 'para:UNITREE', maxLeverage: 5 }],
-          ],
-          updatedAt: Date.now(),
-        }),
-      },
-    },
-    serviceHyperliquid: {
-      refreshTradingMeta: jest.fn(),
-    },
-  };
-  const Ctor = ServiceUniversalSearch as unknown as new (args: {
-    backgroundApi: unknown;
-  }) => ServiceUniversalSearch;
-  const service = new Ctor({ backgroundApi });
-  (service as any).getClient = jest.fn().mockResolvedValue(client);
-  return { service, client };
-}
-
 describe('ServiceUniversalSearch perps asset capability', () => {
   test('requests the dex-aware asset type contract', async () => {
     const client = {
@@ -112,75 +80,66 @@ describe('ServiceUniversalSearch perps asset capability', () => {
       }),
     ]);
   });
+  // Rows the endpoint returns for `usdc` because they are USDC settled, not
+  // because the query matches anything the row displays.
+  const searchAssets = [
+    { type: 'perps', name: 'BTC', subtitle: 'Bitcoin' },
+    { type: 'xyz', name: 'AMAT', subtitle: 'Applied Materials' },
+    { type: 'xyz', name: 'EWJ', subtitle: 'Japan ETF' },
+    { type: 'para', name: 'UNITREE', subtitle: 'Unitree' },
+  ].map((asset) => ({
+    ...asset,
+    logoUrl: 'https://example.com/logo.png',
+    maxLeverage: null,
+    midPx: '1',
+    dayNtlVlm: null,
+  }));
 
-  test('drops rows a short query does not literally match', async () => {
-    const { service } = buildService([
-      {
-        type: 'xyz',
-        logoUrl: 'https://example.com/xyzAMAT.png',
-        name: 'AMAT',
-        maxLeverage: null,
-        midPx: '491',
-        dayNtlVlm: null,
-        subtitle: 'Applied Materials',
+  function buildSearchService() {
+    const backgroundApi = {
+      simpleDb: {
+        perp: {
+          getTradingUniverse: jest.fn().mockResolvedValue({
+            universesByDex: [
+              [{ name: 'BTC', maxLeverage: 40 }],
+              [
+                { name: 'xyz:AMAT', maxLeverage: 10 },
+                { name: 'xyz:EWJ', maxLeverage: 10 },
+              ],
+              [{ name: 'para:UNITREE', maxLeverage: 5 }],
+            ],
+            updatedAt: Date.now(),
+          }),
+        },
       },
-      {
-        type: 'perps',
-        logoUrl: 'https://example.com/BTC.png',
-        name: 'BTC',
-        maxLeverage: 40,
-        midPx: '90000',
-        dayNtlVlm: '1',
-        subtitle: 'Bitcoin',
-      },
-    ]);
+      serviceHyperliquid: { refreshTradingMeta: jest.fn() },
+    };
+    const Ctor = ServiceUniversalSearch as unknown as new (args: {
+      backgroundApi: unknown;
+    }) => ServiceUniversalSearch;
+    const service = new Ctor({ backgroundApi });
+    (service as any).getClient = jest.fn().mockResolvedValue({
+      get: jest.fn().mockResolvedValue({ data: { data: searchAssets } }),
+    });
+    return service;
+  }
 
-    const result = await service.universalSearchOfPerp({ input: 'usdc' });
+  test.each<[string, string[]]>([
+    ['usdc', []],
+    ['btc', ['BTC']],
+    // An exact dex prefix browses that sub-dex, a fragment of one does not.
+    ['xyz', ['AMAT', 'EWJ']],
+    ['ar', []],
+    // Longer and non-ASCII queries stay on the endpoint's own ranking.
+    ['japan', ['BTC', 'AMAT', 'EWJ', 'UNITREE']],
+    ['比特币', ['BTC', 'AMAT', 'EWJ', 'UNITREE']],
+  ])('keeps the rows a %p query can match', async (input, expected) => {
+    const service = buildSearchService();
 
-    expect(result.items).toEqual([]);
-  });
+    const result = await service.universalSearchOfPerp({ input });
 
-  test('keeps a dex prefix match for a short query', async () => {
-    const { service } = buildService([
-      {
-        type: 'xyz',
-        logoUrl: 'https://example.com/xyzAMAT.png',
-        name: 'AMAT',
-        maxLeverage: null,
-        midPx: '491',
-        dayNtlVlm: null,
-        subtitle: 'Applied Materials',
-      },
-    ]);
-
-    const result = await service.universalSearchOfPerp({ input: 'xyz' });
-
-    expect(result.items).toEqual([
-      expect.objectContaining({
-        payload: expect.objectContaining({ name: 'AMAT', maxLeverage: 10 }),
-      }),
-    ]);
-  });
-
-  test('keeps description matches for a longer query', async () => {
-    const { service } = buildService([
-      {
-        type: 'xyz',
-        logoUrl: 'https://example.com/xyzEWJ.png',
-        name: 'EWJ',
-        maxLeverage: null,
-        midPx: '322',
-        dayNtlVlm: null,
-        subtitle: 'Japan ETF',
-      },
-    ]);
-
-    const result = await service.universalSearchOfPerp({ input: 'japan' });
-
-    expect(result.items).toEqual([
-      expect.objectContaining({
-        payload: expect.objectContaining({ name: 'EWJ' }),
-      }),
-    ]);
+    expect(
+      result.items.map((item) => (item.payload as { name: string }).name),
+    ).toEqual(expected);
   });
 });

--- a/packages/kit-bg/src/services/ServiceUniversalSearch.perpsAssetCapability.test.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.perpsAssetCapability.test.ts
@@ -19,6 +19,38 @@ jest.mock('./ServiceBase', () => ({
 // eslint-disable-next-line import/first
 import ServiceUniversalSearch from './ServiceUniversalSearch';
 
+function buildService(assets: any[]) {
+  const client = {
+    get: jest.fn().mockResolvedValue({ data: { data: assets } }),
+  };
+  const backgroundApi = {
+    simpleDb: {
+      perp: {
+        getTradingUniverse: jest.fn().mockResolvedValue({
+          universesByDex: [
+            [{ name: 'BTC', maxLeverage: 40 }],
+            [
+              { name: 'xyz:AMAT', maxLeverage: 10 },
+              { name: 'xyz:EWJ', maxLeverage: 10 },
+            ],
+            [{ name: 'para:UNITREE', maxLeverage: 5 }],
+          ],
+          updatedAt: Date.now(),
+        }),
+      },
+    },
+    serviceHyperliquid: {
+      refreshTradingMeta: jest.fn(),
+    },
+  };
+  const Ctor = ServiceUniversalSearch as unknown as new (args: {
+    backgroundApi: unknown;
+  }) => ServiceUniversalSearch;
+  const service = new Ctor({ backgroundApi });
+  (service as any).getClient = jest.fn().mockResolvedValue(client);
+  return { service, client };
+}
+
 describe('ServiceUniversalSearch perps asset capability', () => {
   test('requests the dex-aware asset type contract', async () => {
     const client = {
@@ -77,6 +109,77 @@ describe('ServiceUniversalSearch perps asset capability', () => {
           assetType: 'para',
           name: 'UNITREE',
         }),
+      }),
+    ]);
+  });
+
+  test('drops rows a short query does not literally match', async () => {
+    const { service } = buildService([
+      {
+        type: 'xyz',
+        logoUrl: 'https://example.com/xyzAMAT.png',
+        name: 'AMAT',
+        maxLeverage: null,
+        midPx: '491',
+        dayNtlVlm: null,
+        subtitle: 'Applied Materials',
+      },
+      {
+        type: 'perps',
+        logoUrl: 'https://example.com/BTC.png',
+        name: 'BTC',
+        maxLeverage: 40,
+        midPx: '90000',
+        dayNtlVlm: '1',
+        subtitle: 'Bitcoin',
+      },
+    ]);
+
+    const result = await service.universalSearchOfPerp({ input: 'usdc' });
+
+    expect(result.items).toEqual([]);
+  });
+
+  test('keeps a dex prefix match for a short query', async () => {
+    const { service } = buildService([
+      {
+        type: 'xyz',
+        logoUrl: 'https://example.com/xyzAMAT.png',
+        name: 'AMAT',
+        maxLeverage: null,
+        midPx: '491',
+        dayNtlVlm: null,
+        subtitle: 'Applied Materials',
+      },
+    ]);
+
+    const result = await service.universalSearchOfPerp({ input: 'xyz' });
+
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        payload: expect.objectContaining({ name: 'AMAT', maxLeverage: 10 }),
+      }),
+    ]);
+  });
+
+  test('keeps description matches for a longer query', async () => {
+    const { service } = buildService([
+      {
+        type: 'xyz',
+        logoUrl: 'https://example.com/xyzEWJ.png',
+        name: 'EWJ',
+        maxLeverage: null,
+        midPx: '322',
+        dayNtlVlm: null,
+        subtitle: 'Japan ETF',
+      },
+    ]);
+
+    const result = await service.universalSearchOfPerp({ input: 'japan' });
+
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        payload: expect.objectContaining({ name: 'EWJ' }),
       }),
     ]);
   });

--- a/packages/kit-bg/src/services/ServiceUniversalSearch.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.ts
@@ -56,6 +56,11 @@ const PERPS_UNIVERSE_SEARCH_MAX_AGE_MS = timerUtils.getTimeDurationMs({
   minute: 5,
 });
 const PERPS_ASSET_TYPE_VERSION = 2;
+// The search index also matches collateral and description text, so `usdc`
+// pulls in every USDC settled market. Only short, ticker shaped queries are
+// held to a literal match; a longer query is where description hits such as
+// `nasdaq` or `japan` are the point.
+const PERPS_SEARCH_LITERAL_MATCH_MAX_QUERY_LENGTH = 4;
 
 @backgroundClass()
 class ServiceUniversalSearch extends ServiceBase {
@@ -1292,41 +1297,51 @@ class ServiceUniversalSearch extends ServiceBase {
             ? await this.readTradablePerpMaxLeverageMap()
             : cachedPerpMaxLeverage;
 
+        const normalizedQuery = input.trim().toLowerCase();
+        const requiresLiteralMatch =
+          normalizedQuery.length > 0 &&
+          normalizedQuery.length <= PERPS_SEARCH_LITERAL_MATCH_MAX_QUERY_LENGTH;
+
         const items: IUniversalSearchPerpResult['items'] =
           rawAssets
-            ?.filter((asset) => {
+            ?.map((asset) => ({
+              asset,
+              coin: buildCoinFromSearchAssetType({
+                assetType: asset.type,
+                name: asset.name,
+              }),
+            }))
+            .filter(({ asset, coin }) => {
+              if (
+                requiresLiteralMatch &&
+                ![asset.name, asset.subtitle, coin].some((field) =>
+                  field?.toLowerCase().includes(normalizedQuery),
+                )
+              ) {
+                return false;
+              }
               // The search index still carries delisted assets — `xyz:UNITREE`
               // survives there after moving to `para`, so the same ticker would
               // appear twice with one dead row.
               if (!tradablePerpMaxLeverage) {
                 return true;
               }
-              const coin = buildCoinFromSearchAssetType({
-                assetType: asset.type,
-                name: asset.name,
-              });
               return Boolean(coin && tradablePerpMaxLeverage.has(coin));
             })
-            .map((asset) => {
-              const coin = buildCoinFromSearchAssetType({
+            .map(({ asset, coin }) => ({
+              type: EUniversalSearchType.Perp,
+              payload: {
                 assetType: asset.type,
+                logoUrl: asset.logoUrl,
                 name: asset.name,
-              });
-              return {
-                type: EUniversalSearchType.Perp,
-                payload: {
-                  assetType: asset.type,
-                  logoUrl: asset.logoUrl,
-                  name: asset.name,
-                  maxLeverage:
-                    (coin ? tradablePerpMaxLeverage?.get(coin) : undefined) ??
-                    asset.maxLeverage,
-                  midPx: asset.midPx,
-                  dayNtlVlm: asset.dayNtlVlm,
-                  subtitle: asset.subtitle,
-                },
-              };
-            }) ?? [];
+                maxLeverage:
+                  (coin ? tradablePerpMaxLeverage?.get(coin) : undefined) ??
+                  asset.maxLeverage,
+                midPx: asset.midPx,
+                dayNtlVlm: asset.dayNtlVlm,
+                subtitle: asset.subtitle,
+              },
+            })) ?? [];
 
         return { items };
       } catch (error) {

--- a/packages/kit-bg/src/services/ServiceUniversalSearch.ts
+++ b/packages/kit-bg/src/services/ServiceUniversalSearch.ts
@@ -56,10 +56,10 @@ const PERPS_UNIVERSE_SEARCH_MAX_AGE_MS = timerUtils.getTimeDurationMs({
   minute: 5,
 });
 const PERPS_ASSET_TYPE_VERSION = 2;
-// The search index also matches collateral and description text, so `usdc`
-// pulls in every USDC settled market. Only short, ticker shaped queries are
-// held to a literal match; a longer query is where description hits such as
-// `nasdaq` or `japan` are the point.
+// The search index also matches collateral text, so `usdc` returns every
+// USDC settled market. Only short ASCII tickers are held to a literal match:
+// a longer query is where the index's description hits such as `nasdaq` are
+// the point, and a non-ASCII one is where its localized aliases are.
 const PERPS_SEARCH_LITERAL_MATCH_MAX_QUERY_LENGTH = 4;
 
 @backgroundClass()
@@ -1299,22 +1299,19 @@ class ServiceUniversalSearch extends ServiceBase {
 
         const normalizedQuery = input.trim().toLowerCase();
         const requiresLiteralMatch =
-          normalizedQuery.length > 0 &&
+          /^[a-z0-9]+$/.test(normalizedQuery) &&
           normalizedQuery.length <= PERPS_SEARCH_LITERAL_MATCH_MAX_QUERY_LENGTH;
 
         const items: IUniversalSearchPerpResult['items'] =
           rawAssets
-            ?.map((asset) => ({
-              asset,
-              coin: buildCoinFromSearchAssetType({
-                assetType: asset.type,
-                name: asset.name,
-              }),
-            }))
-            .filter(({ asset, coin }) => {
+            ?.filter((asset) => {
+              // `asset.type` is the dex prefix, so matching it exactly keeps
+              // `xyz` browsing that sub-dex without a fragment such as `ar`
+              // waving through every `para` row.
               if (
                 requiresLiteralMatch &&
-                ![asset.name, asset.subtitle, coin].some((field) =>
+                asset.type?.toLowerCase() !== normalizedQuery &&
+                ![asset.name, asset.subtitle].some((field) =>
                   field?.toLowerCase().includes(normalizedQuery),
                 )
               ) {
@@ -1326,22 +1323,32 @@ class ServiceUniversalSearch extends ServiceBase {
               if (!tradablePerpMaxLeverage) {
                 return true;
               }
+              const coin = buildCoinFromSearchAssetType({
+                assetType: asset.type,
+                name: asset.name,
+              });
               return Boolean(coin && tradablePerpMaxLeverage.has(coin));
             })
-            .map(({ asset, coin }) => ({
-              type: EUniversalSearchType.Perp,
-              payload: {
+            .map((asset) => {
+              const coin = buildCoinFromSearchAssetType({
                 assetType: asset.type,
-                logoUrl: asset.logoUrl,
                 name: asset.name,
-                maxLeverage:
-                  (coin ? tradablePerpMaxLeverage?.get(coin) : undefined) ??
-                  asset.maxLeverage,
-                midPx: asset.midPx,
-                dayNtlVlm: asset.dayNtlVlm,
-                subtitle: asset.subtitle,
-              },
-            })) ?? [];
+              });
+              return {
+                type: EUniversalSearchType.Perp,
+                payload: {
+                  assetType: asset.type,
+                  logoUrl: asset.logoUrl,
+                  name: asset.name,
+                  maxLeverage:
+                    (coin ? tradablePerpMaxLeverage?.get(coin) : undefined) ??
+                    asset.maxLeverage,
+                  midPx: asset.midPx,
+                  dayNtlVlm: asset.dayNtlVlm,
+                  subtitle: asset.subtitle,
+                },
+              };
+            }) ?? [];
 
         return { items };
       } catch (error) {


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60751](https://onekeyhq.atlassian.net/browse/OK-60751)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary

- Hold a short ASCII perps search query to a literal match on `name`, `subtitle` or an exact dex prefix, so `usdc` no longer lists 56 unrelated markets.
- Leave longer and non-ASCII queries to the endpoint's own ranking, so description hits (`nasdaq`, `bitcoin`) and localized aliases keep working.
- Additive change: 22 added lines in the service, nothing removed or restructured.

## Intent & Context

QA reported (OK-60751) that searching `usdc` in universal search fills the Perps section with markets that have nothing to do with the query — `CASHCAT`, `GRAM`, `AMAT`, `ARM`, `ASML` and so on — where the expected result is an empty Perps section.

The first suspicion was a regression from the HIP-3 work in 18e310d9 (OK-59307), which added `assetTypeVersion: 2` to this request. That turned out not to be the cause, so this PR adds an app side guard instead of reverting anything.

## Root Cause

Server side. `/wallet/v1/proxy/hyperliquid/perpsAsset` matches the query as a substring of the asset's collateral / description text, not only against the ticker or display name:

```
query=usdc&assetTypeVersion=2  -> 56 rows (perps 2 + xyz 38 + para 16)
query=usdc&assetTypeVersion=1  -> 40 rows (perps 2 + xyz 38)
query=usdc (no version param)  -> 40 rows
```

So the noise predates `assetTypeVersion: 2`; that param only widened the result set with the 16 `para` rows. Probing the endpoint confirms the substring behaviour, because every substring of `USDC` returns the same set while non substrings return nothing:

```
usdc -> 56    usd -> 56    sd -> 56    dc -> 57
usc  -> 0     udc -> 0
nasdaq -> 12 stocks    stock -> 24    shares -> 13
```

The app simply rendered what the endpoint returned: `universalSearchOfPerp` only filtered *out* delisted assets, and the UI does no relevance filtering of its own.

## Design Decisions

- **Substring match, not fuzzy scoring.** The endpoint already ranks results; the client only needs to reject rows that do not contain the query at all. A scorer would be more code and a second, competing notion of relevance.
- **Match `name` and `subtitle` by substring, the dex by exact `asset.type`.** Matching against the dex prefixed coin (`xyz:AMAT`) instead would let a fragment such as `ar`, `pa` or `xy` wave through every row of that sub-dex — the exact noise this PR removes, on the most common short queries. An exact `asset.type` comparison still lets `xyz` or `para` browse a sub-dex, and removes the need for the resolved coin in the predicate.
- **Only enforce it for ASCII queries of 4 characters or fewer.** Description search is a deliberate server feature and is valuable for longer queries: replaying live responses through an always-on literal filter would have dropped every result for `nasdaq` (12), `stock` (24) and `shares` (13), plus semantic hits such as `japan` -> `KIOXIA` / `SOFTBANK`. The ASCII guard matters because the endpoint also answers localized aliases — on wallet.onekeytest.com the Chinese word for bitcoin returns BTC, the Chinese word for Japan returns EWJ, the Chinese word for ethereum returns ETH — and those queries are 2–3 characters, so a length-only gate would have dropped all of them. Nothing in the client restricts the charset: the UI only trims the input and `universalSearch` passes it through verbatim.
- **Fix stays in the app.** The endpoint's relevance should still be fixed server side; this is a client side guard so 6.5.0 does not ship the broken list.

## Changes Detail

- `packages/kit-bg/src/services/ServiceUniversalSearch.ts` — add `PERPS_SEARCH_LITERAL_MATCH_MAX_QUERY_LENGTH` and an early `return false` inside the existing filter in `universalSearchOfPerpCached`. No existing line changed.
- `packages/kit-bg/src/services/ServiceUniversalSearch.perpsAssetCapability.test.ts` — one fixture plus a table of cases: `usdc` drops everything, `btc` keeps its own row, `xyz` browses the sub-dex, `ar` does not, and `japan` / a Chinese alias stay on the endpoint's ranking.

## Trade-offs

Short queries now lose a few genuinely semantic hits, for example `btc` -> `IREN` (a bitcoin miner) and `eth` -> `CRDO`. That was judged an acceptable price for removing the `usdc` / `usd` / `ai` / `sol` noise.

Replaying live endpoint responses through the final filter:

```
usdc     56 -> 0     usd    56 -> 0     sol     5 -> 2 (drops Bloom Energy / Nokia / Quantinuum)
ai       30 -> 11    eth     5 -> 4     btc     3 -> 2     ar     57 -> 16
xyz      46 -> 44    para   17 -> 16    nasdaq 12 -> 12    japan   4 -> 4
bitcoin   6 -> 6     unitree 2 -> 2     CJK bitcoin 5 -> 5  CJK japan 2 -> 2
```

## Risk Assessment

- **Risk Level**: Low
- **Affected Platforms**: Extension / Mobile / Desktop / Web (background runtime, all platforms)
- **Runtime scope**: bg runtime only — `ServiceUniversalSearch` runs in background and the filtered list is serialized to main; no shared native resource or persisted state is touched.
- **Risk Areas**: The 4 character threshold. A short ticker whose row carries no matching text in `name` / `subtitle` and no matching dex would be dropped; every ticker checked against live data (`btc`, `eth`, `sol`, `xrp`, `ada`, `bnb`, `sui`, `apt`, `arb`, `ena`, `ldo`, `trx`, `ton`, `nvda`, `tsla`, `aapl`, `amd`, `goog`, `meta`, `gold`) keeps its own row. Nothing outside perps search is touched.

## Test plan

- [ ] Universal search `usdc` — Perps section shows no results
- [ ] Universal search `usd` and `sd` — Perps section shows no results
- [ ] Universal search `btc`, `eth`, `sol`, `nvda`, `gold` — the matching market is still listed first
- [ ] Universal search `ar` — only markets whose ticker or name carries `ar`, no unrelated `para` rows
- [ ] Universal search `xyz` and `para` — sub-dex markets are still listed
- [ ] Universal search `nasdaq`, `japan`, `bitcoin`, `unitree` — description matches are unchanged
- [ ] Universal search with a Chinese alias (bitcoin / Japan) — results are unchanged
- [ ] Tap a perps result — it still opens the correct market, including sub-dex ones (`xyz:` / `para:`)
- [x] `yarn jest packages/kit-bg/src/services/ServiceUniversalSearch.perpsAssetCapability.test.ts` — 7 passed
- [x] `yarn agent:check --profile commit` — pass

[OK-60751]: https://onekeyhq.atlassian.net/browse/OK-60751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ