### PR TITLE
fix: stop perps order books overwriting each other's tick option (OK-59102, OK-59100)

### DIFF
--- a/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
+++ b/packages/kit/src/components/TradingView/TradingViewPerpsV2/TradingViewPerpsV2.tsx
@@ -335,6 +335,30 @@ export function TradingViewPerpsV2(
   const isChartLinesReady = chartLinesReadyWebviewKey === _webviewKey;
   const isChartContentReady = chartContentReadyWebviewKey === _webviewKey;
 
+  // OK-59100: on iOS this flag gates both the header pan gesture and the tab
+  // scroller, and nothing ever reset it — a stray `open` arriving before the
+  // chart is live never receives its matching `close` and locks scrolling for
+  // the rest of the session (fail-closed). Accept `open` only once the chart
+  // reports ready; a reload invalidates any pending open state anyway.
+  const isChartContentReadyRef = useRef(isChartContentReady);
+  isChartContentReadyRef.current = isChartContentReady;
+  const guardedInteractionOverlayOpenChange = useCallback(
+    (isOpen: boolean) => {
+      if (isOpen && !isChartContentReadyRef.current) {
+        return;
+      }
+      onInteractionOverlayOpenChange?.(isOpen);
+    },
+    [onInteractionOverlayOpenChange],
+  );
+  // Any transition out of ready (reload, navigation, render-process loss)
+  // discards overlay state the chart can no longer close on its own.
+  useEffect(() => {
+    if (!isChartContentReady) {
+      onInteractionOverlayOpenChange?.(false);
+    }
+  }, [isChartContentReady, onInteractionOverlayOpenChange]);
+
   const prevWebviewKeyRef = useRef(_webviewKey);
   useEffect(() => {
     if (prevWebviewKeyRef.current !== _webviewKey) {
@@ -629,7 +653,7 @@ export function TradingViewPerpsV2(
     onOrderPriceUpdate,
     onChartOrderIntent,
     onTouchScroll,
-    onInteractionOverlayOpenChange,
+    onInteractionOverlayOpenChange: guardedInteractionOverlayOpenChange,
   });
 
   // Chart lines management (liquidation, position, orders)

--- a/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
+++ b/packages/kit/src/states/jotai/contexts/hyperliquid/actions.ts
@@ -1496,13 +1496,23 @@ class ContextJotaiActionsHyperliquid extends ContextJotaiActionsBase {
       payload: null | {
         symbol: string;
         option: IPerpOrderBookTickOptionPersist | null;
+        // 'seed' means "establish a default if this symbol has none"; the
+        // render-time check the caller made can be stale by the time the effect
+        // runs, so the authoritative one happens here against the live atom.
+        source?: 'seed';
       },
     ) => {
       if (!payload?.symbol) return;
-      const { symbol, option } = payload;
+      const { symbol, option, source } = payload;
       const prev = get(orderBookTickOptionsAtom());
+      // Merged rather than atom-only: seeding happens early in app life, when
+      // the atom can still be missing symbols the module cache already holds.
+      const prevMerged = getPerpsOrderBookTickOptionsWithCache(prev);
+      if (source === 'seed' && option && prevMerged[symbol]) {
+        return;
+      }
       const next: Record<string, IPerpOrderBookTickOptionPersist> = {
-        ...prev,
+        ...prevMerged,
       };
 
       if (!option) {

--- a/packages/kit/src/views/Perp/components/OrderBook/index.tsx
+++ b/packages/kit/src/views/Perp/components/OrderBook/index.tsx
@@ -766,14 +766,6 @@ export function OrderBook({
         : [],
     [horizontal, isEmpty, resolvedMaxLevelsPerSide],
   );
-  let verticalAsks: IFormattedOBLevel[] = [];
-  let verticalBids: IFormattedOBLevel[] = [];
-  if (!horizontal) {
-    verticalAsks = isEmpty
-      ? verticalEmptyLevels
-      : aggregatedData.asks.toReversed();
-    verticalBids = isEmpty ? verticalEmptyLevels : aggregatedData.bids;
-  }
   const depthEpoch = useOrderBookEpoch(
     _symbol,
     selectedTickOption?.value,
@@ -782,6 +774,7 @@ export function OrderBook({
 
   const isMobileVariant =
     variant === 'mobileHorizontal' || variant === 'mobileVertical';
+
   const traceInnerLayout = useCallback(
     (name: string, event: LayoutChangeEvent) => {
       if (!isMobileVariant) {
@@ -842,38 +835,66 @@ export function OrderBook({
   // REACT-NATIVE-1JZ: build the native depth-bar `percents` arrays once per data
   // change (useMemo) instead of inside JSX on every render, then frame-coalesce
   // them (useRafCoalesced) so high-frequency L2 ticks collapse to ~one Nitro
-  // prop write per displayed frame. Only the depth-bar *visual* data is gated
-  // here — the price/size ladder text below still reads `aggregatedData`
-  // directly, so the numbers the user reads stay maximally fresh.
-  const bidPercentsRaw = useMemo(
-    () =>
-      aggregatedData.bids.map((item) =>
+  // prop write per displayed frame.
+  //
+  // Bars and the rows drawn over them must come from one snapshot: coalescing
+  // only the percents left a stale depth block behind an updated row, which the
+  // native bar's CADisplayLink easing stretches into a visible skew.
+  const bidLadderRaw = useMemo(
+    () => ({
+      percents: aggregatedData.bids.map((item) =>
         calculatePercentage(item.cumSize, bidDepth),
       ),
+      levels: aggregatedData.bids,
+    }),
     [aggregatedData.bids, bidDepth],
   );
-  const askPercentsRaw = useMemo(
-    () =>
-      aggregatedData.asks.map((item) =>
+  const askLadderRaw = useMemo(
+    () => ({
+      percents: aggregatedData.asks.map((item) =>
         calculatePercentage(item.cumSize, askDepth),
       ),
+      levels: aggregatedData.asks,
+    }),
     [aggregatedData.asks, askDepth],
   );
   // Vertical layout draws asks top-to-bottom reversed; keep its own derived
-  // array so the reversal isn't recomputed in JSX each render.
-  const reversedAskPercentsRaw = useMemo(
-    () =>
-      aggregatedData.asks
-        .toReversed()
-        .map((item) => calculatePercentage(item.cumSize, askDepth)),
-    [aggregatedData.asks, askDepth],
-  );
-  const bidPercents = useRafCoalesced(bidPercentsRaw, depthEpoch);
-  const askPercents = useRafCoalesced(askPercentsRaw, depthEpoch);
-  const reversedAskPercents = useRafCoalesced(
-    reversedAskPercentsRaw,
+  // arrays so the reversal isn't recomputed in JSX each render. `levels` rides
+  // along for the same reason the horizontal ladders carry it: the rows drawn
+  // over these bars, and the tap that resolves against them, have to come from
+  // the frame the user is looking at.
+  const reversedAskLadderRaw = useMemo(() => {
+    const levels = aggregatedData.asks.toReversed();
+    return {
+      percents: levels.map((item) =>
+        calculatePercentage(item.cumSize, askDepth),
+      ),
+      levels,
+    };
+  }, [aggregatedData.asks, askDepth]);
+  // Mobile is already throttled to 200ms upstream, so coalescing to the frame
+  // can merge nothing and only adds latency. Desktop has no such snapshot —
+  // bursts still land within a frame there, which REACT-NATIVE-1JZ was about.
+  const bidLadder = useRafCoalesced(bidLadderRaw, depthEpoch, !isMobileVariant);
+  const askLadder = useRafCoalesced(askLadderRaw, depthEpoch, !isMobileVariant);
+  const bidPercents = bidLadder.percents;
+  const askPercents = askLadder.percents;
+  // Vertical-only, and vertical never renders on a mobile variant.
+  const reversedAskLadder = useRafCoalesced(
+    reversedAskLadderRaw,
     depthEpoch,
+    !isMobileVariant,
   );
+  const reversedAskPercents = reversedAskLadder.percents;
+  // Drawn from the same snapshot as the bars behind them: reading the live
+  // arrays here let a row show a price whose bar had not caught up, and could
+  // put a level the user never pressed into the order form.
+  let verticalAsks: IFormattedOBLevel[] = [];
+  let verticalBids: IFormattedOBLevel[] = [];
+  if (!horizontal) {
+    verticalAsks = isEmpty ? verticalEmptyLevels : reversedAskLadder.levels;
+    verticalBids = isEmpty ? verticalEmptyLevels : bidLadder.levels;
+  }
 
   const blockColors = useBlockColors();
   const textColor = useTextColor();
@@ -1031,7 +1052,7 @@ export function OrderBook({
               <View style={styles.absoluteContainer}>
                 <View style={styles.levelListContainer}>
                   <View style={styles.levelList}>
-                    {aggregatedData.bids.map((item, index) => (
+                    {bidLadder.levels.map((item, index) => (
                       <Pressable
                         key={index}
                         onPress={() => handleSelectLevel('bid', item, index)}
@@ -1072,7 +1093,7 @@ export function OrderBook({
                     ))}
                   </View>
                   <View style={styles.levelList}>
-                    {aggregatedData.asks.map((item, index) => (
+                    {askLadder.levels.map((item, index) => (
                       <Pressable
                         key={index}
                         onPress={() => handleSelectLevel('ask', item, index)}
@@ -1198,7 +1219,7 @@ export function OrderBook({
         </View>
         <View style={styles.absoluteContainer}>
           {verticalAsks.map((itemData, index) => {
-            const originalIndex = aggregatedData.asks.length - 1 - index;
+            const originalIndex = verticalAsks.length - 1 - index;
             return (
               <Pressable
                 key={index}
@@ -1938,24 +1959,30 @@ export function OrderBookMobile({
   // prices/sizes still showed frame N-1, briefly separating the bar fill from
   // its own price/size text (PR review r3363420755). The raw arrays keep their
   // own useMemo identities so this wrapper only changes when real data changes.
+  // `levels` rides along so a tap resolves against the frame the user sees;
+  // reading live arrays could put a price they never pressed into the form.
   const askLadderRaw = useMemo(
     () => ({
       percents: askPercentsRaw,
       prices: askPricesRaw,
       sizes: askSizesRaw,
+      levels: reversedAsks,
     }),
-    [askPercentsRaw, askPricesRaw, askSizesRaw],
+    [askPercentsRaw, askPricesRaw, askSizesRaw, reversedAsks],
   );
   const bidLadderRaw = useMemo(
     () => ({
       percents: bidPercentsRaw,
       prices: bidPricesRaw,
       sizes: bidSizesRaw,
+      levels: aggregatedData.bids,
     }),
-    [bidPercentsRaw, bidPricesRaw, bidSizesRaw],
+    [aggregatedData.bids, bidPercentsRaw, bidPricesRaw, bidSizesRaw],
   );
-  const askLadder = useRafCoalesced(askLadderRaw, depthEpoch);
-  const bidLadder = useRafCoalesced(bidLadderRaw, depthEpoch);
+  // Mobile-only, and mobile is already throttled to 200ms upstream
+  // (`enableVisualSnapshot`), so frame coalescing can merge nothing here.
+  const askLadder = useRafCoalesced(askLadderRaw, depthEpoch, false);
+  const bidLadder = useRafCoalesced(bidLadderRaw, depthEpoch, false);
   // Spacers reserve the height of each rendered depth column so the foreground
   // spread row stays aligned. Each side can be empty independently, and
   // DepthBarColumn falls back to its placeholder rows for that side.
@@ -2020,25 +2047,22 @@ export function OrderBookMobile({
   );
   const handleAskRowPress = useCallback(
     (rowIndex: number) => {
-      const item = reversedAsks[rowIndex];
+      const levels = askLadder.levels;
+      const item = levels[rowIndex];
       if (item) {
-        handleSelectLevel(
-          'ask',
-          item,
-          aggregatedData.asks.length - 1 - rowIndex,
-        );
+        handleSelectLevel('ask', item, levels.length - 1 - rowIndex);
       }
     },
-    [aggregatedData.asks.length, handleSelectLevel, reversedAsks],
+    [askLadder.levels, handleSelectLevel],
   );
   const handleBidRowPress = useCallback(
     (rowIndex: number) => {
-      const item = aggregatedData.bids[rowIndex];
+      const item = bidLadder.levels[rowIndex];
       if (item) {
         handleSelectLevel('bid', item, rowIndex);
       }
     },
-    [aggregatedData.bids, handleSelectLevel],
+    [bidLadder.levels, handleSelectLevel],
   );
 
   return (

--- a/packages/kit/src/views/Perp/components/OrderBook/tickSizeUtils.test.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/tickSizeUtils.test.ts
@@ -6,7 +6,7 @@ import {
   buildReferenceTickOptions,
   buildTickOptions,
   getTickOptionsDataDuringTransition,
-  shouldPersistOrderBookTickOption,
+  shouldSeedOrderBookTickOption,
 } from './tickSizeUtils';
 
 describe('getTickOptionsDataDuringTransition', () => {
@@ -149,49 +149,52 @@ describe('buildReferenceTickOptions', () => {
   });
 });
 
-describe('shouldPersistOrderBookTickOption', () => {
-  it('does not replace precision while order book data is transitioning', () => {
+describe('shouldSeedOrderBookTickOption', () => {
+  const readyToSeed = {
+    isReady: true,
+    isFallbackList: false,
+    hasLoadedPersistedOptions: true,
+    hasPersistedOption: false,
+  };
+
+  it('seeds a symbol that has no stored option yet', () => {
+    expect(shouldSeedOrderBookTickOption(readyToSeed)).toBe(true);
+  });
+
+  it('adopts an existing option instead of overwriting it', () => {
+    // The whole point of seed-only: a second order book with its own derived
+    // list must not fight the value the first one established.
     expect(
-      shouldPersistOrderBookTickOption({
-        isReady: false,
-        persisted: { value: '0.2', nSigFigs: 5, mantissa: 2 },
-        next: { value: '0.1', nSigFigs: 5, mantissa: null },
+      shouldSeedOrderBookTickOption({
+        ...readyToSeed,
+        hasPersistedOption: true,
       }),
     ).toBe(false);
   });
 
-  it('does not rewrite a matching persisted selection', () => {
+  it('refuses a fallback-derived list', () => {
+    // The fallback builder labels the same tick with a different nSigFigs, and
+    // the transition branch can hand one back after szDecimals has arrived.
     expect(
-      shouldPersistOrderBookTickOption({
-        isReady: true,
-        persisted: { value: '0.1', nSigFigs: 5, mantissa: null },
-        next: { value: '0.1', nSigFigs: 5, mantissa: null },
+      shouldSeedOrderBookTickOption({ ...readyToSeed, isFallbackList: true }),
+    ).toBe(false);
+  });
+
+  it('waits for the stored options to load', () => {
+    // Seeding is first-write-wins, so a seed that beats the load would replace
+    // the user's own choice permanently rather than shadow it.
+    expect(
+      shouldSeedOrderBookTickOption({
+        ...readyToSeed,
+        hasLoadedPersistedOptions: false,
       }),
     ).toBe(false);
   });
 
-  it('initializes a missing selection after market data arrives', () => {
+  it('waits for tick options to be derived at all', () => {
     expect(
-      shouldPersistOrderBookTickOption({
-        isReady: true,
-        persisted: undefined,
-        next: { value: '0.1', nSigFigs: 5, mantissa: null },
-      }),
-    ).toBe(true);
-  });
-
-  it.each([
-    ['value', { value: '0.2', nSigFigs: 5 as const, mantissa: 2 as const }],
-    ['nSigFigs', { value: '0.1', nSigFigs: 4 as const, mantissa: null }],
-    ['mantissa', { value: '0.1', nSigFigs: 5 as const, mantissa: 2 as const }],
-  ])('syncs a selection whose %s changed', (_field, persisted) => {
-    expect(
-      shouldPersistOrderBookTickOption({
-        isReady: true,
-        persisted,
-        next: { value: '0.1', nSigFigs: 5, mantissa: null },
-      }),
-    ).toBe(true);
+      shouldSeedOrderBookTickOption({ ...readyToSeed, isReady: false }),
+    ).toBe(false);
   });
 });
 

--- a/packages/kit/src/views/Perp/components/OrderBook/tickSizeUtils.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/tickSizeUtils.ts
@@ -28,13 +28,32 @@ export interface IReferenceTickOptionsData {
   tickOptions: ITickParam[];
   defaultTickOption: ITickParam;
   priceDecimals: number;
+  // Set only by the szDecimals-less fallback builder, which labels the same
+  // tick differently; callers use it to refuse that list where the labelling
+  // has to be right.
+  isFallback?: boolean;
 }
 
-type IOrderBookTickOptionState = {
-  value: string;
-  nSigFigs?: INSig;
-  mantissa?: IMantissa | null;
-};
+export function shouldSeedOrderBookTickOption({
+  isReady,
+  isFallbackList,
+  hasLoadedPersistedOptions,
+  hasPersistedOption,
+}: {
+  isReady: boolean;
+  isFallbackList: boolean;
+  hasLoadedPersistedOptions: boolean;
+  hasPersistedOption: boolean;
+}) {
+  // Seeding is first-write-wins, so each of these would otherwise be permanent:
+  // a list that is not ready, a fallback list that labels ticks differently, a
+  // seed racing the stored preferences load, or overwriting a value another
+  // order book already established (OK-59102).
+  if (!isReady || isFallbackList || !hasLoadedPersistedOptions) {
+    return false;
+  }
+  return !hasPersistedOption;
+}
 
 export function getTickOptionsDataDuringTransition<
   T extends { symbol: string },
@@ -56,26 +75,6 @@ export function getTickOptionsDataDuringTransition<
     return cached;
   }
   return reference?.symbol === symbol ? reference : null;
-}
-
-export function shouldPersistOrderBookTickOption({
-  isReady,
-  persisted,
-  next,
-}: {
-  isReady: boolean;
-  persisted: IOrderBookTickOptionState | undefined;
-  next: IOrderBookTickOptionState;
-}) {
-  if (!isReady) {
-    return false;
-  }
-
-  return (
-    persisted?.value !== next.value ||
-    (persisted?.nSigFigs ?? null) !== (next.nSigFigs ?? null) ||
-    (persisted?.mantissa ?? null) !== (next.mantissa ?? null)
-  );
 }
 
 function floorLog10(x: number): number {

--- a/packages/kit/src/views/Perp/components/OrderBook/useRafCoalesced.test.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/useRafCoalesced.test.ts
@@ -1,0 +1,109 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useRafCoalesced } from './useRafCoalesced';
+
+type ITestValue = { id: string };
+
+// The hook emits on the next animation frame, so drive rAF manually instead of
+// waiting on real frames.
+let pendingFrames: Array<() => void> = [];
+
+function flushFrames() {
+  const frames = pendingFrames;
+  pendingFrames = [];
+  frames.forEach((frame) => frame());
+}
+
+type IFrameGlobals = {
+  requestAnimationFrame?: (callback: (time: number) => void) => number;
+  cancelAnimationFrame?: (handle: number) => void;
+};
+
+const frameGlobals = globalThis as IFrameGlobals;
+const originalRequestAnimationFrame = frameGlobals.requestAnimationFrame;
+const originalCancelAnimationFrame = frameGlobals.cancelAnimationFrame;
+
+beforeEach(() => {
+  pendingFrames = [];
+  // Assigned rather than spied: the jest environment does not define these, so
+  // there is nothing for spyOn to attach to.
+  frameGlobals.requestAnimationFrame = (callback) => {
+    pendingFrames.push(() => callback(0));
+    return pendingFrames.length;
+  };
+  frameGlobals.cancelAnimationFrame = () => undefined;
+});
+
+afterEach(() => {
+  frameGlobals.requestAnimationFrame = originalRequestAnimationFrame;
+  frameGlobals.cancelAnimationFrame = originalCancelAnimationFrame;
+});
+
+describe('useRafCoalesced', () => {
+  it('holds the previous value until the next frame', () => {
+    const first = { id: 'first' };
+    const second = { id: 'second' };
+    const { result, rerender } = renderHook(
+      ({ value }: { value: ITestValue }) => useRafCoalesced(value, 'epoch'),
+      { initialProps: { value: first } },
+    );
+
+    expect(result.current).toBe(first);
+
+    rerender({ value: second });
+    expect(result.current).toBe(first);
+
+    act(() => {
+      flushFrames();
+    });
+    expect(result.current).toBe(second);
+  });
+
+  it('emits synchronously when the flush key changes', () => {
+    const first = { id: 'first' };
+    const second = { id: 'second' };
+    const { result, rerender } = renderHook(
+      ({ value, flushKey }: { value: ITestValue; flushKey: string }) =>
+        useRafCoalesced(value, flushKey),
+      { initialProps: { value: first, flushKey: 'a' } },
+    );
+
+    rerender({ value: second, flushKey: 'b' });
+    expect(result.current).toBe(second);
+  });
+
+  it('passes the live value straight through while disabled', () => {
+    const first = { id: 'first' };
+    const second = { id: 'second' };
+    const { result, rerender } = renderHook(
+      ({ value }: { value: ITestValue }) =>
+        useRafCoalesced(value, 'epoch', false),
+      { initialProps: { value: first } },
+    );
+
+    rerender({ value: second });
+    // No frame flush: a disabled hook must not defer anything.
+    expect(result.current).toBe(second);
+    expect(pendingFrames).toHaveLength(0);
+  });
+
+  it('returns the live value on the first render after being re-enabled', () => {
+    // Guards the regression this flag introduced: `emitted` keeps whatever was
+    // current when the hook was switched off, which by the time it comes back
+    // can be an entirely different coin or tick size.
+    const first = { id: 'first' };
+    const second = { id: 'second' };
+    const third = { id: 'third' };
+    const { result, rerender } = renderHook(
+      ({ value, enabled }: { value: ITestValue; enabled: boolean }) =>
+        useRafCoalesced(value, 'epoch', enabled),
+      { initialProps: { value: first, enabled: true } },
+    );
+
+    rerender({ value: second, enabled: false });
+    expect(result.current).toBe(second);
+
+    rerender({ value: third, enabled: true });
+    expect(result.current).toBe(third);
+  });
+});

--- a/packages/kit/src/views/Perp/components/OrderBook/useRafCoalesced.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/useRafCoalesced.ts
@@ -37,8 +37,16 @@ const RAF_COALESCE_ENABLED = true;
  * it changes, the latest value is emitted synchronously within the same render.
  * The order book passes its depth epoch (coin / tick-size / empty<->full switch)
  * so the native view never snaps to a stale previous-frame array.
+ *
+ * `enabled` (optional) turns the whole mechanism off. Callers already fed by a
+ * throttled upstream have nothing to coalesce, and leaving it on would still
+ * schedule a frame and a state update per change for a value they discard.
  */
-export function useRafCoalesced<T>(value: T, flushKey?: unknown): T {
+export function useRafCoalesced<T>(
+  value: T,
+  flushKey?: unknown,
+  enabled = true,
+): T {
   const [emitted, setEmitted] = useState<T>(value);
   const latestRef = useRef<T>(value);
   const frameRef = useRef<number | null>(null);
@@ -46,10 +54,30 @@ export function useRafCoalesced<T>(value: T, flushKey?: unknown): T {
 
   latestRef.current = value;
 
+  const isActive = RAF_COALESCE_ENABLED && enabled;
+  const wasActiveRef = useRef(isActive);
+  const cameBackOn = isActive && !wasActiveRef.current;
+  wasActiveRef.current = isActive;
+
   // Resolve the value this render returns. Default to whatever was last emitted.
   let resolved = emitted;
 
-  if (!RAF_COALESCE_ENABLED) {
+  if (!isActive) {
+    // Switched off: hand the value straight back without touching state, so no
+    // frame is scheduled and no render is queued for a result nobody reads.
+    // Keep the flush key current so re-enabling never sees a stale one, and
+    // drop any frame still pending from before the switch.
+    prevFlushKeyRef.current = flushKey;
+    if (frameRef.current !== null) {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+    resolved = value;
+  } else if (cameBackOn) {
+    // Switched back on: `emitted` still holds whatever was current before the
+    // hook was disabled, which by now can be an entirely different coin or tick
+    // size. Seed from the live value so the first active render never shows it.
+    prevFlushKeyRef.current = flushKey;
     resolved = value;
   } else if (prevFlushKeyRef.current !== flushKey) {
     // flushKey changed (coin / tick / empty switch): emit the latest value
@@ -65,12 +93,12 @@ export function useRafCoalesced<T>(value: T, flushKey?: unknown): T {
   // "Adjust state during render" pattern: when the resolved value diverges from
   // committed state, request a re-render so the committed value catches up.
   // React re-runs this component immediately without painting the stale state.
-  if (resolved !== emitted) {
+  if (isActive && resolved !== emitted) {
     setEmitted(resolved);
   }
 
   useEffect(() => {
-    if (!RAF_COALESCE_ENABLED) {
+    if (!isActive) {
       return undefined;
     }
 
@@ -90,7 +118,7 @@ export function useRafCoalesced<T>(value: T, flushKey?: unknown): T {
     });
 
     return undefined;
-  }, [emitted, value]);
+  }, [emitted, isActive, value]);
 
   useEffect(
     () => () => {

--- a/packages/kit/src/views/Perp/components/OrderBook/useTickOptions.ts
+++ b/packages/kit/src/views/Perp/components/OrderBook/useTickOptions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import BigNumber from 'bignumber.js';
 
@@ -12,7 +12,6 @@ import {
   resolveOrderBookSizeDecimals,
 } from '@onekeyhq/shared/src/utils/perpsUtils';
 import type { IBookLevel } from '@onekeyhq/shared/types/hyperliquid/sdk';
-import type { IPerpOrderBookTickOptionPersist } from '@onekeyhq/shared/types/hyperliquid/types';
 
 import {
   type ITickParam,
@@ -20,7 +19,7 @@ import {
   buildTickOptions,
   getDefaultTickOption,
   getTickOptionsDataDuringTransition,
-  shouldPersistOrderBookTickOption,
+  shouldSeedOrderBookTickOption,
 } from './tickSizeUtils';
 
 interface ITickOptionsResult {
@@ -63,6 +62,7 @@ export function useTickOptions({
     tickOptions: ITickParam[];
     defaultTickOption: ITickParam;
     priceDecimals: number;
+    isFallback?: boolean;
   } | null>(null);
 
   const [persistedTickOptions] = useOrderBookTickOptionsAtom();
@@ -72,8 +72,22 @@ export function useTickOptions({
   );
   const actions = useHyperliquidActions();
 
+  // Seeding makes the first write authoritative, so a seed that lands before
+  // the stored preferences finish loading would permanently replace the user's
+  // choice rather than transiently shadow it.
+  const [hasLoadedPersistedTickOptions, setHasLoadedPersistedTickOptions] =
+    useState(false);
   useEffect(() => {
-    void actions.current.ensureOrderBookTickOptionsLoaded();
+    let cancelled = false;
+    void (async () => {
+      await actions.current.ensureOrderBookTickOptionsLoaded();
+      if (!cancelled) {
+        setHasLoadedPersistedTickOptions(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [actions]);
 
   const topBidPrice = bids[0]?.px;
@@ -117,6 +131,7 @@ export function useTickOptions({
     if (marketTickOptionsData) {
       if (
         cached &&
+        !cached.isFallback &&
         marketTickOptionsData.priceDecimals <= cached.priceDecimals
       ) {
         return cached;
@@ -127,7 +142,10 @@ export function useTickOptions({
 
     const priceDecimals = getDisplayPriceScaleDecimals(marketPrice);
 
-    if (cached && priceDecimals <= cached.priceDecimals) {
+    if (
+      cached &&
+      (!cached.isFallback || priceDecimals <= cached.priceDecimals)
+    ) {
       return cached;
     }
 
@@ -143,11 +161,15 @@ export function useTickOptions({
     const tickLabelDecimals =
       new BigNumber(defaultTickOption.label).decimalPlaces() ?? 0;
 
+    // Derived without szDecimals, so it uses a different multiplier set than
+    // buildReferenceTickOptions and can label the same tick with a different
+    // nSigFigs. Tagged so a later reference list can displace it (OK-59102).
     const result = {
       symbol,
       tickOptions,
       defaultTickOption,
       priceDecimals: Math.max(priceDecimals, tickLabelDecimals),
+      isFallback: true,
     };
 
     // Cache the result
@@ -212,28 +234,37 @@ export function useTickOptions({
   useEffect(() => {
     if (!symbol) return;
 
-    const persisted = persistedTickOptions[symbol];
-    const currentPersist: IPerpOrderBookTickOptionPersist = {
-      value: selectedTickOption.value,
-      nSigFigs: selectedTickOption.nSigFigs ?? null,
-      mantissa: selectedTickOption.mantissa ?? null,
-    };
-
+    // Seed-only writer. The persisted tick option is a user preference, so an
+    // order book adopts it and never writes a derived correction back: two
+    // books whose instance-local lists disagree on nSigFigs for the same value
+    // would otherwise overwrite each other without ever converging (OK-59102).
     if (
-      shouldPersistOrderBookTickOption({
+      !shouldSeedOrderBookTickOption({
         isReady: Boolean(tickOptionsData),
-        persisted,
-        next: currentPersist,
+        // Read off the data rather than inferred from szDecimals: the
+        // transition branch can hand back a cached fallback list after
+        // szDecimals has arrived.
+        isFallbackList: Boolean(tickOptionsData?.isFallback),
+        hasLoadedPersistedOptions: hasLoadedPersistedTickOptions,
+        hasPersistedOption: Boolean(persistedTickOptionsForRender[symbol]),
       })
     ) {
-      void actions.current.setOrderBookTickOption({
-        symbol,
-        option: currentPersist,
-      });
+      return;
     }
+
+    void actions.current.setOrderBookTickOption({
+      symbol,
+      option: {
+        value: selectedTickOption.value,
+        nSigFigs: selectedTickOption.nSigFigs ?? null,
+        mantissa: selectedTickOption.mantissa ?? null,
+      },
+      source: 'seed',
+    });
   }, [
     symbol,
-    persistedTickOptions,
+    hasLoadedPersistedTickOptions,
+    persistedTickOptionsForRender,
     selectedTickOption,
     tickOptionsData,
     actions,

--- a/packages/shared/src/utils/perpsOrderBookTickOptionsCache.ts
+++ b/packages/shared/src/utils/perpsOrderBookTickOptionsCache.ts
@@ -22,8 +22,11 @@ export function getPerpsOrderBookTickOptionsCache(): IPerpsOrderBookTickOptionsC
 export function setPerpsOrderBookTickOptionsCache(
   options: IPerpsOrderBookTickOptionsCache,
 ) {
+  // Debounced like every other SWR writer. flushNow() is for app-background,
+  // and forcing it here made each write a synchronous full-store read, merge
+  // and MMKV rewrite on the calling runtime; simpleDb holds the durable copy,
+  // so this cache only needs to be eventually consistent.
   swrCacheUtils.set(ORDER_BOOK_TICK_OPTIONS_CACHE_KEY, options);
-  swrCacheUtils.flushNow();
 }
 
 export function getPerpsOrderBookTickOptionsWithCache(


### PR DESCRIPTION


<!-- github-pr-monitor:jira-links:start -->
[OK-59102](https://onekeyhq.atlassian.net/browse/OK-59102) [OK-59100](https://onekeyhq.atlassian.net/browse/OK-59100)

----------

<!-- github-pr-monitor:jira-links:end -->


## Summary
- Persist the order book tick option only to **seed** a symbol that has none, instead of writing back a derived correction whenever it differs from what is stored.
- Stop a tick-option list derived without `szDecimals` from being pinned as the cached one, so the real reference list can supersede it.
- Drop the synchronous `flushNow()` from the tick option cache write path.
- Remove the temporary OK-59100 / OK-59102 field diagnostics.

## Intent & Context
QA reported two iOS bugs that always appeared and disappeared together: the order book flickering as a whole block (OK-59102), and the chart page scrolling without following the finger while the two order buttons stopped responding (OK-59100). Repro: Perps home → BTC → chart page → back → switch to another coin → chart page.

Earlier attempts on this branch treated them as separate rendering defects and did not hold up. This change comes from instrumenting the actual write path and catching the loop in a reproduction.

## Root Cause
Two `PerpOrderBook` instances are alive whenever the chart page is pushed over the Perps tab (tab root + chart page). This is by design and is not a leak — an instance census confirmed the count peaks at 2 with correct mount/unmount pairing.

Each instance derived its tick-option list from **its own** book snapshot and wrote the result back into the **shared** persisted atom whenever it differed (`shouldPersistOrderBookTickOption` had no convergence condition). The two lists disagreed, so they overwrote each other indefinitely. One captured reproduction: **850 tick-option writes and 839 global L2 resubscribes**, ending in `Maximum update depth exceeded`.

Why the lists diverged: `changeActiveAsset` publishes an optimistic instrument with `universe: undefined` and hydrates a cached book behind it, so an order book can render a real price while `szDecimals` is still missing. Without `szDecimals`, `buildReferenceTickOptions` bails and the fallback builder runs with a different multiplier set — labelling the same `0.1` tick as `nSigFigs: 5` instead of `null`. That list was cached, and the reference list could not displace it because the hysteresis guard kept the cached one on **equal** `priceDecimals`.

Why both symptoms: each resubscribe made the incoming book fail `isL2BookForTarget` on whichever instance disagreed, dropping it to cold cache — that is the whole-book flicker. The render churn saturated the UI thread that `HeaderScrollGestureWrapper` drives `scrollTo` on (its pan callbacks are worklets, so this is not JS-thread starvation), and the synchronous per-write MMKV flush starved the JS thread the order buttons' `onPress` runs on.

## Design Decisions
- **Seed-only, not "seed then repair".** A repair branch was considered and rejected: it fires exactly in the state where an instance's list cannot resolve the shared entry, and it does not even cover the more common drift case where `byValue` matches but the `nSigFigs` meaning changed. Seed-only is safe by construction — writes happen only on the `undefined → defined` transition — rather than safe by enumeration of today's list shapes. Explicit user selection keeps its own unconditional path.
- **Authoritative seed check in the action.** The hook's existence check reads render-time state, so two instances can both pass it. `setOrderBookTickOption` re-checks against the live atom via `get()`.
- **`flushNow()` removal.** It is the app-background path; forcing it per write made every write a synchronous full-store read, merge, and MMKV rewrite. `simpleDb` holds the durable copy, so this cache only needs to be eventually consistent.

## Changes Detail
- `OrderBook/useTickOptions.ts` — seed-only persist, gated on stored preferences having loaded and on a list built with `szDecimals`; fallback-derived lists tagged `isFallback` so a reference list supersedes them and they never overwrite one.
- `states/jotai/contexts/hyperliquid/actions.ts` — `source: 'seed'` resolved against the live atom; the persisted map is built from the merged view so an early seed cannot drop symbols the module cache still holds.
- `shared/src/utils/perpsOrderBookTickOptionsCache.ts` — debounced write instead of `flushNow()`.
- `OrderBook/index.tsx`, `PerpOrderBook.tsx`, `PerpsGlobalEffects.tsx`, `PerpMarketFooter.tsx`, `MobilePerpMarket.tsx`, `TradingViewPerpsV2.tsx`, `utils/perpsFieldDiagnostics.ts` — field diagnostics removed.

Also retained from earlier on this branch (independent defects found while investigating, not the root cause): horizontal order book depth bars and ladder rows reading one snapshot, mobile skipping `useRafCoalesced`, and the TradingView interaction-overlay chart-ready gating.

## Risk Assessment
- **Risk Level**: Medium
- **Affected Platforms**: Mobile (iOS verified), and the shared Perps order book path on all platforms
- **Risk Areas**: tick-option selection is what the L2 subscription parameters are derived from. The behavioural change is that an order book no longer rewrites a stored tick option it disagrees with — whichever value is persisted first now wins until the user changes it explicitly.

## Test plan
Verified on iOS simulator (iPhone 16 Pro / iOS 18.6) against instrumented builds:
- [x] Repro path (BTC → chart → back → switch coin → chart): tick-option writes **850 → 0**, global resubscribes **839 → 3** (all genuine coin changes), no `Maximum update depth exceeded`.
- [x] Seed path exercised on coins with no stored entry: exactly one write per symbol, every write over an empty entry, and the seeded list came from the reference builder (`0.01:null`, not `0.01:5`).
- [x] The optimistic `universe: undefined` window is skipped rather than seeded from — confirmed in the log as `szDecimals` missing → no seed, then `szDecimals` present → single seed.
- [x] Order book instance count peaks at 2 with matched mount/unmount.
- [x] App boots clean after diagnostics removal.
- [ ] Real device pass (bundle self-test + QA).

## Rebase note
Developed on `release/v6.5.0` (PR #12930, now closed) and re-applied onto `hotfix/v6.5.2`. The `OrderBook/` files and the tick-option cache were untouched on 6.5.2 and were taken directly; `actions.ts` and `TradingViewPerpsV2.tsx` had their own 6.5.2 changes, so only this fix's delta was three-way applied on top of them — verified the net diff against 6.5.2 is exactly this fix and nothing else.

Pre-existing on this base and unrelated to this PR: `yarn tsc:staged` reports `isInstallerPath` missing on `AppUpdater` in `DesktopApiAppUpdate.ts:832`. Confirmed by running the same check on a clean `hotfix/v6.5.2` worktree with these changes stashed.

[OK-59102]: https://onekeyhq.atlassian.net/browse/OK-59102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OK-59100]: https://onekeyhq.atlassian.net/browse/OK-59100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ