### PR TITLE
fix: keep Android browser content above toolbar(OK-60781)

### DIFF
--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -607,7 +607,12 @@ function MobileBrowser() {
                   <Stack flex={1}>
                     {browserDashboardContent}
                     {platformEnv.isNativeAndroid ? (
-                      <Freeze freeze={showDiscoveryPage}>{content}</Freeze>
+                      <Animated.View
+                        collapsable={false}
+                        style={[styles.webPageLayer, webPageAnimatedStyle]}
+                      >
+                        <Freeze freeze={showDiscoveryPage}>{content}</Freeze>
+                      </Animated.View>
                     ) : null}
                   </Stack>
                 </Stack>

--- a/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
+++ b/packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx
@@ -609,6 +609,17 @@ function MobileBrowser() {
                     {platformEnv.isNativeAndroid ? (
                       <Animated.View
                         collapsable={false}
+                        pointerEvents={
+                          shouldShowRootWebPageLayer ? 'auto' : 'none'
+                        }
+                        accessibilityElementsHidden={
+                          !shouldShowRootWebPageLayer
+                        }
+                        importantForAccessibility={
+                          shouldShowRootWebPageLayer
+                            ? 'auto'
+                            : 'no-hide-descendants'
+                        }
                         style={[styles.webPageLayer, webPageAnimatedStyle]}
                       >
                         <Freeze freeze={showDiscoveryPage}>{content}</Freeze>


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-60781](https://onekeyhq.atlassian.net/browse/OK-60781)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Resize the Android Discovery browser WebView container together with the animated bottom toolbar.
- Keep fixed-position DApp controls visible above the toolbar while preserving the existing Android pager and WebView lifecycle.

## Intent & Context
The mobile browser toolbar still covered the bottom of web pages on Android. An ADB screenshot from a Pixel 8 reproduced the issue on the Uniswap swap confirmation sheet: its bottom action button extended behind the OneKey browser toolbar and only its top edge remained visible.

The earlier OK-58585 change applied the viewport adjustment only to the iOS root WebView layer. OK-60781 extends the same behavior to Android without changing the iOS path.

## Root Cause
On Android, browser WebViews remain inside OuterTabPagerView while the browser toolbar is absolutely positioned above that pager. The Android WebView container therefore kept the full available height even when the toolbar was expanded. Although webPageAnimatedStyle already tracked the toolbar height, it was only attached to the iOS WebView layer.

## Design Decisions
- Keep Android WebViews inside the pager so existing tab switching, Freeze behavior, and WebView lifecycle remain unchanged.
- Add an absolute-fill Animated.View around the Android browser content and reuse webPageAnimatedStyle. Its bottom edge now follows the toolbar height, including the safe-area inset.
- Leave iOS, desktop, web, navigation, URL validation, and JSBridge behavior unchanged.

## Changes Detail
- packages/kit/src/views/Discovery/pages/Browser/Browser.native.tsx: wrap Android browser content in an animated container whose bottom offset follows the browser toolbar.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile Android
- **Risk Areas**: Android WebView viewport resizing during toolbar show/hide animation and interaction with pager/freezing behavior.

## Test plan
- [x] Reproduced the overlap with an ADB screenshot on a Pixel 8 using the Uniswap swap confirmation sheet.
- [x] Run yarn agent:check --profile commit.
- [ ] Reload the Android app and confirm the Uniswap bottom action remains fully visible above the expanded browser toolbar.
- [ ] Scroll down and up, confirming the WebView expands/contracts with the toolbar without blank frames or visible scroll jumps.
- [ ] Switch browser tabs and Discovery header tabs, confirming WebViews remain mounted and interactive.

[OK-60781]: https://onekeyhq.atlassian.net/browse/OK-60781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ