### PR TITLE
feat: add remote inscription protection control(OK-60768)

### DIFF
--- a/packages/kit-bg/src/apis/backgroundApiPermissions.test.ts
+++ b/packages/kit-bg/src/apis/backgroundApiPermissions.test.ts
@@ -9,6 +9,14 @@ describe('backgroundApiPermissions', () => {
     ).toBe(false);
   });
 
+  it('blocks UI writes to the inscription protection control', () => {
+    expect(
+      isBackgroundApiAtomWritable(
+        EAtomNames.inscriptionProtectionControlPersistAtom,
+      ),
+    ).toBe(false);
+  });
+
   it('keeps regular cross-runtime atoms writable', () => {
     expect(isBackgroundApiAtomWritable(EAtomNames.settingsPersistAtom)).toBe(
       true,

--- a/packages/kit-bg/src/apis/backgroundApiPermissions.ts
+++ b/packages/kit-bg/src/apis/backgroundApiPermissions.ts
@@ -13,6 +13,7 @@ import type {
 // These values are authoritative in bg and must never accept the generic
 // UI-to-bg Jotai synchronization write path.
 const BACKGROUND_OWNED_ATOM_NAMES = new Set<EAtomNames>([
+  EAtomNames.inscriptionProtectionControlPersistAtom,
   EAtomNames.perpsUnifoldActiveRecipientAtom,
 ]);
 

--- a/packages/kit-bg/src/services/ServiceBootstrap.ts
+++ b/packages/kit-bg/src/services/ServiceBootstrap.ts
@@ -133,6 +133,9 @@ class ServiceBootstrap extends ServiceBase {
         timedDeferred('serviceSetting.fetchReviewControl', () =>
           this.backgroundApi.serviceSetting.fetchReviewControl(),
         ),
+        timedDeferred('serviceSetting.fetchInscriptionProtectionControl', () =>
+          this.backgroundApi.serviceSetting.fetchInscriptionProtectionControl(),
+        ),
         timedDeferred(
           'servicePassword.addExtIntervalCheckLockStatusListener',
           () =>

--- a/packages/kit-bg/src/services/ServiceSetting.inscriptionProtection.test.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.inscriptionProtection.test.ts
@@ -1,0 +1,211 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return */
+
+const mockSettingsPersistAtom = {
+  get: jest.fn(),
+  set: jest.fn(),
+};
+
+jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
+  backgroundClass: () => (target: unknown) => target,
+  backgroundMethod:
+    () =>
+    (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+  backgroundMethodForDev:
+    () =>
+    (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+  toastIfError:
+    () =>
+    (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) =>
+      descriptor,
+}));
+
+jest.mock('@onekeyhq/shared/src/logger/logger', () => {
+  function createLoggerProxy(): any {
+    return new Proxy(jest.fn(), {
+      get: () => createLoggerProxy(),
+    });
+  }
+  return { defaultLogger: createLoggerProxy() };
+});
+
+jest.mock('../states/jotai/atoms/prime', () => ({
+  primePersistAtom: { get: jest.fn() },
+}));
+
+jest.mock('../states/jotai/atoms/settings', () => ({
+  settingsPersistAtom: mockSettingsPersistAtom,
+  settingsFiatPaySiteWhitelistPersistAtom: {},
+  settingsLastActivityAtom: {},
+}));
+
+jest.mock('../states/jotai/atoms', () => ({
+  currencyPersistAtom: {},
+  desktopBluetoothAtom: {},
+}));
+
+jest.mock('../states/jotai/atoms/devSettings', () => ({
+  devSettingsPersistAtom: { get: jest.fn(), set: jest.fn() },
+}));
+
+jest.mock('@onekeyhq/shared/src/appApiClient/appApiClient', () => ({
+  appApiClient: {
+    getClient: jest.fn(),
+    getRawDataClient: jest.fn(),
+  },
+}));
+
+jest.mock('../endpoints', () => ({
+  getEndpointInfo: jest.fn(),
+}));
+
+const ServiceSetting = require('./ServiceSetting')
+  .default as typeof import('./ServiceSetting').default;
+
+function createService({
+  inscriptionProtection = true,
+  inscriptionProtectionServerEnabled,
+}: {
+  inscriptionProtection?: boolean;
+  inscriptionProtectionServerEnabled?: boolean;
+} = {}) {
+  let settingsState: {
+    inscriptionProtection: boolean;
+    inscriptionProtectionServerEnabled?: boolean;
+  } = {
+    inscriptionProtection,
+    ...(inscriptionProtectionServerEnabled === undefined
+      ? {}
+      : { inscriptionProtectionServerEnabled }),
+  };
+  const get = jest.fn();
+  const service = new ServiceSetting({
+    backgroundApi: {
+      simpleDb: { appStatus: {} },
+      serviceAccount: { getAccount: jest.fn() },
+    },
+  });
+
+  mockSettingsPersistAtom.get.mockImplementation(async () => settingsState);
+  mockSettingsPersistAtom.set.mockImplementation(
+    async (builder: (value: typeof settingsState) => typeof settingsState) => {
+      settingsState = builder(settingsState);
+      return settingsState;
+    },
+  );
+  jest.spyOn(service, 'getClient').mockResolvedValue({ get } as never);
+
+  return {
+    get,
+    getSettingsState: () => settingsState,
+    service,
+  };
+}
+
+describe('ServiceSetting inscription protection control', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('persists the server value without overwriting the user preference', async () => {
+    const { get, getSettingsState, service } = createService({
+      inscriptionProtection: true,
+      inscriptionProtectionServerEnabled: true,
+    });
+    get.mockResolvedValue({
+      data: {
+        data: [
+          {
+            key: 'BTC_INSCRIPTION_PROTECTION_ENABLED',
+            value: '{"value":false}',
+          },
+        ],
+      },
+    });
+
+    await service.fetchInscriptionProtectionControl();
+
+    expect(get).toHaveBeenCalledWith('/utility/v1/setting', {
+      params: { key: 'BTC_INSCRIPTION_PROTECTION_ENABLED' },
+    });
+    expect(getSettingsState()).toEqual({
+      inscriptionProtection: true,
+      inscriptionProtectionServerEnabled: false,
+    });
+  });
+
+  it.each([
+    ['a missing key', []],
+    [
+      'an invalid JSON value',
+      [
+        {
+          key: 'BTC_INSCRIPTION_PROTECTION_ENABLED',
+          value: 'invalid',
+        },
+      ],
+    ],
+    [
+      'a non-boolean value',
+      [
+        {
+          key: 'BTC_INSCRIPTION_PROTECTION_ENABLED',
+          value: '{"value":"false"}',
+        },
+      ],
+    ],
+  ])('keeps the last valid value for %s', async (_label, data) => {
+    const { get, getSettingsState, service } = createService({
+      inscriptionProtectionServerEnabled: true,
+    });
+    get.mockResolvedValue({ data: { data } });
+
+    await service.fetchInscriptionProtectionControl();
+
+    expect(mockSettingsPersistAtom.set).not.toHaveBeenCalled();
+    expect(getSettingsState().inscriptionProtectionServerEnabled).toBe(true);
+  });
+
+  it('keeps the last valid value when the request fails', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const { get, getSettingsState, service } = createService({
+      inscriptionProtectionServerEnabled: false,
+    });
+    get.mockRejectedValue(new Error('network error'));
+
+    await service.fetchInscriptionProtectionControl();
+
+    expect(mockSettingsPersistAtom.set).not.toHaveBeenCalled();
+    expect(getSettingsState().inscriptionProtectionServerEnabled).toBe(false);
+    consoleError.mockRestore();
+  });
+
+  it.each([
+    [true, true, true, true],
+    [true, false, true, false],
+    [false, true, true, false],
+    [true, true, false, false],
+    [true, undefined, true, true],
+  ])(
+    'combines local=%s server=%s eligible=%s into %s',
+    async (localEnabled, serverEnabled, eligible, expected) => {
+      const { service } = createService({
+        inscriptionProtection: localEnabled,
+        inscriptionProtectionServerEnabled: serverEnabled,
+      });
+      jest
+        .spyOn(service, 'checkInscriptionProtectionEnabled')
+        .mockResolvedValue(eligible);
+
+      await expect(
+        service.getEffectiveInscriptionProtection({
+          networkId: 'btc--0',
+          accountId: 'account-id',
+        }),
+      ).resolves.toBe(expected);
+    },
+  );
+});

--- a/packages/kit-bg/src/services/ServiceSetting.inscriptionProtection.test.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.inscriptionProtection.test.ts
@@ -243,6 +243,39 @@ describe('ServiceSetting inscription protection control', () => {
     expect(getControlState().enabled).toBe(false);
   });
 
+  it('bypasses a successful cached request when forced', async () => {
+    const { get, getControlState, service } = createService({
+      inscriptionProtectionServerEnabled: true,
+    });
+    get
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              key: 'BTC_INSCRIPTION_PROTECTION_ENABLED',
+              value: '{"value":false}',
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              key: 'BTC_INSCRIPTION_PROTECTION_ENABLED',
+              value: '{"value":true}',
+            },
+          ],
+        },
+      });
+
+    await service.fetchInscriptionProtectionControl();
+    await service.fetchInscriptionProtectionControl({ forceRefresh: true });
+
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(getControlState().enabled).toBe(true);
+  });
+
   it.each([
     [true, true, true, true],
     [true, false, true, false],

--- a/packages/kit-bg/src/services/ServiceSetting.inscriptionProtection.test.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.inscriptionProtection.test.ts
@@ -4,6 +4,10 @@ const mockSettingsPersistAtom = {
   get: jest.fn(),
   set: jest.fn(),
 };
+const mockInscriptionProtectionControlPersistAtom = {
+  get: jest.fn(),
+  set: jest.fn(),
+};
 
 jest.mock('@onekeyhq/shared/src/background/backgroundDecorators', () => ({
   backgroundClass: () => (target: unknown) => target,
@@ -35,6 +39,8 @@ jest.mock('../states/jotai/atoms/prime', () => ({
 }));
 
 jest.mock('../states/jotai/atoms/settings', () => ({
+  inscriptionProtectionControlPersistAtom:
+    mockInscriptionProtectionControlPersistAtom,
   settingsPersistAtom: mockSettingsPersistAtom,
   settingsFiatPaySiteWhitelistPersistAtom: {},
   settingsLastActivityAtom: {},
@@ -65,20 +71,15 @@ const ServiceSetting = require('./ServiceSetting')
 
 function createService({
   inscriptionProtection = true,
-  inscriptionProtectionServerEnabled,
+  inscriptionProtectionServerEnabled = true,
 }: {
   inscriptionProtection?: boolean;
   inscriptionProtectionServerEnabled?: boolean;
 } = {}) {
-  let settingsState: {
-    inscriptionProtection: boolean;
-    inscriptionProtectionServerEnabled?: boolean;
-  } = {
+  let settingsState: { inscriptionProtection: boolean } = {
     inscriptionProtection,
-    ...(inscriptionProtectionServerEnabled === undefined
-      ? {}
-      : { inscriptionProtectionServerEnabled }),
   };
+  let controlState = { enabled: inscriptionProtectionServerEnabled };
   const get = jest.fn();
   const service = new ServiceSetting({
     backgroundApi: {
@@ -94,10 +95,20 @@ function createService({
       return settingsState;
     },
   );
+  mockInscriptionProtectionControlPersistAtom.get.mockImplementation(
+    async () => controlState,
+  );
+  mockInscriptionProtectionControlPersistAtom.set.mockImplementation(
+    async (builder: (value: typeof controlState) => typeof controlState) => {
+      controlState = builder(controlState);
+      return controlState;
+    },
+  );
   jest.spyOn(service, 'getClient').mockResolvedValue({ get } as never);
 
   return {
     get,
+    getControlState: () => controlState,
     getSettingsState: () => settingsState,
     service,
   };
@@ -109,7 +120,7 @@ describe('ServiceSetting inscription protection control', () => {
   });
 
   it('persists the server value without overwriting the user preference', async () => {
-    const { get, getSettingsState, service } = createService({
+    const { get, getControlState, getSettingsState, service } = createService({
       inscriptionProtection: true,
       inscriptionProtectionServerEnabled: true,
     });
@@ -131,8 +142,33 @@ describe('ServiceSetting inscription protection control', () => {
     });
     expect(getSettingsState()).toEqual({
       inscriptionProtection: true,
-      inscriptionProtectionServerEnabled: false,
     });
+    expect(getControlState()).toEqual({ enabled: false });
+    expect(mockSettingsPersistAtom.set).not.toHaveBeenCalled();
+  });
+
+  it('keeps the control value isolated from UI settings snapshots', async () => {
+    const { get, getControlState, service } = createService({
+      inscriptionProtection: true,
+      inscriptionProtectionServerEnabled: true,
+    });
+    get.mockResolvedValue({
+      data: {
+        data: [
+          {
+            key: 'BTC_INSCRIPTION_PROTECTION_ENABLED',
+            value: '{"value":false}',
+          },
+        ],
+      },
+    });
+
+    await service.fetchInscriptionProtectionControl();
+    await mockSettingsPersistAtom.set(() => ({
+      inscriptionProtection: false,
+    }));
+
+    expect(getControlState()).toEqual({ enabled: false });
   });
 
   it.each([
@@ -156,31 +192,55 @@ describe('ServiceSetting inscription protection control', () => {
       ],
     ],
   ])('keeps the last valid value for %s', async (_label, data) => {
-    const { get, getSettingsState, service } = createService({
+    const { get, getControlState, service } = createService({
       inscriptionProtectionServerEnabled: true,
     });
     get.mockResolvedValue({ data: { data } });
 
     await service.fetchInscriptionProtectionControl();
 
-    expect(mockSettingsPersistAtom.set).not.toHaveBeenCalled();
-    expect(getSettingsState().inscriptionProtectionServerEnabled).toBe(true);
+    expect(
+      mockInscriptionProtectionControlPersistAtom.set,
+    ).not.toHaveBeenCalled();
+    expect(getControlState().enabled).toBe(true);
   });
 
   it('keeps the last valid value when the request fails', async () => {
-    const consoleError = jest
-      .spyOn(console, 'error')
-      .mockImplementation(() => undefined);
-    const { get, getSettingsState, service } = createService({
+    const { get, getControlState, service } = createService({
       inscriptionProtectionServerEnabled: false,
     });
     get.mockRejectedValue(new Error('network error'));
 
     await service.fetchInscriptionProtectionControl();
 
-    expect(mockSettingsPersistAtom.set).not.toHaveBeenCalled();
-    expect(getSettingsState().inscriptionProtectionServerEnabled).toBe(false);
-    consoleError.mockRestore();
+    expect(
+      mockInscriptionProtectionControlPersistAtom.set,
+    ).not.toHaveBeenCalled();
+    expect(getControlState().enabled).toBe(false);
+  });
+
+  it('retries immediately after a failed request', async () => {
+    const { get, getControlState, service } = createService({
+      inscriptionProtectionServerEnabled: true,
+    });
+    get
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce({
+        data: {
+          data: [
+            {
+              key: 'BTC_INSCRIPTION_PROTECTION_ENABLED',
+              value: '{"value":false}',
+            },
+          ],
+        },
+      });
+
+    await service.fetchInscriptionProtectionControl();
+    await service.fetchInscriptionProtectionControl();
+
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(getControlState().enabled).toBe(false);
   });
 
   it.each([
@@ -188,7 +248,6 @@ describe('ServiceSetting inscription protection control', () => {
     [true, false, true, false],
     [false, true, true, false],
     [true, true, false, false],
-    [true, undefined, true, true],
   ])(
     'combines local=%s server=%s eligible=%s into %s',
     async (localEnabled, serverEnabled, eligible, expected) => {

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -77,6 +77,7 @@ import {
 } from '../states/jotai/atoms';
 import { primePersistAtom } from '../states/jotai/atoms/prime';
 import {
+  inscriptionProtectionControlPersistAtom,
   settingsFiatPaySiteWhitelistPersistAtom,
   settingsLastActivityAtom,
   settingsPersistAtom,
@@ -521,31 +522,28 @@ class ServiceSetting extends ServiceBase {
 
   private _fetchInscriptionProtectionControl = memoizee(
     async () => {
-      try {
-        const client = await this.getClient(EServiceEndpointEnum.Utility);
-        const response = await client.get<{
-          data: { value: string; key: string }[];
-        }>('/utility/v1/setting', {
-          params: {
-            key: INSCRIPTION_PROTECTION_SETTING_KEY,
-          },
-        });
-        const matched = response.data.data.find(
-          (item) => item.key === INSCRIPTION_PROTECTION_SETTING_KEY,
+      const client = await this.getClient(EServiceEndpointEnum.Utility);
+      const response = await client.get<{
+        data: { value: string; key: string }[];
+      }>('/utility/v1/setting', {
+        params: {
+          key: INSCRIPTION_PROTECTION_SETTING_KEY,
+        },
+      });
+      const matched = response.data.data.find(
+        (item) => item.key === INSCRIPTION_PROTECTION_SETTING_KEY,
+      );
+      const serverEnabled = matched
+        ? parseInscriptionProtectionServerEnabled(matched.value)
+        : undefined;
+      if (serverEnabled === undefined) {
+        throw new OneKeyLocalError(
+          'Invalid inscription protection control response',
         );
-        const serverEnabled = matched
-          ? parseInscriptionProtectionServerEnabled(matched.value)
-          : undefined;
-        if (serverEnabled === undefined) {
-          return;
-        }
-        await settingsPersistAtom.set((prev) => ({
-          ...prev,
-          inscriptionProtectionServerEnabled: serverEnabled,
-        }));
-      } catch (e) {
-        console.error('fetchInscriptionProtectionControl error', e);
       }
+      await inscriptionProtectionControlPersistAtom.set(() => ({
+        enabled: serverEnabled,
+      }));
     },
     {
       promise: true,
@@ -555,7 +553,15 @@ class ServiceSetting extends ServiceBase {
 
   @backgroundMethod()
   public async fetchInscriptionProtectionControl() {
-    await this._fetchInscriptionProtectionControl();
+    try {
+      await this._fetchInscriptionProtectionControl();
+    } catch (error) {
+      void this._fetchInscriptionProtectionControl.clear();
+      defaultLogger.setting.page.consoleError(
+        'fetchInscriptionProtectionControl error',
+        error instanceof Error ? error.message : 'Unknown error',
+      );
+    }
   }
 
   private async syncFiatPaySiteWhitelistToRuntime(origins: string[]) {
@@ -657,6 +663,20 @@ class ServiceSetting extends ServiceBase {
   }
 
   @backgroundMethod()
+  public async setInscriptionProtection(enabled: boolean) {
+    await settingsPersistAtom.set((prev) => ({
+      ...prev,
+      inscriptionProtection: enabled,
+    }));
+  }
+
+  @backgroundMethod()
+  public async getInscriptionProtectionServerEnabled() {
+    const { enabled } = await inscriptionProtectionControlPersistAtom.get();
+    return enabled;
+  }
+
+  @backgroundMethod()
   public async getEffectiveInscriptionProtection({
     networkId,
     accountId,
@@ -666,19 +686,16 @@ class ServiceSetting extends ServiceBase {
     accountId: string;
     mergeDeriveAssetsEnabled?: boolean;
   }) {
-    const [settings, accountEligible] = await Promise.all([
+    const [settings, control, accountEligible] = await Promise.all([
       settingsPersistAtom.get(),
+      inscriptionProtectionControlPersistAtom.get(),
       this.checkInscriptionProtectionEnabled({
         networkId,
         accountId,
         mergeDeriveAssetsEnabled,
       }),
     ]);
-    return (
-      accountEligible &&
-      settings.inscriptionProtection &&
-      (settings.inscriptionProtectionServerEnabled ?? true)
-    );
+    return accountEligible && settings.inscriptionProtection && control.enabled;
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -97,6 +97,19 @@ export type IAccountDerivationConfigItem = {
   defaultNetworkId: string;
 };
 
+const INSCRIPTION_PROTECTION_SETTING_KEY = 'BTC_INSCRIPTION_PROTECTION_ENABLED';
+
+function parseInscriptionProtectionServerEnabled(
+  value: string,
+): boolean | undefined {
+  try {
+    const parsed = JSON.parse(value) as { value?: unknown };
+    return typeof parsed?.value === 'boolean' ? parsed.value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 @backgroundClass()
 class ServiceSetting extends ServiceBase {
   constructor({ backgroundApi }: { backgroundApi: any }) {
@@ -506,6 +519,45 @@ class ServiceSetting extends ServiceBase {
     }
   }
 
+  private _fetchInscriptionProtectionControl = memoizee(
+    async () => {
+      try {
+        const client = await this.getClient(EServiceEndpointEnum.Utility);
+        const response = await client.get<{
+          data: { value: string; key: string }[];
+        }>('/utility/v1/setting', {
+          params: {
+            key: INSCRIPTION_PROTECTION_SETTING_KEY,
+          },
+        });
+        const matched = response.data.data.find(
+          (item) => item.key === INSCRIPTION_PROTECTION_SETTING_KEY,
+        );
+        const serverEnabled = matched
+          ? parseInscriptionProtectionServerEnabled(matched.value)
+          : undefined;
+        if (serverEnabled === undefined) {
+          return;
+        }
+        await settingsPersistAtom.set((prev) => ({
+          ...prev,
+          inscriptionProtectionServerEnabled: serverEnabled,
+        }));
+      } catch (e) {
+        console.error('fetchInscriptionProtectionControl error', e);
+      }
+    },
+    {
+      promise: true,
+      maxAge: timerUtils.getTimeDurationMs({ minute: 5 }),
+    },
+  );
+
+  @backgroundMethod()
+  public async fetchInscriptionProtectionControl() {
+    await this._fetchInscriptionProtectionControl();
+  }
+
   private async syncFiatPaySiteWhitelistToRuntime(origins: string[]) {
     if (platformEnv.isDesktop) {
       void globalThis.desktopApiProxy?.webview.setFiatPaySiteWhitelist(origins);
@@ -602,6 +654,31 @@ class ServiceSetting extends ServiceBase {
   public async getInscriptionProtection() {
     const { inscriptionProtection } = await settingsPersistAtom.get();
     return inscriptionProtection;
+  }
+
+  @backgroundMethod()
+  public async getEffectiveInscriptionProtection({
+    networkId,
+    accountId,
+    mergeDeriveAssetsEnabled,
+  }: {
+    networkId: string;
+    accountId: string;
+    mergeDeriveAssetsEnabled?: boolean;
+  }) {
+    const [settings, accountEligible] = await Promise.all([
+      settingsPersistAtom.get(),
+      this.checkInscriptionProtectionEnabled({
+        networkId,
+        accountId,
+        mergeDeriveAssetsEnabled,
+      }),
+    ]);
+    return (
+      accountEligible &&
+      settings.inscriptionProtection &&
+      (settings.inscriptionProtectionServerEnabled ?? true)
+    );
   }
 
   @backgroundMethod()

--- a/packages/kit-bg/src/services/ServiceSetting.ts
+++ b/packages/kit-bg/src/services/ServiceSetting.ts
@@ -552,7 +552,14 @@ class ServiceSetting extends ServiceBase {
   );
 
   @backgroundMethod()
-  public async fetchInscriptionProtectionControl() {
+  public async fetchInscriptionProtectionControl({
+    forceRefresh,
+  }: {
+    forceRefresh?: boolean;
+  } = {}) {
+    if (forceRefresh) {
+      void this._fetchInscriptionProtectionControl.clear();
+    }
     try {
       await this._fetchInscriptionProtectionControl();
     } catch (error) {

--- a/packages/kit-bg/src/services/ServiceSwap.ts
+++ b/packages/kit-bg/src/services/ServiceSwap.ts
@@ -815,17 +815,13 @@ export default class ServiceSwap extends ServiceBase {
       }
 
       if (requestProtocol !== EProtocolOfExchange.STOCK) {
-        const inscriptionProtection =
-          await this.backgroundApi.serviceSetting.getInscriptionProtection();
-        const checkInscriptionProtectionEnabled =
-          await this.backgroundApi.serviceSetting.checkInscriptionProtectionEnabled(
+        const withCheckInscription =
+          await this.backgroundApi.serviceSetting.getEffectiveInscriptionProtection(
             {
               networkId,
               accountId,
             },
           );
-        const withCheckInscription =
-          checkInscriptionProtectionEnabled && inscriptionProtection;
         params.withCheckInscription = withCheckInscription;
       }
     }
@@ -1037,17 +1033,13 @@ export default class ServiceSwap extends ServiceBase {
         } catch (e) {
           console.error(e);
         }
-        const inscriptionProtection =
-          await this.backgroundApi.serviceSetting.getInscriptionProtection();
-        const checkInscriptionProtectionEnabled =
-          await this.backgroundApi.serviceSetting.checkInscriptionProtectionEnabled(
+        const withCheckInscription =
+          await this.backgroundApi.serviceSetting.getEffectiveInscriptionProtection(
             {
               networkId,
               accountId,
             },
           );
-        const withCheckInscription =
-          checkInscriptionProtectionEnabled && inscriptionProtection;
         params.withCheckInscription = withCheckInscription;
       }
       let fetchSignal: AbortSignal | undefined;

--- a/packages/kit-bg/src/states/jotai/atomNames.ts
+++ b/packages/kit-bg/src/states/jotai/atomNames.ts
@@ -5,6 +5,7 @@ export enum EAtomNames {
   demoPriceNotPersistAtom = 'demoPriceNotPersistAtom',
   // accountIdAtom = 'accountIdAtom',
   settingsPersistAtom = 'settingsPersistAtom',
+  inscriptionProtectionControlPersistAtom = 'inscriptionProtectionControlPersistAtom',
   settingsAtom = 'settingsAtom',
   devSettingsPersistAtom = 'devSettingsPersistAtom',
   currencyPersistAtom = 'currencyPersistAtom',

--- a/packages/kit-bg/src/states/jotai/atoms/settings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/settings.ts
@@ -46,7 +46,6 @@ export type ISettingsPersistAtom = {
   transferAllowList: boolean;
   spendDustUTXO: boolean;
   inscriptionProtection: boolean;
-  inscriptionProtectionServerEnabled?: boolean;
   isFirstTimeSwap: boolean;
   isPrivateSendGuideClicked?: boolean;
   swapBatchApproveAndSwap: boolean;
@@ -100,7 +99,6 @@ export const settingsAtomInitialValue: ISettingsPersistAtom = {
   transferAllowList: false,
   spendDustUTXO: false,
   inscriptionProtection: true,
-  inscriptionProtectionServerEnabled: true,
   isFirstTimeSwap: true,
   isPrivateSendGuideClicked: false,
   swapBatchApproveAndSwap: true,
@@ -130,6 +128,19 @@ export const { target: settingsPersistAtom, use: useSettingsPersistAtom } =
     persist: true,
     name: EAtomNames.settingsPersistAtom,
     initialValue: settingsAtomInitialValue,
+  });
+
+export type IInscriptionProtectionControlPersistAtom = {
+  enabled: boolean;
+};
+
+export const { target: inscriptionProtectionControlPersistAtom } =
+  globalAtom<IInscriptionProtectionControlPersistAtom>({
+    persist: true,
+    name: EAtomNames.inscriptionProtectionControlPersistAtom,
+    initialValue: {
+      enabled: true,
+    },
   });
 
 type ISettingsLastActivityPersistAtom = {

--- a/packages/kit-bg/src/states/jotai/atoms/settings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/settings.ts
@@ -46,6 +46,7 @@ export type ISettingsPersistAtom = {
   transferAllowList: boolean;
   spendDustUTXO: boolean;
   inscriptionProtection: boolean;
+  inscriptionProtectionServerEnabled?: boolean;
   isFirstTimeSwap: boolean;
   isPrivateSendGuideClicked?: boolean;
   swapBatchApproveAndSwap: boolean;
@@ -99,6 +100,7 @@ export const settingsAtomInitialValue: ISettingsPersistAtom = {
   transferAllowList: false,
   spendDustUTXO: false,
   inscriptionProtection: true,
+  inscriptionProtectionServerEnabled: true,
   isFirstTimeSwap: true,
   isPrivateSendGuideClicked: false,
   swapBatchApproveAndSwap: true,

--- a/packages/kit-bg/src/states/jotai/atoms/settings.ts
+++ b/packages/kit-bg/src/states/jotai/atoms/settings.ts
@@ -8,7 +8,7 @@ import { swapSlippageAutoValue } from '@onekeyhq/shared/types/swap/SwapProvider.
 import { ESwapSlippageSegmentKey } from '@onekeyhq/shared/types/swap/types';
 
 import { EAtomNames } from '../atomNames';
-import { globalAtom } from '../utils';
+import { globalAtom, globalAtomComputedR } from '../utils';
 
 export type IEndpointType = 'prod' | 'test';
 
@@ -141,6 +141,20 @@ export const { target: inscriptionProtectionControlPersistAtom } =
     initialValue: {
       enabled: true,
     },
+  });
+
+export type IInscriptionProtectionStateAtom = {
+  localEnabled: boolean;
+  serverEnabled: boolean;
+};
+
+export const { use: useInscriptionProtectionStateAtom } =
+  globalAtomComputedR<IInscriptionProtectionStateAtom>({
+    read: (get) => ({
+      localEnabled: get(settingsPersistAtom.atom()).inscriptionProtection,
+      serverEnabled: get(inscriptionProtectionControlPersistAtom.atom())
+        .enabled,
+    }),
   });
 
 type ISettingsLastActivityPersistAtom = {

--- a/packages/kit-bg/src/vaults/impls/btc/Vault.ts
+++ b/packages/kit-bg/src/vaults/impls/btc/Vault.ts
@@ -1343,17 +1343,13 @@ export default class VaultBtc extends VaultBase {
   );
 
   async _collectUTXOsInfoByApi() {
-    const inscriptionProtection =
-      await this.backgroundApi.serviceSetting.getInscriptionProtection();
-    const checkInscriptionProtectionEnabled =
-      await this.backgroundApi.serviceSetting.checkInscriptionProtectionEnabled(
+    const withCheckInscription =
+      await this.backgroundApi.serviceSetting.getEffectiveInscriptionProtection(
         {
           networkId: this.networkId,
           accountId: this.accountId,
         },
       );
-    const withCheckInscription =
-      checkInscriptionProtectionEnabled && inscriptionProtection;
     return this._collectUTXOsInfoByApiWithCache(withCheckInscription);
   }
 
@@ -1453,17 +1449,13 @@ export default class VaultBtc extends VaultBase {
   );
 
   async _collectClaimedUtxosInfo() {
-    const inscriptionProtection =
-      await this.backgroundApi.serviceSetting.getInscriptionProtection();
-    const checkInscriptionProtectionEnabled =
-      await this.backgroundApi.serviceSetting.checkInscriptionProtectionEnabled(
+    const withCheckInscription =
+      await this.backgroundApi.serviceSetting.getEffectiveInscriptionProtection(
         {
           networkId: this.networkId,
           accountId: this.accountId,
         },
       );
-    const withCheckInscription =
-      checkInscriptionProtectionEnabled && inscriptionProtection;
     return this._collectClaimedUtxosWithCache(withCheckInscription);
   }
 

--- a/packages/kit/src/provider/Container/StateActiveContainer/index.ios.tsx
+++ b/packages/kit/src/provider/Container/StateActiveContainer/index.ios.tsx
@@ -7,6 +7,7 @@ import backgroundApiProxy from '../../../background/instance/backgroundApiProxy'
 export const StateActiveContainer = () => {
   const callback = useCallback(() => {
     void backgroundApiProxy.serviceNotification.clearBadgeWhenAppStart();
+    void backgroundApiProxy.serviceSetting.fetchInscriptionProtectionControl();
   }, []);
   useHandleAppStateActive(callback, {
     onActiveFromBlur: callback,

--- a/packages/kit/src/provider/Container/StateActiveContainer/index.tsx
+++ b/packages/kit/src/provider/Container/StateActiveContainer/index.tsx
@@ -22,6 +22,7 @@ export const StateActiveContainer = () => {
   }, []);
   const callback = useCallback(() => {
     void backgroundApiProxy.serviceNotification.clearBadgeWhenAppStart();
+    void backgroundApiProxy.serviceSetting.fetchInscriptionProtectionControl();
   }, []);
   useHandleAppStateActive(callback, {
     onActiveFromBlur: callback,

--- a/packages/kit/src/provider/Container/StateActiveContainer/index.tsx
+++ b/packages/kit/src/provider/Container/StateActiveContainer/index.tsx
@@ -15,7 +15,12 @@ export const StateActiveContainer = () => {
     void (async () => {
       if (platformEnv.isExtension && !extSpecialChecked) {
         extSpecialChecked = true;
-        await backgroundApiProxy.servicePassword.checkLockStatus();
+        await Promise.all([
+          backgroundApiProxy.servicePassword.checkLockStatus(),
+          backgroundApiProxy.serviceSetting.fetchInscriptionProtectionControl({
+            forceRefresh: true,
+          }),
+        ]);
       }
       void backgroundApiProxy.serviceNotification.clearBadgeWhenAppStart();
     })();

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/BulkSendAddressesInput.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/BulkSendAddressesInput.tsx
@@ -19,6 +19,7 @@ import { useAppRoute } from '@onekeyhq/kit/src/hooks/useAppRoute';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { useActiveAccount } from '@onekeyhq/kit/src/states/jotai/contexts/accountSelector';
 import { EmptyNoWalletView } from '@onekeyhq/kit/src/views/AccountManagerStacks/pages/AccountSelectorStack/WalletDetails/EmptyView';
+import { useInscriptionProtectionStateAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IAccountDeriveTypes } from '@onekeyhq/kit-bg/src/vaults/types';
 import {
   POLLING_DEBOUNCE_INTERVAL,
@@ -67,6 +68,7 @@ function BaseBulkSendAddressesInput() {
   >();
 
   const { activeAccount } = useActiveAccount({ num: 0 });
+  const [inscriptionProtectionState] = useInscriptionProtectionStateAtom();
 
   const { accountId, networkId, indexedAccountId, tokenInfo, isInModal } =
     route.params ?? {};
@@ -374,6 +376,8 @@ function BaseBulkSendAddressesInput() {
         }
       }
     },
+    // The policy state is an intentional invalidation signal; bg computes the final value.
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
     [
       isOneToMany,
       availableWallets,
@@ -382,6 +386,8 @@ function BaseBulkSendAddressesInput() {
       selectedToken,
       setSelectedTokenDetail,
       setTokenDetailsState,
+      inscriptionProtectionState.localEnabled,
+      inscriptionProtectionState.serverEnabled,
     ],
     {
       debounced: POLLING_DEBOUNCE_INTERVAL,

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/BulkSendAddressesInput.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAddressesInput/BulkSendAddressesInput.tsx
@@ -315,9 +315,9 @@ function BaseBulkSendAddressesInput() {
         tokenDetailsRequestIdRef.current = requestId;
         console.log('addresses input fetchSelectedTokenFiatInfo');
 
-        const [checkInscriptionProtectionEnabled, vaultSettings] =
+        const [effectiveInscriptionProtection, vaultSettings] =
           await Promise.all([
-            backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
+            backgroundApiProxy.serviceSetting.getEffectiveInscriptionProtection(
               {
                 networkId: selectedNetworkId,
                 accountId: selectedAccountId,
@@ -328,7 +328,7 @@ function BaseBulkSendAddressesInput() {
             }),
           ]);
         const withCheckInscription =
-          checkInscriptionProtectionEnabled && vaultSettings.hasFrozenBalance;
+          effectiveInscriptionProtection && vaultSettings.hasFrozenBalance;
 
         try {
           const resp = await backgroundApiProxy.serviceToken.fetchTokensDetails(

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/BulkSendAmountsInput.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/BulkSendAmountsInput.tsx
@@ -23,6 +23,7 @@ import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
 import { convertTokenFiatToCurrency } from '@onekeyhq/kit/src/utils/fiatConvert';
 import {
   useCurrencyPersistAtom,
+  useInscriptionProtectionStateAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type {
@@ -911,6 +912,7 @@ function BulkSendAmountsInputContent({
 }: IBulkSendAmountsInputRouteParams) {
   const intl = useIntl();
   const [settings] = useSettingsPersistAtom();
+  const [inscriptionProtectionState] = useInscriptionProtectionStateAtom();
   const [{ currencyMap }] = useCurrencyPersistAtom();
   const hasCustomAmounts = useMemo(
     () =>
@@ -1534,7 +1536,16 @@ function BulkSendAmountsInputContent({
         }
       }
     },
-    [networkId, accountId, tokenInfo, bulkSendMode],
+    // The policy state is an intentional invalidation signal; bg computes the final value.
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+    [
+      networkId,
+      accountId,
+      tokenInfo,
+      bulkSendMode,
+      inscriptionProtectionState.localEnabled,
+      inscriptionProtectionState.serverEnabled,
+    ],
     {
       debounced: POLLING_DEBOUNCE_INTERVAL,
       pollingInterval: POLLING_INTERVAL_FOR_TOKEN,
@@ -1722,6 +1733,8 @@ function BulkSendAmountsInputContent({
         setSenderBalancesLoading(false);
       }
     },
+    // The policy state is an intentional invalidation signal; bg computes the final value.
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
     [
       networkId,
       tokenInfo,
@@ -1729,6 +1742,8 @@ function BulkSendAmountsInputContent({
       senders,
       accountId,
       buildSenderBalanceAddressKey,
+      inscriptionProtectionState.localEnabled,
+      inscriptionProtectionState.serverEnabled,
     ],
     {
       debounced: POLLING_DEBOUNCE_INTERVAL,

--- a/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/BulkSendAmountsInput.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendAmountsInput/BulkSendAmountsInput.tsx
@@ -1471,9 +1471,9 @@ function BulkSendAmountsInputContent({
           ...prev,
           isRefreshing: true,
         }));
-        const [checkInscriptionProtectionEnabled, vaultSettings] =
+        const [effectiveInscriptionProtection, vaultSettings] =
           await Promise.all([
-            backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
+            backgroundApiProxy.serviceSetting.getEffectiveInscriptionProtection(
               {
                 networkId,
                 accountId,
@@ -1484,7 +1484,7 @@ function BulkSendAmountsInputContent({
             }),
           ]);
         const withCheckInscription =
-          checkInscriptionProtectionEnabled && vaultSettings.hasFrozenBalance;
+          effectiveInscriptionProtection && vaultSettings.hasFrozenBalance;
 
         try {
           const resp = await backgroundApiProxy.serviceToken.fetchTokensDetails(
@@ -1569,7 +1569,7 @@ function BulkSendAmountsInputContent({
               try {
                 const withCheckInscription =
                   vaultSettings.hasFrozenBalance &&
-                  (await backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
+                  (await backgroundApiProxy.serviceSetting.getEffectiveInscriptionProtection(
                     {
                       networkId,
                       accountId: sender.accountId,

--- a/packages/kit/src/views/BulkSend/pages/BulkSendProcess/BulkSendProcess.tsx
+++ b/packages/kit/src/views/BulkSend/pages/BulkSendProcess/BulkSendProcess.tsx
@@ -574,13 +574,13 @@ function BulkSendProcessContent({
             try {
               const [
                 nativeTokenAddress,
-                checkInscriptionProtectionEnabled,
+                effectiveInscriptionProtection,
                 vaultSettings,
               ] = await Promise.all([
                 backgroundApiProxy.serviceToken.getNativeTokenAddress({
                   networkId,
                 }),
-                backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
+                backgroundApiProxy.serviceSetting.getEffectiveInscriptionProtection(
                   {
                     networkId,
                     accountId: txAccountId,
@@ -591,7 +591,7 @@ function BulkSendProcessContent({
                 }),
               ]);
               const withCheckInscription =
-                checkInscriptionProtectionEnabled &&
+                effectiveInscriptionProtection &&
                 vaultSettings.hasFrozenBalance;
               const resp =
                 await backgroundApiProxy.serviceToken.fetchTokensDetails({

--- a/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelector/TabSwitcher.tsx
+++ b/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelector/TabSwitcher.tsx
@@ -5,8 +5,6 @@ import { useIntl } from 'react-intl';
 import { SegmentControl } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
-import { ChainSelectorTestIDs } from '../../testIDs';
-
 export type ITabType = 'portfolio' | 'network';
 
 type ITabSwitcherProps = {
@@ -29,12 +27,10 @@ export function TabSwitcher({ activeTab, onTabChange }: ITabSwitcherProps) {
       {
         label: intl.formatMessage({ id: ETranslations.global_all_networks }),
         value: 'portfolio',
-        testID: ChainSelectorTestIDs.unifiedAllNetworksTab,
       },
       {
         label: intl.formatMessage({ id: ETranslations.global_single_network }),
         value: 'network',
-        testID: ChainSelectorTestIDs.unifiedSingleNetworkTab,
       },
     ],
     [intl],

--- a/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelector/TabSwitcher.tsx
+++ b/packages/kit/src/views/ChainSelector/components/UnifiedNetworkSelector/TabSwitcher.tsx
@@ -5,6 +5,8 @@ import { useIntl } from 'react-intl';
 import { SegmentControl } from '@onekeyhq/components';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 
+import { ChainSelectorTestIDs } from '../../testIDs';
+
 export type ITabType = 'portfolio' | 'network';
 
 type ITabSwitcherProps = {
@@ -27,10 +29,12 @@ export function TabSwitcher({ activeTab, onTabChange }: ITabSwitcherProps) {
       {
         label: intl.formatMessage({ id: ETranslations.global_all_networks }),
         value: 'portfolio',
+        testID: ChainSelectorTestIDs.unifiedAllNetworksTab,
       },
       {
         label: intl.formatMessage({ id: ETranslations.global_single_network }),
         value: 'network',
+        testID: ChainSelectorTestIDs.unifiedSingleNetworkTab,
       },
     ],
     [intl],

--- a/packages/kit/src/views/ChainSelector/testIDs.ts
+++ b/packages/kit/src/views/ChainSelector/testIDs.ts
@@ -17,6 +17,4 @@ export const ChainSelectorTestIDs = {
   // --- UnifiedNetworkSelector ---
   unifiedAddNetworkBtn: 'chain-selector-unified-add-network-btn',
   unifiedPortfolioConfirmBtn: 'page-footer-confirm', // preserve existing
-  unifiedAllNetworksTab: 'chain-selector-unified-all-networks-tab',
-  unifiedSingleNetworkTab: 'chain-selector-unified-single-network-tab',
 } as const;

--- a/packages/kit/src/views/ChainSelector/testIDs.ts
+++ b/packages/kit/src/views/ChainSelector/testIDs.ts
@@ -17,4 +17,6 @@ export const ChainSelectorTestIDs = {
   // --- UnifiedNetworkSelector ---
   unifiedAddNetworkBtn: 'chain-selector-unified-add-network-btn',
   unifiedPortfolioConfirmBtn: 'page-footer-confirm', // preserve existing
+  unifiedAllNetworksTab: 'chain-selector-unified-all-networks-tab',
+  unifiedSingleNetworkTab: 'chain-selector-unified-single-network-tab',
 } as const;

--- a/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
+++ b/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
@@ -241,6 +241,12 @@ function BalanceDetailsContent({
   });
 
   const renderFrozenBalance = useCallback(() => {
+    if (
+      networkUtils.isBTCNetwork(networkId) &&
+      !(settings.inscriptionProtectionServerEnabled ?? true)
+    ) {
+      return null;
+    }
     if (!deriveInfoItems && networkUtils.isBTCNetwork(networkId)) {
       if (
         !(

--- a/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
+++ b/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
@@ -22,7 +22,7 @@ import type { IDialogShowProps } from '@onekeyhq/components/src/composite/Dialog
 import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/backgroundApiProxy';
 import { useHelpLink } from '@onekeyhq/kit/src/hooks/useHelpLink';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import { useInscriptionProtectionStateAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { IAccountDeriveInfoItems } from '@onekeyhq/kit-bg/src/vaults/types';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
 import platformEnv from '@onekeyhq/shared/src/platformEnv';
@@ -63,13 +63,9 @@ function BalanceDetailsContent({
   onClose?: () => void;
 }) {
   const intl = useIntl();
-  const [settings] = useSettingsPersistAtom();
+  const [inscriptionProtectionState] = useInscriptionProtectionStateAtom();
   const { result } = usePromiseResult(async () => {
-    const [
-      vaultSettings,
-      { networkAccounts: n },
-      inscriptionProtectionServerEnabled,
-    ] = await Promise.all([
+    const [vaultSettings, { networkAccounts: n }] = await Promise.all([
       backgroundApiProxy.serviceNetwork.getVaultSettings({ networkId }),
       backgroundApiProxy.serviceAccount.getNetworkAccountsInSameIndexedAccountIdWithDeriveTypes(
         {
@@ -78,7 +74,6 @@ function BalanceDetailsContent({
           excludeEmptyAccount: true,
         },
       ),
-      backgroundApiProxy.serviceSetting.getInscriptionProtectionServerEnabled(),
     ]);
 
     const effectiveMergeDeriveAssetsEnabled =
@@ -103,7 +98,6 @@ function BalanceDetailsContent({
 
     return {
       inscriptionEnabled: i,
-      inscriptionProtectionServerEnabled,
       effectiveMergeDeriveAssetsEnabled,
       showDeriveItems: s,
       networkAccounts: n,
@@ -118,7 +112,6 @@ function BalanceDetailsContent({
 
   const {
     inscriptionEnabled,
-    inscriptionProtectionServerEnabled,
     effectiveMergeDeriveAssetsEnabled,
     showDeriveItems,
     networkAccounts,
@@ -138,7 +131,6 @@ function BalanceDetailsContent({
         !accountId ||
         !networkId ||
         isUndefined(inscriptionEnabled) ||
-        isUndefined(inscriptionProtectionServerEnabled) ||
         isUndefined(showDeriveItems) ||
         isUndefined(networkAccounts)
       )
@@ -236,13 +228,16 @@ function BalanceDetailsContent({
         network: n,
       };
     },
+    // The policy state is an intentional invalidation signal; bg computes the final value.
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
     [
       accountId,
       networkId,
       inscriptionEnabled,
-      inscriptionProtectionServerEnabled,
       effectiveMergeDeriveAssetsEnabled,
       showDeriveItems,
+      inscriptionProtectionState.localEnabled,
+      inscriptionProtectionState.serverEnabled,
       networkAccounts,
     ],
     {
@@ -261,7 +256,7 @@ function BalanceDetailsContent({
   const renderFrozenBalance = useCallback(() => {
     if (
       networkUtils.isBTCNetwork(networkId) &&
-      !inscriptionProtectionServerEnabled
+      !inscriptionProtectionState.serverEnabled
     ) {
       return null;
     }
@@ -342,7 +337,7 @@ function BalanceDetailsContent({
             })}
           </YStack>
         ) : null}
-        {inscriptionEnabled && inscriptionProtectionServerEnabled ? (
+        {inscriptionEnabled && inscriptionProtectionState.serverEnabled ? (
           <>
             <Divider my="$3" />
             <XStack justifyContent="space-between" alignItems="center">
@@ -379,7 +374,7 @@ function BalanceDetailsContent({
               <Switch
                 testID="home-switch"
                 size={ESwitchSize.small}
-                value={settings.inscriptionProtection}
+                value={inscriptionProtectionState.localEnabled}
                 onChange={async (value) => {
                   await backgroundApiProxy.serviceSetting.setInscriptionProtection(
                     value,
@@ -398,7 +393,8 @@ function BalanceDetailsContent({
     deriveInfoItems,
     howToTransferOrdinalsAssetsUrl,
     inscriptionEnabled,
-    inscriptionProtectionServerEnabled,
+    inscriptionProtectionState.localEnabled,
+    inscriptionProtectionState.serverEnabled,
     isLoading,
     network?.symbol,
     networkAccounts,
@@ -407,7 +403,6 @@ function BalanceDetailsContent({
     overview?.deriveItems,
     overview?.frozenBalanceParsed,
     refreshDetails,
-    settings.inscriptionProtection,
     showDeriveItems,
     whatIsFrozenBalanceUrl,
     intl,

--- a/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
+++ b/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
@@ -137,7 +137,9 @@ function BalanceDetailsContent({
         accountId,
       });
       const withCheckInscription =
-        inscriptionEnabled && settings.inscriptionProtection;
+        inscriptionEnabled &&
+        settings.inscriptionProtection &&
+        (settings.inscriptionProtectionServerEnabled ?? true);
       let r: Partial<IFetchAccountDetailsResp> & {
         deriveItems?: {
           deriveType: string;
@@ -222,6 +224,7 @@ function BalanceDetailsContent({
       inscriptionEnabled,
       showDeriveItems,
       settings.inscriptionProtection,
+      settings.inscriptionProtectionServerEnabled,
       networkAccounts,
     ],
     {
@@ -315,7 +318,8 @@ function BalanceDetailsContent({
             })}
           </YStack>
         ) : null}
-        {inscriptionEnabled ? (
+        {inscriptionEnabled &&
+        (settings.inscriptionProtectionServerEnabled ?? true) ? (
           <>
             <Divider my="$3" />
             <XStack justifyContent="space-between" alignItems="center">
@@ -380,6 +384,7 @@ function BalanceDetailsContent({
     overview?.frozenBalanceParsed,
     setSettings,
     settings.inscriptionProtection,
+    settings.inscriptionProtectionServerEnabled,
     showDeriveItems,
     whatIsFrozenBalanceUrl,
     intl,

--- a/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
+++ b/packages/kit/src/views/Home/components/BalanceDetailsDialog/index.tsx
@@ -63,12 +63,14 @@ function BalanceDetailsContent({
   onClose?: () => void;
 }) {
   const intl = useIntl();
-  const [settings, setSettings] = useSettingsPersistAtom();
+  const [settings] = useSettingsPersistAtom();
   const { result } = usePromiseResult(async () => {
-    const [vaultSettings, { networkAccounts: n }] = await Promise.all([
-      backgroundApiProxy.serviceNetwork.getVaultSettings({
-        networkId,
-      }),
+    const [
+      vaultSettings,
+      { networkAccounts: n },
+      inscriptionProtectionServerEnabled,
+    ] = await Promise.all([
+      backgroundApiProxy.serviceNetwork.getVaultSettings({ networkId }),
       backgroundApiProxy.serviceAccount.getNetworkAccountsInSameIndexedAccountIdWithDeriveTypes(
         {
           networkId,
@@ -76,15 +78,17 @@ function BalanceDetailsContent({
           excludeEmptyAccount: true,
         },
       ),
+      backgroundApiProxy.serviceSetting.getInscriptionProtectionServerEnabled(),
     ]);
 
+    const effectiveMergeDeriveAssetsEnabled =
+      mergeDeriveAssetsEnabled ?? vaultSettings?.mergeDeriveAssetsEnabled;
     const i =
       await backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
         {
           networkId,
           accountId,
-          mergeDeriveAssetsEnabled:
-            mergeDeriveAssetsEnabled ?? vaultSettings?.mergeDeriveAssetsEnabled,
+          mergeDeriveAssetsEnabled: effectiveMergeDeriveAssetsEnabled,
         },
       );
 
@@ -99,6 +103,8 @@ function BalanceDetailsContent({
 
     return {
       inscriptionEnabled: i,
+      inscriptionProtectionServerEnabled,
+      effectiveMergeDeriveAssetsEnabled,
       showDeriveItems: s,
       networkAccounts: n,
     };
@@ -110,7 +116,13 @@ function BalanceDetailsContent({
     deriveInfoItems,
   ]);
 
-  const { inscriptionEnabled, showDeriveItems, networkAccounts } = result ?? {};
+  const {
+    inscriptionEnabled,
+    inscriptionProtectionServerEnabled,
+    effectiveMergeDeriveAssetsEnabled,
+    showDeriveItems,
+    networkAccounts,
+  } = result ?? {};
 
   const {
     result: { overview, network, account } = {
@@ -119,12 +131,14 @@ function BalanceDetailsContent({
       account: undefined,
     },
     isLoading,
+    run: refreshDetails,
   } = usePromiseResult(
     async () => {
       if (
         !accountId ||
         !networkId ||
         isUndefined(inscriptionEnabled) ||
+        isUndefined(inscriptionProtectionServerEnabled) ||
         isUndefined(showDeriveItems) ||
         isUndefined(networkAccounts)
       )
@@ -137,9 +151,13 @@ function BalanceDetailsContent({
         accountId,
       });
       const withCheckInscription =
-        inscriptionEnabled &&
-        settings.inscriptionProtection &&
-        (settings.inscriptionProtectionServerEnabled ?? true);
+        await backgroundApiProxy.serviceSetting.getEffectiveInscriptionProtection(
+          {
+            networkId,
+            accountId,
+            mergeDeriveAssetsEnabled: effectiveMergeDeriveAssetsEnabled,
+          },
+        );
       let r: Partial<IFetchAccountDetailsResp> & {
         deriveItems?: {
           deriveType: string;
@@ -222,9 +240,9 @@ function BalanceDetailsContent({
       accountId,
       networkId,
       inscriptionEnabled,
+      inscriptionProtectionServerEnabled,
+      effectiveMergeDeriveAssetsEnabled,
       showDeriveItems,
-      settings.inscriptionProtection,
-      settings.inscriptionProtectionServerEnabled,
       networkAccounts,
     ],
     {
@@ -243,7 +261,7 @@ function BalanceDetailsContent({
   const renderFrozenBalance = useCallback(() => {
     if (
       networkUtils.isBTCNetwork(networkId) &&
-      !(settings.inscriptionProtectionServerEnabled ?? true)
+      !inscriptionProtectionServerEnabled
     ) {
       return null;
     }
@@ -324,8 +342,7 @@ function BalanceDetailsContent({
             })}
           </YStack>
         ) : null}
-        {inscriptionEnabled &&
-        (settings.inscriptionProtectionServerEnabled ?? true) ? (
+        {inscriptionEnabled && inscriptionProtectionServerEnabled ? (
           <>
             <Divider my="$3" />
             <XStack justifyContent="space-between" alignItems="center">
@@ -363,11 +380,11 @@ function BalanceDetailsContent({
                 testID="home-switch"
                 size={ESwitchSize.small}
                 value={settings.inscriptionProtection}
-                onChange={(value) => {
-                  setSettings((v) => ({
-                    ...v,
-                    inscriptionProtection: value,
-                  }));
+                onChange={async (value) => {
+                  await backgroundApiProxy.serviceSetting.setInscriptionProtection(
+                    value,
+                  );
+                  await refreshDetails();
                 }}
               />
             </XStack>
@@ -381,6 +398,7 @@ function BalanceDetailsContent({
     deriveInfoItems,
     howToTransferOrdinalsAssetsUrl,
     inscriptionEnabled,
+    inscriptionProtectionServerEnabled,
     isLoading,
     network?.symbol,
     networkAccounts,
@@ -388,9 +406,8 @@ function BalanceDetailsContent({
     onClose,
     overview?.deriveItems,
     overview?.frozenBalanceParsed,
-    setSettings,
+    refreshDetails,
     settings.inscriptionProtection,
-    settings.inscriptionProtectionServerEnabled,
     showDeriveItems,
     whatIsFrozenBalanceUrl,
     intl,

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -919,7 +919,7 @@ function SendAmountInputContainer() {
           ],
         });
       } else if (!isNFT && tokenInfo) {
-        const checkInscriptionProtectionEnabled =
+        const accountEligibleForInscriptionProtection =
           await backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
             {
               networkId: network.id,
@@ -927,7 +927,9 @@ function SendAmountInputContainer() {
             },
           );
         const withCheckInscription =
-          checkInscriptionProtectionEnabled && settings.inscriptionProtection;
+          accountEligibleForInscriptionProtection &&
+          settings.inscriptionProtection &&
+          (settings.inscriptionProtectionServerEnabled ?? true);
         tokenResp = await serviceToken.fetchTokensDetails({
           networkId: network.id,
           accountId: account.id,
@@ -957,6 +959,7 @@ function SendAmountInputContainer() {
       token,
       tokenInfo,
       settings.inscriptionProtection,
+      settings.inscriptionProtectionServerEnabled,
     ],
     {
       watchLoading: true,
@@ -2186,7 +2189,9 @@ function SendAmountInputContainer() {
     // Spendable balance depends on this setting; feeding it in (and keying the
     // sibling cache on it) keeps siblings on the same balance contract as the
     // current page and invalidates the cache when the user toggles it mid-flow.
-    inscriptionProtection: !!settings.inscriptionProtection,
+    inscriptionProtection:
+      !!settings.inscriptionProtection &&
+      (settings.inscriptionProtectionServerEnabled ?? true),
   });
 
   const performAutoSwitchToAccount = useCallback(

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -60,6 +60,7 @@ import { SendTestIDs } from '@onekeyhq/kit/src/views/Send/testIDs';
 import { SwapRefreshButtonBase } from '@onekeyhq/kit/src/views/Swap/components/SwapRefreshButton';
 import {
   useCurrencyPersistAtom,
+  useInscriptionProtectionStateAtom,
   useSettingsPersistAtom,
 } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type {
@@ -811,6 +812,7 @@ function SendAmountInputContainer() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isMaxSend, setIsMaxSend] = useState(false);
   const [settings, setSettings] = useSettingsPersistAtom();
+  const [inscriptionProtectionState] = useInscriptionProtectionStateAtom();
   const [{ currencyMap }] = useCurrencyPersistAtom();
   const [selectedUTXOs] = useSelectedUTXOsAtom();
   const sendConfirmActions = useSendConfirmActions();
@@ -945,7 +947,20 @@ function SendAmountInputContainer() {
       // balance was fetched for — it lags `currentAccountId` after a switch.
       return [tokenResp?.[0], nftResp?.[0], frozenBalanceSettings, account.id];
     },
-    [account, isNFT, network, nft, serviceNFT, serviceToken, token, tokenInfo],
+    // The policy state is an intentional invalidation signal; bg computes the final value.
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+    [
+      account,
+      isNFT,
+      network,
+      nft,
+      serviceNFT,
+      serviceToken,
+      token,
+      tokenInfo,
+      inscriptionProtectionState.localEnabled,
+      inscriptionProtectionState.serverEnabled,
+    ],
     {
       watchLoading: true,
       alwaysSetState: true,

--- a/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/SendAmountInputContainer.tsx
@@ -919,17 +919,13 @@ function SendAmountInputContainer() {
           ],
         });
       } else if (!isNFT && tokenInfo) {
-        const accountEligibleForInscriptionProtection =
-          await backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
+        const withCheckInscription =
+          await backgroundApiProxy.serviceSetting.getEffectiveInscriptionProtection(
             {
               networkId: network.id,
               accountId: account.id,
             },
           );
-        const withCheckInscription =
-          accountEligibleForInscriptionProtection &&
-          settings.inscriptionProtection &&
-          (settings.inscriptionProtectionServerEnabled ?? true);
         tokenResp = await serviceToken.fetchTokensDetails({
           networkId: network.id,
           accountId: account.id,
@@ -949,18 +945,7 @@ function SendAmountInputContainer() {
       // balance was fetched for — it lags `currentAccountId` after a switch.
       return [tokenResp?.[0], nftResp?.[0], frozenBalanceSettings, account.id];
     },
-    [
-      account,
-      isNFT,
-      network,
-      nft,
-      serviceNFT,
-      serviceToken,
-      token,
-      tokenInfo,
-      settings.inscriptionProtection,
-      settings.inscriptionProtectionServerEnabled,
-    ],
+    [account, isNFT, network, nft, serviceNFT, serviceToken, token, tokenInfo],
     {
       watchLoading: true,
       alwaysSetState: true,
@@ -2186,12 +2171,6 @@ function SendAmountInputContainer() {
     networkId,
     indexedAccountId: account?.indexedAccountId ?? '',
     tokenAddress: tokenInfo?.address ?? '',
-    // Spendable balance depends on this setting; feeding it in (and keying the
-    // sibling cache on it) keeps siblings on the same balance contract as the
-    // current page and invalidates the cache when the user toggles it mid-flow.
-    inscriptionProtection:
-      !!settings.inscriptionProtection &&
-      (settings.inscriptionProtectionServerEnabled ?? true),
   });
 
   const performAutoSwitchToAccount = useCallback(

--- a/packages/kit/src/views/Send/pages/SendAmountInput/hooks/useSiblingDeriveBalances.ts
+++ b/packages/kit/src/views/Send/pages/SendAmountInput/hooks/useSiblingDeriveBalances.ts
@@ -42,10 +42,6 @@ type IParams = {
   // vaultSettings.isNativeTokenContractAddressEmpty is true). Non-empty for
   // ERC20-style contracts.
   tokenAddress: string;
-  // Global inscription-protection setting. Part of the spendable-balance
-  // contract, so it must be both an input to the fetch and part of the cache
-  // key — otherwise toggling it mid-flow keeps serving stale sibling balances.
-  inscriptionProtection: boolean;
 };
 
 // Fetches the available balance of the same token under every other deriveType
@@ -65,27 +61,33 @@ export function useSiblingDeriveBalances({
   networkId,
   indexedAccountId,
   tokenAddress,
-  inscriptionProtection,
 }: IParams) {
   const cacheRef = useRef<ICache | null>(null);
 
-  const cacheKey = `${networkId}|${indexedAccountId}|${tokenAddress}|${inscriptionProtection}`;
+  const baseCacheKey = `${networkId}|${indexedAccountId}|${tokenAddress}`;
 
   const fetch = useCallback(async (): Promise<ISiblingDeriveBalancesResult> => {
     if (!networkId || !indexedAccountId) {
       return { siblings: [], hadError: false };
     }
 
-    const cache = cacheRef.current;
-    if (
-      cache &&
-      cache.key === cacheKey &&
-      Date.now() - cache.fetchedAt < CACHE_TTL_MS
-    ) {
-      return { siblings: cache.data, hadError: false };
-    }
-
     try {
+      const [localProtectionEnabled, serverProtectionEnabled] =
+        await Promise.all([
+          backgroundApiProxy.serviceSetting.getInscriptionProtection(),
+          backgroundApiProxy.serviceSetting.getInscriptionProtectionServerEnabled(),
+        ]);
+      const cacheKey = `${baseCacheKey}|${localProtectionEnabled}|${serverProtectionEnabled}`;
+
+      const cache = cacheRef.current;
+      if (
+        cache &&
+        cache.key === cacheKey &&
+        Date.now() - cache.fetchedAt < CACHE_TTL_MS
+      ) {
+        return { siblings: cache.data, hadError: false };
+      }
+
       const { networkAccounts } =
         await backgroundApiProxy.serviceAccount.getNetworkAccountsInSameIndexedAccountIdWithDeriveTypes(
           {
@@ -103,15 +105,13 @@ export function useSiblingDeriveBalances({
           const account = item.account;
           if (!account) return null;
           try {
-            const checkInscriptionProtectionEnabled =
-              await backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
+            const withCheckInscription =
+              await backgroundApiProxy.serviceSetting.getEffectiveInscriptionProtection(
                 {
                   networkId,
                   accountId: account.id,
                 },
               );
-            const withCheckInscription =
-              checkInscriptionProtectionEnabled && inscriptionProtection;
 
             const resp =
               await backgroundApiProxy.serviceToken.fetchTokensDetails({
@@ -157,13 +157,7 @@ export function useSiblingDeriveBalances({
     } catch {
       return { siblings: [], hadError: true };
     }
-  }, [
-    cacheKey,
-    networkId,
-    indexedAccountId,
-    tokenAddress,
-    inscriptionProtection,
-  ]);
+  }, [baseCacheKey, networkId, indexedAccountId, tokenAddress]);
 
   return { fetch };
 }

--- a/packages/kit/src/views/Send/pages/SendConfirm/SendConfirmContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendConfirm/SendConfirmContainer.tsx
@@ -13,6 +13,7 @@ import {
   useSendFeeStatusAtom,
   useSendTxStatusAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/sendConfirm';
+import { useInscriptionProtectionStateAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -50,6 +51,7 @@ function SendConfirmContainer() {
     updateSendFeeStatus,
     updatePreCheckTxStatus,
   } = useSendConfirmActions().current;
+  const [inscriptionProtectionState] = useInscriptionProtectionStateAtom();
   const [sendFeeStatus] = useSendFeeStatusAtom();
   const [sendAlertStatus] = useSendTxStatusAtom();
   const [preCheckTxStatus] = usePreCheckTxStatusAtom();
@@ -81,47 +83,54 @@ function SendConfirmContainer() {
   }, []);
 
   const { network } =
-    usePromiseResult(async () => {
-      updateUnsignedTxs(unsignedTxs);
-      updateNativeTokenInfo({
-        isLoading: true,
-        balance: '0',
-        logoURI: '',
-        info: undefined,
-      });
-      const [n, nativeTokenAddress] = await Promise.all([
-        backgroundApiProxy.serviceNetwork.getNetwork({ networkId }),
-        backgroundApiProxy.serviceToken.getNativeTokenAddress({ networkId }),
-      ]);
-      const withCheckInscription =
-        await backgroundApiProxy.serviceSetting.getEffectiveInscriptionProtection(
-          {
-            networkId,
-            accountId,
-          },
-        );
-      const r = await backgroundApiProxy.serviceToken.fetchTokensDetails({
-        networkId,
+    usePromiseResult(
+      async () => {
+        updateUnsignedTxs(unsignedTxs);
+        updateNativeTokenInfo({
+          isLoading: true,
+          balance: '0',
+          logoURI: '',
+          info: undefined,
+        });
+        const [n, nativeTokenAddress] = await Promise.all([
+          backgroundApiProxy.serviceNetwork.getNetwork({ networkId }),
+          backgroundApiProxy.serviceToken.getNativeTokenAddress({ networkId }),
+        ]);
+        const withCheckInscription =
+          await backgroundApiProxy.serviceSetting.getEffectiveInscriptionProtection(
+            {
+              networkId,
+              accountId,
+            },
+          );
+        const r = await backgroundApiProxy.serviceToken.fetchTokensDetails({
+          networkId,
+          accountId,
+          contractList: [nativeTokenAddress],
+          withFrozenBalance: true,
+          withCheckInscription,
+        });
+        const balance = r[0].balanceParsed;
+        updateNativeTokenInfo({
+          isLoading: false,
+          balance,
+          logoURI: r[0].info.logoURI ?? '',
+          info: r[0].info,
+        });
+        return { network: n };
+      },
+      // The policy state is an intentional invalidation signal; bg computes the final value.
+      // oxlint-disable-next-line react-hooks/exhaustive-deps
+      [
         accountId,
-        contractList: [nativeTokenAddress],
-        withFrozenBalance: true,
-        withCheckInscription,
-      });
-      const balance = r[0].balanceParsed;
-      updateNativeTokenInfo({
-        isLoading: false,
-        balance,
-        logoURI: r[0].info.logoURI ?? '',
-        info: r[0].info,
-      });
-      return { network: n };
-    }, [
-      accountId,
-      networkId,
-      unsignedTxs,
-      updateNativeTokenInfo,
-      updateUnsignedTxs,
-    ]).result ?? {};
+        networkId,
+        unsignedTxs,
+        updateNativeTokenInfo,
+        updateUnsignedTxs,
+        inscriptionProtectionState.localEnabled,
+        inscriptionProtectionState.serverEnabled,
+      ],
+    ).result ?? {};
 
   usePromiseResult(async () => {
     try {

--- a/packages/kit/src/views/Send/pages/SendConfirm/SendConfirmContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendConfirm/SendConfirmContainer.tsx
@@ -13,7 +13,6 @@ import {
   useSendFeeStatusAtom,
   useSendTxStatusAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/sendConfirm';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import {
   EAppEventBusNames,
   appEventBus,
@@ -51,7 +50,6 @@ function SendConfirmContainer() {
     updateSendFeeStatus,
     updatePreCheckTxStatus,
   } = useSendConfirmActions().current;
-  const [settings] = useSettingsPersistAtom();
   const [sendFeeStatus] = useSendFeeStatusAtom();
   const [sendAlertStatus] = useSendTxStatusAtom();
   const [preCheckTxStatus] = usePreCheckTxStatusAtom();
@@ -95,17 +93,13 @@ function SendConfirmContainer() {
         backgroundApiProxy.serviceNetwork.getNetwork({ networkId }),
         backgroundApiProxy.serviceToken.getNativeTokenAddress({ networkId }),
       ]);
-      const accountEligibleForInscriptionProtection =
-        await backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
+      const withCheckInscription =
+        await backgroundApiProxy.serviceSetting.getEffectiveInscriptionProtection(
           {
             networkId,
             accountId,
           },
         );
-      const withCheckInscription =
-        accountEligibleForInscriptionProtection &&
-        settings.inscriptionProtection &&
-        (settings.inscriptionProtectionServerEnabled ?? true);
       const r = await backgroundApiProxy.serviceToken.fetchTokensDetails({
         networkId,
         accountId,
@@ -127,8 +121,6 @@ function SendConfirmContainer() {
       unsignedTxs,
       updateNativeTokenInfo,
       updateUnsignedTxs,
-      settings.inscriptionProtection,
-      settings.inscriptionProtectionServerEnabled,
     ]).result ?? {};
 
   usePromiseResult(async () => {

--- a/packages/kit/src/views/Send/pages/SendConfirm/SendConfirmContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendConfirm/SendConfirmContainer.tsx
@@ -95,7 +95,7 @@ function SendConfirmContainer() {
         backgroundApiProxy.serviceNetwork.getNetwork({ networkId }),
         backgroundApiProxy.serviceToken.getNativeTokenAddress({ networkId }),
       ]);
-      const checkInscriptionProtectionEnabled =
+      const accountEligibleForInscriptionProtection =
         await backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
           {
             networkId,
@@ -103,7 +103,9 @@ function SendConfirmContainer() {
           },
         );
       const withCheckInscription =
-        checkInscriptionProtectionEnabled && settings.inscriptionProtection;
+        accountEligibleForInscriptionProtection &&
+        settings.inscriptionProtection &&
+        (settings.inscriptionProtectionServerEnabled ?? true);
       const r = await backgroundApiProxy.serviceToken.fetchTokensDetails({
         networkId,
         accountId,
@@ -126,6 +128,7 @@ function SendConfirmContainer() {
       updateNativeTokenInfo,
       updateUnsignedTxs,
       settings.inscriptionProtection,
+      settings.inscriptionProtectionServerEnabled,
     ]).result ?? {};
 
   usePromiseResult(async () => {

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -266,7 +266,7 @@ function SendDataInputContainer() {
           ],
         });
       } else if (!isNFT && tokenInfo) {
-        const checkInscriptionProtectionEnabled =
+        const accountEligibleForInscriptionProtection =
           await backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
             {
               networkId: network.id,
@@ -274,7 +274,9 @@ function SendDataInputContainer() {
             },
           );
         const withCheckInscription =
-          checkInscriptionProtectionEnabled && settings.inscriptionProtection;
+          accountEligibleForInscriptionProtection &&
+          settings.inscriptionProtection &&
+          (settings.inscriptionProtectionServerEnabled ?? true);
         tokenResp = await serviceToken.fetchTokensDetails({
           networkId: network.id,
           accountId: account.id,
@@ -302,6 +304,7 @@ function SendDataInputContainer() {
       token,
       tokenInfo,
       settings.inscriptionProtection,
+      settings.inscriptionProtectionServerEnabled,
     ],
     { watchLoading: true, alwaysSetState: true },
   );

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -42,6 +42,7 @@ import type {
   IChainValue,
   IQRCodeHandlerParseResult,
 } from '@onekeyhq/kit-bg/src/services/ServiceScanQRCode/utils/parseQRCode/type';
+import { useInscriptionProtectionStateAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { ITransferInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import { OneKeyInternalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -114,6 +115,7 @@ type ISendAmountInputParams =
 function SendDataInputContainer() {
   const intl = useIntl();
   const media = useMedia();
+  const [inscriptionProtectionState] = useInscriptionProtectionStateAtom();
 
   const navigation =
     useAppNavigation<IPageNavigationProp<ISendInputFlowParamList>>();
@@ -288,7 +290,20 @@ function SendDataInputContainer() {
 
       return [tokenResp?.[0], nftResp?.[0], frozenBalanceSettings];
     },
-    [account, isNFT, network, nft, serviceNFT, serviceToken, token, tokenInfo],
+    // The policy state is an intentional invalidation signal; bg computes the final value.
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+    [
+      account,
+      isNFT,
+      network,
+      nft,
+      serviceNFT,
+      serviceToken,
+      token,
+      tokenInfo,
+      inscriptionProtectionState.localEnabled,
+      inscriptionProtectionState.serverEnabled,
+    ],
     { watchLoading: true, alwaysSetState: true },
   );
 

--- a/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendDataInput/SendDataInputContainer.tsx
@@ -42,7 +42,6 @@ import type {
   IChainValue,
   IQRCodeHandlerParseResult,
 } from '@onekeyhq/kit-bg/src/services/ServiceScanQRCode/utils/parseQRCode/type';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import type { ITransferInfo } from '@onekeyhq/kit-bg/src/vaults/types';
 import { OneKeyInternalError } from '@onekeyhq/shared/src/errors';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -116,7 +115,6 @@ function SendDataInputContainer() {
   const intl = useIntl();
   const media = useMedia();
 
-  const [settings] = useSettingsPersistAtom();
   const navigation =
     useAppNavigation<IPageNavigationProp<ISendInputFlowParamList>>();
 
@@ -266,17 +264,13 @@ function SendDataInputContainer() {
           ],
         });
       } else if (!isNFT && tokenInfo) {
-        const accountEligibleForInscriptionProtection =
-          await backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
+        const withCheckInscription =
+          await backgroundApiProxy.serviceSetting.getEffectiveInscriptionProtection(
             {
               networkId: network.id,
               accountId: account.id,
             },
           );
-        const withCheckInscription =
-          accountEligibleForInscriptionProtection &&
-          settings.inscriptionProtection &&
-          (settings.inscriptionProtectionServerEnabled ?? true);
         tokenResp = await serviceToken.fetchTokensDetails({
           networkId: network.id,
           accountId: account.id,
@@ -294,18 +288,7 @@ function SendDataInputContainer() {
 
       return [tokenResp?.[0], nftResp?.[0], frozenBalanceSettings];
     },
-    [
-      account,
-      isNFT,
-      network,
-      nft,
-      serviceNFT,
-      serviceToken,
-      token,
-      tokenInfo,
-      settings.inscriptionProtection,
-      settings.inscriptionProtectionServerEnabled,
-    ],
+    [account, isNFT, network, nft, serviceNFT, serviceToken, token, tokenInfo],
     { watchLoading: true, alwaysSetState: true },
   );
 

--- a/packages/kit/src/views/Send/pages/SendReplaceTx/SendReplaceTxContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendReplaceTx/SendReplaceTxContainer.tsx
@@ -148,7 +148,7 @@ function SendReplaceTxContainer() {
           await backgroundApiProxy.serviceToken.getNativeTokenAddress({
             networkId,
           });
-        const checkInscriptionProtectionEnabled =
+        const accountEligibleForInscriptionProtection =
           await backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
             {
               networkId,
@@ -156,7 +156,9 @@ function SendReplaceTxContainer() {
             },
           );
         const withCheckInscription =
-          checkInscriptionProtectionEnabled && settings.inscriptionProtection;
+          accountEligibleForInscriptionProtection &&
+          settings.inscriptionProtection &&
+          (settings.inscriptionProtectionServerEnabled ?? true);
         const r = await backgroundApiProxy.serviceToken.fetchTokensDetails({
           networkId,
           accountId,
@@ -166,7 +168,13 @@ function SendReplaceTxContainer() {
         });
         return r[0];
       },
-      [accountId, network, networkId, settings.inscriptionProtection],
+      [
+        accountId,
+        network,
+        networkId,
+        settings.inscriptionProtection,
+        settings.inscriptionProtectionServerEnabled,
+      ],
       { watchLoading: true },
     );
 

--- a/packages/kit/src/views/Send/pages/SendReplaceTx/SendReplaceTxContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendReplaceTx/SendReplaceTxContainer.tsx
@@ -25,7 +25,10 @@ import backgroundApiProxy from '@onekeyhq/kit/src/background/instance/background
 import { useAccountData } from '@onekeyhq/kit/src/hooks/useAccountData';
 import useAppNavigation from '@onekeyhq/kit/src/hooks/useAppNavigation';
 import { usePromiseResult } from '@onekeyhq/kit/src/hooks/usePromiseResult';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
+import {
+  useInscriptionProtectionStateAtom,
+  useSettingsPersistAtom,
+} from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { REPLACE_TX_FEE_UP_RATIO } from '@onekeyhq/shared/src/consts/walletConsts';
 import { EOneKeyErrorClassNames } from '@onekeyhq/shared/src/errors/types/errorTypes';
 import { ETranslations } from '@onekeyhq/shared/src/locale';
@@ -109,6 +112,7 @@ function SendReplaceTxContainer() {
   );
 
   const [settings] = useSettingsPersistAtom();
+  const [inscriptionProtectionState] = useInscriptionProtectionStateAtom();
 
   const [feeInfo, setFeeInfo] = useState<IFeeInfoUnit | undefined>(undefined);
   const [isInit, setIsInit] = useState(false);
@@ -164,7 +168,15 @@ function SendReplaceTxContainer() {
         });
         return r[0];
       },
-      [accountId, network, networkId],
+      // The policy state is an intentional invalidation signal; bg computes the final value.
+      // oxlint-disable-next-line react-hooks/exhaustive-deps
+      [
+        accountId,
+        network,
+        networkId,
+        inscriptionProtectionState.localEnabled,
+        inscriptionProtectionState.serverEnabled,
+      ],
       { watchLoading: true },
     );
 

--- a/packages/kit/src/views/Send/pages/SendReplaceTx/SendReplaceTxContainer.tsx
+++ b/packages/kit/src/views/Send/pages/SendReplaceTx/SendReplaceTxContainer.tsx
@@ -148,17 +148,13 @@ function SendReplaceTxContainer() {
           await backgroundApiProxy.serviceToken.getNativeTokenAddress({
             networkId,
           });
-        const accountEligibleForInscriptionProtection =
-          await backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
+        const withCheckInscription =
+          await backgroundApiProxy.serviceSetting.getEffectiveInscriptionProtection(
             {
               networkId,
               accountId,
             },
           );
-        const withCheckInscription =
-          accountEligibleForInscriptionProtection &&
-          settings.inscriptionProtection &&
-          (settings.inscriptionProtectionServerEnabled ?? true);
         const r = await backgroundApiProxy.serviceToken.fetchTokensDetails({
           networkId,
           accountId,
@@ -168,13 +164,7 @@ function SendReplaceTxContainer() {
         });
         return r[0];
       },
-      [
-        accountId,
-        network,
-        networkId,
-        settings.inscriptionProtection,
-        settings.inscriptionProtectionServerEnabled,
-      ],
+      [accountId, network, networkId],
       { watchLoading: true },
     );
 

--- a/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
+++ b/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
@@ -17,6 +17,7 @@ import {
   useTxFeeInfoInitAtom,
   useUnsignedTxsAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/signatureConfirm';
+import { useInscriptionProtectionStateAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { POLLING_INTERVAL_FOR_NATIVE_TOKEN_INFO } from '@onekeyhq/shared/src/consts/walletConsts';
 import {
   EAppEventBusNames,
@@ -98,6 +99,7 @@ function TxConfirm() {
     updateCustomRpcStatus,
   } = useSignatureConfirmActions().current;
 
+  const [inscriptionProtectionState] = useInscriptionProtectionStateAtom();
   const [reactiveUnsignedTxs] = useUnsignedTxsAtom();
   const [decodedTxsInit] = useDecodedTxsInitAtom();
   const [effectiveFeePayer] = useEffectiveFeePayerAtom();
@@ -203,45 +205,54 @@ function TxConfirm() {
     updateSendTxStatus,
   ]);
 
-  const fetchNativeTokenInfo = useCallback(async () => {
-    const nativeTokenAddress =
-      await backgroundApiProxy.serviceToken.getNativeTokenAddress({
-        networkId,
-      });
+  const fetchNativeTokenInfo = useCallback(
+    async () => {
+      const nativeTokenAddress =
+        await backgroundApiProxy.serviceToken.getNativeTokenAddress({
+          networkId,
+        });
 
-    const withCheckInscription =
-      await backgroundApiProxy.serviceSetting.getEffectiveInscriptionProtection(
-        {
+      const withCheckInscription =
+        await backgroundApiProxy.serviceSetting.getEffectiveInscriptionProtection(
+          {
+            networkId,
+            accountId,
+          },
+        );
+      const tokenResp =
+        await backgroundApiProxy.serviceToken.fetchTokensDetails({
           networkId,
           accountId,
-        },
-      );
-    const tokenResp = await backgroundApiProxy.serviceToken.fetchTokensDetails({
-      networkId,
+          contractList: [nativeTokenAddress],
+          withFrozenBalance: true,
+          withCheckInscription,
+        });
+      // Coin-control txs can only spend the user-selected UTXOs, so treat the
+      // selected subtotal as the spendable balance. The account-level balance
+      // fetched above excludes find-address claimed UTXOs (never aggregated),
+      // which would otherwise read as 0 and falsely trip the insufficient
+      // native balance checks.
+      const balance =
+        transferPayload?.selectedUtxoTotalAmount ??
+        tokenResp?.[0]?.balanceParsed;
+      updateNativeTokenInfo({
+        isLoading: false,
+        balance,
+        logoURI: tokenResp?.[0]?.info.logoURI ?? '',
+        info: tokenResp?.[0]?.info,
+      });
+    },
+    // The policy state is an intentional invalidation signal; bg computes the final value.
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+    [
+      updateNativeTokenInfo,
       accountId,
-      contractList: [nativeTokenAddress],
-      withFrozenBalance: true,
-      withCheckInscription,
-    });
-    // Coin-control txs can only spend the user-selected UTXOs, so treat the
-    // selected subtotal as the spendable balance. The account-level balance
-    // fetched above excludes find-address claimed UTXOs (never aggregated),
-    // which would otherwise read as 0 and falsely trip the insufficient
-    // native balance checks.
-    const balance =
-      transferPayload?.selectedUtxoTotalAmount ?? tokenResp?.[0]?.balanceParsed;
-    updateNativeTokenInfo({
-      isLoading: false,
-      balance,
-      logoURI: tokenResp?.[0]?.info.logoURI ?? '',
-      info: tokenResp?.[0]?.info,
-    });
-  }, [
-    updateNativeTokenInfo,
-    accountId,
-    networkId,
-    transferPayload?.selectedUtxoTotalAmount,
-  ]);
+      networkId,
+      inscriptionProtectionState.localEnabled,
+      inscriptionProtectionState.serverEnabled,
+      transferPayload?.selectedUtxoTotalAmount,
+    ],
+  );
 
   usePromiseResult(
     async () => {

--- a/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
+++ b/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
@@ -211,7 +211,7 @@ function TxConfirm() {
         networkId,
       });
 
-    const checkInscriptionProtectionEnabled =
+    const accountEligibleForInscriptionProtection =
       await backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
         {
           networkId,
@@ -219,7 +219,9 @@ function TxConfirm() {
         },
       );
     const withCheckInscription =
-      checkInscriptionProtectionEnabled && settings.inscriptionProtection;
+      accountEligibleForInscriptionProtection &&
+      settings.inscriptionProtection &&
+      (settings.inscriptionProtectionServerEnabled ?? true);
     const tokenResp = await backgroundApiProxy.serviceToken.fetchTokensDetails({
       networkId,
       accountId,
@@ -245,6 +247,7 @@ function TxConfirm() {
     accountId,
     networkId,
     settings.inscriptionProtection,
+    settings.inscriptionProtectionServerEnabled,
     transferPayload?.selectedUtxoTotalAmount,
   ]);
 

--- a/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
+++ b/packages/kit/src/views/SignatureConfirm/pages/TxConfirm/TxConfirm.tsx
@@ -17,7 +17,6 @@ import {
   useTxFeeInfoInitAtom,
   useUnsignedTxsAtom,
 } from '@onekeyhq/kit/src/states/jotai/contexts/signatureConfirm';
-import { useSettingsPersistAtom } from '@onekeyhq/kit-bg/src/states/jotai/atoms';
 import { POLLING_INTERVAL_FOR_NATIVE_TOKEN_INFO } from '@onekeyhq/shared/src/consts/walletConsts';
 import {
   EAppEventBusNames,
@@ -99,7 +98,6 @@ function TxConfirm() {
     updateCustomRpcStatus,
   } = useSignatureConfirmActions().current;
 
-  const [settings] = useSettingsPersistAtom();
   const [reactiveUnsignedTxs] = useUnsignedTxsAtom();
   const [decodedTxsInit] = useDecodedTxsInitAtom();
   const [effectiveFeePayer] = useEffectiveFeePayerAtom();
@@ -211,17 +209,13 @@ function TxConfirm() {
         networkId,
       });
 
-    const accountEligibleForInscriptionProtection =
-      await backgroundApiProxy.serviceSetting.checkInscriptionProtectionEnabled(
+    const withCheckInscription =
+      await backgroundApiProxy.serviceSetting.getEffectiveInscriptionProtection(
         {
           networkId,
           accountId,
         },
       );
-    const withCheckInscription =
-      accountEligibleForInscriptionProtection &&
-      settings.inscriptionProtection &&
-      (settings.inscriptionProtectionServerEnabled ?? true);
     const tokenResp = await backgroundApiProxy.serviceToken.fetchTokensDetails({
       networkId,
       accountId,
@@ -246,8 +240,6 @@ function TxConfirm() {
     updateNativeTokenInfo,
     accountId,
     networkId,
-    settings.inscriptionProtection,
-    settings.inscriptionProtectionServerEnabled,
     transferPayload?.selectedUtxoTotalAmount,
   ]);
 


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60768](https://onekeyhq.atlassian.net/browse/OK-60768)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Add rollout control for phasing out BTC inscription protection in App 6.6.0.
- Disable inscription protection across supported BTC transaction flows when the feature is unavailable.
- Hide the inscription protection switch and protected balance section while retaining the existing implementation for compatibility.

## Intent & Context
BTC inscription protection is being phased out in App 6.6.0. The feature remains available during rollout and can be disabled after the user-facing announcement, without removing the existing implementation used by earlier clients.

Related issue: [OK-60768](https://onekeyhq.atlassian.net/browse/OK-60768)

## Changes Detail
- Apply the feature availability state to Send, transaction confirmation, Swap, Bulk Send, and BTC Vault flows.
- Hide BTC inscription protection controls and protected balance details when disabled.
- Preserve the user's existing preference and the current protection implementation.
- Add coverage for enabled, disabled, and fallback states.

## Risk Assessment
- **Risk Level**: High
- **Affected Platforms**: Extension / Mobile / Desktop / Web
- **Risk Areas**: BTC transaction behavior after inscription protection is disabled.

## Test plan
- [x] Run inscription protection unit tests (10/10 passed).
- [x] Run lint, format, and TypeScript checks.
- [x] Verify enabled and disabled states in Desktop Balance Details.
- [ ] QA BTC Send, Swap, and Bulk Send flows before production rollout.


[OK-60768]: https://onekeyhq.atlassian.net/browse/OK-60768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ